### PR TITLE
SALTO-2884 transform unordered lists to maps

### DIFF
--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -40,7 +40,6 @@ import { Credentials } from '../src/client/credentials'
 import { isStandardTypeName } from '../src/autogen/types'
 
 const log = logger(module)
-const { makeArray } = collections.array
 const { awu } = collections.asynciterable
 
 const logging = (message: string): void => {
@@ -627,8 +626,9 @@ describe('Netsuite adapter E2E with real account', () => {
           roleToCreateThatDependsOnCustomRecord.elemID
         ) as InstanceElement
         expect(fetchedRole.value.name).toEqual(randomString)
-        const permissions = makeArray(fetchedRole.value.permissions?.permission)
-        const customRecordTypePermission = permissions
+        const permissions = fetchedRole.value.permissions?.permission
+        expect(_.isPlainObject(permissions)).toBeTruthy()
+        const customRecordTypePermission = Object.values(permissions as Values)
           .find(permission => isReferenceExpression(permission.permkey)
           && permission.permkey.elemID
             .isEqual(customRecordTypeToCreate.elemID.createNestedID('attr', SCRIPT_ID)))

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -296,7 +296,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
       instance => instance.elemID.typeName === CUSTOM_RECORD_TYPE
     )
 
-    const customRecordTypes = await createCustomRecordTypes(
+    const customRecordTypes = createCustomRecordTypes(
       customRecordTypeInstances,
       standardTypes.customrecordtype.type
     )

--- a/packages/netsuite-adapter/src/autogen/types/standard_types/entryForm.ts
+++ b/packages/netsuite-adapter/src/autogen/types/standard_types/entryForm.ts
@@ -1309,7 +1309,7 @@ export const entryFormType = (): TypeAndInnerTypes => {
         },
       },
       subLists: {
-        refType: createRefToElmWithValue(new ListType(entryForm_tabs_tab_subItems_subTab_subLists)),
+        refType: createRefToElmWithValue(entryForm_tabs_tab_subItems_subTab_subLists),
         annotations: {
         },
       },
@@ -1332,7 +1332,7 @@ export const entryFormType = (): TypeAndInnerTypes => {
         },
       },
       subLists: {
-        refType: createRefToElmWithValue(new ListType(entryForm_tabs_tab_subItems_subLists)),
+        refType: createRefToElmWithValue(entryForm_tabs_tab_subItems_subLists),
         annotations: {
         },
       },

--- a/packages/netsuite-adapter/src/autogen/types/standard_types/transactionForm.ts
+++ b/packages/netsuite-adapter/src/autogen/types/standard_types/transactionForm.ts
@@ -689,12 +689,12 @@ export const transactionFormType = (): TypeAndInnerTypes => {
         refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
         annotations: {
         },
-      }, /* Original description: This field accepts references to the advancedpdftemplate custom type.   For information about other possible values, see transactionform_advancedtemplate.   If this field appears in the project, you must reference the ADVANCEDPRINTING feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. ADVANCEDPRINTING must be enabled for this field to appear in your account. */
+      }, /* Original description: This field accepts references to the advancedpdftemplate custom type.   For information about other possible values, see transactionform_advancedtemplate.   If this field appears in the SuiteCloud project, you must reference the ADVANCEDPRINTING feature in the manifest file to avoid SuiteCloud project warnings. In the manifest file, you can specify whether this feature is required in your account. ADVANCEDPRINTING must be enabled for this field to appear in your account. */
       emailTemplate: {
         refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
         annotations: {
         },
-      }, /* Original description: This field accepts references to the advancedpdftemplate custom type.   For information about other possible values, see transactionform_advancedtemplate.   If this field appears in the project, you must reference the ADVANCEDPRINTING feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. ADVANCEDPRINTING must be enabled for this field to appear in your account. */
+      }, /* Original description: This field accepts references to the advancedpdftemplate custom type.   For information about other possible values, see transactionform_advancedtemplate.   If this field appears in the SuiteCloud project, you must reference the ADVANCEDPRINTING feature in the manifest file to avoid SuiteCloud project warnings. In the manifest file, you can specify whether this feature is required in your account. ADVANCEDPRINTING must be enabled for this field to appear in your account. */
     },
     path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
   })
@@ -1582,7 +1582,7 @@ export const transactionFormType = (): TypeAndInnerTypes => {
         },
       },
       subLists: {
-        refType: createRefToElmWithValue(new ListType(transactionForm_tabs_tab_subItems_subTab_subLists)),
+        refType: createRefToElmWithValue(transactionForm_tabs_tab_subItems_subTab_subLists),
         annotations: {
         },
       },
