### PR TITLE
SALTO-2478 Change salesforce adapter config default timeout

### DIFF
--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -89,10 +89,10 @@ const MAX_ITEMS_IN_READ_METADATA_REQUEST = 10
 const MAX_ITEMS_IN_LIST_METADATA_REQUEST = 3
 
 const DEFAULT_RETRY_OPTS: Required<ClientRetryConfig> = {
-  maxAttempts: 5, // try 5 times
+  maxAttempts: 3, // try 3 times
   retryDelay: 5000, // wait for 5s before trying again
   retryStrategy: 'NetworkError', // retry on network errors
-  timeout: 60 * 1000 * 15, // timeout per request retry in milliseconds
+  timeout: 60 * 1000 * 8, // timeout per request retry in milliseconds
 }
 
 const DEFAULT_READ_METADATA_CHUNK_SIZE: Required<ReadMetadataChunkSizeConfig> = {

--- a/packages/salesforce-adapter/test/client.test.ts
+++ b/packages/salesforce-adapter/test/client.test.ts
@@ -61,7 +61,7 @@ describe('salesforce client', () => {
     }),
     config: {
       retry: {
-        maxAttempts: 4, // try 4 times
+        maxAttempts: 3, // try 3 times
         retryDelay: 100, // wait for 100ms before trying again
       },
       maxConcurrentApiRequests: {
@@ -144,7 +144,7 @@ describe('salesforce client', () => {
         throw new Error('client should have failed')
       } catch (e) {
         expect(e.message).toBe('something awful happened')
-        expect(e.attempts).toBe(4)
+        expect(e.attempts).toBe(3)
       }
       expect(dodoScope.isDone()).toBeTruthy()
     })
@@ -340,8 +340,6 @@ describe('salesforce client', () => {
       beforeEach(() => {
         expectedProperties = mockFileProperties({ type: 'CustomObject', fullName: 'A__c' })
         testConnection.metadata.list
-          .mockImplementationOnce(nullFailingImplementation)
-          .mockImplementationOnce(rangeErrorFailingImplementation)
           .mockImplementationOnce(unknownErrorToRetryImplementation)
           .mockImplementationOnce(pollingTimeOutImplementation)
           .mockResolvedValueOnce([expectedProperties])

--- a/packages/salesforce-adapter/test/client.test.ts
+++ b/packages/salesforce-adapter/test/client.test.ts
@@ -312,7 +312,6 @@ describe('salesforce client', () => {
     let testClient: SalesforceClient
     let testConnection: MockInterface<Connection>
     let nullFailingImplementation: Metadata['list']
-    let rangeErrorFailingImplementation: Metadata['list']
     let unknownErrorToRetryImplementation: Metadata['list']
     let pollingTimeOutImplementation: Metadata['list']
 
@@ -324,9 +323,6 @@ describe('salesforce client', () => {
         // Intentionally access .result on null
         (null as unknown as { result: FileProperties[] }).result
       )
-      rangeErrorFailingImplementation = async () => {
-        throw new RangeError('Too many properties to enumerate')
-      }
       unknownErrorToRetryImplementation = async () => {
         throw new Error('unknown_error: retry your request')
       }


### PR DESCRIPTION
_Change salesforce adapter config default timeout_

---
_Additional context for reviewer_:

* after consultation with Tamir, changing configuration shouldn't break any tests, so I only changed the tests that rely on the fact that we retry 5 times.
---
_Release Notes_: 
Salesforce-adapter:

* by lowering the number of time we attempt to do a retry from 5 to 3 and the duration of each try ,we might make the adapter more stable
---

_User Notifications_: 
None
