### PR TITLE
SALTO-2849: Support automations in Jira DC

### DIFF
--- a/packages/jira-adapter/src/change_validators/account_id.ts
+++ b/packages/jira-adapter/src/change_validators/account_id.ts
@@ -141,7 +141,9 @@ export const accountIdValidator: (
 ) =>
   ChangeValidator = (client, config, getIdMapFunc) => async changes =>
     log.time(async () => {
-      if (!(config.fetch.showUserDisplayNames ?? true)) {
+      if (!(config.fetch.showUserDisplayNames ?? true)
+        // Temporary until we support it in DC
+        || client.isDataCenter) {
         return []
       }
       const idMap = await getIdMapFunc()

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -36,9 +36,9 @@ import { globalProjectContextsValidator } from './global_project_contexts'
 import { systemFieldsValidator } from './system_fields'
 import { workflowPropertiesValidator } from './workflow_properties'
 import { permissionSchemeValidator } from './sd_portals_permission_scheme'
-import { accountIdValidator } from './account_id'
 import { wrongUserPermissionSchemeValidator } from './wrong_user_permission_scheme'
 import { GetIdMapFunc } from '../users_map'
+import { accountIdValidator } from './account_id'
 
 const {
   deployTypesNotSupportedValidator,


### PR DESCRIPTION
Added support for automation in Jira DC

----

There is a little difference in the requests in DC and Cloud (mainly the URL prefix and sometimes the HTTP method)

---
_Release Notes_: 
None

---
_User Notifications_: 
None