### PR TITLE
SALTO-2458/add field support for indexs

### DIFF
--- a/packages/workspace/src/workspace/changed_at_index.ts
+++ b/packages/workspace/src/workspace/changed_at_index.ts
@@ -39,7 +39,7 @@ const { isDefined } = values
 const { awu } = collections.asynciterable
 
 const log = logger(module)
-export const CHANGED_AT_INDEX_VERSION = 2
+export const CHANGED_AT_INDEX_VERSION = 3
 const CHANGED_AT_INDEX_KEY = 'changed_at_index'
 
 const getAllElementsChanges = async (

--- a/packages/workspace/src/workspace/changed_at_index.ts
+++ b/packages/workspace/src/workspace/changed_at_index.ts
@@ -65,12 +65,9 @@ const getChangedAtDates = (change: Change<Element>): Record<string, ElemID[]> =>
   }
   if (isObjectType(changeElement)) {
     Object.values(changeElement.fields)
-      .filter(field => field.annotations[CORE_ANNOTATIONS.CHANGED_AT])
       .forEach(addElementToDatesMap)
   }
-  if (changeElement.annotations[CORE_ANNOTATIONS.CHANGED_AT]) {
-    addElementToDatesMap(changeElement)
-  }
+  addElementToDatesMap(changeElement)
   return datesMap
 }
 

