### PR TITLE
SALTO-2909 hide types by default in all simple adapters

### DIFF
--- a/packages/adapter-components/src/config/ducktype.ts
+++ b/packages/adapter-components/src/config/ducktype.ts
@@ -38,8 +38,6 @@ export type AdapterDuckTypeApiConfig = AdapterApiConfig<
   DuckTypeTransformationConfig, DuckTypeTransformationDefaultConfig
 >
 
-export type DuckTypeUserFetchConfig = UserFetchConfig & { hideTypes?: boolean }
-
 export const createDucktypeAdapterApiConfigType = ({
   adapter,
   additionalFields,
@@ -90,7 +88,7 @@ export const validateApiDefinitionConfig = (
  */
 export const validateFetchConfig = (
   fetchConfigPath: string,
-  userFetchConfig: DuckTypeUserFetchConfig,
+  userFetchConfig: UserFetchConfig,
   adapterApiConfig: AdapterApiConfig,
 ): void => {
   validateSupportedTypes(

--- a/packages/adapter-components/src/config/index.ts
+++ b/packages/adapter-components/src/config/index.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-export { createDucktypeAdapterApiConfigType, AdapterDuckTypeApiConfig, DuckTypeTransformationConfig, DuckTypeTransformationDefaultConfig, TypeDuckTypeConfig, TypeDuckTypeDefaultsConfig, validateApiDefinitionConfig as validateDuckTypeApiDefinitionConfig, validateFetchConfig as validateDuckTypeFetchConfig, DuckTypeUserFetchConfig } from './ducktype'
+export { createDucktypeAdapterApiConfigType, AdapterDuckTypeApiConfig, DuckTypeTransformationConfig, DuckTypeTransformationDefaultConfig, TypeDuckTypeConfig, TypeDuckTypeDefaultsConfig, validateApiDefinitionConfig as validateDuckTypeApiDefinitionConfig, validateFetchConfig as validateDuckTypeFetchConfig } from './ducktype'
 export { createRequestConfigs, validateRequestConfig, FetchRequestConfig, DeployRequestConfig, UrlParams, DeploymentRequestsByAction, RecurseIntoCondition, isRecurseIntoConditionByField } from './request'
 export { createAdapterApiConfigType, getConfigWithDefault, AdapterApiConfig, UserFetchConfig, TypeConfig, createUserFetchConfigType } from './shared'
 export { mergeWithDefaultConfig } from './merge'

--- a/packages/adapter-components/src/config/shared.ts
+++ b/packages/adapter-components/src/config/shared.ts
@@ -132,10 +132,13 @@ export const createUserFetchConfigType = (
   additionalFields?: Record<string, FieldDefinition>,
   fetchCriteriaType?: ObjectType,
 ): ObjectType => {
-  const fetchEntryType = new ObjectType({
+  const fetchEntryType = createMatchingObjectType<Omit<FetchEntry<undefined>, 'criteria'>>({
     elemID: new ElemID(adapter, 'FetchEntry'),
     fields: {
-      type: { refType: BuiltinTypes.STRING },
+      type: {
+        refType: BuiltinTypes.STRING,
+        annotations: { _required: true },
+      },
     },
     annotations: {
       [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
@@ -146,11 +149,17 @@ export const createUserFetchConfigType = (
     fetchEntryType.fields.criteria = new Field(fetchEntryType, 'criteria', fetchCriteriaType)
   }
 
-  return new ObjectType({
+  return createMatchingObjectType<UserFetchConfig>({
     elemID: new ElemID(adapter, 'userFetchConfig'),
     fields: {
-      include: { refType: new ListType(fetchEntryType) },
-      exclude: { refType: new ListType(fetchEntryType) },
+      include: {
+        refType: new ListType(fetchEntryType),
+        annotations: { _required: true },
+      },
+      exclude: {
+        refType: new ListType(fetchEntryType),
+        annotations: { _required: true },
+      },
       hideTypes: { refType: BuiltinTypes.BOOLEAN },
       ...additionalFields,
     },

--- a/packages/adapter-components/src/config/shared.ts
+++ b/packages/adapter-components/src/config/shared.ts
@@ -52,6 +52,7 @@ type FetchEntry<T extends Record<string, unknown> | undefined> = {
 export type UserFetchConfig<T extends Record<string, unknown> | undefined = undefined> = {
   include: FetchEntry<T>[]
   exclude: FetchEntry<T>[]
+  hideTypes?: boolean
 }
 
 export const createAdapterApiConfigType = ({
@@ -150,6 +151,7 @@ export const createUserFetchConfigType = (
     fields: {
       include: { refType: new ListType(fetchEntryType) },
       exclude: { refType: new ListType(fetchEntryType) },
+      hideTypes: { refType: BuiltinTypes.BOOLEAN },
       ...additionalFields,
     },
     annotations: {

--- a/packages/adapter-components/src/filters/hide_types.ts
+++ b/packages/adapter-components/src/filters/hide_types.ts
@@ -27,7 +27,7 @@ const log = logger(module)
  */
 export const hideTypesFilterCreator: <
  TClient,
- TContext extends { fetch: Pick<UserFetchConfig, 'hideTypes'> & { [x: string]: unknown } },
+ TContext extends { fetch: Pick<UserFetchConfig, 'hideTypes'> },
  TResult extends void | filter.FilterResult = void,
 > () => FilterCreator<TClient, TContext, TResult> = (
 ) => ({ config }) => ({

--- a/packages/adapter-components/src/filters/hide_types.ts
+++ b/packages/adapter-components/src/filters/hide_types.ts
@@ -16,26 +16,28 @@
 import { Element, isObjectType, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
 import { filter } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
-import { DuckTypeUserFetchConfig } from '../../config/ducktype'
-import { FilterCreator } from '../../filter_utils'
+import { UserFetchConfig } from '../config'
+import { FilterCreator } from '../filter_utils'
 
 const log = logger(module)
 
 /**
- * Hide types if needed
+ * Hide types if needed according to configuration.
+ * Note: This should apply only to hard-coded types - it is the adapter's responsibility to ensure this.
  */
 export const hideTypesFilterCreator: <
  TClient,
- TContext extends { fetch: DuckTypeUserFetchConfig },
+ TContext extends { fetch: Pick<UserFetchConfig, 'hideTypes'> & { [x: string]: unknown } },
  TResult extends void | filter.FilterResult = void,
- > () => FilterCreator<TClient, TContext, TResult> = () => ({ config }) => ({
-   onFetch: async (elements: Element[]) => log.time(async () => {
-     if (config.fetch.hideTypes) {
-       elements
-         .filter(isObjectType)
-         .forEach(objType => {
-           objType.annotations[CORE_ANNOTATIONS.HIDDEN] = true
-         })
-     }
-   }, 'Hide types filter'),
- })
+> () => FilterCreator<TClient, TContext, TResult> = (
+) => ({ config }) => ({
+  onFetch: async (elements: Element[]) => log.time(async () => {
+    if (config.fetch.hideTypes) {
+      elements
+        .filter(isObjectType)
+        .forEach(objType => {
+          objType.annotations[CORE_ANNOTATIONS.HIDDEN] = true
+        })
+    }
+  }, 'Hide types filter'),
+})

--- a/packages/adapter-components/src/filters/index.ts
+++ b/packages/adapter-components/src/filters/index.ts
@@ -16,4 +16,4 @@
 export { serviceUrlFilterCreator } from './service_url'
 export { referencedInstanceNamesFilterCreator } from './referenced_instance_names'
 export { queryFilterCreator } from './query'
-export * as ducktype from './ducktype'
+export { hideTypesFilterCreator } from './hide_types'

--- a/packages/adapter-components/test/config/shared.test.ts
+++ b/packages/adapter-components/test/config/shared.test.ts
@@ -19,9 +19,10 @@ describe('config_shared', () => {
   describe('createUserFetchConfigType', () => {
     it('should return default type when no custom fields were added', () => {
       const type = createUserFetchConfigType('myAdapter')
-      expect(Object.keys(type.fields)).toHaveLength(2)
+      expect(Object.keys(type.fields)).toHaveLength(3)
       expect(type.fields.include).toBeDefined()
       expect(type.fields.exclude).toBeDefined()
+      expect(type.fields.hideTypes).toBeDefined()
     })
   })
   describe('getConfigWithDefault', () => {

--- a/packages/adapter-components/test/filters/hide_types.test.ts
+++ b/packages/adapter-components/test/filters/hide_types.test.ts
@@ -36,11 +36,6 @@ describe('hide types filter', () => {
     config: {
       fetch: {
         hideTypes,
-        include: [
-          { type: 't1' },
-          { type: 't2' },
-        ],
-        exclude: [],
       },
     },
   }) as FilterType

--- a/packages/adapter-components/test/filters/hide_types.test.ts
+++ b/packages/adapter-components/test/filters/hide_types.test.ts
@@ -14,10 +14,10 @@
 * limitations under the License.
 */
 import { ObjectType, ElemID, isObjectType, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
-import { FilterWith } from '../../../src/filter_utils'
-import { Paginator } from '../../../src/client'
-import { hideTypesFilterCreator } from '../../../src/filters/ducktype/hide_types'
-import { createMockQuery } from '../../../src/elements/query'
+import { FilterWith } from '../../src/filter_utils'
+import { Paginator } from '../../src/client'
+import { hideTypesFilterCreator } from '../../src/filters/hide_types'
+import { createMockQuery } from '../../src/elements/query'
 
 describe('hide types filter', () => {
   type FilterType = FilterWith<'onFetch'>

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -110,6 +110,7 @@ import prioritySchemeFetchFilter from './filters/data_center/priority_scheme/pri
 import prioritySchemeDeployFilter from './filters/data_center/priority_scheme/priority_scheme_deploy'
 import prioritySchemeProjectAssociationFilter from './filters/data_center/priority_scheme/priority_scheme_project_association'
 import { GetIdMapFunc, getIdMapFuncCreator } from './users_map'
+import commonFilters from './filters/common'
 
 const {
   generateTypes,
@@ -217,6 +218,7 @@ export const DEFAULT_FILTERS = [
   deployDcIssueEventsFilter,
   // Must be last
   defaultInstancesDeployFilter,
+  ...Object.values(commonFilters),
 ]
 
 export interface JiraAdapterParams {

--- a/packages/jira-adapter/src/adapter_creator.ts
+++ b/packages/jira-adapter/src/adapter_creator.ts
@@ -55,10 +55,14 @@ const adapterConfigFromConfig = (
   config: Readonly<InstanceElement> | undefined,
   defaultConfig: JiraConfig
 ): JiraConfig => {
-  const fullConfig = configUtils.mergeWithDefaultConfig(
+  const configWithoutFetch = configUtils.mergeWithDefaultConfig(
     _.omit(defaultConfig, 'fetch'),
-    config?.value
+    _.omit(config?.value ?? {}, 'fetch'),
   )
+  const fetch = _.defaults(
+    {}, config?.value.fetch, defaultConfig.fetch,
+  )
+  const fullConfig = { ...configWithoutFetch, fetch }
 
   validateConfig(fullConfig)
 

--- a/packages/jira-adapter/src/adapter_creator.ts
+++ b/packages/jira-adapter/src/adapter_creator.ts
@@ -60,7 +60,7 @@ const adapterConfigFromConfig = (
     _.omit(config?.value ?? {}, 'fetch'),
   )
   const fetch = _.defaults(
-    {}, config?.value.fetch, defaultConfig.fetch,
+    {}, config?.value.fetch, _.pick(defaultConfig.fetch, 'hideTypes'),
   )
   const fullConfig = { ...configWithoutFetch, fetch }
 

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -134,7 +134,10 @@ export const PARTIAL_DEFAULT_CONFIG: Omit<JiraConfig, 'apiDefinitions'> = {
     usePrivateAPI: true,
     boardColumnRetry: 5,
   },
-  fetch: elements.query.INCLUDE_ALL_CONFIG,
+  fetch: {
+    ...elements.query.INCLUDE_ALL_CONFIG,
+    hideTypes: true,
+  },
   deploy: {
     forceDelete: false,
   },
@@ -221,7 +224,7 @@ export const configType = createMatchingObjectType<Partial<JiraConfig>>({
     masking: { refType: maskingConfigType },
   },
   annotations: {
-    [CORE_ANNOTATIONS.DEFAULT]: _.omit(PARTIAL_DEFAULT_CONFIG, ['client', 'masking']),
+    [CORE_ANNOTATIONS.DEFAULT]: _.omit(PARTIAL_DEFAULT_CONFIG, ['client', 'masking', 'fetch.hideTypes']),
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },
 })

--- a/packages/jira-adapter/src/filters/common.ts
+++ b/packages/jira-adapter/src/filters/common.ts
@@ -14,15 +14,14 @@
 * limitations under the License.
 */
 import { filters } from '@salto-io/adapter-components'
-import { FilterContext } from '../config'
-import { FilterCreator, FilterResult } from '../filter'
-import OktaClient from '../client/client'
+import { FilterCreator } from '../filter'
 
 /**
- *  Resolves references in elements name using referenced idFields
+ * Filter creators of all the common filters
  */
-const filter: FilterCreator = params =>
-  filters.referencedInstanceNamesFilterCreator<OktaClient, FilterContext, FilterResult>(
-  )(params)
+const filterCreators: Record<string, FilterCreator> = {
+  hideTypes: filters.hideTypesFilterCreator(),
+  referencedInstanceNames: filters.referencedInstanceNamesFilterCreator(),
+}
 
-export default filter
+export default filterCreators

--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -24,13 +24,13 @@ import changeValidator from './change_validators'
 import { OktaConfig, API_DEFINITIONS_CONFIG } from './config'
 import { paginate } from './client/pagination'
 import { FilterCreator, Filter, filtersRunner } from './filter'
+import commonFilters from './filters/common'
 import replaceObjectWithIdFilter from './filters/replace_object_with_id'
 import fieldReferencesFilter from './filters/field_references'
 import urlReferencesFilter from './filters/url_references'
 import defaultDeployFilter from './filters/default_deploy'
 import groupDeploymentFilter from './filters/group_deployment'
 import appDeploymentFilter from './filters/app_deployment'
-import referencedIdFields from './filters/referenced_id_fields'
 import appStructureFilter from './filters/app_structure'
 import standardRolesFilter from './filters/standard_roles'
 import { OKTA } from './constants'
@@ -57,7 +57,7 @@ export const DEFAULT_FILTERS = [
   groupDeploymentFilter,
   appDeploymentFilter,
   // should run after fieldReferences
-  referencedIdFields,
+  ...Object.values(commonFilters),
   // should run last
   defaultDeployFilter,
 ]

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -740,7 +740,10 @@ export const DEFAULT_API_DEFINITIONS: OktaApiConfig = {
 }
 
 export const DEFAULT_CONFIG: OktaConfig = {
-  [FETCH_CONFIG]: elements.query.INCLUDE_ALL_CONFIG,
+  [FETCH_CONFIG]: {
+    ...elements.query.INCLUDE_ALL_CONFIG,
+    hideTypes: true,
+  },
   [API_DEFINITIONS_CONFIG]: DEFAULT_API_DEFINITIONS,
 }
 
@@ -762,7 +765,7 @@ export const configType = createMatchingObjectType<Partial<OktaConfig>>({
     },
   },
   annotations: {
-    [CORE_ANNOTATIONS.DEFAULT]: _.omit(DEFAULT_CONFIG, API_DEFINITIONS_CONFIG),
+    [CORE_ANNOTATIONS.DEFAULT]: _.omit(DEFAULT_CONFIG, API_DEFINITIONS_CONFIG, `${FETCH_CONFIG}.hideTypes`),
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },
 })

--- a/packages/okta-adapter/src/filters/common.ts
+++ b/packages/okta-adapter/src/filters/common.ts
@@ -14,16 +14,14 @@
 * limitations under the License.
 */
 import { filters } from '@salto-io/adapter-components'
-import { FilterContext } from '../config'
 import { FilterCreator } from '../filter'
-import ZendeskClient from '../client/client'
 
 /**
- * Filter creators of all the common ducktype filters
+ * Filter creators of all the common filters
  */
-const filterCreators: FilterCreator[] = filters.ducktype
-  .DUCKTYPE_MANDATORY_FILTER_CREATORS
-  .map(filterCreator => params =>
-    filterCreator<ZendeskClient, FilterContext>()(params))
+const filterCreators: Record<string, FilterCreator> = {
+  hideTypes: filters.hideTypesFilterCreator(),
+  referencedInstanceNames: filters.referencedInstanceNamesFilterCreator(),
+}
 
 export default filterCreators

--- a/packages/stripe-adapter/src/adapter.ts
+++ b/packages/stripe-adapter/src/adapter.ts
@@ -26,6 +26,7 @@ import { StripeConfig, API_DEFINITIONS_CONFIG, FETCH_CONFIG } from './config'
 import { FilterCreator, Filter, filtersRunner } from './filter'
 import { STRIPE } from './constants'
 import changeValidator from './change_validator'
+import commonFilters from './filters/common'
 import fieldReferencesFilter from './filters/field_references'
 
 const { createPaginator, getWithCursorPagination } = clientUtils
@@ -36,6 +37,7 @@ const log = logger(module)
 export const DEFAULT_FILTERS = [
   // fieldReferencesFilter should run after all elements were created
   fieldReferencesFilter,
+  ...Object.values(commonFilters),
 ]
 
 export interface StripeAdapterParams {

--- a/packages/stripe-adapter/src/config.ts
+++ b/packages/stripe-adapter/src/config.ts
@@ -129,7 +129,10 @@ export const DEFAULT_API_DEFINITIONS: StripeApiConfig = {
 }
 
 export const DEFAULT_CONFIG: StripeConfig = {
-  [FETCH_CONFIG]: elements.query.INCLUDE_ALL_CONFIG,
+  [FETCH_CONFIG]: {
+    ...elements.query.INCLUDE_ALL_CONFIG,
+    hideTypes: true,
+  },
   [API_DEFINITIONS_CONFIG]: DEFAULT_API_DEFINITIONS,
 }
 
@@ -149,7 +152,7 @@ export const configType = createMatchingObjectType<Partial<StripeConfig>>({
     },
   },
   annotations: {
-    [CORE_ANNOTATIONS.DEFAULT]: _.omit(DEFAULT_CONFIG, API_DEFINITIONS_CONFIG),
+    [CORE_ANNOTATIONS.DEFAULT]: _.omit(DEFAULT_CONFIG, API_DEFINITIONS_CONFIG, `${FETCH_CONFIG}.hideTypes`),
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },
 })

--- a/packages/stripe-adapter/src/filters/common.ts
+++ b/packages/stripe-adapter/src/filters/common.ts
@@ -13,10 +13,15 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { hideTypesFilterCreator } from './hide_types'
+import { filters } from '@salto-io/adapter-components'
+import { FilterCreator } from '../filter'
 
-export { hideTypesFilterCreator } from './hide_types'
+/**
+ * Filter creators of all the common filters
+ */
+const filterCreators: Record<string, FilterCreator> = {
+  hideTypes: filters.hideTypesFilterCreator(),
+  referencedInstanceNames: filters.referencedInstanceNamesFilterCreator(),
+}
 
-export const DUCKTYPE_MANDATORY_FILTER_CREATORS = [
-  hideTypesFilterCreator,
-]
+export default filterCreators

--- a/packages/workato-adapter/src/adapter.ts
+++ b/packages/workato-adapter/src/adapter.ts
@@ -25,10 +25,9 @@ import { FilterCreator, Filter, filtersRunner } from './filter'
 import { FETCH_CONFIG, WorkatoConfig } from './config'
 import addRootFolderFilter from './filters/add_root_folder'
 import fieldReferencesFilter from './filters/field_references'
-import referencedIdFieldsFilter from './filters/referenced_id_fields'
 import recipeCrossServiceReferencesFilter from './filters/cross_service/recipe_references'
 import serviceUrlFilter from './filters/service_url'
-import ducktypeCommonFilters from './filters/ducktype_common'
+import commonFilters from './filters/common'
 import { WORKATO } from './constants'
 import changeValidator from './change_validator'
 import { paginate } from './client/pagination'
@@ -43,10 +42,9 @@ export const DEFAULT_FILTERS = [
   // fieldReferencesFilter should run after all element manipulations are done
   fieldReferencesFilter,
   recipeCrossServiceReferencesFilter,
-  // referencedIdFieldsFilter should run after element references are resolved
-  referencedIdFieldsFilter,
   serviceUrlFilter,
-  ...ducktypeCommonFilters,
+  // referencedIdFieldsFilter should run after element references are resolved
+  ...Object.values(commonFilters),
 ]
 
 export interface WorkatoAdapterParams {

--- a/packages/workato-adapter/src/config.ts
+++ b/packages/workato-adapter/src/config.ts
@@ -42,7 +42,7 @@ export const API_DEFINITIONS_CONFIG = 'apiDefinitions'
 
 export type WorkatoClientConfig = clientUtils.ClientBaseConfig<clientUtils.ClientRateLimitConfig>
 
-export type WorkatoFetchConfig = configUtils.DuckTypeUserFetchConfig & {
+export type WorkatoFetchConfig = configUtils.UserFetchConfig & {
   serviceConnectionNames?: Record<string, string[]>
 }
 export type WorkatoApiConfig = configUtils.AdapterDuckTypeApiConfig
@@ -232,7 +232,6 @@ export const configType = new ObjectType({
       refType: createUserFetchConfigType(
         WORKATO,
         {
-          hideTypes: { refType: BuiltinTypes.BOOLEAN },
           serviceConnectionNames: {
             refType: new MapType(new ListType(BuiltinTypes.STRING)),
           },

--- a/packages/workato-adapter/src/filters/common.ts
+++ b/packages/workato-adapter/src/filters/common.ts
@@ -14,16 +14,14 @@
 * limitations under the License.
 */
 import { filters } from '@salto-io/adapter-components'
-import { FilterContext } from '../config'
-import { FilterCreator, FilterResult } from '../filter'
-import ZendeskClient from '../client/client'
+import { FilterCreator } from '../filter'
 
 /**
- *  Resolves references in elements name using referenced idFields
- *
+ * Filter creators of all the common filters
  */
-const filter: FilterCreator = params =>
-  filters.referencedInstanceNamesFilterCreator<ZendeskClient, FilterContext, FilterResult>(
-  )(params)
+const filterCreators: Record<string, FilterCreator> = {
+  hideTypes: filters.hideTypesFilterCreator(),
+  referencedInstanceNames: filters.referencedInstanceNamesFilterCreator(),
+}
 
-export default filter
+export default filterCreators

--- a/packages/workato-adapter/test/filters/referenced_id_fields.test.ts
+++ b/packages/workato-adapter/test/filters/referenced_id_fields.test.ts
@@ -20,7 +20,9 @@ import { DEFAULT_CONFIG, FETCH_CONFIG, SUPPORTED_TYPES, DEFAULT_ID_FIELDS } from
 import WorkatoClient from '../../src/client/client'
 import { WORKATO } from '../../src/constants'
 import { paginate } from '../../src/client/pagination'
-import filterCreator from '../../src/filters/referenced_id_fields'
+import commonCreators from '../../src/filters/common'
+
+const filterCreator = commonCreators.referencedInstanceNames
 
 describe('referenced id fields filter', () => {
   let client: WorkatoClient

--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -87,10 +87,9 @@ import guideLocalesFilter from './filters/guide_locale'
 import webhookFilter from './filters/webhook'
 import targetFilter from './filters/target'
 import defaultDeployFilter from './filters/default_deploy'
-import ducktypeCommonFilters from './filters/ducktype_common'
+import commonFilters from './filters/common'
 import handleTemplateExpressionFilter from './filters/handle_template_expressions'
 import handleAppInstallationsFilter from './filters/handle_app_installations'
-import referencedIdFieldsFilter from './filters/referenced_id_fields'
 import brandLogoFilter from './filters/brand_logo'
 import articleFilter from './filters/article/article'
 import articleBodyFilter from './filters/article/article_body'
@@ -188,14 +187,13 @@ export const DEFAULT_FILTERS = [
   // unorderedListsFilter should run after fieldReferencesFilter
   unorderedListsFilter,
   dynamicContentReferencesFilter,
-  referencedIdFieldsFilter,
   articleBodyFilter,
   guideParentSection,
   serviceUrlFilter,
-  ...ducktypeCommonFilters,
+  ...Object.values(commonFilters),
   handleAppInstallationsFilter,
   handleTemplateExpressionFilter,
-  collisionErrorsFilter, // needs to be after referencedIdFieldsFilter
+  collisionErrorsFilter, // needs to be after referencedIdFieldsFilter (which is part of the common filters)
   deployBrandedGuideTypesFilter,
   guideArrangePaths,
   fetchCategorySection, // need to be after arrange paths as it uses the 'name'/'title' field
@@ -388,7 +386,7 @@ export default class ZendeskAdapter implements AdapterOperations {
   }) => Promise<Required<Filter>>
 
   public constructor({
-    filterCreators = DEFAULT_FILTERS,
+    filterCreators = DEFAULT_FILTERS as FilterCreator[],
     client,
     credentials,
     getElemIdFunc,

--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -187,10 +187,11 @@ export const DEFAULT_FILTERS = [
   // unorderedListsFilter should run after fieldReferencesFilter
   unorderedListsFilter,
   dynamicContentReferencesFilter,
-  articleBodyFilter,
   guideParentSection,
   serviceUrlFilter,
   ...Object.values(commonFilters),
+  // articleBodyFilter should run after referencedInstanceNames (which is part of the common filters)
+  articleBodyFilter,
   handleAppInstallationsFilter,
   handleTemplateExpressionFilter,
   collisionErrorsFilter, // needs to be after referencedIdFieldsFilter (which is part of the common filters)

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -66,7 +66,7 @@ export type Guide = {
 
 export type ZendeskClientConfig = clientUtils.ClientBaseConfig<clientUtils.ClientRateLimitConfig>
 
-export type ZendeskFetchConfig = configUtils.DuckTypeUserFetchConfig
+export type ZendeskFetchConfig = configUtils.UserFetchConfig
   & {
     enableMissingReferences?: boolean
     greedyAppReferences?: boolean
@@ -2398,7 +2398,6 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
       refType: createUserFetchConfigType(
         ZENDESK,
         {
-          hideTypes: { refType: BuiltinTypes.BOOLEAN },
           enableMissingReferences: { refType: BuiltinTypes.BOOLEAN },
           greedyAppReferences: { refType: BuiltinTypes.BOOLEAN },
           appReferenceLocators: { refType: IdLocatorType },

--- a/packages/zendesk-adapter/src/filters/common.ts
+++ b/packages/zendesk-adapter/src/filters/common.ts
@@ -14,16 +14,14 @@
 * limitations under the License.
 */
 import { filters } from '@salto-io/adapter-components'
-import { FilterContext } from '../config'
 import { FilterCreator } from '../filter'
-import WorkatoClient from '../client/client'
 
 /**
- *  Resolves references in elements name using referenced idFields
- *
+ * Filter creators of all the common filters
  */
-const filter: FilterCreator = params =>
-  filters.referencedInstanceNamesFilterCreator<WorkatoClient, FilterContext>(
-  )(params)
+const filterCreators: Record<string, FilterCreator> = {
+  hideTypes: filters.hideTypesFilterCreator(),
+  referencedInstanceNames: filters.referencedInstanceNamesFilterCreator(),
+}
 
-export default filter
+export default filterCreators

--- a/packages/zendesk-adapter/test/filters/referenced_id_fields.test.ts
+++ b/packages/zendesk-adapter/test/filters/referenced_id_fields.test.ts
@@ -18,8 +18,10 @@ import { filterUtils } from '@salto-io/adapter-components'
 import { DEFAULT_CONFIG, FETCH_CONFIG, SUPPORTED_TYPES } from '../../src/config'
 import { ZENDESK } from '../../src/constants'
 
-import filterCreator from '../../src/filters/referenced_id_fields'
 import { createFilterCreatorParams } from '../utils'
+import commonCreators from '../../src/filters/common'
+
+const filterCreator = commonCreators.referencedInstanceNames
 
 describe('referenced id fields filter', () => {
   type FilterType = filterUtils.FilterWith<'onFetch'>

--- a/packages/zuora-billing-adapter/src/adapter.ts
+++ b/packages/zuora-billing-adapter/src/adapter.ts
@@ -24,6 +24,7 @@ import { logger } from '@salto-io/logging'
 import ZuoraClient from './client/client'
 import { ZuoraConfig, API_DEFINITIONS_CONFIG, FETCH_CONFIG, ZuoraApiConfig, getUpdatedConfig, SETTING_TYPES, SUPPORTED_TYPES } from './config'
 import { FilterCreator, Filter, filtersRunner } from './filter'
+import commonFilters from './filters/common'
 import fieldReferencesFilter from './filters/field_references'
 import objectDefsFilter from './filters/object_defs'
 import objectDefSplitFilter from './filters/object_def_split'
@@ -41,7 +42,11 @@ const { createPaginator } = clientUtils
 const { generateTypes, getAllInstances } = elementUtils.swagger
 const log = logger(module)
 
+const { hideTypes, ...otherCommonFilters } = commonFilters
+
 export const DEFAULT_FILTERS = [
+  // hideTypes should run before creating custom objects, so that it doesn't hide them
+  hideTypes,
   // objectDefsFilter should run before everything else
   objectDefsFilter,
 
@@ -57,6 +62,7 @@ export const DEFAULT_FILTERS = [
 
   financeInformationReferencesFilter,
 
+  ...Object.values(otherCommonFilters),
   // objectDefSplitFilter should run at the end - splits elements to divide to multiple files
   objectDefSplitFilter,
 ]

--- a/packages/zuora-billing-adapter/src/config.ts
+++ b/packages/zuora-billing-adapter/src/config.ts
@@ -782,7 +782,10 @@ export const DEFAULT_API_DEFINITIONS: ZuoraApiConfig = {
 }
 
 export const DEFAULT_CONFIG: ZuoraConfig = {
-  [FETCH_CONFIG]: elements.query.INCLUDE_ALL_CONFIG,
+  [FETCH_CONFIG]: {
+    ...elements.query.INCLUDE_ALL_CONFIG,
+    hideTypes: true,
+  },
   [API_DEFINITIONS_CONFIG]: DEFAULT_API_DEFINITIONS,
 }
 
@@ -822,7 +825,7 @@ export const configType = createMatchingObjectType<Partial<ZuoraConfig>>({
     },
   },
   annotations: {
-    [CORE_ANNOTATIONS.DEFAULT]: _.omit(DEFAULT_CONFIG, API_DEFINITIONS_CONFIG),
+    [CORE_ANNOTATIONS.DEFAULT]: _.omit(DEFAULT_CONFIG, API_DEFINITIONS_CONFIG, `${FETCH_CONFIG}.hideTypes`),
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },
 })

--- a/packages/zuora-billing-adapter/src/filters/common.ts
+++ b/packages/zuora-billing-adapter/src/filters/common.ts
@@ -14,16 +14,14 @@
 * limitations under the License.
 */
 import { filters } from '@salto-io/adapter-components'
-import { FilterContext } from '../config'
-import { FilterCreator, FilterResult } from '../filter'
-import ZendeskClient from '../client/client'
+import { FilterCreator } from '../filter'
 
 /**
- * Filter creators of all the common ducktype filters
+ * Filter creators of all the common filters
  */
-const filterCreators: FilterCreator[] = filters.ducktype
-  .DUCKTYPE_MANDATORY_FILTER_CREATORS
-  .map(filterCreator => params =>
-    filterCreator<ZendeskClient, FilterContext, FilterResult>()(params))
+const filterCreators: Record<string, FilterCreator> = {
+  hideTypes: filters.hideTypesFilterCreator(),
+  referencedInstanceNames: filters.referencedInstanceNamesFilterCreator(),
+}
 
 export default filterCreators

--- a/packages/zuora-billing-adapter/test/adapter.test.ts
+++ b/packages/zuora-billing-adapter/test/adapter.test.ts
@@ -25,6 +25,8 @@ import {
   MapType,
   ObjectType,
   Values,
+  isObjectType,
+  CORE_ANNOTATIONS,
 } from '@salto-io/adapter-api'
 import * as adapterComponents from '@salto-io/adapter-components'
 import { elements as elementUtils } from '@salto-io/adapter-components'
@@ -313,10 +315,12 @@ describe('adapter', () => {
           'WorkflowExport',
         ])
         expect(elements.filter(isInstanceElement)).toHaveLength(145)
-        expect(await awu(elements).filter(isObjectDef).toArray()).toHaveLength(2)
+        const objectDefs = (await awu(elements).filter(isObjectDef).toArray()).filter(isObjectType)
+        expect(objectDefs).toHaveLength(2)
         expect([...new Set(
-          await awu(elements).filter(isObjectDef).map(e => e.elemID.name).toArray()
+          objectDefs.map(e => e.elemID.name)
         )].sort()).toEqual(['account', 'accountingcode'])
+        expect(objectDefs.find(obj => obj.annotations[CORE_ANNOTATIONS.HIDDEN])).toBeUndefined()
         // ensure pagination is working
         expect(elements.filter(isInstanceElement).filter(inst => inst.elemID.typeName === 'WorkflowExport')).toHaveLength(6)
       })


### PR DESCRIPTION
* support `hideTypes` in swagger-based simple adapters as well
* refactor common filters to include `hideTypes` and `referencedInstanceNames`

---

Will add noise-reduction before merging

---
_Release Notes_: 

_Jira adapter_:
* The types folder will be hidden by default

_Stripe adapter_:
* The types folder will be hidden by default

_Okta adapter_:
* The types folder will be hidden by default

_Zuora-Billing adapter_:
* The system types folder will be hidden by default. Standard and custom object definitions will still be visible.

---
_User Notifications_: 

_Jira adapter_:
* The types folder will be hidden by default

_Stripe adapter_:
* The types folder will be hidden by default

_Okta adapter_:
* The types folder will be hidden by default

_Zuora-Billing adapter_:
* The system types folder will be hidden by default. Standard and custom object definitions will still be visible.
