### PR TITLE
SALTO-2476: Replacing global context of a field with another one failed

### DIFF
--- a/packages/jira-adapter/src/dependency_changers/global_field_contexts.ts
+++ b/packages/jira-adapter/src/dependency_changers/global_field_contexts.ts
@@ -1,0 +1,54 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Change, dependencyChange, DependencyChanger, getChangeData, InstanceElement, isAdditionChange, isAdditionOrRemovalChange, isInstanceChange, isRemovalChange } from '@salto-io/adapter-api'
+import { getParent } from '@salto-io/adapter-utils'
+import { collections } from '@salto-io/lowerdash'
+import _ from 'lodash'
+import { FIELD_CONTEXT_TYPE_NAME } from '../filters/fields/constants'
+
+
+export const globalFieldContextsDependencyChanger: DependencyChanger = async changes => {
+  const globalContextChanges = Array.from(changes.entries())
+    .map(([key, change]) => ({ key, change }))
+    .filter(
+      (change): change is { key: collections.set.SetId; change: Change<InstanceElement> } =>
+        isInstanceChange(change.change)
+    )
+    .filter(({ change }) => getChangeData(change).elemID.typeName === FIELD_CONTEXT_TYPE_NAME)
+    .filter(({ change }) => isAdditionOrRemovalChange(change))
+    .filter(({ change }) => _.isEmpty(getChangeData(change).value.projectIds))
+
+  const fieldToContexts = _.groupBy(
+    globalContextChanges,
+    ({ change }) => getParent(getChangeData(change)).elemID.getFullName()
+  )
+
+  return Object.values(fieldToContexts)
+    .flatMap(contextsGroup => {
+      const removalChanges = contextsGroup.filter(({ change }) => isRemovalChange(change))
+      const additionChanges = contextsGroup.filter(({ change }) => isAdditionChange(change))
+
+      return additionChanges.flatMap(
+        additionChange => removalChanges.map(
+          removalChange => dependencyChange(
+            'add',
+            additionChange.key,
+            removalChange.key,
+          )
+        )
+      )
+    })
+}

--- a/packages/jira-adapter/src/dependency_changers/global_field_contexts.ts
+++ b/packages/jira-adapter/src/dependency_changers/global_field_contexts.ts
@@ -29,7 +29,8 @@ export const globalFieldContextsDependencyChanger: DependencyChanger = async cha
     )
     .filter(({ change }) => getChangeData(change).elemID.typeName === FIELD_CONTEXT_TYPE_NAME)
     .filter(({ change }) => isAdditionOrRemovalChange(change))
