### PR TITLE
SALTO-820: Resolve field parent when resolving references

### DIFF
--- a/packages/workspace/test/core/expressions.test.ts
+++ b/packages/workspace/test/core/expressions.test.ts
@@ -24,9 +24,7 @@ const { awu } = collections.asynciterable
 
 describe('Test Salto Expressions', () => {
   const refTo = ({ elemID }: { elemID: ElemID }, ...path: string[]): ReferenceExpression => (
-    new ReferenceExpression(
-      elemID.createNestedID(...path)
-    )
+    new ReferenceExpression(path.length === 0 ? elemID : elemID.createNestedID(...path))
   )
 
   describe('Reference Expression', () => {
@@ -486,6 +484,9 @@ describe('Test Salto Expressions', () => {
             annotations: { ref: refTo(referencedType, 'attr', 'value') },
           },
         },
+        annotations: {
+          ref: refTo(referencedType),
+        },
       })
       const fieldToResolve = objectType.fields.field
       const resolved = await resolve(
@@ -504,6 +505,10 @@ describe('Test Salto Expressions', () => {
     })
     it('should resolve references in the field', () => {
       expect(resolvedField.annotations.ref.value).toEqual(referencedType.annotations.value)
+    })
+    it('should resolve the fields parent', () => {
+      expect(resolvedField.parent.annotations.ref).toBeInstanceOf(ReferenceExpression)
+      expect(resolvedField.parent.annotations.ref.value).toEqual(referencedType)
     })
   })
 


### PR DESCRIPTION
When resolving references we would not resolve the field's parent type.
this was done as a small performance improvement but now we have a case where
we actually need the field's parent resolved in an adapter.

---

The netsuite adapter will soon require that the field's parent is resolved when deploying `customrecordtype`s

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
