### PR TITLE
SALTO-2120

### DIFF
--- a/packages/cli/src/callbacks.ts
+++ b/packages/cli/src/callbacks.ts
@@ -30,7 +30,8 @@ import {
   formatNotChangingFetchMode,
 } from './formatter'
 import Prompts from './prompts'
-import { CliOutput, WriteStream } from './types'
+import { CliOutput } from './types'
+import { outputLine } from './outputer'
 
 const { awu } = collections.asynciterable
 export const getUserBooleanInput = async (prompt: string): Promise<boolean> => {
@@ -183,9 +184,9 @@ export const getCredentialsFromUser = async (credentialsType: ObjectType):
   return new InstanceElement(ElemID.CONFIG_NAME, credentialsType, values)
 }
 
-export const getConfigWithHeader = async (output: WriteStream, credentialsType: ObjectType):
+export const getConfigWithHeader = async (output: CliOutput, credentialsType: ObjectType):
   Promise<InstanceElement> => {
-  output.write(formatCredentialsHeader(credentialsType.elemID.adapter))
+  outputLine(formatCredentialsHeader(credentialsType.elemID.adapter), output)
   return getCredentialsFromUser(credentialsType)
 }
 

--- a/packages/cli/src/callbacks.ts
+++ b/packages/cli/src/callbacks.ts
@@ -184,7 +184,7 @@ export const getCredentialsFromUser = async (credentialsType: ObjectType):
   return new InstanceElement(ElemID.CONFIG_NAME, credentialsType, values)
 }
 
-export const getConfigWithHeader = async (output: CliOutput, credentialsType: ObjectType):
+export const getConfigWithHeader = async (credentialsType: ObjectType, output: CliOutput):
   Promise<InstanceElement> => {
   outputLine(formatCredentialsHeader(credentialsType.elemID.adapter), output)
   return getCredentialsFromUser(credentialsType)

--- a/packages/cli/src/commands/service.ts
+++ b/packages/cli/src/commands/service.ts
@@ -36,7 +36,7 @@ import { Workspace } from '@salto-io/workspace'
 import { naclCase } from '@salto-io/adapter-utils'
 import { values } from '@salto-io/lowerdash'
 import _ from 'lodash'
-import { getCredentialsFromUser } from '../callbacks'
+import { getConfigWithHeader } from '../callbacks'
 import { CliExitCode, CliOutput, KeyedOption } from '../types'
 import { createCommandGroupDef, createWorkspaceCommand, WorkspaceCommandAction } from '../command_builder'
 import {
@@ -121,7 +121,6 @@ const getLoginConfig = async (
   } else {
     const configType = authMethods[authType]
     if (configType) {
-      outputLine(formatCredentialsHeader(configType.credentialsType.elemID.adapter), output)
       newConfig = await getLoginInput(configType.credentialsType)
     } else {
       throw new Error(`Adapter does not support authentication of type ${authType}`)
@@ -153,7 +152,9 @@ const getLoginInputFlow = async (
 ): Promise<void> => {
   const getLoginInput = isDefined(loginParameters)
     ? createConfigFromLoginParameters(loginParameters)
-    : getCredentialsFromUser
+    // In this option we need to ask the user to enter his credentials
+    : (credentialsType: ObjectType) : Promise<InstanceElement> =>
+      getConfigWithHeader(output, credentialsType)
   const newConfig = await getLoginConfig(authType, authMethods, output, getLoginInput)
   const result = await verifyCredentials(newConfig)
   if (!result.success) {

--- a/packages/cli/src/commands/service.ts
+++ b/packages/cli/src/commands/service.ts
@@ -152,9 +152,9 @@ const getLoginInputFlow = async (
 ): Promise<void> => {
   const getLoginInput = isDefined(loginParameters)
     ? createConfigFromLoginParameters(loginParameters)
-    // In this option we need to ask the user to enter his credentials
+    // In this login option we ask the user to enter his credentials
     : (credentialsType: ObjectType) : Promise<InstanceElement> =>
-      getConfigWithHeader(output, credentialsType)
+      getConfigWithHeader(credentialsType, output)
   const newConfig = await getLoginConfig(authType, authMethods, output, getLoginInput)
   const result = await verifyCredentials(newConfig)
   if (!result.success) {


### PR DESCRIPTION
When login using --login-parameters, there won't be a message asking to enter credentials
---

Moved the request output to be part of the login function, instead of default it every time

---
_Release Notes_: 
No more of that irrelevant output