### PR TITLE
SALTO-2804: Improve SDF client validation to run server-side validation

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -462,6 +462,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
           ?? DEFAULT_DEPLOY_REFERENCED_ELEMENTS,
         validate: this.validateBeforeDeploy,
         additionalDependencies: this.additionalDependencies,
+        filtersRunner: this.createFiltersRunner(this.isPartialFetch()),
       }),
       getChangeGroupIds: getChangeGroupIdsFunc(this.client.isSuiteAppConfigured()),
     }

--- a/packages/netsuite-adapter/src/change_validator.ts
+++ b/packages/netsuite-adapter/src/change_validator.ts
@@ -38,6 +38,7 @@ import exchangeRateValidator from './change_validators/currency_exchange_rate'
 import netsuiteClientValidation from './change_validators/client_validation'
 import NetsuiteClient from './client/client'
 import { AdditionalDependencies } from './client/types'
+import { Filter } from './filter'
 
 
 const changeValidators: ChangeValidator[] = [
@@ -78,6 +79,7 @@ const getChangeValidator: ({
   fetchByQuery,
   deployReferencedElements,
   additionalDependencies,
+  filtersRunner,
 } : {
   client: NetsuiteClient
   withSuiteApp: boolean
@@ -86,6 +88,7 @@ const getChangeValidator: ({
   fetchByQuery: FetchByQueryFunc
   deployReferencedElements?: boolean
   additionalDependencies: AdditionalDependencies
+  filtersRunner: Required<Filter>
   }) => ChangeValidator = (
     {
       client,
@@ -95,6 +98,7 @@ const getChangeValidator: ({
       fetchByQuery,
       deployReferencedElements,
       additionalDependencies,
+      filtersRunner,
     }
   ) =>
     async changes => {
@@ -109,7 +113,8 @@ const getChangeValidator: ({
           changes,
           client,
           additionalDependencies,
-          deployReferencedElements
+          filtersRunner,
+          deployReferencedElements,
         ) : [],
       ]))
 

--- a/packages/netsuite-adapter/src/change_validators/client_validation.ts
+++ b/packages/netsuite-adapter/src/change_validators/client_validation.ts
@@ -23,10 +23,17 @@ import { ManifestValidationError, ObjectsDeployError } from '../errors'
 import { SCRIPT_ID } from '../constants'
 import { getElementValueOrAnnotations } from '../types'
 import { Filter } from '../filter'
+import { objectValidationErrorRegex } from '../client/sdf_client'
 
 const { awu } = collections.asynciterable
 
 const detailedErrorMessageRegex = RegExp('^Details: [a-z0-9A-Z_ ]+', 'gm')
+
+const mapObjectDeployErrorToInstance = (error: Error) => {
+  const scriptIdArray = error.message.match(objectValidationErrorRegex)
+  const detailedErrorArray = error.message.match(detailedErrorMessageRegex)
+  
+}
 
 export type ClientChangeValidator = (
   changes: ReadonlyArray<Change>,
@@ -63,9 +70,9 @@ const changeValidator: ClientChangeValidator = async (
         additionalDependencies
       )
       if (errors.length > 0) {
-        return errors.map(error => {
+        return errors.flatMap(error => {
           if (error instanceof ObjectsDeployError) {
-            const detailedErrorArray = error.message.match(detailedErrorMessageRegex)
+            
             return groupChanges.map(getChangeData)
               .filter(element => error.failedObjects.has(
                 getElementValueOrAnnotations(element)[SCRIPT_ID]
@@ -86,7 +93,7 @@ const changeValidator: ClientChangeValidator = async (
             elemID: getChangeData(change).elemID,
             detailedMessage: error.message,
           }))
-        }).flat()
+        })
       }
       return []
     })

--- a/packages/netsuite-adapter/src/change_validators/client_validation.ts
+++ b/packages/netsuite-adapter/src/change_validators/client_validation.ts
@@ -63,7 +63,7 @@ const changeValidator: ClientChangeValidator = async (
             ))
             .map(element => ({
               message: 'SDF Objects Validation Error',
-              severity: 'Warning' as const,
+              severity: 'Error' as const,
               elemID: element.elemID,
               detailedMessage: error.invalidObjects.get(
                 getElementValueOrAnnotations(element)[SCRIPT_ID]
@@ -75,7 +75,7 @@ const changeValidator: ClientChangeValidator = async (
           : `Validation Error on ${groupId}`
         return groupChanges.map(change => ({
           message,
-          severity: 'Warning' as const,
+          severity: 'Error' as const,
           elemID: getChangeData(change).elemID,
           detailedMessage: error.message,
         }))

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -36,7 +36,7 @@ import { CONFIG_FEATURES, APPLICATION_ID, SCRIPT_ID } from '../constants'
 import { LazyElementsSourceIndexes } from '../elements_source_index/types'
 import { convertElementMapsToLists } from '../mapped_lists/utils'
 import { toConfigDeployResult, toSetConfigTypes } from '../suiteapp_config_elements'
-import { FeaturesDeployError, ManifestValidationError, ObjectsDeployError, ObjectsValidationError, SettingsDeployError } from '../errors'
+import { FeaturesDeployError, ObjectsDeployError, SettingsDeployError } from '../errors'
 import { toCustomRecordTypeInstance } from '../custom_records/custom_record_type'
 
 const { awu } = collections.asynciterable
@@ -201,57 +201,6 @@ export default class NetsuiteClient {
       .toArray()
   }
 
-  private async sdfValidate(
-    changes: ReadonlyArray<Change>,
-    deployReferencedElements: boolean,
-    additionalDependencies: AdditionalDependencies
-  ): Promise<Error[]> {
-    const changesToValidate = Array.from(changes)
-
-    const someElementToDeploy = getChangeData(changes[0])
-    const suiteAppId = getElementValueOrAnnotations(someElementToDeploy)[APPLICATION_ID]
-
-    const errors: Error[] = []
-
-    while (changesToValidate.length > 0) {
-      // eslint-disable-next-line no-await-in-loop
-      const customizationInfos = await NetsuiteClient.toCustomizationInfos(
-        changes.map(getChangeData),
-        deployReferencedElements
-      )
-
-      try {
-        log.debug('validating %d changes', changesToValidate.length)
-        // eslint-disable-next-line no-await-in-loop
-        await log.time(
-          () => this.sdfClient.deploy(
-            customizationInfos,
-            suiteAppId,
-            { additionalDependencies, validateOnly: true }
-          ),
-          'sdfValidate'
-        )
-        return errors
-      } catch (error) {
-        errors.push(error)
-        if (error instanceof ManifestValidationError) {
-          return errors
-        }
-        if (error instanceof ObjectsValidationError) {
-          _.remove(
-            changesToValidate,
-            change => error.invalidObjects.has(
-              (getChangeData(change) as InstanceElement).value.scriptid
-            )
-          )
-        } else {
-          return errors
-        }
-      }
-    }
-    return errors
-  }
-
   private async sdfDeploy(
     changes: ReadonlyArray<Change>,
     deployReferencedElements: boolean,
@@ -323,9 +272,11 @@ export default class NetsuiteClient {
     groupID: string,
     deployReferencedElements: boolean,
     additionalSdfDependencies: AdditionalDependencies,
-  ): Promise<Error[]> {
+  ): Promise<readonly Error[]> {
     if (groupID.startsWith(SDF_CHANGE_GROUP_ID)) {
-      return this.sdfValidate(changes, deployReferencedElements, additionalSdfDependencies)
+      return (await this.sdfDeploy(
+        changes, deployReferencedElements, additionalSdfDependencies
+      )).errors
     }
     return []
   }

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -204,14 +204,13 @@ export default class NetsuiteClient {
   }
 
   private async sdfDeploy({
-    changes, deployReferencedElements, additionalDependencies, validateOnly = false
+    changes, deployReferencedElements, additionalDependencies, validateOnly = false,
   }: {
-    changes: ReadonlyArray<Change>,
-    deployReferencedElements: boolean,
-    additionalDependencies: AdditionalDependencies,
+    changes: ReadonlyArray<Change>
+    deployReferencedElements: boolean
+    additionalDependencies: AdditionalDependencies
     validateOnly?: boolean
-  }
-  ): Promise<DeployResult> {
+  }): Promise<DeployResult> {
     const changesToDeploy = Array.from(changes)
 
     const someElementToDeploy = getChangeData(changes[0])
@@ -230,7 +229,11 @@ export default class NetsuiteClient {
         log.debug('deploying %d changes', changesToDeploy.length)
         // eslint-disable-next-line no-await-in-loop
         await log.time(
-          () => this.sdfClient.deploy(customizationInfos, suiteAppId, { additionalDependencies, validateOnly }),
+          () => this.sdfClient.deploy(
+            customizationInfos,
+            suiteAppId,
+            { additionalDependencies, validateOnly }
+          ),
           'sdfDeploy'
         )
         return { errors, appliedChanges: changesToDeploy }
@@ -285,9 +288,12 @@ export default class NetsuiteClient {
     additionalSdfDependencies: AdditionalDependencies,
   ): Promise<ReadonlyArray<Error>> {
     if (groupID.startsWith(SDF_CHANGE_GROUP_ID)) {
-      return (await this.sdfDeploy(
-        { changes, deployReferencedElements, additionalDependencies: additionalSdfDependencies, validateOnly: true }
-      )).errors
+      return (await this.sdfDeploy({
+        changes,
+        deployReferencedElements,
+        additionalDependencies: additionalSdfDependencies,
+        validateOnly: true,
+      })).errors
     }
     return []
   }
@@ -302,7 +308,11 @@ export default class NetsuiteClient {
   ):
     Promise<DeployResult> {
     if (groupID.startsWith(SDF_CHANGE_GROUP_ID)) {
-      return this.sdfDeploy({ changes, deployReferencedElements, additionalDependencies: additionalSdfDependencies })
+      return this.sdfDeploy({
+        changes,
+        deployReferencedElements,
+        additionalDependencies: additionalSdfDependencies,
+      })
     }
 
     const instancesChanges = changes.filter(isInstanceChange)

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -42,8 +42,6 @@ import { toCustomRecordTypeInstance } from '../custom_records/custom_record_type
 const { awu } = collections.asynciterable
 const log = logger(module)
 
-const manifestErrorRegex = RegExp('^Details: The manifest', 'm')
-
 const GROUP_TO_DEPLOY_TYPE: Record<string, DeployType> = {
   [SUITEAPP_CREATING_FILES_GROUP_ID]: 'add',
   [SUITEAPP_UPDATING_FILES_GROUP_ID]: 'update',
@@ -239,10 +237,8 @@ export default class NetsuiteClient {
         return { errors, appliedChanges: changesToDeploy }
       } catch (error) {
         errors.push(error)
-        if (manifestErrorRegex.test(error.message)) {
-          log.debug('manifest validation error, failed to deploy : %o', changesToDeploy)
-          errors[-1] = new ManifestValidationError(error.message)
-          return { errors, appliedChanges: [] }
+        if (error instanceof ManifestValidationError) {
+          log.debug('manifest validation errror: sdf deploy failed')
         }
         if (error instanceof FeaturesDeployError) {
           const successfullyDeployedChanges = NetsuiteClient.toFeaturesDeployPartialSuccessResult(

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -204,7 +204,8 @@ export default class NetsuiteClient {
   private async sdfDeploy(
     changes: ReadonlyArray<Change>,
     deployReferencedElements: boolean,
-    additionalDependencies: AdditionalDependencies
+    additionalDependencies: AdditionalDependencies,
+    validateOnly = false
   ): Promise<DeployResult> {
     const changesToDeploy = Array.from(changes)
 
@@ -222,9 +223,11 @@ export default class NetsuiteClient {
       )
       try {
         log.debug('deploying %d changes', changesToDeploy.length)
+        const sdfDeployParams = validateOnly
+          ? { additionalDependencies, validateOnly } : { additionalDependencies }
         // eslint-disable-next-line no-await-in-loop
         await log.time(
-          () => this.sdfClient.deploy(customizationInfos, suiteAppId, { additionalDependencies }),
+          () => this.sdfClient.deploy(customizationInfos, suiteAppId, sdfDeployParams),
           'sdfDeploy'
         )
         return { errors, appliedChanges: changesToDeploy }
@@ -275,7 +278,7 @@ export default class NetsuiteClient {
   ): Promise<readonly Error[]> {
     if (groupID.startsWith(SDF_CHANGE_GROUP_ID)) {
       return (await this.sdfDeploy(
-        changes, deployReferencedElements, additionalSdfDependencies
+        changes, deployReferencedElements, additionalSdfDependencies, true
       )).errors
     }
     return []

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -110,6 +110,7 @@ const CUSTOM_OBJECT_VALIDATION_ERROR = 'An error occurred during custom object v
 const deployStartMessageRegex = RegExp('^Begin deployment$', 'm')
 const settingsValidationErrorRegex = RegExp('^Validation of account settings failed.$', 'm')
 const objectValidationErrorRegex = RegExp(`^${CUSTOM_OBJECT_VALIDATION_ERROR} \\(([a-z0-9A-Z_]+)\\)`, 'gm')
+const deployObjectValidationErrorRegex = RegExp(`^${CUSTOM_OBJECT_VALIDATION_ERROR} \\((?<${OBJECT_ID}>[a-z0-9_]+)\\)`, 'gm')
 const deployedObjectRegex = RegExp(`^(Create|Update) object -- (?<${OBJECT_ID}>[a-z0-9_]+)`, 'gm')
 const errorObjectRegex = RegExp(`^An unexpected error has occurred. \\((?<${OBJECT_ID}>[a-z0-9_]+)\\)`, 'm')
 const manifestErrorRegex = RegExp('^Details: The manifest ([a-z0-9_ ]+)', 'm')
@@ -950,7 +951,7 @@ export default class SdfClient {
       // we'll get here when the deploy failed in the validation phase.
       // in this case we're looking for validation error message lines.
       const validationErrorObjects = getGroupItemFromRegex(
-        errorMessage, objectValidationErrorRegex, OBJECT_ID
+        errorMessage, deployObjectValidationErrorRegex, OBJECT_ID
       )
       return validationErrorObjects.length > 0
         ? new ObjectsDeployError(errorMessage, new Set(validationErrorObjects))

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -908,7 +908,6 @@ export default class SdfClient {
 
   private static customizeDeployError(error: Error): Error {
     const errorMessage = error.message
-
     if (settingsValidationErrorRegex.test(errorMessage)) {
       return new SettingsDeployError(errorMessage, new Set([CONFIG_FEATURES]))
     }

--- a/packages/netsuite-adapter/src/errors.ts
+++ b/packages/netsuite-adapter/src/errors.ts
@@ -40,15 +40,6 @@ export class SettingsDeployError extends Error {
   }
 }
 
-export class ObjectsValidationError extends Error {
-  invalidObjects: Map<string, string>
-  constructor(message: string, invalidObjects: Map<string, string>) {
-    super(message)
-    this.invalidObjects = invalidObjects
-    this.name = 'ObjectsValidationError'
-  }
-}
-
 export class ManifestValidationError extends Error {
   constructor(message: string) {
     super(message)

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -880,6 +880,7 @@ describe('Adapter', () => {
           fetchByQuery: expect.anything(),
           deployReferencedElements: expect.anything(),
           validate: expect.anything(),
+          filtersRunner: expect.anything(),
           additionalDependencies: expect.anything(),
         })
       })
@@ -908,6 +909,7 @@ describe('Adapter', () => {
           withSuiteApp: expect.anything(),
           warnStaleData: false,
           fetchByQuery: expect.anything(),
+          filtersRunner: expect.anything(),
           deployReferencedElements: expect.anything(),
           validate: expect.anything(),
           additionalDependencies: expect.anything(),
@@ -938,6 +940,7 @@ describe('Adapter', () => {
           withSuiteApp: expect.anything(),
           warnStaleData: true,
           fetchByQuery: expect.anything(),
+          filtersRunner: expect.anything(),
           deployReferencedElements: expect.anything(),
           validate: expect.anything(),
           additionalDependencies: expect.anything(),

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -59,6 +59,7 @@ const DEFAULT_SDF_DEPLOY_PARAMS = {
       objects: [],
     },
   },
+  validateOnly: false,
 }
 
 jest.mock('../src/config', () => ({
@@ -608,7 +609,7 @@ describe('Adapter', () => {
           .toHaveBeenCalledWith(
             [await toCustomizationInfo(expectedResolvedInstance)],
             undefined,
-            DEFAULT_SDF_DEPLOY_PARAMS
+            DEFAULT_SDF_DEPLOY_PARAMS,
           )
         expect(post.isEqual(instance)).toBe(true)
       })
@@ -621,7 +622,7 @@ describe('Adapter', () => {
         expect(client.deploy).toHaveBeenCalledWith(
           [await toCustomizationInfo(fileInstance)],
           undefined,
-          DEFAULT_SDF_DEPLOY_PARAMS
+          DEFAULT_SDF_DEPLOY_PARAMS,
         )
         expect(post.isEqual(fileInstance)).toBe(true)
       })
@@ -634,7 +635,7 @@ describe('Adapter', () => {
         expect(client.deploy).toHaveBeenCalledWith(
           [await toCustomizationInfo(folderInstance)],
           undefined,
-          DEFAULT_SDF_DEPLOY_PARAMS
+          DEFAULT_SDF_DEPLOY_PARAMS,
         )
         expect(post.isEqual(folderInstance)).toBe(true)
       })
@@ -654,7 +655,7 @@ describe('Adapter', () => {
             [await toCustomizationInfo(folderInstance), await toCustomizationInfo(fileInstance)]
           ),
           undefined,
-          DEFAULT_SDF_DEPLOY_PARAMS
+          DEFAULT_SDF_DEPLOY_PARAMS,
         )
         expect(result.errors).toHaveLength(0)
         expect(result.appliedChanges).toHaveLength(2)

--- a/packages/netsuite-adapter/test/change_validator.test.ts
+++ b/packages/netsuite-adapter/test/change_validator.test.ts
@@ -31,13 +31,13 @@ const DEFAULT_OPTIONS = {
     exclude: { features: [], objects: [] },
   },
   deployReferencedElements: false,
+  filtersRunner: {
+    preDeploy: jest.fn(),
+  } as unknown as Required<Filter>,
 }
 
 jest.mock('../src/change_validators/client_validation')
 const netsuiteClientValidationMock = netsuiteClientValidation as jest.Mock
-const mockFiltersRunner = {
-  preDeploy: jest.fn(),
-} as unknown as Required<Filter>
 
 describe('change validator', () => {
   const file = fileType()
@@ -58,7 +58,7 @@ describe('change validator', () => {
     describe('without SuiteApp', () => {
       it('should have change error when removing an instance with file cabinet type', async () => {
         const changeValidator = getChangeValidator(
-          { ...DEFAULT_OPTIONS, client, fetchByQuery, filtersRunner: mockFiltersRunner }
+          { ...DEFAULT_OPTIONS, client, fetchByQuery }
         )
         const instance = new InstanceElement('test', file)
         const changeErrors = await changeValidator([toChange({ before: instance })])
@@ -76,7 +76,6 @@ describe('change validator', () => {
             withSuiteApp: true,
             client,
             fetchByQuery,
-            filtersRunner: mockFiltersRunner,
           }
         )
         const instance = new InstanceElement('test', file)
@@ -110,10 +109,8 @@ describe('change validator', () => {
       const changeErrors = await getChangeValidator(
         {
           ...DEFAULT_OPTIONS,
-          withSuiteApp: true,
           client,
           fetchByQuery,
-          filtersRunner: mockFiltersRunner,
         }
       )([change])
       expect(changeErrors).toHaveLength(0)
@@ -125,7 +122,6 @@ describe('change validator', () => {
           warnStaleData: true,
           client,
           fetchByQuery,
-          filtersRunner: mockFiltersRunner,
         }
       )([change])
       expect(changeErrors).toHaveLength(1)
@@ -139,10 +135,8 @@ describe('change validator', () => {
       await getChangeValidator(
         {
           ...DEFAULT_OPTIONS,
-          withSuiteApp: true,
           client,
           fetchByQuery,
-          filtersRunner: mockFiltersRunner,
         }
       )([toChange({ after: new InstanceElement('test', file) })])
       expect(netsuiteClientValidationMock).not.toHaveBeenCalled()
@@ -155,14 +149,13 @@ describe('change validator', () => {
           client,
           fetchByQuery,
           validate: true,
-          filtersRunner: mockFiltersRunner,
         }
       )(changes)
       expect(netsuiteClientValidationMock).toHaveBeenCalledWith(
         changes,
         client,
         DEFAULT_OPTIONS.additionalDependencies,
-        mockFiltersRunner,
+        DEFAULT_OPTIONS.filtersRunner,
         DEFAULT_OPTIONS.deployReferencedElements,
       )
     })

--- a/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
@@ -51,6 +51,7 @@ describe('client validation', () => {
     ]
   })
   it('should not have errors', async () => {
+    mockValidate.mockReturnValue([])
     const changeErrors = await clientValidation(
       changes, client, {} as unknown as AdditionalDependencies
     )
@@ -58,9 +59,9 @@ describe('client validation', () => {
   })
   it('should have SDF Objects Validation Error for instance', async () => {
     const detailedMessage = 'error on objectName'
-    mockValidate.mockRejectedValue(
-      new ObjectsValidationError('error message', new Map([['objectName', detailedMessage]]))
-    )
+    mockValidate.mockReturnValue([
+      new ObjectsValidationError('error message', new Map([['objectName', detailedMessage]])),
+    ])
     const changeErrors = await clientValidation(
       changes, client, {} as unknown as AdditionalDependencies
     )
@@ -74,9 +75,9 @@ describe('client validation', () => {
   })
   it('should have SDF Objects Validation Error for customRecordType', async () => {
     const detailedMessage = 'error on customrecord1'
-    mockValidate.mockRejectedValue(
-      new ObjectsValidationError('error message', new Map([['customrecord1', detailedMessage]]))
-    )
+    mockValidate.mockReturnValue([
+      new ObjectsValidationError('error message', new Map([['customrecord1', detailedMessage]])),
+    ])
     const changeErrors = await clientValidation(
       changes, client, {} as unknown as AdditionalDependencies
     )
@@ -90,7 +91,7 @@ describe('client validation', () => {
   })
   it('should have SDF Manifest Validation Error', async () => {
     const detailedMessage = 'manifest error'
-    mockValidate.mockRejectedValue(new ManifestValidationError(detailedMessage))
+    mockValidate.mockReturnValue([new ManifestValidationError(detailedMessage)])
     const changeErrors = await clientValidation(
       changes, client, {} as unknown as AdditionalDependencies
     )
@@ -104,7 +105,7 @@ describe('client validation', () => {
   })
   it('should have general Validation Error', async () => {
     const detailedMessage = 'some error'
-    mockValidate.mockRejectedValue(new Error(detailedMessage))
+    mockValidate.mockReturnValue([new Error(detailedMessage)])
     const changeErrors = await clientValidation(
       changes, client, {} as unknown as AdditionalDependencies
     )

--- a/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
@@ -43,7 +43,7 @@ describe('client validation', () => {
         after: new InstanceElement(
           'instanceName',
           workflowType().type,
-          { [SCRIPT_ID]: 'objectName' }
+          { [SCRIPT_ID]: 'object_name' }
         ),
       }), toChange({
         after: new ObjectType({
@@ -64,14 +64,14 @@ describe('client validation', () => {
     expect(changeErrors).toHaveLength(0)
   })
   it('should have SDF Objects Validation Error for instance', async () => {
-    const detailedMessage = 'Details: The isparent field must be set to a valid Boolean value'
+    const detailedMessage = 'Details: The isparent field must be set to a valid Boolean value, \'T\' or \'F\'.'
     const fullErrorMessage = `validation failed.
-An error occurred during custom object validation. (objectName)
-${detailedMessage}, 'T' or 'F'.
-File: ~/Objects/objectName.xml`
+An error occurred during custom object validation. (object_name)
+${detailedMessage}
+File: ~/Objects/object_name.xml`
 
     mockValidate.mockReturnValue([
-      new ObjectsDeployError(fullErrorMessage, new Set(['objectName'])),
+      new ObjectsDeployError(fullErrorMessage, new Set(['object_name'])),
     ])
     const changeErrors = await clientValidation(
       changes, client, {} as unknown as AdditionalDependencies, mockFiltersRunner
@@ -85,11 +85,11 @@ File: ~/Objects/objectName.xml`
     })
   })
   it('should have SDF Objects Validation Error for customRecordType', async () => {
-    const detailedMessage = 'Details: The isparent field must be set to a valid Boolean value'
+    const detailedMessage = 'Details: The isparent field must be set to a valid Boolean value, \'T\' or \'F\'.'
     const fullErrorMessage = `validation failed.
-An error occurred during custom object validation. (objectName)
-${detailedMessage}, 'T' or 'F'.
-File: ~/Objects/objectName.xml`
+An error occurred during custom object validation. (customrecord1)
+${detailedMessage}
+File: ~/Objects/customrecord1.xml`
     mockValidate.mockReturnValue([
       new ObjectsDeployError(fullErrorMessage, new Set(['customrecord1'])),
     ])

--- a/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
@@ -69,7 +69,7 @@ describe('client validation', () => {
       detailedMessage,
       elemID: getChangeData(changes[0]).elemID,
       message: 'SDF Objects Validation Error',
-      severity: 'Warning',
+      severity: 'Error',
     })
   })
   it('should have SDF Objects Validation Error for customRecordType', async () => {
@@ -85,7 +85,7 @@ describe('client validation', () => {
       detailedMessage,
       elemID: getChangeData(changes[1]).elemID,
       message: 'SDF Objects Validation Error',
-      severity: 'Warning',
+      severity: 'Error',
     })
   })
   it('should have SDF Manifest Validation Error', async () => {
@@ -99,7 +99,7 @@ describe('client validation', () => {
       detailedMessage,
       elemID: getChangeData(changes[0]).elemID,
       message: 'SDF Manifest Validation Error',
-      severity: 'Warning',
+      severity: 'Error',
     })
   })
   it('should have general Validation Error', async () => {
@@ -113,7 +113,7 @@ describe('client validation', () => {
       detailedMessage,
       elemID: getChangeData(changes[0]).elemID,
       message: 'Validation Error on SDF',
-      severity: 'Warning',
+      severity: 'Error',
     })
   })
 })

--- a/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
@@ -19,7 +19,7 @@ import { CUSTOM_RECORD_TYPE, METADATA_TYPE, NETSUITE, SCRIPT_ID } from '../../sr
 import clientValidation from '../../src/change_validators/client_validation'
 import NetsuiteClient from '../../src/client/client'
 import { AdditionalDependencies } from '../../src/client/types'
-import { ManifestValidationError, ObjectsDeployError } from '../../src/errors'
+import { ManifestValidationError, ObjectsDeployError, SettingsDeployError } from '../../src/errors'
 import { workflowType } from '../../src/autogen/types/standard_types/workflow'
 
 describe('client validation', () => {
@@ -136,6 +136,21 @@ File: ~/Objects/customrecord1.xml`
       detailedMessage,
       elemID: getChangeData(changes[0]).elemID,
       message: 'Validation Error on SDF',
+      severity: 'Error',
+    })
+  })
+
+  it('should have settings deploy error', async () => {
+    const detailedMessage = 'Validation of account settings failed.'
+    mockValidate.mockReturnValue([new SettingsDeployError(`${detailedMessage}`, new Set(['workflow']))])
+    const changeErrors = await clientValidation(
+      changes, client, {} as unknown as AdditionalDependencies, mockFiltersRunner
+    )
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0]).toEqual({
+      detailedMessage,
+      elemID: getChangeData(changes[0]).elemID,
+      message: 'SDF Settings Validation Error',
       severity: 'Error',
     })
   })

--- a/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
@@ -64,12 +64,15 @@ describe('client validation', () => {
     expect(changeErrors).toHaveLength(0)
   })
   it('should have SDF Objects Validation Error for instance', async () => {
-    const detailedMessage = 'Details: The isparent field must be set to a valid Boolean value, \'T\' or \'F\'.'
-    const fullErrorMessage = `validation failed.
-An error occurred during custom object validation. (object_name)
-${detailedMessage}
+    const detailedMessage = `An error occurred during custom object validation. (object_name)
+Details: The object field daterange is missing.
+Details: The object field kpi must not be OPENJOBS.
+Details: The object field periodrange is missing.
+Details: The object field compareperiodrange is missing.
+Details: The object field defaultgeneraltype must not be ENTITY_ENTITY_NAME.
+Details: The object field type must not be 449.
 File: ~/Objects/object_name.xml`
-
+    const fullErrorMessage = `Validation failed.\n\n${detailedMessage}`
     mockValidate.mockReturnValue([
       new ObjectsDeployError(fullErrorMessage, new Set(['object_name'])),
     ])
@@ -85,11 +88,15 @@ File: ~/Objects/object_name.xml`
     })
   })
   it('should have SDF Objects Validation Error for customRecordType', async () => {
-    const detailedMessage = 'Details: The isparent field must be set to a valid Boolean value, \'T\' or \'F\'.'
-    const fullErrorMessage = `validation failed.
-An error occurred during custom object validation. (customrecord1)
-${detailedMessage}
+    const detailedMessage = `An error occurred during custom object validation. (customrecord1)
+Details: The object field daterange is missing.
+Details: The object field kpi must not be OPENJOBS.
+Details: The object field periodrange is missing.
+Details: The object field compareperiodrange is missing.
+Details: The object field defaultgeneraltype must not be ENTITY_ENTITY_NAME.
+Details: The object field type must not be 449.
 File: ~/Objects/customrecord1.xml`
+    const fullErrorMessage = `Validation failed.\n\n${detailedMessage}`
     mockValidate.mockReturnValue([
       new ObjectsDeployError(fullErrorMessage, new Set(['customrecord1'])),
     ])

--- a/packages/netsuite-adapter/test/client/client.test.ts
+++ b/packages/netsuite-adapter/test/client/client.test.ts
@@ -159,7 +159,8 @@ describe('NetsuiteClient', () => {
               additionalDependencies: {
                 exclude: { features: [], objects: [] }, include: { features: [], objects: [] },
               },
-            }
+              validateOnly: false,
+            },
           )
         })
         it('should transform field to customrecordtype instance', async () => {
@@ -195,7 +196,8 @@ describe('NetsuiteClient', () => {
               additionalDependencies: {
                 exclude: { features: [], objects: [] }, include: { features: [], objects: [] },
               },
-            }
+              validateOnly: false,
+            },
           )
         })
         it('should try again to deploy after ObjectsDeployError field fail', async () => {

--- a/packages/netsuite-adapter/test/client/client.test.ts
+++ b/packages/netsuite-adapter/test/client/client.test.ts
@@ -323,7 +323,7 @@ describe('NetsuiteClient', () => {
             values: { scriptid: 'someObject' },
           }],
           undefined,
-          { additionalDependencies: validateParams[1], validateOnly: true }
+          { additionalDependencies: validateParams[1] }
         )
       })
       it('should skip validation', async () => {

--- a/packages/netsuite-adapter/test/client/client.test.ts
+++ b/packages/netsuite-adapter/test/client/client.test.ts
@@ -323,7 +323,7 @@ describe('NetsuiteClient', () => {
             values: { scriptid: 'someObject' },
           }],
           undefined,
-          { additionalDependencies: validateParams[1] }
+          { additionalDependencies: validateParams[1], validateOnly: true }
         )
       })
       it('should skip validation', async () => {

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -33,7 +33,7 @@ import SdfClient, {
 import { CustomizationInfo, CustomTypeInfo, FileCustomizationInfo, FolderCustomizationInfo, SdfDeployParams, TemplateCustomTypeInfo } from '../../src/client/types'
 import { fileCabinetTopLevelFolders } from '../../src/client/constants'
 import { DEFAULT_COMMAND_TIMEOUT_IN_MINUTES } from '../../src/config'
-import { FeaturesDeployError, ObjectsDeployError, SettingsDeployError } from '../../src/errors'
+import { FeaturesDeployError, ManifestValidationError, ObjectsDeployError, SettingsDeployError } from '../../src/errors'
 
 const DEFAULT_DEPLOY_PARAMS: [undefined, SdfDeployParams] = [
   undefined,
@@ -1833,7 +1833,7 @@ Details: The manifest contains a dependency on ${errorReferenceName} object, but
           // should throw before this test
           expect(false).toBeTruthy()
         } catch (e) {
-          expect(e instanceof SettingsDeployError).toBeTruthy()
+          expect(e instanceof ManifestValidationError).toBeTruthy()
           expect(e.message).toContain(manifestErrorMessage)
         }
       })

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -1747,7 +1747,7 @@ File: ~/AccountConfiguration/features.xml`
       })
       it('should throw ObjectsValidationError', async () => {
         let errorMessage: string
-        const objectErrorMessage = 'An error occurred during custom object validation. (failObject)'
+        const objectErrorMessage = 'An error occurred during custom object validation. Details: The availableexternally field must be set to a valid Boolean value, \'T\' or \'F\'.'
         mockExecuteAction.mockImplementation(context => {
           if (context.commandName === COMMANDS.CREATE_PROJECT) {
             return Promise.resolve({ isSuccess: () => true })

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -33,7 +33,7 @@ import SdfClient, {
 import { CustomizationInfo, CustomTypeInfo, FileCustomizationInfo, FolderCustomizationInfo, SdfDeployParams, TemplateCustomTypeInfo } from '../../src/client/types'
 import { fileCabinetTopLevelFolders } from '../../src/client/constants'
 import { DEFAULT_COMMAND_TIMEOUT_IN_MINUTES } from '../../src/config'
-import { FeaturesDeployError, ManifestValidationError, ObjectsDeployError, ObjectsValidationError, SettingsDeployError } from '../../src/errors'
+import { FeaturesDeployError, ManifestValidationError, ObjectsDeployError, SettingsDeployError } from '../../src/errors'
 
 const DEFAULT_DEPLOY_PARAMS: [undefined, SdfDeployParams] = [
   undefined,
@@ -1795,7 +1795,6 @@ File: ~/AccountConfiguration/features.xml`
       })
       it('should throw ObjectsValidationError', async () => {
         let errorMessage: string
-        const objectErrorMessage = 'An error occurred during custom object validation. Details: The availableexternally field must be set to a valid Boolean value, \'T\' or \'F\'.'
         mockExecuteAction.mockImplementation(context => {
           if (context.commandName === COMMANDS.CREATE_PROJECT) {
             return Promise.resolve({ isSuccess: () => true })
@@ -1834,9 +1833,9 @@ File: ~/Objects/${failObject}.xml`
           // should throw before this test
           expect(false).toBeTruthy()
         } catch (e) {
-          expect(e instanceof ObjectsValidationError).toBeTruthy()
-          expect(e.invalidObjects instanceof Map).toBeTruthy()
-          expect(e.invalidObjects.get(failObject)).toContain(objectErrorMessage)
+          expect(e instanceof ObjectsDeployError).toBeTruthy()
+          expect(e.failedObjects instanceof Set).toBeTruthy()
+          expect(e.failedObjects.has(failObject)).toBeTruthy()
         }
       })
       it('should throw ManifestValidationError', async () => {
@@ -1883,7 +1882,7 @@ Details: The manifest contains a dependency on ${errorReferenceName} object, but
           expect(false).toBeTruthy()
         } catch (e) {
           expect(e instanceof ManifestValidationError).toBeTruthy()
-          expect(e.message).toEqual(manifestErrorMessage)
+          expect(e.message).toContain(manifestErrorMessage)
         }
       })
       it('should throw error', async () => {

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -1324,6 +1324,54 @@ describe('sdf client', () => {
         await expect(client.deploy([{} as CustomTypeInfo], ...DEFAULT_DEPLOY_PARAMS)).rejects
           .toThrow(new Error(errorMessage))
       })
+      it('should throw ObjectsDeployError when deploy failed on object validation', async () => {
+        const errorMessage = `
+The deployment process has encountered an error.
+Deploying to TSTDRV2259448 - Salto Extended Dev - Administrator.
+2022-03-31 05:36:02 (PST) Installation started
+Info -- Account [(PRODUCTION) Salto Extended Dev]
+Info -- Account Customization Project [TempSdfProject-5492f41d-307d-4fc9-bc78-ef0834e9a197]
+Info -- Framework Version [1.0]
+Validate manifest -- Success
+Validate deploy file -- Success
+Validate configuration -- Success
+Validate objects -- Failed
+Validate files -- Success
+Validate folders -- Success
+Validate translation imports -- Success
+Validation of referenceability from custom objects to translations collection strings in progress. -- Success
+Validate preferences -- Success
+Validate flags -- Success
+Validate for circular dependencies -- Success
+*** ERROR ***
+Validation failed.
+
+An error occurred during custom object validation. (custform_114_t1441298_782)
+File: ~/Objects/custform_114_t1441298_782.xml
+        `
+        mockExecuteAction.mockImplementation(({ commandName }) => {
+          if (commandName === COMMANDS.DEPLOY_PROJECT) {
+            throw errorMessage
+          }
+          return { isSuccess: () => true }
+        })
+        let isRejected: boolean
+        try {
+          await client.deploy([{
+            typeName: 'typeName',
+            values: {
+              key: 'val',
+            },
+            scriptId: 'scriptId',
+          } as CustomTypeInfo], ...DEFAULT_DEPLOY_PARAMS)
+          isRejected = false
+        } catch (e) {
+          isRejected = true
+          expect(e instanceof ObjectsDeployError).toBeTruthy()
+          expect(e instanceof ObjectsDeployError && e.failedObjects).toEqual(new Set(['custform_114_t1441298_782']))
+        }
+        expect(isRejected).toBe(true)
+      })
 
       it('should throw ObjectsDeployError when deploy failed with error object message', async () => {
         const errorMessage = `


### PR DESCRIPTION
_SDF client validation changed to run server-side_

---

_None_

---
_Release Notes_: 
_Netsuite adapter_:
* Client validation now runs server side by default
* client_validation changeErrors severity changed to 'Error' from 'Warning'
* only ObjectValidation and manifestValidation Errors are supported, other validation errors are classified as 'SDF validation error'

---
_User Notifications_: 
_None_
