### PR TITLE
SALTO-2299: TransformationConfig update & Lowercase status names in Jira

### DIFF
--- a/packages/adapter-components/src/config/index.ts
+++ b/packages/adapter-components/src/config/index.ts
@@ -18,5 +18,5 @@ export { createRequestConfigs, validateRequestConfig, FetchRequestConfig, Deploy
 export { createAdapterApiConfigType, getConfigWithDefault, AdapterApiConfig, UserFetchConfig, TypeConfig, createUserFetchConfigType } from './shared'
 export { mergeWithDefaultConfig } from './merge'
 export { createSwaggerAdapterApiConfigType, AdapterSwaggerApiConfig, RequestableAdapterSwaggerApiConfig, TypeSwaggerConfig, RequestableTypeSwaggerConfig, TypeSwaggerDefaultConfig, TypeNameOverrideConfig, validateApiDefinitionConfig as validateSwaggerApiDefinitionConfig, validateFetchConfig as validateSwaggerFetchConfig } from './swagger'
-export { createTransformationConfigTypes, validateTransoformationConfig, TransformationDefaultConfig, TransformationConfig, StandaloneFieldConfigType, FieldToOmitType, FieldToHideType, getTransformationConfigByType, dereferenceFieldName, isReferencedIdField, NameTrasformationOptions } from './transformation'
+export { createTransformationConfigTypes, validateTransoformationConfig, TransformationDefaultConfig, TransformationConfig, StandaloneFieldConfigType, FieldToOmitType, FieldToHideType, getTransformationConfigByType, dereferenceFieldName, isReferencedIdField, NameMappingOptions } from './transformation'
 export * as configMigrations from './config_migrations'

--- a/packages/adapter-components/src/config/index.ts
+++ b/packages/adapter-components/src/config/index.ts
@@ -18,5 +18,5 @@ export { createRequestConfigs, validateRequestConfig, FetchRequestConfig, Deploy
 export { createAdapterApiConfigType, getConfigWithDefault, AdapterApiConfig, UserFetchConfig, TypeConfig, createUserFetchConfigType } from './shared'
 export { mergeWithDefaultConfig } from './merge'
 export { createSwaggerAdapterApiConfigType, AdapterSwaggerApiConfig, RequestableAdapterSwaggerApiConfig, TypeSwaggerConfig, RequestableTypeSwaggerConfig, TypeSwaggerDefaultConfig, TypeNameOverrideConfig, validateApiDefinitionConfig as validateSwaggerApiDefinitionConfig, validateFetchConfig as validateSwaggerFetchConfig } from './swagger'
-export { createTransformationConfigTypes, validateTransoformationConfig, TransformationDefaultConfig, TransformationConfig, StandaloneFieldConfigType, FieldToOmitType, FieldToHideType, getTransformationConfigByType, dereferenceFieldName, isReferencedIdField } from './transformation'
+export { createTransformationConfigTypes, validateTransoformationConfig, TransformationDefaultConfig, TransformationConfig, StandaloneFieldConfigType, FieldToOmitType, FieldToHideType, getTransformationConfigByType, dereferenceFieldName, isReferencedIdField, NameTrasformationOptions } from './transformation'
 export * as configMigrations from './config_migrations'

--- a/packages/adapter-components/src/config/transformation.ts
+++ b/packages/adapter-components/src/config/transformation.ts
@@ -38,7 +38,7 @@ export type FieldTypeOverrideType = {
   fieldType: string
   restrictions?: RestrictionAnnotationType
 }
-export type NameTrasformationOptions = 'default' | 'lowercase' | 'uppercase'
+export type NameMappingOptions = 'lowercase' | 'uppercase'
 
 export type TransformationConfig = {
   // explicitly set types for fields that are not generated correctly
@@ -67,8 +67,8 @@ export type TransformationConfig = {
   serviceIdField?: string
   // The url of the type in the service
   serviceUrl?: string
-  // change instance id and filename
-  saltoNameTransformation?: NameTrasformationOptions
+  // if provided, instance id and file name change, otherwise there’s no change
+  nameMapping?: NameMappingOptions
 }
 
 export type TransformationDefaultConfig = types.PickyRequired<Partial<Omit<TransformationConfig, 'isSingleton'>>, 'idFields'>

--- a/packages/adapter-components/src/config/transformation.ts
+++ b/packages/adapter-components/src/config/transformation.ts
@@ -66,6 +66,8 @@ export type TransformationConfig = {
   serviceIdField?: string
   // The url of the type in the service
   serviceUrl?: string
+  // set to true to convert instance naclName and filename to lowercase
+  convertNameToLowercase?: boolean
 }
 
 export type TransformationDefaultConfig = types.PickyRequired<Partial<Omit<TransformationConfig, 'isSingleton'>>, 'idFields'>

--- a/packages/adapter-components/src/config/transformation.ts
+++ b/packages/adapter-components/src/config/transformation.ts
@@ -38,6 +38,7 @@ export type FieldTypeOverrideType = {
   fieldType: string
   restrictions?: RestrictionAnnotationType
 }
+export type NameTrasformationOptions = 'default' | 'lowercase' | 'uppercase'
 
 export type TransformationConfig = {
   // explicitly set types for fields that are not generated correctly
@@ -66,8 +67,8 @@ export type TransformationConfig = {
   serviceIdField?: string
   // The url of the type in the service
   serviceUrl?: string
-  // set to true to convert instance naclName and filename to lowercase
-  convertNameToLowercase?: boolean
+  // change instance id and filename
+  saltoNameTransformation?: NameTrasformationOptions
 }
 
 export type TransformationDefaultConfig = types.PickyRequired<Partial<Omit<TransformationConfig, 'isSingleton'>>, 'idFields'>

--- a/packages/adapter-components/src/elements/instance_elements.ts
+++ b/packages/adapter-components/src/elements/instance_elements.ts
@@ -62,6 +62,7 @@ export const getInstanceFilePath = ({
   naclName,
   typeName,
   isSettingType,
+  convertNameToLowercase,
   adapterName,
 }: {
   fileNameFields: string[] | undefined
@@ -69,6 +70,7 @@ export const getInstanceFilePath = ({
   naclName: string
   typeName: string
   isSettingType: boolean
+  convertNameToLowercase: boolean | undefined
   adapterName: string
 }): string[] => {
   const fileNameParts = (fileNameFields !== undefined
@@ -77,6 +79,7 @@ export const getInstanceFilePath = ({
   const fileName = ((fileNameParts?.every(p => _.isString(p) || _.isNumber(p))
     ? fileNameParts.join('_')
     : undefined))
+  const naclCaseFileName = fileName ? pathNaclCase(naclCase(fileName)) : pathNaclCase(naclName)
   return isSettingType
     ? [
       adapterName,
@@ -88,7 +91,7 @@ export const getInstanceFilePath = ({
       adapterName,
       RECORDS_PATH,
       pathNaclCase(typeName),
-      fileName ? pathNaclCase(naclCase(fileName)) : pathNaclCase(naclName),
+      convertNameToLowercase ? naclCaseFileName.toLowerCase() : naclCaseFileName,
     ]
 }
 
@@ -97,11 +100,13 @@ export const generateInstanceNameFromConfig = (
   typeName: string,
   apiDefinitions: AdapterApiConfig
 ): string | undefined => {
-  const { idFields } = getConfigWithDefault(
+  const { idFields, convertNameToLowercase } = getConfigWithDefault(
     apiDefinitions.types[typeName]?.transformation ?? {},
     apiDefinitions.typeDefaults.transformation
   )
-  return getInstanceName(values, idFields)
+  return convertNameToLowercase
+    ? getInstanceName(values, idFields)?.toLowerCase()
+    : getInstanceName(values, idFields)
 }
 
 export const removeNullValues = async (
@@ -132,6 +137,7 @@ export const getInstanceNaclName = ({
   getElemIdFunc,
   serviceIdField,
   typeElemId,
+  convertNameToLowercase,
 }:{
   entry: Values
   name: string
@@ -140,10 +146,12 @@ export const getInstanceNaclName = ({
   getElemIdFunc?: ElemIdGetter
   serviceIdField?: string
   typeElemId: ElemID
+  convertNameToLowercase: boolean | undefined
 }): string => {
-  const desiredName = naclCase(
+  const naclName = naclCase(
     parentName ? `${parentName}${ID_SEPARATOR}${name}` : String(name)
   )
+  const desiredName = convertNameToLowercase ? naclName.toLowerCase() : naclName
   return getElemIdFunc && serviceIdField
     ? getElemIdFunc(
       adapterName,
@@ -193,7 +201,7 @@ export const toBasicInstance = async ({
   })
 
   const {
-    idFields, fileNameFields, serviceIdField,
+    idFields, fileNameFields, serviceIdField, convertNameToLowercase,
   } = getConfigWithDefault(
     transformationConfigByType[type.elemID.name],
     transformationDefaultConfig,
@@ -210,6 +218,7 @@ export const toBasicInstance = async ({
     getElemIdFunc,
     serviceIdField,
     typeElemId: type.elemID,
+    convertNameToLowercase,
   })
 
   const filePath = getInstanceFilePath({
@@ -218,6 +227,7 @@ export const toBasicInstance = async ({
     naclName,
     typeName: type.elemID.name,
     isSettingType: type.isSettings,
+    convertNameToLowercase,
     adapterName,
   })
 

--- a/packages/adapter-components/src/filters/referenced_instance_names.ts
+++ b/packages/adapter-components/src/filters/referenced_instance_names.ts
@@ -26,7 +26,7 @@ import { collections, values as lowerDashValues } from '@salto-io/lowerdash'
 import { FilterCreator } from '../filter_utils'
 import { AdapterApiConfig, getTransformationConfigByType,
   TransformationConfig, TransformationDefaultConfig, getConfigWithDefault,
-  dereferenceFieldName, isReferencedIdField } from '../config'
+  dereferenceFieldName, isReferencedIdField, NameTrasformationOptions } from '../config'
 import { joinInstanceNameParts, getInstanceFilePath, getInstanceNaclName } from '../elements/instance_elements'
 import { findDuplicates } from '../config/validation_utils'
 
@@ -39,7 +39,7 @@ const { getUpdatedReference, createReferencesTransformFunc } = references
 type TransformationIdConfig = {
   idFields: string[]
   extendsParentId?: boolean
-  convertNameToLowercase: boolean | undefined
+  saltoNameTransformation: NameTrasformationOptions | undefined
 }
 
 const getFirstParentElemId = (instance: InstanceElement): ElemID | undefined => {
@@ -104,7 +104,7 @@ const createInstanceNameAndFilePath = (
   configByType: Record<string, TransformationConfig>,
   getElemIdFunc?: ElemIdGetter,
 ): { newNaclName: string; filePath: string[] } => {
-  const { idFields, convertNameToLowercase } = idConfig
+  const { idFields, saltoNameTransformation } = idConfig
   const newNameParts = createInstanceReferencedNameParts(instance, idFields)
   const newName = joinInstanceNameParts(newNameParts) ?? instance.elemID.name
   const parentName = getFirstParentElemId(instance)?.name
@@ -119,7 +119,7 @@ const createInstanceNameAndFilePath = (
     getElemIdFunc,
     serviceIdField,
     typeElemId: instance.refType.elemID,
-    convertNameToLowercase,
+    saltoNameTransformation,
   })
 
   const filePath = getInstanceFilePath({
@@ -128,7 +128,7 @@ const createInstanceNameAndFilePath = (
     naclName: newNaclName,
     typeName,
     isSettingType: configByType[typeName].isSingleton ?? false,
-    convertNameToLowercase: configByType[typeName].convertNameToLowercase ?? false,
+    saltoNameTransformation: configByType[typeName].saltoNameTransformation,
     adapterName: adapter,
   })
   return { newNaclName, filePath }
@@ -310,7 +310,7 @@ export const addReferencesToInstanceNames = async (
     idConfig: {
       idFields: configByType[instance.elemID.typeName].idFields,
       extendsParentId: configByType[instance.elemID.typeName].extendsParentId,
-      convertNameToLowercase: configByType[instance.elemID.typeName].convertNameToLowercase,
+      saltoNameTransformation: configByType[instance.elemID.typeName].saltoNameTransformation,
     },
   }))
 

--- a/packages/adapter-components/src/filters/referenced_instance_names.ts
+++ b/packages/adapter-components/src/filters/referenced_instance_names.ts
@@ -39,6 +39,7 @@ const { getUpdatedReference, createReferencesTransformFunc } = references
 type TransformationIdConfig = {
   idFields: string[]
   extendsParentId?: boolean
+  convertNameToLowercase: boolean | undefined
 }
 
 const getFirstParentElemId = (instance: InstanceElement): ElemID | undefined => {
@@ -103,7 +104,7 @@ const createInstanceNameAndFilePath = (
   configByType: Record<string, TransformationConfig>,
   getElemIdFunc?: ElemIdGetter,
 ): { newNaclName: string; filePath: string[] } => {
-  const { idFields } = idConfig
+  const { idFields, convertNameToLowercase } = idConfig
   const newNameParts = createInstanceReferencedNameParts(instance, idFields)
   const newName = joinInstanceNameParts(newNameParts) ?? instance.elemID.name
   const parentName = getFirstParentElemId(instance)?.name
@@ -118,6 +119,7 @@ const createInstanceNameAndFilePath = (
     getElemIdFunc,
     serviceIdField,
     typeElemId: instance.refType.elemID,
+    convertNameToLowercase,
   })
 
   const filePath = getInstanceFilePath({
@@ -126,6 +128,7 @@ const createInstanceNameAndFilePath = (
     naclName: newNaclName,
     typeName,
     isSettingType: configByType[typeName].isSingleton ?? false,
+    convertNameToLowercase: configByType[typeName].convertNameToLowercase ?? false,
     adapterName: adapter,
   })
   return { newNaclName, filePath }
@@ -307,6 +310,7 @@ export const addReferencesToInstanceNames = async (
     idConfig: {
       idFields: configByType[instance.elemID.typeName].idFields,
       extendsParentId: configByType[instance.elemID.typeName].extendsParentId,
+      convertNameToLowercase: configByType[instance.elemID.typeName].convertNameToLowercase,
     },
   }))
 

--- a/packages/adapter-components/src/filters/referenced_instance_names.ts
+++ b/packages/adapter-components/src/filters/referenced_instance_names.ts
@@ -26,7 +26,7 @@ import { collections, values as lowerDashValues } from '@salto-io/lowerdash'
 import { FilterCreator } from '../filter_utils'
 import { AdapterApiConfig, getTransformationConfigByType,
   TransformationConfig, TransformationDefaultConfig, getConfigWithDefault,
-  dereferenceFieldName, isReferencedIdField, NameTrasformationOptions } from '../config'
+  dereferenceFieldName, isReferencedIdField, NameMappingOptions } from '../config'
 import { joinInstanceNameParts, getInstanceFilePath, getInstanceNaclName } from '../elements/instance_elements'
 import { findDuplicates } from '../config/validation_utils'
 
@@ -39,7 +39,7 @@ const { getUpdatedReference, createReferencesTransformFunc } = references
 type TransformationIdConfig = {
   idFields: string[]
   extendsParentId?: boolean
-  saltoNameTransformation: NameTrasformationOptions | undefined
+  nameMapping?: NameMappingOptions
 }
 
 const getFirstParentElemId = (instance: InstanceElement): ElemID | undefined => {
@@ -104,7 +104,7 @@ const createInstanceNameAndFilePath = (
   configByType: Record<string, TransformationConfig>,
   getElemIdFunc?: ElemIdGetter,
 ): { newNaclName: string; filePath: string[] } => {
-  const { idFields, saltoNameTransformation } = idConfig
+  const { idFields, nameMapping } = idConfig
   const newNameParts = createInstanceReferencedNameParts(instance, idFields)
   const newName = joinInstanceNameParts(newNameParts) ?? instance.elemID.name
   const parentName = getFirstParentElemId(instance)?.name
@@ -119,7 +119,7 @@ const createInstanceNameAndFilePath = (
     getElemIdFunc,
     serviceIdField,
     typeElemId: instance.refType.elemID,
-    saltoNameTransformation,
+    nameMapping,
   })
 
   const filePath = getInstanceFilePath({
@@ -128,7 +128,7 @@ const createInstanceNameAndFilePath = (
     naclName: newNaclName,
     typeName,
     isSettingType: configByType[typeName].isSingleton ?? false,
-    saltoNameTransformation: configByType[typeName].saltoNameTransformation,
+    nameMapping: configByType[typeName].nameMapping,
     adapterName: adapter,
   })
   return { newNaclName, filePath }
@@ -310,7 +310,7 @@ export const addReferencesToInstanceNames = async (
     idConfig: {
       idFields: configByType[instance.elemID.typeName].idFields,
       extendsParentId: configByType[instance.elemID.typeName].extendsParentId,
-      saltoNameTransformation: configByType[instance.elemID.typeName].saltoNameTransformation,
+      nameMapping: configByType[instance.elemID.typeName].nameMapping,
     },
   }))
 

--- a/packages/adapter-components/test/elements/ducktype/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/ducktype/instance_elements.test.ts
@@ -356,14 +356,14 @@ describe('ducktype_instance_elements', () => {
       ))).toBeTruthy()
       expect(inst?.path).toEqual([ADAPTER_NAME, RECORDS_PATH, 'bla', instanceName])
     })
-    it('should convert name to lowercase when convertNameToLowercase is true', async () => {
-      entry.name = 'CAPSLOCK NaMe'
-      const inst = await toInstance({
+    it('should convert name if saltoNametransformation exists', async () => {
+      entry.name = 'CaPSlOCK NaMe'
+      const inst1 = await toInstance({
         type,
         transformationConfigByType: {
           bla: {
             idFields: ['name'],
-            convertNameToLowercase: true,
+            saltoNameTransformation: 'lowercase',
           },
         },
         transformationDefaultConfig: {
@@ -372,9 +372,40 @@ describe('ducktype_instance_elements', () => {
         defaultName: 'abc',
         entry,
       })
-      expect(inst).toBeDefined()
-      expect(inst?.elemID.getFullName()).toEqual('myAdapter.bla.instance.capslock_name@s')
-      expect(inst?.path).toEqual([ADAPTER_NAME, RECORDS_PATH, 'bla', 'capslock_name'])
+      const inst2 = await toInstance({
+        type,
+        transformationConfigByType: {
+          bla: {
+            idFields: ['name'],
+            saltoNameTransformation: 'uppercase',
+          },
+        },
+        transformationDefaultConfig: {
+          idFields: ['somethingElse'],
+        },
+        defaultName: 'abc',
+        entry,
+      })
+      const inst3 = await toInstance({
+        type,
+        transformationConfigByType: {
+          bla: {
+            idFields: ['name'],
+            saltoNameTransformation: 'default',
+          },
+        },
+        transformationDefaultConfig: {
+          idFields: ['somethingElse'],
+        },
+        defaultName: 'abc',
+        entry,
+      })
+      expect(inst1?.elemID.getFullName()).toEqual('myAdapter.bla.instance.capslock_name@s')
+      expect(inst1?.path).toEqual([ADAPTER_NAME, RECORDS_PATH, 'bla', 'capslock_name'])
+      expect(inst2?.elemID.getFullName()).toEqual('myAdapter.bla.instance.CAPSLOCK_NAME@S')
+      expect(inst2?.path).toEqual([ADAPTER_NAME, RECORDS_PATH, 'bla', 'CAPSLOCK_NAME'])
+      expect(inst3?.elemID.getFullName()).toEqual('myAdapter.bla.instance.CaPSlOCK_NaMe@s')
+      expect(inst3?.path).toEqual([ADAPTER_NAME, RECORDS_PATH, 'bla', 'CaPSlOCK_NaMe'])
     })
   })
 })

--- a/packages/adapter-components/test/elements/ducktype/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/ducktype/instance_elements.test.ts
@@ -356,14 +356,14 @@ describe('ducktype_instance_elements', () => {
       ))).toBeTruthy()
       expect(inst?.path).toEqual([ADAPTER_NAME, RECORDS_PATH, 'bla', instanceName])
     })
-    it('should convert name if saltoNametransformation exists', async () => {
+    it('should convert name if nameMapping exists', async () => {
       entry.name = 'CaPSlOCK NaMe'
       const inst1 = await toInstance({
         type,
         transformationConfigByType: {
           bla: {
             idFields: ['name'],
-            saltoNameTransformation: 'lowercase',
+            nameMapping: 'lowercase',
           },
         },
         transformationDefaultConfig: {
@@ -377,21 +377,7 @@ describe('ducktype_instance_elements', () => {
         transformationConfigByType: {
           bla: {
             idFields: ['name'],
-            saltoNameTransformation: 'uppercase',
-          },
-        },
-        transformationDefaultConfig: {
-          idFields: ['somethingElse'],
-        },
-        defaultName: 'abc',
-        entry,
-      })
-      const inst3 = await toInstance({
-        type,
-        transformationConfigByType: {
-          bla: {
-            idFields: ['name'],
-            saltoNameTransformation: 'default',
+            nameMapping: 'uppercase',
           },
         },
         transformationDefaultConfig: {
@@ -404,8 +390,6 @@ describe('ducktype_instance_elements', () => {
       expect(inst1?.path).toEqual([ADAPTER_NAME, RECORDS_PATH, 'bla', 'capslock_name'])
       expect(inst2?.elemID.getFullName()).toEqual('myAdapter.bla.instance.CAPSLOCK_NAME@S')
       expect(inst2?.path).toEqual([ADAPTER_NAME, RECORDS_PATH, 'bla', 'CAPSLOCK_NAME'])
-      expect(inst3?.elemID.getFullName()).toEqual('myAdapter.bla.instance.CaPSlOCK_NaMe@s')
-      expect(inst3?.path).toEqual([ADAPTER_NAME, RECORDS_PATH, 'bla', 'CaPSlOCK_NaMe'])
     })
   })
 })

--- a/packages/adapter-components/test/elements/ducktype/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/ducktype/instance_elements.test.ts
@@ -356,5 +356,25 @@ describe('ducktype_instance_elements', () => {
       ))).toBeTruthy()
       expect(inst?.path).toEqual([ADAPTER_NAME, RECORDS_PATH, 'bla', instanceName])
     })
+    it('should convert name to lowercase when convertNameToLowercase is true', async () => {
+      entry.name = 'CAPSLOCK NaMe'
+      const inst = await toInstance({
+        type,
+        transformationConfigByType: {
+          bla: {
+            idFields: ['name'],
+            convertNameToLowercase: true,
+          },
+        },
+        transformationDefaultConfig: {
+          idFields: ['somethingElse'],
+        },
+        defaultName: 'abc',
+        entry,
+      })
+      expect(inst).toBeDefined()
+      expect(inst?.elemID.getFullName()).toEqual('myAdapter.bla.instance.capslock_name@s')
+      expect(inst?.path).toEqual([ADAPTER_NAME, RECORDS_PATH, 'bla', 'capslock_name'])
+    })
   })
 })

--- a/packages/adapter-components/test/elements/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/instance_elements.test.ts
@@ -59,4 +59,29 @@ describe('generateInstanceNameFromConfig', () => {
       }
     )).toBe('name')
   })
+  it('should create name in lower case if convertToLowercase is true', () => {
+    expect(generateInstanceNameFromConfig(
+      {
+        name: 'name',
+        id: 'ID',
+      },
+      'test',
+      {
+        typeDefaults: {
+          transformation: {
+            idFields: ['name'],
+          },
+        },
+        types: {
+          test: {
+            transformation: {
+              idFields: ['id'],
+              convertNameToLowercase: true,
+            },
+          },
+        },
+        supportedTypes: {},
+      }
+    )).toBe('id')
+  })
 })

--- a/packages/adapter-components/test/elements/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/instance_elements.test.ts
@@ -15,6 +15,8 @@
 */
 
 import { generateInstanceNameFromConfig } from '../../src/elements/instance_elements'
+import { NameTrasformationOptions } from '../../src/config'
+
 
 describe('generateInstanceNameFromConfig', () => {
   it('should return the name of the instance based on the type config', () => {
@@ -60,28 +62,59 @@ describe('generateInstanceNameFromConfig', () => {
     )).toBe('name')
   })
   it('should create name in lower case if convertToLowercase is true', () => {
+    const lowercaseTransfomation : NameTrasformationOptions = 'lowercase'
+    const uppercaseTransfomation : NameTrasformationOptions = 'uppercase'
+    const defaultTransfomation : NameTrasformationOptions = 'default'
     expect(generateInstanceNameFromConfig(
       {
         name: 'name',
-        id: 'ID',
+        id: 'Id',
       },
       'test',
       {
         typeDefaults: {
           transformation: {
-            idFields: ['name'],
+            idFields: ['id'],
+            saltoNameTransformation: lowercaseTransfomation,
           },
         },
-        types: {
-          test: {
-            transformation: {
-              idFields: ['id'],
-              convertNameToLowercase: true,
-            },
-          },
-        },
+        types: {},
         supportedTypes: {},
       }
     )).toBe('id')
+    expect(generateInstanceNameFromConfig(
+      {
+        name: 'name',
+        id: 'Id',
+      },
+      'test',
+      {
+        typeDefaults: {
+          transformation: {
+            idFields: ['id'],
+            saltoNameTransformation: uppercaseTransfomation,
+          },
+        },
+        types: {},
+        supportedTypes: {},
+      }
+    )).toBe('ID')
+    expect(generateInstanceNameFromConfig(
+      {
+        name: 'name',
+        id: 'Id',
+      },
+      'test',
+      {
+        typeDefaults: {
+          transformation: {
+            idFields: ['id'],
+            saltoNameTransformation: defaultTransfomation,
+          },
+        },
+        types: {},
+        supportedTypes: {},
+      }
+    )).toBe('Id')
   })
 })

--- a/packages/adapter-components/test/elements/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/instance_elements.test.ts
@@ -15,7 +15,7 @@
 */
 
 import { generateInstanceNameFromConfig } from '../../src/elements/instance_elements'
-import { NameTrasformationOptions } from '../../src/config'
+import { NameMappingOptions } from '../../src/config'
 
 
 describe('generateInstanceNameFromConfig', () => {
@@ -61,10 +61,9 @@ describe('generateInstanceNameFromConfig', () => {
       }
     )).toBe('name')
   })
-  it('should create name in lower case if convertToLowercase is true', () => {
-    const lowercaseTransfomation : NameTrasformationOptions = 'lowercase'
-    const uppercaseTransfomation : NameTrasformationOptions = 'uppercase'
-    const defaultTransfomation : NameTrasformationOptions = 'default'
+  it('should covert name if nameMapping exists', () => {
+    const lowercaseTransfomation : NameMappingOptions = 'lowercase'
+    const uppercaseTransfomation : NameMappingOptions = 'uppercase'
     expect(generateInstanceNameFromConfig(
       {
         name: 'name',
@@ -75,7 +74,7 @@ describe('generateInstanceNameFromConfig', () => {
         typeDefaults: {
           transformation: {
             idFields: ['id'],
-            saltoNameTransformation: lowercaseTransfomation,
+            nameMapping: lowercaseTransfomation,
           },
         },
         types: {},
@@ -92,7 +91,7 @@ describe('generateInstanceNameFromConfig', () => {
         typeDefaults: {
           transformation: {
             idFields: ['id'],
-            saltoNameTransformation: uppercaseTransfomation,
+            nameMapping: uppercaseTransfomation,
           },
         },
         types: {},
@@ -109,7 +108,6 @@ describe('generateInstanceNameFromConfig', () => {
         typeDefaults: {
           transformation: {
             idFields: ['id'],
-            saltoNameTransformation: defaultTransfomation,
           },
         },
         types: {},

--- a/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
@@ -1337,7 +1337,7 @@ describe('swagger_instance_elements', () => {
       })).rejects.toThrow(new Error('Invalid type config - type myAdapter.Pet has no request config'))
     })
 
-    it('should convert name and filename if saltoNameTransformation exists', async () => {
+    it('should convert name and filename if nameMapping exists', async () => {
       const objectTypes = generateObjectTypes()
       const res = await getAllInstances({
         paginator: mockPaginator,
@@ -1354,7 +1354,7 @@ describe('swagger_instance_elements', () => {
               },
               transformation: {
                 idFields: ['name'],
-                saltoNameTransformation: 'lowercase',
+                nameMapping: 'lowercase',
               },
             },
             Owner: {
@@ -1363,7 +1363,7 @@ describe('swagger_instance_elements', () => {
               },
               transformation: {
                 idFields: ['name'],
-                saltoNameTransformation: 'uppercase',
+                nameMapping: 'uppercase',
               },
             },
           },

--- a/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
@@ -1337,7 +1337,7 @@ describe('swagger_instance_elements', () => {
       })).rejects.toThrow(new Error('Invalid type config - type myAdapter.Pet has no request config'))
     })
 
-    it('should convert name to lowercase if convertNameToLowercase is true', async () => {
+    it('should convert name and filename if saltoNameTransformation exists', async () => {
       const objectTypes = generateObjectTypes()
       const res = await getAllInstances({
         paginator: mockPaginator,
@@ -1354,7 +1354,16 @@ describe('swagger_instance_elements', () => {
               },
               transformation: {
                 idFields: ['name'],
-                convertNameToLowercase: true,
+                saltoNameTransformation: 'lowercase',
+              },
+            },
+            Owner: {
+              request: {
+                url: '/owner',
+              },
+              transformation: {
+                idFields: ['name'],
+                saltoNameTransformation: 'uppercase',
               },
             },
           },
@@ -1362,23 +1371,31 @@ describe('swagger_instance_elements', () => {
         fetchQuery: createElementQuery({
           include: [
             { type: 'Status' },
+            { type: 'Owner' },
           ],
           exclude: [],
         }),
         supportedTypes: {
           Status: ['Status'],
+          Owner: ['Owner'],
         },
         objectTypes,
         computeGetArgs: simpleGetArgs,
         nestedFieldFinder: returnFullEntry,
       })
-      expect(res.map(e => e.elemID.name)).toEqual(['done'])
+      expect(res.map(e => e.elemID.name)).toEqual(['done', 'OWNER2'])
       expect(res.map(e => e.path)).toEqual([
         [
           ADAPTER_NAME,
           'Records',
           'Status',
           'done',
+        ],
+        [
+          ADAPTER_NAME,
+          'Records',
+          'Owner',
+          'OWNER2',
         ],
       ])
     })

--- a/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
@@ -58,11 +58,19 @@ describe('swagger_instance_elements', () => {
           additionalProperties: { refType: new MapType(Food) },
         },
       })
+      const Status = new ObjectType({
+        elemID: new ElemID(ADAPTER_NAME, 'Status'),
+        fields: {
+          id: { refType: BuiltinTypes.STRING },
+          name: { refType: BuiltinTypes.STRING },
+        },
+      })
 
       return {
         Owner,
         Pet,
         Food,
+        Status,
       }
     }
 
@@ -106,6 +114,11 @@ describe('swagger_instance_elements', () => {
           if (getParams.url === '/owner') {
             yield [
               { name: 'owner2' },
+            ].flatMap(extractPageEntries)
+          }
+          if (getParams.url === '/status') {
+            yield [
+              { id: '1', name: 'DoNe' },
             ].flatMap(extractPageEntries)
           }
         }
@@ -1322,6 +1335,52 @@ describe('swagger_instance_elements', () => {
         },
         objectTypes,
       })).rejects.toThrow(new Error('Invalid type config - type myAdapter.Pet has no request config'))
+    })
+
+    it('should convert name to lowercase if convertNameToLowercase is true', async () => {
+      const objectTypes = generateObjectTypes()
+      const res = await getAllInstances({
+        paginator: mockPaginator,
+        apiConfig: {
+          typeDefaults: {
+            transformation: {
+              idFields: ['id'],
+            },
+          },
+          types: {
+            Status: {
+              request: {
+                url: '/status',
+              },
+              transformation: {
+                idFields: ['name'],
+                convertNameToLowercase: true,
+              },
+            },
+          },
+        },
+        fetchQuery: createElementQuery({
+          include: [
+            { type: 'Status' },
+          ],
+          exclude: [],
+        }),
+        supportedTypes: {
+          Status: ['Status'],
+        },
+        objectTypes,
+        computeGetArgs: simpleGetArgs,
+        nestedFieldFinder: returnFullEntry,
+      })
+      expect(res.map(e => e.elemID.name)).toEqual(['done'])
+      expect(res.map(e => e.path)).toEqual([
+        [
+          ADAPTER_NAME,
+          'Records',
+          'Status',
+          'done',
+        ],
+      ])
     })
   })
 

--- a/packages/adapter-components/test/filters/referenced_instance_name.test.ts
+++ b/packages/adapter-components/test/filters/referenced_instance_name.test.ts
@@ -20,7 +20,7 @@ import { addReferencesToInstanceNames, referencedInstanceNamesFilterCreator,
 import { FilterWith } from '../../src/filter_utils'
 import { Paginator } from '../../src/client'
 import { createMockQuery } from '../../src/elements/query'
-import { NameTrasformationOptions } from '../../src/config'
+import { NameMappingOptions } from '../../src/config'
 
 const ADAPTER_NAME = 'myAdapter'
 
@@ -174,7 +174,7 @@ describe('referenced instances', () => {
       sameRecipeOne, sameRecipeTwo, lastRecipe, groupType, ...groups,
       folderType, folderOne, folderTwo, statusType, status]
   }
-  const lowercaseName : NameTrasformationOptions = 'lowercase'
+  const lowercaseName : NameMappingOptions = 'lowercase'
   const config = {
     apiDefinitions: {
       types: {
@@ -202,7 +202,7 @@ describe('referenced instances', () => {
         status: {
           transformation: {
             idFields: ['name', '&fav_recipe'],
-            saltoNameTransformation: lowercaseName,
+            nameMapping: lowercaseName,
           },
         },
       },

--- a/packages/jira-adapter/e2e_test/instances/board.ts
+++ b/packages/jira-adapter/e2e_test/instances/board.ts
@@ -33,7 +33,7 @@ export const createKanbanBoardValues = (name: string, allElements: Element[]): V
       {
         name: 'second',
         statuses: [
-          createReference(new ElemID(JIRA, 'Status', 'instance', 'Done'), allElements),
+          createReference(new ElemID(JIRA, 'Status', 'instance', 'done'), allElements),
         ],
         min: 2,
         max: 4,
@@ -59,7 +59,7 @@ export const createScrumBoardValues = (name: string, allElements: Element[]): Va
       {
         name: 'second',
         statuses: [
-          createReference(new ElemID(JIRA, 'Status', 'instance', 'Done'), allElements),
+          createReference(new ElemID(JIRA, 'Status', 'instance', 'done'), allElements),
         ],
       },
     ],

--- a/packages/jira-adapter/e2e_test/instances/workflow.ts
+++ b/packages/jira-adapter/e2e_test/instances/workflow.ts
@@ -24,7 +24,7 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
     {
       name: 'Build Broken',
       description: '',
-      to: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'Backlog'), allElements),
+      to: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'backlog'), allElements),
       type: 'global',
       rules: {
         triggers: [
@@ -80,7 +80,7 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
     {
       name: 'Create',
       description: '',
-      to: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'Backlog'), allElements),
+      to: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'backlog'), allElements),
       type: 'initial',
       rules: {
         validators: [
@@ -162,9 +162,9 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
       name: 'TransitionToShared',
       description: '',
       from: [
-        createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'Done'), allElements),
+        createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'done'), allElements),
       ],
-      to: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'Backlog'), allElements),
+      to: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'backlog'), allElements),
       type: 'directed',
       rules: {
         validators: [
@@ -197,7 +197,7 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
             configuration: {
               parentStatuses: [
                 {
-                  id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'In_Progress@s'), allElements),
+                  id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'in_progress@s'), allElements),
                 },
               ],
             },
@@ -213,7 +213,7 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
             configuration: {
               mostRecentStatusOnly: false,
               previousStatus: {
-                id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'Done'), allElements),
+                id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'done'), allElements),
               },
             },
           },
@@ -291,7 +291,7 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
                 mostRecentStatusOnly: true,
                 reverseCondition: true,
                 previousStatus: {
-                  id: createReference(new ElemID(JIRA, 'Status', 'instance', 'Done'), allElements),
+                  id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'done'), allElements),
                 },
               },
             },
@@ -299,10 +299,10 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
               type: 'SeparationOfDutiesCondition',
               configuration: {
                 toStatus: {
-                  id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'Backlog'), allElements),
+                  id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'backlog'), allElements),
                 },
                 fromStatus: {
-                  id: createReference(new ElemID(JIRA, 'Status', 'instance', 'Done'), allElements),
+                  id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'done'), allElements),
                 },
               },
             },
