### PR TITLE
SALTO-2213: Fixed columnConfig name

### DIFF
--- a/packages/jira-adapter/src/filters/board/board_columns.ts
+++ b/packages/jira-adapter/src/filters/board/board_columns.ts
@@ -47,7 +47,7 @@ const UPDATE_COLUMNS_RESPONSE_SCHEME = Joi.object({
 const isUpdateColumnsResponse = createSchemeGuard<UpdateColumnsResponse>(UPDATE_COLUMNS_RESPONSE_SCHEME, 'Received an invalid columns update response')
 
 type BoardConfigResponse = {
-  columnsConfig: {
+  [COLUMNS_CONFIG_FIELD]: {
     columns: {
       name: string
     }[]
@@ -55,7 +55,7 @@ type BoardConfigResponse = {
 }
 
 const BOARD_CONFIG_RESPONSE_SCHEME = Joi.object({
-  columnsConfig: Joi.object({
+  [COLUMNS_CONFIG_FIELD]: Joi.object({
     columns: Joi.array().items(Joi.object({
       name: Joi.string().required(),
     }).unknown(true)),
@@ -156,7 +156,7 @@ const removeRedundantColumns = async (
     return
   }
 
-  if (response.data.columnsConfig.columns[1]?.name !== 'Backlog') {
+  if (response.data[COLUMNS_CONFIG_FIELD].columns[1]?.name !== 'Backlog') {
     log.debug(`${instance.elemID.getFullName()} removing second backlog column`)
     instance.value[COLUMNS_CONFIG_FIELD].columns.shift()
   } else {

--- a/packages/jira-adapter/test/filters/board/board_columns.test.ts
+++ b/packages/jira-adapter/test/filters/board/board_columns.test.ts
@@ -55,7 +55,7 @@ describe('boardColumnsFilter', () => {
     type = new ObjectType({
       elemID: new ElemID(JIRA, BOARD_TYPE_NAME),
       fields: {
-        columnConfig: {
+        [COLUMNS_CONFIG_FIELD]: {
           refType: columnConfigType,
         },
       },
@@ -67,7 +67,7 @@ describe('boardColumnsFilter', () => {
       {
         type: 'kanban',
         config: {
-          columnConfig: {
+          [COLUMNS_CONFIG_FIELD]: {
             columns: [
               {
                 name: 'Backlog',
@@ -130,7 +130,7 @@ describe('boardColumnsFilter', () => {
       connection.get.mockResolvedValue({
         status: 200,
         data: {
-          columnsConfig: {
+          [COLUMNS_CONFIG_FIELD]: {
             columns: [
               {
                 name: 'Backlog',
@@ -160,7 +160,7 @@ describe('boardColumnsFilter', () => {
       connection.get.mockResolvedValue({
         status: 200,
         data: {
-          columnsConfig: {
+          [COLUMNS_CONFIG_FIELD]: {
             columns: [
               {
                 name: 'Backlog',

--- a/packages/jira-adapter/test/filters/board/board_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/board/board_deployment.test.ts
@@ -88,7 +88,7 @@ describe('boardDeploymentFilter', () => {
           projectKeyOrId: '3',
           type: 'project',
         },
-        columnConfig: {
+        [COLUMNS_CONFIG_FIELD]: {
           columns: [
             {
               name: 'someColumn',


### PR DESCRIPTION
Accidently write `columnsConfig` instead of `columnConfig` in some places 🤦‍♂️

---
_Release Notes_: 
None (no effect on the user)

---
_User Notifications_: 
None