### PR TITLE
SALTO-3168, SALTO-3166: zendesk missing broken reference to group id in view restriction

### DIFF
--- a/packages/zendesk-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-adapter/src/filters/field_references.ts
@@ -45,6 +45,7 @@ const NEIGHBOR_FIELD_TO_TYPE_NAMES: Record<string, string> = {
   ticket_form_id: 'ticket_form',
   locale_id: 'locale',
   via_id: 'channel',
+  current_via_id: 'channel',
 }
 
 const SPECIAL_CONTEXT_NAMES: Record<string, string> = {

--- a/packages/zendesk-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-adapter/src/filters/field_references.ts
@@ -44,6 +44,7 @@ const NEIGHBOR_FIELD_TO_TYPE_NAMES: Record<string, string> = {
   set_schedule: 'business_hours_schedule',
   ticket_form_id: 'ticket_form',
   locale_id: 'locale',
+  via_id: 'channel',
 }
 
 const SPECIAL_CONTEXT_NAMES: Record<string, string> = {
@@ -80,6 +81,9 @@ const getValueLookupType: referenceUtils.ContextValueMapperFunc = val => {
 
 const getLowerCaseSingularLookupType: referenceUtils.ContextValueMapperFunc = val => {
   const lowercaseVal = val.toLowerCase()
+  if (['user', 'users'].includes(lowercaseVal)) {
+    return undefined
+  }
   // for now this simple conversion to singular form seems good enough, but
   // we may need to improve it later on
   if (lowercaseVal.endsWith('s')) {

--- a/packages/zendesk-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-adapter/src/filters/field_references.ts
@@ -698,6 +698,7 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
     },
     serializationStrategy: 'id',
     target: { typeContext: 'neighborType' },
+    zendeskMissingRefStrategy: 'typeAndValue',
   },
   {
     src: {
@@ -710,6 +711,7 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
     },
     serializationStrategy: 'id',
     target: { typeContext: 'neighborType' },
+    zendeskMissingRefStrategy: 'typeAndValue',
   },
   {
     src: { field: 'id', parentTypes: ['workspace__apps'] },


### PR DESCRIPTION
_zendesk add broken reference to view element_

---

_Additional context for reviewer_
None

---
_Release Notes_: 
zendesk:
* add broken reference to group id in view restriction
*  add broken reference to via_id in conditions

---
_User Notifications_: 
None
