### PR TITLE
SALTO-2553/add get changed at index size

### DIFF
--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -433,7 +433,6 @@ export const mockWorkspace = ({
     getElementFileNames: mockFunction<Workspace['getElementFileNames']>(),
     getChangedElementsBetween: mockFunction<Workspace['getChangedElementsBetween']>(),
     getReferencedStaticFilePaths: mockFunction<Workspace['getReferencedStaticFilePaths']>(),
-    getChangedAtIndexSize: mockFunction<Workspace['getChangedAtIndexSize']>(),
     isChangedAtIndexEmpty: mockFunction<Workspace['isChangedAtIndexEmpty']>(),
   }
 }

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -433,6 +433,7 @@ export const mockWorkspace = ({
     getElementFileNames: mockFunction<Workspace['getElementFileNames']>(),
     getChangedElementsBetween: mockFunction<Workspace['getChangedElementsBetween']>(),
     getReferencedStaticFilePaths: mockFunction<Workspace['getReferencedStaticFilePaths']>(),
+    getChangedAtIndexSize: mockFunction<Workspace['getChangedAtIndexSize']>(),
   }
 }
 

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -434,6 +434,7 @@ export const mockWorkspace = ({
     getChangedElementsBetween: mockFunction<Workspace['getChangedElementsBetween']>(),
     getReferencedStaticFilePaths: mockFunction<Workspace['getReferencedStaticFilePaths']>(),
     getChangedAtIndexSize: mockFunction<Workspace['getChangedAtIndexSize']>(),
+    isChangedAtIndexEmpty: mockFunction<Workspace['isChangedAtIndexEmpty']>(),
   }
 }
 

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -253,6 +253,7 @@ export type Workspace = {
   }): Promise<StaticFile | undefined>
   getChangedElementsBetween(dateRange: DateRange, envName?: string): Promise<ElemID[]>
   getReferencedStaticFilePaths(elementIds: ElemID[], envName?: string): Promise<string[]>
+  getChangedAtIndexSize(envName?: string): Promise<number>
 }
 
 type SingleState = {
@@ -981,6 +982,14 @@ export const loadWorkspace = async (
     )
     return result.filter(values.isDefined).flat()
   }
+
+  const getChangedAtIndexSize = async (envName?: string): Promise<number> => {
+    const env = envName ?? currentEnv()
+    const currentWorkspaceState = await getWorkspaceState()
+    const keys = await awu(currentWorkspaceState.states[env].changedBy.keys()).toArray()
+    return keys.length
+  }
+
   return {
     uid: workspaceConfig.uid,
     name: workspaceConfig.name,
@@ -1378,6 +1387,7 @@ export const loadWorkspace = async (
       (naclFilesSource.getStaticFile(filepath, encoding, env ?? currentEnv())),
     getChangedElementsBetween,
     getReferencedStaticFilePaths,
+    getChangedAtIndexSize,
   }
 }
 

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -253,7 +253,6 @@ export type Workspace = {
   }): Promise<StaticFile | undefined>
   getChangedElementsBetween(dateRange: DateRange, envName?: string): Promise<ElemID[]>
   getReferencedStaticFilePaths(elementIds: ElemID[], envName?: string): Promise<string[]>
-  getChangedAtIndexSize(envName?: string): Promise<number>
   isChangedAtIndexEmpty(envName?: string): Promise<boolean>
 }
 
@@ -984,13 +983,6 @@ export const loadWorkspace = async (
     return result.filter(values.isDefined).flat()
   }
 
-  const getChangedAtIndexSize = async (envName?: string): Promise<number> => {
-    const env = envName ?? currentEnv()
-    const currentWorkspaceState = await getWorkspaceState()
-    const keys = await awu(currentWorkspaceState.states[env].changedBy.keys()).toArray()
-    return keys.length
-  }
-
   const isChangedAtIndexEmpty = async (envName?: string): Promise<boolean> => {
     const env = envName ?? currentEnv()
     const currentWorkspaceState = await getWorkspaceState()
@@ -1394,7 +1386,6 @@ export const loadWorkspace = async (
       (naclFilesSource.getStaticFile(filepath, encoding, env ?? currentEnv())),
     getChangedElementsBetween,
     getReferencedStaticFilePaths,
-    getChangedAtIndexSize,
     isChangedAtIndexEmpty,
   }
 }

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -254,6 +254,7 @@ export type Workspace = {
   getChangedElementsBetween(dateRange: DateRange, envName?: string): Promise<ElemID[]>
   getReferencedStaticFilePaths(elementIds: ElemID[], envName?: string): Promise<string[]>
   getChangedAtIndexSize(envName?: string): Promise<number>
+  isChangedAtIndexEmpty(envName?: string): Promise<boolean>
 }
 
 type SingleState = {
@@ -990,6 +991,12 @@ export const loadWorkspace = async (
     return keys.length
   }
 
+  const isChangedAtIndexEmpty = async (envName?: string): Promise<boolean> => {
+    const env = envName ?? currentEnv()
+    const currentWorkspaceState = await getWorkspaceState()
+    return currentWorkspaceState.states[env].changedBy.isEmpty()
+  }
+
   return {
     uid: workspaceConfig.uid,
     name: workspaceConfig.name,
@@ -1388,6 +1395,7 @@ export const loadWorkspace = async (
     getChangedElementsBetween,
     getReferencedStaticFilePaths,
     getChangedAtIndexSize,
+    isChangedAtIndexEmpty,
   }
 }
 

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -2342,6 +2342,12 @@ describe('workspace', () => {
         expect(result[0].getFullName()).toEqual('salesforce.lead')
       })
     })
