### PR TITLE
Salto-2397 - suppress noisy exchange rate changes

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -58,11 +58,8 @@ import suiteAppConfigElementsFilter from './filters/suiteapp_config_elements'
 import configFeaturesFilter from './filters/config_features'
 import omitSdfUntypedValues from './filters/omit_sdf_untyped_values'
 import omitFieldsFilter from './filters/omit_fields'
-<<<<<<< HEAD
 import addFieldsToCustomRecordType from './filters/custom_record_type_fields'
-=======
 import currencyExchangeRate from './filters/currency_exchange_rate'
->>>>>>> 73c62ebe (added filter to adapter)
 import { createFilterCreatorsWithLogs, Filter, FilterCreator } from './filter'
 import { getConfigFromConfigChanges, NetsuiteConfig, DEFAULT_DEPLOY_REFERENCED_ELEMENTS, DEFAULT_WARN_STALE_DATA, DEFAULT_USE_CHANGES_DETECTION, DEFAULT_VALIDATE } from './config'
 import { andQuery, buildNetsuiteQuery, NetsuiteQuery, NetsuiteQueryParameters, notQuery, QueryParams, convertToQueryParams } from './query'

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -58,7 +58,11 @@ import suiteAppConfigElementsFilter from './filters/suiteapp_config_elements'
 import configFeaturesFilter from './filters/config_features'
 import omitSdfUntypedValues from './filters/omit_sdf_untyped_values'
 import omitFieldsFilter from './filters/omit_fields'
+<<<<<<< HEAD
 import addFieldsToCustomRecordType from './filters/custom_record_type_fields'
+=======
+import currencyExchangeRate from './filters/currency_exchange_rate'
+>>>>>>> 73c62ebe (added filter to adapter)
 import { createFilterCreatorsWithLogs, Filter, FilterCreator } from './filter'
 import { getConfigFromConfigChanges, NetsuiteConfig, DEFAULT_DEPLOY_REFERENCED_ELEMENTS, DEFAULT_WARN_STALE_DATA, DEFAULT_USE_CHANGES_DETECTION, DEFAULT_VALIDATE } from './config'
 import { andQuery, buildNetsuiteQuery, NetsuiteQuery, NetsuiteQueryParameters, notQuery, QueryParams, convertToQueryParams } from './query'
@@ -151,6 +155,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
       dataInstancesReferences,
       dataInstancesInternalId,
       suiteAppInternalIds,
+      currencyExchangeRate,
       // AuthorInformation filters must run after SDFInternalIds filter
       systemNoteAuthorInformation,
       savedSearchesAuthorInformation,

--- a/packages/netsuite-adapter/src/change_validator.ts
+++ b/packages/netsuite-adapter/src/change_validator.ts
@@ -34,12 +34,14 @@ import undeployableConfigFeaturesValidator from './change_validators/undeployabl
 import { validateDependsOnInvalidElement } from './change_validators/dependencies'
 import notYetSupportedValuesValidator from './change_validators/not_yet_supported_values'
 import workflowAccountSpecificValuesValidator from './change_validators/workflow_account_specific_values'
