### PR TITLE
SALTO-2302 Change Jira status deployment to the new statuses API

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/index.ts
@@ -16,7 +16,7 @@
 import { InstanceElement, Element, ElemID, CORE_ANNOTATIONS, ReferenceExpression } from '@salto-io/adapter-api'
 import { naclCase } from '@salto-io/adapter-utils'
 import { CUSTOM_FIELDS_SUFFIX } from '../../src/filters/fields/field_name_filter'
-import { AUTOMATION_TYPE, ISSUE_TYPE_NAME, ISSUE_TYPE_SCHEMA_NAME, JIRA, NOTIFICATION_SCHEME_TYPE_NAME, SECURITY_LEVEL_TYPE, SECURITY_SCHEME_TYPE, WEBHOOK_TYPE, WORKFLOW_TYPE_NAME } from '../../src/constants'
+import { AUTOMATION_TYPE, ISSUE_TYPE_NAME, ISSUE_TYPE_SCHEMA_NAME, JIRA, NOTIFICATION_SCHEME_TYPE_NAME, SECURITY_LEVEL_TYPE, SECURITY_SCHEME_TYPE, WEBHOOK_TYPE, WORKFLOW_TYPE_NAME, STATUS_TYPE_NAME } from '../../src/constants'
 import { createReference, findType } from '../utils'
 import { createKanbanBoardValues, createScrumBoardValues } from './board'
 import { createContextValues, createFieldValues } from './field'
@@ -32,6 +32,7 @@ import { createDashboardValues, createGadget1Values, createGadget2Values } from 
 import { createNotificationSchemeValues } from './notificationScheme'
 import { createAutomationValues } from './automation'
 import { createWebhookValues } from './webhook'
+import { createStatusValues } from './status'
 
 export const createInstances = (fetchedElements: Element[]): InstanceElement[][] => {
   const randomString = `createdByOssE2e${String(Date.now()).substring(6)}`
@@ -230,6 +231,12 @@ export const createInstances = (fetchedElements: Element[]): InstanceElement[][]
     },
   )
 
+  const status = new InstanceElement(
+    randomString.toLowerCase(),
+    findType(STATUS_TYPE_NAME, fetchedElements),
+    createStatusValues(randomString.toLowerCase(), fetchedElements),
+  )
+
   return [
     [issueType],
     [field],
@@ -256,5 +263,6 @@ export const createInstances = (fetchedElements: Element[]): InstanceElement[][]
     [automation],
     [webhook],
     [group],
+    [status],
   ]
 }

--- a/packages/jira-adapter/e2e_test/instances/status.ts
+++ b/packages/jira-adapter/e2e_test/instances/status.ts
@@ -1,0 +1,24 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, Values, Element } from '@salto-io/adapter-api'
+import { createReference } from '../utils'
+import { JIRA } from '../../src/constants'
+
+export const createStatusValues = (name: string, allElements: Element[]): Values => ({
+  name,
+  description: `description for ${name}`,
+  statusCategory: createReference(new ElemID(JIRA, 'StatusCategory', 'instance', 'Done'), allElements),
+})

--- a/packages/jira-adapter/src/change_validators/status.ts
+++ b/packages/jira-adapter/src/change_validators/status.ts
@@ -13,11 +13,12 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ChangeValidator, getChangeData, isAdditionOrModificationChange, isInstanceChange, SeverityLevel } from '@salto-io/adapter-api'
+import { ChangeValidator, getChangeData, isAdditionOrModificationChange, isInstanceChange, SeverityLevel, isReferenceExpression } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { STATUS_TYPE_NAME } from '../constants'
 
 const { awu } = collections.asynciterable
