### PR TITLE
SALTO-3343: WorkflowShcemes' names can be modified to existing names 

### DIFF
--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -40,6 +40,7 @@ import { wrongUserPermissionSchemeValidator } from './wrong_user_permission_sche
 import { GetIdMapFunc } from '../users_map'
 import { accountIdValidator } from './account_id'
 import { screenSchemeDefaultValidator } from './screen_scheme_default'
+import { workflowSchemeDupsValidator } from './workflow_scheme_dups'
 
 const {
   deployTypesNotSupportedValidator,
@@ -72,6 +73,7 @@ export default (
     screenSchemeDefaultValidator,
     wrongUserPermissionSchemeValidator(client, config, getIdMapFunc),
     accountIdValidator(client, config, getIdMapFunc),
+    workflowSchemeDupsValidator,
   ]
 
   return createChangeValidator(validators)

--- a/packages/jira-adapter/src/change_validators/workflow_scheme_dups.ts
+++ b/packages/jira-adapter/src/change_validators/workflow_scheme_dups.ts
@@ -41,6 +41,6 @@ export const workflowSchemeDupsValidator: ChangeValidator = async (changes, elem
       elemID: instance.elemID,
       severity: 'Error' as SeverityLevel,
       message: 'Workflow scheme names must be unique',
-      detailedMessage: `A workflow scheme with the name "${instance.value.name}" already exists`,
+      detailedMessage: `A workflow scheme with the name "${instance.value.name}" already exists (the name is case insensitive)`,
     }))
 }

--- a/packages/jira-adapter/src/change_validators/workflow_scheme_dups.ts
+++ b/packages/jira-adapter/src/change_validators/workflow_scheme_dups.ts
@@ -1,0 +1,46 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ChangeValidator, getChangeData, isAdditionOrModificationChange, isInstanceChange, SeverityLevel } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { WORKFLOW_SCHEME_TYPE_NAME } from '../constants'
+
+const { awu } = collections.asynciterable
+
+export const workflowSchemeDupsValidator: ChangeValidator = async (changes, elementSource) => {
+  if (elementSource === undefined) {
+    return []
+  }
+
+  const nameToInstance = await awu(await elementSource.list())
+    .filter(id => id.idType === 'instance' && id.typeName === WORKFLOW_SCHEME_TYPE_NAME)
+    .map(id => elementSource.get(id))
+    .groupBy(instance => instance.value.name?.toLowerCase())
+
+  return changes
+    .filter(isInstanceChange)
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+    .filter(instance => instance.elemID.typeName === WORKFLOW_SCHEME_TYPE_NAME)
+    .filter(instance => Object.prototype.hasOwnProperty.call(nameToInstance, instance.value.name?.toLowerCase())
+        && nameToInstance[instance.value.name?.toLowerCase()]
+          .some(dupInstance => !instance.elemID.isEqual(dupInstance.elemID)))
+    .map(instance => ({
+      elemID: instance.elemID,
+      severity: 'Error' as SeverityLevel,
+      message: 'Workflow scheme names must be unique',
+      detailedMessage: `A workflow scheme with the name "${instance.value.name}" already exists`,
+    }))
+}

--- a/packages/jira-adapter/test/change_validators/workflow_scheme_dups.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflow_scheme_dups.test.ts
@@ -1,0 +1,87 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { toChange, ObjectType, ElemID, InstanceElement, ReadOnlyElementsSource } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { workflowSchemeDupsValidator } from '../../src/change_validators/workflow_scheme_dups'
+import { JIRA, WORKFLOW_SCHEME_TYPE_NAME } from '../../src/constants'
+
+describe('workflowSchemeDupsValidator', () => {
+  let type: ObjectType
+  let instance1: InstanceElement
+  let instance2: InstanceElement
+  let elementSource: ReadOnlyElementsSource
+
+  beforeEach(() => {
+    type = new ObjectType({ elemID: new ElemID(JIRA, WORKFLOW_SCHEME_TYPE_NAME) })
+    instance1 = new InstanceElement(
+      'instance1',
+      type,
+      {
+        name: 'name1',
+      }
+    )
+
+    instance2 = new InstanceElement(
+      'instance2',
+      type,
+      {
+        name: 'name2',
+      }
+    )
+
+    elementSource = buildElementsSourceFromElements([instance1, instance2])
+  })
+  it('should return an error if instance name is not unique', async () => {
+    instance1.value.name = 'name2'
+    expect(await workflowSchemeDupsValidator(
+      [
+        toChange({
+          after: instance1,
+        }),
+      ],
+      elementSource,
+    )).toEqual([
+      {
+        elemID: instance1.elemID,
+        severity: 'Error',
+        message: 'Workflow scheme names must be unique',
+        detailedMessage: 'A workflow scheme with the name "name2" already exists',
+      },
+    ])
+  })
+  it('should not return an error if instance name is not unique', async () => {
+    expect(await workflowSchemeDupsValidator(
+      [
+        toChange({
+          after: instance1,
+        }),
+      ],
+      elementSource,
+    )).toEqual([])
+  })
+
+  it('should do nothing if workflow scheme does not have a name', async () => {
+    delete instance1.value.name
+    expect(await workflowSchemeDupsValidator(
+      [
+        toChange({
+          after: instance1,
+        }),
+      ],
+      elementSource,
+    )).toEqual([])
+  })
+})

--- a/packages/jira-adapter/test/change_validators/workflow_scheme_dups.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflow_scheme_dups.test.ts
@@ -58,11 +58,42 @@ describe('workflowSchemeDupsValidator', () => {
         elemID: instance1.elemID,
         severity: 'Error',
         message: 'Workflow scheme names must be unique',
-        detailedMessage: 'A workflow scheme with the name "name2" already exists',
+        detailedMessage: 'A workflow scheme with the name "name2" already exists (the name is case insensitive)',
       },
     ])
   })
-  it('should not return an error if instance name is not unique', async () => {
+
+  it('should return an error if instance name is not unique with different case', async () => {
+    instance1.value.name = 'NaMe2'
+    expect(await workflowSchemeDupsValidator(
+      [
+        toChange({
+          after: instance1,
+        }),
+      ],
+      elementSource,
+    )).toEqual([
+      {
+        elemID: instance1.elemID,
+        severity: 'Error',
+        message: 'Workflow scheme names must be unique',
+        detailedMessage: 'A workflow scheme with the name "NaMe2" already exists (the name is case insensitive)',
+      },
+    ])
+  })
+
+  it('should do nothing if element source is not passed', async () => {
+    instance1.value.name = 'name2'
+    expect(await workflowSchemeDupsValidator(
+      [
+        toChange({
+          after: instance1,
+        }),
+      ],
+    )).toEqual([])
+  })
+
+  it('should not return an error if instance name is unique', async () => {
     expect(await workflowSchemeDupsValidator(
       [
         toChange({


### PR DESCRIPTION
Added validation for workflow scheme name uniqueness on deploy

---

_Additional context for reviewer_

---
_Release Notes_: 
Added validation for workflow scheme name uniqueness on deploy

---
_User Notifications_: 
None