### PR TITLE
SALTO-2551: Ignore empty tag in ticket field checkboxes

### DIFF
--- a/packages/zendesk-adapter/src/change_validators/duplicate_option_values.ts
+++ b/packages/zendesk-adapter/src/change_validators/duplicate_option_values.ts
@@ -40,6 +40,7 @@ export const isRelevantChange = (change: Change<InstanceElement>): boolean => {
         isModificationChange(change)
         && (change.data.before.value.tag === change.data.after.value.tag)
       )
+      && !_.isEmpty(instance.value.tag)
   }
   if (RELEVANT_PARENT_AND_CHILD_TYPES.some(pair => pair.child === changeTypeName)) {
     return !(
@@ -135,7 +136,7 @@ export const duplicateCustomFieldOptionValuesValidator: ChangeValidator = async 
       relevantTypeToElementIds,
       typeName: pair.parent,
       elementSource,
-      filter: inst => inst.value.type === CHECKBOX_TYPE_NAME && inst.value.tag !== '',
+      filter: inst => inst.value.type === CHECKBOX_TYPE_NAME && !_.isEmpty(inst.value.tag),
     })
     return relevantChanges
       .filter(change => getRelevantPairType(change)?.parent === pair.parent)

--- a/packages/zendesk-adapter/test/change_validators/duplicate_option_values.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/duplicate_option_values.test.ts
@@ -26,6 +26,16 @@ describe('duplicateCustomFieldOptionValuesValidator', () => {
     ticketFieldType,
     { type: 'checkbox', title: 'myCheckbox', tag: 'cTag' },
   )
+  const checkboxWithNullTagTicketField = new InstanceElement(
+    'emptyCheckbox1',
+    ticketFieldType,
+    { type: 'checkbox', title: 'emptyCheckbox1', tag: null },
+  )
+  const checkboxWithEmptyTagAsStringTicketField = new InstanceElement(
+    'emptyCheckbox2',
+    ticketFieldType,
+    { type: 'checkbox', title: 'emptyCheckbox2', tag: '' },
+  )
   const ticketFieldOption1 = new InstanceElement(
     'option1',
     ticketFieldOptionType,
@@ -58,6 +68,7 @@ describe('duplicateCustomFieldOptionValuesValidator', () => {
     const elementsSource = buildElementsSourceFromElements([
       ticketFieldType, ticketFieldOptionType, checkboxTicketField, ticketFieldOption1,
       ticketFieldOption2, taggerTicketField, optionToAdd, checkboxToAdd,
+      checkboxWithNullTagTicketField, checkboxWithEmptyTagAsStringTicketField,
     ].map(e => e.clone()))
     const elementsToAdd = [optionToAdd, checkboxToAdd]
     const errors = await duplicateCustomFieldOptionValuesValidator(
@@ -89,6 +100,7 @@ describe('duplicateCustomFieldOptionValuesValidator', () => {
     const elementsSource = buildElementsSourceFromElements([
       ticketFieldType, ticketFieldOptionType, checkboxTicketField, ticketFieldOption1,
       ticketFieldOption2, taggerTicketField, checkboxToAdd,
+      checkboxWithNullTagTicketField, checkboxWithEmptyTagAsStringTicketField,
     ].map(e => e.clone()))
     const errors = await duplicateCustomFieldOptionValuesValidator(
       [toChange({ after: checkboxToAdd })],
@@ -122,6 +134,7 @@ describe('duplicateCustomFieldOptionValuesValidator', () => {
       ticketFieldType, ticketFieldOptionType, checkboxTicketField, ticketFieldOption1,
       ticketFieldOption2, taggerTicketField, optionToChangeAfter, checkboxToChangeAfter,
       instanceOfIrrelevantType, textToAdd,
+      checkboxWithNullTagTicketField, checkboxWithEmptyTagAsStringTicketField,
     ].map(e => e.clone()))
     const errors = await duplicateCustomFieldOptionValuesValidator(
       [
@@ -131,6 +144,24 @@ describe('duplicateCustomFieldOptionValuesValidator', () => {
         toChange({ before: checkboxToChangeBefore, after: checkboxToChangeAfter }),
         toChange({ after: instanceOfIrrelevantType }),
       ],
+      elementsSource,
+    )
+    expect(errors).toHaveLength(0)
+  })
+  it('should return no error if we add another checkbox with empty tag', async () => {
+    const checkboxToAddNullTag = new InstanceElement(
+      'checkbox2', ticketFieldType, { type: 'checkbox', title: 'myCheckbox2', tag: null }
+    )
+    const checkboxToAddEmptyStrTag = new InstanceElement(
+      'checkbox3', ticketFieldType, { type: 'checkbox', title: 'myCheckbox3', tag: '' }
+    )
+    const elementsSource = buildElementsSourceFromElements([
+      ticketFieldType, ticketFieldOptionType, checkboxTicketField, ticketFieldOption1,
+      ticketFieldOption2, taggerTicketField, checkboxToAddNullTag, checkboxToAddEmptyStrTag,
+      checkboxWithNullTagTicketField, checkboxWithEmptyTagAsStringTicketField,
+    ].map(e => e.clone()))
+    const errors = await duplicateCustomFieldOptionValuesValidator(
+      [toChange({ after: checkboxToAddNullTag }), toChange({ after: checkboxToAddEmptyStrTag })],
       elementsSource,
     )
     expect(errors).toHaveLength(0)


### PR DESCRIPTION
_Ignore empty tag in ticket field checkboxes in the change validators_

---

_Additional context for reviewer_
Fixes a bug that returned a change validator error if you added a checkbox with empty tag and one already existed in your account. It started to happen because zendesk changed the value of empty tag from empty string to null

---
_Release Notes_: 
_Zendesk Adapter_
* Fixed a bug that created a change validator error if you added a checkbox with empty tag when there was already an existent checkbox with empty tag

---
_User Notifications_: 
_None_
