### PR TITLE
SALTO-2292 Add reference to emailTemplate under AutoResponse

### DIFF
--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -366,6 +366,10 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     target: { parentContext: 'instanceParent', type: 'CompactLayout' },
   },
   {
+    src: { field: 'template', parentTypes: ['RuleEntry'] },
+    target: { type: 'EmailTemplate' },
+  },
+  {
     // sometimes has a value that is not a reference - should only convert to reference
     // if lookupValueType exists
     src: { field: 'lookupValue', parentTypes: ['WorkflowFieldUpdate'] },


### PR DESCRIPTION
_Add reference to emailTemplate under Autoresponse_

---
_Additional context for reviewer_:
None

---
_Release Notes_: 
Salesforce-adapter:

* Add reference from the template field to emailTemplate under AutoResponse
---

_User Notifications_: 
Salesforce-adapter:

* Add reference from the template field to emailTemplate under AutoResponse