### PR TITLE
SALTO-2701 new getSinglePage for workato

### DIFF
--- a/packages/workato-adapter/src/client/client.ts
+++ b/packages/workato-adapter/src/client/client.ts
@@ -59,7 +59,7 @@ export default class WorkatoClient extends clientUtils.AdapterHTTPClient<
       return await super.getSinglePage(args)
     } catch (e) {
       const status = e.response?.status
-      // Workato returns 400 when asking to get pages from non-Dev Workato-Eviroments (Production/test)
+      // Workato returns 400 when asking to get pages from non-Dev Workato-Environments (Production/test)
       if (
         (status === 400 && [
           '/roles',

--- a/packages/workato-adapter/src/client/client.ts
+++ b/packages/workato-adapter/src/client/client.ts
@@ -53,24 +53,22 @@ export default class WorkatoClient extends clientUtils.AdapterHTTPClient<
   }
 
   public async getSinglePage(
-      args: clientUtils.ClientBaseParams,
+    args: clientUtils.ClientBaseParams,
   ): Promise<clientUtils.Response<clientUtils.ResponseValue | clientUtils.ResponseValue[]>> {
-      try {
-          return await super.getSinglePage(args)
-      } catch (e) {
-          const status = e.response?.status
-          // Workato returns 400 when asking to get pages from non-Dev Workato-Eviroments (Production/test)
-          if (
-              (status === 400 && [
-                  '/roles',
-              ].includes(args.url))
-          ) {
-              log.warn('Suppressing %d error %o', status, e)
-              return { data: [], status }
-          }
-          throw e
+    try {
+      return await super.getSinglePage(args)
+    } catch (e) {
+      const status = e.response?.status
+      // Workato returns 400 when asking to get pages from non-Dev Workato-Eviroments (Production/test)
+      if (
+        (status === 400 && [
+          '/roles',
+        ].includes(args.url))
+      ) {
+        log.warn('Suppressing %d error %o', status, e)
+        return { data: [], status }
       }
+      throw e
+    }
   }
-
 }
-

--- a/packages/workato-adapter/src/client/client.ts
+++ b/packages/workato-adapter/src/client/client.ts
@@ -14,11 +14,13 @@
 * limitations under the License.
 */
 import { client as clientUtils } from '@salto-io/adapter-components'
+import { logger } from '@salto-io/logging'
 import { createConnection } from './connection'
 import { WORKATO } from '../constants'
 import { Credentials } from '../auth'
 
 const { DEFAULT_RETRY_OPTS, RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS } = clientUtils
+const log = logger(module)
 
 const DEFAULT_MAX_CONCURRENT_API_REQUESTS: Required<clientUtils.ClientRateLimitConfig> = {
   total: RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,
@@ -49,4 +51,26 @@ export default class WorkatoClient extends clientUtils.AdapterHTTPClient<
       }
     )
   }
+
+  public async getSinglePage(
+      args: clientUtils.ClientBaseParams,
+  ): Promise<clientUtils.Response<clientUtils.ResponseValue | clientUtils.ResponseValue[]>> {
+      try {
+          return await super.getSinglePage(args)
+      } catch (e) {
+          const status = e.response?.status
+          // Workato returns 400 when asking to get pages from non-Dev Workato-Eviroments (Production/test)
+          if (
+              (status === 400 && [
+                  '/roles',
+              ].includes(args.url))
+          ) {
+              log.warn('Suppressing %d error %o', status, e)
+              return { data: [], status }
+          }
+          throw e
+      }
+  }
+
 }
+

--- a/packages/workato-adapter/test/client/client.test.ts
+++ b/packages/workato-adapter/test/client/client.test.ts
@@ -23,7 +23,7 @@ describe('client', () => {
     let client: WorkatoClient
     beforeEach(() => {
       mockAxios = new MockAdapter(axios)
-      client = new WorkatoClient({ credentials: { username: 'dummy_user', token: 'dummy_token'}})
+      client = new WorkatoClient({ credentials: { username: 'dummy_user', token: 'dummy_token' } })
     })
 
     afterEach(() => {

--- a/packages/workato-adapter/test/client/client.test.ts
+++ b/packages/workato-adapter/test/client/client.test.ts
@@ -1,0 +1,53 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import WorkatoClient from '../../src/client/client'
+
+describe('client', () => {
+  describe('getSinglePage', () => {
+    let mockAxios: MockAdapter
+    let client: WorkatoClient
+    beforeEach(() => {
+      mockAxios = new MockAdapter(axios)
+      client = new WorkatoClient({ credentials: { username: 'dummy_user', token: 'dummy_token'}})
+    })
+
+    afterEach(() => {
+      mockAxios.restore()
+    })
+
+    it('should return an empty result when there is a 400 response and we asked for roles', async () => {
+      // The first replyOnce with 200 is for the client authentication
+      mockAxios.onGet().replyOnce(200).onGet().replyOnce(400)
+      const res = await client.getSinglePage({ url: '/roles' })
+      expect(res.data).toEqual([])
+      expect(res.status).toEqual(400)
+    })
+    it('should throw when there is a 400 response but we did not ask for roles', async () => {
+      // The first replyOnce with 200 is for the client authentication
+      mockAxios.onGet().replyOnce(200).onGet().replyOnce(400)
+      await expect(client.getSinglePage({ url: '/api_access_profiles' })).rejects.toThrow()
+    })
+    it('should throw if there is no status in the error', async () => {
+      // The first replyOnce with 200 is for the client authentication
+      mockAxios.onGet().replyOnce(200).onGet().replyOnce(() => { throw new Error('Err') })
+      await expect(
+        client.getSinglePage({ url: '/connections' })
+      ).rejects.toThrow()
+    })
+  })
+})


### PR DESCRIPTION
Bugfix - repair fetch. This PR ignore the page /roles when it gets 400.

____________________________________________________________________________________

As part of the new Workato environment feature. Team Management is viewd only in dev environment. At another environment all pages of Team managment (/roles only for now) will return 400 (Error - Bad Request). For now, we ignore this page when it gets 400.

____________________________________________________________________________________

Release Notes:
_Workato Adapter_:
* Avoid failing fetch on non-dev environments due to a failure to get roles

____________________________________________________________________________________

User Notifications:
None