### PR TITLE
Salto 3204 - Performance improvement of Elements By Selectors

### DIFF
--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -34,7 +34,8 @@ import * as serialization from './src/serializer/elements'
 import * as pathIndex from './src/workspace/path_index'
 import { Author } from './src/workspace/changed_by_index'
 import { createElementSelector, ElementSelector, validateSelectorsMatches, createTopLevelSelector,
-  selectElementsBySelectors, selectElementIdsByTraversal, createElementSelectors, ElementIDToValue } from './src/workspace/element_selector'
+  selectElementsBySelectorsWithoutReferences, selectElementsBySelectors,
+  selectElementIdsByTraversal, createElementSelectors, ElementIDToValue } from './src/workspace/element_selector'
 import * as validator from './src/validator'
 import * as elementSource from './src/workspace/elements_source'
 import * as remoteMap from './src/workspace/remote_map'
@@ -78,6 +79,7 @@ export {
   createElementSelector,
   ElementSelector,
   validateSelectorsMatches,
+  selectElementsBySelectorsWithoutReferences,
   selectElementsBySelectors,
   createElementSelectors,
   createTopLevelSelector,

--- a/packages/workspace/src/workspace/element_selector.ts
+++ b/packages/workspace/src/workspace/element_selector.ts
@@ -107,6 +107,8 @@ export const validateSelectorsMatches = (selectors: ElementSelector[],
   }
 }
 
+// this function is a synchronous version for selectElementsBySelectors below that allows better performance
+// for use cases where there is no need to get referenced elements.
 export const selectElementsBySelectorsWithoutReferences = (
   { elementIds, selectors, includeNested = false }: {
     elementIds: ElemID[]

--- a/packages/workspace/src/workspace/element_selector.ts
+++ b/packages/workspace/src/workspace/element_selector.ts
@@ -107,6 +107,22 @@ export const validateSelectorsMatches = (selectors: ElementSelector[],
   }
 }
 
+export const selectElementsBySelectorsWithoutReferences = (
+  { elementIds, selectors, includeNested = false }: {
+    elementIds: ElemID[]
+    selectors: ElementSelector[]
+    includeNested?: boolean
+  }
+): ElemID[] => {
+  if (selectors.length === 0) {
+    return elementIds
+  }
+  return elementIds.filter(elementId =>
+    (selectors.some(selector =>
+      match(elementId, selector, includeNested))
+    ))
+}
+
 export const selectElementsBySelectors = (
   {
     elementIds, selectors, referenceSourcesIndex, includeNested = false,
@@ -117,21 +133,17 @@ export const selectElementsBySelectors = (
     includeNested?: boolean
   }
 ): AsyncIterable<ElemID> => {
-  const matches: Record<string, boolean> = { }
   if (selectors.length === 0) {
     return elementIds
   }
   return awu(elementIds).filter(obj => awu(selectors).some(
-    async selector => {
-      const result = await matchWithReferenceBy(
+    selector =>
+      (matchWithReferenceBy(
         isElementContainer(obj) ? obj.elemID : obj as ElemID,
         selector,
         referenceSourcesIndex,
         includeNested
-      )
-      matches[selector.origin] = matches[selector.origin] || result
-      return result
-    }
+      ))
   ))
 }
 

--- a/packages/workspace/test/element_selector.test.ts
+++ b/packages/workspace/test/element_selector.test.ts
@@ -17,7 +17,7 @@ import { ElemID, PrimitiveTypes, ObjectType, PrimitiveType, BuiltinTypes,
   ListType, MapType, InstanceElement } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { selectElementsBySelectors, createElementSelectors, createElementSelector,
-  selectElementIdsByTraversal,
+  selectElementIdsByTraversal, selectElementsBySelectorsWithoutReferences,
   ElementSelector } from '../src/workspace/element_selector'
 import { createInMemoryElementSource } from '../src/workspace/elements_source'
 import { InMemoryRemoteMap, RemoteMap } from '../src/workspace/remote_map'
@@ -109,6 +109,21 @@ const selectElements = async ({
     includeNested,
   }))
 ).toArray()
