### PR TITLE
SALTO-3370: fixed dashboard validator where are are not gadgets

### DIFF
--- a/packages/jira-adapter/src/change_validators/dashboard_layout.ts
+++ b/packages/jira-adapter/src/change_validators/dashboard_layout.ts
@@ -28,7 +28,7 @@ export const dashboardLayoutValidator: ChangeValidator = async changes =>
     .map(getChangeData)
     .filter(instance => instance.elemID.typeName === DASHBOARD_TYPE)
     .map(instance => {
-      const invalidGadgets = instance.value.gadgets
+      const invalidGadgets = (instance.value.gadgets ?? [])
         .filter(isReferenceExpression)
         .filter((gadget: ReferenceExpression) =>
           gadget.value.value.position.column >= instance.value.layout.length)

--- a/packages/jira-adapter/test/change_validators/dashboard_layout.test.ts
+++ b/packages/jira-adapter/test/change_validators/dashboard_layout.test.ts
@@ -67,4 +67,16 @@ describe('dashboardLayoutValidator', () => {
     expect(await dashboardLayoutValidator([toChange({ before: instance, after: afterInstance })]))
       .toEqual([])
   })
+
+  it('should not return an error when there are no gadgets', async () => {
+    instance.value.layout = 'AA'
+
+    delete instance.value.gadgets
+
+    const afterInstance = instance.clone()
+    afterInstance.value.layout = 'AAA'
+
+    expect(await dashboardLayoutValidator([toChange({ before: instance, after: afterInstance })]))
+      .toEqual([])
+  })
 })


### PR DESCRIPTION
Fixed a bug where the dashboard layout validator would throw an error if the dashboard does not have gadgets

---
_Release Notes_: 
__Jira Adapter__:
- Fixed a bug where the dashboard layout validator would throw an error if the dashboard does not have gadgets

---
_User Notifications_: 
None