### PR TITLE
SALTO-3267: Change Zendesk login from subdomain to URL

### DIFF
--- a/packages/zendesk-adapter/README.md
+++ b/packages/zendesk-adapter/README.md
@@ -15,7 +15,7 @@ Salto supports authenticating with Zendesk using either a combination of user-na
   - Client ID of the OAuth Client
   - The generated Client Secret
   - The Port you provided in the redirect URL
-  - Your Zendesk account subdomain.
+  - Your Zendesk account base URL
 
 ## Known limitations
 * Sunshine APIs (including custom objects) are not yet supported. Please reach out if interested.

--- a/packages/zendesk-adapter/e2e_test/credentials_store/adapter.ts
+++ b/packages/zendesk-adapter/e2e_test/credentials_store/adapter.ts
@@ -22,6 +22,7 @@ type Args = {
   username: string
   password: string
   subdomain: string
+  baseUrl: string
 }
 
 const adapter: Adapter<Args, Credentials> = {
@@ -37,13 +38,17 @@ const adapter: Adapter<Args, Credentials> = {
     },
     subdomain: {
       type: 'string',
-      demand: true,
+      demand: false,
+    },
+    baseUrl: {
+      type: 'string',
+      demand: false,
     },
   },
   credentials: async args => ({
     username: args.username,
     password: args.password,
-    baseUrl: args.subdomain,
+    baseUrl: args.baseUrl ?? `https://${args.subdomain}.zendesk.com`,
   }),
   validateCredentials: async credentials => {
     await clientUtils.validateCredentials(credentials, { createConnection })

--- a/packages/zendesk-adapter/e2e_test/credentials_store/adapter.ts
+++ b/packages/zendesk-adapter/e2e_test/credentials_store/adapter.ts
@@ -43,7 +43,7 @@ const adapter: Adapter<Args, Credentials> = {
   credentials: async args => ({
     username: args.username,
     password: args.password,
-    subdomain: args.subdomain,
+    baseUrl: args.subdomain,
   }),
   validateCredentials: async credentials => {
     await clientUtils.validateCredentials(credentials, { createConnection })

--- a/packages/zendesk-adapter/e2e_test/jest_environment.ts
+++ b/packages/zendesk-adapter/e2e_test/jest_environment.ts
@@ -29,6 +29,7 @@ CredsSpec<Required<UsernamePasswordCredentials>> => {
   const userNameEnvVarName = addEnvName('ZENDESK_USERNAME')
   const passwordEnvVarName = addEnvName('ZENDESK_PASSWORD')
   const subdomainEnvVarName = addEnvName('ZENDESK_SUBDOMAIN')
+  const baseUrlEnvVarName = addEnvName('ZENDESK_URL')
   return {
     envHasCreds: env => userNameEnvVarName in env,
     fromEnv: env => {
@@ -36,7 +37,8 @@ CredsSpec<Required<UsernamePasswordCredentials>> => {
       return {
         username: envUtils.required(userNameEnvVarName),
         password: envUtils.required(passwordEnvVarName),
-        baseUrl: envUtils.required(subdomainEnvVarName),
+        subdomain: envUtils.required(subdomainEnvVarName),
+        baseUrl: envUtils.required(baseUrlEnvVarName),
       }
     },
     validate: async (_creds: UsernamePasswordCredentials): Promise<void> => {

--- a/packages/zendesk-adapter/e2e_test/jest_environment.ts
+++ b/packages/zendesk-adapter/e2e_test/jest_environment.ts
@@ -36,7 +36,7 @@ CredsSpec<Required<UsernamePasswordCredentials>> => {
       return {
         username: envUtils.required(userNameEnvVarName),
         password: envUtils.required(passwordEnvVarName),
-        subdomain: envUtils.required(subdomainEnvVarName),
+        baseUrl: envUtils.required(subdomainEnvVarName),
       }
     },
     validate: async (_creds: UsernamePasswordCredentials): Promise<void> => {

--- a/packages/zendesk-adapter/specific-cli-options.md
+++ b/packages/zendesk-adapter/specific-cli-options.md
@@ -4,9 +4,9 @@
 Supprted parameters are:
 * `username`
 * `password`
-* `subdomain`
+* `baseUrl` - e.g. https://\<mysubdomain\>.zendesk.com/
 
 ### Example
 ```
-salto account add zendesk --login-parameters username=SomeUsername password=SomePasswd subdomain=SomeSubdomain
+salto account add zendesk --login-parameters username=SomeUsername password=SomePasswd baseUrl=https://someSubDomain.zendesk.com/
 ```

--- a/packages/zendesk-adapter/src/auth.ts
+++ b/packages/zendesk-adapter/src/auth.ts
@@ -20,18 +20,18 @@ import * as constants from './constants'
 export type UsernamePasswordCredentials = {
   username: string
   password: string
-  subdomain: string
+  baseUrl: string
 }
 
 export type OauthAccessTokenCredentials = {
   accessToken: string
-  subdomain: string
+  baseUrl: string
 }
 
 export type OauthRequestParameters = {
   clientId: string
   port: number
-  subdomain: string
+  baseUrl: string
 }
 
 export const usernamePasswordCredentialsType = createMatchingObjectType<
@@ -47,11 +47,11 @@ export const usernamePasswordCredentialsType = createMatchingObjectType<
       refType: BuiltinTypes.STRING,
       annotations: { _required: true },
     },
-    subdomain: {
+    baseUrl: {
       refType: BuiltinTypes.STRING,
       annotations: {
         _required: true,
-        message: 'subdomain (https://<your subdomain>.zendesk.com)',
+        message: 'Base URL (https://<your-subdomain>.zendesk.com/)',
       },
     },
   },
@@ -66,11 +66,11 @@ export const oauthAccessTokenCredentialsType = createMatchingObjectType<
       refType: BuiltinTypes.STRING,
       annotations: { _required: true },
     },
-    subdomain: {
+    baseUrl: {
       refType: BuiltinTypes.STRING,
       annotations: {
         _required: true,
-        message: 'subdomain (https://<your subdomain>.zendesk.com)',
+        message: 'Base URL (https://<your-subdomain>.zendesk.com/)',
       },
     },
   },
@@ -95,11 +95,11 @@ export const oauthRequestParametersType = createMatchingObjectType<
         _required: true,
       },
     },
-    subdomain: {
+    baseUrl: {
       refType: BuiltinTypes.STRING,
       annotations: {
-        message: 'subdomain',
         _required: true,
+        message: 'Base URL (https://<your-subdomain>.zendesk.com/)',
       },
     },
   },

--- a/packages/zendesk-adapter/src/auth.ts
+++ b/packages/zendesk-adapter/src/auth.ts
@@ -20,17 +20,20 @@ import * as constants from './constants'
 export type UsernamePasswordCredentials = {
   username: string
   password: string
+  subdomain?: string
   baseUrl: string
 }
 
 export type OauthAccessTokenCredentials = {
   accessToken: string
+  subdomain?: string
   baseUrl: string
 }
 
 export type OauthRequestParameters = {
   clientId: string
   port: number
+  subdomain?: string
   baseUrl: string
 }
 
@@ -47,11 +50,18 @@ export const usernamePasswordCredentialsType = createMatchingObjectType<
       refType: BuiltinTypes.STRING,
       annotations: { _required: true },
     },
+    subdomain: {
+      refType: BuiltinTypes.STRING,
+      annotations: {
+        _required: false,
+        message: 'subdomain (https://<your-subdomain>.zendesk.com)',
+      },
+    },
     baseUrl: {
       refType: BuiltinTypes.STRING,
       annotations: {
         _required: true,
-        message: 'Base URL (https://<your-subdomain>.zendesk.com/)',
+        message: 'Base URL (https://<your-subdomain>.zendesk.com)',
       },
     },
   },
@@ -66,11 +76,18 @@ export const oauthAccessTokenCredentialsType = createMatchingObjectType<
       refType: BuiltinTypes.STRING,
       annotations: { _required: true },
     },
+    subdomain: {
+      refType: BuiltinTypes.STRING,
+      annotations: {
+        _required: false,
+        message: 'subdomain (https://<your-subdomain>.zendesk.com)',
+      },
+    },
     baseUrl: {
       refType: BuiltinTypes.STRING,
       annotations: {
         _required: true,
-        message: 'Base URL (https://<your-subdomain>.zendesk.com/)',
+        message: 'Base URL (https://<your-subdomain>.zendesk.com)',
       },
     },
   },
