### PR TITLE
SALTO-2594: add deploy for Zendesk Guide permission groups

### DIFF
--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -1747,6 +1747,28 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
       fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
       fieldTypeOverrides: [{ fieldName: 'id', fieldType: 'number' }],
     },
+    deployRequests: {
+      add: {
+        url: '/guide/permission_groups',
+        deployAsField: 'permission_group',
+        method: 'post',
+      },
+      modify: {
+        url: '/guide/permission_groups/{permissionGroupId}',
+        method: 'put',
+        deployAsField: 'permission_group',
+        urlParamsToFields: {
+          permissionGroupId: 'id',
+        },
+      },
+      remove: {
+        url: '/guide/permission_groups/{permissionGroupId}',
+        method: 'delete',
+        urlParamsToFields: {
+          permissionGroupId: 'id',
+        },
+      },
+    },
   },
   user_segments: {
     request: {


### PR DESCRIPTION
_Support deploy for Zendesk Guide permission groups_

---

_Additional context for reviewer_
None

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
