### PR TITLE
SALTO-2629: inconsistent order in instances in Jira

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/workflow.ts
+++ b/packages/jira-adapter/e2e_test/instances/workflow.ts
@@ -29,16 +29,16 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
       rules: {
         triggers: [
           {
+            key: 'com.atlassian.jira.plugins.jira-development-integration-plugin:branch-created-trigger',
+          },
+          {
             key: 'com.atlassian.jira.plugins.jira-development-integration-plugin:commit-created-trigger',
           },
           {
-            key: 'com.atlassian.jira.plugins.jira-development-integration-plugin:review-closed-trigger',
+            key: 'com.atlassian.jira.plugins.jira-development-integration-plugin:pull-request-created-trigger',
           },
           {
             key: 'com.atlassian.jira.plugins.jira-development-integration-plugin:pull-request-declined-trigger',
-          },
-          {
-            key: 'com.atlassian.jira.plugins.jira-development-integration-plugin:pull-request-created-trigger',
           },
           {
             key: 'com.atlassian.jira.plugins.jira-development-integration-plugin:pull-request-merged-trigger',
@@ -47,19 +47,19 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
             key: 'com.atlassian.jira.plugins.jira-development-integration-plugin:pull-request-reopened-trigger',
           },
           {
-            key: 'com.atlassian.jira.plugins.jira-development-integration-plugin:branch-created-trigger',
-          },
-          {
-            key: 'com.atlassian.jira.plugins.jira-development-integration-plugin:review-started-trigger',
-          },
-          {
             key: 'com.atlassian.jira.plugins.jira-development-integration-plugin:review-abandoned-trigger',
           },
           {
             key: 'com.atlassian.jira.plugins.jira-development-integration-plugin:review-approval-trigger',
           },
           {
+            key: 'com.atlassian.jira.plugins.jira-development-integration-plugin:review-closed-trigger',
+          },
+          {
             key: 'com.atlassian.jira.plugins.jira-development-integration-plugin:review-rejected-trigger',
+          },
+          {
+            key: 'com.atlassian.jira.plugins.jira-development-integration-plugin:review-started-trigger',
           },
           {
             key: 'com.atlassian.jira.plugins.jira-development-integration-plugin:review-summarized-trigger',
@@ -93,26 +93,18 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
         ],
         postFunctions: [
           {
-            type: 'UpdateIssueFieldFunction',
-            configuration: {
-              fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Assignee'), allElements),
-              fieldValue: '',
-            },
+            type: 'AssignToCurrentUserFunction',
           },
           {
-            type: 'UpdateIssueCustomFieldPostFunction',
-            configuration: {
-              mode: 'replace',
-              fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Created'), allElements),
-              fieldValue: 'ww',
-            },
+            type: 'AssignToLeadFunction',
           },
           {
-            type: 'SetIssueSecurityFromRoleFunction',
+            type: 'AssignToReporterFunction',
+          },
+          {
+            type: 'ClearFieldValuePostFunction',
             configuration: {
-              projectRole: {
-                id: createReference(new ElemID(JIRA, 'ProjectRole', 'instance', 'Administrators'), allElements),
-              },
+              fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Environment'), allElements),
             },
           },
           {
@@ -124,28 +116,7 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
             },
           },
           {
-            type: 'ClearFieldValuePostFunction',
-            configuration: {
-              fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Environment'), allElements),
-            },
-          },
-          {
-            type: 'UpdateIssueStatusFunction',
-          },
-          {
-            type: 'AssignToCurrentUserFunction',
-          },
-          {
-            type: 'AssignToLeadFunction',
-          },
-          {
-            type: 'AssignToReporterFunction',
-          },
-          {
             type: 'CreateCommentFunction',
-          },
-          {
-            type: 'IssueStoreFunction',
           },
           {
             type: 'FireIssueEventFunction',
@@ -154,6 +125,35 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
                 id: createReference(new ElemID(JIRA, 'IssueEvent', 'instance', 'Issue_Assigned@s'), allElements),
               },
             },
+          },
+          {
+            type: 'IssueStoreFunction',
+          },
+          {
+            type: 'SetIssueSecurityFromRoleFunction',
+            configuration: {
+              projectRole: {
+                id: createReference(new ElemID(JIRA, 'ProjectRole', 'instance', 'Administrators'), allElements),
+              },
+            },
+          },
+          {
+            type: 'UpdateIssueCustomFieldPostFunction',
+            configuration: {
+              mode: 'replace',
+              fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Created'), allElements),
+              fieldValue: 'ww',
+            },
+          },
+          {
+            type: 'UpdateIssueFieldFunction',
+            configuration: {
+              fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Assignee'), allElements),
+              fieldValue: '',
+            },
+          },
+          {
+            type: 'UpdateIssueStatusFunction',
           },
         ],
       },
