### PR TITLE
SALTO-2333 replace ids with names in workflow scheme migration error - Jira

### DIFF
--- a/packages/jira-adapter/src/filters/workflow_scheme.ts
+++ b/packages/jira-adapter/src/filters/workflow_scheme.ts
@@ -145,9 +145,6 @@ const replaceIDsWithNames = (messages: string[], ids: string[],
   const newMessages = messages
   messages.forEach((_message, i) => {
     ids.forEach(id => {
-      if (idToInstance[id] === undefined) {
-        throw (new Error('can not find id'))
-      }
       newMessages[i] = newMessages[i].replace(id, idToInstance[id].elemID.getFullName())
     })
     newMessages[i] = newMessages[i].replace(new RegExp('ID', 'g'), 'name')
@@ -213,6 +210,7 @@ export const deployWorkflowScheme = async (
           err.response.data.errorMessages, elementsSource
         )
       } catch (error) {
+        log.warn(`failed to reformat the workflow scheme ${getChangeData(change).elemID.getFullName()} migration error `)
         throw (err)
       }
       throw (err)

--- a/packages/jira-adapter/test/filters/workflow_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/workflow_scheme.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, InstanceElement, ObjectType, toChange, ReadOnlyElementsSource } from '@salto-io/adapter-api'
 import { deployment, client as clientUtils } from '@salto-io/adapter-components'
 import { MockInterface } from '@salto-io/test-utils'
 import _ from 'lodash'
@@ -40,6 +40,7 @@ describe('workflowScheme', () => {
   let filter: Filter
   let client: JiraClient
   let connection: MockInterface<clientUtils.APIConnection>
+  let elementsSource: ReadOnlyElementsSource
   beforeEach(async () => {
     const { client: cli, paginator, connection: conn } = mockClient()
     client = cli
@@ -48,6 +49,7 @@ describe('workflowScheme', () => {
     filter = workflowSchemeFilter(getFilterParams({
       client,
       paginator,
+      elementsSource,
     }))
     workflowSchemeType = new ObjectType({
       elemID: new ElemID(JIRA, 'WorkflowScheme'),

--- a/packages/jira-adapter/test/filters/workflow_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/workflow_scheme.test.ts
@@ -611,13 +611,18 @@ describe('workflowScheme', () => {
         new ObjectType({ elemID: new ElemID(JIRA, ISSUE_TYPE_NAME) }),
         { id: '2' }
       )
-      const statusInstance = new InstanceElement(
-        'statusInstance',
+      const statusFirstInstance = new InstanceElement(
+        'statusFirstInstance',
         new ObjectType({ elemID: new ElemID(JIRA, STATUS_TYPE_NAME) }),
         { id: '3' }
       )
+      const statusSecondInstance = new InstanceElement(
+        'statusSecondInstance',
+        new ObjectType({ elemID: new ElemID(JIRA, STATUS_TYPE_NAME) }),
+        { id: '4' }
+      )
       elementsSource = buildElementsSourceFromElements(
-        [workflowSchemeInstance, statusInstance, issueInstance]
+        [workflowSchemeInstance, statusFirstInstance, statusSecondInstance, issueInstance]
       )
       const { client: cli, paginator, connection: conn } = mockClient()
       client = cli
@@ -629,7 +634,7 @@ describe('workflowScheme', () => {
       }))
 
       deployChangeMock.mockResolvedValue({ draft: true })
-      connection.post.mockImplementation(() => { throw new ServiceError(['Issue type with ID 2 is missing the mappings required for statuses with IDs 3']) })
+      connection.post.mockImplementation(() => { throw new ServiceError(['Issue type with ID 2 is missing the mappings required for statuses with IDs 3,4']) })
 
       const instanceBefore = workflowSchemeInstance.clone()
       workflowSchemeInstance.value.workflow = 'other workflow'
@@ -639,7 +644,7 @@ describe('workflowScheme', () => {
       expect(result).toBeDefined()
       expect(result?.deployResult.errors).toHaveLength(1)
       const errorMessage = result?.deployResult.errors[0].message
-      expect(errorMessage).toInclude('Issue type with name issueInstance is missing the mappings required for statuses with names statusInstance')
+      expect(errorMessage).toInclude('Issue type with name issueInstance is missing the mappings required for statuses with names statusFirstInstance,statusSecondInstance')
     })
 
     it('should throw the regular error message when fail to reformat it', async () => {

--- a/packages/jira-adapter/test/filters/workflow_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/workflow_scheme.test.ts
@@ -639,7 +639,7 @@ describe('workflowScheme', () => {
       expect(result).toBeDefined()
       expect(result?.deployResult.errors).toHaveLength(1)
       const errorMessage = result?.deployResult.errors[0].message
-      expect(errorMessage).toInclude('Issue type with name jira.IssueType.instance.issueInstance is missing the mappings required for statuses with names jira.Status.instance.statusInstance')
+      expect(errorMessage).toInclude('Issue type with name issueInstance is missing the mappings required for statuses with names statusInstance')
     })
 
     it('should throw the regular error message when fail to reformat it', async () => {


### PR DESCRIPTION
_Jira's error message for workflow scheme migration error included internal IDs. In this PR I replaced them with their Salto name_

---

Example: 

Before:
 
`Issue type with ID 10008 is missing the mappings required for statuses with IDs 10018,3,4,10165,10005.`

After : 

`Issue type with name Bug is missing the mappings required for statuses with names a_shared_status2@s,in_progress@s,reopened,a_shared_status4@s,done.`

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
