### PR TITLE
SALTO-2414: Differentiate between string length and list length restrictions

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -323,7 +323,7 @@ Type:
 - max: `number`- relevant for number fields, specifies the maximum valid value (inclusive).
 - regex: `string` - relevant for string fields, specifies a pattern that values must match.
 - max_length: `number` - relevant for string fields, specifies the maximum valid length for the field.
-- max_container_size: `number` - relevant for list fields, specifies the maximum allowed values in the list.
+- max_list_length: `number` - relevant for list fields, specifies the maximum allowed values in the list.
 
 Default: `undefined`
 Applicable to: Fields

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -323,6 +323,7 @@ Type:
 - max: `number`- relevant for number fields, specifies the maximum valid value (inclusive).
 - regex: `string` - relevant for string fields, specifies a pattern that values must match.
 - max_length: `number` - relevant for string fields, specifies the maximum valid length for the field.
+- max_container_size: `number` - relevant for list fields, specifies the maximum allowed values in the list.
 
 Default: `undefined`
 Applicable to: Fields

--- a/packages/adapter-api/src/builtins.ts
+++ b/packages/adapter-api/src/builtins.ts
@@ -94,6 +94,12 @@ const restrictionType = new ObjectType({
         StandardBuiltinTypes.NUMBER,
       ),
     },
+    max_container_size: {
+      refType: new TypeReference(
+        StandardBuiltinTypes.NUMBER.elemID,
+        StandardBuiltinTypes.NUMBER
+      ),
+    },
   },
 })
 
