### PR TITLE
SALTO-3068 improve fields to omit filter

### DIFF
--- a/packages/netsuite-adapter/config_doc.md
+++ b/packages/netsuite-adapter/config_doc.md
@@ -31,7 +31,8 @@ netsuite {
       ]
     }
     fieldsToOmit = [{
-      type = "workflow_workflowstates_workflowstate"
+      type = "workflow"
+      subtype = "workflow_workflowstates_workflowstate"
       fields = [
         "positionx",
         "positiony",

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -299,6 +299,9 @@ const fieldsToOmitConfig = createMatchingObjectType<FieldToOmitParams>({
       refType: BuiltinTypes.STRING,
       annotations: { _required: true },
     },
+    subtype: {
+      refType: BuiltinTypes.STRING,
+    },
     fields: {
       refType: new ListType(BuiltinTypes.STRING),
       annotations: { _required: true },

--- a/packages/netsuite-adapter/src/filters/omit_fields.ts
+++ b/packages/netsuite-adapter/src/filters/omit_fields.ts
@@ -36,20 +36,24 @@ const filterCreator: FilterCreator = ({ config }): FilterWith<'onFetch'> => ({
       return
     }
 
+    const typeNames = elements.filter(isObjectType).map(elem => elem.elemID.name).concat(CUSTOM_FIELDS_LIST)
     const fieldsToOmitByType = Object.fromEntries(
-      elements.filter(isObjectType).map(elem => elem.elemID.name).concat(CUSTOM_FIELDS_LIST)
-        .map((typeName: string): [string, string[]] => [
-          typeName,
-          fieldsToOmit
-            .filter(params => isFullRegexMatch(typeName, params.type))
-            .flatMap(params => params.fields),
-        ])
-        .filter(([_t, fields]) => fields.length > 0)
+      typeNames.map((typeName: string): [string, string[]] => [
+        typeName,
+        fieldsToOmit
+          .filter(({ type, subtype }) => isFullRegexMatch(typeName, subtype !== undefined ? subtype : type))
+          .flatMap(params => params.fields),
+      ]).filter(([_t, fields]) => fields.length > 0)
     )
 
     if (_.isEmpty(fieldsToOmitByType)) {
       return
     }
+
+    const typesForDeepTransformation = new Set(
+      typeNames.filter(typeName => fieldsToOmit
+        .some(({ type, subtype }) => subtype !== undefined && isFullRegexMatch(typeName, type)))
+    )
 
     const omitValues = (value: Values, typeName: string): Values => (
       typeName in fieldsToOmitByType
@@ -72,12 +76,15 @@ const filterCreator: FilterCreator = ({ config }): FilterWith<'onFetch'> => ({
     await awu(elements)
       .filter(isInstanceElement)
       .forEach(async instance => {
-        instance.value = await transformValues({
-          values: omitValues(instance.value, instance.elemID.typeName),
-          type: await instance.getType(),
-          transformFunc,
-          strict: false,
-        }) ?? {}
+        instance.value = omitValues(instance.value, instance.elemID.typeName)
+        if (typesForDeepTransformation.has(instance.elemID.typeName)) {
+          instance.value = await transformValues({
+            values: instance.value,
+            type: await instance.getType(),
+            transformFunc,
+            strict: false,
+          }) ?? {}
+        }
       })
 
     await awu(elements)
@@ -85,11 +92,13 @@ const filterCreator: FilterCreator = ({ config }): FilterWith<'onFetch'> => ({
       .filter(isCustomRecordType)
       .forEach(async type => {
         type.annotations = omitValues(type.annotations, CUSTOM_RECORD_TYPE)
-        type.annotations = await transformElementAnnotations({
-          element: type,
-          transformFunc,
-          strict: false,
-        })
+        if (typesForDeepTransformation.has(CUSTOM_RECORD_TYPE)) {
+          type.annotations = await transformElementAnnotations({
+            element: type,
+            transformFunc,
+            strict: false,
+          })
+        }
         Object.values(type.fields).forEach(field => {
           field.annotations = omitValues(field.annotations, CUSTOM_FIELDS_LIST)
         })

--- a/packages/netsuite-adapter/src/query.ts
+++ b/packages/netsuite-adapter/src/query.ts
@@ -50,6 +50,7 @@ export type QueryParams = {
 
 export type FieldToOmitParams = {
   type: string
+  subtype?: string
   fields: string[]
 }
 
@@ -202,6 +203,10 @@ export const validateFieldsToOmitConfig = (fieldsToOmitConfig: unknown): void =>
   if (corruptedTypes.length !== 0) {
     throw new Error(`${ERROR_MESSAGE_PREFIX} Expected "type" field to be a string, but found:\n${JSON.stringify(corruptedTypes, null, 4)}.`)
   }
+  const corruptedSubtypes = fieldsToOmitConfig.filter(obj => obj.subtype !== undefined && typeof obj.subtype !== 'string')
+  if (corruptedSubtypes.length !== 0) {
+    throw new Error(`${ERROR_MESSAGE_PREFIX} Expected "subtype" field to be a string, but found:\n${JSON.stringify(corruptedSubtypes, null, 4)}.`)
+  }
   const corruptedFields = fieldsToOmitConfig.filter(
     obj => !Array.isArray(obj.fields)
     || obj.fields.length === 0
@@ -211,7 +216,7 @@ export const validateFieldsToOmitConfig = (fieldsToOmitConfig: unknown): void =>
     throw new Error(`${ERROR_MESSAGE_PREFIX} Expected "fields" field to be an array of strings, but found:\n${JSON.stringify(corruptedFields, null, 4)}.`)
   }
   const invalidRegexes = fieldsToOmitConfig
-    .flatMap(obj => [obj.type, ...obj.fields])
+    .flatMap(obj => [obj.type, ...(obj.subtype ? [obj.subtype] : []), ...obj.fields])
     .filter(reg => !regex.isValidRegex(reg))
   if (invalidRegexes.length !== 0) {
     throw new Error(`${ERROR_MESSAGE_PREFIX} The following regular expressions are invalid:\n${JSON.stringify(invalidRegexes, null, 4)}.`)

--- a/packages/netsuite-adapter/test/filters/omit_fields.test.ts
+++ b/packages/netsuite-adapter/test/filters/omit_fields.test.ts
@@ -77,7 +77,7 @@ describe('omit fields filter', () => {
   it('should omit fields in inner type', async () => {
     await filterCreator({
       ...defaultOpts,
-      config: { fetch: { fieldsToOmit: [{ type: 'inner.*', fields: ['.*2'] }] } },
+      config: { fetch: { fieldsToOmit: [{ type: 'some.*', subtype: 'inner.*', fields: ['.*2'] }] } },
     }).onFetch?.([instance, type, innerType])
     expect(instance.value).toEqual({
       field1: true,
@@ -103,6 +103,7 @@ describe('omit fields filter', () => {
       annotationRefsOrTypes: await toAnnotationRefTypes(customrecordtype),
       annotations: {
         scriptid: 'customrecord1',
+        istoplevel: true,
         permissions: {
           permission: [
             {
@@ -129,7 +130,7 @@ describe('omit fields filter', () => {
         fetch: {
           fieldsToOmit: [
             { type: 'customrecordtype', fields: ['links'] },
-            { type: 'customrecordtype_permissions_permission', fields: ['.*level'] },
+            { type: 'customrecordtype', subtype: 'customrecordtype_permissions_permission', fields: ['.*level'] },
             { type: 'customrecordcustomfield', fields: ['is.*'] },
           ],
         },
@@ -137,6 +138,8 @@ describe('omit fields filter', () => {
     }).onFetch?.([customrecordtype, customRecordObjectType, ...Object.values(customrecordInnerTypes)])
     expect(customRecordObjectType.annotations).toEqual({
       scriptid: 'customrecord1',
+      // used to verify that a field that match 'type' but doesn't match the 'subtype' is not omitted
+      istoplevel: true,
       permissions: {
         permission: [
           {

--- a/packages/netsuite-adapter/test/query.test.ts
+++ b/packages/netsuite-adapter/test/query.test.ts
@@ -425,6 +425,9 @@ describe('NetsuiteQuery', () => {
       expect(() => {
         validateFieldsToOmitConfig([{ type: 'a', fields: ['b'] }])
       }).not.toThrow()
+      expect(() => {
+        validateFieldsToOmitConfig([{ type: 'a', subtype: 'c', fields: ['b'] }])
+      }).not.toThrow()
     })
     it('should throw an error when input is not an array', () => {
       expect(() => {
@@ -435,6 +438,11 @@ describe('NetsuiteQuery', () => {
       expect(() => {
         validateFieldsToOmitConfig([{ type: { name: 'a' }, fields: ['b'] }])
       }).toThrow('Expected "type" field to be a string')
+    })
+    it('should throw an error when "subtype" field is not a string', () => {
+      expect(() => {
+        validateFieldsToOmitConfig([{ type: 'a', subtype: { name: 'c' }, fields: ['b'] }])
+      }).toThrow('Expected "subtype" field to be a string')
     })
     it('should throw an error when "fields" field is not an array', () => {
       expect(() => {
@@ -449,6 +457,9 @@ describe('NetsuiteQuery', () => {
     it('should throw an error when regexes are invalid', () => {
       expect(() => {
         validateFieldsToOmitConfig([{ type: 'aa(a.*', fields: ['bb(b.*'] }])
+      }).toThrow('The following regular expressions are invalid')
+      expect(() => {
+        validateFieldsToOmitConfig([{ type: 'aaa.*', subtype: 'cc(c.*', fields: ['bbb.*'] }])
       }).toThrow('The following regular expressions are invalid')
     })
   })


### PR DESCRIPTION
add `subtype` to `fieldsToOmit` config so we only run `transformValues` for elements that the type property match their type name.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- improve fields to omit filter

---
_User Notifications_: 
Netsuite Adapter:
- use the following config to omit nested values in instances:
```
fieldsToOmit = [{
  type = "workflow"
  subtype = "workflow_workflowstates_workflowstate"
  fields = [
    "positionx",
    "positiony",
  ]
}]
```