### PR TITLE
SALTO-3333 Add delay before swagger url retry

### DIFF
--- a/packages/adapter-components/src/elements/swagger/swagger.ts
+++ b/packages/adapter-components/src/elements/swagger/swagger.ts
@@ -15,7 +15,10 @@
 */
 import SwaggerParser from '@apidevtools/swagger-parser'
 import { logger } from '@salto-io/logging'
+import { promises } from '@salto-io/lowerdash'
 import { OpenAPI } from 'openapi-types'
+
+const { sleep } = promises.timeout
 
 const DEFAULT_NUMBER_OF_RETRIES = 5
 
@@ -38,10 +41,11 @@ export const loadSwagger = async (
       parser,
     }
   } catch (err) {
-    log.warn(`Failed to load swagger file ${swaggerPath} with error: ${err}. Retries left: ${numberOfRetries}`)
+    log.warn(`Failed to load swagger file ${swaggerPath} with error: ${err}. Retries left: ${numberOfRetries} (retrying in 5s)`)
     if (numberOfRetries <= 0) {
       throw err
     }
+    await sleep(5000)
     return loadSwagger(swaggerPath, numberOfRetries - 1)
   }
 }

--- a/packages/adapter-components/test/elements/swagger/swagger.test.ts
+++ b/packages/adapter-components/test/elements/swagger/swagger.test.ts
@@ -18,24 +18,40 @@ import { loadSwagger } from '../../../src/elements/swagger'
 
 const mockBundle = jest.fn()
 
+class ErrorWithStatus extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message)
+  }
+}
 jest.mock('@apidevtools/swagger-parser', () =>
   jest.fn().mockImplementation(
     () => ({ bundle: mockBundle })
   ))
 
 describe('loadSwagger', () => {
+  jest.setTimeout(15 * 1000)
+
   beforeEach(() => {
     mockBundle.mockClear()
   })
-  it('should retry when failing', async () => {
-    mockBundle.mockRejectedValueOnce(new Error('Failed to load swagger'))
-    await loadSwagger('url')
+  it('should retry when failing with status arg', async () => {
+    mockBundle.mockRejectedValueOnce(new ErrorWithStatus('Failed to load swagger', 400))
+    await loadSwagger('url', 3, 10)
     expect(mockBundle).toHaveBeenCalledTimes(2)
   })
 
+  it('should not retry when failing without status arg', async () => {
+    mockBundle.mockRejectedValueOnce(new Error('Failed to load swagger'))
+    await expect(loadSwagger('url', 3, 10)).rejects.toThrow()
+    expect(mockBundle).toHaveBeenCalledTimes(1)
+  })
+
   it('should throw if failed after retries', async () => {
-    mockBundle.mockRejectedValue(new Error('Failed to load swagger'))
-    await expect(loadSwagger('url')).rejects.toThrow()
-    expect(mockBundle).toHaveBeenCalledTimes(6)
+    mockBundle.mockRejectedValue(new ErrorWithStatus('Failed to load swagger', 400))
+    await expect(loadSwagger('url', 3, 10)).rejects.toThrow()
+    expect(mockBundle).toHaveBeenCalledTimes(4)
   })
 })

--- a/packages/lowerdash/src/promises/timeout.ts
+++ b/packages/lowerdash/src/promises/timeout.ts
@@ -35,3 +35,5 @@ export const withTimeout = <T>(
     timeoutPromise,
   ]) as Promise<T>
 }
+
+export const sleep = (delayMs: number): Promise<void> => new Promise(r => setTimeout(r, delayMs))

--- a/packages/lowerdash/src/promises/timeout.ts
+++ b/packages/lowerdash/src/promises/timeout.ts
@@ -36,4 +36,9 @@ export const withTimeout = <T>(
   ]) as Promise<T>
 }
 
-export const sleep = (delayMs: number): Promise<void> => new Promise(r => setTimeout(r, delayMs))
+export const sleep = (delayMs: number): Promise<void> => {
+  if (delayMs <= 0) {
+    return Promise.resolve()
+  }
+  return new Promise(r => setTimeout(r, delayMs))
+}

--- a/packages/lowerdash/test/promises/timeout.test.ts
+++ b/packages/lowerdash/test/promises/timeout.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { PromiseTimedOutError, withTimeout } from '../../src/promises/timeout'
+import { PromiseTimedOutError, withTimeout, sleep } from '../../src/promises/timeout'
 
 describe('withTimeout', () => {
   const wait = (
@@ -112,5 +112,15 @@ describe('withTimeout', () => {
       expect(await p).toBeInstanceOf(PromiseTimedOutError)
       expect(await p).toMatchObject({ message: 'Promise timed out after 1 ms' })
     })
+  })
+})
+
+describe('sleep', () => {
+  it('should wait at least the specified time and not much more than it', async () => {
+    const before = Date.now()
+    await sleep(1000)
+    const delay = Date.now() - before
+    expect(delay).toBeGreaterThan(1000)
+    expect(delay).toBeLessThan(5000)
   })
 })

