### PR TITLE
SALTO-2982: Change guide fetch method to avoid unnecessary requests (Zendesk guide)

### DIFF
--- a/packages/adapter-components/src/elements/ducktype/index.ts
+++ b/packages/adapter-components/src/elements/ducktype/index.ts
@@ -16,6 +16,6 @@
 export { toInstance } from './instance_elements'
 export { replaceInstanceTypeForDeploy, restoreInstanceTypeFromDeploy } from './deployment_placeholder_types'
 export { extractStandaloneFields } from './standalone_field_extractor'
-export { getAllElements, getTypeAndInstances, ConfigChangeSuggestion, FetchElements, EntriesRequester, getEntriesResponseValues } from './transformer'
+export { getAllElements, getTypeAndInstances, ConfigChangeSuggestion, FetchElements, EntriesRequester, getEntriesResponseValues, getNewElementsFromInstances } from './transformer'
 export { generateType, toNestedTypeName } from './type_elements'
 export { addRemainingTypes } from './add_remaining_types'

--- a/packages/adapter-components/src/elements/ducktype/index.ts
+++ b/packages/adapter-components/src/elements/ducktype/index.ts
@@ -16,6 +16,6 @@
 export { toInstance } from './instance_elements'
 export { replaceInstanceTypeForDeploy, restoreInstanceTypeFromDeploy } from './deployment_placeholder_types'
 export { extractStandaloneFields } from './standalone_field_extractor'
-export { getAllElements, getTypeAndInstances, ConfigChangeSuggestion, FetchElements, EntriesRequester, getEntriesResponseValues, getNewElementsFromInstances } from './transformer'
+export { getAllElements, getTypeAndInstances, ConfigChangeSuggestion, FetchElements, EntriesRequester, getEntriesResponseValues, getNewElementsFromInstances, getUniqueConfigSuggestions } from './transformer'
 export { generateType, toNestedTypeName } from './type_elements'
 export { addRemainingTypes } from './add_remaining_types'

--- a/packages/adapter-components/src/elements/ducktype/transformer.ts
+++ b/packages/adapter-components/src/elements/ducktype/transformer.ts
@@ -83,17 +83,27 @@ export const getEntriesResponseValues: EntriesRequester = async ({
   )).flat()
 )
 
+export const getUniqueConfigSuggestions = (
+  configSuggestions: ConfigChangeSuggestion[]
+): ConfigChangeSuggestion[] => (_.uniqBy(configSuggestions, suggestion => suggestion.typeToExclude))
+
 /**
  * Creates new type based on instances values,
  * then creates new instances pointing the new type
  */
