### PR TITLE
SALTO-2667: Fixed plan comparison for template expressions

### DIFF
--- a/packages/core/src/core/plan/plan.ts
+++ b/packages/core/src/core/plan/plan.ts
@@ -174,7 +174,6 @@ const compareValuesAndLazyResolveRefs = async (
     // code generator, but its here in order for the method to "fail fast" as some
     // can stop when the first non equal values are encountered.
     return !(await awu(first).some(
-      // eslint-disable-next-line no-use-before-define
       async (value, index) => !await compareValuesAndLazyResolveRefs(
         value,
         second[index],


### PR DESCRIPTION
Fixed plan comparison for template expressions

---

When comparing template expression in `compareValuesAndLazyResolveRefs` no condition would match template expressions so it would go to the default comparison of `_.isEqual` [here](https://github.com/salto-io/salto/blob/main/packages/core/src/core/plan/plan.ts#L152)
Besides being inefficient, the templates are not resolved at that point so it always compares `undefined` to `undefined` when looking at the value

---
_Release Notes_: 
None (not sure if this has an effect on the user since until now we didn't have inner references inside templates)

---
_User Notifications_: 
None