### PR TITLE
SALTO-2466: create broken references in template expression

### DIFF
--- a/packages/zendesk-adapter/src/filters/dynamic_content_references.ts
+++ b/packages/zendesk-adapter/src/filters/dynamic_content_references.ts
@@ -31,6 +31,8 @@ import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { FilterCreator } from '../filter'
 import { DYNAMIC_CONTENT_ITEM_TYPE_NAME } from './dynamic_content'
+import { createMissingInstance } from './references/missing_references'
+import { ZENDESK } from '../constants'
 
 const { awu } = collections.asynciterable
 const PLACEHOLDER_REGEX = /({{.+?}})/g
@@ -50,7 +52,19 @@ const transformDynamicContentDependencies = async (
     }
     const itemInstance = placeholderToItem[placeholder[0]]
     if (!itemInstance) {
-      return [part]
+      const matches = placeholder[0].match(/.*\.(.*)\}\}/)
+      if (!matches) {
+        return [part]
+      }
+      const missingInstance = createMissingInstance(
+        ZENDESK,
+        DYNAMIC_CONTENT_ITEM_TYPE_NAME,
+        matches[1]
+      )
+      return [
+        OPEN_BRACKETS,
+        new ReferenceExpression(missingInstance.elemID, missingInstance),
+        CLOSE_BRACKETS]
     }
     return [
       OPEN_BRACKETS,

--- a/packages/zendesk-adapter/src/filters/dynamic_content_references.ts
+++ b/packages/zendesk-adapter/src/filters/dynamic_content_references.ts
@@ -61,6 +61,7 @@ const transformDynamicContentDependencies = async (
         DYNAMIC_CONTENT_ITEM_TYPE_NAME,
         matches[1]
       )
+      missingInstance.value.placeholder = `{{${matches[1]}}}`
       return [
         OPEN_BRACKETS,
         new ReferenceExpression(missingInstance.elemID, missingInstance),

--- a/packages/zendesk-adapter/src/filters/dynamic_content_references.ts
+++ b/packages/zendesk-adapter/src/filters/dynamic_content_references.ts
@@ -61,7 +61,7 @@ const transformDynamicContentDependencies = async (
         DYNAMIC_CONTENT_ITEM_TYPE_NAME,
         matches[1]
       )
-      missingInstance.value.placeholder = `{{${matches[1]}}}`
+      missingInstance.value.placeholder = `${placeholder[0]}`
       return [
         OPEN_BRACKETS,
         new ReferenceExpression(missingInstance.elemID, missingInstance),

--- a/packages/zendesk-adapter/src/filters/dynamic_content_references.ts
+++ b/packages/zendesk-adapter/src/filters/dynamic_content_references.ts
@@ -58,12 +58,14 @@ const transformDynamicContentDependencies = async (
         return [part]
       }
       const matches = placeholder[0].match(/.*\.([a-zA-Z0-9_]+)\}\}/)
-      if (!matches) {
+      // matches can return null
+      if (!matches || matches.length < 2) {
         return [part]
       }
       const missingInstance = createMissingInstance(
         ZENDESK,
         DYNAMIC_CONTENT_ITEM_TYPE_NAME,
+        // matches[1] is the value after the ".", it is caught by the capture group in the regex
         matches[1]
       )
       missingInstance.value.placeholder = `${placeholder[0]}`

--- a/packages/zendesk-adapter/src/filters/dynamic_content_references.ts
+++ b/packages/zendesk-adapter/src/filters/dynamic_content_references.ts
@@ -45,7 +45,7 @@ const log = logger(module)
 const transformDynamicContentDependencies = async (
   instance: InstanceElement,
   placeholderToItem: Record<string, InstanceElement>,
-  enableMissingReference: boolean | undefined
+  enableMissingReference?: boolean,
 ): Promise<void> => {
   const partToTemplate = (part: string): TemplatePart[] => {
     const placeholder = part.match(INNER_PLACEHOLDER_REGEX)
@@ -54,8 +54,11 @@ const transformDynamicContentDependencies = async (
     }
     const itemInstance = placeholderToItem[placeholder[0]]
     if (!itemInstance) {
+      if (!enableMissingReference) {
+        return [part]
+      }
       const matches = placeholder[0].match(/.*\.([a-zA-Z0-9_]+)\}\}/)
-      if (!enableMissingReference || !matches) {
+      if (!matches) {
         return [part]
       }
       const missingInstance = createMissingInstance(

--- a/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
@@ -160,6 +160,7 @@ const formulaToTemplate = (formula: string,
       ZENDESK_REFERENCE_TYPE_TO_SALTO_TYPE[type],
       innerId
     )
+    missingInstance.value.id = innerId
     return new ReferenceExpression(
       missingInstance.elemID,
       missingInstance

--- a/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
@@ -23,6 +23,9 @@ import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { FilterCreator } from '../filter'
 import { DYNAMIC_CONTENT_ITEM_TYPE_NAME } from './dynamic_content'
+import { createMissingInstance } from './references/missing_references'
+import { ZENDESK } from '../constants'
+
 
 const { awu } = collections.asynciterable
 const log = logger(module)
@@ -152,7 +155,15 @@ const formulaToTemplate = (formula: string,
       return new ReferenceExpression(elem.elemID, elem)
     }
     // if no id was detected we return the original expression.
-    return expression
+    const missingInstance = createMissingInstance(
+      ZENDESK,
+      ZENDESK_REFERENCE_TYPE_TO_SALTO_TYPE[type],
+      innerId
+    )
+    return new ReferenceExpression(
+      missingInstance.elemID,
+      missingInstance
+    )
   }
 
   const handleDynamicContentReference = (expression: string, ref: RegExpMatchArray):

--- a/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
+++ b/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
@@ -21,6 +21,7 @@ import ZendeskClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
 import { DEFAULT_CONFIG } from '../../src/config'
 import { ZENDESK } from '../../src/constants'
+import { createMissingInstance } from '../../src/filters/references/missing_references'
 
 describe('handle templates filter', () => {
   let client: ZendeskClient
@@ -176,7 +177,14 @@ describe('handle templates filter', () => {
 
     it('should resolve almost-template normally', () => {
       const fetchedMacroAlmostTemplate = elements.filter(isInstanceElement).find(i => i.elemID.name === 'macroAlmost')
-      expect(fetchedMacroAlmostTemplate?.value.actions[0].value).toEqual('almost template {{ticket.not_an_actual_field_1452}} and {{ticket.ticket_field_1454}}')
+      const missingInstance = createMissingInstance(ZENDESK, 'ticket_field', '1454')
+      missingInstance.value.id = '1454'
+      expect(fetchedMacroAlmostTemplate?.value.actions[0].value).toEqual(new TemplateExpression({
+        parts: ['almost template {{ticket.not_an_actual_field_1452}} and {{',
+          new ReferenceExpression(missingInstance.elemID, missingInstance),
+          '}}',
+        ],
+      }))
       const fetchedMacroAlmostTemplate2 = elements.filter(isInstanceElement).find(i => i.elemID.name === 'macroAlmost2')
       expect(fetchedMacroAlmostTemplate2?.value.actions[0].value).toEqual('{{ticket.ticket_field_1452}}')
     })


### PR DESCRIPTION
_create broken references in template expression_

---

_Additional context for reviewer_
None

---
_Release Notes_: 
Zendesk:
* Create broken references for missing references in template expression. 
Will affect types such as macro and ticket_field.

---
_User Notifications_: 
Zendesk:
* Create broken references for missing references in template expression. 
Will affect types such as macro and ticket_field.