### PR TITLE
SALTO-2481-change-severity-to-finding-unknown-type

### DIFF
--- a/packages/adapter-components/src/elements/type_elements.ts
+++ b/packages/adapter-components/src/elements/type_elements.ts
@@ -176,7 +176,7 @@ export const fixFieldTypes = (
     }
     const type = definedTypes[typeName] ?? toPrimitiveType(typeName)
     if (isEqualElements(type, BuiltinTypes.UNKNOWN) && typeName.toLowerCase() !== 'unknown') {
-      log.error('could not find type %s, falling back to unknown', typeName)
+      log.warn('could not find type %s, falling back to unknown', typeName)
     }
     return type
   }


### PR DESCRIPTION
Changing the "could not find type %s, falling back to unknown" log's severity level from error to warning 

---

_Additional context for reviewer_

---
_Release Notes_: 
* "unknown type" logs will become warnings.