### PR TITLE
SALTO-3218: Verify side conversations enabled before deployment of a macro with side conversation action fields

### DIFF
--- a/packages/zendesk-adapter/e2e_test/adapter.test.ts
+++ b/packages/zendesk-adapter/e2e_test/adapter.test.ts
@@ -1001,6 +1001,7 @@ describe('Zendesk adapter E2E', () => {
     })
     it('should fetch the regular instances and types', async () => {
       const typesToFetch = [
+        'account_features',
         'account_setting',
         'app_installation',
         'automation',

--- a/packages/zendesk-adapter/src/change_validator.ts
+++ b/packages/zendesk-adapter/src/change_validator.ts
@@ -51,6 +51,7 @@ import {
   childInOrderValidator,
   orderChildrenParentValidator,
   macroActionsTicketFieldDeactivationValidator,
+  sideConversationsValidator,
 } from './change_validators'
 import ZendeskClient from './client/client'
 
@@ -97,6 +98,7 @@ export default ({
     automationAllConditionsValidator,
     macroActionsTicketFieldDeactivationValidator,
     customRoleRemovalValidator(client),
+    sideConversationsValidator,
     requiredAppOwnedParametersValidator,
     oneTranslationPerLocaleValidator,
     articleRemovalValidator,

--- a/packages/zendesk-adapter/src/change_validators/index.ts
+++ b/packages/zendesk-adapter/src/change_validators/index.ts
@@ -49,3 +49,4 @@ export { guideOrderDeletionValidator } from './guide_order/order_deletion_valida
 export { articleAttachmentSizeValidator } from './article_attachment_size'
 export { macroActionsTicketFieldDeactivationValidator } from './macro_actions'
 export { customRoleRemovalValidator } from './custom_role_removal'
+export { sideConversationsValidator } from './side_conversation'

--- a/packages/zendesk-adapter/src/change_validators/macro.ts
+++ b/packages/zendesk-adapter/src/change_validators/macro.ts
@@ -15,7 +15,8 @@
 */
 import { ChangeValidator, getChangeData,
   isAdditionOrModificationChange, isInstanceElement } from '@salto-io/adapter-api'
-import { MACRO_TYPE_NAME, ATTACHMENTS_FIELD_NAME } from '../filters/macro_attachments'
+import { MACRO_TYPE_NAME } from '../constants'
+import { ATTACHMENTS_FIELD_NAME } from '../filters/macro_attachments'
 
 const MAX_ATTACHMENTS_IN_MACRO = 5
 

--- a/packages/zendesk-adapter/src/change_validators/macro_actions.ts
+++ b/packages/zendesk-adapter/src/change_validators/macro_actions.ts
@@ -25,12 +25,12 @@ import { collections } from '@salto-io/lowerdash'
 import Joi from 'joi'
 import { createSchemeGuard } from '@salto-io/adapter-utils'
 import _ from 'lodash'
-import { MACRO_TYPE_NAME } from '../filters/macro_attachments'
+import { MACRO_TYPE_NAME } from '../constants'
 
 const { awu } = collections.asynciterable
 const log = logger(module)
 
-type ActionsType = {
+export type ActionsType = {
   field: string | ReferenceExpression
   value: unknown
 }
@@ -40,7 +40,7 @@ const EXPECTED_ACTION_SCHEMA = Joi.object({
   value: Joi.required(),
 }).unknown(true).required()
 
-const isAction = createSchemeGuard<ActionsType>(
+export const isAction = createSchemeGuard<ActionsType>(
   EXPECTED_ACTION_SCHEMA, 'Received an invalid value for macro actions'
 )
 

--- a/packages/zendesk-adapter/src/change_validators/side_conversation.ts
+++ b/packages/zendesk-adapter/src/change_validators/side_conversation.ts
@@ -1,0 +1,84 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { ChangeValidator, ElemID, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, isInstanceElement } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { FEATURE_TYPE_NAME, MACRO_TYPE_NAME, ZENDESK } from '../constants'
+import { ActionsType, isAction } from './macro_actions'
+
+const log = logger(module)
+
+// Map side conversation field name in macro instances to side conversation feature name in the account feature instance
+const SIDE_CONVERSATION_MAP: Record<string, string> = {
+  side_conversation: 'side_conversations_email',
+  side_conversation_slack: 'side_conversations_slack',
+  side_conversation_ticket: 'side_conversations_tickets',
+}
+
+const getSideConversationFields = (macroInstance: InstanceElement): string[] => {
+  const actionWithTicketFields = macroInstance.value.actions
+    ?.filter(isAction)
+    .filter((action: ActionsType) =>
+      _.isString(action.field) && Object.keys(SIDE_CONVERSATION_MAP).includes(action.field))
+    .map((action: ActionsType) => action.field)
+  return actionWithTicketFields
+}
+
+/**
+ * Verify side_conversation features are enabled before deployment of a macro with side_conversation fields
+ */
+export const sideConversationsValidator: ChangeValidator = async (
+  changes, elementSource
+) => {
+  const relevantInstances = changes
+    .filter(isAdditionOrModificationChange)
+    .filter(isInstanceChange)
+    .map(getChangeData)
+    .filter(instance => instance.elemID.typeName === MACRO_TYPE_NAME)
+    .filter(macroInstance => !_.isEmpty(getSideConversationFields(macroInstance)))
+
+  if (elementSource === undefined) {
+    log.error('Failed to run sideConversationsValidator because no element source was provided')
+    return []
+  }
+  if (_.isEmpty(relevantInstances)) {
+    return []
+  }
+
+  const featureInstance = await elementSource.get(
+    new ElemID(ZENDESK, FEATURE_TYPE_NAME, 'instance', ElemID.CONFIG_NAME)
+  )
+  if (!isInstanceElement(featureInstance)) {
+    log.error(`Failed to run sideConversationsValidator because ${FEATURE_TYPE_NAME} instance was not found`)
+    return []
+  }
+  const accountDisabledSCFields = Object.keys(SIDE_CONVERSATION_MAP)
+    .filter(fieldOption => featureInstance.value[SIDE_CONVERSATION_MAP[fieldOption]]?.enabled !== true)
+
+  return relevantInstances.flatMap(macroInstance => {
+    const macrosDisabledSCFields = _.uniq(getSideConversationFields(macroInstance))
+      .filter(fieldName => accountDisabledSCFields.includes(fieldName))
+    if (_.isEmpty(macrosDisabledSCFields)) {
+      return []
+    }
+    return [{
+      elemID: macroInstance.elemID,
+      severity: 'Error',
+      message: 'Can not change macro with side conversation fields when the feature is disabled in the account',
+      detailedMessage: `Can not change ${macroInstance.elemID.name} because the macro contains the following side conversation actions which are disabled in the account: ${macrosDisabledSCFields.join(', ')}`,
+    }]
+  })
+}

--- a/packages/zendesk-adapter/src/change_validators/side_conversation.ts
+++ b/packages/zendesk-adapter/src/change_validators/side_conversation.ts
@@ -28,14 +28,13 @@ const SIDE_CONVERSATION_MAP: Record<string, string> = {
   side_conversation_ticket: 'side_conversations_tickets',
 }
 
-const getSideConversationFields = (macroInstance: InstanceElement): string[] => {
-  const actionWithTicketFields = macroInstance.value.actions
-    ?.filter(isAction)
+const getSideConversationFields = (macroInstance: InstanceElement): string[] => (
+  (macroInstance.value.actions ?? [])
+    .filter(isAction)
     .filter((action: ActionsType) =>
       _.isString(action.field) && Object.keys(SIDE_CONVERSATION_MAP).includes(action.field))
     .map((action: ActionsType) => action.field)
-  return actionWithTicketFields
-}
+)
 
 /**
  * Verify side_conversation features are enabled before deployment of a macro with side_conversation fields
@@ -43,17 +42,17 @@ const getSideConversationFields = (macroInstance: InstanceElement): string[] => 
 export const sideConversationsValidator: ChangeValidator = async (
   changes, elementSource
 ) => {
+  if (elementSource === undefined) {
+    log.error('Failed to run sideConversationsValidator because no element source was provided')
+    return []
+  }
+
   const relevantInstances = changes
     .filter(isAdditionOrModificationChange)
     .filter(isInstanceChange)
     .map(getChangeData)
     .filter(instance => instance.elemID.typeName === MACRO_TYPE_NAME)
     .filter(macroInstance => !_.isEmpty(getSideConversationFields(macroInstance)))
-
-  if (elementSource === undefined) {
-    log.error('Failed to run sideConversationsValidator because no element source was provided')
-    return []
-  }
   if (_.isEmpty(relevantInstances)) {
     return []
   }

--- a/packages/zendesk-adapter/src/change_validators/side_conversation.ts
+++ b/packages/zendesk-adapter/src/change_validators/side_conversation.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2022 Salto Labs Ltd.
+*                      Copyright 2023 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with
@@ -16,7 +16,7 @@
 import _ from 'lodash'
 import { ChangeValidator, ElemID, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, isInstanceElement } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
-import { FEATURE_TYPE_NAME, MACRO_TYPE_NAME, ZENDESK } from '../constants'
+import { ACCOUNT_FEATURES_TYPE_NAME, MACRO_TYPE_NAME, ZENDESK } from '../constants'
 import { ActionsType, isAction } from './macro_actions'
 
 const log = logger(module)
@@ -59,10 +59,10 @@ export const sideConversationsValidator: ChangeValidator = async (
   }
 
   const featureInstance = await elementSource.get(
-    new ElemID(ZENDESK, FEATURE_TYPE_NAME, 'instance', ElemID.CONFIG_NAME)
+    new ElemID(ZENDESK, ACCOUNT_FEATURES_TYPE_NAME, 'instance', ElemID.CONFIG_NAME)
   )
   if (!isInstanceElement(featureInstance)) {
-    log.error(`Failed to run sideConversationsValidator because ${FEATURE_TYPE_NAME} instance was not found`)
+    log.error(`Failed to run sideConversationsValidator because ${ACCOUNT_FEATURES_TYPE_NAME} instance was not found`)
     return []
   }
   const accountDisabledSCFields = Object.keys(SIDE_CONVERSATION_MAP)

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -2382,6 +2382,20 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
       ],
     },
   },
+  features: {
+    request: {
+      url: '/api/v2/account/features',
+    },
+    transformation: {
+      dataField: 'features',
+    },
+  },
+  feature: {
+    transformation: {
+      sourceTypeName: 'features__features',
+      isSingleton: true,
+    },
+  },
 }
 
 export const SUPPORTED_TYPES = {
@@ -2418,6 +2432,7 @@ export const SUPPORTED_TYPES = {
   view: ['views'],
   webhook: ['webhooks'],
   workspace: ['workspaces'],
+  feature: ['features'],
 }
 
 // Types in Zendesk Guide which relate to a certain brand

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -2390,7 +2390,7 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
       dataField: 'features',
     },
   },
-  feature: {
+  account_features: {
     transformation: {
       sourceTypeName: 'features__features',
       isSingleton: true,
@@ -2432,7 +2432,7 @@ export const SUPPORTED_TYPES = {
   view: ['views'],
   webhook: ['webhooks'],
   workspace: ['workspaces'],
-  feature: ['features'],
+  account_features: ['features'],
 }
 
 // Types in Zendesk Guide which relate to a certain brand

--- a/packages/zendesk-adapter/src/constants.ts
+++ b/packages/zendesk-adapter/src/constants.ts
@@ -35,7 +35,7 @@ export const USER_FIELD_TYPE_NAME = 'user_field'
 export const FIELD_TYPE_NAMES = [TICKET_FIELD_TYPE_NAME, USER_FIELD_TYPE_NAME, ORG_FIELD_TYPE_NAME]
 export const CUSTOM_ROLE_TYPE_NAME = 'custom_role'
 export const MACRO_TYPE_NAME = 'macro'
-export const FEATURE_TYPE_NAME = 'feature'
+export const ACCOUNT_FEATURES_TYPE_NAME = 'account_features'
 export const EVERYONE_USER_TYPE = 'Everyone'
 export const TICKET_FORM_TYPE_NAME = 'ticket_form'
 

--- a/packages/zendesk-adapter/src/constants.ts
+++ b/packages/zendesk-adapter/src/constants.ts
@@ -34,6 +34,8 @@ export const ORG_FIELD_TYPE_NAME = 'organization_field'
 export const USER_FIELD_TYPE_NAME = 'user_field'
 export const FIELD_TYPE_NAMES = [TICKET_FIELD_TYPE_NAME, USER_FIELD_TYPE_NAME, ORG_FIELD_TYPE_NAME]
 export const CUSTOM_ROLE_TYPE_NAME = 'custom_role'
+export const MACRO_TYPE_NAME = 'macro'
+export const FEATURE_TYPE_NAME = 'feature'
 export const EVERYONE_USER_TYPE = 'Everyone'
 export const TICKET_FORM_TYPE_NAME = 'ticket_form'
 

--- a/packages/zendesk-adapter/src/filters/macro_attachments.ts
+++ b/packages/zendesk-adapter/src/filters/macro_attachments.ts
@@ -26,7 +26,7 @@ import { logger } from '@salto-io/logging'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
 import { values, collections } from '@salto-io/lowerdash'
 import { FilterCreator } from '../filter'
-import { ZENDESK } from '../constants'
+import { ZENDESK, MACRO_TYPE_NAME } from '../constants'
 import { addId, deployChange, deployChanges } from '../deployment'
 import { getZendeskError } from '../errors'
 import { lookupFunc } from './field_references'
@@ -38,7 +38,6 @@ const { awu } = collections.asynciterable
 
 const { RECORDS_PATH, SUBTYPES_PATH, TYPES_PATH } = elementsUtils
 
-export const MACRO_TYPE_NAME = 'macro'
 export const MACRO_ATTACHMENT_TYPE_NAME = 'macro_attachment'
 export const ATTACHMENTS_FIELD_NAME = 'attachments'
 const MACRO_ATTACHMENT_DATA_FIELD = 'macro_attachment'

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -301,6 +301,8 @@ describe('adapter', () => {
           'zendesk.dynamic_content_item__variants.instance.dynamic_content_item_544_s__en_US_b@uuumuuum',
           'zendesk.dynamic_content_item__variants.instance.dynamic_content_item_544_s__es@uuumuu',
           'zendesk.dynamic_content_item__variants.instance.dynamic_content_item_544_s__he@uuumuu',
+          'zendesk.feature',
+          'zendesk.features',
           'zendesk.group',
           'zendesk.group.instance.Support',
           'zendesk.group.instance.Support2',

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -139,6 +139,7 @@ describe('adapter', () => {
           elementsSource: buildElementsSourceFromElements([]),
         }).fetch({ progressReporter: { reportProgress: () => null } })
         expect(elements.map(e => e.elemID.getFullName()).sort()).toEqual([
+          'zendesk.account_features',
           'zendesk.account_setting',
           'zendesk.account_setting.instance',
           'zendesk.account_setting__active_features',
@@ -301,7 +302,6 @@ describe('adapter', () => {
           'zendesk.dynamic_content_item__variants.instance.dynamic_content_item_544_s__en_US_b@uuumuuum',
           'zendesk.dynamic_content_item__variants.instance.dynamic_content_item_544_s__es@uuumuu',
           'zendesk.dynamic_content_item__variants.instance.dynamic_content_item_544_s__he@uuumuu',
-          'zendesk.feature',
           'zendesk.features',
           'zendesk.group',
           'zendesk.group.instance.Support',

--- a/packages/zendesk-adapter/test/change_validators/macro.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/macro.test.ts
@@ -14,9 +14,9 @@
 * limitations under the License.
 */
 import { ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
-import { ZENDESK } from '../../src/constants'
+import { ZENDESK, MACRO_TYPE_NAME } from '../../src/constants'
 import { maxAttachmentsInMacroValidator } from '../../src/change_validators/macro'
-import { MACRO_TYPE_NAME, MACRO_ATTACHMENT_TYPE_NAME, ATTACHMENTS_FIELD_NAME } from '../../src/filters/macro_attachments'
+import { MACRO_ATTACHMENT_TYPE_NAME, ATTACHMENTS_FIELD_NAME } from '../../src/filters/macro_attachments'
 
 describe('macro', () => {
   const attachment = new InstanceElement(

--- a/packages/zendesk-adapter/test/change_validators/macro_acitions.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/macro_acitions.test.ts
@@ -15,8 +15,7 @@
 */
 import { ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { ZENDESK } from '../../src/constants'
-import { MACRO_TYPE_NAME } from '../../src/filters/macro_attachments'
+import { ZENDESK, MACRO_TYPE_NAME } from '../../src/constants'
 import { macroActionsTicketFieldDeactivationValidator } from '../../src/change_validators'
 
 describe('macro action ticket field test', () => {

--- a/packages/zendesk-adapter/test/change_validators/side_conversation.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/side_conversation.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2022 Salto Labs Ltd.
+*                      Copyright 2023 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with
@@ -15,12 +15,12 @@
 */
 import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { ZENDESK, MACRO_TYPE_NAME, FEATURE_TYPE_NAME } from '../../src/constants'
+import { ZENDESK, MACRO_TYPE_NAME, ACCOUNT_FEATURES_TYPE_NAME } from '../../src/constants'
 import { sideConversationsValidator } from '../../src/change_validators'
 
 describe('macro side conversation fields', () => {
   const macroType = new ObjectType({ elemID: new ElemID(ZENDESK, MACRO_TYPE_NAME) })
-  const featureType = new ObjectType({ elemID: new ElemID(ZENDESK, FEATURE_TYPE_NAME) })
+  const featureType = new ObjectType({ elemID: new ElemID(ZENDESK, ACCOUNT_FEATURES_TYPE_NAME) })
 
   it('should return an error when macro contains disabled side conversation fields', async () => {
     const macroInstance1 = new InstanceElement(

--- a/packages/zendesk-adapter/test/change_validators/side_conversation.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/side_conversation.test.ts
@@ -1,0 +1,212 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { ZENDESK, MACRO_TYPE_NAME, FEATURE_TYPE_NAME } from '../../src/constants'
+import { sideConversationsValidator } from '../../src/change_validators'
+
+describe('macro side conversation fields', () => {
+  const macroType = new ObjectType({ elemID: new ElemID(ZENDESK, MACRO_TYPE_NAME) })
+  const featureType = new ObjectType({ elemID: new ElemID(ZENDESK, FEATURE_TYPE_NAME) })
+
+  it('should return an error when macro contains disabled side conversation fields', async () => {
+    const macroInstance1 = new InstanceElement(
+      'test',
+      macroType,
+      {
+        title: 'test',
+        actions: [
+          {
+            field: 'comment_value_html',
+            value: '<p>Test</p>',
+          },
+          {
+            field: 'side_conversation_ticket',
+            value: ['fwd: {{ticket.title}} (Ticket #{{ticket.id}}', 'text/html'],
+          },
+        ],
+      }
+    )
+    const macroInstance2 = new InstanceElement(
+      'test',
+      macroType,
+      {
+        title: 'test',
+        actions: [
+          {
+            field: 'side_conversation',
+            value: ['test', 'text/html'],
+          },
+          {
+            field: 'side_conversation',
+            value: ['test', 'text/html'],
+          },
+          {
+            field: 'comment_value_html',
+            value: '<p>Test</p>',
+          },
+          {
+            field: 'side_conversation_slack',
+            value: ['fwd: {{ticket.title}} (Ticket #{{ticket.id}}', '<p>test</p>'],
+          },
+        ],
+      }
+    )
+    const featureInstance = new InstanceElement(
+      ElemID.CONFIG_NAME,
+      featureType,
+      {
+        macro_preview: {
+          enabled: true,
+        },
+        side_conversations_email: {
+          enabled: false,
+        },
+        side_conversations_slack: {
+          enabled: false,
+        },
+        side_conversations_tickets: {
+          enabled: false,
+        },
+      },
+    )
+    const errors = await sideConversationsValidator(
+      [toChange({ after: macroInstance1 }), toChange({ after: macroInstance2 })],
+      buildElementsSourceFromElements([featureInstance])
+    )
+    expect(errors).toHaveLength(2)
+    expect(errors[0]).toEqual({
+      elemID: macroInstance1.elemID,
+      severity: 'Error',
+      message: 'Can not change macro with side conversation fields when the feature is disabled in the account',
+      detailedMessage: `Can not change ${macroInstance1.elemID.name} because the macro contains the following side conversation actions which are disabled in the account: side_conversation_ticket`,
+    })
+    expect(errors[1]).toEqual({
+      elemID: macroInstance2.elemID,
+      severity: 'Error',
+      message: 'Can not change macro with side conversation fields when the feature is disabled in the account',
+      detailedMessage: `Can not change ${macroInstance2.elemID.name} because the macro contains the following side conversation actions which are disabled in the account: side_conversation, side_conversation_slack`,
+    })
+  })
+  it('should not return an error when all macro side conversation fields are enabled', async () => {
+    const macroInstance = new InstanceElement(
+      'test',
+      macroType,
+      {
+        title: 'test',
+        actions: [
+          {
+            field: 'comment_value_html',
+            value: '<p>Test</p>',
+          },
+          {
+            field: 'side_conversation_ticket',
+            value: ['fwd: {{ticket.title}} (Ticket #{{ticket.id}}', 'text/html'],
+          },
+          {
+            field: 'side_conversation_slack',
+            value: ['fwd: {{ticket.title}} (Ticket #{{ticket.id}}', '<p>test</p>'],
+          },
+        ],
+      }
+    )
+    const featureInstance = new InstanceElement(
+      ElemID.CONFIG_NAME,
+      featureType,
+      {
+        macro_preview: {
+          enabled: true,
+        },
+        side_conversations_email: {
+          enabled: false,
+        },
+        side_conversations_slack: {
+          enabled: true,
+        },
+        side_conversations_tickets: {
+          enabled: true,
+        },
+      },
+    )
+    const errors = await sideConversationsValidator(
+      [toChange({ after: macroInstance })],
+      buildElementsSourceFromElements([featureInstance])
+    )
+    expect(errors).toHaveLength(0)
+  })
+  it('should not return an error when macro has no side conversation fields', async () => {
+    const macroInstance = new InstanceElement(
+      'test',
+      macroType,
+      {
+        title: 'test',
+        actions: [
+          {
+            field: 'comment_value_html',
+            value: '<p>Test</p>',
+          },
+        ],
+      }
+    )
+    const featureInstance = new InstanceElement(
+      ElemID.CONFIG_NAME,
+      featureType,
+      {
+        macro_preview: {
+          enabled: true,
+        },
+        side_conversations_email: {
+          enabled: false,
+        },
+        side_conversations_slack: {
+          enabled: true,
+        },
+        side_conversations_tickets: {
+          enabled: false,
+        },
+      },
+    )
+    const errors = await sideConversationsValidator(
+      [toChange({ after: macroInstance })],
+      buildElementsSourceFromElements([featureInstance])
+    )
+    expect(errors).toHaveLength(0)
+  })
+  it('should return nothing if feature instance is missing', async () => {
+    const macroInstance = new InstanceElement(
+      'test',
+      macroType,
+      {
+        title: 'test',
+        actions: [
+          {
+            field: 'side_conversation_ticket',
+            value: ['fwd: {{ticket.title}} (Ticket #{{ticket.id}}', 'text/html'],
+          },
+          {
+            field: 'comment_value_html',
+            value: '<p>Test</p>',
+          },
+        ],
+      }
+    )
+    const errors = await sideConversationsValidator(
+      [toChange({ after: macroInstance })],
+      buildElementsSourceFromElements([])
+    )
+    expect(errors).toHaveLength(0)
+  })
+})

--- a/packages/zendesk-adapter/test/filters/macro_attachments.test.ts
+++ b/packages/zendesk-adapter/test/filters/macro_attachments.test.ts
@@ -21,8 +21,8 @@ import {
 import { filterUtils } from '@salto-io/adapter-components'
 import { createFilterCreatorParams } from '../utils'
 import ZendeskClient from '../../src/client/client'
-import { ZENDESK } from '../../src/constants'
-import filterCreator, { ATTACHMENTS_FIELD_NAME, MACRO_ATTACHMENT_TYPE_NAME, MACRO_TYPE_NAME } from '../../src/filters/macro_attachments'
+import { ZENDESK, MACRO_TYPE_NAME } from '../../src/constants'
+import filterCreator, { ATTACHMENTS_FIELD_NAME, MACRO_ATTACHMENT_TYPE_NAME } from '../../src/filters/macro_attachments'
 
 const mockDeployChange = jest.fn()
 jest.mock('@salto-io/adapter-components', () => {


### PR DESCRIPTION
Verify side conversations enabled before deployment of a macro with side conversation action fields

---

Macros have actions that might include side conversations. There're 3 types of side conversations that can be activated in the account, the activation status of each of those features can be found in `account_features` settings instance.
This change adds the `account_features` instance and a change validator that use it to verify that all side conversation fields in the changed `macro` instance are enabled before deployment.

I kept `account_features` instance visible, it's not deployable and there's a change validator alerting this when trying to deploy the instance. will also add noise reduction before merging.

---
_Release Notes_: 

_Zendesk adapter_:
- Users will be notified when trying to deploy a macro with side conversation actions if the feature is disabled in the target account.
- Add account_features settings element

---
_User Notifications_: 

_Zendesk adapter_:
- Add account_features settings element
