### PR TITLE
SALTO-2976 Resolve template expressions inside zendesk resolved ticket field options

### DIFF
--- a/packages/zendesk-adapter/package.json
+++ b/packages/zendesk-adapter/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@salto-io/test-utils": "0.3.25",
+    "@salto-io/workspace": "0.3.25",
     "@types/jest": "^27.4.0",
     "@types/lodash": "^4.14.168",
     "@types/uuid": "^8.3.0",

--- a/packages/zendesk-adapter/src/filters/custom_field_options/creator.ts
+++ b/packages/zendesk-adapter/src/filters/custom_field_options/creator.ts
@@ -114,7 +114,7 @@ export const createCustomFieldOptionsFilterCreator = (
           // does not restore references correctly when the resolved values contain templates
           const originalInstance = await elementsSource.get(instance.elemID)
           if (originalInstance === undefined) {
-            log.error('Could not find original instance for %s, not replacing options', originalInstance.elemID.getFullName())
+            log.error('Could not find original instance for %s, not replacing options', instance.elemID.getFullName())
             return instance
           }
           const originalOptions = makeArray(originalInstance.value[CUSTOM_FIELD_OPTIONS_FIELD_NAME])

--- a/packages/zendesk-adapter/src/filters/custom_field_options/creator.ts
+++ b/packages/zendesk-adapter/src/filters/custom_field_options/creator.ts
@@ -16,14 +16,15 @@
 import _ from 'lodash'
 import {
   Change, getChangeData, InstanceElement, isInstanceElement, Element,
-  isObjectType, Field, BuiltinTypes, ReferenceExpression, isRemovalChange,
+  isObjectType, Field, BuiltinTypes, ReferenceExpression, isRemovalChange, isReferenceExpression,
 } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
-import { getParents } from '@salto-io/adapter-utils'
+import { getParents, replaceTemplatesWithValues } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../../filter'
 import { addIdsToChildrenUponAddition, deployChange, deployChanges, deployChangesByGroups } from '../../deployment'
 import { applyforInstanceChangesOfType } from '../utils'
 import { API_DEFINITIONS_CONFIG } from '../../config'
+import { prepRef } from '../handle_template_expressions'
 
 export const CUSTOM_FIELD_OPTIONS_FIELD_NAME = 'custom_field_options'
 export const DEFAULT_CUSTOM_FIELD_OPTION_FIELD_NAME = 'default_custom_field_option'
@@ -37,7 +38,7 @@ const { makeArray } = collections.array
 
 export const createCustomFieldOptionsFilterCreator = (
   { parentTypeName, childTypeName }: CustomFieldOptionsFilterCreatorParams
-): FilterCreator => ({ config, client }) => ({
+): FilterCreator => ({ config, client, elementsSource }) => ({
   onFetch: async (elements: Element[]): Promise<void> => {
     const parentType = elements
       .filter(isObjectType)
@@ -80,10 +81,21 @@ export const createCustomFieldOptionsFilterCreator = (
       [parentTypeName],
       (instance: InstanceElement) => {
         const defaultValue = instance.value[DEFAULT_CUSTOM_FIELD_OPTION_FIELD_NAME]
-        makeArray(instance.value[CUSTOM_FIELD_OPTIONS_FIELD_NAME])
-          .forEach(option => {
+        const options = makeArray(instance.value[CUSTOM_FIELD_OPTIONS_FIELD_NAME])
+        if (options.length > 0) {
+          // if there is a template expression in raw_name, resolve it
+          // (workaround until template expressions can be resolved in core).
+          replaceTemplatesWithValues(
+            { values: options, fieldName: 'raw_name' },
+            // onDeploy this value will not exist, so we don't need the shared context
+            {},
+            prepRef,
+          )
+
+          options.forEach(option => {
             option.default = (defaultValue !== undefined) && (option.value === defaultValue)
           })
+        }
         return instance
       }
     )
@@ -92,12 +104,16 @@ export const createCustomFieldOptionsFilterCreator = (
     await applyforInstanceChangesOfType(
       changes,
       [parentTypeName],
-      (instance: InstanceElement) => {
+      async (instance: InstanceElement) => {
         const options = makeArray(instance.value[CUSTOM_FIELD_OPTIONS_FIELD_NAME])
-        if (options) {
-          options.forEach(option => {
-            delete option.default
-          })
+        if (options.length > 0) {
+          // replace with the original references - since the current restore logic
+          // does not restore references correctly when the resolved values contain templates
+          const originalInstance = await elementsSource.get(instance.elemID)
+          const originalOptions = makeArray(originalInstance.value[CUSTOM_FIELD_OPTIONS_FIELD_NAME])
+          if (originalOptions.every(isReferenceExpression)) {
+            instance.value[CUSTOM_FIELD_OPTIONS_FIELD_NAME] = originalOptions
+          }
         }
         return instance
       }

--- a/packages/zendesk-adapter/src/filters/custom_field_options/creator.ts
+++ b/packages/zendesk-adapter/src/filters/custom_field_options/creator.ts
@@ -110,6 +110,9 @@ export const createCustomFieldOptionsFilterCreator = (
       async (instance: InstanceElement) => {
         const options = makeArray(instance.value[CUSTOM_FIELD_OPTIONS_FIELD_NAME])
         if (options.length > 0) {
+          options.forEach(option => {
+            delete option.default
+          })
           // replace with the original references - since the current restore logic
           // does not restore references correctly when the resolved values contain templates
           const originalInstance = await elementsSource.get(instance.elemID)

--- a/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
@@ -240,7 +240,7 @@ const replaceFormulasWithTemplates = async (
   }
 }
 
-const prepRef = (part: ReferenceExpression): TemplatePart => {
+export const prepRef = (part: ReferenceExpression): TemplatePart => {
   if (SALTO_TYPE_TO_ZENDESK_REFERENCE_TYPE[part.elemID.typeName]) {
     return `${SALTO_TYPE_TO_ZENDESK_REFERENCE_TYPE[part.elemID.typeName]}_${part.value.value.id}`
   }

--- a/packages/zendesk-adapter/test/filters/custom_field_options/ticket_field.test.ts
+++ b/packages/zendesk-adapter/test/filters/custom_field_options/ticket_field.test.ts
@@ -15,9 +15,11 @@
 */
 import {
   ObjectType, ElemID, InstanceElement, isObjectType, isInstanceElement,
-  ReferenceExpression, CORE_ANNOTATIONS, toChange,
+  ReferenceExpression, CORE_ANNOTATIONS, toChange, isReferenceExpression,
 } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
+import { createTemplateExpression } from '@salto-io/adapter-utils'
+import { elementSource } from '@salto-io/workspace'
 import { ZENDESK } from '../../../src/constants'
 import filterCreator from '../../../src/filters/custom_field_options/ticket_field'
 import {
@@ -60,21 +62,25 @@ describe('ticket field filter', () => {
   const child1 = new InstanceElement(
     'child1',
     childObjType,
-    { id: 22, name: 'child1', value: 'v1', default: false },
+    { id: 22, name: 'child1', value: 'v1', default: false, raw_name: 'aaa' },
     undefined,
     { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(parent.elemID, parent)] },
   )
   const child2 = new InstanceElement(
     'child2',
     childObjType,
-    { id: 33, name: 'child2', value: 'v2', default: true },
+    { id: 33, name: 'child2', value: 'v2', default: true, raw_name: createTemplateExpression({ parts: ['aaa ', new ReferenceExpression(parent.elemID, parent)] }) },
     undefined,
     { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(parent.elemID, parent)] },
   )
 
   beforeEach(async () => {
     jest.clearAllMocks()
-    filter = filterCreator(createFilterCreatorParams({})) as FilterType
+    filter = filterCreator(createFilterCreatorParams({
+      elementsSource: elementSource.createInMemoryElementSource([
+        parent.clone(),
+      ]),
+    })) as FilterType
   })
 
   describe('onFetch', () => {
@@ -154,8 +160,8 @@ describe('ticket field filter', () => {
         id: 11,
         name: 'parent',
         [CUSTOM_FIELD_OPTIONS_FIELD_NAME]: [
-          { id: 22, name: 'child1', value: 'v1' },
-          { id: 33, name: 'child2', value: 'v2' },
+          { id: 22, name: 'child1', value: 'v1', raw_name: 'aaa' },
+          { id: 33, name: 'child2', value: 'v2', raw_name: createTemplateExpression({ parts: ['aaa ', new ReferenceExpression(parent.elemID, parent)] }) },
         ],
         [DEFAULT_CUSTOM_FIELD_OPTION_FIELD_NAME]: 'v2',
       },
@@ -166,10 +172,10 @@ describe('ticket field filter', () => {
       await filter?.preDeploy([change])
     })
 
-    it('should add default to the options', async () => {
+    it('should add default to the options and resolve template expressions', async () => {
       expect(clonedResolvedParent.value[CUSTOM_FIELD_OPTIONS_FIELD_NAME]).toEqual([
-        { id: 22, name: 'child1', value: 'v1', default: false },
-        { id: 33, name: 'child2', value: 'v2', default: true },
+        { id: 22, name: 'child1', value: 'v1', default: false, raw_name: 'aaa' },
+        { id: 33, name: 'child2', value: 'v2', default: true, raw_name: 'aaa ticket.ticket_field_11' },
       ])
     })
     it('should add default as false to all the options if there is no default', async () => {
@@ -177,8 +183,8 @@ describe('ticket field filter', () => {
       delete clonedParentWithNoDefault.value[DEFAULT_CUSTOM_FIELD_OPTION_FIELD_NAME]
       await filter?.preDeploy([toChange({ after: clonedParentWithNoDefault })])
       expect(clonedParentWithNoDefault.value[CUSTOM_FIELD_OPTIONS_FIELD_NAME]).toEqual([
-        { id: 22, name: 'child1', value: 'v1', default: false },
-        { id: 33, name: 'child2', value: 'v2', default: false },
+        { id: 22, name: 'child1', value: 'v1', default: false, raw_name: 'aaa' },
+        { id: 33, name: 'child2', value: 'v2', default: false, raw_name: 'aaa ticket.ticket_field_11' },
       ])
     })
   })
@@ -190,8 +196,8 @@ describe('ticket field filter', () => {
         id: 11,
         name: 'parent',
         [CUSTOM_FIELD_OPTIONS_FIELD_NAME]: [
-          { id: 22, name: 'child1', value: 'v1', default: false },
-          { id: 33, name: 'child2', value: 'v2', default: true },
+          { id: 22, name: 'child1', value: 'v1', default: false, raw_name: 'aaa' },
+          { id: 33, name: 'child2', value: 'v2', default: true, raw_name: 'aaa ticket.ticket_field_11' },
         ],
         [DEFAULT_CUSTOM_FIELD_OPTION_FIELD_NAME]: 'v2',
       },
@@ -202,10 +208,14 @@ describe('ticket field filter', () => {
       await filter?.onDeploy([change])
     })
 
-    it('should remove default from all the options', async () => {
-      expect(clonedResolvedParent.value[CUSTOM_FIELD_OPTIONS_FIELD_NAME]).toEqual([
-        { id: 22, name: 'child1', value: 'v1' },
-        { id: 33, name: 'child2', value: 'v2' },
+    it('should replace objects with value field, so that restore will always convert the value back to a reference', async () => {
+      expect(clonedResolvedParent.value[CUSTOM_FIELD_OPTIONS_FIELD_NAME].map(isReferenceExpression))
+        .toEqual([true, true])
+      expect(clonedResolvedParent.value[CUSTOM_FIELD_OPTIONS_FIELD_NAME].map(
+        (ref: ReferenceExpression) => ref.elemID.getFullName()
+      )).toEqual([
+        'zendesk.ticket_field__custom_field_options.instance.child1',
+        'zendesk.ticket_field__custom_field_options.instance.child2',
       ])
     })
     it('should do nothing if there is no options field', async () => {

--- a/packages/zendesk-adapter/tsconfig.json
+++ b/packages/zendesk-adapter/tsconfig.json
@@ -22,5 +22,6 @@
         { "path": "../logging" },
         { "path": "../lowerdash" },
         { "path": "../test-utils" },
+        { "path": "../workspace" },
     ]
 }


### PR DESCRIPTION
Based on @Eldardar 's analysis and replacing https://github.com/salto-io/salto/pull/3527/files.

This is an edge case - the correct solution would be to complete the support for template expressions in core, _and_ to avoid using `fullValue` to resolve references. But as a quick workaround, adding handling for the two cases where this can happen (we only resolve `fullValue` for ticket field options and user field options).

---
_Release Notes_: 
_Zendesk adapter_:
* Fix bug where creating a ticket or user field would fail if some of the options had templates in their name.

---
_User Notifications_: 
None