### PR TITLE
SALTO-2438: Invalid query response when parsing JQLs

### DIFF
--- a/packages/jira-adapter/src/filters/jql/types.ts
+++ b/packages/jira-adapter/src/filters/jql/types.ts
@@ -29,7 +29,7 @@ export type JqlParseResponse = {
 const JQL_PARSE_RESPONSE_SCHEME = Joi.object({
   queries: Joi.array().items(
     Joi.object({
-      query: Joi.string().required(),
+      query: Joi.string().required().allow(''),
       structure: Joi.object().optional(),
       errors: Joi.array().items(Joi.string()).optional(),
     }).unknown(true).required(),

--- a/packages/jira-adapter/test/filters/jql/jql_references.test.ts
+++ b/packages/jira-adapter/test/filters/jql/jql_references.test.ts
@@ -144,6 +144,64 @@ describe('jqlReferencesFilter', () => {
       )
     })
 
+    it('should work with empty jql', async () => {
+      instance.value.jql = ''
+
+      connection.post.mockResolvedValue({
+        status: 200,
+        data: {
+          queries: [
+            {
+              query: '',
+              structure: {
+                where: {
+                  field: {
+                    name: 'status',
+                  },
+                  operator: '=',
+                  operand: {
+                    value: 'Done',
+                  },
+                },
+              },
+            },
+          ],
+        },
+      })
+
+      await filter.onFetch?.([instance, fieldInstance, doneInstance, todoInstance])
+      expect(instance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toEqual([
+        {
+          reference: new ReferenceExpression(fieldInstance.elemID, fieldInstance),
+          occurrences: [
+            {
+              location: new ReferenceExpression(instance.elemID.createNestedID('jql'), ''),
+            },
+          ],
+        },
+        {
+          reference: new ReferenceExpression(doneInstance.elemID, doneInstance),
+          occurrences: [
+            {
+              location: new ReferenceExpression(instance.elemID.createNestedID('jql'), ''),
+            },
+          ],
+        },
+      ])
+
+      expect(connection.post).toHaveBeenCalledWith(
+        '/rest/api/3/jql/parse',
+        {
+          queries: [''],
+        },
+        {
+          params: {
+            validation: 'none',
+          },
+        },
+      )
+    })
+
     it('should parse correctly jql with multiple values', async () => {
       const jql = 'status IN (Done, "To Do") AND otherfield = 2 AND issuetype = 3'
       connection.post.mockResolvedValue({


### PR DESCRIPTION
Fixed scheme to work with empty queries (which are valid queries)

---
_Release Notes_: 
- Fixed JQL references when there are empty JQLs

---
_User Notifications_: 
None