### PR TITLE
SALTO-3086 - Salesforce: fetch the display name of EntitlementProcess instances

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -78,6 +78,7 @@ import splitCustomLabels from './filters/split_custom_labels'
 import fetchFlowsFilter from './filters/fetch_flows'
 import customMetadataToObjectTypeFilter from './filters/custom_metadata_to_object_type'
 import deployFlowsFilter from './filters/deploy_flows'
+import enrichStandardObjects from './filters/enrich_standard_objects_from_query'
 import { FetchElements, SalesforceConfig } from './types'
 import { getConfigFromConfigChanges } from './config_change'
 import { LocalFilterCreator, Filter, FilterResult, RemoteFilterCreator, LocalFilterCreatorDefinition, RemoteFilterCreatorDefinition } from './filter'
@@ -105,6 +106,7 @@ export const allFilters: Array<LocalFilterCreatorDefinition | RemoteFilterCreato
   { creator: customMetadataToObjectTypeFilter },
   // customObjectsFilter depends on missingFieldsFilter and settingsFilter
   { creator: customObjectsFromDescribeFilter, addsNewInformation: true },
+  { creator: enrichStandardObjects, addsNewInformation: true },
   // customSettingsFilter depends on customObjectsFilter
   { creator: customSettingsFilter, addsNewInformation: true },
   { creator: customObjectsToObjectTypeFilter },

