### PR TITLE
SALTO-1899 Convert LightningComponentBundle resources into map

### DIFF
--- a/packages/salesforce-adapter/e2e_test/adapter.test.ts
+++ b/packages/salesforce-adapter/e2e_test/adapter.test.ts
@@ -386,7 +386,7 @@ describe('Salesforce adapter E2E with real account', () => {
         'testLightningComponentBundle')[0] as InstanceElement
       expect(lwc.value[constants.INSTANCE_FULL_NAME_FIELD])
         .toEqual('testLightningComponentBundle')
-      const lwcResource = lwc.value.lwcResources?.lwcResource['lwc_testLightningComponentBundle_testLightningComponentBundle_js@ddv']
+      const lwcResource = lwc.value.lwcResources?.lwcResource['testLightningComponentBundle_js@v']
       expect(lwcResource).toBeDefined()
       expect(isStaticFile(lwcResource.source)).toBe(true)
       const lwcResourceStaticFile = lwcResource.source as StaticFile

--- a/packages/salesforce-adapter/e2e_test/adapter.test.ts
+++ b/packages/salesforce-adapter/e2e_test/adapter.test.ts
@@ -386,8 +386,7 @@ describe('Salesforce adapter E2E with real account', () => {
         'testLightningComponentBundle')[0] as InstanceElement
       expect(lwc.value[constants.INSTANCE_FULL_NAME_FIELD])
         .toEqual('testLightningComponentBundle')
-      const lwcResource = makeArray(lwc.value.lwcResources?.lwcResource)
-        .find(resource => resource.filePath === 'lwc/testLightningComponentBundle/testLightningComponentBundle.js')
+      const lwcResource = lwc.value.lwcResources?.lwcResource['lwc_testLightningComponentBundle_testLightningComponentBundle_js@ddv']
       expect(lwcResource).toBeDefined()
       expect(isStaticFile(lwcResource.source)).toBe(true)
       const lwcResourceStaticFile = lwcResource.source as StaticFile

--- a/packages/salesforce-adapter/src/filters/convert_maps.ts
+++ b/packages/salesforce-adapter/src/filters/convert_maps.ts
@@ -90,7 +90,7 @@ const EMAIL_TEMPLATE_MAP_FIELD_DEF: Record<string, MapDef> = {
 }
 
 const LIGHTNING_COMPONENT_BUNDLE_MAP: Record<string, MapDef> = {
-  'lwcResources.lwcResource': { key: 'filePath', mapper: (item => item.split('/').reverse().map(v => naclCase(v))) },
+  'lwcResources.lwcResource': { key: 'filePath', mapper: (item => [naclCase(_.last(item.split('/')))]) },
 }
 
 export const metadataTypeToFieldToMapDef: Record<string, Record<string, MapDef>> = {
@@ -152,9 +152,8 @@ const convertArraysToMaps = (
         )
       ))
     } else {
-      const res = _.get(instance.value, fieldName)
       _.set(instance.value, fieldName, convertField(
-        makeArray(res),
+        makeArray(_.get(instance.value, fieldName)),
         item => mapper(item[mapDef.key])[0],
         !!mapDef.mapToList,
         fieldName,
@@ -224,7 +223,7 @@ const updateFieldTypes = async (
         if (isObjectType(deepInnerType)) {
           const keyFieldType = deepInnerType.fields[mapDef.key]
           if (!keyFieldType) {
-            log.error('could not find key field %s for field %s', fieldName)
+            log.error('could not find key field %s for field %s', mapDef.key, field.elemID.getFullName())
             return
           }
           keyFieldType.annotations[CORE_ANNOTATIONS.REQUIRED] = true

--- a/packages/salesforce-adapter/src/filters/convert_maps.ts
+++ b/packages/salesforce-adapter/src/filters/convert_maps.ts
@@ -90,7 +90,7 @@ const EMAIL_TEMPLATE_MAP_FIELD_DEF: Record<string, MapDef> = {
 }
 
 const LIGHTNING_COMPONENT_BUNDLE_MAP: Record<string, MapDef> = {
-  'lwcResources.lwcResource': { key: 'filePath', mapper: (item => [naclCase(item)]) },
+  'lwcResources.lwcResource': { key: 'filePath', mapper: (item => item.split('/').reverse().map(v => naclCase(v))) },
 }
 
 export const metadataTypeToFieldToMapDef: Record<string, Record<string, MapDef>> = {
@@ -136,16 +136,17 @@ const convertArraysToMaps = (
   Object.entries(instanceMapFieldDef).filter(
     ([fieldName]) => _.get(instance.value, fieldName) !== undefined
   ).forEach(([fieldName, mapDef]) => {
+    const mapper = mapDef.mapper ?? defaultMapper
     if (mapDef.nested) {
       const firstLevelGroups = _.groupBy(
         makeArray(_.get(instance.value, fieldName)),
-        mapDef.mapper ?? (item => (mapDef.mapper ?? defaultMapper)(item[mapDef.key])[0])
+        (item => mapper(item[mapDef.key])[0])
       )
       _.set(instance.value, fieldName, _.mapValues(
         firstLevelGroups,
         firstLevelValues => convertField(
           firstLevelValues,
-          item => (mapDef.mapper ?? defaultMapper)(item[mapDef.key])[1],
+          item => mapper(item[mapDef.key])[1],
           !!mapDef.mapToList,
           fieldName,
         )
@@ -154,7 +155,7 @@ const convertArraysToMaps = (
       const res = _.get(instance.value, fieldName)
       _.set(instance.value, fieldName, convertField(
         makeArray(res),
-        item => (mapDef.mapper ?? defaultMapper)(item[mapDef.key])[0],
+        item => mapper(item[mapDef.key])[0],
         !!mapDef.mapToList,
         fieldName,
       ))

--- a/packages/salesforce-adapter/src/filters/convert_maps.ts
+++ b/packages/salesforce-adapter/src/filters/convert_maps.ts
@@ -231,7 +231,6 @@ const updateFieldTypes = async (
       } else {
         f.refType = createRefToElmWithValue(new MapType(innerType))
       }
-
       // make the key field required
       const deepInnerType = await getDeepInnerType(innerType)
       if (isObjectType(deepInnerType)) {
@@ -246,6 +245,16 @@ const updateFieldTypes = async (
       const innerField = fieldType.fields[mapDef.innerField]
       const innerFieldType = await innerField.getType()
       innerField.refType = createRefToElmWithValue(new MapType(innerFieldType))
+      // make the key field required
+      const deepInnerType = await getDeepInnerType(innerFieldType)
+      if (isObjectType(deepInnerType)) {
+        const keyFieldType = deepInnerType.fields[mapDef.key]
+        if (!keyFieldType) {
+          log.error('could not find key field %s for field %s', f.elemID.getFullName())
+          return
+        }
+        keyFieldType.annotations[CORE_ANNOTATIONS.REQUIRED] = true
+      }
     }
   })
 }

--- a/packages/salesforce-adapter/src/filters/hardcoded_lists.json
+++ b/packages/salesforce-adapter/src/filters/hardcoded_lists.json
@@ -105,7 +105,6 @@
   "salesforce.LeadConvertSettings.field.objectMapping",
   "salesforce.LightningPage.field.flexiPageRegions",
   "salesforce.LightningPageRegion.field.componentInstances",
-  "salesforce.LightningComponentBundle.field.lwcResources.lwcResource",
   "salesforce.ListView.field.columns",
   "salesforce.ListView.field.filters",
   "salesforce.LookupFilter.field.filterItems",

--- a/packages/salesforce-adapter/test/filters/convert_maps.test.ts
+++ b/packages/salesforce-adapter/test/filters/convert_maps.test.ts
@@ -24,15 +24,11 @@ import {
   toChange,
   isObjectType,
 } from '@salto-io/adapter-api'
-import { values as lowerdashValues } from '@salto-io/lowerdash'
 import { FilterWith } from '../../src/filter'
 import filterCreator from '../../src/filters/convert_maps'
 import { generateProfileType, defaultFilterContext } from '../utils'
 import { createInstanceElement } from '../../src/transformers/transformer'
 import { mockTypes } from '../mock_elements'
-
-
-const { isDefined } = lowerdashValues
 
 type layoutAssignmentType = { layout: string; recordType?: string }
 

--- a/packages/salesforce-adapter/test/filters/convert_maps.test.ts
+++ b/packages/salesforce-adapter/test/filters/convert_maps.test.ts
@@ -24,11 +24,15 @@ import {
   toChange,
   isObjectType,
 } from '@salto-io/adapter-api'
+import { values as lowerdashValues } from '@salto-io/lowerdash'
 import { FilterWith } from '../../src/filter'
 import filterCreator from '../../src/filters/convert_maps'
 import { generateProfileType, defaultFilterContext } from '../utils'
 import { createInstanceElement } from '../../src/transformers/transformer'
 import { mockTypes } from '../mock_elements'
+
+
+const { isDefined } = lowerdashValues
 
 type layoutAssignmentType = { layout: string; recordType?: string }
 
@@ -350,6 +354,10 @@ describe('Convert maps filter', () => {
           const lwcResourceType = await lwcResourcesType.fields.lwcResource.getType()
           expect(isMapType(lwcResourceType)).toBeTruthy()
         }
+      })
+      it('should use the custom mapper to create the key', async () => {
+        const lwc = elements[0] as InstanceElement
+        expect(Object.keys(lwc.value.lwcResources.lwcResource)[0]).toEqual('lwc_js@v')
       })
     })
   })

--- a/packages/salesforce-adapter/test/filters/convert_maps.test.ts
+++ b/packages/salesforce-adapter/test/filters/convert_maps.test.ts
@@ -57,111 +57,17 @@ const generateProfileInstance = ({
     }
   )
 )
+describe('Convert maps filter', () => {
+  describe('ProfileMaps filter', () => {
+    describe('on fetch', () => {
+      const filter = filterCreator({ config: { ...defaultFilterContext } }) as FilterWith<'onFetch' | 'preDeploy'>
+      let profileObj: ObjectType
+      let instances: InstanceElement[]
 
-describe('ProfileMaps filter', () => {
-  describe('on fetch', () => {
-    const filter = filterCreator({ config: { ...defaultFilterContext } }) as FilterWith<'onFetch' | 'preDeploy'>
-    let profileObj: ObjectType
-    let instances: InstanceElement[]
-
-    describe('with regular instances', () => {
-      const generateInstances = (objType: ObjectType): InstanceElement[] => ([
-        generateProfileInstance({
-          profileObj: objType,
-          instanceName: 'aaa',
-          applications: ['app1', 'app2'],
-          fields: ['Account.AccountNumber', 'Contact.HasOptedOutOfEmail'],
-          layoutAssignments: [
-            { layout: 'Account-Account Layout' },
-            // dots etc are escaped in the layout's name
-            { layout: 'Account-random characters %3B%2E%2B%3F%22aaa%27_%2B- bbb', recordType: 'something' },
-            { layout: 'Account-random characters %3B%2E%2B%3F%22aaa%27_%2B- bbb', recordType: 'repetition' },
-            { layout: 'Account-random characters %3B%2E%2B%3F%22aaa%27_%2B- bbb', recordType: 'repetition' },
-          ],
-        }),
-        generateProfileInstance({
-          profileObj: objType,
-          instanceName: 'bbb',
-          applications: ['someApp'],
-          fields: ['Account.AccountNumber'],
-          layoutAssignments: [
-            { layout: 'Account-Account Layout' },
-          ],
-        }),
-      ])
-      beforeAll(async () => {
-        profileObj = generateProfileType()
-        instances = generateInstances(profileObj)
-        await filter.onFetch([profileObj, ...instances])
-      })
-
-      it('should convert object field types to maps', async () => {
-        expect(profileObj).toEqual(generateProfileType(true))
-        const fieldType = await profileObj.fields.applicationVisibilities.getType()
-        expect(isMapType(fieldType)).toBeTruthy()
-        expect(isListType((fieldType as MapType).getInnerType())).toBeFalsy()
-      })
-      it('should mark the fields that are used for keys as _required=true', async () => {
-        expect(profileObj).toEqual(generateProfileType(true))
-        const fieldType = await profileObj.fields.applicationVisibilities.getType()
-        expect(isMapType(fieldType)).toBeTruthy()
-        expect(isListType((fieldType as MapType).getInnerType())).toBeFalsy()
-      })
-      it('should convert instance values to maps', () => {
-        expect((instances[0] as InstanceElement).value).toEqual({
-          applicationVisibilities: {
-            app1: { application: 'app1', default: true, visible: false },
-            app2: { application: 'app2', default: true, visible: false },
-          },
-          fieldPermissions: {
-            Account: {
-              AccountNumber: {
-                field: 'Account.AccountNumber',
-                editable: true,
-                readable: true,
-              },
-            },
-            Contact: {
-              HasOptedOutOfEmail: {
-                field: 'Contact.HasOptedOutOfEmail',
-                editable: true,
-                readable: true,
-              },
-            },
-          },
-          layoutAssignments: {
-            'Account_Account_Layout@bs': [
-              { layout: 'Account-Account Layout' },
-            ],
-            'Account_random_characters__3B_2E_2B_3F_22aaa_27__2B__bbb@bssppppppupbs': [
-              { layout: 'Account-random characters %3B%2E%2B%3F%22aaa%27_%2B- bbb', recordType: 'something' },
-              { layout: 'Account-random characters %3B%2E%2B%3F%22aaa%27_%2B- bbb', recordType: 'repetition' },
-              { layout: 'Account-random characters %3B%2E%2B%3F%22aaa%27_%2B- bbb', recordType: 'repetition' },
-            ],
-          },
-        })
-      })
-      it('should contain the original elements after fetch + preDeploy', async () => {
-        const afterProfileObj = generateProfileType()
-        const afterInstances = generateInstances(afterProfileObj)
-        await filter.onFetch([afterProfileObj, ...afterInstances])
-        const changes = instances.map(
-          (inst, idx) => toChange({ before: inst, after: afterInstances[idx] })
-        )
-        await filter.preDeploy(changes)
-        expect(afterProfileObj).toEqual(generateProfileType(false, true))
-        expect(profileObj).toEqual(generateProfileType(true))
-        expect(afterInstances).toEqual(generateInstances(afterProfileObj))
-        expect(instances).toEqual(generateInstances(profileObj))
-      })
-    })
-
-    describe('with unexpected non-unique fields', () => {
-      beforeAll(async () => {
-        profileObj = generateProfileType()
-        instances = [
+      describe('with regular instances', () => {
+        const generateInstances = (objType: ObjectType): InstanceElement[] => ([
           generateProfileInstance({
-            profileObj,
+            profileObj: objType,
             instanceName: 'aaa',
             applications: ['app1', 'app2'],
             fields: ['Account.AccountNumber', 'Contact.HasOptedOutOfEmail'],
@@ -174,182 +80,277 @@ describe('ProfileMaps filter', () => {
             ],
           }),
           generateProfileInstance({
-            profileObj,
-            instanceName: 'unexpected values',
-            applications: ['sameApp', 'sameApp'],
-            fields: ['Account.AccountNumber', 'Contact.HasOptedOutOfEmail', 'Account.AccountNumber'],
+            profileObj: objType,
+            instanceName: 'bbb',
+            applications: ['someApp'],
+            fields: ['Account.AccountNumber'],
             layoutAssignments: [
               { layout: 'Account-Account Layout' },
+            ],
+          }),
+        ])
+        beforeAll(async () => {
+          profileObj = generateProfileType()
+          instances = generateInstances(profileObj)
+          await filter.onFetch([profileObj, ...instances])
+        })
+
+        it('should convert object field types to maps', async () => {
+          expect(profileObj).toEqual(generateProfileType(true))
+          const fieldType = await profileObj.fields.applicationVisibilities.getType()
+          expect(isMapType(fieldType)).toBeTruthy()
+          expect(isListType((fieldType as MapType).getInnerType())).toBeFalsy()
+        })
+        it('should mark the fields that are used for keys as _required=true', async () => {
+          expect(profileObj).toEqual(generateProfileType(true))
+          const fieldType = await profileObj.fields.applicationVisibilities.getType()
+          expect(isMapType(fieldType)).toBeTruthy()
+          expect(isListType((fieldType as MapType).getInnerType())).toBeFalsy()
+        })
+        it('should convert instance values to maps', () => {
+          expect((instances[0] as InstanceElement).value).toEqual({
+            applicationVisibilities: {
+              app1: { application: 'app1', default: true, visible: false },
+              app2: { application: 'app2', default: true, visible: false },
+            },
+            fieldPermissions: {
+              Account: {
+                AccountNumber: {
+                  field: 'Account.AccountNumber',
+                  editable: true,
+                  readable: true,
+                },
+              },
+              Contact: {
+                HasOptedOutOfEmail: {
+                  field: 'Contact.HasOptedOutOfEmail',
+                  editable: true,
+                  readable: true,
+                },
+              },
+            },
+            layoutAssignments: {
+              'Account_Account_Layout@bs': [
+                { layout: 'Account-Account Layout' },
+              ],
+              'Account_random_characters__3B_2E_2B_3F_22aaa_27__2B__bbb@bssppppppupbs': [
+                { layout: 'Account-random characters %3B%2E%2B%3F%22aaa%27_%2B- bbb', recordType: 'something' },
+                { layout: 'Account-random characters %3B%2E%2B%3F%22aaa%27_%2B- bbb', recordType: 'repetition' },
+                { layout: 'Account-random characters %3B%2E%2B%3F%22aaa%27_%2B- bbb', recordType: 'repetition' },
+              ],
+            },
+          })
+        })
+        it('should contain the original elements after fetch + preDeploy', async () => {
+          const afterProfileObj = generateProfileType()
+          const afterInstances = generateInstances(afterProfileObj)
+          await filter.onFetch([afterProfileObj, ...afterInstances])
+          const changes = instances.map(
+            (inst, idx) => toChange({ before: inst, after: afterInstances[idx] })
+          )
+          await filter.preDeploy(changes)
+          expect(afterProfileObj).toEqual(generateProfileType(false, true))
+          expect(profileObj).toEqual(generateProfileType(true))
+          expect(afterInstances).toEqual(generateInstances(afterProfileObj))
+          expect(instances).toEqual(generateInstances(profileObj))
+        })
+      })
+
+      describe('with unexpected non-unique fields', () => {
+        beforeAll(async () => {
+          profileObj = generateProfileType()
+          instances = [
+            generateProfileInstance({
+              profileObj,
+              instanceName: 'aaa',
+              applications: ['app1', 'app2'],
+              fields: ['Account.AccountNumber', 'Contact.HasOptedOutOfEmail'],
+              layoutAssignments: [
+                { layout: 'Account-Account Layout' },
+                // dots etc are escaped in the layout's name
+                { layout: 'Account-random characters %3B%2E%2B%3F%22aaa%27_%2B- bbb', recordType: 'something' },
+                { layout: 'Account-random characters %3B%2E%2B%3F%22aaa%27_%2B- bbb', recordType: 'repetition' },
+                { layout: 'Account-random characters %3B%2E%2B%3F%22aaa%27_%2B- bbb', recordType: 'repetition' },
+              ],
+            }),
+            generateProfileInstance({
+              profileObj,
+              instanceName: 'unexpected values',
+              applications: ['sameApp', 'sameApp'],
+              fields: ['Account.AccountNumber', 'Contact.HasOptedOutOfEmail', 'Account.AccountNumber'],
+              layoutAssignments: [
+                { layout: 'Account-Account Layout' },
+                { layout: 'too.many.separators', recordType: 'something' },
+                { layout: 'too.many.wrongIndexing', recordType: 'something' },
+              ],
+            }),
+          ]
+          await filter.onFetch([profileObj, ...instances])
+        })
+
+        it('should convert all fields with duplicates into (maps of) lists', async () => {
+          const fieldType = await profileObj.fields.applicationVisibilities.getType()
+          expect(isMapType(fieldType)).toBeTruthy()
+          expect(isListType(await (fieldType as MapType).getInnerType())).toBeTruthy()
+          expect(Array.isArray(
+            (instances[1] as InstanceElement).value.applicationVisibilities.sameApp
+          )).toBeTruthy()
+          expect(Array.isArray(
+            (instances[0] as InstanceElement).value.applicationVisibilities.app1
+          )).toBeTruthy()
+          expect(Array.isArray(
+            (instances[1] as InstanceElement).value.fieldPermissions.Account.AccountNumber
+          )).toBeTruthy()
+          expect(Array.isArray(
+            (instances[0] as InstanceElement).value.fieldPermissions.Contact.HasOptedOutOfEmail
+          )).toBeTruthy()
+        })
+
+        it('should not fail even if there are unexpected API_NAME_SEPARATORs in the indexed value', () => {
+          const inst = instances[1] as InstanceElement
+          expect(inst.value.layoutAssignments).toEqual({
+            'Account_Account_Layout@bs': [{ layout: 'Account-Account Layout' }],
+            too: [
               { layout: 'too.many.separators', recordType: 'something' },
               { layout: 'too.many.wrongIndexing', recordType: 'something' },
             ],
-          }),
-        ]
-        await filter.onFetch([profileObj, ...instances])
-      })
-
-      it('should convert all fields with duplicates into (maps of) lists', async () => {
-        const fieldType = await profileObj.fields.applicationVisibilities.getType()
-        expect(isMapType(fieldType)).toBeTruthy()
-        expect(isListType(await (fieldType as MapType).getInnerType())).toBeTruthy()
-        expect(Array.isArray(
-          (instances[1] as InstanceElement).value.applicationVisibilities.sameApp
-        )).toBeTruthy()
-        expect(Array.isArray(
-          (instances[0] as InstanceElement).value.applicationVisibilities.app1
-        )).toBeTruthy()
-        expect(Array.isArray(
-          (instances[1] as InstanceElement).value.fieldPermissions.Account.AccountNumber
-        )).toBeTruthy()
-        expect(Array.isArray(
-          (instances[0] as InstanceElement).value.fieldPermissions.Contact.HasOptedOutOfEmail
-        )).toBeTruthy()
-      })
-
-      it('should not fail even if there are unexpected API_NAME_SEPARATORs in the indexed value', () => {
-        const inst = instances[1] as InstanceElement
-        expect(inst.value.layoutAssignments).toEqual({
-          'Account_Account_Layout@bs': [{ layout: 'Account-Account Layout' }],
-          too: [
-            { layout: 'too.many.separators', recordType: 'something' },
-            { layout: 'too.many.wrongIndexing', recordType: 'something' },
-          ],
+          })
         })
       })
     })
+
+    describe('deploy (pre + on)', () => {
+      const filter = filterCreator({ config: defaultFilterContext }) as FilterWith<'preDeploy' | 'onDeploy'>
+      let beforeProfileObj: ObjectType
+      let afterProfileObj: ObjectType
+      let beforeInstances: InstanceElement[]
+      let afterInstances: InstanceElement[]
+      let changes: Change[]
+
+      const generateInstances = (objType: ObjectType): InstanceElement[] => ([
+        new InstanceElement(
+          'profile1',
+          objType,
+          {
+            applicationVisibilities: {
+              app1: { application: 'app1', default: true, visible: false },
+              app2: { application: 'app2', default: true, visible: false },
+            },
+            fieldPermissions: {
+              Account: {
+                AccountNumber: {
+                  field: 'Account.AccountNumber',
+                  editable: true,
+                  readable: true,
+                },
+              },
+              Contact: {
+                HasOptedOutOfEmail: {
+                  field: 'Contact.HasOptedOutOfEmail',
+                  editable: true,
+                  readable: true,
+                },
+              },
+            },
+            layoutAssignments: {
+              'Account_Account_Layout@bs': [
+                { layout: 'Account-Account Layout' },
+              ],
+              'Account_random_characters__3B_2E_2B_3F_22aaa_27__2B__bbb@bssppppppupbs': [
+                { layout: 'Account-random characters %3B%2E%2B%3F%22aaa%27_%2B- bbb', recordType: 'something' },
+                { layout: 'Account-random characters %3B%2E%2B%3F%22aaa%27_%2B- bbb', recordType: 'repetition' },
+                { layout: 'Account-random characters %3B%2E%2B%3F%22aaa%27_%2B- bbb', recordType: 'repetition' },
+              ],
+            },
+          }
+        ),
+        new InstanceElement(
+          'profile2',
+          objType,
+          {
+            applicationVisibilities: {
+              app1: { application: 'app1', default: false, visible: false },
+              app2: { application: 'app2', default: true, visible: false },
+            },
+            fieldPermissions: {
+              Account: {
+                AccountNumber: {
+                  field: 'Account.AccountNumber',
+                  editable: true,
+                  readable: true,
+                },
+              },
+              Contact: {
+                HasOptedOutOfEmail: {
+                  field: 'Contact.HasOptedOutOfEmail',
+                  editable: true,
+                  readable: true,
+                },
+              },
+            },
+            layoutAssignments: {
+              'Account_Account_Layout@bs': [
+                { layout: 'Account-Account Layout' },
+              ],
+            },
+          }
+        ),
+      ])
+
+      beforeAll(async () => {
+        beforeProfileObj = generateProfileType(true)
+        beforeInstances = generateInstances(beforeProfileObj)
+        afterProfileObj = generateProfileType(true)
+        afterInstances = generateInstances(afterProfileObj)
+        changes = beforeInstances.map((inst, idx) => (
+          toChange({ before: inst, after: afterInstances[idx] })
+        ))
+        await filter.preDeploy(changes)
+      })
+      it('should convert the object back to list on preDeploy', () => {
+        expect(afterProfileObj).toEqual(generateProfileType(false, true))
+      })
+
+      it('should convert the instances back to lists on preDeploy', () => {
+        expect(Array.isArray(afterInstances[0].value.applicationVisibilities)).toBeTruthy()
+        expect(Array.isArray(afterInstances[0].value.fieldPermissions)).toBeTruthy()
+        expect(Array.isArray(afterInstances[0].value.layoutAssignments)).toBeTruthy()
+        expect(Array.isArray(beforeInstances[0].value.applicationVisibilities)).toBeTruthy()
+        expect(Array.isArray(beforeInstances[0].value.fieldPermissions)).toBeTruthy()
+        expect(Array.isArray(beforeInstances[0].value.layoutAssignments)).toBeTruthy()
+      })
+
+      it('should return object and instances to their original form', async () => {
+        await filter.onDeploy(changes)
+        expect(beforeProfileObj).toEqual(generateProfileType(true))
+        expect(afterProfileObj).toEqual(generateProfileType(true))
+        expect(beforeInstances).toEqual(generateInstances(beforeProfileObj))
+        expect(afterInstances).toEqual(generateInstances(afterProfileObj))
+      })
+    })
   })
 
-  describe('deploy (pre + on)', () => {
-    const filter = filterCreator({ config: defaultFilterContext }) as FilterWith<'preDeploy' | 'onDeploy'>
-    let beforeProfileObj: ObjectType
-    let afterProfileObj: ObjectType
-    let beforeInstances: InstanceElement[]
-    let afterInstances: InstanceElement[]
-    let changes: Change[]
-
-    const generateInstances = (objType: ObjectType): InstanceElement[] => ([
-      new InstanceElement(
-        'profile1',
-        objType,
-        {
-          applicationVisibilities: {
-            app1: { application: 'app1', default: true, visible: false },
-            app2: { application: 'app2', default: true, visible: false },
-          },
-          fieldPermissions: {
-            Account: {
-              AccountNumber: {
-                field: 'Account.AccountNumber',
-                editable: true,
-                readable: true,
-              },
-            },
-            Contact: {
-              HasOptedOutOfEmail: {
-                field: 'Contact.HasOptedOutOfEmail',
-                editable: true,
-                readable: true,
-              },
-            },
-          },
-          layoutAssignments: {
-            'Account_Account_Layout@bs': [
-              { layout: 'Account-Account Layout' },
-            ],
-            'Account_random_characters__3B_2E_2B_3F_22aaa_27__2B__bbb@bssppppppupbs': [
-              { layout: 'Account-random characters %3B%2E%2B%3F%22aaa%27_%2B- bbb', recordType: 'something' },
-              { layout: 'Account-random characters %3B%2E%2B%3F%22aaa%27_%2B- bbb', recordType: 'repetition' },
-              { layout: 'Account-random characters %3B%2E%2B%3F%22aaa%27_%2B- bbb', recordType: 'repetition' },
-            ],
-          },
-        }
-      ),
-      new InstanceElement(
-        'profile2',
-        objType,
-        {
-          applicationVisibilities: {
-            app1: { application: 'app1', default: false, visible: false },
-            app2: { application: 'app2', default: true, visible: false },
-          },
-          fieldPermissions: {
-            Account: {
-              AccountNumber: {
-                field: 'Account.AccountNumber',
-                editable: true,
-                readable: true,
-              },
-            },
-            Contact: {
-              HasOptedOutOfEmail: {
-                field: 'Contact.HasOptedOutOfEmail',
-                editable: true,
-                readable: true,
-              },
-            },
-          },
-          layoutAssignments: {
-            'Account_Account_Layout@bs': [
-              { layout: 'Account-Account Layout' },
-            ],
-          },
-        }
-      ),
-    ])
-
+  describe('Convert inner field to map', () => {
+    let elements: Element[]
+    type FilterType = FilterWith<'onFetch'| 'preDeploy'>
+    let filter: FilterType
     beforeAll(async () => {
-      beforeProfileObj = generateProfileType(true)
-      beforeInstances = generateInstances(beforeProfileObj)
-      afterProfileObj = generateProfileType(true)
-      afterInstances = generateInstances(afterProfileObj)
-      changes = beforeInstances.map((inst, idx) => (
-        toChange({ before: inst, after: afterInstances[idx] })
-      ))
-      await filter.preDeploy(changes)
-    })
-    it('should convert the object back to list on preDeploy', () => {
-      expect(afterProfileObj).toEqual(generateProfileType(false, true))
-    })
+      const lwc = createInstanceElement({ fullName: 'lwc', lwcResources: { lwcResource: [{ filePath: 'dir/lwc.js', source: 'lwc.ts' }] } }, mockTypes.LightningComponentBundle)
+      elements = [lwc]
 
-    it('should convert the instances back to lists on preDeploy', () => {
-      expect(Array.isArray(afterInstances[0].value.applicationVisibilities)).toBeTruthy()
-      expect(Array.isArray(afterInstances[0].value.fieldPermissions)).toBeTruthy()
-      expect(Array.isArray(afterInstances[0].value.layoutAssignments)).toBeTruthy()
-      expect(Array.isArray(beforeInstances[0].value.applicationVisibilities)).toBeTruthy()
-      expect(Array.isArray(beforeInstances[0].value.fieldPermissions)).toBeTruthy()
-      expect(Array.isArray(beforeInstances[0].value.layoutAssignments)).toBeTruthy()
+      filter = filterCreator({ config: { ...defaultFilterContext } }) as FilterType
+      await filter.onFetch(elements)
     })
-
-    it('should return object and instances to their original form', async () => {
-      await filter.onDeploy(changes)
-      expect(beforeProfileObj).toEqual(generateProfileType(true))
-      expect(afterProfileObj).toEqual(generateProfileType(true))
-      expect(beforeInstances).toEqual(generateInstances(beforeProfileObj))
-      expect(afterInstances).toEqual(generateInstances(afterProfileObj))
-    })
-  })
-})
-
-describe('convert inner field to map', () => {
-  let elements: Element[]
-  type FilterType = FilterWith<'onFetch'| 'preDeploy'>
-  let filter: FilterType
-  beforeAll(async () => {
-    const lwc = createInstanceElement({ fullName: 'lwc', lwcResources: { lwcResource: [{ filePath: 'dir/lwc.js', source: 'lwc.ts' }] } }, mockTypes.LightningComponentBundle)
-    elements = [lwc]
-
-    filter = filterCreator({ config: { ...defaultFilterContext } }) as FilterType
-    await filter.onFetch(elements)
-  })
-  describe('on fetch', () => {
-    it('should convert lwcresource inner field to map ', async () => {
-      const lwc = elements[0] as InstanceElement
-      const fieldType = await lwc.getType()
-      const lwcResourcesType = await fieldType.fields.lwcResources.getType()
-      if (isObjectType(lwcResourcesType)) {
-        const lwcResourceType = await lwcResourcesType.fields.lwcResource.getType()
-        expect(isMapType(lwcResourceType)).toBeTruthy()
-      }
+    describe('on fetch', () => {
+      it('should convert lwcresource inner field to map ', async () => {
+        const lwc = elements[0] as InstanceElement
+        const fieldType = await lwc.getType()
+        const lwcResourcesType = await fieldType.fields.lwcResources.getType()
+        if (isObjectType(lwcResourcesType)) {
+          const lwcResourceType = await lwcResourcesType.fields.lwcResource.getType()
+          expect(isMapType(lwcResourceType)).toBeTruthy()
+        }
+      })
     })
   })
 })

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -98,6 +98,10 @@ export const mockTypes = {
         refType: allMissingSubTypes.find(t => t.elemID.typeName === 'TargetConfigs') as TypeElement
         ,
       },
+      lwcResources: { refType: createMetadataObjectType({ annotations: { metadataType: 'LwcResources' },
+        fields: {
+          lwcResource: { refType: new ListType(BuiltinTypes.STRING) },
+        } }) },
     },
   }),
   Layout: createMetadataObjectType({


### PR DESCRIPTION
_Convert LightningComponentBundle resources into map_

---
_Additional context for reviewer_:
None

---
_Release Notes_: 
Salesforce-adapter:

* Convert LightningComponentBundle resources into map
* Add support for converting inner fields from array into map.
---

_User Notifications_: 
Salesforce-adapter:

* LightningComponentBundle resources will be saved as map instead of array.