### PR TITLE
SALTO-2419: Remove unused export getNaclFilesSourceParams

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -21,7 +21,7 @@ export { getAdaptersCredentialsTypes, getDefaultAdapterConfig, getAdaptersConfig
 export { createDiffChanges, getEnvsDeletionsDiff } from './src/core/diff'
 export { RenameElementIdError } from './src/core/rename'
 export {
-  loadLocalWorkspace, initLocalWorkspace, loadLocalElementsSources, getNaclFilesSourceParams,
+  loadLocalWorkspace, initLocalWorkspace, loadLocalElementsSources,
   CACHE_DIR_NAME, STATES_DIR_NAME, locateWorkspaceRoot, createEnvironmentSource,
   getAdapterConfigsPerAccount,
 } from './src/local-workspace/workspace'

--- a/packages/core/src/local-workspace/workspace.ts
+++ b/packages/core/src/local-workspace/workspace.ts
@@ -71,7 +71,7 @@ type GetNaclFilesSourceParamsArgs = {
   excludeDirs?: string[]
 }
 
-export const getNaclFilesSourceParamsImpl = ({
+const getNaclFilesSourceParams = ({
   sourceBaseDir,
   cacheDir,
   name,
@@ -111,21 +111,6 @@ export const getNaclFilesSourceParamsImpl = ({
   }
 }
 
-export const getNaclFilesSourceParams = (
-  sourceBaseDir: string,
-  cacheDir: string,
-  name: string,
-  excludeDirs: string[] = [],
-): {
-  naclFilesStore: dirStore.DirectoryStore<string>
-  staticFileSource: staticFiles.StaticFilesSource
-} => {
-  const remoteMapCreator = createRemoteMapCreator(cacheDir)
-  return getNaclFilesSourceParamsImpl(
-    { sourceBaseDir, cacheDir, name, excludeDirs, remoteMapCreator, persistent: false }
-  )
-}
-
 const loadNaclFileSource = async (
   sourceBaseDir: string,
   cacheBaseDir: string,
@@ -134,7 +119,7 @@ const loadNaclFileSource = async (
   remoteMapCreator: remoteMap.RemoteMapCreator,
   excludeDirs: string[] = []
 ): Promise<nacl.NaclFilesSource> => {
-  const { naclFilesStore, staticFileSource } = getNaclFilesSourceParamsImpl({
+  const { naclFilesStore, staticFileSource } = getNaclFilesSourceParams({
     sourceBaseDir,
     cacheDir: cacheBaseDir,
     name: sourceName,


### PR DESCRIPTION
Remove unused export, the references to it were deleted from the SAAS 

---

None

---
_Release Notes_: 

None

---
_User Notifications_: 

None