@@ -124,6 +130,8 @@ export type RestrictionAnnotationType = Partial<{
   regex: string
   // eslint-disable-next-line camelcase
   max_length: number
+  // eslint-disable-next-line camelcase
+  max_container_size: number
 }>
 
 const StandardCoreAnnotationTypes: TypeMap = {

--- a/packages/adapter-api/src/builtins.ts
+++ b/packages/adapter-api/src/builtins.ts
@@ -94,7 +94,7 @@ const restrictionType = new ObjectType({
         StandardBuiltinTypes.NUMBER,
       ),
     },
-    max_container_size: {
+    max_list_length: {
       refType: new TypeReference(
         StandardBuiltinTypes.NUMBER.elemID,
         StandardBuiltinTypes.NUMBER
@@ -131,7 +131,7 @@ export type RestrictionAnnotationType = Partial<{
   // eslint-disable-next-line camelcase
   max_length: number
   // eslint-disable-next-line camelcase
-  max_container_size: number
+  max_list_length: number
 }>
 
 const StandardCoreAnnotationTypes: TypeMap = {

--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -45,7 +45,7 @@ import {
   InvalidValueMaxLengthValidationError,
   isValidationError,
   InvalidTypeValidationError,
-  InvalidValueMaxContainerSizeValidationError,
+  InvalidValueMaxListLengthValidationError,
 } from '../validator'
 
 // There are two issues with naive json stringification:
@@ -99,7 +99,7 @@ const NameToType = {
   InvalidValueRangeValidationError: InvalidValueRangeValidationError,
   InvalidValueMaxLengthValidationError: InvalidValueMaxLengthValidationError,
   InvalidTypeValidationError: InvalidTypeValidationError,
-  InvalidValueMaxContainerSizeValidationError: InvalidValueMaxContainerSizeValidationError,
+  InvalidValueMaxListLengthValidationError: InvalidValueMaxListLengthValidationError,
 }
 const nameToTypeEntries = Object.entries(NameToType)
 const possibleTypes = Object.values(NameToType)
@@ -417,12 +417,12 @@ const generalDeserialize = async <T>(
           maxLength: v.maxLength,
         })
       ),
-      InvalidValueMaxContainerSizeValidationError: v => (
-        new InvalidValueMaxContainerSizeValidationError({
+      InvalidValueMaxListLengthValidationError: v => (
+        new InvalidValueMaxListLengthValidationError({
           elemID: reviveElemID(v.elemID),
           fieldName: v.fieldName,
           size: v.size,
-          maxContainerSize: v.maxContainerSize,
+          maxListLength: v.maxContainerSize,
         })
       ),
       InvalidTypeValidationError: v => (

--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -31,7 +31,22 @@ import { DuplicateVariableNameError } from '../merger/internal/variables'
 import { MultiplePrimitiveTypesError } from '../merger/internal/primitives'
 
 import { InvalidStaticFile } from '../workspace/static_files/common'
-import { ValidationError, InvalidValueValidationError, InvalidValueTypeValidationError, InvalidStaticFileError, CircularReferenceValidationError, IllegalReferenceValidationError, UnresolvedReferenceValidationError, MissingRequiredFieldValidationError, RegexMismatchValidationError, InvalidValueRangeValidationError, InvalidValueMaxLengthValidationError, isValidationError, InvalidTypeValidationError } from '../validator'
+import {
+  ValidationError,
+  InvalidValueValidationError,
+  InvalidValueTypeValidationError,
+  InvalidStaticFileError,
+  CircularReferenceValidationError,
+  IllegalReferenceValidationError,
+  UnresolvedReferenceValidationError,
+  MissingRequiredFieldValidationError,
+  RegexMismatchValidationError,
+  InvalidValueRangeValidationError,
+  InvalidValueMaxLengthValidationError,
+  isValidationError,
+  InvalidTypeValidationError,
+  InvalidValueMaxContainerSizeValidationError,
+} from '../validator'
 
 // There are two issues with naive json stringification:
 //
@@ -45,7 +60,7 @@ import { ValidationError, InvalidValueValidationError, InvalidValueTypeValidatio
 // To address this issue the serialization process:
 //
 // 1. Adds a '_salto_class' field with the class name to the object during the serialization.
-// 2. Replaces all of the pointers with "placeholder" objects
+// 2. Replaces all the pointers with "placeholder" objects
 //
 // The deserialization process recover the information by creating the classes based
 // on the _salto_class field, and then replacing the placeholders using the regular merge method.
@@ -84,6 +99,7 @@ const NameToType = {
   InvalidValueRangeValidationError: InvalidValueRangeValidationError,
   InvalidValueMaxLengthValidationError: InvalidValueMaxLengthValidationError,
   InvalidTypeValidationError: InvalidTypeValidationError,
+  InvalidValueMaxContainerSizeValidationError: InvalidValueMaxContainerSizeValidationError,
 }
 const nameToTypeEntries = Object.entries(NameToType)
 const possibleTypes = Object.values(NameToType)
@@ -399,6 +415,14 @@ const generalDeserialize = async <T>(
           fieldName: v.fieldName,
           value: v.value,
           maxLength: v.maxLength,
+        })
+      ),
+      InvalidValueMaxContainerSizeValidationError: v => (
+        new InvalidValueMaxContainerSizeValidationError({
+          elemID: reviveElemID(v.elemID),
+          fieldName: v.fieldName,
+          value: v.value,
+          maxContainerSize: v.maxContainerSize,
         })
       ),
       InvalidTypeValidationError: v => (

--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -421,7 +421,7 @@ const generalDeserialize = async <T>(
         new InvalidValueMaxContainerSizeValidationError({
           elemID: reviveElemID(v.elemID),
           fieldName: v.fieldName,
-          value: v.value,
+          size: v.size,
           maxContainerSize: v.maxContainerSize,
         })
       ),

--- a/packages/workspace/src/validator.ts
+++ b/packages/workspace/src/validator.ts
@@ -356,7 +356,7 @@ const validateAnnotationsValue = (
     const maxListLength = restrictions.max_list_length
     if ((values.isDefined(maxListLength) && value.length > maxListLength)) {
       return [new InvalidValueMaxListLengthValidationError(
-        { elemID, size: value.length, fieldName: elemID.name, maxListLength: maxListLength }
+        { elemID, size: value.length, fieldName: elemID.name, maxListLength }
       )]
     }
   }

--- a/packages/workspace/src/validator.ts
+++ b/packages/workspace/src/validator.ts
@@ -186,22 +186,22 @@ export class InvalidValueMaxLengthValidationError extends ValidationError {
   }
 }
 
-export class InvalidValueMaxContainerSizeValidationError extends ValidationError {
+export class InvalidValueMaxListLengthValidationError extends ValidationError {
   readonly size: number
   readonly fieldName: string
-  readonly maxContainerSize: number
+  readonly maxListLength: number
 
-  constructor({ elemID, size, fieldName, maxContainerSize }:
-                { elemID: ElemID; size: number; fieldName: string; maxContainerSize: number }) {
+  constructor({ elemID, size, fieldName, maxListLength }:
+                { elemID: ElemID; size: number; fieldName: string; maxListLength: number }) {
     super({
       elemID,
       error: `List of size "${size}" is too large for field.`
-        + ` ${fieldName} maximum length is ${maxContainerSize}`,
+        + ` ${fieldName} maximum length is ${maxListLength}`,
       severity: 'Warning',
     })
     this.size = size
     this.fieldName = fieldName
-    this.maxContainerSize = maxContainerSize
+    this.maxListLength = maxListLength
   }
 }
 
@@ -353,10 +353,10 @@ const validateAnnotationsValue = (
   }
 
   if (isListType(type) && shouldEnforceValue() && _.isArray(value)) {
-    const maxContainerSize = restrictions.max_container_size
-    if ((values.isDefined(maxContainerSize) && value.length > maxContainerSize)) {
-      return [new InvalidValueMaxContainerSizeValidationError(
-        { elemID, size: value.length, fieldName: elemID.name, maxContainerSize }
+    const maxListLength = restrictions.max_list_length
+    if ((values.isDefined(maxListLength) && value.length > maxListLength)) {
+      return [new InvalidValueMaxListLengthValidationError(
+        { elemID, size: value.length, fieldName: elemID.name, maxListLength: maxListLength }
       )]
     }
   }

--- a/packages/workspace/src/validator.ts
+++ b/packages/workspace/src/validator.ts
@@ -187,6 +187,26 @@ export class InvalidValueMaxLengthValidationError extends ValidationError {
     this.maxLength = maxLength
   }
 }
+
+export class InvalidValueMaxContainerSizeValidationError extends ValidationError {
+  readonly value: Value
+  readonly fieldName: string
+  readonly maxContainerSize: number
+
+  constructor({ elemID, value, fieldName, maxContainerSize }:
+                { elemID: ElemID; value: Value; fieldName: string; maxContainerSize: number }) {
+    super({
+      elemID,
+      error: `Value "${value}" is too large for field.`
+        + ` ${fieldName} maximum length is ${maxContainerSize}`,
+      severity: 'Warning',
+    })
+    this.value = value
+    this.fieldName = fieldName
+    this.maxContainerSize = maxContainerSize
+  }
+}
+
 export class MissingRequiredFieldValidationError extends ValidationError {
   readonly fieldName: string
 
@@ -335,10 +355,11 @@ const validateAnnotationsValue = (
   }
 
   if (isListType(type) && shouldEnforceValue()) {
-    const maxLength = restrictions.max_length
-    if ((values.isDefined(maxLength) && _.isArray(value) && value.length > maxLength)) {
-      return [new InvalidValueMaxLengthValidationError(
-        { elemID, value: value.toString(), fieldName: elemID.name, maxLength }
+    const maxContainerSize = restrictions.max_container_size
+    if ((values.isDefined(maxContainerSize)
+      && _.isArray(value) && value.length > maxContainerSize)) {
+      return [new InvalidValueMaxContainerSizeValidationError(
+        { elemID, value: value.toString(), fieldName: elemID.name, maxContainerSize }
       )]
     }
   }

--- a/packages/workspace/src/validator.ts
+++ b/packages/workspace/src/validator.ts
@@ -195,7 +195,7 @@ export class InvalidValueMaxListLengthValidationError extends ValidationError {
                 { elemID: ElemID; size: number; fieldName: string; maxListLength: number }) {
     super({
       elemID,
-      error: `List of size "${size}" is too large for field.`
+      error: `List of size ${size} is too large for field.`
         + ` ${fieldName} maximum length is ${maxListLength}`,
       severity: 'Warning',
     })

--- a/packages/workspace/test/validator.test.ts
+++ b/packages/workspace/test/validator.test.ts
@@ -1215,7 +1215,7 @@ describe('Elements validation', () => {
           )
           expect(errors).toHaveLength(1)
           expect(errors[0]).toBeInstanceOf(InvalidValueMaxListLengthValidationError)
-          expect(errors[0].message).toMatch('Value "one,two,three,four,five,six,seven,eight,nine,ten" is too large for field')
+          expect(errors[0].message).toMatch('List of size 10 is too large for field')
           expect(errors[0].message).toMatch('restrictedListLength maximum length is 6')
           expect(errors[0].elemID).toEqual(extInst.elemID.createNestedID('restrictedListLength'))
         })

--- a/packages/workspace/test/validator.test.ts
+++ b/packages/workspace/test/validator.test.ts
@@ -27,7 +27,7 @@ import {
   InvalidStaticFileError,
   RegexMismatchValidationError,
   InvalidValueMaxLengthValidationError,
-  InvalidValueMaxContainerSizeValidationError,
+  InvalidValueMaxListLengthValidationError,
 } from '../src/validator'
 import { MissingStaticFile, AccessDeniedStaticFile } from '../src/workspace/static_files/common'
 import { IllegalReference } from '../src/parser/parse'
@@ -230,7 +230,7 @@ describe('Elements validation', () => {
         refType: new ListType(BuiltinTypes.STRING),
         annotations: {
           [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({
-            max_container_size: 6,
+            max_list_length: 6,
           }),
         },
       },
@@ -1214,7 +1214,7 @@ describe('Elements validation', () => {
             ])
           )
           expect(errors).toHaveLength(1)
-          expect(errors[0]).toBeInstanceOf(InvalidValueMaxContainerSizeValidationError)
+          expect(errors[0]).toBeInstanceOf(InvalidValueMaxListLengthValidationError)
           expect(errors[0].message).toMatch('Value "one,two,three,four,five,six,seven,eight,nine,ten" is too large for field')
           expect(errors[0].message).toMatch('restrictedListLength maximum length is 6')
           expect(errors[0].elemID).toEqual(extInst.elemID.createNestedID('restrictedListLength'))


### PR DESCRIPTION
Having only one restriction for both means that the length restriction applies both to the list length and the string length in case we have a list of strings. 
Also added documentation for the list length restriction. 

---

None

---
_Release Notes_: 

Core - Added ability to restrict list sizes for specific fields.

---
_User Notifications_: 

None