### PR TITLE
SALTO-2819 - SalesForce: Create a filter that converts fields to lowercase

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -75,6 +75,7 @@ import currencyIsoCodeFilter from './filters/currency_iso_code'
 import enumFieldPermissionsFilter from './filters/field_permissions_enum'
 import splitCustomLabels from './filters/split_custom_labels'
 import customMetadataTypeFilter from './filters/custom_metadata_type'
+import convertToLowerCaseFilter from './filters/convert_to_lowercase'
 import { FetchElements, SalesforceConfig } from './types'
 import { getConfigFromConfigChanges } from './config_change'
 import { LocalFilterCreator, Filter, FilterResult, RemoteFilterCreator, LocalFilterCreatorDefinition, RemoteFilterCreatorDefinition } from './filter'
@@ -147,6 +148,7 @@ export const allFilters: Array<LocalFilterCreatorDefinition | RemoteFilterCreato
   // should run after convertListsFilter
   { creator: replaceFieldValuesFilter },
   { creator: valueToStaticFileFilter },
+  { creator: convertToLowerCaseFilter },
   { creator: fieldReferencesFilter },
   // should run after customObjectsInstancesFilter for now
   { creator: referenceAnnotationsFilter },

--- a/packages/salesforce-adapter/src/filters/convert_to_lowercase.ts
+++ b/packages/salesforce-adapter/src/filters/convert_to_lowercase.ts
@@ -50,7 +50,14 @@ const convertField = async (
  */
 export const makeFilter = (): LocalFilterCreator => () => ({
   /**
-   * Upon fetch, mark all list fields as list fields in all fetched types
+   * Upon fetch, convert the contents of specific fields to lowercase.
+   * The fullName property of some elements is always lower case, regardless of how the element's
+   * name is displayed to the user. This causes issues when fields refer to said elements, because
+   * the contents of the fields is the same mixed-case value that is displayed to the user.
+   * (e.g. the entitlementProcess field of some EntitlementTemplate instance can be 'Some Process'
+   * whereas the fullName property of the matching EntitlementProcess is 'some process').
+   * In order to work around this issue, we convert certain fields to lower case on ingestion, and
+   * assume they will be converted to a reference shortly after.
    *
    * @param elements the already fetched elements
    */

--- a/packages/salesforce-adapter/src/filters/convert_to_lowercase.ts
+++ b/packages/salesforce-adapter/src/filters/convert_to_lowercase.ts
@@ -1,0 +1,68 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { collections } from '@salto-io/lowerdash'
+import { Element, ElemID, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
+import { LocalFilterCreator } from '../filter'
+import { SALESFORCE } from '../constants'
+
+const { awu } = collections.asynciterable
+
+type FieldIdentifier = {
+  parentType: ElemID
+  fieldName: string
+}
+
+const fieldsToConvert: Array<FieldIdentifier> = [
+  {
+    parentType: new ElemID(SALESFORCE, 'EntitlementTemplate'),
+    fieldName: 'entitlementProcess',
+  },
+]
+
+const convertField = async (
+  instance: InstanceElement,
+  fieldIdentifierMap: Record<string, FieldIdentifier[]>
+): Promise<void> => {
+  const instanceElemId = (await instance.getType()).elemID.getFullName()
+  const fieldDescriptors = fieldIdentifierMap[instanceElemId]
+  if (!fieldDescriptors) {
+    return
+  }
+  fieldDescriptors.filter(fieldDesc => fieldDesc.fieldName in instance.value).forEach(fieldDesc => {
+    instance.value[fieldDesc.fieldName] = instance.value[fieldDesc.fieldName].toLocaleLowerCase()
+  })
+}
+
+/**
+ */
+export const makeFilter = (): LocalFilterCreator => () => ({
+  /**
+   * Upon fetch, mark all list fields as list fields in all fetched types
+   *
+   * @param elements the already fetched elements
+   */
+  onFetch: async (elements: Element[]) => {
+    const typesOfInterest = await awu(fieldsToConvert).groupBy(fieldDesc => fieldDesc.parentType.getFullName())
+
+    const instancesToConvert = await awu(elements)
+      .filter(isInstanceElement)
+      .filter(async inst => (await inst.getType()).elemID.getFullName() in typesOfInterest)
+      .toArray()
+    await awu(instancesToConvert).forEach(instance => convertField(instance, typesOfInterest))
+  },
+})
+
+export default makeFilter()

--- a/packages/salesforce-adapter/test/filters/convert_to_lowercase.test.ts
+++ b/packages/salesforce-adapter/test/filters/convert_to_lowercase.test.ts
@@ -1,0 +1,102 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { ObjectType, ElemID, InstanceElement, Element, BuiltinTypes, createRefToElmWithValue } from '@salto-io/adapter-api'
+import { makeFilter } from '../../src/filters/convert_to_lowercase'
+import * as constants from '../../src/constants'
+import { FilterWith } from '../../src/filter'
+import { defaultFilterContext } from '../utils'
+
+describe('convert to lowercase filter', () => {
+  const mockType = new ObjectType({
+    elemID: new ElemID(constants.SALESFORCE, 'EntitlementTemplate'),
+    fields: {
+      entitlementProcess: {
+        refType: BuiltinTypes.STRING,
+      },
+    },
+  })
+
+  const mockTypeThatShouldntChange = new ObjectType({
+    elemID: new ElemID(constants.SALESFORCE, 'EntitlementShmemplate'),
+    fields: {
+      entitlementProcess: {
+        refType: BuiltinTypes.STRING,
+      },
+    },
+  })
+
+  const mockInstance = new InstanceElement(
+    'instance_of_entitlement_template',
+    mockType,
+    {
+      entitlementProcess: 'Mixed Case',
+    }
+  )
+
+  const mockInstanceLowerCase = new InstanceElement(
+    'instance_of_entitlement_template_with_lowercase_field',
+    mockType,
+    {
+      entitlementProcess: 'lower case',
+    },
+  )
+
+  const mockInstanceDifferentType = new InstanceElement(
+    'instance_of_some_other_type',
+    mockTypeThatShouldntChange,
+    {
+      entitlementProcess: 'SpOnGeBoB CaSe',
+    }
+  )
+
+  let testElements: Element[]
+
+  const filter = makeFilter()({ config: defaultFilterContext }) as FilterWith<'onFetch'>
+
+  beforeEach(() => {
+    testElements = [
+      _.assign(_.clone(mockInstance), { refType: createRefToElmWithValue(mockType) }),
+      _.assign(_.clone(mockInstanceLowerCase), { refType: createRefToElmWithValue(mockType) }),
+      _.assign(_.clone(mockInstanceDifferentType), { refType: createRefToElmWithValue(mockTypeThatShouldntChange) }),
+    ]
+  })
+
+  describe('on fetch', () => {
+    let mixedCaseInst: InstanceElement
+    let lowerCaseInst: InstanceElement
+    let unchangedInst: InstanceElement
+
+    beforeEach(async () => {
+      await filter.onFetch(testElements)
+      mixedCaseInst = testElements[0] as InstanceElement
+      lowerCaseInst = testElements[1] as InstanceElement
+      unchangedInst = testElements[2] as InstanceElement
+    })
+
+    it('should convert mixed case fields to lower case', async () => {
+      expect(mixedCaseInst.value.entitlementProcess).toEqual('mixed case')
+    })
+
+    it('should not modify lower case fields', async () => {
+      expect(lowerCaseInst.value.entitlementProcess).toEqual('lower case')
+    })
+
+    it('should not modify instances of unknown types', async () => {
+      expect(unchangedInst.value.entitlementProcess).toEqual('SpOnGeBoB CaSe')
+    })
+  })
+})


### PR DESCRIPTION
Create a new filter that converts specific fields to lowercase

---

Some elements in SalesForce have names that are always provided as lower case, even if the name that's displayed in the SalesForce UI is mixed case. This causes problems when we want to create references to these elements, because the contents of the referring fields are mixed case. 
This PR creates a filter that changes said referring fields to lower case, so that we can easily change them into references.

---
_Release Notes_: 
SalesForce: The value of EntitlementTemplate.entitlementProcess field will now always appear as lower case, even if the EntitlementProcess it refers to has upper case letters in its name.

---
_User Notifications_: 
The value of EntitlementTemplate.entitlementProcess field will now always appear as lower case, even if the EntitlementProcess it refers to has upper case letters in its name.