### PR TITLE
SALTO-2522: export zendesk salto app marketplace headers

### DIFF
--- a/packages/zendesk-adapter/index.ts
+++ b/packages/zendesk-adapter/index.ts
@@ -16,5 +16,5 @@
 
 export { adapter } from './src/adapter_creator'
 export {
-  APP_MARKETPLACE_HEADERS as ZENDESK_SALTO_APP_MARKETPLACE_HEADERS
+  APP_MARKETPLACE_HEADERS as ZENDESK_SALTO_APP_MARKETPLACE_HEADERS,
 } from './src/client/connection'

--- a/packages/zendesk-adapter/index.ts
+++ b/packages/zendesk-adapter/index.ts
@@ -15,3 +15,6 @@
 */
 
 export { adapter } from './src/adapter_creator'
+export {
+  APP_MARKETPLACE_HEADERS as ZENDESK_SALTO_APP_MARKETPLACE_HEADERS
+} from './src/client/connection'

--- a/packages/zendesk-adapter/src/client/connection.ts
+++ b/packages/zendesk-adapter/src/client/connection.ts
@@ -28,7 +28,7 @@ const MARKETPLACE_NAME = 'Salto'
 const MARKETPLACE_ORG_ID = 5110
 const MARKETPLACE_APP_ID = 608042
 
-const APP_MARKETPLACE_HEADERS = {
+export const APP_MARKETPLACE_HEADERS = {
   'X-Zendesk-Marketplace-Name': MARKETPLACE_NAME,
   'X-Zendesk-Marketplace-Organization-Id': MARKETPLACE_ORG_ID,
   'X-Zendesk-Marketplace-App-Id': MARKETPLACE_APP_ID,


### PR DESCRIPTION
_export zendesk salto app marketplace headers_

---

_Additional context for reviewer_
We need to send this header in the auth process to zendesk in the SaaS, and therefore, we need to extract those headers

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
