### PR TITLE
SALTO-2792 pass state and current versions to adapters

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -118,6 +118,8 @@ export type AdapterOperationsContext = {
   config?: InstanceElement
   getElemIdFunc?: ElemIdGetter
   elementsSource: ReadOnlyElementsSource
+  stateVersion: string | undefined
+  currentVersion: string
 }
 
 export type AdapterSuccessInstallResult = { success: true; installedVersion: string }

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -113,13 +113,14 @@ export const preview = async (
   checkOnly = false,
 ): Promise<Plan> => {
   const stateElements = workspace.state()
-  const adapters = await getAdapters(
-    accounts,
-    await workspace.accountCredentials(accounts),
-    workspace.accountConfig.bind(workspace),
-    await workspace.elements(),
-    getAccountToServiceNameMap(workspace, accounts),
-  )
+  const adapters = await getAdapters({
+    adapters: accounts,
+    credentials: await workspace.accountCredentials(accounts),
+    getConfig: workspace.accountConfig.bind(workspace),
+    workspaceElementsSource: await workspace.elements(),
+    accountToServiceName: getAccountToServiceNameMap(workspace, accounts),
+    stateVersion: await workspace.state().getStateSaltoVersion(),
+  })
   return getPlan({
     before: stateElements,
     after: await workspace.elements(),
@@ -147,13 +148,14 @@ export const deploy = async (
   checkOnly = false,
 ): Promise<DeployResult> => {
   const changedElements = elementSource.createInMemoryElementSource()
-  const adapters = await getAdapters(
-    accounts,
-    await workspace.accountCredentials(accounts),
-    workspace.accountConfig.bind(workspace),
-    await workspace.elements(),
-    getAccountToServiceNameMap(workspace, accounts)
-  )
+  const adapters = await getAdapters({
+    adapters: accounts,
+    credentials: await workspace.accountCredentials(accounts),
+    getConfig: workspace.accountConfig.bind(workspace),
+    workspaceElementsSource: await workspace.elements(),
+    accountToServiceName: getAccountToServiceNameMap(workspace, accounts),
+    stateVersion: await workspace.state().getStateSaltoVersion(),
+  })
 
   const getUpdatedElement = async (change: Change): Promise<ChangeDataType> => {
     const changeElem = getChangeData(change)

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -33,6 +33,7 @@ import { getPlan, Plan } from './plan'
 import { AdapterEvents, createAdapterProgressReporter } from './adapters/progress'
 import { IDFilter } from './plan/plan'
 import { getAdaptersCreatorConfigs } from './adapters'
+import { version } from '../generated/version.json'
 
 const { awu, groupByAsync } = collections.asynciterable
 const { mapValuesAsync } = promises.object
@@ -1073,14 +1074,16 @@ export const getFetchAdapterAndServicesSetup = async (
         awu(await (await workspace.elements()).getAll()).filter(e => e.elemID.adapter === account),
         workspace.state()
       ))
-  const adaptersCreatorConfigs = await getAdaptersCreatorConfigs(
-    fetchServices,
-    await workspace.accountCredentials(fetchServices),
-    workspace.accountConfig.bind(workspace),
-    await workspace.elements(),
-    accountToServiceNameMap,
-    elemIDGetters,
-  )
+  const adaptersCreatorConfigs = await getAdaptersCreatorConfigs({
+    accounts: fetchServices,
+    credentials: await workspace.accountCredentials(fetchServices),
+    getConfig: workspace.accountConfig.bind(workspace),
+    elementsSource: await workspace.elements(),
+    accountToServiceName: accountToServiceNameMap,
+    elemIdGetters: elemIDGetters,
+    stateVersion: await workspace.state().getStateSaltoVersion(),
+    currentVersion: version,
+  })
   const currentConfigs = Object.values(adaptersCreatorConfigs)
     .map(creatorConfig => creatorConfig.config)
     .filter(config => !_.isUndefined(config)) as InstanceElement[]

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -156,7 +156,7 @@ describe('api.ts', () => {
       })
       // eslint-disable-next-line jest/no-disabled-tests
       it.skip('should pass the state elements to getAdaptersCreatorConfigs', async () => {
-        const elementsSource = mockGetAdaptersCreatorConfigs.mock.calls[0][3]
+        const { elementsSource } = mockGetAdaptersCreatorConfigs.mock.calls[0]
         expect(await elementsSource.has(new ElemID(mockService, 'test', 'instance', 'state_instance'))).toBeTruthy()
         expect(await elementsSource.has(new ElemID(mockService, 'test', 'instance', 'workspace_instance'))).toBeFalsy()
       })

--- a/packages/core/test/core/adapters/adapters.test.ts
+++ b/packages/core/test/core/adapters/adapters.test.ts
@@ -146,13 +146,15 @@ describe('adapters.ts', () => {
     const d1Type = new ObjectType({ elemID: new ElemID('d1', 'type2') })
 
     it('should return default adapter config when there is no config', async () => {
-      const result = await getAdaptersCreatorConfigs(
-        [serviceName],
-        { [sfConfig.elemID.adapter]: sfConfig },
-        async () => undefined,
-        buildElementsSourceFromElements([]),
-        { [serviceName]: serviceName }
-      )
+      const result = await getAdaptersCreatorConfigs({
+        accounts: [serviceName],
+        credentials: { [sfConfig.elemID.adapter]: sfConfig },
+        getConfig: async () => undefined,
+        elementsSource: buildElementsSourceFromElements([]),
+        accountToServiceName: { [serviceName]: serviceName },
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
+      })
       expect(result[serviceName]).toEqual(
         expect.objectContaining({
           credentials: sfConfig,
@@ -167,13 +169,15 @@ describe('adapters.ts', () => {
     })
 
     it('should return adapter config when there is config', async () => {
-      const result = await getAdaptersCreatorConfigs(
-        [serviceName],
-        { [sfConfig.elemID.adapter]: sfConfig },
-        async name => (name === sfConfig.elemID.adapter ? sfConfig : undefined),
-        buildElementsSourceFromElements([]),
-        { [serviceName]: serviceName },
-      )
+      const result = await getAdaptersCreatorConfigs({
+        accounts: [serviceName],
+        credentials: { [sfConfig.elemID.adapter]: sfConfig },
+        getConfig: async name => (name === sfConfig.elemID.adapter ? sfConfig : undefined),
+        elementsSource: buildElementsSourceFromElements([]),
+        accountToServiceName: { [serviceName]: serviceName },
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
+      })
       expect(result[serviceName]).toEqual(
         expect.objectContaining({
           credentials: sfConfig,
@@ -187,16 +191,18 @@ describe('adapters.ts', () => {
     let result: Record<string, AdapterOperationsContext>
     describe('multi app adapter config', () => {
       beforeEach(async () => {
-        result = await getAdaptersCreatorConfigs(
-          [serviceName, 'd1'],
-          { [sfConfig.elemID.adapter]: sfConfig },
-          async name => (name === sfConfig.elemID.adapter ? sfConfig : undefined),
-          buildElementsSourceFromElements([
+        result = await getAdaptersCreatorConfigs({
+          accounts: [serviceName, 'd1'],
+          credentials: { [sfConfig.elemID.adapter]: sfConfig },
+          getConfig: async name => (name === sfConfig.elemID.adapter ? sfConfig : undefined),
+          elementsSource: buildElementsSourceFromElements([
             objectType,
             d1Type,
           ]),
-          { [serviceName]: serviceName, d1: 'dummy' },
-        )
+          accountToServiceName: { [serviceName]: serviceName, d1: 'dummy' },
+          stateVersion: '0.3.0',
+          currentVersion: '0.3.0',
+        })
       })
 
       it('should only return elements that belong to the relevant account', async () => {
@@ -245,6 +251,8 @@ describe('adapters.ts', () => {
             credentials: sfConfig,
             config: undefined,
             elementsSource: utils.buildElementsSourceFromElements([]),
+            stateVersion: '0.3.0',
+            currentVersion: '0.3.0',
           },
         },
         { salesforce: 'salesforce' },
@@ -259,6 +267,8 @@ describe('adapters.ts', () => {
           [accounts[0]]: {
             credentials: (credentials as unknown as InstanceElement),
             elementsSource: utils.buildElementsSourceFromElements([]),
+            stateVersion: '0.3.0',
+            currentVersion: '0.3.0',
           },
         }
       )).toThrow()
@@ -270,6 +280,8 @@ describe('adapters.ts', () => {
           notExist: {
             credentials: sfConfig,
             elementsSource: utils.buildElementsSourceFromElements([]),
+            stateVersion: '0.3.0',
+            currentVersion: '0.3.0',
           },
         }
       )).toThrow()

--- a/packages/dummy-adapter/test/adapter_creator.test.ts
+++ b/packages/dummy-adapter/test/adapter_creator.test.ts
@@ -43,6 +43,8 @@ describe('adapter creator', () => {
         defaultParams
       ),
       elementsSource: buildElementsSourceFromElements([]),
+      stateVersion: '0.3.0',
+      currentVersion: '0.3.0',
     })).toBeInstanceOf(DummyAdapter)
   })
 })

--- a/packages/jira-adapter/test/adapter.test.ts
+++ b/packages/jira-adapter/test/adapter.test.ts
@@ -67,6 +67,8 @@ describe('adapter', () => {
       credentials: createCredentialsInstance({ baseUrl: 'http:/jira.net', user: 'u', token: 't' }),
       config,
       getElemIdFunc,
+      stateVersion: '0.3.0',
+      currentVersion: '0.3.0',
     })
   })
   describe('deploy', () => {

--- a/packages/jira-adapter/test/adapter_creator.test.ts
+++ b/packages/jira-adapter/test/adapter_creator.test.ts
@@ -88,6 +88,8 @@ describe('adapter creator', () => {
           elementsSource,
           credentials: credentialsInstance,
           config: createConfigInstance(configWithExtraValue),
+          stateVersion: '0.3.0',
+          currentVersion: '0.3.0',
         })
       })
       it('should return jira operations', () => {
@@ -98,7 +100,12 @@ describe('adapter creator', () => {
     describe('without config', () => {
       it('should fail to create operations', () => {
         expect(
-          () => adapter.operations({ elementsSource, credentials: credentialsInstance })
+          () => adapter.operations({
+            elementsSource,
+            credentials: credentialsInstance,
+            stateVersion: '0.3.0',
+            currentVersion: '0.3.0',
+          })
         ).toThrow()
       })
     })
@@ -112,6 +119,8 @@ describe('adapter creator', () => {
             ...getDefaultConfig({ isDataCenter: false }),
             fetch: undefined,
           } as unknown as JiraConfig),
+          stateVersion: '0.3.0',
+          currentVersion: '0.3.0',
         })).toThrow()
       })
     })
@@ -125,6 +134,8 @@ describe('adapter creator', () => {
             ...getDefaultConfig({ isDataCenter: false }),
             apiDefinitions: { typeDefaults: 2 },
           } as unknown as JiraConfig),
+          stateVersion: '0.3.0',
+          currentVersion: '0.3.0',
         })).toThrow()
       })
     })

--- a/packages/netsuite-adapter/test/adapter_creator.test.ts
+++ b/packages/netsuite-adapter/test/adapter_creator.test.ts
@@ -173,6 +173,8 @@ describe('NetsuiteAdapter creator', () => {
         credentials,
         config,
         elementsSource: buildElementsSourceFromElements([]),
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
       })
       expect(SdfClient).toHaveBeenCalledWith({
         credentials: {
@@ -194,6 +196,8 @@ describe('NetsuiteAdapter creator', () => {
         credentials,
         config,
         elementsSource: buildElementsSourceFromElements([]),
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
       })
       expect(SuiteAppClient).not.toHaveBeenCalled()
     })
@@ -211,6 +215,8 @@ describe('NetsuiteAdapter creator', () => {
         credentials: cred,
         config,
         elementsSource: buildElementsSourceFromElements([]),
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
       })).toThrow('Missing SuiteApp login creds')
     })
 
@@ -227,6 +233,8 @@ describe('NetsuiteAdapter creator', () => {
         credentials: cred,
         config,
         elementsSource: buildElementsSourceFromElements([]),
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
       })
       expect(SuiteAppClient).toHaveBeenCalledWith({
         credentials: { ...cred.value, accountId: 'FOO_A' },
@@ -255,6 +263,8 @@ describe('NetsuiteAdapter creator', () => {
         credentials: cred,
         config: configuration,
         elementsSource: buildElementsSourceFromElements([]),
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
       })
       expect(SuiteAppClient).toHaveBeenCalledWith({
         credentials: { ...cred.value, accountId: 'FOO_A' },
@@ -275,6 +285,8 @@ describe('NetsuiteAdapter creator', () => {
         config,
         getElemIdFunc: mockGetElemIdFunc,
         elementsSource,
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
       })
       expect(NetsuiteAdapter).toHaveBeenCalledWith({
         client: expect.any(Object),
@@ -308,6 +320,8 @@ describe('NetsuiteAdapter creator', () => {
         config: conf,
         getElemIdFunc: mockGetElemIdFunc,
         elementsSource,
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
       })
       expect(NetsuiteAdapter).toHaveBeenCalledWith({
         client: expect.any(Object),
@@ -327,6 +341,8 @@ describe('NetsuiteAdapter creator', () => {
         credentials,
         getElemIdFunc: mockGetElemIdFunc,
         elementsSource,
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
       })
       expect(NetsuiteAdapter).toHaveBeenCalledWith({
         client: expect.any(Object),
@@ -350,6 +366,8 @@ describe('NetsuiteAdapter creator', () => {
           config: invalidConfig,
           getElemIdFunc: mockGetElemIdFunc,
           elementsSource: buildElementsSourceFromElements([]),
+          stateVersion: '0.3.0',
+          currentVersion: '0.3.0',
         })
       ).toThrow()
     })
@@ -372,6 +390,8 @@ describe('NetsuiteAdapter creator', () => {
           config: invalidConfig,
           getElemIdFunc: mockGetElemIdFunc,
           elementsSource: buildElementsSourceFromElements([]),
+          stateVersion: '0.3.0',
+          currentVersion: '0.3.0',
         })
       ).toThrow()
     })
@@ -396,6 +416,8 @@ describe('NetsuiteAdapter creator', () => {
           config: invalidConfig,
           getElemIdFunc: mockGetElemIdFunc,
           elementsSource: buildElementsSourceFromElements([]),
+          stateVersion: '0.3.0',
+          currentVersion: '0.3.0',
         })
       ).toThrow()
     })
@@ -418,6 +440,8 @@ describe('NetsuiteAdapter creator', () => {
           config: invalidConfig,
           getElemIdFunc: mockGetElemIdFunc,
           elementsSource: buildElementsSourceFromElements([]),
+          stateVersion: '0.3.0',
+          currentVersion: '0.3.0',
         })
       ).toThrow()
     })
