### PR TITLE
SALTO-2768: fix references from permission sets

### DIFF
--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -153,7 +153,7 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
   // note: not all field values under ReportColumn match this rule - but it's ok because
   // only the ones that match are currently extracted (SALTO-1758)
   {
-    src: { field: 'field', parentTypes: ['FilterItem', 'ReportColumn'] },
+    src: { field: 'field', parentTypes: ['FilterItem', 'ReportColumn', 'PermissionSetFieldPermissions'] },
     target: { type: CUSTOM_FIELD },
   },
   {
@@ -530,7 +530,7 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
 // Optional reference that should not be used if enumFieldPermissions config is on
 const fieldPermissionEnumDisabledExtraMappingDefs: FieldReferenceDefinition[] = [
   {
-    src: { field: 'field', parentTypes: ['ProfileFieldLevelSecurity', 'PermissionSetFieldPermissions'] },
+    src: { field: 'field', parentTypes: ['ProfileFieldLevelSecurity'] },
     target: { type: CUSTOM_FIELD },
   },
 ]


### PR DESCRIPTION
Fix issue where references from permission sets are missing

---

This is reverting another part of #3204 

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_