### PR TITLE
Lint max line length 120

### DIFF
--- a/eslintrc.js
+++ b/eslintrc.js
@@ -157,14 +157,17 @@ module.exports = {
         'no-unused-expressions': 'off',
         '@typescript-eslint/no-unused-expressions': ['error'],
         '@typescript-eslint/await-thenable': ['error'],
-        'max-len': ['error',
-            {
-                'code': 120,
-                'ignoreUrls': true,
-                'ignoreStrings': true,
-                'ignoreTemplateLiterals': true,
-                'ignoreRegExpLiterals': true
-            }]
+        'max-len':
+            [
+                'error',
+                {
+                    'code': 120,
+                    'ignoreUrls': true,
+                    'ignoreStrings': true,
+                    'ignoreTemplateLiterals': true,
+                    'ignoreRegExpLiterals': true
+                }
+            ]
     },
     overrides: [
         {

--- a/eslintrc.js
+++ b/eslintrc.js
@@ -157,6 +157,14 @@ module.exports = {
         'no-unused-expressions': 'off',
         '@typescript-eslint/no-unused-expressions': ['error'],
         '@typescript-eslint/await-thenable': ['error'],
+        'max-len': ['error',
+            {
+                'code': 120,
+                'ignoreUrls': true,
+                'ignoreStrings': true,
+                'ignoreTemplateLiterals': true,
+                'ignoreRegExpLiterals': true
+            }]
     },
     overrides: [
         {


### PR DESCRIPTION
Linter allows length of lines to be up to 120

---

There are some additional defaults that i've added, they are described in the link below
* I didn't add ignoreComments as a personal reference 
* I added ignoreRegExpLiterals as a personal reference and because we have some long regexes in our code

https://smartdevpreneur.com/how-to-use-and-disable-eslint-max-len-line-length-rule/#ESLint_Max-Len_Defaults:~:text=len%20rule.-,ESLint%20Max%2DLen%20Ignore%20Comments%2C%20URLs%2C%20Strings%2C%20and%20Template%20Literals,%E2%80%9CignoreTemplateLiterals%E2%80%9D%3A%20true,-Here%E2%80%99s%20an%20example

---
_Release Notes_: 
None

---
_User Notifications_: 
None