### PR TITLE
SALTO-2699: Clean Okta nacls

### DIFF
--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -512,6 +512,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
         { fieldName: 'policyRules', fieldType: 'list<AuthorizationServerPolicyRule>' },
       ],
       serviceIdField: 'id',
+      fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),
     },
   },
   api__v1__brands: {
@@ -706,6 +707,31 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
       fieldTypeOverrides: [
         { fieldName: 'userType', fieldType: 'UserTypePolicyRuleCondition' },
       ],
+    },
+  },
+  OAuth2Scope: {
+    transformation: {
+      fieldTypeOverrides: [
+        { fieldName: '_links', fieldType: 'map<unknown>' },
+      ],
+      fieldsToOmit: [
+        { fieldName: '_links' },
+      ],
+    },
+  },
+  OAuth2Claim: {
+    transformation: {
+      fieldsToOmit: [
+        { fieldName: '_links' },
+      ],
+    },
+  },
+  AuthorizationServerPolicyRule: {
+    transformation: {
+      fieldTypeOverrides: [
+        { fieldName: '_links', fieldType: 'map<unknown>' },
+      ],
+      fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),
     },
   },
 }

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -390,6 +390,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
       url: '/api/v1/meta/schemas/user/default',
     },
     transformation: {
+      fieldTypeOverrides: [{ fieldName: 'description', fieldType: 'string' }],
       serviceIdField: 'id',
       fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),
       fieldsToHide: [{ fieldName: 'id' }],
@@ -589,6 +590,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
   },
   GroupRule: {
     transformation: {
+      fieldTypeOverrides: [{ fieldName: 'allGroupsValid', fieldType: 'boolean' }],
       serviceIdField: 'id',
       fieldsToHide: [{ fieldName: 'id' }],
     },
@@ -679,6 +681,23 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
       fieldsToOmit: [
         // we are not managing secrets
         { fieldName: 'credentials' },
+      ],
+    },
+  },
+  IdentityProviderCredentialsClient: {
+    transformation: {
+      fieldsToOmit: [
+        // we are not managing secrets
+        { fieldName: 'client_secret' },
+      ],
+    },
+  },
+  AuthenticatorProviderConfiguration: {
+    transformation: {
+      fieldsToOmit: [
+        // we are not managing secrets
+        { fieldName: 'secretKey' },
+        { fieldName: 'sharedSecret' },
       ],
     },
   },

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -682,6 +682,13 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
       ],
     },
   },
+  PolicyRuleConditions: {
+    transformation: {
+      fieldTypeOverrides: [
+        { fieldName: 'userType', fieldType: 'UserTypePolicyRuleCondition' },
+      ],
+    },
+  },
 }
 
 const DEFAULT_SWAGGER_CONFIG: OktaApiConfig['swagger'] = {
@@ -695,6 +702,8 @@ const DEFAULT_SWAGGER_CONFIG: OktaApiConfig['swagger'] = {
     { typeName: 'PasswordPolicies', cloneFrom: 'api__v1__policies' },
     // TODO SALTO-2735 this is not the right type to clone from
     { typeName: 'RolePage', cloneFrom: 'api__v1__groups___groupId___roles@uuuuuu_00123_00125uu' },
+    // This type is missing from the swagger but both have the same structure
+    { typeName: 'UserTypePolicyRuleCondition', cloneFrom: 'GroupPolicyRuleCondition' },
   ],
 }
 

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -117,6 +117,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
       ],
       idFields: ['label'],
       serviceIdField: 'id',
+      fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),
       fieldsToHide: [{ fieldName: 'id' }],
     },
   },
@@ -264,6 +265,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
         { fieldName: 'CSRs', fieldType: 'list<Csr>' },
       ],
       serviceIdField: 'id',
+      fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),
       fieldsToHide: [{ fieldName: 'id' }],
     },
   },
@@ -286,6 +288,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
         { fieldName: 'featureDependencies', fieldType: 'list<Feature>' },
       ],
       serviceIdField: 'id',
+      fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),
       fieldsToHide: [{ fieldName: 'id' }],
     },
   },
@@ -388,6 +391,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
     },
     transformation: {
       serviceIdField: 'id',
+      fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),
       fieldsToHide: [{ fieldName: 'id' }],
     },
   },
