### PR TITLE
SALTO-2405: Improve CLI error message 

### DIFF
--- a/packages/cli/src/commands/common/accounts.ts
+++ b/packages/cli/src/commands/common/accounts.ts
@@ -64,7 +64,7 @@ export const getAndValidateActiveAccounts = (
     const diffAccounts = _.difference(inputAccounts, validAccounts)
     if (diffAccounts.length > 0) {
       const accountsErrorMessage = diffAccounts.length === 1 ? 'an account' : 'accounts'
-      throw new Error(`Environment ${workspace.currentEnv()} does not have ${accountsErrorMessage} named ${diffAccounts}`)
+      throw new Error(`Environment ${workspace.currentEnv()} does not have ${accountsErrorMessage} named ${diffAccounts.join(', ')}`)
     }
   }
 

--- a/packages/cli/src/commands/common/accounts.ts
+++ b/packages/cli/src/commands/common/accounts.ts
@@ -63,7 +63,8 @@ export const getAndValidateActiveAccounts = (
   if (inputAccounts) {
     const diffAccounts = _.difference(inputAccounts, validAccounts)
     if (diffAccounts.length > 0) {
-      throw new Error(`Not all accounts (${diffAccounts.length}) are set up for this workspace`)
+      const accountsErrorMessage = diffAccounts.length === 1 ? 'an account' : 'accounts'
+      throw new Error(`Environment ${workspace.currentEnv()} does not have ${accountsErrorMessage} named ${diffAccounts}`)
     }
   }
 

--- a/packages/cli/test/commands/commons.test.ts
+++ b/packages/cli/test/commands/commons.test.ts
@@ -35,6 +35,10 @@ describe('Commands commons tests', () => {
     it('Should throw an error if the account does not exist in the workspace', () => {
       expect(() => getAndValidateActiveAccounts(mockWorkspace, ['wtfService'])).toThrow()
     })
+
+    it('Should throw an error if the accounts does not exist in the workspace', () => {
+      expect(() => getAndValidateActiveAccounts(mockWorkspace, ['wtfService1', 'wtfService2'])).toThrow()
+    })
   })
   describe('getAndValidateActiveAccounts with workspace with no accounts', () => {
     const mockWorkspace = mocks.mockWorkspace({ accounts: [] })

--- a/packages/cli/test/commands/commons.test.ts
+++ b/packages/cli/test/commands/commons.test.ts
@@ -33,11 +33,11 @@ describe('Commands commons tests', () => {
     })
 
     it('Should throw an error if the account does not exist in the workspace', () => {
-      expect(() => getAndValidateActiveAccounts(mockWorkspace, ['wtfService'])).toThrow()
+      expect(() => getAndValidateActiveAccounts(mockWorkspace, ['wtfService'])).toThrow(`Environment ${mockWorkspace.currentEnv()} does not have an account named wtfService`)
     })
 
     it('Should throw an error if the accounts does not exist in the workspace', () => {
-      expect(() => getAndValidateActiveAccounts(mockWorkspace, ['wtfService1', 'wtfService2'])).toThrow()
+      expect(() => getAndValidateActiveAccounts(mockWorkspace, ['wtfService1', 'wtfService2'])).toThrow(`Environment ${mockWorkspace.currentEnv()} does not have accounts named wtfService1, wtfService2`)
     })
   })
   describe('getAndValidateActiveAccounts with workspace with no accounts', () => {


### PR DESCRIPTION
_Improve CLI error message_

---
_Additional context for reviewer_:
None

---
_Release Notes_: 
CLI:

* Improve CLI error message when specifying a non existing account name in deploy / fetch commands
---

_User Notifications_: 
None