### PR TITLE
Zendesk - use generic createFilterCreatorParams in the tests

### DIFF
--- a/packages/zendesk-adapter/test/filters/account_settings.test.ts
+++ b/packages/zendesk-adapter/test/filters/account_settings.test.ts
@@ -17,7 +17,6 @@ import {
   ObjectType, ElemID, InstanceElement,
 } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
-import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/account_settings'
 import { createFilterCreatorParams } from '../utils'
@@ -35,7 +34,6 @@ jest.mock('@salto-io/adapter-components', () => {
 })
 
 describe('account settings filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'deploy'>
   let filter: FilterType
   const accountSettings = new InstanceElement(
@@ -59,10 +57,7 @@ describe('account settings filter', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks()
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
   it('should remove autorouting_tag if it is empty', async () => {
     const clonedAfter = accountSettings.clone()

--- a/packages/zendesk-adapter/test/filters/account_settings.test.ts
+++ b/packages/zendesk-adapter/test/filters/account_settings.test.ts
@@ -16,12 +16,11 @@
 import {
   ObjectType, ElemID, InstanceElement,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG } from '../../src/config'
+import { filterUtils } from '@salto-io/adapter-components'
 import ZendeskClient from '../../src/client/client'
-import { paginate } from '../../src/client/pagination'
 import { ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/account_settings'
+import { createFilterCreatorParams } from '../utils'
 
 const mockDeployChange = jest.fn()
 jest.mock('@salto-io/adapter-components', () => {
@@ -63,15 +62,7 @@ describe('account settings filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
   it('should remove autorouting_tag if it is empty', async () => {
     const clonedAfter = accountSettings.clone()

--- a/packages/zendesk-adapter/test/filters/add_field_options.test.ts
+++ b/packages/zendesk-adapter/test/filters/add_field_options.test.ts
@@ -16,14 +16,13 @@
 import {
   ObjectType, ElemID, InstanceElement, toChange,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG } from '../../src/config'
+import { filterUtils } from '@salto-io/adapter-components'
 import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
-import { paginate } from '../../src/client/pagination'
 import filterCreator from '../../src/filters/add_field_options'
 import { CUSTOM_FIELD_OPTIONS_FIELD_NAME, ORG_FIELD_TYPE_NAME } from '../../src/filters/organization_field'
 import { USER_FIELD_TYPE_NAME } from '../../src/filters/custom_field_options/user_field'
+import { createFilterCreatorParams } from '../utils'
 
 describe('add field options filter', () => {
   let client: ZendeskClient
@@ -35,15 +34,7 @@ describe('add field options filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
   describe('preDeploy', () => {
     it.each([USER_FIELD_TYPE_NAME, ORG_FIELD_TYPE_NAME])('should add null as id for new childs of %s', async fieldTypeName => {

--- a/packages/zendesk-adapter/test/filters/add_field_options.test.ts
+++ b/packages/zendesk-adapter/test/filters/add_field_options.test.ts
@@ -17,7 +17,6 @@ import {
   ObjectType, ElemID, InstanceElement, toChange,
 } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
-import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/add_field_options'
 import { CUSTOM_FIELD_OPTIONS_FIELD_NAME, ORG_FIELD_TYPE_NAME } from '../../src/filters/organization_field'
@@ -25,16 +24,12 @@ import { USER_FIELD_TYPE_NAME } from '../../src/filters/custom_field_options/use
 import { createFilterCreatorParams } from '../utils'
 
 describe('add field options filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'preDeploy' | 'onDeploy'>
   let filter: FilterType
 
   beforeEach(async () => {
     jest.clearAllMocks()
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
   describe('preDeploy', () => {
     it.each([USER_FIELD_TYPE_NAME, ORG_FIELD_TYPE_NAME])('should add null as id for new childs of %s', async fieldTypeName => {

--- a/packages/zendesk-adapter/test/filters/add_restriction.test.ts
+++ b/packages/zendesk-adapter/test/filters/add_restriction.test.ts
@@ -20,7 +20,6 @@ import { ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/add_restriction'
 import { createFilterCreatorParams } from '../utils'
 
-
 describe('custom field option restriction filter', () => {
   let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'onFetch'>

--- a/packages/zendesk-adapter/test/filters/add_restriction.test.ts
+++ b/packages/zendesk-adapter/test/filters/add_restriction.test.ts
@@ -15,13 +15,11 @@
 */
 import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
-import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/add_restriction'
 import { createFilterCreatorParams } from '../utils'
 
 describe('custom field option restriction filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'onFetch'>
   let filter: FilterType
   const typeName = 'ticket_field__custom_field_options'
@@ -44,10 +42,7 @@ describe('custom field option restriction filter', () => {
     BuiltinTypes.STRING,
   )
   beforeEach(async () => {
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
 
   describe('onFetch', () => {

--- a/packages/zendesk-adapter/test/filters/add_restriction.test.ts
+++ b/packages/zendesk-adapter/test/filters/add_restriction.test.ts
@@ -14,76 +14,68 @@
 * limitations under the License.
 */
 import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { filterUtils } from '@salto-io/adapter-components'
 import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/add_restriction'
-import { paginate } from '../../src/client/pagination'
-import { DEFAULT_CONFIG } from '../../src/config'
+import { createFilterCreatorParams } from '../utils'
+
 
 describe('custom field option restriction filter', () => {
   let client: ZendeskClient
-    type FilterType = filterUtils.FilterWith<'onFetch'>
-    let filter: FilterType
-    const typeName = 'ticket_field__custom_field_options'
-    const objTypeNoValue = new ObjectType({ elemID: new ElemID(ZENDESK, typeName) })
-    const objTypeWithValue = new ObjectType({ elemID: new ElemID(ZENDESK, typeName) })
-    objTypeWithValue.fields.value = new Field(
-      objTypeWithValue,
-      'value',
-      BuiltinTypes.STRING,
-    )
-    const objTypeWithTwoFields = new ObjectType({ elemID: new ElemID(ZENDESK, typeName) })
-    objTypeWithTwoFields.fields.value = new Field(
-      objTypeWithTwoFields,
-      'value',
-      BuiltinTypes.STRING,
-    )
-    objTypeWithTwoFields.fields.other = new Field(
-      objTypeWithTwoFields,
-      'other',
-      BuiltinTypes.STRING,
-    )
-    beforeEach(async () => {
-      client = new ZendeskClient({
-        credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-      })
-      filter = filterCreator({
-        client,
-        paginator: clientUtils.createPaginator({
-          client,
-          paginationFuncCreator: paginate,
-        }),
-        config: DEFAULT_CONFIG,
-        fetchQuery: elementUtils.query.createMockQuery(),
-      }) as FilterType
+  type FilterType = filterUtils.FilterWith<'onFetch'>
+  let filter: FilterType
+  const typeName = 'ticket_field__custom_field_options'
+  const objTypeNoValue = new ObjectType({ elemID: new ElemID(ZENDESK, typeName) })
+  const objTypeWithValue = new ObjectType({ elemID: new ElemID(ZENDESK, typeName) })
+  objTypeWithValue.fields.value = new Field(
+    objTypeWithValue,
+    'value',
+    BuiltinTypes.STRING,
+  )
+  const objTypeWithTwoFields = new ObjectType({ elemID: new ElemID(ZENDESK, typeName) })
+  objTypeWithTwoFields.fields.value = new Field(
+    objTypeWithTwoFields,
+    'value',
+    BuiltinTypes.STRING,
+  )
+  objTypeWithTwoFields.fields.other = new Field(
+    objTypeWithTwoFields,
+    'other',
+    BuiltinTypes.STRING,
+  )
+  beforeEach(async () => {
+    client = new ZendeskClient({
+      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+  })
 
-    describe('onFetch', () => {
-      it('should add a regex restriction to the value field when exists', async () => {
-        const elements = [objTypeWithValue].map(e => e.clone())
-        await filter.onFetch(elements)
-        expect(elements).toHaveLength(1)
-        expect(elements[0].fields.value.annotations[CORE_ANNOTATIONS.RESTRICTION].regex)
-          .toBeDefined()
-        expect(elements[0].fields.value.annotations[CORE_ANNOTATIONS.RESTRICTION].regex)
-          .toEqual('^[0-9A-Za-z-_.\\/~:^]+$')
-      })
-      it('should add a regex restriction only to the value field and not to the other field', async () => {
-        const elements = [objTypeWithTwoFields].map(e => e.clone())
-        await filter.onFetch(elements)
-        expect(elements).toHaveLength(1)
-        expect(elements[0].fields.value.annotations[CORE_ANNOTATIONS.RESTRICTION].regex)
-          .toEqual('^[0-9A-Za-z-_.\\/~:^]+$')
-        expect(elements[0]
-          .fields.other.annotations[CORE_ANNOTATIONS.RESTRICTION]).not.toBeDefined()
-      })
-      it('should not add a regex restriction to the value field when the field does not exists', async () => {
-        const elements = [objTypeNoValue].map(e => e.clone())
-        await filter.onFetch(elements)
-        expect(elements).toHaveLength(1)
-        expect(elements[0]
-          .fields.value?.annotations[CORE_ANNOTATIONS.RESTRICTION].regex).not.toBeDefined()
-      })
+  describe('onFetch', () => {
+    it('should add a regex restriction to the value field when exists', async () => {
+      const elements = [objTypeWithValue].map(e => e.clone())
+      await filter.onFetch(elements)
+      expect(elements).toHaveLength(1)
+      expect(elements[0].fields.value.annotations[CORE_ANNOTATIONS.RESTRICTION].regex)
+        .toBeDefined()
+      expect(elements[0].fields.value.annotations[CORE_ANNOTATIONS.RESTRICTION].regex)
+        .toEqual('^[0-9A-Za-z-_.\\/~:^]+$')
     })
+    it('should add a regex restriction only to the value field and not to the other field', async () => {
+      const elements = [objTypeWithTwoFields].map(e => e.clone())
+      await filter.onFetch(elements)
+      expect(elements).toHaveLength(1)
+      expect(elements[0].fields.value.annotations[CORE_ANNOTATIONS.RESTRICTION].regex)
+        .toEqual('^[0-9A-Za-z-_.\\/~:^]+$')
+      expect(elements[0]
+        .fields.other.annotations[CORE_ANNOTATIONS.RESTRICTION]).not.toBeDefined()
+    })
+    it('should not add a regex restriction to the value field when the field does not exists', async () => {
+      const elements = [objTypeNoValue].map(e => e.clone())
+      await filter.onFetch(elements)
+      expect(elements).toHaveLength(1)
+      expect(elements[0]
+        .fields.value?.annotations[CORE_ANNOTATIONS.RESTRICTION].regex).not.toBeDefined()
+    })
+  })
 })

--- a/packages/zendesk-adapter/test/filters/app.test.ts
+++ b/packages/zendesk-adapter/test/filters/app.test.ts
@@ -51,6 +51,9 @@ describe('app installation filter', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks()
+    client = new ZendeskClient({
+      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
+    })
     filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
 

--- a/packages/zendesk-adapter/test/filters/app.test.ts
+++ b/packages/zendesk-adapter/test/filters/app.test.ts
@@ -51,10 +51,7 @@ describe('app installation filter', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks()
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
 
   it('should remove settings object on fetch', async () => {

--- a/packages/zendesk-adapter/test/filters/app.test.ts
+++ b/packages/zendesk-adapter/test/filters/app.test.ts
@@ -16,12 +16,11 @@
 import {
   ObjectType, ElemID, InstanceElement,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG } from '../../src/config'
+import { filterUtils } from '@salto-io/adapter-components'
 import ZendeskClient from '../../src/client/client'
-import { paginate } from '../../src/client/pagination'
 import { ZENDESK } from '../../src/constants'
 import filterCreator, { APP_INSTALLATION_TYPE_NAME } from '../../src/filters/app'
+import { createFilterCreatorParams } from '../utils'
 
 const mockDeployChange = jest.fn()
 jest.mock('@salto-io/adapter-components', () => {
@@ -55,15 +54,7 @@ describe('app installation filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
 
   it('should remove settings object on fetch', async () => {

--- a/packages/zendesk-adapter/test/filters/app.test.ts
+++ b/packages/zendesk-adapter/test/filters/app.test.ts
@@ -51,7 +51,7 @@ describe('app installation filter', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks()
-    filter = filterCreator(createFilterCreatorParams({})) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
 
   it('should remove settings object on fetch', async () => {

--- a/packages/zendesk-adapter/test/filters/app_owned_convert_list_to_map.test.ts
+++ b/packages/zendesk-adapter/test/filters/app_owned_convert_list_to_map.test.ts
@@ -15,11 +15,11 @@
 */
 import _ from 'lodash'
 import { ObjectType, ElemID, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG } from '../../src/config'
+import { filterUtils } from '@salto-io/adapter-components'
+import { createFilterCreatorParams } from '../utils'
 import ZendeskClient from '../../src/client/client'
 import { APP_OWNED_TYPE_NAME, ZENDESK } from '../../src/constants'
-import { paginate } from '../../src/client/pagination'
+
 import filterCreator, { AppOwnedParameter } from '../../src/filters/app_owned_convert_list_to_map'
 
 describe('appOwnedConvertListToMap filter', () => {
@@ -74,15 +74,7 @@ describe('appOwnedConvertListToMap filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
 
   describe('onFetch', () => {

--- a/packages/zendesk-adapter/test/filters/app_owned_convert_list_to_map.test.ts
+++ b/packages/zendesk-adapter/test/filters/app_owned_convert_list_to_map.test.ts
@@ -17,13 +17,11 @@ import _ from 'lodash'
 import { ObjectType, ElemID, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import { createFilterCreatorParams } from '../utils'
-import ZendeskClient from '../../src/client/client'
 import { APP_OWNED_TYPE_NAME, ZENDESK } from '../../src/constants'
 
 import filterCreator, { AppOwnedParameter } from '../../src/filters/app_owned_convert_list_to_map'
 
 describe('appOwnedConvertListToMap filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'onFetch'>
   let filter: FilterType
   const appOwnedType = new ObjectType({ elemID: new ElemID(ZENDESK, APP_OWNED_TYPE_NAME) })
@@ -71,10 +69,7 @@ describe('appOwnedConvertListToMap filter', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks()
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
 
   describe('onFetch', () => {

--- a/packages/zendesk-adapter/test/filters/article.test.ts
+++ b/packages/zendesk-adapter/test/filters/article.test.ts
@@ -16,10 +16,9 @@
 import {
   ObjectType, ElemID, InstanceElement,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG } from '../../src/config'
+import { filterUtils } from '@salto-io/adapter-components'
+import { createFilterCreatorParams } from '../utils'
 import ZendeskClient from '../../src/client/client'
-import { paginate } from '../../src/client/pagination'
 import { ARTICLE_TYPE_NAME, ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/article'
 
@@ -68,15 +67,7 @@ describe('article filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'brandWithHC' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
 
   describe('deploy', () => {

--- a/packages/zendesk-adapter/test/filters/article_body.test.ts
+++ b/packages/zendesk-adapter/test/filters/article_body.test.ts
@@ -15,31 +15,17 @@
 */
 import { ElemID, InstanceElement, ObjectType,
   BuiltinTypes, toChange, isInstanceElement, TemplateExpression, ReferenceExpression } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { filterUtils } from '@salto-io/adapter-components'
 import filterCreator from '../../src/filters/article_body'
-import ZendeskClient from '../../src/client/client'
-import { paginate } from '../../src/client/pagination'
-import { DEFAULT_CONFIG } from '../../src/config'
 import { ARTICLE_TYPE_NAME, BRAND_TYPE_NAME, ZENDESK } from '../../src/constants'
+import { createFilterCreatorParams } from '../utils'
 
 describe('article body filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'onFetch' | 'onDeploy' | 'preDeploy'>
   let filter: FilterType
 
   beforeAll(() => {
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'c' },
-    })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
 
   const brandType = new ObjectType({

--- a/packages/zendesk-adapter/test/filters/brand_logo.test.ts
+++ b/packages/zendesk-adapter/test/filters/brand_logo.test.ts
@@ -12,7 +12,8 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/import FormData from 'form-data'
+*/
+import FormData from 'form-data'
 import {
   ObjectType, ElemID, InstanceElement, isInstanceElement, StaticFile, ReferenceExpression,
   CORE_ANNOTATIONS, getChangeData,

--- a/packages/zendesk-adapter/test/filters/brand_logo.test.ts
+++ b/packages/zendesk-adapter/test/filters/brand_logo.test.ts
@@ -12,18 +12,16 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/
-import FormData from 'form-data'
+*/import FormData from 'form-data'
 import {
   ObjectType, ElemID, InstanceElement, isInstanceElement, StaticFile, ReferenceExpression,
   CORE_ANNOTATIONS, getChangeData,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { filterUtils } from '@salto-io/adapter-components'
 import filterCreator, { BRAND_LOGO_TYPE, LOGO_FIELD } from '../../src/filters/brand_logo'
-import { DEFAULT_CONFIG } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
-import { paginate } from '../../src/client/pagination'
 import { BRAND_LOGO_TYPE_NAME, BRAND_TYPE_NAME, ZENDESK } from '../../src/constants'
+import { createFilterCreatorParams } from '../utils'
 
 jest.useFakeTimers()
 
@@ -52,15 +50,7 @@ describe('brand logo filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
 
   describe('onFetch', () => {

--- a/packages/zendesk-adapter/test/filters/business_hours_schedule.test.ts
+++ b/packages/zendesk-adapter/test/filters/business_hours_schedule.test.ts
@@ -16,10 +16,9 @@
 import {
   ObjectType, ElemID, InstanceElement,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG } from '../../src/config'
+import { filterUtils } from '@salto-io/adapter-components'
+import { createFilterCreatorParams } from '../utils'
 import ZendeskClient from '../../src/client/client'
-import { paginate } from '../../src/client/pagination'
 import { ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/business_hours_schedule'
 
@@ -56,15 +55,7 @@ describe('business hours schedule filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
 
   it('should pass the correct params to deployChange and client on create', async () => {

--- a/packages/zendesk-adapter/test/filters/collistion_errors.test.ts
+++ b/packages/zendesk-adapter/test/filters/collistion_errors.test.ts
@@ -14,11 +14,10 @@
 * limitations under the License.
 */
 import { ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG } from '../../src/config'
+import { filterUtils } from '@salto-io/adapter-components'
+import { createFilterCreatorParams } from '../utils'
 import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
-import { paginate } from '../../src/client/pagination'
 import filterCreator from '../../src/filters/collision_errors'
 import { FilterResult } from '../../src/filter'
 
@@ -36,15 +35,7 @@ describe('collision errors', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
 
   describe('onFetch', () => {

--- a/packages/zendesk-adapter/test/filters/collistion_errors.test.ts
+++ b/packages/zendesk-adapter/test/filters/collistion_errors.test.ts
@@ -16,13 +16,11 @@
 import { ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import { createFilterCreatorParams } from '../utils'
-import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/collision_errors'
 import { FilterResult } from '../../src/filter'
 
 describe('collision errors', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'onFetch' | 'deploy', FilterResult>
   let filter: FilterType
   const objType = new ObjectType({ elemID: new ElemID(ZENDESK, 'obj') })
@@ -32,10 +30,7 @@ describe('collision errors', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks()
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
 
   describe('onFetch', () => {

--- a/packages/zendesk-adapter/test/filters/custom_field_options/ticket_field.test.ts
+++ b/packages/zendesk-adapter/test/filters/custom_field_options/ticket_field.test.ts
@@ -12,21 +12,19 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/
-import {
+*/import {
   ObjectType, ElemID, InstanceElement, isObjectType, isInstanceElement,
   ReferenceExpression, CORE_ANNOTATIONS, toChange,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG } from '../../../src/config'
+import { filterUtils } from '@salto-io/adapter-components'
 import ZendeskClient from '../../../src/client/client'
 import { ZENDESK } from '../../../src/constants'
-import { paginate } from '../../../src/client/pagination'
 import filterCreator from '../../../src/filters/custom_field_options/ticket_field'
 import {
   CUSTOM_FIELD_OPTIONS_FIELD_NAME,
   DEFAULT_CUSTOM_FIELD_OPTION_FIELD_NAME,
 } from '../../../src/filters/custom_field_options/creator'
+import { createFilterCreatorParams } from '../../utils'
 
 const mockDeployChange = jest.fn()
 jest.mock('@salto-io/adapter-components', () => {
@@ -80,15 +78,7 @@ describe('ticket field filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
 
   describe('onFetch', () => {

--- a/packages/zendesk-adapter/test/filters/custom_field_options/ticket_field.test.ts
+++ b/packages/zendesk-adapter/test/filters/custom_field_options/ticket_field.test.ts
@@ -18,7 +18,6 @@ import {
   ReferenceExpression, CORE_ANNOTATIONS, toChange,
 } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
-import ZendeskClient from '../../../src/client/client'
 import { ZENDESK } from '../../../src/constants'
 import filterCreator from '../../../src/filters/custom_field_options/ticket_field'
 import {
@@ -40,7 +39,6 @@ jest.mock('@salto-io/adapter-components', () => {
 })
 
 describe('ticket field filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'onFetch' | 'deploy' | 'preDeploy' | 'onDeploy'>
   let filter: FilterType
   const parentTypeName = 'ticket_field'
@@ -76,10 +74,7 @@ describe('ticket field filter', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks()
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
 
   describe('onFetch', () => {

--- a/packages/zendesk-adapter/test/filters/custom_field_options/ticket_field.test.ts
+++ b/packages/zendesk-adapter/test/filters/custom_field_options/ticket_field.test.ts
@@ -12,7 +12,8 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/import {
+*/
+import {
   ObjectType, ElemID, InstanceElement, isObjectType, isInstanceElement,
   ReferenceExpression, CORE_ANNOTATIONS, toChange,
 } from '@salto-io/adapter-api'

--- a/packages/zendesk-adapter/test/filters/deploy_branded_guide_types.test.ts
+++ b/packages/zendesk-adapter/test/filters/deploy_branded_guide_types.test.ts
@@ -18,7 +18,6 @@ import {
 } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import { createFilterCreatorParams } from '../utils'
-import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/deploy_branded_guide_types'
 
@@ -35,7 +34,6 @@ jest.mock('@salto-io/adapter-components', () => {
 })
 
 describe('deployBrandedGuideTypes filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'deploy'>
   let filter: FilterType
   const brandInstnace = new InstanceElement(
@@ -63,10 +61,7 @@ describe('deployBrandedGuideTypes filter', () => {
   )
   beforeEach(async () => {
     jest.clearAllMocks()
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
 
   describe('deploy', () => {

--- a/packages/zendesk-adapter/test/filters/deploy_branded_guide_types.test.ts
+++ b/packages/zendesk-adapter/test/filters/deploy_branded_guide_types.test.ts
@@ -16,10 +16,9 @@
 import {
   ObjectType, ElemID, InstanceElement, ReferenceExpression,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG } from '../../src/config'
+import { filterUtils } from '@salto-io/adapter-components'
+import { createFilterCreatorParams } from '../utils'
 import ZendeskClient from '../../src/client/client'
-import { paginate } from '../../src/client/pagination'
 import { ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/deploy_branded_guide_types'
 
@@ -67,15 +66,7 @@ describe('deployBrandedGuideTypes filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
 
   describe('deploy', () => {

--- a/packages/zendesk-adapter/test/filters/dynamic_content.test.ts
+++ b/packages/zendesk-adapter/test/filters/dynamic_content.test.ts
@@ -19,7 +19,6 @@ import {
 } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import { createFilterCreatorParams } from '../utils'
-import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
 import filterCreator, {
   DYNAMIC_CONTENT_ITEM_TYPE_NAME, DYNAMIC_CONTENT_ITEM_VARIANT_TYPE_NAME, VARIANTS_FIELD_NAME,
@@ -38,7 +37,6 @@ jest.mock('@salto-io/adapter-components', () => {
 })
 
 describe('dynmaic content filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'deploy' | 'preDeploy' | 'onDeploy'>
   let filter: FilterType
   const parentTypeName = DYNAMIC_CONTENT_ITEM_TYPE_NAME
@@ -118,10 +116,7 @@ describe('dynmaic content filter', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks()
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
 
   describe('preDeploy', () => {

--- a/packages/zendesk-adapter/test/filters/dynamic_content.test.ts
+++ b/packages/zendesk-adapter/test/filters/dynamic_content.test.ts
@@ -17,11 +17,10 @@ import {
   ObjectType, ElemID, InstanceElement,
   ReferenceExpression, CORE_ANNOTATIONS, toChange,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG } from '../../src/config'
+import { filterUtils } from '@salto-io/adapter-components'
+import { createFilterCreatorParams } from '../utils'
 import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
-import { paginate } from '../../src/client/pagination'
 import filterCreator, {
   DYNAMIC_CONTENT_ITEM_TYPE_NAME, DYNAMIC_CONTENT_ITEM_VARIANT_TYPE_NAME, VARIANTS_FIELD_NAME,
 } from '../../src/filters/dynamic_content'
@@ -122,15 +121,7 @@ describe('dynmaic content filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
 
   describe('preDeploy', () => {

--- a/packages/zendesk-adapter/test/filters/dynamic_content_references.test.ts
+++ b/packages/zendesk-adapter/test/filters/dynamic_content_references.test.ts
@@ -19,7 +19,6 @@ import {
   ListType,
 } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
-import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/dynamic_content_references'
 import { DYNAMIC_CONTENT_ITEM_TYPE_NAME } from '../../src/filters/dynamic_content'
@@ -27,7 +26,6 @@ import { createMissingInstance } from '../../src/filters/references/missing_refe
 import { createFilterCreatorParams } from '../utils'
 
 describe('dynamic content references filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
   let filter: FilterType
   let dynamicContentType: ObjectType
@@ -48,10 +46,7 @@ describe('dynamic content references filter', () => {
       },
     })
 
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
 
   const createInstances = (): {

--- a/packages/zendesk-adapter/test/filters/dynamic_content_references.test.ts
+++ b/packages/zendesk-adapter/test/filters/dynamic_content_references.test.ts
@@ -12,7 +12,8 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/import {
+*/
+import {
   ObjectType, ElemID, InstanceElement, ReferenceExpression, TemplateExpression, BuiltinTypes,
   toChange,
   ListType,

--- a/packages/zendesk-adapter/test/filters/dynamic_content_references.test.ts
+++ b/packages/zendesk-adapter/test/filters/dynamic_content_references.test.ts
@@ -12,20 +12,18 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/
-import {
+*/import {
   ObjectType, ElemID, InstanceElement, ReferenceExpression, TemplateExpression, BuiltinTypes,
   toChange,
   ListType,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG } from '../../src/config'
+import { filterUtils } from '@salto-io/adapter-components'
 import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
-import { paginate } from '../../src/client/pagination'
 import filterCreator from '../../src/filters/dynamic_content_references'
 import { DYNAMIC_CONTENT_ITEM_TYPE_NAME } from '../../src/filters/dynamic_content'
 import { createMissingInstance } from '../../src/filters/references/missing_references'
+import { createFilterCreatorParams } from '../utils'
 
 describe('dynamic content references filter', () => {
   let client: ZendeskClient
@@ -52,15 +50,7 @@ describe('dynamic content references filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
 
   const createInstances = (): {

--- a/packages/zendesk-adapter/test/filters/field_references.test.ts
+++ b/packages/zendesk-adapter/test/filters/field_references.test.ts
@@ -12,7 +12,8 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/import { ElemID, InstanceElement, ObjectType, ReferenceExpression, Element,
+*/
+import { ElemID, InstanceElement, ObjectType, ReferenceExpression, Element,
   BuiltinTypes, isInstanceElement, ListType } from '@salto-io/adapter-api'
 import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import filterCreator from '../../src/filters/field_references'

--- a/packages/zendesk-adapter/test/filters/field_references.test.ts
+++ b/packages/zendesk-adapter/test/filters/field_references.test.ts
@@ -15,24 +15,18 @@
 */
 import { ElemID, InstanceElement, ObjectType, ReferenceExpression, Element,
   BuiltinTypes, isInstanceElement, ListType } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { filterUtils } from '@salto-io/adapter-components'
 import filterCreator from '../../src/filters/field_references'
-import ZendeskClient from '../../src/client/client'
 import { DEFAULT_CONFIG, FETCH_CONFIG } from '../../src/config'
 import { ZENDESK } from '../../src/constants'
 import { createFilterCreatorParams } from '../utils'
-import { paginate } from '../../src/client/pagination'
 
 describe('References by id filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'onFetch'>
   let filter: FilterType
 
   beforeAll(() => {
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'c' },
-    })
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
 
   const brandType = new ObjectType({
@@ -436,11 +430,6 @@ describe('References by id filter', () => {
       })
       it('should not create missing references if enable missing references is false', async () => {
         const newFilter = filterCreator(createFilterCreatorParams({
-          client,
-          paginator: clientUtils.createPaginator({
-            client,
-            paginationFuncCreator: paginate,
-          }),
           config: {
             ...DEFAULT_CONFIG,
             fetch: {
@@ -448,7 +437,6 @@ describe('References by id filter', () => {
               enableMissingReferences: false,
             },
           },
-          fetchQuery: elementUtils.query.createMockQuery(),
         })) as FilterType
         const clonedElements = originalElements.map(element => element.clone())
         await newFilter.onFetch(clonedElements)

--- a/packages/zendesk-adapter/test/filters/field_references.test.ts
+++ b/packages/zendesk-adapter/test/filters/field_references.test.ts
@@ -12,15 +12,15 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/
-import { ElemID, InstanceElement, ObjectType, ReferenceExpression, Element,
+*/import { ElemID, InstanceElement, ObjectType, ReferenceExpression, Element,
   BuiltinTypes, isInstanceElement, ListType } from '@salto-io/adapter-api'
 import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import filterCreator from '../../src/filters/field_references'
 import ZendeskClient from '../../src/client/client'
-import { paginate } from '../../src/client/pagination'
 import { DEFAULT_CONFIG, FETCH_CONFIG } from '../../src/config'
 import { ZENDESK } from '../../src/constants'
+import { createFilterCreatorParams } from '../utils'
+import { paginate } from '../../src/client/pagination'
 
 describe('References by id filter', () => {
   let client: ZendeskClient
@@ -31,15 +31,7 @@ describe('References by id filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'c' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
 
   const brandType = new ObjectType({
@@ -442,7 +434,7 @@ describe('References by id filter', () => {
         expect(brokenTrigger.value.conditions.all[5].value).toEqual('current_groups')
       })
       it('should not create missing references if enable missing references is false', async () => {
-        const newFilter = filterCreator({
+        const newFilter = filterCreator(createFilterCreatorParams({
           client,
           paginator: clientUtils.createPaginator({
             client,
@@ -456,7 +448,7 @@ describe('References by id filter', () => {
             },
           },
           fetchQuery: elementUtils.query.createMockQuery(),
-        }) as FilterType
+        })) as FilterType
         const clonedElements = originalElements.map(element => element.clone())
         await newFilter.onFetch(clonedElements)
         const brokenTrigger = clonedElements.filter(

--- a/packages/zendesk-adapter/test/filters/handle_app_installations.test.ts
+++ b/packages/zendesk-adapter/test/filters/handle_app_installations.test.ts
@@ -14,14 +14,14 @@
 * limitations under the License.
 */
 
-import { client as clientUtils, elements as elementUtils, filterUtils } from '@salto-io/adapter-components'
+import { filterUtils } from '@salto-io/adapter-components'
 import { BuiltinTypes, ElemID, InstanceElement, MapType, ObjectType, ReferenceExpression, TemplateExpression, toChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import ZendeskClient from '../../src/client/client'
-import { paginate } from '../../src/client/pagination'
 import filterCreator from '../../src/filters/handle_app_installations'
 import { DEFAULT_CONFIG, FETCH_CONFIG } from '../../src/config'
 import { ZENDESK } from '../../src/constants'
+import { createFilterCreatorParams } from '../utils'
 
 describe('handle app installations filter', () => {
   let client: ZendeskClient
@@ -91,15 +91,7 @@ after
     field2, option1, option2, group1, group2]
 
   const initFilterAndFetch = async (config = DEFAULT_CONFIG): Promise<void> => {
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client, config })) as FilterType
     await filter.onFetch([app, ...SUPPORTING_ELEMENTS])
   }
 

--- a/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
+++ b/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
@@ -12,16 +12,14 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/
-import { ElemID, InstanceElement, ObjectType, ReferenceExpression,
+*/import { ElemID, InstanceElement, ObjectType, ReferenceExpression,
   BuiltinTypes, TemplateExpression, MapType, toChange, isInstanceElement } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { filterUtils } from '@salto-io/adapter-components'
 import filterCreator from '../../src/filters/handle_template_expressions'
 import ZendeskClient from '../../src/client/client'
-import { paginate } from '../../src/client/pagination'
-import { DEFAULT_CONFIG } from '../../src/config'
 import { ZENDESK } from '../../src/constants'
 import { createMissingInstance } from '../../src/filters/references/missing_references'
+import { createFilterCreatorParams } from '../utils'
 
 describe('handle templates filter', () => {
   let client: ZendeskClient
@@ -32,15 +30,7 @@ describe('handle templates filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'c' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
 
   const testType = new ObjectType({

--- a/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
+++ b/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
@@ -12,7 +12,8 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/import { ElemID, InstanceElement, ObjectType, ReferenceExpression,
+*/
+import { ElemID, InstanceElement, ObjectType, ReferenceExpression,
   BuiltinTypes, TemplateExpression, MapType, toChange, isInstanceElement } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import filterCreator from '../../src/filters/handle_template_expressions'

--- a/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
+++ b/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
@@ -17,21 +17,16 @@ import { ElemID, InstanceElement, ObjectType, ReferenceExpression,
   BuiltinTypes, TemplateExpression, MapType, toChange, isInstanceElement } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import filterCreator from '../../src/filters/handle_template_expressions'
-import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
 import { createMissingInstance } from '../../src/filters/references/missing_references'
 import { createFilterCreatorParams } from '../utils'
 
 describe('handle templates filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'onFetch' | 'onDeploy' | 'preDeploy'>
   let filter: FilterType
 
   beforeAll(() => {
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'c' },
-    })
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
 
   const testType = new ObjectType({

--- a/packages/zendesk-adapter/test/filters/hardcoded_channel.test.ts
+++ b/packages/zendesk-adapter/test/filters/hardcoded_channel.test.ts
@@ -15,13 +15,11 @@
 */
 import { ObjectType, ElemID, InstanceElement, isObjectType } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
-import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
 import filterCreator, { TRIGGER_DEFINITION_TYPE_NAME, CHANNEL_TYPE_NAME } from '../../src/filters/hardcoded_channel'
 import { createFilterCreatorParams } from '../utils'
 
 describe('hardcoded channel filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'onFetch'>
   let filter: FilterType
   const channelObjType = new ObjectType({ elemID: new ElemID(ZENDESK, CHANNEL_TYPE_NAME) })
@@ -53,10 +51,7 @@ describe('hardcoded channel filter', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks()
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
 
   describe('onFetch', () => {

--- a/packages/zendesk-adapter/test/filters/hardcoded_channel.test.ts
+++ b/packages/zendesk-adapter/test/filters/hardcoded_channel.test.ts
@@ -14,12 +14,11 @@
 * limitations under the License.
 */
 import { ObjectType, ElemID, InstanceElement, isObjectType } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG } from '../../src/config'
+import { filterUtils } from '@salto-io/adapter-components'
 import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
-import { paginate } from '../../src/client/pagination'
 import filterCreator, { TRIGGER_DEFINITION_TYPE_NAME, CHANNEL_TYPE_NAME } from '../../src/filters/hardcoded_channel'
+import { createFilterCreatorParams } from '../utils'
 
 describe('hardcoded channel filter', () => {
   let client: ZendeskClient
@@ -57,15 +56,7 @@ describe('hardcoded channel filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
 
   describe('onFetch', () => {

--- a/packages/zendesk-adapter/test/filters/help_center_fetch_section_and_category.test.ts
+++ b/packages/zendesk-adapter/test/filters/help_center_fetch_section_and_category.test.ts
@@ -19,13 +19,11 @@ import {
   InstanceElement,
   ObjectType,
 } from '@salto-io/adapter-api'
-import ZendeskClient from '../../src/client/client'
 import filterCreator from '../../src/filters/help_center_fetch_section_and_category'
 import { ZENDESK } from '../../src/constants'
 import { createFilterCreatorParams } from '../utils'
 
 describe('guid section filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'onFetch'>
   let filter: FilterType
 
@@ -38,10 +36,7 @@ describe('guid section filter', () => {
 
 
   beforeEach(async () => {
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
 
   describe('onFetch', () => {

--- a/packages/zendesk-adapter/test/filters/help_center_fetch_section_and_category.test.ts
+++ b/packages/zendesk-adapter/test/filters/help_center_fetch_section_and_category.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { filterUtils } from '@salto-io/adapter-components'
 import {
   ElemID,
   InstanceElement,
@@ -21,9 +21,8 @@ import {
 } from '@salto-io/adapter-api'
 import ZendeskClient from '../../src/client/client'
 import filterCreator from '../../src/filters/help_center_fetch_section_and_category'
-import { paginate } from '../../src/client/pagination'
-import { DEFAULT_CONFIG } from '../../src/config'
 import { ZENDESK } from '../../src/constants'
+import { createFilterCreatorParams } from '../utils'
 
 describe('guid section filter', () => {
   let client: ZendeskClient
@@ -42,15 +41,7 @@ describe('guid section filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
 
   describe('onFetch', () => {

--- a/packages/zendesk-adapter/test/filters/help_center_locale.test.ts
+++ b/packages/zendesk-adapter/test/filters/help_center_locale.test.ts
@@ -19,7 +19,9 @@ import { MockInterface } from '@salto-io/test-utils'
 import { DEFAULT_CONFIG, FETCH_CONFIG } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
 import filterCreator from '../../src/filters/help_center_locale'
+import { createFilterCreatorParams } from '../utils'
 import { paginate } from '../../src/client/pagination'
+
 
 describe('help center locale filter', () => {
   let mockClient: MockInterface<ZendeskClient>
@@ -32,7 +34,7 @@ describe('help center locale filter', () => {
     mockClient = {
       getSinglePage: mockGetSinglePage,
     } as unknown as MockInterface<ZendeskClient>
-    filter = filterCreator({
+    filter = filterCreator(createFilterCreatorParams({
       client: mockClient as unknown as ZendeskClient,
       paginator: clientUtils.createPaginator({
         client: mockClient as unknown as ZendeskClient,
@@ -45,8 +47,7 @@ describe('help center locale filter', () => {
           enableGuide: true,
         },
       },
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    })) as FilterType
   })
 
   describe('onFetch', () => {

--- a/packages/zendesk-adapter/test/filters/help_center_locale.test.ts
+++ b/packages/zendesk-adapter/test/filters/help_center_locale.test.ts
@@ -36,10 +36,6 @@ describe('help center locale filter', () => {
     } as unknown as MockInterface<ZendeskClient>
     filter = filterCreator(createFilterCreatorParams({
       client: mockClient as unknown as ZendeskClient,
-      paginator: clientUtils.createPaginator({
-        client: mockClient as unknown as ZendeskClient,
-        paginationFuncCreator: paginate,
-      }),
       config: {
         ...DEFAULT_CONFIG,
         [FETCH_CONFIG]: {

--- a/packages/zendesk-adapter/test/filters/help_center_section_and_category.test.ts
+++ b/packages/zendesk-adapter/test/filters/help_center_section_and_category.test.ts
@@ -21,7 +21,6 @@ import {
   ObjectType, ReferenceExpression,
   toChange,
 } from '@salto-io/adapter-api'
-import ZendeskClient from '../../src/client/client'
 import filterCreator from '../../src/filters/help_center_section_and_category'
 
 
@@ -29,7 +28,6 @@ import { ZENDESK } from '../../src/constants'
 import { createFilterCreatorParams } from '../utils'
 
 describe('guid section filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
   let filter: FilterType
 
@@ -75,10 +73,7 @@ describe('guid section filter', () => {
 
 
   beforeEach(async () => {
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
 
   describe('preDeploy', () => {

--- a/packages/zendesk-adapter/test/filters/help_center_section_and_category.test.ts
+++ b/packages/zendesk-adapter/test/filters/help_center_section_and_category.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { filterUtils } from '@salto-io/adapter-components'
 import {
   ElemID,
   InstanceElement,
@@ -23,9 +23,10 @@ import {
 } from '@salto-io/adapter-api'
 import ZendeskClient from '../../src/client/client'
 import filterCreator from '../../src/filters/help_center_section_and_category'
-import { paginate } from '../../src/client/pagination'
-import { DEFAULT_CONFIG } from '../../src/config'
+
+
 import { ZENDESK } from '../../src/constants'
+import { createFilterCreatorParams } from '../utils'
 
 describe('guid section filter', () => {
   let client: ZendeskClient
@@ -77,15 +78,7 @@ describe('guid section filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
 
   describe('preDeploy', () => {

--- a/packages/zendesk-adapter/test/filters/help_center_translation.test.ts
+++ b/packages/zendesk-adapter/test/filters/help_center_translation.test.ts
@@ -14,9 +14,7 @@
 * limitations under the License.
 */
 
-import { client as clientUtils,
-  filterUtils,
-  elements as elementUtils } from '@salto-io/adapter-components'
+import { filterUtils } from '@salto-io/adapter-components'
 import {
   CORE_ANNOTATIONS,
   ElemID,
@@ -25,8 +23,7 @@ import {
 } from '@salto-io/adapter-api'
 import ZendeskClient from '../../src/client/client'
 import filterCreator from '../../src/filters/help_center_translation'
-import { paginate } from '../../src/client/pagination'
-import { DEFAULT_CONFIG } from '../../src/config'
+import { createFilterCreatorParams } from '../utils'
 import { ZENDESK } from '../../src/constants'
 import { removedTranslationParentId } from '../../src/filters/help_center_section_and_category'
 
@@ -98,15 +95,7 @@ describe('guild section translation filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
 
   describe('deploy', () => {

--- a/packages/zendesk-adapter/test/filters/help_center_translation.test.ts
+++ b/packages/zendesk-adapter/test/filters/help_center_translation.test.ts
@@ -21,14 +21,12 @@ import {
   InstanceElement,
   ObjectType, ReferenceExpression,
 } from '@salto-io/adapter-api'
-import ZendeskClient from '../../src/client/client'
 import filterCreator from '../../src/filters/help_center_translation'
 import { createFilterCreatorParams } from '../utils'
 import { ZENDESK } from '../../src/constants'
 import { removedTranslationParentId } from '../../src/filters/help_center_section_and_category'
 
 describe('guild section translation filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'deploy'>
   let filter: FilterType
 
@@ -92,10 +90,7 @@ describe('guild section translation filter', () => {
   enSectionTranslationInstance.annotations[CORE_ANNOTATIONS.PARENT] = [sectionInstance.value]
 
   beforeEach(async () => {
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
 
   describe('deploy', () => {

--- a/packages/zendesk-adapter/test/filters/macro_attachments.test.ts
+++ b/packages/zendesk-adapter/test/filters/macro_attachments.test.ts
@@ -18,10 +18,9 @@ import {
   ObjectType, ElemID, InstanceElement, isInstanceElement, StaticFile,
   CORE_ANNOTATIONS, ReferenceExpression, ListType, BuiltinTypes, getChangeData, ModificationChange,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG } from '../../src/config'
+import { filterUtils } from '@salto-io/adapter-components'
+import { createFilterCreatorParams } from '../utils'
 import ZendeskClient from '../../src/client/client'
-import { paginate } from '../../src/client/pagination'
 import { ZENDESK } from '../../src/constants'
 import filterCreator, { ATTACHMENTS_FIELD_NAME, MACRO_ATTACHMENT_TYPE_NAME, MACRO_TYPE_NAME } from '../../src/filters/macro_attachments'
 
@@ -61,15 +60,7 @@ describe('macro attachment filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
 
   describe('onFetch', () => {

--- a/packages/zendesk-adapter/test/filters/omit_inactive.test.ts
+++ b/packages/zendesk-adapter/test/filters/omit_inactive.test.ts
@@ -14,13 +14,14 @@
 * limitations under the License.
 */
 import { ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
 import { API_DEFINITIONS_CONFIG, DEFAULT_CONFIG } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
 import { paginate } from '../../src/client/pagination'
 import filterCreator from '../../src/filters/omit_inactive'
 import { FilterResult } from '../../src/filter'
+import { createFilterCreatorParams } from '../utils'
 
 describe('omit inactive', () => {
   let client: ZendeskClient
@@ -44,7 +45,7 @@ describe('omit inactive', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
+    filter = filterCreator(createFilterCreatorParams({
       client,
       paginator: clientUtils.createPaginator({
         client,
@@ -78,8 +79,7 @@ describe('omit inactive', () => {
           },
         },
       },
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    })) as FilterType
   })
 
   describe('onFetch', () => {

--- a/packages/zendesk-adapter/test/filters/omit_inactive.test.ts
+++ b/packages/zendesk-adapter/test/filters/omit_inactive.test.ts
@@ -16,14 +16,12 @@
 import { ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import { API_DEFINITIONS_CONFIG, DEFAULT_CONFIG } from '../../src/config'
-import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/omit_inactive'
 import { FilterResult } from '../../src/filter'
 import { createFilterCreatorParams } from '../utils'
 
 describe('omit inactive', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'onFetch', FilterResult>
   let filter: FilterType
   const objType1 = new ObjectType({ elemID: new ElemID(ZENDESK, 'trigger') })
@@ -41,11 +39,7 @@ describe('omit inactive', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks()
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
     filter = filterCreator(createFilterCreatorParams({
-      client,
       config: {
         ...DEFAULT_CONFIG,
         [API_DEFINITIONS_CONFIG]: {

--- a/packages/zendesk-adapter/test/filters/omit_inactive.test.ts
+++ b/packages/zendesk-adapter/test/filters/omit_inactive.test.ts
@@ -14,11 +14,10 @@
 * limitations under the License.
 */
 import { ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { filterUtils } from '@salto-io/adapter-components'
 import { API_DEFINITIONS_CONFIG, DEFAULT_CONFIG } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
-import { paginate } from '../../src/client/pagination'
 import filterCreator from '../../src/filters/omit_inactive'
 import { FilterResult } from '../../src/filter'
 import { createFilterCreatorParams } from '../utils'
@@ -47,10 +46,6 @@ describe('omit inactive', () => {
     })
     filter = filterCreator(createFilterCreatorParams({
       client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
       config: {
         ...DEFAULT_CONFIG,
         [API_DEFINITIONS_CONFIG]: {

--- a/packages/zendesk-adapter/test/filters/organization_field.test.ts
+++ b/packages/zendesk-adapter/test/filters/organization_field.test.ts
@@ -19,7 +19,6 @@ import {
 } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 
-import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
 
 import filterCreator, {
@@ -40,7 +39,6 @@ jest.mock('@salto-io/adapter-components', () => {
 })
 
 describe('organization field filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'deploy'>
   let filter: FilterType
   const parentTypeName = ORG_FIELD_TYPE_NAME
@@ -54,10 +52,7 @@ describe('organization field filter', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks()
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
   describe('deploy', () => {
     const resolvedParent = new InstanceElement(

--- a/packages/zendesk-adapter/test/filters/organization_field.test.ts
+++ b/packages/zendesk-adapter/test/filters/organization_field.test.ts
@@ -12,7 +12,8 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/import {
+*/
+import {
   ObjectType, ElemID, InstanceElement,
   ReferenceExpression, CORE_ANNOTATIONS, toChange,
 } from '@salto-io/adapter-api'

--- a/packages/zendesk-adapter/test/filters/organization_field.test.ts
+++ b/packages/zendesk-adapter/test/filters/organization_field.test.ts
@@ -12,19 +12,19 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/
-import {
+*/import {
   ObjectType, ElemID, InstanceElement,
   ReferenceExpression, CORE_ANNOTATIONS, toChange,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG } from '../../src/config'
+import { filterUtils } from '@salto-io/adapter-components'
+
 import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
-import { paginate } from '../../src/client/pagination'
+
 import filterCreator, {
   ORG_FIELD_OPTION_TYPE_NAME, ORG_FIELD_TYPE_NAME, CUSTOM_FIELD_OPTIONS_FIELD_NAME,
 } from '../../src/filters/organization_field'
+import { createFilterCreatorParams } from '../utils'
 
 const mockDeployChange = jest.fn()
 jest.mock('@salto-io/adapter-components', () => {
@@ -56,15 +56,7 @@ describe('organization field filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
   describe('deploy', () => {
     const resolvedParent = new InstanceElement(

--- a/packages/zendesk-adapter/test/filters/referenced_id_fields.test.ts
+++ b/packages/zendesk-adapter/test/filters/referenced_id_fields.test.ts
@@ -16,14 +16,12 @@
 import { ObjectType, ElemID, InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import { DEFAULT_CONFIG, FETCH_CONFIG, SUPPORTED_TYPES } from '../../src/config'
-import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
 
 import filterCreator from '../../src/filters/referenced_id_fields'
 import { createFilterCreatorParams } from '../utils'
 
 describe('referenced id fields filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'onFetch'>
   let filter: FilterType
   const localeObj = new ObjectType({ elemID: new ElemID(ZENDESK, 'locales') })
@@ -36,16 +34,13 @@ describe('referenced id fields filter', () => {
   )
   beforeEach(async () => {
     jest.clearAllMocks()
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
   })
 
   // Will be unskipped after SALTO-2312
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip('should resolve ids in instances names if & exist in the config', async () => {
     const elements = [dynamicContentItemVarIns].map(e => e.clone())
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
     await filter.onFetch(elements)
     expect(elements.map(e => e.elemID.getFullName()).sort())
       .toEqual(['zendesk.dynamic_content_item__variants.instance.es'])
@@ -53,7 +48,6 @@ describe('referenced id fields filter', () => {
   it('should not add referenced id fields if & is not in the config', async () => {
     const elements = [dynamicContentItemVarIns].map(e => e.clone())
     filter = filterCreator(createFilterCreatorParams({
-      client,
       config: {
         fetch: DEFAULT_CONFIG[FETCH_CONFIG],
         apiDefinitions: {

--- a/packages/zendesk-adapter/test/filters/referenced_id_fields.test.ts
+++ b/packages/zendesk-adapter/test/filters/referenced_id_fields.test.ts
@@ -14,12 +14,13 @@
 * limitations under the License.
 */
 import { ObjectType, ElemID, InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { filterUtils } from '@salto-io/adapter-components'
 import { DEFAULT_CONFIG, FETCH_CONFIG, SUPPORTED_TYPES } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
-import { paginate } from '../../src/client/pagination'
+
 import filterCreator from '../../src/filters/referenced_id_fields'
+import { createFilterCreatorParams } from '../utils'
 
 describe('referenced id fields filter', () => {
   let client: ZendeskClient
@@ -44,27 +45,15 @@ describe('referenced id fields filter', () => {
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip('should resolve ids in instances names if & exist in the config', async () => {
     const elements = [dynamicContentItemVarIns].map(e => e.clone())
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
     await filter.onFetch(elements)
     expect(elements.map(e => e.elemID.getFullName()).sort())
       .toEqual(['zendesk.dynamic_content_item__variants.instance.es'])
   })
   it('should not add referenced id fields if & is not in the config', async () => {
     const elements = [dynamicContentItemVarIns].map(e => e.clone())
-    filter = filterCreator({
+    filter = filterCreator(createFilterCreatorParams({
       client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
       config: {
         fetch: DEFAULT_CONFIG[FETCH_CONFIG],
         apiDefinitions: {
@@ -83,8 +72,7 @@ describe('referenced id fields filter', () => {
           supportedTypes: SUPPORTED_TYPES,
         },
       },
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    })) as FilterType
     await filter.onFetch(elements)
     expect(elements.map(e => e.elemID.getFullName()).sort())
       .toEqual(['zendesk.dynamic_content_item__variants.instance.123'])

--- a/packages/zendesk-adapter/test/filters/references/list_values_missing_references.test.ts
+++ b/packages/zendesk-adapter/test/filters/references/list_values_missing_references.test.ts
@@ -22,7 +22,6 @@ import { ZENDESK } from '../../../src/constants'
 import { createFilterCreatorParams } from '../../utils'
 
 describe('list values missing references filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'onFetch'>
   let filter: FilterType
 

--- a/packages/zendesk-adapter/test/filters/references/list_values_missing_references.test.ts
+++ b/packages/zendesk-adapter/test/filters/references/list_values_missing_references.test.ts
@@ -17,7 +17,6 @@ import { ElemID, InstanceElement, ObjectType, ReferenceExpression, Element,
   BuiltinTypes, isInstanceElement, ListType } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import filterCreator from '../../../src/filters/references/list_values_missing_references'
-import ZendeskClient from '../../../src/client/client'
 import { ZENDESK } from '../../../src/constants'
 import { createFilterCreatorParams } from '../../utils'
 
@@ -26,10 +25,7 @@ describe('list values missing references filter', () => {
   let filter: FilterType
 
   beforeAll(() => {
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'c' },
-    })
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
 
   const triggerType = new ObjectType({

--- a/packages/zendesk-adapter/test/filters/references/list_values_missing_references.test.ts
+++ b/packages/zendesk-adapter/test/filters/references/list_values_missing_references.test.ts
@@ -12,15 +12,13 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/
-import { ElemID, InstanceElement, ObjectType, ReferenceExpression, Element,
+*/import { ElemID, InstanceElement, ObjectType, ReferenceExpression, Element,
   BuiltinTypes, isInstanceElement, ListType } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { filterUtils } from '@salto-io/adapter-components'
 import filterCreator from '../../../src/filters/references/list_values_missing_references'
 import ZendeskClient from '../../../src/client/client'
-import { paginate } from '../../../src/client/pagination'
-import { DEFAULT_CONFIG } from '../../../src/config'
 import { ZENDESK } from '../../../src/constants'
+import { createFilterCreatorParams } from '../../utils'
 
 describe('list values missing references filter', () => {
   let client: ZendeskClient
@@ -31,15 +29,7 @@ describe('list values missing references filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'c' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
 
   const triggerType = new ObjectType({

--- a/packages/zendesk-adapter/test/filters/references/list_values_missing_references.test.ts
+++ b/packages/zendesk-adapter/test/filters/references/list_values_missing_references.test.ts
@@ -12,7 +12,8 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/import { ElemID, InstanceElement, ObjectType, ReferenceExpression, Element,
+*/
+import { ElemID, InstanceElement, ObjectType, ReferenceExpression, Element,
   BuiltinTypes, isInstanceElement, ListType } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import filterCreator from '../../../src/filters/references/list_values_missing_references'

--- a/packages/zendesk-adapter/test/filters/remove_brand_logo_field.test.ts
+++ b/packages/zendesk-adapter/test/filters/remove_brand_logo_field.test.ts
@@ -16,13 +16,12 @@
 import {
   ObjectType, ElemID, InstanceElement,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG } from '../../src/config'
+import { filterUtils } from '@salto-io/adapter-components'
 import ZendeskClient from '../../src/client/client'
-import { paginate } from '../../src/client/pagination'
 import { BRAND_TYPE_NAME, ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/remove_brand_logo_field'
 import { LOGO_FIELD, BRAND_LOGO_TYPE } from '../../src/filters/brand_logo'
+import { createFilterCreatorParams } from '../utils'
 
 const mockDeployChange = jest.fn()
 jest.mock('@salto-io/adapter-components', () => {
@@ -70,15 +69,7 @@ describe('remove brand logo field filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
 
   it('should pass the correct params to deployChange and client on create', async () => {

--- a/packages/zendesk-adapter/test/filters/remove_brand_logo_field.test.ts
+++ b/packages/zendesk-adapter/test/filters/remove_brand_logo_field.test.ts
@@ -17,7 +17,6 @@ import {
   ObjectType, ElemID, InstanceElement,
 } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
-import ZendeskClient from '../../src/client/client'
 import { BRAND_TYPE_NAME, ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/remove_brand_logo_field'
 import { LOGO_FIELD, BRAND_LOGO_TYPE } from '../../src/filters/brand_logo'
@@ -36,7 +35,6 @@ jest.mock('@salto-io/adapter-components', () => {
 })
 
 describe('remove brand logo field filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'deploy'>
   let filter: FilterType
   const brandType = new ObjectType({
@@ -66,10 +64,7 @@ describe('remove brand logo field filter', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks()
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
 
   it('should pass the correct params to deployChange and client on create', async () => {

--- a/packages/zendesk-adapter/test/filters/remove_definition_instances.test.ts
+++ b/packages/zendesk-adapter/test/filters/remove_definition_instances.test.ts
@@ -15,14 +15,12 @@
 */
 import { ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
-import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/remove_definition_instances'
 import { FilterResult } from '../../src/filter'
 import { createFilterCreatorParams } from '../utils'
 
 describe('remove definition instances', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'onFetch', FilterResult>
   let filter: FilterType
   const randomObjType = new ObjectType({ elemID: new ElemID(ZENDESK, 'obj') })
@@ -34,10 +32,7 @@ describe('remove definition instances', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks()
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
 
   describe('onFetch', () => {

--- a/packages/zendesk-adapter/test/filters/remove_definition_instances.test.ts
+++ b/packages/zendesk-adapter/test/filters/remove_definition_instances.test.ts
@@ -12,15 +12,13 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/
-import { ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG } from '../../src/config'
+*/import { ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
 import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
-import { paginate } from '../../src/client/pagination'
 import filterCreator from '../../src/filters/remove_definition_instances'
 import { FilterResult } from '../../src/filter'
+import { createFilterCreatorParams } from '../utils'
 
 describe('remove definition instances', () => {
   let client: ZendeskClient
@@ -38,15 +36,7 @@ describe('remove definition instances', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
 
   describe('onFetch', () => {

--- a/packages/zendesk-adapter/test/filters/remove_definition_instances.test.ts
+++ b/packages/zendesk-adapter/test/filters/remove_definition_instances.test.ts
@@ -12,7 +12,8 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/import { ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
+*/
+import { ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'

--- a/packages/zendesk-adapter/test/filters/reorder/automation.test.ts
+++ b/packages/zendesk-adapter/test/filters/reorder/automation.test.ts
@@ -19,7 +19,6 @@ import {
   toChange, getChangeData,
 } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
-import ZendeskClient from '../../../src/client/client'
 import { ZENDESK } from '../../../src/constants'
 import filterCreator, { ORDER_FIELD_NAME } from '../../../src/filters/reorder/automation'
 import { createOrderTypeName } from '../../../src/filters/reorder/creator'
@@ -38,7 +37,6 @@ jest.mock('@salto-io/adapter-components', () => {
 })
 
 describe('automation reorder filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'onFetch' | 'deploy' | 'preDeploy' | 'onDeploy'>
   let filter: FilterType
   const typeName = 'automation'
@@ -50,10 +48,7 @@ describe('automation reorder filter', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks()
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
 
   describe('onFetch', () => {

--- a/packages/zendesk-adapter/test/filters/reorder/automation.test.ts
+++ b/packages/zendesk-adapter/test/filters/reorder/automation.test.ts
@@ -12,19 +12,17 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/
-import {
+*/import {
   ObjectType, ElemID, InstanceElement, Element, isObjectType,
   isInstanceElement, ReferenceExpression, ModificationChange,
   toChange, getChangeData,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG } from '../../../src/config'
+import { filterUtils } from '@salto-io/adapter-components'
 import ZendeskClient from '../../../src/client/client'
 import { ZENDESK } from '../../../src/constants'
-import { paginate } from '../../../src/client/pagination'
 import filterCreator, { ORDER_FIELD_NAME } from '../../../src/filters/reorder/automation'
 import { createOrderTypeName } from '../../../src/filters/reorder/creator'
+import { createFilterCreatorParams } from '../../utils'
 
 const mockDeployChange = jest.fn()
 jest.mock('@salto-io/adapter-components', () => {
@@ -54,15 +52,7 @@ describe('automation reorder filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
 
   describe('onFetch', () => {

--- a/packages/zendesk-adapter/test/filters/reorder/automation.test.ts
+++ b/packages/zendesk-adapter/test/filters/reorder/automation.test.ts
@@ -12,7 +12,8 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/import {
+*/
+import {
   ObjectType, ElemID, InstanceElement, Element, isObjectType,
   isInstanceElement, ReferenceExpression, ModificationChange,
   toChange, getChangeData,

--- a/packages/zendesk-adapter/test/filters/reorder/ticket_form.test.ts
+++ b/packages/zendesk-adapter/test/filters/reorder/ticket_form.test.ts
@@ -12,7 +12,8 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/import {
+*/
+import {
   ObjectType, ElemID, InstanceElement, Element, isObjectType,
   isInstanceElement, ReferenceExpression, ModificationChange,
   toChange, getChangeData,

--- a/packages/zendesk-adapter/test/filters/reorder/ticket_form.test.ts
+++ b/packages/zendesk-adapter/test/filters/reorder/ticket_form.test.ts
@@ -12,17 +12,15 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/
-import {
+*/import {
   ObjectType, ElemID, InstanceElement, Element, isObjectType,
   isInstanceElement, ReferenceExpression, ModificationChange,
   toChange, getChangeData,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG } from '../../../src/config'
+import { filterUtils } from '@salto-io/adapter-components'
+import { createFilterCreatorParams } from '../../utils'
 import ZendeskClient from '../../../src/client/client'
 import { ZENDESK } from '../../../src/constants'
-import { paginate } from '../../../src/client/pagination'
 import filterCreator from '../../../src/filters/reorder/ticket_form'
 import { createOrderTypeName } from '../../../src/filters/reorder/creator'
 
@@ -54,15 +52,7 @@ describe('ticket form reorder filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
 
   describe('onFetch', () => {

--- a/packages/zendesk-adapter/test/filters/reorder/ticket_form.test.ts
+++ b/packages/zendesk-adapter/test/filters/reorder/ticket_form.test.ts
@@ -20,7 +20,6 @@ import {
 } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import { createFilterCreatorParams } from '../../utils'
-import ZendeskClient from '../../../src/client/client'
 import { ZENDESK } from '../../../src/constants'
 import filterCreator from '../../../src/filters/reorder/ticket_form'
 import { createOrderTypeName } from '../../../src/filters/reorder/creator'
@@ -38,7 +37,6 @@ jest.mock('@salto-io/adapter-components', () => {
 })
 
 describe('ticket form reorder filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'onFetch' | 'deploy' | 'preDeploy' | 'onDeploy'>
   let filter: FilterType
   const typeName = 'ticket_form'
@@ -50,10 +48,7 @@ describe('ticket form reorder filter', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks()
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
 
   describe('onFetch', () => {

--- a/packages/zendesk-adapter/test/filters/reorder/trigger.test.ts
+++ b/packages/zendesk-adapter/test/filters/reorder/trigger.test.ts
@@ -12,18 +12,16 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/
-import {
+*/import {
   ObjectType, ElemID, InstanceElement, isObjectType, isInstanceElement,
   ReferenceExpression, ModificationChange,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG } from '../../../src/config'
+import { filterUtils } from '@salto-io/adapter-components'
 import ZendeskClient from '../../../src/client/client'
 import { ZENDESK } from '../../../src/constants'
-import { paginate } from '../../../src/client/pagination'
 import filterCreator, { TRIGGER_CATEGORY_TYPE_NAME, TYPE_NAME as TRIGGER_TYPE_NAME } from '../../../src/filters/reorder/trigger'
 import { createOrderTypeName } from '../../../src/filters/reorder/creator'
+import { createFilterCreatorParams } from '../../utils'
 
 const mockDeployChange = jest.fn()
 jest.mock('@salto-io/adapter-components', () => {
@@ -60,15 +58,7 @@ describe('trigger reorder filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
 
   describe('onFetch', () => {

--- a/packages/zendesk-adapter/test/filters/reorder/trigger.test.ts
+++ b/packages/zendesk-adapter/test/filters/reorder/trigger.test.ts
@@ -12,7 +12,8 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/import {
+*/
+import {
   ObjectType, ElemID, InstanceElement, isObjectType, isInstanceElement,
   ReferenceExpression, ModificationChange,
 } from '@salto-io/adapter-api'

--- a/packages/zendesk-adapter/test/filters/reorder/trigger.test.ts
+++ b/packages/zendesk-adapter/test/filters/reorder/trigger.test.ts
@@ -18,7 +18,6 @@ import {
   ReferenceExpression, ModificationChange,
 } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
-import ZendeskClient from '../../../src/client/client'
 import { ZENDESK } from '../../../src/constants'
 import filterCreator, { TRIGGER_CATEGORY_TYPE_NAME, TYPE_NAME as TRIGGER_TYPE_NAME } from '../../../src/filters/reorder/trigger'
 import { createOrderTypeName } from '../../../src/filters/reorder/creator'
@@ -37,7 +36,6 @@ jest.mock('@salto-io/adapter-components', () => {
 })
 
 describe('trigger reorder filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'onFetch' | 'deploy'>
   let filter: FilterType
   const triggerTypeName = TRIGGER_TYPE_NAME
@@ -56,10 +54,7 @@ describe('trigger reorder filter', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks()
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
 
   describe('onFetch', () => {

--- a/packages/zendesk-adapter/test/filters/reorder/view.test.ts
+++ b/packages/zendesk-adapter/test/filters/reorder/view.test.ts
@@ -12,20 +12,18 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/
-import {
+*/import {
   ObjectType, ElemID, InstanceElement, Element, isObjectType,
   isInstanceElement, ReferenceExpression, ModificationChange,
   toChange, getChangeData,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG } from '../../../src/config'
+import { filterUtils } from '@salto-io/adapter-components'
 import ZendeskClient from '../../../src/client/client'
 import { ZENDESK } from '../../../src/constants'
-import { paginate } from '../../../src/client/pagination'
 import filterCreator, { ORDER_FIELD_NAME } from '../../../src/filters/reorder/view'
 import { VIEW_TYPE_NAME } from '../../../src/filters/view'
 import { createOrderTypeName } from '../../../src/filters/reorder/creator'
+import { createFilterCreatorParams } from '../../utils'
 
 const mockDeployChange = jest.fn()
 jest.mock('@salto-io/adapter-components', () => {
@@ -55,15 +53,7 @@ describe('view reorder filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
 
   describe('onFetch', () => {

--- a/packages/zendesk-adapter/test/filters/reorder/view.test.ts
+++ b/packages/zendesk-adapter/test/filters/reorder/view.test.ts
@@ -12,7 +12,8 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/import {
+*/
+import {
   ObjectType, ElemID, InstanceElement, Element, isObjectType,
   isInstanceElement, ReferenceExpression, ModificationChange,
   toChange, getChangeData,

--- a/packages/zendesk-adapter/test/filters/reorder/view.test.ts
+++ b/packages/zendesk-adapter/test/filters/reorder/view.test.ts
@@ -19,7 +19,6 @@ import {
   toChange, getChangeData,
 } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
-import ZendeskClient from '../../../src/client/client'
 import { ZENDESK } from '../../../src/constants'
 import filterCreator, { ORDER_FIELD_NAME } from '../../../src/filters/reorder/view'
 import { VIEW_TYPE_NAME } from '../../../src/filters/view'
@@ -39,7 +38,6 @@ jest.mock('@salto-io/adapter-components', () => {
 })
 
 describe('view reorder filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'onFetch' | 'deploy' | 'preDeploy' | 'onDeploy'>
   let filter: FilterType
   const typeName = VIEW_TYPE_NAME
@@ -51,10 +49,7 @@ describe('view reorder filter', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks()
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
 
   describe('onFetch', () => {

--- a/packages/zendesk-adapter/test/filters/restriction.test.ts
+++ b/packages/zendesk-adapter/test/filters/restriction.test.ts
@@ -12,14 +12,14 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/
-import { ObjectType, ElemID, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG } from '../../src/config'
+*/import { ObjectType, ElemID, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+
 import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
-import { paginate } from '../../src/client/pagination'
+
 import filterCreator, { RESTRICTION_FIELD_NAME } from '../../src/filters/restriction'
+import { createFilterCreatorParams } from '../utils'
 
 describe('restriction filter', () => {
   let client: ZendeskClient
@@ -63,15 +63,7 @@ describe('restriction filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
 
   describe('onFetch', () => {

--- a/packages/zendesk-adapter/test/filters/restriction.test.ts
+++ b/packages/zendesk-adapter/test/filters/restriction.test.ts
@@ -16,14 +16,12 @@
 import { ObjectType, ElemID, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 
-import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
 
 import filterCreator, { RESTRICTION_FIELD_NAME } from '../../src/filters/restriction'
 import { createFilterCreatorParams } from '../utils'
 
 describe('restriction filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'onFetch'>
   let filter: FilterType
   const viewObjType = new ObjectType({ elemID: new ElemID(ZENDESK, 'view') })
@@ -61,10 +59,7 @@ describe('restriction filter', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks()
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
 
   describe('onFetch', () => {

--- a/packages/zendesk-adapter/test/filters/restriction.test.ts
+++ b/packages/zendesk-adapter/test/filters/restriction.test.ts
@@ -12,7 +12,8 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/import { ObjectType, ElemID, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
+*/
+import { ObjectType, ElemID, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 
 import ZendeskClient from '../../src/client/client'

--- a/packages/zendesk-adapter/test/filters/routing_attribute.test.ts
+++ b/packages/zendesk-adapter/test/filters/routing_attribute.test.ts
@@ -17,7 +17,6 @@ import {
   ObjectType, ElemID, InstanceElement,
 } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
-import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/routing_attribute'
 import { createFilterCreatorParams } from '../utils'
@@ -35,7 +34,6 @@ jest.mock('@salto-io/adapter-components', () => {
 })
 
 describe('routing attribute filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'deploy'>
   let filter: FilterType
   const routingAttribute = new InstanceElement(
@@ -46,10 +44,7 @@ describe('routing attribute filter', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks()
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
 
   describe('deploy', () => {

--- a/packages/zendesk-adapter/test/filters/routing_attribute.test.ts
+++ b/packages/zendesk-adapter/test/filters/routing_attribute.test.ts
@@ -16,12 +16,11 @@
 import {
   ObjectType, ElemID, InstanceElement,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG } from '../../src/config'
+import { filterUtils } from '@salto-io/adapter-components'
 import ZendeskClient from '../../src/client/client'
-import { paginate } from '../../src/client/pagination'
 import { ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/routing_attribute'
+import { createFilterCreatorParams } from '../utils'
 
 const mockDeployChange = jest.fn()
 jest.mock('@salto-io/adapter-components', () => {
@@ -50,15 +49,7 @@ describe('routing attribute filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
 
   describe('deploy', () => {

--- a/packages/zendesk-adapter/test/filters/service_url.test.ts
+++ b/packages/zendesk-adapter/test/filters/service_url.test.ts
@@ -12,14 +12,12 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/
-import { ObjectType, ElemID, InstanceElement, CORE_ANNOTATIONS, toChange, getChangeData } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG } from '../../src/config'
+*/import { ObjectType, ElemID, InstanceElement, CORE_ANNOTATIONS, toChange, getChangeData } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
 import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
-import { paginate } from '../../src/client/pagination'
 import filterCreator from '../../src/filters/service_url'
+import { createFilterCreatorParams } from '../utils'
 
 describe('service url filter', () => {
   let client: ZendeskClient
@@ -35,15 +33,7 @@ describe('service url filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
 
   describe('onFetch', () => {

--- a/packages/zendesk-adapter/test/filters/service_url.test.ts
+++ b/packages/zendesk-adapter/test/filters/service_url.test.ts
@@ -15,13 +15,11 @@
 */
 import { ObjectType, ElemID, InstanceElement, CORE_ANNOTATIONS, toChange, getChangeData } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
-import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/service_url'
 import { createFilterCreatorParams } from '../utils'
 
 describe('service url filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'onFetch' | 'onDeploy'>
   let filter: FilterType
   const roleObjType = new ObjectType({ elemID: new ElemID(ZENDESK, 'custom_role') })
@@ -31,10 +29,7 @@ describe('service url filter', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks()
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
 
   describe('onFetch', () => {

--- a/packages/zendesk-adapter/test/filters/service_url.test.ts
+++ b/packages/zendesk-adapter/test/filters/service_url.test.ts
@@ -12,7 +12,8 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/import { ObjectType, ElemID, InstanceElement, CORE_ANNOTATIONS, toChange, getChangeData } from '@salto-io/adapter-api'
+*/
+import { ObjectType, ElemID, InstanceElement, CORE_ANNOTATIONS, toChange, getChangeData } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'

--- a/packages/zendesk-adapter/test/filters/sla_policy.test.ts
+++ b/packages/zendesk-adapter/test/filters/sla_policy.test.ts
@@ -18,7 +18,6 @@ import {
 } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import { createFilterCreatorParams } from '../utils'
-import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
 import filterCreator, { SLA_POLICY_TYPE_NAME } from '../../src/filters/sla_policy'
 
@@ -35,7 +34,6 @@ jest.mock('@salto-io/adapter-components', () => {
 })
 
 describe('sla policy filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'deploy'>
   let filter: FilterType
   const slaPolicyType = new ObjectType({
@@ -83,10 +81,7 @@ describe('sla policy filter', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks()
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
 
   describe('deploy', () => {

--- a/packages/zendesk-adapter/test/filters/sla_policy.test.ts
+++ b/packages/zendesk-adapter/test/filters/sla_policy.test.ts
@@ -12,7 +12,8 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/import {
+*/
+import {
   ObjectType, ElemID, InstanceElement,
 } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'

--- a/packages/zendesk-adapter/test/filters/sla_policy.test.ts
+++ b/packages/zendesk-adapter/test/filters/sla_policy.test.ts
@@ -12,14 +12,12 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/
-import {
+*/import {
   ObjectType, ElemID, InstanceElement,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG } from '../../src/config'
+import { filterUtils } from '@salto-io/adapter-components'
+import { createFilterCreatorParams } from '../utils'
 import ZendeskClient from '../../src/client/client'
-import { paginate } from '../../src/client/pagination'
 import { ZENDESK } from '../../src/constants'
 import filterCreator, { SLA_POLICY_TYPE_NAME } from '../../src/filters/sla_policy'
 
@@ -87,15 +85,7 @@ describe('sla policy filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
 
   describe('deploy', () => {

--- a/packages/zendesk-adapter/test/filters/tag.test.ts
+++ b/packages/zendesk-adapter/test/filters/tag.test.ts
@@ -14,12 +14,11 @@
 * limitations under the License.
 */
 import { ObjectType, ElemID, InstanceElement, isInstanceElement, toChange, getChangeData, ReferenceExpression } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
 import { mockFunction } from '@salto-io/test-utils'
-import { DEFAULT_CONFIG } from '../../src/config'
-import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
 import filterCreator, { TAG_TYPE_NAME } from '../../src/filters/tag'
+import { createFilterCreatorParams } from '../utils'
 
 const mockDeployChange = jest.fn()
 jest.mock('@salto-io/adapter-components', () => {
@@ -34,7 +33,6 @@ jest.mock('@salto-io/adapter-components', () => {
 })
 
 describe('tags filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy' | 'deploy'>
   let filter: FilterType
   const slaPolicyType = new ObjectType({ elemID: new ElemID(ZENDESK, 'sla_policy') })
@@ -140,9 +138,6 @@ describe('tags filter', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks()
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
     mockPaginator = mockFunction<clientUtils.Paginator>()
       .mockImplementationOnce(async function *get() {
         yield [
@@ -155,12 +150,9 @@ describe('tags filter', () => {
           ] },
         ]
       })
-    filter = filterCreator({
-      client,
+    filter = filterCreator(createFilterCreatorParams({
       paginator: mockPaginator,
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    }))as FilterType
   })
 
   describe('onFetch', () => {

--- a/packages/zendesk-adapter/test/filters/target.test.ts
+++ b/packages/zendesk-adapter/test/filters/target.test.ts
@@ -16,7 +16,6 @@
 import { ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import { createFilterCreatorParams } from '../utils'
-import ZendeskClient from '../../src/client/client'
 import { TARGET_TYPE_NAME, ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/target'
 
@@ -33,7 +32,6 @@ jest.mock('@salto-io/adapter-components', () => {
 })
 
 describe('target filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'deploy'>
   let filter: FilterType
   const target = new InstanceElement(
@@ -51,10 +49,7 @@ describe('target filter', () => {
   )
   beforeEach(async () => {
     jest.clearAllMocks()
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
   describe('deploy', () => {
     it('should pass the correct params to deployChange on create - no auth', async () => {

--- a/packages/zendesk-adapter/test/filters/target.test.ts
+++ b/packages/zendesk-adapter/test/filters/target.test.ts
@@ -14,10 +14,9 @@
 * limitations under the License.
 */
 import { ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG } from '../../src/config'
+import { filterUtils } from '@salto-io/adapter-components'
+import { createFilterCreatorParams } from '../utils'
 import ZendeskClient from '../../src/client/client'
-import { paginate } from '../../src/client/pagination'
 import { TARGET_TYPE_NAME, ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/target'
 
@@ -55,15 +54,7 @@ describe('target filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
   describe('deploy', () => {
     it('should pass the correct params to deployChange on create - no auth', async () => {

--- a/packages/zendesk-adapter/test/filters/unordered_lists.test.ts
+++ b/packages/zendesk-adapter/test/filters/unordered_lists.test.ts
@@ -17,13 +17,11 @@ import {
   ObjectType, ElemID, InstanceElement, Element, isInstanceElement, ReferenceExpression,
 } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
-import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/unordered_lists'
 import { createFilterCreatorParams } from '../utils'
 
 describe('Unordered lists filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'onFetch'>
   let filter: FilterType
 
@@ -122,10 +120,7 @@ describe('Unordered lists filter', () => {
   let elements: Element[]
 
   beforeAll(async () => {
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
 
     elements = generateElements()
     await filter.onFetch(elements)

--- a/packages/zendesk-adapter/test/filters/unordered_lists.test.ts
+++ b/packages/zendesk-adapter/test/filters/unordered_lists.test.ts
@@ -12,16 +12,14 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/
-import {
+*/import {
   ObjectType, ElemID, InstanceElement, Element, isInstanceElement, ReferenceExpression,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG } from '../../src/config'
+import { filterUtils } from '@salto-io/adapter-components'
 import ZendeskClient from '../../src/client/client'
-import { paginate } from '../../src/client/pagination'
 import { ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/unordered_lists'
+import { createFilterCreatorParams } from '../utils'
 
 describe('Unordered lists filter', () => {
   let client: ZendeskClient
@@ -126,15 +124,7 @@ describe('Unordered lists filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
 
     elements = generateElements()
     await filter.onFetch(elements)

--- a/packages/zendesk-adapter/test/filters/unordered_lists.test.ts
+++ b/packages/zendesk-adapter/test/filters/unordered_lists.test.ts
@@ -12,7 +12,8 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/import {
+*/
+import {
   ObjectType, ElemID, InstanceElement, Element, isInstanceElement, ReferenceExpression,
 } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'

--- a/packages/zendesk-adapter/test/filters/user.test.ts
+++ b/packages/zendesk-adapter/test/filters/user.test.ts
@@ -16,14 +16,12 @@
 import { ObjectType, ElemID, InstanceElement, isInstanceElement, toChange, getChangeData } from '@salto-io/adapter-api'
 import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
 import { mockFunction } from '@salto-io/test-utils'
-import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/user'
 import { createFilterCreatorParams } from '../utils'
 
 
 describe('user filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
   let filter: FilterType
   const macroType = new ObjectType({ elemID: new ElemID(ZENDESK, 'macro') })
@@ -247,9 +245,6 @@ describe('user filter', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks()
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
     mockPaginator = mockFunction<clientUtils.Paginator>()
       .mockImplementationOnce(async function *get() {
         yield [
@@ -263,7 +258,7 @@ describe('user filter', () => {
         ]
       })
     filter = filterCreator(
-      createFilterCreatorParams({ client, paginator: mockPaginator })
+      createFilterCreatorParams({ paginator: mockPaginator })
     ) as FilterType
   })
 
@@ -460,7 +455,7 @@ describe('user filter', () => {
           ]
         })
       const newFilter = filterCreator(
-        createFilterCreatorParams({ client, paginator })
+        createFilterCreatorParams({ paginator })
       ) as FilterType
       await newFilter.onFetch(elements)
       expect(elements.map(e => e.elemID.getFullName()).sort())
@@ -498,7 +493,7 @@ describe('user filter', () => {
           ]
         })
       const newFilter = filterCreator(
-        createFilterCreatorParams({ client, paginator })
+        createFilterCreatorParams({ paginator })
       ) as FilterType
       await newFilter.onFetch(elements)
       const instances = elements.filter(isInstanceElement)
@@ -710,7 +705,7 @@ describe('user filter', () => {
           ]
         })
       const newFilter = filterCreator(
-        createFilterCreatorParams({ client, paginator })
+        createFilterCreatorParams({ paginator })
       ) as FilterType
       const changes = instances.map(instance => toChange({ after: instance }))
       // We call preDeploy here because it sets the mappings

--- a/packages/zendesk-adapter/test/filters/user.test.ts
+++ b/packages/zendesk-adapter/test/filters/user.test.ts
@@ -14,12 +14,13 @@
 * limitations under the License.
 */
 import { ObjectType, ElemID, InstanceElement, isInstanceElement, toChange, getChangeData } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
 import { mockFunction } from '@salto-io/test-utils'
-import { DEFAULT_CONFIG } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/user'
+import { createFilterCreatorParams } from '../utils'
+
 
 describe('user filter', () => {
   let client: ZendeskClient
@@ -261,12 +262,9 @@ describe('user filter', () => {
           ] },
         ]
       })
-    filter = filterCreator({
-      client,
-      paginator: mockPaginator,
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(
+      createFilterCreatorParams({ client, paginator: mockPaginator })
+    ) as FilterType
   })
 
   describe('onFetch', () => {
@@ -461,12 +459,9 @@ describe('user filter', () => {
             ] },
           ]
         })
-      const newFilter = filterCreator({
-        client,
-        paginator,
-        config: DEFAULT_CONFIG,
-        fetchQuery: elementUtils.query.createMockQuery(),
-      }) as FilterType
+      const newFilter = filterCreator(
+        createFilterCreatorParams({ client, paginator })
+      ) as FilterType
       await newFilter.onFetch(elements)
       expect(elements.map(e => e.elemID.getFullName()).sort())
         .toEqual([
@@ -502,12 +497,9 @@ describe('user filter', () => {
             ] },
           ]
         })
-      const newFilter = filterCreator({
-        client,
-        paginator,
-        config: DEFAULT_CONFIG,
-        fetchQuery: elementUtils.query.createMockQuery(),
-      }) as FilterType
+      const newFilter = filterCreator(
+        createFilterCreatorParams({ client, paginator })
+      ) as FilterType
       await newFilter.onFetch(elements)
       const instances = elements.filter(isInstanceElement)
       const macro = instances.find(e => e.elemID.typeName === 'macro')
@@ -717,12 +709,9 @@ describe('user filter', () => {
             ] },
           ]
         })
-      const newFilter = filterCreator({
-        client,
-        paginator,
-        config: DEFAULT_CONFIG,
-        fetchQuery: elementUtils.query.createMockQuery(),
-      }) as FilterType
+      const newFilter = filterCreator(
+        createFilterCreatorParams({ client, paginator })
+      ) as FilterType
       const changes = instances.map(instance => toChange({ after: instance }))
       // We call preDeploy here because it sets the mappings
       await newFilter.preDeploy(changes)

--- a/packages/zendesk-adapter/test/filters/view.test.ts
+++ b/packages/zendesk-adapter/test/filters/view.test.ts
@@ -17,7 +17,6 @@ import {
   ObjectType, ElemID, InstanceElement, toChange,
 } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
-import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/view'
 import { createFilterCreatorParams } from '../utils'
@@ -35,7 +34,6 @@ jest.mock('@salto-io/adapter-components', () => {
 })
 
 describe('views filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'deploy' | 'preDeploy' | 'onDeploy'>
   let filter: FilterType
   const view = new InstanceElement(
@@ -129,10 +127,7 @@ describe('views filter', () => {
   )
   beforeEach(async () => {
     jest.clearAllMocks()
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
 
   describe('preDeploy', () => {

--- a/packages/zendesk-adapter/test/filters/view.test.ts
+++ b/packages/zendesk-adapter/test/filters/view.test.ts
@@ -12,16 +12,14 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/
-import {
+*/import {
   ObjectType, ElemID, InstanceElement, toChange,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG } from '../../src/config'
+import { filterUtils } from '@salto-io/adapter-components'
 import ZendeskClient from '../../src/client/client'
-import { paginate } from '../../src/client/pagination'
 import { ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/view'
+import { createFilterCreatorParams } from '../utils'
 
 const mockDeployChange = jest.fn()
 jest.mock('@salto-io/adapter-components', () => {
@@ -133,15 +131,7 @@ describe('views filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
 
   describe('preDeploy', () => {

--- a/packages/zendesk-adapter/test/filters/view.test.ts
+++ b/packages/zendesk-adapter/test/filters/view.test.ts
@@ -12,7 +12,8 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/import {
+*/
+import {
   ObjectType, ElemID, InstanceElement, toChange,
 } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'

--- a/packages/zendesk-adapter/test/filters/webhook.test.ts
+++ b/packages/zendesk-adapter/test/filters/webhook.test.ts
@@ -15,7 +15,6 @@
 */
 import { ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
-import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
 import filterCreator, { WEBHOOK_TYPE_NAME, AUTH_TYPE_TO_PLACEHOLDER_AUTH_DATA } from '../../src/filters/webhook'
 import { createFilterCreatorParams } from '../utils'
@@ -33,7 +32,6 @@ jest.mock('@salto-io/adapter-components', () => {
 })
 
 describe('webhook filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'deploy'>
   let filter: FilterType
   const webhook = new InstanceElement(
@@ -57,10 +55,7 @@ describe('webhook filter', () => {
   )
   beforeEach(async () => {
     jest.clearAllMocks()
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
   describe('deploy', () => {
     it('should pass the correct params to deployChange on create - basic_auth', async () => {

--- a/packages/zendesk-adapter/test/filters/webhook.test.ts
+++ b/packages/zendesk-adapter/test/filters/webhook.test.ts
@@ -12,7 +12,8 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/import { ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
+*/
+import { ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'

--- a/packages/zendesk-adapter/test/filters/webhook.test.ts
+++ b/packages/zendesk-adapter/test/filters/webhook.test.ts
@@ -12,14 +12,12 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/
-import { ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG } from '../../src/config'
+*/import { ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
 import ZendeskClient from '../../src/client/client'
-import { paginate } from '../../src/client/pagination'
 import { ZENDESK } from '../../src/constants'
 import filterCreator, { WEBHOOK_TYPE_NAME, AUTH_TYPE_TO_PLACEHOLDER_AUTH_DATA } from '../../src/filters/webhook'
+import { createFilterCreatorParams } from '../utils'
 
 const mockDeployChange = jest.fn()
 jest.mock('@salto-io/adapter-components', () => {
@@ -61,15 +59,7 @@ describe('webhook filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
   describe('deploy', () => {
     it('should pass the correct params to deployChange on create - basic_auth', async () => {

--- a/packages/zendesk-adapter/test/filters/workspace.test.ts
+++ b/packages/zendesk-adapter/test/filters/workspace.test.ts
@@ -16,12 +16,11 @@
 import {
   ObjectType, ElemID, InstanceElement, toChange,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG } from '../../src/config'
+import { filterUtils } from '@salto-io/adapter-components'
 import ZendeskClient from '../../src/client/client'
-import { paginate } from '../../src/client/pagination'
 import { ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/workspace'
+import { createFilterCreatorParams } from '../utils'
 
 const mockDeployChange = jest.fn()
 jest.mock('@salto-io/adapter-components', () => {
@@ -80,15 +79,8 @@ describe('workspace filter', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    filter = filterCreator({
-      client,
-      paginator: clientUtils.createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      }),
-      config: DEFAULT_CONFIG,
-      fetchQuery: elementUtils.query.createMockQuery(),
-    }) as FilterType
+
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
   describe('preDeploy', () => {
     beforeEach(async () => {

--- a/packages/zendesk-adapter/test/filters/workspace.test.ts
+++ b/packages/zendesk-adapter/test/filters/workspace.test.ts
@@ -17,7 +17,6 @@ import {
   ObjectType, ElemID, InstanceElement, toChange,
 } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
-import ZendeskClient from '../../src/client/client'
 import { ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/workspace'
 import { createFilterCreatorParams } from '../utils'
@@ -35,7 +34,6 @@ jest.mock('@salto-io/adapter-components', () => {
 })
 
 describe('workspace filter', () => {
-  let client: ZendeskClient
   type FilterType = filterUtils.FilterWith<'deploy' | 'preDeploy' | 'onDeploy'>
   let filter: FilterType
   const workspace = new InstanceElement(
@@ -76,11 +74,7 @@ describe('workspace filter', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks()
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
-
-    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
   describe('preDeploy', () => {
     beforeEach(async () => {

--- a/packages/zendesk-adapter/test/utils.ts
+++ b/packages/zendesk-adapter/test/utils.ts
@@ -1,0 +1,43 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { client as clientUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { ReadOnlyElementsSource } from '@salto-io/adapter-api'
+import { DEFAULT_CONFIG, ZendeskConfig } from '../src/config'
+import ZendeskClient from '../src/client/client'
+import { paginate } from '../src/client/pagination'
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const createFilterCreatorParams = ({
+  client,
+  paginator = clientUtils.createPaginator({
+    client,
+    paginationFuncCreator: paginate,
+  }),
+  config = DEFAULT_CONFIG,
+  fetchQuery = elementUtils.query.createMockQuery(),
+  elementsSource = buildElementsSourceFromElements([]),
+} :
+                                              {
+                                                  client: ZendeskClient
+                                                  paginator?: clientUtils.Paginator
+                                                  config?: ZendeskConfig
+                                                  fetchQuery?: elementUtils.query.ElementQuery
+                                                  elementsSource?: ReadOnlyElementsSource
+                                              }) => ({
+  client, paginator, config, fetchQuery, elementsSource,
+})

--- a/packages/zendesk-adapter/test/utils.ts
+++ b/packages/zendesk-adapter/test/utils.ts
@@ -21,7 +21,6 @@ import { DEFAULT_CONFIG, ZendeskConfig } from '../src/config'
 import ZendeskClient from '../src/client/client'
 import { paginate } from '../src/client/pagination'
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const createFilterCreatorParams = ({
   client,
   paginator = clientUtils.createPaginator({

--- a/packages/zendesk-adapter/test/utils.ts
+++ b/packages/zendesk-adapter/test/utils.ts
@@ -21,6 +21,7 @@ import { DEFAULT_CONFIG, ZendeskConfig } from '../src/config'
 import ZendeskClient from '../src/client/client'
 import { paginate } from '../src/client/pagination'
 
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const createFilterCreatorParams = ({
   client,
   paginator = clientUtils.createPaginator({

--- a/packages/zendesk-adapter/test/utils.ts
+++ b/packages/zendesk-adapter/test/utils.ts
@@ -21,7 +21,6 @@ import { DEFAULT_CONFIG, ZendeskConfig } from '../src/config'
 import ZendeskClient from '../src/client/client'
 import { paginate } from '../src/client/pagination'
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const createFilterCreatorParams = ({
   client,
   paginator = clientUtils.createPaginator({
@@ -32,12 +31,19 @@ export const createFilterCreatorParams = ({
   fetchQuery = elementUtils.query.createMockQuery(),
   elementsSource = buildElementsSourceFromElements([]),
 } :
-                                              {
-                                                  client: ZendeskClient
-                                                  paginator?: clientUtils.Paginator
-                                                  config?: ZendeskConfig
-                                                  fetchQuery?: elementUtils.query.ElementQuery
-                                                  elementsSource?: ReadOnlyElementsSource
-                                              }) => ({
+{
+  client: ZendeskClient
+  paginator?: clientUtils.Paginator
+  config?: ZendeskConfig
+  fetchQuery?: elementUtils.query.ElementQuery
+  elementsSource?: ReadOnlyElementsSource
+}) :
+{
+    client: ZendeskClient
+    paginator?: clientUtils.Paginator
+    config?: ZendeskConfig
+    fetchQuery?: elementUtils.query.ElementQuery
+    elementsSource?: ReadOnlyElementsSource
+} => ({
   client, paginator, config, fetchQuery, elementsSource,
 })

--- a/packages/zendesk-adapter/test/utils.ts
+++ b/packages/zendesk-adapter/test/utils.ts
@@ -21,8 +21,18 @@ import { DEFAULT_CONFIG, ZendeskConfig } from '../src/config'
 import ZendeskClient from '../src/client/client'
 import { paginate } from '../src/client/pagination'
 
+type FilterCreatorParams = {
+    client: ZendeskClient
+    paginator: clientUtils.Paginator
+    config: ZendeskConfig
+    fetchQuery: elementUtils.query.ElementQuery
+    elementsSource: ReadOnlyElementsSource
+}
+
 export const createFilterCreatorParams = ({
-  client,
+  client = new ZendeskClient({
+    credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
+  }),
   paginator = clientUtils.createPaginator({
     client,
     paginationFuncCreator: paginate,
@@ -30,20 +40,6 @@ export const createFilterCreatorParams = ({
   config = DEFAULT_CONFIG,
   fetchQuery = elementUtils.query.createMockQuery(),
   elementsSource = buildElementsSourceFromElements([]),
-} :
-{
-  client: ZendeskClient
-  paginator?: clientUtils.Paginator
-  config?: ZendeskConfig
-  fetchQuery?: elementUtils.query.ElementQuery
-  elementsSource?: ReadOnlyElementsSource
-}) :
-{
-    client: ZendeskClient
-    paginator?: clientUtils.Paginator
-    config?: ZendeskConfig
-    fetchQuery?: elementUtils.query.ElementQuery
-    elementsSource?: ReadOnlyElementsSource
-} => ({
+} : Partial<FilterCreatorParams>) : FilterCreatorParams => ({
   client, paginator, config, fetchQuery, elementsSource,
 })


### PR DESCRIPTION
Created a generic function for createFilterParams in zendesk, and refactored the tests to use it

---

the only logic is in utils.ts,

---
_Release Notes_: 
No change for users

---
_User Notifications_: 
No user notifications
