### PR TITLE
SALTO-2914: change validator for creation or removal of help center

### DIFF
--- a/packages/zendesk-adapter/src/change_validator.ts
+++ b/packages/zendesk-adapter/src/change_validator.ts
@@ -40,7 +40,9 @@ import {
   brandFieldForBrandBasedElementsValidator,
   translationForDefaultLocaleValidator,
   articleRemovalValidator,
-  articleLabelNamesRemovalValidator, helpCenterActivationValidator,
+  articleLabelNamesRemovalValidator,
+  helpCenterActivationValidator,
+  helpCenterCreationOrRemovalValidator,
 } from './change_validators'
 import ZendeskClient from './client/client'
 
@@ -92,6 +94,7 @@ export default ({
     brandFieldForBrandBasedElementsValidator,
     translationForDefaultLocaleValidator,
     helpCenterActivationValidator,
+    helpCenterCreationOrRemovalValidator(client, apiConfig),
   ]
   return createSkipParentsOfSkippedInstancesValidator(validators)
 }

--- a/packages/zendesk-adapter/src/change_validators/help_center_activation.ts
+++ b/packages/zendesk-adapter/src/change_validators/help_center_activation.ts
@@ -67,7 +67,7 @@ export const helpCenterActivationValidator: ChangeValidator = async changes => {
   return relevantInstances
     .flatMap(instance => [{
       elemID: instance.elemID,
-      severity: 'Error',
+      severity: 'Warning',
       message: 'Activation or deactivation of help center for a certain brand is not supported via Salto.',
       detailedMessage: `Activation or deactivation of help center for a certain brand is not supported via Salto. To activate or deactivate a help center, please go to ${instance.value.brand_url}/hc/admin/general_settings`,
     }])

--- a/packages/zendesk-adapter/src/change_validators/help_center_activation.ts
+++ b/packages/zendesk-adapter/src/change_validators/help_center_activation.ts
@@ -40,7 +40,7 @@ const BRAND_SCHEMA = Joi.object({
 }).unknown(true).required()
 
 
-const isBrand = createSchemeGuardForInstance<BrandType>(
+export const isBrand = createSchemeGuardForInstance<BrandType>(
   BRAND_SCHEMA, 'Received an invalid value for brand'
 )
 

--- a/packages/zendesk-adapter/src/change_validators/help_center_creation_or_removal.ts
+++ b/packages/zendesk-adapter/src/change_validators/help_center_creation_or_removal.ts
@@ -14,30 +14,56 @@
 * limitations under the License.
 */
 import {
+  Change, ChangeError,
   ChangeValidator,
-  getChangeData,
-  isInstanceChange,
+  getChangeData, InstanceElement, isAdditionChange,
+  isInstanceChange, isModificationChange,
 } from '@salto-io/adapter-api'
 import { BRAND_TYPE_NAME } from '../constants'
-import { invalidBrandChange } from './help_center_activation'
 import ZendeskClient from '../client/client'
 import { ZendeskApiConfig } from '../config'
+import { isBrand, invalidBrandChange } from './help_center_activation'
 
+export const invalidBrandAdditionChange = (change: Change<InstanceElement>, fieldToCheck: 'has_help_center' | 'help_center_state')
+  : boolean => {
+  if (!isBrand(getChangeData(change))) {
+    return false
+  }
+  return isAdditionChange(change)
+    && (change.data.after.value[fieldToCheck] === true)
+}
+
+/**
+ * This change validator checks that the field 'has_help_center' in a brand has not been changed or
+ * that a brand was created and has_help_center is not equal to true.
+ * This is since Salto does not support the cration or deletion of help center.
+ */
 export const helpCenterCreationOrRemovalValidator:
   (client: ZendeskClient, apiConfig: ZendeskApiConfig) =>
   ChangeValidator = (client, apiConfig) => async changes => {
-    const relevantInstances = changes
+    const relevantChanges = changes
       .filter(isInstanceChange)
       .filter(change => getChangeData(change).elemID.typeName === BRAND_TYPE_NAME)
-      .filter(change => invalidBrandChange(change, 'has_help_center'))
-      .map(getChangeData)
+      .filter(change => invalidBrandChange(change, 'has_help_center')
+        || invalidBrandAdditionChange(change, 'has_help_center'))
 
-    return relevantInstances
-      .flatMap(instance => [{
-        elemID: instance.elemID,
-        severity: 'Error',
-        message: 'Creation or removal of help center for a certain brand is not supported via Salto.',
-        detailedMessage: `Creation or removal of help center for a certain brand is not supported via Salto.
-        To create or remove a help center, please go to ${client.getUrl().href}${apiConfig.types.brand.transformation?.serviceUrl}`,
-      }])
+    return relevantChanges
+      .flatMap((change: Change): ChangeError[] => {
+        if (isModificationChange(change)) {
+          return [{
+            elemID: getChangeData(change).elemID,
+            severity: 'Error',
+            message: 'Creation or removal of help center for a certain brand is not supported via Salto.',
+            detailedMessage: `Creation or removal of help center for a certain brand is not supported via Salto.
+            To create or remove a help center, please go to ${client.getUrl().href}${apiConfig.types.brand.transformation?.serviceUrl}`,
+          }]
+        }
+        return [{
+          elemID: getChangeData(change).elemID,
+          severity: 'Warning', // TO DO waiting for Tomer to help with the phrasing
+          message: 'Creation of a brand with a help center is not supported via Salto.',
+          detailedMessage: `Creation of a brand with a help center is not supported via Salto.
+            To create a help center, please go to ${client.getUrl().href}${(apiConfig.types.brand.transformation?.serviceUrl)?.slice(1)}`,
+        }]
+      })
   }

--- a/packages/zendesk-adapter/src/change_validators/help_center_creation_or_removal.ts
+++ b/packages/zendesk-adapter/src/change_validators/help_center_creation_or_removal.ts
@@ -55,7 +55,7 @@ export const helpCenterCreationOrRemovalValidator:
             severity: 'Error',
             message: 'Creation or removal of help center for a certain brand is not supported via Salto.',
             detailedMessage: `Creation or removal of help center for a certain brand is not supported via Salto.
-            To create or remove a help center, please go to ${client.getUrl().href}${apiConfig.types.brand.transformation?.serviceUrl?.slice(1)}`,
+      To create or remove a help center, please go to ${client.getUrl().href}${apiConfig.types.brand.transformation?.serviceUrl?.slice(1)}`,
           }]
         }
         return [{

--- a/packages/zendesk-adapter/src/change_validators/help_center_creation_or_removal.ts
+++ b/packages/zendesk-adapter/src/change_validators/help_center_creation_or_removal.ts
@@ -1,0 +1,43 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  ChangeValidator,
+  getChangeData,
+  isInstanceChange,
+} from '@salto-io/adapter-api'
+import { BRAND_TYPE_NAME } from '../constants'
+import { invalidBrandChange } from './help_center_activation'
+import ZendeskClient from '../client/client'
+import { ZendeskApiConfig } from '../config'
+
+export const helpCenterCreationOrRemovalValidator:
+  (client: ZendeskClient, apiConfig: ZendeskApiConfig) =>
+  ChangeValidator = (client, apiConfig) => async changes => {
+    const relevantInstances = changes
+      .filter(isInstanceChange)
+      .filter(change => getChangeData(change).elemID.typeName === BRAND_TYPE_NAME)
+      .filter(change => invalidBrandChange(change, 'has_help_center'))
+      .map(getChangeData)
+
+    return relevantInstances
+      .flatMap(instance => [{
+        elemID: instance.elemID,
+        severity: 'Error',
+        message: 'Creation or removal of help center for a certain brand is not supported via Salto.',
+        detailedMessage: `Creation or removal of help center for a certain brand is not supported via Salto.
+        To create or remove a help center, please go to ${client.getUrl().href}${apiConfig.types.brand.transformation?.serviceUrl}`,
+      }])
+  }

--- a/packages/zendesk-adapter/src/change_validators/help_center_creation_or_removal.ts
+++ b/packages/zendesk-adapter/src/change_validators/help_center_creation_or_removal.ts
@@ -55,15 +55,15 @@ export const helpCenterCreationOrRemovalValidator:
             severity: 'Error',
             message: 'Creation or removal of help center for a certain brand is not supported via Salto.',
             detailedMessage: `Creation or removal of help center for a certain brand is not supported via Salto.
-            To create or remove a help center, please go to ${client.getUrl().href}${apiConfig.types.brand.transformation?.serviceUrl}`,
+            To create or remove a help center, please go to ${client.getUrl().href}${apiConfig.types.brand.transformation?.serviceUrl?.slice(1)}`,
           }]
         }
         return [{
           elemID: getChangeData(change).elemID,
-          severity: 'Warning', // TO DO waiting for Tomer to help with the phrasing
+          severity: 'Warning',
           message: 'Creation of a brand with a help center is not supported via Salto.',
-          detailedMessage: `Creation of a brand with a help center is not supported via Salto.
-            To create a help center, please go to ${client.getUrl().href}${(apiConfig.types.brand.transformation?.serviceUrl)?.slice(1)}`,
+          detailedMessage: `Creation of a brand with a help center is not supported via Salto. The brand will be created without a help center. After creating the brand, 
+            to create a help center, please go to ${client.getUrl().href}${(apiConfig.types.brand.transformation?.serviceUrl)?.slice(1)}`,
         }]
       })
   }

