### PR TITLE
SALTO-2457 SALTO-2431 Retry after errors - upon salesforce fetch

### DIFF
--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -117,7 +117,7 @@ const errorMessagesToRetry = [
   'Polling time out',
   'SERVER_UNAVAILABLE',
   'system may be currently unavailable',
-  'Unexpected internal servlet state'
+  'Unexpected internal servlet state',
 ]
 
 type RateLimitBucketName = keyof ClientRateLimitConfig

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -116,6 +116,8 @@ const errorMessagesToRetry = [
   'retry your request',
   'Polling time out',
   'SERVER_UNAVAILABLE',
+  'system may be currently unavailable',
+  'Unexpected internal servlet state'
 ]
 
 type RateLimitBucketName = keyof ClientRateLimitConfig


### PR DESCRIPTION
_Retry after 'System may be currently unavailable' and 'Unexpected internal servlet state' errors - upon salesforce fetch_

---
_Additional context for reviewer_:
None

---
_Release Notes_: 
Salesforce-adapter:

* automatically retry fetch after 'System may be currently unavailable' and 'Unexpected internal servlet state' errors 
---

_User Notifications_: 
None
