### PR TITLE
SALTO-3188 - Don't assume that the order field exists on order object

### DIFF
--- a/packages/adapter-components/src/filters/referenced_instance_names.ts
+++ b/packages/adapter-components/src/filters/referenced_instance_names.ts
@@ -146,6 +146,7 @@ const createNewInstance = async (
     element: currentInstance,
     transformFunc: createReferencesTransformFunc(currentInstance.elemID, newElemId),
     strict: false,
+    allowEmpty: true,
   })
   return new InstanceElement(
     newElemId.name,

--- a/packages/adapter-components/src/filters/referenced_instance_names.ts
+++ b/packages/adapter-components/src/filters/referenced_instance_names.ts
@@ -146,7 +146,6 @@ const createNewInstance = async (
     element: currentInstance,
     transformFunc: createReferencesTransformFunc(currentInstance.elemID, newElemId),
     strict: false,
-    allowEmpty: true,
   })
   return new InstanceElement(
     newElemId.name,

--- a/packages/zendesk-adapter/src/change_validators/guide_order/guide_order_validators_utils.ts
+++ b/packages/zendesk-adapter/src/change_validators/guide_order/guide_order_validators_utils.ts
@@ -72,7 +72,7 @@ export const validateOrderElementAdded = (
 
   return relevantChildInstances
     .filter(child => relevantOrderInstances.every(
-      order => order.value[orderField] !== undefined // fields with a value of empty list are sometimes removed
+      order => order.value[orderField] !== undefined
           && !order.value[orderField].map((childRef: InstanceElement) => childRef.value.elemID).includes(child.elemID)
     ))
     .map(child => createNoOrderInstanceWarning(child, orderTypeName))

--- a/packages/zendesk-adapter/src/change_validators/guide_order/guide_order_validators_utils.ts
+++ b/packages/zendesk-adapter/src/change_validators/guide_order/guide_order_validators_utils.ts
@@ -72,7 +72,8 @@ export const validateOrderElementAdded = (
 
   return relevantChildInstances
     .filter(child => relevantOrderInstances.every(
-      order => !order.value[orderField].map((childRef: InstanceElement) => childRef.value.elemID).includes(child.elemID)
+      order => order.value[orderField] !== undefined // fields with a value of empty list are sometimes removed
+          && !order.value[orderField].map((childRef: InstanceElement) => childRef.value.elemID).includes(child.elemID)
     ))
     .map(child => createNoOrderInstanceWarning(child, orderTypeName))
 }

--- a/packages/zendesk-adapter/test/change_validators/guide_order_validators.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/guide_order_validators.test.ts
@@ -193,6 +193,19 @@ describe('GuideOrdersValidator', () => {
       }])
     }
 
+    const testValidatorWithUndefinedOrderField = async (
+      validator: ChangeValidator,
+      orderField: string,
+    ): Promise<void> => {
+      const emptyOrderChanges = orderChanges.map(change => {
+        const emptyOrderInstance = getChangeData(change).clone()
+        delete emptyOrderInstance.value[orderField]
+        return toChange({ after: emptyOrderInstance })
+      })
+      const errors = await validator([...childChanges, ...emptyOrderChanges])
+      expect(errors).toMatchObject([])
+    }
+
     it('With order element', async () => {
       await testValidatorWithOrderInstances(categoryOrderValidator)
       await testValidatorWithOrderInstances(sectionOrderValidator)
@@ -202,6 +215,11 @@ describe('GuideOrdersValidator', () => {
       await testValidatorWithoutOrderInstances(categoryOrderValidator, categoryInstance, CATEGORY_ORDER_TYPE_NAME)
       await testValidatorWithoutOrderInstances(sectionOrderValidator, sectionInstance, SECTION_ORDER_TYPE_NAME)
       await testValidatorWithoutOrderInstances(articleOrderValidator, articleInstance, ARTICLE_ORDER_TYPE_NAME)
+    })
+    it('with order element with undefined order field', async () => {
+      await testValidatorWithUndefinedOrderField(categoryOrderValidator, CATEGORIES_FIELD)
+      await testValidatorWithUndefinedOrderField(sectionOrderValidator, SECTIONS_FIELD)
+      await testValidatorWithUndefinedOrderField(articleOrderValidator, ARTICLES_FIELD)
     })
   })
 })


### PR DESCRIPTION
On guide order change validator - handle cases when the order field is undefined

---

In theory it should be impossible, but at some points fields with empty lists may be deleted 

---
_Release Notes_:
None

---
_User Notifications_: 
None