### PR TITLE
SAAS-6766: Wrong changes when comparing lists without primitives

### DIFF
--- a/packages/adapter-utils/src/list_comparison.ts
+++ b/packages/adapter-utils/src/list_comparison.ts
@@ -202,7 +202,7 @@ export const getArrayIndexMapping = (before: Value[], after: Value[]): IndexMapp
       return {
         beforeIndex,
         afterIndex: matchedAfterIndex,
-        // The min after index is the max  after index we matched to so far
+        // The min after index is the max after index we matched to so far
         minAfterIndex: maxAfterIndexMatched,
       }
     }

--- a/packages/adapter-utils/src/list_comparison.ts
+++ b/packages/adapter-utils/src/list_comparison.ts
@@ -199,10 +199,17 @@ export const getArrayIndexMapping = (before: Value[], after: Value[]): IndexMapp
     if (matchedAfterIndex !== undefined && !matchedAfterIndexes.has(matchedAfterIndex)) {
       maxAfterIndexMatched = Math.max(maxAfterIndexMatched, matchedAfterIndex, minAfterIndex)
       matchedAfterIndexes.add(matchedAfterIndex)
+      return {
+        beforeIndex,
+        afterIndex: matchedAfterIndex,
+        // The min after index is the max  after index we matched to so far
+        minAfterIndex: maxAfterIndexMatched,
+      }
     }
+
     return {
       beforeIndex,
-      afterIndex: matchedAfterIndex,
+      afterIndex: undefined,
       // The min after index is the max  after index we matched to so far
       minAfterIndex: maxAfterIndexMatched,
     }

--- a/packages/adapter-utils/test/compare.test.ts
+++ b/packages/adapter-utils/test/compare.test.ts
@@ -353,6 +353,41 @@ describe('detailedCompare', () => {
           },
         ])
       })
+
+      it('should work with empty objects in the list', () => {
+        beforeInst.value.list = [
+          {
+            val: [],
+          },
+          {},
+          {},
+        ]
+
+        afterInst.value.list = [
+          {
+            val: [],
+          },
+        ]
+        const listChanges = detailedCompare(beforeInst, afterInst, { compareListItems: true })
+        expect(listChanges).toEqual([
+          {
+            id: listID.createNestedID('1'),
+            data: { before: {} },
+            action: 'remove',
+            elemIDs: {
+              before: listID.createNestedID('1'),
+            },
+          },
+          {
+            id: listID.createNestedID('2'),
+            data: { before: {} },
+            action: 'remove',
+            elemIDs: {
+              before: listID.createNestedID('2'),
+            },
+          },
+        ])
+      })
     })
   })
 


### PR DESCRIPTION
Fixed a bug in list comparison when comparing to lists without primitives

---
_Release Notes_: 
None

---
_User Notifications_: 
None