### PR TITLE
SALTO-2232: Fix detection of missing static file errors

### DIFF
--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -30,7 +30,7 @@ import { DuplicateAnnotationFieldDefinitionError, ConflictingFieldTypesError,
 import { DuplicateVariableNameError } from '../merger/internal/variables'
 import { MultiplePrimitiveTypesError } from '../merger/internal/primitives'
 
-import { InvalidStaticFile } from '../workspace/static_files/common'
+import { InvalidStaticFile, MissingStaticFile, AccessDeniedStaticFile } from '../workspace/static_files/common'
 import {
   ValidationError,
   InvalidValueValidationError,
@@ -80,6 +80,8 @@ const NameToType = {
   TypeReference: TypeReference,
   VariableExpression: VariableExpression,
   StaticFile: StaticFile,
+  MissingStaticFile: MissingStaticFile,
+  AccessDeniedStaticFile: AccessDeniedStaticFile,
   DuplicateAnnotationError: DuplicateAnnotationError,
   DuplicateInstanceKeyError: DuplicateInstanceKeyError,
   DuplicateAnnotationFieldDefinitionError: DuplicateAnnotationFieldDefinitionError,
@@ -303,6 +305,8 @@ const generalDeserialize = async <T>(
           { filepath: v.filepath, hash: v.hash, encoding: v.encoding }
         )
       ),
+      MissingStaticFile: v => new MissingStaticFile(v.filepath),
+      AccessDeniedStaticFile: v => new AccessDeniedStaticFile(v.filepath),
       DuplicateAnnotationError: v => (
         new DuplicateAnnotationError({
           elemID: reviveElemID(v.elemID),
@@ -365,7 +369,7 @@ const generalDeserialize = async <T>(
       InvalidStaticFileError: v => (
         new InvalidStaticFileError({
           elemID: reviveElemID(v.elemID),
-          value: { message: v.error },
+          error: v.error,
         })
       ),
       CircularReferenceValidationError: v => (

--- a/packages/workspace/src/validator.ts
+++ b/packages/workspace/src/validator.ts
@@ -259,10 +259,10 @@ export class CircularReferenceValidationError extends ValidationError {
 }
 
 export class InvalidStaticFileError extends ValidationError {
-  constructor({ elemID, value }: { elemID: ElemID; value: InvalidStaticFile }) {
+  constructor({ elemID, error }: { elemID: ElemID; error: string }) {
     super({
       elemID,
-      error: value.message,
+      error,
       severity: 'Error',
     })
   }
@@ -485,7 +485,7 @@ const validateValue = (
   }
 
   if (value instanceof InvalidStaticFile) {
-    return [new InvalidStaticFileError({ elemID, value })]
+    return [new InvalidStaticFileError({ elemID, error: value.message })]
   }
 
   if (value instanceof StaticFile) {

--- a/packages/workspace/src/workspace/nacl_files/index.ts
+++ b/packages/workspace/src/workspace/nacl_files/index.ts
@@ -15,5 +15,5 @@
 */
 export { ParsedNaclFile, ParsedNaclFileData } from './parsed_nacl_file'
 export { ChangeSet } from './elements_cache'
-export { NaclFile, FILE_EXTENSION, NaclFilesSource, naclFilesSource, getParsedNaclFiles, RoutingMode, getFunctions } from './nacl_files_source'
+export { NaclFile, FILE_EXTENSION, NaclFilesSource, naclFilesSource, RoutingMode, getFunctions } from './nacl_files_source'
 export { ENVS_PREFIX } from './multi_env/multi_env_source'

--- a/packages/workspace/src/workspace/static_files/common.ts
+++ b/packages/workspace/src/workspace/static_files/common.ts
@@ -17,6 +17,7 @@ import { StaticFile, Value } from '@salto-io/adapter-api'
 
 export abstract class InvalidStaticFile {
   constructor(
+    public readonly filepath: string,
     public readonly message: string,
   ) {
   }
@@ -43,6 +44,7 @@ export class MissingStaticFile extends InvalidStaticFile {
     filepath: string,
   ) {
     super(
+      filepath,
       `Missing static file: ${filepath}`,
     )
   }
@@ -53,9 +55,14 @@ export class AccessDeniedStaticFile extends InvalidStaticFile {
     filepath: string,
   ) {
     super(
+      filepath,
       `Unable to access static file: ${filepath}`,
     )
   }
 }
 
-export const isInvalidStaticFile = (val: Value): boolean => val instanceof InvalidStaticFile
+export const isInvalidStaticFile = (
+  val: Value
+): val is InvalidStaticFile => (
+  val instanceof InvalidStaticFile
+)

--- a/packages/workspace/test/validator.test.ts
+++ b/packages/workspace/test/validator.test.ts
@@ -2192,12 +2192,12 @@ describe('Elements validation', () => {
     const elemID = new ElemID('adapter', 'bla')
     it('should have correct message for missing', () =>
       expect(
-        new InvalidStaticFileError({ elemID, value: new MissingStaticFile('path') })
+        new InvalidStaticFileError({ elemID, error: new MissingStaticFile('path').message })
           .message
       ).toEqual('Error validating "adapter.bla": Missing static file: path'))
     it('should have correct message for invalid', () =>
       expect(
-        new InvalidStaticFileError({ elemID, value: new AccessDeniedStaticFile('path') })
+        new InvalidStaticFileError({ elemID, error: new AccessDeniedStaticFile('path').message })
           .message
       ).toEqual('Error validating "adapter.bla": Unable to access static file: path'))
   })


### PR DESCRIPTION
- Fix static file index in naclFileSource to include missing static file references as well
- Fix serialization of MissingStaticFile and AccessDeniedStaticFile in elements
- Force parsing of files that are affected by static files changes even if the nacl file itself hasn't changed

---

This should fix the error when a missing static file is created
It does not fix the issue where a static file is deleted - this would still not create a salto error and requires a separate fix

---
_Release Notes_: 
Core:
- Fixed issue where missing static file errors would not go away even after the missing static file was created

---
_User Notifications_: 
_None_
