### PR TITLE
SALTO-2635: Make the Jira addTypeToFieldName option True by default

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/board.ts
+++ b/packages/jira-adapter/e2e_test/instances/board.ts
@@ -65,7 +65,7 @@ export const createScrumBoardValues = (name: string, allElements: Element[]): Va
     ],
   },
   estimation: {
-    field: createReference(new ElemID(JIRA, 'Field', 'instance', 'Original_estimate@s'), allElements),
-    timeTracking: createReference(new ElemID(JIRA, 'Field', 'instance', 'Remaining_Estimate@s'), allElements),
+    field: createReference(new ElemID(JIRA, 'Field', 'instance', 'Original_estimate__number@suu'), allElements),
+    timeTracking: createReference(new ElemID(JIRA, 'Field', 'instance', 'Remaining_Estimate__number@suu'), allElements),
   },
 })

--- a/packages/jira-adapter/e2e_test/instances/fieldConfiguration.ts
+++ b/packages/jira-adapter/e2e_test/instances/fieldConfiguration.ts
@@ -27,7 +27,7 @@ export const createFieldConfigurationValues = (
 export const createFieldConfigurationItemValues = (
   allElements: Element[],
 ): Values => ({
-  id: createReference(new ElemID(JIRA, 'Field', 'instance', 'Assignee'), allElements),
+  id: createReference(new ElemID(JIRA, 'Field', 'instance', 'Assignee__user'), allElements),
   description: 'For example operating system, software platform and/or hardware specifications (include as appropriate for the issue).',
   isHidden: false,
   isRequired: false,

--- a/packages/jira-adapter/e2e_test/instances/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/index.ts
@@ -48,12 +48,12 @@ export const createInstances = (fetchedElements: Element[]): InstanceElement[][]
   )
 
   const field = new InstanceElement(
-    `${randomString}__${CUSTOM_FIELDS_SUFFIX}`,
+    `${randomString}__cascadingselect__${CUSTOM_FIELDS_SUFFIX}`,
     findType('Field', fetchedElements),
     createFieldValues(randomString),
   )
 
-  const fieldContextName = naclCase(`${randomString}__${CUSTOM_FIELDS_SUFFIX}_${randomString}`)
+  const fieldContextName = naclCase(`${randomString}__cascadingselect__${CUSTOM_FIELDS_SUFFIX}_${randomString}`)
   const fieldContext = new InstanceElement(
     fieldContextName,
     findType('CustomFieldContext', fetchedElements),
@@ -179,7 +179,7 @@ export const createInstances = (fetchedElements: Element[]): InstanceElement[][]
   )
 
   const fieldConfigurationItem = new InstanceElement(
-    `${randomString}_Assignee`,
+    `${randomString}_Assignee__user`,
     findType('FieldConfigurationItem', fetchedElements),
     createFieldConfigurationItemValues(fetchedElements),
     undefined,

--- a/packages/jira-adapter/e2e_test/instances/screen.ts
+++ b/packages/jira-adapter/e2e_test/instances/screen.ts
@@ -28,15 +28,15 @@ export const createScreenValues = (name: string, allElements: Element[]): Values
     'Field_Tab@s': {
       name: 'Field Tab',
       fields: [
-        createReference(new ElemID(JIRA, 'Field', 'instance', 'Assignee'), allElements),
+        createReference(new ElemID(JIRA, 'Field', 'instance', 'Assignee__user'), allElements),
       ],
       position: 2,
     },
     tab3: {
       name: 'tab3',
       fields: [
-        createReference(new ElemID(JIRA, 'Field', 'instance', 'Created'), allElements),
-        createReference(new ElemID(JIRA, 'Field', 'instance', 'Creator'), allElements),
+        createReference(new ElemID(JIRA, 'Field', 'instance', 'Created__datetime'), allElements),
+        createReference(new ElemID(JIRA, 'Field', 'instance', 'Creator__user'), allElements),
       ],
       position: 1,
     },

--- a/packages/jira-adapter/e2e_test/instances/securityScheme.ts
+++ b/packages/jira-adapter/e2e_test/instances/securityScheme.ts
@@ -53,7 +53,7 @@ export const createSecurityLevelValues = (name: string, allElements: Element[]):
     {
       holder: {
         type: 'groupCustomField',
-        parameter: createReference(new ElemID(JIRA, FIELD_TYPE_NAME, 'instance', 'Impact__c'), allElements),
+        parameter: createReference(new ElemID(JIRA, FIELD_TYPE_NAME, 'instance', 'Impact__select__c'), allElements),
       },
     },
     {

--- a/packages/jira-adapter/e2e_test/instances/workflow.ts
+++ b/packages/jira-adapter/e2e_test/instances/workflow.ts
@@ -104,14 +104,14 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
           {
             type: 'ClearFieldValuePostFunction',
             configuration: {
-              fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Environment'), allElements),
+              fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Environment__string'), allElements),
             },
           },
           {
             type: 'CopyValueFromOtherFieldPostFunction',
             configuration: {
-              sourceFieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Assignee'), allElements),
-              destinationFieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Creator'), allElements),
+              sourceFieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Assignee__user'), allElements),
+              destinationFieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Creator__user'), allElements),
               copyType: 'parent',
             },
           },
@@ -141,14 +141,14 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
             type: 'UpdateIssueCustomFieldPostFunction',
             configuration: {
               mode: 'replace',
-              fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Created'), allElements),
+              fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Created__datetime'), allElements),
               fieldValue: 'ww',
             },
           },
           {
             type: 'UpdateIssueFieldFunction',
             configuration: {
-              fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Assignee'), allElements),
+              fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Assignee__user'), allElements),
               fieldValue: '',
             },
           },
@@ -172,22 +172,22 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
             type: 'DateFieldValidator',
             configuration: {
               comparator: '>',
-              date1: createReference(new ElemID(JIRA, 'Field', 'instance', 'Created'), allElements),
-              date2: createReference(new ElemID(JIRA, 'Field', 'instance', 'Created'), allElements),
+              date1: createReference(new ElemID(JIRA, 'Field', 'instance', 'Created__datetime'), allElements),
+              date2: createReference(new ElemID(JIRA, 'Field', 'instance', 'Created__datetime'), allElements),
               includeTime: false,
             },
           },
           {
             type: 'FieldHasSingleValueValidator',
             configuration: {
-              fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Last_Viewed@s'), allElements),
+              fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Last_Viewed__datetime@suu'), allElements),
               excludeSubtasks: false,
             },
           },
           {
             type: 'FieldHasSingleValueValidator',
             configuration: {
-              fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Remaining_Estimate@s'), allElements),
+              fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Remaining_Estimate__number@suu'), allElements),
               excludeSubtasks: true,
             },
           },
@@ -197,7 +197,7 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
               ignoreContext: true,
               errorMessage: 'wwww',
               fieldIds: [
-                createReference(new ElemID(JIRA, 'Field', 'instance', 'Assignee'), allElements),
+                createReference(new ElemID(JIRA, 'Field', 'instance', 'Assignee__user'), allElements),
               ],
             },
           },
