### PR TITLE
SALTO-3212: fix missing zendesk template expression in macro action value fields

### DIFF
--- a/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
@@ -51,9 +51,9 @@ BRACKETS.forEach(([opener, closer]) => {
   // dynamic content references look different, but can still be part of template
   typeSearchRegexes.push(new RegExp(`(${opener})([^\\$}]*dc\\.[\\w]+[^}]*)(${closer})`, 'g'))
 })
-const potentialReferenceTypeRegex = new RegExp(`((?:${POTENTIAL_REFERENCE_TYPES.join('|')})_[\\d]+)`, 'g')
+const potentialReferenceTypeRegex = new RegExp(`((?:${POTENTIAL_REFERENCE_TYPES.join('|')})_\u200B?[\\d]+)`, 'g')
 const potentialMacroFields = [
-  'comment_value', 'comment_value_html', 'side_conversation', 'side_conversation_ticket',
+  'comment_value', 'comment_value_html', 'side_conversation', 'side_conversation_ticket', 'subject', 'side_conversation_slack',
 ]
 // triggers and automations notify users, webhooks
 // groups or targets with text that can include templates.
@@ -145,7 +145,7 @@ const formulaToTemplate = (
 ): TemplateExpression | string => {
   const handleZendeskReference = (expression: string, ref: RegExpMatchArray): TemplatePart[] => {
     const reference = ref.pop() ?? ''
-    const splitReference = reference.split(/_([\d]+)/).filter(v => !_.isEmpty(v))
+    const splitReference = reference.split(/_\u200B?([\d]+)/).filter(v => !_.isEmpty(v))
     // should be exactly of the form TYPE_INNERID, so should contain exactly two parts
     if (splitReference.length !== 2) {
       return [expression]

--- a/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
@@ -51,7 +51,7 @@ BRACKETS.forEach(([opener, closer]) => {
   // dynamic content references look different, but can still be part of template
   typeSearchRegexes.push(new RegExp(`(${opener})([^\\$}]*dc\\.[\\w]+[^}]*)(${closer})`, 'g'))
 })
-const potentialReferenceTypeRegex = new RegExp(`((?:${POTENTIAL_REFERENCE_TYPES.join('|')})_\u200B?[\\d]+)`, 'g')
+const potentialReferenceTypeRegex = new RegExp(`((?:${POTENTIAL_REFERENCE_TYPES.join('|')})_?[\\d]+)`, 'g')
 const potentialMacroFields = [
   'comment_value', 'comment_value_html', 'side_conversation', 'side_conversation_ticket', 'subject', 'side_conversation_slack',
 ]
@@ -145,7 +145,7 @@ const formulaToTemplate = (
 ): TemplateExpression | string => {
   const handleZendeskReference = (expression: string, ref: RegExpMatchArray): TemplatePart[] => {
     const reference = ref.pop() ?? ''
-    const splitReference = reference.split(/_\u200B?([\d]+)/).filter(v => !_.isEmpty(v))
+    const splitReference = reference.split(/_?([\d]+)/).filter(v => !_.isEmpty(v))
     // should be exactly of the form TYPE_INNERID, so should contain exactly two parts
     if (splitReference.length !== 2) {
       return [expression]

--- a/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
@@ -51,7 +51,7 @@ BRACKETS.forEach(([opener, closer]) => {
   // dynamic content references look different, but can still be part of template
   typeSearchRegexes.push(new RegExp(`(${opener})([^\\$}]*dc\\.[\\w]+[^}]*)(${closer})`, 'g'))
 })
-const potentialReferenceTypeRegex = new RegExp(`((?:${POTENTIAL_REFERENCE_TYPES.join('|')})_?[\\d]+)`, 'g')
+const potentialReferenceTypeRegex = new RegExp(`((?:${POTENTIAL_REFERENCE_TYPES.join('|')})_[\\d]+)`, 'g')
 const potentialMacroFields = [
   'comment_value', 'comment_value_html', 'side_conversation', 'side_conversation_ticket', 'subject', 'side_conversation_slack',
 ]
@@ -145,7 +145,7 @@ const formulaToTemplate = (
 ): TemplateExpression | string => {
   const handleZendeskReference = (expression: string, ref: RegExpMatchArray): TemplatePart[] => {
     const reference = ref.pop() ?? ''
-    const splitReference = reference.split(/_?([\d]+)/).filter(v => !_.isEmpty(v))
+    const splitReference = reference.split(/_([\d]+)/).filter(v => !_.isEmpty(v))
     // should be exactly of the form TYPE_INNERID, so should contain exactly two parts
     if (splitReference.length !== 2) {
       return [expression]

--- a/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
+++ b/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
@@ -121,13 +121,42 @@ describe('handle templates filter', () => {
     testType,
     {
       id: 1020,
-      actions: [{ value: [
-        'Improved needs for {{ticket.ticket_field_option_title_1454}}',
-        '<p>Improved needs for {{ticket.ticket_field_option_title_1454}} due to something</p>',
-        'hello',
-        'text/html',
+      actions: [
+        {
+          value:
+            [
+              'Improved needs for {{ticket.ticket_field_option_title_1454}}',
+              '<p>Improved needs for {{ticket.ticket_field_option_title_1454}} due to something</p>',
+              'hello',
+              'text/html',
+            ],
+          field: 'side_conversation_ticket',
+        },
+        {
+          value:
+            [
+              'Improved needs for {{ticket.ticket_field_option_title_1454}}',
+              '<p>Improved needs for {{ticket.ticket_field_option_title_1454}} due to something</p>',
+              'hello',
+              'text/html',
+            ],
+          field: 'side_conversation_slack',
+        },
+        {
+          value:
+            [
+              'Improved needs for {{ticket.ticket_field_1452}}',
+              '<p>Improved needs for {{ticket.ticket_field_1452}} due to something</p>',
+              'hello',
+              'text/html',
+            ],
+          field: 'side_conversation',
+        },
+        {
+          value: 'Improved needs for {{ticket.ticket_field_1452}} - {{ticket.ticket_field_1452}}',
+          field: 'subject',
+        },
       ],
-      field: 'side_conversation_ticket' }],
     },
   )
 
@@ -285,6 +314,27 @@ describe('handle templates filter', () => {
         'hello',
         'text/html',
       ])
+      expect(macroWithSideConv.value.actions[1].value).toEqual([
+        new TemplateExpression({ parts: [`Improved needs for {{${TICKET_FIELD_OPTION_TITLE}_`, new ReferenceExpression(placeholder3.elemID, placeholder3), '}}'] }),
+        new TemplateExpression({ parts: [`<p>Improved needs for {{${TICKET_FIELD_OPTION_TITLE}_`, new ReferenceExpression(placeholder3.elemID, placeholder3), '}} due to something</p>'] }),
+        'hello',
+        'text/html',
+      ])
+      expect(macroWithSideConv.value.actions[2].value).toEqual([
+        new TemplateExpression({ parts: [`Improved needs for {{${TICKET_TICKET_FIELD}_`, new ReferenceExpression(placeholder1.elemID, placeholder1), '}}'] }),
+        new TemplateExpression({ parts: [`<p>Improved needs for {{${TICKET_TICKET_FIELD}_`, new ReferenceExpression(placeholder1.elemID, placeholder1), '}} due to something</p>'] }),
+        'hello',
+        'text/html',
+      ])
+      expect(macroWithSideConv.value.actions[3].value).toEqual(
+        new TemplateExpression({ parts: [
+          `Improved needs for {{${TICKET_TICKET_FIELD}_`,
+          new ReferenceExpression(placeholder1.elemID, placeholder1),
+          `}} - {{${TICKET_TICKET_FIELD}_`,
+          new ReferenceExpression(placeholder1.elemID, placeholder1),
+          '}}',
+        ] }),
+      )
     })
   })
   describe('preDeploy', () => {


### PR DESCRIPTION
_fix missing zendesk template expression in macro action value fields_

---

_Additional context for reviewer_
None

---
_Release Notes_: 
None

---
_User Notifications_: 
None
