### PR TITLE
SALTO-2833 Add change Validator to prevent the deploy of Case AssignmentRules with Case team

### DIFF
--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -32,6 +32,7 @@ import recordTypeDeletionValidator from './change_validators/record_type_deletio
 import flowsValidator from './change_validators/flows'
 import fullNameChangedValidator from './change_validators/fullname_changed'
 import invalidListViewFilterScope from './change_validators/invalid_listview_filterscope'
+import caseAssignmentRulesValidator from './change_validators/case_assignmentRules'
 
 import { ChangeValidatorName, CheckOnlyChangeValidatorName, SalesforceConfig } from './types'
 
@@ -52,6 +53,7 @@ export const changeValidators: Record<ChangeValidatorName, ChangeValidatorCreato
   flowsValidator: (config, isSandbox) => flowsValidator(config, isSandbox),
   fullNameChangedValidator: () => fullNameChangedValidator,
   invalidListViewFilterScope: () => invalidListViewFilterScope,
+  caseAssignmentRulesValidator: () => caseAssignmentRulesValidator,
 }
 
 const checkOnlyChangeValidators

--- a/packages/salesforce-adapter/src/change_validators/case_assignmentRules.ts
+++ b/packages/salesforce-adapter/src/change_validators/case_assignmentRules.ts
@@ -26,6 +26,8 @@ import { apiName } from '../transformers/transformer'
 
 const { awu } = collections.asynciterable
 
+export const CASE = 'Case'
+
 type RuleEntry = { // with team
   team: string
 }
@@ -56,7 +58,7 @@ const createChangeError = (instance: InstanceElement): ChangeError => ({
   elemID: instance.elemID,
   severity: 'Error',
   message: 'Deployment of case assignment rule that references a predefined case team is not supported. Please remove the ‘team’ property in order to deploy this element and then configure its team via the salesforce UI.',
-  detailedMessage: 'Deployment of case assignment rule that references a predefined case team is not supported. Please remove the ‘team’ property in order to deploy this element and then configure its team via the salesforce UI.',
+  detailedMessage: 'Deployment of case assignment rule that references a predefined case team is not supported in SF. Please  visit: https://help.salesforce.com/s/articleView?id=000387900&type=1',
 })
 
 /**
@@ -67,7 +69,7 @@ const changeValidator: ChangeValidator = async changes => awu(changes)
   .filter(isAdditionOrModificationChange)
   .map(getChangeData)
   .filter(isInstanceOfType(ASSIGNMENT_RULES_METADATA_TYPE))
-  .filter(async change => await apiName(change) === 'Case')
+  .filter(async change => await apiName(change) === CASE)
   .filter(instance => isAssignmentRulesWithTeam(instance.value))
   .map(createChangeError)
   .toArray()

--- a/packages/salesforce-adapter/src/change_validators/case_assignmentRules.ts
+++ b/packages/salesforce-adapter/src/change_validators/case_assignmentRules.ts
@@ -1,0 +1,51 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  ChangeError, getChangeData, ChangeValidator,
+  isInstanceChange, InstanceElement, isAdditionOrModificationChange,
+} from '@salto-io/adapter-api'
+import { values, collections } from '@salto-io/lowerdash'
+import { isInstanceOfType } from '../filters/utils'
+import { ASSIGNMENT_RULES_METADATA_TYPE } from '../constants'
+import { apiName } from '../transformers/transformer'
+
+const { awu } = collections.asynciterable
+const { isDefined } = values
+
+const isCaseRuleWithTeams = (instance: InstanceElement): boolean =>
+  instance.value.assignmentRule.ruleEntry.some(entry => isDefined(entry.team))
+
+const createChangeError = (instance: InstanceElement): ChangeError => ({
+  elemID: instance.elemID,
+  severity: 'Error',
+  message: 'Deployment of case assignment rule that references a predefined case team is not supported. Please remove the ‘team’ property in order to deploy this element and then configure its team via the salesforce UI.',
+  detailedMessage: 'Deployment of case assignment rule that references a predefined case team is not supported. Please remove the ‘team’ property in order to deploy this element and then configure its team via the salesforce UI.',
+})
+
+/**
+ * SF does not support deploy of case assignment rules with case teams.
+ */
+const changeValidator: ChangeValidator = async changes => awu(changes)
+  .filter(isInstanceChange)
+  .filter(isAdditionOrModificationChange)
+  .map(getChangeData)
+  .filter(isInstanceOfType(ASSIGNMENT_RULES_METADATA_TYPE))
+  .filter(async change => await apiName(change) === 'Case')
+  .filter(isCaseRuleWithTeams)
+  .map(createChangeError)
+  .toArray()
+
+export default changeValidator

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -93,6 +93,7 @@ export type ChangeValidatorName = (
   | 'flowsValidator'
   | 'fullNameChangedValidator'
   | 'invalidListViewFilterScope'
+  | 'caseAssignmentRulesValidator'
 )
 
 export type CheckOnlyChangeValidatorName = 'checkOnlyDeploy'
@@ -560,6 +561,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     flowsValidator: { refType: BuiltinTypes.BOOLEAN },
     fullNameChangedValidator: { refType: BuiltinTypes.BOOLEAN },
     invalidListViewFilterScope: { refType: BuiltinTypes.BOOLEAN },
