### PR TITLE
INCIDENT-494: changed jql parsing errors to not fail fetch

### DIFF
--- a/packages/jira-adapter/src/filters/jql/types.ts
+++ b/packages/jira-adapter/src/filters/jql/types.ts
@@ -18,7 +18,8 @@ import Joi from 'joi'
 
 export type ParsedJql = {
   query: string
-  structure: Record<string, unknown>
+  structure?: Record<string, unknown>
+  errors?: string[]
 }
 
 export type JqlParseResponse = {
@@ -29,7 +30,8 @@ const JQL_PARSE_RESPONSE_SCHEME = Joi.object({
   queries: Joi.array().items(
     Joi.object({
       query: Joi.string().required(),
-      structure: Joi.object().required(),
+      structure: Joi.object().optional(),
+      errors: Joi.array().items(Joi.string()).optional(),
     }).unknown(true).required(),
   ).required(),
 })

--- a/packages/jira-adapter/test/filters/jql/jql_references.test.ts
+++ b/packages/jira-adapter/test/filters/jql/jql_references.test.ts
@@ -103,7 +103,6 @@ describe('jqlReferencesFilter', () => {
                 },
               },
             },
-            errors: [],
           },
         ],
       },
@@ -251,12 +250,35 @@ describe('jqlReferencesFilter', () => {
       ])
     })
 
-    it('should throw if jql pares response in invalid', async () => {
+    it('should do nothing if jql pares response in invalid', async () => {
       connection.post.mockResolvedValue({
         status: 200,
         data: {},
       })
-      await expect(filter.onFetch?.([instance, fieldInstance, doneInstance])).rejects.toThrow()
+      await filter.onFetch?.([instance, fieldInstance, doneInstance, todoInstance])
+      expect(instance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeUndefined()
+    })
+
+    it('should do nothing if failed to parse jql', async () => {
+      connection.post.mockResolvedValue({
+        status: 200,
+        data: {
+          queries: [
+            {
+              query: 'status = Done',
+              errors: ['error'],
+            },
+          ],
+        },
+      })
+      await filter.onFetch?.([instance, fieldInstance, doneInstance, todoInstance])
+      expect(instance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeUndefined()
+    })
+
+    it('should do nothing if request failed', async () => {
+      connection.post.mockRejectedValue(new Error('error'))
+      await filter.onFetch?.([instance, fieldInstance, doneInstance, todoInstance])
+      expect(instance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeUndefined()
     })
   })
 })


### PR DESCRIPTION
- Failures in parsing JQLs for references will now not fail the entire fetch
- Parsing the response to log the specific failed jqls and omit only them

---
_Release Notes_: 
- Failures in parsing JQLs for references will now not fail the entire fetch

---
_User Notifications_: 
None