### PR TITLE
SALTO-2437 remove webpack workaround for old requestretry library

### DIFF
--- a/packages/cli/webpack.config.js
+++ b/packages/cli/webpack.config.js
@@ -54,10 +54,6 @@ module.exports = {
       /node_modules\/yargs/, // Ignore warnings due to yarg's dynamic module loading
     ],
   },
-  externals: {
-    vertx: 'commonjs vertx',    // workaround for: https://github.com/stefanpenner/es6-promise/issues/305
-                                // caused by requestretry which depends on an old version of es6-promise
-  },
   plugins: [
     new webpack.EnvironmentPlugin({
       // SALTO_TELEMETRY_TOKEN should be defined in the build system, i.e. circleci


### PR DESCRIPTION
Cleanup old webpack workaround that is no longer relevant after the requestretry version bump.

Will merge after https://github.com/salto-io/salto/pull/3138 to separate the vulnerability fix from the cleanup in case there is any regression in webpack (please review only the 2nd commit here).


---
_Release Notes_: 
None

---
_User Notifications_: 
None