### PR TITLE
SALTO-2401 Throw validation error for unexpected values in adapters config

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -291,6 +291,7 @@ Currently the following core annotations are supported:
 - [_creatable](#_created_at)
 - [_updatable](#_changed_by)
 - [_deletable](#_changed_at)
+- [_additional_properties](#_additional_properties)
 
 #### `_required`
 This annotation is used on field blocks to specify that an instance must contain a value for this field.
@@ -703,6 +704,27 @@ For the deletion of the following instance, an error will be shown to the user a
 ```HCL
 salto.notDeletable instance {
   someField = 2
+}
+```
+
+#### `_additional_properties`
+This annotation can be used on types to specify whether the type allows additional properties.
+When it is set to false, values of this type may only contain the fields that this type allows, any additional value would cause a validation warning.
+
+Type: `boolean`
+Default: `true`
+Applicable to: Types
+Example:
+```HCL
+type salto.example_type {
+  number field {
+  }
+  _additional_properties = false
+}
+
+salto.example_type example_instance {
+  field = 1 // This is valid, as 'field' is a property of the type
+  other_field = 2 // This will cause a warning because 'other_field' does not appear in the type definition
 }
 ```
 

--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -40,6 +40,7 @@ import {
   IllegalReferenceValidationError,
   UnresolvedReferenceValidationError,
   MissingRequiredFieldValidationError,
+  AdditionalPropertiesValidationError,
   RegexMismatchValidationError,
   InvalidValueRangeValidationError,
   InvalidValueMaxLengthValidationError,
@@ -99,6 +100,7 @@ const NameToType = {
   IllegalReferenceValidationError: IllegalReferenceValidationError,
   UnresolvedReferenceValidationError: UnresolvedReferenceValidationError,
   MissingRequiredFieldValidationError: MissingRequiredFieldValidationError,
+  AdditionalPropertiesValidationError: AdditionalPropertiesValidationError,
   RegexMismatchValidationError: RegexMismatchValidationError,
   InvalidValueRangeValidationError: InvalidValueRangeValidationError,
   InvalidValueMaxLengthValidationError: InvalidValueMaxLengthValidationError,
@@ -407,6 +409,14 @@ const generalDeserialize = async <T>(
           elemID: reviveElemID(v.elemID),
           fieldName: v.fieldName,
         })
+      ),
+      AdditionalPropertiesValidationError: v => (
+        new AdditionalPropertiesValidationError({
+          elemID: reviveElemID(v.elemID),
+          fieldName: v.fieldName,
+          typeName: v.typeName,
+        })
+
       ),
       RegexMismatchValidationError: v => (
         new RegexMismatchValidationError({

--- a/packages/workspace/src/validator.ts
+++ b/packages/workspace/src/validator.ts
@@ -218,6 +218,24 @@ export class MissingRequiredFieldValidationError extends ValidationError {
   }
 }
 
+export class AdditionalPropertiesValidationError extends ValidationError {
+  readonly fieldName: string
+  readonly typeName: string
+
+  constructor(
+    { elemID, fieldName, typeName }: { elemID: ElemID; fieldName: string; typeName: string }
+  ) {
+    super({
+      elemID,
+      error: `Field '${fieldName}' is not defined in the '${typeName}'`
+      + ' type which does not allow additional properties.',
+      severity: 'Warning',
+    })
+    this.fieldName = fieldName
+    this.typeName = typeName
+  }
+}
+
 export class UnresolvedReferenceValidationError extends ValidationError {
   readonly target: ElemID
   constructor(
@@ -234,7 +252,6 @@ export const isUnresolvedRefError = (
 ): err is UnresolvedReferenceValidationError => (
   err instanceof UnresolvedReferenceValidationError
 )
-
 
 export class IllegalReferenceValidationError extends ValidationError {
   readonly reason: string
@@ -511,15 +528,15 @@ const validateValue = (
     if (!_.isObjectLike(value)) {
       return [new InvalidValueTypeValidationError({ elemID, value, type: type.elemID })]
     }
-    const objType = toObjectType(type, value)
+    const objectType = toObjectType(type, value)
     return Object.keys(value).flatMap(
       // eslint-disable-next-line no-use-before-define
-      k => validateFieldValue(
-        elemID.createNestedID(k),
-        value[k],
-        objType.fields[k]?.refType.type ?? BuiltinTypes.UNKNOWN,
-        objType.fields[k]?.annotations ?? {},
-      )
+      k => validateFieldValueAndName({
+        parentElemID: elemID,
+        value: value[k],
+        fieldName: k,
+        objType: objectType,
+      })
     )
   }
 
@@ -586,6 +603,34 @@ const validateFieldValue = (
     item.nestedID,
     item.value,
     innerType,
+  ))
+}
+
+const validateNotAdditionalProperty = (
+  elemID: ElemID,
+  fieldName: string,
+  objType : ObjectType,
+) : ValidationError[] =>
+  (!Object.prototype.hasOwnProperty.call(objType.fields, fieldName)
+    ? [new AdditionalPropertiesValidationError(
+      { elemID, fieldName, typeName: objType.elemID.typeName }
+    )]
+    : [])
+
+const validateFieldValueAndName = ({ parentElemID, value, fieldName, objType } : {
+  parentElemID: ElemID
+  value: Value
+  fieldName: string
+  objType: ObjectType
+ }): ValidationError[] => {
+  const errors = objType.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES] === false
+    ? validateNotAdditionalProperty(parentElemID, fieldName, objType)
+    : []
+  return errors.concat(validateFieldValue(
+    parentElemID.createNestedID(fieldName),
+    value,
+    objType.fields[fieldName]?.refType.type ?? BuiltinTypes.UNKNOWN,
+    objType.fields[fieldName]?.annotations ?? {},
   ))
 }
 


### PR DESCRIPTION
Fixed performance problem that caused revert. See JIRA ticket for more details 

---
_Release Notes_: 
Core:
A new annotation was added- _additional_properties. It allows warning when unexpected values are present in NaCl

---
_User Notifications_: 
None
