### PR TITLE
SALTO-2776 - Fix Zendesk's dynamic content reference regex in macros

### DIFF
--- a/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
@@ -32,7 +32,7 @@ const { awu } = collections.asynciterable
 const log = logger(module)
 const BRACKETS = [['{{', '}}'], ['{%', '%}']]
 const REFERENCE_MARKER_REGEX = /\$\{(.+?)}/
-const DYNAMIC_CONTENT_REGEX = /(dc\.[\w]+)/g
+const DYNAMIC_CONTENT_REGEX = /(dc\.[\w-]+)/g
 
 export const ZENDESK_REFERENCE_TYPE_TO_SALTO_TYPE: Record<string, string> = {
   'ticket.ticket_field': 'ticket_field',

--- a/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
+++ b/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
@@ -87,7 +87,11 @@ describe('handle templates filter', () => {
     },
   })
 
-  const dynamicContentRecord = new InstanceElement('dynamic-content-test', dynamicContentType, {
+  const dynamicContentRecord = new InstanceElement('dynamic_content_test', dynamicContentType, {
+    placeholder: '{{dc.dynamic_content_test}}',
+  })
+
+  const hyphenDynamicContentRecord = new InstanceElement('dynamic-content-test', dynamicContentType, {
     placeholder: '{{dc.dynamic-content-test}}',
   })
 
@@ -121,8 +125,8 @@ describe('handle templates filter', () => {
   const macro1 = new InstanceElement('macro1', testType, { id: 1001, actions: [{ value: 'non template', field: 'comment_value_html' }] })
   const macro2 = new InstanceElement('macro2', testType, { id: 1002, actions: [{ value: '{{ticket.ticket_field_1452}}', field: 'comment_value' }] })
   const macro3 = new InstanceElement('macro3', testType, { id: 1003, actions: [{ value: 'multiple refs {{ticket.ticket_field_1452}} and {{ticket.ticket_field_option_title_1453}}', field: 'comment_value_html' }] })
-  const macroComplicated = new InstanceElement('macroComplicated', testType, { id: 1003, actions: [{ value: '{{some other irrelevancies-ticket.ticket_field_1452 | something irrelevant | dynamic content now: dc.dynamic-content-test | and done}}', field: 'comment_value_html' }] })
-  const macroDifferentBracket = new InstanceElement('macroDifferentBracket', testType, { id: 1010, actions: [{ value: '{%some other irrelevancies-ticket.ticket_field_1452 | something irrelevant | dynamic content now: dc.dynamic-content-test | and done%}', field: 'comment_value_html' }] })
+  const macroComplicated = new InstanceElement('macroComplicated', testType, { id: 1003, actions: [{ value: '{{some other irrelevancies-ticket.ticket_field_1452 | something irrelevant | dynamic content now: dc.dynamic_content_test | and done}}', field: 'comment_value_html' }] })
+  const macroDifferentBracket = new InstanceElement('macroDifferentBracket', testType, { id: 1010, actions: [{ value: '{%some other irrelevancies-ticket.ticket_field_1452 | something irrelevant | dynamic content now: dc.dynamic_content_test | and done%}', field: 'comment_value_html' }] })
   const macroWithSideConversationTicketTemplate = new InstanceElement(
     'macroSideConvTicket',
     testType,
@@ -138,7 +142,8 @@ describe('handle templates filter', () => {
     },
   )
 
-  const macroWithDC = new InstanceElement('macroDynamicContent', testType, { id: 1033, actions: [{ value: 'dynamic content ref {{dc.dynamic-content-test}} and {{ticket.ticket_field_option_title_1453}}', field: 'comment_value_html' }] })
+  const macroWithDC = new InstanceElement('macroDynamicContent', testType, { id: 1033, actions: [{ value: 'dynamic content ref {{dc.dynamic_content_test}} and {{ticket.ticket_field_option_title_1453}}', field: 'comment_value_html' }] })
+  const macroWithHyphenDC = new InstanceElement('macroHyphenDynamicContent', testType, { id: 1034, actions: [{ value: 'dynamic content ref {{dc.dynamic-content-test}} and {{ticket.ticket_field_option_title_1453}}', field: 'comment_value_html' }] })
 
   const macroAlmostTemplate = new InstanceElement('macroAlmost', testType, { id: 1001, actions: [{ value: 'almost template {{ticket.not_an_actual_field_1452}} and {{ticket.ticket_field_1454}}', field: 'comment_value_html' }] })
   const macroAlmostTemplate2 = new InstanceElement('macroAlmost2', testType, { id: 1001, actions: [{ value: '{{ticket.ticket_field_1452}}', field: 'not_template_field' }] })
@@ -158,8 +163,9 @@ describe('handle templates filter', () => {
     placeholder2Type, placeholder1, placeholder2, macro1, macro2, macro3, macroAlmostTemplate,
     macroAlmostTemplate2, target, trigger, webhook, targetType, triggerType, webhookType,
     automation, automationType, dynamicContent, dynamicContentItemType, appInstallation,
-    appInstallationType, macroWithDC, dynamicContentRecord, macroComplicated,
-    macroDifferentBracket, macroWithSideConversationTicketTemplate, placeholder3])
+    appInstallationType, macroWithDC, macroWithHyphenDC, dynamicContentRecord,
+    hyphenDynamicContentRecord, macroComplicated, macroDifferentBracket,
+    macroWithSideConversationTicketTemplate, placeholder3])
     .map(element => element.clone())
 
   describe('on fetch', () => {
@@ -230,6 +236,16 @@ describe('handle templates filter', () => {
         new TemplateExpression({ parts: [
           'dynamic content ref {{',
           new ReferenceExpression(dynamicContentRecord.elemID, dynamicContentRecord),
+          '}} and {{',
+          new ReferenceExpression(placeholder2.elemID, placeholder2),
+          '}}'] })
+      )
+
+      const fetchedHyphenDCMacro = elements.filter(isInstanceElement).find(i => i.elemID.name === 'macroHyphenDynamicContent')
+      expect(fetchedHyphenDCMacro?.value.actions[0].value).toEqual(
+        new TemplateExpression({ parts: [
+          'dynamic content ref {{',
+          new ReferenceExpression(hyphenDynamicContentRecord.elemID, hyphenDynamicContentRecord),
           '}} and {{',
           new ReferenceExpression(placeholder2.elemID, placeholder2),
           '}}'] })

--- a/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
+++ b/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
@@ -87,8 +87,8 @@ describe('handle templates filter', () => {
     },
   })
 
-  const dynamicContentRecord = new InstanceElement('dynamic_content_test', dynamicContentType, {
-    placeholder: '{{dc.dynamic_content_test}}',
+  const dynamicContentRecord = new InstanceElement('dynamic-content-test', dynamicContentType, {
+    placeholder: '{{dc.dynamic-content-test}}',
   })
 
   const webhookType = new ObjectType({
@@ -121,8 +121,8 @@ describe('handle templates filter', () => {
   const macro1 = new InstanceElement('macro1', testType, { id: 1001, actions: [{ value: 'non template', field: 'comment_value_html' }] })
   const macro2 = new InstanceElement('macro2', testType, { id: 1002, actions: [{ value: '{{ticket.ticket_field_1452}}', field: 'comment_value' }] })
   const macro3 = new InstanceElement('macro3', testType, { id: 1003, actions: [{ value: 'multiple refs {{ticket.ticket_field_1452}} and {{ticket.ticket_field_option_title_1453}}', field: 'comment_value_html' }] })
-  const macroComplicated = new InstanceElement('macroComplicated', testType, { id: 1003, actions: [{ value: '{{some other irrelevancies-ticket.ticket_field_1452 | something irrelevant | dynamic content now: dc.dynamic_content_test | and done}}', field: 'comment_value_html' }] })
-  const macroDifferentBracket = new InstanceElement('macroDifferentBracket', testType, { id: 1010, actions: [{ value: '{%some other irrelevancies-ticket.ticket_field_1452 | something irrelevant | dynamic content now: dc.dynamic_content_test | and done%}', field: 'comment_value_html' }] })
+  const macroComplicated = new InstanceElement('macroComplicated', testType, { id: 1003, actions: [{ value: '{{some other irrelevancies-ticket.ticket_field_1452 | something irrelevant | dynamic content now: dc.dynamic-content-test | and done}}', field: 'comment_value_html' }] })
+  const macroDifferentBracket = new InstanceElement('macroDifferentBracket', testType, { id: 1010, actions: [{ value: '{%some other irrelevancies-ticket.ticket_field_1452 | something irrelevant | dynamic content now: dc.dynamic-content-test | and done%}', field: 'comment_value_html' }] })
   const macroWithSideConversationTicketTemplate = new InstanceElement(
     'macroSideConvTicket',
     testType,
@@ -138,7 +138,7 @@ describe('handle templates filter', () => {
     },
   )
 
-  const macroWithDC = new InstanceElement('macroDynamicContent', testType, { id: 1033, actions: [{ value: 'dynamic content ref {{dc.dynamic_content_test}} and {{ticket.ticket_field_option_title_1453}}', field: 'comment_value_html' }] })
+  const macroWithDC = new InstanceElement('macroDynamicContent', testType, { id: 1033, actions: [{ value: 'dynamic content ref {{dc.dynamic-content-test}} and {{ticket.ticket_field_option_title_1453}}', field: 'comment_value_html' }] })
 
   const macroAlmostTemplate = new InstanceElement('macroAlmost', testType, { id: 1001, actions: [{ value: 'almost template {{ticket.not_an_actual_field_1452}} and {{ticket.ticket_field_1454}}', field: 'comment_value_html' }] })
   const macroAlmostTemplate2 = new InstanceElement('macroAlmost2', testType, { id: 1001, actions: [{ value: '{{ticket.ticket_field_1452}}', field: 'not_template_field' }] })


### PR DESCRIPTION
Zendesk adapter:
Changed Zendesk's regex for dynamic content to catch '-' char

---

---
_Release Notes_: 
macros that use dynamic content reference with the character '-' will work

---
_User Notifications_: 
