### PR TITLE
SALTO-2978: Support priority scheme in Jira DC

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/datacenter/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/datacenter/index.ts
@@ -14,12 +14,13 @@
 * limitations under the License.
 */
 import { InstanceElement, Element, ReferenceExpression, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
-import { AUTOMATION_TYPE, WORKFLOW_TYPE_NAME } from '../../../src/constants'
+import { AUTOMATION_TYPE, PRIORITY_SCHEME_TYPE_NAME, WORKFLOW_TYPE_NAME } from '../../../src/constants'
 import { findType } from '../../utils'
 import { createAutomationValues } from './automation'
 import { createKanbanBoardValues, createScrumBoardValues } from './board'
 import { createFieldConfigurationItemValues, createFieldConfigurationValues } from './fieldConfiguration'
 import { createFilterValues } from './filter'
+import { createPrioritySchemeValues } from './priorityScheme'
 import { createWorkflowValues } from './workflow'
 
 export const createInstances = (randomString: string, fetchedElements: Element[]): InstanceElement[][] => {
@@ -71,6 +72,12 @@ export const createInstances = (randomString: string, fetchedElements: Element[]
     createFilterValues(randomString, fetchedElements),
   )
 
+  const priorityScheme = new InstanceElement(
+    randomString,
+    findType(PRIORITY_SCHEME_TYPE_NAME, fetchedElements),
+    createPrioritySchemeValues(randomString, fetchedElements),
+  )
+
   return [
     [fieldConfiguration],
     [fieldConfigurationItem],
@@ -79,5 +86,6 @@ export const createInstances = (randomString: string, fetchedElements: Element[]
     [kanbanBoard],
     [scrumBoard],
     [filter],
+    [priorityScheme],
   ]
 }

--- a/packages/jira-adapter/e2e_test/instances/datacenter/priorityScheme.ts
+++ b/packages/jira-adapter/e2e_test/instances/datacenter/priorityScheme.ts
@@ -20,7 +20,7 @@ import { JIRA, PRIORITY_TYPE_NAME } from '../../../src/constants'
 
 export const createPrioritySchemeValues = (name: string, allElements: Element[]): Values => ({
   name,
-  description: name,
+  description: `desc-${name}`,
   optionIds: [
     createReference(new ElemID(JIRA, PRIORITY_TYPE_NAME, 'instance', 'Highest'), allElements),
     createReference(new ElemID(JIRA, PRIORITY_TYPE_NAME, 'instance', 'High'), allElements),

--- a/packages/jira-adapter/e2e_test/instances/datacenter/priorityScheme.ts
+++ b/packages/jira-adapter/e2e_test/instances/datacenter/priorityScheme.ts
@@ -1,0 +1,29 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, Values, Element } from '@salto-io/adapter-api'
+import { createReference } from '../../utils'
+import { JIRA, PRIORITY_TYPE_NAME } from '../../../src/constants'
+
+
+export const createPrioritySchemeValues = (name: string, allElements: Element[]): Values => ({
+  name,
+  description: name,
+  optionIds: [
+    createReference(new ElemID(JIRA, PRIORITY_TYPE_NAME, 'instance', 'Highest'), allElements),
+    createReference(new ElemID(JIRA, PRIORITY_TYPE_NAME, 'instance', 'High'), allElements),
+  ],
+  defaultOptionId: createReference(new ElemID(JIRA, PRIORITY_TYPE_NAME, 'instance', 'High'), allElements),
+})

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -106,6 +106,9 @@ import automationLabelFetchFilter from './filters/automation/automation_label/la
 import automationLabelDeployFilter from './filters/automation/automation_label/label_deployment'
 import filtersDcDeployFilter from './filters/data_center/filters_permissions'
 import deployDcIssueEventsFilter from './filters/data_center/issue_events'
+import prioritySchemeFetchFilter from './filters/data_center/priority_scheme/priority_scheme_fetch'
+import prioritySchemeDeployFilter from './filters/data_center/priority_scheme/priority_scheme_deploy'
+import prioritySchemeProjectAssociationFilter from './filters/data_center/priority_scheme/priority_scheme_project_association'
 import { GetIdMapFunc, getIdMapFuncCreator } from './users_map'
 
 const {
@@ -153,6 +156,9 @@ export const DEFAULT_FILTERS = [
   issueTypeFilter,
   issueTypeSchemeReferences,
   issueTypeSchemeFilter,
+  prioritySchemeFetchFilter,
+  prioritySchemeDeployFilter,
+  prioritySchemeProjectAssociationFilter,
   sharePermissionFilter,
   boardFilter,
   boardColumnsFilter,

--- a/packages/jira-adapter/src/client/pagination.ts
+++ b/packages/jira-adapter/src/client/pagination.ts
@@ -19,6 +19,11 @@ import { client as clientUtils } from '@salto-io/adapter-components'
 
 const { makeArray } = collections.array
 
+const ITEM_INDEX_PAGINATION_URLS = [
+  '/rest/api/3/users/search',
+  '/rest/api/2/priorityschemes',
+]
+
 const removeScopedObjectsImpl = <T extends clientUtils.ResponseValue>(
   response: T | T[],
 ): T | T[] => {
@@ -43,7 +48,7 @@ export const removeScopedObjects: clientUtils.PageEntriesExtractor = (
 )
 
 export const paginate: clientUtils.PaginationFuncCreator = args => {
-  if (args.getParams?.url === '/rest/api/3/users/search') {
+  if (ITEM_INDEX_PAGINATION_URLS.includes(args.getParams?.url)) {
     // special handling for endpoints that use pagination without meta-data
     // if more cases encountered should be moved to an object with url and items per page
     return clientUtils.getWithItemIndexPagination({ firstIndex: 0, itemsPerPage: 50 })

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -765,6 +765,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
         { fieldName: 'issueSecurityScheme', fieldType: 'ProjectSecurityScheme' },
         { fieldName: 'issueTypeScreenScheme', fieldType: 'IssueTypeScreenScheme' },
         { fieldName: 'fieldConfigurationScheme', fieldType: 'FieldConfigurationScheme' },
+        { fieldName: 'priorityScheme', fieldType: 'number' },
         { fieldName: 'issueTypeScheme', fieldType: ISSUE_TYPE_SCHEMA_NAME },
         { fieldName: 'fieldContexts', fieldType: `list<${FIELD_CONTEXT_TYPE_NAME}>` },
       ],

--- a/packages/jira-adapter/src/constants.ts
+++ b/packages/jira-adapter/src/constants.ts
@@ -66,3 +66,4 @@ export const ACCOUNT_ID_STRING = 'ACCOUNT_ID'
 export const ACCOUNT_IDS_FIELDS_NAMES = ['leadAccountId', 'authorAccountId', 'accountId']
 export const JIRA_USERS_PAGE = 'jira/people/search'
 export const ISSUE_EVENT_TYPE_NAME = 'IssueEvent'
+export const PRIORITY_SCHEME_TYPE_NAME = 'PriorityScheme'

--- a/packages/jira-adapter/src/filters/data_center/priority_scheme/priority_scheme_deploy.ts
+++ b/packages/jira-adapter/src/filters/data_center/priority_scheme/priority_scheme_deploy.ts
@@ -47,7 +47,7 @@ const createScheme = async (change: AdditionChange<InstanceElement>, client: Jir
   })
 
   if (!isPrioritySchemeResponse(response.data)) {
-    throw new Error('Received an invalid create priority scheme response')
+    throw new Error('Received an invalid create priority scheme response.')
   }
 
   instance.value.id = response.data.id

--- a/packages/jira-adapter/src/filters/data_center/priority_scheme/priority_scheme_deploy.ts
+++ b/packages/jira-adapter/src/filters/data_center/priority_scheme/priority_scheme_deploy.ts
@@ -1,0 +1,140 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { AdditionChange, CORE_ANNOTATIONS, getChangeData, InstanceElement, isAdditionChange, isInstanceChange, isModificationChange, ModificationChange, RemovalChange } from '@salto-io/adapter-api'
+import { createSchemeGuard, resolveChangeElement, resolveValues } from '@salto-io/adapter-utils'
+import Joi from 'joi'
+import _ from 'lodash'
+import { logger } from '@salto-io/logging'
+import { FilterCreator } from '../../../filter'
+import { PRIORITY_SCHEME_TYPE_NAME } from '../../../constants'
+import { deployChanges } from '../../../deployment/standard_deployment'
+import JiraClient from '../../../client/client'
+import { getLookUpName } from '../../../reference_mapping'
+import { addAnnotationRecursively, findObject, setTypeDeploymentAnnotations } from '../../../utils'
+
+const log = logger(module)
+
+type PrioritySchemeResponse = {
+  id: number
+}
+
+const PRIORITY_SCHEME_RESPONSE_SCHEME = Joi.object({
+  id: Joi.number().required(),
+}).unknown(true).required()
+
+export const isPrioritySchemeResponse = createSchemeGuard<PrioritySchemeResponse>(PRIORITY_SCHEME_RESPONSE_SCHEME, 'Received an invalid priority scheme response')
+
+const createScheme = async (change: AdditionChange<InstanceElement>, client: JiraClient): Promise<void> => {
+  const instance = getChangeData(change)
+  const resolvedInstance = await resolveValues(instance, getLookUpName)
+
+  const response = await client.post({
+    url: '/rest/api/2/priorityschemes',
+    data: resolvedInstance.value,
+  })
+
+  if (!isPrioritySchemeResponse(response.data)) {
+    throw new Error('Received an invalid create priority scheme response')
+  }
+
+  instance.value.id = response.data.id
+}
+
+/**
+ * The default priority scheme contains all the priorities and can't be modified.
+ * Therefore if the user adds or removes a priority, we don't want to really send the
+ * request to update the default scheme with the priorities because it will fail,
+ * so we should just skip it.
+ */
+const shouldSkipChange = async (change: ModificationChange<InstanceElement>): Promise<boolean> => {
+  const instance = getChangeData(change)
+  if (!instance.value.defaultScheme) {
+    return false
+  }
+
+  const resolvedChange = await resolveChangeElement(change, getLookUpName)
+
+  const beforeWithoutIds = _.omit(resolvedChange.data.before.value, 'optionIds')
+  const afterWithoutIds = _.omit(resolvedChange.data.after.value, 'optionIds')
+
+  return _.isEqual(beforeWithoutIds, afterWithoutIds)
+}
+
+const updateScheme = async (change: ModificationChange<InstanceElement>, client: JiraClient): Promise<void> => {
+  if (await shouldSkipChange(change)) {
+    log.debug('Skipping priority scheme change')
+    return
+  }
+  const instance = getChangeData(change)
+  const resolvedInstance = await resolveValues(instance, getLookUpName)
+
+  await client.put({
+    url: `/rest/api/2/priorityschemes/${resolvedInstance.value.id}`,
+    data: resolvedInstance.value,
+  })
+}
+
+const deleteScheme = async (change: RemovalChange<InstanceElement>, client: JiraClient): Promise<void> => {
+  const instance = getChangeData(change)
+
+  await client.delete({
+    url: `/rest/api/2/priorityschemes/${instance.value.id}`,
+  })
+}
+
+const filter: FilterCreator = ({ client }) => ({
+  onFetch: async elements => {
+    if (!client.isDataCenter) {
+      return
+    }
+
+    const schemeType = findObject(elements, PRIORITY_SCHEME_TYPE_NAME)
+    if (schemeType === undefined) {
+      return
+    }
+
+    setTypeDeploymentAnnotations(schemeType)
+    await addAnnotationRecursively(schemeType, CORE_ANNOTATIONS.CREATABLE)
+    await addAnnotationRecursively(schemeType, CORE_ANNOTATIONS.UPDATABLE)
+  },
+  deploy: async changes => {
+    const [relevantChanges, leftoverChanges] = _.partition(
+      changes,
+      change => isInstanceChange(change)
+        && getChangeData(change).elemID.typeName === PRIORITY_SCHEME_TYPE_NAME
+    )
+
+    const deployResult = await deployChanges(
+      relevantChanges.filter(isInstanceChange),
+      async change => {
+        if (isAdditionChange(change)) {
+          await createScheme(change, client)
+        } else if (isModificationChange(change)) {
+          await updateScheme(change, client)
+        } else {
+          await deleteScheme(change, client)
+        }
+      }
+    )
+
+    return {
+      leftoverChanges,
+      deployResult,
+    }
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/src/filters/data_center/priority_scheme/priority_scheme_deploy.ts
+++ b/packages/jira-adapter/src/filters/data_center/priority_scheme/priority_scheme_deploy.ts
@@ -117,7 +117,14 @@ const filter: FilterCreator = ({ client }) => ({
         && getChangeData(change).elemID.typeName === PRIORITY_SCHEME_TYPE_NAME
     )
 
+    if (relevantChanges.length !== 0 && !client.isDataCenter) {
+      // We should never get here since there is a change validator that will stop us before
+      throw new Error('Deploying priority schemes is not supported on Jira Cloud')
+    }
+
     const deployResult = await deployChanges(
+      // relevantChanges already contains only instances at this point,
+      // but the TS compiler is not aware of that
       relevantChanges.filter(isInstanceChange),
       async change => {
         if (isAdditionChange(change)) {

--- a/packages/jira-adapter/src/filters/data_center/priority_scheme/priority_scheme_fetch.ts
+++ b/packages/jira-adapter/src/filters/data_center/priority_scheme/priority_scheme_fetch.ts
@@ -1,0 +1,83 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemIdGetter, InstanceElement, ObjectType, Values } from '@salto-io/adapter-api'
+import { client as clientUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { collections } from '@salto-io/lowerdash'
+import { naclCase, pathNaclCase } from '@salto-io/adapter-utils'
+import { FilterCreator } from '../../../filter'
+import { JIRA, PRIORITY_SCHEME_TYPE_NAME } from '../../../constants'
+import { createPrioritySchemeType } from './types'
+
+const { makeArray } = collections.array
+const { awu } = collections.asynciterable
+
+const fetchSchemeValues = async (paginator: clientUtils.Paginator): Promise<Values[]> => {
+  const paginationArgs = {
+    url: '/rest/api/2/priorityschemes',
+    paginationField: 'startAt',
+  }
+  const schemeValues = await awu(paginator(
+    paginationArgs,
+    page => makeArray(page.schemes) as clientUtils.ResponseValue[]
+  )).flat().toArray()
+  return schemeValues
+}
+
+const createInstance = (values: Values, type: ObjectType, getElemIdFunc: ElemIdGetter | undefined): InstanceElement => {
+  const serviceIds = elementUtils.createServiceIds(values, 'id', type.elemID)
+
+  const defaultName = naclCase(values.name)
+
+  const instanceName = getElemIdFunc && serviceIds
+    ? getElemIdFunc(JIRA, serviceIds, defaultName).name
+    : defaultName
+
+  return new InstanceElement(
+    instanceName,
+    type,
+    values,
+    [JIRA, elementUtils.RECORDS_PATH, PRIORITY_SCHEME_TYPE_NAME, pathNaclCase(instanceName)]
+  )
+}
+
+const transformInstance = (instance: InstanceElement): void => {
+  if (!instance.value.defaultScheme) {
+    delete instance.value.defaultScheme
+  }
+}
+
+
+const filter: FilterCreator = ({ paginator, client, fetchQuery, getElemIdFunc }) => ({
+  onFetch: async elements => {
+    if (!client.isDataCenter || !fetchQuery.isTypeMatch(PRIORITY_SCHEME_TYPE_NAME)) {
+      return
+    }
+
+    const schemeValues = await fetchSchemeValues(paginator)
+
+    const type = createPrioritySchemeType()
+    schemeValues
+      .map(values => createInstance(values, type, getElemIdFunc))
+      .forEach(instance => {
+        transformInstance(instance)
+        elements.push(instance)
+      })
+
+    elements.push(type)
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/src/filters/data_center/priority_scheme/priority_scheme_project_association.ts
+++ b/packages/jira-adapter/src/filters/data_center/priority_scheme/priority_scheme_project_association.ts
@@ -1,0 +1,50 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
+import JiraClient from '../../../client/client'
+import { PROJECT_TYPE } from '../../../constants'
+import { FilterCreator } from '../../../filter'
+import { isPrioritySchemeResponse } from './priority_scheme_deploy'
+
+const getProjectPriorityScheme = async (instance: InstanceElement, client: JiraClient): Promise<number | undefined> => {
+  const response = await client.getSinglePage({
+    url: `/rest/api/2/project/${instance.value.id}/priorityscheme`,
+  })
+
+  if (!isPrioritySchemeResponse(response.data)) {
+    // No need to log, it will be logged inside isPrioritySchemeResponse
+    return undefined
+  }
+
+  return response.data.id
+}
+
+const filter: FilterCreator = ({ client }) => ({
+  onFetch: async elements => {
+    if (!client.isDataCenter) {
+      return
+    }
+
+    await Promise.all(elements
+      .filter(isInstanceElement)
+      .filter(instance => instance.elemID.typeName === PROJECT_TYPE)
+      .map(async instance => {
+        instance.value.priorityScheme = await getProjectPriorityScheme(instance, client)
+      }))
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/src/filters/data_center/priority_scheme/priority_scheme_project_association.ts
+++ b/packages/jira-adapter/src/filters/data_center/priority_scheme/priority_scheme_project_association.ts
@@ -24,12 +24,9 @@ const getProjectPriorityScheme = async (instance: InstanceElement, client: JiraC
     url: `/rest/api/2/project/${instance.value.id}/priorityscheme`,
   })
 
-  if (!isPrioritySchemeResponse(response.data)) {
-    // No need to log, it will be logged inside isPrioritySchemeResponse
-    return undefined
-  }
-
-  return response.data.id
+  return isPrioritySchemeResponse(response.data)
+    ? response.data.id
+    : undefined
 }
 
 const filter: FilterCreator = ({ client }) => ({

--- a/packages/jira-adapter/src/filters/data_center/priority_scheme/types.ts
+++ b/packages/jira-adapter/src/filters/data_center/priority_scheme/types.ts
@@ -1,0 +1,37 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, ListType, ObjectType } from '@salto-io/adapter-api'
+import { elements } from '@salto-io/adapter-components'
+import { JIRA, PRIORITY_SCHEME_TYPE_NAME } from '../../../constants'
+
+export const createPrioritySchemeType = (): ObjectType => new ObjectType({
+  elemID: new ElemID(JIRA, PRIORITY_SCHEME_TYPE_NAME),
+  fields: {
+    id: {
+      refType: BuiltinTypes.SERVICE_ID_NUMBER,
+      annotations: {
+        [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,
+      },
+    },
+    name: { refType: BuiltinTypes.STRING },
+    description: { refType: BuiltinTypes.STRING },
+    defaultOptionId: { refType: BuiltinTypes.STRING },
+    defaultScheme: { refType: BuiltinTypes.BOOLEAN },
+    optionIds: { refType: new ListType(BuiltinTypes.STRING) },
+  },
+  path: [JIRA, elements.TYPES_PATH, PRIORITY_SCHEME_TYPE_NAME],
+})

--- a/packages/jira-adapter/src/filters/project.ts
+++ b/packages/jira-adapter/src/filters/project.ts
@@ -75,6 +75,7 @@ const deployProjectSchemes = async (
   await deployScheme(instance, client, WORKFLOW_SCHEME_FIELD, 'workflowSchemeId')
   await deployScheme(instance, client, ISSUE_TYPE_SCREEN_SCHEME_FIELD, 'issueTypeScreenSchemeId')
   await deployScheme(instance, client, ISSUE_TYPE_SCHEME, 'issueTypeSchemeId')
+  await deployPriorityScheme(instance, client)
 }
 
 type ComponentsResponse = {
@@ -290,9 +291,6 @@ const filter: FilterCreator = ({ config, client }) => ({
         }
 
         await deployScheme(instance, client, FIELD_CONFIG_SCHEME_FIELD, 'fieldConfigurationSchemeId')
-        if (client.isDataCenter) {
-          await deployPriorityScheme(instance, client)
-        }
 
         if (isAdditionChange(change)) {
           // In some projects, some components are created as a side effect

--- a/packages/jira-adapter/src/filters/project.ts
+++ b/packages/jira-adapter/src/filters/project.ts
@@ -32,6 +32,7 @@ const COMPONENTS_FIELD = 'components'
 const ISSUE_TYPE_SCREEN_SCHEME_FIELD = 'issueTypeScreenScheme'
 const FIELD_CONFIG_SCHEME_FIELD = 'fieldConfigurationScheme'
 const ISSUE_TYPE_SCHEME = 'issueTypeScheme'
+const PRIORITY_SCHEME = 'priorityScheme'
 
 const log = logger(module)
 
@@ -50,6 +51,21 @@ const deployScheme = async (
       },
     })
   }
+}
+
+const deployPriorityScheme = async (
+  instance: InstanceElement,
+  client: JiraClient,
+): Promise<void> => {
+  if (!client.isDataCenter) {
+    return
+  }
+  await client.put({
+    url: `/rest/api/2/project/${instance.value.id}/priorityscheme`,
+    data: {
+      id: instance.value[PRIORITY_SCHEME],
+    },
+  })
 }
 
 const deployProjectSchemes = async (
@@ -173,6 +189,10 @@ const filter: FilterCreator = ({ config, client }) => ({
       setFieldDeploymentAnnotations(projectType, ISSUE_TYPE_SCHEME)
       setFieldDeploymentAnnotations(projectType, COMPONENTS_FIELD)
       setFieldDeploymentAnnotations(projectType, PROJECT_CONTEXTS_FIELD)
+
+      if (client.isDataCenter) {
+        setFieldDeploymentAnnotations(projectType, PRIORITY_SCHEME)
+      }
     }
 
     elements
@@ -237,11 +257,13 @@ const filter: FilterCreator = ({ config, client }) => ({
                 FIELD_CONFIG_SCHEME_FIELD,
                 ISSUE_TYPE_SCHEME,
                 PROJECT_CONTEXTS_FIELD,
+                PRIORITY_SCHEME,
               ]
               : [
                 COMPONENTS_FIELD,
                 FIELD_CONFIG_SCHEME_FIELD,
                 PROJECT_CONTEXTS_FIELD,
+                PRIORITY_SCHEME,
               ],
           })
         } catch (error) {
@@ -266,7 +288,11 @@ const filter: FilterCreator = ({ config, client }) => ({
         if (shouldSeparateSchemeDeployment(change, client.isDataCenter)) {
           await deployProjectSchemes(instance, client)
         }
+
         await deployScheme(instance, client, FIELD_CONFIG_SCHEME_FIELD, 'fieldConfigurationSchemeId')
+        if (client.isDataCenter) {
+          await deployPriorityScheme(instance, client)
+        }
 
         if (isAdditionChange(change)) {
           // In some projects, some components are created as a side effect

--- a/packages/jira-adapter/src/filters/service_url/service_url_information.ts
+++ b/packages/jira-adapter/src/filters/service_url/service_url_information.ts
@@ -16,6 +16,7 @@
 import { Element, InstanceElement, isInstanceElement, CORE_ANNOTATIONS, getChangeData, isInstanceChange, isAdditionChange } from '@salto-io/adapter-api'
 import { getParents } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
+import { PRIORITY_SCHEME_TYPE_NAME } from '../../constants'
 import { FilterCreator } from '../../filter'
 
 const log = logger(module)
@@ -63,45 +64,50 @@ const boardInformation: ServiceUrlSupplier = {
   supplier: createBoardServiceUrl,
 }
 
-const ProjectComponentInformation: ServiceUrlSupplier = {
+const projectComponentInformation: ServiceUrlSupplier = {
   typeName: 'ProjectComponent',
   supplier: createProjectComponentServiceUrl,
 }
 
-const CustomFieldContextInformation: ServiceUrlSupplier = {
+const customFieldContextInformation: ServiceUrlSupplier = {
   typeName: 'CustomFieldContext',
   supplier: createCustomFieldContextServiceUrl,
 }
 
-const FieldInformation: ServiceUrlSupplier = {
+const fieldInformation: ServiceUrlSupplier = {
   typeName: 'Field',
   supplier: createFieldServiceUrl,
 }
 
-const DashboardGadgetInformation: ServiceUrlSupplier = {
+const dashboardGadgetInformation: ServiceUrlSupplier = {
   typeName: 'DashboardGadget',
   supplier: createDashboardGadgetServiceUrl,
 }
 
-const WebhookInformation: ServiceUrlSupplier = {
+const webhookInformation: ServiceUrlSupplier = {
   typeName: 'Webhook',
   supplier: (_: InstanceElement) => '/plugins/servlet/webhooks#',
 }
 
-const SecurityLevelInformation: ServiceUrlSupplier = {
+const securityLevelInformation: ServiceUrlSupplier = {
   typeName: 'SecurityLevel',
   supplier: createSecurityLevelServiceUrl,
+}
 
+const prioritySchemeInformation: ServiceUrlSupplier = {
+  typeName: PRIORITY_SCHEME_TYPE_NAME,
+  supplier: instance => `/secure/admin/EditPriorityScheme!default.jspa?schemeId=${instance.value.id}`,
 }
 
 const serviceUrlInformation: ServiceUrlSupplier[] = [
   boardInformation,
-  ProjectComponentInformation,
-  CustomFieldContextInformation,
-  FieldInformation,
-  DashboardGadgetInformation,
-  WebhookInformation,
-  SecurityLevelInformation,
+  projectComponentInformation,
+  customFieldContextInformation,
+  fieldInformation,
+  dashboardGadgetInformation,
+  webhookInformation,
+  securityLevelInformation,
+  prioritySchemeInformation,
 ]
 
 const supplyServiceUrl = (

--- a/packages/jira-adapter/src/product_settings/data_center/api_config.ts
+++ b/packages/jira-adapter/src/product_settings/data_center/api_config.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import { PRIORITY_SCHEME_TYPE_NAME } from '../../constants'
 import { JiraApiConfig } from '../../config/api_config'
 
 export const DC_ADDITIONAL_TYPE_NAME_OVERRIDES = [
@@ -139,5 +140,8 @@ export const DC_DEFAULT_API_DEFINITIONS: Partial<JiraApiConfig> = {
         dataField: '.',
       },
     },
+  },
+  supportedTypes: {
+    [PRIORITY_SCHEME_TYPE_NAME]: [],
   },
 }

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -21,7 +21,7 @@ import { AUTOMATION_PROJECT_TYPE, AUTOMATION_FIELD, AUTOMATION_COMPONENT_VALUE_T
   BOARD_ESTIMATION_TYPE, ISSUE_TYPE_NAME, ISSUE_TYPE_SCHEMA_NAME, AUTOMATION_STATUS,
   AUTOMATION_CONDITION, AUTOMATION_CONDITION_CRITERIA, AUTOMATION_SUBTASK,
   AUTOMATION_ROLE, AUTOMATION_GROUP, AUTOMATION_EMAIL_RECIPENT, PROJECT_TYPE,
-  SECURITY_LEVEL_TYPE, SECURITY_SCHEME_TYPE, STATUS_TYPE_NAME, WORKFLOW_TYPE_NAME, AUTOMATION_COMPARE_VALUE, AUTOMATION_TYPE, AUTOMATION_LABEL_TYPE, GROUP_TYPE_NAME } from './constants'
+  SECURITY_LEVEL_TYPE, SECURITY_SCHEME_TYPE, STATUS_TYPE_NAME, WORKFLOW_TYPE_NAME, AUTOMATION_COMPARE_VALUE, AUTOMATION_TYPE, AUTOMATION_LABEL_TYPE, GROUP_TYPE_NAME, PRIORITY_SCHEME_TYPE_NAME } from './constants'
 import { getFieldsLookUpName } from './filters/fields/field_type_references_filter'
 import { getRefType } from './references/workflow_properties'
 
@@ -258,6 +258,11 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     src: { field: 'issueSecurityScheme', parentTypes: ['Project'] },
     serializationStrategy: 'id',
     target: { type: 'SecurityScheme' },
+  },
+  {
+    src: { field: 'priorityScheme', parentTypes: ['Project'] },
+    serializationStrategy: 'id',
+    target: { type: PRIORITY_SCHEME_TYPE_NAME },
   },
   {
     src: { field: 'fields', parentTypes: ['ScreenableTab'] },
@@ -542,6 +547,16 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     src: { field: 'value', parentTypes: ['WorkflowProperty'] },
     JiraSerializationStrategy: 'groupStrategyByOriginalName',
     target: { typeContext: 'workflowStatusPropertiesContext' },
+  },
+  {
+    src: { field: 'optionIds', parentTypes: ['PriorityScheme'] },
+    serializationStrategy: 'id',
+    target: { type: 'Priority' },
+  },
+  {
+    src: { field: 'defaultOptionId', parentTypes: ['PriorityScheme'] },
+    serializationStrategy: 'id',
+    target: { type: 'Priority' },
   },
 ]
 

--- a/packages/jira-adapter/test/filters/data_center/priority_scheme/priority_scheme_deploy.test.ts
+++ b/packages/jira-adapter/test/filters/data_center/priority_scheme/priority_scheme_deploy.test.ts
@@ -1,0 +1,190 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType, CORE_ANNOTATIONS, BuiltinTypes, toChange } from '@salto-io/adapter-api'
+import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
+import { MockInterface } from '@salto-io/test-utils'
+import { getFilterParams, mockClient } from '../../../utils'
+import prioritySchemeDeployFilter from '../../../../src/filters/data_center/priority_scheme/priority_scheme_deploy'
+import { JIRA, PRIORITY_SCHEME_TYPE_NAME } from '../../../../src/constants'
+import JiraClient from '../../../../src/client/client'
+
+describe('prioritySchemeDeployFilter', () => {
+  let filter: filterUtils.FilterWith<'onFetch' | 'deploy'>
+  let type: ObjectType
+  let instance: InstanceElement
+  let client: JiraClient
+  let connection: MockInterface<clientUtils.APIConnection>
+
+
+  beforeEach(async () => {
+    const { client: cli, paginator, connection: conn } = mockClient(true)
+    client = cli
+    connection = conn
+
+    filter = prioritySchemeDeployFilter(getFilterParams({
+      client,
+      paginator,
+    })) as filterUtils.FilterWith<'onFetch' | 'deploy'>
+
+    type = new ObjectType({
+      elemID: new ElemID(JIRA, PRIORITY_SCHEME_TYPE_NAME),
+      fields: {
+        name: {
+          refType: BuiltinTypes.STRING,
+        },
+      },
+    })
+
+    instance = new InstanceElement(
+      'instance',
+      type,
+      {
+        name: 'someName',
+        description: 'desc',
+      }
+    )
+  })
+
+  describe('onFetch', () => {
+    it('should add deployment annotations', async () => {
+      await filter.onFetch([type])
+
+      expect(type.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+        [CORE_ANNOTATIONS.DELETABLE]: true,
+      })
+
+      expect(type.fields.name.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
+    })
+
+    it('should not add deployment annotations if not data center', async () => {
+      const { client: cli, paginator, connection: conn } = mockClient(false)
+      client = cli
+      connection = conn
+
+      filter = prioritySchemeDeployFilter(getFilterParams({
+        client,
+        paginator,
+      })) as filterUtils.FilterWith<'onFetch' | 'deploy'>
+
+      await filter.onFetch([type])
+
+      expect(type.annotations).toEqual({})
+      expect(type.fields.name.annotations).toEqual({})
+    })
+
+    it('should not add deployment annotations if type not found', async () => {
+      await filter.onFetch([])
+      expect(type.annotations).toEqual({})
+      expect(type.fields.name.annotations).toEqual({})
+    })
+  })
+
+  describe('deploy', () => {
+    beforeEach(() => {
+      connection.post.mockResolvedValue({
+        status: 200,
+        data: {
+          id: 2,
+        },
+      })
+    })
+
+    it('should create priority scheme', async () => {
+      await filter.deploy([toChange({ after: instance })])
+
+      expect(instance.value.id).toBe(2)
+
+      expect(connection.post).toHaveBeenCalledWith(
+        '/rest/api/2/priorityschemes',
+        {
+          name: 'someName',
+          description: 'desc',
+        },
+        undefined,
+      )
+    })
+
+    it('should throw if received invalid response from create', async () => {
+      connection.post.mockResolvedValue({
+        status: 200,
+        data: {},
+      })
+      const { deployResult } = await filter.deploy([toChange({ after: instance })])
+      expect(deployResult.errors).toHaveLength(1)
+    })
+
+    it('should delete priority scheme', async () => {
+      instance.value.id = 2
+      await filter.deploy([toChange({ before: instance })])
+
+      expect(connection.delete).toHaveBeenCalledWith(
+        '/rest/api/2/priorityschemes/2',
+        undefined,
+      )
+    })
+
+    it('should modify priority scheme', async () => {
+      instance.value.id = 2
+      await filter.deploy([toChange({ before: instance, after: instance })])
+
+      expect(connection.put).toHaveBeenCalledWith(
+        '/rest/api/2/priorityschemes/2',
+        {
+          id: 2,
+          name: 'someName',
+          description: 'desc',
+        },
+        undefined,
+      )
+    })
+
+    it('should skip default scheme if there were changes only in optionIds', async () => {
+      instance.value.id = 2
+      instance.value.defaultScheme = true
+      const after = instance.clone()
+      after.value.optionIds = [1]
+      await filter.deploy([toChange({ before: instance, after })])
+
+      expect(connection.put).not.toHaveBeenCalled()
+    })
+
+    it('should not skip default scheme if there were other changes besides optionIds', async () => {
+      instance.value.id = 2
+      instance.value.defaultScheme = true
+      const after = instance.clone()
+      after.value.optionIds = [1]
+      after.value.description = 'desc2'
+      await filter.deploy([toChange({ before: instance, after })])
+
+      expect(connection.put).toHaveBeenCalledWith(
+        '/rest/api/2/priorityschemes/2',
+        {
+          id: 2,
+          name: 'someName',
+          description: 'desc2',
+          optionIds: [1],
+          defaultScheme: true,
+        },
+        undefined,
+      )
+    })
+  })
+})

--- a/packages/jira-adapter/test/filters/data_center/priority_scheme/priority_scheme_deploy.test.ts
+++ b/packages/jira-adapter/test/filters/data_center/priority_scheme/priority_scheme_deploy.test.ts
@@ -54,6 +54,7 @@ describe('prioritySchemeDeployFilter', () => {
       {
         name: 'someName',
         description: 'desc',
+        optionIds: [1, 2],
       }
     )
   })
@@ -91,9 +92,16 @@ describe('prioritySchemeDeployFilter', () => {
     })
 
     it('should not add deployment annotations if type not found', async () => {
-      await filter.onFetch([])
-      expect(type.annotations).toEqual({})
-      expect(type.fields.name.annotations).toEqual({})
+      const otherType = new ObjectType({
+        elemID: new ElemID(JIRA, 'other'),
+        fields: {
+          name: {
+            refType: BuiltinTypes.STRING,
+          },
+        },
+      })
+      await filter.onFetch([otherType])
+      expect(otherType.annotations).toEqual({})
     })
   })
 
@@ -117,6 +125,7 @@ describe('prioritySchemeDeployFilter', () => {
         {
           name: 'someName',
           description: 'desc',
+          optionIds: [1, 2],
         },
         undefined,
       )
@@ -151,6 +160,7 @@ describe('prioritySchemeDeployFilter', () => {
           id: 2,
           name: 'someName',
           description: 'desc',
+          optionIds: [1, 2],
         },
         undefined,
       )

--- a/packages/jira-adapter/test/filters/data_center/priority_scheme/priority_scheme_fetch.test.ts
+++ b/packages/jira-adapter/test/filters/data_center/priority_scheme/priority_scheme_fetch.test.ts
@@ -1,0 +1,158 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Element, Value, InstanceElement, ElemID } from '@salto-io/adapter-api'
+import { filterUtils, client as clientUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { MockInterface } from '@salto-io/test-utils'
+import { getFilterParams, mockClient } from '../../../utils'
+import prioritySchemeFetchFilter from '../../../../src/filters/data_center/priority_scheme/priority_scheme_fetch'
+import JiraClient from '../../../../src/client/client'
+import { JIRA } from '../../../../src/constants'
+
+
+describe('prioritySchemeFetchFilter', () => {
+  let filter: filterUtils.FilterWith<'onFetch'>
+  let client: JiraClient
+  let paginator: clientUtils.Paginator
+  let connection: MockInterface<clientUtils.APIConnection>
+  let fetchQuery: MockInterface<elementUtils.query.ElementQuery>
+  let prioritySchemeResponse: Value
+
+  beforeEach(async () => {
+    const { client: cli, paginator: cliPaginator, connection: conn } = mockClient(true)
+    client = cli
+    paginator = cliPaginator
+    connection = conn
+
+    fetchQuery = elementUtils.query.createMockQuery()
+
+    filter = prioritySchemeFetchFilter(getFilterParams({
+      client,
+      paginator,
+      fetchQuery,
+    })) as filterUtils.FilterWith<'onFetch'>
+
+    prioritySchemeResponse = {
+      status: 200,
+      data: {
+        schemes: [
+          {
+            id: '1',
+            name: 'name',
+            description: 'desc',
+            optionIds: [
+              '1',
+              '2',
+            ],
+            defaultOptionId: '2',
+          },
+        ],
+      },
+    }
+
+    connection.get.mockResolvedValue(prioritySchemeResponse)
+  })
+
+  describe('onFetch', () => {
+    it('should fetch priority schemes from the service', async () => {
+      const elements: Element[] = []
+      await filter.onFetch(elements)
+
+      expect(elements).toHaveLength(2)
+
+      const [instance, type] = elements
+
+      expect((instance as InstanceElement).value).toEqual({
+        id: '1',
+        name: 'name',
+        description: 'desc',
+        optionIds: ['1', '2'],
+        defaultOptionId: '2',
+      })
+
+      expect(instance.elemID.getFullName()).toEqual('jira.PriorityScheme.instance.name')
+      expect(type.elemID.getFullName()).toEqual('jira.PriorityScheme')
+
+      expect(connection.get).toHaveBeenCalledWith(
+        '/rest/api/2/priorityschemes',
+        undefined,
+      )
+    })
+
+    it('should not fetch priority schemes if running in jira cloud', async () => {
+      const { client: cli, paginator: cliPaginator, connection: conn } = mockClient(false)
+      client = cli
+      paginator = cliPaginator
+      connection = conn
+
+      filter = prioritySchemeFetchFilter(getFilterParams({
+        client,
+        paginator,
+        fetchQuery,
+      })) as filterUtils.FilterWith<'onFetch'>
+
+      const elements: Element[] = []
+      await filter.onFetch(elements)
+
+      expect(elements).toHaveLength(0)
+
+      expect(connection.get).not.toHaveBeenCalled()
+    })
+
+    it('should not fetch priority schemes if priority schemes were excluded', async () => {
+      fetchQuery.isTypeMatch.mockReturnValue(false)
+      const elements: Element[] = []
+      await filter.onFetch(elements)
+
+      expect(elements).toHaveLength(0)
+
+      expect(connection.get).not.toHaveBeenCalled()
+    })
+
+    it('should use elemIdGetter', async () => {
+      filter = prioritySchemeFetchFilter(getFilterParams({
+        client,
+        paginator,
+        getElemIdFunc: () => new ElemID(JIRA, 'someName'),
+      })) as filterUtils.FilterWith<'onFetch'>
+
+      const elements: Element[] = []
+      await filter.onFetch(elements)
+
+      const instance = elements[0]
+      expect(instance.elemID.getFullName()).toEqual('jira.PriorityScheme.instance.someName')
+    })
+
+    it('should return default when it is true', async () => {
+      prioritySchemeResponse.data.schemes[0].defaultScheme = true
+
+      const elements: Element[] = []
+      await filter.onFetch(elements)
+
+      expect(elements).toHaveLength(2)
+
+      const [instance] = elements
+
+      expect((instance as InstanceElement).value).toEqual({
+        id: '1',
+        name: 'name',
+        description: 'desc',
+        optionIds: ['1', '2'],
+        defaultOptionId: '2',
+        defaultScheme: true,
+      })
+    })
+  })
+})

--- a/packages/jira-adapter/test/filters/data_center/priority_scheme/priority_scheme_project_association.test.ts
+++ b/packages/jira-adapter/test/filters/data_center/priority_scheme/priority_scheme_project_association.test.ts
@@ -1,0 +1,113 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Value, InstanceElement, ElemID, ObjectType } from '@salto-io/adapter-api'
+import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
+import { MockInterface } from '@salto-io/test-utils'
+import { getFilterParams, mockClient } from '../../../utils'
+import prioritySchemeProjectAssociationFilter from '../../../../src/filters/data_center/priority_scheme/priority_scheme_project_association'
+import JiraClient from '../../../../src/client/client'
+import { JIRA, PROJECT_TYPE } from '../../../../src/constants'
+
+
+describe('prioritySchemeProjectAssociationFilter', () => {
+  let filter: filterUtils.FilterWith<'onFetch'>
+  let client: JiraClient
+  let paginator: clientUtils.Paginator
+  let connection: MockInterface<clientUtils.APIConnection>
+  let prioritySchemeResponse: Value
+
+  let projectInstance: InstanceElement
+  let projectType: ObjectType
+
+  beforeEach(async () => {
+    const { client: cli, paginator: cliPaginator, connection: conn } = mockClient(true)
+    client = cli
+    paginator = cliPaginator
+    connection = conn
+
+    filter = prioritySchemeProjectAssociationFilter(getFilterParams({
+      client,
+      paginator,
+    })) as filterUtils.FilterWith<'onFetch'>
+
+    prioritySchemeResponse = {
+      status: 200,
+      data: {
+        id: 2,
+      },
+    }
+
+    projectType = new ObjectType({
+      elemID: new ElemID(JIRA, PROJECT_TYPE),
+    })
+
+    projectInstance = new InstanceElement(
+      'inst',
+      projectType,
+      {
+        id: 1,
+      }
+    )
+
+    connection.get.mockResolvedValue(prioritySchemeResponse)
+  })
+
+  describe('onFetch', () => {
+    it('should fetch project priority scheme', async () => {
+      await filter.onFetch([projectInstance])
+
+      expect(projectInstance.value).toEqual({
+        id: 1,
+        priorityScheme: 2,
+      })
+
+      expect(connection.get).toHaveBeenCalledWith(
+        '/rest/api/2/project/1/priorityscheme',
+        undefined,
+      )
+    })
+
+    it('should not fetch priority scheme if running in jira cloud', async () => {
+      const { client: cli, paginator: cliPaginator, connection: conn } = mockClient(false)
+      client = cli
+      paginator = cliPaginator
+      connection = conn
+
+      filter = prioritySchemeProjectAssociationFilter(getFilterParams({
+        client,
+        paginator,
+      })) as filterUtils.FilterWith<'onFetch'>
+
+      await filter.onFetch([projectInstance])
+
+      expect(projectInstance.value).toEqual({
+        id: 1,
+      })
+
+      expect(connection.get).not.toHaveBeenCalled()
+    })
+
+    it('should do nothing if response is invalid', async () => {
+      prioritySchemeResponse.data = {}
+
+      await filter.onFetch([projectInstance])
+
+      expect(projectInstance.value).toEqual({
+        id: 1,
+      })
+    })
+  })
+})

--- a/packages/jira-adapter/test/filters/project.test.ts
+++ b/packages/jira-adapter/test/filters/project.test.ts
@@ -63,6 +63,7 @@ describe('projectFilter', () => {
         issueTypeScreenScheme: { refType: BuiltinTypes.STRING },
         fieldConfigurationScheme: { refType: BuiltinTypes.STRING },
         issueTypeScheme: { refType: BuiltinTypes.STRING },
+        priorityScheme: { refType: BuiltinTypes.STRING },
         components: { refType: BuiltinTypes.STRING },
       },
     })
@@ -108,11 +109,13 @@ describe('projectFilter', () => {
         issueSecurityScheme: {
           id: '8',
         },
+        priorityScheme: 9,
       }
-      await filter.onFetch([type, instance])
     })
 
-    it('should add the deployment annotations to the schemes', () => {
+    it('should add the deployment annotations to the schemes', async () => {
+      await filter.onFetch([type, instance])
+
       expect(type.fields.workflowScheme.annotations).toEqual({
         [CORE_ANNOTATIONS.CREATABLE]: true,
         [CORE_ANNOTATIONS.UPDATABLE]: true,
@@ -129,9 +132,51 @@ describe('projectFilter', () => {
         [CORE_ANNOTATIONS.CREATABLE]: true,
         [CORE_ANNOTATIONS.UPDATABLE]: true,
       })
+
+      expect(type.fields.priorityScheme.annotations).toEqual({
+      })
     })
 
-    it('should add the deployment annotations to the components', () => {
+    it('should not add the deployment annotations to priority scheme if cloud', async () => {
+      const { client: cli, paginator, connection: conn } = mockClient(true)
+      client = cli
+      connection = conn
+
+      deployChangeMock.mockClear()
+
+      filter = projectFilter(getFilterParams({
+        client,
+        paginator,
+      })) as typeof filter
+
+      await filter.onFetch([type, instance])
+
+      expect(type.fields.workflowScheme.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
+      expect(type.fields.issueTypeScreenScheme.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
+      expect(type.fields.fieldConfigurationScheme.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
+      expect(type.fields.issueTypeScheme.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
+
+      expect(type.fields.priorityScheme.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
+    })
+
+    it('should add the deployment annotations to the components', async () => {
+      await filter.onFetch([type, instance])
+
       expect(type.fields.components.annotations).toEqual({
         [CORE_ANNOTATIONS.CREATABLE]: true,
         [CORE_ANNOTATIONS.UPDATABLE]: true,
@@ -139,10 +184,14 @@ describe('projectFilter', () => {
     })
 
     it('should set the leadAccountId', async () => {
+      await filter.onFetch([type, instance])
+
       expect(instance.value.leadAccountId).toEqual('1')
     })
 
     it('should set the schemas ids', async () => {
+      await filter.onFetch([type, instance])
+
       expect(instance.value.workflowScheme).toEqual('2')
       expect(instance.value.issueTypeScreenScheme).toEqual('3')
       expect(instance.value.fieldConfigurationScheme).toEqual('4')
@@ -153,6 +202,8 @@ describe('projectFilter', () => {
     })
 
     it('For impartial instance should set undefined', async () => {
+      await filter.onFetch([type, instance])
+
       instance.value = {
       }
       await filter.onFetch([instance])
@@ -167,28 +218,64 @@ describe('projectFilter', () => {
       const afterInstance = instance.clone()
       afterInstance.value.workflowScheme = 1
       afterInstance.value.id = 2
+      afterInstance.value.priorityScheme = 9
 
       change = toChange({ before: instance, after: afterInstance })
-
-      await filter.deploy([change])
     })
-    it('should call deployChange and ignore scheme', () => {
+    it('should call deployChange and ignore scheme', async () => {
+      await filter.deploy([change])
       expect(deployChangeMock).toHaveBeenCalledWith({
         change,
         client,
         endpointDetails: getDefaultConfig({ isDataCenter: false })
           .apiDefinitions.types.Project.deployRequests,
         fieldsToIgnore: ['components', 'workflowScheme', 'issueTypeScreenScheme',
-          'fieldConfigurationScheme', 'issueTypeScheme', PROJECT_CONTEXTS_FIELD],
+          'fieldConfigurationScheme', 'issueTypeScheme', PROJECT_CONTEXTS_FIELD, 'priorityScheme'],
       })
     })
 
-    it('should call the endpoint to set the scheme', () => {
+    it('should call the endpoint to set the scheme', async () => {
+      await filter.deploy([change])
       expect(connection.put).toHaveBeenCalledWith(
         '/rest/api/3/workflowscheme/project',
         {
           workflowSchemeId: 1,
           projectId: 2,
+        },
+        undefined,
+      )
+    })
+
+    it('should call the endpoint to set the priorityScheme', async () => {
+      const { client: cli, paginator, connection: conn } = mockClient(true)
+      client = cli
+      connection = conn
+
+      deployChangeMock.mockClear()
+
+      filter = projectFilter(getFilterParams({
+        client,
+        paginator,
+      })) as typeof filter
+
+      await filter.deploy([change])
+
+      expect(connection.put).toHaveBeenCalledWith(
+        '/rest/api/2/project/2/priorityscheme',
+        {
+          id: 9,
+        },
+        undefined,
+      )
+    })
+
+    it('should not call the endpoint to set the priorityScheme if cloud', async () => {
+      await filter.deploy([change])
+
+      expect(connection.put).not.toHaveBeenCalledWith(
+        '/rest/api/2/project/2/priorityscheme',
+        {
+          id: 9,
         },
         undefined,
       )
@@ -200,6 +287,7 @@ describe('projectFilter', () => {
 
     beforeEach(async () => {
       instance.value.id = 3
+      instance.value.priorityScheme = 9
       change = toChange({ after: instance })
 
       connection.get.mockResolvedValue({
@@ -215,27 +303,31 @@ describe('projectFilter', () => {
           ],
         },
       })
-
-      await filter.deploy([change])
     })
-    it('should call deployChange and ignore the right fields', () => {
+    it('should call deployChange and ignore the right fields', async () => {
+      await filter.deploy([change])
+
       expect(deployChangeMock).toHaveBeenCalledWith({
         change,
         client,
         endpointDetails: getDefaultConfig({ isDataCenter: false })
           .apiDefinitions.types.Project.deployRequests,
-        fieldsToIgnore: ['components', 'fieldConfigurationScheme', PROJECT_CONTEXTS_FIELD],
+        fieldsToIgnore: ['components', 'fieldConfigurationScheme', PROJECT_CONTEXTS_FIELD, 'priorityScheme'],
       })
     })
 
-    it('should call the endpoint to get the components', () => {
+    it('should call the endpoint to get the components', async () => {
+      await filter.deploy([change])
+
       expect(connection.get).toHaveBeenCalledWith(
         '/rest/api/3/project/3',
         undefined,
       )
     })
 
-    it('should call the endpoint to remove the components', () => {
+    it('should call the endpoint to remove the components', async () => {
+      await filter.deploy([change])
+
       expect(connection.delete).toHaveBeenCalledWith(
         '/rest/api/3/component/1',
         undefined,
@@ -243,6 +335,41 @@ describe('projectFilter', () => {
 
       expect(connection.delete).toHaveBeenCalledWith(
         '/rest/api/3/component/2',
+        undefined,
+      )
+    })
+
+    it('should call the endpoint to set the priorityScheme', async () => {
+      const { client: cli, paginator, connection: conn } = mockClient(true)
+      client = cli
+      connection = conn
+
+      deployChangeMock.mockClear()
+
+      filter = projectFilter(getFilterParams({
+        client,
+        paginator,
+      })) as typeof filter
+
+      await filter.deploy([change])
+
+      expect(connection.put).toHaveBeenCalledWith(
+        '/rest/api/2/project/3/priorityscheme',
+        {
+          id: 9,
+        },
+        undefined,
+      )
+    })
+
+    it('should not call the endpoint to set the priorityScheme if cloud', async () => {
+      await filter.deploy([change])
+
+      expect(connection.put).not.toHaveBeenCalledWith(
+        '/rest/api/2/project/3/priorityscheme',
+        {
+          id: 9,
+        },
         undefined,
       )
     })
@@ -260,6 +387,7 @@ describe('projectFilter', () => {
 
       instance.value.id = '3'
       instance.value.key = 'key'
+
       change = toChange({ after: instance })
 
       connection.get.mockImplementation(async url => {
@@ -304,7 +432,7 @@ describe('projectFilter', () => {
         client,
         endpointDetails: getDefaultConfig({ isDataCenter: false })
           .apiDefinitions.types.Project.deployRequests,
-        fieldsToIgnore: ['components', 'fieldConfigurationScheme', PROJECT_CONTEXTS_FIELD],
+        fieldsToIgnore: ['components', 'fieldConfigurationScheme', PROJECT_CONTEXTS_FIELD, 'priorityScheme'],
       })
     })
 
@@ -402,7 +530,7 @@ describe('projectFilter', () => {
         client,
         endpointDetails: getDefaultConfig({ isDataCenter: false })
           .apiDefinitions.types.Project.deployRequests,
-        fieldsToIgnore: ['components', 'fieldConfigurationScheme', PROJECT_CONTEXTS_FIELD],
+        fieldsToIgnore: ['components', 'fieldConfigurationScheme', PROJECT_CONTEXTS_FIELD, 'priorityScheme'],
       })
     })
 

--- a/packages/jira-adapter/test/filters/project.test.ts
+++ b/packages/jira-adapter/test/filters/project.test.ts
@@ -137,7 +137,7 @@ describe('projectFilter', () => {
       })
     })
 
-    it('should not add the deployment annotations to priority scheme if cloud', async () => {
+    it('should add the deployment annotations to priority scheme if DC', async () => {
       const { client: cli, paginator, connection: conn } = mockClient(true)
       client = cli
       connection = conn
@@ -218,7 +218,7 @@ describe('projectFilter', () => {
       const afterInstance = instance.clone()
       afterInstance.value.workflowScheme = 1
       afterInstance.value.id = 2
-      afterInstance.value.priorityScheme = 9
+      afterInstance.value.priorityScheme = 10
 
       change = toChange({ before: instance, after: afterInstance })
     })
@@ -263,7 +263,7 @@ describe('projectFilter', () => {
       expect(connection.put).toHaveBeenCalledWith(
         '/rest/api/2/project/2/priorityscheme',
         {
-          id: 9,
+          id: 10,
         },
         undefined,
       )
@@ -275,7 +275,7 @@ describe('projectFilter', () => {
       expect(connection.put).not.toHaveBeenCalledWith(
         '/rest/api/2/project/2/priorityscheme',
         {
-          id: 9,
+          id: 10,
         },
         undefined,
       )
@@ -287,7 +287,7 @@ describe('projectFilter', () => {
 
     beforeEach(async () => {
       instance.value.id = 3
-      instance.value.priorityScheme = 9
+      instance.value.priorityScheme = 11
       change = toChange({ after: instance })
 
       connection.get.mockResolvedValue({
@@ -356,7 +356,7 @@ describe('projectFilter', () => {
       expect(connection.put).toHaveBeenCalledWith(
         '/rest/api/2/project/3/priorityscheme',
         {
-          id: 9,
+          id: 11,
         },
         undefined,
       )
@@ -368,7 +368,7 @@ describe('projectFilter', () => {
       expect(connection.put).not.toHaveBeenCalledWith(
         '/rest/api/2/project/3/priorityscheme',
         {
-          id: 9,
+          id: 11,
         },
         undefined,
       )
@@ -635,7 +635,7 @@ describe('projectFilter', () => {
           endpointDetails: getDefaultConfig({ isDataCenter: true })
             .apiDefinitions.types.Project.deployRequests,
           fieldsToIgnore: ['components', 'workflowScheme', 'issueTypeScreenScheme',
-            'fieldConfigurationScheme', 'issueTypeScheme', PROJECT_CONTEXTS_FIELD],
+            'fieldConfigurationScheme', 'issueTypeScheme', PROJECT_CONTEXTS_FIELD, 'priorityScheme'],
         })
       })
       it('should call the endpoint to set the scheme', () => {


### PR DESCRIPTION
Added support for fetching and deploying priority scheme and the association between project to priority scheme

---
_Release Notes_: 
None

---
_User Notifications_: 
None