### PR TITLE
SALTO-2124: add restriction filter for ticket_field__custom_field_options.value

### DIFF
--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -76,6 +76,8 @@ import brandLogoFilter from './filters/brand_logo'
 import removeBrandLogoFieldFilter from './filters/remove_brand_logo_field'
 import { getConfigFromConfigChanges } from './config_change'
 import { dependencyChanger } from './dependency_changers'
+import customFieldOptionsFilter from './filters/add_restriction'
+
 
 const log = logger(module)
 const { createPaginator } = clientUtils
@@ -122,6 +124,7 @@ export const DEFAULT_FILTERS = [
   removeBrandLogoFieldFilter,
   fieldReferencesFilter,
   appsFilter,
+  customFieldOptionsFilter,
   appOwnedConvertListToMapFilter,
   slaPolicyFilter,
   routingAttributeFilter,

--- a/packages/zendesk-adapter/src/filters/add_restriction.ts
+++ b/packages/zendesk-adapter/src/filters/add_restriction.ts
@@ -26,19 +26,20 @@ import { FilterCreator } from '../filter'
 type AllRestrictionsToMake = Record<string, RestrictionAnnotationType>
 type RestrictionByType = Record<string, AllRestrictionsToMake>
 
-const TO_ADD_RESTRICTION: RestrictionByType = {
+const TYPE_NAME_TO_FIELD_RESTRICTIONS: RestrictionByType = {
   ticket_field__custom_field_options: {
     value: {
       regex: '^[0-9A-Za-z-_.\\/~:^]+$',
+      enforce_value: true,
     },
   },
 }
 
 
-const addRestriction = (obj:ObjectType) : void => {
-  const typeToChange = TO_ADD_RESTRICTION[obj.elemID.typeName]
+const addRestriction = (obj: ObjectType) : void => {
+  const typeToChange = TYPE_NAME_TO_FIELD_RESTRICTIONS[obj.elemID.typeName]
   Object.keys(typeToChange).forEach(field => {
-    if (obj.fields[field]?.annotations) {
+    if (Object.prototype.hasOwnProperty.call(typeToChange, field)) {
       obj.fields[field].annotations[CORE_ANNOTATIONS.RESTRICTION] = createRestriction(
         typeToChange[field]
       )
@@ -50,7 +51,7 @@ const filterCreator: FilterCreator = () => ({
   onFetch: async (elements: Element[]): Promise<void> => {
     elements
       .filter(isObjectType)
-      .filter(obj => TO_ADD_RESTRICTION[obj.elemID.typeName] ?? false)
+      .filter(obj => Object.keys(TYPE_NAME_TO_FIELD_RESTRICTIONS).includes(obj.elemID.typeName))
       .forEach(addRestriction)
   },
 })

--- a/packages/zendesk-adapter/src/filters/add_restriction.ts
+++ b/packages/zendesk-adapter/src/filters/add_restriction.ts
@@ -39,7 +39,7 @@ const TYPE_NAME_TO_FIELD_RESTRICTIONS: RestrictionByType = {
 const addRestriction = (obj: ObjectType) : void => {
   const typeToChange = TYPE_NAME_TO_FIELD_RESTRICTIONS[obj.elemID.typeName]
   Object.keys(typeToChange).forEach(field => {
-    if (Object.prototype.hasOwnProperty.call(typeToChange, field)) {
+    if (Object.prototype.hasOwnProperty.call(obj.fields, field)) {
       obj.fields[field].annotations[CORE_ANNOTATIONS.RESTRICTION] = createRestriction(
         typeToChange[field]
       )

--- a/packages/zendesk-adapter/src/filters/add_restriction.ts
+++ b/packages/zendesk-adapter/src/filters/add_restriction.ts
@@ -1,0 +1,58 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  CORE_ANNOTATIONS,
+  createRestriction,
+  Element,
+  isObjectType,
+  ObjectType,
+  RestrictionAnnotationType,
+} from '@salto-io/adapter-api'
+import { FilterCreator } from '../filter'
+
+type AllRestrictionsToMake = Record<string, RestrictionAnnotationType>
+type RestrictionByType = Record<string, AllRestrictionsToMake>
+
+const TO_ADD_RESTRICTION: RestrictionByType = {
+  ticket_field__custom_field_options: {
+    value: {
+      regex: '^[0-9A-Za-z-_.\\/~:^]+$',
+    },
+  },
+}
+
+
+const addRestriction = (obj:ObjectType) : void => {
+  const typeToChange = TO_ADD_RESTRICTION[obj.elemID.typeName]
+  Object.keys(typeToChange).forEach(field => {
+    if (obj.fields[field]?.annotations) {
+      obj.fields[field].annotations[CORE_ANNOTATIONS.RESTRICTION] = createRestriction(
+        typeToChange[field]
+      )
+    }
+  })
+}
+
+const filterCreator: FilterCreator = () => ({
+  onFetch: async (elements: Element[]): Promise<void> => {
+    elements
+      .filter(isObjectType)
+      .filter(obj => TO_ADD_RESTRICTION[obj.elemID.typeName] ?? false)
+      .forEach(addRestriction)
+  },
+})
+
+export default filterCreator

--- a/packages/zendesk-adapter/test/filters/add_restriction.test.ts
+++ b/packages/zendesk-adapter/test/filters/add_restriction.test.ts
@@ -1,0 +1,69 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType } from '@salto-io/adapter-api'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import ZendeskClient from '../../src/client/client'
+import { ZENDESK } from '../../src/constants'
+import filterCreator from '../../src/filters/add_restriction'
+import { paginate } from '../../src/client/pagination'
+import { DEFAULT_CONFIG } from '../../src/config'
+
+describe('custom field option restriction filter', () => {
+  let client: ZendeskClient
+    type FilterType = filterUtils.FilterWith<'onFetch'>
+    let filter: FilterType
+    const typeName = 'ticket_field__custom_field_options'
+    const objTypeNoValue = new ObjectType({ elemID: new ElemID(ZENDESK, typeName) })
+    const objTypeWithValue = new ObjectType({ elemID: new ElemID(ZENDESK, typeName) })
+    objTypeWithValue.fields.value = new Field(
+      objTypeWithValue,
+      'value',
+      BuiltinTypes.STRING,
+    )
+    beforeEach(async () => {
+      client = new ZendeskClient({
+        credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
+      })
+      filter = filterCreator({
+        client,
+        paginator: clientUtils.createPaginator({
+          client,
+          paginationFuncCreator: paginate,
+        }),
+        config: DEFAULT_CONFIG,
+        fetchQuery: elementUtils.query.createMockQuery(),
+      }) as FilterType
+    })
+
+    describe('onFetch', () => {
+      it('should add a regex restriction to the value field when exists', async () => {
+        const elements = [objTypeWithValue].map(e => e.clone())
+        await filter.onFetch(elements)
+        expect(elements).toHaveLength(1)
+        expect(elements[0].fields.value.annotations[CORE_ANNOTATIONS.RESTRICTION].regex)
+          .toBeDefined()
+        expect(elements[0].fields.value.annotations[CORE_ANNOTATIONS.RESTRICTION].regex)
+          .toEqual('^[0-9A-Za-z-_.\\/~:^]+$')
+      })
+      it('should not add a regex restriction to the value field when the field does not exists', async () => {
+        const elements = [objTypeNoValue].map(e => e.clone())
+        await filter.onFetch(elements)
+        expect(elements).toHaveLength(1)
+        // eslint-disable-next-line max-len
+        expect(elements[0].fields.value?.annotations[CORE_ANNOTATIONS.RESTRICTION].regex).not.toBeDefined()
+      })
+    })
+})


### PR DESCRIPTION
_Add restriction filter for ticket_field__custom_field_options.value_

---
_Additional context for reviewer_:
None

---
_Release Notes_: 
_Zendesk adapter_
* Add restriction filter of regex for the type ticket_field__custom_field_options.value

---
_User Notifications_: 
_Zendesk adapter_
* Add restriction filter of regex for the type ticket_field__custom_field_options.value