--- a/packages/workspace/src/workspace/changed_at_index.ts
+++ b/packages/workspace/src/workspace/changed_at_index.ts
@@ -93,10 +93,9 @@ const updateRemovalChange = (
 ): void => {
   Object.entries(getChangedAtDates(change)).forEach(entry => {
     const [date, elemIds] = entry
-    if (!datesMap[date]) {
-      datesMap[date] = new Set()
+    if (datesMap[date]) {
+      elemIds.forEach(elemId => datesMap[date].delete(elemId.getFullName()))
     }
-    elemIds.forEach(elemId => datesMap[date].delete(elemId.getFullName()))
   })
 }
 

--- a/packages/workspace/src/workspace/changed_at_index.ts
+++ b/packages/workspace/src/workspace/changed_at_index.ts
@@ -30,7 +30,7 @@ import {
 } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { collections, values } from '@salto-io/lowerdash'
-import _, { isEmpty } from 'lodash'
+import _, { entries, isEmpty } from 'lodash'
 import { ElementsSource } from './elements_source'
 import { RemoteMap } from './remote_map'
 
@@ -51,29 +51,39 @@ const getAllElementsChanges = async (
     .concat(currentChanges)
     .toArray()
 
-const getChangedAtDates = (change: Change<Element>): string[] => {
-  const element = getChangeData(change)
-  const dates = []
-  if (isObjectType(element)) {
-    dates.push(...Object.values(element.fields)
-      .map(field => field.annotations[CORE_ANNOTATIONS.CHANGED_AT])
-      .filter(isDefined))
+const getChangedAtDates = (change: Change<Element>): Record<string, ElemID[]> => {
+  const changeElement = getChangeData(change)
+  const datesMap: Record<string, ElemID[]> = {}
+  const addElementToDatesMap = (element: Element): void => {
+    const date = element.annotations[CORE_ANNOTATIONS.CHANGED_AT]
+    if (isDefined(date)) {
+      if (!datesMap[date]) {
+        datesMap[date] = []
+      }
+      datesMap[date].push(element.elemID)
+    }
   }
-  if (element.annotations[CORE_ANNOTATIONS.CHANGED_AT]) {
-    dates.push(element.annotations[CORE_ANNOTATIONS.CHANGED_AT])
+  if (isObjectType(changeElement)) {
+    Object.values(changeElement.fields)
+      .filter(field => field.annotations[CORE_ANNOTATIONS.CHANGED_AT])
+      .forEach(addElementToDatesMap)
   }
-  return dates
+  if (changeElement.annotations[CORE_ANNOTATIONS.CHANGED_AT]) {
+    addElementToDatesMap(changeElement)
+  }
+  return datesMap
 }
 
 const updateAdditionChange = (
   change: AdditionChange<Element>,
   datesMap: Record<string, Set<string>>,
 ): void => {
-  getChangedAtDates(change).forEach(modificationDate => {
-    if (!datesMap[modificationDate]) {
-      datesMap[modificationDate] = new Set()
+  Object.entries(getChangedAtDates(change)).forEach(entry => {
+    const [date, elemIds] = entry
+    if (!datesMap[date]) {
+      datesMap[date] = new Set()
     }
-    datesMap[modificationDate].add(change.data.after.elemID.getFullName())
+    elemIds.forEach(elemId => datesMap[date].add(elemId.getFullName()))
   })
 }
 
@@ -81,10 +91,12 @@ const updateRemovalChange = (
   change: RemovalChange<Element>,
   datesMap: Record<string, Set<string>>,
 ): void => {
-  getChangedAtDates(change).forEach(modificationDate => {
-    if (datesMap[modificationDate]) {
-      datesMap[modificationDate].delete(change.data.before.elemID.getFullName())
+  Object.entries(getChangedAtDates(change)).forEach(entry => {
+    const [date, elemIds] = entry
+    if (!datesMap[date]) {
+      datesMap[date] = new Set()
     }
+    elemIds.forEach(elemId => datesMap[date].delete(elemId.getFullName()))
   })
 }
 
@@ -122,9 +134,9 @@ const getUniqueDates = (changes: Change<Element>[]): Set<string> => {
   const dateSet = new Set<string>()
   changes.flatMap(change => (
     isModificationChange(change)
-      ? [...getChangedAtDates(toChange({ before: change.data.before })),
-        ...getChangedAtDates(toChange({ after: change.data.after }))]
-      : [...getChangedAtDates(change)])
+      ? [...Object.keys(getChangedAtDates(toChange({ before: change.data.before }))),
+        ...Object.keys(getChangedAtDates(toChange({ after: change.data.after })))]
+      : [...Object.keys(getChangedAtDates(change))])
     .forEach(date => dateSet.add(date)))
   return dateSet
 }

--- a/packages/workspace/src/workspace/changed_at_index.ts
+++ b/packages/workspace/src/workspace/changed_at_index.ts
@@ -30,7 +30,7 @@ import {
 } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { collections, values } from '@salto-io/lowerdash'
-import _, { entries, isEmpty } from 'lodash'
+import _, { isEmpty } from 'lodash'
 import { ElementsSource } from './elements_source'
 import { RemoteMap } from './remote_map'
 

--- a/packages/workspace/src/workspace/changed_by_index.ts
+++ b/packages/workspace/src/workspace/changed_by_index.ts
@@ -39,7 +39,7 @@ const { isDefined } = values
 const { awu } = collections.asynciterable
 
 const log = logger(module)
-export const CHANGED_BY_INDEX_VERSION = 2
+export const CHANGED_BY_INDEX_VERSION = 3
 const CHANGED_BY_INDEX_KEY = 'changed_by_index'
 const UNKNOWN_USER_NAME = 'Unknown'
 const CHANGED_BY_KEY_DELIMITER = '@@'

--- a/packages/workspace/src/workspace/changed_by_index.ts
+++ b/packages/workspace/src/workspace/changed_by_index.ts
@@ -100,7 +100,7 @@ const getChangeAuthors = (change: Change<Element>): Record<string, ElemID[]> => 
   if (changeElement.annotations[CORE_ANNOTATIONS.CHANGED_BY]) {
     addElementToMap(changeElement)
   }
-  return Object.keys(authors).length > 0 ? authors : { UNKNOWN_USER_NAME: [changeElement.elemID] }
+  return Object.keys(authors).length > 0 ? authors : { [UNKNOWN_USER_NAME]: [changeElement.elemID] }
 }
 
 const updateAdditionChange = (

--- a/packages/workspace/src/workspace/changed_by_index.ts
+++ b/packages/workspace/src/workspace/changed_by_index.ts
@@ -95,9 +95,7 @@ const getChangeAuthors = (change: Change<Element>): Record<string, ElemID[]> => 
     authors[authorKey].push(element.elemID)
   }
   if (isObjectType(changeElement)) {
-    Object.values(changeElement.fields)
-      .filter(field => field.annotations[CORE_ANNOTATIONS.CHANGED_BY])
-      .forEach(addElementToMap)
+    Object.values(changeElement.fields).forEach(addElementToMap)
   }
   addElementToMap(changeElement)
   return authors

--- a/packages/workspace/src/workspace/changed_by_index.ts
+++ b/packages/workspace/src/workspace/changed_by_index.ts
@@ -86,7 +86,9 @@ const getChangeAuthors = (change: Change<Element>): Record<string, ElemID[]> => 
   const changeElement = getChangeData(change)
   const authors: Record<string, ElemID[]> = {}
   const addElementToMap = (element: Element): void => {
-    const authorKey = elementToAuthorKey(element)
+    const authorKey = element.annotations[CORE_ANNOTATIONS.CHANGED_BY]
+      ? elementToAuthorKey(element)
+      : UNKNOWN_USER_NAME
     if (!authors[authorKey]) {
       authors[authorKey] = []
     }
@@ -97,10 +99,8 @@ const getChangeAuthors = (change: Change<Element>): Record<string, ElemID[]> => 
       .filter(field => field.annotations[CORE_ANNOTATIONS.CHANGED_BY])
       .forEach(addElementToMap)
   }
-  if (changeElement.annotations[CORE_ANNOTATIONS.CHANGED_BY]) {
-    addElementToMap(changeElement)
-  }
-  return Object.keys(authors).length > 0 ? authors : { [UNKNOWN_USER_NAME]: [changeElement.elemID] }
+  addElementToMap(changeElement)
+  return authors
 }
 
 const updateAdditionChange = (

--- a/packages/workspace/src/workspace/changed_by_index.ts
+++ b/packages/workspace/src/workspace/changed_by_index.ts
@@ -70,6 +70,9 @@ export const authorToAuthorKey = (author: Author): string => {
   return `${author.account}${CHANGED_BY_KEY_DELIMITER}${author.user}`
 }
 
+const elementToAuthorKey = (element: Element): string =>
+  `${element.elemID.adapter}${CHANGED_BY_KEY_DELIMITER}${element.annotations[CORE_ANNOTATIONS.CHANGED_BY]}`
+
 const getAllElementsChanges = async (
   currentChanges: Change<Element>[],
   elementsSource: ElementsSource
@@ -79,24 +82,27 @@ const getAllElementsChanges = async (
     .concat(currentChanges)
     .toArray()
 
-const getChangeAuthors = (change: Change<Element>): string[] => {
-  const element = getChangeData(change)
-  const authors = []
-  if (isObjectType(element)) {
-    Object.values(element.fields).forEach(field => {
+const getChangeAuthors = (change: Change<Element>): Record<string, ElemID[]> => {
+  const changeElement = getChangeData(change)
+  const authors: Record<string, ElemID[]> = {}
+  const addElementToMap = (element: Element): void => {
+    const authorKey = elementToAuthorKey(element)
+    if (!authors[authorKey]) {
+      authors[authorKey] = []
+    }
+    authors[authorKey].push(element.elemID)
+  }
+  if (isObjectType(changeElement)) {
+    Object.values(changeElement.fields).forEach(field => {
       if (field.annotations[CORE_ANNOTATIONS.CHANGED_BY]) {
-        authors.push(`${element.elemID.adapter}${CHANGED_BY_KEY_DELIMITER}${
-          field.annotations[CORE_ANNOTATIONS.CHANGED_BY]
-        }`)
+        addElementToMap(field)
       }
     })
   }
-  if (element.annotations[CORE_ANNOTATIONS.CHANGED_BY]) {
-    authors.push(`${element.elemID.adapter}${CHANGED_BY_KEY_DELIMITER}${
-      element.annotations[CORE_ANNOTATIONS.CHANGED_BY]
-    }`)
+  if (changeElement.annotations[CORE_ANNOTATIONS.CHANGED_BY]) {
+    addElementToMap(changeElement)
   }
-  return authors.length > 0 ? authors : [UNKNOWN_USER_NAME]
+  return Object.keys(authors).length > 0 ? authors : { UNKNOWN_USER_NAME: [changeElement.elemID] }
 }
 
 const updateAdditionChange = (
@@ -104,11 +110,13 @@ const updateAdditionChange = (
   authorMap: Record<string, Set<string>>,
 ): void => {
   const authors = getChangeAuthors(change)
-  authors.forEach(author => {
-    if (!authorMap[author]) {
-      authorMap[author] = new Set()
+  Object.entries(authors).forEach(entry => {
+    const [author, elements] = entry
+    if (authorMap[author]) {
+      elements.forEach(element => {
+        authorMap[author].add(element.getFullName())
+      })
     }
-    authorMap[author].add(change.data.after.elemID.getFullName())
   })
 }
 
@@ -117,9 +125,12 @@ const updateRemovalChange = (
   authorMap: Record<string, Set<string>>,
 ): void => {
   const authors = getChangeAuthors(change)
-  authors.forEach(author => {
+  Object.entries(authors).forEach(entry => {
+    const [author, elements] = entry
     if (authorMap[author]) {
-      authorMap[author].delete(change.data.before.elemID.getFullName())
+      elements.forEach(element => {
+        authorMap[author].delete(element.getFullName())
+      })
     }
   })
 }
@@ -160,13 +171,13 @@ const getUniqueAuthors = (changes: Change<Element>[]): Set<string> => {
     if (isModificationChange(change)) {
       if (change.data.after.annotations[CORE_ANNOTATIONS.CHANGED_BY]
           !== change.data.before.annotations[CORE_ANNOTATIONS.CHANGED_BY]) {
-        getChangeAuthors(toChange({ before: change.data.before }))
+        Object.keys(getChangeAuthors(toChange({ before: change.data.before })))
           .forEach(author => authorSet.add(author))
-        getChangeAuthors(toChange({ after: change.data.after }))
+        Object.keys(getChangeAuthors(toChange({ after: change.data.after })))
           .forEach(author => authorSet.add(author))
       }
     } else {
-      getChangeAuthors(change).forEach(author => authorSet.add(author))
+      Object.keys(getChangeAuthors(change)).forEach(author => authorSet.add(author))
     }
   })
   return authorSet

--- a/packages/workspace/src/workspace/changed_by_index.ts
+++ b/packages/workspace/src/workspace/changed_by_index.ts
@@ -110,11 +110,12 @@ const updateAdditionChange = (
   const authors = getChangeAuthors(change)
   Object.entries(authors).forEach(entry => {
     const [author, elements] = entry
-    if (authorMap[author]) {
-      elements.forEach(element => {
-        authorMap[author].add(element.getFullName())
-      })
+    if (!authorMap[author]) {
+      authorMap[author] = new Set()
     }
+    elements.forEach(element => {
+      authorMap[author].add(element.getFullName())
+    })
   })
 }
 

--- a/packages/workspace/src/workspace/changed_by_index.ts
+++ b/packages/workspace/src/workspace/changed_by_index.ts
@@ -93,11 +93,9 @@ const getChangeAuthors = (change: Change<Element>): Record<string, ElemID[]> => 
     authors[authorKey].push(element.elemID)
   }
   if (isObjectType(changeElement)) {
-    Object.values(changeElement.fields).forEach(field => {
-      if (field.annotations[CORE_ANNOTATIONS.CHANGED_BY]) {
-        addElementToMap(field)
-      }
-    })
+    Object.values(changeElement.fields)
+      .filter(field => field.annotations[CORE_ANNOTATIONS.CHANGED_BY])
+      .forEach(addElementToMap)
   }
   if (changeElement.annotations[CORE_ANNOTATIONS.CHANGED_BY]) {
     addElementToMap(changeElement)

--- a/packages/workspace/test/workspace/changed_at_index.test.ts
+++ b/packages/workspace/test/workspace/changed_at_index.test.ts
@@ -28,6 +28,7 @@ describe('changed at index', () => {
   let knownUserInstance: InstanceElement
   let unknownUserInstance: InstanceElement
   let knownUserSecondInstance: InstanceElement
+  const objectFieldElementId = new ElemID('test', 'object', 'field', 'field')
 
   beforeEach(() => {
     jest.resetAllMocks()
@@ -94,7 +95,7 @@ describe('changed at index', () => {
       expect(changedAtIndex.getMany).toHaveBeenCalledWith(['2000-01-01T00:00:00.000Z', '2001-01-01T00:00:00.000Z', '2000-02-01T00:00:00.000Z', '2000-03-01T00:00:00.000Z'])
       expect(changedAtIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: '2000-01-01T00:00:00.000Z', value: [knownUserInstance.elemID] }]))
       expect(changedAtIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: '2001-01-01T00:00:00.000Z', value: [knownUserSecondInstance.elemID] }]))
-      expect(changedAtIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: '2000-02-01T00:00:00.000Z', value: [object.elemID] }]))
+      expect(changedAtIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: '2000-02-01T00:00:00.000Z', value: [objectFieldElementId] }]))
       expect(changedAtIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: '2000-03-01T00:00:00.000Z', value: [object.elemID] }]))
     })
   })
@@ -120,7 +121,7 @@ describe('changed at index', () => {
       expect(changedAtIndex.getMany).toHaveBeenCalledWith(['2000-01-01T00:00:00.000Z', '2001-01-01T00:00:00.000Z', '2000-02-01T00:00:00.000Z', '2000-03-01T00:00:00.000Z'])
       expect(changedAtIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: '2000-01-01T00:00:00.000Z', value: [knownUserInstance.elemID] }]))
       expect(changedAtIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: '2001-01-01T00:00:00.000Z', value: [knownUserSecondInstance.elemID] }]))
-      expect(changedAtIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: '2000-02-01T00:00:00.000Z', value: [object.elemID] }]))
+      expect(changedAtIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: '2000-02-01T00:00:00.000Z', value: [objectFieldElementId] }]))
       expect(changedAtIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: '2000-03-01T00:00:00.000Z', value: [object.elemID] }]))
     })
   })
