### PR TITLE
SALTO-2352: Remove sync content from Static files

### DIFF
--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -65,10 +65,6 @@ export class StaticFile {
     }
   }
 
-  get content(): Buffer | undefined {
-    return this.internalContent
-  }
-
   async getContent(): Promise<Buffer | undefined> {
     return this.internalContent
   }

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -456,8 +456,9 @@ export const resolveValues: ResolveValuesFunc = async (
       })
     }
     if (isStaticFile(value)) {
+      const content = await value.getContent()
       return value.encoding === 'binary'
-        ? value.content : value.content?.toString(value.encoding)
+        ? content : content?.toString(value.encoding)
     }
     return value
   }

--- a/packages/core/src/local-workspace/dir_store.ts
+++ b/packages/core/src/local-workspace/dir_store.ts
@@ -47,7 +47,7 @@ const buildLocalDirectoryStore = <T extends dirStore.ContentType>(
   directoryFilter?: FilePathFilter,
   initUpdated?: FileMap<T>,
   initDeleted? : string[],
-): dirStore.SyncDirectoryStore<T> => {
+): dirStore.DirectoryStore<T> => {
   let currentBaseDir = path.join(..._.compact([baseDir, storeName, nameSuffix]))
   let updated: FileMap<T> = initUpdated || {}
   let deleted: string[] = initDeleted || []
@@ -94,17 +94,6 @@ const buildLocalDirectoryStore = <T extends dirStore.ContentType>(
         filename,
         buffer: await fileUtils.readFile(absFileName, { encoding }) as T,
         timestamp: (await fileUtils.stat(absFileName)).mtimeMs,
-      }
-      : undefined
-  }
-
-  const readFileSync = (filename: string): dirStore.File<T> | undefined => {
-    const absFileName = getAbsFileName(filename)
-    return fileUtils.existsSync(absFileName)
-      ? {
-        filename,
-        buffer: fileUtils.readFileSync(absFileName, { encoding }) as T,
-        timestamp: fileUtils.statSync(absFileName).mtimeMs,
       }
       : undefined
   }
@@ -156,11 +145,6 @@ const buildLocalDirectoryStore = <T extends dirStore.ContentType>(
     return (updated[relFilename] ? updated[relFilename] : readFile(relFilename))
   }
 
-  const getSync = (filename: string): dirStore.File<T> | undefined => {
-    const relFilename = getRelativeFileName(filename)
-    return (updated[relFilename] ? updated[relFilename] : readFileSync(relFilename))
-  }
-
   const list = async (): Promise<string[]> =>
     _(await listDirFiles())
       .concat(Object.keys(updated))
@@ -205,7 +189,6 @@ const buildLocalDirectoryStore = <T extends dirStore.ContentType>(
     list,
     isEmpty,
     get,
-    getSync,
     set: async (file: dirStore.File<T>): Promise<void> => {
       let relFilename: string
       try {
@@ -284,7 +267,7 @@ const buildLocalDirectoryStore = <T extends dirStore.ContentType>(
         (await fileUtils.stat(filePath)).size)))
     },
 
