### PR TITLE
SALTO-3303: fix a bug with users Id - Jira DC

### DIFF
--- a/packages/jira-adapter/src/change_validators/wrong_user_permission_scheme.ts
+++ b/packages/jira-adapter/src/change_validators/wrong_user_permission_scheme.ts
@@ -50,8 +50,10 @@ export const wrongUserPermissionSchemeValidator: (
     if (!(config.fetch.convertUsersIds ?? true)) {
       return []
     }
-    const { baseUrl } = client
-    const idMap = await getIdMapFunc()
+    const { baseUrl, isDataCenter } = client
+    const idMap = isDataCenter
+      ? Object.fromEntries(Object.entries(await getIdMapFunc()).map(([key, mapValue]) => [mapValue, key]))
+      : await getIdMapFunc()
     const wrongUserPermissionSchemePredicate = wrongUserPermissionSchemePredicateCreator(idMap)
     return changes
       .filter(isInstanceChange)

--- a/packages/jira-adapter/src/filters/account_id/user_id_filter.ts
+++ b/packages/jira-adapter/src/filters/account_id/user_id_filter.ts
@@ -14,7 +14,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { getChangeData, isAdditionOrModificationChange, isInstanceElement, isInstanceChange } from '@salto-io/adapter-api'
+import { isInstanceElement } from '@salto-io/adapter-api'
 import { walkOnElement } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
@@ -61,33 +61,6 @@ const filter: FilterCreator = ({ client, config, getIdMapFunc }) => ({
         }
       })
   }, 'user_id_filter fetch'),
-  preDeploy: async changes => {
-    if (!(config.fetch.convertUsersIds ?? true)
-        || !client.isDataCenter) {
-      return
-    }
-    const idMap = await getIdMapFunc()
-    const reversedIdMap: IdMap = Object.fromEntries(Object.entries(idMap).map(([key, mapValue]) => [mapValue, key]))
-    changes
-      .filter(isInstanceChange)
-      .filter(isAdditionOrModificationChange)
-      .map(getChangeData)
-      .forEach(element =>
-        walkOnElement({ element, func: walkOnUsers(convertId(reversedIdMap)) }))
-  },
-  onDeploy: async changes => log.time(async () => {
-    if (!(config.fetch.convertUsersIds ?? true)
-       || !client.isDataCenter) {
-      return
-    }
-    const idMap = await getIdMapFunc()
-    changes
-      .filter(isInstanceChange)
-      .filter(isAdditionOrModificationChange)
-      .map(getChangeData)
-      .forEach(element =>
-        walkOnElement({ element, func: walkOnUsers(convertId(idMap)) }))
-  }, 'user_id_filter deploy'),
 })
 
 export default filter

--- a/packages/jira-adapter/src/filters/account_id/user_id_filter.ts
+++ b/packages/jira-adapter/src/filters/account_id/user_id_filter.ts
@@ -21,7 +21,7 @@ import { collections } from '@salto-io/lowerdash'
 import { FilterCreator } from '../../filter'
 import { walkOnUsers, WalkOnUsersCallback } from './account_id_filter'
 import { IdMap } from '../../users_map'
-import { AUTOMATION_TYPE, DASHBOARD_TYPE } from '../../constants'
+import { PROJECT_TYPE } from '../../constants'
 
 const { awu } = collections.asynciterable
 const log = logger(module)
