### PR TITLE
SALTO-2267 add support for more template values

### DIFF
--- a/packages/zendesk-support-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-support-adapter/src/filters/handle_template_expressions.ts
@@ -43,8 +43,11 @@ const saltoTypeToZendeskReferenceType = Object.fromEntries(
 )
 
 const potentialReferenceTypes = ['ticket.ticket_field', 'ticket.ticket_field_option_title']
-const potentialMacroFields = ['comment_value', 'comment_value_html']
-const potentialTriggerFields = ['notification_webhook', 'notification_user']
+const potentialMacroFields = ['comment_value', 'comment_value_html', 'side_conversation']
+// triggers and automations notify users, webhooks
+// groups or targets with text that can include templates.
+const notificationTypes = ['notification_webhook', 'notification_user', 'notification_group', 'notification_target']
+
 const NoValidator = (): boolean => true
 const potentialTemplates: PotentialTemplateField[] = [
   {
@@ -60,6 +63,11 @@ const potentialTemplates: PotentialTemplateField[] = [
     containerValidator: NoValidator,
   },
   {
+    instanceType: 'target',
+    fieldName: 'subject',
+    containerValidator: NoValidator,
+  },
+  {
     instanceType: 'webhook',
     fieldName: 'endpoint',
     containerValidator: NoValidator,
@@ -69,7 +77,19 @@ const potentialTemplates: PotentialTemplateField[] = [
     pathToContainer: ['actions'],
     fieldName: 'value',
     containerValidator: (container: Values): boolean =>
-      potentialTriggerFields.includes(container.field),
+      notificationTypes.includes(container.field),
+  },
+  {
+    instanceType: 'automation',
+    pathToContainer: ['actions'],
+    fieldName: 'value',
+    containerValidator: (container: Values): boolean =>
+      notificationTypes.includes(container.field),
+  },
+  {
+    instanceType: 'dynamic_content_item__variants',
+    fieldName: 'content',
+    containerValidator: NoValidator,
   },
 ]
 

--- a/packages/zendesk-support-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-support-adapter/src/filters/handle_template_expressions.ts
@@ -91,6 +91,19 @@ const potentialTemplates: PotentialTemplateField[] = [
     fieldName: 'content',
     containerValidator: NoValidator,
   },
+  {
+    instanceType: 'app_installation',
+    pathToContainer: ['settings'],
+    fieldName: 'uri_templates',
+    containerValidator: NoValidator,
+  },
+  {
+    instanceType: 'app_installation',
+    pathToContainer: ['settings_objects'],
+    fieldName: 'value',
+    containerValidator: (container: Values): boolean =>
+      container.name === 'uri_templates',
+  },
 ]
 
 // This function receives a formula that contains zendesk-style references and replaces

--- a/packages/zendesk-support-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-support-adapter/src/filters/handle_template_expressions.ts
@@ -21,6 +21,7 @@ import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { FilterCreator } from '../filter'
+import { DYNAMIC_CONTENT_ITEM_TYPE_NAME } from './dynamic_content'
 
 const { awu } = collections.asynciterable
 const log = logger(module)
@@ -147,7 +148,7 @@ const formulaToTemplate = (formula: string,
       const dynamicContentReference = expression.match(/\$\{dc\.(.+?)\}/)
       if (dynamicContentReference) {
         const dcPlaceholder = dynamicContentReference.pop() ?? ''
-        const ref = instancesByType.dynamic_content_item.find(instance =>
+        const ref = (instancesByType[DYNAMIC_CONTENT_ITEM_TYPE_NAME] ?? []).find(instance =>
           instance.value.placeholder === `{{dc.${dcPlaceholder}}}`)
         if (ref) {
           return new ReferenceExpression(ref.elemID, ref)
@@ -211,7 +212,7 @@ const filterCreator: FilterCreator = () => {
                       '_',
                       new ReferenceExpression(part.elemID.createNestedID('id'), part.value.value.id)]
                   }
-                  if (part.elemID.typeName === 'dynamic_content_item') {
+                  if (part.elemID.typeName === DYNAMIC_CONTENT_ITEM_TYPE_NAME) {
                     return part.value.value.placeholder.match(/{{(.*)}}/).pop()
                   }
                 }

--- a/packages/zendesk-support-adapter/test/filters/handle_template_expressions.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/handle_template_expressions.test.ts
@@ -50,6 +50,30 @@ describe('handle templates filter', () => {
     },
   })
 
+  const triggerType = new ObjectType({
+    elemID: new ElemID(ZENDESK_SUPPORT, 'trigger'),
+    fields: {
+      id: { refType: BuiltinTypes.NUMBER },
+      actions: { refType: new MapType(BuiltinTypes.STRING) },
+    },
+  })
+
+  const targetType = new ObjectType({
+    elemID: new ElemID(ZENDESK_SUPPORT, 'target'),
+    fields: {
+      id: { refType: BuiltinTypes.NUMBER },
+      actions: { refType: new MapType(BuiltinTypes.STRING) },
+    },
+  })
+
+  const webhookType = new ObjectType({
+    elemID: new ElemID(ZENDESK_SUPPORT, 'webhook'),
+    fields: {
+      id: { refType: BuiltinTypes.NUMBER },
+      actions: { refType: new MapType(BuiltinTypes.STRING) },
+    },
+  })
+
   const placeholder1Type = new ObjectType({
     elemID: new ElemID(ZENDESK_SUPPORT, 'ticket_field'),
   })
@@ -61,12 +85,17 @@ describe('handle templates filter', () => {
   const placeholder1 = new InstanceElement('placeholder1', placeholder1Type, { id: 1452 })
   const placeholder2 = new InstanceElement('placeholder2', placeholder2Type, { id: 1453 })
   const macro1 = new InstanceElement('macro1', testType, { id: 1001, actions: [{ value: 'non template', field: 'comment_value_html' }] })
-  const macro2 = new InstanceElement('macro2', testType, { id: 1002, actions: [{ value: '{{ticket.ticket_field_1452}}', field: 'comment_value_html' }] })
+  const macro2 = new InstanceElement('macro2', testType, { id: 1002, actions: [{ value: '{{ticket.ticket_field_1452}}', field: 'comment_value' }] })
   const macro3 = new InstanceElement('macro3', testType, { id: 1003, actions: [{ value: 'multiple refs {{ticket.ticket_field_1452}} and {{ticket.ticket_field_option_title_1453}}', field: 'comment_value_html' }] })
   const macroAlmostTemplate = new InstanceElement('macroAlmost', testType, { id: 1001, actions: [{ value: 'almost template {{ticket.not_an_actual_field_1452}} and {{ticket.ticket_field_1454}}', field: 'comment_value_html' }] })
 
+  const target = new InstanceElement('target', targetType, { id: 1004, target_url: 'url: {{ticket.ticket_field_1452}}' })
+  const trigger = new InstanceElement('trigger', triggerType, { id: 1005, actions: [{ value: 'ticket: {{ticket.ticket_field_1452}}', field: 'notification_webhook' }] })
+  const webhook = new InstanceElement('webhook', webhookType, { id: 1006, endpoint: 'endpoint: {{ticket.ticket_field_1452}}' })
+
   const generateElements = (): (InstanceElement | ObjectType)[] => ([testType, placeholder1Type,
-    placeholder2Type, placeholder1, placeholder2, macro1, macro2, macro3, macroAlmostTemplate])
+    placeholder2Type, placeholder1, placeholder2, macro1, macro2, macro3, macroAlmostTemplate,
+    target, trigger, webhook, targetType, triggerType, webhookType])
     .map(element => element.clone())
 
   describe('on fetch', () => {
@@ -92,6 +121,18 @@ describe('handle templates filter', () => {
       const fetchedMacro2 = elements.filter(isInstanceElement).find(i => i.elemID.name === 'macro2')
       expect(fetchedMacro2?.value.actions[0].value).toEqual(new TemplateExpression({ parts: [
         '{{',
+        new ReferenceExpression(placeholder1.elemID, placeholder1), '}}'] }))
+      const fetchedTarget = elements.filter(isInstanceElement).find(i => i.elemID.name === 'target')
+      expect(fetchedTarget?.value.target_url).toEqual(new TemplateExpression({ parts: [
+        'url: {{',
+        new ReferenceExpression(placeholder1.elemID, placeholder1), '}}'] }))
+      const fetchedWebhook = elements.filter(isInstanceElement).find(i => i.elemID.name === 'webhook')
+      expect(fetchedWebhook?.value.endpoint).toEqual(new TemplateExpression({ parts: [
+        'endpoint: {{',
+        new ReferenceExpression(placeholder1.elemID, placeholder1), '}}'] }))
+      const fetchedTrigger = elements.filter(isInstanceElement).find(i => i.elemID.name === 'trigger')
+      expect(fetchedTrigger?.value.actions[0].value).toEqual(new TemplateExpression({ parts: [
+        'ticket: {{',
         new ReferenceExpression(placeholder1.elemID, placeholder1), '}}'] }))
     })
 

--- a/packages/zendesk-support-adapter/test/filters/handle_template_expressions.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/handle_template_expressions.test.ts
@@ -88,18 +88,17 @@ describe('handle templates filter', () => {
   const macro2 = new InstanceElement('macro2', testType, { id: 1002, actions: [{ value: '{{ticket.ticket_field_1452}}', field: 'comment_value' }] })
   const macro3 = new InstanceElement('macro3', testType, { id: 1003, actions: [{ value: 'multiple refs {{ticket.ticket_field_1452}} and {{ticket.ticket_field_option_title_1453}}', field: 'comment_value_html' }] })
   const macroAlmostTemplate = new InstanceElement('macroAlmost', testType, { id: 1001, actions: [{ value: 'almost template {{ticket.not_an_actual_field_1452}} and {{ticket.ticket_field_1454}}', field: 'comment_value_html' }] })
-
+  const macroAlmostTemplate2 = new InstanceElement('macroAlmost2', testType, { id: 1001, actions: [{ value: '{{ticket.ticket_field_1452}}', field: 'not_template_field' }] })
   const target = new InstanceElement('target', targetType, { id: 1004, target_url: 'url: {{ticket.ticket_field_1452}}' })
   const trigger = new InstanceElement('trigger', triggerType, { id: 1005, actions: [{ value: 'ticket: {{ticket.ticket_field_1452}}', field: 'notification_webhook' }] })
   const webhook = new InstanceElement('webhook', webhookType, { id: 1006, endpoint: 'endpoint: {{ticket.ticket_field_1452}}' })
 
   const generateElements = (): (InstanceElement | ObjectType)[] => ([testType, placeholder1Type,
     placeholder2Type, placeholder1, placeholder2, macro1, macro2, macro3, macroAlmostTemplate,
-    target, trigger, webhook, targetType, triggerType, webhookType])
+    macroAlmostTemplate2, target, trigger, webhook, targetType, triggerType, webhookType])
     .map(element => element.clone())
 
   describe('on fetch', () => {
-    let fetchedMacroAlmostTemplate: InstanceElement | undefined
     let elements: (InstanceElement | ObjectType)[]
 
     beforeAll(async () => {
@@ -113,8 +112,10 @@ describe('handle templates filter', () => {
     })
 
     it('should resolve almost-template normally', () => {
-      fetchedMacroAlmostTemplate = elements.filter(isInstanceElement).find(i => i.elemID.name === 'macroAlmost')
+      const fetchedMacroAlmostTemplate = elements.filter(isInstanceElement).find(i => i.elemID.name === 'macroAlmost')
       expect(fetchedMacroAlmostTemplate?.value.actions[0].value).toEqual('almost template {{ticket.not_an_actual_field_1452}} and {{ticket.ticket_field_1454}}')
+      const fetchedMacroAlmostTemplate2 = elements.filter(isInstanceElement).find(i => i.elemID.name === 'macroAlmost2')
+      expect(fetchedMacroAlmostTemplate2?.value.actions[0].value).toEqual('{{ticket.ticket_field_1452}}')
     })
 
     it('should resolve one template correctly', () => {


### PR DESCRIPTION
For the zendesk_support adapter - add support for more fields that can contain template values

---

---
_Release Notes_: 
Placeholders that reference other zendesk elements will be parsed as references rather than kept as-is.

---
_User Notifications_: 
Placeholders that reference other zendesk elements will be parsed as references rather than kept as-is.
This affects: Triggers, macros, automations, webhooks.
e.g:
{{ticket.ticket_field_#NUMBER}} => {{ ${ zendesk_support.ticket_field.instance.THE_RELEVANT_INSTANCE }}}
