### PR TITLE
SALTO-2366 SALTO-2367 settings path

### DIFF
--- a/packages/adapter-components/src/elements/constants.ts
+++ b/packages/adapter-components/src/elements/constants.ts
@@ -18,3 +18,4 @@
 export const RECORDS_PATH = 'Records'
 export const TYPES_PATH = 'Types'
 export const SUBTYPES_PATH = 'Subtypes'
+export const SETTINGS_NESTED_PATH = 'Settings'

--- a/packages/adapter-components/src/elements/index.ts
+++ b/packages/adapter-components/src/elements/index.ts
@@ -19,7 +19,7 @@ import * as soap from './soap'
 import * as subtypes from './subtypes'
 import * as query from './query'
 import { computeGetArgs, simpleGetArgs, createUrl, replaceUrlParams } from './request_parameters'
-import { RECORDS_PATH, TYPES_PATH, SUBTYPES_PATH } from './constants'
+import { RECORDS_PATH, TYPES_PATH, SUBTYPES_PATH, SETTINGS_NESTED_PATH } from './constants'
 import { findDataField, returnFullEntry, FindNestedFieldFunc } from './field_finder'
 import { filterTypes } from './type_elements'
 import { getInstanceName, generateInstanceNameFromConfig, createServiceIds, removeNullValues } from './instance_elements'
@@ -31,7 +31,7 @@ export {
   subtypes,
   computeGetArgs, simpleGetArgs,
   findDataField, returnFullEntry, FindNestedFieldFunc,
-  RECORDS_PATH, TYPES_PATH, SUBTYPES_PATH,
+  RECORDS_PATH, TYPES_PATH, SUBTYPES_PATH, SETTINGS_NESTED_PATH,
   filterTypes,
   getInstanceName,
   generateInstanceNameFromConfig,

--- a/packages/adapter-components/src/elements/instance_elements.ts
+++ b/packages/adapter-components/src/elements/instance_elements.ts
@@ -20,7 +20,7 @@ import {
 } from '@salto-io/adapter-api'
 import { pathNaclCase, naclCase, transformValues, TransformFunc } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
-import { RECORDS_PATH } from './constants'
+import { RECORDS_PATH, SETTINGS_NESTED_PATH } from './constants'
 import { TransformationConfig, TransformationDefaultConfig, getConfigWithDefault,
   RecurseIntoCondition, isRecurseIntoConditionByField, AdapterApiConfig, dereferenceFieldName } from '../config'
 
@@ -81,6 +81,7 @@ export const getInstanceFilePath = ({
     ? [
       adapterName,
       RECORDS_PATH,
+      SETTINGS_NESTED_PATH,
       pathNaclCase(typeName),
     ]
     : [

--- a/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
@@ -1423,6 +1423,7 @@ describe('swagger_instance_elements', () => {
         [
           ADAPTER_NAME,
           'Records',
+          'Settings',
           'Owner',
         ],
       ])

--- a/packages/zendesk-support-adapter/src/filters/reorder/creator.ts
+++ b/packages/zendesk-support-adapter/src/filters/reorder/creator.ts
@@ -26,7 +26,7 @@ import { deployChange } from '../../deployment'
 import { API_DEFINITIONS_CONFIG } from '../../config'
 import ZendeskClient from '../../client/client'
 
-const { TYPES_PATH, SUBTYPES_PATH, RECORDS_PATH } = elementsUtils
+const { TYPES_PATH, SUBTYPES_PATH, RECORDS_PATH, SETTINGS_NESTED_PATH } = elementsUtils
 
 export type DeployFuncType = (
   change: Change<InstanceElement>,
@@ -99,7 +99,7 @@ export const createReorderFilterCreator = (
           inactive: instancesReferences.filter(ref => !ref.value.value[activeFieldName]),
         }
         : { active: instancesReferences },
-      [ZENDESK_SUPPORT, RECORDS_PATH, typeName, typeNameNaclCase],
+      [ZENDESK_SUPPORT, RECORDS_PATH, SETTINGS_NESTED_PATH, typeNameNaclCase],
     )
     // Those types already exist since we added the empty version of them
     //  via the add remaining types mechanism. So we first need to remove the old versions

--- a/packages/zendesk-support-adapter/src/filters/reorder/trigger.ts
+++ b/packages/zendesk-support-adapter/src/filters/reorder/trigger.ts
@@ -31,7 +31,7 @@ export const TYPE_NAME = 'trigger'
 export const TRIGGER_CATEGORY_TYPE_NAME = 'trigger_category'
 const TRIGGER_ORDER_ENTRY_TYPE_NAME = 'trigger_order_entry'
 
-const { RECORDS_PATH, SUBTYPES_PATH, TYPES_PATH } = elementsUtils
+const { RECORDS_PATH, SUBTYPES_PATH, TYPES_PATH, SETTINGS_NESTED_PATH } = elementsUtils
 const log = logger(module)
 
 type TriggerOrderEntry = {
@@ -154,7 +154,7 @@ const filterCreator: FilterCreator = ({ config, client, paginator, fetchQuery })
       ElemID.CONFIG_NAME,
       type,
       { order },
-      [ZENDESK_SUPPORT, RECORDS_PATH, TYPE_NAME, typeNameNaclCase],
+      [ZENDESK_SUPPORT, RECORDS_PATH, SETTINGS_NESTED_PATH, typeNameNaclCase],
     )
     // Those types already exist since we added the empty version of them
     //  via the add remaining types mechanism. So we first need to remove the old versions


### PR DESCRIPTION
Change path hints for settings instances to be under a `Settings` folder.

This impacts:
1. Jira settings instances
2. Zendesk settings instances, including `x_order` instances
3. Zuora settings instances
4. Workato settings instances


---
_Release Notes_: 

_Jira adapter_:
* New Settings instances will be created under a `Records/Settings` folder

_Zendesk adapter_:
* New Settings instances will be created under a `Records/Settings` folder

_Zuora-billing adapter_:
* New Settings instances will be created under a `Records/Settings` folder

_Workato adapter_:
* New Settings instances will be created under a `Records/Settings` folder


---
_User Notifications_: 
None (existing elements are not impacted)