### PR TITLE
SALTO-2765: fixed multiline template expression causing pending changes

### DIFF
--- a/packages/workspace/src/parser/internal/native/consumers/values.ts
+++ b/packages/workspace/src/parser/internal/native/consumers/values.ts
@@ -22,6 +22,7 @@
 import { Value, TemplateExpression, ElemID, Values } from '@salto-io/adapter-api'
 import _, { trimEnd } from 'lodash'
 import { Token } from 'moo'
+import { createTemplateExpression } from '@salto-io/adapter-utils'
 import { Consumer, ParseContext, ConsumerReturnType } from '../types'
 import { createReferenceExpresion, unescapeTemplateMarker, addValuePromiseWatcher,
   registerRange, positionAtStart, positionAtEnd } from '../helpers'
@@ -78,7 +79,7 @@ const createTemplateExpressions = (
     token: Required<Token>
   ) => string = defaultStringTokenTranformFunc
 ): TemplateExpression => (
-  new TemplateExpression({ parts: tokens.map(token => {
+  createTemplateExpression({ parts: tokens.map(token => {
     if (token.type === TOKEN_TYPES.REFERENCE) {
       const ref = createReferenceExpresion(token.value)
       return ref instanceof IllegalReference ? token.text : ref

--- a/packages/workspace/test/parser/parse.test.ts
+++ b/packages/workspace/test/parser/parse.test.ts
@@ -725,9 +725,9 @@ value
 
       it('should parse references to multiline template as TemplateExpression', () => {
         expect(multilineRefObj.annotations.tmpl).toBeInstanceOf(TemplateExpression)
-        expect(multilineRefObj.annotations.tmpl.parts).toEqual(['multiline\n', 'template {{', expect.objectContaining({
+        expect(multilineRefObj.annotations.tmpl.parts).toEqual(['multiline\ntemplate {{', expect.objectContaining({
           elemID: new ElemID('te@mp', 'late', 'instance', 'multiline_stuff@us'),
-        }), '}}\n', 'value'])
+        }), '}}\nvalue'])
       })
     })
 


### PR DESCRIPTION
Fixed multiline template expression causing pending changes

---

When there is a multiline string, our parser returns each line as a separate token. When the entire multiline is a string we just join the strings, but when it is a template expression we pass each token as a separate part, and passing multiple strings in a row to new Template expression causes pending changes

So I changed to use createTemplateExpression which handles this case

---
_Release Notes_: 
_Core__:
- Fixed a bug where multiline template expression would cause a pending change in the workspace

---
_User Notifications_: 
None