+const NO_CATEGORY_STATUS = 'jira.StatusCategory.instance.No_Category@s'
 
 export const statusValidator: ChangeValidator = async changes => (
   awu(changes)
@@ -25,12 +26,14 @@ export const statusValidator: ChangeValidator = async changes => (
     .filter(isAdditionOrModificationChange)
     .map(getChangeData)
     .filter(instance => instance.elemID.typeName === STATUS_TYPE_NAME)
-    .filter(instance => instance.value.statusCategory === undefined)
+    .filter(instance =>
+      isReferenceExpression(instance.value.statusCategory)
+      && instance.value.statusCategory.elemID.getFullName() === NO_CATEGORY_STATUS)
     .map(async instance => ({
       elemID: instance.elemID,
       severity: 'Error' as SeverityLevel,
-      message: 'statusCategory is required in order to deploy statuses',
-      detailedMessage: `The status ${instance.elemID.getFullName()} is missing statusCategory`,
+      message: 'statusCategory can not have No_Category value',
+      detailedMessage: `The status ${instance.elemID.getFullName()} have an invalid statusCategory, statusCategory should be one of the following: [ Done, In_Progress, To_Do ]`,
     }))
     .toArray()
 )

--- a/packages/jira-adapter/src/change_validators/status.ts
+++ b/packages/jira-adapter/src/change_validators/status.ts
@@ -18,7 +18,7 @@ import { collections } from '@salto-io/lowerdash'
 import { STATUS_TYPE_NAME } from '../constants'
 
 const { awu } = collections.asynciterable
-const NO_CATEGORY_STATUS = 'jira.StatusCategory.instance.No_Category@s'
+const NO_CATEGORY_STATUS = 'No Category'
 
 export const statusValidator: ChangeValidator = async changes => (
   awu(changes)
@@ -28,12 +28,12 @@ export const statusValidator: ChangeValidator = async changes => (
     .filter(instance => instance.elemID.typeName === STATUS_TYPE_NAME)
     .filter(instance =>
       isReferenceExpression(instance.value.statusCategory)
-      && instance.value.statusCategory.elemID.getFullName() === NO_CATEGORY_STATUS)
+      && instance.value.statusCategory.value.value.name === NO_CATEGORY_STATUS)
     .map(async instance => ({
       elemID: instance.elemID,
       severity: 'Error' as SeverityLevel,
       message: 'statusCategory can not have No_Category value',
-      detailedMessage: `The status ${instance.elemID.getFullName()} have an invalid statusCategory, statusCategory should be one of the following: [ Done, In_Progress, To_Do ]`,
+      detailedMessage: `The status ${instance.elemID.getFullName()} has an invalid statusCategory, statusCategory should be one of the following: [ Done, In_Progress, To_Do ]`,
     }))
     .toArray()
 )

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1286,11 +1286,11 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       ],
       serviceUrl: '/secure/admin/EditStatus!default.jspa?id={id}',
     },
-    jspRequests: {
-      add: '/secure/admin/AddStatus.jspa',
-      modify: '/secure/admin/EditStatus.jspa',
-      remove: '/secure/admin/DeleteStatus.jspa',
-      query: '/rest/workflowDesigner/1.0/statuses',
+    deployRequests: {
+      remove: {
+        url: '/rest/api/3/statuses?id={id}',
+        method: 'delete',
+      },
     },
   },
 

--- a/packages/jira-adapter/src/filters/statuses/status_deployment.ts
+++ b/packages/jira-adapter/src/filters/statuses/status_deployment.ts
@@ -13,13 +13,18 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { CORE_ANNOTATIONS, Element, getChangeData, isInstanceChange, isInstanceElement } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, Element, isInstanceElement, isInstanceChange, getChangeData, Change, InstanceElement, isAdditionOrModificationChange, DeployResult, isModificationChange, AdditionChange, ModificationChange, Values, isReferenceExpression, ReferenceExpression } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
+import { collections } from '@salto-io/lowerdash'
+import { applyFunctionToChangeData, resolveValues } from '@salto-io/adapter-utils'
+import { getLookUpName } from '../../reference_mapping'
 import { findObject, setFieldDeploymentAnnotations } from '../../utils'
 import { FilterCreator } from '../../filter'
-import { deployWithJspEndpoints } from '../../deployment/jsp_deployment'
 import { STATUS_TYPE_NAME } from '../../constants'
