### PR TITLE
SALTO-2990 - Added shouldResolve flag to workspace.accountConfig

### DIFF
--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import path from 'path'
 import { Element, SaltoError, SaltoElementError, ElemID, InstanceElement, DetailedChange, Change,
   Value, toChange, isRemovalChange, getChangeData,
-  ReadOnlyElementsSource, isAdditionOrModificationChange, StaticFile } from '@salto-io/adapter-api'
+  ReadOnlyElementsSource, isAdditionOrModificationChange, StaticFile, isInstanceElement } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { applyDetailedChanges, naclCase, resolvePath, safeJsonStringify } from '@salto-io/adapter-utils'
 import { collections, promises, values } from '@salto-io/lowerdash'
@@ -1035,7 +1035,7 @@ export const loadWorkspace = async (
         [unresolvedAccountConfig],
         adaptersConfig.getElements(),
       ))[0]
-      if (!(resolvedAccountConfig instanceof InstanceElement)) {
+      if (!isInstanceElement(resolvedAccountConfig)) {
         log.error('Failed to resolve accountConfig, expected InstanceElement')
         return undefined
       }

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -1025,19 +1025,21 @@ export const loadWorkspace = async (
     accountConfig: async (name, defaultValue, shouldResolve) => {
       const unresolvedAccountConfig = await adaptersConfig.getAdapter(name, defaultValue)
       if (!unresolvedAccountConfig) {
-        log.error('Failed to get account config, received undefined')
+        log.error('Failed to get accountConfig, received undefined')
         return undefined
       }
-      if (!(unresolvedAccountConfig instanceof InstanceElement)) {
-        log.error('Failed to get account config, expected InstanceElement')
+      if (!shouldResolve) {
+        return unresolvedAccountConfig
+      }
+      const resolvedAccountConfig = (await resolve(
+        [unresolvedAccountConfig],
+        adaptersConfig.getElements(),
+      ))[0]
+      if (!(resolvedAccountConfig instanceof InstanceElement)) {
+        log.error('Failed to resolve accountConfig, expected InstanceElement')
         return undefined
       }
-      return shouldResolve
-        ? (await resolve(
-          [unresolvedAccountConfig],
-          adaptersConfig.getElements(),
-        ))[0] as InstanceElement
-        : unresolvedAccountConfig
+      return resolvedAccountConfig
     },
     serviceConfig: (name, defaultValue) => adaptersConfig.getAdapter(name, defaultValue),
     accountConfigPaths: adaptersConfig.getElementNaclFiles,

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -1024,7 +1024,15 @@ export const loadWorkspace = async (
     servicesCredentials: accountCredentials,
     accountConfig: async (name, defaultValue, shouldResolve) => {
       const unresolvedAccountConfig = await adaptersConfig.getAdapter(name, defaultValue)
-      return shouldResolve && unresolvedAccountConfig
+      if (!unresolvedAccountConfig) {
+        log.error('Failed to get account config, received undefined')
+        return undefined
+      }
+      if (!(unresolvedAccountConfig instanceof InstanceElement)) {
+        log.error('Failed to get account config, expected InstanceElement')
+        return undefined
+      }
+      return shouldResolve
         ? (await resolve(
           [unresolvedAccountConfig],
           adaptersConfig.getElements(),

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -2954,25 +2954,43 @@ describe('workspace', () => {
     beforeEach(async () => {
       resolveMock.mockClear()
       adaptersConfig = mockAdaptersConfigSource()
-      adaptersConfig.getAdapter.mockResolvedValue(configInstanceElement)
       adaptersConfig.getElements.mockReturnValue(createInMemoryElementSource([
         configObjectType,
       ]))
       workspace = await createWorkspace(undefined, undefined, undefined, adaptersConfig)
-      resolveMock.mockImplementation(async elem => elem)
     })
     afterAll(() => {
       resolveMock.mockRestore()
     })
     describe('when called with name only', () => {
       it('should return the unresolved accountConfig', async () => {
+        adaptersConfig.getAdapter.mockResolvedValue(configInstanceElement)
+        resolveMock.mockImplementation(async elem => elem)
         expect(await workspace.accountConfig('new')).toEqual(configInstanceElement)
         expect(resolveMock).not.toHaveBeenCalled()
       })
     })
     describe('when called with shouldResolve', () => {
       it('should return the resolved accountConfig', async () => {
+        adaptersConfig.getAdapter.mockResolvedValue(configInstanceElement)
+        resolveMock.mockImplementation(async elem => elem)
         expect(await workspace.accountConfig('new', undefined, true)).toEqual(configInstanceElement)
+        expect(resolveMock).toHaveBeenCalled()
+      })
+    })
+    describe('when getAdapter return undefined', () => {
+      it('should return undefined', async () => {
+        adaptersConfig.getAdapter.mockResolvedValue(undefined)
+        resolveMock.mockImplementation(async elem => elem)
+        expect(await workspace.accountConfig('new')).toEqual(undefined)
+        expect(resolveMock).not.toHaveBeenCalled()
+      })
+    })
+    describe('when resolve returned Element', () => {
+      it('should return undefined', async () => {
+        adaptersConfig.getAdapter.mockResolvedValue(configInstanceElement)
+        resolveMock.mockResolvedValue([configObjectType])
+        expect(await workspace.accountConfig('new', undefined, true)).toEqual(undefined)
         expect(resolveMock).toHaveBeenCalled()
       })
     })

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -2948,27 +2948,31 @@ describe('workspace', () => {
     let workspace: Workspace
     let adaptersConfig: MockInterface<AdaptersConfigSource>
     const configElemId = new ElemID('dummy', 'new')
+    const configObjectType = new ObjectType({ elemID: configElemId })
+    const configInstanceElement = new InstanceElement('aaa', configObjectType)
     const resolveMock = jest.spyOn(ExpressionsModule, 'resolve')
     beforeEach(async () => {
+      resolveMock.mockClear()
       adaptersConfig = mockAdaptersConfigSource()
+      adaptersConfig.getAdapter.mockResolvedValue(configInstanceElement)
       adaptersConfig.getElements.mockReturnValue(createInMemoryElementSource([
-        new ObjectType({ elemID: configElemId }),
+        configObjectType,
       ]))
       workspace = await createWorkspace(undefined, undefined, undefined, adaptersConfig)
       resolveMock.mockImplementation(async elem => elem)
     })
-    afterEach(() => {
-      jest.clearAllMocks()
+    afterAll(() => {
+      resolveMock.mockRestore()
     })
     describe('when called with name only', () => {
       it('should return the unresolved accountConfig', async () => {
-        expect(await workspace.accountConfig('new')).toEqual(configElemId)
+        expect(await workspace.accountConfig('new')).toEqual(configInstanceElement)
         expect(resolveMock).not.toHaveBeenCalled()
       })
     })
     describe('when called with shouldResolve', () => {
       it('should return the resolved accountConfig', async () => {
-        expect(await workspace.accountConfig('new', undefined, true)).toEqual({})
+        expect(await workspace.accountConfig('new', undefined, true)).toEqual(configInstanceElement)
         expect(resolveMock).toHaveBeenCalled()
       })
     })

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -53,7 +53,7 @@ import { mockState } from '../common/state'
 import * as multiEnvSrcLib from '../../src/workspace/nacl_files/multi_env/multi_env_source'
 import { AdaptersConfigSource } from '../../src/workspace/adapters_config_source'
 import { createElementSelector } from '../../src/workspace/element_selector'
-import * as ExpressionsModule from '../../src/expressions'
+import * as expressionsModule from '../../src/expressions'
 
 const { awu } = collections.asynciterable
 
@@ -2950,7 +2950,7 @@ describe('workspace', () => {
     const configElemId = new ElemID('dummy', 'new')
     const configObjectType = new ObjectType({ elemID: configElemId })
     const configInstanceElement = new InstanceElement('aaa', configObjectType)
-    const resolveMock = jest.spyOn(ExpressionsModule, 'resolve')
+    const resolveMock = jest.spyOn(expressionsModule, 'resolve')
     beforeEach(async () => {
       resolveMock.mockClear()
       adaptersConfig = mockAdaptersConfigSource()

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -53,6 +53,7 @@ import { mockState } from '../common/state'
 import * as multiEnvSrcLib from '../../src/workspace/nacl_files/multi_env/multi_env_source'
 import { AdaptersConfigSource } from '../../src/workspace/adapters_config_source'
 import { createElementSelector } from '../../src/workspace/element_selector'
+import * as ExpressionsModule from '../../src/expressions'
 
 const { awu } = collections.asynciterable
 
@@ -2939,6 +2940,36 @@ describe('workspace', () => {
         expect(workspaceConf.setWorkspaceConfig as jest.Mock).toHaveBeenLastCalledWith(
           expect.objectContaining({ currentEnv: 'default' })
         )
+      })
+    })
+  })
+
+  describe('accountConfig', () => {
+    let workspace: Workspace
+    let adaptersConfig: MockInterface<AdaptersConfigSource>
+    const configElemId = new ElemID('dummy', 'new')
+    const resolveMock = jest.spyOn(ExpressionsModule, 'resolve')
+    beforeEach(async () => {
+      adaptersConfig = mockAdaptersConfigSource()
+      adaptersConfig.getElements.mockReturnValue(createInMemoryElementSource([
+        new ObjectType({ elemID: configElemId }),
+      ]))
+      workspace = await createWorkspace(undefined, undefined, undefined, adaptersConfig)
+      resolveMock.mockImplementation(async elem => elem)
+    })
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+    describe('when called with name only', () => {
+      it('should return the unresolved accountConfig', async () => {
+        expect(await workspace.accountConfig('new')).toEqual(configElemId)
+        expect(resolveMock).not.toHaveBeenCalled()
+      })
+    })
+    describe('when called with shouldResolve', () => {
+      it('should return the resolved accountConfig', async () => {
+        expect(await workspace.accountConfig('new', undefined, true)).toEqual({})
+        expect(resolveMock).toHaveBeenCalled()
       })
     })
   })


### PR DESCRIPTION
Access to the adapter config element is required from the workspace API.

---

_Additional context for reviewer_

---
_Release Notes_: 
-

---
_User Notifications_: 
-