### PR TITLE
SALTO-3407 calculate detailedChanges on plan creation

### DIFF
--- a/packages/adapter-api/src/change.ts
+++ b/packages/adapter-api/src/change.ts
@@ -96,6 +96,10 @@ export type DetailedChange<T = ChangeDataType | Values | Value> =
     path?: ReadonlyArray<string>
   }
 
+export type ChangeWithDetails = Change & {
+  detailedChanges: DetailedChange[]
+}
+
 export type ChangeParams<T> = { before?: T; after?: T }
 
 type ChangeParamType<T> = T extends ChangeParams<infer U> ? U : never

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -494,6 +494,14 @@ const toPlanItem = (
   action: parent.action,
   changes: () => [parent, ...subChanges],
   detailedChanges: () => detailed,
+  changesWithDetails: () => {
+    const changes = [parent, ...subChanges]
+    const detailedChangesByChange = _.groupBy(detailed, change => change.id.createBaseID().parent.getFullName())
+    return changes.map(change => ({
+      ...change,
+      detailedChanges: () => detailedChangesByChange[getChangeData(change).elemID.getFullName()],
+    }))
+  },
 })
 
 const createChange = (action: 'add' | 'modify' | 'remove', ...path: string[]): Change => {

--- a/packages/core/src/core/plan/plan_item.ts
+++ b/packages/core/src/core/plan/plan_item.ts
@@ -20,14 +20,14 @@ import { Change, getChangeData, DetailedChange, CompareOptions } from '@salto-io
 import { detailedCompare } from '@salto-io/adapter-utils'
 
 export type PlanItemId = NodeId
-type ChangeWithDetailedChanges = Change & {
+export type ChangeWithDetails = Change & {
   detailedChanges: () => DetailedChange[]
 }
 export type PlanItem = Group<Change> & {
   action: ActionName
   changes: () => Iterable<Change>
   detailedChanges: () => Iterable<DetailedChange>
-  changesWithDetailed: () => Iterable<ChangeWithDetailedChanges>
+  changesWithDetails: () => Iterable<ChangeWithDetails>
 }
 
 const getGroupAction = (group: Group<Change>): ActionName => {
@@ -68,7 +68,7 @@ export const addPlanItemAccessors = (
       .map(change => getDetailedChanges(change, compareOptions))
       .flatten()
   },
-  changesWithDetailed() {
+  changesWithDetails() {
     return wu(group.items.values())
       .map(change => ({
         ...change,

--- a/packages/core/test/common/plan.ts
+++ b/packages/core/test/common/plan.ts
@@ -15,21 +15,22 @@
 */
 import wu from 'wu'
 import {
-  Change, ObjectType, isObjectType, ElemID, getChangeData,
+  Change, ObjectType, isObjectType, ElemID, getChangeData, ChangeWithDetails,
 } from '@salto-io/adapter-api'
 import { Group, DAG } from '@salto-io/dag'
 import { Plan, PlanItem, PlanItemId } from '../../src/core/plan'
 import { addPlanItemAccessors } from '../../src/core/plan/plan_item'
+import { toDetailedChanges } from '../../src/core/plan/plan'
 import { getAllElements } from './elements'
 
 export const createPlan = (changeGroups: Change[][]): Plan => {
-  const toGroup = (changes: Change[]): Group<Change> => ({
+  const toGroup = (changes: Change[]): Group<ChangeWithDetails> => ({
     groupKey: changes.length > 0
       ? getChangeData(changes[0]).elemID.createTopLevelParentID().parent.getFullName()
       : '',
-    items: new Map(changes.map((change, idx) => [`${idx}`, change])),
+    items: new Map(changes.map((change, idx) => [`${idx}`, { ...change, detailedChanges: toDetailedChanges(change) }])),
   })
-  const graph = new DAG<Group<Change>>(
+  const graph = new DAG<Group<ChangeWithDetails>>(
     changeGroups.map((_changes, idx) => [`${idx}`, new Set()]),
     new Map(changeGroups.map((changes, idx) => [`${idx}`, toGroup(changes)])),
   )

--- a/packages/core/test/core/plan/plan_item.test.ts
+++ b/packages/core/test/core/plan/plan_item.test.ts
@@ -167,4 +167,106 @@ describe('PlanItem', () => {
       expect(isListType(await _.get(fromListChange.data, 'after').getType())).toBeFalsy()
     })
   })
+
+  describe('changesWithDetailed method', () => {
+    it('should break field modification to specific value changes', async () => {
+      const [plan, newElement] = await planWithTypeChanges()
+      const planItem = getFirstPlanItem(plan)
+      const changes = [...planItem.changesWithDetailed()]
+      expect(changes).toHaveLength(1)
+      const detailedChanges = changes[0].detailedChanges()
+      expect(detailedChanges).toHaveLength(2)
+
+      expect(detailedChanges[0].id).toEqual(newElement.elemID.createNestedID('attr', 'label'))
+      expect(detailedChanges[0].action).toEqual('add')
+      expect(_.get(detailedChanges[0].data, 'after')).toEqual(newElement.annotations.label)
+
+      expect(detailedChanges[1].id).toEqual(newElement.elemID.createNestedID('attr', 'new'))
+      expect(detailedChanges[1].action).toEqual('add')
+      expect(_.get(detailedChanges[1].data, 'after')).toEqual(newElement.annotations.new)
+    })
+    it('should return field changes with the correct id', async () => {
+      const [plan, newElement] = await planWithFieldChanges()
+      const planItem = getFirstPlanItem(plan)
+      const changes = [...planItem.changesWithDetailed()]
+      expect(changes).toHaveLength(2)
+
+      const detailedChanges1 = changes[0].detailedChanges()
+      expect(detailedChanges1).toHaveLength(1)
+      expect(detailedChanges1[0].id).toEqual(newElement.fields.new.elemID)
+      expect(detailedChanges1[0].action).toEqual('add')
+
+      const detailedChanges2 = changes[1].detailedChanges()
+      expect(detailedChanges2).toHaveLength(1)
+      expect(detailedChanges2[0].id).toEqual(newElement.fields.location.elemID.createNestedID('label'))
+      expect(detailedChanges2[0].action).toEqual('modify')
+      expect(_.get(detailedChanges2[0].data, 'after')).toEqual(newElement.fields.location.annotations.label)
+    })
+    it('should return add / remove changes at the appropriate level', async () => {
+      const [plan, newElement] = await planWithNewType()
+      const planItem = getFirstPlanItem(plan)
+      const changes = [...planItem.changesWithDetailed()]
+      expect(changes).toHaveLength(1)
+      const detailedChanges = changes[0].detailedChanges()
+      expect(detailedChanges).toHaveLength(1)
+      expect(detailedChanges[0].id).toEqual(newElement.elemID)
+    })
+    it('should return deep nested changes', async () => {
+      const [plan, updatedInst] = await planWithInstanceChange()
+      const planItem = getFirstPlanItem(plan)
+      const changes = [...planItem.changesWithDetailed()]
+      expect(changes).toHaveLength(1)
+      const detailedChanges = changes[0].detailedChanges()
+      expect(detailedChanges).toHaveLength(2)
+      const [listChange, nameRemove] = detailedChanges
+      expect(listChange.action).toEqual('modify')
+      expect(listChange.id).toEqual(updatedInst.elemID.createNestedID('nicknames', '1'))
+      expect(nameRemove.action).toEqual('remove')
+      expect(nameRemove.id).toEqual(updatedInst.elemID.createNestedID('office', 'name'))
+    })
+    it('should return list modification when a value is added', async () => {
+      const [plan, updatedInst] = await planWithListChange()
+      const planItem = getFirstPlanItem(plan)
+      const changes = [...planItem.changesWithDetailed()]
+      expect(changes).toHaveLength(1)
+      const detailedChanges = changes[0].detailedChanges()
+      expect(detailedChanges).toHaveLength(1)
+      const [listChange] = detailedChanges
+      expect(listChange.action).toEqual('modify')
+      expect(listChange.id).toEqual(updatedInst.elemID.createNestedID('nicknames'))
+    })
+
+    it('should return list of annotationType changes in case of annotationType change', async () => {
+      const [plan, obj] = await planWithAnnotationTypesChanges()
+      const planItem = getFirstPlanItem(plan)
+      const changes = [...planItem.changesWithDetailed()]
+      expect(changes).toHaveLength(1)
+      const detailedChanges = changes[0].detailedChanges()
+      expect(detailedChanges).toHaveLength(1)
+      const [annoChange] = detailedChanges
+      expect(annoChange.action).toEqual('add')
+      expect(annoChange.id).toEqual(obj.elemID.createNestedID('annotation', 'new'))
+    })
+
+    it('should return is list value modification when a field is changed to list', async () => {
+      const [plan, changedElem] = await planWithFieldIsListChanges()
+      const planItem = getFirstPlanItem(plan)
+      const changes = [...planItem.changesWithDetailed()]
+      expect(changes).toHaveLength(2)
+
+      const detailedChanges1 = changes[0].detailedChanges()
+      expect(detailedChanges1).toHaveLength(1)
+      const [toListChange] = detailedChanges1
+      expect(toListChange.action).toEqual('modify')
+      expect(toListChange.id).toEqual(changedElem.fields.name.elemID)
+      expect(isListType(await _.get(toListChange.data, 'after').getType())).toBeTruthy()
+
+      const detailedChanges2 = changes[1].detailedChanges()
+      expect(detailedChanges2).toHaveLength(1)
+      const [fromListChange] = detailedChanges2
+      expect(fromListChange.action).toEqual('modify')
+      expect(fromListChange.id).toEqual(changedElem.fields.rooms.elemID)
+      expect(isListType(await _.get(fromListChange.data, 'after').getType())).toBeFalsy()
+    })
+  })
 })

--- a/packages/core/test/core/plan/plan_item.test.ts
+++ b/packages/core/test/core/plan/plan_item.test.ts
@@ -172,7 +172,7 @@ describe('PlanItem', () => {
     it('should break field modification to specific value changes', async () => {
       const [plan, newElement] = await planWithTypeChanges()
       const planItem = getFirstPlanItem(plan)
-      const changes = [...planItem.changesWithDetailed()]
+      const changes = [...planItem.changesWithDetails()]
       expect(changes).toHaveLength(1)
       const detailedChanges = changes[0].detailedChanges()
       expect(detailedChanges).toHaveLength(2)
@@ -188,7 +188,7 @@ describe('PlanItem', () => {
     it('should return field changes with the correct id', async () => {
       const [plan, newElement] = await planWithFieldChanges()
       const planItem = getFirstPlanItem(plan)
-      const changes = [...planItem.changesWithDetailed()]
+      const changes = [...planItem.changesWithDetails()]
       expect(changes).toHaveLength(2)
 
       const detailedChanges1 = changes[0].detailedChanges()
@@ -205,7 +205,7 @@ describe('PlanItem', () => {
     it('should return add / remove changes at the appropriate level', async () => {
       const [plan, newElement] = await planWithNewType()
       const planItem = getFirstPlanItem(plan)
-      const changes = [...planItem.changesWithDetailed()]
+      const changes = [...planItem.changesWithDetails()]
       expect(changes).toHaveLength(1)
       const detailedChanges = changes[0].detailedChanges()
       expect(detailedChanges).toHaveLength(1)
@@ -214,7 +214,7 @@ describe('PlanItem', () => {
     it('should return deep nested changes', async () => {
       const [plan, updatedInst] = await planWithInstanceChange()
       const planItem = getFirstPlanItem(plan)
-      const changes = [...planItem.changesWithDetailed()]
+      const changes = [...planItem.changesWithDetails()]
       expect(changes).toHaveLength(1)
       const detailedChanges = changes[0].detailedChanges()
       expect(detailedChanges).toHaveLength(2)
@@ -227,7 +227,7 @@ describe('PlanItem', () => {
     it('should return list modification when a value is added', async () => {
       const [plan, updatedInst] = await planWithListChange()
       const planItem = getFirstPlanItem(plan)
-      const changes = [...planItem.changesWithDetailed()]
+      const changes = [...planItem.changesWithDetails()]
       expect(changes).toHaveLength(1)
       const detailedChanges = changes[0].detailedChanges()
       expect(detailedChanges).toHaveLength(1)
@@ -239,7 +239,7 @@ describe('PlanItem', () => {
     it('should return list of annotationType changes in case of annotationType change', async () => {
       const [plan, obj] = await planWithAnnotationTypesChanges()
       const planItem = getFirstPlanItem(plan)
-      const changes = [...planItem.changesWithDetailed()]
+      const changes = [...planItem.changesWithDetails()]
       expect(changes).toHaveLength(1)
       const detailedChanges = changes[0].detailedChanges()
       expect(detailedChanges).toHaveLength(1)
@@ -251,7 +251,7 @@ describe('PlanItem', () => {
     it('should return is list value modification when a field is changed to list', async () => {
       const [plan, changedElem] = await planWithFieldIsListChanges()
       const planItem = getFirstPlanItem(plan)
-      const changes = [...planItem.changesWithDetailed()]
+      const changes = [...planItem.changesWithDetails()]
       expect(changes).toHaveLength(2)
 
       const detailedChanges1 = changes[0].detailedChanges()


### PR DESCRIPTION

---

_Additional context for reviewer_

---
_Release Notes_: 
Core:
- Calculate `detailedChanges` on plan creation, so they are calculated once and not every time they are used.
- Change `Plan` to extend `GroupDAG<ChangeWithDetails>` so the `detailedChanges` are accessible through the `changes()` method of a `PlanItem`.

---
_User Notifications_: 
None