### PR TITLE
SALTO-3109 - Salesforce: validate account settings

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -77,6 +77,7 @@ import enumFieldPermissionsFilter from './filters/field_permissions_enum'
 import splitCustomLabels from './filters/split_custom_labels'
 import fetchFlowsFilter from './filters/fetch_flows'
 import customMetadataToObjectTypeFilter from './filters/custom_metadata_to_object_type'
+import organizationWideDefaults from './filters/organization_wide_sharing_defaults'
 import { FetchElements, SalesforceConfig } from './types'
 import { getConfigFromConfigChanges } from './config_change'
 import { LocalFilterCreator, Filter, FilterResult, RemoteFilterCreator, LocalFilterCreatorDefinition, RemoteFilterCreatorDefinition } from './filter'
@@ -163,6 +164,7 @@ export const allFilters: Array<LocalFilterCreatorDefinition | RemoteFilterCreato
   { creator: extraDependenciesFilter, addsNewInformation: true },
   { creator: customTypeSplit },
   { creator: profileInstanceSplitFilter },
+  { creator: organizationWideDefaults, addsNewInformation: true },
 ]
 
 // By default we run all filters and provide a client

--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -34,6 +34,7 @@ import invalidListViewFilterScope from './change_validators/invalid_listview_fil
 import caseAssignmentRulesValidator from './change_validators/case_assignmentRules'
 import unknownUser from './change_validators/unknown_users'
 import animationRuleRecordType from './change_validators/animation_rule_recordtype'
+import accountSettings from './change_validators/account_settings'
 import SalesforceClient from './client/client'
 
 import { ChangeValidatorName, SalesforceConfig } from './types'
@@ -72,6 +73,7 @@ export const changeValidators: Record<ChangeValidatorName, ChangeValidatorDefini
   omitData: { creator: omitDataValidator, defaultInDeploy: false, defaultInValidate: true },
   unknownUser: { creator: (_config, _isSandbox, client) => unknownUser(client), ...defaultAlwaysRun },
   animationRuleRecordType: { creator: () => animationRuleRecordType, ...defaultAlwaysRun },
