### PR TITLE
SALTO-2627: Add "additional_fields = false" annotations to all configuration relevant types

### DIFF
--- a/packages/adapter-components/src/client/config.ts
+++ b/packages/adapter-components/src/client/config.ts
@@ -57,6 +57,9 @@ export const createClientConfigType = <RateLimitConfig extends ClientRateLimitCo
       get: createFieldDefWithMin(-1),
       ...Object.fromEntries((bucketNames ?? []).map(name => [name, createFieldDefWithMin(-1)])),
     },
+    annotations: {
+      [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+    },
   })
 
   const clientPageSizeFields: Record<keyof Required<ClientPageSizeConfig>, FieldDefinition> = {
@@ -66,6 +69,9 @@ export const createClientConfigType = <RateLimitConfig extends ClientRateLimitCo
   const clientPageSizeConfigType = new ObjectType({
     elemID: new ElemID(adapter, 'clientPageSizeConfig'),
     fields: clientPageSizeFields,
+    annotations: {
+      [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+    },
   })
 
   const clientRetryConfigType = new ObjectType({
@@ -73,6 +79,9 @@ export const createClientConfigType = <RateLimitConfig extends ClientRateLimitCo
     fields: {
       maxAttempts: createFieldDefWithMin(1),
       retryDelay: { refType: BuiltinTypes.NUMBER },
+    },
+    annotations: {
+      [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
     },
   })
 
@@ -82,6 +91,9 @@ export const createClientConfigType = <RateLimitConfig extends ClientRateLimitCo
       retry: { refType: clientRetryConfigType },
       rateLimit: { refType: clientRateLimitConfigType },
       pageSize: { refType: clientPageSizeConfigType },
+    },
+    annotations: {
+      [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
     },
   })
   return clientConfigType

--- a/packages/adapter-components/src/config/index.ts
+++ b/packages/adapter-components/src/config/index.ts
@@ -17,6 +17,6 @@ export { createDucktypeAdapterApiConfigType, AdapterDuckTypeApiConfig, DuckTypeT
 export { createRequestConfigs, validateRequestConfig, FetchRequestConfig, DeployRequestConfig, UrlParams, DeploymentRequestsByAction, RecurseIntoCondition, isRecurseIntoConditionByField } from './request'
 export { createAdapterApiConfigType, getConfigWithDefault, AdapterApiConfig, UserFetchConfig, TypeConfig, createUserFetchConfigType } from './shared'
 export { mergeWithDefaultConfig } from './merge'
-export { createSwaggerAdapterApiConfigType, AdapterSwaggerApiConfig, RequestableAdapterSwaggerApiConfig, TypeSwaggerConfig, RequestableTypeSwaggerConfig, TypeSwaggerDefaultConfig, TypeNameOverrideConfig, validateApiDefinitionConfig as validateSwaggerApiDefinitionConfig, validateFetchConfig as validateSwaggerFetchConfig } from './swagger'
+export { createTypeNameOverrideConfigType, createSwaggerAdapterApiConfigType, AdapterSwaggerApiConfig, RequestableAdapterSwaggerApiConfig, TypeSwaggerConfig, RequestableTypeSwaggerConfig, TypeSwaggerDefaultConfig, TypeNameOverrideConfig, validateApiDefinitionConfig as validateSwaggerApiDefinitionConfig, validateFetchConfig as validateSwaggerFetchConfig } from './swagger'
 export { createTransformationConfigTypes, validateTransoformationConfig, TransformationDefaultConfig, TransformationConfig, StandaloneFieldConfigType, FieldToOmitType, FieldToHideType, getTransformationConfigByType, dereferenceFieldName, isReferencedIdField, NameMappingOptions } from './transformation'
 export * as configMigrations from './config_migrations'

--- a/packages/adapter-components/src/config/request.ts
+++ b/packages/adapter-components/src/config/request.ts
@@ -104,6 +104,9 @@ export const createRequestConfigs = (
         },
       },
     },
+    annotations: {
+      [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+    },
   })
   const dependsOnConfigType = createMatchingObjectType<DependsOnConfig>({
     elemID: new ElemID(adapter, 'dependsOnConfig'),
@@ -120,6 +123,9 @@ export const createRequestConfigs = (
           _required: true,
         },
       },
+    },
+    annotations: {
+      [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
     },
   })
 
@@ -138,6 +144,9 @@ export const createRequestConfigs = (
           _required: true,
         },
       },
+    },
+    annotations: {
+      [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
     },
   })
 
