### PR TITLE
SALTO-2749: Upgrade NetSuite SDF version to 2022.2.1

### DIFF
--- a/.circleci/build-images/e2e-test/.dockerignore
+++ b/.circleci/build-images/e2e-test/.dockerignore
@@ -1,1 +1,0 @@
-build.sh

--- a/.circleci/build-images/e2e-test/Dockerfile
+++ b/.circleci/build-images/e2e-test/Dockerfile
@@ -1,8 +1,0 @@
-FROM cimg/node:14.15
-# install open jdk 11 as it's a requirement of netsuite-adapter
-RUN sudo apt-get update && sudo apt-get install -y openjdk-11-jdk; \
-        # Fix "Error - trustAnchors parameter must be non-empty", taken from https://github.com/infosiftr/openjdk/blob/258870647c5a4281c4cc81d0d17b6fd95bcf4141/11/jdk/Dockerfile
-        # ca-certificates-java does not work on src:openjdk-11: (https://bugs.debian.org/914424, https://bugs.debian.org/894979, https://salsa.debian.org/java-team/ca-certificates-java/commit/813b8c4973e6c4bb273d5d02f8d4e0aa0b226c50#d4b95d176f05e34cd0b718357c532dc5a6d66cd7_54_56)
-        sudo keytool -importkeystore -srckeystore /etc/ssl/certs/java/cacerts -destkeystore /etc/ssl/certs/java/cacerts.jks -deststoretype JKS -srcstorepass changeit -deststorepass changeit -noprompt; \
-        sudo mv /etc/ssl/certs/java/cacerts.jks /etc/ssl/certs/java/cacerts; \
-        sudo /var/lib/dpkg/info/ca-certificates-java.postinst configure;

--- a/.circleci/build-images/e2e-test/build.sh
+++ b/.circleci/build-images/e2e-test/build.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-docker build -t saltolabs/salto-e2e .
-
-docker push saltolabs/salto-e2e

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,8 @@ jobs:
 
       - persist_to_workspace:
           root: .
-          paths: '*'
+          paths:
+            - '*'
 
   save_project_cache:
     docker:
@@ -158,7 +159,7 @@ jobs:
 
   e2e_test:
     docker:
-      - image: saltolabs/salto-e2e
+      - image: cimg/node:14.15
 
     resource_class: large
     working_directory: /mnt/ramdisk/project
@@ -167,6 +168,9 @@ jobs:
       - attach_workspace:
           at: .
 
+      - run:
+          name: Install java
+          command: sudo apt update && sudo apt install -y openjdk-17-jdk --no-install-recommends
       - run:
           name: Run E2E tests
           command: yarn test --reporters=default --reporters=jest-junit --coverage=false

--- a/packages/netsuite-adapter/README.md
+++ b/packages/netsuite-adapter/README.md
@@ -5,22 +5,16 @@ Netsuite adapter for salto.io
 ### Prerequisites
 ###### taken from https://github.com/oracle/netsuite-suitecloud-sdk/tree/master/packages/node-cli
 
-Install Java 11 (OpenJDK / JDK)
+Install Java 17 (OpenJDK / JDK)
 ```
-OpenJDK - http://jdk.java.net/archive/ (explanation at https://dzone.com/articles/installing-openjdk-11-on-macos)
-JDK - https://www.oracle.com/java/technologies/javase-jdk11-downloads.html
+OpenJDK
+    (using macOS)
+    brew install openjdk@17
+    sudo ln -sfn /usr/local/opt/openjdk\@17/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-17.jdk
+    export JAVA_HOME=`/usr/libexec/java_home -v 17`
+JDK - https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html
 ```
 
