### PR TITLE
SALTO-2816 SALTO-2820 SALTO-2822 SALTO-2823 create missing queues and emailTemplate references in cloud service objects

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -76,7 +76,6 @@ import enumFieldPermissionsFilter from './filters/field_permissions_enum'
 import splitCustomLabels from './filters/split_custom_labels'
 import customMetadataTypeFilter from './filters/custom_metadata_type'
 import fetchFlowsFilter from './filters/fetch_flows'
-import customLabelReferenceFilter from './filters/custom_label_referenece'
 import { FetchElements, SalesforceConfig } from './types'
 import { getConfigFromConfigChanges } from './config_change'
 import { LocalFilterCreator, Filter, FilterResult, RemoteFilterCreator, LocalFilterCreatorDefinition, RemoteFilterCreatorDefinition } from './filter'
@@ -144,7 +143,6 @@ export const allFilters: Array<LocalFilterCreatorDefinition | RemoteFilterCreato
   { creator: customMetadataTypeFilter },
   { creator: xmlAttributesFilter },
   { creator: minifyDeployFilter },
-  { creator: customLabelReferenceFilter },
   // The following filters should remain last in order to make sure they fix all elements
   { creator: convertListsFilter },
   { creator: convertTypeFilter },

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -76,6 +76,7 @@ import enumFieldPermissionsFilter from './filters/field_permissions_enum'
 import splitCustomLabels from './filters/split_custom_labels'
 import customMetadataTypeFilter from './filters/custom_metadata_type'
 import fetchFlowsFilter from './filters/fetch_flows'
+import customLabelReferenceFilter from './filters/custom_label_referenece'
 import { FetchElements, SalesforceConfig } from './types'
 import { getConfigFromConfigChanges } from './config_change'
 import { LocalFilterCreator, Filter, FilterResult, RemoteFilterCreator, LocalFilterCreatorDefinition, RemoteFilterCreatorDefinition } from './filter'
@@ -143,6 +144,7 @@ export const allFilters: Array<LocalFilterCreatorDefinition | RemoteFilterCreato
   { creator: customMetadataTypeFilter },
   { creator: xmlAttributesFilter },
   { creator: minifyDeployFilter },
+  { creator: customLabelReferenceFilter },
   // The following filters should remain last in order to make sure they fix all elements
   { creator: convertListsFilter },
   { creator: convertTypeFilter },

--- a/packages/salesforce-adapter/src/filters/field_references.ts
+++ b/packages/salesforce-adapter/src/filters/field_references.ts
@@ -94,6 +94,10 @@ const contextStrategyLookup: Record<
   neighborPicklistObjectLookup: neighborContextFunc({ contextFieldName: 'picklistObject' }),
   neighborSharedToTypeLookup: neighborContextFunc({ contextFieldName: 'sharedToType', contextValueMapper: shareToMapper }),
   neighborTableLookup: neighborContextFunc({ contextFieldName: 'table' }),
+  neighborCaseOwnerTypeLookup: neighborContextFunc({ contextFieldName: 'caseOwnerType' }),
+  neighborAssignedToTypeLookup: neighborContextFunc({ contextFieldName: 'assignedToType' }),
+  neighborRelatedEntityTypeLookup: neighborContextFunc({ contextFieldName: 'relatedEntityType' }),
+
 }
 
 

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -113,6 +113,7 @@ export type ReferenceContextStrategyName = (
   | 'neighborLookupValueTypeLookup' | 'neighborObjectLookup' | 'neighborPicklistObjectLookup'
   | 'neighborTypeLookup' | 'neighborActionTypeFlowLookup' | 'neighborActionTypeLookup' | 'parentObjectLookup'
   | 'parentInputObjectLookup' | 'parentOutputObjectLookup' | 'neighborSharedToTypeLookup' | 'neighborTableLookup'
+  | 'neighborCaseOwnerTypeLookup' | 'neighborAssignedToTypeLookup' | 'neighborRelatedEntityTypeLookup'
 )
 
 type SourceDef = {
@@ -547,6 +548,43 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
   {
     src: { field: 'column', parentTypes: ['ReportFilterItem', 'DashboardFilterColumn', 'DashboardTableColumn'] },
     target: { type: CUSTOM_FIELD },
+  },
+  {
+    src: { field: 'caseOwner', parentTypes: ['EmailToCaseRoutingAddress'] },
+    target: { typeContext: 'neighborCaseOwnerTypeLookup' },
+  },
+  {
+    src: { field: 'assignedTo', parentTypes: ['RuleEntry', 'EscalationAction'] },
+    target: { typeContext: 'neighborAssignedToTypeLookup' },
+  },
+  {
+    src: { field: 'assignedToTemplate', parentTypes: ['EscalationAction'] },
+    target: { type: 'EmailTemplate' },
+  },
+  {
+    src: { field: 'caseAssignNotificationTemplate', parentTypes: ['CaseSettings'] },
+    target: { type: 'EmailTemplate' },
+  },
+  {
+    src: { field: 'caseCloseNotificationTemplate', parentTypes: ['CaseSettings'] },
+    target: { type: 'EmailTemplate' },
+  },
+  {
+    src: { field: 'caseCommentNotificationTemplate', parentTypes: ['CaseSettings'] },
+    target: { type: 'EmailTemplate' },
+  },
+  {
+    src: { field: 'caseCreateNotificationTemplate', parentTypes: ['CaseSettings'] },
+    target: { type: 'EmailTemplate' },
+  },
+  {
+    src: { field: 'relatedEntityType', parentTypes: ['ServiceChannel'] },
+    target: { type: CUSTOM_OBJECT },
+  },
+  {
+    src: { field: 'secondaryRoutingPriorityField', parentTypes: ['ServiceChannel'] },
+    serializationStrategy: 'relativeApiName',
+    target: { parentContext: 'neighborRelatedEntityTypeLookup', type: CUSTOM_FIELD },
   },
 ]
 


### PR DESCRIPTION
_create missing queues and emailTemplate references in cloud service objects_

---
_Additional context for reviewer_:
None

---
_Release Notes_: 
Salesforce-adapter:

* create missing queues and emailTemplate references in cloud service objects
---

_User Notifications_: 
Salesforce-adapter:

* create missing queues and emailTemplate references in cloud service objects
