### PR TITLE
SALTO-2638: Omit the subscriptions field in Jira filters

### DIFF
--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -476,6 +476,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       ],
       fieldsToOmit: [
         { fieldName: 'expand' },
+        { fieldName: 'subscriptions' },
       ],
       serviceUrl: '/issues/?filter={id}',
     },


### PR DESCRIPTION
_Omit the subscriptions field in Jira filters_


---
_Release Notes_: 
_Jira_
* filters 'subscriptions' field won't appear in the filter's NaCl any more 

---
_User Notifications_: 
_Jira_
* filters 'subscriptions' field won't appear in the filter's NaCl any more 

