### PR TITLE
Reduced deploy concurrency in Jira

### DIFF
--- a/packages/jira-adapter/src/client/client.ts
+++ b/packages/jira-adapter/src/client/client.ts
@@ -28,7 +28,7 @@ const {
 const DEFAULT_MAX_CONCURRENT_API_REQUESTS: Required<clientUtils.ClientRateLimitConfig> = {
   total: RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,
   get: 20,
-  deploy: 20,
+  deploy: 2,
 }
 
 const DEFAULT_PAGE_SIZE: Required<clientUtils.ClientPageSizeConfig> = {

--- a/packages/jira-adapter/src/filters/workflow/workflow_modification_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_modification_filter.ts
@@ -139,7 +139,7 @@ const deployWorkflowModification = async ({
     })
   } catch (err) {
     await cleanTempInstance()
-    if (err.response?.data?.errorMessages.some((message: string) => message.includes('is missing the mappings required for statuses with IDs'))) {
+    if (err.response?.data?.errorMessages?.some((message: string) => message.includes('is missing the mappings required for statuses with IDs'))) {
       throw new Error(`Modification to an active workflow ${getChangeData(change).elemID.getFullName()} is not backward compatible`)
     }
     throw err


### PR DESCRIPTION
Reduced deploy concurrency in Jira because I saw we sometimes get 500 when deploying many objects in parallel
Also added `?` to fix an error message

---
_Release Notes_: 
__Jira Adapter__:
- Reduced default deploy concurrency

---
_User Notifications_: 
None