### PR TITLE
SALTO-3357: Internal error 500 is thrown when reordering fields in screen

### DIFF
--- a/packages/jira-adapter/src/filters/screen/screenable_tab.ts
+++ b/packages/jira-adapter/src/filters/screen/screenable_tab.ts
@@ -47,9 +47,10 @@ const deployTabFieldsRemoval = async (
   const { removedIds } = getDiffIds(fieldsBefore, fieldsAfter)
   const tabId = getChangeData(resolvedChange).value.id
 
-  await Promise.all(removedIds.map(id => client.delete({
+  // Running this in parallel might cause a bug later when reoordering the fields. See SALTO-3357
+  await awu(removedIds).forEach(id => client.delete({
     url: `/rest/api/3/screens/${parentScreenId}/tabs/${tabId}/fields/${id}`,
-  })))
+  }))
 }
 
 const deployTabFieldsAdditionsAndOrder = async (
@@ -68,12 +69,13 @@ const deployTabFieldsAdditionsAndOrder = async (
   const { addedIds } = getDiffIds(fieldsBefore, fieldsAfter)
   const tabId = getChangeData(resolvedChange).value.id
 
-  await Promise.all(addedIds.map(id => client.post({
+  // Running this in parallel might cause a bug later when reoordering the fields. See SALTO-3357
+  await awu(addedIds).forEach(id => client.post({
     url: `/rest/api/3/screens/${parentScreenId}/tabs/${tabId}/fields`,
     data: {
       fieldId: id,
     },
-  })))
+  }))
 
   if (!_.isEqual(fieldsBefore, fieldsAfter) && fieldsAfter.length > 1) {
     await client.post({


### PR DESCRIPTION
Adding fields to a screen in parallel can cause the next requests on the screen to return 500 (due to a Jira bug) so I change it to run sequentially (just in case I did it also for fields removal)

---
_Release Notes_: 
__Jira Adapter__:
- Fixed a bug where modifying a screen would return 500 sometimes

---
_User Notifications_: 
None