### PR TITLE
SALTO-3440 - Salesforce: validate FolderShare.sharedTo user

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/unknown_users.ts
+++ b/packages/salesforce-adapter/src/change_validators/unknown_users.ts
@@ -40,6 +40,7 @@ type UserFieldGetter = {
 // https://stackoverflow.com/a/44154193
 const TYPES_WITH_USER_FIELDS = [
   'CaseSettings',
+  'FolderShare',
 ] as const
 type TypeWithUserFields = typeof TYPES_WITH_USER_FIELDS[number]
 
@@ -73,6 +74,18 @@ const userFieldValue = (expectedFieldName: string): GetUserField => (
   }
 )
 
+const getFolderShareUser = (instance: InstanceElement, fieldName: string): string | undefined => {
+  if (fieldName !== 'sharedTo') {
+    log.error(`Unexpected field name: ${fieldName}.`)
+    return undefined
+  }
+  if (instance.value.sharedToType !== 'User') {
+    log.debug('sharedToType is not User. Skipping.')
+    return undefined
+  }
+  return instance.value.sharedTo
+}
+
 const USER_GETTERS: TypesWithUserFields = {
   CaseSettings: [
     {
@@ -82,6 +95,12 @@ const USER_GETTERS: TypesWithUserFields = {
     {
       field: 'defaultCaseOwner',
       getter: (instance, fieldName) => getCaseSettingsOwner(instance, fieldName),
+    },
+  ],
+  FolderShare: [
+    {
+      field: 'sharedTo',
+      getter: getFolderShareUser,
     },
   ],
 }

--- a/packages/salesforce-adapter/test/change_validators/unknown_users.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/unknown_users.test.ts
@@ -88,6 +88,47 @@ describe('unknown user change validator', () => {
       expect(changeErrors).toBeEmpty()
     })
   })
+  describe('when the username is in a FolderShare instance', () => {
+    let change: Change
+
+    describe('when the username exists', () => {
+      beforeEach(() => {
+        const beforeRecord = createInstanceElement({
+          fullName: 'someName',
+          sharedTo: IRRELEVANT_USERNAME,
+          sharedToType: 'User',
+        }, mockTypes.FolderShare)
+        const afterRecord = beforeRecord.clone()
+        afterRecord.value.sharedTo = TEST_USERNAME
+        change = toChange({ before: beforeRecord, after: afterRecord })
+
+        setupClientMock([TEST_USERNAME])
+      })
+
+      it('should pass validation', async () => {
+        const changeErrors = await validator([change])
+        expect(changeErrors).toBeEmpty()
+      })
+    })
+    describe('when the username doesn\'t exist but sharedToType is not \'User\'', () => {
+      beforeEach(() => {
+        const beforeRecord = createInstanceElement({
+          fullName: 'someName',
+          sharedTo: IRRELEVANT_USERNAME,
+          sharedToType: 'Role',
+        }, mockTypes.FolderShare)
+        const afterRecord = beforeRecord.clone()
+        afterRecord.value.sharedTo = TEST_USERNAME
+        change = toChange({ before: beforeRecord, after: afterRecord })
+
+        setupClientMock([])
+      })
+      it('should pass validation', async () => {
+        const changeErrors = await validator([change])
+        expect(changeErrors).toBeEmpty()
+      })
+    })
+  })
   describe('when a username does not exist in Salesforce', () => {
     let change: Change
     beforeEach(() => {

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -361,6 +361,19 @@ export const mockTypes = {
       },
     }
   ),
+  FolderShare: createCustomObjectType(
+    'FolderShare',
+    {
+      fields: {
+        sharedTo: {
+          refType: BuiltinTypes.STRING,
+        },
+        sharedToType: {
+          refType: BuiltinTypes.STRING,
+        },
+      },
+    }
+  ),
 }
 
 export const lwcJsResourceContent = "import { LightningElement } from 'lwc';\nexport default class BikeCard extends LightningElement {\n   name = 'Electra X4';\n   description = 'A sweet bike built for comfort.';\n   category = 'Mountain';\n   material = 'Steel';\n   price = '$2,700';\n   pictureUrl = 'https://s3-us-west-1.amazonaws.com/sfdc-demo/ebikes/electrax4.jpg';\n }"


### PR DESCRIPTION
Use the existing infrastructure to ensure that if FolderShare.sharedTo represents a user, that use exists in the target env.

---

N/A

---
_Release Notes_: 
Salesforce: Improved validation of FolderShare instances

---
_User Notifications_: 
N/A
