### PR TITLE
SALTO-2520: Changed dc authorization to use password

### DIFF
--- a/packages/jira-adapter/src/client/connection.ts
+++ b/packages/jira-adapter/src/client/connection.ts
@@ -51,15 +51,12 @@ export const createConnection: clientUtils.ConnectionCreator<Credentials> = retr
   clientUtils.axiosConnection({
     retryOptions,
     authParamsFunc: async credentials => (
-      credentials.isDataCenter
-        ? {
-          headers: { Authorization: `Bearer ${credentials.token}` },
-        } : {
-          auth: {
-            username: credentials.user,
-            password: credentials.token,
-          },
-        }
+      {
+        auth: {
+          username: credentials.user,
+          password: credentials.token,
+        },
+      }
     ),
     baseURLFunc: ({ baseUrl }) => baseUrl,
     credValidateFunc: async () => '', // There is no login endpoint to call

--- a/packages/jira-adapter/test/client/connection.test.ts
+++ b/packages/jira-adapter/test/client/connection.test.ts
@@ -67,29 +67,4 @@ describe('validateCredentials', () => {
       await expect(validateCredentials({ connection })).rejects.toThrow(new Error('Network Error'))
     })
   })
-
-  describe('when authorized with dataCenter', () => {
-    let result: string
-
-    beforeEach(async () => {
-      connection = await createConnection({ retries: 1 }).login(
-        { baseUrl: 'http://myJira.net', user: 'me', token: 'tok', isDataCenter: true }
-      )
-      result = await validateCredentials({
-        connection,
-      })
-    })
-
-    it('should get server info with auth headers', () => {
-      expect(mockAxios.history.get).toContainEqual(expect.objectContaining({
-        url: '/rest/api/3/serverInfo',
-        baseURL: 'http://myJira.net',
-        headers: expect.objectContaining({ Authorization: 'Bearer tok' }),
-      }))
-    })
-
-    it('should return the base url from the response as account id', () => {
-      expect(result).toEqual('http://my.jira.net')
-    })
-  })
 })


### PR DESCRIPTION
Changed DC authorization to work with password since there are limitation when working with the API key (websudo)

---
_Release Notes_: 
None

---
_User Notifications_: 
None