### PR TITLE
SALTO-2277: change custom object instances path

### DIFF
--- a/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
@@ -23,7 +23,7 @@ import SalesforceClient from '../client/client'
 import { SalesforceRecord } from '../client/types'
 import {
   SALESFORCE, RECORDS_PATH, INSTALLED_PACKAGES_PATH, CUSTOM_OBJECT_ID_FIELD,
-  OBJECTS_PATH, FIELD_ANNOTATIONS, MAX_QUERY_LENGTH,
+  FIELD_ANNOTATIONS, MAX_QUERY_LENGTH,
 } from '../constants'
 import { FilterResult, RemoteFilterCreator } from '../filter'
 import { apiName, isCustomObject, Types, createInstanceServiceIds, isNameField } from '../transformers/transformer'
@@ -169,10 +169,10 @@ const recordToInstance = async (
     const typeNamespace = await getNamespace(type)
     const instanceFileName = pathNaclCase(instanceName)
     if (typeNamespace) {
-      return [SALESFORCE, INSTALLED_PACKAGES_PATH, typeNamespace, OBJECTS_PATH,
-        type.elemID.typeName, RECORDS_PATH, instanceFileName]
+      return [SALESFORCE, INSTALLED_PACKAGES_PATH, typeNamespace,
+        RECORDS_PATH, type.elemID.typeName, instanceFileName]
     }
-    return [SALESFORCE, OBJECTS_PATH, type.elemID.typeName, RECORDS_PATH, instanceFileName]
+    return [SALESFORCE, RECORDS_PATH, type.elemID.typeName, instanceFileName]
   }
   const { name } = Types.getElemId(
     instanceSaltoName,

--- a/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
@@ -420,11 +420,10 @@ describe('Custom Object Instances filter', () => {
         it('should create instances according to results', () => {
           expect(instances.length).toEqual(2)
         })
-
-        it('should create the instances with record path acccording to object', () => {
+        it('should create the instances with record path according to object', () => {
           expect(instances[0].path).toEqual(
-            [SALESFORCE, INSTALLED_PACKAGES_PATH, testNamespace, OBJECTS_PATH,
-              simpleName, RECORDS_PATH, expectedFirstInstanceName]
+            [SALESFORCE, INSTALLED_PACKAGES_PATH, testNamespace,
+              RECORDS_PATH, simpleName, expectedFirstInstanceName]
           )
         })
 
@@ -476,11 +475,10 @@ describe('Custom Object Instances filter', () => {
         it('should create instances according to results', () => {
           expect(instances.length).toEqual(2)
         })
-
         it('should create the instances with record path acccording to object', () => {
           expect(instances[0].path).toEqual(
-            [SALESFORCE, INSTALLED_PACKAGES_PATH, testNamespace, OBJECTS_PATH,
-              withNameName, RECORDS_PATH, expectedFirstInstanceName]
+            [SALESFORCE, INSTALLED_PACKAGES_PATH, testNamespace,
+              RECORDS_PATH, withNameName, expectedFirstInstanceName]
           )
         })
 
@@ -521,11 +519,10 @@ describe('Custom Object Instances filter', () => {
         it('should create instances according to results', () => {
           expect(instances.length).toEqual(2)
         })
-
         it('should create the instances with record path acccording to object', () => {
           expect(instances[0].path).toEqual(
-            [SALESFORCE, INSTALLED_PACKAGES_PATH, testNamespace, OBJECTS_PATH,
-              withAddressName, RECORDS_PATH, expectedFirstInstanceName]
+            [SALESFORCE, INSTALLED_PACKAGES_PATH, testNamespace,
+              RECORDS_PATH, withAddressName, expectedFirstInstanceName]
           )
         })
 

--- a/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
@@ -25,7 +25,7 @@ import filterCreator, { buildSelectQueries } from '../../src/filters/custom_obje
 import mockAdapter from '../adapter'
 import {
   LABEL, CUSTOM_OBJECT, API_NAME, METADATA_TYPE, SALESFORCE, INSTALLED_PACKAGES_PATH,
-  RECORDS_PATH, FIELD_ANNOTATIONS,
+  OBJECTS_PATH, RECORDS_PATH, FIELD_ANNOTATIONS,
 } from '../../src/constants'
 import { Types } from '../../src/transformers/transformer'
 import { buildFetchProfile } from '../../src/fetch_profile/fetch_profile'
@@ -82,8 +82,8 @@ const createCustomObject = (
     fields: additionalFields ? Object.assign(basicFields, additionalFields) : basicFields,
   })
   const path = namespace
-    ? [SALESFORCE, INSTALLED_PACKAGES_PATH, namespace, RECORDS_PATH, obj.elemID.name]
-    : [SALESFORCE, RECORDS_PATH, obj.elemID.name]
+    ? [SALESFORCE, INSTALLED_PACKAGES_PATH, namespace, OBJECTS_PATH, obj.elemID.name]
+    : [SALESFORCE, OBJECTS_PATH, obj.elemID.name]
   obj.path = path
   return obj
 }
@@ -539,7 +539,7 @@ describe('Custom Object Instances filter', () => {
         it('should create instances according to results', () => {
           expect(instances.length).toEqual(2)
         })
-        it('should create the instances with record path acccording to object', () => {
+        it('should create the instances with record path according to object', () => {
           expect(instances[0].path).toEqual(
             [SALESFORCE, INSTALLED_PACKAGES_PATH, testNamespace,
               RECORDS_PATH, withAddressName, expectedFirstInstanceName]


### PR DESCRIPTION
Change custom object instances path from being under the object folder to the records folder where all other instances are

---


---
_Release Notes_: 
_Salesforce Adapter:_
* Changed custom object instances path from being under the object folder to the records folder 

---
_User Notifications_: 
_None_
