### PR TITLE
SALTO-3267: Add domain as optional login param in Zendesk

### DIFF
--- a/packages/cli/src/commands/account.ts
+++ b/packages/cli/src/commands/account.ts
@@ -144,9 +144,10 @@ const getLoginConfig = async (
 const createConfigFromLoginParameters = (loginParameters: string[]) => (
   async (credentialsType: ObjectType): Promise<InstanceElement> => {
     const configValues = Object.fromEntries(loginParameters.map(entryFromRawLoginParameter))
-    const requiredFields = Object.fromEntries(Object.entries(credentialsType.fields)
-      .filter(([_fieldName, field]) => field.annotations[CORE_ANNOTATIONS.REQUIRED] !== false))
-    const missingLoginParameters = Object.keys(requiredFields)
+    const requiredFields = Object.entries(credentialsType.fields)
+      .filter(([_fieldName, field]) => field.annotations[CORE_ANNOTATIONS.REQUIRED] !== false)
+      .map(([fieldName]) => fieldName)
+    const missingLoginParameters = requiredFields
       .filter(key => _.isUndefined(configValues[key]))
     if (!_.isEmpty(missingLoginParameters)) {
       throw new Error(`Missing the following login parameters: ${missingLoginParameters}`)

--- a/packages/cli/src/commands/account.ts
+++ b/packages/cli/src/commands/account.ts
@@ -20,6 +20,7 @@ import {
   InstanceElement,
   OAuthMethod,
   ObjectType,
+  CORE_ANNOTATIONS,
 } from '@salto-io/adapter-api'
 import { EOL } from 'os'
 import {
@@ -143,7 +144,9 @@ const getLoginConfig = async (
 const createConfigFromLoginParameters = (loginParameters: string[]) => (
   async (credentialsType: ObjectType): Promise<InstanceElement> => {
     const configValues = Object.fromEntries(loginParameters.map(entryFromRawLoginParameter))
-    const missingLoginParameters = Object.keys(credentialsType.fields)
+    const requiredFields = Object.fromEntries(Object.entries(credentialsType.fields)
+      .filter(([_fieldName, field]) => field.annotations[CORE_ANNOTATIONS.REQUIRED] !== false))
+    const missingLoginParameters = Object.keys(requiredFields)
       .filter(key => _.isUndefined(configValues[key]))
     if (!_.isEmpty(missingLoginParameters)) {
       throw new Error(`Missing the following login parameters: ${missingLoginParameters}`)

--- a/packages/zendesk-adapter/e2e_test/adapter.ts
+++ b/packages/zendesk-adapter/e2e_test/adapter.ts
@@ -46,4 +46,4 @@ export const realAdapter = (
   return { client, adapter }
 }
 
-export const credsLease = (): Promise<CredsLease<Required<Credentials>>> => creds(credsSpec(), log)
+export const credsLease = (): Promise<CredsLease<Credentials>> => creds(credsSpec(), log)

--- a/packages/zendesk-adapter/e2e_test/jest_environment.ts
+++ b/packages/zendesk-adapter/e2e_test/jest_environment.ts
@@ -37,6 +37,7 @@ CredsSpec<Required<UsernamePasswordCredentials>> => {
         username: envUtils.required(userNameEnvVarName),
         password: envUtils.required(passwordEnvVarName),
         subdomain: envUtils.required(subdomainEnvVarName),
+        domain: 'zendesk',
       }
     },
     validate: async (_creds: UsernamePasswordCredentials): Promise<void> => {

--- a/packages/zendesk-adapter/e2e_test/jest_environment.ts
+++ b/packages/zendesk-adapter/e2e_test/jest_environment.ts
@@ -22,7 +22,7 @@ import { UsernamePasswordCredentials } from '../src/auth'
 const log = logger(module)
 
 export const credsSpec = (envName?: string):
-CredsSpec<Required<UsernamePasswordCredentials>> => {
+CredsSpec<UsernamePasswordCredentials> => {
   const addEnvName = (varName: string): string => (envName === undefined
     ? varName
     : [varName, envName].join('_'))
@@ -37,7 +37,6 @@ CredsSpec<Required<UsernamePasswordCredentials>> => {
         username: envUtils.required(userNameEnvVarName),
         password: envUtils.required(passwordEnvVarName),
         subdomain: envUtils.required(subdomainEnvVarName),
-        domain: 'zendesk.com',
       }
     },
     validate: async (_creds: UsernamePasswordCredentials): Promise<void> => {

--- a/packages/zendesk-adapter/e2e_test/jest_environment.ts
+++ b/packages/zendesk-adapter/e2e_test/jest_environment.ts
@@ -37,7 +37,7 @@ CredsSpec<Required<UsernamePasswordCredentials>> => {
         username: envUtils.required(userNameEnvVarName),
         password: envUtils.required(passwordEnvVarName),
         subdomain: envUtils.required(subdomainEnvVarName),
-        domain: 'zendesk',
+        domain: 'zendesk.com',
       }
     },
     validate: async (_creds: UsernamePasswordCredentials): Promise<void> => {

--- a/packages/zendesk-adapter/specific-cli-options.md
+++ b/packages/zendesk-adapter/specific-cli-options.md
@@ -1,10 +1,11 @@
 # Zendesk CLI options
 
 ## Non interactive Login Parameters
-Supprted parameters are:
+Supported parameters are:
 * `username`
 * `password`
 * `subdomain`
+* `domain` (optional)
 
 ### Example
 ```

--- a/packages/zendesk-adapter/src/adapter_creator.ts
+++ b/packages/zendesk-adapter/src/adapter_creator.ts
@@ -60,7 +60,8 @@ see https://support.zendesk.com/hc/en-us/articles/4408845965210 for more informa
 */
 
 const credentialsFromConfig = (config: Readonly<InstanceElement>): Credentials => {
-  const domain = config.value.domain ? config.value.domain : undefined
+  const domain = config.value.domain === undefined || config.value.domain === ''
+    ? undefined : config.value.domain
   if (config.value.authType === 'oauth') {
     return {
       accessToken: config.value.accessToken,

--- a/packages/zendesk-adapter/src/adapter_creator.ts
+++ b/packages/zendesk-adapter/src/adapter_creator.ts
@@ -61,7 +61,8 @@ see https://support.zendesk.com/hc/en-us/articles/4408845965210 for more informa
 
 const credentialsFromConfig = (config: Readonly<InstanceElement>): Credentials => {
   const domain = config.value.domain === undefined || config.value.domain === ''
-    ? undefined : config.value.domain
+    ? undefined
+    : config.value.domain
   if (config.value.authType === 'oauth') {
     return {
       accessToken: config.value.accessToken,

--- a/packages/zendesk-adapter/src/adapter_creator.ts
+++ b/packages/zendesk-adapter/src/adapter_creator.ts
@@ -31,7 +31,7 @@ import {
   GUIDE_SUPPORTED_TYPES,
 } from './config'
 import ZendeskClient from './client/client'
-import { createConnection } from './client/connection'
+import { createConnection, instanceUrl } from './client/connection'
 import { configCreator } from './config_creator'
 
 const log = logger(module)
@@ -60,22 +60,25 @@ see https://support.zendesk.com/hc/en-us/articles/4408845965210 for more informa
 */
 
 const credentialsFromConfig = (config: Readonly<InstanceElement>): Credentials => {
+  const domain = config.value.domain ? config.value.domain : undefined
   if (config.value.authType === 'oauth') {
     return {
       accessToken: config.value.accessToken,
       subdomain: config.value.subdomain,
+      domain,
     }
   }
   return {
     username: config.value.username,
     password: config.value.password,
     subdomain: config.value.subdomain,
+    domain,
   }
 }
 
 export const createUrlFromUserInput = (value: Values): string => {
-  const { subdomain, port, clientId } = value
-  return `https://${subdomain}.zendesk.com/oauth/authorizations/new?response_type=token&redirect_uri=http://localhost:${port}&client_id=${clientId}&scope=read%20write`
+  const { subdomain, domain, port, clientId } = value
+  return `${instanceUrl(subdomain, domain)}/oauth/authorizations/new?response_type=token&redirect_uri=http://localhost:${port}&client_id=${clientId}&scope=read%20write`
 }
 
 const createOAuthRequest = (userInput: InstanceElement): OAuthRequestParameters => ({
@@ -169,10 +172,11 @@ export const adapter: Adapter = {
       credentialsType: oauthAccessTokenCredentialsType,
       oauthRequestParameters: oauthRequestParametersType,
       createFromOauthResponse: (inputConfig: Values, response: OauthAccessTokenResponse) => {
-        const { subdomain } = inputConfig
+        const { subdomain, domain } = inputConfig
         const { accessToken } = response.fields
         return {
           subdomain,
+          domain,
           accessToken,
         }
       },

--- a/packages/zendesk-adapter/src/auth.ts
+++ b/packages/zendesk-adapter/src/auth.ts
@@ -17,6 +17,9 @@ import { ElemID, BuiltinTypes } from '@salto-io/adapter-api'
 import { createMatchingObjectType } from '@salto-io/adapter-utils'
 import * as constants from './constants'
 
+const SUBDOMAIN_MESSAGE = 'subdomain (https://<your subdomain>.zendesk.com)'
+const DOMAIN_MESSAGE = 'domain (optional) - only fill in if your account is not under zendesk.com (https://<subdomain>.<your zendesk domain>)'
+
 export type UsernamePasswordCredentials = {
   username: string
   password: string
@@ -54,14 +57,14 @@ export const usernamePasswordCredentialsType = createMatchingObjectType<
       refType: BuiltinTypes.STRING,
       annotations: {
         _required: true,
-        message: 'subdomain (https://<your subdomain>.zendesk.com)',
+        message: SUBDOMAIN_MESSAGE,
       },
     },
     domain: {
       refType: BuiltinTypes.STRING,
       annotations: {
         _required: false,
-        message: 'domain (optional) (https://<subdomain>.<your zendesk domain>.com)',
+        message: DOMAIN_MESSAGE,
       },
     },
   },
@@ -80,14 +83,14 @@ export const oauthAccessTokenCredentialsType = createMatchingObjectType<
       refType: BuiltinTypes.STRING,
       annotations: {
         _required: true,
-        message: 'subdomain (https://<your subdomain>.zendesk.com)',
+        message: SUBDOMAIN_MESSAGE,
       },
     },
     domain: {
       refType: BuiltinTypes.STRING,
       annotations: {
         _required: false,
-        message: 'domain (optional) (https://<subdomain>.<your zendesk domain>.com)',
+        message: DOMAIN_MESSAGE,
       },
     },
   },
@@ -123,7 +126,7 @@ export const oauthRequestParametersType = createMatchingObjectType<
       refType: BuiltinTypes.STRING,
       annotations: {
         _required: false,
-        message: 'domain (optional) (https://<subdomain>.<your zendesk domain>.com)',
+        message: DOMAIN_MESSAGE,
       },
     },
   },

--- a/packages/zendesk-adapter/src/auth.ts
+++ b/packages/zendesk-adapter/src/auth.ts
@@ -21,17 +21,20 @@ export type UsernamePasswordCredentials = {
   username: string
   password: string
   subdomain: string
+  domain?: string
 }
 
 export type OauthAccessTokenCredentials = {
   accessToken: string
   subdomain: string
+  domain?: string
 }
 
 export type OauthRequestParameters = {
   clientId: string
   port: number
   subdomain: string
+  domain?: string
 }
 
 export const usernamePasswordCredentialsType = createMatchingObjectType<
@@ -54,6 +57,13 @@ export const usernamePasswordCredentialsType = createMatchingObjectType<
         message: 'subdomain (https://<your subdomain>.zendesk.com)',
       },
     },
+    domain: {
+      refType: BuiltinTypes.STRING,
+      annotations: {
+        _required: false,
+        message: 'domain (optional) (https://<subdomain>.<your zendesk domain>.com)',
+      },
+    },
   },
 })
 
@@ -71,6 +81,13 @@ export const oauthAccessTokenCredentialsType = createMatchingObjectType<
       annotations: {
         _required: true,
         message: 'subdomain (https://<your subdomain>.zendesk.com)',
+      },
+    },
+    domain: {
+      refType: BuiltinTypes.STRING,
+      annotations: {
+        _required: false,
+        message: 'domain (optional) (https://<subdomain>.<your zendesk domain>.com)',
       },
     },
   },
@@ -100,6 +117,13 @@ export const oauthRequestParametersType = createMatchingObjectType<
       annotations: {
         message: 'subdomain',
         _required: true,
+      },
+    },
+    domain: {
+      refType: BuiltinTypes.STRING,
+      annotations: {
+        _required: false,
+        message: 'domain (optional) (https://<subdomain>.<your zendesk domain>.com)',
       },
     },
   },

