### PR TITLE
SALTO-2114 app installation will lose the "settings_object" item

### DIFF
--- a/packages/zendesk-support-adapter/src/filters/app.ts
+++ b/packages/zendesk-support-adapter/src/filters/app.ts
@@ -17,6 +17,7 @@ import _ from 'lodash'
 import Joi from 'joi'
 import {
   Change, getChangeData, InstanceElement, isAdditionChange, isAdditionOrModificationChange,
+  isInstanceElement, Element,
 } from '@salto-io/adapter-api'
 import { retry } from '@salto-io/lowerdash'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
@@ -83,6 +84,12 @@ Promise<void> => {
  * Deploys app installation
  */
 const filterCreator: FilterCreator = ({ config, client }) => ({
+  onFetch: async (elements: Element[]) =>
+    elements
+      .filter(isInstanceElement)
+      .filter(e => e.elemID.typeName === APP_INSTALLATION_TYPE_NAME).forEach(e => {
+        delete e.value.settings_objects
+      }),
   deploy: async (changes: Change<InstanceElement>[]) => {
     const [relevantChanges, leftoverChanges] = _.partition(
       changes,

--- a/packages/zendesk-support-adapter/test/filters/app.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/app.test.ts
@@ -37,7 +37,7 @@ jest.mock('@salto-io/adapter-components', () => {
 
 describe('app installation filter', () => {
   let client: ZendeskClient
-  type FilterType = filterUtils.FilterWith<'deploy'>
+  type FilterType = filterUtils.FilterWith<'deploy' | 'onFetch'>
   let filter: FilterType
   let mockGet: jest.SpyInstance
   const app = new InstanceElement(
@@ -64,6 +64,14 @@ describe('app installation filter', () => {
       config: DEFAULT_CONFIG,
       fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
+  })
+
+  it('should remove settings object on fetch', async () => {
+    const appClone = app.clone()
+    await filter.onFetch([appClone])
+    const appCloneWithoutSettingsObject = app.clone()
+    appCloneWithoutSettingsObject.value.settings_objects = undefined
+    expect(appClone).toEqual(appCloneWithoutSettingsObject)
   })
 
   it('should pass the correct params to deployChange and client on create and wait until the job is done', async () => {


### PR DESCRIPTION
App installation will no longer include unnecessary "settings_object" attribute, which is a duplicate of "settings" attribute

---

---
_Release Notes_: 
Zendesk:
App installation will no longer include unnecessary "settings_object" attribute, which is a duplicate of "settings" attribute
---
_User Notifications_:
Zendesk: 
Future fetches of zendesk will no longer include unnecessary "settings_object" attribute, which is a duplicate of "settings" attribute. Current workspaces will continue to work with no need to change.