### PR TITLE
SALTO-2755: Fix a bug causing AppUser instances to disappear - Okta

### DIFF
--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -78,6 +78,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
         { fieldName: '_links' },
       ],
       idFields: ['profile.name'],
+      serviceIdField: 'id',
     },
     deployRequests: {
       add: {
@@ -118,6 +119,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
         { fieldName: 'targetGroups', fieldType: 'list<Group>' },
       ],
       idFields: ['label'],
+      serviceIdField: 'id',
     },
   },
   api__v1__apps: {
@@ -160,6 +162,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
       standaloneFields: [{ fieldName: 'appUsers' }],
       // TODO SALTO-2644 It's possible to have many applications with the same name
       idFields: ['name', 'status'],
+      serviceIdField: 'id',
       fieldsToHide: [
         { fieldName: 'id' },
         { fieldName: '_links' },
@@ -272,6 +275,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
         { fieldName: 'users', fieldType: 'list<IdentityProviderApplicationUser>' },
         { fieldName: 'CSRs', fieldType: 'list<Csr>' },
       ],
+      serviceIdField: 'id',
     },
   },
   api__v1__features: {
@@ -292,6 +296,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
       fieldTypeOverrides: [
         { fieldName: 'featureDependencies', fieldType: 'list<Feature>' },
       ],
+      serviceIdField: 'id',
     },
   },
   // Policy type is splitted to different kinds of policies
@@ -407,6 +412,9 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
     request: {
       url: '/api/v1/meta/schemas/user/default',
     },
+    transformation: {
+      serviceIdField: 'id',
+    },
   },
   User: {
     transformation: {
@@ -414,6 +422,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
         { fieldName: 'roles', fieldType: 'list<Role>' },
       ],
       idFields: ['profile.firstName', 'profile.lastName'],
+      serviceIdField: 'id',
       fieldsToOmit: [
         { fieldName: 'lastLogin' },
       ],
@@ -427,6 +436,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
       ],
       idFields: ['name', 'type'],
       standaloneFields: [{ fieldName: 'policyRules' }],
+      serviceIdField: 'id',
       fieldsToHide: [
         { fieldName: 'id' },
       ],
@@ -450,6 +460,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
         { fieldName: 'lastUpdated' },
         { fieldName: '_links' },
       ],
+      serviceIdField: 'id',
     },
   },
   OrgContactTypeObj: {
@@ -512,6 +523,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
       fieldsToOmit: [
         { fieldName: '_links' },
       ],
+      serviceIdField: 'id',
     },
   },
   AuthorizationServerPolicy: {
@@ -519,6 +531,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
       fieldTypeOverrides: [
         { fieldName: 'policyRules', fieldType: 'list<AuthorizationServerPolicyRule>' },
       ],
+      serviceIdField: 'id',
     },
   },
   api__v1__brands: {
@@ -554,21 +567,60 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
   GroupSchema: {
     transformation: {
       idFields: ['title'],
+      serviceIdField: 'id',
     },
   },
   Domain: {
     transformation: {
       isSingleton: true,
+      serviceIdField: 'id',
     },
   },
   OrgSetting: {
     transformation: {
       isSingleton: true,
+      serviceIdField: 'id',
     },
   },
   Brand: {
     transformation: {
       isSingleton: true,
+      serviceIdField: 'id',
+    },
+  },
+  Authenticator: {
+    transformation: {
+      serviceIdField: 'id',
+    },
+  },
+  EventHook: {
+    transformation: {
+      serviceIdField: 'id',
+    },
+  },
+  GroupRule: {
+    transformation: {
+      serviceIdField: 'id',
+    },
+  },
+  InlineHook: {
+    transformation: {
+      serviceIdField: 'id',
+    },
+  },
+  NetworkZone: {
+    transformation: {
+      serviceIdField: 'id',
+    },
+  },
+  TrustedOrigin: {
+    transformation: {
+      serviceIdField: 'id',
+    },
+  },
+  UserType: {
+    transformation: {
+      serviceIdField: 'id',
     },
   },
   GroupSchemaAttribute: {
@@ -602,6 +654,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
         { fieldName: 'created' },
         { fieldName: 'lastUpdated' },
       ],
+      serviceIdField: 'id',
     },
   },
   AppUserCredentials: {

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -38,7 +38,6 @@ export type OktaConfig = {
 }
 
 const DEFAULT_ID_FIELDS = ['name']
-const DEFAULT_SERVICE_ID_FIELD = 'id'
 const DEFAULT_FIELDS_TO_OMIT: configUtils.FieldToOmitType[] = [
   { fieldName: 'created' },
   { fieldName: 'lastUpdated' },
@@ -696,7 +695,6 @@ export const DEFAULT_API_DEFINITIONS: OktaApiConfig = {
   typeDefaults: {
     transformation: {
       idFields: DEFAULT_ID_FIELDS,
-      serviceIdField: DEFAULT_SERVICE_ID_FIELD,
       fieldsToOmit: DEFAULT_FIELDS_TO_OMIT,
     },
   },


### PR DESCRIPTION
Solve a bug causing AppUser instances in Okta to disappear every second fetch.

---

`AppUser` instances represent the assignment of user to app, those instances don't have a service id of their own, and the id that the service returns is actually the user id. 
Because the default `serviceIdField` for Okta is the field 'id', users assigned to more than one app created duplication which caused a merge error.

For now I removed the default `serviceIdField`, and later we will add a better solution.

---
_Release Notes_: 

_Okta adapter_
* Fix a bug causing AppUser instances to disappear every second fetch

---

