### PR TITLE
Salto-2443: Extract share to references from ReportFolder

### DIFF
--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -344,6 +344,8 @@ export const LIGHTNING_PAGE_TYPE = 'LightningPage'
 export const FLEXI_PAGE_TYPE = 'FlexiPage'
 export const CUSTOM_LABEL_METADATA_TYPE = 'CustomLabel'
 export const CUSTOM_LABELS_METADATA_TYPE = 'CustomLabels'
+export const ROLE_METADATA_TYPE = 'Role'
+export const GROUP_METADATA_TYPE = 'Group'
 
 // Artifitial Types
 export const CURRENCY_CODE_TYPE_NAME = 'CurrencyIsoCodes'

--- a/packages/salesforce-adapter/src/filters/field_references.ts
+++ b/packages/salesforce-adapter/src/filters/field_references.ts
@@ -25,7 +25,7 @@ import {
   WORKFLOW_ACTION_ALERT_METADATA_TYPE, WORKFLOW_FIELD_UPDATE_METADATA_TYPE,
   WORKFLOW_FLOW_ACTION_METADATA_TYPE, WORKFLOW_OUTBOUND_MESSAGE_METADATA_TYPE,
   WORKFLOW_TASK_METADATA_TYPE, CPQ_LOOKUP_OBJECT_NAME, CPQ_RULE_LOOKUP_OBJECT_FIELD,
-  QUICK_ACTION_METADATA_TYPE,
+  QUICK_ACTION_METADATA_TYPE, GROUP_METADATA_TYPE, ROLE_METADATA_TYPE,
 } from '../constants'
 import { buildElementsSourceForFetch, extractFlatCustomObjectFields, hasApiName } from './utils'
 
@@ -50,6 +50,15 @@ const flowActionCallMapper: referenceUtils.ContextValueMapperFunc = (val: string
     apex: 'ApexClass',
     emailAlert: WORKFLOW_ACTION_ALERT_METADATA_TYPE,
     quickAction: QUICK_ACTION_METADATA_TYPE,
+  }
+  return typeMapping[val]
+}
+
+const shareToMapper: referenceUtils.ContextValueMapperFunc = (val: string) => {
+  const typeMapping: Record<string, string> = {
+    Role: ROLE_METADATA_TYPE,
+    Group: GROUP_METADATA_TYPE,
+    RoleAndSubordinates: ROLE_METADATA_TYPE,
   }
   return typeMapping[val]
 }
@@ -82,6 +91,7 @@ const contextStrategyLookup: Record<
   parentInputObjectLookup: neighborContextFunc({ contextFieldName: 'inputObject', levelsUp: 1 }),
   parentOutputObjectLookup: neighborContextFunc({ contextFieldName: 'outputObject', levelsUp: 1 }),
   neighborPicklistObjectLookup: neighborContextFunc({ contextFieldName: 'picklistObject' }),
+  neighborSharedToTypeLookup: neighborContextFunc({ contextFieldName: 'sharedToType', contextValueMapper: shareToMapper }),
 }
 
 

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -346,7 +346,7 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
   },
   {
     src: { field: 'sharedTo', parentTypes: ['FolderShare'] },
-    target: { typeContext: 'neighborTypeLookup' },
+    target: { typeContext: 'neighborSharedToTypeLookup' },
   },
   {
     // sometimes has a value that is not a reference - should only convert to reference

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -112,7 +112,7 @@ export type ReferenceContextStrategyName = (
   'instanceParent' | 'neighborTypeWorkflow' | 'neighborCPQLookup' | 'neighborCPQRuleLookup'
   | 'neighborLookupValueTypeLookup' | 'neighborObjectLookup' | 'neighborPicklistObjectLookup'
   | 'neighborTypeLookup' | 'neighborActionTypeFlowLookup' | 'neighborActionTypeLookup' | 'parentObjectLookup'
-  | 'parentInputObjectLookup' | 'parentOutputObjectLookup'
+  | 'parentInputObjectLookup' | 'parentOutputObjectLookup' | 'neighborSharedToTypeLookup'
 )
 
 type SourceDef = {
@@ -343,6 +343,10 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     src: { field: 'value', parentTypes: ['FilterItem'] },
     serializationStrategy: 'relativeApiName',
     target: { parentContext: 'instanceParent', type: RECORD_TYPE_METADATA_TYPE },
+  },
+  {
+    src: { field: 'sharedTo', parentTypes: ['FolderShare'] },
+    target: { typeContext: 'neighborTypeLookup' },
   },
   {
     // sometimes has a value that is not a reference - should only convert to reference

--- a/packages/salesforce-adapter/test/filters/field_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/field_references.test.ts
@@ -236,6 +236,23 @@ describe('FieldReferences filter', () => {
       fieldValue: 'fffff',
       parentType: 'Account',
     }),
+    // shareTo should point to salesforce.Role.instance.CFO (neighbor context)
+    ...generateObjectAndInstance({
+      type: 'Role',
+      objType: 'Role',
+      instanceName: 'CFO',
+      fieldName: 'fullName',
+      fieldValue: 'CFO',
+    }),
+    ...generateObjectAndInstance({
+      type: 'FolderShare',
+      objType: 'FolderShare',
+      instanceName: 'folderShare',
+      fieldName: 'sharedTo',
+      fieldValue: 'CFO',
+      contextFieldName: 'sharedToType',
+      contextFieldValue: 'Role',
+    }),
   ])
 
   describe('on fetch', () => {
@@ -350,6 +367,14 @@ describe('FieldReferences filter', () => {
       ) as InstanceElement
       expect(inst.value.field).not.toBeInstanceOf(ReferenceExpression)
       expect(inst.value.field).toEqual('fffff')
+    })
+
+    it('should resolve field with neighbor context using share to type mapping when context is a string', async () => {
+      const inst = await awu(elements).find(
+        async e => isInstanceElement(e) && await metadataType(e) === 'FolderShare'
+      ) as InstanceElement
+      expect(inst.value.sharedTo).toBeInstanceOf(ReferenceExpression)
+      expect(inst.value.sharedTo?.elemID.getFullName()).toEqual('salesforce.Role.instance.CFO')
     })
   })
 


### PR DESCRIPTION
_Extract share to references from ReportFolder_

---
_Additional context for reviewer_:
None

---
_Release Notes_: 
Salesforce-adapter:

* Extract references from shrareTo types in Report Folders
---

_User Notifications_: 
Salesforce-adapter:

* ShraredTo field will be properly parsed as references from ReportFolder, showing up as ReferenceExpression in nacl