### PR TITLE
SALTO-2365: Change path-hint of folder instances to sit inside their own folder

### DIFF
--- a/packages/netsuite-adapter/src/transformer.ts
+++ b/packages/netsuite-adapter/src/transformer.ts
@@ -66,9 +66,14 @@ export const createInstanceElement = async (customizationInfo: CustomizationInfo
   }
 
   const getInstancePath = (instanceName: string): string[] => {
-    if (isFolderCustomizationInfo(customizationInfo)
-      || isFileCustomizationInfo(customizationInfo)) {
+    if (isFileCustomizationInfo(customizationInfo)) {
       return [NETSUITE, FILE_CABINET_PATH, ...customizationInfo.path.map(removeDotPrefix)]
+    }
+    if (isFolderCustomizationInfo(customizationInfo)) {
+      const origFolderPathParts = customizationInfo.path.map(removeDotPrefix)
+      const folderName = origFolderPathParts[origFolderPathParts.length - 1]
+      // we want the folder's nacl to reside within the its folder in the File System.
+      return [NETSUITE, FILE_CABINET_PATH, ...origFolderPathParts, folderName]
     }
     if (isSDFConfigType(type)) {
       return [NETSUITE, SETTINGS_PATH, type.elemID.name]

--- a/packages/netsuite-adapter/src/transformer.ts
+++ b/packages/netsuite-adapter/src/transformer.ts
@@ -72,7 +72,8 @@ export const createInstanceElement = async (customizationInfo: CustomizationInfo
     if (isFolderCustomizationInfo(customizationInfo)) {
       const origFolderPathParts = customizationInfo.path.map(removeDotPrefix)
       const folderName = origFolderPathParts[origFolderPathParts.length - 1]
-      // we want the folder's nacl to reside within the its folder in the File System.
+      // We want folder instances to sit inside their own folder,
+      // e.g. "/FileCabinet/SuiteScripts/MyFolder/MyFolder.nacl"
       return [NETSUITE, FILE_CABINET_PATH, ...origFolderPathParts, folderName]
     }
     if (isSDFConfigType(type)) {

--- a/packages/netsuite-adapter/test/transformer.test.ts
+++ b/packages/netsuite-adapter/test/transformer.test.ts
@@ -342,7 +342,7 @@ describe('Transformer', () => {
         )
         expect(result.path)
           .toEqual([NETSUITE, FILE_CABINET_PATH, 'Templates', 'E-mail Templates',
-            'Inner EmailTemplates Folder'])
+            'Inner EmailTemplates Folder', 'Inner EmailTemplates Folder'])
       })
 
       it('should create instance path correctly for folder instance when it has . prefix', async () => {
@@ -351,7 +351,8 @@ describe('Transformer', () => {
         const result = await createInstanceElement(folderCustomizationInfoWithDotPrefix,
           folder, mockGetElemIdFunc)
         expect(result.path)
-          .toEqual([NETSUITE, FILE_CABINET_PATH, 'Templates', 'E-mail Templates', '_hiddenFolder'])
+          .toEqual([NETSUITE, FILE_CABINET_PATH, 'Templates', 'E-mail Templates', '_hiddenFolder',
+            '_hiddenFolder'])
       })
 
       it('should transform path field correctly', async () => {


### PR DESCRIPTION

_Release Notes_: 
SALTO-2365: Change path-hint of folder instances to sit inside their own folder