### PR TITLE
SALTO-2152 - Salesforce: ensure fullName is not changed

### DIFF
--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -31,6 +31,7 @@ import sbaaApprovalRulesCustomCondition from './change_validators/sbaa_approval_
 import recordTypeDeletionValidator from './change_validators/record_type_deletion'
 import activeFlowValidator from './change_validators/active_flow_modifications'
 import flowDeletionValidator from './change_validators/flow_deletion'
+import fullNameChangedValidator from './change_validators/fullname_changed'
 
 import { ChangeValidatorName, CheckOnlyChangeValidatorName, SalesforceConfig } from './types'
 
@@ -50,6 +51,7 @@ export const changeValidators: Record<ChangeValidatorName, ChangeValidatorCreato
   recordTypeDeletion: () => recordTypeDeletionValidator,
   activeFlowValidator: () => activeFlowValidator,
   flowDeletionValidator: () => flowDeletionValidator,
+  fullNameChangedValidator: () => fullNameChangedValidator,
 }
 
 const checkOnlyChangeValidators

--- a/packages/salesforce-adapter/src/change_validators/fullname_changed.ts
+++ b/packages/salesforce-adapter/src/change_validators/fullname_changed.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import {
-  ChangeError, isModificationChange, isInstanceChange, ChangeValidator, getChangeData,
+  ChangeError, isModificationChange, isInstanceChange, ChangeValidator,
   InstanceElement, ModificationChange,
 } from '@salto-io/adapter-api'
 import { INSTANCE_FULL_NAME_FIELD } from '../constants'
@@ -24,13 +24,17 @@ export const wasFullNameChanged = (change: ModificationChange<InstanceElement>):
   return before.value[INSTANCE_FULL_NAME_FIELD] !== after.value[INSTANCE_FULL_NAME_FIELD]
 }
 
-const fullNameChangeError = (instance: InstanceElement): ChangeError =>
-  ({
-    elemID: instance.elemID,
+const fullNameChangeError = (change: ModificationChange<InstanceElement>): ChangeError => {
+  const { before, after } = change.data
+  return {
+    elemID: after.elemID,
     severity: 'Error',
-    message: `You cannot change the fullName property of an element. ID of element that was changed: ${instance.elemID}`,
+    message: 'You cannot change the fullName property of an element. '
+      + `The fullName property of '${after.elemID}' was changed from `
+      + `${before.value[INSTANCE_FULL_NAME_FIELD]} to ${after.value[INSTANCE_FULL_NAME_FIELD]}`,
     detailedMessage: 'You cannot change the fullName property of an element.',
-  })
+  }
+}
 
 /**
  * It is forbidden to modify the fullName property of objects - it is used as an identifier and
@@ -41,7 +45,6 @@ const changeValidator: ChangeValidator = async changes => (
     .filter(isModificationChange)
     .filter(isInstanceChange)
     .filter(wasFullNameChanged)
-    .map(getChangeData)
     .map(fullNameChangeError)
 )
 

--- a/packages/salesforce-adapter/src/change_validators/fullname_changed.ts
+++ b/packages/salesforce-adapter/src/change_validators/fullname_changed.ts
@@ -19,30 +19,30 @@ import {
 } from '@salto-io/adapter-api'
 import { INSTANCE_FULL_NAME_FIELD } from '../constants'
 
-export const wasFullnameChanged = (change: ModificationChange<InstanceElement>): boolean => {
+export const wasFullNameChanged = (change: ModificationChange<InstanceElement>): boolean => {
   const { before, after } = change.data
   return before.value[INSTANCE_FULL_NAME_FIELD] !== after.value[INSTANCE_FULL_NAME_FIELD]
 }
 
-const fullnameChangeError = (instance: InstanceElement): ChangeError =>
+const fullNameChangeError = (instance: InstanceElement): ChangeError =>
   ({
     elemID: instance.elemID,
     severity: 'Error',
-    message: `You cannot change the fullName property of an object. ID of object that was changed: ${instance.elemID}`,
-    detailedMessage: 'You cannot change the fullName property of an object.',
+    message: `You cannot change the fullName property of an element. ID of element that was changed: ${instance.elemID}`,
+    detailedMessage: 'You cannot change the fullName property of an element.',
   })
 
 /**
- * It is forbidden to add or modify a field with unknown type.
- * A missing type means this field is not accessible on Salesforce.
+ * It is forbidden to modify the fullName property of objects - it is used as an identifier and
+ * changing it is not supported.
  */
 const changeValidator: ChangeValidator = async changes => (
   changes
     .filter(isModificationChange)
     .filter(isInstanceChange)
-    .filter(wasFullnameChanged)
+    .filter(wasFullNameChanged)
     .map(getChangeData)
-    .map(fullnameChangeError)
+    .map(fullNameChangeError)
 )
 
 export default changeValidator

--- a/packages/salesforce-adapter/src/change_validators/fullname_changed.ts
+++ b/packages/salesforce-adapter/src/change_validators/fullname_changed.ts
@@ -19,6 +19,7 @@ import {
 } from '@salto-io/adapter-api'
 import { INSTANCE_FULL_NAME_FIELD } from '../constants'
 
