### PR TITLE
SALTO-3156: Added mapping by HTTP_ERROR_CODE for user facing errors in Salesforce adapter

### DIFF
--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -1081,8 +1081,8 @@ export const resolveTypeShallow = async (
   }
 }
 
-export const createSchemeGuard = <T>(scheme: Joi.AnySchema, errorMessage?: string)
-: (value: unknown) => value is T => (value): value is T => {
+export const createSchemeGuard = <T, U = unknown>(scheme: Joi.AnySchema, errorMessage?: string)
+: (value: U) => value is U & T => (value): value is U & T => {
     const { error } = scheme.validate(value)
     if (error !== undefined) {
       if (errorMessage !== undefined) {

--- a/packages/salesforce-adapter/src/client/decorators.ts
+++ b/packages/salesforce-adapter/src/client/decorators.ts
@@ -1,0 +1,59 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import Joi from 'joi'
+import { createSchemeGuard } from '@salto-io/adapter-utils'
+import _ from 'lodash'
+import { decorators, values } from '@salto-io/lowerdash'
+import { logger } from '@salto-io/logging'
+import { ERROR_CODE_TO_USER_VISIBLE_ERROR, isMappableErrorCode } from './user_facing_errors'
+
+const log = logger(module)
+const { isDefined } = values
+
+const JSFORCE_ERROR_SCHEMA = Joi.object({
+  errorCode: Joi.string().required(),
+}).unknown(true).required()
+
+export type JSForceError = Error & {
+  errorCode: string
+}
+
+const isJSForceError = createSchemeGuard<JSForceError, Error>(JSFORCE_ERROR_SCHEMA)
+
+const getErrorCode = (jsforceError: JSForceError): number | undefined => {
+  const errorCode = Number(_.last(jsforceError.errorCode.split('_')))
+  if (Number.isNaN(errorCode)) {
+    log.warn('Could not parse JSForce errorCode: %s', jsforceError.errorCode)
+    return undefined
+  }
+  return errorCode
+}
+
+export const mapErrors = decorators.wrapMethodWith(
+  async (original: decorators.OriginalCall): Promise<unknown> => {
+    try {
+      return await Promise.resolve(original.call())
+    } catch (e: unknown) {
+      if (_.isError(e) && isJSForceError(e)) {
+        const errorCode = getErrorCode(e)
+        if (isDefined(errorCode) && isMappableErrorCode(errorCode)) {
+          e.message = ERROR_CODE_TO_USER_VISIBLE_ERROR[errorCode]
+        }
+      }
+      throw e
+    }
+  }
+)

--- a/packages/salesforce-adapter/src/client/user_facing_errors.ts
+++ b/packages/salesforce-adapter/src/client/user_facing_errors.ts
@@ -1,0 +1,34 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+
+const MAPPABLE_ERROR_CODES = [
+  502,
+] as const
+
+export type MappableErrorCode = typeof MAPPABLE_ERROR_CODES[number]
+
+const VISIBLE_ERROR_502 = 'We are unable to connect to your Salesforce account right now. '
+  + 'This is either an issue on the Salesforce side (please check https://status.salesforce.com/current/incidents) '
+  + 'or on the Salto side (please check https://status.salto.io/ or contact support@salto.io)'
+
+export const ERROR_CODE_TO_USER_VISIBLE_ERROR: Record<MappableErrorCode, string> = {
+  502: VISIBLE_ERROR_502,
+}
+
+export const isMappableErrorCode = (errorCode: number): errorCode is MappableErrorCode => (
+  (MAPPABLE_ERROR_CODES as ReadonlyArray<number>).includes(errorCode)
+)


### PR DESCRIPTION
Previous to this PR, we used to pass the HTTP errors as they came in the response from Salesforce. In some cases, we would like to change the user facing error displayed to the users.

---

This PR adds the ability to set a custom user facing error message for a specific HTTP error code.

---
_Release Notes_: 
Salesforce Adapter:
- User friendly error message for HTTP_ERROR_502

---
_User Notifications_: 
_None_