### PR TITLE
SALTO-2411 Extract references from Salesforce Queues

### DIFF
--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -379,6 +379,14 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     target: { parentContext: 'neighborTableLookup', type: CUSTOM_FIELD },
   },
   {
+    src: { field: 'publicGroup', parentTypes: ['PublicGroups'] },
+    target: { type: 'Group' },
+  },
+  {
+    src: { field: 'role', parentTypes: ['Roles'] },
+    target: { type: 'Role' },
+  },
+  {
     // sometimes has a value that is not a reference - should only convert to reference
     // if lookupValueType exists
     src: { field: 'lookupValue', parentTypes: ['WorkflowFieldUpdate'] },


### PR DESCRIPTION
_Extract references from Salesforce Queues_

---
_Additional context for reviewer_:
None

---
_Release Notes_: 
Salesforce-adapter:

* Add Group and Role references from queueMembers under Queue type
---

_User Notifications_: 
Salesforce-adapter:

* Add Group and Role references from queueMembers under Queue type

