### PR TITLE
Fix SDF deploy flag typo

### DIFF
--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -955,7 +955,7 @@ export default class SdfClient {
     await SdfClient.fixManifest(projectName, customizationInfos, additionalDependencies)
     try {
       const custCommandArguments = {
-        ...(type === 'AccountCustomization' ? { ccountspecificvalues: 'WARNING' } : {}),
+        ...(type === 'AccountCustomization' ? { accountspecificvalues: 'WARNING' } : {}),
         ...(validateOnly ? { server: true } : {}),
       }
       await this.executeProjectAction(

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -210,9 +210,23 @@ describe('sdf client', () => {
   const addDependenciesCommandMatcher = expect
     .objectContaining({ commandName: COMMANDS.ADD_PROJECT_DEPENDENCIES })
   const deployProjectCommandMatcher = expect
-    .objectContaining({ commandName: COMMANDS.DEPLOY_PROJECT })
+    .objectContaining({
+      commandName: COMMANDS.DEPLOY_PROJECT,
+      arguments: { accountspecificvalues: 'WARNING' },
+    })
+  const deploySuiteAppProjectCommandMatcher = expect
+    .objectContaining({
+      commandName: COMMANDS.DEPLOY_PROJECT,
+      arguments: {},
+    })
   const validateProjectCommandMatcher = expect
-    .objectContaining({ commandName: COMMANDS.VALIDATE_PROJECT })
+    .objectContaining({
+      commandName: COMMANDS.VALIDATE_PROJECT,
+      arguments: {
+        accountspecificvalues: 'WARNING',
+        server: true,
+      },
+    })
   const deleteAuthIdCommandMatcher = expect.objectContaining({
     commandName: COMMANDS.MANAGE_AUTH,
     arguments: expect.objectContaining({
@@ -1275,7 +1289,7 @@ describe('sdf client', () => {
         expect(mockExecuteAction).toHaveBeenNthCalledWith(1, createProjectCommandMatcher)
         expect(mockExecuteAction).toHaveBeenNthCalledWith(2, saveTokenCommandMatcher)
         expect(mockExecuteAction).toHaveBeenNthCalledWith(3, addDependenciesCommandMatcher)
-        expect(mockExecuteAction).toHaveBeenNthCalledWith(4, deployProjectCommandMatcher)
+        expect(mockExecuteAction).toHaveBeenNthCalledWith(4, deploySuiteAppProjectCommandMatcher)
       })
 
       it('should succeed for TemplateCustomTypeInfo', async () => {


### PR DESCRIPTION
Fix SDF deploy flag typo

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Fix pre-deploy error on ACCOUNT_SPECIFIC_VALUE

---
_User Notifications_: 
None