### PR TITLE
SALTO-3136 SF - Allow users to user config on checkOnly CV

### DIFF
--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -31,7 +31,7 @@ import {
 import { validateFetchParameters } from './fetch_profile/fetch_profile'
 import { ConfigValidationError } from './config_validation'
 import { updateDeprecatedConfiguration } from './deprecated_config'
-import createChangeValidator, { changeValidators } from './change_validator'
+import createChangeValidator, { changeValidators, checkOnlyChangeValidators } from './change_validator'
 import { getChangeGroupIds } from './group_changes'
 import { ConfigChange } from './config_change'
 import { configCreator } from './config_creator'
@@ -93,7 +93,7 @@ SalesforceConfig => {
       throw new ConfigValidationError(['validators'], 'Enabled validators configuration must be an object if it is defined')
     }
     if (_.isPlainObject(validators)) {
-      const validValidatorsNames = Object.keys(changeValidators)
+      const validValidatorsNames = Object.keys({ ...changeValidators, ...checkOnlyChangeValidators })
       Object.entries(validators as {}).forEach(([key, value]) => {
         if (!validValidatorsNames.includes(key)) {
           throw new ConfigValidationError(['validators', key], `Validator ${key} does not exist, expected one of ${validValidatorsNames.join(',')}`)

--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -31,7 +31,7 @@ import {
 import { validateFetchParameters } from './fetch_profile/fetch_profile'
 import { ConfigValidationError } from './config_validation'
 import { updateDeprecatedConfiguration } from './deprecated_config'
-import createChangeValidator, { changeValidators, checkOnlyChangeValidators } from './change_validator'
+import createChangeValidator, { changeValidators, validationChangeValidators } from './change_validator'
 import { getChangeGroupIds } from './group_changes'
 import { ConfigChange } from './config_change'
 import { configCreator } from './config_creator'
@@ -93,7 +93,7 @@ SalesforceConfig => {
       throw new ConfigValidationError(['validators'], 'Enabled validators configuration must be an object if it is defined')
     }
     if (_.isPlainObject(validators)) {
-      const validValidatorsNames = Object.keys({ ...changeValidators, ...checkOnlyChangeValidators })
+      const validValidatorsNames = Object.keys({ ...changeValidators, ...validationChangeValidators })
       Object.entries(validators as {}).forEach(([key, value]) => {
         if (!validValidatorsNames.includes(key)) {
           throw new ConfigValidationError(['validators', key], `Validator ${key} does not exist, expected one of ${validValidatorsNames.join(',')}`)

--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -31,7 +31,7 @@ import {
 import { validateFetchParameters } from './fetch_profile/fetch_profile'
 import { ConfigValidationError } from './config_validation'
 import { updateDeprecatedConfiguration } from './deprecated_config'
-import createChangeValidator, { changeValidators, validationChangeValidators } from './change_validator'
+import createChangeValidator, { changeValidators } from './change_validator'
 import { getChangeGroupIds } from './group_changes'
 import { ConfigChange } from './config_change'
 import { configCreator } from './config_creator'
@@ -93,7 +93,7 @@ SalesforceConfig => {
       throw new ConfigValidationError(['validators'], 'Enabled validators configuration must be an object if it is defined')
     }
     if (_.isPlainObject(validators)) {
-      const validValidatorsNames = Object.keys({ ...changeValidators, ...validationChangeValidators })
+      const validValidatorsNames = Object.keys(changeValidators)
       Object.entries(validators as {}).forEach(([key, value]) => {
         if (!validValidatorsNames.includes(key)) {
           throw new ConfigValidationError(['validators', key], `Validator ${key} does not exist, expected one of ${validValidatorsNames.join(',')}`)

--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -34,33 +34,37 @@ import fullNameChangedValidator from './change_validators/fullname_changed'
 import invalidListViewFilterScope from './change_validators/invalid_listview_filterscope'
 import caseAssignmentRulesValidator from './change_validators/case_assignmentRules'
 
-import { ChangeValidatorName, CheckOnlyChangeValidatorName, SalesforceConfig } from './types'
+import { ChangeValidatorName, SalesforceConfig } from './types'
 
 type ChangeValidatorCreator = (config: SalesforceConfig, isSandbox: boolean) => ChangeValidator
-export const changeValidators: Record<ChangeValidatorName, ChangeValidatorCreator> = {
-  managedPackage: () => packageValidator,
-  picklistStandardField: () => picklistStandardFieldValidator,
-  customObjectInstances: () => customObjectInstancesValidator,
-  unknownField: () => unknownFieldValidator,
-  customFieldType: () => customFieldTypeValidator,
-  standardFieldLabel: () => standardFieldLabelValidator,
-  mapKeys: () => mapKeysValidator,
-  multipleDefaults: () => multipleDefaultsValidator,
-  picklistPromote: () => picklistPromoteValidator,
-  cpqValidator: () => cpqValidator,
-  sbaaApprovalRulesCustomCondition: () => sbaaApprovalRulesCustomCondition,
-  recordTypeDeletion: () => recordTypeDeletionValidator,
-  flowsValidator: (config, isSandbox) => flowsValidator(config, isSandbox),
-  fullNameChangedValidator: () => fullNameChangedValidator,
-  invalidListViewFilterScope: () => invalidListViewFilterScope,
-  caseAssignmentRulesValidator: () => caseAssignmentRulesValidator,
+
+type ChangeValidatorDefinition = {
+  creator: ChangeValidatorCreator
+  defaultInDeploy: boolean
+  defaultInValidate: boolean
 }
 
-export const validationChangeValidators
-  : Record<CheckOnlyChangeValidatorName, ChangeValidatorCreator> = {
-    omitData: omitDataValidator,
-  }
+const defaultAlwaysRun = { defaultInDeploy: true, defaultInValidate: true }
 
+export const changeValidators: Record<ChangeValidatorName, ChangeValidatorDefinition> = {
+  managedPackage: { creator: () => packageValidator, ...defaultAlwaysRun },
+  picklistStandardField: { creator: () => picklistStandardFieldValidator, ...defaultAlwaysRun },
+  customObjectInstances: { creator: () => customObjectInstancesValidator, ...defaultAlwaysRun },
+  unknownField: { creator: () => unknownFieldValidator, ...defaultAlwaysRun },
+  customFieldType: { creator: () => customFieldTypeValidator, ...defaultAlwaysRun },
+  standardFieldLabel: { creator: () => standardFieldLabelValidator, ...defaultAlwaysRun },
+  mapKeys: { creator: () => mapKeysValidator, ...defaultAlwaysRun },
+  multipleDefaults: { creator: () => multipleDefaultsValidator, ...defaultAlwaysRun },
+  picklistPromote: { creator: () => picklistPromoteValidator, ...defaultAlwaysRun },
+  cpqValidator: { creator: () => cpqValidator, ...defaultAlwaysRun },
+  sbaaApprovalRulesCustomCondition: { creator: () => sbaaApprovalRulesCustomCondition, ...defaultAlwaysRun },
+  recordTypeDeletion: { creator: () => recordTypeDeletionValidator, ...defaultAlwaysRun },
+  flowsValidator: { creator: (config, isSandbox) => flowsValidator(config, isSandbox), ...defaultAlwaysRun },
+  fullNameChangedValidator: { creator: () => fullNameChangedValidator, ...defaultAlwaysRun },
+  invalidListViewFilterScope: { creator: () => invalidListViewFilterScope, ...defaultAlwaysRun },
+  caseAssignmentRulesValidator: { creator: () => caseAssignmentRulesValidator, ...defaultAlwaysRun },
+  omitData: { creator: omitDataValidator, defaultInDeploy: false, defaultInValidate: true },
+}
 
 const createSalesforceChangeValidator = ({ config, isSandbox, checkOnly }: {
   config: SalesforceConfig
@@ -68,18 +72,14 @@ const createSalesforceChangeValidator = ({ config, isSandbox, checkOnly }: {
   checkOnly: boolean
 }): ChangeValidator => {
   const isCheckOnly = checkOnly || (config.client?.deploy?.checkOnly ?? false)
-  // SALTO-2700: Separate Validators
-  const possibleValidationChangeValidators = isCheckOnly ? Object.entries(validationChangeValidators)
-    : Object.entries(validationChangeValidators).filter(
-      ([name]) => config.validators?.[name as ChangeValidatorName] !== undefined
-    )
   const [activeValidators, disabledValidators] = _.partition(
-    [...Object.entries(changeValidators), ...possibleValidationChangeValidators],
-    ([name]) => config.validators?.[name as ChangeValidatorName] ?? true,
+    Object.entries(changeValidators),
+    ([name, defenition]) => config.validators?.[name as ChangeValidatorName]
+        ?? (isCheckOnly ? defenition.defaultInValidate : defenition.defaultInDeploy),
   )
   return createChangeValidator(
-    activeValidators.map(([_name, validator]) => validator(config, isSandbox)),
-    disabledValidators.map(([_name, validator]) => validator(config, isSandbox)),
+    activeValidators.map(([_name, validator]) => validator.creator(config, isSandbox)),
+    disabledValidators.map(([_name, validator]) => validator.creator(config, isSandbox)),
   )
 }
 export default createSalesforceChangeValidator

--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -13,7 +13,6 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import _ from 'lodash'
 import { ChangeValidator } from '@salto-io/adapter-api'
 import { createChangeValidator } from '@salto-io/adapter-utils'
 import packageValidator from './change_validators/package'

--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -72,10 +72,12 @@ const createSalesforceChangeValidator = ({ config, isSandbox, checkOnly }: {
   checkOnly: boolean
 }): ChangeValidator => {
   const isCheckOnly = checkOnly || (config.client?.deploy?.checkOnly ?? false)
-  const [activeValidators, disabledValidators] = _.partition(
-    Object.entries(changeValidators),
-    ([name, defenition]) => config.validators?.[name as ChangeValidatorName]
-        ?? (isCheckOnly ? defenition.defaultInValidate : defenition.defaultInDeploy),
+  const activeValidators = Object.entries(changeValidators).filter(
+    ([name, definition]) => config.validators?.[name as ChangeValidatorName]
+          ?? (isCheckOnly ? definition.defaultInValidate : definition.defaultInDeploy)
+  )
+  const disabledValidators = Object.entries(changeValidators).filter(
+    ([name]) => config.validators?.[name as ChangeValidatorName] === false
   )
   return createChangeValidator(
     activeValidators.map(([_name, validator]) => validator.creator(config, isSandbox)),

--- a/packages/salesforce-adapter/src/change_validators/omit_data.ts
+++ b/packages/salesforce-adapter/src/change_validators/omit_data.ts
@@ -30,7 +30,7 @@ const createChangeError = (instanceElemID: ElemID): ChangeError => ({
  * Data (CustomObject instances) is deployed although running in Salesforce validation process
  * (salesforce.client.deploy.checkOnly=true)
  */
-const createCheckOnlyDeployValidator = (): ChangeValidator => (
+const createOmitDataValidator = (): ChangeValidator => (
   async changes => awu(changes)
     .filter(isInstanceOfCustomObjectChange)
     .map(getChangeData)
@@ -38,4 +38,4 @@ const createCheckOnlyDeployValidator = (): ChangeValidator => (
     .toArray()
 )
 
-export default createCheckOnlyDeployValidator
+export default createOmitDataValidator

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -97,7 +97,7 @@ export type ChangeValidatorName = (
   | 'caseAssignmentRulesValidator'
 )
 
-export type CheckOnlyChangeValidatorName = 'checkOnlyDeploy'
+export type CheckOnlyChangeValidatorName = 'omitData'
 
 
 export type ChangeValidatorConfig = Partial<Record<ChangeValidatorName | CheckOnlyChangeValidatorName, boolean>>
@@ -563,7 +563,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     fullNameChangedValidator: { refType: BuiltinTypes.BOOLEAN },
     invalidListViewFilterScope: { refType: BuiltinTypes.BOOLEAN },
     caseAssignmentRulesValidator: { refType: BuiltinTypes.BOOLEAN },
-    checkOnlyDeploy: { refType: BuiltinTypes.BOOLEAN },
+    omitData: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -95,12 +95,10 @@ export type ChangeValidatorName = (
   | 'fullNameChangedValidator'
   | 'invalidListViewFilterScope'
   | 'caseAssignmentRulesValidator'
+  | 'omitData'
 )
 
-export type CheckOnlyChangeValidatorName = 'omitData'
-
-
-export type ChangeValidatorConfig = Partial<Record<ChangeValidatorName | CheckOnlyChangeValidatorName, boolean>>
+export type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
 
 type ObjectIdSettings = {
   objectsRegex: string

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -100,7 +100,7 @@ export type ChangeValidatorName = (
 export type CheckOnlyChangeValidatorName = 'checkOnlyDeploy'
 
 
-export type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
+export type ChangeValidatorConfig = Partial<Record<ChangeValidatorName | CheckOnlyChangeValidatorName, boolean>>
 
 type ObjectIdSettings = {
   objectsRegex: string
@@ -563,6 +563,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     fullNameChangedValidator: { refType: BuiltinTypes.BOOLEAN },
     invalidListViewFilterScope: { refType: BuiltinTypes.BOOLEAN },
     caseAssignmentRulesValidator: { refType: BuiltinTypes.BOOLEAN },
+    checkOnlyDeploy: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/salesforce-adapter/test/change_validator.test.ts
+++ b/packages/salesforce-adapter/test/change_validator.test.ts
@@ -16,7 +16,7 @@
 import _ from 'lodash'
 import { ChangeValidator } from '@salto-io/adapter-api'
 import { createChangeValidator } from '@salto-io/adapter-utils'
-import createSalesforceChangeValidator, { changeValidators, checkOnlyChangeValidators } from '../src/change_validator'
+import createSalesforceChangeValidator, { changeValidators, validationChangeValidators } from '../src/change_validator'
 
 jest.mock('@salto-io/adapter-utils', () => {
   const actual = jest.requireActual('@salto-io/adapter-utils')
@@ -56,7 +56,7 @@ describe('createSalesforceChangeValidator', () => {
         validator = createSalesforceChangeValidator({
           config: { validators:
                 { customFieldType: false,
-                  checkOnlyDeploy: true } },
+                  omitData: true } },
           isSandbox: false,
           checkOnly: false,
         })
@@ -70,8 +70,8 @@ describe('createSalesforceChangeValidator', () => {
           expect.arrayContaining([]), disabledValidators
         )
       })
-      it('should run checkOnlyDeploy CV despite that checkOnly is false', () => {
-        const enabledValidatorsCount = Object.values({ ..._.omit({ ...changeValidators }, 'customFieldType'), ..._.pick({ ...checkOnlyChangeValidators }, 'checkOnlyDeploy') }).length
+      it('should run omitData CV despite that checkOnly is false', () => {
+        const enabledValidatorsCount = Object.values({ ..._.omit({ ...changeValidators }, 'customFieldType'), ..._.pick({ ...validationChangeValidators }, 'omitData') }).length
         expect(createChangeValidatorMock.mock.calls[0][0]).toHaveLength(enabledValidatorsCount)
       })
     })

--- a/packages/salesforce-adapter/test/change_validator.test.ts
+++ b/packages/salesforce-adapter/test/change_validator.test.ts
@@ -62,10 +62,11 @@ describe('createSalesforceChangeValidator', () => {
       it('should create a validator', () => {
         expect(validator).toBeDefined()
       })
-      it('should put the increase the size of thedisabled validator by one', () => {
+      it('should customFieldType in the disabled validator list', () => {
+        const disabledValidators = [changeValidators.customFieldType.creator({}, false,)]
         expect(createChangeValidator).toHaveBeenCalledWith(
           expect.toBeArrayOfSize(Object.values(changeValidators).filter(cv => cv.defaultInDeploy).length - 1),
-          expect.toBeArrayOfSize(Object.values(changeValidators).filter(cv => !cv.defaultInDeploy).length + 1)
+          disabledValidators
         )
       })
     })
@@ -100,7 +101,7 @@ describe('createSalesforceChangeValidator', () => {
           expect(validator).toBeDefined()
           expect(createChangeValidator).toHaveBeenCalledWith(
             expect.toBeArrayOfSize(Object.values(changeValidators).filter(cv => cv.defaultInDeploy).length),
-            expect.toBeArrayOfSize(Object.values(changeValidators).filter(cv => !cv.defaultInDeploy).length)
+            []
           )
         })
       })

--- a/packages/salesforce-adapter/test/change_validators/omit_data.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/omit_data.test.ts
@@ -16,7 +16,7 @@
 import {
   ChangeError, ElemID, InstanceElement, ObjectType, toChange, ChangeValidator,
 } from '@salto-io/adapter-api'
-import createCheckOnlyDeployValidator from '../../src/change_validators/check_only_deploy'
+import createCheckOnlyDeployValidator from '../../src/change_validators/omit_data'
 import { CUSTOM_OBJECT } from '../../src/constants'
 
 describe('checkOnly deploy validator', () => {


### PR DESCRIPTION
_Allow users to user config on checkOnly CV_

---
_Additional context for reviewer_:
None

---
_Release Notes_: 
Salesforce-adapter:

CheckOnly change Validator are now configurable via config overrides
---

_User Notifications_: 
None