### PR TITLE
cli - fix issue with defining a keyed option without a short name

### DIFF
--- a/packages/cli/src/command_register.ts
+++ b/packages/cli/src/command_register.ts
@@ -48,7 +48,7 @@ const createOptionString = (
   isNegation = false
 ): string => {
   const actualName = isNegation ? `${OPTION_NEGATION_PREFIX}${name}` : name
-  const aliasAndName = alias ? `-${alias}, --${actualName}` : `--${actualName}`
+  const aliasAndName = alias ? `-${alias}, --${actualName}` : `,--${actualName}`
   const varDef = (type === 'boolean')
     ? ''
     // Keyed string/stringsList options are always wrapped with <>


### PR DESCRIPTION
Fixed issue with the way we defined keyed options in commander
commander expects short name and name, when specifying only the long name
it seems like things silently don't work.
adding a comma at the beginning seems to solve it though...

---

Funny enough it seems like all of our keyed options so far have a short name.
Found out about this issue when adding a test command locally...

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_