### PR TITLE
SALTO-2932 Improve parent-child change validators and deploy flow

### DIFF
--- a/packages/zendesk-adapter/src/change_validators/child_parent/missing_from_parent.ts
+++ b/packages/zendesk-adapter/src/change_validators/child_parent/missing_from_parent.ts
@@ -42,7 +42,7 @@ export const missingFromParentValidatorCreator = (
   apiConfig: ZendeskApiConfig,
 ): ChangeValidator => async (changes, elementSource) => {
   if (elementSource === undefined) {
-    log.warn('Elements source was not passed to missingFromParentValidatorCreator. Skipping validator')
+    log.warn('Element source was not passed to missingFromParentValidatorCreator. Skipping validator')
     return []
   }
   const relationships = getChildAndParentTypeNames(apiConfig)

--- a/packages/zendesk-adapter/src/change_validators/child_parent/removed_from_parent.ts
+++ b/packages/zendesk-adapter/src/change_validators/child_parent/removed_from_parent.ts
@@ -36,16 +36,18 @@ export const removedFromParentValidatorCreator = (
     return relevantRelations.flatMap(relation => {
       const nonFullyRemovedChildren = getRemovedAndAddedChildren(change, relation.fieldName)
         .removed
+        .map(id => id)
         .filter(childId =>
-          (changeByID[childId] === undefined) || !isRemovalChange(changeByID[childId]))
+          (changeByID[childId.getFullName()] === undefined)
+          || !isRemovalChange(changeByID[childId.getFullName()]))
       if (_.isEmpty(nonFullyRemovedChildren)) {
         return []
       }
       return [{
         elemID: instance.elemID,
         severity: 'Error',
-        message: `Error while trying to remove ${typeName}, because the related instance still exists, please remove it as well`,
-        detailedMessage: `Error while trying to remove ${instance.elemID.getFullName()}, because the related instance ${nonFullyRemovedChildren.join(', ')} still exists, please remove it as well`,
+        message: `Error while trying to remove ${relation.fieldName} from ${typeName}, because the related instances still exist`,
+        detailedMessage: `Error while trying to remove from ${typeName} "${instance.elemID.name}" the ${relation.fieldName} ${nonFullyRemovedChildren.map(id => `"${id.name}"`).join(', ')}, because the related instances still exist. Please remove them as well`,
       }]
     })
   })

--- a/packages/zendesk-adapter/src/change_validators/child_parent/removed_from_parent.ts
+++ b/packages/zendesk-adapter/src/change_validators/child_parent/removed_from_parent.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { ChangeValidator, getChangeData, isInstanceChange, isModificationChange, isRemovalChange, InstanceElement, ChangeError } from '@salto-io/adapter-api'
+import { ChangeValidator, getChangeData, isInstanceChange, isModificationChange, isRemovalChange, ChangeError } from '@salto-io/adapter-api'
 import { ZendeskApiConfig } from '../../config'
 import { getChildAndParentTypeNames, getRemovedAndAddedChildren, ChildParentRelationship } from './utils'
 import { FIELD_TYPE_NAMES } from '../../constants'
@@ -32,7 +32,7 @@ export const removedFromParentValidatorCreator = (
     .filter(change => parentTypes.has(getChangeData(change).elemID.typeName))
   const changeByID = _.keyBy(instanceChanges, change => getChangeData(change).elemID.getFullName())
   return relevantChanges.flatMap(change => {
-    const instance = getChangeData(change) as InstanceElement
+    const instance = getChangeData(change)
     const { typeName } = instance.elemID
     const relevantRelations = relationships.filter(r => r.parent === typeName)
     return relevantRelations.flatMap((relation: ChildParentRelationship): ChangeError[] => {

--- a/packages/zendesk-adapter/src/change_validators/child_parent/removed_from_parent.ts
+++ b/packages/zendesk-adapter/src/change_validators/child_parent/removed_from_parent.ts
@@ -49,14 +49,14 @@ export const removedFromParentValidatorCreator = (
           elemID: instance.elemID,
           severity: 'Warning',
           message: `Removing ${relation.fieldName} from ${typeName} will also remove related instances`,
-          detailedMessage: `The following ${relation.fieldName} are no longer referenced from ${typeName} "${instance.elemID.name}", but the instances still exist:\n${nonFullyRemovedChildren.map(id => `- ${id.name}`).join('\n')}\n\nIf you continue with the deploy they will be removed from the service, and any references to them will break. It is recommended to remove them in Salto first and deploy again.`,
+          detailedMessage: `The following ${relation.fieldName} are no longer referenced from ${typeName} "${instance.elemID.name}", but the instances still exist:\n${nonFullyRemovedChildren.map(id => `- ${id.name}`).join('\n')}\n\nIf you continue with the deploy they will be removed from the service, and any references to them will break. It is recommended to remove these options in Salto first and deploy again.`,
         }]
       }
       return [{
         elemID: instance.elemID,
         severity: 'Error',
         message: `Cannot remove ${relation.fieldName} from ${typeName} without removing the related instances`,
-        detailedMessage: `The following ${relation.fieldName} are no longer referenced from ${typeName} "${instance.elemID.name}", but the instances still exist:\n${nonFullyRemovedChildren.map(id => `- ${id.name}`).join('\n')}\n\nPlease remove them first and deploy again.`,
+        detailedMessage: `The following ${relation.fieldName} are no longer referenced from ${typeName} "${instance.elemID.name}", but the instances still exist:\n${nonFullyRemovedChildren.map(id => `- ${id.name}`).join('\n')}\n\nPlease remove these options first and deploy again.`,
       }]
     })
   })

