### PR TITLE
SALTO-2232: Revert "Revert "Salto 2232 fix changes in static files are not detected (#3054)" (#3070)"

### DIFF
--- a/packages/core/src/local-workspace/static_files_cache.ts
+++ b/packages/core/src/local-workspace/static_files_cache.ts
@@ -20,7 +20,7 @@ import { safeJsonStringify } from '@salto-io/adapter-utils'
 
 export const CACHE_FILENAME = 'static-file-cache'
 
-export type StaticFilesCacheState = Record<string, staticFiles.StaticFilesCacheResult>
+export type StaticFilesCacheState = Record<string, staticFiles.StaticFilesData>
 
 export const buildLocalStaticFilesCache = (
   baseDir: string,
@@ -37,10 +37,10 @@ export const buildLocalStaticFilesCache = (
   let cache: Promise<StaticFilesCacheState> = initCacheState || initCache()
 
   return {
-    get: async (filepath: string): Promise<staticFiles.StaticFilesCacheResult> => (
+    get: async (filepath: string): Promise<staticFiles.StaticFilesData> => (
       (await cache)[filepath]
     ),
-    put: async (item: staticFiles.StaticFilesCacheResult): Promise<void> => {
+    put: async (item: staticFiles.StaticFilesData): Promise<void> => {
       (await cache)[item.filepath] = item
     },
     flush: async () => {
@@ -65,5 +65,8 @@ export const buildLocalStaticFilesCache = (
       cacheDir = newCacheDir
     },
     clone: () => buildLocalStaticFilesCache(cacheDir, currentName, cache),
+    list: async () => (
+      Object.keys((await cache))
+    ),
   }
 }

--- a/packages/core/test/workspace/local/static_files_cache.test.ts
+++ b/packages/core/test/workspace/local/static_files_cache.test.ts
@@ -111,4 +111,19 @@ describe('Static Files Cache', () => {
     return expect(staticFilesCacheClone.get(baseMetaData.filepath))
       .resolves.toEqual(expectedResult)
   })
+  it('list', async () => {
+    const file1 = {
+      filepath: 'file1.txt',
+      hash: 'HASH',
+      modified: 123,
+    }
+    const file2 = {
+      filepath: 'file2.txt',
+      hash: 'HASH',
+      modified: 123,
+    }
+    await staticFilesCache.put(file1)
+    await staticFilesCache.put(file2)
+    expect(await staticFilesCache.list()).toEqual([file1.filepath, file2.filepath])
+  })
 })

--- a/packages/core/test/workspace/local/workspace.test.ts
+++ b/packages/core/test/workspace/local/workspace.test.ts
@@ -61,6 +61,7 @@ jest.mock('../../../src/local-workspace/dir_store')
 jest.mock('../../../src/local-workspace/static_files_cache', () => ({
   buildLocalStaticFilesCache: () => ({
     rename: jest.fn(),
+    list: jest.fn().mockResolvedValue([]),
   }),
 }))
 jest.mock('../../../src/local-workspace/remote_map', () => ({

--- a/packages/lang-server/test/workspace.ts
+++ b/packages/lang-server/test/workspace.ts
@@ -144,6 +144,7 @@ const buildMockWorkspace = async (
 ):
 Promise<Workspace> => {
   const mockStaticFilesCache: staticFiles.StaticFilesCache = {
+    list: mockFunction<staticFiles.StaticFilesCache['list']>(),
     get: mockFunction<staticFiles.StaticFilesCache['get']>(),
     put: mockFunction<staticFiles.StaticFilesCache['put']>(),
     flush: mockFunction<staticFiles.StaticFilesCache['flush']>(),

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -54,7 +54,7 @@ export const HASH_KEY = 'hash'
 
 const PARSE_CONCURRENCY = 100
 const DUMP_CONCURRENCY = 100
-// TODO: this should moved into cache implemenation
+// TODO: this should moved into cache implementation
 const CACHE_READ_CONCURRENCY = 100
 const UPDATE_INDEX_CONCURRENCY = 100
 
@@ -590,7 +590,7 @@ const buildNaclFilesSource = (
     if (!ignoreFileChanges) {
       const preChangeHash = await currentState.parsedNaclFiles.getHash()
       const cacheFilenames = await currentState.parsedNaclFiles.list()
-      const modifiedStaticFiles = await staticFilesSource.load()
+      const modifiedStaticFiles = await staticFilesSource.load?.() ?? []
       const naclFilenames = new Set(await naclFilesStore.list())
       const fileNames = new Set()
       await withLimitedConcurrency(

--- a/packages/workspace/src/workspace/nacl_files/parsed_nacl_file.ts
+++ b/packages/workspace/src/workspace/nacl_files/parsed_nacl_file.ts
@@ -19,6 +19,7 @@ import { SourceMap, ParseError } from '../../parser'
 export type ParsedNaclFileData = {
   errors: () => Promise<ParseError[] | undefined>
   referenced: () => Promise<string[]>
+  staticFiles: () => Promise<string[]>
 }
 
 export type ParsedNaclFile = {

--- a/packages/workspace/src/workspace/nacl_files/parsed_nacl_files_cache.ts
+++ b/packages/workspace/src/workspace/nacl_files/parsed_nacl_files_cache.ts
@@ -42,6 +42,7 @@ type CacheSources = {
   metadata: RemoteMap<FileCacheMetadata>
   errors: RemoteMap<ParseError[]>
   referenced: RemoteMap<string[]>
+  staticFiles: RemoteMap<string[]>
 }
 
 export type ParsedNaclFileCache = {
@@ -76,6 +77,7 @@ const parseNaclFileFromCacheSources = async (
   data: {
     errors: async () => (await cacheSources.errors.get(filename) ?? []),
     referenced: async () => (await cacheSources.referenced.get(filename) ?? []),
+    staticFiles: async () => (await cacheSources.staticFiles.get(filename) ?? []),
   },
   sourceMap: () => cacheSources.sourceMap.get(filename),
 })
@@ -142,6 +144,12 @@ const getCacheSources = async (
     deserialize: data => (JSON.parse(data)),
     persistent,
   })),
+  staticFiles: (await remoteMapCreator({
+    namespace: getRemoteMapCacheNamespace(cacheName, 'staticFiles'),
+    serialize: (val: string[]) => safeJsonStringify(val ?? []),
+    deserialize: data => (JSON.parse(data)),
+    persistent,
+  })),
 })
 
 const copyAllSourcesToNewName = async (
@@ -173,7 +181,7 @@ export const createParseResultCache = (
   return {
     put: async (filename: string, value: ParsedNaclFile): Promise<void> => {
       cachedHash = undefined
-      const { metadata, errors, referenced, sourceMap, elements } = await cacheSources
+      const { metadata, errors, referenced, sourceMap, elements, staticFiles } = await cacheSources
       const fileErrors = await value.data.errors()
       const currentError = await errors.get(filename)
       if (!_.isEqual((currentError ?? []), (fileErrors ?? []))) {
@@ -184,6 +192,7 @@ export const createParseResultCache = (
         }
       }
       await referenced.set(value.filename, await value.data.referenced())
+      await staticFiles.set(value.filename, await value.data.staticFiles())
       const sourceMapValue = await value.sourceMap?.()
       if (sourceMapValue !== undefined) {
         await sourceMap.set(value.filename, sourceMapValue)
@@ -194,7 +203,7 @@ export const createParseResultCache = (
       await metadata.set(filename, { hash: hash.toMD5(value.buffer ?? '') })
     },
     putAll: async (files: Record<string, ParsedNaclFile>): Promise<void> => {
-      const { metadata, errors, referenced, sourceMap, elements } = await cacheSources
+      const { metadata, errors, referenced, sourceMap, elements, staticFiles } = await cacheSources
       cachedHash = undefined
       const errorEntriesToAdd = awu(Object.keys(files))
         .map(async file => {
@@ -215,6 +224,8 @@ export const createParseResultCache = (
       await errors.deleteAll(errorEntriesToDelete)
       await referenced.setAll(awu(Object.keys(files))
         .map(async file => ({ key: file, value: await files[file].data.referenced() })))
+      await staticFiles.setAll(awu(Object.keys(files))
+        .map(async file => ({ key: file, value: await files[file].data.staticFiles() })))
       await sourceMap.setAll(awu(Object.keys(files))
         .map(async file => {
           const fileSourceMap = await files[file].sourceMap?.()

--- a/packages/workspace/src/workspace/static_files/cache.ts
+++ b/packages/workspace/src/workspace/static_files/cache.ts
@@ -13,17 +13,18 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-export type StaticFilesCacheResult = {
+export type StaticFilesData = {
   modified: number
   hash: string
   filepath: string
 }
 
 export type StaticFilesCache = {
-  get(filepath: string): Promise<StaticFilesCacheResult | undefined>
-  put(item: StaticFilesCacheResult): Promise<void>
+  get(filepath: string): Promise<StaticFilesData | undefined>
+  put(item: StaticFilesData): Promise<void>
   flush(): Promise<void>
   clear(): Promise<void>
   rename(name: string): Promise<void>
   clone(): StaticFilesCache
+  list(): Promise<string[]>
 }

--- a/packages/workspace/src/workspace/static_files/common.ts
+++ b/packages/workspace/src/workspace/static_files/common.ts
@@ -23,7 +23,8 @@ export abstract class InvalidStaticFile {
 }
 
 export type StaticFilesSource = {
-  load(): Promise<string[]>
+  // Load is optional for backwards compatibility
+  load?(): Promise<string[]>
   getStaticFile: (filepath: string, encoding: BufferEncoding) =>
     Promise<StaticFile | InvalidStaticFile>
   getContent: (filepath: string) => Promise<Buffer>

--- a/packages/workspace/src/workspace/static_files/common.ts
+++ b/packages/workspace/src/workspace/static_files/common.ts
@@ -23,6 +23,7 @@ export abstract class InvalidStaticFile {
 }
 
 export type StaticFilesSource = {
+  load(): Promise<string[]>
   getStaticFile: (filepath: string, encoding: BufferEncoding) =>
     Promise<StaticFile | InvalidStaticFile>
   getContent: (filepath: string) => Promise<Buffer>

--- a/packages/workspace/src/workspace/static_files/index.ts
+++ b/packages/workspace/src/workspace/static_files/index.ts
@@ -13,6 +13,6 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-export { StaticFilesCache, StaticFilesCacheResult } from './cache'
+export { StaticFilesCache, StaticFilesData } from './cache'
 export { buildStaticFilesSource, buildInMemStaticFilesSource, LazyStaticFile, AbsoluteStaticFile } from './source'
 export { StaticFilesSource, MissingStaticFile, AccessDeniedStaticFile } from './common'

--- a/packages/workspace/src/workspace/static_files/source.ts
+++ b/packages/workspace/src/workspace/static_files/source.ts
@@ -13,14 +13,30 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { StaticFile, StaticFileParameters } from '@salto-io/adapter-api'
+import { StaticFile, StaticFileParameters, calculateStaticFileHash } from '@salto-io/adapter-api'
 
+import wu from 'wu'
+import { values, promises } from '@salto-io/lowerdash'
 import { SyncDirectoryStore } from '../dir_store'
-import { StaticFilesCache } from './cache'
+import { StaticFilesCache, StaticFilesData } from './cache'
 
 import {
   InvalidStaticFile, StaticFilesSource, MissingStaticFile, AccessDeniedStaticFile,
 } from './common'
+
+const { withLimitedConcurrency } = promises.array
+
+class StaticFileAccessDeniedError extends Error {
+  constructor(filepath: string) {
+    super(`access denied for ${filepath}`)
+  }
+}
+
+class MissingStaticFileError extends Error {
+  constructor(filepath: string) {
+    super(`missing static file ${filepath}`)
+  }
+}
 
 export class AbsoluteStaticFile extends StaticFile {
   protected dirStore: SyncDirectoryStore<Buffer>
@@ -67,50 +83,106 @@ export const buildStaticFilesSource = (
   staticFilesDirStore: SyncDirectoryStore<Buffer>,
   staticFilesCache: StaticFilesCache,
 ): StaticFilesSource => {
-  const staticFilesSource: StaticFilesSource = {
-    getStaticFile: async (
-      filepath: string,
-      encoding: BufferEncoding,
-    ): Promise<StaticFile | InvalidStaticFile> => {
-      const cachedResult = await staticFilesCache.get(filepath)
-      let modified: number | undefined
-      try {
-        modified = await staticFilesDirStore.mtimestamp(filepath)
-      } catch (err) {
-        return new AccessDeniedStaticFile(filepath)
-      }
-      if (modified === undefined) {
-        return new MissingStaticFile(filepath)
-      }
+  const getStaticFileData = async (filepath: string): Promise<
+    ({ hasChanged: false } | { hasChanged: true; buffer: Buffer}) & StaticFilesData
+  > => {
+    const cachedResult = await staticFilesCache.get(filepath)
+    let modified: number | undefined
+    try {
+      modified = await staticFilesDirStore.mtimestamp(filepath)
+    } catch (err) {
+      throw new StaticFileAccessDeniedError(filepath)
+    }
+    if (modified === undefined) {
+      throw new MissingStaticFileError(filepath)
+    }
 
-      const hashModified = cachedResult ? cachedResult.modified : undefined
+    const cacheModified = cachedResult ? cachedResult.modified : undefined
 
-      if (hashModified === undefined
-        || modified > hashModified
-        || cachedResult === undefined) {
-        const file = await staticFilesDirStore.get(filepath)
-        if (file === undefined) {
-          return new MissingStaticFile(filepath)
-        }
-        const staticFileBuffer = file.buffer
+    if (cachedResult === undefined
+        || cacheModified === undefined
+        || modified > cacheModified) {
+      const file = await staticFilesDirStore.get(filepath)
+      if (file === undefined) {
+        throw new MissingStaticFileError(filepath)
+      }
+      const staticFileBuffer = file.buffer
+      const hash = calculateStaticFileHash(staticFileBuffer)
+      await staticFilesCache.put({
+        hash,
+        modified,
+        filepath,
+      })
+      return {
+        filepath,
+        hash,
+        modified,
+        buffer: staticFileBuffer,
+        hasChanged: true,
+      }
+    }
+    return {
+      ...cachedResult,
+      hasChanged: false,
+    }
+  }
+
+  const getStaticFile = async (
+    filepath: string,
+    encoding: BufferEncoding,
+  ): Promise<StaticFile | InvalidStaticFile> => {
+    try {
+      const staticFileData = await getStaticFileData(filepath)
+
+      if (staticFileData.hasChanged) {
         const staticFileWithHashAndContent = new AbsoluteStaticFile({ filepath,
-          content: staticFileBuffer,
+          content: staticFileData.buffer,
           encoding },
         staticFilesDirStore)
-        await staticFilesCache.put({
-          hash: staticFileWithHashAndContent.hash,
-          modified,
-          filepath,
-        })
         return staticFileWithHashAndContent
       }
       return new LazyStaticFile(
         filepath,
-        cachedResult.hash,
+        staticFileData.hash,
         staticFilesDirStore,
         encoding,
       )
+    } catch (e) {
+      if (e instanceof MissingStaticFileError) {
+        return new MissingStaticFile(filepath)
+      }
+      if (e instanceof StaticFileAccessDeniedError) {
+        return new AccessDeniedStaticFile(filepath)
+      }
+      throw e
+    }
+  }
+
+  const staticFilesSource: StaticFilesSource = {
+    load: async (): Promise<string[]> => {
+      const existingFiles = new Set(await staticFilesDirStore.list())
+      const cachedFileNames = new Set(await staticFilesCache.list())
+      const newFiles = wu(existingFiles.keys())
+        .filter(name => !cachedFileNames.has(name))
+        .toArray()
+      const deletedFiles = wu(cachedFileNames.keys())
+        .filter(name => !existingFiles.has(name))
+        .toArray()
+
+      const modifiedFilesSet = new Set((await withLimitedConcurrency(
+        wu(existingFiles.keys())
+          .filter(name => cachedFileNames.has(name))
+          .map(name => async () => ((await getStaticFileData(name)).hasChanged ? name : undefined)),
+        500
+      )).filter(values.isDefined))
+
+      return [
+        ...newFiles,
+        ...deletedFiles,
+        ...modifiedFilesSet.keys(),
+      ]
     },
+    getStaticFile,
     getContent: async (
       filepath: string
     ): Promise<Buffer> => {

--- a/packages/workspace/test/common/nacl_file_source.ts
+++ b/packages/workspace/test/common/nacl_file_source.ts
@@ -112,6 +112,7 @@ export const createMockNaclFileSource = (
         data: {
           errors: () => Promise.resolve([]),
           referenced: () => Promise.resolve([]),
+          staticFiles: () => Promise.resolve([]),
         },
         elements: () => Promise.resolve(naclFiles[filename] || []),
         buffer: '',

--- a/packages/workspace/test/common/nacl_file_store.ts
+++ b/packages/workspace/test/common/nacl_file_store.ts
@@ -316,6 +316,7 @@ export const mockParseCache = (): ParsedNaclFileCache => ({
     data: {
       errors: () => Promise.resolve([]),
       referenced: () => Promise.resolve([]),
+      staticFiles: () => Promise.resolve([]),
     },
   }),
   flush: () => Promise.resolve(undefined),

--- a/packages/workspace/test/utils.ts
+++ b/packages/workspace/test/utils.ts
@@ -63,6 +63,7 @@ export const registerTestFunction = (
 )
 
 export const mockStaticFilesSource = (staticFiles: StaticFile[] = []): StaticFilesSource => ({
+  load: jest.fn().mockResolvedValue([]),
   getStaticFile: jest.fn().mockImplementation((filepath: string, _encoding: BufferEncoding) => (
     staticFiles.find(sf => sf.filepath === filepath) ?? new MissingStaticFile(filepath)
   )),

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
@@ -409,6 +409,7 @@ describe('Nacl Files Source', () => {
           data: {
             errors: () => Promise.resolve([]),
             referenced: () => Promise.resolve([]),
+            staticFiles: () => Promise.resolve([]),
           },
         },
       ]

--- a/packages/workspace/test/workspace/static_files/source.test.ts
+++ b/packages/workspace/test/workspace/static_files/source.test.ts
@@ -30,7 +30,7 @@ import {
 
 describe('Static Files', () => {
   describe('Static Files Source', () => {
-    let staticFilesSource: StaticFilesSource
+    let staticFilesSource: Required<StaticFilesSource>
     let mockDirStore: SyncDirectoryStore<Buffer>
     let mockCacheStore: StaticFilesCache
     beforeEach(() => {

--- a/packages/workspace/test/workspace/static_files/source.test.ts
+++ b/packages/workspace/test/workspace/static_files/source.test.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import { StaticFile } from '@salto-io/adapter-api'
+import _ from 'lodash'
 import { SyncDirectoryStore } from '../../../src/workspace/dir_store'
 import { buildStaticFilesSource, StaticFilesCache, LazyStaticFile, buildInMemStaticFilesSource } from '../../../src/workspace/static_files'
 
@@ -34,6 +35,7 @@ describe('Static Files', () => {
     let mockCacheStore: StaticFilesCache
     beforeEach(() => {
       mockCacheStore = {
+        list: jest.fn().mockResolvedValue([]),
         get: jest.fn().mockResolvedValue(undefined),
         getByFile: jest.fn().mockResolvedValue(undefined),
         put: jest.fn().mockResolvedValue(Promise.resolve()),
@@ -250,6 +252,62 @@ describe('Static Files', () => {
       it('should invoke the dir store delete method with the static file file path attribute', async () => {
         await staticFilesSource.delete(exampleStaticFileWithContent)
         expect(mockDirStore.delete).toHaveBeenCalledWith(exampleStaticFileWithContent.filepath)
+      })
+    })
+    describe('load', () => {
+      let changedFiles: string[]
+      const newFile = {
+        filename: 'new.txt',
+        modified: 12345,
+        hash: '9cd599a3523898e6a12e13ec787da50a',
+        buffer: 'new',
+      }
+      const modifiedFileBefore = {
+        filename: 'modified.txt',
+        modified: 12345,
+        hash: 'ab8d71b3fdce92efd8bdf29cffd36116',
+        buffer: 'before',
+      }
+      const modifiedFileAfter = {
+        filename: 'modified.txt',
+        modified: 12346,
+        hash: '99fd6b62bc270c9bc820dc111f370acd',
+        buffer: 'after',
+      }
+      const regFile = {
+        filename: 'reg.txt',
+        modified: 12345,
+        hash: '4200f0916f146d2ac5448e91a3afe1b3',
+        buffer: 'reg',
+      }
+      const deletedFile = {
+        filename: 'deleted.txt',
+        modified: 12345,
+        hash: '12e7bce94552f7a4288921f908df9b8c',
+        buffer: 'del',
+      }
+      const dirStoreFiles = _.keyBy([newFile, modifiedFileAfter, regFile], 'filename')
+      const cacheFiles = _.keyBy([deletedFile, modifiedFileBefore, regFile], 'filename')
+      beforeEach(async () => {
+        mockDirStore.list = jest.fn().mockResolvedValueOnce(Object.keys(dirStoreFiles))
+        mockCacheStore.list = jest.fn().mockResolvedValueOnce(Object.keys(cacheFiles))
+        mockDirStore.get = jest.fn().mockImplementation(async name => dirStoreFiles[name])
+        mockDirStore.mtimestamp = jest.fn()
+          .mockImplementation(async name => dirStoreFiles[name].modified)
+        mockCacheStore.get = jest.fn().mockImplementation(async name => cacheFiles[name])
+        changedFiles = await staticFilesSource.load()
+      })
+      it('should detect addition of new files', () => {
+        expect(changedFiles).toContain(newFile.filename)
+      })
+      it('should detect deletions of existing files', () => {
+        expect(changedFiles).toContain(deletedFile.filename)
+      })
+      it('should detect changes in modified files', () => {
+        expect(changedFiles).toContain(modifiedFileAfter.filename)
+      })
+      it('should not return files that were not changed', () => {
+        expect(changedFiles).not.toContain(regFile.filename)
       })
     })
   })


### PR DESCRIPTION


---

Continuing the chain of reverts to bring back @roironn's original implementation, this time making the interface change less breaking.
@alonstern - the revert is mostly unchanged (only fixing a conflict in the exports of the static files module), my changes are in the second commit

---
_Release Notes_: 
Core:
- Fixed issue where errors relating to static files would not be updated properly

---
_User Notifications_: 
_None_
