### PR TITLE
SALTO-2995 query customrecords system notes only if needed

### DIFF
--- a/packages/netsuite-adapter/src/filters/author_information/system_note.ts
+++ b/packages/netsuite-adapter/src/filters/author_information/system_note.ts
@@ -237,12 +237,16 @@ const filterCreator: FilterCreator = ({ client, config, elementsSource, elements
     const instancesWithInternalId = getInstancesWithInternalIds(elements)
     const customRecordTypesWithInternalIds = getCustomRecordTypesWithInternalIds(elements)
     const customRecordsWithInternalIds = await getCustomRecordsWithInternalIds(elements)
+    const customRecordTypeNames = new Set(
+      customRecordsWithInternalIds.map(({ elemID }) => elemID.typeName)
+    )
 
     const queryIds = _.uniq(instancesWithInternalId
       .map(instance => TYPES_TO_INTERNAL_ID[instance.elemID.typeName.toLowerCase()]))
     if (customRecordTypesWithInternalIds.length > 0) {
       queryIds.push(
         ...customRecordTypesWithInternalIds
+          .filter(({ elemID }) => customRecordTypeNames.has(elemID.name))
           .map(getInternalId)
           .concat(TYPES_TO_INTERNAL_ID[CUSTOM_RECORD_TYPE])
       )


### PR DESCRIPTION
query customrecords system notes only if needed

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Query customrecords system notes only if needed

---
_User Notifications_: 
None