### PR TITLE
SALTO-2947: support user display name in Jira DC

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/datacenter/automation.ts
+++ b/packages/jira-adapter/e2e_test/instances/datacenter/automation.ts
@@ -22,7 +22,7 @@ export const createAutomationValues = (name: string): Values => ({
   canOtherRuleTrigger: false,
   notifyOnError: 'FIRSTERROR',
   authorAccountId: {
-    id: 'JIRAUSER10000',
+    id: 'salto',
   },
   actorAccountId: 'JIRAUSER10000',
   trigger: {

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -261,7 +261,9 @@ export default class JiraAdapter implements AdapterOperations {
     )
 
     this.paginator = paginator
-    this.getIdMapFunc = getIdMapFuncCreator(paginator)
+    // insert isDataCenter
+    this.getIdMapFunc = getIdMapFuncCreator(paginator, client.isDataCenter)
+    // this.getIdMapFunc = getIdMapFuncCreator(paginator)
 
     const filterContext = {}
     this.createFiltersRunner = () => (

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -71,7 +71,7 @@ import duplicateIdsFilter from './filters/duplicate_ids'
 import unresolvedParentsFilter from './filters/unresolved_parents'
 import fieldNameFilter from './filters/fields/field_name_filter'
 import accountIdFilter from './filters/account_id/account_id_filter'
-import addDisplayNameFilter from './filters/account_id/add_display_name_filter'
+import userIdFilter from './filters/account_id/user_id_filter'
 import fieldStructureFilter from './filters/fields/field_structure_filter'
 import fieldDeploymentFilter from './filters/fields/field_deployment_filter'
 import contextDeploymentFilter from './filters/fields/context_deployment_filter'
@@ -209,7 +209,7 @@ export const DEFAULT_FILTERS = [
   // Must run after user filter
   accountIdFilter,
   // Must run after accountIdFilter
-  addDisplayNameFilter,
+  userIdFilter,
   // Must run after accountIdFilter
   wrongUserPermissionSchemeFilter,
   deployDcIssueEventsFilter,

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -261,9 +261,7 @@ export default class JiraAdapter implements AdapterOperations {
     )
 
     this.paginator = paginator
-    // insert isDataCenter
     this.getIdMapFunc = getIdMapFuncCreator(paginator, client.isDataCenter)
-    // this.getIdMapFunc = getIdMapFuncCreator(paginator)
 
     const filterContext = {}
     this.createFiltersRunner = () => (

--- a/packages/jira-adapter/src/change_validators/account_id.ts
+++ b/packages/jira-adapter/src/change_validators/account_id.ts
@@ -141,7 +141,7 @@ export const accountIdValidator: (
 ) =>
   ChangeValidator = (client, config, getIdMapFunc) => async changes =>
     log.time(async () => {
-      if (!(config.fetch.showUserDisplayNames ?? true)
+      if (!(config.fetch.convertUsersIds ?? true)
         // Temporary until we support it in DC
         || client.isDataCenter) {
         return []

--- a/packages/jira-adapter/src/change_validators/wrong_user_permission_scheme.ts
+++ b/packages/jira-adapter/src/change_validators/wrong_user_permission_scheme.ts
@@ -47,7 +47,7 @@ export const wrongUserPermissionSchemeValidator: (
   config: JiraConfig,
   getIdMapFunc: GetIdMapFunc
   ) => ChangeValidator = (client, config, getIdMapFunc) => async changes => {
-    if (!(config.fetch.showUserDisplayNames ?? true)) {
+    if (!(config.fetch.convertUsersIds ?? true)) {
       return []
     }
     const { baseUrl } = client

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -57,7 +57,7 @@ type JiraFetchFilters = {
 type JiraFetchConfig = configUtils.UserFetchConfig<JiraFetchFilters> & {
   fallbackToInternalId?: boolean
   addTypeToFieldName?: boolean
-  showUserDisplayNames?: boolean
+  convertUsersIds?: boolean
   parseTemplateExpressions?: boolean
 }
 

--- a/packages/jira-adapter/src/filters/permission_scheme/wrong_user_permission_scheme_filter.ts
+++ b/packages/jira-adapter/src/filters/permission_scheme/wrong_user_permission_scheme_filter.ts
@@ -38,7 +38,7 @@ const filter: FilterCreator = ({ config, getIdMapFunc }) => {
   let erroneousPermissionSchemes: Record<string, PermissionHolder[]> = {}
   return ({
     preDeploy: async (changes: Change<ChangeDataType>[]) => {
-      if (!(config.fetch.showUserDisplayNames ?? true)) {
+      if (!(config.fetch.convertUsersIds ?? true)) {
         return
       }
       const idMap = await getIdMapFunc()

--- a/packages/jira-adapter/src/users_map.ts
+++ b/packages/jira-adapter/src/users_map.ts
@@ -29,17 +29,14 @@ export const getIdMapFuncCreator = (paginator: clientUtils.Paginator, isDataCent
   return async (): Promise<IdMap> => {
     if (idMap === undefined) {
       if (usersCallPromise === undefined) {
-        let paginationArgs
-        if (isDataCenter) {
-          paginationArgs = {
+        const paginationArgs = isDataCenter
+          ? {
             url: '/rest/api/2/user/search?username=.',
           }
-        } else {
-          paginationArgs = {
+          : {
             url: '/rest/api/3/users/search',
             paginationField: 'startAt',
           }
-        }
         usersCallPromise = toArrayAsync(paginator(
           paginationArgs,
           page => makeArray(page) as clientUtils.ResponseValue[]

--- a/packages/jira-adapter/src/users_map.ts
+++ b/packages/jira-adapter/src/users_map.ts
@@ -49,7 +49,7 @@ export const getIdMapFuncCreator = (paginator: clientUtils.Paginator, isDataCent
         idMap = Object.fromEntries((await usersCallPromise)
           .flat()
           .filter(user => user.key !== undefined)
-          .map(user => [[user.key, user.name], [user.name, user.key]].flat()))
+          .map(user => [user.key, user.name]))
       } else {
         idMap = Object.fromEntries((await usersCallPromise)
           .flat()

--- a/packages/jira-adapter/test/adapter.test.ts
+++ b/packages/jira-adapter/test/adapter.test.ts
@@ -60,7 +60,7 @@ describe('adapter', () => {
 
     const config = createConfigInstance(getDefaultConfig({ isDataCenter: false }))
     config.value.client.usePrivateAPI = false
-    config.value.fetch.showUserDisplayNames = false
+    config.value.fetch.convertUsersIds = false
 
     adapter = adapterCreator.operations({
       elementsSource,

--- a/packages/jira-adapter/test/change_validators/account_id.test.ts
+++ b/packages/jira-adapter/test/change_validators/account_id.test.ts
@@ -237,7 +237,7 @@ Go to ${url} to see valid users and account IDs.`,
   })
   it('should not raise errors when the flag is off', async () => {
     const configOff = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
-    configOff.fetch.showUserDisplayNames = false
+    configOff.fetch.convertUsersIds = false
     const validatorOff = accountIdValidator(
       client,
       configOff,

--- a/packages/jira-adapter/test/change_validators/wrong_user_permission_scheme.test.ts
+++ b/packages/jira-adapter/test/change_validators/wrong_user_permission_scheme.test.ts
@@ -107,7 +107,7 @@ Check ${url} to see valid users and account IDs.`,
   })
   it('should not return a warning when the flag is off', async () => {
     const configOff = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
-    configOff.fetch.showUserDisplayNames = false
+    configOff.fetch.convertUsersIds = false
     const validatorOff = wrongUserPermissionSchemeValidator(client, configOff, getIdMapFunc)
     expect(await validatorOff(
       changes

--- a/packages/jira-adapter/test/filters/account_id/account_id_common.ts
+++ b/packages/jira-adapter/test/filters/account_id/account_id_common.ts
@@ -257,6 +257,24 @@ export const checkDisplayNames = (
     expect(instance.value.holder.parameter.displayName).toEqual(`disp${id}h`)
   }
 }
+export const checkInstanceUserIds = (
+  instance: InstanceElement,
+  id: string,
+  prefix: string,
+  holderType = true
+) : void => {
+  expect(instance.value.accountId.id).toEqual(`${prefix}${id}`)
+  expect(instance.value.leadAccountId.id).toEqual(`${prefix}${id}l`)
+  expect(instance.value.nested.accountId.id).toEqual(`${prefix}${id}n`)
+  expect(instance.value.nested.authorAccountId.id).toEqual(`${prefix}${id}an`)
+  expect(instance.value.nested.actor2.value.id).toEqual(`${prefix}${id}${id}n`)
+  expect(instance.value.actor.value.id).toEqual(`${prefix}${id}${id}`)
+  expect(instance.value.list[0].accountId.id).toEqual(`${prefix}${id}list1`)
+  expect(instance.value.list[1].accountId.id).toEqual(`${prefix}${id}list2`)
+  if (holderType) {
+    expect(instance.value.holder.parameter.id).toEqual(`${prefix}${id}h`)
+  }
+}
 
 export const createInstanceElementArrayWithDisplayNames = (
   size: number,

--- a/packages/jira-adapter/test/filters/account_id/user_id_filter.test.ts
+++ b/packages/jira-adapter/test/filters/account_id/user_id_filter.test.ts
@@ -13,14 +13,14 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ElemID, ElemIdGetter, InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import { ElemID, ElemIdGetter, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
 import { mockFunction, MockInterface } from '@salto-io/test-utils'
 import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
 import _ from 'lodash'
 import { collections } from '@salto-io/lowerdash'
 import { getFilterParams, mockClient } from '../../utils'
 import { getDefaultConfig, JiraConfig } from '../../../src/config/config'
-import addDisplayNameFilter from '../../../src/filters/account_id/add_display_name_filter'
+import addDisplayNameFilter from '../../../src/filters/account_id/user_id_filter'
 import * as common from './account_id_common'
 import { ACCOUNT_ID_TYPES, PARAMETER_STYLE_TYPES } from '../../../src/filters/account_id/account_id_filter'
 
@@ -101,7 +101,7 @@ describe('add_display_name_filter', () => {
 
     beforeEach(() => {
       configFFOff = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
-      configFFOff.fetch.showUserDisplayNames = false
+      configFFOff.fetch.convertUsersIds = false
       const { client, paginator, connection } = mockClient()
       connectionFFOff = connection
       filterFFOff = addDisplayNameFilter(getFilterParams({
@@ -161,5 +161,156 @@ describe('add_display_name_filter', () => {
     expect(instance.value.holder.parameter.displayName).toBeUndefined()
     expect(instance.value.list[0].accountId.displayName).toBeUndefined()
     expect(instance.value.list[1].accountId.displayName).toBeUndefined()
+  })
+})
+
+describe('convert userId to key in Jira DC', () => {
+  let mockConnection: MockInterface<clientUtils.APIConnection>
+  let filter: filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
+  let elemIdGetter: jest.MockedFunction<ElemIdGetter>
+  let config: JiraConfig
+
+  let objectType: ObjectType
+  let instances: InstanceElement[] = []
+  const EMPTY_STRING = ''
+  const NAME_PREFIX = 'name'
+
+  beforeEach(() => {
+    elemIdGetter = mockFunction<ElemIdGetter>()
+      .mockImplementation((adapterName, _serviceIds, name) => new ElemID(adapterName, name))
+
+    config = _.cloneDeep(getDefaultConfig({ isDataCenter: true }))
+    const { client, paginator, connection, getIdMapFunc } = mockClient(true)
+    mockConnection = connection
+    filter = addDisplayNameFilter(getFilterParams({
+      client,
+      paginator,
+      config,
+      getIdMapFunc,
+      getElemIdFunc: elemIdGetter,
+    })) as typeof filter
+
+
+    objectType = common.createObjectedType('SecurityLevel')
+
+
+    instances = []
+    for (let i = 0; i < 3; i += 1) {
+      instances[i] = common.createObjectedInstance(i.toString(), objectType)
+    }
+
+    mockConnection.get.mockResolvedValue({
+      status: 200,
+      data: [{
+        key: '2',
+        name: `${NAME_PREFIX}2`,
+      }, {
+        key: '2l',
+        name: `${NAME_PREFIX}2l`,
+      }, {
+        key: '2n',
+        name: `${NAME_PREFIX}2n`,
+      }, {
+        key: '2an',
+        name: `${NAME_PREFIX}2an`,
+      }, {
+        key: '22n',
+        name: `${NAME_PREFIX}22n`,
+      }, {
+        key: '22',
+        name: `${NAME_PREFIX}22`,
+      }, {
+        key: '2h',
+        name: `${NAME_PREFIX}2h`,
+      }, {
+        key: '2list1',
+        name: `${NAME_PREFIX}2list1`,
+      }, {
+        key: '2list2',
+        name: `${NAME_PREFIX}2list2`,
+      }, {
+        key: '0',
+        name: `${NAME_PREFIX}0`,
+      }, {
+        key: '0l',
+        name: `${NAME_PREFIX}0l`,
+      }, {
+        key: '0n',
+        name: `${NAME_PREFIX}0n`,
+      }, {
+        key: '0an',
+        name: `${NAME_PREFIX}0an`,
+      }, {
+        key: '00n',
+        name: `${NAME_PREFIX}00n`,
+      }, {
+        key: '00',
+        name: `${NAME_PREFIX}00`,
+      }, {
+        key: '0h',
+        name: `${NAME_PREFIX}0h`,
+      }, {
+        key: '0list1',
+        name: `${NAME_PREFIX}0list1`,
+      }, {
+        key: '0list2',
+        name: `${NAME_PREFIX}0list2`,
+      }],
+    })
+  })
+  describe('fetch', () => {
+    it('should convert userId to key and backwards for all 5 types', async () => {
+      await filter.onFetch([instances[2]])
+      expect(mockConnection.get).toHaveBeenCalledOnce()
+      expect(mockConnection.get).toHaveBeenCalledWith(
+        '/rest/api/2/user/search?username=.',
+        undefined
+      )
+      common.checkInstanceUserIds(instances[2], '2', NAME_PREFIX)
+      await filter.preDeploy([
+        toChange({ after: instances[0] }),
+        toChange({ before: instances[1], after: instances[2] }),
+      ])
+      expect(mockConnection.get).toHaveBeenCalledOnce()
+      expect(mockConnection.get).toHaveBeenCalledWith(
+        '/rest/api/2/user/search?username=.',
+        undefined
+      )
+      common.checkInstanceUserIds(instances[2], '2', EMPTY_STRING)
+      common.checkInstanceUserIds(instances[0], '0', EMPTY_STRING)
+      await filter.onDeploy([
+        toChange({ after: instances[0] }),
+        toChange({ before: instances[1], after: instances[2] }),
+      ])
+      expect(mockConnection.get).toHaveBeenCalledOnce()
+      expect(mockConnection.get).toHaveBeenCalledWith(
+        '/rest/api/2/user/search?username=.',
+        undefined
+      )
+      common.checkInstanceUserIds(instances[2], '2', NAME_PREFIX)
+      common.checkInstanceUserIds(instances[0], '0', NAME_PREFIX)
+    })
+    it('should convert userId to key and backwards in all defined types', async () => {
+      await awu(ACCOUNT_ID_TYPES).forEach(async typeName => {
+        const type = common.createType(typeName)
+        const instance = common.createObjectedInstance('2', type)
+        await filter.onFetch([instance])
+        common.checkInstanceUserIds(instance, '2', NAME_PREFIX, PARAMETER_STYLE_TYPES.includes(typeName))
+        await filter.preDeploy([toChange({ after: instance })])
+        common.checkInstanceUserIds(instance, '2', EMPTY_STRING, PARAMETER_STYLE_TYPES.includes(typeName))
+        await filter.onDeploy([toChange({ after: instance })])
+        common.checkInstanceUserIds(instance, '2', NAME_PREFIX, PARAMETER_STYLE_TYPES.includes(typeName))
+      })
+    })
+    it('should not convert userId to key or backwards for undefined types', async () => {
+      const type = common.createType('Other')
+      const instance = common.createObjectedInstance('2', type)
+      await filter.onFetch([instance])
+      common.checkInstanceUserIds(instances[2], '2', EMPTY_STRING)
+      await filter.preDeploy([toChange({ after: instance })])
+      common.checkInstanceUserIds(instance, '2', EMPTY_STRING)
+      await filter.onDeploy([toChange({ after: instance })])
+      common.checkInstanceUserIds(instance, '2', EMPTY_STRING)
+    })
   })
 })

--- a/packages/jira-adapter/test/filters/permission_scheme/wrong_user_permission_scheme_filter.test.ts
+++ b/packages/jira-adapter/test/filters/permission_scheme/wrong_user_permission_scheme_filter.test.ts
@@ -108,7 +108,7 @@ describe('wrongUsersPermissionSchemeFilter', () => {
   })
   it('flag off', async () => {
     const configFFOff = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
-    configFFOff.fetch.showUserDisplayNames = false
+    configFFOff.fetch.convertUsersIds = false
     const { paginator: paginFFOff, connection: connectionFFOff } = mockClient()
     const filterFFOff = wrongUserPermissionSchemeFilter(getFilterParams({
       paginator: paginFFOff,

--- a/packages/jira-adapter/test/utils.ts
+++ b/packages/jira-adapter/test/utils.ts
@@ -75,7 +75,7 @@ export const mockClient = (isDataCenter = false): ClientWithMockConnection => {
   const paginator = clientUtils.createPaginator(
     { paginationFuncCreator: paginate, client }
   )
-  const getIdMapFunc = getIdMapFuncCreator(paginator)
+  const getIdMapFunc = getIdMapFuncCreator(paginator, client.isDataCenter)
   return { client, paginator, connection, getIdMapFunc }
 }
 


### PR DESCRIPTION
_Convert users Id with their Username _

---

_changed it by expanding `display_name_filter` functionality, while using Jira DC it will perform:_
before: 
`{
 id = "JIRAUSER1000"
}`
after:
`{
  id = "username"
}`

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