@@ -311,10 +311,10 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
               configuration: {
                 statuses: [
                   {
-                    id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'Backlog'), allElements),
+                    id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'backlog'), allElements),
                   },
                   {
-                    id: createReference(new ElemID(JIRA, 'Status', 'instance', 'Done'), allElements),
+                    id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'done'), allElements),
                   },
                 ],
               },
@@ -368,7 +368,7 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
   ],
   statuses: [
     {
-      id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'Backlog'), allElements),
+      id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'backlog'), allElements),
       name: 'CustomBacklog',
       properties: [{
         key: 'jira.issue.editable',
@@ -376,7 +376,7 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
       }],
     },
     {
-      id: createReference(new ElemID(JIRA, 'Status', 'instance', 'Done'), allElements),
+      id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'done'), allElements),
       name: 'Done',
       properties: [{
         key: 'jira.issue.editable',

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1285,7 +1285,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
         },
       ],
       serviceUrl: '/secure/admin/EditStatus!default.jspa?id={id}',
-      convertNameToLowercase: true,
+      saltoNameTransformation: 'lowercase',
     },
     deployRequests: {
       remove: {

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1285,6 +1285,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
         },
       ],
       serviceUrl: '/secure/admin/EditStatus!default.jspa?id={id}',
+      convertNameToLowercase: true,
     },
     deployRequests: {
       remove: {

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1285,7 +1285,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
         },
       ],
       serviceUrl: '/secure/admin/EditStatus!default.jspa?id={id}',
