### PR TITLE
SALTO-2967: turn ids to emails in section, category and article translations

### DIFF
--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -1703,10 +1703,12 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
       dataField: 'translations',
       fieldsToHide: FIELDS_TO_HIDE.concat(
         { fieldName: 'id', fieldType: 'number' },
-        { fieldName: 'created_by_id', fieldType: 'number' },
-        { fieldName: 'updated_by_id', fieldType: 'number' },
       ),
-      fieldTypeOverrides: [{ fieldName: 'id', fieldType: 'number' }],
+      fieldTypeOverrides: [
+        { fieldName: 'id', fieldType: 'number' },
+        { fieldName: 'created_by_id', fieldType: 'unknown' },
+        { fieldName: 'updated_by_id', fieldType: 'unknown' },
+      ],
       fieldsToOmit: FIELDS_TO_OMIT.concat(
         { fieldName: 'html_url', fieldType: 'string' },
         { fieldName: 'source_id', fieldType: 'number' },
@@ -1906,10 +1908,12 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
       dataField: 'translations',
       fieldsToHide: FIELDS_TO_HIDE.concat(
         { fieldName: 'id', fieldType: 'number' },
-        { fieldName: 'created_by_id', fieldType: 'number' },
-        { fieldName: 'updated_by_id', fieldType: 'number' },
       ),
-      fieldTypeOverrides: [{ fieldName: 'id', fieldType: 'number' }],
+      fieldTypeOverrides: [
+        { fieldName: 'id', fieldType: 'number' },
+        { fieldName: 'created_by_id', fieldType: 'unknown' },
+        { fieldName: 'updated_by_id', fieldType: 'unknown' },
+      ],
       fieldsToOmit: FIELDS_TO_OMIT.concat(
         { fieldName: 'html_url', fieldType: 'string' },
         { fieldName: 'source_id', fieldType: 'number' },
@@ -2019,7 +2023,11 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
       sourceTypeName: 'category__translations',
       dataField: 'translations',
       fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
-      fieldTypeOverrides: [{ fieldName: 'id', fieldType: 'number' }],
+      fieldTypeOverrides: [
+        { fieldName: 'id', fieldType: 'number' },
+        { fieldName: 'created_by_id', fieldType: 'unknown' },
+        { fieldName: 'updated_by_id', fieldType: 'unknown' },
+      ],
       fieldsToOmit: FIELDS_TO_OMIT.concat(
         { fieldName: 'html_url', fieldType: 'string' },
         { fieldName: 'source_id', fieldType: 'number' },

--- a/packages/zendesk-adapter/src/filters/user.ts
+++ b/packages/zendesk-adapter/src/filters/user.ts
@@ -169,6 +169,9 @@ const TYPE_NAME_TO_REPLACER: Record<string, UserReplacer> = {
   workspace: workspaceReplacer,
   user_segment: fieldReplacer(['added_user_ids']),
   article: fieldReplacer(['author_id']),
+  section_translation: fieldReplacer(['created_by_id', 'updated_by_id']),
+  category_translation: fieldReplacer(['created_by_id', 'updated_by_id']),
+  article_translation: fieldReplacer(['created_by_id', 'updated_by_id']),
 }
 
 const getUsers = async (paginator: clientUtils.Paginator): Promise<User[]> => {

--- a/packages/zendesk-adapter/test/filters/user.test.ts
+++ b/packages/zendesk-adapter/test/filters/user.test.ts
@@ -392,7 +392,7 @@ describe('user filter', () => {
         .find(e => e.elemID.typeName === SECTION_TRANSLATION_TYPE_NAME)
       expect(sectionTranslation?.value).toEqual({
         updated_by_id: 'a@a.com',
-        created_by_id: 'b@b.com' ,
+        created_by_id: 'b@b.com',
       })
       const userSegment = instances.find(e => e.elemID.typeName === 'user_segment')
       expect(userSegment?.value).toEqual({
@@ -631,7 +631,7 @@ describe('user filter', () => {
     it('should change the user ids to emails', async () => {
       const instances = [
         macroInstance, slaPolicyInstance, triggerInstance, workspaceInstance, userSegmentInstance,
-        articleInstance, sectionTranslationInstance
+        articleInstance, sectionTranslationInstance,
       ].map(e => e.clone())
       const changes = instances.map(instance => toChange({ after: instance }))
       // We call preDeploy here because it sets the mappings


### PR DESCRIPTION
_Turn ids to emails in section, category and article translations_

---

_Additional context for reviewer_
None

---
_Release Notes_: 
None

---
_User Notifications_: 
None
