### PR TITLE
SALTO-2751: Empty values removal causes automation deployment to fail

### DIFF
--- a/packages/adapter-components/src/elements/instance_elements.ts
+++ b/packages/adapter-components/src/elements/instance_elements.ts
@@ -130,6 +130,7 @@ export const removeNullValues = async (
     type,
     transformFunc: ({ value }) => (value === null ? undefined : value),
     strict: false,
+    allowEmpty: true,
   }) ?? {}
 
 export const createServiceIds = (

--- a/packages/adapter-components/src/elements/instance_elements.ts
+++ b/packages/adapter-components/src/elements/instance_elements.ts
@@ -123,14 +123,15 @@ export const generateInstanceNameFromConfig = (
 
 export const removeNullValues = async (
   values: Values,
-  type: ObjectType
+  type: ObjectType,
+  allowEmpty = false,
 ): Promise<Values> =>
   await transformValues({
     values,
     type,
     transformFunc: ({ value }) => (value === null ? undefined : value),
     strict: false,
-    allowEmpty: true,
+    allowEmpty,
   }) ?? {}
 
 export const createServiceIds = (

--- a/packages/jira-adapter/e2e_test/instances/automation.ts
+++ b/packages/jira-adapter/e2e_test/instances/automation.ts
@@ -29,18 +29,10 @@ export const createAutomationValues = (name: string, allElements: Element[]): Va
   },
   trigger: {
     component: 'TRIGGER',
-    schemaVersion: 2,
-    type: 'jira.issue.field.changed',
+    schemaVersion: 1,
+    type: 'jira.manual.trigger.issue',
     value: {
-      changeType: 'VALUE_ADDED',
-      fields: [
-        {
-          value: 'components',
-          type: 'field',
-        },
-      ],
-      actions: [
-        'create',
+      groups: [
       ],
     },
   },

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -89,6 +89,7 @@ import forbiddenPermissionSchemeFilter from './filters/forbidden_permission_sche
 import maskingFilter from './filters/masking'
 import avatarsFilter from './filters/avatars'
 import iconUrlFilter from './filters/icon_url'
+import removeEmptyValuesFilter from './filters/remove_empty_values'
 import jqlReferencesFilter from './filters/jql/jql_references'
 import userFilter from './filters/user'
 import { JIRA } from './constants'
@@ -165,6 +166,7 @@ export const DEFAULT_FILTERS = [
   userFilter,
   forbiddenPermissionSchemeFilter,
   jqlReferencesFilter,
+  removeEmptyValuesFilter,
   maskingFilter,
   referenceBySelfLinkFilter,
   // Must run after referenceBySelfLinkFilter

--- a/packages/jira-adapter/src/filters/automation/automation_deployment.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_deployment.ts
@@ -81,7 +81,7 @@ const importAutomation = async (
   client: JiraClient,
   cloudId: string,
 ): Promise<clientUtils.Response<clientUtils.ResponseValue | clientUtils.ResponseValue[]>> => {
-  const resolvedInstance = await resolveValues(instance, getLookUpName)
+  const resolvedInstance = await resolveValues(instance, getLookUpName, undefined, true)
 
   const ruleScopes = generateRuleScopes(resolvedInstance, cloudId)
 
@@ -144,7 +144,7 @@ const updateAutomation = async (
   client: JiraClient,
   cloudId: string,
 ): Promise<void> => {
-  const resolvedInstance = await resolveValues(instance, getLookUpName)
+  const resolvedInstance = await resolveValues(instance, getLookUpName, undefined, true)
 
   const ruleScopes = generateRuleScopes(resolvedInstance, cloudId)
 

--- a/packages/jira-adapter/src/filters/automation/automation_structure.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_structure.ts
@@ -270,7 +270,8 @@ const filter: FilterCreator = () => {
         .forEach(async instance => {
           instance.value = await elementUtils.removeNullValues(
             instance.value,
-            await instance.getType()
+            await instance.getType(),
+            true,
           )
           await removeRedundantKeys(instance)
           await removeInnerIds(instance)

--- a/packages/jira-adapter/src/filters/references_by_self_link.ts
+++ b/packages/jira-adapter/src/filters/references_by_self_link.ts
@@ -97,6 +97,7 @@ const filter: FilterCreator = () => ({
         pathID: inst.elemID,
         transformFunc: transformSelfLinkToReference(elementsBySelfLink),
         strict: false,
+        allowEmpty: true,
       }) ?? inst.value
     })
   },

--- a/packages/jira-adapter/src/filters/remove_empty_values.ts
+++ b/packages/jira-adapter/src/filters/remove_empty_values.ts
@@ -13,36 +13,28 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { CORE_ANNOTATIONS, isInstanceElement } from '@salto-io/adapter-api'
+import { isInstanceElement } from '@salto-io/adapter-api'
 import { transformValues } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
+import { DASHBOARD_GADGET_TYPE, WEBHOOK_TYPE, WORKFLOW_TYPE_NAME } from '../constants'
 import { FilterCreator } from '../filter'
 
 const { awu } = collections.asynciterable
 
-const isStringNumber = (value: string): boolean => !Number.isNaN(Number(value))
+const RELEVANT_TYPES: string[] = [WORKFLOW_TYPE_NAME, DASHBOARD_GADGET_TYPE, WEBHOOK_TYPE]
 
-/**
- * Remove hidden value from lists, since core does not support it
- */
 const filter: FilterCreator = () => ({
   onFetch: async elements => {
     await awu(elements)
       .filter(isInstanceElement)
+      .filter(instance => RELEVANT_TYPES.includes(instance.elemID.typeName))
       .forEach(async instance => {
         instance.value = await transformValues({
           values: instance.value,
           type: await instance.getType(),
-          pathID: instance.elemID,
-          allowEmpty: true,
+          transformFunc: ({ value }) => value,
           strict: false,
-          transformFunc: ({ value, field, path }) => {
-            const isInArray = path?.getFullNameParts().some(isStringNumber)
-            if (isInArray && field?.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE]) {
-              return undefined
-            }
-            return value
-          },
+          allowEmpty: false,
         }) ?? {}
       })
   },

--- a/packages/jira-adapter/src/filters/user.ts
+++ b/packages/jira-adapter/src/filters/user.ts
@@ -34,6 +34,7 @@ const filter: FilterCreator = () => ({
           values: instance.value,
           type: await instance.getType(),
           strict: false,
+          allowEmpty: true,
           transformFunc: ({ value, field }) => {
             if (USER_TYPE_NAMES.includes(field?.refType.elemID.typeName ?? '')) {
               return value.displayName

--- a/packages/jira-adapter/src/filters/workflow/workflow_modification_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_modification_filter.ts
@@ -44,6 +44,7 @@ const replaceWorkflowInScheme = async (
   const instance = await transformElement({
     element: scheme,
     strict: false,
+    allowEmpty: true,
     elementsSource,
     transformFunc: ({ value }) => {
       if (isReferenceExpression(value) && value.elemID.isEqual(beforeWorkflow.elemID)) {

--- a/packages/jira-adapter/test/filters/remove_empty_values.test.ts
+++ b/packages/jira-adapter/test/filters/remove_empty_values.test.ts
@@ -1,0 +1,69 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import { JIRA, WORKFLOW_TYPE_NAME } from '../../src/constants'
+import removeEmptyValuesFilter from '../../src/filters/remove_empty_values'
+import { getFilterParams } from '../utils'
+
+describe('removeEmptyValues', () => {
+  let filter: filterUtils.FilterWith<'onFetch'>
+  let instance: InstanceElement
+  let type: ObjectType
+  beforeEach(async () => {
+    filter = removeEmptyValuesFilter(getFilterParams({})) as typeof filter
+
+    type = new ObjectType({
+      elemID: new ElemID(JIRA, WORKFLOW_TYPE_NAME),
+    })
+
+    instance = new InstanceElement(
+      'instance',
+      type,
+      {
+        empty: [],
+        notEmpty: 'a',
+      }
+    )
+  })
+
+  it('should remove empty value from relevant type', async () => {
+    await filter.onFetch([instance])
+    expect(instance.value).toEqual({
+      notEmpty: 'a',
+    })
+  })
+  it('should not remove empty value from irrelevant type', async () => {
+    const irrelevantType = new ObjectType({
+      elemID: new ElemID(JIRA, 'irrelevant'),
+    })
+
+    instance = new InstanceElement(
+      'instance',
+      irrelevantType,
+      {
+        empty: [],
+        notEmpty: 'a',
+      }
+    )
+
+    await filter.onFetch([instance])
+    expect(instance.value).toEqual({
+      empty: [],
+      notEmpty: 'a',
+    })
+  })
+})


### PR DESCRIPTION
Fix a bug where we would omit empty values from automations when the API on deploy still expected them to exist.

---
Changed all the places in the adapter where we would implicitly omit all the empty values from elements.
Added filter to omit empty values only from the values we really want to

---
_Release Notes_: 
_Jira Adapter_:
- Fixed a bug where empty arrays would be omitted from automations causing the deployment to fail in some cases. 

---
_User Notifications_: 
_Jira Adapter_:
- Some values might be added to automations