### PR TITLE
SALTO-2633: add dependency changer between field that modified to a new context - Jira

### DIFF
--- a/packages/jira-adapter/src/dependency_changers/field_contexts.ts
+++ b/packages/jira-adapter/src/dependency_changers/field_contexts.ts
@@ -17,7 +17,7 @@ import { dependencyChange, DependencyChanger, getChangeData, isAdditionChange, i
 import { FIELD_CONTEXT_TYPE_NAME, FIELD_TYPE_NAME } from '../filters/fields/constants'
 
 export const fieldContextDependencyChanger: DependencyChanger = async (changes, dependencies) => {
-  const modificationChanges = Array.from(changes.entries() ?? [])
+  const modificationChanges = Array.from(changes.entries())
     .map(([key, change]) => ({ key, change }))
     .filter(
       change =>
@@ -34,7 +34,7 @@ export const fieldContextDependencyChanger: DependencyChanger = async (changes, 
             return false
           }
           return isAdditionChange(change) && getChangeData(change).elemID.typeName
-           === FIELD_CONTEXT_TYPE_NAME
+            === FIELD_CONTEXT_TYPE_NAME
         })
       return contextDependencies.map(
         contextKey =>

--- a/packages/jira-adapter/src/dependency_changers/field_contexts.ts
+++ b/packages/jira-adapter/src/dependency_changers/field_contexts.ts
@@ -1,0 +1,48 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { dependencyChange, DependencyChanger, getChangeData, isAdditionChange, isInstanceChange, isModificationChange } from '@salto-io/adapter-api'
+import { FIELD_CONTEXT_TYPE_NAME, FIELD_TYPE_NAME } from '../filters/fields/constants'
+
+export const fieldContextDependencyChanger: DependencyChanger = async (changes, dependencies) => {
+  const modificationChanges = Array.from(changes.entries() ?? [])
+    .map(([key, change]) => ({ key, change }))
+    .filter(
+      change =>
+        isInstanceChange(change.change)
+        && isModificationChange(change.change)
+        && getChangeData(change.change).elemID.typeName === FIELD_TYPE_NAME
+    ).map(({ key }) => key)
+  return modificationChanges
+    .flatMap(modificationKey => {
+      const contextDependencies = Array.from(dependencies.get(modificationKey) ?? [])
+        .filter(key => {
+          const change = changes.get(key)
+          if (change === undefined) {
+            return false
+          }
+          return isAdditionChange(change) && getChangeData(change).elemID.typeName
+           === FIELD_CONTEXT_TYPE_NAME
+        })
+      return contextDependencies.map(
+        contextKey =>
+          dependencyChange(
+            'remove',
+            modificationKey,
+            contextKey
+          )
+      )
+    })
+}

--- a/packages/jira-adapter/src/dependency_changers/index.ts
+++ b/packages/jira-adapter/src/dependency_changers/index.ts
@@ -22,7 +22,7 @@ import { projectDependencyChanger } from './project'
 import { projectContextsDependencyChanger } from './project_contexts'
 import { removalsDependencyChanger } from './removals'
 import { workflowDependencyChanger } from './workflow'
-import { fieldContextDependencyChanger } from './field_context'
+import { fieldContextDependencyChanger } from './field_contexts'
 
 const { awu } = collections.asynciterable
 

--- a/packages/jira-adapter/src/dependency_changers/index.ts
+++ b/packages/jira-adapter/src/dependency_changers/index.ts
@@ -22,6 +22,7 @@ import { projectDependencyChanger } from './project'
 import { projectContextsDependencyChanger } from './project_contexts'
 import { removalsDependencyChanger } from './removals'
 import { workflowDependencyChanger } from './workflow'
+import { fieldContextDependencyChanger } from './field_context'
 
 const { awu } = collections.asynciterable
 
@@ -33,6 +34,7 @@ const DEPENDENCY_CHANGERS: DependencyChanger[] = [
   removalsDependencyChanger,
   globalFieldContextsDependencyChanger,
   projectContextsDependencyChanger,
+  fieldContextDependencyChanger,
 ]
 
 export const dependencyChanger: DependencyChanger = async (

--- a/packages/jira-adapter/test/dependency_changers/field_contexts.test.ts
+++ b/packages/jira-adapter/test/dependency_changers/field_contexts.test.ts
@@ -90,6 +90,35 @@ describe('fieldContextsDependencyChanger', () => {
     const dependencyChanges = [
       ...await fieldContextDependencyChanger(inputChanges, inputDeps),
     ]
-    expect(dependencyChanges).toHaveLength(0)
+    expect(dependencyChanges).toBeEmpty()
+  })
+  it('should not reverse any dependency because the dependency does not in the input dependencies', async () => {
+    const inputChanges = new Map([
+      [0, toChange({ before: fieldInstance, after: modifiedFieldInstance })],
+      [1, toChange({ after: contextInstance })],
+
+    ])
+    const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([
+    ])
+
+    const dependencyChanges = [
+      ...await fieldContextDependencyChanger(inputChanges, inputDeps),
+    ]
+    expect(dependencyChanges).toBeEmpty()
+  })
+
+  it('should not reverse any dependency because the modified field does not have a relevant dependency', async () => {
+    const inputChanges = new Map([
+      [0, toChange({ before: fieldInstance, after: modifiedFieldInstance })],
+
+    ])
+    const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([
+      [0, new Set([1])],
+    ])
+
+    const dependencyChanges = [
+      ...await fieldContextDependencyChanger(inputChanges, inputDeps),
+    ]
+    expect(dependencyChanges).toBeEmpty()
   })
 })

--- a/packages/jira-adapter/test/dependency_changers/field_contexts.test.ts
+++ b/packages/jira-adapter/test/dependency_changers/field_contexts.test.ts
@@ -1,0 +1,95 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, InstanceElement, ElemID, toChange, ReferenceExpression, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { fieldContextDependencyChanger } from '../../src/dependency_changers/field_contexts'
+import { JIRA } from '../../src/constants'
+import { FIELD_CONTEXT_TYPE_NAME, FIELD_TYPE_NAME } from '../../src/filters/fields/constants'
+
+describe('fieldContextsDependencyChanger', () => {
+  let contextType: ObjectType
+  let fieldType: ObjectType
+  let contextInstance: InstanceElement
+  let fieldInstance: InstanceElement
+  let modifiedFieldInstance: InstanceElement
+
+  beforeEach(() => {
+    fieldType = new ObjectType({
+      elemID: new ElemID(JIRA, FIELD_TYPE_NAME),
+    })
+    contextType = new ObjectType({
+      elemID: new ElemID(JIRA, FIELD_CONTEXT_TYPE_NAME),
+    })
+
+    fieldInstance = new InstanceElement(
+      'inst',
+      fieldType,
+      {
+        description: 'description',
+      },
+    )
+    modifiedFieldInstance = new InstanceElement(
+      'inst',
+      fieldType,
+      {
+        description: 'change description',
+      },
+    )
+    contextInstance = new InstanceElement(
+      'inst',
+      contextType,
+      undefined,
+      undefined,
+      {
+        [CORE_ANNOTATIONS.PARENT]:
+        [new ReferenceExpression(fieldInstance.elemID, fieldInstance)],
+      }
+    )
+  })
+  it('should reverse the dependency between the field and the context', async () => {
+    const inputChanges = new Map([
+      [0, toChange({ before: fieldInstance, after: modifiedFieldInstance })],
+      [1, toChange({ after: contextInstance })],
+
+    ])
+    const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([
+      [0, new Set([1])],
+    ])
+
+    const dependencyChanges = [
+      ...await fieldContextDependencyChanger(inputChanges, inputDeps),
+    ]
+    expect(dependencyChanges).toHaveLength(1)
+    expect(dependencyChanges[0].action).toEqual('remove')
+    expect(dependencyChanges[0].dependency.source).toEqual(0)
+    expect(dependencyChanges[0].dependency.target).toEqual(1)
+  })
+  it('should not reverse any dependency because we do not add new context', async () => {
+    const inputChanges = new Map([
+      [0, toChange({ before: fieldInstance, after: modifiedFieldInstance })],
+      [1, toChange({ before: contextInstance, after: contextInstance })],
+
+    ])
+    const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([
+      [0, new Set([1])],
+    ])
+
+    const dependencyChanges = [
+      ...await fieldContextDependencyChanger(inputChanges, inputDeps),
+    ]
+    expect(dependencyChanges).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
_Add dependency changer between field that modified to a new context_

---

_When a change validator omitted an adding of a context, the dependency caused omitting the modification change as well_

---
_Release Notes_: 
_Jira_
* fixed a bug related to the dependency between adding a new field context to modifying the field

---
_User Notifications_: 
None
