### PR TITLE
SALTO-2806 - SalesForce: Retry on socket hang up

### DIFF
--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -121,6 +121,7 @@ const errorMessagesToRetry = [
   'SERVER_UNAVAILABLE',
   'system may be currently unavailable',
   'Unexpected internal servlet state',
+  'socket hang up',
 ]
 
 type RateLimitBucketName = keyof ClientRateLimitConfig


### PR DESCRIPTION
Add 'socket hang up' to the list of errors that would cause us to retry

---

---
_Release Notes_: 
SalesForce adapter is more resilient in the face of errors from the SalesForce API

---
_User Notifications_: 
N/A
