### PR TITLE
SALTO-2606 support more zendesk types for missing references- trigger

### DIFF
--- a/packages/zendesk-adapter/src/change_validators/brand_creation.ts
+++ b/packages/zendesk-adapter/src/change_validators/brand_creation.ts
@@ -15,14 +15,14 @@
 */
 import { ChangeValidator, getChangeData,
   isAdditionChange, isInstanceElement } from '@salto-io/adapter-api'
-import { BRAND_NAME } from '../constants'
+import { BRAND_TYPE_NAME } from '../constants'
 
 export const brandCreationValidator: ChangeValidator = async changes => (
   changes
     .filter(isAdditionChange)
     .map(getChangeData)
     .filter(isInstanceElement)
-    .filter(instance => instance.elemID.typeName === BRAND_NAME)
+    .filter(instance => instance.elemID.typeName === BRAND_TYPE_NAME)
     .flatMap(instance => (
       [{
         elemID: instance.elemID,

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import { ElemID, CORE_ANNOTATIONS, BuiltinTypes, ListType } from '@salto-io/adapter-api'
 import { createMatchingObjectType } from '@salto-io/adapter-utils'
 import { client as clientUtils, config as configUtils, elements } from '@salto-io/adapter-components'
-import { BRAND_NAME, ZENDESK } from './constants'
+import { BRAND_TYPE_NAME, ZENDESK } from './constants'
 
 const { createClientConfigType } = clientUtils
 const {
@@ -483,7 +483,7 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
       fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
   },
-  [BRAND_NAME]: {
+  [BRAND_TYPE_NAME]: {
     transformation: {
       sourceTypeName: 'brands__brands',
       // We currently not supporting in attachements

--- a/packages/zendesk-adapter/src/constants.ts
+++ b/packages/zendesk-adapter/src/constants.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 export const ZENDESK = 'zendesk'
-export const BRAND_NAME = 'brand'
+export const BRAND_TYPE_NAME = 'brand'
 export const TARGET_TYPE_NAME = 'target'
 export const APP_OWNED_TYPE_NAME = 'app_owned'
 export const BRAND_LOGO_TYPE_NAME = 'brand_logo'

--- a/packages/zendesk-adapter/src/filters/brand_logo.ts
+++ b/packages/zendesk-adapter/src/filters/brand_logo.ts
@@ -25,7 +25,7 @@ import { logger } from '@salto-io/logging'
 import FormData from 'form-data'
 import { collections } from '@salto-io/lowerdash'
 import ZendeskClient from '../client/client'
-import { BRAND_LOGO_TYPE_NAME, BRAND_NAME, ZENDESK } from '../constants'
+import { BRAND_LOGO_TYPE_NAME, BRAND_TYPE_NAME, ZENDESK } from '../constants'
 import { getZendeskError } from '../errors'
 import { FilterCreator } from '../filter'
 
@@ -135,7 +135,7 @@ const filterCreator: FilterCreator = ({ client }) => ({
   onFetch: async elements => {
     const brandsWithLogos = elements
       .filter(isInstanceElement)
-      .filter(e => e.elemID.typeName === BRAND_NAME)
+      .filter(e => e.elemID.typeName === BRAND_TYPE_NAME)
       .filter(e => !_.isEmpty(e.value[LOGO_FIELD]))
     elements.push(BRAND_LOGO_TYPE)
     const logoInstances = (await Promise.all(

--- a/packages/zendesk-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-adapter/src/filters/field_references.ts
@@ -207,7 +207,7 @@ const ZendeskReferenceSerializationStrategyLookup: Record<
 }
 
 export type ReferenceContextStrategyName = 'neighborField'
-  | 'whitelistedNeighborField'
+  | 'allowlistedNeighborField'
   | 'neighborType'
   | 'parentSubject'
   | 'parentTitle'
@@ -222,7 +222,7 @@ export const contextStrategyLookup: Record<
   ReferenceContextStrategyName, referenceUtils.ContextFunc
 > = {
   neighborField: neighborContextFunc({ contextFieldName: 'field', contextValueMapper: getValueLookupType }),
-  whitelistedNeighborField: neighborContextFunc({ contextFieldName: 'field', contextValueMapper: val => NEIGHBOR_FIELD_TO_TYPE_NAMES[val] }),
+  allowlistedNeighborField: neighborContextFunc({ contextFieldName: 'field', contextValueMapper: val => NEIGHBOR_FIELD_TO_TYPE_NAMES[val] }),
   neighborReferenceTicketField: neighborContextFunc({ contextFieldName: 'field', getLookUpName: neighborReferenceTicketFieldLookupFunc, contextValueMapper: neighborReferenceTicketFieldLookupType }),
   neighborReferenceTicketFormCondition: neighborContextFunc({ contextFieldName: 'parent_field_id', getLookUpName: neighborReferenceTicketFieldLookupFunc, contextValueMapper: neighborReferenceTicketFieldLookupType }),
   neighborReferenceUserAndOrgField: neighborContextFunc({ contextFieldName: 'field', getLookUpName: neighborReferenceUserAndOrgFieldLookupFunc, contextValueMapper: neighborReferenceUserAndOrgFieldLookupType }),
@@ -730,7 +730,7 @@ const commonFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[] = [
         'trigger__conditions__any',
       ],
     },
-    target: { typeContext: 'whitelistedNeighborField' },
+    target: { typeContext: 'allowlistedNeighborField' },
     zendeskMissingRefStrategy: 'typeAndValue',
   },
 ]

--- a/packages/zendesk-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-adapter/src/filters/field_references.ts
@@ -14,13 +14,14 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { Element, ElemID, InstanceElement, isInstanceElement, ObjectType } from '@salto-io/adapter-api'
+import { Element, isInstanceElement } from '@salto-io/adapter-api'
 import { references as referenceUtils } from '@salto-io/adapter-components'
-import { GetLookupNameFunc, naclCase } from '@salto-io/adapter-utils'
+import { GetLookupNameFunc } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
-import { BRAND_NAME } from '../constants'
+import { BRAND_TYPE_NAME } from '../constants'
 import { FETCH_CONFIG } from '../config'
+import { ZendeskMissingReferenceStrategyLookup } from './references/missing_references'
 
 const { neighborContextGetter } = referenceUtils
 const log = logger(module)
@@ -34,6 +35,15 @@ const neighborContextFunc = (args: {
   getLookUpName: async ({ ref }) => ref.elemID.name,
   ...args,
 })
+
+// TODO: Support in types with list values
+const NEIGHBOR_FIELD_TO_TYPE_NAMES: Record<string, string> = {
+  brand_id: 'brand',
+  group_id: 'group',
+  schedule_id: 'business_hours_schedule',
+  within_schedule: 'business_hours_schedule',
+  set_schedule: 'business_hours_schedule',
+}
 
 const SPECIAL_CONTEXT_NAMES: Record<string, string> = {
   schedule_id: 'business_hours_schedule',
@@ -197,6 +207,7 @@ const ZendeskReferenceSerializationStrategyLookup: Record<
 }
 
 export type ReferenceContextStrategyName = 'neighborField'
+  | 'whitelistedNeighborField'
   | 'neighborType'
   | 'parentSubject'
   | 'parentTitle'
@@ -211,6 +222,7 @@ export const contextStrategyLookup: Record<
   ReferenceContextStrategyName, referenceUtils.ContextFunc
 > = {
   neighborField: neighborContextFunc({ contextFieldName: 'field', contextValueMapper: getValueLookupType }),
+  whitelistedNeighborField: neighborContextFunc({ contextFieldName: 'field', contextValueMapper: val => NEIGHBOR_FIELD_TO_TYPE_NAMES[val] }),
   neighborReferenceTicketField: neighborContextFunc({ contextFieldName: 'field', getLookUpName: neighborReferenceTicketFieldLookupFunc, contextValueMapper: neighborReferenceTicketFieldLookupType }),
   neighborReferenceTicketFormCondition: neighborContextFunc({ contextFieldName: 'parent_field_id', getLookUpName: neighborReferenceTicketFieldLookupFunc, contextValueMapper: neighborReferenceTicketFieldLookupType }),
   neighborReferenceUserAndOrgField: neighborContextFunc({ contextFieldName: 'field', getLookUpName: neighborReferenceUserAndOrgFieldLookupFunc, contextValueMapper: neighborReferenceUserAndOrgFieldLookupType }),
@@ -221,26 +233,6 @@ export const contextStrategyLookup: Record<
   neighborSubject: neighborContextFunc({ contextFieldName: 'subject', contextValueMapper: getValueLookupType }),
   parentTitle: neighborContextFunc({ contextFieldName: 'title', levelsUp: 1, contextValueMapper: getValueLookupType }),
   parentValue: neighborContextFunc({ contextFieldName: 'value', levelsUp: 2, contextValueMapper: getValueLookupType }),
-}
-
-const MISSING_REF_PREFIX = 'missing_'
-export const ZendeskMissingReferenceStrategyLookup: Record<
-referenceUtils.MissingReferenceStrategyName, referenceUtils.MissingReferenceStrategy
-> = {
-  typeAndValue: {
-    create: ({ value, adapter, typeName }) => {
-      if (!_.isString(typeName) || !value) {
-        return undefined
-      }
-      return new InstanceElement(
-        naclCase(`${MISSING_REF_PREFIX}${value}`),
-        new ObjectType({ elemID: new ElemID(adapter, typeName) }),
-        {},
-        undefined,
-        { [referenceUtils.MISSING_ANNOTATION]: true },
-      )
-    },
-  },
 }
 
 type ZendeskFieldReferenceDefinition = referenceUtils.FieldReferenceDefinition<
@@ -271,22 +263,22 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
   {
     src: { field: 'brand_id' },
     serializationStrategy: 'id',
-    target: { type: BRAND_NAME },
+    target: { type: BRAND_TYPE_NAME },
   },
   {
     src: { field: 'brand_ids' },
     serializationStrategy: 'id',
-    target: { type: BRAND_NAME },
+    target: { type: BRAND_TYPE_NAME },
   },
   {
     src: { field: 'default_brand_id' },
     serializationStrategy: 'id',
-    target: { type: BRAND_NAME },
+    target: { type: BRAND_TYPE_NAME },
   },
   {
     src: { field: 'restricted_brand_ids' },
     serializationStrategy: 'id',
-    target: { type: BRAND_NAME },
+    target: { type: BRAND_TYPE_NAME },
   },
   {
     src: { field: 'category_id' },
@@ -729,9 +721,32 @@ const commonFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[] = [
     serializationStrategy: 'id',
     target: { typeContext: 'neighborSubject' },
   },
+  {
+    src: {
+      field: 'value',
+      parentTypes: [
+        'trigger__actions',
+        'trigger__conditions__all',
+        'trigger__conditions__any',
+      ],
+    },
+    target: { typeContext: 'whitelistedNeighborField' },
+    zendeskMissingRefStrategy: 'typeAndValue',
+  },
 ]
 
 const secondIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[] = [
+  {
+    src: {
+      field: 'value',
+      parentTypes: [
+        'trigger__conditions__all',
+      ],
+    },
+    zendeskSerializationStrategy: 'ticketFieldOption',
+    target: { typeContext: 'neighborReferenceTicketField' },
+    zendeskMissingRefStrategy: 'typeAndValue',
+  },
   {
     src: {
       field: 'value',

--- a/packages/zendesk-adapter/src/filters/references/missing_references.ts
+++ b/packages/zendesk-adapter/src/filters/references/missing_references.ts
@@ -1,0 +1,40 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import _ from 'lodash'
+import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import { references as referenceUtils } from '@salto-io/adapter-components'
+import { naclCase } from '@salto-io/adapter-utils'
+
+const MISSING_REF_PREFIX = 'missing_'
+export const ZendeskMissingReferenceStrategyLookup: Record<
+referenceUtils.MissingReferenceStrategyName, referenceUtils.MissingReferenceStrategy
+> = {
+  typeAndValue: {
+    create: ({ value, adapter, typeName }) => {
+      if (!_.isString(typeName) || !value) {
+        return undefined
+      }
+      return new InstanceElement(
+        naclCase(`${MISSING_REF_PREFIX}${value}`),
+        new ObjectType({ elemID: new ElemID(adapter, typeName) }),
+        {},
+        undefined,
+        { [referenceUtils.MISSING_ANNOTATION]: true },
+      )
+    },
+  },
+}

--- a/packages/zendesk-adapter/src/filters/remove_brand_logo_field.ts
+++ b/packages/zendesk-adapter/src/filters/remove_brand_logo_field.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import { InstanceElement, Change, getChangeData } from '@salto-io/adapter-api'
 import { FilterCreator } from '../filter'
 import { deployChange, deployChanges } from '../deployment'
-import { BRAND_NAME } from '../constants'
+import { BRAND_TYPE_NAME } from '../constants'
 import { LOGO_FIELD } from './brand_logo'
 
 /**
@@ -28,7 +28,7 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
   deploy: async (changes: Change<InstanceElement>[]) => {
     const [brandChanges, leftoverChanges] = _.partition(
       changes,
-      change => getChangeData(change).elemID.typeName === BRAND_NAME,
+      change => getChangeData(change).elemID.typeName === BRAND_TYPE_NAME,
     )
     const deployResult = await deployChanges(
       brandChanges,

--- a/packages/zendesk-adapter/test/change_validators/brand_creation.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/brand_creation.test.ts
@@ -14,12 +14,12 @@
 * limitations under the License.
 */
 import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
-import { BRAND_NAME, ZENDESK } from '../../src/constants'
+import { BRAND_TYPE_NAME, ZENDESK } from '../../src/constants'
 import { brandCreationValidator } from '../../src/change_validators/brand_creation'
 
 describe('brandCreationValidator', () => {
   const brandType = new ObjectType({
-    elemID: new ElemID(ZENDESK, BRAND_NAME),
+    elemID: new ElemID(ZENDESK, BRAND_TYPE_NAME),
   })
   const brandInstance = new InstanceElement(
     'New Test',

--- a/packages/zendesk-adapter/test/filters/brand_logo.test.ts
+++ b/packages/zendesk-adapter/test/filters/brand_logo.test.ts
@@ -23,7 +23,7 @@ import filterCreator, { BRAND_LOGO_TYPE, LOGO_FIELD } from '../../src/filters/br
 import { DEFAULT_CONFIG } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
-import { BRAND_LOGO_TYPE_NAME, BRAND_NAME, ZENDESK } from '../../src/constants'
+import { BRAND_LOGO_TYPE_NAME, BRAND_TYPE_NAME, ZENDESK } from '../../src/constants'
 
 jest.useFakeTimers()
 
@@ -34,7 +34,7 @@ describe('brand logo filter', () => {
   let mockGet: jest.SpyInstance
   let mockPut: jest.SpyInstance
   const brandType = new ObjectType({
-    elemID: new ElemID(ZENDESK, BRAND_NAME),
+    elemID: new ElemID(ZENDESK, BRAND_TYPE_NAME),
     fields: {
       [LOGO_FIELD]: { refType: new ObjectType(BRAND_LOGO_TYPE) },
     },
@@ -122,7 +122,7 @@ describe('brand logo filter', () => {
       await filter.onFetch(elements)
 
       const instances = elements.filter(isInstanceElement)
-      const brand = instances.find(e => e.elemID.typeName === BRAND_NAME)
+      const brand = instances.find(e => e.elemID.typeName === BRAND_TYPE_NAME)
       const logo = instances.find(
         e => e.elemID.typeName === BRAND_LOGO_TYPE_NAME
       ) as InstanceElement

--- a/packages/zendesk-adapter/test/filters/field_references.test.ts
+++ b/packages/zendesk-adapter/test/filters/field_references.test.ts
@@ -305,6 +305,9 @@ describe('References by id filter', () => {
           all: [
             { field: 'custom_fields_6001', operator: 'is', value: 'v15' },
             { field: 'requester.custom_fields.key_uf1', value: 9002 },
+            { field: 'brand_id', operator: 'is', value: 'you_like_crazy' },
+            { field: 'group_id', operator: 'is', value: 'a_thing' },
+            { field: 'schedule_id', operator: 'is', value: 'someone_you_love' },
           ],
         },
       },
@@ -425,6 +428,15 @@ describe('References by id filter', () => {
         expect(brokenTrigger.value.conditions.all[0].value.value).toEqual(undefined)
         expect(brokenTrigger.value.conditions.all[1].value).toBeInstanceOf(ReferenceExpression)
         expect(brokenTrigger.value.conditions.all[1].value.value).toBeInstanceOf(InstanceElement)
+        expect(brokenTrigger.value.conditions.all[2].value).toBeInstanceOf(ReferenceExpression)
+        expect(brokenTrigger.value.conditions.all[2].value.elemID.name)
+          .toEqual('missing_you_like_crazy')
+        expect(brokenTrigger.value.conditions.all[3].value).toBeInstanceOf(ReferenceExpression)
+        expect(brokenTrigger.value.conditions.all[3].value.elemID.name)
+          .toEqual('missing_a_thing')
+        expect(brokenTrigger.value.conditions.all[4].value).toBeInstanceOf(ReferenceExpression)
+        expect(brokenTrigger.value.conditions.all[4].value.elemID.name)
+          .toEqual('missing_someone_you_love')
       })
       it('should not create missing references if enable missing references is false', async () => {
         const newFilter = filterCreator({

--- a/packages/zendesk-adapter/test/filters/remove_brand_logo_field.test.ts
+++ b/packages/zendesk-adapter/test/filters/remove_brand_logo_field.test.ts
@@ -20,7 +20,7 @@ import { client as clientUtils, filterUtils, elements as elementUtils } from '@s
 import { DEFAULT_CONFIG } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
-import { BRAND_NAME, ZENDESK } from '../../src/constants'
+import { BRAND_TYPE_NAME, ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/remove_brand_logo_field'
 import { LOGO_FIELD, BRAND_LOGO_TYPE } from '../../src/filters/brand_logo'
 
@@ -41,7 +41,7 @@ describe('remove brand logo field filter', () => {
   type FilterType = filterUtils.FilterWith<'deploy'>
   let filter: FilterType
   const brandType = new ObjectType({
-    elemID: new ElemID(ZENDESK, BRAND_NAME),
+    elemID: new ElemID(ZENDESK, BRAND_TYPE_NAME),
     fields: {
       [LOGO_FIELD]: { refType: new ObjectType(BRAND_LOGO_TYPE) },
     },


### PR DESCRIPTION
Adding missing references for brand, schedule and group values in Trigger instances

To Do:

- [x] Add UT
- [ ] Support more types
- [ ] Support list values

---

_Additional context for reviewer_
* Changed BRAND_NAME const to BRAND_TYPE_NAME
* Moved missing references strategies to a different file for more order

---
_Release Notes_: 
* Adding missing references for brand, schedule and group values in Trigger instances

---
_User Notifications_: 
* missing references will convert from string into Salto unresolved references