@@ -93,6 +110,13 @@ export const oauthRequestParametersType = createMatchingObjectType<
       annotations: {
         message: 'Port',
         _required: true,
+      },
+    },
+    subdomain: {
+      refType: BuiltinTypes.STRING,
+      annotations: {
+        _required: false,
+        message: 'subdomain (https://<your-subdomain>.zendesk.com)',
       },
     },
     baseUrl: {

--- a/packages/zendesk-adapter/src/client/client.ts
+++ b/packages/zendesk-adapter/src/client/client.ts
@@ -18,7 +18,7 @@ import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { logger } from '@salto-io/logging'
 import { values } from '@salto-io/lowerdash'
-import { createConnection, createResourceConnection, instanceUrl } from './connection'
+import { createConnection, createResourceConnection } from './connection'
 import { ZENDESK } from '../constants'
 import { Credentials } from '../auth'
 
@@ -71,7 +71,7 @@ export default class ZendeskClient extends clientUtils.AdapterHTTPClient<
   }
 
   public getUrl(): URL {
-    return new URL(instanceUrl(this.credentials.subdomain))
+    return new URL(this.credentials.baseUrl)
   }
 
   public async getSinglePage(

--- a/packages/zendesk-adapter/test/change_validator.test.ts
+++ b/packages/zendesk-adapter/test/change_validator.test.ts
@@ -20,7 +20,7 @@ import { ZENDESK } from '../src/constants'
 import ZendeskClient from '../src/client/client'
 
 describe('change validator creator', () => {
-  const client = new ZendeskClient({ credentials: { username: 'a', password: 'b', subdomain: 'ignore' } })
+  const client = new ZendeskClient({ credentials: { username: 'a', password: 'b', baseUrl: 'https://ignore.zendesk.com' } })
   describe('deployNotSupportedValidator', () => {
     it('should not fail if there are no deploy changes', async () => {
       expect(await createChangeValidator({

--- a/packages/zendesk-adapter/test/change_validators/guide_creation_or_removal.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/guide_creation_or_removal.test.ts
@@ -25,7 +25,7 @@ describe('helpCenterCreationOrRemovalValidator', () => {
     credentials: {
       username: 'a',
       password: 'b',
-      subdomain: 'ignore',
+      baseUrl: 'https://ignore.zendesk.com',
     },
   })
   const config = _.cloneDeep(DEFAULT_CONFIG[API_DEFINITIONS_CONFIG])

--- a/packages/zendesk-adapter/test/change_validators/target.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/target.test.ts
@@ -21,7 +21,7 @@ import ZendeskClient from '../../src/client/client'
 import { API_DEFINITIONS_CONFIG, DEFAULT_CONFIG } from '../../src/config'
 
 describe('targetAuthDataValidator', () => {
-  const client = new ZendeskClient({ credentials: { username: 'a', password: 'b', subdomain: 'ignore' } })
+  const client = new ZendeskClient({ credentials: { username: 'a', password: 'b', baseUrl: 'https://ignore.zendesk.com' } })
   const config = _.cloneDeep(DEFAULT_CONFIG[API_DEFINITIONS_CONFIG])
   const changeValidator = targetAuthDataValidator(client, config)
 

--- a/packages/zendesk-adapter/test/change_validators/webhook.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/webhook.test.ts
@@ -20,7 +20,7 @@ import { WEBHOOK_TYPE_NAME } from '../../src/filters/webhook'
 import ZendeskClient from '../../src/client/client'
 
 describe('webhookAuthDataValidator', () => {
-  const client = new ZendeskClient({ credentials: { username: 'a', password: 'b', subdomain: 'ignore' } })
+  const client = new ZendeskClient({ credentials: { username: 'a', password: 'b', baseUrl: 'https://ignore.zendesk.com' } })
   const changeValidator = webhookAuthDataValidator(client)
 
   const webhookType = new ObjectType({

--- a/packages/zendesk-adapter/test/client/client.test.ts
+++ b/packages/zendesk-adapter/test/client/client.test.ts
@@ -23,7 +23,7 @@ describe('client', () => {
     let client: ZendeskClient
     beforeEach(() => {
       mockAxios = new MockAdapter(axios)
-      client = new ZendeskClient({ credentials: { username: 'a', password: 'b', subdomain: 'ignore' } })
+      client = new ZendeskClient({ credentials: { username: 'a', password: 'b', baseUrl: 'https://ignore.zendesk.com' } })
     })
 
     afterEach(() => {

--- a/packages/zendesk-adapter/test/client/connection.test.ts
+++ b/packages/zendesk-adapter/test/client/connection.test.ts
@@ -33,7 +33,7 @@ describe('client connection', () => {
       mockAxiosAdapter
         .onGet('/api/v2/account/settings').reply(200, { settings: {} })
         .onGet('/api/v2/a/b').reply(200, { something: 'bla' })
-      const apiConn = await conn.login({ username: 'user123', password: 'pwd456', subdomain: 'abc' })
+      const apiConn = await conn.login({ username: 'user123', password: 'pwd456', baseUrl: 'abc' })
       expect(apiConn.accountId).toEqual('abc')
       expect(mockAxiosAdapter.history.get.length).toBe(1)
 
@@ -53,7 +53,7 @@ describe('client connection', () => {
       const conn = createConnection({ retries: 3 })
       mockAxiosAdapter
         .onGet('/api/v2/account/settings').reply(403)
-      await expect(() => conn.login({ username: 'user123', password: 'pwd456', subdomain: 'abc' })).rejects.toThrow('Unauthorized - update credentials and try again')
+      await expect(() => conn.login({ username: 'user123', password: 'pwd456', baseUrl: 'abc' })).rejects.toThrow('Unauthorized - update credentials and try again')
     })
   })
 })

--- a/packages/zendesk-adapter/test/filters/app.test.ts
+++ b/packages/zendesk-adapter/test/filters/app.test.ts
@@ -52,7 +52,7 @@ describe('app installation filter', () => {
   beforeEach(async () => {
     jest.clearAllMocks()
     client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
+      credentials: { username: 'a', password: 'b', baseUrl: 'ignore' },
     })
     filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })

--- a/packages/zendesk-adapter/test/filters/article/article.test.ts
+++ b/packages/zendesk-adapter/test/filters/article/article.test.ts
@@ -194,7 +194,7 @@ describe('article filter', () => {
   beforeEach(async () => {
     jest.clearAllMocks()
     client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
+      credentials: { username: 'a', password: 'b', baseUrl: 'https://ignore.zendesk.com' },
     })
     const elementsSource = buildElementsSourceFromElements([
       userSegmentType,

--- a/packages/zendesk-adapter/test/filters/article/utils.test.ts
+++ b/packages/zendesk-adapter/test/filters/article/utils.test.ts
@@ -122,7 +122,7 @@ describe('article utility functions', () => {
   beforeEach(async () => {
     jest.clearAllMocks()
     client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
+      credentials: { username: 'a', password: 'b', baseUrl: 'https://ignore.zendesk.com' },
     })
   })
 

--- a/packages/zendesk-adapter/test/filters/brand_logo.test.ts
+++ b/packages/zendesk-adapter/test/filters/brand_logo.test.ts
@@ -49,7 +49,7 @@ describe('brand logo filter', () => {
   beforeEach(async () => {
     jest.clearAllMocks()
     client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
+      credentials: { username: 'a', password: 'b', baseUrl: 'https://ignore.zendesk.com' },
     })
     filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })

--- a/packages/zendesk-adapter/test/filters/business_hours_schedule.test.ts
+++ b/packages/zendesk-adapter/test/filters/business_hours_schedule.test.ts
@@ -53,7 +53,7 @@ describe('business hours schedule filter', () => {
   beforeEach(async () => {
     jest.clearAllMocks()
     client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
+      credentials: { username: 'a', password: 'b', baseUrl: 'https://ignore.zendesk.com' },
     })
     filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })

--- a/packages/zendesk-adapter/test/filters/everyone_user_segment.test.ts
+++ b/packages/zendesk-adapter/test/filters/everyone_user_segment.test.ts
@@ -36,7 +36,7 @@ describe('everyoneUserSegment filter', () => {
   beforeEach(async () => {
     jest.clearAllMocks()
     client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'brandWithHC' },
+      credentials: { username: 'a', password: 'b', baseUrl: 'https://brandWithHC.zendesk.com' },
     })
     filter = filterCreator(createFilterCreatorParams({
       client,

--- a/packages/zendesk-adapter/test/filters/guide_arrange_paths.test.ts
+++ b/packages/zendesk-adapter/test/filters/guide_arrange_paths.test.ts
@@ -215,7 +215,7 @@ describe('guide arrange paths', () => {
 
   beforeEach(async () => {
     client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'brandWithHC' },
+      credentials: { username: 'a', password: 'b', baseUrl: 'https://brandWithHC.zendesk.com' },
     })
     filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })

--- a/packages/zendesk-adapter/test/filters/guide_default_language_settings.test.ts
+++ b/packages/zendesk-adapter/test/filters/guide_default_language_settings.test.ts
@@ -45,7 +45,7 @@ const createSettings = (name: string, locale: string, brand: InstanceElement): I
 const defaultSettings1 = createSettings('default', 'def', brand1)
 const defaultSettings2 = createSettings('default2', 'def', brand2)
 
-const client = new ZendeskClient({ credentials: { username: 'a', password: 'b', subdomain: 'ignore' } })
+const client = new ZendeskClient({ credentials: { username: 'a', password: 'b', baseUrl: 'https://ignore.zendesk.com' } })
 client.put = jest.fn()
 client.post = jest.fn()
 client.delete = jest.fn()

--- a/packages/zendesk-adapter/test/filters/guide_guide_settings.test.ts
+++ b/packages/zendesk-adapter/test/filters/guide_guide_settings.test.ts
@@ -72,7 +72,7 @@ describe('guide_settings filter', () => {
 
   beforeEach(async () => {
     client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'brandWithHC' },
+      credentials: { username: 'a', password: 'b', baseUrl: 'https://brandWithHC.zendesk.com' },
     })
     filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })

--- a/packages/zendesk-adapter/test/filters/guide_orders.test.ts
+++ b/packages/zendesk-adapter/test/filters/guide_orders.test.ts
@@ -27,7 +27,7 @@ import ZendeskClient from '../../src/client/client'
 const { createUrl } = elementsUtils
 
 const client = new ZendeskClient({
-  credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
+  credentials: { username: 'a', password: 'b', baseUrl: 'https://ignore.zendesk.com' },
 })
 client.put = jest.fn()
 

--- a/packages/zendesk-adapter/test/filters/guide_service_url.test.ts
+++ b/packages/zendesk-adapter/test/filters/guide_service_url.test.ts
@@ -154,7 +154,7 @@ describe('guide service_url filter', () => {
 
   beforeEach(async () => {
     client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'brandWithHC' },
+      credentials: { username: 'a', password: 'b', baseUrl: 'https://brandWithHC.zendesk.com' },
     })
     filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })

--- a/packages/zendesk-adapter/test/filters/handle_app_installations.test.ts
+++ b/packages/zendesk-adapter/test/filters/handle_app_installations.test.ts
@@ -30,7 +30,7 @@ describe('handle app installations filter', () => {
 
   beforeAll(() => {
     client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'c' },
+      credentials: { username: 'a', password: 'b', baseUrl: 'https://c.zendesk.com' },
     })
   })
 

--- a/packages/zendesk-adapter/test/filters/macro_attachments.test.ts
+++ b/packages/zendesk-adapter/test/filters/macro_attachments.test.ts
@@ -58,7 +58,7 @@ describe('macro attachment filter', () => {
   beforeEach(async () => {
     jest.clearAllMocks()
     client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
+      credentials: { username: 'a', password: 'b', baseUrl: 'https://ignore.zendesk.com' },
     })
     filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })

--- a/packages/zendesk-adapter/test/utils.ts
+++ b/packages/zendesk-adapter/test/utils.ts
@@ -33,7 +33,7 @@ type FilterCreatorParams = {
 
 export const createFilterCreatorParams = ({
   client = new ZendeskClient({
-    credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
+    credentials: { username: 'a', password: 'b', baseUrl: 'https://ignore.zendesk.com' },
   }),
   paginator = clientUtils.createPaginator({
     client,


### PR DESCRIPTION
To allow custom domains when connecting a Zendesk account, we are replacing subdomain with baseUrl as we do in Jira, Okta, etc

---

_Additional context for reviewer_

This is the first PR in the process of replacing `subdomain` to `baseUrl` in Zendesk
For now the open source will be able to receive both `subdomain` or `baseUrl` from the credentials config file

---
_Release Notes_: 

Zendesk
- When connecting a new Zendesk application via CLI, user will be asked to provide the account's url instead of subdomain

---
_User Notifications_: 
None