-      saltoNameTransformation: 'lowercase',
+      nameMapping: 'lowercase',
     },
     deployRequests: {
       remove: {

--- a/packages/jira-adapter/system_config_doc.md
+++ b/packages/jira-adapter/system_config_doc.md
@@ -1774,7 +1774,7 @@ jira {
             },
           ]
           serviceUrl = "/secure/admin/EditStatus!default.jspa?id={id}"
-          saltoNameTransformation = "lowercase"
+          nameMapping = "lowercase"
         }
         deployRequests = {
           remove = {

--- a/packages/jira-adapter/system_config_doc.md
+++ b/packages/jira-adapter/system_config_doc.md
@@ -15,7 +15,7 @@ jira {
           newName = "IssueType"
         },
         {
-          originalName = "StatusDetails"
+          originalName = "JiraStatus"
           newName = "Status"
         },
         {
@@ -115,7 +115,7 @@ jira {
           newName = "ScreenSchemes"
         },
         {
-          originalName = "rest__api__3__status"
+          originalName = "PageOfStatuses"
           newName = "Statuses"
         },
         {
@@ -137,6 +137,14 @@ jira {
         {
           originalName = "Webhook"
           newName = "AppWebhook"
+        },
+        {
+          originalName = "PageBeanGroupDetails"
+          newName = "Groups"
+        },
+        {
+          originalName = "GroupDetails"
+          newName = "Group"
         },
       ]
       additionalTypes = [
@@ -182,6 +190,7 @@ jira {
         transformation = {
           dataField = "."
           isSingleton = true
+          serviceUrl = "/secure/admin/ViewApplicationProperties.jspa"
         }
       }
       Dashboards = {
@@ -296,6 +305,7 @@ jira {
               fieldName = "gadgets"
             },
           ]
+          serviceUrl = "/jira/dashboards/{id}"
         }
         deployRequests = {
           add = {
@@ -528,9 +538,6 @@ jira {
           ]
           fieldsToOmit = [
             {
-              fieldName = "isGlobalContext"
-            },
-            {
               fieldName = "isAnyIssueType"
             },
           ]
@@ -606,6 +613,7 @@ jira {
               fieldName = "id"
             },
           ]
+          serviceUrl = "/secure/admin/ConfigureFieldLayout!default.jspa?=&id={id}"
         }
         deployRequests = {
           add = {
@@ -659,6 +667,7 @@ jira {
               fieldName = "id"
             },
           ]
+          serviceUrl = "/secure/admin/ConfigureFieldLayoutScheme!default.jspa?=&id={id}"
         }
         deployRequests = {
           add = {
@@ -733,6 +742,7 @@ jira {
               fieldName = "expand"
             },
           ]
+          serviceUrl = "/issues/?filter={id}"
         }
         deployRequests = {
           add = {
@@ -811,6 +821,7 @@ jira {
               fieldName = "id"
             },
           ]
+          serviceUrl = "/secure/admin/ConfigureOptionSchemes!default.jspa?fieldId=&schemeId={id}"
         }
         deployRequests = {
           add = {
@@ -879,6 +890,7 @@ jira {
               fieldName = "id"
             },
           ]
+          serviceUrl = "/secure/admin/ConfigureIssueTypeScreenScheme.jspa?id={id}"
         }
         request = {
           url = "/rest/api/3/issuetypescreenscheme"
@@ -958,6 +970,14 @@ jira {
               fieldType = "string"
             },
           ]
+          fieldsToOmit = [
+            {
+              fieldName = "value"
+            },
+            {
+              fieldName = "expand"
+            },
+          ]
         }
       }
       PermissionGrant = {
@@ -976,6 +996,7 @@ jira {
               fieldName = "id"
             },
           ]
+          serviceUrl = "/secure/admin/EditPermissions!default.jspa?schemeId={id}"
         }
         request = {
           url = "/rest/api/3/project/{projectId}/permissionscheme"
@@ -1130,6 +1151,7 @@ jira {
               fieldName = "id"
             },
           ]
+          serviceUrl = "/secure/admin/projectcategories/EditProjectCategory!default.jspa?id={id}"
         }
         deployRequests = {
           add = {
@@ -1193,6 +1215,10 @@ jira {
               fieldName = "issueTypeScheme"
               fieldType = "IssueTypeScheme"
             },
+            {
+              fieldName = "fieldContexts"
+              fieldType = "list<CustomFieldContext>"
+            },
           ]
           fieldsToHide = [
             {
@@ -1204,6 +1230,7 @@ jira {
               fieldName = "components"
             },
           ]
+          serviceUrl = "/secure/project/EditProject!default.jspa?pid={id}"
         }
         deployRequests = {
           add = {
@@ -1313,6 +1340,7 @@ jira {
               fieldName = "id"
             },
           ]
+          serviceUrl = "/secure/admin/EditNotifications!default.jspa?schemeId={id}"
         }
         jspRequests = {
           add = "/secure/admin/AddNotificationScheme.jspa"
@@ -1388,6 +1416,7 @@ jira {
               fieldName = "id"
             },
           ]
+          serviceUrl = "/secure/admin/EditResolution!default.jspa?id={id}"
         }
         jspRequests = {
           add = "/secure/admin/AddResolution.jspa"
@@ -1408,6 +1437,7 @@ jira {
               fieldName = "id"
             },
           ]
