### PR TITLE
SALTO-1634 - Add service/account information to logs

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -36,7 +36,7 @@ export type DeployExtraProperties = {
 
 export type DeployResult = {
   appliedChanges: ReadonlyArray<Change>
-  errors: ReadonlyArray<Error>
+  errors: ReadonlyArray<Error & {service?:string; account?: string}>
   extraProperties?: DeployExtraProperties
 }
 

--- a/packages/adapter-api/src/error.ts
+++ b/packages/adapter-api/src/error.ts
@@ -23,6 +23,8 @@ export type SaltoError = {
     message: string
     severity: SeverityLevel
     source?: SaltoErrorSource
+    account?: string
+    service?: string
 }
 
 export type SaltoElementError = SaltoError & {

--- a/packages/adapter-utils/src/collisions.ts
+++ b/packages/adapter-utils/src/collisions.ts
@@ -35,8 +35,8 @@ export const groupInstancesByTypeAndElemID = async (
   ))
 
 
-export const createWarningFromMsg = (message: string): SaltoError =>
-  ({ message, severity: 'Warning' })
+export const createWarningFromMsg = (message: string, serviceName: string): SaltoError =>
+  ({ message, severity: 'Warning', service: serviceName })
 
 export const getInstanceDesc = (instanceId: string, baseUrl?: string): string =>
   (baseUrl ? `${baseUrl}/${instanceId}` : `Instance with Id - ${instanceId}`)
@@ -76,7 +76,7 @@ const logInstancesWithCollidingElemID = async (
         .map(instance => _.pickBy(instance.value, val => val != null))
       const relevantInstanceValuesStr = relevantInstanceValues
         .map(instValues => safeJsonStringify(instValues, elementExpressionStringifyReplacer, 2)).join('\n')
-      log.debug(`Omitted instances of type ${type} with colliding ElemID ${elemID} with values - 
+      log.debug(`Omitted instances of type ${type} with colliding ElemID ${elemID} with values -
   ${relevantInstanceValuesStr}`)
     })
   })
@@ -134,6 +134,7 @@ Alternatively, you can exclude ${type} from the ${configurationName} configurati
         ...overflowMsg,
         '',
         epilogue,
-      ].join('\n'))
+      ].join('\n'),
+      adapterName)
     }))
 }

--- a/packages/adapter-utils/test/collisions.test.ts
+++ b/packages/adapter-utils/test/collisions.test.ts
@@ -54,6 +54,7 @@ describe('collisions', () => {
       expect(errors).toHaveLength(1)
       expect(errors[0]).toEqual({
         severity: 'Warning',
+        service: 'salto',
         message: `Omitted 2 instances of obj due to Salto ID collisions.
 Current Salto ID configuration for obj is defined as [title].
 

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -49,7 +49,10 @@ export const emptyLine = (): string => ''
 
 const planItemName = (step: PlanItem): string => step.groupKey
 
-const formatError = (err: { message: string }): string => header(err.message)
+const formatError = (err: { message: string; account?: string; service?: string }): string => {
+  const origin = err.account ?? err.service
+  return header([origin ? `[${err.account ?? err.service}]` : '', `${err.message}`].join(''))
+}
 
 export const formatWordsSeries = (words: string[]): string => (words.length > 1
   ? `${words.slice(0, -1).join(', ')} and ${_.last(words)}`

--- a/packages/core/src/core/deploy/deploy_actions.ts
+++ b/packages/core/src/core/deploy/deploy_actions.ts
@@ -32,16 +32,22 @@ type DeployOrValidateParams = {
   checkOnly: boolean
 }
 
+const addAccountToErrors = (deployResult: Promise<DeployResult>, accountName: string): Promise<DeployResult> => (
+  deployResult.then(result => {
+    result.errors.forEach(err => { err.account = accountName }); return deployResult
+  })
+)
+
 const deployOrValidate = (
   { adapter, adapterName, opts, checkOnly }: DeployOrValidateParams
 ): Promise<DeployResult> => {
   if (!checkOnly) {
-    return adapter.deploy(opts)
+    return addAccountToErrors(adapter.deploy(opts), adapterName)
   }
   if (_.isUndefined(adapter.validate)) {
     throw new Error(`Check-Only deployment is not supported in adapter ${adapterName}`)
   }
-  return adapter.validate(opts)
+  return addAccountToErrors(adapter.validate(opts), adapterName)
 }
 
 const deployAction = (

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -407,6 +407,7 @@ const fetchAndProcessMergeErrors = async (
     accountName: string,
   ): Promise<void> => {
     errors.forEach(error => {
+      error.account = accountName
       if (isSaltoElementError(error)) {
         error.elemID = createAdapterReplacedID(error.elemID, accountName)
       }
@@ -446,6 +447,7 @@ const fetchAndProcessMergeErrors = async (
             progressReporter: progressReporters[accountName],
           })
           const { updatedConfig, errors } = fetchResult
+          errors?.forEach(err => { err.account = accountName; err.service = accountToServiceNameMap[accountName] })
           if (
             fetchResult.elements.length > 0 && accountName !== accountToServiceNameMap[accountName]
           ) {
@@ -898,7 +900,7 @@ export const fetchChangesFromWorkspace = async (
       config => config.elemID.adapter,
     )
     Object.entries(configsByAdapter).forEach(([adapter, configs]) => {
-      log.warn(`Found different configs for ${adapter} - 
+      log.warn(`Found different configs for ${adapter} -
       ${configs.map(config => safeJsonStringify(config.value, undefined, 2)).join('\n')}`)
     })
   }

--- a/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
@@ -115,7 +115,8 @@ const createWarnings = async (
         ...overflowMsg,
         '',
         epilogue,
-      ].join('\n'))
+      ].join('\n'),
+      SALESFORCE)
     })
 
   const typesOfIllegalRefSources = _.uniq([...illegalRefSources]
@@ -123,7 +124,7 @@ const createWarnings = async (
     .map(source => source.type))
 
   const illegalOriginsWarnings = illegalRefSources.size === 0 ? [] : [createWarningFromMsg(`Omitted ${illegalRefSources.size} instances due to the previous SaltoID collisions and/or missing instances.
-  Types of the omitted instances are: ${typesOfIllegalRefSources.join(', ')}.`)]
+  Types of the omitted instances are: ${typesOfIllegalRefSources.join(', ')}.`, SALESFORCE)]
 
   return [
     ...collisionWarnings,

--- a/packages/zendesk-adapter/test/filters/collistion_errors.test.ts
+++ b/packages/zendesk-adapter/test/filters/collistion_errors.test.ts
@@ -40,6 +40,7 @@ describe('collision errors', () => {
       expect(filterResult.errors).toHaveLength(1)
       expect(filterResult.errors?.[0]).toEqual({
         severity: 'Warning',
+        service: 'zendesk',
         message: `Omitted 2 instances of obj due to Salto ID collisions.
 Current Salto ID configuration for obj is defined as [name].
 


### PR DESCRIPTION
Make it easier to tell which service/account an error occurred in
---

_Additional context for reviewer_

---
_Release Notes_: 
When logging errors, include information about the service/account the error occurred in

---
_User Notifications_: 
N/A
