### PR TITLE
SALTO-3072 support multiple parameters in dependsOn configuration in simple adapters

### DIFF
--- a/packages/adapter-components/src/elements/request_parameters.ts
+++ b/packages/adapter-components/src/elements/request_parameters.ts
@@ -17,9 +17,11 @@ import _ from 'lodash'
 import { Element, Values, isInstanceElement, isPrimitiveValue, InstanceElement } from '@salto-io/adapter-api'
 import { resolvePath, safeJsonStringify } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
+import { values as lowerdashValues } from '@salto-io/lowerdash'
 import { ClientGetWithPaginationParams } from '../client'
 import { FetchRequestConfig, ARG_PLACEHOLDER_MATCHER, UrlParams } from '../config/request'
 
+const { isDefined } = lowerdashValues
 const log = logger(module)
 
 const FIELD_PATH_DELIMITER = '.'
@@ -70,24 +72,31 @@ const computeDependsOnURLs = (
     throw new Error(`cannot resolve endpoint ${url} - missing context`)
   }
 
-  if (urlParams.length > 1) {
-    // not needed yet (when it is, we will need to decide which combinations to use)
-    throw new Error(`too many variables in endpoint ${url}`)
-  }
-  const argName = urlParams[0].slice(1, -1)
-  const referenceDetails = dependsOn.find(({ pathParam }) => pathParam === argName)
-  if (referenceDetails === undefined) {
-    log.error('could not resolve path param %s in url %s with dependsOn config %s', argName, url, safeJsonStringify(dependsOn))
-    throw new Error(`could not resolve path param ${argName} in url ${url}`)
-  }
-  const contextInstances = (contextElements[referenceDetails.from.type] ?? []).filter(
-    isInstanceElement
-  )
-  if (contextInstances.length === 0) {
-    throw new Error(`no instances found for ${referenceDetails.from.type}, cannot call endpoint ${url}`)
-  }
-  const potentialParams = contextInstances.map(e => e.value[referenceDetails.from.field])
-  return _.uniq(potentialParams.map(p => url.replace(ARG_PLACEHOLDER_MATCHER, p)))
+  const potentialParamsByArg = urlParams.map(urlParam => {
+    const argName = urlParam.slice(1, -1)
+    const referenceDetails = dependsOn.find(({ pathParam }) => pathParam === argName)
+    if (referenceDetails === undefined) {
+      log.error('could not resolve path param %s in url %s with dependsOn config %s', argName, url, safeJsonStringify(dependsOn))
+      throw new Error(`could not resolve path param ${argName} in url ${url}`)
+    }
+    const contextInstances = (contextElements[referenceDetails.from.type] ?? []).filter(
+      isInstanceElement
+    )
+    if (contextInstances.length === 0) {
+      throw new Error(`no instances found for ${referenceDetails.from.type}, cannot call endpoint ${url}`)
+    }
+    const potentialParams = contextInstances
+      .map(e => e.value[referenceDetails.from.field])
+      .filter(isDefined)
+      .map(_.toString)
+    return _.uniq(potentialParams).map(val => ({ [urlParam]: val }))
+  })
+
+  const allArgCombinations = potentialParamsByArg.reduce((acc, potentialParams) => acc.flatMap(
+    combo => potentialParams.map(param => ({ ...combo, ...param }))
+  ))
+
+  return allArgCombinations.map(p => url.replace(ARG_PLACEHOLDER_MATCHER, match => p[match]))
 }
 
 export const replaceUrlParams = (url: string, paramValues: Record<string, unknown>): string =>

--- a/packages/adapter-components/test/elements/request_parameters.test.ts
+++ b/packages/adapter-components/test/elements/request_parameters.test.ts
@@ -146,7 +146,111 @@ describe('request_parameters', () => {
         },
       ])
     })
