### PR TITLE
SALTO-2296: remove _parent annotation from custom object instances

### DIFF
--- a/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
@@ -29,7 +29,7 @@ import { Element, Values, Field, InstanceElement, ReferenceExpression, SaltoErro
 import { FilterResult, RemoteFilterCreator } from '../filter'
 import { apiName, isInstanceOfCustomObject, isCustomObject } from '../transformers/transformer'
 import { FIELD_ANNOTATIONS, KEY_PREFIX, KEY_PREFIX_LENGTH, SALESFORCE } from '../constants'
-import { addElementParentReference, isLookupField, isMasterDetailField } from './utils'
+import { isLookupField, isMasterDetailField } from './utils'
 import { DataManagement } from '../fetch_profile/data_management'
 
 const { makeArray } = collections.array
@@ -192,7 +192,6 @@ const replaceLookupsWithRefsAndCreateRefMap = async (
       }
       reverseReferencesMap.get(await serializeInstanceInternalID(refTarget))
         .add(await serializeInstanceInternalID(instance))
-      addElementParentReference(instance, refTarget)
       return new ReferenceExpression(refTarget.elemID)
     }
 

--- a/packages/salesforce-adapter/test/filters/custom_object_instances_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_object_instances_references.test.ts
@@ -162,45 +162,6 @@ describe('Custom Object Instances References filter', () => {
       },
     }
   )
-  const toParentName = 'toParentrName'
-  const toParentElemID = new ElemID(SALESFORCE, toParentName)
-  const toParentObj = new ObjectType({
-    elemID: toParentElemID,
-    annotations: {
-      [API_NAME]: toParentName,
-      [METADATA_TYPE]: CUSTOM_OBJECT,
-    },
-    fields: {
-      Id: {
-        refType: stringType,
-        annotations: {
-          [CORE_ANNOTATIONS.REQUIRED]: false,
-          [LABEL]: 'Id',
-          [API_NAME]: 'Id',
-        },
-      },
-      MasterDetailToParent: {
-        refType: Types.primitiveDataTypes.MasterDetail,
-        annotations: {
-          [LABEL]: 'detailOfToParent',
-          [API_NAME]: 'MasterDetailToParent',
-          referenceTo: [
-            masterName,
-          ],
-        },
-      },
-      MasterDetailToParent2: {
-        refType: Types.primitiveDataTypes.MasterDetail,
-        annotations: {
-          [LABEL]: 'detailOfToParent2',
-          [API_NAME]: 'MasterDetailToParent2',
-          referenceTo: [
-            masterName,
-          ],
-        },
-      },
-    },
-  })
 
   beforeAll(() => {
     client = mockClient().client
@@ -263,15 +224,6 @@ describe('Custom Object Instances References filter', () => {
         MasterDetailExample: '',
       },
     )
-    const masterToAnotherInstanceName = 'masterToAnotherInstance'
-    const masterToAnotherInstance = new InstanceElement(
-      masterToAnotherInstanceName,
-      masterObj,
-      {
-        Id: 'masterToAnotherId',
-        MasterDetailExample: '',
-      },
-    )
     const duplicateInstName = 'duplicateInstance'
     const firstDupInst = new InstanceElement(
       duplicateInstName,
@@ -306,59 +258,16 @@ describe('Custom Object Instances References filter', () => {
         LookupExample: 'toDuplicate',
       }
     )
-    const toParentInstanceName = 'toParentInstance'
-    const toParentInstance = new InstanceElement(
-      toParentInstanceName,
-      toParentObj,
-      {
-        Id: '1234',
-        MasterDetailToParent: 'masterToId',
-        MasterDetailToParent2: 'masterToAnotherId',
-      },
-    )
-    const toParentDupInstanceName = 'toParentDupInstance'
-    const toParentDupInstance = new InstanceElement(
-      toParentDupInstanceName,
-      toParentObj,
-      {
-        Id: '1234',
-        MasterDetailToParent: 'masterToId',
-        MasterDetailToParent2: 'masterToId',
-      },
-    )
-    const toParentEmptyInsatceName = 'toParentEmptyInstance'
-    const toParentEmptyInstance = new InstanceElement(
-      toParentEmptyInsatceName,
-      toParentObj,
-      {
-        Id: '1234',
-      },
-    )
-    const toParentInvalidInstanceName = 'toParentInvalidInstance'
-    const toParentInvalidInstance = new InstanceElement(
-      toParentInvalidInstanceName,
-      toParentObj,
-      {
-        Id: '1234',
-        MasterDetailToParent: 'notExisted',
-      },
-    )
     const objects = [
       refFromObj,
       refToObj,
       masterObj,
       userObj,
-      toParentObj,
     ]
     const legalInstances = [
       refToInstance,
       refFromInstance,
       masterToInstance,
-      masterToAnotherInstance,
-      toParentInstance,
-      toParentDupInstance,
-      toParentEmptyInstance,
-      toParentInvalidInstance,
     ]
     const illegalInstances = [
       refFromEmptyRefsInstance,
@@ -450,44 +359,6 @@ describe('Custom Object Instances References filter', () => {
         ) || errorMessages.some(errorMsg => errorMsg.includes(instance.value.Id))
         expect(warningsIncludeNameOrId).toBeTruthy()
       })
-    })
-
-    it('should create a list of parent annotations in the instance of custom object with masterDetail field', () => {
-      const afterFilterParentAnnotation = elements.find(
-        e => e.elemID.isEqual(toParentInstance.elemID)
-      )
-      expect(afterFilterParentAnnotation).toBeDefined()
-      expect(afterFilterParentAnnotation?.annotations[CORE_ANNOTATIONS.PARENT])
-        .toEqual([
-          new ReferenceExpression(masterToInstance.elemID),
-          new ReferenceExpression(masterToAnotherInstance.elemID),
-        ])
-    })
-    it('should ignore references in the parent annotations in case of duplications', () => {
-      const afterFilterParentAnnotation = elements.find(
-        e => e.elemID.isEqual(toParentDupInstance.elemID)
-      )
-      expect(afterFilterParentAnnotation).toBeDefined()
-      expect(afterFilterParentAnnotation?.annotations[CORE_ANNOTATIONS.PARENT])
-        .toEqual([
-          new ReferenceExpression(masterToInstance.elemID),
-        ])
-    })
-    it('should not create a parent annotation in case of a non-existing value', () => {
-      const afterFilterParentAnnotation = elements.find(
-        e => e.elemID.isEqual(toParentEmptyInstance.elemID)
-      )
-      expect(afterFilterParentAnnotation).toBeDefined()
-      expect(afterFilterParentAnnotation?.annotations[CORE_ANNOTATIONS.PARENT])
-        .toEqual(undefined)
-    })
-    it('should not create a parent annotation in case of a non-ReferenceExpression value', () => {
-      const afterFilterParentAnnotation = elements.find(
-        e => e.elemID.isEqual(toParentInvalidInstance.elemID)
-      )
-      expect(afterFilterParentAnnotation).toBeDefined()
-      expect(afterFilterParentAnnotation?.annotations[CORE_ANNOTATIONS.PARENT])
-        .toEqual(undefined)
     })
   })
 })


### PR DESCRIPTION

---

this is basically a revert of #2421

---
_Release Notes_: 
Salesforce Adapter:
- Removed _parent annotation from custom object records

---
_User Notifications_: 
Salesforce Adapter:
- Removed _parent annotation from custom object records
