### PR TITLE
SALTO-3254 rename ids inside template expressions

### DIFF
--- a/packages/adapter-components/src/filters/referenced_instance_names.ts
+++ b/packages/adapter-components/src/filters/referenced_instance_names.ts
@@ -202,13 +202,11 @@ const updateAllReferences = ({
   instanceOriginalName,
   nameToInstance,
   newElemId,
-  oldElemId,
 }:{
   referenceIndex: Record<string, { path: ElemID; value: ReferenceExpression }[]>
   instanceOriginalName: string
   nameToInstance: Record<string, Element>
   newElemId: ElemID
-  oldElemId: ElemID
 }): void => {
   const referencesToChange = referenceIndex[instanceOriginalName]
   if (referencesToChange === undefined || referencesToChange.length === 0) {
@@ -236,7 +234,7 @@ const updateAllReferences = ({
           // update only the relevant parts
           const updatedTemplate = createTemplateExpression({
             parts: oldValue.parts
-              .map(part => ((isReferenceExpression(part) && part.elemID.isEqual(oldElemId))
+              .map(part => ((isReferenceExpression(part) && part.elemID.getFullName() === instanceOriginalName)
                 ? updatedReference
                 : part
               ))
@@ -369,7 +367,6 @@ export const addReferencesToInstanceNames = async (
           instanceOriginalName: originalFullName,
           nameToInstance,
           newElemId: newInstance.elemID,
-          oldElemId: instance.elemID,
         })
 
         if (nameToInstance[originalFullName] !== undefined) {

--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -187,11 +187,10 @@ export const DEFAULT_FILTERS = [
   // unorderedListsFilter should run after fieldReferencesFilter
   unorderedListsFilter,
   dynamicContentReferencesFilter,
+  articleBodyFilter,
   guideParentSection,
   serviceUrlFilter,
   ...Object.values(commonFilters),
-  // articleBodyFilter should run after referencedInstanceNames (which is part of the common filters)
-  articleBodyFilter,
   handleAppInstallationsFilter,
   handleTemplateExpressionFilter,
   collisionErrorsFilter, // needs to be after referencedIdFieldsFilter (which is part of the common filters)

--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -187,10 +187,10 @@ export const DEFAULT_FILTERS = [
   // unorderedListsFilter should run after fieldReferencesFilter
   unorderedListsFilter,
   dynamicContentReferencesFilter,
-  articleBodyFilter,
   guideParentSection,
   serviceUrlFilter,
   ...Object.values(commonFilters),
+  articleBodyFilter,
   handleAppInstallationsFilter,
   handleTemplateExpressionFilter,
   collisionErrorsFilter, // needs to be after referencedIdFieldsFilter (which is part of the common filters)


### PR DESCRIPTION
Looks like any template expressions created before the rename filter is run are not updated.

---
_Release Notes_: 
None (no impact on users)

---
_User Notifications_: 
None