+import JiraClient from '../../client/client'
+
+const { awu } = collections.asynciterable
 
 const log = logger(module)
 const STATUS_CATEGORY_NAME_TO_ID : Record<string, number> = {
@@ -27,74 +32,186 @@ const STATUS_CATEGORY_NAME_TO_ID : Record<string, number> = {
   DONE: 3,
   IN_PROGRESS: 4,
 }
+const STATUS_CATEGORY_ID_TO_NAME : Record<number, string> = {
+  2: 'TODO',
+  3: 'DONE',
+  4: 'IN_PROGRESS',
+}
+const STATUS_DEPLOYMENT_LIMIT = 50
 
-const filter: FilterCreator = ({ client, config }) => ({
-  onFetch: async (elements: Element[]) => {
-    elements
-      .filter(isInstanceElement)
-      .filter(instance => instance.elemID.typeName === STATUS_TYPE_NAME)
-      .filter(instance => instance.value.statusCategory !== undefined)
-      .forEach(instance => {
+const modifyStatuses = async (
+  modificationValues: Values[],
+  client: JiraClient,
+): Promise<void> => {
+  await Promise.all(
+    _.chunk(modificationValues, STATUS_DEPLOYMENT_LIMIT)
+      .map(async statusChunk =>
+        client.put({
+          url: '/rest/api/3/statuses',
+          data: {
+            statuses: statusChunk,
+          },
+        }))
+  )
+}
+
+const addStatuses = async (
+  additionValues: Values[],
+  client: JiraClient,
+): Promise<void> => {
+  await Promise.all(
+    _.chunk(additionValues, STATUS_DEPLOYMENT_LIMIT)
+      .map(async statusChunk =>
+        client.post({
+          url: '/rest/api/3/statuses',
+          data: {
+            scope: {
+              type: 'GLOBAL',
+            },
+            statuses: statusChunk,
+          },
+        }))
+  )
+}
+
+const deployStatuses = async (
+  changes: Array<AdditionChange<InstanceElement> | ModificationChange<InstanceElement>>,
+  client: JiraClient,
+): Promise<void> => {
+  const [modificationValues, additionValues] = _.partition(changes,
+    change => isModificationChange(change))
+    .map(changesByType =>
+      changesByType
+        .map(getChangeData)
+        .map(instance => instance.value))
+
+  if (modificationValues.length > 0) {
+    await modifyStatuses(modificationValues, client)
+  }
+
+  if (additionValues.length > 0) {
+    await addStatuses(additionValues, client)
+  }
+}
+
+const filter: FilterCreator = ({ client, config }) => {
+  let statusCategoryReferences: Record<string, ReferenceExpression>
+  return {
+    onFetch: async (elements: Element[]) => {
+      elements
+        .filter(isInstanceElement)
+        .filter(instance => instance.elemID.typeName === STATUS_TYPE_NAME)
+        .filter(instance => instance.value.statusCategory !== undefined)
+        .forEach(instance => {
         // statusCategory has a fixed number of options so we map the statusCategory name to its id
-        instance.value.statusCategory = STATUS_CATEGORY_NAME_TO_ID[instance.value.statusCategory]
+          instance.value.statusCategory = STATUS_CATEGORY_NAME_TO_ID[instance.value.statusCategory]
         ?? instance.value.statusCategory
-      })
+        })
 
-    if (!config.client.usePrivateAPI) {
-      log.debug('Skipping status deployment filter because private API is not enabled')
-      return
-    }
+      if (!config.client.usePrivateAPI) {
+        log.debug('Skipping status deployment filter because private API is not enabled')
+        return
+      }
 
-    const statusType = findObject(elements, STATUS_TYPE_NAME)
-    if (statusType === undefined) {
-      return
-    }
+      const statusType = findObject(elements, STATUS_TYPE_NAME)
+      if (statusType === undefined) {
+        return
+      }
 
-    statusType.annotations[CORE_ANNOTATIONS.CREATABLE] = true
-    statusType.annotations[CORE_ANNOTATIONS.UPDATABLE] = true
-    statusType.annotations[CORE_ANNOTATIONS.DELETABLE] = true
-    setFieldDeploymentAnnotations(statusType, 'statusCategory')
-    setFieldDeploymentAnnotations(statusType, 'description')
-    setFieldDeploymentAnnotations(statusType, 'name')
-    setFieldDeploymentAnnotations(statusType, 'id')
-  },
+      statusType.annotations[CORE_ANNOTATIONS.CREATABLE] = true
+      statusType.annotations[CORE_ANNOTATIONS.UPDATABLE] = true
+      statusType.annotations[CORE_ANNOTATIONS.DELETABLE] = true
+      setFieldDeploymentAnnotations(statusType, 'statusCategory')
+      setFieldDeploymentAnnotations(statusType, 'description')
+      setFieldDeploymentAnnotations(statusType, 'name')
+      setFieldDeploymentAnnotations(statusType, 'id')
+    },
 
-  deploy: async changes => {
-    const [relevantChanges, leftoverChanges] = _.partition(
-      changes,
-      change => isInstanceChange(change)
+    preDeploy: async changes => {
+      statusCategoryReferences = Object.fromEntries(changes
+        .filter(isInstanceChange)
+        .filter(isAdditionOrModificationChange)
+        .filter(change => getChangeData(change).elemID.typeName === STATUS_TYPE_NAME)
+        .map(change => getChangeData(change))
+        .filter(isInstanceElement)
+        .filter(instance => isReferenceExpression(instance.value.statusCategory))
+        .map(instance =>
+          [instance.elemID.getFullName(), _.cloneDeep(instance.value.statusCategory)]))
+
+      await awu(changes)
+        .filter(isInstanceChange)
+        .filter(isAdditionOrModificationChange)
+        .filter(change => getChangeData(change).elemID.typeName === STATUS_TYPE_NAME)
+        .forEach(async change => applyFunctionToChangeData<Change<InstanceElement>>(
+          change,
+          async instance => {
+            const resolvedInstance = await resolveValues(instance, getLookUpName)
+            instance.value.statusCategory = STATUS_CATEGORY_ID_TO_NAME[
+              resolvedInstance.value.statusCategory
+            ]
+            return instance
+          },
+        ))
+    },
+
+    deploy: async changes => {
+      const [relevantChanges, leftoverChanges] = _.partition(
+        changes,
+        change => isInstanceChange(change)
+        && isAdditionOrModificationChange(change)
         && getChangeData(change).elemID.typeName === STATUS_TYPE_NAME
-    )
+      )
 
-    if (relevantChanges.length === 0) {
+      if (relevantChanges.length === 0) {
+        return {
+          leftoverChanges,
+          deployResult: {
+            errors: [],
+            appliedChanges: [],
+          },
+        }
+      }
+
+      let deployResult: DeployResult
+      try {
+        await deployStatuses(
+          relevantChanges
+            .filter(isInstanceChange)
+            .filter(isAdditionOrModificationChange),
+          client,
+        )
+        deployResult = {
+          errors: [],
+          appliedChanges: relevantChanges,
+        }
+      } catch (err) {
+        deployResult = {
+          errors: [err],
+          appliedChanges: [],
+        }
+      }
+
       return {
         leftoverChanges,
-        deployResult: {
-          errors: [],
-          appliedChanges: [],
-        },
+        deployResult,
       }
-    }
+    },
 
-    const jspRequests = config.apiDefinitions.types[STATUS_TYPE_NAME]?.jspRequests
-    if (jspRequests === undefined) {
-      throw new Error(`${STATUS_TYPE_NAME} jsp urls are missing from the configuration`)
-    }
-
-    const deployResult = await deployWithJspEndpoints({
-      changes: relevantChanges.filter(isInstanceChange),
-      client,
-      urls: jspRequests,
-      serviceValuesTransformer: (serviceValues, currentInstance) => _.omit({
-        ...currentInstance.value,
-        ...serviceValues,
-      }, 'iconURL'),
-    })
-    return {
-      leftoverChanges,
-      deployResult,
-    }
-  },
-})
+    onDeploy: async changes => {
+      changes
+        .filter(isInstanceChange)
+        .filter(isAdditionOrModificationChange)
+        .filter(change => getChangeData(change).elemID.typeName === STATUS_TYPE_NAME)
+        .forEach(async change => applyFunctionToChangeData<Change<InstanceElement>>(
+          change,
+          async instance => {
+            const originalReference = statusCategoryReferences[instance.elemID.getFullName()]
+            instance.value.statusCategory = originalReference
+            return instance
+          },
+        ))
+    },
+  }
+}
 
 export default filter

--- a/packages/jira-adapter/src/filters/statuses/status_deployment.ts
+++ b/packages/jira-adapter/src/filters/statuses/status_deployment.ts
@@ -13,18 +13,14 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { CORE_ANNOTATIONS, Element, isInstanceElement, isInstanceChange, getChangeData, Change, InstanceElement, isAdditionOrModificationChange, DeployResult, isModificationChange, AdditionChange, ModificationChange, Values, isReferenceExpression, ReferenceExpression } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, Element, isInstanceElement, isInstanceChange, getChangeData, Change, InstanceElement, isAdditionOrModificationChange, DeployResult, isModificationChange, AdditionChange, ModificationChange, Values, isReferenceExpression, isAdditionChange } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
-import { collections } from '@salto-io/lowerdash'
-import { applyFunctionToChangeData, resolveValues } from '@salto-io/adapter-utils'
-import { getLookUpName } from '../../reference_mapping'
+import { client as clientUtils } from '@salto-io/adapter-components'
 import { findObject, setFieldDeploymentAnnotations } from '../../utils'
 import { FilterCreator } from '../../filter'
 import { STATUS_TYPE_NAME } from '../../constants'
 import JiraClient from '../../client/client'
