### PR TITLE
SALTO-2217: Elements fragment refactor

### DIFF
--- a/packages/adapter-api/src/change.ts
+++ b/packages/adapter-api/src/change.ts
@@ -16,7 +16,7 @@
 import {
   AdditionDiff, ModificationDiff, RemovalDiff, ActionName,
 } from '@salto-io/dag'
-import { values as lowerDashValues } from '@salto-io/lowerdash'
+import { values as lowerDashValues, collections } from '@salto-io/lowerdash'
 import {
   ObjectType, InstanceElement, Field, isInstanceElement, isObjectType, isField, TypeElement,
 } from './elements'
@@ -86,10 +86,12 @@ export const isFieldChange = <T extends Change<unknown>>(change: T):
     isField(getChangeData(change))
   )
 
+export type PathIndex = collections.treeMap.TreeMap<string>
+
 export type DetailedChange<T = ChangeDataType | Values | Value> =
   Change<T> & {
     id: ElemID
-    path?: ReadonlyArray<string>
+    pathIndex?: PathIndex
   }
 
 export type ChangeParams<T> = { before?: T; after?: T }

--- a/packages/adapter-api/src/change.ts
+++ b/packages/adapter-api/src/change.ts
@@ -86,12 +86,10 @@ export const isFieldChange = <T extends Change<unknown>>(change: T):
     isField(getChangeData(change))
   )
 
-export type PathIndex = collections.treeMap.TreeMap<string>
-
 export type DetailedChange<T = ChangeDataType | Values | Value> =
   Change<T> & {
     id: ElemID
-    pathIndex?: PathIndex
+    pathIndex?: collections.treeMap.TreeMap<string>
   }
 
 export type ChangeParams<T> = { before?: T; after?: T }

--- a/packages/adapter-api/src/elements.ts
+++ b/packages/adapter-api/src/elements.ts
@@ -366,7 +366,9 @@ export class PrimitiveType<Primitive extends PrimitiveTypes = PrimitiveTypes> ex
       primitive: this.primitive,
       annotationRefsOrTypes: this.cloneAnnotationTypes(),
       annotations: this.cloneAnnotations(),
-      path: this.pathIndex !== undefined ? this.pathIndex.clone() : undefined,
+      path: this.pathIndex !== undefined
+        ? new collections.treeMap.TreeMap<string>(this.pathIndex.entries())
+        : undefined,
     })
     res.annotate(additionalAnnotations)
     return res
@@ -438,7 +440,9 @@ export class ObjectType extends Element {
       annotationRefsOrTypes: this.cloneAnnotationTypes(),
       annotations: this.cloneAnnotations(),
       isSettings,
-      path: this.pathIndex !== undefined ? this.pathIndex.clone() : undefined,
+      path: this.pathIndex !== undefined
+        ? new collections.treeMap.TreeMap<string>(this.pathIndex.entries())
+        : undefined,
     })
 
     res.annotate(additionalAnnotations)
@@ -498,7 +502,9 @@ export class InstanceElement extends Element {
       this.elemID.name,
       this.refType.clone(),
       cloneDeepWithoutRefs(this.value),
-      this.pathIndex,
+      this.pathIndex !== undefined
+        ? new collections.treeMap.TreeMap<string>(this.pathIndex.entries())
+        : undefined,
       cloneDeepWithoutRefs(this.annotations),
     )
   }
@@ -516,7 +522,13 @@ export class Variable extends Element {
   }
 
   clone(): Variable {
-    return new Variable(this.elemID, cloneDeepWithoutRefs(this.value), this.pathIndex)
+    return new Variable(
+      this.elemID,
+      cloneDeepWithoutRefs(this.value),
+      this.pathIndex !== undefined
+        ? new collections.treeMap.TreeMap<string>(this.pathIndex.entries())
+        : undefined,
+    )
   }
 }
 

--- a/packages/adapter-api/src/elements.ts
+++ b/packages/adapter-api/src/elements.ts
@@ -142,6 +142,13 @@ export abstract class Element {
    * @return {Type} the cloned instance
    */
   abstract clone(annotations?: Values): Element
+
+  /**
+   * Return a copy of this instance with only the ElemID - empty value.
+   * Needs to be implemented by each subclass as this is structure dependent.
+   * @return {Type} the cloned instance
+   */
+   abstract cloneEmpty(annotations?: Values): Element
 }
 export type ElementMap = Record<string, Element>
 
@@ -192,6 +199,10 @@ export class ListType<T extends TypeElement = TypeElement> extends Element {
   }
 
   clone(): ListType {
+    return new ListType(this.refInnerType.clone())
+  }
+
+  cloneEmpty(): ListType {
     return new ListType(this.refInnerType.clone())
   }
 
@@ -252,6 +263,10 @@ export class MapType<T extends TypeElement = TypeElement> extends Element {
   }
 
   clone(): MapType {
+    return new MapType(this.refInnerType.clone())
+  }
+
+  cloneEmpty(): MapType {
     return new MapType(this.refInnerType.clone())
   }
 
@@ -326,6 +341,14 @@ export class Field extends Element {
       annotations === undefined ? this.cloneAnnotations() : annotations,
     )
   }
+
+  cloneEmpty(): Field {
+    return new Field(
+      this.parent,
+      this.name,
+      this.refType.clone(),
+    )
+  }
 }
 export type FieldMap = Record<string, Field>
 
@@ -372,6 +395,13 @@ export class PrimitiveType<Primitive extends PrimitiveTypes = PrimitiveTypes> ex
     })
     res.annotate(additionalAnnotations)
     return res
+  }
+
+  cloneEmpty(): PrimitiveType {
+    return new PrimitiveType({
+      elemID: this.elemID,
+      primitive: this.primitive,
+    })
   }
 }
 
@@ -444,10 +474,16 @@ export class ObjectType extends Element {
         ? new collections.treeMap.TreeMap<string>(this.pathIndex.entries())
         : undefined,
     })
-
     res.annotate(additionalAnnotations)
-
     return res
+  }
+
+  cloneEmpty(): ObjectType {
+    const { isSettings } = this
+    return new ObjectType({
+      elemID: this.elemID,
+      isSettings,
+    })
   }
 }
 
@@ -508,6 +544,13 @@ export class InstanceElement extends Element {
       cloneDeepWithoutRefs(this.annotations),
     )
   }
+
+  cloneEmpty(): InstanceElement {
+    return new InstanceElement(
+      this.elemID.name,
+      this.refType.clone(),
+    )
+  }
 }
 
 export class Variable extends Element {
@@ -529,6 +572,10 @@ export class Variable extends Element {
         ? new collections.treeMap.TreeMap<string>(this.pathIndex.entries())
         : undefined,
     )
+  }
+
+  cloneEmpty(): Variable {
+    return new Variable(this.elemID, undefined)
   }
 }
 

--- a/packages/adapter-api/src/elements.ts
+++ b/packages/adapter-api/src/elements.ts
@@ -203,7 +203,7 @@ export class ListType<T extends TypeElement = TypeElement> extends Element {
   }
 
   cloneEmpty(): ListType {
-    return new ListType(this.refInnerType.clone())
+    return this.clone()
   }
 
   async getInnerType(elementsSource?: ReadOnlyElementsSource): Promise<TypeElement> {
@@ -267,7 +267,7 @@ export class MapType<T extends TypeElement = TypeElement> extends Element {
   }
 
   cloneEmpty(): MapType {
-    return new MapType(this.refInnerType.clone())
+    return this.clone()
   }
 
   async getInnerType(elementsSource?: ReadOnlyElementsSource): Promise<TypeElement> {

--- a/packages/adapter-api/test/elements.test.ts
+++ b/packages/adapter-api/test/elements.test.ts
@@ -18,7 +18,8 @@ import { BuiltinTypes, CORE_ANNOTATIONS } from '../src/builtins'
 import {
   Field, InstanceElement, ObjectType, PrimitiveType, isObjectType, isInstanceElement,
   PrimitiveTypes, ListType, isPrimitiveType, isType, isListType, isEqualElements, Variable,
-  isVariable, isMapType, MapType, isContainerType, createRefToElmWithValue, PlaceholderObjectType,
+  isVariable, isMapType, MapType, isContainerType, createRefToElmWithValue,
+  PlaceholderObjectType, createPathIndexFromPath,
 } from '../src/elements'
 import { ElemID, INSTANCE_ANNOTATIONS } from '../src/element_id'
 import { TypeReference } from '../src/values'
@@ -75,7 +76,8 @@ describe('Test elements.ts', () => {
       annotations: {},
       path: ['testPath'],
     })
-    expect(primToClone.clone().path).toEqual(['testPath'])
+    expect(primToClone.clone().pathIndex)
+      .toEqual(createPathIndexFromPath(primID, ['testPath']))
   })
 
   it('should create a basic object type with all params passed to the constructor', async () => {
@@ -130,7 +132,8 @@ describe('Test elements.ts', () => {
         path: ['a', 'b', 'c', 'd'],
       })
       const newObj = obj.clone()
-      expect(newObj.path).toEqual(['a', 'b', 'c', 'd'])
+      expect(newObj.pathIndex)
+        .toEqual(createPathIndexFromPath(otID, ['a', 'b', 'c', 'd']))
     })
 
     it('should identify equal fields', () => {

--- a/packages/adapter-api/test/elements.test.ts
+++ b/packages/adapter-api/test/elements.test.ts
@@ -68,7 +68,7 @@ describe('Test elements.ts', () => {
     expect(primNum.primitive).toBe(PrimitiveTypes.NUMBER)
   })
 
-  it('should clone path when a primitive type is cloned', () => {
+  it('should clone pathIndex when a primitive type is cloned', () => {
     const primToClone = new PrimitiveType({
       elemID: primID,
       primitive: PrimitiveTypes.STRING,
@@ -76,8 +76,8 @@ describe('Test elements.ts', () => {
       annotations: {},
       path: ['testPath'],
     })
-    expect(primToClone.clone().pathIndex)
-      .toEqual(createPathIndexFromPath(primID, ['testPath']))
+    expect(Array.from(primToClone.clone().pathIndex?.entries() ?? []))
+      .toEqual([[primID.getFullName(), ['testPath']]])
   })
 
   it('should create a basic object type with all params passed to the constructor', async () => {
@@ -892,6 +892,103 @@ describe('Test elements.ts', () => {
     it('Should return placeholder type if type is not ObjectType', async () => {
       const instance = new InstanceElement('instance', BuiltinTypes.STRING as unknown as ObjectType)
       expect(await instance.getType()).toBeInstanceOf(PlaceholderObjectType)
+    })
+  })
+  describe('cloneEmpty', () => {
+    const elemID = new ElemID('adapter', 'test')
+    describe('ObjectType', () => {
+      it('should clone an empty element', async () => {
+        const objType = new ObjectType({
+          elemID,
+          fields: {
+            f1: {
+              refType: BuiltinTypes.BOOLEAN,
+              annotations: { f1Anno: 1 },
+            },
+          },
+          annotations: { test: 1 },
+          annotationRefsOrTypes: { test: BuiltinTypes.NUMBER },
+          path: ['path'],
+        })
+        const emptyCloned = objType.cloneEmpty()
+        expect(emptyCloned.elemID).toEqual(objType.elemID)
+        expect(emptyCloned.annotations).toEqual({})
+        expect(emptyCloned.annotations).not.toEqual(objType.annotations)
+        expect(emptyCloned.annotationRefTypes).toEqual({})
+        expect(emptyCloned.annotationRefTypes).not.toEqual(objType.annotationRefTypes)
+        expect(emptyCloned.fields).toEqual({})
+        expect(emptyCloned.fields).not.toEqual(objType.fields)
+        expect(emptyCloned.pathIndex).toEqual(undefined)
+        expect(emptyCloned.pathIndex).not.toEqual(objType.pathIndex)
+      })
+    })
+    describe('Field', () => {
+      it('should clone an empty element', async () => {
+        const field = new Field(
+          new ObjectType({ elemID }), 'f1', BuiltinTypes.NUMBER, { f1Anno: 1 }
+        )
+        field.annotationRefTypes.f1Anno = createRefToElmWithValue(BuiltinTypes.NUMBER)
+        const emptyCloned = field.cloneEmpty()
+        expect(emptyCloned.elemID).toEqual(field.elemID)
+        expect(emptyCloned.annotations).toEqual({})
+        expect(emptyCloned.annotations).not.toEqual(field.annotations)
+        expect(emptyCloned.annotationRefTypes).toEqual({})
+        expect(emptyCloned.annotationRefTypes).not.toEqual(field.annotationRefTypes)
+      })
+    })
+    describe('InstanceElement', () => {
+      it('should clone an empty element', async () => {
+        const instance = new InstanceElement(
+          'test', new ObjectType({ elemID }), { f1: true }, ['path'], { i1Anno: 'hello' }
+        )
+        instance.annotationRefTypes.i1Anno = createRefToElmWithValue(BuiltinTypes.STRING)
+        const emptyCloned = instance.cloneEmpty()
+        expect(emptyCloned.elemID).toEqual(instance.elemID)
+        expect(emptyCloned.annotations).toEqual({})
+        expect(emptyCloned.annotations).not.toEqual(instance.annotations)
+        expect(emptyCloned.annotationRefTypes).toEqual({})
+        expect(emptyCloned.annotationRefTypes).not.toEqual(instance.annotationRefTypes)
+        expect(emptyCloned.value).toEqual({})
+        expect(emptyCloned.value).not.toEqual(instance.value)
+        expect(emptyCloned.pathIndex).toEqual(undefined)
+        expect(emptyCloned.pathIndex).not.toEqual(instance.pathIndex)
+      })
+    })
+    describe('PrimitiveType', () => {
+      it('should clone an empty element', async () => {
+        const primitiveType = new PrimitiveType({
+          elemID,
+          primitive: 1,
+          annotations: { pt1Anno: 1 },
+          annotationRefsOrTypes: { pt1Anno: BuiltinTypes.NUMBER },
+          path: ['path'],
+        })
+        const emptyCloned = primitiveType.cloneEmpty()
+        expect(emptyCloned.elemID).toEqual(primitiveType.elemID)
+        expect(emptyCloned.annotations).toEqual({})
+        expect(emptyCloned.annotations).not.toEqual(primitiveType.annotations)
+        expect(emptyCloned.annotationRefTypes).toEqual({})
+        expect(emptyCloned.annotationRefTypes).not.toEqual(primitiveType.annotationRefTypes)
+        expect(emptyCloned.pathIndex).toEqual(undefined)
+        expect(emptyCloned.pathIndex).not.toEqual(primitiveType.pathIndex)
+      })
+      describe('Variable', () => {
+        it('should clone an empty element', async () => {
+          const variable = new Variable(elemID, 1, ['path'])
+          variable.annotations = { v1Anno: 2 }
+          variable.annotationRefTypes.v1Anno = createRefToElmWithValue(BuiltinTypes.NUMBER)
+          const emptyCloned = variable.cloneEmpty()
+          expect(emptyCloned.elemID).toEqual(variable.elemID)
+          expect(emptyCloned.value).toEqual(undefined)
+          expect(emptyCloned.value).not.toEqual(variable.value)
+          expect(emptyCloned.annotations).toEqual({})
+          expect(emptyCloned.annotations).not.toEqual(variable.annotations)
+          expect(emptyCloned.annotationRefTypes).toEqual({})
+          expect(emptyCloned.annotationRefTypes).not.toEqual(variable.annotationRefTypes)
+          expect(emptyCloned.pathIndex).toEqual(undefined)
+          expect(emptyCloned.pathIndex).not.toEqual(variable.pathIndex)
+        })
+      })
     })
   })
 })

--- a/packages/adapter-components/src/elements/ducktype/transformer.ts
+++ b/packages/adapter-components/src/elements/ducktype/transformer.ts
@@ -200,7 +200,7 @@ const getEntriesForType = async (
   })
   return {
     instances: instances.map(inst => new InstanceElement(
-      inst.elemID.name, newType, inst.value, inst.path, inst.annotations,
+      inst.elemID.name, newType, inst.value, inst.pathIndex, inst.annotations,
     )),
     type: newType,
     nestedTypes: newNestedTypes.concat(nestedFieldDetails ? type : []),

--- a/packages/adapter-components/src/elements/type_elements.ts
+++ b/packages/adapter-components/src/elements/type_elements.ts
@@ -16,7 +16,10 @@
 */
 import _ from 'lodash'
 import { FieldDefinition, Field, CORE_ANNOTATIONS, TypeElement, isObjectType, isContainerType,
-  getDeepInnerType, ObjectType, BuiltinTypes, createRestriction, createRefToElmWithValue, PrimitiveType, LIST_ID_PREFIX, GENERIC_ID_PREFIX, GENERIC_ID_SUFFIX, MAP_ID_PREFIX, ListType, MapType, isEqualElements, isPrimitiveType, PrimitiveTypes, isTypeReference } from '@salto-io/adapter-api'
+  getDeepInnerType, ObjectType, BuiltinTypes, createRestriction, createRefToElmWithValue,
+  PrimitiveType, LIST_ID_PREFIX, GENERIC_ID_PREFIX, GENERIC_ID_SUFFIX, MAP_ID_PREFIX, ListType,
+  MapType, isEqualElements, isPrimitiveType, PrimitiveTypes, isTypeReference,
+  createPathIndexFromPath } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { values, collections } from '@salto-io/lowerdash'
 import { FieldToHideType, FieldTypeOverrideType, getTypeTransformationConfig } from '../config/transformation'
@@ -107,8 +110,10 @@ export const filterTypes = async (
   }).filter(values.isDefined)
 
   relevantTypes
-    .filter(t => t.path === undefined)
-    .forEach(t => { t.path = [adapterName, TYPES_PATH, t.elemID.name] })
+    .filter(t => t.pathIndex === undefined)
+    .forEach(t => {
+      t.pathIndex = createPathIndexFromPath(t.elemID, [adapterName, TYPES_PATH, t.elemID.name])
+    })
 
   const innerObjectTypes = await awu(relevantTypes)
     .filter(isContainerType)
@@ -118,8 +123,12 @@ export const filterTypes = async (
 
   const subtypes = await getSubtypes([...relevantTypes.filter(isObjectType), ...innerObjectTypes])
   subtypes
-    .filter(t => t.path === undefined)
-    .forEach(t => { t.path = [adapterName, TYPES_PATH, SUBTYPES_PATH, t.elemID.name] })
+    .filter(t => t.pathIndex === undefined)
+    .forEach(t => {
+      t.pathIndex = createPathIndexFromPath(
+        t.elemID, [adapterName, TYPES_PATH, SUBTYPES_PATH, t.elemID.name]
+      )
+    })
 
   return [...relevantTypes, ...subtypes]
 }

--- a/packages/adapter-components/test/elements/ducktype/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/ducktype/instance_elements.test.ts
@@ -14,7 +14,8 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { ObjectType, ElemID, InstanceElement, BuiltinTypes, ReferenceExpression } from '@salto-io/adapter-api'
+import { ObjectType, ElemID, InstanceElement, BuiltinTypes, ReferenceExpression,
+  createPathIndexFromPath } from '@salto-io/adapter-api'
 // eslint-disable-next-line
 import { toInstance } from '../../../src/elements/ducktype'
 import { RECORDS_PATH } from '../../../src/elements/constants'
@@ -69,7 +70,8 @@ describe('ducktype_instance_elements', () => {
         type,
         entry,
       ))).toBeTruthy()
-      expect(inst?.path).toEqual([ADAPTER_NAME, RECORDS_PATH, 'bla', 'some_other_name'])
+      expect(inst?.pathIndex)
+        .toEqual(createPathIndexFromPath(inst?.elemID as ElemID, [ADAPTER_NAME, RECORDS_PATH, 'bla', 'some_other_name']))
     })
     it('should use fileNameFields for path when available', async () => {
       const inst = await toInstance({
@@ -92,7 +94,8 @@ describe('ducktype_instance_elements', () => {
         type,
         entry,
       ))).toBeTruthy()
-      expect(inst?.path).toEqual([ADAPTER_NAME, RECORDS_PATH, 'bla', '54775_some_other_name'])
+      expect(inst?.pathIndex)
+        .toEqual(createPathIndexFromPath(inst?.elemID as ElemID, [ADAPTER_NAME, RECORDS_PATH, 'bla', '54775_some_other_name']))
     })
     it('should convert number id fields to string', async () => {
       const inst = await toInstance({
@@ -114,7 +117,8 @@ describe('ducktype_instance_elements', () => {
         type,
         entry,
       ))).toBeTruthy()
-      expect(inst?.path).toEqual([ADAPTER_NAME, RECORDS_PATH, 'bla', 'some_other_name_54775'])
+      expect(inst?.pathIndex)
+        .toEqual(createPathIndexFromPath(inst?.elemID as ElemID, [ADAPTER_NAME, RECORDS_PATH, 'bla', 'some_other_name_54775']))
     })
     it('should escape id part when it only contains digits', async () => {
       const inst = await toInstance({
@@ -136,7 +140,8 @@ describe('ducktype_instance_elements', () => {
         type,
         entry,
       ))).toBeTruthy()
-      expect(inst?.path).toEqual([ADAPTER_NAME, RECORDS_PATH, 'bla', '54775'])
+      expect(inst?.pathIndex)
+        .toEqual(createPathIndexFromPath(inst?.elemID as ElemID, [ADAPTER_NAME, RECORDS_PATH, 'bla', '54775']))
     })
     it('should include parent name when nestName is true', async () => {
       const parent = new InstanceElement('abc', type, {})
@@ -165,7 +170,8 @@ describe('ducktype_instance_elements', () => {
           _parent: [new ReferenceExpression(parent.elemID)],
         }
       ))).toBeTruthy()
-      expect(inst?.path).toEqual([ADAPTER_NAME, RECORDS_PATH, 'bla', 'abc__some_other_name'])
+      expect(inst?.pathIndex)
+        .toEqual(createPathIndexFromPath(inst?.elemID as ElemID, [ADAPTER_NAME, RECORDS_PATH, 'bla', 'abc__some_other_name']))
     })
     it('should omit fields from the top level', async () => {
       const inst = await toInstance({
@@ -354,7 +360,8 @@ describe('ducktype_instance_elements', () => {
         type,
         entry,
       ))).toBeTruthy()
-      expect(inst?.path).toEqual([ADAPTER_NAME, RECORDS_PATH, 'bla', instanceName])
+      expect(inst?.pathIndex)
+        .toEqual(createPathIndexFromPath(inst?.elemID as ElemID, [ADAPTER_NAME, RECORDS_PATH, 'bla', instanceName]))
     })
   })
 })

