### PR TITLE
SALTO-2705: Changed messages about unsupported fields from warning to info

### DIFF
--- a/packages/core/src/core/plan/change_validators/check_deployment_annotations.ts
+++ b/packages/core/src/core/plan/change_validators/check_deployment_annotations.ts
@@ -86,7 +86,7 @@ export const checkDeploymentAnnotationsValidator: ChangeValidator = async change
 
       return unsupportedPaths.map(({ path, field }) => ({
         elemID: instance.elemID,
-        severity: 'Warning',
+        severity: 'Info',
         message: ERROR_MESSAGE(field),
         detailedMessage: detailedNestedElementErrorMessage(path),
       }))

--- a/packages/core/test/core/plan/change_validators/check_deployment_annotations.test.ts
+++ b/packages/core/test/core/plan/change_validators/check_deployment_annotations.test.ts
@@ -83,7 +83,7 @@ describe('checkDeploymentAnnotationsValidator', () => {
     ])
     expect(errors).toEqual([{
       elemID: instance.elemID,
-      severity: 'Warning',
+      severity: 'Info',
       message: `The change of ${type.fields.notUpdatableField.elemID.getFullName()} is not supported and will be omitted from deploy`,
       detailedMessage: 'Deploying "notUpdatableField" in adapter.test.instance.instance is not supported',
     }])
@@ -97,7 +97,7 @@ describe('checkDeploymentAnnotationsValidator', () => {
     ])
     expect(errors).toEqual([{
       elemID: instance.elemID,
-      severity: 'Warning',
+      severity: 'Info',
       message: `The change of ${type.fields.notUpdatableField.elemID.getFullName()} is not supported and will be omitted from deploy`,
       detailedMessage: 'Deploying "inner.notUpdatableField" in adapter.test.instance.instance is not supported',
     }])


### PR DESCRIPTION
Changed messages about unsupported fields from warning to info

---
_Release Notes_: 
_Jira Adapter_:
- Changed messages about unsupported fields from warning to info

---
_User Notifications_: 
None