### PR TITLE
SALTO-2495: fix getRelativePath to work on fields, attrs and annotations

### DIFF
--- a/packages/adapter-api/src/element_id.ts
+++ b/packages/adapter-api/src/element_id.ts
@@ -294,7 +294,10 @@ export class ElemID {
       throw new Error(`Cannot get relative path of ${this.getFullName()} and ${other.getFullName()
       } - ${this.getFullName()} is not parent of ${other.getFullName()}`)
     }
-    return other.createTopLevelParentID().path.slice(this.nestingLevel)
+    const relPath = other.createTopLevelParentID().path.slice(this.nestingLevel)
+    return ['attr', 'annotation', 'field'].includes(other.idType)
+      ? [other.idType as string].concat(relPath)
+      : relPath
   }
 
   isAttrID(): boolean {

--- a/packages/adapter-api/test/elements.test.ts
+++ b/packages/adapter-api/test/elements.test.ts
@@ -455,6 +455,21 @@ describe('Test elements.ts', () => {
         const nestedID = elemID.createNestedID(...nested)
         expect(elemID.getRelativePath(nestedID)).toEqual(nested)
       })
+      it('should return the correct relative path - field', () => {
+        const elemID = new ElemID('adapter', 'typeName')
+        const nestedID = new ElemID('adapter', 'typeName', 'field', 'f1')
+        expect(elemID.getRelativePath(nestedID)).toEqual(['field', 'f1'])
+      })
+      it('should return the correct relative path - annotation', () => {
+        const elemID = new ElemID('adapter', 'typeName')
+        const nestedID = new ElemID('adapter', 'typeName', 'annotation', 'f1')
+        expect(elemID.getRelativePath(nestedID)).toEqual(['annotation', 'f1'])
+      })
+      it('should return the correct relative path - attr', () => {
+        const elemID = new ElemID('adapter', 'typeName')
+        const nestedID = new ElemID('adapter', 'typeName', 'attr', 'f1')
+        expect(elemID.getRelativePath(nestedID)).toEqual(['attr', 'f1'])
+      })
       it('should return the empty result if they are the same elemIDs', () => {
         const elemID = new ElemID('adapter', 'typeName', 'instance', 'test')
         const nestedID = new ElemID('adapter', 'typeName', 'instance', 'test')


### PR DESCRIPTION
_fix getRelativePath to work on fields, attrs and annotations_

---

_Additional context for reviewer_
None

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