@@ -439,6 +463,8 @@ describe('NetsuiteAdapter creator', () => {
             config: invalidConfig,
             getElemIdFunc: mockGetElemIdFunc,
             elementsSource: buildElementsSourceFromElements([]),
+            stateVersion: '0.3.0',
+            currentVersion: '0.3.0',
           })
         ).toThrow()
       })
@@ -459,6 +485,8 @@ describe('NetsuiteAdapter creator', () => {
             config: invalidConfig,
             getElemIdFunc: mockGetElemIdFunc,
             elementsSource: buildElementsSourceFromElements([]),
+            stateVersion: '0.3.0',
+            currentVersion: '0.3.0',
           })
         ).toThrow()
       })
@@ -478,6 +506,8 @@ describe('NetsuiteAdapter creator', () => {
             config: invalidConfig,
             getElemIdFunc: mockGetElemIdFunc,
             elementsSource: buildElementsSourceFromElements([]),
+            stateVersion: '0.3.0',
+            currentVersion: '0.3.0',
           })
         ).toThrow()
       })
@@ -497,6 +527,8 @@ describe('NetsuiteAdapter creator', () => {
             config: invalidConfig,
             getElemIdFunc: mockGetElemIdFunc,
             elementsSource: buildElementsSourceFromElements([]),
+            stateVersion: '0.3.0',
+            currentVersion: '0.3.0',
           })
         ).toThrow()
       })