@@ -441,6 +445,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
   OrgContactTypeObj: {
     transformation: {
       idFields: ['contactType'],
+      fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),
     },
   },
   api__v1__templates__sms: {
@@ -495,9 +500,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
         { fieldName: 'policies', fieldType: 'list<AuthorizationServerPolicy>' },
         { fieldName: 'clients', fieldType: 'list<OAuth2Client>' },
       ],
-      fieldsToOmit: [
-        { fieldName: '_links' },
-      ],
+      fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),
       fieldsToHide: [{ fieldName: 'id' }],
       serviceIdField: 'id',
     },
@@ -544,6 +547,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
     transformation: {
       idFields: ['title'],
       serviceIdField: 'id',
+      fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),
       fieldsToHide: [{ fieldName: 'id' }],
     },
   },
@@ -565,18 +569,21 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
     transformation: {
       isSingleton: true,
       serviceIdField: 'id',
+      fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),
       fieldsToHide: [{ fieldName: 'id' }],
     },
   },
   Authenticator: {
     transformation: {
       serviceIdField: 'id',
+      fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),
       fieldsToHide: [{ fieldName: 'id' }],
     },
   },
   EventHook: {
     transformation: {
       serviceIdField: 'id',
+      fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),
       fieldsToHide: [{ fieldName: 'id' }],
     },
   },
@@ -589,25 +596,31 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
   InlineHook: {
     transformation: {
       serviceIdField: 'id',
+      fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),
       fieldsToHide: [{ fieldName: 'id' }],
     },
   },
   NetworkZone: {
     transformation: {
       serviceIdField: 'id',
+      fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),
       fieldsToHide: [{ fieldName: 'id' }],
     },
   },
   TrustedOrigin: {
     transformation: {
       serviceIdField: 'id',
+      fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),
       fieldsToHide: [{ fieldName: 'id' }],
     },
   },
   UserType: {
     transformation: {
       serviceIdField: 'id',
-      fieldsToHide: [{ fieldName: 'id' }],
+      fieldsToHide: [
+        { fieldName: 'id' },
+        { fieldName: '_links' },
+      ],
     },
   },
   GroupSchemaAttribute: {

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -117,6 +117,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
       ],
       idFields: ['label'],
       serviceIdField: 'id',
+      fieldsToHide: [{ fieldName: 'id' }],
     },
   },
   api__v1__apps: {
@@ -263,6 +264,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
         { fieldName: 'CSRs', fieldType: 'list<Csr>' },
       ],
       serviceIdField: 'id',
+      fieldsToHide: [{ fieldName: 'id' }],
     },
   },
   api__v1__features: {
@@ -284,6 +286,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
         { fieldName: 'featureDependencies', fieldType: 'list<Feature>' },
       ],
       serviceIdField: 'id',
+      fieldsToHide: [{ fieldName: 'id' }],
     },
   },
   // Policy type is splitted to different kinds of policies
@@ -379,28 +382,13 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
       ],
     },
   },
-  // TODO SALTO-2733 returns 400 bad request
-  OAuthAuthorizationPolicies: {
-    request: {
-      url: '/api/v1/policies',
-      queryParams: {
-        type: 'OAUTH_AUTHORIZATION_POLICY',
-      },
-      recurseInto: [
-        {
-          type: 'api__v1__policies___policyId___rules@uuuuuu_00123_00125uu',
-          toField: 'policyRules',
-          context: [{ name: 'policyId', fromField: 'id' }],
-        },
-      ],
-    },
-  },
   UserSchema: {
     request: {
       url: '/api/v1/meta/schemas/user/default',
     },
     transformation: {
       serviceIdField: 'id',
+      fieldsToHide: [{ fieldName: 'id' }],
     },
   },
   User: {
@@ -510,6 +498,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
       fieldsToOmit: [
         { fieldName: '_links' },
       ],
+      fieldsToHide: [{ fieldName: 'id' }],
       serviceIdField: 'id',
     },
   },
