### PR TITLE
SALTO-3031_NodeSkippedError_does_not_contain_the_skipped_node

### DIFF
--- a/packages/core/src/core/deploy/deploy_actions.ts
+++ b/packages/core/src/core/deploy/deploy_actions.ts
@@ -142,8 +142,10 @@ export const deployActions = async (
         const item = deployPlan.getItem(key) as PlanItem
         if (nodeError instanceof NodeSkippedError) {
           reportProgress(item, 'cancelled', deployPlan.getItem(nodeError.causingNode).groupKey)
+          deployErrors.push(new DeployError(item.groupKey, `Element ${key} was not deployed, as it depends on element ${nodeError.causingNode} which failed to deploy`))
+        } else {
+          deployErrors.push(new DeployError(item.groupKey, nodeError.message))
         }
-        deployErrors.push(new DeployError(item.groupKey, nodeError.message))
       })
       if (error.circularDependencyError) {
         error.circularDependencyError.causingNodeIds.forEach((id: PlanItemId) => {


### PR DESCRIPTION
Make NodeSkippedError to contains the skipped node

---
Please see [ticket](https://salto-io.atlassian.net/jira/software/c/projects/SALTO/issues/SALTO-3031?filter=myopenissues)
As I implement this messaging ticket, I see that the error is thrown from dag package which is a graph package that isn't necessarily in deploy context. So I decided to add the parent of skipped node to NodeSkippedError type, and use it to re-messaging the error on deployActions. WDYT?

---
_Release Notes_: 
None

---
_User Notifications_: 
None