### PR TITLE
SALTO-2891 - Improve logging of static files

### DIFF
--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -983,7 +983,7 @@ export const elementExpressionStringifyReplacer: Replacer = (_key, value) => {
     return `TypeReference(${value.elemID.getFullName()}, ${value.type ? '<omitted>' : '<no value>'})`
   }
   if (isStaticFile(value)) {
-    return `StaticFile(${value.filepath})`
+    return `StaticFile(${value.filepath}, ${value.hash ? value.hash : '<unknown hash>'})`
   }
   if (value instanceof ElemID) {
     return `ElemID(${value.getFullName()})`

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -982,6 +982,9 @@ export const elementExpressionStringifyReplacer: Replacer = (_key, value) => {
   if (isTypeReference(value)) {
     return `TypeReference(${value.elemID.getFullName()}, ${value.type ? '<omitted>' : '<no value>'})`
   }
+  if (isStaticFile(value)) {
+    return `StaticFile(${value.filepath})`
+  }
   if (value instanceof ElemID) {
     return `ElemID(${value.getFullName()})`
   }

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -2272,7 +2272,7 @@ describe('Test utils.ts', () => {
   "annotationRefTypes": {},
   "path": [],
   "value": {
-    "fileValue": "StaticFile(${valueFile.filepath})"
+    "fileValue": "StaticFile(${valueFile.filepath}, ${valueFile.hash})"
   },
   "refType": "TypeReference(salto.obj_staticfile, <omitted>)"
 }`)

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -2243,6 +2243,40 @@ describe('Test utils.ts', () => {
   "refType": "TypeReference(salto.obj, <omitted>)"
 }`)
       })
+      it('should replace static file objects with the file\'s path', () => {
+        const element = new ObjectType({
+          elemID: new ElemID('salto', 'obj_staticfile'),
+          annotationRefsOrTypes: {
+            refValue: BuiltinTypes.STRING,
+            reg: BuiltinTypes.STRING,
+
+          },
+          annotations: {},
+          fields: {
+            fileValue: { refType: BuiltinTypes.STRING },
+          },
+        })
+        const instance = new InstanceElement(
+          'test3',
+          element,
+          {
+            fileValue: valueFile,
+          },
+          [],
+          {},
+        )
+        const res = safeJsonStringify(instance, elementExpressionStringifyReplacer, 2)
+        expect(res).toEqual(`{
+  "elemID": "ElemID(salto.obj_staticfile.instance.test3)",
+  "annotations": {},
+  "annotationRefTypes": {},
+  "path": [],
+  "value": {
+    "fileValue": "StaticFile(${valueFile.filepath})"
+  },
+  "refType": "TypeReference(salto.obj_staticfile, <omitted>)"
+}`)
+      })
     })
   })
 


### PR DESCRIPTION
Instead of dumping the entire StaticFile object, just print its path (similar to what we do with references and element IDs)

---
_Additional Context_:
N/A

---
_Release Notes_: 
Improved logging of static files

---
_User Notifications_: 
N/A
