### PR TITLE
Salto-2410: Extract references from Salesforce Sharing Rules

### DIFF
--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -349,6 +349,18 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     target: { typeContext: 'neighborSharedToTypeLookup' },
   },
   {
+    src: { field: 'role', parentTypes: ['SharedTo'] },
+    target: { type: 'Role' },
+  },
+  {
+    src: { field: 'roleAndSubordinates', parentTypes: ['SharedTo'] },
+    target: { type: 'Role' },
+  },
+  {
+    src: { field: 'group', parentTypes: ['SharedTo'] },
+    target: { type: 'Group' },
+  },
+  {
     // sometimes has a value that is not a reference - should only convert to reference
     // if lookupValueType exists
     src: { field: 'lookupValue', parentTypes: ['WorkflowFieldUpdate'] },

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -133,7 +133,7 @@ export type FieldReferenceDefinition = {
 
 export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
   {
-    src: { field: 'field', parentTypes: [WORKFLOW_FIELD_UPDATE_METADATA_TYPE, LAYOUT_ITEM_METADATA_TYPE, SUMMARY_LAYOUT_ITEM_METADATA_TYPE, 'WorkflowEmailRecipient', 'QuickActionLayoutItem', 'FieldSetItem'] },
+    src: { field: 'field', parentTypes: [WORKFLOW_FIELD_UPDATE_METADATA_TYPE, LAYOUT_ITEM_METADATA_TYPE, SUMMARY_LAYOUT_ITEM_METADATA_TYPE, 'WorkflowEmailRecipient', 'QuickActionLayoutItem', 'FieldSetItem', 'FilterItem'] },
     serializationStrategy: 'relativeApiName',
     target: { parentContext: 'instanceParent', type: CUSTOM_FIELD },
   },


### PR DESCRIPTION
_Extract references from Salesforce Sharing Rules_

---
_Additional context for reviewer_:
None

---
_Release Notes_: 
Salesforce-adapter:

* Extract references from shraredTo and FilterItems types in Sharing Rules
---

_User Notifications_: 
Salesforce-adapter:

* ShraredTo and FilterItems field will be properly parsed as references from Sharing Rules, showing up as ReferenceExpression in nacl