### PR TITLE
SALTO-2768 - Add PermissionSet to convert_maps with same logic as Profile

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/profile_map_keys.ts
+++ b/packages/salesforce-adapter/src/change_validators/profile_map_keys.ts
@@ -19,7 +19,7 @@ import {
 } from '@salto-io/adapter-api'
 import { TransformFunc, transformValues, resolveValues } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
-import { getInstanceChanges, PROFILE_MAP_FIELD_DEF, defaultMapper } from '../filters/convert_maps'
+import { getInstanceChanges, PROFILE_AND_PERMISSIONS_SET_MAP_FIELD_DEF, defaultMapper } from '../filters/convert_maps'
 import { API_NAME_SEPARATOR, PROFILE_METADATA_TYPE } from '../constants'
 import { getLookUpName } from '../transformers/reference_mapping'
 
@@ -35,10 +35,10 @@ const getMapKeyErrors = async (
   const errors: ChangeError[] = []
   await awu(Object.entries(after.value)).filter(
     async ([fieldName]) => isMapType(await (await after.getType()).fields[fieldName]?.getType())
-    && PROFILE_MAP_FIELD_DEF[fieldName] !== undefined
+    && PROFILE_AND_PERMISSIONS_SET_MAP_FIELD_DEF[fieldName] !== undefined
   ).forEach(async ([fieldName, fieldValues]) => {
     const fieldType = await (await after.getType()).fields[fieldName].getType() as MapType
-    const mapDef = PROFILE_MAP_FIELD_DEF[fieldName]
+    const mapDef = PROFILE_AND_PERMISSIONS_SET_MAP_FIELD_DEF[fieldName]
     const findInvalidPaths: TransformFunc = async ({ value, path, field }) => {
       if (isObjectType(await field?.getType()) && path !== undefined) {
         if (value[mapDef.key] === undefined) {

--- a/packages/salesforce-adapter/src/filters/convert_maps.ts
+++ b/packages/salesforce-adapter/src/filters/convert_maps.ts
@@ -25,7 +25,7 @@ import { naclCase, applyFunctionToChangeData } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 
 import { LocalFilterCreator } from '../filter'
-import { API_NAME_SEPARATOR, PROFILE_METADATA_TYPE, BUSINESS_HOURS_METADATA_TYPE, EMAIL_TEMPLATE_METADATA_TYPE } from '../constants'
+import { API_NAME_SEPARATOR, PROFILE_METADATA_TYPE, BUSINESS_HOURS_METADATA_TYPE, EMAIL_TEMPLATE_METADATA_TYPE, PERMISSION_SET_METADATA_TYPE } from '../constants'
 import { metadataType } from '../transformers/transformer'
 
 const { awu } = collections.asynciterable
@@ -58,7 +58,7 @@ const BUSINESS_HOURS_MAP_FIELD_DEF: Record<string, MapDef> = {
   businessHours: { key: 'name' },
 }
 
-export const PROFILE_MAP_FIELD_DEF: Record<string, MapDef> = {
+export const PROFILE_AND_PERMISSIONS_SET_MAP_FIELD_DEF: Record<string, MapDef> = {
   // One-level maps
   applicationVisibilities: { key: 'application' },
   classAccesses: { key: 'apexClass' },
@@ -89,7 +89,8 @@ const EMAIL_TEMPLATE_MAP_FIELD_DEF: Record<string, MapDef> = {
 export const metadataTypeToFieldToMapDef: Record<string, Record<string, MapDef>> = {
   [BUSINESS_HOURS_METADATA_TYPE]: BUSINESS_HOURS_MAP_FIELD_DEF,
   [EMAIL_TEMPLATE_METADATA_TYPE]: EMAIL_TEMPLATE_MAP_FIELD_DEF,
-  [PROFILE_METADATA_TYPE]: PROFILE_MAP_FIELD_DEF,
+  [PROFILE_METADATA_TYPE]: PROFILE_AND_PERMISSIONS_SET_MAP_FIELD_DEF,
+  [PERMISSION_SET_METADATA_TYPE]: PROFILE_AND_PERMISSIONS_SET_MAP_FIELD_DEF,
 }
 
 /**


### PR DESCRIPTION
This misses tests + adding PermissionSet to the change validator 

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
