### PR TITLE
SALTO-3278: Jira Group Security Level and Scheme on delete

### DIFF
--- a/packages/jira-adapter/src/filters/security_scheme/security_scheme.ts
+++ b/packages/jira-adapter/src/filters/security_scheme/security_scheme.ts
@@ -18,6 +18,7 @@ import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { objects } from '@salto-io/lowerdash'
 import { getParents } from '@salto-io/adapter-utils'
+import { client as clientUtils } from '@salto-io/adapter-components'
 import { findObject, getFilledJspUrls, setFieldDeploymentAnnotations, setTypeDeploymentAnnotations } from '../../utils'
 import { FilterCreator } from '../../filter'
 import { deployWithJspEndpoints } from '../../deployment/jsp_deployment'
@@ -238,11 +239,22 @@ const filter: FilterCreator = ({ client, config }) => ({
         deployLevels: (levelsChanges: Change<InstanceElement>[]) => deployChanges(
           levelsChanges as Change<InstanceElement>[],
           async change => {
-            await defaultDeployChange({
-              change,
-              client,
-              apiDefinitions: config.apiDefinitions,
-            })
+            try {
+              await defaultDeployChange({
+                change,
+                client,
+                apiDefinitions: config.apiDefinitions,
+              })
+            } catch (err) {
+              if (err instanceof clientUtils.HTTPError
+                && err.response.status === 404
+                && isRemovalChange(change)) {
+                // if delete fails on 404 it can be considered a success
+                log.debug(`Received 404 error ${err.message} for ${getChangeData(change).elemID.getFullName()}. The element is already removed`)
+                return
+              }
+              throw err
+            }
           }
         ),
       }

--- a/packages/jira-adapter/test/filters/security_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/security_scheme.test.ts
@@ -748,5 +748,24 @@ describe('securitySchemeFilter', () => {
       expect(appliedChanges.length).toEqual(0)
       expect(leftoverChanges.length).toEqual(0)
     })
+    it('Should not throw when delete request fail and the instance is already deleted', async () => {
+      connection.delete.mockRejectedValueOnce(new clientUtils.HTTPError('message', {
+        status: 404,
+        data: {},
+      }))
+      const { deployResult: { errors, appliedChanges } } = await filter.deploy(
+        [toChange({ before: securityLevelInstance })]
+      )
+      expect(errors).toHaveLength(0)
+      expect(appliedChanges).toHaveLength(1)
+    })
+    it('Should throw when the request fail with 500', async () => {
+      connection.delete.mockRejectedValueOnce(new Error('Name already exists'))
+      const { deployResult: { errors, appliedChanges } } = await filter.deploy(
+        [toChange({ before: securityLevelInstance })]
+      )
+      expect(errors).toHaveLength(1)
+      expect(appliedChanges).toHaveLength(0)
+    })
   })
 })


### PR DESCRIPTION
_were not grouped on delete. In the cloud the API is tolerant to a level delete that does not exist_


---
_Release Notes_: 
None

---
_User Notifications_: 
None