### PR TITLE
SALTO-3109 - Salesforce: Fetch org wide sharing defaults

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -77,6 +77,7 @@ import enumFieldPermissionsFilter from './filters/field_permissions_enum'
 import splitCustomLabels from './filters/split_custom_labels'
 import fetchFlowsFilter from './filters/fetch_flows'
 import customMetadataToObjectTypeFilter from './filters/custom_metadata_to_object_type'
+import organizationWideDefaults from './filters/organization_wide_sharing_defaults'
 import { FetchElements, SalesforceConfig } from './types'
 import { getConfigFromConfigChanges } from './config_change'
 import { LocalFilterCreator, Filter, FilterResult, RemoteFilterCreator, LocalFilterCreatorDefinition, RemoteFilterCreatorDefinition } from './filter'
@@ -163,6 +164,7 @@ export const allFilters: Array<LocalFilterCreatorDefinition | RemoteFilterCreato
   { creator: extraDependenciesFilter, addsNewInformation: true },
   { creator: customTypeSplit },
   { creator: profileInstanceSplitFilter },
+  { creator: organizationWideDefaults, addsNewInformation: true },
 ]
 
 // By default we run all filters and provide a client

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -105,6 +105,7 @@ export const allFilters: Array<LocalFilterCreatorDefinition | RemoteFilterCreato
   { creator: customMetadataToObjectTypeFilter },
   // customObjectsFilter depends on missingFieldsFilter and settingsFilter
   { creator: customObjectsFromDescribeFilter, addsNewInformation: true },
+  { creator: organizationWideDefaults, addsNewInformation: true },
   // customSettingsFilter depends on customObjectsFilter
   { creator: customSettingsFilter, addsNewInformation: true },
   { creator: customObjectsToObjectTypeFilter },
@@ -164,7 +165,6 @@ export const allFilters: Array<LocalFilterCreatorDefinition | RemoteFilterCreato
   { creator: extraDependenciesFilter, addsNewInformation: true },
   { creator: customTypeSplit },
   { creator: profileInstanceSplitFilter },
-  { creator: organizationWideDefaults, addsNewInformation: true },
 ]
 
 // By default we run all filters and provide a client

--- a/packages/salesforce-adapter/src/filters/organization_wide_sharing_defaults.ts
+++ b/packages/salesforce-adapter/src/filters/organization_wide_sharing_defaults.ts
@@ -25,10 +25,6 @@ import SalesforceClient from '../client/client'
 
 const log = logger(module)
 
