### PR TITLE
SALTO-2622: Set correct nacl source hash when source is empty

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -530,8 +530,12 @@ const buildNaclFilesState = async ({
     ),
     updateSearchableNamesIndex(changes),
   ])
-  if (postChangeHash && (postChangeHash !== preChangeHash)) {
-    await currentState.metadata.set(HASH_KEY, postChangeHash)
+  if (postChangeHash !== preChangeHash) {
+    if (postChangeHash === undefined) {
+      await currentState.metadata.delete(HASH_KEY)
+    } else {
+      await currentState.metadata.set(HASH_KEY, postChangeHash)
+    }
   }
   return {
     state: currentState,


### PR DESCRIPTION
This fixes an issue where if a nacl source was non-empty once and then became empty
it would be constantly invalidated because we would never set the empty hash

---

No release notes because it is a fairly unlikely scenario and the effect is not visible to the user other than a performance issue

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_