--- a/packages/zendesk-adapter/src/client/client.ts
+++ b/packages/zendesk-adapter/src/client/client.ts
@@ -71,7 +71,7 @@ export default class ZendeskClient extends clientUtils.AdapterHTTPClient<
   }
 
   public getUrl(): URL {
-    return new URL(instanceUrl(this.credentials.subdomain))
+    return new URL(instanceUrl(this.credentials.subdomain, this.credentials.domain))
   }
 
   public async getSinglePage(

--- a/packages/zendesk-adapter/src/client/connection.ts
+++ b/packages/zendesk-adapter/src/client/connection.ts
@@ -23,7 +23,7 @@ import { Credentials, isOauthAccessTokenCredentials, OauthAccessTokenCredentials
 const log = logger(module)
 
 export const instanceUrl = (subdomain: string, domain?: string): string => (
-  domain === undefined ? `https://${subdomain}.zendesk.com` : `https://${subdomain}.${domain}.com`
+  domain === undefined ? `https://${subdomain}.zendesk.com` : `https://${subdomain}.${domain}`
 )
 const baseUrl = instanceUrl
 // A URL for resource files

--- a/packages/zendesk-adapter/src/client/connection.ts
+++ b/packages/zendesk-adapter/src/client/connection.ts
@@ -22,10 +22,12 @@ import { Credentials, isOauthAccessTokenCredentials, OauthAccessTokenCredentials
 
 const log = logger(module)
 
-export const instanceUrl = (subdomain: string): string => `https://${subdomain}.zendesk.com`
+export const instanceUrl = (subdomain: string, domain?: string): string => (
+  domain === undefined ? `https://${subdomain}.zendesk.com` : `https://${subdomain}.${domain}.com`
+)
 const baseUrl = instanceUrl
 // A URL for resource files
-const resourceUrl = (subdomain: string): string => (new URL('/', instanceUrl(subdomain))).href
+const resourceUrl = (subdomain: string, domain?: string): string => (new URL('/', instanceUrl(subdomain, domain))).href
 
 const MARKETPLACE_NAME = 'Salto'
 const MARKETPLACE_ORG_ID = 5110
@@ -47,8 +49,7 @@ export const validateCredentials = async ({ credentials, connection }: {
     log.error('Failed to validate credentials: %s', e)
     throw new clientUtils.UnauthorizedError(e)
   }
-
-  return credentials.subdomain
+  return instanceUrl(credentials.subdomain, credentials.domain)
 }
 
 const usernamePasswordAuthParamsFunc = (
@@ -80,7 +81,7 @@ export const createConnection: clientUtils.ConnectionCreator<Credentials> = (
         ? accessTokenAuthParamsFunc(creds)
         : usernamePasswordAuthParamsFunc(creds)
     ),
-    baseURLFunc: ({ subdomain }) => baseUrl(subdomain),
+    baseURLFunc: ({ subdomain, domain }) => baseUrl(subdomain, domain),
     credValidateFunc: validateCredentials,
   })
 )
@@ -91,7 +92,7 @@ export const createResourceConnection:
       creds: Credentials,
     ): Promise<clientUtils.AuthenticatedAPIConnection> => {
       const httpClient = axios.create({
-        baseURL: resourceUrl(creds.subdomain),
+        baseURL: resourceUrl(creds.subdomain, creds.domain),
         headers: APP_MARKETPLACE_HEADERS,
       })
       axiosRetry(httpClient, retryOptions)

--- a/packages/zendesk-adapter/test/adapter_creator.test.ts
+++ b/packages/zendesk-adapter/test/adapter_creator.test.ts
@@ -182,6 +182,13 @@ describe('adapter creator', () => {
       port: 8080,
       clientId: 'client',
     })).toEqual('https://abc.zendesk.com/oauth/authorizations/new?response_type=token&redirect_uri=http://localhost:8080&client_id=client&scope=read%20write')
