### PR TITLE
SALTO-2976 handling zendesk template expressions inside references

### DIFF
--- a/packages/zendesk-adapter/src/filters/custom_field_options/creator.ts
+++ b/packages/zendesk-adapter/src/filters/custom_field_options/creator.ts
@@ -114,7 +114,7 @@ export const createCustomFieldOptionsFilterCreator = (
       change => getChangeData(change).elemID.typeName === parentTypeName,
     )
     if (parentChanges.length === 0) {
-      // The service does not allow us to have an field with no options - therefore, we need to do
+      // The service does not allow us to have a field with no options - therefore, we need to do
       //  the removal changes last
       const [removalChanges, nonRemovalChanges] = _.partition(childrenChanges, isRemovalChange)
       const deployResult = await deployChangesByGroups(


### PR DESCRIPTION
Handling referenced templateExpressions because ticket_fields_custom_option type is deployed via its parents.

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
