### PR TITLE
SALTO-3360: Fixed redundant warnings in Jira adapter fetch

### DIFF
--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1604,19 +1604,13 @@ const SUPPORTED_TYPES = {
   Field: ['Fields'],
   FieldConfiguration: ['FieldConfigurations'],
   FieldConfigurationScheme: ['FieldsConfigurationScheme'],
-  // Should remove when doing the configuration migration
-  FieldsConfigurationIssueTypeItem: ['FieldsConfigurationIssueTypeItem'],
   Filter: ['Filters'],
   IssueLinkType: ['IssueLinkTypes'],
   IssueEvent: ['IssueEvents'],
   IssueType: ['IssueType'],
   SecurityScheme: ['SecuritySchemes'],
   IssueTypeScheme: ['IssueTypeSchemes'],
-  // Should remove when doing the configuration migration
-  IssueTypeSchemeMappings: ['IssueTypeSchemeMappings'],
   IssueTypeScreenScheme: ['IssueTypeScreenSchemes'],
-  // Should remove when doing the configuration migration
-  IssueTypeScreenSchemeItems: ['IssueTypeScreenSchemeItems'],
   NotificationScheme: ['NotificationSchemes'],
   Permissions_permissions: ['Permissions'],
   PermissionScheme: ['PermissionSchemes'],


### PR DESCRIPTION
Fixed Jira API config to avoid creating redundant warnings about the types IssueTypeSchemeMappings FieldsConfigurationIssueTypeItem IssueTypeScreenSchemeItems not having endpoints. This is because the types are in the SUPPORTED_TYPES although they shouldn’t be because they are used only in recurseInto

---
_Release Notes_: 
None

---
_User Notifications_: 
None