### PR TITLE
SALTO-3163 Serialize ids to strings for workspace conditions

### DIFF
--- a/packages/zendesk-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-adapter/src/filters/field_references.ts
@@ -170,6 +170,7 @@ type ZendeskReferenceSerializationStrategyName = 'ticketField'
   | 'ticketFieldAlternative'
   | 'ticketFieldOption'
   | 'userFieldOption'
+  | 'idString'
 const ZendeskReferenceSerializationStrategyLookup: Record<
   ZendeskReferenceSerializationStrategyName
   | referenceUtils.ReferenceSerializationStrategyName,
@@ -202,6 +203,11 @@ const ZendeskReferenceSerializationStrategyLookup: Record<
   },
   userFieldOption: {
     serialize: customFieldOptionSerialization,
+    lookup: val => val,
+    lookupIndexName: 'id',
+  },
+  idString: {
+    serialize: async ({ ref }) => _.toString(ref.value.value.id),
     lookup: val => val,
     lookupIndexName: 'id',
   },
@@ -764,6 +770,13 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
 ]
 
 const commonFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[] = [
+  // note: this overlaps with additional strategies, but because the first strategy
+  // is chosen for serialization, it is safe
+  {
+    src: { field: 'value', parentTypes: ['workspace__conditions__all'] },
+    zendeskSerializationStrategy: 'idString',
+    target: { typeContext: 'neighborField' },
+  },
   // only one of these applies in a given instance
   {
     src: { field: 'value' },

--- a/packages/zendesk-adapter/test/filters/field_references.test.ts
+++ b/packages/zendesk-adapter/test/filters/field_references.test.ts
@@ -183,6 +183,27 @@ describe('References by id filter', () => {
       },
     },
   })
+  const workspaceType = new ObjectType({
+    elemID: new ElemID(ZENDESK, 'workspace'),
+    fields: {
+      id: { refType: BuiltinTypes.NUMBER },
+      conditions: {
+        refType: new ObjectType({
+          elemID: new ElemID(ZENDESK, 'workspace__conditions'),
+          fields: {
+            all: { refType: new ListType(new ObjectType({
+              elemID: new ElemID(ZENDESK, 'workspace__conditions__all'),
+              fields: {
+                field: { refType: BuiltinTypes.STRING },
+                operator: { refType: BuiltinTypes.STRING },
+                value: { refType: BuiltinTypes.STRING },
+              },
+            })) },
+          },
+        }),
+      },
+    },
+  })
 
   const generateElements = (
   ): Element[] => ([
@@ -191,6 +212,7 @@ describe('References by id filter', () => {
     triggerCategoryType,
     ticketFormType,
     triggerType,
+    workspaceType,
     someTypeWithValue,
     someTypeWithNestedValuesAndSubject,
     someTypeWithNestedValueList,
@@ -313,6 +335,18 @@ describe('References by id filter', () => {
         },
       }
     ),
+    new InstanceElement(
+      'workspace1',
+      workspaceType,
+      {
+        id: 7001,
+        conditions: {
+          all: [
+            { field: 'group_id', operator: 'is', value: '2003' },
+          ],
+        },
+      },
+    ),
   ])
 
   describe('on fetch', () => {
@@ -331,6 +365,13 @@ describe('References by id filter', () => {
       )[0] as InstanceElement
       expect(trigger10.value.category_id).toBeInstanceOf(ReferenceExpression)
       expect(trigger10.value.category_id.elemID.getFullName()).toEqual('zendesk.trigger_category.instance.triggerCategory5')
+
+      const workspace1 = elements.filter(
+        e => isInstanceElement(e) && e.elemID.name === 'workspace1'
+      )[0] as InstanceElement
+      expect(workspace1.value.conditions.all[0].value).toBeInstanceOf(ReferenceExpression)
+      expect(workspace1.value.conditions.all[0].value.elemID.getFullName())
+        .toEqual('zendesk.group.instance.group3')
 
       const inst = elements.filter(
         e => isInstanceElement(e) && e.elemID.name === 'inst1'

--- a/packages/zendesk-adapter/test/resolve_changes.test.ts
+++ b/packages/zendesk-adapter/test/resolve_changes.test.ts
@@ -305,4 +305,50 @@ describe('resolveChanges', () => {
       ],
     })
   })
+  it('should resolve to string when using idString serialization', async () => {
+    const workspaceType = new ObjectType({
+      elemID: new ElemID(ZENDESK, 'workspace'),
+      fields: {
+        id: { refType: BuiltinTypes.NUMBER },
+        conditions: {
+          refType: new ObjectType({
+            elemID: new ElemID(ZENDESK, 'workspace__conditions'),
+            fields: {
+              all: { refType: new ListType(new ObjectType({
+                elemID: new ElemID(ZENDESK, 'workspace__conditions__all'),
+                fields: {
+                  field: { refType: BuiltinTypes.STRING },
+                  operator: { refType: BuiltinTypes.STRING },
+                  value: { refType: BuiltinTypes.STRING },
+                },
+              })) },
+            },
+          }),
+        },
+      },
+    })
+    const groupType = new ObjectType({
+      elemID: new ElemID(ZENDESK, 'group'),
+      fields: {
+        id: { refType: BuiltinTypes.NUMBER },
+      },
+    })
+    const group = new InstanceElement('group3', groupType, { id: 2003 })
+    const workspace = new InstanceElement(
+      'workspace1',
+      workspaceType,
+      {
+        id: 7001,
+        conditions: {
+          all: [
+            { field: 'group_id', operator: 'is', value: new ReferenceExpression(group.elemID, group) },
+          ],
+        },
+      },
+    )
+    expect(
+      getChangeData(await resolveChangeElement(toChange({ after: workspace }), lookupFunc))
+        .value.conditions.all[0].value
+    ).toEqual('2003')
+  })
 })


### PR DESCRIPTION
Workspace condition values must be strings - sending integers fails the deploy.

---

The same serialization strategy is used in a lot of other types as well, but so far it seems like the other types support serializing to numbers as well - so starting with the minimal fix to avoid introducing accidental regressions. if we see this happening on any of the other types, we will change the default to serializing to a string instead.

---
_Release Notes_: 

_Zendesk adapter_:
* Fix a bug where workspace creation would fail if the workspace had a `group_id` condition

---
_User Notifications_: 
None