### PR TITLE
SALTO-2585: add fieldConfigurationScheme plugin urls - Jira DC

### DIFF
--- a/packages/jira-adapter/src/product_settings/data_center/data_center.ts
+++ b/packages/jira-adapter/src/product_settings/data_center/data_center.ts
@@ -187,6 +187,26 @@ const PLUGIN_URL_PATTERNS: UrlPattern[] = [
   },
   {
     httpMethods: ['get', 'post'],
+    url: '/rest/api/3/fieldconfigurationscheme',
+  },
+  {
+    httpMethods: ['put', 'delete'],
+    url: '/rest/api/3/fieldconfigurationscheme/\\d+',
+  },
+  {
+    httpMethods: ['get'],
+    url: '/rest/api/3/fieldconfigurationscheme/mapping.+',
+  },
+  {
+    httpMethods: ['put'],
+    url: '/rest/api/3/fieldconfigurationscheme/\\d+/mapping',
+  },
+  {
+    httpMethods: ['post'],
+    url: '/rest/api/3/fieldconfigurationscheme/\\d+/mapping/delete',
+  },
+  {
+    httpMethods: ['get', 'post'],
     url: '/rest/api/3/fieldconfiguration',
   },
   {


### PR DESCRIPTION
_Add fieldConfigurationScheme plugin urls - Jira DC_

---

_Additional context for reviewer_
link to the plugin PR: https://github.com/salto-io/jira-dc-app/pull/25

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
