### PR TITLE
SALTO-2601: added basic parsing for smart values

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -38,6 +38,7 @@ import boardSubQueryFilter from './filters/board/board_subquery'
 import boardEstimationFilter from './filters/board/board_estimation'
 import boardDeploymentFilter from './filters/board/board_deployment'
 import automationDeploymentFilter from './filters/automation/automation_deployment'
+import smartValueReferenceFilter from './filters/automation/smart_values/smart_value_reference_filter'
 import webhookFilter from './filters/webhook/webhook'
 import screenFilter from './filters/screen/screen'
 import issueTypeScreenSchemeFilter from './filters/issue_type_screen_scheme'
@@ -183,6 +184,7 @@ export const DEFAULT_FILTERS = [
   hiddenValuesInListsFilter,
   queryFilter,
   missingDescriptionsFilter,
+  smartValueReferenceFilter,
   // Must be last
   defaultInstancesDeployFilter,
 ]

--- a/packages/jira-adapter/src/filters/automation/smart_values/smart_value_reference_filter.ts
+++ b/packages/jira-adapter/src/filters/automation/smart_values/smart_value_reference_filter.ts
@@ -122,7 +122,7 @@ const filterCreator: FilterCreator = () => {
   const deployTemplateMapping: Record<string, TemplateExpression> = {}
   return ({
     onFetch: async (elements: Element[]) => log.time(async () =>
-      replaceFormulasWithTemplates(elements.filter(isInstanceElement)), 'Template creation filter'),
+      replaceFormulasWithTemplates(elements.filter(isInstanceElement)), 'Smart values creation filter'),
 
     preDeploy: async (changes: Change<InstanceElement>[]) => log.time(() => {
       filterAutomations(changes.map(getChangeData)).filter(isInstanceElement).flatMap(
@@ -138,7 +138,7 @@ const filterCreator: FilterCreator = () => {
           }
         })
       )
-    }, 'Template resolve filter'),
+    }, 'Smart values resolve filter'),
 
     onDeploy: async (changes: Change<InstanceElement>[]) => log.time(() => {
       filterAutomations(changes.map(getChangeData)).filter(isInstanceElement).flatMap(
@@ -153,7 +153,7 @@ const filterCreator: FilterCreator = () => {
           }
         })
       )
-    }, 'Templates restore filter'),
+    }, 'Smart values restore filter'),
   })
 }
 