--- a/packages/adapter-components/test/elements/ducktype/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/ducktype/type_elements.test.ts
@@ -80,7 +80,13 @@ describe('ducktype_type_elements', () => {
       })
       expect(nestedTypes).toHaveLength(1)
       expect(type.fields.name.refType.elemID.getFullName()).toEqual('Map<myAdapter.typeName__nested>')
-      expect(type.path).toEqual([ADAPTER_NAME, TYPES_PATH, 'typeName'])
+      expect(Array.from(type.pathIndex?.entries() ?? []))
+        .toEqual([
+          [
+            type.elemID.getFullName(),
+            [ADAPTER_NAME, TYPES_PATH, 'typeName'],
+          ],
+        ])
     })
     it('should override field types for types with fieldTypeOverrides even if there are no entries', () => {
       const entries: Values[] = []

--- a/packages/adapter-components/test/elements/ducktype/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/ducktype/type_elements.test.ts
@@ -53,7 +53,13 @@ describe('ducktype_type_elements', () => {
       })
       expect(type.isEqual(new ObjectType({ elemID: new ElemID(ADAPTER_NAME, 'typeName'), fields: { name: { refType: BuiltinTypes.NUMBER } } }))).toBeTruthy()
       expect(nestedTypes).toHaveLength(0)
-      expect(type.path).toEqual([ADAPTER_NAME, TYPES_PATH, 'typeName'])
+      expect(Array.from(type.pathIndex?.entries() ?? []))
+        .toEqual([
+          [
+            type.elemID.getFullName(),
+            [ADAPTER_NAME, TYPES_PATH, 'typeName'],
+          ],
+        ])
     })
     it('should override field types for types with nested fieldTypeOverrides', () => {
       const entries: Values[] = [{
@@ -89,7 +95,13 @@ describe('ducktype_type_elements', () => {
       })
       expect(type.isEqual(new ObjectType({ elemID: new ElemID(ADAPTER_NAME, 'typeName'), fields: { id: { refType: BuiltinTypes.NUMBER } } }))).toBeTruthy()
       expect(nestedTypes).toHaveLength(0)
-      expect(type.path).toEqual([ADAPTER_NAME, TYPES_PATH, 'typeName'])
+      expect(Array.from(type.pathIndex?.entries() ?? []))
+        .toEqual([
+          [
+            type.elemID.getFullName(),
+            [ADAPTER_NAME, TYPES_PATH, 'typeName'],
+          ],
+        ])
     })
     it('should generate types recursively with correct fields when hasDynamicFields=false', () => {
       const entries = [

--- a/packages/adapter-components/test/elements/ducktype/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/ducktype/type_elements.test.ts
@@ -13,7 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ObjectType, Values, ElemID, BuiltinTypes, MapType, ListType } from '@salto-io/adapter-api'
+import { ObjectType, Values, ElemID, BuiltinTypes, MapType, ListType,
+  createPathIndexFromPath } from '@salto-io/adapter-api'
 // eslint-disable-next-line
 import { generateType, toNestedTypeName } from '../../../src/elements/ducktype'
 import { TYPES_PATH, SUBTYPES_PATH } from '../../../src/elements'
@@ -36,7 +37,8 @@ describe('ducktype_type_elements', () => {
       })
       expect(type.isEqual(new ObjectType({ elemID: new ElemID(ADAPTER_NAME, 'typeName'), fields: {} }))).toBeTruthy()
       expect(nestedTypes).toHaveLength(0)
-      expect(type.path).toEqual([ADAPTER_NAME, TYPES_PATH, 'typeName'])
+      expect(type.pathIndex)
+        .toEqual(createPathIndexFromPath(type.elemID, [ADAPTER_NAME, TYPES_PATH, 'typeName']))
     })
     it('should override field types for types with fieldTypeOverrides', () => {
       const entries: Values[] = [{ name: 'test' }]
@@ -588,7 +590,8 @@ describe('ducktype_type_elements', () => {
         fields: {},
       }))).toBeTruthy()
       expect(nestedTypes).toHaveLength(0)
-      expect(type.path).toEqual([ADAPTER_NAME, TYPES_PATH, 'typeName_requiring_naclcase'])
+      expect(type.pathIndex)
+        .toEqual(createPathIndexFromPath(type.elemID, [ADAPTER_NAME, TYPES_PATH, 'typeName_requiring_naclcase']))
     })
     it('should use subtypes path for subtypes', () => {
       const entries: Values[] = []
@@ -606,7 +609,8 @@ describe('ducktype_type_elements', () => {
         fields: {},
       }))).toBeTruthy()
       expect(nestedTypes).toHaveLength(0)
-      expect(type.path).toEqual([ADAPTER_NAME, TYPES_PATH, SUBTYPES_PATH, 'parent_type', 'subtypeName'])
+      expect(type.pathIndex)
+        .toEqual(createPathIndexFromPath(type.elemID, [ADAPTER_NAME, TYPES_PATH, SUBTYPES_PATH, 'parent_type', 'subtypeName']))
     })
     it('should mark singleton types as isSettings=true', () => {
       const entries = [

--- a/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
@@ -15,7 +15,7 @@
 */
 
 import { collections } from '@salto-io/lowerdash'
-import { ObjectType, ElemID, BuiltinTypes, ListType, MapType, InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
+import { ObjectType, ElemID, BuiltinTypes, ListType, MapType, InstanceElement, ReferenceExpression, createPathIndexFromPath } from '@salto-io/adapter-api'
 import { mockFunction } from '@salto-io/test-utils'
 import { getAllInstances } from '../../../src/elements/swagger'
 import { returnFullEntry } from '../../../src/elements/field_finder'
@@ -1419,13 +1419,8 @@ describe('swagger_instance_elements', () => {
       expect(res.map(e => e.elemID.name)).toEqual([
         `${ElemID.CONFIG_NAME}`,
       ])
-      expect(res.map(e => e.path)).toEqual([
-        [
-          ADAPTER_NAME,
-          'Records',
-          'Settings',
-          'Owner',
-        ],
+      expect(res.map(e => e.pathIndex)).toEqual([
+        createPathIndexFromPath(res[0].elemID, [ADAPTER_NAME, 'Records', 'Settings', 'Owner']),
       ])
     })
     it('should fail if singleton type have more than one instance', async () => {

--- a/packages/adapter-components/test/elements/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/type_elements.test.ts
@@ -14,7 +14,8 @@
 * limitations under the License.
 */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { FieldDefinition, BuiltinTypes, ObjectType, ElemID, createRefToElmWithValue } from '@salto-io/adapter-api'
+import { FieldDefinition, BuiltinTypes, ObjectType, ElemID, createRefToElmWithValue,
+  createPathIndexFromPath } from '@salto-io/adapter-api'
 import { SUBTYPES_PATH, TYPES_PATH } from '../../src/elements/constants'
 import { filterTypes, hideFields, markServiceIdField } from '../../src/elements/type_elements'
 
@@ -101,11 +102,14 @@ describe('type_elements', () => {
       const filteredTypes = await filterTypes('adapterName', [typeA, typeC, typeD], ['C', 'E'])
 
       expect(filteredTypes[0].elemID.getFullNameParts()).toEqual(['adapterName', 'C'])
-      expect(filteredTypes[0].path).toEqual(['adapterName', TYPES_PATH, 'C'])
+      expect(filteredTypes[0].pathIndex)
+        .toEqual(createPathIndexFromPath(filteredTypes[0].elemID, ['adapterName', TYPES_PATH, 'C']))
       expect(filteredTypes[1].elemID.getFullNameParts()).toEqual(['adapterName', 'A'])
-      expect(filteredTypes[1].path).toEqual(['adapterName', TYPES_PATH, SUBTYPES_PATH, 'A'])
+      expect(filteredTypes[1].pathIndex)
+        .toEqual(createPathIndexFromPath(filteredTypes[1].elemID, ['adapterName', TYPES_PATH, SUBTYPES_PATH, 'A']))
       expect(filteredTypes[2].elemID.getFullNameParts()).toEqual(['adapterName', 'B'])
-      expect(filteredTypes[2].path).toEqual(['adapter', 'somePath'])
+      expect(filteredTypes[2].pathIndex)
+        .toEqual(createPathIndexFromPath(filteredTypes[2].elemID, ['adapter', 'somePath']))
     })
   })
 

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -75,7 +75,7 @@ export const toObjectType = (type: MapType | ObjectType | ListType, value: Value
         ])),
       annotationRefsOrTypes: type.annotationRefTypes,
       annotations: type.annotations,
-      path: type.path,
+      path: type.pathIndex,
     })
 )
 
@@ -335,7 +335,7 @@ export const transformElement = async <T extends Element>(
       element.elemID.name,
       element.refType,
       transformedValues,
-      element.path,
+      element.pathIndex,
       transformedAnnotations
     )
     return newElement as T
@@ -370,7 +370,7 @@ export const transformElement = async <T extends Element>(
       fields: clonedFields,
       annotationRefsOrTypes: element.annotationRefTypes,
       annotations: transformedAnnotations,
-      path: element.path,
+      path: element.pathIndex,
       isSettings: element.isSettings,
     })
 
@@ -393,7 +393,7 @@ export const transformElement = async <T extends Element>(
       elemID: element.elemID,
       primitive: element.primitive,
       annotationRefsOrTypes: element.annotationRefTypes,
-      path: element.path,
+      path: element.pathIndex,
       annotations: transformedAnnotations,
     })
 
@@ -738,7 +738,9 @@ export const flattenElementStr = (element: Element): Element => {
     annotations: flatValues(obj.annotations),
     fields: _(obj.fields).mapKeys((_v, k) => flatStr(k)).mapValues(flattenField).value(),
     isSettings: obj.isSettings,
-    path: obj.path?.map(flatStr),
+    // TODO: we did flat str here but I am not sure if its necessary.
+    //  if it is, we can implement it
+    path: obj.pathIndex,
   })
 
   const flattenPrimitiveType = (prim: PrimitiveType): PrimitiveType => new PrimitiveType({
@@ -746,14 +748,16 @@ export const flattenElementStr = (element: Element): Element => {
     primitive: prim.primitive,
     annotationRefsOrTypes: _.mapKeys(prim.annotationRefTypes, (_v, k) => flatStr(k)),
     annotations: flatValues(prim.annotations),
-    path: prim.path?.map(flatStr),
+    // TODO: we did flat str here but I am not sure if its necessary.
+    //  if it is, we can implement it
+    path: prim.pathIndex,
   })
 
   const flattenInstance = (inst: InstanceElement): InstanceElement => new InstanceElement(
     flatStr(inst.elemID.name),
     inst.refType,
     flatValues(inst.value),
-    inst.path?.map(flatStr),
+    inst.pathIndex,
     flatValues(inst.annotations)
   )
 
@@ -815,7 +819,7 @@ export const filterByID = async <T extends Element | Values>(
       annotations: await filterAnnotations(value.annotations),
       annotationRefsOrTypes: await filterAnnotationType(value.annotationRefTypes),
       fields: _.keyBy(filteredFields.filter(isDefined), field => field.name),
-      path: value.path,
+      path: value.pathIndex,
       isSettings: value.isSettings,
     }) as Value as T
   }
@@ -825,7 +829,7 @@ export const filterByID = async <T extends Element | Values>(
       annotations: await filterAnnotations(value.annotations),
       annotationRefsOrTypes: await filterAnnotationType(value.annotationRefTypes),
       primitive: value.primitive,
-      path: value.path,
+      path: value.pathIndex,
     }) as Value as T
   }
   if (isField(value)) {
@@ -841,7 +845,7 @@ export const filterByID = async <T extends Element | Values>(
       value.elemID.name,
       value.refType,
       await filterByID(value.elemID, value.value, filterFunc),
-      value.path,
+      value.pathIndex,
       await filterInstanceAnnotations(value.annotations)
     ) as Value as T
   }

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -1246,7 +1246,7 @@ describe('Test utils.ts', () => {
 
         expect(resolvedPrim.primitive).toEqual(prim.primitive)
         expect(resolvedPrim.elemID).toEqual(prim.elemID)
-        expect(resolvedPrim.path).toEqual(prim.path)
+        expect(resolvedPrim.pathIndex).toEqual(prim.pathIndex)
         expect(resolvedPrim.annotationRefTypes).toEqual(prim.annotationRefTypes)
 
         expect(resolvedPrim.annotations).not.toEqual(prim.annotations)
@@ -1289,7 +1289,7 @@ describe('Test utils.ts', () => {
         expect(resolvedField.getType()).toEqual(field.getType())
         expect(resolvedField.name).toEqual(field.name)
         expect(resolvedField.elemID).toEqual(field.elemID)
-        expect(resolvedField.path).toEqual(field.path)
+        expect(resolvedField.pathIndex).toEqual(field.pathIndex)
         expect(resolvedField.parent).toBe(field.parent)
 
         expect(resolvedField.annotations).not.toEqual(field.annotations)

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -22,6 +22,7 @@ import {
   AdapterAuthentication, OAuthRequestParameters, OauthAccessTokenResponse,
   createRefToElmWithValue,
   StaticFile,
+  createPathIndexFromPath,
 } from '@salto-io/adapter-api'
 import {
   Plan, PlanItem, EVENT_TYPES, DeployResult,
@@ -743,7 +744,10 @@ export const deploy = async (
 
 export const staticFileChange = (action: 'add' | 'modify' | 'remove', withContent = false): DetailedChange => {
   const id = new ElemID('salesforce')
-  const path = ['salesforce', 'Records', 'advancedpdftemplate', 'custtmpl_103_t2257860_156']
+  const path = createPathIndexFromPath(
+    id,
+    ['salesforce', 'Records', 'advancedpdftemplate', 'custtmpl_103_t2257860_156'],
+  )
   const beforeFile = new StaticFile({
     filepath: 'salesforce/advancedpdftemplate/custtmpl_103_t2257860_156.xml',
     encoding: 'binary',
@@ -759,12 +763,12 @@ export const staticFileChange = (action: 'add' | 'modify' | 'remove', withConten
 
   if (action === 'add') {
     const data = { after: afterFile }
-    return { id, action, data, path }
+    return { id, action, data, pathIndex: path }
   }
   if (action === 'modify') {
     const data = { before: beforeFile, after: afterFile }
-    return { id, action, data, path }
+    return { id, action, data, pathIndex: path }
   }
   const data = { before: beforeFile }
-  return { id, action, data, path }
+  return { id, action, data, pathIndex: path }
 }

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -151,7 +151,8 @@ const toChangesWithPath = (
       log.debug(`no path index was found for the top level element id ${changeID.getFullName()}`)
       return change
     }
-    const changePathIndex = pathIndex.getPathIndexOfId(changeID, parentPathIndex)
+    const changePathIndex = collections.treeMap.TreeMap
+      .getTreeMapOfId(parentPathIndex, changeID.getFullName())
     return _.merge({}, change, { change: { pathIndex: changePathIndex } })
   })
 

--- a/packages/core/src/core/list.ts
+++ b/packages/core/src/core/list.ts
@@ -103,7 +103,7 @@ export const listUnresolvedReferences = async (
           rootElem.elemID.name,
           rootElem.refType,
           {},
-          rootElem.path,
+          rootElem.pathIndex,
         )
         setPath(newInstance, id, val)
         return newInstance

--- a/packages/core/src/core/rename.ts
+++ b/packages/core/src/core/rename.ts
@@ -110,7 +110,7 @@ const getRenameElementChanges = async (
         targetElemId.name,
         element.refType,
         element.value,
-        element.path,
+        element.pathIndex,
         element.annotations
       ),
     },

--- a/packages/core/src/core/restore.ts
+++ b/packages/core/src/core/restore.ts
@@ -41,8 +41,7 @@ const splitChangeByPath = async (
     )
     return {
       ...filteredChange,
-      // TODO: (maybe) fix me!!! - I am not sure that this should be change.id
-      pathIndex: createPathIndexFromPath(change.id, hint as string[]),
+      pathIndex: createPathIndexFromPath(filteredChange.id, hint as string[]),
     }
   }))
 }

--- a/packages/core/src/core/restore.ts
+++ b/packages/core/src/core/restore.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { ElemID, DetailedChange, isRemovalChange } from '@salto-io/adapter-api'
+import { ElemID, DetailedChange, isRemovalChange, createPathIndexFromPath } from '@salto-io/adapter-api'
 import { filterByID, applyFunctionToChangeData } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { pathIndex, ElementSelector, elementSource, remoteMap } from '@salto-io/workspace'
@@ -41,7 +41,8 @@ const splitChangeByPath = async (
     )
     return {
       ...filteredChange,
-      path: hint,
+      // TODO: (maybe) fix me!!! - I am not sure that this should be change.id
+      pathIndex: createPathIndexFromPath(change.id, hint as string[]),
     }
   }))
 }

