### PR TITLE
SALTO-2844: Jira DC support issueEvents- add, edit and delete

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -103,7 +103,8 @@ import permissionSchemeFilter from './filters/permission_scheme/sd_portals_permi
 import allowedPermissionsSchemeFilter from './filters/permission_scheme/allowed_permission_schemes'
 import automationLabelFetchFilter from './filters/automation/automation_label/label_fetch'
 import automationLabelDeployFilter from './filters/automation/automation_label/label_deployment'
-import filtersDcDeployFilter from './filters/filters_dc_deploy'
+import filtersDcDeployFilter from './filters/data_center/filters_permissions'
+import deployDcIssueEventsFilter from './filters/data_center/issue_events'
 import { GetIdMapFunc, getIdMapFuncCreator } from './users_map'
 
 const {
@@ -206,6 +207,7 @@ export const DEFAULT_FILTERS = [
   addDisplayNameFilter,
   // Must run after accountIdFilter
   wrongUserPermissionSchemeFilter,
+  deployDcIssueEventsFilter,
   // Must be last
   defaultInstancesDeployFilter,
 ]

--- a/packages/jira-adapter/src/constants.ts
+++ b/packages/jira-adapter/src/constants.ts
@@ -65,3 +65,4 @@ export const ACCOUNT_ID_INFO_TYPE = 'AccountIdInfo'
 export const ACCOUNT_ID_STRING = 'ACCOUNT_ID'
 export const ACCOUNT_IDS_FIELDS_NAMES = ['leadAccountId', 'authorAccountId', 'accountId']
 export const JIRA_USERS_PAGE = 'jira/people/search'
+export const ISSUE_EVENT_TYPE_NAME = 'IssueEvent'

--- a/packages/jira-adapter/src/filters/data_center/filters_permissions.ts
+++ b/packages/jira-adapter/src/filters/data_center/filters_permissions.ts
@@ -15,7 +15,7 @@
 */
 import { getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, Value } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { FilterCreator } from '../filter'
+import { FilterCreator } from '../../filter'
 
 const isFilterInstance = (instanceElement: InstanceElement): boolean =>
   instanceElement.elemID.typeName === 'Filter'

--- a/packages/jira-adapter/src/filters/data_center/issue_events.ts
+++ b/packages/jira-adapter/src/filters/data_center/issue_events.ts
@@ -1,0 +1,40 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { CORE_ANNOTATIONS } from '@salto-io/adapter-api'
+import { addAnnotationRecursively, findObject, setTypeDeploymentAnnotations } from '../../utils'
+import { FilterCreator } from '../../filter'
+import { ISSUE_EVENT_TYPE_NAME } from '../../constants'
+
+/**
+ * Filter to support deploy in DC, handles annotations of IssueEvents
+ */
+const filter: FilterCreator = ({ client }) => ({
+  onFetch: async elements => {
+    if (!client.isDataCenter) {
+      return
+    }
+    const issueEventType = findObject(elements, ISSUE_EVENT_TYPE_NAME)
+    if (issueEventType === undefined) {
+      return
+    }
+    setTypeDeploymentAnnotations(issueEventType)
+    await addAnnotationRecursively(issueEventType, CORE_ANNOTATIONS.CREATABLE)
+    await addAnnotationRecursively(issueEventType, CORE_ANNOTATIONS.UPDATABLE)
+    issueEventType.fields.id.annotations[CORE_ANNOTATIONS.CREATABLE] = false
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/test/filters/data_center/filters_permissions.test.ts
+++ b/packages/jira-adapter/test/filters/data_center/filters_permissions.test.ts
@@ -17,10 +17,10 @@ import { BuiltinTypes, ElemID, ElemIdGetter, InstanceElement, ObjectType, toChan
 import { mockFunction } from '@salto-io/test-utils'
 import { filterUtils } from '@salto-io/adapter-components'
 import _ from 'lodash'
-import { getFilterParams, mockClient } from '../utils'
-import { getDefaultConfig } from '../../src/config/config'
-import { JIRA } from '../../src/constants'
-import filtersDcDeployFilter from '../../src/filters/filters_dc_deploy'
+import { getFilterParams, mockClient } from '../../utils'
+import { getDefaultConfig } from '../../../src/config/config'
+import { JIRA } from '../../../src/constants'
+import filtersDcDeployFilter from '../../../src/filters/data_center/filters_permissions'
 
 const verifyEditInstance0 = (
   permissions: Value[],

--- a/packages/jira-adapter/test/filters/data_center/issue_events.test.ts
+++ b/packages/jira-adapter/test/filters/data_center/issue_events.test.ts
@@ -1,0 +1,117 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, ElemIdGetter, ObjectType } from '@salto-io/adapter-api'
+import { mockFunction } from '@salto-io/test-utils'
+import { filterUtils } from '@salto-io/adapter-components'
+import _ from 'lodash'
+import { getFilterParams, mockClient } from '../../utils'
+import { getDefaultConfig } from '../../../src/config/config'
+import { JIRA } from '../../../src/constants'
+import issueEventsDcDeployFilter from '../../../src/filters/data_center/issue_events'
+
+describe('issue_events', () => {
+  let filter: filterUtils.FilterWith<'onFetch'>
+  let objectType: ObjectType
+  let objectWrongType: ObjectType
+  beforeEach(() => {
+    const elemIdGetter = mockFunction<ElemIdGetter>()
+      .mockImplementation((adapterName, _serviceIds, name) => new ElemID(adapterName, name))
+
+    const config = _.cloneDeep(getDefaultConfig({ isDataCenter: true }))
+
+    const { client, paginator } = mockClient(true)
+    filter = issueEventsDcDeployFilter(getFilterParams({
+      client,
+      paginator,
+      config,
+      getElemIdFunc: elemIdGetter,
+    })) as typeof filter
+
+    objectType = new ObjectType({
+      elemID: new ElemID(JIRA, 'IssueEvent'),
+      fields:
+      {
+        name: { refType: BuiltinTypes.STRING },
+        templateName: { refType: BuiltinTypes.STRING },
+        description: { refType: BuiltinTypes.STRING },
+        id: { refType: BuiltinTypes.SERVICE_ID_NUMBER },
+      },
+    })
+    objectWrongType = new ObjectType({
+      elemID: new ElemID(JIRA, 'PermissionScheme'),
+      fields:
+      {
+        name: { refType: BuiltinTypes.STRING },
+        templateName: { refType: BuiltinTypes.STRING },
+        description: { refType: BuiltinTypes.STRING },
+        id: { refType: BuiltinTypes.SERVICE_ID_NUMBER },
+      },
+    })
+  })
+  it('should change annotations on type', async () => {
+    await filter.onFetch([objectWrongType, objectType])
+    expect(objectType.annotations[CORE_ANNOTATIONS.CREATABLE]).toBeTrue()
+    expect(objectType.annotations[CORE_ANNOTATIONS.UPDATABLE]).toBeTrue()
+    expect(objectType.fields.id.annotations[CORE_ANNOTATIONS.CREATABLE]).toBeFalse()
+    expect(objectType.fields.id.annotations[CORE_ANNOTATIONS.UPDATABLE]).toBeTrue()
+    expect(objectType.fields.name.annotations[CORE_ANNOTATIONS.UPDATABLE]).toBeTrue()
+    expect(objectType.fields.name.annotations[CORE_ANNOTATIONS.CREATABLE]).toBeTrue()
+    expect(objectType.fields.description.annotations[CORE_ANNOTATIONS.UPDATABLE]).toBeTrue()
+    expect(objectType.fields.description.annotations[CORE_ANNOTATIONS.CREATABLE]).toBeTrue()
+    expect(objectType.fields.templateName.annotations[CORE_ANNOTATIONS.UPDATABLE]).toBeTrue()
+    expect(objectType.fields.templateName.annotations[CORE_ANNOTATIONS.CREATABLE]).toBeTrue()
+  })
+  it('should not add annotations when operating on a different type', async () => {
+    await filter.onFetch([objectWrongType])
+    expect(objectWrongType.annotations[CORE_ANNOTATIONS.CREATABLE]).toBeUndefined()
+    expect(objectWrongType.annotations[CORE_ANNOTATIONS.UPDATABLE]).toBeUndefined()
+    expect(objectWrongType.fields.id.annotations[CORE_ANNOTATIONS.CREATABLE]).toBeUndefined()
+    expect(objectWrongType.fields.id.annotations[CORE_ANNOTATIONS.UPDATABLE]).toBeUndefined()
+    expect(objectWrongType.fields.name.annotations[CORE_ANNOTATIONS.UPDATABLE]).toBeUndefined()
+    expect(objectWrongType.fields.name.annotations[CORE_ANNOTATIONS.CREATABLE]).toBeUndefined()
+    expect(objectWrongType.fields.description.annotations[CORE_ANNOTATIONS.UPDATABLE])
+      .toBeUndefined()
+    expect(objectWrongType.fields.description.annotations[CORE_ANNOTATIONS.CREATABLE])
+      .toBeUndefined()
+    expect(objectWrongType.fields.templateName.annotations[CORE_ANNOTATIONS.UPDATABLE])
+      .toBeUndefined()
+    expect(objectWrongType.fields.templateName.annotations[CORE_ANNOTATIONS.CREATABLE])
+      .toBeUndefined()
+  })
+  it('should not change type on cloud flow', async () => {
+    const elemIdGetter = mockFunction<ElemIdGetter>()
+      .mockImplementation((adapterName, _serviceIds, name) => new ElemID(adapterName, name))
+    const config = _.cloneDeep(getDefaultConfig({ isDataCenter: true }))
+    const { client, paginator } = mockClient()
+    const cloudFilter = issueEventsDcDeployFilter(getFilterParams({
+      client,
+      paginator,
+      config,
+      getElemIdFunc: elemIdGetter,
+    })) as typeof filter
+    await cloudFilter.onFetch([objectType])
+    expect(objectType.annotations[CORE_ANNOTATIONS.CREATABLE]).toBeUndefined()
+    expect(objectType.annotations[CORE_ANNOTATIONS.UPDATABLE]).toBeUndefined()
+    expect(objectType.fields.id.annotations[CORE_ANNOTATIONS.CREATABLE]).toBeUndefined()
+    expect(objectType.fields.id.annotations[CORE_ANNOTATIONS.UPDATABLE]).toBeUndefined()
+    expect(objectType.fields.name.annotations[CORE_ANNOTATIONS.UPDATABLE]).toBeUndefined()
+    expect(objectType.fields.name.annotations[CORE_ANNOTATIONS.CREATABLE]).toBeUndefined()
+    expect(objectType.fields.description.annotations[CORE_ANNOTATIONS.UPDATABLE]).toBeUndefined()
+    expect(objectType.fields.description.annotations[CORE_ANNOTATIONS.CREATABLE]).toBeUndefined()
+    expect(objectType.fields.templateName.annotations[CORE_ANNOTATIONS.UPDATABLE]).toBeUndefined()
+    expect(objectType.fields.templateName.annotations[CORE_ANNOTATIONS.CREATABLE]).toBeUndefined()
+  })
+})


### PR DESCRIPTION
_Added support for add (post) for JIRA DC IssueEvents
Plugin part available [here_](https://github.com/salto-io/jira-dc-app/pull/18) and [here](https://github.com/salto-io/jira-dc-app/pull/16) 

---

It seems I did some mess here, did not merge the add part (which was reviewed) and overrode it with a push -f :man-facepalming:
The current push in OSS only involved the changes to delete and put in the data_center.ts file, and one line in the filter file (issue_events)- I removed a line that did not allow to update (I accidentally set before the id to be updateable = false )
Also renamed the folders and files

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
