### PR TITLE
SALTO-3057 - Zendesk Adapter - Added a flag to disable collision value stringify

### DIFF
--- a/packages/adapter-utils/src/collisions.ts
+++ b/packages/adapter-utils/src/collisions.ts
@@ -73,7 +73,7 @@ const logInstancesWithCollidingElemID = async (
     const instancesCount = Object.values(elemIDtoInstances).flat().length
     log.debug(`Omitted ${instancesCount} instances of type ${type} due to Salto ID collisions`)
     Object.entries(elemIDtoInstances).forEach(([elemID, elemIDInstances]) => {
-      // For some reason safeJsonStringify is really slow, so we use this flag to avoid it in case of big environments
+      // For some reason safeJsonStringify is really slow, temporary we skip it by flag to stress test big envs
       if (skipLogCollisionStringify) {
         log.debug(`Omitted instances of type ${type} with colliding ElemID ${elemID}`)
         return

--- a/packages/adapter-utils/src/collisions.ts
+++ b/packages/adapter-utils/src/collisions.ts
@@ -67,8 +67,8 @@ export const getInstancesWithCollidingElemID = (instances: InstanceElement[]): I
 
 const logInstancesWithCollidingElemID = async (
   typeToElemIDtoInstances: Record<string, Record<string, InstanceElement[]>>,
-  skipLogCollisionStringify?: boolean)
-: Promise<void> => {
+  skipLogCollisionStringify?: boolean
+): Promise<void> => {
   Object.entries(typeToElemIDtoInstances).forEach(([type, elemIDtoInstances]) => {
     const instancesCount = Object.values(elemIDtoInstances).flat().length
     log.debug(`Omitted ${instancesCount} instances of type ${type} due to Salto ID collisions`)

--- a/packages/adapter-utils/src/collisions.ts
+++ b/packages/adapter-utils/src/collisions.ts
@@ -66,12 +66,18 @@ export const getInstancesWithCollidingElemID = (instances: InstanceElement[]): I
     .flat()
 
 const logInstancesWithCollidingElemID = async (
-  typeToElemIDtoInstances: Record<string, Record<string, InstanceElement[]>>
-): Promise<void> => {
+  typeToElemIDtoInstances: Record<string, Record<string, InstanceElement[]>>,
+  skipCollisionStringify?: boolean)
+: Promise<void> => {
   Object.entries(typeToElemIDtoInstances).forEach(([type, elemIDtoInstances]) => {
     const instancesCount = Object.values(elemIDtoInstances).flat().length
     log.debug(`Omitted ${instancesCount} instances of type ${type} due to Salto ID collisions`)
     Object.entries(elemIDtoInstances).forEach(([elemID, elemIDInstances]) => {
+      // For some reason safeJsonStringify is really slow, so we use this flag to avoid it in case of big environments
+      if (skipCollisionStringify) {
+        log.debug(`Omitted instances of type ${type} with colliding ElemID ${elemID}`)
+        return
+      }
       const relevantInstanceValues = elemIDInstances
         .map(instance => _.pickBy(instance.value, val => val != null))
       const relevantInstanceValuesStr = relevantInstanceValues
@@ -93,6 +99,7 @@ export const getAndLogCollisionWarnings = async ({
   maxBreakdownElements = MAX_BREAKDOWN_ELEMENTS,
   maxBreakdownDetailsElements = MAX_BREAKDOWN_DETAILS_ELEMENTS,
   baseUrl,
+  skipCollisionStringify,
 }: {
   instances: InstanceElement[]
   getTypeName: (instance: InstanceElement) => Promise<string>
@@ -104,9 +111,10 @@ export const getAndLogCollisionWarnings = async ({
   maxBreakdownElements?: number
   maxBreakdownDetailsElements?: number
   baseUrl?: string
+  skipCollisionStringify?: boolean
 }): Promise<SaltoError[]> => {
   const typeToElemIDtoInstances = await groupInstancesByTypeAndElemID(instances, getTypeName)
-  await logInstancesWithCollidingElemID(typeToElemIDtoInstances)
+  await logInstancesWithCollidingElemID(typeToElemIDtoInstances, skipCollisionStringify)
   return Promise.all(Object.entries(typeToElemIDtoInstances)
     .map(async ([type, elemIDtoInstances]) => {
       const numInstances = Object.values(elemIDtoInstances)

--- a/packages/adapter-utils/src/collisions.ts
+++ b/packages/adapter-utils/src/collisions.ts
@@ -67,14 +67,14 @@ export const getInstancesWithCollidingElemID = (instances: InstanceElement[]): I
 
 const logInstancesWithCollidingElemID = async (
   typeToElemIDtoInstances: Record<string, Record<string, InstanceElement[]>>,
-  skipCollisionStringify?: boolean)
+  skipLogCollisionStringify?: boolean)
 : Promise<void> => {
   Object.entries(typeToElemIDtoInstances).forEach(([type, elemIDtoInstances]) => {
     const instancesCount = Object.values(elemIDtoInstances).flat().length
     log.debug(`Omitted ${instancesCount} instances of type ${type} due to Salto ID collisions`)
     Object.entries(elemIDtoInstances).forEach(([elemID, elemIDInstances]) => {
       // For some reason safeJsonStringify is really slow, so we use this flag to avoid it in case of big environments
-      if (skipCollisionStringify) {
+      if (skipLogCollisionStringify) {
         log.debug(`Omitted instances of type ${type} with colliding ElemID ${elemID}`)
         return
       }
@@ -99,7 +99,7 @@ export const getAndLogCollisionWarnings = async ({
   maxBreakdownElements = MAX_BREAKDOWN_ELEMENTS,
   maxBreakdownDetailsElements = MAX_BREAKDOWN_DETAILS_ELEMENTS,
   baseUrl,
-  skipCollisionStringify,
+  skipLogCollisionStringify,
 }: {
   instances: InstanceElement[]
   getTypeName: (instance: InstanceElement) => Promise<string>
@@ -111,10 +111,10 @@ export const getAndLogCollisionWarnings = async ({
   maxBreakdownElements?: number
   maxBreakdownDetailsElements?: number
   baseUrl?: string
-  skipCollisionStringify?: boolean
+  skipLogCollisionStringify?: boolean
 }): Promise<SaltoError[]> => {
   const typeToElemIDtoInstances = await groupInstancesByTypeAndElemID(instances, getTypeName)
-  await logInstancesWithCollidingElemID(typeToElemIDtoInstances, skipCollisionStringify)
+  await logInstancesWithCollidingElemID(typeToElemIDtoInstances, skipLogCollisionStringify)
   return Promise.all(Object.entries(typeToElemIDtoInstances)
     .map(async ([type, elemIDtoInstances]) => {
       const numInstances = Object.values(elemIDtoInstances)

--- a/packages/adapter-utils/src/collisions.ts
+++ b/packages/adapter-utils/src/collisions.ts
@@ -73,7 +73,7 @@ const logInstancesWithCollidingElemID = async (
     const instancesCount = Object.values(elemIDtoInstances).flat().length
     log.debug(`Omitted ${instancesCount} instances of type ${type} due to Salto ID collisions`)
     Object.entries(elemIDtoInstances).forEach(([elemID, elemIDInstances]) => {
-      // For some reason safeJsonStringify is really slow, temporary we skip it by flag to stress test big envs
+      // SALTO-3059
       if (skipLogCollisionStringify) {
         log.debug(`Omitted instances of type ${type} with colliding ElemID ${elemID}`)
         return

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -66,6 +66,7 @@ export type ZendeskFetchConfig = configUtils.DuckTypeUserFetchConfig
     greedyAppReferences?: boolean
     appReferenceLocators?: IdLocator[]
     enableGuide?: boolean
+    skipCollisionStringify?: boolean
   }
 export type ZendeskApiConfig = configUtils.AdapterApiConfig<
   configUtils.DuckTypeTransformationConfig & { omitInactive?: boolean }

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -66,7 +66,6 @@ export type ZendeskFetchConfig = configUtils.DuckTypeUserFetchConfig
     greedyAppReferences?: boolean
     appReferenceLocators?: IdLocator[]
     enableGuide?: boolean
-    skipCollisionStringify?: boolean
   }
 export type ZendeskApiConfig = configUtils.AdapterApiConfig<
   configUtils.DuckTypeTransformationConfig & { omitInactive?: boolean }

--- a/packages/zendesk-adapter/src/filters/collision_errors.ts
+++ b/packages/zendesk-adapter/src/filters/collision_errors.ts
@@ -18,7 +18,7 @@ import { config as configUtils } from '@salto-io/adapter-components'
 import { getAndLogCollisionWarnings, getInstancesWithCollidingElemID } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../filter'
 import { ZENDESK } from '../constants'
-import { API_DEFINITIONS_CONFIG } from '../config'
+import { API_DEFINITIONS_CONFIG, FETCH_CONFIG } from '../config'
 
 /**
  * Adds collision warnings
@@ -37,6 +37,7 @@ const filterCreator: FilterCreator = ({ config }) => ({
         config[API_DEFINITIONS_CONFIG].typeDefaults.transformation,
       ).idFields,
       idFieldsName: 'idFields',
+      skipCollisionStringify: config[FETCH_CONFIG].skipCollisionStringify,
     })
     return { errors: collistionWarnings }
   },

--- a/packages/zendesk-adapter/src/filters/collision_errors.ts
+++ b/packages/zendesk-adapter/src/filters/collision_errors.ts
@@ -37,7 +37,7 @@ const filterCreator: FilterCreator = ({ config }) => ({
         config[API_DEFINITIONS_CONFIG].typeDefaults.transformation,
       ).idFields,
       idFieldsName: 'idFields',
-      skipCollisionStringify: config[FETCH_CONFIG].skipCollisionStringify,
+      skipLogCollisionStringify: config[FETCH_CONFIG].enableGuide,
     })
     return { errors: collistionWarnings }
   },

--- a/packages/zendesk-adapter/src/filters/collision_errors.ts
+++ b/packages/zendesk-adapter/src/filters/collision_errors.ts
@@ -37,7 +37,7 @@ const filterCreator: FilterCreator = ({ config }) => ({
         config[API_DEFINITIONS_CONFIG].typeDefaults.transformation,
       ).idFields,
       idFieldsName: 'idFields',
-      // Needed to skipsafeJsonStringify which takes a lot of tim (SALTO-3059)
+      // Needed because 'safeJsonStringify' is really slow, which causes problems with articles stress test (SALTO-3059)
       skipLogCollisionStringify: config[FETCH_CONFIG].enableGuide,
     })
     return { errors: collistionWarnings }

--- a/packages/zendesk-adapter/src/filters/collision_errors.ts
+++ b/packages/zendesk-adapter/src/filters/collision_errors.ts
@@ -37,6 +37,7 @@ const filterCreator: FilterCreator = ({ config }) => ({
         config[API_DEFINITIONS_CONFIG].typeDefaults.transformation,
       ).idFields,
       idFieldsName: 'idFields',
+      // Needed to skipsafeJsonStringify which takes a lot of tim (SALTO-3059)
       skipLogCollisionStringify: config[FETCH_CONFIG].enableGuide,
     })
     return { errors: collistionWarnings }


### PR DESCRIPTION
Added a flag to disable the log that stringifies elements values
It will be used to stress test environments with many articles, because for some reason that stringify is really really slow

---

None

---
_Release Notes_: 
None

---
_User Notifications_: 
None