+  accountSettings: { creator: (_config, _isSandbox, client) => accountSettings(client), ...defaultAlwaysRun },
 }
 
 const createSalesforceChangeValidator = ({ config, isSandbox, checkOnly, client }: {

--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -73,7 +73,7 @@ export const changeValidators: Record<ChangeValidatorName, ChangeValidatorDefini
   omitData: { creator: omitDataValidator, defaultInDeploy: false, defaultInValidate: true },
   unknownUser: { creator: (_config, _isSandbox, client) => unknownUser(client), ...defaultAlwaysRun },
   animationRuleRecordType: { creator: () => animationRuleRecordType, ...defaultAlwaysRun },
-  accountSettings: { creator: (_config, _isSandbox, client) => accountSettings(client), ...defaultAlwaysRun },
+  accountSettings: { creator: accountSettings, ...defaultAlwaysRun },
 }
 
 const createSalesforceChangeValidator = ({ config, isSandbox, checkOnly, client }: {

--- a/packages/salesforce-adapter/src/change_validators/account_settings.ts
+++ b/packages/salesforce-adapter/src/change_validators/account_settings.ts
@@ -1,0 +1,64 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { logger } from '@salto-io/logging'
+import { collections } from '@salto-io/lowerdash'
+import { ChangeError, ChangeValidator, getChangeData, InstanceElement, isAdditionOrModificationChange,
+  isInstanceElement } from '@salto-io/adapter-api'
+import { buildSelectQueries, isInstanceOfType, queryClient } from '../filters/utils'
+import { SalesforceRecord } from '../client/types'
+import SalesforceClient from '../client/client'
+
+const { awu } = collections.asynciterable
+const log = logger(module)
+
+const isRecordTypeInvalid = (globalSharingSettings: SalesforceRecord, instance: InstanceElement): boolean => (
+  globalSharingSettings.DefaultAccountAccess !== 'Read'
+  && instance.value.enableAccountOwnerReport !== undefined
+)
+
+const invalidRecordTypeError = (instance: InstanceElement): ChangeError => (
+  {
+    elemID: instance.elemID,
+    severity: 'Error',
+    message: 'You cannot set a value for AccountSettings.enableAccountOwnerReport unless your organization-wide sharing access level for Accounts is set to Private',
+    detailedMessage: `In ${instance.elemID.getFullName()}, enableAccountOwnerReport is set to '${instance.value.enableAccountOwnerReport}' but the organization-wide sharing access level for Accounts is not set to 'Private'.`,
+  }
+)
+
+const changeValidator = (client: SalesforceClient): ChangeValidator => async changes => {
+  const query = await buildSelectQueries('Organization', ['DefaultAccountAccess'])
+  const queryResult = await queryClient(client, query)
+
+  if (queryResult.length !== 1) {
+    log.error(`Expected a single Organization instance. Found ${queryResult ? queryResult.length : 0} instead`)
+    log.error('Unexpected Organization instances: %o', queryResult)
+    return []
+  }
+
+  const changedInstances = changes
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+    .filter(isInstanceElement)
+
+  return awu(changedInstances)
+    .filter(isInstanceOfType('AccountSettings'))
+    .filter(accountSettingsInstance => isRecordTypeInvalid(queryResult[0], accountSettingsInstance))
+    .map(invalidRecordTypeError)
+    .toArray()
+}
+
+export default changeValidator

--- a/packages/salesforce-adapter/src/change_validators/account_settings.ts
+++ b/packages/salesforce-adapter/src/change_validators/account_settings.ts
@@ -16,17 +16,18 @@
 
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
-import { ChangeError, ChangeValidator, getChangeData, InstanceElement, isAdditionOrModificationChange,
-  isInstanceElement } from '@salto-io/adapter-api'
-import { buildSelectQueries, isInstanceOfType, queryClient } from '../filters/utils'
-import { SalesforceRecord } from '../client/types'
-import SalesforceClient from '../client/client'
+import {
+  ChangeError, ChangeValidator, ElemID, getChangeData, InstanceElement, isAdditionOrModificationChange,
+  isInstanceElement,
+} from '@salto-io/adapter-api'
+import { isInstanceOfType } from '../filters/utils'
+import { SALESFORCE } from '../constants'
 
 const { awu } = collections.asynciterable
 const log = logger(module)
 
-const isRecordTypeInvalid = (globalSharingSettings: SalesforceRecord, instance: InstanceElement): boolean => (
-  globalSharingSettings.DefaultAccountAccess !== 'Read'
+const isRecordTypeInvalid = (globalSharingSettings: InstanceElement, instance: InstanceElement): boolean => (
+  globalSharingSettings.value.defaultAccountAccess !== 'Read'
   && instance.value.enableAccountOwnerReport !== undefined
 )
 
@@ -39,13 +40,15 @@ const invalidRecordTypeError = (instance: InstanceElement): ChangeError => (
   }
 )
 
-const changeValidator = (client: SalesforceClient): ChangeValidator => async changes => {
-  const query = await buildSelectQueries('Organization', ['DefaultAccountAccess'])
-  const queryResult = await queryClient(client, query)
+const changeValidator = (): ChangeValidator => async (changes, elementsSource) => {
+  if (elementsSource === undefined) {
+    log.error('Change validator did not receive an element source.')
+    return []
+  }
+  const orgWideSettings = await elementsSource.get(new ElemID(SALESFORCE, 'Organization', 'instance'))
 
-  if (queryResult.length !== 1) {
-    log.error(`Expected a single Organization instance. Found ${queryResult ? queryResult.length : 0} instead`)
-    log.error('Unexpected Organization instances: %o', queryResult)
+  if (orgWideSettings === undefined || !isInstanceElement(orgWideSettings)) {
+    log.error('Expected a single Organization instance. Found %o instead', orgWideSettings)
     return []
   }
 
@@ -56,7 +59,7 @@ const changeValidator = (client: SalesforceClient): ChangeValidator => async cha
 
   return awu(changedInstances)
     .filter(isInstanceOfType('AccountSettings'))
-    .filter(accountSettingsInstance => isRecordTypeInvalid(queryResult[0], accountSettingsInstance))
+    .filter(accountSettingsInstance => isRecordTypeInvalid(orgWideSettings, accountSettingsInstance))
     .map(invalidRecordTypeError)
     .toArray()
 }

--- a/packages/salesforce-adapter/src/filters/organization_wide_sharing_defaults.ts
+++ b/packages/salesforce-adapter/src/filters/organization_wide_sharing_defaults.ts
@@ -65,7 +65,7 @@ const ORGANIZATION_OBJECT_TYPE = new ObjectType({
 const filterCreator: RemoteFilterCreator = ({ client }) => ({
   onFetch: async elements => {
     const queryResult = await queryClient(client, ['SELECT FIELDS(ALL) FROM Organization LIMIT 200'])
-    if (queryResult.length > 1) {
+    if (queryResult.length !== 1) {
       log.warn(`Expected Organization object to be a singleton. Got ${queryResult.length} elements`)
       return
     }

--- a/packages/salesforce-adapter/src/filters/organization_wide_sharing_defaults.ts
+++ b/packages/salesforce-adapter/src/filters/organization_wide_sharing_defaults.ts
@@ -14,53 +14,14 @@
 * limitations under the License.
 */
 
-import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, ObjectType } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { RemoteFilterCreator } from '../filter'
 import { queryClient } from './utils'
-import { createInstanceElement, getTypePath } from '../transformers/transformer'
-import { SALESFORCE } from '../constants'
+import { createInstanceElement } from '../transformers/transformer'
+import { ORGANIZATION_OBJECT_TYPE } from '../transformers/salesforce_types'
 
 const log = logger(module)
-
-const ORGANIZATION_OBJECT_TYPE = new ObjectType({
-  elemID: new ElemID(SALESFORCE, 'Organization'),
-  fields: {
-    fullName: {
-      refType: BuiltinTypes.STRING,
-    },
-    DefaultAccountAccess: {
-      refType: BuiltinTypes.STRING,
-    },
-    DefaultCalendarAccess: {
-      refType: BuiltinTypes.STRING,
-    },
-    DefaultCampaignAccess: {
-      refType: BuiltinTypes.STRING,
-    },
-    DefaultCaseAccess: {
-      refType: BuiltinTypes.STRING,
-    },
-    DefaultContactAccess: {
-      refType: BuiltinTypes.STRING,
-    },
-    DefaultLeadAccess: {
-      refType: BuiltinTypes.STRING,
-    },
-    DefaultOpportunityAccess: {
-      refType: BuiltinTypes.STRING,
-    },
-    DefaultPricebookAccess: {
-      refType: BuiltinTypes.STRING,
-    },
-  },
-  annotations: {
-    // [CORE_ANNOTATIONS.HIDDEN]: true,
-    [CORE_ANNOTATIONS.UPDATABLE]: false,
-  },
-  isSettings: true,
-  path: getTypePath('Organization'),
-})
 
 const filterCreator: RemoteFilterCreator = ({ client }) => ({
   onFetch: async elements => {

--- a/packages/salesforce-adapter/src/filters/organization_wide_sharing_defaults.ts
+++ b/packages/salesforce-adapter/src/filters/organization_wide_sharing_defaults.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2022 Salto Labs Ltd.
+*                      Copyright 2023 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with
@@ -18,14 +18,17 @@ import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, ObjectType } from '@salto-io/ad
 import { logger } from '@salto-io/logging'
 import { RemoteFilterCreator } from '../filter'
 import { queryClient } from './utils'
-import { createInstanceElement } from '../transformers/transformer'
-import { SALESFORCE, TYPES_PATH } from '../constants'
+import { createInstanceElement, getTypePath } from '../transformers/transformer'
+import { SALESFORCE } from '../constants'
 
 const log = logger(module)
 
 const ORGANIZATION_OBJECT_TYPE = new ObjectType({
   elemID: new ElemID(SALESFORCE, 'Organization'),
   fields: {
+    fullName: {
+      refType: BuiltinTypes.STRING,
+    },
     DefaultAccountAccess: {
       refType: BuiltinTypes.STRING,
     },
@@ -56,7 +59,7 @@ const ORGANIZATION_OBJECT_TYPE = new ObjectType({
     [CORE_ANNOTATIONS.UPDATABLE]: false,
   },
   isSettings: true,
-  path: [SALESFORCE, TYPES_PATH, 'Organization'],
+  path: getTypePath('Organization'),
 })
 
 const filterCreator: RemoteFilterCreator = ({ client }) => ({
@@ -71,7 +74,7 @@ const filterCreator: RemoteFilterCreator = ({ client }) => ({
       .filter(([key]) => (Object.keys(ORGANIZATION_OBJECT_TYPE.fields).includes(key)))
     const organizationInstance = createInstanceElement(
       {
-        fullName: new ElemID(SALESFORCE, 'Organization', 'instance', organizationObject.Name).getFullName(),
+        fullName: 'Organization', // Note: Query results don't have a fullName field
         ...Object.fromEntries(relevantFields),
       },
       ORGANIZATION_OBJECT_TYPE,

--- a/packages/salesforce-adapter/src/filters/organization_wide_sharing_defaults.ts
+++ b/packages/salesforce-adapter/src/filters/organization_wide_sharing_defaults.ts
@@ -1,0 +1,89 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, ObjectType } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { RemoteFilterCreator } from '../filter'
+import { queryClient } from './utils'
+import { createInstanceElement } from '../transformers/transformer'
+import { SALESFORCE, TYPES_PATH } from '../constants'
+
+const log = logger(module)
+
+const ORGANIZATION_OBJECT_TYPE = new ObjectType({
+  elemID: new ElemID(SALESFORCE, 'Organization'),
+  fields: {
+    DefaultAccountAccess: {
+      refType: BuiltinTypes.STRING,
+    },
+    DefaultCalendarAccess: {
+      refType: BuiltinTypes.STRING,
+    },
+    DefaultCampaignAccess: {
+      refType: BuiltinTypes.STRING,
+    },
+    DefaultCaseAccess: {
+      refType: BuiltinTypes.STRING,
+    },
+    DefaultContactAccess: {
+      refType: BuiltinTypes.STRING,
+    },
+    DefaultLeadAccess: {
+      refType: BuiltinTypes.STRING,
+    },
+    DefaultOpportunityAccess: {
+      refType: BuiltinTypes.STRING,
+    },
+    DefaultPricebookAccess: {
+      refType: BuiltinTypes.STRING,
+    },
+  },
+  annotations: {
+    // [CORE_ANNOTATIONS.HIDDEN]: true,
+    [CORE_ANNOTATIONS.UPDATABLE]: false,
+  },
+  isSettings: true,
+  path: [SALESFORCE, TYPES_PATH, 'Organization'],
+})
+
+const filterCreator: RemoteFilterCreator = ({ client }) => ({
+  onFetch: async elements => {
+    const queryResult = await queryClient(client, ['SELECT FIELDS(ALL) FROM Organization LIMIT 200'])
+    if (queryResult.length > 1) {
+      log.warn(`Expected Organization object to be a singleton. Got ${queryResult.length} elements`)
+      return
+    }
+    const organizationObject = queryResult[0]
+    const relevantFields = Object.entries(organizationObject)
+      .filter(([key]) => (Object.keys(ORGANIZATION_OBJECT_TYPE.fields).includes(key)))
+    const organizationInstance = createInstanceElement(
+      {
+        fullName: new ElemID(SALESFORCE, 'Organization', 'instance', organizationObject.Name).getFullName(),
+        ...Object.fromEntries(relevantFields),
+      },
+      ORGANIZATION_OBJECT_TYPE,
+      undefined,
+      {
+        // [CORE_ANNOTATIONS.HIDDEN]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: false,
+        // [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,
+      }
+    )
+    elements.push(ORGANIZATION_OBJECT_TYPE, organizationInstance)
+  },
+})
+
+export default filterCreator

--- a/packages/salesforce-adapter/src/transformers/salesforce_types.ts
+++ b/packages/salesforce-adapter/src/transformers/salesforce_types.ts
@@ -197,3 +197,42 @@ export const allMissingSubTypes = [
   lightningComponentBundleSupportedFormFactorsType,
   lightningComponentBundleSupportedFormFactorType,
 ]
+
+export const ORGANIZATION_OBJECT_TYPE = new ObjectType({
+  elemID: new ElemID(SALESFORCE, 'Organization'),
+  fields: {
+    fullName: {
+      refType: BuiltinTypes.STRING,
+    },
+    DefaultAccountAccess: {
+      refType: BuiltinTypes.STRING,
+    },
+    DefaultCalendarAccess: {
+      refType: BuiltinTypes.STRING,
+    },
+    DefaultCampaignAccess: {
+      refType: BuiltinTypes.STRING,
+    },
+    DefaultCaseAccess: {
+      refType: BuiltinTypes.STRING,
+    },
+    DefaultContactAccess: {
+      refType: BuiltinTypes.STRING,
+    },
+    DefaultLeadAccess: {
+      refType: BuiltinTypes.STRING,
+    },
+    DefaultOpportunityAccess: {
+      refType: BuiltinTypes.STRING,
+    },
+    DefaultPricebookAccess: {
+      refType: BuiltinTypes.STRING,
+    },
+  },
+  annotations: {
+    // [CORE_ANNOTATIONS.HIDDEN]: true,
+    [CORE_ANNOTATIONS.UPDATABLE]: false,
+  },
+  isSettings: true,
+  path: [...subTypesPath, 'Organization'],
+})

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -98,6 +98,7 @@ export type ChangeValidatorName = (
   | 'omitData'
   | 'unknownUser'
   | 'animationRuleRecordType'
+  | 'accountSettings'
 )
 
 export type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
@@ -587,6 +588,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     omitData: { refType: BuiltinTypes.BOOLEAN },
     unknownUser: { refType: BuiltinTypes.BOOLEAN },
     animationRuleRecordType: { refType: BuiltinTypes.BOOLEAN },
+    accountSettings: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/salesforce-adapter/test/change_validators/account_settings.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/account_settings.test.ts
@@ -1,0 +1,84 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { toChange } from '@salto-io/adapter-api'
+import * as filterUtilsModule from '../../src/filters/utils'
+import { CUSTOM_OBJECT_ID_FIELD } from '../../src/constants'
+import { mockTypes } from '../mock_elements'
+import { createInstanceElement } from '../../src/transformers/transformer'
+import changeValidatorCreator from '../../src/change_validators/account_settings'
+import mockAdapter from '../adapter'
+
+jest.mock('../../src/filters/utils', () => ({
+  ...jest.requireActual('../../src/filters/utils'),
+  queryClient: jest.fn(),
+}))
+
+const mockedFilterUtils = jest.mocked(filterUtilsModule)
+
+const setMockQueryResult = (defaultAccountAccess: string): void => {
+  mockedFilterUtils.queryClient.mockResolvedValue([{
+    [CUSTOM_OBJECT_ID_FIELD]: 'SomeId',
+    DefaultAccountAccess: defaultAccountAccess,
+  }])
+}
+
+describe('Account settings validator', () => {
+  const instanceBefore = createInstanceElement({ fullName: 'whatever' }, mockTypes.AccountSettings)
+  const { client } = mockAdapter({})
+  const changeValidator = changeValidatorCreator(client)
+
+  describe('When the global setting is \'Private\'', () => {
+    beforeEach(() => {
+      setMockQueryResult('Read')
+    })
+
+    it('Should pass validation if enableAccountOwnerReport exists', async () => {
+      const instanceAfter = instanceBefore.clone()
+      instanceAfter.value.enableAccountOwnerReport = true
+      const change = toChange({ before: instanceBefore, after: instanceAfter })
+      const errors = await changeValidator([change])
+      expect(errors).toBeEmpty()
+    })
+    it('Should pass validation if enableAccountOwnerReport does not exist', async () => {
+      const instanceAfter = instanceBefore.clone()
+      const change = toChange({ before: instanceBefore, after: instanceAfter })
+      const errors = await changeValidator([change])
+      expect(errors).toBeEmpty()
+    })
+  })
+
+  describe('When the global setting is not \'Private\'', () => {
+    beforeEach(() => {
+      setMockQueryResult('Edit')
+    })
+
+    it('Should fail validation if enableAccountOwnerReport exists', async () => {
+      const instanceAfter = instanceBefore.clone()
+      instanceAfter.value.enableAccountOwnerReport = true
+      const change = toChange({ before: instanceBefore, after: instanceAfter })
+      const errors = await changeValidator([change])
+      expect(errors).toHaveLength(1)
+      expect(errors).toIncludeAllPartialMembers([{ elemID: instanceBefore.elemID }])
+    })
+    it('Should pass validation if enableAccountOwnerReport does not exist', async () => {
+      const instanceAfter = instanceBefore.clone()
+      const change = toChange({ before: instanceBefore, after: instanceAfter })
+      const errors = await changeValidator([change])
+      expect(errors).toBeEmpty()
+    })
+  })
+})

--- a/packages/salesforce-adapter/test/change_validators/account_settings.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/account_settings.test.ts
@@ -14,70 +14,61 @@
 * limitations under the License.
 */
 
-import { toChange } from '@salto-io/adapter-api'
-import * as filterUtilsModule from '../../src/filters/utils'
-import { CUSTOM_OBJECT_ID_FIELD } from '../../src/constants'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { ElemID, ReadOnlyElementsSource, toChange } from '@salto-io/adapter-api'
+import { SALESFORCE } from '../../src/constants'
 import { mockTypes } from '../mock_elements'
 import { createInstanceElement } from '../../src/transformers/transformer'
 import changeValidatorCreator from '../../src/change_validators/account_settings'
-import mockAdapter from '../adapter'
+import { ORGANIZATION_OBJECT_TYPE } from '../../src/transformers/salesforce_types'
 
-jest.mock('../../src/filters/utils', () => ({
-  ...jest.requireActual('../../src/filters/utils'),
-  queryClient: jest.fn(),
-}))
-
-const mockedFilterUtils = jest.mocked(filterUtilsModule)
-
-const setMockQueryResult = (defaultAccountAccess: string): void => {
-  mockedFilterUtils.queryClient.mockResolvedValue([{
-    [CUSTOM_OBJECT_ID_FIELD]: 'SomeId',
-    DefaultAccountAccess: defaultAccountAccess,
-  }])
+const mockElementsSource = (defaultAccountAccess: string): ReadOnlyElementsSource => {
+  const element = createInstanceElement(
+    {
+      fullName: new ElemID(SALESFORCE, 'Organization', 'instance').getFullName(),
+      defaultAccountAccess,
+    },
+    ORGANIZATION_OBJECT_TYPE
+  )
+  return buildElementsSourceFromElements([element])
 }
 
 describe('Account settings validator', () => {
   const instanceBefore = createInstanceElement({ fullName: 'whatever' }, mockTypes.AccountSettings)
-  const { client } = mockAdapter({})
-  const changeValidator = changeValidatorCreator(client)
+  const changeValidator = changeValidatorCreator()
 
   describe('When the global setting is \'Private\'', () => {
-    beforeEach(() => {
-      setMockQueryResult('Read')
-    })
-
+    const elementsSource = mockElementsSource('Read')
     it('Should pass validation if enableAccountOwnerReport exists', async () => {
       const instanceAfter = instanceBefore.clone()
       instanceAfter.value.enableAccountOwnerReport = true
       const change = toChange({ before: instanceBefore, after: instanceAfter })
-      const errors = await changeValidator([change])
+      const errors = await changeValidator([change], elementsSource)
       expect(errors).toBeEmpty()
     })
     it('Should pass validation if enableAccountOwnerReport does not exist', async () => {
       const instanceAfter = instanceBefore.clone()
       const change = toChange({ before: instanceBefore, after: instanceAfter })
-      const errors = await changeValidator([change])
+      const errors = await changeValidator([change], elementsSource)
       expect(errors).toBeEmpty()
     })
   })
 
   describe('When the global setting is not \'Private\'', () => {
-    beforeEach(() => {
-      setMockQueryResult('Edit')
-    })
+    const elementsSource = mockElementsSource('Edit')
 
     it('Should fail validation if enableAccountOwnerReport exists', async () => {
       const instanceAfter = instanceBefore.clone()
       instanceAfter.value.enableAccountOwnerReport = true
       const change = toChange({ before: instanceBefore, after: instanceAfter })
-      const errors = await changeValidator([change])
+      const errors = await changeValidator([change], elementsSource)
       expect(errors).toHaveLength(1)
       expect(errors).toIncludeAllPartialMembers([{ elemID: instanceBefore.elemID }])
     })
     it('Should pass validation if enableAccountOwnerReport does not exist', async () => {
       const instanceAfter = instanceBefore.clone()
       const change = toChange({ before: instanceBefore, after: instanceAfter })
-      const errors = await changeValidator([change])
+      const errors = await changeValidator([change], elementsSource)
       expect(errors).toBeEmpty()
     })
   })

--- a/packages/salesforce-adapter/test/filters/organization_wide_sharing_defaults.test.ts
+++ b/packages/salesforce-adapter/test/filters/organization_wide_sharing_defaults.test.ts
@@ -1,0 +1,68 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { Element, ElemID } from '@salto-io/adapter-api'
+import filterCreator from '../../src/filters/organization_wide_sharing_defaults'
+import { FilterWith } from '../../src/filter'
+import mockAdapter from '../adapter'
+import { defaultFilterContext } from '../utils'
+import * as filterUtilsModule from '../../src/filters/utils'
+import { CUSTOM_OBJECT_ID_FIELD, SALESFORCE } from '../../src/constants'
+
+jest.mock('../../src/filters/utils', () => ({
+  ...jest.requireActual('../../src/filters/utils'),
+  queryClient: jest.fn(),
+}))
+
+const mockedFilterUtils = jest.mocked(filterUtilsModule)
+
+const setupClientMock = (): void => {
+  mockedFilterUtils.queryClient.mockResolvedValue([{
+    [CUSTOM_OBJECT_ID_FIELD]: 'SomeId',
+    DefaultAccountAccess: 'Edit',
+    DefaultContactAccess: 'ControlledByParent',
+    DefaultOpportunityAccess: 'None',
+    DefaultLeadAccess: 'ReadEditTransfer',
+    DefaultCaseAccess: 'None',
+    DefaultCalendarAccess: 'HideDetailsInsert',
+    DefaultPricebookAccess: 'ReadSelect',
+    DefaultCampaignAccess: 'All',
+  }])
+}
+describe('When fetching organization-wide defaults', () => {
+  let filter: FilterWith<'onFetch'>
+
+  beforeAll(() => {
+    filter = filterCreator({
+      config: { ...defaultFilterContext },
+      client: mockAdapter({}).client,
+    }) as typeof filter
+  })
+
+  beforeEach(() => {
+    setupClientMock()
+  })
+
+  it('should fetch them', async () => {
+    const elements: Element[] = []
+    await filter.onFetch(elements)
+    expect(elements).toHaveLength(2)
+    expect(elements).toIncludeAllPartialMembers([
+      { elemID: new ElemID(SALESFORCE, 'Organization') },
+      { elemID: new ElemID(SALESFORCE, 'Organization', 'instance', '_config') },
+    ])
+  })
+})

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -361,6 +361,18 @@ export const mockTypes = {
       },
     }
   ),
+  AccountSettings: new ObjectType({
+    elemID: new ElemID(SALESFORCE, 'AccountSettings'),
+    fields: {
+      enableAccountOwnerReport: {
+        refType: BuiltinTypes.BOOLEAN,
+      },
+    },
+    annotations: {
+      metadataType: 'AccountSettings',
+    },
+    isSettings: true,
+  }),
 }
 
 export const lwcJsResourceContent = "import { LightningElement } from 'lwc';\nexport default class BikeCard extends LightningElement {\n   name = 'Electra X4';\n   description = 'A sweet bike built for comfort.';\n   category = 'Mountain';\n   material = 'Steel';\n   price = '$2,700';\n   pictureUrl = 'https://s3-us-west-1.amazonaws.com/sfdc-demo/ebikes/electrax4.jpg';\n }"


### PR DESCRIPTION
Add a change validator for `AccountSettings.enableAccountOwnerReport`. This field may only exist if the global account sharing policy is 'Private'

---

The actual value of the global account sharing setting is 'Read', 'Edit', etc. It is never actually set to 'Private' in the API data, but rather translated to other values (including 'Private') in the Salesforce UI.

---
_Release Notes_: 
Salesforce: Improved pre-deploy validation of account settings.

---
_User Notifications_: 
N/A
