### PR TITLE
SALTO-2843: Support fields deployment in Jira DC

### DIFF
--- a/packages/jira-adapter/src/filters/fields/contexts.ts
+++ b/packages/jira-adapter/src/filters/fields/contexts.ts
@@ -84,7 +84,7 @@ export const getContexts = async (
   client: JiraClient,
 ): Promise<InstanceElement[]> => {
   const fieldInstance = getChangeData(fieldChange)
-  const resp = await client.getSinglePage({ url: `/rest/api/3/field/${fieldInstance.value.id}/contexts` })
+  const resp = await client.getSinglePage({ url: `/rest/api/3/field/${fieldInstance.value.id}/context` })
   if (!Array.isArray(resp.data.values)) {
     log.warn(`Received unexpected response from Jira when querying contexts for instance ${getChangeData(fieldChange).elemID.getFullName()}: ${safeJsonStringify(resp.data.values)}`)
     throw new Error(`Received unexpected response from Jira when querying contexts for instance ${getChangeData(fieldChange).elemID.getFullName()}`)

--- a/packages/jira-adapter/src/product_settings/data_center.ts
+++ b/packages/jira-adapter/src/product_settings/data_center.ts
@@ -109,8 +109,44 @@ const PLUGIN_URL_PATTERNS: UrlPattern[] = [
     url: '/rest/api/3/field/search',
   },
   {
-    httpMethods: ['get'],
+    httpMethods: ['put', 'delete'],
+    url: '/rest/api/3/field/.*',
+  },
+  {
+    httpMethods: ['get', 'post'],
     url: '/rest/api/3/field/.*/context',
+  },
+  {
+    httpMethods: ['put', 'delete'],
+    url: '/rest/api/3/field/.*/context/\\d+',
+  },
+  {
+    httpMethods: ['put'],
+    url: '/rest/api/3/field/.*/context/\\d+/issuetype',
+  },
+  {
+    httpMethods: ['post'],
+    url: '/rest/api/3/field/.*/context/\\d+/issuetype/remove',
+  },
+  {
+    httpMethods: ['put'],
+    url: '/rest/api/3/field/.*/context/\\d+/project',
+  },
+  {
+    httpMethods: ['post'],
+    url: '/rest/api/3/field/.*/context/\\d+/project/remove',
+  },
+  {
+    httpMethods: ['post', 'put'],
+    url: '/rest/api/3/field/.*/context/\\d+/option',
+  },
+  {
+    httpMethods: ['delete'],
+    url: '/rest/api/3/field/.*/context/\\d+/option/\\d+',
+  },
+  {
+    httpMethods: ['put'],
+    url: '/rest/api/3/field/.*/context/\\d+/option/move',
   },
   {
     httpMethods: ['get'],

--- a/packages/jira-adapter/test/filters/fields/field_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_deployment.test.ts
@@ -104,7 +104,7 @@ describe('fields_deployment', () => {
     mockConnection.get.mockImplementation(async url => ({
       status: 200,
       data: {
-        values: url === '/rest/api/3/field/field_1/contexts'
+        values: url === '/rest/api/3/field/field_1/context'
           ? [{ id: '4' }]
           : [],
       },


### PR DESCRIPTION
Added support for fields deployment in Jira DC

Plugin PR: https://github.com/salto-io/jira-dc-app/pull/19

---
_Release Notes_: 
None

---
_User Notifications_: 
None