### PR TITLE
SALTO-3230 -Adapter-components - referenced_instance_names.ts: allow empty on transformElement by default

### DIFF
--- a/packages/adapter-components/src/filters/referenced_instance_names.ts
+++ b/packages/adapter-components/src/filters/referenced_instance_names.ts
@@ -145,6 +145,7 @@ const createNewInstance = async (
     element: currentInstance,
     transformFunc: createReferencesTransformFunc(currentInstance.elemID, newElemId),
     strict: false,
+    allowEmpty: true,
   })
   return new InstanceElement(
     newElemId.name,

--- a/packages/zendesk-adapter/src/change_validators/required_app_owned_parameters.ts
+++ b/packages/zendesk-adapter/src/change_validators/required_app_owned_parameters.ts
@@ -83,7 +83,7 @@ const unpopulatedParameters = (
     return []
   }
   const appOwned = appOwnedInstances[appInstallation.value.app_id]
-  if (appOwned?.value.parameters === undefined || !isAppOwned(appOwned)) {
+  if (_.isEmpty(appOwned?.value.parameters) || !isAppOwned(appOwned)) {
     return []
   }
   const { parameters } = appOwned.value


### PR DESCRIPTION
'referenced_instance_names' filter will no longer remove fields with empty values from elements
Relevant for Zendesk, Okta and Workato adapters

---

Noise reduction - https://github.com/salto-io/salto_private/pull/4838

---
_Release Notes_:
Zendesk Adapter:
* New fields with an empty value (undefined, empty lists...) will be added to elements (these fields exists but were removed)
Okta Adapter:
* New fields with an empty value (undefined, empty lists...) will be added to elements (these fields exists but were removed)
Workato Adapter:
* New fields with an empty value (undefined, empty lists...) will be added to elements (these fields exists but were removed)

---
_User Notifications_: 
Zendesk Adapter:
* New fields with an empty value (undefined, empty lists...) will be added to elements (these fields exists but were removed)
Okta Adapter:
* New fields with an empty value (undefined, empty lists...) will be added to elements (these fields exists but were removed)
Workato Adapter:
* New fields with an empty value (undefined, empty lists...) will be added to elements (these fields exists but were removed)
