### PR TITLE
SALTO-2487: fix adapter renaming to work on static files

### DIFF
--- a/packages/workspace/src/element_adapter_rename.ts
+++ b/packages/workspace/src/element_adapter_rename.ts
@@ -104,8 +104,12 @@ const updateTemplateExpression = (value: TemplateExpression, accountName: string
   })
 }
 
-const updateStaticFile = (value: StaticFile, accountName: string, oldAccount: string): void => {
-  _.set(value, 'filepath', value.filepath.replace(`${oldAccount}/`, `${accountName}/`))
+const updateStaticFile = (
+  value: StaticFile,
+  newAccountName: string,
+  oldAccountName: string,
+): void => {
+  _.set(value, 'filepath', value.filepath.replace(`${oldAccountName}/`, `${newAccountName}/`))
 }
 
 const updateElement = (value: Element, accountName: string): void => {

--- a/packages/workspace/src/element_adapter_rename.ts
+++ b/packages/workspace/src/element_adapter_rename.ts
@@ -34,6 +34,8 @@ import {
   isTemplateExpression,
   ReferenceExpression,
   TemplateExpression,
+  isStaticFile,
+  StaticFile,
 } from '@salto-io/adapter-api'
 import { transformElement, TransformFunc } from '@salto-io/adapter-utils'
 import { UnresolvedReference } from './expressions'
@@ -102,6 +104,10 @@ const updateTemplateExpression = (value: TemplateExpression, accountName: string
   })
 }
 
+const updateStaticFile = (value: StaticFile, accountName: string, oldAccount: string): void => {
+  _.set(value, 'filepath', value.filepath.replace(`${oldAccount}/`, `${accountName}/`))
+}
+
 const updateElement = (value: Element, accountName: string): void => {
   _.set(value, 'elemID', createAdapterReplacedID(value.elemID, accountName))
   value.annotationRefTypes = _.mapValues(value.annotationRefTypes,
@@ -117,11 +123,14 @@ const updateElement = (value: Element, accountName: string): void => {
   }
 }
 
-const transformElemIDAdapter = (accountName: string): TransformFunc => async (
+const transformElemIDAdapter = (accountName: string, oldAccount: string): TransformFunc => async (
   { value }
 ) => {
   if (isReferenceExpression(value)) {
     updateReferenceExpression(value, accountName)
+  }
+  if (isStaticFile(value)) {
+    updateStaticFile(value, accountName, oldAccount)
   }
   if (isTemplateExpression(value)) {
     updateTemplateExpression(value, accountName)
@@ -141,7 +150,7 @@ export const updateElementsWithAlternativeAccount = async (elementsToUpdate: Ele
     if (element.elemID.adapter === oldAccount) {
       await transformElement({
         element,
-        transformFunc: transformElemIDAdapter(newAccount),
+        transformFunc: transformElemIDAdapter(newAccount, oldAccount),
         strict: false,
         runOnFields: true,
         elementsSource: source,

--- a/packages/workspace/test/workspace/element_adapter_rename.test.ts
+++ b/packages/workspace/test/workspace/element_adapter_rename.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, ElemID, InstanceElement, ListType, MapType, ObjectType, ReferenceExpression, TemplateExpression, TypeReference } from '@salto-io/adapter-api'
+import { BuiltinTypes, ElemID, InstanceElement, ListType, MapType, ObjectType, ReferenceExpression, StaticFile, TemplateExpression, TypeReference } from '@salto-io/adapter-api'
 import { createInMemoryElementSource } from '../../src/workspace/elements_source'
 import { createAdapterReplacedID, updateElementsWithAlternativeAccount } from '../../src/element_adapter_rename'
 import { UnresolvedReference } from '../../src/expressions'
@@ -57,6 +57,10 @@ describe('rename adapter in elements', () => {
       mapOfMapField: { refType: new MapType(new MapType(innerType)) },
     },
   })
+  const staticFileToChange = new StaticFile({
+    filepath: `static-resources/${serviceName}/test.txt`,
+    content: Buffer.from('test'),
+  })
   const instanceToChange = new InstanceElement('InstanceElement', objectToChange, {
     field: new ReferenceExpression(innerType.elemID),
     templateField: new TemplateExpression({
@@ -68,6 +72,7 @@ describe('rename adapter in elements', () => {
       ],
     }),
     innerRefField: innerType,
+    staticFileField: staticFileToChange,
   })
   // the adapter change is supposed to set this value to undefined if it finds unresolved reference.
   instanceToChange.value.field.value = new UnresolvedReference(innerType.elemID)
@@ -95,6 +100,10 @@ describe('rename adapter in elements', () => {
       mapOfMapField: { refType: new MapType(new MapType(changedInnerType)) },
     },
   })
+  const changedStaticFile = new StaticFile({
+    filepath: `static-resources/${newServiceName}/test.txt`,
+    content: Buffer.from('test'),
+  })
   const changedInstance = new InstanceElement('InstanceElement', changedObject, {
     field: new ReferenceExpression(changedInnerType.elemID),
     templateField: new TemplateExpression({
@@ -106,6 +115,7 @@ describe('rename adapter in elements', () => {
       ],
     }),
     innerRefField: changedInnerType,
+    staticFileField: changedStaticFile,
   })
   const changedUnresolvedReferenceInstanceToChange = new InstanceElement('InstanceElement',
     new TypeReference(changedObject.elemID))


### PR DESCRIPTION
_Fix adapter renaming to work on static files_

---

_Additional context for reviewer_

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
