### PR TITLE
SALTO-2879: element clone with many elements stuck

### DIFF
--- a/packages/adapter-api/src/element_id.ts
+++ b/packages/adapter-api/src/element_id.ts
@@ -153,10 +153,9 @@ export class ElemID {
   }
 
   private fullNameParts(): string[] {
-    const parts = ElemID.TOP_LEVEL_ID_TYPES.includes(this.idType)
+    return ElemID.TOP_LEVEL_ID_TYPES.includes(this.idType)
       ? [this.adapter, this.typeName]
       : [this.adapter, this.typeName, this.idType, ...this.nameParts]
-    return parts.filter(part => !_.isEmpty(part)) as string[]
   }
 
   private generateFullName(): string {

--- a/packages/adapter-api/src/element_id.ts
+++ b/packages/adapter-api/src/element_id.ts
@@ -119,6 +119,7 @@ export class ElemID {
   readonly typeName: string
   readonly idType: ElemIDType
   private readonly nameParts: ReadonlyArray<string>
+  private fullName: string
   constructor(
     adapter: string,
     typeName?: string,
@@ -129,26 +130,7 @@ export class ElemID {
     this.typeName = _.isEmpty(typeName) ? ElemID.CONFIG_NAME : typeName as string
     this.idType = idType || ElemID.getDefaultIdType(adapter)
     this.nameParts = name
-    this.validateVariable()
-  }
-
-  private validateVariable(): void {
-    if (this.adapter === ElemID.VARIABLES_NAMESPACE && this.idType !== 'var'
-      && this.typeName !== ElemID.CONFIG_NAME) {
-      throw new Error(`Cannot create ID ${this.getFullName()
-      } - type must be 'var', not '${this.idType}'`)
-    }
-    if (this.idType === 'var') {
-      if (this.adapter !== ElemID.VARIABLES_NAMESPACE) {
-        throw new Error(`Cannot create ID for variable ${this.getFullName()
-        } -  it must be in the ${ElemID.VARIABLES_NAMESPACE
-        } namespace, not in ${this.adapter}`)
-      }
-      if (!_.isEmpty(this.nameParts)) {
-        throw new Error(`Cannot create ID ${this.getFullName()
-        }.${this.nameParts.join(ElemID.NAMESPACE_SEPARATOR)} - object variables are not supported`)
-      }
-    }
+    this.fullName = this.generateFullName()
   }
 
   get name(): string {
@@ -177,17 +159,21 @@ export class ElemID {
     return parts.filter(part => !_.isEmpty(part)) as string[]
   }
 
-  getFullName(): string {
+  private generateFullName(): string {
     const nameParts = this.fullNameParts()
-    return this.fullNameParts()
+    return nameParts
       // If the last part of the name is empty we can omit it
       .filter((part, idx) => idx !== nameParts.length - 1 || part !== ElemID.CONFIG_NAME)
       .join(ElemID.NAMESPACE_SEPARATOR)
   }
 
+  getFullName(): string {
+    return this.fullName
+  }
+
   getFullNameParts(): string[] {
     const nameParts = this.fullNameParts()
-    return this.fullNameParts()
+    return nameParts
       // If the last part of the name is empty we can omit it
       .filter((part, idx) => idx !== nameParts.length - 1 || part !== ElemID.CONFIG_NAME)
   }

--- a/packages/adapter-api/src/element_id.ts
+++ b/packages/adapter-api/src/element_id.ts
@@ -153,9 +153,10 @@ export class ElemID {
   }
 
   private fullNameParts(): string[] {
-    return ElemID.TOP_LEVEL_ID_TYPES.includes(this.idType)
+    const parts = ElemID.TOP_LEVEL_ID_TYPES.includes(this.idType)
       ? [this.adapter, this.typeName]
       : [this.adapter, this.typeName, this.idType, ...this.nameParts]
+    return parts.filter(part => !_.isEmpty(part)) as string[]
   }
 
   private generateFullName(): string {

--- a/packages/adapter-api/src/element_id.ts
+++ b/packages/adapter-api/src/element_id.ts
@@ -119,7 +119,7 @@ export class ElemID {
   readonly typeName: string
   readonly idType: ElemIDType
   private readonly nameParts: ReadonlyArray<string>
-  private fullName: string
+  private readonly fullName: string
   constructor(
     adapter: string,
     typeName?: string,

--- a/packages/adapter-api/test/elements.test.ts
+++ b/packages/adapter-api/test/elements.test.ts
@@ -294,20 +294,6 @@ describe('Test elements.ts', () => {
     const nestedListId = new ListType(new TypeReference(listId)).elemID
 
     describe('constructor', () => {
-      it('should throw error on variables not in the var namespace', () => {
-        expect((() => new ElemID('salesforce', 'varName',
-          'var'))).toThrow(/.*salesforce\.varName[^.].*/)
-      })
-      it('should throw error on id types which are not \'var\' in the var namespace', () => {
-        expect((() => new ElemID(ElemID.VARIABLES_NAMESPACE, 'varName',
-          'type'))).toThrow(/.*var\.varName[^.].*/)
-        expect((() => new ElemID(ElemID.VARIABLES_NAMESPACE, 't', 'instance',
-          'name'))).toThrow(/.*var\.t\.instance\.name[^.].*/)
-      })
-      it('should throw error on nested variables', () => {
-        expect((() => new ElemID(ElemID.VARIABLES_NAMESPACE, 'varName', 'var',
-          'k'))).toThrow(/.*var\.varName\.k[^.].*/)
-      })
       it('should create a variable when no type is provided but the namespace is var', () => {
         expect(new ElemID(ElemID.VARIABLES_NAMESPACE, 'varName').idType).toEqual('var')
       })

--- a/packages/adapter-utils/src/collisions.ts
+++ b/packages/adapter-utils/src/collisions.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import { InstanceElement, SaltoError } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
-import { safeJsonStringify, referenceExpressionStringifyReplacer } from './utils'
+import { safeJsonStringify, elementExpressionStringifyReplacer } from './utils'
 
 const { groupByAsync } = collections.asynciterable
 const log = logger(module)
@@ -75,7 +75,7 @@ const logInstancesWithCollidingElemID = async (
       const relevantInstanceValues = elemIDInstances
         .map(instance => _.pickBy(instance.value, val => val != null))
       const relevantInstanceValuesStr = relevantInstanceValues
-        .map(instValues => safeJsonStringify(instValues, referenceExpressionStringifyReplacer, 2)).join('\n')
+        .map(instValues => safeJsonStringify(instValues, elementExpressionStringifyReplacer, 2)).join('\n')
       log.debug(`Omitted instances of type ${type} with colliding ElemID ${elemID} with values - 
   ${relevantInstanceValuesStr}`)
     })

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -975,12 +975,15 @@ export const createDefaultInstanceFromType = async (name: string, objectType: Ob
 
 type Replacer = (key: string, value: Value) => Value
 
-export const referenceExpressionStringifyReplacer: Replacer = (_key, value) => {
+export const elementExpressionStringifyReplacer: Replacer = (_key, value) => {
   if (isReferenceExpression(value)) {
     return `ReferenceExpression(${value.elemID.getFullName()}, ${value.value ? '<omitted>' : '<no value>'})`
   }
   if (isTypeReference(value)) {
     return `TypeReference(${value.elemID.getFullName()}, ${value.type ? '<omitted>' : '<no value>'})`
+  }
+  if (value instanceof ElemID) {
+    return `ElemID(${value.getFullName()})`
   }
   return value
 }

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -32,7 +32,7 @@ import {
   flatValues, mapKeysRecursive, createDefaultInstanceFromType, applyInstancesDefaults,
   restoreChangeElement, RestoreValuesFunc, getAllReferencedIds, applyFunctionToChangeData,
   transformElement, toObjectType, getParents, resolveTypeShallow,
-  referenceExpressionStringifyReplacer,
+  elementExpressionStringifyReplacer,
   createSchemeGuard,
   getParent,
 } from '../src/utils'
@@ -2229,18 +2229,10 @@ describe('Test utils.ts', () => {
         )
       })
       it('should replace the reference expression object with a serialized representation', () => {
-        const res = safeJsonStringify(inst, referenceExpressionStringifyReplacer, 2)
+        const res = safeJsonStringify(inst, elementExpressionStringifyReplacer, 2)
         expect(res).not.toEqual(safeJsonStringify(inst))
         expect(res).toEqual(`{
-  "elemID": {
-    "adapter": "salto",
-    "typeName": "obj",
-    "idType": "instance",
-    "nameParts": [
-      "test2"
-    ],
-    "fullName": "salto.obj.instance.test2"
-  },
+  "elemID": "ElemID(salto.obj.instance.test2)",
   "annotations": {},
   "annotationRefTypes": {},
   "value": {

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -2238,7 +2238,8 @@ describe('Test utils.ts', () => {
     "idType": "instance",
     "nameParts": [
       "test2"
-    ]
+    ],
+    "fullName": "salto.obj.instance.test2"
   },
   "annotations": {},
   "annotationRefTypes": {},

--- a/packages/core/src/local-workspace/state.ts
+++ b/packages/core/src/local-workspace/state.ts
@@ -192,7 +192,9 @@ export const localState = (
     const elementsByAccount = _.groupBy(elements, element => element.elemID.adapter)
     const accountToElementStrings = await promises.object.mapValuesAsync(
       elementsByAccount,
-      accountElements => serialize(accountElements),
+      accountElements => serialize(
+        _.sortBy(accountElements, element => element.elemID.getFullName())
+      ),
     )
     const accountToDates = await inMemState.getAccountsUpdateDates()
     const accountToPathIndex = pathIndex.serializePathIndexByAccount(

--- a/packages/jira-adapter/src/filters/duplicate_ids.ts
+++ b/packages/jira-adapter/src/filters/duplicate_ids.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
-import { naclCase, referenceExpressionStringifyReplacer, safeJsonStringify } from '@salto-io/adapter-utils'
+import { naclCase, elementExpressionStringifyReplacer, safeJsonStringify } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
@@ -57,7 +57,7 @@ const filter: FilterCreator = ({ config }) => ({
     duplicateInstances
       .filter(isInstanceElement)
       .forEach(instance => {
-        log.debug(`Found a duplicate instance ${instance.elemID.getFullName()} with values: ${safeJsonStringify(instance.value, referenceExpressionStringifyReplacer, 2)}`)
+        log.debug(`Found a duplicate instance ${instance.elemID.getFullName()} with values: ${safeJsonStringify(instance.value, elementExpressionStringifyReplacer, 2)}`)
       })
 
     if (!config.fetch.fallbackToInternalId) {

--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -219,7 +219,7 @@ export const serialize = async <T = Element>(
     }
     return undefined
   }
-  const cloneElements = elements.map(element => {
+  const clonedElements = elements.map(element => {
     const clone = _.cloneDeepWith(element, replacer)
     return isSaltoSerializable(element) ? saltoClassReplacer(clone) : clone
   })
@@ -230,7 +230,7 @@ export const serialize = async <T = Element>(
   // We don't use safeJsonStringify to save some time, because we know  we made sure there aren't
   // circles
   // eslint-disable-next-line no-restricted-syntax
-  return JSON.stringify(cloneElements)
+  return JSON.stringify(clonedElements)
 }
 
 export type StaticFileReviver =

--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -141,7 +141,7 @@ function isSerializedClass(value: any): value is SerializedClass {
     && value[SALTO_CLASS_FIELD] in NameToType
 }
 
-export const serialize = async <T extends { elemID: ElemID } = Element>(
+export const serialize = async <T = Element>(
   elements: T[],
   referenceSerializerMode: 'replaceRefWithValue' | 'keepRef' = 'replaceRefWithValue',
   storeStaticFile?: (file: StaticFile) => Promise<void>
@@ -221,15 +221,8 @@ export const serialize = async <T extends { elemID: ElemID } = Element>(
   }
   const cloneElements = elements.map(element => {
     const clone = _.cloneDeepWith(element, replacer)
-    return {
-      element: isSaltoSerializable(element) ? saltoClassReplacer(clone) : clone,
-      id: element.elemID,
-    }
+    return isSaltoSerializable(element) ? saltoClassReplacer(clone) : clone
   })
-  const sortedElements = _(cloneElements)
-    .sortBy(({ id }) => id.getFullName())
-    .map(({ element }) => element)
-    .value()
 
   // Avoiding Promise.all to not reach Promise.all limit
   await awu(promises).forEach(promise => promise)
@@ -237,7 +230,7 @@ export const serialize = async <T extends { elemID: ElemID } = Element>(
   // We don't use safeJsonStringify to save some time, because we know  we made sure there aren't
   // circles
   // eslint-disable-next-line no-restricted-syntax
-  return JSON.stringify(sortedElements)
+  return JSON.stringify(cloneElements)
 }
 
 export type StaticFileReviver =

--- a/packages/workspace/src/workspace/nacl_files/parsed_nacl_files_cache.ts
+++ b/packages/workspace/src/workspace/nacl_files/parsed_nacl_files_cache.ts
@@ -124,7 +124,7 @@ const getCacheSources = async (
   metadata: await getMetadata(cacheName, remoteMapCreator, persistent),
   elements: await remoteMapCreator({
     namespace: getRemoteMapCacheNamespace(cacheName, 'elements'),
-    serialize: async (elements: Element[]) => serialize(elements ?? [], 'keepRef'),
+    serialize: async (elements: Element[]) => serialize(_.sortBy(elements ?? [], element => element.elemID.getFullName()), 'keepRef'),
     deserialize: async data => (deserialize(
       data,
       async sf => staticFilesSource.getStaticFile(sf.filepath, sf.encoding),

--- a/packages/workspace/src/workspace/nacl_files/parsed_nacl_files_cache.ts
+++ b/packages/workspace/src/workspace/nacl_files/parsed_nacl_files_cache.ts
@@ -124,7 +124,7 @@ const getCacheSources = async (
   metadata: await getMetadata(cacheName, remoteMapCreator, persistent),
   elements: await remoteMapCreator({
     namespace: getRemoteMapCacheNamespace(cacheName, 'elements'),
-    serialize: async (elements: Element[]) => serialize(_.sortBy(elements ?? [], element => element.elemID.getFullName()), 'keepRef'),
+    serialize: async (elements: Element[]) => serialize(elements ?? [], 'keepRef'),
     deserialize: async data => (deserialize(
       data,
       async sf => staticFilesSource.getStaticFile(sf.filepath, sf.encoding),

--- a/packages/workspace/test/serializer/serializer.test.ts
+++ b/packages/workspace/test/serializer/serializer.test.ts
@@ -236,7 +236,10 @@ describe('State/cache serialization', () => {
       createInMemoryElementSource(elementsToSerialize)
     )
     const serialized = await serialize(await awu(resolved).toArray(), 'keepRef')
-    const deserialized = await deserialize(serialized)
+    const deserialized = _.sortBy(
+      await deserialize(serialized),
+      element => element.elemID.getFullName()
+    )
     const sortedElements = _.sortBy(elementsToSerialize, e => e.elemID.getFullName())
     const sortedElementsWithoutRefs = sortedElements
       // we need to make sure the types are empty as well... Not just the refs
@@ -292,12 +295,6 @@ describe('State/cache serialization', () => {
     expect(innerRefsInst.value.a).toBeInstanceOf(ReferenceExpression)
     expect(innerRefsInst.value.b.b).toBeInstanceOf(ReferenceExpression)
     expect(innerRefsInst.value.c).toBe(2)
-  })
-
-  it('should create the same result for the same input regardless of elements order', async () => {
-    const serialized = await serialize(elements)
-    const shuffledSer = await serialize(_.shuffle(elements))
-    expect(serialized).toEqual(shuffledSer)
   })
 
   it('should throw error if trying to deserialize a non element object', async () => {

--- a/packages/workspace/test/serializer/serializer.test.ts
+++ b/packages/workspace/test/serializer/serializer.test.ts
@@ -213,6 +213,13 @@ describe('State/cache serialization', () => {
     expect(serialized).not.toMatch(subInstance.constructor.name)
   })
 
+  it('should serialize and deserialize elem id correctly', async () => {
+    const serialized = await serialize([subInstance])
+    expect(serialized).toBe('[{"elemID":{"adapter":"salesforce","typeName":"test","idType":"instance","nameParts":["sub_me"]},"annotations":{"test":"annotation"},"annotationRefTypes":{},"path":["path","test"],"value":{"name":"me","num":7},"refType":{"elemID":{"adapter":"salesforce","typeName":"test","idType":"type","nameParts":[],"fullName":"salesforce.test"},"_salto_class":"TypeReference"},"_salto_class":"InstanceElement"}]')
+    const deserialized = await deserialize(serialized)
+    expect(deserialized[0].elemID.getFullName()).toBe(subInstance.elemID.getFullName())
+  })
+
   it('should call the static files handler with the static files', async () => {
     const file = new StaticFile({ filepath: 'filepath', content: Buffer.from('content') })
     subInstance.value.a = file

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -819,7 +819,7 @@ describe('workspace', () => {
 
     it('should return the correct changes', async () => {
       const primaryEnvChanges = changes.default.changes
-      expect(primaryEnvChanges).toHaveLength(27)
+      expect(primaryEnvChanges).toHaveLength(26)
       expect((primaryEnvChanges.find(c => c.action === 'add') as AdditionChange<Element>).data.after)
         .toEqual(newAddedObject)
       const multiLocChange = primaryEnvChanges

--- a/packages/zendesk-adapter/src/filters/macro_attachments.ts
+++ b/packages/zendesk-adapter/src/filters/macro_attachments.ts
@@ -20,7 +20,7 @@ import {
   BuiltinTypes, Change, CORE_ANNOTATIONS, ElemID, getChangeData, InstanceElement,
   isInstanceElement, isRemovalChange, isStaticFile, ObjectType, ReferenceExpression, StaticFile,
 } from '@salto-io/adapter-api'
-import { normalizeFilePathPart, naclCase, referenceExpressionStringifyReplacer,
+import { normalizeFilePathPart, naclCase, elementExpressionStringifyReplacer,
   resolveChangeElement, safeJsonStringify, pathNaclCase } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
@@ -78,7 +78,7 @@ const replaceAttachmentId = (
   }
   if (!isArrayOfRefExprToInstances(attachments)) {
     log.error(`Failed to deploy macro because its attachment field has an invalid format: ${
-      safeJsonStringify(attachments, referenceExpressionStringifyReplacer)}`)
+      safeJsonStringify(attachments, elementExpressionStringifyReplacer)}`)
     throw new Error('Failed to deploy macro because its attachment field has an invalid format')
   }
   parentInstance.value[ATTACHMENTS_FIELD_NAME] = attachments


### PR DESCRIPTION
Two improvements:
- Changed to not create the full name of element id every time, which apparently takes a lot of time
- In https://github.com/salto-io/salto/pull/2172/files#diff-9dbe7ce03ec23e4cbc6ee78890e55f8501df20c904372e2bef6e1c9231784f72R43 we changed `getMergeableParentID` to look at the elements value instead of id to look for arrays, which takes a lot of time. I changed it to check if the value is array only if the id is array

Cloning our entire Jira dev account to another env would take 30 minutes, now it takes 1.2 minutes

---
_Release Notes_: 
_Core_:
- Performance improvements to element clone operation


---
_User Notifications_: 
None