### PR TITLE
SALTO-2442: Refactor the field context to not reference other projects

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -168,7 +168,6 @@ export const DEFAULT_FILTERS = [
   fieldReferencesFilter,
   // Must run after fieldReferencesFilter
   contextsProjectsFilter,
-  // Must run after fieldReferencesFilter
   fieldConfigurationIrrelevantFields,
   // Must run after fieldConfigurationIrrelevantFields
   fieldConfigurationSplitFilter,

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -240,7 +240,7 @@ export default class JiraAdapter implements AdapterOperations {
           getElemIdFunc,
           elementsSource,
           fetchQuery: this.fetchQuery,
-          globalContext: filterContext,
+          adapterContext: filterContext,
         },
         filterCreators,
         objects.concatObjects

--- a/packages/jira-adapter/src/change_validators/global_project_contexts.ts
+++ b/packages/jira-adapter/src/change_validators/global_project_contexts.ts
@@ -1,0 +1,115 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ChangeValidator, getChangeData, isAdditionChange, isAdditionOrModificationChange, isInstanceChange, isRemovalOrModificationChange, ReferenceExpression } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import _ from 'lodash'
+import { PROJECT_CONTEXTS_FIELD } from '../filters/fields/contexts_projects_filter'
+import { PROJECT_TYPE } from '../constants'
+import { FIELD_CONTEXT_TYPE_NAME } from '../filters/fields/constants'
+
+const { awu } = collections.asynciterable
+
+export const globalProjectContextsValidator: ChangeValidator = async (changes, elementsSource) => {
+  if (elementsSource === undefined) {
+    return []
+  }
+
+  const ids = await awu(await elementsSource.list()).toArray()
+
+  const projects = await awu(ids)
+    .filter(id => id.typeName === PROJECT_TYPE)
+    .filter(id => id.idType === 'instance')
+    .map(id => elementsSource.get(id))
+    .toArray()
+
+  const contexts = await awu(ids)
+    .filter(id => id.typeName === FIELD_CONTEXT_TYPE_NAME)
+    .filter(id => id.idType === 'instance')
+    .map(id => elementsSource.get(id))
+    .toArray()
+
+  const projectContexts = new Set(projects
+    .flatMap(proj => proj.value[PROJECT_CONTEXTS_FIELD] ?? [])
+    .map(ref => ref.elemID.getFullName()))
+
+  const [referencedContexts, nonReferencedContexts] = _.partition(
+    contexts,
+    context => projectContexts.has(context.elemID.getFullName())
+  )
+
+  const referencedContextErrors = referencedContexts
+    .filter(context => context.value.isGlobalContext)
+    .map(instance => ({
+      elemID: instance.elemID,
+      severity: 'Error' as const,
+      message: 'Global context cannot be used in individual projects',
+      detailedMessage: `The context ${instance.elemID.getFullName()} is set as global context, and therefore cannot be referenced from individual projects.`,
+    }))
+
+  const idToChange = _.keyBy(changes, change => getChangeData(change).elemID.getFullName())
+
+  const [nonReferencedNewContexts, nonReferencedExistingContexts] = _.partition(
+    nonReferencedContexts,
+    context => context.elemID.getFullName() in idToChange
+      && isAdditionChange(idToChange[context.elemID.getFullName()])
+  )
+
+  const nonReferencedNewContextErrors = nonReferencedNewContexts
+    .filter(context => !context.value.isGlobalContext)
+    .map(instance => ({
+      elemID: instance.elemID,
+      severity: 'Error' as const,
+      message: 'Field context is not used in any project',
+      detailedMessage: `The context ${instance.elemID.getFullName()} is not used by any project and it is not a global context, so it cannot be created.`,
+    }))
+
+  const nonReferencedExistingContextErrors = changes
+    .filter(change => getChangeData(change).elemID.typeName === PROJECT_TYPE)
+    .filter(isInstanceChange)
+    .map(change => {
+      const beforeContexts = new Set(isRemovalOrModificationChange(change)
+        ? change.data.before.value[PROJECT_CONTEXTS_FIELD]
+          ?.map((ref: ReferenceExpression) => ref.elemID.getFullName()) ?? []
+        : [])
+      const afterContexts = new Set(isAdditionOrModificationChange(change)
+        ? change.data.after.value[PROJECT_CONTEXTS_FIELD]
+          ?.map((ref: ReferenceExpression) => ref.elemID.getFullName()) ?? []
+        : [])
+
+      return {
+        instance: getChangeData(change),
+        removedContexts: nonReferencedExistingContexts.filter(
+          context => beforeContexts.has(context.elemID.getFullName())
+            && !afterContexts.has(context.elemID.getFullName())
+        ),
+      }
+    })
+    .filter(({ removedContexts }) => removedContexts.length > 0)
+    .map(({ instance, removedContexts }) => ({
+      elemID: instance.elemID,
+      severity: 'Error' as const,
+      message: 'Cannot remove field context from a project',
+      detailedMessage: `A field context which is not global must be referenced by at least one project. The deployment of ${instance.elemID.getFullName()} will results the following contexts to have no references: ${removedContexts.map(context => context.elemID.getFullName()).join(', ')} and therefore the project cannot be deployed.
+To solve this either modify the project to keep a reference to these contexts, or remove the contexts from the workspace`,
+    }))
+
+
+  return [
+    ...nonReferencedNewContextErrors,
+    ...nonReferencedExistingContextErrors,
+    ...referencedContextErrors,
+  ]
+}

--- a/packages/jira-adapter/src/change_validators/global_project_contexts.ts
+++ b/packages/jira-adapter/src/change_validators/global_project_contexts.ts
@@ -13,44 +13,27 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ChangeValidator, getChangeData, isAdditionChange, isAdditionOrModificationChange, isInstanceChange, isRemovalOrModificationChange, ReferenceExpression } from '@salto-io/adapter-api'
+import { Change, ChangeError, ChangeValidator, getChangeData, InstanceElement, isAdditionChange, isAdditionOrModificationChange, isInstanceChange, isReferenceExpression, isRemovalOrModificationChange, ReferenceExpression, Element } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
+import { logger } from '@salto-io/logging'
 import { PROJECT_CONTEXTS_FIELD } from '../filters/fields/contexts_projects_filter'
 import { PROJECT_TYPE } from '../constants'
 import { FIELD_CONTEXT_TYPE_NAME } from '../filters/fields/constants'
 
 const { awu } = collections.asynciterable
+const log = logger(module)
 