@@ -518,6 +550,8 @@ describe('NetsuiteAdapter creator', () => {
             config: invalidConfig,
             getElemIdFunc: mockGetElemIdFunc,
             elementsSource: buildElementsSourceFromElements([]),
+            stateVersion: '0.3.0',
+            currentVersion: '0.3.0',
           })
         ).toThrow()
       })
@@ -539,6 +573,8 @@ describe('NetsuiteAdapter creator', () => {
             config: invalidConfig,
             getElemIdFunc: mockGetElemIdFunc,
             elementsSource: buildElementsSourceFromElements([]),
+            stateVersion: '0.3.0',
+            currentVersion: '0.3.0',
           })
         ).toThrow()
       })
@@ -561,6 +597,8 @@ describe('NetsuiteAdapter creator', () => {
             config: invalidConfig,
             getElemIdFunc: mockGetElemIdFunc,
             elementsSource: buildElementsSourceFromElements([]),
+            stateVersion: '0.3.0',
+            currentVersion: '0.3.0',
           })
         ).toThrow()
       })
@@ -581,6 +619,8 @@ describe('NetsuiteAdapter creator', () => {
             config: invalidConfig,
             getElemIdFunc: mockGetElemIdFunc,
             elementsSource: buildElementsSourceFromElements([]),
+            stateVersion: '0.3.0',
+            currentVersion: '0.3.0',
           })
         ).toThrow()
       })
