### PR TITLE
SALTO-2628 - Warn (in logs) when duplicate type names causes concealment

### DIFF
--- a/packages/adapter-components/src/elements/subtypes.ts
+++ b/packages/adapter-components/src/elements/subtypes.ts
@@ -38,8 +38,8 @@ export const getSubtypes = async (
         return
       }
       if (fieldType.elemID.getFullName() in subtypes) {
-        if (validateUniqueness && subtypes[fieldType.elemID.getFullName()].isEqual(fieldType)) {
-          log.warn(`duplicate ElemIDs of subtypes found. the duplicate is ${fieldType.elemID.getFullName()}`)
+        if (validateUniqueness && !subtypes[fieldType.elemID.getFullName()].isEqual(fieldType)) {
+          log.warn(`duplicate ElemIDs of subtypes found. The duplicate is ${fieldType.elemID.getFullName()}`)
         }
         return
       }


### PR DESCRIPTION
Fixed a bug that caused the warning to be issued on the wrong items, and also a typo

---
_Release Notes_: 
None

---
_User Notifications_: 
None