@@ -237,8 +237,8 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
           {
             type: 'WindowsDateValidator',
             configuration: {
-              date1: createReference(new ElemID(JIRA, 'Field', 'instance', 'Created'), allElements),
-              date2: createReference(new ElemID(JIRA, 'Field', 'instance', 'Created'), allElements),
+              date1: createReference(new ElemID(JIRA, 'Field', 'instance', 'Created__datetime'), allElements),
+              date2: createReference(new ElemID(JIRA, 'Field', 'instance', 'Created__datetime'), allElements),
               windowsDays: 2,
             },
           },
@@ -349,13 +349,13 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
               type: 'UserIsInCustomFieldCondition',
               configuration: {
                 allowUserInField: false,
-                fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Assignee'), allElements),
+                fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Assignee__user'), allElements),
               },
             },
             {
               type: 'ValueFieldCondition',
               configuration: {
-                fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Remaining_Estimate@s'), allElements),
+                fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Remaining_Estimate__number@suu'), allElements),
                 fieldValue: 'val',
                 comparisonType: 'STRING',
                 comparator: '>',

--- a/packages/jira-adapter/src/filters/fields/field_name_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/field_name_filter.ts
@@ -53,7 +53,7 @@ const getInstanceName = (
   const defaultName = naclCase(
     [
       baseName,
-      config.fetch.addTypeToFieldName ? getFieldType(instance) : undefined,
+      (config.fetch.addTypeToFieldName ?? true) ? getFieldType(instance) : undefined,
       isCustomField(instance) ? CUSTOM_FIELDS_SUFFIX : undefined,
     ].filter(values.isDefined).join('__')
   )

--- a/packages/jira-adapter/test/filters/fields/field_name_filter.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_name_filter.test.ts
@@ -33,6 +33,8 @@ describe('field_name_filter', () => {
 
     config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
 
+    config.fetch.addTypeToFieldName = false
+
     const { client, paginator } = mockClient()
     filter = fieldNameFilter(getFilterParams({
       client,
@@ -71,7 +73,7 @@ describe('field_name_filter', () => {
   })
 
   it('should add field type if configured to', async () => {
-    config.fetch.addTypeToFieldName = true
+    delete config.fetch.addTypeToFieldName
     const custom = new InstanceElement(
       'custom',
       fieldType,


### PR DESCRIPTION
Changed `addTypeToFieldName` default to true

---
_Release Notes_: 
_Jira Adapter_:
- The default of the configuration option `addTypeToFieldName` was changed to true

---
_User Notifications_: 
None