### PR TITLE
SALTO-2369 Fix lwc targetConfigs property type

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -144,11 +144,11 @@ export const allFilters: Array<LocalFilterCreatorDefinition | RemoteFilterCreato
   { creator: customMetadataTypeFilter },
   // The following filters should remain last in order to make sure they fix all elements
   { creator: convertListsFilter },
+  { creator: xmlAttributesFilter },
   { creator: convertTypeFilter },
   // should be after convertTypeFilter & convertMapsFilter and before profileInstanceSplitFilter
   { creator: enumFieldPermissionsFilter },
   // should run after convertListsFilter
-  { creator: xmlAttributesFilter },
   { creator: replaceFieldValuesFilter },
   { creator: valueToStaticFileFilter },
   { creator: fieldReferencesFilter },

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -142,9 +142,9 @@ export const allFilters: Array<LocalFilterCreatorDefinition | RemoteFilterCreato
   { creator: currencyIsoCodeFilter },
   { creator: splitCustomLabels },
   { creator: customMetadataTypeFilter },
+  { creator: xmlAttributesFilter },
   // The following filters should remain last in order to make sure they fix all elements
   { creator: convertListsFilter },
-  { creator: xmlAttributesFilter },
   { creator: convertTypeFilter },
   // should be after convertTypeFilter & convertMapsFilter and before profileInstanceSplitFilter
   { creator: enumFieldPermissionsFilter },


### PR DESCRIPTION
_SALTO-2369 Fix lwc targetConfogs property type_

---
_Additional context for reviewer_:
before the change in order, it would first attempt to cast `salesforce.LightningComponentBundle.instance.example.targetConfigs.targetConfig.0.property.0.required` field into boolean and only then remove the attribute_prefix but it wouldnt math the type so the casting didn't occurred.

---
_Release Notes_: 
Salesforce-adapter:

* Fix property.required field casting into boolean under LightningComponentBundle.targetConfigs
---

_User Notifications_: 
None
