### PR TITLE
SALTO-2579: Cryptic error when trying to deploy a CustomFieldContext instance

### DIFF
--- a/packages/jira-adapter/src/filters/fields/context_options.ts
+++ b/packages/jira-adapter/src/filters/fields/context_options.ts
@@ -194,13 +194,17 @@ export const setContextOptions = async (
 
   const { added, modified, removed } = getOptionChanges(contextChange)
 
+  if (added.length === 0 && modified.length === 0 && removed.length === 0) {
+    return
+  }
+
   const [addedWithParentId, addedWithoutParentId] = _.partition(
     added,
     option => option.optionId !== undefined || option.parentValue === undefined
   )
 
   const fieldId = (
-    await getParents(getChangeData(contextChange))[0].getResolvedValue(elementsSource)
+    await getParents(getChangeData(contextChange))[0].value
   ).value.id
 
   const url = `/rest/api/3/field/${fieldId}/context/${getChangeData(contextChange).value.id}/option`


### PR DESCRIPTION
Fixed a bug when deploying a field with its context in the same deployment

---

The issue was that `.getResolvedValue(elementsSource)` uses the elements source even if the reference is resolved and in the element source we don't eve the field internal id if it was just created in the same deployment

---
_Release Notes_: 
_Jira Adapter_:
Fixed a recent regression in deploying a new field with its contexts in the same deployment

---
_User Notifications_: 
None