### PR TITLE
SALTO-2927 Flows-missing-references-to-custom-labels

### DIFF
--- a/packages/adapter-components/src/references/field_references.ts
+++ b/packages/adapter-components/src/references/field_references.ts
@@ -157,7 +157,7 @@ export const replaceReferenceValues = async <
             element: instance,
           })
           : resolvePath(element, referenceId)
-        // this validation is necessary to a reference from '$Label.check' and not 'check'
+        // this validation is necessary to create a reference from '$Label.check' and not 'check'
         if (!sourceTransformation.validate(val, serializedRefExpression)) {
           log.warn(`Invalid reference ${val} => [${serializedRefExpression} (element '${element.elemID.getFullName()}')]`)
           return undefined

--- a/packages/adapter-components/src/references/field_references.ts
+++ b/packages/adapter-components/src/references/field_references.ts
@@ -157,7 +157,7 @@ export const replaceReferenceValues = async <
             element: instance,
           })
           : resolvePath(element, referenceId)
-
+        // this validation is necessary to a reference from '$Label.check' and not 'check'
         if (!sourceTransformation.validate(val, serializedRefExpression)) {
           log.warn(`Invalid reference ${val} => [${serializedRefExpression} (element '${element.elemID.getFullName()}')]`)
           return undefined

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -107,12 +107,12 @@ const ReferenceSerializationStrategyLookup: Record<
     lookup: val => val,
   },
   customLabel: {
-    serialize: async ({ ref }) => `$Label.${ref.elemID.name}`,
+    serialize: async ({ ref, path }) => `$Label${API_NAME_SEPARATOR}${await safeApiName({ ref, path })}`,
     lookup: val => {
       if (val.includes('$Label')) {
         return val.split(API_NAME_SEPARATOR)[1]
       }
-      return val
+      return undefined
     },
   },
 }

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -112,7 +112,7 @@ const ReferenceSerializationStrategyLookup: Record<
       if (val.includes('$Label')) {
         return val.split(API_NAME_SEPARATOR)[1]
       }
-      return undefined
+      return val
     },
   },
 }

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -31,7 +31,7 @@ import {
   CPQ_CONSUMPTION_RATE_FIELDS, CPQ_CONSUMPTION_SCHEDULE_FIELDS, CPQ_GROUP_FIELDS,
   CPQ_QUOTE_LINE_FIELDS, DEFAULT_OBJECT_TO_API_MAPPING, SCHEDULE_CONTRAINT_FIELD_TO_API_MAPPING,
   TEST_OBJECT_TO_API_MAPPING, CPQ_TESTED_OBJECT, CPQ_PRICE_SCHEDULE, CPQ_DISCOUNT_SCHEDULE,
-  CPQ_CONFIGURATION_ATTRIBUTE, CPQ_DEFAULT_OBJECT_FIELD, CPQ_QUOTE, CPQ_CONSTRAINT_FIELD,
+  CPQ_CONFIGURATION_ATTRIBUTE, CPQ_DEFAULT_OBJECT_FIELD, CPQ_QUOTE, CPQ_CONSTRAINT_FIELD, CUSTOM_LABEL_METADATA_TYPE,
 } from '../constants'
 
 const log = logger(module)
@@ -57,7 +57,7 @@ const safeApiName = ({ ref, path, relative }: {
 }
 
 type ReferenceSerializationStrategyName = 'absoluteApiName' | 'relativeApiName' | 'configurationAttributeMapping' | 'lookupQueryMapping' | 'scheduleConstraintFieldMapping'
- | 'mapKey'
+ | 'mapKey' | 'customLabel'
 const ReferenceSerializationStrategyLookup: Record<
   ReferenceSerializationStrategyName, ReferenceSerializationStrategy
 > = {
@@ -105,6 +105,15 @@ const ReferenceSerializationStrategyLookup: Record<
   mapKey: {
     serialize: async ({ ref }) => ref.elemID.name,
     lookup: val => val,
+  },
+  customLabel: {
+    serialize: async ({ ref }) => `$Label.${ref.elemID.name}`,
+    lookup: val => {
+      if (val.includes('$Label')) {
+        return val.split(API_NAME_SEPARATOR)[1]
+      }
+      return val
+    },
   },
 }
 
@@ -599,6 +608,11 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     src: { field: 'entitlementProcess', parentTypes: ['EntitlementTemplate'] },
     target: { type: 'EntitlementProcess' },
     sourceTransformation: 'asCaseInsensitiveString',
+  },
+  {
+    src: { field: 'elementReference', parentTypes: ['FlowElementReferenceOrValue'] },
+    serializationStrategy: 'customLabel',
+    target: { type: CUSTOM_LABEL_METADATA_TYPE },
   },
 ]
 

--- a/packages/salesforce-adapter/test/filters/field_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/field_references.test.ts
@@ -21,9 +21,10 @@ import { FilterWith } from '../../src/filter'
 import filterCreator, { addReferences } from '../../src/filters/field_references'
 import { fieldNameToTypeMappingDefs } from '../../src/transformers/reference_mapping'
 import { OBJECTS_PATH, SALESFORCE, CUSTOM_OBJECT, METADATA_TYPE, INSTANCE_FULL_NAME_FIELD, CUSTOM_OBJECT_ID_FIELD, API_NAME, API_NAME_SEPARATOR, WORKFLOW_ACTION_REFERENCE_METADATA_TYPE, WORKFLOW_RULE_METADATA_TYPE, CPQ_QUOTE_LINE_FIELDS, CPQ_CUSTOM_SCRIPT, CPQ_CONFIGURATION_ATTRIBUTE, CPQ_DEFAULT_OBJECT_FIELD, CPQ_LOOKUP_QUERY, CPQ_TESTED_OBJECT, CPQ_DISCOUNT_SCHEDULE, CPQ_CONSTRAINT_FIELD } from '../../src/constants'