--- a/packages/jira-adapter/src/filters/automation/smart_values/smart_value_reference_filter.ts
+++ b/packages/jira-adapter/src/filters/automation/smart_values/smart_value_reference_filter.ts
@@ -1,0 +1,138 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  Change, Element, getChangeData, InstanceElement, isInstanceElement,
+  ReferenceExpression, TemplateExpression, TemplatePart, Values,
+} from '@salto-io/adapter-api'
+import { replaceTemplatesWithValues, resolveTemplates } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+import { collections } from '@salto-io/lowerdash'
+import _ from 'lodash'
+import { AUTOMATION_TYPE } from '../../../constants'
+import { FilterCreator } from '../../../filter'
+import { FIELD_TYPE_NAME } from '../../fields/constants'
+import { stringToTemplate } from './template_expression_generator'
+
+const { awu } = collections.asynciterable
+const log = logger(module)
+
+
+type Component = {
+  value?: Values
+  rawValue?: unknown
+}
+
+const getAutomations = (instances: InstanceElement[]): InstanceElement[] =>
+  instances.filter(instance => instance.elemID.typeName === AUTOMATION_TYPE)
+
+const replaceFormulasWithTemplates = async (instances: InstanceElement[]): Promise<void> => {
+  const fields = instances.filter(instance => instance.elemID.typeName === FIELD_TYPE_NAME)
+  const fieldsByName = _.keyBy(fields.filter(instance => _.isString(instance.value.name)),
+    (instance: InstanceElement): string => instance.value.name)
+  const fieldsById = _.keyBy(fields.filter(instance => instance.value.id),
+    (instance: InstanceElement): number => instance.value.id)
+  getAutomations(instances).forEach(instance => {
+    [...(instance.value.components ?? []), instance.value.trigger]
+      .forEach((component: Component) => {
+        try {
+          const { value } = component
+          if (value !== undefined && _.isPlainObject(value)) {
+            Object.keys(value).filter(key => _.isString(value[key])).forEach(key => {
+              value[key] = stringToTemplate(value[key], fieldsByName, fieldsById)
+            })
+          }
+
+          if (component.rawValue !== undefined && _.isString(component.rawValue)) {
+            component.rawValue = stringToTemplate(component.rawValue, fieldsByName, fieldsById)
+          }
+        } catch (e) {
+          log.error('Error parsing templates in fetch', e)
+        }
+      })
+  })
+}
+
+const prepRef = (part: ReferenceExpression): TemplatePart => {
+  if (part.elemID.isTopLevel()) {
+    return part.value.value.id
+  }
+  return part.value
+}
+
+/**
+ * Process values that can reference other objects and turn them into TemplateExpressions
+ */
+const filterCreator: FilterCreator = () => {
+  const deployTemplateMapping: Record<string, TemplateExpression> = {}
+  return ({
+    onFetch: async (elements: Element[]) => log.time(async () =>
+      replaceFormulasWithTemplates(elements.filter(isInstanceElement)), 'Template creation filter'),
+
+    preDeploy: (changes: Change<InstanceElement>[]) => log.time(async () => {
+      await (Promise.all(getAutomations(await awu(changes).map(getChangeData).toArray())
+        .filter(isInstanceElement).flatMap(
+          async instance => [...(instance.value.components ?? []), instance.value.trigger]
+            .flatMap(async component => {
+              try {
+                if (_.isPlainObject(component.value)) {
+                  Object.keys(component.value).forEach(k => {
+                    replaceTemplatesWithValues(
+                      { fieldName: k, values: [component.value] },
+                      deployTemplateMapping,
+                      prepRef
+                    )
+                  })
+                }
+                replaceTemplatesWithValues(
+                  { fieldName: 'rawValue', values: [component] },
+                  deployTemplateMapping,
+                  prepRef
+                )
+              } catch (e) {
+                log.error('Error parsing templates in deployment', e)
+              }
+            })
+        )))
+    }, 'Template resolve filter'),
+
+    onDeploy: async (changes: Change<InstanceElement>[]) => log.time(async () => {
+      await (Promise.all(getAutomations(await awu(changes).map(getChangeData).toArray())
+        .filter(isInstanceElement).flatMap(
+          async instance => [...(instance.value.components ?? []), instance.value.trigger]
+            .flatMap(async component => {
+              try {
+                if (component.value) {
+                  Object.keys(component.value).forEach(k => {
+                    resolveTemplates(
+                      { fieldName: k, values: [component.value] },
+                      deployTemplateMapping
+                    )
+                  })
+                }
+                resolveTemplates(
+                  { fieldName: 'rawValue', values: [component] },
+                  deployTemplateMapping
+                )
+              } catch (e) {
+                log.error('Error restoring templates in deployment', e)
+              }
+            })
+        )))
+    }, 'Templates restore filter'),
+  })
+}
+
+export default filterCreator

--- a/packages/jira-adapter/src/filters/automation/smart_values/smart_value_reference_filter.ts
+++ b/packages/jira-adapter/src/filters/automation/smart_values/smart_value_reference_filter.ts
@@ -110,7 +110,7 @@ const prepRef = (part: ReferenceExpression): TemplatePart => {
     return part.value.value.id
   }
   if (!_.isString(part.value)) {
-    throw new Error(`Received an invalid value inside a template expression: ${safeJsonStringify(part.value)}`)
+    throw new Error(`Received an invalid value inside a template expression ${part.elemID.getFullName()}: ${safeJsonStringify(part.value)}`)
   }
   return part.value
 }

--- a/packages/jira-adapter/src/filters/automation/smart_values/template_expression_generator.ts
+++ b/packages/jira-adapter/src/filters/automation/smart_values/template_expression_generator.ts
@@ -1,0 +1,83 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  InstanceElement, ReferenceExpression, TemplateExpression, TemplatePart,
+} from '@salto-io/adapter-api'
+import { extractTemplate } from '@salto-io/adapter-utils'
+
+const REFERENCE_MARKER_REGEX = /(\{\{.+?\}\})/
+
+const FIELD_REGEX = /^([a-zA-Z0-9_ ]+)(?: |$|\.)/
+
+const handleJiraReference = (
+  ref: string,
+  fieldsByName: Record<string, InstanceElement>,
+  fieldsById: Record<string, InstanceElement>,
+): TemplatePart => {
+  if (fieldsById[ref] !== undefined) {
+    const instance = fieldsById[ref]
+    return new ReferenceExpression(instance.elemID, instance)
+  }
+
+  if (fieldsByName[ref] !== undefined) {
+    const instance = fieldsByName[ref]
+    return new ReferenceExpression(instance.elemID.createNestedID('name'), instance.value.name)
+  }
+  return ref
+}
+
+// This function receives a string that contains issue references and replaces
+// it with salto style templates.
+export const stringToTemplate = (
+  referenceStr: string,
+  fieldsByName: Record<string, InstanceElement>,
+  fieldsById: Record<number, InstanceElement>,
+
+): TemplateExpression | string => {
+  const possibleIssues = ['issue', 'destinationIssue', 'triggerIssue', '']
+  const possibleFieldKeywords = ['fields', '']
+
+  const possiblePrefixes = possibleIssues
+    .flatMap(issueKey => possibleFieldKeywords
+      .map(fieldKey => [issueKey, fieldKey].filter(key => key !== '').join('.')))
+    .filter(prefix => prefix !== '')
+    .map(prefix => `${prefix}.`)
+
+  return extractTemplate(
+    referenceStr,
+    [REFERENCE_MARKER_REGEX],
+    expression => {
+      if (!expression.startsWith('{{') || !expression.endsWith('}}')) {
+        return expression
+      }
+
+      const smartValue = expression.slice(2, -2)
+
+      const prefix = possiblePrefixes.find(pref => smartValue.startsWith(pref)) ?? ''
+
+      const jiraReference = smartValue.slice(prefix.length).match(FIELD_REGEX)
+      if (jiraReference) {
+        const innerRef = jiraReference[1]
+        return [
+          `{{${prefix}`,
+          handleJiraReference(innerRef, fieldsByName, fieldsById),
+          `${smartValue.substring(prefix.length + innerRef.length)}}}`,
+        ]
+      }
+      return expression
+    },
+  )
+}

