### PR TITLE
SALTO-2702 Support Zendesk missing references in routing_attribute_value and user_segment (guide) types

### DIFF
--- a/packages/zendesk-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-adapter/src/filters/field_references.ts
@@ -118,6 +118,9 @@ const neighborReferenceTicketFieldLookupFunc: GetLookupNameFunc = async ({ ref }
 const neighborReferenceTicketFieldLookupType: referenceUtils.ContextValueMapperFunc = val =>
   (val === TICKET_FIELD_OPTION_TYPE_NAME ? val : undefined)
 
+const allowListLookupType: referenceUtils.ContextValueMapperFunc = val =>
+  (NEIGHBOR_FIELD_TO_TYPE_NAMES[val])
+
 const neighborReferenceUserAndOrgFieldLookupFunc: GetLookupNameFunc = async ({ ref }) => {
   if (isInstanceElement(ref.value) && ref.value.value.type === 'dropdown') {
     if (ref.elemID.typeName === USER_FIELD_TYPE_NAME) {
@@ -226,8 +229,8 @@ export const contextStrategyLookup: Record<
   neighborField: neighborContextFunc({ contextFieldName: 'field', contextValueMapper: getValueLookupType }),
   // We use allow lists because there are types we don't support (such organizarion or requester)
   // and they'll as false positives
-  allowlistedNeighborField: neighborContextFunc({ contextFieldName: 'field', contextValueMapper: val => NEIGHBOR_FIELD_TO_TYPE_NAMES[val] }),
-  allowlistedNeighborSubject: neighborContextFunc({ contextFieldName: 'subject', contextValueMapper: val => NEIGHBOR_FIELD_TO_TYPE_NAMES[val] }),
+  allowlistedNeighborField: neighborContextFunc({ contextFieldName: 'field', contextValueMapper: allowListLookupType }),
+  allowlistedNeighborSubject: neighborContextFunc({ contextFieldName: 'subject', contextValueMapper: allowListLookupType }),
   neighborReferenceTicketField: neighborContextFunc({ contextFieldName: 'field', getLookUpName: neighborReferenceTicketFieldLookupFunc, contextValueMapper: neighborReferenceTicketFieldLookupType }),
   neighborReferenceTicketFormCondition: neighborContextFunc({ contextFieldName: 'parent_field_id', getLookUpName: neighborReferenceTicketFieldLookupFunc, contextValueMapper: neighborReferenceTicketFieldLookupType }),
   neighborReferenceUserAndOrgField: neighborContextFunc({ contextFieldName: 'field', getLookUpName: neighborReferenceUserAndOrgFieldLookupFunc, contextValueMapper: neighborReferenceUserAndOrgFieldLookupType }),

--- a/packages/zendesk-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-adapter/src/filters/field_references.ts
@@ -43,6 +43,7 @@ const NEIGHBOR_FIELD_TO_TYPE_NAMES: Record<string, string> = {
   within_schedule: 'business_hours_schedule',
   set_schedule: 'business_hours_schedule',
   ticket_form_id: 'ticket_form',
+  locale_id: 'locale',
 }
 
 const SPECIAL_CONTEXT_NAMES: Record<string, string> = {
@@ -208,6 +209,7 @@ const ZendeskReferenceSerializationStrategyLookup: Record<
 
 export type ReferenceContextStrategyName = 'neighborField'
   | 'allowlistedNeighborField'
+  | 'allowlistedNeighborSubject'
   | 'neighborType'
   | 'parentSubject'
   | 'parentTitle'
@@ -222,7 +224,10 @@ export const contextStrategyLookup: Record<
   ReferenceContextStrategyName, referenceUtils.ContextFunc
 > = {
   neighborField: neighborContextFunc({ contextFieldName: 'field', contextValueMapper: getValueLookupType }),
+  // We use allow lists because there are types we don't support (such organizarion or requester)
+  // and they'll as false positives
   allowlistedNeighborField: neighborContextFunc({ contextFieldName: 'field', contextValueMapper: val => NEIGHBOR_FIELD_TO_TYPE_NAMES[val] }),
+  allowlistedNeighborSubject: neighborContextFunc({ contextFieldName: 'subject', contextValueMapper: val => NEIGHBOR_FIELD_TO_TYPE_NAMES[val] }),
   neighborReferenceTicketField: neighborContextFunc({ contextFieldName: 'field', getLookUpName: neighborReferenceTicketFieldLookupFunc, contextValueMapper: neighborReferenceTicketFieldLookupType }),
   neighborReferenceTicketFormCondition: neighborContextFunc({ contextFieldName: 'parent_field_id', getLookUpName: neighborReferenceTicketFieldLookupFunc, contextValueMapper: neighborReferenceTicketFieldLookupType }),
   neighborReferenceUserAndOrgField: neighborContextFunc({ contextFieldName: 'field', getLookUpName: neighborReferenceUserAndOrgFieldLookupFunc, contextValueMapper: neighborReferenceUserAndOrgFieldLookupType }),
@@ -306,6 +311,7 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
     src: { field: 'locale_id' },
     serializationStrategy: 'id',
     target: { type: 'locale' },
+    zendeskMissingRefStrategy: 'typeAndValue',
   },
   {
     src: { field: 'locale_ids' },
@@ -316,6 +322,7 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
     src: { field: 'default_locale_id' },
     serializationStrategy: 'id',
     target: { type: 'locale' },
+    zendeskMissingRefStrategy: 'typeAndValue',
   },
   {
     src: { field: 'variants', parentTypes: ['dynamic_content_item'] },
@@ -757,6 +764,8 @@ const commonFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[] = [
         'automation__conditions__all',
         'automation__conditions__any',
         'macro__actions',
+        'routing_attribute_value__conditions__all',
+        'routing_attribute_value__conditions__any',
         'sla_policy__filter__all',
         'sla_policy__filter__any',
         'trigger__actions',
@@ -769,6 +778,17 @@ const commonFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[] = [
       ],
     },
     target: { typeContext: 'allowlistedNeighborField' },
+    zendeskMissingRefStrategy: 'typeAndValue',
+  },
+  {
+    src: {
+      field: 'value',
+      parentTypes: [
+        'routing_attribute_value__conditions__all',
+        'routing_attribute_value__conditions__any',
+      ],
+    },
+    target: { typeContext: 'allowlistedNeighborSubject' },
     zendeskMissingRefStrategy: 'typeAndValue',
   },
 ]
@@ -832,6 +852,7 @@ const secondIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition
     },
     zendeskSerializationStrategy: 'ticketFieldOption',
     target: { typeContext: 'neighborSubjectReferenceTicketField' },
+    zendeskMissingRefStrategy: 'typeAndValue',
   },
   {
     src: {
@@ -854,6 +875,7 @@ const secondIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition
     },
     zendeskSerializationStrategy: 'userFieldOption',
     target: { typeContext: 'neighborSubjectReferenceUserAndOrgField' },
+    zendeskMissingRefStrategy: 'typeAndValue',
   },
   {
     src: {
@@ -881,6 +903,7 @@ const secondIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition
     src: { field: 'group_ids', parentTypes: ['user_segment'] },
     serializationStrategy: 'id',
     target: { type: 'group' },
+    zendeskMissingRefStrategy: 'typeAndValue',
   },
 ]
 

--- a/packages/zendesk-adapter/src/filters/references/missing_references.ts
+++ b/packages/zendesk-adapter/src/filters/references/missing_references.ts
@@ -23,6 +23,7 @@ const MISSING_REF_PREFIX = 'missing_'
 
 export const VALUES_TO_SKIP_BY_TYPE: Record<string, string[]> = {
   group: ['current_groups', 'group_id'],
+  webhook: ['(Value no longer exists. Choose another.)'],
 }
 
 export const createMissingInstance = (


### PR DESCRIPTION
Add Zendesk routing_attribute_value and user_segment (guide) types to missing references configuration
---

_Additional context for reviewer_

---
_Release Notes_: 
* Add Zendesk routing_attribute_value and user_segment (guide) types to missing references configuration

---
_User Notifications_: 
* missing references values will be replaced in routing_attribute_value and user_segment instances
