### PR TITLE
SAAS-4004: Fix issues in static file cache migration

### DIFF
--- a/eslintrc.js
+++ b/eslintrc.js
@@ -126,6 +126,12 @@ module.exports = {
         '@typescript-eslint/explicit-module-boundary-types': ['off'],
         '@typescript-eslint/return-await': ['error', 'in-try-catch'],
         '@typescript-eslint/no-floating-promises': ['error'],
+        '@typescript-eslint/no-misused-promises': [
+          'error', 
+          { 
+            'checksVoidReturn': false,
+          }
+        ],
         'jest/valid-describe': ['off'],
         'import/extensions': [ 'error', 'never', {
             'json': 'always',

--- a/packages/core/src/local-workspace/remote_map.ts
+++ b/packages/core/src/local-workspace/remote_map.ts
@@ -244,7 +244,7 @@ const closeTmpConnection = async (
 
 export const closeRemoteMapsOfLocation = async (location: string): Promise<void> => {
   const persistentConnection = persistentDBConnections[location]
-  if (persistentConnection) {
+  if (await persistentConnection) {
     await closeConnection(location, persistentConnection, persistentDBConnections)
   }
   const tmpConnections = tmpDBConnections[location]
@@ -255,7 +255,7 @@ export const closeRemoteMapsOfLocation = async (location: string): Promise<void>
     delete tmpDBConnections[location]
   }
   const readOnlyConnection = readonlyDBConnections[location]
-  if (readOnlyConnection) {
+  if (await readOnlyConnection) {
     await closeConnection(location, readOnlyConnection, readonlyDBConnections)
   }
   const roConnectionsPerMap = readonlyDBConnectionsPerRemoteMap[location]

--- a/packages/core/src/local-workspace/static_files_cache.ts
+++ b/packages/core/src/local-workspace/static_files_cache.ts
@@ -35,7 +35,7 @@ const migrateLegacyStaticFilesCache = async (
   const currentCacheFile = path.join(cacheDir, name, CACHE_FILENAME)
 
   if (await exists(currentCacheFile)) {
-    if (remoteCache.isEmpty()) {
+    if (await remoteCache.isEmpty()) {
       log.debug('importing legacy static files cache from file: %s', currentCacheFile)
       const oldCache: Record<string, staticFiles.StaticFilesData> = JSON.parse(
         await readTextFile(currentCacheFile)
@@ -47,7 +47,7 @@ const migrateLegacyStaticFilesCache = async (
     } else {
       log.debug('static files cache already populated, ignoring legacy static files cache file: %s', currentCacheFile)
     }
-    log.debug('deleting legeacy static files cache file: %s', currentCacheFile)
+    log.debug('deleting legacy static files cache file: %s', currentCacheFile)
     await rm(currentCacheFile)
   }
 }

--- a/packages/salesforce-adapter/src/change_validators/picklist_promote.ts
+++ b/packages/salesforce-adapter/src/change_validators/picklist_promote.ts
@@ -51,11 +51,13 @@ const createChangeErrors = ({ pickListField, gvsElemID }:
   return [picklistErr]
 }
 
-const referencedGvsElemID = (change: ModificationChange<Field>): ElemID | undefined => {
+const referencedGvsElemID = async (
+  change: ModificationChange<Field>
+): Promise<ElemID | undefined> => {
   const referencedGvs = getChangeData(change).annotations[VALUE_SET_FIELDS.VALUE_SET_NAME]
   if (isReferenceExpression(referencedGvs)) {
     const referencedValue = referencedGvs.value
-    if (isInstanceOfType(GLOBAL_VALUE_SET)(referencedValue)) {
+    if (await isInstanceOfType(GLOBAL_VALUE_SET)(referencedValue)) {
       return referencedValue.elemID
     }
   }
@@ -63,7 +65,7 @@ const referencedGvsElemID = (change: ModificationChange<Field>): ElemID | undefi
 }
 
 /**
- * Promoting picklist value-set to global is forbbiden
+ * Promoting picklist value-set to global is forbidden
  */
 const changeValidator: ChangeValidator = async changes => {
   const isGVSInstance = isInstanceOfType(GLOBAL_VALUE_SET)
@@ -76,7 +78,7 @@ const changeValidator: ChangeValidator = async changes => {
   return awu(changes.filter(isModificationChange).filter(isFieldChange))
     .filter(isGlobalPicklistChange)
     .map(async change => {
-      const gvsElemID = referencedGvsElemID(change)
+      const gvsElemID = await referencedGvsElemID(change)
       return {
         pickListField: getChangeData(change),
         gvsElemID: (gvsElemID && gvsIDs.has(gvsElemID.getFullName())) ? gvsElemID : undefined,

--- a/packages/salesforce-adapter/src/filters/profile_permissions.ts
+++ b/packages/salesforce-adapter/src/filters/profile_permissions.ts
@@ -109,7 +109,7 @@ const addMissingPermissions = async (
 
 const isAdminProfileChange = async (change: Change): Promise<boolean> => {
   const changeElem = getChangeData(change)
-  return isInstanceOfType(PROFILE_METADATA_TYPE)(changeElem)
+  return await isInstanceOfType(PROFILE_METADATA_TYPE)(changeElem)
     && await apiName(changeElem) === ADMIN_PROFILE
 }
 

--- a/packages/salesforce-adapter/src/filters/replace_instance_field_values.ts
+++ b/packages/salesforce-adapter/src/filters/replace_instance_field_values.ts
@@ -53,7 +53,7 @@ const getRelevantFieldMapping = async (
   { elementsSource, key, value }: GetRelevantFieldMappingParams
 ): Promise<multiIndex.Index<[string], string>> => {
   const isReferencedCustomObject = async (elem: Element): Promise<boolean> => (
-    isCustomObject(elem)
+    await isCustomObject(elem)
     && Object.values(metadataTypeToInstanceName).includes(await apiName(elem))
   )
 

--- a/packages/workspace/src/parser/dump.ts
+++ b/packages/workspace/src/parser/dump.ts
@@ -64,7 +64,7 @@ const dumpAttributes = (
   valuePromiseWatchers: ValuePromiseWatcher[]
 ): Value => {
   const funcVal = getFunctionExpression(value, functions)
-  if (funcVal) {
+  if (funcVal === undefined) {
     return funcVal
   }
 

--- a/packages/workspace/src/parser/dump.ts
+++ b/packages/workspace/src/parser/dump.ts
@@ -64,7 +64,7 @@ const dumpAttributes = (
   valuePromiseWatchers: ValuePromiseWatcher[]
 ): Value => {
   const funcVal = getFunctionExpression(value, functions)
-  if (funcVal === undefined) {
+  if (funcVal !== undefined) {
     return funcVal
   }
 

--- a/packages/workspace/src/parser/functions.ts
+++ b/packages/workspace/src/parser/functions.ts
@@ -58,7 +58,7 @@ export const evaluateFunction = (
 export const getFunctionExpression = (
   val: Value,
   functions: Functions,
-): Promise<FunctionExpression | undefined> => {
+): Promise<FunctionExpression> | undefined => {
   const [funcPerhaps] = Object.values(functions)
     .filter(maybeRelevantFuncObj => maybeRelevantFuncObj.isSerializedAsFunction(val))
     .map(funcObj => funcObj.dump(val))


### PR DESCRIPTION
Fix a bug where we always assumes the cache was empty (and thus did the migration and deleted the old cache)

Added the relevant lint rule + fixed small similar bugs   

---

None

---
_Release Notes_: 

None
---
_User Notifications_: 

None