@@ -159,6 +168,9 @@ export const createRequestConfigs = (
       fromContext: {
         refType: BuiltinTypes.STRING,
       },
+    },
+    annotations: {
+      [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
     },
   })
   const recurseIntoConfigType = createMatchingObjectType<RecurseIntoConfig>({
@@ -188,6 +200,9 @@ export const createRequestConfigs = (
       conditions: {
         refType: new ListType(recurseIntoConditionType),
       },
+    },
+    annotations: {
+      [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
     },
   })
 
@@ -224,11 +239,17 @@ export const createRequestConfigs = (
   const fetchRequestConfigType = new ObjectType({
     elemID: new ElemID(adapter, 'fetchRequestConfig'),
     fields: fetchEndpointFields,
+    annotations: {
+      [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+    },
   })
 
   const fetchRequestDefaultConfigType = new ObjectType({
     elemID: new ElemID(adapter, 'fetchRequestDefaultConfig'),
     fields: _.omit(fetchEndpointFields, ['url']),
+    annotations: {
+      [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+    },
   })
 
 
@@ -248,6 +269,12 @@ export const createRequestConfigs = (
       deployAsField: {
         refType: BuiltinTypes.STRING,
       },
+      fieldsToIgnore: {
+        refType: new ListType(BuiltinTypes.STRING),
+      },
+    },
+    annotations: {
+      [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
     },
   })
 
@@ -263,6 +290,9 @@ export const createRequestConfigs = (
       remove: {
         refType: deployRequestConfigType,
       },
+    },
+    annotations: {
+      [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
     },
   })
 

--- a/packages/adapter-components/src/config/shared.ts
+++ b/packages/adapter-components/src/config/shared.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import {
-  ElemID, ObjectType, BuiltinTypes, FieldDefinition, ListType, MapType, Field,
+  ElemID, ObjectType, BuiltinTypes, FieldDefinition, ListType, MapType, Field, CORE_ANNOTATIONS,
 } from '@salto-io/adapter-api'
 import { createMatchingObjectType } from '@salto-io/adapter-utils'
 import type { TransformationConfig, TransformationDefaultConfig } from './transformation'
@@ -82,6 +82,9 @@ export const createAdapterApiConfigType = ({
       },
       ...additionalTypeFields,
     },
+    annotations: {
+      [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+    },
   })
 
   const typesConfigType = createMatchingObjectType<TypeConfig>({
@@ -93,6 +96,9 @@ export const createAdapterApiConfigType = ({
       },
       transformation: { refType: transformationTypes.transformation },
       ...additionalTypeFields,
+    },
+    annotations: {
+      [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
     },
   })
 
@@ -113,6 +119,9 @@ export const createAdapterApiConfigType = ({
       },
       ...additionalFields,
     },
+    annotations: {
+      [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+    },
   })
   return adapterApiConfigType
 }
@@ -127,6 +136,9 @@ export const createUserFetchConfigType = (
     fields: {
       type: { refType: BuiltinTypes.STRING },
     },
+    annotations: {
+      [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+    },
   })
 
   if (fetchCriteriaType !== undefined) {
@@ -139,6 +151,9 @@ export const createUserFetchConfigType = (
       include: { refType: new ListType(fetchEntryType) },
       exclude: { refType: new ListType(fetchEntryType) },
       ...additionalFields,
+    },
+    annotations: {
+      [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
     },
   })
 }

--- a/packages/adapter-components/src/config/swagger.ts
+++ b/packages/adapter-components/src/config/swagger.ts
@@ -58,27 +58,32 @@ export type RequestableAdapterSwaggerApiConfig = AdapterSwaggerApiConfig & {
   types: Record<string, RequestableTypeSwaggerConfig>
 }
 
