### PR TITLE
SALTO-3011: Support groups in Jira DC

### DIFF
--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1422,7 +1422,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
         method: 'post',
       },
       remove: {
-        url: '/rest/api/3/group?groupId={groupId}',
+        url: '/rest/api/3/group?groupname={name}',
         method: 'delete',
       },
     },

--- a/packages/jira-adapter/src/product_settings/data_center/data_center.ts
+++ b/packages/jira-adapter/src/product_settings/data_center/data_center.ts
@@ -214,6 +214,10 @@ const PLUGIN_URL_PATTERNS: UrlPattern[] = [
     httpMethods: ['put'],
     url: '/rest/api/3/priority/.+',
   },
+  {
+    httpMethods: ['get'],
+    url: '/rest/api/3/group/bulk',
+  },
 ]
 
 const replaceRestVersion = (url: string): string => url.replace(


### PR DESCRIPTION
Added support for groups in Jira DC

Plugin PR: https://github.com/salto-io/jira-dc-app/pull/28

---
_Release Notes_: 
None

---
_User Notifications_: 
None