### PR TITLE
SALTO-2902/sort list fields

### DIFF
--- a/packages/jira-adapter/src/filters/sort_lists.ts
+++ b/packages/jira-adapter/src/filters/sort_lists.ts
@@ -18,7 +18,7 @@ import { transformValues } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
-import { AUTOMATION_TYPE, DASHBOARD_TYPE, NOTIFICATION_EVENT_TYPE_NAME, NOTIFICATION_SCHEME_TYPE_NAME, PROJECT_ROLE_TYPE, WORKFLOW_RULES_TYPE_NAME, WORKFLOW_TRANSITION_TYPE_NAME, WORKFLOW_TYPE_NAME } from '../constants'
+import { AUTOMATION_TYPE, DASHBOARD_TYPE, NOTIFICATION_EVENT_TYPE_NAME, NOTIFICATION_SCHEME_TYPE_NAME, PROJECT_ROLE_TYPE, WORKFLOW_RULES_TYPE_NAME, WORKFLOW_STATUS_TYPE_NAME, WORKFLOW_TRANSITION_TYPE_NAME, WORKFLOW_TYPE_NAME } from '../constants'
 import { FilterCreator } from '../filter'
 
 const { awu } = collections.asynciterable
@@ -79,6 +79,9 @@ const VALUES_TO_SORT: Record<string, Record<string, string[]>> = {
   },
   [PROJECT_ROLE_TYPE]: {
     actors: ['displayName'],
+  },
+  [WORKFLOW_STATUS_TYPE_NAME]: {
+    properties: ['key'],
   },
 }
 

--- a/packages/jira-adapter/src/filters/sort_lists.ts
+++ b/packages/jira-adapter/src/filters/sort_lists.ts
@@ -18,7 +18,7 @@ import { transformValues } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
-import { AUTOMATION_TYPE, NOTIFICATION_EVENT_TYPE_NAME, NOTIFICATION_SCHEME_TYPE_NAME, WORKFLOW_RULES_TYPE_NAME, WORKFLOW_TRANSITION_TYPE_NAME, WORKFLOW_TYPE_NAME } from '../constants'
+import { AUTOMATION_TYPE, DASHBOARD_TYPE, NOTIFICATION_EVENT_TYPE_NAME, NOTIFICATION_SCHEME_TYPE_NAME, PROJECT_ROLE_TYPE, WORKFLOW_RULES_TYPE_NAME, WORKFLOW_TRANSITION_TYPE_NAME, WORKFLOW_TYPE_NAME } from '../constants'
 import { FilterCreator } from '../filter'
 
 const { awu } = collections.asynciterable
@@ -72,6 +72,13 @@ const VALUES_TO_SORT: Record<string, Record<string, string[]>> = {
   },
   [WORKFLOW_TRANSITION_TYPE_NAME]: {
     from: ['elemID.name'],
+    properties: ['key'],
+  },
+  [DASHBOARD_TYPE]: {
+    gadgets: ['elemID.name'],
+  },
+  [PROJECT_ROLE_TYPE]: {
+    actors: ['displayName'],
   },
 }
 


### PR DESCRIPTION
sorted the following list fields
project role - actors field - by display name
dashboard - gadgets field - by each gadget's id
workflow Transition - properties field - by each property name (not id because its not in dc).
workflow status - properties field - by key 

---

_Additional context for reviewer_

---
_Release Notes_: 


---
_User Notifications_: 
jira_adapter:
the following list fields are now being sorted on fetch to avoid file changes noise
dashboard.gadgets
workflow.Transition.properties
workflow.statuses.properties
projectRole.actors
