### PR TITLE
SALTO-3385: get all the pages of users while creating idMap - Jira DC

### DIFF
--- a/packages/adapter-components/src/client/pagination.ts
+++ b/packages/adapter-components/src/client/pagination.ts
@@ -29,6 +29,7 @@ type RecursiveQueryArgFunc = Record<string, (entry: ResponseValue) => string>
 export type ClientGetWithPaginationParams = ClientBaseParams & {
   recursiveQueryParams?: RecursiveQueryArgFunc
   paginationField?: string
+  queryParamsPageSizeName?: string
 }
 
 export type PageEntriesExtractor = (page: ResponseValue) => ResponseValue[]
@@ -158,14 +159,18 @@ export const traverseRequests: (
  */
 export const getWithItemOffsetPagination = ({
   firstIndex,
-  itemsPerPage,
+  queryParamsPageSizeName,
 } : {
   firstIndex: number
-  itemsPerPage: number
+  queryParamsPageSizeName: string | undefined
 }): PaginationFunc => {
   const nextPage: PaginationFunc = ({ page, getParams, currentParams, pageSize }) => {
-    const { paginationField } = getParams
-    if (paginationField === undefined || page.length < pageSize) {
+    const { paginationField, queryParams } = getParams
+
+    const itemsPerPage = queryParamsPageSizeName && queryParams
+      ? Number(queryParams[queryParamsPageSizeName])
+      : pageSize
+    if (paginationField === undefined || page.length < itemsPerPage) {
       return []
     }
     return [{

--- a/packages/adapter-components/src/client/pagination.ts
+++ b/packages/adapter-components/src/client/pagination.ts
@@ -167,7 +167,8 @@ export const getWithItemOffsetPagination = ({
   const nextPage: PaginationFunc = ({ page, getParams, currentParams, pageSize }) => {
     const { paginationField, queryParams } = getParams
 
-    const itemsPerPage = queryParamsPageSizeName && queryParams
+    const itemsPerPage = queryParamsPageSizeName !== undefined
+      && queryParams?.[queryParamsPageSizeName] !== undefined
       ? Number(queryParams[queryParamsPageSizeName])
       : pageSize
     if (paginationField === undefined || page.length < itemsPerPage) {

--- a/packages/adapter-components/src/client/pagination.ts
+++ b/packages/adapter-components/src/client/pagination.ts
@@ -169,7 +169,7 @@ export const getWithItemOffsetPagination = ({
     const { paginationField, queryParams } = getParams
 
     const itemsPerPage = (pageSizeArgName !== undefined && queryParams !== undefined
-       && !Number.isNaN(Number(queryParams?.[pageSizeArgName])))
+      && !Number.isNaN(Number(queryParams?.[pageSizeArgName])))
       ? Number(queryParams[pageSizeArgName])
       : pageSize
 

--- a/packages/adapter-components/test/client/pagination.test.ts
+++ b/packages/adapter-components/test/client/pagination.test.ts
@@ -343,16 +343,18 @@ describe('client_pagination', () => {
       expect(paginationFunc).toHaveBeenCalledWith({ currentParams: {}, getParams, page: [{ a: 'a1' }], pageSize: 1, responseData: { items: [{ a: 'a1' }] } })
     })
   })
-
   describe('getWithItemIndexPagination', () => {
     it('should query a single page if data has less items than page size', async () => {
-      const paginate = getWithItemIndexPagination({ firstIndex: 0, itemsPerPage: 10 })
+      const paginate = getWithItemIndexPagination({ firstIndex: 0, queryParamsPageSizeName: 'maxResults' })
       const args = {
         getParams: {
           url: '/ep',
           paginationField: 'startAt',
+          queryParams: {
+            maxResults: '20',
+          },
         },
-        pageSize: 10,
+        pageSize: 30,
       }
       expect(paginate({
         ...args,
@@ -364,13 +366,72 @@ describe('client_pagination', () => {
       })).toEqual([])
       expect(paginate({
         ...args,
-        currentParams: { startAt: '10' },
+        currentParams: { startAt: '20' },
         responseData: {},
         page: [],
       })).toEqual([])
     })
+    it('should query a single page with default size if data has less items than page size and pageSize not provided', async () => {
+      const paginate = getWithItemIndexPagination({ firstIndex: 0, queryParamsPageSizeName: undefined })
+      const args = {
+        getParams: {
+          url: '/ep',
+          paginationField: 'startAt',
+        },
+        pageSize: 30,
+      }
+      expect(paginate({
+        ...args,
+        currentParams: {},
+        responseData: {},
+        page: [{
+          a: 'a1',
+        }],
+      })).toEqual([])
+    })
     it('should query multiple pages if response has more items than page size (or equal)', async () => {
-      const paginate = getWithItemIndexPagination({ firstIndex: 0, itemsPerPage: 2 })
+      const paginate = getWithItemIndexPagination({ firstIndex: 0, queryParamsPageSizeName: 'maxResults' })
+      const args = {
+        getParams: {
+          url: '/ep',
+          paginationField: 'startAt',
+          queryParams: {
+            maxResults: '2',
+          },
+        },
+        pageSize: 30,
+      }
+      expect(paginate({
+        ...args,
+        currentParams: {},
+        responseData: {},
+        page: [{
+          a: 'a1',
+        }, {
+          b: 'b2',
+        }],
+      })).toEqual([{ startAt: '2' }])
+      expect(paginate({
+        ...args,
+        currentParams: { startAt: '2' },
+        responseData: {},
+        page: [{
+          a: 'a1',
+        }, {
+          b: 'b2',
+        }],
+      })).toEqual([{ startAt: '4' }])
+      expect(paginate({
+        ...args,
+        currentParams: { startAt: '4' },
+        responseData: {},
+        page: [{
+          a: 'a2',
+        }],
+      })).toEqual([])
+    })
+    it('should query multiple pages if response has more items than page size (or equal) with default pageSize', async () => {
+      const paginate = getWithItemIndexPagination({ firstIndex: 0, queryParamsPageSizeName: undefined })
       const args = {
         getParams: {
           url: '/ep',

--- a/packages/adapter-components/test/client/pagination.test.ts
+++ b/packages/adapter-components/test/client/pagination.test.ts
@@ -345,7 +345,7 @@ describe('client_pagination', () => {
   })
   describe('getWithItemIndexPagination', () => {
     it('should query a single page if data has less items than page size', async () => {
-      const paginate = getWithItemIndexPagination({ firstIndex: 0, queryParamsPageSizeName: 'maxResults' })
+      const paginate = getWithItemIndexPagination({ firstIndex: 0, pageSizeArgName: 'maxResults' })
       const args = {
         getParams: {
           url: '/ep',
@@ -371,8 +371,8 @@ describe('client_pagination', () => {
         page: [],
       })).toEqual([])
     })
-    it('should query a single page with default size if data has less items than page size and pageSize not provided', async () => {
-      const paginate = getWithItemIndexPagination({ firstIndex: 0, queryParamsPageSizeName: undefined })
+    it('should query a single page with default size if data has less items than page size and pageSizeArgName is not provided', async () => {
+      const paginate = getWithItemIndexPagination({ firstIndex: 0, pageSizeArgName: undefined })
       const args = {
         getParams: {
           url: '/ep',
@@ -389,8 +389,29 @@ describe('client_pagination', () => {
         }],
       })).toEqual([])
     })
+    it('should query a single page with default size if data has less items than page size and maxResults is not a number', async () => {
+      const paginate = getWithItemIndexPagination({ firstIndex: 0, pageSizeArgName: undefined })
+      const args = {
+        getParams: {
+          url: '/ep',
+          paginationField: 'startAt',
+          queryParams: {
+            maxResults: 'not a number',
+          },
+        },
+        pageSize: 30,
+      }
+      expect(paginate({
+        ...args,
+        currentParams: {},
+        responseData: {},
+        page: [{
+          a: 'a1',
+        }],
+      })).toEqual([])
+    })
     it('should query multiple pages if response has more items than page size (or equal)', async () => {
-      const paginate = getWithItemIndexPagination({ firstIndex: 0, queryParamsPageSizeName: 'maxResults' })
+      const paginate = getWithItemIndexPagination({ firstIndex: 0, pageSizeArgName: 'maxResults' })
       const args = {
         getParams: {
           url: '/ep',
@@ -430,12 +451,53 @@ describe('client_pagination', () => {
         }],
       })).toEqual([])
     })
-    it('should query multiple pages if response has more items than page size (or equal) with default pageSize', async () => {
-      const paginate = getWithItemIndexPagination({ firstIndex: 0, queryParamsPageSizeName: undefined })
+    it('should query multiple pages if response has more items than page size (or equal) with pageSizeArgName is not provided', async () => {
+      const paginate = getWithItemIndexPagination({ firstIndex: 0, pageSizeArgName: undefined })
       const args = {
         getParams: {
           url: '/ep',
           paginationField: 'startAt',
+        },
+        pageSize: 2,
+      }
+      expect(paginate({
+        ...args,
+        currentParams: {},
+        responseData: {},
+        page: [{
+          a: 'a1',
+        }, {
+          b: 'b2',
+        }],
+      })).toEqual([{ startAt: '2' }])
+      expect(paginate({
+        ...args,
+        currentParams: { startAt: '2' },
+        responseData: {},
+        page: [{
+          a: 'a1',
+        }, {
+          b: 'b2',
+        }],
+      })).toEqual([{ startAt: '4' }])
+      expect(paginate({
+        ...args,
+        currentParams: { startAt: '4' },
+        responseData: {},
+        page: [{
+          a: 'a2',
+        }],
+      })).toEqual([])
+    })
+    it('should query multiple pages if response has more items than page size (or equal) and maxResults is not a number', async () => {
+      const paginate = getWithItemIndexPagination({ firstIndex: 0, pageSizeArgName: 'maxResults' })
+      const args = {
+        getParams: {
+          url: '/ep',
+          paginationField: 'startAt',
+          queryParams: {
+            maxResults: 'not a number',
+          },
         },
         pageSize: 2,
       }

--- a/packages/jira-adapter/src/client/pagination.ts
+++ b/packages/jira-adapter/src/client/pagination.ts
@@ -55,7 +55,7 @@ export const paginate: clientUtils.PaginationFuncCreator = args => {
     return clientUtils.getWithItemIndexPagination(
       {
         firstIndex: 0,
-        queryParamsPageSizeName: args.getParams.queryParamsPageSizeName,
+        pageSizeArgName: args.getParams.pageSizeArgName,
       }
     )
   }

--- a/packages/jira-adapter/src/client/pagination.ts
+++ b/packages/jira-adapter/src/client/pagination.ts
@@ -21,7 +21,7 @@ const { makeArray } = collections.array
 
 const ITEM_INDEX_PAGINATION_URLS = [
   '/rest/api/3/users/search',
-  '/rest/api/2/user/search?username=.',
+  '/rest/api/2/user/search',
   '/rest/api/2/priorityschemes',
 ]
 

--- a/packages/jira-adapter/src/client/pagination.ts
+++ b/packages/jira-adapter/src/client/pagination.ts
@@ -21,6 +21,7 @@ const { makeArray } = collections.array
 
 const ITEM_INDEX_PAGINATION_URLS = [
   '/rest/api/3/users/search',
+  '/rest/api/2/user/search?username=.',
   '/rest/api/2/priorityschemes',
 ]
 
@@ -51,7 +52,12 @@ export const paginate: clientUtils.PaginationFuncCreator = args => {
   if (ITEM_INDEX_PAGINATION_URLS.includes(args.getParams?.url)) {
     // special handling for endpoints that use pagination without meta-data
     // if more cases encountered should be moved to an object with url and items per page
-    return clientUtils.getWithItemIndexPagination({ firstIndex: 0, itemsPerPage: 50 })
+    return clientUtils.getWithItemIndexPagination(
+      {
+        firstIndex: 0,
+        queryParamsPageSizeName: args.getParams.queryParamsPageSizeName,
+      }
+    )
   }
   return clientUtils.getWithOffsetAndLimit()
 }

--- a/packages/jira-adapter/src/users_map.ts
+++ b/packages/jira-adapter/src/users_map.ts
@@ -33,10 +33,11 @@ export const getIdMapFuncCreator = (paginator: clientUtils.Paginator, isDataCent
       if (usersCallPromise === undefined) {
         const paginationArgs = isDataCenter
           ? {
-            url: '/rest/api/2/user/search?username=.',
+            url: '/rest/api/2/user/search',
             paginationField: 'startAt',
             queryParams: {
               maxResults: '1000',
+              username: '.',
             },
             queryParamsPageSizeName: 'maxResults',
           }

--- a/packages/jira-adapter/test/filters/account_id/user_id_filter.test.ts
+++ b/packages/jira-adapter/test/filters/account_id/user_id_filter.test.ts
@@ -328,7 +328,13 @@ describe('convert userId to key in Jira DC', () => {
       expect(mockConnection.get).toHaveBeenCalledOnce()
       expect(mockConnection.get).toHaveBeenCalledWith(
         '/rest/api/2/user/search?username=.',
-        undefined
+        {
+          headers: undefined,
+          params: {
+            maxResults: '1000',
+          },
+          responseType: undefined,
+        }
       )
       expect(automationInstance.value.authorAccountId).toEqual({ id: 'salto' })
       expect(dashboardInstance.value.editPermissions.user.accountId).toEqual({ id: 'admin' })
@@ -344,7 +350,13 @@ describe('convert userId to key in Jira DC', () => {
       expect(mockConnection.get).toHaveBeenCalledOnce()
       expect(mockConnection.get).toHaveBeenCalledWith(
         '/rest/api/2/user/search?username=.',
-        undefined
+        {
+          headers: undefined,
+          params: {
+            maxResults: '1000',
+          },
+          responseType: undefined,
+        }
       )
       expect(automationInstance.value.authorAccountId).toEqual({ id: 'JIRAUSER10100' })
       expect(dashboardInstance.value.editPermissions.user.accountId).toEqual({ id: 'JIRAUSER10200' })
@@ -357,7 +369,13 @@ describe('convert userId to key in Jira DC', () => {
       expect(mockConnection.get).toHaveBeenCalledOnce()
       expect(mockConnection.get).toHaveBeenCalledWith(
         '/rest/api/2/user/search?username=.',
-        undefined
+        {
+          headers: undefined,
+          params: {
+            maxResults: '1000',
+          },
+          responseType: undefined,
+        }
       )
       expect(automationInstance.value.authorAccountId).toEqual({ id: 'salto' })
       expect(dashboardInstance.value.editPermissions.user.accountId).toEqual({ id: 'admin' })

--- a/packages/jira-adapter/test/filters/account_id/user_id_filter.test.ts
+++ b/packages/jira-adapter/test/filters/account_id/user_id_filter.test.ts
@@ -327,11 +327,12 @@ describe('convert userId to key in Jira DC', () => {
       await filter.onFetch([automationInstance, dashboardInstance, projectInstance])
       expect(mockConnection.get).toHaveBeenCalledOnce()
       expect(mockConnection.get).toHaveBeenCalledWith(
-        '/rest/api/2/user/search?username=.',
+        '/rest/api/2/user/search',
         {
           headers: undefined,
           params: {
             maxResults: '1000',
+            username: '.',
           },
           responseType: undefined,
         }
@@ -349,11 +350,12 @@ describe('convert userId to key in Jira DC', () => {
       ])
       expect(mockConnection.get).toHaveBeenCalledOnce()
       expect(mockConnection.get).toHaveBeenCalledWith(
-        '/rest/api/2/user/search?username=.',
+        '/rest/api/2/user/search',
         {
           headers: undefined,
           params: {
             maxResults: '1000',
+            username: '.',
           },
           responseType: undefined,
         }
@@ -368,11 +370,12 @@ describe('convert userId to key in Jira DC', () => {
       ])
       expect(mockConnection.get).toHaveBeenCalledOnce()
       expect(mockConnection.get).toHaveBeenCalledWith(
-        '/rest/api/2/user/search?username=.',
+        '/rest/api/2/user/search',
         {
           headers: undefined,
           params: {
             maxResults: '1000',
+            username: '.',
           },
           responseType: undefined,
         }


### PR DESCRIPTION
_get all the pages of users while creating idMap_

---

_Additional context for reviewer_
when I attempt to perform fetch and deploy in DC 9 server (with 21,000 users) I found out few bugs. 

In this PR I fixed those issues: 
* get all the pages of users instead of only the first one
* get the maximum amount of users in each get request (1000) instead of the adapter default (50) 

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