+          serviceUrl = "/secure/admin/ConfigureFieldScreen.jspa?id={id}"
         }
         deployRequests = {
           add = {
@@ -1492,8 +1522,9 @@ jira {
         }
       }
       Statuses = {
-        transformation = {
-          dataField = "."
+        request = {
+          url = "/rest/api/3/statuses/search"
+          paginationField = "startAt"
         }
       }
       Workflows = {
@@ -1552,6 +1583,7 @@ jira {
               fieldName = "updated"
             },
           ]
+          serviceUrl = "/secure/admin/workflows/ViewWorkflowSteps.jspa?workflowMode=live&workflowName={name}"
         }
         deployRequests = {
           add = {
@@ -1586,6 +1618,7 @@ jira {
               fieldName = "levels"
             },
           ]
+          serviceUrl = "/secure/admin/EditIssueSecurityScheme!default.jspa?=&schemeId={id}"
         }
         jspRequests = {
           add = "/secure/admin/AddIssueSecurityScheme.jspa"
@@ -1704,7 +1737,23 @@ jira {
         transformation = {
           fieldTypeOverrides = [
             {
-              fieldName = "untranslatedName"
+              fieldName = "id"
+              fieldType = "string"
+            },
+            {
+              fieldName = "name"
+              fieldType = "string"
+            },
+            {
+              fieldName = "statusCategory"
+              fieldType = "string"
+            },
+            {
+              fieldName = "scope"
+              fieldType = "StatusScope"
+            },
+            {
+              fieldName = "description"
               fieldType = "string"
             },
           ]
@@ -1713,12 +1762,25 @@ jira {
               fieldName = "id"
             },
           ]
+          fieldsToOmit = [
+            {
+              fieldName = "scope"
+            },
+            {
+              fieldName = "icon"
+            },
+            {
+              fieldName = "resolved"
+            },
+          ]
+          serviceUrl = "/secure/admin/EditStatus!default.jspa?id={id}"
+          saltoNameTransformation = "lowercase"
         }
-        jspRequests = {
-          add = "/secure/admin/AddStatus.jspa"
-          modify = "/secure/admin/EditStatus.jspa"
-          remove = "/secure/admin/DeleteStatus.jspa"
-          query = "/rest/workflowDesigner/1.0/statuses"
+        deployRequests = {
+          remove = {
+            url = "/rest/api/3/statuses?id={id}"
+            method = "delete"
+          }
         }
       }
       WorkflowScheme = {
@@ -1728,6 +1790,7 @@ jira {
               fieldName = "id"
             },
           ]
+          serviceUrl = "/secure/admin/EditWorkflowScheme.jspa?schemeId={id}"
         }
         deployRequests = {
           add = {
@@ -1760,12 +1823,19 @@ jira {
             {
               fieldName = "subtask"
             },
+            {
+              fieldName = "avatarId"
+            },
+            {
+              fieldName = "iconUrl"
+            },
           ]
           fieldsToHide = [
             {
               fieldName = "id"
             },
           ]
+          serviceUrl = "/secure/admin/EditIssueType!default.jspa?id={id}"
         }
         deployRequests = {
           add = {
@@ -1785,6 +1855,7 @@ jira {
       AttachmentSettings = {
         transformation = {
           isSingleton = true
+          serviceUrl = "/secure/admin/ViewAttachmentSettings.jspa"
         }
       }
       Permissions_permissions = {
@@ -1831,6 +1902,32 @@ jira {
               fieldName = "type"
             },
           ]
+        }
+      }
+      Group = {
+        transformation = {
+          fieldsToHide = [
+            {
+              fieldName = "groupId"
+            },
+          ]
+          serviceIdField = "groupId"
+        }
+        deployRequests = {
+          add = {
+            url = "/rest/api/3/group"
+            method = "post"
+          }
+          remove = {
+            url = "/rest/api/3/group?groupId={groupId}"
+            method = "delete"
+          }
+        }
+      }
+      Groups = {
+        request = {
+          url = "/rest/api/3/group/bulk"
+          paginationField = "startAt"
         }
       }
       Board = {
@@ -1909,6 +2006,7 @@ jira {
               fieldName = "id"
             },
           ]
+          serviceUrl = "/secure/admin/EditLinkType!default.jspa?id={id}"
         }
       }
       ProjectRole = {
@@ -1918,6 +2016,7 @@ jira {
               fieldName = "id"
             },
           ]
+          serviceUrl = "/secure/project/EditProjectRole!default.jspa?id={id}"
         }
         deployRequests = {
           add = {
@@ -1934,6 +2033,16 @@ jira {
           }
         }
       }
