### PR TITLE
SALTO-2804 fix bug in client validation on SettingsDeployError

### DIFF
--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -966,8 +966,7 @@ export default class SdfClient {
         executor
       )
     } catch (e) {
-      const error = e instanceof Error ? e : new Error(String(e))
-      throw SdfClient.customizeDeployError(error)
+      throw SdfClient.customizeDeployError(toError(e))
     }
   }
 

--- a/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
@@ -140,7 +140,7 @@ File: ~/Objects/customrecord1.xml`
     })
   })
 
-  it('should have settings deploy error', async () => {
+  it('should have settings deploy error for a specific change', async () => {
     const detailedMessage = 'Validation of account settings failed.'
     mockValidate.mockReturnValue([new SettingsDeployError(`${detailedMessage}`, new Set(['workflow']))])
     const changeErrors = await clientValidation(
@@ -153,5 +153,19 @@ File: ~/Objects/customrecord1.xml`
       message: 'SDF Settings Validation Error',
       severity: 'Error',
     })
+  })
+  it('should have settings deploy error for all changes', async () => {
+    const detailedMessage = 'Validation of account settings failed.'
+    mockValidate.mockReturnValue([new SettingsDeployError(`${detailedMessage}`, new Set(['abc']))])
+    const changeErrors = await clientValidation(
+      changes, client, {} as unknown as AdditionalDependencies, mockFiltersRunner
+    )
+    expect(changeErrors).toHaveLength(2)
+    expect(changeErrors).toEqual(changes.map(change => ({
+      detailedMessage,
+      elemID: getChangeData(change).elemID,
+      message: 'SDF Settings Validation Error',
+      severity: 'Error',
+    })))
   })
 })


### PR DESCRIPTION
we should return changeErrors for all changes when non of them is in `error.failedConfigTypes`

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None