+import exchangeRateValidator from './change_validators/currency_exchange_rate'
 import netsuiteClientValidation from './change_validators/client_validation'
 import NetsuiteClient from './client/client'
 import { AdditionalDependencies } from './client/types'
 
 
 const changeValidators: ChangeValidator[] = [
+  exchangeRateValidator,
   workflowAccountSpecificValuesValidator,
   accountSpecificValuesValidator,
   dataAccountSpecificValuesValidator,

--- a/packages/netsuite-adapter/src/change_validators/currency_exchange_rate.ts
+++ b/packages/netsuite-adapter/src/change_validators/currency_exchange_rate.ts
@@ -30,9 +30,9 @@ const changeValidator: ChangeValidator = async changes => (
       if (!instance.value?.exchangeRate) {
         return {
           elemID: instance.elemID,
-          severity: 'Error',
-          message: 'Currency cannot be deployed',
-          detailedMessage: '\'exchangeRate\' field must be specified when deploying a new curreny. Please edit the field at the nacl file',
+          severity: 'Warning',
+          message: 'Currency exchangeRate is set with a default value',
+          detailedMessage: 'A default value has been set for the \'exchangeRate\' field. Please edit the field at the service after deploying',
         } as ChangeError
       }
       return undefined

--- a/packages/netsuite-adapter/src/change_validators/currency_exchange_rate.ts
+++ b/packages/netsuite-adapter/src/change_validators/currency_exchange_rate.ts
@@ -14,19 +14,15 @@
 * limitations under the License.
 */
 
-import { ChangeError, ChangeValidator, getChangeData, InstanceElement, isAdditionChange, isInstanceChange } from '@salto-io/adapter-api'
+import { ChangeError, ChangeValidator } from '@salto-io/adapter-api'
 import { values } from '@salto-io/lowerdash'
-import { CURRENCY } from '../constants'
-import { DEFAULT_EXCHANGE_RATE } from '../filters/currency_exchange_rate'
+import { DEFAULT_EXCHANGE_RATE, getCurrencyAdditionsWithoutExchangeRate } from '../filters/currency_exchange_rate'
+
 
 const { isDefined } = values
 
 const changeValidator: ChangeValidator = async changes => (
-  changes
-    .filter(isInstanceChange)
-    .filter(isAdditionChange)
-    .map(change => getChangeData<InstanceElement>(change))
-    .filter(instance => instance.elemID.typeName === CURRENCY)
+  getCurrencyAdditionsWithoutExchangeRate(changes)
     .map(instance => {
       if (!instance.value?.exchangeRate) {
         return {

--- a/packages/netsuite-adapter/src/change_validators/currency_exchange_rate.ts
+++ b/packages/netsuite-adapter/src/change_validators/currency_exchange_rate.ts
@@ -32,7 +32,7 @@ const changeValidator: ChangeValidator = async changes => (
           elemID: instance.elemID,
           severity: 'Warning',
           message: 'Currency exchangeRate is set with a default value',
-          detailedMessage: 'A default value has been set for the \'exchangeRate\' field. Please edit the field at the service after deploying',
+          detailedMessage: '\'exchangeRate\' is omitted from fetch configuration by default. As this field has to be created in the target environment for this deployment to succeed, it will be deployed with a default value of 1. Please make sure this value is set to your desired value in the NetSuite UI of the target environment after deploying. See https://docs.salto.io/docs/netsuite#overriding-configuration-values for more details.',
         } as ChangeError
       }
       return undefined

--- a/packages/netsuite-adapter/src/change_validators/currency_exchange_rate.ts
+++ b/packages/netsuite-adapter/src/change_validators/currency_exchange_rate.ts
@@ -1,0 +1,44 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { ChangeError, ChangeValidator, getChangeData, InstanceElement, isAdditionChange, isInstanceChange } from '@salto-io/adapter-api'
+import { collections, values } from '@salto-io/lowerdash'
+
+const { awu } = collections.asynciterable
+const { isDefined } = values
+
+const changeValidator: ChangeValidator = async changes => (
+  awu(changes)
+    .filter(isInstanceChange)
+    .filter(isAdditionChange)
+    .filter(async change => getChangeData<InstanceElement>(change).elemID.typeName === 'currency')
+    .map(async change => {
+      const instance = getChangeData(change)
+      if (!instance.value?.exchangeRate) {
+        return {
+          elemID: instance.elemID,
+          severity: 'Error',
+          message: 'Currency cannot be deployed',
+          detailedMessage: '\'exchangeRate\' field must be specified when deploying a new curreny. Please edit the field at the nacl file',
+        } as ChangeError
+      }
+      return undefined
+    })
+    .filter(isDefined)
+    .toArray()
+)
+
+export default changeValidator

--- a/packages/netsuite-adapter/src/change_validators/currency_exchange_rate.ts
+++ b/packages/netsuite-adapter/src/change_validators/currency_exchange_rate.ts
@@ -16,6 +16,7 @@
 
 import { ChangeError, ChangeValidator } from '@salto-io/adapter-api'
 import { values } from '@salto-io/lowerdash'
+import { EXCHANGE_RATE } from '../constants'
 import { DEFAULT_EXCHANGE_RATE, getCurrencyAdditionsWithoutExchangeRate } from '../filters/currency_exchange_rate'
 
 
@@ -23,17 +24,12 @@ const { isDefined } = values
 
 const changeValidator: ChangeValidator = async changes => (
   getCurrencyAdditionsWithoutExchangeRate(changes)
-    .map(instance => {
-      if (!instance.value?.exchangeRate) {
-        return {
-          elemID: instance.elemID,
-          severity: 'Warning',
-          message: 'Currency exchangeRate is set with a default value',
-          detailedMessage: `'exchangeRate' is omitted from fetch configuration by default. As this field has to be created in the target environment for this deployment to succeed, it will be deployed with a default value of ${DEFAULT_EXCHANGE_RATE}. Please make sure this value is set to your desired value in the NetSuite UI of the target environment after deploying. See https://docs.salto.io/docs/netsuite#overriding-configuration-values for more details.`,
-        } as ChangeError
-      }
-      return undefined
-    })
+    .map(instance => ({
+      elemID: instance.elemID,
+      severity: 'Warning',
+      message: `Currency ${EXCHANGE_RATE} is set with a default value`,
+      detailedMessage: `'${EXCHANGE_RATE}' is omitted from fetch configuration by default. As this field has to be created in the target environment for this deployment to succeed, it will be deployed with a default value of ${DEFAULT_EXCHANGE_RATE}. Please make sure this value is set to your desired value in the NetSuite UI of the target environment after deploying. See https://docs.salto.io/docs/netsuite#overriding-configuration-values for more details.`,
+    } as ChangeError))
     .filter(isDefined)
 )
 

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -29,6 +29,7 @@ import {
   INSTALLED_SUITEAPPS, LOCKED_ELEMENTS_TO_EXCLUDE, AUTHOR_INFO_CONFIG, ADDITIONAL_DEPS, VALIDATE,
   STRICT_INSTANCE_STRUCTURE,
   FIELDS_TO_OMIT,
+  CURRENCY,
 } from './constants'
 import { NetsuiteQueryParameters, FetchParams, convertToQueryParams, QueryParams, FetchTypeQueryParams, FieldToOmitParams } from './query'
 import { ITEM_TYPE_TO_SEARCH_STRING, TYPES_TO_INTERNAL_ID } from './data_elements/types'
@@ -179,7 +180,7 @@ export const fetchDefault: FetchParams = {
   },
   fieldsToOmit: [
     {
-      type: 'currency',
+      type: CURRENCY,
       fields: [
         'exchangeRate',
       ],
@@ -187,7 +188,7 @@ export const fetchDefault: FetchParams = {
   ],
   [EXCLUDE]: {
     types: [
-      // Has a definition field which is a long XML and it contains   'translationScriptId'
+      // Has a definition field which is a long XML and it contains 'translationScriptId'
       // value that changes every fetch
       { name: WORKBOOK },
       // Has a definition field which is a long XML and it contains 'translationScriptId'

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -177,9 +177,17 @@ export const fetchDefault: FetchParams = {
       '^/Templates.*',
     ],
   },
+  fieldsToOmit: [
+    {
+      type: 'currency',
+      fields: [
+        'exchangeRate',
+      ],
+    },
+  ],
   [EXCLUDE]: {
     types: [
-      // Has a definition field which is a long XML and it contains 'translationScriptId'
+      // Has a definition field which is a long XML and it contains   'translationScriptId'
       // value that changes every fetch
       { name: WORKBOOK },
       // Has a definition field which is a long XML and it contains 'translationScriptId'

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -30,6 +30,7 @@ import {
   STRICT_INSTANCE_STRUCTURE,
   FIELDS_TO_OMIT,
   CURRENCY,
+  EXCHANGE_RATE,
 } from './constants'
 import { NetsuiteQueryParameters, FetchParams, convertToQueryParams, QueryParams, FetchTypeQueryParams, FieldToOmitParams } from './query'
 import { ITEM_TYPE_TO_SEARCH_STRING, TYPES_TO_INTERNAL_ID } from './data_elements/types'
@@ -182,7 +183,7 @@ export const fetchDefault: FetchParams = {
     {
       type: CURRENCY,
       fields: [
-        'exchangeRate',
+        EXCHANGE_RATE,
       ],
     },
   ],

--- a/packages/netsuite-adapter/src/constants.ts
+++ b/packages/netsuite-adapter/src/constants.ts
@@ -63,6 +63,7 @@ export const PERMITTED_ROLE = 'permittedrole'
 export const RECORD_TYPE = 'recordType'
 export const APPLICATION_ID = 'application_id'
 export const CUSTOM_FIELD_PREFIX = 'custom_'
+export const EXCHANGE_RATE = 'exchangeRate'
 
 // Field Annotations
 export const IS_ATTRIBUTE = 'isAttribute'

--- a/packages/netsuite-adapter/src/constants.ts
+++ b/packages/netsuite-adapter/src/constants.ts
@@ -49,6 +49,7 @@ export const FILE = 'file'
 export const FOLDER = 'folder'
 export const SELECT_OPTION = 'selectOption'
 export const CONFIG_FEATURES = 'companyFeatures'
+export const CURRENCY = 'currency'
 
 // Type Annotations
 export const SOURCE = 'source'

--- a/packages/netsuite-adapter/src/filters/currency_exchange_rate.ts
+++ b/packages/netsuite-adapter/src/filters/currency_exchange_rate.ts
@@ -14,19 +14,25 @@
 * limitations under the License.
 */
 
-import { getChangeData, InstanceElement, isAdditionChange, isInstanceChange } from '@salto-io/adapter-api'
+import { ChangeDataType, getChangeData, InstanceElement, isAdditionChange, isInstanceChange, Change } from '@salto-io/adapter-api'
 import { CURRENCY } from '../constants'
 import { FilterWith } from '../filter'
 
 export const DEFAULT_EXCHANGE_RATE = 1
 
+export const getCurrencyAdditionsWithoutExchangeRate = (
+  changes: readonly Change<ChangeDataType>[]
+): InstanceElement[] => (
+  changes
+    .filter(isInstanceChange)
+    .filter(isAdditionChange)
+    .map(change => getChangeData<InstanceElement>(change))
+    .filter(instance => instance.elemID.typeName === CURRENCY)
+)
+
 const filterCreator = (): FilterWith<'preDeploy'> => ({
   preDeploy: async changes => {
-    changes
-      .filter(isInstanceChange)
-      .filter(isAdditionChange)
-      .map(change => getChangeData<InstanceElement>(change))
-      .filter(instance => instance.elemID.typeName === CURRENCY)
+    getCurrencyAdditionsWithoutExchangeRate(changes)
       .map(instance => {
         if (!instance.value?.exchangeRate) {
           instance.value.exchangeRate = DEFAULT_EXCHANGE_RATE

--- a/packages/netsuite-adapter/src/filters/currency_exchange_rate.ts
+++ b/packages/netsuite-adapter/src/filters/currency_exchange_rate.ts
@@ -28,16 +28,16 @@ export const getCurrencyAdditionsWithoutExchangeRate = (
     .filter(isAdditionChange)
     .map(change => getChangeData<InstanceElement>(change))
     .filter(instance => instance.elemID.typeName === CURRENCY)
+    .filter(instance => !instance.value.exchangeRate)
 )
 
 const filterCreator = (): FilterWith<'preDeploy'> => ({
   preDeploy: async changes => {
     getCurrencyAdditionsWithoutExchangeRate(changes)
-      .map(instance => {
+      .forEach(instance => {
         if (!instance.value?.exchangeRate) {
           instance.value.exchangeRate = DEFAULT_EXCHANGE_RATE
         }
-        return instance
       })
   },
 })

--- a/packages/netsuite-adapter/src/filters/currency_exchange_rate.ts
+++ b/packages/netsuite-adapter/src/filters/currency_exchange_rate.ts
@@ -14,20 +14,18 @@
 * limitations under the License.
 */
 
-import { collections } from '@salto-io/lowerdash'
 import { getChangeData, isAdditionChange, isInstanceChange } from '@salto-io/adapter-api'
 import { FilterWith } from '../filter'
 
-const { awu } = collections.asynciterable
-const DEFAULT_EXCHANGE_RATE = 1
+export const DEFAULT_EXCHANGE_RATE = 1
 
 const filterCreator = (): FilterWith<'onDeploy'> => ({
   onDeploy: async changes => {
-    awu(changes)
+    (changes)
       .filter(isInstanceChange)
       .filter(isAdditionChange)
-      .filter(async change => getChangeData(change).elemID.typeName === 'currency')
-      .map(async change => {
+      .filter(change => getChangeData(change).elemID.typeName === 'currency')
+      .forEach(change => {
         const instance = getChangeData(change)
         if (!instance.value?.exchangeRate) {
           instance.value.exchangeRate = DEFAULT_EXCHANGE_RATE

--- a/packages/netsuite-adapter/src/filters/currency_exchange_rate.ts
+++ b/packages/netsuite-adapter/src/filters/currency_exchange_rate.ts
@@ -14,22 +14,24 @@
 * limitations under the License.
 */
 
-import { getChangeData, isAdditionChange, isInstanceChange } from '@salto-io/adapter-api'
+import { getChangeData, InstanceElement, isAdditionChange, isInstanceChange } from '@salto-io/adapter-api'
+import { CURRENCY } from '../constants'
 import { FilterWith } from '../filter'
 
 export const DEFAULT_EXCHANGE_RATE = 1
 
-const filterCreator = (): FilterWith<'onDeploy'> => ({
-  onDeploy: async changes => {
-    (changes)
+const filterCreator = (): FilterWith<'preDeploy'> => ({
+  preDeploy: async changes => {
+    changes
       .filter(isInstanceChange)
       .filter(isAdditionChange)
-      .filter(change => getChangeData(change).elemID.typeName === 'currency')
-      .forEach(change => {
-        const instance = getChangeData(change)
+      .map(change => getChangeData<InstanceElement>(change))
+      .filter(instance => instance.elemID.typeName === CURRENCY)
+      .map(instance => {
         if (!instance.value?.exchangeRate) {
           instance.value.exchangeRate = DEFAULT_EXCHANGE_RATE
         }
+        return instance
       })
   },
 })

--- a/packages/netsuite-adapter/src/filters/currency_exchange_rate.ts
+++ b/packages/netsuite-adapter/src/filters/currency_exchange_rate.ts
@@ -14,30 +14,28 @@
 * limitations under the License.
 */
 
-import { ChangeDataType, getChangeData, InstanceElement, isAdditionChange, isInstanceChange, Change } from '@salto-io/adapter-api'
-import { CURRENCY } from '../constants'
+import { getChangeData, InstanceElement, isAdditionChange, isInstanceChange, Change } from '@salto-io/adapter-api'
+import { CURRENCY, EXCHANGE_RATE } from '../constants'
 import { FilterWith } from '../filter'
 
 export const DEFAULT_EXCHANGE_RATE = 1
 
 export const getCurrencyAdditionsWithoutExchangeRate = (
-  changes: readonly Change<ChangeDataType>[]
+  changes: ReadonlyArray<Change>
 ): InstanceElement[] => (
   changes
     .filter(isInstanceChange)
     .filter(isAdditionChange)
-    .map(change => getChangeData<InstanceElement>(change))
+    .map(getChangeData)
     .filter(instance => instance.elemID.typeName === CURRENCY)
-    .filter(instance => !instance.value.exchangeRate)
+    .filter(instance => !instance.value[EXCHANGE_RATE])
 )
 
 const filterCreator = (): FilterWith<'preDeploy'> => ({
   preDeploy: async changes => {
     getCurrencyAdditionsWithoutExchangeRate(changes)
       .forEach(instance => {
-        if (!instance.value?.exchangeRate) {
-          instance.value.exchangeRate = DEFAULT_EXCHANGE_RATE
-        }
+        instance.value[EXCHANGE_RATE] = DEFAULT_EXCHANGE_RATE
       })
   },
 })

--- a/packages/netsuite-adapter/src/filters/currency_exchange_rate.ts
+++ b/packages/netsuite-adapter/src/filters/currency_exchange_rate.ts
@@ -1,0 +1,39 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { collections } from '@salto-io/lowerdash'
+import { getChangeData, isAdditionChange, isInstanceChange } from '@salto-io/adapter-api'
+import { FilterWith } from '../filter'
+
+const { awu } = collections.asynciterable
+const DEFAULT_EXCHANGE_RATE = 1
+
+const filterCreator = (): FilterWith<'onDeploy'> => ({
+  onDeploy: async changes => {
+    awu(changes)
+      .filter(isInstanceChange)
+      .filter(isAdditionChange)
+      .filter(async change => getChangeData(change).elemID.typeName === 'currency')
+      .map(async change => {
+        const instance = getChangeData(change)
+        if (!instance.value?.exchangeRate) {
+          instance.value.exchangeRate = DEFAULT_EXCHANGE_RATE
+        }
+      })
+  },
+})
+
+export default filterCreator

--- a/packages/netsuite-adapter/test/change_validators/currency_exchange_rate.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/currency_exchange_rate.test.ts
@@ -22,26 +22,28 @@ import currencyExchangeRateValidator from '../../src/change_validators/currency_
 const currencyType = new ObjectType({ elemID: new ElemID(NETSUITE, CURRENCY) })
 
 describe('currency exchange rate validator', () => {
-  const instance = new InstanceElement(
-    'currency',
-    currencyType,
-    {
-      name: 'Canadian Dollar',
-      symbol: 'CAD',
-      isBaseCurrency: false,
-      isInactive: false,
-      overrideCurrencyFormat: false,
-      displaySymbol: '$',
-      symbolPlacement: '_beforeNumber',
-      exchangeRate: 40.35,
-    }
-  )
+  let instance: InstanceElement
+  beforeEach(() => {
+    instance = new InstanceElement(
+      'currency',
+      currencyType,
+      {
+        name: 'Canadian Dollar',
+        symbol: 'CAD',
+        isBaseCurrency: false,
+        isInactive: false,
+        overrideCurrencyFormat: false,
+        displaySymbol: '$',
+        symbolPlacement: '_beforeNumber',
+        exchangeRate: 40.35,
+      }
+    )
+  })
 
   it('should have changeError when exchangeRate isn\'t specified', async () => {
-    const after = instance.clone()
-    delete after.value.exchangeRate
+    delete instance.value.exchangeRate
     const changeErrors = await currencyExchangeRateValidator(
-      [toChange({ after })]
+      [toChange({ after: instance })]
     )
     expect(changeErrors).toHaveLength(1)
     expect(changeErrors[0].severity).toEqual('Warning')
@@ -50,9 +52,8 @@ describe('currency exchange rate validator', () => {
   })
 
   it('should not have changeError when exchangeRate is specified', async () => {
-    const after = instance.clone()
     const changeErrors = await currencyExchangeRateValidator(
-      [toChange({ after })]
+      [toChange({ after: instance })]
     )
     expect(changeErrors).toHaveLength(0)
   })

--- a/packages/netsuite-adapter/test/change_validators/currency_exchange_rate.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/currency_exchange_rate.test.ts
@@ -87,7 +87,7 @@ describe('currency exchange rate validator', () => {
     expect(changeErrors[0].detailedMessage).toContain('\'exchangeRate\' is omitted from fetch')
   })
 
-  it('should not have changeError when exchangeRate isn\'t specified', async () => {
+  it('should not have changeError when exchangeRate is specified', async () => {
     const after = instance.clone()
     const changeErrors = await currencyExchangeRateValidator(
       [toChange({ after })]

--- a/packages/netsuite-adapter/test/change_validators/currency_exchange_rate.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/currency_exchange_rate.test.ts
@@ -14,50 +14,12 @@
 * limitations under the License.
 */
 
-import { BuiltinTypes, ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
-import { NETSUITE } from '../../src/constants'
+import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import { CURRENCY, EXCHANGE_RATE, NETSUITE } from '../../src/constants'
 import currencyExchangeRateValidator from '../../src/change_validators/currency_exchange_rate'
 
 
-export const currencyType = new ObjectType({
-  elemID: new ElemID(NETSUITE, 'currency'),
-  fields: {
-    name: {
-      refType: BuiltinTypes.STRING,
-    },
-    symbol: {
-      refType: BuiltinTypes.STRING,
-    },
-    isBaseCurrency: {
-      refType: BuiltinTypes.BOOLEAN,
-    },
-    isInactive: {
-      refType: BuiltinTypes.BOOLEAN,
-    },
-    overrideCurrencyFormat: {
-      refType: BuiltinTypes.BOOLEAN,
-    },
-    displaySymbol: {
-      refType: BuiltinTypes.STRING,
-    },
-    symbolPlacement: {
-      refType: BuiltinTypes.STRING,
-    },
-    locale: {
-      refType: BuiltinTypes.STRING,
-    },
-    formatSample: {
-      refType: BuiltinTypes.STRING,
-    },
-    exchangeRate: {
-      refType: BuiltinTypes.NUMBER,
-    },
-    currencyPrecision: {
-      refType: BuiltinTypes.STRING,
-    },
-  },
-  annotations: { source: 'soap' },
-})
+const currencyType = new ObjectType({ elemID: new ElemID(NETSUITE, CURRENCY) })
 
 describe('currency exchange rate validator', () => {
   const instance = new InstanceElement(
@@ -84,7 +46,7 @@ describe('currency exchange rate validator', () => {
     expect(changeErrors).toHaveLength(1)
     expect(changeErrors[0].severity).toEqual('Warning')
     expect(changeErrors[0].elemID).toEqual(instance.elemID)
-    expect(changeErrors[0].detailedMessage).toContain('\'exchangeRate\' is omitted from fetch')
+    expect(changeErrors[0].detailedMessage).toContain(`'${EXCHANGE_RATE}' is omitted from fetch`)
   })
 
   it('should not have changeError when exchangeRate is specified', async () => {

--- a/packages/netsuite-adapter/test/change_validators/currency_exchange_rate.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/currency_exchange_rate.test.ts
@@ -19,7 +19,7 @@ import { NETSUITE } from '../../src/constants'
 import currencyExchangeRateValidator from '../../src/change_validators/currency_exchange_rate'
 
 
-const currencyType = new ObjectType({
+export const currencyType = new ObjectType({
   elemID: new ElemID(NETSUITE, 'currency'),
   fields: {
     name: {
@@ -82,9 +82,9 @@ describe('currency exchange rate validator', () => {
       [toChange({ after })]
     )
     expect(changeErrors).toHaveLength(1)
-    expect(changeErrors[0].severity).toEqual('Error')
+    expect(changeErrors[0].severity).toEqual('Warning')
     expect(changeErrors[0].elemID).toEqual(instance.elemID)
-    expect(changeErrors[0].detailedMessage).toContain('\'exchangeRate\' field must be specified when deploying a new curreny')
+    expect(changeErrors[0].detailedMessage).toContain('\'exchangeRate\' is omitted from fetch')
   })
 
   it('should not have changeError when exchangeRate isn\'t specified', async () => {

--- a/packages/netsuite-adapter/test/change_validators/currency_exchange_rate.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/currency_exchange_rate.test.ts
@@ -75,7 +75,7 @@ describe('currency exchange rate validator', () => {
     }
   )
 
-  it('shoulde have changeError when exchangeRate isn\'t specified', async () => {
+  it('should have changeError when exchangeRate isn\'t specified', async () => {
     const after = instance.clone()
     delete after.value.exchangeRate
     const changeErrors = await currencyExchangeRateValidator(
@@ -85,5 +85,13 @@ describe('currency exchange rate validator', () => {
     expect(changeErrors[0].severity).toEqual('Error')
     expect(changeErrors[0].elemID).toEqual(instance.elemID)
     expect(changeErrors[0].detailedMessage).toContain('\'exchangeRate\' field must be specified when deploying a new curreny')
+  })
+
+  it('should not have changeError when exchangeRate isn\'t specified', async () => {
+    const after = instance.clone()
+    const changeErrors = await currencyExchangeRateValidator(
+      [toChange({ after })]
+    )
+    expect(changeErrors).toHaveLength(0)
   })
 })

--- a/packages/netsuite-adapter/test/change_validators/currency_exchange_rate.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/currency_exchange_rate.test.ts
@@ -1,0 +1,89 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { BuiltinTypes, ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import { NETSUITE } from '../../src/constants'
+import currencyExchangeRateValidator from '../../src/change_validators/currency_exchange_rate'
+
+
+const currencyType = new ObjectType({
+  elemID: new ElemID(NETSUITE, 'currency'),
+  fields: {
+    name: {
+      refType: BuiltinTypes.STRING,
+    },
+    symbol: {
+      refType: BuiltinTypes.STRING,
+    },
+    isBaseCurrency: {
+      refType: BuiltinTypes.BOOLEAN,
+    },
+    isInactive: {
+      refType: BuiltinTypes.BOOLEAN,
+    },
+    overrideCurrencyFormat: {
+      refType: BuiltinTypes.BOOLEAN,
+    },
+    displaySymbol: {
+      refType: BuiltinTypes.STRING,
+    },
+    symbolPlacement: {
+      refType: BuiltinTypes.STRING,
+    },
+    locale: {
+      refType: BuiltinTypes.STRING,
+    },
+    formatSample: {
+      refType: BuiltinTypes.STRING,
+    },
+    exchangeRate: {
+      refType: BuiltinTypes.NUMBER,
+    },
+    currencyPrecision: {
+      refType: BuiltinTypes.STRING,
+    },
+  },
+  annotations: { source: 'soap' },
+})
+
+describe('currency exchange rate validator', () => {
+  const instance = new InstanceElement(
+    'currency',
+    currencyType,
+    {
+      name: 'Canadian Dollar',
+      symbol: 'CAD',
+      isBaseCurrency: false,
+      isInactive: false,
+      overrideCurrencyFormat: false,
+      displaySymbol: '$',
+      symbolPlacement: '_beforeNumber',
+      exchangeRate: 40.35,
+    }
+  )
+
+  it('shoulde have changeError when exchangeRate isn\'t specified', async () => {
+    const after = instance.clone()
+    delete after.value.exchangeRate
+    const changeErrors = await currencyExchangeRateValidator(
+      [toChange({ after })]
+    )
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0].severity).toEqual('Error')
+    expect(changeErrors[0].elemID).toEqual(instance.elemID)
+    expect(changeErrors[0].detailedMessage).toContain('\'exchangeRate\' field must be specified when deploying a new curreny')
+  })
+})

--- a/packages/netsuite-adapter/test/filters/currency_exchange_rate.test.ts
+++ b/packages/netsuite-adapter/test/filters/currency_exchange_rate.test.ts
@@ -1,0 +1,50 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { getChangeData, InstanceElement, toChange } from '@salto-io/adapter-api'
+import { currencyType } from '../change_validators/currency_exchange_rate.test'
+import filterCreator, { DEFAULT_EXCHANGE_RATE } from '../../src/filters/currency_exchange_rate'
+
+describe('currency exchange rate filter', () => {
+  const instance = new InstanceElement(
+    'currency',
+    currencyType,
+    {
+      name: 'Canadian Dollar',
+      symbol: 'CAD',
+      isBaseCurrency: false,
+      isInactive: false,
+      overrideCurrencyFormat: false,
+      displaySymbol: '$',
+      symbolPlacement: '_beforeNumber',
+    }
+  )
+
+  it('should not change instance when exchange rate is specified', async () => {
+    const after = instance.clone()
+    after.value.exchangeRate = 0.35
+    const change = toChange({ after })
+    await filterCreator().onDeploy([change], { errors: [new Error('error')], appliedChanges: [] })
+    expect(getChangeData(change).value).toEqual(after.value)
+  })
+
+  it('should insert exchang rate with default value when it is not specified', async () => {
+    const after = instance.clone()
+    const change = toChange({ after })
+    await filterCreator().onDeploy([change], { errors: [new Error('error')], appliedChanges: [] })
+    expect(getChangeData(change).value.exchangeRate).toEqual(DEFAULT_EXCHANGE_RATE)
+  })
+})

--- a/packages/netsuite-adapter/test/filters/currency_exchange_rate.test.ts
+++ b/packages/netsuite-adapter/test/filters/currency_exchange_rate.test.ts
@@ -17,10 +17,11 @@
 import { getChangeData, InstanceElement, toChange } from '@salto-io/adapter-api'
 import { currencyType } from '../change_validators/currency_exchange_rate.test'
 import filterCreator, { DEFAULT_EXCHANGE_RATE } from '../../src/filters/currency_exchange_rate'
+import { CURRENCY } from '../../src/constants'
 
 describe('currency exchange rate filter', () => {
   const instance = new InstanceElement(
-    'currency',
+    CURRENCY,
     currencyType,
     {
       name: 'Canadian Dollar',
@@ -37,14 +38,14 @@ describe('currency exchange rate filter', () => {
     const after = instance.clone()
     after.value.exchangeRate = 0.35
     const change = toChange({ after })
-    await filterCreator().onDeploy([change], { errors: [new Error('error')], appliedChanges: [] })
+    await filterCreator().preDeploy([change])
     expect(getChangeData(change).value).toEqual(after.value)
   })
 
   it('should insert exchang rate with default value when it is not specified', async () => {
     const after = instance.clone()
     const change = toChange({ after })
-    await filterCreator().onDeploy([change], { errors: [new Error('error')], appliedChanges: [] })
+    await filterCreator().preDeploy([change])
     expect(getChangeData(change).value.exchangeRate).toEqual(DEFAULT_EXCHANGE_RATE)
   })
 })

--- a/packages/netsuite-adapter/test/filters/currency_exchange_rate.test.ts
+++ b/packages/netsuite-adapter/test/filters/currency_exchange_rate.test.ts
@@ -21,31 +21,32 @@ import { CURRENCY, NETSUITE } from '../../src/constants'
 const currencyType = new ObjectType({ elemID: new ElemID(NETSUITE, CURRENCY) })
 
 describe('currency exchange rate filter', () => {
-  const instance = new InstanceElement(
-    CURRENCY,
-    currencyType,
-    {
-      name: 'Canadian Dollar',
-      symbol: 'CAD',
-      isBaseCurrency: false,
-      isInactive: false,
-      overrideCurrencyFormat: false,
-      displaySymbol: '$',
-      symbolPlacement: '_beforeNumber',
-    }
-  )
+  let instance: InstanceElement
+  beforeEach(() => {
+    instance = new InstanceElement(
+      CURRENCY,
+      currencyType,
+      {
+        name: 'Canadian Dollar',
+        symbol: 'CAD',
+        isBaseCurrency: false,
+        isInactive: false,
+        overrideCurrencyFormat: false,
+        displaySymbol: '$',
+        symbolPlacement: '_beforeNumber',
+      }
+    )
+  })
 
   it('should not change instance when exchange rate is specified', async () => {
-    const after = instance.clone()
-    after.value.exchangeRate = 0.35
-    const change = toChange({ after })
+    instance.value.exchangeRate = 0.35
+    const change = toChange({ after: instance })
     await filterCreator().preDeploy([change])
-    expect(getChangeData(change).value).toEqual(after.value)
+    expect(getChangeData(change).value.exchangeRate).toEqual(0.35)
   })
 
   it('should insert exchang rate with default value when it is not specified', async () => {
-    const after = instance.clone()
-    const change = toChange({ after })
+    const change = toChange({ after: instance })
     await filterCreator().preDeploy([change])
     expect(getChangeData(change).value.exchangeRate).toEqual(DEFAULT_EXCHANGE_RATE)
   })

--- a/packages/netsuite-adapter/test/filters/currency_exchange_rate.test.ts
+++ b/packages/netsuite-adapter/test/filters/currency_exchange_rate.test.ts
@@ -14,10 +14,11 @@
 * limitations under the License.
 */
 
-import { getChangeData, InstanceElement, toChange } from '@salto-io/adapter-api'
-import { currencyType } from '../change_validators/currency_exchange_rate.test'
+import { ElemID, getChangeData, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
 import filterCreator, { DEFAULT_EXCHANGE_RATE } from '../../src/filters/currency_exchange_rate'
-import { CURRENCY } from '../../src/constants'
+import { CURRENCY, NETSUITE } from '../../src/constants'
+
+const currencyType = new ObjectType({ elemID: new ElemID(NETSUITE, CURRENCY) })
 
 describe('currency exchange rate filter', () => {
   const instance = new InstanceElement(


### PR DESCRIPTION
_suppressd noisy exchange rate changes_

---

_None_

---
_Release Notes_: 
_Netsuite Adapter_:
* exchangeRate will not be fetched by default 
* when deploying a new currency without exchangeRate a default value will be set

---
_User Notifications_: 
_exchangeRate will not appear in the nacl by default_
