### PR TITLE
SALTO-2964, SALTO-3071-Replace enableGuide flag with object & Allow limit guide for specific brands (Zendesk Guide)

### DIFF
--- a/packages/zendesk-adapter/e2e_test/adapter.test.ts
+++ b/packages/zendesk-adapter/e2e_test/adapter.test.ts
@@ -178,7 +178,9 @@ const usedConfig = {
       { type: '.*' },
     ],
     exclude: [],
-    enableGuide: true,
+    guide: {
+      brands: ['.*'],
+    },
   },
   [API_DEFINITIONS_CONFIG]: {
     ...DEFAULT_CONFIG[API_DEFINITIONS_CONFIG],

--- a/packages/zendesk-adapter/e2e_test/adapter.test.ts
+++ b/packages/zendesk-adapter/e2e_test/adapter.test.ts
@@ -921,7 +921,9 @@ describe('Zendesk adapter E2E', () => {
               { type: '.*' },
             ],
             exclude: [],
-            enableGuide: true,
+            guide: {
+              brands: ['.*'],
+            },
           },
           [API_DEFINITIONS_CONFIG]: {
             ...DEFAULT_CONFIG[API_DEFINITIONS_CONFIG],

--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -36,7 +36,7 @@ import {
   ZendeskConfig,
   CLIENT_CONFIG,
   GUIDE_TYPES_TO_HANDLE_BY_BRAND,
-  GUIDE_BRAND_SPECIFIC_TYPES, GUIDE_SUPPORTED_TYPES, ZendeskFetchConfig,
+  GUIDE_BRAND_SPECIFIC_TYPES, GUIDE_SUPPORTED_TYPES, ZendeskFetchConfig, isGuideEnabled,
 } from './config'
 import {
   ZENDESK,
@@ -292,8 +292,7 @@ const getBrandsForGuide = (
   elements: InstanceElement[],
   fetchConfig: ZendeskFetchConfig,
 ): InstanceElement[] => {
-  const brandsConfig = fetchConfig.guide?.brands
-  const brandsRegexList = brandsConfig === undefined || _.isEmpty(brandsConfig) ? ['.*'] : brandsConfig
+  const brandsRegexList = fetchConfig.guide?.brands ?? []
   return elements
     .filter(instance => instance.elemID.typeName === BRAND_TYPE_NAME)
     .filter(brandInstance => brandInstance.value.has_help_center)
@@ -388,7 +387,7 @@ export default class ZendeskAdapter implements AdapterOperations {
 
   @logDuration('generating instances and types from service')
   private async getElements(): Promise<ReturnType<typeof getAllElements>> {
-    const isGuideDisabled = !this.userConfig[FETCH_CONFIG].enableGuide
+    const isGuideDisabled = !isGuideEnabled(this.userConfig[FETCH_CONFIG])
     const { supportedTypes: allSupportedTypes } = this.userConfig.apiDefinitions
     const supportedTypes = isGuideDisabled
       ? _.omit(allSupportedTypes, ...Object.keys(GUIDE_SUPPORTED_TYPES))

--- a/packages/zendesk-adapter/src/adapter_creator.ts
+++ b/packages/zendesk-adapter/src/adapter_creator.ts
@@ -85,7 +85,7 @@ const createOAuthRequest = (userInput: InstanceElement): OAuthRequestParameters 
 
 const adapterConfigFromConfig = (config: Readonly<InstanceElement> | undefined): ZendeskConfig => {
   const configValue = config?.value ?? {}
-  const isGuideDisabled = !config?.value.fetch.enableGuide
+  const isGuideDisabled = config?.value.fetch.guide === undefined
   DEFAULT_CONFIG.apiDefinitions.supportedTypes = isGuideDisabled
     ? DEFAULT_CONFIG.apiDefinitions.supportedTypes
     : { ...DEFAULT_CONFIG.apiDefinitions.supportedTypes, ...GUIDE_SUPPORTED_TYPES }

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -69,7 +69,6 @@ export type ZendeskFetchConfig = configUtils.DuckTypeUserFetchConfig
     enableMissingReferences?: boolean
     greedyAppReferences?: boolean
     appReferenceLocators?: IdLocator[]
-    enableGuide?: boolean
     guide?: Guide
   }
 export type ZendeskApiConfig = configUtils.AdapterApiConfig<
@@ -2270,10 +2269,6 @@ export const DEFAULT_CONFIG: ZendeskConfig = {
     ],
     hideTypes: true,
     enableMissingReferences: true,
-    enableGuide: false,
-    guide: {
-      brands: ['.*'],
-    },
   },
   [API_DEFINITIONS_CONFIG]: {
     typeDefaults: {
@@ -2349,7 +2344,6 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
           enableMissingReferences: { refType: BuiltinTypes.BOOLEAN },
           greedyAppReferences: { refType: BuiltinTypes.BOOLEAN },
           appReferenceLocators: { refType: IdLocatorType },
-          enableGuide: { refType: BuiltinTypes.BOOLEAN },
           guide: { refType: GuideType },
         },
       ),
@@ -2364,7 +2358,6 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
       API_DEFINITIONS_CONFIG,
       `${FETCH_CONFIG}.hideTypes`,
       `${FETCH_CONFIG}.enableMissingReferences`,
-      `${FETCH_CONFIG}.enableGuide`,
     ),
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },
@@ -2389,3 +2382,9 @@ export const validateGuideTypesConfig = (
     throw Error(`Invalid Zendesk Guide type(s) ${zendeskGuideTypesWithoutDataField} does not have dataField attribute in the type definition.`)
   }
 }
+
+export const isGuideEnabled = (
+  fetchConfig: ZendeskFetchConfig
+): boolean => (
+  fetchConfig.guide?.brands !== undefined && !_.isEmpty(fetchConfig.guide.brands)
+)

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -58,6 +58,10 @@ export type IdLocator = {
   type: string[]
 }
 
+export type Guide = {
+  brands: string[]
+}
+
 export type ZendeskClientConfig = clientUtils.ClientBaseConfig<clientUtils.ClientRateLimitConfig>
 
 export type ZendeskFetchConfig = configUtils.DuckTypeUserFetchConfig
@@ -66,6 +70,7 @@ export type ZendeskFetchConfig = configUtils.DuckTypeUserFetchConfig
     greedyAppReferences?: boolean
     appReferenceLocators?: IdLocator[]
     enableGuide?: boolean
+    guide?: Guide
   }
 export type ZendeskApiConfig = configUtils.AdapterApiConfig<
   configUtils.DuckTypeTransformationConfig & { omitInactive?: boolean }
@@ -2266,6 +2271,9 @@ export const DEFAULT_CONFIG: ZendeskConfig = {
     hideTypes: true,
     enableMissingReferences: true,
     enableGuide: false,
+    guide: {
+      brands: ['.*'],
+    },
   },
   [API_DEFINITIONS_CONFIG]: {
     typeDefaults: {
@@ -2312,6 +2320,21 @@ const IdLocatorType = createMatchingObjectType<IdLocator>({
   },
 })
 
+const GuideType = createMatchingObjectType<Guide>({
+  elemID: new ElemID(ZENDESK, 'GuideType'),
+  fields: {
+    brands: {
+      refType: new ListType(BuiltinTypes.STRING),
+      annotations: {
+        _required: true,
+      },
+    },
+  },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+  },
+})
+
 export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
   elemID: new ElemID(ZENDESK),
   fields: {
@@ -2327,6 +2350,7 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
           greedyAppReferences: { refType: BuiltinTypes.BOOLEAN },
           appReferenceLocators: { refType: IdLocatorType },
           enableGuide: { refType: BuiltinTypes.BOOLEAN },
+          guide: { refType: GuideType },
         },
       ),
     },

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -2358,6 +2358,7 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
       API_DEFINITIONS_CONFIG,
       `${FETCH_CONFIG}.hideTypes`,
       `${FETCH_CONFIG}.enableMissingReferences`,
