### PR TITLE
SALTO-2801 Fix "Can not resolve value of reference with ElemID serviceid" error …

### DIFF
--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -172,9 +172,11 @@ export default class NetsuiteClient {
     elements: Element[],
     deployReferencedElements: boolean
   ): Promise<CustomizationInfo[]> {
+    const elemIdSet = new Set(elements.map(element => element.elemID.getFullName()))
     const fieldsParents = _(elements)
       .filter(isField)
       .map(field => field.parent)
+      .filter(parent => !elemIdSet.has(parent.elemID.getFullName()))
       .uniqBy(parent => parent.elemID.name)
       .value()
 

--- a/packages/netsuite-adapter/src/reference_dependencies.ts
+++ b/packages/netsuite-adapter/src/reference_dependencies.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import {
   isInstanceElement, isPrimitiveType, ElemID, getFieldType,
@@ -149,7 +150,10 @@ const getRequiredReferencedElements = (
 
   log.debug(`adding referenced element:${os.EOL}${requiredReferencedElements.map(elem => elem.elemID.getFullName()).join('\n')}`)
 
-  return Array.from(new Set(sourceElements.concat(requiredReferencedElements)))
+  return _.uniqBy(
+    sourceElements.concat(requiredReferencedElements),
+    element => element.elemID.getFullName()
+  )
 }
 
 export const getReferencedElements = async (


### PR DESCRIPTION
…on SDF validation of custom record type addition

---
_Release Notes_: 
Netsuite Adapter:
- Fix "Can not resolve value of reference with ElemID serviceid" error on SDF validation of custom record type addition.

---
_User Notifications_: 
None