### PR TITLE
SALTO-3025 - Zendesk Adapter - Remove dependency between a guide order instance and its parent

### DIFF
--- a/packages/zendesk-adapter/src/dependency_changers/guide_order_change.ts
+++ b/packages/zendesk-adapter/src/dependency_changers/guide_order_change.ts
@@ -19,6 +19,7 @@ import {
 } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { GUIDE_ORDER_TYPES } from '../filters/guide_order/guide_order_utils'
+import { ChangeWithKey } from './types'
 
 const createDependencyChange = (
   orderChange: {key: collections.set.SetId; change: Change<InstanceElement>},
@@ -36,7 +37,7 @@ const createDependencyChange = (
   ))
 }
 
-const isRelevantChange = (change: Change<InstanceElement>): boolean =>
+const isOrderRelevantChange = (change: Change<InstanceElement>): boolean =>
   isRemovalChange(change) && isInstanceChange(change)
   && GUIDE_ORDER_TYPES.includes(change.data.before.elemID.typeName)
 
@@ -47,11 +48,11 @@ export const guideOrderDependencyChanger: DependencyChanger = async changes => {
   const instanceChanges = Array.from(changes.entries())
     .map(([key, change]) => ({ key, change }))
     .filter(
-      (change): change is { key: collections.set.SetId; change: Change<InstanceElement> } =>
+      (change): change is ChangeWithKey<Change<InstanceElement>> =>
         isInstanceChange(change.change)
     )
 
-  const relevantOrderChanges = instanceChanges.filter(({ change }) => isRelevantChange(change))
+  const relevantOrderChanges = instanceChanges.filter(({ change }) => isOrderRelevantChange(change))
 
   return relevantOrderChanges.flatMap(change => createDependencyChange(change, instanceChanges))
 }

--- a/packages/zendesk-adapter/src/dependency_changers/guide_order_change.ts
+++ b/packages/zendesk-adapter/src/dependency_changers/guide_order_change.ts
@@ -37,7 +37,7 @@ const createDependencyChange = (
   ))
 }
 
-const isOrderRelevantChange = (change: Change<InstanceElement>): boolean =>
+const isRelevantOrderChange = (change: Change<InstanceElement>): boolean =>
   isRemovalChange(change) && isInstanceChange(change)
   && GUIDE_ORDER_TYPES.includes(change.data.before.elemID.typeName)
 
@@ -52,7 +52,7 @@ export const guideOrderDependencyChanger: DependencyChanger = async changes => {
         isInstanceChange(change.change)
     )
 
-  const relevantOrderChanges = instanceChanges.filter(({ change }) => isOrderRelevantChange(change))
+  const relevantOrderChanges = instanceChanges.filter(({ change }) => isRelevantOrderChange(change))
 
   return relevantOrderChanges.flatMap(change => createDependencyChange(change, instanceChanges))
 }

