### PR TITLE
SALTO-2406 CLI help message for salto service command use short help message

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,7 +46,7 @@
     "@salto-io/salesforce-adapter": "0.3.29",
     "@salto-io/workspace": "0.3.29",
     "chalk": "^2.4.2",
-    "commander": "^6.2.1",
+    "commander": "^10.0.0",
     "express": "^4.17.1",
     "figlet": "^1.2.4",
     "glob": "^7.1.6",

--- a/packages/cli/src/command_builder.ts
+++ b/packages/cli/src/command_builder.ts
@@ -31,7 +31,10 @@ const VERBOSE_LOG_LEVEL: LogLevel = 'debug'
 
 type BasicCommandProperties = {
   name: string
+  // full description shown when running -h on command
   description: string
+  // short description shown when running -h on parent command (if needed)
+  summary?: string
 }
 
 export type CommandOptions<T> = BasicCommandProperties & {
@@ -161,7 +164,7 @@ const validateCommandOptionDefinitions = <T>(
 
 export const createPublicCommandDef = <T>(def: CommandInnerDef<T>): CommandDef<T> => {
   const {
-    properties: { name, description, keyedOptions = [], positionalOptions = [] },
+    properties: { name, description, summary, keyedOptions = [], positionalOptions = [] },
     action,
   } = def
   const commanderAction: CommandAction = async ({
@@ -200,7 +203,7 @@ export const createPublicCommandDef = <T>(def: CommandInnerDef<T>): CommandDef<T
 
   // Add verbose to all commands
   const properties = {
-    ...{ name, description, positionalOptions },
+    ...{ name, description, summary, positionalOptions },
     keyedOptions: [
       ...keyedOptions,
       VERBOSE_OPTION as KeyedOption<T>,

--- a/packages/cli/src/command_register.ts
+++ b/packages/cli/src/command_register.ts
@@ -99,14 +99,16 @@ const registerCommand = <T>(
   cliArgs: CliArgs,
 ): void => {
   const {
-    properties: { name, description, keyedOptions = [], positionalOptions = [] },
+    properties: { name, description, summary, keyedOptions = [], positionalOptions = [] },
     action,
   } = commandDef
   const command = new commander.Command()
     .command(`${name} ${positionalOptionsStr(positionalOptions)}`)
     .exitOverride()
   command.description(description)
-  if (description.includes('\n')) {
+  if (summary) {
+    command.summary(summary)
+  } else if (description.includes('\n')) {
     command.summary(description.split('\n')[0])
   }
   positionalOptions.forEach(positionalOption =>

--- a/packages/cli/src/command_register.ts
+++ b/packages/cli/src/command_register.ts
@@ -106,6 +106,9 @@ const registerCommand = <T>(
     .command(`${name} ${positionalOptionsStr(positionalOptions)}`)
     .exitOverride()
   command.description(description)
+  if (description.includes('\n')) {
+    command.summary(description.split('\n')[0])
+  }
   positionalOptions.forEach(positionalOption =>
     // Positional options are added as non-required Options because for positional options
     // requireness derives from <> or [] in the command and not option definition

--- a/packages/cli/src/command_register.ts
+++ b/packages/cli/src/command_register.ts
@@ -28,8 +28,8 @@ export const VERSION_CODE = 'commander.version'
 export const createProgramCommand = (): commander.Command => (
   new commander.Command('salto')
     .version(`${versionString}\n`)
-    .passCommandToAction(false)
     .exitOverride()
+    .showHelpAfterError('See \'salto --help\'.')
 )
 
 const wrapWithRequired = (innerStr: string): string =>
@@ -103,7 +103,6 @@ const registerCommand = <T>(
     action,
   } = commandDef
   const command = new commander.Command()
-    .passCommandToAction(false)
     .command(`${name} ${positionalOptionsStr(positionalOptions)}`)
     .exitOverride()
   command.description(description)

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -26,6 +26,7 @@ describe('cli as a whole', () => {
   jest.spyOn(logger, 'end').mockResolvedValue(undefined)
   const consoleErrorSpy = jest.spyOn(console, 'error')
   const stdout = jest.spyOn(process.stdout, 'write')
+  const stderr = jest.spyOn(process.stderr, 'write')
 
   describe('when called with --help', () => {
     beforeEach(async () => {
@@ -60,12 +61,13 @@ describe('cli as a whole', () => {
   describe('when called with an invalid command', () => {
     beforeEach(async () => {
       consoleErrorSpy.mockClear()
+      stderr.mockClear()
       o = await mocks.cli({ args: ['nosuchcommand'] })
     })
 
     it('outputs an error message to stderr', () => {
-      expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringMatching(/unknown command 'nosuchcommand'/))
-      expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringMatching(/--help/))
+      expect(stderr).toHaveBeenCalledWith(expect.stringMatching(/unknown command 'nosuchcommand'/))
+      expect(stderr).toHaveBeenCalledWith(expect.stringMatching(/--help/))
     })
 
     it('exits with code 1', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5161,12 +5161,17 @@ commander@9.4.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.0.tgz#bc4a40918fefe52e22450c111ecd6b7acce6f11c"
   integrity sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==
 
+commander@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.0.tgz#71797971162cd3cf65f0b9d24eb28f8d303acdf1"
+  integrity sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==
+
 commander@^2.11.0, commander@^2.19.0, commander@^2.20.0, commander@^2.7.1, commander@^2.9.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@^6.1.0, commander@^6.2.0, commander@^6.2.1:
+commander@^6.1.0, commander@^6.2.0:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==


### PR DESCRIPTION
Multi-line descriptions of commands are automatically shortened when showing help on parent command. 

---

Updated commander package 6.2.1->10.0.0 and added a `summary` field to be used for a shorter explanation whenever required. 

---
_Release Notes_: 
CLI:
* cleaner help view when subcommand has multi-line description
---
_User Notifications_: _None_