### PR TITLE
SALTO-2616-skip-zendesk-e2e-brand-logo

### DIFF
--- a/packages/zendesk-adapter/e2e_test/adapter.test.ts
+++ b/packages/zendesk-adapter/e2e_test/adapter.test.ts
@@ -475,7 +475,9 @@ describe('Zendesk adapter E2E', () => {
             .toContain(instance.elemID.getFullName())
         })
     })
-    it('should fetch brand_logo correctly', async () => {
+    // Will be reenabled once SALTO-2616 is fixed
+    // eslint-disable-next-line jest/no-disabled-tests
+    it.skip('should fetch brand_logo correctly', async () => {
       const fetchedBrandLogoInstance = elements
         .filter(inst => inst.elemID.typeName === 'brand_logo')
         .filter(isInstanceElement)


### PR DESCRIPTION
Temporary disable Zendesk e2e brand_logo deploy test

---

_Additional context for reviewer_

---
_Release Notes_: 
-

---
_User Notifications_: 
None.