### PR TITLE
SALTO-3281: project role in filter shared permission is not created

### DIFF
--- a/packages/jira-adapter/src/filters/share_permission.ts
+++ b/packages/jira-adapter/src/filters/share_permission.ts
@@ -118,7 +118,7 @@ const filter: FilterCreator = () => ({
             await transformSharedPermissions(
               instance,
               sharedPermission => {
-                if (sharedPermission.role !== undefined) {
+                if (sharedPermission.type === 'project' && sharedPermission.role !== undefined) {
                   sharedPermission.type = 'projectRole'
                 }
               },

--- a/packages/jira-adapter/test/filters/share_permission.test.ts
+++ b/packages/jira-adapter/test/filters/share_permission.test.ts
@@ -13,14 +13,14 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, ElemID, Field, InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import { BuiltinTypes, ElemID, Field, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import { JIRA } from '../../src/constants'
 import sharePermissionFilter from '../../src/filters/share_permission'
 import { getFilterParams } from '../utils'
 
 describe('sharePermissionFilter', () => {
-  let filter: filterUtils.FilterWith<'onFetch'>
+  let filter: filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
   let instance: InstanceElement
   let type: ObjectType
   let sharePermissionType: ObjectType
@@ -117,5 +117,51 @@ describe('sharePermissionFilter', () => {
     expect((await sharePermissionType.fields.role.getType()).elemID.getFullName()).toBe('jira.ProjectRolePermission')
     expect((await sharePermissionType.fields.project.getType()).elemID.getFullName()).toBe('jira.ProjectPermission')
     expect(elements).toHaveLength(3)
+  })
+
+  it('if there is role should change type to projectRole', async () => {
+    instance.value.permissions.type = 'project'
+    instance.value.permissions.role = {
+      id: 1,
+    }
+    await filter.preDeploy([toChange({ after: instance })])
+    expect(instance.value).toEqual({
+      permissions: {
+        type: 'projectRole',
+        role: {
+          id: 1,
+        },
+      },
+    })
+  })
+
+  it('if there is no role should not change type to projectRole', async () => {
+    instance.value.permissions.type = 'project'
+    await filter.preDeploy([toChange({ after: instance })])
+    expect(instance.value).toEqual({
+      permissions: {
+        type: 'project',
+      },
+    })
+  })
+
+  it('should change projectRole to project on deploy', async () => {
+    instance.value.permissions.type = 'projectRole'
+    await filter.onDeploy([toChange({ after: instance })])
+    expect(instance.value).toEqual({
+      permissions: {
+        type: 'project',
+      },
+    })
+  })
+
+  it('should not change non projectRole types on deploy', async () => {
+    instance.value.permissions.type = 'user'
+    await filter.onDeploy([toChange({ after: instance })])
+    expect(instance.value).toEqual({
+      permissions: {
+        type: 'user',
+      },
+    })
   })
 })


### PR DESCRIPTION
 Fixed creating a shared permission of a project role

---
_Release Notes_: 
__Jira Adapter__:
- Fixed creating a shared permission of a project role

---
_User Notifications_: 
None