### PR TITLE
Revert "SALTO-2687: Fixed jql-ast dependency"

### DIFF
--- a/packages/jira-adapter/package.json
+++ b/packages/jira-adapter/package.json
@@ -67,8 +67,5 @@
     "ts-jest": "^27.1.2",
     "tsc-watch": "^2.2.1",
     "typescript": "3.9.3"
-  },
-  "resolutions": {
-    "antlr4ts": "0.5.0-alpha.4"
   }
 }


### PR DESCRIPTION
Reverts salto-io/salto#3365

It looks like the `resolutions` config does not have an effect on the SaaS, added this config in the SaaS package.json instead

---
_Release Notes_: 
None

---
_User Notifications_: 
None