### PR TITLE
SALTO-1444 remove hardcoded annotations for custom objects deploy

### DIFF
--- a/packages/cli/e2e_test/helpers/templates.ts
+++ b/packages/cli/e2e_test/helpers/templates.ts
@@ -40,6 +40,18 @@ export const customObject = (
         annotations: { label: data.betaLabel },
       },
     },
+    annotations: {
+      deploymentStatus: 'Deployed',
+      pluralLabel: 'Tests',
+      sharingModel: 'ReadWrite',
+      nameField: { type: 'Text', label: 'Name' },
+    },
+    annotationRefsOrTypes: {
+      deploymentStatus: BuiltinTypes.STRING,
+      pluralLabel: BuiltinTypes.STRING,
+      sharingModel: BuiltinTypes.STRING,
+      nameField: new ObjectType({ elemID: new ElemID('salesforce', 'CustomObject') }),
+    },
   })
 }
 

--- a/packages/cli/e2e_test/salto.test.ts
+++ b/packages/cli/e2e_test/salto.test.ts
@@ -219,8 +219,23 @@ describe.each([
         annotations {
           serviceid metadataType {
           }
+          salesforce.CustomField nameField {
+          }
+          string pluralLabel {
+          }
+          string sharingModel {
+          }
+          string deploymentStatus {
+          }
         }
         metadataType = "CustomObject"
+        nameField = {
+          label = "Name"
+          type = "Text"
+        }
+        pluralLabel = "TestDiffObjozkjqxojoxhfs"
+        sharingModel = "ReadWrite"
+        deploymentStatus = "Deployed"
         ${accountName}.Text Alpha {
           label = "Alpha"
           _required = false

--- a/packages/salesforce-adapter/e2e_test/adapter.test.ts
+++ b/packages/salesforce-adapter/e2e_test/adapter.test.ts
@@ -476,6 +476,8 @@ describe('Salesforce adapter E2E with real account', () => {
         annotationRefsOrTypes: {
           deploymentStatus: BuiltinTypes.STRING,
           enableHistory: BuiltinTypes.BOOLEAN,
+          pluralLabel: BuiltinTypes.STRING,
+          sharingModel: BuiltinTypes.STRING,
           nameField: new ObjectType({ elemID: nameFieldElemID,
             fields: {
               [constants.LABEL]: { refType: BuiltinTypes.STRING },
@@ -489,6 +491,8 @@ describe('Salesforce adapter E2E with real account', () => {
           [constants.METADATA_TYPE]: constants.CUSTOM_OBJECT,
           deploymentStatus: 'InDevelopment',
           enableHistory: true,
+          pluralLabel: 'Tests',
+          sharingModel: 'ReadWrite',
           nameField: {
             [constants.LABEL]: customObjectName,
             type: 'AutoNumber',
@@ -553,6 +557,16 @@ describe('Salesforce adapter E2E with real account', () => {
         annotations: {
           [constants.API_NAME]: customObjectName,
           [constants.METADATA_TYPE]: constants.CUSTOM_OBJECT,
+          deploymentStatus: 'Deployed',
+          pluralLabel: 'Tests',
+          sharingModel: 'ReadWrite',
+          nameField: { type: 'Text', label: 'Name' },
+        },
+        annotationRefsOrTypes: {
+          deploymentStatus: BuiltinTypes.STRING,
+          pluralLabel: BuiltinTypes.STRING,
+          sharingModel: BuiltinTypes.STRING,
+          nameField: new ObjectType({ elemID: new ElemID('salesforce', 'CustomObject') }),
         },
         fields: {
           description: {
@@ -595,6 +609,16 @@ describe('Salesforce adapter E2E with real account', () => {
           [constants.LABEL]: 'test label',
           [constants.API_NAME]: customObjectName,
           [constants.METADATA_TYPE]: constants.CUSTOM_OBJECT,
+          deploymentStatus: 'Deployed',
+          pluralLabel: 'Tests',
+          sharingModel: 'ReadWrite',
+          nameField: { type: 'Text', label: 'Name' },
+        },
+        annotationRefsOrTypes: {
+          deploymentStatus: BuiltinTypes.STRING,
+          pluralLabel: BuiltinTypes.STRING,
+          sharingModel: BuiltinTypes.STRING,
+          nameField: new ObjectType({ elemID: new ElemID('salesforce', 'CustomObject') }),
         },
       })
 
@@ -622,6 +646,16 @@ describe('Salesforce adapter E2E with real account', () => {
           [constants.LABEL]: 'test2 label',
           [constants.API_NAME]: customObjectName,
           [constants.METADATA_TYPE]: constants.CUSTOM_OBJECT,
+          deploymentStatus: 'Deployed',
+          pluralLabel: 'Tests',
+          sharingModel: 'ReadWrite',
+          nameField: { type: 'Text', label: 'Name' },
+        },
+        annotationRefsOrTypes: {
+          deploymentStatus: BuiltinTypes.STRING,
+          pluralLabel: BuiltinTypes.STRING,
+          sharingModel: BuiltinTypes.STRING,
+          nameField: new ObjectType({ elemID: new ElemID('salesforce', 'CustomObject') }),
         },
       })
 
@@ -817,6 +851,8 @@ describe('Salesforce adapter E2E with real account', () => {
         },
         annotationRefsOrTypes: {
           deploymentStatus: BuiltinTypes.STRING,
+          pluralLabel: BuiltinTypes.STRING,
+          sharingModel: BuiltinTypes.STRING,
           nameField: nameFieldType,
         },
         annotations: {
@@ -825,6 +861,8 @@ describe('Salesforce adapter E2E with real account', () => {
           [constants.API_NAME]: customObjectName,
           [constants.METADATA_TYPE]: constants.CUSTOM_OBJECT,
           deploymentStatus: 'InDevelopment',
+          pluralLabel: 'Tests',
+          sharingModel: 'ReadWrite',
           nameField: {
             [constants.LABEL]: customObjectName,
             type: 'AutoNumber',
@@ -854,6 +892,8 @@ describe('Salesforce adapter E2E with real account', () => {
         {
           [constants.DEFAULT_VALUE_FORMULA]: 'test2',
           [constants.LABEL]: 'test label 2',
+          pluralLabel: 'Tests',
+          sharingModel: 'ReadWrite',
           deploymentStatus: 'Deployed',
           nameField: {
             [constants.LABEL]: customObjectName,
@@ -920,6 +960,16 @@ describe('Salesforce adapter E2E with real account', () => {
           [constants.LABEL]: 'Object Label',
           [constants.API_NAME]: customObjectName,
           [constants.METADATA_TYPE]: constants.CUSTOM_OBJECT,
+          deploymentStatus: 'Deployed',
+          pluralLabel: 'Tests',
+          sharingModel: 'ReadWrite',
+          nameField: { type: 'Text', label: 'Name' },
+        },
+        annotationRefsOrTypes: {
+          deploymentStatus: BuiltinTypes.STRING,
+          pluralLabel: BuiltinTypes.STRING,
+          sharingModel: BuiltinTypes.STRING,
+          nameField: new ObjectType({ elemID: new ElemID('salesforce', 'CustomObject') }),
         },
       })
 
@@ -1463,8 +1513,16 @@ describe('Salesforce adapter E2E with real account', () => {
               ...customFieldsObject.annotations,
               [constants.API_NAME]: customObjectAddFieldsName,
               [constants.METADATA_TYPE]: constants.CUSTOM_OBJECT,
+              deploymentStatus: 'Deployed',
+              pluralLabel: 'Tests',
+              sharingModel: 'ReadWrite',
+              nameField: { type: 'Text', label: 'Name' },
             },
-            annotationRefsOrTypes: { ...customFieldsObject.annotationRefTypes },
+            annotationRefsOrTypes: { ...customFieldsObject.annotationRefTypes,
+              deploymentStatus: BuiltinTypes.STRING,
+              pluralLabel: BuiltinTypes.STRING,
+              sharingModel: BuiltinTypes.STRING,
+              nameField: new ObjectType({ elemID: new ElemID('salesforce', 'CustomObject') }) },
           })
 
           // Resolve reference expression before deploy
@@ -2346,6 +2404,16 @@ describe('Salesforce adapter E2E with real account', () => {
           [constants.LABEL]: 'test label',
           [constants.API_NAME]: customObjectName,
           [constants.METADATA_TYPE]: constants.CUSTOM_OBJECT,
+          deploymentStatus: 'Deployed',
+          pluralLabel: 'Tests',
+          sharingModel: 'ReadWrite',
+          nameField: { type: 'Text', label: 'Name' },
+        },
+        annotationRefsOrTypes: {
+          deploymentStatus: BuiltinTypes.STRING,
+          pluralLabel: BuiltinTypes.STRING,
+          sharingModel: BuiltinTypes.STRING,
+          nameField: new ObjectType({ elemID: new ElemID('salesforce', 'CustomObject') }),
         },
       })
 
@@ -2404,6 +2472,16 @@ describe('Salesforce adapter E2E with real account', () => {
           [constants.LABEL]: 'test label',
           [constants.API_NAME]: customObjectName,
           [constants.METADATA_TYPE]: constants.CUSTOM_OBJECT,
+          deploymentStatus: 'Deployed',
+          pluralLabel: 'Tests',
+          sharingModel: 'ReadWrite',
+          nameField: { type: 'Text', label: 'Name' },
+        },
+        annotationRefsOrTypes: {
+          deploymentStatus: BuiltinTypes.STRING,
+          pluralLabel: BuiltinTypes.STRING,
+          sharingModel: BuiltinTypes.STRING,
+          nameField: new ObjectType({ elemID: new ElemID('salesforce', 'CustomObject') }),
         },
       })
 
@@ -2427,6 +2505,16 @@ describe('Salesforce adapter E2E with real account', () => {
           [constants.METADATA_TYPE]: constants.CUSTOM_OBJECT,
           [constants.TOPICS_FOR_OBJECTS_ANNOTATION]: { [constants
             .TOPICS_FOR_OBJECTS_FIELDS.ENABLE_TOPICS]: true },
+          deploymentStatus: 'Deployed',
+          pluralLabel: 'Tests',
+          sharingModel: 'ReadWrite',
+          nameField: { type: 'Text', label: 'Name' },
+        },
+        annotationRefsOrTypes: {
+          deploymentStatus: BuiltinTypes.STRING,
+          pluralLabel: BuiltinTypes.STRING,
+          sharingModel: BuiltinTypes.STRING,
+          nameField: new ObjectType({ elemID: new ElemID('salesforce', 'CustomObject') }),
         },
       })
 
@@ -2454,6 +2542,16 @@ describe('Salesforce adapter E2E with real account', () => {
           [constants.LABEL]: 'test label',
           [constants.API_NAME]: customObjectName,
           [constants.METADATA_TYPE]: constants.CUSTOM_OBJECT,
+          deploymentStatus: 'Deployed',
+          pluralLabel: 'Tests',
+          sharingModel: 'ReadWrite',
+          nameField: { type: 'Text', label: 'Name' },
+        },
+        annotationRefsOrTypes: {
+          deploymentStatus: BuiltinTypes.STRING,
+          pluralLabel: BuiltinTypes.STRING,
+          sharingModel: BuiltinTypes.STRING,
+          nameField: new ObjectType({ elemID: new ElemID('salesforce', 'CustomObject') }),
         },
       })
 

--- a/packages/salesforce-adapter/e2e_test/adapter.test.ts
+++ b/packages/salesforce-adapter/e2e_test/adapter.test.ts
@@ -1515,7 +1515,7 @@ describe('Salesforce adapter E2E with real account', () => {
               [constants.METADATA_TYPE]: constants.CUSTOM_OBJECT,
               deploymentStatus: 'Deployed',
               pluralLabel: 'Tests',
-              sharingModel: 'ReadWrite',
+              sharingModel: 'ControlledByParent',
               nameField: { type: 'Text', label: 'Name' },
             },
             annotationRefsOrTypes: { ...customFieldsObject.annotationRefTypes,

--- a/packages/salesforce-adapter/src/filters/utils.ts
+++ b/packages/salesforce-adapter/src/filters/utils.ts
@@ -29,12 +29,12 @@ import SalesforceClient from '../client/client'
 import { OptionalFeatures } from '../types'
 import {
   API_NAME, LABEL, CUSTOM_OBJECT, METADATA_TYPE, NAMESPACE_SEPARATOR, API_NAME_SEPARATOR,
-  INSTANCE_FULL_NAME_FIELD, SALESFORCE, INTERNAL_ID_FIELD, INTERNAL_ID_ANNOTATION, CUSTOM_FIELD,
+  INSTANCE_FULL_NAME_FIELD, SALESFORCE, INTERNAL_ID_FIELD, INTERNAL_ID_ANNOTATION,
   KEY_PREFIX,
   MAX_QUERY_LENGTH,
 } from '../constants'
-import { JSONBool, CustomObject, SalesforceRecord } from '../client/types'
-import { metadataType, apiName, defaultApiName, Types, isCustomSettingsObject, isCustomObject } from '../transformers/transformer'
+import { JSONBool, SalesforceRecord } from '../client/types'
+import { metadataType, apiName, defaultApiName, Types, isCustomObject } from '../transformers/transformer'
 import { Filter, FilterContext } from '../filter'
 
 const { toArrayAsync, awu } = collections.asynciterable
@@ -121,22 +121,6 @@ export const addDefaults = async (element: ChangeDataType): Promise<void> => {
     addMetadataType(elem)
     addLabel(elem)
     await awu(Object.values(elem.fields)).forEach(addFieldDefaults)
-    if (!isCustomSettingsObject(elem) && !(await isCustomMetadataType(elem))) {
-      const defaults: Partial<CustomObject> = {
-        deploymentStatus: 'Deployed',
-        pluralLabel: `${elem.annotations.label}s`,
-        sharingModel: Object.values(elem.fields).some(isMasterDetailField)
-          ? 'ControlledByParent'
-          : 'ReadWrite',
-        nameField: { type: 'Text', label: 'Name' },
-      }
-      const nameFieldType = new ObjectType({ elemID: new ElemID(SALESFORCE, CUSTOM_FIELD) })
-      Object.entries(defaults).forEach(([name, value]) => {
-        setAnnotationDefault(
-          elem, name, value, name === 'nameField' ? nameFieldType : BuiltinTypes.STRING
-        )
-      })
-    }
   }
   if (isInstanceElement(element)) {
     await addInstanceDefaults(element)

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -323,17 +323,6 @@ describe('SalesforceAdapter CRUD', () => {
         expect(objAnnotations.label).toEqual('Test')
         expect(result.annotationRefTypes.label.elemID)
           .toEqual(BuiltinTypes.STRING.elemID)
-        expect(objAnnotations.deploymentStatus).toEqual('Deployed')
-        expect(result.annotationRefTypes.deploymentStatus.elemID)
-          .toEqual(BuiltinTypes.STRING.elemID)
-        expect(objAnnotations.nameField).toEqual({ type: 'Text', label: 'Name' })
-        expect(result.annotationRefTypes.nameField.elemID).toEqual(
-          new ElemID(constants.SALESFORCE, constants.CUSTOM_FIELD)
-        )
-        expect(objAnnotations.pluralLabel).toEqual('Tests')
-        expect(result.annotationRefTypes.pluralLabel.elemID).toEqual(BuiltinTypes.STRING.elemID)
-        expect(objAnnotations.sharingModel).toEqual('ReadWrite')
-        expect(result.annotationRefTypes.sharingModel.elemID).toEqual(BuiltinTypes.STRING.elemID)
         expect(
           result.fields.description.annotations[constants.API_NAME]
         ).toBe('Test__c.description__c')

--- a/packages/salesforce-adapter/test/filters/utils.test.ts
+++ b/packages/salesforce-adapter/test/filters/utils.test.ts
@@ -15,7 +15,7 @@
 */
 import { ObjectType, ElemID, BuiltinTypes, Field, InstanceElement, createRefToElmWithValue } from '@salto-io/adapter-api'
 import { addDefaults } from '../../src/filters/utils'
-import { SALESFORCE, LABEL, API_NAME, CUSTOM_FIELD, INSTANCE_FULL_NAME_FIELD, METADATA_TYPE, CUSTOM_OBJECT, CUSTOM_SETTINGS_TYPE } from '../../src/constants'
+import { SALESFORCE, LABEL, API_NAME, INSTANCE_FULL_NAME_FIELD, METADATA_TYPE, CUSTOM_OBJECT, CUSTOM_SETTINGS_TYPE } from '../../src/constants'
 import { Types } from '../../src/transformers/transformer'
 import { CustomObject } from '../../src/client/types'
 import { mockTypes } from '../mock_elements'
@@ -83,10 +83,6 @@ describe('addDefaults', () => {
           [API_NAME]: 'test__c',
           [METADATA_TYPE]: CUSTOM_OBJECT,
           [LABEL]: 'test',
-          deploymentStatus: 'Deployed',
-          pluralLabel: 'tests',
-          nameField: { type: 'Text', label: 'Name' },
-          sharingModel: 'ReadWrite',
         } as Partial<CustomObject>)
       })
       it('should add annotation types', () => {
@@ -94,13 +90,7 @@ describe('addDefaults', () => {
           [API_NAME]: createRefToElmWithValue(BuiltinTypes.SERVICE_ID),
           [METADATA_TYPE]: createRefToElmWithValue(BuiltinTypes.SERVICE_ID),
           [LABEL]: createRefToElmWithValue(BuiltinTypes.STRING),
-          deploymentStatus: createRefToElmWithValue(BuiltinTypes.STRING),
-          pluralLabel: createRefToElmWithValue(BuiltinTypes.STRING),
-          sharingModel: createRefToElmWithValue(BuiltinTypes.STRING),
         })
-        expect(object.annotationRefTypes.nameField?.elemID).toEqual(
-          new ElemID(SALESFORCE, CUSTOM_FIELD)
-        )
       })
       it('should add defaults to fields', () => {
         expect(object.fields.a.annotations).toMatchObject({
@@ -127,7 +117,6 @@ describe('addDefaults', () => {
       it('should add missing annotations', () => {
         expect(object.annotations).toMatchObject({
           [API_NAME]: 'test__c',
-          sharingModel: 'ReadWrite',
         } as Partial<CustomObject>)
       })
       it('should not override existing annotations', () => {
@@ -136,37 +125,16 @@ describe('addDefaults', () => {
           nameField: { type: 'AutoNumber', label: 'Name' },
         } as Partial<CustomObject>)
       })
-      it('should add plural label according to the label', () => {
-        expect(object.annotations).toHaveProperty('pluralLabel', 'myLabels')
-      })
       it('should add missing annotation types', () => {
         expect(object.annotationRefTypes).toMatchObject({
           [API_NAME]: createRefToElmWithValue(BuiltinTypes.SERVICE_ID),
           [LABEL]: createRefToElmWithValue(BuiltinTypes.STRING),
         })
-        expect(object.annotationRefTypes.nameField?.elemID).toEqual(
-          new ElemID(SALESFORCE, CUSTOM_FIELD)
-        )
       })
       it('should not override existing annotation types', () => {
         expect(object.annotationRefTypes).toMatchObject({
           sharingModel: createRefToElmWithValue(BuiltinTypes.HIDDEN_STRING),
         })
-      })
-    })
-    describe('when object has a master detail field', () => {
-      let object: ObjectType
-      beforeEach(async () => {
-        object = new ObjectType({
-          elemID: new ElemID(SALESFORCE, 'test'),
-          fields: {
-            a: { refType: Types.primitiveDataTypes.MasterDetail },
-          },
-        })
-        await addDefaults(object)
-      })
-      it('should set sharing model to controlled by parent', () => {
-        expect(object.annotations).toHaveProperty('sharingModel', 'ControlledByParent')
       })
     })
   })


### PR DESCRIPTION
_remove hardcoded annotations for custom objects deploy_

---
_Additional context for reviewer_:

None
---
_Release Notes_: 
Salesforce-adapter:

* remove hardcoded (pluralLabel, deploymentStatus, sharingModel and nameField) annotations for custom objects deploy
---

_User Notifications_: 
Salesforce-adapter:

* None