--- a/packages/core/test/core/diff.test.ts
+++ b/packages/core/test/core/diff.test.ts
@@ -196,7 +196,7 @@ describe('diff', () => {
         const removeChange = changes.find(c => c.action === 'remove')
         expect(removeChange).toBeDefined()
         expect(removeChange?.id).toEqual(singlePathObjMerged.elemID)
-        expect(removeChange?.path).toBeUndefined()
+        expect(removeChange?.pathIndex).toBeUndefined()
       })
       it('should create remove changes for elements which have different values in the fromElements and toElements', () => {
         const modifyChange = changes.find(c => c.action === 'modify')

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -24,6 +24,7 @@ import {
   TypeReference,
   StaticFile,
   isStaticFile,
+  createPathIndexFromPath,
 } from '@salto-io/adapter-api'
 import * as utils from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
@@ -674,17 +675,18 @@ describe('fetch', () => {
       describe('when adapter returns splitted elements with added nested elements', () => {
         describe('when nested elements are fields', () => {
           beforeEach(async () => {
+            // TODO: fix me!!!
             const newTypeBaseWPath = newTypeBase.clone()
-            newTypeBaseWPath.path = ['a', 'b']
+            newTypeBaseWPath.pathIndex = createPathIndexFromPath(newTypeBaseWPath.elemID, ['a', 'b'])
             const newTypeExtWPath = newTypeExt.clone()
-            newTypeExtWPath.path = ['c', 'd']
+            newTypeExtWPath.pathIndex = createPathIndexFromPath(newTypeExtWPath.elemID, ['c', 'd'])
             mockAdapters[newTypeDifferentAdapterID.adapter].fetch.mockResolvedValueOnce(
               Promise.resolve({ elements: [
                 newTypeBaseWPath,
                 newTypeExtWPath] })
             )
             const newTypeBaseWPathDifferentID = newTypeBaseDifferentAdapterID.clone()
-            newTypeBaseWPathDifferentID.path = ['a', 'b']
+            newTypeBaseWPathDifferentID.pathIndex = createPathIndexFromPath(newTypeBaseWPathDifferentID.elemID, ['a', 'b'])
             const result = await fetchChanges(
               mockAdapters,
               createElementSource([newTypeBaseWPathDifferentID]),
@@ -701,7 +703,7 @@ describe('fetch', () => {
           })
           it('should populate the change with the containing parent path', () => {
             expect(changes[0].change.id.getFullName()).toBe(`${newTypeDifferentAdapterID.adapter}.new.field.ext`)
-            expect(changes[0].change.path).toEqual(['c', 'd'])
+            expect(changes[0].change.pathIndex?.get(changes[0].change.id.getFullName())).toEqual(['c', 'd'])
           })
         })
         describe('when nested elements are annotations', () => {
@@ -743,7 +745,7 @@ describe('fetch', () => {
           })
           it('should populate the change with the containing parent path', () => {
             expect(changes[0].change.id.getFullName()).toBe(`${newTypeDifferentAdapterID.adapter}.new.attr.baba`)
-            expect(changes[0].change.path).toEqual(['c', 'd'])
+            expect(changes[0].change.pathIndex?.get(changes[0].change.id.getFullName())).toEqual(['c', 'd'])
           })
         })
       })

--- a/packages/core/test/core/restore.test.ts
+++ b/packages/core/test/core/restore.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Element, ObjectType, ElemID, BuiltinTypes, ListType, InstanceElement, DetailedChange, isAdditionChange, isRemovalChange, isModificationChange } from '@salto-io/adapter-api'
+import { Element, ObjectType, ElemID, BuiltinTypes, ListType, InstanceElement, DetailedChange, isAdditionChange, isRemovalChange, isModificationChange, createPathIndexFromPath } from '@salto-io/adapter-api'
 import { merger, pathIndex, remoteMap } from '@salto-io/workspace'
 import { collections } from '@salto-io/lowerdash'
 import { createRestoreChanges } from '../../src/core/restore'
@@ -190,7 +190,7 @@ describe('restore', () => {
           expect(change.id).toEqual(multiPathObjMerged.elemID)
           expect(change.data.after.elemID).toEqual(change.id)
         })
-        const changePaths = addChanges.map(change => change.path)
+        const changePaths = addChanges.map(change => change.pathIndex?.get(change.id.getFullName()))
         expect(changePaths).toContainEqual(['salto', 'obj', 'multi', 'anno'])
         expect(changePaths).toContainEqual(['salto', 'obj', 'multi', 'fields'])
       })
@@ -199,14 +199,15 @@ describe('restore', () => {
         expect(removeChange).toBeDefined()
         expect(removeChange?.id).toEqual(singlePathObjMerged.elemID)
         expect(removeChange?.data.before.elemID).toEqual(removeChange?.id)
-        expect(removeChange?.path).toBeUndefined()
+        expect(removeChange?.pathIndex).toBeUndefined()
       })
       it('should create modify changes for elements which have different values in the state and ws with proper path', () => {
         const modifyChange = changes.find(isModificationChange)
         expect(modifyChange).toBeDefined()
         expect(modifyChange?.id).toEqual(singlePathInstMergedAfter.elemID
           .createNestedID('nested').createNestedID('str'))
-        expect(modifyChange?.path).toEqual(['salto', 'inst', 'simple'])
+        expect(modifyChange?.pathIndex)
+          .toEqual(createPathIndexFromPath(modifyChange?.id as ElemID, ['salto', 'inst', 'simple']))
       })
     })
   })

--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -546,25 +546,26 @@ export const generateElements = async (
       const annotationRefsOrTypes = generateAnnotationTypes(
         normalRandom(defaultParams.objectAnnoMean, defaultParams.objectAnnoStd)
       )
+      const elemID = new ElemID(DUMMY_ADAPTER, name)
+      const annotationsPath = [DUMMY_ADAPTER, 'Objects', name, `${name}Annotations`]
+      const fieldsPath = [DUMMY_ADAPTER, 'Objects', name, `${name}Fields`]
+      const fields = await generateFields()
       const fullObjType = new ObjectType({
-        elemID: new ElemID(DUMMY_ADAPTER, name),
-        fields: await generateFields(),
+        elemID,
+        fields,
         annotationRefsOrTypes,
         annotations: await generateAnnotations(annotationRefsOrTypes),
-      })
-      const fieldsObjType = new ObjectType({
-        elemID: fullObjType.elemID,
-        fields: fullObjType.fields,
-        path: [DUMMY_ADAPTER, 'Objects', name, `${name}Fields`],
-      })
-      const annoTypesObjType = new ObjectType({
-        elemID: fullObjType.elemID,
-        annotationRefsOrTypes: await fullObjType.getAnnotationTypes(),
-        annotations: fullObjType.annotations,
-        path: [DUMMY_ADAPTER, 'Objects', name, `${name}Annotations`],
+        path: new collections.treeMap.TreeMap<string>([
+          [elemID.getFullName(), annotationsPath],
+          ...Object.keys(fields)
+            .map(fieldName => [
+              elemID.createNestedID('field', fieldName).getFullName(),
+              fieldsPath,
+            ] as [string, string[]]),
+        ]),
       })
       await updateElementRank(fullObjType)
-      return [fieldsObjType, annoTypesObjType]
+      return [fullObjType]
     }))).flat()
 
 

--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -24,6 +24,7 @@ import {
   DeployAction,
   createRestriction,
   SeverityLevel,
+  createPathIndexFromPath,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { uniqueNamesGenerator, adjectives, colors, names } from 'unique-names-generator'
@@ -259,6 +260,7 @@ const profileType = new ObjectType({
   path: [DUMMY_ADAPTER, 'Default', 'Profile'],
 })
 
+// TODO: fix me!!! - currently returns splitted elements
 export const generateElements = async (
   params: GeneratorParams,
   progressReporter: ProgressReporter
@@ -700,7 +702,10 @@ export const generateElements = async (
       })
 
       await awu(parsedNaclFile.elements).forEach(elem => {
-        elem.path = [DUMMY_ADAPTER, 'extra', file.basename.replace(new RegExp(`.${MOCK_NACL_SUFFIX}$`), '')]
+        elem.pathIndex = createPathIndexFromPath(
+          elem.elemID,
+          [DUMMY_ADAPTER, 'extra', file.basename.replace(new RegExp(`.${MOCK_NACL_SUFFIX}$`), '')],
+        )
       })
       return parsedNaclFile.elements
     })).flat().toArray()

--- a/packages/dummy-adapter/test/generator.test.ts
+++ b/packages/dummy-adapter/test/generator.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { isObjectType, isInstanceElement, isPrimitiveType, isMapType, isListType } from '@salto-io/adapter-api'
+import { isObjectType, isInstanceElement, isPrimitiveType, isMapType, isListType, getTopLevelPath, createPathIndexFromPath, ElemID } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import path from 'path'
@@ -50,11 +50,11 @@ describe('elements generator', () => {
       const primitives = elements.filter(isPrimitiveType)
       const [types, objects] = _.partition(
         elements.filter(isObjectType),
-        e => e.path !== undefined && e.path[1] === 'Types'
+        e => e.pathIndex !== undefined && getTopLevelPath(e)[1] === 'Types'
       )
       const [profiles, records] = _.partition(
         elements.filter(isInstanceElement),
-        e => e.path !== undefined && e.path[2] === 'Profile'
+        e => e.pathIndex !== undefined && getTopLevelPath(e)[2] === 'Profile'
       )
       expect(primitives).toHaveLength(testParams.numOfPrimitiveTypes)
       expect(types).toHaveLength(testParams.numOfTypes)
@@ -91,7 +91,7 @@ describe('elements generator', () => {
         useOldProfiles: true,
       }, mockProgressReporter)
       const profiles = elements.filter(isInstanceElement).filter(
-        e => e.path !== undefined && e.path[2] === 'Profile'
+        e => e.pathIndex !== undefined && getTopLevelPath(e)[2] === 'Profile'
       )
       expect(profiles).toHaveLength(testParams.numOfProfiles)
     })
@@ -105,8 +105,11 @@ describe('elements generator', () => {
       const multiFilesObj = elements.filter(e => e.elemID.getFullName() === 'dummy.multiFilesObj')
       expect(singleFileObj).toBeDefined()
       expect(multiFilesObj).toHaveLength(2)
-      expect(singleFileObj?.path).toEqual(['dummy', 'extra', 'single'])
-      expect(multiFilesObj.map(e => e.path)).toEqual([
+      expect(singleFileObj?.pathIndex)
+        .toEqual(createPathIndexFromPath(
+          singleFileObj?.elemID as ElemID, ['dummy', 'extra', 'single']
+        ))
+      expect(multiFilesObj.map(e => e.pathIndex)).toEqual([
         ['dummy', 'extra', 'multi1'],
         ['dummy', 'extra', 'multi2'],
       ])

--- a/packages/dummy-adapter/test/generator.test.ts
+++ b/packages/dummy-adapter/test/generator.test.ts
@@ -97,12 +97,13 @@ describe('elements generator', () => {
     })
 
     it('should return elements in the extra nacl dir', async () => {
+      const multiFileElemID = new ElemID('dummy', 'multiFilesObj')
       const elements = await generateElements({
         ...testParams,
         extraNaclPath: EXTRA_NACL_PATH,
       }, mockProgressReporter)
       const singleFileObj = elements.find(e => e.elemID.getFullName() === 'dummy.singleFileObj')
-      const multiFilesObj = elements.filter(e => e.elemID.getFullName() === 'dummy.multiFilesObj')
+      const multiFilesObj = elements.filter(e => e.elemID.isEqual(multiFileElemID))
       expect(singleFileObj).toBeDefined()
       expect(multiFilesObj).toHaveLength(2)
       expect(singleFileObj?.pathIndex)
@@ -110,8 +111,8 @@ describe('elements generator', () => {
           singleFileObj?.elemID as ElemID, ['dummy', 'extra', 'single']
         ))
       expect(multiFilesObj.map(e => e.pathIndex)).toEqual([
-        ['dummy', 'extra', 'multi1'],
-        ['dummy', 'extra', 'multi2'],
+        createPathIndexFromPath(multiFileElemID, ['dummy', 'extra', 'multi1']),
+        createPathIndexFromPath(multiFileElemID, ['dummy', 'extra', 'multi2']),
       ])
     })
 

--- a/packages/jira-adapter/src/filters/duplicate_ids.ts
+++ b/packages/jira-adapter/src/filters/duplicate_ids.ts
@@ -80,7 +80,7 @@ If changing the names is not possible, you can add the fetch.fallbackToInternalI
         getInstanceName(instance),
         instance.refType,
         instance.value,
-        instance.path,
+        instance.pathIndex,
         instance.annotations,
       ))
 

--- a/packages/jira-adapter/src/filters/field_configuration/field_configuration_split.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/field_configuration_split.ts
@@ -27,7 +27,7 @@ const createFieldItemInstance = (
   naclCase(`${instance.elemID.name}_${fieldItemValues.id.elemID.name}`),
   fieldItemType,
   fieldItemValues,
-  instance.path,
+  instance.pathIndex,
   {
     [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(instance.elemID, instance)],
   }

--- a/packages/jira-adapter/src/filters/fields/field_name_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/field_name_filter.ts
@@ -93,7 +93,7 @@ const filter: FilterCreator = ({ config, getElemIdFunc }) => ({
           name,
           instance.refType,
           instance.value,
-          instance.path,
+          instance.pathIndex,
           instance.annotations,
         )
       })

--- a/packages/lowerdash/src/collections/tree_map.ts
+++ b/packages/lowerdash/src/collections/tree_map.ts
@@ -195,6 +195,32 @@ export class TreeMap<T> implements Map<string, T[]> {
       wu(this.entries()).map(entry => (cloneEntry ? cloneEntry(entry) : _.cloneDeep(entry)))
     )
   }
+
+  // This function returns the value of the id if exists.
+  // Otherwise, it returns the value of its first ancestor that has a value
+  getClosestValue(id: string): T[] {
+    const idParts = id.split(this.separator)
+    let key: string
+    do {
+      key = idParts.join(this.separator)
+      const value = this.get(key)
+      if (value !== undefined) {
+        return value
+      }
+      idParts.pop()
+    } while (idParts.length > 0)
+    return []
+  }
+
+  static getTreeMapOfId = <S>(
+    treeMap: TreeMap<S>,
+    id: string,
+  ): TreeMap<S> => (
+    new TreeMap([
+      ...(treeMap.has(id) ? [] : [[id, treeMap.getClosestValue(id)] as [string, S[]]]),
+      ...treeMap.entriesWithPrefix(id),
+    ])
+  )
 }
 
 export class PartialTreeMap<T> extends TreeMap<T> {

--- a/packages/lowerdash/src/collections/tree_map.ts
+++ b/packages/lowerdash/src/collections/tree_map.ts
@@ -177,15 +177,6 @@ export class TreeMap<T> implements Map<string, T[]> {
     this.iterEntry(this.data).forEach(([key, value]) => callbackfn(value, key, this))
   }
 
-  valuesWithPrefix(prefix: string): IterableIterator<T[]> {
-    const path = prefix.split(this.separator)
-    const prefixSubtree = TreeMap.getFromPath(this.data, path)
-    if (prefixSubtree === undefined) {
-      return wu([])
-    }
-    return this.iterEntry(prefixSubtree, path).map(([_key, values]) => values)
-  }
-
   entriesWithPrefix(prefix: string): IterableIterator<[string, T[]]> {
     const path = prefix.split(this.separator)
     const prefixSubtree = TreeMap.getFromPath(this.data, path)
@@ -195,9 +186,14 @@ export class TreeMap<T> implements Map<string, T[]> {
     return this.iterEntry(prefixSubtree, path)
   }
 
-  clone(): TreeMap<T> {
-    // TODO: this isn't really cloning - we need to reimplement it
-    return new TreeMap(this.entries())
+  valuesWithPrefix(prefix: string): IterableIterator<T[]> {
+    return wu(this.entriesWithPrefix(prefix)).map(([_key, values]) => values)
+  }
+
+  clone(cloneEntry?: (entry: [string, T[]]) => [string, T[]]): TreeMap<T> {
+    return new TreeMap(
+      wu(this.entries()).map(entry => (cloneEntry ? cloneEntry(entry) : _.cloneDeep(entry)))
+    )
   }
 }
 

--- a/packages/lowerdash/src/collections/tree_map.ts
+++ b/packages/lowerdash/src/collections/tree_map.ts
@@ -173,6 +173,11 @@ export class TreeMap<T> implements Map<string, T[]> {
     }
     return this.iterEntry(prefixSubtree, path).map(([_key, values]) => values)
   }
+
+  clone(): TreeMap<T> {
+    // TODO: this isn't really cloning - we need to reimplement it
+    return new TreeMap(this.entries())
+  }
 }
 
 export class PartialTreeMap<T> extends TreeMap<T> {

--- a/packages/lowerdash/test/collections/tree_map.test.ts
+++ b/packages/lowerdash/test/collections/tree_map.test.ts
@@ -259,4 +259,92 @@ describe('tree map', () => {
       })
     })
   })
+  describe('entriesWithPrefix', () => {
+    let tree: TreeMap<string>
+    beforeEach(() => {
+      tree = new TreeMap(baseEntries, separator)
+    })
+    describe('when iterating a prefix that exists', () => {
+      let iteratedEntries: [string, string[]][]
+      beforeEach(() => {
+        iteratedEntries = [...tree.entriesWithPrefix('salesforce|test')]
+      })
+      it('should iterate all values with the given prefix', () => {
+        expect(iteratedEntries).toEqual(
+          baseEntries
+            .filter(([key]) => key.startsWith('salesforce|test'))
+            .map(([key, value]) => [key, value])
+        )
+      })
+    })
+    describe('when iterating a prefix that does not exist', () => {
+      let iteratedEntries: [string, string[]][]
+      beforeEach(() => {
+        iteratedEntries = [...tree.entriesWithPrefix('salesforce|test|no|such|prefix')]
+      })
+      it('should return an empty iterator', () => {
+        expect(iteratedEntries).toHaveLength(0)
+      })
+    })
+  })
+  describe('fromTreeMapEntry', () => {
+    let tree: TreeMap<string>
+    beforeEach(() => {
+      tree = new TreeMap(baseEntries, separator)
+    })
+    it('should create TreeMap from TreeMapEntry', () => {
+      const newTree = TreeMap.fromTreeMapEntry(tree.root, '|')
+      expect(newTree).toBeInstanceOf(TreeMap)
+      expect(Array.from(newTree.entries())).toEqual(Array.from(tree.entries()))
+    })
+    it('should create empty TreeMap if the TreeMapEntry is empty', () => {
+      const newTree = TreeMap.fromTreeMapEntry({ children: {}, value: [] })
+      expect(newTree).toBeInstanceOf(TreeMap)
+      expect(Array.from(newTree.entries())).toEqual([])
+    })
+  })
+  describe('clone', () => {
+    let tree: TreeMap<string>
+    beforeEach(() => {
+      tree = new TreeMap(baseEntries, separator)
+    })
+    describe('using default clone function', () => {
+      let clonedTree: TreeMap<string>
+      beforeEach(() => {
+        clonedTree = tree.clone()
+      })
+      it('should clone the TreeMap correctly', () => {
+        expect(Array.from(clonedTree.entries())).toEqual(Array.from(tree.entries()))
+      })
+      it('should create a new instance', () => {
+        expect(clonedTree).not.toBe(tree)
+      })
+      it('should create a new instance of the entries', () => {
+        expect(clonedTree.get('salto')).not.toBe(tree.get('salto'))
+      })
+    })
+    describe('using custom clone function', () => {
+      let clonedTree: TreeMap<string>
+      beforeEach(() => {
+        clonedTree = tree.clone(entry => _.cloneDeep([entry[0], entry[1].concat('test')]))
+      })
+      it('should clone the TreeMap correctly', () => {
+        expect(Array.from(clonedTree.entries()))
+          .toEqual(Array.from(tree.entries()).map(entry => [entry[0], entry[1].concat('test')]))
+      })
+      it('should create a new instance', () => {
+        expect(clonedTree).not.toBe(tree)
+      })
+    })
+    it('should create TreeMap from TreeMapEntry', () => {
+      const newTree = TreeMap.fromTreeMapEntry(tree.root, '|')
+      expect(newTree).toBeInstanceOf(TreeMap)
+      expect(Array.from(newTree.entries())).toEqual(Array.from(tree.entries()))
+    })
+    it('should create empty TreeMap if the TreeMapEntry is empty', () => {
+      const newTree = TreeMap.fromTreeMapEntry({ children: {}, value: [] })
+      expect(newTree).toBeInstanceOf(TreeMap)
+      expect(Array.from(newTree.entries())).toEqual([])
+    })
+  })
 })

--- a/packages/netsuite-adapter/src/change_validators/safe_deploy.ts
+++ b/packages/netsuite-adapter/src/change_validators/safe_deploy.ts
@@ -75,7 +75,7 @@ const getInstanceToCompare = (instance: InstanceElement): InstanceElement =>
     instance.elemID.name,
     instance.refType,
     _.omit(instance.value, LAST_FETCH_TIME),
-    instance.path,
+    instance.pathIndex,
     instance.annotations
   )
 

--- a/packages/netsuite-adapter/src/filters/parse_saved_searchs.ts
+++ b/packages/netsuite-adapter/src/filters/parse_saved_searchs.ts
@@ -30,7 +30,7 @@ const filterCreator: FilterCreator = ({ elementsSource }) => ({
     // We create another element not using element.clone because
     // we need the new element to have a parsed save search type.
       new InstanceElement(instance.elemID.name, savedsearch, instance.value,
-        instance.path, instance.annotations)
+        instance.pathIndex, instance.annotations)
 
     const assignSavedSearchValues = async (
       instance: InstanceElement,

--- a/packages/netsuite-adapter/test/config.test.ts
+++ b/packages/netsuite-adapter/test/config.test.ts
@@ -112,8 +112,13 @@ describe('config', () => {
         },
       }
     ))).toBe(true)
