### PR TITLE
Salto 2572 handle article bodies

### DIFF
--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -468,7 +468,7 @@ export default class ZendeskAdapter implements AdapterOperations {
           subdomainToGuideChanges[subdomain]
         )
         const guideChangesBeforeRestore = [...brandDeployResults.appliedChanges]
-        await runner.onDeploy(guideChangesBeforeRestore)
+        await brandRunner.onDeploy(guideChangesBeforeRestore)
 
         return {
           appliedChanges: guideChangesBeforeRestore,

--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -81,6 +81,7 @@ import referencedIdFieldsFilter from './filters/referenced_id_fields'
 import brandLogoFilter from './filters/brand_logo'
 import removeBrandLogoFieldFilter from './filters/remove_brand_logo_field'
 import articleFilter from './filters/article'
+import articleBodyFilter from './filters/article_body'
 import { getConfigFromConfigChanges } from './config_change'
 import { dependencyChanger } from './dependency_changers'
 import customFieldOptionsFilter from './filters/add_restriction'
@@ -139,6 +140,7 @@ export const DEFAULT_FILTERS = [
   removeBrandLogoFieldFilter,
   // help center filters need to be before fieldReferencesFilter (assume fields are strings)
   articleFilter,
+  articleBodyFilter,
   hcSectionCategoryFilter,
   hcTranslationFilter,
   fieldReferencesFilter,

--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -140,7 +140,6 @@ export const DEFAULT_FILTERS = [
   removeBrandLogoFieldFilter,
   // help center filters need to be before fieldReferencesFilter (assume fields are strings)
   articleFilter,
-  articleBodyFilter,
   hcSectionCategoryFilter,
   hcTranslationFilter,
   fieldReferencesFilter,
@@ -160,6 +159,7 @@ export const DEFAULT_FILTERS = [
   referencedIdFieldsFilter,
   // need to be after referencedIdFieldsFilter as 'name' is removed
   fetchCategorySection,
+  articleBodyFilter,
   serviceUrlFilter,
   ...ducktypeCommonFilters,
   handleAppInstallationsFilter,

--- a/packages/zendesk-adapter/src/change_validators/translation_for_default_locale.ts
+++ b/packages/zendesk-adapter/src/change_validators/translation_for_default_locale.ts
@@ -74,7 +74,6 @@ export const translationForDefaultLocaleValidator: ChangeValidator = async chang
       elemID: instance.elemID,
       severity: 'Error',
       message: `${instance.elemID.typeName} instance does not have a translation for the source locale`,
-      detailedMessage: `${instance.elemID.typeName} instance "${instance.elemID.name}" must have a \
-      translation for the source locale ${instance.value.source_locale}`,
+      detailedMessage: `${instance.elemID.typeName} instance "${instance.elemID.name}" must have a translation for the source locale ${instance.value.source_locale}`,
     }])
 }

--- a/packages/zendesk-adapter/src/change_validators/translation_for_default_locale.ts
+++ b/packages/zendesk-adapter/src/change_validators/translation_for_default_locale.ts
@@ -74,7 +74,7 @@ export const translationForDefaultLocaleValidator: ChangeValidator = async chang
       elemID: instance.elemID,
       severity: 'Error',
       message: `${instance.elemID.typeName} instance does not have a translation for the source locale`,
