### PR TITLE
SALTO-3016 fix bug in client validation when a FileCabinet instance is referenced

### DIFF
--- a/packages/netsuite-adapter/src/change_validators/client_validation.ts
+++ b/packages/netsuite-adapter/src/change_validators/client_validation.ts
@@ -57,7 +57,10 @@ const changeValidator: ClientChangeValidator = async (
     data: _.mapValues(change.data, (element: Element) => element.clone()),
   })) as Change[]
   await filtersRunner.preDeploy(clonedChanges)
-  const getChangeGroupIds = getChangeGroupIdsFunc(client.isSuiteAppConfigured())
+
+  // SALTO-3016 we can validate only SDF elements because
+  // we need FileCabinet references to be included in the SDF project
+  const getChangeGroupIds = getChangeGroupIdsFunc(false)
   const { changeGroupIdMap } = await getChangeGroupIds(
     new Map(clonedChanges.map(change => [changeId(change), change]))
   )

--- a/packages/netsuite-adapter/src/group_changes.ts
+++ b/packages/netsuite-adapter/src/group_changes.ts
@@ -25,7 +25,7 @@ import _ from 'lodash'
 import * as suiteAppFileCabinet from './suiteapp_file_cabinet'
 import { isSuiteAppConfigInstance, isSDFConfigTypeName, isDataObjectType, isFileCabinetInstance, isStandardInstanceOrCustomRecordType, isCustomRecordType } from './types'
 import { APPLICATION_ID } from './constants'
-import { fileCabinetTypesNames } from './types/file_cabinet_types'
+import { isPathAllowedBySdf } from './types/file_cabinet_types'
 
 const { awu } = collections.asynciterable
 
@@ -62,7 +62,7 @@ const getChangeGroupIdsWithoutSuiteApp: ChangeGroupIdFunction = async changes =>
   const isSdfChange = (change: Change): boolean => {
     const changeData = getChangeData(change)
     return isStandardInstanceOrCustomRecordType(changeData)
-      || fileCabinetTypesNames.has(changeData.elemID.typeName)
+      || (isFileCabinetInstance(changeData) && isPathAllowedBySdf(changeData))
       || isSDFConfigTypeName(changeData.elemID.typeName)
   }
   return {

--- a/packages/netsuite-adapter/src/types/file_cabinet_types.ts
+++ b/packages/netsuite-adapter/src/types/file_cabinet_types.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 /* eslint-disable camelcase */
-import { BuiltinTypes, CORE_ANNOTATIONS, createRestriction, ElemID, ObjectType } from '@salto-io/adapter-api'
+import { BuiltinTypes, CORE_ANNOTATIONS, createRestriction, ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
 import * as constants from '../constants'
 import { fieldTypes } from './field_types'
 
@@ -136,3 +136,12 @@ export const getFileCabinetTypes = (): Readonly<Record<string, ObjectType>> => (
   file: fileType(),
   folder: folderType(),
 })
+
+const allowedSdfPaths = [
+  '/SuiteScripts/',
+  '/Templates/E-mail Templates/',
+  '/Templates/Marketing Templates/',
+  '/Web Site Hosting Files/',
+] as const
+export const isPathAllowedBySdf = ({ value: { path } }: InstanceElement): boolean =>
+  typeof path === 'string' && allowedSdfPaths.some(allowedPath => path.startsWith(allowedPath))

--- a/packages/netsuite-adapter/test/group_changes.test.ts
+++ b/packages/netsuite-adapter/test/group_changes.test.ts
@@ -44,7 +44,17 @@ describe('Group Changes without Salto suiteApp', () => {
     },
   })
 
-  const fileInstance = new InstanceElement('fileInstance', file)
+  const fileInstance = new InstanceElement(
+    'fileInstance',
+    file,
+    { path: '/SuiteScripts/a.txt' }
+  )
+
+  const nonSdfFileInstance = new InstanceElement(
+    'fileInstance2',
+    file,
+    { path: '/not/allowed/path' }
+  )
 
   const dummyType = new ObjectType({ elemID: new ElemID(NETSUITE, 'dummytype') })
   const nonSdfInstance = new InstanceElement('nonSdfInstance', dummyType)
@@ -68,6 +78,7 @@ describe('Group Changes without Salto suiteApp', () => {
       ],
       [nonSdfInstance.elemID.getFullName(), toChange({ after: nonSdfInstance })],
       [dummyType.elemID.getFullName(), toChange({ after: dummyType })],
+      [nonSdfFileInstance.elemID.getFullName(), toChange({ after: nonSdfFileInstance })],
     ]))).changeGroupIdMap
   })
 
@@ -96,6 +107,10 @@ describe('Group Changes without Salto suiteApp', () => {
 
   it('should not set group id for non SDF types', () => {
     expect(changeGroupIds.has(dummyType.elemID.getFullName())).toBe(false)
+  })
+
+  it('should not set group id for FileCabinet instances in non-allowed paths', () => {
+    expect(changeGroupIds.has(nonSdfFileInstance.elemID.getFullName())).toBe(false)
   })
 })
 


### PR DESCRIPTION

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Fix bug in client validation when a FileCabinet instance is referenced

---
_User Notifications_: 
None