### PR TITLE
SALTO-2253: Fixed lacking of space in CLI error messages 

### DIFF
--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -60,19 +60,19 @@ export const formatWordsSeries = (words: string[]): string => (words.length > 1
   */
 
 const formatSourceLocation = (sl: Readonly<SourceLocation>): string =>
-  `${chalk.underline(sl.sourceRange.filename)}(${chalk.cyan(`line: ${sl.sourceRange.start.line}`)})\n`
+  `${chalk.underline(sl.sourceRange.filename)}(${chalk.cyan(`line: ${sl.sourceRange.start.line}`)})`
 
 const formatSourceLocations = (sourceLocations: ReadonlyArray<SourceLocation>): string =>
-  (sourceLocations.length > 0
-    ? `\n on ${sourceLocations.map(formatSourceLocation).join('\n and ')}`
-    : '')
+  `${sourceLocations.map(formatSourceLocation).join(EOL)}`
 
-export const formatWorkspaceError = (we: Readonly<errors.WorkspaceError<SaltoError>>): string =>
-  `${formatError(we)}${formatSourceLocations(we.sourceLocations)}`
+export const formatWorkspaceError = (we: Readonly<errors.WorkspaceError<SaltoError>>): string => {
+  const possibleEOL = we.sourceLocations.length > 0 ? EOL : ''
+  return `${formatError(we)}${possibleEOL}${formatSourceLocations(we.sourceLocations)}`
+}
 
 const indent = (text: string, level: number): string => {
   const indentText = _.repeat('  ', level)
-  return text.split('\n').map(line => `${indentText}${line}`).join('\n')
+  return text.split(EOL).map(line => `${indentText}${line}`).join(EOL)
 }
 
 const singleOrPluralString = (number: number, single: string, plural: string): string =>
@@ -235,8 +235,7 @@ export const formatChangeErrors = (
         errorsIndent)
     }
     const formattedError = formatWorkspaceError(firstErr)
-    const possibleSpace = formattedError.trimEnd() === formattedError ? ' ' : ''
-    return indent(`${formattedError}${possibleSpace}${firstErr.severity}: ${firstErr.detailedMessage}`,
+    return indent(`${formattedError}${EOL}${firstErr.severity}: ${firstErr.detailedMessage}`,
       errorsIndent)
   }
   const ret = _(wsChangeErrors)

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -234,11 +234,9 @@ export const formatChangeErrors = (
       return indent(`${firstErr.severity}: ${formatError(firstErr)} (${groupedChangeErrors.length} Elements)`,
         errorsIndent)
     }
-    let formattedError = formatWorkspaceError(firstErr)
-    if (formattedError.trim() === formattedError) {
-      formattedError += ' '
-    }
-    return indent(`${formattedError}${firstErr.severity}: ${firstErr.detailedMessage}`,
+    const formattedError = formatWorkspaceError(firstErr)
+    const possibleSpace = formattedError.trimEnd() === formattedError ? ' ' : ''
+    return indent(`${formattedError}${possibleSpace}${firstErr.severity}: ${firstErr.detailedMessage}`,
       errorsIndent)
   }
   const ret = _(wsChangeErrors)

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -234,7 +234,10 @@ export const formatChangeErrors = (
       return indent(`${firstErr.severity}: ${formatError(firstErr)} (${groupedChangeErrors.length} Elements)`,
         errorsIndent)
     }
-    const formattedError = formatWorkspaceError(firstErr)
+    let formattedError = formatWorkspaceError(firstErr)
+    if (formattedError.trim() === formattedError) {
+      formattedError += ' '
+    }
     return indent(`${formattedError}${firstErr.severity}: ${firstErr.detailedMessage}`,
       errorsIndent)
   }

--- a/packages/cli/src/workspace/workspace.ts
+++ b/packages/cli/src/workspace/workspace.ts
@@ -16,6 +16,7 @@
 import _ from 'lodash'
 import wu from 'wu'
 import semver from 'semver'
