### PR TITLE
SALTO-2855 Allow restricting reference rules to specific types

### DIFF
--- a/packages/adapter-components/src/references/context.ts
+++ b/packages/adapter-components/src/references/context.ts
@@ -82,7 +82,7 @@ export const neighborContextGetter = ({
       context.elemID,
       context.value ?? elemByElemID.get(context.elemID.getFullName()),
     )
-    return getLookUpName({ ref: refWithValue, field: contextField, path })
+    return getLookUpName({ ref: refWithValue, field: contextField, path, element: instance })
   }
 
   try {

--- a/packages/adapter-components/src/references/field_references.ts
+++ b/packages/adapter-components/src/references/field_references.ts
@@ -171,7 +171,7 @@ export const replaceReferenceValues = async <
       return refExpr
     }
 
-    const reference = await awu(await resolverFinder(field))
+    const reference = await awu(await resolverFinder(field, instance))
       .filter(refResolver => refResolver.target !== undefined)
       .map(async refResolver => toValidatedReference(
         refResolver.serializationStrategy,
@@ -286,7 +286,7 @@ export const generateLookupFunc = <
       return undefined
     }
 
-    const strategies = (await resolverFinder(args.field))
+    const strategies = (await resolverFinder(args.field, args.element))
       .filter(def => def.target?.type === undefined || args.ref.elemID.typeName === def.target.type)
       .map(def => def.serializationStrategy)
 

--- a/packages/adapter-components/src/references/field_references.ts
+++ b/packages/adapter-components/src/references/field_references.ts
@@ -306,12 +306,12 @@ export const generateLookupFunc = <
     return strategies[0]
   }
 
-  return async ({ ref, path, field }) => {
+  return async ({ ref, path, field, element }) => {
     if (!isElement(ref.value)) {
       return ref.value
     }
 
-    const strategy = await determineLookupStrategy({ ref, path, field })
+    const strategy = await determineLookupStrategy({ ref, path, field, element })
     if (strategy !== undefined && !isRelativeSerializer(strategy)) {
       return strategy.serialize({ ref, field })
     }

--- a/packages/adapter-components/src/references/field_references.ts
+++ b/packages/adapter-components/src/references/field_references.ts
@@ -149,6 +149,7 @@ export const replaceReferenceValues = async <
               ? await serializer.serialize({
                 ref: new ReferenceExpression(element.elemID, elem),
                 field,
+                element: instance,
               })
               : resolvePath(element, referenceId),
             val,
@@ -313,7 +314,7 @@ export const generateLookupFunc = <
 
     const strategy = await determineLookupStrategy({ ref, path, field, element })
     if (strategy !== undefined && !isRelativeSerializer(strategy)) {
-      return strategy.serialize({ ref, field })
+      return strategy.serialize({ ref, field, element })
     }
 
     if (isInstanceElement(ref.value)) {

--- a/packages/adapter-components/src/references/reference_mapping.ts
+++ b/packages/adapter-components/src/references/reference_mapping.ts
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { Field, Value, Element, isInstanceElement, ElemID } from '@salto-io/adapter-api'
-import { types } from '@salto-io/lowerdash'
+import { Field, Value, Element, isInstanceElement, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { collections, types } from '@salto-io/lowerdash'
 import { GetLookupNameFunc } from '@salto-io/adapter-utils'
+
+const { awu } = collections.asynciterable
 
 export type ApiNameFunc = (elem: Element) => string
 export type LookupFunc = (val: Value, context?: string) => string
@@ -89,8 +91,10 @@ export type ExtendedReferenceTargetDefinition<
 > = ReferenceTargetDefinition<T> & { lookup: LookupFunc }
 
 type SourceDef = {
-  field: string | RegExp
+  field: string
   parentTypes?: string[]
+  // when available, only consider instances matching one or more of the specified types
+  instanceTypes?: (string | RegExp)[]
 }
 
 /**
@@ -119,6 +123,20 @@ export type FieldReferenceDefinition<
 // We can extract the api name from the elem id as long as we don't support renaming
 const elemLookupName: ApiNameFunc = elem => elem.elemID.name
 
+const matchName = (name: string, matcher: string | RegExp): boolean => (
+  _.isString(matcher)
+    ? matcher === name
+    : matcher.test(name)
+)
+
+const matchInstanceType = async (
+  inst: InstanceElement,
+  matchers: (string | RegExp)[],
+): Promise<boolean> => {
+  const typeName = elemLookupName(await inst.getType())
+  return matchers.some(matcher => matchName(typeName, matcher))
+}
+
 type FieldReferenceResolverDetails<T extends string> = {
   serializationStrategy: ReferenceSerializationStrategy
   target?: ExtendedReferenceTargetDefinition<T>
@@ -145,19 +163,22 @@ export class FieldReferenceResolver<T extends string> {
     return new FieldReferenceResolver<S>(def)
   }
 
-  match(field: Field): boolean {
+  async match(field: Field, element?: Element): Promise<boolean> {
     return (
-      field.name === this.src.field
+      matchName(field.name, this.src.field)
       && (
         this.src.parentTypes === undefined
         || this.src.parentTypes.includes(elemLookupName(field.parent))
       )
+      && (this.src.instanceTypes === undefined
+        || (isInstanceElement(element) && matchInstanceType(element, this.src.instanceTypes)))
     )
   }
 }
 
 export type ReferenceResolverFinder<T extends string> = (
-  field: Field
+  field: Field,
+  element?: Element,
 ) => Promise<FieldReferenceResolverDetails<T>[]>
 
 /**
@@ -182,7 +203,9 @@ export const generateReferenceResolverFinder = <
     .groupBy(def => def.src.field)
     .value()
 
-  return (async field => (
-    (matchersByFieldName[field.name] ?? []).filter(resolver => resolver.match(field))
+  return (async (field, element) => (
+    awu(matchersByFieldName[field.name] ?? [])
+      .filter(resolver => resolver.match(field, element))
+      .toArray()
   ))
 }


### PR DESCRIPTION
Counterpart of https://github.com/salto-io/salto/pull/3438 for the shared infra - allowing to restrict reference rules only to instances of specific types, to help avoid overlaps between rules in a structured way.

---

Will follow up with usages in the relevant adapters.

---
_Release Notes_: 
None

---
_User Notifications_: 
None