### PR TITLE
SALTO-2709 - Exported CONFIG_DIR_NAME from @salto-io/core

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -37,7 +37,6 @@ export {
   AppConfig,
   configFromDisk,
   CommandConfig,
-  getConfigDir,
   CONFIG_DIR_NAME,
 } from './src/app_config'
 export {

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -38,6 +38,7 @@ export {
   configFromDisk,
   CommandConfig,
   getConfigDir,
+  CONFIG_DIR_NAME,
 } from './src/app_config'
 export {
   telemetrySender, Telemetry, TelemetryEvent,

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -37,6 +37,7 @@ export {
   AppConfig,
   configFromDisk,
   CommandConfig,
+  getConfigDir,
   CONFIG_DIR_NAME,
 } from './src/app_config'
 export {

--- a/packages/core/src/app_config.ts
+++ b/packages/core/src/app_config.ts
@@ -38,10 +38,6 @@ const DEFAULT_SALTO_HOME = path.join(os.homedir(), '.salto')
 export const CONFIG_DIR_NAME = 'salto.config'
 const CONFIG_FILENAME = 'config.nacl'
 
-export const getConfigDir = (baseDir: string): string => (
-  path.join(path.resolve(baseDir), CONFIG_DIR_NAME)
-)
-
 export const getSaltoHome = (): string =>
   process.env[SALTO_HOME_VAR] || DEFAULT_SALTO_HOME
 

--- a/packages/core/src/app_config.ts
+++ b/packages/core/src/app_config.ts
@@ -38,6 +38,10 @@ const DEFAULT_SALTO_HOME = path.join(os.homedir(), '.salto')
 export const CONFIG_DIR_NAME = 'salto.config'
 const CONFIG_FILENAME = 'config.nacl'
 
+export const getConfigDir = (baseDir: string): string => (
+  path.join(path.resolve(baseDir), CONFIG_DIR_NAME)
+)
+
 export const getSaltoHome = (): string =>
   process.env[SALTO_HOME_VAR] || DEFAULT_SALTO_HOME
 

--- a/packages/core/src/local-workspace/workspace.ts
+++ b/packages/core/src/local-workspace/workspace.ts
@@ -83,7 +83,7 @@ const getNaclFilesSourceParams = ({
   staticFileSource: staticFiles.StaticFilesSource
 } => {
   const dirPathToIgnore = (dirPath: string): boolean =>
-    !(excludeDirs.concat(getConfigDir(sourceBaseDir))).includes(dirPath)
+    !(excludeDirs.concat(path.join(path.resolve(sourceBaseDir), CONFIG_DIR_NAME))).includes(dirPath)
 
   const naclFilesStore = localDirectoryStore({
     baseDir: sourceBaseDir,
@@ -159,7 +159,7 @@ export const createEnvironmentSource = async ({
     remoteMapCreator,
   ),
   state: localState(
-    path.join(getConfigDir(baseDir), STATES_DIR_NAME, env),
+    path.join(path.resolve(baseDir), CONFIG_DIR_NAME, STATES_DIR_NAME, env),
     env,
     remoteMapCreator,
     stateStaticFilesSource ?? state.buildOverrideStateStaticFilesSource(localDirectoryStore({

--- a/packages/core/src/local-workspace/workspace.ts
+++ b/packages/core/src/local-workspace/workspace.ts
@@ -25,7 +25,7 @@ import { Workspace, loadWorkspace, EnvironmentsSources, initWorkspace, nacl, rem
 import { collections } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import { localDirectoryStore, createExtensionFileFilter } from './dir_store'
-import { CONFIG_DIR_NAME, getConfigDir, getLocalStoragePath } from '../app_config'
+import { CONFIG_DIR_NAME, getLocalStoragePath } from '../app_config'
 import { localState } from './state'
 import { workspaceConfigSource } from './workspace_config'
 import { buildLocalStaticFilesCache } from './static_files_cache'


### PR DESCRIPTION
Exporting CONFIG_DIR_NAME from `@salto-io/core`.

---

_Additional context for reviewer_

---
_Release Notes_: 
-

---
_User Notifications_: 
-
