### PR TITLE
Revert "Salto-2861: Add edit permissions to Jira cloud's filters (#38…

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/cloud/filter.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/filter.ts
@@ -40,17 +40,4 @@ export const createFilterValues = (name: string, allElements: Element[]): Values
         name: createReference(new ElemID(JIRA, GROUP_TYPE_NAME, 'instance', 'site_admins@b'), allElements),
       } },
   ],
-  editPermissions: [
-    {
-      type: 'user',
-      user: {
-        displayName: 'Automation for Jira',
-        active: true,
-        accountId: {
-          id: '557058:f58131cb-b67d-43c7-b30d-6b58d40bd077',
-          displayName: 'Automation for Jira',
-        },
-      },
-    },
-  ],
 })

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -443,7 +443,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
     request: {
       url: '/rest/api/3/filter/search',
       queryParams: {
-        expand: 'description,owner,jql,sharePermissions,editPermissions',
+        expand: 'description,owner,jql,sharePermissions',
       },
       paginationField: 'startAt',
       recurseInto: [


### PR DESCRIPTION
…30)"

This reverts commit 953cb6fe56b8c9a6b300d1d5bfcb0f0f2d2029c6.

_Replace me with a description of the changes in this PR_

---

_Additional context for reviewer_

---
_Release Notes_: 
(Remove the 2861 note about Jira Edit Permissions

---
_User Notifications_: 
None
