### PR TITLE
Salto-2861: Add edit permissions to Jira cloud's filters

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/cloud/filter.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/filter.ts
@@ -40,4 +40,17 @@ export const createFilterValues = (name: string, allElements: Element[]): Values
         name: createReference(new ElemID(JIRA, GROUP_TYPE_NAME, 'instance', 'site_admins@b'), allElements),
       } },
   ],
+  editPermissions: [
+    {
+      type: 'user',
+      user: {
+        displayName: 'Automation for Jira',
+        active: true,
+        accountId: {
+          id: '557058:f58131cb-b67d-43c7-b30d-6b58d40bd077',
+          displayName: 'Automation for Jira',
+        },
+      },
+    },
+  ],
 })

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -443,7 +443,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
     request: {
       url: '/rest/api/3/filter/search',
       queryParams: {
-        expand: 'description,owner,jql,sharePermissions',
+        expand: 'description,owner,jql,sharePermissions,editPermissions',
       },
       paginationField: 'startAt',
       recurseInto: [


### PR DESCRIPTION
_Also add E2E_

---

_tested with all different permission options. Does not impact the cloud. User filter is working properly_

---
_Release Notes_: 
**Jira Adapter:**
- Added edit permissions to filters

---
_User Notifications_: 
_Jira: Edit permissions will be added to Jira's NaCls (when available)_
