### PR TITLE
SALTO-2135 Extract field references from ReportGrouping in Report

### DIFF
--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -370,6 +370,10 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     target: { type: 'EmailTemplate' },
   },
   {
+    src: { field: 'field', parentTypes: ['ReportGrouping'] },
+    target: { parentContext: 'instanceParent', type: CUSTOM_FIELD },
+  },
+  {
     // sometimes has a value that is not a reference - should only convert to reference
     // if lookupValueType exists
     src: { field: 'lookupValue', parentTypes: ['WorkflowFieldUpdate'] },


### PR DESCRIPTION
_Extract field references from actionCalls in Report_

---
_Additional context for reviewer_:
None

---
_Release Notes_: 
Salesforce-adapter:

* Add reference to the custom field in ReportGrouping under Report

---

_User Notifications_: 
Salesforce-adapter:

* Add reference to the custom field in ReportGrouping under Report