### PR TITLE
SALTO-3365: Fixed a regression bug that caused retrieval of excluded instances from installed packages

### DIFF
--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -145,7 +145,6 @@ const listMetadataObjectsWithinFolders = async (
   )
   const elements = result
     .map(props => withFullPath(props, folderPathByName))
-    .filter(props => notInSkipList(metadataQuery, props, false))
     .concat(includedFolderElements)
   const configChanges = (errors?.map(createListMetadataObjectsConfigChange) ?? [])
     .concat(folders.configChanges)
@@ -346,7 +345,7 @@ export const retrieveMetadataInstances = async ({
       // We get folders as part of getting the records inside them
       .filter(type => type.annotations.folderContentType === undefined)
       .map(listFilesOfType)
-  ))
+  )).filter(props => notInSkipList(metadataQuery, props, false))
 
   log.info('going to retrieve %d files', filesToRetrieve.length)
 


### PR DESCRIPTION
This is an edge case on [this](https://app-staging.salto.io/orgs/e1264bd9-af40-456d-a87f-0b1754c7e3f8/envs/9d1738e5-0045-4ee9-805d-80cc6eee8da0/explore?file=%2Fsalto.config%2Fadapters%2Fsalesforce%2Fsalesforce.nacl) env. 
As you can see, CPQ is not in the fetch config, but installed on the org. One of the `client.retrieve` flows (For types that are not listed within folders) didn't filter out the result, hence we retrieved the instances from CPQ.

---

_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
