### PR TITLE
SALTO-2483 Allow parsing nacl file without calculating sourceMap

### DIFF
--- a/packages/workspace/src/parser/internal/native/parse.ts
+++ b/packages/workspace/src/parser/internal/native/parse.ts
@@ -30,12 +30,25 @@ const isVariableDef = (context: ParseContext): boolean => (
   && context.lexer.peek()?.value === Keywords.VARIABLES_DEFINITION
 )
 
-export const parseBuffer = async (
+export async function parseBuffer(
   content: string,
   filename: string,
-  functions: Functions = {},
-  calcSourceMap = true
-): Promise<Required<ParseResult>> => {
+  functions: Functions,
+  calcSourceMap: true,
+): Promise<Required<ParseResult>>
+export async function parseBuffer(
+  content: string,
+  filename: string,
+  functions: Functions,
+  calcSourceMap: boolean,
+): Promise<ParseResult>
+
+export async function parseBuffer(
+  content: string,
+  filename: string,
+  functions: Functions,
+  calcSourceMap: boolean,
+): Promise<ParseResult> {
   const context: ParseContext = {
     calcSourceMap,
     filename,
@@ -99,6 +112,6 @@ export const parseBuffer = async (
     // Elements string are flatten to solve a memory leak
     elements: elements.map(flattenElementStr),
     errors: context.errors,
-    sourceMap: context.sourceMap,
+    sourceMap: calcSourceMap ? context.sourceMap : undefined,
   }
 }

--- a/packages/workspace/src/parser/parse.ts
+++ b/packages/workspace/src/parser/parse.ts
@@ -43,13 +43,27 @@ export type SourceRange = InternalSourceRange
  * @returns elements: Type elements found in the Nacl file
  *          errors: Errors encountered during parsing
  */
-export const parse = async (
+export async function parse(
+  naclFile: Buffer,
+  filename: string,
+  functions?: Functions,
+  calcSourceMap?: true
+): Promise<Required<ParseResult>>
+export async function parse(
+  naclFile: Buffer,
+  filename: string,
+  functions: Functions,
+  calcSourceMap: boolean
+): Promise<ParseResult>
+
+export async function parse(
   naclFile: Buffer,
   filename: string,
   functions: Functions = {},
-): Promise<Required<ParseResult>> => {
+  calcSourceMap = true,
+): Promise<ParseResult> {
   const srcString = naclFile.toString()
-  return parseBuffer(srcString, filename, functions)
+  return parseBuffer(srcString, filename, functions, calcSourceMap)
 }
 
 export type Token = {

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -217,7 +217,7 @@ export const toParsedNaclFile = async (
 }
 
 const parseNaclFile = async (
-  naclFile: NaclFile, functions: Functions
+  naclFile: NaclFile, functions: Functions,
 ): Promise<Required<ParseResult>> =>
   (parse(Buffer.from(naclFile.buffer), naclFile.filename, functions))
 
@@ -848,14 +848,15 @@ const buildNaclFilesSource = (
                 buffer)
               : await toParsedNaclFile(
                 { filename, buffer },
-                await parseNaclFile({ filename, buffer }, functions),
+                await parse(Buffer.from(buffer), filename, functions, false),
               )
             if (((await parsed.data.errors()) ?? []).length > 0) {
               logNaclFileUpdateErrorContext(filename, fileChanges, naclFileData, buffer)
             }
             await removeDanglingStaticFiles(fileChanges)
             log.trace('Nacl source %s finished updating file %s with %d changes', sourceName, filename, fileChanges.length)
-            return { ...parsed, buffer }
+            const { data, elements } = parsed
+            return { filename, elements, data, buffer }
           } catch (e) {
             log.error('failed to update NaCl file %s due to %o with %o changes',
               filename, e, fileChanges)

--- a/packages/workspace/test/parser/parse.test.ts
+++ b/packages/workspace/test/parser/parse.test.ts
@@ -855,6 +855,18 @@ value
       .toEqual(new ElemID('salesforce', 'anotherType'))
   })
 
+  describe('parse when calcSourceMap is false', () => {
+    it('should not return a sourceMap', async () => {
+      const body = `
+        type salesforce.string is string {
+        }
+      `
+      const parsed = await parse(Buffer.from(body), 'none', functions, false)
+      expect(parsed.errors).toHaveLength(0)
+      expect(parsed.sourceMap).toBeUndefined()
+    })
+  })
+
   describe('tokenizeContent', () => {
     it('seperate and token each part of a line correctly', () => {
       expect(Array.from(tokenizeContent('aaa   bbb ccc.ddd   "eee fff  ggg.hhh"'))).toEqual([


### PR DESCRIPTION
Remove redundant calculation of sourceMaps in order to improve performance when updating nacl files.

---
_Release Notes_: 
Workspace:
- Improved performance when updating nacl files.

---
_User Notifications_: 
None
