### PR TITLE
SALTO-2673: Modifying active workflow fails

### DIFF
--- a/packages/jira-adapter/src/filters/workflow/workflow_modification_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_modification_filter.ts
@@ -76,7 +76,13 @@ const deployWorkflowModification = async ({
   const tempInstance = originalInstance.clone()
   tempInstance.value.name = `${tempInstance.value.name}-${uuidv4()}`
 
+  const idToWorkflowSchemes = _.keyBy(
+    workflowSchemes,
+    scheme => scheme.elemID.getFullName()
+  )
+
   const workflowSchemesWithTemp = await awu(workflowSchemes)
+    .map(scheme => scheme.clone())
     .map(scheme => replaceWorkflowInScheme(
       scheme,
       originalInstance,
@@ -87,18 +93,12 @@ const deployWorkflowModification = async ({
     .toArray()
 
   const cleanTempInstance = async (): Promise<void> => {
-    const updateWorkflowSchemes = await awu(workflowSchemesWithTemp)
-      .map(scheme => replaceWorkflowInScheme(
-        scheme, tempInstance, originalInstance, elementsSource
-      ))
-      .filter(values.isDefined)
-      .toArray()
-
-    await awu(updateWorkflowSchemes).forEach(async scheme => {
+    await awu(workflowSchemesWithTemp).forEach(async schemeWithTemp => {
+      const scheme = idToWorkflowSchemes[schemeWithTemp.elemID.getFullName()]
       await preDeployWorkflowScheme(scheme, 'modify', elementsSource)
       try {
         await deployWorkflowScheme(
-          toChange({ before: scheme, after: scheme }),
+          toChange({ before: schemeWithTemp, after: scheme }),
           client,
           paginator,
           config,
@@ -127,10 +127,11 @@ const deployWorkflowModification = async ({
   )
 
   try {
-    await awu(workflowSchemesWithTemp).forEach(async scheme => {
-      await preDeployWorkflowScheme(scheme, 'modify', elementsSource)
+    await awu(workflowSchemesWithTemp).forEach(async schemeWithTemp => {
+      const scheme = idToWorkflowSchemes[schemeWithTemp.elemID.getFullName()]
+      await preDeployWorkflowScheme(schemeWithTemp, 'modify', elementsSource)
       await deployWorkflowScheme(
-        toChange({ before: scheme, after: scheme }),
+        toChange({ before: scheme, after: schemeWithTemp }),
         client,
         paginator,
         config,

--- a/packages/jira-adapter/test/filters/workflow/workflow_modification_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_modification_filter.test.ts
@@ -171,7 +171,7 @@ describe('workflowModificationFilter', () => {
       tempSchemeInstance.value.updateDraftIfNeeded = true
       expect(deployWorkflowSchemeMock).toHaveBeenNthCalledWith(
         1,
-        toChange({ before: tempSchemeInstance, after: tempSchemeInstance }),
+        toChange({ before: workflowSchemeInstance, after: tempSchemeInstance }),
         client,
         paginator,
         config,
@@ -196,7 +196,7 @@ describe('workflowModificationFilter', () => {
       schemeInstance.value.updateDraftIfNeeded = true
       expect(deployWorkflowSchemeMock).toHaveBeenNthCalledWith(
         2,
-        toChange({ before: schemeInstance, after: schemeInstance }),
+        toChange({ before: tempSchemeInstance, after: schemeInstance }),
         client,
         paginator,
         config,
@@ -252,7 +252,7 @@ describe('workflowModificationFilter', () => {
       tempSchemeInstance.value.updateDraftIfNeeded = true
       expect(deployWorkflowSchemeMock).toHaveBeenNthCalledWith(
         1,
-        toChange({ before: tempSchemeInstance, after: tempSchemeInstance }),
+        toChange({ before: workflowSchemeInstance, after: tempSchemeInstance }),
         client,
         paginator,
         config,
@@ -263,7 +263,7 @@ describe('workflowModificationFilter', () => {
       schemeInstance.value.updateDraftIfNeeded = true
       expect(deployWorkflowSchemeMock).toHaveBeenNthCalledWith(
         2,
-        toChange({ before: schemeInstance, after: schemeInstance }),
+        toChange({ before: tempSchemeInstance, after: schemeInstance }),
         client,
         paginator,
         config,
@@ -308,7 +308,7 @@ describe('workflowModificationFilter', () => {
       tempSchemeInstance.value.updateDraftIfNeeded = true
       expect(deployWorkflowSchemeMock).toHaveBeenNthCalledWith(
         1,
-        toChange({ before: tempSchemeInstance, after: tempSchemeInstance }),
+        toChange({ before: workflowSchemeInstance, after: tempSchemeInstance }),
         client,
         paginator,
         config,
@@ -319,7 +319,7 @@ describe('workflowModificationFilter', () => {
       schemeInstance.value.updateDraftIfNeeded = true
       expect(deployWorkflowSchemeMock).toHaveBeenNthCalledWith(
         2,
-        toChange({ before: schemeInstance, after: schemeInstance }),
+        toChange({ before: tempSchemeInstance, after: schemeInstance }),
         client,
         paginator,
         config,


### PR DESCRIPTION
Fixed a bug with modifying active workflows

---

To modify active workflow we need to edit the workflow scheme that uses it. Recently we changed `defaultDeployChange` to do nothing if the before and after are equal so when we tried to update the workflow scheme it didn't actually do anything

---
_Release Notes_: 
_Jira Adapter_:
- Fixed a bug with deploying active workflows

---
_User Notifications_: 
None