### PR TITLE
SALTO-2352: Fixed state inconsistency

### DIFF
--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -158,7 +158,7 @@ export const serialize = async <T = Element>(
     if (storeStaticFile !== undefined) {
       promises.push(storeStaticFile(e))
     }
-    return _.omit(saltoClassReplacer(e), 'content', 'internalContent')
+    return _.pick(saltoClassReplacer(e), SALTO_CLASS_FIELD, 'filepath', 'hash', 'encoding')
   }
   const referenceExpressionReplacer = (e: ReferenceExpression):
     ReferenceExpression & SerializedClass => {

--- a/packages/workspace/test/serializer/serializer.test.ts
+++ b/packages/workspace/test/serializer/serializer.test.ts
@@ -28,7 +28,7 @@ import { TestFuncImpl } from '../utils'
 
 import { serialize, deserialize, SALTO_CLASS_FIELD, deserializeMergeErrors, deserializeValidationErrors } from '../../src/serializer/elements'
 import { resolve } from '../../src/expressions'
-import { LazyStaticFile } from '../../src/workspace/static_files/source'
+import { AbsoluteStaticFile, LazyStaticFile } from '../../src/workspace/static_files/source'
 import { createInMemoryElementSource } from '../../src/workspace/elements_source'
 import { MergeError, DuplicateAnnotationError } from '../../src/merger/internal/common'
 import {
@@ -295,6 +295,19 @@ describe('State/cache serialization', () => {
 
   it('should throw error if trying to deserialize a non element object', async () => {
     await expect(deserialize(safeJsonStringify([{ test }]))).rejects.toThrow()
+  })
+
+  it('should not serialize redundant values in StaticFile sub classes', async () => {
+    const absInstance = new InstanceElement(
+      'instance',
+      model,
+      {
+        file: new AbsoluteStaticFile({ filepath: 'filepath', content: Buffer.from('content'), absoluteFilePath: 'absolute/filepath' }),
+      },
+    )
+    expect(
+      await serialize([absInstance])
+    ).not.toContain('absolute/filepath')
   })
 
   describe('functions', () => {


### PR DESCRIPTION
The static files refactor PR caused the full path of static files to be saved in the state which made the state different when it is flushed in different locations (can affect the SaaS operation repo where we copy the workspace to another location in the disk)

---
_Release Notes_: 
None (the static files refactor feature is behind ff in the SaaS and we didn't release OSS version yet)

---
_User Notifications_: 
None