### PR TITLE
SALTO-3391: Deployment of Salesforce MetadataRelationship fields

### DIFF
--- a/packages/salesforce-adapter/src/client/types.ts
+++ b/packages/salesforce-adapter/src/client/types.ts
@@ -16,7 +16,7 @@
 import { MetadataInfo, SaveResult } from 'jsforce'
 import _ from 'lodash'
 import { Value } from '@salto-io/adapter-api'
-import { FIELD_TYPE_NAMES, CUSTOM_OBJECT_ID_FIELD } from '../constants'
+import { FIELD_TYPE_NAMES, CUSTOM_OBJECT_ID_FIELD, isRelationshipFieldName } from '../constants'
 
 export type JSONBool = boolean | 'true' | 'false'
 
@@ -224,10 +224,7 @@ export class CustomField implements MetadataInfo {
     } else if (type === FIELD_TYPE_NAMES.CHECKBOX && !formula) {
       // For Checkbox the default value comes from defaultVal and not defaultValFormula
       this.defaultValue = defaultVal
-    } else if (type === FIELD_TYPE_NAMES.LOOKUP) {
-      this.relationshipName = relationshipName
-      this.referenceTo = relatedTo
-    } else if (type === FIELD_TYPE_NAMES.MASTER_DETAIL) {
+    } else if (isRelationshipFieldName(type)) {
       this.relationshipName = relationshipName
       this.referenceTo = relatedTo
     } else if (type === FIELD_TYPE_NAMES.ROLLUP_SUMMARY && summaryFilterItems) {

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -63,6 +63,18 @@ export enum FIELD_TYPE_NAMES {
   FILE = 'File',
 }
 
+const RELATIONSHIP_FIELD_NAMES = [
+  'MetadataRelationship',
+  'Lookup',
+  'MasterDetail',
+] as const
+
+type RelationshipFieldName = typeof RELATIONSHIP_FIELD_NAMES[number]
+
+export const isRelationshipFieldName = (fieldName: string): fieldName is RelationshipFieldName => (
+  (RELATIONSHIP_FIELD_NAMES as ReadonlyArray<string>).includes(fieldName)
+)
+
 export enum INTERNAL_FIELD_TYPE_NAMES {
   UNKNOWN = 'Unknown', // internal-only placeholder for fields whose type is unknown
   ANY = 'AnyType',

--- a/packages/salesforce-adapter/src/transformers/xml_transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/xml_transformer.ts
@@ -22,7 +22,6 @@ import { collections, values as lowerDashValues } from '@salto-io/lowerdash'
 import { Values, StaticFile, InstanceElement } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { MapKeyFunc, mapKeysRecursive, TransformFunc, transformValues } from '@salto-io/adapter-utils'
-import fs from 'fs'
 import { API_VERSION } from '../client/client'
 import {
   INSTANCE_FULL_NAME_FIELD, IS_ATTRIBUTE, METADATA_CONTENT_FIELD, SALESFORCE, XML_ATTRIBUTE_PREFIX,
@@ -444,14 +443,12 @@ export const createDeployPackage = (deleteBeforeUpdate?: boolean): DeployPackage
       const typeName = getManifestTypeName(type)
       deleteManifest.get(typeName).push(name)
     },
-    getZip: async () => {
+    getZip: () => {
       zip.file(`${PACKAGE}/package.xml`, toPackageXml(addManifest))
       if (deleteManifest.size !== 0) {
         zip.file(`${PACKAGE}/${deletionsPackageName}`, toPackageXml(deleteManifest))
       }
-      const buffer = await zip.generateAsync({ type: 'nodebuffer' })
-      fs.writeFileSync('/Users/tamir/xmls/out.zip', buffer)
-      return buffer
+      return zip.generateAsync({ type: 'nodebuffer' })
     },
     getDeletionsPackageName: () => deletionsPackageName,
   }

--- a/packages/salesforce-adapter/src/transformers/xml_transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/xml_transformer.ts
@@ -22,6 +22,7 @@ import { collections, values as lowerDashValues } from '@salto-io/lowerdash'
 import { Values, StaticFile, InstanceElement } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { MapKeyFunc, mapKeysRecursive, TransformFunc, transformValues } from '@salto-io/adapter-utils'
+import fs from 'fs'
 import { API_VERSION } from '../client/client'
 import {
   INSTANCE_FULL_NAME_FIELD, IS_ATTRIBUTE, METADATA_CONTENT_FIELD, SALESFORCE, XML_ATTRIBUTE_PREFIX,
@@ -443,12 +444,14 @@ export const createDeployPackage = (deleteBeforeUpdate?: boolean): DeployPackage
       const typeName = getManifestTypeName(type)
       deleteManifest.get(typeName).push(name)
     },
-    getZip: () => {
+    getZip: async () => {
       zip.file(`${PACKAGE}/package.xml`, toPackageXml(addManifest))
       if (deleteManifest.size !== 0) {
         zip.file(`${PACKAGE}/${deletionsPackageName}`, toPackageXml(deleteManifest))
       }
-      return zip.generateAsync({ type: 'nodebuffer' })
+      const buffer = await zip.generateAsync({ type: 'nodebuffer' })
+      fs.writeFileSync('/Users/tamir/xmls/out.zip', buffer)
+      return buffer
     },
     getDeletionsPackageName: () => deletionsPackageName,
   }


### PR DESCRIPTION
Deployed `MetadataRelationship` CustomField was missing the `referenceTo` annotation which caused failure.

---

There was special handling for field types that have the `referenceTo` annotations [here](https://github.com/salto-io/salto/blob/main/packages/salesforce-adapter/src/client/types.ts#L227), but there was no handling
for `MetadataRelationship` fields.

---
_Release Notes_: 
Salesforce Adapter:
- Support deployment of `MetadataRelationship` fields.

---
_User Notifications_: 
_None_