+      TimeTrackingProvider = {
+        transformation = {
+          serviceUrl = "/secure/admin/TimeTrackingAdmin.jspa"
+        }
+      }
+      Automation = {
+        transformation = {
+          serviceUrl = "/jira/settings/automation#/rule/{id}"
+        }
+      }
       IssueEvent = {
         transformation = {
           fieldsToHide = [
@@ -1941,6 +2050,7 @@ jira {
               fieldName = "id"
             },
           ]
+          serviceUrl = "/secure/admin/ListEventTypes.jspa"
         }
       }
       Priority = {
@@ -1950,6 +2060,7 @@ jira {
               fieldName = "id"
             },
           ]
+          serviceUrl = "/secure/admin/EditPriority!default.jspa?id={id}"
         }
         jspRequests = {
           add = "/secure/admin/AddPriority.jspa"
@@ -1965,6 +2076,12 @@ jira {
             },
             {
               fieldName = "remainingSeats"
+            },
+            {
+              fieldName = "groupDetails"
+            },
+            {
+              fieldName = "defaultGroupsDetails"
             },
           ]
         }
@@ -1985,6 +2102,7 @@ jira {
               fieldName = "id"
             },
           ]
+          serviceUrl = "/secure/admin/ConfigureFieldScreenScheme.jspa?id={id}"
         }
         deployRequests = {
           add = {
@@ -2147,6 +2265,13 @@ jira {
       ]
       Board = [
         "Boards",
+      ]
+      Group = [
+        "Groups",
+      ]
+      Automation = [
+      ]
+      Webhook = [
       ]
     }
   }


### PR DESCRIPTION
Add `nameMapping` option to `TransformationConfig` and set use it to lowercase instance ids for Jira `Status` instances

---

As the same Jira status instance might appear in different cases sometimes, we want to convert all status salto names to lowercase. To enable this change I added `nameMapping` to `TransformationConfig`, and we convert the instance id and filepath when the instance is created.

---
_Release Notes_: 

Jira: convert `Status` instance names  lowercase. To update existing status element ids please run `salto fetch --regenerate-salto-ids`

---
_User Notifications_: 

Jira: On the next fetch with `--regenerate-salto-ids` status instances ids will change to lowercase.
