### PR TITLE
SALTO-3197: Improve SF CLI login/add for test org (Sandbox/Scratch Org)

### DIFF
--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -292,7 +292,10 @@ export const usernamePasswordCredentialsType = new ObjectType({
       refType: BuiltinTypes.STRING,
       annotations: { message: 'Token (empty if your org uses IP whitelisting)' },
     },
-    sandbox: { refType: BuiltinTypes.BOOLEAN },
+    sandbox: {
+      refType: BuiltinTypes.BOOLEAN,
+      annotations: { message: 'Is Sandbox/Scratch Org' },
+    },
   },
 })
 


### PR DESCRIPTION
When adding a Salesforce environment, change "Sandbox" prompt to "Is Sandbox/Scratch Org"

---

before:
![image](https://user-images.githubusercontent.com/37732337/211566597-1a28aabc-8b97-4457-ab79-949e5aa3e6ec.png)

after:
![image](https://user-images.githubusercontent.com/37732337/211566531-d87e19f1-7f73-4baf-a206-d53548f4e9f4.png)


---
_Release Notes_: 
In `salto account add salesforce`, clarified the "Sandbox" option by changing it to "Is Sandbox/Scratch Org" because they use the same flow.

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