@@ -178,18 +178,27 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
             },
           },
           {
-            type: 'WindowsDateValidator',
+            type: 'FieldHasSingleValueValidator',
             configuration: {
-              date1: createReference(new ElemID(JIRA, 'Field', 'instance', 'Created'), allElements),
-              date2: createReference(new ElemID(JIRA, 'Field', 'instance', 'Created'), allElements),
-              windowsDays: 2,
+              fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Last_Viewed@s'), allElements),
+              excludeSubtasks: false,
             },
           },
           {
             type: 'FieldHasSingleValueValidator',
             configuration: {
-              fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Last_Viewed@s'), allElements),
-              excludeSubtasks: false,
+              fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Remaining_Estimate@s'), allElements),
+              excludeSubtasks: true,
+            },
+          },
+          {
+            type: 'FieldRequiredValidator',
+            configuration: {
+              ignoreContext: true,
+              errorMessage: 'wwww',
+              fieldIds: [
+                createReference(new ElemID(JIRA, 'Field', 'instance', 'Assignee'), allElements),
+              ],
             },
           },
           {
@@ -226,20 +235,11 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
             },
           },
           {
-            type: 'FieldRequiredValidator',
+            type: 'WindowsDateValidator',
             configuration: {
-              ignoreContext: true,
-              errorMessage: 'wwww',
-              fieldIds: [
-                createReference(new ElemID(JIRA, 'Field', 'instance', 'Assignee'), allElements),
-              ],
-            },
-          },
-          {
-            type: 'FieldHasSingleValueValidator',
-            configuration: {
-              fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Remaining_Estimate@s'), allElements),
-              excludeSubtasks: true,
+              date1: createReference(new ElemID(JIRA, 'Field', 'instance', 'Created'), allElements),
+              date2: createReference(new ElemID(JIRA, 'Field', 'instance', 'Created'), allElements),
+              windowsDays: 2,
             },
           },
         ],
@@ -257,6 +257,12 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
           operator: 'AND',
           conditions: [
             {
+              type: 'AllowOnlyAssignee',
+            },
+            {
+              type: 'AllowOnlyReporter',
+            },
+            {
               type: 'AlwaysFalseCondition',
             },
             {
@@ -266,16 +272,25 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
               type: 'BlockInProgressApprovalCondition',
             },
             {
-              type: 'RemoteOnlyCondition',
+              type: 'InAnyProjectRoleCondition',
+              configuration: {
+                projectRoles: [
+                  {
+                    id: createReference(new ElemID(JIRA, 'ProjectRole', 'instance', 'Administrators'), allElements),
+                  },
+                ],
+              },
             },
             {
-              type: 'AllowOnlyAssignee',
+              type: 'InProjectRoleCondition',
+              configuration: {
+                projectRole: {
+                  id: createReference(new ElemID(JIRA, 'ProjectRole', 'instance', 'Administrators'), allElements),
+                },
+              },
             },
             {
               type: 'OnlyBambooNotificationsCondition',
-            },
-            {
-              type: 'AllowOnlyReporter',
             },
             {
               type: 'PermissionCondition',
@@ -294,6 +309,9 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
                   id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'done'), allElements),
                 },
               },
+            },
+            {
+              type: 'RemoteOnlyCondition',
             },
             {
               type: 'SeparationOfDutiesCondition',
@@ -328,28 +346,10 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
               },
             },
             {
-              type: 'InAnyProjectRoleCondition',
-              configuration: {
-                projectRoles: [
-                  {
-                    id: createReference(new ElemID(JIRA, 'ProjectRole', 'instance', 'Administrators'), allElements),
-                  },
-                ],
-              },
-            },
-            {
               type: 'UserIsInCustomFieldCondition',
               configuration: {
                 allowUserInField: false,
                 fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Assignee'), allElements),
-              },
-            },
-            {
-              type: 'InProjectRoleCondition',
-              configuration: {
-                projectRole: {
-                  id: createReference(new ElemID(JIRA, 'ProjectRole', 'instance', 'Administrators'), allElements),
-                },
               },
             },
             {

--- a/packages/jira-adapter/src/filters/sort_lists.ts
+++ b/packages/jira-adapter/src/filters/sort_lists.ts
@@ -103,19 +103,6 @@ const sortLists = async (instance: InstanceElement): Promise<void> => {
       return value
     },
   }) ?? {}