-const filterValues = <T>(obj: Record<string, T>, fn: (value: T) => boolean): Record<string, T> => (
-  Object.fromEntries(Object.entries(obj).filter(([key, value]) => [key, fn(value)]))
-)
-
 
 const enrichTypeWithFields = async (client: SalesforceClient, type: ObjectType): Promise<void> => {
   const apiName = type.elemID.typeName // TODO
@@ -78,7 +74,7 @@ const createOrganizationType = (): ObjectType => (
 const filterCreator: RemoteFilterCreator = ({ client }) => ({
   onFetch: async elements => {
     const filterNulls = (obj: Values): void => {
-      filterValues(obj, value => value !== null)
+      _.pickBy(obj, value => value !== null)
       _.mapValues(obj, value => (_.isPlainObject(value) ? filterNulls(value) : value))
     }
 

--- a/packages/salesforce-adapter/src/filters/organization_wide_sharing_defaults.ts
+++ b/packages/salesforce-adapter/src/filters/organization_wide_sharing_defaults.ts
@@ -65,7 +65,7 @@ const ORGANIZATION_OBJECT_TYPE = new ObjectType({
 const filterCreator: RemoteFilterCreator = ({ client }) => ({
   onFetch: async elements => {
     const queryResult = await queryClient(client, ['SELECT FIELDS(ALL) FROM Organization LIMIT 200'])
-    if (queryResult.length > 1) {
+    if (queryResult.length !== 1) {
       log.warn(`Expected Organization object to be a singleton. Got ${queryResult.length} elements`)
       return
     }

--- a/packages/salesforce-adapter/src/filters/organization_wide_sharing_defaults.ts
+++ b/packages/salesforce-adapter/src/filters/organization_wide_sharing_defaults.ts
@@ -15,7 +15,7 @@
 */
 
 import _ from 'lodash'
-import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, ObjectType, Values } from '@salto-io/adapter-api'
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, ObjectType } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { RemoteFilterCreator } from '../filter'
 import { queryClient } from './utils'
@@ -73,11 +73,6 @@ const createOrganizationType = (): ObjectType => (
 
 const filterCreator: RemoteFilterCreator = ({ client }) => ({
   onFetch: async elements => {
-    const filterNulls = (obj: Values): Values => (
-      _.mapValues(_.pickBy(obj, value => value !== null),
-        value => (_.isPlainObject(value) ? filterNulls(value) : value))
-    )
-
     const objectType = createOrganizationType()
     await enrichTypeWithFields(client, objectType)
 
@@ -87,7 +82,7 @@ const filterCreator: RemoteFilterCreator = ({ client }) => ({
       return
     }
 
-    const organizationObject = filterNulls(_.mapKeys(queryResult[0], (_value, key) => _.camelCase(key)))
+    const organizationObject = _.mapKeys(queryResult[0], (_value, key) => _.camelCase(key))
 
     const organizationInstance = createInstanceElement(
       {

--- a/packages/salesforce-adapter/src/filters/organization_wide_sharing_defaults.ts
+++ b/packages/salesforce-adapter/src/filters/organization_wide_sharing_defaults.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2022 Salto Labs Ltd.
+*                      Copyright 2023 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with
@@ -18,14 +18,17 @@ import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, ObjectType } from '@salto-io/ad
 import { logger } from '@salto-io/logging'
 import { RemoteFilterCreator } from '../filter'
 import { queryClient } from './utils'
-import { createInstanceElement } from '../transformers/transformer'
-import { SALESFORCE, TYPES_PATH } from '../constants'
+import { createInstanceElement, getTypePath } from '../transformers/transformer'
+import { SALESFORCE } from '../constants'
 
 const log = logger(module)
 
 const ORGANIZATION_OBJECT_TYPE = new ObjectType({
   elemID: new ElemID(SALESFORCE, 'Organization'),
   fields: {
+    fullName: {
+      refType: BuiltinTypes.STRING,
+    },
     DefaultAccountAccess: {
       refType: BuiltinTypes.STRING,
     },
@@ -56,7 +59,7 @@ const ORGANIZATION_OBJECT_TYPE = new ObjectType({
     [CORE_ANNOTATIONS.UPDATABLE]: false,
   },
   isSettings: true,
-  path: [SALESFORCE, TYPES_PATH, 'Organization'],
+  path: getTypePath('Organization'),
 })
 
 const filterCreator: RemoteFilterCreator = ({ client }) => ({
@@ -71,7 +74,7 @@ const filterCreator: RemoteFilterCreator = ({ client }) => ({
       .filter(([key]) => (Object.keys(ORGANIZATION_OBJECT_TYPE.fields).includes(key)))
     const organizationInstance = createInstanceElement(
       {
-        fullName: new ElemID(SALESFORCE, 'Organization', 'instance', organizationObject.Name).getFullName(),
+        fullName: 'Organization', // Note: Query results don't have a fullName field
         ...Object.fromEntries(relevantFields),
       },
       ORGANIZATION_OBJECT_TYPE,

--- a/packages/salesforce-adapter/src/filters/organization_wide_sharing_defaults.ts
+++ b/packages/salesforce-adapter/src/filters/organization_wide_sharing_defaults.ts
@@ -73,10 +73,10 @@ const createOrganizationType = (): ObjectType => (
 
 const filterCreator: RemoteFilterCreator = ({ client }) => ({
   onFetch: async elements => {
-    const filterNulls = (obj: Values): void => {
-      _.pickBy(obj, value => value !== null)
-      _.mapValues(obj, value => (_.isPlainObject(value) ? filterNulls(value) : value))
-    }
+    const filterNulls = (obj: Values): Values => (
+      _.mapValues(_.pickBy(obj, value => value !== null),
+        value => (_.isPlainObject(value) ? filterNulls(value) : value))
+    )
 
     const objectType = createOrganizationType()
     await enrichTypeWithFields(client, objectType)
@@ -87,8 +87,7 @@ const filterCreator: RemoteFilterCreator = ({ client }) => ({
       return
     }
 
-    const organizationObject = _.mapKeys(queryResult[0], (_value, key) => _.camelCase(key))
-    filterNulls(organizationObject)
+    const organizationObject = filterNulls(_.mapKeys(queryResult[0], (_value, key) => _.camelCase(key)))
 
     const organizationInstance = createInstanceElement(
       {

--- a/packages/salesforce-adapter/src/filters/organization_wide_sharing_defaults.ts
+++ b/packages/salesforce-adapter/src/filters/organization_wide_sharing_defaults.ts
@@ -1,0 +1,89 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, ObjectType } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { RemoteFilterCreator } from '../filter'
+import { queryClient } from './utils'
+import { createInstanceElement } from '../transformers/transformer'
+import { SALESFORCE, TYPES_PATH } from '../constants'
+
+const log = logger(module)
+
+const ORGANIZATION_OBJECT_TYPE = new ObjectType({
+  elemID: new ElemID(SALESFORCE, 'Organization'),
+  fields: {
+    DefaultAccountAccess: {
+      refType: BuiltinTypes.STRING,
+    },
+    DefaultCalendarAccess: {
+      refType: BuiltinTypes.STRING,
+    },
+    DefaultCampaignAccess: {
+      refType: BuiltinTypes.STRING,
+    },
+    DefaultCaseAccess: {
+      refType: BuiltinTypes.STRING,
+    },
+    DefaultContactAccess: {
+      refType: BuiltinTypes.STRING,
+    },
+    DefaultLeadAccess: {
+      refType: BuiltinTypes.STRING,
+    },
+    DefaultOpportunityAccess: {
+      refType: BuiltinTypes.STRING,
+    },
+    DefaultPricebookAccess: {
+      refType: BuiltinTypes.STRING,
+    },
+  },
+  annotations: {
+    // [CORE_ANNOTATIONS.HIDDEN]: true,
+    [CORE_ANNOTATIONS.UPDATABLE]: false,
+  },
+  isSettings: true,
+  path: [SALESFORCE, TYPES_PATH, 'Organization'],
+})
+
+const filterCreator: RemoteFilterCreator = ({ client }) => ({
+  onFetch: async elements => {
+    const queryResult = await queryClient(client, ['SELECT FIELDS(ALL) FROM Organization LIMIT 200'])
+    if (queryResult.length > 1) {
+      log.warn(`Expected Organization object to be a singleton. Got ${queryResult.length} elements`)
+      return
+    }
+    const organizationObject = queryResult[0]
+    const relevantFields = Object.entries(organizationObject)
+      .filter(([key]) => (Object.keys(ORGANIZATION_OBJECT_TYPE.fields).includes(key)))
+    const organizationInstance = createInstanceElement(
+      {
+        fullName: new ElemID(SALESFORCE, 'Organization', 'instance', organizationObject.Name).getFullName(),
+        ...Object.fromEntries(relevantFields),
+      },
+      ORGANIZATION_OBJECT_TYPE,
+      undefined,
+      {
+        // [CORE_ANNOTATIONS.HIDDEN]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: false,
+        // [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,
+      }
+    )
+    elements.push(ORGANIZATION_OBJECT_TYPE, organizationInstance)
+  },
+})
+
+export default filterCreator

--- a/packages/salesforce-adapter/test/filters/organization_wide_sharing_defaults.test.ts
+++ b/packages/salesforce-adapter/test/filters/organization_wide_sharing_defaults.test.ts
@@ -1,0 +1,68 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { Element, ElemID } from '@salto-io/adapter-api'
+import filterCreator from '../../src/filters/organization_wide_sharing_defaults'
+import { FilterWith } from '../../src/filter'
+import mockAdapter from '../adapter'
+import { defaultFilterContext } from '../utils'
+import * as filterUtilsModule from '../../src/filters/utils'
+import { CUSTOM_OBJECT_ID_FIELD, SALESFORCE } from '../../src/constants'
+
+jest.mock('../../src/filters/utils', () => ({
+  ...jest.requireActual('../../src/filters/utils'),
+  queryClient: jest.fn(),
+}))
+
+const mockedFilterUtils = jest.mocked(filterUtilsModule)
+
+const setupClientMock = (): void => {
+  mockedFilterUtils.queryClient.mockResolvedValue([{
+    [CUSTOM_OBJECT_ID_FIELD]: 'SomeId',
+    DefaultAccountAccess: 'Edit',
+    DefaultContactAccess: 'ControlledByParent',
+    DefaultOpportunityAccess: 'None',
+    DefaultLeadAccess: 'ReadEditTransfer',
+    DefaultCaseAccess: 'None',
+    DefaultCalendarAccess: 'HideDetailsInsert',
+    DefaultPricebookAccess: 'ReadSelect',
+    DefaultCampaignAccess: 'All',
+  }])
+}
+describe('When fetching organization-wide defaults', () => {
+  let filter: FilterWith<'onFetch'>
+
+  beforeAll(() => {
+    filter = filterCreator({
+      config: { ...defaultFilterContext },
+      client: mockAdapter({}).client,
+    }) as typeof filter
+  })
+
+  beforeEach(() => {
+    setupClientMock()
+  })
+
+  it('should fetch them', async () => {
+    const elements: Element[] = []
+    await filter.onFetch(elements)
+    expect(elements).toHaveLength(2)
+    expect(elements).toIncludeAllPartialMembers([
+      { elemID: new ElemID(SALESFORCE, 'Organization') },
+      { elemID: new ElemID(SALESFORCE, 'Organization', 'instance', '_config') },
+    ])
+  })
+})

--- a/packages/salesforce-adapter/test/filters/organization_wide_sharing_defaults.test.ts
+++ b/packages/salesforce-adapter/test/filters/organization_wide_sharing_defaults.test.ts
@@ -129,6 +129,8 @@ describe('When fetching organization-wide defaults', () => {
       DefaultCalendarAccess: 'HideDetailsInsert',
       DefaultPricebookAccess: 'ReadSelect',
       DefaultCampaignAccess: 'All',
+      SomeIrrelevantField: 'SomeIrrelevantValue',
+      FieldWithNullValue: null,
     }])
     setDescribeSObjectsReturnValue([
       'defaultAccountAccess',
@@ -138,7 +140,6 @@ describe('When fetching organization-wide defaults', () => {
       'defaultContactAccess',
       'defaultLeadAccess',
       'defaultOpportunityAccess',
-      'fullName',
     ])
   })
 
@@ -160,7 +161,7 @@ describe('When fetching organization-wide defaults', () => {
           defaultContactAccess: 'ControlledByParent',
           defaultLeadAccess: 'ReadEditTransfer',
           defaultOpportunityAccess: 'None',
-          fullName: 'Organization',
+          fullName: 'OrganizationSettings',
         },
       },
     ])

--- a/packages/salesforce-adapter/test/filters/organization_wide_sharing_defaults.test.ts
+++ b/packages/salesforce-adapter/test/filters/organization_wide_sharing_defaults.test.ts
@@ -130,7 +130,6 @@ describe('When fetching organization-wide defaults', () => {
       DefaultPricebookAccess: 'ReadSelect',
       DefaultCampaignAccess: 'All',
       SomeIrrelevantField: 'SomeIrrelevantValue',
-      FieldWithNullValue: null,
     }])
     setDescribeSObjectsReturnValue([
       'defaultAccountAccess',


### PR DESCRIPTION
Fetch the organization-wide default sharing settings as a hidden instance.

---

_Additional context for reviewer_
https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_objects_organization.htm
We need this information in order to implement a change validator as described in the ticket.

---
_Release Notes_: 
N/A

---
_User Notifications_: 
N/A
