### PR TITLE
SALTO-2768 - Remove PermissionSet from EnumFieldPermissions filter

### DIFF
--- a/packages/salesforce-adapter/src/filters/field_permissions_enum.ts
+++ b/packages/salesforce-adapter/src/filters/field_permissions_enum.ts
@@ -20,7 +20,7 @@ import { applyFunctionToChangeData } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { LocalFilterCreator } from '../filter'
 import { apiName } from '../transformers/transformer'
-import { SALESFORCE, METADATA_TYPE, PROFILE_METADATA_TYPE, PERMISSION_SET_METADATA_TYPE, TYPES_PATH, SUBTYPES_PATH } from '../constants'
+import { SALESFORCE, METADATA_TYPE, PROFILE_METADATA_TYPE, TYPES_PATH, SUBTYPES_PATH } from '../constants'
 import { isInstanceOfType, isInstanceOfTypeChange } from './utils'
 
 const { awu } = collections.asynciterable
@@ -28,7 +28,6 @@ const log = logger(module)
 
 const metadataTypesWithFieldPermissions = [
   PROFILE_METADATA_TYPE,
-  PERMISSION_SET_METADATA_TYPE,
 ]
 
 const FIELD_PERMISSIONS = 'fieldPermissions'


### PR DESCRIPTION
As an alternative solution for the issue, we can remove the fieldPermissions enum logic to not run on PermissionSets

---

No reason to merge both this and https://github.com/salto-io/salto/pull/3392

---
_Release Notes_: 
* enumFieldPermission support for PermissionSet temporary removed

---
_User Notifications_: 
* If there was a fetch with `enumFieldPermission = true` that included PermissionSet instances before, the next fetch will include changes in PermissionSet's fieldPermission values structure
