### PR TITLE
SALTO-2425: Apply naclCase of field names in salesforce

### DIFF
--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -1249,7 +1249,7 @@ export const getSObjectFieldElement = (
     delete annotations[CORE_ANNOTATIONS.REQUIRED]
   }
 
-  const fieldName = Types.getElemId(field.name, true, serviceIds).name
+  const fieldName = Types.getElemId(naclCase(field.name), true, serviceIds).name
   return new Field(parent, fieldName, naclFieldType, annotations)
 }
 

--- a/packages/salesforce-adapter/test/transformers/transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/transformer.test.ts
@@ -572,6 +572,52 @@ describe('transformer', () => {
         expect(await fieldElement.getType()).toEqual(Types.primitiveDataTypes.Text)
       })
     })
+    describe('when field has invalid characters in its name', () => {
+      let field: Field
+      beforeEach(() => {
+        const fieldDefinition: SalesforceField = {
+          aggregatable: false,
+          cascadeDelete: false,
+          dependentPicklist: false,
+          externalId: false,
+          htmlFormatted: false,
+          autoNumber: false,
+          byteLength: 18,
+          calculated: true,
+          caseSensitive: false,
+          createable: true,
+          custom: false,
+          defaultedOnCreate: true,
+          deprecatedAndHidden: false,
+          digits: 0,
+          filterable: true,
+          groupable: true,
+          idLookup: false,
+          label: 'Invalid%5FName',
+          length: 18,
+          name: 'Invalid%5FName__c',
+          nameField: false,
+          namePointing: true,
+          nillable: false,
+          permissionable: false,
+          polymorphicForeignKey: true,
+          precision: 0,
+          queryByDistance: false,
+          restrictedPicklist: false,
+          scale: 0,
+          searchPrefilterable: false,
+          soapType: 'xsd:double',
+          sortable: true,
+          type: 'currency',
+          unique: false,
+          updateable: true,
+        }
+        field = getSObjectFieldElement(dummyElem, fieldDefinition, serviceIds)
+      })
+      it('should create a field with a valid name', () => {
+        expect(field.name).not.toInclude('%')
+      })
+    })
   })
 
   describe('toCustomField', () => {


### PR DESCRIPTION
While both the UI and API of salesforce prevent invalid names from being set on fields.
in real life, of course we encountered a case where a field name had a "%" in it...
since naclCase should not have any effect on an valid field name, applying it should do nothing
in all valid cases, and it will fix the invalid strange case...

---

---
_Release Notes_: 
Salesforce Adapter:
- Fix failure on fetch when salesforce field has an invalid character in its api name (a case that should never happen)

---
_User Notifications_: 
_None_