@@ -1605,7 +1605,7 @@ export const transactionFormType = (): TypeAndInnerTypes => {
         },
       },
       subLists: {
-        refType: createRefToElmWithValue(new ListType(transactionForm_tabs_tab_subItems_subLists)),
+        refType: createRefToElmWithValue(transactionForm_tabs_tab_subItems_subLists),
         annotations: {
         },
       },

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -34,7 +34,7 @@ import { SDF_CHANGE_GROUP_ID, SUITEAPP_CREATING_FILES_GROUP_ID, SUITEAPP_CREATIN
 import { DeployResult, getElementValueOrAnnotations, isCustomRecordType } from '../types'
 import { CONFIG_FEATURES, APPLICATION_ID, SCRIPT_ID } from '../constants'
 import { LazyElementsSourceIndexes } from '../elements_source_index/types'
-import { createConvertElementMapsToLists } from '../mapped_lists/utils'
+import { createConvertStandardElementMapsToLists } from '../mapped_lists/utils'
 import { toConfigDeployResult, toSetConfigTypes } from '../suiteapp_config_elements'
 import { FeaturesDeployError, ObjectsDeployError, SettingsDeployError, ManifestValidationError } from '../errors'
 import { toCustomRecordTypeInstance } from '../custom_records/custom_record_type'
@@ -182,7 +182,7 @@ export default class NetsuiteClient {
       .uniqBy(parent => parent.elemID.name)
       .value()
 
-    const convertElementMapsToLists = await createConvertElementMapsToLists(elementsSourceIndex)
+    const convertElementMapsToLists = await createConvertStandardElementMapsToLists(elementsSourceIndex)
     return awu(await getReferencedElements(
       elements.concat(fieldsParents),
       deployReferencedElements

--- a/packages/netsuite-adapter/src/filters/convert_lists.ts
+++ b/packages/netsuite-adapter/src/filters/convert_lists.ts
@@ -21,22 +21,7 @@ import { transformElementAnnotations, TransformFunc, transformValues } from '@sa
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { FilterWith } from '../filter'
-import { SCRIPT_ID } from '../constants'
 import { datasetType } from '../autogen/types/standard_types/dataset'
-import { savedcsvimportType } from '../autogen/types/standard_types/savedcsvimport'
-import { customsegmentType } from '../autogen/types/standard_types/customsegment'
-import { bundleinstallationscriptType } from '../autogen/types/standard_types/bundleinstallationscript'
-import { clientscriptType } from '../autogen/types/standard_types/clientscript'
-import { customrecordactionscriptType } from '../autogen/types/standard_types/customrecordactionscript'
-import { mapreducescriptType } from '../autogen/types/standard_types/mapreducescript'
-import { massupdatescriptType } from '../autogen/types/standard_types/massupdatescript'
-import { portletType } from '../autogen/types/standard_types/portlet'
-import { restletType } from '../autogen/types/standard_types/restlet'
-import { scheduledscriptType } from '../autogen/types/standard_types/scheduledscript'
-import { sdfinstallationscriptType } from '../autogen/types/standard_types/sdfinstallationscript'
-import { suiteletType } from '../autogen/types/standard_types/suitelet'
-import { usereventscriptType } from '../autogen/types/standard_types/usereventscript'
-import { workflowactionscriptType } from '../autogen/types/standard_types/workflowactionscript'
 import { isCustomRecordType } from '../types'
 
 const { awu } = collections.asynciterable
@@ -44,38 +29,7 @@ const { awu } = collections.asynciterable
 type FieldFullNameToOrderBy = Map<string, string | undefined>
 
 const unorderedListFields: FieldFullNameToOrderBy = new Map([
-  [datasetType().innerTypes.dataset_dependencies
-    .fields.dependency.elemID.getFullName(), undefined],
-  [savedcsvimportType().innerTypes.savedcsvimport_filemappings
-    .fields.filemapping.elemID.getFullName(), 'file'],
-  [customsegmentType().innerTypes.customsegment_segmentapplication_transactionbody_applications
-    .fields.application.elemID.getFullName(), 'id'],
-  [customsegmentType().innerTypes.customsegment_segmentapplication_transactionline_applications
-    .fields.application.elemID.getFullName(), 'id'],
-  [bundleinstallationscriptType().innerTypes.bundleinstallationscript_scriptdeployments
-    .fields.scriptdeployment.elemID.getFullName(), SCRIPT_ID],
-  [clientscriptType().innerTypes.clientscript_scriptdeployments
-    .fields.scriptdeployment.elemID.getFullName(), SCRIPT_ID],
-  [customrecordactionscriptType().innerTypes.customrecordactionscript_scriptdeployments
-    .fields.scriptdeployment.elemID.getFullName(), SCRIPT_ID],
-  [mapreducescriptType().innerTypes.mapreducescript_scriptdeployments
-    .fields.scriptdeployment.elemID.getFullName(), SCRIPT_ID],
-  [massupdatescriptType().innerTypes.massupdatescript_scriptdeployments
-    .fields.scriptdeployment.elemID.getFullName(), SCRIPT_ID],
-  [portletType().innerTypes.portlet_scriptdeployments
-    .fields.scriptdeployment.elemID.getFullName(), SCRIPT_ID],
-  [restletType().innerTypes.restlet_scriptdeployments
-    .fields.scriptdeployment.elemID.getFullName(), SCRIPT_ID],
-  [scheduledscriptType().innerTypes.scheduledscript_scriptdeployments
-    .fields.scriptdeployment.elemID.getFullName(), SCRIPT_ID],
-  [sdfinstallationscriptType().innerTypes.sdfinstallationscript_scriptdeployments
-    .fields.scriptdeployment.elemID.getFullName(), SCRIPT_ID],
-  [suiteletType().innerTypes.suitelet_scriptdeployments
-    .fields.scriptdeployment.elemID.getFullName(), SCRIPT_ID],
-  [usereventscriptType().innerTypes.usereventscript_scriptdeployments
-    .fields.scriptdeployment.elemID.getFullName(), SCRIPT_ID],
-  [workflowactionscriptType().innerTypes.workflowactionscript_scriptdeployments
-    .fields.scriptdeployment.elemID.getFullName(), SCRIPT_ID],
+  [datasetType().innerTypes.dataset_dependencies.fields.dependency.elemID.getFullName(), undefined],
 ])
 
 const castAndOrderLists: TransformFunc = async ({ value, field }) => {

--- a/packages/netsuite-adapter/src/filters/custom_records.ts
+++ b/packages/netsuite-adapter/src/filters/custom_records.ts
@@ -13,20 +13,16 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, ElemID, Field, FieldDefinition, getChangeData, InstanceElement, isInstanceChange, isInstanceElement, ListType, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
+import { Change, Field, FieldDefinition, getChangeData, InstanceElement, isInstanceChange, isInstanceElement, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
-import { NETSUITE, PARENT, SCRIPT_ID, SOAP_SCRIPT_ID } from '../constants'
+import { PARENT, SCRIPT_ID, SOAP_SCRIPT_ID } from '../constants'
 import { FilterWith } from '../filter'
 import { isCustomRecordType } from '../types'
 
 const { awu } = collections.asynciterable
-const { makeArray } = collections.array
 
 const REC_TYPE = 'recType'
 const FIELDS_TO_DELETE = [REC_TYPE, 'owner', 'customForm', 'created', 'lastModified']
-const TRANSLATION_LIST = 'translationsList'
-const TRANSLATIONS = 'customRecordTranslations'
-const CUSTOM_RECORD_TRANSLATION_LIST = 'customRecordTranslationsList'
 
 const addFieldsToType = (type: ObjectType): void => {
   const fieldNameToDef: Record<string, FieldDefinition> = {
@@ -37,18 +33,6 @@ const addFieldsToType = (type: ObjectType): void => {
     [REC_TYPE]: {
       refType: type,
       annotations: { isReference: true },
-    },
-    [TRANSLATION_LIST]: {
-      refType: new ObjectType({
-        elemID: new ElemID(NETSUITE, CUSTOM_RECORD_TRANSLATION_LIST),
-        fields: {
-          [TRANSLATIONS]: {
-            refType: new ListType(
-              new ObjectType({ elemID: new ElemID(NETSUITE, TRANSLATIONS) })
-            ),
-          },
-        },
-      }),
     },
   }
 
@@ -67,11 +51,6 @@ const filterCreator = (): FilterWith<'onFetch' | 'preDeploy'> => ({
         FIELDS_TO_DELETE.forEach(fieldName => {
           delete instance.value[fieldName]
         })
-        if (instance.value[TRANSLATION_LIST]?.[TRANSLATIONS]) {
-          instance.value[TRANSLATION_LIST][TRANSLATIONS] = makeArray(
-            instance.value[TRANSLATION_LIST][TRANSLATIONS]
-          )
-        }
       })
   },
   preDeploy: async changes => {

--- a/packages/netsuite-adapter/src/mapped_lists/mapping.ts
+++ b/packages/netsuite-adapter/src/mapped_lists/mapping.ts
@@ -14,7 +14,82 @@
 * limitations under the License.
 */
 
+const customrecordtypeMapping = {
+  customrecordtype_links_link: 'linkcategory',
+  customrecordtype_permissions_permission: 'permittedrole',
+}
+
+const customsegmentMapping = {
+  customsegment_permissions_permission: 'role',
+  customsegment_segmentapplication_crm_applications_application: 'id',
+  customsegment_segmentapplication_customrecords_applications_application: 'id',
+  customsegment_segmentapplication_otherrecords_applications_application: 'id',
+  customsegment_segmentapplication_transactionbody_applications_application: 'id',
+  customsegment_segmentapplication_transactionline_applications_application: 'id',
+  customsegment_segmentapplication_entities_applications_application: 'id',
+  customsegment_segmentapplication_items_applications_application: 'id',
+}
+
+const savedcsvimportMapping = {
+  savedcsvimport_filemappings_filemapping: 'file',
+  savedcsvimport_recordmappings_recordmapping: 'record',
+  savedcsvimport_recordmappings_recordmapping_fieldmappings_fieldmapping: 'field',
+}
+
+const customtransactiontypeMapping = {
+  customtransactiontype_permissions_permission: 'permittedrole',
+}
+
+const roleMapping = {
+  role_permissions_permission: 'permkey',
+  role_recordrestrictions_recordrestriction: 'segment',
+}
+
+const roleAccessMapping = {
+  sdfinstallationscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess: 'role',
+  workflow_workflowcustomfields_workflowcustomfield_roleaccesses_roleaccess: 'role',
+  workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_roleaccesses_roleaccess: 'role',
+  entitycustomfield_roleaccesses_roleaccess: 'role',
+  itemoptioncustomfield_roleaccesses_roleaccess: 'role',
+  crmcustomfield_roleaccesses_roleaccess: 'role',
+  itemcustomfield_roleaccesses_roleaccess: 'role',
+  customrecordactionscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess: 'role',
+  workflowactionscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess: 'role',
+  mapreducescript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess: 'role',
+  clientscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess: 'role',
+  usereventscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess: 'role',
+  transactionbodycustomfield_roleaccesses_roleaccess: 'role',
+  scheduledscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess: 'role',
+  itemnumbercustomfield_roleaccesses_roleaccess: 'role',
+  suitelet_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess: 'role',
+  massupdatescript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess: 'role',
+  bundleinstallationscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess: 'role',
+  portlet_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess: 'role',
+  transactioncolumncustomfield_roleaccesses_roleaccess: 'role',
+  restlet_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess: 'role',
+  customrecordtype_customrecordcustomfields_customrecordcustomfield_roleaccesses_roleaccess: 'role',
+  othercustomfield_roleaccesses_roleaccess: 'role',
+}
+
+const translationsMapping = {
+  translation: ['locale', 'language'],
+  classTranslation: ['locale', 'language'],
+  customRecordTranslations: ['locale', 'language'],
+}
+
+export const dataTypesToConvert: ReadonlySet<string> = new Set(
+  Object.keys(translationsMapping).map(key => `${key}List`)
+)
+
 export const listMappedByFieldMapping: Record<string, string | string[]> = {
+  ...customrecordtypeMapping,
+  ...customsegmentMapping,
+  ...savedcsvimportMapping,
+  ...customtransactiontypeMapping,
+  ...roleMapping,
+  ...roleAccessMapping,
+  ...translationsMapping,
+
   // addressForm
   addressForm_mainFields_defaultFieldGroup_fields: 'position',
   addressForm_mainFields_defaultFieldGroup_fields_field: 'id',
@@ -28,23 +103,6 @@ export const listMappedByFieldMapping: Record<string, string | string[]> = {
 
   // clientscript
   clientscript_buttons_button: 'buttonlabel',
-
-  // customrecordtype
-  customrecordtype_links_link: 'linkcategory',
-  customrecordtype_permissions_permission: 'permittedrole',
-
-  // customsegment permissions
-  customsegment_permissions_permission: 'role',
-
-  // customsegment applications
-  customsegment_segmentapplication_crm_applications_application: 'id',
-  customsegment_segmentapplication_customrecords_applications_application: 'id',
-  customsegment_segmentapplication_otherrecords_applications_application: 'id',
-  customsegment_segmentapplication_transactionbody_applications_application: 'id',
-  customsegment_segmentapplication_transactionline_applications_application: 'id',
-
-  // customtransactiontype
-  customtransactiontype_permissions_permission: 'permittedrole',
 
   // entryForm
   entryForm_actionbar_buttons_button: 'id',
@@ -64,12 +122,6 @@ export const listMappedByFieldMapping: Record<string, string | string[]> = {
   entryForm_tabs_tab_subItems_subTab: 'id',
   entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields: 'position',
   entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_field: 'id',
-
-  // entitycustomfield
-  entitycustomfield_roleaccesses_roleaccess: 'role',
-
-  // othercustomfield
-  othercustomfield_roleaccesses_roleaccess: 'role',
 
   // transactionbodycustomfield
   transactionbodycustomfield_customfieldfilters_customfieldfilter: 'fldfilter',
@@ -146,8 +198,30 @@ export const listMappedByFieldMapping: Record<string, string | string[]> = {
   workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_fieldsettings_fieldsetting: 'targetfield',
   workflow_workflowstates_workflowstate_workflowactions_customaction_parametersettings_parametersetting: 'targetparameter',
   workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customaction_parametersettings_parametersetting: 'targetparameter',
-
-  // workflow role access
-  workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_roleaccesses_roleaccess: 'role',
-  workflow_workflowcustomfields_workflowcustomfield_roleaccesses_roleaccess: 'role',
 }
+
+const scriptdeploymentsTypes = [
+  'bundleinstallationscript_scriptdeployments_scriptdeployment',
+  'clientscript_scriptdeployments_scriptdeployment',
+  'customrecordactionscript_scriptdeployments_scriptdeployment',
+  'mapreducescript_scriptdeployments_scriptdeployment',
+  'massupdatescript_scriptdeployments_scriptdeployment',
+  'portlet_scriptdeployments_scriptdeployment',
+  'restlet_scriptdeployments_scriptdeployment',
+  'scheduledscript_scriptdeployments_scriptdeployment',
+  'sdfinstallationscript_scriptdeployments_scriptdeployment',
+  'suitelet_scriptdeployments_scriptdeployment',
+  'usereventscript_scriptdeployments_scriptdeployment',
+  'workflowactionscript_scriptdeployments_scriptdeployment',
+]
+
+export const mapsWithoutIndex: ReadonlySet<string> = new Set(
+  scriptdeploymentsTypes
+    .concat(Object.keys(customrecordtypeMapping))
+    .concat(Object.keys(customsegmentMapping))
+    .concat(Object.keys(savedcsvimportMapping))
+    .concat(Object.keys(customtransactiontypeMapping))
+    .concat(Object.keys(roleMapping))
+    .concat(Object.keys(roleAccessMapping))
+    .concat(Object.keys(translationsMapping))
+)

--- a/packages/netsuite-adapter/src/mapped_lists/mapping.ts
+++ b/packages/netsuite-adapter/src/mapped_lists/mapping.ts
@@ -14,13 +14,7 @@
 * limitations under the License.
 */
 
-const customrecordtypeMapping = {
-  customrecordtype_links_link: 'linkcategory',
-  customrecordtype_permissions_permission: 'permittedrole',
-}
-
 const customsegmentMapping = {
-  customsegment_permissions_permission: 'role',
   customsegment_segmentapplication_crm_applications_application: 'id',
   customsegment_segmentapplication_customrecords_applications_application: 'id',
   customsegment_segmentapplication_otherrecords_applications_application: 'id',
@@ -34,10 +28,6 @@ const savedcsvimportMapping = {
   savedcsvimport_filemappings_filemapping: 'file',
   savedcsvimport_recordmappings_recordmapping: 'record',
   savedcsvimport_recordmappings_recordmapping_fieldmappings_fieldmapping: 'field',
-}
-
-const customtransactiontypeMapping = {
-  customtransactiontype_permissions_permission: 'permittedrole',
 }
 
 const roleMapping = {
@@ -71,6 +61,19 @@ const roleAccessMapping = {
   othercustomfield_roleaccesses_roleaccess: 'role',
 }
 
+const permissionsMapping = {
+  customrecordtype_permissions_permission: 'permittedrole',
+  customsegment_permissions_permission: 'role',
+  customtransactiontype_permissions_permission: 'permittedrole',
+}
+
+const linksMapping = {
+  customrecordtype_links_link: 'linkcategory',
+  customtransactiontype_links_link: 'linkcategory',
+  suitelet_scriptdeployments_scriptdeployment_links_link: 'linkcategory',
+  transactionForm_linkedForms_linkedForm: 'type',
+}
+
 const translationsMapping = {
   translation: ['locale', 'language'],
   classTranslation: ['locale', 'language'],
@@ -82,12 +85,12 @@ export const dataTypesToConvert: ReadonlySet<string> = new Set(
 )
 
 export const listMappedByFieldMapping: Record<string, string | string[]> = {
-  ...customrecordtypeMapping,
   ...customsegmentMapping,
   ...savedcsvimportMapping,
-  ...customtransactiontypeMapping,
   ...roleMapping,
   ...roleAccessMapping,
+  ...permissionsMapping,
+  ...linksMapping,
   ...translationsMapping,
 
   // addressForm
@@ -107,7 +110,9 @@ export const listMappedByFieldMapping: Record<string, string | string[]> = {
   // entryForm
   entryForm_actionbar_buttons_button: 'id',
   entryForm_actionbar_customButtons_customButton: 'label',
+  entryForm_actionbar_customMenu_customMenuItem: 'label',
   entryForm_actionbar_menu_menuitem: 'id',
+  entryForm_buttons_standardButtons_button: 'id',
   entryForm_mainFields_fieldGroup_fields: 'position',
   entryForm_mainFields_fieldGroup_fields_field: 'id',
   entryForm_mainFields_defaultFieldGroup_fields: 'position',
@@ -119,12 +124,13 @@ export const listMappedByFieldMapping: Record<string, string | string[]> = {
   entryForm_tabs_tab_fieldGroups_fieldGroup_fields: 'position',
   entryForm_tabs_tab_fieldGroups_fieldGroup_fields_field: 'id',
   entryForm_tabs_tab_subItems_subList: 'id',
+  entryForm_tabs_tab_subItems_subLists_subList: 'id',
   entryForm_tabs_tab_subItems_subTab: 'id',
+  entryForm_tabs_tab_subItems_subTab_subLists_subList: 'id',
+  entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields: 'position',
+  entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_field: 'id',
   entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields: 'position',
   entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_field: 'id',
-
-  // transactionbodycustomfield
-  transactionbodycustomfield_customfieldfilters_customfieldfilter: 'fldfilter',
 
   // transactionForm
   transactionForm_mainFields_defaultFieldGroup_fields: 'position',
@@ -133,6 +139,9 @@ export const listMappedByFieldMapping: Record<string, string | string[]> = {
   transactionForm_mainFields_fieldGroup_fields_field: 'id',
   transactionForm_actionbar_buttons_button: 'id',
   transactionForm_actionbar_menu_menuitem: 'id',
+  transactionForm_actionbar_customButtons_customButton: 'label',
+  transactionForm_actionbar_customMenu_customMenuItem: 'label',
+  transactionForm_buttons_standardButtons_button: 'id',
   transactionForm_quickViewFields_field: 'id',
   transactionForm_roles_role: 'id',
   transactionForm_tabs_tab: 'id',
@@ -142,10 +151,15 @@ export const listMappedByFieldMapping: Record<string, string | string[]> = {
   transactionForm_tabs_tab_fieldGroups_fieldGroup_fields_field: 'id',
   transactionForm_tabs_tab_subItems_subList: 'id',
   transactionForm_tabs_tab_subItems_subList_columns_column: 'id',
+  transactionForm_tabs_tab_subItems_subLists_subList: 'id',
   transactionForm_tabs_tab_subItems_subTab: 'id',
   transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields: 'position',
   transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_field: 'id',
+  transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields: 'position',
+  transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_field: 'id',
+  transactionForm_tabs_tab_subItems_subTab_subLists_subList: 'id',
   transactionForm_totalBox_totalBoxField: 'id',
+  transactionForm_preferences_preference: 'id',
 
   // workflow parameters
   workflow_initcondition_parameters_parameter: 'name',
@@ -177,10 +191,6 @@ export const listMappedByFieldMapping: Record<string, string | string[]> = {
   workflow_workflowstates_workflowstate_workflowtransitions_workflowtransition_initcondition_parameters_parameter: 'name',
   workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initcondition_parameters_parameter: 'name',
 
-  // workflow field filters
-  workflow_workflowcustomfields_workflowcustomfield_customfieldfilters_customfieldfilter: 'fldfilter',
-  workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_customfieldfilters_customfieldfilter: 'fldfilter',
-
   // workflow actions
   workflow_workflowstates_workflowstate_workflowactions: 'triggertype',
 
@@ -198,6 +208,31 @@ export const listMappedByFieldMapping: Record<string, string | string[]> = {
   workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_fieldsettings_fieldsetting: 'targetfield',
   workflow_workflowstates_workflowstate_workflowactions_customaction_parametersettings_parametersetting: 'targetparameter',
   workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customaction_parametersettings_parametersetting: 'targetparameter',
+
+  // custom field filters
+  bundleinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter: 'fldfilter',
+  clientscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter: 'fldfilter',
+  crmcustomfield_customfieldfilters_customfieldfilter: 'fldfilter',
+  customrecordactionscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter: 'fldfilter',
+  customrecordtype_customrecordcustomfields_customrecordcustomfield_customfieldfilters_customfieldfilter: 'fldfilter',
+  entitycustomfield_customfieldfilters_customfieldfilter: 'fldfilter',
+  itemcustomfield_customfieldfilters_customfieldfilter: 'fldfilter',
+  itemnumbercustomfield_customfieldfilters_customfieldfilter: 'fldfilter',
+  itemoptioncustomfield_customfieldfilters_customfieldfilter: 'fldfilter',
+  mapreducescript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter: 'fldfilter',
+  massupdatescript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter: 'fldfilter',
+  othercustomfield_customfieldfilters_customfieldfilter: 'fldfilter',
+  portlet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter: 'fldfilter',
+  restlet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter: 'fldfilter',
+  scheduledscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter: 'fldfilter',
+  sdfinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter: 'fldfilter',
+  suitelet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter: 'fldfilter',
+  transactionbodycustomfield_customfieldfilters_customfieldfilter: 'fldfilter',
+  transactioncolumncustomfield_customfieldfilters_customfieldfilter: 'fldfilter',
+  usereventscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter: 'fldfilter',
+  workflow_workflowcustomfields_workflowcustomfield_customfieldfilters_customfieldfilter: 'fldfilter',
+  workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_customfieldfilters_customfieldfilter: 'fldfilter',
+  workflowactionscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter: 'fldfilter',
 }
 
 const scriptdeploymentsTypes = [
@@ -217,11 +252,11 @@ const scriptdeploymentsTypes = [
 
 export const mapsWithoutIndex: ReadonlySet<string> = new Set(
   scriptdeploymentsTypes
-    .concat(Object.keys(customrecordtypeMapping))
     .concat(Object.keys(customsegmentMapping))
     .concat(Object.keys(savedcsvimportMapping))
-    .concat(Object.keys(customtransactiontypeMapping))
     .concat(Object.keys(roleMapping))
     .concat(Object.keys(roleAccessMapping))
+    .concat(Object.keys(permissionsMapping))
+    .concat(Object.keys(linksMapping))
     .concat(Object.keys(translationsMapping))
 )

--- a/packages/netsuite-adapter/src/mapped_lists/mapping.ts
+++ b/packages/netsuite-adapter/src/mapped_lists/mapping.ts
@@ -14,7 +14,21 @@
 * limitations under the License.
 */
 
-const customsegmentMapping = {
+
+const translationsMapping = {
+  translation: ['locale', 'language'],
+  classTranslation: ['locale', 'language'],
+  customRecordTranslations: ['locale', 'language'],
+}
+
+export const dataTypesToConvert: ReadonlySet<string> = new Set(
+  Object.keys(translationsMapping).map(key => `${key}List`)
+)
+
+const unorderedListMappedByFieldMapping = {
+  ...translationsMapping,
+
+  // customsegment mapping
   customsegment_segmentapplication_crm_applications_application: 'id',
   customsegment_segmentapplication_customrecords_applications_application: 'id',
   customsegment_segmentapplication_otherrecords_applications_application: 'id',
@@ -22,20 +36,17 @@ const customsegmentMapping = {
   customsegment_segmentapplication_transactionline_applications_application: 'id',
   customsegment_segmentapplication_entities_applications_application: 'id',
   customsegment_segmentapplication_items_applications_application: 'id',
-}
 
-const savedcsvimportMapping = {
+  // savedcsvimport mapping
   savedcsvimport_filemappings_filemapping: 'file',
   savedcsvimport_recordmappings_recordmapping: 'record',
   savedcsvimport_recordmappings_recordmapping_fieldmappings_fieldmapping: 'field',
-}
 
-const roleMapping = {
+  // role mapping
   role_permissions_permission: 'permkey',
   role_recordrestrictions_recordrestriction: 'segment',
-}
 
-const roleAccessMapping = {
+  // role access mapping
   sdfinstallationscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess: 'role',
   workflow_workflowcustomfields_workflowcustomfield_roleaccesses_roleaccess: 'role',
   workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_roleaccesses_roleaccess: 'role',
@@ -59,39 +70,21 @@ const roleAccessMapping = {
   restlet_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess: 'role',
   customrecordtype_customrecordcustomfields_customrecordcustomfield_roleaccesses_roleaccess: 'role',
   othercustomfield_roleaccesses_roleaccess: 'role',
-}
 
-const permissionsMapping = {
+  // permissions mapping
   customrecordtype_permissions_permission: 'permittedrole',
   customsegment_permissions_permission: 'role',
   customtransactiontype_permissions_permission: 'permittedrole',
-}
 
-const linksMapping = {
+  // links mapping
   customrecordtype_links_link: 'linkcategory',
   customtransactiontype_links_link: 'linkcategory',
   suitelet_scriptdeployments_scriptdeployment_links_link: 'linkcategory',
   transactionForm_linkedForms_linkedForm: 'type',
 }
 
-const translationsMapping = {
-  translation: ['locale', 'language'],
-  classTranslation: ['locale', 'language'],
-  customRecordTranslations: ['locale', 'language'],
-}
-
-export const dataTypesToConvert: ReadonlySet<string> = new Set(
-  Object.keys(translationsMapping).map(key => `${key}List`)
-)
-
 export const listMappedByFieldMapping: Record<string, string | string[]> = {
-  ...customsegmentMapping,
-  ...savedcsvimportMapping,
-  ...roleMapping,
-  ...roleAccessMapping,
-  ...permissionsMapping,
-  ...linksMapping,
-  ...translationsMapping,
+  ...unorderedListMappedByFieldMapping,
 
   // addressForm
   addressForm_mainFields_defaultFieldGroup_fields: 'position',
@@ -251,12 +244,5 @@ const scriptdeploymentsTypes = [
 ]
 
 export const mapsWithoutIndex: ReadonlySet<string> = new Set(
-  scriptdeploymentsTypes
-    .concat(Object.keys(customsegmentMapping))
-    .concat(Object.keys(savedcsvimportMapping))
-    .concat(Object.keys(roleMapping))
-    .concat(Object.keys(roleAccessMapping))
-    .concat(Object.keys(permissionsMapping))
-    .concat(Object.keys(linksMapping))
-    .concat(Object.keys(translationsMapping))
+  scriptdeploymentsTypes.concat(Object.keys(unorderedListMappedByFieldMapping))
 )

--- a/packages/netsuite-adapter/src/mapped_lists/utils.ts
+++ b/packages/netsuite-adapter/src/mapped_lists/utils.ts
@@ -15,47 +15,55 @@
 */
 import {
   Values, InstanceElement, isMapType, ObjectType, isField, isListType, Field,
-  MapType, isObjectType, createRefToElmWithValue, isContainerType, ElemID, Value,
-  BuiltinTypes, Element, ChangeDataType, isInstanceElement, TypeRefMap,
+  MapType, isObjectType, isContainerType, ElemID, Value,
+  BuiltinTypes, Element, ChangeDataType, isInstanceElement, TypeElement,
+  FieldDefinition, ListType, TypeReference,
 } from '@salto-io/adapter-api'
 import { naclCase, transformElement, transformElementAnnotations, TransformFunc, transformValues } from '@salto-io/adapter-utils'
-import { collections } from '@salto-io/lowerdash'
+import { collections, promises } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { INDEX, LIST_MAPPED_BY_FIELD, SCRIPT_ID } from '../constants'
-import { listMappedByFieldMapping } from './mapping'
+import { dataTypesToConvert, listMappedByFieldMapping, mapsWithoutIndex } from './mapping'
 import { captureServiceIdInfo } from '../service_id_info'
 import { getStandardTypes, isStandardTypeName } from '../autogen/types'
 import { isCustomRecordType } from '../types'
 import { toAnnotationRefTypes } from '../custom_records/custom_record_type'
 import { LazyElementsSourceIndexes } from '../elements_source_index/types'
 
+const { mapValuesAsync } = promises.object
 const { awu } = collections.asynciterable
 const { makeArray } = collections.array
 
 const log = logger(module)
 
 export type MappedList = {
+  field: Field
   path: ElemID
   value: Values
 }
 
 export const validateTypesFieldMapping = (elements: ObjectType[]): void => {
   const typesMap = _.keyBy(elements, element => element.elemID.name)
-  Object.entries(listMappedByFieldMapping).forEach(([typeName, fieldNameList]) => {
+  const validateType = (typeName: string): void => {
     const type = typesMap[typeName]
     if (type === undefined) {
-      log.error(`type '${typeName}' should have mapping field but '${typeName}' is not in elements`)
-      throw new Error('missing some types with field mapping')
+      throw new Error(`type '${typeName}' should have mapping field but '${typeName}' is not in elements`)
     }
+  }
+  Object.entries(listMappedByFieldMapping).forEach(([typeName, fieldNameList]) => {
+    validateType(typeName)
     makeArray(fieldNameList).forEach(fieldName => {
-      if (type.fields[fieldName] === undefined) {
-        log.error(`type '${typeName}' should have mapping field '${fieldName}' but '${typeName}' has no '${fieldName}' field`)
-        throw new Error('missing some types with field mapping')
+      if (typesMap[typeName].fields[fieldName] === undefined) {
+        throw new Error(`type '${typeName}' should have mapping field '${fieldName}' but '${typeName}' has no '${fieldName}' field`)
       }
     })
   })
+  mapsWithoutIndex.forEach(validateType)
 }
+
+const shouldAddIndex = (type: TypeElement | TypeReference): boolean =>
+  !mapsWithoutIndex.has(type.elemID.name)
 
 export const convertFieldsTypesFromListToMap = async (
   element: ObjectType,
@@ -83,15 +91,17 @@ export const convertFieldsTypesFromListToMap = async (
     const newField = new Field(
       field.parent,
       field.name,
-      createRefToElmWithValue(new MapType(innerType)),
+      new MapType(innerType),
       { ...field.annotations, [LIST_MAPPED_BY_FIELD]: listMappedByField }
     )
     element.fields[fieldName] = newField
-    innerType.fields[INDEX] = new Field(
-      innerType,
-      INDEX,
-      createRefToElmWithValue(BuiltinTypes.NUMBER)
-    )
+    if (shouldAddIndex(innerType)) {
+      innerType.fields[INDEX] = new Field(
+        innerType,
+        INDEX,
+        BuiltinTypes.NUMBER
+      )
+    }
   })
 }
 
@@ -158,13 +168,14 @@ const getUniqueItemKey = (
 
 const transformMappedLists: TransformFunc = async ({ value, field, path }) => {
   const mapFieldNameList = makeArray(field?.annotations[LIST_MAPPED_BY_FIELD])
-  if (!_.isArray(value) || _.isEmpty(mapFieldNameList) || !isMapType(await field?.getType())) {
+  const fieldType = await field?.getType()
+  if (!_.isArray(value) || _.isEmpty(mapFieldNameList) || !isMapType(fieldType)) {
     return value
   }
-
+  const withIndex = shouldAddIndex(fieldType.refInnerType)
   const keySet: Set<string> = new Set()
   return _(value)
-    .map((item, index) => ({ ...item, [INDEX]: index }))
+    .map((item, index) => ({ ...item, ...withIndex ? { [INDEX]: index } : {} }))
     .keyBy(item => getUniqueItemKey(item, mapFieldNameList, keySet, path))
     .value()
 }
@@ -206,7 +217,7 @@ export const getMappedLists = async (
   const mappedLists: MappedList[] = []
   const lookForMappedLists: TransformFunc = async ({ value, field, path }) => {
     if (path && field && await isMappedList(value, field)) {
-      mappedLists.push({ path, value })
+      mappedLists.push({ field, path, value })
     }
     return value
   }
@@ -223,35 +234,74 @@ export const getMappedLists = async (
   return mappedLists
 }
 
-export const createConvertElementMapsToLists = async (
+export const convertDataInstanceMapsToLists = async (instance: InstanceElement): Promise<InstanceElement> => {
+  const typeWithFields = (type: ObjectType, fields: Record<string, FieldDefinition>): ObjectType =>
+    new ObjectType({
+      elemID: type.elemID,
+      annotationRefsOrTypes: type.annotationRefTypes,
+      annotations: type.annotations,
+      fields,
+    })
+
+  const convertDataTypeFieldsToLists = async (type: ObjectType): Promise<ObjectType> =>
+    typeWithFields(type, await mapValuesAsync(type.fields, async field => {
+      const fieldType = await field.getType()
+      return {
+        annotations: field.annotations,
+        refType: isMapType(fieldType) && field.annotations[LIST_MAPPED_BY_FIELD]
+          ? new ListType(fieldType.refInnerType)
+          : fieldType,
+      }
+    }))
+
+  const convertDataType = async (type: ObjectType): Promise<ObjectType> =>
+    typeWithFields(type, await mapValuesAsync(type.fields, async field => {
+      const fieldType = await field.getType()
+      return {
+        annotations: field.annotations,
+        refType: isObjectType(fieldType) && dataTypesToConvert.has(fieldType.elemID.name)
+          ? await convertDataTypeFieldsToLists(fieldType)
+          : field.refType,
+      }
+    }))
+
+  return transformElement({
+    element: new InstanceElement(
+      instance.elemID.name,
+      await convertDataType(await instance.getType()),
+      instance.value,
+      undefined,
+      instance.annotations,
+    ),
+    transformFunc: async ({ value, field }) => (
+      field !== undefined && await isMappedList(value, field)
+        ? Object.values(value)
+        : value
+    ),
+    strict: false,
+  })
+}
+
+export const createConvertStandardElementMapsToLists = async (
   elementsSourceIndexes: LazyElementsSourceIndexes
 ): Promise<(
   element: ChangeDataType
 ) => Promise<ChangeDataType>> => {
   // using hardcoded types so the transformed elements will have fields with List<> ref types.
   const standardTypes = getStandardTypes()
+  const customRecordTypeAnnotationRefTypes = toAnnotationRefTypes(standardTypes.customrecordtype.type)
   const { mapKeyFieldsIndex } = await elementsSourceIndexes.getIndexes()
-
-  let cachedCustomRecordTypeAnnotationRefTypes: TypeRefMap
-  const customRecordTypeAnnotationRefTypes = async (): Promise<TypeRefMap> => {
-    if (cachedCustomRecordTypeAnnotationRefTypes === undefined) {
-      cachedCustomRecordTypeAnnotationRefTypes = await toAnnotationRefTypes(standardTypes.customrecordtype.type)
-    }
-    return cachedCustomRecordTypeAnnotationRefTypes
-  }
 
   const convertToList: TransformFunc = async ({ value, field }) => (
     field !== undefined && await isMappedList(value, field, mapKeyFieldsIndex)
       ? _.sortBy(
         Object.values(value),
         [INDEX, mapKeyFieldsIndex[field.elemID.getFullName()]].flat()
-      ).filter(_.isObject).map(item => _.omit(item, INDEX))
+      ).map(item => (_.isObject(item) ? _.omit(item, INDEX) : item))
       : value
   )
 
-  return async (
-    element: ChangeDataType
-  ): Promise<ChangeDataType> => {
+  return element => {
     if (isInstanceElement(element) && isStandardTypeName(element.refType.elemID.name)) {
       return transformElement({
         element: new InstanceElement(
@@ -271,13 +321,13 @@ export const createConvertElementMapsToLists = async (
             element.fields,
             ({ refType, annotations }) => ({ refType, annotations })
           ),
-          annotationRefsOrTypes: await customRecordTypeAnnotationRefTypes(),
+          annotationRefsOrTypes: customRecordTypeAnnotationRefTypes,
           annotations: element.annotations,
         }),
         transformFunc: convertToList,
         strict: false,
       })
     }
-    return element
+    return Promise.resolve(element)
   }
 }

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -40,6 +40,7 @@ import { SuiteAppFileCabinetOperations } from '../src/suiteapp_file_cabinet'
 import getChangeValidator from '../src/change_validator'
 import { FetchByQueryFunc } from '../src/change_validators/safe_deploy'
 import { getStandardTypesNames } from '../src/autogen/types'
+import { createCustomRecordTypes } from '../src/custom_records/custom_record_type'
 
 const DEFAULT_SDF_DEPLOY_PARAMS = {
   additionalDependencies: {
@@ -132,6 +133,7 @@ describe('Adapter', () => {
 
   const { standardTypes, enums, additionalTypes, fieldTypes } = getMetadataTypes()
   const metadataTypes = metadataTypesToList({ standardTypes, enums, additionalTypes, fieldTypes })
+    .concat(createCustomRecordTypes([], standardTypes.customrecordtype.type))
 
   beforeEach(() => {
     jest.clearAllMocks()

--- a/packages/netsuite-adapter/test/custom_records/custom_record_type.test.ts
+++ b/packages/netsuite-adapter/test/custom_records/custom_record_type.test.ts
@@ -29,7 +29,7 @@ describe('custom record type transformer', () => {
           [SCRIPT_ID]: 'customrecord1',
         }
       )
-      const [customRecordType] = await createCustomRecordTypes([instance], type)
+      const [customRecordType] = createCustomRecordTypes([instance], type)
       expect(customRecordType.elemID.name).toEqual('customrecord1')
       expect(customRecordType.annotations).toEqual({
         [METADATA_TYPE]: 'customrecordtype',
@@ -38,7 +38,7 @@ describe('custom record type transformer', () => {
       })
       expect(Object.keys(customRecordType.annotationRefTypes))
         .toEqual(Object.keys(type.fields).concat('source'))
-      expect(Object.keys(customRecordType.fields)).toEqual([SCRIPT_ID, INTERNAL_ID])
+      expect(Object.keys(customRecordType.fields)).toEqual([SCRIPT_ID, INTERNAL_ID, 'translationsList'])
       expect(customRecordType.path).toEqual([NETSUITE, CUSTOM_RECORDS_PATH, 'customrecord1'])
     })
   })

--- a/packages/netsuite-adapter/test/filters/convert_lists.test.ts
+++ b/packages/netsuite-adapter/test/filters/convert_lists.test.ts
@@ -18,7 +18,6 @@ import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
 import { CUSTOM_RECORD_TYPE, METADATA_TYPE, NETSUITE, SCRIPT_ID } from '../../src/constants'
 import { datasetType } from '../../src/autogen/types/standard_types/dataset'
 import { entitycustomfieldType } from '../../src/autogen/types/standard_types/entitycustomfield'
-import { savedcsvimportType } from '../../src/autogen/types/standard_types/savedcsvimport'
 import filterCreator from '../../src/filters/convert_lists'
 import { customrecordtypeType } from '../../src/autogen/types/standard_types/customrecordtype'
 
@@ -51,36 +50,6 @@ describe('convert_lists filter', () => {
     instance.value.dependencies.dependency = ['b', 'a', 'c']
     await filterCreator().onFetch([instance])
     expect(instance.value.dependencies.dependency).toEqual(['a', 'b', 'c'])
-  })
-
-  it('should sort object list values if in unorderedListFields', async () => {
-    const savedCsvImportInstance = new InstanceElement('instance',
-      savedcsvimportType().type,
-      {
-        filemappings: {
-          filemapping: [
-            {
-              file: 'VENDORBILL:EXPENSE',
-              foreignkey: 'External ID',
-            },
-            {
-              file: 'VENDORBILL',
-              primarykey: 'External ID',
-            },
-          ],
-        },
-      })
-    await filterCreator().onFetch([savedCsvImportInstance])
-    expect(savedCsvImportInstance.value.filemappings.filemapping).toEqual([
-      {
-        file: 'VENDORBILL',
-        primarykey: 'External ID',
-      },
-      {
-        file: 'VENDORBILL:EXPENSE',
-        foreignkey: 'External ID',
-      },
-    ])
   })
 
   it('should not sort list if in unorderedListFields', async () => {

--- a/packages/netsuite-adapter/test/filters/convert_lists_to_maps.test.ts
+++ b/packages/netsuite-adapter/test/filters/convert_lists_to_maps.test.ts
@@ -14,214 +14,341 @@
 * limitations under the License.
 */
 import { promises } from '@salto-io/lowerdash'
-import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import { BuiltinTypes, Change, ElemID, getChangeData, InstanceElement, isListType, isObjectType, ListType, MapType, ObjectType, toChange } from '@salto-io/adapter-api'
 import filterCreator from '../../src/filters/convert_lists_to_maps'
 import { getStandardTypes } from '../../src/autogen/types'
 import { getInnerStandardTypes, getTopLevelStandardTypes } from '../../src/types'
-import { CUSTOM_RECORD_TYPE, METADATA_TYPE, NETSUITE, SCRIPT_ID } from '../../src/constants'
+import { CUSTOM_RECORD_TYPE, LIST_MAPPED_BY_FIELD, METADATA_TYPE, NETSUITE, SCRIPT_ID } from '../../src/constants'
+import { TypeAndInnerTypes } from '../../src/types/object_types'
+
+const getDataType = ({ withMaps }: { withMaps: boolean }): TypeAndInnerTypes => {
+  const classTranslationType = new ObjectType({
+    elemID: new ElemID(NETSUITE, 'classTranslation'),
+    fields: {
+      locale: { refType: BuiltinTypes.STRING },
+      language: { refType: BuiltinTypes.STRING },
+      name: { refType: BuiltinTypes.STRING },
+    },
+  })
+  const classTranslationListType = new ObjectType({
+    elemID: new ElemID(NETSUITE, 'classTranslationList'),
+    fields: {
+      classTranslation: withMaps
+        ? { refType: new MapType(classTranslationType), annotations: { [LIST_MAPPED_BY_FIELD]: ['locale', 'language'] } }
+        : { refType: new ListType(classTranslationType) },
+      replaceAll: { refType: BuiltinTypes.BOOLEAN },
+    },
+  })
+  const type = new ObjectType({
+    elemID: new ElemID(NETSUITE, 'subsidiary'),
+    fields: {
+      identifier: { refType: BuiltinTypes.SERVICE_ID },
+      internalId: { refType: BuiltinTypes.STRING },
+      classTranslationList: { refType: classTranslationListType },
+    },
+  })
+  return {
+    type,
+    innerTypes: {
+      classTranslationType,
+      classTranslationListType,
+    },
+  }
+}
 
 describe('convert lists to maps filter', () => {
-  const standardTypes = getStandardTypes()
-  let instance: InstanceElement
-  let instanceWithMixedFieldKeys: InstanceElement
-  let customRecordType: ObjectType
-  beforeAll(async () => {
-    instance = new InstanceElement(
-      'workflow1',
-      standardTypes.workflow.type,
-      {
-        scriptid: 'customworkflow_changed_id',
-        workflowcustomfields: {
-          workflowcustomfield: [
-            {
-              scriptid: 'custworkflow1',
-            },
-            {
-              scriptid: 'custworkflow2',
-            },
-          ],
+  describe('onFetch', () => {
+    const standardTypes = getStandardTypes()
+    let instance: InstanceElement
+    let instanceWithMixedFieldKeys: InstanceElement
+    let customRecordType: ObjectType
+    let dataInstance: InstanceElement
+    beforeAll(async () => {
+      instance = new InstanceElement(
+        'workflow1',
+        standardTypes.workflow.type,
+        {
+          scriptid: 'customworkflow_changed_id',
+          workflowcustomfields: {
+            workflowcustomfield: [
+              {
+                scriptid: 'custworkflow1',
+              },
+              {
+                scriptid: 'custworkflow2',
+              },
+            ],
+          },
+          workflowstates: {
+            workflowstate: [
+              {
+                scriptid: 'workflowstate1',
+                workflowactions: [
+                  {
+                    triggertype: 'ONENTRY',
+                  },
+                ],
+              },
+            ],
+          },
+        }
+      )
+      instanceWithMixedFieldKeys = new InstanceElement(
+        'centercategory',
+        standardTypes.centercategory.type,
+        {
+          scriptid: 'custcentercategory2',
+          links: {
+            link: [
+              {
+                linklabel: 'Asset Register',
+                linkobject: '[scriptid=customscript_ncfar_assetregisterreport.customdeploy1]',
+                linktasktype: 'SCRIPT',
+                shortlist: false,
+              },
+              {
+                linklabel: 'Asset Summary',
+                linkobject: '[scriptid=customscript_ncfar_summaryreport_sl.customdeploy1]',
+                linktasktype: 'SCRIPT',
+                shortlist: false,
+              },
+              {
+                linklabel: 'Depreciation Schedule',
+                linkid: 'id1',
+                linktasktype: 'SCRIPT',
+                shortlist: false,
+              },
+              {
+                linklabel: 'Depreciation Schedule (portrait)',
+                linkid: 'id2',
+                linktasktype: 'SCRIPT',
+                shortlist: false,
+              },
+              {
+                linklabel: 'Report Status',
+                linkobject: '[scriptid=customscript_ncfar_reportstatus_sl.customdeploy_ncfar_reportstatus_sl]',
+                linktasktype: 'SCRIPT',
+                shortlist: false,
+              },
+            ],
+          },
+        }
+      )
+      customRecordType = new ObjectType({
+        elemID: new ElemID(NETSUITE, 'customrecord1'),
+        annotationRefsOrTypes: await promises.object.mapValuesAsync(
+          standardTypes.customrecordtype.type.fields,
+          field => field.getType()
+        ),
+        annotations: {
+          [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
+          instances: {
+            instance: [{
+              [SCRIPT_ID]: 'customrecord1_record1',
+            }, {
+              [SCRIPT_ID]: 'customrecord1_record2',
+            }],
+          },
         },
-        workflowstates: {
-          workflowstate: [
-            {
-              scriptid: 'workflowstate1',
-              workflowactions: [
-                {
-                  triggertype: 'ONENTRY',
-                },
-              ],
-            },
-          ],
-        },
-      }
-    )
-    instanceWithMixedFieldKeys = new InstanceElement(
-      'centercategory',
-      standardTypes.centercategory.type,
-      {
-        scriptid: 'custcentercategory2',
-        links: {
-          link: [
-            {
-              linklabel: 'Asset Register',
-              linkobject: '[scriptid=customscript_ncfar_assetregisterreport.customdeploy1]',
-              linktasktype: 'SCRIPT',
-              shortlist: false,
-            },
-            {
-              linklabel: 'Asset Summary',
-              linkobject: '[scriptid=customscript_ncfar_summaryreport_sl.customdeploy1]',
-              linktasktype: 'SCRIPT',
-              shortlist: false,
-            },
-            {
-              linklabel: 'Depreciation Schedule',
-              linkid: 'id1',
-              linktasktype: 'SCRIPT',
-              shortlist: false,
-            },
-            {
-              linklabel: 'Depreciation Schedule (portrait)',
-              linkid: 'id2',
-              linktasktype: 'SCRIPT',
-              shortlist: false,
-            },
-            {
-              linklabel: 'Report Status',
-              linkobject: '[scriptid=customscript_ncfar_reportstatus_sl.customdeploy_ncfar_reportstatus_sl]',
-              linktasktype: 'SCRIPT',
-              shortlist: false,
-            },
-          ],
-        },
-      }
-    )
-    customRecordType = new ObjectType({
-      elemID: new ElemID(NETSUITE, 'customrecord1'),
-      annotationRefsOrTypes: await promises.object.mapValuesAsync(
-        standardTypes.customrecordtype.type.fields,
-        field => field.getType()
-      ),
-      annotations: {
-        [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
-        instances: {
-          instance: [{
-            [SCRIPT_ID]: 'customrecord1_record1',
+      })
+      const dataType = getDataType({ withMaps: false })
+      dataInstance = new InstanceElement('subsidiary1', dataType.type, {
+        identifier: 'subsidiary1',
+        internalId: '1',
+        classTranslationList: {
+          classTranslation: [{
+            language: 'Czech',
+            name: 'a',
           }, {
-            [SCRIPT_ID]: 'customrecord1_record2',
+            language: 'Danish',
+            name: 'b',
+          }, {
+            language: 'German',
+            name: 'c',
           }],
         },
-      },
-    })
-    await filterCreator().onFetch([
-      ...getTopLevelStandardTypes(standardTypes),
-      ...getInnerStandardTypes(standardTypes),
-      instance,
-      instanceWithMixedFieldKeys,
-      customRecordType,
-    ])
-  })
+      })
 
-  it('should modify instance values', () => {
-    expect(instance.value).toEqual({
-      scriptid: 'customworkflow_changed_id',
-      workflowcustomfields: {
-        workflowcustomfield: {
-          custworkflow1: {
-            scriptid: 'custworkflow1',
-            index: 0,
-          },
-          custworkflow2: {
-            scriptid: 'custworkflow2',
-            index: 1,
+      await filterCreator().onFetch([
+        ...getTopLevelStandardTypes(standardTypes),
+        ...getInnerStandardTypes(standardTypes),
+        instance,
+        instanceWithMixedFieldKeys,
+        customRecordType,
+        dataType.type,
+        ...Object.values(dataType.innerTypes),
+        dataInstance,
+      ])
+    })
+    it('should modify standard instance values', () => {
+      expect(instance.value).toEqual({
+        scriptid: 'customworkflow_changed_id',
+        workflowcustomfields: {
+          workflowcustomfield: {
+            custworkflow1: {
+              scriptid: 'custworkflow1',
+              index: 0,
+            },
+            custworkflow2: {
+              scriptid: 'custworkflow2',
+              index: 1,
+            },
           },
         },
-      },
-      workflowstates: {
-        workflowstate: {
-          workflowstate1: {
-            scriptid: 'workflowstate1',
-            index: 0,
-            workflowactions: {
-              ONENTRY: {
-                triggertype: 'ONENTRY',
-                index: 0,
+        workflowstates: {
+          workflowstate: {
+            workflowstate1: {
+              scriptid: 'workflowstate1',
+              index: 0,
+              workflowactions: {
+                ONENTRY: {
+                  triggertype: 'ONENTRY',
+                  index: 0,
+                },
               },
             },
           },
         },
-      },
+      })
     })
-  })
-
-  it('should modify instance values with mixed field keys', () => {
-    expect(instanceWithMixedFieldKeys.value).toEqual({
-      scriptid: 'custcentercategory2',
-      links: {
-        link: {
-          'customscript_ncfar_assetregisterreport_customdeploy1@uuv': {
-            linklabel: 'Asset Register',
-            linkobject: '[scriptid=customscript_ncfar_assetregisterreport.customdeploy1]',
-            linktasktype: 'SCRIPT',
-            shortlist: false,
-            index: 0,
-          },
-          'customscript_ncfar_summaryreport_sl_customdeploy1@uuuv': {
-            linklabel: 'Asset Summary',
-            linkobject: '[scriptid=customscript_ncfar_summaryreport_sl.customdeploy1]',
-            linktasktype: 'SCRIPT',
-            shortlist: false,
-            index: 1,
-          },
-          id1: {
-            linklabel: 'Depreciation Schedule',
-            linkid: 'id1',
-            linktasktype: 'SCRIPT',
-            shortlist: false,
-            index: 2,
-          },
-          id2: {
-            linklabel: 'Depreciation Schedule (portrait)',
-            linkid: 'id2',
-            linktasktype: 'SCRIPT',
-            shortlist: false,
-            index: 3,
-          },
-          'customscript_ncfar_reportstatus_sl_customdeploy_ncfar_reportstatus_sl@uuuvuuu': {
-            linklabel: 'Report Status',
-            linkobject: '[scriptid=customscript_ncfar_reportstatus_sl.customdeploy_ncfar_reportstatus_sl]',
-            linktasktype: 'SCRIPT',
-            shortlist: false,
-            index: 4,
+    it('should modify data instance values', () => {
+      expect(dataInstance.value).toEqual({
+        identifier: 'subsidiary1',
+        internalId: '1',
+        classTranslationList: {
+          classTranslation: {
+            Czech: {
+              language: 'Czech',
+              name: 'a',
+            },
+            Danish: {
+              language: 'Danish',
+              name: 'b',
+            },
+            German: {
+              language: 'German',
+              name: 'c',
+            },
           },
         },
-      },
+      })
     })
-  })
-
-  it('should modify custom record type annotations', () => {
-    expect(customRecordType.annotations).toEqual({
-      [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
-      instances: {
-        instance: {
-          customrecord1_record1: {
-            [SCRIPT_ID]: 'customrecord1_record1',
-            index: 0,
-          },
-          customrecord1_record2: {
-            [SCRIPT_ID]: 'customrecord1_record2',
-            index: 1,
+    it('should modify instance values with mixed field keys', () => {
+      expect(instanceWithMixedFieldKeys.value).toEqual({
+        scriptid: 'custcentercategory2',
+        links: {
+          link: {
+            'customscript_ncfar_assetregisterreport_customdeploy1@uuv': {
+              linklabel: 'Asset Register',
+              linkobject: '[scriptid=customscript_ncfar_assetregisterreport.customdeploy1]',
+              linktasktype: 'SCRIPT',
+              shortlist: false,
+              index: 0,
+            },
+            'customscript_ncfar_summaryreport_sl_customdeploy1@uuuv': {
+              linklabel: 'Asset Summary',
+              linkobject: '[scriptid=customscript_ncfar_summaryreport_sl.customdeploy1]',
+              linktasktype: 'SCRIPT',
+              shortlist: false,
+              index: 1,
+            },
+            id1: {
+              linklabel: 'Depreciation Schedule',
+              linkid: 'id1',
+              linktasktype: 'SCRIPT',
+              shortlist: false,
+              index: 2,
+            },
+            id2: {
+              linklabel: 'Depreciation Schedule (portrait)',
+              linkid: 'id2',
+              linktasktype: 'SCRIPT',
+              shortlist: false,
+              index: 3,
+            },
+            'customscript_ncfar_reportstatus_sl_customdeploy_ncfar_reportstatus_sl@uuuvuuu': {
+              linklabel: 'Report Status',
+              linkobject: '[scriptid=customscript_ncfar_reportstatus_sl.customdeploy_ncfar_reportstatus_sl]',
+              linktasktype: 'SCRIPT',
+              shortlist: false,
+              index: 4,
+            },
           },
         },
-      },
+      })
+    })
+    it('should modify custom record type annotations', () => {
+      expect(customRecordType.annotations).toEqual({
+        [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
+        instances: {
+          instance: {
+            customrecord1_record1: {
+              [SCRIPT_ID]: 'customrecord1_record1',
+              index: 0,
+            },
+            customrecord1_record2: {
+              [SCRIPT_ID]: 'customrecord1_record2',
+              index: 1,
+            },
+          },
+        },
+      })
     })
   })
+  describe('preDeploy', () => {
+    let dataInstanceChange: Change<InstanceElement>
+    beforeAll(async () => {
+      dataInstanceChange = toChange({
+        after: new InstanceElement('subsidiary1', getDataType({ withMaps: true }).type, {
+          identifier: 'subsidiary1',
+          internalId: '1',
+          classTranslationList: {
+            classTranslation: {
+              Czech: {
+                language: 'Czech',
+                name: 'a',
+              },
+              Danish: {
+                language: 'Danish',
+                name: 'b',
+              },
+              German: {
+                language: 'German',
+                name: 'c',
+              },
+            },
+          },
+        }),
+      })
 
-  it('should throw when missing some types with field mapping', async () => {
-    await expect(filterCreator().onFetch([
-      standardTypes.workflow.type,
-      ...Object.values(standardTypes.workflow.innerTypes),
-      instance,
-    ])).rejects.toThrow('missing some types with field mapping')
+      await filterCreator().preDeploy([dataInstanceChange])
+    })
+    it('should modify data instance values', () => {
+      expect(getChangeData(dataInstanceChange).value).toEqual({
+        identifier: 'subsidiary1',
+        internalId: '1',
+        classTranslationList: {
+          classTranslation: [{
+            language: 'Czech',
+            name: 'a',
+          }, {
+            language: 'Danish',
+            name: 'b',
+          }, {
+            language: 'German',
+            name: 'c',
+          }],
+        },
+      })
+    })
+    it('should modify data instance ref type', () => {
+      const instance = getChangeData(dataInstanceChange)
+      expect(
+        isObjectType(instance.refType.type)
+        && isObjectType(instance.refType.type.fields.classTranslationList.refType.type)
+        && isListType(instance.refType.type.fields.classTranslationList.refType.type
+          .fields.classTranslation.refType.type)
+      ).toBeTruthy()
+    })
   })
 })

--- a/packages/netsuite-adapter/test/filters/custom_records.test.ts
+++ b/packages/netsuite-adapter/test/filters/custom_records.test.ts
@@ -58,13 +58,6 @@ describe('fix custom record objects filter', () => {
         'custom_field',
       ])
     })
-    it('should transform values', () => {
-      expect(instance.value).toEqual({
-        translationsList: {
-          customRecordTranslations: [{ lang: 'english' }],
-        },
-      })
-    })
   })
   describe('preDeploy', () => {
     beforeEach(async () => {
@@ -85,7 +78,6 @@ describe('fix custom record objects filter', () => {
       expect(Object.keys(type.fields)).toEqual([
         'parent',
         'recType',
-        'translationsList',
       ])
     })
     it('should add recordType to instance', () => {

--- a/packages/netsuite-adapter/test/filters/omit_fields.test.ts
+++ b/packages/netsuite-adapter/test/filters/omit_fields.test.ts
@@ -100,7 +100,7 @@ describe('omit fields filter', () => {
           },
         },
       },
-      annotationRefsOrTypes: await toAnnotationRefTypes(customrecordtype),
+      annotationRefsOrTypes: toAnnotationRefTypes(customrecordtype),
       annotations: {
         scriptid: 'customrecord1',
         istoplevel: true,

--- a/packages/netsuite-adapter/test/mapped_lists/utils.test.ts
+++ b/packages/netsuite-adapter/test/mapped_lists/utils.test.ts
@@ -14,8 +14,8 @@
 * limitations under the License.
 */
 import { collections } from '@salto-io/lowerdash'
-import { BuiltinTypes, createRefToElmWithValue, ElemID, Field, FieldMap, InstanceElement, isListType, isMapType, ListType, MapType, ObjectType } from '@salto-io/adapter-api'
-import { convertFieldsTypesFromListToMap, createConvertElementMapsToLists, convertInstanceListsToMaps, getMappedLists, isMappedList, validateTypesFieldMapping, convertAnnotationListsToMaps } from '../../src/mapped_lists/utils'
+import { BuiltinTypes, createRefToElmWithValue, ElemID, Field, FieldMap, InstanceElement, isListType, isMapType, isObjectType, ListType, MapType, ObjectType } from '@salto-io/adapter-api'
+import { convertFieldsTypesFromListToMap, createConvertStandardElementMapsToLists, convertInstanceListsToMaps, getMappedLists, isMappedList, validateTypesFieldMapping, convertAnnotationListsToMaps, convertDataInstanceMapsToLists } from '../../src/mapped_lists/utils'
 import { getStandardTypes } from '../../src/autogen/types'
 import { LIST_MAPPED_BY_FIELD, NETSUITE, SCRIPT_ID } from '../../src/constants'
 import { getInnerStandardTypes, getTopLevelStandardTypes } from '../../src/types'
@@ -28,12 +28,25 @@ describe('mapped lists', () => {
   const standardTypes = getStandardTypes()
   const { workflow, kpiscorecard, customrecordtype } = standardTypes
 
+  const classTranslationType = new ObjectType({
+    elemID: new ElemID(NETSUITE, 'classTranslation'),
+    fields: {
+      locale: { refType: BuiltinTypes.STRING },
+      language: { refType: BuiltinTypes.STRING },
+      name: { refType: BuiltinTypes.STRING },
+    },
+  })
+
   let instance: InstanceElement
   let transformedInstance: InstanceElement
   let transformedBackInstance: InstanceElement
   let customRecordType: ObjectType
   let transformedCustomRecordType: ObjectType
   let transformedBackCustomRecordType: ObjectType
+  let classTranslationListType: ObjectType
+  let dataInstance: InstanceElement
+  let transformedDataInstance: InstanceElement
+  let transformedBackDataInstance: InstanceElement
   beforeAll(async () => {
     instance = new InstanceElement(
       'instanceName',
@@ -123,22 +136,57 @@ describe('mapped lists', () => {
         },
         metadataType: 'customrecordtype',
       },
-      annotationRefsOrTypes: await toAnnotationRefTypes(customrecordtype.type),
+      annotationRefsOrTypes: toAnnotationRefTypes(customrecordtype.type),
+    })
+
+    classTranslationListType = new ObjectType({
+      elemID: new ElemID(NETSUITE, 'classTranslationList'),
+      fields: {
+        classTranslation: { refType: new ListType(classTranslationType) },
+        replaceAll: { refType: BuiltinTypes.BOOLEAN },
+      },
+    })
+    const dataType = new ObjectType({
+      elemID: new ElemID(NETSUITE, 'subsidiary'),
+      fields: {
+        identifier: { refType: BuiltinTypes.SERVICE_ID },
+        internalId: { refType: BuiltinTypes.STRING },
+        classTranslationList: { refType: classTranslationListType },
+      },
+    })
+    dataInstance = new InstanceElement('subsidiary1', dataType, {
+      identifier: 'subsidiary1',
+      internalId: '1',
+      classTranslationList: {
+        classTranslation: [{
+          language: 'Czech',
+          name: 'a',
+        }, {
+          language: 'Danish',
+          name: 'b',
+        }, {
+          language: 'German',
+          name: 'c',
+        }],
+      },
     })
 
     await awu([
       ...Object.values(workflow.innerTypes),
       ...Object.values(kpiscorecard.innerTypes),
       ...Object.values(customrecordtype.innerTypes),
+      classTranslationListType,
     ])
       .forEach(t => convertFieldsTypesFromListToMap(t))
 
     transformedInstance = instance.clone()
-    transformedInstance.value = await convertInstanceListsToMaps(instance) ?? instance.value
+    transformedInstance.value = await convertInstanceListsToMaps(instance) ?? {}
     transformedCustomRecordType = customRecordType.clone()
     transformedCustomRecordType.annotations = await convertAnnotationListsToMaps(customRecordType)
+    transformedDataInstance = dataInstance.clone()
+    transformedDataInstance.value = await convertInstanceListsToMaps(dataInstance) ?? {}
 
-    const convertElementMapsToLists = await createConvertElementMapsToLists({ getIndexes: () => ({
+    const convertElementMapsToLists = await createConvertStandardElementMapsToLists({ getIndexes: () => ({
       mapKeyFieldsIndex: {
         'netsuite.workflow_workflowcustomfields.field.workflowcustomfield': 'scriptid',
         'netsuite.workflow_workflowstates.field.workflowstate': 'scriptid',
@@ -149,17 +197,34 @@ describe('mapped lists', () => {
     }) } as unknown as LazyElementsSourceIndexes)
     transformedBackInstance = await convertElementMapsToLists(transformedInstance) as InstanceElement
     transformedBackCustomRecordType = await convertElementMapsToLists(transformedCustomRecordType) as ObjectType
+    transformedBackDataInstance = await convertDataInstanceMapsToLists(transformedDataInstance)
   })
-
   describe('validateTypesFieldMapping', () => {
-    const standardTypesAndInnerTypes = [
+    const types = [
       ...getTopLevelStandardTypes(standardTypes),
       ...getInnerStandardTypes(standardTypes),
+      new ObjectType({
+        elemID: new ElemID(NETSUITE, 'translation'),
+        fields: {
+          locale: { refType: BuiltinTypes.STRING },
+          language: { refType: BuiltinTypes.STRING },
+        },
+      }),
+      classTranslationType,
+      new ObjectType({
+        elemID: new ElemID(NETSUITE, 'customRecordTranslations'),
+        fields: {
+          locale: { refType: BuiltinTypes.STRING },
+          language: { refType: BuiltinTypes.STRING },
+        },
+      }),
     ]
+    it('should not throw', () => {
+      expect(() => validateTypesFieldMapping(types)).not.toThrow()
+    })
     it('should throw when missing some types with field mapping', async () => {
-      const missingTypes = standardTypesAndInnerTypes
-        .filter(element => element.elemID.name !== 'addressForm_mainFields_defaultFieldGroup_fields')
-      await expect(async () => validateTypesFieldMapping(missingTypes)).rejects.toThrow('missing some types with field mapping')
+      const missingTypes = types.filter(element => element.elemID.name !== 'addressForm_mainFields_defaultFieldGroup_fields')
+      expect(() => validateTypesFieldMapping(missingTypes)).toThrow()
 
       const typeWithMissingField = new ObjectType({
         elemID: new ElemID(NETSUITE, 'addressForm_mainFields_defaultFieldGroup_fields'),
@@ -169,11 +234,9 @@ describe('mapped lists', () => {
           },
         },
       })
-      await expect(async () => validateTypesFieldMapping([...missingTypes, typeWithMissingField]))
-        .rejects.toThrow('missing some types with field mapping')
+      expect(() => validateTypesFieldMapping([...missingTypes, typeWithMissingField])).toThrow()
     })
   })
-
   it('should modify ObjectTypes fields', async () => {
     const workflowcustomfields = workflow.innerTypes.workflow_workflowcustomfields
     expect(workflowcustomfields).toBeDefined()
@@ -195,8 +258,18 @@ describe('mapped lists', () => {
     expect(isMapType(await workflowactions.getType())).toBeTruthy()
     expect(workflowactions.annotations)
       .toEqual({ [LIST_MAPPED_BY_FIELD]: 'triggertype' })
-  })
 
+    expect(isMapType(await classTranslationListType.fields.classTranslation.getType())).toBeTruthy()
+    expect(classTranslationListType.fields.classTranslation.annotations)
+      .toEqual({ [LIST_MAPPED_BY_FIELD]: ['locale', 'language'] })
+  })
+  it('should add index field', () => {
+    expect(workflow.innerTypes.workflow_workflowstates_workflowstate_workflowactions.fields.index).toBeDefined()
+  })
+  it('should not add index field to unordered lists', async () => {
+    expect(customrecordtype.innerTypes.customrecordtype_permissions_permission.fields.index).toBeUndefined()
+    expect(classTranslationType.fields.index).toBeUndefined()
+  })
   it('should not modify ObjectTypes fields when types has no field to map by', async () => {
     const highlightings = kpiscorecard.innerTypes.kpiscorecard_highlightings
     expect(highlightings).toBeDefined()
@@ -204,8 +277,7 @@ describe('mapped lists', () => {
     expect(isListType(await highlighting.getType())).toBeTruthy()
     expect(highlighting.annotations[LIST_MAPPED_BY_FIELD]).toBeUndefined()
   })
-
-  it('should modify instance values', () => {
+  it('should modify standard instance values', () => {
     expect(transformedInstance.value).toEqual({
       scriptid: 'customworkflow_changed_id',
       workflowcustomfields: {
@@ -272,7 +344,28 @@ describe('mapped lists', () => {
       },
     })
   })
-
+  it('should modify data instance values', () => {
+    expect(transformedDataInstance.value).toEqual({
+      identifier: 'subsidiary1',
+      internalId: '1',
+      classTranslationList: {
+        classTranslation: {
+          Czech: {
+            language: 'Czech',
+            name: 'a',
+          },
+          Danish: {
+            language: 'Danish',
+            name: 'b',
+          },
+          German: {
+            language: 'German',
+            name: 'c',
+          },
+        },
+      },
+    })
+  })
   it('should modify custom record type annotations', () => {
     expect(transformedCustomRecordType.annotations).toEqual({
       scriptid: 'customrecord1',
@@ -281,14 +374,12 @@ describe('mapped lists', () => {
           customrole1: {
             permittedlevel: 'EDIT',
             permittedrole: '[scriptid=customrole1]',
-            index: 0,
           },
         },
       },
       metadataType: 'customrecordtype',
     })
   })
-
   it('should not convert list if the inner type is not an ObjectType', async () => {
     const elemID = new ElemID(NETSUITE, 'newType')
     const type = new ObjectType({
@@ -304,7 +395,6 @@ describe('mapped lists', () => {
     expect(isListType(await primitiveList.getType())).toBeTruthy()
     expect(primitiveList.annotations).toEqual({})
   })
-
   it('should use \'key\' as item key if item has no \'LIST_MAPPED_BY_FIELD\' field', async () => {
     const inst = new InstanceElement(
       'instance',
@@ -339,7 +429,6 @@ describe('mapped lists', () => {
       },
     })
   })
-
   describe('isMappedList', () => {
     const elemID = new ElemID(NETSUITE, 'newType')
     const elemIDinner = new ElemID(NETSUITE, 'inner')
@@ -402,7 +491,9 @@ describe('mapped lists', () => {
   })
   it('should return mapped lists', async () => {
     expect(await getMappedLists(transformedInstance)).toEqual([
-      { path: new ElemID('netsuite', 'workflow', 'instance', 'instanceName', 'workflowcustomfields', 'workflowcustomfield'),
+      {
+        field: workflow.innerTypes.workflow_workflowcustomfields.fields.workflowcustomfield,
+        path: new ElemID('netsuite', 'workflow', 'instance', 'instanceName', 'workflowcustomfields', 'workflowcustomfield'),
         value: {
           custworkflow1: {
             scriptid: 'custworkflow1',
@@ -424,8 +515,11 @@ describe('mapped lists', () => {
             scriptid: '[type=workflow, scriptid=custworkflow2]',
             index: 4,
           },
-        } },
-      { path: new ElemID('netsuite', 'workflow', 'instance', 'instanceName', 'workflowstates', 'workflowstate'),
+        },
+      },
+      {
+        field: workflow.innerTypes.workflow_workflowstates.fields.workflowstate,
+        path: new ElemID('netsuite', 'workflow', 'instance', 'instanceName', 'workflowstates', 'workflowstate'),
         value: {
           workflowstate1: {
             index: 0,
@@ -461,8 +555,11 @@ describe('mapped lists', () => {
               },
             },
           },
-        } },
-      { path: new ElemID('netsuite', 'workflow', 'instance', 'instanceName', 'workflowstates', 'workflowstate', 'workflowstate1', 'workflowactions'),
+        },
+      },
+      {
+        field: workflow.innerTypes.workflow_workflowstates_workflowstate.fields.workflowactions,
+        path: new ElemID('netsuite', 'workflow', 'instance', 'instanceName', 'workflowstates', 'workflowstate', 'workflowstate1', 'workflowactions'),
         value: {
           BEFORELOAD: {
             index: 1,
@@ -492,8 +589,11 @@ describe('mapped lists', () => {
             },
             triggertype: 'ONENTRY',
           },
-        } },
-      { path: new ElemID('netsuite', 'workflow', 'instance', 'instanceName', 'workflowstates', 'workflowstate', 'workflowstate1', 'workflowactions', 'ONENTRY', 'setfieldvalueaction'),
+        },
+      },
+      {
+        field: workflow.innerTypes.workflow_workflowstates_workflowstate_workflowactions.fields.setfieldvalueaction,
+        path: new ElemID('netsuite', 'workflow', 'instance', 'instanceName', 'workflowstates', 'workflowstate', 'workflowstate1', 'workflowactions', 'ONENTRY', 'setfieldvalueaction'),
         value: {
           workflowaction1: {
             index: 0,
@@ -503,8 +603,11 @@ describe('mapped lists', () => {
             index: 1,
             scriptid: 'workflowaction2',
           },
-        } },
-      { path: new ElemID('netsuite', 'workflow', 'instance', 'instanceName', 'workflowstates', 'workflowstate', 'workflowstate1', 'workflowactions', 'BEFORELOAD', 'setfieldvalueaction'),
+        },
+      },
+      {
+        field: workflow.innerTypes.workflow_workflowstates_workflowstate_workflowactions.fields.setfieldvalueaction,
+        path: new ElemID('netsuite', 'workflow', 'instance', 'instanceName', 'workflowstates', 'workflowstate', 'workflowstate1', 'workflowactions', 'BEFORELOAD', 'setfieldvalueaction'),
         value: {
           workflowaction3: {
             index: 0,
@@ -514,11 +617,21 @@ describe('mapped lists', () => {
             index: 1,
             scriptid: 'workflowaction4',
           },
-        } },
+        },
+      },
     ])
   })
-  it('should convert map back to a list in instance', () => {
+  it('should convert map back to a list in standard instance', () => {
     expect(transformedBackInstance.value).toEqual(instance.value)
+  })
+  it('should convert map back to a list in data instance', async () => {
+    expect(transformedBackDataInstance.value).toEqual(dataInstance.value)
+    expect(
+      isObjectType(transformedBackDataInstance.refType.type)
+      && isObjectType(transformedBackDataInstance.refType.type.fields.classTranslationList.refType.type)
+      && isListType(transformedBackDataInstance.refType.type.fields.classTranslationList.refType.type
+        .fields.classTranslation.refType.type)
+    ).toBeTruthy()
   })
   it('should convert map back to a list in type', () => {
     expect(transformedBackCustomRecordType.isEqual(customRecordType)).toBeTruthy()

--- a/packages/netsuite-adapter/test/mapped_lists/utils.test.ts
+++ b/packages/netsuite-adapter/test/mapped_lists/utils.test.ts
@@ -70,6 +70,9 @@ describe('mapped lists', () => {
             {
               scriptid: '[type=workflow, scriptid=custworkflow2]',
             },
+            {
+              scriptid: 's0m@ $CR1pt!*()',
+            },
           ],
         },
         workflowstates: {
@@ -302,6 +305,10 @@ describe('mapped lists', () => {
             scriptid: '[type=workflow, scriptid=custworkflow2]',
             index: 4,
           },
+          's0m___CR1pt_____2@mszclojku': {
+            scriptid: 's0m@ $CR1pt!*()',
+            index: 5,
+          },
         },
       },
       workflowstates: {
@@ -514,6 +521,10 @@ describe('mapped lists', () => {
           custworkflow2_3: {
             scriptid: '[type=workflow, scriptid=custworkflow2]',
             index: 4,
+          },
+          's0m___CR1pt_____2@mszclojku': {
+            scriptid: 's0m@ $CR1pt!*()',
+            index: 5,
           },
         },
       },


### PR DESCRIPTION
In order to prevent unnecessary diffs between envs:
- Increase coverage of fields to transform from lists to maps
- Remove `index` field from unordered mapped lists

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Increase coverage of fields to transform from lists to maps
- Remove `index` field from unordered mapped lists

---
_User Notifications_: 
Netsuite Adapter:
- More lists are going to be transformed to maps
- `index` field will be removed from maps that the original list is unordered