### PR TITLE
SALTO-2492: Separate filters that require a client from ones that do not

### DIFF
--- a/packages/salesforce-adapter/e2e_test/utils.ts
+++ b/packages/salesforce-adapter/e2e_test/utils.ts
@@ -21,7 +21,7 @@ import { MetadataInfo } from 'jsforce'
 import { SalesforceRecord } from '../src/client/types'
 import { FilterContext, FilterResult } from '../src/filter'
 import { SALESFORCE } from '../src/constants'
-import SalesforceAdapter, { DEFAULT_FILTERS } from '../src/adapter'
+import SalesforceAdapter, { allFilters } from '../src/adapter'
 import SalesforceClient from '../src/client/client'
 import { createInstanceElement, metadataType, apiName, MetadataValues, isInstanceOfCustomObject } from '../src/transformers/transformer'
 import { fetchMetadataType } from '../src/fetch'
@@ -239,7 +239,7 @@ export const runFiltersOnFetch = async (
   client: SalesforceClient,
   context: Partial<FilterContext>,
   elements: Element[],
-  filterCreators = DEFAULT_FILTERS
+  filterCreators = allFilters.map(({ creator }) => creator)
 ): Promise<void | FilterResult> =>
   filter.filtersRunner({ client, config: { ...defaultFilterContext, ...context } }, filterCreators)
     .onFetch(elements)

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -73,7 +73,7 @@ import currencyIsoCodeFilter from './filters/currency_iso_code'
 import splitCustomLabels from './filters/split_custom_labels'
 import { FetchElements, SalesforceConfig } from './types'
 import { getConfigFromConfigChanges } from './config_change'
-import { FilterCreator, Filter, FilterResult } from './filter'
+import { LocalFilterCreator, Filter, FilterResult, RemoteFilterCreator } from './filter'
 import { addDefaults } from './filters/utils'
 import { retrieveMetadataInstances, fetchMetadataType, fetchMetadataInstances, listMetadataObjects } from './fetch'
 import { isCustomObjectInstanceChanges, deployCustomObjectInstancesGroup } from './custom_object_instances_deploy'
@@ -87,66 +87,78 @@ const { concatObjects } = objects
 
 const log = logger(module)
 
