### PR TITLE
SALTO-2878 fix custom record type translation converter bug

### DIFF
--- a/packages/netsuite-adapter/src/filters/translation_converter.ts
+++ b/packages/netsuite-adapter/src/filters/translation_converter.ts
@@ -121,18 +121,18 @@ const filterCreator = (): FilterWith<'onFetch' | 'preDeploy'> => ({
   },
 
   preDeploy: async changes => {
-    const [fields, elements] = _.partition(
+    const [fields, typesAndInstances] = _.partition(
       changes.flatMap(change => Object.values(change.data)),
       isField
     )
-    const elemIdSet = new Set(elements.map(element => element.elemID.getFullName()))
+    const elemIdSet = new Set(typesAndInstances.map(element => element.elemID.getFullName()))
     const fieldParents = _.uniqBy(
       fields
         .map(field => field.parent)
         .filter(parent => !elemIdSet.has(parent.elemID.getFullName())),
       parent => parent.elemID.name
     )
-    const elementsToTransform = elements
+    const elementsToTransform = typesAndInstances
       .concat(fieldParents)
       .filter(element => isInstanceElement(element) || (
         isObjectType(element) && isCustomRecordType(element)


### PR DESCRIPTION
To reproduce-
1. change an annotation in a custom record type
2. add a field that has a `*Translate` field (that needs to be transformed to `{ ”text”: val, ”@_translate”: ”T” }`)

This will make `transformValues` to throw the error-

`Can not resolve value of reference with ElemID serviceid without elementsSource because value does not exist`

This happens because we need to transform only the root custom record type modification change and not its field addition change.

---
_Release Notes_: 
Netsuite Adapter:
- fix custom record type translation converter bug

---
_User Notifications_: 
None
