### PR TITLE
SAAS-6480 make adapter provides getDefaultConfig function

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -134,7 +134,8 @@ export type Adapter = {
   validateCredentials: (config: Readonly<InstanceElement>) => Promise<AccountId>
   authenticationMethods: AdapterAuthentication
   configType?: ObjectType
-  getDefaultConfig?: () => Promise<InstanceElement[]>
+  getDefaultConfig: (adapterConfigOverrides?: InstanceElement)
+    => Promise<InstanceElement[] | undefined>
   install?: () => Promise<AdapterInstallResult>
 }
 

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -1078,6 +1078,16 @@ export const resolveTypeShallow = async (
   }
 }
 
+export const buildDefaultAdapterConfig = async (
+  configType: ObjectType,
+): Promise<InstanceElement[] | undefined> => {
+  const defaultConf = ([await createDefaultInstanceFromType(ElemID.CONFIG_NAME, configType)].flat())
+  if (defaultConf.length === 0) {
+    return undefined
+  }
+  return defaultConf
+}
+
 export const createSchemeGuard = <T>(scheme: Joi.AnySchema, errorMessage?: string)
 : (value: unknown) => value is T => (value): value is T => {
     const { error } = scheme.validate(value)

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -69,12 +69,14 @@ describe('api.ts', () => {
     operations: mockFunction<Adapter['operations']>().mockReturnValue(mockAdapterOps),
     authenticationMethods: { basic: { credentialsType: mockConfigType } },
     validateCredentials: mockFunction<Adapter['validateCredentials']>().mockResolvedValue(''),
+    getDefaultConfig: mockFunction<Adapter['getDefaultConfig']>().mockResolvedValue(undefined),
   }
 
   const mockEmptyAdapter = {
     operations: mockFunction<Adapter['operations']>().mockReturnValue(mockAdapterOps),
     authenticationMethods: { basic: { credentialsType: mockEmptyConfigType } },
     validateCredentials: mockFunction<Adapter['validateCredentials']>().mockResolvedValue(''),
+    getDefaultConfig: mockFunction<Adapter['getDefaultConfig']>().mockResolvedValue(undefined),
   }
   const mockAdapterWithInstall = {
     authenticationMethods: { basic: {
@@ -83,6 +85,7 @@ describe('api.ts', () => {
     operations: mockFunction<Adapter['operations']>().mockReturnValue(mockAdapterOps),
     validateCredentials: mockFunction<Adapter['validateCredentials']>().mockResolvedValue(''),
     install: jest.fn().mockResolvedValue({ success: true, installedVersion: '123' }),
+    getDefaultConfig: mockFunction<Adapter['getDefaultConfig']>().mockResolvedValue(undefined),
   }
 
   adapterCreators[mockService] = mockAdapter
@@ -496,6 +499,7 @@ describe('api.ts', () => {
           },
           operations: mockFunction<Adapter['operations']>().mockReturnValue(mockAdapterOps),
           validateCredentials: mockFunction<Adapter['validateCredentials']>().mockResolvedValue(''),
+          getDefaultConfig: mockFunction<Adapter['getDefaultConfig']>().mockResolvedValue([]),
         }
       })
 

--- a/packages/core/test/core/adapters/adapters.test.ts
+++ b/packages/core/test/core/adapters/adapters.test.ts
@@ -100,13 +100,6 @@ describe('adapters.ts', () => {
       createDefaultInstanceFromTypeMock.mockReset()
     })
 
-    it('should call createDefaultInstanceFromType when getDefaultConfig is undefined', async () => {
-      delete mockAdapter.getDefaultConfig
-      const defaultConfigs = await getDefaultAdapterConfig('mockAdapter', 'mockAdapter')
-      expect(createDefaultInstanceFromType).toHaveBeenCalled()
-      expect(defaultConfigs).toHaveLength(1)
-      expect(defaultConfigs?.[0].value).toEqual({ val: 'aaa' })
-    })
     it('should use getDefaultConfig when defined', async () => {
       const defaultConfigs = await getDefaultAdapterConfig('mockAdapter', 'mockAdapter')
       expect(mockAdapter.getDefaultConfig).toHaveBeenCalled()

--- a/packages/dummy-adapter/src/adapter_creator.ts
+++ b/packages/dummy-adapter/src/adapter_creator.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import { Adapter, ElemID, CORE_ANNOTATIONS, BuiltinTypes, ObjectType, ListType } from '@salto-io/adapter-api'
+import { buildDefaultAdapterConfig } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import DummyAdapter from './adapter'
 import { GeneratorParams, DUMMY_ADAPTER, defaultParams, changeErrorType } from './generator'
@@ -40,4 +41,5 @@ export const adapter: Adapter = {
     credentialsType: new ObjectType({ elemID: new ElemID(DUMMY_ADAPTER) }),
   } }),
   configType,
+  getDefaultConfig: () => buildDefaultAdapterConfig(configType),
 }

--- a/packages/jira-adapter/src/adapter_creator.ts
+++ b/packages/jira-adapter/src/adapter_creator.ts
@@ -19,6 +19,7 @@ import {
   InstanceElement, Adapter, Values, ElemID,
 } from '@salto-io/adapter-api'
 import { client as clientUtils, config as configUtils } from '@salto-io/adapter-components'
+import { buildDefaultAdapterConfig } from '@salto-io/adapter-utils'
 import JiraClient from './client/client'
 import JiraAdapter from './adapter'
 import { Credentials, basicAuthCredentialsType } from './auth'
@@ -142,4 +143,5 @@ export const adapter: Adapter = {
     },
   },
   configType,
+  getDefaultConfig: () => buildDefaultAdapterConfig(configType),
 }

--- a/packages/netsuite-adapter/src/adapter_creator.ts
+++ b/packages/netsuite-adapter/src/adapter_creator.ts
@@ -19,6 +19,7 @@ import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { SdkDownloadService } from '@salto-io/suitecloud-cli'
 import Bottleneck from 'bottleneck'
+import { buildDefaultAdapterConfig } from '@salto-io/adapter-utils'
 import { configType, DEFAULT_CONCURRENCY, NetsuiteConfig, validateDeployParams } from './config'
 import {
   NETSUITE, TYPES_TO_SKIP, FILE_PATHS_REGEX_SKIP_LIST, CLIENT_CONFIG,
@@ -279,4 +280,5 @@ export const adapter: Adapter = {
       return { success: false, errors: [err.message ?? err] }
     }
   },
+  getDefaultConfig: () => buildDefaultAdapterConfig(configType),
 }