@@ -73,7 +73,7 @@ const filter: FilterCreator = ({ client, config, getIdMapFunc }) => ({
       .filter(isInstanceChange)
       .filter(isAdditionOrModificationChange)
       .map(getChangeData)
-      .filter(instance => instance.elemID.typeName === AUTOMATION_TYPE || instance.elemID.typeName === DASHBOARD_TYPE)
+      .filter(instance => instance.elemID.typeName !== PROJECT_TYPE)
       .forEach(element =>
         walkOnElement({ element, func: walkOnUsers(convertId(reversedIdMap)) }))
   },
@@ -87,7 +87,7 @@ const filter: FilterCreator = ({ client, config, getIdMapFunc }) => ({
       .filter(isInstanceChange)
       .filter(isAdditionOrModificationChange)
       .map(getChangeData)
-      .filter(instance => instance.elemID.typeName === AUTOMATION_TYPE || instance.elemID.typeName === DASHBOARD_TYPE)
+      .filter(instance => instance.elemID.typeName !== PROJECT_TYPE)
       .forEach(element =>
         walkOnElement({ element, func: walkOnUsers(convertId(idMap)) }))
   }, 'user_id_filter deploy'),

--- a/packages/jira-adapter/src/filters/account_id/user_id_filter.ts
+++ b/packages/jira-adapter/src/filters/account_id/user_id_filter.ts
@@ -21,7 +21,7 @@ import { collections } from '@salto-io/lowerdash'
 import { FilterCreator } from '../../filter'
 import { walkOnUsers, WalkOnUsersCallback } from './account_id_filter'
 import { IdMap } from '../../users_map'
-import { AUTOMATION_TYPE } from '../../constants'
+import { AUTOMATION_TYPE, DASHBOARD_TYPE } from '../../constants'
 
 const { awu } = collections.asynciterable
 const log = logger(module)
@@ -73,7 +73,7 @@ const filter: FilterCreator = ({ client, config, getIdMapFunc }) => ({
       .filter(isInstanceChange)
       .filter(isAdditionOrModificationChange)
       .map(getChangeData)
-      .filter(instance => instance.elemID.typeName === AUTOMATION_TYPE)
+      .filter(instance => instance.elemID.typeName === AUTOMATION_TYPE || instance.elemID.typeName === DASHBOARD_TYPE)
       .forEach(element =>
         walkOnElement({ element, func: walkOnUsers(convertId(reversedIdMap)) }))
   },
@@ -87,7 +87,7 @@ const filter: FilterCreator = ({ client, config, getIdMapFunc }) => ({
       .filter(isInstanceChange)
       .filter(isAdditionOrModificationChange)
       .map(getChangeData)
-      .filter(instance => instance.elemID.typeName === AUTOMATION_TYPE)
+      .filter(instance => instance.elemID.typeName === AUTOMATION_TYPE || instance.elemID.typeName === DASHBOARD_TYPE)
       .forEach(element =>
         walkOnElement({ element, func: walkOnUsers(convertId(idMap)) }))
   }, 'user_id_filter deploy'),

--- a/packages/jira-adapter/src/filters/permission_scheme/wrong_user_permission_scheme_filter.ts
+++ b/packages/jira-adapter/src/filters/permission_scheme/wrong_user_permission_scheme_filter.ts
@@ -34,14 +34,16 @@ export const wrongUserPermissionSchemePredicateCreator = (idMap: IdMap): OmitCha
  * pre deploy removes permissions within a permission scheme that contain a wrong account id.
  * on deploy adds those permissions back
  */
-const filter: FilterCreator = ({ config, getIdMapFunc }) => {
+const filter: FilterCreator = ({ config, client, getIdMapFunc }) => {
   let erroneousPermissionSchemes: Record<string, PermissionHolder[]> = {}
   return ({
     preDeploy: async (changes: Change<ChangeDataType>[]) => {
       if (!(config.fetch.convertUsersIds ?? true)) {
         return
       }
-      const idMap = await getIdMapFunc()
+      const idMap = client.isDataCenter
+        ? Object.fromEntries(Object.entries(await getIdMapFunc()).map(([key, mapValue]) => [mapValue, key]))
+        : await getIdMapFunc()
       erroneousPermissionSchemes = omitChanges(
         changes,
         wrongUserPermissionSchemePredicateCreator(idMap)

--- a/packages/jira-adapter/test/filters/account_id/user_id_filter.test.ts
+++ b/packages/jira-adapter/test/filters/account_id/user_id_filter.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ElemID, ElemIdGetter, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import { ElemID, ElemIdGetter, InstanceElement, ObjectType } from '@salto-io/adapter-api'
 import { mockFunction, MockInterface } from '@salto-io/test-utils'
 import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
 import _ from 'lodash'
@@ -267,38 +267,12 @@ describe('convert userId to key in Jira DC', () => {
         undefined
       )
       common.checkInstanceUserIds(instances[2], '2', NAME_PREFIX)
-      await filter.preDeploy([
-        toChange({ after: instances[0] }),
-        toChange({ before: instances[1], after: instances[2] }),
-      ])
-      expect(mockConnection.get).toHaveBeenCalledOnce()
-      expect(mockConnection.get).toHaveBeenCalledWith(
-        '/rest/api/2/user/search?username=.',
-        undefined
-      )
-      common.checkInstanceUserIds(instances[2], '2', EMPTY_STRING)
-      common.checkInstanceUserIds(instances[0], '0', EMPTY_STRING)
-      await filter.onDeploy([
-        toChange({ after: instances[0] }),
-        toChange({ before: instances[1], after: instances[2] }),
-      ])
-      expect(mockConnection.get).toHaveBeenCalledOnce()
-      expect(mockConnection.get).toHaveBeenCalledWith(
-        '/rest/api/2/user/search?username=.',
-        undefined
-      )
-      common.checkInstanceUserIds(instances[2], '2', NAME_PREFIX)
-      common.checkInstanceUserIds(instances[0], '0', NAME_PREFIX)
     })
     it('should convert userId to key and backwards in all defined types', async () => {
       await awu(ACCOUNT_ID_TYPES).forEach(async typeName => {
         const type = common.createType(typeName)
         const instance = common.createObjectedInstance('2', type)
         await filter.onFetch([instance])
-        common.checkInstanceUserIds(instance, '2', NAME_PREFIX, PARAMETER_STYLE_TYPES.includes(typeName))
-        await filter.preDeploy([toChange({ after: instance })])
-        common.checkInstanceUserIds(instance, '2', EMPTY_STRING, PARAMETER_STYLE_TYPES.includes(typeName))
-        await filter.onDeploy([toChange({ after: instance })])
         common.checkInstanceUserIds(instance, '2', NAME_PREFIX, PARAMETER_STYLE_TYPES.includes(typeName))
       })
     })
@@ -307,10 +281,6 @@ describe('convert userId to key in Jira DC', () => {
       const instance = common.createObjectedInstance('2', type)
       await filter.onFetch([instance])
       common.checkInstanceUserIds(instances[2], '2', EMPTY_STRING)
-      await filter.preDeploy([toChange({ after: instance })])
-      common.checkInstanceUserIds(instance, '2', EMPTY_STRING)
-      await filter.onDeploy([toChange({ after: instance })])
-      common.checkInstanceUserIds(instance, '2', EMPTY_STRING)
     })
   })
 })


### PR DESCRIPTION
_fix a bug with Users Id in Jira DC_

---

_The bug came from differences between our development DC local server to a real DC server_

* make the part in `user_id_filter` where we convert the userName to userKey and backwards only for automation instances (`preDeploy` and `onDeploy` - which is needed only for them.
* added a suitable `idMap` to `wrong_user_permission_scheme_filter` and to `wrong_user_permission_scheme` (change validator) to support DC userNames 

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
