### PR TITLE
SALTO-2688 Zendesk E2E cleanup function

### DIFF
--- a/packages/zendesk-adapter/e2e_test/adapter.test.ts
+++ b/packages/zendesk-adapter/e2e_test/adapter.test.ts
@@ -81,10 +81,12 @@ const cleanup = async (adapterAttr: Reals): Promise<void> => {
     .filter(isInstanceElement)
     .filter(instance => instance.elemID.typeName === BRAND_TYPE_NAME)
     .filter(brand => brand.elemID.name.startsWith('Testbrand'))
-  await deployChanges(
-    adapterAttr,
-    { BRAND_TYPE_NAME: e2eBrandInstances.map(brand => toChange({ before: brand })) }
-  )
+  if (e2eBrandInstances.length > 0) {
+    await deployChanges(
+      adapterAttr,
+      { BRAND_TYPE_NAME: e2eBrandInstances.map(brand => toChange({ before: brand })) }
+    )
+  }
 }
 
 describe('Zendesk adapter E2E', () => {


### PR DESCRIPTION
Adding to Zendesk cleanup function that deletes all 'brand' instances which start with 'Testbrand'. This is necessary to verify we have no more 5 brands in the environment
---

_Additional context for reviewer_

---
_Release Notes_: 
-

---
_User Notifications_: 
-