### PR TITLE
SALTO-3114: improve subdomain handling when creating brands

### DIFF
--- a/packages/zendesk-adapter/src/change_validator.ts
+++ b/packages/zendesk-adapter/src/change_validator.ts
@@ -89,7 +89,7 @@ export default ({
     invalidActionsValidator,
     orderInstanceContainsAllTheInstancesValidator,
     triggerOrderInstanceContainsAllTheInstancesValidator,
-    brandCreationValidator,
+    brandCreationValidator(client),
     webhookAuthDataValidator(client),
     targetAuthDataValidator(client, apiConfig),
     phoneNumbersValidator,

--- a/packages/zendesk-adapter/src/change_validators/brand_creation.ts
+++ b/packages/zendesk-adapter/src/change_validators/brand_creation.ts
@@ -55,8 +55,8 @@ export const brandCreationValidator: (client: ZendeskClient) =>
     return brandAddition.flatMap(instance => (
       [{
         elemID: instance.elemID,
-        severity: 'Warning',
-        message: 'Verify brand subdomain uniqueness',
+        severity: 'Error',
+        message: 'Brand subdomain is already taken',
         detailedMessage: `Brand subdomains are globally unique, please make sure to set an available subdomain for brand ${instance.value.name} before attempting to create it from Salto`,
       }]
     ))

--- a/packages/zendesk-adapter/src/change_validators/brand_creation.ts
+++ b/packages/zendesk-adapter/src/change_validators/brand_creation.ts
@@ -57,7 +57,7 @@ export const brandCreationValidator: (client: ZendeskClient) =>
         elemID: instance.elemID,
         severity: 'Warning',
         message: 'Verify brand subdomain uniqueness',
-        detailedMessage: `Brand subdomains are globally unique, please make sure to set an available subdomain for brand ${instance.value.name}`,
+        detailedMessage: `Brand subdomains are globally unique, please make sure to set an available subdomain for brand ${instance.value.name} before attempting to create it from Salto`,
       }]
     ))
   }

--- a/packages/zendesk-adapter/src/change_validators/brand_creation.ts
+++ b/packages/zendesk-adapter/src/change_validators/brand_creation.ts
@@ -70,16 +70,16 @@ const isChangeInSubdomain = (change: Change<InstanceElement>): boolean => {
  */
 export const brandCreationValidator: (client: ZendeskClient) =>
   ChangeValidator = client => async changes => {
-    const brandAddition = await awu(changes)
+    const brandSubdomainChanges = await awu(changes)
       .filter(isInstanceChange)
+      .filter(change => getChangeData(change).elemID.typeName === BRAND_TYPE_NAME)
       .filter(isChangeInSubdomain)
       .map(getChangeData)
       .filter(isInstanceElement)
-      .filter(instance => instance.elemID.typeName === BRAND_TYPE_NAME)
       .map(async instance => ({ instance, valid: await isSubdomainValid(instance, client) }))
       .toArray()
 
-    return brandAddition
+    return brandSubdomainChanges
       .filter(brandDetails => !brandDetails.valid)
       .map(({ instance, valid }): ChangeError => {
         if (valid === undefined) {

--- a/packages/zendesk-adapter/test/change_validators/brand_creation.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/brand_creation.test.ts
@@ -58,7 +58,7 @@ describe('brandCreationValidator', () => {
       elemID: brandInstance.elemID,
       severity: 'Warning',
       message: 'Verify brand subdomain uniqueness',
-      detailedMessage: `Brand subdomains are globally unique, please make sure to set an available subdomain for brand ${brandInstance.value.name}`,
+      detailedMessage: `Brand subdomains are globally unique, please make sure to set an available subdomain for brand ${brandInstance.value.name} before attempting to create it from Salto`,
     }])
   })
   it('should not return an error if the brand was modified', async () => {

--- a/packages/zendesk-adapter/test/change_validators/brand_creation.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/brand_creation.test.ts
@@ -56,8 +56,8 @@ describe('brandCreationValidator', () => {
     })
     expect(errors).toEqual([{
       elemID: brandInstance.elemID,
-      severity: 'Warning',
-      message: 'Verify brand subdomain uniqueness',
+      severity: 'Error',
+      message: 'Brand subdomain is already taken',
       detailedMessage: `Brand subdomains are globally unique, please make sure to set an available subdomain for brand ${brandInstance.value.name} before attempting to create it from Salto`,
     }])
   })


### PR DESCRIPTION
_improve subdomain handling when creating brands_

---

_Additional context for reviewer_
None

---
_Release Notes_: 
Zendesk:
* check availability of subdomain before creation of brand

---
_User Notifications_: 
None
