### PR TITLE
SALTO-3013: fixed FieldConfigurationScheme warning log

### DIFF
--- a/packages/jira-adapter/src/filters/field_configuration/field_configuration_dependencies.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/field_configuration_dependencies.ts
@@ -42,7 +42,9 @@ const getProjectUsedFields = (instance: InstanceElement): InstanceElement[] => {
 const getProjectFieldConfigurations = (instance: InstanceElement): InstanceElement[] => {
   const fieldConfigurationRef = instance.value.fieldConfigurationScheme
   if (!isReferenceExpression(fieldConfigurationRef)) {
-    log.warn(`${instance.elemID.getFullName()} has a field configuration scheme value that is not a reference so we can't calculate the _generated_dependencies`)
+    if (fieldConfigurationRef !== undefined) {
+      log.warn(`${instance.elemID.getFullName()} has a field configuration scheme value that is not a reference so we can't calculate the _generated_dependencies`)
+    }
     return []
   }
   return fieldConfigurationRef.value.value.items


### PR DESCRIPTION
Made the log too spammy in the last PR. It should be printed only when `fieldConfigurationScheme` is present but not reference 

---
_Release Notes_: 
None

---
_User Notifications_: 
None