### PR TITLE
Require to pass in element to getLookUpName

### DIFF
--- a/packages/adapter-components/src/references/reference_mapping.ts
+++ b/packages/adapter-components/src/references/reference_mapping.ts
@@ -163,7 +163,7 @@ export class FieldReferenceResolver<T extends string> {
     return new FieldReferenceResolver<S>(def)
   }
 
-  async match(field: Field, element?: Element): Promise<boolean> {
+  async match(field: Field, element: Element): Promise<boolean> {
     return (
       matchName(field.name, this.src.field)
       && (
@@ -178,7 +178,7 @@ export class FieldReferenceResolver<T extends string> {
 
 export type ReferenceResolverFinder<T extends string> = (
   field: Field,
-  element?: Element,
+  element: Element,
 ) => Promise<FieldReferenceResolverDetails<T>[]>
 
 /**

--- a/packages/adapter-components/test/references/field_references.test.ts
+++ b/packages/adapter-components/test/references/field_references.test.ts
@@ -472,6 +472,7 @@ describe('Field references', () => {
         ),
         field: new Field(new ObjectType({ elemID: new ElemID('adapter', 'api_access_profile') }), 'api_client_id', BuiltinTypes.NUMBER),
         path: new ElemID('adapter', 'somePath'),
+        element: new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'some_type') }), {}),
       })
 
       expect(res).toEqual(2)
@@ -485,6 +486,7 @@ describe('Field references', () => {
         ),
         field: new Field(new ObjectType({ elemID: new ElemID('adapter', 'api_access_profile') }), 'api_client_id', BuiltinTypes.NUMBER),
         path: new ElemID('adapter', 'somePath'),
+        element: new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'some_type') }), {}),
       })
 
       expect(res).toEqual(3)
@@ -498,6 +500,7 @@ describe('Field references', () => {
         ),
         field: new Field(new ObjectType({ elemID: new ElemID('adapter', 'api_access_profile') }), 'api_collection_ids', BuiltinTypes.NUMBER),
         path: new ElemID('adapter', 'somePath'),
+        element: new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'some_type') }), {}),
       })
 
       expect(res).toEqual('name')
@@ -511,6 +514,7 @@ describe('Field references', () => {
         ),
         field: new Field(new ObjectType({ elemID: new ElemID('adapter', 'api_access_profile') }), 'api_collection_ids', BuiltinTypes.NUMBER),
         path: new ElemID('adapter', 'somePath'),
+        element: new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'some_type') }), {}),
       })
 
       expect(res).toEqual(2)
@@ -524,6 +528,7 @@ describe('Field references', () => {
         ),
         field: new Field(new ObjectType({ elemID: new ElemID('adapter', 'someType') }), 'api_collection_ids', BuiltinTypes.NUMBER),
         path: new ElemID('adapter', 'somePath'),
+        element: new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'some_type') }), {}),
       })
 
       expect(res).toEqual({ id: 2, name: 'name' })
@@ -536,6 +541,7 @@ describe('Field references', () => {
           { id: 2, name: 'name' },
         ),
         path: new ElemID('adapter', 'somePath'),
+        element: new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'some_type') }), {}),
       })
 
       expect(res).toEqual({ id: 2, name: 'name' })
@@ -579,6 +585,7 @@ describe('Field references', () => {
         ),
         field: new Field(new ObjectType({ elemID: new ElemID('adapter', 'obj2') }), 'refValue', BuiltinTypes.NUMBER),
         path: new ElemID('adapter', 'somePath'),
+        element: new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'some_type') }), {}),
       })
 
       expect(res).toEqual(2)

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -439,7 +439,7 @@ export type GetLookupNameFuncArgs = {
   ref: ReferenceExpression
   field?: Field
   path?: ElemID
-  element?: Element
+  element: Element
 }
 export type GetLookupNameFunc = (args: GetLookupNameFuncArgs) => Promise<Value>
 
@@ -543,7 +543,7 @@ export const restoreValues: RestoreValuesFunc = async (
 
     const ref = allReferencesPaths.get(path.getFullName())
     if (ref !== undefined) {
-      const refValue = await getLookUpName({ ref, field, path })
+      const refValue = await getLookUpName({ ref, field, path, element: targetElement })
       if (isEqualResolvedValues(refValue, value)) {
         return ref
       }

--- a/packages/jira-adapter/test/filters/fields/field_type_references.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_type_references.test.ts
@@ -154,6 +154,7 @@ describe('fields_references', () => {
         new ElemID(JIRA, FIELD_CONTEXT_TYPE_NAME, 'instance', 'name', 'options', 'a1'),
         { value: 'a1', id: '1' },
       ),
+      element: new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'some_type') }), {}),
     })).toBe('1')
 
     expect(await getFieldsLookUpName({
@@ -162,6 +163,7 @@ describe('fields_references', () => {
         new ElemID(JIRA, FIELD_CONTEXT_TYPE_NAME, 'instance', 'name', 'options', 'a1'),
         { value: 'a1', id: '1' },
       ),
+      element: new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'some_type') }), {}),
     })).toBe('1')
 
     expect(await getFieldsLookUpName({
@@ -170,6 +172,7 @@ describe('fields_references', () => {
         new ElemID(JIRA, FIELD_CONTEXT_TYPE_NAME, 'instance', 'name', 'options', 'c1'),
         { value: 'c1', id: '3' },
       ),
+      element: new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'some_type') }), {}),
     })).toBe('3')
 
     expect(await getFieldsLookUpName({
@@ -178,6 +181,7 @@ describe('fields_references', () => {
         new ElemID(JIRA, FIELD_CONTEXT_TYPE_NAME, 'instance', 'name', 'options', 'c1'),
         { value: 'c1', id: '3' },
       ),
+      element: new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'some_type') }), {}),
     })).toBeInstanceOf(ReferenceExpression)
   })
 })

--- a/packages/netsuite-adapter/test/transformer.test.ts
+++ b/packages/netsuite-adapter/test/transformer.test.ts
@@ -747,7 +747,10 @@ describe('Transformer', () => {
         fileInstance.value[PATH],
         fileInstance
       )
-      expect(getLookUpName({ ref })).toEqual('[/Templates/file.name]')
+      expect(getLookUpName({
+        ref,
+        element: new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'some_type') }), {}),
+      })).toEqual('[/Templates/file.name]')
     })
 
     it('should resolve to netsuite scriptid reference representation', async () => {
@@ -756,7 +759,10 @@ describe('Transformer', () => {
         workflowInstance.value[PATH],
         workflowInstance
       )
-      expect(getLookUpName({ ref })).toEqual('[scriptid=top_level]')
+      expect(getLookUpName({
+        ref,
+        element: new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'some_type') }), {}),
+      })).toEqual('[scriptid=top_level]')
     })
 
     it('should resolve to netsuite scriptid reference representation with nesting levels', async () => {
@@ -765,7 +771,10 @@ describe('Transformer', () => {
         'two_nesting',
         workflowInstance
       )
-      expect(getLookUpName({ ref })).toEqual('[scriptid=top_level.one_nesting.two_nesting]')
+      expect(getLookUpName({
+        ref,
+        element: new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'some_type') }), {}),
+      })).toEqual('[scriptid=top_level.one_nesting.two_nesting]')
     })
 
     it('should resolve custom record type to netsuite scriptid reference', async () => {
@@ -774,7 +783,10 @@ describe('Transformer', () => {
         'record1',
         customRecordType
       )
-      expect(getLookUpName({ ref })).toEqual('[scriptid=customrecord1.record1]')
+      expect(getLookUpName({
+        ref,
+        element: new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'some_type') }), {}),
+      })).toEqual('[scriptid=customrecord1.record1]')
     })
 
     it('should resolve custom record type field to netsuite scriptid reference', async () => {
@@ -783,7 +795,10 @@ describe('Transformer', () => {
         'record1',
         customRecordType
       )
-      expect(getLookUpName({ ref })).toEqual('[scriptid=customrecord1.custom_field]')
+      expect(getLookUpName({
+        ref,
+        element: new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'some_type') }), {}),
+      })).toEqual('[scriptid=customrecord1.custom_field]')
     })
 
     describe('when the resolved value should be returned', () => {
@@ -793,7 +808,10 @@ describe('Transformer', () => {
           'resolved_value',
           await workflowInstance.getType(),
         )
-        expect(getLookUpName({ ref })).toEqual(ref.value)
+        expect(getLookUpName({
+          ref,
+          element: new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'some_type') }), {}),
+        })).toEqual(ref.value)
       })
 
       it('should return value when reference is on FileCabinetType but not on PATH field', async () => {
@@ -802,7 +820,10 @@ describe('Transformer', () => {
           fileInstance.value[description],
           fileInstance
         )
-        expect(getLookUpName({ ref })).toEqual(ref.value)
+        expect(getLookUpName({
+          ref,
+          element: new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'some_type') }), {}),
+        })).toEqual(ref.value)
       })
 
       it('should return value when reference is on CustomType but not on SCRIPT_ID field', async () => {
@@ -811,7 +832,10 @@ describe('Transformer', () => {
           workflowInstance.value.workflowstates,
           workflowInstance
         )
-        expect(getLookUpName({ ref })).toEqual(ref.value)
+        expect(getLookUpName({
+          ref,
+          element: new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'some_type') }), {}),
+        })).toEqual(ref.value)
       })
     })
   })

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -611,7 +611,7 @@ export class FieldReferenceResolver {
     return new FieldReferenceResolver(def)
   }
 
-  async match(field: Field, element?: Element): Promise<boolean> {
+  async match(field: Field, element: Element): Promise<boolean> {
     return (
       matchName(field.name, this.src.field)
       && await matchApiName(field.parent, this.src.parentTypes)
@@ -623,7 +623,7 @@ export class FieldReferenceResolver {
 
 export type ReferenceResolverFinder = (
   field: Field,
-  element?: Element,
+  element: Element,
 ) => Promise<FieldReferenceResolver[]>
 
 /**
@@ -689,11 +689,11 @@ const getLookUpNameImpl = (defs = fieldNameToTypeMappingDefs): GetLookupNameFunc
     if (!isInstanceAnnotation) {
       const strategy = await determineLookupStrategy({ ref, path, field, element })
       if (strategy !== undefined) {
-        return strategy.serialize({ ref, field })
+        return strategy.serialize({ ref, field, element })
       }
       if (isElement(ref.value)) {
         const defaultStrategy = ReferenceSerializationStrategyLookup.absoluteApiName
-        return defaultStrategy.serialize({ ref })
+        return defaultStrategy.serialize({ ref, element })
       }
     }
     return ref.value

--- a/packages/salesforce-adapter/test/transformers/transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/transformer.test.ts
@@ -1867,7 +1867,8 @@ describe('transformer', () => {
             mockBusinessHoursInstance
           ),
           field: testField,
-          path: new ElemID(SALESFORCE, 'EntitlementProcess'),
+          path: new ElemID(SALESFORCE, 'EntitlementProcess', 'field', 'something'),
+          element: new ObjectType({ elemID: new ElemID(SALESFORCE, 'EntitlementProcess') }),
         })).toEqual('Default')
       })
     })
@@ -1906,6 +1907,7 @@ describe('transformer', () => {
           path: mockLayoutInstance.elemID.createNestedID(
             'layoutSections', '0', 'layoutColumns', '0', 'layoutItems', '0', 'field'
           ),
+          element: mockLayoutInstance,
         })).toEqual('Test__c')
       })
       it('should resolve to current value if referenced value is not an element', async () => {
@@ -1917,10 +1919,12 @@ describe('transformer', () => {
           path: mockLayoutInstance.elemID.createNestedID(
             'layoutSections', '0', 'layoutColumns', '0', 'layoutItems', '0', 'field'
           ),
+          element: mockLayoutInstance,
         })).toEqual(refValue)
         expect(await getLookUpName({
           ref: new ReferenceExpression(testField.elemID, refValue),
           field: mockLayoutItem.fields.field,
+          element: mockLayoutInstance,
         })).toEqual(refValue)
       })
     })
@@ -1947,6 +1951,7 @@ describe('transformer', () => {
           ref: new ReferenceExpression(testField.elemID, testField, refObject),
           field: workflowFieldUpdate.fields.field,
           path: mockWorkflowFieldUpdateInstance.elemID.createNestedID('field'),
+          element: mockWorkflowFieldUpdateInstance,
         })).toEqual('Test__c')
       })
     })
@@ -2048,6 +2053,7 @@ describe('transformer', () => {
           ref: mockProductRuleInst.value[CPQ_LOOKUP_PRODUCT_FIELD],
           field: mockProductRuleType.fields[CPQ_LOOKUP_PRODUCT_FIELD],
           path: mockProductRuleInst.elemID.createNestedID(CPQ_LOOKUP_PRODUCT_FIELD),
+          element: mockProductRuleInst,
         })).toEqual('Test__c')
       })
     })
@@ -2090,6 +2096,7 @@ describe('transformer', () => {
           ref: new ReferenceExpression(mockAlertInstance.elemID, mockAlertInstance),
           field: workflowActionReference.fields.name,
           path: mockWorkflowRuleInstance.elemID.createNestedID('actions', '0', 'name'),
+          element: mockWorkflowRuleInstance,
         })).toEqual('alert1')
       })
     })
@@ -2105,6 +2112,7 @@ describe('transformer', () => {
         expect(await getLookUpName({
           ref: new ReferenceExpression(testField.elemID, testField, refObject),
           path: srcInst.elemID.createNestedID('test'),
+          element: srcInst,
         })).toEqual('Lead.Test__c')
       })
     })
@@ -2121,6 +2129,7 @@ describe('transformer', () => {
           ref: new ReferenceExpression(testField.elemID, testField, refObject),
           field: srcObject.fields.test,
           path: srcInst.elemID.createNestedID('test'),
+          element: srcInst,
         })).toEqual('Lead.Test__c')
       })
     })


### PR DESCRIPTION
From now on `element` will be a required argument for `getLookUpName`, this adds it and fixes all the current usages.
Adding in a separate PR as this adds some noise

---

Follow up for https://github.com/salto-io/salto/pull/3439 and https://github.com/salto-io/salto/pull/3438.

---
_Release Notes_: 
None

---
_User Notifications_: 
None