### PR TITLE
SALTO-2228: add change validator for attempting to deploy a system field

### DIFF
--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -32,6 +32,7 @@ import { maskingValidator } from './masking'
 import { automationsValidator } from './automations'
 import { lockedFieldsValidator } from './locked_fields'
 import { globalProjectContextsValidator } from './global_project_contexts'
+import { systemFieldsValidator } from './system_fields'
 
 const {
   deployTypesNotSupportedValidator,
@@ -57,6 +58,7 @@ export default (
     maskingValidator(client),
     lockedFieldsValidator,
     globalProjectContextsValidator,
+    systemFieldsValidator,
   ]
 
   return createChangeValidator(validators)

--- a/packages/jira-adapter/src/change_validators/system_fields.ts
+++ b/packages/jira-adapter/src/change_validators/system_fields.ts
@@ -27,6 +27,6 @@ export const systemFieldsValidator: ChangeValidator = async changes => (
       elemID: instance.elemID,
       severity: 'Error',
       message: 'Can not deploy changes to a Jira system field',
-      detailedMessage: `${instance.elemID.getFullName()} is a built-in Jira system field, and can not be edited or deleted. Changes to this field will be not deployed`,
+      detailedMessage: `${instance.elemID.getFullName()} is a built-in Jira system field, and can not be edited or deleted. Changes to this field will not be deployed`,
     }))
 )

--- a/packages/jira-adapter/src/change_validators/system_fields.ts
+++ b/packages/jira-adapter/src/change_validators/system_fields.ts
@@ -1,0 +1,32 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ChangeValidator, getChangeData, isInstanceElement, SeverityLevel } from '@salto-io/adapter-api'
+import { FIELD_TYPE_NAME } from '../filters/fields/constants'
+
+
+export const systemFieldsValidator: ChangeValidator = async changes => (
+  changes
+    .map(getChangeData)
+    .filter(isInstanceElement)
+    .filter(instance => instance.elemID.typeName === FIELD_TYPE_NAME)
+    .filter(instance => instance.value.schema)
+    .map(instance => ({
+      elemID: instance.elemID,
+      severity: 'Error' as SeverityLevel,
+      message: 'Cannot deploy a system field',
+      detailedMessage: `The field ${instance.elemID.getFullName()} is a system field and cannot be deployed`,
+    }))
+)

--- a/packages/jira-adapter/src/change_validators/system_fields.ts
+++ b/packages/jira-adapter/src/change_validators/system_fields.ts
@@ -13,19 +13,20 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ChangeValidator, getChangeData, isInstanceElement, SeverityLevel } from '@salto-io/adapter-api'
+import { ChangeValidator, getChangeData, isInstanceElement } from '@salto-io/adapter-api'
 import { FIELD_TYPE_NAME } from '../filters/fields/constants'
 
 
 export const systemFieldsValidator: ChangeValidator = async changes => (
   changes
+    .filter(change => change !== undefined)
     .map(getChangeData)
     .filter(isInstanceElement)
     .filter(instance => instance.elemID.typeName === FIELD_TYPE_NAME)
     .filter(instance => instance.value.schema)
     .map(instance => ({
       elemID: instance.elemID,
-      severity: 'Error' as SeverityLevel,
+      severity: 'Error',
       message: 'Cannot deploy a system field',
       detailedMessage: `The field ${instance.elemID.getFullName()} is a system field and cannot be deployed`,
     }))

--- a/packages/jira-adapter/src/change_validators/system_fields.ts
+++ b/packages/jira-adapter/src/change_validators/system_fields.ts
@@ -19,11 +19,10 @@ import { FIELD_TYPE_NAME } from '../filters/fields/constants'
 
 export const systemFieldsValidator: ChangeValidator = async changes => (
   changes
-    .filter(change => change !== undefined)
     .map(change => (isModificationChange(change) ? change.data.before : getChangeData(change)))
     .filter(isInstanceElement)
     .filter(instance => instance.elemID.typeName === FIELD_TYPE_NAME)
-    .filter(instance => instance.value.schema)
+    .filter(instance => instance.value.schema !== undefined)
     .map(instance => ({
       elemID: instance.elemID,
       severity: 'Error',

--- a/packages/jira-adapter/src/change_validators/system_fields.ts
+++ b/packages/jira-adapter/src/change_validators/system_fields.ts
@@ -13,21 +13,21 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ChangeValidator, getChangeData, isInstanceElement } from '@salto-io/adapter-api'
+import { ChangeValidator, isInstanceElement, isModificationChange, getChangeData } from '@salto-io/adapter-api'
 import { FIELD_TYPE_NAME } from '../filters/fields/constants'
 
 
 export const systemFieldsValidator: ChangeValidator = async changes => (
   changes
     .filter(change => change !== undefined)
-    .map(getChangeData)
+    .map(change => (isModificationChange(change) ? change.data.before : getChangeData(change)))
     .filter(isInstanceElement)
     .filter(instance => instance.elemID.typeName === FIELD_TYPE_NAME)
     .filter(instance => instance.value.schema)
     .map(instance => ({
       elemID: instance.elemID,
       severity: 'Error',
-      message: 'Cannot deploy a system field',
-      detailedMessage: `The field ${instance.elemID.getFullName()} is a system field and cannot be deployed`,
+      message: 'Can not deploy changes to a Jira system field',
+      detailedMessage: `${instance.elemID.getFullName()} is a built-in Jira system field, and can not be edited or deleted. Changes to this field will be not deployed`,
     }))
 )

--- a/packages/jira-adapter/test/change_validators/system_fields.test.ts
+++ b/packages/jira-adapter/test/change_validators/system_fields.test.ts
@@ -31,7 +31,7 @@ describe('systemFieldsValidator', () => {
         elemID: systemFieldInstance.elemID,
         severity: 'Error',
         message: 'Can not deploy changes to a Jira system field',
-        detailedMessage: 'jira.Field.instance.instance is a built-in Jira system field, and can not be edited or deleted. Changes to this field will be not deployed',
+        detailedMessage: 'jira.Field.instance.instance is a built-in Jira system field, and can not be edited or deleted. Changes to this field will not be deployed',
       },
     ])
   })
@@ -48,7 +48,7 @@ describe('systemFieldsValidator', () => {
         elemID: systemFieldInstance.elemID,
         severity: 'Error',
         message: 'Can not deploy changes to a Jira system field',
-        detailedMessage: 'jira.Field.instance.instance is a built-in Jira system field, and can not be edited or deleted. Changes to this field will be not deployed',
+        detailedMessage: 'jira.Field.instance.instance is a built-in Jira system field, and can not be edited or deleted. Changes to this field will not be deployed',
       },
     ])
   })