@@ -230,7 +231,7 @@ describe('changed at index', () => {
         expect(changedAtIndex.clear).toHaveBeenCalled()
         expect(changedAtIndex.getMany).toHaveBeenCalledWith(['2000-01-01T00:00:00.000Z', '2000-02-01T00:00:00.000Z', '2000-03-01T00:00:00.000Z'])
         expect(changedAtIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: '2000-01-01T00:00:00.000Z', value: [knownUserInstance.elemID] }]))
-        expect(changedAtIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: '2000-02-01T00:00:00.000Z', value: [object.elemID] }]))
+        expect(changedAtIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: '2000-02-01T00:00:00.000Z', value: [objectFieldElementId] }]))
         expect(changedAtIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: '2000-03-01T00:00:00.000Z', value: [object.elemID] }]))
       })
     })
@@ -253,7 +254,7 @@ describe('changed at index', () => {
         expect(changedAtIndex.clear).toHaveBeenCalled()
         expect(changedAtIndex.getMany).toHaveBeenCalledWith(['2000-02-01T00:00:00.000Z', '2000-03-01T00:00:00.000Z', '2000-01-01T00:00:00.000Z'])
         expect(changedAtIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: '2000-01-01T00:00:00.000Z', value: [knownUserInstance.elemID] }]))
