### PR TITLE
SALTO-2508: fix zendesk fetch to stop omitting fields with empty list

### DIFF
--- a/packages/zendesk-adapter/src/filters/dynamic_content_references.ts
+++ b/packages/zendesk-adapter/src/filters/dynamic_content_references.ts
@@ -55,6 +55,7 @@ const transformDynamicContentDependencies = async (
       }
       return value
     },
+    allowEmpty: true,
   }) ?? instance.value
 }
 
@@ -88,6 +89,7 @@ const returnDynamicContentsToApiValue = async (
       }
       return value
     },
+    allowEmpty: true,
   }) ?? instance.value
 }
 
@@ -126,6 +128,7 @@ const filterCreator: FilterCreator = () => {
             }
             return value
           },
+          allowEmpty: true,
         }) ?? instance.value
       }), 'Dynamic content references filter'),
   })

--- a/packages/zendesk-adapter/test/filters/dynamic_content_references.test.ts
+++ b/packages/zendesk-adapter/test/filters/dynamic_content_references.test.ts
@@ -16,6 +16,7 @@
 import {
   ObjectType, ElemID, InstanceElement, ReferenceExpression, TemplateExpression, BuiltinTypes,
   toChange,
+  ListType,
 } from '@salto-io/adapter-api'
 import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { DEFAULT_CONFIG } from '../../src/config'
@@ -43,6 +44,7 @@ describe('dynamic content references filter', () => {
       elemID: new ElemID(ZENDESK, 'someType'),
       fields: {
         raw_value: { refType: BuiltinTypes.STRING },
+        empty_value: { refType: new ListType(BuiltinTypes.NUMBER) },
       },
     })
 
@@ -77,6 +79,7 @@ describe('dynamic content references filter', () => {
       type,
       {
         raw_value: '{{somePlaceholder}} {{notExistsPlaceholder}} {{somePlaceholder}}',
+        empty_value: [],
       }
     )
     return {
@@ -97,6 +100,7 @@ describe('dynamic content references filter', () => {
           new ReferenceExpression(dynamicContentInstance.elemID, dynamicContentInstance),
           '}}'],
       }))
+      expect(instance.value.empty_value).toEqual([])
     })
   })
 
@@ -127,6 +131,7 @@ describe('dynamic content references filter', () => {
           new ReferenceExpression(dynamicContentInstance.elemID, dynamicContentInstance),
           '}}'],
       }))
+      expect(instanceCopy.value.empty_value).toEqual([])
     })
   })
 })


### PR DESCRIPTION
_fix zendesk fetch to stop omitting fields with empty list_

---

_Additional context for reviewer_
Zendesk fetches and deploys removed fields from instances if their values was empty list.

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