-      detailedMessage: `${instance.elemID.typeName} instance "${instance.elemID.name}" must have a 
+      detailedMessage: `${instance.elemID.typeName} instance "${instance.elemID.name}" must have a \
       translation for the source locale ${instance.value.source_locale}`,
     }])
 }

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -1627,6 +1627,7 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
         { fieldName: 'vote_sum' },
         { fieldName: 'vote_count' },
         { fieldName: 'edited_at' },
+        { fieldName: 'body' },
         { fieldName: 'html_url', fieldType: 'string' },
       ),
       serviceUrl: '/knowledge/articles/{id}',

--- a/packages/zendesk-adapter/src/filters/article_body.ts
+++ b/packages/zendesk-adapter/src/filters/article_body.ts
@@ -1,0 +1,66 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import {
+  InstanceElement, isInstanceElement,
+} from '@salto-io/adapter-api'
+import { FilterCreator } from '../filter'
+import { ARTICLE_TYPE_NAME, BRAND_TYPE_NAME } from '../constants'
+
+const ARTICLE_TYPES = [ARTICLE_TYPE_NAME, 'article_translation']
+const BODY_FIELD = 'body'
+
+const ARTICLE_REF_URL_REGEX = /(https:\/\/.*\.zendesk\.com\/hc\/.*\/articles\/\d*)/g
+const BASE_URL_REGEX = /(https:\/\/.*\.zendesk\.com)/
+
+const referenceArticleUrl = (articleUrl: string, brandInstances: InstanceElement[]): string => {
+  const brand = brandInstances
+    .find(brandInstance => brandInstance.value.brand_url === articleUrl.match(BASE_URL_REGEX))
+  return `\${${brand?.elemID.getFullName()}}/hc...`
+}
+
+const updateArticleBody = (
+  articleInstace: InstanceElement,
+  brandInstances: InstanceElement[],
+): void => {
+  const originalArticleBody = articleInstace.value[BODY_FIELD]
+  if (!_.isString(originalArticleBody)) {
+    return
+  }
+  const processedArticleBody = originalArticleBody.replaceAll(
+    ARTICLE_REF_URL_REGEX,
+    articleUrl => referenceArticleUrl(articleUrl, brandInstances),
+  )
+  articleInstace.value.body = processedArticleBody
+}
+
+/**
+ * Process body value in article instances to reference other objects
+ */
+const filterCreator: FilterCreator = () => ({
+  onFetch: async elements => {
+    const brandInstances = elements
+      .filter(isInstanceElement)
+      .filter(e => e.elemID.typeName === BRAND_TYPE_NAME)
+    elements
+      .filter(isInstanceElement)
+      .filter(instance => ARTICLE_TYPES.includes(instance.elemID.typeName))
+      .filter(articleInstance => !_.isEmpty(articleInstance.value[BODY_FIELD]))
+      .forEach(articleInstance => updateArticleBody(articleInstance, brandInstances))
+  },
+})
+
+export default filterCreator

--- a/packages/zendesk-adapter/src/filters/article_body.ts
+++ b/packages/zendesk-adapter/src/filters/article_body.ts
@@ -106,7 +106,7 @@ const filterCreator: FilterCreator = () => {
       await awu(changes)
         .filter(isAdditionOrModificationChange)
         .filter(isInstanceChange)
-        .filter(change => getChangeData(change).elemID.typeName === ARTICLE_TYPE_NAME)
+        .filter(change => ARTICLE_TYPES.includes(getChangeData(change).elemID.typeName))
         .forEach(async change => {
           await applyFunctionToChangeData<Change<InstanceElement>>(
             change,
@@ -126,7 +126,7 @@ const filterCreator: FilterCreator = () => {
       await awu(changes)
         .filter(isAdditionOrModificationChange)
         .filter(isInstanceChange)
-        .filter(change => getChangeData(change).elemID.typeName === ARTICLE_TYPE_NAME)
+        .filter(change => ARTICLE_TYPES.includes(getChangeData(change).elemID.typeName))
         .forEach(async change => {
           await applyFunctionToChangeData<Change<InstanceElement>>(
             change,

--- a/packages/zendesk-adapter/src/filters/article_body.ts
+++ b/packages/zendesk-adapter/src/filters/article_body.ts
@@ -69,7 +69,7 @@ const updateArticleBody = (
   const processedArticleBody = extractTemplate(
     originalArticleBody,
     [ARTICLE_REF_URL_REGEX],
-    articleUrl => referenceArticleUrl({ articleUrl, brandInstances, articleInstances}),
+    articleUrl => referenceArticleUrl({ articleUrl, brandInstances, articleInstances }),
   )
   articleInstace.value.body = processedArticleBody
 }

--- a/packages/zendesk-adapter/src/filters/article_body.ts
+++ b/packages/zendesk-adapter/src/filters/article_body.ts
@@ -32,13 +32,15 @@ const ARTICLE_REF_URL_REGEX = /(https:\/\/.*\.zendesk\.com\/hc\/.*\/articles\/\d
 const BASE_URL_REGEX = /(https:\/\/.*\.zendesk\.com)/
 const ARTICLE_ID_URL_REGEX = /\/articles\/(\d*)/
 
-// const BRANDS_SKIP_LIST = ['https://support.zendesk.com']
-
-const referenceArticleUrl = (
-  articleUrl: string,
-  brandInstances: InstanceElement[],
-  articleInstances: InstanceElement[],
-): TemplatePart[] => {
+const referenceArticleUrl = ({
+  articleUrl,
+  brandInstances,
+  articleInstances,
+}: {
+  articleUrl: string
+  brandInstances: InstanceElement[]
+  articleInstances: InstanceElement[]
+}): TemplatePart[] => {
   const urlSubdomain = articleUrl.match(BASE_URL_REGEX)?.pop()
   const urlBrand = brandInstances
     .find(brandInstance => brandInstance.value.brand_url === urlSubdomain)
@@ -67,7 +69,7 @@ const updateArticleBody = (
   const processedArticleBody = extractTemplate(
     originalArticleBody,
     [ARTICLE_REF_URL_REGEX],
-    expression => referenceArticleUrl(expression, brandInstances, articleInstances),
+    articleUrl => referenceArticleUrl({ articleUrl, brandInstances, articleInstances}),
   )
   articleInstace.value.body = processedArticleBody
 }
@@ -89,14 +91,12 @@ const filterCreator: FilterCreator = () => {
   const deployTemplateMapping: Record<string, TemplateExpression> = {}
   return {
     onFetch: async elements => {
-      const brandInstances = elements
-        .filter(isInstanceElement)
+      const instances = elements.filter(isInstanceElement)
+      const brandInstances = instances
         .filter(e => e.elemID.typeName === BRAND_TYPE_NAME)
-      const articleInstances = elements
-        .filter(isInstanceElement)
+      const articleInstances = instances
         .filter(e => e.elemID.typeName === ARTICLE_TYPE_NAME)
-      elements
-        .filter(isInstanceElement)
+      instances
         .filter(instance => ARTICLE_TYPES.includes(instance.elemID.typeName))
         .filter(articleInstance => !_.isEmpty(articleInstance.value[BODY_FIELD]))
         .forEach(articleInstance => (

--- a/packages/zendesk-adapter/test/change_validators/translation_for_default_locale.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/translation_for_default_locale.test.ts
@@ -120,8 +120,7 @@ describe('translationForDefaultLocaleValidator',
           elemID: invalidSectionInstance.elemID,
           severity: 'Error',
           message: `${invalidSectionInstance.elemID.typeName} instance does not have a translation for the source locale`,
-          detailedMessage: `${invalidSectionInstance.elemID.typeName} instance "${invalidSectionInstance.elemID.name}" must have a \
-          translation for the source locale ${invalidSectionInstance.value.source_locale.value.value.id}`,
+          detailedMessage: `${invalidSectionInstance.elemID.typeName} instance "${invalidSectionInstance.elemID.name}" must have a translation for the source locale ${invalidSectionInstance.value.source_locale.value.value.id}`,
         }])
       })
 
@@ -180,8 +179,7 @@ describe('translationForDefaultLocaleValidator',
           elemID: invalidArticleInstance.elemID,
           severity: 'Error',
           message: `${invalidArticleInstance.elemID.typeName} instance does not have a translation for the source locale`,
-          detailedMessage: `${invalidArticleInstance.elemID.typeName} instance "${invalidArticleInstance.elemID.name}" must have a \
-          translation for the source locale ${invalidArticleInstance.value.source_locale.value.value.id}`,
+          detailedMessage: `${invalidArticleInstance.elemID.typeName} instance "${invalidArticleInstance.elemID.name}" must have a translation for the source locale ${invalidArticleInstance.value.source_locale.value.value.id}`,
         }])
       })
 

--- a/packages/zendesk-adapter/test/change_validators/translation_for_default_locale.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/translation_for_default_locale.test.ts
@@ -120,8 +120,8 @@ describe('translationForDefaultLocaleValidator',
           elemID: invalidSectionInstance.elemID,
           severity: 'Error',
           message: `${invalidSectionInstance.elemID.typeName} instance does not have a translation for the source locale`,
-          detailedMessage: `${invalidSectionInstance.elemID.typeName} instance "${invalidSectionInstance.elemID.name}" must have a 
-      translation for the source locale ${invalidSectionInstance.value.source_locale.value.value.id}`,
+          detailedMessage: `${invalidSectionInstance.elemID.typeName} instance "${invalidSectionInstance.elemID.name}" must have a \
+          translation for the source locale ${invalidSectionInstance.value.source_locale.value.value.id}`,
         }])
       })
 
@@ -180,8 +180,8 @@ describe('translationForDefaultLocaleValidator',
           elemID: invalidArticleInstance.elemID,
           severity: 'Error',
           message: `${invalidArticleInstance.elemID.typeName} instance does not have a translation for the source locale`,
-          detailedMessage: `${invalidArticleInstance.elemID.typeName} instance "${invalidArticleInstance.elemID.name}" must have a 
-      translation for the source locale ${invalidArticleInstance.value.source_locale.value.value.id}`,
+          detailedMessage: `${invalidArticleInstance.elemID.typeName} instance "${invalidArticleInstance.elemID.name}" must have a \
+          translation for the source locale ${invalidArticleInstance.value.source_locale.value.value.id}`,
         }])
       })
 

--- a/packages/zendesk-adapter/test/filters/article_body.test.ts
+++ b/packages/zendesk-adapter/test/filters/article_body.test.ts
@@ -1,0 +1,160 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType,
+  BuiltinTypes, toChange, isInstanceElement, TemplateExpression, ReferenceExpression } from '@salto-io/adapter-api'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import filterCreator from '../../src/filters/article_body'
+import ZendeskClient from '../../src/client/client'
+import { paginate } from '../../src/client/pagination'
+import { DEFAULT_CONFIG } from '../../src/config'
+import { ARTICLE_TYPE_NAME, BRAND_TYPE_NAME, ZENDESK } from '../../src/constants'
+
+describe('article body filter', () => {
+  let client: ZendeskClient
+  type FilterType = filterUtils.FilterWith<'onFetch' | 'onDeploy' | 'preDeploy'>
+  let filter: FilterType
+
+  beforeAll(() => {
+    client = new ZendeskClient({
+      credentials: { username: 'a', password: 'b', subdomain: 'c' },
+    })
+    filter = filterCreator({
+      client,
+      paginator: clientUtils.createPaginator({
+        client,
+        paginationFuncCreator: paginate,
+      }),
+      config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
+    }) as FilterType
+  })
+
+  const brandType = new ObjectType({
+    elemID: new ElemID(ZENDESK, BRAND_TYPE_NAME),
+    fields: {
+      id: { refType: BuiltinTypes.NUMBER },
+      brand_url: { refType: BuiltinTypes.STRING },
+    },
+  })
+  const articleType = new ObjectType({
+    elemID: new ElemID(ZENDESK, ARTICLE_TYPE_NAME),
+    fields: {
+      id: { refType: BuiltinTypes.NUMBER },
+    },
+  })
+  const articleTranslationType = new ObjectType({
+    elemID: new ElemID(ZENDESK, 'article_translation'),
+    fields: {
+      id: { refType: BuiltinTypes.NUMBER },
+      body: { refType: BuiltinTypes.STRING },
+    },
+  })
+
+  const brandInstance = new InstanceElement(
+    'brand1',
+    brandType,
+    // eslint-disable-next-line no-template-curly-in-string
+    { id: 7777, brand_url: 'https://coolSubdomain.zendesk.com' },
+  )
+  const articleInstance = new InstanceElement(
+    'refArticle',
+    articleType,
+    // eslint-disable-next-line no-template-curly-in-string
+    { id: 1666 },
+  )
+  const templatedTranslationInstance = new InstanceElement(
+    'article1',
+    articleTranslationType,
+    // eslint-disable-next-line no-template-curly-in-string
+    { id: 1003, body: '<p><a href="https://coolSubdomain.zendesk.com/hc/en-us/articles/1666" target="_self">linkedArticle</a></p>kjdsahjkdshjkdsjkh\n<a href="https://coolSubdomain.zendesk.com/hc/en-us/articles/1666' },
+  )
+  const nonTemplatedTranslationInstance = new InstanceElement(
+    'article2',
+    articleTranslationType,
+    // eslint-disable-next-line no-template-curly-in-string
+    { id: 1004, body: '<a href="https://coolSubdomain.zendesk.com/hc/en-us/nonarticles/1666" target="_self">linkedArticle</a>' },
+  )
+
+
+  const generateElements = (): (InstanceElement | ObjectType)[] => ([
+    brandInstance, articleInstance, templatedTranslationInstance, nonTemplatedTranslationInstance,
+  ]).map(element => element.clone())
+
+  describe('on fetch', () => {
+    let elements: (InstanceElement | ObjectType)[]
+
+    beforeAll(async () => {
+      elements = generateElements()
+      await filter.onFetch(elements)
+    })
+
+
+    it('should add templates correctly', () => {
+      const fetchedTranslation1 = elements.filter(isInstanceElement).find(i => i.elemID.name === 'article1')
+      // eslint-disable-next-line no-template-curly-in-string
+      expect(fetchedTranslation1?.value.body).toEqual(new TemplateExpression({ parts: [
+        '<p><a href="',
+        new ReferenceExpression(brandInstance.elemID.createNestedID('brand_url'), brandInstance.value.brand_url),
+        '/hc/en-us/articles/',
+        new ReferenceExpression(articleInstance.elemID, articleInstance),
+        '" target="_self">linkedArticle</a></p>kjdsahjkdshjkdsjkh\n<a href="',
+        new ReferenceExpression(brandInstance.elemID.createNestedID('brand_url'), brandInstance.value.brand_url),
+        '/hc/en-us/articles/',
+        new ReferenceExpression(articleInstance.elemID, articleInstance),
+      ] }))
+    })
+    it('should resolve non-template normally', () => {
+      const fetchedTranslation2 = elements.filter(isInstanceElement).find(i => i.elemID.name === 'article2')
+      expect(fetchedTranslation2?.value.body).toEqual('<a href="https://coolSubdomain.zendesk.com/hc/en-us/nonarticles/1666" target="_self">linkedArticle</a>')
+    })
+  })
+  describe('preDeploy', () => {
+    let elementsBeforeFetch: (InstanceElement | ObjectType)[]
+    let elementsAfterPreDeploy: (InstanceElement | ObjectType)[]
+
+    beforeAll(async () => {
+      elementsBeforeFetch = generateElements()
+      const elementsAfterFetch = elementsBeforeFetch.map(e => e.clone())
+      await filter.onFetch(elementsAfterFetch)
+      elementsAfterPreDeploy = elementsAfterFetch.map(e => e.clone())
+      await filter.preDeploy(elementsAfterPreDeploy.map(e => toChange({ before: e, after: e })))
+    })
+
+    it('Returns elements to origin after predeploy', () => {
+      expect(elementsAfterPreDeploy).toEqual(elementsBeforeFetch)
+    })
+  })
+
+  describe('onDeploy', () => {
+    let elementsAfterFetch: (InstanceElement | ObjectType)[]
+    let elementsAfterOnDeploy: (InstanceElement | ObjectType)[]
+
+    beforeAll(async () => {
+      // we recreate feth and onDeploy to have the templates in place to be restored by onDeploy
+      const elementsBeforeFetch = generateElements()
+      elementsAfterFetch = elementsBeforeFetch.map(e => e.clone())
+      await filter.onFetch(elementsAfterFetch)
+      const elementsAfterPreDeploy = elementsAfterFetch.map(e => e.clone())
+      await filter.preDeploy(elementsAfterPreDeploy.map(e => toChange({ before: e, after: e })))
+      elementsAfterOnDeploy = elementsAfterPreDeploy.map(e => e.clone())
+      await filter.onDeploy(elementsAfterOnDeploy.map(e => toChange({ before: e, after: e })))
+    })
+
+    it('Returns elements to after fetch state (with templates) after onDeploy', () => {
+      expect(elementsAfterOnDeploy).toEqual(elementsAfterFetch)
+    })
+  })
+})


### PR DESCRIPTION
Adding a Zendesk filter of creating templateExpressions in article body values

To Do:

- [ ] add UT
- [x] support article_translations

---

_Additional context for reviewer_
* Bugfix of not running the `onDeploy` filters has been added

---
_Release Notes_: 
* Support multi-env article bodies.

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
