### PR TITLE
SALTO-2697 - updateAccountConfig supported without passing explicit elementSource

### DIFF
--- a/packages/workspace/src/workspace/adapters_config_source.ts
+++ b/packages/workspace/src/workspace/adapters_config_source.ts
@@ -46,14 +46,6 @@ export type AdaptersConfigSource = {
   isConfigFile(filePath: string): boolean
 } & PartialNaclFilesSource
 
-const removeUndefined = async (instance: InstanceElement): Promise<InstanceElement> =>
-  transformElement({
-    element: instance,
-    strict: false,
-    allowEmpty: true,
-    transformFunc: ({ value }) => value,
-  })
-
 const updateValidationErrorsCache = async (
   validationErrorsMap: RemoteMap<ValidationError[]>,
   elementsSource: ReadOnlyElementsSource,
@@ -150,6 +142,15 @@ export const buildAdaptersConfigSource = async ({
       })))
     // If flush is not called here the removal seems to be ignored
     await naclSource.flush()
+
+    const removeUndefined = async (instance: InstanceElement): Promise<InstanceElement> =>
+      transformElement({
+        element: instance,
+        strict: false,
+        allowEmpty: true,
+        transformFunc: ({ value }) => value,
+        elementsSource: naclSource,
+      })
 
     const configsToUpdate = await Promise.all(configsArr.map(removeUndefined))
     await naclSource.updateNaclFiles(


### PR DESCRIPTION
Currently, `updateAccountConfig` doesn't work when calling it without explicit ElementSource (even though it already has the relevant element source - `adapter_config_source`).
This PR fixes the issue :) .

---

_Additional context for reviewer_

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
