### PR TITLE
SALTO-3130 SF - changed error logs to be adaptive to validation

### DIFF
--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -177,6 +177,7 @@ const isUnFoundDelete = (message: DeployMessage, deletionsPackageName: string): 
 const processDeployResponse = (
   result: SFDeployResult,
   deletionsPackageName: string,
+  checkOnly: boolean,
 ): { successfulFullNames: ReadonlyArray<MetadataId>; errors: ReadonlyArray<Error> } => {
   const allFailureMessages = makeArray(result.details)
     .flatMap(detail => makeArray(detail.componentFailures))
@@ -191,7 +192,7 @@ const processDeployResponse = (
     .filter(failure => !isUnFoundDelete(failure, deletionsPackageName))
     .map(getUserFriendlyDeployMessage)
     .map(failure => new Error(
-      `Failed to deploy ${failure.fullName} with error: ${failure.problem} (${failure.problemType})`
+      `Failed to ${checkOnly ? 'validate' : 'deploy'} ${failure.fullName} with error: ${failure.problem} (${failure.problemType})`
     ))
   const codeCoverageWarningErrors = makeArray(result.details)
     .map(detail => detail.runTestResult as RunTestsResult | undefined)
@@ -309,7 +310,7 @@ export const deployMetadata = async (
   log.debug('deploy result: %s', safeJsonStringify(deployRes, undefined, 2))
 
   const { errors, successfulFullNames } = processDeployResponse(
-    deployRes, pkg.getDeletionsPackageName()
+    deployRes, pkg.getDeletionsPackageName(), checkOnly ?? false
   )
   const isSuccessfulChange = (change: Change<MetadataInstanceElement>): boolean => {
     const changeElem = getChangeData(change)


### PR DESCRIPTION
_changed error logs to be adaptive to validation_

---

_Additional context for reviewer_

---
_Release Notes_: 
None
---
_User Notifications_: 
None