-
+    it('should create all combinations if url contains more than one id', () => {
+      const Pet = new ObjectType({ elemID: new ElemID('bla', 'Pet') })
+      const Owner = new ObjectType({ elemID: new ElemID('bla', 'Owner') })
+      const Food = new ObjectType({ elemID: new ElemID('bla', 'Food') })
+      expect(computeGetArgs(
+        {
+          url: '/a/b/{owner_id}/{pet_id}/{food_id}',
+          dependsOn: [
+            { pathParam: 'pet_id', from: { type: 'Pet', field: 'id' } },
+            { pathParam: 'food_id', from: { type: 'Food', field: 'id' } },
+            { pathParam: 'owner_id', from: { type: 'Owner', field: 'id' } },
+          ],
+        },
+        {
+          Pet: [
+            new InstanceElement('dog', Pet, { id: 'dogID' }),
+            new InstanceElement('cat', Pet, { id: 'catID' }),
+            new InstanceElement('cat', Pet, { id: 'catID' }),
+            new InstanceElement('dog', Pet, { id: 'dogID' }),
+          ],
+          Owner: [
+            new InstanceElement('o1', Owner, { id: 'o1' }),
+            new InstanceElement('o2', Owner, { id: 'o2' }),
+            new InstanceElement('o3', Owner, { id: 'o3' }),
+          ],
+          Food: [
+            new InstanceElement('bamba', Food, { id: 'bamba' }),
+            new InstanceElement('bissli', Food, { id: 'bissli' }),
+          ],
+        },
+      )).toEqual([
+        {
+          url: '/a/b/o1/dogID/bamba',
+          paginationField: undefined,
+          queryParams: undefined,
+          recursiveQueryParams: undefined,
+        },
+        {
+          url: '/a/b/o1/dogID/bissli',
+          paginationField: undefined,
+          queryParams: undefined,
+          recursiveQueryParams: undefined,
+        },
+        {
+          url: '/a/b/o1/catID/bamba',
+          paginationField: undefined,
+          queryParams: undefined,
+          recursiveQueryParams: undefined,
+        },
+        {
+          url: '/a/b/o1/catID/bissli',
+          paginationField: undefined,
+          queryParams: undefined,
+          recursiveQueryParams: undefined,
+        },
+        {
+          url: '/a/b/o2/dogID/bamba',
+          paginationField: undefined,
+          queryParams: undefined,
+          recursiveQueryParams: undefined,
+        },
+        {
+          url: '/a/b/o2/dogID/bissli',
+          paginationField: undefined,
+          queryParams: undefined,
+          recursiveQueryParams: undefined,
+        },
+        {
+          url: '/a/b/o2/catID/bamba',
+          paginationField: undefined,
+          queryParams: undefined,
+          recursiveQueryParams: undefined,
+        },
+        {
+          url: '/a/b/o2/catID/bissli',
+          paginationField: undefined,
+          queryParams: undefined,
+          recursiveQueryParams: undefined,
+        },
+        {
+          url: '/a/b/o3/dogID/bamba',
+          paginationField: undefined,
+          queryParams: undefined,
+          recursiveQueryParams: undefined,
+        },
+        {
+          url: '/a/b/o3/dogID/bissli',
+          paginationField: undefined,
+          queryParams: undefined,
+          recursiveQueryParams: undefined,
+        },
+        {
+          url: '/a/b/o3/catID/bamba',
+          paginationField: undefined,
+          queryParams: undefined,
+          recursiveQueryParams: undefined,
+        },
+        {
+          url: '/a/b/o3/catID/bissli',
+          paginationField: undefined,
+          queryParams: undefined,
+          recursiveQueryParams: undefined,
+        },
+      ])
+    })
     it('should fail if no context is provided', () => {
       expect(() => computeGetArgs(
         {
@@ -180,18 +284,6 @@ describe('request_parameters', () => {
         },
         {},
       )).toThrow(new Error('invalid endpoint definition /a/b/{pet_id'))
-    })
-    it('should fail if url contains too many arguments', () => {
-      expect(() => computeGetArgs(
-        {
-          url: '/a/b/{pet_id}/{another_id}',
-          dependsOn: [
-            { pathParam: 'pet_id', from: { type: 'Pet', field: 'id' } },
-            { pathParam: 'another_id', from: { type: 'Pet', field: 'id' } },
-          ],
-        },
-        {},
-      )).toThrow(new Error('too many variables in endpoint /a/b/{pet_id}/{another_id}'))
     })
     it('should fail if argument definition is not found in dependsOn', () => {
       expect(() => computeGetArgs(


### PR DESCRIPTION
The `dependsOn` config allows making requests that depend on earlier responses - e.g. making requests to `/workflows/{workflow_id}/export` where `workflow_id` are the resulting ids of earlier queries.
Until now we supported one parameter per URL - now we will be able to query all combinations of multiple parameters, e.g. make requests for `/api/v2/help_center{/locale}/sections/{section_id}/articles` that combine all possible values of locale + section id.

---

_Release Notes_: 
None (not user facing)

---
_User Notifications_: 
None