--- a/packages/zendesk-adapter/src/dependency_changers/guide_order_change.ts
+++ b/packages/zendesk-adapter/src/dependency_changers/guide_order_change.ts
@@ -27,7 +27,7 @@ const createDependencyChange = (
   const orderParent = getChangeData(orderChange.change).annotations[CORE_ANNOTATIONS.PARENT][0]
 
   const parentChanges = changes.filter(change =>
-    getChangeData(change.change).value.id === orderParent.value.value.id)
+    getChangeData(change.change).elemID === orderParent.value.elemID)
 
   return parentChanges.map(parentChange => dependencyChange(
     'remove',

--- a/packages/zendesk-adapter/src/dependency_changers/guide_order_changer.ts
+++ b/packages/zendesk-adapter/src/dependency_changers/guide_order_changer.ts
@@ -1,0 +1,57 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  Change, dependencyChange, DependencyChanger, getChangeData, InstanceElement,
+  isInstanceChange, DependencyChange, isRemovalChange, CORE_ANNOTATIONS,
+} from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { GUIDE_ORDER_TYPES } from '../filters/guide_order/guide_order_utils'
+
+const createDependencyChange = (
+  orderChange: {key: collections.set.SetId; change: Change<InstanceElement>},
+  changes: {key: collections.set.SetId; change: Change<InstanceElement>}[]
+): DependencyChange[] => {
+  const orderParent = getChangeData(orderChange.change).annotations[CORE_ANNOTATIONS.PARENT][0]
+
+  const parentChanges = changes.filter(change =>
+    getChangeData(change.change).value.id === orderParent.value.value.id)
+
+  return parentChanges.map(parentChange => dependencyChange(
+    'remove',
+    orderChange.key,
+    parentChange.key
+  ))
+}
+
+const isRelevantChange = (change: Change<InstanceElement>): boolean =>
+  isRemovalChange(change) && isInstanceChange(change)
+  && GUIDE_ORDER_TYPES.includes(change.data.before.elemID.typeName)
+
+/**
+ * Removed the dependency between an order instance and its parent, to avoid circular dependency
+ */
+export const guideOrderDependencyChanger: DependencyChanger = async changes => {
+  const instanceChanges = Array.from(changes.entries())
+    .map(([key, change]) => ({ key, change }))
+    .filter(
+      (change): change is { key: collections.set.SetId; change: Change<InstanceElement> } =>
+        isInstanceChange(change.change)
+    )
+
+  const relevantOrderChanges = instanceChanges.filter(({ change }) => isRelevantChange(change))
+
+  return relevantOrderChanges.flatMap(change => createDependencyChange(change, instanceChanges))
+}

--- a/packages/zendesk-adapter/src/dependency_changers/index.ts
+++ b/packages/zendesk-adapter/src/dependency_changers/index.ts
@@ -17,7 +17,7 @@ import { DependencyChanger } from '@salto-io/adapter-api'
 import { deployment } from '@salto-io/adapter-components'
 import { collections } from '@salto-io/lowerdash'
 import { customFieldOptionDependencyChanger } from './custom_field_option_change'
-import { guideOrderDependencyChanger } from './guide_order_changer'
+import { guideOrderDependencyChanger } from './guide_order_change'
 
 const { awu } = collections.asynciterable
 

--- a/packages/zendesk-adapter/src/dependency_changers/index.ts
+++ b/packages/zendesk-adapter/src/dependency_changers/index.ts
@@ -17,12 +17,14 @@ import { DependencyChanger } from '@salto-io/adapter-api'
 import { deployment } from '@salto-io/adapter-components'
 import { collections } from '@salto-io/lowerdash'
 import { customFieldOptionDependencyChanger } from './custom_field_option_change'
+import { guideOrderDependencyChanger } from './guide_order_changer'
 
 const { awu } = collections.asynciterable
 
 const DEPENDENCY_CHANGERS: DependencyChanger[] = [
   deployment.dependency.removeStandaloneFieldDependency,
   customFieldOptionDependencyChanger,
+  guideOrderDependencyChanger,
 ]
 
 export const dependencyChanger: DependencyChanger = async (

--- a/packages/zendesk-adapter/src/dependency_changers/types.ts
+++ b/packages/zendesk-adapter/src/dependency_changers/types.ts
@@ -1,0 +1,22 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Change } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+
+export type ChangeWithKey<ChangeType extends Change> = {
+    key: collections.set.SetId
+    change: ChangeType
+}

--- a/packages/zendesk-adapter/test/dependency_changers/guide_order_change.test.ts
+++ b/packages/zendesk-adapter/test/dependency_changers/guide_order_change.test.ts
@@ -1,0 +1,75 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  InstanceElement,
+  toChange,
+  CORE_ANNOTATIONS,
+  ReferenceExpression, ObjectType, ElemID,
+} from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import {
+  BRAND_TYPE_NAME,
+  CATEGORY_TYPE_NAME,
+  SECTION_TYPE_NAME,
+  ZENDESK,
+} from '../../src/constants'
+import { createOrderType } from '../../src/filters/guide_order/guide_order_utils'
+import { guideOrderDependencyChanger } from '../../src/dependency_changers/guide_order_change'
+
+describe('guideOrderDependencyChanger', () => {
+  const brand = new InstanceElement('brand', new ObjectType({ elemID: new ElemID(ZENDESK, BRAND_TYPE_NAME) }))
+  const category = new InstanceElement('category', new ObjectType({ elemID: new ElemID(ZENDESK, CATEGORY_TYPE_NAME) }))
+  const section = new InstanceElement('section', new ObjectType({ elemID: new ElemID(ZENDESK, SECTION_TYPE_NAME) }))
+  const categoriesOrder = new InstanceElement(
+    'categories', createOrderType(CATEGORY_TYPE_NAME), {}, undefined,
+    { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(brand.elemID, brand)] }
+  )
+  const sectionsInCategoryOrder = new InstanceElement(
+    'categories', createOrderType(CATEGORY_TYPE_NAME), {}, undefined,
+    { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(category.elemID, category)] }
+  )
+  const sectionsInSectionOrder = new InstanceElement(
+    'categories', createOrderType(CATEGORY_TYPE_NAME), {}, undefined,
+    { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(section.elemID, section)] }
+  )
+  const articlesOrder = new InstanceElement(
+    'categories', createOrderType(CATEGORY_TYPE_NAME), {}, undefined,
+    { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(section.elemID, section)] }
+  )
+
+  it('should remove dependency from the order instances to their parents', async () => {
+    const inputChanges = new Map([
+      [0, toChange({ before: brand })],
+      [1, toChange({ before: category })],
+      [2, toChange({ before: section })],
+      [3, toChange({ before: categoriesOrder })],
+      [4, toChange({ before: sectionsInCategoryOrder })],
+      [5, toChange({ before: sectionsInSectionOrder })],
+      [6, toChange({ before: articlesOrder })],
+    ])
+    const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([
+      [0, new Set()], [1, new Set()], [2, new Set()], [3, new Set()], [4, new Set()], [5, new Set()], [6, new Set()],
+    ])
+
+    const dependencyChanges = [...await guideOrderDependencyChanger(inputChanges, inputDeps)]
+    expect(dependencyChanges.length).toBe(4)
+    expect(dependencyChanges.every(change => change.action === 'remove')).toBe(true)
+    expect(dependencyChanges[0].dependency).toMatchObject({ source: 3, target: 0 })
+    expect(dependencyChanges[1].dependency).toMatchObject({ source: 4, target: 1 })
+    expect(dependencyChanges[2].dependency).toMatchObject({ source: 5, target: 2 })
+    expect(dependencyChanges[3].dependency).toMatchObject({ source: 6, target: 2 })
+  })
+})


### PR DESCRIPTION
When removing guide order instance and it's parent, removed the dependency between them to break a circle

---

None

---
_Release Notes_: 
None

---
_User Notifications_: 
None