### PR TITLE
SALTO-2772 SF - convert_map filter- convert the type even if there are no instances of this type in our WS

### DIFF
--- a/packages/salesforce-adapter/src/filters/convert_maps.ts
+++ b/packages/salesforce-adapter/src/filters/convert_maps.ts
@@ -389,11 +389,11 @@ const filter: LocalFilterCreator = () => ({
 
   preDeploy: async changes => {
     await awu(Object.keys(metadataTypeToFieldToMapDef)).forEach(async targetMetadataType => {
-      const mapFieldDef = metadataTypeToFieldToMapDef[targetMetadataType]
       const instanceChanges = await getInstanceChanges(changes, targetMetadataType)
       if (instanceChanges.length === 0) {
         return
       }
+      const mapFieldDef = metadataTypeToFieldToMapDef[targetMetadataType]
       // since transformElement and salesforce do not require list fields to be defined as lists,
       // we only mark fields as lists of their map inner value is a list,
       // so that we can convert the object back correctly in onDeploy

--- a/packages/salesforce-adapter/test/filters/convert_maps.test.ts
+++ b/packages/salesforce-adapter/test/filters/convert_maps.test.ts
@@ -338,7 +338,8 @@ describe('Convert maps filter', () => {
     let filter: FilterType
     beforeAll(async () => {
       const lwc = createInstanceElement({ fullName: 'lwc', lwcResources: { lwcResource: [{ filePath: 'dir/lwc.js', source: 'lwc.ts' }] } }, mockTypes.LightningComponentBundle)
-      elements = [lwc]
+      const lwcType = mockTypes.LightningComponentBundle
+      elements = [lwc, lwcType]
 
       filter = filterCreator({ config: { ...defaultFilterContext } }) as FilterType
       await filter.onFetch(elements)

--- a/packages/salesforce-adapter/test/filters/convert_maps.test.ts
+++ b/packages/salesforce-adapter/test/filters/convert_maps.test.ts
@@ -23,14 +23,12 @@ import {
   Change,
   toChange,
   isObjectType,
-  ElemID, BuiltinTypes,
 } from '@salto-io/adapter-api'
 import { FilterWith } from '../../src/filter'
 import filterCreator from '../../src/filters/convert_maps'
 import { generateProfileType, defaultFilterContext } from '../utils'
 import { createInstanceElement } from '../../src/transformers/transformer'
 import { mockTypes } from '../mock_elements'
-import { EMAIL_TEMPLATE_METADATA_TYPE, METADATA_TYPE, SALESFORCE } from '../../src/constants'
 
 type layoutAssignmentType = { layout: string; recordType?: string }
 
@@ -365,18 +363,7 @@ describe('Convert maps filter', () => {
     type FilterType = FilterWith<'onFetch'>
     let filter: FilterType
     beforeAll(async () => {
-      const emailTemplateID = new ElemID(SALESFORCE, EMAIL_TEMPLATE_METADATA_TYPE)
-
-      const fields = {
-        attachments: { refType: BuiltinTypes.STRING },
-      }
-
-      const emailTemplateType = new ObjectType({
-        annotations: { [METADATA_TYPE]: EMAIL_TEMPLATE_METADATA_TYPE },
-        elemID: emailTemplateID,
-        fields,
-        path: ['Objects', 'dir'],
-      })
+      const emailTemplateType = mockTypes.EmailTemplate
 
       elements = [emailTemplateType]
 


### PR DESCRIPTION
_SF - convert_map filter- convert the type even if there are no instances of this type in our WS_

---
_Additional context for reviewer_:
In SF adapter under the convert_map filter we only update the type if there are instances of this type in our WS. it can create problems when we later on will try to clone instances of this type from other workspaces.

we need to modify it so it will change the type even if there are no instances of this type.

---
_Release Notes_: 
Salesforce-adapter:

* convert_map filter- convert the type even if there are no instances of this type in our WS
---

_User Notifications_: 
Salesforce-adapter:

* this will cause change in the Nacls of following types: BusinessHoursSettings, EmailTemplate, LightningComponentBundle and Profile