--- a/packages/jira-adapter/test/filters/automation/smart_values/smart_value_reference_filter.test.ts
+++ b/packages/jira-adapter/test/filters/automation/smart_values/smart_value_reference_filter.test.ts
@@ -1,0 +1,219 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType, ReferenceExpression,
+  BuiltinTypes, TemplateExpression, MapType, toChange, isInstanceElement } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import { logger } from '@salto-io/logging'
+import filterCreator from '../../../../src/filters/automation/smart_values/smart_value_reference_filter'
+import { getFilterParams } from '../../../utils'
+
+const logging = logger('jira-adapter/src/filters/automation/smart_values/smart_value_reference_filter')
+const logErrorSpy = jest.spyOn(logging, 'error')
+
+describe('smart_value_reference_filter', () => {
+    type FilterType = filterUtils.FilterWith<'onFetch' | 'onDeploy' | 'preDeploy'>
+    let filter: FilterType
+    let automationType: ObjectType
+    let fieldType: ObjectType
+    let fieldInstance: InstanceElement
+    let automationInstance: InstanceElement
+    let emptyAutomationInstance: InstanceElement
+
+    beforeEach(() => {
+      logErrorSpy.mockReset()
+
+      filter = filterCreator(getFilterParams()) as FilterType
+
+
+      automationType = new ObjectType({
+        elemID: new ElemID('jira', 'Automation'),
+        fields: {
+          id: { refType: BuiltinTypes.NUMBER },
+          actions: { refType: new MapType(BuiltinTypes.STRING) },
+        },
+      })
+
+      fieldType = new ObjectType({
+        elemID: new ElemID('jira', 'Field'),
+        fields: {
+          id: { refType: BuiltinTypes.NUMBER },
+          actions: { refType: new MapType(BuiltinTypes.STRING) },
+        },
+      })
+
+      fieldInstance = new InstanceElement('field_one', fieldType, { name: 'fieldOne', id: 'fieldId' })
+
+      automationInstance = new InstanceElement('autom', automationType,
+        { components: [
+          {
+            value: {
+              inner: 'Field is: {{issue.fieldOne}} {{issue.fieldId}} ending',
+            },
+            rawValue: 'Field is: {{issue.fieldOne}} {{issue.fieldId}} ending',
+          },
+        ] })
+
+      emptyAutomationInstance = new InstanceElement('emptyAutom', automationType)
+    })
+
+
+    const generateElements = (): (InstanceElement | ObjectType)[] => ([fieldInstance,
+      automationInstance, fieldType, automationType, emptyAutomationInstance])
+      .map(element => element.clone())
+
+    describe('on fetch successful', () => {
+      let elements: (InstanceElement | ObjectType)[]
+      let automation: InstanceElement
+
+      beforeEach(async () => {
+        elements = generateElements()
+        await filter.onFetch(elements)
+        const automationResult = elements.filter(isInstanceElement).find(i => i.elemID.name === 'autom')
+        expect(automationResult).toBeDefined()
+        automation = automationResult as InstanceElement
+      })
+
+      it('should ignore empty automation', () => {
+        expect(elements.filter(isInstanceElement).find(i => i.elemID.name === 'emptyAutom'))
+          .toEqual(emptyAutomationInstance)
+      })
+
+      it('should resolve simple template in value', () => {
+        expect(automation.value.components[0].value.inner).toEqual(new TemplateExpression({
+          parts: [
+            'Field is: ',
+            '{{issue.',
+            new ReferenceExpression(fieldInstance.elemID.createNestedID('name'), 'fieldOne'),
+            '}}',
+            ' ',
+            '{{issue.',
+            new ReferenceExpression(fieldInstance.elemID, fieldInstance),
+            '}}',
+            ' ending',
+          ],
+        }))
+      })
+
+      it('should resolve simple template in rawValue', () => {
+        expect(automation.value.components[0].rawValue).toEqual(new TemplateExpression({
+          parts: [
+            'Field is: ',
+            '{{issue.',
+            new ReferenceExpression(fieldInstance.elemID.createNestedID('name'), 'fieldOne'),
+            '}}',
+            ' ',
+            '{{issue.',
+            new ReferenceExpression(fieldInstance.elemID, fieldInstance),
+            '}}',
+            ' ending',
+          ],
+        }))
+      })
+    })
+    describe('on fetch failure', () => {
+      it('logs exception without error', async () => {
+        // weird value to cause error
+        const errorInstance = new InstanceElement('emptyelement', automationType, { components: [undefined] })
+        await filter.onFetch([automationType, errorInstance])
+        expect(logErrorSpy).toHaveBeenCalledWith('Error parsing templates in fetch', expect.any(Error))
+      })
+
+      it('should do nothing for components without a value', async () => {
+        delete automationInstance.value.components[0].value
+        delete automationInstance.value.components[0].rawValue
+        const originalAutomation = automationInstance.clone()
+        await filter.onFetch([automationInstance])
+        expect(automationInstance.value).toEqual(originalAutomation.value)
+      })
+    })
+    describe('preDeploy', () => {
+      let elementsBeforeFetch: (InstanceElement | ObjectType)[]
+      let elementsAfterPreDeploy: (InstanceElement | ObjectType)[]
+
+      beforeEach(async () => {
+        elementsBeforeFetch = generateElements()
+        const elementsAfterFetch = elementsBeforeFetch.map(e => e.clone())
+        await filter.onFetch(elementsAfterFetch)
+        elementsAfterPreDeploy = elementsAfterFetch.map(e => e.clone())
+        await filter.preDeploy(elementsAfterPreDeploy.map(e => toChange({ before: e, after: e })))
+      })
+
+      it('Returns elements to origin after predeploy', () => {
+        expect(elementsAfterPreDeploy).toEqual(elementsBeforeFetch)
+      })
+    })
+
+    describe('on preDeploy failure', () => {
+      it('logs exception without error', async () => {
+        // weird value to cause error
+        const errorInstance = new InstanceElement('emptyelement', automationType, { components: [undefined] })
+        await filter.preDeploy([toChange({ before: errorInstance, after: errorInstance })])
+        expect(logErrorSpy).toHaveBeenCalledWith('Error parsing templates in deployment', expect.any(Error))
+      })
+
+      it('should do nothing for components without a value', async () => {
+        delete automationInstance.value.components[0].value
+        delete automationInstance.value.components[0].rawValue
+        const originalAutomation = automationInstance.clone()
+        await filter.preDeploy([toChange({
+          before: automationInstance,
+          after: automationInstance,
+        })])
+        expect(automationInstance.value).toEqual(originalAutomation.value)
+      })
+    })
+
+    describe('onDeploy', () => {
+      let elementsAfterFetch: (InstanceElement | ObjectType)[]
+      let elementsAfterOnDeploy: (InstanceElement | ObjectType)[]
+
+      beforeEach(async () => {
+        // we recreate fetch and onDeploy to have the templates in place to be restored by onDeploy
+        const elementsBeforeFetch = generateElements()
+        elementsAfterFetch = elementsBeforeFetch.map(e => e.clone())
+        await filter.onFetch(elementsAfterFetch)
+        const elementsAfterPreDeploy = elementsAfterFetch.map(e => e.clone())
+        await filter.preDeploy(elementsAfterPreDeploy.map(e => toChange({ before: e, after: e })))
+        elementsAfterOnDeploy = elementsAfterPreDeploy.map(e => e.clone())
+        await filter.onDeploy(elementsAfterOnDeploy.map(e => toChange({ before: e, after: e })))
+      })
+
+      it('Returns elements to after fetch state (with templates) after onDeploy', () => {
+        expect(elementsAfterOnDeploy).toEqual(elementsAfterFetch)
+      })
+    })
+
+
+    describe('on onDeploy failure', () => {
+      it('logs exception without error', async () => {
+        // weird value to cause error
+        const errorInstance = new InstanceElement('emptyelement', automationType, { components: [undefined] })
+        await filter.onDeploy([toChange({ before: errorInstance, after: errorInstance })])
+        expect(logErrorSpy).toHaveBeenCalledWith('Error restoring templates in deployment', expect.any(Error))
+      })
+
+      it('should do nothing for components without a value', async () => {
+        delete automationInstance.value.components[0].value
+        delete automationInstance.value.components[0].rawValue
+        const originalAutomation = automationInstance.clone()
+        await filter.onDeploy([toChange({
+          before: automationInstance,
+          after: automationInstance,
+        })])
+        expect(automationInstance.value).toEqual(originalAutomation.value)
+      })
+    })
+})

