### PR TITLE
SALTO-2789 - Add parameter to clone element to all environments

### DIFF
--- a/packages/cli/src/commands/element.ts
+++ b/packages/cli/src/commands/element.ts
@@ -314,10 +314,10 @@ const validateToEnvs = (
   workspace: Workspace
 ) : { envsToCloneTo: string[]; envsValidateError?: string } => {
   if (!toEnvs && !toAllEnvs) {
-    return { envsToCloneTo: [], envsValidateError: 'Must declare either --to-envs or --to-all-envs' }
+    return { envsToCloneTo: [], envsValidateError: 'either \'--to-envs or\' \'--to-all-envs\' is required' }
   }
   if (toEnvs && toAllEnvs) {
-    return { envsToCloneTo: [], envsValidateError: 'Can\'t choose both --to-envs and --to-all-envs' }
+    return { envsToCloneTo: [], envsValidateError: 'both \'--to-envs\' and \'--to-all-envs\' is not allowed' }
   }
   const envsToCloneTo = toEnvs || [...workspace.envs()]
   return { envsToCloneTo }
@@ -407,6 +407,7 @@ const cloneDef = createWorkspaceCommand({
         required: false,
         description: 'Clone to all environments but for the source environment',
         type: 'boolean',
+        alias: 'a',
 
       },
       // TODO: Check if needed

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -339,6 +339,9 @@ ${Prompts.LIST_IDS(ids)}
     error: string
   ): string => `Failed to clone the specified elements to the target environments: ${error}`
 
+  public static readonly CLONE_NO_TARGET_ENV = 'Either \'--to-envs or\' \'--to-all-envs\' is required'
+  public static readonly CLONE_CONFLICT_TARGET_ENV = 'both \'--to-envs\' and \'--to-all-envs\' is not allowed'
+
   public static readonly UNKNOWN_STATE_SALTO_VERSION = 'Can not determine the Salto version that was when the state of the accounts was last fetched. It is highly recommended to run the fetch command before proceeding - do you want to cancel?'
   public static readonly OLD_STATE_SALTO_VERSION = (
     stateSaltoVersion: string

--- a/packages/cli/test/commands/element.test.ts
+++ b/packages/cli/test/commands/element.test.ts
@@ -23,6 +23,7 @@ import * as mocks from '../mocks'
 import * as callbacks from '../../src/callbacks'
 import Prompts from '../../src/prompts'
 import { formatTargetEnvRequired } from '../../src/formatter'
+import { MockWorkspace } from '../mocks'
 
 const { awu } = collections.asynciterable
 
@@ -339,6 +340,59 @@ Cloning the specified elements to inactive.
       it('should print failure to console', () => {
         expect(output.stderr.content)
           .toContain(Prompts.INVALID_ENV_TARGET_CURRENT)
+      })
+    })
+
+    describe('clone with target envs and --to-all-envs params', () => {
+      const runClone = async ({ toEnvs, toAllEnvs, workspace }
+          : {toEnvs?: string[]; toAllEnvs?: boolean; workspace?: MockWorkspace })
+          : Promise<{ result: CliExitCode; output: mocks.MockCliOutput }> => {
+        const cliArgs = mocks.mockCliArgs()
+        const { output } = cliArgs
+        const selector = new ElemID('salto', 'Account')
+        const result = await cloneAction({
+          ...mocks.mockCliCommandArgs(cloneName, cliArgs),
+          input: {
+            elementSelector: [selector.getFullName()],
+            toEnvs,
+            toAllEnvs,
+            env: 'active',
+            force: true,
+            allowElementDeletions: false,
+          },
+          workspace: workspace || mocks.mockWorkspace({}),
+        })
+        return { result, output }
+      }
+
+      it('should fail receiving both toEnvs and toAllEnvs', async () => {
+        const { result, output } = await runClone({ toEnvs: ['env1'], toAllEnvs: true })
+        expect(result).toBe(CliExitCode.UserInputError)
+        expect(output.stderr.content).toContain(Prompts.CLONE_CONFLICT_TARGET_ENV)
+      })
+
+      it('should fail not receiving one of toEnvs or toAllEnvs', async () => {
+        const { result, output } = await runClone({ })
+        expect(result).toBe(CliExitCode.UserInputError)
+        expect(output.stderr.content).toContain(Prompts.CLONE_NO_TARGET_ENV)
+      })
+
+      it('should fail running toAllEnvs with only current env', async () => {
+        const workspace = mocks.mockWorkspace({ envs: ['active'] })
+        const { result, output } = await runClone({ toAllEnvs: true, workspace })
+        expect(result).toBe(CliExitCode.UserInputError)
+        expect(output.stderr.content).toContain(Prompts.TARGET_ENVS_REQUIRED)
+      })
+
+      it('should succeed cloning to all envs', async () => {
+        const envsToCloneTo = ['env1', 'env2', 'env3']
+        const workspace = mocks.mockWorkspace({ envs: ['active', ...envsToCloneTo] })
+        const selector = new ElemID('salto', 'Account')
+        workspace.getElementIdsBySelectors.mockResolvedValue(awu([selector]))
+
+        const { result, output } = await runClone({ toAllEnvs: true, workspace })
+        expect(result).toBe(CliExitCode.Success)
+        expect(output.stdout.content).toContain(envsToCloneTo.join(', '))
       })
     })
 


### PR DESCRIPTION
Added --to-all-envs parameter to element clone, which clones the elements to all environments but the source env

--to-envs and --to-all-envs can't be used together, and at least one of them have to be used
commander package doesn't give an option to do it so I created a function to do it manually

Release Notes:
In order to clone an element to all environments, the user can use a single parameter instead of using --to-envs and type all of them