### PR TITLE
SALTO-3022: Support IssueType to IssueTypeScheme connection changes

### DIFF
--- a/packages/jira-adapter/src/product_settings/data_center/data_center.ts
+++ b/packages/jira-adapter/src/product_settings/data_center/data_center.ts
@@ -295,6 +295,18 @@ const PLUGIN_URL_PATTERNS: UrlPattern[] = [
     httpMethods: ['put'],
     url: '/rest/api/3/issuetypescheme/project',
   },
+  {
+    httpMethods: ['put'],
+    url: '/rest/api/3/issuetypescheme/.*/issuetype',
+  },
+  {
+    httpMethods: ['delete'],
+    url: '/rest/api/3/issuetypescheme/.*/issuetype/.*',
+  },
+  {
+    httpMethods: ['put'],
+    url: '/rest/api/3/issuetypescheme/.*/issuetype/move',
+  },
 ]
 
 const replaceRestVersion = (url: string): string => url.replace(

--- a/packages/jira-adapter/src/product_settings/data_center/data_center.ts
+++ b/packages/jira-adapter/src/product_settings/data_center/data_center.ts
@@ -297,15 +297,15 @@ const PLUGIN_URL_PATTERNS: UrlPattern[] = [
   },
   {
     httpMethods: ['put'],
-    url: '/rest/api/3/issuetypescheme/.*/issuetype',
+    url: '/rest/api/3/issuetypescheme/.+/issuetype',
   },
   {
     httpMethods: ['delete'],
-    url: '/rest/api/3/issuetypescheme/.*/issuetype/.*',
+    url: '/rest/api/3/issuetypescheme/.+/issuetype/.+',
   },
   {
     httpMethods: ['put'],
-    url: '/rest/api/3/issuetypescheme/.*/issuetype/move',
+    url: '/rest/api/3/issuetypescheme/.+/issuetype/move',
   },
 ]
 


### PR DESCRIPTION
Added support for modifying issue types in issue type scheme in Jira dc

Plugin PR: https://github.com/salto-io/jira-dc-app/pull/43

---
_Release Notes_: 
None

---
_User Notifications_: 
None