-        expect(changedAtIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: '2000-02-01T00:00:00.000Z', value: [object.elemID] }]))
+        expect(changedAtIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: '2000-02-01T00:00:00.000Z', value: [objectFieldElementId] }]))
         expect(changedAtIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: '2000-03-01T00:00:00.000Z', value: [object.elemID] }]))
       })
     })

--- a/packages/workspace/test/workspace/changed_by_index.test.ts
+++ b/packages/workspace/test/workspace/changed_by_index.test.ts
@@ -40,7 +40,8 @@ describe('changed by index', () => {
   let knownUserInstance: InstanceElement
   let unKnownUserInstance: InstanceElement
   let knownUserSecondInstance: InstanceElement
-  const objectFieldElementId = new ElemID('test', 'object', 'field', 'field')
+  const objectKnownFieldElementId = new ElemID('test', 'object', 'field', 'known')
+  const objectUnknownFieldElementId = new ElemID('test', 'object', 'field', 'unknown')
 
   beforeEach(() => {
     jest.resetAllMocks()
@@ -55,10 +56,14 @@ describe('changed by index', () => {
         [CORE_ANNOTATIONS.CHANGED_BY]: 'user two',
       },
       fields: {
-        field: {
+        known: {
           annotations: {
             [CORE_ANNOTATIONS.CHANGED_BY]: 'user three',
           },
+          refType: BuiltinTypes.STRING,
+        },
+        unknown: {
+          annotations: {},
           refType: BuiltinTypes.STRING,
         },
       },
@@ -108,7 +113,8 @@ describe('changed by index', () => {
       expect(changedByIndex.getMany).toHaveBeenCalledWith(['test@@user one', 'Unknown', 'test@@user three', 'test@@user two'])
       expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user one', value: expect.arrayContaining([knownUserInstance.elemID, knownUserSecondInstance.elemID]) }]))
       expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user two', value: [object.elemID] }]))
-      expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user three', value: [objectFieldElementId] }]))
+      expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user three', value: [objectKnownFieldElementId] }]))
+      expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'Unknown', value: [objectUnknownFieldElementId] }]))
     })
   })
 
