### PR TITLE
SALTO-2835 Allow restricting reference rules to specific types

### DIFF
--- a/packages/salesforce-adapter/src/filters/replace_instance_field_values.ts
+++ b/packages/salesforce-adapter/src/filters/replace_instance_field_values.ts
@@ -68,9 +68,9 @@ const getRelevantFieldMapping = async (
   })
 }
 
-const shouldReplace = async (field: Field): Promise<boolean> => {
+const shouldReplace = async (field: Field, instance: InstanceElement): Promise<boolean> => {
   const resolverFinder = generateReferenceResolverFinder(fieldSelectMapping)
-  return (await resolverFinder(field)).length > 0
+  return (await resolverFinder(field, instance)).length > 0
 }
 
 const replaceInstanceValues = async (
@@ -78,7 +78,7 @@ const replaceInstanceValues = async (
   nameLookup: multiIndex.Index<[string], string>
 ): Promise<void> => {
   const transformFunc: TransformFunc = async ({ value, field }) => {
-    if (_.isUndefined(field) || !(await shouldReplace(field))) {
+    if (_.isUndefined(field) || !(await shouldReplace(field, instance))) {
       return value
     }
 

--- a/packages/salesforce-adapter/src/filters/value_to_static_file.ts
+++ b/packages/salesforce-adapter/src/filters/value_to_static_file.ts
@@ -45,7 +45,9 @@ const shouldReplace = async (
   instance: InstanceElement
 ): Promise<boolean> => {
   const resolverFinder = generateReferenceResolverFinder(fieldSelectMapping)
-  return _.isString(value) && hasCodeField(instance) && (await resolverFinder(field)).length > 0
+  return (_.isString(value)
+    && hasCodeField(instance)
+    && (await resolverFinder(field, instance)).length > 0)
 }
 
 

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -607,7 +607,7 @@ export class FieldReferenceResolver {
   async match(field: Field, element?: Element): Promise<boolean> {
     return (
       matchName(field.name, this.src.field)
-      && matchApiName(field.parent, this.src.parentTypes)
+      && await matchApiName(field.parent, this.src.parentTypes)
       && (this.src.instanceTypes === undefined
         || (isInstanceElement(element) && matchInstanceType(element, this.src.instanceTypes)))
     )
@@ -674,13 +674,13 @@ const getLookUpNameImpl = (defs = fieldNameToTypeMappingDefs): GetLookupNameFunc
     return strategies[0]
   }
 
-  return async ({ ref, path, field }) => {
+  return async ({ ref, path, field, element }) => {
     // We skip resolving instance annotations because they are not deployed to the service
     // and we need the full element context in those
     const isInstanceAnnotation = path?.idType === 'instance' && path.isAttrID()
 
     if (!isInstanceAnnotation) {
-      const strategy = await determineLookupStrategy({ ref, path, field })
+      const strategy = await determineLookupStrategy({ ref, path, field, element })
       if (strategy !== undefined) {
         return strategy.serialize({ ref, field })
       }

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -140,15 +140,6 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     target: { parentContext: 'instanceParent', type: CUSTOM_FIELD },
   },
   {
-    src: {
-      field: 'field',
-      parentTypes: ['FilterItem'],
-      instanceTypes: ['SharingRules'],
-    },
-    serializationStrategy: 'relativeApiName',
-    target: { parentContext: 'instanceParent', type: CUSTOM_FIELD },
-  },
-  {
     src: { field: 'flowName', parentTypes: ['FlowSubflow'] },
     target: { type: 'Flow' },
   },
@@ -166,11 +157,27 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
   {
     src: {
       field: 'field',
-      parentTypes: ['FilterItem', 'ReportColumn', 'PermissionSetFieldPermissions'],
+      parentTypes: ['ReportColumn', 'PermissionSetFieldPermissions'],
+    },
+    target: { type: CUSTOM_FIELD },
+  },
+  {
+    src: {
+      field: 'field',
+      parentTypes: ['FilterItem'],
       // match everything except SharingRules (which uses a different serialization strategy)
       instanceTypes: [/^(?!SharingRules$).*/],
     },
     target: { type: CUSTOM_FIELD },
+  },
+  {
+    src: {
+      field: 'field',
+      parentTypes: ['FilterItem'],
+      instanceTypes: ['SharingRules'],
+    },
+    serializationStrategy: 'relativeApiName',
+    target: { parentContext: 'instanceParent', type: CUSTOM_FIELD },
   },
   {
     src: { field: 'offsetFromField', parentTypes: ['WorkflowTask', 'WorkflowTimeTrigger'] },

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Field, isElement, Value, Element, ReferenceExpression, ElemID } from '@salto-io/adapter-api'
+import { Field, isElement, Value, Element, ReferenceExpression, ElemID, isInstanceElement, InstanceElement } from '@salto-io/adapter-api'
 import { references as referenceUtils } from '@salto-io/adapter-components'
 import { GetLookupNameFunc, GetLookupNameFuncArgs } from '@salto-io/adapter-utils'
 import _ from 'lodash'
@@ -118,6 +118,8 @@ export type ReferenceContextStrategyName = (
 type SourceDef = {
   field: string | RegExp
   parentTypes: string[]
+  // when available, only consider instances matching one or more of the specified types
+  instanceTypes?: (string | RegExp)[]
 }
 
 /**
@@ -133,7 +135,16 @@ export type FieldReferenceDefinition = {
 
 export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
   {
-    src: { field: 'field', parentTypes: [WORKFLOW_FIELD_UPDATE_METADATA_TYPE, LAYOUT_ITEM_METADATA_TYPE, SUMMARY_LAYOUT_ITEM_METADATA_TYPE, 'WorkflowEmailRecipient', 'QuickActionLayoutItem', 'FieldSetItem', 'FilterItem'] },
+    src: { field: 'field', parentTypes: [WORKFLOW_FIELD_UPDATE_METADATA_TYPE, LAYOUT_ITEM_METADATA_TYPE, SUMMARY_LAYOUT_ITEM_METADATA_TYPE, 'WorkflowEmailRecipient', 'QuickActionLayoutItem', 'FieldSetItem'] },
+    serializationStrategy: 'relativeApiName',
+    target: { parentContext: 'instanceParent', type: CUSTOM_FIELD },
+  },
+  {
+    src: {
+      field: 'field',
+      parentTypes: ['FilterItem'],
+      instanceTypes: ['SharingRules'],
+    },
     serializationStrategy: 'relativeApiName',
     target: { parentContext: 'instanceParent', type: CUSTOM_FIELD },
   },
@@ -153,7 +164,12 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
   // note: not all field values under ReportColumn match this rule - but it's ok because
   // only the ones that match are currently extracted (SALTO-1758)
   {
-    src: { field: 'field', parentTypes: ['FilterItem', 'ReportColumn', 'PermissionSetFieldPermissions'] },
+    src: {
+      field: 'field',
+      parentTypes: ['FilterItem', 'ReportColumn', 'PermissionSetFieldPermissions'],
+      // match everything except SharingRules (which uses a different serialization strategy)
+      instanceTypes: [/^(?!SharingRules$).*/],
+    },
     target: { type: CUSTOM_FIELD },
   },
   {
@@ -551,15 +567,23 @@ export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
   ...fieldPermissionEnumDisabledExtraMappingDefs,
 ]
 
-const matchName = (fieldName: string, matcher: string | RegExp): boolean => (
+const matchName = (name: string, matcher: string | RegExp): boolean => (
   _.isString(matcher)
-    ? matcher === fieldName
-    : matcher.test(fieldName)
+    ? matcher === name
+    : matcher.test(name)
 )
 
 const matchApiName = async (elem: Element, types: string[]): Promise<boolean> => (
   types.includes(await apiName(elem))
 )
+
+const matchInstanceType = async (
+  inst: InstanceElement,
+  matchers: (string | RegExp)[],
+): Promise<boolean> => {
+  const typeName = await apiName(await inst.getType())
+  return matchers.some(matcher => matchName(typeName, matcher))
+}
 
 export class FieldReferenceResolver {
   src: SourceDef
@@ -580,15 +604,20 @@ export class FieldReferenceResolver {
     return new FieldReferenceResolver(def)
   }
 
-  async match(field: Field): Promise<boolean> {
+  async match(field: Field, element?: Element): Promise<boolean> {
     return (
       matchName(field.name, this.src.field)
       && matchApiName(field.parent, this.src.parentTypes)
+      && (this.src.instanceTypes === undefined
+        || (isInstanceElement(element) && matchInstanceType(element, this.src.instanceTypes)))
     )
   }
 }
 
-export type ReferenceResolverFinder = (field: Field) => Promise<FieldReferenceResolver[]>
+export type ReferenceResolverFinder = (
+  field: Field,
+  element?: Element,
+) => Promise<FieldReferenceResolver[]>
 
 /**
  * Generates a function that filters the relevant resolvers for a given field.
@@ -611,10 +640,10 @@ export const generateReferenceResolverFinder = (
     .mapValues(items => items.map(item => item.def))
     .value()
 
-  return (async field => awu([
+  return (async (field, element) => awu([
     ...(matchersByFieldName[field.name] ?? []),
     ...(regexFieldMatchersByParent[await apiName(field.parent)] || []),
-  ]).filter(resolver => resolver.match(field)).toArray())
+  ]).filter(resolver => resolver.match(field, element)).toArray())
 }
 
 const getLookUpNameImpl = (defs = fieldNameToTypeMappingDefs): GetLookupNameFunc => {
@@ -626,7 +655,7 @@ const getLookUpNameImpl = (defs = fieldNameToTypeMappingDefs): GetLookupNameFunc
       log.debug('could not determine field for path %s', args.path?.getFullName())
       return undefined
     }
-    const strategies = (await resolverFinder(args.field))
+    const strategies = (await resolverFinder(args.field, args.element))
       .map(def => def.serializationStrategy)
 
     if (strategies.length === 0) {

--- a/packages/salesforce-adapter/test/filters/field_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/field_references.test.ts
@@ -114,156 +114,192 @@ const generateObjectAndInstance = ({
 describe('FieldReferences filter', () => {
   const filter = filterCreator({ config: defaultFilterContext }) as FilterWith<'onFetch'>
 
-  const generateElements = (
-  ): Element[] => ([
-    customObjectType,
-    ...generateObjectAndInstance({
-      type: 'Account',
-      fieldName: 'name',
-    }),
-    ...generateObjectAndInstance({
-      type: 'SBQQ__QuoteLine__c',
-      fieldName: 'name',
-    }),
-    ...generateObjectAndInstance({
-      type: 'SBQQ__Quote__c',
-      fieldName: 'SBQQ__Account__c',
-    }),
+  const generateElements = (): Element[] => {
+    const filterItemType = new ObjectType({
+      elemID: new ElemID(SALESFORCE, 'FilterItem'),
+      annotations: { [METADATA_TYPE]: 'FilterItem' },
+      fields: {
+        // note: does not exactly match the real type
+        field: { refType: BuiltinTypes.STRING },
+      },
+    })
 
-    // site1.authorizationRequiredPage should point to page1
-    ...generateObjectAndInstance({
-      type: 'ApexPage',
-      objType: 'ApexPage',
-      instanceName: 'page1',
-      fieldName: 'any',
-      fieldValue: 'aaa',
-    }),
-    ...generateObjectAndInstance({
-      type: 'ApexClass',
-      objType: 'ApexClass',
-      instanceName: 'class5',
-      fieldName: 'any',
-      fieldValue: 'aaa',
-    }),
-    ...generateObjectAndInstance({
-      type: 'CustomSite',
-      objType: 'CustomSite',
-      instanceName: 'site1',
-      fieldName: 'authorizationRequiredPage',
-      fieldValue: 'page1',
-    }),
-    // report53.reportType should point to Account
-    ...generateObjectAndInstance({
-      type: 'Report',
-      objType: 'Report',
-      instanceName: 'report53',
-      fieldName: 'reportType',
-      fieldValue: 'Account',
-    }),
-    // filterItem643.field should point to Account.name (default strategy)
-    ...generateObjectAndInstance({
-      type: 'FilterItem',
-      objType: 'FilterItem',
-      instanceName: 'filterItem643',
-      fieldName: 'field',
-      fieldValue: 'Account.name',
-    }),
-    // fieldUpdate54.field should point to Account.name (instanceParent)
-    ...generateObjectAndInstance({
-      type: 'WorkflowFieldUpdate',
-      objType: 'WorkflowFieldUpdate',
-      instanceName: 'fieldUpdate54',
-      fieldName: 'field',
-      fieldValue: 'name',
-      parentType: 'Account',
-    }),
-    // customScript1[CPQ_QUOTE_LINE_FIELDS] should point to SBQQ__QuoteLine__c.name (target parent)
-    ...generateObjectAndInstance({
-      type: CPQ_CUSTOM_SCRIPT,
-      objType: CPQ_CUSTOM_SCRIPT,
-      instanceName: 'customScript1',
-      fieldName: CPQ_QUOTE_LINE_FIELDS,
-      fieldValue: ['name'],
-    }),
-    ...generateObjectAndInstance({
-      type: CPQ_CONFIGURATION_ATTRIBUTE,
-      objType: CPQ_CONFIGURATION_ATTRIBUTE,
-      instanceName: 'configAttr1',
-      fieldName: CPQ_DEFAULT_OBJECT_FIELD,
-      fieldValue: 'Quote__c',
-    }),
-    ...generateObjectAndInstance({
-      type: CPQ_DISCOUNT_SCHEDULE,
-      objType: CPQ_DISCOUNT_SCHEDULE,
-      instanceName: 'discountSchedule1',
-      fieldName: CPQ_CONSTRAINT_FIELD,
-      fieldValue: 'Account__c',
-    }),
-    ...generateObjectAndInstance({
-      type: CPQ_LOOKUP_QUERY,
-      objType: CPQ_LOOKUP_QUERY,
-      instanceName: 'lookupQuery1',
-      fieldName: CPQ_TESTED_OBJECT,
-      fieldValue: 'Quote',
-    }),
-    // name should point to ApexPage.instance.page1 (neighbor context)
-    ...generateObjectAndInstance({
-      type: 'AppMenuItem',
-      objType: 'AppMenuItem',
-      instanceName: 'appMenuItem',
-      fieldName: 'name',
-      fieldValue: 'page1',
-      contextFieldName: 'type',
-      contextFieldValue: 'ApexPage',
-    }),
-    // actionName should point to ApexClass.instance.class5 (neighbor context with reference)
-    new InstanceElement('apex', customObjectType, { [INSTANCE_FULL_NAME_FIELD]: 'apex' }), // fake instance so we have a reference
-    ...generateObjectAndInstance({
-      type: 'FlowActionCall',
-      objType: 'FlowActionCall',
-      instanceName: 'flowAction',
-      fieldName: 'actionName',
-      fieldValue: 'class5',
-      contextFieldName: 'actionType',
-      contextFieldValue: new ReferenceExpression(customObjectType.elemID.createNestedID('instance', 'apex')),
-    }),
-    // layoutItem436.field will remain the same (Account.fffff doesn't exist)
-    ...generateObjectAndInstance({
-      type: 'LayoutItem',
-      objType: 'LayoutItem',
-      instanceName: 'layoutItem436',
-      fieldName: 'field',
-      fieldValue: 'fffff',
-      parentType: 'Account',
-    }),
-    // shareTo should point to salesforce.Role.instance.CFO (neighbor context)
-    ...generateObjectAndInstance({
-      type: 'Role',
-      objType: 'Role',
-      instanceName: 'CFO',
-      fieldName: 'fullName',
-      fieldValue: 'CFO',
-    }),
-    ...generateObjectAndInstance({
-      type: 'FolderShare',
-      objType: 'FolderShare',
-      instanceName: 'folderShare',
-      fieldName: 'sharedTo',
-      fieldValue: 'CFO',
-      contextFieldName: 'sharedToType',
-      contextFieldValue: 'Role',
-    }),
-    // field should point to salesforce.Account.field.Id (neighbor context)
-    ...generateObjectAndInstance({
-      type: 'ReportTypeColumn',
-      objType: 'ReportTypeColumn',
-      instanceName: 'reportTypeColumn',
-      fieldName: 'field',
-      fieldValue: 'Id',
-      contextFieldName: 'table',
-      contextFieldValue: 'Account',
-    }),
-  ])
+    const sharingRulesType = new ObjectType({
+      elemID: new ElemID(SALESFORCE, 'SharingRules'),
+      annotations: { [METADATA_TYPE]: 'SharingRules' },
+      fields: {
+        someFilterField: { refType: filterItemType },
+      },
+    })
+    return [
+      customObjectType,
+      // sharingRules555 should point to Account.name (rule contains instanceTypes constraint)
+      filterItemType,
+      sharingRulesType,
+      new InstanceElement(
+        'sharingRules555',
+        sharingRulesType,
+        {
+          someFilterField: {
+            field: 'name',
+          },
+        },
+        undefined,
+        {
+          [CORE_ANNOTATIONS.PARENT]: [
+            new ReferenceExpression(new ElemID(SALESFORCE, 'Account')),
+          ],
+        },
+      ),
+      ...generateObjectAndInstance({
+        type: 'Account',
+        fieldName: 'name',
+      }),
+      ...generateObjectAndInstance({
+        type: 'SBQQ__QuoteLine__c',
+        fieldName: 'name',
+      }),
+      ...generateObjectAndInstance({
+        type: 'SBQQ__Quote__c',
+        fieldName: 'SBQQ__Account__c',
+      }),
+
+      // site1.authorizationRequiredPage should point to page1
+      ...generateObjectAndInstance({
+        type: 'ApexPage',
+        objType: 'ApexPage',
+        instanceName: 'page1',
+        fieldName: 'any',
+        fieldValue: 'aaa',
+      }),
+      ...generateObjectAndInstance({
+        type: 'ApexClass',
+        objType: 'ApexClass',
+        instanceName: 'class5',
+        fieldName: 'any',
+        fieldValue: 'aaa',
+      }),
+      ...generateObjectAndInstance({
+        type: 'CustomSite',
+        objType: 'CustomSite',
+        instanceName: 'site1',
+        fieldName: 'authorizationRequiredPage',
+        fieldValue: 'page1',
+      }),
+      // report53.reportType should point to Account
+      ...generateObjectAndInstance({
+        type: 'Report',
+        objType: 'Report',
+        instanceName: 'report53',
+        fieldName: 'reportType',
+        fieldValue: 'Account',
+      }),
+      // filterItem643.field should point to Account.name (default strategy)
+      ...generateObjectAndInstance({
+        type: 'FilterItem',
+        objType: 'FilterItem',
+        instanceName: 'filterItem643',
+        fieldName: 'field',
+        fieldValue: 'Account.name',
+      }),
+      // fieldUpdate54.field should point to Account.name (instanceParent)
+      ...generateObjectAndInstance({
+        type: 'WorkflowFieldUpdate',
+        objType: 'WorkflowFieldUpdate',
+        instanceName: 'fieldUpdate54',
+        fieldName: 'field',
+        fieldValue: 'name',
+        parentType: 'Account',
+      }),
+      // customScript1[CPQ_QUOTE_LINE_FIELDS] should point to SBQQ__QuoteLine__c.name
+      // (target parent)
+      ...generateObjectAndInstance({
+        type: CPQ_CUSTOM_SCRIPT,
+        objType: CPQ_CUSTOM_SCRIPT,
+        instanceName: 'customScript1',
+        fieldName: CPQ_QUOTE_LINE_FIELDS,
+        fieldValue: ['name'],
+      }),
+      ...generateObjectAndInstance({
+        type: CPQ_CONFIGURATION_ATTRIBUTE,
+        objType: CPQ_CONFIGURATION_ATTRIBUTE,
+        instanceName: 'configAttr1',
+        fieldName: CPQ_DEFAULT_OBJECT_FIELD,
+        fieldValue: 'Quote__c',
+      }),
+      ...generateObjectAndInstance({
+        type: CPQ_DISCOUNT_SCHEDULE,
+        objType: CPQ_DISCOUNT_SCHEDULE,
+        instanceName: 'discountSchedule1',
+        fieldName: CPQ_CONSTRAINT_FIELD,
+        fieldValue: 'Account__c',
+      }),
+      ...generateObjectAndInstance({
+        type: CPQ_LOOKUP_QUERY,
+        objType: CPQ_LOOKUP_QUERY,
+        instanceName: 'lookupQuery1',
+        fieldName: CPQ_TESTED_OBJECT,
+        fieldValue: 'Quote',
+      }),
+      // name should point to ApexPage.instance.page1 (neighbor context)
+      ...generateObjectAndInstance({
+        type: 'AppMenuItem',
+        objType: 'AppMenuItem',
+        instanceName: 'appMenuItem',
+        fieldName: 'name',
+        fieldValue: 'page1',
+        contextFieldName: 'type',
+        contextFieldValue: 'ApexPage',
+      }),
+      // actionName should point to ApexClass.instance.class5 (neighbor context with reference)
+      new InstanceElement('apex', customObjectType, { [INSTANCE_FULL_NAME_FIELD]: 'apex' }), // fake instance so we have a reference
+      ...generateObjectAndInstance({
+        type: 'FlowActionCall',
+        objType: 'FlowActionCall',
+        instanceName: 'flowAction',
+        fieldName: 'actionName',
+        fieldValue: 'class5',
+        contextFieldName: 'actionType',
+        contextFieldValue: new ReferenceExpression(customObjectType.elemID.createNestedID('instance', 'apex')),
+      }),
+      // layoutItem436.field will remain the same (Account.fffff doesn't exist)
+      ...generateObjectAndInstance({
+        type: 'LayoutItem',
+        objType: 'LayoutItem',
+        instanceName: 'layoutItem436',
+        fieldName: 'field',
+        fieldValue: 'fffff',
+        parentType: 'Account',
+      }),
+      // shareTo should point to salesforce.Role.instance.CFO (neighbor context)
+      ...generateObjectAndInstance({
+        type: 'Role',
+        objType: 'Role',
+        instanceName: 'CFO',
+        fieldName: 'fullName',
+        fieldValue: 'CFO',
+      }),
+      ...generateObjectAndInstance({
+        type: 'FolderShare',
+        objType: 'FolderShare',
+        instanceName: 'folderShare',
+        fieldName: 'sharedTo',
+        fieldValue: 'CFO',
+        contextFieldName: 'sharedToType',
+        contextFieldValue: 'Role',
+      }),
+      // field should point to salesforce.Account.field.Id (neighbor context)
+      ...generateObjectAndInstance({
+        type: 'ReportTypeColumn',
+        objType: 'ReportTypeColumn',
+        instanceName: 'reportTypeColumn',
+        fieldName: 'field',
+        fieldValue: 'Id',
+        contextFieldName: 'table',
+        contextFieldValue: 'Account',
+      }),
+    ]
+  }
 
   describe('on fetch', () => {
     let elements: Element[]
@@ -306,6 +342,13 @@ describe('FieldReferences filter', () => {
       ) as InstanceElement
       expect(inst.value.field).toBeInstanceOf(ReferenceExpression)
       expect(inst.value.field?.elemID.getFullName()).toEqual('salesforce.Account.field.name')
+    })
+    it('should resolve fields with relative value based on instanceType condition', async () => {
+      const inst = await awu(elements).find(
+        async e => isInstanceElement(e) && await metadataType(e) === 'SharingRules'
+      ) as InstanceElement
+      expect(inst.value.someFilterField.field).toBeInstanceOf(ReferenceExpression)
+      expect(inst.value.someFilterField.field?.elemID.getFullName()).toEqual('salesforce.Account.field.name')
     })
 
     it('should resolve field with relative value array using parent target', async () => {


### PR DESCRIPTION
Support specifying instance type matchers that will restrict rules for resolving references to only look at source instances of specific types.
This is the salesforce part - see the linked PR for the adapter-components counterpart (we may eventually consolidate these behaviors, but currently the change is in a part that is not shared).

Also change one offending rule to demonstrate how this can be used - there are probably others that should be reviewed, and we may want to consider restricting more rules this way.


---

We had some overlaps between rules in salesforce that caused references to not be serialized correctly on deploy. This does not defend against that, but provides an easier way to restrict rules so that it is easier to avoid overlaps.

---
_Release Notes_: 
Salesforce adapter:
* Fix bug that caused deployments of some instances to fail when they contained references to fields

---
_User Notifications_: 
None