### PR TITLE
SALTO-2988 clone non-primitive values on resolve

### DIFF
--- a/packages/adapter-components/src/references/field_references.ts
+++ b/packages/adapter-components/src/references/field_references.ts
@@ -24,7 +24,6 @@ import {
   CreateMissingRefFunc,
   GetReferenceIdFunc,
   ReferenceSerializationStrategyLookup,
-  ReferenceSerializationStrategyWithSerialize,
 } from './reference_mapping'
 import { ContextFunc } from './context'
 
@@ -314,15 +313,11 @@ export const generateLookupFunc = <
       return ref.value
     }
 
-    const strategy = await determineLookupStrategy({ ref, path, field, element })
+    const strategy = await determineLookupStrategy({
+      ref, path, field, element,
+    }) ?? ReferenceSerializationStrategyLookup.fullValue
     if (strategy !== undefined && !isRelativeSerializer(strategy)) {
       return strategy.serialize({ ref, field, element })
-    }
-
-    if (isElement(ref.value)) {
-      // eslint-disable-next-line max-len
-      const defaultStrategy = ReferenceSerializationStrategyLookup.fullValue as ReferenceSerializationStrategyWithSerialize
-      return defaultStrategy.serialize({ ref, field, element })
     }
     return cloneDeepWithoutRefs(ref.value)
   }

--- a/packages/adapter-components/src/references/field_references.ts
+++ b/packages/adapter-components/src/references/field_references.ts
@@ -23,6 +23,8 @@ import {
   FieldReferenceResolver, generateReferenceResolverFinder, FieldReferenceDefinition,
   CreateMissingRefFunc,
   GetReferenceIdFunc,
+  ReferenceSerializationStrategyLookup,
+  ReferenceSerializationStrategyWithSerialize,
 } from './reference_mapping'
 import { ContextFunc } from './context'
 
@@ -317,9 +319,11 @@ export const generateLookupFunc = <
       return strategy.serialize({ ref, field, element })
     }
 
-    if (isInstanceElement(ref.value)) {
-      return ref.value.value
+    if (isElement(ref.value)) {
+      // eslint-disable-next-line max-len
+      const defaultStrategy = ReferenceSerializationStrategyLookup.fullValue as ReferenceSerializationStrategyWithSerialize
+      return defaultStrategy.serialize({ ref, field, element })
     }
-    return ref.value
+    return cloneDeepWithoutRefs(ref.value)
   }
 }

--- a/packages/adapter-components/src/references/field_references.ts
+++ b/packages/adapter-components/src/references/field_references.ts
@@ -316,7 +316,7 @@ export const generateLookupFunc = <
     const strategy = await determineLookupStrategy({
       ref, path, field, element,
     }) ?? ReferenceSerializationStrategyLookup.fullValue
-    if (strategy !== undefined && !isRelativeSerializer(strategy)) {
+    if (!isRelativeSerializer(strategy)) {
       return strategy.serialize({ ref, field, element })
     }
     return cloneDeepWithoutRefs(ref.value)

--- a/packages/adapter-components/src/references/reference_mapping.ts
+++ b/packages/adapter-components/src/references/reference_mapping.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { Field, Value, Element, isInstanceElement, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { Field, Value, Element, isInstanceElement, ElemID, InstanceElement, cloneDeepWithoutRefs } from '@salto-io/adapter-api'
 import { collections, types } from '@salto-io/lowerdash'
 import { GetLookupNameFunc } from '@salto-io/adapter-utils'
 
@@ -41,13 +41,18 @@ export type ReferenceSerializationStrategy = {
     getReferenceId: GetReferenceIdFunc
   }>
 )
+export type ReferenceSerializationStrategyWithSerialize = ReferenceSerializationStrategy & {
+  serialize: GetLookupNameFunc
+}
 
 export type ReferenceSerializationStrategyName = 'fullValue' | 'id' | 'name' | 'nameWithPath'
 export const ReferenceSerializationStrategyLookup: Record<
   ReferenceSerializationStrategyName, ReferenceSerializationStrategy
 > = {
   fullValue: {
-    serialize: ({ ref }) => (isInstanceElement(ref.value) ? ref.value.value : ref.value),
+    serialize: ({ ref }) => cloneDeepWithoutRefs(
+      isInstanceElement(ref.value) ? ref.value.value : ref.value
+    ),
     lookup: val => val,
   },
   id: {

--- a/packages/adapter-components/src/references/reference_mapping.ts
+++ b/packages/adapter-components/src/references/reference_mapping.ts
@@ -41,9 +41,6 @@ export type ReferenceSerializationStrategy = {
     getReferenceId: GetReferenceIdFunc
   }>
 )
-export type ReferenceSerializationStrategyWithSerialize = ReferenceSerializationStrategy & {
-  serialize: GetLookupNameFunc
-}
 
 export type ReferenceSerializationStrategyName = 'fullValue' | 'id' | 'name' | 'nameWithPath'
 export const ReferenceSerializationStrategyLookup: Record<

--- a/packages/adapter-components/test/references/field_references.test.ts
+++ b/packages/adapter-components/test/references/field_references.test.ts
@@ -520,11 +520,12 @@ describe('Field references', () => {
       expect(res).toEqual(2)
     })
 
-    it('should resolve using full value strategy when no rule is matched', async () => {
+    it('should resolve using full value strategy when no rule is matched, and clone the values', async () => {
+      const inst = new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'someType') }), { id: 2, name: 'name' })
       const res = await lookupNameFunc({
         ref: new ReferenceExpression(
           new ElemID('adapter', 'someType', 'instance', 'instance'),
-          new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'someType') }), { id: 2, name: 'name' }),
+          inst,
         ),
         field: new Field(new ObjectType({ elemID: new ElemID('adapter', 'someType') }), 'api_collection_ids', BuiltinTypes.NUMBER),
         path: new ElemID('adapter', 'somePath'),
@@ -532,6 +533,8 @@ describe('Field references', () => {
       })
 
       expect(res).toEqual({ id: 2, name: 'name' })
+      res.name = 'bla'
+      expect(inst.value).toEqual({ id: 2, name: 'name' })
     })
 
     it('should resolve using full value strategy when field is undefined', async () => {

--- a/packages/zendesk-adapter/src/filters/custom_field_options/creator.ts
+++ b/packages/zendesk-adapter/src/filters/custom_field_options/creator.ts
@@ -110,9 +110,6 @@ export const createCustomFieldOptionsFilterCreator = (
       async (instance: InstanceElement) => {
         const options = makeArray(instance.value[CUSTOM_FIELD_OPTIONS_FIELD_NAME])
         if (options.length > 0) {
-          options.forEach(option => {
-            delete option.default
-          })
           // replace with the original references - since the current restore logic
           // does not restore references correctly when the resolved values contain templates
           const originalInstance = await elementsSource.get(instance.elemID)


### PR DESCRIPTION
1. When using the `fullValue` serialization strategy, we should clone the values to avoid filters subsequently modifying the "referenced" resolved values (as was done in zendesk) and actually modifying the referenced instances' values
2. Fixing an inconsistency in how `getLookUpName`'s default serialization strategy was chosen (explicitly use `fullValue` as the fallback)

---
_Release Notes_: 
None (no impact on users)

---
_User Notifications_: 
None