-
-
-  Object.entries(VALUES_TO_SORT[instance.elemID.typeName] ?? {})
-    .forEach(([fieldName, sortBy]) => {
-      if (instance.value[fieldName] === undefined) {
-        return
-      }
-
-      instance.value[fieldName] = _.orderBy(
-        instance.value[fieldName],
-        sortBy.map(fieldPath => item => getValue(_.get(item, fieldPath))),
-      )
-    })
 }
 
 const filter: FilterCreator = () => ({

--- a/packages/jira-adapter/src/filters/sort_lists.ts
+++ b/packages/jira-adapter/src/filters/sort_lists.ts
@@ -17,7 +17,7 @@ import { InstanceElement, isInstanceElement, isReferenceExpression, Value } from
 import { transformValues } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
-import { AUTOMATION_TYPE, NOTIFICATION_EVENT_TYPE_NAME, WORKFLOW_TYPE_NAME } from '../constants'
+import { AUTOMATION_TYPE, NOTIFICATION_EVENT_TYPE_NAME, NOTIFICATION_SCHEME_TYPE_NAME, WORKFLOW_RULES_TYPE_NAME, WORKFLOW_TYPE_NAME } from '../constants'
 import { FilterCreator } from '../filter'
 
 const { awu } = collections.asynciterable
@@ -27,6 +27,12 @@ type ValueToSort = {
   fieldName: string
   sortBy: string[]
 }
+
+const WORKFLOW_CONDITION_SORT_BY = ['type', 'nodeType', 'operator', 'configuration.fieldId', 'configuration.comparator',
+  'configuration.fieldValue', 'configuration.permissionKey', 'configuration.ignoreLoopTransitions',
+  'configuration.includeCurrentStatus', 'configuration.mostRecentStatusOnly', 'configuration.reverseCondition',
+  'configuration.previousStatus.id', 'configuration.value', 'configuration.toStatus.id', 'configuration.fromStatus.id',
+  'configuration.group', 'configuration.allowUserInField', 'configuration.projectRole.id', 'configuration.comparisonType']
 
 const VALUES_TO_SORT: ValueToSort[] = [
   {
@@ -58,6 +64,46 @@ const VALUES_TO_SORT: ValueToSort[] = [
     typeName: NOTIFICATION_EVENT_TYPE_NAME,
     fieldName: 'notifications',
     sortBy: ['type', 'parameter.elemID.name', 'parameter'],
+  },
+  {
+    typeName: 'FieldConfigurationScheme',
+    fieldName: 'items',
+    sortBy: ['issueTypeId', 'fieldConfigurationId'],
+  },
+  {
+    typeName: NOTIFICATION_SCHEME_TYPE_NAME,
+    fieldName: 'notificationSchemeEvents',
+    sortBy: ['eventType'],
+  },
+  {
+    typeName: WORKFLOW_RULES_TYPE_NAME,
+    fieldName: 'postFunctions',
+    sortBy: ['type', 'configuration.event.id', 'configuration.fieldId', 'configuration.sourceFieldId', 'configuration.destinationFieldId',
+      'configuration.copyType', 'configuration.projectRole.id', 'configuration.issueSecurityLevel.id', 'configuration.webhook.id',
+      'configuration.mode', 'configuration.fieldValue', 'configuration.value'],
+  },
+  {
+    typeName: WORKFLOW_RULES_TYPE_NAME,
+    fieldName: 'validators',
+    sortBy: ['type', 'configuration.comparator', 'configuration.date1', 'configuration.date2', 'configuration.expression',
+      'configuration.includeTime', 'configuration.windowsDays', 'configuration.ignoreContext', 'configuration.errorMessage',
+      'configuration.fieldId', 'configuration.excludeSubtasks', 'configuration.permissionKey', 'configuration.mostRecentStatusOnly',
+      'configuration.previousStatus.id', 'configuration.nullAllowed', 'configuration.username'],
+  },
+  {
+    typeName: WORKFLOW_RULES_TYPE_NAME,
+    fieldName: 'conditions',
+    sortBy: WORKFLOW_CONDITION_SORT_BY,
+  },
+  {
+    typeName: WORKFLOW_RULES_TYPE_NAME,
+    fieldName: 'triggers',
+    sortBy: ['key'],
+  },
+  {
+    typeName: 'WorkflowCondition',
+    fieldName: 'conditions',
+    sortBy: WORKFLOW_CONDITION_SORT_BY,
   },
 ]
 


### PR DESCRIPTION
Added sort to values in `NotificationScheme`, `FieldConfigurationScheme` and `Workflow`

---
_Release Notes_: 
_Jira Adapter_:
- Fixed order inconsistency in different environments in `NotificationScheme`, `FieldConfigurationScheme` and `Workflow`

---
_User Notifications_: 
_Jira Adapter_:
- The order of values in `NotificationScheme`, `FieldConfigurationScheme` and `Workflow` might change after the next fetch