### PR TITLE
SALTO-3296: deleting issueTypeScheme defaultIssueTypeId from the issueTypeIds list does not delete it from the field defaultIssueTypeId

### DIFF
--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -41,6 +41,7 @@ import { GetIdMapFunc } from '../users_map'
 import { accountIdValidator } from './account_id'
 import { screenSchemeDefaultValidator } from './screen_scheme_default'
 import { workflowSchemeDupsValidator } from './workflow_scheme_dups'
+import { issueTypeSchemeDefaultTypeValidator } from './issue_type_scheme_default_type'
 
 const {
   deployTypesNotSupportedValidator,
@@ -56,6 +57,7 @@ export default (
     defaultFieldConfigurationValidator,
     screenValidator,
     issueTypeSchemeValidator,
+    issueTypeSchemeDefaultTypeValidator,
     projectDeletionValidator(client, config),
     statusValidator,
     privateApiValidator(config),

--- a/packages/jira-adapter/src/change_validators/issue_type_scheme_default_type.ts
+++ b/packages/jira-adapter/src/change_validators/issue_type_scheme_default_type.ts
@@ -1,0 +1,34 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ChangeValidator, getChangeData, isAdditionOrModificationChange, isInstanceChange, isReferenceExpression, ReferenceExpression, SeverityLevel } from '@salto-io/adapter-api'
+import { ISSUE_TYPE_SCHEMA_NAME } from '../constants'
+
+export const issueTypeSchemeDefaultTypeValidator: ChangeValidator = async changes =>
+  changes
+    .filter(isInstanceChange)
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+    .filter(instance => instance.elemID.typeName === ISSUE_TYPE_SCHEMA_NAME)
+    .filter(instance => isReferenceExpression(instance.value.defaultIssueTypeId))
+    .filter(instance => (instance.value.issueTypeIds ?? [])
+      .filter(isReferenceExpression)
+      .every((issueType: ReferenceExpression) => !issueType.elemID.isEqual(instance.value.defaultIssueTypeId.elemID)))
+    .map(instance => ({
+      elemID: instance.elemID,
+      severity: 'Error' as SeverityLevel,
+      message: 'Default issue type is not included in the scheme\'s types',
+      detailedMessage: 'The default issue type of an issue type scheme must be included in the issue type list of the scheme',
+    }))

--- a/packages/jira-adapter/src/change_validators/issue_type_scheme_default_type.ts
+++ b/packages/jira-adapter/src/change_validators/issue_type_scheme_default_type.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2022 Salto Labs Ltd.
+*                      Copyright 2023 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/test/change_validators/issue_type_scheme_default_type.test.ts
+++ b/packages/jira-adapter/test/change_validators/issue_type_scheme_default_type.test.ts
@@ -1,0 +1,70 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { toChange, ObjectType, ElemID, InstanceElement, Change, getChangeData, ReferenceExpression } from '@salto-io/adapter-api'
+import { issueTypeSchemeDefaultTypeValidator } from '../../src/change_validators/issue_type_scheme_default_type'
+import { ISSUE_TYPE_NAME, ISSUE_TYPE_SCHEMA_NAME, JIRA } from '../../src/constants'
+
+describe('issueTypeSchemeDefaultTypeValidator', () => {
+  let issueTypeSchemeChange: Change<InstanceElement>
+
+  beforeEach(() => {
+    const issueTypeSchemeType = new ObjectType({ elemID: new ElemID(JIRA, ISSUE_TYPE_SCHEMA_NAME) })
+
+    issueTypeSchemeChange = toChange({
+      after: new InstanceElement(
+        'instance',
+        issueTypeSchemeType,
+        {
+          defaultIssueTypeId: new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'issueType1')),
+          issueTypeIds: [
+            new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'issueType1')),
+            new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'issueType2')),
+          ],
+        }
+      ),
+    })
+  })
+
+  it('should return an error if the default type is not included in issueTypeIds', async () => {
+    getChangeData(issueTypeSchemeChange).value.issueTypeIds = [
+      new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'issueType2')),
+    ]
+    expect(await issueTypeSchemeDefaultTypeValidator([issueTypeSchemeChange])).toEqual([
+      {
+        elemID: getChangeData(issueTypeSchemeChange).elemID,
+        severity: 'Error',
+        message: 'Default issue type is not included in the scheme\'s types',
+        detailedMessage: 'The default issue type of an issue type scheme must be included in the issue type list of the scheme',
+      },
+    ])
+  })
+
+  it('should return an error if the default type is set and issueTypeIds is undefined', async () => {
+    delete getChangeData(issueTypeSchemeChange).value.issueTypeIds
+    expect(await issueTypeSchemeDefaultTypeValidator([issueTypeSchemeChange])).toEqual([
+      {
+        elemID: getChangeData(issueTypeSchemeChange).elemID,
+        severity: 'Error',
+        message: 'Default issue type is not included in the scheme\'s types',
+        detailedMessage: 'The default issue type of an issue type scheme must be included in the issue type list of the scheme',
+      },
+    ])
+  })
+
+  it('should not return an error if the default type is included in issueTypeIds', async () => {
+    expect(await issueTypeSchemeDefaultTypeValidator([issueTypeSchemeChange])).toEqual([])
+  })
+})

--- a/packages/jira-adapter/test/change_validators/issue_type_scheme_default_type.test.ts
+++ b/packages/jira-adapter/test/change_validators/issue_type_scheme_default_type.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2022 Salto Labs Ltd.
+*                      Copyright 2023 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with


### PR DESCRIPTION
Added change validator for when setting a default type in an issue type scheme that is not present in the types of the scheme


---
_Release Notes_: 
__Jira Adapter__:
- Added change validator for when setting a default type in an issue type scheme that is not present in the types of the scheme 

---
_User Notifications_: 
None