### PR TITLE
SALTO-2773 SALTO-2853 Change transformValues to use the allowEmpty flag so it wont automatically omit empty values 

### DIFF
--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -237,7 +237,7 @@ export const transformValues = async (
       ),
       _.isUndefined
     )
-    return _.isEmpty(result) ? undefined : result
+    return _.isEmpty(result) && !allowEmpty ? undefined : result
   }
   if (_.isArray(newVal)) {
     const result = await awu(newVal)

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -230,13 +230,14 @@ export const transformValues = async (
 
   const newVal = isTopLevel ? await transformFunc({ value: values, path: pathID }) : values
   if (_.isPlainObject(newVal)) {
-    const temp = await mapValuesAsync(
-      newVal ?? {},
-      (value, key) => transformValue(value, pathID?.createNestedID(key), fieldMapper(key))
+    const result = _.omitBy(
+      await mapValuesAsync(
+        newVal ?? {},
+        (value, key) => transformValue(value, pathID?.createNestedID(key), fieldMapper(key))
+      ),
+      _.isUndefined
     )
-    const result = _.omitBy(temp, _.isUndefined)
-    const res = _.isEmpty(result) && !allowEmpty ? undefined : result
-    return res
+    return _.isEmpty(result) ? undefined : result
   }
   if (_.isArray(newVal)) {
     const result = await awu(newVal)

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -230,14 +230,13 @@ export const transformValues = async (
 
   const newVal = isTopLevel ? await transformFunc({ value: values, path: pathID }) : values
   if (_.isPlainObject(newVal)) {
-    const result = _.omitBy(
-      await mapValuesAsync(
-        newVal ?? {},
-        (value, key) => transformValue(value, pathID?.createNestedID(key), fieldMapper(key))
-      ),
-      _.isUndefined
+    const temp = await mapValuesAsync(
+      newVal ?? {},
+      (value, key) => transformValue(value, pathID?.createNestedID(key), fieldMapper(key))
     )
-    return _.isEmpty(result) && !allowEmpty ? undefined : result
+    const result = _.omitBy(temp, _.isUndefined)
+    const res = _.isEmpty(result) && !allowEmpty ? undefined : result
+    return res
   }
   if (_.isArray(newVal)) {
     const result = await awu(newVal)

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -230,14 +230,13 @@ export const transformValues = async (
 
   const newVal = isTopLevel ? await transformFunc({ value: values, path: pathID }) : values
   if (_.isPlainObject(newVal)) {
-    const result = _.omitBy(
-      await mapValuesAsync(
-        newVal ?? {},
-        (value, key) => transformValue(value, pathID?.createNestedID(key), fieldMapper(key))
-      ),
-      _.isUndefined
+    const temp = await mapValuesAsync(
+      newVal ?? {},
+      (value, key) => transformValue(value, pathID?.createNestedID(key), fieldMapper(key))
     )
-    return _.isEmpty(result) ? undefined : result
+    const result = _.omitBy(temp, _.isUndefined)
+    const res = _.isEmpty(result) && !allowEmpty ? undefined : result
+    return res
   }
   if (_.isArray(newVal)) {
     const result = await awu(newVal)
@@ -248,7 +247,7 @@ export const transformValues = async (
       ))
       .filter(value => !_.isUndefined(value))
       .toArray()
-    return result.length === 0 ? undefined : result
+    return result.length === 0 && !allowEmpty ? undefined : result
   }
   return newVal
 }

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -739,6 +739,30 @@ describe('Test utils.ts', () => {
         ])
       })
     })
+
+    describe('with allowEmpty', () => {
+      it('should not remove empty list', async () => {
+        const result = await transformValues({
+          values: [],
+          type: new ListType(BuiltinTypes.NUMBER),
+          transformFunc: ({ value }) => value,
+          allowEmpty: true,
+        })
+
+        expect(result).toEqual([])
+      })
+
+      it('should not remove empty object', async () => {
+        const result = await transformValues({
+          values: {},
+          type: new ObjectType({ elemID: new ElemID('adapter', 'type') }),
+          transformFunc: ({ value }) => value,
+          allowEmpty: true,
+        })
+
+        expect(result).toEqual({})
+      })
+    })
   })
 
   describe('transformElement', () => {

--- a/packages/jira-adapter/jest.config.js
+++ b/packages/jira-adapter/jest.config.js
@@ -29,7 +29,7 @@ module.exports = deepMerge(
     ],
     coverageThreshold: {
       'global': {
-        branches: 93.5,
+        branches: 93.4,
         functions: 95,
         lines: 95,
         statements: 95,

--- a/packages/jira-adapter/jest.config.js
+++ b/packages/jira-adapter/jest.config.js
@@ -29,7 +29,7 @@ module.exports = deepMerge(
     ],
     coverageThreshold: {
       'global': {
-        branches: 93.4,
+        branches: 93.5,
         functions: 95,
         lines: 95,
         statements: 95,

--- a/packages/zendesk-adapter/src/filters/dynamic_content_references.ts
+++ b/packages/zendesk-adapter/src/filters/dynamic_content_references.ts
@@ -168,6 +168,7 @@ const filterCreator: FilterCreator = ({ config }) => {
             return value
           },
           allowEmpty: true,
+          strict: false,
         }) ?? instance.value
       }), 'Dynamic content references filter'),
   })

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -900,7 +900,7 @@ describe('adapter', () => {
             toChange({ before: new InstanceElement('inst2', groupType) }),
             // explicitly state key so that it appears in the instance's generated type
             toChange({ after: new InstanceElement('inst3', brandType, { ref, key: undefined }) }),
-            toChange({ after: new InstanceElement('inst4', anotherType) }),
+            toChange({ after: new InstanceElement('inst4', anotherType, { key: undefined }) }),
             modificationChange,
           ],
         },

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -900,7 +900,7 @@ describe('adapter', () => {
             toChange({ before: new InstanceElement('inst2', groupType) }),
             // explicitly state key so that it appears in the instance's generated type
             toChange({ after: new InstanceElement('inst3', brandType, { ref, key: undefined }) }),
-            toChange({ after: new InstanceElement('inst4', anotherType, { key: undefined }) }),
+            toChange({ after: new InstanceElement('inst4', anotherType) }),
             modificationChange,
           ],
         },


### PR DESCRIPTION
_Change transformValues to use the allowEmpty flag so it wont automatically omit empty values_

---
_Additional context for reviewer_:
related to: https://github.com/salto-io/salto/pull/3412#issue-1390450814

---
_Release Notes_: 
Salesforce-adapter:

* Fix transformValues so it wont delete empty values regardless of the allowEmpty flag.
---

_User Notifications_: 
None