@@ -601,6 +641,8 @@ describe('NetsuiteAdapter creator', () => {
             config: invalidConfig,
             getElemIdFunc: mockGetElemIdFunc,
             elementsSource: buildElementsSourceFromElements([]),
+            stateVersion: '0.3.0',
+            currentVersion: '0.3.0',
           })
         ).toThrow()
       })
@@ -621,6 +663,8 @@ describe('NetsuiteAdapter creator', () => {
             config: validConfig,
             getElemIdFunc: mockGetElemIdFunc,
             elementsSource: buildElementsSourceFromElements([]),
+            stateVersion: '0.3.0',
+            currentVersion: '0.3.0',
           })
         ).not.toThrow()
       })

--- a/packages/okta-adapter/test/adapter.test.ts
+++ b/packages/okta-adapter/test/adapter.test.ts
@@ -62,6 +62,8 @@ describe('Okta adapter', () => {
       credentials: createCredentialsInstance({ baseUrl: 'http:/okta.test', token: 't' }),
       config,
       getElemIdFunc,
+      stateVersion: '0.3.0',
+      currentVersion: '0.3.0',
     })
   })
 

--- a/packages/salesforce-adapter/test/adapter.creator.test.ts
+++ b/packages/salesforce-adapter/test/adapter.creator.test.ts
@@ -149,6 +149,8 @@ describe('SalesforceAdapter creator', () => {
         credentials,
         config,
         elementsSource: buildElementsSourceFromElements([]),
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
       })
       expect(SalesforceClient).toHaveBeenCalledWith({
         credentials: new UsernamePasswordCredentials({
@@ -173,6 +175,8 @@ describe('SalesforceAdapter creator', () => {
         credentials,
         config,
         elementsSource: buildElementsSourceFromElements([]),
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
       })
       expect(SalesforceAdapter).toHaveBeenCalledWith({
         config: {
@@ -210,6 +214,8 @@ describe('SalesforceAdapter creator', () => {
         credentials,
         config: invalidConfig,
         elementsSource: buildElementsSourceFromElements([]),
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
       })).toThrow()
     })
 
@@ -232,6 +238,8 @@ describe('SalesforceAdapter creator', () => {
         credentials,
         config: invalidConfig,
         elementsSource: buildElementsSourceFromElements([]),
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
       })).toThrow('Failed to load config due to an invalid fetch.data.includeObjects value. The following regular expressions are invalid: \\')
     })
 
@@ -255,6 +263,8 @@ describe('SalesforceAdapter creator', () => {
         credentials,
         config: invalidConfig,
         elementsSource: buildElementsSourceFromElements([]),
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
       })).toThrow('Failed to load config due to an invalid fetch.data.excludeObjects value. The following regular expressions are invalid: \\')
     })
 
@@ -278,6 +288,8 @@ describe('SalesforceAdapter creator', () => {
         credentials,
         config: invalidConfig,
         elementsSource: buildElementsSourceFromElements([]),
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
       })).toThrow('Failed to load config due to an invalid fetch.data.allowReferenceTo value. The following regular expressions are invalid: \\')
     })
 
@@ -303,6 +315,8 @@ describe('SalesforceAdapter creator', () => {
         credentials,
         config: invalidConfig,
         elementsSource: buildElementsSourceFromElements([]),
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
       })).toThrow('Failed to load config due to an invalid fetch.data.saltoIDSettings.overrides value. The following regular expressions are invalid: \\')
     })
 
