### PR TITLE
SALTO-3153: remove updated and created fields from zendesk guide

### DIFF
--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -32,6 +32,12 @@ const {
   createDucktypeAdapterApiConfigType,
   validateDuckTypeFetchConfig,
 } = configUtils
+const UPDATED_CREATED_FIELDS = [
+  { fieldName: 'created_by_id', fieldType: 'unknown' },
+  { fieldName: 'updated_by_id', fieldType: 'unknown' },
+  { fieldName: 'created_at', fieldType: 'unknown' },
+  { fieldName: 'updated_at', fieldType: 'unknown' },
+]
 
 export const DEFAULT_ID_FIELDS = ['name']
 export const DEFAULT_FILENAME_FIELDS = ['name']
@@ -1740,10 +1746,7 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
         { fieldName: 'html_url', fieldType: 'string' },
         { fieldName: 'source_id', fieldType: 'number' },
         { fieldName: 'source_type', fieldType: 'string' },
-        { fieldName: 'created_by_id', fieldType: 'unknown' },
-        { fieldName: 'updated_by_id', fieldType: 'unknown' },
-        { fieldName: 'created_at', fieldType: 'unknown' },
-        { fieldName: 'updated_at', fieldType: 'unknown' },
+        ...UPDATED_CREATED_FIELDS,
       ),
       // serviceUrl is created in help_center_service_url filter
     },
@@ -1969,10 +1972,7 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
         { fieldName: 'html_url', fieldType: 'string' },
         { fieldName: 'source_id', fieldType: 'number' },
         { fieldName: 'source_type', fieldType: 'string' },
-        { fieldName: 'created_by_id', fieldType: 'unknown' },
-        { fieldName: 'updated_by_id', fieldType: 'unknown' },
-        { fieldName: 'created_at', fieldType: 'unknown' },
-        { fieldName: 'updated_at', fieldType: 'unknown' },
+        ...UPDATED_CREATED_FIELDS
       ),
       // serviceUrl is created in help_center_service_url filter
     },
@@ -2088,10 +2088,7 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
         { fieldName: 'html_url', fieldType: 'string' },
         { fieldName: 'source_id', fieldType: 'number' },
         { fieldName: 'source_type', fieldType: 'string' },
-        { fieldName: 'created_by_id', fieldType: 'unknown' },
-        { fieldName: 'updated_by_id', fieldType: 'unknown' },
-        { fieldName: 'created_at', fieldType: 'unknown' },
-        { fieldName: 'updated_at', fieldType: 'unknown' },
+        ...UPDATED_CREATED_FIELDS
       ),
       // serviceUrl is created in help_center_service_url filter
     },

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -1735,13 +1735,15 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
       ),
       fieldTypeOverrides: [
         { fieldName: 'id', fieldType: 'number' },
-        { fieldName: 'created_by_id', fieldType: 'unknown' },
-        { fieldName: 'updated_by_id', fieldType: 'unknown' },
       ],
       fieldsToOmit: FIELDS_TO_OMIT.concat(
         { fieldName: 'html_url', fieldType: 'string' },
         { fieldName: 'source_id', fieldType: 'number' },
         { fieldName: 'source_type', fieldType: 'string' },
+        { fieldName: 'created_by_id', fieldType: 'unknown' },
+        { fieldName: 'updated_by_id', fieldType: 'unknown' },
+        { fieldName: 'created_at', fieldType: 'unknown' },
+        { fieldName: 'updated_at', fieldType: 'unknown' },
       ),
       // serviceUrl is created in help_center_service_url filter
     },
@@ -1967,6 +1969,10 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
         { fieldName: 'html_url', fieldType: 'string' },
         { fieldName: 'source_id', fieldType: 'number' },
         { fieldName: 'source_type', fieldType: 'string' },
+        { fieldName: 'created_by_id', fieldType: 'unknown' },
+        { fieldName: 'updated_by_id', fieldType: 'unknown' },
+        { fieldName: 'created_at', fieldType: 'unknown' },
+        { fieldName: 'updated_at', fieldType: 'unknown' },
       ),
       // serviceUrl is created in help_center_service_url filter
     },
@@ -2082,6 +2088,10 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
         { fieldName: 'html_url', fieldType: 'string' },
         { fieldName: 'source_id', fieldType: 'number' },
         { fieldName: 'source_type', fieldType: 'string' },
+        { fieldName: 'created_by_id', fieldType: 'unknown' },
+        { fieldName: 'updated_by_id', fieldType: 'unknown' },
+        { fieldName: 'created_at', fieldType: 'unknown' },
+        { fieldName: 'updated_at', fieldType: 'unknown' },
       ),
       // serviceUrl is created in help_center_service_url filter
     },

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -32,12 +32,6 @@ const {
   createDucktypeAdapterApiConfigType,
   validateDuckTypeFetchConfig,
 } = configUtils