@@ -555,59 +544,70 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
     transformation: {
       idFields: ['title'],
       serviceIdField: 'id',
+      fieldsToHide: [{ fieldName: 'id' }],
     },
   },
   Domain: {
     transformation: {
       isSingleton: true,
       serviceIdField: 'id',
+      fieldsToHide: [{ fieldName: 'id' }],
     },
   },
   OrgSetting: {
     transformation: {
       isSingleton: true,
       serviceIdField: 'id',
+      fieldsToHide: [{ fieldName: 'id' }],
     },
   },
   Brand: {
     transformation: {
       isSingleton: true,
       serviceIdField: 'id',
+      fieldsToHide: [{ fieldName: 'id' }],
     },
   },
   Authenticator: {
     transformation: {
       serviceIdField: 'id',
+      fieldsToHide: [{ fieldName: 'id' }],
     },
   },
   EventHook: {
     transformation: {
       serviceIdField: 'id',
+      fieldsToHide: [{ fieldName: 'id' }],
     },
   },
   GroupRule: {
     transformation: {
       serviceIdField: 'id',
+      fieldsToHide: [{ fieldName: 'id' }],
     },
   },
   InlineHook: {
     transformation: {
       serviceIdField: 'id',
+      fieldsToHide: [{ fieldName: 'id' }],
     },
   },
   NetworkZone: {
     transformation: {
       serviceIdField: 'id',
+      fieldsToHide: [{ fieldName: 'id' }],
     },
   },
   TrustedOrigin: {
     transformation: {
       serviceIdField: 'id',
+      fieldsToHide: [{ fieldName: 'id' }],
     },
   },
   UserType: {
     transformation: {
       serviceIdField: 'id',
+      fieldsToHide: [{ fieldName: 'id' }],
     },
   },
   GroupSchemaAttribute: {
@@ -642,6 +642,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
         { fieldName: 'lastUpdated' },
       ],
       serviceIdField: 'id',
+      fieldsToHide: [{ fieldName: 'id' }],
     },
   },
   AppUserCredentials: {
@@ -679,7 +680,6 @@ const DEFAULT_SWAGGER_CONFIG: OktaApiConfig['swagger'] = {
     { typeName: 'ProfileEnrollmentPolicies', cloneFrom: 'api__v1__policies' },
     { typeName: 'IdentityProviderRoutingRules', cloneFrom: 'api__v1__policies' },
     { typeName: 'PasswordPolicies', cloneFrom: 'api__v1__policies' },
-    { typeName: 'OAuthAuthorizationPolicies', cloneFrom: 'api__v1__policies' },
     // TODO SALTO-2735 this is not the right type to clone from
     { typeName: 'RolePage', cloneFrom: 'api__v1__groups___groupId___roles@uuuuuu_00123_00125uu' },
   ],
@@ -717,7 +717,6 @@ export const SUPPORTED_TYPES = {
     'ProfileEnrollmentPolicies',
     'IdentityProviderRoutingRules',
     'PasswordPolicies',
-    'OAuthAuthorizationPolicies',
   ],
   SmsTemplate: ['api__v1__templates__sms'],
   TrustedOrigin: ['api__v1__trustedOrigins'],

--- a/packages/okta-adapter/src/reference_mapping.ts
+++ b/packages/okta-adapter/src/reference_mapping.ts
@@ -73,6 +73,16 @@ export const referencesRules: referenceUtils.FieldReferenceDefinition<never>[] =
     target: { type: USER_TYPE_NAME },
   },
   {
+    src: { field: 'include', parentTypes: ['UserTypePolicyRuleCondition'] },
+    serializationStrategy: 'id',
+    target: { type: USERTYPE_TYPE_NAME },
+  },
+  {
+    src: { field: 'exclude', parentTypes: ['UserTypePolicyRuleCondition'] },
+    serializationStrategy: 'id',
+    target: { type: USERTYPE_TYPE_NAME },
+  },
+  {
     src: { field: 'createdBy', parentTypes: [USERTYPE_TYPE_NAME, 'EventHook', 'TrustedOrigin'] },
     serializationStrategy: 'id',
     target: { type: USER_TYPE_NAME },


### PR DESCRIPTION
Some config changes to make Okta nacls better 💯 

---

_Additional context for reviewer_

Changes:
- Hide `id` field from all types (except nested types and setting types)
- Omit `_links` field from all relevant types
- Add missing fields from type definitions with `fieldTypeOverrides`
- Omit more secret fields
- remove duplicate type: 'AuthorizationPolicy` (fetched as part of `recurseInto` of `AuthorizationServer`
- Add one reference from `PolicyRule` type to `UserType` type

---
_Release Notes_: 
None

---
_User Notifications_: 
None