@@ -328,6 +342,8 @@ describe('SalesforceAdapter creator', () => {
         credentials,
         config: invalidConfig,
         elementsSource: buildElementsSourceFromElements([]),
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
       })).toThrow('Failed to load config due to an invalid fetch.data.includeObjects value. includeObjects is required when dataManagement is configured')
     })
 
@@ -347,6 +363,8 @@ describe('SalesforceAdapter creator', () => {
         credentials,
         config: invalidConfig,
         elementsSource: buildElementsSourceFromElements([]),
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
       })).toThrow('Failed to load config due to an invalid fetch.data.saltoIDSettings value. saltoIDSettings is required when dataManagement is configured')
     })
 
@@ -371,6 +389,8 @@ describe('SalesforceAdapter creator', () => {
         credentials,
         config: invalidConfig,
         elementsSource: buildElementsSourceFromElements([]),
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
       })).toThrow('Failed to load config due to an invalid fetch.data.saltoIDSettings.defaultIdFields value. saltoIDSettings.defaultIdFields is required when dataManagement is configured')
     })
 
@@ -393,6 +413,8 @@ describe('SalesforceAdapter creator', () => {
         credentials,
         config: invalidConfig,
         elementsSource: buildElementsSourceFromElements([]),
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
       })).toThrow('Failed to load config due to an invalid client.maxConcurrentApiRequests value. maxConcurrentApiRequests values cannot be set to 0. Invalid keys: read')
     })
     it('should not throw an error when all rate limits client.maxConcurrentApiRequests are valid', () => {
@@ -413,6 +435,8 @@ describe('SalesforceAdapter creator', () => {
         credentials,
         config: validConfig,
         elementsSource: buildElementsSourceFromElements([]),
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
       })).not.toThrow()
     })
 
@@ -426,6 +450,8 @@ describe('SalesforceAdapter creator', () => {
         credentials,
         config: validConfig,
         elementsSource: buildElementsSourceFromElements([]),
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
       })).not.toThrow()
     })
 
@@ -447,6 +473,8 @@ describe('SalesforceAdapter creator', () => {
         credentials,
         config: validConfig,
         elementsSource: buildElementsSourceFromElements([]),
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
       }
       expect(() => adapter.operations(adapterContext)).not.toThrow()
       validConfig.value.client.retry.retryStrategy = 'HTTPOrNetworkError'
@@ -467,6 +495,8 @@ describe('SalesforceAdapter creator', () => {
         credentials,
         config: invalidConfig,
         elementsSource: buildElementsSourceFromElements([]),
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
       })).toThrow('Failed to load config due to an invalid client.clientConfig.retry.retryStrategy value. retryStrategy value \'somethingElse\' is not supported')
     })
 
@@ -474,6 +504,8 @@ describe('SalesforceAdapter creator', () => {
       expect(() => adapter.operations({
         credentials,
         elementsSource: buildElementsSourceFromElements([]),
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
       })).not.toThrow()
     })
   })
@@ -488,6 +520,8 @@ describe('SalesforceAdapter creator', () => {
           credentials,
           elementsSource: buildElementsSourceFromElements([]),
           config: configClone,
+          stateVersion: '0.3.0',
+          currentVersion: '0.3.0',
         })).toThrow('Failed to load config due to an invalid instancesRegexSkippedList value. The following regular expressions are invalid: (')
       })
 
@@ -499,6 +533,8 @@ describe('SalesforceAdapter creator', () => {
           credentials,
           elementsSource: buildElementsSourceFromElements([]),
           config: configClone,
+          stateVersion: '0.3.0',
+          currentVersion: '0.3.0',
         })).not.toThrow()
       })
     })
@@ -512,6 +548,8 @@ describe('SalesforceAdapter creator', () => {
           credentials,
           elementsSource: buildElementsSourceFromElements([]),
           config: configClone,
+          stateVersion: '0.3.0',
+          currentVersion: '0.3.0',
         })).toThrow('Failed to load config due to an invalid dataManagement.includeObjects value. includeObjects is required when dataManagement is configured')
       })
 
@@ -531,6 +569,8 @@ describe('SalesforceAdapter creator', () => {
           credentials,
           elementsSource: buildElementsSourceFromElements([]),
           config: configClone,
+          stateVersion: '0.3.0',
+          currentVersion: '0.3.0',
         })).not.toThrow()
       })
 
@@ -552,6 +592,8 @@ describe('SalesforceAdapter creator', () => {
           credentials,
           elementsSource: buildElementsSourceFromElements([]),
           config: configClone,
+          stateVersion: '0.3.0',
+          currentVersion: '0.3.0',
         })).toThrow('Failed to load config due to an invalid dataManagement value. fetch.data configuration option cannot be used with dataManagement option. The configuration of dataManagement should be moved to fetch.data')
       })
     })
@@ -565,6 +607,8 @@ describe('SalesforceAdapter creator', () => {
           credentials,
           elementsSource: buildElementsSourceFromElements([]),
           config: configClone,
+          stateVersion: '0.3.0',
+          currentVersion: '0.3.0',
         })).not.toThrow()
       })
     })
