### PR TITLE
SALTO-2452: Allow remove elements with unresolved elements

### DIFF
--- a/packages/core/src/core/plan/change_validators/unresolved_references.ts
+++ b/packages/core/src/core/plan/change_validators/unresolved_references.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ChangeValidator, getChangeData, Element, ElemID, SeverityLevel, isReferenceExpression, isTemplateExpression } from '@salto-io/adapter-api'
+import { ChangeValidator, getChangeData, Element, ElemID, SeverityLevel, isReferenceExpression, isTemplateExpression, isAdditionOrModificationChange } from '@salto-io/adapter-api'
 import { walkOnElement, WalkOnFunc, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
 import { values, collections } from '@salto-io/lowerdash'
 import { expressions } from '@salto-io/workspace'
@@ -43,6 +43,7 @@ const getUnresolvedReferences = (element: Element): ElemID[] => {
 
 export const changeValidator: ChangeValidator = async changes => (
   awu(changes)
+    .filter(isAdditionOrModificationChange)
     .map(getChangeData)
     .map(async element => {
       const unresolvedReferences = getUnresolvedReferences(element)

--- a/packages/core/test/core/plan/change_validators/unresolved_references.test.ts
+++ b/packages/core/test/core/plan/change_validators/unresolved_references.test.ts
@@ -130,4 +130,18 @@ describe('unresolved_references', () => {
     const errors = await unresolvedReferencesValidator([toChange({ after: type })])
     expect(errors).toHaveLength(0)
   })
+  it('should not return errors if there are unresolved references in removal change', async () => {
+    const instance = new InstanceElement(
+      'instance',
+      new ObjectType({ elemID: new ElemID('adapter', 'type') }),
+      {
+        value: new ReferenceExpression(
+          unresolvedElemId,
+          new expressions.UnresolvedReference(unresolvedElemId)
+        ),
+      }
+    )
+    const errors = await unresolvedReferencesValidator([toChange({ before: instance })])
+    expect(errors).toHaveLength(0)
+  })
 })


### PR DESCRIPTION
_SALTO-2452: Allow removal of elements with unresolved elements_

---

_Additional context for reviewer_
Currently, we are preventing any kind of change on elements if they contain unresolved references.
There is no need to do it on removal changes since we do not update the element, we just remove it

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
