### PR TITLE
SALTO-3046: zendesk guide add type folders for order and settings elements

### DIFF
--- a/packages/zendesk-adapter/src/filters/guide_arrange_paths.ts
+++ b/packages/zendesk-adapter/src/filters/guide_arrange_paths.ts
@@ -119,9 +119,9 @@ const getNameFromName = (instance?: InstanceElement): string => instance?.value.
 
 
 const GUIDE_ELEMENT_NAME: Record<string, (instance?: InstanceElement) => string> = {
-  [CATEGORY_ORDER_TYPE_NAME]: () => 'categories_order',
-  [SECTION_ORDER_TYPE_NAME]: () => 'sections_order',
-  [ARTICLE_ORDER_TYPE_NAME]: () => 'articles_order',
+  [CATEGORY_ORDER_TYPE_NAME]: () => 'category_order',
+  [SECTION_ORDER_TYPE_NAME]: () => 'section_order',
+  [ARTICLE_ORDER_TYPE_NAME]: () => 'article_order',
   [GUIDE_SETTINGS_TYPE_NAME]: () => 'brand_settings',
   [GUIDE_LANGUAGE_SETTINGS_TYPE_NAME]: (instance?: InstanceElement) => instance?.value.locale ?? NO_VALUE_DEFAULT,
   [ARTICLE_TRANSLATION_TYPE_NAME]: getTranslationLocale,

--- a/packages/zendesk-adapter/src/filters/guide_arrange_paths.ts
+++ b/packages/zendesk-adapter/src/filters/guide_arrange_paths.ts
@@ -265,6 +265,8 @@ const filterCreator: FilterCreator = () => ({
         const needTypeDirectory = [
           CATEGORY_TYPE_NAME,
           GUIDE_LANGUAGE_SETTINGS_TYPE_NAME,
+          CATEGORY_ORDER_TYPE_NAME,
+          GUIDE_SETTINGS_TYPE_NAME,
         ].includes(instance.elemID.typeName)
         instance.path = pathForBrandSpecificRootElements(instance, fullNameByNameBrand[brandElemId], needTypeDirectory)
       })
@@ -333,7 +335,7 @@ const filterCreator: FilterCreator = () => ({
         const parentId = getParent(instance).value.id
         instance.path = pathForOtherLevels({
           instance,
-          needTypeDirectory: false,
+          needTypeDirectory: true,
           needOwnFolder: false,
           parent: parentsById[parentId],
         })

--- a/packages/zendesk-adapter/test/filters/guide_arrange_paths.test.ts
+++ b/packages/zendesk-adapter/test/filters/guide_arrange_paths.test.ts
@@ -242,6 +242,7 @@ describe('guide arrange paths', () => {
         [
           ...GUIDE_PATH,
           ...BRAND_PATH,
+          GUIDE_ELEMENT_DIRECTORY[GUIDE_SETTINGS_TYPE_NAME],
           'brand_settings',
         ],
         [
@@ -334,11 +335,13 @@ describe('guide arrange paths', () => {
           'category_name',
           GUIDE_ELEMENT_DIRECTORY[SECTION_TYPE_NAME],
           'section_name',
+          GUIDE_ELEMENT_DIRECTORY[SECTION_ORDER_TYPE_NAME],
           'sections_order',
         ],
         [
           ...GUIDE_PATH,
           ...BRAND_PATH,
+          GUIDE_ELEMENT_DIRECTORY[CATEGORY_ORDER_TYPE_NAME],
           'categories_order',
         ],
       ])
@@ -360,6 +363,7 @@ describe('guide arrange paths', () => {
         [
           ...GUIDE_PATH,
           ...BRAND_PATH,
+          GUIDE_ELEMENT_DIRECTORY[GUIDE_SETTINGS_TYPE_NAME],
           'brand_settings',
         ],
         [

--- a/packages/zendesk-adapter/test/filters/guide_arrange_paths.test.ts
+++ b/packages/zendesk-adapter/test/filters/guide_arrange_paths.test.ts
@@ -336,13 +336,13 @@ describe('guide arrange paths', () => {
           GUIDE_ELEMENT_DIRECTORY[SECTION_TYPE_NAME],
           'section_name',
           GUIDE_ELEMENT_DIRECTORY[SECTION_ORDER_TYPE_NAME],
-          'sections_order',
+          'section_order',
         ],
         [
           ...GUIDE_PATH,
           ...BRAND_PATH,
           GUIDE_ELEMENT_DIRECTORY[CATEGORY_ORDER_TYPE_NAME],
-          'categories_order',
+          'category_order',
         ],
       ])
     })


### PR DESCRIPTION
_zendesk guide add type folders for order and settings elements_

---

_Additional context for reviewer_
None

---
_Release Notes_: 
None

---
_User Notifications_: 
None