### PR TITLE
SALTO-2983 Fix Everyone validator to not assume instance exists

### DIFF
--- a/packages/zendesk-adapter/src/change_validators/everyone_user_segment_modification.ts
+++ b/packages/zendesk-adapter/src/change_validators/everyone_user_segment_modification.ts
@@ -14,26 +14,15 @@
 * limitations under the License.
 */
 import { ChangeValidator, ElemID, getChangeData, isInstanceChange } from '@salto-io/adapter-api'
-import { logger } from '@salto-io/logging'
 import { EVERYONE } from '../filters/everyone_user_segment'
 import { USER_SEGMENT_TYPE_NAME, ZENDESK } from '../constants'
 
-const log = logger(module)
-
-export const everyoneUserSegmentModificationValidator: ChangeValidator = async (
-  changes,
-  elementSource,
-) => {
-  if (elementSource === undefined) {
-    log.error('Failed to run customRoleNameValidator because no element source was provided')
-    return []
-  }
+export const everyoneUserSegmentModificationValidator: ChangeValidator = async changes => {
   const everyoneUserSegmentElemID = new ElemID(ZENDESK, USER_SEGMENT_TYPE_NAME, 'instance', EVERYONE)
-  const everyoneUserSegmentInstance = await elementSource.get(everyoneUserSegmentElemID)
   return changes
     .filter(isInstanceChange)
     .map(getChangeData)
-    .filter(instance => instance.elemID.isEqual(everyoneUserSegmentInstance.elemID))
+    .filter(instance => instance.elemID.isEqual(everyoneUserSegmentElemID))
     .flatMap(instance => (
       [{
         elemID: instance.elemID,


### PR DESCRIPTION
Fix bug that's causing failures in zendesk deployments when Guide is disabled.

---
_Release Notes_: 
_Zendesk adapter_:
* Fix bug that caused a crash in deployments

---
_User Notifications_: 
None