### PR TITLE
SALTO-3013: Excluding FieldConfigurationScheme causes fetch to fail

### DIFF
--- a/packages/jira-adapter/test/filters/field_configuration/field_configuration_dependencies.test.ts
+++ b/packages/jira-adapter/test/filters/field_configuration/field_configuration_dependencies.test.ts
@@ -213,5 +213,15 @@ describe('fieldConfigurationItemsFilter', () => {
       ])
       expect(projectInstance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeUndefined()
     })
+
+    it('should not add generated dependencies if fieldConfigurationScheme is not a reference', async () => {
+      projectInstance.value.fieldConfigurationScheme = '3'
+      await filter.onFetch([
+        projectInstance,
+        fieldInstance,
+        fieldConfigurationInstance,
+      ])
+      expect(projectInstance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeUndefined()
+    })
   })
 })


### PR DESCRIPTION
Fixed an issue where excluding FieldConfigurationScheme would cause the fetch the fail

---
_Release Notes_: 
_Jira Adapter_:
- Fixed an issue where excluding FieldConfigurationScheme would cause the fetch the fail

---
_User Notifications_: 
None