### PR TITLE
SALTO-2267 handle templates in reference index

### DIFF
--- a/packages/workspace/src/workspace/reference_indexes.ts
+++ b/packages/workspace/src/workspace/reference_indexes.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, ElemID, getChangeData, isReferenceExpression, Element, isModificationChange, toChange, isObjectTypeChange, isRemovalOrModificationChange, isAdditionOrModificationChange } from '@salto-io/adapter-api'
+import { Change, ElemID, getChangeData, isReferenceExpression, Element, isModificationChange, toChange, isObjectTypeChange, isRemovalOrModificationChange, isAdditionOrModificationChange, isTemplateExpression } from '@salto-io/adapter-api'
 import { walkOnElement, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
@@ -44,6 +44,13 @@ const getReferences = (element: Element): ReferenceDetails[] => {
     func: ({ value, path: referenceSource }) => {
       if (isReferenceExpression(value)) {
         references.push({ referenceSource, referenceTarget: value.elemID })
+      }
+      if (isTemplateExpression(value)) {
+        value.parts.forEach(part => {
+          if (isReferenceExpression(part)) {
+            references.push({ referenceSource, referenceTarget: part.elemID })
+          }
+        })
       }
       return WALK_NEXT_STEP.RECURSE
     },


### PR DESCRIPTION
Part of adding support for template content in zendesk fields. This handles adding the references inside templates to the reference index

---


---
_Release Notes_: 
None

---
_User Notifications_: 
None