-
-    expect(configFromConfigChanges[1].path).toEqual(['lockedElements'])
+    expect(Array.from(configFromConfigChanges[1].pathIndex?.entries() ?? []))
+      .toEqual([
+        [
+          configFromConfigChanges[1].elemID.getFullName(),
+          ['lockedElements'],
+        ],
+      ])
   })
 
   it('should return updated currentConfig when having suggestions and the currentConfig has values', () => {

--- a/packages/netsuite-adapter/test/suiteapp_config_elements.test.ts
+++ b/packages/netsuite-adapter/test/suiteapp_config_elements.test.ts
@@ -57,8 +57,13 @@ describe('config elements', () => {
       expect(configInstance.elemID.typeName)
         .toEqual(SUITEAPP_CONFIG_TYPES_TO_TYPE_NAMES[configType])
       expect(isInstanceElement(configInstance) && configInstance.value).toEqual({ configRecord })
-      expect(configInstance.path)
-        .toEqual([NETSUITE, SETTINGS_PATH, SUITEAPP_CONFIG_TYPES_TO_TYPE_NAMES[configType]])
+      expect(Array.from(configInstance.pathIndex?.entries() ?? []))
+        .toEqual([
+          [
+            configInstance.elemID.getFullName(),
+            [NETSUITE, SETTINGS_PATH, SUITEAPP_CONFIG_TYPES_TO_TYPE_NAMES[configType]],
+          ],
+        ])
     })
   })
   describe('deploy', () => {

--- a/packages/netsuite-adapter/test/transformer.test.ts
+++ b/packages/netsuite-adapter/test/transformer.test.ts
@@ -144,7 +144,13 @@ describe('Transformer', () => {
 
     it('should create instance path correctly for custom type instance', async () => {
       const result = await transformCustomFieldRecord(XML_TEMPLATES.WITH_SCRIPT_ID)
-      expect(result.path).toEqual([NETSUITE, RECORDS_PATH, ENTITY_CUSTOM_FIELD, result.elemID.name])
+      expect(Array.from(result.pathIndex?.entries() ?? []))
+        .toEqual([
+          [
+            result.elemID.getFullName(),
+            [NETSUITE, RECORDS_PATH, ENTITY_CUSTOM_FIELD, result.elemID.name],
+          ],
+        ])
     })
 
     it('should transform attributes', async () => {
@@ -319,9 +325,15 @@ describe('Transformer', () => {
       it('should create instance path correctly for file instance', async () => {
         const result = await createInstanceElement(fileCustomizationInfo, file,
           mockGetElemIdFunc)
-        expect(result.path)
-          .toEqual([NETSUITE, FILE_CABINET_PATH, 'Templates', 'E-mail Templates',
-            'Inner EmailTemplates Folder', 'content.html'])
+        expect(Array.from(result.pathIndex?.entries() ?? []))
+          .toEqual([
+            [
+              result.elemID.getFullName(),
+              [
+                NETSUITE, FILE_CABINET_PATH, 'Templates', 'E-mail Templates', 'Inner EmailTemplates Folder', 'content.html',
+              ],
+            ],
+          ])
       })
 
       it('should create instance path correctly for file instance when it has . prefix', async () => {
@@ -329,9 +341,13 @@ describe('Transformer', () => {
         fileCustomizationInfoWithDotPrefix.path = ['Templates', 'E-mail Templates', '.hiddenFolder', '..hiddenFile.xml']
         const result = await createInstanceElement(fileCustomizationInfoWithDotPrefix,
           file, mockGetElemIdFunc)
-        expect(result.path).toEqual(
-          [NETSUITE, FILE_CABINET_PATH, 'Templates', 'E-mail Templates', '_hiddenFolder', '_hiddenFile.xml']
-        )
+        expect(Array.from(result.pathIndex?.entries() ?? []))
+          .toEqual([
+            [
+              result.elemID.getFullName(),
+              [NETSUITE, FILE_CABINET_PATH, 'Templates', 'E-mail Templates', '_hiddenFolder', '_hiddenFile.xml'],
+            ],
+          ])
       })
 
       it('should create instance path correctly for folder instance', async () => {
@@ -340,9 +356,13 @@ describe('Transformer', () => {
           folder,
           mockGetElemIdFunc
         )
-        expect(result.path)
-          .toEqual([NETSUITE, FILE_CABINET_PATH, 'Templates', 'E-mail Templates',
-            'Inner EmailTemplates Folder', 'Inner EmailTemplates Folder'])
+        expect(Array.from(result.pathIndex?.entries() ?? []))
+          .toEqual([
+            [
+              result.elemID.getFullName(),
+              [NETSUITE, FILE_CABINET_PATH, 'Templates', 'E-mail Templates', 'Inner EmailTemplates Folder', 'Inner EmailTemplates Folder'],
+            ],
+          ])
       })
 
       it('should create instance path correctly for folder instance when it has . prefix', async () => {
@@ -350,9 +370,13 @@ describe('Transformer', () => {
         folderCustomizationInfoWithDotPrefix.path = ['Templates', 'E-mail Templates', '.hiddenFolder']
         const result = await createInstanceElement(folderCustomizationInfoWithDotPrefix,
           folder, mockGetElemIdFunc)
-        expect(result.path)
-          .toEqual([NETSUITE, FILE_CABINET_PATH, 'Templates', 'E-mail Templates', '_hiddenFolder',
-            '_hiddenFolder'])
+        expect(Array.from(result.pathIndex?.entries() ?? []))
+          .toEqual([
+            [
+              result.elemID.getFullName(),
+              [NETSUITE, FILE_CABINET_PATH, 'Templates', 'E-mail Templates', '_hiddenFolder', '_hiddenFolder'],
+            ],
+          ])
       })
 
       it('should transform path field correctly', async () => {

--- a/packages/salesforce-adapter/src/filters/cpq/custom_script.ts
+++ b/packages/salesforce-adapter/src/filters/cpq/custom_script.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { Element, ObjectType, ListType, InstanceElement, isAdditionOrModificationChange, getChangeData, Change, ChangeDataType, isListType, Field, isPrimitiveType, isObjectTypeChange, StaticFile, isFieldChange, isAdditionChange, isInstanceElement, createRefToElmWithValue } from '@salto-io/adapter-api'
+import { Element, ObjectType, ListType, InstanceElement, isAdditionOrModificationChange, getChangeData, Change, ChangeDataType, isListType, Field, isPrimitiveType, isObjectTypeChange, StaticFile, isFieldChange, isAdditionChange, isInstanceElement, createRefToElmWithValue, getTopLevelPath } from '@salto-io/adapter-api'
 import { applyFunctionToChangeData } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
@@ -82,7 +82,7 @@ const codeValueToFile = (
 ): InstanceElement => {
   if (_.isString(cpqCustomScriptInstance.value[CPQ_CODE_FIELD])) {
     cpqCustomScriptInstance.value[CPQ_CODE_FIELD] = new StaticFile({
-      filepath: `${(cpqCustomScriptInstance.path ?? []).join('/')}.js`,
+      filepath: `${getTopLevelPath(cpqCustomScriptInstance).join('/')}.js`,
       content: Buffer.from(cpqCustomScriptInstance.value[CPQ_CODE_FIELD]),
       encoding: 'utf-8',
     })

--- a/packages/salesforce-adapter/src/filters/custom_object_split.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_split.ts
@@ -44,16 +44,6 @@ Promise<ObjectType> => {
     ...pathPrefix,
     customFieldsFileName(customObject.elemID.name),
   ]
-  const annotationToPath = Object.keys(customObject.annotations)
-    .map(annotation => [
-      customObject.elemID.createNestedID('attr', annotation).getFullName(),
-      annotationsPath,
-    ] as [string, string[]])
-  const annotationTypeToPath = Object.keys(customObject.annotationRefTypes)
-    .map(annotationType => [
-      customObject.elemID.createNestedID('annotation', annotationType).getFullName(),
-      annotationsPath,
-    ] as [string, string[]])
   const shouldSplitFields = splitAllFields.includes(await apiName(customObject))
   const createPerFieldPath = (fieldName: string): string[] => [
     ...pathPrefix,
@@ -62,8 +52,6 @@ Promise<ObjectType> => {
   ]
   customObject.pathIndex = new collections.treeMap.TreeMap<string>([
     [customObject.elemID.getFullName(), annotationsPath],
-    ...annotationToPath,
-    ...annotationTypeToPath,
     ...Object.entries(customObject.fields)
       .map(([fieldName, field]) => {
         const groupedFieldsPath = isCustom(field.elemID.getFullName())

--- a/packages/salesforce-adapter/src/filters/custom_object_split.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_split.ts
@@ -44,6 +44,16 @@ Promise<ObjectType> => {
     ...pathPrefix,
     customFieldsFileName(customObject.elemID.name),
   ]
+  const annotationToPath = Object.keys(customObject.annotations)
+    .map(annotation => [
+      customObject.elemID.createNestedID('attr', annotation).getFullName(),
+      annotationsPath,
+    ] as [string, string[]])
+  const annotationTypeToPath = Object.keys(customObject.annotationRefTypes)
+    .map(annotationType => [
+      customObject.elemID.createNestedID('annotation', annotationType).getFullName(),
+      annotationsPath,
+    ] as [string, string[]])
   const shouldSplitFields = splitAllFields.includes(await apiName(customObject))
   const createPerFieldPath = (fieldName: string): string[] => [
     ...pathPrefix,
@@ -52,6 +62,8 @@ Promise<ObjectType> => {
   ]
   customObject.pathIndex = new collections.treeMap.TreeMap<string>([
     [customObject.elemID.getFullName(), annotationsPath],
+    ...annotationToPath,
+    ...annotationTypeToPath,
     ...Object.entries(customObject.fields)
       .map(([fieldName, field]) => {
         const groupedFieldsPath = isCustom(field.elemID.getFullName())

--- a/packages/salesforce-adapter/src/filters/layouts.ts
+++ b/packages/salesforce-adapter/src/filters/layouts.ts
@@ -15,7 +15,7 @@
 */
 import { logger } from '@salto-io/logging'
 import {
-  Element, InstanceElement, ObjectType, ElemID, isInstanceElement,
+  Element, InstanceElement, ObjectType, ElemID, isInstanceElement, createPathIndexFromPath,
 } from '@salto-io/adapter-api'
 import { naclCase, pathNaclCase } from '@salto-io/adapter-utils'
 import { multiIndex, collections } from '@salto-io/lowerdash'
@@ -48,11 +48,14 @@ const fixLayoutPath = async (
   customObject: ObjectType,
   layoutName: string,
 ): Promise<void> => {
-  layout.path = [
-    ...await getObjectDirectoryPath(customObject),
-    layout.elemID.typeName,
-    pathNaclCase(naclCase(layoutName)),
-  ]
+  layout.pathIndex = createPathIndexFromPath(
+    layout.elemID,
+    [
+      ...await getObjectDirectoryPath(customObject),
+      layout.elemID.typeName,
+      pathNaclCase(naclCase(layoutName)),
+    ]
+  )
 }
 
 /**

--- a/packages/salesforce-adapter/src/filters/profile_instance_split.ts
+++ b/packages/salesforce-adapter/src/filters/profile_instance_split.ts
@@ -37,12 +37,18 @@ const splitProfileToPaths = async (profile: InstanceElement): Promise<InstanceEl
   const fieldsToPath = await Promise.all(
     Object.keys(profile.value)
       .map(async fieldName => [
-        profile.elemID.createNestedID(fieldName).getFullName(), // Need to validate if this is true,
+        profile.elemID.createNestedID(fieldName).getFullName(),
         [...profilePath, await toNaclFilename(fieldName, profileType)],
       ] as [string, string[]])
   )
+  const annotationsToPath = Object.keys(profile.annotations)
+    .map(annotationName => [
+      profile.elemID.createNestedID(annotationName).getFullName(),
+      [...profilePath, DEFAULT_NACL_FILENAME],
+    ] as [string, string[]])
   profile.pathIndex = new collections.treeMap.TreeMap<string>([
     [profile.elemID.getFullName(), [...profilePath, DEFAULT_NACL_FILENAME]],
+    ...annotationsToPath,
     // TODO: check if I need that sort
     // I am not sure if we need that sort - I am keeping it because of the following doc
     // keep the default filename first so that it comes up first when searching the path index

--- a/packages/salesforce-adapter/src/filters/profile_instance_split.ts
+++ b/packages/salesforce-adapter/src/filters/profile_instance_split.ts
@@ -41,14 +41,8 @@ const splitProfileToPaths = async (profile: InstanceElement): Promise<InstanceEl
         [...profilePath, await toNaclFilename(fieldName, profileType)],
       ] as [string, string[]])
   )
-  const annotationsToPath = Object.keys(profile.annotations)
-    .map(annotationName => [
-      profile.elemID.createNestedID(annotationName).getFullName(),
-      [...profilePath, DEFAULT_NACL_FILENAME],
-    ] as [string, string[]])
   profile.pathIndex = new collections.treeMap.TreeMap<string>([
     [profile.elemID.getFullName(), [...profilePath, DEFAULT_NACL_FILENAME]],
-    ...annotationsToPath,
     // TODO: check if I need that sort
     // I am not sure if we need that sort - I am keeping it because of the following doc
     // keep the default filename first so that it comes up first when searching the path index

--- a/packages/salesforce-adapter/src/filters/profile_paths.ts
+++ b/packages/salesforce-adapter/src/filters/profile_paths.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Element, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
+import { createPathIndexFromPath, Element, getTopLevelPath, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
 import { pathNaclCase, naclCase } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 
@@ -47,11 +47,14 @@ const replacePath = async (
     // Authenticated_Website2 nacls.
     ? 'Authenticated Website2'
     : profileInternalIdToName.get(getInternalId(profile))
-  if (name !== undefined && profile.path) {
-    profile.path = [
-      ...profile.path.slice(0, -1),
-      pathNaclCase(naclCase(name)),
-    ]
+  if (name !== undefined && profile.pathIndex) {
+    profile.pathIndex = createPathIndexFromPath(
+      profile.elemID,
+      [
+        ...getTopLevelPath(profile).slice(0, -1),
+        pathNaclCase(naclCase(name)),
+      ]
+    )
   }
 }
 

--- a/packages/salesforce-adapter/src/filters/value_to_static_file.ts
+++ b/packages/salesforce-adapter/src/filters/value_to_static_file.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import {
-  Element, InstanceElement, Field, isInstanceElement, Value, StaticFile,
+  Element, InstanceElement, Field, isInstanceElement, Value, StaticFile, getTopLevelPath,
 } from '@salto-io/adapter-api'
 import { transformValues, TransformFunc } from '@salto-io/adapter-utils'
 import _ from 'lodash'
@@ -53,12 +53,12 @@ const createStaticFile = async (
   instance: InstanceElement,
   value: string
 ): Promise<StaticFile | undefined> => {
-  if (instance.path === undefined) {
+  if (instance.pathIndex === undefined) {
     log.error(`could not extract value of instance ${await apiName(instance)} to static file, instance path is undefined`)
     return undefined
   }
   return new StaticFile({
-    filepath: `${instance.path.join('/')}.js`,
+    filepath: `${getTopLevelPath(instance).join('/')}.js`,
     content: Buffer.from(value),
     encoding: 'utf-8',
   })

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -162,7 +162,13 @@ describe('SalesforceAdapter fetch', () => {
       expect(flow.fields.enum.annotations[CORE_ANNOTATIONS.DEFAULT]).toBe('yes')
       // Note the order here is important because we expect restriction values to be sorted
       expect(getRestriction(flow.fields.enum).values).toEqual(['no', 'yes'])
-      expect(flow.path).toEqual([constants.SALESFORCE, constants.TYPES_PATH, 'Flow'])
+      expect(Array.from(flow.pathIndex?.entries() ?? []))
+        .toEqual([
+          [
+            flow.elemID.getFullName(),
+            [constants.SALESFORCE, constants.TYPES_PATH, 'Flow'],
+          ],
+        ])
       expect(isServiceId(await flow.fields[constants.INSTANCE_FULL_NAME_FIELD].getType()))
         .toEqual(true)
       expect(isServiceId((await flow.getAnnotationTypes())[constants.METADATA_TYPE]))
@@ -742,8 +748,13 @@ public class MyClass${index} {
       const [testElem] = findElements(result, 'EmailFolder', 'MyFolder')
       const testInst = testElem as InstanceElement
       expect(testInst).toBeDefined()
-      expect(testInst.path)
-        .toEqual([constants.SALESFORCE, constants.RECORDS_PATH, 'EmailFolder', 'MyFolder'])
+      expect(Array.from(testInst.pathIndex?.entries() ?? []))
+        .toEqual([
+          [
+            testInst.elemID.getFullName(),
+            [constants.SALESFORCE, constants.RECORDS_PATH, 'EmailFolder', 'MyFolder'],
+          ],
+        ])
       expect(testInst.value[constants.INSTANCE_FULL_NAME_FIELD]).toEqual('MyFolder')
       expect(testInst.value.name).toEqual('My folder')
     })
@@ -786,9 +797,14 @@ public class MyClass${index} {
       const { elements: result } = await adapter.fetch(mockFetchOpts)
       const [testInst] = findElements(result, 'ApexPage', 'th_con_app__ThHomepage')
       expect(testInst).toBeDefined()
-      expect(testInst.path)
-        .toEqual([constants.SALESFORCE, constants.INSTALLED_PACKAGES_PATH,
-          namespaceName, constants.RECORDS_PATH, 'ApexPage', 'th_con_app__ThHomepage'])
+      expect(Array.from(testInst.pathIndex?.entries() ?? []))
+        .toEqual([
+          [
+            testInst.elemID.getFullName(),
+            [constants.SALESFORCE, constants.INSTALLED_PACKAGES_PATH,
+              namespaceName, constants.RECORDS_PATH, 'ApexPage', 'th_con_app__ThHomepage'],
+          ],
+        ])
     })
 
     it('should fetch metadata instances with namespace', async () => {
@@ -807,9 +823,14 @@ public class MyClass${index} {
       const { elements: result } = await adapter.fetch(mockFetchOpts)
       const [testInst] = findElements(result, 'Test', 'asd__Test')
       expect(testInst).toBeDefined()
-      expect(testInst.path)
-        .toEqual([constants.SALESFORCE, constants.INSTALLED_PACKAGES_PATH,
-          namespaceName, constants.RECORDS_PATH, 'Test', 'asd__Test'])
+      expect(Array.from(testInst.pathIndex?.entries() ?? []))
+        .toEqual([
+          [
+            testInst.elemID.getFullName(),
+            [constants.SALESFORCE, constants.INSTALLED_PACKAGES_PATH,
+              namespaceName, constants.RECORDS_PATH, 'Test', 'asd__Test'],
+          ],
+        ])
     })
 
     it('should fetch metadata instances with namespace when fullname already includes the namespace', async () => {
@@ -828,10 +849,14 @@ public class MyClass${index} {
       const { elements: result } = await adapter.fetch(mockFetchOpts)
       const [testInst] = findElements(result, 'Test', 'asd__Test')
       expect(testInst).toBeDefined()
-      expect(testInst.path).toEqual(
-        [constants.SALESFORCE, constants.INSTALLED_PACKAGES_PATH, namespaceName,
-          constants.RECORDS_PATH, 'Test', 'asd__Test']
-      )
+      expect(Array.from(testInst.pathIndex?.entries() ?? []))
+        .toEqual([
+          [
+            testInst.elemID.getFullName(),
+            [constants.SALESFORCE, constants.INSTALLED_PACKAGES_PATH, namespaceName,
+              constants.RECORDS_PATH, 'Test', 'asd__Test'],
+          ],
+        ])
     })
 
     it('should not fail the fetch on instances too large', async () => {

--- a/packages/salesforce-adapter/test/filters/currency_iso_code.test.ts
+++ b/packages/salesforce-adapter/test/filters/currency_iso_code.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Element, ObjectType, BuiltinTypes, ElemID } from '@salto-io/adapter-api'
+import { Element, ObjectType, BuiltinTypes, ElemID, createPathIndexFromPath } from '@salto-io/adapter-api'
 import { findElements as findElementsByID } from '@salto-io/adapter-utils'
 import currencyIsoCodeFilter from '../../src/filters/currency_iso_code'
 import { FilterWith } from '../../src/filter'
@@ -84,7 +84,10 @@ describe('currencyIsoCode filter', () => {
       expect(currencyCodesType[0]).toMatchObject(expect.objectContaining({
         isSettings: true,
         fields: expect.objectContaining({ valueSet: expect.objectContaining({}) }),
-        path: [SALESFORCE, 'Types', 'CurrencyIsoCodes'],
+        pathIndex: createPathIndexFromPath(
+          currencyCodesType[0].elemID,
+          [SALESFORCE, 'Types', 'CurrencyIsoCodes'],
+        ),
       }))
     })
 
@@ -92,7 +95,10 @@ describe('currencyIsoCode filter', () => {
       const currencyCodeRecord = findElements(elements, CURRENCY_CODE_TYPE_NAME, ElemID.CONFIG_NAME)
       expect(currencyCodeRecord).toHaveLength(1)
       expect(currencyCodeRecord[0]).toMatchObject({
-        path: [SALESFORCE, 'Records', 'Settings', 'CurrencyIsoCodes'],
+        pathIndex: createPathIndexFromPath(
+          currencyCodeRecord[0].elemID,
+          [SALESFORCE, 'Records', 'Settings', 'CurrencyIsoCodes']
+        ),
         value: {
           valueSet: expect.arrayContaining([
             expect.objectContaining({ label: 'USD' }),

--- a/packages/salesforce-adapter/test/filters/custom_object_split.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_object_split.test.ts
@@ -110,14 +110,6 @@ describe('Custom Object Split filter', () => {
               [SALESFORCE, OBJECTS_PATH, typeName, 'CustomObjectAnnotations'],
             ],
             [
-              customObject.elemID.createNestedID('attr', METADATA_TYPE).getFullName(),
-              [SALESFORCE, OBJECTS_PATH, typeName, 'CustomObjectAnnotations'],
-            ],
-            [
-              customObject.elemID.createNestedID('attr', API_NAME).getFullName(),
-              [SALESFORCE, OBJECTS_PATH, typeName, 'CustomObjectAnnotations'],
-            ],
-            [
               customObject.elemID.createNestedID('field', 'standard').getFullName(),
               [SALESFORCE, OBJECTS_PATH, typeName, 'CustomObjectStandardFields'],
             ],
@@ -149,14 +141,6 @@ describe('Custom Object Split filter', () => {
           .toEqual([
             [
               customObject.elemID.getFullName(),
-              [SALESFORCE, INSTALLED_PACKAGES_PATH, 'namespace', OBJECTS_PATH, typeName, 'CustomObjectAnnotations'],
-            ],
-            [
-              customObject.elemID.createNestedID('attr', METADATA_TYPE).getFullName(),
-              [SALESFORCE, INSTALLED_PACKAGES_PATH, 'namespace', OBJECTS_PATH, typeName, 'CustomObjectAnnotations'],
-            ],
-            [
-              customObject.elemID.createNestedID('attr', API_NAME).getFullName(),
               [SALESFORCE, INSTALLED_PACKAGES_PATH, 'namespace', OBJECTS_PATH, typeName, 'CustomObjectAnnotations'],
             ],
             [
@@ -206,14 +190,6 @@ describe('Custom Object Split filter', () => {
                 [SALESFORCE, OBJECTS_PATH, typeName, 'CustomObjectAnnotations'],
               ],
               [
-                customObject.elemID.createNestedID('attr', METADATA_TYPE).getFullName(),
-                [SALESFORCE, OBJECTS_PATH, typeName, 'CustomObjectAnnotations'],
-              ],
-              [
-                customObject.elemID.createNestedID('attr', API_NAME).getFullName(),
-                [SALESFORCE, OBJECTS_PATH, typeName, 'CustomObjectAnnotations'],
-              ],
-              [
                 customObject.elemID.createNestedID('field', 'custom__c').getFullName(),
                 [SALESFORCE, OBJECTS_PATH, typeName, 'CustomObjectCustomFields'],
               ],
@@ -245,14 +221,6 @@ describe('Custom Object Split filter', () => {
             .toEqual([
               [
                 customObject.elemID.getFullName(),
-                [SALESFORCE, OBJECTS_PATH, typeName, 'CustomObjectAnnotations'],
-              ],
-              [
-                customObject.elemID.createNestedID('attr', METADATA_TYPE).getFullName(),
-                [SALESFORCE, OBJECTS_PATH, typeName, 'CustomObjectAnnotations'],
-              ],
-              [
-                customObject.elemID.createNestedID('attr', API_NAME).getFullName(),
                 [SALESFORCE, OBJECTS_PATH, typeName, 'CustomObjectAnnotations'],
               ],
               [
@@ -354,14 +322,6 @@ describe('Custom Object Split filter', () => {
             [SALESFORCE, OBJECTS_PATH, typeName, `${typeName}Annotations`],
           ],
           [
-            elemId.createNestedID('attr', METADATA_TYPE).getFullName(),
-            [SALESFORCE, OBJECTS_PATH, typeName, `${typeName}Annotations`],
-          ],
-          [
-            elemId.createNestedID('attr', API_NAME).getFullName(),
-            [SALESFORCE, OBJECTS_PATH, typeName, `${typeName}Annotations`],
-          ],
-          [
             elemId.createNestedID('field', 'Standard').getFullName(),
             [SALESFORCE, OBJECTS_PATH, typeName, OBJECT_FIELDS_PATH, 'Standard'],
           ],
@@ -384,14 +344,6 @@ describe('Custom Object Split filter', () => {
         .toEqual([
           [
             elemId.getFullName(),
-            [SALESFORCE, OBJECTS_PATH, typeName, `${typeName}Annotations`],
-          ],
-          [
-            elemId.createNestedID('attr', METADATA_TYPE).getFullName(),
-            [SALESFORCE, OBJECTS_PATH, typeName, `${typeName}Annotations`],
-          ],
-          [
-            elemId.createNestedID('attr', API_NAME).getFullName(),
             [SALESFORCE, OBJECTS_PATH, typeName, `${typeName}Annotations`],
           ],
           [

--- a/packages/salesforce-adapter/test/filters/custom_object_split.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_object_split.test.ts
@@ -110,6 +110,14 @@ describe('Custom Object Split filter', () => {
               [SALESFORCE, OBJECTS_PATH, typeName, 'CustomObjectAnnotations'],
             ],
             [
+              customObject.elemID.createNestedID('attr', METADATA_TYPE).getFullName(),
+              [SALESFORCE, OBJECTS_PATH, typeName, 'CustomObjectAnnotations'],
+            ],
+            [
+              customObject.elemID.createNestedID('attr', API_NAME).getFullName(),
+              [SALESFORCE, OBJECTS_PATH, typeName, 'CustomObjectAnnotations'],
+            ],
+            [
               customObject.elemID.createNestedID('field', 'standard').getFullName(),
               [SALESFORCE, OBJECTS_PATH, typeName, 'CustomObjectStandardFields'],
             ],
@@ -144,6 +152,14 @@ describe('Custom Object Split filter', () => {
               [SALESFORCE, INSTALLED_PACKAGES_PATH, 'namespace', OBJECTS_PATH, typeName, 'CustomObjectAnnotations'],
             ],
             [
+              customObject.elemID.createNestedID('attr', METADATA_TYPE).getFullName(),
+              [SALESFORCE, INSTALLED_PACKAGES_PATH, 'namespace', OBJECTS_PATH, typeName, 'CustomObjectAnnotations'],
+            ],
+            [
+              customObject.elemID.createNestedID('attr', API_NAME).getFullName(),
+              [SALESFORCE, INSTALLED_PACKAGES_PATH, 'namespace', OBJECTS_PATH, typeName, 'CustomObjectAnnotations'],
+            ],
+            [
               customObject.elemID.createNestedID('field', 'standard').getFullName(),
               [SALESFORCE, INSTALLED_PACKAGES_PATH, 'namespace', OBJECTS_PATH, typeName, 'CustomObjectStandardFields'],
             ],
@@ -165,9 +181,6 @@ describe('Custom Object Split filter', () => {
           const objectWithNoStandardFields = new ObjectType({
             elemID: CUSTOM_OBJECT_TYPE_ID,
             fields: {
-              standard: {
-                refType: BuiltinTypes.STRING,
-              },
               custom__c: {
                 refType: BuiltinTypes.STRING,
               },
@@ -179,17 +192,25 @@ describe('Custom Object Split filter', () => {
               },
             },
             annotations: {
-              [METADATA_TYPE]: 'NonCustomObject',
+              [METADATA_TYPE]: CUSTOM_OBJECT,
               [API_NAME]: 'objectRandom__c',
             },
           })
-          const elements = await runFilter(objectWithNoStandardFields.clone())
-          expect(elements).toHaveLength(1)
-          const [customObject] = elements
+          const fragments = await runFilter(objectWithNoStandardFields.clone())
+          expect(fragments).toHaveLength(1)
+          const [customObject] = fragments
           expect(Array.from(customObject.pathIndex?.entries() ?? []))
             .toEqual([
               [
                 customObject.elemID.getFullName(),
+                [SALESFORCE, OBJECTS_PATH, typeName, 'CustomObjectAnnotations'],
+              ],
+              [
+                customObject.elemID.createNestedID('attr', METADATA_TYPE).getFullName(),
+                [SALESFORCE, OBJECTS_PATH, typeName, 'CustomObjectAnnotations'],
+              ],
+              [
+                customObject.elemID.createNestedID('attr', API_NAME).getFullName(),
                 [SALESFORCE, OBJECTS_PATH, typeName, 'CustomObjectAnnotations'],
               ],
               [
@@ -217,9 +238,9 @@ describe('Custom Object Split filter', () => {
               [API_NAME]: 'objectRandom__c',
             },
           })
-          const elements = await runFilter(objectWithNoCustomFields.clone())
-          expect(elements).toHaveLength(1)
-          const [customObject] = elements
+          const fragments = await runFilter(objectWithNoCustomFields.clone())
+          expect(fragments).toHaveLength(1)
+          const [customObject] = fragments
           expect(Array.from(customObject.pathIndex?.entries() ?? []))
             .toEqual([
               [
@@ -227,7 +248,15 @@ describe('Custom Object Split filter', () => {
                 [SALESFORCE, OBJECTS_PATH, typeName, 'CustomObjectAnnotations'],
               ],
               [
-                customObject.elemID.createNestedID('field', 'standard').getFullName(),
+                customObject.elemID.createNestedID('attr', METADATA_TYPE).getFullName(),
+                [SALESFORCE, OBJECTS_PATH, typeName, 'CustomObjectAnnotations'],
+              ],
+              [
+                customObject.elemID.createNestedID('attr', API_NAME).getFullName(),
+                [SALESFORCE, OBJECTS_PATH, typeName, 'CustomObjectAnnotations'],
+              ],
+              [
+                customObject.elemID.createNestedID('field', 'Standard').getFullName(),
                 [SALESFORCE, OBJECTS_PATH, typeName, 'CustomObjectStandardFields'],
               ],
             ])
@@ -322,7 +351,19 @@ describe('Custom Object Split filter', () => {
         .toEqual([
           [
             elemId.getFullName(),
-            [SALESFORCE, OBJECTS_PATH, typeName, OBJECT_FIELDS_PATH, `${typeName}Annotations`],
+            [SALESFORCE, OBJECTS_PATH, typeName, `${typeName}Annotations`],
+          ],
+          [
+            elemId.createNestedID('attr', METADATA_TYPE).getFullName(),
+            [SALESFORCE, OBJECTS_PATH, typeName, `${typeName}Annotations`],
+          ],
+          [
+            elemId.createNestedID('attr', API_NAME).getFullName(),
+            [SALESFORCE, OBJECTS_PATH, typeName, `${typeName}Annotations`],
+          ],
+          [
+            elemId.createNestedID('field', 'Standard').getFullName(),
+            [SALESFORCE, OBJECTS_PATH, typeName, OBJECT_FIELDS_PATH, 'Standard'],
           ],
           [
             elemId.createNestedID('field', 'Custom__c').getFullName(),
@@ -331,10 +372,6 @@ describe('Custom Object Split filter', () => {
           [
             elemId.createNestedID('field', 'OtherCustom__c').getFullName(),
             [SALESFORCE, OBJECTS_PATH, typeName, OBJECT_FIELDS_PATH, 'OtherCustom__c'],
-          ],
-          [
-            elemId.createNestedID('field', 'Standard').getFullName(),
-            [SALESFORCE, OBJECTS_PATH, typeName, OBJECT_FIELDS_PATH, 'Standard'],
           ],
         ])
     })
@@ -347,7 +384,19 @@ describe('Custom Object Split filter', () => {
         .toEqual([
           [
             elemId.getFullName(),
-            [SALESFORCE, OBJECTS_PATH, typeName, OBJECT_FIELDS_PATH, `${typeName}Annotations`],
+            [SALESFORCE, OBJECTS_PATH, typeName, `${typeName}Annotations`],
+          ],
+          [
+            elemId.createNestedID('attr', METADATA_TYPE).getFullName(),
+            [SALESFORCE, OBJECTS_PATH, typeName, `${typeName}Annotations`],
+          ],
+          [
+            elemId.createNestedID('attr', API_NAME).getFullName(),
+            [SALESFORCE, OBJECTS_PATH, typeName, `${typeName}Annotations`],
+          ],
+          [
+            elemId.createNestedID('field', 'Standard').getFullName(),
+            [SALESFORCE, OBJECTS_PATH, typeName, 'OtherType__cStandardFields'],
           ],
           [
             elemId.createNestedID('field', 'Custom__c').getFullName(),
@@ -356,10 +405,6 @@ describe('Custom Object Split filter', () => {
           [
             elemId.createNestedID('field', 'OtherCustom__c').getFullName(),
             [SALESFORCE, OBJECTS_PATH, typeName, 'OtherType__cCustomFields'],
-          ],
-          [
-            elemId.createNestedID('field', 'Standard').getFullName(),
-            [SALESFORCE, OBJECTS_PATH, typeName, 'OtherType__cStandardFields'],
           ],
         ])
     })

--- a/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
@@ -14,7 +14,9 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { ElemID, ObjectType, Element, CORE_ANNOTATIONS, PrimitiveType, PrimitiveTypes, FieldDefinition, isInstanceElement, InstanceElement, ServiceIds, BuiltinTypes, createRefToElmWithValue } from '@salto-io/adapter-api'
+import { ElemID, ObjectType, Element, CORE_ANNOTATIONS, PrimitiveType, PrimitiveTypes,
+  FieldDefinition, isInstanceElement, InstanceElement, ServiceIds, BuiltinTypes,
+  createRefToElmWithValue, getTopLevelPath, createPathIndexFromPath } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { ConfigChangeSuggestion, isDataManagementConfigSuggestions } from '../../src/types'
 import { getNamespaceFromString } from '../../src/filters/utils'
@@ -84,7 +86,7 @@ const createCustomObject = (
   const path = namespace
     ? [SALESFORCE, INSTALLED_PACKAGES_PATH, namespace, OBJECTS_PATH, obj.elemID.name]
     : [SALESFORCE, OBJECTS_PATH, obj.elemID.name]
-  obj.path = path
+  obj.pathIndex = createPathIndexFromPath(obj.elemID, path)
   return obj
 }
 
@@ -422,7 +424,7 @@ describe('Custom Object Instances filter', () => {
         })
 
         it('should create the instances with record path acccording to object', () => {
-          expect(instances[0].path).toEqual(
+          expect(getTopLevelPath(instances[0])).toEqual(
             [SALESFORCE, INSTALLED_PACKAGES_PATH, testNamespace, OBJECTS_PATH,
               simpleName, RECORDS_PATH, expectedFirstInstanceName]
           )
@@ -478,7 +480,7 @@ describe('Custom Object Instances filter', () => {
         })
 
         it('should create the instances with record path acccording to object', () => {
-          expect(instances[0].path).toEqual(
+          expect(getTopLevelPath(instances[0])).toEqual(
             [SALESFORCE, INSTALLED_PACKAGES_PATH, testNamespace, OBJECTS_PATH,
               withNameName, RECORDS_PATH, expectedFirstInstanceName]
           )
@@ -523,10 +525,14 @@ describe('Custom Object Instances filter', () => {
         })
 
         it('should create the instances with record path acccording to object', () => {
-          expect(instances[0].path).toEqual(
-            [SALESFORCE, INSTALLED_PACKAGES_PATH, testNamespace, OBJECTS_PATH,
-              withAddressName, RECORDS_PATH, expectedFirstInstanceName]
-          )
+          expect(Array.from(instances[0].pathIndex?.entries() ?? []))
+            .toEqual([
+              [
+                instances[0].elemID.getFullName(),
+                [SALESFORCE, INSTALLED_PACKAGES_PATH, testNamespace, OBJECTS_PATH,
+                  withAddressName, RECORDS_PATH, expectedFirstInstanceName],
+              ],
+            ])
         })
 
         it('should create the instances with ElemID name according to the getElemID func', () => {

--- a/packages/salesforce-adapter/test/filters/layouts.test.ts
+++ b/packages/salesforce-adapter/test/filters/layouts.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { InstanceElement, CORE_ANNOTATIONS, ReferenceExpression, BuiltinTypes } from '@salto-io/adapter-api'
+import { InstanceElement, CORE_ANNOTATIONS, ReferenceExpression, BuiltinTypes, createPathIndexFromPath, getTopLevelPath } from '@salto-io/adapter-api'
 import { naclCase, pathNaclCase } from '@salto-io/adapter-utils'
 import { mockTypes } from '../mock_elements'
 import { createCustomObjectType, createMetadataTypeElement, defaultFilterContext } from '../utils'
@@ -42,7 +42,7 @@ describe('Test layout filter', () => {
         }
       )
       const testSobjPath = [...await getObjectDirectoryPath(testSObj), pathNaclCase(apiName)]
-      testSObj.path = testSobjPath
+      testSObj.pathIndex = createPathIndexFromPath(testSObj.elemID, testSobjPath)
 
       const shortName = 'Test Layout'
       const fullName = `${apiName}-${shortName}`
@@ -87,7 +87,7 @@ describe('Test layout filter', () => {
 
       const instance = elements[1] as InstanceElement
       expect(instance.elemID).toEqual(LAYOUT_TYPE_ID.createNestedID('instance', naclCase(shortName)))
-      expect(instance.path).toEqual([...testSobjPath.slice(0, -1), 'Layout', pathNaclCase(instance.elemID.name)])
+      expect(getTopLevelPath(instance)).toEqual([...testSobjPath.slice(0, -1), 'Layout', pathNaclCase(instance.elemID.name)])
 
       expect(instance.annotations[CORE_ANNOTATIONS.PARENT]).toContainEqual(
         new ReferenceExpression(testSObj.elemID)

--- a/packages/salesforce-adapter/test/filters/profile_paths.test.ts
+++ b/packages/salesforce-adapter/test/filters/profile_paths.test.ts
@@ -59,8 +59,13 @@ describe('profile paths filter', () => {
     instance.value[INSTANCE_FULL_NAME_FIELD] = 'Admin'
     instance.value[INTERNAL_ID_FIELD] = 'AdminInternalId'
     await filter.onFetch([instance])
-    expect(instance.path)
-      .toEqual([SALESFORCE, RECORDS_PATH, PROFILE_METADATA_TYPE, 'System_Administrator'])
+    expect(Array.from(instance.pathIndex?.entries() ?? []))
+      .toEqual([
+        [
+          instance.elemID.getFullName(),
+          [SALESFORCE, RECORDS_PATH, PROFILE_METADATA_TYPE, 'System_Administrator'],
+        ],
+      ])
   })
 
   it('should replace instance path for PlatformPortal Profile', async () => {
@@ -68,8 +73,13 @@ describe('profile paths filter', () => {
     instance.value[INSTANCE_FULL_NAME_FIELD] = 'PlatformPortal'
     instance.value[INTERNAL_ID_FIELD] = 'PlatformPortalInternalId'
     await filter.onFetch([instance])
-    expect(instance.path)
-      .toEqual([SALESFORCE, RECORDS_PATH, PROFILE_METADATA_TYPE, 'Authenticated_Website2'])
+    expect(Array.from(instance.pathIndex?.entries() ?? []))
+      .toEqual([
+        [
+          instance.elemID.getFullName(),
+          [SALESFORCE, RECORDS_PATH, PROFILE_METADATA_TYPE, 'Authenticated_Website2'],
+        ],
+      ])
   })
 
   it('should not replace instance path for other metadataTypes', async () => {
@@ -77,16 +87,16 @@ describe('profile paths filter', () => {
     instance.value[INSTANCE_FULL_NAME_FIELD] = 'Admin'
     instance.value[INTERNAL_ID_FIELD] = 'AdminInternalId'
     await filter.onFetch([instance])
-    expect(instance.path).toEqual(origInstance.path)
+    expect(instance.pathIndex).toEqual(origInstance.pathIndex)
   })
 
   it('should not replace instance path if it has no path', async () => {
     (await instance.getType()).annotations[METADATA_TYPE] = PROFILE_METADATA_TYPE
     instance.value[INSTANCE_FULL_NAME_FIELD] = 'Admin'
     instance.value[INTERNAL_ID_FIELD] = 'AdminInternalId'
-    instance.path = undefined
+    instance.pathIndex = undefined
     await filter.onFetch([instance])
-    expect(instance.path).toBeUndefined()
+    expect(instance.pathIndex).toBeUndefined()
   })
   describe('when feature is throwing an error', () => {
     it('should return a warning', async () => {
@@ -118,7 +128,13 @@ describe('profile paths filter', () => {
         },
       }) as FilterWith<'onFetch'>
       await filter.onFetch([instance])
-      expect(instance.path).toEqual([SALESFORCE, RECORDS_PATH, PROFILE_METADATA_TYPE, 'test'])
+      expect(Array.from(instance.pathIndex?.entries() ?? []))
+        .toEqual([
+          [
+            instance.elemID.getFullName(),
+            [SALESFORCE, RECORDS_PATH, PROFILE_METADATA_TYPE, 'test'],
+          ],
+        ])
       expect(connection.query).not.toHaveBeenCalled()
     })
   })

--- a/packages/salesforce-adapter/test/filters/settings_type.test.ts
+++ b/packages/salesforce-adapter/test/filters/settings_type.test.ts
@@ -108,14 +108,13 @@ describe('Test Settings Type', () => {
       )
       expect(testElements).toHaveLength(5)
       expect(isObjectType(testElements[3])).toBeTruthy()
-      const { path } = testElements[3]
-      expect(path).toBeDefined()
-      expect(path).toHaveLength(3)
-      if (path !== undefined) {
-        expect(path[0]).toEqual(constants.SALESFORCE)
-        expect(path[1]).toEqual(constants.TYPES_PATH)
-        expect(path[2]).toEqual('MacroSettings')
-      }
+      expect(Array.from(testElements[3].pathIndex?.entries() ?? []))
+        .toEqual([
+          [
+            testElements[3].elemID.getFullName(),
+            [constants.SALESFORCE, constants.TYPES_PATH, 'MacroSettings'],
+          ],
+        ])
       expect(isInstanceElement(testElements[4])).toBeTruthy()
       expect(await (testElements[4] as InstanceElement).getType()).toEqual(testElements[3])
     })

--- a/packages/salesforce-adapter/test/filters/standard_value_sets.test.ts
+++ b/packages/salesforce-adapter/test/filters/standard_value_sets.test.ts
@@ -105,13 +105,23 @@ describe('Standard Value Sets filter', () => {
     expect(elements.length).toBe(3)
     const simpsonsSvs = elements[1]
     expect(simpsonsSvs.elemID).toEqual(mockSVSType.elemID.createNestedID('instance', 'Simpsons'))
-    expect(simpsonsSvs.path)
-      .toEqual([constants.SALESFORCE, constants.RECORDS_PATH, 'standard_value_set', 'Simpsons'])
+    expect(Array.from(simpsonsSvs.pathIndex?.entries() ?? []))
+      .toEqual([
+        [
+          simpsonsSvs.elemID.getFullName(),
+          [constants.SALESFORCE, constants.RECORDS_PATH, 'standard_value_set', 'Simpsons'],
+        ],
+      ])
     expect(extractFullNamesFromValueList((simpsonsSvs as InstanceElement).value[STANDARD_VALUE])).toEqual(['Bart', 'Homer', 'Lisa'])
     const numbersSvs = elements[2]
     expect(numbersSvs.elemID).toEqual(mockSVSType.elemID.createNestedID('instance', 'Numbers'))
-    expect(numbersSvs.path)
-      .toEqual([constants.SALESFORCE, constants.RECORDS_PATH, 'standard_value_set', 'Numbers'])
+    expect(Array.from(numbersSvs.pathIndex?.entries() ?? []))
+      .toEqual([
+        [
+          numbersSvs.elemID.getFullName(),
+          [constants.SALESFORCE, constants.RECORDS_PATH, 'standard_value_set', 'Numbers'],
+        ],
+      ])
     expect(extractFullNamesFromValueList((numbersSvs as InstanceElement).value[STANDARD_VALUE])).toEqual(['One', 'Two', 'Three'])
   })
   it('should replace value list with references for standard picklist fields', async () => {

--- a/packages/salesforce-adapter/test/filters/value_to_static_file.test.ts
+++ b/packages/salesforce-adapter/test/filters/value_to_static_file.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Element, ElemID, ObjectType, InstanceElement, isInstanceElement, BuiltinTypes, StaticFile, FieldDefinition } from '@salto-io/adapter-api'
+import { Element, ElemID, ObjectType, InstanceElement, isInstanceElement, BuiltinTypes, StaticFile, FieldDefinition, getTopLevelPath } from '@salto-io/adapter-api'
 import { FilterWith } from '../../src/filter'
 import SalesforceClient from '../../src/client/client'
 import filterCreator from '../../src/filters/value_to_static_file'
@@ -93,7 +93,7 @@ describe('value to static file filter', () => {
       webLinkType, anotherType]
 
     codeAsFile = new StaticFile({
-      filepath: `${(webLinkInstanceCode.path ?? []).join('/')}.js`,
+      filepath: `${getTopLevelPath(webLinkInstanceCode).join('/')}.js`,
       content: Buffer.from(webLinkInstanceCode.value.url),
       encoding: 'utf-8',
     })
@@ -135,16 +135,16 @@ describe('value to static file filter', () => {
         let instanceUndefinedPath: InstanceElement | undefined
         beforeAll(async () => {
           instanceUndefinedPath = elements?.filter(isInstanceElement)
-            .find(e => e.path === undefined)
+            .find(e => e.pathIndex === undefined)
           if (instanceUndefinedPath !== undefined) {
-            instanceUndefinedPath.path = undefined
+            instanceUndefinedPath.pathIndex = undefined
           }
           await filter.onFetch(elements)
         })
 
         it('do not replace value for undefined path', () => {
           instanceUndefinedPath = elements?.filter(isInstanceElement)
-            .find(e => e.path === undefined)
+            .find(e => e.pathIndex === undefined)
           expect(instanceUndefinedPath?.value[URL]).toBe(codeAsString)
           expect(instanceUndefinedPath?.value[NOT_URL]).toBe(anotherFieldContent)
         })

--- a/packages/salesforce-adapter/test/filters/workflow.test.ts
+++ b/packages/salesforce-adapter/test/filters/workflow.test.ts
@@ -19,6 +19,7 @@ import {
   ElemID, InstanceElement, ObjectType, Element, isInstanceElement, Change,
   getChangeData, ModificationChange, isModificationChange, Value, isListType, ListType,
   createRefToElmWithValue,
+  getTopLevelPath,
 } from '@salto-io/adapter-api'
 import { FilterWith } from '../../src/filter'
 import filterCreator, {
@@ -163,9 +164,9 @@ describe('Workflow filter', () => {
     it('should set non workflow instances path correctly', async () => {
       const dummyInstance = generateWorkFlowInstance()
       dummyInstance.refType = dummyRefToObj
-      const beforeFilterPath = dummyInstance.path
+      const beforeFilterPath = getTopLevelPath(dummyInstance)
       await filter.onFetch([dummyInstance])
-      expect(dummyInstance.path).toEqual(beforeFilterPath)
+      expect(getTopLevelPath(dummyInstance)).toEqual(beforeFilterPath)
     })
   })
 

--- a/packages/salesforce-adapter/test/transformers/transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/transformer.test.ts
@@ -14,7 +14,9 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { ObjectType, ElemID, Field, BuiltinTypes, TypeElement, Field as TypeField, Values, CORE_ANNOTATIONS, ReferenceExpression, InstanceElement, getRestriction, ListType, createRestriction, isServiceId, createRefToElmWithValue } from '@salto-io/adapter-api'
+import { ObjectType, ElemID, Field, BuiltinTypes, TypeElement, Field as TypeField, Values,
+  CORE_ANNOTATIONS, ReferenceExpression, InstanceElement, getRestriction, ListType,
+  getTopLevelPath, createRestriction, isServiceId, createRefToElmWithValue } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { Field as SalesforceField } from 'jsforce'
 import { restoreValues, resolveValues } from '@salto-io/adapter-utils'
@@ -1236,7 +1238,7 @@ describe('transformer', () => {
         childTypeNames: new Set(),
         client,
       })
-      expect(element.path).not.toContain(SUBTYPES_PATH)
+      expect(getTopLevelPath(element)).not.toContain(SUBTYPES_PATH)
     })
 
     it('should create a type which is not a base element as subtype', async () => {
@@ -1247,7 +1249,7 @@ describe('transformer', () => {
         childTypeNames: new Set(),
         client,
       })
-      expect(element.path).toContain(SUBTYPES_PATH)
+      expect(getTopLevelPath(element)).toContain(SUBTYPES_PATH)
     })
 
     it('should add internal id field for base types', async () => {
@@ -1299,7 +1301,7 @@ describe('transformer', () => {
       })
       expect(elements).toHaveLength(1)
       const [element] = elements
-      expect(element.path).not.toContain(SUBTYPES_PATH)
+      expect(getTopLevelPath(element)).not.toContain(SUBTYPES_PATH)
       expect(connection.metadata.describeValueType).toHaveBeenCalledTimes(0)
     })
 
@@ -1316,10 +1318,10 @@ describe('transformer', () => {
       })
       expect(elements).toHaveLength(3)
       const [element, fieldType, nestedFieldType] = elements
-      expect(element.path).not.toContain(SUBTYPES_PATH)
-      expect(fieldType.path).toContain(SUBTYPES_PATH)
+      expect(getTopLevelPath(element)).not.toContain(SUBTYPES_PATH)
+      expect(getTopLevelPath(fieldType)).toContain(SUBTYPES_PATH)
       expect(connection.metadata.describeValueType).toHaveBeenCalledTimes(1)
-      expect(nestedFieldType.path).toContain(SUBTYPES_PATH)
+      expect(getTopLevelPath(nestedFieldType)).toContain(SUBTYPES_PATH)
       expect(await nestedFieldType.fields.inner.getType()).toEqual(BuiltinTypes.STRING)
     })
 
@@ -1336,9 +1338,9 @@ describe('transformer', () => {
       })
       expect(elements).toHaveLength(3)
       const [element, fieldType, nestedFieldType] = elements
-      expect(element.path).not.toContain(SUBTYPES_PATH)
-      expect(fieldType.path).toContain(SUBTYPES_PATH)
-      expect(nestedFieldType.path).toContain(SUBTYPES_PATH)
+      expect(getTopLevelPath(element)).not.toContain(SUBTYPES_PATH)
+      expect(getTopLevelPath(fieldType)).toContain(SUBTYPES_PATH)
+      expect(getTopLevelPath(nestedFieldType)).toContain(SUBTYPES_PATH)
       expect(connection.metadata.describeValueType).toHaveBeenCalledTimes(1)
     })
 
@@ -1352,8 +1354,8 @@ describe('transformer', () => {
       })
       expect(elements).toHaveLength(2)
       const [element, fieldType] = elements
-      expect(element.path).not.toContain(SUBTYPES_PATH)
-      expect(fieldType.path).toContain(SUBTYPES_PATH)
+      expect(getTopLevelPath(element)).not.toContain(SUBTYPES_PATH)
+      expect(getTopLevelPath(fieldType)).toContain(SUBTYPES_PATH)
       expect(connection.metadata.describeValueType).toHaveBeenCalledTimes(1)
     })
 
@@ -1373,7 +1375,7 @@ describe('transformer', () => {
         client,
       })
       expect(elements).toHaveLength(1)
-      expect(elements[0].path).not.toContain(SUBTYPES_PATH)
+      expect(getTopLevelPath(elements[0])).not.toContain(SUBTYPES_PATH)
       expect(connection.metadata.describeValueType).toHaveBeenCalledTimes(0)
     })
 
@@ -1389,7 +1391,7 @@ describe('transformer', () => {
         client,
       })
       expect(elements).toHaveLength(1)
-      expect(elements[0].path).not.toContain(SUBTYPES_PATH)
+      expect(getTopLevelPath(elements[0])).not.toContain(SUBTYPES_PATH)
       expect(connection.metadata.describeValueType).toHaveBeenCalledTimes(0)
     })
 

--- a/packages/salesforce-adapter/test/utils.ts
+++ b/packages/salesforce-adapter/test/utils.ts
@@ -16,16 +16,13 @@
 import _ from 'lodash'
 import {
   Element, ElemID, Values, ObjectType, Field, TypeElement, BuiltinTypes, ListType, MapType,
-  CORE_ANNOTATIONS, PrimitiveType, PrimitiveTypes,
+  CORE_ANNOTATIONS, PrimitiveType, PrimitiveTypes, createPathIndexFromPath,
 } from '@salto-io/adapter-api'
 import {
   findElements as findElementsByID, buildElementsSourceFromElements,
 } from '@salto-io/adapter-utils'
 import JSZip from 'jszip'
 import * as constants from '../src/constants'
-import {
-  annotationsFileName, customFieldsFileName, standardFieldsFileName,
-} from '../src/filters/custom_object_split'
 import { getNamespaceFromString } from '../src/filters/utils'
 import { FilterContext } from '../src/filter'
 import { allSystemFields } from '../src/adapter'
@@ -104,24 +101,6 @@ export const createEncodedZipContent = async (files: ZipFile[],
   const zip = new JSZip()
   files.forEach(file => zip.file(file.path, file.content))
   return (await zip.generateAsync({ type: 'nodebuffer' })).toString(encoding)
-}
-
-export const findCustomFieldsObject = (elements: Element[], name: string): ObjectType => {
-  const customObjects = findElements(elements, name) as ObjectType[]
-  return customObjects
-    .find(obj => obj.path?.slice(-1)[0] === customFieldsFileName(name)) as ObjectType
-}
-
-export const findStandardFieldsObject = (elements: Element[], name: string): ObjectType => {
-  const customObjects = findElements(elements, name) as ObjectType[]
-  return customObjects
-    .find(obj => obj.path?.slice(-1)[0] === standardFieldsFileName(name)) as ObjectType
-}
-
-export const findAnnotationsObject = (elements: Element[], name: string): ObjectType => {
-  const customObjects = findElements(elements, name) as ObjectType[]
-  return customObjects
-    .find(obj => obj.path?.slice(-1)[0] === annotationsFileName(name)) as ObjectType
 }
 
 export const findFullCustomObject = (elements: Element[], name: string): ObjectType => {
@@ -279,7 +258,7 @@ export const createCustomSettingsObject = (
     ? [constants.SALESFORCE, constants.INSTALLED_PACKAGES_PATH, namespace,
       constants.OBJECTS_PATH, obj.elemID.name]
     : [constants.SALESFORCE, constants.OBJECTS_PATH, obj.elemID.name]
-  obj.path = path
+  obj.pathIndex = createPathIndexFromPath(obj.elemID, path)
   return obj
 }
 

--- a/packages/workspace/src/element_adapter_rename.ts
+++ b/packages/workspace/src/element_adapter_rename.ts
@@ -31,6 +31,8 @@ import {
   Element,
   ElemID,
   GLOBAL_ADAPTER,
+  createPathIndexFromPath,
+  getTopLevelPath,
 } from '@salto-io/adapter-api'
 import { transformElement, TransformFunc } from '@salto-io/adapter-utils'
 import { UnresolvedReference } from './expressions'
@@ -113,9 +115,17 @@ const transformElemIDAdapter = (accountName: string): TransformFunc => async (
 export const updateElementsWithAlternativeAccount = async (elementsToUpdate: Element[],
   newAccount: string, oldAccount: string, source?: ReadOnlyElementsSource): Promise<void> =>
   awu(elementsToUpdate).forEach(async element => {
-    if (element.path !== undefined && (element.path[0] === oldAccount)) {
-      element.path = [newAccount, ...element.path.slice(1)]
+    // TODO: fix it - THIS IS WRONG RIGHT NOW
+    if (element.pathIndex !== undefined && (getTopLevelPath(element)[0] === oldAccount)) {
+      element.pathIndex = createPathIndexFromPath(
+        element.elemID, [newAccount, ...getTopLevelPath(element).slice(1)]
+      )
     }
+    // if (element.pathIndex !== undefined && (element.path[0] === oldAccount)) {
+    //   element.pathIndex = createPathIndexFromPath(
+    //     element.elemID, [newAccount, ...element.path.slice(1)]
+    //   )
+    // }
     if (element.elemID.adapter === oldAccount) {
       await transformElement({
         element,

--- a/packages/workspace/src/merger/internal/variables.ts
+++ b/packages/workspace/src/merger/internal/variables.ts
@@ -29,6 +29,7 @@ const mergeVariableDefinitions = (
   errors: variableDefs.length > 1
     ? [new DuplicateVariableNameError({ elemID: variableDefs[0].elemID })]
     : [],
+  pathIndex: variableDefs[0].pathIndex,
 })
 
 export const mergeVariables = (

--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -267,12 +267,16 @@ const generalDeserialize = async <T>(
       return restoreClasses(v.innerType)
     }
 
+    const reviveTreeMap = <S>(v: Value): collections.treeMap.TreeMap<S> => (
+      collections.treeMap.TreeMap.fromTreeMapEntry(v.data, v.separator)
+    )
+
     const revivers: ReviverMap = {
       InstanceElement: v => new InstanceElement(
         v.elemID.nameParts[0],
         reviveRefTypeOfElement(v),
         restoreClasses(v.value),
-        v.path,
+        v.pathIndex ? reviveTreeMap(v.pathIndex) : v.path,
         restoreClasses(v.annotations),
       ),
       ObjectType: v => {
@@ -282,19 +286,23 @@ const generalDeserialize = async <T>(
           annotationRefsOrTypes: reviveAnnotationRefTypes(v),
           annotations: restoreClasses(v.annotations),
           isSettings: v.isSettings,
-          path: v.path,
+          path: v.pathIndex ? reviveTreeMap(v.pathIndex) : v.path,
         })
         return r
       },
       Variable: v => (
-        new Variable(reviveElemID(v.elemID), restoreClasses(v.value))
+        new Variable(
+          reviveElemID(v.elemID),
+          restoreClasses(v.value),
+          v.pathIndex ? reviveTreeMap(v.pathIndex) : v.path
+        )
       ),
       PrimitiveType: v => new PrimitiveType({
         elemID: reviveElemID(v.elemID),
         primitive: v.primitive,
         annotationRefsOrTypes: reviveAnnotationRefTypes(v),
         annotations: restoreClasses(v.annotations),
-        path: v.path,
+        path: v.pathIndex ? reviveTreeMap(v.pathIndex) : v.path,
       }),
       ListType: v => new ListType(reviveRefInnerType(v)),
       MapType: v => new MapType(reviveRefInnerType(v)),

--- a/packages/workspace/src/workspace/adapters_config_source.ts
+++ b/packages/workspace/src/workspace/adapters_config_source.ts
@@ -159,7 +159,13 @@ export const buildAdaptersConfigSource = async ({
         data: { after: conf },
         pathIndex: createPathIndexFromPath(
           conf.elemID,
-          [...CONFIG_PATH, conf.elemID.adapter, ...getTopLevelPath(conf) ?? [conf.elemID.adapter]]
+          [
+            ...CONFIG_PATH,
+            conf.elemID.adapter,
+            ...(_.isEmpty(getTopLevelPath(conf))
+              ? [conf.elemID.adapter]
+              : getTopLevelPath(conf)),
+          ]
         ),
       }))
     )

--- a/packages/workspace/src/workspace/adapters_config_source.ts
+++ b/packages/workspace/src/workspace/adapters_config_source.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { DetailedChange, ElemID, InstanceElement, ObjectType, ReadOnlyElementsSource, SaltoError } from '@salto-io/adapter-api'
+import { createPathIndexFromPath, DetailedChange, ElemID, getTopLevelPath, InstanceElement, ObjectType, ReadOnlyElementsSource, SaltoError } from '@salto-io/adapter-api'
 import { applyDetailedChanges, buildElementsSourceFromElements, detailedCompare, transformElement } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
@@ -154,7 +154,13 @@ export const buildAdaptersConfigSource = async ({
     const configsToUpdate = await Promise.all(configsArr.map(removeUndefined))
     await naclSource.updateNaclFiles(
       configsToUpdate.map(conf => ({
-        id: conf.elemID, action: 'add', data: { after: conf }, path: [...CONFIG_PATH, conf.elemID.adapter, ...conf.path ?? [conf.elemID.adapter]],
+        id: conf.elemID,
+        action: 'add',
+        data: { after: conf },
+        pathIndex: createPathIndexFromPath(
+          conf.elemID,
+          [...CONFIG_PATH, conf.elemID.adapter, ...getTopLevelPath(conf) ?? [conf.elemID.adapter]]
+        ),
       }))
     )
   }

--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -258,7 +258,7 @@ const getHiddenTypeChanges = async (
     }
     return isChangeToHidden(change, false)
       ? createRemoveChange(elem, elemId)
-      : createAddChange(elem, elemId)
+      : createAddChange(elem, elemId) // TODO: should I add pathIndex?
   })
   .filter(values.isDefined)
   .toArray()
@@ -456,6 +456,7 @@ const getHiddenFieldAndAnnotationValueChanges = async (
           if (annotationsToHide?.has(name)) {
             hiddenValueChanges.push(createRemoveChange(attrValue, path.createNestedID(name)))
           } else if (annotationsToUnHide?.has(name)) {
+            // TODO: should I add pathIndex?
             hiddenValueChanges.push(createAddChange(attrValue, path.createNestedID(name)))
           }
         })

--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -25,7 +25,6 @@ import { mergeElements, MergeResult } from '../merger'
 import { State } from './state'
 import { createAddChange, createRemoveChange } from './nacl_files/multi_env/projections'
 import { ElementsSource } from './elements_source'
-import { splitElementByPath } from './path_index'
 
 const { pickAsync } = promises.object
 const { awu } = collections.asynciterable
@@ -289,7 +288,6 @@ const getInstanceTypeHiddenChanges = async (
     fromHiddenChanges.map(change => change.id.createTopLevelParentID().parent.getFullName())
   )
 
-  const pathIndex = await state.getPathIndex()
   const r = await awu(await state.getAll())
     .flatMap(async elem => {
       if (isInstanceElement(elem)) {
@@ -297,8 +295,7 @@ const getInstanceTypeHiddenChanges = async (
           return [createRemoveChange(elem, elem.elemID)]
         }
         if (fromHiddenElemIds.has(elem.refType.elemID.getFullName())) {
-          return (await splitElementByPath(elem, pathIndex))
-            .map(fragment => createAddChange(fragment, elem.elemID, fragment.path))
+          return [createAddChange(elem, elem.elemID, elem.pathIndex)]
         }
       }
       return []
@@ -673,7 +670,7 @@ const diffElements = <T extends Element>(visibleElem?: T, fullElem?: T): T | und
       annotationRefsOrTypes: diffAnnoTypes,
       annotations: diffAnno,
       fields: diffFields,
-      path: fullElem.path,
+      path: fullElem.pathIndex,
       isSettings: fullElem.isSettings,
     }) as unknown as T
   }
@@ -683,7 +680,7 @@ const diffElements = <T extends Element>(visibleElem?: T, fullElem?: T): T | und
       primitive: fullElem.primitive,
       annotationRefsOrTypes: diffAnnoTypes as ReferenceMap,
       annotations: diffAnno,
-      path: fullElem.path,
+      path: fullElem.pathIndex,
     }) as unknown as T
   }
   if (isInstanceElement(fullElem) && isInstanceElement(visibleElem)) {
@@ -695,7 +692,7 @@ const diffElements = <T extends Element>(visibleElem?: T, fullElem?: T): T | und
       fullElem.elemID.name,
       fullElem.refType,
       diffValue,
-      fullElem.path,
+      fullElem.pathIndex,
       diffAnno
     )
     return res as unknown as T

--- a/packages/workspace/src/workspace/nacl_files/addition_wrapper.ts
+++ b/packages/workspace/src/workspace/nacl_files/addition_wrapper.ts
@@ -181,7 +181,7 @@ export const wrapNestedValues = (
 }
 
 const getPathFromDetailedAddition = (addition: DetailedAddition): string[] => (
-  addition.pathIndex.get(addition.id.getFullName()) ?? []
+  addition.pathIndex?.get(addition.id.getFullName()) ?? []
 )
 
 export const wrapAdditions = (

--- a/packages/workspace/src/workspace/nacl_files/multi_env/projections.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/projections.ts
@@ -17,6 +17,7 @@ import _ from 'lodash'
 import {
   Values, isObjectType, TypeElement, ObjectType, PrimitiveType, Field, InstanceElement,
   Element, isType, isField, isInstanceElement, getChangeData, Value, ElemID, DetailedChange,
+  PathIndex,
 } from '@salto-io/adapter-api'
 import { applyFunctionToChangeData } from '@salto-io/adapter-utils'
 import { ElementsSource } from '../../elements_source'
@@ -79,7 +80,7 @@ const projectInstance = (
       src.elemID.name,
       src.refType,
       projectedValue,
-      src.path,
+      src.pathIndex,
       projectedAnnotations
     )
 }
@@ -103,23 +104,23 @@ export const projectElementOrValueToEnv = (
 export const createAddChange = (
   value: Element | Value,
   id: ElemID,
-  path?: ReadonlyArray<string>
+  pathIndex?: PathIndex
 ): DetailedChange => ({
   data: { after: value },
   action: 'add',
   id,
-  path,
+  pathIndex,
 })
 
 export const createRemoveChange = (
   value: Element | Value,
   id: ElemID,
-  path?: ReadonlyArray<string>
+  pathIndex?: PathIndex
 ): DetailedChange => ({
   data: { before: value },
   action: 'remove',
   id,
-  path,
+  pathIndex,
 })
 
 export const projectChange = async (

--- a/packages/workspace/src/workspace/nacl_files/multi_env/projections.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/projections.ts
@@ -17,8 +17,8 @@ import _ from 'lodash'
 import {
   Values, isObjectType, TypeElement, ObjectType, PrimitiveType, Field, InstanceElement,
   Element, isType, isField, isInstanceElement, getChangeData, Value, ElemID, DetailedChange,
-  PathIndex,
 } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
 import { applyFunctionToChangeData } from '@salto-io/adapter-utils'
 import { ElementsSource } from '../../elements_source'
 
@@ -104,7 +104,7 @@ export const projectElementOrValueToEnv = (
 export const createAddChange = (
   value: Element | Value,
   id: ElemID,
-  pathIndex?: PathIndex
+  pathIndex?: collections.treeMap.TreeMap<string>
 ): DetailedChange => ({
   data: { after: value },
   action: 'add',
@@ -115,12 +115,10 @@ export const createAddChange = (
 export const createRemoveChange = (
   value: Element | Value,
   id: ElemID,
-  pathIndex?: PathIndex
 ): DetailedChange => ({
   data: { before: value },
   action: 'remove',
   id,
-  pathIndex,
 })
 
 export const projectChange = async (

--- a/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
@@ -74,7 +74,8 @@ const filterByFile = async (
       e,
       getMergeableParentID(id, fileElements).mergeableID
     ) !== undefined
-  ))
+  )),
+  true
 )
 
 const isEmptyAnnoAndAnnoTypes = (element: Element): boolean =>

--- a/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
@@ -106,6 +106,11 @@ const separateChangeByFiles = async (
   if (_.isEmpty(elementNaclFiles)) {
     return [change]
   }
+  // Note: this is the only place in the workspace (aside from updateNaclFiles in naclFileSource)
+  //  that we are splitting the elements. Therefore, from this point, we can't assume that
+  //  the changes are merged.
+  //  Once we implement the merge of pathIndex in mergeElements, we would be able to keep the
+  //  changes merged and we won't need this function
   const sortedChanges = (await Promise.all(
     (elementNaclFiles)
       .map(async filename => {

--- a/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
@@ -300,7 +300,7 @@ const createMergeableChange = async (
   return {
     action: 'modify',
     id: mergeableID,
-    path: refChange.path,
+    pathIndex: refChange.pathIndex,
     data: {
       before: base,
       after: baseAfter,
@@ -416,18 +416,23 @@ export const routeDefault = async (
   return routeDefaultRemoveOrModify(change, primarySource, commonSource, secondarySources)
 }
 
-const getChangePathHint = async (
-  change: DetailedChange,
-  commonSource: NaclFilesSource
-): Promise<ReadonlyArray<string> | undefined> => {
-  if (change.path) return change.path
-  const refFilename = (await commonSource.getSourceRanges(change.id))
-    .map(sourceRange => sourceRange.filename)[0]
+// const getChangePathHint = async (
+//   change: DetailedChange,
+//   commonSource: NaclFilesSource
+// ): Promise<ReadonlyArray<string> | undefined> => {
+//   // TODO: fix me!!!
+//   // if (change.path) return change.path
+//   if (change.pathIndex) {
+//     return change.pathIndex.get(change.id.getFullName())
+//       ?? change.pathIndex.get(change.id.createTopLevelParentID().parent.getFullName())
+//   }
+//   const refFilename = (await commonSource.getSourceRanges(change.id))
+//     .map(sourceRange => sourceRange.filename)[0]
 
-  return refFilename
-    ? toPathHint(refFilename)
-    : undefined
-}
+//   return refFilename
+//     ? toPathHint(refFilename)
+//     : undefined
+// }
 
 export const routeIsolated = async (
   change: DetailedChange,
@@ -437,7 +442,7 @@ export const routeIsolated = async (
 ): Promise<RoutedChangesByRole> => {
   // This is an add change, which means the element is not in common.
   // so we will add it to the current action environment.
-  const pathHint = await getChangePathHint(change, commonSource)
+  // const pathHint = await getChangePathHint(change, commonSource)
 
   if (change.action === 'add') {
     return { primarySource: [change] }
@@ -475,7 +480,7 @@ export const routeIsolated = async (
   return {
     // No need to apply addToSource to primary env changes since it was handled by the original plan
     primarySource: [...currentEnvChanges, ...addCommonProjectionToCurrentChanges],
-    commonSource: [createRemoveChange(currentCommonElement, change.id, pathHint)],
+    commonSource: [createRemoveChange(currentCommonElement, change.id, change.pathIndex)],
     secondarySources: secondaryChanges,
   }
 }

--- a/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
@@ -328,7 +328,6 @@ export const getChangesToUpdate = (
   changes: DetailedChange[],
   sourceMap: SourceMap
 ): DetailedChange[] => {
-  // TODO: fix me!!! - we need to test this flow with nested additions
   const isNestedAddition = (dc: DetailedChange): boolean => (dc.pathIndex || false)
     && dc.action === 'add'
     && dc.id.idType !== 'instance'

--- a/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
@@ -74,13 +74,16 @@ export const getChangeLocations = (
       const possibleLocations = sourceMap.get(parentID.getFullName()) || []
       if (possibleLocations.length > 0) {
         const foundInPath = possibleLocations.find(sr =>
-          sr.filename === createFileNameFromPath(change.path))
+          // TODO: fix me!!!
+          // sr.filename === createFileNameFromPath(change.path))
+          sr.filename === createFileNameFromPath())
         // TODO: figure out how to choose the correct location if there is more than one option
         return [lastNestedLocation(foundInPath || possibleLocations[0])]
       }
     }
     // Fallback to using the path from the element itself
-    const naclFilePath = change.path ?? getChangeData(change).path
+    // TODO: fix me!!!
+    const naclFilePath = change.pathIndex ?? getChangeData(change).pathIndex
     const endOfFileLocation = { col: 1, line: Infinity, byte: Infinity }
     return [{
       filename: createFileNameFromPath(naclFilePath),
@@ -316,14 +319,18 @@ const parentElementExistsInPath = (
 ): boolean => {
   const { parent } = dc.id.createTopLevelParentID()
   return _.some(sourceMap.get(parent.getFullName())?.map(
-    range => range.filename === createFileNameFromPath(dc.path)
+    // TODO: fix me!!!
+    // range => range.filename === createFileNameFromPath(dc.path)
+    range => range.filename === createFileNameFromPath()
   ))
 }
 export const getChangesToUpdate = (
   changes: DetailedChange[],
   sourceMap: SourceMap
 ): DetailedChange[] => {
-  const isNestedAddition = (dc: DetailedChange): boolean => (dc.path || false)
+  // TODO: fix me!!!
+  // const isNestedAddition = (dc: DetailedChange): boolean => (dc.path || false)
+  const isNestedAddition = (dc: DetailedChange): boolean => (dc.pathIndex || false)
     && dc.action === 'add'
     && dc.id.idType !== 'instance'
     && dc.id.nestingLevel === (dc.id.isAnnotationTypeID() ? 2 : 1)

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -40,6 +40,7 @@ import { RemoteMap, RemoteMapCreator } from '../remote_map'
 import { ParsedNaclFile } from './parsed_nacl_file'
 import { ParsedNaclFileCache, createParseResultCache } from './parsed_nacl_files_cache'
 import { isInvalidStaticFile } from '../static_files/common'
+import { splitDetailedChange } from '../path_index'
 
 const { awu } = collections.asynciterable
 type ThenableIterable<T> = collections.asynciterable.ThenableIterable<T>
@@ -756,8 +757,8 @@ const buildNaclFilesSource = (
     await awu(emptyNaclFiles).forEach(naclFile => naclFilesStore.delete(naclFile.filename))
   }
 
-  const updateNaclFiles = async (changes: DetailedChange[]): Promise<ChangeSet<Change>> => {
-    // TODO: return to fragments
+  const updateNaclFiles = async (mergedChanges: DetailedChange[]): Promise<ChangeSet<Change>> => {
+    const changes = mergedChanges.flatMap(splitDetailedChange)
     const preChangeHash = await (await state)?.parsedNaclFiles.getHash()
     const getNaclFileData = async (filename: string): Promise<string> => {
       const naclFile = await naclFilesStore.get(filename)

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -19,7 +19,7 @@ import { logger } from '@salto-io/logging'
 import { Element, ElemID, Value, DetailedChange, isElement, getChangeData, isObjectType,
   isInstanceElement, isIndexPathPart, isReferenceExpression, isContainerType, isVariable, Change,
   placeholderReadonlyElementsSource, ObjectType, isModificationChange,
-  isObjectTypeChange, toChange, isAdditionChange, StaticFile, isStaticFile } from '@salto-io/adapter-api'
+  isObjectTypeChange, toChange, isAdditionChange, StaticFile, isStaticFile, createPathIndexFromPath } from '@salto-io/adapter-api'
 import { resolvePath, TransformFuncArgs, transformElement, safeJsonStringify } from '@salto-io/adapter-utils'
 import { promises, values, collections } from '@salto-io/lowerdash'
 import { AdditionDiff } from '@salto-io/dag'
@@ -656,7 +656,9 @@ const buildNaclFilesSource = (
       elements: async () => {
         const parsedElement = await parsed.elements()
         return parsedElement && parsedElement.map(elem => {
-          elem.path = toPathHint(filename)
+          // TODO: double check it - I think its wrong
+          // We need to do it and merge elements with path indexes
+          elem.pathIndex = createPathIndexFromPath(elem.elemID, toPathHint(filename))
           return elem
         })
       },
@@ -755,6 +757,7 @@ const buildNaclFilesSource = (
   }
 
   const updateNaclFiles = async (changes: DetailedChange[]): Promise<ChangeSet<Change>> => {
+    // TODO: return to fragments
     const preChangeHash = await (await state)?.parsedNaclFiles.getHash()
     const getNaclFileData = async (filename: string): Promise<string> => {
       const naclFile = await naclFilesStore.get(filename)

--- a/packages/workspace/src/workspace/path_index.ts
+++ b/packages/workspace/src/workspace/path_index.ts
@@ -361,29 +361,3 @@ export const splitDetailedChange = (
     id: change.id,
   }))
 }
-
-const getPathOfId = (elemID: ElemID, pathIndex: collections.treeMap.TreeMap<string>): string[] => {
-  const idParts = elemID.getFullNameParts()
-  const topLevelKey = elemID.createTopLevelParentID().parent.getFullName()
-  let key: string
-  do {
-    key = idParts.join(ElemID.NAMESPACE_SEPARATOR)
-    const pathHint = pathIndex.get(key)
-    if (pathHint !== undefined) {
-      return pathHint
-    }
-    idParts.pop()
-  } while (idParts.length > 0 && key !== topLevelKey)
-  return []
-}
-
-export const getPathIndexOfId = (
-  elemID: ElemID, pathIndex: collections.treeMap.TreeMap<string>
-): collections.treeMap.TreeMap<string> => {
-  const rootPath = getPathOfId(elemID, pathIndex)
-  const pathIndexOfId = new collections.treeMap.TreeMap<string>(
-    pathIndex.entriesWithPrefix(elemID.getFullName())
-  )
-  pathIndexOfId.set(elemID.getFullName(), rootPath)
-  return pathIndexOfId
-}

--- a/packages/workspace/test/workspace/adapters_config.test.ts
+++ b/packages/workspace/test/workspace/adapters_config.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { InstanceElement, ObjectType, ElemID, DetailedChange, getChangeData } from '@salto-io/adapter-api'
+import { InstanceElement, ObjectType, ElemID, DetailedChange, getChangeData, createPathIndexFromPath } from '@salto-io/adapter-api'
 import { mockFunction, MockInterface } from '@salto-io/test-utils'
 import wu from 'wu'
 import { collections } from '@salto-io/lowerdash'
@@ -155,37 +155,61 @@ describe('adapters config', () => {
     expect(await configSource.getAdapter('salesforce')).toBeUndefined()
   })
   it('should set adapter in nacl files source with the default path', async () => {
-    await configSource.setAdapter('salesforce', 'salesforce', new InstanceElement(
+    const instance = new InstanceElement(
       ElemID.CONFIG_NAME,
       new ObjectType({
         elemID: new ElemID('salesforce', ElemID.CONFIG_NAME),
       })
-    ))
-    expect(mockNaclFilesSource.updateNaclFiles).toHaveBeenCalledWith([expect.objectContaining({ path: ['salto.config', 'adapters', 'salesforce', 'salesforce'] })])
+    )
+    await configSource.setAdapter('salesforce', 'salesforce', instance)
+    expect(mockNaclFilesSource.updateNaclFiles)
+      .toHaveBeenCalledWith([
+        expect.objectContaining({
+          pathIndex: createPathIndexFromPath(
+            instance.elemID,
+            ['salto.config', 'adapters', 'salesforce', 'salesforce']
+          ),
+        })])
     expect(mockNaclFilesSource.flush).toHaveBeenCalled()
   })
 
   it('should set adapter in nacl files source with the config path', async () => {
-    await configSource.setAdapter('salesforce', 'salesforce', new InstanceElement(
+    const instance = new InstanceElement(
       ElemID.CONFIG_NAME,
       new ObjectType({
         elemID: new ElemID('salesforce', ElemID.CONFIG_NAME),
       }),
       {},
       ['dir', 'file']
-    ))
-    expect(mockNaclFilesSource.updateNaclFiles).toHaveBeenCalledWith([expect.objectContaining({ path: ['salto.config', 'adapters', 'salesforce', 'dir', 'file'] })])
+    )
+    await configSource.setAdapter('salesforce', 'salesforce', instance)
+    expect(mockNaclFilesSource.updateNaclFiles)
+      .toHaveBeenCalledWith([
+        expect.objectContaining({
+          pathIndex: createPathIndexFromPath(
+            instance.elemID,
+            ['salto.config', 'adapters', 'salesforce', 'dir', 'file']
+          ),
+        })])
     expect(mockNaclFilesSource.flush).toHaveBeenCalled()
   })
 
   it('should set adapter in nacl files source with the config path, if account name isnt same as service', async () => {
-    await configSource.setAdapter('salesforce2', 'salesforce', new InstanceElement(
+    const instance = new InstanceElement(
       ElemID.CONFIG_NAME,
       new ObjectType({
         elemID: new ElemID('salesforce2', ElemID.CONFIG_NAME),
       }),
-    ))
-    expect(mockNaclFilesSource.updateNaclFiles).toHaveBeenCalledWith([expect.objectContaining({ path: ['salto.config', 'adapters', 'salesforce2', 'salesforce2'] })])
+    )
+    await configSource.setAdapter('salesforce2', 'salesforce', instance)
+    expect(mockNaclFilesSource.updateNaclFiles)
+      .toHaveBeenCalledWith([
+        expect.objectContaining({
+          pathIndex: createPathIndexFromPath(
+            instance.elemID,
+            ['salto.config', 'adapters', 'salesforce2', 'salesforce2']
+          ),
+        })])
     expect(mockNaclFilesSource.flush).toHaveBeenCalled()
   })
 

--- a/packages/workspace/test/workspace/hidden_values.test.ts
+++ b/packages/workspace/test/workspace/hidden_values.test.ts
@@ -698,12 +698,13 @@ describe('handleHiddenChanges', () => {
       it('should create add changes with the instance value from the state', () => {
         const addChanges = changes
           .filter(c => c.id.getFullName() === hidden.elemID.getFullName() && isAdditionChange(c))
-        expect(addChanges).toHaveLength(2)
-        expect(addChanges.map(c => c.path)).toEqual(
-          [
-            ['this', 'is', 'path', 'to', 'hidden'],
-            ['this', 'is', 'path', 'to', 'hidden2'],
-          ]
+        expect(addChanges).toHaveLength(1)
+        // TODO: fix me!!!
+        expect(addChanges.map(c => c.pathIndex)).toEqual(
+          new collections.treeMap.TreeMap([
+            ['', ['this', 'is', 'path', 'to', 'hidden']],
+            ['', ['this', 'is', 'path', 'to', 'hidden2']],
+          ])
         )
       })
     })

--- a/packages/workspace/test/workspace/hidden_values.test.ts
+++ b/packages/workspace/test/workspace/hidden_values.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { ObjectType, ElemID, BuiltinTypes, PrimitiveType, PrimitiveTypes, isObjectType, InstanceElement, isInstanceElement, CORE_ANNOTATIONS, DetailedChange, getChangeData, INSTANCE_ANNOTATIONS, ReferenceExpression, MapType, isRemovalChange, isAdditionChange } from '@salto-io/adapter-api'
+import { ObjectType, ElemID, BuiltinTypes, PrimitiveType, PrimitiveTypes, isObjectType, InstanceElement, isInstanceElement, CORE_ANNOTATIONS, DetailedChange, getChangeData, INSTANCE_ANNOTATIONS, ReferenceExpression, MapType, isRemovalChange, isAdditionChange, createPathIndexFromPath } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { mockState } from '../common/state'
 import { MergeResult } from '../../src/merger'
@@ -698,14 +698,11 @@ describe('handleHiddenChanges', () => {
       it('should create add changes with the instance value from the state', () => {
         const addChanges = changes
           .filter(c => c.id.getFullName() === hidden.elemID.getFullName() && isAdditionChange(c))
-        expect(addChanges).toHaveLength(1)
-        // TODO: fix me!!!
-        expect(addChanges.map(c => c.pathIndex)).toEqual(
-          new collections.treeMap.TreeMap([
-            ['', ['this', 'is', 'path', 'to', 'hidden']],
-            ['', ['this', 'is', 'path', 'to', 'hidden2']],
-          ])
-        )
+        expect(addChanges).toHaveLength(2)
+        expect(addChanges.map(c => c.pathIndex)).toEqual([
+          createPathIndexFromPath(hidden.elemID, ['this', 'is', 'path', 'to', 'hidden']),
+          createPathIndexFromPath(hidden.elemID, ['this', 'is', 'path', 'to', 'hidden2']),
+        ])
       })
     })
   })

--- a/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
+++ b/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
@@ -563,7 +563,7 @@ describe('multi env source', () => {
         _.sortBy(elementChanges[primarySourceName]
           .changes, c => getChangeData(c).elemID.getFullName())
       ).toEqual(_.sortBy(detailedChanges, c => getChangeData(c).elemID.getFullName())
-        .map(dc => _.omit(dc, ['path', 'id'])))
+        .map(dc => _.omit(dc, ['pathIndex', 'id'])))
       expect(sortElemArray(elements)).toEqual(sortElemArray([commonObject, newEnvFragment]))
     })
   })

--- a/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
+++ b/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import path from 'path'
-import { Element, ElemID, BuiltinTypes, ObjectType, DetailedChange, Change, getChangeData, StaticFile } from '@salto-io/adapter-api'
+import { Element, ElemID, BuiltinTypes, ObjectType, DetailedChange, Change, getChangeData, StaticFile, createPathIndexFromPath } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import * as utils from '@salto-io/adapter-utils'
 import { MockInterface } from '@salto-io/test-utils'
@@ -440,7 +440,7 @@ describe('multi env source', () => {
         await multiEnvSourceWithMockSources.getAll(primarySourceName)
       ).toArray()
       expect(currentElements).toHaveLength(2)
-      const detailedChange = { ...change, id: commonElemID, path: ['test'] } as DetailedChange
+      const detailedChange = { ...change, id: commonElemID, pathIndex: createPathIndexFromPath(commonElemID, ['test']) } as DetailedChange
       const elementChanges = (await multiEnvSourceWithMockSources
         .updateNaclFiles(primarySourceName, [detailedChange]))
       expect(elementChanges[primarySourceName].changes).toEqual([change])
@@ -537,19 +537,19 @@ describe('multi env source', () => {
         {
           action: 'remove',
           data: { before: envObject },
-          path: ['bla1'],
+          pathIndex: createPathIndexFromPath(envElemID, ['bla1']),
           id: envElemID,
         },
         {
           action: 'modify',
           data: { before: mergedSaltoObject, after: newEnvFragment },
-          path: ['bla'],
+          pathIndex: createPathIndexFromPath(objectElemID, ['bla']),
           id: objectElemID,
         },
         {
           action: 'add',
           data: { after: commonObject },
-          path: ['bla1'],
+          pathIndex: createPathIndexFromPath(commonElemID, ['bla1']),
           id: commonElemID,
         },
       ] as DetailedChange[]

--- a/packages/workspace/test/workspace/nacl_files/nacl_file_update.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_file_update.test.ts
@@ -95,7 +95,7 @@ describe('getChangeLocations', () => {
     })
     it('should use the default filename when no path is provided', () => {
       const noPath = mockType.clone()
-      noPath.path = undefined
+      noPath.pathIndex = undefined
       const change: DetailedChange = { ...toChange({ after: noPath }), id: noPath.elemID }
       result = getChangeLocations(change, new Map())
       expect(result).toHaveLength(1)

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Element, ElemID, ObjectType, DetailedChange, StaticFile, SaltoError, Value, BuiltinTypes, createRefToElmWithValue, InstanceElement } from '@salto-io/adapter-api'
+import { Element, ElemID, ObjectType, DetailedChange, StaticFile, SaltoError, Value, BuiltinTypes, createRefToElmWithValue, InstanceElement, getTopLevelPath } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { MockInterface } from '@salto-io/test-utils'
@@ -80,7 +80,8 @@ const validateParsedNaclFile = async (
     const parsedElements = await awu((await parsed.elements()) ?? []).toArray()
     expect(parsedElements).toEqual(elements)
     parsedElements.forEach(
-      elem => expect(elem.path).toEqual(naclFileSourceModule.toPathHint(filename))
+      // TODO: fix me!!!
+      elem => expect(getTopLevelPath(elem)).toEqual(naclFileSourceModule.toPathHint(filename))
     )
     expect(await parsed.data.errors()).toEqual(errors)
     expect(parsed.filename).toEqual(filename)

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
@@ -80,7 +80,6 @@ const validateParsedNaclFile = async (
     const parsedElements = await awu((await parsed.elements()) ?? []).toArray()
     expect(parsedElements).toEqual(elements)
     parsedElements.forEach(
-      // TODO: fix me!!!
       elem => expect(getTopLevelPath(elem)).toEqual(naclFileSourceModule.toPathHint(filename))
     )
     expect(await parsed.data.errors()).toEqual(errors)

--- a/packages/workspace/test/workspace/state.test.ts
+++ b/packages/workspace/test/workspace/state.test.ts
@@ -18,9 +18,9 @@ import { collections } from '@salto-io/lowerdash'
 import { mockFunction, MockInterface } from '@salto-io/test-utils'
 import { serialize } from '../../src/serializer'
 import { StateData, buildInMemState, buildStateData } from '../../src/workspace/state'
-import { PathIndex, getElementsPathHints } from '../../src/workspace/path_index'
+import { PathIndex, Path, getElementsPathHints } from '../../src/workspace/path_index'
 import { createInMemoryElementSource } from '../../src/workspace/elements_source'
-import { InMemoryRemoteMap, RemoteMapCreator } from '../../src/workspace/remote_map'
+import { InMemoryRemoteMap, RemoteMapCreator, RemoteMapEntry } from '../../src/workspace/remote_map'
 import { StaticFilesSource } from '../../src/workspace/static_files/common'
 import { mockStaticFilesSource } from '../utils'
 
@@ -42,7 +42,7 @@ describe('state', () => {
   let newElem: ObjectType
 
   beforeAll(async () => {
-    pathIndex = new InMemoryRemoteMap(getElementsPathHints([elem]))
+    pathIndex = new InMemoryRemoteMap([] as RemoteMapEntry<Path[]>[])
   })
 
   beforeEach(() => {

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -23,6 +23,7 @@ import {
   SaltoError,
   StaticFile,
   isStaticFile,
+  createPathIndexFromPath,
 } from '@salto-io/adapter-api'
 import { findElement, applyDetailedChanges } from '@salto-io/adapter-utils'
 // eslint-disable-next-line no-restricted-imports
@@ -1182,7 +1183,7 @@ describe('workspace', () => {
 
     const changes: DetailedChange[] = [
       {
-        path: ['file'],
+        pathIndex: createPathIndexFromPath(newMultiLineField.elemID, ['file']),
         id: newMultiLineField.elemID,
         action: 'add',
         data: {
@@ -1265,55 +1266,56 @@ describe('workspace', () => {
         data: { before: oldField, after: newField },
       },
       {
-        path: ['other', 'bar'],
+        pathIndex: createPathIndexFromPath(anotherNewField.elemID, ['other', 'bar']),
         id: anotherNewField.elemID,
         action: 'add',
         data: { after: anotherNewField },
       },
+      // TODO: fix all those comment out lines
       {
-        path: ['other', 'battr'],
+        // path: ['other', 'battr'],
         id: new ElemID('salesforce', 'lead', 'attr', 'bobo'),
         action: 'add',
         data: { after: 'baba' },
       },
       {
-        path: ['other', 'boo'],
+        // path: ['other', 'boo'],
         id: new ElemID('salesforce', 'lead', 'attr', 'nono'),
         action: 'add',
         data: { after: 'nono' },
       },
       {
-        path: ['other', 'boo'],
+        // path: ['other', 'boo'],
         id: new ElemID('salesforce', 'lead', 'attr', 'momo'),
         action: 'add',
         data: { after: 'momo' },
       },
       { // Add to an exiting path
-        path: ['file'],
+        // path: ['file'],
         id: new ElemID('salesforce', 'lead', 'attr', 'dodo'),
         action: 'add',
         data: { after: 'dodo' },
       },
       { // new annotation type to a type with no annotation types block
-        path: ['file'],
+        // path: ['file'],
         id: new ElemID('salesforce', 'lead', 'annotation', 'newAnnoType1'),
         action: 'add',
         data: { after: createRefToElmWithValue(BuiltinTypes.STRING) },
       },
       { // new annotation type to a type with no annotation types block
-        path: ['file'],
+        // path: ['file'],
         id: new ElemID('salesforce', 'lead', 'annotation', 'newAnnoType2'),
         action: 'add',
         data: { after: createRefToElmWithValue(BuiltinTypes.NUMBER) },
       },
       { // new hidden annotation type
-        path: ['file'],
+        // path: ['file'],
         id: new ElemID('salesforce', 'lead', 'annotation', 'newHiddenAnno'),
         action: 'add',
         data: { after: createRefToElmWithValue(BuiltinTypes.HIDDEN_STRING) },
       },
       { // new annotation type to a type with annotation types block
-        path: ['file'],
+        // path: ['file'],
         id: new ElemID('salesforce', 'WithAnnotationsBlock', 'annotation', 'secondAnnotation'),
         action: 'add',
         data: { after: createRefToElmWithValue(BuiltinTypes.NUMBER) },
@@ -1559,10 +1561,11 @@ describe('workspace', () => {
         action: 'remove',
         data: { before: true },
       },
+      // TODO: fix all those comment out path properties
       {
         id: nonHiddenObjWithOnlyHiddeNotInNacl.elemID.createNestedID('attr', 'hidden'),
         action: 'modify',
-        path: ['should', 'not', 'matter'],
+        // path: ['should', 'not', 'matter'],
         data: {
           before: 'hidden',
           after: 'changed',
@@ -1571,7 +1574,7 @@ describe('workspace', () => {
       {
         id: new ElemID('salesforce', 'Inconsistent_Case'),
         action: 'add',
-        path: ['Inconsistent_Case'],
+        // path: ['Inconsistent_Case'],
         data: {
           after: new ObjectType({
             elemID: new ElemID('salesforce', 'Inconsistent_Case'),
@@ -3838,13 +3841,14 @@ describe('stateOnly update', () => {
     })
     ws = await createWorkspace(dirStore, state)
     const changes: DetailedChange[] = [
+      // TODO: fix all those comments out paths
       {
         action: 'add',
         data: {
           after: objectWithHiddenToAdd,
         },
         id: objectWithHiddenToAdd.elemID,
-        path: ['salto', 'objwithhidden.nacl'],
+        // path: ['salto', 'objwithhidden.nacl'],
       },
       {
         action: 'add',
@@ -3852,7 +3856,7 @@ describe('stateOnly update', () => {
           after: hiddenInstToAdd,
         },
         id: hiddenInstToAdd.elemID,
-        path: ['salto', 'inst.nacl'],
+        // path: ['salto', 'inst.nacl'],
       },
       {
         action: 'modify',

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -1271,51 +1271,50 @@ describe('workspace', () => {
         action: 'add',
         data: { after: anotherNewField },
       },
-      // TODO: fix all those comment out lines
       {
-        // path: ['other', 'battr'],
         id: new ElemID('salesforce', 'lead', 'attr', 'bobo'),
         action: 'add',
         data: { after: 'baba' },
+        pathIndex: createPathIndexFromPath(new ElemID('salesforce', 'lead', 'attr', 'bobo'), ['other', 'battr']),
       },
       {
-        // path: ['other', 'boo'],
+        pathIndex: createPathIndexFromPath(new ElemID('salesforce', 'lead', 'attr', 'nono'), ['other', 'boo']),
         id: new ElemID('salesforce', 'lead', 'attr', 'nono'),
         action: 'add',
         data: { after: 'nono' },
       },
       {
-        // path: ['other', 'boo'],
+        pathIndex: createPathIndexFromPath(new ElemID('salesforce', 'lead', 'attr', 'momo'), ['other', 'boo']),
         id: new ElemID('salesforce', 'lead', 'attr', 'momo'),
         action: 'add',
         data: { after: 'momo' },
       },
       { // Add to an exiting path
-        // path: ['file'],
+        pathIndex: createPathIndexFromPath(new ElemID('salesforce', 'lead', 'attr', 'dodo'), ['file']),
         id: new ElemID('salesforce', 'lead', 'attr', 'dodo'),
         action: 'add',
         data: { after: 'dodo' },
       },
       { // new annotation type to a type with no annotation types block
-        // path: ['file'],
+        pathIndex: createPathIndexFromPath(new ElemID('salesforce', 'lead', 'annotation', 'newAnnoType1'), ['file']),
         id: new ElemID('salesforce', 'lead', 'annotation', 'newAnnoType1'),
         action: 'add',
         data: { after: createRefToElmWithValue(BuiltinTypes.STRING) },
       },
       { // new annotation type to a type with no annotation types block
-        // path: ['file'],
+        pathIndex: createPathIndexFromPath(new ElemID('salesforce', 'lead', 'annotation', 'newAnnoType2'), ['file']),
         id: new ElemID('salesforce', 'lead', 'annotation', 'newAnnoType2'),
         action: 'add',
         data: { after: createRefToElmWithValue(BuiltinTypes.NUMBER) },
       },
       { // new hidden annotation type
-        // path: ['file'],
+        pathIndex: createPathIndexFromPath(new ElemID('salesforce', 'lead', 'annotation', 'newHiddenAnno'), ['file']),
         id: new ElemID('salesforce', 'lead', 'annotation', 'newHiddenAnno'),
         action: 'add',
         data: { after: createRefToElmWithValue(BuiltinTypes.HIDDEN_STRING) },
       },
       { // new annotation type to a type with annotation types block
-        // path: ['file'],
+        pathIndex: createPathIndexFromPath(new ElemID('salesforce', 'WithAnnotationsBlock', 'annotation', 'secondAnnotation'), ['file']),
         id: new ElemID('salesforce', 'WithAnnotationsBlock', 'annotation', 'secondAnnotation'),
         action: 'add',
         data: { after: createRefToElmWithValue(BuiltinTypes.NUMBER) },
@@ -1561,11 +1560,13 @@ describe('workspace', () => {
         action: 'remove',
         data: { before: true },
       },
-      // TODO: fix all those comment out path properties
       {
         id: nonHiddenObjWithOnlyHiddeNotInNacl.elemID.createNestedID('attr', 'hidden'),
         action: 'modify',
-        // path: ['should', 'not', 'matter'],
+        pathIndex: createPathIndexFromPath(
+          nonHiddenObjWithOnlyHiddeNotInNacl.elemID.createNestedID('attr', 'hidden'),
+          ['should', 'not', 'matter'],
+        ),
         data: {
           before: 'hidden',
           after: 'changed',
@@ -1574,7 +1575,10 @@ describe('workspace', () => {
       {
         id: new ElemID('salesforce', 'Inconsistent_Case'),
         action: 'add',
-        // path: ['Inconsistent_Case'],
+        pathIndex: createPathIndexFromPath(
+          new ElemID('salesforce', 'Inconsistent_Case'),
+          ['Inconsistent_Case'],
+        ),
         data: {
           after: new ObjectType({
             elemID: new ElemID('salesforce', 'Inconsistent_Case'),
@@ -1892,7 +1896,7 @@ describe('workspace', () => {
     it('should update file correctly when elements are removed and added in the same file', () => {
       expect(elemMap).not.toHaveProperty(renamedTypes.before.elemID.getFullName())
       const addedElement = elemMap[renamedTypes.after.elemID.getFullName()]
-      expect(addedElement).toMatchObject(_.omit(renamedTypes.after, 'path'))
+      expect(addedElement).toMatchObject(_.omit(renamedTypes.after, 'pathIndex'))
       expect(dirStore.set).toHaveBeenCalledWith(expect.objectContaining({
         filename: 'renamed_type.nacl',
         buffer: expect.stringMatching(/^\s*type salesforce.RenamedType2 {\s*}\s*$/),
@@ -3841,14 +3845,13 @@ describe('stateOnly update', () => {
     })
     ws = await createWorkspace(dirStore, state)
     const changes: DetailedChange[] = [
-      // TODO: fix all those comments out paths
       {
         action: 'add',
         data: {
           after: objectWithHiddenToAdd,
         },
         id: objectWithHiddenToAdd.elemID,
-        // path: ['salto', 'objwithhidden.nacl'],
+        pathIndex: createPathIndexFromPath(objectWithHiddenToAdd.elemID, ['salto', 'objwithhidden.nacl']),
       },
       {
         action: 'add',
@@ -3856,7 +3859,7 @@ describe('stateOnly update', () => {
           after: hiddenInstToAdd,
         },
         id: hiddenInstToAdd.elemID,
-        // path: ['salto', 'inst.nacl'],
+        pathIndex: createPathIndexFromPath(hiddenInstToAdd.elemID, ['salto', 'inst.nacl']),
       },
       {
         action: 'modify',

--- a/packages/zendesk-support-adapter/.vscode/launch.json
+++ b/packages/zendesk-support-adapter/.vscode/launch.json
@@ -13,7 +13,10 @@
         "${workspaceRoot}/node_modules/.bin/jest",
         "--runInBand",
         "--config",
-        "${workspaceRoot}/jest.config.js"
+        "${workspaceRoot}/jest.config.js",
+        "test/adapter.test.ts",
+        "-t",
+        "should return the applied changes"
       ],
       "outFiles": [],
       "console": "integratedTerminal",

--- a/packages/zuora-billing-adapter/src/transformers/standard_objects.ts
+++ b/packages/zuora-billing-adapter/src/transformers/standard_objects.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Element, ObjectType, InstanceElement, ElemID } from '@salto-io/adapter-api'
+import { Element, ObjectType, InstanceElement, ElemID, getTopLevelPath } from '@salto-io/adapter-api'
 import { client as clientUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { pathNaclCase } from '@salto-io/adapter-utils'
 import {
@@ -45,11 +45,12 @@ export const getStandardObjectElements = async ({
   apiConfig: ZuoraApiConfig
 }): Promise<Element[]> => {
   const standardObjecWrapperTypeName = standardObjectWrapperType.elemID.name
+  const path = getTopLevelPath(customObjectDefType)
   const standardObjectDefType = new ObjectType({
     ...customObjectDefType,
     elemID: new ElemID(ZUORA_BILLING, STANDARD_OBJECT_DEFINITION_TYPE),
-    path: customObjectDefType.path !== undefined
-      ? [...customObjectDefType.path.slice(0, -1), STANDARD_OBJECT_DEFINITION_TYPE]
+    path: path !== undefined
+      ? [...path.slice(0, -1), STANDARD_OBJECT_DEFINITION_TYPE]
       : undefined,
   })
 


### PR DESCRIPTION
_Elements fragment refactor_

---

_Additional context for reviewer_
WIP - please do not review (opened in order to run it against the CI pipeline)

---
_Release Notes_: 
* Adapters' fetch will now return elements and not fragments (won't return two elements with the same ID)
* Change Elements to have pathIndex instead of path

---
_User Notifications_: 
_None_