-const UPDATED_CREATED_FIELDS = [
-  { fieldName: 'created_by_id', fieldType: 'unknown' },
-  { fieldName: 'updated_by_id', fieldType: 'unknown' },
-  { fieldName: 'created_at', fieldType: 'unknown' },
-  { fieldName: 'updated_at', fieldType: 'unknown' },
-]
 
 export const DEFAULT_ID_FIELDS = ['name']
 export const DEFAULT_FILENAME_FIELDS = ['name']
@@ -51,6 +45,8 @@ export const FIELDS_TO_OMIT: configUtils.FieldToOmitType[] = [
 export const FIELDS_TO_HIDE: configUtils.FieldToHideType[] = [
   { fieldName: 'created_at', fieldType: 'string' },
   { fieldName: 'updated_at', fieldType: 'string' },
+  { fieldName: 'created_by_id', fieldType: 'unknown' },
+  { fieldName: 'updated_by_id', fieldType: 'unknown' },
 ]
 
 export const CLIENT_CONFIG = 'client'
@@ -1738,7 +1734,6 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
       dataField: 'translations',
       fieldsToHide: FIELDS_TO_HIDE.concat(
         { fieldName: 'id', fieldType: 'number' },
-        ...UPDATED_CREATED_FIELDS,
       ),
       fieldTypeOverrides: [
         { fieldName: 'id', fieldType: 'number' },
@@ -1962,7 +1957,6 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
       dataField: 'translations',
       fieldsToHide: FIELDS_TO_HIDE.concat(
         { fieldName: 'id', fieldType: 'number' },
-        ...UPDATED_CREATED_FIELDS,
       ),
       fieldTypeOverrides: [
         { fieldName: 'id', fieldType: 'number' },
@@ -2078,7 +2072,6 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
       dataField: 'translations',
       fieldsToHide: FIELDS_TO_HIDE.concat(
         { fieldName: 'id', fieldType: 'number' },
-        ...UPDATED_CREATED_FIELDS,
       ),
       fieldTypeOverrides: [
         { fieldName: 'id', fieldType: 'number' },

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -1965,8 +1965,6 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
       ),
       fieldTypeOverrides: [
         { fieldName: 'id', fieldType: 'number' },
-        { fieldName: 'created_by_id', fieldType: 'unknown' },
-        { fieldName: 'updated_by_id', fieldType: 'unknown' },
       ],
       fieldsToOmit: FIELDS_TO_OMIT.concat(
         { fieldName: 'html_url', fieldType: 'string' },
@@ -2081,8 +2079,6 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
       fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
       fieldTypeOverrides: [
         { fieldName: 'id', fieldType: 'number' },
-        { fieldName: 'created_by_id', fieldType: 'unknown' },
-        { fieldName: 'updated_by_id', fieldType: 'unknown' },
       ],
       fieldsToOmit: FIELDS_TO_OMIT.concat(
         { fieldName: 'html_url', fieldType: 'string' },

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -1738,6 +1738,7 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
       dataField: 'translations',
       fieldsToHide: FIELDS_TO_HIDE.concat(
         { fieldName: 'id', fieldType: 'number' },
+        ...UPDATED_CREATED_FIELDS,
       ),
       fieldTypeOverrides: [
         { fieldName: 'id', fieldType: 'number' },
@@ -1746,7 +1747,6 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
         { fieldName: 'html_url', fieldType: 'string' },
         { fieldName: 'source_id', fieldType: 'number' },
         { fieldName: 'source_type', fieldType: 'string' },
-        ...UPDATED_CREATED_FIELDS,
       ),
       // serviceUrl is created in help_center_service_url filter
     },
@@ -1962,6 +1962,7 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
       dataField: 'translations',
       fieldsToHide: FIELDS_TO_HIDE.concat(
         { fieldName: 'id', fieldType: 'number' },
+        ...UPDATED_CREATED_FIELDS,
       ),
       fieldTypeOverrides: [
         { fieldName: 'id', fieldType: 'number' },
@@ -1970,7 +1971,6 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
         { fieldName: 'html_url', fieldType: 'string' },
         { fieldName: 'source_id', fieldType: 'number' },
         { fieldName: 'source_type', fieldType: 'string' },
-        ...UPDATED_CREATED_FIELDS
       ),
       // serviceUrl is created in help_center_service_url filter
     },
@@ -2076,7 +2076,10 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
       fileNameFields: ['&locale'],
       sourceTypeName: 'category__translations',
       dataField: 'translations',
-      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
+      fieldsToHide: FIELDS_TO_HIDE.concat(
+        { fieldName: 'id', fieldType: 'number' },
+        ...UPDATED_CREATED_FIELDS,
+      ),
       fieldTypeOverrides: [
         { fieldName: 'id', fieldType: 'number' },
       ],
@@ -2084,7 +2087,6 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
         { fieldName: 'html_url', fieldType: 'string' },
         { fieldName: 'source_id', fieldType: 'number' },
         { fieldName: 'source_type', fieldType: 'string' },
-        ...UPDATED_CREATED_FIELDS
       ),
       // serviceUrl is created in help_center_service_url filter
     },


### PR DESCRIPTION
_remove updated and created fields from zendesk guide_

---

_Additional context for reviewer_
None

---
_Release Notes_: 
None

---
_User Notifications_: 
None