--- a/packages/zendesk-adapter/src/change_validators/index.ts
+++ b/packages/zendesk-adapter/src/change_validators/index.ts
@@ -40,3 +40,4 @@ export { articleLabelNamesRemovalValidator } from './article_label_names_removal
 export { brandFieldForBrandBasedElementsValidator } from './brand_field_for_branded_based_elements'
 export { translationForDefaultLocaleValidator } from './translation_for_default_locale'
 export { helpCenterActivationValidator } from './help_center_activation'
+export { helpCenterCreationOrRemovalValidator } from './help_center_creation_or_removal'

--- a/packages/zendesk-adapter/test/change_validators/help_center_activation.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/help_center_activation.test.ts
@@ -47,7 +47,7 @@ describe('helpCenterActivationValidator', () => {
     )
     expect(errors).toEqual([{
       elemID: brandTwoInstance.elemID,
-      severity: 'Error',
+      severity: 'Warning',
       message: 'Activation or deactivation of help center for a certain brand is not supported via Salto.',
       detailedMessage: `Activation or deactivation of help center for a certain brand is not supported via Salto. To activate or deactivate a help center, please go to ${brandTwoInstance.value.brand_url}/hc/admin/general_settings`,
     }])

--- a/packages/zendesk-adapter/test/change_validators/help_center_creation_or_removal.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/help_center_creation_or_removal.test.ts
@@ -59,9 +59,10 @@ describe('helpCenterCreationOrRemovalValidator', () => {
     )
     expect(errors).toEqual([{
       elemID: brandTwoInstance.elemID,
-      severity: 'Error',
-      message: 'Creation or removal of help center for a certain brand is not supported via Salto.',
-      detailedMessage: `Creation or removal of help center for a certain brand is not supported via Salto.
+      severity: 'Warning',
+      message: 'Creation or removal of help center for a brand is not supported via Salto.',
+      // we expect the service url to always exist.
+      detailedMessage: `Creation or removal of help center for brand ${brandTwoInstance.elemID.getFullName()} is not supported via Salto.
       To create or remove a help center, please go to ${client.getUrl().href}${config.types.brand.transformation?.serviceUrl?.slice(1)}`,
     }])
   })
@@ -90,7 +91,7 @@ describe('helpCenterCreationOrRemovalValidator', () => {
       elemID: brandOneInstance.elemID,
       severity: 'Warning',
       message: 'Creation of a brand with a help center is not supported via Salto.',
-      detailedMessage: `Creation of a brand with a help center is not supported via Salto. The brand will be created without a help center. After creating the brand, 
+      detailedMessage: `Creation of a brand with a help center is not supported via Salto. The brand ${brandOneInstance.elemID.getFullName()} will be created without a help center. After creating the brand, 
             to create a help center, please go to ${client.getUrl().href}${(config.types.brand.transformation?.serviceUrl)?.slice(1)}`,
     }])
   })

