### PR TITLE
SALTO-2473: rephrase change validation zendesk error of removed from parent

### DIFF
--- a/packages/zendesk-adapter/src/change_validators/child_parent/removed_from_parent.ts
+++ b/packages/zendesk-adapter/src/change_validators/child_parent/removed_from_parent.ts
@@ -44,9 +44,8 @@ export const removedFromParentValidatorCreator = (
       return [{
         elemID: instance.elemID,
         severity: 'Error',
-        message: `Can not change ${typeName} because there are removed references to children instances while the children instances still exist`,
-        detailedMessage: `Can not change ${instance.elemID.getFullName()} because there are removed references in ${
-          relation.fieldName}, but the instances still exist: ${nonFullyRemovedChildren.join(', ')}`,
+        message: `Error while trying to remove ${typeName}, because the related instance still exists, please remove it as well`,
+        detailedMessage: `Error while trying to remove ${instance.elemID.getFullName()}, because the related instance ${nonFullyRemovedChildren.join(', ')} still exists, please remove it as well`,
       }]
     })
   })

--- a/packages/zendesk-adapter/test/change_validators/removed_from_parent.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/removed_from_parent.test.ts
@@ -62,8 +62,8 @@ describe('removedFromParentValidatorCreator', () => {
     expect(errors).toEqual([{
       elemID: clonedTicketField.elemID,
       severity: 'Error',
-      message: `Can not change ${clonedTicketField.elemID.typeName} because there are removed references to children instances while the children instances still exist`,
-      detailedMessage: `Can not change ${clonedTicketField.elemID.getFullName()} because there are removed references in custom_field_options, but the instances still exist: ${option2.elemID.getFullName()}`,
+      message: `Error while trying to remove ${clonedTicketField.elemID.typeName}, because the related instance still exists, please remove it as well`,
+      detailedMessage: `Error while trying to remove ${clonedTicketField.elemID.getFullName()}, because the related instance ${option2.elemID.getFullName()} still exists, please remove it as well`,
     }])
   })
   it('should not return an error when remove an option from the parent and remove the instance as well', async () => {


### PR DESCRIPTION
Rephrase change validation Zendesk error when user removed the option for the ticket field but didn't remove the ticket field option instance.

---

_Additional context for reviewer_
None

---
_Release Notes_: 
None

---
_User Notifications_: 
None
