### PR TITLE
SALTO-2474: fix adapter rename to rename TemplateExpressions as well

### DIFF
--- a/packages/workspace/src/element_adapter_rename.ts
+++ b/packages/workspace/src/element_adapter_rename.ts
@@ -32,6 +32,8 @@ import {
   ElemID,
   GLOBAL_ADAPTER,
   isTemplateExpression,
+  ReferenceExpression,
+  TemplateExpression,
 } from '@salto-io/adapter-api'
 import { transformElement, TransformFunc } from '@salto-io/adapter-utils'
 import { UnresolvedReference } from './expressions'
@@ -82,47 +84,51 @@ const updateRefTypeWithId = (refType: TypeReference, accountName: string): void 
   _.set(refType, 'elemID', refType.type.elemID)
 }
 
-const updateReferenceExpression = (value: unknown, accountName: string): void => {
-  if (isReferenceExpression(value)) {
-    _.set(value, 'elemID', createAdapterReplacedID(value.elemID, accountName))
-    // This will happen because we used resolve on a list of elements, and some of the types
-    // will not resolve by the time we reach an element that references them. Since we don't
-    // care about resolved values, we can just remove this.
-    if (value.value instanceof UnresolvedReference) {
-      value.value = undefined
-    }
+const updateReferenceExpression = (value: ReferenceExpression, accountName: string): void => {
+  _.set(value, 'elemID', createAdapterReplacedID(value.elemID, accountName))
+  // This will happen because we used resolve on a list of elements, and some of the types
+  // will not resolve by the time we reach an element that references them. Since we don't
+  // care about resolved values, we can just remove this.
+  if (value.value instanceof UnresolvedReference) {
+    value.value = undefined
   }
 }
 
-const updateTemplateExpression = (value: unknown, accountName: string): void => {
-  if (isTemplateExpression(value)) {
-    value.parts.forEach(part => updateReferenceExpression(part, accountName))
-  }
+const updateTemplateExpression = (value: TemplateExpression, accountName: string): void => {
+  value.parts.forEach(part => {
+    if (isReferenceExpression(part)) {
+      updateReferenceExpression(part, accountName)
+    }
+  })
 }
 
-const updateElement = (value: unknown, accountName: string): void => {
-  if (isElement(value) && value.elemID.adapter !== accountName) {
-    _.set(value, 'elemID', createAdapterReplacedID(value.elemID, accountName))
-    value.annotationRefTypes = _.mapValues(value.annotationRefTypes,
-      annotation => {
-        const annotationType = _.clone(annotation)
-        updateRefTypeWithId(annotationType, accountName)
-        return annotationType
-      })
-    if (isField(value)) {
-      const fieldType = _.clone(value.refType)
-      updateRefTypeWithId(fieldType, accountName)
-      value.refType = fieldType
-    }
+const updateElement = (value: Element, accountName: string): void => {
+  _.set(value, 'elemID', createAdapterReplacedID(value.elemID, accountName))
+  value.annotationRefTypes = _.mapValues(value.annotationRefTypes,
+    annotation => {
+      const annotationType = _.clone(annotation)
+      updateRefTypeWithId(annotationType, accountName)
+      return annotationType
+    })
+  if (isField(value)) {
+    const fieldType = _.clone(value.refType)
+    updateRefTypeWithId(fieldType, accountName)
+    value.refType = fieldType
   }
 }
 
 const transformElemIDAdapter = (accountName: string): TransformFunc => async (
   { value }
 ) => {
-  updateReferenceExpression(value, accountName)
-  updateTemplateExpression(value, accountName)
-  updateElement(value, accountName)
+  if (isReferenceExpression(value)) {
+    updateReferenceExpression(value, accountName)
+  }
+  if (isTemplateExpression(value)) {
+    updateTemplateExpression(value, accountName)
+  }
+  if (isElement(value) && value.elemID.adapter !== accountName) {
+    updateElement(value, accountName)
+  }
   return value
 }
 

--- a/packages/workspace/test/workspace/element_adapter_rename.test.ts
+++ b/packages/workspace/test/workspace/element_adapter_rename.test.ts
@@ -60,7 +60,12 @@ describe('rename adapter in elements', () => {
   const instanceToChange = new InstanceElement('InstanceElement', objectToChange, {
     field: new ReferenceExpression(innerType.elemID),
     templateField: new TemplateExpression({
-      parts: ['prefix', new ReferenceExpression(innerType.elemID)],
+      parts: [
+        'prefix',
+        new ReferenceExpression(innerType.elemID),
+        'middle',
+        new ReferenceExpression(innerRefType.elemID),
+      ],
     }),
     innerRefField: innerType,
   })
@@ -93,7 +98,12 @@ describe('rename adapter in elements', () => {
   const changedInstance = new InstanceElement('InstanceElement', changedObject, {
     field: new ReferenceExpression(changedInnerType.elemID),
     templateField: new TemplateExpression({
-      parts: ['prefix', new ReferenceExpression(changedInnerType.elemID)],
+      parts: [
+        'prefix',
+        new ReferenceExpression(changedInnerType.elemID),
+        'middle',
+        new ReferenceExpression(changedInnerRefType.elemID),
+      ],
     }),
     innerRefField: changedInnerType,
   })

--- a/packages/workspace/test/workspace/element_adapter_rename.test.ts
+++ b/packages/workspace/test/workspace/element_adapter_rename.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, ElemID, InstanceElement, ListType, MapType, ObjectType, ReferenceExpression, TypeReference } from '@salto-io/adapter-api'
+import { BuiltinTypes, ElemID, InstanceElement, ListType, MapType, ObjectType, ReferenceExpression, TemplateExpression, TypeReference } from '@salto-io/adapter-api'
 import { createInMemoryElementSource } from '../../src/workspace/elements_source'
 import { createAdapterReplacedID, updateElementsWithAlternativeAccount } from '../../src/element_adapter_rename'
 import { UnresolvedReference } from '../../src/expressions'
@@ -50,6 +50,7 @@ describe('rename adapter in elements', () => {
     path: [serviceName, 'somepath'],
     fields: {
       field: { refType: innerType },
+      templateField: { refType: innerType },
       listField: { refType: new ListType(innerType) },
       listOfListField: { refType: new ListType(new ListType(innerType)) },
       mapField: { refType: new MapType(innerType) },
@@ -58,6 +59,9 @@ describe('rename adapter in elements', () => {
   })
   const instanceToChange = new InstanceElement('InstanceElement', objectToChange, {
     field: new ReferenceExpression(innerType.elemID),
+    templateField: new TemplateExpression({
+      parts: ['prefix', new ReferenceExpression(innerType.elemID)],
+    }),
     innerRefField: innerType,
   })
   // the adapter change is supposed to set this value to undefined if it finds unresolved reference.
@@ -79,6 +83,7 @@ describe('rename adapter in elements', () => {
     elemID: new ElemID(newServiceName, 'objectType'),
     fields: {
       field: { refType: changedInnerType },
+      templateField: { refType: changedInnerType },
       listField: { refType: new ListType(changedInnerType) },
       listOfListField: { refType: new ListType(new ListType(changedInnerType)) },
       mapField: { refType: new MapType(changedInnerType) },
@@ -87,6 +92,9 @@ describe('rename adapter in elements', () => {
   })
   const changedInstance = new InstanceElement('InstanceElement', changedObject, {
     field: new ReferenceExpression(changedInnerType.elemID),
+    templateField: new TemplateExpression({
+      parts: ['prefix', new ReferenceExpression(changedInnerType.elemID)],
+    }),
     innerRefField: changedInnerType,
   })
   const changedUnresolvedReferenceInstanceToChange = new InstanceElement('InstanceElement',


### PR DESCRIPTION
_fix adapter rename to rename TemplateExpressions as well_

---

_Additional context for reviewer_
None

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