--- a/packages/zendesk-adapter/src/change_validators/child_parent/removed_from_parent.ts
+++ b/packages/zendesk-adapter/src/change_validators/child_parent/removed_from_parent.ts
@@ -45,9 +45,9 @@ export const removedFromParentValidatorCreator = (
       }
       return [{
         elemID: instance.elemID,
-        severity: 'Error',
-        message: `Error while trying to remove ${relation.fieldName} from ${typeName}, because the related instances still exist`,
-        detailedMessage: `Error while trying to remove from ${typeName} "${instance.elemID.name}" the ${relation.fieldName} ${nonFullyRemovedChildren.map(id => `"${id.name}"`).join(', ')}, because the related instances still exist. Please remove them as well`,
+        severity: 'Warning',
+        message: `Removing ${relation.fieldName} from ${typeName} will also remove related instances`,
+        detailedMessage: `The following ${relation.fieldName} are no longer referenced from ${typeName} "${instance.elemID.name}", but the instances still exist:\n${nonFullyRemovedChildren.map(id => `- ${id.name}`).join('\n')}.\n\nIf you continue with the deploy they will be removed from the service, and any references to them will break. It is recommended to remove them in Salto first and deploy again.`,
       }]
     })
   })

--- a/packages/zendesk-adapter/src/change_validators/duplicate_option_values.ts
+++ b/packages/zendesk-adapter/src/change_validators/duplicate_option_values.ts
@@ -19,14 +19,15 @@ import {
   Change, ChangeValidator, ElemID, getChangeData, InstanceElement, isAdditionOrModificationChange,
   isInstanceChange, isInstanceElement, isModificationChange, ReadOnlyElementsSource,
 } from '@salto-io/adapter-api'
+import { TICKET_FIELD_TYPE_NAME, USER_FIELD_TYPE_NAME, ORG_FIELD_TYPE_NAME } from '../constants'
 
 const { awu } = collections.asynciterable
 
 type ParentAndChildTypePair = { parent: string; child: string }
 export const RELEVANT_PARENT_AND_CHILD_TYPES: ParentAndChildTypePair[] = [
-  { parent: 'ticket_field', child: 'ticket_field__custom_field_options' },
-  { parent: 'user_field', child: 'user_field__custom_field_options' },
-  { parent: 'organization_field', child: 'organization_field__custom_field_options' },
+  { parent: TICKET_FIELD_TYPE_NAME, child: 'ticket_field__custom_field_options' },
+  { parent: USER_FIELD_TYPE_NAME, child: 'user_field__custom_field_options' },
+  { parent: ORG_FIELD_TYPE_NAME, child: 'organization_field__custom_field_options' },
 ]
 
 export const CHECKBOX_TYPE_NAME = 'checkbox'

--- a/packages/zendesk-adapter/src/change_validators/empty_custom_field_options.ts
+++ b/packages/zendesk-adapter/src/change_validators/empty_custom_field_options.ts
@@ -18,8 +18,8 @@ import { ChangeValidator, getChangeData,
   isAdditionOrModificationChange, isInstanceElement } from '@salto-io/adapter-api'
 import { CUSTOM_FIELD_OPTIONS_FIELD_NAME } from '../filters/custom_field_options/creator'
 import { createEmptyFieldErrorMessage } from './utils'
+import { FIELD_TYPE_NAMES } from '../constants'
 