--- a/packages/zendesk-adapter/test/change_validators/help_center_creation_or_removal.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/help_center_creation_or_removal.test.ts
@@ -62,7 +62,7 @@ describe('helpCenterCreationOrRemovalValidator', () => {
       severity: 'Error',
       message: 'Creation or removal of help center for a certain brand is not supported via Salto.',
       detailedMessage: `Creation or removal of help center for a certain brand is not supported via Salto.
-        To create or remove a help center, please go to ${client.getUrl().href}${config.types.brand.transformation?.serviceUrl?.slice(1)}`,
+      To create or remove a help center, please go to ${client.getUrl().href}${config.types.brand.transformation?.serviceUrl?.slice(1)}`,
     }])
   })
 

--- a/packages/zendesk-adapter/test/change_validators/help_center_creation_or_removal.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/help_center_creation_or_removal.test.ts
@@ -66,7 +66,7 @@ describe('helpCenterCreationOrRemovalValidator', () => {
     }])
   })
 
-  it('should not return an error when help_center_state is not changed', async () => {
+  it('should not return an error when has_help_center is not changed', async () => {
     const brandTwoInstance = new InstanceElement(
       'Test2',
       BrandType,
@@ -82,11 +82,17 @@ describe('helpCenterCreationOrRemovalValidator', () => {
     expect(errors).toHaveLength(0)
   })
 
-  it('should not return an error when the change is addition', async () => {
+  it('should return a warning when the change is addition', async () => {
     const errors = await changeValidator(
       [toChange({ after: brandOneInstance })]
     )
-    expect(errors).toHaveLength(0)
+    expect(errors).toEqual([{
+      elemID: brandOneInstance.elemID,
+      severity: 'Warning',
+      message: 'Creation of a brand with a help center is not supported via Salto.',
+      detailedMessage: `Creation of a brand with a help center is not supported via Salto.
+            To create a help center, please go to ${client.getUrl().href}${config.types.brand.transformation?.serviceUrl?.slice(1)}`,
+    }])
   })
 
   it('should not return an error when the change is removal', async () => {

--- a/packages/zendesk-adapter/test/change_validators/help_center_creation_or_removal.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/help_center_creation_or_removal.test.ts
@@ -62,7 +62,7 @@ describe('helpCenterCreationOrRemovalValidator', () => {
       severity: 'Error',
       message: 'Creation or removal of help center for a certain brand is not supported via Salto.',
       detailedMessage: `Creation or removal of help center for a certain brand is not supported via Salto.
-        To create or remove a help center, please go to ${client.getUrl().href}${config.types.brand.transformation?.serviceUrl}`,
+        To create or remove a help center, please go to ${client.getUrl().href}${config.types.brand.transformation?.serviceUrl?.slice(1)}`,
     }])
   })
 