@@ -132,9 +138,9 @@ describe('changed by index', () => {
     it('should add the new instances changed by values to index', () => {
       expect(changedByIndex.getMany).toHaveBeenCalledWith(['test@@user one', 'Unknown', 'test@@user three', 'test@@user two'])
       expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user one', value: [knownUserInstance.elemID, knownUserSecondInstance.elemID] }]))
-      expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'Unknown', value: [unKnownUserInstance.elemID] }]))
+      expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'Unknown', value: [unKnownUserInstance.elemID, objectUnknownFieldElementId] }]))
       expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user two', value: [object.elemID] }]))
-      expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user three', value: [objectFieldElementId] }]))
+      expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user three', value: [objectKnownFieldElementId] }]))
     })
   })
   describe('when elements were modified', () => {
@@ -264,9 +270,9 @@ describe('changed by index', () => {
         expect(changedByIndex.clear).toHaveBeenCalled()
         expect(changedByIndex.getMany).toHaveBeenCalledWith(['test@@user one', 'Unknown', 'test@@user three', 'test@@user two'])
         expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user one', value: [knownUserInstance.elemID] }]))
-        expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'Unknown', value: [unKnownUserInstance.elemID] }]))
+        expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'Unknown', value: [unKnownUserInstance.elemID, objectUnknownFieldElementId] }]))
         expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user two', value: [object.elemID] }]))