+
+const selectElementsWitoutRef = ({
+  elements,
+  selectors,
+  includeNested = false,
+}: {
+  elements: ElemID[]
+  selectors: string[]
+  includeNested?: boolean
+}):ElemID[] =>
+  selectElementsBySelectorsWithoutReferences({
+    elementIds: elements,
+    selectors: createElementSelectors(selectors).validSelectors,
+    includeNested,
+  })
 
 describe('element selector', () => {
   it('should handle asterisks in adapter and type', async () => {
@@ -575,5 +590,210 @@ describe('referencedBy', () => {
       source: createInMemoryElementSource([]),
       referenceSourcesIndex,
     })).rejects.toThrow()
+  })
+})
+
+describe('element selector without ref by', () => {
+  it('should handle asterisks in adapter and type', () => {
+    const elements = [
+      new ElemID('salesforce', 'sometype'),
+      new ElemID('salesforce', 'othertype'),
+      new ElemID('otheradapter', 'othertype'),
+      new ElemID('salesforce', 'othertype', 'instance'),
+    ]
+    const selectedElements = selectElementsWitoutRef({ elements, selectors: ['*.*'] })
+    expect(selectedElements).toEqual([elements[0], elements[1], elements[2]])
+  })
+
+  it('should only select specific type when given specific type element', () => {
+    const elements = [
+      new ElemID('salesforce', 'sometype'),
+      new ElemID('salesforce', 'sometypewithsameprefix'),
+      new ElemID('otheradapter', 'othertype'),
+      new ElemID('salesforce', 'othertype', 'instance', 'y'),
+      new ElemID('salesforce', 'sometype', 'instance', 'x'),
+    ]
+    const selectedElements = selectElementsWitoutRef({ elements, selectors: ['salesforce.sometype'] })
+    expect(selectedElements).toEqual([elements[0]])
+  })
+
+  it('should only select specific types when given multiple typeNames', () => {
+    const elements = [
+      new ElemID('salesforce', 'sometype'),
+      new ElemID('salesforce', 'sometypewithsameprefix'),
+      new ElemID('salesforce', 'withsamesuffixsometype'),
+      new ElemID('salesforce', 'othertype'),
+      new ElemID('salesforce', 'othertypewithsameprefix'),
+      new ElemID('salesforce', 'withsamesuffixothertype'),
+      new ElemID('otheradapter', 'sometype'),
+      new ElemID('otheradapter', 'othertype'),
+      new ElemID('salesforce', 'othertype', 'instance', 'y'),
+      new ElemID('salesforce', 'sometype', 'instance', 'x'),
+    ]
+    const selectedElements = selectElementsWitoutRef({ elements, selectors: ['salesforce.sometype|othertype'] })
+    expect(selectedElements).toEqual([elements[0], elements[3]])
+  })
+
+  it('should handle asterisks in field type and instance name', () => {
+    const elements = [
+      new ElemID('salesforce', 'sometype', 'instance', 'one_instance'),
+      new ElemID('salesforce', 'sometype', 'instance', 'second_instance_specialchar@s'),
+      new ElemID('salesforce', 'othertype', 'type', 'typename'),
+      new ElemID('otheradapter', 'othertype', 'instance', 'some_other_instance2'),
+      new ElemID('salesforce', 'othertype', 'instance', 'some_other_instance'),
+    ]
+    const selectedElements = selectElementsWitoutRef({ elements, selectors: ['salesforce.*.instance.*'] })
+    expect(selectedElements).toEqual([elements[0], elements[1], elements[4]])
+  })
+
+  it('should select elements with the same selector length when includeNested is false and name selectors length is 1', () => {
+    const elements = [
+      new ElemID('salesforce', 'sometype', 'instance', 'A'),
+      new ElemID('salesforce', 'sometype', 'instance', 'A', 'B'),
+      new ElemID('salesforce', 'sometype', 'instance', 'A', 'B', 'C'),
+      new ElemID('salesforce', 'othertype', 'instance', 'NotA'),
+      new ElemID('salesforce', 'othertype', 'instance', '_config'),
+      new ElemID('salesforce', 'othertype', 'instance', '_config', 'B'),
+    ]
+    expect(selectElementsWitoutRef(
+      { elements, selectors: ['salesforce.*.instance.A'] }
+    )).toEqual([elements[0]])
+    expect(selectElementsWitoutRef(
+      { elements, selectors: ['salesforce.*.instance._config'] }
+    )).toEqual([elements[4]])
+  })
+
+  it('should select also nested elements when includeNested is true and name selectors length is 1', () => {
+    const elements = [
+      new ElemID('salesforce', 'sometype', 'instance', 'A'),
+      new ElemID('salesforce', 'sometype', 'instance', 'A', 'B'),
+      new ElemID('salesforce', 'sometype', 'instance', 'A', 'B', 'C'),
+      new ElemID('salesforce', 'othertype', 'instance', 'NotA'),
+      new ElemID('salesforce', 'othertype', 'instance', '_config'),
+      new ElemID('salesforce', 'othertype', 'instance', '_config', 'B'),
+    ]
+    expect(selectElementsWitoutRef(
+      { elements, selectors: ['salesforce.*.instance.A'], includeNested: true }
+    )).toEqual([elements[0], elements[1], elements[2]])
+    expect(selectElementsWitoutRef(
+      { elements, selectors: ['salesforce.*.instance._config'], includeNested: true }
+    )).toEqual([elements[4], elements[5]])
+  })
+
+  it('should select fields and attributes when includeNested is true', () => {
+    const elements = [
+      new ElemID('salesforce', 'sometype'),
+      new ElemID('salesforce', 'sometype', 'field', 'A',),
+      new ElemID('salesforce', 'sometype', 'attr', 'B', 'B', 'C'),
+      new ElemID('salesforce', 'sometype', 'instance', 'NotA'),
+    ]
+    const selectedElements = selectElementsWitoutRef(
+      { elements, selectors: ['salesforce.*'], includeNested: true }
+    )
+    expect(selectedElements).toEqual([elements[0], elements[1], elements[2]])
+  })
+
+  it('should select elements with the same selector length when includeNested is false and name selectors length is 2', () => {
+    const elements = [
+      new ElemID('salesforce', 'sometype', 'instance', 'A'),
+      new ElemID('salesforce', 'sometype', 'instance', 'A', 'B'),
+      new ElemID('salesforce', 'sometype', 'instance', 'A', 'B', 'C'),
+      new ElemID('salesforce', 'othertype', 'instance', 'NotA', 'B'),
+      new ElemID('salesforce', 'othertype', 'instance', '_config'),
+      new ElemID('salesforce', 'othertype', 'instance', '_config', 'B'),
+    ]
+    expect(selectElementsWitoutRef(
+      { elements, selectors: ['salesforce.*.instance.A.*'] }
+    )).toEqual([elements[1]])
+    expect(selectElementsWitoutRef(
+      { elements, selectors: ['salesforce.*.instance._config.*'] }
+    )).toEqual([elements[5]])
+  })
+
+  it('should select also nested elements when includeNested is true and name selectors length is 2', () => {
+    const elements = [
+      new ElemID('salesforce', 'sometype', 'instance', 'A'),
+      new ElemID('salesforce', 'sometype', 'instance', 'A', 'B'),
+      new ElemID('salesforce', 'sometype', 'instance', 'A', 'B', 'C'),
+      new ElemID('salesforce', 'othertype', 'instance', 'NotA', 'B'),
+      new ElemID('salesforce', 'othertype', 'instance', '_config'),
+      new ElemID('salesforce', 'othertype', 'instance', '_config', 'B'),
+    ]
+    expect(selectElementsWitoutRef(
+      { elements, selectors: ['salesforce.*.instance.A.*'], includeNested: true }
+    )).toEqual([elements[1], elements[2]])
+    expect(selectElementsWitoutRef(
+      { elements, selectors: ['salesforce.*.instance._config.*'], includeNested: true }
+    )).toEqual([elements[5]])
+  })
+
+  it('should handle asterisks alongside partial names in type', () => {
+    const elements = [
+      new ElemID('salesforce', 'sometype__c'),
+      new ElemID('salesforce', 'othertype'),
+      new ElemID('otheradapter', 'othertype', 'instance', 'some other instace2'),
+      new ElemID('salesforce', 'othertype__c'),
+    ]
+    const selectedElements = selectElementsWitoutRef({ elements, selectors: ['salesforce.*__c'] })
+    expect(selectedElements).toEqual([elements[0], elements[3]])
+  })
+  it('should handle asterisks only in name', () => {
+    const elements = [
+      new ElemID('salesforce', 'ApexClass', 'instance', 'American'),
+      new ElemID('salesforce', 'othertype'),
+      new ElemID('salesforce', 'othertype', 'instance', 'American', 'Australian'),
+      new ElemID('otheradapter', 'ApexClass', 'instance', 'Bob'),
+      new ElemID('salesforce', 'ApexClass', 'instance', 'Analog'),
+    ]
+    const selectedElements = selectElementsWitoutRef(
+      { elements, selectors: ['salesforce.ApexClass.instance.A*'] }
+    )
+    expect(selectedElements).toEqual([elements[0], elements[4]])
+  })
+
+  it('should handle two asterisks in name', () => {
+    const elements = [
+      new ElemID('salesforce', 'ApexClass', 'instance', 'American'),
+      new ElemID('salesforce', 'othertype'),
+      new ElemID('salesforce', 'othertype', 'instance', 'American', 'Australian'),
+      new ElemID('otheradapter', 'ApexClass', 'instance', 'Bob'),
+      new ElemID('salesforce', 'ApexClass', 'instance', 'Imericchan'),
+      new ElemID('salesforce', 'ApexClass', 'instance', 'eric'),
+      new ElemID('salesforce', 'ApexClass', 'instance', 'Imeric'),
+      new ElemID('salesforce', 'ApexClass', 'instance', 'ericchan'),
+    ]
+    const selectedElements = selectElementsWitoutRef(
+      { elements, selectors: ['salesforce.ApexClass.instance.*eric*'] }
+    )
+    expect(selectedElements).toEqual(
+      [elements[0], elements[4], elements[5], elements[6], elements[7]]
+    )
+  })
+
+  it('should use two selectors and allow any element that matches one of them', () => {
+    const elements = [
+      new ElemID('salesforce', 'value'),
+      new ElemID('netsuite', 'value'),
+      new ElemID('jira', 'value'),
+    ]
+    const selectedElements = selectElementsWitoutRef({ elements, selectors: ['salesforce.*', 'netsuite.*'] })
+    expect(selectedElements).toEqual([elements[0], elements[1]])
+  })
+  it('returns all elements with no selectors', () => {
+    const elements = [
+      new ElemID('salesforce', 'value'),
+      new ElemID('netsuite', 'value'),
+      new ElemID('jira', 'value'),
+    ]
+    expect(selectElementsWitoutRef({ elements, selectors: [] })).toEqual(elements)
+  })
+  it('should use a wildcard and a specific element id and not throw error if the wildcard covers the element id', () => {
+    const elements = [
+      new ElemID('salesforce', 'value'),
+    ]
+    const selectedElements = selectElementsWitoutRef(
+      { elements, selectors: ['salesforce.*', 'salesforce.value'] }
+    )
+    expect(selectedElements).toEqual([elements[0]])
   })
 })


### PR DESCRIPTION
A synchronous version for selectElementsBySelectors that will improve performance for use cases where there is no need to get referenced elements.

---

also added a small refactor to the existing code since the array matches wasn't in use so that code was redundant.

---
_Release Notes_: 
none.

---
_User Notifications_: 
none.