@@ -90,8 +90,8 @@ describe('helpCenterCreationOrRemovalValidator', () => {
       elemID: brandOneInstance.elemID,
       severity: 'Warning',
       message: 'Creation of a brand with a help center is not supported via Salto.',
-      detailedMessage: `Creation of a brand with a help center is not supported via Salto.
-            To create a help center, please go to ${client.getUrl().href}${config.types.brand.transformation?.serviceUrl?.slice(1)}`,
+      detailedMessage: `Creation of a brand with a help center is not supported via Salto. The brand will be created without a help center. After creating the brand, 
+            to create a help center, please go to ${client.getUrl().href}${(config.types.brand.transformation?.serviceUrl)?.slice(1)}`,
     }])
   })
 

--- a/packages/zendesk-adapter/test/change_validators/help_center_creation_or_removal.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/help_center_creation_or_removal.test.ts
@@ -1,0 +1,98 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import ZendeskClient from '../../src/client/client'
+import { API_DEFINITIONS_CONFIG, DEFAULT_CONFIG } from '../../src/config'
+import { helpCenterCreationOrRemovalValidator } from '../../src/change_validators'
+import { BRAND_TYPE_NAME, ZENDESK } from '../../src/constants'
+
+describe('helpCenterCreationOrRemovalValidator', () => {
+  const client = new ZendeskClient({
+    credentials: {
+      username: 'a',
+      password: 'b',
+      subdomain: 'ignore',
+    },
+  })
+  const config = _.cloneDeep(DEFAULT_CONFIG[API_DEFINITIONS_CONFIG])
+  const changeValidator = helpCenterCreationOrRemovalValidator(client, config)
+
+  const BrandType = new ObjectType({
+    elemID: new ElemID(ZENDESK, BRAND_TYPE_NAME),
+  })
+
+  const brandOneInstance = new InstanceElement(
+    'Test1',
+    BrandType,
+    {
+      help_center_state: 'enabled',
+      has_help_center: true,
+      brand_url: 'https://free-tifder.zendesk.com',
+    },
+  )
+  it('should return an error when has_help_center is changed', async () => {
+    const brandTwoInstance = new InstanceElement(
+      'Test2',
+      BrandType,
+      {
+        help_center_state: 'enabled',
+        has_help_center: false,
+        brand_url: 'https://free-tifder.zendesk.com',
+      },
+    )
+    const errors = await changeValidator(
+      [toChange({ before: brandOneInstance, after: brandTwoInstance })]
+    )
+    expect(errors).toEqual([{
+      elemID: brandTwoInstance.elemID,
+      severity: 'Error',
+      message: 'Creation or removal of help center for a certain brand is not supported via Salto.',
+      detailedMessage: `Creation or removal of help center for a certain brand is not supported via Salto.
+        To create or remove a help center, please go to ${client.getUrl().href}${config.types.brand.transformation?.serviceUrl}`,
+    }])
+  })
+
+  it('should not return an error when help_center_state is not changed', async () => {
+    const brandTwoInstance = new InstanceElement(
+      'Test2',
+      BrandType,
+      {
+        help_center_state: 'enabled',
+        has_help_center: true,
+        brand_url: 'https://free.zendesk.com',
+      },
+    )
+    const errors = await changeValidator(
+      [toChange({ before: brandOneInstance, after: brandTwoInstance })]
+    )
+    expect(errors).toHaveLength(0)
+  })
+
+  it('should not return an error when the change is addition', async () => {
+    const errors = await changeValidator(
+      [toChange({ after: brandOneInstance })]
+    )
+    expect(errors).toHaveLength(0)
+  })
+
+  it('should not return an error when the change is removal', async () => {
+    const errors = await changeValidator(
+      [toChange({ before: brandOneInstance })]
+    )
+    expect(errors).toHaveLength(0)
+  })
+})

--- a/packages/zendesk-adapter/test/change_validators/help_center_creation_or_removal.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/help_center_creation_or_removal.test.ts
@@ -101,4 +101,17 @@ describe('helpCenterCreationOrRemovalValidator', () => {
     )
     expect(errors).toHaveLength(0)
   })
+
+  it('should not return an error when the brand is not valid', async () => {
+    const invalidBrandInstance = new InstanceElement(
+      'Test1',
+      BrandType,
+      {}
+      ,
+    )
+    const errors = await changeValidator(
+      [toChange({ after: invalidBrandInstance })]
+    )
+    expect(errors).toHaveLength(0)
+  })
 })


### PR DESCRIPTION
_Add change validator for creation or removal of help center_

---

_Additional context for reviewer_
None

---
_Release Notes_: 
Zendesk:
* Add change validator for creation or removal of help center

---
_User Notifications_: 
None
