### PR TITLE
SALTO-2642-support-Zendesk-missing-references-for-list-values

### DIFF
--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -33,6 +33,7 @@ import createChangeValidator from './change_validator'
 import { paginate } from './client/pagination'
 import { getChangeGroupIds } from './group_change'
 import fieldReferencesFilter, { lookupFunc } from './filters/field_references'
+import listValuesMissingReferencesFilter from './filters/references/list_values_missing_references'
 import unorderedListsFilter from './filters/unordered_lists'
 import viewFilter from './filters/view'
 import workspaceFilter from './filters/workspace'
@@ -123,6 +124,8 @@ export const DEFAULT_FILTERS = [
   // removeBrandLogoFieldFilter should be after brandLogoFilter
   removeBrandLogoFieldFilter,
   fieldReferencesFilter,
+  // listValuesMissingReferencesFilter should be after fieldReferencesFilter
+  listValuesMissingReferencesFilter,
   appsFilter,
   customFieldOptionsFilter,
   appOwnedConvertListToMapFilter,

--- a/packages/zendesk-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-adapter/src/filters/field_references.ts
@@ -36,13 +36,13 @@ const neighborContextFunc = (args: {
   ...args,
 })
 
-// TODO: Support in types with list values
 const NEIGHBOR_FIELD_TO_TYPE_NAMES: Record<string, string> = {
   brand_id: 'brand',
   group_id: 'group',
   schedule_id: 'business_hours_schedule',
   within_schedule: 'business_hours_schedule',
   set_schedule: 'business_hours_schedule',
+  ticket_form_id: 'ticket_form',
 }
 
 const SPECIAL_CONTEXT_NAMES: Record<string, string> = {
@@ -729,11 +729,15 @@ const commonFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[] = [
         'automation__conditions__all',
         'automation__conditions__any',
         'macro__actions',
+        'sla_policy__filter__all',
+        'sla_policy__filter__any',
         'trigger__actions',
         'trigger__conditions__all',
         'trigger__conditions__any',
         'view__conditions__all',
         'view__conditions__any',
+        'workspace__conditions__all',
+        'workspace__conditions__any',
       ],
     },
     target: { typeContext: 'allowlistedNeighborField' },

--- a/packages/zendesk-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-adapter/src/filters/field_references.ts
@@ -239,6 +239,7 @@ type ZendeskFieldReferenceDefinition = referenceUtils.FieldReferenceDefinition<
   ReferenceContextStrategyName
 > & {
   zendeskSerializationStrategy?: ZendeskReferenceSerializationStrategyName
+  // Strategy for non-list values. For list values please check listValuesMissingRefereces filter
   zendeskMissingRefStrategy?: referenceUtils.MissingReferenceStrategyName
 }
 
@@ -294,6 +295,7 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
     src: { field: 'group_restrictions' },
     serializationStrategy: 'id',
     target: { type: 'group' },
+    zendeskMissingRefStrategy: 'typeAndValue',
   },
   {
     src: { field: 'group_id' },
@@ -591,6 +593,7 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
     src: { field: 'ticket_form_id' },
     serializationStrategy: 'id',
     target: { type: 'ticket_form' },
+    zendeskMissingRefStrategy: 'typeAndValue',
   },
   {
     src: { field: 'ticket_form_ids' },

--- a/packages/zendesk-adapter/src/filters/references/list_values_missing_references.ts
+++ b/packages/zendesk-adapter/src/filters/references/list_values_missing_references.ts
@@ -16,9 +16,9 @@
 import _ from 'lodash'
 import { Element, isInstanceElement, isReferenceExpression, ReferenceExpression } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
+import { FETCH_CONFIG } from '../../config'
 import { FilterCreator } from '../../filter'
 import { createMissingInstance } from './missing_references'
-import { FETCH_CONFIG } from 'src/config'
 
 const log = logger(module)
 

--- a/packages/zendesk-adapter/src/filters/references/list_values_missing_references.ts
+++ b/packages/zendesk-adapter/src/filters/references/list_values_missing_references.ts
@@ -29,17 +29,23 @@ type FieldMissingReferenceDefinition = {
 
 const potentiallyMissingListValues: FieldMissingReferenceDefinition[] = [
   {
-    instanceType: 'trigger',
+    instanceType: 'automation',
     instancePath: 'actions',
     fieldNameToValueType: {
-      notification_sms_group: 'group',
       notification_group: 'group',
+      notification_target: 'target',
+      notification_webhook: 'webhook',
     },
   },
   {
     instanceType: 'trigger',
     instancePath: 'actions',
-    fieldNameToValueType: { notification_sms_group: 'group' },
+    fieldNameToValueType: {
+      notification_group: 'group',
+      notification_sms_group: 'group',
+      notification_target: 'target',
+      notification_webhook: 'webhook',
+    },
   },
 ]
 

--- a/packages/zendesk-adapter/src/filters/references/list_values_missing_references.ts
+++ b/packages/zendesk-adapter/src/filters/references/list_values_missing_references.ts
@@ -29,6 +29,12 @@ type FieldMissingReferenceDefinition = {
   valueIndexToRedefine: number
 }
 
+const isNumberStr = (str: string | undefined): boolean => (
+  !_.isEmpty(str) && !Number.isNaN(Number(str))
+)
+
+const NON_NUMERIC_MISSING_VALUES_TYPES = ['webhook']
+
 const potentiallyMissingListValues: FieldMissingReferenceDefinition[] = [
   {
     instanceType: 'automation',
@@ -76,7 +82,10 @@ const filter: FilterCreator = ({ config }) => ({
           const valueType = def.fieldNameToValueType[obj.field]
           if (fieldRefTypes.includes(obj.field)
             && !isReferenceExpression(valueToRedefine)
-            && !VALUES_TO_SKIP_BY_TYPE[valueType]?.includes(valueToRedefine)) {
+            && !VALUES_TO_SKIP_BY_TYPE[valueType]?.includes(valueToRedefine)
+            && (isNumberStr(valueToRedefine)
+              || NON_NUMERIC_MISSING_VALUES_TYPES.includes(valueType)
+            )) {
             const missingInstance = createMissingInstance(
               instance.elemID.adapter,
               valueType,

--- a/packages/zendesk-adapter/src/filters/references/list_values_missing_references.ts
+++ b/packages/zendesk-adapter/src/filters/references/list_values_missing_references.ts
@@ -1,0 +1,82 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _, { keys } from 'lodash'
+import { Element, isInstanceElement, isReferenceExpression, ReferenceExpression } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { FilterCreator } from '../../filter'
+import { createMissingInstance } from './missing_references'
+
+const log = logger(module)
+
+type FieldMissingReferenceDefinition = {
+  instanceType: string
+  instancePath: string
+  fieldNameToValueType: Record<string, string>
+}
+
+const potentiallyMissingListValues: FieldMissingReferenceDefinition[] = [
+  {
+    instanceType: 'trigger',
+    instancePath: 'actions',
+    fieldNameToValueType: {
+      notification_sms_group: 'group',
+      notification_group: 'group',
+    },
+  },
+  {
+    instanceType: 'trigger',
+    instancePath: 'actions',
+    fieldNameToValueType: { notification_sms_group: 'group' },
+  },
+]
+
+const isNumberStr = (str: string | undefined): boolean => (
+  !_.isEmpty(str) && !Number.isNaN(_.toNumber(str))
+)
+
+/**
+ * Convert field list values into references, based on predefined configuration.
+ */
+const filter: FilterCreator = () => ({
+  onFetch: async (elements: Element[]) => log.time(async () => {
+    potentiallyMissingListValues.forEach(def => {
+      const fieldRefTypes = keys(def.fieldNameToValueType)
+      const instances = elements
+        .filter(isInstanceElement)
+        .filter(instance => instance.elemID.typeName === def.instanceType)
+      instances.forEach(instance => {
+        const valueObjects = _.get(instance.value, def.instancePath)
+        if (!_.isArray(valueObjects)) {
+          return
+        }
+        valueObjects.forEach(obj => {
+          if (fieldRefTypes.includes(obj.field)
+            && !isReferenceExpression(obj.value[0])
+            && isNumberStr(obj.value[0])) {
+            const missingInstance = createMissingInstance(
+              instance.elemID.adapter,
+              def.fieldNameToValueType[obj.field],
+              obj.value[0]
+            )
+            obj.value[0] = new ReferenceExpression(missingInstance.elemID, missingInstance)
+          }
+        })
+      })
+    })
+  }, 'List values missing references filter'),
+})
+
+export default filter

--- a/packages/zendesk-adapter/src/filters/references/list_values_missing_references.ts
+++ b/packages/zendesk-adapter/src/filters/references/list_values_missing_references.ts
@@ -18,6 +18,7 @@ import { Element, isInstanceElement, isReferenceExpression, ReferenceExpression 
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../../filter'
 import { createMissingInstance } from './missing_references'
+import { FETCH_CONFIG } from 'src/config'
 
 const log = logger(module)
 
@@ -59,8 +60,11 @@ const isNumberStr = (str: string | undefined): boolean => (
 /**
  * Convert field list values into references, based on predefined configuration.
  */
-const filter: FilterCreator = () => ({
+const filter: FilterCreator = ({ config }) => ({
   onFetch: async (elements: Element[]) => log.time(async () => {
+    if (!config[FETCH_CONFIG].enableMissingReferences) {
+      return
+    }
     potentiallyMissingListValues.forEach(def => {
       const fieldRefTypes = Object.keys(def.fieldNameToValueType)
       const instances = elements

--- a/packages/zendesk-adapter/src/filters/references/missing_references.ts
+++ b/packages/zendesk-adapter/src/filters/references/missing_references.ts
@@ -21,8 +21,8 @@ import { naclCase } from '@salto-io/adapter-utils'
 
 const MISSING_REF_PREFIX = 'missing_'
 
-const VALUES_TO_SKIP_BY_TYPE: Record<string, string> = {
-  group: 'current_groups',
+export const VALUES_TO_SKIP_BY_TYPE: Record<string, string[]> = {
+  group: ['current_groups', 'group_id'],
 }
 
 export const createMissingInstance = (
@@ -44,7 +44,7 @@ referenceUtils.MissingReferenceStrategyName, referenceUtils.MissingReferenceStra
 > = {
   typeAndValue: {
     create: ({ value, adapter, typeName }) => {
-      if (!_.isString(typeName) || !value || VALUES_TO_SKIP_BY_TYPE[typeName] === value) {
+      if (!_.isString(typeName) || !value || VALUES_TO_SKIP_BY_TYPE[typeName]?.includes(value)) {
         return undefined
       }
       return createMissingInstance(adapter, typeName, value)

--- a/packages/zendesk-adapter/src/filters/references/missing_references.ts
+++ b/packages/zendesk-adapter/src/filters/references/missing_references.ts
@@ -25,6 +25,20 @@ const VALUES_TO_SKIP_BY_TYPE: Record<string, string> = {
   group: 'current_groups',
 }
 
+export const createMissingInstance = (
+  adapter: string,
+  typeName: string,
+  refName: string
+): InstanceElement => (
+  new InstanceElement(
+    naclCase(`${MISSING_REF_PREFIX}${refName}`),
+    new ObjectType({ elemID: new ElemID(adapter, typeName) }),
+    {},
+    undefined,
+    { [referenceUtils.MISSING_ANNOTATION]: true },
+  )
+)
+
 export const ZendeskMissingReferenceStrategyLookup: Record<
 referenceUtils.MissingReferenceStrategyName, referenceUtils.MissingReferenceStrategy
 > = {
@@ -33,13 +47,7 @@ referenceUtils.MissingReferenceStrategyName, referenceUtils.MissingReferenceStra
       if (!_.isString(typeName) || !value || VALUES_TO_SKIP_BY_TYPE[typeName] === value) {
         return undefined
       }
-      return new InstanceElement(
-        naclCase(`${MISSING_REF_PREFIX}${value}`),
-        new ObjectType({ elemID: new ElemID(adapter, typeName) }),
-        {},
-        undefined,
-        { [referenceUtils.MISSING_ANNOTATION]: true },
-      )
+      return createMissingInstance(adapter, typeName, value)
     },
   },
 }

--- a/packages/zendesk-adapter/test/filters/references/list_values_missing_references.test.ts
+++ b/packages/zendesk-adapter/test/filters/references/list_values_missing_references.test.ts
@@ -70,7 +70,9 @@ describe('list values missing references filter', () => {
         id: 7001,
         actions: [
           { field: 'notification_sms_group', value: ['123456789', '+123456678', 'sms message'] },
-          { field: 'notification_sms_group', value: ['group_id', '+123456678', 'sms message'] },
+          { field: 'notification_sms_grouwp', value: ['group_id', '+123456678', 'sms message'] },
+          { field: 'notification_webhook', value: ['01GB7WWYD3QM8G7BWTR7A28XWR', ['one', 'two']] },
+          { field: 'notification_target', value: ['01GB7WWYD3QM8G7BWTR7A28XWR', 'target'] },
         ],
       },
     ),
@@ -89,7 +91,7 @@ describe('list values missing references filter', () => {
         const brokenTrigger = elements.filter(
           e => isInstanceElement(e) && e.elemID.name === 'trigger1'
         )[0] as InstanceElement
-        expect(brokenTrigger.value.actions).toHaveLength(2)
+        expect(brokenTrigger.value.actions).toHaveLength(4)
         const triggerFirstAction = brokenTrigger.value.actions[0].value
         expect(triggerFirstAction[0]).toBeInstanceOf(ReferenceExpression)
         expect(triggerFirstAction[0].value.elemID.name)
@@ -97,16 +99,36 @@ describe('list values missing references filter', () => {
         expect(triggerFirstAction[1]).not.toBeInstanceOf(ReferenceExpression)
         expect(triggerFirstAction[2]).not.toBeInstanceOf(ReferenceExpression)
       })
+      it('should create missing references for a non-numeric webhook first element in a list', () => {
+        const brokenTrigger = elements.filter(
+          e => isInstanceElement(e) && e.elemID.name === 'trigger1'
+        )[0] as InstanceElement
+        expect(brokenTrigger.value.actions[2].field).toBe('notification_webhook')
+        const webhookAction = brokenTrigger.value.actions[2].value
+        expect(webhookAction[0]).toBeInstanceOf(ReferenceExpression)
+        expect(webhookAction[0].value.elemID.name)
+          .toEqual('missing_01GB7WWYD3QM8G7BWTR7A28XWR')
+        expect(webhookAction[1]).not.toBeInstanceOf(ReferenceExpression)
+      })
+      it('should not create missing references for skip_list values in the first element in a list', () => {
+        const brokenTrigger = elements.filter(
+          e => isInstanceElement(e) && e.elemID.name === 'trigger1'
+        )[0] as InstanceElement
+        expect(brokenTrigger.value.actions[3].field).toBe('notification_target')
+        const targetAction = brokenTrigger.value.actions[3].value
+        expect(targetAction[0]).not.toBeInstanceOf(ReferenceExpression)
+        expect(targetAction[0]).toEqual('01GB7WWYD3QM8G7BWTR7A28XWR')
+        expect(targetAction[1]).not.toBeInstanceOf(ReferenceExpression)
+        expect(targetAction[2]).not.toBeInstanceOf(ReferenceExpression)
+      })
       it('should not create missing references for non-numeric first element in a list', () => {
         const brokenTrigger = elements.filter(
           e => isInstanceElement(e) && e.elemID.name === 'trigger1'
         )[0] as InstanceElement
-        expect(brokenTrigger.value.actions).toHaveLength(2)
         const triggerSecondAction = brokenTrigger.value.actions[1].value
         expect(triggerSecondAction[0]).not.toBeInstanceOf(ReferenceExpression)
         expect(triggerSecondAction[0]).toEqual('group_id')
         expect(triggerSecondAction[1]).not.toBeInstanceOf(ReferenceExpression)
-        expect(triggerSecondAction[2]).not.toBeInstanceOf(ReferenceExpression)
       })
     })
   })

--- a/packages/zendesk-adapter/test/filters/references/list_values_missing_references.test.ts
+++ b/packages/zendesk-adapter/test/filters/references/list_values_missing_references.test.ts
@@ -1,0 +1,113 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType, ReferenceExpression, Element,
+  BuiltinTypes, isInstanceElement, ListType } from '@salto-io/adapter-api'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import filterCreator from '../../../src/filters/references/list_values_missing_references'
+import ZendeskClient from '../../../src/client/client'
+import { paginate } from '../../../src/client/pagination'
+import { DEFAULT_CONFIG } from '../../../src/config'
+import { ZENDESK } from '../../../src/constants'
+
+describe('list values missing references filter', () => {
+  let client: ZendeskClient
+  type FilterType = filterUtils.FilterWith<'onFetch'>
+  let filter: FilterType
+
+  beforeAll(() => {
+    client = new ZendeskClient({
+      credentials: { username: 'a', password: 'b', subdomain: 'c' },
+    })
+    filter = filterCreator({
+      client,
+      paginator: clientUtils.createPaginator({
+        client,
+        paginationFuncCreator: paginate,
+      }),
+      config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
+    }) as FilterType
+  })
+
+  const triggerType = new ObjectType({
+    elemID: new ElemID(ZENDESK, 'trigger'),
+    fields: {
+      id: { refType: BuiltinTypes.NUMBER },
+      // eslint-disable-next-line camelcase
+      category_id: { refType: new ListType(BuiltinTypes.NUMBER) },
+      actions: {
+        refType: new ListType(new ObjectType({
+          elemID: new ElemID(ZENDESK, 'trigger__actions'),
+          fields: {
+            field: { refType: BuiltinTypes.STRING },
+            value: { refType: BuiltinTypes.STRING },
+          },
+        })),
+      },
+    },
+  })
+
+  const generateElements = (
+  ): Element[] => ([
+    triggerType,
+    new InstanceElement(
+      'trigger1',
+      triggerType,
+      {
+        id: 7001,
+        actions: [
+          { field: 'notification_sms_group', value: ['123456789', '+123456678', 'sms message'] },
+          { field: 'notification_sms_group', value: ['not_missing_due_to_not_numeric', '+123456678', 'sms message'] },
+        ],
+      },
+    ),
+  ])
+
+  describe('on fetch', () => {
+    let elements: Element[]
+
+    beforeAll(async () => {
+      elements = generateElements()
+      await filter.onFetch(elements)
+    })
+
+    describe('missing references', () => {
+      it('should create missing references for a numeric first element in a list', () => {
+        const brokenTrigger = elements.filter(
+          e => isInstanceElement(e) && e.elemID.name === 'trigger1'
+        )[0] as InstanceElement
+        expect(brokenTrigger.value.actions).toHaveLength(2)
+        const triggerFirstAction = brokenTrigger.value.actions[0].value
+        expect(triggerFirstAction[0]).toBeInstanceOf(ReferenceExpression)
+        expect(triggerFirstAction[0].value.elemID.name)
+          .toEqual('missing_123456789')
+        expect(triggerFirstAction[1]).not.toBeInstanceOf(ReferenceExpression)
+        expect(triggerFirstAction[2]).not.toBeInstanceOf(ReferenceExpression)
+      })
+      it('should not create missing references for non-numeric first element in a list', () => {
+        const brokenTrigger = elements.filter(
+          e => isInstanceElement(e) && e.elemID.name === 'trigger1'
+        )[0] as InstanceElement
+        expect(brokenTrigger.value.actions).toHaveLength(2)
+        const triggerSecondAction = brokenTrigger.value.actions[1].value
+        expect(triggerSecondAction[0]).not.toBeInstanceOf(ReferenceExpression)
+        expect(triggerSecondAction[0]).toEqual('not_missing_due_to_not_numeric')
+        expect(triggerSecondAction[1]).not.toBeInstanceOf(ReferenceExpression)
+        expect(triggerSecondAction[2]).not.toBeInstanceOf(ReferenceExpression)
+      })
+    })
+  })
+})

--- a/packages/zendesk-adapter/test/filters/references/list_values_missing_references.test.ts
+++ b/packages/zendesk-adapter/test/filters/references/list_values_missing_references.test.ts
@@ -70,7 +70,7 @@ describe('list values missing references filter', () => {
         id: 7001,
         actions: [
           { field: 'notification_sms_group', value: ['123456789', '+123456678', 'sms message'] },
-          { field: 'notification_sms_group', value: ['not_missing_due_to_not_numeric', '+123456678', 'sms message'] },
+          { field: 'notification_sms_group', value: ['group_id', '+123456678', 'sms message'] },
         ],
       },
     ),
@@ -104,7 +104,7 @@ describe('list values missing references filter', () => {
         expect(brokenTrigger.value.actions).toHaveLength(2)
         const triggerSecondAction = brokenTrigger.value.actions[1].value
         expect(triggerSecondAction[0]).not.toBeInstanceOf(ReferenceExpression)
-        expect(triggerSecondAction[0]).toEqual('not_missing_due_to_not_numeric')
+        expect(triggerSecondAction[0]).toEqual('group_id')
         expect(triggerSecondAction[1]).not.toBeInstanceOf(ReferenceExpression)
         expect(triggerSecondAction[2]).not.toBeInstanceOf(ReferenceExpression)
       })


### PR DESCRIPTION
Adding a new Zendesk filter which converts the first element in a 'value' field to a missing references. These paths are taken by a fixed list in the filter.
Supported types & fields:
* Trigger - all group variations, target, ticket_form
* Automation - all group variations, target, ticket_form
* View - ticket_form
* Workspace (new) - group, brand
* Macro - ticket_form
* SLA policy (new) - group, brand, ticket_form

To Do:
- [x] UT
- [x] add more types and fields

---

_Additional context for reviewer_
* Igonring fixed values by checking if they aren't numbers, because it was already supposed to be converted in field_references filter

---
_Release Notes_: 
* Adding support for all group variations, target, ticket_form, webhook to the missing references field
* Adding missing references to workspaces and sla_policy types

---
_User Notifications_: 
* Missing references for Workspace & SLA_policy types
* Missing references for all group variations, target, ticket_form fields
