### PR TITLE
SALTO-3146: apply detailed changes fails when there is an object that looks like a list

### DIFF
--- a/packages/adapter-utils/test/compare.test.ts
+++ b/packages/adapter-utils/test/compare.test.ts
@@ -823,6 +823,42 @@ describe('applyDetailedChanges', () => {
     })
   })
 
+  describe('When there is object with number as keys', () => {
+    let beforeInst: InstanceElement
+    let afterInst: InstanceElement
+    let outputInst: InstanceElement
+    beforeEach(() => {
+      const instType = new ObjectType({ elemID: new ElemID('test', 'type') })
+      beforeInst = new InstanceElement(
+        'inst',
+        instType,
+        {
+          a: {
+            1: 'a',
+            2: 'b',
+          },
+        }
+      )
+
+      afterInst = new InstanceElement(
+        'inst',
+        instType,
+        {
+          a: {
+            1: 'b',
+            2: 'a',
+          },
+        }
+      )
+      const listChanges = detailedCompare(beforeInst, afterInst, { compareListItems: true })
+      outputInst = beforeInst.clone()
+      applyDetailedChanges(outputInst, listChanges)
+    })
+    it('should apply the changes', () => {
+      expect(outputInst.value.a).toEqual(afterInst.value.a)
+    })
+  })
+
   describe('Should apply changes in the correct order', () => {
     let beforeInst: InstanceElement
     beforeEach(() => {


### PR DESCRIPTION
When there is an object with keys that are numbers, applyDetailedChanges would mistakenly treat it as a list


---
_Release Notes_: 
_Core_: 
- Fixed regression in fetch when there is an object with keys that are numbers

---
_User Notifications_: 
None