### PR TITLE
SALTO-2361  Fix multiple_defaults change validator

### DIFF
--- a/packages/salesforce-adapter/test/change_validators/multiple_defaults.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/multiple_defaults.test.ts
@@ -285,10 +285,13 @@ describe('multiple defaults change validator', () => {
                 testRecordType1: {
                   default: false,
                 },
+                testRecordType2: {
+                  default: true,
+                },
               },
               test2: {
                 testRecordType2: {
-                  default: true,
+                  default: false,
                 },
               },
 
@@ -314,7 +317,7 @@ describe('multiple defaults change validator', () => {
               },
               test2: {
                 testRecordType2: {
-                  default: false,
+                  default: true,
                 },
               },
 

--- a/packages/salesforce-adapter/test/change_validators/multiple_defaults.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/multiple_defaults.test.ts
@@ -290,7 +290,7 @@ describe('multiple defaults change validator', () => {
                 },
               },
               test2: {
-                testRecordType2: {
+                testRecordType3: {
                   default: false,
                 },
               },
@@ -345,8 +345,6 @@ describe('multiple defaults change validator', () => {
                 testRecordType1: {
                   default: false,
                 },
-              },
-              test2: {
                 testRecordType2: {
                   default: true,
                 },


### PR DESCRIPTION
_fix multiple_defaults change validator_

---
_Additional context for reviewer_:
None

---
_Release Notes_: 
Salesforce-adapter:

* Fix multiple_defaults change validator that caused problems in deployments of Profiles
---

_User Notifications_: 
Salesforce-adapter:
None

