### PR TITLE
SALTO-2451: Reverse create soap client condition

### DIFF
--- a/packages/adapter-components/src/elements/soap/type_elements/types_generator.ts
+++ b/packages/adapter-components/src/elements/soap/type_elements/types_generator.ts
@@ -68,9 +68,10 @@ export const extractTypes = async (
 ): Promise<ObjectType[]> => {
   log.debug('Generating SOAP types')
 
-  const { wsdl: wsdlObj } = wsdl instanceof soap.WSDL
-    ? { wsdl }
-    : (await soap.createClientAsync(wsdl)) as unknown as { wsdl: soap.WSDL }
+  const { wsdl: wsdlObj } = typeof wsdl === 'string'
+    ? (await soap.createClientAsync(wsdl)) as unknown as { wsdl: soap.WSDL }
+    : { wsdl }
+
   const schemas = Object.values(wsdlObj.definitions.schemas)
   const unresolvedTypes = schemas
     .map((schema: SchemaElement) => convertComplexTypes(adapterName, schema, camelCase))


### PR DESCRIPTION
To solve the error of `The "path" argument must be of type string or an instance of Buffer or URL. Received an instance of WSDL` 

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None