### PR TITLE
SALTO-3155: Fix bug causing categories_order instances of excluded brands to be created (Zendesk guide)

### DIFF
--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -36,7 +36,7 @@ import {
   ZendeskConfig,
   CLIENT_CONFIG,
   GUIDE_TYPES_TO_HANDLE_BY_BRAND,
-  GUIDE_BRAND_SPECIFIC_TYPES, GUIDE_SUPPORTED_TYPES, ZendeskFetchConfig, isGuideEnabled,
+  GUIDE_BRAND_SPECIFIC_TYPES, GUIDE_SUPPORTED_TYPES, isGuideEnabled,
 } from './config'
 import {
   ZENDESK,
@@ -44,6 +44,7 @@ import {
   BRAND_TYPE_NAME,
   ARTICLE_ATTACHMENT_TYPE_NAME,
 } from './constants'
+import { getBrandsForGuide } from './filters/utils'
 import { GUIDE_ORDER_TYPES } from './filters/guide_order/guide_order_utils'
 import createChangeValidator from './change_validator'
 import { paginate } from './client/pagination'
@@ -280,17 +281,6 @@ const getBrandsFromElementsSource = async (
     .filter(isInstanceElement)
     .toArray()
 )
-
-const getBrandsForGuide = (
-  elements: InstanceElement[],
-  fetchConfig: ZendeskFetchConfig,
-): InstanceElement[] => {
-  const brandsRegexList = fetchConfig.guide?.brands ?? []
-  return elements
-    .filter(instance => instance.elemID.typeName === BRAND_TYPE_NAME)
-    .filter(brandInstance => brandInstance.value.has_help_center)
-    .filter(brandInstance => brandsRegexList.some(regex => new RegExp(regex).test(brandInstance.value.name)))
-}
 
 /**
  * Fetch Guide (help_center) elements for the given brands.

--- a/packages/zendesk-adapter/src/filters/utils.ts
+++ b/packages/zendesk-adapter/src/filters/utils.ts
@@ -22,6 +22,8 @@ import { applyFunctionToChangeData, createSchemeGuard, getParents, resolveChange
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import { lookupFunc } from './field_references'
+import { ZendeskFetchConfig } from '../config'
+import { BRAND_TYPE_NAME } from '../constants'
 
 const { awu } = collections.asynciterable
 const log = logger(module)
@@ -103,3 +105,14 @@ value is (Condition | SubjectCondition)[] => (
     ? isSubjectConditions(value)
     : isConditions(value)
 )
+
+export const getBrandsForGuide = (
+  elements: InstanceElement[],
+  fetchConfig: ZendeskFetchConfig,
+): InstanceElement[] => {
+  const brandsRegexList = fetchConfig.guide?.brands ?? []
+  return elements
+    .filter(instance => instance.elemID.typeName === BRAND_TYPE_NAME)
+    .filter(brandInstance => brandInstance.value.has_help_center)
+    .filter(brandInstance => brandsRegexList.some(regex => new RegExp(regex).test(brandInstance.value.name)))
+}

--- a/packages/zendesk-adapter/test/filters/utils.test.ts
+++ b/packages/zendesk-adapter/test/filters/utils.test.ts
@@ -54,7 +54,7 @@ describe('Zendesk utils', () => {
           name: 'NoHelpCenterBrand',
           has_help_center: false,
         },
-      )
+      ),
     ]
 
     it('should return all brands with help center', async () => {

--- a/packages/zendesk-adapter/test/filters/utils.test.ts
+++ b/packages/zendesk-adapter/test/filters/utils.test.ts
@@ -47,9 +47,17 @@ describe('Zendesk utils', () => {
           has_help_center: true,
         },
       ),
+      new InstanceElement(
+        'TestforGuide',
+        brandType,
+        {
+          name: 'NoHelpCenterBrand',
+          has_help_center: false,
+        },
+      )
     ]
 
-    it('should return all brands', async () => {
+    it('should return all brands with help center', async () => {
       const fetchConfig = {
         include: [{ type: '.*' }],
         exclude: [],

--- a/packages/zendesk-adapter/test/filters/utils.test.ts
+++ b/packages/zendesk-adapter/test/filters/utils.test.ts
@@ -1,0 +1,80 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { ZENDESK, BRAND_TYPE_NAME } from '../../src/constants'
+import { getBrandsForGuide } from '../../src/filters/utils'
+
+describe('Zendesk utils', () => {
+  describe('getBrandsForGuide', () => {
+    const brandType = new ObjectType({
+      elemID: new ElemID(ZENDESK, BRAND_TYPE_NAME),
+    })
+    const brandInstances = [
+      new InstanceElement(
+        'guideTest',
+        brandType,
+        {
+          name: 'guideTest',
+          has_help_center: true,
+        },
+      ),
+      new InstanceElement(
+        'TestforGuide',
+        brandType,
+        {
+          name: 'TestforGuide',
+          has_help_center: true,
+        },
+      ),
+      new InstanceElement(
+        'BrandBrand',
+        brandType,
+        {
+          name: 'BrandBrand',
+          has_help_center: true,
+        },
+      ),
+    ]
+
+    it('should return all brands', async () => {
+      const fetchConfig = {
+        include: [{ type: '.*' }],
+        exclude: [],
+        guide: { brands: ['.*'] },
+      }
+      const res = getBrandsForGuide(brandInstances, fetchConfig)
+      expect(res.map(r => r.elemID.name).sort()).toEqual(['BrandBrand', 'TestforGuide', 'guideTest'])
+    })
+    it('it should exclude all brands that contain the word Test', async () => {
+      const fetchConfig = {
+        include: [{ type: '.*' }],
+        exclude: [],
+        guide: { brands: ['^((?!Test).)*$'] },
+      }
+      const res = getBrandsForGuide(brandInstances, fetchConfig)
+      expect(res.map(r => r.elemID.name)).toEqual(['BrandBrand'])
+    })
+    it('should return an empty list of brands', async () => {
+      const fetchConfig = {
+        include: [{ type: '.*' }],
+        exclude: [],
+        guide: { brands: ['NoBrand', 'SomeBrand'] },
+      }
+      const res = getBrandsForGuide(brandInstances, fetchConfig)
+      expect(res).toEqual([])
+    })
+  })
+})


### PR DESCRIPTION
Fix a bug causing `categories_order` instanceד of excluded brands to be created

---

_Additional context for reviewer_

Changes:
1. Move `getBrandsForGuide` func to utils.ts so we can use in filters too
2. Use `getBrandsForGuide` to calculate brands before creating `categories_order`  instances
3.  Added some tests

---
_Release Notes_: 
None

---
_User Notifications_: 
None