@@ -579,6 +623,8 @@ describe('SalesforceAdapter creator', () => {
       credentials,
       config: deprecatedConfig,
       elementsSource: buildElementsSourceFromElements([]),
+      stateVersion: '0.3.0',
+      currentVersion: '0.3.0',
     })
     it('pass to the adapter operation configuration without deprecated fields', () => {
       expect(SalesforceAdapter).toHaveBeenCalledWith({

--- a/packages/stripe-adapter/test/adapter.test.ts
+++ b/packages/stripe-adapter/test/adapter.test.ts
@@ -84,6 +84,8 @@ describe('stripe swagger adapter', () => {
       credentials: CREDENTIALS,
       config,
       elementsSource: buildElementsSourceFromElements([]),
+      stateVersion: '0.3.0',
+      currentVersion: '0.3.0',
     }).fetch({ progressReporter: { reportProgress: () => null } })
 
     return elements.filter(isInstanceElement)
@@ -328,6 +330,8 @@ describe('stripe swagger adapter', () => {
         credentials: CREDENTIALS,
         config: DEFAULT_CONFIG_INSTANCE,
         elementsSource: buildElementsSourceFromElements([]),
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
       })
       const deployOptions = { changeGroup: { groupID: '', changes: [] } }
       await expect(adapterOperations.deploy(deployOptions)).rejects.toThrow(new Error('Not implemented.'))

--- a/packages/stripe-adapter/test/adapter_creator.test.ts
+++ b/packages/stripe-adapter/test/adapter_creator.test.ts
@@ -65,6 +65,8 @@ describe('adapter creator', () => {
         },
       ),
       elementsSource: buildElementsSourceFromElements([]),
+      stateVersion: '0.3.0',
+      currentVersion: '0.3.0',
     })).toBeDefined()
   })
   it('should return the stripe adapter if configuration is missing', () => {
@@ -75,6 +77,8 @@ describe('adapter creator', () => {
         { token: 'aaa' },
       ),
       elementsSource: buildElementsSourceFromElements([]),
+      stateVersion: '0.3.0',
+      currentVersion: '0.3.0',
     })).toBeDefined()
     expect(adapter.operations({
       credentials: new InstanceElement(
@@ -84,6 +88,8 @@ describe('adapter creator', () => {
       ),
       config: new InstanceElement(STRIPE, adapter.configType as ObjectType),
       elementsSource: buildElementsSourceFromElements([]),
+      stateVersion: '0.3.0',
+      currentVersion: '0.3.0',
     })).toBeDefined()
   })
   it('should ignore unexpected configuration values', () => {
@@ -108,6 +114,8 @@ describe('adapter creator', () => {
         },
       ),
       elementsSource: buildElementsSourceFromElements([]),
+      stateVersion: '0.3.0',
+      currentVersion: '0.3.0',
     })).toBeDefined()
   })
 
@@ -142,6 +150,8 @@ describe('adapter creator', () => {
         },
       ),
       elementsSource: buildElementsSourceFromElements([]),
+      stateVersion: '0.3.0',
+      currentVersion: '0.3.0',
     })).toThrow(new Error('Duplicate fieldsToHide params found in apiDefinitions for the following types: Product'))
 
     expect(() => adapter.operations({
@@ -169,6 +179,8 @@ describe('adapter creator', () => {
         },
       ),
       elementsSource: buildElementsSourceFromElements([]),
+      stateVersion: '0.3.0',
+      currentVersion: '0.3.0',
     })).toThrow(new Error('Invalid type names in fetch: country_spec2 does not match any of the supported types.'))
   })
 

--- a/packages/workato-adapter/test/adapter.test.ts
+++ b/packages/workato-adapter/test/adapter.test.ts
@@ -74,6 +74,8 @@ describe('adapter', () => {
             }
           ),
           elementsSource: buildElementsSourceFromElements([]),
+          stateVersion: '0.3.0',
+          currentVersion: '0.3.0',
         }).fetch({ progressReporter: { reportProgress: () => null } })
         expect(elements).toHaveLength(85)
         expect(elements.filter(isObjectType)).toHaveLength(49)
@@ -278,6 +280,8 @@ describe('adapter', () => {
             },
           ),
           elementsSource: buildElementsSourceFromElements([]),
+          stateVersion: '0.3.0',
+          currentVersion: '0.3.0',
         }).fetch({ progressReporter: { reportProgress: () => null } })
         expect(elements.map(e => e.elemID.getFullName()).sort()).toEqual([
           'workato.api_access_profile',
@@ -332,6 +336,8 @@ describe('adapter', () => {
             }
             return new ElemID(adapterName, name)
           },
+          stateVersion: '0.3.0',
+          currentVersion: '0.3.0',
         })
         const { elements } = await operations
           .fetch({ progressReporter: { reportProgress: () => null } })
@@ -406,6 +412,8 @@ describe('adapter', () => {
             }
           ),
           elementsSource: buildElementsSourceFromElements([]),
+          stateVersion: '0.3.0',
+          currentVersion: '0.3.0',
         }) as types.PickyRequired<AdapterOperations, 'postFetch'>
         const fetchResult = await adapterOperations.fetch({
           progressReporter: { reportProgress: () => null },
@@ -455,6 +463,8 @@ describe('adapter', () => {
           }
         ),
         elementsSource: buildElementsSourceFromElements([]),
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
       })
       await expect(operations.deploy({ changeGroup: { groupID: '', changes: [] } })).rejects.toThrow(new Error('Not implemented.'))
     })

--- a/packages/workato-adapter/test/adapter_creator.test.ts
+++ b/packages/workato-adapter/test/adapter_creator.test.ts
@@ -60,6 +60,8 @@ describe('adapter creator', () => {
         },
       ),
       elementsSource: buildElementsSourceFromElements([]),