@@ -65,13 +65,12 @@ describe('systemFieldsValidator', () => {
         elemID: systemFieldInstance.elemID,
         severity: 'Error',
         message: 'Can not deploy changes to a Jira system field',
-        detailedMessage: 'jira.Field.instance.instance is a built-in Jira system field, and can not be edited or deleted. Changes to this field will be not deployed',
+        detailedMessage: 'jira.Field.instance.instance is a built-in Jira system field, and can not be edited or deleted. Changes to this field will not be deployed',
       },
     ])
   })
 
   it('should return an error when attempting to remove a system field', async () => {
-    // const systemFieldInstance = new InstanceElement('instance', type, { schema: {} })
     expect(await systemFieldsValidator([
       toChange({
         before: systemFieldInstance,
@@ -81,7 +80,7 @@ describe('systemFieldsValidator', () => {
         elemID: systemFieldInstance.elemID,
         severity: 'Error',
         message: 'Can not deploy changes to a Jira system field',
-        detailedMessage: 'jira.Field.instance.instance is a built-in Jira system field, and can not be edited or deleted. Changes to this field will be not deployed',
+        detailedMessage: 'jira.Field.instance.instance is a built-in Jira system field, and can not be edited or deleted. Changes to this field will not be deployed',
       },
     ])
   })

--- a/packages/jira-adapter/test/change_validators/system_fields.test.ts
+++ b/packages/jira-adapter/test/change_validators/system_fields.test.ts
@@ -20,11 +20,61 @@ import { JIRA } from '../../src/constants'
 
 describe('systemFieldsValidator', () => {
   const type = new ObjectType({ elemID: new ElemID(JIRA, FIELD_TYPE_NAME) })
-  it('should return an error if a field is a system field', async () => {
-    const systemFieldInstance = new InstanceElement('instance', type, { schema: {} })
+  const systemFieldInstance = new InstanceElement('instance', type, { schema: {}, description: 'description' })
+  it('should return an error if the field is a system field', async () => {
     expect(await systemFieldsValidator([
       toChange({
         after: systemFieldInstance,
+      }),
+    ])).toEqual([
+      {
+        elemID: systemFieldInstance.elemID,
+        severity: 'Error',
+        message: 'Can not deploy changes to a Jira system field',
+        detailedMessage: 'jira.Field.instance.instance is a built-in Jira system field, and can not be edited or deleted. Changes to this field will be not deployed',
+      },
+    ])
+  })
+
+  it('should return an error when attempting to modify a system field', async () => {
+    const modifiedSystemFieldInstance = new InstanceElement('instance', type, { schema: {}, description: 'modified description' })
+    expect(await systemFieldsValidator([
+      toChange({
+        before: systemFieldInstance,
+        after: modifiedSystemFieldInstance,
+      }),
+    ])).toEqual([
+      {
+        elemID: systemFieldInstance.elemID,
+        severity: 'Error',
+        message: 'Can not deploy changes to a Jira system field',
+        detailedMessage: 'jira.Field.instance.instance is a built-in Jira system field, and can not be edited or deleted. Changes to this field will be not deployed',
+      },
+    ])
+  })
+
+  it('should return an error when attempting to remove the schema field from a system field', async () => {
+    const modifiedSystemFieldInstance = new InstanceElement('instance', type, { description: 'description' })
+    expect(await systemFieldsValidator([
+      toChange({
+        before: systemFieldInstance,
+        after: modifiedSystemFieldInstance,
+      }),
+    ])).toEqual([
+      {
+        elemID: systemFieldInstance.elemID,
+        severity: 'Error',
+        message: 'Can not deploy changes to a Jira system field',
+        detailedMessage: 'jira.Field.instance.instance is a built-in Jira system field, and can not be edited or deleted. Changes to this field will be not deployed',
+      },
+    ])
+  })
+
+  it('should return an error when attempting to remove a system field', async () => {
+    // const systemFieldInstance = new InstanceElement('instance', type, { schema: {} })
+    expect(await systemFieldsValidator([
+      toChange({
+        before: systemFieldInstance,
       }),
     ])).toEqual([
       {

--- a/packages/jira-adapter/test/change_validators/system_fields.test.ts
+++ b/packages/jira-adapter/test/change_validators/system_fields.test.ts
@@ -1,0 +1,48 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { toChange, ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { FIELD_TYPE_NAME } from '../../src/filters/fields/constants'
+import { systemFieldsValidator } from '../../src/change_validators/system_fields'
+import { JIRA } from '../../src/constants'
+
+describe('systemFieldsValidator', () => {
+  const type = new ObjectType({ elemID: new ElemID(JIRA, FIELD_TYPE_NAME) })
+  it('should return an error if a field is a system field', async () => {
+    const systemFieldInstance = new InstanceElement('instance', type)
+    systemFieldInstance.value.schema = {}
+    expect(await systemFieldsValidator([
+      toChange({
+        after: systemFieldInstance,
+      }),
+    ])).toEqual([
+      {
+        elemID: systemFieldInstance.elemID,
+        severity: 'Error',
+        message: 'Cannot deploy a system field',
+        detailedMessage: 'The field jira.Field.instance.instance is a system field and cannot be deployed',
+      },
+    ])
+  })
+
+  it('should not return an error if the field is not a system field', async () => {
+    const notSystemFieldInstance = new InstanceElement('instance', type)
+    expect(await systemFieldsValidator([
+      toChange({
+        after: notSystemFieldInstance,
+      }),
+    ])).toEqual([])
+  })
+})

--- a/packages/jira-adapter/test/change_validators/system_fields.test.ts
+++ b/packages/jira-adapter/test/change_validators/system_fields.test.ts
@@ -30,8 +30,8 @@ describe('systemFieldsValidator', () => {
       {
         elemID: systemFieldInstance.elemID,
         severity: 'Error',
-        message: 'Cannot deploy a system field',
-        detailedMessage: 'The field jira.Field.instance.instance is a system field and cannot be deployed',
+        message: 'Can not deploy changes to a Jira system field',
+        detailedMessage: 'jira.Field.instance.instance is a built-in Jira system field, and can not be edited or deleted. Changes to this field will be not deployed',
       },
     ])
   })

--- a/packages/jira-adapter/test/change_validators/system_fields.test.ts
+++ b/packages/jira-adapter/test/change_validators/system_fields.test.ts
@@ -21,8 +21,7 @@ import { JIRA } from '../../src/constants'
 describe('systemFieldsValidator', () => {
   const type = new ObjectType({ elemID: new ElemID(JIRA, FIELD_TYPE_NAME) })
   it('should return an error if a field is a system field', async () => {
-    const systemFieldInstance = new InstanceElement('instance', type)
-    systemFieldInstance.value.schema = {}
+    const systemFieldInstance = new InstanceElement('instance', type, { schema: {} })
     expect(await systemFieldsValidator([
       toChange({
         after: systemFieldInstance,


### PR DESCRIPTION
_Add change validator for attempting to deploy a system field_ 

---

_Additional context for reviewer_
Until now, the deploy would fail but appears as an internal error.
In order to determine if the field is a system field I checked if the 'schema' field exists.

---
_Release Notes_: 
_Jira Adapter_
* Added an indicative error when attempting to deploy a system field

---
_User Notifications_: 
_None_
