### PR TITLE
SALTO-2868: fixed an error message when deploy a non backward compatible workflow

### DIFF
--- a/packages/jira-adapter/src/filters/workflow/workflow_modification_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_modification_filter.ts
@@ -141,7 +141,7 @@ const deployWorkflowModification = async ({
     })
   } catch (err) {
     await cleanTempInstance()
-    if (err.response?.data?.errorMessages?.some((message: string) => message.includes('is missing the mappings required for statuses with IDs'))) {
+    if (err.response?.data?.errorMessages?.some((message: string) => message.includes('is missing the mappings required for statuses with'))) {
       throw new Error(`Modification to an active workflow ${getChangeData(change).elemID.getFullName()} is not backward compatible`)
     }
     throw err

--- a/packages/jira-adapter/test/filters/workflow/workflow_modification_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_modification_filter.test.ts
@@ -222,7 +222,7 @@ describe('workflowModificationFilter', () => {
       deployWorkflowSchemeMock.mockRejectedValueOnce({
         response: {
           data: {
-            errorMessages: ['is missing the mappings required for statuses with IDs'],
+            errorMessages: ['is missing the mappings required for statuses with'],
           },
         },
       })


### PR DESCRIPTION

We recently changed the error message that is thrown when migration params are needed to deploy a workflow scheme. This caused a regression in the error message we show when we try to deploy a non-backward compatible workflow

---
_Release Notes_: 
_Jira Adapter_:
- Fixed the error message when deploying a non backward compatible workflow

---
_User Notifications_: 
None