+      stateVersion: '0.3.0',
+      currentVersion: '0.3.0',
     })).toBeDefined()
   })
 
@@ -82,6 +84,8 @@ describe('adapter creator', () => {
         },
       ),
       elementsSource: buildElementsSourceFromElements([]),
+      stateVersion: '0.3.0',
+      currentVersion: '0.3.0',
     })).toBeDefined()
   })
 
@@ -116,6 +120,8 @@ describe('adapter creator', () => {
         },
       ),
       elementsSource: buildElementsSourceFromElements([]),
+      stateVersion: '0.3.0',
+      currentVersion: '0.3.0',
     })).toThrow(new Error('Invalid type names in fetch: a,b does not match any of the supported types.'))
   })
 
@@ -150,6 +156,8 @@ describe('adapter creator', () => {
         },
       ),
       elementsSource: buildElementsSourceFromElements([]),
+      stateVersion: '0.3.0',
+      currentVersion: '0.3.0',
     })).toThrow(new Error('Unsupported service names in fetch.serviceConnectionNames: unsupportedName. The supported services are: salesforce,netsuite,zuora_billing'))
   })
 

--- a/packages/zendesk-adapter/package.json
+++ b/packages/zendesk-adapter/package.json
@@ -40,12 +40,14 @@
     "form-data": "^4.0.0",
     "joi": "^17.4.0",
     "lodash": "^4.17.21",
+    "semver": "^7.3.2",
     "uuid": "^8.3.0"
   },
   "devDependencies": {
     "@salto-io/test-utils": "0.3.23",
     "@types/jest": "^27.4.0",
     "@types/lodash": "^4.14.168",
+    "@types/semver": "^7.3.3",
     "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "4.22.1",
     "@typescript-eslint/parser": "4.22.1",

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -102,6 +102,8 @@ describe('adapter', () => {
             }
           ),
           elementsSource: buildElementsSourceFromElements([]),
+          stateVersion: '0.3.0',
+          currentVersion: '0.3.0',
         }).fetch({ progressReporter: { reportProgress: () => null } })
         expect(elements.map(e => e.elemID.getFullName()).sort()).toEqual([
           'zendesk.account_setting',
@@ -599,6 +601,8 @@ describe('adapter', () => {
             },
           ),
           elementsSource: buildElementsSourceFromElements([]),
+          stateVersion: '0.3.0',
+          currentVersion: '0.3.0',
         }).fetch({ progressReporter: { reportProgress: () => null } })
         const instances = elements.filter(isInstanceElement)
         expect(instances.map(e => e.elemID.getFullName()).sort())
@@ -668,6 +672,8 @@ describe('adapter', () => {
           }
           return new ElemID(adapterName, name)
         },
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
       })
       const { elements } = await operations
         .fetch({ progressReporter: { reportProgress: () => null } })
@@ -876,6 +882,8 @@ describe('adapter', () => {
           }
         ),
         elementsSource: buildElementsSourceFromElements([]),
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
       })
     })
     afterEach(() => {

--- a/packages/zendesk-adapter/test/adapter_creator.test.ts
+++ b/packages/zendesk-adapter/test/adapter_creator.test.ts
@@ -86,6 +86,8 @@ describe('adapter creator', () => {
         },
       ),
       elementsSource: buildElementsSourceFromElements([]),
+      stateVersion: '0.3.0',
+      currentVersion: '0.3.0',
     })).toBeDefined()
 
     // with OAuth auth method
@@ -115,6 +117,8 @@ describe('adapter creator', () => {
         },
       ),
       elementsSource: buildElementsSourceFromElements([]),
+      stateVersion: '0.3.0',
+      currentVersion: '0.3.0',
     })).toBeDefined()
   })
 
@@ -139,6 +143,8 @@ describe('adapter creator', () => {
         },
       ),
       elementsSource: buildElementsSourceFromElements([]),
+      stateVersion: '0.3.0',
+      currentVersion: '0.3.0',
     })).toBeDefined()
   })
 
@@ -173,6 +179,8 @@ describe('adapter creator', () => {
         },
       ),
       elementsSource: buildElementsSourceFromElements([]),
+      stateVersion: '0.3.0',
+      currentVersion: '0.3.0',
     })).toThrow(new Error('Invalid type names in fetch: a,b does not match any of the supported types.'))
   })
 

--- a/packages/zuora-billing-adapter/test/adapter.test.ts
+++ b/packages/zuora-billing-adapter/test/adapter.test.ts
@@ -259,6 +259,8 @@ describe('adapter', () => {
             DEFAULT_CONFIG,
           ),
           elementsSource: buildElementsSourceFromElements([]),
+          stateVersion: '0.3.0',
+          currentVersion: '0.3.0',
         }).fetch({ progressReporter: { reportProgress: () => null } })
 
         expect(adapterComponents.elements.swagger.generateTypes).toHaveBeenCalledTimes(2)
@@ -341,6 +343,8 @@ describe('adapter', () => {
           }
         ),
         elementsSource: buildElementsSourceFromElements([]),
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
       }).fetch({ progressReporter: { reportProgress: () => null } })
       expect(updatedConfig).toBeUndefined()
     })
