### PR TITLE
SALTO-2784: Deploying automation with a "jira.lookup.issues" component type fails

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/automation.ts
+++ b/packages/jira-adapter/e2e_test/instances/automation.ts
@@ -15,7 +15,7 @@
 */
 import { ElemID, TemplateExpression, Values, Element } from '@salto-io/adapter-api'
 import { createReference } from '../utils'
-import { JIRA, PRIORITY_TYPE_NAME } from '../../src/constants'
+import { JIRA, PRIORITY_TYPE_NAME, PROJECT_TYPE } from '../../src/constants'
 import { FIELD_TYPE_NAME } from '../../src/filters/fields/constants'
 
 
@@ -188,6 +188,35 @@ export const createAutomationValues = (name: string, allElements: Element[]): Va
         ],
         sendNotifications: false,
       },
+    },
+    {
+      component: 'ACTION',
+      schemaVersion: 1,
+      type: 'jira.lookup.issues',
+      value: {
+        name: {
+          type: 'FREE',
+          value: 'lookupIssues',
+        },
+        type: 'JQL',
+        query: {
+          type: 'SMART',
+          value: new TemplateExpression({ parts: [
+            createReference(new ElemID(JIRA, FIELD_TYPE_NAME, 'instance', 'Project__project'), allElements),
+            ' = ',
+            createReference(new ElemID(JIRA, PROJECT_TYPE, 'instance', 'Test_Project@s'), allElements, ['key']),
+            ' ORDER BY ',
+            createReference(new ElemID(JIRA, FIELD_TYPE_NAME, 'instance', 'Rank__gh_lexo_rank__c@uubbuu'), allElements, ['name']),
+            ' ASC',
+          ] }),
+        },
+        lazy: false,
+        id: '_customsmartvalue_id_166080756221912123',
+      },
+      children: [
+      ],
+      conditions: [
+      ],
     },
   ],
   canOtherRuleTrigger: false,

--- a/packages/jira-adapter/src/filters/automation/automation_structure.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_structure.ts
@@ -117,7 +117,12 @@ const removeInnerIds = async (instance: InstanceElement): Promise<void> => {
     strict: false,
     allowEmpty: true,
     transformFunc: async ({ value, path }) => (
-      path !== undefined && path.name === 'id' && !path.createParentID().isTopLevel()
+      // We want to remove all the ids besides the id in the of the automation itself
+      // and ids inside component values
+      path !== undefined
+        && path.name === 'id'
+        && !path.getFullNameParts().includes('value')
+        && !path.createParentID().isTopLevel()
         ? undefined
         : value
     ),

--- a/packages/jira-adapter/test/filters/automation/automation_structure.test.ts
+++ b/packages/jira-adapter/test/filters/automation/automation_structure.test.ts
@@ -64,6 +64,7 @@ describe('automationStructureFilter', () => {
             id: '2',
             component: 'CONDITION',
             value: {
+              id: 'someId',
               linkType: 'inward:10003',
               value: '123',
             },
@@ -187,6 +188,11 @@ describe('automationStructureFilter', () => {
     it('should remove inner ids', async () => {
       await filter.onFetch([instance])
       expect(instance.value.components[0].id).toBeUndefined()
+    })
+
+    it('should not remove inner ids in components values', async () => {
+      await filter.onFetch([instance])
+      expect(instance.value.components[2].value.id).toBe('someId')
     })
 
     it('should remove redundant keys', async () => {


### PR DESCRIPTION
Fixed an issue where automation with a specific component type would fail with 500 because of a recent API change.

---

A new id value was added under the `value` field and if it is not passed in the request, it fails with 500.
The id can be modified in deploy so it is env safe to show it in the NaCl.

---
_Release Notes_: 
_Jira Adapter_:
- Fixed a bug where deploying automation with certain components fails with 500.

---
_User Notifications_: 
_Jira Adapter_:
- Some id values might be added to automation after the next fetch