### PR TITLE
SALTO-2876: removed occurrences from generated dependencies

### DIFF
--- a/packages/jira-adapter/src/filters/field_configuration/field_configuration_dependencies.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/field_configuration_dependencies.ts
@@ -72,7 +72,6 @@ const filter: FilterCreator = () => ({
           instance,
           fieldConfigItems.map(item => ({
             reference: new ReferenceExpression(item.elemID, item),
-            location: new ReferenceExpression(instance.elemID.createNestedID('fieldConfigurationScheme'), instance.value.fieldConfigurationScheme),
           }))
         )
       })

--- a/packages/jira-adapter/test/filters/field_configuration/field_configuration_dependencies.test.ts
+++ b/packages/jira-adapter/test/filters/field_configuration/field_configuration_dependencies.test.ts
@@ -179,9 +179,6 @@ describe('fieldConfigurationItemsFilter', () => {
       ])
       expect(projectInstance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toHaveLength(1)
 
-      expect(projectInstance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES][0]
-        .occurrences[0].location.elemID).toEqual(projectInstance.elemID.createNestedID('fieldConfigurationScheme'))
-
       expect(projectInstance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES][0].reference
         .elemID).toEqual(fieldConfigurationItems[0].elemID)
     })


### PR DESCRIPTION
Removed occurrences from generated dependencies in Jira import the text diff results on generating dependency

---
_Release Notes_: 
_Jira Adapter_:
- Removed occurrences from generated dependencies in projects

---
_User Notifications_: 
_Jira Adapter_:
- Removed occurrences from generated dependencies in projects