### PR TITLE
SAAS-4004: Move static files cache to RocksDB 

### DIFF
--- a/packages/core/src/local-workspace/adapters_config.ts
+++ b/packages/core/src/local-workspace/adapters_config.ts
@@ -40,7 +40,7 @@ const createNaclSource = async (
 
   const staticFileSource = staticFiles.buildStaticFilesSource(
     naclStaticFilesStore,
-    buildLocalStaticFilesCache(localStorage, 'config-cache', remoteMapCreator),
+    buildLocalStaticFilesCache(localStorage, 'config-cache', remoteMapCreator, persistent),
   )
 
   const source = await nacl.naclFilesSource(

--- a/packages/core/src/local-workspace/adapters_config.ts
+++ b/packages/core/src/local-workspace/adapters_config.ts
@@ -40,7 +40,7 @@ const createNaclSource = async (
 
   const staticFileSource = staticFiles.buildStaticFilesSource(
     naclStaticFilesStore,
-    buildLocalStaticFilesCache(localStorage, 'config-cache'),
+    buildLocalStaticFilesCache(localStorage, 'config-cache', remoteMapCreator),
   )
 
   const source = await nacl.naclFilesSource(

--- a/packages/core/src/local-workspace/remote_map.ts
+++ b/packages/core/src/local-workspace/remote_map.ts
@@ -208,7 +208,7 @@ const deleteLocation = async (location: string): Promise<void> => {
   try {
     await promisify(getRemoteDbImpl().destroy.bind(getRemoteDbImpl(), location))()
   } catch (e) {
-    // If the DB does not exist, we don't want to throw error upon destory
+    // If the DB does not exist, we don't want to throw error upon destroy
     if (!isDBNotExistErr(e)) {
       throw e
     }
@@ -330,11 +330,11 @@ const getOpenDBConnection = async (
   loc: string,
   isReadOnly: boolean
 ): Promise<rocksdb> => {
-  const newDb = getRemoteDbImpl()(loc)
   log.debug('opening connection to %s, read-only=%s', loc, isReadOnly)
   if (currentConnectionsCount >= MAX_CONNECTIONS) {
     throw new Error(`Failed to open rocksdb connection - too many open connections already (${currentConnectionsCount} connections)`)
   }
+  const newDb = getRemoteDbImpl()(loc)
   await promisify(newDb.open.bind(newDb, { readOnly: isReadOnly }))()
   currentConnectionsCount += 1
   return newDb

--- a/packages/core/src/local-workspace/remote_map.ts
+++ b/packages/core/src/local-workspace/remote_map.ts
@@ -601,10 +601,10 @@ remoteMap.RemoteMapCreator => {
       }
     }
     const createDBConnections = async (): Promise<void> => {
-      tmpDBConnections[location] = tmpDBConnections[location] ?? {}
       if (tmpDB === undefined) {
         const tmpConnection = getOpenDBConnection(tmpLocation, false)
         tmpDB = await tmpConnection
+        tmpDBConnections[location] = tmpDBConnections[location] ?? {}
         tmpDBConnections[location][tmpLocation] = tmpConnection
       }
       const mainDBConnections = persistent ? persistentDBConnections : readonlyDBConnections

--- a/packages/core/src/local-workspace/remote_map.ts
+++ b/packages/core/src/local-workspace/remote_map.ts
@@ -585,8 +585,8 @@ remoteMap.RemoteMapCreator => {
         await promisify(newDb.open.bind(newDb, { readOnly }))()
         await promisify(newDb.close.bind(newDb))()
       } catch (e) {
-        await withCreatorLock(async () => {
-          if (newDb.status === 'new' && readOnly) {
+        if (newDb.status === 'new' && readOnly) {
+          await withCreatorLock(async () => {
             log.info('DB does not exist. Creating on %s', loc)
             try {
               await promisify(newDb.open.bind(newDb))()
@@ -594,10 +594,10 @@ remoteMap.RemoteMapCreator => {
             } catch (err) {
               throw new Error(`Failed to open DB in write mode - ${loc}. Error: ${err}`)
             }
-          } else {
-            throw e
-          }
-        })
+          })
+        } else {
+          throw e
+        }
       }
     }
     const createDBConnections = async (): Promise<void> => {

--- a/packages/core/src/local-workspace/static_files_cache.ts
+++ b/packages/core/src/local-workspace/static_files_cache.ts
@@ -18,6 +18,9 @@ import { readTextFile, exists, rm } from '@salto-io/file'
 import { staticFiles, remoteMap } from '@salto-io/workspace'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
+import { collections } from '@salto-io/lowerdash'
+
+const { awu } = collections.asynciterable
 
 const log = logger(module)
 
@@ -97,7 +100,7 @@ export const buildLocalStaticFilesCache = (
       buildLocalStaticFilesCache(cacheDir, name, remoteMapCreator)
     ),
     list: async () => (
-      Object.keys((await cache))
+      awu((await cache).keys()).toArray()
     ),
   }
 }

--- a/packages/core/src/local-workspace/static_files_cache.ts
+++ b/packages/core/src/local-workspace/static_files_cache.ts
@@ -56,6 +56,7 @@ export const buildLocalStaticFilesCache = (
   cacheDir: string,
   name: string,
   remoteMapCreator: remoteMap.RemoteMapCreator,
+  persistent: boolean,
 ): staticFiles.StaticFilesCache => {
   const createRemoteMap = async (
     cacheName: string
@@ -64,9 +65,8 @@ export const buildLocalStaticFilesCache = (
       namespace: `staticFilesCache-${cacheName}`,
       serialize: cacheEntry => safeJsonStringify(cacheEntry),
       deserialize: async data => JSON.parse(data),
-      persistent: true,
+      persistent,
     })
-
 
   const initCache = async (): Promise<StaticFilesCacheState> => {
     const remoteCache = createRemoteMap(name)
@@ -97,7 +97,7 @@ export const buildLocalStaticFilesCache = (
       await currentCache.clear()
     },
     clone: () => (
-      buildLocalStaticFilesCache(cacheDir, name, remoteMapCreator)
+      buildLocalStaticFilesCache(cacheDir, name, remoteMapCreator, persistent)
     ),
     list: async () => (
       awu((await cache).keys()).toArray()

--- a/packages/core/src/local-workspace/static_files_cache.ts
+++ b/packages/core/src/local-workspace/static_files_cache.ts
@@ -14,57 +14,88 @@
 * limitations under the License.
 */
 import path from 'path'
-import { readTextFile, exists, mkdirp, replaceContents, rm, rename } from '@salto-io/file'
-import { staticFiles } from '@salto-io/workspace'
+import { readTextFile, exists, rm } from '@salto-io/file'
+import { staticFiles, remoteMap } from '@salto-io/workspace'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
 
-export const CACHE_FILENAME = 'static-file-cache'
+const log = logger(module)
 
-export type StaticFilesCacheState = Record<string, staticFiles.StaticFilesData>
+type StaticFilesCacheState = remoteMap.RemoteMap<staticFiles.StaticFilesData>
+
+const migrateLegacyStaticFilesCache = async (
+  cacheDir: string,
+  name: string,
+  remoteCache: StaticFilesCacheState
+): Promise<void> => {
+  const CACHE_FILENAME = 'static-file-cache'
+  const currentCacheFile = path.join(cacheDir, name, CACHE_FILENAME)
+
+  if (await exists(currentCacheFile)) {
+    if (remoteCache.isEmpty()) {
+      log.debug('importing legacy static files cache from file: %s', currentCacheFile)
+      const oldCache: Record<string, staticFiles.StaticFilesData> = JSON.parse(
+        await readTextFile(currentCacheFile)
+      )
+      await remoteCache.setAll(
+        Object.values(oldCache).map(item => ({ value: item, key: item.filepath }))
+      )
+      await remoteCache.flush()
+    } else {
+      log.debug('static files cache already populated, ignoring legacy static files cache file: %s', currentCacheFile)
+    }
+    log.debug('deleting legeacy static files cache file: %s', currentCacheFile)
+    await rm(currentCacheFile)
+  }
+}
 
 export const buildLocalStaticFilesCache = (
-  baseDir: string,
+  cacheDir: string,
   name: string,
-  initCacheState?: Promise<StaticFilesCacheState>,
+  remoteMapCreator: remoteMap.RemoteMapCreator,
 ): staticFiles.StaticFilesCache => {
-  let currentName = name
-  let cacheDir = path.join(baseDir, currentName)
-  let currentCacheFile = path.join(cacheDir, CACHE_FILENAME)
+  const createRemoteMap = async (
+    cacheName: string
+  ): Promise<StaticFilesCacheState> =>
+    remoteMapCreator<staticFiles.StaticFilesData>({
+      namespace: `staticFilesCache-${cacheName}`,
+      serialize: cacheEntry => safeJsonStringify(cacheEntry),
+      deserialize: async data => JSON.parse(data),
+      persistent: true,
+    })
 
-  const initCache = async (): Promise<StaticFilesCacheState> =>
-    (!(await exists(currentCacheFile)) ? {} : JSON.parse(await readTextFile(currentCacheFile)))
 
-  let cache: Promise<StaticFilesCacheState> = initCacheState || initCache()
+  const initCache = async (): Promise<StaticFilesCacheState> => {
+    const remoteCache = createRemoteMap(name)
+    await migrateLegacyStaticFilesCache(cacheDir, name, await remoteCache)
+    return remoteCache
+  }
+
+  let cache = initCache()
 
   return {
-    get: async (filepath: string): Promise<staticFiles.StaticFilesData> => (
-      (await cache)[filepath]
+    get: async (filepath: string): Promise<staticFiles.StaticFilesData | undefined> => (
+      (await cache).get(filepath)
     ),
     put: async (item: staticFiles.StaticFilesData): Promise<void> => {
-      (await cache)[item.filepath] = item
+      await (await cache).set(item.filepath, item)
     },
     flush: async () => {
-      if (!await exists(cacheDir)) {
-        await mkdirp(cacheDir)
-      }
-      await replaceContents(currentCacheFile, safeJsonStringify((await cache)))
+      await (await cache).flush()
     },
     clear: async () => {
-      await rm(currentCacheFile)
-      cache = Promise.resolve({})
+      await (await cache).clear()
     },
     rename: async (newName: string) => {
-      const newCacheDir = path.join(baseDir, newName)
-      const newCacheFile = path.join(newCacheDir, CACHE_FILENAME)
-      if (await exists(currentCacheFile)) {
-        await mkdirp(newCacheDir)
-        await rename(currentCacheFile, newCacheFile)
-      }
-      currentName = newName
-      currentCacheFile = newCacheFile
-      cacheDir = newCacheDir
+      const currentCache = await cache
+      const newCache = await createRemoteMap(newName)
+      await newCache.setAll(currentCache.entries())
+      cache = Promise.resolve(newCache)
+      await currentCache.clear()
     },
-    clone: () => buildLocalStaticFilesCache(cacheDir, currentName, cache),
+    clone: () => (
+      buildLocalStaticFilesCache(cacheDir, name, remoteMapCreator)
+    ),
     list: async () => (
       Object.keys((await cache))
     ),

--- a/packages/core/src/local-workspace/workspace.ts
+++ b/packages/core/src/local-workspace/workspace.ts
@@ -67,6 +67,7 @@ type GetNaclFilesSourceParamsArgs = {
   cacheDir: string
   name: string
   remoteMapCreator: remoteMap.RemoteMapCreator
+  persistent: boolean
   excludeDirs?: string[]
 }
 
@@ -75,6 +76,7 @@ export const getNaclFilesSourceParamsImpl = ({
   cacheDir,
   name,
   remoteMapCreator,
+  persistent,
   excludeDirs = [],
 }: GetNaclFilesSourceParamsArgs): {
   naclFilesStore: dirStore.DirectoryStore<string>
@@ -101,7 +103,7 @@ export const getNaclFilesSourceParamsImpl = ({
   const cacheName = name === COMMON_ENV_PREFIX ? 'common' : name
   const staticFileSource = buildStaticFilesSource(
     naclStaticFilesStore,
-    buildLocalStaticFilesCache(cacheDir, cacheName, remoteMapCreator),
+    buildLocalStaticFilesCache(cacheDir, cacheName, remoteMapCreator, persistent),
   )
   return {
     naclFilesStore,
@@ -120,7 +122,7 @@ export const getNaclFilesSourceParams = (
 } => {
   const remoteMapCreator = createRemoteMapCreator(cacheDir)
   return getNaclFilesSourceParamsImpl(
-    { sourceBaseDir, cacheDir, name, excludeDirs, remoteMapCreator }
+    { sourceBaseDir, cacheDir, name, excludeDirs, remoteMapCreator, persistent: false }
   )
 }
 
@@ -137,6 +139,7 @@ const loadNaclFileSource = async (
     cacheDir: cacheBaseDir,
     name: sourceName,
     remoteMapCreator,
+    persistent,
     excludeDirs,
   })
   return naclFilesSource(

--- a/packages/core/test/workspace/local/remote_map_connection.test.ts
+++ b/packages/core/test/workspace/local/remote_map_connection.test.ts
@@ -52,8 +52,8 @@ describe('connection creation', () => {
       const writeCalls = mockCalls.filter(args => args[0].readOnly === false)
       const readOnlyCalls = mockCalls.filter(args => args[0].readOnly === true)
       // 1 for the creation, 2 tmp connections and 1 (persistent) db connection,
-      // 2 load time destroys attempts
-      expect(writeCalls).toHaveLength(6)
+      // 0 load time destroys attempts
+      expect(writeCalls).toHaveLength(4)
       expect(readOnlyCalls).toHaveLength(0)
     })
     it('should try to open with read only mode if remote map is not persistent', async () => {

--- a/packages/core/test/workspace/local/remote_map_connection.test.ts
+++ b/packages/core/test/workspace/local/remote_map_connection.test.ts
@@ -51,9 +51,9 @@ describe('connection creation', () => {
       const mockCalls = mockOpen.mock.calls
       const writeCalls = mockCalls.filter(args => args[0].readOnly === false)
       const readOnlyCalls = mockCalls.filter(args => args[0].readOnly === true)
-      // 1 for the creation, 2 tmp connections and 1 (persistent) db connection,
+      // 0 for the creation, 2 tmp connections and 1 (persistent) db connection,
       // 0 load time destroys attempts
-      expect(writeCalls).toHaveLength(4)
+      expect(writeCalls).toHaveLength(3)
       expect(readOnlyCalls).toHaveLength(0)
     })
     it('should try to open with read only mode if remote map is not persistent', async () => {

--- a/packages/core/test/workspace/local/remote_map_connection.test.ts
+++ b/packages/core/test/workspace/local/remote_map_connection.test.ts
@@ -13,20 +13,27 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import _ from 'lodash'
 import { remoteMap as rm } from '@salto-io/workspace'
-import { createRemoteMapCreator, createReadOnlyRemoteMapCreator } from '../../../src/local-workspace/remote_map'
+import { createRemoteMapCreator, createReadOnlyRemoteMapCreator, MAX_CONNECTIONS, closeAllRemoteMaps } from '../../../src/local-workspace/remote_map'
 
 describe('connection creation', () => {
   const DB_LOCATION = '/tmp/test_db'
   const mockOpen = jest.fn().mockImplementation((_opts, cb) => { cb() })
   const mockClose = jest.fn().mockImplementation(cb => { cb() })
-  beforeEach(() => {
+  beforeEach(async () => {
+    // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+    const mockedRocksdb = () => ({
+      open: mockOpen,
+      close: mockClose,
+      status: 'open',
+    })
+    mockedRocksdb.destroy = jest.fn().mockImplementation((_loc, cb) => { cb() })
     jest.mock('../../../src/local-workspace/rocksdb', () => ({
-      default: () => ({
-        open: mockOpen,
-        close: mockClose,
-      }),
+      default: mockedRocksdb,
     }))
+
+    await closeAllRemoteMaps()
   })
   afterEach(() => {
     jest.clearAllMocks()
@@ -87,7 +94,71 @@ describe('connection creation', () => {
     })
     it('should throw exception if db does not exist', async () => {
       mockOpen.mockImplementationOnce((_opts, _cb) => { throw new Error('err') })
-      await expect(createMap(DB_LOCATION, 'integration')).rejects.toThrow()
+      await expect(createMap(DB_LOCATION, 'integration')).rejects.toThrow('err')
+    })
+  })
+  describe('connection cache limits', () => {
+    describe('when opening many connections', () => {
+      const createMap = async (
+        location: string,
+      ): Promise<rm.RemoteMap<string>> =>
+        createRemoteMapCreator(location)({
+          namespace: 'namespace',
+          batchInterval: 1000,
+          serialize: str => str,
+          deserialize: async str => Promise.resolve(str),
+          persistent: true,
+        })
+      const createReadOnlyMap = async (
+        location: string,
+      ): Promise<rm.RemoteMap<string>> =>
+        createReadOnlyRemoteMapCreator(location)({
+          namespace: 'namespace', deserialize: async str => str,
+        })
+      it('should correctly count when openning different db', async () => {
+        // We open two connections each time
+        await Promise.all(_.times(MAX_CONNECTIONS / 2, async idx => {
+          await createMap(`${DB_LOCATION}/${idx}`)
+        }))
+
+        await expect(createMap(`${DB_LOCATION}/tooMany`)).rejects.toThrow('too many open connections')
+      })
+      it('should correctly count when openning the same DB', async () => {
+        // We open the main connections once, and tmp connection each time
+        await Promise.all(_.times(MAX_CONNECTIONS - 1, async () => {
+          await createMap(DB_LOCATION)
+        }))
+
+        await expect(createMap(DB_LOCATION)).rejects.toThrow('too many open connections')
+      })
+      it('should correcly count read only db connections', async () => {
+        // One connection per db
+        await Promise.all(_.times(MAX_CONNECTIONS, async () => {
+          await createReadOnlyMap(DB_LOCATION)
+        }))
+
+        await expect(createReadOnlyMap(DB_LOCATION)).rejects.toThrow('too many open connections')
+      })
+      it('should decrease the count when closing RO connections', async () => {
+        const maps: rm.RemoteMap<string>[] = []
+        // One connection per db
+        await Promise.all(_.times(MAX_CONNECTIONS, async () => {
+          maps.push(await createReadOnlyMap(DB_LOCATION))
+        }))
+
+        await maps[0].close()
+        await createReadOnlyMap(DB_LOCATION)
+
+        await expect(createReadOnlyMap(DB_LOCATION)).rejects.toThrow('too many open connections')
+      })
+      it('should count together RO & RW connections', async () => {
+        // One connection per db
+        await Promise.all(_.times(MAX_CONNECTIONS, async () => {
+          await createReadOnlyMap(DB_LOCATION)
+        }))
+
+        await expect(createMap(DB_LOCATION)).rejects.toThrow('too many open connections')
+      })
     })
   })
 })

--- a/packages/core/test/workspace/local/static_files_cache.test.ts
+++ b/packages/core/test/workspace/local/static_files_cache.test.ts
@@ -13,103 +13,96 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-
-import path from 'path'
 import * as file from '@salto-io/file'
+import { collections } from '@salto-io/lowerdash'
+import { mockFunction } from '@salto-io/test-utils'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
-import { staticFiles } from '@salto-io/workspace'
+import { staticFiles, remoteMap } from '@salto-io/workspace'
+import { buildLocalStaticFilesCache } from '../../../src/local-workspace/static_files_cache'
 
-import {
-  buildLocalStaticFilesCache, CACHE_FILENAME,
-} from '../../../src/local-workspace/static_files_cache'
+const { DefaultMap } = collections.map
 
 jest.mock('@salto-io/file')
 describe('Static Files Cache', () => {
-  afterEach(() => {
-    jest.clearAllMocks()
-  })
-
   const mockFileExists = file.exists as jest.Mock
-  const mockReplaceContents = file.replaceContents as jest.Mock
-  const mockRm = file.rm as jest.Mock
-  const mockRename = file.rename as unknown as jest.Mock
   const mockReadFile = file.readTextFile as unknown as jest.Mock
+
   let staticFilesCache: staticFiles.StaticFilesCache
 
   const baseMetaData = {
     hash: 'hashz',
     filepath: 'some/path.ext',
   }
-
   const expectedResult = {
     filepath: baseMetaData.filepath,
     hash: baseMetaData.hash,
     modified: 123,
   }
 
-  const expectedCacheKey = baseMetaData.filepath
-
-  const expectedCacheContent = safeJsonStringify({
-    [expectedCacheKey]: expectedResult,
-  })
-
   beforeEach(() => {
-    jest.resetAllMocks()
-    staticFilesCache = buildLocalStaticFilesCache('', 'cacheDir')
+    jest.clearAllMocks()
   })
-  it('does not fail if no cache file exists', async () => {
-    expect((await staticFilesCache.get(baseMetaData.filepath))).toBeUndefined()
-  })
-  it('uses content of cache file if existed', async () => {
-    mockFileExists.mockResolvedValueOnce(true)
-    mockReadFile.mockResolvedValueOnce(expectedCacheContent)
-    staticFilesCache = buildLocalStaticFilesCache('', 'cacheDir')
-    return expect(staticFilesCache.get(baseMetaData.filepath)).resolves.toEqual(expectedResult)
-  })
-  it('puts and retrieves value', async () => {
-    await staticFilesCache.put(expectedResult)
-    return expect(staticFilesCache.get(baseMetaData.filepath)).resolves.toEqual(expectedResult)
-  })
-  it('flushes state to cache file', async () => {
-    await staticFilesCache.put(expectedResult)
-    await staticFilesCache.flush()
-    expect(mockReplaceContents).toHaveBeenCalledTimes(1)
-    const [filepath, content] = mockReplaceContents.mock.calls[0]
-    expect(filepath).toMatch(new RegExp(`cacheDir\\/${CACHE_FILENAME}`))
-    expect(content).toEqual(expectedCacheContent)
-  })
-  it('clear', async () => {
-    await staticFilesCache.clear()
-    expect(mockRm).toHaveBeenCalledTimes(1)
-    expect(mockRm).toHaveBeenCalledWith(path.join('cacheDir', CACHE_FILENAME))
-  })
+  describe('new cache', () => {
+    let remoteMapCreator: jest.MockedFunction<remoteMap.RemoteMapCreator>
 
-  it('creates an empty cache when flushing after clear', async () => {
-    await staticFilesCache.put(expectedResult)
-    await staticFilesCache.clear()
-    await staticFilesCache.flush()
-    expect(mockRm).toHaveBeenCalledTimes(1)
-    expect(mockRm).toHaveBeenCalledWith(path.join('cacheDir', CACHE_FILENAME))
-    expect(mockReplaceContents).toHaveBeenCalledTimes(1)
-    const [filepath, content] = mockReplaceContents.mock.calls[0]
-    expect(filepath).toMatch(new RegExp(`cacheDir\\/${CACHE_FILENAME}`))
-    expect(content).toEqual('{}')
+    beforeEach(() => {
+      // We keep a cache to simulate the fact that remote maps
+      // with the same namespace point to the same entries.
+      const remoteMaps = new DefaultMap(() => new remoteMap.InMemoryRemoteMap())
+      remoteMapCreator = mockFunction<remoteMap.RemoteMapCreator>().mockImplementation(
+        async opts => remoteMaps.get(opts.namespace)
+      )
+      staticFilesCache = buildLocalStaticFilesCache('path', 'test-env', remoteMapCreator)
+    })
+    it('should handle unknown file paths', async () => {
+      expect((await staticFilesCache.get(baseMetaData.filepath))).toBeUndefined()
+    })
+    it('puts and retrieves value', async () => {
+      await staticFilesCache.put(expectedResult)
+      expect(await staticFilesCache.get(baseMetaData.filepath)).toEqual(expectedResult)
+    })
+    it('clear', async () => {
+      await staticFilesCache.put(expectedResult)
+      await staticFilesCache.clear()
+      expect(await staticFilesCache.get(baseMetaData.filepath)).toBeUndefined()
+    })
+    it('rename', async () => {
+      await staticFilesCache.put(expectedResult)
+      await staticFilesCache.rename('new-env')
+      expect(remoteMapCreator).toHaveBeenCalledTimes(2)
+      expect(remoteMapCreator).toHaveBeenLastCalledWith(expect.objectContaining({ namespace: 'staticFilesCache-new-env' }))
+      expect(await staticFilesCache.get(baseMetaData.filepath)).toEqual(expectedResult)
+    })
+    it('clone', async () => {
+      await staticFilesCache.put(expectedResult)
+      const cloned = staticFilesCache.clone()
+      expect(await cloned.get(baseMetaData.filepath)).toEqual(expectedResult)
+      expect(cloned).not.toBe(staticFilesCache)
+    })
   })
-
-  it('rename', async () => {
-    mockFileExists.mockResolvedValueOnce(true)
-    await staticFilesCache.rename('new')
-    expect(mockRename).toHaveBeenCalledTimes(1)
-    expect(mockRename).toHaveBeenCalledWith(
-      path.join('cacheDir', CACHE_FILENAME),
-      path.join('new', CACHE_FILENAME)
+  describe('when migrating cache', () => {
+    const expectedCacheKey = baseMetaData.filepath
+    const expectedCacheContent = safeJsonStringify({
+      [expectedCacheKey]: expectedResult,
+    })
+    const remoteMapCreator = mockFunction<remoteMap.RemoteMapCreator>().mockImplementation(
+      async () => new remoteMap.InMemoryRemoteMap()
     )
-  })
-  it('clones', async () => {
-    await staticFilesCache.put(expectedResult)
-    const staticFilesCacheClone = staticFilesCache.clone()
-    return expect(staticFilesCacheClone.get(baseMetaData.filepath))
-      .resolves.toEqual(expectedResult)
+
+    it('migrates old cache file if exists', async () => {
+      mockFileExists.mockResolvedValueOnce(true)
+      mockReadFile.mockResolvedValueOnce(expectedCacheContent)
+      staticFilesCache = buildLocalStaticFilesCache('path', 'test-env', remoteMapCreator)
+      return expect(staticFilesCache.get(baseMetaData.filepath)).resolves.toEqual(expectedResult)
+    })
+    it('does not import old cache file if cache already populated', async () => {
+      const oldCache = buildLocalStaticFilesCache('path', 'test-env', remoteMapCreator)
+      await oldCache.put({ filepath: 'something.txt', hash: 'bla', modified: 123 })
+      mockFileExists.mockResolvedValueOnce(true)
+      mockReadFile.mockResolvedValueOnce(expectedCacheContent)
+      staticFilesCache = buildLocalStaticFilesCache('path', 'test-env', remoteMapCreator)
+      return expect(staticFilesCache.get(baseMetaData.filepath)).resolves.toEqual(expectedResult)
+    })
   })
   it('list', async () => {
     const file1 = {

--- a/packages/core/test/workspace/local/static_files_cache.test.ts
+++ b/packages/core/test/workspace/local/static_files_cache.test.ts
@@ -132,7 +132,7 @@ describe('Static Files Cache', () => {
     it('should respect the persistent parameter', async () => {
       const cache = buildLocalStaticFilesCache('path', 'test-env', remoteMapCreator, false)
       await cache.get('bla')
-      expect(remoteMapCreator).toHaveBeenCalledOnce()
+      expect(remoteMapCreator).toHaveBeenCalledTimes(1)
       expect(remoteMapCreator).toHaveBeenCalledWith(expect.objectContaining({ persistent: true }))
     })
   })

--- a/packages/core/test/workspace/local/static_files_cache.test.ts
+++ b/packages/core/test/workspace/local/static_files_cache.test.ts
@@ -79,6 +79,21 @@ describe('Static Files Cache', () => {
       expect(await cloned.get(baseMetaData.filepath)).toEqual(expectedResult)
       expect(cloned).not.toBe(staticFilesCache)
     })
+    it('list', async () => {
+      const file1 = {
+        filepath: 'file1.txt',
+        hash: 'HASH',
+        modified: 123,
+      }
+      const file2 = {
+        filepath: 'file2.txt',
+        hash: 'HASH',
+        modified: 123,
+      }
+      await staticFilesCache.put(file1)
+      await staticFilesCache.put(file2)
+      expect(await staticFilesCache.list()).toEqual([file1.filepath, file2.filepath])
+    })
   })
   describe('when migrating cache', () => {
     const expectedCacheKey = baseMetaData.filepath
@@ -103,20 +118,5 @@ describe('Static Files Cache', () => {
       staticFilesCache = buildLocalStaticFilesCache('path', 'test-env', remoteMapCreator)
       return expect(staticFilesCache.get(baseMetaData.filepath)).resolves.toEqual(expectedResult)
     })
-  })
-  it('list', async () => {
-    const file1 = {
-      filepath: 'file1.txt',
-      hash: 'HASH',
-      modified: 123,
-    }
-    const file2 = {
-      filepath: 'file2.txt',
-      hash: 'HASH',
-      modified: 123,
-    }
-    await staticFilesCache.put(file1)
-    await staticFilesCache.put(file2)
-    expect(await staticFilesCache.list()).toEqual([file1.filepath, file2.filepath])
   })
 })

--- a/packages/core/test/workspace/local/static_files_cache.test.ts
+++ b/packages/core/test/workspace/local/static_files_cache.test.ts
@@ -133,7 +133,7 @@ describe('Static Files Cache', () => {
       const cache = buildLocalStaticFilesCache('path', 'test-env', remoteMapCreator, false)
       await cache.get('bla')
       expect(remoteMapCreator).toHaveBeenCalledTimes(1)
-      expect(remoteMapCreator).toHaveBeenCalledWith(expect.objectContaining({ persistent: true }))
+      expect(remoteMapCreator).toHaveBeenCalledWith(expect.objectContaining({ persistent: false }))
     })
   })
 })


### PR DESCRIPTION
Move static files cache to RocksDB, so it will also exist in the operation repo.

---

This PR also tries to fix some races when opening the RocksDB connection 

---

_Release Notes_: 

None

---

_User Notifications_: 

None