### PR TITLE
SALTO-3412 Update Workato auth headers

### DIFF
--- a/packages/workato-adapter/src/auth.ts
+++ b/packages/workato-adapter/src/auth.ts
@@ -25,7 +25,12 @@ export type UsernameTokenCredentials = {
 export const usernameTokenCredentialsType = createMatchingObjectType<UsernameTokenCredentials>({
   elemID: new ElemID(constants.WORKATO),
   fields: {
-    username: { refType: BuiltinTypes.STRING },
+    username: {
+      refType: BuiltinTypes.STRING,
+      annotations: {
+        message: 'message (optional) - keep empty if using token-based authentication',
+      },
+    },
     token: {
       refType: BuiltinTypes.STRING,
       annotations: { _required: true },

--- a/packages/workato-adapter/src/auth.ts
+++ b/packages/workato-adapter/src/auth.ts
@@ -13,20 +13,24 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ElemID, ObjectType, BuiltinTypes } from '@salto-io/adapter-api'
+import { ElemID, BuiltinTypes } from '@salto-io/adapter-api'
+import { createMatchingObjectType } from '@salto-io/adapter-utils'
 import * as constants from './constants'
 
-export const usernameTokenCredentialsType = new ObjectType({
+export type UsernameTokenCredentials = {
+  username?: string
+  token: string
+}
+
+export const usernameTokenCredentialsType = createMatchingObjectType<UsernameTokenCredentials>({
   elemID: new ElemID(constants.WORKATO),
   fields: {
     username: { refType: BuiltinTypes.STRING },
-    token: { refType: BuiltinTypes.STRING },
+    token: {
+      refType: BuiltinTypes.STRING,
+      annotations: { _required: true },
+    },
   },
 })
-
-export type UsernameTokenCredentials = {
-  username: string
-  token: string
-}
 
 export type Credentials = UsernameTokenCredentials

--- a/packages/workato-adapter/src/client/connection.ts
+++ b/packages/workato-adapter/src/client/connection.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import _ from 'lodash'
 import { AccountId, CredentialError } from '@salto-io/adapter-api'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { Credentials } from '../auth'
@@ -38,10 +39,15 @@ export const validateCredentials = async ({ connection }: {
 export const createConnection: clientUtils.ConnectionCreator<Credentials> = retryOptions => (
   clientUtils.axiosConnection({
     retryOptions,
-    authParamsFunc: async ({ token }: Credentials) => ({
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
+    authParamsFunc: async ({ username, token }: Credentials) => ({
+      headers: _.isEmpty(username)
+        ? {
+          Authorization: `Bearer ${token}`,
+        }
+        : {
+          'x-user-email': username,
+          'x-user-token': token,
+        },
     }),
     baseURLFunc: () => BASE_URL,
     credValidateFunc: validateCredentials,

--- a/packages/workato-adapter/src/client/connection.ts
+++ b/packages/workato-adapter/src/client/connection.ts
@@ -38,10 +38,9 @@ export const validateCredentials = async ({ connection }: {
 export const createConnection: clientUtils.ConnectionCreator<Credentials> = retryOptions => (
   clientUtils.axiosConnection({
     retryOptions,
-    authParamsFunc: async ({ username, token }: Credentials) => ({
+    authParamsFunc: async ({ token }: Credentials) => ({
       headers: {
-        'x-user-email': username,
-        'x-user-token': token,
+        Authorization: `Bearer ${token}`,
       },
     }),
     baseURLFunc: () => BASE_URL,

--- a/packages/workato-adapter/test/adapter.test.ts
+++ b/packages/workato-adapter/test/adapter.test.ts
@@ -37,7 +37,7 @@ describe('adapter', () => {
   beforeEach(async () => {
     mockAxiosAdapter = new MockAdapter(axios, { delayResponse: 1, onNoMatch: 'throwException' })
     mockAxiosAdapter.onGet(
-      '/users/me', undefined, expect.objectContaining({ 'x-user-email': 'user123', 'x-user-token': 'token456' }),
+      '/users/me', undefined, expect.objectContaining({ Authorization: 'Bearer token456' }),
     ).reply(200, {
       id: 'user123',
     });

--- a/packages/workato-adapter/test/adapter.test.ts
+++ b/packages/workato-adapter/test/adapter.test.ts
@@ -59,7 +59,7 @@ describe('adapter', () => {
           credentials: new InstanceElement(
             'config',
             usernameTokenCredentialsType,
-            { username: 'user123', token: 'token456' },
+            { token: 'token456' },
           ),
           config: new InstanceElement(
             'config',
@@ -256,7 +256,7 @@ describe('adapter', () => {
           credentials: new InstanceElement(
             'config',
             usernameTokenCredentialsType,
-            { username: 'user123', token: 'token456' },
+            { token: 'token456' },
           ),
           config: new InstanceElement(
             'config',
@@ -304,7 +304,7 @@ describe('adapter', () => {
           credentials: new InstanceElement(
             'config',
             usernameTokenCredentialsType,
-            { username: 'user123', token: 'token456' },
+            { token: 'token456' },
           ),
           config: new InstanceElement(
             'config',
@@ -386,7 +386,7 @@ describe('adapter', () => {
           credentials: new InstanceElement(
             'config',
             usernameTokenCredentialsType,
-            { username: 'user123', token: 'token456' },
+            { token: 'token456' },
           ),
           config: new InstanceElement(
             'config',
@@ -442,7 +442,7 @@ describe('adapter', () => {
         credentials: new InstanceElement(
           'config',
           usernameTokenCredentialsType,
-          { username: 'user123', token: 'token456' },
+          { token: 'token456' },
         ),
         config: new InstanceElement(
           'config',

--- a/packages/workato-adapter/test/client/client.test.ts
+++ b/packages/workato-adapter/test/client/client.test.ts
@@ -23,7 +23,7 @@ describe('client', () => {
     let client: WorkatoClient
     beforeEach(() => {
       mockAxios = new MockAdapter(axios)
-      client = new WorkatoClient({ credentials: { username: 'dummy_user', token: 'dummy_token' } })
+      client = new WorkatoClient({ credentials: { token: 'dummy_token' } })
     })
 
     afterEach(() => {

--- a/packages/workato-adapter/test/client/connection.test.ts
+++ b/packages/workato-adapter/test/client/connection.test.ts
@@ -70,7 +70,7 @@ describe('client connection', () => {
       mockAxiosAdapter.restore()
     })
 
-    it('should make get requests with correct parameters', async () => {
+    it('should make get requests with correct parameters with token auth', async () => {
       const conn = createConnection({ retries: 3 })
       mockAxiosAdapter.onGet(
         '/users/me', undefined, expect.objectContaining({ Authorization: 'Bearer token123' }),
@@ -78,6 +78,27 @@ describe('client connection', () => {
         id: 'user123',
       }).onGet(
         '/a/b', undefined, expect.objectContaining({ Authorization: 'Bearer token123' }),
+      ).reply(200, {
+        something: 'bla',
+      })
+      const apiConn = await conn.login({ token: 'token123' })
+      expect(apiConn.accountId).toEqual('')
+      expect(mockAxiosAdapter.history.get.length).toBe(1)
+
+      const getRes = apiConn.get('/a/b')
+      const res = await getRes
+      expect(res.data).toEqual({ something: 'bla' })
+      expect(res.status).toEqual(200)
+      expect(mockAxiosAdapter.history.get.length).toBe(2)
+    })
+    it('should make get requests with correct parameters with legacy username + API key auth', async () => {
+      const conn = createConnection({ retries: 3 })
+      mockAxiosAdapter.onGet(
+        '/users/me', undefined, expect.objectContaining({ 'x-user-email': 'user123', 'x-user-token': 'token123' }),
+      ).reply(200, {
+        id: 'user123',
+      }).onGet(
+        '/a/b', undefined, expect.objectContaining({ 'x-user-email': 'user123', 'x-user-token': 'token123' }),
       ).reply(200, {
         something: 'bla',
       })

--- a/packages/workato-adapter/test/client/connection.test.ts
+++ b/packages/workato-adapter/test/client/connection.test.ts
@@ -73,11 +73,11 @@ describe('client connection', () => {
     it('should make get requests with correct parameters', async () => {
       const conn = createConnection({ retries: 3 })
       mockAxiosAdapter.onGet(
-        '/users/me', undefined, expect.objectContaining({ 'x-user-email': 'user123', 'x-user-token': 'token123' }),
+        '/users/me', undefined, expect.objectContaining({ Authorization: 'Bearer token123' }),
       ).reply(200, {
         id: 'user123',
       }).onGet(
-        '/a/b', undefined, expect.objectContaining({ 'x-user-email': 'user123', 'x-user-token': 'token123' }),
+        '/a/b', undefined, expect.objectContaining({ Authorization: 'Bearer token123' }),
       ).reply(200, {
         something: 'bla',
       })


### PR DESCRIPTION
Update Workato auth headers to the new format:
* API key was replaced by token (but we already called it token)
* Username is no longer needed (but still collecting it for now, until we finish the migration)
* Switching the auth headers from `x-user-email` and `x-user-token` to `Authorization: Bearer <token>`

Note that this will only take effect *when the username is not specified* - in order to allow for a migration period.

Will follow up with a separate documentation PR with auth instructions.

---

Note: Still needs to be tested after the migration happens tonight - but preparing a PR so we can bump this ASAP if it works as expected. 
Existing authentication API keys should remain usable in the new headers (but will confirm before merging)
See additional details in the ticket.


---
_Release Notes_: 
_Workato Adapter_:
* Update to support new API Client token-based authentication

---
_User Notifications_: 
None (no impact on existing users)