### PR TITLE
SALTO-2910: add plugin urls for IssueTypeScreenScheme - Jira DC

### DIFF
--- a/packages/jira-adapter/src/product_settings/data_center.ts
+++ b/packages/jira-adapter/src/product_settings/data_center.ts
@@ -124,6 +124,30 @@ const PLUGIN_URL_PATTERNS: UrlPattern[] = [
     httpMethods: ['get'],
     url: '/rest/api/3/field/.*/context/.*/option',
   },
+  {
+    httpMethods: ['get'],
+    url: '/rest/api/3/issuetypescreenscheme',
+  },
+  {
+    httpMethods: ['put', 'delete'],
+    url: '/rest/api/3/issuetypescreenscheme/\\d+',
+  },
+  {
+    httpMethods: ['put'],
+    url: '/rest/api/3/issuetypescreenscheme/\\d+/mapping',
+  },
+  {
+    httpMethods: ['put'],
+    url: '/rest/api/3/issuetypescreenscheme/\\d+/mapping/default',
+  },
+  {
+    httpMethods: ['post'],
+    url: '/rest/api/3/issuetypescreenscheme/\\d+/mapping/remove',
+  },
+  {
+    httpMethods: ['get'],
+    url: '/rest/api/3/issuetypescreenscheme/mapping.+',
+  },
 ]
 
 const DC_DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {

--- a/packages/jira-adapter/src/product_settings/data_center.ts
+++ b/packages/jira-adapter/src/product_settings/data_center.ts
@@ -125,7 +125,7 @@ const PLUGIN_URL_PATTERNS: UrlPattern[] = [
     url: '/rest/api/3/field/.*/context/.*/option',
   },
   {
-    httpMethods: ['get'],
+    httpMethods: ['get', 'post'],
     url: '/rest/api/3/issuetypescreenscheme',
   },
   {


### PR DESCRIPTION
_Add plugin urls for IssueTypeScreenScheme_

---

link to the plugin PR: https://github.com/salto-io/jira-dc-app/pull/20

---

_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
