### PR TITLE
SALTO-3027: add notificationScheme plugin urls

### DIFF
--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -870,11 +870,6 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
         { fieldName: 'notifications', fieldType: 'List<PermissionHolder>' },
       ],
     },
-    // jspRequests: {
-    //   add: '/secure/admin/AddNotification.jspa',
-    //   remove: '/secure/admin/DeleteNotification.jspa',
-    //   query: '/rest/api/3/notificationscheme/{id}?expand=all',
-    // },
   },
   PageBeanIssueTypeScreenSchemesProjects: {
     request: {

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -862,11 +862,6 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       fieldsToHide: [{ fieldName: 'id' }],
       serviceUrl: '/secure/admin/EditNotifications!default.jspa?schemeId={id}',
     },
-    jspRequests: {
-      add: '/secure/admin/AddNotificationScheme.jspa',
-      modify: '/secure/admin/EditNotificationScheme.jspa',
-      remove: '/secure/admin/DeleteNotificationScheme.jspa',
-    },
   },
   NotificationSchemeEvent: {
     transformation: {
@@ -875,11 +870,11 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
         { fieldName: 'notifications', fieldType: 'List<PermissionHolder>' },
       ],
     },
-    jspRequests: {
-      add: '/secure/admin/AddNotification.jspa',
-      remove: '/secure/admin/DeleteNotification.jspa',
-      query: '/rest/api/3/notificationscheme/{id}?expand=all',
-    },
+    // jspRequests: {
+    //   add: '/secure/admin/AddNotification.jspa',
+    //   remove: '/secure/admin/DeleteNotification.jspa',
+    //   query: '/rest/api/3/notificationscheme/{id}?expand=all',
+    // },
   },
   PageBeanIssueTypeScreenSchemesProjects: {
     request: {

--- a/packages/jira-adapter/src/filters/notification_scheme/notification_scheme_deployment.ts
+++ b/packages/jira-adapter/src/filters/notification_scheme/notification_scheme_deployment.ts
@@ -54,6 +54,15 @@ const filter: FilterCreator = ({ client, config, paginator }) => ({
   },
 
   deploy: async changes => {
+    if (client.isDataCenter) {
+      return {
+        leftoverChanges: changes,
+        deployResult: {
+          appliedChanges: [],
+          errors: [],
+        },
+      }
+    }
     const [relevantChanges, leftoverChanges] = _.partition(
       changes,
       change => isInstanceChange(change)
@@ -115,6 +124,9 @@ const filter: FilterCreator = ({ client, config, paginator }) => ({
   },
 
   preDeploy: async changes => {
+    if (client.isDataCenter) {
+      return
+    }
     changes
       .filter(isInstanceChange)
       .filter(isRemovalOrModificationChange)
@@ -126,6 +138,9 @@ const filter: FilterCreator = ({ client, config, paginator }) => ({
   },
 
   onDeploy: async changes => {
+    if (client.isDataCenter) {
+      return
+    }
     changes
       .filter(isInstanceChange)
       .filter(isRemovalOrModificationChange)

--- a/packages/jira-adapter/src/product_settings/cloud.ts
+++ b/packages/jira-adapter/src/product_settings/cloud.ts
@@ -115,6 +115,29 @@ const CLOUD_DEFAULT_API_DEFINITIONS: Partial<JiraApiConfig> = {
         ],
       },
     },
+    NotificationScheme: {
+      request: {
+        url: '/rest/api/3/project/{projectId}/notificationscheme',
+      },
+      jspRequests: {
+        add: '/secure/admin/AddNotificationScheme.jspa',
+        modify: '/secure/admin/EditNotificationScheme.jspa',
+        remove: '/secure/admin/DeleteNotificationScheme.jspa',
+      },
+    },
+    NotificationSchemeEvent: {
+      transformation: {
+        fieldTypeOverrides: [
+          { fieldName: 'eventType', fieldType: 'number' },
+          { fieldName: 'notifications', fieldType: 'List<PermissionHolder>' },
+        ],
+      },
+      jspRequests: {
+        add: '/secure/admin/AddNotification.jspa',
+        remove: '/secure/admin/DeleteNotification.jspa',
+        query: '/rest/api/3/notificationscheme/{id}?expand=all',
+      },
+    },
   },
 }
 

--- a/packages/jira-adapter/src/product_settings/data_center/api_config.ts
+++ b/packages/jira-adapter/src/product_settings/data_center/api_config.ts
@@ -140,6 +140,22 @@ export const DC_DEFAULT_API_DEFINITIONS: Partial<JiraApiConfig> = {
         dataField: '.',
       },
     },
+    NotificationScheme: {
+      deployRequests: {
+        add: {
+          url: '/rest/api/3/notificationscheme',
+          method: 'post',
+        },
+        modify: {
+          url: '/rest/api/3/notificationscheme/{id}',
+          method: 'put',
+        },
+        remove: {
+          url: '/rest/api/3/notificationscheme/{id}',
+          method: 'delete',
+        },
+      },
+    },
     SecurityLevel: {
       deployRequests: {
         add: {

--- a/packages/jira-adapter/src/product_settings/data_center/data_center.ts
+++ b/packages/jira-adapter/src/product_settings/data_center/data_center.ts
@@ -297,7 +297,7 @@ const PLUGIN_URL_PATTERNS: UrlPattern[] = [
   },
   {
     httpMethods: ['put', 'delete'],
-    url: '/rest/api/3/notificationscheme/\\d+',
+    url: '/rest/api/3/notificationscheme/.+',
   },
   {
     httpMethods: ['post'],

--- a/packages/jira-adapter/src/product_settings/data_center/data_center.ts
+++ b/packages/jira-adapter/src/product_settings/data_center/data_center.ts
@@ -293,6 +293,14 @@ const PLUGIN_URL_PATTERNS: UrlPattern[] = [
   },
   {
     httpMethods: ['post'],
+    url: '/rest/api/3/notificationscheme',
+  },
+  {
+    httpMethods: ['put', 'delete'],
+    url: '/rest/api/3/notificationscheme/\\d+',
+  },
+  {
+    httpMethods: ['post'],
     url: '/rest/api/3/resolution',
   },
   {


### PR DESCRIPTION
_add notificationScheme plugin urls_

---

* few modifications to make Jira DC not using JSP calls when deploying notification schemes

* link to the plugin PR [here](https://github.com/salto-io/jira-dc-app/pull/45)

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