+      `${FETCH_CONFIG}.guide`,
     ),
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },

--- a/packages/zendesk-adapter/src/config_creator.ts
+++ b/packages/zendesk-adapter/src/config_creator.ts
@@ -51,7 +51,7 @@ export const getConfig = async (
   }
   if (options.value.enableGuide === true) {
     const configWithGuide = defaultConf.clone()
-    configWithGuide.value.fetch = { ...configWithGuide.value.fetch, enableGuide: true }
+    configWithGuide.value.fetch = { ...configWithGuide.value.fetch, guide: { brands: ['.*'] } }
     return configWithGuide
   }
   return defaultConf

--- a/packages/zendesk-adapter/src/filters/collision_errors.ts
+++ b/packages/zendesk-adapter/src/filters/collision_errors.ts
@@ -19,7 +19,7 @@ import { getAndLogCollisionWarnings, getInstancesWithCollidingElemID } from '@sa
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
 import { ZENDESK } from '../constants'
-import { API_DEFINITIONS_CONFIG, FETCH_CONFIG } from '../config'
+import { API_DEFINITIONS_CONFIG, FETCH_CONFIG, isGuideEnabled } from '../config'
 
 const log = logger(module)
 
@@ -41,7 +41,7 @@ const filterCreator: FilterCreator = ({ config }) => ({
       ).idFields,
       idFieldsName: 'idFields',
       // Needed because 'safeJsonStringify' is really slow, which causes problems with articles stress test (SALTO-3059)
-      skipLogCollisionStringify: config[FETCH_CONFIG].enableGuide,
+      skipLogCollisionStringify: isGuideEnabled(config[FETCH_CONFIG]),
     })
     return { errors: collistionWarnings }
   }, 'collisionErrorsFilter'),

