### PR TITLE
SALTO-3369: Deploying WorkflowScheme without items does not delete the items in the service

### DIFF
--- a/packages/jira-adapter/src/filters/workflow_scheme.ts
+++ b/packages/jira-adapter/src/filters/workflow_scheme.ts
@@ -127,13 +127,11 @@ export const preDeployWorkflowScheme = async (
   action: ActionName,
   elementsSource?: ReadOnlyElementsSource
 ): Promise<void> => {
-  if (instance.value.items !== undefined) {
-    const resolvedInstance = await resolveValues(instance, getLookUpName, elementsSource)
-    instance.value.issueTypeMappings = _(resolvedInstance.value.items)
-      .keyBy(mapping => mapping.issueType)
-      .mapValues(mapping => mapping.workflow)
-      .value()
-  }
+  const resolvedInstance = await resolveValues(instance, getLookUpName, elementsSource)
+  instance.value.issueTypeMappings = _(resolvedInstance.value.items ?? [])
+    .keyBy(mapping => mapping.issueType)
+    .mapValues(mapping => mapping.workflow)
+    .value()
 
   if (action === 'modify') {
     instance.value.updateDraftIfNeeded = true

--- a/packages/jira-adapter/test/filters/workflow_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/workflow_scheme.test.ts
@@ -159,10 +159,11 @@ describe('workflowScheme', () => {
       await filter.preDeploy?.([toChange({ before: instance, after: instance })])
       expect(instance.value).toEqual({
         updateDraftIfNeeded: true,
+        issueTypeMappings: {},
       })
     })
 
-    it('should do nothing if there are no items', async () => {
+    it('should add empty list if there are no items', async () => {
       const instance = new InstanceElement(
         'instance',
         workflowSchemeType,
@@ -173,6 +174,7 @@ describe('workflowScheme', () => {
       await filter.preDeploy?.([toChange({ after: instance })])
       expect(instance.value).toEqual({
         val: 1,
+        issueTypeMappings: {},
       })
     })
   })


### PR DESCRIPTION
Fixed a bug where a deployment of a workflow scheme without items would not change the items in the service

---
_Release Notes_: 
__Jira-adapter__:
- Fixed a bug where a deployment of a workflow scheme without items would not change the items in the service

---
_User Notifications_: 
None