### PR TITLE
SALTO-2852 bug fix - nacl paths exceed length limit

### DIFF
--- a/packages/adapter-utils/package.json
+++ b/packages/adapter-utils/package.json
@@ -63,7 +63,6 @@
     "jest-circus": "^27.4.5",
     "jest-each": "^26.6.2",
     "jest-junit": "^12.0.0",
-    "truncate-utf8-bytes": "^1.0.2",
     "ts-jest": "^27.1.2",
     "tsc-watch": "^2.2.1",
     "typescript": "4.1.3"

--- a/packages/adapter-utils/package.json
+++ b/packages/adapter-utils/package.json
@@ -37,6 +37,7 @@
     "fast-safe-stringify": "^2.0.7",
     "joi": "^17.4.0",
     "lodash": "^4.17.21",
+    "truncate-utf8-bytes": "^1.0.2",
     "wu": "^2.1.0"
   },
   "devDependencies": {

--- a/packages/adapter-utils/package.json
+++ b/packages/adapter-utils/package.json
@@ -47,6 +47,7 @@
     "@types/moxios": "^0.4.10",
     "@types/shelljs": "^0.7.8",
     "@types/supertest": "^2.0.4",
+    "@types/truncate-utf8-bytes": "^1.0.0",
     "@types/wu": "^2.1.40",
     "@typescript-eslint/eslint-plugin": "4.22.1",
     "@typescript-eslint/parser": "4.22.1",
@@ -62,6 +63,7 @@
     "jest-circus": "^27.4.5",
     "jest-each": "^26.6.2",
     "jest-junit": "^12.0.0",
+    "truncate-utf8-bytes": "^1.0.2",
     "ts-jest": "^27.1.2",
     "tsc-watch": "^2.2.1",
     "typescript": "4.1.3"

--- a/packages/adapter-utils/src/nacl_case_utils.ts
+++ b/packages/adapter-utils/src/nacl_case_utils.ts
@@ -140,10 +140,10 @@ export const normalizeStaticResourcePath = (name: string): string => {
   // In case the file has a too long extension length or no extension at all
   if (_.isEmpty(extBuffer) || extBuffer.byteLength > MAX_PATH_EXTENSION_LENGTH) {
     const addedSuffix = `_${nameHash}`
-    return nameBuffer.slice(0, MAX_PATH_LENGTH - addedSuffix.length).toString().concat(addedSuffix)
+    return truncate(nameBuffer.toString(), MAX_PATH_LENGTH - addedSuffix.length).concat(addedSuffix)
   }
   const addedSuffix = `_${nameHash}${extBuffer.toString()}`
-  return nameBuffer.slice(0, MAX_PATH_LENGTH - addedSuffix.length).toString().concat(addedSuffix)
+  return truncate(nameBuffer.toString(), MAX_PATH_LENGTH - addedSuffix.length).concat(addedSuffix)
 }
 
 export const invertNaclCase = (name: string): string => {

--- a/packages/adapter-utils/src/nacl_case_utils.ts
+++ b/packages/adapter-utils/src/nacl_case_utils.ts
@@ -138,7 +138,7 @@ export const normalizeStaticResourcePath = (name: string): string => {
   if (extIndex === -1 || nameBuffer.byteLength - extIndex > MAX_PATH_EXTENSION_LENGTH) {
     return nameBuffer.slice(0, MAX_PATH_LENGTH).toString().concat(`_${nameHash}`)
   }
-  return nameBuffer.slice(0, extIndex).toString()
+  return nameBuffer.slice(0, Math.min(MAX_PATH_LENGTH, extIndex)).toString()
     .concat(`_${nameHash}`)
     .concat(nameBuffer.slice(extIndex).toString())
 }

--- a/packages/adapter-utils/src/nacl_case_utils.ts
+++ b/packages/adapter-utils/src/nacl_case_utils.ts
@@ -13,7 +13,6 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import _ from 'lodash'
 import path from 'path'
 import truncate from 'truncate-utf8-bytes'
 import invert from 'lodash/invert'

--- a/packages/adapter-utils/src/nacl_case_utils.ts
+++ b/packages/adapter-utils/src/nacl_case_utils.ts
@@ -13,6 +13,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import _ from 'lodash'
+import path from 'path'
+import truncate from 'truncate-utf8-bytes'
 import invert from 'lodash/invert'
 import { hash as hashUtils } from '@salto-io/lowerdash'
 
@@ -133,14 +136,14 @@ export const normalizeStaticResourcePath = (name: string): string => {
     return name
   }
   const nameHash = hashUtils.toMD5(name)
-  const extIndex = nameBuffer.lastIndexOf('.')
+  const extBuffer = Buffer.from(path.extname(name))
   // In case the file has a too long extension length or no extension at all
-  if (extIndex === -1 || nameBuffer.byteLength - extIndex > MAX_PATH_EXTENSION_LENGTH) {
-    return nameBuffer.slice(0, MAX_PATH_LENGTH).toString().concat(`_${nameHash}`)
+  if (_.isEmpty(extBuffer) || extBuffer.byteLength > MAX_PATH_EXTENSION_LENGTH) {
+    const addedSuffix = `_${nameHash}`
+    return nameBuffer.slice(0, MAX_PATH_LENGTH - addedSuffix.length).toString().concat(addedSuffix)
   }
-  return nameBuffer.slice(0, Math.min(MAX_PATH_LENGTH, extIndex)).toString()
-    .concat(`_${nameHash}`)
-    .concat(nameBuffer.slice(extIndex).toString())
+  const addedSuffix = `_${nameHash}${extBuffer.toString()}`
+  return nameBuffer.slice(0, MAX_PATH_LENGTH - addedSuffix.length).toString().concat(addedSuffix)
 }
 
 export const invertNaclCase = (name: string): string => {

--- a/packages/adapter-utils/src/nacl_case_utils.ts
+++ b/packages/adapter-utils/src/nacl_case_utils.ts
@@ -128,19 +128,18 @@ export const naclCase = (name?: string): string => {
 
 export const normalizeStaticResourcePath = (name: string): string => {
   const nameBuffer = Buffer.from(name)
-  const nameByteLength = nameBuffer.byteLength
-  if (nameByteLength <= MAX_PATH_LENGTH) {
-    return naclCase(name)
+  if (nameBuffer.byteLength <= MAX_PATH_LENGTH) {
+    return name
   }
   const nameHash = hashUtils.toMD5(name)
   const extIndex = nameBuffer.lastIndexOf('.')
   // In case the file has a too long extension length or no extension at all
-  if (extIndex === -1 || nameByteLength - extIndex > MAX_PATH_LENGTH) {
-    return naclCase(nameBuffer.slice(0, MAX_PATH_LENGTH).toString().concat(`_${nameHash}`))
+  if (extIndex === -1 || nameBuffer.byteLength - extIndex > MAX_PATH_LENGTH) {
+    return nameBuffer.slice(0, MAX_PATH_LENGTH).toString().concat(`_${nameHash}`)
   }
-  return naclCase(nameBuffer.slice(0, MAX_PATH_LENGTH).toString()
+  return nameBuffer.slice(0, MAX_PATH_LENGTH).toString()
     .concat(`_${nameHash}`)
-    .concat(nameBuffer.slice(extIndex).toString()))
+    .concat(nameBuffer.slice(extIndex).toString())
 }
 
 export const invertNaclCase = (name: string): string => {

--- a/packages/adapter-utils/src/nacl_case_utils.ts
+++ b/packages/adapter-utils/src/nacl_case_utils.ts
@@ -125,6 +125,14 @@ export const naclCase = (name?: string): string => {
   return `${cleanName}${suffixFromList(specialCharsMappingList)}`
 }
 
+export const elemNameToNaclCasedPath = (name: string): string => {
+  const extIndex = name.lastIndexOf('.')
+  if (extIndex === -1) {
+    return naclCase(name)
+  }
+  return naclCase(name.slice(0, extIndex)).concat(name.slice(extIndex))
+}
+
 export const invertNaclCase = (name: string): string => {
   if (name === '') {
     return ''

--- a/packages/adapter-utils/src/nacl_case_utils.ts
+++ b/packages/adapter-utils/src/nacl_case_utils.ts
@@ -22,6 +22,7 @@ const NACL_CUSTOM_MAPPING_PREFIX = '_'
 // This can have an effect at a time we add a ~15 chars suffix
 // So we are taking an extra buffer and limit it to 200
 const MAX_PATH_LENGTH = 200
+const MAX_PATH_EXTENSION_LENGTH = 20
 
 export const pathNaclCase = (name?: string): string =>
   (name ? name.split(NACL_ESCAPING_SUFFIX_SEPARATOR)[0] : '').slice(0, MAX_PATH_LENGTH)
@@ -134,10 +135,10 @@ export const normalizeStaticResourcePath = (name: string): string => {
   const nameHash = hashUtils.toMD5(name)
   const extIndex = nameBuffer.lastIndexOf('.')
   // In case the file has a too long extension length or no extension at all
-  if (extIndex === -1 || nameBuffer.byteLength - extIndex > MAX_PATH_LENGTH) {
+  if (extIndex === -1 || nameBuffer.byteLength - extIndex > MAX_PATH_EXTENSION_LENGTH) {
     return nameBuffer.slice(0, MAX_PATH_LENGTH).toString().concat(`_${nameHash}`)
   }
-  return nameBuffer.slice(0, MAX_PATH_LENGTH).toString()
+  return nameBuffer.slice(0, extIndex).toString()
     .concat(`_${nameHash}`)
     .concat(nameBuffer.slice(extIndex).toString())
 }

--- a/packages/adapter-utils/test/nacl_case_utils.test.ts
+++ b/packages/adapter-utils/test/nacl_case_utils.test.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
+import truncate from 'truncate-utf8-bytes'
 import { hash as hashUtils } from '@salto-io/lowerdash'
 import { invertNaclCase, naclCase, normalizeStaticResourcePath, pathNaclCase } from '../src/nacl_case_utils'
 
@@ -167,27 +168,29 @@ describe('naclCase utils', () => {
     describe('With a very long path', () => {
       const longString = new Array(30).fill('123456שבע0_').join('').concat('.extension')
       const longStringHash = hashUtils.toMD5(longString)
-      it('Should return at extacly 200 chars', () => {
-        expect(Buffer.from(normalizeStaticResourcePath(longString)).byteLength).toEqual(200)
+      it('Should return at extacly 200 chars or less', () => {
+        expect(Buffer.from(normalizeStaticResourcePath(longString)).byteLength)
+          .toBeLessThanOrEqual(200)
       })
 
       it('Should return the first 200 chars, hash and the extension', () => {
         const addedSuffix = `_${longStringHash}.extension`
         expect(normalizeStaticResourcePath(longString))
-          .toEqual(longString.slice(0, 200 - addedSuffix.length).concat(addedSuffix))
+          .toEqual(truncate(longString.toString(), 200 - addedSuffix.length).concat(addedSuffix))
       })
     })
     describe('With a very long extension', () => {
       const longString = 'aaa.'.concat(new Array(30).fill('1234חמש890_').join(''))
       const longStringHash = hashUtils.toMD5(longString)
-      it('Should return exactly 200 chars', () => {
-        expect(Buffer.from(normalizeStaticResourcePath(longString)).byteLength).toEqual(200)
+      it('Should return 200 chars or less', () => {
+        expect(Buffer.from(normalizeStaticResourcePath(longString)).byteLength)
+          .toBeLessThanOrEqual(200)
       })
 
       it('Should return the first 200 chars and hash', () => {
         const addedSuffix = `_${longStringHash}`
         expect(normalizeStaticResourcePath(longString))
-          .toEqual(longString.slice(0, 200 - addedSuffix.length).concat(addedSuffix))
+          .toEqual(truncate(longString.toString(), 200 - addedSuffix.length).concat(addedSuffix))
       })
     })
   })

--- a/packages/adapter-utils/test/nacl_case_utils.test.ts
+++ b/packages/adapter-utils/test/nacl_case_utils.test.ts
@@ -14,7 +14,8 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { invertNaclCase, naclCase, pathNaclCase } from '../src/nacl_case_utils'
+import { hash as hashUtils } from '@salto-io/lowerdash'
+import { invertNaclCase, naclCase, normalizeStaticResourcePath, pathNaclCase } from '../src/nacl_case_utils'
 
 describe('naclCase utils', () => {
   const generateRandomChar = (): string =>
@@ -150,6 +151,28 @@ describe('naclCase utils', () => {
 
       it('Should return the first 200 chars', () => {
         expect(pathNaclCase(longString)).toEqual(longString.slice(0, 200))
+      })
+    })
+  })
+
+  describe('normalizeStaticResourcePath func', () => {
+    describe('With a short path', () => {
+      const shortPaths = [
+        'lalala.txt', 'aבגדe.טקסט', 'noExtention',
+      ]
+      it('Should remain the same', () => {
+        shortPaths.forEach(path => expect(normalizeStaticResourcePath(path)).toEqual(path))
+      })
+    })
+    describe('With a very long path', () => {
+      const longString = new Array(30).fill('1234567890_').join('').concat('.extension')
+      const longStringHash = hashUtils.toMD5(longString)
+      it('Should return at most 200 chars', () => {
+        expect(normalizeStaticResourcePath(longString).length).toBeLessThanOrEqual(200 + `_${longStringHash}.extension`.length)
+      })
+
+      it('Should return the first 200 chars and the extension', () => {
+        expect(normalizeStaticResourcePath(longString)).toEqual(longString.slice(0, 200).concat(`_${longStringHash}.extension`))
       })
     })
   })

--- a/packages/adapter-utils/test/nacl_case_utils.test.ts
+++ b/packages/adapter-utils/test/nacl_case_utils.test.ts
@@ -14,8 +14,6 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import truncate from 'truncate-utf8-bytes'
-import { hash as hashUtils } from '@salto-io/lowerdash'
 import { invertNaclCase, naclCase, normalizeFilePathPart, pathNaclCase } from '../src/nacl_case_utils'
 
 describe('naclCase utils', () => {

--- a/packages/adapter-utils/test/nacl_case_utils.test.ts
+++ b/packages/adapter-utils/test/nacl_case_utils.test.ts
@@ -191,5 +191,16 @@ describe('naclCase utils', () => {
         expect(normalizeFilePathPart(longString)).not.toContain(extension)
       })
     })
+    describe('With a short non ascii extension', () => {
+      const extension = '.סיומת'
+      const longString = new Array(17).fill('1234חמש890_').join('').concat(extension)
+      it('Should return 200 chars or less', () => {
+        expect(Buffer.from(normalizeFilePathPart(longString)).byteLength)
+          .toBeLessThanOrEqual(200)
+      })
+      it('Should not contain the full file extension', () => {
+        expect(normalizeFilePathPart(longString)).not.toContain(extension)
+      })
+    })
   })
 })

--- a/packages/adapter-utils/test/nacl_case_utils.test.ts
+++ b/packages/adapter-utils/test/nacl_case_utils.test.ts
@@ -167,12 +167,23 @@ describe('naclCase utils', () => {
     describe('With a very long path', () => {
       const longString = new Array(30).fill('1234567890_').join('').concat('.extension')
       const longStringHash = hashUtils.toMD5(longString)
-      it('Should return at most 200 chars', () => {
+      it('Should return at most 200 chars (not included hash + extension)', () => {
         expect(normalizeStaticResourcePath(longString).length).toBeLessThanOrEqual(200 + `_${longStringHash}.extension`.length)
       })
 
-      it('Should return the first 200 chars and the extension', () => {
+      it('Should return the first 200 chars, hash and the extension', () => {
         expect(normalizeStaticResourcePath(longString)).toEqual(longString.slice(0, 200).concat(`_${longStringHash}.extension`))
+      })
+    })
+    describe('With a very long extension', () => {
+      const longString = 'aaa.'.concat(new Array(30).fill('1234567890_').join(''))
+      const longStringHash = hashUtils.toMD5(longString)
+      it('Should return at most 200 chars (not included hash + extension)', () => {
+        expect(normalizeStaticResourcePath(longString).length).toBeLessThanOrEqual(200 + `_${longStringHash}`.length)
+      })
+
+      it('Should return the first 200 chars, hash and the extension', () => {
+        expect(normalizeStaticResourcePath(longString)).toEqual(longString.slice(0, 200).concat(`_${longStringHash}`))
       })
     })
   })

--- a/packages/adapter-utils/test/nacl_case_utils.test.ts
+++ b/packages/adapter-utils/test/nacl_case_utils.test.ts
@@ -16,7 +16,7 @@
 import _ from 'lodash'
 import truncate from 'truncate-utf8-bytes'
 import { hash as hashUtils } from '@salto-io/lowerdash'
-import { invertNaclCase, naclCase, normalizeStaticResourcePath, pathNaclCase } from '../src/nacl_case_utils'
+import { invertNaclCase, naclCase, normalizeFilePathPart, pathNaclCase } from '../src/nacl_case_utils'
 
 describe('naclCase utils', () => {
   const generateRandomChar = (): string =>
@@ -162,35 +162,35 @@ describe('naclCase utils', () => {
         'lalala.txt', 'aבגדe.טקסט', 'noExtention',
       ]
       it('Should remain the same', () => {
-        shortPaths.forEach(path => expect(normalizeStaticResourcePath(path)).toEqual(path))
+        shortPaths.forEach(path => expect(normalizeFilePathPart(path)).toEqual(path))
       })
     })
     describe('With a very long path', () => {
-      const longString = new Array(30).fill('123456שבע0_').join('').concat('.extension')
-      const longStringHash = hashUtils.toMD5(longString)
+      const longPathPrefix = new Array(17).fill('123456שבע0_').join('')
+      const extension = '.extension'
+      const longString = longPathPrefix.concat(extension)
+      const anotherLongString = longPathPrefix.concat('a').concat(extension)
       it('Should return at extacly 200 chars or less', () => {
-        expect(Buffer.from(normalizeStaticResourcePath(longString)).byteLength)
+        expect(Buffer.from(normalizeFilePathPart(longString)).byteLength)
           .toBeLessThanOrEqual(200)
       })
-
-      it('Should return the first 200 chars, hash and the extension', () => {
-        const addedSuffix = `_${longStringHash}.extension`
-        expect(normalizeStaticResourcePath(longString))
-          .toEqual(truncate(longString.toString(), 200 - addedSuffix.length).concat(addedSuffix))
+      it('Should contain the full file extension', () => {
+        expect(normalizeFilePathPart(longString)).toContain(extension)
+      })
+      it('Should maintain difference between different strings', () => {
+        expect(normalizeFilePathPart(longString))
+          .not.toEqual(normalizeFilePathPart(anotherLongString))
       })
     })
     describe('With a very long extension', () => {
-      const longString = 'aaa.'.concat(new Array(30).fill('1234חמש890_').join(''))
-      const longStringHash = hashUtils.toMD5(longString)
+      const extension = new Array(17).fill('1234חמש890_').join('')
+      const longString = 'aaa.'.concat(extension)
       it('Should return 200 chars or less', () => {
-        expect(Buffer.from(normalizeStaticResourcePath(longString)).byteLength)
+        expect(Buffer.from(normalizeFilePathPart(longString)).byteLength)
           .toBeLessThanOrEqual(200)
       })
-
-      it('Should return the first 200 chars and hash', () => {
-        const addedSuffix = `_${longStringHash}`
-        expect(normalizeStaticResourcePath(longString))
-          .toEqual(truncate(longString.toString(), 200 - addedSuffix.length).concat(addedSuffix))
+      it('Should not contain the full file extension', () => {
+        expect(normalizeFilePathPart(longString)).not.toContain(extension)
       })
     })
   })

--- a/packages/adapter-utils/test/nacl_case_utils.test.ts
+++ b/packages/adapter-utils/test/nacl_case_utils.test.ts
@@ -165,25 +165,29 @@ describe('naclCase utils', () => {
       })
     })
     describe('With a very long path', () => {
-      const longString = new Array(30).fill('1234567890_').join('').concat('.extension')
+      const longString = new Array(30).fill('123456שבע0_').join('').concat('.extension')
       const longStringHash = hashUtils.toMD5(longString)
-      it('Should return at most 200 chars (not included hash + extension)', () => {
-        expect(normalizeStaticResourcePath(longString).length).toBeLessThanOrEqual(200 + `_${longStringHash}.extension`.length)
+      it('Should return at extacly 200 chars', () => {
+        expect(Buffer.from(normalizeStaticResourcePath(longString)).byteLength).toEqual(200)
       })
 
       it('Should return the first 200 chars, hash and the extension', () => {
-        expect(normalizeStaticResourcePath(longString)).toEqual(longString.slice(0, 200).concat(`_${longStringHash}.extension`))
+        const addedSuffix = `_${longStringHash}.extension`
+        expect(normalizeStaticResourcePath(longString))
+          .toEqual(longString.slice(0, 200 - addedSuffix.length).concat(addedSuffix))
       })
     })
     describe('With a very long extension', () => {
-      const longString = 'aaa.'.concat(new Array(30).fill('1234567890_').join(''))
+      const longString = 'aaa.'.concat(new Array(30).fill('1234חמש890_').join(''))
       const longStringHash = hashUtils.toMD5(longString)
-      it('Should return at most 200 chars (not included hash + extension)', () => {
-        expect(normalizeStaticResourcePath(longString).length).toBeLessThanOrEqual(200 + `_${longStringHash}`.length)
+      it('Should return exactly 200 chars', () => {
+        expect(Buffer.from(normalizeStaticResourcePath(longString)).byteLength).toEqual(200)
       })
 
-      it('Should return the first 200 chars, hash and the extension', () => {
-        expect(normalizeStaticResourcePath(longString)).toEqual(longString.slice(0, 200).concat(`_${longStringHash}`))
+      it('Should return the first 200 chars and hash', () => {
+        const addedSuffix = `_${longStringHash}`
+        expect(normalizeStaticResourcePath(longString))
+          .toEqual(longString.slice(0, 200 - addedSuffix.length).concat(addedSuffix))
       })
     })
   })

--- a/packages/zendesk-adapter/src/filters/brand_logo.ts
+++ b/packages/zendesk-adapter/src/filters/brand_logo.ts
@@ -21,7 +21,7 @@ import {
   ReferenceExpression, StaticFile,
 } from '@salto-io/adapter-api'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
-import { naclCase, safeJsonStringify, getParent, normalizeStaticResourcePath } from '@salto-io/adapter-utils'
+import { naclCase, safeJsonStringify, getParent, normalizeStaticResourcePath, pathNaclCase } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import FormData from 'form-data'
 import { collections } from '@salto-io/lowerdash'
@@ -105,7 +105,8 @@ const getBrandLogo = async ({ client, brand }: {
   const name = elementsUtils.ducktype.toNestedTypeName(
     brand.value.name, logoValues.file_name
   )
-  const pathName = normalizeStaticResourcePath(name)
+  const pathName = pathNaclCase(name)
+  const resourcePathName = normalizeStaticResourcePath(name)
 
   const { id, file_name: filename } = brand.value.logo
   const content = await getLogoContent(client, id, filename)
@@ -120,7 +121,7 @@ const getBrandLogo = async ({ client, brand }: {
       filename: logoValues.file_name,
       contentType: logoValues.content_type,
       content: new StaticFile({
-        filepath: `${ZENDESK}/${BRAND_LOGO_TYPE.elemID.name}/${pathName}`,
+        filepath: `${ZENDESK}/${BRAND_LOGO_TYPE.elemID.name}/${resourcePathName}`,
         content,
       }),
     },

--- a/packages/zendesk-adapter/src/filters/brand_logo.ts
+++ b/packages/zendesk-adapter/src/filters/brand_logo.ts
@@ -105,7 +105,7 @@ const getBrandLogo = async ({ client, brand }: {
   const name = elementsUtils.ducktype.toNestedTypeName(
     brand.value.name, logoValues.file_name
   )
-  const pathName = pathNaclCase(name)
+  const pathName = pathNaclCase(naclCase(name))
   const resourcePathName = normalizeStaticResourcePath(name)
 
   const { id, file_name: filename } = brand.value.logo

--- a/packages/zendesk-adapter/src/filters/brand_logo.ts
+++ b/packages/zendesk-adapter/src/filters/brand_logo.ts
@@ -21,7 +21,7 @@ import {
   ReferenceExpression, StaticFile,
 } from '@salto-io/adapter-api'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
-import { naclCase, pathNaclCase, safeJsonStringify, getParent } from '@salto-io/adapter-utils'
+import { naclCase, safeJsonStringify, getParent, elemNameToNaclCasedPath } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import FormData from 'form-data'
 import { collections } from '@salto-io/lowerdash'
@@ -105,7 +105,7 @@ const getBrandLogo = async ({ client, brand }: {
   const name = elementsUtils.ducktype.toNestedTypeName(
     brand.value.name, logoValues.file_name
   )
-  const pathName = pathNaclCase(name)
+  const pathName = elemNameToNaclCasedPath(name)
 
   const { id, file_name: filename } = brand.value.logo
   const content = await getLogoContent(client, id, filename)

--- a/packages/zendesk-adapter/src/filters/brand_logo.ts
+++ b/packages/zendesk-adapter/src/filters/brand_logo.ts
@@ -21,7 +21,7 @@ import {
   ReferenceExpression, StaticFile,
 } from '@salto-io/adapter-api'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
-import { naclCase, safeJsonStringify, getParent, normalizeStaticResourcePath, pathNaclCase } from '@salto-io/adapter-utils'
+import { naclCase, safeJsonStringify, getParent, normalizeFilePathPart, pathNaclCase } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import FormData from 'form-data'
 import { collections } from '@salto-io/lowerdash'
@@ -106,7 +106,7 @@ const getBrandLogo = async ({ client, brand }: {
     brand.value.name, logoValues.file_name
   )
   const pathName = pathNaclCase(naclCase(name))
-  const resourcePathName = normalizeStaticResourcePath(name)
+  const resourcePathName = normalizeFilePathPart(name)
 
   const { id, file_name: filename } = brand.value.logo
   const content = await getLogoContent(client, id, filename)

--- a/packages/zendesk-adapter/src/filters/brand_logo.ts
+++ b/packages/zendesk-adapter/src/filters/brand_logo.ts
@@ -21,7 +21,7 @@ import {
   ReferenceExpression, StaticFile,
 } from '@salto-io/adapter-api'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
-import { naclCase, safeJsonStringify, getParent, elemNameToNaclCasedPath } from '@salto-io/adapter-utils'
+import { naclCase, safeJsonStringify, getParent, normalizeStaticResourcePath } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import FormData from 'form-data'
 import { collections } from '@salto-io/lowerdash'
@@ -105,7 +105,7 @@ const getBrandLogo = async ({ client, brand }: {
   const name = elementsUtils.ducktype.toNestedTypeName(
     brand.value.name, logoValues.file_name
   )
-  const pathName = elemNameToNaclCasedPath(name)
+  const pathName = normalizeStaticResourcePath(name)
 
   const { id, file_name: filename } = brand.value.logo
   const content = await getLogoContent(client, id, filename)

--- a/packages/zendesk-adapter/src/filters/help_center_locale.ts
+++ b/packages/zendesk-adapter/src/filters/help_center_locale.ts
@@ -17,7 +17,7 @@ import Joi from 'joi'
 import {
   BuiltinTypes, ElemID, InstanceElement, ObjectType,
 } from '@salto-io/adapter-api'
-import { createSchemeGuard, naclCase, pathNaclCase } from '@salto-io/adapter-utils'
+import { createSchemeGuard, elemNameToNaclCasedPath, naclCase } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
 import { FilterCreator } from '../filter'
@@ -84,7 +84,7 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
         localeName,
         localeType,
         { id: locale, default: locale === defaultLocale },
-        [ZENDESK, RECORDS_PATH, LOCALE_TYPE_NAME, pathNaclCase(naclCase(locale))],
+        [ZENDESK, RECORDS_PATH, LOCALE_TYPE_NAME, elemNameToNaclCasedPath(locale)],
       )
     })
     elements.push(localeType)

--- a/packages/zendesk-adapter/src/filters/help_center_locale.ts
+++ b/packages/zendesk-adapter/src/filters/help_center_locale.ts
@@ -17,7 +17,7 @@ import Joi from 'joi'
 import {
   BuiltinTypes, ElemID, InstanceElement, ObjectType,
 } from '@salto-io/adapter-api'
-import { createSchemeGuard, normalizeStaticResourcePath, naclCase } from '@salto-io/adapter-utils'
+import { createSchemeGuard, naclCase, pathNaclCase } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
 import { FilterCreator } from '../filter'
@@ -84,7 +84,7 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
         localeName,
         localeType,
         { id: locale, default: locale === defaultLocale },
-        [ZENDESK, RECORDS_PATH, LOCALE_TYPE_NAME, normalizeStaticResourcePath(locale)],
+        [ZENDESK, RECORDS_PATH, LOCALE_TYPE_NAME, pathNaclCase(locale)],
       )
     })
     elements.push(localeType)

--- a/packages/zendesk-adapter/src/filters/help_center_locale.ts
+++ b/packages/zendesk-adapter/src/filters/help_center_locale.ts
@@ -17,7 +17,7 @@ import Joi from 'joi'
 import {
   BuiltinTypes, ElemID, InstanceElement, ObjectType,
 } from '@salto-io/adapter-api'
-import { createSchemeGuard, elemNameToNaclCasedPath, naclCase } from '@salto-io/adapter-utils'
+import { createSchemeGuard, normalizeStaticResourcePath, naclCase } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
 import { FilterCreator } from '../filter'
@@ -84,7 +84,7 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
         localeName,
         localeType,
         { id: locale, default: locale === defaultLocale },
-        [ZENDESK, RECORDS_PATH, LOCALE_TYPE_NAME, elemNameToNaclCasedPath(locale)],
+        [ZENDESK, RECORDS_PATH, LOCALE_TYPE_NAME, normalizeStaticResourcePath(locale)],
       )
     })
     elements.push(localeType)

--- a/packages/zendesk-adapter/src/filters/help_center_locale.ts
+++ b/packages/zendesk-adapter/src/filters/help_center_locale.ts
@@ -84,7 +84,7 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
         localeName,
         localeType,
         { id: locale, default: locale === defaultLocale },
-        [ZENDESK, RECORDS_PATH, LOCALE_TYPE_NAME, pathNaclCase(naclCase(locale))],
+        [ZENDESK, RECORDS_PATH, LOCALE_TYPE_NAME, pathNaclCase(localeName)],
       )
     })
     elements.push(localeType)

--- a/packages/zendesk-adapter/src/filters/help_center_locale.ts
+++ b/packages/zendesk-adapter/src/filters/help_center_locale.ts
@@ -84,7 +84,7 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
         localeName,
         localeType,
         { id: locale, default: locale === defaultLocale },
-        [ZENDESK, RECORDS_PATH, LOCALE_TYPE_NAME, pathNaclCase(locale)],
+        [ZENDESK, RECORDS_PATH, LOCALE_TYPE_NAME, pathNaclCase(naclCase(locale))],
       )
     })
     elements.push(localeType)

--- a/packages/zendesk-adapter/src/filters/macro_attachments.ts
+++ b/packages/zendesk-adapter/src/filters/macro_attachments.ts
@@ -20,7 +20,7 @@ import {
   BuiltinTypes, Change, CORE_ANNOTATIONS, ElemID, getChangeData, InstanceElement,
   isInstanceElement, isRemovalChange, isStaticFile, ObjectType, ReferenceExpression, StaticFile,
 } from '@salto-io/adapter-api'
-import { elemNameToNaclCasedPath, naclCase, referenceExpressionStringifyReplacer,
+import { normalizeStaticResourcePath, naclCase, referenceExpressionStringifyReplacer,
   resolveChangeElement, safeJsonStringify } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
@@ -119,7 +119,7 @@ const createAttachmentInstance = ({
   const name = elementsUtils.ducktype.toNestedTypeName(
     macro.value.title, attachment.filename
   )
-  const pathName = elemNameToNaclCasedPath(name)
+  const pathName = normalizeStaticResourcePath(name)
   return new InstanceElement(
     naclCase(name),
     attachmentType,

--- a/packages/zendesk-adapter/src/filters/macro_attachments.ts
+++ b/packages/zendesk-adapter/src/filters/macro_attachments.ts
@@ -21,7 +21,7 @@ import {
   isInstanceElement, isRemovalChange, isStaticFile, ObjectType, ReferenceExpression, StaticFile,
 } from '@salto-io/adapter-api'
 import { normalizeStaticResourcePath, naclCase, referenceExpressionStringifyReplacer,
-  resolveChangeElement, safeJsonStringify } from '@salto-io/adapter-utils'
+  resolveChangeElement, safeJsonStringify, pathNaclCase } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
 import { values, collections } from '@salto-io/lowerdash'
@@ -119,16 +119,18 @@ const createAttachmentInstance = ({
   const name = elementsUtils.ducktype.toNestedTypeName(
     macro.value.title, attachment.filename
   )
-  const pathName = normalizeStaticResourcePath(name)
+  const naclName = naclCase(name)
+  const pathName = pathNaclCase(name)
+  const resourcePathName = normalizeStaticResourcePath(name)
   return new InstanceElement(
-    naclCase(name),
+    naclName,
     attachmentType,
     {
       id: attachment.id,
       filename: attachment.filename,
       contentType: attachment.content_type,
       content: new StaticFile({
-        filepath: `${ZENDESK}/${attachmentType.elemID.name}/${pathName}`,
+        filepath: `${ZENDESK}/${attachmentType.elemID.name}/${resourcePathName}`,
         content,
       }),
     },

--- a/packages/zendesk-adapter/src/filters/macro_attachments.ts
+++ b/packages/zendesk-adapter/src/filters/macro_attachments.ts
@@ -20,8 +20,8 @@ import {
   BuiltinTypes, Change, CORE_ANNOTATIONS, ElemID, getChangeData, InstanceElement,
   isInstanceElement, isRemovalChange, isStaticFile, ObjectType, ReferenceExpression, StaticFile,
 } from '@salto-io/adapter-api'
-import { naclCase, pathNaclCase, referenceExpressionStringifyReplacer, resolveChangeElement,
-  safeJsonStringify } from '@salto-io/adapter-utils'
+import { elemNameToNaclCasedPath, naclCase, referenceExpressionStringifyReplacer,
+  resolveChangeElement, safeJsonStringify } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
 import { values, collections } from '@salto-io/lowerdash'
@@ -119,7 +119,7 @@ const createAttachmentInstance = ({
   const name = elementsUtils.ducktype.toNestedTypeName(
     macro.value.title, attachment.filename
   )
-  const pathName = pathNaclCase(naclCase(name))
+  const pathName = elemNameToNaclCasedPath(name)
   return new InstanceElement(
     naclCase(name),
     attachmentType,

--- a/packages/zendesk-adapter/src/filters/macro_attachments.ts
+++ b/packages/zendesk-adapter/src/filters/macro_attachments.ts
@@ -120,7 +120,7 @@ const createAttachmentInstance = ({
     macro.value.title, attachment.filename
   )
   const naclName = naclCase(name)
-  const pathName = pathNaclCase(name)
+  const pathName = pathNaclCase(naclName)
   const resourcePathName = normalizeStaticResourcePath(name)
   return new InstanceElement(
     naclName,

--- a/packages/zendesk-adapter/src/filters/macro_attachments.ts
+++ b/packages/zendesk-adapter/src/filters/macro_attachments.ts
@@ -20,7 +20,7 @@ import {
   BuiltinTypes, Change, CORE_ANNOTATIONS, ElemID, getChangeData, InstanceElement,
   isInstanceElement, isRemovalChange, isStaticFile, ObjectType, ReferenceExpression, StaticFile,
 } from '@salto-io/adapter-api'
-import { normalizeStaticResourcePath, naclCase, referenceExpressionStringifyReplacer,
+import { normalizeFilePathPart, naclCase, referenceExpressionStringifyReplacer,
   resolveChangeElement, safeJsonStringify, pathNaclCase } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
@@ -121,7 +121,7 @@ const createAttachmentInstance = ({
   )
   const naclName = naclCase(name)
   const pathName = pathNaclCase(naclName)
-  const resourcePathName = normalizeStaticResourcePath(name)
+  const resourcePathName = normalizeFilePathPart(name)
   return new InstanceElement(
     naclName,
     attachmentType,

--- a/packages/zendesk-adapter/src/filters/macro_attachments.ts
+++ b/packages/zendesk-adapter/src/filters/macro_attachments.ts
@@ -119,7 +119,7 @@ const createAttachmentInstance = ({
   const name = elementsUtils.ducktype.toNestedTypeName(
     macro.value.title, attachment.filename
   )
-  const pathName = pathNaclCase(name)
+  const pathName = pathNaclCase(naclCase(name))
   return new InstanceElement(
     naclCase(name),
     attachmentType,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5032,24 +5032,12 @@ collect-v8-coverage@^1.0.0:
   resolved "https://registry.yarnpkg.com/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz#cc2c8e94fc18bbdffe64d6534570c8a673b27f59"
   integrity sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==
 
-color-convert@^1.9.0:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
-  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
-  dependencies:
-    color-name "1.1.3"
-
-color-convert@^2.0.1:
+color-convert@^1.9.0, color-convert@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
   integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
   dependencies:
     color-name "~1.1.4"
-
-color-name@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
-  integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
 color-name@~1.1.4:
   version "1.1.4"
@@ -5446,40 +5434,12 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-debug@2.6.9, debug@^2.6.9:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
-  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
-  dependencies:
-    ms "2.0.0"
-
-debug@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
-  dependencies:
-    ms "2.0.0"
-
-debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@2.6.9, debug@3.1.0, debug@4, debug@^2.6.9, debug@^3.1.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
-
-debug@^3.1.0:
-  version "3.2.7"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
-  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
-  dependencies:
-    ms "^2.1.1"
-
-debug@^4.3.1, debug@^4.3.2, debug@^4.3.3:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
-  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
-  dependencies:
-    ms "2.1.2"
 
 debuglog@^1.0.1:
   version "1.0.1"
@@ -9489,20 +9449,10 @@ moo@^0.5.0, moo@^0.5.1:
   resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.1.tgz#7aae7f384b9b09f620b6abf6f74ebbcd1b65dbc4"
   integrity sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==
 
-ms@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
-  integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
-
 ms@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
-
-ms@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
-  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
 ms@^2.0.0, ms@^2.1.1:
   version "2.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3583,6 +3583,11 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.0.tgz#fef1904e4668b6e5ecee60c52cc6a078ffa6697d"
   integrity sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==
 
+"@types/truncate-utf8-bytes@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.0.tgz#f35d5bd14a86e09bf91c1610c636cb39d71e7b98"
+  integrity sha512-pa3icl1RawLUUKmQE1h0G381EpWMU8bTnZT4YF3Ey9D7VI4fL1BQvgZ8HKbYok9kKXeUSCr/E3vnscW8Ck3QKg==
+
 "@types/uuid@^8.3.0":
   version "8.3.4"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
@@ -5027,12 +5032,24 @@ collect-v8-coverage@^1.0.0:
   resolved "https://registry.yarnpkg.com/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz#cc2c8e94fc18bbdffe64d6534570c8a673b27f59"
   integrity sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==
 
-color-convert@^1.9.0, color-convert@^2.0.1:
+color-convert@^1.9.0:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
+  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
+  dependencies:
+    color-name "1.1.3"
+
+color-convert@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
   integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
   dependencies:
     color-name "~1.1.4"
+
+color-name@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+  integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
 color-name@~1.1.4:
   version "1.1.4"
@@ -5429,12 +5446,40 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-debug@2.6.9, debug@3.1.0, debug@4, debug@^2.6.9, debug@^3.1.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3:
+debug@2.6.9, debug@^2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
+
+debug@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
+
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
+
+debug@^3.1.0:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
+  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
+  dependencies:
+    ms "^2.1.1"
+
+debug@^4.3.1, debug@^4.3.2, debug@^4.3.3:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
 
 debuglog@^1.0.1:
   version "1.0.1"
@@ -9444,10 +9489,20 @@ moo@^0.5.0, moo@^0.5.1:
   resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.1.tgz#7aae7f384b9b09f620b6abf6f74ebbcd1b65dbc4"
   integrity sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==
 
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+  integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
+
 ms@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
+
+ms@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
 ms@^2.0.0, ms@^2.1.1:
   version "2.1.3"
@@ -12360,6 +12415,13 @@ trim-repeated@^1.0.0:
   dependencies:
     escape-string-regexp "^1.0.2"
 
+truncate-utf8-bytes@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz#405923909592d56f78a5818434b0b78489ca5f2b"
+  integrity sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==
+  dependencies:
+    utf8-byte-length "^1.0.1"
+
 ts-jest@^27.1.2:
   version "27.1.2"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-27.1.2.tgz#5991d6eb3fd8e1a8d4b8f6de3ec0a3cc567f3151"
@@ -12603,6 +12665,11 @@ url@0.10.3:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+utf8-byte-length@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz#f45f150c4c66eee968186505ab93fcbb8ad6bf61"
+  integrity sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA==
 
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Nacl paths appears to exceed the length limit in Zendesk static resource paths (macro_attachment and brand_logo).
This PR adds trim functionality of a file name to comply with filesystem restrictions.

---

_Additional context for reviewer_

---
_Release Notes_: 
* Static files with long names would be shortened and would concatenated with the name's hash

---
_User Notifications_: 

-