### PR TITLE
SALTO-2527 SALTO-2386 Retry after SERVER_UNAVAILABLE error - upon salesforce fetch

### DIFF
--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -115,6 +115,7 @@ const errorMessagesToRetry = [
    */
   'retry your request',
   'Polling time out',
+  'SERVER_UNAVAILABLE',
 ]
 
 type RateLimitBucketName = keyof ClientRateLimitConfig


### PR DESCRIPTION
_Retry after SERVER_UNAVAILABLE error - upon salesforce fetch_

---
_Additional context for reviewer_:
None

---
_Release Notes_: 
Salesforce-adapter:

* automatically retry fetch with sf: SERVER_UNAVAILABLE error
---

_User Notifications_: 
None