-        expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user three', value: [objectFieldElementId] }]))
+        expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user three', value: [objectKnownFieldElementId] }]))
       })
     })
 
@@ -286,11 +292,11 @@ describe('changed by index', () => {
       })
       it('should update changed by index using the element source', () => {
         expect(changedByIndex.clear).toHaveBeenCalled()
-        expect(changedByIndex.getMany).toHaveBeenCalledWith(['test@@user three', 'test@@user two', 'test@@user one', 'Unknown'])
+        expect(changedByIndex.getMany).toHaveBeenCalledWith(['test@@user three', 'Unknown', 'test@@user two', 'test@@user one'])
         expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user one', value: [knownUserInstance.elemID] }]))
-        expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'Unknown', value: [unKnownUserInstance.elemID] }]))
+        expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'Unknown', value: [objectUnknownFieldElementId, unKnownUserInstance.elemID] }]))
         expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user two', value: [object.elemID] }]))
-        expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user three', value: [objectFieldElementId] }]))
+        expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user three', value: [objectKnownFieldElementId] }]))
       })
     })
   })

--- a/packages/workspace/test/workspace/changed_by_index.test.ts
+++ b/packages/workspace/test/workspace/changed_by_index.test.ts
@@ -40,6 +40,7 @@ describe('changed by index', () => {
   let knownUserInstance: InstanceElement
   let unKnownUserInstance: InstanceElement
   let knownUserSecondInstance: InstanceElement
+  const objectFieldElementId = new ElemID('test', 'object', 'field', 'field')
 
   beforeEach(() => {
     jest.resetAllMocks()
@@ -107,7 +108,7 @@ describe('changed by index', () => {
       expect(changedByIndex.getMany).toHaveBeenCalledWith(['test@@user one', 'Unknown', 'test@@user three', 'test@@user two'])
       expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user one', value: expect.arrayContaining([knownUserInstance.elemID, knownUserSecondInstance.elemID]) }]))
       expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user two', value: [object.elemID] }]))
-      expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user three', value: [object.elemID] }]))
+      expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user three', value: [objectFieldElementId] }]))
     })
   })
 
@@ -133,7 +134,7 @@ describe('changed by index', () => {
       expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user one', value: [knownUserInstance.elemID, knownUserSecondInstance.elemID] }]))
       expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'Unknown', value: [unKnownUserInstance.elemID] }]))
       expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user two', value: [object.elemID] }]))
