### PR TITLE
SALTO-2785: Salto restore does not restore empty values

### DIFF
--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -856,13 +856,13 @@ export const filterByID = async <T extends Element | Values>(
       ),
       isDefined,
     )
-    return _.isEmpty(filteredObj) ? undefined : filteredObj as Value as T
+    return !_.isEmpty(value) && _.isEmpty(filteredObj) ? undefined : filteredObj as Value as T
   }
   if (_.isArray(value)) {
     const filteredArray = (await Promise.all(value
       .map(async (item, i) => filterByID(id.createNestedID(i.toString()), item, filterFunc))))
       .filter(isDefined)
-    return _.isEmpty(filteredArray) ? undefined : filteredArray as Value as T
+    return !_.isEmpty(value) && _.isEmpty(filteredArray) ? undefined : filteredArray as Value as T
   }
 
   return value

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -237,7 +237,7 @@ export const transformValues = async (
       ),
       _.isUndefined
     )
-    return _.isEmpty(result) && !allowEmpty ? undefined : result
+    return _.isEmpty(result) ? undefined : result
   }
   if (_.isArray(newVal)) {
     const result = await awu(newVal)
@@ -248,7 +248,7 @@ export const transformValues = async (
       ))
       .filter(value => !_.isUndefined(value))
       .toArray()
-    return result.length === 0 && !allowEmpty ? undefined : result
+    return result.length === 0 ? undefined : result
   }
   return newVal
 }

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -237,7 +237,7 @@ export const transformValues = async (
       ),
       _.isUndefined
     )
-    return _.isEmpty(result) ? undefined : result
+    return _.isEmpty(result) && !allowEmpty ? undefined : result
   }
   if (_.isArray(newVal)) {
     const result = await awu(newVal)
@@ -248,7 +248,7 @@ export const transformValues = async (
       ))
       .filter(value => !_.isUndefined(value))
       .toArray()
-    return result.length === 0 ? undefined : result
+    return result.length === 0 && !allowEmpty ? undefined : result
   }
   return newVal
 }

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -739,6 +739,30 @@ describe('Test utils.ts', () => {
         ])
       })
     })
+
+    describe('with allowEmpty', () => {
+      it('should not remove empty list', async () => {
+        const result = await transformValues({
+          values: [],
+          type: new ListType(BuiltinTypes.NUMBER),
+          transformFunc: ({ value }) => value,
+          allowEmpty: true,
+        })
+
+        expect(result).toEqual([])
+      })
+
+      it('should not remove empty object', async () => {
+        const result = await transformValues({
+          values: {},
+          type: new ObjectType({ elemID: new ElemID('adapter', 'type') }),
+          transformFunc: ({ value }) => value,
+          allowEmpty: true,
+        })
+
+        expect(result).toEqual({})
+      })
+    })
   })
 
   describe('transformElement', () => {
@@ -1857,23 +1881,6 @@ describe('Test utils.ts', () => {
       )
       expect(filteredInstance?.value).toEqual({ obj: inst.value.obj, map: inst.value.map })
       expect(filteredInstance?.annotations).toEqual(inst.annotations)
-    })
-
-    it('should not filter empty values', async () => {
-      const instance = new InstanceElement(
-        'instance',
-        obj,
-        {
-          emptyList: [],
-          emptyObj: {},
-        },
-      )
-      const filteredInstance = await filterByID(
-        instance.elemID,
-        instance,
-        async () => true
-      )
-      expect(filteredInstance?.value).toEqual({ emptyList: [], emptyObj: {} })
     })
 
     it('should return undefined if the base item fails the filter func', async () => {

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -1859,6 +1859,23 @@ describe('Test utils.ts', () => {
       expect(filteredInstance?.annotations).toEqual(inst.annotations)
     })
 
+    it('should not filter empty values', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        obj,
+        {
+          emptyList: [],
+          emptyObj: {},
+        },
+      )
+      const filteredInstance = await filterByID(
+        instance.elemID,
+        instance,
+        async () => true
+      )
+      expect(filteredInstance?.value).toEqual({ emptyList: [], emptyObj: {} })
+    })
+
     it('should return undefined if the base item fails the filter func', async () => {
       const filteredInstance = await filterByID(
         inst.elemID,

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -739,30 +739,6 @@ describe('Test utils.ts', () => {
         ])
       })
     })
-
-    describe('with allowEmpty', () => {
-      it('should not remove empty list', async () => {
-        const result = await transformValues({
-          values: [],
-          type: new ListType(BuiltinTypes.NUMBER),
-          transformFunc: ({ value }) => value,
-          allowEmpty: true,
-        })
-
-        expect(result).toEqual([])
-      })
-
-      it('should not remove empty object', async () => {
-        const result = await transformValues({
-          values: {},
-          type: new ObjectType({ elemID: new ElemID('adapter', 'type') }),
-          transformFunc: ({ value }) => value,
-          allowEmpty: true,
-        })
-
-        expect(result).toEqual({})
-      })
-    })
   })
 
   describe('transformElement', () => {
@@ -1881,6 +1857,23 @@ describe('Test utils.ts', () => {
       )
       expect(filteredInstance?.value).toEqual({ obj: inst.value.obj, map: inst.value.map })
       expect(filteredInstance?.annotations).toEqual(inst.annotations)
+    })
+
+    it('should not filter empty values', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        obj,
+        {
+          emptyList: [],
+          emptyObj: {},
+        },
+      )
+      const filteredInstance = await filterByID(
+        instance.elemID,
+        instance,
+        async () => true
+      )
+      expect(filteredInstance?.value).toEqual({ emptyList: [], emptyObj: {} })
     })
 
     it('should return undefined if the base item fails the filter func', async () => {

--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -123,6 +123,7 @@ export const getElementHiddenParts = async <T extends Element>(
         : undefined
     ),
     strict: true,
+    allowEmpty: true,
     elementsSource,
   })
   // remove all annotation types from the hidden element so they don't cause merge conflicts
@@ -212,6 +213,7 @@ const removeHiddenFromValues = (
     pathID,
     elementsSource,
     strict: false,
+    allowEmpty: true,
   })
 )
 
@@ -518,6 +520,7 @@ const getHiddenFieldAndAnnotationValueChanges = async (
         strict: true,
         elementsSource: state,
         runOnFields: true,
+        allowEmpty: true,
       })
     })
 


### PR DESCRIPTION
Fixed Salto restore to work with empty values

---

changed filterById not to omit empty value if it was originally an empty value

---
_Release Notes_: 
_Core_:
- Fixed Salto restore to work with empty values

---
_User Notifications_: 
None