### PR TITLE
SALTO-2570: update NOT_YET_SUPPORTED change validator error messages

### DIFF
--- a/packages/netsuite-adapter/src/change_validators/not_yet_supported_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/not_yet_supported_values.ts
@@ -35,8 +35,8 @@ const changeValidator: ChangeValidator = async changes => (
     .map(element => ({
       elemID: element.elemID,
       severity: 'Error',
-      message: 'Instances with values set to \'NOT_YET_SUPPORTED\' cannot be deployed.',
-      detailedMessage: 'Please see https://docs.salto.io/docs/netsuite#deploy-troubleshooting for more details.',
+      message: 'Elements with values set to \'NOT_YET_SUPPORTED\' cannot be deployed',
+      detailedMessage: 'Elements with values set to \'NOT_YET_SUPPORTED\' cannot be deployed. Please see https://docs.salto.io/docs/netsuite#deploy-troubleshooting for more details.',
     } as ChangeError))
     .toArray()
 )

--- a/packages/netsuite-adapter/src/change_validators/not_yet_supported_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/not_yet_supported_values.ts
@@ -35,8 +35,8 @@ const changeValidator: ChangeValidator = async changes => (
     .map(element => ({
       elemID: element.elemID,
       severity: 'Error',
-      message: 'Elements with values set to \'NOT_YET_SUPPORTED\' cannot be deployed',
-      detailedMessage: 'Elements with values set to \'NOT_YET_SUPPORTED\' cannot be deployed. In order to deploy, please manually replace \'NOT_YET_SUPPORTED\' with a valid value.',
+      message: 'Instances with values set to \'NOT_YET_SUPPORTED\' cannot be deployed.',
+      detailedMessage: 'Please see https://docs.salto.io/docs/netsuite#deploy-troubleshooting for more details.',
     } as ChangeError))
     .toArray()
 )


### PR DESCRIPTION
_Error message in the NOT_YET_SUPPORTED updated_

---

_None_

---
_Release Notes_: 
_Netsuite adapter_:
* Error message updated to address the netsuite deploy troubleshooting doc


---
_User Notifications_: 
_None_
