### PR TITLE
Fix getRelativeID for nested ids in fields

### DIFF
--- a/packages/adapter-api/src/element_id.ts
+++ b/packages/adapter-api/src/element_id.ts
@@ -281,7 +281,7 @@ export class ElemID {
       } - ${this.getFullName()} is not parent of ${other.getFullName()}`)
     }
     const relPath = other.createTopLevelParentID().path.slice(this.nestingLevel)
-    return ['attr', 'annotation', 'field'].includes(other.idType)
+    return this.idType === 'type' && ['attr', 'annotation', 'field'].includes(other.idType)
       ? [other.idType as string].concat(relPath)
       : relPath
   }

--- a/packages/adapter-api/test/elements.test.ts
+++ b/packages/adapter-api/test/elements.test.ts
@@ -441,6 +441,12 @@ describe('Test elements.ts', () => {
         const nestedID = elemID.createNestedID(...nested)
         expect(elemID.getRelativePath(nestedID)).toEqual(nested)
       })
+      it('should return the correct relative path - both nested in field', () => {
+        const nested = ['b', 'c']
+        const elemID = new ElemID('adapter', 'typeName', 'field', 'test', 'a')
+        const nestedID = elemID.createNestedID(...nested)
+        expect(elemID.getRelativePath(nestedID)).toEqual(nested)
+      })
       it('should return the correct relative path - field', () => {
         const elemID = new ElemID('adapter', 'typeName')
         const nestedID = new ElemID('adapter', 'typeName', 'field', 'f1')


### PR DESCRIPTION


---

Old code would add `field` even if "this" element ID was already a field :(

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_