### PR TITLE
SALTO-3193 Support complex file cabinet regexes

### DIFF
--- a/packages/netsuite-adapter/src/query.ts
+++ b/packages/netsuite-adapter/src/query.ts
@@ -243,7 +243,10 @@ const buildTypesQuery = (types: FetchTypeQueryParams[]): TypesQuery => {
 
 const buildFileCabinetQuery = (fileMatchers: string[]): FileCabinetQuery => {
   const parentFolderMatchers = fileMatchers.flatMap(
-    matcher => _.range(matcher.length).map(i => new RegExp(`^${matcher.slice(0, i + 1)}$`))
+    matcher => _.range(matcher.length)
+      .map(i => matcher.slice(0, i + 1))
+      .filter(regex.isValidRegex)
+      .map(reg => new RegExp(`^${reg}$`))
   )
   return {
     isFileMatch: filePath =>

--- a/packages/netsuite-adapter/test/query.test.ts
+++ b/packages/netsuite-adapter/test/query.test.ts
@@ -230,6 +230,18 @@ describe('NetsuiteQuery', () => {
       expect(query.isTypeMatch('subsidiary')).toBeTruthy()
       expect(query.isObjectMatch({ type: 'subsidiary', instanceId: 'aaa' })).toBeTruthy()
     })
+
+    it('support complex file cabinet regexes', () => {
+      const query = andQuery(buildNetsuiteQuery({
+        types: [],
+        fileCabinet: ['^/SuiteScripts.*'],
+      }), notQuery(buildNetsuiteQuery({
+        types: [],
+        fileCabinet: ['^/SuiteScripts/[^/]+\\.xml'],
+      })))
+      expect(query.isFileMatch('/SuiteScripts/inner/test.xml')).toBeTruthy()
+      expect(query.isFileMatch('/SuiteScripts/test.xml')).toBeFalsy()
+    })
   })
 
   describe('validateParameters', () => {


### PR DESCRIPTION
Trying to exclude by a specific suffix in a specific folder makes a fetch throw:

The regex: `"^/SuiteScripts/test/[^/]+\\.xml"`

The Error: `Invalid regular expression: /^^/SuiteScripts/test/[$/: Unterminated character class`

This is caused by the way we create subregexes of file cabinet parent folders - we take all slices of the path but it can be invalid (like `^/SuiteScripts/test/[` ). We need to filter out all invalid subregexes.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Support complex file cabinet regexes

---
_User Notifications_: 
None