### PR TITLE
SALTO-2963 Support limiting requests per minute

### DIFF
--- a/packages/adapter-components/src/client/base.ts
+++ b/packages/adapter-components/src/client/base.ts
@@ -33,15 +33,17 @@ export abstract class AdapterClientBase<TRateLimitConfig extends ClientRateLimit
     defaults: {
       retry: Required<ClientRetryConfig>
       rateLimit: Required<TRateLimitConfig>
+      maxRequestsPerMinute: number
       pageSize: Required<ClientPageSizeConfig>
     },
   ) {
     this.clientName = clientName
     this.config = config
-    this.rateLimiters = createRateLimitersFromConfig<TRateLimitConfig>(
-      _.defaults({}, config?.rateLimit, defaults.rateLimit),
-      this.clientName,
-    )
+    this.rateLimiters = createRateLimitersFromConfig<TRateLimitConfig>({
+      rateLimit: _.defaults({}, config?.rateLimit, defaults.rateLimit),
+      clientName: this.clientName,
+      maxRequestsPerMinute: config?.maxRequestsPerMinute ?? defaults.maxRequestsPerMinute,
+    })
     this.getPageSizeInner = (
       this.config?.pageSize?.get
       ?? defaults.pageSize.get

--- a/packages/adapter-components/src/client/config.ts
+++ b/packages/adapter-components/src/client/config.ts
@@ -35,6 +35,7 @@ export type ClientRetryConfig = Partial<{
 export type ClientBaseConfig<RateLimitConfig extends ClientRateLimitConfig> = Partial<{
   retry: ClientRetryConfig
   rateLimit: RateLimitConfig
+  maxRequestsPerMinute: number
   pageSize: ClientPageSizeConfig
 }>
 
@@ -90,6 +91,7 @@ export const createClientConfigType = <RateLimitConfig extends ClientRateLimitCo
     fields: {
       retry: { refType: clientRetryConfigType },
       rateLimit: { refType: clientRateLimitConfigType },
+      maxRequestsPerMinute: createFieldDefWithMin(-1),
       pageSize: { refType: clientPageSizeConfigType },
     },
     annotations: {
@@ -109,5 +111,8 @@ export const validateClientConfig = <RateLimitConfig extends ClientRateLimitConf
     if (invalidValues.length > 0) {
       throw Error(`${clientConfigPath}.rateLimit values cannot be set to 0. Invalid keys: ${invalidValues.map(([name]) => name).join(', ')}`)
     }
+  }
+  if (clientConfig?.maxRequestsPerMinute === 0) {
+    throw Error(`${clientConfigPath}.maxRequestsPerMinute value cannot be set to 0`)
   }
 }

--- a/packages/adapter-components/src/client/http_client.ts
+++ b/packages/adapter-components/src/client/http_client.ts
@@ -95,6 +95,7 @@ export abstract class AdapterHTTPClient<
     defaults: {
       retry: Required<ClientRetryConfig>
       rateLimit: Required<TRateLimitConfig>
+      maxRequestsPerMinute: number
       pageSize: Required<ClientPageSizeConfig>
     },
   ) {

--- a/packages/adapter-components/test/client/config.test.ts
+++ b/packages/adapter-components/test/client/config.test.ts
@@ -20,7 +20,7 @@ describe('client_config', () => {
   describe('createClientConfigType', () => {
     it('should return default type when no custom buckets were added', async () => {
       const type = createClientConfigType('myAdapter')
-      expect(Object.keys(type.fields)).toHaveLength(3)
+      expect(Object.keys(type.fields)).toHaveLength(4)
       expect(type.fields.rateLimit).toBeDefined()
       expect(type.fields.retry).toBeDefined()
       expect(type.fields.pageSize).toBeDefined()
@@ -35,7 +35,7 @@ describe('client_config', () => {
         a: number
         b: number
       }>('myAdapter', ['a', 'b'])
-      expect(Object.keys(type.fields)).toHaveLength(3)
+      expect(Object.keys(type.fields)).toHaveLength(4)
       expect(type.fields.rateLimit).toBeDefined()
       expect(type.fields.retry).toBeDefined()
       expect(type.fields.pageSize).toBeDefined()

--- a/packages/adapter-components/test/client/http_client.test.ts
+++ b/packages/adapter-components/test/client/http_client.test.ts
@@ -47,6 +47,7 @@ describe('client_http_client', () => {
         {
           pageSize: { get: 123 },
           rateLimit: { total: -1, get: 3, deploy: 4 },
+          maxRequestsPerMinute: -1,
           retry: { maxAttempts: 3, retryDelay: 123 },
         }
       )

--- a/packages/adapter-components/test/client/rate_limit.test.ts
+++ b/packages/adapter-components/test/client/rate_limit.test.ts
@@ -28,10 +28,10 @@ type MyRateLimitConfig = {
 class A {
   readonly rateLimiters: BottleneckBuckets<MyRateLimitConfig>
   constructor(limits: MyRateLimitConfig) {
-    this.rateLimiters = createRateLimitersFromConfig(
-      limits,
-      'abc',
-    )
+    this.rateLimiters = createRateLimitersFromConfig({
+      rateLimit: limits,
+      clientName: 'abc',
+    })
   }
 
   @throttle<MyRateLimitConfig>({})

--- a/packages/jira-adapter/config_doc.md
+++ b/packages/jira-adapter/config_doc.md
@@ -45,6 +45,7 @@ jira {
 |---------------------------------------------------------------|--------------------------|------------
 | [retry](#retry-configuration-options)                         | `{}` (no overrides)      | Configuration for retrying on errors
 | [rateLimit](#rate-limit-configuration-options)                | `{}` (no overrides)      | Limits on the number of concurrent requests of different types
+| [maxRequestsPerMinute]                                        |                          | Limits on the number of requests per minute
 | usePrivateAPI                                                 | true                     | Whether to use Jira Private API when fetching and deploying changes
 
 #### Client retry options

--- a/packages/jira-adapter/config_doc.md
+++ b/packages/jira-adapter/config_doc.md
@@ -45,7 +45,7 @@ jira {
 |---------------------------------------------------------------|--------------------------|------------
 | [retry](#retry-configuration-options)                         | `{}` (no overrides)      | Configuration for retrying on errors
 | [rateLimit](#rate-limit-configuration-options)                | `{}` (no overrides)      | Limits on the number of concurrent requests of different types
-| [maxRequestsPerMinute]                                        |                          | Limits on the number of requests per minute
+| [maxRequestsPerMinute]                                        | unlimited                | Limits on the number of requests per minute
 | usePrivateAPI                                                 | true                     | Whether to use Jira Private API when fetching and deploying changes
 
 #### Client retry options

--- a/packages/jira-adapter/src/client/client.ts
+++ b/packages/jira-adapter/src/client/client.ts
@@ -63,6 +63,7 @@ export default class JiraClient extends clientUtils.AdapterHTTPClient<
       {
         pageSize: DEFAULT_PAGE_SIZE,
         rateLimit: DEFAULT_MAX_CONCURRENT_API_REQUESTS,
+        maxRequestsPerMinute: RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,
         retry: DEFAULT_RETRY_OPTS,
       }
     )

--- a/packages/okta-adapter/config_doc.md
+++ b/packages/okta-adapter/config_doc.md
@@ -41,6 +41,7 @@ okta {
 |---------------------------------------------------------------|--------------------------|------------
 | [retry](#retry-configuration-options)                         | `{}` (no overrides)      | Configuration for retrying on errors
 | [rateLimit](#rate-limit-configuration-options)                | `{}` (no overrides)      | Limits on the number of concurrent requests of different types
+| [maxRequestsPerMinute]                                        |  700                     | Limits on the number of requests per minute
 
 #### Client retry options
 

--- a/packages/okta-adapter/src/client/client.ts
+++ b/packages/okta-adapter/src/client/client.ts
@@ -28,6 +28,7 @@ const DEFAULT_MAX_CONCURRENT_API_REQUESTS: Required<clientUtils.ClientRateLimitC
   get: 2,
   deploy: 2,
 }
+const DEFAULT_MAX_REQUESTS_PER_MINUTE = 700
 
 const DEFAULT_PAGE_SIZE: Required<clientUtils.ClientPageSizeConfig> = {
   get: 50,
@@ -47,6 +48,7 @@ export default class OktaClient extends clientUtils.AdapterHTTPClient<
         pageSize: DEFAULT_PAGE_SIZE,
         rateLimit: DEFAULT_MAX_CONCURRENT_API_REQUESTS,
         // TODO SALTO-2649: add better handling for rate limits
+        maxRequestsPerMinute: DEFAULT_MAX_REQUESTS_PER_MINUTE,
         retry: {
           maxAttempts: 5, // try 5 times
           retryDelay: 10000, // wait for 10s before trying again, change after SALTO-2649

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -450,10 +450,12 @@ export default class SalesforceClient {
 
     setPollIntervalForConnection(this.conn, pollingConfig)
     this.setFetchPollingTimeout()
-    this.rateLimiters = createRateLimitersFromConfig(
-      _.defaults({}, config?.maxConcurrentApiRequests, DEFAULT_MAX_CONCURRENT_API_REQUESTS),
-      SALESFORCE
-    )
+    this.rateLimiters = createRateLimitersFromConfig({
+      rateLimit: _.defaults(
+        {}, config?.maxConcurrentApiRequests, DEFAULT_MAX_CONCURRENT_API_REQUESTS,
+      ),
+      clientName: SALESFORCE,
+    })
     this.dataRetry = config?.dataRetry ?? DEFAULT_CUSTOM_OBJECTS_DEFAULT_RETRY_OPTIONS
     this.clientName = 'SFDC'
     this.readMetadataChunkSize = _.merge(

--- a/packages/stripe-adapter/config_doc.md
+++ b/packages/stripe-adapter/config_doc.md
@@ -37,6 +37,7 @@ stripe {
 |---------------------------------------------------------------|--------------------------|------------
 | [retry](#retry-configuration-options)                         | `{}` (no overrides)      | Configuration for retrying on errors
 | [rateLimit](#rate-limit-configuration-options)                | `{}` (no overrides)      | Limits on the number of concurrent requests of different types
+| [maxRequestsPerMinute]                                        |                          | Limits on the number of requests per minute
 
 #### Client retry options
 

--- a/packages/stripe-adapter/config_doc.md
+++ b/packages/stripe-adapter/config_doc.md
@@ -37,7 +37,7 @@ stripe {
 |---------------------------------------------------------------|--------------------------|------------
 | [retry](#retry-configuration-options)                         | `{}` (no overrides)      | Configuration for retrying on errors
 | [rateLimit](#rate-limit-configuration-options)                | `{}` (no overrides)      | Limits on the number of concurrent requests of different types
-| [maxRequestsPerMinute]                                        |                          | Limits on the number of requests per minute
+| [maxRequestsPerMinute]                                        | unlimited                | Limits on the number of requests per minute
 
 #### Client retry options
 

--- a/packages/stripe-adapter/src/client/client.ts
+++ b/packages/stripe-adapter/src/client/client.ts
@@ -47,6 +47,7 @@ export default class StripeClient extends clientUtils.AdapterHTTPClient<
       {
         pageSize: DEFAULT_PAGE_SIZE,
         rateLimit: DEFAULT_MAX_CONCURRENT_API_REQUESTS,
+        maxRequestsPerMinute: RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,
         retry: DEFAULT_RETRY_OPTS,
       }
     )

--- a/packages/workato-adapter/config_doc.md
+++ b/packages/workato-adapter/config_doc.md
@@ -45,7 +45,7 @@ workato {
 |---------------------------------------------------------------|--------------------------|------------
 | [retry](#retry-configuration-options)                         | `{}` (no overrides)      | Configuration for retrying on errors
 | [rateLimit](#rate-limit-configuration-options)                | `{}` (no overrides)      | Limits on the number of concurrent requests of different types
-| [maxRequestsPerMinute]                                        |                          | Limits on the number of requests per minute
+| [maxRequestsPerMinute]                                        | unlimited                | Limits on the number of requests per minute
 
 #### Client retry options
 

--- a/packages/workato-adapter/config_doc.md
+++ b/packages/workato-adapter/config_doc.md
@@ -45,6 +45,7 @@ workato {
 |---------------------------------------------------------------|--------------------------|------------
 | [retry](#retry-configuration-options)                         | `{}` (no overrides)      | Configuration for retrying on errors
 | [rateLimit](#rate-limit-configuration-options)                | `{}` (no overrides)      | Limits on the number of concurrent requests of different types
+| [maxRequestsPerMinute]                                        |                          | Limits on the number of requests per minute
 
 #### Client retry options
 

--- a/packages/workato-adapter/src/client/client.ts
+++ b/packages/workato-adapter/src/client/client.ts
@@ -44,6 +44,7 @@ export default class WorkatoClient extends clientUtils.AdapterHTTPClient<
       {
         pageSize: DEFAULT_PAGE_SIZE,
         rateLimit: DEFAULT_MAX_CONCURRENT_API_REQUESTS,
+        maxRequestsPerMinute: RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,
         retry: DEFAULT_RETRY_OPTS,
       }
     )

--- a/packages/zendesk-adapter/config_doc.md
+++ b/packages/zendesk-adapter/config_doc.md
@@ -40,6 +40,7 @@ zendesk {
 |---------------------------------------------------------------|--------------------------|------------
 | [retry](#retry-configuration-options)                         | `{}` (no overrides)      | Configuration for retrying on errors
 | [rateLimit](#rate-limit-configuration-options)                | `{}` (no overrides)      | Limits on the number of concurrent requests of different types
+| [maxRequestsPerMinute]                                        | 700                      | Limits on the number of requests per minute
 
 #### Client retry options
 

--- a/packages/zendesk-adapter/config_doc.md
+++ b/packages/zendesk-adapter/config_doc.md
@@ -40,7 +40,7 @@ zendesk {
 |---------------------------------------------------------------|--------------------------|------------
 | [retry](#retry-configuration-options)                         | `{}` (no overrides)      | Configuration for retrying on errors
 | [rateLimit](#rate-limit-configuration-options)                | `{}` (no overrides)      | Limits on the number of concurrent requests of different types
-| [maxRequestsPerMinute]                                        | 700                      | Limits on the number of requests per minute
+| [maxRequestsPerMinute]                                        | unlimited                | Limits on the number of requests per minute
 
 #### Client retry options
 

--- a/packages/zendesk-adapter/src/client/client.ts
+++ b/packages/zendesk-adapter/src/client/client.ts
@@ -32,7 +32,6 @@ const DEFAULT_MAX_CONCURRENT_API_REQUESTS: Required<clientUtils.ClientRateLimitC
   get: 20,
   deploy: 20,
 }
-const DEFAULT_MAX_REQUESTS_PER_MINUTE = 700
 
 const DEFAULT_PAGE_SIZE: Required<clientUtils.ClientPageSizeConfig> = {
   get: 20,
@@ -59,7 +58,7 @@ export default class ZendeskClient extends clientUtils.AdapterHTTPClient<
       {
         pageSize: DEFAULT_PAGE_SIZE,
         rateLimit: DEFAULT_MAX_CONCURRENT_API_REQUESTS,
-        maxRequestsPerMinute: DEFAULT_MAX_REQUESTS_PER_MINUTE,
+        maxRequestsPerMinute: RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,
         retry: DEFAULT_RETRY_OPTS,
       },
     )

--- a/packages/zendesk-adapter/src/client/client.ts
+++ b/packages/zendesk-adapter/src/client/client.ts
@@ -32,6 +32,7 @@ const DEFAULT_MAX_CONCURRENT_API_REQUESTS: Required<clientUtils.ClientRateLimitC
   get: 20,
   deploy: 20,
 }
+const DEFAULT_MAX_REQUESTS_PER_MINUTE = 700
 
 const DEFAULT_PAGE_SIZE: Required<clientUtils.ClientPageSizeConfig> = {
   get: 20,
@@ -58,6 +59,7 @@ export default class ZendeskClient extends clientUtils.AdapterHTTPClient<
       {
         pageSize: DEFAULT_PAGE_SIZE,
         rateLimit: DEFAULT_MAX_CONCURRENT_API_REQUESTS,
+        maxRequestsPerMinute: DEFAULT_MAX_REQUESTS_PER_MINUTE,
         retry: DEFAULT_RETRY_OPTS,
       },
     )

--- a/packages/zuora-billing-adapter/config_doc.md
+++ b/packages/zuora-billing-adapter/config_doc.md
@@ -36,6 +36,7 @@ zuora_billing {
 |---------------------------------------------------------------|--------------------------|------------
 | [retry](#retry-configuration-options)                         | `{}` (no overrides)      | Configuration for retrying on errors
 | [rateLimit](#rate-limit-configuration-options)                | `{}` (no overrides)      | Limits on the number of concurrent requests of different types
+| [maxRequestsPerMinute]                                        |                          | Limits on the number of requests per minute
 
 #### Client retry options
 

--- a/packages/zuora-billing-adapter/config_doc.md
+++ b/packages/zuora-billing-adapter/config_doc.md
@@ -36,7 +36,7 @@ zuora_billing {
 |---------------------------------------------------------------|--------------------------|------------
 | [retry](#retry-configuration-options)                         | `{}` (no overrides)      | Configuration for retrying on errors
 | [rateLimit](#rate-limit-configuration-options)                | `{}` (no overrides)      | Limits on the number of concurrent requests of different types
-| [maxRequestsPerMinute]                                        |                          | Limits on the number of requests per minute
+| [maxRequestsPerMinute]                                        | unlimited                | Limits on the number of requests per minute
 
 #### Client retry options
 

--- a/packages/zuora-billing-adapter/src/client/client.ts
+++ b/packages/zuora-billing-adapter/src/client/client.ts
@@ -46,6 +46,7 @@ export default class ZuoraClient extends clientUtils.AdapterHTTPClient<
       {
         pageSize: DEFAULT_PAGE_SIZE,
         rateLimit: DEFAULT_MAX_CONCURRENT_API_REQUESTS,
+        maxRequestsPerMinute: RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,
         retry: DEFAULT_RETRY_OPTS,
       }
     )


### PR DESCRIPTION
Support limiting requests in a specific timeframe and not only concurrent requests. This is needed at least for Zendesk and Okta, and will likely be useful in other adapters as well.

---

Using the simplest approach for now - one global limit in a constant timeframe, and without parsing headers (I think we should also add better handling for them, but since they will require per-adapter customization and some refactoring, I think it's best to do separately - see details in the ticket).

---
_Release Notes_: 
_Adapter Components_:
* Support limiting the number of API requests in a minute

_Okta adapter_:
* Limit the number of API requests in a minute

---
_User Notifications_: 
None