### PR TITLE
SALTO-2805 use ChangeDataType instead of Element in proper places

### DIFF
--- a/packages/netsuite-adapter/src/change_validators/dependencies.ts
+++ b/packages/netsuite-adapter/src/change_validators/dependencies.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import {
-  Change, ChangeError, Element, getChangeData, SeverityLevel,
+  Change, ChangeDataType, ChangeError, getChangeData, SeverityLevel,
 } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { findDependingElementsFromRefs } from '../reference_dependencies'
@@ -31,7 +31,7 @@ export const validateDependsOnInvalidElement = async (
     inputInvalidElementIds.map(id => [id, 'invalid'])
   )
 
-  const isInvalid = async (element: Element): Promise<boolean> => {
+  const isInvalid = async (element: ChangeDataType): Promise<boolean> => {
     const status = elemValidity.get(element.elemID.getFullName())
     if (status !== undefined) {
       return status === 'invalid'

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-import { AccountId, Change, getChangeData, InstanceElement, isInstanceChange, isModificationChange, CredentialError, Element, isInstanceElement, isField, isObjectType } from '@salto-io/adapter-api'
+import { AccountId, Change, getChangeData, InstanceElement, isInstanceChange, isModificationChange, CredentialError, isInstanceElement, isField, isObjectType, ChangeDataType } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { decorators, collections, values } from '@salto-io/lowerdash'
 import { resolveValues } from '@salto-io/adapter-utils'
@@ -170,7 +170,7 @@ export default class NetsuiteClient {
   }
 
   private static async toCustomizationInfos(
-    elements: Element[],
+    elements: ChangeDataType[],
     deployReferencedElements: boolean
   ): Promise<CustomizationInfo[]> {
     const elemIdSet = new Set(elements.map(element => element.elemID.getFullName()))

--- a/packages/netsuite-adapter/src/data_elements/data_elements.ts
+++ b/packages/netsuite-adapter/src/data_elements/data_elements.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { InstanceElement, ObjectType, Element, BuiltinTypes, ElemIdGetter, OBJECT_SERVICE_ID, toServiceIdsString, OBJECT_NAME, Values, createRefToElmWithValue } from '@salto-io/adapter-api'
+import { InstanceElement, ObjectType, BuiltinTypes, ElemIdGetter, OBJECT_SERVICE_ID, toServiceIdsString, OBJECT_NAME, Values, createRefToElmWithValue } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { elements as elementUtils } from '@salto-io/adapter-components'
 import _ from 'lodash'
@@ -136,7 +136,7 @@ export const getDataElements = async (
   client: NetsuiteClient,
   query: NetsuiteQuery,
   elemIdGetter?: ElemIdGetter,
-): Promise<Element[]> => {
+): Promise<(ObjectType | InstanceElement)[]> => {
   const types = await getDataTypes(client)
 
   const typesToFetch = Object.keys(TYPE_TO_IDENTIFIER).filter(query.isTypeMatch)

--- a/packages/netsuite-adapter/src/suiteapp_config_elements.ts
+++ b/packages/netsuite-adapter/src/suiteapp_config_elements.ts
@@ -15,7 +15,7 @@
 */
 import os from 'os'
 import _ from 'lodash'
-import { BuiltinTypes, Element, ElemID, getChangeData, InstanceElement, isInstanceElement, ModificationChange, ObjectType } from '@salto-io/adapter-api'
+import { BuiltinTypes, ElemID, getChangeData, InstanceElement, isInstanceElement, ModificationChange, ObjectType } from '@salto-io/adapter-api'
 import { NETSUITE, SELECT_OPTION, SETTINGS_PATH, TYPES_PATH } from './constants'
 import { SUITEAPP_CONFIG_TYPES_TO_TYPE_NAMES, DeployResult } from './types'
 import { NetsuiteQuery } from './query'
@@ -33,7 +33,9 @@ export const getConfigTypes = (): ObjectType[] => ([new ObjectType({
 export const toConfigElements = (
   configRecords: ConfigRecord[],
   fetchQuery: NetsuiteQuery
-): Element[] => {
+): (
+  ObjectType | InstanceElement
+)[] => {
   const elements = configRecords
     .flatMap(configRecord => {
       const typeName = SUITEAPP_CONFIG_TYPES_TO_TYPE_NAMES[configRecord.configType]


### PR DESCRIPTION
This is a preparation for https://salto-io.atlassian.net/browse/SALTO-2805 - In order to avoid future casting of `Element[]` to `ChangeDataType[]`

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None