### PR TITLE
SALTO-3324: Creating a screenScheme without a default screen should be blocked screen

### DIFF
--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -39,6 +39,7 @@ import { permissionSchemeValidator } from './sd_portals_permission_scheme'
 import { wrongUserPermissionSchemeValidator } from './wrong_user_permission_scheme'
 import { GetIdMapFunc } from '../users_map'
 import { accountIdValidator } from './account_id'
+import { screenSchemeDefaultValidator } from './screen_scheme_default'
 
 const {
   deployTypesNotSupportedValidator,
@@ -68,6 +69,7 @@ export default (
     systemFieldsValidator,
     workflowPropertiesValidator,
     permissionSchemeValidator,
+    screenSchemeDefaultValidator,
     wrongUserPermissionSchemeValidator(client, config, getIdMapFunc),
     accountIdValidator(client, config, getIdMapFunc),
   ]

--- a/packages/jira-adapter/src/change_validators/screen_scheme_default.ts
+++ b/packages/jira-adapter/src/change_validators/screen_scheme_default.ts
@@ -1,0 +1,31 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ChangeValidator, getChangeData, isAdditionOrModificationChange, isInstanceChange, SeverityLevel } from '@salto-io/adapter-api'
+import { SCREEN_SCHEME_TYPE } from '../constants'
+
+export const screenSchemeDefaultValidator: ChangeValidator = async changes =>
+  changes
+    .filter(isInstanceChange)
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+    .filter(instance => instance.elemID.typeName === SCREEN_SCHEME_TYPE)
+    .filter(instance => instance.value.screens?.default === undefined)
+    .map(instance => ({
+      elemID: instance.elemID,
+      severity: 'Error' as SeverityLevel,
+      message: 'ScreenScheme must include default screen',
+      detailedMessage: 'ScreenScheme does not include a default screen',
+    }))

--- a/packages/jira-adapter/src/constants.ts
+++ b/packages/jira-adapter/src/constants.ts
@@ -67,3 +67,4 @@ export const ACCOUNT_IDS_FIELDS_NAMES = ['leadAccountId', 'authorAccountId', 'ac
 export const JIRA_USERS_PAGE = 'jira/people/search'
 export const ISSUE_EVENT_TYPE_NAME = 'IssueEvent'
 export const PRIORITY_SCHEME_TYPE_NAME = 'PriorityScheme'
+export const SCREEN_SCHEME_TYPE = 'ScreenScheme'

--- a/packages/jira-adapter/test/change_validators/screen_scheme_default.test.ts
+++ b/packages/jira-adapter/test/change_validators/screen_scheme_default.test.ts
@@ -1,0 +1,77 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { toChange, ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { screenSchemeDefaultValidator } from '../../src/change_validators/screen_scheme_default'
+import { JIRA, SCREEN_SCHEME_TYPE } from '../../src/constants'
+
+describe('screenSchemeDefaultValidator', () => {
+  let type: ObjectType
+  let instance: InstanceElement
+
+  beforeEach(() => {
+    type = new ObjectType({ elemID: new ElemID(JIRA, SCREEN_SCHEME_TYPE) })
+    instance = new InstanceElement(
+      'instance',
+      type,
+      {
+        screens: {
+          default: '123',
+        },
+      }
+    )
+  })
+  it('should return an error if there is no default screen', async () => {
+    delete instance.value.screens.default
+
+    expect(await screenSchemeDefaultValidator([
+      toChange({
+        after: instance,
+      }),
+    ])).toEqual([
+      {
+        elemID: instance.elemID,
+        severity: 'Error',
+        message: 'ScreenScheme must include default screen',
+        detailedMessage: 'ScreenScheme does not include a default screen',
+      },
+    ])
+  })
+
+  it('should return an error if there is no screens', async () => {
+    delete instance.value.screens
+
+    expect(await screenSchemeDefaultValidator([
+      toChange({
+        after: instance,
+      }),
+    ])).toEqual([
+      {
+        elemID: instance.elemID,
+        severity: 'Error',
+        message: 'ScreenScheme must include default screen',
+        detailedMessage: 'ScreenScheme does not include a default screen',
+      },
+    ])
+  })
+
+  it('should not return an error if there is default screen', async () => {
+    expect(await screenSchemeDefaultValidator([
+      toChange({
+        after: instance,
+      }),
+    ])).toEqual([])
+  })
+})

--- a/packages/jira-adapter/test/change_validators/screen_scheme_default.test.ts
+++ b/packages/jira-adapter/test/change_validators/screen_scheme_default.test.ts
@@ -18,11 +18,10 @@ import { screenSchemeDefaultValidator } from '../../src/change_validators/screen
 import { JIRA, SCREEN_SCHEME_TYPE } from '../../src/constants'
 
 describe('screenSchemeDefaultValidator', () => {
-  let type: ObjectType
   let instance: InstanceElement
 
   beforeEach(() => {
-    type = new ObjectType({ elemID: new ElemID(JIRA, SCREEN_SCHEME_TYPE) })
+    const type = new ObjectType({ elemID: new ElemID(JIRA, SCREEN_SCHEME_TYPE) })
     instance = new InstanceElement(
       'instance',
       type,


### PR DESCRIPTION
Added a change validator to prevent deploying a screen scheme without a default screen

---

_Additional context for reviewer_

---
_Release Notes_: 
__Jira Adapter__:
- Added a change validator to prevent deploying a screen scheme without a default screen

---
_User Notifications_: 
None