### PR TITLE
SALTO-2730: Change deployChange params

### DIFF
--- a/packages/adapter-components/src/deployment/deployment.ts
+++ b/packages/adapter-components/src/deployment/deployment.ts
@@ -82,16 +82,26 @@ export const filterIgnoredValues = async (
  * @param endpointDetails The details of of what endpoints to use for each action
  * @param fieldsToIgnore Fields to omit for the deployment
  * @param additionalUrlVars Additional url vars to add to the request url
+ * @param queryParams Query params to add to the request url
  * @returns: The response data of the request
  */
-export const deployChange = async (
-  change: Change<InstanceElement>,
-  client: HTTPWriteClientInterface,
-  endpointDetails?: DeploymentRequestsByAction,
-  fieldsToIgnore: string[] | ((path: ElemID) => boolean) = [],
-  additionalUrlVars?: Record<string, string>,
-  elementsSource?: ReadOnlyElementsSource,
-): Promise<ResponseResult> => {
+export const deployChange = async ({
+  change,
+  client,
+  endpointDetails,
+  fieldsToIgnore = [],
+  additionalUrlVars,
+  queryParams,
+  elementsSource,
+}:{
+  change: Change<InstanceElement>
+  client: HTTPWriteClientInterface
+  endpointDetails?: DeploymentRequestsByAction
+  fieldsToIgnore?: string[] | ((path: ElemID) => boolean)
+  additionalUrlVars?: Record<string, string>
+  queryParams?: Record<string, string>
+  elementsSource?: ReadOnlyElementsSource
+}): Promise<ResponseResult> => {
   const instance = getChangeData(change)
   const endpoint = endpointDetails?.[change.action]
   if (endpoint === undefined) {
@@ -118,6 +128,6 @@ export const deployChange = async (
     return undefined
   }
 
-  const response = await client[endpoint.method]({ url, data })
+  const response = await client[endpoint.method]({ url, data, queryParams })
   return response.data
 }

--- a/packages/adapter-components/test/deployment/deployment.test.ts
+++ b/packages/adapter-components/test/deployment/deployment.test.ts
@@ -69,11 +69,11 @@ describe('deployChange', () => {
   })
 
   it('When no endpoint for deploying the element should throw an error', async () => {
-    await expect(() => deployChange(
-      toChange({ before: instance, after: instance }),
-      httpClient,
-      endpoint
-    )).rejects.toThrow(
+    await expect(() => deployChange({
+      change: toChange({ before: instance, after: instance }),
+      client: httpClient,
+      endpointDetails: endpoint,
+    })).rejects.toThrow(
       'No endpoint of type modify for test'
     )
   })
@@ -84,11 +84,11 @@ describe('deployChange', () => {
       data: {},
     })
     instance.value.obj = { id: 1 }
-    await deployChange(
-      toChange({ before: instance }),
-      httpClient,
-      endpoint
-    )
+    await deployChange({
+      change: toChange({ before: instance }),
+      client: httpClient,
+      endpointDetails: endpoint,
+    })
 
     expect(instance.value.obj.id).toBe(1)
     expect(httpClient.delete).toHaveBeenCalledWith(expect.objectContaining({
@@ -101,12 +101,12 @@ describe('deployChange', () => {
       status: 200,
       data: {},
     })
-    await deployChange(
-      toChange({ after: instance }),
-      httpClient,
-      endpoint,
-      path => path.name === 'ignored',
-    )
+    await deployChange({
+      change: toChange({ after: instance }),
+      client: httpClient,
+      endpointDetails: endpoint,
+      fieldsToIgnore: path => path.name === 'ignored',
+    })
 
     expect(httpClient.post).toHaveBeenCalledWith({
       url: '/test/endpoint',

--- a/packages/jira-adapter/src/deployment/standard_deployment.ts
+++ b/packages/jira-adapter/src/deployment/standard_deployment.ts
@@ -72,14 +72,14 @@ export const defaultDeployChange = async ({
     }
   }
 
-  const response = await deployment.deployChange(
-    changeToDeploy,
+  const response = await deployment.deployChange({
+    change: changeToDeploy,
     client,
-    apiDefinitions.types[getChangeData(change).elemID.typeName]?.deployRequests,
+    endpointDetails: apiDefinitions.types[getChangeData(change).elemID.typeName]?.deployRequests,
     fieldsToIgnore,
     additionalUrlVars,
     elementsSource,
-  )
+  })
 
   if (isAdditionChange(change)) {
     if (!Array.isArray(response)) {

--- a/packages/jira-adapter/test/adapter.test.ts
+++ b/packages/jira-adapter/test/adapter.test.ts
@@ -76,8 +76,8 @@ describe('adapter', () => {
        typeof deployment.deployChange
       >
       deployChangeMock.mockClear()
-      deployChangeMock.mockImplementation(async change => {
-        if (isRemovalChange(change)) {
+      deployChangeMock.mockImplementation(async params => {
+        if (isRemovalChange(params.change)) {
           throw new Error('some error')
         }
         return { id: 2 }
@@ -135,8 +135,8 @@ describe('adapter', () => {
     })
 
     it('should return the errors', async () => {
-      deployChangeMock.mockImplementation(async change => {
-        if (isRemovalChange(change)) {
+      deployChangeMock.mockImplementation(async params => {
+        if (isRemovalChange(params.change)) {
           throw new Error('some error')
         }
         throw new client.HTTPError('some error', { status: 400, data: { errorMessages: ['errorMessage'], errors: { key: 'value' } } })

--- a/packages/jira-adapter/test/adapter.test.ts
+++ b/packages/jira-adapter/test/adapter.test.ts
@@ -121,17 +121,14 @@ describe('adapter', () => {
         },
       })
 
-      expect(deployChangeMock).toHaveBeenCalledWith(
-        toChange({
+      expect(deployChangeMock).toHaveBeenCalledWith({
+        change: toChange({
           before: new InstanceElement('inst1', fieldConfigurationIssueTypeItemType),
           after: new InstanceElement('inst1', fieldConfigurationIssueTypeItemType, { issueTypeId: '3' }),
         }),
-        expect.any(JiraClient),
-        undefined,
-        [],
-        undefined,
-        undefined,
-      )
+        client: expect.any(JiraClient),
+        fieldsToIgnore: [],
+      })
     })
 
     it('should return the errors', async () => {

--- a/packages/jira-adapter/test/filters/board/board_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/board/board_deployment.test.ts
@@ -191,15 +191,13 @@ describe('boardDeploymentFilter', () => {
       it('deploy should call the right endpoints', async () => {
         await filter.deploy([change])
 
-        expect(deployChangeMock).toHaveBeenCalledWith(
+        expect(deployChangeMock).toHaveBeenCalledWith({
           change,
           client,
-          getDefaultConfig({ isDataCenter: false })
+          endpointDetails: getDefaultConfig({ isDataCenter: false })
             .apiDefinitions.types[BOARD_TYPE_NAME].deployRequests,
-          [COLUMNS_CONFIG_FIELD, 'subQuery', 'estimation'],
-          undefined,
-          undefined
-        )
+          fieldsToIgnore: [COLUMNS_CONFIG_FIELD, 'subQuery', 'estimation'],
+        })
 
         expect(connection.put).toHaveBeenCalledWith(
           '/rest/greenhopper/1.0/rapidviewconfig/columns',

--- a/packages/jira-adapter/test/filters/dashboard/dashboard_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/dashboard/dashboard_deployment.test.ts
@@ -173,18 +173,16 @@ describe('dashboardDeploymentFilter', () => {
 
     it('should call the default deploy', async () => {
       await filter.deploy([change])
-      expect(deployChangeMock).toHaveBeenCalledWith(
-        await resolveChangeElement(change, getLookUpName),
+      expect(deployChangeMock).toHaveBeenCalledWith({
+        change: await resolveChangeElement(change, getLookUpName),
         client,
-        getDefaultConfig({ isDataCenter: false })
+        endpointDetails: getDefaultConfig({ isDataCenter: false })
           .apiDefinitions.types[DASHBOARD_TYPE].deployRequests,
-        [
+        fieldsToIgnore: [
           'layout',
           'gadgets',
         ],
-        undefined,
-        undefined,
-      )
+      })
     })
 
     it('should call layout with the right parameters on addition', async () => {

--- a/packages/jira-adapter/test/filters/dashboard/gadget.test.ts
+++ b/packages/jira-adapter/test/filters/dashboard/gadget.test.ts
@@ -266,15 +266,13 @@ describe('gadgetFilter', () => {
 
     it('should call the default deploy', async () => {
       await filter.deploy([change])
-      expect(deployChangeMock).toHaveBeenCalledWith(
-        await resolveChangeElement(change, getLookUpName),
+      expect(deployChangeMock).toHaveBeenCalledWith({
+        change: await resolveChangeElement(change, getLookUpName),
         client,
-        getDefaultConfig({ isDataCenter: false })
+        endpointDetails: getDefaultConfig({ isDataCenter: false })
           .apiDefinitions.types[DASHBOARD_GADGET_TYPE].deployRequests,
-        ['properties'],
-        undefined,
-        undefined,
-      )
+        fieldsToIgnore: ['properties'],
+      })
     })
 
     it('should do nothing if removal throws 404', async () => {

--- a/packages/jira-adapter/test/filters/field_configurations_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/field_configurations_scheme.test.ts
@@ -144,14 +144,12 @@ describe('field_configurations_scheme', () => {
         await filter.deploy?.([change])
       })
       it('should call deployChange and ignore items', () => {
-        expect(deployChangeMock).toHaveBeenCalledWith(
+        expect(deployChangeMock).toHaveBeenCalledWith({
           change,
-          expect.any(JiraClient),
-          expect.any(Object),
-          ['items'],
-          undefined,
-          undefined,
-        )
+          client: expect.any(JiraClient),
+          endpointDetails: expect.any(Object),
+          fieldsToIgnore: ['items'],
+        })
       })
 
       it('should call the endpoint to add the new items', () => {

--- a/packages/jira-adapter/test/filters/fields/contexts.test.ts
+++ b/packages/jira-adapter/test/filters/fields/contexts.test.ts
@@ -109,21 +109,19 @@ describe('deployContextChange', () => {
       getDefaultConfig({ isDataCenter: false }).apiDefinitions
     )
 
-    expect(deployChangeMock).toHaveBeenCalledWith(
-      await resolveChangeElement(change, getLookUpName),
+    expect(deployChangeMock).toHaveBeenCalledWith({
+      change: await resolveChangeElement(change, getLookUpName),
       client,
-      getDefaultConfig({ isDataCenter: false })
+      endpointDetails: getDefaultConfig({ isDataCenter: false })
         .apiDefinitions.types.CustomFieldContext.deployRequests,
-      [
+      fieldsToIgnore: [
         'defaultValue',
         'options',
         'isGlobalContext',
         'issueTypeIds',
         'projectIds',
       ],
-      undefined,
-      undefined,
-    )
+    })
   })
 
   it('should not throw if deploy failed because the field was deleted', async () => {

--- a/packages/jira-adapter/test/filters/fields/field_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_deployment.test.ts
@@ -83,14 +83,12 @@ describe('fields_deployment', () => {
 
     const change = toChange({ after: instance })
     await filter.deploy([change])
-    expect(deployChangeMock).toHaveBeenCalledWith(
+    expect(deployChangeMock).toHaveBeenCalledWith({
       change,
       client,
-      getDefaultConfig({ isDataCenter: false }).apiDefinitions.types.Field.deployRequests,
-      ['contexts'],
-      undefined,
-      undefined,
-    )
+      endpointDetails: getDefaultConfig({ isDataCenter: false }).apiDefinitions.types.Field.deployRequests,
+      fieldsToIgnore: ['contexts'],
+    })
   })
 
   it('if an addition should remove default context', async () => {

--- a/packages/jira-adapter/test/filters/fields/field_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_deployment.test.ts
@@ -86,7 +86,8 @@ describe('fields_deployment', () => {
     expect(deployChangeMock).toHaveBeenCalledWith({
       change,
       client,
-      endpointDetails: getDefaultConfig({ isDataCenter: false }).apiDefinitions.types.Field.deployRequests,
+      endpointDetails: getDefaultConfig({ isDataCenter: false })
+        .apiDefinitions.types.Field.deployRequests,
       fieldsToIgnore: ['contexts'],
     })
   })

--- a/packages/jira-adapter/test/filters/issue_type_schemas/issue_type_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/issue_type_schemas/issue_type_scheme.test.ts
@@ -106,14 +106,12 @@ describe('issueTypeScheme', () => {
         await filter.deploy?.([change])
       })
       it('should call deployChange and ignore issueTypeIds', () => {
-        expect(deployChangeMock).toHaveBeenCalledWith(
+        expect(deployChangeMock).toHaveBeenCalledWith({
           change,
-          expect.any(JiraClient),
-          expect.any(Object),
-          ['issueTypeIds'],
-          undefined,
-          undefined,
-        )
+          client: expect.any(JiraClient),
+          endpointDetails: expect.any(Object),
+          fieldsToIgnore: ['issueTypeIds'],
+        })
       })
 
       it('should call the endpoint to add the new issue types ids', () => {
@@ -173,14 +171,12 @@ describe('issueTypeScheme', () => {
         await filter.deploy?.([change])
       })
       it('should call deployChange', () => {
-        expect(deployChangeMock).toHaveBeenCalledWith(
-          toChange({ after: instanceBefore }),
-          expect.any(JiraClient),
-          expect.any(Object),
-          [],
-          undefined,
-          undefined,
-        )
+        expect(deployChangeMock).toHaveBeenCalledWith({
+          change: toChange({ after: instanceBefore }),
+          client: expect.any(JiraClient),
+          endpointDetails: expect.any(Object),
+          fieldsToIgnore: []
+        })
       })
 
       it('should add the id to the instance', () => {

--- a/packages/jira-adapter/test/filters/issue_type_schemas/issue_type_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/issue_type_schemas/issue_type_scheme.test.ts
@@ -175,7 +175,7 @@ describe('issueTypeScheme', () => {
           change: toChange({ after: instanceBefore }),
           client: expect.any(JiraClient),
           endpointDetails: expect.any(Object),
-          fieldsToIgnore: []
+          fieldsToIgnore: [],
         })
       })
 

--- a/packages/jira-adapter/test/filters/issue_type_screen_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/issue_type_screen_scheme.test.ts
@@ -134,15 +134,13 @@ describe('issueTypeScreenScheme', () => {
         await filter.deploy?.([change])
       })
       it('should call deployChange and ignore issueTypeMappings', () => {
-        expect(deployChangeMock).toHaveBeenCalledWith(
+        expect(deployChangeMock).toHaveBeenCalledWith({
           change,
           client,
-          getDefaultConfig({ isDataCenter: false })
+          endpointDetails: getDefaultConfig({ isDataCenter: false })
             .apiDefinitions.types.IssueTypeScreenScheme.deployRequests,
-          ['issueTypeMappings'],
-          undefined,
-          undefined,
-        )
+          fieldsToIgnore: ['issueTypeMappings'],
+        })
       })
 
       it('should call the endpoint to remove the removed and modified items', () => {

--- a/packages/jira-adapter/test/filters/project.test.ts
+++ b/packages/jira-adapter/test/filters/project.test.ts
@@ -173,14 +173,14 @@ describe('projectFilter', () => {
       await filter.deploy([change])
     })
     it('should call deployChange and ignore scheme', () => {
-      expect(deployChangeMock).toHaveBeenCalledWith(
+      expect(deployChangeMock).toHaveBeenCalledWith({
         change,
         client,
-        getDefaultConfig({ isDataCenter: false }).apiDefinitions.types.Project.deployRequests,
-        ['components', 'workflowScheme', 'issueTypeScreenScheme', 'fieldConfigurationScheme', 'issueTypeScheme', PROJECT_CONTEXTS_FIELD],
-        undefined,
-        undefined,
-      )
+        endpointDetails: getDefaultConfig({ isDataCenter: false })
+          .apiDefinitions.types.Project.deployRequests,
+        fieldsToIgnore: ['components', 'workflowScheme', 'issueTypeScreenScheme',
+          'fieldConfigurationScheme', 'issueTypeScheme', PROJECT_CONTEXTS_FIELD],
+      })
     })
 
     it('should call the endpoint to set the scheme', () => {
@@ -219,14 +219,13 @@ describe('projectFilter', () => {
       await filter.deploy([change])
     })
     it('should call deployChange and ignore the right fields', () => {
-      expect(deployChangeMock).toHaveBeenCalledWith(
+      expect(deployChangeMock).toHaveBeenCalledWith({
         change,
         client,
-        getDefaultConfig({ isDataCenter: false }).apiDefinitions.types.Project.deployRequests,
-        ['components', 'fieldConfigurationScheme', PROJECT_CONTEXTS_FIELD],
-        undefined,
-        undefined,
-      )
+        endpointDetails: getDefaultConfig({ isDataCenter: false })
+          .apiDefinitions.types.Project.deployRequests,
+        fieldsToIgnore: ['components', 'fieldConfigurationScheme', PROJECT_CONTEXTS_FIELD],
+      })
     })
 
     it('should call the endpoint to get the components', () => {
@@ -300,14 +299,13 @@ describe('projectFilter', () => {
       await filter.deploy([change])
     })
     it('should call deployChange and ignore the right fields', () => {
-      expect(deployChangeMock).toHaveBeenCalledWith(
+      expect(deployChangeMock).toHaveBeenCalledWith({
         change,
         client,
-        getDefaultConfig({ isDataCenter: false }).apiDefinitions.types.Project.deployRequests,
-        ['components', 'fieldConfigurationScheme', PROJECT_CONTEXTS_FIELD],
-        undefined,
-        undefined,
-      )
+        endpointDetails: getDefaultConfig({ isDataCenter: false })
+          .apiDefinitions.types.Project.deployRequests,
+        fieldsToIgnore: ['components', 'fieldConfigurationScheme', PROJECT_CONTEXTS_FIELD],
+      })
     })
 
     it('should call the endpoint to get the projectId', () => {
@@ -399,14 +397,13 @@ describe('projectFilter', () => {
       await filter.deploy([change])
     })
     it('should call deployChange and ignore the right fields', () => {
-      expect(deployChangeMock).toHaveBeenCalledWith(
+      expect(deployChangeMock).toHaveBeenCalledWith({
         change,
         client,
-        getDefaultConfig({ isDataCenter: false }).apiDefinitions.types.Project.deployRequests,
-        ['components', 'fieldConfigurationScheme', PROJECT_CONTEXTS_FIELD],
-        undefined,
-        undefined,
-      )
+        endpointDetails: getDefaultConfig({ isDataCenter: false })
+          .apiDefinitions.types.Project.deployRequests,
+        fieldsToIgnore: ['components', 'fieldConfigurationScheme', PROJECT_CONTEXTS_FIELD],
+      })
     })
 
     it('should call the endpoint to get the projectId', () => {

--- a/packages/jira-adapter/test/filters/screen/screen.test.ts
+++ b/packages/jira-adapter/test/filters/screen/screen.test.ts
@@ -122,14 +122,13 @@ describe('screenFilter', () => {
       })
       await filter.deploy?.([change])
 
-      expect(deployChangeMock).toHaveBeenCalledWith(
+      expect(deployChangeMock).toHaveBeenCalledWith({
         change,
         client,
-        getDefaultConfig({ isDataCenter: false }).apiDefinitions.types.Screen.deployRequests,
-        ['tabs'],
-        undefined,
-        undefined,
-      )
+        endpointDetails: getDefaultConfig({ isDataCenter: false })
+          .apiDefinitions.types.Screen.deployRequests,
+        fieldsToIgnore: ['tabs'],
+      })
     })
 
     it('should call deployChange and ignore tabs and names if were not changed', async () => {
@@ -139,14 +138,13 @@ describe('screenFilter', () => {
       })
       await filter.deploy?.([change])
 
-      expect(deployChangeMock).toHaveBeenCalledWith(
+      expect(deployChangeMock).toHaveBeenCalledWith({
         change,
         client,
-        getDefaultConfig({ isDataCenter: false }).apiDefinitions.types.Screen.deployRequests,
-        ['tabs', 'name'],
-        undefined,
-        undefined,
-      )
+        endpointDetails: getDefaultConfig({ isDataCenter: false })
+          .apiDefinitions.types.Screen.deployRequests,
+        fieldsToIgnore: ['tabs', 'name'],
+      })
     })
 
     it('should call endpoints to reorder tabs', async () => {

--- a/packages/jira-adapter/test/filters/screen/screenable_tab.test.ts
+++ b/packages/jira-adapter/test/filters/screen/screenable_tab.test.ts
@@ -104,18 +104,18 @@ describe('screenableTab', () => {
       }) as ModificationChange<InstanceElement>
       await deployTabs(change, client, getDefaultConfig({ isDataCenter: false }))
 
-      expect(deployChangeMock).toHaveBeenCalledWith(
-        toChange({
+      expect(deployChangeMock).toHaveBeenCalledWith({
+        change: toChange({
           after: new InstanceElement('tab', screenTabType, {
             name: 'tab',
           }),
         }),
         client,
-        getDefaultConfig({ isDataCenter: false }).apiDefinitions.types.ScreenableTab.deployRequests,
-        ['fields', 'position'],
-        { screenId: 'screenId' },
-        undefined,
-      )
+        endpointDetails: getDefaultConfig({ isDataCenter: false })
+          .apiDefinitions.types.ScreenableTab.deployRequests,
+        fieldsToIgnore: ['fields', 'position'],
+        additionalUrlVars: { screenId: 'screenId' },
+      })
     })
 
     it('should call deployChange and ignore fields and names of were not changed', async () => {
@@ -136,17 +136,17 @@ describe('screenableTab', () => {
       }) as ModificationChange<InstanceElement>
       await deployTabs(change, client, getDefaultConfig({ isDataCenter: false }))
 
-      expect(deployChangeMock).toHaveBeenCalledWith(
-        toChange({
+      expect(deployChangeMock).toHaveBeenCalledWith({
+        change: toChange({
           before: new InstanceElement('tab', screenTabType, { name: 'tab', description: 'desc' }),
           after: new InstanceElement('tab', screenTabType, { name: 'tab' }),
         }),
         client,
-        getDefaultConfig({ isDataCenter: false }).apiDefinitions.types.ScreenableTab.deployRequests,
-        ['fields', 'position', 'name'],
-        { screenId: 'screenId' },
-        undefined,
-      )
+        endpointDetails: getDefaultConfig({ isDataCenter: false })
+          .apiDefinitions.types.ScreenableTab.deployRequests,
+        fieldsToIgnore: ['fields', 'position', 'name'],
+        additionalUrlVars: { screenId: 'screenId' },
+      })
     })
 
     it('should remove  automatically created tabs tab on create', async () => {
@@ -170,16 +170,16 @@ describe('screenableTab', () => {
       }) as AdditionChange<InstanceElement>
       await deployTabs(change, client, getDefaultConfig({ isDataCenter: false }))
 
-      expect(deployChangeMock).toHaveBeenCalledWith(
-        toChange({
+      expect(deployChangeMock).toHaveBeenCalledWith({
+        change: toChange({
           before: new InstanceElement('fieldTab', screenTabType, { name: 'fieldTab', id: 'tabId' }),
         }),
         client,
-        getDefaultConfig({ isDataCenter: false }).apiDefinitions.types.ScreenableTab.deployRequests,
-        ['fields', 'position'],
-        { screenId: 'screenId' },
-        undefined,
-      )
+        endpointDetails: getDefaultConfig({ isDataCenter: false })
+          .apiDefinitions.types.ScreenableTab.deployRequests,
+        fieldsToIgnore: ['fields', 'position'],
+        additionalUrlVars: { screenId: 'screenId' },
+      })
     })
 
     describe('deploying fields', () => {

--- a/packages/jira-adapter/test/filters/workflow/workflow_deploy_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_deploy_filter.test.ts
@@ -71,8 +71,8 @@ describe('workflowDeployFilter', () => {
 
       await filter.deploy([change])
 
-      expect(deployChangeMock).toHaveBeenCalledWith(
-        toChange({
+      expect(deployChangeMock).toHaveBeenCalledWith({
+        change: toChange({
           after: new InstanceElement(
             'instance',
             workflowType,
@@ -107,11 +107,10 @@ describe('workflowDeployFilter', () => {
           ),
         }),
         client,
-        getDefaultConfig({ isDataCenter: false }).apiDefinitions.types.Workflow.deployRequests,
-        expect.toBeFunction(),
-        undefined,
-        undefined,
-      )
+        endpointDetails: getDefaultConfig({ isDataCenter: false })
+          .apiDefinitions.types.Workflow.deployRequests,
+        fieldsToIgnore: expect.toBeFunction(),
+      })
     })
 
     it('should change ids from number to string on condition configuration', async () => {
@@ -147,8 +146,8 @@ describe('workflowDeployFilter', () => {
 
       await filter.deploy([change])
 
-      expect(deployChangeMock).toHaveBeenCalledWith(
-        toChange({
+      expect(deployChangeMock).toHaveBeenCalledWith({
+        change: toChange({
           after: new InstanceElement(
             'instance',
             workflowType,
@@ -178,11 +177,10 @@ describe('workflowDeployFilter', () => {
           ),
         }),
         client,
-        getDefaultConfig({ isDataCenter: false }).apiDefinitions.types.Workflow.deployRequests,
-        expect.toBeFunction(),
-        undefined,
-        undefined,
-      )
+        endpointDetails: getDefaultConfig({ isDataCenter: false })
+          .apiDefinitions.types.Workflow.deployRequests,
+        fieldsToIgnore: expect.toBeFunction(),
+      })
     })
 
     it('should add operations value', async () => {
@@ -212,8 +210,8 @@ describe('workflowDeployFilter', () => {
 
       await filter.deploy([change])
 
-      expect(deployChangeMock).toHaveBeenCalledWith(
-        toChange({
+      expect(deployChangeMock).toHaveBeenCalledWith({
+        change: toChange({
           after: new InstanceElement(
             'instance',
             workflowType,
@@ -223,11 +221,10 @@ describe('workflowDeployFilter', () => {
           ),
         }),
         client,
-        getDefaultConfig({ isDataCenter: false }).apiDefinitions.types.Workflow.deployRequests,
-        expect.toBeFunction(),
-        undefined,
-        undefined,
-      )
+        endpointDetails: getDefaultConfig({ isDataCenter: false })
+          .apiDefinitions.types.Workflow.deployRequests,
+        fieldsToIgnore: expect.toBeFunction(),
+      })
     })
 
     it('should not change the values if there are no rules', async () => {
@@ -248,8 +245,8 @@ describe('workflowDeployFilter', () => {
 
       await filter.deploy([change])
 
-      expect(deployChangeMock).toHaveBeenCalledWith(
-        toChange({
+      expect(deployChangeMock).toHaveBeenCalledWith({
+        change: toChange({
           after: new InstanceElement(
             'instance',
             workflowType,
@@ -264,11 +261,10 @@ describe('workflowDeployFilter', () => {
           ),
         }),
         client,
-        getDefaultConfig({ isDataCenter: false }).apiDefinitions.types.Workflow.deployRequests,
-        expect.toBeFunction(),
-        undefined,
-        undefined,
-      )
+        endpointDetails: getDefaultConfig({ isDataCenter: false })
+          .apiDefinitions.types.Workflow.deployRequests,
+        fieldsToIgnore: expect.toBeFunction(),
+      })
     })
 
     it('should throw an error if workflow is invalid', async () => {

--- a/packages/jira-adapter/test/filters/workflow_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/workflow_scheme.test.ts
@@ -195,15 +195,13 @@ describe('workflowScheme', () => {
 
       const change = toChange({ after: instance })
       await filter.deploy?.([change])
-      expect(deployChangeMock).toHaveBeenCalledWith(
+      expect(deployChangeMock).toHaveBeenCalledWith({
         change,
         client,
-        getDefaultConfig({ isDataCenter: false })
+        endpointDetails: getDefaultConfig({ isDataCenter: false })
           .apiDefinitions.types.WorkflowScheme.deployRequests,
-        ['items'],
-        undefined,
-        undefined,
-      )
+        fieldsToIgnore: ['items'],
+      })
     })
 
     it('when draft should call publish draft', async () => {
@@ -253,15 +251,13 @@ describe('workflowScheme', () => {
       instanceBefore.value.description = 'desc'
       await filter.deploy?.([toChange({ before: instanceBefore, after: instance })])
 
-      expect(deployChangeMock).toHaveBeenCalledWith(
-        toChange({ before: instanceBefore, after: instance }),
+      expect(deployChangeMock).toHaveBeenCalledWith({
+        change: toChange({ before: instanceBefore, after: instance }),
         client,
-        getDefaultConfig({ isDataCenter: false })
+        endpointDetails: getDefaultConfig({ isDataCenter: false })
           .apiDefinitions.types.WorkflowScheme.deployRequests,
-        ['items'],
-        undefined,
-        undefined,
-      )
+        fieldsToIgnore: ['items'],
+      })
 
       expect(connection.post).toHaveBeenCalledWith(
         '/rest/api/3/workflowscheme/1/draft/publish',
@@ -335,15 +331,13 @@ describe('workflowScheme', () => {
       await filter.deploy?.([toChange({ before: instanceBefore, after: instance })])
 
 
-      expect(deployChangeMock).toHaveBeenCalledWith(
-        toChange({ before: instanceBefore, after: instance }),
+      expect(deployChangeMock).toHaveBeenCalledWith({
+        change: toChange({ before: instanceBefore, after: instance }),
         client,
-        getDefaultConfig({ isDataCenter: false })
+        endpointDetails: getDefaultConfig({ isDataCenter: false })
           .apiDefinitions.types.WorkflowScheme.deployRequests,
-        ['items'],
-        undefined,
-        undefined,
-      )
+        fieldsToIgnore: ['items'],
+      })
 
 
       expect(connection.get).toHaveBeenCalledWith(
@@ -399,15 +393,13 @@ describe('workflowScheme', () => {
       instanceBefore.value.description = 'desc'
       await filter.deploy?.([toChange({ before: instanceBefore, after: instance })])
 
-      expect(deployChangeMock).toHaveBeenCalledWith(
-        toChange({ before: instanceBefore, after: instance }),
+      expect(deployChangeMock).toHaveBeenCalledWith({
+        change: toChange({ before: instanceBefore, after: instance }),
         client,
-        getDefaultConfig({ isDataCenter: false })
+        endpointDetails: getDefaultConfig({ isDataCenter: false })
           .apiDefinitions.types.WorkflowScheme.deployRequests,
-        ['items'],
-        undefined,
-        undefined,
-      )
+        fieldsToIgnore: ['items'],
+      })
 
       expect(connection.get).toHaveBeenCalledWith(
         '/rest/api/3/workflowscheme/1',
@@ -469,15 +461,13 @@ describe('workflowScheme', () => {
       instanceBefore.value.description = 'desc'
       await filter.deploy?.([toChange({ before: instanceBefore, after: instance })])
 
-      expect(deployChangeMock).toHaveBeenCalledWith(
-        toChange({ before: instanceBefore, after: instance }),
+      expect(deployChangeMock).toHaveBeenCalledWith({
+        change: toChange({ before: instanceBefore, after: instance }),
         client,
-        getDefaultConfig({ isDataCenter: false })
+        endpointDetails: getDefaultConfig({ isDataCenter: false })
           .apiDefinitions.types.WorkflowScheme.deployRequests,
-        ['items'],
-        undefined,
-        undefined,
-      )
+        fieldsToIgnore: ['items'],
+      })
 
       expect(instance.value.statusMigrations).toBeUndefined()
       expect(instance.value.id).toBe('1')

--- a/packages/zendesk-adapter/src/deployment.ts
+++ b/packages/zendesk-adapter/src/deployment.ts
@@ -126,12 +126,12 @@ export const deployChange = async (
 ): Promise<deployment.ResponseResult> => {
   const { deployRequests } = apiDefinitions.types[getChangeData(change).elemID.typeName]
   try {
-    const response = await deployment.deployChange(
+    const response = await deployment.deployChange({
       change,
       client,
-      deployRequests,
-      fieldsToIgnore
-    )
+      endpointDetails: deployRequests,
+      fieldsToIgnore,
+    })
     addId({
       change,
       apiDefinitions,

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -980,8 +980,8 @@ describe('adapter', () => {
           ],
         },
       })
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        toChange({
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: toChange({
           after: new InstanceElement(
             instance.elemID.name,
             new ObjectType({
@@ -1001,10 +1001,9 @@ describe('adapter', () => {
             { [CORE_ANNOTATIONS.SERVICE_URL]: 'https://abc.zendesk.com/admin/people/team/groups' },
           ),
         }),
-        expect.anything(),
-        expect.anything(),
-        undefined,
-      )
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+      })
     })
     it('should not try to deploy instances', async () => {
       mockDeployChange.mockImplementation(async () => ({}))

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -739,7 +739,7 @@ describe('adapter', () => {
     const brandType = new ObjectType({ elemID: new ElemID(ZENDESK, 'brand') })
     const anotherType = new ObjectType({ elemID: new ElemID(ZENDESK, 'anotherType') })
     beforeEach(() => {
-      mockDeployChange.mockImplementation(async change => {
+      mockDeployChange.mockImplementation(async ({ change }) => {
         if (isRemovalChange(change)) {
           throw new Error('some error')
         }
@@ -1017,8 +1017,8 @@ describe('adapter', () => {
         },
       })
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        toChange({ before: new InstanceElement(
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: toChange({ before: new InstanceElement(
           'inst',
           new ObjectType({
             elemID: groupType.elemID,
@@ -1032,10 +1032,10 @@ describe('adapter', () => {
             path: [ZENDESK, elementsUtils.TYPES_PATH, 'group'],
           }),
         ) }),
-        expect.anything(),
-        expect.anything(),
-        undefined,
-      )
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        fieldsToIgnore: undefined,
+      })
       expect(deployRes.appliedChanges).toEqual([
         toChange({ before: new InstanceElement('inst', groupType) }),
       ])

--- a/packages/zendesk-adapter/test/filters/account_settings.test.ts
+++ b/packages/zendesk-adapter/test/filters/account_settings.test.ts
@@ -81,12 +81,12 @@ describe('account settings filter', () => {
       [{ action: 'modify', data: { before: accountSettings, after: clonedAfter } }]
     )
     expect(mockDeployChange).toHaveBeenCalledTimes(1)
-    expect(mockDeployChange).toHaveBeenCalledWith(
-      { action: 'modify', data: { before: accountSettings, after: clonedAfter } },
-      expect.anything(),
-      expect.anything(),
-      ['routing.autorouting_tag']
-    )
+    expect(mockDeployChange).toHaveBeenCalledWith({
+      change: { action: 'modify', data: { before: accountSettings, after: clonedAfter } },
+      client: expect.anything(),
+      endpointDetails: expect.anything(),
+      fieldsToIgnore: ['routing.autorouting_tag']
+    })
     expect(res.leftoverChanges).toHaveLength(0)
     expect(res.deployResult.errors).toHaveLength(0)
     expect(res.deployResult.appliedChanges)
@@ -103,12 +103,12 @@ describe('account settings filter', () => {
       [{ action: 'modify', data: { before: accountSettings, after: clonedAfter } }]
     )
     expect(mockDeployChange).toHaveBeenCalledTimes(1)
-    expect(mockDeployChange).toHaveBeenCalledWith(
-      { action: 'modify', data: { before: accountSettings, after: clonedAfter } },
-      expect.anything(),
-      expect.anything(),
-      []
-    )
+    expect(mockDeployChange).toHaveBeenCalledWith({
+      change: { action: 'modify', data: { before: accountSettings, after: clonedAfter } },
+      client: expect.anything(),
+      endpointDetails: expect.anything(),
+      fieldsToIgnore: []
+    })
     expect(res.leftoverChanges).toHaveLength(0)
     expect(res.deployResult.errors).toHaveLength(0)
     expect(res.deployResult.appliedChanges)
@@ -136,12 +136,12 @@ describe('account settings filter', () => {
       [{ action: 'modify', data: { before: accountSettings, after: clonedAfter } }]
     )
     expect(mockDeployChange).toHaveBeenCalledTimes(1)
-    expect(mockDeployChange).toHaveBeenCalledWith(
-      { action: 'modify', data: { before: accountSettings, after: clonedAfter } },
-      expect.anything(),
-      expect.anything(),
-      ['routing.autorouting_tag']
-    )
+    expect(mockDeployChange).toHaveBeenCalledWith({
+      change: { action: 'modify', data: { before: accountSettings, after: clonedAfter } },
+      client: expect.anything(),
+      endpointDetails: expect.anything(),
+      fieldsToIgnore: ['routing.autorouting_tag']
+    })
     expect(res.leftoverChanges).toHaveLength(0)
     expect(res.deployResult.errors).toHaveLength(1)
     expect(res.deployResult.appliedChanges).toHaveLength(0)

--- a/packages/zendesk-adapter/test/filters/account_settings.test.ts
+++ b/packages/zendesk-adapter/test/filters/account_settings.test.ts
@@ -85,7 +85,7 @@ describe('account settings filter', () => {
       change: { action: 'modify', data: { before: accountSettings, after: clonedAfter } },
       client: expect.anything(),
       endpointDetails: expect.anything(),
-      fieldsToIgnore: ['routing.autorouting_tag']
+      fieldsToIgnore: ['routing.autorouting_tag'],
     })
     expect(res.leftoverChanges).toHaveLength(0)
     expect(res.deployResult.errors).toHaveLength(0)
@@ -107,7 +107,7 @@ describe('account settings filter', () => {
       change: { action: 'modify', data: { before: accountSettings, after: clonedAfter } },
       client: expect.anything(),
       endpointDetails: expect.anything(),
-      fieldsToIgnore: []
+      fieldsToIgnore: [],
     })
     expect(res.leftoverChanges).toHaveLength(0)
     expect(res.deployResult.errors).toHaveLength(0)
@@ -140,7 +140,7 @@ describe('account settings filter', () => {
       change: { action: 'modify', data: { before: accountSettings, after: clonedAfter } },
       client: expect.anything(),
       endpointDetails: expect.anything(),
-      fieldsToIgnore: ['routing.autorouting_tag']
+      fieldsToIgnore: ['routing.autorouting_tag'],
     })
     expect(res.leftoverChanges).toHaveLength(0)
     expect(res.deployResult.errors).toHaveLength(1)

--- a/packages/zendesk-adapter/test/filters/app.test.ts
+++ b/packages/zendesk-adapter/test/filters/app.test.ts
@@ -82,12 +82,12 @@ describe('app installation filter', () => {
     mockGet.mockResolvedValue({ status: 200, data: { status: 'completed' } })
     const res = await filter.deploy([{ action: 'add', data: { after: clonedApp } }])
     expect(mockDeployChange).toHaveBeenCalledTimes(1)
-    expect(mockDeployChange).toHaveBeenCalledWith(
-      { action: 'add', data: { after: clonedApp } },
-      expect.anything(),
-      expect.anything(),
-      ['app', 'settings.title', 'settings_objects']
-    )
+    expect(mockDeployChange).toHaveBeenCalledWith({
+      change: { action: 'add', data: { after: clonedApp } },
+      client: expect.anything(),
+      endpointDetails: expect.anything(),
+      fieldsToIgnore: ['app', 'settings.title', 'settings_objects']
+    })
     expect(mockGet).toHaveBeenCalledTimes(1)
     expect(mockGet).toHaveBeenCalledWith({
       url: '/apps/job_statuses/123',
@@ -110,12 +110,12 @@ describe('app installation filter', () => {
       [{ action: 'modify', data: { before: clonedBeforeApp, after: clonedAfterApp } }]
     )
     expect(mockDeployChange).toHaveBeenCalledTimes(1)
-    expect(mockDeployChange).toHaveBeenCalledWith(
-      { action: 'modify', data: { before: clonedBeforeApp, after: clonedAfterApp } },
-      expect.anything(),
-      expect.anything(),
-      ['app', 'settings.title', 'settings_objects']
-    )
+    expect(mockDeployChange).toHaveBeenCalledWith({
+      change: { action: 'modify', data: { before: clonedBeforeApp, after: clonedAfterApp } },
+      client: expect.anything(),
+      endpointDetails: expect.anything(),
+      fieldsToIgnore: ['app', 'settings.title', 'settings_objects']
+    })
     expect(mockGet).toHaveBeenCalledTimes(0)
     expect(res.leftoverChanges).toHaveLength(0)
     expect(res.deployResult.errors).toHaveLength(0)
@@ -130,12 +130,12 @@ describe('app installation filter', () => {
     mockDeployChange.mockImplementation(async () => { throw new Error('err') })
     const res = await filter.deploy([{ action: 'add', data: { after: clonedApp } }])
     expect(mockDeployChange).toHaveBeenCalledTimes(1)
-    expect(mockDeployChange).toHaveBeenCalledWith(
-      { action: 'add', data: { after: clonedApp } },
-      expect.anything(),
-      expect.anything(),
-      ['app', 'settings.title', 'settings_objects']
-    )
+    expect(mockDeployChange).toHaveBeenCalledWith({
+      change: { action: 'add', data: { after: clonedApp } },
+      client: expect.anything(),
+      endpointDetails: expect.anything(),
+      fieldsToIgnore: ['app', 'settings.title', 'settings_objects']
+    })
     expect(mockGet).toHaveBeenCalledTimes(0)
     expect(res.leftoverChanges).toHaveLength(0)
     expect(res.deployResult.errors).toHaveLength(1)
@@ -149,12 +149,12 @@ describe('app installation filter', () => {
     mockGet.mockImplementation(async () => { throw new Error('err') })
     const res = await filter.deploy([{ action: 'add', data: { after: clonedApp } }])
     expect(mockDeployChange).toHaveBeenCalledTimes(1)
-    expect(mockDeployChange).toHaveBeenCalledWith(
-      { action: 'add', data: { after: clonedApp } },
-      expect.anything(),
-      expect.anything(),
-      ['app', 'settings.title', 'settings_objects']
-    )
+    expect(mockDeployChange).toHaveBeenCalledWith({
+      change: { action: 'add', data: { after: clonedApp } },
+      client: expect.anything(),
+      endpointDetails: expect.anything(),
+      fieldsToIgnore: ['app', 'settings.title', 'settings_objects']
+    })
     expect(mockGet).toHaveBeenCalledTimes(1)
     expect(mockGet).toHaveBeenCalledWith({
       url: '/apps/job_statuses/123',
@@ -171,12 +171,12 @@ describe('app installation filter', () => {
     mockGet.mockResolvedValue({ status: 200, data: { status: 'failed' } })
     const res = await filter.deploy([{ action: 'add', data: { after: clonedApp } }])
     expect(mockDeployChange).toHaveBeenCalledTimes(1)
-    expect(mockDeployChange).toHaveBeenCalledWith(
-      { action: 'add', data: { after: clonedApp } },
-      expect.anything(),
-      expect.anything(),
-      ['app', 'settings.title', 'settings_objects']
-    )
+    expect(mockDeployChange).toHaveBeenCalledWith({
+      change: { action: 'add', data: { after: clonedApp } },
+      client: expect.anything(),
+      endpointDetails: expect.anything(),
+      fieldsToIgnore: ['app', 'settings.title', 'settings_objects']
+    })
     expect(mockGet).toHaveBeenCalledTimes(1)
     expect(mockGet).toHaveBeenCalledWith({
       url: '/apps/job_statuses/123',
@@ -193,12 +193,12 @@ describe('app installation filter', () => {
     mockGet.mockResolvedValue({ status: 200, data: { status: 'failed' } })
     const res = await filter.deploy([{ action: 'add', data: { after: clonedApp } }])
     expect(mockDeployChange).toHaveBeenCalledTimes(1)
-    expect(mockDeployChange).toHaveBeenCalledWith(
-      { action: 'add', data: { after: clonedApp } },
-      expect.anything(),
-      expect.anything(),
-      ['app', 'settings.title', 'settings_objects']
-    )
+    expect(mockDeployChange).toHaveBeenCalledWith({
+      change: { action: 'add', data: { after: clonedApp } },
+      client: expect.anything(),
+      endpointdDetails: expect.anything(),
+      fieldsToIgnore: ['app', 'settings.title', 'settings_objects']
+    })
     expect(mockGet).toHaveBeenCalledTimes(0)
     expect(res.leftoverChanges).toHaveLength(0)
     expect(res.deployResult.errors).toHaveLength(1)

--- a/packages/zendesk-adapter/test/filters/app.test.ts
+++ b/packages/zendesk-adapter/test/filters/app.test.ts
@@ -86,7 +86,7 @@ describe('app installation filter', () => {
       change: { action: 'add', data: { after: clonedApp } },
       client: expect.anything(),
       endpointDetails: expect.anything(),
-      fieldsToIgnore: ['app', 'settings.title', 'settings_objects']
+      fieldsToIgnore: ['app', 'settings.title', 'settings_objects'],
     })
     expect(mockGet).toHaveBeenCalledTimes(1)
     expect(mockGet).toHaveBeenCalledWith({
@@ -114,7 +114,7 @@ describe('app installation filter', () => {
       change: { action: 'modify', data: { before: clonedBeforeApp, after: clonedAfterApp } },
       client: expect.anything(),
       endpointDetails: expect.anything(),
-      fieldsToIgnore: ['app', 'settings.title', 'settings_objects']
+      fieldsToIgnore: ['app', 'settings.title', 'settings_objects'],
     })
     expect(mockGet).toHaveBeenCalledTimes(0)
     expect(res.leftoverChanges).toHaveLength(0)
@@ -134,7 +134,7 @@ describe('app installation filter', () => {
       change: { action: 'add', data: { after: clonedApp } },
       client: expect.anything(),
       endpointDetails: expect.anything(),
-      fieldsToIgnore: ['app', 'settings.title', 'settings_objects']
+      fieldsToIgnore: ['app', 'settings.title', 'settings_objects'],
     })
     expect(mockGet).toHaveBeenCalledTimes(0)
     expect(res.leftoverChanges).toHaveLength(0)
@@ -153,7 +153,7 @@ describe('app installation filter', () => {
       change: { action: 'add', data: { after: clonedApp } },
       client: expect.anything(),
       endpointDetails: expect.anything(),
-      fieldsToIgnore: ['app', 'settings.title', 'settings_objects']
+      fieldsToIgnore: ['app', 'settings.title', 'settings_objects'],
     })
     expect(mockGet).toHaveBeenCalledTimes(1)
     expect(mockGet).toHaveBeenCalledWith({
@@ -175,7 +175,7 @@ describe('app installation filter', () => {
       change: { action: 'add', data: { after: clonedApp } },
       client: expect.anything(),
       endpointDetails: expect.anything(),
-      fieldsToIgnore: ['app', 'settings.title', 'settings_objects']
+      fieldsToIgnore: ['app', 'settings.title', 'settings_objects'],
     })
     expect(mockGet).toHaveBeenCalledTimes(1)
     expect(mockGet).toHaveBeenCalledWith({
@@ -196,8 +196,8 @@ describe('app installation filter', () => {
     expect(mockDeployChange).toHaveBeenCalledWith({
       change: { action: 'add', data: { after: clonedApp } },
       client: expect.anything(),
-      endpointdDetails: expect.anything(),
-      fieldsToIgnore: ['app', 'settings.title', 'settings_objects']
+      endpointDetails: expect.anything(),
+      fieldsToIgnore: ['app', 'settings.title', 'settings_objects'],
     })
     expect(mockGet).toHaveBeenCalledTimes(0)
     expect(res.leftoverChanges).toHaveLength(0)

--- a/packages/zendesk-adapter/test/filters/business_hours_schedule.test.ts
+++ b/packages/zendesk-adapter/test/filters/business_hours_schedule.test.ts
@@ -75,12 +75,12 @@ describe('business hours schedule filter', () => {
     mockPut.mockResolvedValue({ status: 200, data: { schedule: { id } } })
     const res = await filter.deploy([{ action: 'add', data: { after: clonedSchedule } }])
     expect(mockDeployChange).toHaveBeenCalledTimes(1)
-    expect(mockDeployChange).toHaveBeenCalledWith(
-      { action: 'add', data: { after: clonedSchedule } },
-      expect.anything(),
-      expect.anything(),
-      ['holidays']
-    )
+    expect(mockDeployChange).toHaveBeenCalledWith({
+      change: { action: 'add', data: { after: clonedSchedule } },
+      client: expect.anything(),
+      endpointDetails: expect.anything(),
+      fieldsToIgnore: ['holidays']
+    })
     expect(mockPut).toHaveBeenCalledTimes(1)
     expect(mockPut).toHaveBeenCalledWith({
       url: '/business_hours/schedules/2/workweek',
@@ -107,12 +107,12 @@ describe('business hours schedule filter', () => {
       [{ action: 'modify', data: { before: clonedBeforeSchedule, after: clonedAfterSchedule } }]
     )
     expect(mockDeployChange).toHaveBeenCalledTimes(1)
-    expect(mockDeployChange).toHaveBeenCalledWith(
-      { action: 'modify', data: { before: clonedBeforeSchedule, after: clonedAfterSchedule } },
-      expect.anything(),
-      expect.anything(),
-      ['holidays']
-    )
+    expect(mockDeployChange).toHaveBeenCalledWith({
+      change: { action: 'modify', data: { before: clonedBeforeSchedule, after: clonedAfterSchedule } },
+      client: expect.anything(),
+      endpointDetails: expect.anything(),
+      fieldsToIgnore: ['holidays']
+    })
     expect(mockPut).toHaveBeenCalledTimes(1)
     expect(mockPut).toHaveBeenCalledWith({
       url: '/business_hours/schedules/2/workweek',
@@ -135,12 +135,12 @@ describe('business hours schedule filter', () => {
     mockPut.mockResolvedValue({ status: 200, data: { schedule: { id } } })
     const res = await filter.deploy([{ action: 'remove', data: { before: clonedSchedule } }])
     expect(mockDeployChange).toHaveBeenCalledTimes(1)
-    expect(mockDeployChange).toHaveBeenCalledWith(
-      { action: 'remove', data: { before: clonedSchedule } },
-      expect.anything(),
-      expect.anything(),
-      ['holidays']
-    )
+    expect(mockDeployChange).toHaveBeenCalledWith({
+      change: { action: 'remove', data: { before: clonedSchedule } },
+      client: expect.anything(),
+      endpointDetails: expect.anything(),
+      fieldsToIgnore: ['holidays']
+    })
     expect(mockPut).toHaveBeenCalledTimes(0)
     expect(res.leftoverChanges).toHaveLength(0)
     expect(res.deployResult.errors).toHaveLength(0)
@@ -162,12 +162,12 @@ describe('business hours schedule filter', () => {
       [{ action: 'modify', data: { before: clonedBeforeSchedule, after: clonedAfterSchedule } }]
     )
     expect(mockDeployChange).toHaveBeenCalledTimes(1)
-    expect(mockDeployChange).toHaveBeenCalledWith(
-      { action: 'modify', data: { before: clonedBeforeSchedule, after: clonedAfterSchedule } },
-      expect.anything(),
-      expect.anything(),
-      ['holidays']
-    )
+    expect(mockDeployChange).toHaveBeenCalledWith({
+      change: { action: 'modify', data: { before: clonedBeforeSchedule, after: clonedAfterSchedule } },
+      client: expect.anything(),
+      endpointDetails: expect.anything(),
+      fieldsToIgnore: ['holidays']
+    })
     expect(mockPut).toHaveBeenCalledTimes(0)
     expect(res.leftoverChanges).toHaveLength(0)
     expect(res.deployResult.errors).toHaveLength(0)
@@ -185,12 +185,12 @@ describe('business hours schedule filter', () => {
     mockPut.mockResolvedValue({ status: 200, data: { schedule: { id } } })
     const res = await filter.deploy([{ action: 'add', data: { after: clonedSchedule } }])
     expect(mockDeployChange).toHaveBeenCalledTimes(1)
-    expect(mockDeployChange).toHaveBeenCalledWith(
-      { action: 'add', data: { after: clonedSchedule } },
-      expect.anything(),
-      expect.anything(),
-      ['holidays']
-    )
+    expect(mockDeployChange).toHaveBeenCalledWith({
+      change: { action: 'add', data: { after: clonedSchedule } },
+      client: expect.anything(),
+      endpointDetails: expect.anything(),
+      fieldsToIgnore: ['holidays']
+    })
     expect(mockPut).toHaveBeenCalledTimes(0)
     expect(res.leftoverChanges).toHaveLength(0)
     expect(res.deployResult.errors).toHaveLength(1)
@@ -204,12 +204,12 @@ describe('business hours schedule filter', () => {
     mockPut.mockImplementation(async () => { throw new Error('err') })
     const res = await filter.deploy([{ action: 'add', data: { after: clonedSchedule } }])
     expect(mockDeployChange).toHaveBeenCalledTimes(1)
-    expect(mockDeployChange).toHaveBeenCalledWith(
-      { action: 'add', data: { after: clonedSchedule } },
-      expect.anything(),
-      expect.anything(),
-      ['holidays']
-    )
+    expect(mockDeployChange).toHaveBeenCalledWith({
+      change: { action: 'add', data: { after: clonedSchedule } },
+      client: expect.anything(),
+      endpointDetails: expect.anything(),
+      fieldsToIgnore: ['holidays']
+    })
     expect(mockPut).toHaveBeenCalledTimes(1)
     expect(res.leftoverChanges).toHaveLength(0)
     expect(res.deployResult.errors).toHaveLength(1)

--- a/packages/zendesk-adapter/test/filters/business_hours_schedule.test.ts
+++ b/packages/zendesk-adapter/test/filters/business_hours_schedule.test.ts
@@ -79,7 +79,7 @@ describe('business hours schedule filter', () => {
       change: { action: 'add', data: { after: clonedSchedule } },
       client: expect.anything(),
       endpointDetails: expect.anything(),
-      fieldsToIgnore: ['holidays']
+      fieldsToIgnore: ['holidays'],
     })
     expect(mockPut).toHaveBeenCalledTimes(1)
     expect(mockPut).toHaveBeenCalledWith({
@@ -111,7 +111,7 @@ describe('business hours schedule filter', () => {
       change: { action: 'modify', data: { before: clonedBeforeSchedule, after: clonedAfterSchedule } },
       client: expect.anything(),
       endpointDetails: expect.anything(),
-      fieldsToIgnore: ['holidays']
+      fieldsToIgnore: ['holidays'],
     })
     expect(mockPut).toHaveBeenCalledTimes(1)
     expect(mockPut).toHaveBeenCalledWith({
@@ -139,7 +139,7 @@ describe('business hours schedule filter', () => {
       change: { action: 'remove', data: { before: clonedSchedule } },
       client: expect.anything(),
       endpointDetails: expect.anything(),
-      fieldsToIgnore: ['holidays']
+      fieldsToIgnore: ['holidays'],
     })
     expect(mockPut).toHaveBeenCalledTimes(0)
     expect(res.leftoverChanges).toHaveLength(0)
@@ -166,7 +166,7 @@ describe('business hours schedule filter', () => {
       change: { action: 'modify', data: { before: clonedBeforeSchedule, after: clonedAfterSchedule } },
       client: expect.anything(),
       endpointDetails: expect.anything(),
-      fieldsToIgnore: ['holidays']
+      fieldsToIgnore: ['holidays'],
     })
     expect(mockPut).toHaveBeenCalledTimes(0)
     expect(res.leftoverChanges).toHaveLength(0)
@@ -189,7 +189,7 @@ describe('business hours schedule filter', () => {
       change: { action: 'add', data: { after: clonedSchedule } },
       client: expect.anything(),
       endpointDetails: expect.anything(),
-      fieldsToIgnore: ['holidays']
+      fieldsToIgnore: ['holidays'],
     })
     expect(mockPut).toHaveBeenCalledTimes(0)
     expect(res.leftoverChanges).toHaveLength(0)
@@ -208,7 +208,7 @@ describe('business hours schedule filter', () => {
       change: { action: 'add', data: { after: clonedSchedule } },
       client: expect.anything(),
       endpointDetails: expect.anything(),
-      fieldsToIgnore: ['holidays']
+      fieldsToIgnore: ['holidays'],
     })
     expect(mockPut).toHaveBeenCalledTimes(1)
     expect(res.leftoverChanges).toHaveLength(0)

--- a/packages/zendesk-adapter/test/filters/custom_field_options/ticket_field.test.ts
+++ b/packages/zendesk-adapter/test/filters/custom_field_options/ticket_field.test.ts
@@ -258,12 +258,12 @@ describe('ticket field filter', () => {
           }))
         const res = await filter.deploy(clonedElements.map(e => ({ action: 'add', data: { after: e } })))
         expect(mockDeployChange).toHaveBeenCalledTimes(1)
-        expect(mockDeployChange).toHaveBeenCalledWith(
-          { action: 'add', data: { after: clonedElements[0] } },
-          expect.anything(),
-          expect.anything(),
-          [DEFAULT_CUSTOM_FIELD_OPTION_FIELD_NAME],
-        )
+        expect(mockDeployChange).toHaveBeenCalledWith({
+          change: { action: 'add', data: { after: clonedElements[0] } },
+          client: expect.anything(),
+          endpointDetails: expect.anything(),
+          fieldsToIgnore: [DEFAULT_CUSTOM_FIELD_OPTION_FIELD_NAME],
+        })
         expect(res.leftoverChanges).toHaveLength(0)
         expect(res.deployResult.errors).toHaveLength(0)
         const expectedElements = [ticketField, option1, option2].map(e => e.clone())
@@ -294,12 +294,12 @@ describe('ticket field filter', () => {
         const res = await filter.deploy(clonedElements.map((e, index) =>
           ({ action: 'modify', data: { before: e, after: clonedElementsAfter[index] } })))
         expect(mockDeployChange).toHaveBeenCalledTimes(1)
-        expect(mockDeployChange).toHaveBeenCalledWith(
-          { action: 'modify', data: { before: clonedElements[0], after: clonedElementsAfter[0] } },
-          expect.anything(),
-          expect.anything(),
-          [DEFAULT_CUSTOM_FIELD_OPTION_FIELD_NAME],
-        )
+        expect(mockDeployChange).toHaveBeenCalledWith({
+          change: { action: 'modify', data: { before: clonedElements[0], after: clonedElementsAfter[0] } },
+          client: expect.anything(),
+          endpointDetails: expect.anything(),
+          fieldsToIgnore: [DEFAULT_CUSTOM_FIELD_OPTION_FIELD_NAME],
+        })
         expect(res.leftoverChanges).toHaveLength(0)
         expect(res.deployResult.errors).toHaveLength(0)
         expect(res.deployResult.appliedChanges).toHaveLength(3)
@@ -319,12 +319,12 @@ describe('ticket field filter', () => {
         const res = await filter.deploy(clonedElements.map(e =>
           ({ action: 'remove', data: { before: e } })))
         expect(mockDeployChange).toHaveBeenCalledTimes(1)
-        expect(mockDeployChange).toHaveBeenCalledWith(
-          { action: 'remove', data: { before: clonedElements[0] } },
-          expect.anything(),
-          expect.anything(),
-          [DEFAULT_CUSTOM_FIELD_OPTION_FIELD_NAME],
-        )
+        expect(mockDeployChange).toHaveBeenCalledWith({
+          change: { action: 'remove', data: { before: clonedElements[0] } },
+          client: expect.anything(),
+          endpointDetails: expect.anything(),
+          fieldsToIgnore: [DEFAULT_CUSTOM_FIELD_OPTION_FIELD_NAME],
+        })
         expect(res.leftoverChanges).toHaveLength(0)
         expect(res.deployResult.errors).toHaveLength(0)
         expect(res.deployResult.appliedChanges).toHaveLength(3)
@@ -339,12 +339,12 @@ describe('ticket field filter', () => {
         })
         const res = await filter.deploy([{ action: 'add', data: { after: clonedTicketField } }])
         expect(mockDeployChange).toHaveBeenCalledTimes(1)
-        expect(mockDeployChange).toHaveBeenCalledWith(
-          { action: 'add', data: { after: clonedTicketField } },
-          expect.anything(),
-          expect.anything(),
-          [DEFAULT_CUSTOM_FIELD_OPTION_FIELD_NAME],
-        )
+        expect(mockDeployChange).toHaveBeenCalledWith({
+          change: { action: 'add', data: { after: clonedTicketField } },
+          client: expect.anything(),
+          endpointDetails: expect.anything(),
+          fieldsToIgnore: [DEFAULT_CUSTOM_FIELD_OPTION_FIELD_NAME],
+        })
         expect(res.leftoverChanges).toHaveLength(0)
         expect(res.deployResult.errors).toHaveLength(1)
         expect(res.deployResult.appliedChanges).toHaveLength(0)
@@ -357,12 +357,12 @@ describe('ticket field filter', () => {
           }))
         const res = await filter.deploy(clonedElements.map(e => ({ action: 'add', data: { after: e } })))
         expect(mockDeployChange).toHaveBeenCalledTimes(1)
-        expect(mockDeployChange).toHaveBeenCalledWith(
-          { action: 'add', data: { after: clonedElements[0] } },
-          expect.anything(),
-          expect.anything(),
-          [DEFAULT_CUSTOM_FIELD_OPTION_FIELD_NAME],
-        )
+        expect(mockDeployChange).toHaveBeenCalledWith({
+          change: { action: 'add', data: { after: clonedElements[0] } },
+          client: expect.anything(),
+          endpointDetails: expect.anything(),
+          fieldsToIgnore: [DEFAULT_CUSTOM_FIELD_OPTION_FIELD_NAME],
+        })
         expect(res.leftoverChanges).toHaveLength(0)
         expect(res.deployResult.errors).toHaveLength(0)
         const expectedElements = [ticketField, option1, option2].map(e => e.clone())
@@ -381,12 +381,12 @@ describe('ticket field filter', () => {
           { action: 'add', data: { after: clonedTicketField } },
         ])
         expect(mockDeployChange).toHaveBeenCalledTimes(1)
-        expect(mockDeployChange).toHaveBeenCalledWith(
-          { action: 'add', data: { after: clonedTicketField } },
-          expect.anything(),
-          expect.anything(),
-          [DEFAULT_CUSTOM_FIELD_OPTION_FIELD_NAME],
-        )
+        expect(mockDeployChange).toHaveBeenCalledWith({
+          change: { action: 'add', data: { after: clonedTicketField } },
+          client: expect.anything(),
+          endpointDetails: expect.anything(),
+          fieldsToIgnore: [DEFAULT_CUSTOM_FIELD_OPTION_FIELD_NAME],
+        })
         expect(res.leftoverChanges).toHaveLength(0)
         expect(res.deployResult.errors).toHaveLength(0)
         const expectedTicketField = ticketField.clone()
@@ -410,12 +410,12 @@ describe('ticket field filter', () => {
           { action: 'modify', data: { before: clonedChildBefore, after: clonedChildAfter } },
         ])
         expect(mockDeployChange).toHaveBeenCalledTimes(1)
-        expect(mockDeployChange).toHaveBeenCalledWith(
-          { action: 'modify', data: { before: clonedChildBefore, after: clonedChildAfter } },
-          expect.anything(),
-          expect.anything(),
-          undefined,
-        )
+        expect(mockDeployChange).toHaveBeenCalledWith({
+          change: { action: 'modify', data: { before: clonedChildBefore, after: clonedChildAfter } },
+          client: expect.anything(),
+          endpointDetails: expect.anything(),
+          fieldsToIgnore: undefined,
+        })
         expect(res.leftoverChanges).toHaveLength(0)
         expect(res.deployResult.errors).toHaveLength(0)
         expect(res.deployResult.appliedChanges).toHaveLength(1)

--- a/packages/zendesk-adapter/test/filters/dynamic_content.test.ts
+++ b/packages/zendesk-adapter/test/filters/dynamic_content.test.ts
@@ -295,10 +295,12 @@ describe('dynmaic content filter', () => {
       beforeElements.forEach((e, i) => {
         expect(mockDeployChange).toHaveBeenNthCalledWith(
           i + 1,
-          { action: 'modify', data: { before: e, after: afterElements[i] } },
-          expect.anything(),
-          expect.anything(),
-          undefined,
+          {
+            change: { action: 'modify', data: { before: e, after: afterElements[i] } },
+            client: expect.anything(),
+            endpointDetails: expect.anything(),
+            fieldsToOmit: undefined,
+          },
         )
       })
       expect(res.leftoverChanges).toHaveLength(0)

--- a/packages/zendesk-adapter/test/filters/dynamic_content.test.ts
+++ b/packages/zendesk-adapter/test/filters/dynamic_content.test.ts
@@ -240,12 +240,12 @@ describe('dynmaic content filter', () => {
         }))
       const res = await filter.deploy(clonedElements.map(e => ({ action: 'add', data: { after: e } })))
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'add', data: { after: clonedElements[0] } },
-        expect.anything(),
-        expect.anything(),
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'add', data: { after: clonedElements[0] } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
         undefined,
-      )
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
       const expectedElements = [resolvedParent, child1Resolved, child2Resolved].map(e => e.clone())
@@ -264,12 +264,12 @@ describe('dynmaic content filter', () => {
       mockDeployChange.mockImplementation(async () => ({}))
       const res = await filter.deploy(clonedElements.map(e => ({ action: 'remove', data: { before: e } })))
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'remove', data: { before: clonedElements[0] } },
-        expect.anything(),
-        expect.anything(),
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'remove', data: { before: clonedElements[0] } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
         undefined,
-      )
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
       expect(res.deployResult.appliedChanges).toHaveLength(3)
@@ -315,12 +315,12 @@ describe('dynmaic content filter', () => {
       })
       const res = await filter.deploy([{ action: 'add', data: { after: clonedResolvedParent } }])
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'add', data: { after: clonedResolvedParent } },
-        expect.anything(),
-        expect.anything(),
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'add', data: { after: clonedResolvedParent } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
         undefined,
-      )
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(1)
       expect(res.deployResult.appliedChanges).toHaveLength(0)

--- a/packages/zendesk-adapter/test/filters/macro_attachments.test.ts
+++ b/packages/zendesk-adapter/test/filters/macro_attachments.test.ts
@@ -314,12 +314,12 @@ describe('macro attachment filter', () => {
       resolvedClonedMacro.value[ATTACHMENTS_FIELD_NAME] = [attachmentId]
       // It's actually not deployed with id but its added to the element that we check
       resolvedClonedMacro.value.id = macroId
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'add', data: { after: resolvedClonedMacro } },
-        expect.anything(),
-        expect.anything(),
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'add', data: { after: resolvedClonedMacro } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
         undefined
-      )
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
       expect(res.deployResult.appliedChanges).toHaveLength(2)
@@ -381,12 +381,12 @@ describe('macro attachment filter', () => {
       const resolvedClonedAfterMacro = clonedAfterMacro.clone()
       resolvedClonedBeforeMacro.value[ATTACHMENTS_FIELD_NAME] = [attachmentId]
       resolvedClonedAfterMacro.value[ATTACHMENTS_FIELD_NAME] = [newAttachmentId]
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'modify', data: { before: resolvedClonedBeforeMacro, after: resolvedClonedAfterMacro } },
-        expect.anything(),
-        expect.anything(),
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'modify', data: { before: resolvedClonedBeforeMacro, after: resolvedClonedAfterMacro } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
         undefined
-      )
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
       expect(res.deployResult.appliedChanges).toHaveLength(2)
@@ -453,12 +453,12 @@ describe('macro attachment filter', () => {
       const resolvedClonedAfterMacro = clonedMacro.clone()
       resolvedClonedBeforeMacro.value[ATTACHMENTS_FIELD_NAME] = [attachmentId]
       resolvedClonedAfterMacro.value[ATTACHMENTS_FIELD_NAME] = [newAttachmentId]
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'modify', data: { before: resolvedClonedBeforeMacro, after: resolvedClonedAfterMacro } },
-        expect.anything(),
-        expect.anything(),
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'modify', data: { before: resolvedClonedBeforeMacro, after: resolvedClonedAfterMacro } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
         undefined
-      )
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
       expect(res.deployResult.appliedChanges).toHaveLength(1)
@@ -501,12 +501,12 @@ describe('macro attachment filter', () => {
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
       const resolvedClonedMacro = clonedMacro.clone()
       resolvedClonedMacro.value[ATTACHMENTS_FIELD_NAME] = [attachmentId]
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'remove', data: { before: resolvedClonedMacro } },
-        expect.anything(),
-        expect.anything(),
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'remove', data: { before: resolvedClonedMacro } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
         undefined
-      )
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
       expect(res.deployResult.appliedChanges).toHaveLength(2)

--- a/packages/zendesk-adapter/test/filters/macro_attachments.test.ts
+++ b/packages/zendesk-adapter/test/filters/macro_attachments.test.ts
@@ -318,7 +318,7 @@ describe('macro attachment filter', () => {
         change: { action: 'add', data: { after: resolvedClonedMacro } },
         client: expect.anything(),
         endpointDetails: expect.anything(),
-        undefined
+        undefined,
       })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
@@ -385,7 +385,7 @@ describe('macro attachment filter', () => {
         change: { action: 'modify', data: { before: resolvedClonedBeforeMacro, after: resolvedClonedAfterMacro } },
         client: expect.anything(),
         endpointDetails: expect.anything(),
-        undefined
+        undefined,
       })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
@@ -457,7 +457,7 @@ describe('macro attachment filter', () => {
         change: { action: 'modify', data: { before: resolvedClonedBeforeMacro, after: resolvedClonedAfterMacro } },
         client: expect.anything(),
         endpointDetails: expect.anything(),
-        undefined
+        undefined,
       })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
@@ -505,7 +505,7 @@ describe('macro attachment filter', () => {
         change: { action: 'remove', data: { before: resolvedClonedMacro } },
         client: expect.anything(),
         endpointDetails: expect.anything(),
-        undefined
+        undefined,
       })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)

--- a/packages/zendesk-adapter/test/filters/organization_field.test.ts
+++ b/packages/zendesk-adapter/test/filters/organization_field.test.ts
@@ -105,12 +105,12 @@ describe('organization field filter', () => {
       const changes = clonedElements.map(e => toChange({ after: e }))
       const res = await filter.deploy(changes)
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'add', data: { after: clonedElements[0] } },
-        expect.anything(),
-        expect.anything(),
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'add', data: { after: clonedElements[0] } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
         undefined,
-      )
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
       const expectedElements = [resolvedParent, child1Resolved, child2Resolved].map(e => e.clone())
@@ -129,12 +129,12 @@ describe('organization field filter', () => {
       mockDeployChange.mockImplementation(async () => ({}))
       const res = await filter.deploy(clonedElements.map(e => ({ action: 'remove', data: { before: e } })))
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'remove', data: { before: clonedElements[0] } },
-        expect.anything(),
-        expect.anything(),
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'remove', data: { before: clonedElements[0] } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
         undefined,
-      )
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
       expect(res.deployResult.appliedChanges).toHaveLength(3)
@@ -157,12 +157,12 @@ describe('organization field filter', () => {
         action: 'modify', data: { before: e, after: afterElements[i] },
       })))
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'modify', data: { before: beforeElements[0], after: afterElements[0] } },
-        expect.anything(),
-        expect.anything(),
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'modify', data: { before: beforeElements[0], after: afterElements[0] } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
         undefined,
-      )
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
       expect(res.deployResult.appliedChanges).toHaveLength(3)
@@ -193,12 +193,12 @@ describe('organization field filter', () => {
         action: 'modify', data: { before: e, after: afterElements[i] },
       })))
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'modify', data: { before: clonedResolvedParent, after: clonedResolvedParent } },
-        expect.anything(),
-        expect.anything(),
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'modify', data: { before: clonedResolvedParent, after: clonedResolvedParent } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
         undefined,
-      )
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
       expect(res.deployResult.appliedChanges).toHaveLength(2)
@@ -213,12 +213,12 @@ describe('organization field filter', () => {
       })
       const res = await filter.deploy([{ action: 'add', data: { after: clonedResolvedParent } }])
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'add', data: { after: clonedResolvedParent } },
-        expect.anything(),
-        expect.anything(),
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'add', data: { after: clonedResolvedParent } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
         undefined,
-      )
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(1)
       expect(res.deployResult.appliedChanges).toHaveLength(0)

--- a/packages/zendesk-adapter/test/filters/remove_brand_logo_field.test.ts
+++ b/packages/zendesk-adapter/test/filters/remove_brand_logo_field.test.ts
@@ -86,12 +86,12 @@ describe('remove brand logo field filter', () => {
     mockDeployChange.mockImplementation(async () => ({ brand: { brandId } }))
     const res = await filter.deploy([{ action: 'add', data: { after: clonedBrand } }])
     expect(mockDeployChange).toHaveBeenCalledTimes(1)
-    expect(mockDeployChange).toHaveBeenCalledWith(
-      { action: 'add', data: { after: clonedBrand } },
-      expect.anything(),
-      expect.anything(),
-      [LOGO_FIELD]
-    )
+    expect(mockDeployChange).toHaveBeenCalledWith({
+      change: { action: 'add', data: { after: clonedBrand } },
+      client: expect.anything(),
+      endpointDetails: expect.anything(),
+      fieldsToIgnore: [LOGO_FIELD],
+    })
     expect(res.leftoverChanges).toHaveLength(0)
     expect(res.deployResult.errors).toHaveLength(0)
     expect(res.deployResult.appliedChanges).toHaveLength(1)
@@ -110,12 +110,12 @@ describe('remove brand logo field filter', () => {
       [{ action: 'modify', data: { before: clonedBeforeBrand, after: clonedAfterBrand } }]
     )
     expect(mockDeployChange).toHaveBeenCalledTimes(1)
-    expect(mockDeployChange).toHaveBeenCalledWith(
-      { action: 'modify', data: { before: clonedBeforeBrand, after: clonedAfterBrand } },
-      expect.anything(),
-      expect.anything(),
-      [LOGO_FIELD]
-    )
+    expect(mockDeployChange).toHaveBeenCalledWith({
+      change: { action: 'modify', data: { before: clonedBeforeBrand, after: clonedAfterBrand } },
+      client: expect.anything(),
+      endpointDetails: expect.anything(),
+      fieldsToIgnore: [LOGO_FIELD],
+    })
     expect(res.leftoverChanges).toHaveLength(0)
     expect(res.deployResult.errors).toHaveLength(0)
     expect(res.deployResult.appliedChanges).toHaveLength(1)
@@ -130,12 +130,12 @@ describe('remove brand logo field filter', () => {
     mockDeployChange.mockImplementation(async () => ({ brand: { brandId } }))
     const res = await filter.deploy([{ action: 'remove', data: { before: clonedBrand } }])
     expect(mockDeployChange).toHaveBeenCalledTimes(1)
-    expect(mockDeployChange).toHaveBeenCalledWith(
-      { action: 'remove', data: { before: clonedBrand } },
-      expect.anything(),
-      expect.anything(),
-      [LOGO_FIELD]
-    )
+    expect(mockDeployChange).toHaveBeenCalledWith({
+      change: { action: 'remove', data: { before: clonedBrand } },
+      client: expect.anything(),
+      endpointDetails: expect.anything(),
+      fieldsToIgnore: [LOGO_FIELD],
+    })
     expect(res.leftoverChanges).toHaveLength(0)
     expect(res.deployResult.errors).toHaveLength(0)
     expect(res.deployResult.appliedChanges).toHaveLength(1)
@@ -147,12 +147,12 @@ describe('remove brand logo field filter', () => {
     mockDeployChange.mockImplementation(async () => { throw new Error('err') })
     const res = await filter.deploy([{ action: 'add', data: { after: clonedBrand } }])
     expect(mockDeployChange).toHaveBeenCalledTimes(1)
-    expect(mockDeployChange).toHaveBeenCalledWith(
-      { action: 'add', data: { after: clonedBrand } },
-      expect.anything(),
-      expect.anything(),
-      [LOGO_FIELD]
-    )
+    expect(mockDeployChange).toHaveBeenCalledWith({
+      change: { action: 'add', data: { after: clonedBrand } },
+      client: expect.anything(),
+      endpointDetails: expect.anything(),
+      fieldsToIgnore: [LOGO_FIELD],
+    })
     expect(res.leftoverChanges).toHaveLength(0)
     expect(res.deployResult.errors).toHaveLength(1)
     expect(res.deployResult.appliedChanges).toHaveLength(0)

--- a/packages/zendesk-adapter/test/filters/reorder/automation.test.ts
+++ b/packages/zendesk-adapter/test/filters/reorder/automation.test.ts
@@ -131,18 +131,18 @@ describe('automation reorder filter', () => {
           { id: 11, position: 3 },
         ],
       }
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        {
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: {
           action: 'modify',
           data: {
             after: instanceToDeploy,
             before,
           },
         },
-        expect.anything(),
-        expect.anything(),
-        undefined,
-      )
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        fieldsToIgnore: undefined,
+      })
     })
     it('should return an error if there are multiple order changes', async () => {
       const res = await filter.deploy([change, change])

--- a/packages/zendesk-adapter/test/filters/reorder/ticket_form.test.ts
+++ b/packages/zendesk-adapter/test/filters/reorder/ticket_form.test.ts
@@ -119,12 +119,12 @@ describe('ticket form reorder filter', () => {
       expect(res.deployResult.errors).toHaveLength(0)
       expect(res.deployResult.appliedChanges).toEqual([change])
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
+      expect(mockDeployChange).toHaveBeenCalledWith({
         change,
-        expect.anything(),
-        expect.anything(),
-        undefined,
-      )
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        fieldsToIgnore: undefined,
+      })
     })
     it('should return an error if there are multiple order changes', async () => {
       const res = await filter.deploy([change, change])

--- a/packages/zendesk-adapter/test/filters/reorder/trigger.test.ts
+++ b/packages/zendesk-adapter/test/filters/reorder/trigger.test.ts
@@ -196,18 +196,18 @@ describe('trigger reorder filter', () => {
           ],
         },
       }
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        {
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: {
           action: 'modify',
           data: {
             after: instanceToDeploy,
             before,
           },
         },
-        expect.anything(),
-        expect.anything(),
-        undefined,
-      )
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        fieldsToIgnore: undefined,
+      })
     })
     it('should return an error if there are multiple order changes', async () => {
       const res = await filter.deploy([change, change])

--- a/packages/zendesk-adapter/test/filters/reorder/view.test.ts
+++ b/packages/zendesk-adapter/test/filters/reorder/view.test.ts
@@ -132,18 +132,18 @@ describe('view reorder filter', () => {
           { id: 11, position: 3 },
         ],
       }
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        {
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: {
           action: 'modify',
           data: {
             after: instanceToDeploy,
             before,
           },
         },
-        expect.anything(),
-        expect.anything(),
-        undefined,
-      )
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        fieldsToIgnore: undefined,
+      })
     })
     it('should return an error if there are multiple order changes', async () => {
       const res = await filter.deploy([change, change])

--- a/packages/zendesk-adapter/test/filters/routing_attribute.test.ts
+++ b/packages/zendesk-adapter/test/filters/routing_attribute.test.ts
@@ -68,12 +68,12 @@ describe('routing attribute filter', () => {
       mockDeployChange.mockImplementation(async () => ({ attribute: { id } }))
       const res = await filter.deploy([{ action: 'add', data: { after: clonedAttribute } }])
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'add', data: { after: clonedAttribute } },
-        expect.anything(),
-        expect.anything(),
-        ['values'],
-      )
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'add', data: { after: clonedAttribute } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        fieldsToIgnore: ['values'],
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
       expect(res.deployResult.appliedChanges).toHaveLength(1)
@@ -92,12 +92,12 @@ describe('routing attribute filter', () => {
       const res = await filter
         .deploy([{ action: 'modify', data: { before: clonedAttributeBefore, after: clonedAttributeAfter } }])
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'modify', data: { before: clonedAttributeBefore, after: clonedAttributeAfter } },
-        expect.anything(),
-        expect.anything(),
-        ['values']
-      )
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'modify', data: { before: clonedAttributeBefore, after: clonedAttributeAfter } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        fieldsToIgnore: ['values'],
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
       expect(res.deployResult.appliedChanges).toHaveLength(1)
@@ -129,12 +129,12 @@ describe('routing attribute filter', () => {
       })
       const res = await filter.deploy([{ action: 'add', data: { after: clonedAttribute } }])
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'add', data: { after: clonedAttribute } },
-        expect.anything(),
-        expect.anything(),
-        ['values'],
-      )
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'add', data: { after: clonedAttribute } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        fieldsToIgnore: ['values'],
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(1)
       expect(res.deployResult.appliedChanges).toHaveLength(0)

--- a/packages/zendesk-adapter/test/filters/sla_policy.test.ts
+++ b/packages/zendesk-adapter/test/filters/sla_policy.test.ts
@@ -109,12 +109,12 @@ describe('sla policy filter', () => {
       mockDeployChange.mockImplementation(async () => ({ sla_policy: { id } }))
       const res = await filter.deploy([{ action: 'add', data: { after: clonedSlaPolicy } }])
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'add', data: { after: clonedSlaPolicyToDeploy } },
-        expect.anything(),
-        expect.anything(),
-        undefined,
-      )
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'add', data: { after: clonedSlaPolicyToDeploy } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        fieldsToIgnore: undefined,
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
       expect(res.deployResult.appliedChanges).toHaveLength(1)
@@ -128,12 +128,12 @@ describe('sla policy filter', () => {
       mockDeployChange.mockImplementation(async () => ({ sla_policy: { id } }))
       const res = await filter.deploy([{ action: 'add', data: { after: clonedSlaPolicy } }])
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'add', data: { after: clonedSlaPolicy } },
-        expect.anything(),
-        expect.anything(),
-        undefined,
-      )
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'add', data: { after: clonedSlaPolicy } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        fieldsToIgnore: undefined,
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
       expect(res.deployResult.appliedChanges).toHaveLength(1)
@@ -154,12 +154,12 @@ describe('sla policy filter', () => {
       const res = await filter
         .deploy([{ action: 'modify', data: { before: clonedSlaPolicyBefore, after: clonedSlaPolicyAfter } }])
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'modify', data: { before: clonedSlaPolicyBefore, after: clonedSlaPolicyToDeploy } },
-        expect.anything(),
-        expect.anything(),
-        undefined
-      )
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'modify', data: { before: clonedSlaPolicyBefore, after: clonedSlaPolicyToDeploy } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        fieldsToIgnore: undefined,
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
       expect(res.deployResult.appliedChanges).toHaveLength(1)
@@ -183,12 +183,12 @@ describe('sla policy filter', () => {
       const res = await filter
         .deploy([{ action: 'modify', data: { before: clonedSlaPolicyBefore, after: clonedSlaPolicyAfter } }])
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'modify', data: { before: clonedSlaPolicyBefore, after: clonedSlaPolicyAfter } },
-        expect.anything(),
-        expect.anything(),
-        undefined
-      )
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'modify', data: { before: clonedSlaPolicyBefore, after: clonedSlaPolicyAfter } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        fieldsToIgnore: undefined,
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
       expect(res.deployResult.appliedChanges).toHaveLength(1)
@@ -220,12 +220,12 @@ describe('sla policy filter', () => {
       })
       const res = await filter.deploy([{ action: 'add', data: { after: clonedSlaPolicy } }])
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'add', data: { after: clonedSlaPolicy } },
-        expect.anything(),
-        expect.anything(),
-        undefined,
-      )
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'add', data: { after: clonedSlaPolicy } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        fieldsToIgnore: undefined,
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(1)
       expect(res.deployResult.appliedChanges).toHaveLength(0)

--- a/packages/zendesk-adapter/test/filters/target.test.ts
+++ b/packages/zendesk-adapter/test/filters/target.test.ts
@@ -76,12 +76,12 @@ describe('target filter', () => {
       mockDeployChange.mockImplementation(async () => ({ target: { id } }))
       const res = await filter.deploy([{ action: 'add', data: { after: clonedTarget } }])
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'add', data: { after: deployedTarget } },
-        expect.anything(),
-        expect.anything(),
-        undefined,
-      )
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'add', data: { after: deployedTarget } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        fieldsToIgnore: undefined,
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
       expect(res.deployResult.appliedChanges).toHaveLength(1)
@@ -104,12 +104,12 @@ describe('target filter', () => {
       const res = await filter
         .deploy([{ action: 'modify', data: { before: clonedTargetBefore, after: clonedTargetAfter } }])
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'modify', data: { before: clonedTargetBefore, after: deployedTargetAfter } },
-        expect.anything(),
-        expect.anything(),
-        undefined,
-      )
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'modify', data: { before: clonedTargetBefore, after: deployedTargetAfter } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        fieldsToIgnore: undefined,
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
       expect(res.deployResult.appliedChanges).toHaveLength(1)
@@ -135,12 +135,12 @@ describe('target filter', () => {
       const res = await filter
         .deploy([{ action: 'modify', data: { before: clonedTargetBefore, after: clonedTargetAfter } }])
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'modify', data: { before: clonedTargetBefore, after: deployedTargetAfter } },
-        expect.anything(),
-        expect.anything(),
-        undefined,
-      )
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'modify', data: { before: clonedTargetBefore, after: deployedTargetAfter } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        fieldsToIgnore: undefined,
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
       expect(res.deployResult.appliedChanges).toHaveLength(1)
@@ -168,12 +168,12 @@ describe('target filter', () => {
       const res = await filter
         .deploy([{ action: 'modify', data: { before: clonedTargetBefore, after: deployedTargetAfter } }])
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'modify', data: { before: clonedTargetBefore, after: deployedTargetAfter } },
-        expect.anything(),
-        expect.anything(),
-        undefined,
-      )
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'modify', data: { before: clonedTargetBefore, after: deployedTargetAfter } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        fieldsToIgnore: undefined,
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
       expect(res.deployResult.appliedChanges).toHaveLength(1)
@@ -208,12 +208,12 @@ describe('target filter', () => {
       delete deployedTarget.value.password
       const res = await filter.deploy([{ action: 'add', data: { after: clonedTarget } }])
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'add', data: { after: deployedTarget } },
-        expect.anything(),
-        expect.anything(),
-        undefined,
-      )
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'add', data: { after: deployedTarget } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        fieldsToIgnore: undefined,
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(1)
       expect(res.deployResult.appliedChanges).toHaveLength(0)

--- a/packages/zendesk-adapter/test/filters/view.test.ts
+++ b/packages/zendesk-adapter/test/filters/view.test.ts
@@ -223,12 +223,12 @@ describe('views filter', () => {
       mockDeployChange.mockImplementation(async () => ({ view: { id } }))
       const res = await filter.deploy([{ action: 'add', data: { after: clonedView } }])
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'add', data: { after: clonedView } },
-        expect.anything(),
-        expect.anything(),
-        ['conditions', 'execution'],
-      )
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'add', data: { after: clonedView } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        fieldsToIgnore: ['conditions', 'execution'],
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
       expect(res.deployResult.appliedChanges).toHaveLength(1)
@@ -247,12 +247,12 @@ describe('views filter', () => {
       const res = await filter
         .deploy([{ action: 'modify', data: { before: clonedViewBefore, after: clonedViewAfter } }])
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'modify', data: { before: clonedViewBefore, after: clonedViewAfter } },
-        expect.anything(),
-        expect.anything(),
-        ['conditions', 'execution'],
-      )
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'modify', data: { before: clonedViewBefore, after: clonedViewAfter } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        fieldsToIgnore: ['conditions', 'execution'],
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
       expect(res.deployResult.appliedChanges).toHaveLength(1)
@@ -283,12 +283,12 @@ describe('views filter', () => {
       })
       const res = await filter.deploy([{ action: 'add', data: { after: view } }])
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'add', data: { after: view } },
-        expect.anything(),
-        expect.anything(),
-        ['conditions', 'execution'],
-      )
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'add', data: { after: view } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        fieldsToIgnore: ['conditions', 'execution'],
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(1)
       expect(res.deployResult.appliedChanges).toHaveLength(0)

--- a/packages/zendesk-adapter/test/filters/webhook.test.ts
+++ b/packages/zendesk-adapter/test/filters/webhook.test.ts
@@ -83,12 +83,12 @@ describe('webhook filter', () => {
       mockDeployChange.mockImplementation(async () => ({ webhook: { id } }))
       const res = await filter.deploy([{ action: 'add', data: { after: clonedWebhook } }])
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'add', data: { after: deployedWebhook } },
-        expect.anything(),
-        expect.anything(),
-        undefined,
-      )
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'add', data: { after: deployedWebhook } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        fieldsToIgnore: undefined,
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
       expect(res.deployResult.appliedChanges).toHaveLength(1)
@@ -104,12 +104,12 @@ describe('webhook filter', () => {
       mockDeployChange.mockImplementation(async () => ({ webhook: { id } }))
       const res = await filter.deploy([{ action: 'add', data: { after: clonedWebhook } }])
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'add', data: { after: deployedWebhook } },
-        expect.anything(),
-        expect.anything(),
-        undefined,
-      )
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'add', data: { after: deployedWebhook } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        fieldsToIgnore: undefined,
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
       expect(res.deployResult.appliedChanges).toHaveLength(1)
@@ -132,12 +132,12 @@ describe('webhook filter', () => {
       const res = await filter
         .deploy([{ action: 'modify', data: { before: clonedWebhookBefore, after: clonedWebhookAfter } }])
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'modify', data: { before: clonedWebhookBefore, after: deployedWebhookAfter } },
-        expect.anything(),
-        expect.anything(),
-        undefined,
-      )
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'modify', data: { before: clonedWebhookBefore, after: deployedWebhookAfter } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        fieldsToIgnore: undefined,
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
       expect(res.deployResult.appliedChanges).toHaveLength(1)
@@ -162,12 +162,12 @@ describe('webhook filter', () => {
       const res = await filter
         .deploy([{ action: 'modify', data: { before: clonedWebhookBefore, after: clonedWebhookAfter } }])
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'modify', data: { before: clonedWebhookBefore, after: deployedWebhookAfter } },
-        expect.anything(),
-        expect.anything(),
-        undefined,
-      )
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'modify', data: { before: clonedWebhookBefore, after: deployedWebhookAfter } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        fieldsToIgnore: undefined,
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
       expect(res.deployResult.appliedChanges).toHaveLength(1)
@@ -193,12 +193,12 @@ describe('webhook filter', () => {
       const res = await filter
         .deploy([{ action: 'modify', data: { before: clonedWebhookBefore, after: deployedWebhookAfter } }])
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'modify', data: { before: clonedWebhookBefore, after: deployedWebhookAfter } },
-        expect.anything(),
-        expect.anything(),
-        undefined,
-      )
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'modify', data: { before: clonedWebhookBefore, after: deployedWebhookAfter } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        fieldsToIgnore: undefined,
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
       expect(res.deployResult.appliedChanges).toHaveLength(1)
@@ -234,12 +234,12 @@ describe('webhook filter', () => {
       ]
       const res = await filter.deploy([{ action: 'add', data: { after: clonedWebhook } }])
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'add', data: { after: deployedWebhook } },
-        expect.anything(),
-        expect.anything(),
-        undefined,
-      )
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'add', data: { after: deployedWebhook } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        fieldsToIgnore: undefined,
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(1)
       expect(res.deployResult.appliedChanges).toHaveLength(0)

--- a/packages/zendesk-adapter/test/filters/workspace.test.ts
+++ b/packages/zendesk-adapter/test/filters/workspace.test.ts
@@ -134,12 +134,12 @@ describe('workspace filter', () => {
       mockDeployChange.mockImplementation(async () => ({ workspace: { id } }))
       const res = await filter.deploy([{ action: 'add', data: { after: workspace } }])
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'add', data: { after: workspace } },
-        expect.anything(),
-        expect.anything(),
-        ['selected_macros'],
-      )
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'add', data: { after: workspace } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        fieldsToIgnore: ['selected_macros'],
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
       expect(res.deployResult.appliedChanges).toHaveLength(1)
@@ -158,12 +158,12 @@ describe('workspace filter', () => {
       const res = await filter
         .deploy([{ action: 'modify', data: { before: clonedWSBefore, after: clonedWSAfter } }])
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'modify', data: { before: clonedWSBefore, after: clonedWSAfter } },
-        expect.anything(),
-        expect.anything(),
-        ['selected_macros']
-      )
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'modify', data: { before: clonedWSBefore, after: clonedWSAfter } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        fieldsToIgnore: ['selected_macros'],
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
       expect(res.deployResult.appliedChanges).toHaveLength(1)
@@ -194,12 +194,12 @@ describe('workspace filter', () => {
       })
       const res = await filter.deploy([{ action: 'add', data: { after: workspace } }])
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith(
-        { action: 'add', data: { after: workspace } },
-        expect.anything(),
-        expect.anything(),
-        ['selected_macros'],
-      )
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'add', data: { after: workspace } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        fieldsToIgnore: ['selected_macros'],
+      })
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(1)
       expect(res.deployResult.appliedChanges).toHaveLength(0)


### PR DESCRIPTION
Change `deployChange` params in adapter-components to receive object instead of parameters

---

_Additional context for reviewer_


---

