### PR TITLE
SALTO-2851: automation validation should handle reference expression

### DIFF
--- a/packages/zendesk-adapter/src/change_validators/automation_all_conditions.ts
+++ b/packages/zendesk-adapter/src/change_validators/automation_all_conditions.ts
@@ -33,7 +33,7 @@ const fieldExist = (field: string): boolean =>
   ['status', 'type', 'group_id', 'assignee_id', 'requester_id'].includes(field)
 
 
-export const isNotValidData = (instance: InstanceElement): boolean => {
+const isNotValidData = (instance: InstanceElement): boolean => {
   const allConditions = instance.value.conditions?.all ?? []
   return !(isConditions(allConditions)
       && allConditions.some(condition => fieldExist(condition.field)))
@@ -43,9 +43,9 @@ export const automationAllConditionsValidator: ChangeValidator = async changes =
   const relevantInstances = await awu(changes)
     .filter(isAdditionOrModificationChange)
     .map(getChangeData)
-    .map(data => resolveValues(data, lookupFunc))
     .filter(isInstanceElement)
     .filter(instance => instance.elemID.typeName === AUTOMATION_TYPE_NAME)
+    .map(data => resolveValues(data, lookupFunc))
     .filter(isNotValidData)
     .toArray()
 

--- a/packages/zendesk-adapter/src/change_validators/automation_all_conditions.ts
+++ b/packages/zendesk-adapter/src/change_validators/automation_all_conditions.ts
@@ -20,26 +20,34 @@ import {
   isAdditionOrModificationChange, isInstanceElement,
 } from '@salto-io/adapter-api'
 
+import { resolveValues } from '@salto-io/adapter-utils'
+import { collections } from '@salto-io/lowerdash'
 import { isConditions } from '../filters/utils'
+import { lookupFunc } from '../filters/field_references'
 
+
+const { awu } = collections.asynciterable
 export const AUTOMATION_TYPE_NAME = 'automation'
 
 const fieldExist = (field: string): boolean =>
   ['status', 'type', 'group_id', 'assignee_id', 'requester_id'].includes(field)
 
-const isNotValidData = (instance: InstanceElement): boolean => {
+
+export const isNotValidData = (instance: InstanceElement): boolean => {
   const allConditions = instance.value.conditions?.all ?? []
   return !(isConditions(allConditions)
       && allConditions.some(condition => fieldExist(condition.field)))
 }
 
 export const automationAllConditionsValidator: ChangeValidator = async changes => {
-  const relevantInstances = changes
+  const relevantInstances = await awu(changes)
     .filter(isAdditionOrModificationChange)
     .map(getChangeData)
+    .map(data => resolveValues(data, lookupFunc))
     .filter(isInstanceElement)
     .filter(instance => instance.elemID.typeName === AUTOMATION_TYPE_NAME)
     .filter(isNotValidData)
+    .toArray()
 
   return relevantInstances
     .flatMap(instance => [{


### PR DESCRIPTION
_automation validation should handle reference expression_

---

_Additional context for reviewer_
None

---
_Release Notes_: 
Zendesk:
* automation validation should handle reference expression

---
_User Notifications_: 
Zendesk:
* automation validation should handle reference expression
