### PR TITLE
SALTO-2363: fixed deploying workflow and workflow scheme in one deployment

### DIFF
--- a/packages/jira-adapter/src/filters/workflow/workflow_modification_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_modification_filter.ts
@@ -184,7 +184,12 @@ const filter: FilterCreator = ({ client, config, elementsSource, paginator }) =>
 
     const workflowSchemes = await awu(await elementsSource.list())
       .filter(id => id.typeName === WORKFLOW_SCHEME_TYPE_NAME)
+      .filter(id => id.idType === 'instance')
       .map(id => elementsSource.get(id))
+      // instance.value.id is undefined when the workflow scheme
+      // is an addition change in the current deployment and was
+      // not deployed yet
+      .filter(instance => instance.value.id !== undefined)
       .toArray()
 
     const deployResult = await deployChanges(

--- a/packages/jira-adapter/test/filters/workflow/workflow_modification_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_modification_filter.test.ts
@@ -84,6 +84,18 @@ describe('workflowModificationFilter', () => {
       'workflowSchemeInstance',
       workflowSchemeType,
       {
+        id: '1',
+        defaultWorkflow: new ReferenceExpression(
+          workflowInstance.elemID,
+          workflowInstance,
+        ),
+      }
+    )
+
+    const newWorkflowSchemeInstance = new InstanceElement(
+      'newWorkflowSchemeInstance',
+      workflowSchemeType,
+      {
         defaultWorkflow: new ReferenceExpression(
           workflowInstance.elemID,
           workflowInstance,
@@ -93,6 +105,7 @@ describe('workflowModificationFilter', () => {
 
     elementsSource = buildElementsSourceFromElements([
       workflowSchemeInstance,
+      newWorkflowSchemeInstance,
       workflowInstance,
     ])
 
@@ -190,6 +203,8 @@ describe('workflowModificationFilter', () => {
         config,
         elementsSource,
       )
+
+      expect(deployWorkflowSchemeMock).toHaveBeenCalledTimes(2)
 
       expect(deployWorkflowMock).toHaveBeenNthCalledWith(
         4,


### PR DESCRIPTION
Fixed deployment of a modification of a workflow and an addition of a workflow scheme that uses that workflow

---

The issue was that when modifying a workflow, we first change the references of the workflow scheme that uses it, and if the workflow scheme is an addition then it was not created yet and does not have an id so we would fail when trying to change it.

---
_Release Notes_: 
__Jira Adapter__:
- Fixed bug in updating workflows

---
_User Notifications_: 
None