+    describe('getChangedAtIndexSize', () => {
+      it('get correct element ids without full date range', async () => {
+        const result = await workspace.getChangedAtIndexSize()
+        expect(result).toEqual(1)
+      })
+    })
   })
   describe('static files index', () => {
     let workspace: Workspace

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -2300,52 +2300,88 @@ describe('workspace', () => {
     const naclFileStore = mockDirStore(undefined, undefined, {
       'firstFile.nacl': firstFile,
     })
-    beforeEach(async () => {
-      workspace = await createWorkspace(
-        naclFileStore,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        {
-          '': {
-            naclFiles: createMockNaclFileSource([]),
+    const emptyFileStore = mockDirStore(undefined, undefined, {})
+    describe('empty index', () => {
+      beforeEach(async () => {
+        workspace = await createWorkspace(
+          emptyFileStore,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          {
+            '': {
+              naclFiles: createMockNaclFileSource([]),
+            },
+            default: {
+              naclFiles: await naclFilesSource(
+                'default',
+                emptyFileStore,
+                mockStaticFilesSource(),
+                persistentMockCreateRemoteMap(),
+                true
+              ),
+              state: createState([]),
+            },
           },
-          default: {
-            naclFiles: await naclFilesSource(
-              'default',
-              naclFileStore,
-              mockStaticFilesSource(),
-              persistentMockCreateRemoteMap(),
-              true
-            ),
-            state: createState([]),
-          },
-        },
-      )
-    })
-    describe('getChangedElementsBetween', () => {
-      it('get correct element ids without full date range', async () => {
-        const dateRange = { start: new Date('1999-01-01T00:00:00.000Z') }
-        const result = await workspace.getChangedElementsBetween(dateRange)
-        expect(result[0].getFullName()).toEqual('salesforce.lead')
+        )
       })
-      it('get correct element ids until date failure', async () => {
-        const dateRange = { end: new Date('1999-02-01T00:00:00.000Z'), start: new Date('1999-01-01T00:00:00.000Z') }
-        const result = await workspace.getChangedElementsBetween(dateRange)
-        expect(result.length).toEqual(0)
-      })
-      it('get correct element ids until date success', async () => {
-        const dateRange = { end: new Date('2001-01-01T00:00:00.000Z'), start: new Date('1999-01-01T00:00:00.000Z') }
-        const result = await workspace.getChangedElementsBetween(dateRange)
-        expect(result[0].getFullName()).toEqual('salesforce.lead')
+      describe('isChangedAtIndexEmpty', () => {
+        it('should return true', async () => {
+          const result = await workspace.isChangedAtIndexEmpty()
+          expect(result).toBeTruthy()
+        })
       })
     })
-    describe('getChangedAtIndexSize', () => {
-      it('get correct element ids without full date range', async () => {
-        const result = await workspace.getChangedAtIndexSize()
-        expect(result).toEqual(1)
+    describe('populated index', () => {
+      beforeEach(async () => {
+        workspace = await createWorkspace(
+          naclFileStore,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          {
+            '': {
+              naclFiles: createMockNaclFileSource([]),
+            },
+            default: {
+              naclFiles: await naclFilesSource(
+                'default',
+                naclFileStore,
+                mockStaticFilesSource(),
+                persistentMockCreateRemoteMap(),
+                true
+              ),
+              state: createState([]),
+            },
+          },
+        )
+      })
+      describe('getChangedElementsBetween', () => {
+        it('get correct element ids without full date range', async () => {
+          const dateRange = { start: new Date('1999-01-01T00:00:00.000Z') }
+          const result = await workspace.getChangedElementsBetween(dateRange)
+          expect(result[0].getFullName()).toEqual('salesforce.lead')
+        })
+        it('get correct element ids until date failure', async () => {
+          const dateRange = { end: new Date('1999-02-01T00:00:00.000Z'), start: new Date('1999-01-01T00:00:00.000Z') }
+          const result = await workspace.getChangedElementsBetween(dateRange)
+          expect(result.length).toEqual(0)
+        })
+        it('get correct element ids until date success', async () => {
+          const dateRange = { end: new Date('2001-01-01T00:00:00.000Z'), start: new Date('1999-01-01T00:00:00.000Z') }
+          const result = await workspace.getChangedElementsBetween(dateRange)
+          expect(result[0].getFullName()).toEqual('salesforce.lead')
+        })
+      })
+      describe('isChangedAtIndexEmpty', () => {
+        it('should return false', async () => {
+          const result = await workspace.isChangedAtIndexEmpty()
+          expect(result).toBeFalsy()
+        })
       })
     })
   })


### PR DESCRIPTION
add method to determine size of changed at index.

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