--- a/packages/lowerdash/test/promises/timeout.test.ts
+++ b/packages/lowerdash/test/promises/timeout.test.ts
@@ -16,7 +16,6 @@
 import { PromiseTimedOutError, withTimeout, sleep } from '../../src/promises/timeout'
 
 describe('withTimeout', () => {
-  jest.setTimeout(10 * 1000)
 
   const wait = (
     timeout: number,
@@ -118,11 +117,26 @@ describe('withTimeout', () => {
 })
 
 describe('sleep', () => {
+  let setTimeout: jest.SpyInstance
+  beforeEach(() => {
+    setTimeout = jest.spyOn(global, 'setTimeout')
+  })
+  afterAll(() => {
+    jest.clearAllMocks()
+  })
+
   it('should wait at least the specified time and not much more than it', async () => {
     const before = Date.now()
     await sleep(1000)
     const delay = Date.now() - before
+    expect(setTimeout).toHaveBeenCalledTimes(1)
+    expect(setTimeout).toHaveBeenCalledWith(1000)
     expect(delay).toBeGreaterThan(1000)
     expect(delay).toBeLessThan(5000)
+  })
+  it('should return immediately when delay is non-positive', async () => {
+    await sleep(0)
+    await sleep(-5)
+    expect(setTimeout).not.toHaveBeenCalled()
   })
 })

--- a/packages/lowerdash/test/promises/timeout.test.ts
+++ b/packages/lowerdash/test/promises/timeout.test.ts
@@ -16,6 +16,8 @@
 import { PromiseTimedOutError, withTimeout, sleep } from '../../src/promises/timeout'
 
 describe('withTimeout', () => {
+  jest.setTimeout(10 * 1000)
+
   const wait = (
     timeout: number,
   ): Promise<void> => new Promise(resolve => setTimeout(resolve, timeout))

--- a/packages/lowerdash/test/promises/timeout.test.ts
+++ b/packages/lowerdash/test/promises/timeout.test.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import _ from 'lodash'
 import { PromiseTimedOutError, withTimeout, sleep } from '../../src/promises/timeout'
 
 describe('withTimeout', () => {
@@ -118,20 +119,17 @@ describe('withTimeout', () => {
 describe('sleep', () => {
   let setTimeout: jest.SpyInstance
   beforeEach(() => {
-    setTimeout = jest.spyOn(global, 'setTimeout')
+    jest.clearAllMocks()
+    setTimeout = jest.spyOn(global, 'setTimeout').mockImplementation((cb: TimerHandler) => (_.isFunction(cb) ? cb() : undefined))
   })
   afterAll(() => {
     jest.clearAllMocks()
   })
 
   it('should wait at least the specified time and not much more than it', async () => {
-    const before = Date.now()
     await sleep(1000)
-    const delay = Date.now() - before
     expect(setTimeout).toHaveBeenCalledTimes(1)
-    expect(setTimeout).toHaveBeenCalledWith(1000)
-    expect(delay).toBeGreaterThan(1000)
-    expect(delay).toBeLessThan(5000)
+    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 1000)
   })
   it('should return immediately when delay is non-positive', async () => {
     await sleep(0)

--- a/packages/lowerdash/test/promises/timeout.test.ts
+++ b/packages/lowerdash/test/promises/timeout.test.ts
@@ -16,7 +16,6 @@
 import { PromiseTimedOutError, withTimeout, sleep } from '../../src/promises/timeout'
 
 describe('withTimeout', () => {
-
   const wait = (
     timeout: number,
   ): Promise<void> => new Promise(resolve => setTimeout(resolve, timeout))

--- a/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
+++ b/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
@@ -38,6 +38,7 @@ import { buildDataManagement, DataManagement } from './fetch_profile/data_manage
 
 const { toArrayAsync } = collections.asynciterable
 const { partition } = promises.array
+const { sleep } = promises.timeout
 const { awu, keyByAsync } = collections.asynciterable
 const { toMD5 } = hash
 const log = logger(module)
@@ -173,8 +174,6 @@ type CrudFnArgs = {
 }
 
 export type CrudFn = (fnArgs: CrudFnArgs) => Promise<InstanceAndResult[]>
-
-const sleep = (delayMillis: number): Promise<void> => new Promise(r => setTimeout(r, delayMillis))
 
 const isRetryableErr = (retryableFailures: string[]) =>
   (instAndRes: InstanceAndResult): boolean =>


### PR DESCRIPTION
Add delay before retrying, to improve our chances of succeeding on 503 and similar transient errors.
Also change to only retry on HTTP errors (right now we also retry when there are parsing errors / inconsistency in the swagger)

---
_Release Notes_: 
None

---
_User Notifications_: 
None