### PR TITLE
SALTO-2463 - Fetch InstalledPackage Records regardless of namespace config

### DIFF
--- a/packages/salesforce-adapter/src/fetch_profile/metadata_query.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/metadata_query.ts
@@ -38,6 +38,10 @@ const PERMANENT_SKIP_LIST: MetadataQueryParams[] = [
   { metadataType: 'EscalationRule' },
 ]
 
+const ACCEPT_ALL_NAMESPACES_TYPE_LIST = [
+  'InstalledPackage',
+]
+
 export const buildMetadataQuery = (
   { include = [{}], exclude = [] }: MetadataParams,
   target?: string[],
@@ -52,7 +56,10 @@ export const buildMetadataQuery = (
       name = '.*',
     }: MetadataQueryParams
   ): boolean => {
-    const realNamespace = namespace === '' ? DEFAULT_NAMESPACE : namespace
+    // eslint-disable-next-line no-nested-ternary
+    const realNamespace = ACCEPT_ALL_NAMESPACES_TYPE_LIST.includes(instance.metadataType)
+      ? '.*'
+      : (namespace === '' ? DEFAULT_NAMESPACE : namespace)
     return regex.isFullRegexMatch(instance.metadataType, metadataType)
     && regex.isFullRegexMatch(instance.namespace, realNamespace)
     && regex.isFullRegexMatch(instance.name, name)

--- a/packages/salesforce-adapter/src/fetch_profile/metadata_query.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/metadata_query.ts
@@ -38,9 +38,16 @@ const PERMANENT_SKIP_LIST: MetadataQueryParams[] = [
   { metadataType: 'EscalationRule' },
 ]
 
-const ACCEPT_ALL_NAMESPACES_TYPE_LIST = [
+// Instances of these types will match all namespaces
+// and not just standard if '' (aka default) is provided in the namespace filter
+const DEFAULT_NAMESPACE_MATCH_ALL_TYPE_LIST = [
   'InstalledPackage',
 ]
+
+const getDefaultNamespace = (metadataType: string): string =>
+  (DEFAULT_NAMESPACE_MATCH_ALL_TYPE_LIST.includes(metadataType)
+    ? '.*'
+    : DEFAULT_NAMESPACE)
 
 export const buildMetadataQuery = (
   { include = [{}], exclude = [] }: MetadataParams,
@@ -56,10 +63,9 @@ export const buildMetadataQuery = (
       name = '.*',
     }: MetadataQueryParams
   ): boolean => {
-    // eslint-disable-next-line no-nested-ternary
-    const realNamespace = ACCEPT_ALL_NAMESPACES_TYPE_LIST.includes(instance.metadataType)
-      ? '.*'
-      : (namespace === '' ? DEFAULT_NAMESPACE : namespace)
+    const realNamespace = namespace === ''
+      ? getDefaultNamespace(instance.metadataType)
+      : namespace
     return regex.isFullRegexMatch(instance.metadataType, metadataType)
     && regex.isFullRegexMatch(instance.namespace, realNamespace)
     && regex.isFullRegexMatch(instance.name, name)

--- a/packages/salesforce-adapter/test/fetch_profile/metadata_query.test.ts
+++ b/packages/salesforce-adapter/test/fetch_profile/metadata_query.test.ts
@@ -170,13 +170,22 @@ describe('buildMetadataQuery', () => {
       expect(query.isInstanceMatch({ namespace: 'notstandard', metadataType: '', name: '' })).toBeFalsy()
     })
 
-    it('should not filter InstalledPackage by namespace', () => {
+    it('should return InstalledPackage with namespace if \'\' namespace is provided', () => {
       const query = buildMetadataQuery({
         include: [
           { namespace: '' },
         ],
       })
       expect(query.isInstanceMatch({ namespace: 'SBQQ', metadataType: 'InstalledPackage', name: 'lala' })).toBeTruthy()
+    })
+
+    it('should not return InstalledPackage with a different namespace then one specifically provided', () => {
+      const query = buildMetadataQuery({
+        include: [
+          { namespace: 'SBAA' },
+        ],
+      })
+      expect(query.isInstanceMatch({ namespace: 'SBQQ', metadataType: 'InstalledPackage', name: 'lala' })).toBeFalsy()
     })
   })
 

--- a/packages/salesforce-adapter/test/fetch_profile/metadata_query.test.ts
+++ b/packages/salesforce-adapter/test/fetch_profile/metadata_query.test.ts
@@ -169,6 +169,15 @@ describe('buildMetadataQuery', () => {
       expect(query.isInstanceMatch({ namespace: 'standard', metadataType: '', name: '' })).toBeTruthy()
       expect(query.isInstanceMatch({ namespace: 'notstandard', metadataType: '', name: '' })).toBeFalsy()
     })
+
+    it('should not filter InstalledPackage by namespace', () => {
+      const query = buildMetadataQuery({
+        include: [
+          { namespace: '' },
+        ],
+      })
+      expect(query.isInstanceMatch({ namespace: 'SBQQ', metadataType: 'InstalledPackage', name: 'lala' })).toBeTruthy()
+    })
   })
 
   it('isTypeMatch should return correct results', () => {


### PR DESCRIPTION


---
_Release Notes_: 

_Salesforce_:
* Added logic that fetches the InstalledPackage records even if the config specifies only fetching standard namespace Records of other metadataTypes cause they are system-wide Records and not really part of the namespace

---
_User Notifications_: 

_Salesforce_:
* InstalledPackage Records will be added to existing Workspaces on the next fetch
