### PR TITLE
fix an issue where templates wouldn't parse for ids that include '@'

### DIFF
--- a/packages/workspace/src/parser/internal/native/lexer.ts
+++ b/packages/workspace/src/parser/internal/native/lexer.ts
@@ -67,13 +67,13 @@ export const rules: Record<string, moo.Rules> = {
     [TOKEN_TYPES.INVALID]: { match: /[^ \n]+/, error: true },
   },
   string: {
-    [TOKEN_TYPES.REFERENCE]: { match: /\$\{[ \t]*[\d\w.]+[ \t]*\}/, value: s => s.slice(2, -1).trim() },
+    [TOKEN_TYPES.REFERENCE]: { match: /\$\{[ \t]*[\d\w.@]+[ \t]*\}/, value: s => s.slice(2, -1).trim() },
     [TOKEN_TYPES.DOUBLE_QUOTES]: { match: '"', pop: 1 },
     [TOKEN_TYPES.CONTENT]: { match: /(?:[^"\\\r\n]|\\.)+?(?="|\r|\n|\$\{)/, lineBreaks: false },
     [TOKEN_TYPES.NEWLINE]: { match: /[\r\n]+/, lineBreaks: true, pop: 1 },
   },
   multilineString: {
-    [TOKEN_TYPES.REFERENCE]: { match: /\$\{[ \t]*[\d\w.]+[ \t]*\}/, value: s => s.slice(2, -1).trim() },
+    [TOKEN_TYPES.REFERENCE]: { match: /\$\{[ \t]*[\d\w.@]+[ \t]*\}/, value: s => s.slice(2, -1).trim() },
     [TOKEN_TYPES.MULTILINE_END]: { match: /^[ \t]*'''/, pop: 1 },
     [TOKEN_TYPES.CONTENT]: { match: /.*\\\$\{.*[(\r\n)(\n)]|.*?(?=\$\{)|.*[(\r\n)(\n)]/, lineBreaks: true },
   },

--- a/packages/workspace/src/parser/internal/native/lexer.ts
+++ b/packages/workspace/src/parser/internal/native/lexer.ts
@@ -46,7 +46,7 @@ export const TOKEN_TYPES = {
   CONFLICT_CONTENT: 'mergeConflictContent',
 }
 
-const WORD_PART = '[\\w.@]'
+const WORD_PART = '[a-zA-Z_][\\w.@]*'
 
 export const rules: Record<string, moo.Rules> = {
   main: {
@@ -62,20 +62,20 @@ export const rules: Record<string, moo.Rules> = {
     [TOKEN_TYPES.CCURLY]: '}',
     [TOKEN_TYPES.OCURLY]: '{',
     [TOKEN_TYPES.EQUAL]: '=',
-    [TOKEN_TYPES.WORD]: new RegExp(`[a-zA-Z_]${WORD_PART}*`, 's'),
+    [TOKEN_TYPES.WORD]: new RegExp(WORD_PART, 's'),
     [TOKEN_TYPES.COMMENT]: /\/\//,
     [TOKEN_TYPES.WHITESPACE]: { match: /[ \t]+/ },
     [TOKEN_TYPES.NEWLINE]: { match: /[\r\n]+/, lineBreaks: true },
     [TOKEN_TYPES.INVALID]: { match: /[^ \n]+/, error: true },
   },
   string: {
-    [TOKEN_TYPES.REFERENCE]: { match: new RegExp(`\\$\\{[ \\t]*${WORD_PART}+[ \\t]*\\}`), value: s => s.slice(2, -1).trim() },
+    [TOKEN_TYPES.REFERENCE]: { match: new RegExp(`\\$\\{[ \\t]*${WORD_PART}[ \\t]*\\}`), value: s => s.slice(2, -1).trim() },
     [TOKEN_TYPES.DOUBLE_QUOTES]: { match: '"', pop: 1 },
     [TOKEN_TYPES.CONTENT]: { match: /(?:[^"\\\r\n]|\\.)+?(?="|\r|\n|\$\{)/, lineBreaks: false },
     [TOKEN_TYPES.NEWLINE]: { match: /[\r\n]+/, lineBreaks: true, pop: 1 },
   },
   multilineString: {
-    [TOKEN_TYPES.REFERENCE]: { match: new RegExp(`\\$\\{[ \\t]*${WORD_PART}+[ \\t]*\\}`), value: s => s.slice(2, -1).trim() },
+    [TOKEN_TYPES.REFERENCE]: { match: new RegExp(`\\$\\{[ \\t]*${WORD_PART}[ \\t]*\\}`), value: s => s.slice(2, -1).trim() },
     [TOKEN_TYPES.MULTILINE_END]: { match: /^[ \t]*'''/, pop: 1 },
     [TOKEN_TYPES.CONTENT]: { match: /.*\\\$\{.*[(\r\n)(\n)]|.*?(?=\$\{)|.*[(\r\n)(\n)]/, lineBreaks: true },
   },

--- a/packages/workspace/src/parser/internal/native/lexer.ts
+++ b/packages/workspace/src/parser/internal/native/lexer.ts
@@ -46,6 +46,8 @@ export const TOKEN_TYPES = {
   CONFLICT_CONTENT: 'mergeConflictContent',
 }
 
+const WORD_PART = '[\\w.@]'
+
 export const rules: Record<string, moo.Rules> = {
   main: {
     [TOKEN_TYPES.MERGE_CONFLICT]: { match: '<<<<<<<', push: 'mergeConflict' },
@@ -60,20 +62,20 @@ export const rules: Record<string, moo.Rules> = {
     [TOKEN_TYPES.CCURLY]: '}',
     [TOKEN_TYPES.OCURLY]: '{',
     [TOKEN_TYPES.EQUAL]: '=',
-    [TOKEN_TYPES.WORD]: /[a-zA-Z_][\w.@]*/s,
+    [TOKEN_TYPES.WORD]: new RegExp(`[a-zA-Z_]${WORD_PART}*`, 's'),
     [TOKEN_TYPES.COMMENT]: /\/\//,
     [TOKEN_TYPES.WHITESPACE]: { match: /[ \t]+/ },
     [TOKEN_TYPES.NEWLINE]: { match: /[\r\n]+/, lineBreaks: true },
     [TOKEN_TYPES.INVALID]: { match: /[^ \n]+/, error: true },
   },
   string: {
-    [TOKEN_TYPES.REFERENCE]: { match: /\$\{[ \t]*[\d\w.@]+[ \t]*\}/, value: s => s.slice(2, -1).trim() },
+    [TOKEN_TYPES.REFERENCE]: { match: new RegExp(`\\$\\{[ \\t]*${WORD_PART}+[ \\t]*\\}`), value: s => s.slice(2, -1).trim() },
     [TOKEN_TYPES.DOUBLE_QUOTES]: { match: '"', pop: 1 },
     [TOKEN_TYPES.CONTENT]: { match: /(?:[^"\\\r\n]|\\.)+?(?="|\r|\n|\$\{)/, lineBreaks: false },
     [TOKEN_TYPES.NEWLINE]: { match: /[\r\n]+/, lineBreaks: true, pop: 1 },
   },
   multilineString: {
-    [TOKEN_TYPES.REFERENCE]: { match: /\$\{[ \t]*[\d\w.@]+[ \t]*\}/, value: s => s.slice(2, -1).trim() },
+    [TOKEN_TYPES.REFERENCE]: { match: new RegExp(`\\$\\{[ \\t]*${WORD_PART}+[ \\t]*\\}`), value: s => s.slice(2, -1).trim() },
     [TOKEN_TYPES.MULTILINE_END]: { match: /^[ \t]*'''/, pop: 1 },
     [TOKEN_TYPES.CONTENT]: { match: /.*\\\$\{.*[(\r\n)(\n)]|.*?(?=\$\{)|.*[(\r\n)(\n)]/, lineBreaks: true },
   },

--- a/packages/workspace/test/parser/parse.test.ts
+++ b/packages/workspace/test/parser/parse.test.ts
@@ -232,7 +232,7 @@ value
 
     describe('parse result', () => {
       it('should have all types', () => {
-        expect(elements.length).toBe(22)
+        expect(elements.length).toBe(24)
         expect(genericTypes.length).toBe(2)
       })
     })

--- a/packages/workspace/test/parser/parse.test.ts
+++ b/packages/workspace/test/parser/parse.test.ts
@@ -208,13 +208,13 @@ describe('Salto parser', () => {
       }
 
       type salesforce.templates {
-        tmpl = "hello {{$\{temp.late.instance.stuff@us}}}"
+        tmpl = "hello {{$\{temp.la@te.instance.stuff@us}}}"
       }
       
       type salesforce.multiline_templates {
         tmpl = '''
 multiline
-template {{$\{temp.late.instance.multiline_stuff@us}}}
+template {{$\{te@mp.late.instance.multiline_stuff@us}}}
 value
 '''
       }
@@ -719,14 +719,14 @@ value
       it('should parse references to template as TemplateExpression', () => {
         expect(refObj.annotations.tmpl).toBeInstanceOf(TemplateExpression)
         expect(refObj.annotations.tmpl.parts).toEqual(['hello {{', expect.objectContaining({
-          elemID: new ElemID('temp', 'late', 'instance', 'stuff@us'),
+          elemID: new ElemID('temp', 'la@te', 'instance', 'stuff@us'),
         }), '}}'])
       })
 
       it('should parse references to multiline template as TemplateExpression', () => {
         expect(multilineRefObj.annotations.tmpl).toBeInstanceOf(TemplateExpression)
         expect(multilineRefObj.annotations.tmpl.parts).toEqual(['multiline\n', 'template {{', expect.objectContaining({
-          elemID: new ElemID('temp', 'late', 'instance', 'multiline_stuff@us'),
+          elemID: new ElemID('te@mp', 'late', 'instance', 'multiline_stuff@us'),
         }), '}}\n', 'value'])
       })
     })

--- a/packages/workspace/test/parser/parse.test.ts
+++ b/packages/workspace/test/parser/parse.test.ts
@@ -16,7 +16,7 @@
 import {
   ObjectType, PrimitiveType, PrimitiveTypes, Element, ElemID, Variable, isMapType, isContainerType,
   isObjectType, InstanceElement, BuiltinTypes, isListType, isVariable,
-  isType, isPrimitiveType, ListType, ReferenceExpression, VariableExpression,
+  isType, isPrimitiveType, ListType, ReferenceExpression, VariableExpression, TemplateExpression,
 } from '@salto-io/adapter-api'
 
 // import each from 'jest-each'
@@ -206,7 +206,19 @@ describe('Salto parser', () => {
       type salesforce.escapedDashBeforeQuote {
         str = "you can't run away \\\\"
       }
+
+      type salesforce.templates {
+        tmpl = "hello {{$\{temp.late.instance.stuff@us}}}"
+      }
       
+      type salesforce.multiline_templates {
+        tmpl = '''
+multiline
+template {{$\{temp.late.instance.multiline_stuff@us}}}
+value
+'''
+      }
+
       `
     beforeAll(async () => {
       const parsed = await parse(Buffer.from(body), 'none', functions)
@@ -692,6 +704,30 @@ describe('Salto parser', () => {
 
       it('should parse references to variables as VariableExpressions', () => {
         expect(refObj.annotations.toVar).toBeInstanceOf(VariableExpression)
+      })
+    })
+
+    describe('templates', () => {
+      let refObj: ObjectType
+      let multilineRefObj: ObjectType
+
+      beforeAll(() => {
+        refObj = elements[22] as ObjectType
+        multilineRefObj = elements[23] as ObjectType
+      })
+
+      it('should parse references to template as TemplateExpression', () => {
+        expect(refObj.annotations.tmpl).toBeInstanceOf(TemplateExpression)
+        expect(refObj.annotations.tmpl.parts).toEqual(['hello {{', expect.objectContaining({
+          elemID: new ElemID('temp', 'late', 'instance', 'stuff@us'),
+        }), '}}'])
+      })
+
+      it('should parse references to multiline template as TemplateExpression', () => {
+        expect(multilineRefObj.annotations.tmpl).toBeInstanceOf(TemplateExpression)
+        expect(multilineRefObj.annotations.tmpl.parts).toEqual(['multiline\n', 'template {{', expect.objectContaining({
+          elemID: new ElemID('temp', 'late', 'instance', 'multiline_stuff@us'),
+        }), '}}\n', 'value'])
       })
     })
 


### PR DESCRIPTION
Fix an issue where templates wouldn't be parsed for ids that include "@"

---

This hasn't been an issue in the past because we had no usage of templates. But it's now required for zendesk

---
_Release Notes_: 
None

---
_User Notifications_: 
None
