### PR TITLE
SALTO-2632: Avoid possible type conflicts upon partial fetch

### DIFF
--- a/packages/salesforce-adapter/src/fetch_profile/metadata_query.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/metadata_query.ts
@@ -42,6 +42,8 @@ const PERMANENT_SKIP_LIST: MetadataQueryParams[] = [
   // (AssignmentRules and EscalationRules)
   { metadataType: 'AssignmentRule' },
   { metadataType: 'EscalationRule' },
+  // May conflict with the MetadataType ForecastingCategoryMapping
+  { metadataType: 'CustomObject', name: 'ForecastingCategoryMapping' },
 ]
 
 // Instances of these types will match all namespaces


### PR DESCRIPTION
Excluding the `ForecastingCategoryMapping` CustomObject instance to avoid possible conflicts with the MetadataType ForecastingCategoryMapping.

---

_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
