### PR TITLE
SALTO-2427: Support fetch of Layout instances to standard objects within installed packages

### DIFF
--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -155,21 +155,17 @@ const listMetadataObjectsWithinFolders = async (
 const getFullName = (obj: FileProperties): string => {
   const namePrefix = obj.namespacePrefix
     ? `${obj.namespacePrefix}${NAMESPACE_SEPARATOR}` : ''
-  // Ensure fullName starts with the namespace prefix if there is one
-  // needed due to a SF quirk where sometimes metadata instances return without a namespace
-  // in the fullName even when they should have it
-  const fullNameWithCorrectedObjectName = obj.fullName.startsWith(namePrefix) ? obj.fullName : `${namePrefix}${obj.fullName}`
   if (obj.type === LAYOUT_TYPE_ID_METADATA_TYPE && obj.namespacePrefix) {
   // Ensure layout name starts with the namespace prefix if there is one.
   // needed due to a SF quirk where sometimes layout metadata instances fullNames return as
   // <namespace>__<objectName>-<layoutName> where it should be
   // <namespace>__<objectName>-<namespace>__<layoutName>
-    const [objectName, ...layoutName] = fullNameWithCorrectedObjectName.split('-')
+    const [objectName, ...layoutName] = obj.fullName.split('-')
     if (layoutName.length !== 0 && !layoutName[0].startsWith(obj.namespacePrefix)) {
       return `${objectName}-${namePrefix}${layoutName.join('-')}`
     }
   }
-  return fullNameWithCorrectedObjectName
+  return obj.fullName
 }
 
 const getInstanceFromMetadataInformation = (metadata: MetadataInfo,

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -851,7 +851,7 @@ public class MyClass${index} {
         { valueTypeFields: [] },
         [
           {
-            props: { fullName: 'Test', namespacePrefix: namespaceName },
+            props: { fullName: 'asd__Test', namespacePrefix: namespaceName },
             values: { fullName: `${namespaceName}__Test` },
           },
         ]

--- a/packages/salesforce-adapter/test/fetch_installed_packages_layout.test.ts
+++ b/packages/salesforce-adapter/test/fetch_installed_packages_layout.test.ts
@@ -99,7 +99,7 @@ describe('Test fetching layouts of installed packages', () => {
     const instance = elements
       .filter(isInstanceElement)
       .find(inst => inst.elemID.typeName === constants.LAYOUT_TYPE_ID_METADATA_TYPE)
-    const targetFullName = namespacePrefix ? 'SBQQ__TestApiName__c-SBQQ__Test Layout' : `${apiName}-Test Layout`
+    const targetFullName = `${apiName}-SBQQ__Test Layout`
     expect(instance).toBeDefined()
     expect(instance?.elemID).toEqual(LAYOUT_TYPE_ID.createNestedID('instance', naclCase(targetFullName)))
   }


### PR DESCRIPTION
Layout instances from installed package to objects from another package were not fetched due to assumption that always added the namespace to the Object name upon fetch.

---

## Please do not merge this
before [this](https://github.com/salto-io/salto_private/pull/4818) noise suppression PR is merged.
I did test this on my CPQ org and removing this statement didn't delete any layouts, so I feel pretty comfortable with removing the problematic code.

---
_Release Notes_: 
Salesforce Adapter:
- Support fetching Layout instances from installed package to Objects outside the package.

---
_User Notifications_: 
_None_