--- a/packages/jira-adapter/test/filters/automation/smart_values/smart_value_reference_filter.test.ts
+++ b/packages/jira-adapter/test/filters/automation/smart_values/smart_value_reference_filter.test.ts
@@ -57,14 +57,17 @@ describe('smart_value_reference_filter', () => {
       fieldInstance = new InstanceElement('field_one', fieldType, { name: 'fieldOne', id: 'fieldId' })
 
       automationInstance = new InstanceElement('autom', automationType,
-        { components: [
-          {
-            value: {
-              inner: 'Field is: {{issue.fieldOne}} {{issue.fieldId}} ending',
+        {
+          trigger: {},
+          components: [
+            {
+              value: {
+                inner: 'Field is: {{issue.fieldOne}} {{issue.fieldId}} ending',
+              },
+              rawValue: 'Field is: {{issue.fieldOne}} {{issue.fieldId}} ending',
             },
-            rawValue: 'Field is: {{issue.fieldOne}} {{issue.fieldId}} ending',
-          },
-        ] })
+          ],
+        })
 
       emptyAutomationInstance = new InstanceElement('emptyAutom', automationType)
     })
@@ -124,13 +127,6 @@ describe('smart_value_reference_filter', () => {
       })
     })
     describe('on fetch failure', () => {
-      it('logs exception without error', async () => {
-        // weird value to cause error
-        const errorInstance = new InstanceElement('emptyelement', automationType, { components: [undefined] })
-        await filter.onFetch([automationType, errorInstance])
-        expect(logErrorSpy).toHaveBeenCalledWith('Error parsing templates in fetch', expect.any(Error))
-      })
-
       it('should do nothing for components without a value', async () => {
         delete automationInstance.value.components[0].value
         delete automationInstance.value.components[0].rawValue
@@ -157,13 +153,6 @@ describe('smart_value_reference_filter', () => {
     })
 
     describe('on preDeploy failure', () => {
-      it('logs exception without error', async () => {
-        // weird value to cause error
-        const errorInstance = new InstanceElement('emptyelement', automationType, { components: [undefined] })
-        await filter.preDeploy([toChange({ before: errorInstance, after: errorInstance })])
-        expect(logErrorSpy).toHaveBeenCalledWith('Error parsing templates in deployment', expect.any(Error))
-      })
-
       it('should do nothing for components without a value', async () => {
         delete automationInstance.value.components[0].value
         delete automationInstance.value.components[0].rawValue
@@ -198,13 +187,6 @@ describe('smart_value_reference_filter', () => {
 
 
     describe('on onDeploy failure', () => {
-      it('logs exception without error', async () => {
-        // weird value to cause error
-        const errorInstance = new InstanceElement('emptyelement', automationType, { components: [undefined] })
-        await filter.onDeploy([toChange({ before: errorInstance, after: errorInstance })])
-        expect(logErrorSpy).toHaveBeenCalledWith('Error restoring templates in deployment', expect.any(Error))
-      })
-
       it('should do nothing for components without a value', async () => {
         delete automationInstance.value.components[0].value
         delete automationInstance.value.components[0].rawValue

--- a/packages/jira-adapter/test/filters/automation/smart_values/template_expression_generator.test.ts
+++ b/packages/jira-adapter/test/filters/automation/smart_values/template_expression_generator.test.ts
@@ -1,0 +1,237 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType, ReferenceExpression,
+  BuiltinTypes, TemplateExpression, MapType } from '@salto-io/adapter-api'
+import { stringToTemplate } from '../../../../src/filters/automation/smart_values/template_expression_generator'
+
+describe('stringToTemplate', () => {
+  let idToField: Record<string, InstanceElement>
+  let nameToField: Record<string, InstanceElement>
+  let systemField: InstanceElement
+  let customField: InstanceElement
+
+  beforeEach(() => {
+    const fieldType = new ObjectType({
+      elemID: new ElemID('jira', 'Field'),
+      fields: {
+        id: { refType: BuiltinTypes.NUMBER },
+        actions: { refType: new MapType(BuiltinTypes.STRING) },
+      },
+    })
+
+    systemField = new InstanceElement(
+      'system',
+      fieldType,
+      {
+        id: 'system',
+        name: 'SystemName',
+      }
+    )
+
+    customField = new InstanceElement(
+      'custom',
+      fieldType,
+      {
+        id: 'customfield_1234',
+        name: 'Custom Field',
+      }
+    )
+
+    idToField = {}
+    nameToField = {};
+
+    [systemField, customField].forEach(field => {
+      idToField[field.value.id] = field
+      nameToField[field.value.name] = field
+    })
+  })
+
+  it('should resolve system field by id', () => {
+    expect(stringToTemplate(
+      '1-{{system}} 2-{{issue.system}} 3-{{issue.system.something}} 4-{{issue.fields.system.something}} 5-{{fields.system}} 6-{{destinationIssue.system}} 7-{{triggerIssue.system}}system',
+      nameToField,
+      idToField
+    )).toEqual(new TemplateExpression({
+      parts: [
+        '1-',
+        '{{',
+        new ReferenceExpression(systemField.elemID, systemField),
+        '}}',
+        ' 2-',
+        '{{issue.',
+        new ReferenceExpression(systemField.elemID, systemField),
+        '}}',
+        ' 3-',
+        '{{issue.',
+        new ReferenceExpression(systemField.elemID, systemField),
+        '.something}}',
+        ' 4-',
+        '{{issue.fields.',
+        new ReferenceExpression(systemField.elemID, systemField),
+        '.something}}',
+        ' 5-',
+        '{{fields.',
+        new ReferenceExpression(systemField.elemID, systemField),
+        '}}',
+        ' 6-',
+        '{{destinationIssue.',
+        new ReferenceExpression(systemField.elemID, systemField),
+        '}}',
+        ' 7-',
+        '{{triggerIssue.',
+        new ReferenceExpression(systemField.elemID, systemField),
+        '}}',
+        'system',
+      ],
+    }))
+  })
+
+  it('should resolve system field by name', () => {
+    expect(stringToTemplate(
+      '1-{{SystemName}} 2-{{issue.SystemName}} 3-{{issue.SystemName.something}} 4-{{issue.fields.SystemName.something}} 5-{{fields.SystemName}} 6-{{destinationIssue.SystemName}} 7-{{triggerIssue.SystemName}}SystemName',
+      nameToField,
+      idToField
+    )).toEqual(new TemplateExpression({
+      parts: [
+        '1-',
+        '{{',
+        new ReferenceExpression(systemField.elemID.createNestedID('name'), 'SystemName'),
+        '}}',
+        ' 2-',
+        '{{issue.',
+        new ReferenceExpression(systemField.elemID.createNestedID('name'), 'SystemName'),
+        '}}',
+        ' 3-',
+        '{{issue.',
+        new ReferenceExpression(systemField.elemID.createNestedID('name'), 'SystemName'),
+        '.something}}',
+        ' 4-',
+        '{{issue.fields.',
+        new ReferenceExpression(systemField.elemID.createNestedID('name'), 'SystemName'),
+        '.something}}',
+        ' 5-',
+        '{{fields.',
+        new ReferenceExpression(systemField.elemID.createNestedID('name'), 'SystemName'),
+        '}}',
+        ' 6-',
+        '{{destinationIssue.',
+        new ReferenceExpression(systemField.elemID.createNestedID('name'), 'SystemName'),
+        '}}',
+        ' 7-',
+        '{{triggerIssue.',
+        new ReferenceExpression(systemField.elemID.createNestedID('name'), 'SystemName'),
+        '}}',
+        'SystemName',
+      ],
+    }))
+  })
+
+  it('should resolve custom field by id', () => {
+    expect(stringToTemplate(
+      '1-{{customfield_1234}} 2-{{issue.customfield_1234}} 3-{{issue.customfield_1234.something}} 4-{{issue.fields.customfield_1234.something}} 5-{{fields.customfield_1234}} 6-{{destinationIssue.customfield_1234}} 7-{{triggerIssue.customfield_1234}}customfield_1234',
+      nameToField,
+      idToField
+    )).toEqual(new TemplateExpression({
+      parts: [
+        '1-',
+        '{{',
+        new ReferenceExpression(customField.elemID, customField),
+        '}}',
+        ' 2-',
+        '{{issue.',
+        new ReferenceExpression(customField.elemID, customField),
+        '}}',
+        ' 3-',
+        '{{issue.',
+        new ReferenceExpression(customField.elemID, customField),
+        '.something}}',
+        ' 4-',
+        '{{issue.fields.',
+        new ReferenceExpression(customField.elemID, customField),
+        '.something}}',
+        ' 5-',
+        '{{fields.',
+        new ReferenceExpression(customField.elemID, customField),
+        '}}',
+        ' 6-',
+        '{{destinationIssue.',
+        new ReferenceExpression(customField.elemID, customField),
+        '}}',
+        ' 7-',
+        '{{triggerIssue.',
+        new ReferenceExpression(customField.elemID, customField),
+        '}}',
+        'customfield_1234',
+      ],
+    }))
+  })
+
+  it('should resolve custom field by name', () => {
+    expect(stringToTemplate(
+      '1-{{Custom Field}} 2-{{issue.Custom Field}} 3-{{issue.Custom Field.something}} 4-{{issue.fields.Custom Field.something}} 5-{{fields.Custom Field}} 6-{{destinationIssue.Custom Field}} 7-{{triggerIssue.Custom Field}}Custom Field',
+      nameToField,
+      idToField
+    )).toEqual(new TemplateExpression({
+      parts: [
+        '1-',
+        '{{',
+        new ReferenceExpression(customField.elemID.createNestedID('name'), 'Custom Field'),
+        '}}',
+        ' 2-',
+        '{{issue.',
+        new ReferenceExpression(customField.elemID.createNestedID('name'), 'Custom Field'),
+        '}}',
+        ' 3-',
+        '{{issue.',
+        new ReferenceExpression(customField.elemID.createNestedID('name'), 'Custom Field'),
+        '.something}}',
+        ' 4-',
+        '{{issue.fields.',
+        new ReferenceExpression(customField.elemID.createNestedID('name'), 'Custom Field'),
+        '.something}}',
+        ' 5-',
+        '{{fields.',
+        new ReferenceExpression(customField.elemID.createNestedID('name'), 'Custom Field'),
+        '}}',
+        ' 6-',
+        '{{destinationIssue.',
+        new ReferenceExpression(customField.elemID.createNestedID('name'), 'Custom Field'),
+        '}}',
+        ' 7-',
+        '{{triggerIssue.',
+        new ReferenceExpression(customField.elemID.createNestedID('name'), 'Custom Field'),
+        '}}',
+        'Custom Field',
+      ],
+    }))
+  })
+
+  it('should ignore unknown fields', () => {
+    expect(stringToTemplate(
+      '1-{{unknown}} 2-{{issue.unknown}}',
+      nameToField,
+      idToField
+    )).toBe('1-{{unknown}} 2-{{issue.unknown}}')
+  })
+
+  it('should ignore invalid fields', () => {
+    expect(stringToTemplate(
+      '1-{{.}} 2-{{}}',
+      nameToField,
+      idToField
+    )).toBe('1-{{.}} 2-{{}}')
+  })
+})

--- a/packages/jira-adapter/test/filters/automation/smart_values/template_expression_generator.test.ts
+++ b/packages/jira-adapter/test/filters/automation/smart_values/template_expression_generator.test.ts
@@ -60,11 +60,12 @@ describe('stringToTemplate', () => {
   })
 
   it('should resolve system field by id', () => {
-    expect(stringToTemplate(
-      '1-{{system}} 2-{{issue.system}} 3-{{issue.system.something}} 4-{{issue.fields.system.something}} 5-{{fields.system}} 6-{{destinationIssue.system}} 7-{{triggerIssue.system}}system',
-      nameToField,
-      idToField
-    )).toEqual(new TemplateExpression({
+    const x = stringToTemplate({
+      referenceStr: '1-{{system}} 2-{{issue.system}} 3-{{issue.system.something}} 4-{{issue.fields.system.something}} 5-{{fields.system}} 6-{{destinationIssue.system}} 7-{{triggerIssue.system}}system',
+      fieldInstancesByName: nameToField,
+      fieldInstancesById: idToField,
+    })
+    expect(x).toEqual(new TemplateExpression({
       parts: [
         '1-',
         '{{',
@@ -100,11 +101,11 @@ describe('stringToTemplate', () => {
   })
 
   it('should resolve system field by name', () => {
-    expect(stringToTemplate(
-      '1-{{SystemName}} 2-{{issue.SystemName}} 3-{{issue.SystemName.something}} 4-{{issue.fields.SystemName.something}} 5-{{fields.SystemName}} 6-{{destinationIssue.SystemName}} 7-{{triggerIssue.SystemName}}SystemName',
-      nameToField,
-      idToField
-    )).toEqual(new TemplateExpression({
+    expect(stringToTemplate({
+      referenceStr: '1-{{SystemName}} 2-{{issue.SystemName}} 3-{{issue.SystemName.something}} 4-{{issue.fields.SystemName.something}} 5-{{fields.SystemName}} 6-{{destinationIssue.SystemName}} 7-{{triggerIssue.SystemName}}SystemName',
+      fieldInstancesByName: nameToField,
+      fieldInstancesById: idToField,
+    })).toEqual(new TemplateExpression({
       parts: [
         '1-',
         '{{',
@@ -140,11 +141,11 @@ describe('stringToTemplate', () => {
   })
 
   it('should resolve custom field by id', () => {
-    expect(stringToTemplate(
-      '1-{{customfield_1234}} 2-{{issue.customfield_1234}} 3-{{issue.customfield_1234.something}} 4-{{issue.fields.customfield_1234.something}} 5-{{fields.customfield_1234}} 6-{{destinationIssue.customfield_1234}} 7-{{triggerIssue.customfield_1234}}customfield_1234',
-      nameToField,
-      idToField
-    )).toEqual(new TemplateExpression({
+    expect(stringToTemplate({
+      referenceStr: '1-{{customfield_1234}} 2-{{issue.customfield_1234}} 3-{{issue.customfield_1234.something}} 4-{{issue.fields.customfield_1234.something}} 5-{{fields.customfield_1234}} 6-{{destinationIssue.customfield_1234}} 7-{{triggerIssue.customfield_1234}}customfield_1234',
+      fieldInstancesByName: nameToField,
+      fieldInstancesById: idToField,
+    })).toEqual(new TemplateExpression({
       parts: [
         '1-',
         '{{',
@@ -180,11 +181,11 @@ describe('stringToTemplate', () => {
   })
 
   it('should resolve custom field by name', () => {
-    expect(stringToTemplate(
-      '1-{{Custom Field}} 2-{{issue.Custom Field}} 3-{{issue.Custom Field.something}} 4-{{issue.fields.Custom Field.something}} 5-{{fields.Custom Field}} 6-{{destinationIssue.Custom Field}} 7-{{triggerIssue.Custom Field}}Custom Field',
-      nameToField,
-      idToField
-    )).toEqual(new TemplateExpression({
+    expect(stringToTemplate({
+      referenceStr: '1-{{Custom Field}} 2-{{issue.Custom Field}} 3-{{issue.Custom Field.something}} 4-{{issue.fields.Custom Field.something}} 5-{{fields.Custom Field}} 6-{{destinationIssue.Custom Field}} 7-{{triggerIssue.Custom Field}}Custom Field',
+      fieldInstancesByName: nameToField,
+      fieldInstancesById: idToField,
+    })).toEqual(new TemplateExpression({
       parts: [
         '1-',
         '{{',
@@ -220,18 +221,18 @@ describe('stringToTemplate', () => {
   })
 
   it('should ignore unknown fields', () => {
-    expect(stringToTemplate(
-      '1-{{unknown}} 2-{{issue.unknown}}',
-      nameToField,
-      idToField
-    )).toBe('1-{{unknown}} 2-{{issue.unknown}}')
+    expect(stringToTemplate({
+      referenceStr: '1-{{unknown}} 2-{{issue.unknown}}',
+      fieldInstancesByName: nameToField,
+      fieldInstancesById: idToField,
+    })).toBe('1-{{unknown}} 2-{{issue.unknown}}')
   })
 
   it('should ignore invalid fields', () => {
-    expect(stringToTemplate(
-      '1-{{.}} 2-{{}}',
-      nameToField,
-      idToField
-    )).toBe('1-{{.}} 2-{{}}')
+    expect(stringToTemplate({
+      referenceStr: '1-{{.}} 2-{{}}',
+      fieldInstancesByName: nameToField,
+      fieldInstancesById: idToField,
+    })).toBe('1-{{.}} 2-{{}}')
   })
 })


### PR DESCRIPTION
Process some smart values in jira as templates referencing field instances

---

This PR supports parsing the following:
`abc {{fieldName}}`
`abc {{fieldId}}`
`abc {{<fieldName/fieldId>.somethingElse}}`
`abc {{issue.<fieldName/fieldId>}}`
`abc {{issue.fields.<fieldName/fieldId>}}`
`abc {{fields.<fieldName/fieldId>}}`
`abc {{triggerIssue.<fieldName/fieldId>}}`
`abc {{destinationIssue.<fieldName/fieldId>}}`

Does not support yet
things like
`{{or(issue.fieldName,or(equals(issue.fieldName2,null),equals(issue.fieldName3,null)))}}`

---
_Release Notes_: 
_Jira Adapter_:
Parse smart values under automations as template values, that include references to the instances of the fields that the smart value references.
 
---
_User Notifications_: 
_Jira Adapter_:
Some value fields under Automation components will change. Instead of containing the old text, they will contain templates, which are a mix of references to the referenced fields, and the text around the referenced fields.