### PR TITLE
SALTO-2652 Enable deploy QuickAction with only one QuickActionLayoutColumns

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/profile_map_keys.ts
+++ b/packages/salesforce-adapter/src/change_validators/profile_map_keys.ts
@@ -76,6 +76,7 @@ const getMapKeyErrors = async (
       type: fieldType,
       transformFunc: findInvalidPaths,
       strict: false,
+      allowEmpty: true,
       pathID: after.elemID.createNestedID(fieldName),
     })
   })

--- a/packages/salesforce-adapter/src/filters/convert_types.ts
+++ b/packages/salesforce-adapter/src/filters/convert_types.ts
@@ -48,6 +48,7 @@ const filterCreator: LocalFilterCreator = () => ({
             type: await instance.getType(),
             transformFunc: transformPrimitive,
             strict: false,
+            allowEmpty: true,
           }
         ) || {}
       })

--- a/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
@@ -201,6 +201,7 @@ const replaceLookupsWithRefsAndCreateRefMap = async (
         type: await instance.getType(),
         transformFunc,
         strict: false,
+        allowEmpty: true,
       }
     ) ?? instance.value
   }

--- a/packages/salesforce-adapter/src/filters/custom_objects_to_object_type.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_to_object_type.ts
@@ -257,6 +257,7 @@ export const transformFieldAnnotations = async (
       type: annotationsType,
       transformFunc: transformPrimitive,
       strict: false,
+      allowEmpty: true,
     }
   ) || {}
 }
@@ -270,6 +271,7 @@ const transformObjectAnnotationValues = (instance: InstanceElement,
       values: instance.value,
       type: annotationsObject,
       transformFunc: transformPrimitive,
+      allowEmpty: true,
     }
   )
 }

--- a/packages/salesforce-adapter/src/filters/foreign_key_references.ts
+++ b/packages/salesforce-adapter/src/filters/foreign_key_references.ts
@@ -58,6 +58,7 @@ const resolveReferences = async (
     type: await instance.getType(),
     transformFunc: transformPrimitive,
     strict: false,
+    allowEmpty: true,
   }) ?? instance.value
 }
 

--- a/packages/salesforce-adapter/src/filters/remove_fields_and_values.ts
+++ b/packages/salesforce-adapter/src/filters/remove_fields_and_values.ts
@@ -65,6 +65,7 @@ const removeValuesFromInstances = async (
         type: await inst.getType(),
         transformFunc: removeValuesFunc,
         strict: false,
+        allowEmpty: true,
         pathID: inst.elemID,
       }) || inst.value
     })

--- a/packages/salesforce-adapter/src/filters/replace_instance_field_values.ts
+++ b/packages/salesforce-adapter/src/filters/replace_instance_field_values.ts
@@ -96,6 +96,7 @@ const replaceInstanceValues = async (
       type: await instance.getType(),
       transformFunc,
       strict: false,
+      allowEmpty: true,
     }
   ) ?? values
 }

--- a/packages/salesforce-adapter/src/filters/value_to_static_file.ts
+++ b/packages/salesforce-adapter/src/filters/value_to_static_file.ts
@@ -82,6 +82,7 @@ const extractToStaticFile = async (instance: InstanceElement): Promise<void> => 
       type: await instance.getType(),
       transformFunc,
       strict: false,
+      allowEmpty: true,
     }
   ) ?? values
 }

--- a/packages/salesforce-adapter/src/filters/xml_attributes.ts
+++ b/packages/salesforce-adapter/src/filters/xml_attributes.ts
@@ -47,6 +47,7 @@ const removeAttributePrefix = async (instance: InstanceElement): Promise<void> =
     values: instance.value,
     type,
     strict: false,
+    allowEmpty: true,
     transformFunc: async ({ value, field }) => {
       const fieldType = await field?.getType()
       return isObjectType(fieldType) ? removeAttributePrefixForValue(value, fieldType) : value

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -1121,12 +1121,13 @@ export const transformPrimitive: TransformFunc = async ({ value, path, field }) 
   }
   const fieldType = await field?.getType()
 