+
+    expect(createUrlFromUserInput({
+      subdomain: 'abc',
+      domain: 'zendesk1.org',
+      port: 8080,
+      clientId: 'client',
+    })).toEqual('https://abc.zendesk1.org/oauth/authorizations/new?response_type=token&redirect_uri=http://localhost:8080&client_id=client&scope=read%20write')
   })
 
   it('should validate credentials using createConnection', async () => {
@@ -209,10 +216,17 @@ describe('adapter creator', () => {
     expect(await adapter.validateCredentials(new InstanceElement(
       'config',
       usernamePasswordCredentialsType,
-      { username: 'user123', password: 'pwd456', subdomain: 'abc', domain: 'zendesk1' },
+      { username: 'user123', password: 'pwd456', subdomain: 'abc', domain: 'zendesk1.com' },
     ))).toEqual('https://abc.zendesk1.com')
 
-    expect(connection.createConnection).toHaveBeenCalledTimes(3)
+    // with domain is an empty string
+    expect(await adapter.validateCredentials(new InstanceElement(
+      'config',
+      oauthAccessTokenCredentialsType,
+      { authType: 'oauth', accessToken: 'token', subdomain: 'abc', domain: '' },
+    ))).toEqual('https://abc.zendesk.com')
+
+    expect(connection.createConnection).toHaveBeenCalledTimes(4)
     expect(connection.validateCredentials).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
@@ -222,6 +236,20 @@ describe('adapter creator', () => {
 
     expect(connection.validateCredentials).toHaveBeenNthCalledWith(
       2,
+      expect.objectContaining({
+        credentials: { accessToken: 'token', subdomain: 'abc' },
+      })
+    )
+
+    expect(connection.validateCredentials).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        credentials: { username: 'user123', password: 'pwd456', subdomain: 'abc', domain: 'zendesk1.com' },
+      })
+    )
+
+    expect(connection.validateCredentials).toHaveBeenNthCalledWith(
+      4,
       expect.objectContaining({
         credentials: { accessToken: 'token', subdomain: 'abc' },
       })

--- a/packages/zendesk-adapter/test/adapter_creator.test.ts
+++ b/packages/zendesk-adapter/test/adapter_creator.test.ts
@@ -196,16 +196,23 @@ describe('adapter creator', () => {
       'config',
       usernamePasswordCredentialsType,
       { username: 'user123', password: 'pwd456', subdomain: 'abc' },
-    ))).toEqual('abc')
+    ))).toEqual('https://abc.zendesk.com')
 
     // OAuth auth method
     expect(await adapter.validateCredentials(new InstanceElement(
       'config',
       oauthAccessTokenCredentialsType,
       { authType: 'oauth', accessToken: 'token', subdomain: 'abc' },
-    ))).toEqual('abc')
+    ))).toEqual('https://abc.zendesk.com')
 
