### PR TITLE
SALTO-3215: Invalid CPQ default config 

### DIFF
--- a/packages/salesforce-adapter/cpq-sbaa-config-doc.md
+++ b/packages/salesforce-adapter/cpq-sbaa-config-doc.md
@@ -89,7 +89,7 @@ salesforce {
         },
         {
           metadataType = "EmailTemplate"
-          name: '^MarketoEmailTemplates/*',
+          name = "^MarketoEmailTemplates/*"
         },
         {
           metadataType = "ContentAsset"


### PR DESCRIPTION
A small change in the example for CPQ config.

---

_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