-import { metadataType, apiName } from '../../src/transformers/transformer'
+import { metadataType, apiName, createInstanceElement } from '../../src/transformers/transformer'
 import { CUSTOM_OBJECT_TYPE_ID } from '../../src/filters/custom_objects_to_object_type'
 import { defaultFilterContext } from '../utils'
+import { mockTypes } from '../mock_elements'
 
 const { awu } = collections.asynciterable
 
@@ -131,6 +132,22 @@ describe('FieldReferences filter', () => {
         someFilterField: { refType: filterItemType },
       },
     })
+    const FlowElementReferenceOrValueType = new ObjectType({
+      elemID: new ElemID(SALESFORCE, 'FlowElementReferenceOrValue'),
+      annotations: { [METADATA_TYPE]: 'FlowElementReferenceOrValue' },
+      fields: {
+        elementReference: { refType: BuiltinTypes.STRING },
+      },
+    })
+    const FlowType = new ObjectType({
+      elemID: new ElemID(SALESFORCE, 'Flow'),
+      annotations: { [METADATA_TYPE]: 'Flow' },
+      fields: {
+        // note: does not exactly match the real type
+        inputAssignments: { refType: new ListType(FlowElementReferenceOrValueType) },
+      },
+    })
+    const checkLabel = createInstanceElement({ fullName: 'check' }, mockTypes.CustomLabel)
     return [
       customObjectType,
       // sharingRules555 should point to Account.name (rule contains instanceTypes constraint)
@@ -151,6 +168,19 @@ describe('FieldReferences filter', () => {
           ],
         },
       ),
+      FlowElementReferenceOrValueType,
+      FlowType,
+      new InstanceElement(
+        'flow1',
+        FlowType,
+        {
+          inputAssignments: [
+            { elementReference: 'check' },
+            { elementReference: '$Label.check' },
+          ],
+        }
+      ),
+      checkLabel,
       ...generateObjectAndInstance({
         type: 'Account',
         fieldName: 'name',
@@ -388,6 +418,16 @@ describe('FieldReferences filter', () => {
       expect(inst.value[CPQ_CONSTRAINT_FIELD]).toBeDefined()
       expect(inst.value[CPQ_CONSTRAINT_FIELD]).toBeInstanceOf(ReferenceExpression)
       expect(inst.value[CPQ_CONSTRAINT_FIELD]?.elemID.getFullName()).toEqual('salesforce.SBQQ__Quote__c.field.SBQQ__Account__c')
+    })
+
+    it('should resolve field with CustomLabel strategy', async () => {
+      const inst = await awu(elements).find(
+        async e => isInstanceElement(e)
+              && await apiName(await e.getType()) === 'Flow'
+      ) as InstanceElement
+      expect(inst.value.inputAssignments[0].elementReference).toEqual('check')
+      expect(inst.value.inputAssignments[1].elementReference).toBeInstanceOf(ReferenceExpression)
+      expect(inst.value.inputAssignments[1].elementReference.elemID.getFullName()).toEqual('salesforce.CustomLabel.instance.check')
     })
 
     it('should resolve field with neighbor context using app menu item mapping when context is a string', async () => {

--- a/packages/salesforce-adapter/test/filters/field_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/field_references.test.ts
@@ -147,6 +147,16 @@ describe('FieldReferences filter', () => {
         inputAssignments: { refType: new ListType(FlowElementReferenceOrValueType) },
       },
     })
+    const flowInstance = new InstanceElement(
+      'flow1',
+      FlowType,
+      {
+        inputAssignments: [
+          { elementReference: 'check' },
+          { elementReference: '$Label.check' },
+        ],
+      }
+    )
     const checkLabel = createInstanceElement({ fullName: 'check' }, mockTypes.CustomLabel)
     return [
       customObjectType,
@@ -170,16 +180,7 @@ describe('FieldReferences filter', () => {
       ),
       FlowElementReferenceOrValueType,
       FlowType,
-      new InstanceElement(
-        'flow1',
-        FlowType,
-        {
-          inputAssignments: [
-            { elementReference: 'check' },
-            { elementReference: '$Label.check' },
-          ],
-        }
-      ),
+      flowInstance,
       checkLabel,
       ...generateObjectAndInstance({
         type: 'Account',

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -326,6 +326,11 @@ export const mockTypes = {
       [API_NAME]: CPQ_QUOTE,
     },
   }),
+  CustomLabel: createMetadataObjectType({
+    annotations: {
+      metadataType: 'CustomLabel',
+    },
+  }),
 }
 
 export const lwcJsResourceContent = "import { LightningElement } from 'lwc';\nexport default class BikeCard extends LightningElement {\n   name = 'Electra X4';\n   description = 'A sweet bike built for comfort.';\n   category = 'Mountain';\n   material = 'Steel';\n   price = '$2,700';\n   pictureUrl = 'https://s3-us-west-1.amazonaws.com/sfdc-demo/ebikes/electrax4.jpg';\n }"


### PR DESCRIPTION
_Flows missing references to custom labels_

---
_Additional context for reviewer_:
tested fetch and deploy

---
_Release Notes_: 
Salesforce-adapter:

* Add reference to CustomLabel in flow's inputAssignments
---

_User Notifications_: 
Salesforce-adapter:

* create reference in the relevant flow's fields