--- a/packages/okta-adapter/src/adapter_creator.ts
+++ b/packages/okta-adapter/src/adapter_creator.ts
@@ -17,6 +17,7 @@ import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import { InstanceElement, Adapter } from '@salto-io/adapter-api'
 import { client as clientUtils, config as configUtils } from '@salto-io/adapter-components'
+import { buildDefaultAdapterConfig } from '@salto-io/adapter-utils'
 import OktaClient from './client/client'
 import OktaAdapter from './adapter'
 import { Credentials, accessTokenCredentialsType } from './auth'
@@ -109,4 +110,5 @@ export const adapter: Adapter = {
     },
   },
   configType,
+  getDefaultConfig: () => buildDefaultAdapterConfig(configType),
 }

--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -19,6 +19,7 @@ import {
   InstanceElement, Adapter, OAuthRequestParameters, OauthAccessTokenResponse,
   Values,
 } from '@salto-io/adapter-api'
+import { buildDefaultAdapterConfig } from '@salto-io/adapter-utils'
 import SalesforceClient, { validateCredentials } from './client/client'
 import SalesforceAdapter from './adapter'
 import {
@@ -217,4 +218,5 @@ export const adapter: Adapter = {
     },
   },
   configType,
+  getDefaultConfig: () => buildDefaultAdapterConfig(configType),
 }

--- a/packages/stripe-adapter/src/adapter_creator.ts
+++ b/packages/stripe-adapter/src/adapter_creator.ts
@@ -19,6 +19,7 @@ import {
 } from '@salto-io/adapter-api'
 import { client as clientUtils, config as configUtils } from '@salto-io/adapter-components'
 import _ from 'lodash'
+import { buildDefaultAdapterConfig } from '@salto-io/adapter-utils'
 import StripeClient from './client/client'
 import StripeAdapter from './adapter'
 import {
@@ -111,4 +112,5 @@ export const adapter: Adapter = {
     },
   },
   configType,
