### PR TITLE
SALTO-2396: Remove "account" instances from NS default fetch config

### DIFF
--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -178,6 +178,7 @@ export const fetchDefault: FetchParams = {
       { name: 'solution' },
       { name: 'giftCertificateItem' }, // requires special features enabled in the account. O.W fetch will fail
       { name: 'downloadItem' }, // requires special features enabled in the account. O.W fetch will fail
+      { name: 'account' },
       {
         name: Object.keys(ITEM_TYPE_TO_SEARCH_STRING)
           .filter(itemTypeName => !['giftCertificateItem', 'downloadItem'].includes(itemTypeName))


### PR DESCRIPTION
_Remove "account" instances from NS default fetch config_

---

_Additional context for reviewer_
None

---
_Release Notes_: 
_Netsuite Adapter_
* "account" instances are not fetched by default

---
_User Notifications_: 
None
