### PR TITLE
SALTO-3376: cannot deploy ticket form when `required_on_statuses` has both `statuses` and `custom_statuses` fields

### DIFF
--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -112,6 +112,7 @@ import everyoneUserSegmentFilter from './filters/everyone_user_segment'
 import guideArrangePaths from './filters/guide_arrange_paths'
 import guideDefaultLanguage from './filters/guide_default_language_settings'
 import guideAddBrandToArticleTranslation from './filters/guide_add_brand_to_translation'
+import ticketFormDeploy from './filters/ticket_form'
 
 const { makeArray } = collections.array
 const log = logger(module)
@@ -156,6 +157,7 @@ export const DEFAULT_FILTERS = [
   tagsFilter,
   guideAddBrandToArticleTranslation,
   macroAttachmentsFilter,
+  ticketFormDeploy,
   brandLogoFilter,
   // removeBrandLogoFilter should be after brandLogoFilter
   removeBrandLogoFilter,

--- a/packages/zendesk-adapter/src/change_validators/order.ts
+++ b/packages/zendesk-adapter/src/change_validators/order.ts
@@ -22,10 +22,9 @@ import {
 import { collections } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import { createOrderTypeName } from '../filters/reorder/creator'
-import { ORG_FIELD_TYPE_NAME, USER_FIELD_TYPE_NAME } from '../constants'
+import { ORG_FIELD_TYPE_NAME, TICKET_FORM_TYPE_NAME, USER_FIELD_TYPE_NAME } from '../constants'
 import { TYPE_NAME as AUTOMATION_TYPE_NAME } from '../filters/reorder/automation'
 import { TYPE_NAME as SLA_POLICY_TYPE_NAME } from '../filters/reorder/sla_policy'
-import { TYPE_NAME as TICKET_FORM_TYPE_NAME } from '../filters/reorder/ticket_form'
 import { TYPE_NAME as VIEW_TYPE_NAME } from '../filters/reorder/view'
 import { TYPE_NAME as WORKSPACE_TYPE_NAME } from '../filters/reorder/workspace'
 

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -1531,13 +1531,6 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
       },
     },
   },
-  ticket_form__agent_conditions__child_fields__required_on_statuses: {
-    transformation: {
-      fieldsToOmit: FIELDS_TO_OMIT.concat(
-        { fieldName: 'statuses' },
-      ),
-    },
-  },
   // eslint-disable-next-line camelcase
   ticket_fields: {
     request: {

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -1531,6 +1531,13 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
       },
     },
   },
