### PR TITLE
SALTO-2507: fix element adapter rename to work on container fields

### DIFF
--- a/packages/workspace/test/workspace/element_adapter_rename.test.ts
+++ b/packages/workspace/test/workspace/element_adapter_rename.test.ts
@@ -55,6 +55,7 @@ describe('rename adapter in elements', () => {
       listOfListField: { refType: new ListType(new ListType(innerType)) },
       mapField: { refType: new MapType(innerType) },
       mapOfMapField: { refType: new MapType(new MapType(innerType)) },
+      nonResolvedMapField: { refType: new MapType(new TypeReference(innerType.elemID)) },
     },
   })
   const staticFileToChange = new StaticFile({
@@ -98,6 +99,7 @@ describe('rename adapter in elements', () => {
       listOfListField: { refType: new ListType(new ListType(changedInnerType)) },
       mapField: { refType: new MapType(changedInnerType) },
       mapOfMapField: { refType: new MapType(new MapType(changedInnerType)) },
+      nonResolvedMapField: { refType: new MapType(new TypeReference(changedInnerType.elemID)) },
     },
   })
   const changedStaticFile = new StaticFile({


### PR DESCRIPTION
_fix element adapter rename to work on container fields_

---

_Additional context for reviewer_
It was found out during the zendesk migration that if a container field ref type was not resolved, we wouldn't fix its adapter name. This PR fix this behavior

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
