### PR TITLE
SALTO-2541 replace display name with account ID in user filter

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -191,6 +191,7 @@ export const DEFAULT_FILTERS = [
   missingDescriptionsFilter,
   smartValueReferenceFilter,
   permissionSchemeFilter,
+  // Must run after user filter
   accountIdFilter,
   // Must run after accountIdFilter
   addDisplayNameFilter,

--- a/packages/jira-adapter/src/change_validators/account_id.ts
+++ b/packages/jira-adapter/src/change_validators/account_id.ts
@@ -19,7 +19,7 @@ import { logger } from '@salto-io/logging'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { walkOnElement } from '@salto-io/adapter-utils'
 import _ from 'lodash'
-import { walkOnUsers, WalkOnUsersCallback } from '../filters/account_id/account_id_filter'
+import { isDeployableAccountIdType, walkOnUsers, WalkOnUsersCallback } from '../filters/account_id/account_id_filter'
 import { JiraConfig } from '../config/config'
 import { createIdToUserMap, IdMap } from '../filters/account_id/add_display_name_filter'
 import JiraClient from '../client/client'
@@ -143,7 +143,9 @@ export const accountIdValidator: (
         .filter(isAdditionOrModificationChange)
         .filter(isInstanceChange)
         .map(change => getChangeData(change))
-        .map(element =>
-          createChangeErrorsForAccountIdIssues(element, idMap, baseUrl))
-        .flat()
+        .filter(isDeployableAccountIdType)
+        .forEach(element =>
+          walkOnElement({ element,
+            func: walkOnUsers(checkAndCreateChangeErrors(idMap, baseUrl, changeErrors)) }))
+      return changeErrors
     }, 'display name validator')

--- a/packages/jira-adapter/src/change_validators/account_id.ts
+++ b/packages/jira-adapter/src/change_validators/account_id.ts
@@ -144,8 +144,7 @@ export const accountIdValidator: (
         .filter(isInstanceChange)
         .map(change => getChangeData(change))
         .filter(isDeployableAccountIdType)
-        .forEach(element =>
-          walkOnElement({ element,
-            func: walkOnUsers(checkAndCreateChangeErrors(idMap, baseUrl, changeErrors)) }))
-      return changeErrors
+        .map(element =>
+          createChangeErrorsForAccountIdIssues(element, idMap, baseUrl))
+        .flat()
     }, 'display name validator')

