### PR TITLE
SALTO-2860: Deploy of filters does not work when the element includes  a share permission

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/filter.ts
+++ b/packages/jira-adapter/e2e_test/instances/filter.ts
@@ -1,0 +1,43 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, TemplateExpression, Values, Element } from '@salto-io/adapter-api'
+import { createReference } from '../utils'
+import { GROUP_TYPE_NAME, JIRA, PROJECT_TYPE } from '../../src/constants'
+import { FIELD_TYPE_NAME } from '../../src/filters/fields/constants'
+
+
+export const createFilterValues = (name: string, allElements: Element[]): Values => ({
+  name,
+  jql: new TemplateExpression({ parts: [
+    createReference(new ElemID(JIRA, FIELD_TYPE_NAME, 'instance', 'Project__project'), allElements),
+    ' = ',
+    createReference(new ElemID(JIRA, PROJECT_TYPE, 'instance', 'Test_Project@s'), allElements, ['key']),
+    ' ORDER BY ',
+    createReference(new ElemID(JIRA, FIELD_TYPE_NAME, 'instance', 'Rank__gh_lexo_rank__c@uubbuu'), allElements, ['name']),
+    ' ASC',
+  ] }),
+  sharePermissions: [
+    { type: 'project',
+      project: {
+        id: createReference(new ElemID(JIRA, PROJECT_TYPE, 'instance', 'Test_Project@s'), allElements),
+      } },
+    // project should be before group- that is the fetch order
+    { type: 'group',
+      group: {
+        name: createReference(new ElemID(JIRA, GROUP_TYPE_NAME, 'instance', 'site_admins@b'), allElements, ['name']),
+      } },
+  ],
+})

--- a/packages/jira-adapter/e2e_test/instances/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/index.ts
@@ -13,10 +13,10 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { InstanceElement, Element, ElemID, CORE_ANNOTATIONS, ReferenceExpression, TemplateExpression } from '@salto-io/adapter-api'
+import { InstanceElement, Element, ElemID, CORE_ANNOTATIONS, ReferenceExpression } from '@salto-io/adapter-api'
 import { naclCase } from '@salto-io/adapter-utils'
 import { CUSTOM_FIELDS_SUFFIX } from '../../src/filters/fields/field_name_filter'
-import { AUTOMATION_TYPE, ISSUE_TYPE_NAME, ISSUE_TYPE_SCHEMA_NAME, JIRA, NOTIFICATION_SCHEME_TYPE_NAME, SECURITY_LEVEL_TYPE, SECURITY_SCHEME_TYPE, WEBHOOK_TYPE, WORKFLOW_TYPE_NAME, STATUS_TYPE_NAME, PROJECT_TYPE } from '../../src/constants'
+import { AUTOMATION_TYPE, ISSUE_TYPE_NAME, ISSUE_TYPE_SCHEMA_NAME, JIRA, NOTIFICATION_SCHEME_TYPE_NAME, SECURITY_LEVEL_TYPE, SECURITY_SCHEME_TYPE, WEBHOOK_TYPE, WORKFLOW_TYPE_NAME, STATUS_TYPE_NAME } from '../../src/constants'
 import { createReference, findType } from '../utils'
 import { createKanbanBoardValues, createScrumBoardValues } from './board'
 import { createContextValues, createFieldValues } from './field'
@@ -33,7 +33,7 @@ import { createNotificationSchemeValues } from './notificationScheme'
 import { createAutomationValues } from './automation'
 import { createWebhookValues } from './webhook'
 import { createStatusValues } from './status'
-import { FIELD_TYPE_NAME } from '../../src/filters/fields/constants'
+import { createFilterValues } from './filter'
 
 export const createInstances = (fetchedElements: Element[]): InstanceElement[][] => {
   const randomString = `createdByOssE2e${String(Date.now()).substring(6)}`
@@ -142,17 +142,7 @@ export const createInstances = (fetchedElements: Element[]): InstanceElement[][]
   const filter = new InstanceElement(
     randomString,
     findType('Filter', fetchedElements),
-    {
-      name: randomString,
-      jql: new TemplateExpression({ parts: [
-        createReference(new ElemID(JIRA, FIELD_TYPE_NAME, 'instance', 'Project__project'), fetchedElements),
-        ' = ',
-        createReference(new ElemID(JIRA, PROJECT_TYPE, 'instance', 'Test_Project@s'), fetchedElements, ['key']),
-        ' ORDER BY ',
-        createReference(new ElemID(JIRA, FIELD_TYPE_NAME, 'instance', 'Rank__gh_lexo_rank__c@uubbuu'), fetchedElements, ['name']),
-        ' ASC',
-      ] }),
-    },
+    createFilterValues(randomString, fetchedElements),
   )
 
   const issueLinkType = new InstanceElement(

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -491,6 +491,13 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       },
     },
   },
+  GroupName: {
+    transformation: {
+      fieldsToOmit: [
+        { fieldName: 'groupId' },
+      ],
+    },
+  },
   IssueTypeSchemes: {
     request: {
       url: '/rest/api/3/issuetypescheme',

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -378,6 +378,11 @@ ReferenceContextStrategyName
     target: { type: 'Group' },
   },
   {
+    src: { field: 'name', parentTypes: ['GroupName'] },
+    serializationStrategy: 'nameWithPath',
+    target: { type: 'Group' },
+  },
+  {
     src: { field: 'boardId', parentTypes: [AUTOMATION_COMPONENT_VALUE_TYPE] },
     serializationStrategy: 'id',
     target: { type: 'Board' },


### PR DESCRIPTION
_When a Jira filter contained a share permission with a group it could not be deployed as it contains both name and id which might conflict_


---

We now remove the group id, and replace the name with a group reference

---
_Release Notes_: 
Jira adapter: 
-Jira's filters with share (view) permissions for groups can now be deployed. Groups' names are now references.

---
_User Notifications_: 
_Group id will be removed in filters that have a share permission with a group_
