### PR TITLE
SAAS-6386 create getStaticFileUniqueName

### DIFF
--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -78,6 +78,10 @@ export class StaticFile {
   }
 }
 
+type StaticFileMetadata = Pick<StaticFile, 'filepath' | 'hash'>
+export const getStaticFileUniqueName = ({ filepath, hash }: StaticFileMetadata): string =>
+  `${filepath}-${hash}`
+
 const getResolvedValue = async (
   elemID: ElemID,
   elementsSource?: ReadOnlyElementsSource,

--- a/packages/workspace/src/workspace/state/index.ts
+++ b/packages/workspace/src/workspace/state/index.ts
@@ -14,6 +14,6 @@
 * limitations under the License.
 */
 export { State, StateData, StateMetadataKey, buildStateData, createStateNamespace } from './state'
-export { buildHistoryStateStaticFilesSource } from './static_files_sources/history_static_files_source'
+export { buildHistoryStateStaticFilesSource, getFileName as getHistoryStateStaticFilesSourceFileName } from './static_files_sources/history_static_files_source'
 export { buildOverrideStateStaticFilesSource } from './static_files_sources/override_static_files_source'
 export { buildInMemState } from './in_mem'

--- a/packages/workspace/src/workspace/state/index.ts
+++ b/packages/workspace/src/workspace/state/index.ts
@@ -14,6 +14,6 @@
 * limitations under the License.
 */
 export { State, StateData, StateMetadataKey, buildStateData, createStateNamespace } from './state'
-export { buildHistoryStateStaticFilesSource, getFileName as getHistoryStateStaticFilesSourceFileName } from './static_files_sources/history_static_files_source'
+export { buildHistoryStateStaticFilesSource } from './static_files_sources/history_static_files_source'
 export { buildOverrideStateStaticFilesSource } from './static_files_sources/override_static_files_source'
 export { buildInMemState } from './in_mem'

--- a/packages/workspace/src/workspace/state/static_files_sources/history_static_files_source.ts
+++ b/packages/workspace/src/workspace/state/static_files_sources/history_static_files_source.ts
@@ -20,7 +20,7 @@ import { StateStaticFilesSource, StateStaticFilesStore } from '../../static_file
 
 const log = logger(module)
 
-const getFileName = (filepath: string, hash: string): string =>
+export const getFileName = (filepath: string, hash: string): string =>
   `${filepath}-${hash}`
 
 /**

--- a/packages/workspace/src/workspace/state/static_files_sources/history_static_files_source.ts
+++ b/packages/workspace/src/workspace/state/static_files_sources/history_static_files_source.ts
@@ -13,15 +13,12 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { StaticFile } from '@salto-io/adapter-api'
+import { getStaticFileUniqueName, StaticFile } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { LazyStaticFile } from '../../static_files/source'
 import { StateStaticFilesSource, StateStaticFilesStore } from '../../static_files/common'
 
 const log = logger(module)
-
-export const getFileName = (filepath: string, hash: string): string =>
-  `${filepath}-${hash}`
 
 /**
  * Builds a static file source that preserve the history of the static files
@@ -41,7 +38,7 @@ export const buildHistoryStateStaticFilesSource = (
 
   return {
     persistStaticFile: async (file: StaticFile): Promise<void> => {
-      const path = getFileName(file.filepath, file.hash)
+      const path = getStaticFileUniqueName(file)
       const existingFiles = await listFiles()
       if (existingFiles.has(path)) {
         return
@@ -54,19 +51,19 @@ export const buildHistoryStateStaticFilesSource = (
       }
       await dirStore.set({
         buffer: content,
-        filename: getFileName(file.filepath, file.hash),
+        filename: getStaticFileUniqueName(file),
       })
-      existingFiles.add(getFileName(file.filepath, file.hash))
+      existingFiles.add(getStaticFileUniqueName(file))
     },
-    getStaticFile: async (path, encoding, hash) => {
+    getStaticFile: async (filepath, encoding, hash) => {
       if (hash === undefined) {
-        throw new Error(`path ${path} was passed without a hash to getStaticFile`)
+        throw new Error(`path ${filepath} was passed without a hash to getStaticFile`)
       }
       return new LazyStaticFile(
-        path,
+        filepath,
         hash,
-        dirStore.getFullPath(path),
-        async () => (await dirStore.get(getFileName(path, hash)))?.buffer,
+        dirStore.getFullPath(filepath),
+        async () => (await dirStore.get(getStaticFileUniqueName({ filepath, hash })))?.buffer,
         encoding
       )
     },


### PR DESCRIPTION
Create getStaticFileUniqueName to use in `history_static_files_source.ts` and outside of the OSS

---

_Additional context for reviewer_

---
_Release Notes_: 
Adapter API:
- Create `getStaticFileUniqueName` that receives a `StaticFile` and returns a unique name (a concatenation of the filepath & hash) 

---
_User Notifications_: 
None