### PR TITLE
SALTO-2424: fix quick fetch failure for accounts with different time formats

### DIFF
--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/custom_record_type.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/custom_record_type.ts
@@ -15,7 +15,7 @@
 * limitations under the License.
 */
 import { logger } from '@salto-io/logging'
-import { convertSuiteQLStringToDate } from '../date_formats'
+import { convertSuiteQLStringToDate, SUITEQL_DATE_FORMAT } from '../date_formats'
 import { ChangedObject, TypeChangesDetector } from '../types'
 
 const log = logger(module)
@@ -25,7 +25,7 @@ const changesDetector: TypeChangesDetector = {
     const [startDate, endDate] = dateRange.toSuiteQLRange()
 
     const results = await client.runSuiteQL(`
-        SELECT scriptid, TO_CHAR(lastmodifieddate, 'MM-DD-YYYY') AS lastmodifieddate
+        SELECT scriptid, TO_CHAR(lastmodifieddate, '${SUITEQL_DATE_FORMAT}') AS lastmodifieddate
         FROM customrecordtype
         WHERE lastmodifieddate BETWEEN ${startDate} AND ${endDate}
         ORDER BY scriptid ASC

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/custom_record_type.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/custom_record_type.ts
@@ -25,9 +25,9 @@ const changesDetector: TypeChangesDetector = {
     const [startDate, endDate] = dateRange.toSuiteQLRange()
 
     const results = await client.runSuiteQL(`
-        SELECT scriptid, lastmodifieddate
+        SELECT scriptid, TO_CHAR(lastmodifieddate, 'MM-DD-YYYY') AS lastmodifieddate
         FROM customrecordtype
-        WHERE lastmodifieddate BETWEEN '${startDate}' AND '${endDate}'
+        WHERE lastmodifieddate BETWEEN ${startDate} AND ${endDate}
         ORDER BY scriptid ASC
       `)
 

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/custom_type.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/custom_type.ts
@@ -16,7 +16,7 @@
 import { logger } from '@salto-io/logging'
 import { FIELD_TYPES } from '../../types'
 import NetsuiteClient from '../../client/client'
-import { convertSuiteQLStringToDate } from '../date_formats'
+import { convertSuiteQLStringToDate, SUITEQL_DATE_FORMAT } from '../date_formats'
 import { ChangedObject, DateRange, TypeChangesDetector } from '../types'
 
 const log = logger(module)
@@ -26,7 +26,7 @@ const getChanges = async (type: string, client: NetsuiteClient, dateRange: DateR
   const [startDate, endDate] = dateRange.toSuiteQLRange()
 
   const results = await client.runSuiteQL(`
-      SELECT scriptid, TO_CHAR(lastmodifieddate, 'MM-DD-YYYY') AS lastmodifieddate
+      SELECT scriptid, TO_CHAR(lastmodifieddate, '${SUITEQL_DATE_FORMAT}') AS lastmodifieddate
       FROM ${type}
       WHERE lastmodifieddate BETWEEN ${startDate} AND ${endDate}
       ORDER BY scriptid ASC

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/custom_type.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/custom_type.ts
@@ -26,9 +26,9 @@ const getChanges = async (type: string, client: NetsuiteClient, dateRange: DateR
   const [startDate, endDate] = dateRange.toSuiteQLRange()
 
   const results = await client.runSuiteQL(`
-      SELECT scriptid, lastmodifieddate
+      SELECT scriptid, TO_CHAR(lastmodifieddate, 'MM-DD-YYYY') AS lastmodifieddate
       FROM ${type}
-      WHERE lastmodifieddate BETWEEN '${startDate}' AND '${endDate}'
+      WHERE lastmodifieddate BETWEEN ${startDate} AND ${endDate}
       ORDER BY scriptid ASC
     `)
 

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/file_cabinet.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/file_cabinet.ts
@@ -27,7 +27,7 @@ export const getChangedFiles: FileCabinetChangesDetector = async (client, dateRa
     SELECT mediaitemfolder.appfolder, file.name, file.id
     FROM file
     JOIN mediaitemfolder ON mediaitemfolder.id = file.folder
-    WHERE file.lastmodifieddate BETWEEN '${startDate}' AND '${endDate}'
+    WHERE file.lastmodifieddate BETWEEN ${startDate} AND ${endDate}
     ORDER BY file.id ASC
   `)
 
@@ -56,7 +56,7 @@ export const getChangedFolders: FileCabinetChangesDetector = async (client, date
   const results = await client.runSuiteQL(`
     SELECT appfolder, id
     FROM mediaitemfolder
-    WHERE lastmodifieddate BETWEEN '${startDate}' AND '${endDate}'
+    WHERE lastmodifieddate BETWEEN ${startDate} AND ${endDate}
     ORDER BY id ASC
   `)
 

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/role.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/role.ts
@@ -90,7 +90,7 @@ const changesDetector: TypeChangesDetector = {
       SELECT role.scriptid, role.id
       FROM role
       JOIN systemnote ON systemnote.recordid = role.id
-      WHERE systemnote.date BETWEEN '${startDate}' AND '${endDate}' AND systemnote.recordtypeid = -118
+      WHERE systemnote.date BETWEEN ${startDate} AND ${endDate} AND systemnote.recordtypeid = -118
       ORDER BY role.id ASC
     `)
 

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/script.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/script.ts
@@ -56,7 +56,7 @@ const changesDetector: TypeChangesDetector = {
       SELECT script.scriptid, script.id
       FROM script
       JOIN systemnote ON systemnote.recordid = script.id
-      WHERE systemnote.date BETWEEN '${startDate}' AND '${endDate}' AND systemnote.recordtypeid = -417
+      WHERE systemnote.date BETWEEN ${startDate} AND ${endDate} AND systemnote.recordtypeid = -417
       ORDER BY script.id ASC
     `)
 
@@ -65,14 +65,14 @@ const changesDetector: TypeChangesDetector = {
       FROM scriptdeployment 
       JOIN systemnote ON systemnote.recordid = scriptdeployment.primarykey
       JOIN script ON scriptdeployment.script = script.id
-      WHERE systemnote.date BETWEEN '${startDate}' AND '${endDate}' AND systemnote.recordtypeid = -418
+      WHERE systemnote.date BETWEEN ${startDate} AND ${endDate} AND systemnote.recordtypeid = -418
       ORDER BY scriptdeployment.primarykey ASC
     `)
 
     const scriptFieldsChangesPromise = client.runSuiteQL(`
       SELECT internalid
       FROM customfield
-      WHERE fieldtype = 'SCRIPT' AND lastmodifieddate BETWEEN '${startDate}' AND '${endDate}'
+      WHERE fieldtype = 'SCRIPT' AND lastmodifieddate BETWEEN ${startDate} AND ${endDate}
       ORDER BY internalid ASC
     `)
 

--- a/packages/netsuite-adapter/src/changes_detector/date_formats.ts
+++ b/packages/netsuite-adapter/src/changes_detector/date_formats.ts
@@ -21,7 +21,7 @@ const SAVED_SEARCH_DATE_PATTERN = /(?<month>\d+)\/(?<day>\d+)\/(?<year>\d+) (?<h
 
 const log = logger(module)
 
-const formatSuiteQLDate = (date: Date): string => `${date.getUTCMonth() + 1}/${date.getUTCDate()}/${date.getUTCFullYear()}`
+const formatSuiteQLDate = (date: Date): string => `TO_DATE('${date.getUTCMonth() + 1}/${date.getUTCDate()}/${date.getUTCFullYear()}', 'MM/DD/YYYY')`
 
 const formatSavedSearchDate = (date: Date): string => {
   const hour = date.getUTCHours() > 12 ? date.getUTCHours() - 12 : date.getUTCHours()

--- a/packages/netsuite-adapter/src/changes_detector/date_formats.ts
+++ b/packages/netsuite-adapter/src/changes_detector/date_formats.ts
@@ -18,10 +18,10 @@ import { DateRange } from './types'
 
 const SUITEQL_DATE_PATTERN = /(?<month>\d+)\/(?<day>\d+)\/(?<year>\d+)/
 const SAVED_SEARCH_DATE_PATTERN = /(?<month>\d+)\/(?<day>\d+)\/(?<year>\d+) (?<hour>\d+):(?<minute>\d+) (?<ampm>\w+)/
-
+export const SUITEQL_DATE_FORMAT = 'MM/DD/YYYY'
 const log = logger(module)
 
-const formatSuiteQLDate = (date: Date): string => `TO_DATE('${date.getUTCMonth() + 1}/${date.getUTCDate()}/${date.getUTCFullYear()}', 'MM/DD/YYYY')`
+const formatSuiteQLDate = (date: Date): string => `TO_DATE('${date.getUTCMonth() + 1}/${date.getUTCDate()}/${date.getUTCFullYear()}', '${SUITEQL_DATE_FORMAT}')`
 
 const formatSavedSearchDate = (date: Date): string => {
   const hour = date.getUTCHours() > 12 ? date.getUTCHours() - 12 : date.getUTCHours()

--- a/packages/netsuite-adapter/test/changes_detector/custom_field.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/custom_field.test.ts
@@ -49,9 +49,9 @@ describe('custom_field', () => {
 
     it('should make the right query', () => {
       expect(runSuiteQLMock).toHaveBeenCalledWith(`
-      SELECT scriptid, lastmodifieddate
+      SELECT scriptid, TO_CHAR(lastmodifieddate, 'MM-DD-YYYY') AS lastmodifieddate
       FROM customfield
-      WHERE lastmodifieddate BETWEEN '1/11/2021' AND '2/23/2021'
+      WHERE lastmodifieddate BETWEEN TO_DATE('1/11/2021', 'MM/DD/YYYY') AND TO_DATE('2/23/2021', 'MM/DD/YYYY')
       ORDER BY scriptid ASC
     `)
     })

--- a/packages/netsuite-adapter/test/changes_detector/custom_field.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/custom_field.test.ts
@@ -49,7 +49,7 @@ describe('custom_field', () => {
 
     it('should make the right query', () => {
       expect(runSuiteQLMock).toHaveBeenCalledWith(`
-      SELECT scriptid, TO_CHAR(lastmodifieddate, 'MM-DD-YYYY') AS lastmodifieddate
+      SELECT scriptid, TO_CHAR(lastmodifieddate, 'MM/DD/YYYY') AS lastmodifieddate
       FROM customfield
       WHERE lastmodifieddate BETWEEN TO_DATE('1/11/2021', 'MM/DD/YYYY') AND TO_DATE('2/23/2021', 'MM/DD/YYYY')
       ORDER BY scriptid ASC

--- a/packages/netsuite-adapter/test/changes_detector/custom_list.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/custom_list.test.ts
@@ -50,7 +50,7 @@ describe('custom_list', () => {
 
     it('should make the right query', () => {
       expect(runSuiteQLMock).toHaveBeenCalledWith(`
-      SELECT scriptid, TO_CHAR(lastmodifieddate, 'MM-DD-YYYY') AS lastmodifieddate
+      SELECT scriptid, TO_CHAR(lastmodifieddate, 'MM/DD/YYYY') AS lastmodifieddate
       FROM customlist
       WHERE lastmodifieddate BETWEEN TO_DATE('1/11/2021', 'MM/DD/YYYY') AND TO_DATE('2/23/2021', 'MM/DD/YYYY')
       ORDER BY scriptid ASC

--- a/packages/netsuite-adapter/test/changes_detector/custom_list.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/custom_list.test.ts
@@ -50,9 +50,9 @@ describe('custom_list', () => {
 
     it('should make the right query', () => {
       expect(runSuiteQLMock).toHaveBeenCalledWith(`
-      SELECT scriptid, lastmodifieddate
+      SELECT scriptid, TO_CHAR(lastmodifieddate, 'MM-DD-YYYY') AS lastmodifieddate
       FROM customlist
-      WHERE lastmodifieddate BETWEEN '1/11/2021' AND '2/23/2021'
+      WHERE lastmodifieddate BETWEEN TO_DATE('1/11/2021', 'MM/DD/YYYY') AND TO_DATE('2/23/2021', 'MM/DD/YYYY')
       ORDER BY scriptid ASC
     `)
     })

--- a/packages/netsuite-adapter/test/changes_detector/custom_record_type.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/custom_record_type.test.ts
@@ -52,7 +52,7 @@ describe('custom_record_type', () => {
 
     it('should make the right query', () => {
       expect(runSuiteQLMock).toHaveBeenCalledWith(`
-        SELECT scriptid, TO_CHAR(lastmodifieddate, 'MM-DD-YYYY') AS lastmodifieddate
+        SELECT scriptid, TO_CHAR(lastmodifieddate, 'MM/DD/YYYY') AS lastmodifieddate
         FROM customrecordtype
         WHERE lastmodifieddate BETWEEN TO_DATE('1/11/2021', 'MM/DD/YYYY') AND TO_DATE('2/23/2021', 'MM/DD/YYYY')
         ORDER BY scriptid ASC

--- a/packages/netsuite-adapter/test/changes_detector/custom_record_type.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/custom_record_type.test.ts
@@ -52,9 +52,9 @@ describe('custom_record_type', () => {
 
     it('should make the right query', () => {
       expect(runSuiteQLMock).toHaveBeenCalledWith(`
-        SELECT scriptid, lastmodifieddate
+        SELECT scriptid, TO_CHAR(lastmodifieddate, 'MM-DD-YYYY') AS lastmodifieddate
         FROM customrecordtype
-        WHERE lastmodifieddate BETWEEN '1/11/2021' AND '2/23/2021'
+        WHERE lastmodifieddate BETWEEN TO_DATE('1/11/2021', 'MM/DD/YYYY') AND TO_DATE('2/23/2021', 'MM/DD/YYYY')
         ORDER BY scriptid ASC
       `)
     })

--- a/packages/netsuite-adapter/test/changes_detector/file_cabinet.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/file_cabinet.test.ts
@@ -50,7 +50,7 @@ describe('file_cabinet', () => {
     SELECT mediaitemfolder.appfolder, file.name, file.id
     FROM file
     JOIN mediaitemfolder ON mediaitemfolder.id = file.folder
-    WHERE file.lastmodifieddate BETWEEN '1/11/2021' AND '2/23/2021'
+    WHERE file.lastmodifieddate BETWEEN TO_DATE('1/11/2021', 'MM/DD/YYYY') AND TO_DATE('2/23/2021', 'MM/DD/YYYY')
     ORDER BY file.id ASC
   `)
       })
@@ -107,7 +107,7 @@ describe('file_cabinet', () => {
         expect(runSuiteQLMock).toHaveBeenCalledWith(`
     SELECT appfolder, id
     FROM mediaitemfolder
-    WHERE lastmodifieddate BETWEEN '1/11/2021' AND '2/23/2021'
+    WHERE lastmodifieddate BETWEEN TO_DATE('1/11/2021', 'MM/DD/YYYY') AND TO_DATE('2/23/2021', 'MM/DD/YYYY')
     ORDER BY id ASC
   `)
       })

--- a/packages/netsuite-adapter/test/changes_detector/role.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/role.test.ts
@@ -93,7 +93,7 @@ describe('role', () => {
       SELECT role.scriptid, role.id
       FROM role
       JOIN systemnote ON systemnote.recordid = role.id
-      WHERE systemnote.date BETWEEN '1/11/2021' AND '2/23/2021' AND systemnote.recordtypeid = -118
+      WHERE systemnote.date BETWEEN TO_DATE('1/11/2021', 'MM/DD/YYYY') AND TO_DATE('2/23/2021', 'MM/DD/YYYY') AND systemnote.recordtypeid = -118
       ORDER BY role.id ASC
     `)
 

--- a/packages/netsuite-adapter/test/changes_detector/script.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/script.test.ts
@@ -95,7 +95,7 @@ describe('script', () => {
       SELECT script.scriptid, script.id
       FROM script
       JOIN systemnote ON systemnote.recordid = script.id
-      WHERE systemnote.date BETWEEN '1/11/2021' AND '2/23/2021' AND systemnote.recordtypeid = -417
+      WHERE systemnote.date BETWEEN TO_DATE('1/11/2021', 'MM/DD/YYYY') AND TO_DATE('2/23/2021', 'MM/DD/YYYY') AND systemnote.recordtypeid = -417
       ORDER BY script.id ASC
     `)
 
@@ -104,14 +104,14 @@ describe('script', () => {
       FROM scriptdeployment 
       JOIN systemnote ON systemnote.recordid = scriptdeployment.primarykey
       JOIN script ON scriptdeployment.script = script.id
-      WHERE systemnote.date BETWEEN '1/11/2021' AND '2/23/2021' AND systemnote.recordtypeid = -418
+      WHERE systemnote.date BETWEEN TO_DATE('1/11/2021', 'MM/DD/YYYY') AND TO_DATE('2/23/2021', 'MM/DD/YYYY') AND systemnote.recordtypeid = -418
       ORDER BY scriptdeployment.primarykey ASC
     `)
 
       expect(runSuiteQLMock).toHaveBeenNthCalledWith(3, `
       SELECT internalid
       FROM customfield
-      WHERE fieldtype = 'SCRIPT' AND lastmodifieddate BETWEEN '1/11/2021' AND '2/23/2021'
+      WHERE fieldtype = 'SCRIPT' AND lastmodifieddate BETWEEN TO_DATE('1/11/2021', 'MM/DD/YYYY') AND TO_DATE('2/23/2021', 'MM/DD/YYYY')
       ORDER BY internalid ASC
     `)
     })


### PR DESCRIPTION
_suiteQL queries changed to support different time formats in user accounts_

---

_None_

---
_Release Notes_: 
_Netsuite Adapter_:
* Changed formatSuiteQLDate to use TO_DATE with MM/DD/YYYY date format
* Added TO_CHAR to lastmodifieddate to return it in the above date format

---
_User Notifications_: 
_None_
