### PR TITLE
SAAS-5457: Update state cache when it is not synced

### DIFF
--- a/packages/core/test/common/helpers.ts
+++ b/packages/core/test/common/helpers.ts
@@ -14,10 +14,21 @@
 * limitations under the License.
 */
 import { Element } from '@salto-io/adapter-api'
-import { elementSource } from '@salto-io/workspace'
+import { elementSource, remoteMap } from '@salto-io/workspace'
 
 export const createElementSource = (
   elements: readonly Element[]
 ): elementSource.RemoteElementSource => (
   elementSource.createInMemoryElementSource(elements as Element[])
 )
+
+export const inMemRemoteMapCreator = (): remoteMap.RemoteMapCreator => {
+  const maps = new Map<string, remoteMap.RemoteMap<unknown>>()
+  return async <T, K extends string = string>(opts: remoteMap.CreateRemoteMapParams<T>) => {
+    const map = maps.get(opts.namespace) ?? new remoteMap.InMemoryRemoteMap<T, K>()
+    if (!maps.has(opts.namespace)) {
+      maps.set(opts.namespace, map)
+    }
+    return map as remoteMap.RemoteMap<T, K>
+  }
+}

--- a/packages/core/test/workspace/local/state.test.ts
+++ b/packages/core/test/workspace/local/state.test.ts
@@ -24,6 +24,7 @@ import { localState, filePathGlob, ZIPPED_STATE_EXTENSION } from '../../../src/l
 import { getAllElements } from '../../common/elements'
 import { version } from '../../../src/generated/version.json'
 import { mockStaticFilesSource } from '../../common/state'
+import { inMemRemoteMapCreator } from '../../common/helpers'
 
 const { awu } = collections.asynciterable
 const { serialize } = serialization