@@ -368,6 +372,8 @@ describe('adapter', () => {
           }
         ),
         elementsSource: buildElementsSourceFromElements([]),
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
       }).fetch({ progressReporter: { reportProgress: () => null } })
       expect(updatedConfig).toBeDefined()
       expect(updatedConfig?.config[0].value[FETCH_CONFIG].include).toEqual([{ type: '.*' }])
@@ -399,6 +405,8 @@ describe('adapter', () => {
           }
         ),
         elementsSource: buildElementsSourceFromElements([]),
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
       }).fetch({ progressReporter: { reportProgress: () => null } })
       expect(updatedConfig).toBeDefined()
     })
@@ -426,6 +434,8 @@ describe('adapter', () => {
             }
           ),
           elementsSource: buildElementsSourceFromElements([]),
+          stateVersion: '0.3.0',
+          currentVersion: '0.3.0',
         }).fetch({ progressReporter: { reportProgress: () => null } })
 
         expect(adapterComponents.elements.swagger.generateTypes).toHaveBeenCalledTimes(1)
@@ -480,6 +490,8 @@ describe('adapter', () => {
             }
           ),
           elementsSource: buildElementsSourceFromElements([]),
+          stateVersion: '0.3.0',
+          currentVersion: '0.3.0',
         }).fetch({ progressReporter: { reportProgress: () => null } })
 
         expect(adapterComponents.elements.swagger.generateTypes).toHaveBeenCalledTimes(1)
@@ -524,6 +536,8 @@ describe('adapter', () => {
           DEFAULT_CONFIG,
         ),
         elementsSource: buildElementsSourceFromElements([]),
+        stateVersion: '0.3.0',
+        currentVersion: '0.3.0',
       })
       await expect(operations.deploy({ changeGroup: { groupID: '', changes: [] } })).rejects.toThrow(new Error('Not implemented.'))
     })

--- a/packages/zuora-billing-adapter/test/adapter_creator.test.ts
+++ b/packages/zuora-billing-adapter/test/adapter_creator.test.ts
@@ -65,6 +65,8 @@ describe('adapter creator', () => {
         },
       ),
       elementsSource: buildElementsSourceFromElements([]),
+      stateVersion: '0.3.0',
+      currentVersion: '0.3.0',
     })).toBeDefined()
   })
   it('should return the zuora_billing adapter if configuration is missing', () => {
@@ -75,6 +77,8 @@ describe('adapter creator', () => {
         { clientId: 'id', clientSecret: 'secret', subdomain: 'sandbox.na', production: false },
       ),
       elementsSource: buildElementsSourceFromElements([]),
+      stateVersion: '0.3.0',
+      currentVersion: '0.3.0',
     })).toBeDefined()
     expect(adapter.operations({
       credentials: new InstanceElement(
@@ -84,6 +88,8 @@ describe('adapter creator', () => {
       ),
       config: new InstanceElement(ZUORA_BILLING, adapter.configType as ObjectType),
       elementsSource: buildElementsSourceFromElements([]),
+      stateVersion: '0.3.0',
+      currentVersion: '0.3.0',
     })).toBeDefined()
   })
   it('should ignore unexpected configuration values', () => {
@@ -108,6 +114,8 @@ describe('adapter creator', () => {
         },
       ),
       elementsSource: buildElementsSourceFromElements([]),
+      stateVersion: '0.3.0',
+      currentVersion: '0.3.0',
     })).toBeDefined()
   })
 
@@ -143,6 +151,8 @@ describe('adapter creator', () => {
         },
       ),
       elementsSource: buildElementsSourceFromElements([]),
+      stateVersion: '0.3.0',
+      currentVersion: '0.3.0',
     })).toThrow(new Error('Duplicate fieldsToHide params found in apiDefinitions for the following types: CustomObject'))
 
     expect(() => adapter.operations({
@@ -180,6 +190,8 @@ describe('adapter creator', () => {
         },
       ),
       elementsSource: buildElementsSourceFromElements([]),
+      stateVersion: '0.3.0',
+      currentVersion: '0.3.0',
     })).toThrow(new Error('Invalid type names in fetch: CatalogProduct2 does not match any of the supported types.'))
   })
 
@@ -207,6 +219,8 @@ describe('adapter creator', () => {
         },
       ),
       elementsSource: buildElementsSourceFromElements([]),
+      stateVersion: '0.3.0',
+      currentVersion: '0.3.0',
     })).toThrow(new Error('\'sandbox.na\' is a sandbox subdomain and cannot be used for production'))
     expect(() => adapter.operations({
       credentials: new InstanceElement(
@@ -231,6 +245,8 @@ describe('adapter creator', () => {
         },
       ),
       elementsSource: buildElementsSourceFromElements([]),
+      stateVersion: '0.3.0',
+      currentVersion: '0.3.0',
     })).toThrow(new Error('\'\' is not a valid sandbox subdomain'))
   })
 


### PR DESCRIPTION
Make adapters aware of the previous and current fetch versions. 

---

Also made `getAdaptersCreatorConfigs` and `getAdapters` accept named parameters. `getAdaptersCreatorConfigs` is technically exported, but it is not expected to be used directly externally AFAICT.

Some caveats that will need to be revisited:
1. The state version is actually the minimal version from all accounts - if there was a fetch that only contained some of the accounts, the version may be incorrect
2. The versions are created at the end of the fetch operation - that means they cannot really be used to identify a configuration version (since the adapter configuration is set when the account is first added, which may have been earlier than the fetch)

---
_Release Notes_: 
None

---
_User Notifications_: 
None