### PR TITLE
SALTO-3093: Remove User and AppUser types from default config (Okta)

### DIFF
--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -122,11 +122,6 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
       url: '/api/v1/apps',
       recurseInto: [
         {
-          type: 'api__v1__apps___appId___users@uuuuuu_00123_00125uu',
-          toField: 'appUsers',
-          context: [{ name: 'appId', fromField: 'id' }],
-        },
-        {
           type: 'api__v1__apps___appId___credentials__csrs@uuuuuu_00123_00125uuuu',
           toField: 'CSRs',
           context: [{ name: 'appId', fromField: 'id' }],

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -49,11 +49,6 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
       url: '/api/v1/groups',
       recurseInto: [
         {
-          type: 'api__v1__groups___groupId___users@uuuuuu_00123_00125uu',
-          toField: 'users',
-          context: [{ name: 'groupId', fromField: 'id' }],
-        },
-        {
           type: 'api__v1__groups___groupId___roles@uuuuuu_00123_00125uu',
           toField: 'roles',
           context: [{ name: 'groupId', fromField: 'id' }],
@@ -709,9 +704,6 @@ export const SUPPORTED_TYPES = {
   Feature: ['api__v1__features'],
   Group: [
     'api__v1__groups',
-  ],
-  User: [
-    'api__v1__users',
   ],
   GroupRule: ['api__v1__groups__rules'],
   IdentityProvider: [


### PR DESCRIPTION
Remove `User` and `AppUser` types from default config 

---

I removed `User` and `AppUser` types from Okta's default config, and also group-user assignments.
The rest of the code still exists, so in case someone adds it to the config file everything should work as before (references, deploy..)

---
_Release Notes_: 
None

---
_User Notifications_: 
None
