### PR TITLE
SALTO-2581: Fixed field configuration descriptions

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -45,6 +45,7 @@ import fieldConfigurationFilter from './filters/field_configuration/field_config
 import fieldConfigurationIrrelevantFields from './filters/field_configuration/field_configuration_irrelevant_fields'
 import fieldConfigurationSplitFilter from './filters/field_configuration/field_configuration_split'
 import fieldConfigurationItemsFilter from './filters/field_configuration/field_configuration_items'
+import missingFieldDescriptionsFilter from './filters/field_configuration/missing_field_descriptions'
 import fieldConfigurationDependenciesFilter from './filters/field_configuration/field_configuration_dependencies'
 import missingDescriptionsFilter from './filters/missing_descriptions'
 import fieldConfigurationSchemeFilter from './filters/field_configurations_scheme'
@@ -173,6 +174,7 @@ export const DEFAULT_FILTERS = [
   fieldConfigurationSplitFilter,
   // Must run after fieldConfigurationSplitFilter
   fieldConfigurationDependenciesFilter,
+  missingFieldDescriptionsFilter,
   // Must run after fieldReferencesFilter
   sortListsFilter,
   // Must run after fieldReferencesFilter

--- a/packages/jira-adapter/src/filters/field_configuration/missing_field_descriptions.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/missing_field_descriptions.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Element, isInstanceElement } from '@salto-io/adapter-api'
+import { Element, isInstanceElement, isReferenceExpression } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { FIELD_CONFIGURATION_ITEM_TYPE_NAME } from '../../constants'
 import { FilterCreator } from '../../filter'
@@ -25,6 +25,8 @@ const filter: FilterCreator = () => ({
       .filter(isInstanceElement)
       .filter(instance => instance.elemID.typeName === FIELD_CONFIGURATION_ITEM_TYPE_NAME)
       .filter(instance => _.isEmpty(instance.value.description))
+      .filter(instance => isReferenceExpression(instance.value.id)
+        && isInstanceElement(instance.value.id.value))
       .forEach(instance => {
         instance.value.description = instance.value.id.value.value.description ?? ''
       })

--- a/packages/jira-adapter/src/filters/field_configuration/missing_field_descriptions.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/missing_field_descriptions.ts
@@ -14,24 +14,19 @@
 * limitations under the License.
 */
 import { Element, isInstanceElement } from '@salto-io/adapter-api'
-import { FilterCreator } from '../filter'
-import { PROJECT_ROLE_TYPE } from '../constants'
-import { FIELD_TYPE_NAME } from './fields/constants'
+import _ from 'lodash'
+import { FIELD_CONFIGURATION_ITEM_TYPE_NAME } from '../../constants'
+import { FilterCreator } from '../../filter'
 
-
-const RELEVANT_TYPES = [
-  PROJECT_ROLE_TYPE,
-  FIELD_TYPE_NAME,
-]
 
 const filter: FilterCreator = () => ({
   onFetch: async (elements: Element[]) => {
     elements
       .filter(isInstanceElement)
-      .filter(instance => RELEVANT_TYPES.includes(instance.elemID.typeName))
-      .filter(instance => instance.value.description === undefined)
+      .filter(instance => instance.elemID.typeName === FIELD_CONFIGURATION_ITEM_TYPE_NAME)
+      .filter(instance => _.isEmpty(instance.value.description))
       .forEach(instance => {
-        instance.value.description = ''
+        instance.value.description = instance.value.id.value.value.description ?? ''
       })
   },
 })

--- a/packages/jira-adapter/test/filters/field_configuration/missing_field_descriptions.test.ts
+++ b/packages/jira-adapter/test/filters/field_configuration/missing_field_descriptions.test.ts
@@ -1,0 +1,82 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import { FIELD_TYPE_NAME } from '../../../src/filters/fields/constants'
+import { FIELD_CONFIGURATION_ITEM_TYPE_NAME, JIRA } from '../../../src/constants'
+import missingFieldDescriptionsFilter from '../../../src/filters/field_configuration/missing_field_descriptions'
+import { getFilterParams, mockClient } from '../../utils'
+
+describe('missingFieldDescriptionsFilter', () => {
+  let filter: filterUtils.FilterWith<'onFetch'>
+  let type: ObjectType
+  let fieldType: ObjectType
+  let instance: InstanceElement
+  let fieldInstance: InstanceElement
+
+  beforeEach(async () => {
+    const { client, paginator } = mockClient()
+
+    filter = missingFieldDescriptionsFilter(getFilterParams({
+      client,
+      paginator,
+    })) as typeof filter
+
+    type = new ObjectType({
+      elemID: new ElemID(JIRA, FIELD_CONFIGURATION_ITEM_TYPE_NAME),
+    })
+
+    fieldType = new ObjectType({
+      elemID: new ElemID(JIRA, FIELD_TYPE_NAME),
+    })
+
+    fieldInstance = new InstanceElement(
+      'fieldInstance',
+      fieldType,
+      {
+        description: 'fieldDesc',
+      }
+    )
+
+    instance = new InstanceElement(
+      'instance',
+      type,
+      {
+        id: new ReferenceExpression(fieldInstance.elemID, fieldInstance),
+        description: '',
+      },
+    )
+  })
+
+  describe('onFetch', () => {
+    it('should add description from field when empty', async () => {
+      await filter.onFetch([instance])
+      expect(instance.value.description).toBe('fieldDesc')
+    })
+
+    it('should add empty description from when no field description', async () => {
+      delete fieldInstance.value.description
+      await filter.onFetch([instance])
+      expect(instance.value.description).toBe('')
+    })
+
+    it('should not add description when there is description', async () => {
+      instance.value.description = 'desc'
+      await filter.onFetch([instance])
+      expect(instance.value.description).toBe('desc')
+    })
+  })
+})


### PR DESCRIPTION
In the UI, if the field config item description is empty, it shows the field description. This PR to do the same with the NaCl and replace the empty description with the field description


---
_Release Notes_: 
_Jira Adapter_:
- Fixed field config items' description to use the field description when empty

---
_User Notifications_: 
_Jira Adapter_:
- Some field config item's description might change to the correct value after the next fetch