-      expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user three', value: [object.elemID] }]))
+      expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user three', value: [objectFieldElementId] }]))
     })
   })
   describe('when elements were modified', () => {
@@ -265,7 +266,7 @@ describe('changed by index', () => {
         expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user one', value: [knownUserInstance.elemID] }]))
         expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'Unknown', value: [unKnownUserInstance.elemID] }]))
         expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user two', value: [object.elemID] }]))
-        expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user three', value: [object.elemID] }]))
+        expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user three', value: [objectFieldElementId] }]))
       })
     })
 
@@ -289,7 +290,7 @@ describe('changed by index', () => {
         expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user one', value: [knownUserInstance.elemID] }]))
         expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'Unknown', value: [unKnownUserInstance.elemID] }]))
         expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user two', value: [object.elemID] }]))
-        expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user three', value: [object.elemID] }]))
+        expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user three', value: [objectFieldElementId] }]))
       })
     })
   })

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -2399,7 +2399,9 @@ describe('workspace', () => {
     describe('getChangedElementsByAuthor', () => {
       it('get correct elements', async () => {
         const unknownUser = await workspace.getChangedElementsByAuthors([{ user: 'Unknown', account: '' }])
-        expect(unknownUser[0].getFullName()).toEqual('salesforce.text')
+        expect(unknownUser[0].getFullName()).toEqual('salesforce.lead.field.singleDef')
+        expect(unknownUser[1].getFullName()).toEqual('salesforce.lead.field.multiDef')
+        expect(unknownUser[2].getFullName()).toEqual('salesforce.text')
         const testUser = await workspace.getChangedElementsByAuthors([{ user: 'test user', account: 'salesforce' }])
         expect(testUser[0].getFullName()).toEqual('salesforce.lead')
         const multipleUsers = await workspace.getChangedElementsByAuthors([{ user: 'test user', account: 'salesforce' }, { user: 'Unknown', account: '' }])


### PR DESCRIPTION
after finding a way to retrieve the nacl file paths of field elements (in saas) I changed the code to add the field's element id and not his top level parent.

---

_Additional context for reviewer_

---
_Release Notes_: 


---
_User Notifications_: 
