### PR TITLE
SALTO-2360: Move custom object nested instances to folders

### DIFF
--- a/packages/salesforce-adapter/e2e_test/adapter.test.ts
+++ b/packages/salesforce-adapter/e2e_test/adapter.test.ts
@@ -304,8 +304,13 @@ describe('Salesforce adapter E2E with real account', () => {
 
       expect(convertSettingsInstance).toBeDefined()
       expect(convertSettingsInstance.path)
-        .toEqual([constants.SALESFORCE, constants.OBJECTS_PATH, 'Lead',
-          constants.LEAD_CONVERT_SETTINGS_METADATA_TYPE])
+        .toEqual([
+          constants.SALESFORCE,
+          constants.OBJECTS_PATH,
+          'Lead',
+          constants.LEAD_CONVERT_SETTINGS_METADATA_TYPE,
+          convertSettingsInstance.elemID.name,
+        ])
     })
 
     it('should retrieve EmailTemplate instance', () => {

--- a/packages/salesforce-adapter/src/filters/custom_objects.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects.ts
@@ -50,7 +50,7 @@ import {
 } from '../transformers/transformer'
 import {
   id, addApiName, addMetadataType, addLabel, getNamespace, boolValue,
-  buildAnnotationsObjectType, addElementParentReference, apiNameParts,
+  buildAnnotationsObjectType, addElementParentReference,
   parentApiName,
   getDataFromChanges,
   isInstanceOfTypeChange,
@@ -556,9 +556,6 @@ const dependentMetadataTypes = new Set([CUSTOM_TAB_METADATA_TYPE, DUPLICATE_RULE
 const hasCustomObjectParent = async (instance: InstanceElement): Promise<boolean> =>
   dependentMetadataTypes.has(await metadataType(instance))
 
-const shouldAddElemName = async (instance: InstanceElement): Promise<boolean> =>
-  (await apiNameParts(instance)).length > 1 || await metadataType(instance) === FLEXI_PAGE_TYPE
-
 const fixDependentInstancesPathAndSetParent = async (
   elements: Element[],
   referenceElements: ReadOnlyElementsSource,
@@ -577,8 +574,7 @@ const fixDependentInstancesPathAndSetParent = async (
             )
           )]
         : [pathNaclCase(instance.elemID.typeName)]),
-      ...(await shouldAddElemName(instance)
-        ? [pathNaclCase(instance.elemID.name)] : []),
+      pathNaclCase(instance.elemID.name),
     ]
   }
 

--- a/packages/salesforce-adapter/test/filters/custom_objects.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects.test.ts
@@ -1382,7 +1382,7 @@ describe('Custom Objects filter', () => {
 
         it('should set assignmentRules instance path correctly', async () => {
           expect(assignmentRulesInstance.path)
-            .toEqual([SALESFORCE, OBJECTS_PATH, 'Lead', ASSIGNMENT_RULES_METADATA_TYPE])
+            .toEqual([SALESFORCE, OBJECTS_PATH, 'Lead', ASSIGNMENT_RULES_METADATA_TYPE, assignmentRulesInstance.elemID.name])
         })
 
         it('should add PARENT annotation to assignmentRules instance', async () => {
@@ -1406,7 +1406,7 @@ describe('Custom Objects filter', () => {
 
         it('should set leadConvertSettings instance path correctly', async () => {
           expect(leadConvertSettingsInstance.path)
-            .toEqual([SALESFORCE, OBJECTS_PATH, 'Lead', LEAD_CONVERT_SETTINGS_METADATA_TYPE])
+            .toEqual([SALESFORCE, OBJECTS_PATH, 'Lead', LEAD_CONVERT_SETTINGS_METADATA_TYPE, leadConvertSettingsInstance.elemID.name])
         })
 
         it('should add PARENT annotation to leadConvertSettings instance', async () => {
@@ -1508,7 +1508,7 @@ describe('Custom Objects filter', () => {
 
         it('should set customTab instance path correctly', async () => {
           expect(customTabInstance.path)
-            .toEqual([SALESFORCE, OBJECTS_PATH, 'Lead', CUSTOM_TAB_METADATA_TYPE])
+            .toEqual([SALESFORCE, OBJECTS_PATH, 'Lead', CUSTOM_TAB_METADATA_TYPE, customTabInstance.elemID.name])
         })
 
         it('should add PARENT annotation to customTab instance', async () => {
@@ -1559,7 +1559,7 @@ describe('Custom Objects filter', () => {
 
         it('should set instance path correctly', () => {
           expect(sharingRulesInstance.path)
-            .toEqual([SALESFORCE, OBJECTS_PATH, 'Lead', SHARING_RULES_TYPE])
+            .toEqual([SALESFORCE, OBJECTS_PATH, 'Lead', SHARING_RULES_TYPE, sharingRulesInstance.elemID.name])
         })
 
         it('should add PARENT annotation to instance', () => {
@@ -1583,7 +1583,7 @@ describe('Custom Objects filter', () => {
         })
         it('should set instance path', () => {
           expect(sharingRulesInstance.path).toEqual(
-            [SALESFORCE, OBJECTS_PATH, 'Lead', SHARING_RULES_TYPE]
+            [SALESFORCE, OBJECTS_PATH, 'Lead', SHARING_RULES_TYPE, sharingRulesInstance.elemID.name]
           )
         })
 


### PR DESCRIPTION
This is for consistency in the file tree

---

---
_Release Notes_: 
Salesforce Adapter:
- Moved custom object child instances to consistently be inside a folder

---
_User Notifications_: 
_None_
