### PR TITLE
SALTO-2493 - List of strings supported in LogTags

### DIFF
--- a/packages/logging/src/internal/log-tags.ts
+++ b/packages/logging/src/internal/log-tags.ts
@@ -19,7 +19,7 @@ import safeStringify from 'fast-safe-stringify'
 import { byName as colorsByName } from './colors'
 
 export type PrimitiveType = string | number | boolean
-type LogTagValue = PrimitiveType | undefined | Record<string, unknown> | string[]
+type LogTagValue = PrimitiveType | undefined | Record<string, unknown> | Array<PrimitiveType>
 export type LogTags = Record<string, LogTagValue | (() => LogTagValue)>
 
 export const LOG_TAGS_COLOR = colorsByName.Olive

--- a/packages/logging/src/internal/log-tags.ts
+++ b/packages/logging/src/internal/log-tags.ts
@@ -19,7 +19,7 @@ import safeStringify from 'fast-safe-stringify'
 import { byName as colorsByName } from './colors'
 
 export type PrimitiveType = string | number | boolean
-type LogTagValue = PrimitiveType | undefined | Record<string, unknown>
+type LogTagValue = PrimitiveType | undefined | Record<string, unknown> | string[]
 export type LogTags = Record<string, LogTagValue | (() => LogTagValue)>
 
 export const LOG_TAGS_COLOR = colorsByName.Olive

--- a/packages/logging/test/internal/pino_logger.test.ts
+++ b/packages/logging/test/internal/pino_logger.test.ts
@@ -928,7 +928,7 @@ describe('pino based logger', () => {
           normalTags: 1,
           functionStringTags: () => '5',
           functionObjTag: () => ({ something: 'bad', happened: 'here' }),
-          functionArrTag: () => ['one', 'two', 'three']
+          functionArrTag: () => ['one', 2, false],
         }
         beforeEach(async () => {
           logger = createLogger()
@@ -939,7 +939,7 @@ describe('pino based logger', () => {
           expect(line).toContain('normalTags=1')
           expect(line).toContain('functionStringTags="5"')
           expect(line).toContain('functionObjTag={"something":"bad","happened":"here"}')
-          expect(line).toContain('functionArrTag=["one","two","three"]')
+          expect(line).toContain('functionArrTag=["one",2,false]')
         })
         it('line should contain basic log data', () => {
           expect(line).toMatch(TIMESTAMP_REGEX)
@@ -1012,7 +1012,7 @@ describe('pino based logger', () => {
         })
       })
       describe('with global tags', () => {
-        const moreTags = { anotherTag: 'foo', anotherNumber: 4 }
+        const moreTags = { anotherTag: 'foo', anotherNumber: 4, andAList: [true, 'two', 3] }
         beforeEach(async () => {
           initialConfig.minLevel = 'info'
           initialConfig.globalTags = moreTags
@@ -1027,6 +1027,7 @@ describe('pino based logger', () => {
           expect(line).toContain('"number":1')
           expect(line).toContain('"string":"1"')
           expect(line).toContain('"bool":true')
+          expect(line).toContain('"andAList":[true,"two",3]')
         })
         it('should new log tags', () => {
           expect(line).toContain('"anotherTag":"foo"')

--- a/packages/logging/test/internal/pino_logger.test.ts
+++ b/packages/logging/test/internal/pino_logger.test.ts
@@ -928,6 +928,7 @@ describe('pino based logger', () => {
           normalTags: 1,
           functionStringTags: () => '5',
           functionObjTag: () => ({ something: 'bad', happened: 'here' }),
+          functionArrTag: () => ['one', 'two', 'three']
         }
         beforeEach(async () => {
           logger = createLogger()
@@ -938,6 +939,7 @@ describe('pino based logger', () => {
           expect(line).toContain('normalTags=1')
           expect(line).toContain('functionStringTags="5"')
           expect(line).toContain('functionObjTag={"something":"bad","happened":"here"}')
+          expect(line).toContain('functionArrTag=["one","two","three"]')
         })
         it('line should contain basic log data', () => {
           expect(line).toMatch(TIMESTAMP_REGEX)
@@ -955,7 +957,7 @@ describe('pino based logger', () => {
           logger.assignTags(logTags)
           logger.log(
             'error', 'lots of data %s', 'datadata', 'excessArgs',
-            true, { someArg: { with: 'data' }, anotherArg: 'much simpler' }, 'bad\n\t"string', undefined
+            true, { someArg: { with: 'data' }, anotherArg: 'much simpler' }, 'bad\n\t"string', undefined,
           );
           [line] = consoleStream.contents().split(EOL)
         })


### PR DESCRIPTION
Support `string[]` in LogTags
- [x] Support in the type
- [x] Manual validation for text format
- [x] Manual validation for json format
- [ ] Validate Datadog supports the json format manually
---

_Additional context for reviewer_
Ticket in [here](https://salto-io.atlassian.net/browse/SALTO-2493)

Some local tests:
The log line:
<img width="601" alt="image" src="https://user-images.githubusercontent.com/69420775/179978367-4002672f-e599-4a7a-8427-75ff7ecc525a.png">
On Json format:
<img width="1348" alt="image" src="https://user-images.githubusercontent.com/69420775/179978478-56a20d57-c08c-4562-88f8-0cd0c9d37366.png">
On Text format:
<img width="1316" alt="image" src="https://user-images.githubusercontent.com/69420775/179978980-4e3d01d0-3b63-4fd9-bd30-9002ab005ff6.png">


---
_Release Notes_: 
-

---
_User Notifications_: 
-
