### PR TITLE
SALTO-2614/fix changed by at index update

### DIFF
--- a/packages/workspace/src/workspace/changed_at_index.ts
+++ b/packages/workspace/src/workspace/changed_at_index.ts
@@ -37,7 +37,7 @@ import { RemoteMap } from './remote_map'
 const { isDefined } = values
 
 const log = logger(module)
-export const CHANGED_AT_INDEX_VERSION = 3
+export const CHANGED_AT_INDEX_VERSION = 4
 const CHANGED_AT_INDEX_KEY = 'changed_at_index'
 
 const getChangedAtDates = (change: Change<Element>): Record<string, ElemID[]> => {

--- a/packages/workspace/src/workspace/changed_at_index.ts
+++ b/packages/workspace/src/workspace/changed_at_index.ts
@@ -20,7 +20,6 @@ import {
   Element,
   toChange,
   CORE_ANNOTATIONS,
-  ModificationChange,
   AdditionChange,
   RemovalChange,
   isAdditionChange,
@@ -86,23 +85,6 @@ const updateRemovalChange = (
   })
 }
 
-const updateModificationChange = (
-  change: ModificationChange<Element>,
-  datesMap: Record<string, Set<string>>,
-): void => {
-  if (change.data.after.annotations[CORE_ANNOTATIONS.CHANGED_AT]
-    !== change.data.before.annotations[CORE_ANNOTATIONS.CHANGED_AT]) {
-    updateRemovalChange(
-      toChange({ before: change.data.before }) as RemovalChange<Element>,
-      datesMap,
-    )
-    updateAdditionChange(
-      toChange({ after: change.data.after }) as AdditionChange<Element>,
-      datesMap,
-    )
-  }
-}
-
 const updateChange = (
   change: Change<Element>,
   datesMap: Record<string, Set<string>>,
@@ -112,7 +94,14 @@ const updateChange = (
   } else if (isRemovalChange(change)) {
     updateRemovalChange(change, datesMap)
   } else {
-    updateModificationChange(change, datesMap)
+    updateRemovalChange(
+      toChange({ before: change.data.before }) as RemovalChange<Element>,
+      datesMap,
+    )
+    updateAdditionChange(
+      toChange({ after: change.data.after }) as AdditionChange<Element>,
+      datesMap,
+    )
   }
 }
 

--- a/packages/workspace/src/workspace/changed_by_index.ts
+++ b/packages/workspace/src/workspace/changed_by_index.ts
@@ -20,7 +20,6 @@ import {
   Element,
   toChange,
   CORE_ANNOTATIONS,
-  ModificationChange,
   AdditionChange,
   RemovalChange,
   isAdditionChange,
@@ -122,23 +121,6 @@ const updateRemovalChange = (
   })
 }
 
-const updateModificationChange = (
-  change: ModificationChange<Element>,
-  authorMap: Record<string, Set<string>>,
-): void => {
-  if (change.data.after.annotations[CORE_ANNOTATIONS.CHANGED_BY]
-    !== change.data.before.annotations[CORE_ANNOTATIONS.CHANGED_BY]) {
-    updateRemovalChange(
-      toChange({ before: change.data.before }) as RemovalChange<Element>,
-      authorMap,
-    )
-    updateAdditionChange(
-      toChange({ after: change.data.after }) as AdditionChange<Element>,
-      authorMap,
-    )
-  }
-}
-
 const updateChange = (
   change: Change<Element>,
   authorMap: Record<string, Set<string>>,
@@ -148,7 +130,14 @@ const updateChange = (
   } else if (isRemovalChange(change)) {
     updateRemovalChange(change, authorMap)
   } else {
-    updateModificationChange(change, authorMap)
+    updateRemovalChange(
+      toChange({ before: change.data.before }) as RemovalChange<Element>,
+      authorMap,
+    )
+    updateAdditionChange(
+      toChange({ after: change.data.after }) as AdditionChange<Element>,
+      authorMap,
+    )
   }
 }
 

--- a/packages/workspace/src/workspace/changed_by_index.ts
+++ b/packages/workspace/src/workspace/changed_by_index.ts
@@ -145,13 +145,10 @@ const getUniqueAuthors = (changes: Change<Element>[]): Set<string> => {
   const authorSet = new Set<string>()
   changes.forEach(change => {
     if (isModificationChange(change)) {
-      if (change.data.after.annotations[CORE_ANNOTATIONS.CHANGED_BY]
-          !== change.data.before.annotations[CORE_ANNOTATIONS.CHANGED_BY]) {
-        Object.keys(getChangeAuthors(toChange({ before: change.data.before })))
-          .forEach(author => authorSet.add(author))
-        Object.keys(getChangeAuthors(toChange({ after: change.data.after })))
-          .forEach(author => authorSet.add(author))
-      }
+      Object.keys(getChangeAuthors(toChange({ before: change.data.before })))
+        .forEach(author => authorSet.add(author))
+      Object.keys(getChangeAuthors(toChange({ after: change.data.after })))
+        .forEach(author => authorSet.add(author))
     } else {
       Object.keys(getChangeAuthors(change)).forEach(author => authorSet.add(author))
     }

--- a/packages/workspace/src/workspace/changed_by_index.ts
+++ b/packages/workspace/src/workspace/changed_by_index.ts
@@ -37,7 +37,7 @@ import { RemoteMap } from './remote_map'
 const { isDefined } = values
 
 const log = logger(module)
-export const CHANGED_BY_INDEX_VERSION = 3
+export const CHANGED_BY_INDEX_VERSION = 4
 const CHANGED_BY_INDEX_KEY = 'changed_by_index'
 const UNKNOWN_USER_NAME = 'Unknown'
 const CHANGED_BY_KEY_DELIMITER = '@@'

--- a/packages/workspace/test/workspace/changed_by_index.test.ts
+++ b/packages/workspace/test/workspace/changed_by_index.test.ts
@@ -184,9 +184,10 @@ describe('changed by index', () => {
           true
         )
       })
-      it('should do nothing', () => {
-        expect(changedByIndex.getMany).toHaveBeenCalledWith([])
-        expect(changedByIndex.setAll).toHaveBeenCalledWith([])
+      it('should update both', () => {
+        expect(changedByIndex.getMany).toHaveBeenCalledWith(['test@@user one', 'Unknown'])
+        expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'test@@user one', value: [knownUserInstance.elemID] }]))
+        expect(changedByIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining([{ key: 'Unknown', value: [unKnownUserInstance.elemID] }]))
         expect(changedByIndex.deleteAll).toHaveBeenCalledWith([])
       })
     })


### PR DESCRIPTION
fixed bug in changed by and changed at causing us to ignore changes in objects fields if the object itself did not change his changed by/at value. 
i added tests for that edge case.
and raised the index version to fix the error across workspaces

---

_Additional context for reviewer_
the feature using this is not open to all users so im leaving the release notes empty

---
_Release Notes_: 


---
_User Notifications_: 
