### PR TITLE
SALTO-3083: Jira DC: Fetch fails when creating a new server without adding an issue type 

### DIFF
--- a/packages/jira-adapter/src/filters/issue_type_schemas/issue_type_scheme_references.ts
+++ b/packages/jira-adapter/src/filters/issue_type_schemas/issue_type_scheme_references.ts
@@ -24,7 +24,7 @@ const filter: FilterCreator = () => ({
     const setReferences = (scheme: InstanceElement): void => {
       type IssueTypeMapping = { issueTypeId: ReferenceExpression }
       scheme.value.issueTypeIds = scheme.value.issueTypeIds
-        .map((issueTypeMapping: IssueTypeMapping) => issueTypeMapping.issueTypeId)
+        ?.map((issueTypeMapping: IssueTypeMapping) => issueTypeMapping.issueTypeId)
     }
     elements
       .filter(isInstanceElement)

--- a/packages/jira-adapter/test/filters/issue_type_schemas/issue_type_scheme_references.test.ts
+++ b/packages/jira-adapter/test/filters/issue_type_schemas/issue_type_scheme_references.test.ts
@@ -49,7 +49,7 @@ describe('issueTypeSchemeReferences', () => {
   it('should do nothing if there are no issue types', async () => {
     const issueTypeScheme = new InstanceElement(
       'instance',
-      mockTypes.IssueTypeScreenScheme,
+      mockTypes.IssueTypeScheme,
       {
         name: 'inst',
       }

--- a/packages/jira-adapter/test/filters/issue_type_schemas/issue_type_scheme_references.test.ts
+++ b/packages/jira-adapter/test/filters/issue_type_schemas/issue_type_scheme_references.test.ts
@@ -15,10 +15,10 @@
 */
 import 'jest-extended'
 import { filterUtils } from '@salto-io/adapter-components'
-import { Element, ElemID, ReferenceExpression } from '@salto-io/adapter-api'
+import { Element, ElemID, InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
 import { getFilterParams, mockClient } from '../../utils'
 import issueTypeSchemeReferences from '../../../src/filters/issue_type_schemas/issue_type_scheme_references'
-import { instanceCreators } from '../../mock_elements'
+import { instanceCreators, mockTypes } from '../../mock_elements'
 
 describe('issueTypeSchemeReferences', () => {
   const ISSUE_TYPES_REFERENCES = [
@@ -44,5 +44,19 @@ describe('issueTypeSchemeReferences', () => {
     const elements = await runFilter(issueTypeScheme)
     expect(elements).toEqual([issueTypeScheme])
     expect(issueTypeScheme.value.issueTypeIds).toIncludeSameMembers(ISSUE_TYPES_REFERENCES)
+  })
+
+  it('should do nothing if there are no issue types', async () => {
+    const issueTypeScheme = new InstanceElement(
+      'instance',
+      mockTypes.IssueTypeScreenScheme,
+      {
+        name: 'inst',
+      }
+    )
+
+    const afterInstance = issueTypeScheme.clone()
+    await runFilter(afterInstance)
+    expect(issueTypeScheme.value).toEqual(afterInstance.value)
   })
 })


### PR DESCRIPTION
Fixed Jira first fetch in `atlas-run`

---
_Release Notes_: 
None

---
_User Notifications_: 
None