### PR TITLE
SALTO-3402: Omit CustomRecordType's "permissions" field by default

### DIFF
--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -20,7 +20,7 @@ import {
   createRestriction, MapType,
 } from '@salto-io/adapter-api'
 import { createMatchingObjectType } from '@salto-io/adapter-utils'
-import { CURRENCY, DATASET, EXCHANGE_RATE, NETSUITE, WORKBOOK } from './constants'
+import { CURRENCY, DATASET, EXCHANGE_RATE, NETSUITE, PERMISSIONS, WORKBOOK } from './constants'
 import { NetsuiteQueryParameters, FetchParams, convertToQueryParams, QueryParams, FetchTypeQueryParams, FieldToOmitParams, validateArrayOfStrings, validatePlainObject, validateFetchParameters, FETCH_PARAMS, validateFieldsToOmitConfig } from './query'
 import { ITEM_TYPE_TO_SEARCH_STRING, TYPES_TO_INTERNAL_ID } from './data_elements/types'
 import { AdditionalDependencies, AdditionalSdfDeployDependencies, FailedFiles, FailedTypes } from './client/types'
@@ -247,6 +247,12 @@ export const fetchDefault: FetchParams = {
       type: CURRENCY,
       fields: [
         EXCHANGE_RATE,
+      ],
+    },
+    {
+      type: 'customrecord.*',
+      fields: [
+        PERMISSIONS,
       ],
     },
   ],

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -20,7 +20,9 @@ import {
   createRestriction, MapType,
 } from '@salto-io/adapter-api'
 import { createMatchingObjectType } from '@salto-io/adapter-utils'
-import { CURRENCY, DATASET, EXCHANGE_RATE, NETSUITE, PERMISSIONS, WORKBOOK } from './constants'
+import {
+  CURRENCY, CUSTOM_RECORD_TYPE, DATASET, EXCHANGE_RATE, NETSUITE, PERMISSIONS, WORKBOOK,
+} from './constants'
 import { NetsuiteQueryParameters, FetchParams, convertToQueryParams, QueryParams, FetchTypeQueryParams, FieldToOmitParams, validateArrayOfStrings, validatePlainObject, validateFetchParameters, FETCH_PARAMS, validateFieldsToOmitConfig } from './query'
 import { ITEM_TYPE_TO_SEARCH_STRING, TYPES_TO_INTERNAL_ID } from './data_elements/types'
 import { AdditionalDependencies, AdditionalSdfDeployDependencies, FailedFiles, FailedTypes } from './client/types'
@@ -250,7 +252,7 @@ export const fetchDefault: FetchParams = {
       ],
     },
     {
-      type: 'customrecord.*',
+      type: CUSTOM_RECORD_TYPE,
       fields: [
         PERMISSIONS,
       ],

--- a/packages/netsuite-adapter/src/constants.ts
+++ b/packages/netsuite-adapter/src/constants.ts
@@ -73,6 +73,7 @@ export const IS_SUB_INSTANCE = 'isSubInstance'
 export const PARENT = 'parent'
 export const CUSTOM_FIELD_PREFIX = 'custom_'
 export const EXCHANGE_RATE = 'exchangeRate'
+export const PERMISSIONS = 'permissions'
 
 // Field Annotations
 export const SOAP = 'soap'


### PR DESCRIPTION
_Replace me with a description of the changes in this PR_

---

_Additional context for reviewer_

---
_Release Notes_: 
SALTO-3402: Omit CustomRecordType's "permissions" field by default for new WSs
---
_User Notifications_: 
None