### PR TITLE
SALTO-2039 Add references from workflow to Resolution and Priority - Jira

### DIFF
--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -44,7 +44,15 @@ const toTypeName: referenceUtils.ContextValueMapperFunc = val => {
   return _.capitalize(val)
 }
 
+const resolutionAndPriorityToTypeName: referenceUtils.ContextValueMapperFunc = val => {
+  if (val === 'priority' || val === 'resolution') {
+    return _.capitalize(val)
+  }
+  return undefined
+}
+
 export type ReferenceContextStrategyName = 'parentSelectedFieldType' | 'parentFieldType' | 'workflowStatusPropertiesIdContext' | 'workflowStatusPropertiesNameContext'
+| 'parentFieldId'
 
 export const contextStrategyLookup: Record<
   ReferenceContextStrategyName, referenceUtils.ContextFunc
@@ -53,6 +61,7 @@ export const contextStrategyLookup: Record<
   parentFieldType: neighborContextFunc({ contextFieldName: 'fieldType', levelsUp: 1, contextValueMapper: toTypeName }),
   workflowStatusPropertiesIdContext: neighborContextFunc({ contextFieldName: 'key', contextValueMapper: getRefIdType }),
   workflowStatusPropertiesNameContext: neighborContextFunc({ contextFieldName: 'key', contextValueMapper: getRefNameType }),
+  parentFieldId: neighborContextFunc({ contextFieldName: 'fieldId', contextValueMapper: resolutionAndPriorityToTypeName }),
 }
 
 export const referencesRules: referenceUtils.FieldReferenceDefinition<
@@ -466,6 +475,11 @@ ReferenceContextStrategyName
     src: { field: 'values', parentTypes: [AUTOMATION_COMPARE_VALUE] },
     serializationStrategy: 'nameWithPath',
     target: { typeContext: 'parentSelectedFieldType' },
+  },
+  {
+    src: { field: 'fieldValue', parentTypes: ['PostFunctionConfiguration'] },
+    serializationStrategy: 'id',
+    target: { typeContext: 'parentFieldId' },
   },
   {
     src: { field: 'value', parentTypes: [AUTOMATION_FIELD] },

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -44,7 +44,7 @@ const toTypeName: referenceUtils.ContextValueMapperFunc = val => {
   return _.capitalize(val)
 }
 
-const resolutionAndPriorityToTypeName: referenceUtils.ContextValueMapperFunc = val => {
+export const resolutionAndPriorityToTypeName: referenceUtils.ContextValueMapperFunc = val => {
   if (val === 'priority' || val === 'resolution') {
     return _.capitalize(val)
   }

--- a/packages/jira-adapter/test/product_settings/reference_mapping.test.ts
+++ b/packages/jira-adapter/test/product_settings/reference_mapping.test.ts
@@ -1,0 +1,40 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { resolutionAndPriorityToTypeName } from '../../src/reference_mapping'
+
+describe('resolutionAndPriorityToTypeName', () => {
+  let inputString : string
+  describe('Priority and Resolution', () => {
+    it('should return "Priority"', () => {
+      inputString = 'priority'
+      expect(resolutionAndPriorityToTypeName(inputString)).toEqual('Priority')
+    })
+    it('should return "Resolution"', () => {
+      inputString = 'resolution'
+      expect(resolutionAndPriorityToTypeName(inputString)).toEqual('Resolution')
+    })
+  })
+  describe('any other input', () => {
+    it('should return undefined', () => {
+      inputString = ''
+      expect(resolutionAndPriorityToTypeName(inputString)).toBeUndefined()
+      inputString = 'assignee'
+      expect(resolutionAndPriorityToTypeName(inputString)).toBeUndefined()
+      inputString = 'customfield_10003'
+      expect(resolutionAndPriorityToTypeName(inputString)).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
_Add references from workflow to Resolution and Priority_

---

_example of the change in the NaCl:_
Resolution: 
<img width="1626" alt="Screen Shot 2022-09-08 at 12 27 02" src="https://user-images.githubusercontent.com/77064001/189088498-ee27bde7-8246-4e26-b64a-51f64353ee77.png">
Priority: 
<img width="1587" alt="Screen Shot 2022-09-08 at 12 27 27" src="https://user-images.githubusercontent.com/77064001/189088548-c1f2d1b9-244c-4415-a88b-cfd4ce2f4a0e.png">


---
_Release Notes_: 
_Jira_
* add references from workflow to Resolution and Priority


---
_User Notifications_: 
_Jira_
* workflow Nacl files will have references to Resolution and Priority elements
