### PR TITLE
SALTO-3088 - retry sf request on INTERNAL_ERROR response

### DIFF
--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -125,6 +125,7 @@ const errorMessagesToRetry = [
   'An internal server error has occurred',
   'An unexpected connection error occurred',
   'ECONNREFUSED',
+  'Internal_Error',
 ]
 
 type RateLimitBucketName = keyof ClientRateLimitConfig


### PR DESCRIPTION
retry sf request on INTERNAL_ERROR response

---

_Additional context for reviewer_
None.

---
_Release Notes_: 
SF fetch stability improvement.

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
