### PR TITLE
SALTO-3115 avoid logging inside expressions

### DIFF
--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -1086,7 +1086,7 @@ export const createSchemeGuard = <T>(scheme: Joi.AnySchema, errorMessage?: strin
     const { error } = scheme.validate(value)
     if (error !== undefined) {
       if (errorMessage !== undefined) {
-        log.error(`${errorMessage}: ${error.message}, ${safeJsonStringify(value)}`)
+        log.error(`${errorMessage}: ${error.message}, ${safeJsonStringify(value, elementExpressionStringifyReplacer)}`)
       }
       return false
     }

--- a/packages/jira-adapter/src/filters/workflow/workflow_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_deploy_filter.ts
@@ -15,7 +15,7 @@
 */
 import { AdditionChange, ElemID, getChangeData, InstanceElement, isAdditionChange, isInstanceChange, RemovalChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { resolveChangeElement, safeJsonStringify, walkOnValue, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
+import { resolveChangeElement, safeJsonStringify, walkOnValue, WALK_NEXT_STEP, elementExpressionStringifyReplacer } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../../filter'
 import { isPostFetchWorkflowInstance, WorkflowInstance } from './types'
@@ -85,7 +85,7 @@ export const deployWorkflow = async (
   const resolvedChange = await resolveChangeElement(change, getLookUpName)
   const instance = getChangeData(resolvedChange)
   if (!isPostFetchWorkflowInstance(instance)) {
-    log.error(`values ${safeJsonStringify(instance.value)} of instance ${instance.elemID.getFullName} are invalid`)
+    log.error(`values ${safeJsonStringify(instance.value, elementExpressionStringifyReplacer)} of instance ${instance.elemID.getFullName} are invalid`)
     throw new Error(`instance ${instance.elemID.getFullName()} is not valid for deployment`)
   }
   removeCreateIssuePermissionValidator(instance)

--- a/packages/zendesk-adapter/src/filters/app.ts
+++ b/packages/zendesk-adapter/src/filters/app.ts
@@ -20,7 +20,7 @@ import {
   isInstanceElement, Element,
 } from '@salto-io/adapter-api'
 import { retry } from '@salto-io/lowerdash'
-import { safeJsonStringify } from '@salto-io/adapter-utils'
+import { safeJsonStringify, elementExpressionStringifyReplacer } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
 import { deployChange, deployChanges } from '../deployment'
@@ -48,7 +48,7 @@ const EXPECTED_APP_SCHEMA = Joi.object({
 const isJobStatus = (value: unknown): value is JobStatus => {
   const { error } = EXPECTED_APP_SCHEMA.validate(value)
   if (error !== undefined) {
-    log.error(`Received an invalid response for the job status: ${error.message}, ${safeJsonStringify(value)}`)
+    log.error(`Received an invalid response for the job status: ${error.message}, ${safeJsonStringify(value, elementExpressionStringifyReplacer)}`)
     return false
   }
   return true

--- a/packages/zendesk-adapter/src/filters/app_owned_convert_list_to_map.ts
+++ b/packages/zendesk-adapter/src/filters/app_owned_convert_list_to_map.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import Joi from 'joi'
-import { safeJsonStringify } from '@salto-io/adapter-utils'
+import { safeJsonStringify, elementExpressionStringifyReplacer } from '@salto-io/adapter-utils'
 import { InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
@@ -37,7 +37,7 @@ const isParameters = (values: unknown): values is AppOwnedParameter[] => {
   }
   const { error } = EXPECTED_PARAMETERS_SCHEMA.validate(values)
   if (error !== undefined) {
-    log.error(`Received an invalid response for the app_owned parameters value: ${error.message}, ${safeJsonStringify(values)}`)
+    log.error(`Received an invalid response for the app_owned parameters value: ${error.message}, ${safeJsonStringify(values, elementExpressionStringifyReplacer)}`)
     return false
   }
   return true

--- a/packages/zendesk-adapter/src/filters/article/utils.ts
+++ b/packages/zendesk-adapter/src/filters/article/utils.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import Joi from 'joi'
 import FormData from 'form-data'
 import { logger } from '@salto-io/logging'
-import { naclCase, normalizeFilePathPart, pathNaclCase, replaceTemplatesWithValues, safeJsonStringify } from '@salto-io/adapter-utils'
+import { naclCase, normalizeFilePathPart, pathNaclCase, replaceTemplatesWithValues, safeJsonStringify, elementExpressionStringifyReplacer } from '@salto-io/adapter-utils'
 import { collections, values } from '@salto-io/lowerdash'
 import {
   BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, isReferenceExpression, isStaticFile,
@@ -59,7 +59,7 @@ const EXPECTED_ATTACHMENT_SCHEMA = Joi.array().items(Joi.object({
 const isAttachments = (value: unknown): value is Attachment[] => {
   const { error } = EXPECTED_ATTACHMENT_SCHEMA.validate(value)
   if (error !== undefined) {
-    log.error(`Received an invalid response for the attachments values: ${error.message}, ${safeJsonStringify(value)}`)
+    log.error(`Received an invalid response for the attachments values: ${error.message}, ${safeJsonStringify(value, elementExpressionStringifyReplacer)}`)
     return false
   }
   return true
@@ -245,7 +245,7 @@ export const updateArticleTranslationBody = async ({
   const attachmentElementsNames = attachmentInstances.map(instance => instance.elemID.name)
   const articleTranslations = articleValues?.translations
   if (!Array.isArray(articleTranslations)) {
-    log.error(`Received an invalid translations value for attachment ${articleValues.name} - ${safeJsonStringify(articleTranslations)}`)
+    log.error(`Received an invalid translations value for attachment ${articleValues.name} - ${safeJsonStringify(articleTranslations, elementExpressionStringifyReplacer)}`)
     return
   }
   await awu(articleTranslations)

--- a/packages/zendesk-adapter/src/filters/brand_logo.ts
+++ b/packages/zendesk-adapter/src/filters/brand_logo.ts
@@ -21,7 +21,7 @@ import {
   ReferenceExpression, StaticFile,
 } from '@salto-io/adapter-api'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
-import { naclCase, safeJsonStringify, getParent, normalizeFilePathPart, pathNaclCase } from '@salto-io/adapter-utils'
+import { naclCase, safeJsonStringify, getParent, normalizeFilePathPart, pathNaclCase, elementExpressionStringifyReplacer } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import FormData from 'form-data'
 import { collections } from '@salto-io/lowerdash'
@@ -55,7 +55,7 @@ const EXPECTED_BRAND_SCHEMA = Joi.object({
 const isBrand = (value: unknown): value is Brand => {
   const { error } = EXPECTED_BRAND_SCHEMA.validate(value, { allowUnknown: true })
   if (error !== undefined) {
-    log.error(`Received an invalid response for the brand values: ${error.message}, ${safeJsonStringify(value)}`)
+    log.error(`Received an invalid response for the brand values: ${error.message}, ${safeJsonStringify(value, elementExpressionStringifyReplacer)}`)
     return false
   }
   return true

--- a/packages/zendesk-adapter/src/filters/hardcoded_channel.ts
+++ b/packages/zendesk-adapter/src/filters/hardcoded_channel.ts
@@ -17,7 +17,7 @@ import Joi from 'joi'
 import {
   BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, isInstanceElement, ObjectType, Values,
 } from '@salto-io/adapter-api'
-import { naclCase, safeJsonStringify } from '@salto-io/adapter-utils'
+import { naclCase, safeJsonStringify, elementExpressionStringifyReplacer } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
 import { FilterCreator } from '../filter'
@@ -45,7 +45,7 @@ const EXPECTED_CHANNELS_SCHEMA = Joi.array().items(Joi.object({
 const isChannels = (values: unknown): values is Channel[] => {
   const { error } = EXPECTED_CHANNELS_SCHEMA.validate(values)
   if (error !== undefined) {
-    log.error(`Received an invalid response for the channel values: ${error.message}, ${safeJsonStringify(values)}`)
+    log.error(`Received an invalid response for the channel values: ${error.message}, ${safeJsonStringify(values, elementExpressionStringifyReplacer)}`)
     return false
   }
   return true

--- a/packages/zendesk-adapter/src/filters/macro_attachments.ts
+++ b/packages/zendesk-adapter/src/filters/macro_attachments.ts
@@ -62,7 +62,7 @@ const EXPECTED_ATTACHMENT_SCHEMA = Joi.array().items(Joi.object({
 const isAttachments = (value: unknown): value is Attachment[] => {
   const { error } = EXPECTED_ATTACHMENT_SCHEMA.validate(value)
   if (error !== undefined) {
-    log.error(`Received an invalid response for the attachments values: ${error.message}, ${safeJsonStringify(value)}`)
+    log.error(`Received an invalid response for the attachments values: ${error.message}, ${safeJsonStringify(value, elementExpressionStringifyReplacer)}`)
     return false
   }
   return true

--- a/packages/zendesk-adapter/src/filters/reorder/creator.ts
+++ b/packages/zendesk-adapter/src/filters/reorder/creator.ts
@@ -19,7 +19,7 @@ import {
   BuiltinTypes, ReferenceExpression, Change, getChangeData, isModificationChange, isInstanceChange,
 } from '@salto-io/adapter-api'
 import { elements as elementsUtils, config as configUtils } from '@salto-io/adapter-components'
-import { applyFunctionToChangeData, pathNaclCase, safeJsonStringify } from '@salto-io/adapter-utils'
+import { applyFunctionToChangeData, pathNaclCase, safeJsonStringify, elementExpressionStringifyReplacer } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../../filter'
 import { ZENDESK } from '../../constants'
 import { deployChange } from '../../deployment'
@@ -176,7 +176,7 @@ export const deployFuncCreator = (fieldName: string): DeployFuncType =>
     const instance = getChangeData(clonedChange)
     const { ids } = instance.value
     if (!idsAreNumbers(ids)) {
-      throw new Error(`Not all the ids of ${instance.elemID.getFullName()} are numbers: ${safeJsonStringify(ids)}`)
+      throw new Error(`Not all the ids of ${instance.elemID.getFullName()} are numbers: ${safeJsonStringify(ids, elementExpressionStringifyReplacer)}`)
     }
     const idsWithPositions = ids.map((id, position) => ({ id, position: position + 1 }))
     instance.value[fieldName] = idsWithPositions


### PR DESCRIPTION
`safeJsonStringify` can traverse inside the `resValue` of expressions when not using the replacer - this causes very long logs in some cases.

---
_Release Notes_: 
None

---
_User Notifications_: 
None