### PR TITLE
Salto-2470:  Extract references from a filterItems to recordType

### DIFF
--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -340,6 +340,11 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     target: { type: CUSTOM_FIELD },
   },
   {
+    src: { field: 'value', parentTypes: ['FieldSetItem'] },
+    serializationStrategy: 'relativeApiName',
+    target: { parentContext: 'instanceParent', type: 'RecordType' },
+  },
+  {
     // sometimes has a value that is not a reference - should only convert to reference
     // if lookupValueType exists
     src: { field: 'lookupValue', parentTypes: ['WorkflowFieldUpdate'] },

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -340,9 +340,9 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     target: { type: CUSTOM_FIELD },
   },
   {
-    src: { field: 'value', parentTypes: ['FieldSetItem'] },
+    src: { field: 'value', parentTypes: ['FilterItem'] },
     serializationStrategy: 'relativeApiName',
-    target: { parentContext: 'instanceParent', type: 'RecordType' },
+    target: { parentContext: 'instanceParent', type: RECORD_TYPE_METADATA_TYPE },
   },
   {
     // sometimes has a value that is not a reference - should only convert to reference


### PR DESCRIPTION
_Extract references from a filterItems to recordType_

---
_Additional context for reviewer_:
None

---
_Release Notes_: 
Salesforce-adapter:

* Add reference from the value field to recordType in value field from FilterItems_
---

_User Notifications_: 
* When creating a workFlow Rule with recordType as criteria, the value field of the criteria will be properly parsed as references off RecordType instance, showing up as ReferenceExpression in nacl
