### PR TITLE
SALTO-2920 remove wrong customsegment dependencies from manifest.xml

### DIFF
--- a/packages/netsuite-adapter/src/client/manifest_utils.ts
+++ b/packages/netsuite-adapter/src/client/manifest_utils.ts
@@ -31,6 +31,10 @@ const TEXT_ATTRIBUTE = '#text'
 const REQUIRED_ATTRIBUTE = '@_required'
 const INVALID_DEPENDENCIES = ['ADVANCEDEXPENSEMANAGEMENT', 'SUBSCRIPTIONBILLING', 'WMSSYSTEM', 'BILLINGACCOUNTS']
 
+// customrecordABC.csegXYZ is not a real object in NS -
+// It is used as a reference but it shouldn’t be included in the manifest.
+const wrongCustomSegmentDependencyRegex = RegExp('customrecord[a-z0-9_]+\\.cseg[a-z0-9_]+')
+
 type RequiredDependency = {
   typeName: string
   dependency: string
@@ -105,7 +109,14 @@ const getRequiredObjects = (customizationInfos: CustomizationInfo[]): string[] =
       requiredObjects.push(...captureServiceIdInfo(val)
         .filter(({ serviceIdType, appid }) => serviceIdType === 'scriptid' && appid === undefined)
         .map(serviceIdInfo => serviceIdInfo.serviceId)
-        .filter(scriptId => !objNames.has(scriptId.split('.')[0])))
+        .filter(scriptId => !objNames.has(scriptId.split('.')[0]))
+        .filter(scriptId => {
+          if (wrongCustomSegmentDependencyRegex.test(scriptId)) {
+            log.debug('removing wrong customsegment dependency from manifest: %o', scriptId)
+            return false
+          }
+          return true
+        }))
     })
     return requiredObjects
   }))

--- a/packages/netsuite-adapter/src/client/manifest_utils.ts
+++ b/packages/netsuite-adapter/src/client/manifest_utils.ts
@@ -31,7 +31,7 @@ const TEXT_ATTRIBUTE = '#text'
 const REQUIRED_ATTRIBUTE = '@_required'
 const INVALID_DEPENDENCIES = ['ADVANCEDEXPENSEMANAGEMENT', 'SUBSCRIPTIONBILLING', 'WMSSYSTEM', 'BILLINGACCOUNTS']
 
-// customrecordABC.csegXYZ is not a real object in NS -
+// customrecord*.cseg* is not a real object in NS -
 // It is used as a reference but it shouldn’t be included in the manifest.
 const wrongCustomSegmentDependencyRegex = RegExp('customrecord[a-z0-9_]+\\.cseg[a-z0-9_]+')
 

--- a/packages/netsuite-adapter/test/client/manifest_utils.test.ts
+++ b/packages/netsuite-adapter/test/client/manifest_utils.test.ts
@@ -29,6 +29,7 @@ describe('manifest.xml utils', () => {
       values: {
         '@_scriptid': 'scriptid1',
         key: '__STDRECORDSUBSIDIARYDEFAULTACCTCORPCARDEXP__',
+        // 'somescriptid' should be added to the manifest
         ref: '[scriptid=somescriptid]',
       },
     },
@@ -37,11 +38,20 @@ describe('manifest.xml utils', () => {
       values: {
         '@_scriptid': 'workflow1',
         key: '__STDRECORDSUBSIDIARYDEFAULTACCTCORPCARDEXP__',
+        // 'secondscriptid' should be added to the manifest
         ref: '[scriptid=secondscriptid]',
+        // 'scriptid1' shouldn't be added to the manifest since it is in the SDF project
         ref2: '[scriptid=scriptid1]',
+        // 'workflow1.innerscriptid' shouldn't be added to the manifest since
+        // 'workflow1' is in the SDF project
         ref3: '[scriptid=workflow1.innerscriptid]',
+        // 'external_script_id' shouldn't be added to the manifest since it has appid
         ref4: '[appid=com.salto, scriptid=external_script_id]',
+        // '/SuiteScripts/test.js' shouldn't be added to the manifest since we add only scriptids
         fileRef: '[/SuiteScripts/test.js]',
+        // 'customrecord_test.cseg1' shouldn't be added to the manifest since
+        // it is a wrong customsegment scriptid
+        customSegmentRef: '[scriptid=customrecord_test.cseg1]',
       },
     },
   ]


### PR DESCRIPTION
In some cases we have a NS reference to a customsegment that looks like `[type=customrecordcustomfield, script=customrecord*.cseg*]`. Like other NS references, we add that object dependency to the manifest.

The problem is that `customrecord*.cseg*` is not a real object in NS - It is used as a reference but it shouldn’t be included in the manifest.

---
_Release Notes_: 
Netsuite Adapter:
- Remove wrong customsegment dependencies from manifest.xml

---
_User Notifications_: 
None