### PR TITLE
SALTO-3093: Remove users from config (Okta)

### DIFF
--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -41,6 +41,8 @@ const DEFAULT_ID_FIELDS = ['name']
 const DEFAULT_FIELDS_TO_OMIT: configUtils.FieldToOmitType[] = [
   { fieldName: 'created' },
   { fieldName: 'lastUpdated' },
+  { fieldName: 'createdBy' },
+  { fieldName: 'lastUpdatedBy' },
 ]
 
 const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
@@ -246,11 +248,6 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
     request: {
       url: '/api/v1/idps',
       recurseInto: [
-        {
-          type: 'api__v1__idps___idpId___users@uuuuuu_00123_00125uu',
-          toField: 'users',
-          context: [{ name: 'idpId', fromField: 'id' }],
-        },
         {
           type: 'api__v1__idps___idpId___credentials__csrs@uuuuuu_00123_00125uuuu',
           toField: 'CSRs',


### PR DESCRIPTION
Remove fields with references to `User` type from config 

---

I made 2 changes:
1. remove `recurseInto` for users related to `IdentityProvider`
2. add `createdBy` and `lastUpdatedBy` to `fieldsToOmit` - these fields are reference to `User` instances

---
_Release Notes_: 
None

---
_User Notifications_: 
None
