### PR TITLE
Fix savedcsvimport SDF fetch

### DIFF
--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -62,7 +62,7 @@ const { concatObjects } = lowerdashObjects
 const { matchAll } = strings
 const log = logger(module)
 
-const FAILED_TYPE_NAME_TO_REAL_NAME: Record<string, string> = {
+const RESPONSE_TYPE_NAME_TO_REAL_NAME: Record<string, string> = {
   csvimport: 'savedcsvimport',
   plugintypeimpl: 'pluginimplementation',
 }
@@ -719,8 +719,8 @@ export default class SdfClient {
 
   private static fixTypeName(typeName: string): string {
     // For some type names, SDF might return different names in its
-    // error response, so we replace it with the original name
-    return FAILED_TYPE_NAME_TO_REAL_NAME[typeName] ?? typeName
+    // response, so we replace it with the original name
+    return RESPONSE_TYPE_NAME_TO_REAL_NAME[typeName] ?? typeName
   }
 
   async listInstances(
@@ -736,9 +736,10 @@ export default class SdfClient {
       },
       executor,
     )
-    return results.data.map(
-      ({ type, scriptId }: { type: string; scriptId: string }) => ({ type, instanceId: scriptId })
-    )
+    return results.data.map(({ type, scriptId }: { type: string; scriptId: string }) => ({
+      type: SdfClient.fixTypeName(type),
+      instanceId: scriptId,
+    }))
   }
 
   private async listFilePaths(executor: CommandActionExecutor):


### PR DESCRIPTION
`SdfClient.listInstances` returns `savedcsvimport` object names with type `csvimport` so in case that we try to include (or exclude) `savedcsvimport` specifically (e.g. fetchTarget) we fail.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Fix savedcsvimport SDF fetch

---
_User Notifications_: 
None
