### PR TITLE
SALTO-2811 fix the deletion of flows CV

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/flow_deletion.ts
+++ b/packages/salesforce-adapter/src/change_validators/flow_deletion.ts
@@ -22,15 +22,12 @@ import { FLOW_METADATA_TYPE } from '../constants'
 import { isInstanceOfType } from '../filters/utils'
 
 const { awu } = collections.asynciterable
-const DRAFT = 'Draft'
-
-const isInstanceOfTypeFlow = isInstanceOfType(FLOW_METADATA_TYPE)
 
 const createChangeError = (instance: InstanceElement): ChangeError => ({
   elemID: instance.elemID,
   severity: 'Error',
-  message: 'Cannot delete flow that is not in ‘draft’ status',
-  detailedMessage: `Cannot delete flow that is not in ‘draft’ state. Flow name: ${instance.elemID.getFullName()}, status: ${instance.value.status} `,
+  message: 'Cannot delete flow',
+  detailedMessage: `Cannot delete flow via metadata API. Flow name: ${instance.elemID.getFullName()}`,
 })
 
 /**
@@ -40,8 +37,7 @@ const changeValidator: ChangeValidator = async changes => awu(changes)
   .filter(isInstanceChange)
   .filter(isRemovalChange)
   .map(getChangeData)
-  .filter(isInstanceOfTypeFlow)
-  .filter(instance => instance.value.status !== DRAFT)
+  .filter(isInstanceOfType(FLOW_METADATA_TYPE))
   .map(createChangeError)
   .toArray()
 

--- a/packages/salesforce-adapter/test/change_validators/flow_deletion.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/flow_deletion.test.ts
@@ -20,26 +20,13 @@ import { createInstanceElement } from '../../src/transformers/transformer'
 
 describe('flow deletion change validator', () => {
   let flowChange: Change
-  describe('delete a draft flow', () => {
-    beforeEach(() => {
-      const beforeRecord = createInstanceElement({ fullName: 'flow1', status: 'Draft' }, mockTypes.Flow)
-      flowChange = toChange({ before: beforeRecord })
-    })
-
-    it('should have no error when trying to delete a draft flow', async () => {
-      const changeErrors = await flowDeletionChangeValidator(
-        [flowChange]
-      )
-      expect(changeErrors).toBeEmpty()
-    })
-  })
-  describe('delete a non draft flow', () => {
+  describe('delete flow', () => {
     beforeEach(() => {
       const beforeRecord = createInstanceElement({ fullName: 'flow2', status: 'Active' }, mockTypes.Flow)
       flowChange = toChange({ before: beforeRecord })
     })
 
-    it('should have error when trying to delete a non draft flow', async () => {
+    it('should have error when trying to delete a flow', async () => {
       const changeErrors = await flowDeletionChangeValidator(
         [flowChange]
       )


### PR DESCRIPTION
_fix the deletion of flows CV_

---
_Additional context for reviewer_:
None

---
_Release Notes_: 
Salesforce-adapter:

* fix the flow deletion change validator so it will not be able to delete flows
---

_User Notifications_: 
None
