### PR TITLE
SALTO-3392: fix deployment of a view that contains `custom_statuse_id`

### DIFF
--- a/packages/zendesk-adapter/src/filters/view.ts
+++ b/packages/zendesk-adapter/src/filters/view.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import {
-  Change, getChangeData, InstanceElement, isRemovalChange, Values,
+  Change, getChangeData, InstanceElement, isRemovalChange, Value, Values,
 } from '@salto-io/adapter-api'
 import { values } from '@salto-io/lowerdash'
 import { FilterCreator } from '../filter'
@@ -23,6 +23,8 @@ import { deployChange, deployChanges } from '../deployment'
 import { applyforInstanceChangesOfType } from './utils'
 
 export const VIEW_TYPE_NAME = 'view'
+
+const valToString = (val: Value): string | string[] => (_.isArray(val) ? val.map(String) : val.toString())
 
 /**
  * Deploys views
@@ -36,9 +38,9 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
         instance.value = {
           ...instance.value,
           all: (instance.value.conditions.all ?? [])
-            .map((e: Values) => ({ ...e, value: e.value.toString() })),
+            .map((e: Values) => ({ ...e, value: valToString(e.value) })),
           any: (instance.value.conditions.any ?? [])
-            .map((e: Values) => ({ ...e, value: e.value.toString() })),
+            .map((e: Values) => ({ ...e, value: valToString(e.value) })),
           output: {
             ...instance.value.execution,
             group_by: instance.value.execution.group_by?.toString(),

--- a/packages/zendesk-adapter/test/filters/view.test.ts
+++ b/packages/zendesk-adapter/test/filters/view.test.ts
@@ -109,6 +109,11 @@ describe('views filter', () => {
             operator: 'is',
             value: 3,
           },
+          {
+            field: 'custom_status_id',
+            operator: 'includes',
+            value: [5, 6],
+          },
         ],
         any: [
           {
@@ -147,6 +152,7 @@ describe('views filter', () => {
       expect(clonedView.value.all).toEqual([
         { field: 'status', operator: 'is', value: 'open' },
         { field: 'brand_id', operator: 'is', value: '3' },
+        { field: 'custom_status_id', operator: 'includes', value: ['5', '6'] },
       ])
     })
     it('should add output', async () => {


### PR DESCRIPTION
_fix deployment of a view that contains `custom_statuse_id`_

---

_Additional context for reviewer_

---
_Release Notes_: 
Zendesk:
* fix deployment of a view that contains `custom_statuse_id`.

---
_User Notifications_: 
None
