### PR TITLE
SALTO-3049: fix article attachment size validator bug

### DIFF
--- a/packages/zendesk-adapter/src/change_validators/article_attachment_size.ts
+++ b/packages/zendesk-adapter/src/change_validators/article_attachment_size.ts
@@ -21,7 +21,7 @@ const { awu } = collections.asynciterable
 
 const SIZE_20_MB = 20 * 1024 * 1024
 export const articleAttachmentSizeValidator: ChangeValidator = async changes => {
-  const check = await awu(changes)
+  const invalidAttachments = await awu(changes)
     .filter(isAdditionOrModificationChange)
     .map(getChangeData)
     .filter(isInstanceElement)
@@ -32,7 +32,7 @@ export const articleAttachmentSizeValidator: ChangeValidator = async changes => 
     })
     .toArray()
 
-  return check
+  return invalidAttachments
     .flatMap(instance => (
       [{
         elemID: instance.elemID,


### PR DESCRIPTION
_fix article attachment size validator bug_

---

_Additional context for reviewer_
None

---
_Release Notes_: 
None

---
_User Notifications_: 
None