-const RELEVANT_TYPES = ['ticket_field', 'user_field', 'organization_field']
 const RELEVANT_FIELD_TYPES = ['dropdown', 'tagger', 'multiselect']
 
 export const emptyCustomFieldOptionsValidator: ChangeValidator = async changes => (
@@ -27,7 +27,7 @@ export const emptyCustomFieldOptionsValidator: ChangeValidator = async changes =
     .filter(isAdditionOrModificationChange)
     .map(getChangeData)
     .filter(isInstanceElement)
-    .filter(instance => RELEVANT_TYPES.includes(instance.elemID.typeName))
+    .filter(instance => FIELD_TYPE_NAMES.includes(instance.elemID.typeName))
     .flatMap(instance => {
       if (
         RELEVANT_FIELD_TYPES.includes(instance.value.type)

--- a/packages/zendesk-adapter/src/change_validators/order.ts
+++ b/packages/zendesk-adapter/src/change_validators/order.ts
@@ -20,11 +20,10 @@ import { Change, ChangeValidator, getChangeData, InstanceElement,
 import { collections } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import { createOrderTypeName } from '../filters/reorder/creator'
+import { ORG_FIELD_TYPE_NAME, USER_FIELD_TYPE_NAME } from '../constants'
 import { TYPE_NAME as AUTOMATION_TYPE_NAME } from '../filters/reorder/automation'
-import { TYPE_NAME as ORG_FIELD_TYPE_NAME } from '../filters/reorder/organization_field'
 import { TYPE_NAME as SLA_POLICY_TYPE_NAME } from '../filters/reorder/sla_policy'
 import { TYPE_NAME as TICKET_FORM_TYPE_NAME } from '../filters/reorder/ticket_form'
-import { TYPE_NAME as USER_FIELD_TYPE_NAME } from '../filters/reorder/user_field'
 import { TYPE_NAME as VIEW_TYPE_NAME } from '../filters/reorder/view'
 import { TYPE_NAME as WORKSPACE_TYPE_NAME } from '../filters/reorder/workspace'
 

--- a/packages/zendesk-adapter/src/constants.ts
+++ b/packages/zendesk-adapter/src/constants.ts
@@ -29,6 +29,10 @@ export const USER_SEGMENT_TYPE_NAME = 'user_segment'
 export const GUIDE_SETTINGS_TYPE_NAME = 'guide_settings'
 export const GUIDE_LANGUAGE_SETTINGS_TYPE_NAME = 'guide_language_settings'
 export const PERMISSION_GROUP_TYPE_NAME = 'permission_group'
+export const TICKET_FIELD_TYPE_NAME = 'ticket_field'
+export const ORG_FIELD_TYPE_NAME = 'organization_field'
+export const USER_FIELD_TYPE_NAME = 'user_field'
+export const FIELD_TYPE_NAMES = [TICKET_FIELD_TYPE_NAME, USER_FIELD_TYPE_NAME, ORG_FIELD_TYPE_NAME]
 
 export const CATEGORY_ORDER_TYPE_NAME = 'category_order'
 export const SECTION_ORDER_TYPE_NAME = 'section_order'

--- a/packages/zendesk-adapter/src/filters/add_field_options.ts
+++ b/packages/zendesk-adapter/src/filters/add_field_options.ts
@@ -17,8 +17,8 @@ import { InstanceElement } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { FilterCreator } from '../filter'
 import { applyforInstanceChangesOfType } from './utils'
-import { CUSTOM_FIELD_OPTIONS_FIELD_NAME, ORG_FIELD_TYPE_NAME } from './organization_field'
-import { USER_FIELD_TYPE_NAME } from './custom_field_options/user_field'
+import { CUSTOM_FIELD_OPTIONS_FIELD_NAME } from './organization_field'
+import { ORG_FIELD_TYPE_NAME, USER_FIELD_TYPE_NAME } from '../constants'
 
 const { makeArray } = collections.array
 

--- a/packages/zendesk-adapter/src/filters/custom_field_options/ticket_field.ts
+++ b/packages/zendesk-adapter/src/filters/custom_field_options/ticket_field.ts
@@ -14,12 +14,13 @@
 * limitations under the License.
 */
 import { createCustomFieldOptionsFilterCreator } from './creator'
+import { TICKET_FIELD_TYPE_NAME } from '../../constants'
 
 /**
  * Deploys ticket field and ticket field options
  */
 const filterCreator = createCustomFieldOptionsFilterCreator({
-  parentTypeName: 'ticket_field',
+  parentTypeName: TICKET_FIELD_TYPE_NAME,
   childTypeName: 'ticket_field__custom_field_options',
 })
 

--- a/packages/zendesk-adapter/src/filters/custom_field_options/user_field.ts
+++ b/packages/zendesk-adapter/src/filters/custom_field_options/user_field.ts
@@ -14,8 +14,7 @@
 * limitations under the License.
 */
 import { createCustomFieldOptionsFilterCreator } from './creator'
-
-export const USER_FIELD_TYPE_NAME = 'user_field'
+import { USER_FIELD_TYPE_NAME } from '../../constants'
 
 /**
  * Deploys user field and user field options

--- a/packages/zendesk-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-adapter/src/filters/field_references.ts
@@ -19,7 +19,7 @@ import { references as referenceUtils } from '@salto-io/adapter-components'
 import { GetLookupNameFunc } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
-import { BRAND_TYPE_NAME } from '../constants'
+import { BRAND_TYPE_NAME, TICKET_FIELD_TYPE_NAME, USER_FIELD_TYPE_NAME, ORG_FIELD_TYPE_NAME, FIELD_TYPE_NAMES } from '../constants'
 import { FETCH_CONFIG } from '../config'
 import { ZendeskMissingReferenceStrategyLookup } from './references/missing_references'
 
@@ -93,9 +93,6 @@ const TICKET_FIELD_ALTERNATIVE_PREFIX = 'ticket_fields_'
 const ORG_FIELD_PREFIX = 'organization.custom_fields.'
 const USER_FIELD_PREFIX = 'requester.custom_fields.'
 const ALTERNATE_USER_FIELD_PREFIX = 'user.custom_fields.'
-const TICKET_FIELD_TYPE_NAME = 'ticket_field'
-const ORG_FIELD_TYPE_NAME = 'organization_field'
-const USER_FIELD_TYPE_NAME = 'user_field'
 const TICKET_FIELD_OPTION_TYPE_NAME = 'ticket_field__custom_field_options'
 const ORG_FIELD_OPTION_TYPE_NAME = 'organization_field__custom_field_options'
 const USER_FIELD_OPTION_TYPE_NAME = 'user_field__custom_field_options'
@@ -362,22 +359,22 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
   {
     src: { field: 'active', parentTypes: ['organization_field_order'] },
     serializationStrategy: 'id',
-    target: { type: 'organization_field' },
+    target: { type: ORG_FIELD_TYPE_NAME },
   },
   {
     src: { field: 'inactive', parentTypes: ['organization_field_order'] },
     serializationStrategy: 'id',
-    target: { type: 'organization_field' },
+    target: { type: ORG_FIELD_TYPE_NAME },
   },
   {
     src: { field: 'active', parentTypes: ['user_field_order'] },
     serializationStrategy: 'id',
-    target: { type: 'user_field' },
+    target: { type: USER_FIELD_TYPE_NAME },
   },
   {
     src: { field: 'inactive', parentTypes: ['user_field_order'] },
     serializationStrategy: 'id',
-    target: { type: 'user_field' },
+    target: { type: USER_FIELD_TYPE_NAME },
   },
   {
     src: { field: 'active', parentTypes: ['workspace_order'] },
@@ -442,17 +439,17 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
   {
     src: { field: 'ticket_field_id' },
     serializationStrategy: 'id',
-    target: { type: 'ticket_field' },
+    target: { type: TICKET_FIELD_TYPE_NAME },
   },
   {
     src: { field: 'ticket_field_ids' },
     serializationStrategy: 'id',
-    target: { type: 'ticket_field' },
+    target: { type: TICKET_FIELD_TYPE_NAME },
   },
   {
     src: { field: 'parent_field_id' },
     serializationStrategy: 'id',
-    target: { type: 'ticket_field' },
+    target: { type: TICKET_FIELD_TYPE_NAME },
   },
   {
     src: {
@@ -463,25 +460,25 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
       ],
     },
     serializationStrategy: 'id',
-    target: { type: 'ticket_field' },
+    target: { type: TICKET_FIELD_TYPE_NAME },
   },
   {
-    src: { field: 'custom_field_options', parentTypes: ['ticket_field'] },
+    src: { field: 'custom_field_options', parentTypes: [TICKET_FIELD_TYPE_NAME] },
     serializationStrategy: 'fullValue',
     target: { type: 'ticket_field__custom_field_options' },
   },
   {
-    src: { field: 'default_custom_field_option', parentTypes: ['ticket_field'] },
+    src: { field: 'default_custom_field_option', parentTypes: [TICKET_FIELD_TYPE_NAME] },
     zendeskSerializationStrategy: 'value',
     target: { type: 'ticket_field__custom_field_options' },
   },
   {
-    src: { field: 'custom_field_options', parentTypes: ['user_field'] },
+    src: { field: 'custom_field_options', parentTypes: [USER_FIELD_TYPE_NAME] },
     serializationStrategy: 'fullValue',
     target: { type: 'user_field__custom_field_options' },
   },
   {
-    src: { field: 'default_custom_field_option', parentTypes: ['user_field'] },
+    src: { field: 'default_custom_field_option', parentTypes: [USER_FIELD_TYPE_NAME] },
     zendeskSerializationStrategy: 'value',
     target: { type: 'user_field__custom_field_options' },
   },
@@ -503,7 +500,7 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
       ],
     },
     zendeskSerializationStrategy: 'ticketField',
-    target: { type: 'ticket_field' },
+    target: { type: TICKET_FIELD_TYPE_NAME },
   },
   {
     src: {
@@ -514,7 +511,7 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
       ],
     },
     zendeskSerializationStrategy: 'ticketField',
-    target: { type: 'ticket_field' },
+    target: { type: TICKET_FIELD_TYPE_NAME },
   },
   {
     src: {
@@ -525,7 +522,7 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
       ],
     },
     zendeskSerializationStrategy: 'ticketFieldAlternative',
-    target: { type: 'ticket_field' },
+    target: { type: TICKET_FIELD_TYPE_NAME },
   },
   {
     src: {
@@ -544,7 +541,7 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
       ],
     },
     zendeskSerializationStrategy: 'orgField',
-    target: { type: 'organization_field' },
+    target: { type: ORG_FIELD_TYPE_NAME },
   },
   {
     src: {
@@ -555,7 +552,7 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
       ],
     },
     zendeskSerializationStrategy: 'orgField',
-    target: { type: 'organization_field' },
+    target: { type: ORG_FIELD_TYPE_NAME },
   },
   {
     src: {
@@ -572,7 +569,7 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
       ],
     },
     zendeskSerializationStrategy: 'userField',
-    target: { type: 'user_field' },
+    target: { type: USER_FIELD_TYPE_NAME },
   },
   {
     src: {
@@ -583,7 +580,7 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
       ],
     },
     zendeskSerializationStrategy: 'userFieldAlternative',
-    target: { type: 'user_field' },
+    target: { type: USER_FIELD_TYPE_NAME },
   },
   {
     src: {
@@ -594,17 +591,17 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
       ],
     },
     zendeskSerializationStrategy: 'userField',
-    target: { type: 'user_field' },
+    target: { type: USER_FIELD_TYPE_NAME },
   },
   {
     src: { field: 'id', parentTypes: ['view__execution__columns'] },
     serializationStrategy: 'id',
-    target: { type: 'ticket_field' },
+    target: { type: TICKET_FIELD_TYPE_NAME },
   },
   {
     src: { field: 'id', parentTypes: ['view__execution__custom_fields'] },
     serializationStrategy: 'id',
-    target: { type: 'ticket_field' },
+    target: { type: TICKET_FIELD_TYPE_NAME },
   },
   {
     src: { field: 'ticket_form_id' },
@@ -726,17 +723,17 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
   {
     src: { field: 'group_by', parentTypes: ['view__execution'] },
     serializationStrategy: 'id',
-    target: { type: 'ticket_field' },
+    target: { type: TICKET_FIELD_TYPE_NAME },
   },
   {
     src: { field: 'sort_by', parentTypes: ['view__execution'] },
     serializationStrategy: 'id',
-    target: { type: 'ticket_field' },
+    target: { type: TICKET_FIELD_TYPE_NAME },
   },
   {
     src: { field: 'id', parentTypes: ['view__execution__group', 'view__execution__sort'] },
     serializationStrategy: 'id',
-    target: { type: 'ticket_field' },
+    target: { type: TICKET_FIELD_TYPE_NAME },
   },
   {
     src: { field: 'attachments', parentTypes: ['macro'] },
@@ -744,7 +741,7 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
     target: { type: 'macro_attachment' },
   },
   {
-    src: { field: 'tag', parentTypes: ['ticket_field', 'organization_field', 'user_field'] },
+    src: { field: 'tag', parentTypes: FIELD_TYPE_NAMES },
     serializationStrategy: 'id',
     target: { type: 'tag' },
   },

--- a/packages/zendesk-adapter/src/filters/handle_app_installations.ts
+++ b/packages/zendesk-adapter/src/filters/handle_app_installations.ts
@@ -24,6 +24,7 @@ import { FilterCreator } from '../filter'
 import { FETCH_CONFIG, IdLocator } from '../config'
 import { APP_INSTALLATION_TYPE_NAME } from './app'
 import { ZENDESK_REFERENCE_TYPE_TO_SALTO_TYPE } from './handle_template_expressions'
+import { TICKET_FIELD_TYPE_NAME } from '../constants'
 
 const log = logger(module)
 
@@ -36,7 +37,7 @@ const GENERAL_ID_REGEX = '([\\d]{10,})'
 const LOCATORS: IdLocator[] = [{
   fieldRegex: '(?:(.*_fields)|(.*_field)|^(ticketfield.*))$',
   idRegex: GENERAL_ID_REGEX,
-  type: ['ticket_field'],
+  type: [TICKET_FIELD_TYPE_NAME],
 }, {
   fieldRegex: '.*_options$',
   idRegex: '(custom_field_)([\\d]+)',

--- a/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
@@ -24,7 +24,7 @@ import _ from 'lodash'
 import { FilterCreator } from '../filter'
 import { DYNAMIC_CONTENT_ITEM_TYPE_NAME } from './dynamic_content'
 import { createMissingInstance } from './references/missing_references'
-import { ZENDESK } from '../constants'
+import { ZENDESK, TICKET_FIELD_TYPE_NAME } from '../constants'
 import { FETCH_CONFIG } from '../config'
 
 
@@ -35,7 +35,7 @@ const REFERENCE_MARKER_REGEX = /\$\{(.+?)}/
 const DYNAMIC_CONTENT_REGEX = /(dc\.[\w-]+)/g
 
 export const ZENDESK_REFERENCE_TYPE_TO_SALTO_TYPE: Record<string, string> = {
-  'ticket.ticket_field': 'ticket_field',
+  'ticket.ticket_field': TICKET_FIELD_TYPE_NAME,
   'ticket.ticket_field_option_title': 'ticket_field__custom_field_options',
 }
 

--- a/packages/zendesk-adapter/src/filters/organization_field.ts
+++ b/packages/zendesk-adapter/src/filters/organization_field.ts
@@ -19,9 +19,9 @@ import { FilterCreator } from '../filter'
 import { addIdsToChildrenUponAddition, deployChange, deployChanges } from '../deployment'
 import { API_DEFINITIONS_CONFIG } from '../config'
 import { createAdditionalParentChanges } from './utils'
+import { ORG_FIELD_TYPE_NAME } from '../constants'
 
 export const CUSTOM_FIELD_OPTIONS_FIELD_NAME = 'custom_field_options'
-export const ORG_FIELD_TYPE_NAME = 'organization_field'
 export const ORG_FIELD_OPTION_TYPE_NAME = 'organization_field__custom_field_options'
 
 const filterCreator: FilterCreator = ({ config, client }) => ({

--- a/packages/zendesk-adapter/src/filters/reorder/organization_field.ts
+++ b/packages/zendesk-adapter/src/filters/reorder/organization_field.ts
@@ -14,14 +14,13 @@
 * limitations under the License.
 */
 import { createReorderFilterCreator } from './creator'
-
-export const TYPE_NAME = 'organization_field'
+import { ORG_FIELD_TYPE_NAME } from '../../constants'
 
 /**
  * Add organization field order element with all the organization fields ordered
  */
 const filterCreator = createReorderFilterCreator({
-  typeName: TYPE_NAME,
+  typeName: ORG_FIELD_TYPE_NAME,
   orderFieldName: 'organization_field_ids',
   iterateesToSortBy: [
     instance => !instance.value.active,

--- a/packages/zendesk-adapter/src/filters/reorder/user_field.ts
+++ b/packages/zendesk-adapter/src/filters/reorder/user_field.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { USER_FIELD_TYPE_NAME } from '../custom_field_options/user_field'
+import { USER_FIELD_TYPE_NAME } from '../../constants'
 import { createReorderFilterCreator } from './creator'
 
 export const TYPE_NAME = USER_FIELD_TYPE_NAME

--- a/packages/zendesk-adapter/src/filters/tag.ts
+++ b/packages/zendesk-adapter/src/filters/tag.ts
@@ -22,7 +22,7 @@ import { applyFunctionToChangeData, naclCase } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
-import { ZENDESK } from '../constants'
+import { ZENDESK, FIELD_TYPE_NAMES } from '../constants'
 import { FilterCreator } from '../filter'
 import { isConditions } from './utils'
 
@@ -41,7 +41,6 @@ const TYPE_NAME_TO_TAG_FIELD_NAMES: Record<string, string[]> = {
   user_segment: ['tags', 'or_tags'],
 }
 
-const TYPE_NAME_WITH_CHECKBOXES = ['ticket_field', 'user_field', 'organization_field']
 const TAG_FIELD_NAME_IN_CHECKBOX = 'tag'
 export const TAG_TYPE_NAME = 'tag'
 const TAGS_FILE_NAME = 'tags'
@@ -54,7 +53,7 @@ const extractTags = (value: string): string[] =>
   value.split(TAG_SEPERATOR).filter(tag => !_.isEmpty(tag))
 
 const isRelevantCheckboxInstance = (instance: InstanceElement): boolean => (
-  TYPE_NAME_WITH_CHECKBOXES.includes(instance.elemID.typeName)
+  FIELD_TYPE_NAMES.includes(instance.elemID.typeName)
   && instance.value.type === 'checkbox'
   && !_.isEmpty(instance.value[TAG_FIELD_NAME_IN_CHECKBOX])
 )

--- a/packages/zendesk-adapter/src/group_change.ts
+++ b/packages/zendesk-adapter/src/group_change.ts
@@ -17,7 +17,7 @@ import { values, collections } from '@salto-io/lowerdash'
 import { Change, ChangeGroupIdFunction, getChangeData, ChangeGroupId, ChangeId,
   isInstanceElement, isReferenceExpression } from '@salto-io/adapter-api'
 import { getParents } from '@salto-io/adapter-utils'
-import { SECTION_TYPE_NAME } from './constants'
+import { SECTION_TYPE_NAME, TICKET_FIELD_TYPE_NAME, USER_FIELD_TYPE_NAME, ORG_FIELD_TYPE_NAME } from './constants'
 
 
 const { awu } = collections.asynciterable
@@ -25,10 +25,10 @@ const { awu } = collections.asynciterable
 type ChangeIdFunction = (change: Change) => Promise<string | undefined>
 
 const PARENT_GROUPED_WITH_INNER_TYPE = [
-  'ticket_field',
-  'user_field',
+  TICKET_FIELD_TYPE_NAME,
+  USER_FIELD_TYPE_NAME,
   'dynamic_content_item',
-  'organization_field',
+  ORG_FIELD_TYPE_NAME,
   'macro',
 ]
 const INNER_TYPE_GROUPED_WITH_PARENT = [

--- a/packages/zendesk-adapter/test/change_validators/missing_from_parent.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/missing_from_parent.test.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import { AdditionChange, CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { elementSource } from '@salto-io/workspace'
 import { ZENDESK } from '../../src/constants'
 import {
   createParentReferencesError,
@@ -64,19 +65,23 @@ describe('missingFromParentValidatorCreator', () => {
       new ReferenceExpression(option2.elemID, option2),
     ]
     const addOption3 = toChange({ after: option3 }) as AdditionChange<InstanceElement>
-    const errors = await missingFromParentValidatorCreator(DEFAULT_CONFIG[API_DEFINITIONS_CONFIG])([
-      toChange({ after: option2 }),
-      addOption3,
-      toChange({ before: ticketField, after: clonedTicketField }),
-    ])
+    const errors = await missingFromParentValidatorCreator(DEFAULT_CONFIG[API_DEFINITIONS_CONFIG])(
+      [
+        toChange({ after: option2 }),
+        addOption3,
+        toChange({ before: ticketField, after: clonedTicketField }),
+      ],
+      elementSource.createInMemoryElementSource([clonedTicketField, ticketFieldType]),
+    )
     expect(errors)
       .toEqual([createParentReferencesError(addOption3, ticketField.elemID.getFullName())])
   })
   it('should return an error when we add an option instance but it does not exist in the parent - parent is not modified', async () => {
     const addOption2 = toChange({ after: option2 }) as AdditionChange<InstanceElement>
-    const errors = await missingFromParentValidatorCreator(DEFAULT_CONFIG[API_DEFINITIONS_CONFIG])([
-      toChange({ after: option2 }),
-    ])
+    const errors = await missingFromParentValidatorCreator(DEFAULT_CONFIG[API_DEFINITIONS_CONFIG])(
+      [toChange({ after: option2 })],
+      elementSource.createInMemoryElementSource([ticketField, ticketFieldType]),
+    )
     expect(errors)
       .toEqual([createParentReferencesError(addOption2, ticketField.elemID.getFullName())])
   })
@@ -86,10 +91,13 @@ describe('missingFromParentValidatorCreator', () => {
       new ReferenceExpression(option1.elemID, option1),
       new ReferenceExpression(option2.elemID, option2),
     ]
-    const errors = await missingFromParentValidatorCreator(DEFAULT_CONFIG[API_DEFINITIONS_CONFIG])([
-      toChange({ after: option2 }),
-      toChange({ before: ticketField, after: clonedTicketField }),
-    ])
+    const errors = await missingFromParentValidatorCreator(DEFAULT_CONFIG[API_DEFINITIONS_CONFIG])(
+      [
+        toChange({ after: option2 }),
+        toChange({ before: ticketField, after: clonedTicketField }),
+      ],
+      elementSource.createInMemoryElementSource([clonedTicketField, ticketFieldType]),
+    )
     expect(errors).toEqual([])
   })
 })

--- a/packages/zendesk-adapter/test/change_validators/removed_from_parent.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/removed_from_parent.test.ts
@@ -69,7 +69,7 @@ describe('removedFromParentValidatorCreator', () => {
         detailedMessage: `The following ${CUSTOM_FIELD_OPTIONS_FIELD_NAME} are no longer referenced from ${clonedTicketField.elemID.typeName} "${clonedTicketField.elemID.name}", but the instances still exist:
 - ${option2.elemID.name}
 
-If you continue with the deploy they will be removed from the service, and any references to them will break. It is recommended to remove them in Salto first and deploy again.`,
+If you continue with the deploy they will be removed from the service, and any references to them will break. It is recommended to remove these options in Salto first and deploy again.`,
       }])
     })
     it('should not return an error when remove an option from the parent and remove the instance as well', async () => {
@@ -133,7 +133,7 @@ If you continue with the deploy they will be removed from the service, and any r
         detailedMessage: `The following variants are no longer referenced from ${clonedDynamicContentItem.elemID.typeName} "${clonedDynamicContentItem.elemID.name}", but the instances still exist:
 - ${variant2.elemID.name}
 
-Please remove them first and deploy again.`,
+Please remove these options first and deploy again.`,
       }])
     })
     it('should not return an error when remove an option from the parent and remove the instance as well', async () => {

--- a/packages/zendesk-adapter/test/change_validators/removed_from_parent.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/removed_from_parent.test.ts
@@ -22,62 +22,132 @@ import { CUSTOM_FIELD_OPTIONS_FIELD_NAME } from '../../src/filters/custom_field_
 import { API_DEFINITIONS_CONFIG, DEFAULT_CONFIG } from '../../src/config'
 
 describe('removedFromParentValidatorCreator', () => {
-  const ticketFieldType = new ObjectType({
-    elemID: new ElemID(ZENDESK, 'ticket_field'),
-  })
-  const ticketFieldOptionType = new ObjectType({
-    elemID: new ElemID(ZENDESK, 'ticket_field__custom_field_options'),
-  })
-  const option1 = new InstanceElement(
-    'option1', ticketFieldOptionType, { name: 'test1', value: 'v1' },
-  )
-  const option2 = new InstanceElement(
-    'option2', ticketFieldOptionType, { name: 'test2', value: 'v2' },
-  )
-  const ticketField = new InstanceElement(
-    'field',
-    ticketFieldType,
-    {
-      name: 'test1',
-      [CUSTOM_FIELD_OPTIONS_FIELD_NAME]: [
-        new ReferenceExpression(option1.elemID, option1),
-        new ReferenceExpression(option2.elemID, option2),
-      ],
-    },
-  )
-  option1.annotations[CORE_ANNOTATIONS.PARENT] = [
-    new ReferenceExpression(ticketField.elemID, ticketField),
-  ]
-  option2.annotations[CORE_ANNOTATIONS.PARENT] = [
-    new ReferenceExpression(ticketField.elemID, ticketField),
-  ]
-  it('should return an error when remove an option from the parent but keep the instance', async () => {
-    const clonedTicketField = ticketField.clone()
-    clonedTicketField.value[CUSTOM_FIELD_OPTIONS_FIELD_NAME] = [
-      new ReferenceExpression(option1.elemID, option1),
+  describe('ticket/user/organization field', () => {
+    const ticketFieldType = new ObjectType({
+      elemID: new ElemID(ZENDESK, 'ticket_field'),
+    })
+    const ticketFieldOptionType = new ObjectType({
+      elemID: new ElemID(ZENDESK, 'ticket_field__custom_field_options'),
+    })
+    const option1 = new InstanceElement(
+      'option1', ticketFieldOptionType, { name: 'test1', value: 'v1' },
+    )
+    const option2 = new InstanceElement(
+      'option2', ticketFieldOptionType, { name: 'test2', value: 'v2' },
+    )
+    const ticketField = new InstanceElement(
+      'field',
+      ticketFieldType,
+      {
+        name: 'test1',
+        [CUSTOM_FIELD_OPTIONS_FIELD_NAME]: [
+          new ReferenceExpression(option1.elemID, option1),
+          new ReferenceExpression(option2.elemID, option2),
+        ],
+      },
+    )
+    option1.annotations[CORE_ANNOTATIONS.PARENT] = [
+      new ReferenceExpression(ticketField.elemID, ticketField),
     ]
-    const errors = await removedFromParentValidatorCreator(DEFAULT_CONFIG[API_DEFINITIONS_CONFIG])([
-      toChange({ before: ticketField, after: clonedTicketField }),
-    ])
-    expect(errors).toEqual([{
-      elemID: clonedTicketField.elemID,
-      severity: 'Warning',
-      message: `Removing ${CUSTOM_FIELD_OPTIONS_FIELD_NAME} from ${clonedTicketField.elemID.typeName} will also remove related instances`,
-      detailedMessage: `The following ${CUSTOM_FIELD_OPTIONS_FIELD_NAME} are no longer referenced from ${clonedTicketField.elemID.typeName} "${clonedTicketField.elemID.name}", but the instances still exist:
-- ${option2.elemID.name}.
+    option2.annotations[CORE_ANNOTATIONS.PARENT] = [
+      new ReferenceExpression(ticketField.elemID, ticketField),
+    ]
+    it('should return a warning when removing an option from the parent but keeping the instance', async () => {
+      const clonedTicketField = ticketField.clone()
+      clonedTicketField.value[CUSTOM_FIELD_OPTIONS_FIELD_NAME] = [
+        new ReferenceExpression(option1.elemID, option1),
+      ]
+      const errors = await removedFromParentValidatorCreator(
+        DEFAULT_CONFIG[API_DEFINITIONS_CONFIG]
+      )([
+        toChange({ before: ticketField, after: clonedTicketField }),
+      ])
+      expect(errors).toEqual([{
+        elemID: clonedTicketField.elemID,
+        severity: 'Warning',
+        message: `Removing ${CUSTOM_FIELD_OPTIONS_FIELD_NAME} from ${clonedTicketField.elemID.typeName} will also remove related instances`,
+        detailedMessage: `The following ${CUSTOM_FIELD_OPTIONS_FIELD_NAME} are no longer referenced from ${clonedTicketField.elemID.typeName} "${clonedTicketField.elemID.name}", but the instances still exist:
+- ${option2.elemID.name}
 
 If you continue with the deploy they will be removed from the service, and any references to them will break. It is recommended to remove them in Salto first and deploy again.`,
-    }])
+      }])
+    })
+    it('should not return an error when remove an option from the parent and remove the instance as well', async () => {
+      const clonedTicketField = ticketField.clone()
+      clonedTicketField.value[CUSTOM_FIELD_OPTIONS_FIELD_NAME] = [
+        new ReferenceExpression(option1.elemID, option1),
+      ]
+      const errors = await removedFromParentValidatorCreator(
+        DEFAULT_CONFIG[API_DEFINITIONS_CONFIG]
+      )([
+        toChange({ before: option2 }),
+        toChange({ before: ticketField, after: clonedTicketField }),
+      ])
+      expect(errors).toEqual([])
+    })
   })
-  it('should not return an error when remove an option from the parent and remove the instance as well', async () => {
-    const clonedTicketField = ticketField.clone()
-    clonedTicketField.value[CUSTOM_FIELD_OPTIONS_FIELD_NAME] = [
-      new ReferenceExpression(option1.elemID, option1),
+  describe('other types', () => {
+    const dynamicContentItemType = new ObjectType({
+      elemID: new ElemID(ZENDESK, 'dynamic_content_item'),
+    })
+    const dynamicContentItemVariantsType = new ObjectType({
+      elemID: new ElemID(ZENDESK, 'dynamic_content_item__variants'),
+    })
+    const variant1 = new InstanceElement(
+      'variant1', dynamicContentItemVariantsType, { name: 'test1' },
+    )
+    const variant2 = new InstanceElement(
+      'variant2', dynamicContentItemVariantsType, { name: 'test2' },
+    )
+    const dynamicContentItem = new InstanceElement(
+      'content',
+      dynamicContentItemType,
+      {
+        name: 'bla',
+        variants: [
+          new ReferenceExpression(variant1.elemID, variant1),
+          new ReferenceExpression(variant2.elemID, variant2),
+        ],
+      },
+    )
+    variant1.annotations[CORE_ANNOTATIONS.PARENT] = [
+      new ReferenceExpression(dynamicContentItem.elemID, dynamicContentItem),
     ]
-    const errors = await removedFromParentValidatorCreator(DEFAULT_CONFIG[API_DEFINITIONS_CONFIG])([
-      toChange({ before: option2 }),
-      toChange({ before: ticketField, after: clonedTicketField }),
-    ])
-    expect(errors).toEqual([])
+    variant1.annotations[CORE_ANNOTATIONS.PARENT] = [
+      new ReferenceExpression(dynamicContentItem.elemID, dynamicContentItem),
+    ]
+    it('should return a warning when removing an option from the parent but keeping the instance', async () => {
+      const clonedDynamicContentItem = dynamicContentItem.clone()
+      clonedDynamicContentItem.value.variants = [
+        new ReferenceExpression(variant1.elemID, variant2),
+      ]
+      const errors = await removedFromParentValidatorCreator(
+        DEFAULT_CONFIG[API_DEFINITIONS_CONFIG]
+      )([
+        toChange({ before: dynamicContentItem, after: clonedDynamicContentItem }),
+      ])
+      expect(errors).toEqual([{
+        elemID: clonedDynamicContentItem.elemID,
+        severity: 'Error',
+        message: `Cannot remove variants from ${clonedDynamicContentItem.elemID.typeName} without removing the related instances`,
+        detailedMessage: `The following variants are no longer referenced from ${clonedDynamicContentItem.elemID.typeName} "${clonedDynamicContentItem.elemID.name}", but the instances still exist:
+- ${variant2.elemID.name}
+
+Please remove them first and deploy again.`,
+      }])
+    })
+    it('should not return an error when remove an option from the parent and remove the instance as well', async () => {
+      const clonedDynamicContentItem = dynamicContentItem.clone()
+      clonedDynamicContentItem.value.variants = [
+        new ReferenceExpression(variant1.elemID, variant1),
+      ]
+      const errors = await removedFromParentValidatorCreator(
+        DEFAULT_CONFIG[API_DEFINITIONS_CONFIG]
+      )([
+        toChange({ before: variant2 }),
+        toChange({ before: dynamicContentItem, after: clonedDynamicContentItem }),
+      ])
+      expect(errors).toEqual([])
+    })
   })
 })

--- a/packages/zendesk-adapter/test/change_validators/removed_from_parent.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/removed_from_parent.test.ts
@@ -62,8 +62,8 @@ describe('removedFromParentValidatorCreator', () => {
     expect(errors).toEqual([{
       elemID: clonedTicketField.elemID,
       severity: 'Error',
-      message: `Error while trying to remove ${clonedTicketField.elemID.typeName}, because the related instance still exists, please remove it as well`,
-      detailedMessage: `Error while trying to remove ${clonedTicketField.elemID.getFullName()}, because the related instance ${option2.elemID.getFullName()} still exists, please remove it as well`,
+      message: `Error while trying to remove ${CUSTOM_FIELD_OPTIONS_FIELD_NAME} from ${clonedTicketField.elemID.typeName}, because the related instances still exist`,
+      detailedMessage: `Error while trying to remove from ${clonedTicketField.elemID.typeName} "${clonedTicketField.elemID.name}" the ${CUSTOM_FIELD_OPTIONS_FIELD_NAME} "${option2.elemID.name}", because the related instances still exist. Please remove them as well`,
     }])
   })
   it('should not return an error when remove an option from the parent and remove the instance as well', async () => {

--- a/packages/zendesk-adapter/test/change_validators/removed_from_parent.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/removed_from_parent.test.ts
@@ -61,9 +61,12 @@ describe('removedFromParentValidatorCreator', () => {
     ])
     expect(errors).toEqual([{
       elemID: clonedTicketField.elemID,
-      severity: 'Error',
-      message: `Error while trying to remove ${CUSTOM_FIELD_OPTIONS_FIELD_NAME} from ${clonedTicketField.elemID.typeName}, because the related instances still exist`,
-      detailedMessage: `Error while trying to remove from ${clonedTicketField.elemID.typeName} "${clonedTicketField.elemID.name}" the ${CUSTOM_FIELD_OPTIONS_FIELD_NAME} "${option2.elemID.name}", because the related instances still exist. Please remove them as well`,
+      severity: 'Warning',
+      message: `Removing ${CUSTOM_FIELD_OPTIONS_FIELD_NAME} from ${clonedTicketField.elemID.typeName} will also remove related instances`,
+      detailedMessage: `The following ${CUSTOM_FIELD_OPTIONS_FIELD_NAME} are no longer referenced from ${clonedTicketField.elemID.typeName} "${clonedTicketField.elemID.name}", but the instances still exist:
+- ${option2.elemID.name}.
+
+If you continue with the deploy they will be removed from the service, and any references to them will break. It is recommended to remove them in Salto first and deploy again.`,
     }])
   })
   it('should not return an error when remove an option from the parent and remove the instance as well', async () => {

--- a/packages/zendesk-adapter/test/filters/add_field_options.test.ts
+++ b/packages/zendesk-adapter/test/filters/add_field_options.test.ts
@@ -17,10 +17,9 @@ import {
   ObjectType, ElemID, InstanceElement, toChange,
 } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
-import { ZENDESK } from '../../src/constants'
+import { ZENDESK, USER_FIELD_TYPE_NAME, ORG_FIELD_TYPE_NAME } from '../../src/constants'
 import filterCreator from '../../src/filters/add_field_options'
-import { CUSTOM_FIELD_OPTIONS_FIELD_NAME, ORG_FIELD_TYPE_NAME } from '../../src/filters/organization_field'
-import { USER_FIELD_TYPE_NAME } from '../../src/filters/custom_field_options/user_field'
+import { CUSTOM_FIELD_OPTIONS_FIELD_NAME } from '../../src/filters/organization_field'
 import { createFilterCreatorParams } from '../utils'
 
 describe('add field options filter', () => {

--- a/packages/zendesk-adapter/test/filters/organization_field.test.ts
+++ b/packages/zendesk-adapter/test/filters/organization_field.test.ts
@@ -19,10 +19,10 @@ import {
 } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 
-import { ZENDESK } from '../../src/constants'
+import { ZENDESK, ORG_FIELD_TYPE_NAME } from '../../src/constants'
 
 import filterCreator, {
-  ORG_FIELD_OPTION_TYPE_NAME, ORG_FIELD_TYPE_NAME, CUSTOM_FIELD_OPTIONS_FIELD_NAME,
+  ORG_FIELD_OPTION_TYPE_NAME, CUSTOM_FIELD_OPTIONS_FIELD_NAME,
 } from '../../src/filters/organization_field'
 import { createFilterCreatorParams } from '../utils'
 


### PR DESCRIPTION
A few improvements that will impact the following parent-child "pairs" in zendesk:
* business_hours_schedule + business_hours_schedule_holiday
* ticket_field + ticket_field__custom_field_options
* user_field + user_field__custom_field_options
* organization_field + organization_field__custom_field_options
* routing_attribute + routing_attribute_value
* dynamic_content_item + dynamic_content_item__variants
* article + article_translation
* section + section_translation
* category + category_translation
* macro + macro_attachment
* brand + brand_logo

1. Improve the change validator that identifies instances that still exist but are no longer referenced from the parent:
* For the _ticket/user/organization fields + options_ - the validator will return a warning, but users will still be able to proceed (and the child option will implicitly be removed from the service). this will make this consistent with the service behavior (the removal works, and if there are references from triggers etc they break). We still _recommend_ to do this explicitly, but if users did not understand it was needed then we let them continue with the deployment at their own risk. 
* For the other types, fix the message that incorrectly stated the parent was removed
2. Small fixes in a few other validators

---
_Release Notes_: 
_Zendesk adapter_:
* When a ticket/user/organization field option is removed from the field but the instance is not removed, the user will get a warning but will still be able to proceed, instead of getting a validation error.

---
_User Notifications_: 
None