### PR TITLE
SALTO-2752: fix state hash recalculation when content is unchanged

### DIFF
--- a/packages/core/test/workspace/local/state.test.ts
+++ b/packages/core/test/workspace/local/state.test.ts
@@ -456,4 +456,37 @@ describe('local state', () => {
       })
     })
   })
+  describe('calculateHash', () => {
+    let state: wsState.State
+    let mapCreator: remoteMap.RemoteMapCreator
+    beforeEach(() => {
+      mapCreator = inMemRemoteMapCreator()
+      state = localState('multiple_files', '', mapCreator, mockStaticFilesSource())
+    })
+    describe('when cache is changed in memory', () => {
+      let origHash: string | undefined
+      let calculatedHash: string | undefined
+      beforeEach(async () => {
+        origHash = await state.getHash()
+        await state.set(new ObjectType({ elemID: new ElemID('salesforce', 'dummy') }))
+        await state.calculateHash()
+        calculatedHash = await state.getHash()
+      })
+      it('should calculate a new hash', () => {
+        expect(calculatedHash).not.toEqual(origHash)
+      })
+    })
+    describe('when cache is not changed in memory', () => {
+      let origHash: string | undefined
+      let calculatedHash: string | undefined
+      beforeEach(async () => {
+        origHash = await state.getHash()
+        await state.calculateHash()
+        calculatedHash = await state.getHash()
+      })
+      it('should return the original hash', () => {
+        expect(calculatedHash).toEqual(origHash)
+      })
+    })
+  })
 })


### PR DESCRIPTION
if the cache is not "dirty" we skip calculating it again and flushing it because of this, we should also avoid this calculation when asked to get a new hash.

---

No release notes as this is a very internal potential performance issue that only affects very specific scenarios

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_