### PR TITLE
SALTO-2946 Delete the default SDF FileCabinet folder to prevent permissions error on deploy

### DIFF
--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -899,6 +899,8 @@ export default class SdfClient {
     const project = await this.initProject(suiteAppId)
     const objectsDirPath = SdfClient.getObjectsDirPath(project.projectName)
     const fileCabinetDirPath = SdfClient.getFileCabinetDirPath(project.projectName)
+    // Delete the default FileCabinet folder to prevent permissions error
+    await rm(fileCabinetDirPath)
     await Promise.all(customizationInfos.map(async customizationInfo => {
       if (customizationInfo.typeName === CONFIG_FEATURES) {
         return SdfClient.addFeaturesObjectToProject(customizationInfo, project.projectName)

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -1676,7 +1676,7 @@ File: ~/AccountConfiguration/features.xml`
         expect(writeFileMock).toHaveBeenCalledWith(expect.stringContaining(MOCK_FOLDER_ATTRS_PATH),
           '<folder><description>folder description</description></folder>')
         expect(writeFileMock).toHaveBeenCalledWith(expect.stringContaining('manifest.xml'), MOCK_MANIFEST_VALID_DEPENDENCIES)
-        expect(rmMock).toHaveBeenCalledTimes(1)
+        expect(rmMock).toHaveBeenCalledTimes(2)
         expect(mockExecuteAction).toHaveBeenNthCalledWith(1, createProjectCommandMatcher)
         expect(mockExecuteAction).toHaveBeenNthCalledWith(2, saveTokenCommandMatcher)
         expect(mockExecuteAction).toHaveBeenNthCalledWith(3, addDependenciesCommandMatcher)
@@ -1708,7 +1708,7 @@ File: ~/AccountConfiguration/features.xml`
         expect(writeFileMock).toHaveBeenCalledWith(expect.stringContaining(MOCK_FILE_PATH),
           dummyFileContent)
         expect(writeFileMock).toHaveBeenCalledWith(expect.stringContaining('manifest.xml'), MOCK_MANIFEST_VALID_DEPENDENCIES)
-        expect(rmMock).toHaveBeenCalledTimes(1)
+        expect(rmMock).toHaveBeenCalledTimes(2)
         expect(mockExecuteAction).toHaveBeenNthCalledWith(1, createProjectCommandMatcher)
         expect(mockExecuteAction).toHaveBeenNthCalledWith(2, saveTokenCommandMatcher)
         expect(mockExecuteAction).toHaveBeenNthCalledWith(3, addDependenciesCommandMatcher)
@@ -1734,7 +1734,7 @@ File: ~/AccountConfiguration/features.xml`
         expect(writeFileMock).toHaveBeenCalledTimes(2)
         expect(writeFileMock).toHaveBeenCalledWith(expect.stringContaining('features.xml'), MOCK_FEATURES_XML)
         expect(writeFileMock).toHaveBeenCalledWith(expect.stringContaining('manifest.xml'), MOCK_MANIFEST_VALID_DEPENDENCIES)
-        expect(rmMock).toHaveBeenCalledTimes(1)
+        expect(rmMock).toHaveBeenCalledTimes(2)
         expect(mockExecuteAction).toHaveBeenNthCalledWith(1, createProjectCommandMatcher)
         expect(mockExecuteAction).toHaveBeenNthCalledWith(2, saveTokenCommandMatcher)
         expect(mockExecuteAction).toHaveBeenNthCalledWith(3, addDependenciesCommandMatcher)


### PR DESCRIPTION


---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Delete the default SDF FileCabinet folder to prevent permissions error on deploy

---
_User Notifications_: 
None