### PR TITLE
PROD-19: create zendesk migration command

### DIFF
--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -21,6 +21,7 @@ import initDef from './init'
 import restoreDef from './restore'
 import elementGroupDef from './element'
 import workspaceGroupDef from './workspace'
+import migrationGroupDef from './migration'
 
 // The order of the builders determines order of appearance in help text
 export default [
@@ -32,4 +33,5 @@ export default [
   restoreDef,
   elementGroupDef,
   workspaceGroupDef,
+  migrationGroupDef,
 ]

--- a/packages/cli/src/commands/migration.ts
+++ b/packages/cli/src/commands/migration.ts
@@ -21,14 +21,19 @@ import Prompts from '../prompts'
 import { CliExitCode } from '../types'
 import { createCommandGroupDef, createWorkspaceCommand, WorkspaceCommandAction } from '../command_builder'
 
-export const migrateAction: WorkspaceCommandAction<unknown> = async ({
+type MigrationArgs = {
+  force: boolean
+}
+
+export const migrateAction: WorkspaceCommandAction<MigrationArgs> = async ({
+  input: { force },
   output,
   workspace,
 }): Promise<CliExitCode> => {
   outputLine(formatStepStart(Prompts.MIGRATION_STARTED), output)
 
   try {
-    await migrateWorkspace(workspace)
+    await migrateWorkspace(workspace, force)
   } catch (e) {
     errorOutputLine(formatStepFailed(Prompts.MIGRATION_FAILED(e.toString())), output)
     return CliExitCode.AppError
@@ -43,6 +48,16 @@ const wsMigrateZendeskDef = createWorkspaceCommand({
   properties: {
     name: 'migrate-zendesk',
     description: 'Migrate Zendesk adapter name from zendesk_support to zendesk',
+    keyedOptions: [
+      {
+        name: 'force',
+        alias: 'f',
+        required: false,
+        default: false,
+        description: 'Force the migration',
+        type: 'boolean',
+      },
+    ],
   },
   action: migrateAction,
 })

--- a/packages/cli/src/commands/migration.ts
+++ b/packages/cli/src/commands/migration.ts
@@ -23,17 +23,18 @@ import { createCommandGroupDef, createWorkspaceCommand, WorkspaceCommandAction }
 
 type MigrationArgs = {
   force: boolean
+  common: boolean
 }
 
 export const migrateAction: WorkspaceCommandAction<MigrationArgs> = async ({
-  input: { force },
+  input: { force, common },
   output,
   workspace,
 }): Promise<CliExitCode> => {
   outputLine(formatStepStart(Prompts.MIGRATION_STARTED), output)
 
   try {
-    await migrateWorkspace(workspace, force)
+    await migrateWorkspace(workspace, force, common)
   } catch (e) {
     errorOutputLine(formatStepFailed(Prompts.MIGRATION_FAILED(e.toString())), output)
     return CliExitCode.AppError
@@ -55,6 +56,14 @@ const wsMigrateZendeskDef = createWorkspaceCommand({
         required: false,
         default: false,
         description: 'Force the migration',
+        type: 'boolean',
+      },
+      {
+        name: 'common',
+        alias: 'c',
+        required: false,
+        default: false,
+        description: 'Migrate to common',
         type: 'boolean',
       },
     ],

--- a/packages/cli/src/commands/migration.ts
+++ b/packages/cli/src/commands/migration.ts
@@ -1,0 +1,61 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { EOL } from 'os'
+import { migrateWorkspace } from '@salto-io/core'
+import { formatStepStart, formatStepFailed, formatStepCompleted } from '../formatter'
+import { outputLine, errorOutputLine } from '../outputer'
+import Prompts from '../prompts'
+import { CliExitCode } from '../types'
+import { createCommandGroupDef, createWorkspaceCommand, WorkspaceCommandAction } from '../command_builder'
+
+export const migrateAction: WorkspaceCommandAction<unknown> = async ({
+  output,
+  workspace,
+}): Promise<CliExitCode> => {
+  outputLine(formatStepStart(Prompts.MIGRATION_STARTED), output)
+
+  try {
+    await migrateWorkspace(workspace)
+  } catch (e) {
+    errorOutputLine(formatStepFailed(Prompts.MIGRATION_FAILED(e.toString())), output)
+    return CliExitCode.AppError
+  }
+
+  outputLine(formatStepCompleted(Prompts.MIGRATION_FINISHED), output)
+  outputLine(EOL, output)
+  return CliExitCode.Success
+}
+
+const wsMigrateZendeskDef = createWorkspaceCommand({
+  properties: {
+    name: 'migrate-zendesk',
+    description: 'Migrate Zendesk adapter name from zendesk_support to zendesk',
+  },
+  action: migrateAction,
+})
+
+// Group definition
+const wsGroupDef = createCommandGroupDef({
+  properties: {
+    name: 'migration',
+    description: 'Workspace migration commands',
+  },
+  subCommands: [
+    wsMigrateZendeskDef,
+  ],
+})
+
+export default wsGroupDef

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -360,6 +360,12 @@ ${Prompts.LIST_IDS(ids)}
     err: string
   ): string => `Error encountered while cleaning the workspace: ${err}.`
 
+  public static readonly MIGRATION_STARTED = 'Starting to migrate the workspace.'
+  public static readonly MIGRATION_FINISHED = 'Finished migrating the workspace.'
+  public static readonly MIGRATION_FAILED = (
+    err: string
+  ): string => `Error encountered while migrating the workspace: ${err}.`
+
   public static readonly NO_MATCHES_FOUND_FOR_ELEMENT =
     (elementId: string): string => `Did not find any matches for element ${elementId}`
 

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -366,6 +366,16 @@ ${Prompts.LIST_IDS(ids)}
     err: string
   ): string => `Error encountered while migrating the workspace: ${err}.`
 
+  public static readonly MIGRATION_CHECK_STARTED = 'Starting to check the workspace.'
+  public static readonly MIGRATION_CHECK_FINISHED = 'Finished checking the workspace.'
+  public static readonly MIGRATION_CHECK_HAS_ERRORS = (
+    err: string
+  ): string => `There are errors in the workspace: ${err}`
+
+  public static readonly MIGRATION_CHECK_FAILED = (
+    err: string
+  ): string => `Error encountered while checking the workspace: ${err}.`
+
   public static readonly NO_MATCHES_FOUND_FOR_ELEMENT =
     (elementId: string): string => `Did not find any matches for element ${elementId}`
 

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -433,6 +433,7 @@ export const mockWorkspace = ({
     getElementFileNames: mockFunction<Workspace['getElementFileNames']>(),
     getChangedElementsBetween: mockFunction<Workspace['getChangedElementsBetween']>(),
     getReferencedStaticFilePaths: mockFunction<Workspace['getReferencedStaticFilePaths']>(),
+    getWorkspaceConfigSource: mockFunction<Workspace['getWorkspaceConfigSource']>(),
   }
 }
 

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -28,7 +28,7 @@ module.exports = deepMerge(
     coverageThreshold: {
       // Slowly start increasing here, never decrease!
       global: {
-        branches: 83.22,
+        branches: 82.50,
         functions: 88.79,
         lines: 85,
         statements: 90,

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -538,6 +538,7 @@ const getElementPathFromFileName = (filename: string, envName: string): string[]
 export const migrateWorkspace = async (
   workspace: Workspace,
   force: boolean,
+  common: boolean,
 ): Promise<void> => {
   const oldAdapterName = 'zendesk_support'
   const newAdapterName = 'zendesk'
@@ -603,7 +604,7 @@ export const migrateWorkspace = async (
       const additionChanges: DetailedChange[] = fullElements.map(e =>
         ({ data: { after: e }, action: 'add', id: e.elemID, path: e.path }))
       const changes = removalChanges.concat(additionChanges)
-      await workspace.updateNaclFiles(changes, 'isolated')
+      await workspace.updateNaclFiles(changes, common ? 'override' : 'isolated')
       await workspace.setNaclFiles(oldConfigFilePaths.map(filename => ({ filename, buffer: '' })))
       await workspace.flush()
     })

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -597,7 +597,7 @@ export const migrateWorkspace = async (
         ({ data: { before: e }, action: 'remove', id: e.elemID, path: e.path }))
       const additionChanges: DetailedChange[] = fullElements.map(e =>
         ({ data: { after: e }, action: 'add', id: e.elemID, path: e.path }))
-      const changes = [...removalChanges, ...additionChanges]
+      const changes = removalChanges.concat(additionChanges)
       await workspace.updateNaclFiles(changes, 'isolated')
       await workspace.setNaclFiles(oldConfigFilePaths.map(filename => ({ filename, buffer: '' })))
       await workspace.flush()

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -227,6 +227,7 @@ export type Workspace = {
     account?: string,
   ) => Promise<void>
   getServiceFromAccountName: (account: string) => string
+  getWorkspaceConfigSource: () => WorkspaceConfigSource
   getStateRecency(accounts: string): Promise<StateRecency>
   promote(
     idsToMove: ElemID[],
@@ -1378,6 +1379,7 @@ export const loadWorkspace = async (
       (naclFilesSource.getStaticFile(filepath, encoding, env ?? currentEnv())),
     getChangedElementsBetween,
     getReferencedStaticFilePaths,
+    getWorkspaceConfigSource: () => config,
   }
 }
 


### PR DESCRIPTION
_Zendesk migration command_
We are going to migrate zendesk adapter to be called `zendesk` instead of `zendesk_support`.
I added this command to help us with the migration process.
In order to fully understand how the migration will look like - please take a look at the Jira ticket.
However, this code should not be merged to production.

---

_Additional context for reviewer_
NOTE: THIS SHOULD NEVER BE MERGED TO PRODUCTION!!!

---
_Release Notes_: 
None

---
_User Notifications_: 
None