--- a/packages/zendesk-adapter/src/filters/everyone_user_segment.ts
+++ b/packages/zendesk-adapter/src/filters/everyone_user_segment.ts
@@ -20,7 +20,7 @@ import {
 import { elements as elementsUtils } from '@salto-io/adapter-components'
 import { FilterCreator } from '../filter'
 import { USER_SEGMENT_TYPE_NAME, ZENDESK } from '../constants'
-import { FETCH_CONFIG } from '../config'
+import { FETCH_CONFIG, isGuideEnabled } from '../config'
 
 const log = logger(module)
 const { RECORDS_PATH } = elementsUtils
@@ -41,7 +41,7 @@ export const createEveryoneUserSegmentInstance = (userSegmentType: ObjectType): 
  */
 const filterCreator: FilterCreator = ({ config, fetchQuery }) => ({
   onFetch: async elements => {
-    if (!config[FETCH_CONFIG].enableGuide || !fetchQuery.isTypeMatch(USER_SEGMENT_TYPE_NAME)) {
+    if (!isGuideEnabled(config[FETCH_CONFIG]) || !fetchQuery.isTypeMatch(USER_SEGMENT_TYPE_NAME)) {
       return
     }
     const userSegmentType = elements

--- a/packages/zendesk-adapter/src/filters/guide_create_element_translations.ts
+++ b/packages/zendesk-adapter/src/filters/guide_create_element_translations.ts
@@ -29,6 +29,7 @@ import { createSchemeGuard } from '@salto-io/adapter-utils'
 import { values } from '@salto-io/lowerdash'
 import { FilterCreator } from '../filter'
 import { ARTICLE_TRANSLATION_TYPE_NAME, ARTICLE_TYPE_NAME, ZENDESK } from '../constants'
+import { isGuideEnabled } from '../config'
 
 const log = logger(module)
 
@@ -93,7 +94,7 @@ const createTranslationType = () :ObjectType => new ObjectType({
  */
 const filterCreator: FilterCreator = ({ config, client }) => ({
   onFetch: async (elements: Element[]): Promise<void> => {
-    if (!config.fetch.enableGuide) {
+    if (!isGuideEnabled(config.fetch)) {
       return
     }
     _.remove(elements, isTranslationType)

--- a/packages/zendesk-adapter/src/filters/guide_locale.ts
+++ b/packages/zendesk-adapter/src/filters/guide_locale.ts
@@ -24,7 +24,7 @@ import { elements as elementsUtils } from '@salto-io/adapter-components'
 import { FilterCreator } from '../filter'
 import { ZENDESK } from '../constants'
 import ZendeskClient from '../client/client'
-import { FETCH_CONFIG } from '../config'
+import { FETCH_CONFIG, isGuideEnabled } from '../config'
 
 const log = logger(module)
 
@@ -63,7 +63,7 @@ const getLocales = async (
  */
 const filterCreator: FilterCreator = ({ config, client }) => ({
   onFetch: async elements => {
-    if (!config[FETCH_CONFIG].enableGuide) {
+    if (!isGuideEnabled(config[FETCH_CONFIG])) {
       return
     }
     const localesRes = await getLocales(client)

--- a/packages/zendesk-adapter/src/filters/guide_order/article_order.ts
+++ b/packages/zendesk-adapter/src/filters/guide_order/article_order.ts
@@ -22,7 +22,7 @@ import {
 import { FilterCreator } from '../../filter'
 import { ARTICLE_TYPE_NAME, SECTION_TYPE_NAME, ARTICLES_FIELD, ARTICLE_ORDER_TYPE_NAME } from '../../constants'
 import { createOrderInstance, deployOrderChanges, createOrderType } from './guide_order_utils'
-import { FETCH_CONFIG } from '../../config'
+import { FETCH_CONFIG, isGuideEnabled } from '../../config'
 
 /**
  * Handles the sections and articles orders inside section
@@ -31,7 +31,7 @@ const filterCreator: FilterCreator = ({ client, config }) => ({
   /** Create an InstanceElement of the sections and articles order inside the sections */
   onFetch: async (elements: Element[]) => {
     // If Guide is not enabled in Salto, we don't need to do anything
-    if (!config[FETCH_CONFIG].enableGuide) {
+    if (!isGuideEnabled(config[FETCH_CONFIG])) {
       return
     }
 

--- a/packages/zendesk-adapter/src/filters/guide_order/category_order.ts
+++ b/packages/zendesk-adapter/src/filters/guide_order/category_order.ts
@@ -24,7 +24,7 @@ import { BRAND_TYPE_NAME, CATEGORY_TYPE_NAME, CATEGORIES_FIELD, CATEGORY_ORDER_T
 import {
   createOrderInstance, deployOrderChanges, createOrderType,
 } from './guide_order_utils'
-import { FETCH_CONFIG } from '../../config'
+import { FETCH_CONFIG, isGuideEnabled } from '../../config'
 
 /**
  * Handle the order of categories in brand
@@ -33,7 +33,7 @@ const filterCreator: FilterCreator = ({ client, config }) => ({
   /** Create an InstanceElement of the categories order inside the brands */
   onFetch: async (elements: Element[]) => {
     // If Guide is not enabled in Salto, we don't need to do anything
-    if (!config[FETCH_CONFIG].enableGuide) {
+    if (!isGuideEnabled(config[FETCH_CONFIG])) {
       return
     }
 

--- a/packages/zendesk-adapter/src/filters/guide_order/section_order.ts
+++ b/packages/zendesk-adapter/src/filters/guide_order/section_order.ts
@@ -24,7 +24,7 @@ import { CATEGORY_TYPE_NAME, SECTION_TYPE_NAME, SECTIONS_FIELD, SECTION_ORDER_TY
 import {
   createOrderInstance, deployOrderChanges, createOrderType,
 } from './guide_order_utils'
-import { FETCH_CONFIG } from '../../config'
+import { FETCH_CONFIG, isGuideEnabled } from '../../config'
 
 /**
  * Handles the section orders inside category
@@ -33,7 +33,7 @@ const filterCreator: FilterCreator = ({ client, config }) => ({
   /** Create an InstanceElement of the sections order inside the categories */
   onFetch: async (elements: Element[]) => {
     // If Guide is not enabled in Salto, we don't need to do anything
-    if (!config[FETCH_CONFIG].enableGuide) {
+    if (!isGuideEnabled(config[FETCH_CONFIG])) {
       return
     }
 

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -102,7 +102,9 @@ describe('adapter', () => {
                   type: '.*',
                 }],
                 exclude: [],
-                enableGuide: true,
+                guide: {
+                  brands: ['.*'],
+                },
               },
             }
           ),
@@ -618,7 +620,6 @@ describe('adapter', () => {
                 type: '.*',
               }],
               exclude: [],
-              enableGuide: true,
               guide: {
                 brands: ['.WithGuide'],
               },

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -635,7 +635,7 @@ describe('adapter', () => {
           .filter(isInstanceElement)
           .filter(e => e.elemID.typeName === 'article')
           .map(e => e.elemID.getFullName()).sort()).toEqual([
-          'zendesk.article.instance.brandWithGuide_greatCategory_greatSection_Title_Yo__@uuussa',
+          'zendesk.article.instance.Title_Yo___greatSection_greatCategory_brandWithGuide@ssauuu',
         ])
 
         config.value[FETCH_CONFIG].guide.brands = ['[^myBrand]']
@@ -648,7 +648,7 @@ describe('adapter', () => {
           .filter(isInstanceElement)
           .filter(e => e.elemID.typeName === 'article')
           .map(e => e.elemID.getFullName()).sort()).toEqual([
-          'zendesk.article.instance.brandWithGuide_greatCategory_greatSection_Title_Yo__@uuussa',
+          'zendesk.article.instance.Title_Yo___greatSection_greatCategory_brandWithGuide@ssauuu',
         ])
       })
     })

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -601,6 +601,55 @@ describe('adapter', () => {
         })
         expect(supportAddress?.value.brand_id.elemID.getFullName()).toEqual('zendesk.brand.instance.myBrand')
       })
+
+      it('should generate guide elements according to brands config', async () => {
+        mockAxiosAdapter.onGet().reply(callbackResponseFunc)
+        const creds = new InstanceElement(
+          'config',
+          usernamePasswordCredentialsType,
+          { username: 'user123', password: 'token456', subdomain: 'myBrand' },
+        )
+        const config = new InstanceElement(
+          'config',
+          configType,
+          {
+            [FETCH_CONFIG]: {
+              include: [{
+                type: '.*',
+              }],
+              exclude: [],
+              enableGuide: true,
+              guide: {
+                brands: ['.WithGuide'],
+              },
+            },
+          }
+        )
+        const { elements } = await adapter.operations({
+          credentials: creds,
+          config,
+          elementsSource: buildElementsSourceFromElements([]),
+        }).fetch({ progressReporter: { reportProgress: () => null } })
+        expect(elements
+          .filter(isInstanceElement)
+          .filter(e => e.elemID.typeName === 'article')
+          .map(e => e.elemID.getFullName()).sort()).toEqual([
+          'zendesk.article.instance.brandWithGuide_greatCategory_greatSection_Title_Yo__@uuussa',
+        ])
+
+        config.value[FETCH_CONFIG].guide.brands = ['[^myBrand]']
+        const fetchRes = await adapter.operations({
+          credentials: creds,
+          config,
+          elementsSource: buildElementsSourceFromElements([]),
+        }).fetch({ progressReporter: { reportProgress: () => null } })
+        expect(fetchRes.elements
+          .filter(isInstanceElement)
+          .filter(e => e.elemID.typeName === 'article')
+          .map(e => e.elemID.getFullName()).sort()).toEqual([
+          'zendesk.article.instance.brandWithGuide_greatCategory_greatSection_Title_Yo__@uuussa',
+        ])
+      })
     })
 
     describe('type overrides', () => {

--- a/packages/zendesk-adapter/test/config_creator.test.ts
+++ b/packages/zendesk-adapter/test/config_creator.test.ts
@@ -55,7 +55,9 @@ describe('config_creator', () => {
       resultConfig = await getConfig(options)
     })
     it('should return adapter config with guide', async () => {
-      expect(resultConfig.value?.fetch?.enableGuide).toBeTruthy()
+      expect(resultConfig.value?.fetch?.guide).toEqual({
+        brands: ['.*'],
+      })
       expect(mockLogError).not.toHaveBeenCalled()
     })
   })
@@ -68,7 +70,7 @@ describe('config_creator', () => {
     it('should create default instance from type', async () => {
       expect(mockCreateDefaultInstanceFromType).toHaveBeenCalledWith(ElemID.CONFIG_NAME, configType)
       expect(resultConfig).toEqual(mockDefaultInstanceFromTypeResult)
-      expect(resultConfig.value?.fetch?.enableGuide).toBeUndefined()
+      expect(resultConfig.value?.fetch?.guide).toBeUndefined()
       expect(mockLogError).not.toHaveBeenCalled()
     })
   })
@@ -81,7 +83,7 @@ describe('config_creator', () => {
     it('should create default instance from type', async () => {
       expect(mockCreateDefaultInstanceFromType).toHaveBeenCalledWith(ElemID.CONFIG_NAME, configType)
       expect(resultConfig).toEqual(mockDefaultInstanceFromTypeResult)
-      expect(resultConfig.value?.fetch?.enableGuide).toBeUndefined()
+      expect(resultConfig.value?.fetch?.guide).toBeUndefined()
       expect(mockLogError).not.toHaveBeenCalled()
     })
   })
@@ -97,7 +99,7 @@ describe('config_creator', () => {
     it('should create default instance from type and log error', async () => {
       expect(mockCreateDefaultInstanceFromType).toHaveBeenCalledWith(ElemID.CONFIG_NAME, configType)
       expect(resultConfig).toEqual(mockDefaultInstanceFromTypeResult)
-      expect(resultConfig.value?.fetch?.enableGuide).toBeUndefined()
+      expect(resultConfig.value?.fetch?.guide).toBeUndefined()
       expect(mockLogError).toHaveBeenCalledWith(`Received an invalid instance for config options. Received instance with refType ElemId full name: ${options?.refType.elemID.getFullName()}`)
     })
   })

--- a/packages/zendesk-adapter/test/filters/article/article.test.ts
+++ b/packages/zendesk-adapter/test/filters/article/article.test.ts
@@ -213,7 +213,9 @@ describe('article filter', () => {
             type: '.*',
           }],
           exclude: [],
-          enableGuide: true,
+          guide: {
+            brands: ['.*'],
+          },
         },
       },
     })) as FilterType

--- a/packages/zendesk-adapter/test/filters/everyone_user_segment.test.ts
+++ b/packages/zendesk-adapter/test/filters/everyone_user_segment.test.ts
@@ -47,7 +47,9 @@ describe('everyoneUserSegment filter', () => {
             type: '.*',
           }],
           exclude: [],
-          enableGuide: true,
+          guide: {
+            brands: ['.*'],
+          },
         },
       },
     })) as FilterType

--- a/packages/zendesk-adapter/test/filters/guide_create_element_translation.test.ts
+++ b/packages/zendesk-adapter/test/filters/guide_create_element_translation.test.ts
@@ -80,7 +80,9 @@ describe('guid create translations filter', () => {
 
 
   beforeEach(async () => {
-    config[FETCH_CONFIG].enableGuide = true
+    config[FETCH_CONFIG].guide = {
+      brands: ['.*'],
+    }
     jest.clearAllMocks()
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
@@ -187,7 +189,7 @@ describe('guid create translations filter', () => {
       ])
     })
     it('should do nothing if guide is disabled', async () => {
-      config[FETCH_CONFIG].enableGuide = false
+      config[FETCH_CONFIG].guide = undefined
       filter = filterCreator(createFilterCreatorParams({ config })) as FilterType
       const elements: Element[] = [
         articleDefaultInstance,

--- a/packages/zendesk-adapter/test/filters/guide_locale.test.ts
+++ b/packages/zendesk-adapter/test/filters/guide_locale.test.ts
@@ -38,7 +38,9 @@ describe('guide locale filter', () => {
         ...DEFAULT_CONFIG,
         [FETCH_CONFIG]: {
           ...DEFAULT_CONFIG[FETCH_CONFIG],
-          enableGuide: true,
+          guide: {
+            brands: ['.*'],
+          },
         },
       },
     })) as FilterType
@@ -68,7 +70,7 @@ describe('guide locale filter', () => {
       expect(esLocale).toBeDefined()
       expect(esLocale?.value).toEqual({ id: 'es', default: false })
     })
-    it('should not add locales instances and type if enableGuide is false', async () => {
+    it('should not add locales instances and type if guide is disabled', async () => {
       const elements: Element[] = []
       mockGetSinglePage.mockResolvedValue({
         data: {

--- a/packages/zendesk-adapter/test/filters/guide_orders.test.ts
+++ b/packages/zendesk-adapter/test/filters/guide_orders.test.ts
@@ -210,7 +210,9 @@ const config = { ...DEFAULT_CONFIG }
 describe('Categories order in brand', () => {
   describe('on fetch', () => {
     it('with Guide active in Zendesk And Salto', async () => {
-      config[FETCH_CONFIG].enableGuide = true
+      config[FETCH_CONFIG].guide = {
+        brands: ['.*'],
+      }
       filter = categoryOrderFilter(
         createFilterCreatorParams({ config })
       ) as FilterType
@@ -221,7 +223,9 @@ describe('Categories order in brand', () => {
       })
     })
     it('with Guide not active in Zendesk', async () => {
-      config[FETCH_CONFIG].enableGuide = true
+      config[FETCH_CONFIG].guide = {
+        brands: ['.*'],
+      }
       filter = categoryOrderFilter(
         createFilterCreatorParams({ config })
       ) as FilterType
@@ -233,7 +237,7 @@ describe('Categories order in brand', () => {
       expect(brandWithoutGuide.value.categories).toBeUndefined()
     })
     it('with Guide not active in Salto', async () => {
-      config[FETCH_CONFIG].enableGuide = false
+      config[FETCH_CONFIG].guide = undefined
       filter = categoryOrderFilter(
         createFilterCreatorParams({})
       ) as FilterType
@@ -272,7 +276,9 @@ describe('Categories order in brand', () => {
 
 describe('Sections order in category', () => {
   beforeEach(async () => {
-    config[FETCH_CONFIG].enableGuide = true
+    config[FETCH_CONFIG].guide = {
+      brands: ['.*'],
+    }
     filter = sectionOrderFilter(createFilterCreatorParams({ client })) as FilterType
   })
 
@@ -307,7 +313,9 @@ describe('Sections order in category', () => {
 
 describe('Sections order in section', () => {
   beforeEach(async () => {
-    config[FETCH_CONFIG].enableGuide = true
+    config[FETCH_CONFIG].guide = {
+      brands: ['.*'],
+    }
     filter = sectionOrderFilter(createFilterCreatorParams({ client })) as FilterType
   })
 
@@ -344,7 +352,9 @@ describe('Sections order in section', () => {
 
 describe('Articles order in section', () => {
   beforeEach(async () => {
-    config[FETCH_CONFIG].enableGuide = true
+    config[FETCH_CONFIG].guide = {
+      brands: ['.*'],
+    }
     filter = articleOrderFilter(createFilterCreatorParams({ client })) as FilterType
   })
 


### PR DESCRIPTION
Replace `enableGuide` flag with with `guide` object and allow specify brands for fetch

---

I replaced the `enableGuide` config flag with `guide` object, so it would be easier to add another config options in the future.
For now, the only config option for `guide` object is `brands` that allows to specify the desired brands (or the unwanted) for fetch.
The brand list can have regex, but support only one negative regex for now.

---
_Release Notes_: 

Zendesk adapter
- enable fetch zendesk guide of specific brands.

---

_User Notifications_: 

none