### PR TITLE
SALTO-3421: Jira DC component deployment fails

### DIFF
--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -825,6 +825,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
         { fieldName: 'issueCount', fieldType: 'number' },
         { fieldName: 'leadAccountId', fieldType: 'string' },
         { fieldName: 'componentBean', fieldType: 'ProjectComponent' },
+        { fieldName: 'deleted', fieldType: 'boolean' },
       ],
       fieldsToHide: [
         { fieldName: 'id' },
@@ -838,6 +839,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
         { fieldName: 'realAssigneeType' },
         { fieldName: 'assignee' },
         { fieldName: 'componentBean' },
+        { fieldName: 'deleted' },
       ],
     },
     deployRequests: {


### PR DESCRIPTION
_Removed the `deleted` field, it appears only on DC9 and not cleared why it is there_

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
