### PR TITLE
SALTO-2987: Align issue type between Jira DC and Cloud

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -42,6 +42,7 @@ import smartValueReferenceFilter from './filters/automation/smart_values/smart_v
 import webhookFilter from './filters/webhook/webhook'
 import screenFilter from './filters/screen/screen'
 import issueTypeScreenSchemeFilter from './filters/issue_type_screen_scheme'
+import issueTypeFilter from './filters/issue_type'
 import fieldConfigurationFilter from './filters/field_configuration/field_configuration'
 import fieldConfigurationIrrelevantFields from './filters/field_configuration/field_configuration_irrelevant_fields'
 import fieldConfigurationSplitFilter from './filters/field_configuration/field_configuration_split'
@@ -148,6 +149,7 @@ export const DEFAULT_FILTERS = [
   workflowModificationFilter,
   workflowGroupsFilter,
   workflowSchemeFilter,
+  issueTypeFilter,
   issueTypeSchemeReferences,
   issueTypeSchemeFilter,
   sharePermissionFilter,

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1340,7 +1340,6 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
         { fieldName: 'untranslatedName', fieldType: 'string' },
       ],
       fieldsToOmit: [
-        { fieldName: 'subtask' },
         { fieldName: 'avatarId' },
         { fieldName: 'iconUrl' },
       ],

