### PR TITLE
SALTO-2800 fix bug in getField

### DIFF
--- a/packages/adapter-api/src/utils.ts
+++ b/packages/adapter-api/src/utils.ts
@@ -14,13 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { TypeElement, ObjectType, Element, PrimitiveType, isContainerType, Field, isObjectType, isField, isListType, isMapType, ReadOnlyElementsSource } from './elements'
-import { Values } from './values'
-
-interface AnnoRef {
-  annoType?: TypeElement
-  annoName?: string
-}
+import { TypeElement, ObjectType, PrimitiveType, isContainerType, Field, isObjectType, isField, isListType, isMapType, ReadOnlyElementsSource } from './elements'
 
 type SubElementSearchResult = {
   field?: Field
@@ -39,7 +33,7 @@ export const getDeepInnerType = async (
   return getDeepInnerType(await type.getInnerType(elementsSource), elementsSource)
 }
 
-export const getSubElement = async (
+const getSubElement = async (
   baseType: TypeElement,
   pathParts: ReadonlyArray<string>,
   elementsSource?: ReadOnlyElementsSource,
@@ -51,7 +45,6 @@ export const getSubElement = async (
     if ((isIndexPathPart(key) && isListType(type)) || isMapType(type)) {
       return type.getInnerType(elementsSource)
     }
-    if (type.annotationRefTypes[key]) return (await type.getAnnotationTypes(elementsSource))?.[key]
     if (isObjectType(type)) return type.fields[key]
     return undefined
   }
@@ -142,14 +135,3 @@ export const getFieldNames = async (
   }
   return []
 }
-
-export const getAnnotationKey = (annotations: {[key: string]: TypeElement}, path: string[]):
-  AnnoRef => {
-  // Looking for the longest key in annotations that start with pathParts
-  const annoName = path[0]
-  const annoType = (annoName) ? annotations[annoName] : undefined
-  return { annoName, annoType }
-}
-
-export const getAnnotationValue = (element: Element, annotation: string): Values =>
-  (element.annotations[annotation] || {})

--- a/packages/adapter-api/test/utils.test.ts
+++ b/packages/adapter-api/test/utils.test.ts
@@ -13,80 +13,35 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { collections } from '@salto-io/lowerdash'
 import { getDeepInnerType, getField, getFieldType } from '../src/utils'
-import { ObjectType, ListType, isElement, isField, isListType, isMapType, MapType, PrimitiveType, PrimitiveTypes, ReadOnlyElementsSource } from '../src/elements'
+import { ObjectType, ListType, isElement, isField, isListType, isMapType, MapType, PrimitiveType, PrimitiveTypes } from '../src/elements'
 import { ElemID } from '../src/element_id'
 import { BuiltinTypes } from '../src/builtins'
 import { isSaltoElementError } from '../src/error'
 
-const { awu } = collections.asynciterable
-
 describe('Test utils.ts & isXXX in elements.ts', () => {
-  const mockElemID = new ElemID('test-utils', 'obj')
-  const listOfNum = new ListType(BuiltinTypes.NUMBER)
-  const mapOfNum = new MapType(BuiltinTypes.NUMBER)
-  const mapOfMapOfNum = new MapType(new MapType(BuiltinTypes.NUMBER))
-  const listOfListofNum = new ListType(new ListType(BuiltinTypes.NUMBER))
-  const mapOfListOfNum = new MapType(new ListType(BuiltinTypes.NUMBER))
-  const listOfMapOfNum = new ListType(new MapType(BuiltinTypes.NUMBER))
-  const primElemID = new ElemID('ad', 'prim')
-  const primitiveNum = new PrimitiveType({
-    elemID: primElemID,
-    primitive: PrimitiveTypes.NUMBER,
-  })
-  const mapOfPrimitiveNum = new MapType(primitiveNum)
-  const mapOfMapOfPrimitiveNum = new MapType(new MapType(primitiveNum))
-  const mockObjectType = new ObjectType({
-    elemID: mockElemID,
+  const innerType = new ObjectType({
+    elemID: new ElemID('test-utils', 'innerObj'),
     fields: {
-      fieldTest: {
-        refType: BuiltinTypes.NUMBER,
-      },
-      listFieldTest: {
-        refType: listOfNum,
-      },
-      mapFieldTest: {
-        refType: mapOfNum,
-      },
-      listOfListFieldTest: {
-        refType: listOfListofNum,
-      },
-      mapOfMapFieldTest: {
-        refType: mapOfMapOfNum,
-      },
-      mapOfListFieldTest: {
-        refType: mapOfListOfNum,
-      },
-      listOfMapFieldTest: {
-        refType: listOfMapOfNum,
-      },
-      mapOfPrimitive: {
-        refType: mapOfPrimitiveNum,
-      },
+      innerField: { refType: BuiltinTypes.STRING },
     },
-    annotationRefsOrTypes: {},
-    annotations: {},
   })
-  const mockList = new ListType(BuiltinTypes.NUMBER)
-  const mockMap = new MapType(BuiltinTypes.NUMBER)
-  const mockListList = new ListType(mockList)
-  const mockMapMap = new MapType(mockMap)
-  const srcElements = [
-    mockObjectType,
-    mapOfPrimitiveNum,
-    BuiltinTypes.NUMBER,
-    mockList,
-    mockMap,
-    mockListList,
-    mockMapMap,
-  ]
-  const elmSource: ReadOnlyElementsSource = {
-    get: async elemID => srcElements.find(e => e.elemID.isEqual(elemID)),
-    getAll: async () => awu(srcElements),
-    has: async elemID => srcElements.find(e => e.elemID.isEqual(elemID)) !== undefined,
-    list: async () => awu(srcElements).map(e => e.elemID),
-  }
+  const mockObjectType = new ObjectType({
+    elemID: new ElemID('test-utils', 'obj'),
+    fields: {
+      fieldTest: { refType: BuiltinTypes.NUMBER },
+      listFieldTest: { refType: new ListType(BuiltinTypes.NUMBER) },
+      mapFieldTest: { refType: new MapType(BuiltinTypes.NUMBER) },
+      listOfListFieldTest: { refType: new ListType(new ListType(BuiltinTypes.NUMBER)) },
+      mapOfMapFieldTest: { refType: new MapType(new MapType(BuiltinTypes.NUMBER)) },
+      mapOfListFieldTest: { refType: new MapType(new ListType(BuiltinTypes.NUMBER)) },
+      listOfMapFieldTest: { refType: new ListType(new MapType(BuiltinTypes.NUMBER)) },
+      innerTypeFieldTest: { refType: innerType },
+      listOfInnerTypeFieldTest: { refType: new ListType(innerType) },
+    },
+    annotationRefsOrTypes: { someAnno: innerType },
+  })
+
   describe('isElement func', () => {
     it('should return false for undefined', () => {
       expect(isElement(undefined)).toBeFalsy()
@@ -166,17 +121,6 @@ describe('Test utils.ts & isXXX in elements.ts', () => {
       expect(await getDeepInnerType(await mockObjectType.fields.mapFieldTest.getType() as MapType))
         .toEqual(BuiltinTypes.NUMBER)
     })
-
-    it('should recognize getDeepInnerType in a map with ElementsSource', async () => {
-      expect(await getDeepInnerType(mapOfPrimitiveNum))
-        .toEqual(primitiveNum)
-    })
-
-    it('should recognize getDeepInnerType in a map of map with ElementsSource', async () => {
-      expect(await getDeepInnerType(mapOfMapOfPrimitiveNum))
-        .toEqual(primitiveNum)
-    })
-
     it('should recognize getDeepInnerType in map of maps', async () => {
       expect(await getDeepInnerType(
         await mockObjectType.fields.mapOfMapFieldTest.getType() as MapType
@@ -193,70 +137,110 @@ describe('Test utils.ts & isXXX in elements.ts', () => {
       )).toEqual(BuiltinTypes.NUMBER)
     })
     it('should return the type if not container', async () => {
+      const primitiveNum = new PrimitiveType({
+        elemID: new ElemID('ad', 'prim'),
+        primitive: PrimitiveTypes.NUMBER,
+      })
       expect(await getDeepInnerType(primitiveNum)).toEqual(primitiveNum)
     })
   })
-  describe('getField, getFieldType funcs', () => {
-    describe('With ElementsSource', () => {
-      it('should succeed on a standard field', async () => {
-        expect(await getField(mockObjectType, ['fieldTest'], elmSource)).toEqual(mockObjectType.fields.fieldTest)
-        expect(await getFieldType(mockObjectType, ['fieldTest'], elmSource)).toEqual(BuiltinTypes.NUMBER)
-      })
-
-      it('should succeed on a list field', async () => {
-        expect(await getField(mockObjectType, ['listFieldTest'], elmSource)).toEqual(mockObjectType.fields.listFieldTest)
-        expect(await getFieldType(mockObjectType, ['listFieldTest'], elmSource)).toEqual(new ListType(BuiltinTypes.NUMBER))
-        expect(await getField(mockObjectType, ['listOfListFieldTest'], elmSource))
-          .toEqual(mockObjectType.fields.listOfListFieldTest)
-        expect(await getFieldType(mockObjectType, ['listOfListFieldTest'], elmSource))
-          .toEqual(new ListType(new ListType(BuiltinTypes.NUMBER)))
-      })
-
-      it('should succeed on a map field', async () => {
-        expect(await getField(mockObjectType, ['mapFieldTest'], elmSource)).toEqual(mockObjectType.fields.mapFieldTest)
-        expect(await getFieldType(mockObjectType, ['mapFieldTest'], elmSource)).toEqual(new MapType(BuiltinTypes.NUMBER))
-        expect(await getField(mockObjectType, ['mapOfMapFieldTest'], elmSource))
-          .toEqual(mockObjectType.fields.mapOfMapFieldTest)
-        expect(await getFieldType(mockObjectType, ['mapOfMapFieldTest'], elmSource))
-          .toEqual(new MapType(new MapType(BuiltinTypes.NUMBER)))
-        expect(await getField(mockObjectType, ['mapOfPrimitive'], elmSource)).toEqual(mockObjectType.fields.mapOfPrimitive)
-        expect(await getFieldType(mockObjectType, ['mapOfPrimitive'], elmSource)).toEqual(mapOfPrimitiveNum)
-      })
-
-      it('should return undefined on a nonexistent field', async () => {
-        expect(await getField(mockObjectType, ['nonExistentField'], elmSource)).toBeUndefined()
-        expect(await getFieldType(mockObjectType, ['nonExistentField'], elmSource)).toBeUndefined()
-      })
+  describe('getField', () => {
+    it('should succeed on a standard field', async () => {
+      expect(await getField(mockObjectType, ['fieldTest']))
+        .toEqual(mockObjectType.fields.fieldTest)
     })
-
-    describe('Without ElementsSource', () => {
-      it('should succeed on a standard field', async () => {
-        expect(await getField(mockObjectType, ['fieldTest'])).toEqual(mockObjectType.fields.fieldTest)
-        expect(await getFieldType(mockObjectType, ['fieldTest'])).toEqual(BuiltinTypes.NUMBER)
-      })
-
-      it('should succeed on a list field', async () => {
-        expect(await getField(mockObjectType, ['listFieldTest'])).toEqual(mockObjectType.fields.listFieldTest)
-        expect(await getFieldType(mockObjectType, ['listFieldTest'])).toEqual(new ListType(BuiltinTypes.NUMBER))
-        expect(await getField(mockObjectType, ['listOfListFieldTest']))
-          .toEqual(mockObjectType.fields.listOfListFieldTest)
-        expect(await getFieldType(mockObjectType, ['listOfListFieldTest']))
-          .toEqual(new ListType(new ListType(BuiltinTypes.NUMBER)))
-      })
-
-      it('should succeed on a map field', async () => {
-        expect(await getField(mockObjectType, ['mapFieldTest'])).toEqual(mockObjectType.fields.mapFieldTest)
-        expect(await getFieldType(mockObjectType, ['mapFieldTest'])).toEqual(new MapType(BuiltinTypes.NUMBER))
-        expect(await getField(mockObjectType, ['mapOfMapFieldTest']))
-          .toEqual(mockObjectType.fields.mapOfMapFieldTest)
-        expect(await getFieldType(mockObjectType, ['mapOfMapFieldTest']))
-          .toEqual(new MapType(new MapType(BuiltinTypes.NUMBER)))
-      })
-
-      it('should return undefined on a nonexistent field', async () => {
-        expect(await getField(mockObjectType, ['nonExistentField'])).toBeUndefined()
-        expect(await getFieldType(mockObjectType, ['nonExistentField'])).toBeUndefined()
-      })
+    it('should succeed on a list field', async () => {
+      expect(await getField(mockObjectType, ['listFieldTest']))
+        .toEqual(mockObjectType.fields.listFieldTest)
+      expect(await getField(mockObjectType, ['listOfListFieldTest']))
+        .toEqual(mockObjectType.fields.listOfListFieldTest)
+    })
+    it('should succeed on a map field', async () => {
+      expect(await getField(mockObjectType, ['mapFieldTest']))
+        .toEqual(mockObjectType.fields.mapFieldTest)
+      expect(await getField(mockObjectType, ['mapOfMapFieldTest']))
+        .toEqual(mockObjectType.fields.mapOfMapFieldTest)
+    })
+    it('should success on an inner type field', async () => {
+      expect(await getField(mockObjectType, ['innerTypeFieldTest']))
+        .toEqual(mockObjectType.fields.innerTypeFieldTest)
+      expect(await getField(mockObjectType, ['innerTypeFieldTest', 'innerField']))
+        .toEqual(innerType.fields.innerField)
+    })
+    it('should success on an inner type in a list field', async () => {
+      expect(await getField(mockObjectType, ['listOfInnerTypeFieldTest']))
+        .toEqual(mockObjectType.fields.listOfInnerTypeFieldTest)
+      expect(await getField(mockObjectType, ['listOfInnerTypeFieldTest', '1', 'innerField']))
+        .toEqual(innerType.fields.innerField)
+    })
+    it('should return the closest parent field when the rest of the path is map/list keys', async () => {
+      expect(await getField(mockObjectType, ['listOfInnerTypeFieldTest', '1']))
+        .toEqual(mockObjectType.fields.listOfInnerTypeFieldTest)
+    })
+    it('should return undefined on a nonexistent field', async () => {
+      expect(await getField(mockObjectType, ['nonExistentField'])).toBeUndefined()
+    })
+    it('should return undefined on empty path', async () => {
+      expect(await getField(mockObjectType, [])).toBeUndefined()
+    })
+    it('should return undefined on path to annotation', async () => {
+      expect(await getField(mockObjectType, ['someAnno', 'innerField'])).toBeUndefined()
+    })
+  })
+  describe('getFieldType', () => {
+    it('should succeed on a standard field', async () => {
+      expect(await getFieldType(mockObjectType, ['fieldTest']))
+        .toEqual(BuiltinTypes.NUMBER)
+    })
+    it('should succeed on a list field', async () => {
+      expect(await getFieldType(mockObjectType, ['listFieldTest']))
+        .toEqual(new ListType(BuiltinTypes.NUMBER))
+      expect(await getFieldType(mockObjectType, ['listFieldTest', '1']))
+        .toEqual(BuiltinTypes.NUMBER)
+      expect(await getFieldType(mockObjectType, ['listOfListFieldTest']))
+        .toEqual(new ListType(new ListType(BuiltinTypes.NUMBER)))
+      expect(await getFieldType(mockObjectType, ['listOfListFieldTest', '1']))
+        .toEqual(new ListType(BuiltinTypes.NUMBER))
+      expect(await getFieldType(mockObjectType, ['listOfListFieldTest', '1', '1']))
+        .toEqual(BuiltinTypes.NUMBER)
+    })
+    it('should succeed on a map field', async () => {
+      expect(await getFieldType(mockObjectType, ['mapFieldTest']))
+        .toEqual(new MapType(BuiltinTypes.NUMBER))
+      expect(await getFieldType(mockObjectType, ['mapFieldTest', 'key']))
+        .toEqual(BuiltinTypes.NUMBER)
+      expect(await getFieldType(mockObjectType, ['mapOfMapFieldTest']))
+        .toEqual(new MapType(new MapType(BuiltinTypes.NUMBER)))
+      expect(await getFieldType(mockObjectType, ['mapOfMapFieldTest', 'a']))
+        .toEqual(new MapType(BuiltinTypes.NUMBER))
+      expect(await getFieldType(mockObjectType, ['mapOfMapFieldTest', 'a', 'b']))
+        .toEqual(BuiltinTypes.NUMBER)
+    })
+    it('should success on an inner type field', async () => {
+      expect(await getFieldType(mockObjectType, ['innerTypeFieldTest']))
+        .toEqual(innerType)
+      expect(await getFieldType(mockObjectType, ['innerTypeFieldTest', 'innerField']))
+        .toEqual(BuiltinTypes.STRING)
+    })
+    it('should success on an inner type in a list field', async () => {
+      expect(await getFieldType(mockObjectType, ['listOfInnerTypeFieldTest']))
+        .toEqual(new ListType(innerType))
+      expect(await getFieldType(mockObjectType, ['listOfInnerTypeFieldTest', '1']))
+        .toEqual(innerType)
+      expect(await getFieldType(mockObjectType, ['listOfInnerTypeFieldTest', '1', 'innerField']))
+        .toEqual(BuiltinTypes.STRING)
+    })
+    it('should return undefined on a nonexistent field', async () => {
+      expect(await getFieldType(mockObjectType, ['nonExistentField'])).toBeUndefined()
+    })
+    it('should return undefined on empty path', async () => {
+      expect(await getFieldType(mockObjectType, [])).toBeUndefined()
+    })
+    it('should return undefined on non-number ListType key', async () => {
+      expect(await getFieldType(mockObjectType, ['listFieldTest', 'NaN'])).toBeUndefined()
+    })
+    it('should return undefined on path to annotation', async () => {
+      expect(await getFieldType(mockObjectType, ['someAnno', 'innerField'])).toBeUndefined()
     })
   })
   describe('test error verification', () => {

--- a/packages/salesforce-adapter/src/filters/topics_for_objects.ts
+++ b/packages/salesforce-adapter/src/filters/topics_for_objects.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import {
-  ObjectType, Element, Values, getAnnotationValue, isObjectTypeChange, InstanceElement,
+  ObjectType, Element, Values, isObjectTypeChange, InstanceElement,
   isAdditionOrModificationChange, getChangeData, isAdditionChange, isModificationChange,
   ElemID, toChange,
 } from '@salto-io/adapter-api'
@@ -33,8 +33,8 @@ const { ENABLE_TOPICS, ENTITY_API_NAME } = TOPICS_FOR_OBJECTS_FIELDS
 
 export const DEFAULT_ENABLE_TOPICS_VALUE = false
 
-const getTopicsForObjects = (obj: ObjectType): Values => getAnnotationValue(obj,
-  TOPICS_FOR_OBJECTS_ANNOTATION)
+const getTopicsForObjects = (obj: ObjectType): Values =>
+  obj.annotations[TOPICS_FOR_OBJECTS_ANNOTATION] || {}
 
 const setTopicsForObjects = (object: ObjectType, enableTopics: boolean): void => {
   object.annotate({ [TOPICS_FOR_OBJECTS_ANNOTATION]: { [ENABLE_TOPICS]: enableTopics } })


### PR DESCRIPTION
- Fix bug in `getField` where no field is returned when there is an annotation with the same name as the field.
- Added tests to `getField` & `getFieldType` functions, including getting the closest parent field when the rest of the path is map/list keys, and returning `undefined` on path to annotation.

---
_Additional context for reviewer_

---
_Release Notes_: 
Adapter API:
- Remove unnecessary export of `getSubElement`
- Remove unused functions `getAnnotationKey`, `getAnnotationValue` (it was used in one place only so I moved the implementation over there)
- Fix bug where no field is returned when there is an annotation with the same name as the field

---
_User Notifications_: 
None