+  getDefaultConfig: () => buildDefaultAdapterConfig(configType),
 }

--- a/packages/workato-adapter/src/adapter_creator.ts
+++ b/packages/workato-adapter/src/adapter_creator.ts
@@ -16,6 +16,7 @@
 import { logger } from '@salto-io/logging'
 import { InstanceElement, Adapter, ElemID } from '@salto-io/adapter-api'
 import { client as clientUtils, config as configUtils } from '@salto-io/adapter-components'
+import { buildDefaultAdapterConfig } from '@salto-io/adapter-utils'
 import WorkatoAdapter from './adapter'
 import { Credentials, usernameTokenCredentialsType } from './auth'
 import {
@@ -110,4 +111,5 @@ export const adapter: Adapter = {
     },
   },
   configType,
+  getDefaultConfig: () => buildDefaultAdapterConfig(configType),
 }

--- a/packages/workspace/src/merger/index.ts
+++ b/packages/workspace/src/merger/index.ts
@@ -114,7 +114,6 @@ export const mergeSingleElement = async <T extends Element>(elementParts: T[]): 
   }
 
   const mergedElements = await awu(mergeRes.merged.values()).toArray()
-
   if (mergedElements.length !== 1) {
     throw new Error(`Received invalid number of merged elements when expected one: ${mergedElements.map(e => e.elemID.getFullName()).join(', ')}`)
   }

--- a/packages/zendesk-adapter/src/adapter_creator.ts
+++ b/packages/zendesk-adapter/src/adapter_creator.ts
@@ -16,6 +16,7 @@
 import { logger } from '@salto-io/logging'
 import { InstanceElement, Adapter, Values, OAuthRequestParameters, OauthAccessTokenResponse, ElemID } from '@salto-io/adapter-api'
 import { client as clientUtils, config as configUtils } from '@salto-io/adapter-components'
+import { buildDefaultAdapterConfig } from '@salto-io/adapter-utils'
 import ZendeskAdapter from './adapter'
 import { Credentials, oauthAccessTokenCredentialsType, oauthRequestParametersType, usernamePasswordCredentialsType } from './auth'
 import {
@@ -166,4 +167,5 @@ export const adapter: Adapter = {
     },
   },
   configType,
+  getDefaultConfig: () => buildDefaultAdapterConfig(configType),
 }

--- a/packages/zuora-billing-adapter/src/adapter_creator.ts
+++ b/packages/zuora-billing-adapter/src/adapter_creator.ts
@@ -19,6 +19,7 @@ import {
 } from '@salto-io/adapter-api'
 import { client as clientUtils, config as configUtils } from '@salto-io/adapter-components'
 import _ from 'lodash'
+import { buildDefaultAdapterConfig } from '@salto-io/adapter-utils'
 import ZuoraClient from './client/client'
 import ZuoraAdapter from './adapter'
 import { Credentials, oauthClientCredentialsType, isSandboxSubdomain, toZuoraBaseUrl } from './auth'
@@ -130,4 +131,5 @@ export const adapter: Adapter = {
     },
   },
   configType,
+  getDefaultConfig: () => buildDefaultAdapterConfig(configType),
 }


### PR DESCRIPTION
This is the first drop of SAAS-6480 in the OSS.
We want the user to be able to get a "special" default adapter config (e.g Salesforce with CPQ data)
for that we want that each adapter will provide a function that build a default config. This function can get input with type InstanceElement, which allow the user to ask for a "special" adapter config from the adapter.

Changes in this PR:
- Make field 'getDefaultConfig' in Adapter type mandatory
- Move the logic of building default adapter config from configType to adapter-utils package
- For now, the implementation of 'getDefaultConfig' on each adapter is just the implementation of building the default from the adapter's config type.

Changes in the next drop:
- Define an object type for Salesforce and Zendesk 'getDefaultConfig' input (e.g { addCPQ: boolean })
- Implement validation functions for the object types in the previous bullet
- Implement 'getDefaultConfig' on Salesforce and Zendesk to be able to return adapter config with CPQ or Zendesk Guide (respectively)


---


---
_Release Notes_: 
None
---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. None