-    clone: (): dirStore.SyncDirectoryStore<T> => buildLocalDirectoryStore(
+    clone: (): dirStore.DirectoryStore<T> => buildLocalDirectoryStore(
       currentBaseDir,
       storeName,
       nameSuffix,
@@ -311,16 +294,16 @@ type LocalDirectoryStoreParams = {
 }
 
 export function localDirectoryStore(params: Omit<LocalDirectoryStoreParams, 'encoding'>):
-  dirStore.SyncDirectoryStore<Buffer>
+  dirStore.DirectoryStore<Buffer>
 
 export function localDirectoryStore(
   params: LocalDirectoryStoreParams & Required<Pick<LocalDirectoryStoreParams, 'encoding'>>
-): dirStore.SyncDirectoryStore<string>
+): dirStore.DirectoryStore<string>
 
 export function localDirectoryStore(
   { baseDir, name, nameSuffix, accessiblePath, encoding, fileFilter, directoryFilter }
   : LocalDirectoryStoreParams
-): dirStore.SyncDirectoryStore<dirStore.ContentType> {
+): dirStore.DirectoryStore<dirStore.ContentType> {
   return buildLocalDirectoryStore<dirStore.ContentType>(
     baseDir, name, nameSuffix, accessiblePath, encoding, fileFilter, directoryFilter,
   )

--- a/packages/core/test/common/workspace.ts
+++ b/packages/core/test/common/workspace.ts
@@ -72,8 +72,8 @@ export const mockStaticFilesSource = (
   getStaticFile: jest.fn().mockImplementation((filepath: string, _encoding: BufferEncoding) => (
     files.find(sf => sf.filepath === filepath) ?? undefined
   )),
-  getContent: jest.fn().mockImplementation((filepath: string) => (
-    files.find(sf => sf.filepath === filepath)?.content ?? undefined
+  getContent: jest.fn().mockImplementation(async (filepath: string) => (
+    await files.find(sf => sf.filepath === filepath)?.getContent() ?? undefined
   )),
   persistStaticFile: jest.fn().mockReturnValue([]),
   flush: jest.fn(),

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -1527,7 +1527,7 @@ describe('fetch from workspace', () => {
     const fileTwo = new StaticFile({ filepath: 'file2', encoding: 'utf-8', content: Buffer.from('2') })
     const fileThree = new StaticFile({ filepath: 'file3', encoding: 'utf-8', content: Buffer.from('3') })
     const fileFour = new StaticFile({ filepath: 'file4', encoding: 'utf-8', content: Buffer.from('4') })
-    const validFileContents = [fileOne, fileTwo, fileThree].map(f => f.content)
+
     const existingInstance = new InstanceElement(
       'existing',
       existingElement,
@@ -1776,17 +1776,18 @@ describe('fetch from workspace', () => {
         })
       })
 
-      it('should return changes with static files content from the elements', () => {
+      it('should return changes with static files content from the elements', async () => {
         const changes = [...fetchRes.changes]
         const newStaticInst = changes
           .filter(change => change.change.id.isEqual(newNaclStaticInstance.elemID))
           .map(change => getChangeData(change.change))
         expect(newStaticInst).toHaveLength(1)
-        expect(newStaticInst[0].value.staticFileField.content).toEqual(fileOne.content)
-        expect(newStaticInst[0].value.complexField.staticFileField.content)
-          .toEqual(fileTwo.content)
-        expect(newStaticInst[0].value.complexField.staticFilesArr[0].content)
-          .toEqual(fileThree.content)
+        expect(await newStaticInst[0].value.staticFileField.getContent())
+          .toEqual(await fileOne.getContent())
+        expect(await newStaticInst[0].value.complexField.staticFileField.getContent())
+          .toEqual(await fileTwo.getContent())
+        expect(await newStaticInst[0].value.complexField.staticFilesArr[0].getContent())
+          .toEqual(await fileThree.getContent())
         const modifyStaticVals = changes
           .filter(change =>
             change.change.id.createTopLevelParentID().parent
@@ -1795,7 +1796,6 @@ describe('fetch from workspace', () => {
         expect(modifyStaticVals).toHaveLength(3)
         const staticFileModifies = modifyStaticVals.filter(val => isStaticFile(val))
         expect(staticFileModifies).toHaveLength(3)
-        staticFileModifies.forEach(modify => validFileContents.includes(modify.content))
       })
 
       describe('With warnings', () => {
@@ -1882,17 +1882,18 @@ describe('fetch from workspace', () => {
               .toHaveLength(1))
         })
 
-        it('should return changes with static files content from otherWorkspace when hashes match', () => {
+        it('should return changes with static files content from otherWorkspace when hashes match', async () => {
           const changes = [...fetchRes.changes]
           const newStaticInst = changes
             .filter(change => change.change.id.isEqual(newStateStaticInstance.elemID))
             .map(change => getChangeData(change.change))
           expect(newStaticInst).toHaveLength(1)
-          expect(newStaticInst[0].value.staticFileField.content).toEqual(fileOne.content)
-          expect(newStaticInst[0].value.complexField.staticFileField.content)
-            .toEqual(fileTwo.content)
-          expect(newStaticInst[0].value.complexField.staticFilesArr[0].content)
-            .toEqual(fileThree.content)
+          expect(await newStaticInst[0].value.staticFileField.getContent())
+            .toEqual(await fileOne.getContent())
+          expect(await newStaticInst[0].value.complexField.staticFileField.getContent())
+            .toEqual(await fileTwo.getContent())
+          expect(await newStaticInst[0].value.complexField.staticFilesArr[0].getContent())
+            .toEqual(await fileThree.getContent())
           const modifyStaticVals = changes
             .filter(change =>
               change.change.id.createTopLevelParentID().parent
@@ -1901,7 +1902,6 @@ describe('fetch from workspace', () => {
           expect(modifyStaticVals).toHaveLength(3)
           const staticFileModifies = modifyStaticVals.filter(val => isStaticFile(val))
           expect(staticFileModifies).toHaveLength(3)
-          staticFileModifies.forEach(modify => validFileContents.includes(modify.content))
         })
 
         it('should not have a change on the val and a error if there is a hashes mismatch (for both inner modify and a whole addition)', () => {

--- a/packages/core/test/workspace/local/directory_store.test.ts
+++ b/packages/core/test/workspace/local/directory_store.test.ts
@@ -17,7 +17,7 @@ import * as path from 'path'
 import readdirp from 'readdirp'
 import {
   stat, exists, readFile, replaceContents, mkdirp, rm, isEmptyDir,
-  rename, existsSync, readFileSync, statSync, notFoundAsUndefined,
+  rename, notFoundAsUndefined,
 } from '@salto-io/file'
 import { localDirectoryStore, createExtensionFileFilter } from '../../../src/local-workspace/dir_store'
 
@@ -47,11 +47,8 @@ describe('localDirectoryStore', () => {
   })
 
   const mockStat = stat as unknown as jest.Mock
-  const mockStatSync = statSync as unknown as jest.Mock
   const mockFileExists = exists as jest.Mock
-  const mockFileSyncExists = existsSync as jest.Mock
   const mockReadFile = readFile as unknown as jest.Mock
-  const mockReadFileSync = readFileSync as unknown as jest.Mock
   const mockReaddirp = readdirp.promise as jest.Mock
   const mockReplaceContents = replaceContents as jest.Mock
   const mockMkdir = mkdirp as jest.Mock
@@ -149,47 +146,6 @@ describe('localDirectoryStore', () => {
       expect(mockFileExists.mock.calls[0][0]).toMatch(path.join(baseDir, bufferFileName))
       expect(mockReadFile.mock.calls[0][0]).toMatch(path.join(baseDir, bufferFileName))
       expect(mockReadFile.mock.calls[0][1]).toEqual({ encoding: undefined })
-    })
-  })
-
-  describe('sync get', () => {
-    it('does not return the file if it does not exist', () => {
-      const baseDir = 'not-exists'
-      const naclFileName = 'blabla/notexist.nacl'
-      mockFileSyncExists.mockReturnValue(false)
-      const naclFile = localDirectoryStore({ baseDir, name: '', encoding }).getSync(naclFileName)
-      expect(naclFile).toBeUndefined()
-      expect(mockFileSyncExists.mock.calls[0][0]).toMatch(path.join(baseDir, naclFileName))
-      expect(mockReadFileSync).not.toHaveBeenCalled()
-    })
-
-    it('returns the file if it exist for string dir store', () => {
-      const baseDir = 'exists'
-      const naclFileName = 'blabla/exist.nacl'
-      const content = 'content'
-      mockFileSyncExists.mockReturnValue(true)
-      mockReadFileSync.mockReturnValue(content)
-      mockStatSync.mockReturnValue({ mtimeMs: 7 })
-      const naclFile = localDirectoryStore({ baseDir, name: '', encoding }).getSync(naclFileName)
-      expect(naclFile?.buffer).toBe(content)
-      expect(mockFileSyncExists.mock.calls[0][0]).toMatch(path.join(baseDir, naclFileName))
-      expect(mockReadFileSync.mock.calls[0][0]).toMatch(path.join(baseDir, naclFileName))
-      expect(mockReadFileSync.mock.calls[0][1]).toEqual({ encoding })
-    })
-
-    it('returns the file if it exist for Buffer dir store', () => {
-      const baseDir = '/base'
-      const bufferStore = localDirectoryStore({ baseDir, name: '' })
-      const bufferFileName = 'someBufferFile.ext'
-      const content = Buffer.from('content')
-      mockFileSyncExists.mockReturnValue(true)
-      mockReadFileSync.mockReturnValue(content)
-      mockStatSync.mockReturnValue({ mtimeMs: 7 })
-      const bufferFile = bufferStore.getSync(bufferFileName)
-      expect(bufferFile?.buffer).toBe(content)
-      expect(mockFileSyncExists.mock.calls[0][0]).toMatch(path.join(baseDir, bufferFileName))
-      expect(mockReadFileSync.mock.calls[0][0]).toMatch(path.join(baseDir, bufferFileName))
-      expect(mockReadFileSync.mock.calls[0][1]).toEqual({ encoding: undefined })
     })
   })
 

--- a/packages/lang-server/test/workspace.ts
+++ b/packages/lang-server/test/workspace.ts
@@ -56,28 +56,27 @@ export const mockErrors = (
 })
 
 const mockDirStore = <T extends dirStore.ContentType>(files: Record<string, T> = {}):
-dirStore.SyncDirectoryStore<T> => {
+dirStore.DirectoryStore<T> => {
   let naclFiles = _.mapValues(
     files,
     (buffer, filename) => ({ filename, buffer })
   )
   return {
-    list: mockFunction<dirStore.SyncDirectoryStore<T>['list']>().mockImplementation(async () => Object.keys(naclFiles)),
-    get: mockFunction<dirStore.SyncDirectoryStore<T>['get']>().mockImplementation(async filepath => naclFiles[filepath]),
-    set: mockFunction<dirStore.SyncDirectoryStore<T>['set']>().mockImplementation(async file => { naclFiles[file.filename] = file }),
-    delete: mockFunction<dirStore.SyncDirectoryStore<T>['delete']>().mockImplementation(async filepath => { delete naclFiles[filepath] }),
-    clear: mockFunction<dirStore.SyncDirectoryStore<T>['clear']>().mockImplementation(async () => { naclFiles = {} }),
-    rename: mockFunction<dirStore.SyncDirectoryStore<T>['rename']>(),
-    renameFile: mockFunction<dirStore.SyncDirectoryStore<T>['renameFile']>(),
-    flush: mockFunction<dirStore.SyncDirectoryStore<T>['flush']>(),
-    mtimestamp: mockFunction<dirStore.SyncDirectoryStore<T>['mtimestamp']>().mockResolvedValue(0),
-    getFiles: mockFunction<dirStore.SyncDirectoryStore<T>['getFiles']>().mockImplementation(async filenames => filenames.map(name => naclFiles[name])),
-    getTotalSize: mockFunction<dirStore.SyncDirectoryStore<T>['getTotalSize']>(),
-    clone: mockFunction<dirStore.SyncDirectoryStore<T>['clone']>(),
-    isEmpty: mockFunction<dirStore.SyncDirectoryStore<T>['isEmpty']>(),
-    getFullPath: mockFunction<dirStore.SyncDirectoryStore<T>['getFullPath']>().mockImplementation(filepath => `full-${filepath}`),
-    getSync: mockFunction<dirStore.SyncDirectoryStore<T>['getSync']>(),
-    isPathIncluded: mockFunction<dirStore.SyncDirectoryStore<T>['isPathIncluded']>(),
+    list: mockFunction<dirStore.DirectoryStore<T>['list']>().mockImplementation(async () => Object.keys(naclFiles)),
+    get: mockFunction<dirStore.DirectoryStore<T>['get']>().mockImplementation(async filepath => naclFiles[filepath]),
+    set: mockFunction<dirStore.DirectoryStore<T>['set']>().mockImplementation(async file => { naclFiles[file.filename] = file }),
+    delete: mockFunction<dirStore.DirectoryStore<T>['delete']>().mockImplementation(async filepath => { delete naclFiles[filepath] }),
+    clear: mockFunction<dirStore.DirectoryStore<T>['clear']>().mockImplementation(async () => { naclFiles = {} }),
+    rename: mockFunction<dirStore.DirectoryStore<T>['rename']>(),
+    renameFile: mockFunction<dirStore.DirectoryStore<T>['renameFile']>(),
+    flush: mockFunction<dirStore.DirectoryStore<T>['flush']>(),
+    mtimestamp: mockFunction<dirStore.DirectoryStore<T>['mtimestamp']>().mockResolvedValue(0),
+    getFiles: mockFunction<dirStore.DirectoryStore<T>['getFiles']>().mockImplementation(async filenames => filenames.map(name => naclFiles[name])),
+    getTotalSize: mockFunction<dirStore.DirectoryStore<T>['getTotalSize']>(),
+    clone: mockFunction<dirStore.DirectoryStore<T>['clone']>(),
+    isEmpty: mockFunction<dirStore.DirectoryStore<T>['isEmpty']>(),
+    getFullPath: mockFunction<dirStore.DirectoryStore<T>['getFullPath']>().mockImplementation(filepath => `full-${filepath}`),
+    isPathIncluded: mockFunction<dirStore.DirectoryStore<T>['isPathIncluded']>(),
   }
 }
 

--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -585,8 +585,8 @@ describe('Netsuite adapter E2E with real account', () => {
         const { content } = fetchedEmailTemplate.value
         expect(isStaticFile(content)).toBeTruthy()
         const contentStaticFile = content as StaticFile
-        expect(contentStaticFile.content).toBeDefined()
-        expect((contentStaticFile.content as Buffer).toString())
+        expect(await contentStaticFile.getContent()).toBeDefined()
+        expect((await contentStaticFile.getContent() as Buffer).toString())
           .toEqual(emailTemplateToCreate.value.content)
       })
 
@@ -599,8 +599,8 @@ describe('Netsuite adapter E2E with real account', () => {
         const { content } = fetchedFile.value
         expect(isStaticFile(content)).toBeTruthy()
         const contentStaticFile = content as StaticFile
-        expect(contentStaticFile.content).toBeDefined()
-        expect((contentStaticFile.content as Buffer).toString())
+        expect(await contentStaticFile.getContent()).toBeDefined()
+        expect((await contentStaticFile.getContent() as Buffer).toString())
           .toEqual(fileToCreate.value.content)
       })
 

--- a/packages/netsuite-adapter/src/group_changes.ts
+++ b/packages/netsuite-adapter/src/group_changes.ts
@@ -117,32 +117,32 @@ const getChangesChunks = async (
   return changesChunks
 }
 
-const isSuiteAppFileCabinetModification = (change: Change): boolean => {
+const isSuiteAppFileCabinetModification = async (change: Change): Promise<boolean> => {
   const changeData = getChangeData(change)
   return isFileCabinetInstance(changeData)
-  && suiteAppFileCabinet.isChangeDeployable(change)
+  && await suiteAppFileCabinet.isChangeDeployable(change)
   && isModificationChange(change)
 }
 
-const isSuiteAppFileCabinetAddition = (change: Change): boolean => {
+const isSuiteAppFileCabinetAddition = async (change: Change): Promise<boolean> => {
   const changeData = getChangeData(change)
   return isFileCabinetInstance(changeData)
-  && suiteAppFileCabinet.isChangeDeployable(change)
+  && await suiteAppFileCabinet.isChangeDeployable(change)
   && isAdditionChange(change)
 }
 
-const isSuiteAppFileCabinetDeletion = (change: Change): boolean => {
+const isSuiteAppFileCabinetDeletion = async (change: Change): Promise<boolean> => {
   const changeData = getChangeData(change)
   return isFileCabinetInstance(changeData)
-  && suiteAppFileCabinet.isChangeDeployable(change)
+  && await suiteAppFileCabinet.isChangeDeployable(change)
   && isRemovalChange(change)
 }
 
-const isSdfChange = (change: Change): boolean => {
+const isSdfChange = async (change: Change): Promise<boolean> => {
   const changeData = getChangeData(change)
   return isCustomTypeName(changeData.elemID.typeName)
     || (isFileCabinetInstance(changeData)
-      && !suiteAppFileCabinet.isChangeDeployable(change))
+      && !await suiteAppFileCabinet.isChangeDeployable(change))
     || isSDFConfigTypeName(changeData.elemID.typeName)
 }
 

--- a/packages/salesforce-adapter/src/filters/static_resource_file_ext.ts
+++ b/packages/salesforce-adapter/src/filters/static_resource_file_ext.ts
@@ -19,10 +19,12 @@ import {
 import { findInstances } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
-import wu from 'wu'
 import mime from 'mime-types'
+import { collections } from '@salto-io/lowerdash'
 import { FilterWith } from '../filter'
 import { SALESFORCE, METADATA_CONTENT_FIELD } from '../constants'
+
+const { awu } = collections.asynciterable
 
 const log = logger(module)
 
@@ -30,9 +32,16 @@ export const STATIC_RESOURCE_METADATA_TYPE_ID = new ElemID(SALESFORCE, 'StaticRe
 export const CONTENT_TYPE = 'contentType'
 const RESOURCE_SUFFIX_LENGTH = 'resource'.length
 
-const modifyFileExtension = (staticResourceInstance: InstanceElement): void => {
+const modifyFileExtension = async (staticResourceInstance: InstanceElement): Promise<void> => {
   const staticFile = staticResourceInstance.value[METADATA_CONTENT_FIELD]
-  if (!isStaticFile(staticFile) || staticFile.content === undefined) {
+  if (!isStaticFile(staticFile)) {
+    log.debug(`Could not modify file extension for ${staticResourceInstance.elemID.getFullName()} due to invalid StaticFile`)
+    return
+  }
+
+  const content = await staticFile.getContent()
+
+  if (content === undefined) {
     log.debug(`Could not modify file extension for ${staticResourceInstance.elemID.getFullName()} due to invalid StaticFile`)
     return
   }
@@ -51,7 +60,7 @@ const modifyFileExtension = (staticResourceInstance: InstanceElement): void => {
   const currentFilepath = staticFile.filepath
   staticResourceInstance.value[METADATA_CONTENT_FIELD] = new StaticFile({
     filepath: `${currentFilepath.slice(0, -RESOURCE_SUFFIX_LENGTH)}${newExtension}`,
-    content: staticFile.content,
+    content,
   })
 }
 
@@ -62,7 +71,7 @@ const filterCreator = (): FilterWith<'onFetch'> => ({
    */
   onFetch: async (elements: Element[]): Promise<void> => {
     const staticResourceInstances = findInstances(elements, STATIC_RESOURCE_METADATA_TYPE_ID)
-    wu(staticResourceInstances).forEach(modifyFileExtension)
+    await awu(staticResourceInstances).forEach(modifyFileExtension)
   },
 })
 

--- a/packages/salesforce-adapter/src/filters/static_resource_file_ext.ts
+++ b/packages/salesforce-adapter/src/filters/static_resource_file_ext.ts
@@ -35,14 +35,14 @@ const RESOURCE_SUFFIX_LENGTH = 'resource'.length
 const modifyFileExtension = async (staticResourceInstance: InstanceElement): Promise<void> => {
   const staticFile = staticResourceInstance.value[METADATA_CONTENT_FIELD]
   if (!isStaticFile(staticFile)) {
-    log.debug(`Could not modify file extension for ${staticResourceInstance.elemID.getFullName()} due to invalid StaticFile`)
+    log.debug(`Could not modify file extension for ${staticResourceInstance.elemID.getFullName()} because it is not a StaticFile`)
     return
   }
 
   const content = await staticFile.getContent()
 
   if (content === undefined) {
-    log.debug(`Could not modify file extension for ${staticResourceInstance.elemID.getFullName()} due to invalid StaticFile`)
+    log.debug(`Could not modify file extension for ${staticResourceInstance.elemID.getFullName()} because its content is undefined`)
     return
   }
 

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -699,8 +699,8 @@ public class MyClass${index} {
       const [second] = findElements(result, 'ApexClass', 'MyClass1') as InstanceElement[]
       expect(first.value[constants.INSTANCE_FULL_NAME_FIELD]).toEqual('MyClass0')
       expect(second.value[constants.INSTANCE_FULL_NAME_FIELD]).toEqual('MyClass1')
-      expect(first.value.content.content.toString().includes('Instance0')).toBeTruthy()
-      expect(second.value.content.content.toString().includes('Instance1')).toBeTruthy()
+      expect((await first.value.content.getContent()).toString().includes('Instance0')).toBeTruthy()
+      expect((await second.value.content.getContent()).toString().includes('Instance1')).toBeTruthy()
     })
 
     it('should fetch metadata instances folders using retrieve', async () => {

--- a/packages/salesforce-adapter/test/filters/cpq/custom_script.test.ts
+++ b/packages/salesforce-adapter/test/filters/cpq/custom_script.test.ts
@@ -76,11 +76,12 @@ describe('cpq custom script filter', () => {
     fromServiceCustomScriptValues,
     mockCustomScripInstancePath,
   )
+  const cpqCodeContent = Buffer.from('if (this === "code") return true')
   const afterOnFetchCustomScriptValues = {
     [CPQ_CONSUMPTION_RATE_FIELDS]: ['lala', 'zaza', 'baba'],
     [CPQ_GROUP_FIELDS]: null,
     [CPQ_CODE_FIELD]: new StaticFile({
-      content: Buffer.from('if (this === "code") return true'),
+      content: cpqCodeContent,
       filepath: `${mockCustomScripInstancePath.join('/')}.js`,
       encoding: 'utf-8',
     }),
@@ -252,7 +253,7 @@ describe('cpq custom script filter', () => {
       .clone()
     // Simulating resolve on the static-file
     mockAfterResolveCustomScriptInstance
-      .value[CPQ_CODE_FIELD] = mockAfterResolveCustomScriptInstance.value[CPQ_CODE_FIELD].content.toString('utf-8')
+      .value[CPQ_CODE_FIELD] = cpqCodeContent.toString('utf-8')
     describe('Modification changes', () => {
       beforeAll(async () => {
         const beforeType = mockAfterOnFetchCustomScriptObject.clone()

--- a/packages/salesforce-adapter/test/filters/static_resource_file_ext.test.ts
+++ b/packages/salesforce-adapter/test/filters/static_resource_file_ext.test.ts
@@ -49,7 +49,7 @@ describe('Static Resource File Extension Filter', () => {
 
     const updatedContent = staticResourceInstance.value[METADATA_CONTENT_FIELD]
     expect(isStaticFile(updatedContent)).toEqual(true)
-    expect((updatedContent as StaticFile).content).toEqual(content)
+    expect(await (updatedContent as StaticFile).getContent()).toEqual(content)
     expect((updatedContent as StaticFile).filepath)
       .toEqual('salesforce/staticresources/filename.png')
   })
@@ -62,7 +62,7 @@ describe('Static Resource File Extension Filter', () => {
 
     const updatedContent = staticResourceInstance.value[METADATA_CONTENT_FIELD]
     expect(isStaticFile(updatedContent)).toEqual(true)
-    expect((updatedContent as StaticFile).content).toEqual(content)
+    expect(await (updatedContent as StaticFile).getContent()).toEqual(content)
     expect((updatedContent as StaticFile).filepath).toEqual(filepath)
   })
 
@@ -74,7 +74,7 @@ describe('Static Resource File Extension Filter', () => {
 
     const updatedContent = staticResourceInstance.value[METADATA_CONTENT_FIELD]
     expect(isStaticFile(updatedContent)).toEqual(true)
-    expect((updatedContent as StaticFile).content).toEqual(content)
+    expect(await (updatedContent as StaticFile).getContent()).toEqual(content)
     expect((updatedContent as StaticFile).filepath).toEqual(filepath)
   })
 

--- a/packages/salesforce-adapter/test/transformers/xml_transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/xml_transformer.test.ts
@@ -357,7 +357,7 @@ describe('XML Transformer', () => {
         expect(metadataInfo.status).toEqual('Active')
         expect(isStaticFile(metadataInfo.content)).toEqual(true)
         const contentStaticFile = metadataInfo.content as StaticFile
-        expect(contentStaticFile.content)
+        expect(await contentStaticFile.getContent())
           .toEqual(Buffer.from('public class MyApexClass {\n    public void printLog() {\n        System.debug(\'Created\');\n    }\n}'))
         expect(contentStaticFile.filepath)
           .toEqual('salesforce/Records/ApexClass/MyApexClass.cls')
@@ -464,13 +464,13 @@ describe('XML Transformer', () => {
         expect(emailFolder?.accessType).toEqual('Public')
       })
 
-      it('should transform EmailTemplate zip to MetadataInfo', () => {
+      it('should transform EmailTemplate zip to MetadataInfo', async () => {
         expect(emailTemplate).toBeDefined()
         expect(emailTemplate?.fullName).toEqual('MyFolder/MyEmailTemplate')
         expect(emailTemplate?.name).toEqual('My Email Template')
         expect(isStaticFile(emailTemplate?.content)).toEqual(true)
         const contentStaticFile = emailTemplate?.content as StaticFile
-        expect(contentStaticFile.content).toEqual(Buffer.from('Email Body'))
+        expect(await contentStaticFile.getContent()).toEqual(Buffer.from('Email Body'))
         expect(contentStaticFile.filepath).toEqual('salesforce/Records/EmailTemplate/MyFolder/MyEmailTemplate.email')
       })
 
@@ -513,11 +513,11 @@ describe('XML Transformer', () => {
           ]),
         })
 
-        const verifyMetadataValues = (
+        const verifyMetadataValues = async (
           values: { file: FileProperties; values: MetadataValues}[],
           fileProperties: FileProperties,
           staticFilesExpectedFolder: string
-        ): void => {
+        ): Promise<void> => {
           expect(values).toHaveLength(1)
           const [lwc] = values
           expect(lwc.file).toEqual(fileProperties)
@@ -528,14 +528,14 @@ describe('XML Transformer', () => {
           expect(jsResource).toBeDefined()
           expect(isStaticFile(jsResource.source)).toBe(true)
           const jsResourceStaticFile = jsResource.source as StaticFile
-          expect(jsResourceStaticFile.content).toEqual(Buffer.from('// some javascript content'))
+          expect(await jsResourceStaticFile.getContent()).toEqual(Buffer.from('// some javascript content'))
           expect(jsResourceStaticFile.filepath)
             .toEqual(`${staticFilesExpectedFolder}/myLightningComponentBundle.js`)
           const htmlResource = metadataInfo.lwcResources.lwcResource[1]
           expect(htmlResource).toBeDefined()
           expect(isStaticFile(htmlResource.source)).toBe(true)
           const htmlResourceStaticFile = htmlResource.source as StaticFile
-          expect(htmlResourceStaticFile.content).toEqual(Buffer.from('// some html content'))
+          expect(await htmlResourceStaticFile.getContent()).toEqual(Buffer.from('// some html content'))
           expect(htmlResourceStaticFile.filepath)
             .toEqual(`${staticFilesExpectedFolder}/myLightningComponentBundle.html`)
         }
@@ -545,7 +545,7 @@ describe('XML Transformer', () => {
           const values = await fromRetrieveResult(
             await createRetrieveResult([fileProperties]), [fileProperties], new Set(), new Set(),
           )
-          verifyMetadataValues(
+          await verifyMetadataValues(
             values,
             fileProperties,
             'salesforce/Records/LightningComponentBundle/myLightningComponentBundle'
@@ -557,7 +557,7 @@ describe('XML Transformer', () => {
           const values = await fromRetrieveResult(
             await createRetrieveResult([fileProperties]), [fileProperties], new Set(), new Set(),
           )
-          verifyMetadataValues(
+          await verifyMetadataValues(
             values,
             fileProperties,
             'salesforce/InstalledPackages/myNamespace/Records/LightningComponentBundle/myLightningComponentBundle'
@@ -623,11 +623,11 @@ describe('XML Transformer', () => {
             namespacePrefix,
           })
 
-        const verifyMetadataValues = (
+        const verifyMetadataValues = async (
           values: { file: FileProperties; values: MetadataValues}[],
           fileProperties: FileProperties,
           staticFilesExpectedFolder: string
-        ): void => {
+        ): Promise<void> => {
           expect(values).toHaveLength(1)
           const [auraInstance] = values
           expect(auraInstance.file).toEqual(fileProperties)
@@ -637,42 +637,42 @@ describe('XML Transformer', () => {
           expect(metadataInfo.type).toEqual('Component')
           expect(isStaticFile(metadataInfo.markup)).toBe(true)
           const markupStaticFile = metadataInfo.markup as StaticFile
-          expect(markupStaticFile.content).toEqual(Buffer.from('// some component content'))
+          expect(await markupStaticFile.getContent()).toEqual(Buffer.from('// some component content'))
           expect(markupStaticFile.filepath).toEqual(`${staticFilesExpectedFolder}/myAuraDefinitionBundle.cmp`)
           expect(isStaticFile(metadataInfo.controllerContent)).toBe(true)
           const controllerStaticFile = metadataInfo.controllerContent as StaticFile
-          expect(controllerStaticFile.content).toEqual(Buffer.from('// some controller content'))
+          expect(await controllerStaticFile.getContent()).toEqual(Buffer.from('// some controller content'))
           expect(controllerStaticFile.filepath)
             .toEqual(`${staticFilesExpectedFolder}/myAuraDefinitionBundleController.js`)
           expect(isStaticFile(metadataInfo.designContent)).toBe(true)
           const designStaticFile = metadataInfo.designContent as StaticFile
-          expect(designStaticFile.content).toEqual(Buffer.from('// some design content'))
+          expect(await designStaticFile.getContent()).toEqual(Buffer.from('// some design content'))
           expect(designStaticFile.filepath)
             .toEqual(`${staticFilesExpectedFolder}/myAuraDefinitionBundle.design`)
           expect(isStaticFile(metadataInfo.documentationContent)).toBe(true)
           const documentationStaticFile = metadataInfo.documentationContent as StaticFile
-          expect(documentationStaticFile.content)
+          expect(await documentationStaticFile.getContent())
             .toEqual(Buffer.from('// some documentation content'))
           expect(documentationStaticFile.filepath)
             .toEqual(`${staticFilesExpectedFolder}/myAuraDefinitionBundle.auradoc`)
           expect(isStaticFile(metadataInfo.helperContent)).toBe(true)
           const helperStaticFile = metadataInfo.helperContent as StaticFile
-          expect(helperStaticFile.content).toEqual(Buffer.from('// some helper content'))
+          expect(await helperStaticFile.getContent()).toEqual(Buffer.from('// some helper content'))
           expect(helperStaticFile.filepath)
             .toEqual(`${staticFilesExpectedFolder}/myAuraDefinitionBundleHelper.js`)
           expect(isStaticFile(metadataInfo.rendererContent)).toBe(true)
           const rendererStaticFile = metadataInfo.rendererContent as StaticFile
-          expect(rendererStaticFile.content).toEqual(Buffer.from('// some renderer content'))
+          expect(await rendererStaticFile.getContent()).toEqual(Buffer.from('// some renderer content'))
           expect(rendererStaticFile.filepath)
             .toEqual(`${staticFilesExpectedFolder}/myAuraDefinitionBundleRenderer.js`)
           expect(isStaticFile(metadataInfo.styleContent)).toBe(true)
           const styleStaticFile = metadataInfo.styleContent as StaticFile
-          expect(styleStaticFile.content).toEqual(Buffer.from('// some style content'))
+          expect(await styleStaticFile.getContent()).toEqual(Buffer.from('// some style content'))
           expect(styleStaticFile.filepath)
             .toEqual(`${staticFilesExpectedFolder}/myAuraDefinitionBundle.css`)
           expect(isStaticFile(metadataInfo.SVGContent)).toBe(true)
           const svgStaticFile = metadataInfo.SVGContent as StaticFile
-          expect(svgStaticFile.content).toEqual(Buffer.from('// some svg content'))
+          expect(await svgStaticFile.getContent()).toEqual(Buffer.from('// some svg content'))
           expect(svgStaticFile.filepath)
             .toEqual(`${staticFilesExpectedFolder}/myAuraDefinitionBundle.svg`)
         }
@@ -682,7 +682,7 @@ describe('XML Transformer', () => {
           const values = await fromRetrieveResult(
             await createRetrieveResult([fileProperties]), [fileProperties], new Set(), new Set(),
           )
-          verifyMetadataValues(
+          await verifyMetadataValues(
             values,
             fileProperties,
             'salesforce/Records/AuraDefinitionBundle/myAuraDefinitionBundle'
@@ -694,7 +694,7 @@ describe('XML Transformer', () => {
           const values = await fromRetrieveResult(
             await createRetrieveResult([fileProperties]), [fileProperties], new Set(), new Set(),
           )
-          verifyMetadataValues(
+          await verifyMetadataValues(
             values,
             fileProperties,
             'salesforce/InstalledPackages/myNamespace/Records/AuraDefinitionBundle/myAuraDefinitionBundle'

--- a/packages/workspace/src/workspace/dir_store.ts
+++ b/packages/workspace/src/workspace/dir_store.ts
@@ -38,7 +38,3 @@ export type DirectoryStore<T extends ContentType> = {
   getFullPath(filename: string): string
   isPathIncluded(filePath: string): boolean
 }
-
-export type SyncDirectoryStore<T extends ContentType> = DirectoryStore<T> & {
-  getSync(filename: string): File<T> | undefined
-}

--- a/packages/workspace/test/serializer/serializer.test.ts
+++ b/packages/workspace/test/serializer/serializer.test.ts
@@ -29,7 +29,6 @@ import { TestFuncImpl } from '../utils'
 import { serialize, deserialize, SALTO_CLASS_FIELD, deserializeMergeErrors, deserializeValidationErrors } from '../../src/serializer/elements'
 import { resolve } from '../../src/expressions'
 import { LazyStaticFile } from '../../src/workspace/static_files/source'
-import { SyncDirectoryStore } from '../../src/workspace/dir_store'
 import { createInMemoryElementSource } from '../../src/workspace/elements_source'
 import { MergeError, DuplicateAnnotationError } from '../../src/merger/internal/common'
 import {
@@ -42,6 +41,7 @@ import { DuplicateVariableNameError } from '../../src/merger/internal/variables'
 import { CircularReferenceValidationError, IllegalReferenceValidationError, MissingRequiredFieldValidationError, RegexMismatchValidationError, InvalidValueRangeValidationError, InvalidStaticFileError, InvalidTypeValidationError } from '../../src/validator'
 import { UnresolvedReferenceValidationError } from '../../src/errors'
 import { MissingStaticFile } from '../../src/workspace/static_files'
+import { DirectoryStore } from '../../src/workspace/dir_store'
 
 const { awu } = collections.asynciterable
 describe('State/cache serialization', () => {
@@ -375,7 +375,7 @@ describe('State/cache serialization', () => {
         typeWithLazyStaticFile,
         {
           file: new LazyStaticFile(
-            'some/path.ext', 'hash', {} as unknown as SyncDirectoryStore<Buffer>
+            'some/path.ext', 'hash', {} as unknown as DirectoryStore<Buffer>
           ),
         },
       )

--- a/packages/workspace/test/utils.ts
+++ b/packages/workspace/test/utils.ts
@@ -67,8 +67,8 @@ export const mockStaticFilesSource = (staticFiles: StaticFile[] = []): StaticFil
   getStaticFile: jest.fn().mockImplementation((filepath: string, _encoding: BufferEncoding) => (
     staticFiles.find(sf => sf.filepath === filepath) ?? new MissingStaticFile(filepath)
   )),
-  getContent: jest.fn().mockImplementation((filepath: string) => (
-    staticFiles.find(sf => sf.filepath === filepath)?.content ?? undefined
+  getContent: jest.fn().mockImplementation(async (filepath: string) => (
+    await staticFiles.find(sf => sf.filepath === filepath)?.getContent() ?? undefined
   )),
   persistStaticFile: jest.fn().mockReturnValue([]),
   flush: jest.fn(),

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -3300,14 +3300,14 @@ describe('workspace', () => {
         const elem = await (await workspace.elements()).get(elemID) as Element
         expect(isStaticFile(elem.annotations.static)).toBeTruthy()
         const elemStaticFile = elem.annotations.static as StaticFile
-        expect(elemStaticFile.content).toEqual(defaultStaticFile.content)
+        expect(await elemStaticFile.getContent()).toEqual(await defaultStaticFile.getContent())
       })
 
       it('should deserialize static files from the non-active env', async () => {
         const elem = await (await workspace.elements(true, 'inactive')).get(elemID) as Element
         expect(isStaticFile(elem.annotations.static)).toBeTruthy()
         const elemStaticFile = elem.annotations.static as StaticFile
-        expect(elemStaticFile.content).toEqual(inactiveStaticFile.content)
+        expect(await elemStaticFile.getContent()).toEqual(await inactiveStaticFile.getContent())
       })
     })
 

--- a/packages/zendesk-support-adapter/src/filters/macro_attachments.ts
+++ b/packages/zendesk-support-adapter/src/filters/macro_attachments.ts
@@ -93,7 +93,7 @@ const addAttachment = async (client: ZendeskClient, instance: InstanceElement):
 ReturnType<typeof client.post> => {
   const form = new FormData()
   const fileContent = isStaticFile(instance.value.content)
-    ? instance.value.content.content
+    ? await instance.value.content.getContent()
     : instance.value.content
   form.append('attachment', fileContent, instance.value.filename)
   form.append('filename', instance.value.filename)


### PR DESCRIPTION
Removed the sync `content` property from `StaticFile` and removed `getSync` from dirStore.
This is for the static files refactor task.
I will also open a PR in the SaaS for this

---
_Release Notes_: 
None

---
_User Notifications_: 
None