### PR TITLE
SALTO-2687: Fixed jql-ast dependency

### DIFF
--- a/packages/jira-adapter/package.json
+++ b/packages/jira-adapter/package.json
@@ -67,5 +67,8 @@
     "ts-jest": "^27.1.2",
     "tsc-watch": "^2.2.1",
     "typescript": "3.9.3"
+  },
+  "resolutions": {
+    "antlr4ts": "0.5.0-alpha.4"
   }
 }


### PR DESCRIPTION
There is a problem in the SaaS with the new jql-ast library dependency ([see](https://app.circleci.com/pipelines/github/salto-io/salto_private/28759/workflows/acdb5c17-636c-4346-bc06-9cc0e5c2b341/jobs/663467)). Looks like it installs a different version of `antlr4ts`, a dependency of `jql-ast`, in the saas which `jql-ast` does not seem to work with.
It seems related to the difference in the yarn version between the two. The resolutions config solves this issue.

This issue can happen with any project that uses yarn2 and has the OSS as its dependency, and therefore the fix is in the OSS

---
_Release Notes_: 
None

---
_User Notifications_: 
None