### PR TITLE
SALTO-2417: stop running handleTemplateExpression filter in Zendesk

### DIFF
--- a/packages/zendesk-support-adapter/src/adapter.ts
+++ b/packages/zendesk-support-adapter/src/adapter.ts
@@ -67,7 +67,7 @@ import tagsFilter from './filters/tag'
 import webhookFilter from './filters/webhook'
 import defaultDeployFilter from './filters/default_deploy'
 import ducktypeCommonFilters from './filters/ducktype_common'
-import handleTemplateExpressionFilter from './filters/handle_template_expressions'
+// import handleTemplateExpressionFilter from './filters/handle_template_expressions'
 import referencedIdFieldsFilter from './filters/referenced_id_fields'
 import { getConfigFromConfigChanges } from './config_change'
 import { dependencyChanger } from './dependency_changers'
@@ -124,7 +124,7 @@ export const DEFAULT_FILTERS = [
   referencedIdFieldsFilter,
   serviceUrlFilter,
   ...ducktypeCommonFilters,
-  handleTemplateExpressionFilter,
+  // handleTemplateExpressionFilter,
   // defaultDeployFilter should be last!
   defaultDeployFilter,
 ]


### PR DESCRIPTION
_Stop running handleTemplateExpression filter in Zendesk_

---

_Additional context for reviewer_
None

---
_Release Notes_: 
_Zendesk_support adapter_
* Revert the handle template expression feature


---
_User Notifications_: 
_Zendesk_support adapter_
* comment/value HTML fields in macros in zendesk that includes references to other fields will be shown as strings 