+    caseAssignmentRulesValidator: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/salesforce-adapter/test/change_validators/case_assignmentRules.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/case_assignmentRules.test.ts
@@ -20,34 +20,32 @@ import { createInstanceElement } from '../../src/transformers/transformer'
 
 describe('case AssignmentRules change validator', () => {
   let caseRuleChange: Change
-  describe('deploy a  case AssignmentRules', () => {
-    describe('case AssignmentRules with case teams', () => {
-      beforeEach(() => {
-        const caseRule = createInstanceElement({ fullName: 'Case', assignmentRule: [{ ruleEntry: [{ assignedTo: 'user1' }, { assignedTo: 'user2', team: 'team1' }] }] }, mockTypes.AssignmentRules)
-        caseRuleChange = toChange({ after: caseRule })
-      })
-
-      it('should throw an error', async () => {
-        const changeErrors = await caseChangeValidator(
-          [caseRuleChange]
-        )
-        expect(changeErrors).toHaveLength(1)
-        const [changeError] = changeErrors
-        expect(changeError.severity).toEqual('Error')
-      })
+  describe('case AssignmentRules with case teams', () => {
+    beforeEach(() => {
+      const caseRule = createInstanceElement({ fullName: 'Case', assignmentRule: [{ ruleEntry: [{ assignedTo: 'user1' }, { assignedTo: 'user2', team: 'team1' }] }] }, mockTypes.AssignmentRules)
+      caseRuleChange = toChange({ after: caseRule })
     })
-    describe('case AssignmentRules without case teams', () => {
-      beforeEach(() => {
-        const caseRule = createInstanceElement({ fullName: 'Case', assignmentRule: [{ ruleEntry: [{ assignedTo: 'user1' }, { assignedTo: 'user2' }] }] }, mockTypes.AssignmentRules)
-        caseRuleChange = toChange({ after: caseRule })
-      })
 
-      it('should not throw any error', async () => {
-        const changeErrors = await caseChangeValidator(
-          [caseRuleChange]
-        )
-        expect(changeErrors).toHaveLength(0)
-      })
+    it('should throw an error', async () => {
+      const changeErrors = await caseChangeValidator(
+        [caseRuleChange]
+      )
+      expect(changeErrors).toHaveLength(1)
+      const [changeError] = changeErrors
+      expect(changeError.severity).toEqual('Error')
+    })
+  })
+  describe('case AssignmentRules without case teams', () => {
+    beforeEach(() => {
+      const caseRule = createInstanceElement({ fullName: 'Case', assignmentRule: [{ ruleEntry: [{ assignedTo: 'user1' }, { assignedTo: 'user2' }] }] }, mockTypes.AssignmentRules)
+      caseRuleChange = toChange({ after: caseRule })
+    })
+
+    it('should not throw any error', async () => {
+      const changeErrors = await caseChangeValidator(
+        [caseRuleChange]
+      )
+      expect(changeErrors).toHaveLength(0)
     })
   })
 })

--- a/packages/salesforce-adapter/test/change_validators/case_assignmentRules.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/case_assignmentRules.test.ts
@@ -1,0 +1,53 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Change, toChange } from '@salto-io/adapter-api'
+import caseChangeValidator from '../../src/change_validators/case_assignmentRules'
+import { mockTypes } from '../mock_elements'
+import { createInstanceElement } from '../../src/transformers/transformer'
+
+describe('case AssignmentRules change validator', () => {
+  let caseRuleChange: Change
+  describe('deploy a  case AssignmentRules', () => {
+    describe('case AssignmentRules with case teams', () => {
+      beforeEach(() => {
+        const caseRule = createInstanceElement({ fullName: 'Case', assignmentRule: [{ ruleEntry: [{ assignedTo: 'user1' }, { assignedTo: 'user2', team: 'team1' }] }] }, mockTypes.AssignmentRules)
+        caseRuleChange = toChange({ after: caseRule })
+      })
+
+      it('should throw an error', async () => {
+        const changeErrors = await caseChangeValidator(
+          [caseRuleChange]
+        )
+        expect(changeErrors).toHaveLength(1)
+        const [changeError] = changeErrors
+        expect(changeError.severity).toEqual('Error')
+      })
+    })
+    describe('case AssignmentRules without case teams', () => {
+      beforeEach(() => {
+        const caseRule = createInstanceElement({ fullName: 'Case', assignmentRule: [{ ruleEntry: [{ assignedTo: 'user1' }, { assignedTo: 'user2' }] }] }, mockTypes.AssignmentRules)
+        caseRuleChange = toChange({ after: caseRule })
+      })
+
+      it('should not throw any error', async () => {
+        const changeErrors = await caseChangeValidator(
+          [caseRuleChange]
+        )
+        expect(changeErrors).toHaveLength(0)
+      })
+    })
+  })
+})


### PR DESCRIPTION
_Add change Validator to prevent the deploy of Case AssignmentRules with Case team_

---
_Additional context for reviewer_:
None

---
_Release Notes_: 
Salesforce-adapter:

* Add change Validator to prevent the deploy of Case AssignmentRules with Case team
---

_User Notifications_: 
None