+
 export const wasFullNameChanged = (change: ModificationChange<InstanceElement>): boolean => {
   const { before, after } = change.data
   return before.value[INSTANCE_FULL_NAME_FIELD] !== after.value[INSTANCE_FULL_NAME_FIELD]
@@ -30,8 +31,8 @@ const fullNameChangeError = (change: ModificationChange<InstanceElement>): Chang
     elemID: after.elemID,
     severity: 'Error',
     message: 'You cannot change the fullName property of an element. '
-      + `The fullName property of '${after.elemID}' was changed from `
-      + `${before.value[INSTANCE_FULL_NAME_FIELD]} to ${after.value[INSTANCE_FULL_NAME_FIELD]}`,
+      + `The fullName property of '${after.elemID.getFullName()}' was changed from `
+      + `'${before.value[INSTANCE_FULL_NAME_FIELD]}' to '${after.value[INSTANCE_FULL_NAME_FIELD]}'`,
     detailedMessage: 'You cannot change the fullName property of an element.',
   }
 }

--- a/packages/salesforce-adapter/src/change_validators/fullname_changed.ts
+++ b/packages/salesforce-adapter/src/change_validators/fullname_changed.ts
@@ -1,0 +1,48 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  ChangeError, isModificationChange, isInstanceChange, ChangeValidator, getChangeData,
+  InstanceElement, ModificationChange,
+} from '@salto-io/adapter-api'
+import { INSTANCE_FULL_NAME_FIELD } from '../constants'
+
+export const wasFullnameChanged = (change: ModificationChange<InstanceElement>): boolean => {
+  const { before, after } = change.data
+  return before.value[INSTANCE_FULL_NAME_FIELD] !== after.value[INSTANCE_FULL_NAME_FIELD]
+}
+
+const fullnameChangeError = (instance: InstanceElement): ChangeError =>
+  ({
+    elemID: instance.elemID,
+    severity: 'Error',
+    message: `You cannot change the fullName property of an object. ID of object that was changed: ${instance.elemID}`,
+    detailedMessage: 'You cannot change the fullName property of an object.',
+  })
+
+/**
+ * It is forbidden to add or modify a field with unknown type.
+ * A missing type means this field is not accessible on Salesforce.
+ */
+const changeValidator: ChangeValidator = async changes => (
+  changes
+    .filter(isModificationChange)
+    .filter(isInstanceChange)
+    .filter(wasFullnameChanged)
+    .map(getChangeData)
+    .map(fullnameChangeError)
+)
+
+export default changeValidator

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -92,6 +92,7 @@ export type ChangeValidatorName = (
   | 'recordTypeDeletion'
   | 'activeFlowValidator'
   | 'flowDeletionValidator'
+  | 'fullNameChangedValidator'
 )
 
 export type CheckOnlyChangeValidatorName = 'checkOnlyDeploy'
@@ -557,6 +558,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     recordTypeDeletion: { refType: BuiltinTypes.BOOLEAN },
     activeFlowValidator: { refType: BuiltinTypes.BOOLEAN },
     flowDeletionValidator: { refType: BuiltinTypes.BOOLEAN },
+    fullNameChangedValidator: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/salesforce-adapter/test/change_validators/fullname_change.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/fullname_change.test.ts
@@ -1,0 +1,59 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Change, getAllChangeData, toChange } from '@salto-io/adapter-api'
+import changeValidator from '../../src/change_validators/fullname_changed'
+import { mockTypes } from '../mock_elements'
+import { createInstanceElement } from '../../src/transformers/transformer'
+import { INSTANCE_FULL_NAME_FIELD } from '../../src/constants'
+
+describe('fullname change validator', () => {
+  describe('when fullname changes', () => {
+    let fullnameChange: Change
+    beforeEach(() => {
+      const beforeRecord = createInstanceElement({ fullName: 'original_fullname' }, mockTypes.RecordType)
+      const afterRecord = beforeRecord.clone()
+      afterRecord.value[INSTANCE_FULL_NAME_FIELD] = 'modified_fullname'
+      fullnameChange = toChange({ before: beforeRecord, after: afterRecord })
+    })
+
+    it('should fail validation', async () => {
+      const changeErrors = await changeValidator(
+        [fullnameChange]
+      )
+      expect(changeErrors).toHaveLength(1)
+      const [changeError] = changeErrors
+      const [beforeData] = getAllChangeData(fullnameChange)
+      expect(changeError.elemID).toEqual(beforeData?.elemID)
+      expect(changeError.severity).toEqual('Error')
+    })
+  })
+  describe('when fullname does not change', () => {
+    let fullnameChange: Change
+    beforeEach(() => {
+      const beforeRecord = createInstanceElement({ fullName: 'original_fullname', status: 'ACTIVE' }, mockTypes.Flow)
+      const afterRecord = beforeRecord.clone()
+      afterRecord.value.status = 'INACTIVE'
+      fullnameChange = toChange({ before: beforeRecord, after: afterRecord })
+    })
+
+    it('should pass validation', async () => {
+      const changeErrors = await changeValidator(
+        [fullnameChange]
+      )
+      expect(changeErrors).toBeEmpty()
+    })
+  })
+})


### PR DESCRIPTION
Add a change validator that ensures the fullName property was not changed
---

fullName is used to identify entities in SalesForce. If the user changes its value, they're going to have a Bad Time.

---
_Release Notes_: 
Deploy will now fail for SalesForce entities whose fullName value was changed

---
_User Notifications_: 
N/A
