### PR TITLE
SALTO-2578: Support Filter Subscriptions - Jira

### DIFF
--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -467,6 +467,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       fieldTypeOverrides: [
         { fieldName: 'columns', fieldType: 'list<ColumnItem>' },
         { fieldName: 'expand', fieldType: 'string' },
+        { fieldName: 'subscriptions', fieldType: 'list<FilterSubscription>' },
       ],
       fieldsToHide: [
         {
@@ -1559,6 +1560,14 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
         { fieldName: 'remainingSeats' },
         { fieldName: 'groupDetails' },
         { fieldName: 'defaultGroupsDetails' },
+      ],
+    },
+  },
+
+  FilterSubscription: {
+    transformation: {
+      fieldsToOmit: [
+        { fieldName: 'id' },
       ],
     },
   },


### PR DESCRIPTION
_I added an override to the type of the filter from  'jira.FilterSubscriptionsList' to 'List<jira.FilterSubscription>' and omitted the 'id' field_

---

_Jira recently added a 'subscriptions' field to filters and we wanted to change how it appears in the NaCl_

previously:
<img width="581" alt="before" src="https://user-images.githubusercontent.com/77064001/185416255-fdc69fcf-ffef-4883-9305-cc06f9653bad.png">
 
after the change: 
<img width="583" alt="after" src="https://user-images.githubusercontent.com/77064001/185416298-4b056d1a-2eae-405a-9cb9-d2ccbd56cef1.png">

---
_Release Notes_: 
_Jira adapter_
* Change in the NaCl file of filters with subscriptions

---
_User Notifications_: 
_Jira Adapter_
* Change in the NaCl file of filters with subscriptions