--- a/packages/salesforce-adapter/src/filters/enrich_standard_objects_from_query.ts
+++ b/packages/salesforce-adapter/src/filters/enrich_standard_objects_from_query.ts
@@ -63,14 +63,12 @@ const buildQueryString = (type: string, fields: string[]): string => (
  */
 const filterCreator: RemoteFilterCreator = ({ client }) => ({
   onFetch: async elements => {
-    log.error(`${elements.length} elements`)
     const saltoTypesOfInterest = enrichmentDefs.map(def => def.targetType)
     const instancesToEnrich = await keyByAsync(
       awu(elements).filter(isInstanceElement).filter(isInstanceOfType(...saltoTypesOfInterest)),
       instance => apiName(instance),
     )
     if (_.isEmpty(instancesToEnrich)) {
-      log.error('No elements of interest!')
       // Not fetching instances of any types we care about. Bail out.
       return
     }

--- a/packages/salesforce-adapter/src/filters/enrich_standard_objects_from_query.ts
+++ b/packages/salesforce-adapter/src/filters/enrich_standard_objects_from_query.ts
@@ -43,11 +43,7 @@ const enrichmentDefs: EnrichmentDef[] = [
     fields: [
       {
         source: 'Name',
-        target: 'fullName',
-      },
-      {
-        source: 'NameNorm',
-        target: 'normalizedFullName',
+        target: 'name',
       },
     ],
   },
@@ -73,21 +69,22 @@ const filterCreator: RemoteFilterCreator = ({ client }) => ({
       return
     }
 
-    await awu(enrichmentDefs).forEach(async def => {
-      const queryString = buildQueryString(def.sourceType, def.fields.map(f => f.source))
-      await awu(await client.queryAll(queryString))
-        .flat()
-        .forEach(sfRecord => {
-          def.fields.forEach(({ source, target }) => {
-            const targetInstance = def.instanceLookup(sfRecord, instancesToEnrich)
-            if (!targetInstance) {
-              log.warn(`No matching Salto element for Salesforce record ${sfRecord}`)
-              return
-            }
-            targetInstance.value[target] = sfRecord[source]
+    await awu(enrichmentDefs)
+      .forEach(async def => {
+        const queryString = buildQueryString(def.sourceType, def.fields.map(f => f.source))
+        await awu(await client.queryAll(queryString))
+          .flat()
+          .forEach(sfRecord => {
+            def.fields.forEach(({ source, target }) => {
+              const targetInstance = def.instanceLookup(sfRecord, instancesToEnrich)
+              if (!targetInstance) {
+                log.warn(`No matching Salto element for Salesforce record ${sfRecord}`)
+                return
+              }
+              targetInstance.value[target] = sfRecord[source]
+            })
           })
-        })
-    })
+      })
   },
 })
 

--- a/packages/salesforce-adapter/src/filters/enrich_standard_objects_from_query.ts
+++ b/packages/salesforce-adapter/src/filters/enrich_standard_objects_from_query.ts
@@ -73,7 +73,7 @@ const filterCreator: RemoteFilterCreator = ({ client }) => ({
       return
     }
 
-    enrichmentDefs.forEach(async def => {
+    await awu(enrichmentDefs).forEach(async def => {
       const queryString = buildQueryString(def.sourceType, def.fields.map(f => f.source))
       await awu(await client.queryAll(queryString))
         .flat()

--- a/packages/salesforce-adapter/src/filters/enrich_standard_objects_from_query.ts
+++ b/packages/salesforce-adapter/src/filters/enrich_standard_objects_from_query.ts
@@ -1,0 +1,96 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { logger } from '@salto-io/logging'
+import { collections } from '@salto-io/lowerdash'
+import { InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
+import { RemoteFilterCreator } from '../filter'
+import { apiName } from '../transformers/transformer'
+import { isInstanceOfType } from './utils'
+import { SalesforceRecord } from '../client/types'
+
+const { awu, keyByAsync } = collections.asynciterable
+const log = logger(module)
+
+type EnrichmentDef = {
+  sourceType: string
+  targetType: string
+  instanceLookup: (sfRecord: SalesforceRecord, elements: Record<string, InstanceElement>) => InstanceElement
+  fields: {
+    source: string
+    target: string
+  }[]
+}
+
+const enrichmentDefs: EnrichmentDef[] = [
+  {
+    sourceType: 'SlaProcess',
+    targetType: 'EntitlementProcess',
+    instanceLookup: (sfRecord, elements) => elements[sfRecord.NameNorm],
+    fields: [
+      {
+        source: 'Name',
+        target: 'fullName',
+      },
+      {
+        source: 'NameNorm',
+        target: 'normalizedFullName',
+      },
+    ],
+  },
+]
+
+const buildQueryString = (type: string, fields: string[]): string => (
+  `SELECT ${fields.join()} FROM ${type}`
+)
+
+/**
+ * Enrichment of standard objects.
+ * Some fields are not available via the usual 'metadata describe' API and must be fetched via the query API.
+ */
+const filterCreator: RemoteFilterCreator = ({ client }) => ({
+  onFetch: async elements => {
+    log.error(`${elements.length} elements`)
+    const saltoTypesOfInterest = enrichmentDefs.map(def => def.targetType)
+    const instancesToEnrich = await keyByAsync(
+      awu(elements).filter(isInstanceElement).filter(isInstanceOfType(...saltoTypesOfInterest)),
+      instance => apiName(instance),
+    )
+    if (_.isEmpty(instancesToEnrich)) {
+      log.error('No elements of interest!')
+      // Not fetching instances of any types we care about. Bail out.
+      return
+    }
+
+    enrichmentDefs.forEach(async def => {
+      const queryString = buildQueryString(def.sourceType, def.fields.map(f => f.source))
+      await awu(await client.queryAll(queryString))
+        .flat()
+        .forEach(sfRecord => {
+          def.fields.forEach(({ source, target }) => {
+            const targetInstance = def.instanceLookup(sfRecord, instancesToEnrich)
+            if (!targetInstance) {
+              log.warn(`No matching Salto element for Salesforce record ${sfRecord}`)
+              return
+            }
+            targetInstance.value[target] = sfRecord[source]
+          })
+        })
+    })
+  },
+})
+
+export default filterCreator

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -614,6 +614,10 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     serializationStrategy: 'customLabel',
     target: { type: CUSTOM_LABEL_METADATA_TYPE },
   },
+  {
+    src: { field: 'entitlementProcess', parentTypes: ['EntitlementTemplate'] },
+    target: { type: 'EntitlementProcess' },
+  },
 ]
 
 // Optional reference that should not be used if enumFieldPermissions config is on

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -614,10 +614,6 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     serializationStrategy: 'customLabel',
     target: { type: CUSTOM_LABEL_METADATA_TYPE },
   },
-  {
-    src: { field: 'entitlementProcess', parentTypes: ['EntitlementTemplate'] },
-    target: { type: 'EntitlementProcess' },
-  },
 ]
 
 // Optional reference that should not be used if enumFieldPermissions config is on

--- a/packages/salesforce-adapter/test/filters/enrich_standard_objects_from_query.test.ts
+++ b/packages/salesforce-adapter/test/filters/enrich_standard_objects_from_query.test.ts
@@ -14,7 +14,6 @@
 * limitations under the License.
 */
 
-import { logger } from '@salto-io/logging'
 import { Element, InstanceElement, ObjectType } from '@salto-io/adapter-api'
 import mockAdapter from '../adapter'
 import { defaultFilterContext } from '../utils'
@@ -25,7 +24,6 @@ import SalesforceClient from '../../src/client/client'
 import { SalesforceRecord } from '../../src/client/types'
 import { CUSTOM_OBJECT_ID_FIELD } from '../../src/constants'
 
-const log = logger(module)
 
 describe('Enrich standard objects from query filter', () => {
   let client: SalesforceClient
@@ -95,8 +93,8 @@ describe('Enrich standard objects from query filter', () => {
     it('should enrich objects', async () => {
       setupMocks()
       await filter.onFetch([testElement])
-      log.warn(`In the test - elements[0].fullName: ${(testElement as InstanceElement).value.fullName}`)
-      expect((testElement as InstanceElement).value.fullName).toEqual('Some Name')
+      expect((testElement as InstanceElement).value.fullName).toEqual('some name')
+      expect((testElement as InstanceElement).value.name).toEqual('Some Name')
     })
   })
 })

--- a/packages/salesforce-adapter/test/filters/enrich_standard_objects_from_query.test.ts
+++ b/packages/salesforce-adapter/test/filters/enrich_standard_objects_from_query.test.ts
@@ -1,0 +1,83 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { MockInterface } from '@salto-io/test-utils'
+import { InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import mockAdapter from '../adapter'
+import { defaultFilterContext } from '../utils'
+import Connection from '../../src/client/jsforce'
+import { FilterWith } from '../../src/filter'
+import filterCreator from '../../src/filters/enrich_standard_objects_from_query'
+import { createInstanceElement, createMetadataObjectType } from '../../src/transformers/transformer'
+
+
+describe('Enrich standard objects from query filter', () => {
+  let connection: MockInterface<Connection>
+  let filter: FilterWith<'onFetch'>
+  let entitlementProcessType: ObjectType
+
+  beforeAll(() => {
+    entitlementProcessType = createMetadataObjectType({
+      annotations: {
+        metadataType: 'EntitlementProcess',
+        dirName: 'classes',
+        suffix: 'entitlementProcess',
+        hasMetaFile: true,
+      },
+    })
+  })
+
+  beforeEach(() => {
+    const adapter = mockAdapter({})
+    connection = adapter.connection
+    filter = filterCreator({
+      config: {
+        ...defaultFilterContext,
+        systemFields: ['SystemField', 'NameSystemField'],
+      },
+      client: adapter.client,
+    }) as typeof filter
+  })
+
+  describe('onFetch', () => {
+    let elements: InstanceElement[]
+
+    beforeEach(() => {
+      const mockQueryResult = {
+        Name: 'Some Name',
+        NameNorm: 'some name',
+      }
+      connection.query.mockResolvedValue({
+        done: true,
+        totalSize: 1,
+        records: [mockQueryResult],
+        nextRecordsUrl: undefined,
+      })
+
+      elements = [createInstanceElement(
+        {
+          fullName: 'some name',
+        },
+        entitlementProcessType,
+      )]
+    })
+
+    it('should enrich objects', async () => {
+      await filter.onFetch(elements)
+      expect(elements[0].value.fullName).toEqual('Some Name')
+    })
+  })
+})


### PR DESCRIPTION
EntitlementProcess's fullName is always lower case, but we can get its display name from the query API. Introduce a new filter that enriches instances via the query API.

---

The mixed-case name is not available via the SOAP API (which is used in the existing custom_objects_from_soap_describe filter) because this describe API only returns information about types, not about instances. This is why we need a brand new filter.

---
_Release Notes_: 
N/A

---
_User Notifications_: 
N/A
