### PR TITLE
SALTO-3181: Return fetch warning when no brand matches brands list in guide config

### DIFF
--- a/packages/adapter-components/src/elements/ducktype/transformer.ts
+++ b/packages/adapter-components/src/elements/ducktype/transformer.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { Element, InstanceElement, isObjectType, Values, ObjectType, ElemIdGetter } from '@salto-io/adapter-api'
+import { Element, InstanceElement, isObjectType, Values, ObjectType, ElemIdGetter, SaltoError } from '@salto-io/adapter-api'
 import { naclCase } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections, values as lowerdashValues } from '@salto-io/lowerdash'
@@ -72,6 +72,7 @@ export type ConfigChangeSuggestion = {
 export type FetchElements<T> = {
   configChanges: ConfigChangeSuggestion[]
   elements: T
+  errors?: SaltoError[]
 }
 
 export const getEntriesResponseValues: EntriesRequester = async ({

--- a/packages/workato-adapter/src/adapter.ts
+++ b/packages/workato-adapter/src/adapter.ts
@@ -118,11 +118,11 @@ export default class WorkatoAdapter implements AdapterOperations {
   async fetch({ progressReporter }: FetchOptions): Promise<FetchResult> {
     log.debug('going to fetch workato account configuration..')
     progressReporter.reportProgress({ message: 'Fetching types and instances' })
-    const { elements } = await this.getElements()
+    const { elements, errors } = await this.getElements()
     log.debug('going to run filters on %d fetched elements', elements.length)
     progressReporter.reportProgress({ message: 'Running filters for additional information' })
     await this.createFiltersRunner().onFetch(elements)
-    return { elements }
+    return { elements, errors }
   }
 
   @logDuration('updating cross-service references')

--- a/packages/zendesk-adapter/config_doc.md
+++ b/packages/zendesk-adapter/config_doc.md
@@ -65,7 +65,7 @@ zendesk {
 |---------------------------------------------|-----------------------------------|------------
 | [include](#fetch-entry-options)             | [{ type = ".*" }]                 | List of entries to determine what instances to include in the fetch
 | [exclude](#fetch-entry-options)             | []                                | List of entries to determine what instances to exclude in the fetch
-| [guide](#fetch-entry-options)               | { brands = [] }                   | Configuration for defining which brands will be included in Zendesk Guide fetch
+| [guide](#fetch-entry-options)               | undefined (Guide will be disabled)| Configuration for defining which brands will be included in Zendesk Guide fetch
 
 ## Fetch entry options
 

--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -474,13 +474,14 @@ export default class ZendeskAdapter implements AdapterOperations {
     )
 
     if (_.isEmpty(brandsList)) {
-      log.warn(`Cannot find brands matching the following patterns specified in guide brands config: ${brandsList.toString()}`)
+      const specifiedBrands = Array.from(this.userConfig[FETCH_CONFIG].guide?.brands ?? []).join(', ')
+      log.warn(`Cannot find brands matching the following patterns specified in guide brands config: ${specifiedBrands}`)
       return {
         configChanges: defaultSubdomainElements.configChanges,
         elements: defaultSubdomainElements.elements,
         errors: (defaultSubdomainElements.errors ?? []).concat([
           {
-            message: `Cannot find brands matching the following patterns specified in zendesk.nacl: ${Array.from(this.userConfig[FETCH_CONFIG].guide?.brands ?? []).join(', ')}.`,
+            message: `Cannot find brands matching the following patterns specified in zendesk.nacl: ${specifiedBrands}.`,
             severity: 'Warning',
           },
         ]),

--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -464,7 +464,7 @@ export default class ZendeskAdapter implements AdapterOperations {
       getElemIdFunc: this.getElemIdFunc,
     })
 
-    if (isGuideDisabled) {
+    if (isGuideDisabled || _.isEmpty(this.userConfig[FETCH_CONFIG].guide?.brands)) {
       return defaultSubdomainElements
     }
 

--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -474,14 +474,15 @@ export default class ZendeskAdapter implements AdapterOperations {
     )
 
     if (_.isEmpty(brandsList)) {
-      const specifiedBrands = Array.from(this.userConfig[FETCH_CONFIG].guide?.brands ?? []).join(', ')
-      log.warn(`Cannot find brands matching the following patterns specified in guide brands config: ${specifiedBrands}`)
+      const brandPatterns = Array.from(this.userConfig[FETCH_CONFIG].guide?.brands ?? []).join(', ')
+      const message = `Could not find any brands matching the included patterns: [${brandPatterns}]. Please update the configuration under fetch.guide.brands in the configuration file`
+      log.warn(message)
       return {
         configChanges: defaultSubdomainElements.configChanges,
         elements: defaultSubdomainElements.elements,
         errors: (defaultSubdomainElements.errors ?? []).concat([
           {
-            message: `Cannot find brands matching the following patterns specified in zendesk.nacl: ${specifiedBrands}.`,
+            message,
             severity: 'Warning',
           },
         ]),

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -2382,5 +2382,5 @@ export const validateGuideTypesConfig = (
 export const isGuideEnabled = (
   fetchConfig: ZendeskFetchConfig
 ): boolean => (
-  fetchConfig.guide?.brands !== undefined && !_.isEmpty(fetchConfig.guide.brands)
+  fetchConfig.guide?.brands !== undefined
 )

--- a/packages/zendesk-adapter/src/filters/guide_default_language_settings.ts
+++ b/packages/zendesk-adapter/src/filters/guide_default_language_settings.ts
@@ -26,9 +26,10 @@ import { logger } from '@salto-io/logging'
 import { detailedCompare } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../filter'
 import { FETCH_CONFIG, isGuideEnabled } from '../config'
-import { BRAND_TYPE_NAME, GUIDE_LANGUAGE_SETTINGS_TYPE_NAME, GUIDE_SETTINGS_TYPE_NAME } from '../constants'
+import { GUIDE_LANGUAGE_SETTINGS_TYPE_NAME, GUIDE_SETTINGS_TYPE_NAME } from '../constants'
 import { getZendeskError } from '../errors'
 import { deployChange, deployChanges } from '../deployment'
+import { getBrandsForGuide } from './utils'
 
 const log = logger(module)
 const { awu } = collections.asynciterable
@@ -50,9 +51,7 @@ const filterCreator: FilterCreator = ({ config, client, brandIdToClient = {} }) 
 
     const guideSettings = instances.filter(e => e.elemID.typeName === GUIDE_SETTINGS_TYPE_NAME)
     const guideLanguageSettings = instances.filter(e => e.elemID.typeName === GUIDE_LANGUAGE_SETTINGS_TYPE_NAME)
-    const brands = instances
-      .filter(e => e.elemID.typeName === BRAND_TYPE_NAME)
-      .filter(b => b.value.has_help_center === true)
+    const brands = getBrandsForGuide(instances, config[FETCH_CONFIG])
 
     // Request the default locale for each brand and fill up the brand's language info
     const brandsLanguageInfo = await awu(brands).map(async brand => {

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -677,9 +677,9 @@ describe('adapter', () => {
         }).fetch({ progressReporter: { reportProgress: () => null } })
         expect(errors).toEqual([
           {
-            message: "Cannot find brands matching the following patterns specified in zendesk.nacl: BestBrand.",
-            severity: "Warning",
-          }
+            message: 'Cannot find brands matching the following patterns specified in zendesk.nacl: BestBrand.',
+            severity: 'Warning',
+          },
         ])
       })
     })

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -647,6 +647,41 @@ describe('adapter', () => {
           'zendesk.article.instance.Title_Yo___greatSection_greatCategory_brandWithGuide@ssauuu',
         ])
       })
+
+      it('should return fetch error when no brand matches brands config ', async () => {
+        mockAxiosAdapter.onGet().reply(callbackResponseFunc)
+        const creds = new InstanceElement(
+          'config',
+          usernamePasswordCredentialsType,
+          { username: 'user123', password: 'token456', subdomain: 'myBrand' },
+        )
+        const config = new InstanceElement(
+          'config',
+          configType,
+          {
+            [FETCH_CONFIG]: {
+              include: [{
+                type: '.*',
+              }],
+              exclude: [],
+              guide: {
+                brands: ['BestBrand'],
+              },
+            },
+          }
+        )
+        const { errors } = await adapter.operations({
+          credentials: creds,
+          config,
+          elementsSource: buildElementsSourceFromElements([]),
+        }).fetch({ progressReporter: { reportProgress: () => null } })
+        expect(errors).toEqual([
+          {
+            message: "Cannot find brands matching the following patterns specified in zendesk.nacl: BestBrand.",
+            severity: "Warning",
+          }
+        ])
+      })
     })
 
     describe('type overrides', () => {

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -677,7 +677,7 @@ describe('adapter', () => {
         }).fetch({ progressReporter: { reportProgress: () => null } })
         expect(errors).toEqual([
           {
-            message: 'Cannot find brands matching the following patterns specified in zendesk.nacl: BestBrand.',
+            message: 'Could not find any brands matching the included patterns: [BestBrand]. Please update the configuration under fetch.guide.brands in the configuration file',
             severity: 'Warning',
           },
         ])


### PR DESCRIPTION
Main changes:
- alert the user in case no brand matches the provided `brands` regex list in `guide` config.
- change behavior when `brands = []` in config 

---

I added the option to return fetch error when calling `getAllElements` in ducktype.
In case there's no brand match we'll return the default Zendesk elements & non brand specific guide elements and notify the user about it.
Also, to be consistent with the case of `brands = []`, we will now get guide elements that are not part of specific brand (`user_segments`, `permission_groups` types).


---
_Release Notes_: 
None

---
_User Notifications_: 
None