+export const createTypeNameOverrideConfigType = (
+  adapter: string,
+): ObjectType => new ObjectType({
+  elemID: new ElemID(adapter, 'typeNameOverrideConfig'),
+  fields: {
+    originalName: {
+      refType: BuiltinTypes.STRING,
+      annotations: {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    },
+    newName: {
+      refType: BuiltinTypes.STRING,
+      annotations: {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    },
+  },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+  },
+})
+
 const createSwaggerDefinitionsBaseConfigType = (
   adapter: string,
 ): ObjectType => {
-  const typeNameOverrideConfig = new ObjectType({
-    elemID: new ElemID(adapter, 'typeNameOverrideConfig'),
-    fields: {
-      originalName: {
-        refType: BuiltinTypes.STRING,
-        annotations: {
-          [CORE_ANNOTATIONS.REQUIRED]: true,
-        },
-      },
-      newName: {
-        refType: BuiltinTypes.STRING,
-        annotations: {
-          [CORE_ANNOTATIONS.REQUIRED]: true,
-        },
-      },
-    },
-  })
-
   const additionalTypeConfig = new ObjectType({
     elemID: new ElemID(adapter, 'additionalTypeConfig'),
     fields: {
@@ -95,6 +100,9 @@ const createSwaggerDefinitionsBaseConfigType = (
         },
       },
     },
+    annotations: {
+      [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+    },
   })
 
   const baseConfigType = new ObjectType({
@@ -104,11 +112,14 @@ const createSwaggerDefinitionsBaseConfigType = (
         refType: BuiltinTypes.STRING,
       },
       typeNameOverrides: {
-        refType: new ListType(typeNameOverrideConfig),
+        refType: new ListType(createTypeNameOverrideConfigType(adapter)),
       },
       additionalTypes: {
         refType: new ListType(additionalTypeConfig),
       },
+    },
+    annotations: {
+      [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
     },
   })
   return baseConfigType

--- a/packages/adapter-components/src/config/transformation.ts
+++ b/packages/adapter-components/src/config/transformation.ts
@@ -84,6 +84,9 @@ export const createTransformationConfigTypes = (
       fieldName: { refType: BuiltinTypes.STRING },
       parseJSON: { refType: BuiltinTypes.BOOLEAN },
     },
+    annotations: {
+      [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+    },
   })
 
   const fieldToAdjustConfigType = new ObjectType({

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -127,11 +127,6 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
   },
 
   Dashboard: {
-    standaloneFields: [
-      {
-        fieldName: 'gadgets',
-      },
-    ],
     transformation: {
       fieldTypeOverrides: [
         { fieldName: 'gadgets', fieldType: 'List<DashboardGadget>' },

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -81,6 +81,9 @@ const jspUrlsType = createMatchingObjectType<Partial<JspUrls>>({
     query: { refType: BuiltinTypes.STRING },
     dataField: { refType: BuiltinTypes.STRING },
   },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+  },
 })
 
 
@@ -116,6 +119,9 @@ const apiDefinitionsType = createMatchingObjectType<Partial<JiraApiConfig>>({
     typesToFallbackToInternalId: {
       refType: new ListType(BuiltinTypes.STRING),
     },
+  },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },
 })
 
@@ -161,12 +167,18 @@ const jiraDeployConfigType = new ObjectType({
   fields: {
     forceDelete: { refType: BuiltinTypes.BOOLEAN },
   },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+  },
 })
 
 const fetchFiltersType = createMatchingObjectType<JiraFetchFilters>({
   elemID: new ElemID(JIRA, 'FetchFilters'),
   fields: {
     name: { refType: BuiltinTypes.STRING },
+  },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },
 })
 
@@ -189,6 +201,9 @@ const maskingConfigType = createMatchingObjectType<Partial<MaskingConfig>>({
       refType: new ListType(BuiltinTypes.STRING),
     },
   },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+  },
 })
 
 export const configType = createMatchingObjectType<Partial<JiraConfig>>({
@@ -202,6 +217,7 @@ export const configType = createMatchingObjectType<Partial<JiraConfig>>({
   },
   annotations: {
     [CORE_ANNOTATIONS.DEFAULT]: _.omit(PARTIAL_DEFAULT_CONFIG, ['client', 'masking']),
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },
 })
 

--- a/packages/jira-adapter/system_config_doc.md
+++ b/packages/jira-adapter/system_config_doc.md
@@ -274,11 +274,6 @@ jira {
         }
       }
       Dashboard = {
-        standaloneFields = [
-          {
-            fieldName = "gadgets"
-          },
-        ]
         transformation = {
           fieldTypeOverrides = [
             {

--- a/packages/netsuite-adapter/config_doc.md
+++ b/packages/netsuite-adapter/config_doc.md
@@ -14,7 +14,9 @@ netsuite {
     }
     exclude = {
       types = [
-        { name = "savedsearch", ids = [".*"] }
+        { name = "savedsearch"
+          ids = [".*"]
+        }
       ]
       fileCabinet = [
         "^/Web Site Hosting Files.*",

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -90,6 +90,9 @@ const clientConfigType = new ObjectType({
       refType: new ListType(BuiltinTypes.STRING),
     },
   },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+  },
 })
 
 const suiteAppClientConfigType = new ObjectType({
@@ -105,6 +108,9 @@ const suiteAppClientConfigType = new ObjectType({
         }),
       },
     },
+  },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },
 })
 