-
-const { awu } = collections.asynciterable
 
 const log = logger(module)
 const STATUS_CATEGORY_NAME_TO_ID : Record<string, number> = {
@@ -32,186 +28,169 @@ const STATUS_CATEGORY_NAME_TO_ID : Record<string, number> = {
   DONE: 3,
   IN_PROGRESS: 4,
 }
-const STATUS_CATEGORY_ID_TO_NAME : Record<number, string> = {
-  2: 'TODO',
-  3: 'DONE',
-  4: 'IN_PROGRESS',
-}
 const STATUS_DEPLOYMENT_LIMIT = 50
 
+const createDeployableStatusValues = (
+  statusChanges: Array<Change<InstanceElement>>
+): Values[] => statusChanges
+  .map(getChangeData)
+  .map(instance => instance.value)
+  .map(value => {
+    const deployableValue = _.clone(value)
+    if (isReferenceExpression(value.statusCategory)) {
+      // resolve statusCategory value before deploy
+      const resolvedCategory = _.invert(STATUS_CATEGORY_NAME_TO_ID) [
+        value.statusCategory.value.value.id
+      ]
+      deployableValue.statusCategory = resolvedCategory
+    }
+    return deployableValue
+  })
+
+const setStatusIds = (
+  changes: Array<AdditionChange<InstanceElement>>,
+  response: clientUtils.ResponseValue[],
+): void => {
+  changes
+    .map(getChangeData)
+    .forEach(instance => {
+      const responseValue = response.find(r => r.name === instance.value.name)
+      if (responseValue !== undefined) {
+        instance.value.id = responseValue.id
+      }
+    })
+}
+
 const modifyStatuses = async (
-  modificationValues: Values[],
+  modificationChanges: Array<ModificationChange<InstanceElement>>,
   client: JiraClient,
 ): Promise<void> => {
-  await Promise.all(
-    _.chunk(modificationValues, STATUS_DEPLOYMENT_LIMIT)
-      .map(async statusChunk =>
-        client.put({
-          url: '/rest/api/3/statuses',
-          data: {
-            statuses: statusChunk,
-          },
-        }))
-  )
+  await client.put({
+    url: '/rest/api/3/statuses',
+    data: {
+      statuses: createDeployableStatusValues(modificationChanges),
+    },
+  })
 }
 
 const addStatuses = async (
-  additionValues: Values[],
+  additionChanges: Array<AdditionChange<InstanceElement>>,
   client: JiraClient,
 ): Promise<void> => {
-  await Promise.all(
-    _.chunk(additionValues, STATUS_DEPLOYMENT_LIMIT)
-      .map(async statusChunk =>
-        client.post({
-          url: '/rest/api/3/statuses',
-          data: {
-            scope: {
-              type: 'GLOBAL',
-            },
-            statuses: statusChunk,
-          },
-        }))
-  )
+  const response = await client.post({
+    url: '/rest/api/3/statuses',
+    data: {
+      scope: {
+        type: 'GLOBAL',
+      },
+      statuses: createDeployableStatusValues(additionChanges),
+    },
+  })
+  setStatusIds(additionChanges, response.data as clientUtils.ResponseValue[])
 }
 
 const deployStatuses = async (
   changes: Array<AdditionChange<InstanceElement> | ModificationChange<InstanceElement>>,
   client: JiraClient,
-): Promise<void> => {
-  const [modificationValues, additionValues] = _.partition(changes,
-    change => isModificationChange(change))
-    .map(changesByType =>
-      changesByType
-        .map(getChangeData)
-        .map(instance => instance.value))
+): Promise<DeployResult> => {
+  const deployErrors: Error[] = []
 
-  if (modificationValues.length > 0) {
-    await modifyStatuses(modificationValues, client)
-  }
+  await Promise.all(
+    _.chunk(changes, STATUS_DEPLOYMENT_LIMIT)
+      .map(async statusChangesChunk => {
+        try {
+          const [modificationChanges, additionChanges] = _.partition(
+            changes,
+            change => isModificationChange(change),
+          )
 
-  if (additionValues.length > 0) {
-    await addStatuses(additionValues, client)
+          if (modificationChanges.length > 0) {
+            await modifyStatuses(
+              statusChangesChunk.filter(isModificationChange),
+              client
+            )
+          }
+
+          if (additionChanges.length > 0) {
+            await addStatuses(
+              statusChangesChunk.filter(isAdditionChange),
+              client
+            )
+          }
+        } catch (err) {
+          _.pullAll(changes, statusChangesChunk)
+          deployErrors.push(err)
+        }
+      })
+  )
+
+  return {
+    appliedChanges: changes,
+    errors: deployErrors,
   }
 }
 
-const filter: FilterCreator = ({ client, config }) => {
-  let statusCategoryReferences: Record<string, ReferenceExpression>
-  return {
-    onFetch: async (elements: Element[]) => {
-      elements
-        .filter(isInstanceElement)
-        .filter(instance => instance.elemID.typeName === STATUS_TYPE_NAME)
-        .filter(instance => instance.value.statusCategory !== undefined)
-        .forEach(instance => {
+const filter: FilterCreator = ({ client, config }) => ({
+  onFetch: async (elements: Element[]) => {
+    elements
+      .filter(isInstanceElement)
+      .filter(instance => instance.elemID.typeName === STATUS_TYPE_NAME)
+      .filter(instance => instance.value.statusCategory !== undefined)
+      .forEach(instance => {
         // statusCategory has a fixed number of options so we map the statusCategory name to its id
-          instance.value.statusCategory = STATUS_CATEGORY_NAME_TO_ID[instance.value.statusCategory]
+        instance.value.statusCategory = STATUS_CATEGORY_NAME_TO_ID[instance.value.statusCategory]
         ?? instance.value.statusCategory
-        })
+      })
 
-      if (!config.client.usePrivateAPI) {
-        log.debug('Skipping status deployment filter because private API is not enabled')
-        return
-      }
+    if (!config.client.usePrivateAPI) {
+      log.debug('Skipping status deployment filter because private API is not enabled')
+      return
+    }
 
-      const statusType = findObject(elements, STATUS_TYPE_NAME)
-      if (statusType === undefined) {
-        return
-      }
+    const statusType = findObject(elements, STATUS_TYPE_NAME)
+    if (statusType === undefined) {
+      return
+    }
 
-      statusType.annotations[CORE_ANNOTATIONS.CREATABLE] = true
-      statusType.annotations[CORE_ANNOTATIONS.UPDATABLE] = true
-      statusType.annotations[CORE_ANNOTATIONS.DELETABLE] = true
-      setFieldDeploymentAnnotations(statusType, 'statusCategory')
-      setFieldDeploymentAnnotations(statusType, 'description')
-      setFieldDeploymentAnnotations(statusType, 'name')
-      setFieldDeploymentAnnotations(statusType, 'id')
-    },
+    statusType.annotations[CORE_ANNOTATIONS.CREATABLE] = true
+    statusType.annotations[CORE_ANNOTATIONS.UPDATABLE] = true
+    statusType.annotations[CORE_ANNOTATIONS.DELETABLE] = true
+    setFieldDeploymentAnnotations(statusType, 'statusCategory')
+    setFieldDeploymentAnnotations(statusType, 'description')
+    setFieldDeploymentAnnotations(statusType, 'name')
+    setFieldDeploymentAnnotations(statusType, 'id')
+  },
 
-    preDeploy: async changes => {
-      statusCategoryReferences = Object.fromEntries(changes
-        .filter(isInstanceChange)
-        .filter(isAdditionOrModificationChange)
-        .filter(change => getChangeData(change).elemID.typeName === STATUS_TYPE_NAME)
-        .map(change => getChangeData(change))
-        .filter(isInstanceElement)
-        .filter(instance => isReferenceExpression(instance.value.statusCategory))
-        .map(instance =>
-          [instance.elemID.getFullName(), _.cloneDeep(instance.value.statusCategory)]))
-
-      await awu(changes)
-        .filter(isInstanceChange)
-        .filter(isAdditionOrModificationChange)
-        .filter(change => getChangeData(change).elemID.typeName === STATUS_TYPE_NAME)
-        .forEach(async change => applyFunctionToChangeData<Change<InstanceElement>>(
-          change,
-          async instance => {
-            const resolvedInstance = await resolveValues(instance, getLookUpName)
-            instance.value.statusCategory = STATUS_CATEGORY_ID_TO_NAME[
-              resolvedInstance.value.statusCategory
-            ]
-            return instance
-          },
-        ))
-    },
-
-    deploy: async changes => {
-      const [relevantChanges, leftoverChanges] = _.partition(
-        changes,
-        change => isInstanceChange(change)
+  deploy: async changes => {
+    const [relevantChanges, leftoverChanges] = _.partition(
+      changes,
+      change => isInstanceChange(change)
         && isAdditionOrModificationChange(change)
         && getChangeData(change).elemID.typeName === STATUS_TYPE_NAME
-      )
+    )
 
-      if (relevantChanges.length === 0) {
-        return {
-          leftoverChanges,
-          deployResult: {
-            errors: [],
-            appliedChanges: [],
-          },
-        }
-      }
-
-      let deployResult: DeployResult
-      try {
-        await deployStatuses(
-          relevantChanges
-            .filter(isInstanceChange)
-            .filter(isAdditionOrModificationChange),
-          client,
-        )
-        deployResult = {
-          errors: [],
-          appliedChanges: relevantChanges,
-        }
-      } catch (err) {
-        deployResult = {
-          errors: [err],
-          appliedChanges: [],
-        }
-      }
-
+    if (relevantChanges.length === 0) {
       return {
         leftoverChanges,
-        deployResult,
+        deployResult: {
+          errors: [],
+          appliedChanges: [],
+        },
       }
-    },
+    }
 
-    onDeploy: async changes => {
-      changes
+    const deployResult = await deployStatuses(
+      relevantChanges
         .filter(isInstanceChange)
-        .filter(isAdditionOrModificationChange)
-        .filter(change => getChangeData(change).elemID.typeName === STATUS_TYPE_NAME)
-        .forEach(async change => applyFunctionToChangeData<Change<InstanceElement>>(
-          change,
-          async instance => {
-            const originalReference = statusCategoryReferences[instance.elemID.getFullName()]
-            instance.value.statusCategory = originalReference
-            return instance
-          },
-        ))
-    },
-  }
-}
+        .filter(isAdditionOrModificationChange),
+      client,
+    )
+
+    return {
+      leftoverChanges,
+      deployResult,
+    }
+  },
+})
 
 export default filter

--- a/packages/jira-adapter/src/group_change.ts
+++ b/packages/jira-adapter/src/group_change.ts
@@ -16,7 +16,7 @@
 import { collections, values } from '@salto-io/lowerdash'
 import { ChangeGroupIdFunction, getChangeData, ChangeGroupId, ChangeId, isModificationChange, Change, isAdditionChange, isReferenceExpression } from '@salto-io/adapter-api'
 import { getParent, getParents } from '@salto-io/adapter-utils'
-import { FIELD_CONFIGURATION_ITEM_TYPE_NAME, SECURITY_LEVEL_TYPE, WORKFLOW_TYPE_NAME } from './constants'
+import { FIELD_CONFIGURATION_ITEM_TYPE_NAME, SECURITY_LEVEL_TYPE, WORKFLOW_TYPE_NAME, STATUS_TYPE_NAME } from './constants'
 
 const { awu } = collections.asynciterable
 
@@ -57,10 +57,21 @@ const getFieldConfigItemGroup: ChangeIdFunction = async change => {
   return `${parent.elemID.getFullName()} items`
 }
 
+const getStatusGroup: ChangeIdFunction = async change => {
+  const { typeName } = getChangeData(change).elemID
+  if (isModificationChange(change) && typeName === STATUS_TYPE_NAME) {
+    return 'Status Modifications'
+  } if (isAdditionChange(change) && typeName === STATUS_TYPE_NAME) {
+    return 'Status Additions'
+  }
+  return undefined
+}
+
 const changeIdProviders: ChangeIdFunction[] = [
   getWorkflowGroup,
   getSecurityLevelGroup,
   getFieldConfigItemGroup,
+  getStatusGroup,
 ]
 
 export const getChangeGroupIds: ChangeGroupIdFunction = async changes => ({

--- a/packages/jira-adapter/test/change_validators/status.test.ts
+++ b/packages/jira-adapter/test/change_validators/status.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { toChange, ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { toChange, ObjectType, ElemID, InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
 import { statusValidator } from '../../src/change_validators/status'
 import { JIRA, STATUS_TYPE_NAME } from '../../src/constants'
 
@@ -25,7 +25,10 @@ describe('statusValidator', () => {
     type = new ObjectType({ elemID: new ElemID(JIRA, STATUS_TYPE_NAME) })
     instance = new InstanceElement('instance', type)
   })
-  it('should return if status does not have a category', async () => {
+  it('should return if status category is No_Category', async () => {
+    instance.value.statusCategory = new ReferenceExpression(
+      new ElemID(JIRA, 'StatusCategory', 'instance', 'No_Category@s')
+    )
     expect(await statusValidator([
       toChange({
         after: instance,
@@ -34,14 +37,16 @@ describe('statusValidator', () => {
       {
         elemID: instance.elemID,
         severity: 'Error',
-        message: 'statusCategory is required in order to deploy statuses',
-        detailedMessage: 'The status jira.Status.instance.instance is missing statusCategory',
+        message: 'statusCategory can not have No_Category value',
+        detailedMessage: 'The status jira.Status.instance.instance have an invalid statusCategory, statusCategory should be one of the following: [ Done, In_Progress, To_Do ]',
       },
     ])
   })
 
-  it('should not return an error if there is status category', async () => {
-    instance.value.statusCategory = '1'
+  it('should not return an error if status category is not No_Category', async () => {
+    instance.value.statusCategory = new ReferenceExpression(
+      new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'Done')
+    )
 
     expect(await statusValidator([
       toChange({

--- a/packages/jira-adapter/test/change_validators/status.test.ts
+++ b/packages/jira-adapter/test/change_validators/status.test.ts
@@ -20,14 +20,38 @@ import { JIRA, STATUS_TYPE_NAME } from '../../src/constants'
 describe('statusValidator', () => {
   let type: ObjectType
   let instance: InstanceElement
+  let invalidStatusCategory: InstanceElement
+  let validStatusCategory: InstanceElement
 
   beforeEach(() => {
     type = new ObjectType({ elemID: new ElemID(JIRA, STATUS_TYPE_NAME) })
-    instance = new InstanceElement('instance', type)
+    instance = new InstanceElement(
+      'instance',
+      type,
+      {
+        name: 'status',
+      },
+    )
+
+    invalidStatusCategory = new InstanceElement(
+      'No_Category@s',
+      new ObjectType({ elemID: new ElemID(JIRA, 'StatusCategory') }),
+      {
+        name: 'No Category',
+      }
+    )
+
+    validStatusCategory = new InstanceElement(
+      'Done',
+      new ObjectType({ elemID: new ElemID(JIRA, 'StatusCategory') }),
+      {
+        name: 'Done',
+      }
+    )
   })
   it('should return if status category is No_Category', async () => {
     instance.value.statusCategory = new ReferenceExpression(
-      new ElemID(JIRA, 'StatusCategory', 'instance', 'No_Category@s')
+      invalidStatusCategory.elemID, invalidStatusCategory
     )
     expect(await statusValidator([
       toChange({
@@ -38,16 +62,15 @@ describe('statusValidator', () => {
         elemID: instance.elemID,
         severity: 'Error',
         message: 'statusCategory can not have No_Category value',
-        detailedMessage: 'The status jira.Status.instance.instance have an invalid statusCategory, statusCategory should be one of the following: [ Done, In_Progress, To_Do ]',
+        detailedMessage: 'The status jira.Status.instance.instance has an invalid statusCategory, statusCategory should be one of the following: [ Done, In_Progress, To_Do ]',
       },
     ])
   })
 
   it('should not return an error if status category is not No_Category', async () => {
     instance.value.statusCategory = new ReferenceExpression(
-      new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'Done')
+      validStatusCategory.elemID, validStatusCategory
     )
-
     expect(await statusValidator([
       toChange({
         after: instance,

--- a/packages/jira-adapter/test/filters/statuses/status_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/statuses/status_deployment.test.ts
@@ -246,8 +246,11 @@ describe('statusDeploymentFilter', () => {
     })
 
     it('should deploy first chunk of changes and fail the other', async () => {
+      const responseData = _.range(0, 50)
+        .map(i => ({ id: `${i}`, name: `status${i}` }))
       mockConnection.post
-        .mockResolvedValueOnce({ status: 200, data: [] })
+        .mockResolvedValueOnce({ status: 200,
+          data: responseData })
         .mockRejectedValueOnce((new Error('no status category')))
       const validChanges = _.range(0, 50).map(i => toChange({
         after: new InstanceElement(

--- a/packages/jira-adapter/test/filters/statuses/status_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/statuses/status_deployment.test.ts
@@ -15,6 +15,8 @@
 */
 import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, toChange, ReferenceExpression, getChangeData, getAllChangeData } from '@salto-io/adapter-api'
 import _ from 'lodash'
+import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
+import { MockInterface } from '@salto-io/test-utils'
 import { getFilterParams, mockClient } from '../../utils'
 import statusDeploymentFilter from '../../../src/filters/statuses/status_deployment'
 import { getDefaultConfig, JiraConfig } from '../../../src/config/config'

--- a/packages/jira-adapter/test/group_change.test.ts
+++ b/packages/jira-adapter/test/group_change.test.ts
@@ -15,7 +15,7 @@
 */
 import { ElemID, InstanceElement, ObjectType, toChange, Change, CORE_ANNOTATIONS, ReferenceExpression } from '@salto-io/adapter-api'
 import { getChangeGroupIds } from '../src/group_change'
-import { FIELD_CONFIGURATION_ITEM_TYPE_NAME, FIELD_CONFIGURATION_TYPE_NAME, JIRA, SECURITY_LEVEL_TYPE, SECURITY_SCHEME_TYPE, WORKFLOW_TYPE_NAME } from '../src/constants'
+import { FIELD_CONFIGURATION_ITEM_TYPE_NAME, FIELD_CONFIGURATION_TYPE_NAME, JIRA, SECURITY_LEVEL_TYPE, SECURITY_SCHEME_TYPE, WORKFLOW_TYPE_NAME, STATUS_TYPE_NAME } from '../src/constants'
 
 describe('group change', () => {
   let workflowType: ObjectType
@@ -35,6 +35,12 @@ describe('group change', () => {
   let fieldConfigurationItemInstance3: InstanceElement
   let fieldConfiguration1: InstanceElement
   let fieldConfiguration2: InstanceElement
+
+  let statusType: ObjectType
+  let statusAddition1: InstanceElement
+  let statusAddition2: InstanceElement
+  let statusModification1: InstanceElement
+  let statusModification2: InstanceElement
 
   beforeEach(() => {
     workflowType = new ObjectType({ elemID: new ElemID(JIRA, WORKFLOW_TYPE_NAME) })
@@ -109,6 +115,12 @@ describe('group change', () => {
         ],
       }
     )
+
+    statusType = new ObjectType({ elemID: new ElemID(JIRA, STATUS_TYPE_NAME) })
+    statusAddition1 = new InstanceElement('status1', statusType)
+    statusAddition2 = new InstanceElement('status2', statusType)
+    statusModification1 = new InstanceElement('status3', statusType)
+    statusModification2 = new InstanceElement('status4', statusType)
   })
 
   it('should group workflow modifications', async () => {
@@ -190,5 +202,35 @@ describe('group change', () => {
         after: fieldConfigurationItemInstance1,
       })],
     ]))).rejects.toThrow()
+  })
+
+  it('should group status modification changes', async () => {
+    const changeGroupIds = (await getChangeGroupIds(new Map<string, Change>([
+      [statusModification1.elemID.getFullName(), toChange({
+        before: statusModification1,
+        after: statusModification1,
+      })],
+      [statusModification2.elemID.getFullName(), toChange({
+        before: statusModification2,
+        after: statusModification2,
+      })],
+    ]))).changeGroupIdMap
+
+    expect(changeGroupIds.get(statusModification1.elemID.getFullName())).toBe('Status Modifications')
+    expect(changeGroupIds.get(statusModification2.elemID.getFullName())).toBe('Status Modifications')
+  })
+
+  it('should group status addition changes', async () => {
+    const changeGroupIds = (await getChangeGroupIds(new Map<string, Change>([
+      [statusAddition1.elemID.getFullName(), toChange({
+        after: statusAddition1,
+      })],
+      [statusAddition2.elemID.getFullName(), toChange({
+        after: statusAddition2,
+      })],
+    ]))).changeGroupIdMap
+
+    expect(changeGroupIds.get(statusAddition1.elemID.getFullName())).toBe('Status Additions')
+    expect(changeGroupIds.get(statusAddition2.elemID.getFullName())).toBe('Status Additions')
   })
 })


### PR DESCRIPTION
Change Jira status deployment to the new statuses API

---

Jira created a new API for statuses, we replaces the old deployment of statuses with the new API.
Modification and addition of statuses is done through the client directly, so we can deploy multiple statuses together.

---
_Release Notes_: 
None

---
_User Notifications_: 
None
