### PR TITLE
SALTO-3022: Support IssueType to IssueTypeScheme connection changes

### DIFF
--- a/packages/jira-adapter/src/filters/issue_type_schemas/issue_type_scheme.ts
+++ b/packages/jira-adapter/src/filters/issue_type_schemas/issue_type_scheme.ts
@@ -53,6 +53,8 @@ const deployNewAndDeletedIssueTypeIds = async (
     }
   }
 
+  // We run this sequentially and not in parallel because there is a bug in Jira which lets you
+  // create an invalid issue type scheme (an issue type scheme without any issues) if you delete the issues in parallel
   await awu(Array.from(removedIds)).forEach(id =>
     client.delete({
       url: `/rest/api/3/issuetypescheme/${instance.value.id}/issuetype/${id}`,

--- a/packages/jira-adapter/src/filters/issue_type_schemas/issue_type_scheme.ts
+++ b/packages/jira-adapter/src/filters/issue_type_schemas/issue_type_scheme.ts
@@ -16,8 +16,8 @@
 import { AdditionChange, CORE_ANNOTATIONS, getChangeData, InstanceElement, isAdditionChange, isAdditionOrModificationChange, isInstanceChange, isModificationChange, isObjectType, ModificationChange, ObjectType } from '@salto-io/adapter-api'
 import { resolveChangeElement } from '@salto-io/adapter-utils'
 import _ from 'lodash'
-import { promises } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
+import { collections } from '@salto-io/lowerdash'
 import { getLookUpName } from '../../reference_mapping'
 import JiraClient from '../../client/client'
 import { JiraConfig } from '../../config/config'
@@ -26,7 +26,7 @@ import { FilterCreator } from '../../filter'
 import { getDiffIds } from '../../diff'
 import { ISSUE_TYPE_SCHEMA_NAME } from '../../constants'
 
-const MAX_CONCURRENT_PROMISES = 20
+const { awu } = collections.asynciterable
 
 const log = logger(module)
 
@@ -53,13 +53,10 @@ const deployNewAndDeletedIssueTypeIds = async (
     }
   }
 
-  await promises.array.withLimitedConcurrency(
-    Array.from(removedIds).map(id => () =>
-      client.delete({
-        url: `/rest/api/3/issuetypescheme/${instance.value.id}/issuetype/${id}`,
-      })),
-    MAX_CONCURRENT_PROMISES,
-  )
+  await awu(Array.from(removedIds)).forEach(id =>
+    client.delete({
+      url: `/rest/api/3/issuetypescheme/${instance.value.id}/issuetype/${id}`,
+    }))
 }
 
 const deployIssueTypeIdsOrder = async (


### PR DESCRIPTION
It looks like removing issue types from issue type schemes can create a race condition that can create invalid issue type schemes (issue type schemes without issue types). So changed to requests to not run in parallel.

---
_Release Notes_: 
_Jira adapter_:
- Fixed a race condition issue when removing issue types from an issue type scheme

---
_User Notifications_: 
None