### PR TITLE
SALTO-3074 Edit Zendesk article_attachment elem name

### DIFF
--- a/packages/zendesk-adapter/src/filters/article/utils.ts
+++ b/packages/zendesk-adapter/src/filters/article/utils.ts
@@ -25,7 +25,7 @@ import {
 } from '@salto-io/adapter-api'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
 import ZendeskClient from '../../client/client'
-import { ARTICLE_ATTACHMENT_TYPE_NAME, ZENDESK } from '../../constants'
+import { ARTICLE_ATTACHMENT_TYPE_NAME, ARTICLE_TYPE_NAME, ZENDESK } from '../../constants'
 import { getZendeskError } from '../../errors'
 import { ZendeskApiConfig } from '../../config'
 import { prepRef } from './article_body'
@@ -87,15 +87,28 @@ const createAttachmentInstance = ({
     brand: article.value.brand,
   }
 
-  const name = generateInstanceNameFromConfig(attachmentValues, ARTICLE_ATTACHMENT_TYPE_NAME, apiDefinitions)
-  const naclName = naclCase(name)
-  const pathName = pathNaclCase(naclName)
+  const articleRef = new ReferenceExpression(article.elemID, article)
+  const configInstanceName = generateInstanceNameFromConfig(
+    attachmentValues,
+    ARTICLE_ATTACHMENT_TYPE_NAME,
+    apiDefinitions,
+  )
+  const parentConfigInstanceName = generateInstanceNameFromConfig(
+    article.value,
+    ARTICLE_TYPE_NAME,
+    apiDefinitions,
+  )
+  const tempName = parentConfigInstanceName
+    ? parentConfigInstanceName.concat(`__${configInstanceName}`)
+    : configInstanceName
+  const tempNaclName = naclCase(tempName)
+  const tempPathName = pathNaclCase(tempNaclName)
   return new InstanceElement(
-    naclName,
+    tempNaclName,
     attachmentType,
     attachmentValues,
-    [ZENDESK, RECORDS_PATH, ARTICLE_ATTACHMENT_TYPE_NAME, pathName],
-    { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(article.elemID, article)] },
+    [ZENDESK, RECORDS_PATH, ARTICLE_ATTACHMENT_TYPE_NAME, tempPathName],
+    { [CORE_ANNOTATIONS.PARENT]: [articleRef] },
   )
 }
 

--- a/packages/zendesk-adapter/src/filters/article/utils.ts
+++ b/packages/zendesk-adapter/src/filters/article/utils.ts
@@ -98,6 +98,7 @@ const createAttachmentInstance = ({
     ARTICLE_TYPE_NAME,
     apiDefinitions,
   )
+  // Eventually the element name and path of article_attachment is changed due to it extends the parend id
   const tempName = parentConfigInstanceName
     ? parentConfigInstanceName.concat(`__${configInstanceName}`)
     : configInstanceName

--- a/packages/zendesk-adapter/src/filters/article/utils.ts
+++ b/packages/zendesk-adapter/src/filters/article/utils.ts
@@ -99,7 +99,8 @@ const createAttachmentInstance = ({
     apiDefinitions,
   )
   // Eventually the element name and path of article_attachment is changed due to it extends the parend id
-  const tempName = parentConfigInstanceName
+  const tempName = (parentConfigInstanceName
+    && apiDefinitions.types[ARTICLE_ATTACHMENT_TYPE_NAME].transformation?.extendsParentId)
     ? parentConfigInstanceName.concat(`__${configInstanceName}`)
     : configInstanceName
   const tempNaclName = naclCase(tempName)

--- a/packages/zendesk-adapter/test/filters/article/article.test.ts
+++ b/packages/zendesk-adapter/test/filters/article/article.test.ts
@@ -288,17 +288,17 @@ describe('article filter', () => {
         .toEqual([
           'zendesk.article.instance.articleWithAttachment',
           'zendesk.article_attachment',
-          'zendesk.article_attachment.instance.attachmentFileName_png_false@vu',
+          'zendesk.article_attachment.instance.12345_title__attachmentFileName_png_false@uuuvu',
         ])
       const fetchedAttachment = clonedElements
         .filter(isInstanceElement)
-        .find(i => i.elemID.name === 'attachmentFileName_png_false@vu')
+        .find(i => i.elemID.name === '12345_title__attachmentFileName_png_false@uuuvu')
       expect(fetchedAttachment?.value).toEqual(articleAttachmentInstance.value)
       const fetchedArticle = clonedElements
         .filter(isInstanceElement)
         .find(i => i.elemID.name === 'articleWithAttachment')
       expect(fetchedArticle?.value.attachments).toHaveLength(1)
-      expect(fetchedArticle?.value.attachments[0].elemID.name).toBe('attachmentFileName_png_false@vu')
+      expect(fetchedArticle?.value.attachments[0].elemID.name).toBe('12345_title__attachmentFileName_png_false@uuuvu')
     })
   })
 


### PR DESCRIPTION
This PR fix the bug where Zendesk drops article_attachment instances although their elemIDs are different

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
