### PR TITLE
SALTO-3211 - Added logs to deployments with the data of the deployment

### DIFF
--- a/packages/adapter-components/src/deployment/deployment.ts
+++ b/packages/adapter-components/src/deployment/deployment.ts
@@ -131,7 +131,7 @@ export const deployChange = async ({
   if (_.isEmpty(valuesToDeploy) && isAdditionOrModificationChange(change)) {
     return undefined
   }
-  log.trace(`deploying instance ${instance.elemID.getFullName()} with params ${safeJsonStringify({ url, data, queryParams }, elementExpressionStringifyReplacer)}`)
+  log.trace(`deploying instance ${instance.elemID.getFullName()} with params ${safeJsonStringify({ method: endpoint.method, url, data, queryParams }, elementExpressionStringifyReplacer)}`)
   const response = await client[endpoint.method]({ url, data, queryParams })
   return response.data
 }

--- a/packages/adapter-components/src/deployment/deployment.ts
+++ b/packages/adapter-components/src/deployment/deployment.ts
@@ -106,7 +106,7 @@ export const deployChange = async ({
   elementsSource?: ReadOnlyElementsSource
 }): Promise<ResponseResult> => {
   const instance = getChangeData(change)
-  log.trace(`Deploying instance ${instance.elemID.getFullName()}, ${safeJsonStringify({ action: change.action })}`)
+  log.debug(`Starting deploying instance ${instance.elemID.getFullName()} with action '${change.action}'`)
   const endpoint = endpointDetails?.[change.action]
   if (endpoint === undefined) {
     throw new Error(`No endpoint of type ${change.action} for ${instance.elemID.typeName}`)
@@ -131,7 +131,7 @@ export const deployChange = async ({
   if (_.isEmpty(valuesToDeploy) && isAdditionOrModificationChange(change)) {
     return undefined
   }
-  log.trace(`Deploying instance ${instance.elemID.getFullName()}, ${safeJsonStringify({ url, data, queryParams }, elementExpressionStringifyReplacer)}`)
+  log.trace(`deploying instance ${instance.elemID.getFullName()} with params ${safeJsonStringify({ url, data, queryParams }, elementExpressionStringifyReplacer)}`)
   const response = await client[endpoint.method]({ url, data, queryParams })
   return response.data
 }

--- a/packages/adapter-components/src/deployment/deployment.ts
+++ b/packages/adapter-components/src/deployment/deployment.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import { ActionName, Change, ElemID, getChangeData, InstanceElement, ReadOnlyElementsSource, isAdditionOrModificationChange } from '@salto-io/adapter-api'
-import { transformElement } from '@salto-io/adapter-utils'
+import { elementExpressionStringifyReplacer, safeJsonStringify, transformElement } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { createUrl } from '../elements/request_parameters'
 import { HTTPWriteClientInterface } from '../client/http_client'
@@ -106,7 +106,7 @@ export const deployChange = async ({
   elementsSource?: ReadOnlyElementsSource
 }): Promise<ResponseResult> => {
   const instance = getChangeData(change)
-  log.debug(`Deploying instance ${instance.elemID.getFullName()}`, { action: change.action })
+  log.trace(`Deploying instance ${instance.elemID.getFullName()}, ${safeJsonStringify({ action: change.action })}`)
   const endpoint = endpointDetails?.[change.action]
   if (endpoint === undefined) {
     throw new Error(`No endpoint of type ${change.action} for ${instance.elemID.typeName}`)
@@ -131,8 +131,7 @@ export const deployChange = async ({
   if (_.isEmpty(valuesToDeploy) && isAdditionOrModificationChange(change)) {
     return undefined
   }
-
-  log.debug(`Deploying instance ${instance.elemID.getFullName()}`, { url, data, queryParams })
+  log.trace(`Deploying instance ${instance.elemID.getFullName()}, ${safeJsonStringify({ url, data, queryParams }, elementExpressionStringifyReplacer)}`)
   const response = await client[endpoint.method]({ url, data, queryParams })
   return response.data
 }

--- a/packages/adapter-components/src/deployment/deployment.ts
+++ b/packages/adapter-components/src/deployment/deployment.ts
@@ -16,11 +16,14 @@
 import _ from 'lodash'
 import { ActionName, Change, ElemID, getChangeData, InstanceElement, ReadOnlyElementsSource, isAdditionOrModificationChange } from '@salto-io/adapter-api'
 import { transformElement } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
 import { createUrl } from '../elements/request_parameters'
 import { HTTPWriteClientInterface } from '../client/http_client'
 import { DeploymentRequestsByAction } from '../config/request'
 import { ResponseValue } from '../client'
 import { OPERATION_TO_ANNOTATION } from './annotations'
+
+const log = logger(module)
 
 export type ResponseResult = ResponseValue | ResponseValue[] | undefined
 
@@ -103,6 +106,7 @@ export const deployChange = async ({
   elementsSource?: ReadOnlyElementsSource
 }): Promise<ResponseResult> => {
   const instance = getChangeData(change)
+  log.debug(`Deploying instance ${instance.elemID.getFullName()}`, { action: change.action })
   const endpoint = endpointDetails?.[change.action]
   if (endpoint === undefined) {
     throw new Error(`No endpoint of type ${change.action} for ${instance.elemID.typeName}`)
@@ -128,6 +132,7 @@ export const deployChange = async ({
     return undefined
   }
 
+  log.debug(`Deploying instance ${instance.elemID.getFullName()}`, { url, data, queryParams })
   const response = await client[endpoint.method]({ url, data, queryParams })
   return response.data
 }


### PR DESCRIPTION
On deployment of instances, a debug log will be created with the details of the deployment

---

None

---
_Release Notes_: 
None

---
_User Notifications_: 
None
