### PR TITLE
SALTO-2267 increase reference index to handle new template expressions

### DIFF
--- a/packages/workspace/src/workspace/reference_indexes.ts
+++ b/packages/workspace/src/workspace/reference_indexes.ts
@@ -24,7 +24,7 @@ import { RemoteMap, RemoteMapEntry } from './remote_map'
 const { awu } = collections.asynciterable
 
 const log = logger(module)
-export const REFERENCE_INDEXES_VERSION = 1
+export const REFERENCE_INDEXES_VERSION = 2
 export const REFERENCE_INDEXES_KEY = 'reference_indexes'
 
 type ReferenceDetails = {


### PR DESCRIPTION
Because of the need to add references to TemplateExpression to existing workspaces, we need to increase the version
of ReferenceIndex to make workspaces recalculate their reference index

---

See ticket

---
_Release Notes_: 
None (not officially released feature)

---
_User Notifications_: 
