### PR TITLE
SALTO-2767: Change queryable field annotation default beahvior to false

### DIFF
--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -189,7 +189,6 @@ export const FIELD_ANNOTATIONS = {
   TRACK_HISTORY: 'trackHistory',
   CREATABLE: 'createable',
   UPDATEABLE: 'updateable',
-  // indicates whether a field is queryable by SOQL (default true)
   QUERYABLE: 'queryable',
   // when true, the field should not be deployed to the service
   LOCAL_ONLY: 'localOnly',

--- a/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
@@ -61,10 +61,12 @@ const isReferenceField = (field: Field): boolean => (
 const getReferenceTo = (field: Field): string[] =>
   makeArray(field.annotations[FIELD_ANNOTATIONS.REFERENCE_TO]) as string[]
 
+const isQueryableField = (field: Field): boolean => (
+  field.annotations[FIELD_ANNOTATIONS.QUERYABLE] === true
+)
+
 const getQueryableFields = (object: ObjectType): Field[] => (
-  Object.values(object.fields)
-    // the "queryable" annotation defaults to true when missing
-    .filter(field => field.annotations[FIELD_ANNOTATIONS.QUERYABLE] !== false)
+  Object.values(object.fields).filter(isQueryableField)
 )
 
 const getFieldNamesForQuery = async (field: Field): Promise<string[]> => (
@@ -380,9 +382,9 @@ export const getIdFields = async (
   const idFieldsWithParents = idFieldsNames.flatMap(fieldName =>
     ((fieldName === detectsParentsIndicator)
       ? getParentFieldNames(Object.values(type.fields)) : fieldName))
-  const invalidIdFieldNames = idFieldsWithParents
-    .filter(fieldName => type.fields[fieldName] === undefined
-        || type.fields[fieldName].annotations[FIELD_ANNOTATIONS.QUERYABLE] === false)
+  const invalidIdFieldNames = idFieldsWithParents.filter(fieldName => (
+    type.fields[fieldName] === undefined || !isQueryableField(type.fields[fieldName])
+  ))
   if (invalidIdFieldNames.length > 0) {
     return { idFields: [], invalidFields: invalidIdFieldNames }
   }

--- a/packages/salesforce-adapter/test/change_validators/custom_object_instances.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/custom_object_instances.test.ts
@@ -26,6 +26,7 @@ describe('custom object instances change validator', () => {
         annotations: {
           [FIELD_ANNOTATIONS.UPDATEABLE]: false,
           [FIELD_ANNOTATIONS.CREATABLE]: true,
+          [FIELD_ANNOTATIONS.QUERYABLE]: true,
         },
       },
       nonCreatable: {
@@ -33,6 +34,7 @@ describe('custom object instances change validator', () => {
         annotations: {
           [FIELD_ANNOTATIONS.CREATABLE]: false,
           [FIELD_ANNOTATIONS.UPDATEABLE]: true,
+          [FIELD_ANNOTATIONS.QUERYABLE]: true,
         },
       },
     },

--- a/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
@@ -42,6 +42,7 @@ describe('Custom Object Instances CRUD', () => {
         annotations: {
           [constants.FIELD_ANNOTATIONS.CREATABLE]: true,
           [constants.FIELD_ANNOTATIONS.UPDATEABLE]: false,
+          [constants.FIELD_ANNOTATIONS.QUERYABLE]: true,
           [constants.API_NAME]: 'Id',
         },
       },
@@ -50,6 +51,7 @@ describe('Custom Object Instances CRUD', () => {
         annotations: {
           [constants.FIELD_ANNOTATIONS.CREATABLE]: true,
           [constants.FIELD_ANNOTATIONS.UPDATEABLE]: true,
+          [constants.FIELD_ANNOTATIONS.QUERYABLE]: true,
           [constants.API_NAME]: 'SaltoName',
         },
       },
@@ -58,6 +60,7 @@ describe('Custom Object Instances CRUD', () => {
         annotations: {
           [constants.FIELD_ANNOTATIONS.CREATABLE]: true,
           [constants.FIELD_ANNOTATIONS.UPDATEABLE]: true,
+          [constants.FIELD_ANNOTATIONS.QUERYABLE]: true,
           [constants.API_NAME]: 'NumField',
         },
       },
@@ -66,6 +69,7 @@ describe('Custom Object Instances CRUD', () => {
         annotations: {
           [constants.FIELD_ANNOTATIONS.CREATABLE]: false,
           [constants.FIELD_ANNOTATIONS.UPDATEABLE]: true,
+          [constants.FIELD_ANNOTATIONS.QUERYABLE]: true,
           [constants.API_NAME]: 'NotCreatable',
         },
       },
@@ -74,6 +78,7 @@ describe('Custom Object Instances CRUD', () => {
         annotations: {
           [constants.FIELD_ANNOTATIONS.CREATABLE]: true,
           [constants.FIELD_ANNOTATIONS.UPDATEABLE]: true,
+          [constants.FIELD_ANNOTATIONS.QUERYABLE]: true,
           [constants.API_NAME]: 'AnotherField',
         },
       },
@@ -82,6 +87,7 @@ describe('Custom Object Instances CRUD', () => {
         annotations: {
           [constants.FIELD_ANNOTATIONS.CREATABLE]: true,
           [constants.FIELD_ANNOTATIONS.UPDATEABLE]: true,
+          [constants.FIELD_ANNOTATIONS.QUERYABLE]: true,
           [constants.API_NAME]: 'Address',
         },
       },
@@ -90,6 +96,7 @@ describe('Custom Object Instances CRUD', () => {
         annotations: {
           [constants.FIELD_ANNOTATIONS.CREATABLE]: true,
           [constants.FIELD_ANNOTATIONS.UPDATEABLE]: true,
+          [constants.FIELD_ANNOTATIONS.QUERYABLE]: true,
           [constants.API_NAME]: 'FieldWithNoValue',
         },
       },
@@ -98,6 +105,7 @@ describe('Custom Object Instances CRUD', () => {
         annotations: {
           [constants.FIELD_ANNOTATIONS.CREATABLE]: true,
           [constants.FIELD_ANNOTATIONS.UPDATEABLE]: true,
+          [constants.FIELD_ANNOTATIONS.QUERYABLE]: true,
           [constants.API_NAME]: 'Name',
         },
       },
@@ -264,6 +272,7 @@ describe('Custom Object Instances CRUD', () => {
           refType: idType,
           label: 'id',
           annotations: {
+            [constants.FIELD_ANNOTATIONS.QUERYABLE]: true,
             [CORE_ANNOTATIONS.REQUIRED]: false,
             [constants.LABEL]: 'Record ID',
             [constants.API_NAME]: 'Id',
@@ -277,6 +286,7 @@ describe('Custom Object Instances CRUD', () => {
             [constants.LABEL]: 'Name',
             [constants.API_NAME]: 'Name',
             [constants.FIELD_ANNOTATIONS.CREATABLE]: true,
+            [constants.FIELD_ANNOTATIONS.QUERYABLE]: true,
           },
         },
         // eslint-disable-next-line camelcase
@@ -287,6 +297,7 @@ describe('Custom Object Instances CRUD', () => {
             [constants.LABEL]: 'TestField',
             [constants.API_NAME]: 'Type.TestField__c',
             [constants.FIELD_ANNOTATIONS.CREATABLE]: true,
+            [constants.FIELD_ANNOTATIONS.QUERYABLE]: true,
           },
           annotationRefsOrTypes: {
             [constants.LABEL]: BuiltinTypes.STRING,

--- a/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
@@ -53,6 +53,7 @@ const createCustomObject = (
       refType: stringType,
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: false,
+        [FIELD_ANNOTATIONS.QUERYABLE]: true,
         [LABEL]: 'Id',
         [API_NAME]: 'Id',
       },
@@ -61,6 +62,7 @@ const createCustomObject = (
       refType: stringType,
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: false,
+        [FIELD_ANNOTATIONS.QUERYABLE]: true,
         [LABEL]: 'description label',
         [API_NAME]: 'Name',
       },
@@ -68,6 +70,7 @@ const createCustomObject = (
     TestField: {
       refType: stringType,
       annotations: {
+        [FIELD_ANNOTATIONS.QUERYABLE]: true,
         [LABEL]: 'Test field',
         [API_NAME]: 'TestField',
       },
@@ -365,11 +368,19 @@ describe('Custom Object Instances filter', () => {
             refType: stringType,
             annotations: {
               [API_NAME]: 'Id',
-              queryable: false,
+              [FIELD_ANNOTATIONS.QUERYABLE]: false,
+            },
+          },
+          Other: {
+            refType: stringType,
+            annotations: {
+              [FIELD_ANNOTATIONS.QUERYABLE]: true,
+              [API_NAME]: 'Other',
             },
           },
         },
         annotations: {
+          [FIELD_ANNOTATIONS.QUERYABLE]: true,
           [API_NAME]: noFieldsName,
           [METADATA_TYPE]: CUSTOM_OBJECT,
         },
@@ -384,6 +395,7 @@ describe('Custom Object Instances filter', () => {
         OtherAddress: {
           refType: Types.compoundDataTypes.Address,
           annotations: {
+            [FIELD_ANNOTATIONS.QUERYABLE]: true,
             [LABEL]: 'Address',
             [API_NAME]: 'OtherAddress',
           },
@@ -583,6 +595,7 @@ describe('Custom Object Instances filter', () => {
               [LABEL]: 'parent field',
               [API_NAME]: 'Parent',
               [FIELD_ANNOTATIONS.REFERENCE_TO]: [refToObjectName],
+              [FIELD_ANNOTATIONS.QUERYABLE]: true,
             },
           },
           Pricebook2Id: {
@@ -591,6 +604,7 @@ describe('Custom Object Instances filter', () => {
               [LABEL]: 'Pricebook2Id field',
               [API_NAME]: 'Pricebook2Id',
               [FIELD_ANNOTATIONS.REFERENCE_TO]: [refToFromNamespaceObjectName],
+              [FIELD_ANNOTATIONS.QUERYABLE]: true,
             },
           },
         }
@@ -606,6 +620,7 @@ describe('Custom Object Instances filter', () => {
               [LABEL]: 'parent field',
               [API_NAME]: 'Parent',
               [FIELD_ANNOTATIONS.REFERENCE_TO]: [refFromAndToObjectName],
+              [FIELD_ANNOTATIONS.QUERYABLE]: true,
             },
           },
           Pricebook2Id: {
@@ -614,6 +629,7 @@ describe('Custom Object Instances filter', () => {
               [LABEL]: 'Pricebook2Id field',
               [API_NAME]: 'Pricebook2Id',
               [FIELD_ANNOTATIONS.REFERENCE_TO]: [refToObjectName],
+              [FIELD_ANNOTATIONS.QUERYABLE]: true,
             },
           },
         }
@@ -661,6 +677,7 @@ describe('Custom Object Instances filter', () => {
         Parent: {
           refType: Types.primitiveDataTypes.MasterDetail,
           annotations: {
+            [FIELD_ANNOTATIONS.QUERYABLE]: true,
             [LABEL]: 'master field',
             [API_NAME]: 'MasterField',
             [FIELD_ANNOTATIONS.REFERENCE_TO]: [refToObjectName],
@@ -679,6 +696,7 @@ describe('Custom Object Instances filter', () => {
         Grandparent: {
           refType: Types.primitiveDataTypes.MasterDetail,
           annotations: {
+            [FIELD_ANNOTATIONS.QUERYABLE]: true,
             [LABEL]: 'master field',
             [API_NAME]: 'MasterField',
             [FIELD_ANNOTATIONS.REFERENCE_TO]: [grandparentObjectName],
@@ -694,6 +712,7 @@ describe('Custom Object Instances filter', () => {
         Pricebook2Id: {
           refType: Types.primitiveDataTypes.Lookup,
           annotations: {
+            [FIELD_ANNOTATIONS.QUERYABLE]: true,
             [LABEL]: 'Pricebook2Id field',
             [API_NAME]: 'Pricebook2Id',
             [FIELD_ANNOTATIONS.REFERENCE_TO]: [grandparentObjectName],
@@ -709,6 +728,7 @@ describe('Custom Object Instances filter', () => {
         ProductCode: {
           refType: BuiltinTypes.STRING,
           annotations: {
+            [FIELD_ANNOTATIONS.QUERYABLE]: true,
             [LABEL]: 'ProductCode field',
             [API_NAME]: 'ProductCode',
           },
@@ -723,6 +743,7 @@ describe('Custom Object Instances filter', () => {
         SBQQ__Location__c: {
           refType: Types.primitiveDataTypes.Checkbox,
           annotations: {
+            [FIELD_ANNOTATIONS.QUERYABLE]: true,
             [LABEL]: 'Location checkbox field',
             [API_NAME]: 'SBQQ__Location__c',
             [FIELD_ANNOTATIONS.VALUE_SET]: [
@@ -737,6 +758,7 @@ describe('Custom Object Instances filter', () => {
         SBQQ__DisplayOrder__c: {
           refType: Types.primitiveDataTypes.Number,
           annotations: {
+            [FIELD_ANNOTATIONS.QUERYABLE]: true,
             [LABEL]: 'Display order',
             [API_NAME]: 'SBQQ__DisplayOrder__c',
           },
@@ -751,6 +773,7 @@ describe('Custom Object Instances filter', () => {
         Parent: {
           refType: Types.primitiveDataTypes.MasterDetail,
           annotations: {
+            [FIELD_ANNOTATIONS.QUERYABLE]: true,
             [LABEL]: 'master field',
             [API_NAME]: 'MasterField',
             [FIELD_ANNOTATIONS.REFERENCE_TO]: [parentObjectName],
@@ -766,6 +789,7 @@ describe('Custom Object Instances filter', () => {
         Parent: {
           refType: Types.primitiveDataTypes.MasterDetail,
           annotations: {
+            [FIELD_ANNOTATIONS.QUERYABLE]: true,
             [LABEL]: 'master field',
             [API_NAME]: 'MasterField',
             [FIELD_ANNOTATIONS.REFERENCE_TO]: ['noSuchObject'],

--- a/packages/salesforce-adapter/test/utils.ts
+++ b/packages/salesforce-adapter/test/utils.ts
@@ -232,6 +232,7 @@ export const createCustomSettingsObject = (
       refType: idType,
       label: 'id',
       annotations: {
+        [constants.FIELD_ANNOTATIONS.QUERYABLE]: true,
         [CORE_ANNOTATIONS.REQUIRED]: false,
         [constants.LABEL]: 'Record ID',
         [constants.API_NAME]: 'Id',
@@ -245,6 +246,7 @@ export const createCustomSettingsObject = (
         [constants.LABEL]: 'Name',
         [constants.API_NAME]: 'Name',
         [constants.FIELD_ANNOTATIONS.CREATABLE]: true,
+        [constants.FIELD_ANNOTATIONS.QUERYABLE]: true,
       },
     },
     // eslint-disable-next-line camelcase
@@ -255,6 +257,7 @@ export const createCustomSettingsObject = (
         [constants.LABEL]: 'TestField',
         [constants.API_NAME]: `${name}.TestField__c`,
         [constants.FIELD_ANNOTATIONS.CREATABLE]: true,
+        [constants.FIELD_ANNOTATIONS.QUERYABLE]: true,
       },
       annotationRefsOrTypes: {
         [constants.LABEL]: BuiltinTypes.STRING,


### PR DESCRIPTION
This fixes a new issue where we would try to read fields from the SOAP API even when they did not exist in that API

this was because the queryable annotation behaved differently from the other ones it was assumed "true" if it was missing.
since we do set that annotation on all the fields that come from the SOAP API there is no reason to assume it is true if it is missing

---

---
_Release Notes_: 
Salesforce Adapter:
- Fixed issue with fetching custom object instances with non-queryable fields

---
_User Notifications_: 
_None_