### PR TITLE
SALTO-820 workato: fix netsuite customrecordtype references

### DIFF
--- a/packages/workato-adapter/src/filters/cross_service/netsuite/element_index.ts
+++ b/packages/workato-adapter/src/filters/cross_service/netsuite/element_index.ts
@@ -13,28 +13,25 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Element, ElemID, InstanceElement, isInstanceElement, isObjectType, ObjectType } from '@salto-io/adapter-api'
-import { values } from '@salto-io/lowerdash'
-import { logger } from '@salto-io/logging'
 import _ from 'lodash'
-
-const log = logger(module)
-const { isPlainRecord, isDefined } = values
+import { Element, ElemID, isInstanceElement, isObjectType, ObjectType } from '@salto-io/adapter-api'
 
 export type NetsuiteIndex = {
   scriptId: Record<string, ElemID>
   type: Record<string, Readonly<ObjectType>>
 }
 
+const METADATA_TYPE_ANNOTATION = 'metadataType'
 const CUSTOM_RECORD_TYPE = 'customrecordtype'
-const CUSTOM_RECORD_CUSTOM_FIELDS = 'customrecordcustomfields'
-const CUSTOM_RECORD_CUSTOM_FIELD = 'customrecordcustomfield'
+const CUSTOM_FIELD_PREFIX = 'custom_'
 
 export const indexNetsuiteByTypeAndScriptId = (
   elements: ReadonlyArray<Readonly<Element>>
 ): NetsuiteIndex => {
   const indexInstancesByScriptId = (): Record<string, ElemID> => {
-    const toScriptId = (inst: Readonly<InstanceElement>): string | undefined => inst.value.scriptid
+    const toScriptId = (element: Readonly<Element>): string | undefined => (
+      isInstanceElement(element) ? element.value.scriptid : element.annotations.scriptid
+    )
     const instances = elements.filter(isInstanceElement)
 
     const instanceIndex = _.mapValues(
@@ -45,41 +42,21 @@ export const indexNetsuiteByTypeAndScriptId = (
       e => e.elemID,
     )
 
-    const customRecordTypeInstances = instances.filter(
-      inst => inst.elemID.typeName === CUSTOM_RECORD_TYPE
-    )
-    const nestedFields = (
-      customRecordTypeInstances
-        .flatMap(inst => (
-          Object.entries(
-            inst.value[CUSTOM_RECORD_CUSTOM_FIELDS]?.[CUSTOM_RECORD_CUSTOM_FIELD] ?? {}
-          ).map(([key, item]) => {
-            if (!isPlainRecord(item)) {
-              log.warn(
-                '%s is not a plain object as expected: %o',
-                inst.elemID.createNestedID(
-                  CUSTOM_RECORD_CUSTOM_FIELDS, CUSTOM_RECORD_CUSTOM_FIELD, key
-                ).getFullName(),
-                item
-              )
-              return undefined
-            }
-            return {
-              scriptId: item.scriptid,
-              nestedPath: inst.elemID.createNestedID(
-                CUSTOM_RECORD_CUSTOM_FIELDS,
-                CUSTOM_RECORD_CUSTOM_FIELD,
-                key,
-              ),
-            }
-          }).filter(isDefined)))
-    )
-    // TODO these should be replaced by maps or nested fields under custom objects - see SALTO-1078
-    const customRecordTypeNestedFieldIndex = Object.fromEntries(
-      nestedFields.map(f => [f.scriptId, f.nestedPath])
-    )
+    const customRecordTypes = elements
+      .filter(isObjectType)
+      .filter(element => element.annotations[METADATA_TYPE_ANNOTATION] === CUSTOM_RECORD_TYPE)
+    const customRecordTypeIndex = Object.fromEntries(customRecordTypes
+      .filter(e => toScriptId(e) !== undefined)
+      .map(type => [toScriptId(type), type.elemID]))
+    const customRecordTypeNestedFieldIndex = Object.fromEntries(customRecordTypes
+      .flatMap(type => Object.values(type.fields)
+        .filter(field => field.name.startsWith(CUSTOM_FIELD_PREFIX)
+          && toScriptId(field) !== undefined)
+        .map(field => [toScriptId(field), field.elemID])))
+
     return {
       ...instanceIndex,
+      ...customRecordTypeIndex,
       ...customRecordTypeNestedFieldIndex,
     }
   }

--- a/packages/workato-adapter/test/filters/recipe_references.test.ts
+++ b/packages/workato-adapter/test/filters/recipe_references.test.ts
@@ -854,24 +854,27 @@ describe('Recipe references filter', () => {
   }
   const generateNetsuiteElements = (): Element[] => {
     const customRecordType = new ObjectType({
-      elemID: new ElemID('netsuite', 'customrecordtype'),
-      fields: {},
-    })
-    const myCustomRecord = new InstanceElement(
-      'customrecord16',
-      customRecordType,
-      {
+      elemID: new ElemID('netsuite', 'customrecord16'),
+      fields: {
+        custom_custrecord5: {
+          refType: BuiltinTypes.STRING,
+          annotations: { scriptid: 'custrecord5' },
+        },
+        custom_somethingelse: {
+          refType: BuiltinTypes.STRING,
+          annotations: { scriptid: 'somethingelse' },
+        },
+        custom_custrecordaccount_id: {
+          refType: BuiltinTypes.STRING,
+          annotations: { scriptid: 'custrecordaccount_id' },
+        },
+      },
+      annotations: {
         scriptid: 'customrecord16',
         recordname: 'my custom record',
-        customrecordcustomfields: {
-          customrecordcustomfield: {
-            custrecord5: { scriptid: 'custrecord5', index: 0 },
-            somethingelse: { scriptid: 'somethingelse', index: 1 },
-            custrecordaccount_id: { scriptid: 'custrecordaccount_id', index: 2 },
-          },
-        },
-      }
-    )
+        metadataType: 'customrecordtype',
+      },
+    })
 
     const otherCustomFieldType = new ObjectType({
       elemID: new ElemID('netsuite', 'othercustomfield'),
@@ -913,7 +916,7 @@ describe('Recipe references filter', () => {
     })
 
     return [
-      customRecordType, myCustomRecord,
+      customRecordType,
       otherCustomFieldType, otherCustomFieldInst,
       entitycustomfieldType, entitycustomfieldInst,
       customerType, opportunityType,
@@ -1020,9 +1023,9 @@ describe('Recipe references filter', () => {
         expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES].map(
           dereferenceDep
         )).toEqual([
-          { reference: 'netsuite.customrecordtype.instance.customrecord16', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.block.0', direction: 'output' }] },
-          { reference: 'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.custrecord5', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.input.Custom__c', direction: 'input' }] },
-          { reference: 'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.custrecordaccount_id', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.input.Custom__c', direction: 'input' }] },
+          { reference: 'netsuite.customrecord16', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.block.0', direction: 'output' }] },
+          { reference: 'netsuite.customrecord16.field.custom_custrecord5', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.input.Custom__c', direction: 'input' }] },
+          { reference: 'netsuite.customrecord16.field.custom_custrecordaccount_id', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.input.Custom__c', direction: 'input' }] },
           { reference: 'netsuite.entitycustomfield.instance.custentitycustom_account_city', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.input.Custom__c', direction: 'input' }] },
           { reference: 'netsuite.othercustomfield.instance.custrecord2', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.block.0', direction: 'output' }] },
           { reference: 'salesforce.MyCustom__c', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.block.0.block.0', direction: 'output' }] },
@@ -1095,7 +1098,7 @@ describe('Recipe references filter', () => {
         expect(block1.input.netsuite_object).toBeInstanceOf(
           ReferenceExpression
         )
-        expect(block1.input.netsuite_object.elemID.getFullName()).toEqual('netsuite.customrecordtype.instance.customrecord16')
+        expect(block1.input.netsuite_object.elemID.getFullName()).toEqual('netsuite.customrecord16')
         const block2 = block1.block[0]
         expect(block2.input.sobject_name).toBeInstanceOf(
           ReferenceExpression
@@ -1131,9 +1134,9 @@ describe('Recipe references filter', () => {
         expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES].map(
           dereferenceDep
         )).toEqual([
-          { reference: 'netsuite.customrecordtype.instance.customrecord16', occurrences: [{ location: 'workato.recipe__code.instance.recipe3_code.block.0', direction: 'output' }] },
-          { reference: 'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.custrecord5', occurrences: [{ location: 'workato.recipe__code.instance.recipe3_code.input.Custom__c', direction: 'input' }] },
-          { reference: 'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.custrecordaccount_id', occurrences: [{ location: 'workato.recipe__code.instance.recipe3_code.input.Custom__c', direction: 'input' }] },
+          { reference: 'netsuite.customrecord16', occurrences: [{ location: 'workato.recipe__code.instance.recipe3_code.block.0', direction: 'output' }] },
+          { reference: 'netsuite.customrecord16.field.custom_custrecord5', occurrences: [{ location: 'workato.recipe__code.instance.recipe3_code.input.Custom__c', direction: 'input' }] },
+          { reference: 'netsuite.customrecord16.field.custom_custrecordaccount_id', occurrences: [{ location: 'workato.recipe__code.instance.recipe3_code.input.Custom__c', direction: 'input' }] },
           { reference: 'netsuite.entitycustomfield.instance.custentitycustom_account_city', occurrences: [{ location: 'workato.recipe__code.instance.recipe3_code.input.Custom__c', direction: 'input' }] },
           { reference: 'netsuite.othercustomfield.instance.custrecord2', occurrences: [{ location: 'workato.recipe__code.instance.recipe3_code.block.0', direction: 'output' }] },
         ])
@@ -1165,7 +1168,7 @@ describe('Recipe references filter', () => {
         expect(block1.input.netsuite_object).toBeInstanceOf(
           ReferenceExpression
         )
-        expect(block1.input.netsuite_object.elemID.getFullName()).toEqual('netsuite.customrecordtype.instance.customrecord16')
+        expect(block1.input.netsuite_object.elemID.getFullName()).toEqual('netsuite.customrecord16')
       })
     })
 
@@ -1378,14 +1381,14 @@ describe('Recipe references filter', () => {
           .flatMap(e => e.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES] ?? [])
           .map(dereferenceDep)
       ).toEqual([
-        { reference: 'netsuite.customrecordtype.instance.customrecord16', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.block.0', direction: 'output' }] },
-        { reference: 'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.custrecord5', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.input.Custom__c', direction: 'input' }] },
-        { reference: 'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.custrecordaccount_id', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.input.Custom__c', direction: 'input' }] },
+        { reference: 'netsuite.customrecord16', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.block.0', direction: 'output' }] },
+        { reference: 'netsuite.customrecord16.field.custom_custrecord5', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.input.Custom__c', direction: 'input' }] },
+        { reference: 'netsuite.customrecord16.field.custom_custrecordaccount_id', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.input.Custom__c', direction: 'input' }] },
         { reference: 'netsuite.entitycustomfield.instance.custentitycustom_account_city', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.input.Custom__c', direction: 'input' }] },
         { reference: 'netsuite.othercustomfield.instance.custrecord2', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.block.0', direction: 'output' }] },
-        { reference: 'netsuite.customrecordtype.instance.customrecord16', occurrences: [{ location: 'workato.recipe__code.instance.recipe3_code.block.0', direction: 'output' }] },
-        { reference: 'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.custrecord5', occurrences: [{ location: 'workato.recipe__code.instance.recipe3_code.input.Custom__c', direction: 'input' }] },
-        { reference: 'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.custrecordaccount_id', occurrences: [{ location: 'workato.recipe__code.instance.recipe3_code.input.Custom__c', direction: 'input' }] },
+        { reference: 'netsuite.customrecord16', occurrences: [{ location: 'workato.recipe__code.instance.recipe3_code.block.0', direction: 'output' }] },
+        { reference: 'netsuite.customrecord16.field.custom_custrecord5', occurrences: [{ location: 'workato.recipe__code.instance.recipe3_code.input.Custom__c', direction: 'input' }] },
+        { reference: 'netsuite.customrecord16.field.custom_custrecordaccount_id', occurrences: [{ location: 'workato.recipe__code.instance.recipe3_code.input.Custom__c', direction: 'input' }] },
         { reference: 'netsuite.entitycustomfield.instance.custentitycustom_account_city', occurrences: [{ location: 'workato.recipe__code.instance.recipe3_code.input.Custom__c', direction: 'input' }] },
         { reference: 'netsuite.othercustomfield.instance.custrecord2', occurrences: [{ location: 'workato.recipe__code.instance.recipe3_code.block.0', direction: 'output' }] },
         { reference: 'netsuite.Customer', occurrences: [{ location: 'workato.recipe__code.instance.recipe6_code', direction: 'input' }] },
@@ -1454,9 +1457,9 @@ describe('Recipe references filter', () => {
         expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES].map(
           dereferenceDep
         )).toEqual([
-          { reference: 'netsuite.customrecordtype.instance.customrecord16', occurrences: [{ location: 'workato.recipe__code.instance.recipe5_code.block.0', direction: 'output' }] },
-          { reference: 'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.custrecord5', occurrences: [{ location: 'workato.recipe__code.instance.recipe5_code.input.Custom__c', direction: 'input' }] },
-          { reference: 'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.custrecordaccount_id', occurrences: [{ location: 'workato.recipe__code.instance.recipe5_code.input.Custom__c', direction: 'input' }] },
+          { reference: 'netsuite.customrecord16', occurrences: [{ location: 'workato.recipe__code.instance.recipe5_code.block.0', direction: 'output' }] },
+          { reference: 'netsuite.customrecord16.field.custom_custrecord5', occurrences: [{ location: 'workato.recipe__code.instance.recipe5_code.input.Custom__c', direction: 'input' }] },
+          { reference: 'netsuite.customrecord16.field.custom_custrecordaccount_id', occurrences: [{ location: 'workato.recipe__code.instance.recipe5_code.input.Custom__c', direction: 'input' }] },
           { reference: 'netsuite.entitycustomfield.instance.custentitycustom_account_city', occurrences: [{ location: 'workato.recipe__code.instance.recipe5_code.input.Custom__c', direction: 'input' }] },
           { reference: 'netsuite.othercustomfield.instance.custrecord2', occurrences: [{ location: 'workato.recipe__code.instance.recipe5_code.block.0', direction: 'output' }] },
           { reference: 'salesforce.MyCustom__c', occurrences: [{ location: 'workato.recipe__code.instance.recipe5_code.block.0.block.0', direction: 'output' }] },


### PR DESCRIPTION
When [SALTO-820](https://github.com/salto-io/salto/pull/3313) is merged, all references to `netsuite.customrecordtype` instances & custom fields (inside the instance) should be replaced with references to custom record types & fields.

---
_Release Notes_: 
Workato Adapter:
- Fix Netsuite `customrecordtype` references

---
_User Notifications_: 
Workato Adapter:
- References to `netsuite.customrecordtype` instances & custom fields (inside the instance) will be replaced with references to custom record types & fields (e.g. `netsuite.customrecord1`, `netsuite.customrecord1.field.custom_custrecord_field`)