### PR TITLE
SALTO-2401 Throw validation error for unexpected values in adapters config

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -291,7 +291,7 @@ Currently the following core annotations are supported:
 - [_creatable](#_created_at)
 - [_updatable](#_changed_by)
 - [_deletable](#_changed_at)
-- [-additional_properties](#_additional_properties)
+- [_additional_properties](#_additional_properties)
 
 #### `_required`
 This annotation is used on field blocks to specify that an instance must contain a value for this field.
@@ -709,7 +709,7 @@ salto.notDeletable instance {
 
 #### `_additional_properties`
 This annotation can be used on types to specify whether the type allows additional properties.
-when it is set to false, values of this type may only contain the fields that this type allows, any additional value would cause a validation warning.
+When it is set to false, values of this type may only contain the fields that this type allows, any additional value would cause a validation warning.
 
 Type: `boolean`
 Default: `true`

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -277,48 +277,21 @@ Built-in annotations are available everywhere in Salto. Their names will always 
 Annotations can be of any primitive type, as well as complex types.
 
 Currently the following core annotations are supported:
-- [NaCl Syntax](#nacl-syntax)
-  - [NaCl block types](#nacl-block-types)
-    - [Type blocks](#type-blocks)
-      - [Syntax](#syntax)
-      - [Example](#example)
-    - [Instance blocks](#instance-blocks)
-      - [Syntax](#syntax-1)
-      - [Example](#example-1)
-    - [Settings types and instances](#settings-types-and-instances)
-      - [Syntax](#syntax-2)
-      - [Example](#example-2)
-    - [Variables blocks](#variables-blocks)
-      - [Syntax](#syntax-3)
-      - [Example](#example-3)
-  - [Primitive types and values](#primitive-types-and-values)
-  - [Language features](#language-features)
-    - [References](#references)
-      - [Syntax](#syntax-4)
-      - [Examples](#examples)
-    - [Annotations](#annotations)
-      - [`_required`](#_required)
-      - [`_restriction`](#_restriction)
-      - [_hidden / _hidden_value](#_hidden--_hidden_value)
-      - [_parent](#_parent)
-      - [_generated_dependencies / _depends_on](#_generated_dependencies--_depends_on)
-      - [_service_url](#_service_url)
-      - [_is_service_id](#_is_service_id)
-      - [_created_by](#_created_by)
-      - [_created_at](#_created_at)
-      - [_changed_by](#_changed_by)
-      - [_changed_at](#_changed_at)
-      - [_creatable](#_creatable)
-      - [_updatable](#_updatable)
-      - [_deletable](#_deletable)
-      - [`_additional_properties`](#_additional_properties)
-      - [Adapter-specific annotations example](#adapter-specific-annotations-example)
-    - [Functions](#functions)
-      - [The `file` function](#the-file-function)
-  - [Merge rules](#merge-rules)
-    - [Value merging limitations](#value-merging-limitations)
-    - [Type merging limitations](#type-merging-limitations)
-
+- [_required](#_required)
+- [_restriction](#_restriction)
+- [_hidden / _hidden_value](#_hidden-_hidden_value)
+- [_parent](#_parent)
+- [_generated_dependencies / _depends_on](#_generated_dependencies-_depends_on)
+- [_service_url](#_service_url)
+- [_is_service_id](#_is_service_id)
+- [_created_by](#_created_by)
+- [_created_at](#_created_at)
+- [_changed_by](#_changed_by)
+- [_changed_at](#_changed_at)
+- [_creatable](#_created_at)
+- [_updatable](#_changed_by)
+- [_deletable](#_changed_at)
+- [-additional_properties](#_additional_properties)
 
 #### `_required`
 This annotation is used on field blocks to specify that an instance must contain a value for this field.
@@ -735,7 +708,8 @@ salto.notDeletable instance {
 ```
 
 #### `_additional_properties`
-This annotation is used on types. When it is set as false any instance of that type with a property that does not appear in the type definition will cause a validation warning
+This annotation can be used on types to specify whether the type allows additional properties.
+when it is set to false, values of this type may only contain the fields that this type allows, any additional value would cause a validation warning.
 
 Type: `boolean`
 Default: `true`

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -277,20 +277,48 @@ Built-in annotations are available everywhere in Salto. Their names will always 
 Annotations can be of any primitive type, as well as complex types.
 
 Currently the following core annotations are supported:
-- [_required](#_required)
-- [_restriction](#_restriction)
-- [_hidden / _hidden_value](#_hidden-_hidden_value)
-- [_parent](#_parent)
-- [_generated_dependencies / _depends_on](#_generated_dependencies-_depends_on)
-- [_service_url](#_service_url)
-- [_is_service_id](#_is_service_id)
-- [_created_by](#_created_by)
-- [_created_at](#_created_at)
-- [_changed_by](#_changed_by)
-- [_changed_at](#_changed_at)
-- [_creatable](#_created_at)
-- [_updatable](#_changed_by)
-- [_deletable](#_changed_at)
+- [NaCl Syntax](#nacl-syntax)
+  - [NaCl block types](#nacl-block-types)
+    - [Type blocks](#type-blocks)
+      - [Syntax](#syntax)
+      - [Example](#example)
+    - [Instance blocks](#instance-blocks)
+      - [Syntax](#syntax-1)
+      - [Example](#example-1)
+    - [Settings types and instances](#settings-types-and-instances)
+      - [Syntax](#syntax-2)
+      - [Example](#example-2)
+    - [Variables blocks](#variables-blocks)
+      - [Syntax](#syntax-3)
+      - [Example](#example-3)
+  - [Primitive types and values](#primitive-types-and-values)
+  - [Language features](#language-features)
+    - [References](#references)
+      - [Syntax](#syntax-4)
+      - [Examples](#examples)
+    - [Annotations](#annotations)
+      - [`_required`](#_required)
+      - [`_restriction`](#_restriction)
+      - [_hidden / _hidden_value](#_hidden--_hidden_value)
+      - [_parent](#_parent)
+      - [_generated_dependencies / _depends_on](#_generated_dependencies--_depends_on)
+      - [_service_url](#_service_url)
+      - [_is_service_id](#_is_service_id)
+      - [_created_by](#_created_by)
+      - [_created_at](#_created_at)
+      - [_changed_by](#_changed_by)
+      - [_changed_at](#_changed_at)
+      - [_creatable](#_creatable)
+      - [_updatable](#_updatable)
+      - [_deletable](#_deletable)
+      - [`_additional_properties`](#_additional_properties)
+      - [Adapter-specific annotations example](#adapter-specific-annotations-example)
+    - [Functions](#functions)
+      - [The `file` function](#the-file-function)
+  - [Merge rules](#merge-rules)
+    - [Value merging limitations](#value-merging-limitations)
+    - [Type merging limitations](#type-merging-limitations)
+
 
 #### `_required`
 This annotation is used on field blocks to specify that an instance must contain a value for this field.
@@ -703,6 +731,26 @@ For the deletion of the following instance, an error will be shown to the user a
 ```HCL
 salto.notDeletable instance {
   someField = 2
+}
+```
+
+#### `_additional_properties`
+This annotation is used on types. When it is set as false any instance of that type with a property that does not appear in the type definition will cause a validation warning
+
+Type: `boolean`
+Default: `true`
+Applicable to: Types
+Example:
+```HCL
+type salto.example_type {
+  number field {
+  }
+  _additional_properties = false
+}
+
+salto.example_type example_instance {
+  field = 1 // This is valid, as 'field' is a property of the type
+  other_field = 2 // This will cause a warning because 'other_field' does not appear in the type definition
 }
 ```
 

--- a/packages/adapter-api/src/core_annotations.ts
+++ b/packages/adapter-api/src/core_annotations.ts
@@ -31,4 +31,5 @@ export const CORE_ANNOTATIONS = {
   CREATABLE: '_creatable',
   UPDATABLE: '_updatable',
   DELETABLE: '_deletable',
+  ADDITIONAL_PROPERTIES: '_additional_properties',
 }

--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -414,6 +414,7 @@ const generalDeserialize = async <T>(
         new AdditionalPropertiesValidatorError({
           elemID: reviveElemID(v.elemID),
           fieldName: v.fieldName,
+          typeName: v.typeName,
         })
 
       ),

--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -40,6 +40,7 @@ import {
   IllegalReferenceValidationError,
   UnresolvedReferenceValidationError,
   MissingRequiredFieldValidationError,
+  AdditionalPropertiesValidatorError,
   RegexMismatchValidationError,
   InvalidValueRangeValidationError,
   InvalidValueMaxLengthValidationError,
@@ -99,6 +100,7 @@ const NameToType = {
   IllegalReferenceValidationError: IllegalReferenceValidationError,
   UnresolvedReferenceValidationError: UnresolvedReferenceValidationError,
   MissingRequiredFieldValidationError: MissingRequiredFieldValidationError,
+  AdditionalPropertiesValidatorError: AdditionalPropertiesValidatorError,
   RegexMismatchValidationError: RegexMismatchValidationError,
   InvalidValueRangeValidationError: InvalidValueRangeValidationError,
   InvalidValueMaxLengthValidationError: InvalidValueMaxLengthValidationError,
@@ -407,6 +409,13 @@ const generalDeserialize = async <T>(
           elemID: reviveElemID(v.elemID),
           fieldName: v.fieldName,
         })
+      ),
+      AdditionalPropertiesValidatorError: v => (
+        new AdditionalPropertiesValidatorError({
+          elemID: reviveElemID(v.elemID),
+          fieldName: v.fieldName,
+        })
+
       ),
       RegexMismatchValidationError: v => (
         new RegexMismatchValidationError({

--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -40,7 +40,7 @@ import {
   IllegalReferenceValidationError,
   UnresolvedReferenceValidationError,
   MissingRequiredFieldValidationError,
-  AdditionalPropertiesValidatorError,
+  AdditionalPropertiesValidationError,
   RegexMismatchValidationError,
   InvalidValueRangeValidationError,
   InvalidValueMaxLengthValidationError,
@@ -100,7 +100,7 @@ const NameToType = {
   IllegalReferenceValidationError: IllegalReferenceValidationError,
   UnresolvedReferenceValidationError: UnresolvedReferenceValidationError,
   MissingRequiredFieldValidationError: MissingRequiredFieldValidationError,
-  AdditionalPropertiesValidatorError: AdditionalPropertiesValidatorError,
+  AdditionalPropertiesValidationError: AdditionalPropertiesValidationError,
   RegexMismatchValidationError: RegexMismatchValidationError,
   InvalidValueRangeValidationError: InvalidValueRangeValidationError,
   InvalidValueMaxLengthValidationError: InvalidValueMaxLengthValidationError,
@@ -410,8 +410,8 @@ const generalDeserialize = async <T>(
           fieldName: v.fieldName,
         })
       ),
-      AdditionalPropertiesValidatorError: v => (
-        new AdditionalPropertiesValidatorError({
+      AdditionalPropertiesValidationError: v => (
+        new AdditionalPropertiesValidationError({
           elemID: reviveElemID(v.elemID),
           fieldName: v.fieldName,
           typeName: v.typeName,

--- a/packages/workspace/src/validator.ts
+++ b/packages/workspace/src/validator.ts
@@ -217,6 +217,7 @@ export class MissingRequiredFieldValidationError extends ValidationError {
     this.fieldName = fieldName
   }
 }
+
 export class AdditionalPropertiesValidationError extends ValidationError {
   readonly fieldName: string
   readonly typeName: string
@@ -234,6 +235,7 @@ export class AdditionalPropertiesValidationError extends ValidationError {
     this.typeName = typeName
   }
 }
+
 export class UnresolvedReferenceValidationError extends ValidationError {
   readonly target: ElemID
   constructor(
@@ -250,7 +252,6 @@ export const isUnresolvedRefError = (
 ): err is UnresolvedReferenceValidationError => (
   err instanceof UnresolvedReferenceValidationError
 )
-
 
 export class IllegalReferenceValidationError extends ValidationError {
   readonly reason: string

--- a/packages/workspace/src/validator.ts
+++ b/packages/workspace/src/validator.ts
@@ -463,17 +463,6 @@ const createReferenceValidationErrors = (elemID: ElemID, value: Value): Validati
   return []
 }
 
-const validateNotAdditionalProperty = (
-  elemID: ElemID,
-  fieldName: string,
-  objType : ObjectType,
-) : ValidationError[] =>
-  (!(fieldName in objType.fields)
-    ? [new AdditionalPropertiesValidationError(
-      { elemID, fieldName, typeName: objType.elemID.typeName }
-    )]
-    : [])
-
 const validateValue = (
   elemID: ElemID,
   value: Value,
@@ -614,6 +603,17 @@ const validateFieldValue = (
     innerType,
   ))
 }
+
+const validateNotAdditionalProperty = (
+  elemID: ElemID,
+  fieldName: string,
+  objType : ObjectType,
+) : ValidationError[] =>
+  (!Object.prototype.hasOwnProperty.call(objType.fields, fieldName)
+    ? [new AdditionalPropertiesValidationError(
+      { elemID, fieldName, typeName: objType.elemID.typeName }
+    )]
+    : [])
 
 const validateFieldValueAndName = ({ parentElemID, value, fieldName, objType } : {
   parentElemID: ElemID

--- a/packages/workspace/src/validator.ts
+++ b/packages/workspace/src/validator.ts
@@ -463,7 +463,7 @@ const createReferenceValidationErrors = (elemID: ElemID, value: Value): Validati
   return []
 }
 
-const validateAdditionalPropertiesValue = (
+const validateNotAdditionalProperty = (
   elemID: ElemID,
   fieldName: string,
   objType : ObjectType,
@@ -540,12 +540,12 @@ const validateValue = (
     }
     return Object.keys(value).flatMap(
       // eslint-disable-next-line no-use-before-define
-      k => validateFieldValues(
-        elemID,
-        value[k],
-        k,
-        toObjectType(type, value),
-      )
+      k => validateFieldValueAndName({
+        parentElemID: elemID,
+        value: value[k],
+        fieldName: k,
+        objType: toObjectType(type, value),
+      })
     )
   }
 
@@ -615,14 +615,14 @@ const validateFieldValue = (
   ))
 }
 
-const validateFieldValues = (
-  parentElemID: ElemID,
-  value: Value,
-  fieldName: string,
+const validateFieldValueAndName = ({ parentElemID, value, fieldName, objType } : {
+  parentElemID: ElemID
+  value: Value
+  fieldName: string
   objType: ObjectType
-): ValidationError[] => {
+ }): ValidationError[] => {
   const errors = objType.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES] === false
-    ? validateAdditionalPropertiesValue(parentElemID, fieldName, objType)
+    ? validateNotAdditionalProperty(parentElemID, fieldName, objType)
     : []
   return errors.concat(validateFieldValue(
     parentElemID.createNestedID(fieldName),

--- a/packages/workspace/src/validator.ts
+++ b/packages/workspace/src/validator.ts
@@ -219,15 +219,19 @@ export class MissingRequiredFieldValidationError extends ValidationError {
 }
 export class AdditionalPropertiesValidatorError extends ValidationError {
   readonly fieldName: string
+  readonly typeName: string
 
-  constructor({ elemID, fieldName }: { elemID: ElemID; fieldName: string }) {
+  constructor(
+    { elemID, fieldName, typeName }: { elemID: ElemID; fieldName: string; typeName: string }
+  ) {
     super({
       elemID,
-      error: `Field ${fieldName} is invalid since it is not defined in ${elemID.typeName}`
+      error: `Field ${fieldName} is invalid since it is not defined in ${typeName}`
       + ': the type does not allow additional properties',
       severity: 'Warning',
     })
     this.fieldName = fieldName
+    this.typeName = typeName
   }
 }
 export class UnresolvedReferenceValidationError extends ValidationError {
@@ -463,7 +467,9 @@ const validateAdditionalPropertiesValue = (
   objType: ObjectType, elemID: ElemID, fieldName: string
 ): ValidationError[] =>
   (objType.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES] === false
-    ? [new AdditionalPropertiesValidatorError({ elemID, fieldName })] : [])
+    ? [new AdditionalPropertiesValidatorError(
+      { elemID, fieldName, typeName: objType.elemID.typeName }
+    )] : [])
 
 
 const validateFieldName = (

--- a/packages/workspace/src/validator.ts
+++ b/packages/workspace/src/validator.ts
@@ -217,7 +217,7 @@ export class MissingRequiredFieldValidationError extends ValidationError {
     this.fieldName = fieldName
   }
 }
-export class AdditionalPropertiesValidatorError extends ValidationError {
+export class AdditionalPropertiesValidationError extends ValidationError {
   readonly fieldName: string
   readonly typeName: string
 
@@ -226,8 +226,8 @@ export class AdditionalPropertiesValidatorError extends ValidationError {
   ) {
     super({
       elemID,
-      error: `Field ${fieldName} is invalid since it is not defined in ${typeName}`
-      + ': the type does not allow additional properties',
+      error: `Field '${fieldName}' is not defined in the '${typeName}'`
+      + ' which does not allow additional properties.',
       severity: 'Warning',
     })
     this.fieldName = fieldName
@@ -467,7 +467,7 @@ const validateAdditionalPropertiesValue = (
   objType: ObjectType, elemID: ElemID, fieldName: string
 ): ValidationError[] =>
   (objType.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES] === false
-    ? [new AdditionalPropertiesValidatorError(
+    ? [new AdditionalPropertiesValidationError(
       { elemID, fieldName, typeName: objType.elemID.typeName }
     )] : [])
 

--- a/packages/workspace/test/validator.test.ts
+++ b/packages/workspace/test/validator.test.ts
@@ -871,10 +871,12 @@ describe('Elements validation', () => {
         const topType = new ObjectType({
           elemID: elemIdTop,
           fields: {
-            mapField: { refType: new MapType(nonValidatingType),
+            mapFieldNonValidating: { refType: new MapType(nonValidatingType),
               annotations: { [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false } },
-            listField: { refType: new ListType(validatingType),
+            mapFieldValidating: { refType: new MapType(validatingType) },
+            listFieldNonValidating: { refType: new ListType(nonValidatingType),
               annotations: { [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false } },
+            listFieldValidating: { refType: new ListType(validatingType) },
           },
           annotations: {
             [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
@@ -911,14 +913,23 @@ describe('Elements validation', () => {
             'testinst',
             topType,
             {
-              mapField: {
+              mapFieldNonValidating: {
                 a: { str: 'str' },
                 b: { str: 'str2', additional1: 'do not fail' },
               },
-              listField: [
+              mapFieldValidating: {
+                c: { str: 'str3' },
+                d: { str: 'str4', additional4: 'should fail' },
+              },
+              listFieldValidating: [
                 { str: 'str', additional2: 'should fail' },
                 { str: 'str2' },
                 { str: 'str3', additional3: 'should also fail' },
+              ],
+              listFieldNonValidating: [
+                { str: 'str', additional5: 'should mot fail' },
+                { str: 'str2' },
+                { str: 'str3', additional6: 'should also not fail' },
               ],
             },
           )
@@ -931,10 +942,12 @@ describe('Elements validation', () => {
               nonValidatingType,
             ])
           )
-          expect(errors).toHaveLength(2)
-          expect(errors[0].message).toMatch('Error validating "salto.top.instance.testinst.listField.0":'
+          expect(errors).toHaveLength(3)
+          expect(errors[0].message).toMatch('Error validating "salto.top.instance.testinst.mapFieldValidating.d":'
+            + ' Field \'additional4\' is not defined in the \'validating\' type which does not allow additional properties.')
+          expect(errors[1].message).toMatch('Error validating "salto.top.instance.testinst.listFieldValidating.0":'
             + ' Field \'additional2\' is not defined in the \'validating\' type which does not allow additional properties.')
-          expect(errors[1].message).toMatch('Error validating "salto.top.instance.testinst.listField.2":'
+          expect(errors[2].message).toMatch('Error validating "salto.top.instance.testinst.listFieldValidating.2":'
             + ' Field \'additional3\' is not defined in the \'validating\' type which does not allow additional properties.')
         })
       })

--- a/packages/workspace/test/validator.test.ts
+++ b/packages/workspace/test/validator.test.ts
@@ -871,11 +871,9 @@ describe('Elements validation', () => {
         const topType = new ObjectType({
           elemID: elemIdTop,
           fields: {
-            mapFieldNonValidating: { refType: new MapType(nonValidatingType),
-              annotations: { [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false } },
+            mapFieldNonValidating: { refType: new MapType(nonValidatingType) },
             mapFieldValidating: { refType: new MapType(validatingType) },
-            listFieldNonValidating: { refType: new ListType(nonValidatingType),
-              annotations: { [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false } },
+            listFieldNonValidating: { refType: new ListType(nonValidatingType) },
             listFieldValidating: { refType: new ListType(validatingType) },
           },
           annotations: {

--- a/packages/workspace/test/validator.test.ts
+++ b/packages/workspace/test/validator.test.ts
@@ -777,6 +777,41 @@ describe('Elements validation', () => {
         })
       })
       describe('additional properties annotation', () => {
+        let topType: ObjectType
+        let validatingType: ObjectType
+        let nonValidatingType: ObjectType
+        beforeEach(() => {
+          const elemIdTop = new ElemID('salto', 'top')
+          const elemIdNotValidating = new ElemID('salto', 'notvalidating')
+          const elemIdValidating = new ElemID('salto', 'validating')
+          validatingType = new ObjectType({
+            elemID: elemIdValidating,
+            fields: {
+              str: { refType: BuiltinTypes.STRING },
+            },
+            annotations: {
+              [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+            },
+          })
+          nonValidatingType = new ObjectType({
+            elemID: elemIdNotValidating,
+            fields: {
+              str: { refType: BuiltinTypes.STRING },
+            },
+          })
+          topType = new ObjectType({
+            elemID: elemIdTop,
+            fields: {
+              mapFieldNonValidating: { refType: new MapType(nonValidatingType) },
+              mapFieldValidating: { refType: new MapType(validatingType) },
+              listFieldNonValidating: { refType: new ListType(nonValidatingType) },
+              listFieldValidating: { refType: new ListType(validatingType) },
+            },
+            annotations: {
+              [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+            },
+          })
+        })
         it('should succeed when additional properties is false and there are no additional properties', async () => {
           extType.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES] = false
           extInst.refType = createRefToElmWithValue(extType)
@@ -849,36 +884,6 @@ describe('Elements validation', () => {
             ])
           )
           expect(errors).toHaveLength(0)
-        })
-        const elemIdTop = new ElemID('salto', 'top')
-        const elemIdNotValidating = new ElemID('salto', 'notvalidating')
-        const elemIdValidating = new ElemID('salto', 'validating')
-        const validatingType = new ObjectType({
-          elemID: elemIdValidating,
-          fields: {
-            str: { refType: BuiltinTypes.STRING },
-          },
-          annotations: {
-            [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
-          },
-        })
-        const nonValidatingType = new ObjectType({
-          elemID: elemIdNotValidating,
-          fields: {
-            str: { refType: BuiltinTypes.STRING },
-          },
-        })
-        const topType = new ObjectType({
-          elemID: elemIdTop,
-          fields: {
-            mapFieldNonValidating: { refType: new MapType(nonValidatingType) },
-            mapFieldValidating: { refType: new MapType(validatingType) },
-            listFieldNonValidating: { refType: new ListType(nonValidatingType) },
-            listFieldValidating: { refType: new ListType(validatingType) },
-          },
-          annotations: {
-            [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
-          },
         })
         it('should warn on nested fields when they have the additional properties annotation set to false', async () => {
           const simpleTypeClone = simpleType.clone()

--- a/packages/workspace/test/validator.test.ts
+++ b/packages/workspace/test/validator.test.ts
@@ -776,6 +776,81 @@ describe('Elements validation', () => {
           )).toHaveLength(0)
         })
       })
+      describe('additional properties annotation', () => {
+        it('should succeed when additional properties is false and there are no additional properties', async () => {
+          extType.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES] = false
+          extInst.refType = createRefToElmWithValue(extType)
+          extInst.value.reqNested = {
+            str: 'str',
+            num: 1,
+            bool: true,
+          }
+          const errors = await validateElements(
+            [extInst],
+            createInMemoryElementSource([
+              extInst,
+              extType,
+              ...await getFieldsAndAnnoTypes(extType),
+            ])
+          )
+          expect(errors).toHaveLength(0)
+        })
+        it('should warn when additional properties is false and there are additional properties', async () => {
+          extType.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES] = false
+          extInst.refType = createRefToElmWithValue(extType)
+          extInst.value.additional = 'fail'
+          extInst.value.additional2 = 'fail2'
+          const errors = await validateElements(
+            [extInst],
+            createInMemoryElementSource([
+              extInst,
+              extType,
+              ...await getFieldsAndAnnoTypes(extType),
+            ])
+          )
+          expect(errors).toHaveLength(2)
+          expect(errors[0].message).toMatch('Error validating "salto.nested.instance.nestedinst":'
+            + ' Field additional is invalid since it is not defined in nested: the type does not allow additional properties')
+          expect(errors[0].elemID).toEqual(extInst.elemID)
+          expect(errors[1].message).toMatch('Error validating "salto.nested.instance.nestedinst":'
+            + ' Field additional2 is invalid since it is not defined in nested: the type does not allow additional properties')
+          expect(errors[1].elemID).toEqual(extInst.elemID)
+        })
+        it('should succeed when additional properties is true and there are additional properties', async () => {
+          extType.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES] = true
+          extInst.refType = createRefToElmWithValue(extType)
+          extInst.value.unexpected = 'fail'
+          extInst.value.unexpected2 = 'fail2'
+          const errors = await validateElements(
+            [extInst],
+            createInMemoryElementSource([
+              extInst,
+              extType,
+              ...await getFieldsAndAnnoTypes(extType),
+            ])
+          )
+          expect(errors).toHaveLength(0)
+        })
+        it('should succeed when additional properties is set to false and there are additional properties in nested fields', async () => {
+          extType.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES] = false
+          extInst.refType = createRefToElmWithValue(extType)
+          extInst.value.reqNested = {
+            str: 'str',
+            num: 1,
+            bool: true,
+            additional: 'should not cause warn',
+          }
+          const errors = await validateElements(
+            [extInst],
+            createInMemoryElementSource([
+              extInst,
+              extType,
+              ...await getFieldsAndAnnoTypes(extType),
+            ])
+          )
+          expect(errors).toHaveLength(0)
+        })
+      })
 
       describe('values annotation', () => {
         it('should succeed when all values corresponds to values annotation', async () => {


### PR DESCRIPTION
Added a support for a new core annotation- `_additional_properties` which issues a warning if there is a field that does not exist in the type definition


---
_Release Notes_: 
Core:
A new annotation was added- `_additional_properties`. It allows warning when unexpected values are present in NaCl

---
_User Notifications_: 
None
