### PR TITLE
Salto-2615: add option to make recurseInto values not to fail the instance - Jira

### DIFF
--- a/packages/adapter-components/src/config/request.ts
+++ b/packages/adapter-components/src/config/request.ts
@@ -55,6 +55,7 @@ type RecurseIntoConfig = {
   isSingle?: boolean
   context: RecurseIntoContext[]
   conditions?: RecurseIntoCondition[]
+  skipOnError?: boolean
 }
 
 type BaseRequestConfig = {
@@ -185,6 +186,9 @@ export const createRequestConfigs = (
       },
       conditions: {
         refType: new ListType(recurseIntoConditionType),
+      },
+      skipOnError: {
+        refType: BuiltinTypes.BOOLEAN,
       },
     },
   })

--- a/packages/adapter-components/src/elements/swagger/instance_elements.ts
+++ b/packages/adapter-components/src/elements/swagger/instance_elements.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import _ from 'lodash'
+import _, { map } from 'lodash'
 import {
   InstanceElement, Values, ObjectType, isObjectType, ReferenceExpression, isReferenceExpression,
   isListType, isMapType, TypeElement, PrimitiveType, MapType, ElemIdGetter,
@@ -405,7 +405,8 @@ const getEntriesForType = async (
         return { ...entry, ...Object.fromEntries(extraFields) }
       } catch (err) {
         log.warn(`Failed getting extra field values for ${typeName} entry: ${safeJsonStringify(entry)}. Error: ${err.message}`)
-        return undefined
+        return recurseInto[1].skipOnError ? { ...entry }
+          : undefined
       }
     })
   )).filter(lowerdashValues.isDefined)

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -199,6 +199,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
         {
           type: 'PageBeanCustomFieldContextDefaultValue',
           toField: 'contextDefaults',
+          skipOnError: true,
           context: [{ name: 'fieldId', fromField: 'id' }],
           conditions: [{
             fromField: 'schema.custom',


### PR DESCRIPTION
_Add a flag to `RecurseIntoConfig` which won't fail the instance when we fail to retrieve some property from the service and use it for the `contextDefaults` field under `Field` instances_

---

_In some cases we want to allow skipping values where it might happen in order to avoid unintentionally omitting the instances_

---
_Release Notes_: 
_Jira_:
* Fixed issue where Field instances were omitted if their default value could not be fetched (e.g. Category)
---
_User Notifications_: 
_Jira_:
* Some Field instances that were erroneously omitted due to failure to get some of their attributes will be added (e.g. Category)