-export const getNewElementsFromInstances = (
-  adapterName: string,
-  typeName: string,
-  instances: InstanceElement[],
-  transformationConfigByType: Record<string, DuckTypeTransformationConfig>,
-  transformationDefaultConfig: DuckTypeTransformationDefaultConfig,
-): Entries => {
+export const getNewElementsFromInstances = ({
+  adapterName,
+  typeName,
+  instances,
+  transformationConfigByType,
+  transformationDefaultConfig,
+}: {
+  adapterName: string
+  typeName: string
+  instances: InstanceElement[]
+  transformationConfigByType: Record<string, DuckTypeTransformationConfig>
+  transformationDefaultConfig: DuckTypeTransformationDefaultConfig
+}): Entries => {
   const { hasDynamicFields } = getConfigWithDefault(transformationConfigByType[typeName], transformationDefaultConfig)
 
   const { type: newType, nestedTypes: newNestedTypes } = generateType({
@@ -242,13 +252,13 @@ const getEntriesForType = async (
     return { instances, type, nestedTypes }
   }
   // We generare the type again since we added more fields to the instances from the recurse into
-  const newElements = getNewElementsFromInstances(
+  const newElements = getNewElementsFromInstances({
     adapterName,
-    (nestedFieldDetails?.type ?? type).elemID.typeName,
+    typeName: (nestedFieldDetails?.type ?? type).elemID.typeName,
     instances,
     transformationConfigByType,
-    transformationDefaultConfig
-  )
+    transformationDefaultConfig,
+  })
 
   return {
     instances: newElements.instances,
@@ -406,6 +416,6 @@ export const getAllElements = async ({
   }
   return {
     elements: instancesAndTypes,
-    configChanges: _.uniqBy(configSuggestions, suggestion => suggestion.typeToExclude),
+    configChanges: getUniqueConfigSuggestions(configSuggestions),
   }
 }

--- a/packages/adapter-components/src/elements/ducktype/transformer.ts
+++ b/packages/adapter-components/src/elements/ducktype/transformer.ts
@@ -23,7 +23,7 @@ import { generateType } from './type_elements'
 import { toInstance } from './instance_elements'
 import { TypeConfig, getConfigWithDefault, getTransformationConfigByType } from '../../config'
 import { FindNestedFieldFunc } from '../field_finder'
-import { TypeDuckTypeDefaultsConfig, TypeDuckTypeConfig } from '../../config/ducktype'
+import { TypeDuckTypeDefaultsConfig, TypeDuckTypeConfig, DuckTypeTransformationConfig, DuckTypeTransformationDefaultConfig } from '../../config/ducktype'
 import { ComputeGetArgsFunc } from '../request_parameters'
 import { getElementsWithContext } from '../element_getter'
 import { extractStandaloneFields } from './standalone_field_extractor'
@@ -82,6 +82,36 @@ export const getEntriesResponseValues: EntriesRequester = async ({
     paginator(args, page => makeArray(page) as ResponseValue[])
   )).flat()
 )
+
+/**
+ * Creates new type based on instances values,
+ * then creates new instances pointing the new type
+ */
+export const getNewElementsFromInstances = (
+  adapterName: string,
+  typeName: string,
+  instances: InstanceElement[],
+  transformationConfigByType: Record<string, DuckTypeTransformationConfig>,
+  transformationDefaultConfig: DuckTypeTransformationDefaultConfig,
+): Entries => {
+  const { hasDynamicFields } = getConfigWithDefault(transformationConfigByType[typeName], transformationDefaultConfig)
+
+  const { type: newType, nestedTypes: newNestedTypes } = generateType({
+    adapterName,
+    name: typeName,
+    entries: instances.map(inst => inst.value),
+    hasDynamicFields: hasDynamicFields === true,
+    transformationConfigByType,
+    transformationDefaultConfig,
+  })
+  return {
+    instances: instances.map(inst => new InstanceElement(
+      inst.elemID.name, newType, inst.value, inst.path, inst.annotations
+    )),
+    type: newType,
+    nestedTypes: newNestedTypes,
+  }
+}
 
 const getEntriesForType = async (
   params: GetEntriesParams
@@ -212,20 +242,18 @@ const getEntriesForType = async (
     return { instances, type, nestedTypes }
   }
   // We generare the type again since we added more fields to the instances from the recurse into
-  const { type: newType, nestedTypes: newNestedTypes } = generateType({
+  const newElements = getNewElementsFromInstances(
     adapterName,
-    name: (nestedFieldDetails?.type ?? type).elemID.typeName,
-    entries: instances.map(inst => inst.value),
-    hasDynamicFields: hasDynamicFields === true,
+    (nestedFieldDetails?.type ?? type).elemID.typeName,
+    instances,
     transformationConfigByType,
-    transformationDefaultConfig,
-  })
+    transformationDefaultConfig
+  )
+
   return {
-    instances: instances.map(inst => new InstanceElement(
-      inst.elemID.name, newType, inst.value, inst.path, inst.annotations,
-    )),
-    type: newType,
-    nestedTypes: newNestedTypes.concat(nestedFieldDetails ? type : []),
+    instances: newElements.instances,
+    type: newElements.type,
+    nestedTypes: newElements.nestedTypes.concat(nestedFieldDetails ? type : []),
   }
 }
 

--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -17,7 +17,7 @@ import _, { isString } from 'lodash'
 import {
   FetchResult, AdapterOperations, DeployResult, DeployModifiers, FetchOptions,
   DeployOptions, Change, isInstanceChange, InstanceElement, getChangeData, ElemIdGetter,
-  isInstanceElement,
+  isInstanceElement, Element,
   ReadOnlyElementsSource, isReferenceExpression,
 } from '@salto-io/adapter-api'
 import {
@@ -212,18 +212,18 @@ const SKIP_RESOLVE_TYPE_NAMES = [
 ]
 
 /**
- * Fetch Guide (help_center) elements for the given brands.
- * Each help_center requires a different paginator.
+ * Fetch Guide (help_center) elements of brand.
 */
 const zendeskGuideEntriesFunc = (
-  brandsList: InstanceElement[],
-  brandToPaginator: Record<string, clientUtils.Paginator>,
+  brandInstance: InstanceElement,
 ): elementUtils.ducktype.EntriesRequester => {
   const getZendeskGuideEntriesResponseValues = async ({
+    paginator,
     args,
     typeName,
     typesConfig,
   } : {
+    paginator: clientUtils.Paginator
     args: clientUtils.ClientGetWithPaginationParams
     typeName?: string
     typesConfig?: Record<string, configUtils.TypeDuckTypeConfig>
@@ -231,44 +231,43 @@ const zendeskGuideEntriesFunc = (
     if (typeName === undefined || typesConfig === undefined) {
       return []
     }
-    return (await awu(brandsList).map(async brandInstance => {
-      log.debug(`Fetching type ${typeName} entries for brand ${brandInstance.elemID.name}`)
-      const brandPaginatorResponseValues = (await getEntriesResponseValues({
-        paginator: brandToPaginator[brandInstance.elemID.name],
-        args,
-        typeName,
-        typesConfig,
-      })).flat()
-      // Defining Zendesk Guide element to its corresponding guide (= subdomain)
-      return brandPaginatorResponseValues.flatMap(response => {
-        const responseEntryName = typesConfig[typeName].transformation?.dataField
-        if (responseEntryName === undefined) {
-          return makeArray(response)
-        }
-        const responseEntries = makeArray(
-          (responseEntryName !== configUtils.DATA_FIELD_ENTIRE_OBJECT)
-            ? response[responseEntryName]
-            : response
-        ) as clientUtils.ResponseValue[]
+    log.debug(`Fetching type ${typeName} entries for brand ${brandInstance.elemID.name}`)
+    const brandPaginatorResponseValues = (await getEntriesResponseValues({
+      paginator,
+      args,
+      typeName,
+      typesConfig,
+    })).flat()
+    // Defining Zendesk Guide element to its corresponding guide (= subdomain)
+    return brandPaginatorResponseValues.flatMap(response => {
+      const responseEntryName = typesConfig[typeName].transformation?.dataField
+      if (responseEntryName === undefined) {
+        return makeArray(response)
+      }
+      const responseEntries = makeArray(
+        (responseEntryName !== configUtils.DATA_FIELD_ENTIRE_OBJECT)
+          ? response[responseEntryName]
+          : response
+      ) as clientUtils.ResponseValue[]
+      // Defining Zendesk Guide element to its corresponding brand (= subdomain)
+      responseEntries.forEach(entry => {
+        entry.brand = brandInstance.value.id
+      })
+      // need to add direct parent to a section as it is possible to have a section inside
+      // a section and therefore the elemeID will change accordingly.
+      if (responseEntryName === SECTIONS_TYPE_NAME) {
         responseEntries.forEach(entry => {
-          entry.brand = brandInstance.value.id
+          addParentFields(entry)
         })
-        // need to add direct parent to a section as it is possible to have a section inside
-        // a section and therefore the elemeID will change accordingly.
-        if (responseEntryName === SECTIONS_TYPE_NAME) {
-          responseEntries.forEach(entry => {
-            addParentFields(entry)
-          })
-        }
-        if (responseEntryName === configUtils.DATA_FIELD_ENTIRE_OBJECT) {
-          return responseEntries
-        }
-        return {
-          ...response,
-          [responseEntryName]: responseEntries,
-        }
-      }) as clientUtils.ResponseValue[]
-    }).toArray()).flat()
+      }
+      if (responseEntryName === configUtils.DATA_FIELD_ENTIRE_OBJECT) {
+        return responseEntries
+      }
+      return {
+        ...response,
+        [responseEntryName]: responseEntries,
+      }
+    }) as clientUtils.ResponseValue[]
   }
 
   return getZendeskGuideEntriesResponseValues
@@ -293,6 +292,72 @@ const getBrandsForGuide = (
     .filter(instance => instance.elemID.typeName === BRAND_TYPE_NAME)
     .filter(brandInstance => brandInstance.value.has_help_center)
     .filter(brandInstance => brandsRegexList.some(regex => new RegExp(regex).test(brandInstance.value.name)))
+}
+
+/**
+ * Fetch Guide (help_center) elements for the given brands.
+ * Each help_center requires a different paginator.
+*/
+const getGuideElements = async (
+  brandsList: InstanceElement[],
+  brandToPaginator: Record<string, clientUtils.Paginator>,
+  apiDefinitions: configUtils.AdapterDuckTypeApiConfig,
+  fetchQuery: elementUtils.query.ElementQuery,
+  getElemIdFunc?: ElemIdGetter
+): Promise<elementUtils.ducktype.FetchElements<Element[]>> => {
+  const transformationDefaultConfig = apiDefinitions.typeDefaults.transformation
+  const transformationConfigByType = configUtils.getTransformationConfigByType(apiDefinitions.types)
+
+  // Omit standaloneFields from config to avoid creating types from references
+  const typesConfigWithNoStandaloneFields = _.mapValues(apiDefinitions.types, config => _.omit(config, ['transformation.standaloneFields']))
+  const fetchResultWithDuplicateTypes = await Promise.all(brandsList.map(async brandInstance => {
+    const brandsPaginator = brandToPaginator[brandInstance.elemID.name]
+    log.debug(`Fetching elements for brand ${brandInstance.elemID.name}`)
+    return getAllElements({
+      adapterName: ZENDESK,
+      types: typesConfigWithNoStandaloneFields,
+      shouldAddRemainingTypes: false,
+      supportedTypes: GUIDE_BRAND_SPECIFIC_TYPES,
+      fetchQuery,
+      paginator: brandsPaginator,
+      nestedFieldFinder: findDataField,
+      computeGetArgs,
+      typeDefaults: apiDefinitions.typeDefaults,
+      getElemIdFunc,
+      getEntriesResponseValuesFunc: zendeskGuideEntriesFunc(brandInstance),
+    })
+  }))
+
+  const typeNameToGuideInstances = _.groupBy(
+    fetchResultWithDuplicateTypes.flatMap(result => result.elements).filter(isInstanceElement),
+    instance => instance.elemID.typeName
+  )
+  // Create new types based on the created instances from all brands,
+  // then create new instances with the corresponding type as refType
+  const zendeskGuideElements = Object.entries(typeNameToGuideInstances).flatMap(([typeName, instances]) => {
+    const guideElements = elementUtils.ducktype.getNewElementsFromInstances(
+      ZENDESK,
+      typeName,
+      instances,
+      transformationConfigByType,
+      transformationDefaultConfig,
+    )
+    return [...guideElements.instances, guideElements.type, ...guideElements.nestedTypes]
+  })
+
+  // Create instances from standalone fields that were not created in previous steps
+  await elementUtils.ducktype.extractStandaloneFields({
+    adapterName: ZENDESK,
+    elements: zendeskGuideElements,
+    transformationConfigByType,
+    transformationDefaultConfig,
+    getElemIdFunc,
+  })
+
+  return {
+    elements: zendeskGuideElements,
+    configChanges: fetchResultWithDuplicateTypes.flatMap(fetchResult => fetchResult.configChanges),
+  }
 }
 
 export interface ZendeskAdapterParams {
@@ -421,19 +486,13 @@ export default class ZendeskAdapter implements AdapterOperations {
       ]
     )))
 
-    const zendeskGuideElements = await getAllElements({
-      adapterName: ZENDESK,
-      types: this.userConfig.apiDefinitions.types,
-      shouldAddRemainingTypes: false,
-      supportedTypes: GUIDE_BRAND_SPECIFIC_TYPES,
-      fetchQuery: this.fetchQuery,
-      paginator: this.paginator,
-      nestedFieldFinder: findDataField,
-      computeGetArgs,
-      typeDefaults: this.userConfig.apiDefinitions.typeDefaults,
-      getElemIdFunc: this.getElemIdFunc,
-      getEntriesResponseValuesFunc: zendeskGuideEntriesFunc(brandsList, brandToPaginator),
-    })
+    const zendeskGuideElements = await getGuideElements(
+      brandsList,
+      brandToPaginator,
+      this.userConfig[API_DEFINITIONS_CONFIG],
+      this.fetchQuery,
+      this.getElemIdFunc
+    )
 
     // Remaining types should be added once to avoid overlaps between the generated elements,
     // so we add them once after all elements are generated

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -291,7 +291,7 @@ describe('adapter', () => {
           'zendesk.guide_settings.instance.brandWithGuide',
           'zendesk.guide_settings.instance.myBrand',
           'zendesk.guide_settings__help_center',
-          'zendesk.guide_settings__help_center__feature_restrictions',
+          // 'zendesk.guide_settings__help_center__feature_restrictions',
           'zendesk.guide_settings__help_center__settings',
           'zendesk.guide_settings__help_center__settings__preferences',
           'zendesk.guide_settings__help_center__text_filter',

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -291,7 +291,6 @@ describe('adapter', () => {
           'zendesk.guide_settings.instance.brandWithGuide',
           'zendesk.guide_settings.instance.myBrand',
           'zendesk.guide_settings__help_center',
-          // 'zendesk.guide_settings__help_center__feature_restrictions',
           'zendesk.guide_settings__help_center__settings',
           'zendesk.guide_settings__help_center__settings__preferences',
           'zendesk.guide_settings__help_center__text_filter',


### PR DESCRIPTION
Change how we fetch guide from fetching each type across brands to fetch brand by brand to prevent unnecessary requests with `recurseInto` and `dependsOn`

---

_Additional context for reviewer_

With the previous fetch method we made unnecessary requests in each brand based on entries that returned from other brands. In this change we create the elements in each brand separately, this way recursive requests are done only on the relevant values.

The main flow of fetch now:
- Create all elements (instances and types) for each brand, ignoring `standaloneFields`
- Regenerate the types based on instances from all brands, ignore the types we created in the last step
- Recreating the instances with the correct type
- Creating instances from `standaloneFields`


I also exported function from `adapter-components` that creates types in ducktype method from existing instances and recreates the instances with the new types.

Still need to make some adjustments in tests :)

---
_Release Notes_: 
None

---
_User Notifications_: 
None
