### PR TITLE
SALTO-3087 - added retry on another sf endpoint

### DIFF
--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -372,6 +372,43 @@ const createConnectionFromCredentials = (
   return realConnection(creds.isSandbox, options)
 }
 
+const retryOnBadResponse = async <T extends object>(
+  request: () => Promise<T>,
+  retryAttempts = DEFAULT_RETRY_OPTS.maxAttempts,
+): Promise<T> => {
+  const requestWithRetry = async (attempts: number): Promise<T> => {
+    let res: T
+    try {
+      res = await request()
+    } catch (e) {
+      log.warn('salesforce request failed with the following: "%o"', e)
+      log.warn(`caught exception: ${e.message}. ${attempts} retry attempts left from ${retryAttempts} in total`)
+      if (attempts > 1 && errorMessagesToRetry.some(message => e.message.includes(message))) {
+        log.warn('Encountered invalid result from salesforce, error message: %s, will retry %d more times', e.message, attempts - 1)
+        return requestWithRetry(attempts - 1)
+      }
+      throw e
+    }
+
+    if (typeof res === 'string') {
+      log.warn('Received string when expected object, attempting the json parse the received string')
+
+      try {
+        return JSON.parse(res)
+      } catch (e) {
+        log.warn('Received string that is not json parsable when expected object. Retries left %d', attempts - 1)
+        if (attempts > 1) {
+          return requestWithRetry(attempts - 1)
+        }
+        throw e
+      }
+    }
+
+    return res
+  }
+  return requestWithRetry(retryAttempts)
+}
+
 export const loginFromCredentialsAndReturnOrgId = async (
   connection: Connection, creds: Credentials): Promise<string> => {
   if (creds instanceof UsernamePasswordCredentials) {
@@ -382,7 +419,7 @@ export const loginFromCredentialsAndReturnOrgId = async (
     }
   }
   // Oauth connection doesn't require further login
-  const identityInfo = await connection.identity()
+  const identityInfo = await retryOnBadResponse(() => connection.identity())
   log.debug(`connected salesforce user: ${identityInfo.username}`, { identityInfo })
 
   return identityInfo.organization_id
@@ -469,46 +506,17 @@ export default class SalesforceClient {
     )
   }
 
+  private retryOnBadResponse = <T extends object>(request: () => Promise<T>): Promise<T> => {
+    const retryAttempts = this.retryOptions.maxAttempts ?? DEFAULT_RETRY_OPTS.maxAttempts
+    return retryOnBadResponse(request, retryAttempts)
+  }
+
 
   async ensureLoggedIn(): Promise<void> {
     if (!this.isLoggedIn) {
       await loginFromCredentialsAndReturnOrgId(this.conn, this.credentials)
       this.isLoggedIn = true
     }
-  }
-
-  private retryOnBadResponse<T extends object>(request: () => Promise<T>): Promise<T> {
-    const retryAttempts = this.retryOptions.maxAttempts ?? DEFAULT_RETRY_OPTS.maxAttempts
-    const requestWithRetry = async (attempts: number): Promise<T> => {
-      let res: T
-      try {
-        res = await request()
-      } catch (e) {
-        log.warn(`caught exception: ${e.message}. ${attempts} retry attempts left from ${retryAttempts} in total`)
-        if (attempts > 1 && errorMessagesToRetry.some(message => e.message.includes(message))) {
-          log.warn('Encountered invalid result from salesforce, error message: %s, will retry %d more times', e.message, attempts - 1)
-          return requestWithRetry(attempts - 1)
-        }
-        throw e
-      }
-
-      if (typeof res === 'string') {
-        log.warn('Received string when expected object, attempting the json parse the received string')
-
-        try {
-          return JSON.parse(res)
-        } catch (e) {
-          log.warn('Received string that is not json parsable when expected object. Retries left %d', attempts - 1)
-          if (attempts > 1) {
-            return requestWithRetry(attempts - 1)
-          }
-          throw e
-        }
-      }
-
-      return res
-    }
-    return requestWithRetry(retryAttempts)
   }
 
   @throttle<ClientRateLimitConfig>({ bucketName: 'query' })

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -381,7 +381,6 @@ const retryOnBadResponse = async <T extends object>(
     try {
       res = await request()
     } catch (e) {
-      log.warn('salesforce request failed with the following: "%o"', e)
       log.warn(`caught exception: ${e.message}. ${attempts} retry attempts left from ${retryAttempts} in total`)
       if (attempts > 1 && errorMessagesToRetry.some(message => e.message.includes(message))) {
         log.warn('Encountered invalid result from salesforce, error message: %s, will retry %d more times', e.message, attempts - 1)


### PR DESCRIPTION
added retry on another sf endpoint. We were missing a retry which caused some fetches to fail.

---

None.

---
_Release Notes_: 
Stabilize salesforce fetch on sporadic failures

---
_User Notifications_: 
None.