--- a/packages/jira-adapter/src/filters/account_id/account_id_filter.ts
+++ b/packages/jira-adapter/src/filters/account_id/account_id_filter.ts
@@ -100,7 +100,7 @@ const accountIdsScenarios = (
   if (path.typeName === 'Board') {
     if (path.name === 'users'
         && Array.isArray(value)) {
-      [...Array(value.length).keys()].forEach(index => callback({
+      _.range(value.length).forEach(index => callback({
         value,
         path,
         fieldName: index.toString(),

--- a/packages/jira-adapter/src/filters/account_id/account_id_filter.ts
+++ b/packages/jira-adapter/src/filters/account_id/account_id_filter.ts
@@ -26,12 +26,17 @@ import { accountIdInfoType } from './types'
 const { awu } = collections.asynciterable
 const log = logger(module)
 
+export const OWNER_STYLE_TYPES = ['Filter', 'Dashboard']
+export const NON_DEPLOYABLE_TYPES = [...OWNER_STYLE_TYPES, 'Board']
 export const PARAMETER_STYLE_TYPES = ['PermissionScheme', 'NotificationScheme', 'SecurityLevel']
-export const ACCOUNT_ID_TYPES = PARAMETER_STYLE_TYPES.concat(['Automation', 'Project', 'ProjectComponent', 'ProjectRole'])
+export const DEPLOYABLE_TYPES = [...PARAMETER_STYLE_TYPES,
+  'Automation', 'Project', 'ProjectComponent', 'ProjectRole']
+export const ACCOUNT_ID_TYPES = [...NON_DEPLOYABLE_TYPES, ...DEPLOYABLE_TYPES]
 
 const USER_TYPE = 'user'
 const VALUE_FIELD = 'value'
 const PARAMETER_FIELD = 'parameter'
+const OWNER_FIELD = 'owner'
 
 type AccountIdCacheInfo = {
   path: ElemID
@@ -50,6 +55,9 @@ const addToCache = (
   }
   cache[key].push({ path, object: objectToClone })
 }
+
+export const isDeployableAccountIdType = (instanceElement: InstanceElement): boolean =>
+  DEPLOYABLE_TYPES.includes(instanceElement.elemID.typeName)
 
 const isAccountIdType = (instanceElement: InstanceElement): boolean =>
   ACCOUNT_ID_TYPES.includes(instanceElement.elemID.typeName)
@@ -81,6 +89,24 @@ const accountIdsScenarios = (
       && _.toLower(value.type) === USER_TYPE) {
     callback({ value, path, fieldName: PARAMETER_FIELD })
   }
+  // fourth scenario the type is Filter or Dashboard (coming from the user filter)
+  // the value is under the owner field
+  if (OWNER_STYLE_TYPES.includes(path.typeName)
+      && value.owner !== undefined) {
+    callback({ value, path, fieldName: OWNER_FIELD })
+  }
+  // fifth scenario the type is Board, inside the admins property there is a users
+  // property that is a list of account ids without any additional parameter
+  if (path.typeName === 'Board') {
+    if (path.name === 'users'
+        && Array.isArray(value)) {
+      [...Array(value.length).keys()].forEach(index => callback({
+        value,
+        path,
+        fieldName: index.toString(),
+      }))
+    }
+  }
 }
 
 export const walkOnUsers = (callback: WalkOnUsersCallback): WalkOnFunc => (
@@ -90,7 +116,7 @@ export const walkOnUsers = (callback: WalkOnUsersCallback): WalkOnFunc => (
         return WALK_NEXT_STEP.EXIT
       }
       accountIdsScenarios(value.value, path, callback)
-    } else {
+    } else if (value !== undefined) {
       accountIdsScenarios(value, path, callback)
     }
     return WALK_NEXT_STEP.RECURSE
@@ -150,6 +176,7 @@ const filter: FilterCreator = () => {
         .filter(isInstanceChange)
         .filter(isAdditionOrModificationChange)
         .map(getChangeData)
+        .filter(isDeployableAccountIdType)
         .forEach(element =>
           walkOnElement({ element, func: walkOnUsers(cacheAndSimplifyAccountId(cache)) }))
     },

--- a/packages/jira-adapter/src/filters/user.ts
+++ b/packages/jira-adapter/src/filters/user.ts
@@ -13,35 +13,34 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, Field, isInstanceElement, isListType, isObjectType, ListType } from '@salto-io/adapter-api'
-import { transformValues } from '@salto-io/adapter-utils'
+import { Field, isInstanceElement, isListType, isObjectType, ListType } from '@salto-io/adapter-api'
+import { walkOnElement } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import { FilterCreator } from '../filter'
+import { walkOnUsers, WalkOnUsersCallback } from './account_id/account_id_filter'
+import { accountIdInfoType } from './account_id/types'
 
 const { awu } = collections.asynciterable
+const log = logger(module)
 
 const USER_TYPE_NAMES = ['User', 'UserBean', 'Board_admins_users']
 
+const simplifyUsers: WalkOnUsersCallback = ({ value, fieldName }): void => {
+  if (value[fieldName]?.accountId !== undefined) {
+    value[fieldName] = value[fieldName].accountId
+  }
+}
+
 /**
- * Replaces the user obj with only the display name
+ * Replaces the user obj with only the account id
  */
 const filter: FilterCreator = () => ({
-  onFetch: async elements => {
+  onFetch: async elements => log.time(async () => {
     await awu(elements)
       .filter(isInstanceElement)
-      .forEach(async instance => {
-        instance.value = await transformValues({
-          values: instance.value,
-          type: await instance.getType(),
-          strict: false,
-          allowEmpty: true,
-          transformFunc: ({ value, field }) => {
-            if (USER_TYPE_NAMES.includes(field?.refType.elemID.typeName ?? '')) {
-              return value.displayName
-            }
-            return value
-          },
-        }) ?? instance.value
+      .forEach(async element => {
+        walkOnElement({ element, func: walkOnUsers(simplifyUsers) })
       })
 
     await awu(elements)
@@ -57,7 +56,7 @@ const filter: FilterCreator = () => ({
                 ? [fieldName, new Field(
                   type,
                   field.name,
-                  isListType(fieldType) ? new ListType(BuiltinTypes.STRING) : BuiltinTypes.STRING,
+                  isListType(fieldType) ? new ListType(accountIdInfoType) : accountIdInfoType,
                   field.annotations
                 )]
                 : [fieldName, field])
@@ -65,7 +64,7 @@ const filter: FilterCreator = () => ({
             .toArray()
         )
       })
-  },
+  }, 'user_filter'),
 })
 
 export default filter

--- a/packages/jira-adapter/test/change_validators/account_id.test.ts
+++ b/packages/jira-adapter/test/change_validators/account_id.test.ts
@@ -163,7 +163,7 @@ Go to ${url} to see valid users and account IDs.`,
     const realDisplayName = instances[0].value.nested.actor2[field].displayName
     const accountId = instances[0].value.nested.actor2[field].id
     instances[0].value.nested.actor2[field].displayName = 'wrong'
-    const elemId = instances[0].elemID.createNestedID('nested').createNestedID('actor2').createNestedID(field)
+    const elemId = instances[0].elemID.createNestedID('nested', 'actor2', field)
     const { parent } = elemId.createTopLevelParentID()
     expect(await validator([
       toChange({
@@ -187,16 +187,16 @@ Go to ${url} to see valid users and account IDs.`,
     // two same errors on a single element
     const field1 = 'parameter'
     delete instances[0].value.holder[field1].displayName
-    const elemId1 = instances[0].elemID.createNestedID('holder').createNestedID(field1)
+    const elemId1 = instances[0].elemID.createNestedID('holder', field1)
     const field2 = 'accountId'
     delete instances[0].value.list[0][field2].displayName
-    const elemId2 = instances[0].elemID.createNestedID('list').createNestedID('0').createNestedID(field2)
+    const elemId2 = instances[0].elemID.createNestedID('list', '0', field2)
     // two different errors on a single element
     delete instances[1].value.holder[field1].displayName
-    const elemId3 = instances[1].elemID.createNestedID('holder').createNestedID(field1)
+    const elemId3 = instances[1].elemID.createNestedID('holder', field1)
     const field4 = 'value'
     instances[1].value.actor[field4].id = '403'
-    const elemId4 = instances[1].elemID.createNestedID('actor').createNestedID(field4)
+    const elemId4 = instances[1].elemID.createNestedID('actor', field4)
     const parent4 = instances[1].elemID.createTopLevelParentID().parent
     const changeErrors = await validator([
       toChange({
@@ -234,5 +234,18 @@ Go to ${url} to see valid users and account IDs.`,
         after: instances[1],
       }),
     ])).toEqual([])
+  })
+  it('should not raise errors when the type is not deployable', async () => {
+    const objectType = common.createObjectedType('Filter')
+    instances = common.createInstanceElementArrayWithDisplayNames(2, objectType)
+    const changeErrors = await validator([
+      toChange({
+        after: instances[0],
+      }),
+      toChange({
+        after: instances[1],
+      }),
+    ])
+    expect(changeErrors).toEqual([])
   })
 })

--- a/packages/jira-adapter/test/filters/account_id/account_id_common.ts
+++ b/packages/jira-adapter/test/filters/account_id/account_id_common.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, ElemID, InstanceElement, ObjectType, Values } from '@salto-io/adapter-api'
+import { BuiltinTypes, ElemID, InstanceElement, ListType, ObjectType, Values } from '@salto-io/adapter-api'
 import { accountIdInfoType } from '../../../src/filters/account_id/types'
 import { JIRA } from '../../../src/constants'
 
@@ -80,6 +80,45 @@ export const createType = (
       leadAccountId: { refType: BuiltinTypes.STRING },
       authorAccountId: { refType: BuiltinTypes.STRING },
       nested: { refType: nestedType },
+    },
+  })
+}
+export const createEmptyType = (type: string): ObjectType => new ObjectType({
+  elemID: new ElemID(JIRA, type),
+})
+
+export const createBoardType = (): ObjectType => {
+  const boardAdminsType = createEmptyType('Board_admins')
+  const adminType = new ObjectType({
+    elemID: new ElemID(JIRA, 'BoardAdmins'),
+    fields: {
+      users: { refType: new ListType(boardAdminsType) },
+    },
+  })
+  return new ObjectType({
+    elemID: new ElemID(JIRA, 'Board'),
+    fields: {
+      admins: { refType: adminType },
+    },
+  })
+}
+
+export const createFilterType = (): ObjectType => {
+  const userType = createEmptyType('User')
+  return new ObjectType({
+    elemID: new ElemID(JIRA, 'Filter'),
+    fields: {
+      owner: { refType: userType },
+    },
+  })
+}
+
+export const createDashboardType = (): ObjectType => {
+  const beanUserType = createEmptyType('UserBean')
+  return new ObjectType({
+    elemID: new ElemID(JIRA, 'Dashboard'),
+    fields: {
+      owner: { refType: beanUserType },
     },
   })
 }

--- a/packages/jira-adapter/test/filters/user.test.ts
+++ b/packages/jira-adapter/test/filters/user.test.ts
@@ -116,8 +116,6 @@ describe('userFilter', () => {
       expect((await adminType.fields.users.getType()).elemID.name).toEqual(`List<jira.${ACCOUNT_ID_INFO_TYPE}>`)
       expect((await filterType.fields.owner.getType()).elemID.name).toEqual(ACCOUNT_ID_INFO_TYPE)
       expect((await dashboardType.fields.owner.getType()).elemID.name).toEqual(ACCOUNT_ID_INFO_TYPE)
-      // expect(await filterType.fields.owner.getType()).toEqual(accountIdInfoType)
-      // expect(await dashboardType.fields.owner.getType()).toEqual(accountIdInfoType)
     })
   })
 })

--- a/packages/jira-adapter/test/filters/user.test.ts
+++ b/packages/jira-adapter/test/filters/user.test.ts
@@ -111,6 +111,34 @@ describe('userFilter', () => {
       })
     })
 
+    it('should do nothing on wrong structure', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        boardType,
+        {
+          type: 'ACCOUNT_ID',
+        }
+      )
+      await filter.onFetch?.([instance])
+      expect(instance.value).toEqual({
+        type: 'ACCOUNT_ID',
+      })
+
+      const instance2 = new InstanceElement(
+        'instance2',
+        boardType,
+        {
+          type: 'ACCOUNT_ID',
+          value: 'bla',
+        }
+      )
+      await filter.onFetch?.([instance2])
+      expect(instance2.value).toEqual({
+        type: 'ACCOUNT_ID',
+        value: 'bla',
+      })
+    })
+
     it('should replace field type', async () => {
       await filter.onFetch?.([adminType, filterType, dashboardType])
       expect((await adminType.fields.users.getType()).elemID.name).toEqual(`List<jira.${ACCOUNT_ID_INFO_TYPE}>`)


### PR DESCRIPTION
_JIRA: changed the display name in a few places with account id to make it unique_

---
This PR is based on https://github.com/salto-io/salto/pull/3387 and https://github.com/salto-io/salto/pull/3348, noly the last commit is relevant

In several places the user filter changed one of 3 user types (User, UserBean, Board_admins) with the display name, which was not unique.

-The display name was changed to account id 
-The scenarios were added to the account id filter to add display names (only in fetch)
-The user filter was refactored from transformValue to walkOnElement (using the walkOnUser function). Time of filter was reduced from ~700 ms to ~130ms (JIRA test env
-The user filter before covered all cases of the 3 user types (including possible future ones). Now we only replace the actual scenarios in use:
--In Filter->owner
--in Dashboard ->owner
--in Board->admins->users (a list)


---
_Release Notes_: 
Jira Adapter:
Elements that contained user info only as (non unique) Display name will now have also account Id 

---
_User Notifications_: 
None