-export const globalProjectContextsValidator: ChangeValidator = async (changes, elementsSource) => {
-  if (elementsSource === undefined) {
-    return []
-  }
 
-  const ids = await awu(await elementsSource.list()).toArray()
-
-  const projects = await awu(ids)
-    .filter(id => id.typeName === PROJECT_TYPE)
-    .filter(id => id.idType === 'instance')
-    .map(id => elementsSource.get(id))
-    .toArray()
-
-  const contexts = await awu(ids)
-    .filter(id => id.typeName === FIELD_CONTEXT_TYPE_NAME)
-    .filter(id => id.idType === 'instance')
-    .map(id => elementsSource.get(id))
-    .toArray()
-
-  const projectContexts = new Set(projects
-    .flatMap(proj => proj.value[PROJECT_CONTEXTS_FIELD] ?? [])
-    .map(ref => ref.elemID.getFullName()))
-
-  const [referencedContexts, nonReferencedContexts] = _.partition(
-    contexts,
+const getGlobalContextsUsedInProjectErrors = (
+  contexts: InstanceElement[],
+  projectContexts: Set<string>,
+): ChangeError[] => {
+  const referencedContexts = contexts.filter(
     context => projectContexts.has(context.elemID.getFullName())
   )
 
-  const referencedContextErrors = referencedContexts
+  return referencedContexts
     .filter(context => context.value.isGlobalContext)
     .map(instance => ({
       elemID: instance.elemID,
@@ -58,16 +41,23 @@ export const globalProjectContextsValidator: ChangeValidator = async (changes, e
       message: 'Global context cannot be used in individual projects',
       detailedMessage: `The context ${instance.elemID.getFullName()} is set as global context, and therefore cannot be referenced from individual projects.`,
     }))
+}
 
-  const idToChange = _.keyBy(changes, change => getChangeData(change).elemID.getFullName())
+const getContextsNotUsedInProjectErrors = (
+  contexts: InstanceElement[],
+  projectContexts: Set<string>,
+  idToChange: Record<string, Change<Element>>,
+): ChangeError[] => {
+  const nonReferencedContexts = contexts.filter(
+    context => !projectContexts.has(context.elemID.getFullName())
+  )
 
-  const [nonReferencedNewContexts, nonReferencedExistingContexts] = _.partition(
-    nonReferencedContexts,
+  const nonReferencedNewContexts = nonReferencedContexts.filter(
     context => context.elemID.getFullName() in idToChange
       && isAdditionChange(idToChange[context.elemID.getFullName()])
   )
 
-  const nonReferencedNewContextErrors = nonReferencedNewContexts
+  return nonReferencedNewContexts
     .filter(context => !context.value.isGlobalContext)
     .map(instance => ({
       elemID: instance.elemID,
@@ -75,8 +65,24 @@ export const globalProjectContextsValidator: ChangeValidator = async (changes, e
       message: 'Field context is not used in any project',
       detailedMessage: `The context ${instance.elemID.getFullName()} is not used by any project and it is not a global context, so it cannot be created.`,
     }))
+}
 
-  const nonReferencedExistingContextErrors = changes
+const getProjectRemovedContextsErrors = (
+  contexts: InstanceElement[],
+  projectContexts: Set<string>,
+  idToChange: Record<string, Change<Element>>,
+): ChangeError[] => {
+  const nonReferencedContexts = contexts.filter(
+    context => !projectContexts.has(context.elemID.getFullName())
+  )
+
+  const nonReferencedExistingContexts = nonReferencedContexts.filter(
+    context => !(context.elemID.getFullName() in idToChange
+      && isAdditionChange(idToChange[context.elemID.getFullName()]))
+  )
+
+
+  return Object.values(idToChange)
     .filter(change => getChangeData(change).elemID.typeName === PROJECT_TYPE)
     .filter(isInstanceChange)
     .map(change => {
@@ -102,14 +108,50 @@ export const globalProjectContextsValidator: ChangeValidator = async (changes, e
       elemID: instance.elemID,
       severity: 'Error' as const,
       message: 'Cannot remove field context from a project',
-      detailedMessage: `A field context which is not global must be referenced by at least one project. The deployment of ${instance.elemID.getFullName()} will results the following contexts to have no references: ${removedContexts.map(context => context.elemID.getFullName()).join(', ')} and therefore the project cannot be deployed.
-To solve this either modify the project to keep a reference to these contexts, or remove the contexts from the workspace`,
+      detailedMessage: `A field context which is not global must be referenced by at least one project. The deployment of ${instance.elemID.getFullName()} will result in the following contexts having no references: ${removedContexts.map(context => context.elemID.getFullName()).join(', ')}. Therefore, the project cannot be deployed.
+To solve this, either modify the project to keep a reference to these contexts, or remove the contexts from the workspace`,
     }))
+}
 
+/**
+ * Verify that the field context 'isGlobalContext' matches the project types that uses it
+ */
+export const globalProjectContextsValidator: ChangeValidator = async (changes, elementSource) => {
+  if (elementSource === undefined) {
+    return []
+  }
+
+  const ids = await awu(await elementSource.list()).toArray()
+
+  const projects = await awu(ids)
+    .filter(id => id.typeName === PROJECT_TYPE)
+    .filter(id => id.idType === 'instance')
+    .map(id => elementSource.get(id))
+    .toArray()
+
+  const contexts = await awu(ids)
+    .filter(id => id.typeName === FIELD_CONTEXT_TYPE_NAME)
+    .filter(id => id.idType === 'instance')
+    .map(id => elementSource.get(id))
+    .toArray()
+
+  const projectContexts = new Set(projects
+    .flatMap(proj => proj.value[PROJECT_CONTEXTS_FIELD] ?? [])
+    .filter(ref => {
+      if (!isReferenceExpression(ref)) {
+        log.warn(`Found a non reference expression in ${PROJECT_CONTEXTS_FIELD}`)
+        return false
+      }
+      return true
+    })
+    .map(ref => ref.elemID.getFullName()))
+
+
+  const idToChange = _.keyBy(changes, change => getChangeData(change).elemID.getFullName())
 
   return [
-    ...nonReferencedNewContextErrors,
-    ...nonReferencedExistingContextErrors,
-    ...referencedContextErrors,
+    ...getGlobalContextsUsedInProjectErrors(contexts, projectContexts),
+    ...getContextsNotUsedInProjectErrors(contexts, projectContexts, idToChange),
+    ...getProjectRemovedContextsErrors(contexts, projectContexts, idToChange),
   ]
 }

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -31,6 +31,7 @@ import { dashboardLayoutValidator } from './dashboard_layout'
 import { maskingValidator } from './masking'
 import { automationsValidator } from './automations'
 import { lockedFieldsValidator } from './locked_fields'
+import { globalProjectContextsValidator } from './global_project_contexts'
 
 const {
   deployTypesNotSupportedValidator,
@@ -55,6 +56,7 @@ export default (
     automationsValidator,
     maskingValidator(client),
     lockedFieldsValidator,
+    globalProjectContextsValidator,
   ]
 
   return createChangeValidator(validators)

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -15,7 +15,7 @@
 */
 import { config as configUtils } from '@salto-io/adapter-components'
 import { AUTOMATION_TYPE, BOARD_COLUMN_CONFIG_TYPE, BOARD_ESTIMATION_TYPE, ISSUE_TYPE_NAME, ISSUE_TYPE_SCHEMA_NAME, RESOLUTION_TYPE_NAME, STATUS_TYPE_NAME } from '../constants'
-import { FIELD_TYPE_NAME } from '../filters/fields/constants'
+import { FIELD_CONTEXT_TYPE_NAME, FIELD_TYPE_NAME } from '../filters/fields/constants'
 
 
 export type JspUrls = {
@@ -310,7 +310,6 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
         },
       ],
       fieldsToOmit: [
-        { fieldName: 'isGlobalContext' },
         { fieldName: 'isAnyIssueType' },
       ],
     },
@@ -824,6 +823,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
         { fieldName: 'issueTypeScreenScheme', fieldType: 'IssueTypeScreenScheme' },
         { fieldName: 'fieldConfigurationScheme', fieldType: 'FieldConfigurationScheme' },
         { fieldName: 'issueTypeScheme', fieldType: ISSUE_TYPE_SCHEMA_NAME },
+        { fieldName: 'fieldContexts', fieldType: `list<${FIELD_CONTEXT_TYPE_NAME}>` },
       ],
       fieldsToHide: [
         {

--- a/packages/jira-adapter/src/dependency_changers/dashboard_gadgets.ts
+++ b/packages/jira-adapter/src/dependency_changers/dashboard_gadgets.ts
@@ -15,17 +15,18 @@
 */
 import { Change, dependencyChange, DependencyChanger, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange } from '@salto-io/adapter-api'
 import { getParents } from '@salto-io/adapter-utils'
-import { collections, values } from '@salto-io/lowerdash'
+import { values } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { getGadgetInstanceKey, getGadgetKey } from '../change_validators/dashboard_gadgets'
 import { DASHBOARD_GADGET_TYPE, DASHBOARD_TYPE } from '../constants'
+import { ChangeWithKey } from './types'
 
 
 export const dashboardGadgetsDependencyChanger: DependencyChanger = async changes => {
   const instanceChanges = Array.from(changes.entries())
     .map(([key, change]) => ({ key, change }))
     .filter(
-      (change): change is { key: collections.set.SetId; change: Change<InstanceElement> } =>
+      (change): change is ChangeWithKey<Change<InstanceElement>> =>
         isInstanceChange(change.change)
     )
 

--- a/packages/jira-adapter/src/dependency_changers/global_field_contexts.ts
+++ b/packages/jira-adapter/src/dependency_changers/global_field_contexts.ts
@@ -15,16 +15,16 @@
 */
 import { Change, dependencyChange, DependencyChanger, getChangeData, InstanceElement, isAdditionChange, isAdditionOrRemovalChange, isInstanceChange, isRemovalChange } from '@salto-io/adapter-api'
 import { getParent } from '@salto-io/adapter-utils'
-import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { FIELD_CONTEXT_TYPE_NAME } from '../filters/fields/constants'
+import { ChangeWithKey } from './types'
 
 
 export const globalFieldContextsDependencyChanger: DependencyChanger = async changes => {
   const globalContextChanges = Array.from(changes.entries())
     .map(([key, change]) => ({ key, change }))
     .filter(
-      (change): change is { key: collections.set.SetId; change: Change<InstanceElement> } =>
+      (change): change is ChangeWithKey<Change<InstanceElement>> =>
         isInstanceChange(change.change)
     )
     .filter(({ change }) => getChangeData(change).elemID.typeName === FIELD_CONTEXT_TYPE_NAME)

--- a/packages/jira-adapter/src/dependency_changers/index.ts
+++ b/packages/jira-adapter/src/dependency_changers/index.ts
@@ -19,6 +19,7 @@ import { collections } from '@salto-io/lowerdash'
 import { dashboardGadgetsDependencyChanger } from './dashboard_gadgets'
 import { globalFieldContextsDependencyChanger } from './global_field_contexts'
 import { projectDependencyChanger } from './project'
+import { projectContextsDependencyChanger } from './project_contexts'
 import { removalsDependencyChanger } from './removals'
 import { workflowDependencyChanger } from './workflow'
 
@@ -31,6 +32,7 @@ const DEPENDENCY_CHANGERS: DependencyChanger[] = [
   dashboardGadgetsDependencyChanger,
   removalsDependencyChanger,
   globalFieldContextsDependencyChanger,
+  projectContextsDependencyChanger,
 ]
 
 export const dependencyChanger: DependencyChanger = async (

--- a/packages/jira-adapter/src/dependency_changers/project.ts
+++ b/packages/jira-adapter/src/dependency_changers/project.ts
@@ -14,15 +14,15 @@
 * limitations under the License.
 */
 import { Change, dependencyChange, DependencyChanger, getChangeData, InstanceElement, isAdditionChange, isInstanceChange, isRemovalChange } from '@salto-io/adapter-api'
-import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
+import { ChangeWithKey } from './types'
 
 
 export const projectDependencyChanger: DependencyChanger = async changes => {
   const projectChanges = Array.from(changes.entries())
     .map(([key, change]) => ({ key, change }))
     .filter(
-      (change): change is { key: collections.set.SetId; change: Change<InstanceElement> } =>
+      (change): change is ChangeWithKey<Change<InstanceElement>> =>
         isInstanceChange(change.change)
     )
     .filter(({ change }) => getChangeData(change).elemID.typeName === 'Project')

--- a/packages/jira-adapter/src/dependency_changers/project_contexts.ts
+++ b/packages/jira-adapter/src/dependency_changers/project_contexts.ts
@@ -14,11 +14,14 @@
 * limitations under the License.
 */
 import { Change, dependencyChange, DependencyChanger, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange } from '@salto-io/adapter-api'
-import { collections } from '@salto-io/lowerdash'
 import { PROJECT_TYPE } from '../constants'
 import { FIELD_CONTEXT_TYPE_NAME } from '../filters/fields/constants'
+import { ChangeWithKey } from './types'
 
 
+/**
+ * Make sure contexts will be deployed only after their relevant projects were deployed
+ */
 export const projectContextsDependencyChanger: DependencyChanger = async (
   changes,
   dependencies,
@@ -26,7 +29,7 @@ export const projectContextsDependencyChanger: DependencyChanger = async (
   const projectKeys = Array.from(changes.entries())
     .map(([key, change]) => ({ key, change }))
     .filter(
-      (change): change is { key: collections.set.SetId; change: Change<InstanceElement> } =>
+      (change): change is ChangeWithKey<Change<InstanceElement>> =>
         isInstanceChange(change.change)
         && isAdditionOrModificationChange(change.change)
     )

--- a/packages/jira-adapter/src/dependency_changers/project_contexts.ts
+++ b/packages/jira-adapter/src/dependency_changers/project_contexts.ts
@@ -1,0 +1,63 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Change, dependencyChange, DependencyChanger, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { PROJECT_TYPE } from '../constants'
+import { FIELD_CONTEXT_TYPE_NAME } from '../filters/fields/constants'
+
+
+export const projectContextsDependencyChanger: DependencyChanger = async (
+  changes,
+  dependencies,
+) => {
+  const projectKeys = Array.from(changes.entries())
+    .map(([key, change]) => ({ key, change }))
+    .filter(
+      (change): change is { key: collections.set.SetId; change: Change<InstanceElement> } =>
+        isInstanceChange(change.change)
+        && isAdditionOrModificationChange(change.change)
+    )
+    .filter(({ change }) => getChangeData(change).elemID.typeName === PROJECT_TYPE)
+    .map(({ key }) => key)
+
+  return projectKeys
+    .flatMap(projectKey => {
+      const contextDependencies = Array.from(dependencies.get(projectKey) ?? [])
+        .filter(key => {
+          const change = changes.get(key)
+          if (change === undefined) {
+            return false
+          }
+
+          return getChangeData(change).elemID.typeName === FIELD_CONTEXT_TYPE_NAME
+        })
+
+      return contextDependencies.flatMap(
+        contextKey => [
+          dependencyChange(
+            'remove',
+            projectKey,
+            contextKey,
+          ),
+          dependencyChange(
+            'add',
+            contextKey,
+            projectKey,
+          ),
+        ]
+      )
+    })
+}

--- a/packages/jira-adapter/src/dependency_changers/removals.ts
+++ b/packages/jira-adapter/src/dependency_changers/removals.ts
@@ -15,9 +15,9 @@
 */
 import { CORE_ANNOTATIONS, dependencyChange, DependencyChanger, getChangeData, InstanceElement, isAdditionChange, isInstanceChange, isRemovalChange, RemovalChange } from '@salto-io/adapter-api'
 import { references } from '@salto-io/adapter-utils'
-import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { FIELD_CONTEXT_TYPE_NAME } from '../filters/fields/constants'
+import { ChangeWithKey } from './types'
 
 const TYPES_TO_IGNORE = [
   FIELD_CONTEXT_TYPE_NAME,
@@ -27,7 +27,7 @@ export const removalsDependencyChanger: DependencyChanger = async changes => {
   const removalsChanges = _(Array.from(changes.entries()))
     .map(([key, change]) => ({ key, change }))
     .filter(
-      (change): change is { key: collections.set.SetId; change: RemovalChange<InstanceElement> } =>
+      (change): change is ChangeWithKey<RemovalChange<InstanceElement>> =>
         isInstanceChange(change.change)
         && isRemovalChange(change.change)
         && !TYPES_TO_IGNORE.includes(getChangeData(change.change).elemID.typeName)

--- a/packages/jira-adapter/src/dependency_changers/types.ts
+++ b/packages/jira-adapter/src/dependency_changers/types.ts
@@ -1,0 +1,22 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Change } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+
+export type ChangeWithKey<ChangeType extends Change> = {
+  key: collections.set.SetId
+  change: ChangeType
+}

--- a/packages/jira-adapter/src/dependency_changers/workflow.ts
+++ b/packages/jira-adapter/src/dependency_changers/workflow.ts
@@ -14,9 +14,10 @@
 * limitations under the License.
 */
 import { Change, dependencyChange, DependencyChanger, getAllChangeData, getChangeData, InstanceElement, isInstanceChange, isModificationChange, Values } from '@salto-io/adapter-api'
-import { collections, values } from '@salto-io/lowerdash'
+import { values } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { WORKFLOW_SCHEME_TYPE_NAME, WORKFLOW_TYPE_NAME } from '../constants'
+import { ChangeWithKey } from './types'
 
 
 const getWorkflowSchemeReferences = (instance: InstanceElement): string[] => [
@@ -35,7 +36,7 @@ export const workflowDependencyChanger: DependencyChanger = async changes => {
   const instanceChanges = Array.from(changes.entries())
     .map(([key, change]) => ({ key, change }))
     .filter(
-      (change): change is { key: collections.set.SetId; change: Change<InstanceElement> } =>
+      (change): change is ChangeWithKey<Change<InstanceElement>> =>
         isInstanceChange(change.change)
     )
 

--- a/packages/jira-adapter/src/filter.ts
+++ b/packages/jira-adapter/src/filter.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ReadOnlyElementsSource, SaltoError } from '@salto-io/adapter-api'
+import { ReadOnlyElementsSource, SaltoError, Values } from '@salto-io/adapter-api'
 import { filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import JiraClient from './client/client'
 import { JiraConfig } from './config/config'
@@ -29,6 +29,10 @@ export type Filter = filterUtils.Filter<FilterResult>
 export type FilterAdditionParams = {
   elementsSource: ReadOnlyElementsSource
   fetchQuery: elementUtils.query.ElementQuery
+  // A context for deployment that should be persistent across all the deployment steps.
+  // Note that deployment steps can be executed in parallel so use this cautiously
+  // and only when needed.
+  globalContext: Values
 }
 
 export type FilterCreator = filterUtils.FilterCreator<

--- a/packages/jira-adapter/src/filter.ts
+++ b/packages/jira-adapter/src/filter.ts
@@ -32,7 +32,7 @@ export type FilterAdditionParams = {
   // A context for deployment that should be persistent across all the deployment steps.
   // Note that deployment steps can be executed in parallel so use this cautiously
   // and only when needed.
-  globalContext: Values
+  adapterContext: Values
 }
 
 export type FilterCreator = filterUtils.FilterCreator<

--- a/packages/jira-adapter/src/filters/fields/context_deployment_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/context_deployment_filter.ts
@@ -21,7 +21,7 @@ import { deployChanges } from '../../deployment/standard_deployment'
 import { FIELD_CONTEXT_TYPE_NAME, FIELD_TYPE_NAME } from './constants'
 import { findObject, setFieldDeploymentAnnotations } from '../../utils'
 
-const filter: FilterCreator = ({ client, config }) => ({
+const filter: FilterCreator = ({ client, config, elementsSource }) => ({
   onFetch: async (elements: Element[]) => {
     const fieldType = findObject(elements, FIELD_TYPE_NAME)
     if (fieldType !== undefined) {
@@ -43,7 +43,7 @@ const filter: FilterCreator = ({ client, config }) => ({
 
     const deployResult = await deployChanges(
       relevantChanges.filter(isInstanceChange),
-      change => deployContextChange(change, client, config.apiDefinitions)
+      change => deployContextChange(change, client, config.apiDefinitions, elementsSource)
     )
 
     return {

--- a/packages/jira-adapter/src/filters/fields/context_options.ts
+++ b/packages/jira-adapter/src/filters/fields/context_options.ts
@@ -199,8 +199,9 @@ export const setContextOptions = async (
     option => option.optionId !== undefined || option.parentValue === undefined
   )
 
-  const fieldId = (await getParents(getChangeData(contextChange))[0]
-    .getResolvedValue(elementsSource)).value.id
+  const fieldId = (
+    await getParents(getChangeData(contextChange))[0].getResolvedValue(elementsSource)
+  ).value.id
 
   const url = `/rest/api/3/field/${fieldId}/context/${getChangeData(contextChange).value.id}/option`
   await updateContextOptions({

--- a/packages/jira-adapter/src/filters/fields/contexts_projects_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/contexts_projects_filter.ts
@@ -1,0 +1,165 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Change, ElemID, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, isInstanceElement, isReferenceExpression, isRemovalOrModificationChange, ReadOnlyElementsSource, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { applyFunctionToChangeData } from '@salto-io/adapter-utils'
+import { collections, values } from '@salto-io/lowerdash'
+import { PROJECT_TYPE } from '../../constants'
+import { FilterCreator } from '../../filter'
+import { FIELD_CONTEXT_TYPE_NAME } from './constants'
+
+const { awu } = collections.asynciterable
+
+export const PROJECT_CONTEXTS_FIELD = 'fieldContexts'
+
+const getProjectReferencesFromSource = async (
+  contextId: ElemID,
+  elementsSource: ReadOnlyElementsSource,
+  deployedProjectIds: Set<string>,
+): Promise<ReferenceExpression[]> =>
+  awu(await elementsSource.list())
+    .filter(id => id.typeName === PROJECT_TYPE)
+    .filter(id => id.idType === 'instance')
+    .filter(id => !deployedProjectIds.has(id.getFullName()))
+    .map(id => elementsSource.get(id))
+    .filter(projectInstance => projectInstance.value[PROJECT_CONTEXTS_FIELD]?.some(
+      (context: ReferenceExpression) => context.elemID.isEqual(contextId)
+    ))
+    .map(projectInstance => new ReferenceExpression(projectInstance.elemID, projectInstance))
+    .toArray()
+
+const filter: FilterCreator = ({ elementsSource }) => {
+  const afterContextToProjects: Record<string, ReferenceExpression[]> = {}
+  const beforeContextToProjects: Record<string, ReferenceExpression[]> = {}
+  const deployedProjectIds = new Set<string>()
+
+  const updateContextToProjectChanges = (projectChange: Change<InstanceElement>): void => {
+    if (isAdditionOrModificationChange(projectChange)) {
+      projectChange.data.after.value[PROJECT_CONTEXTS_FIELD]
+        ?.forEach((context: ReferenceExpression) => {
+          if (afterContextToProjects[context.elemID.getFullName()] === undefined) {
+            afterContextToProjects[context.elemID.getFullName()] = []
+          }
+          afterContextToProjects[context.elemID.getFullName()].push(
+            new ReferenceExpression(projectChange.data.after.elemID, projectChange.data.after)
+          )
+        })
+    }
+
+    if (isRemovalOrModificationChange(projectChange)) {
+      projectChange.data.before.value[PROJECT_CONTEXTS_FIELD]
+        ?.forEach((context: ReferenceExpression) => {
+          if (beforeContextToProjects[context.elemID.getFullName()] === undefined) {
+            beforeContextToProjects[context.elemID.getFullName()] = []
+          }
+          beforeContextToProjects[context.elemID.getFullName()].push(
+            new ReferenceExpression(projectChange.data.before.elemID, projectChange.data.before)
+          )
+        })
+    }
+  }
+
+  const getContextChanges = async (): Promise<Change<InstanceElement>[]> => {
+    const existingIds = new Set([
+      ...Object.keys(afterContextToProjects),
+      ...Object.keys(beforeContextToProjects),
+    ])
+
+    return awu(Array.from(existingIds))
+      .map(id => elementsSource.get(ElemID.fromFullName(id)))
+      .filter(values.isDefined)
+      .filter(instance => instance.value.id !== undefined)
+      .map(instance => toChange({ before: instance, after: instance.clone() }))
+      .toArray()
+  }
+
+  return {
+    onFetch: async elements => {
+      elements
+        .filter(isInstanceElement)
+        .filter(instance => instance.elemID.typeName === FIELD_CONTEXT_TYPE_NAME)
+        .forEach(instance => {
+          instance.value.projectIds
+            ?.filter(isReferenceExpression)
+            .forEach((ref: ReferenceExpression) => {
+              if (ref.value.value[PROJECT_CONTEXTS_FIELD] === undefined) {
+                ref.value.value[PROJECT_CONTEXTS_FIELD] = []
+              }
+              ref.value.value[PROJECT_CONTEXTS_FIELD].push(
+                new ReferenceExpression(instance.elemID, instance)
+              )
+            })
+
+          delete instance.value.projectIds
+        })
+    },
+
+    preDeploy: async changes => {
+      const instances = changes.filter(isInstanceChange)
+
+      instances
+        .filter(change => getChangeData(change).elemID.typeName === PROJECT_TYPE)
+        .forEach(change => {
+          updateContextToProjectChanges(change)
+          deployedProjectIds.add(getChangeData(change).elemID.getFullName())
+        })
+
+      const missingChanges = await getContextChanges()
+      missingChanges.forEach(change => changes.push(change))
+
+      await awu(changes)
+        .filter(isInstanceChange)
+        .filter(change => getChangeData(change).elemID.typeName === FIELD_CONTEXT_TYPE_NAME)
+        .forEach(async change => {
+          const projectReferencesFromSource = await getProjectReferencesFromSource(
+            getChangeData(change).elemID,
+            elementsSource,
+            deployedProjectIds,
+          )
+          if (isAdditionOrModificationChange(change)) {
+            change.data.after.value.projectIds = [
+              ...projectReferencesFromSource,
+              ...(afterContextToProjects[getChangeData(change).elemID.getFullName()] ?? []),
+            ]
+          }
+
+          if (isRemovalOrModificationChange(change)) {
+            change.data.before.value.projectIds = [
+              ...projectReferencesFromSource,
+              ...(beforeContextToProjects[getChangeData(change).elemID.getFullName()] ?? []),
+            ]
+          }
+
+          delete afterContextToProjects[getChangeData(change).elemID.getFullName()]
+          delete beforeContextToProjects[getChangeData(change).elemID.getFullName()]
+        })
+    },
+
+    onDeploy: async changes => (
+      awu(changes)
+        .filter(isInstanceChange)
+        .filter(change => getChangeData(change).elemID.typeName === FIELD_CONTEXT_TYPE_NAME)
+        .forEach(change => applyFunctionToChangeData<Change<InstanceElement>>(
+          change,
+          async instance => {
+            delete instance.value.projectIds
+            return instance
+          }
+        ))
+    ),
+  }
+}
+
+export default filter

--- a/packages/jira-adapter/src/filters/fields/contexts_projects_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/contexts_projects_filter.ts
@@ -53,9 +53,11 @@ const appendReference = (
  * A filter to change project to reference field contexts instead of the other way around
  */
 const filter: FilterCreator = ({ elementsSource, adapterContext }) => {
-  adapterContext.afterContextToProjects = {}
-  adapterContext.beforeContextToProjects = {}
-  adapterContext.deployedProjectIds = new Set<string>()
+  if (adapterContext.afterContextToProjects === undefined) {
+    adapterContext.afterContextToProjects = {}
+    adapterContext.beforeContextToProjects = {}
+    adapterContext.deployedProjectIds = new Set<string>()
+  }
 
   const updateContextToProjectChanges = (projectChange: Change<InstanceElement>): void => {
     if (isAdditionOrModificationChange(projectChange)) {

--- a/packages/jira-adapter/src/filters/fields/default_values.ts
+++ b/packages/jira-adapter/src/filters/fields/default_values.ts
@@ -14,9 +14,9 @@
 * limitations under the License.
 */
 
-import { Change, compareSpecialValues, getChangeData, InstanceElement, isAdditionOrModificationChange, isObjectType, isReferenceExpression, isRemovalChange, isRemovalOrModificationChange, ObjectType, Value } from '@salto-io/adapter-api'
+import { Change, compareSpecialValues, getChangeData, InstanceElement, isAdditionOrModificationChange, isObjectType, isReferenceExpression, isRemovalChange, isRemovalOrModificationChange, ObjectType, ReadOnlyElementsSource, Value } from '@salto-io/adapter-api'
 import { client as clientUtils } from '@salto-io/adapter-components'
-import { applyFunctionToChangeData, getParents, resolveChangeElement, resolvePath } from '@salto-io/adapter-utils'
+import { applyFunctionToChangeData, getParents, resolveChangeElement, resolvePath, resolveValues } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { getLookUpName } from '../../reference_mapping'
 import { setFieldDeploymentAnnotations } from '../../utils'
@@ -71,10 +71,13 @@ const resolveDefaultOption = (
 export const updateDefaultValues = async (
   contextChange: Change<InstanceElement>,
   client: clientUtils.HTTPWriteClientInterface,
+  elementsSource?: ReadOnlyElementsSource,
 ): Promise<void> => {
   const resolvedChange = await resolveChangeElement(
     await resolveDefaultOption(contextChange),
-    getLookUpName
+    getLookUpName,
+    resolveValues,
+    elementsSource,
   )
 
   const beforeDefault = isRemovalOrModificationChange(resolvedChange)

--- a/packages/jira-adapter/src/filters/fields/issues_and_projects.ts
+++ b/packages/jira-adapter/src/filters/fields/issues_and_projects.ts
@@ -13,8 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, getChangeData, InstanceElement, isModificationChange } from '@salto-io/adapter-api'
-import { getParents, resolveChangeElement } from '@salto-io/adapter-utils'
+import { Change, getChangeData, InstanceElement, isModificationChange, ReadOnlyElementsSource } from '@salto-io/adapter-api'
+import { getParents, resolveChangeElement, resolveValues } from '@salto-io/adapter-utils'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { getLookUpName } from '../../reference_mapping'
 import { getDiffIds } from '../../diff'
@@ -25,13 +25,20 @@ export const setContextField = async ({
   fieldName,
   endpoint,
   client,
+  elementsSource,
 }: {
   contextChange: Change<InstanceElement>
   fieldName: string
   endpoint: string
   client: clientUtils.HTTPWriteClientInterface
+  elementsSource?: ReadOnlyElementsSource
 }): Promise<void> => {
-  const resolvedChange = await resolveChangeElement(contextChange, getLookUpName)
+  const resolvedChange = await resolveChangeElement(
+    contextChange,
+    getLookUpName,
+    resolveValues,
+    elementsSource,
+  )
   if (!isModificationChange(resolvedChange)) {
     // In create the issue types and projects ids are created
     // with the same request the context is created with

--- a/packages/jira-adapter/src/filters/project.ts
+++ b/packages/jira-adapter/src/filters/project.ts
@@ -23,6 +23,7 @@ import { defaultDeployChange, deployChanges } from '../deployment/standard_deplo
 import { getLookUpName } from '../reference_mapping'
 import { FilterCreator } from '../filter'
 import { findObject, setFieldDeploymentAnnotations } from '../utils'
+import { PROJECT_CONTEXTS_FIELD } from './fields/contexts_projects_filter'
 
 const PROJECT_TYPE_NAME = 'Project'
 
@@ -167,6 +168,7 @@ const filter: FilterCreator = ({ config, client }) => ({
       setFieldDeploymentAnnotations(projectType, FIELD_CONFIG_SCHEME_FIELD)
       setFieldDeploymentAnnotations(projectType, ISSUE_TYPE_SCHEME)
       setFieldDeploymentAnnotations(projectType, COMPONENTS_FIELD)
+      setFieldDeploymentAnnotations(projectType, PROJECT_CONTEXTS_FIELD)
     }
 
     elements
@@ -209,14 +211,18 @@ const filter: FilterCreator = ({ config, client }) => ({
             client,
             apiDefinitions: config.apiDefinitions,
             fieldsToIgnore: isModificationChange(change)
-              ? [COMPONENTS_FIELD,
+              ? [
+                COMPONENTS_FIELD,
                 WORKFLOW_SCHEME_FIELD,
                 ISSUE_TYPE_SCREEN_SCHEME_FIELD,
                 FIELD_CONFIG_SCHEME_FIELD,
-                ISSUE_TYPE_SCHEME]
+                ISSUE_TYPE_SCHEME,
+                PROJECT_CONTEXTS_FIELD,
+              ]
               : [
                 COMPONENTS_FIELD,
                 FIELD_CONFIG_SCHEME_FIELD,
+                PROJECT_CONTEXTS_FIELD,
               ],
           })
         } catch (error) {

--- a/packages/jira-adapter/test/change_validators/global_project_contexts.test.ts
+++ b/packages/jira-adapter/test/change_validators/global_project_contexts.test.ts
@@ -98,8 +98,8 @@ describe('globalProjectContextsValidator', () => {
         elemID: projectInstance.elemID,
         severity: 'Error',
         message: 'Cannot remove field context from a project',
-        detailedMessage: `A field context which is not global must be referenced by at least one project. The deployment of ${projectInstance.elemID.getFullName()} will results the following contexts to have no references: ${contextInstance.elemID.getFullName()} and therefore the project cannot be deployed.
-To solve this either modify the project to keep a reference to these contexts, or remove the contexts from the workspace`,
+        detailedMessage: `A field context which is not global must be referenced by at least one project. The deployment of jira.Project.instance.instance will result in the following contexts having no references: jira.CustomFieldContext.instance.instance. Therefore, the project cannot be deployed.
+To solve this, either modify the project to keep a reference to these contexts, or remove the contexts from the workspace`,
       },
     ])
   })

--- a/packages/jira-adapter/test/change_validators/global_project_contexts.test.ts
+++ b/packages/jira-adapter/test/change_validators/global_project_contexts.test.ts
@@ -1,0 +1,132 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, ElemID, ReadOnlyElementsSource, InstanceElement, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { FIELD_CONTEXT_TYPE_NAME } from '../../src/filters/fields/constants'
+import { PROJECT_CONTEXTS_FIELD } from '../../src/filters/fields/contexts_projects_filter'
+import { globalProjectContextsValidator } from '../../src/change_validators/global_project_contexts'
+import { JIRA, PROJECT_TYPE } from '../../src/constants'
+
+describe('globalProjectContextsValidator', () => {
+  let projectType: ObjectType
+  let contextType: ObjectType
+  let elementsSource: ReadOnlyElementsSource
+  let elements: InstanceElement[]
+  let projectInstance: InstanceElement
+  let contextInstance: InstanceElement
+
+  beforeEach(() => {
+    contextType = new ObjectType({ elemID: new ElemID(JIRA, FIELD_CONTEXT_TYPE_NAME) })
+    projectType = new ObjectType({ elemID: new ElemID(JIRA, PROJECT_TYPE) })
+
+    contextInstance = new InstanceElement(
+      'instance',
+      contextType,
+    )
+
+    projectInstance = new InstanceElement(
+      'instance',
+      projectType,
+    )
+
+    elements = [contextInstance, projectInstance]
+    elementsSource = buildElementsSourceFromElements(elements)
+  })
+
+  it('should return an error when setting a context that is used in a project to be global', async () => {
+    projectInstance.value[PROJECT_CONTEXTS_FIELD] = [
+      new ReferenceExpression(contextInstance.elemID, contextInstance),
+    ]
+
+    contextInstance.value.isGlobalContext = true
+
+    expect(await globalProjectContextsValidator(
+      [toChange({ after: contextInstance })],
+      elementsSource
+    )).toEqual([
+      {
+        elemID: contextInstance.elemID,
+        severity: 'Error',
+        message: 'Global context cannot be used in individual projects',
+        detailedMessage: `The context ${contextInstance.elemID.getFullName()} is set as global context, and therefore cannot be referenced from individual projects.`,
+      },
+    ])
+  })
+
+  it('should return and error when creating a non global context without references', async () => {
+    expect(await globalProjectContextsValidator(
+      [toChange({ after: contextInstance })],
+      elementsSource
+    )).toEqual([
+      {
+        elemID: contextInstance.elemID,
+        severity: 'Error',
+        message: 'Field context is not used in any project',
+        detailedMessage: `The context ${contextInstance.elemID.getFullName()} is not used by any project and it is not a global context, so it cannot be created.`,
+      },
+    ])
+  })
+
+  it('should return an error when removing last references to a context', async () => {
+    const projectBefore = projectInstance.clone()
+    projectBefore.value[PROJECT_CONTEXTS_FIELD] = [
+      new ReferenceExpression(contextInstance.elemID, contextInstance),
+    ]
+
+    projectInstance.value[PROJECT_CONTEXTS_FIELD] = [
+      new ReferenceExpression(new ElemID(JIRA, FIELD_CONTEXT_TYPE_NAME, 'instance', 'other')),
+    ]
+
+    expect(await globalProjectContextsValidator(
+      [toChange({ before: projectBefore, after: projectInstance })],
+      elementsSource
+    )).toEqual([
+      {
+        elemID: projectInstance.elemID,
+        severity: 'Error',
+        message: 'Cannot remove field context from a project',
+        detailedMessage: `A field context which is not global must be referenced by at least one project. The deployment of ${projectInstance.elemID.getFullName()} will results the following contexts to have no references: ${contextInstance.elemID.getFullName()} and therefore the project cannot be deployed.
+To solve this either modify the project to keep a reference to these contexts, or remove the contexts from the workspace`,
+      },
+    ])
+  })
+
+  it('should not return an error when adding a reference to a context', async () => {
+    const projectBefore = projectInstance.clone()
+    projectInstance.value[PROJECT_CONTEXTS_FIELD] = [
+      new ReferenceExpression(contextInstance.elemID, contextInstance),
+    ]
+
+    expect(await globalProjectContextsValidator(
+      [toChange({ before: projectBefore, after: projectInstance })],
+      elementsSource
+    )).toEqual([])
+  })
+
+  it('should not return an error when adding a project', async () => {
+    expect(await globalProjectContextsValidator(
+      [toChange({ after: projectInstance })],
+      elementsSource
+    )).toEqual([])
+  })
+
+  it('should not return an error when removing a project', async () => {
+    expect(await globalProjectContextsValidator(
+      [toChange({ before: projectInstance })],
+      elementsSource
+    )).toEqual([])
+  })
+})

--- a/packages/jira-adapter/test/dependency_changers/project_contexts.test.ts
+++ b/packages/jira-adapter/test/dependency_changers/project_contexts.test.ts
@@ -1,0 +1,102 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, InstanceElement, ElemID, toChange, ReferenceExpression } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { projectContextsDependencyChanger } from '../../src/dependency_changers/project_contexts'
+import { JIRA, PROJECT_TYPE } from '../../src/constants'
+import { FIELD_CONTEXT_TYPE_NAME } from '../../src/filters/fields/constants'
+import { PROJECT_CONTEXTS_FIELD } from '../../src/filters/fields/contexts_projects_filter'
+
+describe('projectContextsDependencyChanger', () => {
+  let contextType: ObjectType
+  let projectType: ObjectType
+  let contextInstance: InstanceElement
+  let projectInstance: InstanceElement
+
+  beforeEach(() => {
+    contextType = new ObjectType({
+      elemID: new ElemID(JIRA, FIELD_CONTEXT_TYPE_NAME),
+    })
+
+    projectType = new ObjectType({
+      elemID: new ElemID(JIRA, PROJECT_TYPE),
+    })
+
+    contextInstance = new InstanceElement(
+      'inst',
+      contextType,
+    )
+
+    projectInstance = new InstanceElement(
+      'inst',
+      projectType,
+      {
+        [PROJECT_CONTEXTS_FIELD]: [
+          new ReferenceExpression(contextInstance.elemID, contextInstance),
+        ],
+      }
+    )
+  })
+
+  it('should reverse the dependency between the project and the context', async () => {
+    const inputChanges = new Map([
+      [0, toChange({ after: projectInstance })],
+      [1, toChange({ after: contextInstance })],
+    ])
+    const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([
+      [0, new Set([1])],
+    ])
+
+    const dependencyChanges = [
+      ...await projectContextsDependencyChanger(inputChanges, inputDeps),
+    ]
+    expect(dependencyChanges).toHaveLength(2)
+    expect(dependencyChanges[0].action).toEqual('remove')
+    expect(dependencyChanges[0].dependency.source).toEqual(0)
+    expect(dependencyChanges[0].dependency.target).toEqual(1)
+
+    expect(dependencyChanges[1].action).toEqual('add')
+    expect(dependencyChanges[1].dependency.source).toEqual(1)
+    expect(dependencyChanges[1].dependency.target).toEqual(0)
+  })
+
+  it('should do nothing when there is no context change', async () => {
+    const inputChanges = new Map([
+      [0, toChange({ after: projectInstance })],
+    ])
+    const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([
+      [0, new Set([1])],
+    ])
+
+    const dependencyChanges = [
+      ...await projectContextsDependencyChanger(inputChanges, inputDeps),
+    ]
+    expect(dependencyChanges).toHaveLength(0)
+  })
+
+  it('should do nothing when there are no dependencies', async () => {
+    const inputChanges = new Map([
+      [0, toChange({ after: projectInstance })],
+      [1, toChange({ after: contextInstance })],
+    ])
+    const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([])
+
+    const dependencyChanges = [
+      ...await projectContextsDependencyChanger(inputChanges, inputDeps),
+    ]
+    expect(dependencyChanges).toHaveLength(0)
+  })
+})

--- a/packages/jira-adapter/test/filters/automation/automation_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/automation/automation_deployment.test.ts
@@ -15,10 +15,10 @@
 */
 import { ElemID, InstanceElement, ObjectType, CORE_ANNOTATIONS, BuiltinTypes, Values, toChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { buildElementsSourceFromElements, safeJsonStringify } from '@salto-io/adapter-utils'
-import { filterUtils, client as clientUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { safeJsonStringify } from '@salto-io/adapter-utils'
+import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
 import { MockInterface } from '@salto-io/test-utils'
-import { mockClient } from '../../utils'
+import { getFilterParams, mockClient } from '../../utils'
 import automationDeploymentFilter from '../../../src/filters/automation/automation_deployment'
 import { getDefaultConfig, JiraConfig } from '../../../src/config/config'
 import { AUTOMATION_TYPE, JIRA } from '../../../src/constants'
@@ -40,13 +40,11 @@ describe('automationDeploymentFilter', () => {
     connection = conn
 
     config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
-    filter = automationDeploymentFilter({
+    filter = automationDeploymentFilter(getFilterParams({
       client,
       paginator,
       config,
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as filterUtils.FilterWith<'onFetch' | 'deploy'>
+    })) as filterUtils.FilterWith<'onFetch' | 'deploy'>
 
     type = new ObjectType({
       elemID: new ElemID(JIRA, AUTOMATION_TYPE),

--- a/packages/jira-adapter/test/filters/automation/automation_fetch.test.ts
+++ b/packages/jira-adapter/test/filters/automation/automation_fetch.test.ts
@@ -15,10 +15,10 @@
 */
 import { ElemID, InstanceElement, ObjectType, Element } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { buildElementsSourceFromElements, safeJsonStringify } from '@salto-io/adapter-utils'
+import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { filterUtils, client as clientUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { MockInterface } from '@salto-io/test-utils'
-import { mockClient } from '../../utils'
+import { getFilterParams, mockClient } from '../../utils'
 import automationFetchFilter from '../../../src/filters/automation/automation_fetch'
 import { getDefaultConfig, JiraConfig } from '../../../src/config/config'
 import { JIRA, PROJECT_TYPE } from '../../../src/constants'
@@ -45,13 +45,12 @@ describe('automationFetchFilter', () => {
 
     fetchQuery = elementUtils.query.createMockQuery()
 
-    filter = automationFetchFilter({
+    filter = automationFetchFilter(getFilterParams({
       client,
       paginator,
       config,
-      elementsSource: buildElementsSourceFromElements([]),
       fetchQuery,
-    }) as filterUtils.FilterWith<'onFetch'>
+    })) as filterUtils.FilterWith<'onFetch'>
 
     projectType = new ObjectType({
       elemID: new ElemID(JIRA, PROJECT_TYPE),
@@ -178,14 +177,12 @@ describe('automationFetchFilter', () => {
 
     it('should use elemIdGetter', async () => {
       const { paginator } = mockClient()
-      filter = automationFetchFilter({
+      filter = automationFetchFilter(getFilterParams({
         client,
         paginator,
         config,
-        elementsSource: buildElementsSourceFromElements([]),
         getElemIdFunc: () => new ElemID(JIRA, 'someName'),
-        fetchQuery: elementUtils.query.createMockQuery(),
-      }) as filterUtils.FilterWith<'onFetch'>
+      })) as filterUtils.FilterWith<'onFetch'>
 
       const elements = [projectInstance]
       await filter.onFetch(elements)

--- a/packages/jira-adapter/test/filters/automation/automation_name_references.test.ts
+++ b/packages/jira-adapter/test/filters/automation/automation_name_references.test.ts
@@ -14,11 +14,9 @@
 * limitations under the License.
 */
 import { InstanceElement, ObjectType, ReferenceExpression, ElemID } from '@salto-io/adapter-api'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { mockClient } from '../../utils'
+import { filterUtils } from '@salto-io/adapter-components'
+import { getFilterParams, mockClient } from '../../utils'
 import automationNameReferencesFilter from '../../../src/filters/automation/automation_name_references'
-import { getDefaultConfig } from '../../../src/config/config'
 import { createAutomationTypes } from '../../../src/filters/automation/types'
 import { JIRA } from '../../../src/constants'
 
@@ -32,13 +30,10 @@ describe('automationNameReferencesTest', () => {
   beforeEach(async () => {
     const { client, paginator } = mockClient()
 
-    filter = automationNameReferencesFilter({
+    filter = automationNameReferencesFilter(getFilterParams({
       client,
       paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    })) as typeof filter
 
     type = createAutomationTypes().automationType
 

--- a/packages/jira-adapter/test/filters/automation/automation_structure.test.ts
+++ b/packages/jira-adapter/test/filters/automation/automation_structure.test.ts
@@ -14,11 +14,9 @@
 * limitations under the License.
 */
 import { InstanceElement, ObjectType, toChange, getAllChangeData, ReferenceExpression, ElemID } from '@salto-io/adapter-api'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { mockClient } from '../../utils'
+import { filterUtils } from '@salto-io/adapter-components'
+import { getFilterParams } from '../../utils'
 import automationStructureFilter from '../../../src/filters/automation/automation_structure'
-import { getDefaultConfig } from '../../../src/config/config'
 import { createAutomationTypes } from '../../../src/filters/automation/types'
 import { JIRA } from '../../../src/constants'
 
@@ -33,15 +31,7 @@ describe('automationStructureFilter', () => {
 
 
   beforeEach(async () => {
-    const { client, paginator } = mockClient()
-
-    filter = automationStructureFilter({
-      client,
-      paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    filter = automationStructureFilter(getFilterParams()) as typeof filter
 
     type = createAutomationTypes().automationType
 

--- a/packages/jira-adapter/test/filters/avatars.test.ts
+++ b/packages/jira-adapter/test/filters/avatars.test.ts
@@ -14,27 +14,16 @@
 * limitations under the License.
 */
 import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { elements as elementUtils } from '@salto-io/adapter-components'
-import { mockClient } from '../utils'
+import { getFilterParams } from '../utils'
 import avatarsFilter from '../../src/filters/avatars'
 import { Filter } from '../../src/filter'
 import { JIRA } from '../../src/constants'
-import { getDefaultConfig } from '../../src/config/config'
 
 describe('avatarsFilter', () => {
   let filter: Filter
   let type: ObjectType
   beforeEach(async () => {
-    const { client, paginator } = mockClient()
-
-    filter = avatarsFilter({
-      client,
-      paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    })
+    filter = avatarsFilter(getFilterParams())
 
     type = new ObjectType({
       elemID: new ElemID(JIRA, 'type'),

--- a/packages/jira-adapter/test/filters/board/board.test.ts
+++ b/packages/jira-adapter/test/filters/board/board.test.ts
@@ -14,25 +14,17 @@
 * limitations under the License.
 */
 import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
-import { filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { filterUtils } from '@salto-io/adapter-components'
 import { JIRA } from '../../../src/constants'
 import boardFilter from '../../../src/filters/board/board'
-import { mockClient, getDefaultAdapterConfig } from '../../utils'
+import { getFilterParams } from '../../utils'
 
 describe('boardFilter', () => {
   let filter: filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
   let instance: InstanceElement
   let type: ObjectType
   beforeEach(async () => {
-    const { client, paginator } = mockClient()
-    filter = boardFilter({
-      client,
-      paginator,
-      config: await getDefaultAdapterConfig(),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    filter = boardFilter(getFilterParams()) as typeof filter
 
     type = new ObjectType({ elemID: new ElemID(JIRA, 'Board') })
 

--- a/packages/jira-adapter/test/filters/board/board_columns.test.ts
+++ b/packages/jira-adapter/test/filters/board/board_columns.test.ts
@@ -14,14 +14,13 @@
 * limitations under the License.
 */
 import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, ListType, ObjectType } from '@salto-io/adapter-api'
-import { filterUtils, elements as elementUtils, client as clientUtils } from '@salto-io/adapter-components'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
 import { MockInterface } from '@salto-io/test-utils'
 import _ from 'lodash'
 import { getDefaultConfig, JiraConfig } from '../../../src/config/config'
 import { BOARD_COLUMN_CONFIG_TYPE, BOARD_TYPE_NAME, JIRA } from '../../../src/constants'
 import boardColumnsFilter, { COLUMNS_CONFIG_FIELD } from '../../../src/filters/board/board_columns'
-import { mockClient } from '../../utils'
+import { getFilterParams, mockClient } from '../../utils'
 
 describe('boardColumnsFilter', () => {
   let filter: filterUtils.FilterWith<'onFetch'>
@@ -36,13 +35,11 @@ describe('boardColumnsFilter', () => {
     config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
     connection = conn
 
-    filter = boardColumnsFilter({
+    filter = boardColumnsFilter(getFilterParams({
       client,
       paginator,
       config,
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    })) as typeof filter
 
     columnConfigType = new ObjectType({
       elemID: new ElemID(JIRA, BOARD_COLUMN_CONFIG_TYPE),

--- a/packages/jira-adapter/test/filters/board/board_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/board/board_deployment.test.ts
@@ -14,8 +14,7 @@
 * limitations under the License.
 */
 import { BuiltinTypes, Change, CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
-import { filterUtils, client as clientUtils, deployment, elements as elementUtils } from '@salto-io/adapter-components'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { filterUtils, client as clientUtils, deployment } from '@salto-io/adapter-components'
 import { MockInterface } from '@salto-io/test-utils'
 import _ from 'lodash'
 import { COLUMNS_CONFIG_FIELD } from '../../../src/filters/board/board_columns'
@@ -23,7 +22,7 @@ import JiraClient, { PRIVATE_API_HEADERS } from '../../../src/client/client'
 import { getDefaultConfig, JiraConfig } from '../../../src/config/config'
 import { BOARD_LOCATION_TYPE, BOARD_TYPE_NAME, JIRA } from '../../../src/constants'
 import boardDeploymentFilter from '../../../src/filters/board/board_deployment'
-import { mockClient } from '../../utils'
+import { getFilterParams, mockClient } from '../../utils'
 
 jest.mock('@salto-io/adapter-components', () => {
   const actual = jest.requireActual('@salto-io/adapter-components')
@@ -52,13 +51,11 @@ describe('boardDeploymentFilter', () => {
 
     config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
 
-    filter = boardDeploymentFilter({
+    filter = boardDeploymentFilter(getFilterParams({
       client,
       paginator,
       config,
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    })) as typeof filter
 
     locationType = new ObjectType({
       elemID: new ElemID(JIRA, BOARD_LOCATION_TYPE),

--- a/packages/jira-adapter/test/filters/board/board_estimation.test.ts
+++ b/packages/jira-adapter/test/filters/board/board_estimation.test.ts
@@ -14,14 +14,13 @@
 * limitations under the License.
 */
 import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
-import { filterUtils, client as clientUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
 import { MockInterface } from '@salto-io/test-utils'
 import _ from 'lodash'
 import { getDefaultConfig, JiraConfig } from '../../../src/config/config'
 import { BOARD_ESTIMATION_TYPE, BOARD_TYPE_NAME, JIRA } from '../../../src/constants'
 import boardEstimationFilter from '../../../src/filters/board/board_estimation'
-import { mockClient } from '../../utils'
+import { getFilterParams, mockClient } from '../../utils'
 
 describe('boardEstimationFilter', () => {
   let filter: filterUtils.FilterWith<'onFetch'>
@@ -37,13 +36,11 @@ describe('boardEstimationFilter', () => {
 
     config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
 
-    filter = boardEstimationFilter({
+    filter = boardEstimationFilter(getFilterParams({
       client,
       paginator,
       config,
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    })) as typeof filter
 
     estimationType = new ObjectType({
       elemID: new ElemID(JIRA, BOARD_ESTIMATION_TYPE),

--- a/packages/jira-adapter/test/filters/board/board_subquery.test.ts
+++ b/packages/jira-adapter/test/filters/board/board_subquery.test.ts
@@ -14,13 +14,12 @@
 * limitations under the License.
 */
 import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
-import { filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { filterUtils } from '@salto-io/adapter-components'
 import _ from 'lodash'
 import { getDefaultConfig, JiraConfig } from '../../../src/config/config'
 import { BOARD_TYPE_NAME, JIRA } from '../../../src/constants'
 import boardSubqueryFilter from '../../../src/filters/board/board_subquery'
-import { mockClient } from '../../utils'
+import { getFilterParams, mockClient } from '../../utils'
 
 describe('boardSubqueryFilter', () => {
   let filter: filterUtils.FilterWith<'onFetch'>
@@ -33,13 +32,11 @@ describe('boardSubqueryFilter', () => {
 
     config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
 
-    filter = boardSubqueryFilter({
+    filter = boardSubqueryFilter(getFilterParams({
       client,
       paginator,
       config,
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    })) as typeof filter
 
     type = new ObjectType({
       elemID: new ElemID(JIRA, BOARD_TYPE_NAME),

--- a/packages/jira-adapter/test/filters/dashboard/dashboard_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/dashboard/dashboard_deployment.test.ts
@@ -15,10 +15,10 @@
 */
 import { BuiltinTypes, Change, CORE_ANNOTATIONS, ElemID, getChangeData, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { buildElementsSourceFromElements, resolveChangeElement } from '@salto-io/adapter-utils'
-import { deployment, filterUtils, client as clientUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { resolveChangeElement } from '@salto-io/adapter-utils'
+import { deployment, filterUtils, client as clientUtils } from '@salto-io/adapter-components'
 import { MockInterface } from '@salto-io/test-utils'
-import { mockClient } from '../../utils'
+import { getFilterParams, mockClient } from '../../utils'
 import dashboardDeploymentFilter from '../../../src/filters/dashboard/dashboard_deployment'
 import { getDefaultConfig, JiraConfig } from '../../../src/config/config'
 import { DASHBOARD_GADGET_POSITION_TYPE, DASHBOARD_GADGET_TYPE, DASHBOARD_TYPE, JIRA } from '../../../src/constants'
@@ -51,13 +51,11 @@ describe('dashboardDeploymentFilter', () => {
     connection = conn
 
     config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
-    filter = dashboardDeploymentFilter({
+    filter = dashboardDeploymentFilter(getFilterParams({
       client,
       paginator,
       config,
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as filterUtils.FilterWith<'onFetch' | 'deploy'>
+    })) as filterUtils.FilterWith<'onFetch' | 'deploy'>
 
     dashboardType = new ObjectType({
       elemID: new ElemID(JIRA, DASHBOARD_TYPE),

--- a/packages/jira-adapter/test/filters/dashboard/dashboard_layout.test.ts
+++ b/packages/jira-adapter/test/filters/dashboard/dashboard_layout.test.ts
@@ -15,10 +15,9 @@
 */
 import { BuiltinTypes, ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { filterUtils, client as clientUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
 import { MockInterface } from '@salto-io/test-utils'
-import { mockClient } from '../../utils'
+import { getFilterParams, mockClient } from '../../utils'
 import dashboardLayoutFilter from '../../../src/filters/dashboard/dashboard_layout'
 import { getDefaultConfig, JiraConfig } from '../../../src/config/config'
 import { DASHBOARD_TYPE, JIRA } from '../../../src/constants'
@@ -40,13 +39,11 @@ describe('dashboardLayoutFilter', () => {
     connection = conn
 
     config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
-    filter = dashboardLayoutFilter({
+    filter = dashboardLayoutFilter(getFilterParams({
       client,
       paginator,
       config,
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as filterUtils.FilterWith<'onFetch'>
+    })) as filterUtils.FilterWith<'onFetch'>
 
     dashboardType = new ObjectType({
       elemID: new ElemID(JIRA, DASHBOARD_TYPE),

--- a/packages/jira-adapter/test/filters/dashboard/gadget.test.ts
+++ b/packages/jira-adapter/test/filters/dashboard/gadget.test.ts
@@ -15,10 +15,10 @@
 */
 import { BuiltinTypes, Change, CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { buildElementsSourceFromElements, resolveChangeElement } from '@salto-io/adapter-utils'
-import { deployment, filterUtils, client as clientUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { resolveChangeElement } from '@salto-io/adapter-utils'
+import { deployment, filterUtils, client as clientUtils } from '@salto-io/adapter-components'
 import { MockInterface } from '@salto-io/test-utils'
-import { mockClient } from '../../utils'
+import { getFilterParams, mockClient } from '../../utils'
 import gadgetFilter from '../../../src/filters/dashboard/gadget'
 import { getDefaultConfig, JiraConfig } from '../../../src/config/config'
 import { DASHBOARD_GADGET_TYPE, DASHBOARD_TYPE, JIRA } from '../../../src/constants'
@@ -53,13 +53,11 @@ describe('gadgetFilter', () => {
     connection = conn
 
     config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
-    filter = gadgetFilter({
+    filter = gadgetFilter(getFilterParams({
       client,
       paginator,
       config,
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as filterUtils.FilterWith<'onFetch' | 'deploy'>
+    })) as filterUtils.FilterWith<'onFetch' | 'deploy'>
 
     dashboardGadgetType = new ObjectType({
       elemID: new ElemID(JIRA, DASHBOARD_GADGET_TYPE),

--- a/packages/jira-adapter/test/filters/duplicate_ids.test.ts
+++ b/packages/jira-adapter/test/filters/duplicate_ids.test.ts
@@ -14,10 +14,8 @@
 * limitations under the License.
 */
 import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
-import { elements as elementUtils } from '@salto-io/adapter-components'
 import _ from 'lodash'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { mockClient } from '../utils'
+import { getFilterParams } from '../utils'
 import duplicateIdsFilter from '../../src/filters/duplicate_ids'
 import { Filter } from '../../src/filter'
 import { getDefaultConfig, JiraConfig } from '../../src/config/config'
@@ -28,19 +26,13 @@ describe('duplicateIdsFilter', () => {
   let type: ObjectType
   let config: JiraConfig
   beforeEach(async () => {
-    const { client, paginator } = mockClient()
-
     config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
 
     config.fetch.fallbackToInternalId = true
 
-    filter = duplicateIdsFilter({
-      client,
-      paginator,
+    filter = duplicateIdsFilter(getFilterParams({
       config,
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    })
+    }))
 
     type = new ObjectType({
       elemID: new ElemID(JIRA, STATUS_TYPE_NAME),

--- a/packages/jira-adapter/test/filters/field_configuration/field_configuration.test.ts
+++ b/packages/jira-adapter/test/filters/field_configuration/field_configuration.test.ts
@@ -14,12 +14,10 @@
 * limitations under the License.
 */
 import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, ListType, ObjectType } from '@salto-io/adapter-api'
-import { filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { getDefaultConfig } from '../../../src/config/config'
+import { filterUtils } from '@salto-io/adapter-components'
 import { JIRA } from '../../../src/constants'
 import fieldConfigurationFilter from '../../../src/filters/field_configuration/field_configuration'
-import { mockClient } from '../../utils'
+import { getFilterParams } from '../../utils'
 
 describe('fieldConfigurationFilter', () => {
   let filter: filterUtils.FilterWith<'onFetch' | 'deploy'>
@@ -27,15 +25,7 @@ describe('fieldConfigurationFilter', () => {
   let fieldConfigurationItemType: ObjectType
 
   beforeEach(async () => {
-    const { client, paginator } = mockClient()
-
-    filter = fieldConfigurationFilter({
-      client,
-      paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    filter = fieldConfigurationFilter(getFilterParams()) as typeof filter
 
     fieldConfigurationItemType = new ObjectType({
       elemID: new ElemID(JIRA, 'FieldConfigurationItem'),

--- a/packages/jira-adapter/test/filters/field_configuration/field_configuration_dependencies.test.ts
+++ b/packages/jira-adapter/test/filters/field_configuration/field_configuration_dependencies.test.ts
@@ -14,12 +14,10 @@
 * limitations under the License.
 */
 import { CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
-import { filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { getDefaultConfig } from '../../../src/config/config'
+import { filterUtils } from '@salto-io/adapter-components'
 import { FIELD_CONFIGURATION_ITEM_TYPE_NAME, FIELD_CONFIGURATION_TYPE_NAME, JIRA, PROJECT_TYPE } from '../../../src/constants'
 import fieldConfigurationDependenciesFilter from '../../../src/filters/field_configuration/field_configuration_dependencies'
-import { mockClient } from '../../utils'
+import { getFilterParams } from '../../utils'
 import { FIELD_TYPE_NAME } from '../../../src/filters/fields/constants'
 
 describe('fieldConfigurationItemsFilter', () => {
@@ -38,15 +36,7 @@ describe('fieldConfigurationItemsFilter', () => {
   let fieldInstance: InstanceElement
 
   beforeEach(async () => {
-    const { client, paginator } = mockClient()
-
-    filter = fieldConfigurationDependenciesFilter({
-      client,
-      paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    filter = fieldConfigurationDependenciesFilter(getFilterParams()) as typeof filter
 
     projectType = new ObjectType({
       elemID: new ElemID(JIRA, PROJECT_TYPE),

--- a/packages/jira-adapter/test/filters/field_configuration/field_configuration_irrelevant_fields.test.ts
+++ b/packages/jira-adapter/test/filters/field_configuration/field_configuration_irrelevant_fields.test.ts
@@ -15,12 +15,10 @@
 */
 import { ElemID, InstanceElement, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
 import { filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { FIELD_TYPE_NAME } from '../../../src/filters/fields/constants'
-import { getDefaultConfig } from '../../../src/config/config'
 import { JIRA } from '../../../src/constants'
 import fieldConfigurationIrrelevantFields from '../../../src/filters/field_configuration/field_configuration_irrelevant_fields'
-import { mockClient } from '../../utils'
+import { getFilterParams } from '../../utils'
 
 
 describe('fieldConfigurationIrrelevantFields', () => {
@@ -29,15 +27,7 @@ describe('fieldConfigurationIrrelevantFields', () => {
   let fieldInstance: InstanceElement
 
   beforeEach(async () => {
-    const { client, paginator } = mockClient()
-
-    filter = fieldConfigurationIrrelevantFields({
-      client,
-      paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    filter = fieldConfigurationIrrelevantFields(getFilterParams()) as typeof filter
 
 
     fieldConfigurationType = new ObjectType({
@@ -99,17 +89,12 @@ describe('fieldConfigurationIrrelevantFields', () => {
     })
 
     it('should do nothing of fields are not fetched', async () => {
-      const { client, paginator } = mockClient()
       const query = elementUtils.query.createMockQuery()
       query.isTypeMatch.mockImplementation(typeName => typeName !== FIELD_TYPE_NAME)
 
-      filter = fieldConfigurationIrrelevantFields({
-        client,
-        paginator,
-        config: getDefaultConfig({ isDataCenter: false }),
-        elementsSource: buildElementsSourceFromElements([]),
+      filter = fieldConfigurationIrrelevantFields(getFilterParams({
         fetchQuery: query,
-      }) as typeof filter
+      })) as typeof filter
 
       const instance = new InstanceElement(
         'instance',

--- a/packages/jira-adapter/test/filters/field_configuration/field_configuration_items.test.ts
+++ b/packages/jira-adapter/test/filters/field_configuration/field_configuration_items.test.ts
@@ -14,14 +14,12 @@
 * limitations under the License.
 */
 import { Change, CORE_ANNOTATIONS, ElemID, getChangeData, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
-import { filterUtils, client as clientUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
 import { MockInterface } from '@salto-io/test-utils'
 import _ from 'lodash'
-import { getDefaultConfig } from '../../../src/config/config'
 import { FIELD_CONFIGURATION_ITEM_TYPE_NAME, FIELD_CONFIGURATION_TYPE_NAME, JIRA } from '../../../src/constants'
 import fieldConfigurationItemsFilter from '../../../src/filters/field_configuration/field_configuration_items'
-import { mockClient } from '../../utils'
+import { getFilterParams, mockClient } from '../../utils'
 
 describe('fieldConfigurationItemsFilter', () => {
   let filter: filterUtils.FilterWith<'deploy'>
@@ -32,13 +30,10 @@ describe('fieldConfigurationItemsFilter', () => {
     const { client, paginator, connection } = mockClient()
     mockConnection = connection
 
-    filter = fieldConfigurationItemsFilter({
+    filter = fieldConfigurationItemsFilter(getFilterParams({
       client,
       paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    })) as typeof filter
 
     type = new ObjectType({
       elemID: new ElemID(JIRA, FIELD_CONFIGURATION_ITEM_TYPE_NAME),

--- a/packages/jira-adapter/test/filters/field_configuration/field_configuration_split.test.ts
+++ b/packages/jira-adapter/test/filters/field_configuration/field_configuration_split.test.ts
@@ -14,12 +14,10 @@
 * limitations under the License.
 */
 import { CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
-import { filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { getDefaultConfig } from '../../../src/config/config'
+import { filterUtils } from '@salto-io/adapter-components'
 import { FIELD_CONFIGURATION_ITEM_TYPE_NAME, FIELD_CONFIGURATION_TYPE_NAME, JIRA } from '../../../src/constants'
 import fieldConfigurationSplitFilter from '../../../src/filters/field_configuration/field_configuration_split'
-import { mockClient } from '../../utils'
+import { getFilterParams, mockClient } from '../../utils'
 import { FIELD_TYPE_NAME } from '../../../src/filters/fields/constants'
 
 describe('fieldConfigurationItemsFilter', () => {
@@ -30,13 +28,10 @@ describe('fieldConfigurationItemsFilter', () => {
   beforeEach(async () => {
     const { client, paginator } = mockClient()
 
-    filter = fieldConfigurationSplitFilter({
+    filter = fieldConfigurationSplitFilter(getFilterParams({
       client,
       paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    })) as typeof filter
 
     fieldConfigurationItemType = new ObjectType({
       elemID: new ElemID(JIRA, FIELD_CONFIGURATION_ITEM_TYPE_NAME),

--- a/packages/jira-adapter/test/filters/field_configurations_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/field_configurations_scheme.test.ts
@@ -14,15 +14,13 @@
 * limitations under the License.
 */
 import { BuiltinTypes, Change, CORE_ANNOTATIONS, ElemID, InstanceElement, ListType, ObjectType, toChange } from '@salto-io/adapter-api'
-import { deployment, client as clientUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { deployment, client as clientUtils } from '@salto-io/adapter-components'
 import { MockInterface } from '@salto-io/test-utils'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { JIRA } from '../../src/constants'
-import { mockClient } from '../utils'
+import { mockClient, getFilterParams } from '../utils'
 import fieldConfigurationsSchemeFilter from '../../src/filters/field_configurations_scheme'
 import { Filter } from '../../src/filter'
 import JiraClient from '../../src/client/client'
-import { getDefaultConfig } from '../../src/config/config'
 
 jest.mock('@salto-io/adapter-components', () => {
   const actual = jest.requireActual('@salto-io/adapter-components')
@@ -44,13 +42,7 @@ describe('field_configurations_scheme', () => {
     const { client, paginator, connection } = mockClient()
     mockConnection = connection
 
-    filter = fieldConfigurationsSchemeFilter({
-      client,
-      paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    })
+    filter = fieldConfigurationsSchemeFilter(getFilterParams({ client, paginator }))
 
     fieldConfigIssueTypeItemType = new ObjectType({
       elemID: new ElemID(JIRA, 'FieldConfigurationIssueTypeItem'),

--- a/packages/jira-adapter/test/filters/fields/context_references_filter.test.ts
+++ b/packages/jira-adapter/test/filters/fields/context_references_filter.test.ts
@@ -14,10 +14,8 @@
 * limitations under the License.
 */
 import { CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, ReferenceExpression, Values } from '@salto-io/adapter-api'
-import { filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { mockClient } from '../../utils'
-import { getDefaultConfig } from '../../../src/config/config'
+import { filterUtils } from '@salto-io/adapter-components'
+import { getFilterParams } from '../../utils'
 import { JIRA } from '../../../src/constants'
 import contextReferencesFilter from '../../../src/filters/fields/context_references_filter'
 
@@ -26,14 +24,7 @@ describe('context_references_filter', () => {
   let fieldType: ObjectType
   let fieldContextType: ObjectType
   beforeEach(() => {
-    const { client, paginator } = mockClient()
-    filter = contextReferencesFilter({
-      client,
-      paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    filter = contextReferencesFilter(getFilterParams()) as typeof filter
 
     fieldType = new ObjectType({ elemID: new ElemID(JIRA, 'Field') })
     fieldContextType = new ObjectType({ elemID: new ElemID(JIRA, 'CustomFieldContext') })

--- a/packages/jira-adapter/test/filters/fields/contexts.test.ts
+++ b/packages/jira-adapter/test/filters/fields/contexts.test.ts
@@ -14,9 +14,9 @@
 * limitations under the License.
 */
 import { CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
-import { deployment, filterUtils, client as clientUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { buildElementsSourceFromElements, resolveChangeElement } from '@salto-io/adapter-utils'
-import { mockClient } from '../../utils'
+import { deployment, filterUtils, client as clientUtils } from '@salto-io/adapter-components'
+import { resolveChangeElement } from '@salto-io/adapter-utils'
+import { getFilterParams, mockClient } from '../../utils'
 import { getDefaultConfig } from '../../../src/config/config'
 import { JIRA } from '../../../src/constants'
 import fieldsDeploymentFilter from '../../../src/filters/fields/field_deployment_filter'
@@ -54,13 +54,10 @@ describe('deployContextChange', () => {
     client = mockCli.client
     paginator = mockCli.paginator
 
-    filter = fieldsDeploymentFilter({
+    filter = fieldsDeploymentFilter(getFilterParams({
       client,
       paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    })) as typeof filter
 
     contextType = new ObjectType({
       elemID: new ElemID(JIRA, FIELD_CONTEXT_TYPE_NAME),

--- a/packages/jira-adapter/test/filters/fields/contexts.test.ts
+++ b/packages/jira-adapter/test/filters/fields/contexts.test.ts
@@ -120,6 +120,7 @@ describe('deployContextChange', () => {
       [
         'defaultValue',
         'options',
+        'isGlobalContext',
         'issueTypeIds',
         'projectIds',
       ],
@@ -211,8 +212,11 @@ describe('deployContextChange', () => {
       })
     })
 
+
+    const instanceBefore = instance.clone()
+    instanceBefore.value.description = 'desc'
     const change = toChange({
-      before: instance,
+      before: instanceBefore,
       after: instance,
     })
     await expect(

--- a/packages/jira-adapter/test/filters/fields/contexts_projects_filter.test.ts
+++ b/packages/jira-adapter/test/filters/fields/contexts_projects_filter.test.ts
@@ -1,0 +1,154 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, getChangeData, InstanceElement, ObjectType, ReadOnlyElementsSource, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { mockClient } from '../../utils'
+import { JIRA, PROJECT_TYPE } from '../../../src/constants'
+import { FIELD_CONTEXT_TYPE_NAME } from '../../../src/filters/fields/constants'
+import contextsProjectsFilter, { PROJECT_CONTEXTS_FIELD } from '../../../src/filters/fields/contexts_projects_filter'
+import { getDefaultConfig } from '../../../src/config/config'
+
+describe('contexts_projects_filter', () => {
+  let filter: filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
+  let contextType: ObjectType
+  let projectType: ObjectType
+  let projectInstance: InstanceElement
+  let contextInstance: InstanceElement
+  let otherProject: InstanceElement
+
+  let elementsSource: ReadOnlyElementsSource
+
+  beforeEach(() => {
+    const { client, paginator } = mockClient()
+
+    contextType = new ObjectType({
+      elemID: new ElemID(JIRA, FIELD_CONTEXT_TYPE_NAME),
+    })
+
+    projectType = new ObjectType({
+      elemID: new ElemID(JIRA, PROJECT_TYPE),
+    })
+
+    contextInstance = new InstanceElement(
+      'inst',
+      contextType,
+      {
+        id: 1,
+      }
+    )
+
+    projectInstance = new InstanceElement(
+      'instance',
+      projectType,
+      {
+        [PROJECT_CONTEXTS_FIELD]: [
+          new ReferenceExpression(contextInstance.elemID, contextInstance),
+        ],
+      }
+    )
+
+    otherProject = new InstanceElement(
+      'otherProject',
+      projectType,
+      {
+        [PROJECT_CONTEXTS_FIELD]: [
+          new ReferenceExpression(contextInstance.elemID, contextInstance),
+        ],
+      }
+    )
+
+    elementsSource = buildElementsSourceFromElements([
+      contextInstance,
+      projectInstance,
+      otherProject,
+    ])
+
+    filter = contextsProjectsFilter({
+      client,
+      paginator,
+      config: getDefaultConfig({ isDataCenter: true }),
+      elementsSource,
+      fetchQuery: elementUtils.query.createMockQuery(),
+    }) as typeof filter
+  })
+
+  describe('onFetch', () => {
+    it('should add the contexts to the projects', async () => {
+      delete projectInstance.value[PROJECT_CONTEXTS_FIELD]
+      contextInstance.value.projectIds = [
+        new ReferenceExpression(projectInstance.elemID, projectInstance),
+      ]
+
+      await filter.onFetch([projectInstance, contextInstance])
+
+      expect(projectInstance.value[PROJECT_CONTEXTS_FIELD]).toHaveLength(1)
+      expect(projectInstance.value[PROJECT_CONTEXTS_FIELD][0]).toBeInstanceOf(ReferenceExpression)
+      expect(projectInstance.value[PROJECT_CONTEXTS_FIELD][0].elemID)
+        .toEqual(contextInstance.elemID)
+
+      expect(contextInstance.value.projectIds).toBeUndefined()
+    })
+  })
+
+  describe('preDeploy', () => {
+    it('should add the changes for the contexts on project addition', async () => {
+      const changes = [toChange({ after: projectInstance })]
+      await filter.preDeploy(changes)
+
+      expect(changes).toHaveLength(2)
+      expect(getChangeData(changes[1]).value.projectIds[0].elemID)
+        .toEqual(otherProject.elemID)
+      expect(getChangeData(changes[1]).value.projectIds[1].elemID)
+        .toEqual(projectInstance.elemID)
+    })
+
+    it('should add the changes for the contexts on project removal', async () => {
+      const changes = [toChange({ before: projectInstance })]
+      await filter.preDeploy(changes)
+
+      expect(changes).toHaveLength(2)
+      expect(getChangeData(changes[1]).value.projectIds[0].elemID)
+        .toEqual(otherProject.elemID)
+    })
+
+    it('should add projectIds to addition contexts', async () => {
+      delete contextInstance.value.id
+      const changes = [
+        toChange({ after: projectInstance }),
+        toChange({ after: contextInstance }),
+      ]
+      await filter.preDeploy(changes)
+
+      expect(changes).toHaveLength(2)
+      expect(getChangeData(changes[1]).value.projectIds[0].elemID)
+        .toEqual(otherProject.elemID)
+    })
+  })
+
+  describe('onDeploy', () => {
+    it('should add the changes for the contexts', async () => {
+      contextInstance.value.projectIds = [
+        new ReferenceExpression(projectInstance.elemID, projectInstance),
+      ]
+
+      const changes = [toChange({ after: contextInstance })]
+      await filter.onDeploy(changes)
+
+      expect(contextInstance.value.projectIds).toBeUndefined()
+    })
+  })
+})

--- a/packages/jira-adapter/test/filters/fields/contexts_projects_filter.test.ts
+++ b/packages/jira-adapter/test/filters/fields/contexts_projects_filter.test.ts
@@ -14,13 +14,12 @@
 * limitations under the License.
 */
 import { ElemID, getChangeData, InstanceElement, ObjectType, ReadOnlyElementsSource, ReferenceExpression, toChange } from '@salto-io/adapter-api'
-import { filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { filterUtils } from '@salto-io/adapter-components'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { mockClient } from '../../utils'
+import { getFilterParams, mockClient } from '../../utils'
 import { JIRA, PROJECT_TYPE } from '../../../src/constants'
 import { FIELD_CONTEXT_TYPE_NAME } from '../../../src/filters/fields/constants'
 import contextsProjectsFilter, { PROJECT_CONTEXTS_FIELD } from '../../../src/filters/fields/contexts_projects_filter'
-import { getDefaultConfig } from '../../../src/config/config'
 
 describe('contexts_projects_filter', () => {
   let filter: filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
@@ -77,13 +76,11 @@ describe('contexts_projects_filter', () => {
       otherProject,
     ])
 
-    filter = contextsProjectsFilter({
+    filter = contextsProjectsFilter(getFilterParams({
       client,
       paginator,
-      config: getDefaultConfig({ isDataCenter: true }),
       elementsSource,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    })) as typeof filter
   })
 
   describe('onFetch', () => {

--- a/packages/jira-adapter/test/filters/fields/field_context_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_context_deployment.test.ts
@@ -14,9 +14,8 @@
 * limitations under the License.
 */
 import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, ListType, MapType, ObjectType, toChange } from '@salto-io/adapter-api'
-import { filterUtils, client as clientUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { mockClient } from '../../utils'
+import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
+import { getFilterParams, mockClient } from '../../utils'
 import { getDefaultConfig } from '../../../src/config/config'
 import { JIRA } from '../../../src/constants'
 import contextDeploymentFilter from '../../../src/filters/fields/context_deployment_filter'
@@ -43,13 +42,10 @@ describe('fieldContextDeployment', () => {
     client = mockCli.client
     paginator = mockCli.paginator
 
-    filter = contextDeploymentFilter({
+    filter = contextDeploymentFilter(getFilterParams({
       client,
       paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    })) as typeof filter
 
     optionType = new ObjectType({
       elemID: new ElemID(JIRA, 'CustomFieldContextOption'),

--- a/packages/jira-adapter/test/filters/fields/field_context_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_context_deployment.test.ts
@@ -95,11 +95,6 @@ describe('fieldContextDeployment', () => {
         [CORE_ANNOTATIONS.UPDATABLE]: true,
       })
 
-      expect(contextType.fields.projectIds.annotations).toEqual({
-        [CORE_ANNOTATIONS.CREATABLE]: true,
-        [CORE_ANNOTATIONS.UPDATABLE]: true,
-      })
-
       expect(contextType.fields.issueTypeIds.annotations).toEqual({
         [CORE_ANNOTATIONS.CREATABLE]: true,
         [CORE_ANNOTATIONS.UPDATABLE]: true,
@@ -154,6 +149,7 @@ describe('fieldContextDeployment', () => {
       change,
       client,
       getDefaultConfig({ isDataCenter: false }).apiDefinitions,
+      expect.anything(),
     )
   })
 })

--- a/packages/jira-adapter/test/filters/fields/field_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_deployment.test.ts
@@ -14,10 +14,9 @@
 * limitations under the License.
 */
 import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, InstanceElement, ListType, MapType, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
-import { deployment, filterUtils, client as clientUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { deployment, filterUtils, client as clientUtils } from '@salto-io/adapter-components'
 import { MockInterface } from '@salto-io/test-utils'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { mockClient } from '../../utils'
+import { getFilterParams, mockClient } from '../../utils'
 import { getDefaultConfig } from '../../../src/config/config'
 import { JIRA } from '../../../src/constants'
 import fieldsDeploymentFilter from '../../../src/filters/fields/field_deployment_filter'
@@ -59,13 +58,10 @@ describe('fields_deployment', () => {
     paginator = mockCli.paginator
     mockConnection = mockCli.connection
 
-    filter = fieldsDeploymentFilter({
+    filter = fieldsDeploymentFilter(getFilterParams({
       client,
       paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    })) as typeof filter
 
     contextType = new ObjectType({
       elemID: new ElemID(JIRA, FIELD_CONTEXT_TYPE_NAME),

--- a/packages/jira-adapter/test/filters/fields/field_name_filter.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_name_filter.test.ts
@@ -14,11 +14,10 @@
 * limitations under the License.
 */
 import { ElemID, ElemIdGetter, InstanceElement, ObjectType } from '@salto-io/adapter-api'
-import { filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { filterUtils } from '@salto-io/adapter-components'
 import { mockFunction } from '@salto-io/test-utils'
 import _ from 'lodash'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { mockClient } from '../../utils'
+import { getFilterParams, mockClient } from '../../utils'
 import { getDefaultConfig, JiraConfig } from '../../../src/config/config'
 import { JIRA } from '../../../src/constants'
 import fieldNameFilter from '../../../src/filters/fields/field_name_filter'
@@ -35,14 +34,12 @@ describe('field_name_filter', () => {
     config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
 
     const { client, paginator } = mockClient()
-    filter = fieldNameFilter({
+    filter = fieldNameFilter(getFilterParams({
       client,
       paginator,
       config,
       getElemIdFunc: elemIdGetter,
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    })) as typeof filter
 
     fieldType = new ObjectType({
       elemID: new ElemID(JIRA, 'Field'),
@@ -168,13 +165,11 @@ describe('field_name_filter', () => {
 
   it('should use the default name when elemIdGetter was not passed', async () => {
     const { client, paginator } = mockClient()
-    filter = fieldNameFilter({
+    filter = fieldNameFilter(getFilterParams({
       client,
       paginator,
       config,
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    })) as typeof filter
 
     const custom = new InstanceElement(
       'custom',

--- a/packages/jira-adapter/test/filters/fields/field_structure.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_structure.test.ts
@@ -14,10 +14,8 @@
 * limitations under the License.
 */
 import { BuiltinTypes, ElemID, Field, InstanceElement, ObjectType } from '@salto-io/adapter-api'
-import { filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { mockClient } from '../../utils'
-import { getDefaultConfig } from '../../../src/config/config'
+import { filterUtils } from '@salto-io/adapter-components'
+import { getFilterParams, mockClient } from '../../utils'
 import { JIRA } from '../../../src/constants'
 import fieldsStructureFilter from '../../../src/filters/fields/field_structure_filter'
 
@@ -29,13 +27,10 @@ describe('fields_structure', () => {
   let fieldContextOptionType: ObjectType
   beforeEach(() => {
     const { client, paginator } = mockClient()
-    filter = fieldsStructureFilter({
+    filter = fieldsStructureFilter(getFilterParams({
       client,
       paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    })) as typeof filter
 
     fieldType = new ObjectType({
       elemID: new ElemID(JIRA, 'Field'),
@@ -193,14 +188,11 @@ describe('fields_structure', () => {
 
   it('should use elemIdGetter when extracting the contexts', async () => {
     const { client, paginator } = mockClient()
-    filter = fieldsStructureFilter({
+    filter = fieldsStructureFilter(getFilterParams({
       client,
       paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
       getElemIdFunc: () => new ElemID(JIRA, 'customName'),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    })) as typeof filter
 
     const instance = new InstanceElement(
       'instance',

--- a/packages/jira-adapter/test/filters/fields/field_type_references.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_type_references.test.ts
@@ -14,10 +14,8 @@
 * limitations under the License.
 */
 import { ElemID, InstanceElement, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
-import { filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { mockClient } from '../../utils'
-import { getDefaultConfig } from '../../../src/config/config'
+import { filterUtils } from '@salto-io/adapter-components'
+import { getFilterParams } from '../../utils'
 import { JIRA } from '../../../src/constants'
 import fieldsTypeReferencesFilter, { getFieldsLookUpName } from '../../../src/filters/fields/field_type_references_filter'
 import { FIELD_CONTEXT_TYPE_NAME } from '../../../src/filters/fields/constants'
@@ -26,14 +24,7 @@ describe('fields_references', () => {
   let filter: filterUtils.FilterWith<'onFetch'>
   let fieldContextType: ObjectType
   beforeEach(() => {
-    const { client, paginator } = mockClient()
-    filter = fieldsTypeReferencesFilter({
-      client,
-      paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    filter = fieldsTypeReferencesFilter(getFilterParams()) as typeof filter
 
     fieldContextType = new ObjectType({
       elemID: new ElemID(JIRA, FIELD_CONTEXT_TYPE_NAME),

--- a/packages/jira-adapter/test/filters/forbidden_permission_schemes.test.ts
+++ b/packages/jira-adapter/test/filters/forbidden_permission_schemes.test.ts
@@ -14,12 +14,10 @@
 * limitations under the License.
 */
 import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
-import { filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { getDefaultConfig } from '../../src/config/config'
+import { filterUtils } from '@salto-io/adapter-components'
 import { JIRA } from '../../src/constants'
 import forbiddenPermissionScheme from '../../src/filters/forbidden_permission_schemes'
-import { mockClient } from '../utils'
+import { getFilterParams } from '../utils'
 
 describe('forbidden permission scheme', () => {
   let filter: filterUtils.FilterWith<'onFetch'>
@@ -44,14 +42,7 @@ describe('forbidden permission scheme', () => {
     }
   )
   beforeEach(async () => {
-    const { client, paginator } = mockClient()
-    filter = forbiddenPermissionScheme({
-      client,
-      paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    filter = forbiddenPermissionScheme(getFilterParams()) as typeof filter
   })
   it('should remove permissions from instances', async () => {
     await filter.onFetch([instance])

--- a/packages/jira-adapter/test/filters/hidden_value_in_lists.test.ts
+++ b/packages/jira-adapter/test/filters/hidden_value_in_lists.test.ts
@@ -14,24 +14,16 @@
 * limitations under the License.
 */
 import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, InstanceElement, ListType, ObjectType } from '@salto-io/adapter-api'
-import { filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { filterUtils } from '@salto-io/adapter-components'
 import { JIRA } from '../../src/constants'
 import hiddenValueInListsFilter from '../../src/filters/hidden_value_in_lists'
-import { mockClient, getDefaultAdapterConfig } from '../utils'
+import { getFilterParams } from '../utils'
 
 describe('hiddenValueInListsFilter', () => {
   let filter: filterUtils.FilterWith<'onFetch'>
   let instance: InstanceElement
   beforeEach(async () => {
-    const { client, paginator } = mockClient()
-    filter = hiddenValueInListsFilter({
-      client,
-      paginator,
-      config: await getDefaultAdapterConfig(),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    filter = hiddenValueInListsFilter(getFilterParams()) as typeof filter
 
     const type = new ObjectType({
       elemID: new ElemID(JIRA, 'someType'),

--- a/packages/jira-adapter/test/filters/icon_url.test.ts
+++ b/packages/jira-adapter/test/filters/icon_url.test.ts
@@ -14,27 +14,16 @@
 * limitations under the License.
 */
 import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { elements as elementUtils } from '@salto-io/adapter-components'
-import { mockClient } from '../utils'
+import { getFilterParams } from '../utils'
 import iconUrlFilter from '../../src/filters/icon_url'
 import { Filter } from '../../src/filter'
 import { JIRA, STATUS_TYPE_NAME } from '../../src/constants'
-import { getDefaultConfig } from '../../src/config/config'
 
 describe('iconUrlFilter', () => {
   let filter: Filter
   let type: ObjectType
   beforeEach(async () => {
-    const { client, paginator } = mockClient()
-
-    filter = iconUrlFilter({
-      client,
-      paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    })
+    filter = iconUrlFilter(getFilterParams())
 
     type = new ObjectType({
       elemID: new ElemID(JIRA, STATUS_TYPE_NAME),

--- a/packages/jira-adapter/test/filters/issue_type_schemas/issue_type_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/issue_type_schemas/issue_type_scheme.test.ts
@@ -14,15 +14,13 @@
 * limitations under the License.
 */
 import { BuiltinTypes, Change, CORE_ANNOTATIONS, ElemID, InstanceElement, ListType, ObjectType, toChange } from '@salto-io/adapter-api'
-import { deployment, client as clientUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { deployment, client as clientUtils } from '@salto-io/adapter-components'
 import { MockInterface } from '@salto-io/test-utils'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { ISSUE_TYPE_SCHEMA_NAME, JIRA } from '../../../src/constants'
-import { mockClient } from '../../utils'
+import { getFilterParams, mockClient } from '../../utils'
 import issueTypeSchemeFilter from '../../../src/filters/issue_type_schemas/issue_type_scheme'
 import { Filter } from '../../../src/filter'
 import JiraClient from '../../../src/client/client'
-import { getDefaultConfig } from '../../../src/config/config'
 
 jest.mock('@salto-io/adapter-components', () => {
   const actual = jest.requireActual('@salto-io/adapter-components')
@@ -43,13 +41,10 @@ describe('issueTypeScheme', () => {
     const { client, paginator, connection } = mockClient()
     mockConnection = connection
 
-    filter = issueTypeSchemeFilter({
+    filter = issueTypeSchemeFilter(getFilterParams({
       client,
       paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    })
+    }))
     type = new ObjectType({
       elemID: new ElemID(JIRA, ISSUE_TYPE_SCHEMA_NAME),
       fields: {

--- a/packages/jira-adapter/test/filters/issue_type_schemas/issue_type_scheme_references.test.ts
+++ b/packages/jira-adapter/test/filters/issue_type_schemas/issue_type_scheme_references.test.ts
@@ -14,10 +14,9 @@
 * limitations under the License.
 */
 import 'jest-extended'
-import { filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { filterUtils } from '@salto-io/adapter-components'
 import { Element, ElemID, ReferenceExpression } from '@salto-io/adapter-api'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { getDefaultAdapterConfig, mockClient } from '../../utils'
+import { getFilterParams, mockClient } from '../../utils'
 import issueTypeSchemeReferences from '../../../src/filters/issue_type_schemas/issue_type_scheme_references'
 import { instanceCreators } from '../../mock_elements'
 
@@ -30,13 +29,10 @@ describe('issueTypeSchemeReferences', () => {
   let runFilter: (...elements: Element[]) => Promise<Element[]>
   beforeAll(async () => {
     const { client, paginator } = mockClient()
-    const filter = issueTypeSchemeReferences({
+    const filter = issueTypeSchemeReferences(getFilterParams({
       client,
       paginator,
-      config: await getDefaultAdapterConfig(),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as filterUtils.FilterWith<'onFetch'>
+    })) as filterUtils.FilterWith<'onFetch'>
     runFilter = async (...elements: Element[]): Promise<Element[]> => {
       await filter.onFetch(elements)
       return elements

--- a/packages/jira-adapter/test/filters/issue_type_screen_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/issue_type_screen_scheme.test.ts
@@ -14,11 +14,10 @@
 * limitations under the License.
 */
 import { BuiltinTypes, Change, CORE_ANNOTATIONS, ElemID, InstanceElement, ListType, ObjectType, toChange } from '@salto-io/adapter-api'
-import { deployment, client as clientUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { deployment, client as clientUtils } from '@salto-io/adapter-components'
 import { MockInterface } from '@salto-io/test-utils'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { JIRA } from '../../src/constants'
-import { mockClient } from '../utils'
+import { getFilterParams, mockClient } from '../utils'
 import issueTypeScreenSchemeFilter from '../../src/filters/issue_type_screen_scheme'
 import { Filter } from '../../src/filter'
 import JiraClient from '../../src/client/client'
@@ -46,13 +45,10 @@ describe('issueTypeScreenScheme', () => {
     client = cli
     mockConnection = connection
 
-    filter = issueTypeScreenSchemeFilter({
+    filter = issueTypeScreenSchemeFilter(getFilterParams({
       client,
       paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    })
+    }))
     issueTypeScreenSchemeItemType = new ObjectType({
       elemID: new ElemID(JIRA, 'IssueTypeScreenSchemeItem'),
       fields: {

--- a/packages/jira-adapter/test/filters/jql/jql_references.test.ts
+++ b/packages/jira-adapter/test/filters/jql/jql_references.test.ts
@@ -14,13 +14,11 @@
 * limitations under the License.
 */
 import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { client as clientUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { client as clientUtils } from '@salto-io/adapter-components'
 import { MockInterface } from '@salto-io/test-utils'
-import { mockClient } from '../../utils'
+import { getFilterParams, mockClient } from '../../utils'
 import jqlReferencesFilter from '../../../src/filters/jql/jql_references'
 import { Filter } from '../../../src/filter'
-import { getDefaultConfig } from '../../../src/config/config'
 import { JIRA, STATUS_TYPE_NAME } from '../../../src/constants'
 import { FIELD_TYPE_NAME } from '../../../src/filters/fields/constants'
 
@@ -38,13 +36,10 @@ describe('jqlReferencesFilter', () => {
     const { client, paginator, connection: conn } = mockClient()
     connection = conn
 
-    filter = jqlReferencesFilter({
+    filter = jqlReferencesFilter(getFilterParams({
       client,
       paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    })
+    }))
 
     type = new ObjectType({
       elemID: new ElemID(JIRA, 'Filter'),

--- a/packages/jira-adapter/test/filters/masking.test.ts
+++ b/packages/jira-adapter/test/filters/masking.test.ts
@@ -14,10 +14,8 @@
 * limitations under the License.
 */
 import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import _ from 'lodash'
-import { elements as elementUtils } from '@salto-io/adapter-components'
-import { mockClient } from '../utils'
+import { getFilterParams } from '../utils'
 import maskingFilter, { MASK_VALUE } from '../../src/filters/masking'
 import { Filter } from '../../src/filter'
 import { getDefaultConfig, JiraConfig } from '../../src/config/config'
@@ -30,17 +28,9 @@ describe('maskingFilter', () => {
   let config: JiraConfig
 
   beforeEach(async () => {
-    const { client, paginator } = mockClient()
-
     config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
 
-    filter = maskingFilter({
-      client,
-      paginator,
-      config,
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    })
+    filter = maskingFilter(getFilterParams({ config }))
 
     type = new ObjectType({
       elemID: new ElemID(JIRA, AUTOMATION_TYPE),

--- a/packages/jira-adapter/test/filters/missing_descriptions.test.ts
+++ b/packages/jira-adapter/test/filters/missing_descriptions.test.ts
@@ -14,10 +14,8 @@
 * limitations under the License.
 */
 import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import _ from 'lodash'
-import { elements as elementUtils } from '@salto-io/adapter-components'
-import { mockClient } from '../utils'
+import { getFilterParams } from '../utils'
 import missingDescriptionsFilter from '../../src/filters/missing_descriptions'
 import { Filter } from '../../src/filter'
 import { getDefaultConfig, JiraConfig } from '../../src/config/config'
@@ -30,17 +28,9 @@ describe('missingDescriptionsFilter', () => {
   let config: JiraConfig
 
   beforeEach(async () => {
-    const { client, paginator } = mockClient()
-
     config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
 
-    filter = missingDescriptionsFilter({
-      client,
-      paginator,
-      config,
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    })
+    filter = missingDescriptionsFilter(getFilterParams({ config }))
 
     type = new ObjectType({
       elemID: new ElemID(JIRA, PROJECT_ROLE_TYPE),

--- a/packages/jira-adapter/test/filters/notification_scheme/notification_scheme_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/notification_scheme/notification_scheme_deployment.test.ts
@@ -15,10 +15,9 @@
 */
 import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, InstanceElement, ListType, ObjectType, toChange, Values } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { filterUtils, client as clientUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
 import { MockInterface } from '@salto-io/test-utils'
-import { mockClient } from '../../utils'
+import { getFilterParams, mockClient } from '../../utils'
 import notificationSchemeDeploymentFilter from '../../../src/filters/notification_scheme/notification_scheme_deployment'
 import { getDefaultConfig, JiraConfig } from '../../../src/config/config'
 import { JIRA, NOTIFICATION_SCHEME_TYPE_NAME, NOTIFICATION_EVENT_TYPE_NAME } from '../../../src/constants'
@@ -45,13 +44,11 @@ describe('notificationSchemeDeploymentFilter', () => {
     client = cli
 
     config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
-    filter = notificationSchemeDeploymentFilter({
+    filter = notificationSchemeDeploymentFilter(getFilterParams({
       client,
       paginator,
       config,
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as filterUtils.FilterWith<'onFetch' | 'deploy' | 'preDeploy' | 'onDeploy'>
+    })) as filterUtils.FilterWith<'onFetch' | 'deploy' | 'preDeploy' | 'onDeploy'>
 
     notificationEventType = new ObjectType({
       elemID: new ElemID(JIRA, NOTIFICATION_EVENT_TYPE_NAME),

--- a/packages/jira-adapter/test/filters/notification_scheme/notification_scheme_structure.test.ts
+++ b/packages/jira-adapter/test/filters/notification_scheme/notification_scheme_structure.test.ts
@@ -14,11 +14,9 @@
 * limitations under the License.
 */
 import { CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { mockClient } from '../../utils'
+import { filterUtils } from '@salto-io/adapter-components'
+import { getFilterParams, mockClient } from '../../utils'
 import notificationSchemeStructureFilter from '../../../src/filters/notification_scheme/notification_scheme_structure'
-import { getDefaultConfig } from '../../../src/config/config'
 import { JIRA, NOTIFICATION_SCHEME_TYPE_NAME } from '../../../src/constants'
 
 describe('notificationSchemeStructureFilter', () => {
@@ -29,13 +27,10 @@ describe('notificationSchemeStructureFilter', () => {
   beforeEach(async () => {
     const { client, paginator } = mockClient()
 
-    filter = notificationSchemeStructureFilter({
+    filter = notificationSchemeStructureFilter(getFilterParams({
       client,
       paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as filterUtils.FilterWith<'onFetch'>
+    })) as filterUtils.FilterWith<'onFetch'>
 
     notificationSchemeType = new ObjectType({
       elemID: new ElemID(JIRA, NOTIFICATION_SCHEME_TYPE_NAME),

--- a/packages/jira-adapter/test/filters/priority.test.ts
+++ b/packages/jira-adapter/test/filters/priority.test.ts
@@ -15,9 +15,7 @@
 */
 import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { elements as elementUtils } from '@salto-io/adapter-components'
-import { mockClient } from '../utils'
+import { getFilterParams, mockClient } from '../utils'
 import priorityFilter from '../../src/filters/priority'
 import { Filter } from '../../src/filter'
 import { getDefaultConfig, JiraConfig } from '../../src/config/config'
@@ -41,13 +39,11 @@ describe('priorityFilter', () => {
     client = cli
 
     config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
-    filter = priorityFilter({
+    filter = priorityFilter(getFilterParams({
       client,
       paginator,
       config,
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    })
+    }))
 
     type = new ObjectType({
       elemID: new ElemID(JIRA, PRIORITY_TYPE_NAME),

--- a/packages/jira-adapter/test/filters/project.test.ts
+++ b/packages/jira-adapter/test/filters/project.test.ts
@@ -22,6 +22,7 @@ import JiraClient from '../../src/client/client'
 import { JIRA } from '../../src/constants'
 import projectFilter from '../../src/filters/project'
 import { mockClient } from '../utils'
+import { PROJECT_CONTEXTS_FIELD } from '../../src/filters/fields/contexts_projects_filter'
 
 jest.mock('@salto-io/adapter-components', () => {
   const actual = jest.requireActual('@salto-io/adapter-components')
@@ -180,7 +181,7 @@ describe('projectFilter', () => {
         change,
         client,
         getDefaultConfig({ isDataCenter: false }).apiDefinitions.types.Project.deployRequests,
-        ['components', 'workflowScheme', 'issueTypeScreenScheme', 'fieldConfigurationScheme', 'issueTypeScheme'],
+        ['components', 'workflowScheme', 'issueTypeScreenScheme', 'fieldConfigurationScheme', 'issueTypeScheme', PROJECT_CONTEXTS_FIELD],
         undefined,
         undefined,
       )
@@ -226,7 +227,7 @@ describe('projectFilter', () => {
         change,
         client,
         getDefaultConfig({ isDataCenter: false }).apiDefinitions.types.Project.deployRequests,
-        ['components', 'fieldConfigurationScheme'],
+        ['components', 'fieldConfigurationScheme', PROJECT_CONTEXTS_FIELD],
         undefined,
         undefined,
       )
@@ -307,7 +308,7 @@ describe('projectFilter', () => {
         change,
         client,
         getDefaultConfig({ isDataCenter: false }).apiDefinitions.types.Project.deployRequests,
-        ['components', 'fieldConfigurationScheme'],
+        ['components', 'fieldConfigurationScheme', PROJECT_CONTEXTS_FIELD],
         undefined,
         undefined,
       )
@@ -406,7 +407,7 @@ describe('projectFilter', () => {
         change,
         client,
         getDefaultConfig({ isDataCenter: false }).apiDefinitions.types.Project.deployRequests,
-        ['components', 'fieldConfigurationScheme'],
+        ['components', 'fieldConfigurationScheme', PROJECT_CONTEXTS_FIELD],
         undefined,
         undefined,
       )

--- a/packages/jira-adapter/test/filters/project.test.ts
+++ b/packages/jira-adapter/test/filters/project.test.ts
@@ -14,14 +14,13 @@
 * limitations under the License.
 */
 import { BuiltinTypes, Change, CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
-import { filterUtils, client as clientUtils, deployment, elements as elementUtils } from '@salto-io/adapter-components'
+import { filterUtils, client as clientUtils, deployment } from '@salto-io/adapter-components'
 import { MockInterface } from '@salto-io/test-utils'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { getDefaultConfig } from '../../src/config/config'
 import JiraClient from '../../src/client/client'
 import { JIRA } from '../../src/constants'
 import projectFilter from '../../src/filters/project'
-import { mockClient } from '../utils'
+import { getFilterParams, mockClient } from '../utils'
 import { PROJECT_CONTEXTS_FIELD } from '../../src/filters/fields/contexts_projects_filter'
 
 jest.mock('@salto-io/adapter-components', () => {
@@ -52,13 +51,10 @@ describe('projectFilter', () => {
 
     deployChangeMock.mockClear()
 
-    filter = projectFilter({
+    filter = projectFilter(getFilterParams({
       client,
       paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    })) as typeof filter
 
     type = new ObjectType({
       elemID: new ElemID(JIRA, 'Project'),

--- a/packages/jira-adapter/test/filters/project_component.test.ts
+++ b/packages/jira-adapter/test/filters/project_component.test.ts
@@ -14,13 +14,11 @@
 * limitations under the License.
 */
 import { CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
-import { filterUtils, client as clientUtils, deployment, elements as elementUtils } from '@salto-io/adapter-components'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { getDefaultConfig } from '../../src/config/config'
+import { filterUtils, client as clientUtils, deployment } from '@salto-io/adapter-components'
 import JiraClient from '../../src/client/client'
 import { JIRA } from '../../src/constants'
 import projectComponentFilter from '../../src/filters/project_component'
-import { mockClient } from '../utils'
+import { getFilterParams, mockClient } from '../utils'
 
 jest.mock('@salto-io/adapter-components', () => {
   const actual = jest.requireActual('@salto-io/adapter-components')
@@ -46,13 +44,10 @@ describe('projectComponentFilter', () => {
     const { client: cli, paginator } = mockClient()
     client = cli
 
-    filter = projectComponentFilter({
+    filter = projectComponentFilter(getFilterParams({
       client,
       paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    })) as typeof filter
 
     type = new ObjectType({
       elemID: new ElemID(JIRA, 'ProjectComponent'),

--- a/packages/jira-adapter/test/filters/references_by_self_link.test.ts
+++ b/packages/jira-adapter/test/filters/references_by_self_link.test.ts
@@ -14,25 +14,15 @@
 * limitations under the License.
 */
 import { InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
-import { filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { filterUtils } from '@salto-io/adapter-components'
 import referenceBySelfLinkFilter from '../../src/filters/references_by_self_link'
 import { mockInstances, mockTypes } from '../mock_elements'
-import { mockClient, getDefaultAdapterConfig } from '../utils'
+import { getFilterParams } from '../utils'
 
 describe('referenceBySelfLinkFilter', () => {
   let filter: filterUtils.FilterWith<'onFetch'>
   beforeEach(async () => {
-    const { client, paginator } = mockClient()
-    filter = referenceBySelfLinkFilter({
-      client,
-      paginator,
-      config: {
-        ...await getDefaultAdapterConfig(),
-      },
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    filter = referenceBySelfLinkFilter(getFilterParams()) as typeof filter
   })
 
   describe('when an instance has a reference by self link', () => {

--- a/packages/jira-adapter/test/filters/remove_self.test.ts
+++ b/packages/jira-adapter/test/filters/remove_self.test.ts
@@ -14,26 +14,17 @@
 * limitations under the License.
 */
 import { BuiltinTypes, ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
-import { filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { getDefaultConfig } from '../../src/config/config'
+import { filterUtils } from '@salto-io/adapter-components'
 import { JIRA } from '../../src/constants'
 import removeSelfFilter from '../../src/filters/remove_self'
-import { mockClient } from '../utils'
+import { getFilterParams } from '../utils'
 
 describe('removeSelfFilter', () => {
   let filter: filterUtils.FilterWith<'onFetch'>
   let instance: InstanceElement
   let type: ObjectType
   beforeEach(async () => {
-    const { client, paginator } = mockClient()
-    filter = removeSelfFilter({
-      client,
-      paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    filter = removeSelfFilter(getFilterParams({})) as typeof filter
 
     type = new ObjectType({
       elemID: new ElemID(JIRA, 'someType'),

--- a/packages/jira-adapter/test/filters/resolution.test.ts
+++ b/packages/jira-adapter/test/filters/resolution.test.ts
@@ -15,9 +15,7 @@
 */
 import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { elements as elementUtils } from '@salto-io/adapter-components'
-import { mockClient } from '../utils'
+import { getFilterParams, mockClient } from '../utils'
 import resolutionFilter from '../../src/filters/resolution'
 import { Filter } from '../../src/filter'
 import { getDefaultConfig, JiraConfig } from '../../src/config/config'
@@ -41,13 +39,11 @@ describe('resolutionFilter', () => {
     client = cli
 
     config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
-    filter = resolutionFilter({
+    filter = resolutionFilter(getFilterParams({
       client,
       paginator,
       config,
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    })
+    }))
 
     type = new ObjectType({
       elemID: new ElemID(JIRA, 'Resolution'),

--- a/packages/jira-adapter/test/filters/screen/screen.test.ts
+++ b/packages/jira-adapter/test/filters/screen/screen.test.ts
@@ -14,11 +14,10 @@
 * limitations under the License.
 */
 import { CORE_ANNOTATIONS, ElemID, InstanceElement, MapType, ObjectType, toChange } from '@salto-io/adapter-api'
-import { deployment, client as clientUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { deployment, client as clientUtils } from '@salto-io/adapter-components'
 import { MockInterface } from '@salto-io/test-utils'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { JIRA } from '../../../src/constants'
-import { mockClient } from '../../utils'
+import { getFilterParams, mockClient } from '../../utils'
 import screenFilter from '../../../src/filters/screen/screen'
 import { Filter } from '../../../src/filter'
 import JiraClient from '../../../src/client/client'
@@ -47,13 +46,10 @@ describe('screenFilter', () => {
     mockConnection = connection
     mockConnection.get.mockResolvedValue({ status: 200, data: [] })
 
-    filter = screenFilter({
+    filter = screenFilter(getFilterParams({
       client,
       paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    })
+    }))
     screenTabType = new ObjectType({
       elemID: new ElemID(JIRA, 'ScreenableTab'),
     })

--- a/packages/jira-adapter/test/filters/screen/screen.test.ts
+++ b/packages/jira-adapter/test/filters/screen/screen.test.ts
@@ -136,9 +136,9 @@ describe('screenFilter', () => {
       )
     })
 
-    it('should call deployChange and ignore tabs and names of were not changed', async () => {
+    it('should call deployChange and ignore tabs and names if were not changed', async () => {
       const change = toChange({
-        before: new InstanceElement('instance2', screenType),
+        before: new InstanceElement('instance2', screenType, { description: 'desc' }),
         after: new InstanceElement('instance2', screenType),
       })
       await filter.deploy?.([change])

--- a/packages/jira-adapter/test/filters/screen/screenable_tab.test.ts
+++ b/packages/jira-adapter/test/filters/screen/screenable_tab.test.ts
@@ -128,15 +128,17 @@ describe('screenableTab', () => {
           },
         },
       })
+      const instanceBefore = instance.clone()
+      instanceBefore.value.tabs.tab.description = 'desc'
       const change = toChange({
-        before: instance,
+        before: instanceBefore,
         after: instance,
       }) as ModificationChange<InstanceElement>
       await deployTabs(change, client, getDefaultConfig({ isDataCenter: false }))
 
       expect(deployChangeMock).toHaveBeenCalledWith(
         toChange({
-          before: new InstanceElement('tab', screenTabType, { name: 'tab' }),
+          before: new InstanceElement('tab', screenTabType, { name: 'tab', description: 'desc' }),
           after: new InstanceElement('tab', screenTabType, { name: 'tab' }),
         }),
         client,

--- a/packages/jira-adapter/test/filters/security_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/security_scheme.test.ts
@@ -15,9 +15,8 @@
 */
 import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, InstanceElement, isReferenceExpression, ListType, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { mockClient } from '../utils'
+import { filterUtils } from '@salto-io/adapter-components'
+import { getFilterParams, mockClient } from '../utils'
 import securitySchemeFilter, { NO_DEFAULT_VALUE } from '../../src/filters/security_scheme/security_scheme'
 import { getDefaultConfig, JiraConfig } from '../../src/config/config'
 import { JIRA, SECURITY_LEVEL_MEMBER_TYPE, SECURITY_LEVEL_TYPE, SECURITY_SCHEME_TYPE } from '../../src/constants'
@@ -44,13 +43,11 @@ describe('securitySchemeFilter', () => {
     client = cli
 
     config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
-    filter = securitySchemeFilter({
+    filter = securitySchemeFilter(getFilterParams({
       client,
       paginator,
       config,
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as filterUtils.FilterWith<'onFetch' | 'deploy' | 'preDeploy' | 'onDeploy'>
+    })) as filterUtils.FilterWith<'onFetch' | 'deploy' | 'preDeploy' | 'onDeploy'>
 
     securityMemberType = new ObjectType({
       elemID: new ElemID(JIRA, SECURITY_LEVEL_MEMBER_TYPE),

--- a/packages/jira-adapter/test/filters/service_url/service_url.test.ts
+++ b/packages/jira-adapter/test/filters/service_url/service_url.test.ts
@@ -14,10 +14,8 @@
 * limitations under the License.
 */
 import { ObjectType, ElemID, InstanceElement, CORE_ANNOTATIONS, toChange, getChangeData } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { mockClient } from '../../utils'
-import { getDefaultConfig } from '../../../src/config/config'
+import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { getFilterParams, mockClient } from '../../utils'
 import JiraClient from '../../../src/client/client'
 import { JIRA } from '../../../src/constants'
 import filterCreator from '../../../src/filters/service_url/service_url'
@@ -37,13 +35,10 @@ describe('service url filter', () => {
     const mockCli = mockClient()
     client = mockCli.client
     paginator = mockCli.paginator
-    filter = filterCreator({
+    filter = filterCreator(getFilterParams({
       client,
       paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    })) as typeof filter
   })
 
   describe('onFetch', () => {

--- a/packages/jira-adapter/test/filters/service_url/service_url_information.test.ts
+++ b/packages/jira-adapter/test/filters/service_url/service_url_information.test.ts
@@ -14,10 +14,8 @@
 * limitations under the License.
 */
 import { ObjectType, ElemID, InstanceElement, CORE_ANNOTATIONS, toChange } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { mockClient } from '../../utils'
-import { getDefaultConfig } from '../../../src/config/config'
+import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { getFilterParams, mockClient } from '../../utils'
 import JiraClient from '../../../src/client/client'
 import { JIRA } from '../../../src/constants'
 import filterCreator from '../../../src/filters/service_url/service_url_information'
@@ -34,13 +32,10 @@ describe('service url information filter', () => {
     const mockCli = mockClient()
     client = mockCli.client
     paginator = mockCli.paginator
-    filter = filterCreator({
+    filter = filterCreator(getFilterParams({
       client,
       paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    })) as typeof filter
   })
 
   describe('onFetch', () => {

--- a/packages/jira-adapter/test/filters/share_permission.test.ts
+++ b/packages/jira-adapter/test/filters/share_permission.test.ts
@@ -14,11 +14,10 @@
 * limitations under the License.
 */
 import { BuiltinTypes, ElemID, Field, InstanceElement, ObjectType } from '@salto-io/adapter-api'
-import { filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { filterUtils } from '@salto-io/adapter-components'
 import { JIRA } from '../../src/constants'
 import sharePermissionFilter from '../../src/filters/share_permission'
-import { mockClient, getDefaultAdapterConfig } from '../utils'
+import { getFilterParams } from '../utils'
 
 describe('sharePermissionFilter', () => {
   let filter: filterUtils.FilterWith<'onFetch'>
@@ -26,14 +25,7 @@ describe('sharePermissionFilter', () => {
   let type: ObjectType
   let sharePermissionType: ObjectType
   beforeEach(async () => {
-    const { client, paginator } = mockClient()
-    filter = sharePermissionFilter({
-      client,
-      paginator,
-      config: await getDefaultAdapterConfig(),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    filter = sharePermissionFilter(getFilterParams()) as typeof filter
 
     sharePermissionType = new ObjectType({
       elemID: new ElemID(JIRA, 'SharePermission'),

--- a/packages/jira-adapter/test/filters/sort_lists.test.ts
+++ b/packages/jira-adapter/test/filters/sort_lists.test.ts
@@ -14,12 +14,9 @@
 * limitations under the License.
 */
 import { BuiltinTypes, ElemID, InstanceElement, ListType, ObjectType, ReferenceExpression, Values } from '@salto-io/adapter-api'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { elements as elementUtils } from '@salto-io/adapter-components'
-import { mockClient } from '../utils'
+import { getFilterParams } from '../utils'
 import sortListsFilter from '../../src/filters/sort_lists'
 import { Filter } from '../../src/filter'
-import { getDefaultConfig } from '../../src/config/config'
 import { JIRA } from '../../src/constants'
 
 describe('sortListsFilter', () => {
@@ -28,15 +25,7 @@ describe('sortListsFilter', () => {
   let instance: InstanceElement
   let sortedValues: Values
   beforeEach(async () => {
-    const { client, paginator } = mockClient()
-
-    filter = sortListsFilter({
-      client,
-      paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    })
+    filter = sortListsFilter(getFilterParams())
 
     permissionSchemeType = new ObjectType({
       elemID: new ElemID(JIRA, 'PermissionScheme'),

--- a/packages/jira-adapter/test/filters/statuses/status_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/statuses/status_deployment.test.ts
@@ -15,9 +15,7 @@
 */
 import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { elements as elementUtils } from '@salto-io/adapter-components'
-import { mockClient } from '../../utils'
+import { getFilterParams, mockClient } from '../../utils'
 import statusDeploymentFilter from '../../../src/filters/statuses/status_deployment'
 import { Filter } from '../../../src/filter'
 import { getDefaultConfig, JiraConfig } from '../../../src/config/config'
@@ -41,13 +39,11 @@ describe('statusDeploymentFilter', () => {
     client = cli
 
     config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
-    filter = statusDeploymentFilter({
+    filter = statusDeploymentFilter(getFilterParams({
       client,
       paginator,
       config,
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    })
+    }))
 
     type = new ObjectType({
       elemID: new ElemID(JIRA, STATUS_TYPE_NAME),

--- a/packages/jira-adapter/test/filters/unresolved_parents.test.ts
+++ b/packages/jira-adapter/test/filters/unresolved_parents.test.ts
@@ -14,27 +14,16 @@
 * limitations under the License.
 */
 import { CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { elements as elementUtils } from '@salto-io/adapter-components'
-import { mockClient } from '../utils'
+import { getFilterParams } from '../utils'
 import unresolvedParentsFilter from '../../src/filters/unresolved_parents'
 import { Filter } from '../../src/filter'
-import { getDefaultConfig } from '../../src/config/config'
 import { JIRA } from '../../src/constants'
 
 describe('unresolvedParentsFilter', () => {
   let filter: Filter
   let type: ObjectType
   beforeEach(async () => {
-    const { client, paginator } = mockClient()
-
-    filter = unresolvedParentsFilter({
-      client,
-      paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    })
+    filter = unresolvedParentsFilter(getFilterParams({}))
 
     type = new ObjectType({
       elemID: new ElemID(JIRA, 'someType'),

--- a/packages/jira-adapter/test/filters/user.test.ts
+++ b/packages/jira-adapter/test/filters/user.test.ts
@@ -14,12 +14,9 @@
 * limitations under the License.
 */
 import { BuiltinTypes, ElemID, InstanceElement, ListType, ObjectType } from '@salto-io/adapter-api'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { elements as elementUtils } from '@salto-io/adapter-components'
-import { mockClient } from '../utils'
+import { getFilterParams } from '../utils'
 import userFilter from '../../src/filters/user'
 import { Filter } from '../../src/filter'
-import { getDefaultConfig } from '../../src/config/config'
 import { JIRA } from '../../src/constants'
 
 describe('userFilter', () => {
@@ -28,15 +25,7 @@ describe('userFilter', () => {
   let type: ObjectType
 
   beforeEach(async () => {
-    const { client, paginator } = mockClient()
-
-    filter = userFilter({
-      client,
-      paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    })
+    filter = userFilter(getFilterParams())
 
     userType = new ObjectType({
       elemID: new ElemID(JIRA, 'User'),

--- a/packages/jira-adapter/test/filters/webhook/webhook.test.ts
+++ b/packages/jira-adapter/test/filters/webhook/webhook.test.ts
@@ -15,10 +15,9 @@
 */
 import { Element, InstanceElement, CORE_ANNOTATIONS, ElemID, ObjectType, toChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { filterUtils, client as clientUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { MockInterface } from '@salto-io/test-utils'
-import { mockClient } from '../../utils'
+import { getFilterParams, mockClient } from '../../utils'
 import webhookFilter from '../../../src/filters/webhook/webhook'
 import { getDefaultConfig, JiraConfig } from '../../../src/config/config'
 import JiraClient, { PRIVATE_API_HEADERS } from '../../../src/client/client'
@@ -55,13 +54,12 @@ describe('webhookFilter', () => {
     fetchQuery = elementUtils.query.createMockQuery()
 
     config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
-    filter = webhookFilter({
+    filter = webhookFilter(getFilterParams({
       client,
       paginator,
       config,
-      elementsSource: buildElementsSourceFromElements([]),
       fetchQuery,
-    }) as filterUtils.FilterWith<'onFetch' | 'deploy' | 'preDeploy' | 'onDeploy'>
+    })) as filterUtils.FilterWith<'onFetch' | 'deploy' | 'preDeploy' | 'onDeploy'>
 
     connection.get.mockResolvedValue({
       status: 200,
@@ -142,14 +140,13 @@ describe('webhookFilter', () => {
 
     it('should use elemIdGetter', async () => {
       const { paginator } = mockClient()
-      filter = webhookFilter({
+      filter = webhookFilter(getFilterParams({
         client,
         paginator,
         config,
-        elementsSource: buildElementsSourceFromElements([]),
         getElemIdFunc: () => new ElemID(JIRA, 'someName2'),
         fetchQuery: elementUtils.query.createMockQuery(),
-      }) as filterUtils.FilterWith<'onFetch' | 'deploy' | 'preDeploy' | 'onDeploy'>
+      })) as filterUtils.FilterWith<'onFetch' | 'deploy' | 'preDeploy' | 'onDeploy'>
       const elements: Element[] = []
       await filter.onFetch(elements)
 

--- a/packages/jira-adapter/test/filters/workflow/groups_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/groups_filter.test.ts
@@ -14,13 +14,11 @@
 * limitations under the License.
 */
 import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
-import { filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { filterUtils } from '@salto-io/adapter-components'
 import JiraClient from '../../../src/client/client'
-import { getDefaultConfig } from '../../../src/config/config'
 import { GROUP_TYPE_NAME, JIRA, WORKFLOW_TYPE_NAME } from '../../../src/constants'
 import workflowGroupsFilter from '../../../src/filters/workflow/groups_filter'
-import { mockClient } from '../../utils'
+import { getFilterParams, mockClient } from '../../utils'
 
 describe('workflowGroupsFilter', () => {
   let filter: filterUtils.FilterWith<'onFetch'>
@@ -38,13 +36,10 @@ describe('workflowGroupsFilter', () => {
 
     const { client: cli, paginator } = mockClient()
     client = cli
-    filter = workflowGroupsFilter({
+    filter = workflowGroupsFilter(getFilterParams({
       client,
       paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    })) as typeof filter
   })
 
   describe('onFetch', () => {

--- a/packages/jira-adapter/test/filters/workflow/step_ids_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/step_ids_filter.test.ts
@@ -14,15 +14,14 @@
 * limitations under the License.
 */
 import { CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
-import { filterUtils, client as clientUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
 import { MockInterface } from '@salto-io/test-utils'
 import _ from 'lodash'
 import JiraClient, { PRIVATE_API_HEADERS } from '../../../src/client/client'
 import { getDefaultConfig, JiraConfig } from '../../../src/config/config'
 import { JIRA, WORKFLOW_TYPE_NAME } from '../../../src/constants'
 import stepIdsFilter from '../../../src/filters/workflow/step_ids_filter'
-import { mockClient } from '../../utils'
+import { getFilterParams, mockClient } from '../../utils'
 
 describe('stepIdsFilter', () => {
   let filter: filterUtils.FilterWith<'onFetch'>
@@ -39,13 +38,11 @@ describe('stepIdsFilter', () => {
 
     config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
 
-    filter = stepIdsFilter({
+    filter = stepIdsFilter(getFilterParams({
       client,
       paginator,
       config,
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    })) as typeof filter
   })
 
   describe('onFetch', () => {

--- a/packages/jira-adapter/test/filters/workflow/transition_ids_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/transition_ids_filter.test.ts
@@ -14,13 +14,11 @@
 * limitations under the License.
 */
 import { CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
-import { filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { filterUtils } from '@salto-io/adapter-components'
 import JiraClient from '../../../src/client/client'
-import { getDefaultConfig } from '../../../src/config/config'
 import { JIRA, WORKFLOW_TYPE_NAME } from '../../../src/constants'
 import transitionIdsFilter from '../../../src/filters/workflow/transition_ids_filter'
-import { mockClient } from '../../utils'
+import { getFilterParams, mockClient } from '../../utils'
 
 describe('transitionIdsFilter', () => {
   let filter: filterUtils.FilterWith<'onFetch' | 'onDeploy'>
@@ -32,13 +30,10 @@ describe('transitionIdsFilter', () => {
     const { client: cli, paginator } = mockClient()
     client = cli
 
-    filter = transitionIdsFilter({
+    filter = transitionIdsFilter(getFilterParams({
       client,
       paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    })) as typeof filter
   })
 
   describe('onFetch', () => {

--- a/packages/jira-adapter/test/filters/workflow/triggers_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/triggers_filter.test.ts
@@ -14,15 +14,14 @@
 * limitations under the License.
 */
 import { ElemID, InstanceElement, isInstanceElement, ObjectType } from '@salto-io/adapter-api'
-import { filterUtils, client as clientUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
 import { MockInterface } from '@salto-io/test-utils'
 import _ from 'lodash'
 import JiraClient, { PRIVATE_API_HEADERS } from '../../../src/client/client'
 import { getDefaultConfig, JiraConfig } from '../../../src/config/config'
 import { JIRA, WORKFLOW_RULES_TYPE_NAME, WORKFLOW_TYPE_NAME } from '../../../src/constants'
 import triggersFilter from '../../../src/filters/workflow/triggers_filter'
-import { mockClient } from '../../utils'
+import { getFilterParams, mockClient } from '../../utils'
 
 describe('triggersFilter', () => {
   let filter: filterUtils.FilterWith<'onFetch'>
@@ -41,13 +40,11 @@ describe('triggersFilter', () => {
 
     config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
 
-    filter = triggersFilter({
+    filter = triggersFilter(getFilterParams({
       client,
       paginator,
       config,
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    })) as typeof filter
   })
 
   describe('onFetch', () => {

--- a/packages/jira-adapter/test/filters/workflow/workflow_deploy_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_deploy_filter.test.ts
@@ -14,14 +14,13 @@
 * limitations under the License.
 */
 import { ElemID, getChangeData, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
-import { deployment, filterUtils, client as clientUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { deployment, filterUtils, client as clientUtils } from '@salto-io/adapter-components'
 import { MockInterface } from '@salto-io/test-utils'
 import JiraClient from '../../../src/client/client'
 import { getDefaultConfig } from '../../../src/config/config'
 import { JIRA, WORKFLOW_TYPE_NAME } from '../../../src/constants'
 import workflowFilter, { INITIAL_VALIDATOR } from '../../../src/filters/workflow/workflow_deploy_filter'
-import { mockClient } from '../../utils'
+import { getFilterParams, mockClient } from '../../utils'
 import { WITH_PERMISSION_VALIDATORS } from './workflow_values'
 
 jest.mock('@salto-io/adapter-components', () => {
@@ -47,13 +46,10 @@ describe('workflowDeployFilter', () => {
     client = cli
     mockConnection = connection
 
-    filter = workflowFilter({
+    filter = workflowFilter(getFilterParams({
       client,
       paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    })) as typeof filter
   })
 
   describe('deploy', () => {

--- a/packages/jira-adapter/test/filters/workflow/workflow_modification_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_modification_filter.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { ElemID, InstanceElement, ObjectType, toChange, ReferenceExpression, ReadOnlyElementsSource, CORE_ANNOTATIONS, ListType, Field, BuiltinTypes } from '@salto-io/adapter-api'
-import { filterUtils, client as clientUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { deployWorkflow } from '../../../src/filters/workflow/workflow_deploy_filter'
@@ -23,7 +23,7 @@ import JiraClient from '../../../src/client/client'
 import { getDefaultConfig, JiraConfig } from '../../../src/config/config'
 import { JIRA, WORKFLOW_SCHEME_TYPE_NAME, WORKFLOW_STATUS_TYPE_NAME, WORKFLOW_TYPE_NAME } from '../../../src/constants'
 import workflowModificationFilter from '../../../src/filters/workflow/workflow_modification_filter'
-import { mockClient } from '../../utils'
+import { getFilterParams, mockClient } from '../../utils'
 
 jest.mock('../../../src/filters/workflow/workflow_deploy_filter', () => ({
   ...jest.requireActual('../../../src/filters/workflow/workflow_deploy_filter'),
@@ -109,13 +109,12 @@ describe('workflowModificationFilter', () => {
       workflowInstance,
     ])
 
-    filter = workflowModificationFilter({
+    filter = workflowModificationFilter(getFilterParams({
       client,
       paginator,
       config,
       elementsSource,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    })) as typeof filter
   })
 
   describe('onFetch', () => {

--- a/packages/jira-adapter/test/filters/workflow/workflow_properties_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_properties_filter.test.ts
@@ -14,13 +14,11 @@
 * limitations under the License.
 */
 import { ElemID, InstanceElement, ListType, ObjectType, toChange } from '@salto-io/adapter-api'
-import { filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { filterUtils } from '@salto-io/adapter-components'
 import JiraClient from '../../../src/client/client'
-import { getDefaultConfig } from '../../../src/config/config'
 import { JIRA, WORKFLOW_TYPE_NAME } from '../../../src/constants'
 import workflowPropertiesFilter from '../../../src/filters/workflow/workflow_properties_filter'
-import { mockClient } from '../../utils'
+import { getFilterParams, mockClient } from '../../utils'
 
 describe('workflowPropertiesFilter', () => {
   let filter: filterUtils.FilterWith<'onFetch' | 'deploy'>
@@ -38,13 +36,10 @@ describe('workflowPropertiesFilter', () => {
 
     const { client: cli, paginator } = mockClient()
     client = cli
-    filter = workflowPropertiesFilter({
+    filter = workflowPropertiesFilter(getFilterParams({
       client,
       paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    })) as typeof filter
   })
 
   describe('onFetch', () => {

--- a/packages/jira-adapter/test/filters/workflow/workflow_structure_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_structure_filter.test.ts
@@ -14,13 +14,11 @@
 * limitations under the License.
 */
 import { BuiltinTypes, ElemID, Field, InstanceElement, ObjectType } from '@salto-io/adapter-api'
-import { filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { filterUtils } from '@salto-io/adapter-components'
 import JiraClient from '../../../src/client/client'
-import { getDefaultConfig } from '../../../src/config/config'
 import { JIRA, WORKFLOW_RULES_TYPE_NAME, WORKFLOW_TYPE_NAME } from '../../../src/constants'
 import workflowFilter from '../../../src/filters/workflow/workflow_structure_filter'
-import { mockClient } from '../../utils'
+import { getFilterParams, mockClient } from '../../utils'
 import { EXPECTED_POST_FUNCTIONS, WITH_POST_FUNCTIONS, WITH_UNSUPPORTED_POST_FUNCTIONS, WITH_VALIDATORS } from './workflow_values'
 
 jest.mock('@salto-io/adapter-components', () => {
@@ -48,13 +46,10 @@ describe('workflowStructureFilter', () => {
 
     const { client: cli, paginator } = mockClient()
     client = cli
-    filter = workflowFilter({
+    filter = workflowFilter(getFilterParams({
       client,
       paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as typeof filter
+    })) as typeof filter
   })
 
   describe('onFetch', () => {

--- a/packages/jira-adapter/test/filters/workflow_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/workflow_scheme.test.ts
@@ -14,12 +14,11 @@
 * limitations under the License.
 */
 import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
-import { deployment, client as clientUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { deployment, client as clientUtils } from '@salto-io/adapter-components'
 import { MockInterface } from '@salto-io/test-utils'
 import _ from 'lodash'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { JIRA } from '../../src/constants'
-import { mockClient } from '../utils'
+import { getFilterParams, mockClient } from '../utils'
 import workflowSchemeFilter, { MAX_TASK_CHECKS } from '../../src/filters/workflow_scheme'
 import { Filter } from '../../src/filter'
 import { getDefaultConfig } from '../../src/config/config'
@@ -46,13 +45,10 @@ describe('workflowScheme', () => {
     client = cli
     connection = conn
 
-    filter = workflowSchemeFilter({
+    filter = workflowSchemeFilter(getFilterParams({
       client,
       paginator,
-      config: getDefaultConfig({ isDataCenter: false }),
-      elementsSource: buildElementsSourceFromElements([]),
-      fetchQuery: elementUtils.query.createMockQuery(),
-    })
+    }))
     workflowSchemeType = new ObjectType({
       elemID: new ElemID(JIRA, 'WorkflowScheme'),
     })

--- a/packages/jira-adapter/test/filters/workflow_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/workflow_scheme.test.ts
@@ -252,10 +252,13 @@ describe('workflowScheme', () => {
         },
       })
 
-      await filter.deploy?.([toChange({ before: instance, after: instance })])
+
+      const instanceBefore = instance.clone()
+      instanceBefore.value.description = 'desc'
+      await filter.deploy?.([toChange({ before: instanceBefore, after: instance })])
 
       expect(deployChangeMock).toHaveBeenCalledWith(
-        toChange({ before: instance, after: instance }),
+        toChange({ before: instanceBefore, after: instance }),
         client,
         getDefaultConfig({ isDataCenter: false })
           .apiDefinitions.types.WorkflowScheme.deployRequests,
@@ -331,11 +334,13 @@ describe('workflowScheme', () => {
         },
       })
 
-      await filter.deploy?.([toChange({ before: instance, after: instance })])
+      const instanceBefore = instance.clone()
+      instanceBefore.value.description = 'desc'
+      await filter.deploy?.([toChange({ before: instanceBefore, after: instance })])
 
 
       expect(deployChangeMock).toHaveBeenCalledWith(
-        toChange({ before: instance, after: instance }),
+        toChange({ before: instanceBefore, after: instance }),
         client,
         getDefaultConfig({ isDataCenter: false })
           .apiDefinitions.types.WorkflowScheme.deployRequests,
@@ -394,10 +399,12 @@ describe('workflowScheme', () => {
         },
       })
 
-      await filter.deploy?.([toChange({ before: instance, after: instance })])
+      const instanceBefore = instance.clone()
+      instanceBefore.value.description = 'desc'
+      await filter.deploy?.([toChange({ before: instanceBefore, after: instance })])
 
       expect(deployChangeMock).toHaveBeenCalledWith(
-        toChange({ before: instance, after: instance }),
+        toChange({ before: instanceBefore, after: instance }),
         client,
         getDefaultConfig({ isDataCenter: false })
           .apiDefinitions.types.WorkflowScheme.deployRequests,
@@ -462,10 +469,12 @@ describe('workflowScheme', () => {
         },
       })
 
-      await filter.deploy?.([toChange({ before: instance, after: instance })])
+      const instanceBefore = instance.clone()
+      instanceBefore.value.description = 'desc'
+      await filter.deploy?.([toChange({ before: instanceBefore, after: instance })])
 
       expect(deployChangeMock).toHaveBeenCalledWith(
-        toChange({ before: instance, after: instance }),
+        toChange({ before: instanceBefore, after: instance }),
         client,
         getDefaultConfig({ isDataCenter: false })
           .apiDefinitions.types.WorkflowScheme.deployRequests,
@@ -506,7 +515,9 @@ describe('workflowScheme', () => {
         },
       })
 
-      const res = await filter.deploy?.([toChange({ before: instance, after: instance })])
+      const instanceBefore = instance.clone()
+      instanceBefore.value.description = 'desc'
+      const res = await filter.deploy?.([toChange({ before: instanceBefore, after: instance })])
       expect(res?.deployResult.appliedChanges).toEqual([])
       expect(res?.deployResult.errors).toHaveLength(1)
     })
@@ -544,7 +555,9 @@ describe('workflowScheme', () => {
         },
       })
 
-      const res = await filter.deploy?.([toChange({ before: instance, after: instance })])
+      const instanceBefore = instance.clone()
+      instanceBefore.value.description = 'desc'
+      const res = await filter.deploy?.([toChange({ before: instanceBefore, after: instance })])
 
       // + 1 is for the internal id check
       expect(connection.get).toHaveBeenCalledTimes(MAX_TASK_CHECKS + 1)
@@ -579,7 +592,9 @@ describe('workflowScheme', () => {
         },
       })
 
-      const res = await filter.deploy?.([toChange({ before: instance, after: instance })])
+      const instanceBefore = instance.clone()
+      instanceBefore.value.description = 'desc'
+      const res = await filter.deploy?.([toChange({ before: instanceBefore, after: instance })])
 
       expect(res?.deployResult.appliedChanges).toEqual([])
       expect(res?.deployResult.errors).toHaveLength(1)

--- a/packages/jira-adapter/test/utils.ts
+++ b/packages/jira-adapter/test/utils.ts
@@ -86,6 +86,6 @@ export const getFilterParams = (params?: Partial<Parameters<FilterCreator>[0]>)
   config: getDefaultConfig({ isDataCenter: false }),
   elementsSource: buildElementsSourceFromElements([]),
   fetchQuery: elementUtils.query.createMockQuery(),
-  globalContext: {},
+  adapterContext: {},
   ...params ?? {},
 })

--- a/packages/jira-adapter/test/utils.ts
+++ b/packages/jira-adapter/test/utils.ts
@@ -14,13 +14,14 @@
 * limitations under the License.
 */
 import { InstanceElement, ElemID, ObjectType } from '@salto-io/adapter-api'
-import { createDefaultInstanceFromType } from '@salto-io/adapter-utils'
-import { client as clientUtils } from '@salto-io/adapter-components'
+import { buildElementsSourceFromElements, createDefaultInstanceFromType } from '@salto-io/adapter-utils'
+import { client as clientUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { mockFunction, MockInterface } from '@salto-io/test-utils'
 import { adapter } from '../src/adapter_creator'
 import { Credentials } from '../src/auth'
-import { JiraConfig, configType } from '../src/config/config'
+import { JiraConfig, configType, getDefaultConfig } from '../src/config/config'
 import JiraClient from '../src/client/client'
+import { FilterCreator } from '../src/filter'
 
 
 export const createCredentialsInstance = (credentials: Credentials): InstanceElement => (
@@ -78,3 +79,13 @@ export const getDefaultAdapterConfig = async (): Promise<JiraConfig> => {
   const defaultConfigInstance = await createDefaultInstanceFromType('jira', configType)
   return defaultConfigInstance.value as JiraConfig
 }
+
+export const getFilterParams = (params?: Partial<Parameters<FilterCreator>[0]>)
+: Parameters<FilterCreator>[0] => ({
+  ...mockClient(),
+  config: getDefaultConfig({ isDataCenter: false }),
+  elementsSource: buildElementsSourceFromElements([]),
+  fetchQuery: elementUtils.query.createMockQuery(),
+  globalContext: {},
+  ...params ?? {},
+})


### PR DESCRIPTION
Changed field context structure to not reference other projects.

Instead of having `projectIds` field inside contexts with references to all the projects the context applies to, we will have a `fieldContexts` inside `project` that will have references to all the contexts that applies to that project.


---
_Release Notes_: 
_Jira Adapter_:
- Changed field contexts structure so that it will no reference other projects

---
_User Notifications_: 
_Jira Adapter_:
- After the next fetch, there might be some changes in the structure of projects and field contexts