### PR TITLE
SALTO-3122 - Salesforce: Change validator for AnimationRule.RecordTypeId

### DIFF
--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -33,7 +33,9 @@ import fullNameChangedValidator from './change_validators/fullname_changed'
 import invalidListViewFilterScope from './change_validators/invalid_listview_filterscope'
 import caseAssignmentRulesValidator from './change_validators/case_assignmentRules'
 import unknownUser from './change_validators/unknown_users'
+import animationRuleRecordType from './change_validators/animation_rule_recordtype'
 import SalesforceClient from './client/client'
+
 import { ChangeValidatorName, SalesforceConfig } from './types'
 
 
@@ -68,6 +70,7 @@ export const changeValidators: Record<ChangeValidatorName, ChangeValidatorDefini
   caseAssignmentRulesValidator: { creator: () => caseAssignmentRulesValidator, ...defaultAlwaysRun },
   omitData: { creator: omitDataValidator, defaultInDeploy: false, defaultInValidate: true },
   unknownUser: { creator: (_config, _isSandbox, client) => unknownUser(client), ...defaultAlwaysRun },
+  animationRuleRecordType: { creator: () => animationRuleRecordType, ...defaultAlwaysRun },
 }
 
 const createSalesforceChangeValidator = ({ config, isSandbox, checkOnly, client }: {
@@ -89,4 +92,5 @@ const createSalesforceChangeValidator = ({ config, isSandbox, checkOnly, client 
     disabledValidators.map(([_name, validator]) => validator.creator(config, isSandbox, client)),
   )
 }
+
 export default createSalesforceChangeValidator

--- a/packages/salesforce-adapter/src/change_validators/animation_rule_recordtype.ts
+++ b/packages/salesforce-adapter/src/change_validators/animation_rule_recordtype.ts
@@ -31,7 +31,7 @@ const invalidRecordTypeError = (instance: InstanceElement): ChangeError => (
     elemID: instance.elemID,
     severity: 'Error',
     message: 'Invalid AnimationRule RecordType',
-    detailedMessage: 'The RecordTypeId field is missing even though RecordTypeContext requires a RecordTypeId.',
+    detailedMessage: `In ${instance.elemID.getFullName()}, The RecordTypeId field is missing even though RecordTypeContext requires a RecordTypeId.`,
   }
 )
 

--- a/packages/salesforce-adapter/src/change_validators/animation_rule_recordtype.ts
+++ b/packages/salesforce-adapter/src/change_validators/animation_rule_recordtype.ts
@@ -1,0 +1,49 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ChangeError, ChangeValidator, getChangeData, InstanceElement, isAdditionOrModificationChange,
+  isInstanceElement } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { isInstanceOfType } from '../filters/utils'
+
+const { awu } = collections.asynciterable
+
+const isRecordTypeInvalid = (instance: InstanceElement): boolean => (
+  instance.value.recordTypeContext !== 'Master'
+  && instance.value.recordTypeContext !== 'All'
+  && instance.value.recordTypeId === undefined
+)
+
+const invalidRecordTypeError = (instance: InstanceElement): ChangeError => (
+  {
+    elemID: instance.elemID,
+    severity: 'Error',
+    message: 'Invalid AnimationRule RecordType',
+    detailedMessage: 'The RecordTypeId field is missing even though RecordTypeContext requires a RecordTypeId.',
+  }
+)
+
+const changeValidator = (): ChangeValidator => async changes => (
+  awu(changes)
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+    .filter(isInstanceElement)
+    .filter(isInstanceOfType('AnimationRule'))
+    .filter(isRecordTypeInvalid)
+    .map(invalidRecordTypeError)
+    .toArray()
+)
+
+export default changeValidator()

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -97,6 +97,7 @@ export type ChangeValidatorName = (
   | 'caseAssignmentRulesValidator'
   | 'omitData'
   | 'unknownUser'
+  | 'animationRuleRecordType'
 )
 
 export type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
@@ -564,6 +565,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     caseAssignmentRulesValidator: { refType: BuiltinTypes.BOOLEAN },
     omitData: { refType: BuiltinTypes.BOOLEAN },
     unknownUser: { refType: BuiltinTypes.BOOLEAN },
+    animationRuleRecordType: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/salesforce-adapter/test/change_validators/animation_rule_recordtype.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/animation_rule_recordtype.test.ts
@@ -1,0 +1,65 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, ElemID, ObjectType, toChange } from '@salto-io/adapter-api'
+import changeValidator from '../../src/change_validators/animation_rule_recordtype'
+import { METADATA_TYPE, SALESFORCE } from '../../src/constants'
+import { createInstanceElement } from '../../src/transformers/transformer'
+
+describe('Invalid AnimationRule RecordType change validator', () => {
+  const animationRuleType = new ObjectType({
+    elemID: new ElemID(SALESFORCE, 'AnimationRule'),
+    fields: {
+      recordTypeContext: {
+        refType: BuiltinTypes.STRING,
+      },
+      recordTypeId: {
+        refType: BuiltinTypes.SERVICE_ID,
+      },
+    },
+    annotations: {
+      [METADATA_TYPE]: 'AnimationRule',
+    },
+  })
+  const animationRuleInstance = createInstanceElement(
+    {
+      fullName: new ElemID(SALESFORCE, 'AnimationRule', 'instance', 'SomeAnimationRule').getFullName(),
+    },
+    animationRuleType,
+  )
+  it('should fail validation if the RecordTypeContext is invalid', async () => {
+    const instance = animationRuleInstance.clone()
+    instance.value.recordTypeContext = 'Custom'
+
+    const errors = await changeValidator([toChange({ after: instance })])
+    expect(errors).not.toBeEmpty()
+    expect(errors[0].message).toEqual('Invalid AnimationRule RecordType')
+  })
+  it('should pass validation if the RecordTypeContext expects a RecordTypeId and it exists', async () => {
+    const instance = animationRuleInstance.clone()
+    instance.value.recordTypeContext = 'Custom'
+    instance.value.recordTypeId = 'SomeId'
+
+    const errors = await changeValidator([toChange({ after: instance })])
+    expect(errors).toBeEmpty()
+  })
+  it('should pass validation if the RecordTypeContext doesn\'t require a RecordTypeId', async () => {
+    const instance = animationRuleInstance.clone()
+    instance.value.recordTypeContext = 'All'
+
+    const errors = await changeValidator([toChange({ after: instance })])
+    expect(errors).toBeEmpty()
+  })
+})


### PR DESCRIPTION
Add a change validator to ensure there's a RecordTypeId if the RecordTypeContext requires one

---

If AnimationRule.RecordTypeContext is 'Custom' then there needs to be a RecordTypeId that refers to the record type. Otherwise we get the following error on deploy:
```
If you don’t specify a RecordTypeId, the value of RecordTypeContext must be All or Master.
```

---
_Release Notes_: 
Salesforce: Improved validation of AnimationRule instances

---
_User Notifications_: 
N/A
