### PR TITLE
SALTO-2373 fix zendesk e2e

### DIFF
--- a/packages/zendesk-support-adapter/e2e_test/mock_elements.ts
+++ b/packages/zendesk-support-adapter/e2e_test/mock_elements.ts
@@ -69,7 +69,7 @@ export const mockDefaultValues: Record<string, Values> = {
       view_deleted_tickets: true,
       ticket_tag_editing: true,
       twitter_search_access: false,
-      forum_access_restricted_content: true,
+      forum_access_restricted_content: false,
       end_user_list_access: 'full',
       ticket_access: 'all',
       ticket_comment_access: 'public',


### PR DESCRIPTION
Attempt to fix a broken/flaky e2e test (we will still need to investigate why the field is not being set correctly)


---
_Release Notes_: 
None

---
_User Notifications_: 
None