-#### M1 Macs
-If you have an M1 mac, you'll need to use homebrew to install the JDK,
-```shell
-$ brew install openjdk@11
-```
-After installing, make sure you create the symlink as homebrew suggests:
-```
-sudo ln -sfn /opt/homebrew/opt/openjdk@11/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-11.jdk
-```
-and then follow [the instructions](https://dzone.com/articles/installing-openjdk-11-on-macos) on how to set the current java version using `java_home`.
 ### Build instructions
 ```
 yarn

--- a/packages/netsuite-adapter/package.json
+++ b/packages/netsuite-adapter/package.json
@@ -36,7 +36,7 @@
     "@salto-io/file": "0.3.28",
     "@salto-io/logging": "0.3.28",
     "@salto-io/lowerdash": "0.3.28",
-    "@salto-io/suitecloud-cli": "1.5.0-salto-1",
+    "@salto-io/suitecloud-cli": "1.6.2-salto-1",
     "ajv": "^7.1.1",
     "async-lock": "^1.2.4",
     "axios": "^0.21.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2999,16 +2999,17 @@
     napi-macros "^2.0.0"
     node-gyp-build "^4.3.0"
 
-"@salto-io/suitecloud-cli@1.5.0-salto-1":
-  version "1.5.0-salto-1"
-  resolved "https://registry.yarnpkg.com/@salto-io/suitecloud-cli/-/suitecloud-cli-1.5.0-salto-1.tgz#e5db00d7791ddb4ec756e0ebb8ef5ac11348a6cd"
-  integrity sha512-LScewgF1ereWTiLM/A97c7KiYuHD/9gfc3YcCy1IxsS+aCfefO695TvWSC6n7+cKHfutWhBG7ehcUrtHpOWRHg==
+"@salto-io/suitecloud-cli@1.6.2-salto-1":
+  version "1.6.2-salto-1"
+  resolved "https://registry.yarnpkg.com/@salto-io/suitecloud-cli/-/suitecloud-cli-1.6.2-salto-1.tgz#e9cd3906818390036d304f9992bb550efaf8ac5d"
+  integrity sha512-vkaybRqnIz/1diKKEH/oKH0Tq2hx9gIw6g6Z1C2DBOnmWHBba+Bm0oszIJj4FUjlcpG9YUmLxTB6qL64InVp6A==
   dependencies:
     "@salto-io/logging" "<0.4.0"
     chalk "4.1.2"
     cli-spinner "0.2.10"
-    commander "8.3.0"
-    inquirer "8.2.0"
+    commander "9.4.0"
+    inquirer "8.2.2"
+    vm2 "3.9.11"
     xml2js "0.4.23"
 
 "@sideway/address@^4.1.3":
@@ -4036,6 +4037,11 @@ acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
+acorn-walk@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
 acorn@^7.1.1:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.2.0.tgz#17ea7e40d7c8640ff54a694c889c26f31704effe"
@@ -4045,6 +4051,11 @@ acorn@^8.0.4, acorn@^8.2.4, acorn@^8.5.0:
   version "8.7.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.1.tgz#0197122c843d1bf6d0a5e83220a788f278f63c30"
   integrity sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==
+
+acorn@^8.7.0:
+  version "8.8.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.1.tgz#0a3f9cbecc4ec3bea6f0a80b66ae8dd2da250b73"
+  integrity sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==
 
 add-stream@^1.0.0:
   version "1.0.0"
@@ -5145,10 +5156,10 @@ combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@8.3.0:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
-  integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
+commander@9.4.0:
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.0.tgz#bc4a40918fefe52e22450c111ecd6b7acce6f11c"
+  integrity sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==
 
 commander@^2.11.0, commander@^2.19.0, commander@^2.20.0, commander@^2.7.1, commander@^2.9.0:
   version "2.20.3"
@@ -7638,10 +7649,10 @@ init-package-json@^3.0.2:
     validate-npm-package-license "^3.0.4"
     validate-npm-package-name "^4.0.0"
 
-inquirer@8.2.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.0.tgz#f44f008dd344bbfc4b30031f45d984e034a3ac3a"
-  integrity sha512-0crLweprevJ02tTuA6ThpoAERAGyVILC4sS74uib58Xf/zSr1/ZWtmm7D5CI+bSQEaA04f0K7idaHpQbSWgiVQ==
+inquirer@8.2.2:
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.2.tgz#1310517a87a0814d25336c78a20b44c3d9b7629d"
+  integrity sha512-pG7I/si6K/0X7p1qU+rfWnpTE1UIkTONN1wxtzh0d+dHXtT/JG6qBgLxoyHVsQa8cFABxAPh0pD6uUUHiAoaow==
   dependencies:
     ansi-escapes "^4.2.1"
     chalk "^4.1.1"
@@ -7653,7 +7664,7 @@ inquirer@8.2.0:
     mute-stream "0.0.8"
     ora "^5.4.1"
     run-async "^2.4.0"
-    rxjs "^7.2.0"
+    rxjs "^7.5.5"
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
     through "^2.3.6"
@@ -11448,13 +11459,6 @@ rxjs@^6.5.2:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^7.2.0:
-  version "7.5.6"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.6.tgz#0446577557862afd6903517ce7cae79ecb9662bc"
-  integrity sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==
-  dependencies:
-    tslib "^2.1.0"
-
 rxjs@^7.5.5:
   version "7.5.7"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.7.tgz#2ec0d57fdc89ece220d2e702730ae8f1e49def39"
@@ -12864,6 +12868,14 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+vm2@3.9.11:
+  version "3.9.11"
+  resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.9.11.tgz#a880f510a606481719ec3f9803b940c5805a06fe"
+  integrity sha512-PFG8iJRSjvvBdisowQ7iVF580DXb1uCIiGaXgm7tynMR1uTBlv7UJlB1zdv5KJ+Tmq1f0Upnj3fayoEOPpCBKg==
+  dependencies:
+    acorn "^8.7.0"
+    acorn-walk "^8.2.0"
 
 vsce@^2.9.2:
   version "2.9.2"


### PR DESCRIPTION
Tested locally:
1. Fetched Dilly with previous version
2. Fetched Dilly with the new version
3. Verified there are no changes in the nacls
4. Deployed CustomRecord and CustomField.

---
_Release Notes_: 
Netsuite Adapter: SALTO-2749: Upgrade NetSuite SDF version to 2022.2.1

---
_User Notifications_: 
Netsuite Adapter: For existing Salto Workspaces, you should reinstall the NetSuite service by creating a temporary Salto Workspace and calling salto `service add netsuite --no-login`.
This will download the new SDF version that will be used globally for all WSs. The temporary Salto Workspace can be deleted.
In addition, as part of SDF requirements, Java 17 is required.