### PR TITLE
SALTO-2845: Jira DC Security Scheme (get)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ yarn-error.log
 # salto logs
 logsalto.log
 
+# salto logs
+logsalto.log
+
 # jest
 /.jest_cache
 

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -105,6 +105,7 @@ import automationLabelFetchFilter from './filters/automation/automation_label/la
 import automationLabelDeployFilter from './filters/automation/automation_label/label_deployment'
 import filtersDcDeployFilter from './filters/data_center/filters_permissions'
 import deployDcIssueEventsFilter from './filters/data_center/issue_events'
+import deployDcSecuritySchemeFilter from './filters/data_center/security_scheme_deploy'
 import { GetIdMapFunc, getIdMapFuncCreator } from './users_map'
 
 const {
@@ -208,6 +209,7 @@ export const DEFAULT_FILTERS = [
   // Must run after accountIdFilter
   wrongUserPermissionSchemeFilter,
   deployDcIssueEventsFilter,
+  deployDcSecuritySchemeFilter,
   // Must be last
   defaultInstancesDeployFilter,
 ]

--- a/packages/jira-adapter/src/filters/data_center/security_scheme_deploy.ts
+++ b/packages/jira-adapter/src/filters/data_center/security_scheme_deploy.ts
@@ -1,0 +1,131 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { getChangeData, isAdditionChange, isInstanceChange } from '@salto-io/adapter-api'
+import { getParents } from '@salto-io/adapter-utils'
+import _ from 'lodash'
+import { SECURITY_LEVEL_TYPE, SECURITY_SCHEME_TYPE } from '../../constants'
+import { JiraApiConfig } from '../../config/api_config'
+import { defaultDeployChange, deployChanges } from '../../deployment/standard_deployment'
+import { FilterCreator } from '../../filter'
+
+
+const SUPPORTED_TYPES = {
+  SecurityScheme: ['SecuritySchemes'],
+}
+
+const DATA_CENTER_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
+  // Cloud platform API
+  SecurityScheme: {
+    deployRequests: {
+      add: {
+        url: 'rest/salto/1.0/issuesecurityschemes?name={name}&description={description}',
+        method: 'post',
+      },
+    },
+  },
+  SecurityLevel: {
+    deployRequests: {
+      add: {
+        url: 'rest/salto/1.0/securitylevel?securitySchemeId={schemeId}',
+        method: 'post',
+      },
+    },
+  },
+}
+
+const DC_REDUCED_API_DEFINITIONS: JiraApiConfig = {
+  platformSwagger: {
+    url: '',
+  },
+  jiraSwagger: {
+    url: '',
+  },
+  typeDefaults: {
+    transformation: {
+      idFields: [],
+    },
+  },
+  types: DATA_CENTER_TYPE_CUSTOMIZATIONS,
+  typesToFallbackToInternalId: [],
+  supportedTypes: SUPPORTED_TYPES,
+}
+
+const filter: FilterCreator = ({ client }) => ({
+  deploy: async changes => {
+    if (!client.isDataCenter) {
+      return { deployResult: { appliedChanges: [], errors: [] }, leftoverChanges: changes }
+    }
+    const [relevantChanges, leftoverChanges] = _.partition(
+      changes,
+      change => isInstanceChange(change)
+        && (
+          getChangeData(change).elemID.typeName === SECURITY_SCHEME_TYPE
+          || getChangeData(change).elemID.typeName === SECURITY_LEVEL_TYPE
+        )
+    )
+
+    // This code is meant to allow adding new levels with a new scheme (no scheme id yet).
+    // Note that deploy is called in groups, so only 1 scheme (if it was changed) with
+    // its changed levels
+    const securitySchemeChange = relevantChanges
+      .filter(isInstanceChange)
+      .find(change => getChangeData(change).elemID.typeName === SECURITY_SCHEME_TYPE)
+
+    const schemesDeployResult = securitySchemeChange !== undefined
+      && isAdditionChange(securitySchemeChange)
+      ? await deployChanges([securitySchemeChange],
+        async change => {
+          await defaultDeployChange({ change, client, apiDefinitions: DC_REDUCED_API_DEFINITIONS })
+        })
+      : {
+        appliedChanges: [],
+        errors: [],
+      }
+
+    if (schemesDeployResult.errors.length !== 0) {
+      return {
+        leftoverChanges,
+        deployResult: schemesDeployResult,
+      }
+    }
+
+    const levelsChanges = relevantChanges
+      .filter(isInstanceChange)
+      .filter(change => getChangeData(change).elemID.typeName === SECURITY_LEVEL_TYPE)
+
+    levelsChanges.forEach(change => {
+      getChangeData(change).value.schemeId = securitySchemeChange !== undefined
+        ? getChangeData(securitySchemeChange).value.id
+        : getParents(getChangeData(change))[0].value.value.id
+    })
+
+    const deployResult = await deployChanges(
+      levelsChanges.filter(isInstanceChange),
+      async change => {
+        await defaultDeployChange({ change, client, apiDefinitions: DC_REDUCED_API_DEFINITIONS })
+      },
+    )
+    deployResult.appliedChanges = [
+      ...deployResult.appliedChanges,
+      ...schemesDeployResult.appliedChanges]
+    return {
+      leftoverChanges,
+      deployResult,
+    }
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/src/filters/security_scheme/security_scheme.ts
+++ b/packages/jira-adapter/src/filters/security_scheme/security_scheme.ts
@@ -223,6 +223,9 @@ const filter: FilterCreator = ({ client, config }) => ({
   },
 
   deploy: async changes => {
+    if (client.isDataCenter) {
+      return { deployResult: { appliedChanges: [], errors: [] }, leftoverChanges: changes }
+    }
     const [relevantChanges, leftoverChanges] = _.partition(
       changes,
       change => isInstanceChange(change)
@@ -232,6 +235,9 @@ const filter: FilterCreator = ({ client, config }) => ({
         )
     )
 
+    // This code is meant to allow adding new levels with a new scheme (no scheme id yet).
+    // Note that deploy is called in groups, so only 1 scheme (if it was changed) with
+    // its changed levels
     const securitySchemeChange = relevantChanges
       .filter(isInstanceChange)
       .find(change => getChangeData(change).elemID.typeName === SECURITY_SCHEME_TYPE)

--- a/packages/jira-adapter/src/product_settings/data_center.ts
+++ b/packages/jira-adapter/src/product_settings/data_center.ts
@@ -73,22 +73,6 @@ const PLUGIN_URL_PATTERNS: UrlPattern[] = [
     url: '/rest/api/3/screens/\\d+',
   },
   {
-    httpMethods: ['get'],
-    url: '/rest/api/3/workflow/search',
-  },
-  {
-    httpMethods: ['post'],
-    url: '/rest/api/3/workflow',
-  },
-  {
-    httpMethods: ['delete'],
-    url: '/rest/api/3/workflow/\\d+',
-  },
-  {
-    httpMethods: ['put', 'delete'],
-    url: '/rest/api/3/screens/\\d+',
-  },
-  {
     httpMethods: ['get', 'post'],
     url: '/rest/api/3/screenscheme',
   },
@@ -159,6 +143,10 @@ const PLUGIN_URL_PATTERNS: UrlPattern[] = [
   {
     httpMethods: ['get'],
     url: '/rest/api/3/field/.*/context/.*/option',
+  },
+  {
+    httpMethods: ['get'],
+    url: '/rest/api/3/issuesecurityschemes/.*/members.*',
   },
 ]
 

--- a/packages/jira-adapter/test/filters/data_center/security_scheme_deploy.test.ts
+++ b/packages/jira-adapter/test/filters/data_center/security_scheme_deploy.test.ts
@@ -1,0 +1,182 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, Change, ChangeDataType, ElemID, ElemIdGetter, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import { mockFunction } from '@salto-io/test-utils'
+import { filterUtils } from '@salto-io/adapter-components'
+import _ from 'lodash'
+import { getFilterParams, mockClient } from '../../utils'
+import { getDefaultConfig } from '../../../src/config/config'
+import { JIRA } from '../../../src/constants'
+import dcSecuritySchemeDeployFilter from '../../../src/filters/data_center/security_scheme_deploy'
+
+const verifyElement = (appliedChanges: readonly Change[], num: number):void => {
+  expect(appliedChanges.length).toEqual(1)
+  const afterChange = (appliedChanges[0].data as { after: ChangeDataType })
+    .after as InstanceElement
+  expect(afterChange.value.id).toEqual(num)
+  expect(afterChange.value.name).toEqual(`name${num}`)
+  expect(afterChange.value.description).toEqual(`description${num}`)
+}
+
+describe('security_scheme_deploy', () => {
+  let filter: filterUtils.FilterWith<'deploy'>
+  let instances: InstanceElement[]
+
+  beforeEach(() => {
+    const elemIdGetter = mockFunction<ElemIdGetter>()
+      .mockImplementation((adapterName, _serviceIds, name) => new ElemID(adapterName, name))
+
+    const config = _.cloneDeep(getDefaultConfig({ isDataCenter: true }))
+
+    const { client, paginator, connection } = mockClient(true)
+    filter = dcSecuritySchemeDeployFilter(getFilterParams({
+      client,
+      paginator,
+      config,
+      getElemIdFunc: elemIdGetter,
+    })) as typeof filter
+
+    const objectType = new ObjectType({
+      elemID: new ElemID(JIRA, 'SecurityScheme'),
+      fields:
+      {
+        str: { refType: BuiltinTypes.STRING }, // wrong structure
+      },
+    })
+    const levelObjectType = new ObjectType({
+      elemID: new ElemID(JIRA, 'SecurityLevel'),
+      fields:
+      {
+        str: { refType: BuiltinTypes.STRING }, // wrong structure
+      },
+    })
+    const wrongObjectType = new ObjectType({
+      elemID: new ElemID(JIRA, 'PermissionScheme'),
+      fields:
+      {
+        str: { refType: BuiltinTypes.STRING }, // wrong structure
+      },
+    })
+
+    instances = []
+    instances[0] = new InstanceElement(
+      'instance1',
+      objectType,
+      {
+        name: 'name1',
+        description: 'description1',
+      }
+    )
+
+    instances[1] = new InstanceElement(
+      'instance2',
+      objectType,
+      {
+        name: 'name2',
+        description: 'description2',
+      }
+    )
+
+    instances[2] = new InstanceElement(
+      'instance3',
+      wrongObjectType,
+      {
+        name: 'name3',
+        description: 'description3',
+      }
+    )
+    instances[3] = new InstanceElement(
+      'instance4',
+      levelObjectType,
+      {
+        name: 'name4',
+        description: 'description4',
+      }
+    )
+
+    connection.post.mockImplementation(async url => {
+      if (url === 'rest/salto/1.0/issuesecurityschemes?name=name1&description=description1') {
+        return {
+          status: 200,
+          data: {
+            id: 1,
+            name: 'name1',
+            description: 'description1',
+          },
+        }
+      }
+      if (url === 'rest/salto/1.0/issuesecurityschemes?name=name2&description=description2') {
+        return {
+          status: 200,
+          data: {
+            id: 2,
+            name: 'name2',
+            description: 'description2',
+          },
+        }
+      }
+      throw new Error(`Unexpected url ${url}`)
+    })
+  })
+  describe('security scheme', async () => {
+    it('should successfully add and update id', async () => {
+      const res = await filter.deploy([toChange({ after: instances[0] })])
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toEqual([])
+      verifyElement(res.deployResult.appliedChanges, 1)
+    })
+    it('should move un-relevant changes correctly', async () => {
+      const res = await filter.deploy(
+        [toChange({ after: instances[1] }),
+          toChange({ after: instances[2] })]
+      )
+      expect(res.leftoverChanges).toHaveLength(1)
+      const leftOver = (res.leftoverChanges[0].data as { after: ChangeDataType })
+        .after as InstanceElement
+      expect(leftOver.value.name).toEqual('name3')
+      expect(res.deployResult.errors).toEqual([])
+      verifyElement(res.deployResult.appliedChanges, 2)
+    })
+    it('should not change elements in the cloud', async () => {
+      const { client, paginator } = mockClient(false)
+      const elemIdGetter = mockFunction<ElemIdGetter>()
+        .mockImplementation((adapterName, _serviceIds, name) => new ElemID(adapterName, name))
+      const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+      filter = dcSecuritySchemeDeployFilter(getFilterParams({
+        client,
+        paginator,
+        config,
+        getElemIdFunc: elemIdGetter,
+      })) as typeof filter
+
+      const res = await filter.deploy(
+        [toChange({ after: instances[0] }),
+          toChange({ after: instances[2] }),
+          toChange({ after: instances[1] })]
+      )
+      expect(res.leftoverChanges).toHaveLength(3)
+      expect(res.deployResult.appliedChanges.length).toEqual(0)
+    })
+  })
+  describe('security level', async () => {
+    it('should successfully add and update id', async () => {
+      const res = await filter.deploy([toChange({ after: instances[0] })])
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toEqual([])
+      verifyElement(res.deployResult.appliedChanges, 1)
+    })
+  })
+})

--- a/packages/jira-adapter/test/filters/security_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/security_scheme.test.ts
@@ -252,6 +252,23 @@ describe('securitySchemeFilter', () => {
       }))
     })
 
+    it('should have no effect when working on data center', async () => {
+      const { client: cli, paginator } = mockClient(true)
+      filter = securitySchemeFilter(getFilterParams({
+        client: cli,
+        paginator,
+        config,
+      })) as filterUtils.FilterWith<'onFetch' | 'deploy' | 'preDeploy' | 'onDeploy'>
+      const { deployResult, leftoverChanges } = await filter.deploy([
+        toChange({ after: securitySchemeInstance }),
+        toChange({ after: securityLevelInstance }),
+      ])
+      expect(deployResult.errors).toHaveLength(0)
+      expect(deployResult.appliedChanges).toHaveLength(0)
+      expect(leftoverChanges).toHaveLength(2)
+      expect(deployWithJspEndpointsMock).not.toHaveBeenCalled()
+    })
+
     it('should call deployWithJspEndpoints in the right order on creation', async () => {
       const { deployResult } = await filter.deploy([
         toChange({ after: securitySchemeInstance }),


### PR DESCRIPTION
_added support for Security Scheme in Jira DC_

---

_plugin PR available [here](https://github.com/salto-io/jira-dc-app/pull/21)_

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
