### PR TITLE
SALTO-3084/fix permission deploy crash

### DIFF
--- a/packages/jira-adapter/src/change_validators/permission_type.ts
+++ b/packages/jira-adapter/src/change_validators/permission_type.ts
@@ -51,7 +51,7 @@ const getInvalidPermissions = (
   permissionScheme: InstanceElement,
   allowedPermissions: Set<string>,
 ): string[] =>
-  permissionScheme.value.permissions
+  (permissionScheme.value.permissions ?? [])
     .map((permission: { permission: string }) => permission.permission)
     .filter((permission: string) => !allowedPermissions.has(permission))
 

--- a/packages/jira-adapter/test/change_validators/permission_type.test.ts
+++ b/packages/jira-adapter/test/change_validators/permission_type.test.ts
@@ -48,6 +48,8 @@ describe('permissionType change validator', () => {
       },
     ],
   })
+  const noFieldPermissionScheme = new InstanceElement('instance2', permissionSchemeObject, {
+  })
 
   beforeEach(() => {
     elements = [invalidPermissionScheme, permissionsInstance, validPermissionScheme]
@@ -79,6 +81,14 @@ describe('permissionType change validator', () => {
     elementsSource = buildElementsSourceFromElements([])
     expect(await permissionTypeValidator(
       [toChange({ after: invalidPermissionScheme })],
+      elementsSource
+    )).toBeEmpty()
+  })
+  it('should not crash if there are no permissions field', async () => {
+    elements = [noFieldPermissionScheme, permissionsInstance]
+    elementsSource = buildElementsSourceFromElements(elements)
+    expect(await permissionTypeValidator(
+      [toChange({ after: noFieldPermissionScheme })],
       elementsSource
     )).toBeEmpty()
   })


### PR DESCRIPTION
the code crashed trying to map an undefined field, i made sure we dont assume it exists.
added ut for it.

---

_Additional context for reviewer_

---
_Release Notes_: 


---
_User Notifications_: 

