### PR TITLE
SALTO-3037: fix incorrect template expression to point at drop-down field and not at specific field option

### DIFF
--- a/packages/zendesk-adapter/src/filters/handle_app_installations.ts
+++ b/packages/zendesk-adapter/src/filters/handle_app_installations.ts
@@ -23,14 +23,14 @@ import _ from 'lodash'
 import { FilterCreator } from '../filter'
 import { FETCH_CONFIG, IdLocator } from '../config'
 import { APP_INSTALLATION_TYPE_NAME } from './app'
-import { ZENDESK_REFERENCE_TYPE_TO_SALTO_TYPE } from './handle_template_expressions'
 import { TICKET_FIELD_TYPE_NAME } from '../constants'
 
 const log = logger(module)
 
 const DELIMITERS = /(\\n | ,)/g
+const CUSTOM_OPTION_TYPE = 'ticket_field__custom_field_options'
 
-const APP_INSTLLATION_SPECIFIC_TYPES = ['group']
+const APP_INSTLLATION_SPECIFIC_TYPES = ['group', TICKET_FIELD_TYPE_NAME, CUSTOM_OPTION_TYPE]
 
 const GENERAL_ID_REGEX = '([\\d]{10,})'
 
@@ -108,8 +108,7 @@ const filterCreator: FilterCreator = ({ config }) => {
     onFetch: async (elements: InstanceElement[]): Promise<void> => log.time(async () =>
       getAppInstallations(elements)
         .forEach(app => replaceFieldsWithTemplates(app, _.groupBy(elements.filter(
-          e => [...Object.values(ZENDESK_REFERENCE_TYPE_TO_SALTO_TYPE),
-            ...APP_INSTLLATION_SPECIFIC_TYPES]
+          e => [...APP_INSTLLATION_SPECIFIC_TYPES]
             .includes((e.elemID.typeName))
         ), e => e.elemID.typeName), locators)),
     'Create template creation filter'),

--- a/packages/zendesk-adapter/src/filters/handle_app_installations.ts
+++ b/packages/zendesk-adapter/src/filters/handle_app_installations.ts
@@ -24,13 +24,14 @@ import { FilterCreator } from '../filter'
 import { FETCH_CONFIG, IdLocator } from '../config'
 import { APP_INSTALLATION_TYPE_NAME } from './app'
 import { TICKET_FIELD_TYPE_NAME } from '../constants'
+import { ZENDESK_REFERENCE_TYPE_TO_SALTO_TYPE } from './handle_template_expressions'
 
 const log = logger(module)
 
 const DELIMITERS = /(\\n | ,)/g
 const CUSTOM_OPTION_TYPE = 'ticket_field__custom_field_options'
 
-const APP_INSTLLATION_SPECIFIC_TYPES = ['group', TICKET_FIELD_TYPE_NAME, CUSTOM_OPTION_TYPE]
+const APP_INSTLLATION_SPECIFIC_TYPES = ['group', CUSTOM_OPTION_TYPE]
 
 const GENERAL_ID_REGEX = '([\\d]{10,})'
 
@@ -108,7 +109,8 @@ const filterCreator: FilterCreator = ({ config }) => {
     onFetch: async (elements: InstanceElement[]): Promise<void> => log.time(async () =>
       getAppInstallations(elements)
         .forEach(app => replaceFieldsWithTemplates(app, _.groupBy(elements.filter(
-          e => [...APP_INSTLLATION_SPECIFIC_TYPES]
+          e => [...Object.values(ZENDESK_REFERENCE_TYPE_TO_SALTO_TYPE),
+            ...APP_INSTLLATION_SPECIFIC_TYPES]
             .includes((e.elemID.typeName))
         ), e => e.elemID.typeName), locators)),
     'Create template creation filter'),

--- a/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
@@ -41,12 +41,8 @@ export const ZENDESK_REFERENCE_TYPE_TO_SALTO_TYPE: Record<string, string> = {
   [TICKET_FIELD_OPTION_TITLE]: TICKET_FIELD_TYPE_NAME,
 }
 
-export const SALTO_TYPE_TO_ZENDESK_REFERENCE_TYPE = Object.fromEntries(
-  Object.entries(ZENDESK_REFERENCE_TYPE_TO_SALTO_TYPE)
-    .map(entry => [entry[1], entry[0]])
-)
 
-const POTENTIAL_REFERENCE_TYPES = [TICKET_TICKET_FIELD, TICKET_FIELD_OPTION_TITLE]
+const POTENTIAL_REFERENCE_TYPES = Object.keys(ZENDESK_REFERENCE_TYPE_TO_SALTO_TYPE)
 const typeSearchRegexes: RegExp[] = []
 BRACKETS.forEach(([opener, closer]) => {
   POTENTIAL_REFERENCE_TYPES.forEach(type => {
@@ -246,7 +242,7 @@ const replaceFormulasWithTemplates = async (
 }
 
 export const prepRef = (part: ReferenceExpression): TemplatePart => {
-  if (SALTO_TYPE_TO_ZENDESK_REFERENCE_TYPE[part.elemID.typeName]) {
+  if (Object.values(ZENDESK_REFERENCE_TYPE_TO_SALTO_TYPE).includes(part.elemID.typeName)) {
     return `${part.value.value.id}`
   }
   if (part.elemID.typeName === DYNAMIC_CONTENT_ITEM_TYPE_NAME

--- a/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
@@ -38,6 +38,7 @@ export const TICKET_FIELD_OPTION_TITLE = 'ticket.ticket_field_option_title'
 
 export const ZENDESK_REFERENCE_TYPE_TO_SALTO_TYPE: Record<string, string> = {
   [TICKET_TICKET_FIELD]: TICKET_FIELD_TYPE_NAME,
+  [TICKET_FIELD_OPTION_TITLE]: TICKET_FIELD_TYPE_NAME,
 }
 
 export const SALTO_TYPE_TO_ZENDESK_REFERENCE_TYPE = Object.fromEntries(
@@ -154,7 +155,7 @@ const formulaToTemplate = (
       return [expression]
     }
     const [type, innerId] = splitReference
-    const elem = (instancesByType[ZENDESK_REFERENCE_TYPE_TO_SALTO_TYPE[TICKET_TICKET_FIELD]] ?? [])
+    const elem = (instancesByType[ZENDESK_REFERENCE_TYPE_TO_SALTO_TYPE[type]] ?? [])
       .find(instance => instance.value.id?.toString() === innerId)
     if (elem) {
       return [
@@ -169,7 +170,7 @@ const formulaToTemplate = (
     // if no id was detected and enableMissingReferences we return a missing reference expression.
     const missingInstance = createMissingInstance(
       ZENDESK,
-      ZENDESK_REFERENCE_TYPE_TO_SALTO_TYPE[TICKET_TICKET_FIELD],
+      ZENDESK_REFERENCE_TYPE_TO_SALTO_TYPE[type],
       innerId
     )
     missingInstance.value.id = innerId

--- a/packages/zendesk-adapter/test/filters/custom_field_options/ticket_field.test.ts
+++ b/packages/zendesk-adapter/test/filters/custom_field_options/ticket_field.test.ts
@@ -27,6 +27,7 @@ import {
   DEFAULT_CUSTOM_FIELD_OPTION_FIELD_NAME,
 } from '../../../src/filters/custom_field_options/creator'
 import { createFilterCreatorParams } from '../../utils'
+import { TICKET_TICKET_FIELD } from '../../../src/filters/handle_template_expressions'
 
 const mockDeployChange = jest.fn()
 jest.mock('@salto-io/adapter-components', () => {
@@ -161,7 +162,7 @@ describe('ticket field filter', () => {
         name: 'parent',
         [CUSTOM_FIELD_OPTIONS_FIELD_NAME]: [
           { id: 22, name: 'child1', value: 'v1', raw_name: 'aaa' },
-          { id: 33, name: 'child2', value: 'v2', raw_name: createTemplateExpression({ parts: ['aaa ', new ReferenceExpression(parent.elemID, parent)] }) },
+          { id: 33, name: 'child2', value: 'v2', raw_name: createTemplateExpression({ parts: [`aaa ${TICKET_TICKET_FIELD}_`, new ReferenceExpression(parent.elemID, parent)] }) },
         ],
         [DEFAULT_CUSTOM_FIELD_OPTION_FIELD_NAME]: 'v2',
       },

--- a/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
+++ b/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
@@ -16,7 +16,10 @@
 import { ElemID, InstanceElement, ObjectType, ReferenceExpression,
   BuiltinTypes, TemplateExpression, MapType, toChange, isInstanceElement } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
-import filterCreator from '../../src/filters/handle_template_expressions'
+import filterCreator, {
+  TICKET_FIELD_OPTION_TITLE,
+  TICKET_TICKET_FIELD,
+} from '../../src/filters/handle_template_expressions'
 import { ZENDESK } from '../../src/constants'
 import { createMissingInstance } from '../../src/filters/references/missing_references'
 import { createFilterCreatorParams } from '../utils'
@@ -106,8 +109,8 @@ describe('handle templates filter', () => {
   })
 
   const placeholder1 = new InstanceElement('placeholder1', placeholder1Type, { id: 1452 })
-  const placeholder2 = new InstanceElement('placeholder2', placeholder2Type, { id: 1453 })
-  const placeholder3 = new InstanceElement('placeholder3', placeholder2Type, { id: 1454 })
+  const placeholder2 = new InstanceElement('placeholder2', placeholder1Type, { id: 1453 })
+  const placeholder3 = new InstanceElement('placeholder3', placeholder1Type, { id: 1454 })
   const macro1 = new InstanceElement('macro1', testType, { id: 1001, actions: [{ value: 'non template', field: 'comment_value_html' }] })
   const macro2 = new InstanceElement('macro2', testType, { id: 1002, actions: [{ value: '{{ticket.ticket_field_1452}}', field: 'comment_value' }] })
   const macro3 = new InstanceElement('macro3', testType, { id: 1003, actions: [{ value: 'multiple refs {{ticket.ticket_field_1452}} and {{ticket.ticket_field_option_title_1453}}', field: 'comment_value_html' }] })
@@ -131,7 +134,7 @@ describe('handle templates filter', () => {
   const macroWithDC = new InstanceElement('macroDynamicContent', testType, { id: 1033, actions: [{ value: 'dynamic content ref {{dc.dynamic_content_test}} and {{ticket.ticket_field_option_title_1453}}', field: 'comment_value_html' }] })
   const macroWithHyphenDC = new InstanceElement('macroHyphenDynamicContent', testType, { id: 1034, actions: [{ value: 'dynamic content ref {{dc.dynamic-content-test}} and {{ticket.ticket_field_option_title_1453}}', field: 'comment_value_html' }] })
 
-  const macroAlmostTemplate = new InstanceElement('macroAlmost', testType, { id: 1001, actions: [{ value: 'almost template {{ticket.not_an_actual_field_1452}} and {{ticket.ticket_field_1454}}', field: 'comment_value_html' }] })
+  const macroAlmostTemplate = new InstanceElement('macroAlmost', testType, { id: 1001, actions: [{ value: 'almost template {{ticket.not_an_actual_field_1452}} and {{ticket.ticket_field_1455}}', field: 'comment_value_html' }] })
   const macroAlmostTemplate2 = new InstanceElement('macroAlmost2', testType, { id: 1001, actions: [{ value: '{{ticket.ticket_field_1452}}', field: 'not_template_field' }] })
   const target = new InstanceElement('target', targetType, { id: 1004, target_url: 'url: {{ticket.ticket_field_1452}}' })
   const trigger = new InstanceElement('trigger', triggerType, { id: 1005, actions: [{ value: 'ticket: {{ticket.ticket_field_1452}}', field: 'notification_webhook' }] })
@@ -169,10 +172,11 @@ describe('handle templates filter', () => {
 
     it('should resolve almost-template normally', () => {
       const fetchedMacroAlmostTemplate = elements.filter(isInstanceElement).find(i => i.elemID.name === 'macroAlmost')
-      const missingInstance = createMissingInstance(ZENDESK, 'ticket_field', '1454')
-      missingInstance.value.id = '1454'
+      const missingInstance = createMissingInstance(ZENDESK, 'ticket_field', '1455')
+      missingInstance.value.id = '1455'
       expect(fetchedMacroAlmostTemplate?.value.actions[0].value).toEqual(new TemplateExpression({
-        parts: ['almost template {{ticket.not_an_actual_field_1452}} and {{',
+        parts: [
+          `almost template {{ticket.not_an_actual_field_1452}} and {{${TICKET_TICKET_FIELD}_`,
           new ReferenceExpression(missingInstance.elemID, missingInstance),
           '}}',
         ],
@@ -184,37 +188,37 @@ describe('handle templates filter', () => {
     it('should resolve one template correctly, in any type', () => {
       const fetchedMacro2 = elements.filter(isInstanceElement).find(i => i.elemID.name === 'macro2')
       expect(fetchedMacro2?.value.actions[0].value).toEqual(new TemplateExpression({ parts: [
-        '{{',
+        `{{${TICKET_TICKET_FIELD}_`,
         new ReferenceExpression(placeholder1.elemID, placeholder1), '}}'] }))
       const fetchedTarget = elements.filter(isInstanceElement).find(i => i.elemID.name === 'target')
       expect(fetchedTarget?.value.target_url).toEqual(new TemplateExpression({ parts: [
-        'url: {{',
+        `url: {{${TICKET_TICKET_FIELD}_`,
         new ReferenceExpression(placeholder1.elemID, placeholder1), '}}'] }))
       const fetchedWebhook = elements.filter(isInstanceElement).find(i => i.elemID.name === 'webhook')
       expect(fetchedWebhook?.value.endpoint).toEqual(new TemplateExpression({ parts: [
-        'endpoint: {{',
+        `endpoint: {{${TICKET_TICKET_FIELD}_`,
         new ReferenceExpression(placeholder1.elemID, placeholder1), '}}'] }))
       const fetchedTrigger = elements.filter(isInstanceElement).find(i => i.elemID.name === 'trigger')
       expect(fetchedTrigger?.value.actions[0].value).toEqual(new TemplateExpression({ parts: [
-        'ticket: {{',
+        `ticket: {{${TICKET_TICKET_FIELD}_`,
         new ReferenceExpression(placeholder1.elemID, placeholder1), '}}'] }))
       const fetchedAutomation = elements.filter(isInstanceElement).find(i => i.elemID.name === 'automation')
       expect(fetchedAutomation?.value.actions[0].value).toEqual(new TemplateExpression({ parts: [
-        'ticket: {{',
+        `ticket: {{${TICKET_TICKET_FIELD}_`,
         new ReferenceExpression(placeholder1.elemID, placeholder1), '}}'] }))
       const fetchedDynamicContent = elements.filter(isInstanceElement).find(i => i.elemID.name === 'dc')
       expect(fetchedDynamicContent?.value.content).toEqual(new TemplateExpression({ parts: [
-        'content: {{',
+        `content: {{${TICKET_TICKET_FIELD}_`,
         new ReferenceExpression(placeholder1.elemID, placeholder1), '}}'] }))
       const fetchedAppInstallation = elements.filter(isInstanceElement).find(i => i.elemID.name === 'appInstallation')
       expect(fetchedAppInstallation?.value.settings.uri_templates).toEqual(
         new TemplateExpression({ parts: [
-          'template: {{',
+          `template: {{${TICKET_TICKET_FIELD}_`,
           new ReferenceExpression(placeholder1.elemID, placeholder1), '}}'] })
       )
       expect(fetchedAppInstallation?.value.settings_objects[0].value).toEqual(
         new TemplateExpression({ parts: [
-          'object template: {{',
+          `object template: {{${TICKET_TICKET_FIELD}_`,
           new ReferenceExpression(placeholder1.elemID, placeholder1), '}}'] })
       )
       const fetchedDCMacro = elements.filter(isInstanceElement).find(i => i.elemID.name === 'macroDynamicContent')
@@ -222,7 +226,7 @@ describe('handle templates filter', () => {
         new TemplateExpression({ parts: [
           'dynamic content ref {{',
           new ReferenceExpression(dynamicContentRecord.elemID, dynamicContentRecord),
-          '}} and {{',
+          `}} and {{${TICKET_FIELD_OPTION_TITLE}_`,
           new ReferenceExpression(placeholder2.elemID, placeholder2),
           '}}'] })
       )
@@ -232,7 +236,7 @@ describe('handle templates filter', () => {
         new TemplateExpression({ parts: [
           'dynamic content ref {{',
           new ReferenceExpression(hyphenDynamicContentRecord.elemID, hyphenDynamicContentRecord),
-          '}} and {{',
+          `}} and {{${TICKET_FIELD_OPTION_TITLE}_`,
           new ReferenceExpression(placeholder2.elemID, placeholder2),
           '}}'] })
       )
@@ -241,7 +245,7 @@ describe('handle templates filter', () => {
     it('should resolve more complicated templates correctly', () => {
       const fetchedMacroComplicated = elements.filter(isInstanceElement).find(i => i.elemID.name === 'macroComplicated')
       expect(fetchedMacroComplicated?.value.actions[0].value).toEqual(new TemplateExpression({
-        parts: ['{{some other irrelevancies-',
+        parts: [`{{some other irrelevancies-${TICKET_TICKET_FIELD}_`,
           new ReferenceExpression(placeholder1.elemID, placeholder1),
           ' | something irrelevant | dynamic content now: ',
           new ReferenceExpression(dynamicContentRecord.elemID, dynamicContentRecord),
@@ -249,7 +253,7 @@ describe('handle templates filter', () => {
       }))
       const fetchedMacroDifferentBracket = elements.filter(isInstanceElement).find(i => i.elemID.name === 'macroDifferentBracket')
       expect(fetchedMacroDifferentBracket?.value.actions[0].value).toEqual(new TemplateExpression({
-        parts: ['{%some other irrelevancies-',
+        parts: [`{%some other irrelevancies-${TICKET_TICKET_FIELD}_`,
           new ReferenceExpression(placeholder1.elemID, placeholder1),
           ' | something irrelevant | dynamic content now: ',
           new ReferenceExpression(dynamicContentRecord.elemID, dynamicContentRecord),
@@ -261,9 +265,9 @@ describe('handle templates filter', () => {
       const fetchedMacro3 = elements.filter(isInstanceElement).find(i => i.elemID.name === 'macro3')
       expect(fetchedMacro3?.value.actions[0].value).toEqual(new TemplateExpression({
         parts: [
-          'multiple refs {{',
+          `multiple refs {{${TICKET_TICKET_FIELD}_`,
           new ReferenceExpression(placeholder1.elemID, placeholder1),
-          '}} and {{',
+          `}} and {{${TICKET_FIELD_OPTION_TITLE}_`,
           new ReferenceExpression(placeholder2.elemID, placeholder2),
           '}}',
         ],
@@ -276,8 +280,8 @@ describe('handle templates filter', () => {
         .filter(i => i.elemID.name === 'macroSideConvTicket')[0]
       expect(macroWithSideConv).toBeDefined()
       expect(macroWithSideConv.value.actions[0].value).toEqual([
-        new TemplateExpression({ parts: ['Improved needs for {{', new ReferenceExpression(placeholder3.elemID, placeholder3), '}}'] }),
-        new TemplateExpression({ parts: ['<p>Improved needs for {{', new ReferenceExpression(placeholder3.elemID, placeholder3), '}} due to something</p>'] }),
+        new TemplateExpression({ parts: [`Improved needs for {{${TICKET_FIELD_OPTION_TITLE}_`, new ReferenceExpression(placeholder3.elemID, placeholder3), '}}'] }),
+        new TemplateExpression({ parts: [`<p>Improved needs for {{${TICKET_FIELD_OPTION_TITLE}_`, new ReferenceExpression(placeholder3.elemID, placeholder3), '}} due to something</p>'] }),
         'hello',
         'text/html',
       ])


### PR DESCRIPTION
_fix incorrect template expression to point at drop-down field and not at specific field option_

---

_Additional context for reviewer_
None

---
_Release Notes_: 
Zendesk:
* fix incorrect template expression to point at drop-down field and not at specific field option

---
_User Notifications_: 
Zendesk:
* fix incorrect template expression to point at drop-down field and not at specific custom field option. 
All placeholders in the form of {{ticket.ticket_field_ID}} or {{ticket.ticket_field_option_title_ID}} will change from {{${ zendesk.ticket_field.instance.<NAME> }}} to {{ticket.ticket_field_${ zendesk.ticket_field.instance.<NAME> }}}. 
This will happen for types: macros, webhooks, automations, triggers, app installations, targets and dynamic content items.