-  if (isContainerType(fieldType) && value === '') {
+  if (isContainerType(fieldType) && _.isEmpty(value)) {
     return undefined
   }
-  if (isObjectType(fieldType) && _.isEmpty(value)) {
-    // eslint-disable-next-line max-len
-    // We parse empty object as "" (empty string), and we dont want to delete them so we replace them with {} (empty object)
+  if (isObjectType(fieldType) && value === '') {
+    // Salesforce returns empty objects in XML as <quickAction></quickAction> for example
+    // We treat them as "" (empty string), and we don't want to delete them
+    // We should replace them with {} (empty object)
     return {}
   }
   if (!isPrimitiveType(fieldType) || !isPrimitiveValue(value)) {
@@ -1313,9 +1314,6 @@ export const toDeployableInstance = async (element: InstanceElement): Promise<In
   const removeLocalOnly: TransformFunc = ({ value, field }) => {
     if (isLocalOnly(field)) {
       return undefined
-    }
-    if (value === '' || value === []) {
-      return {}
     }
     return value
   }

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -1309,11 +1309,15 @@ export const getSObjectFieldElement = (
 }
 
 export const toDeployableInstance = async (element: InstanceElement): Promise<InstanceElement> => {
-  const removeLocalOnly: TransformFunc = ({ value, field }) => (
-    (isLocalOnly(field))
-      ? undefined
-      : value
-  )
+  const removeLocalOnly: TransformFunc = ({ value, field }) => {
+    if (isLocalOnly(field)) {
+      return undefined
+    }
+    if (_.isEmpty(value)) {
+      return {}
+    }
+    return value
+  }
   return transformElement({
     element,
     transformFunc: removeLocalOnly,

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -1311,12 +1311,11 @@ export const getSObjectFieldElement = (
 }
 
 export const toDeployableInstance = async (element: InstanceElement): Promise<InstanceElement> => {
-  const removeLocalOnly: TransformFunc = ({ value, field }) => {
-    if (isLocalOnly(field)) {
-      return undefined
-    }
-    return value
-  }
+  const removeLocalOnly: TransformFunc = ({ value, field }) => (
+    (isLocalOnly(field))
+      ? undefined
+      : value
+  )
   return transformElement({
     element,
     transformFunc: removeLocalOnly,

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -1121,7 +1121,7 @@ export const transformPrimitive: TransformFunc = async ({ value, path, field }) 
   }
   const fieldType = await field?.getType()
 
-  if (isContainerType(fieldType) && _.isEmpty(value)) {
+  if (isContainerType(fieldType) && value === '') {
     return undefined
   }
   if (isObjectType(fieldType) && _.isEmpty(value)) {
@@ -1314,7 +1314,7 @@ export const toDeployableInstance = async (element: InstanceElement): Promise<In
     if (isLocalOnly(field)) {
       return undefined
     }
-    if (_.isEmpty(value)) {
+    if (value === '' || value === []) {
       return {}
     }
     return value

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -1124,7 +1124,10 @@ export const transformPrimitive: TransformFunc = async ({ value, path, field }) 
   if (isContainerType(fieldType) && _.isEmpty(value)) {
     return undefined
   }
-
+  if (isObjectType(fieldType) && value === '') {
+    //
+    return {}
+  }
   if (!isPrimitiveType(fieldType) || !isPrimitiveValue(value)) {
     return value
   }
@@ -1315,6 +1318,7 @@ export const toDeployableInstance = async (element: InstanceElement): Promise<In
     element,
     transformFunc: removeLocalOnly,
     strict: false,
+    allowEmpty: true,
   })
 }
 

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -1124,8 +1124,9 @@ export const transformPrimitive: TransformFunc = async ({ value, path, field }) 
   if (isContainerType(fieldType) && _.isEmpty(value)) {
     return undefined
   }
-  if (isObjectType(fieldType) && value === '') {
-    //
+  if (isObjectType(fieldType) && _.isEmpty(value)) {
+    // eslint-disable-next-line max-len
+    // We parse empty object as "" (empty string), and we dont want to delete them so we replace them with {} (empty object)
     return {}
   }
   if (!isPrimitiveType(fieldType) || !isPrimitiveValue(value)) {

--- a/packages/salesforce-adapter/src/transformers/xml_transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/xml_transformer.ts
@@ -333,6 +333,7 @@ const cloneValuesWithAttributePrefixes = async (instance: InstanceElement): Prom
     transformFunc: createPathsSetCallback,
     pathID: instance.elemID,
     strict: false,
+    allowEmpty: true,
   })
 
   const addAttributePrefixFunc: MapKeyFunc = ({ key, pathID }) => {

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -549,11 +549,10 @@ describe('SalesforceAdapter fetch', () => {
         expect(layout).toBeDefined()
         expect((await layout.getType()).elemID).toEqual(LAYOUT_TYPE_ID)
         expect(layout.value[constants.INSTANCE_FULL_NAME_FIELD]).toBe(layoutName)
-        expect(layout.value.layoutSections.length).toBe(3)
+        expect(layout.value.layoutSections.length).toBe(4)
         expect(layout.value.layoutSections[0].label).toBe('Description Information')
         expect(layout.value.layoutSections[0].layoutColumns[0].layoutItems[0].behavior).toBe('Edit')
         expect(layout.value.layoutSections[0].layoutColumns[1].layoutItems[0].field).toBe('Description2')
-        expect(layout.value.layoutSections[1].layoutColumns).toBeUndefined()
         expect(layout.value.layoutSections[1].label).toBe('Additional Information')
         expect(layout.value.layoutSections[2].style).toBe('CustomLinks')
         expect(
@@ -562,7 +561,6 @@ describe('SalesforceAdapter fetch', () => {
         ).toBe('string')
         expect(layout.value.processMetadataValues[1].name).toBe('leftHandSideReferenceTo')
         // empty objects should be omitted
-        expect(layout.value.processMetadataValues[1].value).toBeUndefined()
         expect(layout.value.processMetadataValues[2].name).toBe('leftHandSideReferenceTo2')
         // empty strings should be kept
         expect(layout.value.processMetadataValues[2].value).toEqual({ stringValue: '' })

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -205,6 +205,30 @@ export const mockTypes = {
       actionType: { refType: BuiltinTypes.STRING },
     },
   }),
+  QuickAction: createMetadataObjectType({
+    annotations: {
+      metadataType: 'QuickAction',
+      dirName: 'quickActions',
+      suffix: 'quickAction',
+    },
+    fields: {
+      quickActionLayout: {
+        refType: createMetadataObjectType({
+          annotations: {
+            metadataType: 'QuickActionLayout',
+          },
+          fields: {
+            quickActionLayoutColumns: {
+              refType: new ListType(createMetadataObjectType(
+                { annotations: { metadataType: 'QuickActionLayoutColumn' } }
+              )),
+            },
+          },
+        }),
+      },
+
+    },
+  }),
 }
 
 export const lwcJsResourceContent = "import { LightningElement } from 'lwc';\nexport default class BikeCard extends LightningElement {\n   name = 'Electra X4';\n   description = 'A sweet bike built for comfort.';\n   category = 'Mountain';\n   material = 'Steel';\n   price = '$2,700';\n   pictureUrl = 'https://s3-us-west-1.amazonaws.com/sfdc-demo/ebikes/electrax4.jpg';\n }"

--- a/packages/salesforce-adapter/test/transformers/xml_transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/xml_transformer.test.ts
@@ -84,6 +84,14 @@ describe('XML Transformer', () => {
         await pkg.add(createInstanceElement({ fullName: 'TestLayout' }, mockTypes.Layout))
         await pkg.add(createInstanceElement({ fullName: 'TestLayout2' }, mockTypes.Layout))
         await pkg.add(createInstanceElement(profileValues, mockTypes.Profile))
+        await pkg.add(createInstanceElement({ fullName: 'TestAction1',
+          quickActionLayout: { fullName: 'twoColumns',
+            quickActionLayoutColumns: [
+              { fullName: 'oneColumn' }, ''] } }, mockTypes.QuickAction))
+        await pkg.add(createInstanceElement({ fullName: 'TestAction2',
+          quickActionLayout: { fullName: 'twoColumns',
+            quickActionLayoutColumns: [
+              { fullName: 'oneColumn' }, []] } }, mockTypes.QuickAction))
         pkg.delete(mockTypes.Profile, 'foo')
         zipFiles = await getZipFiles(pkg)
       })
@@ -110,6 +118,18 @@ describe('XML Transformer', () => {
         expect(zipFiles).toHaveProperty([`${packageName}/layouts/TestLayout.layout`])
         expect(zipFiles).toHaveProperty([`${packageName}/layouts/TestLayout2.layout`])
         expect(zipFiles).toHaveProperty([`${packageName}/profiles/TestProfile.profile`])
+        expect(zipFiles).toHaveProperty([`${packageName}/quickActions/TestAction1.quickAction`])
+        expect(zipFiles).toHaveProperty([`${packageName}/quickActions/TestAction2.quickAction`])
+      })
+      it('should convert empty string into object', () => {
+        const quickActionXmlPath = `${packageName}/quickActions/TestAction1.quickAction`
+        const value = xmlParser.parse(zipFiles[quickActionXmlPath])
+        expect(value.QuickAction.quickActionLayout.quickActionLayoutColumns.length).toBe(2)
+      })
+      it('should convert empty array into object', () => {
+        const quickActionXmlPath = `${packageName}/quickActions/TestAction2.quickAction`
+        const value = xmlParser.parse(zipFiles[quickActionXmlPath])
+        expect(value.QuickAction.quickActionLayout.quickActionLayoutColumns.length).toBe(2)
       })
       describe('serialized xml file', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/salesforce-adapter/test/transformers/xml_transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/xml_transformer.test.ts
@@ -84,14 +84,6 @@ describe('XML Transformer', () => {
         await pkg.add(createInstanceElement({ fullName: 'TestLayout' }, mockTypes.Layout))
         await pkg.add(createInstanceElement({ fullName: 'TestLayout2' }, mockTypes.Layout))
         await pkg.add(createInstanceElement(profileValues, mockTypes.Profile))
-        await pkg.add(createInstanceElement({ fullName: 'TestAction1',
-          quickActionLayout: { fullName: 'twoColumns',
-            quickActionLayoutColumns: [
-              { fullName: 'oneColumn' }, ''] } }, mockTypes.QuickAction))
-        await pkg.add(createInstanceElement({ fullName: 'TestAction2',
-          quickActionLayout: { fullName: 'twoColumns',
-            quickActionLayoutColumns: [
-              { fullName: 'oneColumn' }, []] } }, mockTypes.QuickAction))
         pkg.delete(mockTypes.Profile, 'foo')
         zipFiles = await getZipFiles(pkg)
       })
@@ -118,18 +110,6 @@ describe('XML Transformer', () => {
         expect(zipFiles).toHaveProperty([`${packageName}/layouts/TestLayout.layout`])
         expect(zipFiles).toHaveProperty([`${packageName}/layouts/TestLayout2.layout`])
         expect(zipFiles).toHaveProperty([`${packageName}/profiles/TestProfile.profile`])
-        expect(zipFiles).toHaveProperty([`${packageName}/quickActions/TestAction1.quickAction`])
-        expect(zipFiles).toHaveProperty([`${packageName}/quickActions/TestAction2.quickAction`])
-      })
-      it('should convert empty string into object', () => {
-        const quickActionXmlPath = `${packageName}/quickActions/TestAction1.quickAction`
-        const value = xmlParser.parse(zipFiles[quickActionXmlPath])
-        expect(value.QuickAction.quickActionLayout.quickActionLayoutColumns.length).toBe(2)
-      })
-      it('should convert empty array into object', () => {
-        const quickActionXmlPath = `${packageName}/quickActions/TestAction2.quickAction`
-        const value = xmlParser.parse(zipFiles[quickActionXmlPath])
-        expect(value.QuickAction.quickActionLayout.quickActionLayoutColumns.length).toBe(2)
       })
       describe('serialized xml file', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
_Enable deploy QuickAction with only one QuickActionLayoutColumns_

---
_Additional context for reviewer_:
Salesforce returns empty objects in XML as `<quickAction></quickAction>` for example, We treat them as "" (empty string), and we don't want to delete them so we should replace them with {} (empty object). in addition we added `allowEmpty: true` param to every `transformValues` func so they wont automatically omit them. 

---
_Release Notes_: 
Salesforce-adapter:

* All Object that are defined as empty in Salesforce service will no longer be omitted and will be shown in the Nacl as empty object.
---

_User Notifications_: 
* All Object that are defined as empty in Salesforce service will no longer be omitted and will be shown in the Nacl as empty object.
