### PR TITLE
SALTO-2775: Smart values with {{toString}} causes fetch to fail

### DIFF
--- a/packages/jira-adapter/src/filters/automation/smart_values/template_expression_generator.ts
+++ b/packages/jira-adapter/src/filters/automation/smart_values/template_expression_generator.ts
@@ -42,12 +42,12 @@ const handleJiraReference = ({
   fieldInstancesByName,
   fieldInstancesById,
 }: GenerateTemplateParams): TemplatePart => {
-  if (fieldInstancesById[referenceStr] !== undefined) {
+  if (Object.prototype.hasOwnProperty.call(fieldInstancesById, referenceStr)) {
     const instance = fieldInstancesById[referenceStr]
     return new ReferenceExpression(instance.elemID, instance)
   }
 
-  if (fieldInstancesByName[referenceStr] !== undefined) {
+  if (Object.prototype.hasOwnProperty.call(fieldInstancesByName, referenceStr)) {
     const instance = fieldInstancesByName[referenceStr]
     return new ReferenceExpression(instance.elemID.createNestedID('name'), instance.value.name)
   }

--- a/packages/jira-adapter/src/filters/jql/template_expression_generator.ts
+++ b/packages/jira-adapter/src/filters/jql/template_expression_generator.ts
@@ -165,7 +165,7 @@ const getFieldInfo = (
     position.end = position.start + fieldIdentifier.length
   }
 
-  if (jqlContext.fieldsById[fieldIdentifier] !== undefined) {
+  if (Object.prototype.hasOwnProperty.call(jqlContext.fieldsById, fieldIdentifier)) {
     return {
       instance: jqlContext.fieldsById[fieldIdentifier],
       position,
@@ -173,7 +173,10 @@ const getFieldInfo = (
     }
   }
 
-  if (jqlContext.typeToInstances[FIELD_TYPE_NAME]?.[fieldIdentifier] !== undefined) {
+  if (Object.prototype.hasOwnProperty.call(
+    jqlContext.typeToInstances[FIELD_TYPE_NAME],
+    fieldIdentifier
+  )) {
     return {
       instance: jqlContext.typeToInstances[FIELD_TYPE_NAME][fieldIdentifier],
       position,
@@ -196,12 +199,23 @@ const getValueTokens = (
   // A heuristic that works for the types in CONTEXT_TYPE_TO_FIELD
   // to convert a field name to its values' type
   const typeName = fieldInstance.value.name.replace(/\s+/g, '')
-  const identifierToInstance = jqlContext.typeToInstances[typeName]
+  const identifierToInstance = Object.prototype.hasOwnProperty.call(
+    jqlContext.typeToInstances, typeName
+  ) ? jqlContext.typeToInstances[typeName]
+    : undefined
+
   return getValueOperands(clause.operand)
     .map(operand => {
-      const valueInstance = identifierToInstance?.[operand.value.toLowerCase()]
+      const valueInstance = Object.prototype.hasOwnProperty
+        .call(identifierToInstance ?? {}, operand.value.toLowerCase())
+        ? identifierToInstance?.[operand.value.toLowerCase()]
+        : undefined
 
-      const identifier = CONTEXT_TYPE_TO_FIELD[typeName]
+      const identifier = Object.prototype.hasOwnProperty
+        .call(CONTEXT_TYPE_TO_FIELD, typeName)
+        ? CONTEXT_TYPE_TO_FIELD[typeName]
+        : undefined
+
       const position = getValuePosition(operand)
       if (valueInstance === undefined || identifier === undefined || position === undefined) {
         return undefined

--- a/packages/jira-adapter/test/filters/automation/smart_values/template_expression_generator.test.ts
+++ b/packages/jira-adapter/test/filters/automation/smart_values/template_expression_generator.test.ts
@@ -166,10 +166,10 @@ describe('stringToTemplate', () => {
 
   it('should ignore unknown fields', () => {
     expect(stringToTemplate({
-      referenceStr: '1-{{unknown}} 2-{{issue.unknown}}',
+      referenceStr: '1-{{unknown}} 2-{{issue.unknown}} 3-{{toString}}',
       fieldInstancesByName: nameToField,
       fieldInstancesById: idToField,
-    })).toBe('1-{{unknown}} 2-{{issue.unknown}}')
+    })).toBe('1-{{unknown}} 2-{{issue.unknown}} 3-{{toString}}')
   })
 
   it('should ignore invalid fields', () => {

--- a/packages/jira-adapter/test/filters/jql/template_expression_generator.test.ts
+++ b/packages/jira-adapter/test/filters/jql/template_expression_generator.test.ts
@@ -99,6 +99,12 @@ describe('generateTemplateExpression', () => {
     expect(expression).toBeUndefined()
   })
 
+  it('should parse correctly jql with orderBy with a JS built in name', async () => {
+    const jql = 'ORDER BY __proto__ ASC'
+    const expression = generateTemplateExpression(jql, generateJqlContext(instances))
+    expect(expression).toBeUndefined()
+  })
+
   it('should ignore functions', async () => {
     const jql = 'status = currentUser()'
     const expression = generateTemplateExpression(jql, generateJqlContext(instances))


### PR DESCRIPTION
Smart values with {{toString}} causes fetch to fail

---

Fixed to use `Object.prototype.hasOwnProperty.call` both in the smart values parsing and in the JQL parsing

---
_Release Notes_: 
_Jira Adapter_:
- Fixed a bug that causes fetch to fail with "Cannot read property 'createTopLevelParentID' of undefined"

---
_User Notifications_: 
None