-    .filter(({ change }) => _.isEmpty(getChangeData(change).value.projectIds))
+    .filter(({ change }) => _.isEmpty(getChangeData(change).value.projectIds)
+      || _.isEmpty(getChangeData(change).value.issueTypeIds))
 
   const fieldToContexts = _.groupBy(
     globalContextChanges,

--- a/packages/jira-adapter/src/dependency_changers/index.ts
+++ b/packages/jira-adapter/src/dependency_changers/index.ts
@@ -17,6 +17,7 @@ import { DependencyChanger } from '@salto-io/adapter-api'
 import { deployment } from '@salto-io/adapter-components'
 import { collections } from '@salto-io/lowerdash'
 import { dashboardGadgetsDependencyChanger } from './dashboard_gadgets'
+import { globalFieldContextsDependencyChanger } from './global_field_contexts'
 import { projectDependencyChanger } from './project'
 import { removalsDependencyChanger } from './removals'
 import { workflowDependencyChanger } from './workflow'
@@ -29,6 +30,7 @@ const DEPENDENCY_CHANGERS: DependencyChanger[] = [
   workflowDependencyChanger,
   dashboardGadgetsDependencyChanger,
   removalsDependencyChanger,
+  globalFieldContextsDependencyChanger,
 ]
 
 export const dependencyChanger: DependencyChanger = async (

--- a/packages/jira-adapter/src/dependency_changers/removals.ts
+++ b/packages/jira-adapter/src/dependency_changers/removals.ts
@@ -17,7 +17,11 @@ import { CORE_ANNOTATIONS, dependencyChange, DependencyChanger, getChangeData, I
 import { references } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
+import { FIELD_CONTEXT_TYPE_NAME } from '../filters/fields/constants'
 
+const TYPES_TO_IGNORE = [
+  FIELD_CONTEXT_TYPE_NAME,
+]
 
 export const removalsDependencyChanger: DependencyChanger = async changes => {
   const removalsChanges = _(Array.from(changes.entries()))
@@ -26,6 +30,7 @@ export const removalsDependencyChanger: DependencyChanger = async changes => {
       (change): change is { key: collections.set.SetId; change: RemovalChange<InstanceElement> } =>
         isInstanceChange(change.change)
         && isRemovalChange(change.change)
+        && !TYPES_TO_IGNORE.includes(getChangeData(change.change).elemID.typeName)
     )
     .keyBy(({ change }) => getChangeData(change).elemID.getFullName())
     .value()

--- a/packages/jira-adapter/test/dependency_changers/global_field_contexts.test.ts
+++ b/packages/jira-adapter/test/dependency_changers/global_field_contexts.test.ts
@@ -1,0 +1,92 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, InstanceElement, ElemID, toChange, CORE_ANNOTATIONS, ReferenceExpression } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { globalFieldContextsDependencyChanger } from '../../src/dependency_changers/global_field_contexts'
+import { JIRA } from '../../src/constants'
+import { FIELD_CONTEXT_TYPE_NAME, FIELD_TYPE_NAME } from '../../src/filters/fields/constants'
+
+describe('globalFieldContextsDependencyChanger', () => {
+  let instance: InstanceElement
+  let fieldType: ObjectType
+  beforeEach(() => {
+    const contextType = new ObjectType({
+      elemID: new ElemID(JIRA, FIELD_CONTEXT_TYPE_NAME),
+    })
+
+    fieldType = new ObjectType({
+      elemID: new ElemID(JIRA, FIELD_TYPE_NAME),
+    })
+
+    instance = new InstanceElement(
+      'inst',
+      contextType,
+      {},
+      [],
+      {
+        [CORE_ANNOTATIONS.PARENT]: [
+          new ReferenceExpression(
+            new ElemID(JIRA, FIELD_CONTEXT_TYPE_NAME, 'instance', 'parent'),
+            new InstanceElement(
+              'parent',
+              fieldType,
+            )
+          ),
+        ],
+      }
+    )
+  })
+
+  it('should add dependency from an added global context to a removed global context', async () => {
+    const inputChanges = new Map([
+      [0, toChange({ after: instance })],
+      [1, toChange({ before: instance })],
+    ])
+    const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([])
+
+    const dependencyChanges = [
+      ...await globalFieldContextsDependencyChanger(inputChanges, inputDeps),
+    ]
+    expect(dependencyChanges).toHaveLength(1)
+    expect(dependencyChanges[0].action).toEqual('add')
+    expect(dependencyChanges[0].dependency.source).toEqual(0)
+    expect(dependencyChanges[0].dependency.target).toEqual(1)
+  })
+
+  it('should not add dependency if the parent field is different', async () => {
+    const differentInstance = instance.clone()
+    differentInstance.annotations[CORE_ANNOTATIONS.PARENT] = [
+      new ReferenceExpression(
+        new ElemID(JIRA, FIELD_CONTEXT_TYPE_NAME, 'instance', 'parent2'),
+        new InstanceElement(
+          'parent2',
+          fieldType,
+        )
+      ),
+    ]
+
+    const inputChanges = new Map([
+      [0, toChange({ after: differentInstance })],
+      [1, toChange({ before: instance })],
+    ])
+    const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([])
+
+    const dependencyChanges = [
+      ...await globalFieldContextsDependencyChanger(inputChanges, inputDeps),
+    ]
+    expect(dependencyChanges).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Fixed a bug with replacing the global context of a field in one deployment.

There can be only one global context (a context without `projectIds` or without `issueTypeIds`) per field, so before if we would try to replace a global context with another, we would first try to add the new one with would fail because we first need to delete the old one

---
_Release Notes_: 
_Jira Adapter_:
- Fixed a bug with replacing the global context of a field in one deployment

---
_User Notifications_: 
None