### PR TITLE
SALTO-2510: add safeties to the order instances deploy filters and change validators

### DIFF
--- a/packages/zendesk-adapter/src/change_validators/order.ts
+++ b/packages/zendesk-adapter/src/change_validators/order.ts
@@ -93,8 +93,8 @@ export const orderInstanceContainsAllTheInstancesValidator: ChangeValidator = as
       const [
         orderListOfInstanceActivity, orderListOfTheOtherInstanceActivity,
       ] = instanceActivityValue
-        ? [orderInstance.value.active, orderInstance.value.inactive]
-        : [orderInstance.value.inactive, orderInstance.value.active]
+        ? [orderInstance.value.active ?? [], orderInstance.value.inactive ?? []]
+        : [orderInstance.value.inactive ?? [], orderInstance.value.active ?? []]
       if (!isInstanceInOrderList(orderListOfInstanceActivity, instance)) {
         return [{
           elemID: instance.elemID,

--- a/packages/zendesk-adapter/src/change_validators/trigger_order.ts
+++ b/packages/zendesk-adapter/src/change_validators/trigger_order.ts
@@ -72,11 +72,11 @@ export const triggerOrderInstanceContainsAllTheInstancesValidator: ChangeValidat
         }
       }
       const instanceActivityValue = instance.value.active
-      const orderEntry = orderInstance.value.order.find((entry: Values) =>
+      const orderEntry = (orderInstance.value.order ?? []).find((entry: Values) =>
         (isReferenceExpression(entry.category) && entry.category.elemID.isEqual(categoryId.elemID)))
       if (
         orderEntry === undefined
-        || (instanceActivityValue ? orderEntry.active : orderEntry.inactive)
+        || ((instanceActivityValue ? orderEntry.active : orderEntry.inactive) ?? [])
           .filter(isReferenceExpression)
           .find((ref: ReferenceExpression) => ref.elemID.isEqual(instance.elemID)) === undefined
       ) {
@@ -87,7 +87,7 @@ export const triggerOrderInstanceContainsAllTheInstancesValidator: ChangeValidat
           detailedMessage: `Instance ${instance.elemID.name} of type ${instance.elemID.typeName} not listed in ${instance.elemID.typeName} sort order under the ${categoryId.elemID.name} category, and will be added at the end by default. If order is important, please include it under the ${categoryId.elemID.name} category in the ${instanceActivityValue ? 'active' : 'inactive'} list`,
         }]
       }
-      if ((instanceActivityValue ? orderEntry.inactive : orderEntry.active)
+      if (((instanceActivityValue ? orderEntry.inactive : orderEntry.active) ?? [])
         .filter(isReferenceExpression)
         .find((ref: ReferenceExpression) => ref.elemID.isEqual(instance.elemID))) {
         return [createWrongPlaceErrorMessage(
@@ -104,7 +104,7 @@ export const triggerOrderInstanceContainsAllTheInstancesValidator: ChangeValidat
         ))
         .flatMap((entry: Values) => {
           if (
-            entry.active.concat(entry.inactive)
+            (entry.active ?? []).concat(entry.inactive ?? [])
               .filter(isReferenceExpression)
               .find((ref: ReferenceExpression) =>
                 ref.elemID.isEqual(instance.elemID))

--- a/packages/zendesk-adapter/src/filters/reorder/creator.ts
+++ b/packages/zendesk-adapter/src/filters/reorder/creator.ts
@@ -112,7 +112,8 @@ export const createReorderFilterCreator = (
       .map(getChangeData)
       .filter(instance => instance.elemID.typeName === createOrderTypeName(typeName))
       .forEach(instance => {
-        instance.value[orderFieldName] = instance.value.active.concat(instance.value.inactive)
+        instance.value[orderFieldName] = (instance.value.active ?? [])
+          .concat(instance.value.inactive ?? [])
       })
   },
   onDeploy: async changes => {

--- a/packages/zendesk-adapter/src/filters/reorder/trigger.ts
+++ b/packages/zendesk-adapter/src/filters/reorder/trigger.ts
@@ -66,7 +66,7 @@ const deployFunc: DeployFuncType = async (change, client, apiDefinitions) => {
     // We send position + 1, since the position in the service are starting from 1
     .map((id, position) => ({ id, position: position + 1 }))
   const triggers = order
-    .flatMap(entry => entry.active.concat(entry.inactive).map((id, position) => ({
+    .flatMap(entry => (entry.active ?? []).concat(entry.inactive ?? []).map((id, position) => ({
       id: id.toString(),
       // We send position + 1, since the position in the service are starting from 1
       position: position + 1,

--- a/packages/zendesk-adapter/test/change_validators/trigger_order.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/trigger_order.test.ts
@@ -276,4 +276,29 @@ describe('triggerOrderInstanceContainsAllTheInstancesValidator', () => {
       detailedMessage: `Invalid category id '${invalidTrigger.value.category_id}' for instance ${invalidTrigger.elemID.name} of type ${invalidTrigger.elemID.typeName}`,
     }])
   })
+  it('should not return an error if active field is missing and the change should not result error', async () => {
+    const orderInstanceWithNoTriggers = new InstanceElement(
+      ElemID.CONFIG_NAME,
+      triggerOrderType,
+      {
+        order: [
+          {
+            category: new ReferenceExpression(category1.elemID, category1),
+            inactive: [
+              new ReferenceExpression(trigger3.elemID, trigger3),
+            ],
+          },
+        ],
+      },
+    )
+    const elementsSource = buildElementsSourceFromElements([
+      triggerType, triggerOrderType, triggerCategoryType, orderInstanceWithNoTriggers, trigger3,
+    ].map(e => e.clone()))
+    const elementsToAdd = [trigger3.clone()]
+    const errors = await triggerOrderInstanceContainsAllTheInstancesValidator(
+      elementsToAdd.map(e => toChange({ after: e })),
+      elementsSource,
+    )
+    expect(errors).toEqual([])
+  })
 })

--- a/packages/zendesk-adapter/test/filters/reorder/trigger.test.ts
+++ b/packages/zendesk-adapter/test/filters/reorder/trigger.test.ts
@@ -153,7 +153,7 @@ describe('trigger reorder filter', () => {
         order: [
           { category: '1', active: [11, 22], inactive: [55, 66] },
           { category: '2', active: [33, 44], inactive: [] },
-          { category: '3', active: [], inactive: [] },
+          { category: '3' },
         ],
       },
     )


### PR DESCRIPTION
_add safeties to the order instances deploy filters and change validators_

---

_Additional context for reviewer_
Due to another bug that now omits fields with empty values from nacl, we need to add more safeties to make sure we are ok if the order instance' fields are removed

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
