### PR TITLE
SALTO-2548 fix element source filter

### DIFF
--- a/packages/core/src/core/adapters/adapters.ts
+++ b/packages/core/src/core/adapters/adapters.ts
@@ -132,7 +132,7 @@ export const createElemIDReplacedElementsSource = (
           return ret
         }),
       get: async id => {
-        const element = (await elementsSource.get(createAdapterReplacedID(id, account))).clone()
+        const element = (await elementsSource.get(createAdapterReplacedID(id, account)))?.clone()
         if (element) {
           await updateElementsWithAlternativeAccount(
             [element], adapter, account, elementsSource

--- a/packages/core/src/core/adapters/adapters.ts
+++ b/packages/core/src/core/adapters/adapters.ts
@@ -196,7 +196,7 @@ export const getAdaptersCreatorConfigs = async (
           credentials: credentials[account],
           config: await getConfig(account, defaultConfig),
           elementsSource: createElemIDReplacedElementsSource(filterElementsSource(
-            elementsSource, accountToServiceName[account]
+            elementsSource, account
           ), account, accountToServiceName[account]),
           getElemIdFunc: elemIdGetters[account],
         },

--- a/packages/core/src/core/adapters/adapters.ts
+++ b/packages/core/src/core/adapters/adapters.ts
@@ -123,14 +123,20 @@ export const createElemIDReplacedElementsSource = (
 ): ReadOnlyElementsSource => (
   account === adapter
     ? elementsSource : ({
-      getAll: async () => awu(await elementsSource.getAll()).map(async element => {
-        await updateElementsWithAlternativeAccount([element], adapter, account, elementsSource)
-        return element
-      }),
+      getAll: async () =>
+        awu(await elementsSource.getAll()).map(async element => {
+          const ret = element.clone()
+          await updateElementsWithAlternativeAccount(
+            [ret], adapter, account, elementsSource
+          )
+          return ret
+        }),
       get: async id => {
-        const element = await elementsSource.get(createAdapterReplacedID(id, account))
+        const element = (await elementsSource.get(createAdapterReplacedID(id, account))).clone()
         if (element) {
-          await updateElementsWithAlternativeAccount([element], adapter, account, elementsSource)
+          await updateElementsWithAlternativeAccount(
+            [element], adapter, account, elementsSource
+          )
         }
         return element
       },

--- a/packages/core/test/core/adapters/adapters.test.ts
+++ b/packages/core/test/core/adapters/adapters.test.ts
@@ -185,22 +185,32 @@ describe('adapters.ts', () => {
     it('should return an ReadOnlyElementsSource with only the adapter elements', async () => {
       const objectType = new ObjectType({ elemID: new ElemID(serviceName, 'type1') })
       const result = await getAdaptersCreatorConfigs(
-        [serviceName],
+        [serviceName, 'd1'],
         { [sfConfig.elemID.adapter]: sfConfig },
         async name => (name === sfConfig.elemID.adapter ? sfConfig : undefined),
         buildElementsSourceFromElements([
           new ObjectType({ elemID: new ElemID(serviceName, 'type1') }),
-          new ObjectType({ elemID: new ElemID('dummy', 'type2') }),
+          new ObjectType({ elemID: new ElemID('d1', 'type2') }),
         ]),
-        { [serviceName]: serviceName },
+        { [serviceName]: serviceName, d1: 'dummy' },
       )
       const elementsSource = result[serviceName]?.elementsSource
       expect(elementsSource).toBeDefined()
       expect(await elementsSource.has(objectType.elemID)).toBeTruthy()
+      expect(await elementsSource.has(new ElemID('d1', 'type2'))).toBeFalsy()
       expect(await elementsSource.has(new ElemID('dummy', 'type2'))).toBeFalsy()
 
+
       expect(await elementsSource.get(objectType.elemID)).toBeDefined()
+      expect(await elementsSource.get(new ElemID('d1', 'type2'))).toBeUndefined()
       expect(await elementsSource.get(new ElemID('dummy', 'type2'))).toBeUndefined()
+
+      const d1ElementsSource = result.d1?.elementsSource
+      // since element source is used inside the adapter, it should receive and return
+      // values with default adapter name as account name
+      expect(await d1ElementsSource.get(new ElemID('dummy', 'type2'))).toEqual(new ObjectType({
+        elemID: new ElemID('dummy', 'type2'),
+      }))
 
       expect(await collections.asynciterable.toArrayAsync(await elementsSource.getAll()))
         .toEqual([objectType])

--- a/packages/core/test/core/adapters/adapters.test.ts
+++ b/packages/core/test/core/adapters/adapters.test.ts
@@ -184,13 +184,14 @@ describe('adapters.ts', () => {
 
     it('should return an ReadOnlyElementsSource with only the adapter elements', async () => {
       const objectType = new ObjectType({ elemID: new ElemID(serviceName, 'type1') })
+      const d1Type = new ObjectType({ elemID: new ElemID('d1', 'type2') })
       const result = await getAdaptersCreatorConfigs(
         [serviceName, 'd1'],
         { [sfConfig.elemID.adapter]: sfConfig },
         async name => (name === sfConfig.elemID.adapter ? sfConfig : undefined),
         buildElementsSourceFromElements([
-          new ObjectType({ elemID: new ElemID(serviceName, 'type1') }),
-          new ObjectType({ elemID: new ElemID('d1', 'type2') }),
+          objectType,
+          d1Type,
         ]),
         { [serviceName]: serviceName, d1: 'dummy' },
       )
@@ -209,6 +210,10 @@ describe('adapters.ts', () => {
       // since element source is used inside the adapter, it should receive and return
       // values with default adapter name as account name
       expect(await d1ElementsSource.get(new ElemID('dummy', 'type2'))).toEqual(new ObjectType({
+        elemID: new ElemID('dummy', 'type2'),
+      }))
+      // this tests that the inner element source does not modify the element
+      expect(d1Type).not.toEqual(new ObjectType({
         elemID: new ElemID('dummy', 'type2'),
       }))
 

--- a/packages/core/test/core/adapters/adapters.test.ts
+++ b/packages/core/test/core/adapters/adapters.test.ts
@@ -184,57 +184,56 @@ describe('adapters.ts', () => {
       expect(Object.keys(result)).toEqual([serviceName])
     })
 
-    const setupMultiAppAdapterConfig = async (): Promise<Record<string,
-      AdapterOperationsContext>> =>
-      getAdaptersCreatorConfigs(
-        [serviceName, 'd1'],
-        { [sfConfig.elemID.adapter]: sfConfig },
-        async name => (name === sfConfig.elemID.adapter ? sfConfig : undefined),
-        buildElementsSourceFromElements([
-          objectType,
-          d1Type,
-        ]),
-        { [serviceName]: serviceName, d1: 'dummy' },
-      )
+    let result: Record<string, AdapterOperationsContext>
+    describe('multi app adapter config', () => {
+      beforeEach(async () => {
+        result = await getAdaptersCreatorConfigs(
+          [serviceName, 'd1'],
+          { [sfConfig.elemID.adapter]: sfConfig },
+          async name => (name === sfConfig.elemID.adapter ? sfConfig : undefined),
+          buildElementsSourceFromElements([
+            objectType,
+            d1Type,
+          ]),
+          { [serviceName]: serviceName, d1: 'dummy' },
+        )
+      })
 
-    it('should only return elements that belong to the relevant account', async () => {
-      const result = await setupMultiAppAdapterConfig()
-      const elementsSource = result[serviceName]?.elementsSource
-      expect(elementsSource).toBeDefined()
-      expect(await elementsSource.has(objectType.elemID)).toBeTruthy()
-      expect(await elementsSource.has(new ElemID('d1', 'type2'))).toBeFalsy()
-      expect(await elementsSource.has(new ElemID('dummy', 'type2'))).toBeFalsy()
+      it('should only return elements that belong to the relevant account', async () => {
+        const elementsSource = result[serviceName]?.elementsSource
+        expect(elementsSource).toBeDefined()
+        expect(await elementsSource.has(objectType.elemID)).toBeTruthy()
+        expect(await elementsSource.has(new ElemID('d1', 'type2'))).toBeFalsy()
+        expect(await elementsSource.has(new ElemID('dummy', 'type2'))).toBeFalsy()
 
 
-      expect(await elementsSource.get(objectType.elemID)).toBeDefined()
-      expect(await elementsSource.get(new ElemID('d1', 'type2'))).toBeUndefined()
-      expect(await elementsSource.get(new ElemID('dummy', 'type2'))).toBeUndefined()
+        expect(await elementsSource.get(objectType.elemID)).toBeDefined()
+        expect(await elementsSource.get(new ElemID('d1', 'type2'))).toBeUndefined()
+        expect(await elementsSource.get(new ElemID('dummy', 'type2'))).toBeUndefined()
 
-      expect(await collections.asynciterable.toArrayAsync(await elementsSource.getAll()))
-        .toEqual([objectType])
+        expect(await collections.asynciterable.toArrayAsync(await elementsSource.getAll()))
+          .toEqual([objectType])
 
-      expect(await collections.asynciterable.toArrayAsync(await elementsSource.list()))
-        .toEqual([objectType.elemID])
-    })
+        expect(await collections.asynciterable.toArrayAsync(await elementsSource.list()))
+          .toEqual([objectType.elemID])
+      })
 
-    it('should return renamed elements when account name is different from adapter name', async () => {
-      const result = await setupMultiAppAdapterConfig()
+      it('should return renamed elements when account name is different from adapter name', async () => {
+        const d1ElementsSource = result.d1?.elementsSource
+        // since element source is used inside the adapter, it should receive and return
+        // values with default adapter name as account name
+        expect(await d1ElementsSource.get(new ElemID('dummy', 'type2'))).toEqual(new ObjectType({
+          elemID: new ElemID('dummy', 'type2'),
+        }))
+      })
 
-      const d1ElementsSource = result.d1?.elementsSource
-      // since element source is used inside the adapter, it should receive and return
-      // values with default adapter name as account name
-      expect(await d1ElementsSource.get(new ElemID('dummy', 'type2'))).toEqual(new ObjectType({
-        elemID: new ElemID('dummy', 'type2'),
-      }))
-    })
-
-    it('should not modify elements in the origin elements source', async () => {
-      const result = await setupMultiAppAdapterConfig()
-      const d1ElementsSource = result.d1?.elementsSource
-      await d1ElementsSource.get(new ElemID('dummy', 'type2'))
-      expect(d1Type).not.toEqual(new ObjectType({
-        elemID: new ElemID('dummy', 'type2'),
-      }))
+      it('should not modify elements in the origin elements source', async () => {
+        const d1ElementsSource = result.d1?.elementsSource
+        await d1ElementsSource.get(new ElemID('dummy', 'type2'))
+        expect(d1Type).not.toEqual(new ObjectType({
+          elemID: new ElemID('dummy', 'type2'),
+        }))
+      })
     })
   })
 


### PR DESCRIPTION
Fixes adapter config to correctly handle multi app scenario

---


---
_Release Notes_: 
Netsuite Adapter:
- Fixed issue where saved searches would change on fetch when in a multiple-account workspace 

---
_User Notifications_: 
_None_