### PR TITLE
SALTO-1519: Print skipped elements IDs on deploy

### DIFF
--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -232,7 +232,7 @@ export const formatChangeErrors = (
   }
   const formatElement = (changeError: ChangeWorkspaceError):string => {
     const possibleDetailed: string = detailed ? `${EOL}${indent(chalk.dim(changeError.detailedMessage), errorsIndent + 2)}` : ''
-    return `${indent(changeError.elemID.name, errorsIndent + 1)}${possibleDetailed}`
+    return `${indent(changeError.elemID.getFullName(), errorsIndent + 1)}${possibleDetailed}`
   }
   const formatGroupedChangeErrors = (groupedChangeErrors: ChangeWorkspaceError[]): string => {
     const firstErr: ChangeWorkspaceError = groupedChangeErrors[0]

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -222,28 +222,38 @@ const getElapsedTime = (start: Date): number => Math.ceil(
 type ChangeWorkspaceError = errors.WorkspaceError<ChangeError>
 
 export const formatChangeErrors = (
-  wsChangeErrors: ReadonlyArray<ChangeWorkspaceError>
+  wsChangeErrors: ReadonlyArray<ChangeWorkspaceError>, detailed = false
 ): string => {
+  const errorsIndent = 2
+  const formatSingleChangeError = (changeError: ChangeWorkspaceError): string => {
+    const formattedError = formatWorkspaceError(changeError)
+    return indent(`${formattedError}${EOL}${changeError.severity}: ${changeError.detailedMessage}`,
+      errorsIndent)
+  }
+  const formatElement = (changeError: ChangeWorkspaceError):string => {
+    const possibleDetailed: string = detailed ? `${EOL}${indent(chalk.dim(changeError.detailedMessage), errorsIndent + 2)}` : ''
+    return `${indent(changeError.elemID.name, errorsIndent + 1)}${possibleDetailed}`
+  }
   const formatGroupedChangeErrors = (groupedChangeErrors: ChangeWorkspaceError[]): string => {
-    const errorsIndent = 2
     const firstErr: ChangeWorkspaceError = groupedChangeErrors[0]
     if (firstErr.detailedMessage === '') {
       return ''
     }
-    if (groupedChangeErrors.length > 1) {
-      return indent(`${firstErr.severity}: ${formatError(firstErr)} (${groupedChangeErrors.length} Elements)`,
-        errorsIndent)
+    if (groupedChangeErrors.length === 1) {
+      return formatSingleChangeError(firstErr)
     }
-    const formattedError = formatWorkspaceError(firstErr)
-    return indent(`${formattedError}${EOL}${firstErr.severity}: ${firstErr.detailedMessage}`,
-      errorsIndent)
+
+    const resultMessages: string = [indent(`${firstErr.severity}: ${formatError(firstErr)} in the following elements:`, errorsIndent)]
+      .concat(groupedChangeErrors.map(formatElement))
+      .join(EOL)
+    return resultMessages
   }
   const ret = _(wsChangeErrors)
     .groupBy(ce => ce.message)
     .values()
     .sortBy(errs => -errs.length)
     .map(formatGroupedChangeErrors)
-    .join('\n')
+    .join(EOL)
   return ret
 }
 
@@ -283,7 +293,7 @@ export const formatExecutionPlan = async (
   detailed = false,
 ): Promise<string> => {
   const formattedPlanChangeErrors: string = formatChangeErrors(
-    workspaceErrors
+    workspaceErrors, detailed
   )
   const preDeployCallToActions: string[] = formatDeployActions(
     {

--- a/packages/cli/test/formatter.test.ts
+++ b/packages/cli/test/formatter.test.ts
@@ -159,14 +159,14 @@ describe('formatter', () => {
     it('should have grouped validations', () => {
       const output = formatChangeErrors(groupedChangeErrors)
       let expectedMessage = `    ${groupedChangeErrors[0].severity}: ${chalk.bold(groupedChangeErrors[0].message)} in the following elements:`
-      expectedMessage += `${EOL}      test1${EOL}      test2`
+      expectedMessage += `${EOL}      ${groupedChangeErrors[0].elemID.getFullName()}${EOL}      ${groupedChangeErrors[1].elemID.getFullName()}`
       expect(output).toMatch(expectedMessage)
     })
     it('should display detailed message in detailed mode for grouped validations', () => {
       const output = formatChangeErrors(groupedChangeErrors, true)
       let expectedMessage = `    ${groupedChangeErrors[0].severity}: ${chalk.bold(groupedChangeErrors[0].message)} in the following elements:`
-      expectedMessage += `${EOL}      test1${EOL}        ${chalk.dim(groupedChangeErrors[0].detailedMessage)}`
-      expectedMessage += `${EOL}      test2${EOL}        ${chalk.dim(groupedChangeErrors[1].detailedMessage)}`
+      expectedMessage += `${EOL}      ${groupedChangeErrors[0].elemID.getFullName()}${EOL}        ${chalk.dim(groupedChangeErrors[0].detailedMessage)}`
+      expectedMessage += `${EOL}      ${groupedChangeErrors[1].elemID.getFullName()}${EOL}        ${chalk.dim(groupedChangeErrors[1].detailedMessage)}`
       expect(output).toMatch(expectedMessage)
     })
     it('should contain EOL between title and content', () => {


### PR DESCRIPTION
Added elements IDs list when change validator returns an error.
In addition added the detailed message for each element ID in case the deploy was performed in detailed version (-p)

---


---
_Release Notes_: 
CLI:
When a deploy skips several elements with the same error message the elements ID are listed
When such a deploy is performed in "detailed-plan" mode (-p) for each skipped element a detailed message will be added

---
_User Notifications_: 
Nnoe
