### PR TITLE
SALTO-2305: remove the SALTO-2305 debugging logs

### DIFF
--- a/packages/zendesk-adapter/src/filters/remove_definition_instances.ts
+++ b/packages/zendesk-adapter/src/filters/remove_definition_instances.ts
@@ -14,8 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { cloneDeepWithoutRefs, isInstanceElement } from '@salto-io/adapter-api'
-import { safeJsonStringify } from '@salto-io/adapter-utils'
+import { isInstanceElement } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
 
@@ -37,19 +36,6 @@ const DEFINITION_TYPE_NAMES = [
  */
 const filterCreator: FilterCreator = () => ({
   onFetch: async elements => log.time(async () => {
-    // ---- Start debugging SALTO-2305 ----
-    const triggerDefs = elements
-      .filter(isInstanceElement)
-      .find(inst => inst.elemID.typeName === 'trigger_definition')
-    if (triggerDefs) {
-      const triggerDefsVal = safeJsonStringify(cloneDeepWithoutRefs(triggerDefs?.value))
-      const chunks = _.chunk(triggerDefsVal, 200 * 1024).map(chunk => chunk.join(''))
-      chunks.forEach((chunk, i) => {
-        log.debug(`DEBUGGING2305:${i}:${chunk}`)
-      })
-    }
-    // ---- End debugging SALTO-2305 ----
-
     _.remove(elements,
       element =>
         isInstanceElement(element) && DEFINITION_TYPE_NAMES.includes(element.elemID.typeName))


### PR DESCRIPTION
_remove the SALTO-2305 debugging logs_

---

_Additional context for reviewer_
We added those logs back then to debug the bug that is described in the ticket. We solve the bug and I believe that we don't need those logs anymore

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
