### PR TITLE
SALTO-2997 Return fetchMetadataInstances to work in parallel and not sequential

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -496,13 +496,15 @@ export default class SalesforceAdapter implements AdapterOperations {
     typeInfoPromise: Promise<MetadataObject[]>,
     types: Promise<TypeElement[]>,
   ): Promise<FetchElements<InstanceElement[]>> {
-    const readInstances = async (metadataTypesToRead: ObjectType[]):
+    const readInstances = async (metadataTypes: ObjectType[]):
       Promise<FetchElements<InstanceElement[]>> => {
-      const result = await awu(metadataTypesToRead)
+      const metadataTypesToRead = await awu(metadataTypes)
         .filter(
           async type => !this.metadataTypesOfInstancesFetchedInFilters
             .includes(await apiName(type))
-        ).map(type => this.createMetadataInstances(type)).toArray()
+        ).toArray()
+      const result = await Promise.all(metadataTypesToRead
+        .map(type => this.createMetadataInstances(type)))
       return {
         elements: _.flatten(result.map(r => r.elements)),
         configChanges: _.flatten(result.map(r => r.configChanges)),


### PR DESCRIPTION
_Return fetchMetadataInstances to work in parallel and not sequential_

---
_Additional context for reviewer_:
None

---
_Release Notes_: 
Salesforce-adapter:

* Return fetchMetadataInstances to work in parallel and not sequential
---

_User Notifications_: 
Salesforce-adapter:
None