--- a/packages/jira-adapter/src/filters/issue_type.ts
+++ b/packages/jira-adapter/src/filters/issue_type.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, getChangeData, InstanceElement, isInstanceChange, isInstanceElement } from '@salto-io/adapter-api'
+import { Change, getChangeData, InstanceElement, isAdditionChange, isInstanceChange, isInstanceElement } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { applyFunctionToChangeData } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../filter'
@@ -51,6 +51,7 @@ const filter: FilterCreator = ({ client }) => ({
 
     await awu(changes)
       .filter(isInstanceChange)
+      .filter(isAdditionChange)
       .filter(change => getChangeData(change).elemID.typeName === ISSUE_TYPE_NAME)
       .forEach(change =>
         applyFunctionToChangeData<Change<InstanceElement>>(
@@ -72,6 +73,7 @@ const filter: FilterCreator = ({ client }) => ({
 
     await awu(changes)
       .filter(isInstanceChange)
+      .filter(isAdditionChange)
       .filter(change => getChangeData(change).elemID.typeName === ISSUE_TYPE_NAME)
       .forEach(change =>
         applyFunctionToChangeData<Change<InstanceElement>>(

--- a/packages/jira-adapter/src/filters/issue_type.ts
+++ b/packages/jira-adapter/src/filters/issue_type.ts
@@ -1,0 +1,90 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Change, getChangeData, InstanceElement, isInstanceChange, isInstanceElement } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { applyFunctionToChangeData } from '@salto-io/adapter-utils'
+import { FilterCreator } from '../filter'
+import { ISSUE_TYPE_NAME } from '../constants'
+
+const { awu } = collections.asynciterable
+
+const STANDARD_TYPE = 'standard'
+const SUBTASK_TYPE = 'subtask'
+const STANDARD_HIERARCHY_LEVEL = 0
+const SUBTASK_HIERARCHY_LEVEL = -1
+
+/**
+ * Align the DC issue types values with the Cloud
+ */
+const filter: FilterCreator = ({ client }) => ({
+  onFetch: async elements => {
+    const issueTypes = elements
+      .filter(isInstanceElement)
+      .filter(instance => instance.elemID.typeName === ISSUE_TYPE_NAME)
+
+    if (client.isDataCenter) {
+      issueTypes.forEach(instance => {
+        instance.value.hierarchyLevel = instance.value.subtask ? SUBTASK_HIERARCHY_LEVEL : STANDARD_HIERARCHY_LEVEL
+      })
+    }
+
+    issueTypes.forEach(issueType => { delete issueType.value.subtask })
+  },
+
+  preDeploy: async changes => {
+    if (!client.isDataCenter) {
+      return
+    }
+
+    await awu(changes)
+      .filter(isInstanceChange)
+      .filter(change => getChangeData(change).elemID.typeName === ISSUE_TYPE_NAME)
+      .forEach(change =>
+        applyFunctionToChangeData<Change<InstanceElement>>(
+          change,
+          instance => {
+            instance.value.type = instance.value.hierarchyLevel === SUBTASK_HIERARCHY_LEVEL
+              ? SUBTASK_TYPE
+              : STANDARD_TYPE
+            delete instance.value.hierarchyLevel
+            return instance
+          }
+        ))
+  },
+
+  onDeploy: async changes => {
+    if (!client.isDataCenter) {
+      return
+    }
+
+    await awu(changes)
+      .filter(isInstanceChange)
+      .filter(change => getChangeData(change).elemID.typeName === ISSUE_TYPE_NAME)
+      .forEach(change =>
+        applyFunctionToChangeData<Change<InstanceElement>>(
+          change,
+          instance => {
+            instance.value.hierarchyLevel = instance.value.type === SUBTASK_TYPE
+              ? SUBTASK_HIERARCHY_LEVEL
+              : STANDARD_HIERARCHY_LEVEL
+            delete instance.value.type
+            return instance
+          }
+        ))
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/test/filters/issue_type.test.ts
+++ b/packages/jira-adapter/test/filters/issue_type.test.ts
@@ -1,0 +1,168 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import { ISSUE_TYPE_NAME, JIRA } from '../../src/constants'
+import { getFilterParams, mockClient } from '../utils'
+import issueTypeFilter from '../../src/filters/issue_type'
+import { Filter } from '../../src/filter'
+import JiraClient from '../../src/client/client'
+
+describe('issueTypeFilter', () => {
+  let instance: InstanceElement
+  let filter: Filter
+  let client: JiraClient
+  beforeEach(async () => {
+    const { client: cli, paginator } = mockClient(true)
+    client = cli
+
+    filter = issueTypeFilter(getFilterParams({
+      client,
+      paginator,
+    }))
+    const issueType = new ObjectType({
+      elemID: new ElemID(JIRA, ISSUE_TYPE_NAME),
+      fields: {
+        issueTypeId: { refType: BuiltinTypes.STRING },
+        screenSchemeId: { refType: BuiltinTypes.STRING },
+      },
+    })
+    instance = new InstanceElement(
+      'instance',
+      issueType,
+      {
+        subtask: true,
+      },
+    )
+  })
+
+  describe('onFetch', () => {
+    it('should convert sub task to the right hierarchy', async () => {
+      await filter.onFetch?.([instance])
+      expect(instance.value.hierarchyLevel).toBe(-1)
+      expect(instance.value.subtask).toBeUndefined()
+    })
+
+    it('should convert task to the right hierarchy', async () => {
+      instance.value.subtask = false
+      await filter.onFetch?.([instance])
+      expect(instance.value.hierarchyLevel).toBe(0)
+      expect(instance.value.subtask).toBeUndefined()
+    })
+
+    it('when cloud should only delete subtask', async () => {
+      const { client: cli, paginator } = mockClient(false)
+      client = cli
+
+      filter = issueTypeFilter(getFilterParams({
+        client,
+        paginator,
+      }))
+      await filter.onFetch?.([instance])
+      expect(instance.value.hierarchyLevel).toBeUndefined()
+      expect(instance.value.subtask).toBeUndefined()
+    })
+  })
+
+  describe('preDeploy', () => {
+    it('should convert subtask hierarchy level to type', async () => {
+      instance.value = {
+        hierarchyLevel: -1,
+      }
+      await filter.preDeploy?.([
+        toChange({ after: instance }),
+      ])
+      expect(instance.value).toEqual({
+        type: 'subtask',
+      })
+    })
+
+    it('should convert task hierarchy level to type', async () => {
+      instance.value = {
+        hierarchyLevel: 0,
+      }
+      await filter.preDeploy?.([
+        toChange({ after: instance }),
+      ])
+      expect(instance.value).toEqual({
+        type: 'standard',
+      })
+    })
+
+    it('should do nothing if cloud', async () => {
+      const { client: cli, paginator } = mockClient(false)
+      client = cli
+
+      filter = issueTypeFilter(getFilterParams({
+        client,
+        paginator,
+      }))
+      instance.value = {
+        hierarchyLevel: 0,
+      }
+      await filter.preDeploy?.([
+        toChange({ after: instance }),
+      ])
+      expect(instance.value).toEqual({
+        hierarchyLevel: 0,
+      })
+    })
+  })
+
+  describe('onDeploy', () => {
+    it('should convert subtask type to hierarchy level', async () => {
+      instance.value = {
+        type: 'subtask',
+      }
+      await filter.onDeploy?.([
+        toChange({ after: instance }),
+      ])
+      expect(instance.value).toEqual({
+        hierarchyLevel: -1,
+      })
+    })
+
+    it('should convert task type to hierarchy level', async () => {
+      instance.value = {
+        type: 'standard',
+      }
+      await filter.onDeploy?.([
+        toChange({ after: instance }),
+      ])
+      expect(instance.value).toEqual({
+        hierarchyLevel: 0,
+      })
+    })
+
+    it('should do nothing if cloud', async () => {
+      const { client: cli, paginator } = mockClient(false)
+      client = cli
+
+      filter = issueTypeFilter(getFilterParams({
+        client,
+        paginator,
+      }))
+      instance.value = {
+        type: 'standard',
+      }
+      await filter.onDeploy?.([
+        toChange({ after: instance }),
+      ])
+      expect(instance.value).toEqual({
+        type: 'standard',
+      })
+    })
+  })
+})


### PR DESCRIPTION
Replaced the value `subtask` in Jira DC with `hierarchyLevel` as it is in cloud.
Did to save work when creating the E2E for DC

---
In cloud the issue type has a `hierarchyLevel` values that is 0 for tasks and -1 for subtasks, this is the value we get from fetch and send to deploy. In DC we get from fetch a boolean value called `subtask` and send to deploy a `type` value that is either `standard` or `subtask`

---
_Release Notes_: 
None

---
_User Notifications_: 
None