### PR TITLE
SALTO-2766: Fixed bug of pending changes on notification scheme

### DIFF
--- a/packages/jira-adapter/src/filters/remove_empty_values.ts
+++ b/packages/jira-adapter/src/filters/remove_empty_values.ts
@@ -16,12 +16,17 @@
 import { isInstanceElement } from '@salto-io/adapter-api'
 import { transformValues } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
-import { DASHBOARD_GADGET_TYPE, WEBHOOK_TYPE, WORKFLOW_TYPE_NAME } from '../constants'
+import { DASHBOARD_GADGET_TYPE, NOTIFICATION_SCHEME_TYPE_NAME, WEBHOOK_TYPE, WORKFLOW_TYPE_NAME } from '../constants'
 import { FilterCreator } from '../filter'
 
 const { awu } = collections.asynciterable
 
-const RELEVANT_TYPES: string[] = [WORKFLOW_TYPE_NAME, DASHBOARD_GADGET_TYPE, WEBHOOK_TYPE]
+const RELEVANT_TYPES: string[] = [
+  WORKFLOW_TYPE_NAME,
+  DASHBOARD_GADGET_TYPE,
+  WEBHOOK_TYPE,
+  NOTIFICATION_SCHEME_TYPE_NAME,
+]
 
 const filter: FilterCreator = () => ({
   onFetch: async elements => {


### PR DESCRIPTION
The notification scheme has a hidden value that in some cases might be empty, i.e. `{}`
For some reason, this causes a pending change in the workspace.
As a quick solution, this PR omits the empty values from notification scheme to avoid this case. Later I will look for the real reason in Core


---
_Release Notes_: 
None (this bug did not affect customers so far)

---
_User Notifications_: 
None