### PR TITLE
SALTO-2871 Split Zendesk macro_attachment and brand_logo static file path

### DIFF
--- a/packages/zendesk-adapter/src/filters/brand_logo.ts
+++ b/packages/zendesk-adapter/src/filters/brand_logo.ts
@@ -106,7 +106,7 @@ const getBrandLogo = async ({ client, brand }: {
     brand.value.name, logoValues.file_name
   )
   const pathName = pathNaclCase(naclCase(name))
-  const resourcePathName = normalizeFilePathPart(name)
+  const resourcePathName = `${normalizeFilePathPart(brand.value.name)}/${normalizeFilePathPart(logoValues.file_name)}`
 
   const { id, file_name: filename } = brand.value.logo
   const content = await getLogoContent(client, id, filename)

--- a/packages/zendesk-adapter/src/filters/macro_attachments.ts
+++ b/packages/zendesk-adapter/src/filters/macro_attachments.ts
@@ -121,7 +121,7 @@ const createAttachmentInstance = ({
   )
   const naclName = naclCase(name)
   const pathName = pathNaclCase(naclName)
-  const resourcePathName = normalizeFilePathPart(name)
+  const resourcePathName = `${normalizeFilePathPart(macro.value.title)}/${normalizeFilePathPart(attachment.filename)}`
   return new InstanceElement(
     naclName,
     attachmentType,

--- a/packages/zendesk-adapter/test/filters/brand_logo.test.ts
+++ b/packages/zendesk-adapter/test/filters/brand_logo.test.ts
@@ -114,7 +114,7 @@ describe('brand logo filter', () => {
         filename,
         contentType: 'image/png',
         content: new StaticFile({
-          filepath: 'zendesk/brand_logo/test__brand1_logo.png', encoding: 'binary', content,
+          filepath: 'zendesk/brand_logo/test/brand1_logo.png', encoding: 'binary', content,
         }),
       })
     })
@@ -166,7 +166,7 @@ describe('brand logo filter', () => {
           filename: 'test.png',
           contentType: 'image/png',
           content: new StaticFile({
-            filepath: 'zendesk/brand_logo/test__test.png', encoding: 'binary', content,
+            filepath: 'zendesk/brand_logo/test/test.png', encoding: 'binary', content,
           }),
         },
       )
@@ -223,7 +223,7 @@ describe('brand logo filter', () => {
       const beforeLogo = logoInstance.clone()
       const afterLogo = logoInstance.clone()
       afterLogo.value.content = new StaticFile({
-        filepath: 'zendesk/brand_logo/test__test2.png',
+        filepath: 'zendesk/brand_logo/test/test2.png',
         encoding: 'binary',
         content: Buffer.from('changes!'),
       })

--- a/packages/zendesk-adapter/test/filters/macro_attachments.test.ts
+++ b/packages/zendesk-adapter/test/filters/macro_attachments.test.ts
@@ -136,7 +136,7 @@ describe('macro attachment filter', () => {
         filename,
         contentType: 'text/plain',
         content: new StaticFile({
-          filepath: 'zendesk/macro_attachment/test__test.txt', encoding: 'binary', content,
+          filepath: 'zendesk/macro_attachment/test/test.txt', encoding: 'binary', content,
         }),
       })
     })
@@ -258,7 +258,7 @@ describe('macro attachment filter', () => {
           filename,
           contentType: 'text/plain',
           content: new StaticFile({
-            filepath: 'zendesk/macro_attachment/test__test.txt', encoding: 'binary', content,
+            filepath: 'zendesk/macro_attachment/test/test.txt', encoding: 'binary', content,
           }),
         },
       )


### PR DESCRIPTION
This will allow to run the normalize resource path function (created for SALTO-2852) on each split part and have longer paths.

---

_Additional context for reviewer_

---
_Release Notes_: 

-

---
_User Notifications_: 

-