### PR TITLE
SALTO-2637 Add missing references for brand and group fields to automation, macro and view types + omit Zendesk missing references conversion for fixed values

### DIFF
--- a/packages/zendesk-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-adapter/src/filters/field_references.ts
@@ -725,9 +725,15 @@ const commonFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[] = [
     src: {
       field: 'value',
       parentTypes: [
+        'automation__actions',
+        'automation__conditions__all',
+        'automation__conditions__any',
+        'macro__actions',
         'trigger__actions',
         'trigger__conditions__all',
         'trigger__conditions__any',
+        'view__conditions__all',
+        'view__conditions__any',
       ],
     },
     target: { typeContext: 'allowlistedNeighborField' },

--- a/packages/zendesk-adapter/src/filters/references/missing_references.ts
+++ b/packages/zendesk-adapter/src/filters/references/missing_references.ts
@@ -20,12 +20,17 @@ import { references as referenceUtils } from '@salto-io/adapter-components'
 import { naclCase } from '@salto-io/adapter-utils'
 
 const MISSING_REF_PREFIX = 'missing_'
+
+const TYPE_VALUES_SKIP_LIST: Record<string, string> = {
+  group: 'current_groups',
+}
+
 export const ZendeskMissingReferenceStrategyLookup: Record<
 referenceUtils.MissingReferenceStrategyName, referenceUtils.MissingReferenceStrategy
 > = {
   typeAndValue: {
     create: ({ value, adapter, typeName }) => {
-      if (!_.isString(typeName) || !value) {
+      if (!_.isString(typeName) || !value || TYPE_VALUES_SKIP_LIST[typeName] === value) {
         return undefined
       }
       return new InstanceElement(

--- a/packages/zendesk-adapter/src/filters/references/missing_references.ts
+++ b/packages/zendesk-adapter/src/filters/references/missing_references.ts
@@ -21,7 +21,7 @@ import { naclCase } from '@salto-io/adapter-utils'
 
 const MISSING_REF_PREFIX = 'missing_'
 
-const SKIP_TYPES_AND_FIELD_NAMES: Record<string, string> = {
+const VALUES_TO_SKIP_BY_TYPE: Record<string, string> = {
   group: 'current_groups',
 }
 
@@ -30,7 +30,7 @@ referenceUtils.MissingReferenceStrategyName, referenceUtils.MissingReferenceStra
 > = {
   typeAndValue: {
     create: ({ value, adapter, typeName }) => {
-      if (!_.isString(typeName) || !value || SKIP_TYPES_AND_FIELD_NAMES[typeName] === value) {
+      if (!_.isString(typeName) || !value || VALUES_TO_SKIP_BY_TYPE[typeName] === value) {
         return undefined
       }
       return new InstanceElement(

--- a/packages/zendesk-adapter/src/filters/references/missing_references.ts
+++ b/packages/zendesk-adapter/src/filters/references/missing_references.ts
@@ -21,7 +21,7 @@ import { naclCase } from '@salto-io/adapter-utils'
 
 const MISSING_REF_PREFIX = 'missing_'
 
-const TYPE_VALUES_SKIP_LIST: Record<string, string> = {
+const SKIP_TYPES_AND_FIELD_NAMES: Record<string, string> = {
   group: 'current_groups',
 }
 
@@ -30,7 +30,7 @@ referenceUtils.MissingReferenceStrategyName, referenceUtils.MissingReferenceStra
 > = {
   typeAndValue: {
     create: ({ value, adapter, typeName }) => {
-      if (!_.isString(typeName) || !value || TYPE_VALUES_SKIP_LIST[typeName] === value) {
+      if (!_.isString(typeName) || !value || SKIP_TYPES_AND_FIELD_NAMES[typeName] === value) {
         return undefined
       }
       return new InstanceElement(

--- a/packages/zendesk-adapter/test/filters/field_references.test.ts
+++ b/packages/zendesk-adapter/test/filters/field_references.test.ts
@@ -308,6 +308,7 @@ describe('References by id filter', () => {
             { field: 'brand_id', operator: 'is', value: 'you_like_crazy' },
             { field: 'group_id', operator: 'is', value: 'a_thing' },
             { field: 'schedule_id', operator: 'is', value: 'someone_you_love' },
+            { field: 'group_id', operator: 'is', value: 'current_groups' },
           ],
         },
       },
@@ -437,6 +438,8 @@ describe('References by id filter', () => {
         expect(brokenTrigger.value.conditions.all[4].value).toBeInstanceOf(ReferenceExpression)
         expect(brokenTrigger.value.conditions.all[4].value.elemID.name)
           .toEqual('missing_someone_you_love')
+        expect(brokenTrigger.value.conditions.all[5].value).not.toBeInstanceOf(ReferenceExpression)
+        expect(brokenTrigger.value.conditions.all[5].value).toEqual('current_groups')
       })
       it('should not create missing references if enable missing references is false', async () => {
         const newFilter = filterCreator({


### PR DESCRIPTION
Add missing references for brand and group fields to automation, macro and view types.
Plus, there are fixed values for some types, which don't point to any instance directly (such as "all the user's groups"). This PR support a skip list for some of the values when converting to missing references.

To Do:

- [x] Add UT

---

_Additional context for reviewer_

---
_Release Notes_: 
* Add missing references for brand, schedule and group fields to automation, macro and view types

---
_User Notifications_: 
* Missing references will be add to more types
