### PR TITLE
SALTO-2800 simplify functions: getField, getSubType

### DIFF
--- a/packages/lang-server/src/completions/suggestions.ts
+++ b/packages/lang-server/src/completions/suggestions.ts
@@ -16,7 +16,7 @@
 import _ from 'lodash'
 import { TypeElement, Field, isObjectType, isInstanceElement, isPrimitiveType,
   isField, PrimitiveTypes, BuiltinTypes, Value, getField,
-  getFieldNames, getFieldType, ElemID,
+  getFieldNames, getSubType, ElemID,
   isListType, getRestriction, isMapType, ReadOnlyElementsSource } from '@salto-io/adapter-api'
 import { parser } from '@salto-io/workspace'
 import { resolvePath, safeJsonStringify } from '@salto-io/adapter-utils'
@@ -235,7 +235,7 @@ export const fieldValueSuggestions = async (params: SuggestionsParams): Promise<
     refPathWithAttr,
     params.elements,
   )
-  const valueFieldType = await getFieldType(
+  const valueFieldType = await getSubType(
     await params.ref.element.getType(params.elements),
     refPathWithAttr,
     params.elements,
@@ -283,7 +283,7 @@ export const annoValueSuggestions = async (params: SuggestionsParams): Promise<S
   const valueToken = _.last(params.tokens) || ''
   if (annoType && !_.isEmpty(refPath)) {
     const attrField = await getField(annoType, refPath, params.elements)
-    const attrFieldType = await getFieldType(annoType, refPath, params.elements)
+    const attrFieldType = await getSubType(annoType, refPath, params.elements)
     return (attrField && attrFieldType)
       ? awu(await valueSuggestions(annoName, attrField, attrFieldType, valueToken, params.elements))
         .concat(await referenceSuggestions(params.elements, valueToken))

--- a/packages/netsuite-adapter/src/reference_dependencies.ts
+++ b/packages/netsuite-adapter/src/reference_dependencies.ts
@@ -15,7 +15,7 @@
 */
 import { logger } from '@salto-io/logging'
 import {
-  isInstanceElement, isPrimitiveType, ElemID, getFieldType,
+  isInstanceElement, isPrimitiveType, ElemID, getSubType,
   isReferenceExpression, Value, isServiceId, isObjectType, Element,
 } from '@salto-io/adapter-api'
 import { transformElement, TransformFunc } from '@salto-io/adapter-utils'
@@ -38,7 +38,7 @@ export const findDependingElementsFromRefs = async (
     elemId: ElemID
   ): Promise<boolean> => {
     if (isInstanceElement(topLevelParent)) {
-      const fieldType = await getFieldType(
+      const fieldType = await getSubType(
         await topLevelParent.getType(),
         elemId.createTopLevelParentID().path
       )

--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -20,7 +20,7 @@ import { transformElement, TransformFunc, transformValues, applyFunctionToChange
 import { CORE_ANNOTATIONS, Element, isInstanceElement, isType, TypeElement, getField,
   DetailedChange, isRemovalChange, ElemID, isObjectType, ObjectType, Values,
   isRemovalOrModificationChange, isAdditionOrModificationChange, isElement, isField,
-  ReadOnlyElementsSource, ReferenceMap, isPrimitiveType, PrimitiveType, InstanceElement, Field, isModificationChange, ModificationChange, ReferenceExpression, MapType, getFieldType, isMapType, isTypeReference } from '@salto-io/adapter-api'
+  ReadOnlyElementsSource, ReferenceMap, isPrimitiveType, PrimitiveType, InstanceElement, Field, isModificationChange, ModificationChange, ReferenceExpression, MapType, getSubType, isMapType, isTypeReference } from '@salto-io/adapter-api'
 import { mergeElements, MergeResult } from '../merger'
 import { State } from './state'
 import { createAddChange, createRemoveChange } from './nacl_files/multi_env/projections'
@@ -808,7 +808,7 @@ export const filterOutHiddenChanges = async (
         return { hidden: change }
       }
 
-      const fieldType = changeType && await getFieldType(changeType, changePath, state)
+      const fieldType = changeType && await getSubType(changeType, changePath, state)
       if (isObjectType(fieldType) || isMapType(fieldType)) {
         const visible = await applyFunctionToChangeData(
           change,


### PR DESCRIPTION
simplify functions: getField, getSubType

---
Additional context:
The bugfix was removing the line `if (type.annotationRefTypes[key]) return (await type.getAnnotationTypes(elementsSource))?.[key]`, since the functions should recurse into fields/map/list keys only.
The rest of the code is a refactor to `getField` & `getSubType` (instead of `getFieldType`).

---
_Release Notes_: 
Adapter API:
- Delete unused function `getSubElement`
- Simplify functions: `getField`, `getSubType` (instead of `getFieldType`) 
- Fix bug where no field is returned when there is an annotation with the same name as the field

---
_User Notifications_: 
None