@@ -125,6 +131,9 @@ const queryConfigType = new ObjectType({
       },
     },
   },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+  },
 })
 
 const fetchTypeQueryParamsConfigType = new ObjectType({
@@ -138,6 +147,9 @@ const fetchTypeQueryParamsConfigType = new ObjectType({
     },
     ids: { refType: new ListType(BuiltinTypes.STRING) },
   },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+  },
 })
 
 const queryParamsConfigType = new ObjectType({
@@ -149,6 +161,9 @@ const queryParamsConfigType = new ObjectType({
     fileCabinet: {
       refType: new ListType(BuiltinTypes.STRING),
     },
+  },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },
 })
 
@@ -199,6 +214,9 @@ const authorInfoConfig = new ObjectType({
       refType: BuiltinTypes.BOOLEAN,
     },
   },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+  },
 })
 
 const fieldsToOmitConfig = createMatchingObjectType<FieldToOmitParams>({
@@ -213,6 +231,9 @@ const fieldsToOmitConfig = createMatchingObjectType<FieldToOmitParams>({
       annotations: { _required: true },
     },
   },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+  },
 })
 
 const fetchConfigType = createMatchingObjectType<FetchParams>({
@@ -224,6 +245,9 @@ const fetchConfigType = createMatchingObjectType<FetchParams>({
     [AUTHOR_INFO_CONFIG]: { refType: authorInfoConfig },
     [STRICT_INSTANCE_STRUCTURE]: { refType: BuiltinTypes.BOOLEAN },
     [FIELDS_TO_OMIT]: { refType: new ListType(fieldsToOmitConfig) },
+  },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },
 })
 
@@ -245,6 +269,9 @@ Partial<AdditionalSdfDeployDependencies>
     features: { refType: new ListType(BuiltinTypes.STRING) },
     objects: { refType: new ListType(BuiltinTypes.STRING) },
   },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+  },
 })
 
 const additionalDependenciesType = createMatchingObjectType<
@@ -255,6 +282,9 @@ DeployParams['additionalDependencies']
     include: { refType: additionalDependenciesInnerType },
     exclude: { refType: additionalDependenciesInnerType },
   },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+  },
 })
 
 const deployConfigType = createMatchingObjectType<DeployParams>({
@@ -264,6 +294,9 @@ const deployConfigType = createMatchingObjectType<DeployParams>({
     [VALIDATE]: { refType: BuiltinTypes.BOOLEAN },
     [DEPLOY_REFERENCED_ELEMENTS]: { refType: BuiltinTypes.BOOLEAN },
     [ADDITIONAL_DEPS]: { refType: additionalDependenciesType },
+  },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },
 })
 
@@ -354,6 +387,9 @@ export const configType = new ObjectType({
     [USE_CHANGES_DETECTION]: {
       refType: BuiltinTypes.BOOLEAN,
     },
+  },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },
 })
 

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -115,6 +115,9 @@ const objectIdSettings = new ObjectType({
       },
     },
   } as Record<keyof ObjectIdSettings, FieldDefinition>,
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+  },
 })
 
 const saltoIDSettingsType = new ObjectType({
@@ -130,6 +133,9 @@ const saltoIDSettingsType = new ObjectType({
       refType: new ListType(objectIdSettings),
     },
   } as Record<keyof SaltoIDSettings, FieldDefinition>,
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+  },
 })
 
 export type DataManagementConfig = {
@@ -372,6 +378,9 @@ const dataManagementType = new ObjectType({
       },
     },
   } as Record<keyof DataManagementConfig, FieldDefinition>,
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+  },
 })
 
 const clientPollingConfigType = new ObjectType({
@@ -381,6 +390,9 @@ const clientPollingConfigType = new ObjectType({
     deployTimeout: { refType: BuiltinTypes.NUMBER },
     fetchTimeout: { refType: BuiltinTypes.NUMBER },
   } as Record<keyof ClientPollingConfig, FieldDefinition>,
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+  },
 })
 
 const clientDeployConfigType = new ObjectType({
@@ -401,6 +413,9 @@ const clientDeployConfigType = new ObjectType({
     runTests: { refType: new ListType(BuiltinTypes.STRING) },
     deleteBeforeUpdate: { refType: BuiltinTypes.BOOLEAN },
   } as Record<keyof ClientDeployConfig, FieldDefinition>,
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+  },
 })
 
 const clientRateLimitConfigType = new ObjectType({
@@ -415,6 +430,9 @@ const clientRateLimitConfigType = new ObjectType({
     deploy: { refType: BuiltinTypes.NUMBER },
 
   } as Record<keyof ClientRateLimitConfig, FieldDefinition>,
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+  },
 })
 
 const clientRetryConfigType = new ObjectType({
@@ -432,6 +450,9 @@ const clientRetryConfigType = new ObjectType({
     },
     timeout: { refType: BuiltinTypes.NUMBER },
   } as Record<keyof ClientRetryConfig, FieldDefinition>,
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+  },
 })
 
 const readMetadataChunkSizeConfigType = createMatchingObjectType<ReadMetadataChunkSizeConfig>({
@@ -442,6 +463,9 @@ const readMetadataChunkSizeConfigType = createMatchingObjectType<ReadMetadataChu
       refType: new MapType(BuiltinTypes.NUMBER),
       annotations: { [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ min: 1, max: 10 }) },
     },