@@ -52,7 +53,7 @@ jest.mock('@salto-io/file', () => ({
     if (filename === 'full' || filename.startsWith('deprecated_file')) {
       return Promise.resolve('[{"elemID":{"adapter":"salesforce","nameParts":["_config"]},"refType":{"annotationRefTypes":{},"annotations":{},"elemID":{"adapter":"salesforce","nameParts":[]},"fields":{},"isSettings":false,"_salto_class":"ObjectType"},"value":{"token":"token","sandbox":false,"username":"test@test","password":"pass"},"_salto_class":"InstanceElement"},{"annotationRefTypes":{},"annotations":{"LeadConvertSettings":{"account":[{"input":"bla","output":"foo"}]}},"elemID":{"adapter":"salesforce","nameParts":["test"]},"fields":{"name":{"parentID":{"adapter":"salesforce","nameParts":["test"]},"name":"name","refType":{"annotationRefTypes":{},"annotations":{},"elemID":{"adapter":"","nameParts":["string"]},"fields":{},"isSettings":false,"_salto_class":"ObjectType"},"annotations":{"label":"Name","_required":true},"isList":false,"elemID":{"adapter":"salesforce","nameParts":["test","name"]},"_salto_class":"Field"}},"isSettings":false,"_salto_class":"ObjectType"},{"annotationRefTypes":{},"annotations":{"metadataType":"Settings"},"elemID":{"adapter":"salesforce","nameParts":["settings"]},"fields":{},"isSettings":true,"_salto_class":"ObjectType"}]')
     }
-    if (filename === 'mutiple_adapters') {
+    if (filename === 'multiple_adapters') {
       return Promise.resolve('[{"annotationRefTypes":{},"annotations":{"LeadConvertSettings":{"account":[{"input":"bla","output":"foo"}]}},"elemID":{"adapter":"salesforce","nameParts":["test"]},"fields":{"name":{"parentID":{"adapter":"salesforce","nameParts":["test"]},"name":"name","refType":{"annotationRefTypes":{},"annotations":{},"elemID":{"adapter":"","nameParts":["string"]},"fields":{},"isSettings":false,"_salto_class":"ObjectType"},"annotations":{"label":"Name","_required":true},"isList":false,"elemID":{"adapter":"salesforce","nameParts":["test","name"]},"_salto_class":"Field"}},"isSettings":false,"_salto_class":"ObjectType"},{"annotationRefTypes":{},"annotations":{},"elemID":{"adapter":"netsuite","nameParts":["foo"]},"fields":{},"isSettings":false,"_salto_class":"ObjectType"}]\n{ "salto" :"2020-04-21T09:44:20.824Z", "netsuite":"2020-04-21T09:44:20.824Z"}')
     }
     if (filename === 'on-delete') {
@@ -70,7 +71,7 @@ jest.mock('@salto-io/file', () => ({
     if (filename === 'multiple_files.netsuite.jsonl.zip') {
       return Promise.resolve('[{"elemID":{"adapter":"netsuite","nameParts":["_config"]},"refType":{"annotationRefTypes":{},"annotations":{},"elemID":{"adapter":"netsuite","nameParts":[]},"fields":{},"isSettings":false,"_salto_class":"ObjectType"},"value":{"token":"token","sandbox":false,"username":"test@test","password":"pass"},"_salto_class":"InstanceElement"},{"annotationRefTypes":{},"annotations":{"LeadConvertSettings":{"account":[{"input":"bla","output":"foo"}]}},"elemID":{"adapter":"netsuite","nameParts":["test"]},"fields":{"name":{"parentID":{"adapter":"netsuite","nameParts":["test"]},"name":"name","refType":{"annotationRefTypes":{},"annotations":{},"elemID":{"adapter":"","nameParts":["string"]},"fields":{},"isSettings":false,"_salto_class":"ObjectType"},"annotations":{"label":"Name","_required":true},"isList":false,"elemID":{"adapter":"netsuite","nameParts":["test","name"]},"_salto_class":"Field"}},"isSettings":false,"_salto_class":"ObjectType"},{"annotationRefTypes":{},"annotations":{"metadataType":"Settings"},"elemID":{"adapter":"netsuite","nameParts":["settings"]},"fields":{},"isSettings":true,"_salto_class":"ObjectType"}]\n{ "netsuite" :"2020-04-21T09:44:20.824Z"}')
     }
-    if (filename === 'mutiple_adapters.jsonl.zip') {
+    if (filename === 'multiple_adapters.jsonl.zip') {
       return Promise.resolve('[{"annotationRefTypes":{},"annotations":{"LeadConvertSettings":{"account":[{"input":"bla","output":"foo"}]}},"elemID":{"adapter":"salesforce","nameParts":["test"]},"fields":{"name":{"parentID":{"adapter":"salesforce","nameParts":["test"]},"name":"name","refType":{"annotationRefTypes":{},"annotations":{},"elemID":{"adapter":"","nameParts":["string"]},"fields":{},"isSettings":false,"_salto_class":"ObjectType"},"annotations":{"label":"Name","_required":true},"isList":false,"elemID":{"adapter":"salesforce","nameParts":["test","name"]},"_salto_class":"Field"}},"isSettings":false,"_salto_class":"ObjectType"},{"annotationRefTypes":{},"annotations":{},"elemID":{"adapter":"netsuite","nameParts":["foo"]},"fields":{},"isSettings":false,"_salto_class":"ObjectType"}]\n{ "salto" :"2020-04-21T09:44:20.824Z", "netsuite":"2020-04-21T09:44:20.824Z"}')
     }
     if (filename === 'on-delete.jsonl.zip') {
@@ -175,7 +176,7 @@ describe('local state', () => {
       state = localState('empty', '', remoteMapCreator, mockStaticFilesSource())
     })
 
-    it('should return an unedfined hash', async () => {
+    it('should return an undefined hash', async () => {
       const stateHash = await state.getHash()
       expect(stateHash).toBeUndefined()
     })
@@ -279,7 +280,7 @@ describe('local state', () => {
   })
 
   it('should return undefined version if the version was not provided in the state file', async () => {
-    const state = localState('mutiple_adapters', '', remoteMapCreator, mockStaticFilesSource())
+    const state = localState('multiple_adapters', '', remoteMapCreator, mockStaticFilesSource())
     expect(await state.getStateSaltoVersion()).not.toBeDefined()
   })
 
@@ -382,7 +383,7 @@ describe('local state', () => {
       expect(adapters).toHaveLength(0)
     })
     it('should return all adapters in a full state', async () => {
-      const state = localState('mutiple_adapters', '', remoteMapCreator, mockStaticFilesSource())
+      const state = localState('multiple_adapters', '', remoteMapCreator, mockStaticFilesSource())
       const adapters = await state.existingAccounts()
       expect(adapters).toEqual(['netsuite', 'salto'])
     })
@@ -426,6 +427,33 @@ describe('local state', () => {
         '/tmp': badFiles,
       } })
       expect(results).toEqual([])
+    })
+  })
+  describe('when cache does not match state file', () => {
+    let state: wsState.State
+    let mapCreator: remoteMap.RemoteMapCreator
+    beforeEach(() => {
+      mapCreator = inMemRemoteMapCreator()
+      state = localState('multiple_files', '', mapCreator, mockStaticFilesSource())
+    })
+    describe('flush', () => {
+      beforeEach(async () => {
+        // Force loading the state so it detects the cache is outdated
+        await state.getHash()
+        await state.flush()
+      })
+      it('should update the cache remote maps', async () => {
+        const cachedMetadata = await mapCreator<string>({
+          namespace: 'state--salto_metadata',
+          serialize: async x => x,
+          deserialize: async x => x,
+          persistent: false,
+        })
+        const currentStateHash = await state.getHash()
+        const cachedHash = await cachedMetadata.get('hash')
+        expect(cachedHash).toEqual(currentStateHash)
+        expect(cachedHash).toBeDefined()
+      })
     })
   })
 })

--- a/packages/workspace/src/workspace/state/in_mem.ts
+++ b/packages/workspace/src/workspace/state/in_mem.ts
@@ -55,8 +55,6 @@ export const buildInMemState = (
     const stateDataVal = await awu(getUpdateDate(await stateData()).entries()).toArray()
     return Object.fromEntries(stateDataVal.map(e => [e.key, e.value]))
   }
-  const setHashImpl = async (newHash: string): Promise<void> => (await stateData())
-    .saltoMetadata.set('hash', newHash)
 
   const deleteFromFilesSource = async (elements: Element[]): Promise<void> => {
     const files = await getNestedStaticFiles(elements)
@@ -141,7 +139,7 @@ export const buildInMemState = (
     },
     rename: () => Promise.resolve(),
     getHash: async () => (await stateData()).saltoMetadata.get('hash'),
-    setHash: setHashImpl,
+    setHash: async newHash => (await stateData()).saltoMetadata.set('hash', newHash),
     // hash doesn't get calculated in memory
     calculateHash: async () => Promise.resolve(),
     getStateSaltoVersion: async () => (await stateData()).saltoMetadata.get('version'),

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -503,13 +503,16 @@ export const loadWorkspace = async (
             .filter(element => isHidden(element, state(envName)))
             .map(elem => toChange({ after: elem })).toArray()
           : []
+        log.debug('got %d init hidden element changes', initHiddenElementsChanges.length)
 
-        const stateRemovedElementChanges = await awu(
-          (workspaceChanges[envName] ?? createEmptyChangeSet())
-            .changes
-        ).filter(async change => isRemovalChange(change)
+        const stateRemovedElementChanges = await awu(workspaceChanges[envName]?.changes ?? [])
+          .filter(async change => (
+            isRemovalChange(change)
             && getChangeData(change).elemID.isTopLevel()
-            && !await isHidden(getChangeData(change), state(envName))).toArray()
+            && !await isHidden(getChangeData(change), state(envName))
+          ))
+          .toArray()
+        log.debug('got %d state removed element changes', stateRemovedElementChanges.length)
 
         // To preserve the old ws functionality - hidden values should be added to the workspace
         // cache only if their top level element is in the nacls, or they are marked as hidden
@@ -540,9 +543,8 @@ export const loadWorkspace = async (
             .concat(initHiddenElementsChanges)
             .concat(stateRemovedElementChanges),
           cacheValid,
-          preChangeHash: partialStateChanges.preChangeHash
-            ?? await stateToBuild.mergeManager.getHash(STATE_SOURCE_PREFIX + envName),
-          postChangeHash: await state(envName).getHash(),
+          preChangeHash: partialStateChanges.preChangeHash ?? cachedHash,
+          postChangeHash: stateHash,
         }
       }
 
@@ -1083,11 +1085,12 @@ export const loadWorkspace = async (
       if (!persistent) {
         throw new Error('Can not flush a non-persistent workspace.')
       }
-      await state().flush()
-      await (await getLoadedNaclFilesSource()).flush()
+      // Must call getWorkspaceState first to make sure everything is loaded before flushing
       const currentWSState = await getWorkspaceState()
       await currentWSState.mergeManager.flush()
+      await (await getLoadedNaclFilesSource()).flush()
       await adaptersConfig.flush()
+      await state().flush()
     },
     clone: (): Promise<Workspace> => {
       const sources = _.mapValues(environmentsSources.sources, source =>


### PR DESCRIPTION
Before this change, when the state cache did not match the state file we would not
mark the state cache as dirty and therefore we whould not update the cache.

this meant that until we ran a command that really updated the state file, we were
doomed to parse the state file over and over again

---



---
_Release Notes_: 
Core:
- Improved loadWorkspace performance when external changes are made to the state file (e.g switching git branch)

---
_User Notifications_: 
_None_