### PR TITLE
SALTO-2521: Add reference to compactLayout from recordType

### DIFF
--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -340,7 +340,6 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     target: { type: CUSTOM_FIELD },
   },
   {
-<<<<<<< HEAD
     src: { field: 'value', parentTypes: ['FilterItem'] },
     serializationStrategy: 'relativeApiName',
     target: { parentContext: 'instanceParent', type: RECORD_TYPE_METADATA_TYPE },
@@ -362,7 +361,7 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     target: { type: 'Group' },
   },
   {
-    src: { field: 'compactLayoutAssignment', parentTypes: ['RecordType'] },
+    src: { field: 'compactLayoutAssignment', parentTypes: [RECORD_TYPE_METADATA_TYPE] },
     serializationStrategy: 'relativeApiName',
     target: { parentContext: 'instanceParent', type: 'CompactLayout' },
   },

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -340,6 +340,7 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     target: { type: CUSTOM_FIELD },
   },
   {
+<<<<<<< HEAD
     src: { field: 'value', parentTypes: ['FilterItem'] },
     serializationStrategy: 'relativeApiName',
     target: { parentContext: 'instanceParent', type: RECORD_TYPE_METADATA_TYPE },
@@ -359,6 +360,11 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
   {
     src: { field: 'group', parentTypes: ['SharedTo'] },
     target: { type: 'Group' },
+  },
+  {
+    src: { field: 'compactLayoutAssignment', parentTypes: ['RecordType'] },
+    serializationStrategy: 'relativeApiName',
+    target: { parentContext: 'instanceParent', type: 'CompactLayout' },
   },
   {
     // sometimes has a value that is not a reference - should only convert to reference


### PR DESCRIPTION
_Add reference to compactLayout from recordType_

---
_Additional context for reviewer_:
None

---
_Release Notes_: 
Salesforce-adapter:

* Add reference to compactLayout from recordType
---

_User Notifications_: 
Salesforce-adapter:

* compactLayoutAssignment field will be properly parsed as references from RecordType, showing up as ReferenceExpression in nacl