### PR TITLE
SALTO-2608 - Exports NoWorkspaceConfig error from core package

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -61,3 +61,4 @@ export {
   replicateDB,
   createReadOnlyRemoteMapCreator,
 } from './src/local-workspace/remote_map'
+export { NoWorkspaceConfig } from './src/local-workspace/errors'


### PR DESCRIPTION
Exports the error type for identification of the error outside of the package itself.

---

_Additional context for reviewer_

---
_Release Notes_: 
-

---
_User Notifications_: 
-