-export const DEFAULT_FILTERS = [
-  settingsFilter,
-  customFeedFilterFilter,
+type RemoteFilterCreatorDefinition = {
+  creator: RemoteFilterCreator
+  addsNewInformation: true
+}
+type LocalFilterCreatorDefinition = {
+  creator: LocalFilterCreator
+  addsNewInformation?: false
+}
+
+export const allFilters: Array<LocalFilterCreatorDefinition | RemoteFilterCreatorDefinition> = [
+  { creator: settingsFilter, addsNewInformation: true },
+  { creator: customFeedFilterFilter, addsNewInformation: true },
   // should run before customObjectsFilter
-  workflowFilter,
+  { creator: workflowFilter },
   // customObjectsFilter depends on missingFieldsFilter and settingsFilter
-  customObjectsFilter,
+  { creator: customObjectsFilter, addsNewInformation: true },
   // customSettingsFilter depends on customObjectsFilter
-  customSettingsFilter,
+  { creator: customSettingsFilter, addsNewInformation: true },
   // customObjectsInstancesFilter depends on customObjectsFilter
-  customObjectsInstancesFilter,
-  removeFieldsAndValuesFilter,
-  removeRestrictionAnnotationsFilter,
+  { creator: customObjectsInstancesFilter, addsNewInformation: true },
+  { creator: removeFieldsAndValuesFilter },
+  { creator: removeRestrictionAnnotationsFilter },
   // addMissingIdsFilter should run after customObjectsFilter
-  addMissingIdsFilter,
-  customMetadataRecordsFilter,
-  layoutFilter,
+  { creator: addMissingIdsFilter, addsNewInformation: true },
+  { creator: customMetadataRecordsFilter },
+  { creator: layoutFilter },
   // profilePermissionsFilter depends on layoutFilter because layoutFilter
   // changes ElemIDs that the profile references
-  profilePermissionsFilter,
+  { creator: profilePermissionsFilter },
   // profileMapsFilter should run before profile fieldReferencesFilter
-  convertMapsFilter,
-  standardValueSetFilter,
-  flowFilter,
-  customObjectInstanceReferencesFilter,
-  cpqCustomScriptFilter,
-  cpqLookupFieldsFilter,
-  animationRulesFilter,
-  samlInitMethodFilter,
-  topicsForObjectsFilter,
-  valueSetFilter,
-  globalValueSetFilter,
-  staticResourceFileExtFilter,
-  profilePathsFilter,
-  territoryFilter,
-  elementsUrlFilter,
-  customObjectAuthorFilter,
-  dataInstancesAuthorFilter,
-  sharingRulesAuthorFilter,
-  validationRulesAuthorFilter,
-  hideReadOnlyValuesFilter,
-  currencyIsoCodeFilter,
-  splitCustomLabels,
+  { creator: convertMapsFilter },
+  { creator: standardValueSetFilter, addsNewInformation: true },
+  { creator: flowFilter },
+  { creator: customObjectInstanceReferencesFilter, addsNewInformation: true },
+  { creator: cpqCustomScriptFilter },
+  { creator: cpqLookupFieldsFilter },
+  { creator: animationRulesFilter },
+  { creator: samlInitMethodFilter },
+  { creator: topicsForObjectsFilter },
+  { creator: valueSetFilter },
+  { creator: globalValueSetFilter },
+  { creator: staticResourceFileExtFilter },
+  { creator: profilePathsFilter, addsNewInformation: true },
+  { creator: territoryFilter },
+  { creator: elementsUrlFilter, addsNewInformation: true },
+  { creator: customObjectAuthorFilter, addsNewInformation: true },
+  { creator: dataInstancesAuthorFilter, addsNewInformation: true },
+  { creator: sharingRulesAuthorFilter, addsNewInformation: true },
+  { creator: validationRulesAuthorFilter, addsNewInformation: true },
+  { creator: hideReadOnlyValuesFilter },
+  { creator: currencyIsoCodeFilter },
+  { creator: splitCustomLabels },
   // The following filters should remain last in order to make sure they fix all elements
-  convertListsFilter,
-  convertTypeFilter,
+  { creator: convertListsFilter },
+  { creator: convertTypeFilter },
   // should run after convertListsFilter
-  xmlAttributesFilter,
-  replaceFieldValuesFilter,
-  valueToStaticFileFilter,
-  fieldReferencesFilter,
+  { creator: xmlAttributesFilter },
+  { creator: replaceFieldValuesFilter },
+  { creator: valueToStaticFileFilter },
+  { creator: fieldReferencesFilter },
   // should run after customObjectsInstancesFilter for now
-  referenceAnnotationsFilter,
+  { creator: referenceAnnotationsFilter },
   // foreignLeyReferences should come after referenceAnnotationsFilter
-  foreignKeyReferencesFilter,
+  { creator: foreignKeyReferencesFilter },
   // extraDependenciesFilter should run after addMissingIdsFilter
-  extraDependenciesFilter,
-  customObjectsSplitFilter,
-  profileInstanceSplitFilter,
+  { creator: extraDependenciesFilter, addsNewInformation: true },
+  { creator: customObjectsSplitFilter },
+  { creator: profileInstanceSplitFilter },
 ]
+
+// By default we run all filters and provide a client
+const defaultFilters = allFilters.map(({ creator }) => creator)
 
 export interface SalesforceAdapterParams {
   // Max items to fetch in one retrieve request
@@ -165,7 +177,7 @@ export interface SalesforceAdapterParams {
   nestedMetadataTypes?: Record<string, NestedMetadataTypeInfo>
 
   // Filters to deploy to all adapter operations
-  filterCreators?: FilterCreator[]
+  filterCreators?: Array<LocalFilterCreator | RemoteFilterCreator>
 
   // client to use
   client: SalesforceClient
@@ -293,7 +305,7 @@ export default class SalesforceAdapter implements AdapterOperations {
         isNestedApiNameRelative: true,
       },
     },
-    filterCreators = DEFAULT_FILTERS,
+    filterCreators = defaultFilters,
     client,
     getElemIdFunc,
     elementsSource,

--- a/packages/salesforce-adapter/src/filter.ts
+++ b/packages/salesforce-adapter/src/filter.ts
@@ -41,4 +41,11 @@ export type Filter = filter.Filter<FilterResult>
 
 export type FilterWith<M extends keyof Filter> = filter.FilterWith<FilterResult, M>
 
-export type FilterCreator = filter.FilterCreator<FilterResult, FilterOpts>
+// Local filters only use information in existing elements
+// They can change the format of elements, but cannot use external sources of information
+export type LocalFilterCreator = filter.FilterCreator<FilterResult, Omit<FilterOpts, 'client'>>
+
+// Remote filters can add more information to existing elements
+// They should not change the format of existing elements, they should focus only on adding
+// the new information
+export type RemoteFilterCreator = filter.FilterCreator<FilterResult, FilterOpts>

--- a/packages/salesforce-adapter/src/filters/add_missing_ids.ts
+++ b/packages/salesforce-adapter/src/filters/add_missing_ids.ts
@@ -18,7 +18,7 @@ import {
 } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
-import { FilterCreator } from '../filter'
+import { RemoteFilterCreator } from '../filter'
 import { apiName, metadataType } from '../transformers/transformer'
 import SalesforceClient from '../client/client'
 import { getFullName, getInternalId, setInternalId, ensureSafeFilterFetch } from './utils'
@@ -73,7 +73,7 @@ export const WARNING_MESSAGE = 'Encountered an error while trying populate inter
 /**
  * Add missing env-specific ids using listMetadataObjects.
  */
-const filter: FilterCreator = ({ client, config }) => ({
+const filter: RemoteFilterCreator = ({ client, config }) => ({
   onFetch: ensureSafeFilterFetch({
     warningMessage: WARNING_MESSAGE,
     config,

--- a/packages/salesforce-adapter/src/filters/author_information/custom_objects.ts
+++ b/packages/salesforce-adapter/src/filters/author_information/custom_objects.ts
@@ -20,7 +20,7 @@ import _ from 'lodash'
 import { collections } from '@salto-io/lowerdash'
 import { CUSTOM_FIELD, CUSTOM_OBJECT } from '../../constants'
 import { apiName, getAuthorAnnotations, isCustomObject } from '../../transformers/transformer'
-import { FilterCreator, FilterWith } from '../../filter'
+import { FilterWith, RemoteFilterCreator } from '../../filter'
 import SalesforceClient from '../../client/client'
 import { ensureSafeFilterFetch } from '../utils'
 
@@ -102,7 +102,7 @@ export const WARNING_MESSAGE = 'Encountered an error while trying to populate au
 /*
  * add author information to object types and fields.
  */
-const filterCreator: FilterCreator = ({ client, config }): FilterWith<'onFetch'> => ({
+const filterCreator: RemoteFilterCreator = ({ client, config }): FilterWith<'onFetch'> => ({
   onFetch: ensureSafeFilterFetch({
     warningMessage: WARNING_MESSAGE,
     config,

--- a/packages/salesforce-adapter/src/filters/author_information/data_instances.ts
+++ b/packages/salesforce-adapter/src/filters/author_information/data_instances.ts
@@ -16,7 +16,7 @@
 import { CORE_ANNOTATIONS, Element, InstanceElement } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { isInstanceOfCustomObject } from '../../transformers/transformer'
-import { FilterCreator, FilterWith } from '../../filter'
+import { FilterWith, RemoteFilterCreator } from '../../filter'
 import SalesforceClient from '../../client/client'
 import { conditionQueries, ensureSafeFilterFetch, queryClient } from '../utils'
 
@@ -57,7 +57,7 @@ export const WARNING_MESSAGE = 'Encountered an error while trying to populate au
 /*
  * add author information to data instance elements.
  */
-const filterCreator: FilterCreator = ({ client, config }): FilterWith<'onFetch'> => ({
+const filterCreator: RemoteFilterCreator = ({ client, config }): FilterWith<'onFetch'> => ({
   onFetch: ensureSafeFilterFetch({
     warningMessage: WARNING_MESSAGE,
     config,

--- a/packages/salesforce-adapter/src/filters/author_information/sharing_rules.ts
+++ b/packages/salesforce-adapter/src/filters/author_information/sharing_rules.ts
@@ -20,7 +20,7 @@ import _ from 'lodash'
 import { collections, values } from '@salto-io/lowerdash'
 import { SHARING_RULES_TYPE } from '../../constants'
 import { getAuthorAnnotations } from '../../transformers/transformer'
-import { FilterCreator, FilterWith } from '../../filter'
+import { FilterWith, RemoteFilterCreator } from '../../filter'
 import SalesforceClient from '../../client/client'
 import { ensureSafeFilterFetch, isInstanceOfType } from '../utils'
 
@@ -67,7 +67,7 @@ export const WARNING_MESSAGE = 'Encountered an error while trying to populate au
 /*
  * add author information to sharing rules instances.
  */
-const filterCreator: FilterCreator = ({ client, config }): FilterWith<'onFetch'> => ({
+const filterCreator: RemoteFilterCreator = ({ client, config }): FilterWith<'onFetch'> => ({
   onFetch: ensureSafeFilterFetch({
     warningMessage: WARNING_MESSAGE,
     config,

--- a/packages/salesforce-adapter/src/filters/author_information/validation_rules.ts
+++ b/packages/salesforce-adapter/src/filters/author_information/validation_rules.ts
@@ -20,7 +20,7 @@ import _ from 'lodash'
 import { collections, values } from '@salto-io/lowerdash'
 import { VALIDATION_RULES_METADATA_TYPE } from '../../constants'
 import { getAuthorAnnotations } from '../../transformers/transformer'
-import { FilterCreator, FilterWith } from '../../filter'
+import { FilterWith, RemoteFilterCreator } from '../../filter'
 import SalesforceClient from '../../client/client'
 import { ensureSafeFilterFetch, isInstanceOfType } from '../utils'
 
@@ -53,7 +53,7 @@ export const WARNING_MESSAGE = 'Encountered an error while trying to populate au
 /*
  * Add author information to validation rules instances.
  */
-const filterCreator: FilterCreator = ({ client, config }): FilterWith<'onFetch'> => ({
+const filterCreator: RemoteFilterCreator = ({ client, config }): FilterWith<'onFetch'> => ({
   onFetch: ensureSafeFilterFetch({
     warningMessage: WARNING_MESSAGE,
     config,

--- a/packages/salesforce-adapter/src/filters/convert_lists.ts
+++ b/packages/salesforce-adapter/src/filters/convert_lists.ts
@@ -20,7 +20,7 @@ import {
 } from '@salto-io/adapter-api'
 import { applyRecursive, resolvePath } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
-import { FilterCreator } from '../filter'
+import { LocalFilterCreator } from '../filter'
 import { SALESFORCE } from '../constants'
 import hardcodedListsData from './hardcoded_lists.json'
 import { metadataType } from '../transformers/transformer'
@@ -191,7 +191,7 @@ export const makeFilter = (
   unorderedListFields: ReadonlyArray<UnorderedList>,
   unorderedListAnnotations: ReadonlyArray<UnorderedList>,
   hardcodedLists: ReadonlyArray<string>
-): FilterCreator => () => ({
+): LocalFilterCreator => () => ({
   /**
    * Upon fetch, mark all list fields as list fields in all fetched types
    *

--- a/packages/salesforce-adapter/src/filters/convert_maps.ts
+++ b/packages/salesforce-adapter/src/filters/convert_maps.ts
@@ -24,7 +24,7 @@ import { collections } from '@salto-io/lowerdash'
 import { naclCase, applyFunctionToChangeData } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 
-import { FilterCreator } from '../filter'
+import { LocalFilterCreator } from '../filter'
 import { API_NAME_SEPARATOR, PROFILE_METADATA_TYPE, BUSINESS_HOURS_METADATA_TYPE } from '../constants'
 import { metadataType } from '../transformers/transformer'
 
@@ -339,7 +339,7 @@ export const findInstancesToConvert = (
  * Convert certain instances' fields into maps, so that they are easier to view,
  * could be referenced, and can be split across multiple files.
  */
-const filter: FilterCreator = () => ({
+const filter: LocalFilterCreator = () => ({
   onFetch: async (elements: Element[]) => {
     await awu(Object.keys(metadataTypeToFieldToMapDef)).forEach(async targetMetadataType => {
       const instancesToConvert = await findInstancesToConvert(elements, targetMetadataType)

--- a/packages/salesforce-adapter/src/filters/convert_types.ts
+++ b/packages/salesforce-adapter/src/filters/convert_types.ts
@@ -20,7 +20,7 @@ import {
   transformValues,
 } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
-import { FilterCreator } from '../filter'
+import { LocalFilterCreator } from '../filter'
 import { transformPrimitive } from '../transformers/transformer'
 
 const { awu } = collections.asynciterable
@@ -30,7 +30,7 @@ const { awu } = collections.asynciterable
  * Convert types of values in instance elements to match the expected types according to the
  * instance type definition.
  */
-const filterCreator: FilterCreator = () => ({
+const filterCreator: LocalFilterCreator = () => ({
   /**
    * Upon fetch, convert all instance values to their correct type according to the
    * type definitions

--- a/packages/salesforce-adapter/src/filters/cpq/custom_script.ts
+++ b/packages/salesforce-adapter/src/filters/cpq/custom_script.ts
@@ -18,7 +18,7 @@ import { Element, ObjectType, ListType, InstanceElement, isAdditionOrModificatio
 import { applyFunctionToChangeData } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
-import { FilterCreator } from '../../filter'
+import { LocalFilterCreator } from '../../filter'
 import { isInstanceOfTypeChange } from '../utils'
 import { CPQ_CUSTOM_SCRIPT, CPQ_CONSUMPTION_SCHEDULE_FIELDS, CPQ_GROUP_FIELDS, CPQ_QUOTE_FIELDS, CPQ_QUOTE_LINE_FIELDS, CPQ_CONSUMPTION_RATE_FIELDS, CPQ_CODE_FIELD } from '../../constants'
 import { Types, apiName, isInstanceOfCustomObject, isCustomObject } from '../../transformers/transformer'
@@ -154,7 +154,7 @@ const applyFuncOnCustomScriptFieldChange = async (
     .forEach(change => applyFunctionToChangeData(change, fn))
 }
 
-const filter: FilterCreator = () => ({
+const filter: LocalFilterCreator = () => ({
   onFetch: async (elements: Element[]) => {
     const customObjects = await awu(elements).filter(isCustomObject).toArray() as ObjectType[]
     const cpqCustomScriptObject = await awu(customObjects)

--- a/packages/salesforce-adapter/src/filters/cpq/hide_read_only_values.ts
+++ b/packages/salesforce-adapter/src/filters/cpq/hide_read_only_values.ts
@@ -15,13 +15,13 @@
 */
 import { Element, CORE_ANNOTATIONS, isObjectType } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
-import { FilterCreator } from '../../filter'
+import { LocalFilterCreator } from '../../filter'
 import { isCustomObject } from '../../transformers/transformer'
 import { FIELD_ANNOTATIONS } from '../../constants'
 
 const { awu } = collections.asynciterable
 
-const filter: FilterCreator = ({ config }) => ({
+const filter: LocalFilterCreator = ({ config }) => ({
   onFetch: async (elements: Element[]) => {
     if (config.fetchProfile.dataManagement?.showReadOnlyValues === true) {
       // eslint-disable-next-line no-useless-return

--- a/packages/salesforce-adapter/src/filters/cpq/lookup_fields.ts
+++ b/packages/salesforce-adapter/src/filters/cpq/lookup_fields.ts
@@ -18,7 +18,7 @@ import { Element, ObjectType, ReferenceExpression, Value, Change, ChangeDataType
 import { applyFunctionToChangeData } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
-import { FilterCreator } from '../../filter'
+import { LocalFilterCreator } from '../../filter'
 import { apiName, isCustomObject, relativeApiName } from '../../transformers/transformer'
 import { FIELD_ANNOTATIONS, CPQ_PRODUCT_RULE, CPQ_PRICE_RULE, CPQ_LOOKUP_OBJECT_NAME, DEFAULT_OBJECT_TO_API_MAPPING, CPQ_CONFIGURATION_ATTRIBUTE, CPQ_DEFAULT_OBJECT_FIELD, CPQ_LOOKUP_QUERY, CPQ_TESTED_OBJECT, TEST_OBJECT_TO_API_MAPPING, CUSTOM_OBJECT, CUSTOM_FIELD, CPQ_PRICE_SCHEDULE, SCHEDULE_CONTRAINT_FIELD_TO_API_MAPPING, CPQ_QUOTE, CPQ_CONSTRAINT_FIELD, CPQ_DISCOUNT_SCHEDULE, API_NAME_SEPARATOR } from '../../constants'
 
@@ -253,7 +253,7 @@ const applyFuncOnCustomObjectWithMappingLookupChange = async (
   ))
 }
 
-const filter: FilterCreator = () => ({
+const filter: LocalFilterCreator = () => ({
   onFetch: async (elements: Element[]) => {
     log.debug('Started replacing lookupObject values with references')
     await replaceLookupObjectValueSetValuesWithReferences(

--- a/packages/salesforce-adapter/src/filters/custom_feed_filter.ts
+++ b/packages/salesforce-adapter/src/filters/custom_feed_filter.ts
@@ -16,7 +16,7 @@
 import { FileProperties } from 'jsforce-types'
 import { Element, ElemID } from '@salto-io/adapter-api'
 import { findObjectType } from '@salto-io/adapter-utils'
-import { FilterCreator, FilterResult } from '../filter'
+import { FilterResult, RemoteFilterCreator } from '../filter'
 import { fetchMetadataInstances, listMetadataObjects } from '../fetch'
 import { SALESFORCE } from '../constants'
 
@@ -29,7 +29,7 @@ const fixCustomFeedFullName = (props: FileProperties): FileProperties => ({
   ...props, fullName: `Case.${props.fullName}`,
 })
 
-const filterCreator: FilterCreator = ({ client, config }) => ({
+const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
   onFetch: async (elements: Element[]): Promise<FilterResult> => {
     const customFeedFilterType = findObjectType(
       elements, CUSTOM_FEED_FILTER_METADATA_TYPE_ID

--- a/packages/salesforce-adapter/src/filters/custom_metadata.ts
+++ b/packages/salesforce-adapter/src/filters/custom_metadata.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import { isInstanceElement, Values, isInstanceChange, isAdditionOrModificationChange } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
-import { FilterCreator } from '../filter'
+import { LocalFilterCreator } from '../filter'
 import { isInstanceOfType, isInstanceOfTypeChange } from './utils'
 import { XML_ATTRIBUTE_PREFIX } from '../constants'
 import { isNull } from '../transformers/transformer'
@@ -127,7 +127,7 @@ const formatRecordValuesForService = (values: Values): Values => {
   return values
 }
 
-const filterCreator: FilterCreator = () => ({
+const filterCreator: LocalFilterCreator = () => ({
   onFetch: async elements => {
     await awu(elements)
       .filter(isInstanceElement)

--- a/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
@@ -26,7 +26,7 @@ import {
 } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { Element, Values, Field, InstanceElement, ReferenceExpression, SaltoError } from '@salto-io/adapter-api'
-import { FilterCreator, FilterResult } from '../filter'
+import { FilterResult, RemoteFilterCreator } from '../filter'
 import { apiName, isInstanceOfCustomObject, isCustomObject } from '../transformers/transformer'
 import { FIELD_ANNOTATIONS, KEY_PREFIX, KEY_PREFIX_LENGTH, SALESFORCE } from '../constants'
 import { addElementParentReference, isLookupField, isMasterDetailField } from './utils'
@@ -257,7 +257,7 @@ const buildCustomObjectPrefixKeyMap = async (
   )
 }
 
-const filter: FilterCreator = ({ client, config }) => ({
+const filter: RemoteFilterCreator = ({ client, config }) => ({
   onFetch: async (elements: Element[]): Promise<FilterResult> => {
     const { dataManagement } = config.fetchProfile
     if (dataManagement === undefined) {

--- a/packages/salesforce-adapter/src/filters/custom_object_split.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_split.ts
@@ -18,7 +18,7 @@ import { Element, isObjectType, ObjectType } from '@salto-io/adapter-api'
 import { pathNaclCase } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { isCustom, isCustomObject, apiName } from '../transformers/transformer'
-import { FilterWith, FilterCreator } from '../filter'
+import { FilterWith, LocalFilterCreator } from '../filter'
 import { getObjectDirectoryPath } from './custom_objects'
 import { OBJECT_FIELDS_PATH } from '../constants'
 
@@ -91,7 +91,7 @@ const customObjectToSplitElements = async (
   return _.concat(fieldObjects, annotationsObject)
 }
 
-const filterCreator: FilterCreator = ({ config }): FilterWith<'onFetch'> => ({
+const filterCreator: LocalFilterCreator = ({ config }): FilterWith<'onFetch'> => ({
   onFetch: async (elements: Element[]) => {
     const customObjects = await awu(elements).filter(isCustomObject).toArray() as ObjectType[]
     const newSplitCustomObjects = await awu(customObjects)

--- a/packages/salesforce-adapter/src/filters/custom_objects.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects.ts
@@ -39,7 +39,7 @@ import {
   COMPOUND_FIELD_TYPE_NAMES, INTERNAL_ID_ANNOTATION, INTERNAL_ID_FIELD, LIGHTNING_PAGE_TYPE,
   FLEXI_PAGE_TYPE,
 } from '../constants'
-import { FilterCreator } from '../filter'
+import { RemoteFilterCreator } from '../filter'
 import {
   getSObjectFieldElement, Types, isCustomObject, apiName, transformPrimitive, MetadataValues,
   formulaTypeName, metadataType, isCustom, isCustomSettings, metadataAnnotationTypes,
@@ -843,7 +843,7 @@ const isSideEffectRemoval = (
  * Custom objects filter.
  * Fetches the custom objects via the soap api and adds them to the elements
  */
-const filterCreator: FilterCreator = ({ client, config }) => {
+const filterCreator: RemoteFilterCreator = ({ client, config }) => {
   let originalChanges: Record<string, Change[]> = {}
   return {
     onFetch: async (elements: Element[]): Promise<void> => {

--- a/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
@@ -25,7 +25,7 @@ import {
   SALESFORCE, RECORDS_PATH, INSTALLED_PACKAGES_PATH, CUSTOM_OBJECT_ID_FIELD,
   OBJECTS_PATH, FIELD_ANNOTATIONS, MAX_QUERY_LENGTH,
 } from '../constants'
-import { FilterCreator, FilterResult } from '../filter'
+import { FilterResult, RemoteFilterCreator } from '../filter'
 import { apiName, isCustomObject, Types, createInstanceServiceIds, isNameField } from '../transformers/transformer'
 import { getNamespace, isMasterDetailField, isLookupField, conditionQueries, queryClient } from './utils'
 import { ConfigChangeSuggestion } from '../types'
@@ -410,7 +410,7 @@ export const getCustomObjectsFetchSettings = async (
     .toArray()
 }
 
-const filterCreator: FilterCreator = ({ client, config }) => ({
+const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
   onFetch: async (elements: Element[]): Promise<FilterResult> => {
     const { dataManagement } = config.fetchProfile
     if (dataManagement === undefined) {

--- a/packages/salesforce-adapter/src/filters/custom_settings_filter.ts
+++ b/packages/salesforce-adapter/src/filters/custom_settings_filter.ts
@@ -17,7 +17,7 @@ import { Element, isObjectType, ObjectType } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
-import { FilterCreator, FilterResult } from '../filter'
+import { FilterResult, RemoteFilterCreator } from '../filter'
 import { isCustomSettingsObject, apiName } from '../transformers/transformer'
 import { getAllInstances, getCustomObjectsFetchSettings, CustomObjectFetchSetting } from './custom_objects_instances'
 import { CUSTOM_SETTINGS_TYPE, LIST_CUSTOM_SETTINGS_TYPE } from '../constants'
@@ -37,7 +37,7 @@ const logInvalidCustomSettings = async (
     (log.debug(`Did not fetch instances for Custom Setting - ${await apiName(settings.objectType)} cause ${settings.invalidIdFields} do not exist or are not queryable`)))
 )
 
-const filterCreator: FilterCreator = ({ client, config }) => ({
+const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
   onFetch: async (elements: Element[]): Promise<FilterResult> => {
     if (!config.fetchProfile.shouldFetchAllCustomSettings()) {
       return {}

--- a/packages/salesforce-adapter/src/filters/elements_url.ts
+++ b/packages/salesforce-adapter/src/filters/elements_url.ts
@@ -16,7 +16,7 @@
 import { logger } from '@salto-io/logging'
 import { CORE_ANNOTATIONS, Element } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
-import { FilterCreator } from '../filter'
+import { RemoteFilterCreator } from '../filter'
 import { lightningElementsUrlRetriever } from '../elements_url_retreiver/elements_url_retreiver'
 import { buildElementsSourceForFetch, extractFlatCustomObjectFields, ensureSafeFilterFetch } from './utils'
 
@@ -30,7 +30,7 @@ const getRelevantElements = (elements: Element[]): AsyncIterable<Element> =>
 
 export const WARNING_MESSAGE = 'Encountered an error while trying to populate URLs for some of your salesforce configuration elements. This might affect the availability of the ‘go to service’ functionality in your workspace.'
 
-const filterCreator: FilterCreator = ({ client, config }) => ({
+const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
   onFetch: ensureSafeFilterFetch({
     warningMessage: WARNING_MESSAGE,
     config,

--- a/packages/salesforce-adapter/src/filters/extra_dependencies.ts
+++ b/packages/salesforce-adapter/src/filters/extra_dependencies.ts
@@ -20,7 +20,7 @@ import {
 import { collections, values as lowerDashValues, multiIndex } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import { getAllReferencedIds, buildElementsSourceFromElements, extendGeneratedDependencies } from '@salto-io/adapter-utils'
-import { FilterCreator } from '../filter'
+import { RemoteFilterCreator } from '../filter'
 import { metadataType, apiName, isCustomObject } from '../transformers/transformer'
 import SalesforceClient from '../client/client'
 import { getInternalId, buildElementsSourceForFetch, extractFlatCustomObjectFields, hasInternalId, ensureSafeFilterFetch } from './utils'
@@ -188,7 +188,7 @@ export const WARNING_MESSAGE = 'Encountered an error while trying to query your 
 /**
  * Add references using the tooling API.
  */
-const creator: FilterCreator = ({ client, config }) => ({
+const creator: RemoteFilterCreator = ({ client, config }) => ({
   onFetch: ensureSafeFilterFetch({
     warningMessage: WARNING_MESSAGE,
     config,

--- a/packages/salesforce-adapter/src/filters/field_references.ts
+++ b/packages/salesforce-adapter/src/filters/field_references.ts
@@ -19,7 +19,7 @@ import { getParents } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections, multiIndex } from '@salto-io/lowerdash'
 import { apiName, metadataType } from '../transformers/transformer'
-import { FilterCreator } from '../filter'
+import { LocalFilterCreator } from '../filter'
 import { generateReferenceResolverFinder, ReferenceContextStrategyName, FieldReferenceDefinition, getLookUpName } from '../transformers/reference_mapping'
 import {
   WORKFLOW_ACTION_ALERT_METADATA_TYPE, WORKFLOW_FIELD_UPDATE_METADATA_TYPE,
@@ -131,7 +131,7 @@ export const addReferences = async (
  * Convert field values into references, based on predefined rules.
  *
  */
-const filter: FilterCreator = ({ config }) => ({
+const filter: LocalFilterCreator = ({ config }) => ({
   onFetch: async elements => {
     await addReferences(
       elements,

--- a/packages/salesforce-adapter/src/filters/foreign_key_references.ts
+++ b/packages/salesforce-adapter/src/filters/foreign_key_references.ts
@@ -20,7 +20,7 @@ import {
 import _ from 'lodash'
 import { transformValues, TransformFunc } from '@salto-io/adapter-utils'
 import { values, collections, multiIndex } from '@salto-io/lowerdash'
-import { FilterCreator } from '../filter'
+import { LocalFilterCreator } from '../filter'
 import { FOREIGN_KEY_DOMAIN } from '../constants'
 import { metadataType, apiName } from '../transformers/transformer'
 import { buildElementsSourceForFetch, extractFlatCustomObjectFields, hasApiName } from './utils'
@@ -65,7 +65,7 @@ const resolveReferences = async (
  * Use annotations generated from the DescribeValueType API foreignKeyDomain data to resolve
  * names into reference expressions.
  */
-const filter: FilterCreator = ({ config }) => ({
+const filter: LocalFilterCreator = ({ config }) => ({
   onFetch: async (elements: Element[]) => {
     const referenceElements = buildElementsSourceForFetch(elements, config)
     const elementsWithFields = flatMapAsync(

--- a/packages/salesforce-adapter/src/filters/global_value_sets.ts
+++ b/packages/salesforce-adapter/src/filters/global_value_sets.ts
@@ -15,7 +15,7 @@
 */
 import { Element, ObjectType, Field, ReferenceExpression, ElemID, isObjectType } from '@salto-io/adapter-api'
 import { multiIndex } from '@salto-io/lowerdash'
-import { FilterWith, FilterCreator } from '../filter'
+import { FilterWith, LocalFilterCreator } from '../filter'
 import { VALUE_SET_FIELDS } from '../constants'
 import { isCustomObject, apiName } from '../transformers/transformer'
 import { isInstanceOfType, buildElementsSourceForFetch } from './utils'
@@ -47,7 +47,7 @@ const addGlobalValueSetRefToObject = (
 /**
  * Create filter that adds global value set references where needed
  */
-const filterCreator: FilterCreator = ({ config }): FilterWith<'onFetch'> => ({
+const filterCreator: LocalFilterCreator = ({ config }): FilterWith<'onFetch'> => ({
   /**
    * @param elements the already fetched elements
    */

--- a/packages/salesforce-adapter/src/filters/layouts.ts
+++ b/packages/salesforce-adapter/src/filters/layouts.ts
@@ -20,7 +20,7 @@ import {
 import { naclCase, pathNaclCase } from '@salto-io/adapter-utils'
 import { multiIndex, collections } from '@salto-io/lowerdash'
 import { apiName, isCustomObject } from '../transformers/transformer'
-import { FilterCreator } from '../filter'
+import { LocalFilterCreator } from '../filter'
 import { addElementParentReference, isInstanceOfType, buildElementsSourceForFetch } from './utils'
 import { SALESFORCE, LAYOUT_TYPE_ID_METADATA_TYPE, WEBLINK_METADATA_TYPE } from '../constants'
 import { getObjectDirectoryPath } from './custom_objects'
@@ -59,7 +59,7 @@ const fixLayoutPath = async (
 * Declare the layout filter, this filter adds reference from the sobject to it's layouts.
 * Fixes references in layout items.
 */
-const filterCreator: FilterCreator = ({ config }) => ({
+const filterCreator: LocalFilterCreator = ({ config }) => ({
   /**
    * Upon fetch, shorten layout ID and add reference to layout sobjects.
    * Fixes references in layout items.

--- a/packages/salesforce-adapter/src/filters/profile_instance_split.ts
+++ b/packages/salesforce-adapter/src/filters/profile_instance_split.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import { strings, collections, promises } from '@salto-io/lowerdash'
 import { Element, ObjectType, isMapType, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
 
-import { FilterCreator } from '../filter'
+import { LocalFilterCreator } from '../filter'
 import { metadataType } from '../transformers/transformer'
 import { PROFILE_METADATA_TYPE } from '../constants'
 
@@ -70,7 +70,7 @@ const isProfileInstance = async (elem: Element): Promise<boolean> => (
  * Each map field is assigned to a separate file, and the other fields and annotations
  * to Attributes.nacl.
  */
-const filterCreator: FilterCreator = () => ({
+const filterCreator: LocalFilterCreator = () => ({
   onFetch: async (elements: Element[]) => {
     const profileInstances = await removeAsync(elements, isProfileInstance) as InstanceElement[]
     if (profileInstances.length === 0) {

--- a/packages/salesforce-adapter/src/filters/profile_paths.ts
+++ b/packages/salesforce-adapter/src/filters/profile_paths.ts
@@ -17,7 +17,7 @@ import { Element, InstanceElement, isInstanceElement } from '@salto-io/adapter-a
 import { pathNaclCase, naclCase } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 
-import { FilterCreator, FilterWith } from '../filter'
+import { FilterWith, RemoteFilterCreator } from '../filter'
 import { apiName } from '../transformers/transformer'
 import SalesforceClient from '../client/client'
 import { getInternalId, isInstanceOfType, ensureSafeFilterFetch } from './utils'
@@ -60,7 +60,7 @@ export const WARNING_MESSAGE = 'Failed to update the NaCl file names for some of
 /**
  * replace paths for profile instances upon fetch
  */
-const filterCreator: FilterCreator = ({ client, config }): FilterWith<'onFetch'> => ({
+const filterCreator: RemoteFilterCreator = ({ client, config }): FilterWith<'onFetch'> => ({
   onFetch: ensureSafeFilterFetch({
     warningMessage: WARNING_MESSAGE,
     config,

--- a/packages/salesforce-adapter/src/filters/profile_permissions.ts
+++ b/packages/salesforce-adapter/src/filters/profile_permissions.ts
@@ -22,7 +22,7 @@ import { logger } from '@salto-io/logging'
 import { collections, promises } from '@salto-io/lowerdash'
 import { PROFILE_METADATA_TYPE, ADMIN_PROFILE, API_NAME, SALESFORCE } from '../constants'
 import { isCustomObject, apiName, isCustom, createInstanceElement, metadataAnnotationTypes, MetadataTypeAnnotations } from '../transformers/transformer'
-import { FilterCreator } from '../filter'
+import { LocalFilterCreator } from '../filter'
 import { ProfileInfo, FieldPermissions, ObjectPermissions } from '../client/types'
 import { isInstanceOfType, isMasterDetailField } from './utils'
 
@@ -117,7 +117,7 @@ const isAdminProfileChange = async (change: Change): Promise<boolean> => {
  * Profile permissions filter.
  * creates default Admin Profile.fieldsPermissions and Profile.objectsPermissions.
  */
-const filterCreator: FilterCreator = () => {
+const filterCreator: LocalFilterCreator = () => {
   let isPartialAdminProfile = false
   return {
     preDeploy: async changes => {

--- a/packages/salesforce-adapter/src/filters/reference_annotations.ts
+++ b/packages/salesforce-adapter/src/filters/reference_annotations.ts
@@ -18,7 +18,7 @@ import {
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { collections, multiIndex } from '@salto-io/lowerdash'
-import { FilterCreator } from '../filter'
+import { LocalFilterCreator } from '../filter'
 import { FIELD_ANNOTATIONS, FOREIGN_KEY_DOMAIN, CUSTOM_OBJECT } from '../constants'
 import { apiName, metadataType, isMetadataObjectType, isCustomObject } from '../transformers/transformer'
 import { buildElementsSourceForFetch } from './utils'
@@ -69,7 +69,7 @@ const convertAnnotationsToReferences = async (
 /**
  * Convert referenceTo and foreignKeyDomain annotations into reference expressions.
  */
-const filter: FilterCreator = ({ config }) => ({
+const filter: LocalFilterCreator = ({ config }) => ({
   onFetch: async (elements: Element[]) => {
     const referenceElements = buildElementsSourceForFetch(elements, config)
     const typeToElemID = await multiIndex.keyByAsync({

--- a/packages/salesforce-adapter/src/filters/remove_fields_and_values.ts
+++ b/packages/salesforce-adapter/src/filters/remove_fields_and_values.ts
@@ -18,7 +18,7 @@ import {
 } from '@salto-io/adapter-api'
 import { transformValues, TransformFunc } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
-import { FilterCreator } from '../filter'
+import { LocalFilterCreator } from '../filter'
 import { metadataType } from '../transformers/transformer'
 
 const { awu } = collections.asynciterable
@@ -76,7 +76,7 @@ const removeValuesFromInstances = async (
  * */
 export const makeFilter = (
   typeNameToFieldRemovals: Map<string, string[]>,
-): FilterCreator => () => ({
+): LocalFilterCreator => () => ({
   onFetch: async (elements: Element[]) => {
     await removeValuesFromInstances(elements, typeNameToFieldRemovals)
     await removeFieldsFromTypes(elements, typeNameToFieldRemovals)

--- a/packages/salesforce-adapter/src/filters/remove_restriction_annotations.ts
+++ b/packages/salesforce-adapter/src/filters/remove_restriction_annotations.ts
@@ -15,7 +15,7 @@
 */
 import { isObjectType, Element, ObjectType, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
-import { FilterCreator } from '../filter'
+import { LocalFilterCreator } from '../filter'
 import { metadataType } from '../transformers/transformer'
 
 const { awu } = collections.asynciterable
@@ -39,7 +39,7 @@ const FIELDS_TO_REMOVE_RESTRICTION_FROM_BY_TYPE: Record<string, string[]> = {
  */
 export const makeFilter = (
   typeNameToFieldMapping: Record<string, string[]>,
-): FilterCreator => () => ({
+): LocalFilterCreator => () => ({
   onFetch: async (elements: Element[]) => {
     const removeRestrictionsFromTypeFields = async (type: ObjectType): Promise<void> => {
       const relevantFields = typeNameToFieldMapping[await metadataType(type)]

--- a/packages/salesforce-adapter/src/filters/replace_instance_field_values.ts
+++ b/packages/salesforce-adapter/src/filters/replace_instance_field_values.ts
@@ -18,7 +18,7 @@ import { transformValues, TransformFunc } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import { collections, multiIndex } from '@salto-io/lowerdash'
-import { FilterCreator } from '../filter'
+import { LocalFilterCreator } from '../filter'
 import { apiName, metadataType, isCustomObject } from '../transformers/transformer'
 import { generateReferenceResolverFinder } from '../transformers/reference_mapping'
 import { getInternalId, hasInternalId, buildElementsSourceForFetch } from './utils'
@@ -116,7 +116,7 @@ const replaceInstancesValues = async (
 /**
  * Replace specific field values that are fetched as ids, to their names.
  */
-const filter: FilterCreator = ({ config }) => ({
+const filter: LocalFilterCreator = ({ config }) => ({
   onFetch: async (elements: Element[]) => {
     const referenceElements = buildElementsSourceForFetch(elements, config)
     const idToApiNameLookUp = await getRelevantFieldMapping({

--- a/packages/salesforce-adapter/src/filters/settings_type.ts
+++ b/packages/salesforce-adapter/src/filters/settings_type.ts
@@ -16,7 +16,7 @@
 import { Element, isObjectType, ObjectType, TypeElement } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
-import { FilterCreator, FilterResult } from '../filter'
+import { FilterResult, RemoteFilterCreator } from '../filter'
 import { createMetadataTypeElements, apiName } from '../transformers/transformer'
 import SalesforceClient from '../client/client'
 import { SETTINGS_METADATA_TYPE } from '../constants'
@@ -59,7 +59,7 @@ const getSettingsTypeName = (typeName: string): string => typeName.concat(SETTIN
 /**
  * Add settings type
  */
-const filterCreator: FilterCreator = ({ client, config }) => ({
+const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
   /**
    * Add all settings types and instances as filter.
    *

--- a/packages/salesforce-adapter/src/filters/split_custom_labels.ts
+++ b/packages/salesforce-adapter/src/filters/split_custom_labels.ts
@@ -27,7 +27,7 @@ import _ from 'lodash'
 import Joi from 'joi'
 import { collections } from '@salto-io/lowerdash'
 import { pathNaclCase } from '@salto-io/adapter-utils'
-import { FilterCreator, FilterWith } from '../filter'
+import { LocalFilterCreator, FilterWith } from '../filter'
 import { apiName, createInstanceElement, metadataAnnotationTypes } from '../transformers/transformer'
 import { getDataFromChanges, isInstanceOfType } from './utils'
 import {
@@ -144,7 +144,7 @@ const createCustomLabelsChange = async (customLabelChanges: Change[]): Promise<C
 /**
  * Split custom labels into individual instances
  */
-const filterCreator: FilterCreator = () : FilterWith<'onFetch'> & FilterWith<'onDeploy'> => {
+const filterCreator: LocalFilterCreator = () : FilterWith<'onFetch'> & FilterWith<'onDeploy'> => {
   let customLabelChanges: Change[]
   return {
     onFetch: async elements => {

--- a/packages/salesforce-adapter/src/filters/standard_value_sets.ts
+++ b/packages/salesforce-adapter/src/filters/standard_value_sets.ts
@@ -21,7 +21,7 @@ import {
 import { resolveTypeShallow } from '@salto-io/adapter-utils'
 import { collections, promises } from '@salto-io/lowerdash'
 
-import { FilterCreator, FilterResult } from '../filter'
+import { FilterResult, RemoteFilterCreator } from '../filter'
 import { FIELD_ANNOTATIONS, VALUE_SET_FIELDS } from '../constants'
 import {
   metadataType, apiName, isCustomObject, Types, isCustom,
@@ -196,7 +196,7 @@ const emptyFileProperties = (fullName: string): FileProperties => ({
 */
 export const makeFilter = (
   standardValueSetNames: StandardValuesSets
-): FilterCreator => ({ client, config }) => ({
+): RemoteFilterCreator => ({ client, config }) => ({
   /**
    * Upon fetch, retrieve standard value sets and
    * modify references to them in fetched elements

--- a/packages/salesforce-adapter/src/filters/territory.ts
+++ b/packages/salesforce-adapter/src/filters/territory.ts
@@ -15,7 +15,7 @@
 */
 import { Element, isInstanceElement, InstanceElement, getChangeData, Change, isInstanceChange, isAdditionOrModificationChange } from '@salto-io/adapter-api'
 import { collections, values } from '@salto-io/lowerdash'
-import { FilterCreator } from '../filter'
+import { LocalFilterCreator } from '../filter'
 import { isMetadataObjectType, metadataType, apiName } from '../transformers/transformer'
 import { CONTENT_FILENAME_OVERRIDE } from '../transformers/xml_transformer'
 import { TERRITORY2_TYPE, TERRITORY2_MODEL_TYPE, TERRITORY2_RULE_TYPE } from '../constants'
@@ -70,7 +70,7 @@ const setTerritoryDeployPkgStructure = async (element: InstanceElement): Promise
   element.annotate({ [CONTENT_FILENAME_OVERRIDE]: contentPath })
 }
 
-const filterCreator: FilterCreator = () => ({
+const filterCreator: LocalFilterCreator = () => ({
   onFetch: async elements => {
     // Territory2 and Territory2Model support custom fields - these are returned
     // in a CustomObject with the appropriate name and also in each instance of these types

--- a/packages/salesforce-adapter/src/filters/topics_for_objects.ts
+++ b/packages/salesforce-adapter/src/filters/topics_for_objects.ts
@@ -22,7 +22,7 @@ import _ from 'lodash'
 import { collections, promises } from '@salto-io/lowerdash'
 import { TOPICS_FOR_OBJECTS_FIELDS, TOPICS_FOR_OBJECTS_ANNOTATION, TOPICS_FOR_OBJECTS_METADATA_TYPE, SALESFORCE } from '../constants'
 import { isCustomObject, apiName, metadataType, createInstanceElement, metadataAnnotationTypes, MetadataTypeAnnotations } from '../transformers/transformer'
-import { FilterCreator, FilterWith } from '../filter'
+import { LocalFilterCreator, FilterWith } from '../filter'
 import { TopicsForObjectsInfo } from '../client/types'
 import { boolValue, getInstancesOfMetadataType, isInstanceOfTypeChange } from './utils'
 
@@ -58,7 +58,7 @@ const createTopicsForObjectsInstance = (values: TopicsForObjectsInfo): InstanceE
   )
 )
 
-const filterCreator: FilterCreator = (): FilterWith<'onFetch' | 'onDeploy'> => ({
+const filterCreator: LocalFilterCreator = (): FilterWith<'onFetch' | 'onDeploy'> => ({
   onFetch: async (elements: Element[]): Promise<void> => {
     const customObjectTypes = await awu(elements).filter(isCustomObject).toArray() as ObjectType[]
     if (_.isEmpty(customObjectTypes)) {

--- a/packages/salesforce-adapter/src/filters/value_to_static_file.ts
+++ b/packages/salesforce-adapter/src/filters/value_to_static_file.ts
@@ -21,7 +21,7 @@ import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import { WEBLINK_METADATA_TYPE } from '../constants'
-import { FilterCreator } from '../filter'
+import { LocalFilterCreator } from '../filter'
 import { generateReferenceResolverFinder } from '../transformers/reference_mapping'
 import { apiName, metadataType } from '../transformers/transformer'
 
@@ -88,7 +88,7 @@ const extractToStaticFile = async (instance: InstanceElement): Promise<void> => 
 /**
  * Extract field value to static-resources for chosen intstances.
  */
-const filter: FilterCreator = () => ({
+const filter: LocalFilterCreator = () => ({
   onFetch: async (elements: Element[]) => {
     await awu(elements)
       .filter(isInstanceElement)

--- a/packages/salesforce-adapter/src/filters/workflow.ts
+++ b/packages/salesforce-adapter/src/filters/workflow.ts
@@ -28,7 +28,7 @@ import {
   WORKFLOW_TASK_METADATA_TYPE,
   SALESFORCE,
 } from '../constants'
-import { FilterCreator } from '../filter'
+import { LocalFilterCreator } from '../filter'
 import {
   apiName, metadataType, createInstanceElement, metadataAnnotationTypes, MetadataTypeAnnotations,
   toMetadataInfo,
@@ -165,7 +165,7 @@ const getWorkflowApiName = async (change: Change<InstanceElement>): Promise<stri
   return await isWorkflowInstance(inst) ? apiName(inst) : parentApiName(inst)
 }
 
-const filterCreator: FilterCreator = () => {
+const filterCreator: LocalFilterCreator = () => {
   let originalWorkflowChanges: Record<string, Change<InstanceElement>[]> = {}
   return {
     /**

--- a/packages/salesforce-adapter/test/filters/convert_lists.test.ts
+++ b/packages/salesforce-adapter/test/filters/convert_lists.test.ts
@@ -18,12 +18,9 @@ import { ObjectType, ElemID, InstanceElement, Element, BuiltinTypes, Value, isLi
 import { makeFilter, UnorderedList } from '../../src/filters/convert_lists'
 import * as constants from '../../src/constants'
 import { FilterWith } from '../../src/filter'
-import mockClient from '../client'
 import { defaultFilterContext } from '../utils'
 
 describe('convert lists filter', () => {
-  const { client } = mockClient()
-
   const mockObjNoInstancesId = new ElemID(constants.SALESFORCE, 'noInstances')
   const mockTypeNoInstances = new ObjectType({
     elemID: mockObjNoInstancesId,
@@ -257,7 +254,7 @@ describe('convert lists filter', () => {
   let testElements: Element[]
 
   const filter = makeFilter(unorderedListFields, unorderedListAnnotations,
-    hardcodedLists)({ client, config: defaultFilterContext }) as FilterWith<'onFetch'>
+    hardcodedLists)({ config: defaultFilterContext }) as FilterWith<'onFetch'>
 
   beforeEach(() => {
     const typeClone = mockType.clone()

--- a/packages/salesforce-adapter/test/filters/convert_maps.test.ts
+++ b/packages/salesforce-adapter/test/filters/convert_maps.test.ts
@@ -16,7 +16,6 @@
 import { InstanceElement, ObjectType, MapType, isListType, isMapType, Change, toChange } from '@salto-io/adapter-api'
 import { FilterWith } from '../../src/filter'
 import filterCreator from '../../src/filters/convert_maps'
-import mockClient from '../client'
 import { generateProfileType, defaultFilterContext } from '../utils'
 
 type layoutAssignmentType = { layout: string; recordType?: string }
@@ -48,10 +47,8 @@ const generateProfileInstance = ({
 )
 
 describe('ProfileMaps filter', () => {
-  const { client } = mockClient()
-
   describe('on fetch', () => {
-    const filter = filterCreator({ client, config: { ...defaultFilterContext } }) as FilterWith<'onFetch' | 'preDeploy'>
+    const filter = filterCreator({ config: { ...defaultFilterContext } }) as FilterWith<'onFetch' | 'preDeploy'>
     let profileObj: ObjectType
     let instances: InstanceElement[]
 
@@ -211,7 +208,7 @@ describe('ProfileMaps filter', () => {
   })
 
   describe('deploy (pre + on)', () => {
-    const filter = filterCreator({ client, config: defaultFilterContext }) as FilterWith<'preDeploy' | 'onDeploy'>
+    const filter = filterCreator({ config: defaultFilterContext }) as FilterWith<'preDeploy' | 'onDeploy'>
     let beforeProfileObj: ObjectType
     let afterProfileObj: ObjectType
     let beforeInstances: InstanceElement[]

--- a/packages/salesforce-adapter/test/filters/convert_types.test.ts
+++ b/packages/salesforce-adapter/test/filters/convert_types.test.ts
@@ -22,12 +22,9 @@ import {
 import makeFilter from '../../src/filters/convert_types'
 import * as constants from '../../src/constants'
 import { FilterWith } from '../../src/filter'
-import mockClient from '../client'
 import { defaultFilterContext } from '../utils'
 
 describe('convert types filter', () => {
-  const { client } = mockClient()
-
   const mockObjId = new ElemID(constants.SALESFORCE, 'test')
   const mockType = new ObjectType({
     elemID: mockObjId,
@@ -111,7 +108,7 @@ describe('convert types filter', () => {
 
   let testElements: Element[]
 
-  const filter = makeFilter({ client, config: defaultFilterContext }) as FilterWith<'onFetch'>
+  const filter = makeFilter({ config: defaultFilterContext }) as FilterWith<'onFetch'>
 
   describe('on fetch', () => {
     describe('convert', () => {

--- a/packages/salesforce-adapter/test/filters/cpq/custom_script.test.ts
+++ b/packages/salesforce-adapter/test/filters/cpq/custom_script.test.ts
@@ -16,15 +16,12 @@
 import { ObjectType, ElemID, Element, InstanceElement, ListType, ChangeDataType, Change, toChange, getChangeData, isModificationChange, isAdditionChange, ModificationChange, isObjectTypeChange, AdditionChange, StaticFile, isFieldChange, Field, createRefToElmWithValue } from '@salto-io/adapter-api'
 import { FilterWith } from '../../../src/filter'
 import { fullApiName } from '../../../src/filters/utils'
-import SalesforceClient from '../../../src/client/client'
 import { SALESFORCE, CPQ_CUSTOM_SCRIPT, API_NAME, CPQ_CONSUMPTION_RATE_FIELDS, CPQ_GROUP_FIELDS, METADATA_TYPE, CUSTOM_OBJECT, CPQ_CODE_FIELD } from '../../../src/constants'
 import { Types } from '../../../src/transformers/transformer'
 import filterCreator from '../../../src/filters/cpq/custom_script'
-import mockClient from '../../client'
 import { defaultFilterContext } from '../../utils'
 
 describe('cpq custom script filter', () => {
-  let client: SalesforceClient
   type FilterType = FilterWith<'onFetch' | 'onDeploy' | 'preDeploy'>
   let filter: FilterType
   let elements: Element[]
@@ -94,8 +91,7 @@ describe('cpq custom script filter', () => {
   )
 
   beforeAll(async () => {
-    client = mockClient().client
-    filter = filterCreator({ client, config: defaultFilterContext }) as FilterType
+    filter = filterCreator({ config: defaultFilterContext }) as FilterType
   })
 
   describe('onFetch', () => {

--- a/packages/salesforce-adapter/test/filters/cpq/fields_with_context_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/cpq/fields_with_context_references.test.ts
@@ -15,15 +15,12 @@
 */
 import { ObjectType, ElemID, Element, InstanceElement, isObjectType, ReferenceExpression } from '@salto-io/adapter-api'
 import { FilterWith } from '../../../src/filter'
-import SalesforceClient from '../../../src/client/client'
 import { SALESFORCE, CPQ_PRODUCT_RULE, CPQ_LOOKUP_OBJECT_NAME, API_NAME, METADATA_TYPE, CUSTOM_OBJECT, CPQ_LOOKUP_QUERY, CPQ_LOOKUP_PRODUCT_FIELD, CPQ_LOOKUP_FIELD, CPQ_LOOKUP_MESSAGE_FIELD, API_NAME_SEPARATOR } from '../../../src/constants'
 import { Types } from '../../../src/transformers/transformer'
 import filterCreator from '../../../src/filters/field_references'
-import mockClient from '../../client'
 import { defaultFilterContext } from '../../utils'
 
 describe('fields with context references filter', () => {
-  let client: SalesforceClient
   type FilterType = FilterWith<'onFetch'>
   let filter: FilterType
   let elements: Element[]
@@ -140,8 +137,7 @@ describe('fields with context references filter', () => {
 
   describe('When all context objects exist in elements', () => {
     beforeAll(async () => {
-      client = mockClient().client
-      filter = filterCreator({ client, config: defaultFilterContext }) as FilterType
+      filter = filterCreator({ config: defaultFilterContext }) as FilterType
       elements = [
         ...getCloneOfAllObjects(),
         productRuleWithBadLookupObjInstance.clone(),

--- a/packages/salesforce-adapter/test/filters/cpq/hide_read_only_values.test.ts
+++ b/packages/salesforce-adapter/test/filters/cpq/hide_read_only_values.test.ts
@@ -18,15 +18,12 @@ import { ObjectType, ElemID, Element, CORE_ANNOTATIONS } from '@salto-io/adapter
 import { buildDataManagement } from '../../../src/fetch_profile/data_management'
 import { SaltoIDSettings, DataManagementConfig } from '../../../src/types'
 import { FilterWith } from '../../../src/filter'
-import SalesforceClient from '../../../src/client/client'
 import { SALESFORCE, API_NAME, METADATA_TYPE, CUSTOM_OBJECT, CPQ_TESTED_OBJECT, FIELD_ANNOTATIONS } from '../../../src/constants'
 import { Types } from '../../../src/transformers/transformer'
 import filterCreator from '../../../src/filters/cpq/hide_read_only_values'
-import mockClient from '../../client'
 import { defaultFilterContext } from '../../utils'
 
 describe('hide read only values filter', () => {
-  let client: SalesforceClient
   type FilterType = FilterWith<'onFetch' | 'onDeploy' | 'preDeploy'>
   let filter: FilterType
   let elements: Element[]
@@ -97,9 +94,8 @@ describe('hide read only values filter', () => {
       ]
     })
     it('Should do nothing for not custom object type', async () => {
-      client = mockClient().client
       const config = defaultFilterContext
-      filter = filterCreator({ client, config }) as FilterType
+      filter = filterCreator({ config }) as FilterType
       await filter.onFetch(elements)
       const notCustomObjAfterFilter = elements[1] as ObjectType
       expect(notCustomObjAfterFilter).toBeDefined()
@@ -114,9 +110,8 @@ describe('hide read only values filter', () => {
         .toBeUndefined()
     })
     it('Should add "_hidden_value = true" to read only fields on custom object when showReadOnlyValue flag is undefined', async () => {
-      client = mockClient().client
       const config = defaultFilterContext
-      filter = filterCreator({ client, config }) as FilterType
+      filter = filterCreator({ config }) as FilterType
       await filter.onFetch(elements)
       const customObjAfterFilter = elements[0] as ObjectType
       expect(customObjAfterFilter).toBeDefined()
@@ -130,7 +125,6 @@ describe('hide read only values filter', () => {
         .toBeUndefined()
     })
     it('Should add "_hidden_value = true" to read only fields on custom object when showReadOnlyValue flag = false', async () => {
-      client = mockClient().client
       const dataManagmentConfig = {
         includeObjects: ['*'],
         saltoIDSettings: {} as SaltoIDSettings,
@@ -144,7 +138,7 @@ describe('hide read only values filter', () => {
           dataManagement: buildDataManagement(dataManagmentConfig),
         },
       }
-      filter = filterCreator({ client, config }) as FilterType
+      filter = filterCreator({ config }) as FilterType
       await filter.onFetch(elements)
       const customObjAfterFilter = elements[0] as ObjectType
       expect(customObjAfterFilter).toBeDefined()
@@ -158,7 +152,6 @@ describe('hide read only values filter', () => {
         .toBeUndefined()
     })
     it('Should do nothing to read only fields on custom object when showReadOnlyValue flag = true', async () => {
-      client = mockClient().client
       const dataManagmentConfig = {
         includeObjects: ['*'],
         saltoIDSettings: {} as SaltoIDSettings,
@@ -172,7 +165,7 @@ describe('hide read only values filter', () => {
           dataManagement: buildDataManagement(dataManagmentConfig),
         },
       }
-      filter = filterCreator({ client, config }) as FilterType
+      filter = filterCreator({ config }) as FilterType
       await filter.onFetch(elements)
       const customObjAfterFilter = elements[0] as ObjectType
       expect(customObjAfterFilter).toBeDefined()

--- a/packages/salesforce-adapter/test/filters/cpq/lookup_fields.test.ts
+++ b/packages/salesforce-adapter/test/filters/cpq/lookup_fields.test.ts
@@ -15,15 +15,12 @@
 */
 import { ObjectType, ElemID, Element, ReferenceExpression, isObjectType, ChangeDataType, Change, toChange, AdditionChange, ModificationChange, getChangeData, Field } from '@salto-io/adapter-api'
 import { FilterWith } from '../../../src/filter'
-import SalesforceClient from '../../../src/client/client'
-import mockClient from '../../client'
 import filterCreator from '../../../src/filters/cpq/lookup_fields'
 import { SALESFORCE, CPQ_PRODUCT_RULE, CPQ_LOOKUP_OBJECT_NAME, API_NAME, METADATA_TYPE, CUSTOM_OBJECT, FIELD_ANNOTATIONS, CPQ_CONFIGURATION_ATTRIBUTE, CPQ_DEFAULT_OBJECT_FIELD, CPQ_QUOTE_NO_PRE, CPQ_QUOTE, CPQ_ACCOUNT, CPQ_PRICE_SCHEDULE, CPQ_CONSTRAINT_FIELD, CPQ_ACCOUNT_NO_PRE } from '../../../src/constants'
 import { Types } from '../../../src/transformers/transformer'
 import { defaultFilterContext } from '../../utils'
 
 describe('lookup_object filter', () => {
-  let client: SalesforceClient
   type FilterType = FilterWith<'onFetch' | 'onDeploy' | 'preDeploy'>
   let filter: FilterType
   let elements: Element[]
@@ -137,8 +134,7 @@ describe('lookup_object filter', () => {
 
   describe('onFetch', () => {
     beforeAll(async () => {
-      client = mockClient().client
-      filter = filterCreator({ client, config: defaultFilterContext }) as FilterType
+      filter = filterCreator({ config: defaultFilterContext }) as FilterType
       elements = [
         mockObject.clone(),
         mockProductRuleObject.clone(),

--- a/packages/salesforce-adapter/test/filters/custom_metadata.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_metadata.test.ts
@@ -19,7 +19,6 @@ import { mockTypes, mockInstances } from '../mock_elements'
 import { defaultFilterContext } from '../utils'
 import makeFilter, { ServiceMDTRecordValue, NaclMDTRecordValue } from '../../src/filters/custom_metadata'
 import { FilterWith } from '../../src/filter'
-import mockClient from '../client'
 import { MetadataInstanceElement, createInstanceElement, MetadataValues } from '../../src/transformers/transformer'
 import { XML_ATTRIBUTE_PREFIX } from '../../src/constants'
 
@@ -43,10 +42,7 @@ describe('CustomMetadata filter', () => {
   describe('onFetch', () => {
     let filter: FilterType
     beforeEach(() => {
-      filter = makeFilter({
-        client: mockClient().client,
-        config: defaultFilterContext,
-      }) as FilterType
+      filter = makeFilter({ config: defaultFilterContext }) as FilterType
     })
     describe('with no custom metadata records', () => {
       let elements: Element[]
@@ -111,10 +107,7 @@ describe('CustomMetadata filter', () => {
     beforeAll(() => {
       // Note - intentionally using the same filter and "beforeAll" to mimic real flow where
       // the same filter instance would be used in both preDeploy and onDeploy
-      filter = makeFilter({
-        client: mockClient().client,
-        config: defaultFilterContext,
-      }) as FilterType
+      filter = makeFilter({ config: defaultFilterContext }) as FilterType
     })
     describe('preDeploy', () => {
       let changeInstance: MetadataInstanceElement

--- a/packages/salesforce-adapter/test/filters/custom_object_split.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_object_split.test.ts
@@ -29,7 +29,6 @@ import {
   SALESFORCE,
   OBJECT_FIELDS_PATH,
 } from '../../src/constants'
-import mockClient from '../client'
 import { defaultFilterContext, createCustomObjectType } from '../utils'
 
 type FilterType = FilterWith<'onFetch'>
@@ -42,7 +41,6 @@ const getElementPaths = (elements: Element[]): string[] => elements
 describe('Custom Object Split filter', () => {
   describe('when using default file split', () => {
     const filter = (): FilterType => filterCreator({
-      client: mockClient().client,
       config: defaultFilterContext,
     }) as FilterType
 
@@ -261,7 +259,6 @@ describe('Custom Object Split filter', () => {
   })
   describe('when using per field file split', () => {
     const filter = (separateFieldToFiles: string[]): FilterType => filterCreator({
-      client: mockClient().client,
       config: { ...defaultFilterContext, separateFieldToFiles },
     }) as FilterType
 

--- a/packages/salesforce-adapter/test/filters/field_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/field_references.test.ts
@@ -20,7 +20,6 @@ import { collections } from '@salto-io/lowerdash'
 import { FilterWith } from '../../src/filter'
 import filterCreator, { addReferences } from '../../src/filters/field_references'
 import { fieldNameToTypeMappingDefs } from '../../src/transformers/reference_mapping'
-import mockClient from '../client'
 import { OBJECTS_PATH, SALESFORCE, CUSTOM_OBJECT, METADATA_TYPE, INSTANCE_FULL_NAME_FIELD, CUSTOM_OBJECT_ID_FIELD, API_NAME, API_NAME_SEPARATOR, WORKFLOW_ACTION_REFERENCE_METADATA_TYPE, WORKFLOW_RULE_METADATA_TYPE, CPQ_QUOTE_LINE_FIELDS, CPQ_CUSTOM_SCRIPT, CPQ_CONFIGURATION_ATTRIBUTE, CPQ_DEFAULT_OBJECT_FIELD, CPQ_LOOKUP_QUERY, CPQ_TESTED_OBJECT, CPQ_DISCOUNT_SCHEDULE, CPQ_CONSTRAINT_FIELD } from '../../src/constants'
 import { metadataType, apiName } from '../../src/transformers/transformer'
 import { CUSTOM_OBJECT_TYPE_ID } from '../../src/filters/custom_objects'
@@ -113,9 +112,7 @@ const generateObjectAndInstance = ({
 }
 
 describe('FieldReferences filter', () => {
-  const { client } = mockClient()
-
-  const filter = filterCreator({ client, config: defaultFilterContext }) as FilterWith<'onFetch'>
+  const filter = filterCreator({ config: defaultFilterContext }) as FilterWith<'onFetch'>
 
   const generateElements = (
   ): Element[] => ([
@@ -387,9 +384,7 @@ describe('FieldReferences filter', () => {
 })
 
 describe('FieldReferences filter - neighbor context strategy', () => {
-  const { client } = mockClient()
-
-  const filter = filterCreator({ client, config: defaultFilterContext }) as FilterWith<'onFetch'>
+  const filter = filterCreator({ config: defaultFilterContext }) as FilterWith<'onFetch'>
 
   const parentName = 'User'
   type WorkflowActionReference = {

--- a/packages/salesforce-adapter/test/filters/filters.test.ts
+++ b/packages/salesforce-adapter/test/filters/filters.test.ts
@@ -16,7 +16,7 @@
 import { toChange, Change, FetchOptions } from '@salto-io/adapter-api'
 import { mockFunction, MockInterface } from '@salto-io/test-utils'
 import SalesforceAdapter from '../../src/adapter'
-import { FilterWith, FilterCreator } from '../../src/filter'
+import { FilterWith, LocalFilterCreator } from '../../src/filter'
 import mockAdapter from '../adapter'
 import { mockDeployResult, mockDeployMessage } from '../connection'
 import { apiName, createInstanceElement, metadataType } from '../../src/transformers/transformer'
@@ -26,7 +26,7 @@ describe('SalesforceAdapter filters', () => {
   describe('when filter methods are implemented', () => {
     let adapter: SalesforceAdapter
     let filter: MockInterface<FilterWith<'onFetch' | 'onDeploy' | 'deploy' | 'preDeploy' | 'onPostFetch'>>
-    let filterCreator: jest.MockedFunction<FilterCreator>
+    let filterCreator: jest.MockedFunction<LocalFilterCreator>
     let connection: ReturnType<typeof mockAdapter>['connection']
     const mockFetchOpts: MockInterface<FetchOptions> = {
       progressReporter: { reportProgress: jest.fn() },
@@ -41,7 +41,7 @@ describe('SalesforceAdapter filters', () => {
         onPostFetch: mockFunction<(typeof filter)['onPostFetch']>().mockResolvedValue(),
       }
 
-      filterCreator = mockFunction<FilterCreator>().mockReturnValue(filter)
+      filterCreator = mockFunction<LocalFilterCreator>().mockReturnValue(filter)
       const mocks = mockAdapter({ adapterParams: { filterCreators: [filterCreator] } })
       adapter = mocks.adapter
       connection = mocks.connection

--- a/packages/salesforce-adapter/test/filters/foreign_key_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/foreign_key_references.test.ts
@@ -19,15 +19,12 @@ import { FilterWith } from '../../src/filter'
 import { INSTANCE_FULL_NAME_FIELD, SALESFORCE, FOREIGN_KEY_DOMAIN } from '../../src/constants'
 import referenceAnnotationfilterCreator from '../../src/filters/reference_annotations'
 import filterCreator from '../../src/filters/foreign_key_references'
-import mockClient from '../client'
 import { defaultFilterContext, createMetadataTypeElement } from '../utils'
 
 // Based on the instance_reference test scenarios
 describe('foregin_key_references filter', () => {
-  const { client } = mockClient()
-
-  const refAnnotationFilter = referenceAnnotationfilterCreator({ client, config: defaultFilterContext }) as FilterWith<'onFetch'>
-  const filter = filterCreator({ client, config: defaultFilterContext }) as FilterWith<'onFetch'>
+  const refAnnotationFilter = referenceAnnotationfilterCreator({ config: defaultFilterContext }) as FilterWith<'onFetch'>
+  const filter = filterCreator({ config: defaultFilterContext }) as FilterWith<'onFetch'>
 
   const parentObjFullName = 'parentFullName'
   const parentObjFieldName = 'parentObj'

--- a/packages/salesforce-adapter/test/filters/global_value_sets.test.ts
+++ b/packages/salesforce-adapter/test/filters/global_value_sets.test.ts
@@ -19,7 +19,6 @@ import { FilterWith } from '../../src/filter'
 import filterCreator,
 { GLOBAL_VALUE_SET, CUSTOM_VALUE, MASTER_LABEL } from '../../src/filters/global_value_sets'
 import { Types } from '../../src/transformers/transformer'
-import mockClient from '../client'
 import { defaultFilterContext } from '../utils'
 
 const createGlobalValueSetInstanceElement = (name: string, values: string[]): InstanceElement =>
@@ -73,10 +72,7 @@ const createPicklistObjectType = (
 })
 
 describe('Global Value Sets filter', () => {
-  const filter = filterCreator({
-    client: mockClient().client,
-    config: defaultFilterContext,
-  }) as FilterWith<'onFetch'>
+  const filter = filterCreator({ config: defaultFilterContext }) as FilterWith<'onFetch'>
   const mockElemID = new ElemID(constants.SALESFORCE, 'test')
   let elements: Element[] = []
 

--- a/packages/salesforce-adapter/test/filters/layouts.test.ts
+++ b/packages/salesforce-adapter/test/filters/layouts.test.ts
@@ -20,7 +20,6 @@ import { createCustomObjectType, createMetadataTypeElement, defaultFilterContext
 import makeFilter, { LAYOUT_TYPE_ID } from '../../src/filters/layouts'
 import * as constants from '../../src/constants'
 import { FilterWith } from '../../src/filter'
-import mockClient from '../client'
 import { getObjectDirectoryPath } from '../../src/filters/custom_objects'
 
 describe('Test layout filter', () => {
@@ -81,8 +80,7 @@ describe('Test layout filter', () => {
         testSObj, testLayout, webLinkObj, webLinkInst,
       ]
 
-      const { client } = mockClient()
-      const filter = makeFilter({ client, config: defaultFilterContext }) as FilterWith<'onFetch'>
+      const filter = makeFilter({ config: defaultFilterContext }) as FilterWith<'onFetch'>
       await filter.onFetch(elements)
 
       const instance = elements[1] as InstanceElement

--- a/packages/salesforce-adapter/test/filters/profile_instance_split.test.ts
+++ b/packages/salesforce-adapter/test/filters/profile_instance_split.test.ts
@@ -18,14 +18,11 @@ import { ObjectType, Element, InstanceElement, isInstanceElement } from '@salto-
 import filterCreator from '../../src/filters/profile_instance_split'
 import { FilterWith } from '../../src/filter'
 import { generateProfileType, defaultFilterContext } from '../utils'
-import mockClient from '../client'
 
 
 describe('Profile Instance Split filter', () => {
-  const { client } = mockClient()
-
   describe('Map profile instances', () => {
-    const filter = filterCreator({ client, config: defaultFilterContext }) as FilterWith<'onFetch'>
+    const filter = filterCreator({ config: defaultFilterContext }) as FilterWith<'onFetch'>
 
     let profileObj: ObjectType
     let profileInstances: InstanceElement[]

--- a/packages/salesforce-adapter/test/filters/profile_permissions.test.ts
+++ b/packages/salesforce-adapter/test/filters/profile_permissions.test.ts
@@ -18,14 +18,11 @@ import filterCreator from '../../src/filters/profile_permissions'
 import * as constants from '../../src/constants'
 import { FilterWith } from '../../src/filter'
 import { ProfileInfo } from '../../src/client/types'
-import mockClient from '../client'
 import { Types, createInstanceElement, metadataType, apiName } from '../../src/transformers/transformer'
 import { mockTypes } from '../mock_elements'
 import { defaultFilterContext } from '../utils'
 
 describe('Object Permissions filter', () => {
-  const { client } = mockClient()
-
   const createField = (
     parent: string,
     name: string,
@@ -62,7 +59,7 @@ describe('Object Permissions filter', () => {
   describe('with new object, new fields and no permission change', () => {
     let changes: Change[]
     beforeAll(() => {
-      filter = filterCreator({ client, config: defaultFilterContext }) as typeof filter
+      filter = filterCreator({ config: defaultFilterContext }) as typeof filter
     })
     describe('preDeploy', () => {
       beforeAll(async () => {
@@ -153,7 +150,7 @@ describe('Object Permissions filter', () => {
       field: 'Test2__c.desc__c', readable: true, editable: false,
     }
     beforeAll(() => {
-      filter = filterCreator({ client, config: defaultFilterContext }) as typeof filter
+      filter = filterCreator({ config: defaultFilterContext }) as typeof filter
     })
     describe('preDeploy', () => {
       beforeAll(async () => {

--- a/packages/salesforce-adapter/test/filters/reference_annotations.test.ts
+++ b/packages/salesforce-adapter/test/filters/reference_annotations.test.ts
@@ -16,7 +16,6 @@
 import { ObjectType, ElemID, BuiltinTypes, ReferenceExpression } from '@salto-io/adapter-api'
 import { SALESFORCE, FIELD_ANNOTATIONS, FOREIGN_KEY_DOMAIN } from '../../src/constants'
 import { FilterWith } from '../../src/filter'
-import mockClient from '../client'
 import filterCreator from '../../src/filters/reference_annotations'
 import { defaultFilterContext, createMetadataTypeElement } from '../utils'
 
@@ -25,8 +24,7 @@ describe('reference_annotations filter', () => {
   const parentObjFieldName = 'parentObj'
   const objTypeName = 'obj'
 
-  const { client } = mockClient()
-  const filter = filterCreator({ client, config: defaultFilterContext }) as FilterWith<'onFetch'>
+  const filter = filterCreator({ config: defaultFilterContext }) as FilterWith<'onFetch'>
 
   let nestedType: ObjectType
   let objType: ObjectType

--- a/packages/salesforce-adapter/test/filters/remove_fields_and_values.test.ts
+++ b/packages/salesforce-adapter/test/filters/remove_fields_and_values.test.ts
@@ -17,7 +17,6 @@ import { ObjectType, ElemID, BuiltinTypes, Element, InstanceElement } from '@sal
 import { makeFilter } from '../../src/filters/remove_fields_and_values'
 import * as constants from '../../src/constants'
 import { FilterWith } from '../../src/filter'
-import mockClient from '../client'
 import { defaultFilterContext } from '../utils'
 
 describe('remove fields filter', () => {
@@ -71,14 +70,13 @@ describe('remove fields filter', () => {
     }
   )
 
-  const { client } = mockClient()
   const filter = makeFilter(
     new Map([
       ['typeRemoval', ['remove']],
       ['typeWithInstance', ['removeAlsoFromInstance', 'removeAlsoFromInstance2']],
       ['nested', ['remove']],
     ]),
-  )({ client, config: defaultFilterContext }) as FilterWith<'onFetch'>
+  )({ config: defaultFilterContext }) as FilterWith<'onFetch'>
 
   let testElements: Element[]
 

--- a/packages/salesforce-adapter/test/filters/remove_restriction_annotations.test.ts
+++ b/packages/salesforce-adapter/test/filters/remove_restriction_annotations.test.ts
@@ -17,7 +17,6 @@ import { ObjectType, ElemID, BuiltinTypes, Element, CORE_ANNOTATIONS } from '@sa
 import { makeFilter } from '../../src/filters/remove_restriction_annotations'
 import * as constants from '../../src/constants'
 import { FilterWith } from '../../src/filter'
-import mockClient from '../client'
 import { defaultFilterContext } from '../utils'
 
 describe('remove restriction annotations filter', () => {
@@ -63,10 +62,9 @@ describe('remove restriction annotations filter', () => {
     },
   })
 
-  const { client } = mockClient()
   const filter = makeFilter({
     AnimationRule: ['sobjectType', 'targetField'],
-  })({ client, config: defaultFilterContext }) as FilterWith<'onFetch'>
+  })({ config: defaultFilterContext }) as FilterWith<'onFetch'>
 
   let testElements: Element[]
 

--- a/packages/salesforce-adapter/test/filters/replace_instance_field_values.test.ts
+++ b/packages/salesforce-adapter/test/filters/replace_instance_field_values.test.ts
@@ -17,9 +17,7 @@ import { Element, ElemID, ObjectType, InstanceElement, isInstanceElement, Change
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { FilterWith } from '../../src/filter'
-import SalesforceClient from '../../src/client/client'
 import filterCreator from '../../src/filters/replace_instance_field_values'
-import createClient from '../client'
 import {
   SALESFORCE, METADATA_TYPE, INSTANCE_FULL_NAME_FIELD,
   CUSTOM_OBJECT, INTERNAL_ID_FIELD, CUSTOM_FIELD, API_NAME,
@@ -129,7 +127,6 @@ const types: Record<string, ObjectType> = {
 }
 
 describe('replace instance field values filter', () => {
-  let client: SalesforceClient
   let elements: Element[]
   let orjNumElements: number
   let nonForecastingInstance: Element
@@ -251,8 +248,6 @@ describe('replace instance field values filter', () => {
   }
 
   beforeAll(() => {
-    ({ client } = createClient())
-
     forecastingElementWithIDs = createForecastingElement(true)
     forecastingElementWithNames = createForecastingElement(false)
   })
@@ -267,7 +262,7 @@ describe('replace instance field values filter', () => {
       nonForecastingInstance = elements[elements.length - 1]
       orjNumElements = elements.length
       beforeNonForecastingInstance = nonForecastingInstance.clone()
-      filter = filterCreator({ client, config: defaultFilterContext }) as FilterType
+      filter = filterCreator({ config: defaultFilterContext }) as FilterType
       await filter.onFetch(elements)
 
       namesAfterFilter = []
@@ -309,7 +304,6 @@ describe('replace instance field values filter', () => {
 
     beforeAll(() => {
       filter = filterCreator({
-        client,
         config: {
           ...defaultFilterContext,
           elementsSource: buildElementsSourceFromElements(elements),
@@ -409,7 +403,6 @@ describe('replace instance field values filter', () => {
 
       beforeAll(() => {
         filter = filterCreator({
-          client,
           config: {
             ...defaultFilterContext,
             elementsSource: buildElementsSourceFromElements(elements),

--- a/packages/salesforce-adapter/test/filters/split_custom_labels.test.ts
+++ b/packages/salesforce-adapter/test/filters/split_custom_labels.test.ts
@@ -23,7 +23,6 @@ import {
   ObjectType,
 } from '@salto-io/adapter-api'
 import filterCreator, { CUSTOM_LABEL_INSTANCES_FILE_PATH } from '../../src/filters/split_custom_labels'
-import mockClient from '../client'
 import { defaultFilterContext } from '../utils'
 import { FilterWith } from '../../src/filter'
 import {
@@ -57,7 +56,6 @@ describe('Test split custom labels filter', () => {
 
     let customLabelsInstance: InstanceElement
     const filter = (): FilterWith<'onFetch'> => filterCreator({
-      client: mockClient().client,
       config: defaultFilterContext,
     }) as FilterWith<'onFetch'>
 
@@ -185,10 +183,7 @@ describe('Test split custom labels filter', () => {
           ),
         },
       }
-      filter = filterCreator({
-        client: mockClient().client,
-        config: defaultFilterContext,
-      }) as FilterWith<'preDeploy' | 'onDeploy'>
+      filter = filterCreator({ config: defaultFilterContext }) as typeof filter
     })
     describe('preDeploy', () => {
       it('should prepare CustomLabels change', async () => {

--- a/packages/salesforce-adapter/test/filters/territory.test.ts
+++ b/packages/salesforce-adapter/test/filters/territory.test.ts
@@ -16,7 +16,6 @@
 import { ObjectType, ElemID, BuiltinTypes, InstanceElement, toChange, Change, createRefToElmWithValue } from '@salto-io/adapter-api'
 import { FilterWith } from '../../src/filter'
 import filterCreator from '../../src/filters/territory'
-import mockClient from '../client'
 import { createMetadataTypeElement, defaultFilterContext } from '../utils'
 import { createInstanceElement, MetadataInstanceElement } from '../../src/transformers/transformer'
 import { CONTENT_FILENAME_OVERRIDE } from '../../src/transformers/xml_transformer'
@@ -25,10 +24,7 @@ import { SALESFORCE, TERRITORY2_TYPE, TERRITORY2_MODEL_TYPE, CUSTOM_OBJECT } fro
 describe('territory filter', () => {
   let filter: FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
   beforeEach(() => {
-    filter = filterCreator({
-      client: mockClient().client,
-      config: defaultFilterContext,
-    }) as typeof filter
+    filter = filterCreator({ config: defaultFilterContext }) as typeof filter
   })
   describe('onFetch', () => {
     let type: ObjectType

--- a/packages/salesforce-adapter/test/filters/topics_for_objects.test.ts
+++ b/packages/salesforce-adapter/test/filters/topics_for_objects.test.ts
@@ -18,7 +18,6 @@ import { collections } from '@salto-io/lowerdash'
 import { metadataType, apiName, MetadataTypeAnnotations } from '../../src/transformers/transformer'
 import * as constants from '../../src/constants'
 import { FilterWith } from '../../src/filter'
-import mockClient from '../client'
 import filterCreator from '../../src/filters/topics_for_objects'
 import { defaultFilterContext } from '../utils'
 
@@ -29,7 +28,6 @@ const { TOPICS_FOR_OBJECTS_ANNOTATION, TOPICS_FOR_OBJECTS_FIELDS,
 const { ENABLE_TOPICS, ENTITY_API_NAME } = TOPICS_FOR_OBJECTS_FIELDS
 
 describe('Topics for objects filter', () => {
-  const { client } = mockClient()
   const mockTopicElemID = new ElemID(constants.SALESFORCE, constants.TOPICS_FOR_OBJECTS_ANNOTATION)
   const mockObject = (name: string, withTopics?: boolean): ObjectType => new ObjectType({
     elemID: new ElemID(constants.SALESFORCE, name),
@@ -69,7 +67,7 @@ describe('Topics for objects filter', () => {
 
   describe('onFetch', () => {
     beforeAll(() => {
-      filter = filterCreator({ client, config: defaultFilterContext }) as typeof filter
+      filter = filterCreator({ config: defaultFilterContext }) as typeof filter
     })
     it('should add topicsForObjects to object types and remove topics type & instances', async () => {
       const elements = [mockObject('Test__c'), mockTopicForObject, mockTopic]
@@ -90,7 +88,7 @@ describe('Topics for objects filter', () => {
   describe('preDeploy and onDeploy', () => {
     let changes: Change[]
     beforeAll(() => {
-      filter = filterCreator({ client, config: defaultFilterContext }) as typeof filter
+      filter = filterCreator({ config: defaultFilterContext }) as typeof filter
     })
     describe('preDeploy', () => {
       beforeAll(async () => {

--- a/packages/salesforce-adapter/test/filters/value_to_static_file.test.ts
+++ b/packages/salesforce-adapter/test/filters/value_to_static_file.test.ts
@@ -15,9 +15,7 @@
 */
 import { Element, ElemID, ObjectType, InstanceElement, isInstanceElement, BuiltinTypes, StaticFile, FieldDefinition } from '@salto-io/adapter-api'
 import { FilterWith } from '../../src/filter'
-import SalesforceClient from '../../src/client/client'
 import filterCreator from '../../src/filters/value_to_static_file'
-import mockClient from '../client'
 import { SALESFORCE, WEBLINK_METADATA_TYPE, METADATA_TYPE } from '../../src/constants'
 import { defaultFilterContext } from '../utils'
 
@@ -27,7 +25,6 @@ const URL = 'url'
 const NOT_URL = 'notUrlField'
 
 describe('value to static file filter', () => {
-  let client: SalesforceClient
   let elements: Element[]
   let regularUrl: string
   let codeAsString: string
@@ -36,8 +33,6 @@ describe('value to static file filter', () => {
   let fields: Record<string, FieldDefinition>
 
   beforeAll(() => {
-    client = mockClient().client
-
     anotherFieldContent = 'anotherFieldContent'
     regularUrl = 'www.myAwesomeWebsite.com'
     codeAsString = 'console.log()'
@@ -104,7 +99,7 @@ describe('value to static file filter', () => {
       let filter: FilterType
 
       beforeAll(() => {
-        filter = filterCreator({ client, config: defaultFilterContext }) as FilterType
+        filter = filterCreator({ config: defaultFilterContext }) as FilterType
       })
 
       describe('extract code to static file', () => {

--- a/packages/salesforce-adapter/test/filters/workflow.test.ts
+++ b/packages/salesforce-adapter/test/filters/workflow.test.ts
@@ -25,7 +25,6 @@ import filterCreator, {
   WORKFLOW_ALERTS_FIELD, WORKFLOW_FIELD_UPDATES_FIELD, WORKFLOW_RULES_FIELD,
   WORKFLOW_TASKS_FIELD, WORKFLOW_FIELD_TO_TYPE,
 } from '../../src/filters/workflow'
-import mockClient from '../client'
 import {
   INSTANCE_FULL_NAME_FIELD, RECORDS_PATH, SALESFORCE, WORKFLOW_METADATA_TYPE,
 } from '../../src/constants'
@@ -37,8 +36,7 @@ import { defaultFilterContext } from '../utils'
 const { awu, groupByAsync } = collections.asynciterable
 
 describe('Workflow filter', () => {
-  const { client } = mockClient()
-  const filter = filterCreator({ client, config: defaultFilterContext }) as FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
+  const filter = filterCreator({ config: defaultFilterContext }) as FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
   const dummyElemID = new ElemID(SALESFORCE, 'dummy')
   const dummyObj = new ObjectType({ elemID: dummyElemID })
   const dummyRefToObj = createRefToElmWithValue(dummyObj)
@@ -183,7 +181,7 @@ describe('Workflow filter', () => {
           { action: 'add', data: { after: innerInstance } },
         ]
         // Re-create the filter because it is stateful
-        testFilter = filterCreator({ client, config: defaultFilterContext }) as typeof filter
+        testFilter = filterCreator({ config: defaultFilterContext }) as typeof filter
       })
 
       describe('preDeploy', () => {
@@ -243,7 +241,7 @@ describe('Workflow filter', () => {
         changes = await Promise.all(_.times(5).map(createInnerChange))
 
         // Re-create the filter because it is stateful
-        testFilter = filterCreator({ client, config: defaultFilterContext }) as typeof filter
+        testFilter = filterCreator({ config: defaultFilterContext }) as typeof filter
       })
       describe('preDeploy', () => {
         beforeAll(async () => {


### PR DESCRIPTION
As a first step towards being able to load SFDX XMLs to Salto elements
we need to be able to run only filters that do not require a client.

Starting by separating the existing filters to ones that use a client
and ones that do not

---


---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_