### PR TITLE
SALTO-2828: No errors are displayed upon deployment that fails on UNKNOWN_EXCEPTION from Salesforce

### DIFF
--- a/packages/salesforce-adapter/src/client/jsforce.ts
+++ b/packages/salesforce-adapter/src/client/jsforce.ts
@@ -112,18 +112,10 @@ export interface CodeCoverageWarning {
   namespace?: string
 }
 
-export interface genericErrorMessage {
-  id: string
-  message: string
-  name?: string
-  namespace?: string
-}
-
 export interface RunTestsResult {
   apexLogId?: string
   codeCoverage?: ArrayOrSingle<object> // CodeCoverageResult[]
   codeCoverageWarnings?: ArrayOrSingle<CodeCoverageWarning>
-  errorMessage?: ArrayOrSingle<genericErrorMessage>
   failures?: ArrayOrSingle<RunTestFailure>
   flowCoverage?: ArrayOrSingle<object> // FlowCoverageResult[]
   flowCoverageWarnings?: ArrayOrSingle<object> // FlowCoverageWarning[]

--- a/packages/salesforce-adapter/src/client/jsforce.ts
+++ b/packages/salesforce-adapter/src/client/jsforce.ts
@@ -112,10 +112,15 @@ export interface CodeCoverageWarning {
   namespace?: string
 }
 
+export interface genericErrorMessage {
+  message: string
+}
+
 export interface RunTestsResult {
   apexLogId?: string
   codeCoverage?: ArrayOrSingle<object> // CodeCoverageResult[]
   codeCoverageWarnings?: ArrayOrSingle<CodeCoverageWarning>
+  errorMessage: ArrayOrSingle<genericErrorMessage>
   failures?: ArrayOrSingle<RunTestFailure>
   flowCoverage?: ArrayOrSingle<object> // FlowCoverageResult[]
   flowCoverageWarnings?: ArrayOrSingle<object> // FlowCoverageWarning[]

--- a/packages/salesforce-adapter/src/client/jsforce.ts
+++ b/packages/salesforce-adapter/src/client/jsforce.ts
@@ -113,14 +113,17 @@ export interface CodeCoverageWarning {
 }
 
 export interface genericErrorMessage {
+  id: string
   message: string
+  name?: string
+  namespace?: string
 }
 
 export interface RunTestsResult {
   apexLogId?: string
   codeCoverage?: ArrayOrSingle<object> // CodeCoverageResult[]
   codeCoverageWarnings?: ArrayOrSingle<CodeCoverageWarning>
-  errorMessage: ArrayOrSingle<genericErrorMessage>
+  errorMessage?: ArrayOrSingle<genericErrorMessage>
   failures?: ArrayOrSingle<RunTestFailure>
   flowCoverage?: ArrayOrSingle<object> // FlowCoverageResult[]
   flowCoverageWarnings?: ArrayOrSingle<object> // FlowCoverageWarning[]

--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -39,6 +39,7 @@ import { getUserFriendlyDeployMessage } from './client/user_facing_errors'
 import { QuickDeployParams } from './types'
 
 const { awu } = collections.asynciterable
+const { isDefined } = values
 
 const { makeArray } = collections.array
 const log = logger(module)
@@ -201,10 +202,11 @@ const processDeployResponse = (
     .map(codeCoverageWarning => codeCoverageWarning.message)
     .map(message => new Error(message))
 
-  const genericErrorMessage = makeArray(result.errorMessage)
-    .map(message => Error(message))
+  const errors = [...testErrors, ...componentErrors, ...codeCoverageWarningErrors]
 
-  const errors = [...testErrors, ...componentErrors, ...codeCoverageWarningErrors, ...genericErrorMessage]
+  if (isDefined(result.errorMessage)) {
+    errors.push(Error(result.errorMessage))
+  }
 
   // In checkOnly none of the changes are actually applied
   if (!result.checkOnly && result.rollbackOnError && !result.success) {
@@ -220,7 +222,7 @@ const processDeployResponse = (
   // so we have to look for these messages in both lists
   const unFoundDeleteNames = [...allSuccessMessages, ...allFailureMessages]
     .map(message => getUnFoundDeleteName(message, deletionsPackageName))
-    .filter(values.isDefined)
+    .filter(isDefined)
 
   const successfulFullNames = allSuccessMessages
     .map(success => ({ type: success.componentType, fullName: success.fullName }))
@@ -259,7 +261,7 @@ const validateChanges = async (
 
   const [invalidChanges, validChanges] = _.partition(
     changesAndValidation,
-    ({ error }) => values.isDefined(error)
+    ({ error }) => isDefined(error)
   )
 
   const errors = invalidChanges

--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -195,17 +195,14 @@ const processDeployResponse = (
     .map(failure => new Error(
       `Failed to ${checkOnly ? 'validate' : 'deploy'} ${failure.fullName} with error: ${failure.problem} (${failure.problemType})`
     ))
-
-  const runTestResultMap = makeArray(result.details)
+  const codeCoverageWarningErrors = makeArray(result.details)
     .map(detail => detail.runTestResult as RunTestsResult | undefined)
-  const codeCoverageWarningErrors = runTestResultMap
     .flatMap(runTestResult => makeArray(runTestResult?.codeCoverageWarnings))
     .map(codeCoverageWarning => codeCoverageWarning.message)
     .map(message => new Error(message))
-  const genericErrorMessage = runTestResultMap
-    .flatMap(runTestResult => makeArray(runTestResult?.errorMessage))
-    .map(errorMessage => errorMessage.message)
-    .map(message => new Error(message))
+
+  const genericErrorMessage = makeArray(result.errorMessage)
+    .map(message => Error(message))
 
   const errors = [...testErrors, ...componentErrors, ...codeCoverageWarningErrors, ...genericErrorMessage]
 

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -1044,16 +1044,11 @@ describe('SalesforceAdapter CRUD', () => {
           connection.metadata.deploy.mockReturnValueOnce(mockDeployResult({
             id: 'DeploymentWithErrorMessageErrors',
             success: false,
+            errorMessage: 'UNKNOWN_EXCEPTION: An unexpected error occurred',
             componentSuccess: [{
               fullName: mockDefaultValues.Profile.fullName,
               componentType: constants.PROFILE_METADATA_TYPE,
             }],
-            runTestResult: {
-              errorMessage: [{
-                id: '1',
-                message: 'UNKNOWN_EXCEPTION: An unexpected error occurred',
-              }],
-            },
           }))
           result = await adapter.deploy({
             changeGroup: {

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -1039,6 +1039,34 @@ describe('SalesforceAdapter CRUD', () => {
         })
       })
 
+      describe('when the request has errorMessage', () => {
+        beforeEach(async () => {
+          connection.metadata.deploy.mockReturnValueOnce(mockDeployResult({
+            id: 'DeploymentWithErrorMessageErrors',
+            success: false,
+            componentSuccess: [{
+              fullName: mockDefaultValues.Profile.fullName,
+              componentType: constants.PROFILE_METADATA_TYPE,
+            }],
+            runTestResult: {
+              errorMessage: [{
+                message: 'UNKNOWN_EXCEPTION: An unexpected error occurred',
+              }],
+            },
+          }))
+          result = await adapter.deploy({
+            changeGroup: {
+              groupID: afterInstance.elemID.getFullName(),
+              changes: [{ action: 'modify', data: { before: beforeInstance, after: afterInstance } }],
+            },
+          })
+        })
+        it('should produce a deploy error', () => {
+          expect(result.errors).toHaveLength(1)
+        })
+
+      })
+
       describe('when the request fails because fullNames are not the same', () => {
         beforeEach(async () => {
           afterInstance = beforeInstance.clone()

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -1050,6 +1050,7 @@ describe('SalesforceAdapter CRUD', () => {
             }],
             runTestResult: {
               errorMessage: [{
+                id: '1',
                 message: 'UNKNOWN_EXCEPTION: An unexpected error occurred',
               }],
             },
@@ -1064,7 +1065,6 @@ describe('SalesforceAdapter CRUD', () => {
         it('should produce a deploy error', () => {
           expect(result.errors).toHaveLength(1)
         })
-
       })
 
       describe('when the request fails because fullNames are not the same', () => {

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -1039,9 +1039,9 @@ describe('SalesforceAdapter CRUD', () => {
         })
       })
 
-      describe('when the request has errorMessage', () => {
+      describe('when the DeployResult contains errorMessage', () => {
         beforeEach(async () => {
-          connection.metadata.deploy.mockReturnValueOnce(mockDeployResult({
+          connection.metadata.deploy.mockReturnValue(mockDeployResult({
             id: 'DeploymentWithErrorMessageErrors',
             success: false,
             errorMessage: 'UNKNOWN_EXCEPTION: An unexpected error occurred',

--- a/packages/salesforce-adapter/test/connection.ts
+++ b/packages/salesforce-adapter/test/connection.ts
@@ -164,10 +164,12 @@ type GetDeployResultParams = {
   checkOnly?: boolean
   testCompleted?: number
   testErrors?: number
+  errorMessage?: string
 }
 export const mockDeployResultComplete = ({
   id = _.uniqueId(),
   success = true,
+  errorMessage,
   componentSuccess = [],
   componentFailure = [],
   runTestResult = undefined,
@@ -199,6 +201,7 @@ export const mockDeployResultComplete = ({
   startDate: '2020-05-01T14:21:36.000Z',
   status: success ? 'Succeeded' : 'Failed',
   success,
+  errorMessage,
 })
 
 export const mockDeployResult = (


### PR DESCRIPTION
Errors that are inside the `errorMessage` field will be propagated to the user
---

_Additional context for reviewer_

---
_Release Notes_: 
Salesforce Adapter:
* Deploy failure with `errorMessage` is now propagated to the user
---
_User Notifications_: _None