-    expect(connection.createConnection).toHaveBeenCalledTimes(2)
+    // with domain provided
+    expect(await adapter.validateCredentials(new InstanceElement(
+      'config',
+      usernamePasswordCredentialsType,
+      { username: 'user123', password: 'pwd456', subdomain: 'abc', domain: 'zendesk1' },
+    ))).toEqual('https://abc.zendesk1.com')
+
+    expect(connection.createConnection).toHaveBeenCalledTimes(3)
     expect(connection.validateCredentials).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({

--- a/packages/zendesk-adapter/test/client/connection.test.ts
+++ b/packages/zendesk-adapter/test/client/connection.test.ts
@@ -34,7 +34,7 @@ describe('client connection', () => {
         .onGet('/api/v2/account/settings').reply(200, { settings: {} })
         .onGet('/api/v2/a/b').reply(200, { something: 'bla' })
       const apiConn = await conn.login({ username: 'user123', password: 'pwd456', subdomain: 'abc' })
-      expect(apiConn.accountId).toEqual('abc')
+      expect(apiConn.accountId).toEqual('https://abc.zendesk.com')
       expect(mockAxiosAdapter.history.get.length).toBe(1)
 
       const getRes = apiConn.get('/api/v2/a/b')

--- a/packages/zendesk-adapter/test/client/connection.test.ts
+++ b/packages/zendesk-adapter/test/client/connection.test.ts
@@ -15,7 +15,7 @@
 */
 import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
-import { createConnection } from '../../src/client/connection'
+import { createConnection, instanceUrl } from '../../src/client/connection'
 
 describe('client connection', () => {
   describe('createConnection', () => {
@@ -54,6 +54,15 @@ describe('client connection', () => {
       mockAxiosAdapter
         .onGet('/api/v2/account/settings').reply(403)
       await expect(() => conn.login({ username: 'user123', password: 'pwd456', subdomain: 'abc' })).rejects.toThrow('Unauthorized - update credentials and try again')
+    })
+  })
+
+  describe('instanceUrl', () => {
+    it('should return the correct url', () => {
+      const domain = 'zenzen.org'
+      const subdomain = 'zendesk'
+      expect(instanceUrl(subdomain, domain)).toEqual('https://zendesk.zenzen.org')
+      expect(instanceUrl(subdomain)).toEqual('https://zendesk.zendesk.com')
     })
   })
 })


### PR DESCRIPTION
To allow custom domains in Zendesk, this PR add a new optional `domain` param in zendesk login that would override the default `zendesk` domain

---

_Additional context for reviewer_

- `domain` field was added to zendesk's credentials types that would override `zendesk` domain
- credentials type fields marked with `_required = false` can be skipped when connecting a new account

will add some tests later

---
_Release Notes_: 

zendesk:
- When connecting a new zendesk account via CLI, user can provide custom domain that would replace `zendesk` domain


---
_User Notifications_: 
None
