### PR TITLE
INCIDENT-967: fetch failed with "Cannot read property 'createTopLevelParentID' of undefined"

### DIFF
--- a/packages/core/src/core/plan/plan.ts
+++ b/packages/core/src/core/plan/plan.ts
@@ -429,11 +429,18 @@ const resolveNodeElements = (
   })
 
   const resolvedBefore = _.keyBy(
-    await resolve(beforeItemsToResolve, before),
+    await log.time(
+      () => resolve(beforeItemsToResolve, before),
+      'Resolving before items',
+    ),
     e => e.elemID.getFullName()
   ) as Record<string, ChangeDataType>
+
   const resolvedAfter = _.keyBy(
-    await resolve(afterItemsToResolve, after),
+    await log.time(
+      () => resolve(afterItemsToResolve, after),
+      'Resolving after items',
+    ),
     e => e.elemID.getFullName()
   ) as Record<string, ChangeDataType>
 

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -188,6 +188,7 @@ const fetchConfigType = createUserFetchConfigType(
   {
     fallbackToInternalId: { refType: BuiltinTypes.BOOLEAN },
     addTypeToFieldName: { refType: BuiltinTypes.BOOLEAN },
+    // Default is true
     parseTemplateExpressions: { refType: BuiltinTypes.BOOLEAN },
   },
   fetchFiltersType,

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -57,6 +57,7 @@ type JiraFetchFilters = {
 type JiraFetchConfig = configUtils.UserFetchConfig<JiraFetchFilters> & {
   fallbackToInternalId?: boolean
   addTypeToFieldName?: boolean
+  parseTemplateExpressions?: boolean
 }
 
 export type MaskingConfig = {
@@ -187,6 +188,7 @@ const fetchConfigType = createUserFetchConfigType(
   {
     fallbackToInternalId: { refType: BuiltinTypes.BOOLEAN },
     addTypeToFieldName: { refType: BuiltinTypes.BOOLEAN },
+    parseTemplateExpressions: { refType: BuiltinTypes.BOOLEAN },
   },
   fetchFiltersType,
 )

--- a/packages/jira-adapter/src/filters/automation/smart_values/smart_value_reference_filter.ts
+++ b/packages/jira-adapter/src/filters/automation/smart_values/smart_value_reference_filter.ts
@@ -97,7 +97,13 @@ const replaceFormulasWithTemplates = async (instances: InstanceElement[]): Promi
 
   filterAutomations(instances).forEach(instance => {
     getPossibleSmartValues(instance)
-      .filter(({ obj, key }) => _.isString(obj[key]))
+      .filter(({ obj, key }) => {
+        if (!_.isString(obj[key])) {
+          log.debug(`'${key}' in ${instance.elemID.getFullName()} key is not a string`)
+          return false
+        }
+        return true
+      })
       .forEach(({ obj, key }) => {
         try {
           obj[key] = stringToTemplate({
@@ -106,7 +112,7 @@ const replaceFormulasWithTemplates = async (instances: InstanceElement[]): Promi
             fieldInstancesById,
           })
         } catch (e) {
-          log.error('Error parsing templates in fetch', e)
+          log.error(`Error parsing templates in fetch ${e}, stack: ${e.stack}`)
         }
       })
   })

--- a/packages/jira-adapter/src/filters/jql/jql_references.ts
+++ b/packages/jira-adapter/src/filters/jql/jql_references.ts
@@ -87,11 +87,16 @@ const getJqls = (instance: InstanceElement): JqlDetails[] => {
     .filter(({ jql }) => jql !== undefined)
 }
 
-const filter: FilterCreator = () => {
+const filter: FilterCreator = ({ config }) => {
   const jqlToTemplateExpression: Record<string, TemplateExpression> = {}
 
   return {
     onFetch: async elements => log.time(async () => {
+      if (config.fetch.parseTemplateExpressions === false) {
+        log.debug('Parsing JQL template expression was disabled')
+        return
+      }
+
       const instances = elements.filter(isInstanceElement)
 
       const jqls = instances


### PR DESCRIPTION
- Added logs to help us identify the problematic value
- Fixed the issue in https://salto-io.atlassian.net/browse/INCIDENT-967?focusedCommentId=48047 (though it seems unrelated, but still 🤷‍♂️)
- Added flag to disable parsing template expression (since it looks like the problem is coming from template expression)

---
There is an issue where a fetch failed `Cannot read property 'createTopLevelParentID' of undefined` because it is getting to [here](https://github.com/salto-io/salto/blob/main/packages/workspace/src/expressions.ts#L223) and somehow elemID is undefined at that point

---
_Release Notes_: 
None

---
_User Notifications_: 
None