### PR TITLE
SALTO-2684: CLI prints deployment url message even if its empty

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -228,8 +228,8 @@ export const action: WorkspaceCommandAction<DeployArgs> = async ({
     }
   )
   outputLine(postDeployActionsOutput.join('\n'), output)
-  const deploymentUrls = result.extraProperties?.deploymentUrls
-  if (deploymentUrls !== undefined) {
+  const deploymentUrls = result.extraProperties?.deploymentUrls ?? []
+  if (!_.isEmpty(deploymentUrls)) {
     outputLine(`You can see your deployment here:\n${deploymentUrls.join('\n')}`, output)
   }
   return cliExitCode


### PR DESCRIPTION
_CLI prints deployment url message even if its empty_

---

_Additional context for reviewer_
None

---
_Release Notes_: 
_CLI_
* Bugfix: prevent the CLI from print an unnecessary message upon deployment

---
_User Notifications_: 
_None_
