### PR TITLE
SALTO-2729: Fix reference by name when there are multiple fields with the same name

### DIFF
--- a/packages/jira-adapter/src/filters/jql/template_expression_generator.ts
+++ b/packages/jira-adapter/src/filters/jql/template_expression_generator.ts
@@ -139,7 +139,7 @@ const getFieldInfo = (
   field: JqlField,
   jqlContext: JqlContext,
 ): {
-  fieldInfo: FieldInfo | undefined
+  fieldInfo?: FieldInfo
   error?: 'ambiguous'
  } => {
   let fieldIdentifier = field.value.toLowerCase()

--- a/packages/jira-adapter/test/filters/automation/smart_values/smart_value_reference_filter.test.ts
+++ b/packages/jira-adapter/test/filters/automation/smart_values/smart_value_reference_filter.test.ts
@@ -143,6 +143,14 @@ describe('smart_value_reference_filter', () => {
         await filter.onFetch(elements)
         expect(automation.value).toEqual(originalAutomation.value)
       })
+
+      it('should not parse if there are two fields with the same name', async () => {
+        const auto = automationInstance.clone()
+        const field = fieldInstance.clone()
+        field.value.id = 'id'
+        await filter.onFetch([auto, field, field])
+        expect(auto.value.components[0].value.inner).toBe('Field is: {{issue.fieldOne}} {{issue.fieldId}} ending')
+      })
     })
     describe('preDeploy', () => {
       let elementsBeforeFetch: (InstanceElement | ObjectType)[]

--- a/packages/jira-adapter/test/filters/automation/smart_values/template_expression_generator.test.ts
+++ b/packages/jira-adapter/test/filters/automation/smart_values/template_expression_generator.test.ts
@@ -19,7 +19,7 @@ import { stringToTemplate } from '../../../../src/filters/automation/smart_value
 
 describe('stringToTemplate', () => {
   let idToField: Record<string, InstanceElement>
-  let nameToField: Record<string, InstanceElement>
+  let nameToField: Record<string, InstanceElement[]>
   let systemField: InstanceElement
   let customField: InstanceElement
 
@@ -55,35 +55,37 @@ describe('stringToTemplate', () => {
 
     [systemField, customField].forEach(field => {
       idToField[field.value.id] = field
-      nameToField[field.value.name] = field
+      nameToField[field.value.name] = [field]
     })
   })
 
   it('should resolve system field by id', () => {
-    const x = stringToTemplate({
+    expect(stringToTemplate({
       referenceStr: '1-{{system}} 2-{{issue.system}} 3-{{issue.system.something}} 4-{{issue.fields.system.something}} 5-{{fields.system}} 6-{{destinationIssue.system}} 7-{{triggerIssue.system}}system',
       fieldInstancesByName: nameToField,
       fieldInstancesById: idToField,
+    })).toEqual({
+      template: new TemplateExpression({
+        parts: [
+          '1-{{',
+          new ReferenceExpression(systemField.elemID, systemField),
+          '}} 2-{{issue.',
+          new ReferenceExpression(systemField.elemID, systemField),
+          '}} 3-{{issue.',
+          new ReferenceExpression(systemField.elemID, systemField),
+          '.something}} 4-{{issue.fields.',
+          new ReferenceExpression(systemField.elemID, systemField),
+          '.something}} 5-{{fields.',
+          new ReferenceExpression(systemField.elemID, systemField),
+          '}} 6-{{destinationIssue.',
+          new ReferenceExpression(systemField.elemID, systemField),
+          '}} 7-{{triggerIssue.',
+          new ReferenceExpression(systemField.elemID, systemField),
+          '}}system',
+        ],
+      }),
+      ambiguousTokens: new Set(),
     })
-    expect(x).toEqual(new TemplateExpression({
-      parts: [
-        '1-{{',
-        new ReferenceExpression(systemField.elemID, systemField),
-        '}} 2-{{issue.',
-        new ReferenceExpression(systemField.elemID, systemField),
-        '}} 3-{{issue.',
-        new ReferenceExpression(systemField.elemID, systemField),
-        '.something}} 4-{{issue.fields.',
-        new ReferenceExpression(systemField.elemID, systemField),
-        '.something}} 5-{{fields.',
-        new ReferenceExpression(systemField.elemID, systemField),
-        '}} 6-{{destinationIssue.',
-        new ReferenceExpression(systemField.elemID, systemField),
-        '}} 7-{{triggerIssue.',
-        new ReferenceExpression(systemField.elemID, systemField),
-        '}}system',
-      ],
-    }))
   })
 
   it('should resolve system field by name', () => {
@@ -91,25 +93,28 @@ describe('stringToTemplate', () => {
       referenceStr: '1-{{SystemName}} 2-{{issue.SystemName}} 3-{{issue.SystemName.something}} 4-{{issue.fields.SystemName.something}} 5-{{fields.SystemName}} 6-{{destinationIssue.SystemName}} 7-{{triggerIssue.SystemName}}SystemName',
       fieldInstancesByName: nameToField,
       fieldInstancesById: idToField,
-    })).toEqual(new TemplateExpression({
-      parts: [
-        '1-{{',
-        new ReferenceExpression(systemField.elemID.createNestedID('name'), 'SystemName'),
-        '}} 2-{{issue.',
-        new ReferenceExpression(systemField.elemID.createNestedID('name'), 'SystemName'),
-        '}} 3-{{issue.',
-        new ReferenceExpression(systemField.elemID.createNestedID('name'), 'SystemName'),
-        '.something}} 4-{{issue.fields.',
-        new ReferenceExpression(systemField.elemID.createNestedID('name'), 'SystemName'),
-        '.something}} 5-{{fields.',
-        new ReferenceExpression(systemField.elemID.createNestedID('name'), 'SystemName'),
-        '}} 6-{{destinationIssue.',
-        new ReferenceExpression(systemField.elemID.createNestedID('name'), 'SystemName'),
-        '}} 7-{{triggerIssue.',
-        new ReferenceExpression(systemField.elemID.createNestedID('name'), 'SystemName'),
-        '}}SystemName',
-      ],
-    }))
+    })).toEqual({
+      template: new TemplateExpression({
+        parts: [
+          '1-{{',
+          new ReferenceExpression(systemField.elemID.createNestedID('name'), 'SystemName'),
+          '}} 2-{{issue.',
+          new ReferenceExpression(systemField.elemID.createNestedID('name'), 'SystemName'),
+          '}} 3-{{issue.',
+          new ReferenceExpression(systemField.elemID.createNestedID('name'), 'SystemName'),
+          '.something}} 4-{{issue.fields.',
+          new ReferenceExpression(systemField.elemID.createNestedID('name'), 'SystemName'),
+          '.something}} 5-{{fields.',
+          new ReferenceExpression(systemField.elemID.createNestedID('name'), 'SystemName'),
+          '}} 6-{{destinationIssue.',
+          new ReferenceExpression(systemField.elemID.createNestedID('name'), 'SystemName'),
+          '}} 7-{{triggerIssue.',
+          new ReferenceExpression(systemField.elemID.createNestedID('name'), 'SystemName'),
+          '}}SystemName',
+        ],
+      }),
+      ambiguousTokens: new Set(),
+    })
   })
 
   it('should resolve custom field by id', () => {
@@ -117,25 +122,28 @@ describe('stringToTemplate', () => {
       referenceStr: '1-{{customfield_1234}} 2-{{issue.customfield_1234}} 3-{{issue.customfield_1234.something}} 4-{{issue.fields.customfield_1234.something}} 5-{{fields.customfield_1234}} 6-{{destinationIssue.customfield_1234}} 7-{{triggerIssue.customfield_1234}}customfield_1234',
       fieldInstancesByName: nameToField,
       fieldInstancesById: idToField,
-    })).toEqual(new TemplateExpression({
-      parts: [
-        '1-{{',
-        new ReferenceExpression(customField.elemID, customField),
-        '}} 2-{{issue.',
-        new ReferenceExpression(customField.elemID, customField),
-        '}} 3-{{issue.',
-        new ReferenceExpression(customField.elemID, customField),
-        '.something}} 4-{{issue.fields.',
-        new ReferenceExpression(customField.elemID, customField),
-        '.something}} 5-{{fields.',
-        new ReferenceExpression(customField.elemID, customField),
-        '}} 6-{{destinationIssue.',
-        new ReferenceExpression(customField.elemID, customField),
-        '}} 7-{{triggerIssue.',
-        new ReferenceExpression(customField.elemID, customField),
-        '}}customfield_1234',
-      ],
-    }))
+    })).toEqual({
+      template: new TemplateExpression({
+        parts: [
+          '1-{{',
+          new ReferenceExpression(customField.elemID, customField),
+          '}} 2-{{issue.',
+          new ReferenceExpression(customField.elemID, customField),
+          '}} 3-{{issue.',
+          new ReferenceExpression(customField.elemID, customField),
+          '.something}} 4-{{issue.fields.',
+          new ReferenceExpression(customField.elemID, customField),
+          '.something}} 5-{{fields.',
+          new ReferenceExpression(customField.elemID, customField),
+          '}} 6-{{destinationIssue.',
+          new ReferenceExpression(customField.elemID, customField),
+          '}} 7-{{triggerIssue.',
+          new ReferenceExpression(customField.elemID, customField),
+          '}}customfield_1234',
+        ],
+      }),
+      ambiguousTokens: new Set(),
+    })
   })
 
   it('should resolve custom field by name', () => {
@@ -143,25 +151,28 @@ describe('stringToTemplate', () => {
       referenceStr: '1-{{Custom Field}} 2-{{issue.Custom Field}} 3-{{issue.Custom Field.something}} 4-{{issue.fields.Custom Field.something}} 5-{{fields.Custom Field}} 6-{{destinationIssue.Custom Field}} 7-{{triggerIssue.Custom Field}}Custom Field',
       fieldInstancesByName: nameToField,
       fieldInstancesById: idToField,
-    })).toEqual(new TemplateExpression({
-      parts: [
-        '1-{{',
-        new ReferenceExpression(customField.elemID.createNestedID('name'), 'Custom Field'),
-        '}} 2-{{issue.',
-        new ReferenceExpression(customField.elemID.createNestedID('name'), 'Custom Field'),
-        '}} 3-{{issue.',
-        new ReferenceExpression(customField.elemID.createNestedID('name'), 'Custom Field'),
-        '.something}} 4-{{issue.fields.',
-        new ReferenceExpression(customField.elemID.createNestedID('name'), 'Custom Field'),
-        '.something}} 5-{{fields.',
-        new ReferenceExpression(customField.elemID.createNestedID('name'), 'Custom Field'),
-        '}} 6-{{destinationIssue.',
-        new ReferenceExpression(customField.elemID.createNestedID('name'), 'Custom Field'),
-        '}} 7-{{triggerIssue.',
-        new ReferenceExpression(customField.elemID.createNestedID('name'), 'Custom Field'),
-        '}}Custom Field',
-      ],
-    }))
+    })).toEqual({
+      template: new TemplateExpression({
+        parts: [
+          '1-{{',
+          new ReferenceExpression(customField.elemID.createNestedID('name'), 'Custom Field'),
+          '}} 2-{{issue.',
+          new ReferenceExpression(customField.elemID.createNestedID('name'), 'Custom Field'),
+          '}} 3-{{issue.',
+          new ReferenceExpression(customField.elemID.createNestedID('name'), 'Custom Field'),
+          '.something}} 4-{{issue.fields.',
+          new ReferenceExpression(customField.elemID.createNestedID('name'), 'Custom Field'),
+          '.something}} 5-{{fields.',
+          new ReferenceExpression(customField.elemID.createNestedID('name'), 'Custom Field'),
+          '}} 6-{{destinationIssue.',
+          new ReferenceExpression(customField.elemID.createNestedID('name'), 'Custom Field'),
+          '}} 7-{{triggerIssue.',
+          new ReferenceExpression(customField.elemID.createNestedID('name'), 'Custom Field'),
+          '}}Custom Field',
+        ],
+      }),
+      ambiguousTokens: new Set(),
+    })
   })
 
   it('should ignore unknown fields', () => {
@@ -169,7 +180,10 @@ describe('stringToTemplate', () => {
       referenceStr: '1-{{unknown}} 2-{{issue.unknown}} 3-{{toString}}',
       fieldInstancesByName: nameToField,
       fieldInstancesById: idToField,
-    })).toBe('1-{{unknown}} 2-{{issue.unknown}} 3-{{toString}}')
+    })).toEqual({
+      template: '1-{{unknown}} 2-{{issue.unknown}} 3-{{toString}}',
+      ambiguousTokens: new Set(),
+    })
   })
 
   it('should ignore invalid fields', () => {
@@ -177,6 +191,22 @@ describe('stringToTemplate', () => {
       referenceStr: '1-{{.}} 2-{{}}',
       fieldInstancesByName: nameToField,
       fieldInstancesById: idToField,
-    })).toBe('1-{{.}} 2-{{}}')
+    })).toEqual({
+      template: '1-{{.}} 2-{{}}',
+      ambiguousTokens: new Set(),
+    })
+  })
+
+  it('should return ambiguous fields', () => {
+    nameToField[customField.value.name] = [customField, customField]
+
+    expect(stringToTemplate({
+      referenceStr: '1-{{Custom Field}}',
+      fieldInstancesByName: nameToField,
+      fieldInstancesById: idToField,
+    })).toEqual({
+      template: '1-{{Custom Field}}',
+      ambiguousTokens: new Set(['Custom Field']),
+    })
   })
 })


### PR DESCRIPTION
Now when a token in a JQL or a smart value will match more than one reference (e.g., if there are two fields with the same name), a reference won't be created and a warning will be returned

---

_Additional context for reviewer_

---
_Release Notes_: 
_Jira Adapter_:
- Now when a token in a JQL or a smart value will match more than one reference (e.g., if there are two fields with the same name), a reference won't be created and a warning will be returned

---
_User Notifications_: 
None