+  ticket_form__agent_conditions__child_fields__required_on_statuses: {
+    transformation: {
+      fieldsToOmit: FIELDS_TO_OMIT.concat(
+        { fieldName: 'statuses' },
+      ),
+    },
+  },
   // eslint-disable-next-line camelcase
   ticket_fields: {
     request: {

--- a/packages/zendesk-adapter/src/constants.ts
+++ b/packages/zendesk-adapter/src/constants.ts
@@ -34,6 +34,8 @@ export const ORG_FIELD_TYPE_NAME = 'organization_field'
 export const USER_FIELD_TYPE_NAME = 'user_field'
 export const FIELD_TYPE_NAMES = [TICKET_FIELD_TYPE_NAME, USER_FIELD_TYPE_NAME, ORG_FIELD_TYPE_NAME]
 export const EVERYONE_USER_TYPE = 'Everyone'
+export const TICKET_FORM_TYPE_NAME = 'ticket_form'
+
 
 export const CATEGORY_ORDER_TYPE_NAME = 'category_order'
 export const SECTION_ORDER_TYPE_NAME = 'section_order'

--- a/packages/zendesk-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-adapter/src/filters/field_references.ts
@@ -19,7 +19,14 @@ import { references as referenceUtils } from '@salto-io/adapter-components'
 import { GetLookupNameFunc } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
-import { BRAND_TYPE_NAME, TICKET_FIELD_TYPE_NAME, USER_FIELD_TYPE_NAME, ORG_FIELD_TYPE_NAME, FIELD_TYPE_NAMES } from '../constants'
+import {
+  BRAND_TYPE_NAME,
+  TICKET_FIELD_TYPE_NAME,
+  USER_FIELD_TYPE_NAME,
+  ORG_FIELD_TYPE_NAME,
+  FIELD_TYPE_NAMES,
+  TICKET_FORM_TYPE_NAME,
+} from '../constants'
 import { FETCH_CONFIG } from '../config'
 import { ZendeskMissingReferenceStrategyLookup } from './references/missing_references'
 
@@ -42,7 +49,7 @@ const NEIGHBOR_FIELD_TO_TYPE_NAMES: Record<string, string> = {
   schedule_id: 'business_hours_schedule',
   within_schedule: 'business_hours_schedule',
   set_schedule: 'business_hours_schedule',
-  ticket_form_id: 'ticket_form',
+  ticket_form_id: TICKET_FORM_TYPE_NAME,
   locale_id: 'locale',
   via_id: 'channel',
   current_via_id: 'channel',
@@ -367,12 +374,12 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
   {
     src: { field: 'active', parentTypes: ['ticket_form_order'] },
     serializationStrategy: 'id',
-    target: { type: 'ticket_form' },
+    target: { type: TICKET_FORM_TYPE_NAME },
   },
   {
     src: { field: 'inactive', parentTypes: ['ticket_form_order'] },
     serializationStrategy: 'id',
-    target: { type: 'ticket_form' },
+    target: { type: TICKET_FORM_TYPE_NAME },
   },
   {
     src: { field: 'active', parentTypes: ['organization_field_order'] },
@@ -624,13 +631,13 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
   {
     src: { field: 'ticket_form_id' },
     serializationStrategy: 'id',
-    target: { type: 'ticket_form' },
+    target: { type: TICKET_FORM_TYPE_NAME },
     zendeskMissingRefStrategy: 'typeAndValue',
   },
   {
     src: { field: 'ticket_form_ids' },
     serializationStrategy: 'id',
-    target: { type: 'ticket_form' },
+    target: { type: TICKET_FORM_TYPE_NAME },
   },
   {
     src: { field: 'skill_based_filtered_views' },

--- a/packages/zendesk-adapter/src/filters/reorder/ticket_form.ts
+++ b/packages/zendesk-adapter/src/filters/reorder/ticket_form.ts
@@ -14,14 +14,14 @@
 * limitations under the License.
 */
 import { createReorderFilterCreator } from './creator'
+import { TICKET_FORM_TYPE_NAME } from '../../constants'
 
-export const TYPE_NAME = 'ticket_form'
 
 /**
  * Add ticket forms order element with all the ticket forms ordered
  */
 const filterCreator = createReorderFilterCreator({
-  typeName: TYPE_NAME,
+  typeName: TICKET_FORM_TYPE_NAME,
   orderFieldName: 'ticket_form_ids',
   activeFieldName: 'active',
 })

--- a/packages/zendesk-adapter/src/filters/ticket_form.ts
+++ b/packages/zendesk-adapter/src/filters/ticket_form.ts
@@ -1,0 +1,121 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  Change, DeployResult,
+  getChangeData,
+  InstanceElement, isAdditionChange, isAdditionOrModificationChange, isInstanceChange, isModificationChange, toChange,
+} from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { FilterCreator } from '../filter'
+import { deployChange, deployChanges } from '../deployment'
+
+export const TICKET_FORM_TYPE_NAME = 'ticket_form'
+const SOME_STATUSES = 'SOME_STATUSES'
+
+
+type Child = {
+  // eslint-disable-next-line camelcase
+  required_on_statuses: {
+    type: string
+    statuses?: string[]
+    // eslint-disable-next-line camelcase
+    custom_statuses?: number[]
+  }
+}
+
+type TicketForm = {
+  // eslint-disable-next-line camelcase
+  agent_conditions: {
+    // eslint-disable-next-line camelcase
+    child_fields: Child[]
+  }[]
+}
+
+/**
+ * checks if both statuses and custom_statuses are defined
+ */
+const isInvalidTicketForm = (instanceValue: Record<string, unknown>): instanceValue is TicketForm =>
+  _.isArray(instanceValue.agent_conditions)
+  && instanceValue.agent_conditions.some(condition =>
+    _.isArray(condition.child_fields)
+      && condition.child_fields.some((child: Child) =>
+        _.isObject(child.required_on_statuses)
+        && child.required_on_statuses.type === SOME_STATUSES
+        && (child.required_on_statuses.statuses !== undefined) // even if it is an empty array it is not valid
+        && (child.required_on_statuses.custom_statuses !== undefined
+        && !_.isEmpty(child.required_on_statuses.custom_statuses))))
+
+const invalidTicketFormChange = (change: Change<InstanceElement>): boolean =>
+  TICKET_FORM_TYPE_NAME === getChangeData(change).elemID.typeName
+  && isAdditionOrModificationChange(change)
+  && isInstanceChange(change)
+  && isInvalidTicketForm(getChangeData(change).value)
+
+const returnValidInstance = (arg: InstanceElement): InstanceElement => {
+  const clonedArg = arg.clone()
+  if (isInvalidTicketForm(clonedArg.value)) {
+    clonedArg.value.agent_conditions
+      .forEach(condition => condition.child_fields
+        .forEach(child => {
+          if (child.required_on_statuses.type === SOME_STATUSES
+            && (child.required_on_statuses.statuses !== undefined)
+            && (child.required_on_statuses.custom_statuses !== undefined
+              && !_.isEmpty(child.required_on_statuses.custom_statuses))) {
+            delete child.required_on_statuses.statuses
+          }
+        }))
+  }
+  return clonedArg
+}
+
+
+const filterCreator: FilterCreator = ({ config, client }) => ({
+  deploy: async (changes: Change<InstanceElement>[]) => {
+    const [invalidTicketFormChanges, leftoverChanges] = _.partition(
+      changes,
+      invalidTicketFormChange,
+    )
+
+    const fixedTicketFormChanges = invalidTicketFormChanges.map(change => {
+      if (isAdditionChange(change)) {
+        return toChange({ after: returnValidInstance(getChangeData(change)) })
+      }
+      if (isModificationChange(change)) {
+        const { before } = change.data
+        const { after } = change.data
+        return toChange({ before: returnValidInstance(before), after: returnValidInstance(after) })
+      }
+      return change
+    })
+
+    const tempDeployResult = await deployChanges(
+      fixedTicketFormChanges,
+      async change => {
+        await deployChange(change, client, config.apiDefinitions)
+      }
+    )
+    const deployedChangesElemId = tempDeployResult.appliedChanges
+      .map(change => getChangeData(change).elemID.getFullName())
+
+    const deployResult: DeployResult = {
+      appliedChanges: invalidTicketFormChanges
+        .filter(change => deployedChangesElemId.includes(getChangeData(change).elemID.getFullName())),
+      errors: tempDeployResult.errors,
+    }
+    return { deployResult, leftoverChanges }
+  },
+})
+export default filterCreator

--- a/packages/zendesk-adapter/test/filters/ticket_form.test.ts
+++ b/packages/zendesk-adapter/test/filters/ticket_form.test.ts
@@ -1,0 +1,227 @@
+
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { filterUtils } from '@salto-io/adapter-components'
+import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import filterCreator, { TICKET_FORM_TYPE_NAME } from '../../src/filters/ticket_form'
+import { createFilterCreatorParams } from '../utils'
+import { ZENDESK } from '../../src/constants'
+
+const mockDeployChange = jest.fn()
+jest.mock('@salto-io/adapter-components', () => {
+  const actual = jest.requireActual('@salto-io/adapter-components')
+  return {
+    ...actual,
+    deployment: {
+      ...actual.deployment,
+      deployChange: jest.fn((...args) => mockDeployChange(...args)),
+    },
+  }
+})
+
+describe('ticket form filter', () => {
+  type FilterType = filterUtils.FilterWith<'deploy'>
+  let filter: FilterType
+  const ticketFormType = new ObjectType({ elemID: new ElemID(ZENDESK, TICKET_FORM_TYPE_NAME) })
+  const invalidTicketForm = new InstanceElement(
+    'invalid',
+    ticketFormType,
+    {
+      agent_conditions: [
+        {
+          child_fields: [
+            { required_on_statuses: { type: 'SOME_STATUSES', statuses: ['solved'], custom_statuses: [1] } },
+            { required_on_statuses: { type: 'SOME_STATUSES', statuses: ['solved', 'new'], custom_statuses: [1, 2] } },
+            { required_on_statuses: { type: 'ALL_STATUSES' } },
+          ],
+        },
+        {
+          child_fields: [
+            { required_on_statuses: { type: 'SOME_STATUSES', statuses: ['solved', 'new'], custom_statuses: [1, 2] } },
+            { required_on_statuses: { type: 'NO_STATUSES' } },
+          ],
+        },
+        {
+          child_fields: [
+            { required_on_statuses: { type: 'NO_STATUSES' } },
+          ],
+        },
+      ],
+    },
+  )
+  const fixedTicketForm = new InstanceElement(
+    'invalid',
+    ticketFormType,
+    {
+      agent_conditions: [
+        {
+          child_fields: [
+            { required_on_statuses: { type: 'SOME_STATUSES', custom_statuses: [1] } },
+            { required_on_statuses: { type: 'SOME_STATUSES', custom_statuses: [1, 2] } },
+            { required_on_statuses: { type: 'ALL_STATUSES' } },
+          ],
+        },
+        {
+          child_fields: [
+            { required_on_statuses: { type: 'SOME_STATUSES', custom_statuses: [1, 2] } },
+            { required_on_statuses: { type: 'NO_STATUSES' } },
+          ],
+        },
+        {
+          child_fields: [
+            { required_on_statuses: { type: 'NO_STATUSES' } },
+          ],
+        },
+      ],
+    },
+  )
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
+  })
+
+  describe('deploy', () => {
+    it('should not deploy remove changes', async () => {
+      const clonedElement = invalidTicketForm
+      mockDeployChange
+        .mockImplementation(async () => ({
+          ticket_forms: clonedElement,
+        }))
+      const res = await filter.deploy([toChange({ before: clonedElement })])
+      expect(mockDeployChange).toHaveBeenCalledTimes(0)
+      expect(res.leftoverChanges).toHaveLength(1)
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.deployResult.appliedChanges).toHaveLength(0)
+    })
+
+    it('should not deploy when custum_statuses is undefined', async () => {
+      const validTicketForm = new InstanceElement(
+        'valid',
+        ticketFormType,
+        {
+          agent_conditions: [
+            {
+              child_fields: [
+                { required_on_statuses: { type: 'SOME_STATUSES', statuses: ['solved'] } },
+                { required_on_statuses: { type: 'SOME_STATUSES', statuses: ['solved', 'new'] } },
+                { required_on_statuses: { type: 'ALL_STATUSES' } },
+              ],
+            },
+            {
+              child_fields: [
+                { required_on_statuses: { type: 'SOME_STATUSES', statuses: ['solved', 'new'] } },
+                { required_on_statuses: { type: 'NO_STATUSES' } },
+              ],
+            },
+            {
+              child_fields: [
+                { required_on_statuses: { type: 'NO_STATUSES' } },
+              ],
+            },
+          ],
+        },
+      )
+      mockDeployChange
+        .mockImplementation(async () => ({
+          ticket_forms: validTicketForm,
+        }))
+      const res = await filter.deploy([toChange({ after: validTicketForm })])
+      expect(mockDeployChange).toHaveBeenCalledTimes(0)
+      expect(res.leftoverChanges).toHaveLength(1)
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.deployResult.appliedChanges).toHaveLength(0)
+    })
+    it('should not deploy when custum_statuses is an empty array', async () => {
+      const validTicketForm = new InstanceElement(
+        'valid',
+        ticketFormType,
+        {
+          agent_conditions: [
+            {
+              child_fields: [
+                { required_on_statuses: { type: 'SOME_STATUSES', statuses: ['solved'], custom_statuses: [] } },
+                { required_on_statuses: { type: 'SOME_STATUSES', statuses: ['solved', 'new'], custom_statuses: [] } },
+                { required_on_statuses: { type: 'ALL_STATUSES' } },
+              ],
+            },
+            {
+              child_fields: [
+                { required_on_statuses: { type: 'SOME_STATUSES', statuses: ['solved', 'new'], custom_statuses: [] } },
+                { required_on_statuses: { type: 'NO_STATUSES' } },
+              ],
+            },
+            {
+              child_fields: [
+                { required_on_statuses: { type: 'NO_STATUSES' } },
+              ],
+            },
+          ],
+        },
+      )
+      mockDeployChange
+        .mockImplementation(async () => ({
+          ticket_forms: validTicketForm,
+        }))
+      const res = await filter.deploy([toChange({ after: validTicketForm })])
+      expect(mockDeployChange).toHaveBeenCalledTimes(0)
+      expect(res.leftoverChanges).toHaveLength(1)
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.deployResult.appliedChanges).toHaveLength(0)
+    })
+    it('should deploy modification change when both statuses and custom_statuses appear', async () => {
+      const clonedElement = invalidTicketForm
+      mockDeployChange
+        .mockImplementation(async () => ({
+          ticket_forms: clonedElement,
+        }))
+      const res = await filter.deploy([toChange({ before: clonedElement, after: clonedElement })])
+      expect(mockDeployChange).toHaveBeenCalledTimes(1)
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'modify', data: { before: fixedTicketForm, after: fixedTicketForm } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        undefined,
+      })
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.deployResult.appliedChanges).toHaveLength(1)
+      expect(res.deployResult.appliedChanges)
+        .toEqual([toChange({ before: clonedElement, after: clonedElement })])
+    })
+    it('should deploy addition change when both statuses and custom_statuses appear', async () => {
+      const clonedElement = invalidTicketForm
+      mockDeployChange
+        .mockImplementation(async () => ({
+          ticket_forms: clonedElement,
+        }))
+      const res = await filter.deploy([toChange({ after: clonedElement })])
+      expect(mockDeployChange).toHaveBeenCalledTimes(1)
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'add', data: { after: fixedTicketForm } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        undefined,
+      })
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.deployResult.appliedChanges).toHaveLength(1)
+      expect(res.deployResult.appliedChanges)
+        .toEqual([toChange({ after: clonedElement })])
+    })
+  })
+})


### PR DESCRIPTION
_fix deployment error of ticket form when `required_on_statuses` has both `statuses` and `custom_statuses` fields_

---

_Additional context for reviewer_

---
_Release Notes_: 
* zendesk:
fix deployment error of ticket form when `required_on_statuses` has both `statuses` and `custom_statuses` fields

---
_User Notifications_: 
None
