### PR TITLE
SALTO-2832: Flush all state files when flushing workspace

### DIFF
--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -1148,7 +1148,8 @@ export const loadWorkspace = async (
       await currentWSState.mergeManager.flush()
       await (await getLoadedNaclFilesSource()).flush()
       await adaptersConfig.flush()
-      await state().flush()
+      await awu(Object.values(environmentsSources.sources))
+        .forEach(envSource => envSource.state?.flush())
     },
     clone: (): Promise<Workspace> => {
       const sources = _.mapValues(environmentsSources.sources, source =>

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -2162,6 +2162,35 @@ describe('workspace', () => {
       expect(mapFlushCounter['workspace-default-errors']).toEqual(1)
       expect(mapFlushCounter['workspace-default-validationErrors']).toEqual(1)
     })
+    describe('with multiple environments', () => {
+      let workspace: Workspace
+      let env1StateFlush: jest.SpiedFunction<State['flush']>
+      let env2StateFlush: jest.SpiedFunction<State['flush']>
+      beforeEach(async () => {
+        const env1State = mockState()
+        const env2State = mockState()
+        env1StateFlush = jest.spyOn(env1State, 'flush')
+        env2StateFlush = jest.spyOn(env2State, 'flush')
+        workspace = await createWorkspace(
+          mockDirStore(),
+          undefined,
+          mockWorkspaceConfigSource(undefined, true),
+          undefined,
+          undefined,
+          undefined,
+          {
+            default: { naclFiles: createMockNaclFileSource([]), state: env1State },
+            inactive: { naclFiles: createMockNaclFileSource([]), state: env2State },
+            [COMMON_ENV_PREFIX]: { naclFiles: createMockNaclFileSource([]) },
+          },
+        )
+        await workspace.flush()
+      })
+      it('should flush all state files', () => {
+        expect(env1StateFlush).toHaveBeenCalled()
+        expect(env2StateFlush).toHaveBeenCalled()
+      })
+    })
   })
 
   describe('setCurrentEnv', () => {


### PR DESCRIPTION
Currently all nacl source are flushed when flushing a workspace but only the state of the current environment is flushed.

Since loading a workspace requires loading the state of all environments, it would make sense that for symmetry (and to avoid cache invalidations) we would also flush the state of all environments

---



---
_Release Notes_: 
Core:
- Fixed issue where the cache on multi-env workspaces would not always be fully updated

---
_User Notifications_: 
_None_