### PR TITLE
SALTO-2981 Avoid making multiple requests for identical dependsOn parameters

### DIFF
--- a/packages/adapter-components/src/elements/request_parameters.ts
+++ b/packages/adapter-components/src/elements/request_parameters.ts
@@ -87,7 +87,7 @@ const computeDependsOnURLs = (
     throw new Error(`no instances found for ${referenceDetails.from.type}, cannot call endpoint ${url}`)
   }
   const potentialParams = contextInstances.map(e => e.value[referenceDetails.from.field])
-  return potentialParams.map(p => url.replace(ARG_PLACEHOLDER_MATCHER, p))
+  return _.uniq(potentialParams.map(p => url.replace(ARG_PLACEHOLDER_MATCHER, p)))
 }
 
 export const replaceUrlParams = (url: string, paramValues: Record<string, unknown>): string =>

--- a/packages/adapter-components/test/elements/request_parameters.test.ts
+++ b/packages/adapter-components/test/elements/request_parameters.test.ts
@@ -110,7 +110,7 @@ describe('request_parameters', () => {
       ).toThrow()
     })
 
-    it('should compute dependsOn urls', () => {
+    it('should compute dependsOn urls without duplicates', () => {
       const Pet = new ObjectType({ elemID: new ElemID('bla', 'Pet') })
       const Owner = new ObjectType({ elemID: new ElemID('bla', 'Owner') })
       expect(computeGetArgs(
@@ -124,6 +124,8 @@ describe('request_parameters', () => {
           Pet: [
             new InstanceElement('dog', Pet, { id: 'dogID' }),
             new InstanceElement('cat', Pet, { id: 'catID' }),
+            new InstanceElement('cat', Pet, { id: 'catID' }),
+            new InstanceElement('dog', Pet, { id: 'dogID' }),
           ],
           Owner: [
             new InstanceElement('o1', Owner, { id: 'ghi' }),


### PR DESCRIPTION
When a query depends on other queries, avoid making multiple identical requests.


---
_Release Notes_: 
None

---
_User Notifications_: 
None