### PR TITLE
SALTO-2382: Fixed to fetch all groups pages

### DIFF
--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -1412,6 +1412,13 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
     },
   },
 
+  Groups: {
+    request: {
+      url: '/rest/api/3/group/bulk',
+      paginationField: 'startAt',
+    },
+  },
+
   Board: {
     transformation: {
       fieldTypeOverrides: [


### PR DESCRIPTION
Fixed to fetch all groups pages 🤦‍♂️  

---
_Release Notes_: 
_Jira Adapter_:
- Fixed a bug where only the first page (50) of groups was fetched

---
_User Notifications_: 
_Jira Adapter_:
- Missing groups will be fetched on the next fetch