### PR TITLE
SALTO-2352: Static files refactor

### DIFF
--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -50,7 +50,7 @@ export class StaticFile {
   public readonly filepath: string
   public readonly hash: string
   public readonly encoding: BufferEncoding
-  protected internalContent?: Buffer
+  private internalContent?: Buffer
   constructor(params: StaticFileParameters) {
     this.filepath = params.filepath
     this.encoding = params.encoding ?? DEFAULT_STATIC_FILE_ENCODING

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -200,7 +200,7 @@ ${Prompts.SERVICE_ADD_HELP}`
   public static readonly RESTORE_CALC_DIFF_FINISH = 'Finished calculating the difference between state and NaCL files.'
   public static readonly RESTORE_CALC_DIFF_FAIL = 'Calculating diff failed!'
   public static readonly RESTORE_UPDATE_WORKSPACE_SUCCESS = 'Applied changes'
-  public static readonly STATIC_RESOURCES_NOT_SUPPORTED = `Static resources are not supported for this operation as their content is not kept in the state file.
+  public static readonly STATIC_RESOURCES_NOT_SUPPORTED = `The state version of some of the static resources is not available.
   Therefore, the following files will not be restored:`
   public static readonly RESTORE_SUCCESS_FINISHED = 'Done! Your NaCL files are now updated with the latest changes.'
   public static readonly RESTORE_UPDATE_WORKSPACE_FAIL = 'Failed to apply changes to your NaCL files.'

--- a/packages/cli/test/commands/deploy.test.ts
+++ b/packages/cli/test/commands/deploy.test.ts
@@ -325,6 +325,7 @@ describe('deploy command', () => {
         pathIndex: new InMemoryRemoteMap<pathIndex.Path[]>(),
         accountsUpdateDate: dateMap ?? new InMemoryRemoteMap(),
         saltoMetadata,
+        staticFilesSource: mocks.mockStateStaticFilesSource(),
       }))
     }
     const inputOptions = {

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -27,7 +27,7 @@ import {
   Plan, PlanItem, EVENT_TYPES, DeployResult,
   telemetrySender, Telemetry, Tags, TelemetryEvent, CommandConfig,
 } from '@salto-io/core'
-import { Workspace, errors as wsErrors, state as wsState, parser, remoteMap, elementSource, pathIndex } from '@salto-io/workspace'
+import { Workspace, errors as wsErrors, state as wsState, parser, remoteMap, elementSource, pathIndex, staticFiles } from '@salto-io/workspace'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import { MockInterface, mockFunction } from '@salto-io/test-utils'
@@ -315,6 +315,18 @@ type MockWorkspaceArgs = {
   envs?: string[]
   accounts?: string[]
 }
+
+export const mockStateStaticFilesSource = ()
+: MockInterface<staticFiles.StateStaticFilesSource> => ({
+  persistStaticFile: mockFunction<staticFiles.StateStaticFilesSource['persistStaticFile']>(),
+  getStaticFile: mockFunction<staticFiles.StateStaticFilesSource['getStaticFile']>(),
+  clear: mockFunction<staticFiles.StateStaticFilesSource['clear']>(),
+  rename: mockFunction<staticFiles.StateStaticFilesSource['rename']>(),
+  delete: mockFunction<staticFiles.StateStaticFilesSource['delete']>(),
+  flush: mockFunction<staticFiles.StateStaticFilesSource['flush']>(),
+})
+
+
 export const mockWorkspace = ({
   uid = '123',
   name = '',
@@ -329,6 +341,7 @@ export const mockWorkspace = ({
       saltoMetadata: new InMemoryRemoteMap([
         { key: 'version', value: currentVersion },
       ] as {key: wsState.StateMetadataKey; value: string}[]),
+      staticFilesSource: mockStateStaticFilesSource(),
     })
   )
   return {
@@ -728,18 +741,20 @@ export const deploy = async (
   }
 }
 
-export const staticFileChange = (action: 'add' | 'modify' | 'remove'): DetailedChange => {
+export const staticFileChange = (action: 'add' | 'modify' | 'remove', withContent = false): DetailedChange => {
   const id = new ElemID('salesforce')
   const path = ['salesforce', 'Records', 'advancedpdftemplate', 'custtmpl_103_t2257860_156']
   const beforeFile = new StaticFile({
     filepath: 'salesforce/advancedpdftemplate/custtmpl_103_t2257860_156.xml',
     encoding: 'binary',
     hash: '5fa14331d637ce9b056be8abe433d43d',
+    ...(withContent ? { content: Buffer.from('before') } : {}),
   })
   const afterFile = new StaticFile({
     filepath: 'salesforce/advancedpdftemplate/custtmpl_103_t2257860_156.xml',
     encoding: 'binary',
     hash: '81511e24c8023d819040a196fbaf8ee7',
+    ...(withContent ? { content: Buffer.from('after') } : {}),
   })
 
   if (action === 'add') {

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -45,6 +45,7 @@ export {
   isStackEvent, EVENT_TYPES,
 } from './src/telemetry'
 export { localDirectoryStore } from './src/local-workspace/dir_store'
+export { buildS3DirectoryStore } from './src/local-workspace/s3_dir_store'
 export {
   WORKSPACE_CONFIG_NAME,
   USER_CONFIG_NAME,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,6 +32,7 @@
     "generate": "./generate.sh"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.38.0",
     "@salto-io/adapter-api": "0.3.18",
     "@salto-io/adapter-components": "0.3.18",
     "@salto-io/adapter-utils": "0.3.18",
@@ -51,7 +52,9 @@
     "@salto-io/zuora-billing-adapter": "0.3.18",
     "async-lock": "^1.2.4",
     "axios": "^0.21.3",
+    "bottleneck": "^2.19.5",
     "fs-extra": "^9.1.0",
+    "get-stream": "^6.0.1",
     "glob": "^7.1.6",
     "levelup": "^4.4.0",
     "lodash": "^4.17.21",

--- a/packages/core/src/local-workspace/dir_store.ts
+++ b/packages/core/src/local-workspace/dir_store.ts
@@ -280,6 +280,8 @@ const buildLocalDirectoryStore = <T extends dirStore.ContentType>(
     ),
     getFullPath: filename => getAbsFileName(filename),
     isPathIncluded,
+    exists: async (filename: string): Promise<boolean> =>
+      fileUtils.exists(getAbsFileName(filename)),
   }
 }
 

--- a/packages/core/src/local-workspace/remote_map.ts
+++ b/packages/core/src/local-workspace/remote_map.ts
@@ -550,10 +550,10 @@ remoteMap.RemoteMapCreator => {
       elementsEntries: AsyncIterable<remoteMap.RemoteMapEntry<T, K>>,
       temp = true,
     ): Promise<void> => {
-      const batchInsertIterator = awu(elementsEntries).map(entry => {
+      const batchInsertIterator = awu(elementsEntries).map(async entry => {
         delKeys.delete(entry.key)
         locationCache.set(keyToTempDBKey(entry.key), entry.value)
-        return { key: entry.key, value: serialize(entry.value) }
+        return { key: entry.key, value: await serialize(entry.value) }
       })
       await batchUpdate(batchInsertIterator, temp)
     }
@@ -727,7 +727,7 @@ remoteMap.RemoteMapCreator => {
       set: async (key: string, element: T): Promise<void> => {
         delKeys.delete(key)
         locationCache.set(keyToTempDBKey(key), element)
-        await promisify(tmpDB.put.bind(tmpDB))(keyToTempDBKey(key), serialize(element))
+        await promisify(tmpDB.put.bind(tmpDB))(keyToTempDBKey(key), await serialize(element))
       },
       setAll: setAllImpl,
       deleteAll: async (iterator: AsyncIterable<K>) => awu(iterator).forEach(deleteImpl),

--- a/packages/core/src/local-workspace/s3_dir_store.ts
+++ b/packages/core/src/local-workspace/s3_dir_store.ts
@@ -1,0 +1,144 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import path from 'path'
+import { logger } from '@salto-io/logging'
+import * as AWS from '@aws-sdk/client-s3'
+import { safeJsonStringify } from '@salto-io/adapter-utils'
+import { dirStore, staticFiles } from '@salto-io/workspace'
+import Bottleneck from 'bottleneck'
+import getStream from 'get-stream'
+import { Readable } from 'stream'
+import { values } from '@salto-io/lowerdash'
+
+const log = logger(module)
+
+const DEFAULT_CONCURRENCY_LIMIT = 100
+
+export const buildS3DirectoryStore = (
+  {
+    bucketName,
+    baseDir,
+    S3Client,
+    concurrencyLimit = DEFAULT_CONCURRENCY_LIMIT,
+  }: {
+    bucketName: string
+    baseDir: string
+    S3Client?: AWS.S3
+    concurrencyLimit?: number
+  }
+): staticFiles.StateStaticFilesStore => {
+  const updated: Record<string, dirStore.File<Buffer>> = {}
+  const s3 = S3Client ?? new AWS.S3({})
+  const bottleneck = new Bottleneck({ maxConcurrent: concurrencyLimit })
+
+  const getFullPath = (filePath: string): string =>
+    path.posix.join(baseDir, filePath)
+
+  const readFile = async (filePath: string): Promise<dirStore.File<Buffer> | undefined> => {
+    const fullFilePath = getFullPath(filePath)
+
+    try {
+      const s3Obj = await bottleneck.schedule(
+        () => {
+          log.trace('Reading %s from S3 bucket %s', fullFilePath, bucketName)
+          return s3.getObject({ Bucket: bucketName, Key: fullFilePath })
+        }
+      )
+
+      if (!(s3Obj.Body instanceof Readable)) {
+        log.error('Received unexpected body type from s3.getObject: %s', safeJsonStringify(s3Obj.Body))
+        return undefined
+      }
+
+      const buffer = await getStream.buffer(s3Obj.Body)
+
+      return { buffer, filename: filePath }
+    } catch (err) {
+      if (err.name === 'NoSuchKey') {
+        return undefined
+      }
+      log.warn('Failed to read file %s from S3 bucket %s', fullFilePath, bucketName)
+      throw err
+    }
+  }
+
+  const writeFile = async (file: dirStore.File<Buffer>): Promise<void> => {
+    const fullFilePath = getFullPath(file.filename)
+
+    try {
+      await bottleneck.schedule(
+        () => {
+          log.trace('Writing %s to S3 bucket %s', fullFilePath, bucketName)
+          return s3.putObject({
+            Bucket: bucketName,
+            Key: fullFilePath,
+            Body: file.buffer,
+          })
+        }
+      )
+    } catch (err) {
+      log.warn('Failed to write a file %s to S3 bucket %s', fullFilePath, bucketName)
+      throw err
+    }
+  }
+
+  const listPage = async (token: string | undefined): Promise<AWS.ListObjectsV2CommandOutput> =>
+    bottleneck.schedule(
+      () => {
+        log.trace('Listing %s in S3 bucket %s with token %s', baseDir, bucketName, token)
+        return s3.listObjectsV2({
+          Bucket: bucketName,
+          Prefix: baseDir,
+          ContinuationToken: token,
+        })
+      }
+    )
+
+  const list = async (): Promise<string[]> => log.time(
+    async () => {
+      const paths = new Set<string>(Object.keys(updated))
+      let currentPage: AWS.ListObjectsV2CommandOutput | undefined
+      try {
+        do {
+          // eslint-disable-next-line no-await-in-loop
+          currentPage = await listPage(currentPage?.NextContinuationToken)
+          currentPage.Contents
+            ?.map(({ Key }) => Key && path.posix.relative(baseDir, Key))
+            .filter(values.isDefined)
+            .forEach(key => paths.add(key))
+        } while (currentPage?.NextContinuationToken !== undefined)
+      } catch (err) {
+        log.warn('Failed listing %s in S3 bucket %s with token %s', baseDir, bucketName, currentPage?.NextContinuationToken)
+        throw err
+      }
+
+      return Array.from(paths)
+    },
+    `listing s3 objects for ${baseDir}`,
+  )
+
+  const flush = async (): Promise<void> => {
+    await Promise.all(Object.values(updated).map(f => writeFile(f)))
+  }
+
+  return {
+    get: async filePath => (updated[filePath] ? updated[filePath] : readFile(filePath)),
+    set: async file => { updated[file.filename] = file },
+    list,
+    getFullPath: filePath => `s3://${bucketName}/${getFullPath(filePath)}`,
+    flush,
+  }
+}

--- a/packages/core/src/local-workspace/static_files_cache.ts
+++ b/packages/core/src/local-workspace/static_files_cache.ts
@@ -63,7 +63,7 @@ export const buildLocalStaticFilesCache = (
   ): Promise<StaticFilesCacheState> =>
     remoteMapCreator<staticFiles.StaticFilesData>({
       namespace: `staticFilesCache-${cacheName}`,
-      serialize: cacheEntry => safeJsonStringify(cacheEntry),
+      serialize: async cacheEntry => safeJsonStringify(cacheEntry),
       deserialize: async data => JSON.parse(data),
       persistent,
     })

--- a/packages/core/test/common/state.ts
+++ b/packages/core/test/common/state.ts
@@ -13,8 +13,29 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Element } from '@salto-io/adapter-api'
-import { pathIndex, state, elementSource, remoteMap } from '@salto-io/workspace'
+import { Element, StaticFile } from '@salto-io/adapter-api'
+import { pathIndex, state, elementSource, remoteMap, staticFiles } from '@salto-io/workspace'
+
+export const mockStaticFilesSource = (
+  files: StaticFile[] = [],
+): staticFiles.StaticFilesSource => ({
+  getStaticFile: jest.fn().mockImplementation((filepath: string, _encoding: BufferEncoding) => (
+    files.find(sf => sf.filepath === filepath) ?? undefined
+  )),
+  getContent: jest.fn().mockImplementation(async (filepath: string) => (
+    await files.find(sf => sf.filepath === filepath)?.getContent() ?? undefined
+  )),
+  persistStaticFile: jest.fn().mockReturnValue([]),
+  flush: jest.fn(),
+  clone: jest.fn(),
+  rename: jest.fn(),
+  getTotalSize: jest.fn(),
+  clear: jest.fn(),
+  delete: jest.fn(),
+  isPathIncluded: jest.fn().mockImplementation(
+    filePath => files.find(f => f.filepath === filePath) !== undefined
+  ),
+})
 
 
 export const mockState = (
@@ -29,5 +50,6 @@ export const mockState = (
       accounts.map(accountName => ({ key: accountName, value: new Date() }))
     ),
     saltoMetadata: new remoteMap.InMemoryRemoteMap<string, 'version'>([{ key: 'version', value: '0.0.1' }]),
+    staticFilesSource: mockStaticFilesSource(),
   }))
 )

--- a/packages/core/test/common/workspace.ts
+++ b/packages/core/test/common/workspace.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, Element, ElemID, InstanceElement, ObjectType, SaltoError, Value, StaticFile } from '@salto-io/adapter-api'
+import { BuiltinTypes, Element, ElemID, InstanceElement, ObjectType, SaltoError, Value } from '@salto-io/adapter-api'
 import { mockFunction } from '@salto-io/test-utils'
 import * as workspace from '@salto-io/workspace'
 import { elementSource, errors as wsErrors, staticFiles } from '@salto-io/workspace'
@@ -64,27 +64,6 @@ export const mockErrors = (errors: SaltoError[]): wsErrors.Errors => new wsError
   parse: [],
   merge: [],
   validation: errors.map(err => ({ elemID: new ElemID('test'), error: err.message, ...err })),
-})
-
-export const mockStaticFilesSource = (
-  files: StaticFile[] = [],
-): staticFiles.StaticFilesSource => ({
-  getStaticFile: jest.fn().mockImplementation((filepath: string, _encoding: BufferEncoding) => (
-    files.find(sf => sf.filepath === filepath) ?? undefined
-  )),
-  getContent: jest.fn().mockImplementation(async (filepath: string) => (
-    await files.find(sf => sf.filepath === filepath)?.getContent() ?? undefined
-  )),
-  persistStaticFile: jest.fn().mockReturnValue([]),
-  flush: jest.fn(),
-  clone: jest.fn(),
-  rename: jest.fn(),
-  getTotalSize: jest.fn(),
-  clear: jest.fn(),
-  delete: jest.fn(),
-  isPathIncluded: jest.fn().mockImplementation(
-    filePath => files.find(f => f.filepath === filePath) !== undefined
-  ),
 })
 
 export const mockWorkspace = ({

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -29,7 +29,7 @@ import * as utils from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { elementSource, pathIndex, remoteMap, createAdapterReplacedID } from '@salto-io/workspace'
 import { mockFunction } from '@salto-io/test-utils'
-import { mockWorkspace, mockStaticFilesSource } from '../common/workspace'
+import { mockWorkspace } from '../common/workspace'
 import {
   fetchChanges, FetchChange, generateServiceIdToStateElemId,
   FetchChangesResult, FetchProgressEvents, getAdaptersFirstFetchPartial,
@@ -37,6 +37,7 @@ import {
 } from '../../src/core/fetch'
 import { getPlan, Plan } from '../../src/core/plan'
 import { createElementSource } from '../common/helpers'
+import { mockStaticFilesSource } from '../common/state'
 
 const { createInMemoryElementSource } = elementSource
 const { awu } = collections.asynciterable

--- a/packages/core/test/workspace/local/directory_store.test.ts
+++ b/packages/core/test/workspace/local/directory_store.test.ts
@@ -149,6 +149,28 @@ describe('localDirectoryStore', () => {
     })
   })
 
+  describe('exists', () => {
+    it('returns true if exists in the dir store', async () => {
+      const baseDir = 'exists'
+      const naclFileName = 'blabla/exist.nacl'
+      mockFileExists.mockResolvedValue(true)
+      expect(await localDirectoryStore({ baseDir, name: '', encoding }).exists(naclFileName)).toBeTruthy()
+      expect(mockFileExists).toHaveBeenCalledWith(
+        expect.stringContaining(path.join(baseDir, naclFileName))
+      )
+    })
+
+    it('returns false if does not exist in the dir store', async () => {
+      const baseDir = 'exists'
+      const naclFileName = 'blabla/exist.nacl'
+      mockFileExists.mockResolvedValue(false)
+      expect(await localDirectoryStore({ baseDir, name: '', encoding }).exists(naclFileName)).toBeFalsy()
+      expect(mockFileExists).toHaveBeenCalledWith(
+        expect.stringContaining(path.join(baseDir, naclFileName))
+      )
+    })
+  })
+
   describe('set', () => {
     const filename = 'inner/file'
 

--- a/packages/core/test/workspace/local/remote_map_connection.test.ts
+++ b/packages/core/test/workspace/local/remote_map_connection.test.ts
@@ -46,7 +46,7 @@ describe('connection creation', () => {
       createRemoteMapCreator(DB_LOCATION)({
         namespace,
         batchInterval: 1000,
-        serialize: str => str,
+        serialize: async str => str,
         deserialize: async str => Promise.resolve(str),
         persistent,
       })
@@ -105,7 +105,7 @@ describe('connection creation', () => {
         createRemoteMapCreator(location)({
           namespace: 'namespace',
           batchInterval: 1000,
-          serialize: str => str,
+          serialize: async str => str,
           deserialize: async str => Promise.resolve(str),
           persistent: true,
         })

--- a/packages/core/test/workspace/local/s3_dir_store.test.ts
+++ b/packages/core/test/workspace/local/s3_dir_store.test.ts
@@ -1,0 +1,199 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { staticFiles } from '@salto-io/workspace'
+import * as AWS from '@aws-sdk/client-s3'
+import { Readable } from 'stream'
+import { buildS3DirectoryStore } from '../../../src/local-workspace/s3_dir_store'
+
+describe('buildS3DirectoryStore', () => {
+  const bucketName = 'bucketName'
+  const baseDir = 'baseDir'
+  let directoryStore: staticFiles.StateStaticFilesStore
+  let getObjectMock: jest.Mock
+  let listObjectsV2Mock: jest.Mock
+  let putObjectMock: jest.Mock
+
+  beforeEach(() => {
+    getObjectMock = jest.fn().mockResolvedValue(undefined)
+    listObjectsV2Mock = jest.fn().mockResolvedValue(undefined)
+    putObjectMock = jest.fn().mockResolvedValue(undefined)
+
+    const mockS3Client = {
+      getObject: getObjectMock,
+      listObjectsV2: listObjectsV2Mock,
+      putObject: putObjectMock,
+    }
+
+    directoryStore = buildS3DirectoryStore({
+      bucketName,
+      baseDir,
+      S3Client: mockS3Client as unknown as AWS.S3,
+    })
+  })
+
+  describe('list', () => {
+    it('should return true if the file exists', async () => {
+      listObjectsV2Mock.mockResolvedValueOnce({
+        Contents: [
+          { Key: `${baseDir}/a1` },
+          { Key: `${baseDir}/a2` },
+        ],
+        NextContinuationToken: 'nextToken',
+      }).mockResolvedValueOnce({
+        Contents: [
+          { Key: `${baseDir}/a3` },
+          { Key: `${baseDir}/a4` },
+        ],
+      })
+      expect(await directoryStore.list()).toEqual(['a1', 'a2', 'a3', 'a4'])
+      expect(listObjectsV2Mock).toHaveBeenCalledWith({
+        Bucket: bucketName,
+        Prefix: baseDir,
+        ContinuationToken: undefined,
+      })
+
+      expect(listObjectsV2Mock).toHaveBeenCalledWith({
+        Bucket: bucketName,
+        Prefix: baseDir,
+        ContinuationToken: 'nextToken',
+      })
+    })
+
+    it('should throw on unexpected error', async () => {
+      listObjectsV2Mock.mockRejectedValue(new Error())
+      await expect(directoryStore.list()).rejects.toThrow()
+      expect(listObjectsV2Mock).toHaveBeenCalledWith({
+        Bucket: bucketName,
+        Prefix: baseDir,
+        ContinuationToken: undefined,
+      })
+    })
+
+    it('should use cached data', async () => {
+      listObjectsV2Mock.mockResolvedValueOnce({
+        Contents: [],
+      })
+
+      await directoryStore.set({ filename: 'a/b', buffer: Buffer.from('aaa') })
+      expect(await directoryStore.list()).toEqual(['a/b'])
+
+      expect(listObjectsV2Mock).toHaveBeenCalledWith({
+        Bucket: bucketName,
+        Prefix: baseDir,
+        ContinuationToken: undefined,
+      })
+    })
+  })
+
+  describe('get', () => {
+    it('should return the file if exists', async () => {
+      const readable = new Readable()
+      readable.push('body')
+      readable.push(null)
+      getObjectMock.mockResolvedValue({
+        Body: readable,
+      })
+      expect(await directoryStore.get('a/b')).toEqual({
+        filename: 'a/b', buffer: Buffer.from('body'),
+      })
+      expect(getObjectMock).toHaveBeenCalledWith({
+        Bucket: bucketName,
+        Key: 'baseDir/a/b',
+      })
+    })
+
+    it('should return undefined if received unexpected type', async () => {
+      getObjectMock.mockResolvedValue({
+        Body: 'unexpected',
+      })
+      expect(await directoryStore.get('a/b')).toBeUndefined()
+      expect(getObjectMock).toHaveBeenCalledWith({
+        Bucket: bucketName,
+        Key: 'baseDir/a/b',
+      })
+    })
+
+    it('should return undefined the file does not exist', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      getObjectMock.mockRejectedValue({ name: 'NoSuchKey' })
+      expect(await directoryStore.get('a/b')).toBeUndefined()
+      expect(getObjectMock).toHaveBeenCalledWith({
+        Bucket: bucketName,
+        Key: 'baseDir/a/b',
+      })
+    })
+
+    it('should return undefined the body was not returned', async () => {
+      getObjectMock.mockResolvedValue({})
+      expect(await directoryStore.get('a/b')).toBeUndefined()
+      expect(getObjectMock).toHaveBeenCalledWith({
+        Bucket: bucketName,
+        Key: 'baseDir/a/b',
+      })
+    })
+
+    it('should use cached data', async () => {
+      await directoryStore.set({ filename: 'a/b', buffer: Buffer.from('aaa') })
+      expect(await directoryStore.get('a/b')).toEqual({
+        filename: 'a/b', buffer: Buffer.from('aaa'),
+      })
+
+      expect(getObjectMock).not.toHaveBeenCalled()
+    })
+
+    it('should throw on unexpected error', async () => {
+      getObjectMock.mockRejectedValue(new Error())
+      await expect(directoryStore.get('a/b')).rejects.toThrow()
+      expect(getObjectMock).toHaveBeenCalledWith({
+        Bucket: bucketName,
+        Key: 'baseDir/a/b',
+      })
+    })
+  })
+
+  describe('set', () => {
+    it('should write the file', async () => {
+      await directoryStore.set({ filename: 'a/b', buffer: Buffer.from('aaa') })
+
+      expect(putObjectMock).not.toHaveBeenCalled()
+
+      await directoryStore.flush()
+
+      expect(putObjectMock).toHaveBeenCalledWith({
+        Bucket: bucketName,
+        Key: 'baseDir/a/b',
+        Body: Buffer.from('aaa'),
+      })
+    })
+
+    it('should throw on unexpected error', async () => {
+      putObjectMock.mockRejectedValue(new Error())
+      await directoryStore.set({ filename: '', buffer: Buffer.from('aaa') })
+      await expect(directoryStore.flush()).rejects.toThrow()
+      expect(putObjectMock).toHaveBeenCalledWith({
+        Bucket: bucketName,
+        Key: 'baseDir',
+        Body: Buffer.from('aaa'),
+      })
+    })
+  })
+
+  describe('getFullPath', () => {
+    it('should throw on unexpected error', async () => {
+      expect(directoryStore.getFullPath('somePath')).toBe(`s3://${bucketName}/baseDir/somePath`)
+    })
+  })
+})

--- a/packages/core/test/workspace/local/workspace.test.ts
+++ b/packages/core/test/workspace/local/workspace.test.ts
@@ -27,6 +27,7 @@ import {
 } from '../../../src/local-workspace/workspace'
 import { getSaltoHome } from '../../../src/app_config'
 import * as mockDirStore from '../../../src/local-workspace/dir_store'
+import { mockStaticFilesSource } from '../../common/state'
 
 const { awu } = collections.asynciterable
 const { ENVS_PREFIX } = ws.nacl
@@ -123,9 +124,13 @@ describe('local workspace', () => {
       mockExists.mockResolvedValue(true)
       const creator: ws.remoteMap.RemoteMapCreator = async <T, K extends string = string>() =>
         new ws.remoteMap.InMemoryRemoteMap<T, K>()
-      const elemSources = await loadLocalElementsSources(
-        '.', path.join(getSaltoHome(), 'local'), ['env1', 'env2'], creator
-      )
+      const elemSources = await loadLocalElementsSources({
+        baseDir: '.',
+        localStorage: path.join(getSaltoHome(), 'local'),
+        envs: ['env1', 'env2'],
+        remoteMapCreator: creator,
+        stateStaticFilesSource: mockStaticFilesSource(),
+      })
       expect(Object.keys(elemSources.sources)).toHaveLength(3)
       expect(mockCreateDirStore).toHaveBeenCalledTimes(6)
       const dirStoresBaseDirs = mockCreateDirStore.mock.calls.map(c => c[0])
@@ -208,7 +213,7 @@ describe('local workspace', () => {
         expect(mockLoad).toHaveBeenCalledTimes(1)
         const envSources: ws.EnvironmentsSources = mockLoad.mock.calls[0][3]
         expect(Object.keys(envSources.sources)).toHaveLength(3)
-        expect(mockCreateDirStore).toHaveBeenCalledTimes(11)
+        expect(mockCreateDirStore).toHaveBeenCalledTimes(13)
         const dirStoresBaseDirs = mockCreateDirStore.mock.calls.map(c => c[0])
           .map(params => toWorkspaceRelative(params))
         expect(dirStoresBaseDirs).toContain(path.join(ENVS_PREFIX, 'env2'))
@@ -420,7 +425,7 @@ describe('local workspace', () => {
       expect(mockLoad).toHaveBeenCalledTimes(1)
       const envSources: ws.EnvironmentsSources = mockLoad.mock.calls[0][3]
       expect(Object.keys(envSources.sources)).toHaveLength(2)
-      expect(mockCreateDirStore).toHaveBeenCalledTimes(9)
+      expect(mockCreateDirStore).toHaveBeenCalledTimes(10)
       const dirStoresBaseDirs = mockCreateDirStore.mock.calls.map(c => c[0])
         .map(params => toWorkspaceRelative(params))
       expect(dirStoresBaseDirs).toContain(path.join(ENVS_PREFIX, 'default'))

--- a/packages/lang-server/test/workspace.ts
+++ b/packages/lang-server/test/workspace.ts
@@ -77,6 +77,7 @@ dirStore.DirectoryStore<T> => {
     isEmpty: mockFunction<dirStore.DirectoryStore<T>['isEmpty']>(),
     getFullPath: mockFunction<dirStore.DirectoryStore<T>['getFullPath']>().mockImplementation(filepath => `full-${filepath}`),
     isPathIncluded: mockFunction<dirStore.DirectoryStore<T>['isPathIncluded']>(),
+    exists: mockFunction<dirStore.DirectoryStore<T>['exists']>(),
   }
 }
 
@@ -98,7 +99,7 @@ const persistentMockCreateRemoteMap = ():
         entries: collections.asynciterable.ThenableIterable<RemoteMapEntry<T, K>>
       ): Promise<void> => {
         for await (const entry of entries) {
-          maps[opts.namespace][entry.key] = opts.serialize(entry.value)
+          maps[opts.namespace][entry.key] = await opts.serialize(entry.value)
         }
       },
       delete: async (key: K) => {
@@ -113,7 +114,7 @@ const persistentMockCreateRemoteMap = ():
       getMany: async (keys: K[]): Promise<(T | undefined)[]> => Promise.all(keys.map(get)),
       has: async (key: K): Promise<boolean> => key in maps[opts.namespace],
       set: async (key: K, value: T): Promise<void> => {
-        maps[opts.namespace][key] = opts.serialize(value)
+        maps[opts.namespace][key] = await opts.serialize(value)
       },
       clear: async (): Promise<void> => {
         maps[opts.namespace] = {} as Record<K, string>
@@ -173,6 +174,7 @@ Promise<Workspace> => {
     mockDirStore({}),
     mockStaticFilesCache
   )
+
   const elementsSources = {
     commonSourceName: '',
     sources: {
@@ -195,6 +197,10 @@ Promise<Workspace> => {
           accountsUpdateDate: new InMemoryRemoteMap(),
           saltoVersion: '0.0.1',
           saltoMetadata: new InMemoryRemoteMap(),
+          staticFilesSource: staticFiles.buildStaticFilesSource(
+            mockDirStore({}),
+            mockStaticFilesCache
+          ),
         })),
       },
       inactive: {
@@ -211,6 +217,10 @@ Promise<Workspace> => {
           accountsUpdateDate: new InMemoryRemoteMap(),
           saltoVersion: '0.0.1',
           saltoMetadata: new InMemoryRemoteMap(),
+          staticFilesSource: staticFiles.buildStaticFilesSource(
+            mockDirStore({}),
+            mockStaticFilesCache
+          ),
         })),
       },
     },

--- a/packages/workspace/src/workspace/dir_store.ts
+++ b/packages/workspace/src/workspace/dir_store.ts
@@ -37,4 +37,5 @@ export type DirectoryStore<T extends ContentType> = {
   isEmpty(): Promise<boolean>
   getFullPath(filename: string): string
   isPathIncluded(filePath: string): boolean
+  exists: (filePath: string) => Promise<boolean>
 }

--- a/packages/workspace/src/workspace/nacl_files/elements_cache.ts
+++ b/packages/workspace/src/workspace/nacl_files/elements_cache.ts
@@ -183,7 +183,7 @@ export const createMergeManager = async (flushables: Flushable[],
   const hashes = await mapCreator<string>({
     namespace: fullNamespace,
     persistent,
-    serialize: s => s,
+    serialize: async s => s,
     deserialize: async s => s,
   })
   const getSourceHashKey = (prefix: string): string => `${prefix}_source_hash`

--- a/packages/workspace/src/workspace/nacl_files/index.ts
+++ b/packages/workspace/src/workspace/nacl_files/index.ts
@@ -16,4 +16,5 @@
 export { ParsedNaclFile, ParsedNaclFileData } from './parsed_nacl_file'
 export { ChangeSet } from './elements_cache'
 export { NaclFile, FILE_EXTENSION, NaclFilesSource, naclFilesSource, RoutingMode, getFunctions } from './nacl_files_source'
+export { getNestedStaticFiles } from './nacl_file_update'
 export { ENVS_PREFIX } from './multi_env/multi_env_source'

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -26,8 +26,7 @@ import { AdditionDiff } from '@salto-io/dag'
 import { AwuIterable } from '@salto-io/lowerdash/src/collections/asynciterable'
 import osPath from 'path'
 import { MergeError, mergeElements } from '../../merger'
-import { getChangeLocations, updateNaclFileData, getChangesToUpdate, DetailedChangeWithSource,
-  getNestedStaticFiles } from './nacl_file_update'
+import { getChangeLocations, updateNaclFileData, getChangesToUpdate, DetailedChangeWithSource, getNestedStaticFiles } from './nacl_file_update'
 import { parse, SourceRange, ParseResult, SourceMap } from '../../parser'
 import { ElementsSource, RemoteElementSource } from '../elements_source'
 import { DirectoryStore } from '../dir_store'
@@ -248,7 +247,7 @@ const createNaclFilesState = async (
 ): Promise<NaclFilesState> => ({
   elementsIndex: await remoteMapCreator<string[]>({
     namespace: getRemoteMapNamespace('elements_index', sourceName),
-    serialize: val => safeJsonStringify(val),
+    serialize: async val => safeJsonStringify(val),
     deserialize: data => JSON.parse(data),
     persistent,
   }),
@@ -260,7 +259,7 @@ const createNaclFilesState = async (
   }),
   mergedElements: new RemoteElementSource(await remoteMapCreator<Element>({
     namespace: getRemoteMapNamespace('merged', sourceName),
-    serialize: element => serialize([element], 'keepRef'),
+    serialize: async element => serialize([element], 'keepRef'),
     deserialize: async data => deserializeSingleElement(
       data,
       async sf => staticFilesSource.getStaticFile(sf.filepath, sf.encoding)
@@ -275,25 +274,25 @@ const createNaclFilesState = async (
   ),
   referencedIndex: await remoteMapCreator<string[]>({
     namespace: getRemoteMapNamespace('referenced_index', sourceName),
-    serialize: val => safeJsonStringify(val),
+    serialize: async val => safeJsonStringify(val),
     deserialize: data => JSON.parse(data),
     persistent,
   }),
   searchableNamesIndex: await remoteMapCreator<boolean>({
     namespace: getRemoteMapNamespace('searchableNamesIndex', sourceName),
-    serialize: val => (val === true ? '1' : '0'),
+    serialize: async val => (val === true ? '1' : '0'),
     deserialize: async data => data !== '0',
     persistent,
   }),
   staticFilesIndex: await remoteMapCreator<string[]>({
     namespace: getRemoteMapNamespace('static_files_index', sourceName),
-    serialize: val => safeJsonStringify(val),
+    serialize: async val => safeJsonStringify(val),
     deserialize: data => JSON.parse(data),
     persistent,
   }),
   metadata: await remoteMapCreator<string>({
     namespace: getRemoteMapNamespace('metadata', sourceName),
-    serialize: val => val,
+    serialize: async val => val,
     deserialize: async data => data,
     persistent,
   }),

--- a/packages/workspace/src/workspace/nacl_files/parsed_nacl_files_cache.ts
+++ b/packages/workspace/src/workspace/nacl_files/parsed_nacl_files_cache.ts
@@ -96,7 +96,7 @@ const getMetadata = async (
 ): Promise<RemoteMap<FileCacheMetadata>> => (
   remoteMapCreator({
     namespace: getRemoteMapCacheNamespace(cacheName, 'metadata'),
-    serialize: (val: FileCacheMetadata) => safeJsonStringify(val),
+    serialize: async (val: FileCacheMetadata) => safeJsonStringify(val),
     deserialize: data => JSON.parse(data),
     persistent,
   })
@@ -109,7 +109,7 @@ const getErrors = async (
 ): Promise<RemoteMap<ParseError[]>> => (
   remoteMapCreator({
     namespace: getRemoteMapCacheNamespace(cacheName, 'errors'),
-    serialize: (errors: ParseError[]) => safeJsonStringify(errors ?? []),
+    serialize: async (errors: ParseError[]) => safeJsonStringify(errors ?? []),
     deserialize: data => JSON.parse(data),
     persistent,
   })
@@ -124,7 +124,7 @@ const getCacheSources = async (
   metadata: await getMetadata(cacheName, remoteMapCreator, persistent),
   elements: await remoteMapCreator({
     namespace: getRemoteMapCacheNamespace(cacheName, 'elements'),
-    serialize: (elements: Element[]) => serialize(elements ?? [], 'keepRef'),
+    serialize: async (elements: Element[]) => serialize(elements ?? [], 'keepRef'),
     deserialize: async data => (deserialize(
       data,
       async sf => staticFilesSource.getStaticFile(sf.filepath, sf.encoding),
@@ -133,20 +133,20 @@ const getCacheSources = async (
   }),
   sourceMap: (await remoteMapCreator({
     namespace: getRemoteMapCacheNamespace(cacheName, 'sourceMap'),
-    serialize: (sourceMap: SourceMap) => safeJsonStringify(Array.from(sourceMap.entries())),
+    serialize: async (sourceMap: SourceMap) => safeJsonStringify(Array.from(sourceMap.entries())),
     deserialize: async data => (new SourceMap(JSON.parse(data))),
     persistent,
   })),
   errors: await getErrors(cacheName, remoteMapCreator, persistent),
   referenced: (await remoteMapCreator({
     namespace: getRemoteMapCacheNamespace(cacheName, 'referenced'),
-    serialize: (val: string[]) => safeJsonStringify(val ?? []),
+    serialize: async (val: string[]) => safeJsonStringify(val ?? []),
     deserialize: data => (JSON.parse(data)),
     persistent,
   })),
   staticFiles: (await remoteMapCreator({
     namespace: getRemoteMapCacheNamespace(cacheName, 'staticFiles'),
-    serialize: (val: string[]) => safeJsonStringify(val ?? []),
+    serialize: async (val: string[]) => safeJsonStringify(val ?? []),
     deserialize: data => (JSON.parse(data)),
     persistent,
   })),

--- a/packages/workspace/src/workspace/remote_map.ts
+++ b/packages/workspace/src/workspace/remote_map.ts
@@ -48,7 +48,7 @@ export interface CreateRemoteMapParams<T> {
   namespace: string
   batchInterval?: number
   persistent: boolean
-  serialize: (value: T) => string
+  serialize: (value: T) => Promise<string>
   deserialize: (s: string) => Promise<T>
 }
 

--- a/packages/workspace/src/workspace/state/index.ts
+++ b/packages/workspace/src/workspace/state/index.ts
@@ -14,4 +14,6 @@
 * limitations under the License.
 */
 export { State, StateData, StateMetadataKey, buildStateData, createStateNamespace } from './state'
+export { buildHistoryStateStaticFilesSource } from './static_files_sources/history_static_files_source'
+export { buildOverrideStateStaticFilesSource } from './static_files_sources/override_static_files_source'
 export { buildInMemState } from './in_mem'

--- a/packages/workspace/src/workspace/state/static_files_sources/history_static_files_source.ts
+++ b/packages/workspace/src/workspace/state/static_files_sources/history_static_files_source.ts
@@ -1,0 +1,89 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { StaticFile } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { LazyStaticFile } from '../../static_files/source'
+import { StateStaticFilesSource, StateStaticFilesStore } from '../../static_files/common'
+
+const log = logger(module)
+
+const getFileName = (filepath: string, hash: string): string =>
+  `${filepath}-${hash}`
+
+/**
+ * Builds a static file source that preserve the history of the static files
+ * by appending the hash of the file to its name.
+ */
+export const buildHistoryStateStaticFilesSource = (
+  dirStore: StateStaticFilesStore,
+): StateStaticFilesSource => {
+  let listedFilesCache: Promise<Set<string>> | undefined
+
+  const listFiles = async (): Promise<Set<string>> => {
+    if (listedFilesCache === undefined) {
+      listedFilesCache = dirStore.list().then(files => new Set(files))
+    }
+    return listedFilesCache
+  }
+
+  return {
+    persistStaticFile: async (file: StaticFile): Promise<void> => {
+      const path = getFileName(file.filepath, file.hash)
+      const existingFiles = await listFiles()
+      if (existingFiles.has(path)) {
+        return
+      }
+
+      const content = await file.getContent()
+      if (content === undefined) {
+        log.warn(`Received file ${file.filepath} to set without content`)
+        return
+      }
+      await dirStore.set({
+        buffer: content,
+        filename: getFileName(file.filepath, file.hash),
+      })
+      existingFiles.add(getFileName(file.filepath, file.hash))
+    },
+    getStaticFile: async (path, encoding, hash) => {
+      if (hash === undefined) {
+        throw new Error(`path ${path} was passed without a hash to getStaticFile`)
+      }
+      return new LazyStaticFile(
+        path,
+        hash,
+        dirStore.getFullPath(path),
+        async () => (await dirStore.get(getFileName(path, hash)))?.buffer,
+        encoding
+      )
+    },
+
+    rename: async name => {
+      log.debug('rename to %s ignored in history state static files source', name)
+    },
+    delete: async file => {
+      log.debug('delete %s ignored in history state static files source', file.filepath)
+    },
+    clear: async () => {
+      log.debug('clear ignored in history state static files source')
+    },
+
+    flush: () => log.time(
+      () => dirStore.flush(),
+      'Flushing history static state files source',
+    ),
+  }
+}

--- a/packages/workspace/src/workspace/state/static_files_sources/override_static_files_source.ts
+++ b/packages/workspace/src/workspace/state/static_files_sources/override_static_files_source.ts
@@ -1,0 +1,70 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { hash as lowerdashHash } from '@salto-io/lowerdash'
+import { logger } from '@salto-io/logging'
+import { DirectoryStore } from '../../dir_store'
+import { StateStaticFilesSource } from '../../static_files/common'
+import { LazyStaticFile } from '../../static_files/source'
+
+const log = logger(module)
+
+/**
+ * Builds a static file source that does not preserve
+ * the static files history and overrides it on each set.
+ */
+export const buildOverrideStateStaticFilesSource = (
+  dirStore: DirectoryStore<Buffer>,
+): StateStaticFilesSource => ({
+  persistStaticFile: async file => {
+    const content = await file.getContent()
+    if (content === undefined) {
+      log.warn(`Received file ${file.filepath} to set without content`)
+      return
+    }
+    await dirStore.set({
+      buffer: content,
+      filename: file.filepath,
+    })
+  },
+  getStaticFile: async (path, encoding, hash) => {
+    if (hash === undefined) {
+      throw new Error(`path ${path} was passed without a hash to getStaticFile`)
+    }
+    return new LazyStaticFile(
+      path,
+      hash,
+      dirStore.getFullPath(path),
+      async () => {
+        const content = (await dirStore.get(path))?.buffer
+        return content !== undefined
+            && lowerdashHash.toMD5(content) === hash
+          ? content
+          : undefined
+      },
+      encoding
+    )
+  },
+
+  rename: dirStore.rename,
+  delete: file => dirStore.delete(file.filepath),
+  clear: dirStore.clear,
+  flush: () => log.time(
+    async () => {
+      await dirStore.flush()
+    },
+    'Flushing override static state files source',
+  ),
+})

--- a/packages/workspace/src/workspace/static_files/common.ts
+++ b/packages/workspace/src/workspace/static_files/common.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import { StaticFile, Value } from '@salto-io/adapter-api'
+import { DirectoryStore } from '../dir_store'
 
 export abstract class InvalidStaticFile {
   constructor(
@@ -26,7 +27,7 @@ export abstract class InvalidStaticFile {
 export type StaticFilesSource = {
   // Load is optional for backwards compatibility
   load?(): Promise<string[]>
-  getStaticFile: (filepath: string, encoding: BufferEncoding) =>
+  getStaticFile: (filepath: string, encoding: BufferEncoding, hash?: string) =>
     Promise<StaticFile | InvalidStaticFile>
   getContent: (filepath: string) => Promise<Buffer>
   persistStaticFile: (staticFile: StaticFile) => Promise<void>
@@ -66,3 +67,7 @@ export const isInvalidStaticFile = (
 ): val is InvalidStaticFile => (
   val instanceof InvalidStaticFile
 )
+
+export type StateStaticFilesSource = Pick<StaticFilesSource, 'getStaticFile' | 'persistStaticFile' | 'flush' | 'clear' | 'rename' | 'delete' >
+
+export type StateStaticFilesStore = Pick<DirectoryStore<Buffer>, 'get' | 'set' | 'list' | 'getFullPath' | 'flush'>

--- a/packages/workspace/src/workspace/static_files/index.ts
+++ b/packages/workspace/src/workspace/static_files/index.ts
@@ -15,4 +15,4 @@
 */
 export { StaticFilesCache, StaticFilesData } from './cache'
 export { buildStaticFilesSource, buildInMemStaticFilesSource, LazyStaticFile, AbsoluteStaticFile } from './source'
-export { StaticFilesSource, MissingStaticFile, AccessDeniedStaticFile } from './common'
+export { StaticFilesSource, MissingStaticFile, AccessDeniedStaticFile, StateStaticFilesStore, StateStaticFilesSource } from './common'

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -371,7 +371,7 @@ export const loadWorkspace = async (
           }),
           changedBy: await remoteMapCreator<ElemID[]>({
             namespace: getRemoteMapNamespace('changedBy', envName),
-            serialize: val => safeJsonStringify(val.map(id => id.getFullName())),
+            serialize: async val => safeJsonStringify(val.map(id => id.getFullName())),
             deserialize: data => JSON.parse(data).map((id: string) => ElemID.fromFullName(id)),
             persistent,
           }),
@@ -383,19 +383,19 @@ export const loadWorkspace = async (
           }),
           referenceSources: await remoteMapCreator<ElemID[]>({
             namespace: getRemoteMapNamespace('referenceSources', envName),
-            serialize: val => safeJsonStringify(val.map(id => id.getFullName())),
+            serialize: async val => safeJsonStringify(val.map(id => id.getFullName())),
             deserialize: data => JSON.parse(data).map((id: string) => ElemID.fromFullName(id)),
             persistent,
           }),
           referenceTargets: await remoteMapCreator<ElemID[]>({
             namespace: getRemoteMapNamespace('referenceTargets', envName),
-            serialize: val => safeJsonStringify(val.map(id => id.getFullName())),
+            serialize: async val => safeJsonStringify(val.map(id => id.getFullName())),
             deserialize: data => JSON.parse(data).map((id: string) => ElemID.fromFullName(id)),
             persistent,
           }),
           mapVersions: await remoteMapCreator<number>({
             namespace: getRemoteMapNamespace('mapVersions', envName),
-            serialize: val => val.toString(),
+            serialize: async val => val.toString(),
             deserialize: async data => parseInt(data, 10),
             persistent,
           }),

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -377,7 +377,7 @@ export const loadWorkspace = async (
           }),
           changedAt: await remoteMapCreator<ElemID[]>({
             namespace: getRemoteMapNamespace('changedAt', envName),
-            serialize: val => safeJsonStringify(val.map(id => id.getFullName())),
+            serialize: async val => safeJsonStringify(val.map(id => id.getFullName())),
             deserialize: data => JSON.parse(data).map((id: string) => ElemID.fromFullName(id)),
             persistent,
           }),

--- a/packages/workspace/test/common/nacl_file_store.ts
+++ b/packages/workspace/test/common/nacl_file_store.ts
@@ -335,6 +335,7 @@ export const mockDirStore = (
     ),
     getFullPath: mockFunction<DirectoryStore<string>['getFullPath']>().mockImplementation(filename => filename),
     isPathIncluded: mockFunction<DirectoryStore<string>['isPathIncluded']>().mockReturnValue(true),
+    exists: mockFunction<DirectoryStore<string>['exists']>().mockImplementation(async filename => naclFiles.has(filename)),
   }
 }
 

--- a/packages/workspace/test/common/state.ts
+++ b/packages/workspace/test/common/state.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import { Element } from '@salto-io/adapter-api'
+import { mockStaticFilesSource } from '../utils'
 import { State, buildInMemState } from '../../src/workspace/state'
 import { InMemoryRemoteMap } from '../../src/workspace/remote_map'
 import { createInMemoryElementSource } from '../../src/workspace/elements_source'
@@ -28,5 +29,6 @@ export const mockState = (
     accountsUpdateDate: new InMemoryRemoteMap(),
     saltoVersion: '0.0.1',
     saltoMetadata: new InMemoryRemoteMap(),
+    staticFilesSource: mockStaticFilesSource(),
   }))
 )

--- a/packages/workspace/test/common/static_files_cache.ts
+++ b/packages/workspace/test/common/static_files_cache.ts
@@ -1,0 +1,27 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { mockFunction, MockInterface } from '@salto-io/test-utils'
+import { StaticFilesCache } from '../../src/workspace/static_files/cache'
+
+export const mockStaticFilesCache = (): MockInterface<StaticFilesCache> => ({
+  get: mockFunction<StaticFilesCache['get']>().mockResolvedValue(undefined),
+  put: mockFunction<StaticFilesCache['put']>(),
+  flush: mockFunction<StaticFilesCache['flush']>(),
+  clear: mockFunction<StaticFilesCache['clear']>(),
+  rename: mockFunction<StaticFilesCache['rename']>(),
+  clone: mockFunction<StaticFilesCache['clone']>(),
+  list: mockFunction<StaticFilesCache['list']>(),
+})

--- a/packages/workspace/test/utils.ts
+++ b/packages/workspace/test/utils.ts
@@ -99,7 +99,7 @@ export const persistentMockCreateRemoteMap = (): RemoteMapCreator => {
         entries: collections.asynciterable.ThenableIterable<RemoteMapEntry<T, K>>
       ): Promise<void> => {
         for await (const entry of entries) {
-          maps[opts.namespace][entry.key] = opts.serialize(entry.value)
+          maps[opts.namespace][entry.key] = await opts.serialize(entry.value)
         }
       },
       delete: async (key: K) => {
@@ -114,7 +114,7 @@ export const persistentMockCreateRemoteMap = (): RemoteMapCreator => {
       getMany: async (keys: K[]): Promise<(T | undefined)[]> => Promise.all(keys.map(get)),
       has: async (key: K): Promise<boolean> => key in maps[opts.namespace],
       set: async (key: K, value: T): Promise<void> => {
-        maps[opts.namespace][key] = opts.serialize(value)
+        maps[opts.namespace][key] = await opts.serialize(value)
       },
       clear: async (): Promise<void> => {
         maps[opts.namespace] = {} as Record<K, string>

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.state.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.state.test.ts
@@ -50,6 +50,7 @@ describe('Nacl Files Source', () => {
       clone: () => mockDirStore,
       getFullPath: filename => filename,
       isPathIncluded: jest.fn().mockResolvedValue(true),
+      exists: jest.fn().mockResolvedValue(false),
     }
     mockedStaticFilesSource = mockStaticFilesSource()
   })

--- a/packages/workspace/test/workspace/static_files_sources/history_static_files_source.test.ts
+++ b/packages/workspace/test/workspace/static_files_sources/history_static_files_source.test.ts
@@ -1,0 +1,135 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { StaticFile } from '@salto-io/adapter-api'
+import { hash } from '@salto-io/lowerdash'
+import { MockInterface } from '@salto-io/test-utils'
+import { StateStaticFilesSource } from '../../../src/workspace/static_files/common'
+import { DirectoryStore } from '../../../src/workspace/dir_store'
+import { buildHistoryStateStaticFilesSource } from '../../../src/workspace/state'
+
+describe('buildHistoryStateStaticFilesSource', () => {
+  let directoryStore: MockInterface<DirectoryStore<Buffer>>
+  let staticFilesSource: StateStaticFilesSource
+  beforeEach(async () => {
+    directoryStore = {
+      list: jest.fn(),
+      get: jest.fn(),
+      set: jest.fn(),
+      delete: jest.fn(),
+      clear: jest.fn(),
+      rename: jest.fn(),
+      renameFile: jest.fn(),
+      flush: jest.fn(),
+      mtimestamp: jest.fn(),
+      getFiles: jest.fn(),
+      getTotalSize: jest.fn(),
+      clone: jest.fn(),
+      isEmpty: jest.fn(),
+      getFullPath: jest.fn(),
+      isPathIncluded: jest.fn(),
+      exists: jest.fn().mockResolvedValue(true),
+    }
+
+    staticFilesSource = buildHistoryStateStaticFilesSource(directoryStore)
+  })
+
+
+  describe('get', () => {
+    it('get should return a static file', async () => {
+      directoryStore.get.mockResolvedValue({
+        filename: 'path',
+        buffer: Buffer.from('content'),
+      })
+      const file = await staticFilesSource.getStaticFile('path', 'binary', hash.toMD5('content')) as StaticFile
+      expect(file.filepath).toBe('path')
+      expect(directoryStore.get).not.toHaveBeenCalled()
+
+      expect(await file.getContent()).toEqual(Buffer.from('content'))
+      expect(directoryStore.get).toHaveBeenCalledWith(`path-${hash.toMD5('content')}`)
+
+      expect(await file.getContent()).toEqual(Buffer.from('content'))
+      expect(directoryStore.get).toHaveBeenCalledTimes(1)
+    })
+
+    it('get should return a static file without content if not found in dir store', async () => {
+      directoryStore.get.mockResolvedValue(undefined)
+      const file = await staticFilesSource.getStaticFile('path', 'binary', hash.toMD5('content')) as StaticFile
+      expect(directoryStore.get).not.toHaveBeenCalled()
+
+      expect(await file.getContent()).toBeUndefined()
+      expect(directoryStore.get).toHaveBeenCalledWith(`path-${hash.toMD5('content')}`)
+
+      expect(await file.getContent()).toBeUndefined()
+      expect(directoryStore.get).toHaveBeenCalledTimes(1)
+    })
+
+    it('should throw when hash is not passed', async () => {
+      directoryStore.get.mockResolvedValue(undefined)
+      await expect(staticFilesSource.getStaticFile('path', 'binary')).rejects.toThrow()
+    })
+  })
+
+  describe('set', () => {
+    it('set should call the dir store set if file does not exist in dir store', async () => {
+      directoryStore.list.mockResolvedValue([])
+      await staticFilesSource.persistStaticFile(
+        new StaticFile({ filepath: 'path', content: Buffer.from('content') })
+      )
+      expect(directoryStore.list).toHaveBeenCalled()
+      expect(directoryStore.set).toHaveBeenCalledWith({ filename: `path-${hash.toMD5('content')}`, buffer: Buffer.from('content') })
+    })
+
+    it('set should not call the dir store set if file exists in dir store', async () => {
+      directoryStore.list.mockResolvedValue([`path-${hash.toMD5('content')}`])
+      await staticFilesSource.persistStaticFile(
+        new StaticFile({ filepath: 'path', content: Buffer.from('content') })
+      )
+      expect(directoryStore.list).toHaveBeenCalled()
+      expect(directoryStore.set).not.toHaveBeenCalled()
+    })
+
+    it('set should not call the dir store set if there is no content', async () => {
+      directoryStore.list.mockResolvedValue([])
+      await staticFilesSource.persistStaticFile(
+        new StaticFile({ filepath: 'path', hash: hash.toMD5(Buffer.from('content')) })
+      )
+      expect(directoryStore.set).not.toHaveBeenCalled()
+    })
+  })
+
+  it('flush should call dir store flush', async () => {
+    await staticFilesSource.flush()
+    expect(directoryStore.flush).toHaveBeenCalled()
+  })
+
+  it('rename should do nothing', async () => {
+    await staticFilesSource.rename('name')
+    expect(directoryStore.rename).not.toHaveBeenCalled()
+  })
+
+  it('clear should do nothing', async () => {
+    await staticFilesSource.clear()
+    expect(directoryStore.clear).not.toHaveBeenCalled()
+  })
+
+  it('delete should do nothing', async () => {
+    await staticFilesSource.delete(new StaticFile({
+      filepath: 'name',
+      content: Buffer.from('buf'),
+    }))
+    expect(directoryStore.delete).not.toHaveBeenCalled()
+  })
+})

--- a/packages/workspace/test/workspace/static_files_sources/override_static_files_source.test.ts
+++ b/packages/workspace/test/workspace/static_files_sources/override_static_files_source.test.ts
@@ -1,0 +1,134 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { StaticFile } from '@salto-io/adapter-api'
+import { hash } from '@salto-io/lowerdash'
+import { MockInterface } from '@salto-io/test-utils'
+import { StateStaticFilesSource } from '../../../src/workspace/static_files/common'
+import { DirectoryStore } from '../../../src/workspace/dir_store'
+import { buildOverrideStateStaticFilesSource } from '../../../src/workspace/state'
+
+describe('buildOverrideStateStaticFilesSource', () => {
+  let directoryStore: MockInterface<DirectoryStore<Buffer>>
+  let staticFilesSource: StateStaticFilesSource
+  beforeEach(async () => {
+    directoryStore = {
+      list: jest.fn(),
+      get: jest.fn(),
+      set: jest.fn(),
+      delete: jest.fn(),
+      clear: jest.fn(),
+      rename: jest.fn(),
+      renameFile: jest.fn(),
+      flush: jest.fn(),
+      mtimestamp: jest.fn(),
+      getFiles: jest.fn(),
+      getTotalSize: jest.fn(),
+      clone: jest.fn(),
+      isEmpty: jest.fn(),
+      getFullPath: jest.fn(),
+      isPathIncluded: jest.fn(),
+      exists: jest.fn().mockResolvedValue(true),
+    }
+
+    staticFilesSource = buildOverrideStateStaticFilesSource(directoryStore)
+  })
+
+
+  describe('get', () => {
+    it('get should return a static file with content if md5 matches', async () => {
+      directoryStore.get.mockResolvedValue({
+        filename: 'path',
+        buffer: Buffer.from('content'),
+      })
+      const file = await staticFilesSource.getStaticFile('path', 'binary', hash.toMD5('content')) as StaticFile
+      expect(directoryStore.get).not.toHaveBeenCalled()
+
+      expect(await file.getContent()).toEqual(Buffer.from('content'))
+      expect(directoryStore.get).toHaveBeenCalledWith('path')
+
+      expect(await file.getContent()).toEqual(Buffer.from('content'))
+      expect(directoryStore.get).toHaveBeenCalledTimes(1)
+    })
+
+    it('get should return a static file without content if md5 does not match', async () => {
+      directoryStore.get.mockResolvedValue({
+        filename: 'path',
+        buffer: Buffer.from('content'),
+      })
+      const file = await staticFilesSource.getStaticFile('path', 'binary', hash.toMD5('content2')) as StaticFile
+      expect(directoryStore.get).not.toHaveBeenCalled()
+
+      expect(await file.getContent()).toBeUndefined()
+      expect(directoryStore.get).toHaveBeenCalledWith('path')
+    })
+
+    it('get should return a static file without content if not found in dir store', async () => {
+      directoryStore.get.mockResolvedValue(undefined)
+      const file = await staticFilesSource.getStaticFile('path', 'binary', hash.toMD5('content')) as StaticFile
+      expect(directoryStore.get).not.toHaveBeenCalled()
+
+      expect(await file.getContent()).toBeUndefined()
+      expect(directoryStore.get).toHaveBeenCalledWith('path')
+
+      expect(await file.getContent()).toBeUndefined()
+      expect(directoryStore.get).toHaveBeenCalledTimes(1)
+    })
+
+    it('should throw when hash is not passed', async () => {
+      directoryStore.get.mockResolvedValue(undefined)
+      await expect(staticFilesSource.getStaticFile('path', 'binary')).rejects.toThrow()
+    })
+  })
+
+  describe('set', () => {
+    it('set should call the dir store set', async () => {
+      await staticFilesSource.persistStaticFile(
+        new StaticFile({ filepath: 'path', content: Buffer.from('content') })
+      )
+      expect(directoryStore.set).toHaveBeenCalledWith({ filename: 'path', buffer: Buffer.from('content') })
+    })
+
+    it('set should not call the dir store set if there is no content', async () => {
+      await staticFilesSource.persistStaticFile(
+        new StaticFile({ filepath: 'path', hash: hash.toMD5(Buffer.from('content')) })
+      )
+      expect(directoryStore.set).not.toHaveBeenCalled()
+    })
+  })
+
+  it('flush should call dir store flush', async () => {
+    await staticFilesSource.flush()
+    expect(directoryStore.flush).toHaveBeenCalled()
+  })
+
+  it('rename should call dir store rename', async () => {
+    await staticFilesSource.rename('name')
+    expect(directoryStore.rename).toHaveBeenCalledWith('name')
+  })
+
+  it('clear should call dir store clear', async () => {
+    await staticFilesSource.clear()
+    expect(directoryStore.clear).toHaveBeenCalled()
+  })
+
+  it('delete should call dir store delete', async () => {
+    await staticFilesSource.delete(new StaticFile({
+      filepath: 'name',
+      content: Buffer.from('buf'),
+    }))
+    expect(directoryStore.delete).toHaveBeenCalledWith('name')
+  })
+})

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -135,6 +135,7 @@ const createState = (
   accountsUpdateDate: new InMemoryRemoteMap(),
   changedBy: new InMemoryRemoteMap([{ key: 'name@@account', value: ['elemId'] }]),
   saltoMetadata: new InMemoryRemoteMap([{ key: 'version', value: '0.0.1' }]),
+  staticFilesSource: mockStaticFilesSource(),
 }), persistent)
 const createWorkspace = async (
   dirStore?: DirectoryStore<string>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,6 +33,883 @@
     call-me-maybe "^1.0.1"
     z-schema "^5.0.1"
 
+"@aws-crypto/crc32@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/crc32/-/crc32-2.0.0.tgz#4ad432a3c03ec3087c5540ff6e41e6565d2dc153"
+  integrity sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==
+  dependencies:
+    "@aws-crypto/util" "^2.0.0"
+    "@aws-sdk/types" "^3.1.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/crc32c@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/crc32c/-/crc32c-2.0.0.tgz#4235336ef78f169f6a05248906703b9b78da676e"
+  integrity sha512-vF0eMdMHx3O3MoOXUfBZry8Y4ZDtcuskjjKgJz8YfIDjLStxTZrYXk+kZqtl6A0uCmmiN/Eb/JbC/CndTV1MHg==
+  dependencies:
+    "@aws-crypto/util" "^2.0.0"
+    "@aws-sdk/types" "^3.1.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/ie11-detection@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz#bb6c2facf8f03457e949dcf0921477397ffa4c6e"
+  integrity sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==
+  dependencies:
+    tslib "^1.11.1"
+
+"@aws-crypto/sha1-browser@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha1-browser/-/sha1-browser-2.0.0.tgz#71e735df20ea1d38f59259c4b1a2e00ca74a0eea"
+  integrity sha512-3fIVRjPFY8EG5HWXR+ZJZMdWNRpwbxGzJ9IH9q93FpbgCH8u8GHRi46mZXp3cYD7gealmyqpm3ThZwLKJjWJhA==
+  dependencies:
+    "@aws-crypto/ie11-detection" "^2.0.0"
+    "@aws-crypto/supports-web-crypto" "^2.0.0"
+    "@aws-sdk/types" "^3.1.0"
+    "@aws-sdk/util-locate-window" "^3.0.0"
+    "@aws-sdk/util-utf8-browser" "^3.0.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/sha256-browser@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz#741c9024df55ec59b51e5b1f5d806a4852699fb5"
+  integrity sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==
+  dependencies:
+    "@aws-crypto/ie11-detection" "^2.0.0"
+    "@aws-crypto/sha256-js" "^2.0.0"
+    "@aws-crypto/supports-web-crypto" "^2.0.0"
+    "@aws-crypto/util" "^2.0.0"
+    "@aws-sdk/types" "^3.1.0"
+    "@aws-sdk/util-locate-window" "^3.0.0"
+    "@aws-sdk/util-utf8-browser" "^3.0.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/sha256-js@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz#f1f936039bdebd0b9e2dd834d65afdc2aac4efcb"
+  integrity sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==
+  dependencies:
+    "@aws-crypto/util" "^2.0.0"
+    "@aws-sdk/types" "^3.1.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/sha256-js@^2.0.0":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-2.0.1.tgz#79e1e6cf61f652ef2089c08d471c722ecf1626a9"
+  integrity sha512-mbHTBSPBvg6o/mN/c18Z/zifM05eJrapj5ggoOIeHIWckvkv5VgGi7r/wYpt+QAO2ySKXLNvH2d8L7bne4xrMQ==
+  dependencies:
+    "@aws-crypto/util" "^2.0.1"
+    "@aws-sdk/types" "^3.1.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/supports-web-crypto@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz#fd6cde30b88f77d5a4f57b2c37c560d918014f9e"
+  integrity sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==
+  dependencies:
+    tslib "^1.11.1"
+
+"@aws-crypto/util@^2.0.0", "@aws-crypto/util@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/util/-/util-2.0.1.tgz#976cf619cf85084ca85ec5eb947a6ac6b8b5c98c"
+  integrity sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==
+  dependencies:
+    "@aws-sdk/types" "^3.1.0"
+    "@aws-sdk/util-utf8-browser" "^3.0.0"
+    tslib "^1.11.1"
+
+"@aws-sdk/abort-controller@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/abort-controller/-/abort-controller-3.110.0.tgz#15b493b776ec4f7236c6ad6134a6fe87e9dc5292"
+  integrity sha512-zok/WEVuK7Jh6V9YeA56pNZtxUASon9LTkS7vE65A4UFmNkPGNBCNgoiBcbhWfxwrZ8wtXcQk6rtUut39831mA==
+  dependencies:
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/chunked-blob-reader-native@3.109.0":
+  version "3.109.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.109.0.tgz#4db2ec81faf38fe33cf9dd6f75641afe0826dcfd"
+  integrity sha512-Ybn3vDZ3CqGyprL2qdF6QZqoqlx8lA3qOJepobjuKKDRw+KgGxjUY4NvWe0R2MdRoduyaDj6uvhIay0S1MOSJQ==
+  dependencies:
+    "@aws-sdk/util-base64-browser" "3.109.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/chunked-blob-reader@3.55.0":
+  version "3.55.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.55.0.tgz#db240c78e7c4c826e707f0ca32a4d221c41cf6a0"
+  integrity sha512-o/xjMCq81opAjSBjt7YdHJwIJcGVG5XIV9+C2KXcY5QwVimkOKPybWTv0mXPvSwSilSx+EhpLNhkcJuXdzhw4w==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/client-s3@^3.38.0":
+  version "3.121.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-s3/-/client-s3-3.121.0.tgz#12394dda433c878f10b0f3339f9637f12ebcb5b1"
+  integrity sha512-iJDqFCRNZM6+iF4E3zSCXKLDrDFxon8gzM0sK8TCkSSwa8Fhk/M/5OKslP9eKfJ1mzmh27IgFDoNnD5P59LbSQ==
+  dependencies:
+    "@aws-crypto/sha1-browser" "2.0.0"
+    "@aws-crypto/sha256-browser" "2.0.0"
+    "@aws-crypto/sha256-js" "2.0.0"
+    "@aws-sdk/client-sts" "3.121.0"
+    "@aws-sdk/config-resolver" "3.110.0"
+    "@aws-sdk/credential-provider-node" "3.121.0"
+    "@aws-sdk/eventstream-serde-browser" "3.120.0"
+    "@aws-sdk/eventstream-serde-config-resolver" "3.110.0"
+    "@aws-sdk/eventstream-serde-node" "3.120.0"
+    "@aws-sdk/fetch-http-handler" "3.110.0"
+    "@aws-sdk/hash-blob-browser" "3.110.0"
+    "@aws-sdk/hash-node" "3.110.0"
+    "@aws-sdk/hash-stream-node" "3.110.0"
+    "@aws-sdk/invalid-dependency" "3.110.0"
+    "@aws-sdk/md5-js" "3.110.0"
+    "@aws-sdk/middleware-bucket-endpoint" "3.110.0"
+    "@aws-sdk/middleware-content-length" "3.110.0"
+    "@aws-sdk/middleware-expect-continue" "3.113.0"
+    "@aws-sdk/middleware-flexible-checksums" "3.110.0"
+    "@aws-sdk/middleware-host-header" "3.110.0"
+    "@aws-sdk/middleware-location-constraint" "3.110.0"
+    "@aws-sdk/middleware-logger" "3.110.0"
+    "@aws-sdk/middleware-recursion-detection" "3.110.0"
+    "@aws-sdk/middleware-retry" "3.118.1"
+    "@aws-sdk/middleware-sdk-s3" "3.110.0"
+    "@aws-sdk/middleware-serde" "3.110.0"
+    "@aws-sdk/middleware-signing" "3.110.0"
+    "@aws-sdk/middleware-ssec" "3.110.0"
+    "@aws-sdk/middleware-stack" "3.110.0"
+    "@aws-sdk/middleware-user-agent" "3.110.0"
+    "@aws-sdk/node-config-provider" "3.110.0"
+    "@aws-sdk/node-http-handler" "3.118.1"
+    "@aws-sdk/protocol-http" "3.110.0"
+    "@aws-sdk/signature-v4-multi-region" "3.118.0"
+    "@aws-sdk/smithy-client" "3.110.0"
+    "@aws-sdk/types" "3.110.0"
+    "@aws-sdk/url-parser" "3.110.0"
+    "@aws-sdk/util-base64-browser" "3.109.0"
+    "@aws-sdk/util-base64-node" "3.55.0"
+    "@aws-sdk/util-body-length-browser" "3.55.0"
+    "@aws-sdk/util-body-length-node" "3.55.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.110.0"
+    "@aws-sdk/util-defaults-mode-node" "3.110.0"
+    "@aws-sdk/util-stream-browser" "3.110.0"
+    "@aws-sdk/util-stream-node" "3.110.0"
+    "@aws-sdk/util-user-agent-browser" "3.110.0"
+    "@aws-sdk/util-user-agent-node" "3.118.0"
+    "@aws-sdk/util-utf8-browser" "3.109.0"
+    "@aws-sdk/util-utf8-node" "3.109.0"
+    "@aws-sdk/util-waiter" "3.118.1"
+    "@aws-sdk/xml-builder" "3.109.0"
+    entities "2.2.0"
+    fast-xml-parser "3.19.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/client-sso@3.121.0":
+  version "3.121.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso/-/client-sso-3.121.0.tgz#a0d26c03f0a58ffbce85bcc4cd0384f6c090d900"
+  integrity sha512-uYkeUdNnEla57g4QZT0Cu5ll+m0fUQJPkoTXQI5QKeLH2usVpmrCRbtTWEVTh94Gf2x/HK8Ifu7eO/0PquwwIQ==
+  dependencies:
+    "@aws-crypto/sha256-browser" "2.0.0"
+    "@aws-crypto/sha256-js" "2.0.0"
+    "@aws-sdk/config-resolver" "3.110.0"
+    "@aws-sdk/fetch-http-handler" "3.110.0"
+    "@aws-sdk/hash-node" "3.110.0"
+    "@aws-sdk/invalid-dependency" "3.110.0"
+    "@aws-sdk/middleware-content-length" "3.110.0"
+    "@aws-sdk/middleware-host-header" "3.110.0"
+    "@aws-sdk/middleware-logger" "3.110.0"
+    "@aws-sdk/middleware-recursion-detection" "3.110.0"
+    "@aws-sdk/middleware-retry" "3.118.1"
+    "@aws-sdk/middleware-serde" "3.110.0"
+    "@aws-sdk/middleware-stack" "3.110.0"
+    "@aws-sdk/middleware-user-agent" "3.110.0"
+    "@aws-sdk/node-config-provider" "3.110.0"
+    "@aws-sdk/node-http-handler" "3.118.1"
+    "@aws-sdk/protocol-http" "3.110.0"
+    "@aws-sdk/smithy-client" "3.110.0"
+    "@aws-sdk/types" "3.110.0"
+    "@aws-sdk/url-parser" "3.110.0"
+    "@aws-sdk/util-base64-browser" "3.109.0"
+    "@aws-sdk/util-base64-node" "3.55.0"
+    "@aws-sdk/util-body-length-browser" "3.55.0"
+    "@aws-sdk/util-body-length-node" "3.55.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.110.0"
+    "@aws-sdk/util-defaults-mode-node" "3.110.0"
+    "@aws-sdk/util-user-agent-browser" "3.110.0"
+    "@aws-sdk/util-user-agent-node" "3.118.0"
+    "@aws-sdk/util-utf8-browser" "3.109.0"
+    "@aws-sdk/util-utf8-node" "3.109.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/client-sts@3.121.0":
+  version "3.121.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sts/-/client-sts-3.121.0.tgz#258077598138a102b508519da6551949ea08c37b"
+  integrity sha512-ZqEcxfeYVeSo/VyXSI4XW4MsWYoRmEdxRLWwI7kgFQxgqwVtfhPmvcaw6CA1atMcSR6waiRSpe9pgpj6gKJvyw==
+  dependencies:
+    "@aws-crypto/sha256-browser" "2.0.0"
+    "@aws-crypto/sha256-js" "2.0.0"
+    "@aws-sdk/config-resolver" "3.110.0"
+    "@aws-sdk/credential-provider-node" "3.121.0"
+    "@aws-sdk/fetch-http-handler" "3.110.0"
+    "@aws-sdk/hash-node" "3.110.0"
+    "@aws-sdk/invalid-dependency" "3.110.0"
+    "@aws-sdk/middleware-content-length" "3.110.0"
+    "@aws-sdk/middleware-host-header" "3.110.0"
+    "@aws-sdk/middleware-logger" "3.110.0"
+    "@aws-sdk/middleware-recursion-detection" "3.110.0"
+    "@aws-sdk/middleware-retry" "3.118.1"
+    "@aws-sdk/middleware-sdk-sts" "3.110.0"
+    "@aws-sdk/middleware-serde" "3.110.0"
+    "@aws-sdk/middleware-signing" "3.110.0"
+    "@aws-sdk/middleware-stack" "3.110.0"
+    "@aws-sdk/middleware-user-agent" "3.110.0"
+    "@aws-sdk/node-config-provider" "3.110.0"
+    "@aws-sdk/node-http-handler" "3.118.1"
+    "@aws-sdk/protocol-http" "3.110.0"
+    "@aws-sdk/smithy-client" "3.110.0"
+    "@aws-sdk/types" "3.110.0"
+    "@aws-sdk/url-parser" "3.110.0"
+    "@aws-sdk/util-base64-browser" "3.109.0"
+    "@aws-sdk/util-base64-node" "3.55.0"
+    "@aws-sdk/util-body-length-browser" "3.55.0"
+    "@aws-sdk/util-body-length-node" "3.55.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.110.0"
+    "@aws-sdk/util-defaults-mode-node" "3.110.0"
+    "@aws-sdk/util-user-agent-browser" "3.110.0"
+    "@aws-sdk/util-user-agent-node" "3.118.0"
+    "@aws-sdk/util-utf8-browser" "3.109.0"
+    "@aws-sdk/util-utf8-node" "3.109.0"
+    entities "2.2.0"
+    fast-xml-parser "3.19.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/config-resolver@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/config-resolver/-/config-resolver-3.110.0.tgz#93de506934aa06dd973e5e3dab95b629697372f9"
+  integrity sha512-7VvtKy4CL63BAktQ2vgsjhWDSXpkXO5YdiI56LQnHztrvSuJBBaxJ7R1p/k0b2tEUhYKUziAIW8EKE/7EGPR4g==
+  dependencies:
+    "@aws-sdk/signature-v4" "3.110.0"
+    "@aws-sdk/types" "3.110.0"
+    "@aws-sdk/util-config-provider" "3.109.0"
+    "@aws-sdk/util-middleware" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-env@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.110.0.tgz#c95552fc0a3ae857ced0e171e53082cf3c84bc74"
+  integrity sha512-oFU3IYk/Bl5tdsz1qigtm3I25a9cvXPqlE8VjYjxVDdLujF5zd/4HLbhP4GQWhpEwZmM1ijcSNfLcyywVevTZg==
+  dependencies:
+    "@aws-sdk/property-provider" "3.110.0"
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-imds@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.110.0.tgz#ba4f178ccab65c5760bce38e7f694584dad3fd74"
+  integrity sha512-atl+7/dAB+8fG9XI2fYyCgXKYDbOzot65VAwis+14bOEUCVp7PCJifBEZ/L8GEq564p+Fa2p1IpV0wuQXxqFUQ==
+  dependencies:
+    "@aws-sdk/node-config-provider" "3.110.0"
+    "@aws-sdk/property-provider" "3.110.0"
+    "@aws-sdk/types" "3.110.0"
+    "@aws-sdk/url-parser" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-ini@3.121.0":
+  version "3.121.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.121.0.tgz#d87bfafb8671f04dddd1d2d04b64147040e9e3c7"
+  integrity sha512-wOuGOifwZtTN/prCaG+hO9AtpKjJB/QyRse251+I+inNPg2iSd9rCLfHZdmfL/Zn2XJyfg0ULOl6c/myF5aRDg==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "3.110.0"
+    "@aws-sdk/credential-provider-imds" "3.110.0"
+    "@aws-sdk/credential-provider-sso" "3.121.0"
+    "@aws-sdk/credential-provider-web-identity" "3.110.0"
+    "@aws-sdk/property-provider" "3.110.0"
+    "@aws-sdk/shared-ini-file-loader" "3.110.0"
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-node@3.121.0":
+  version "3.121.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.121.0.tgz#a009c4f71fabc6cab1fc4f7fbae4f851403d9da9"
+  integrity sha512-wY5+oey0eoxkGMTXrZ+tK7FKA91WN8ntBbYBbZL0vktHYCQkBra5fBGV17RNp8ggVkJXAtDdrIjTBEQ/vNrMrQ==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "3.110.0"
+    "@aws-sdk/credential-provider-imds" "3.110.0"
+    "@aws-sdk/credential-provider-ini" "3.121.0"
+    "@aws-sdk/credential-provider-process" "3.110.0"
+    "@aws-sdk/credential-provider-sso" "3.121.0"
+    "@aws-sdk/credential-provider-web-identity" "3.110.0"
+    "@aws-sdk/property-provider" "3.110.0"
+    "@aws-sdk/shared-ini-file-loader" "3.110.0"
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-process@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.110.0.tgz#1f4543edd532beb4b690e6f3aaf74d00af3be5c4"
+  integrity sha512-JJcZePvRTfQHYj/+EEY13yItnZH/e8exlARFUjN0L13UrgHpOJtDQBa+YBHXo6MbTFQh+re25z2kzc+zOYSMNQ==
+  dependencies:
+    "@aws-sdk/property-provider" "3.110.0"
+    "@aws-sdk/shared-ini-file-loader" "3.110.0"
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-sso@3.121.0":
+  version "3.121.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.121.0.tgz#8bac8420f280fcba0c2dd25af4925173bc979db3"
+  integrity sha512-c9XmnndZmJdkSBgDpVQCN8fcVTkRrtDWNUBO6TcA0abxGOOteUS7s9YmJKqMuwABzk+WGJ1B2EVC5b0AMzIFYg==
+  dependencies:
+    "@aws-sdk/client-sso" "3.121.0"
+    "@aws-sdk/property-provider" "3.110.0"
+    "@aws-sdk/shared-ini-file-loader" "3.110.0"
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-web-identity@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.110.0.tgz#236e192826c3856e1f2b8eaa1ad126affd641082"
+  integrity sha512-e4e5u7v3fsUFZsMcFMhMy1NdJBQpunYcLwpYlszm3OEICwTTekQ+hVvnVRd134doHvzepE4yp9sAop0Cj+IRVQ==
+  dependencies:
+    "@aws-sdk/property-provider" "3.110.0"
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/eventstream-codec@3.119.0":
+  version "3.119.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/eventstream-codec/-/eventstream-codec-3.119.0.tgz#6eb5a645a38e0175fa054257addb54757bcf8d62"
+  integrity sha512-HMHVfsYU2yaJ2NMHe1HUhQnWD3hCabC3xTVcAx5SSAE+afc74xoQTCA6oDI6OoCLL47ISLjcrkpvfYCAZ7wHTw==
+  dependencies:
+    "@aws-crypto/crc32" "2.0.0"
+    "@aws-sdk/types" "3.110.0"
+    "@aws-sdk/util-hex-encoding" "3.109.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/eventstream-serde-browser@3.120.0":
+  version "3.120.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.120.0.tgz#99b898ce852a3ef8633baca4cca42e1303d65fbd"
+  integrity sha512-+UUq5vey2mJx1NYhq4Gg/jzs5EJE6gW2g91NPcO842891YxZAOmHciFI5kzLKn8PgSKKhbmCL6pq8UqX4N8lRw==
+  dependencies:
+    "@aws-sdk/eventstream-serde-universal" "3.120.0"
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/eventstream-serde-config-resolver@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.110.0.tgz#5ec8dee49a595b6079fc52bc4355bc15626bb9de"
+  integrity sha512-0kyKUU5/46OGe6rgIqbNRJEQhNYwxLdgcJXlBl6q6CdgyQApz6jsAgG0C5xhSLSi4iJijDRriJTowAhkq4AlWQ==
+  dependencies:
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/eventstream-serde-node@3.120.0":
+  version "3.120.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.120.0.tgz#ff5cd01233e84813dce9cb5eda0dcb8efc9b034b"
+  integrity sha512-+RoUQKzB+MBH6nThLmc/VnmwNMzWxiCD8Z8KbGUG+1ybYqshSwGKObCqDfAIwe+W97xNZpsx4Br7/bcPEY322g==
+  dependencies:
+    "@aws-sdk/eventstream-serde-universal" "3.120.0"
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/eventstream-serde-universal@3.120.0":
+  version "3.120.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.120.0.tgz#9bc7b7a01f4ed94e2d89622917eb652fe97b94f2"
+  integrity sha512-2tZ5+3YlQRfsd0xibgVueWegengOMZIZF3ksq+IygWrRwukI9+QfC7oYe29/yttKoz2AipNKNY+JL9MgjHEdmg==
+  dependencies:
+    "@aws-sdk/eventstream-codec" "3.119.0"
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/fetch-http-handler@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.110.0.tgz#0b6d552659b779c49ba0f99c78a57755864bf1b0"
+  integrity sha512-vk+K4GeCZL2J2rtvKO+T0Q7i3MDpEGZBMg5K2tj9sMcEQwty0BF0aFnP7Eu2l4/Zif2z1mWuUFM2WcZI6DVnbw==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.110.0"
+    "@aws-sdk/querystring-builder" "3.110.0"
+    "@aws-sdk/types" "3.110.0"
+    "@aws-sdk/util-base64-browser" "3.109.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/hash-blob-browser@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.110.0.tgz#9237d9cd239ed1e964cf567dd4d2891b30984417"
+  integrity sha512-NkTosjlYwP2dcBXY6yzhNafAK+W2nceheffvWdyGA29+E9YdRjDminXvKc/WAkZUMOW0CaCbD90otOiimAAYyQ==
+  dependencies:
+    "@aws-sdk/chunked-blob-reader" "3.55.0"
+    "@aws-sdk/chunked-blob-reader-native" "3.109.0"
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/hash-node@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/hash-node/-/hash-node-3.110.0.tgz#b225bfd16596b6485c1c610e8fef8de1e40931c4"
+  integrity sha512-wakl+kP2O8wTGYiQ3InZy+CVfGrIpFfq9fo4zif9PZac0BbUbguUU1dkY34uZiaf+4o2/9MoDYrHU2HYeXKxWw==
+  dependencies:
+    "@aws-sdk/types" "3.110.0"
+    "@aws-sdk/util-buffer-from" "3.55.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/hash-stream-node@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/hash-stream-node/-/hash-stream-node-3.110.0.tgz#786304b29d27a8e3814a49fb93208e8231ebca87"
+  integrity sha512-srlStn+dCnBlQy4oWBz3oFS8vT5Xgxhra91rt9U+vHruCyQ0L1es0J87X4uwy2HRlnIw3daPtVLtxekahEXzKQ==
+  dependencies:
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/invalid-dependency@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/invalid-dependency/-/invalid-dependency-3.110.0.tgz#9104dfd40e35b6737dc7ab01f4e79c76c1109c44"
+  integrity sha512-O8J1InmtJkoiUMbQDtxBfOzgigBp9iSVsNXQrhs2qHh3826cJOfE7NGT3u+NMw73Pk5j2cfmOh1+7k/76IqxOg==
+  dependencies:
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/is-array-buffer@3.55.0":
+  version "3.55.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/is-array-buffer/-/is-array-buffer-3.55.0.tgz#c46122c5636f01d5895e5256a587768c3425ea7a"
+  integrity sha512-NbiPHVYuPxdqdFd6FxzzN3H1BQn/iWA3ri3Ry7AyLeP/tGs1yzEWMwf8BN8TSMALI0GXT6Sh0GDWy3Ok5xB6DA==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/md5-js@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/md5-js/-/md5-js-3.110.0.tgz#0a8745cbcaa609452d034e1b0edfa8f0cf45e2ae"
+  integrity sha512-66gV6CH8O7ymTZMIbGjdUI71K7ErDfudhtN/ULb97kD2TYX4NlFtxNZxx3+iZH1G0H636lWm9hJcU5ELG9B+bw==
+  dependencies:
+    "@aws-sdk/types" "3.110.0"
+    "@aws-sdk/util-utf8-browser" "3.109.0"
+    "@aws-sdk/util-utf8-node" "3.109.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-bucket-endpoint@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.110.0.tgz#76e0dce1d16750340da76736c5737d790db1a95a"
+  integrity sha512-l1q0KzMRFyGSSc7LZGEh2xhCha1933C8uJE5g23b7dZdklEU5I62l4daELo+TBANcxFzDiRXd6g5mly/T+ZTSg==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.110.0"
+    "@aws-sdk/types" "3.110.0"
+    "@aws-sdk/util-arn-parser" "3.55.0"
+    "@aws-sdk/util-config-provider" "3.109.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-content-length@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-content-length/-/middleware-content-length-3.110.0.tgz#f4dc3508952c5fae9740f172d3b76135dd4dba37"
+  integrity sha512-hKU+zdqfAJQg22LXMVu/z35nNIHrVAKpVKPe9+WYVdL/Z7JKUPK7QymqKGOyDuDbzW6OxyulC1zKGEX12zGmdA==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.110.0"
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-expect-continue@3.113.0":
+  version "3.113.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.113.0.tgz#0129967f40ef57eec922ef8e126d77b90853a0fe"
+  integrity sha512-LLtSunCYVWeAhRP+6enn0kYF119WooV6gepMGOWeRCpKXO2iyi8YOx2Mtgc3T8ybiAG/dVlmZoX47Y1HINcuqg==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.110.0"
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-flexible-checksums@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.110.0.tgz#bbf6009d45b7080e262a7351a86acf083ee22af1"
+  integrity sha512-Z/v1Da+e1McxrVr1s4jUykp2EXsOHpTxZ4M0X8vNkXCIVSuaMp4UI0P+LQawbDA+j3FaecqqBfWMZ2sHQ8bpoA==
+  dependencies:
+    "@aws-crypto/crc32" "2.0.0"
+    "@aws-crypto/crc32c" "2.0.0"
+    "@aws-sdk/is-array-buffer" "3.55.0"
+    "@aws-sdk/protocol-http" "3.110.0"
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-host-header@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-host-header/-/middleware-host-header-3.110.0.tgz#a28115e2797b86c2fb583000593b723a51313b92"
+  integrity sha512-/Cknn1vL2LTlclI0MX2RzmtdPlCJ5palCRXxm/mod1oHwg4oNTKRlUX3LUD+L8g7JuJ4h053Ch9KS/A0vanE5Q==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.110.0"
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-location-constraint@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.110.0.tgz#0a710ac704cc7c40ca34edf62387d8ac1fdbdaae"
+  integrity sha512-8ZSo9sqrTMcSp0xEJQ3ypmQpeSMQl1NXXv72khJPweZqDoO0eAbfytwyH4JH4sP0VwVVmuDHdwPXyDZX7I0iQg==
+  dependencies:
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-logger@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-logger/-/middleware-logger-3.110.0.tgz#69eb0b2d0d9833f6fdbe33eb1876254e7cee53ec"
+  integrity sha512-+pz+a+8dfTnzLj79nHrv3aONMp/N36/erMd+7JXeR84QEosVLrFBUwKA8x5x6O3s1iBbQzRKMYEIuja9xn1BPA==
+  dependencies:
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-recursion-detection@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.110.0.tgz#8daa2bc9f62cbf499d9c615726cf2a51f46e70ff"
+  integrity sha512-Wav782zd7bcd1e6txRob76CDOdVOaUQ8HXoywiIm/uFrEEUZvhs2mgnXjVUVCMBUehdNgnL99z420aS13JeL/Q==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.110.0"
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-retry@3.118.1":
+  version "3.118.1"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-retry/-/middleware-retry-3.118.1.tgz#a43799a113c89e76ce676490ecad91af96699fbe"
+  integrity sha512-Dh0EgO3yPHEaRC6CVrofgAMdUQaG0Kkl466iVFHN5n5kExQvCtvpMHwO9N7kqaq9lXten3yhzboRNLIo98E1Kw==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.110.0"
+    "@aws-sdk/service-error-classification" "3.110.0"
+    "@aws-sdk/types" "3.110.0"
+    "@aws-sdk/util-middleware" "3.110.0"
+    tslib "^2.3.1"
+    uuid "^8.3.2"
+
+"@aws-sdk/middleware-sdk-s3@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.110.0.tgz#069603d33fbc349661facb0aaa131a95263e1b88"
+  integrity sha512-/PpZU11dkGldD6yeAccPxFd5nzofLOA3+j25RdIwz2jlJMLl9TeznYRtFH5JhHonP3lsK+IPEnFPwuL6gkBxIQ==
+  dependencies:
+    "@aws-sdk/middleware-bucket-endpoint" "3.110.0"
+    "@aws-sdk/protocol-http" "3.110.0"
+    "@aws-sdk/types" "3.110.0"
+    "@aws-sdk/util-arn-parser" "3.55.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-sdk-sts@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.110.0.tgz#8c1e34b72355c5e63495927a01839f210327f0c1"
+  integrity sha512-EjY/YFdlr5jECde6qIrTIyGBbn/34CKcQGKvmvRd31+3qaClIJLAwNuHfcVzWvCUGbAslsfvdbOpLju33pSQRA==
+  dependencies:
+    "@aws-sdk/middleware-signing" "3.110.0"
+    "@aws-sdk/property-provider" "3.110.0"
+    "@aws-sdk/protocol-http" "3.110.0"
+    "@aws-sdk/signature-v4" "3.110.0"
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-serde@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-serde/-/middleware-serde-3.110.0.tgz#603dcc1f68d78e9123f9b696150374a8357de6c3"
+  integrity sha512-brVupxgEAmcZ9cZvdHEH8zncjvGKIiud8pOe4fiimp5NpHmjBLew4jUbnOKNZNAjaidcKUtz//cxtutD6yXEww==
+  dependencies:
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-signing@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-signing/-/middleware-signing-3.110.0.tgz#8faa6acdaedb1c29614fe7ba88a74534db38f3bb"
+  integrity sha512-y6ZKrGYfgDlFMzWhZmoq5J1UctBgZOUvMmnU9sSeZ020IlEPiOxFMvR0Zu6TcYThp8uy3P0wyjQtGYeTl9Z/kA==
+  dependencies:
+    "@aws-sdk/property-provider" "3.110.0"
+    "@aws-sdk/protocol-http" "3.110.0"
+    "@aws-sdk/signature-v4" "3.110.0"
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-ssec@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-ssec/-/middleware-ssec-3.110.0.tgz#85020a0e54840e572231407dde6d40a82239d03b"
+  integrity sha512-Zrm+h+C+MXv2Q+mh8O/zwK2hUYM4kq4I1vx72RPpvyfIk4/F5ZzeA3LSVluISyAW+iNqS8XFvGFrzl2gB8zWsg==
+  dependencies:
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-stack@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-stack/-/middleware-stack-3.110.0.tgz#5a531c83ec375adf9d7f1bd80b725cebf7b2f01d"
+  integrity sha512-iaLHw6ctOuGa9UxNueU01Xes+15dR+mqioRpUOUZ9Zx+vhXVpD7C8lnNqhRnYeFXs10/rNIzASgsIrAHTlnlIQ==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-user-agent@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.110.0.tgz#52f32e99ecb641babcd59bb010527d5614e908f4"
+  integrity sha512-Y6FgiZr99DilYq6AjeaaWcNwVlSQpNGKrILzvV4Tmz03OaBIspe4KL+8EZ2YA/sAu5Lpw80vItdezqDOwGAlnQ==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.110.0"
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/node-config-provider@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/node-config-provider/-/node-config-provider-3.110.0.tgz#7d032082b85458ea4959f744d473e328be024359"
+  integrity sha512-46p4dCPGYctuybTQTwLpjenA1QFHeyJw/OyggGbtUJUy+833+ldnAwcPVML2aXJKUKv3APGI8vq1kaloyNku3Q==
+  dependencies:
+    "@aws-sdk/property-provider" "3.110.0"
+    "@aws-sdk/shared-ini-file-loader" "3.110.0"
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/node-http-handler@3.118.1":
+  version "3.118.1"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/node-http-handler/-/node-http-handler-3.118.1.tgz#8f71c1b4dffae4cbec1151910c2d6fbf7b966706"
+  integrity sha512-pfWVAUNJEs0UW0KkDqq2/VCz9PIpvg4mYEfCVZ4jR+Rv8F7UezNeM3FrEdHk8dfYShH+OV0hFskHBQJhw1BX2Q==
+  dependencies:
+    "@aws-sdk/abort-controller" "3.110.0"
+    "@aws-sdk/protocol-http" "3.110.0"
+    "@aws-sdk/querystring-builder" "3.110.0"
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/property-provider@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/property-provider/-/property-provider-3.110.0.tgz#ea60c33a8e243246fc21d478ff009063825b9abd"
+  integrity sha512-7NkpmYeOkK3mhWBNU+/zSDqwzeaSPH1qrq4L//WV7WS/weYyE/jusQeZoOxVsuZQnQEXHt5O2hKVeUwShl12xA==
+  dependencies:
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/protocol-http@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/protocol-http/-/protocol-http-3.110.0.tgz#ff3cffa5b1eb7c8564a9e9019a8842b429c7f85c"
+  integrity sha512-qdi2gCbJiyPyLn+afebPNp/5nVCRh1X7t7IRIFl3FHVEC+o54u/ojay/MLZ4M/+X9Fa4Zxsb0Wpp3T0xAHVDBg==
+  dependencies:
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/querystring-builder@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/querystring-builder/-/querystring-builder-3.110.0.tgz#c7f63262e898ab38cdbbbfcd03ddbfde346c9595"
+  integrity sha512-7V3CDXj519izmbBn9ZE68ymASwGriA+Aq+cb/yHSVtffnvXjPtvONNw7G/5iVblisGLSCUe2hSvpYtcaXozbHw==
+  dependencies:
+    "@aws-sdk/types" "3.110.0"
+    "@aws-sdk/util-uri-escape" "3.55.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/querystring-parser@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/querystring-parser/-/querystring-parser-3.110.0.tgz#0551efb7aaa867d3b6705f62d798a45247f5f44b"
+  integrity sha512-//pJHH7hrhdDMZGBPKXKymmC/tJM7gFT0w/qbu/yd3Wm4W2fMB+8gkmj6EZctx7jrsWlfRQuvFejKqEfapur/g==
+  dependencies:
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/service-error-classification@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/service-error-classification/-/service-error-classification-3.110.0.tgz#09398517d4ad9787bd0d904816bfe0ffd68b1f5f"
+  integrity sha512-ccgCE0pU/4RmXR6CP3fLAdhPAve7bK/yXBbGzpSHGAQOXqNxYzOsAvQ30Jg6X+qjLHsI/HR2pLIE65z4k6tynw==
+
+"@aws-sdk/shared-ini-file-loader@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.110.0.tgz#f91b66e7084312df2b337cc990c9585e832fc2fc"
+  integrity sha512-E1ERoqEoG206XNBYWCKLgHkzCbTxdpDEGbsLET2DnvjFsT0s9p2dPvVux3bYl7JVAhyGduE+qcqWk7MzhFCBNQ==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/signature-v4-multi-region@3.118.0":
+  version "3.118.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.118.0.tgz#2a61980dc1857b94b64936c5997ab9dac186f915"
+  integrity sha512-Uih3SR5d3XBeUtiMFkDERx7jLOZSXvVrhikA9p416FIPWZ5649sQ/esYsDvWBB39nbnYMx/QlsR+imCvh8XlhQ==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.110.0"
+    "@aws-sdk/signature-v4" "3.110.0"
+    "@aws-sdk/types" "3.110.0"
+    "@aws-sdk/util-arn-parser" "3.55.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/signature-v4@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4/-/signature-v4-3.110.0.tgz#9dba5d06345fa756b4c23deeec7086f6148a5bf1"
+  integrity sha512-utxxdllOnmQDhbpipnFAbuQ4c2pwefZ+2hi48jKvQRULQ2PO4nxLmdZm6B0FXaTijbKsyO7GrMik+EZ6mi3ARQ==
+  dependencies:
+    "@aws-sdk/is-array-buffer" "3.55.0"
+    "@aws-sdk/types" "3.110.0"
+    "@aws-sdk/util-hex-encoding" "3.109.0"
+    "@aws-sdk/util-middleware" "3.110.0"
+    "@aws-sdk/util-uri-escape" "3.55.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/smithy-client@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/smithy-client/-/smithy-client-3.110.0.tgz#397c0e7ef56ffa058469c641b586978400c09dd7"
+  integrity sha512-gNLYrmdAe/1hVF2Nv2LF4OkL1A0a1o708pEMZHzql9xP164omRDaLrGDhz9tH7tsJEgLz+Bf4E8nTuISeDwvGg==
+  dependencies:
+    "@aws-sdk/middleware-stack" "3.110.0"
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/types@3.110.0", "@aws-sdk/types@^3.1.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.110.0.tgz#09404533b507925eadf9acf9c4356667048e45bd"
+  integrity sha512-dLVoqODU3laaqNFPyN1QLtlQnwX4gNPMXptEBIt/iJpuZf66IYJe6WCzVZGt4Zfa1CnUmrlA428AzdcA/KCr2A==
+
+"@aws-sdk/url-parser@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/url-parser/-/url-parser-3.110.0.tgz#87d5c0a6f6d2f29027c747c65d8a2846302bc792"
+  integrity sha512-tILFB8/Q73yzgO0dErJNnELmmBszd0E6FucwAnG3hfDefjqCBe09Q/1yhu2aARXyRmZa4AKp0sWcdwIWHc8dnA==
+  dependencies:
+    "@aws-sdk/querystring-parser" "3.110.0"
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-arn-parser@3.55.0":
+  version "3.55.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-arn-parser/-/util-arn-parser-3.55.0.tgz#6672eb2975e798a460bedfaf6b5618d4e4b262e1"
+  integrity sha512-76KJxp4MRWufHYWys7DFl64znr5yeJ3AIQNAPCKKw1sP0hzO7p6Kx0PaJnw9x+CPSzOrT4NbuApL6/srYhKDGg==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-base64-browser@3.109.0":
+  version "3.109.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-base64-browser/-/util-base64-browser-3.109.0.tgz#e7faf5c4cbb88bc39b9c1c5a1a79e4c869e9f645"
+  integrity sha512-lAZ6fyDGiRLaIsKT9qh7P9FGuNyZ4gAbr1YOSQk/5mHtaTuUvxlPptZuInNM/0MPQm6lpcot00D8IWTucn4PbA==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-base64-node@3.55.0":
+  version "3.55.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-base64-node/-/util-base64-node-3.55.0.tgz#da9a3fd6752be49163572144793e6b23d0186ff4"
+  integrity sha512-UQ/ZuNoAc8CFMpSiRYmevaTsuRKzLwulZTnM8LNlIt9Wx1tpNvqp80cfvVj7yySKROtEi20wq29h31dZf1eYNQ==
+  dependencies:
+    "@aws-sdk/util-buffer-from" "3.55.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-body-length-browser@3.55.0":
+  version "3.55.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.55.0.tgz#9c2637097501032f6a1afddb76687415fe9b44b6"
+  integrity sha512-Ei2OCzXQw5N6ZkTMZbamUzc1z+z1R1Ja5tMEagz5BxuX4vWdBObT+uGlSzL8yvTbjoPjnxWA2aXyEqaUP3JS8Q==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-body-length-node@3.55.0":
+  version "3.55.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-body-length-node/-/util-body-length-node-3.55.0.tgz#67049bbb6c62d794a1bb5a13b9a678988c925489"
+  integrity sha512-lU1d4I+9wJwydduXs0SxSfd+mHKjxeyd39VwOv6i2KSwWkPbji9UQqpflKLKw+r45jL7+xU/zfeTUg5Tt/3Gew==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-buffer-from@3.55.0":
+  version "3.55.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-buffer-from/-/util-buffer-from-3.55.0.tgz#e7c927974b07a29502aa1ad58509b91d0d7cf0f7"
+  integrity sha512-uVzKG1UgvnV7XX2FPTylBujYMKBPBaq/qFBxfl0LVNfrty7YjpfieQxAe6yRLD+T0Kir/WDQwGvYC+tOYG3IGA==
+  dependencies:
+    "@aws-sdk/is-array-buffer" "3.55.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-config-provider@3.109.0":
+  version "3.109.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-config-provider/-/util-config-provider-3.109.0.tgz#7828b8894b2b23c289ffc5c106cbced7a5d6ee86"
+  integrity sha512-GrAZl/aBv0A28LkyNyq8SPJ5fmViCwz80fWLMeWx/6q5AbivuILogjlWwEZSvZ9zrlHOcFC0+AnCa5pQrjaslw==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-defaults-mode-browser@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.110.0.tgz#b72331874da2c5e8a366cd98828a06fe19b52ae5"
+  integrity sha512-Y2dcOOD20S3bv/IjUqpdKIiDt6995SXNG5Pu/LeSdXNyLCOIm9rX4gHTxl9fC1KK5M/gR9fGJ362f67WwqEEqw==
+  dependencies:
+    "@aws-sdk/property-provider" "3.110.0"
+    "@aws-sdk/types" "3.110.0"
+    bowser "^2.11.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-defaults-mode-node@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.110.0.tgz#52b4c84fc7aa06838ea6bb29d216a2d7615b9036"
+  integrity sha512-Cr3Z5nyrw1KowjbW76xp8hkT/zJtYjAVZ9PS4l84KxIicbVvDOBpxG3yNddkuQcavmlH6G4wH9uM5DcnpKDncg==
+  dependencies:
+    "@aws-sdk/config-resolver" "3.110.0"
+    "@aws-sdk/credential-provider-imds" "3.110.0"
+    "@aws-sdk/node-config-provider" "3.110.0"
+    "@aws-sdk/property-provider" "3.110.0"
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-hex-encoding@3.109.0":
+  version "3.109.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.109.0.tgz#93b20acc27c0a1d7d80f653bf19d3dd01c2ccc65"
+  integrity sha512-s8CgTNrn3cLkrdiohfxLuOYPCanzvHn/aH5RW6DaMoeQiG5Hl9QUiP/WtdQ9QQx3xvpQFpmvxIaSBwSgFNLQxA==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-locate-window@^3.0.0":
+  version "3.55.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-locate-window/-/util-locate-window-3.55.0.tgz#a4136a20ee1bfcb73967a6614caf769ef79db070"
+  integrity sha512-0sPmK2JaJE2BbTcnvybzob/VrFKCXKfN4CUKcvn0yGg/me7Bz+vtzQRB3Xp+YSx+7OtWxzv63wsvHoAnXvgxgg==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-middleware@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-middleware/-/util-middleware-3.110.0.tgz#00a727273974f54424954235867c1ddb0f6dad56"
+  integrity sha512-PTVWrI5fA9d5hHJs6RzX2dIS2jRQ3uW073Fm0BePpQeDdZrEk+S5KNwRhUtpN6sdSV45vm6S9rrjZUG51qwGmA==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-stream-browser@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-stream-browser/-/util-stream-browser-3.110.0.tgz#2b39667008b447a95a6b2c1dceaf99dd3807c8b3"
+  integrity sha512-kAMrHtgrhr6ODRnzt/V+LSDVDvejcbdUp19n4My2vrPwKw3lM65vT+FAPIlGeDQBtOOhmlTbrYM3G3KKnlnHyg==
+  dependencies:
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-stream-node@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-stream-node/-/util-stream-node-3.110.0.tgz#83089ff4c4b7dd6abaf6a489375cbd44765f4fb0"
+  integrity sha512-jgkO7aLRpE3EUqU5XUdo0FmlyBVCFHKyHd/jdEN8h9+XMa44rl2QMdOSFQtwaNI4NC8J+OC66u2dQ+8QQnOLig==
+  dependencies:
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-uri-escape@3.55.0":
+  version "3.55.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-uri-escape/-/util-uri-escape-3.55.0.tgz#ee57743c628a1c9f942dfe73205ce890ec011916"
+  integrity sha512-mmdDLUpFCN2nkfwlLdOM54lTD528GiGSPN1qb8XtGLgZsJUmg3uJSFIN2lPeSbEwJB3NFjVas/rnQC48i7mV8w==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-user-agent-browser@3.110.0":
+  version "3.110.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.110.0.tgz#e0643e6047aab5137540259a42fbfdc37ae4abee"
+  integrity sha512-rNdhmHDMV5dNJctqlBWimkZLJRB+x03DB+61pm+SKSFk6gPIVIvc1WNXqDFphkiswT4vA13ZUkGHzt+N4+noQQ==
+  dependencies:
+    "@aws-sdk/types" "3.110.0"
+    bowser "^2.11.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-user-agent-node@3.118.0":
+  version "3.118.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.118.0.tgz#5cb8d822ebe46b92101ff547ea373658d18ceb7b"
+  integrity sha512-7j21HNumxMkeUpgoMX8o3y66k+qMSEkCPCMGnoiiMtgfWX9SY0S/fLwR1nDBw8HI3NthRXfgWdAXUu8K3Kjp6g==
+  dependencies:
+    "@aws-sdk/node-config-provider" "3.110.0"
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-utf8-browser@3.109.0", "@aws-sdk/util-utf8-browser@^3.0.0":
+  version "3.109.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.109.0.tgz#d013272e1981b23a4c84ac06f154db686c0cf84e"
+  integrity sha512-FmcGSz0v7Bqpl1SE8G1Gc0CtDpug+rvqNCG/szn86JApD/f5x8oByjbEiAyTU2ZH2VevUntx6EW68ulHyH+x+w==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-utf8-node@3.109.0":
+  version "3.109.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8-node/-/util-utf8-node-3.109.0.tgz#89e06d916f5b246c7265f59bac742973ac0767ac"
+  integrity sha512-Ti/ZBdvz2eSTElsucjzNmzpyg2MwfD1rXmxD0hZuIF8bPON/0+sZYnWd5CbDw9kgmhy28dmKue086tbZ1G0iLQ==
+  dependencies:
+    "@aws-sdk/util-buffer-from" "3.55.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-waiter@3.118.1":
+  version "3.118.1"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-waiter/-/util-waiter-3.118.1.tgz#eab970728e14cb31a6705e4daa4863751594bd53"
+  integrity sha512-mCPTpoNHXdBcGEk/8r90ppCB/DHUis+dZPDBDfCENRqcAYq9TDlTl9VB7jhgRkVUhM0HZGNAbUOaI+212jjPiQ==
+  dependencies:
+    "@aws-sdk/abort-controller" "3.110.0"
+    "@aws-sdk/types" "3.110.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/xml-builder@3.109.0":
+  version "3.109.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/xml-builder/-/xml-builder-3.109.0.tgz#dd2d3bf59d29a1c2968f477ec16680d47d81d921"
+  integrity sha512-+aAXynnrqya1Eukz4Gxch4xIXCZolIMWGD4Ll/Q5yXT5uAjGh2HQWd9J0LWE+gYChpWetZbAVYZ3cEJ6F+SpZA==
+  dependencies:
+    tslib "^2.3.1"
+
 "@aws/dynamodb-auto-marshaller@^0.7.1":
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/@aws/dynamodb-auto-marshaller/-/dynamodb-auto-marshaller-0.7.1.tgz#70676c056e4ecb798c08ec2e398a3d93e703858d"
@@ -3313,6 +4190,11 @@ bottleneck@^2.19.5:
   resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.19.5.tgz#5df0b90f59fd47656ebe63c78a98419205cadd91"
   integrity sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==
 
+bowser@^2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.11.0.tgz#5ca3c35757a7aa5771500c70a73a9f91ef420a8f"
+  integrity sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -4669,6 +5551,11 @@ enquirer@^2.3.6:
   dependencies:
     ansi-colors "^4.1.1"
 
+entities@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
+  integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+
 entities@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.2.tgz#ac74db0bba8d33808bbf36809c3a5c3683531436"
@@ -5302,6 +6189,11 @@ fast-safe-stringify@^2.0.8:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
+
+fast-xml-parser@3.19.0:
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz#cb637ec3f3999f51406dd8ff0e6fc4d83e520d01"
+  integrity sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==
 
 fast-xml-parser@^3.15.0:
   version "3.17.1"
@@ -10999,20 +11891,25 @@ tsc-watch@^2.2.1:
     string-argv "^0.1.1"
     strip-ansi "^4.0.0"
 
+tslib@^1.11.1, tslib@^1.9.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
 tslib@^1.8.1:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
-tslib@^1.9.0:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
 tslib@^2.2.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
+tslib@^2.3.1:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tsutils@^3.17.1:
   version "3.17.1"


### PR DESCRIPTION
Added support for saving the state version of the static files.
I will create another PR in the SaaS before this can be merged.

---

I created "OverrideStaticFilesSource" which will override the static files on each set and therefore will not preserve the history of the static files. This will be used in the OSS together with `localDirectoryStore` to save the static files in the local storage.

For the SaaS I created "HistoryStaticFilesSource" which will preserve the history by adding the hash of each file to its name. This will be used in the SaaS together with the S3 directory store.


---
_Release Notes_: 
- Added support for saving to the content of the state version of static files. This will allow operations like `restore` to work on static files when the state version is available

---
_User Notifications_: 
None