### PR TITLE
SALTO-3257 set deprecated flags to false

### DIFF
--- a/packages/zendesk-adapter/e2e_test/mock_elements.ts
+++ b/packages/zendesk-adapter/e2e_test/mock_elements.ts
@@ -90,10 +90,11 @@ export const mockDefaultValues: Record<string, Values> = {
       user_view_access: 'full',
       voice_dashboard_access: true,
       manage_contextual_workspaces: true,
-      manage_organization_fields: true,
-      manage_ticket_fields: true,
-      manage_ticket_forms: true,
-      manage_user_fields: true,
+      // must be false - see SALTO-3257
+      manage_organization_fields: false,
+      manage_ticket_fields: false,
+      manage_ticket_forms: false,
+      manage_user_fields: false,
     },
   },
   group: {

--- a/packages/zendesk-adapter/e2e_test/mock_elements.ts
+++ b/packages/zendesk-adapter/e2e_test/mock_elements.ts
@@ -89,8 +89,8 @@ export const mockDefaultValues: Record<string, Values> = {
       view_access: 'full',
       user_view_access: 'full',
       voice_dashboard_access: true,
-      manage_contextual_workspaces: true,
       // must be false - see SALTO-3257
+      manage_contextual_workspaces: false,
       manage_organization_fields: false,
       manage_ticket_fields: false,
       manage_ticket_forms: false,


### PR DESCRIPTION
Seems the flags are either getting deprecated or temporarily disabled, and this is causing e2e failures (cc @edenhassid who found this)


---
_Release Notes_: 
None

---
_User Notifications_: 
None