### PR TITLE
SALTO-2648 Pass response header params to paginationFunc

### DIFF
--- a/packages/adapter-components/src/client/http_client.ts
+++ b/packages/adapter-components/src/client/http_client.ts
@@ -198,7 +198,7 @@ export abstract class AdapterHTTPClient<
         )
       log.debug('Received response for %s (%s) with status %d', url, safeJsonStringify({ url, queryParams }), res.status)
       log.trace('Full HTTP response for %s: %s', url, safeJsonStringify({
-        url, queryParams, response: res.data,
+        url, queryParams, response: res.data, headers: res.headers,
       }))
       const { data, status, headers: responseHeaders } = res
       return {

--- a/packages/adapter-components/src/client/http_client.ts
+++ b/packages/adapter-components/src/client/http_client.ts
@@ -186,7 +186,7 @@ export abstract class AdapterHTTPClient<
         }
         : undefined
 
-      const { data, status } = isMethodWithData(params)
+      const res = isMethodWithData(params)
         ? await this.apiClient[method](
           url,
           params.data,
@@ -196,13 +196,15 @@ export abstract class AdapterHTTPClient<
           url,
           requestConfig,
         )
-      log.debug('Received response for %s (%s) with status %d', url, safeJsonStringify({ url, queryParams }), status)
+      log.debug('Received response for %s (%s) with status %d', url, safeJsonStringify({ url, queryParams }), res.status)
       log.trace('Full HTTP response for %s: %s', url, safeJsonStringify({
-        url, queryParams, response: data,
+        url, queryParams, response: res.data,
       }))
+      const { data, status, headers: responseHeaders } = res
       return {
         data,
         status,
+        headers: responseHeaders,
       }
     } catch (e) {
       log.warn(`failed to ${method} ${url} ${safeJsonStringify(queryParams)}: ${e}, stack: ${e.stack}, data: ${safeJsonStringify(e?.response?.data)}`)

--- a/packages/adapter-components/src/client/http_connection.ts
+++ b/packages/adapter-components/src/client/http_connection.ts
@@ -34,6 +34,7 @@ export type Response<T> = {
   data: T
   status: number
   statusText?: string
+  headers?: Record<string, string>
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/adapter-components/src/client/index.ts
+++ b/packages/adapter-components/src/client/index.ts
@@ -19,5 +19,5 @@ export { DEFAULT_RETRY_OPTS, RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS } from
 export { logDecorator, requiresLogin } from './decorators'
 export { AdapterHTTPClient, ClientBaseParams, ClientDataParams, ClientOpts, HTTPReadClientInterface, HTTPWriteClientInterface, HTTPError } from './http_client'
 export { axiosConnection, createClientConnection, createRetryOptions, validateCredentials, APIConnection, ConnectionCreator, Response, ResponseValue, UnauthorizedError, Connection, RetryOptions, AuthParams, AuthenticatedAPIConnection } from './http_connection'
-export { createPaginator, getWithCursorPagination, getWithPageOffsetPagination, getWithPageOffsetAndLastPagination, getWithOffsetAndLimit, traverseRequests, ClientGetWithPaginationParams, GetAllItemsFunc, PageEntriesExtractor, PaginationFunc, PaginationFuncCreator, Paginator, PathCheckerFunc } from './pagination'
+export { createPaginator, getWithCursorPagination, getWithPageOffsetPagination, getWithPageOffsetAndLastPagination, getWithOffsetAndLimit, traverseRequests, ClientGetWithPaginationParams, GetAllItemsFunc, PageEntriesExtractor, PaginationFunc, PaginationFuncCreator, Paginator, PathCheckerFunc, defaultPathChecker } from './pagination'
 export { createRateLimitersFromConfig, throttle, BottleneckBuckets } from './rate_limit'

--- a/packages/adapter-components/src/client/pagination.ts
+++ b/packages/adapter-components/src/client/pagination.ts
@@ -44,12 +44,14 @@ export type PaginationFunc = ({
   pageSize,
   getParams,
   currentParams,
+  responseHeaders,
 }: {
   responseData: unknown
   page: ResponseValue[]
   pageSize: number
   getParams: ClientGetWithPaginationParams
   currentParams: Record<string, string>
+  responseHeaders?: unknown
 }) => Record<string, string>[]
 
 export type PaginationFuncCreator<T = {}> = (args: {
@@ -138,6 +140,7 @@ export const traverseRequests: (
       getParams: { ...getParams, paginationField },
       pageSize,
       currentParams: additionalArgs,
+      responseHeaders: response.headers,
     }))
 
     if (recursiveQueryParams !== undefined && Object.keys(recursiveQueryParams).length > 0) {
@@ -194,7 +197,10 @@ export const getWithPageOffsetAndLastPagination = (firstPage: number): Paginatio
  * @return true if the configured endpoint can be used to get the next path, false otherwise.
  */
 export type PathCheckerFunc = (endpointPath: string, nextPath: string) => boolean
-const defaultPathChecker: PathCheckerFunc = (endpointPath, nextPath) => (endpointPath === nextPath)
+export const defaultPathChecker: PathCheckerFunc = (
+  endpointPath,
+  nextPath
+) => (endpointPath === nextPath)
 
 /**
  * Make paginated requests using the specified paginationField, assuming the next page is specified

--- a/packages/adapter-components/test/client/http_client.test.ts
+++ b/packages/adapter-components/test/client/http_client.test.ts
@@ -62,13 +62,13 @@ describe('client_http_client', () => {
       mockAxiosAdapter.onGet('/users/me').reply(200, {
         accountId: 'ACCOUNT_ID',
       })
-      mockAxiosAdapter.onGet('/ep').replyOnce(200, { a: 'b' })
-      mockAxiosAdapter.onGet('/ep2', { a: 'AAA' }).replyOnce(200, { c: 'd' })
+      mockAxiosAdapter.onGet('/ep').replyOnce(200, { a: 'b' }, { h: '123' })
+      mockAxiosAdapter.onGet('/ep2', { a: 'AAA' }).replyOnce(200, { c: 'd' }, { hh: 'header' })
 
       const getRes = await client.getSinglePage({ url: '/ep' })
       const getRes2 = await client.getSinglePage({ url: '/ep2', queryParams: { a: 'AAA' } })
-      expect(getRes).toEqual({ data: { a: 'b' }, status: 200 })
-      expect(getRes2).toEqual({ data: { c: 'd' }, status: 200 })
+      expect(getRes).toEqual({ data: { a: 'b' }, status: 200, headers: { h: '123' } })
+      expect(getRes2).toEqual({ data: { c: 'd' }, status: 200, headers: { hh: 'header' } })
     })
 
     it('should throw Unauthorized on login 401', async () => {


### PR DESCRIPTION
Pass response header to `paginationFunc`

---

Okta's API uses response headers for pagination.
These changes required  in order to implement the new pagination method for Okta (which will be added in a separate PR in the future).

---

