### PR TITLE
SALTO-2667: Separate compare logic between deploy and the rest

### DIFF
--- a/packages/adapter-api/src/elements.ts
+++ b/packages/adapter-api/src/elements.ts
@@ -83,14 +83,14 @@ export abstract class Element {
     return _.mapValues(this.annotationRefTypes, type => type.clone())
   }
 
-  isEqual(other: Element): boolean {
+  isEqual(other: Element, compareReferencesValues = false): boolean {
     return this.elemID.isEqual(other.elemID)
-      && this.isAnnotationsEqual(other)
+      && this.isAnnotationsEqual(other, compareReferencesValues)
   }
 
-  isAnnotationsEqual(other: Element): boolean {
+  isAnnotationsEqual(other: Element, compareReferencesValues = false): boolean {
     return this.isAnnotationsTypesEqual(other)
-      && isEqualValues(this.annotations, other.annotations)
+      && isEqualValues(this.annotations, other.annotations, compareReferencesValues)
   }
 
   isAnnotationsTypesEqual(other: Element): boolean {
@@ -171,8 +171,8 @@ export class ListType<T extends TypeElement = TypeElement> extends Element {
     return new ElemID(GLOBAL_ADAPTER, `${LIST_ID_PREFIX}<${innerTypeOrRef.elemID.getFullName()}>`)
   }
 
-  isEqual(other: ListType): boolean {
-    return super.isEqual(other)
+  isEqual(other: ListType, compareReferencesValues = false): boolean {
+    return super.isEqual(other, compareReferencesValues)
       // eslint-disable-next-line no-use-before-define
       && this.refInnerType.elemID.isEqual(other.refInnerType.elemID) && isListType(other)
   }
@@ -231,8 +231,8 @@ export class MapType<T extends TypeElement = TypeElement> extends Element {
     return new ElemID(GLOBAL_ADAPTER, `${MAP_ID_PREFIX}<${innerTypeOrRef.elemID.getFullName()}>`)
   }
 
-  isEqual(other: MapType): boolean {
-    return super.isEqual(other)
+  isEqual(other: MapType, compareReferencesValues = false): boolean {
+    return super.isEqual(other, compareReferencesValues)
       // eslint-disable-next-line no-use-before-define
       && this.refInnerType.elemID.isEqual(other.refInnerType.elemID) && isMapType(other)
   }
@@ -284,10 +284,10 @@ export class Field extends Element {
     this.refType = getRefType(typeOrRefType)
   }
 
-  isEqual(other: Field): boolean {
+  isEqual(other: Field, compareReferencesValues = false): boolean {
     return this.refType.elemID.isEqual(other.refType.elemID)
       && this.elemID.isEqual(other.elemID)
-      && isEqualValues(this.annotations, other.annotations)
+      && isEqualValues(this.annotations, other.annotations, compareReferencesValues)
   }
 
   async getType(elementsSource?: ReadOnlyElementsSource): Promise<TypeElement> {
@@ -337,8 +337,8 @@ export class PrimitiveType<Primitive extends PrimitiveTypes = PrimitiveTypes> ex
     this.primitive = primitive
   }
 
-  isEqual(other: PrimitiveType): boolean {
-    return super.isEqual(other)
+  isEqual(other: PrimitiveType, compareReferencesValues = false): boolean {
+    return super.isEqual(other, compareReferencesValues)
       && this.primitive === other.primitive
   }
 
@@ -401,14 +401,15 @@ export class ObjectType extends Element {
     return clonedFields
   }
 
-  isEqual(other: ObjectType): boolean {
-    return super.isEqual(other)
+  isEqual(other: ObjectType, compareReferencesValues = false): boolean {
+    return super.isEqual(other, compareReferencesValues)
       && _.isEqual(
         _.mapValues(this.fields, f => f.elemID.getFullName()),
         _.mapValues(other.fields, f => f.elemID.getFullName())
       )
       && _.isEqual(this.isSettings, other.isSettings)
-      && _.every(Object.keys(this.fields).map(n => this.fields[n].isEqual(other.fields[n])))
+      && _.every(Object.keys(this.fields)
+        .map(n => this.fields[n].isEqual(other.fields[n], compareReferencesValues)))
   }
 
   /**
@@ -469,10 +470,10 @@ export class InstanceElement extends Element {
     return type
   }
 
-  isEqual(other: InstanceElement): boolean {
-    return super.isEqual(other)
+  isEqual(other: InstanceElement, compareReferencesValues = false): boolean {
+    return super.isEqual(other, compareReferencesValues)
       && this.refType.elemID.isEqual(other.refType.elemID)
-      && isEqualValues(this.value, other.value)
+      && isEqualValues(this.value, other.value, compareReferencesValues)
   }
 
   /**
@@ -497,8 +498,9 @@ export class Variable extends Element {
     super({ elemID, path })
   }
 
-  isEqual(other: Variable): boolean {
-    return super.isEqual(other) && isEqualValues(this.value, other.value)
+  isEqual(other: Variable, compareReferencesValues = false): boolean {
+    return super.isEqual(other, compareReferencesValues)
+      && isEqualValues(this.value, other.value, compareReferencesValues)
   }
 
   clone(): Variable {
@@ -562,21 +564,28 @@ export function isField(element: any): element is Field {
   return element instanceof Field
 }
 
-const isEqualTypes = (first: TypeElement, second: TypeElement): boolean => {
+const isEqualTypes = (
+  first: TypeElement,
+  second: TypeElement,
+  compareReferencesValues = false,
+): boolean => {
   if (isPrimitiveType(first) && isPrimitiveType(second)) {
-    return first.isEqual(second)
+    return first.isEqual(second, compareReferencesValues)
   } if (isObjectType(first) && isObjectType(second)) {
-    return first.isEqual(second)
+    return first.isEqual(second, compareReferencesValues)
   } if (isListType(first) && isListType(second)) {
-    return first.isEqual(second)
+    return first.isEqual(second, compareReferencesValues)
   } if (isMapType(first) && isMapType(second)) {
-    return first.isEqual(second)
+    return first.isEqual(second, compareReferencesValues)
   }
   return false
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isEqualElements(first?: any, second?: any): boolean {
+export function isEqualElements(
+  first?: unknown,
+  second?: unknown,
+  compareReferencesValues = false
+): boolean {
   if (first === undefined && second === undefined) {
     return true
   }
@@ -586,13 +595,13 @@ export function isEqualElements(first?: any, second?: any): boolean {
   // first.isEqual line appears multiple times since the compiler is not smart
   // enough to understand the 'they are the same type' concept when using or
   if (isType(first) && isType(second)) {
-    return isEqualTypes(first, second)
+    return isEqualTypes(first, second, compareReferencesValues)
   } if (isField(first) && isField(second)) {
-    return first.isEqual(second)
+    return first.isEqual(second, compareReferencesValues)
   } if (isInstanceElement(first) && isInstanceElement(second)) {
-    return first.isEqual(second)
+    return first.isEqual(second, compareReferencesValues)
   } if (isVariable(first) && isVariable(second)) {
-    return first.isEqual(second)
+    return first.isEqual(second, compareReferencesValues)
   }
   return false
 }

--- a/packages/adapter-api/src/elements.ts
+++ b/packages/adapter-api/src/elements.ts
@@ -83,14 +83,14 @@ export abstract class Element {
     return _.mapValues(this.annotationRefTypes, type => type.clone())
   }
 
-  isEqual(other: Element, compareReferencesValues = false): boolean {
+  isEqual(other: Element, compareReferencesByValue = false): boolean {
     return this.elemID.isEqual(other.elemID)
-      && this.isAnnotationsEqual(other, compareReferencesValues)
+      && this.isAnnotationsEqual(other, compareReferencesByValue)
   }
 
-  isAnnotationsEqual(other: Element, compareReferencesValues = false): boolean {
+  isAnnotationsEqual(other: Element, compareReferencesByValue = false): boolean {
     return this.isAnnotationsTypesEqual(other)
-      && isEqualValues(this.annotations, other.annotations, compareReferencesValues)
+      && isEqualValues(this.annotations, other.annotations, compareReferencesByValue)
   }
 
   isAnnotationsTypesEqual(other: Element): boolean {
@@ -171,8 +171,8 @@ export class ListType<T extends TypeElement = TypeElement> extends Element {
     return new ElemID(GLOBAL_ADAPTER, `${LIST_ID_PREFIX}<${innerTypeOrRef.elemID.getFullName()}>`)
   }
 
-  isEqual(other: ListType, compareReferencesValues = false): boolean {
-    return super.isEqual(other, compareReferencesValues)
+  isEqual(other: ListType, compareReferencesByValue = false): boolean {
+    return super.isEqual(other, compareReferencesByValue)
       // eslint-disable-next-line no-use-before-define
       && this.refInnerType.elemID.isEqual(other.refInnerType.elemID) && isListType(other)
   }
@@ -231,8 +231,8 @@ export class MapType<T extends TypeElement = TypeElement> extends Element {
     return new ElemID(GLOBAL_ADAPTER, `${MAP_ID_PREFIX}<${innerTypeOrRef.elemID.getFullName()}>`)
   }
 
-  isEqual(other: MapType, compareReferencesValues = false): boolean {
-    return super.isEqual(other, compareReferencesValues)
+  isEqual(other: MapType, compareReferencesByValue = false): boolean {
+    return super.isEqual(other, compareReferencesByValue)
       // eslint-disable-next-line no-use-before-define
       && this.refInnerType.elemID.isEqual(other.refInnerType.elemID) && isMapType(other)
   }
@@ -284,10 +284,10 @@ export class Field extends Element {
     this.refType = getRefType(typeOrRefType)
   }
 
-  isEqual(other: Field, compareReferencesValues = false): boolean {
+  isEqual(other: Field, compareReferencesByValue = false): boolean {
     return this.refType.elemID.isEqual(other.refType.elemID)
       && this.elemID.isEqual(other.elemID)
-      && isEqualValues(this.annotations, other.annotations, compareReferencesValues)
+      && isEqualValues(this.annotations, other.annotations, compareReferencesByValue)
   }
 
   async getType(elementsSource?: ReadOnlyElementsSource): Promise<TypeElement> {
@@ -337,8 +337,8 @@ export class PrimitiveType<Primitive extends PrimitiveTypes = PrimitiveTypes> ex
     this.primitive = primitive
   }
 
-  isEqual(other: PrimitiveType, compareReferencesValues = false): boolean {
-    return super.isEqual(other, compareReferencesValues)
+  isEqual(other: PrimitiveType, compareReferencesByValue = false): boolean {
+    return super.isEqual(other, compareReferencesByValue)
       && this.primitive === other.primitive
   }
 
@@ -401,15 +401,15 @@ export class ObjectType extends Element {
     return clonedFields
   }
 
-  isEqual(other: ObjectType, compareReferencesValues = false): boolean {
-    return super.isEqual(other, compareReferencesValues)
+  isEqual(other: ObjectType, compareReferencesByValue = false): boolean {
+    return super.isEqual(other, compareReferencesByValue)
       && _.isEqual(
         _.mapValues(this.fields, f => f.elemID.getFullName()),
         _.mapValues(other.fields, f => f.elemID.getFullName())
       )
       && _.isEqual(this.isSettings, other.isSettings)
       && _.every(Object.keys(this.fields)
-        .map(n => this.fields[n].isEqual(other.fields[n], compareReferencesValues)))
+        .map(n => this.fields[n].isEqual(other.fields[n], compareReferencesByValue)))
   }
 
   /**
@@ -470,10 +470,10 @@ export class InstanceElement extends Element {
     return type
   }
 
-  isEqual(other: InstanceElement, compareReferencesValues = false): boolean {
-    return super.isEqual(other, compareReferencesValues)
+  isEqual(other: InstanceElement, compareReferencesByValue = false): boolean {
+    return super.isEqual(other, compareReferencesByValue)
       && this.refType.elemID.isEqual(other.refType.elemID)
-      && isEqualValues(this.value, other.value, compareReferencesValues)
+      && isEqualValues(this.value, other.value, compareReferencesByValue)
   }
 
   /**
@@ -498,9 +498,9 @@ export class Variable extends Element {
     super({ elemID, path })
   }
 
-  isEqual(other: Variable, compareReferencesValues = false): boolean {
-    return super.isEqual(other, compareReferencesValues)
-      && isEqualValues(this.value, other.value, compareReferencesValues)
+  isEqual(other: Variable, compareReferencesByValue = false): boolean {
+    return super.isEqual(other, compareReferencesByValue)
+      && isEqualValues(this.value, other.value, compareReferencesByValue)
   }
 
   clone(): Variable {
@@ -567,16 +567,16 @@ export function isField(element: any): element is Field {
 const isEqualTypes = (
   first: TypeElement,
   second: TypeElement,
-  compareReferencesValues = false,
+  compareReferencesByValue = false,
 ): boolean => {
   if (isPrimitiveType(first) && isPrimitiveType(second)) {
-    return first.isEqual(second, compareReferencesValues)
+    return first.isEqual(second, compareReferencesByValue)
   } if (isObjectType(first) && isObjectType(second)) {
-    return first.isEqual(second, compareReferencesValues)
+    return first.isEqual(second, compareReferencesByValue)
   } if (isListType(first) && isListType(second)) {
-    return first.isEqual(second, compareReferencesValues)
+    return first.isEqual(second, compareReferencesByValue)
   } if (isMapType(first) && isMapType(second)) {
-    return first.isEqual(second, compareReferencesValues)
+    return first.isEqual(second, compareReferencesByValue)
   }
   return false
 }
@@ -584,7 +584,7 @@ const isEqualTypes = (
 export function isEqualElements(
   first?: unknown,
   second?: unknown,
-  compareReferencesValues = false
+  compareReferencesByValue = false
 ): boolean {
   if (first === undefined && second === undefined) {
     return true
@@ -595,13 +595,13 @@ export function isEqualElements(
   // first.isEqual line appears multiple times since the compiler is not smart
   // enough to understand the 'they are the same type' concept when using or
   if (isType(first) && isType(second)) {
-    return isEqualTypes(first, second, compareReferencesValues)
+    return isEqualTypes(first, second, compareReferencesByValue)
   } if (isField(first) && isField(second)) {
-    return first.isEqual(second, compareReferencesValues)
+    return first.isEqual(second, compareReferencesByValue)
   } if (isInstanceElement(first) && isInstanceElement(second)) {
-    return first.isEqual(second, compareReferencesValues)
+    return first.isEqual(second, compareReferencesByValue)
   } if (isVariable(first) && isVariable(second)) {
-    return first.isEqual(second, compareReferencesValues)
+    return first.isEqual(second, compareReferencesByValue)
   }
   return false
 }

--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -215,10 +215,10 @@ const compareStringsIgnoreNewlineDifferences = (s1: string, s2: string): boolean
   (s1 === s2) || (s1.replace(/\r\n/g, '\n') === s2.replace(/\r\n/g, '\n'))
 
 export const shouldResolve = (value: unknown): boolean => (
-  // Do not resolve references to elements because we expect them to have their own
-  // node in the graph and we cannot know here if a difference in an element would
-  // cause a difference in the reference. We do resolve variables because they always
-  // point to a primitive value that we can compare.
+  // We don't resolve references to elements because the logic of how to resolve each
+  // reference currently exists only in the adapter so here we don't know how to
+  // resolve them.
+  // We do resolve variables because they always point to a primitive value that we can compare.
   // If a value is not a reference we decided to return that we should "resolve" it so
   // the value will be treated like a resolved reference
   !isReferenceExpression(value) || !value.elemID.isBaseID() || value.elemID.idType === 'var'

--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -214,30 +214,15 @@ export const isTypeReference = (value: any): value is TypeReference => (
 const compareStringsIgnoreNewlineDifferences = (s1: string, s2: string): boolean =>
   (s1 === s2) || (s1.replace(/\r\n/g, '\n') === s2.replace(/\r\n/g, '\n'))
 
-const shouldResolve = (ref: ReferenceExpression): boolean => (
-  !ref.elemID.isBaseID() || ref.elemID.idType === 'var'
+export const shouldResolve = (value: unknown): boolean => (
+  !isReferenceExpression(value) || !value.elemID.isBaseID() || value.elemID.idType === 'var'
 )
 
-export const shouldCompareByValue = (
+const shouldCompareByValue = (
   first: Value,
   second: Value,
   compareReferencesValues: boolean
-): boolean => {
-  if (!isReferenceExpression(first) && !isReferenceExpression(second)) {
-    return true
-  }
-
-  if (!compareReferencesValues) {
-    return false
-  }
-
-  if ((isReferenceExpression(first) && !isReferenceExpression(second))
-   || (!isReferenceExpression(first) && isReferenceExpression(second))) {
-    return true
-  }
-
-  return shouldResolve(first) && shouldResolve(second)
-}
+): boolean => compareReferencesValues && shouldResolve(first) && shouldResolve(second)
 
 export const compareSpecialValues = (
   first: Value,

--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -218,6 +218,16 @@ const shouldResolve = (ref: ReferenceExpression): boolean => (
   !ref.elemID.isBaseID() || ref.elemID.idType === 'var'
 )
 
+export const shouldCompareByValue = (
+  first: ReferenceExpression,
+  second: ReferenceExpression,
+  compareReferencesValues: boolean
+): boolean => (
+  compareReferencesValues
+  && shouldResolve(first)
+  && shouldResolve(second)
+)
+
 export const compareSpecialValues = (
   first: Value,
   second: Value,
@@ -231,7 +241,7 @@ export const compareSpecialValues = (
     const sValue = isReferenceExpression(second) ? second.value : second
 
     if (isReferenceExpression(first) && isReferenceExpression(second)
-     && !(shouldResolve(first) && compareReferencesValues)) {
+     && !shouldCompareByValue(first, second, compareReferencesValues)) {
       return first.elemID.isEqual(second.elemID)
     }
 

--- a/packages/adapter-api/test/values.test.ts
+++ b/packages/adapter-api/test/values.test.ts
@@ -181,7 +181,7 @@ describe('Values', () => {
         expect(isEqualValues(ref1, ref2)).toBeTruthy()
       })
 
-      it('References to inner properties with the same should not be equal when compareReferencesValues is true', () => {
+      it('References to inner properties with the same should not be equal when compareReferencesByValue is true', () => {
         const ref1 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val1'), 1)
         const ref2 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val1'), 2)
         expect(isEqualValues(ref1, ref2, true)).toBeFalsy()
@@ -204,7 +204,7 @@ describe('Values', () => {
         expect(isEqualValues(ref1, 1)).toBeFalsy()
       })
 
-      it('Reference should not be equal to its resolved value when compareReferencesValues is true', () => {
+      it('Reference should not be equal to its resolved value when compareReferencesByValue is true', () => {
         const ref1 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val1'), 1)
         expect(isEqualValues(ref1, 1, true)).toBeTruthy()
       })

--- a/packages/adapter-api/test/values.test.ts
+++ b/packages/adapter-api/test/values.test.ts
@@ -175,22 +175,28 @@ describe('Values', () => {
         expect(isEqualValues(s1, s2)).toBeTruthy()
       })
 
-      it('References to inner properties with different values should not be equal', () => {
+      it('References to inner properties with different values should be equal by default', () => {
         const ref1 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val'), 1)
         const ref2 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val'), 2)
-        expect(isEqualValues(ref1, ref2)).toBeFalsy()
+        expect(isEqualValues(ref1, ref2)).toBeTruthy()
       })
 
-      it('References to different inner properties with the same value should not be equal', () => {
+      it('References to inner properties with the same should not be equal when compareReferencesValues is true', () => {
         const ref1 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val1'), 1)
-        const ref2 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val2'), 1)
-        expect(isEqualValues(ref1, ref2)).toBeFalsy()
+        const ref2 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val1'), 2)
+        expect(isEqualValues(ref1, ref2, true)).toBeFalsy()
       })
 
       it('References to inner properties with the same should not be equal', () => {
         const ref1 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val1'), 1)
         const ref2 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val1'), 1)
-        expect(isEqualValues(ref1, ref2)).toBeTruthy()
+        expect(isEqualValues(ref1, ref2, true)).toBeTruthy()
+      })
+
+      it('References to different inner properties with the same value should be equal', () => {
+        const ref1 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val1'), 1)
+        const ref2 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val2'), 1)
+        expect(isEqualValues(ref1, ref2, true)).toBeTruthy()
       })
     })
     it('calculate hash', () => {

--- a/packages/adapter-api/test/values.test.ts
+++ b/packages/adapter-api/test/values.test.ts
@@ -174,6 +174,24 @@ describe('Values', () => {
         const s2 = '\na\r\nb\r\n\r\n\r\np'
         expect(isEqualValues(s1, s2)).toBeTruthy()
       })
+
+      it('References to inner properties with different values should not be equal', () => {
+        const ref1 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val'), 1)
+        const ref2 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val'), 2)
+        expect(isEqualValues(ref1, ref2)).toBeFalsy()
+      })
+
+      it('References to different inner properties with the same value should not be equal', () => {
+        const ref1 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val1'), 1)
+        const ref2 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val2'), 1)
+        expect(isEqualValues(ref1, ref2)).toBeFalsy()
+      })
+
+      it('References to inner properties with the same should not be equal', () => {
+        const ref1 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val1'), 1)
+        const ref2 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val1'), 1)
+        expect(isEqualValues(ref1, ref2)).toBeTruthy()
+      })
     })
     it('calculate hash', () => {
       const zOMGBuffer = Buffer.from('ZOMG')

--- a/packages/adapter-api/test/values.test.ts
+++ b/packages/adapter-api/test/values.test.ts
@@ -198,6 +198,16 @@ describe('Values', () => {
         const ref2 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val2'), 1)
         expect(isEqualValues(ref1, ref2, true)).toBeTruthy()
       })
+
+      it('Reference should not be equal to its resolved value by default', () => {
+        const ref1 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val1'), 1)
+        expect(isEqualValues(ref1, 1)).toBeFalsy()
+      })
+
+      it('Reference should not be equal to its resolved value when compareReferencesValues is true', () => {
+        const ref1 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val1'), 1)
+        expect(isEqualValues(ref1, 1, true)).toBeTruthy()
+      })
     })
     it('calculate hash', () => {
       const zOMGBuffer = Buffer.from('ZOMG')

--- a/packages/adapter-utils/src/compare.ts
+++ b/packages/adapter-utils/src/compare.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import _ from 'lodash'
+import _, { isElement } from 'lodash'
 import {
   ChangeDataType, DetailedChange, isField, isInstanceElement, ElemID, Value, ObjectType, isType,
   PrimitiveType, isObjectType, isPrimitiveType, isEqualElements, isEqualValues, isRemovalChange,
@@ -29,9 +29,16 @@ const getValuesChanges = (
   after: Value,
   compareReferencesValues: boolean,
 ): DetailedChange[] => {
-  if (isEqualElements(before, after) || isEqualValues(before, after, compareReferencesValues)) {
+  if (isElement(before) && isElement(after)
+    && isEqualElements(before, after, compareReferencesValues)) {
     return []
   }
+
+  if (!isElement(before) && !isElement(after)
+    && isEqualValues(before, after, compareReferencesValues)) {
+    return []
+  }
+
   if (before === undefined) {
     return [{ id, action: 'add', data: { after } }]
   }
@@ -84,7 +91,6 @@ const getAnnotationTypeChanges = (
   id: ElemID,
   before: Value,
   after: Value,
-  compareReferencesValues: boolean
 ): DetailedChange[] => {
   const hasAnnotationTypes = (elem: ChangeDataType): elem is ObjectType | PrimitiveType =>
     isObjectType(elem) || isPrimitiveType(elem)
@@ -106,7 +112,7 @@ const getAnnotationTypeChanges = (
       id.createNestedID('annotation'),
       beforeUniqueAnnotationsTypes,
       afterUniqueAnnotationsTypes,
-      compareReferencesValues,
+      false,
     )
   }
   return []
@@ -164,7 +170,6 @@ export const detailedCompare = (
     after.elemID,
     before,
     after,
-    compareReferencesValues
   )
 
   const annotationChanges = getValuesChanges(

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -127,7 +127,7 @@ export const preview = async (
     dependencyChangers: defaultDependencyChangers.concat(getAdapterDependencyChangers(adapters)),
     customGroupIdFunctions: getAdapterChangeGroupIdFunctions(adapters),
     topLevelFilters: [shouldElementBeIncluded(accounts)],
-    compareReferencesValues: true,
+    compareReferencesByValue: true,
   })
 }
 

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -127,6 +127,7 @@ export const preview = async (
     dependencyChangers: defaultDependencyChangers.concat(getAdapterDependencyChangers(adapters)),
     customGroupIdFunctions: getAdapterChangeGroupIdFunctions(adapters),
     topLevelFilters: [shouldElementBeIncluded(accounts)],
+    compareReferencesValues: true,
   })
 }
 

--- a/packages/core/src/core/plan/plan.ts
+++ b/packages/core/src/core/plan/plan.ts
@@ -20,7 +20,7 @@ import {
   ChangeValidator, Change, ChangeError, DependencyChanger, ChangeGroupIdFunction, getChangeData,
   isAdditionOrRemovalChange, isFieldChange, ReadOnlyElementsSource, ElemID, isVariable,
   Value, isReferenceExpression, compareSpecialValues, BuiltinTypesByFullName, isAdditionChange,
-  isModificationChange, isRemovalChange, ReferenceExpression, changeId,
+  isModificationChange, isRemovalChange, ReferenceExpression, changeId, shouldCompareByValue,
 } from '@salto-io/adapter-api'
 import { DataNodeMap, DiffNode, DiffGraph, Group, GroupDAG, DAG } from '@salto-io/dag'
 import { logger } from '@salto-io/logging'
@@ -91,7 +91,7 @@ const areReferencesEqual = async (
   // if both values are ReferenceExpressions and should not be resolved
   // they are compared by their elemID
   if (isReferenceExpression(first) && isReferenceExpression(second)
-   && !(shouldResolve(first) && compareReferencesValues)) {
+   && !shouldCompareByValue(first, second, compareReferencesValues)) {
     return {
       returnCode: 'return',
       returnValue: first.elemID.isEqual(second.elemID),

--- a/packages/core/src/core/plan/plan.ts
+++ b/packages/core/src/core/plan/plan.ts
@@ -88,35 +88,34 @@ const areReferencesEqual = async (
   secondVisitedReferences: Set<string>,
   compareReferencesValues: boolean
 ): Promise<ReferenceCompareReturnValue> => {
-  // if both values are ReferenceExpressions and should not be resolved
-  // they are compared by their elemID
-  if (isReferenceExpression(first) && isReferenceExpression(second)
-   && !shouldCompareByValue(first, second, compareReferencesValues)) {
-    return {
-      returnCode: 'return',
-      returnValue: first.elemID.isEqual(second.elemID),
+  if (shouldCompareByValue(first, second, compareReferencesValues)) {
+    const shouldResolveFirst = isReferenceExpression(first) && shouldResolve(first)
+
+    const firstValue = shouldResolveFirst
+      ? await getReferenceValue(first, firstSrc, firstVisitedReferences)
+      : first
+
+    const shouldResolveSecond = isReferenceExpression(second) && shouldResolve(second)
+
+    const secondValue = shouldResolveSecond
+      ? await getReferenceValue(second, secondSrc, secondVisitedReferences)
+      : second
+
+    if (shouldResolveFirst || shouldResolveSecond) {
+      return {
+        returnCode: 'recurse',
+        returnValue: {
+          firstValue,
+          secondValue,
+        },
+      }
     }
   }
 
-  const shouldResolveFirst = isReferenceExpression(first) && shouldResolve(first)
-
-  const firstValue = shouldResolveFirst
-    ? await getReferenceValue(first, firstSrc, firstVisitedReferences)
-    : first
-
-  const shouldResolveSecond = isReferenceExpression(second) && shouldResolve(second)
-
-  const secondValue = shouldResolveSecond
-    ? await getReferenceValue(second, secondSrc, secondVisitedReferences)
-    : second
-
-  if (shouldResolveFirst || shouldResolveSecond) {
+  if (isReferenceExpression(first) && isReferenceExpression(second)) {
     return {
-      returnCode: 'recurse',
-      returnValue: {
-        firstValue,
-        secondValue,
-      },
+      returnCode: 'return',
+      returnValue: first.elemID.isEqual(second.elemID),
     }
   }
 

--- a/packages/core/src/core/plan/plan_item.ts
+++ b/packages/core/src/core/plan/plan_item.ts
@@ -39,7 +39,10 @@ const getGroupAction = (group: Group<Change>): ActionName => {
     : 'modify'
 }
 
-export const addPlanItemAccessors = (group: Group<Change>): PlanItem => Object.assign(group, {
+export const addPlanItemAccessors = (
+  group: Group<Change>,
+  compareReferencesValues = false
+): PlanItem => Object.assign(group, {
   action: getGroupAction(group),
   changes() {
     return group.items.values()
@@ -51,7 +54,12 @@ export const addPlanItemAccessors = (group: Group<Change>): PlanItem => Object.a
         if (change.action !== 'modify') {
           return { ...change, id: elem.elemID }
         }
-        return detailedCompare(change.data.before, change.data.after)
+        return detailedCompare(
+          change.data.before,
+          change.data.after,
+          false,
+          compareReferencesValues
+        )
       })
       .flatten()
   },

--- a/packages/core/src/core/plan/plan_item.ts
+++ b/packages/core/src/core/plan/plan_item.ts
@@ -41,7 +41,7 @@ const getGroupAction = (group: Group<Change>): ActionName => {
 
 export const addPlanItemAccessors = (
   group: Group<Change>,
-  compareReferencesValues = false
+  compareReferencesByValue = false
 ): PlanItem => Object.assign(group, {
   action: getGroupAction(group),
   changes() {
@@ -58,7 +58,7 @@ export const addPlanItemAccessors = (
           change.data.before,
           change.data.after,
           false,
-          compareReferencesValues
+          compareReferencesByValue
         )
       })
       .flatten()

--- a/packages/core/test/core/plan/plan.test.ts
+++ b/packages/core/test/core/plan/plan.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { InstanceElement, getChangeData, isInstanceElement, ChangeGroupIdFunction, ElemID, ObjectType, BuiltinTypes, ReferenceExpression, Variable, VariableExpression, StaticFile } from '@salto-io/adapter-api'
+import { InstanceElement, getChangeData, isInstanceElement, ChangeGroupIdFunction, ElemID, ObjectType, BuiltinTypes, ReferenceExpression, StaticFile } from '@salto-io/adapter-api'
 import { mockFunction } from '@salto-io/test-utils'
 import wu from 'wu'
 import * as mock from '../../common/elements'
@@ -188,161 +188,6 @@ describe('getPlan', () => {
     })
   })
 
-  it('when instances have inner references and there is no change should create empty plan', async () => {
-    const innerType = new ObjectType({
-      elemID: new ElemID('adapter', 'inner'),
-      fields: {
-        inner: { refType: BuiltinTypes.STRING },
-      },
-    })
-
-    const type = new ObjectType({
-      elemID: new ElemID('adapter', 'type'),
-      fields: {
-        ref: { refType: innerType },
-        inner: { refType: innerType },
-        value: { refType: BuiltinTypes.STRING },
-      },
-    })
-
-    const firstInstance1 = new InstanceElement(
-      'instance1',
-      type,
-      {
-        value: 'some value',
-        inner: { inner: new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'instance1', 'value')) },
-        ref: new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'instance1', 'inner')),
-      }
-    )
-
-    const secondInstance1 = new InstanceElement(
-      'instance1',
-      type,
-      {
-        value: 'some value',
-        inner: { inner: 'some value' },
-        ref: { inner: 'some value' },
-      }
-    )
-
-
-    const firstInstance2 = new InstanceElement(
-      'instance2',
-      type,
-      {
-        value: 'some value',
-        inner: { inner: 'some value' },
-        ref: { inner: 'some value' },
-      }
-    )
-
-    const secondInstance2 = new InstanceElement(
-      'instance2',
-      type,
-      {
-        value: 'some value',
-        inner: { inner: new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'instance2', 'value')) },
-        ref: new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'instance2', 'inner')),
-      }
-    )
-
-
-    const firstInstance3 = new InstanceElement(
-      'instance3',
-      type,
-      {
-        ref: new ReferenceExpression(
-          new ElemID('adapter', 'type', 'instance', 'instance3', 'inner'),
-          {
-            inner: new ReferenceExpression(
-              new ElemID('adapter', 'type', 'instance', 'instance3', 'value'),
-              'some value'
-            ),
-          }
-        ),
-      }
-    )
-
-    const secondInstance3 = new InstanceElement(
-      'instance3',
-      type,
-      {
-        ref: { inner: 'some value' },
-      }
-    )
-
-    const firstInstance4 = new InstanceElement(
-      'instance4',
-      type,
-      {
-        ref: { inner: 'some value' },
-      }
-    )
-
-    const secondInstance4 = new InstanceElement(
-      'instance4',
-      type,
-      {
-        ref: new ReferenceExpression(
-          new ElemID('adapter', 'type', 'instance', 'instance4', 'inner'),
-          {
-            inner: new ReferenceExpression(
-              new ElemID('adapter', 'type', 'instance', 'instance4', 'value'),
-              'some value'
-            ),
-          }
-        ),
-      }
-    )
-
-
-    const plan = await getPlan({
-      before: createElementSource(
-        [firstInstance1, firstInstance2, firstInstance3, firstInstance4, type, innerType]
-      ),
-      after: createElementSource(
-        [secondInstance1, secondInstance2, secondInstance3, secondInstance4, type, innerType]
-      ),
-    })
-    expect(plan.size).toBe(0)
-  })
-
-  it('when instances use variables and there is no change should create empty plan', async () => {
-    const variableObject = new Variable(
-      new ElemID('var', 'a'),
-      5
-    )
-
-    const type = new ObjectType({
-      elemID: new ElemID('adapter', 'type'),
-      fields: {
-        value: { refType: BuiltinTypes.NUMBER },
-      },
-    })
-
-    const instance = new InstanceElement(
-      'instance',
-      type,
-      {
-        value: new VariableExpression(variableObject.elemID),
-      }
-    )
-
-    const stateInstance = new InstanceElement(
-      'instance',
-      type,
-      {
-        value: 5,
-      }
-    )
-
-    const plan = await getPlan({
-      before: createElementSource([stateInstance, type]),
-      after: createElementSource([instance, type, variableObject]),
-    })
-    expect(plan.size).toBe(0)
-  })
-
   it('when there is a circular reference in an instance it should behave as undefined', async () => {
     const type = new ObjectType({
       elemID: new ElemID('adapter', 'type'),
@@ -490,6 +335,37 @@ describe('getPlan', () => {
         .flatten()
         .toArray()
       expect(changes.length).toBe(1)
+    })
+
+    it('when true should not add a change to plan when a value of a reference to inner property is changed from its resolved value', async () => {
+      instanceBefore.value.ref = 2
+      const plan = await getPlan({
+        before: createElementSource([instanceBefore, referencedBefore, type]),
+        after: createElementSource([instanceAfter, referencedAfter, type]),
+        compareReferencesValues: true,
+      })
+      expect(plan.size).toBe(1)
+
+      const changes = wu(plan.itemsByEvalOrder())
+        .map(item => item.detailedChanges())
+        .flatten()
+        .toArray()
+      expect(changes.length).toBe(1)
+    })
+
+    it('by default should add a change to plan when a value of a reference to inner property is changed from its resolved value', async () => {
+      instanceBefore.value.ref = 2
+      const plan = await getPlan({
+        before: createElementSource([instanceBefore, referencedBefore, type]),
+        after: createElementSource([instanceAfter, referencedAfter, type]),
+      })
+      expect(plan.size).toBe(2)
+
+      const changes = wu(plan.itemsByEvalOrder())
+        .map(item => item.detailedChanges())
+        .flatten()
+        .toArray()
+      expect(changes.length).toBe(2)
     })
   })
 

--- a/packages/jira-adapter/src/filters/fields/default_values.ts
+++ b/packages/jira-adapter/src/filters/fields/default_values.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-import { Change, compareSpecialValues, getChangeData, InstanceElement, isAdditionOrModificationChange, isObjectType, isReferenceExpression, isRemovalChange, isRemovalOrModificationChange, ObjectType, ReadOnlyElementsSource, Value } from '@salto-io/adapter-api'
+import { Change, getChangeData, InstanceElement, isAdditionOrModificationChange, isEqualValues, isObjectType, isReferenceExpression, isRemovalChange, isRemovalOrModificationChange, ObjectType, ReadOnlyElementsSource, Value } from '@salto-io/adapter-api'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { applyFunctionToChangeData, getParents, resolveChangeElement, resolvePath, resolveValues } from '@salto-io/adapter-utils'
 import _ from 'lodash'
@@ -89,11 +89,7 @@ export const updateDefaultValues = async (
     : undefined
 
   if (isRemovalChange(contextChange)
-      || _.isEqualWith(
-        beforeDefault,
-        afterDefault,
-        compareSpecialValues
-      )
+      || isEqualValues(beforeDefault, afterDefault)
   ) {
     return
   }


### PR DESCRIPTION
Added a `compareReferencesValues` to control the element compare behavior when comparing references. This flag is to true in the deploy flow and false in the other cases.
When the flag is false we will never look at the reference value when comparing, only the reference id. When the flag is true we will compare the reference value when it does not point to an Element or a variable.

This solves two issues of the current behavior:
- A change of a value would not add an element with reference to it to the plan
- In fetch, a change from a value to a reference that resolved to the same value would not be applied

---
_Release Notes_: 
_Core_:
- Fixed a bug where instances with reference to inner properties that changed would not be added to the plan
- Fixed a bug where in fetch, a change from a value to a reference that resolved to the same value would not be applied

---
_User Notifications_: 
None