### PR TITLE
SALTO-2974 include dependencies of translation collection instances i…

### DIFF
--- a/packages/netsuite-adapter/src/reference_dependencies.ts
+++ b/packages/netsuite-adapter/src/reference_dependencies.ts
@@ -150,8 +150,6 @@ const getRequiredReferencedElements = async (
     .map(getRequiredDependency)
     .filter(isDefined)
 
-  log.debug(`adding referenced element:${os.EOL}${requiredReferencedElements.map(elementFullName).join('\n')}`)
-
   const elements = _.uniqBy(sourceElements.concat(requiredReferencedElements), elementFullName)
   const elementsSet = new Set(elements.map(elementFullName))
   // SALTO-2974 Due to SDF bug, it seems like referenced translation collection instances
@@ -165,6 +163,13 @@ const getRequiredReferencedElements = async (
       .toArray(),
     elementFullName
   )
+
+  log.debug(`adding referenced elements:${os.EOL}${
+    requiredReferencedElements
+      .concat(referencedTranslationCollectionInstances)
+      .map(elementFullName)
+      .join(os.EOL)
+  }`)
   return elements.concat(referencedTranslationCollectionInstances)
 }
 

--- a/packages/netsuite-adapter/src/reference_dependencies.ts
+++ b/packages/netsuite-adapter/src/reference_dependencies.ts
@@ -23,12 +23,14 @@ import { transformElement, TransformFunc } from '@salto-io/adapter-utils'
 import { values as lowerDashValues, collections } from '@salto-io/lowerdash'
 import wu from 'wu'
 import os from 'os'
-import { CUSTOM_SEGMENT, DATASET, NETSUITE, SCRIPT_ID, WORKBOOK } from './constants'
+import { CUSTOM_SEGMENT, DATASET, NETSUITE, SCRIPT_ID, TRANSLATION_COLLECTION, WORKBOOK } from './constants'
 import { isCustomRecordType } from './types'
 
 const { awu } = collections.asynciterable
 const { isDefined } = lowerDashValues
 const log = logger(module)
+
+const elementFullName = (element: Element): string => element.elemID.getFullName()
 
 export const findDependingElementsFromRefs = async (
   element: Element
@@ -52,10 +54,10 @@ export const findDependingElementsFromRefs = async (
     if (isReferenceExpression(value)) {
       const { topLevelParent, elemID } = value
       if (topLevelParent
-        && !visitedIdToElement.has(topLevelParent.elemID.getFullName())
+        && !visitedIdToElement.has(elementFullName(topLevelParent))
         && elemID.adapter === NETSUITE
         && await isRefToServiceId(topLevelParent, elemID)) {
-        visitedIdToElement.set(topLevelParent.elemID.getFullName(), topLevelParent)
+        visitedIdToElement.set(elementFullName(topLevelParent), topLevelParent)
       }
     }
     return value
@@ -77,15 +79,15 @@ export const findDependingElementsFromRefs = async (
 const getAllReferencedElements = async (
   sourceElements: ReadonlyArray<Element>
 ): Promise<ReadonlyArray<Element>> => {
-  const visited = new Set<string>(sourceElements.map(elem => elem.elemID.getFullName()))
+  const visited = new Set<string>(sourceElements.map(elementFullName))
   const getNewReferencedElement = async (
     element: Element
   ): Promise<Element[]> => {
     const newElements = (await findDependingElementsFromRefs(element))
-      .filter(elem => !visited.has(elem.elemID.getFullName()))
+      .filter(elem => !visited.has(elementFullName(elem)))
     newElements.forEach(elem => {
-      log.debug(`adding referenced element: ${elem.elemID.getFullName()}`)
-      visited.add(elem.elemID.getFullName())
+      log.debug(`adding referenced element: ${elementFullName(elem)}`)
+      visited.add(elementFullName(elem))
     })
     return [
       ...newElements,
@@ -103,9 +105,9 @@ const getAllReferencedElements = async (
  * of deploy and writing them in the manifest.xml doesn't suffice.
  * Here we add manually all of the quirks we identified.
  */
-const getRequiredReferencedElements = (
+const getRequiredReferencedElements = async (
   sourceElements: ReadonlyArray<Element>
-): ReadonlyArray<Element> => {
+): Promise<ReadonlyArray<Element>> => {
   const getReferencedElement = (
     value: Value,
     predicate: (element: Element) => boolean
@@ -148,12 +150,22 @@ const getRequiredReferencedElements = (
     .map(getRequiredDependency)
     .filter(isDefined)
 
-  log.debug(`adding referenced element:${os.EOL}${requiredReferencedElements.map(elem => elem.elemID.getFullName()).join('\n')}`)
+  log.debug(`adding referenced element:${os.EOL}${requiredReferencedElements.map(elementFullName).join('\n')}`)
 
-  return _.uniqBy(
-    sourceElements.concat(requiredReferencedElements),
-    element => element.elemID.getFullName()
+  const elements = _.uniqBy(sourceElements.concat(requiredReferencedElements), elementFullName)
+  const elementsSet = new Set(elements.map(elementFullName))
+  // SALTO-2974 Due to SDF bug, it seems like referenced translation collection instances
+  // must be included in the SDF project.
+  const referencedTranslationCollectionInstances = _.uniqBy(
+    await awu(elements)
+      .flatMap(findDependingElementsFromRefs)
+      .filter(isInstanceElement)
+      .filter(element => element.elemID.typeName === TRANSLATION_COLLECTION)
+      .filter(element => !elementsSet.has(elementFullName(element)))
+      .toArray(),
+    elementFullName
   )
+  return elements.concat(referencedTranslationCollectionInstances)
 }
 
 export const getReferencedElements = async (


### PR DESCRIPTION
…n SDF deploy

Due to SDF bug, custcollections must be included in the project when referenced

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- include dependencies of translation collection instances in SDF deploy

---
_User Notifications_: 
None