+import { EOL } from 'os'
 import { FetchChange, Tags, StepEmitter } from '@salto-io/core'
 import { SaltoError, DetailedChange } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
@@ -114,7 +115,7 @@ export const formatWorkspaceErrors = async (
     .slice(0, MAX_WORKSPACE_ERRORS_TO_LOG)
     .map(err => workspace.transformError(err))
     .map(async err => formatWorkspaceError(await err))
-)).join('\n')
+)).join(EOL)
 
 const printWorkspaceErrors = async (
   status: WorkspaceStatusErrors['status'],

--- a/packages/cli/test/formatter.test.ts
+++ b/packages/cli/test/formatter.test.ts
@@ -173,7 +173,34 @@ describe('formatter', () => {
       expect(output).toMatch(new RegExp(`${EOL} *Error`)) // "Error" is not proceeded by EOL with indentation
     })
     it('should not contain double EOL in change error with several locations', () => {
-      const output = formatChangeErrors(workspaceErrorWithSourceLocations)
+      const changeErrorWithLocations: ReadonlyArray<wsErrors.WorkspaceError<ChangeError>> = [{
+        sourceLocations: [{
+          sourceRange: {
+            start: { byte: 20, col: 10, line: 5 },
+            end: { byte: 30, col: 10, line: 3 },
+            filename: 'test.nacl',
+          },
+        },
+        {
+          sourceRange: {
+            start: { byte: 100, col: 10, line: 15 },
+            end: { byte: 150, col: 10, line: 15 },
+            filename: 'test.nacl',
+          },
+        },
+        {
+          sourceRange: {
+            start: { byte: 100, col: 10, line: 25 },
+            end: { byte: 150, col: 10, line: 15 },
+            filename: 'test2.nacl',
+          },
+        }],
+        message: 'Operation not supported',
+        detailedMessage: 'Salto does not support "remove" of zendesk...',
+        severity: 'Error',
+        elemID: new ElemID('salesforce', 'test'),
+      }]
+      const output = formatChangeErrors(changeErrorWithLocations)
       expect(output).not.toMatch(new RegExp(`${EOL} *${EOL}`)) // does not contain two EOL with only indent between them
     })
     it('should order validations from most to least occurrences', () => {

--- a/packages/cli/test/formatter.test.ts
+++ b/packages/cli/test/formatter.test.ts
@@ -164,6 +164,18 @@ describe('formatter', () => {
       expect(output)
         .toMatch(new RegExp(`.*${changeErrors[0].message}.*2 Elements`, 's'))
     })
+    it('should contain space between title and content', () => {
+      const changeErrors: ReadonlyArray<wsErrors.WorkspaceError<ChangeError>> = [{
+        elemID: new ElemID('salesforce', 'test'),
+        severity: 'Error',
+        message: 'Message key for test',
+        detailedMessage: 'Validation message',
+        sourceLocations: [],
+      }]
+      const output = formatChangeErrors(changeErrors)
+      expect(output)
+        .toContain(' Error')
+    })
     it('should order validations from most to least occurrences', () => {
       const differentValidationKey: wsErrors.WorkspaceError<ChangeError> = {
         elemID: new ElemID('salesforce', 'test3'),

--- a/packages/cli/test/formatter.test.ts
+++ b/packages/cli/test/formatter.test.ts
@@ -17,6 +17,7 @@ import {
   ObjectType, InstanceElement, ElemID, ChangeError, SaltoError, PrimitiveType,
   PrimitiveTypes, BuiltinTypes, StaticFile,
 } from '@salto-io/adapter-api'
+import { EOL } from 'os'
 import { FetchChange } from '@salto-io/core'
 import { errors as wsErrors } from '@salto-io/workspace'
 import chalk from 'chalk'
@@ -160,7 +161,7 @@ describe('formatter', () => {
       expect(output).toContain('Error')
       expect(output).toMatch(new RegExp(`.*${changeErrors[0].message}.*2 Elements`, 's'))
     })
-    it('should contain space between title and content', () => {
+    it('should contain EOL between title and content', () => {
       const changeErrors: ReadonlyArray<wsErrors.WorkspaceError<ChangeError>> = [{
         elemID: new ElemID('salesforce', 'test'),
         severity: 'Error',
@@ -169,7 +170,11 @@ describe('formatter', () => {
         sourceLocations: [],
       }]
       const output = formatChangeErrors(changeErrors)
-      expect(output).toContain(' Error')
+      expect(output).toMatch(new RegExp(`${EOL} *Error`)) // "Error" is not proceeded by EOL with indentation
+    })
+    it('should not contain double EOL in change error with several locations', () => {
+      const output = formatChangeErrors(workspaceErrorWithSourceLocations)
+      expect(output).not.toMatch(new RegExp(`${EOL} *${EOL}`)) // does not contain two EOL with only indent between them
     })
     it('should order validations from most to least occurrences', () => {
       const differentValidationKey: wsErrors.WorkspaceError<ChangeError> = {

--- a/packages/cli/test/formatter.test.ts
+++ b/packages/cli/test/formatter.test.ts
@@ -135,10 +135,8 @@ describe('formatter', () => {
         sourceLocations: workspaceErrorWithSourceLocations.sourceLocations,
       }]
       const output = formatChangeErrors(changeErrors)
-      expect(output)
-        .toContain('Error')
-      expect(output)
-        .toMatch(new RegExp(`.*${changeErrors[0].detailedMessage}`, 's'))
+      expect(output).toContain('Error')
+      expect(output).toMatch(new RegExp(`.*${changeErrors[0].detailedMessage}`, 's'))
       expect(output).toMatch(new RegExp(`.*${workspaceErrorWithSourceLocations.sourceLocations[0].sourceRange.filename}`, 's'))
     })
     it('should have grouped validations', () => {
@@ -159,10 +157,8 @@ describe('formatter', () => {
 
       }]
       const output = formatChangeErrors(changeErrors)
-      expect(output)
-        .toContain('Error')
-      expect(output)
-        .toMatch(new RegExp(`.*${changeErrors[0].message}.*2 Elements`, 's'))
+      expect(output).toContain('Error')
+      expect(output).toMatch(new RegExp(`.*${changeErrors[0].message}.*2 Elements`, 's'))
     })
     it('should contain space between title and content', () => {
       const changeErrors: ReadonlyArray<wsErrors.WorkspaceError<ChangeError>> = [{
@@ -173,8 +169,7 @@ describe('formatter', () => {
         sourceLocations: [],
       }]
       const output = formatChangeErrors(changeErrors)
-      expect(output)
-        .toContain(' Error')
+      expect(output).toContain(' Error')
     })
     it('should order validations from most to least occurrences', () => {
       const differentValidationKey: wsErrors.WorkspaceError<ChangeError> = {
@@ -200,10 +195,8 @@ describe('formatter', () => {
       },
       differentValidationKey]
       const output = formatChangeErrors(changeErrors)
-      expect(output)
-        .toContain('Error')
-      expect(output)
-        .toMatch(new RegExp(`.*${changeErrors[0].message}.*2 Elements.*\n.*${differentValidationKey.detailedMessage}`, 's'))
+      expect(output).toContain('Error')
+      expect(output).toMatch(new RegExp(`.*${changeErrors[0].message}.*2 Elements.*\n.*${differentValidationKey.detailedMessage}`, 's'))
     })
   })
 


### PR DESCRIPTION
Fixed lacking of space in CLI error messages 

---

---

_Release Notes_: 
_CLI_:
In certain error messages (for instance failure to deploy when operation is not supported) a space was added between the header and the main message.

---

_User Notifications_: 
None