+  },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },
 })
 
@@ -454,6 +478,9 @@ const clientConfigType = new ObjectType({
     maxConcurrentApiRequests: { refType: clientRateLimitConfigType },
     readMetadataChunkSize: { refType: readMetadataChunkSizeConfigType },
   } as Record<keyof SalesforceClientConfig, FieldDefinition>,
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+  },
 })
 
 const metadataQueryType = new ObjectType({
@@ -462,6 +489,9 @@ const metadataQueryType = new ObjectType({
     [METADATA_TYPE]: { refType: BuiltinTypes.STRING },
     [METADATA_NAMESPACE]: { refType: BuiltinTypes.STRING },
     [METADATA_NAME]: { refType: BuiltinTypes.STRING },
+  },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },
 })
 
@@ -479,6 +509,9 @@ const metadataConfigType = createMatchingObjectType<MetadataParams>({
       },
     },
   },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+  },
 })
 
 const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
@@ -489,6 +522,9 @@ const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
     profilePaths: { refType: BuiltinTypes.BOOLEAN },
     addMissingIds: { refType: BuiltinTypes.BOOLEAN },
     authorInformation: { refType: BuiltinTypes.BOOLEAN },
+  },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },
 })
 
@@ -508,6 +544,9 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     cpqValidator: { refType: BuiltinTypes.BOOLEAN },
     sbaaApprovalRulesCustomCondition: { refType: BuiltinTypes.BOOLEAN },
   },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+  },
 })
 
 const fetchConfigType = createMatchingObjectType<FetchParameters>({
@@ -518,6 +557,9 @@ const fetchConfigType = createMatchingObjectType<FetchParameters>({
     optionalFeatures: { refType: optionalFeaturesType },
     fetchAllCustomSettings: { refType: BuiltinTypes.BOOLEAN },
     target: { refType: new ListType(BuiltinTypes.STRING) },
+  },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },
 })
 
@@ -591,5 +633,8 @@ export const configType = createMatchingObjectType<SalesforceConfig>({
     validators: {
       refType: changeValidatorConfigType,
     },
+  },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },
 })

--- a/packages/stripe-adapter/src/config.ts
+++ b/packages/stripe-adapter/src/config.ts
@@ -150,6 +150,7 @@ export const configType = createMatchingObjectType<Partial<StripeConfig>>({
   },
   annotations: {
     [CORE_ANNOTATIONS.DEFAULT]: _.omit(DEFAULT_CONFIG, API_DEFINITIONS_CONFIG),
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },
 })
 

--- a/packages/workato-adapter/src/config.ts
+++ b/packages/workato-adapter/src/config.ts
@@ -247,6 +247,7 @@ export const configType = new ObjectType({
     [CORE_ANNOTATIONS.DEFAULT]: _.omit(
       DEFAULT_CONFIG, API_DEFINITIONS_CONFIG, `${FETCH_CONFIG}.hideTypes`
     ),
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },
 })
 

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -1860,6 +1860,9 @@ const IdLocatorType = createMatchingObjectType<IdLocator>({
       },
     },
   },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+  },
 })
 
 export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
@@ -1892,6 +1895,7 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
       `${FETCH_CONFIG}.enableMissingReferences`,
       `${FETCH_CONFIG}.enableGuide`,
     ),
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },
 })
 


### PR DESCRIPTION
Added _additional_properties = false to all configuration types (hopefully...)
Also fixed several configurations that were not defined in the types, and configuration documentation files that contained errors.
To check this I added additional properties in all adapter configuration files (only at the top level), and also added all available apiDefinitions (when apiDefinitions were not available I added the config from the config_doc)

---

_Additional context for reviewer_

---
_Release Notes_: 
Core:
Unexpected values in adapter NaCl's will cause validation warnings. It will help avoiding typing errors.

---
_User Notifications_: 
None