### PR TITLE
SALTO-3416: add a DC option to account_id validator  - Jira DC

### DIFF
--- a/packages/jira-adapter/src/change_validators/account_id.ts
+++ b/packages/jira-adapter/src/change_validators/account_id.ts
@@ -110,6 +110,7 @@ const checkAndAddChangeErrors = (
     }))
     return
   }
+  // in DC we don't save User's displayName
   if (isDataCenter) {
     return
   }

--- a/packages/jira-adapter/src/change_validators/account_id.ts
+++ b/packages/jira-adapter/src/change_validators/account_id.ts
@@ -85,7 +85,8 @@ Go to ${url} to see valid users and account IDs.`,
 const checkAndAddChangeErrors = (
   idMap: IdMap,
   baseUrl: string,
-  changeErrors: ChangeError[]
+  changeErrors: ChangeError[],
+  isDataCenter: boolean
 ): WalkOnUsersCallback => (
   { value, path, fieldName }
 ): void => {
@@ -107,7 +108,12 @@ const checkAndAddChangeErrors = (
       baseUrl,
       accountId,
     }))
-  } else if (currentDisplayName === undefined) {
+    return
+  }
+  if (isDataCenter) {
+    return
+  }
+  if (currentDisplayName === undefined) {
     changeErrors.push(noDisplayNameChangeError(path.createNestedID(fieldName)))
   } else if (realDisplayName !== currentDisplayName) {
     changeErrors.push(displayNameMismatchChangeError(
@@ -123,11 +129,12 @@ const checkAndAddChangeErrors = (
 const createChangeErrorsForAccountIdIssues = (
   element: InstanceElement,
   idMap: IdMap,
-  baseUrl : string
+  baseUrl : string,
+  isDataCenter: boolean
 ): ChangeError[] => {
   const changeErrors: ChangeError[] = []
   walkOnElement({ element,
-    func: walkOnUsers(checkAndAddChangeErrors(idMap, baseUrl, changeErrors)) })
+    func: walkOnUsers(checkAndAddChangeErrors(idMap, baseUrl, changeErrors, isDataCenter)) })
   return changeErrors
 }
 
@@ -141,13 +148,13 @@ export const accountIdValidator: (
 ) =>
   ChangeValidator = (client, config, getIdMapFunc) => async changes =>
     log.time(async () => {
-      if (!(config.fetch.convertUsersIds ?? true)
-        // Temporary until we support it in DC
-        || client.isDataCenter) {
+      if (!(config.fetch.convertUsersIds ?? true)) {
         return []
       }
-      const idMap = await getIdMapFunc()
-      const { baseUrl } = client
+      const { baseUrl, isDataCenter } = client
+      const idMap = isDataCenter
+        ? Object.fromEntries(Object.entries(await getIdMapFunc()).map(([key, mapValue]) => [mapValue, key]))
+        : await getIdMapFunc()
       return changes
         .filter(isAdditionOrModificationChange)
         .filter(isInstanceChange)
@@ -155,7 +162,7 @@ export const accountIdValidator: (
         .filter(isDeployableAccountIdType)
         .map(
           element => createChangeErrorsForAccountIdIssues(
-            element, idMap, baseUrl
+            element, idMap, baseUrl, isDataCenter
           )
         )
         .flat()


### PR DESCRIPTION
_Add a DC option to account_id validator_

---

_Additional context for reviewer_
fix a bug in account_id validator that did not catch that the accountId was invalid while using Jira DC

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
