### PR TITLE
SALTO-2709 - gitConfigDir removed

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -37,7 +37,6 @@ export {
   AppConfig,
   configFromDisk,
   CommandConfig,
-  getConfigDir,
   CONFIG_DIR_NAME,
 } from './src/app_config'
 export {

--- a/packages/core/src/app_config.ts
+++ b/packages/core/src/app_config.ts
@@ -38,10 +38,6 @@ const DEFAULT_SALTO_HOME = path.join(os.homedir(), '.salto')
 export const CONFIG_DIR_NAME = 'salto.config'
 const CONFIG_FILENAME = 'config.nacl'
 
-export const getConfigDir = (baseDir: string): string => (
-  path.join(path.resolve(baseDir), CONFIG_DIR_NAME)
-)
-
 export const getSaltoHome = (): string =>
   process.env[SALTO_HOME_VAR] || DEFAULT_SALTO_HOME
 


### PR DESCRIPTION
Removal of `getConfigDir` as now CONFIG_DIR_NAME is the source of truth for getting `salto.config`.

---

_Additional context for reviewer_
This PR is the second step of [SALTO-2709](https://salto-io.atlassian.net/browse/SALTO-2709), as the first PR happened in [here](https://github.com/salto-io/salto/pull/3349)

---
_Release Notes_: 
-

---
_User Notifications_: 
-