### PR TITLE
SALTO-2998 fix one-translation-per-locale validator

### DIFF
--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -991,9 +991,11 @@ export const elementExpressionStringifyReplacer: Replacer = (_key, value) => {
   return value
 }
 
-export const safeJsonStringify = (value: Value,
+export const safeJsonStringify = (
+  value: Value,
   replacer?: Replacer,
-  space?: string | number): string =>
+  space?: string | number
+): string =>
   safeStringify(value, replacer, space)
 
 export const getAllReferencedIds = (
@@ -1096,7 +1098,9 @@ export const createSchemeGuardForInstance = <T extends InstanceElement>(
     const { error } = scheme.validate(instance.value)
     if (error !== undefined) {
       if (errorMessage !== undefined) {
-        log.error(`${errorMessage}: ${error.message}, ${safeJsonStringify(instance)}`)
+        log.error('Error validating instance %s: %s, %s. Value: %s',
+          instance.elemID.getFullName(), errorMessage, error.message,
+          safeJsonStringify(instance.value, elementExpressionStringifyReplacer))
       }
       return false
     }

--- a/packages/zendesk-adapter/test/change_validators/one_translation_per_locale.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/one_translation_per_locale.test.ts
@@ -22,8 +22,10 @@ import {
   ReferenceExpression,
   toChange,
 } from '@salto-io/adapter-api'
+import { elementSource } from '@salto-io/workspace'
 import { ZENDESK } from '../../src/constants'
 import { oneTranslationPerLocaleValidator } from '../../src/change_validators'
+import { LOCALE_TYPE_NAME } from '../../src/filters/help_center_locale'
 
 describe('oneTranslationPerLocalValidator',
   () => {
@@ -33,8 +35,11 @@ describe('oneTranslationPerLocalValidator',
     const articleTranslationType = new ObjectType({
       elemID: new ElemID(ZENDESK, 'article_translation'),
     })
+    const guideLocaleType = new ObjectType({
+      elemID: new ElemID(ZENDESK, LOCALE_TYPE_NAME),
+    })
 
-    it('should not return an error when article have different translations with different locale', async () => {
+    it('should not return an error when article has different translations with different locale', async () => {
       const enTranslation = new InstanceElement(
         'Test1',
         articleTranslationType,
@@ -44,12 +49,27 @@ describe('oneTranslationPerLocalValidator',
         undefined,
       )
       const heTranslation = new InstanceElement(
-        'Test1',
+        'Test2',
         articleTranslationType,
         {
           locale: 'he',
         },
         undefined,
+      )
+      const esTranslation = new InstanceElement(
+        'Test3',
+        articleTranslationType,
+        {
+          locale: new ReferenceExpression(new ElemID(ZENDESK, LOCALE_TYPE_NAME, 'instance', 'es')),
+        },
+        undefined,
+      )
+      const esLocale = new InstanceElement(
+        'es',
+        guideLocaleType,
+        {
+          id: 'es',
+        },
       )
       const article = new InstanceElement(
         'Test1',
@@ -65,20 +85,24 @@ describe('oneTranslationPerLocalValidator',
           ],
         },
       )
-      heTranslation.annotations[CORE_ANNOTATIONS.PARENT] = [new ReferenceExpression(
-        articleType.elemID.createNestedID('instance', 'Test1'), article
-      )]
-      enTranslation.annotations[CORE_ANNOTATIONS.PARENT] = [new ReferenceExpression(
-        articleType.elemID.createNestedID('instance', 'Test1'), article
-      )]
+      heTranslation.annotations[CORE_ANNOTATIONS.PARENT] = [
+        new ReferenceExpression(article.elemID, article),
+      ]
+      enTranslation.annotations[CORE_ANNOTATIONS.PARENT] = [
+        new ReferenceExpression(article.elemID, article),
+      ]
+      esTranslation.annotations[CORE_ANNOTATIONS.PARENT] = [
+        new ReferenceExpression(article.elemID, article),
+      ]
 
       const errors = await oneTranslationPerLocaleValidator(
-        [toChange({ after: heTranslation })]
+        [toChange({ after: heTranslation })],
+        elementSource.createInMemoryElementSource([esLocale])
       )
       expect(errors).toHaveLength(0)
     })
 
-    it('should return an error when article have different translations with same locale', async () => {
+    it('should return an error when article has different translations with same locale', async () => {
       const enTranslation = new InstanceElement(
         'Test2',
         articleTranslationType,
@@ -117,7 +141,8 @@ describe('oneTranslationPerLocalValidator',
       )]
 
       const errors = await oneTranslationPerLocaleValidator(
-        [toChange({ after: enTranslation }), toChange({ after: enTranslation2 })]
+        [toChange({ after: enTranslation }), toChange({ after: enTranslation2 })],
+        elementSource.createInMemoryElementSource([]),
       )
       expect(errors).toEqual([{
         elemID: article.elemID,
@@ -136,7 +161,8 @@ describe('oneTranslationPerLocalValidator',
         undefined,
       )
       const errors = await oneTranslationPerLocaleValidator(
-        [toChange({ after: noParentTranslation })]
+        [toChange({ after: noParentTranslation })],
+        elementSource.createInMemoryElementSource([]),
       )
       expect(errors).toHaveLength(0)
     })


### PR DESCRIPTION
It seems a combination of the fact that the validator did not expect to receive references + a problematic log + a recent change that added complex type dependency resulted in very slow deployments validations when a new translation instance is created. This should fix it.

---
_Release Notes_: 
None (not released yet)

---
_User Notifications_: 
None