### PR TITLE
SALTO-2958 - Zendesk adapter - Keep article ref url middle part the same

### DIFF
--- a/packages/zendesk-adapter/src/filters/article_body.ts
+++ b/packages/zendesk-adapter/src/filters/article_body.ts
@@ -30,8 +30,7 @@ const { awu } = collections.asynciterable
 const BODY_FIELD = 'body'
 
 const ARTICLE_REF_URL_REGEX = /(https:\/\/.*\.zendesk\.com\/hc\/.*\/articles\/\d*)/g
-const BASE_URL_REGEX = /(https:\/\/.*\.zendesk\.com)/
-const ARTICLE_ID_URL_REGEX = /\/articles\/(\d*)/
+const ARTICLE_REF_URL_GROUPS_REGEX = /((?<urlSubdomain>https:\/\/.*\.zendesk\.com)(?<translation>\/hc\/.*\/articles\/)(?<urlArticleId>\d*))/g
 
 const referenceArticleUrl = ({
   articleUrl,
@@ -42,10 +41,11 @@ const referenceArticleUrl = ({
   brandInstances: InstanceElement[]
   articleInstances: InstanceElement[]
 }): TemplatePart[] => {
-  const urlSubdomain = articleUrl.match(BASE_URL_REGEX)?.pop()
+  const urlParts = ARTICLE_REF_URL_GROUPS_REGEX.exec(articleUrl)?.groups ?? {}
+  const { urlSubdomain, translation, urlArticleId } = urlParts
+
   const urlBrand = brandInstances
     .find(brandInstance => brandInstance.value.brand_url === urlSubdomain)
-  const urlArticleId = articleUrl.match(ARTICLE_ID_URL_REGEX)?.pop()
   const referencedArticle = articleInstances
     .find(articleInstance => articleInstance.value.id.toString() === urlArticleId)
   if (!isInstanceElement(urlBrand) || !isInstanceElement(referencedArticle)) {
@@ -53,7 +53,7 @@ const referenceArticleUrl = ({
   }
   return [
     new ReferenceExpression(urlBrand.elemID.createNestedID('brand_url'), urlBrand?.value.brand_url),
-    '/hc/en-us/articles/',
+    translation,
     new ReferenceExpression(referencedArticle.elemID, referencedArticle),
   ]
 }

--- a/packages/zendesk-adapter/test/filters/article_body.test.ts
+++ b/packages/zendesk-adapter/test/filters/article_body.test.ts
@@ -65,7 +65,7 @@ describe('article body filter', () => {
     'article1',
     articleTranslationType,
     // eslint-disable-next-line no-template-curly-in-string
-    { id: 1003, body: '<p><a href="https://coolSubdomain.zendesk.com/hc/en-us/articles/1666" target="_self">linkedArticle</a></p>kjdsahjkdshjkdsjkh\n<a href="https://coolSubdomain.zendesk.com/hc/en-us/articles/1666' },
+    { id: 1003, body: '<p><a href="https://coolSubdomain.zendesk.com/hc/en-us/articles/1666" target="_self">linkedArticle</a></p>kjdsahjkdshjkdsjkh\n<a href="https://coolSubdomain.zendesk.com/hc/he/articles/1666' },
   )
   const nonTemplatedTranslationInstance = new InstanceElement(
     'article2',
@@ -98,7 +98,7 @@ describe('article body filter', () => {
         new ReferenceExpression(articleInstance.elemID, articleInstance),
         '" target="_self">linkedArticle</a></p>kjdsahjkdshjkdsjkh\n<a href="',
         new ReferenceExpression(brandInstance.elemID.createNestedID('brand_url'), brandInstance.value.brand_url),
-        '/hc/en-us/articles/',
+        '/hc/he/articles/',
         new ReferenceExpression(articleInstance.elemID, articleInstance),
       ] }))
     })


### PR DESCRIPTION
When replacing article's body urls with ReferenceExpression, keep the middle part (that includes the translation) the same

---

This is a temporary fix for now, there will be a follow up PR to handle these cases in a more generic way

---
_Release Notes_: 
Zendesk adapter:
- bugfix - Article's urls inside articles won't default to en-us, and will keep their original translation

---
_User Notifications_: 
None