### PR TITLE
SALTO-3306: Avoid creating references in article body for excluded brands

### DIFF
--- a/packages/zendesk-adapter/src/filters/article/article_body.ts
+++ b/packages/zendesk-adapter/src/filters/article/article_body.ts
@@ -119,12 +119,17 @@ const matchBrand = (url: string, brands: Record<string, InstanceElement>): Insta
   return undefined
 }
 
-const updateArticleBody = (
-  articleInstance: InstanceElement,
-  additionalInstances: Record<string, Record<string, InstanceElement>>,
-  includedBrands: InstanceElement[],
-  enableMissingReferences?: boolean,
-): SaltoError[] => {
+const updateArticleBody = ({
+  articleInstance,
+  additionalInstances,
+  includedBrands,
+  enableMissingReferences,
+} : {
+  articleInstance: InstanceElement
+  additionalInstances: Record<string, Record<string, InstanceElement>>
+  includedBrands: InstanceElement[]
+  enableMissingReferences?: boolean
+}): SaltoError[] => {
   const errors: SaltoError[] = []
   const originalArticleBody = articleInstance.value[BODY_FIELD]
   if (!_.isString(originalArticleBody)) {
@@ -210,8 +215,12 @@ const filterCreator: FilterCreator = ({ config }) => {
         .filter(instance => instance.elemID.typeName === ARTICLE_TRANSLATION_TYPE_NAME)
         .filter(articleInstance => !_.isEmpty(articleInstance.value[BODY_FIELD]))
         .flatMap(articleInstance => (
-          // eslint-disable-next-line max-len
-          updateArticleBody(articleInstance, additionalInstances, includedBrands, config[FETCH_CONFIG].enableMissingReferences)
+          updateArticleBody({
+            articleInstance,
+            additionalInstances,
+            includedBrands,
+            enableMissingReferences: config[FETCH_CONFIG].enableMissingReferences,
+          })
         ))
 
       return { errors: warnings }

--- a/packages/zendesk-adapter/test/filters/article/article_body.test.ts
+++ b/packages/zendesk-adapter/test/filters/article/article_body.test.ts
@@ -154,9 +154,9 @@ describe('article body filter', () => {
         config[FETCH_CONFIG].guide = { brands: ['.*'] }
         filter = filterCreator(createFilterCreatorParams({ config })) as FilterType
         elements = generateElements()
-        await filter.onFetch(elements)
       })
-      it('should convert all possible urls to references', () => {
+      it('should convert all possible urls to references', async () => {
+        const filterResult = await filter.onFetch(elements) as FilterResult
         const fetchedTranslationWithReferences = elements.filter(isInstanceElement).find(i => i.elemID.name === 'translationWithReferences')
         expect(fetchedTranslationWithReferences?.value.body).toEqual(new TemplateExpression({ parts: [
           '<p><a href="',
@@ -170,8 +170,10 @@ describe('article body filter', () => {
           '/hc/he/articles/', new ReferenceExpression(articleInstance.elemID, articleInstance),
           '-extra_string"',
         ] }))
+        expect(filterResult.errors).toHaveLength(0)
       })
-      it('should only match elements that exists in the matched brand', () => {
+      it('should only match elements that exists in the matched brand', async () => {
+        const filterResult = await filter.onFetch(elements) as FilterResult
         const brandName = emptyBrandInstance.value.name
         const missingArticleInstance = createMissingInstance(ZENDESK, ARTICLES_FIELD, `${brandName}_124`)
         const missingSectionInstance = createMissingInstance(ZENDESK, SECTIONS_FIELD, `${brandName}_123`)
@@ -196,11 +198,14 @@ describe('article body filter', () => {
             new ReferenceExpression(articleInstance.elemID, articleInstance),
             '-extra_string"',
           ] }))
+        expect(filterResult.errors).toHaveLength(0)
       })
-      it('should do nothing if elements do not exists', () => {
+      it('should do nothing if elements do not exists', async () => {
+        const filterResult = await filter.onFetch(elements) as FilterResult
         const fetchedTranslationWithoutReferences = elements.filter(isInstanceElement).find(i => i.elemID.name === 'translationWithoutReferences')
         expect(fetchedTranslationWithoutReferences?.value.body)
           .toEqual('<p><a href="https://nobrand.zendesk.com/hc/en-us/articles/124/sep/sections/124/sep/categories/124/sep/article_attachments/124-extra_string" target="_self">linkedArticle</a></p>kjdsahjkdshjkdsjkh\n<a href="https://nobrand.zendesk.com/hc/he/articles/124-extra_string"')
+        expect(filterResult.errors).toHaveLength(0)
       })
     })
 


### PR DESCRIPTION
Avoid creating references in article body for excluded brands

---

_Additional context for reviewer_

When `article_translation` body contains a url and the linked brand wasn't included in our guide config, we replaced it with missing references. 
Now we'll avoid creating this reference (and leave the url as it is), and alert to user about it.

---
_Release Notes_: 
None

---
_User Notifications_: 
None
