### PR TITLE
SALTO-2487: add tests to adapter renaming to work on static files

### DIFF
--- a/packages/workspace/src/element_adapter_rename.ts
+++ b/packages/workspace/src/element_adapter_rename.ts
@@ -109,6 +109,7 @@ const updateStaticFile = (
   newAccountName: string,
   oldAccountName: string,
 ): void => {
+  // Note: the replace function only replace the first occurrence (which will be the folder name)
   _.set(value, 'filepath', value.filepath.replace(`${oldAccountName}/`, `${newAccountName}/`))
 }
 

--- a/packages/workspace/test/workspace/element_adapter_rename.test.ts
+++ b/packages/workspace/test/workspace/element_adapter_rename.test.ts
@@ -58,7 +58,7 @@ describe('rename adapter in elements', () => {
     },
   })
   const staticFileToChange = new StaticFile({
-    filepath: `static-resources/${serviceName}/test.txt`,
+    filepath: `static-resources/${serviceName}/test${serviceName}.txt`,
     content: Buffer.from('test'),
   })
   const instanceToChange = new InstanceElement('InstanceElement', objectToChange, {
@@ -101,7 +101,7 @@ describe('rename adapter in elements', () => {
     },
   })
   const changedStaticFile = new StaticFile({
-    filepath: `static-resources/${newServiceName}/test.txt`,
+    filepath: `static-resources/${newServiceName}/test${serviceName}.txt`,
     content: Buffer.from('test'),
   })
   const changedInstance = new InstanceElement('InstanceElement', changedObject, {
@@ -138,6 +138,7 @@ describe('rename adapter in elements', () => {
       .value.innerRefField.annotationRefTypes.someRef.type
     changedInstance.value.innerRefField.fields.value = instanceToChange
       .value.innerRefField.fields.value
+    expect(instanceToChange.value.staticFileField).toEqual(changedInstance.value.staticFileField)
     expect(instanceToChange.isEqual(changedInstance)).toBeTruthy()
   })
 


### PR DESCRIPTION
_Add tests to adapter renaming to work on static files_

---

_Additional context for reviewer_
Based on [this](https://github.com/salto-io/salto/pull/3191/files#r924760691) comment

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
