### PR TITLE
SALTO-2556 transform booleans in untyped values

### DIFF
--- a/packages/netsuite-adapter/src/transformer.ts
+++ b/packages/netsuite-adapter/src/transformer.ts
@@ -85,9 +85,14 @@ export const createInstanceElement = async (customizationInfo: CustomizationInfo
 
   const transformPrimitive: TransformFunc = async ({ value, field }) => {
     const fieldType = await field?.getType()
-    if (value === '' || !isPrimitiveType(fieldType) || !isPrimitiveValue(value)) {
+    if (value === '') {
       // We sometimes get empty strings that we want to filter out
-      return value === '' ? undefined : value
+      return undefined
+    }
+    if (!isPrimitiveType(fieldType) || !isPrimitiveValue(value)) {
+      if (value === XML_TRUE_VALUE) return true
+      if (value === XML_FALSE_VALUE) return false
+      return value
     }
 
     switch (fieldType.primitive) {

--- a/packages/netsuite-adapter/test/transformer.test.ts
+++ b/packages/netsuite-adapter/test/transformer.test.ts
@@ -59,8 +59,14 @@ describe('Transformer', () => {
     WITH_TRUE_FIELD: '<entitycustomfield scriptid="custentity_my_script_id">\n'
       + '  <checkspelling>T</checkspelling>\n'
       + '</entitycustomfield>\n',
+    WITH_UNKNOWN_TRUE_FIELD: '<entitycustomfield scriptid="custentity_my_script_id">\n'
+      + '  <unknownattr>T</unknownattr>\n'
+      + '</entitycustomfield>\n',
     WITH_FALSE_FIELD: '<entitycustomfield scriptid="custentity_my_script_id">\n'
       + '  <checkspelling>F</checkspelling>\n'
+      + '</entitycustomfield>\n',
+    WITH_UNKNOWN_FALSE_FIELD: '<entitycustomfield scriptid="custentity_my_script_id">\n'
+      + '  <unknownattr>F</unknownattr>\n'
       + '</entitycustomfield>\n',
     WITH_NUMBER_FIELD: '<entitycustomfield scriptid="custentity_my_script_id">\n'
       + '  <displayheight>123</displayheight>\n'
@@ -176,9 +182,19 @@ describe('Transformer', () => {
       expect(result.value.checkspelling).toEqual(true)
     })
 
+    it('should transform boolean primitive field when is true even if field is unknown', async () => {
+      const result = await transformCustomFieldRecord(XML_TEMPLATES.WITH_UNKNOWN_TRUE_FIELD)
+      expect(result.value.unknownattr).toEqual(true)
+    })
+
     it('should transform boolean primitive field when is false', async () => {
       const result = await transformCustomFieldRecord(XML_TEMPLATES.WITH_FALSE_FIELD)
       expect(result.value.checkspelling).toEqual(false)
+    })
+
+    it('should transform boolean primitive field when is false even if field is unknown', async () => {
+      const result = await transformCustomFieldRecord(XML_TEMPLATES.WITH_UNKNOWN_FALSE_FIELD)
+      expect(result.value.unknownattr).toEqual(false)
     })
 
     it('should transform number primitive field', async () => {


### PR DESCRIPTION
should transform boolean values even if field is unknown - `"T" -> true`, `"F" -> false`

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- transform booleans in untyped values- `"T" -> true`, `"F" -> false`

---
_User Notifications_: 
None
