### PR TITLE
SALTO-2926: Use manifest validation error to fix issues prior to deploy

### DIFF
--- a/packages/netsuite-adapter/src/change_validators/client_validation.ts
+++ b/packages/netsuite-adapter/src/change_validators/client_validation.ts
@@ -112,15 +112,24 @@ const changeValidator: ClientChangeValidator = async (
                 detailedMessage: error.message,
               }))
           }
-          const message = error instanceof ManifestValidationError
-            ? 'SDF Manifest Validation Error'
-            : `Validation Error on ${groupId}`
-          return groupChanges.map(change => ({
-            message,
-            severity: 'Error' as const,
-            elemID: getChangeData(change).elemID,
-            detailedMessage: error.message,
-          }))
+          if (error instanceof ManifestValidationError) {
+            const failedChanges = groupChanges
+              .filter(element => error.errorScriptIds.includes(getChangeData(element).elemID.getFullName()))
+            return (failedChanges.length > 0 ? failedChanges : groupChanges)
+              .map(change => ({
+                message: 'SDF Manifest Validation Error',
+                severity: 'Error' as const,
+                elemID: getChangeData(change).elemID,
+                detailedMessage: error.message,
+              }))
+          }
+          return groupChanges
+            .map(change => ({
+              message: `Validation Error on ${groupId}`,
+              severity: 'Error' as const,
+              elemID: getChangeData(change).elemID,
+              detailedMessage: error.message,
+            }))
         })
       }
       return []

--- a/packages/netsuite-adapter/src/change_validators/client_validation.ts
+++ b/packages/netsuite-adapter/src/change_validators/client_validation.ts
@@ -144,7 +144,7 @@ const changeValidator: ClientChangeValidator = async (
                 message: 'This element depends on missing elements',
                 severity: 'Error' as const,
                 elemID: getChangeData(changeAndMissingDependencies.element).elemID,
-                detailedMessage: `This element depends on the following missing elements: ${changeAndMissingDependencies.dependencies.join(', ')}. Please make sure that all the bundles from the source account are installed and updated in the target account`,
+                detailedMessage: `This element depends on the following missing elements: ${changeAndMissingDependencies.dependencies.join(', ')}. Please make sure that all the bundles from the source account are installed and updated in the target account.`,
               }))
           }
           return groupChanges

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -111,7 +111,7 @@ const settingsValidationErrorRegex = RegExp('^Validation of account settings fai
 export const objectValidationErrorRegex = RegExp(`^An error occurred during custom object validation. \\((?<${OBJECT_ID}>[a-z0-9_]+)\\)`, 'gm')
 const deployedObjectRegex = RegExp(`^(Create|Update) object -- (?<${OBJECT_ID}>[a-z0-9_]+)`, 'gm')
 const errorObjectRegex = RegExp(`^An unexpected error has occurred. \\((?<${OBJECT_ID}>[a-z0-9_]+)\\)`, 'm')
-const manifestErrorDetailsRegex = RegExp('Details: The manifest contains a dependency on [a-z0-9_]+', 'gm')
+const manifestErrorDetailsRegex = RegExp('Details: The manifest contains a dependency on [a-z0-9_]+(\\.[a-z0-9_]+)*', 'gm')
 
 export const MINUTE_IN_MILLISECONDS = 1000 * 60
 const SINGLE_OBJECT_RETRIES = 3
@@ -191,6 +191,7 @@ export const getGroupItemFromRegex = (str: string, regex: RegExp, item: string):
     .map(r => r.groups)
     .filter(isDefined)
     .map(groups => groups[item])
+
 
 type Project = {
   projectName: string
@@ -909,7 +910,7 @@ export default class SdfClient {
     )
   }
 
-  private static getManifestErrorScriptIds(errorMessage: string): string[] {
+  public static getManifestErrorScriptIds(errorMessage: string): string[] {
     return errorMessage
       .match(manifestErrorDetailsRegex)
       ?.map(errorLine => {
@@ -928,7 +929,7 @@ export default class SdfClient {
       return new SettingsDeployError(errorMessage, new Set([CONFIG_FEATURES]))
     }
     if (!deployStartMessageRegex.test(errorMessage)) {
-      // we'll get here when the deploy failed in the validation phase.
+      // we'll get here when the deploy failed in th  e validation phase.
       // in this case we're looking for validation error message lines.
       const validationErrorObjects = getGroupItemFromRegex(
         errorMessage, objectValidationErrorRegex, OBJECT_ID

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -111,7 +111,7 @@ const settingsValidationErrorRegex = RegExp('^Validation of account settings fai
 export const objectValidationErrorRegex = RegExp(`^An error occurred during custom object validation. \\((?<${OBJECT_ID}>[a-z0-9_]+)\\)`, 'gm')
 const deployedObjectRegex = RegExp(`^(Create|Update) object -- (?<${OBJECT_ID}>[a-z0-9_]+)`, 'gm')
 const errorObjectRegex = RegExp(`^An unexpected error has occurred. \\((?<${OBJECT_ID}>[a-z0-9_]+)\\)`, 'm')
-const manifestErrorDetailsRegex = RegExp('Details: The manifest contains a dependency on [a-z0-9_]+(\\.[a-z0-9_]+)*', 'gm')
+const manifestErrorDetailsRegex = RegExp(`Details: The manifest contains a dependency on (?<${OBJECT_ID}>[a-z0-9_]+(\\.[a-z0-9_]+)*)`, 'gm')
 
 export const MINUTE_IN_MILLISECONDS = 1000 * 60
 const SINGLE_OBJECT_RETRIES = 3
@@ -910,20 +910,11 @@ export default class SdfClient {
     )
   }
 
-  public static getManifestErrorScriptIds(errorMessage: string): string[] {
-    return errorMessage
-      .match(manifestErrorDetailsRegex)
-      ?.map(errorLine => {
-        const lineAsArray = errorLine.split(' ')
-        return lineAsArray[lineAsArray.length - 1]
-      }) ?? []
-  }
-
   private static customizeDeployError(error: Error): Error {
     const errorMessage = error.message
     if (settingsValidationErrorRegex.test(errorMessage)) {
-      if (manifestErrorDetailsRegex.test(errorMessage)) {
-        const manifestErrorScriptidArray = this.getManifestErrorScriptIds(errorMessage)
+      const manifestErrorScriptidArray = getGroupItemFromRegex(errorMessage, manifestErrorDetailsRegex, OBJECT_ID)
+      if (manifestErrorScriptidArray.length > 0) {
         return new ManifestValidationError(errorMessage, manifestErrorScriptidArray)
       }
       return new SettingsDeployError(errorMessage, new Set([CONFIG_FEATURES]))

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -913,9 +913,9 @@ export default class SdfClient {
   private static customizeDeployError(error: Error): Error {
     const errorMessage = error.message
     if (settingsValidationErrorRegex.test(errorMessage)) {
-      const manifestErrorScriptidArray = getGroupItemFromRegex(errorMessage, manifestErrorDetailsRegex, OBJECT_ID)
-      if (manifestErrorScriptidArray.length > 0) {
-        return new ManifestValidationError(errorMessage, manifestErrorScriptidArray)
+      const manifestErrorScriptids = getGroupItemFromRegex(errorMessage, manifestErrorDetailsRegex, OBJECT_ID)
+      if (manifestErrorScriptids.length > 0) {
+        return new ManifestValidationError(errorMessage, manifestErrorScriptids)
       }
       return new SettingsDeployError(errorMessage, new Set([CONFIG_FEATURES]))
     }

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -920,7 +920,7 @@ export default class SdfClient {
       return new SettingsDeployError(errorMessage, new Set([CONFIG_FEATURES]))
     }
     if (!deployStartMessageRegex.test(errorMessage)) {
-      // we'll get here when the deploy failed in th  e validation phase.
+      // we'll get here when the deploy failed in the validation phase.
       // in this case we're looking for validation error message lines.
       const validationErrorObjects = getGroupItemFromRegex(
         errorMessage, objectValidationErrorRegex, OBJECT_ID

--- a/packages/netsuite-adapter/src/errors.ts
+++ b/packages/netsuite-adapter/src/errors.ts
@@ -41,10 +41,10 @@ export class SettingsDeployError extends Error {
 }
 
 export class ManifestValidationError extends Error {
-  errorScriptIds: string[]
-  constructor(message: string, errorScriptIds: string[]) {
+  missingDependencyScriptIds: string[]
+  constructor(message: string, missingDependencyScriptIds: string[]) {
     super(message)
     this.name = 'ManifestValidationError'
-    this.errorScriptIds = errorScriptIds
+    this.missingDependencyScriptIds = missingDependencyScriptIds
   }
 }

--- a/packages/netsuite-adapter/src/errors.ts
+++ b/packages/netsuite-adapter/src/errors.ts
@@ -41,8 +41,10 @@ export class SettingsDeployError extends Error {
 }
 
 export class ManifestValidationError extends Error {
-  constructor(message: string) {
+  errorScriptIds: string[]
+  constructor(message: string, errorScriptIds: string[]) {
     super(message)
     this.name = 'ManifestValidationError'
+    this.errorScriptIds = errorScriptIds
   }
 }

--- a/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
@@ -128,7 +128,7 @@ File: ~/Objects/customrecord1.xml`
       severity: 'Error',
     })
   })
-  it('should have SDF Manifest Validation Error and remove ', async () => {
+  it('should have SDF Manifest Validation Error and remove the element causing it', async () => {
     const detailedMessage = `Validation of account settings failed.
     
     An error occurred during account settings validation.

--- a/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
@@ -143,7 +143,7 @@ File: ~/Objects/customrecord1.xml`
     )
     expect(changeErrors).toHaveLength(1)
     expect(changeErrors[0]).toEqual({
-      detailedMessage: 'This element depends on the following missing elements: some_scriptid. Please try redeploying with these elements included.',
+      detailedMessage: 'This element depends on the following missing elements: some_scriptid. Please make sure that all the bundles from the source account are installed and updated in the target account.',
       elemID: getChangeData(changes[0]).elemID,
       message: 'This element depends on missing elements',
       severity: 'Error',

--- a/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
@@ -128,7 +128,7 @@ File: ~/Objects/customrecord1.xml`
   })
   it('should have SDF Manifest Validation Error', async () => {
     const detailedMessage = 'manifest error'
-    mockValidate.mockReturnValue([new ManifestValidationError(detailedMessage)])
+    mockValidate.mockReturnValue([new ManifestValidationError(detailedMessage, [])])
     const changeErrors = await clientValidation(
       changes,
       client,

--- a/packages/netsuite-adapter/test/client/client.test.ts
+++ b/packages/netsuite-adapter/test/client/client.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ElemID, InstanceElement, ObjectType, toChange, Change, BuiltinTypes } from '@salto-io/adapter-api'
+import { ElemID, InstanceElement, ObjectType, toChange, Change, BuiltinTypes, ReferenceExpression } from '@salto-io/adapter-api'
 import SuiteAppClient from '../../src/client/suiteapp_client/suiteapp_client'
 import SdfClient from '../../src/client/sdf_client'
 import * as suiteAppFileCabinet from '../../src/suiteapp_file_cabinet'
@@ -26,6 +26,7 @@ import { featuresType } from '../../src/types/configuration_types'
 import { FeaturesDeployError, ManifestValidationError, ObjectsDeployError, SettingsDeployError } from '../../src/errors'
 import { LazyElementsSourceIndexes } from '../../src/elements_source_index/types'
 import { AdditionalDependencies } from '../../src/client/types'
+
 
 describe('NetsuiteClient', () => {
   describe('with SDF client', () => {
@@ -136,16 +137,15 @@ describe('NetsuiteClient', () => {
       })
 
       it('should try to deploy again after ManifestValidationError', async () => {
-        const successType = new ObjectType({ elemID: new ElemID(NETSUITE, 'type') })
-        const failType = new ObjectType({ elemID: new ElemID(NETSUITE, 'failType') })
+        const type = new ObjectType({ elemID: new ElemID(NETSUITE, 'type') })
         const manifestErrorMessage = 'Details: The manifest contains a dependency on failed_scriptid'
         const manifestValidationError = new ManifestValidationError(manifestErrorMessage, ['failed_scriptid'])
         mockSdfDeploy.mockRejectedValueOnce(manifestValidationError)
         const successChange = toChange({
-          after: new InstanceElement('instance', successType, { scriptid: 'someObject' }),
+          after: new InstanceElement('instance', type, { scriptid: 'someObject', ref: '[scriptid=test_scriptid]' },),
         })
         const failedChange = toChange({
-          after: new InstanceElement(ElemID.CONFIG_NAME, failType, { scriptid: 'scriptid', bad_ref: '[scriptid=failed_scriptid]' }),
+          after: new InstanceElement('failedInstance', type, { scriptid: 'scriptid', bad_ref: '[scriptid=failed_scriptid]' }),
         })
         expect(await client.deploy(
           [successChange, failedChange],
@@ -158,17 +158,71 @@ describe('NetsuiteClient', () => {
         expect(mockSdfDeploy).toHaveBeenCalledTimes(2)
       })
 
-      it('should fail deployment if failed scriptid cant be extracted from error message', async () => {
-        const successType = new ObjectType({ elemID: new ElemID(NETSUITE, 'type') })
-        const failType = new ObjectType({ elemID: new ElemID(NETSUITE, 'failType') })
+      it('should try to deploy again after ManifestValidationError from inner NS ref', async () => {
+        const type = new ObjectType({ elemID: new ElemID(NETSUITE, 'type') })
+        const manifestErrorMessage = 'Details: The manifest contains a dependency on customworkflow1.workflowstate17.workflowaction33'
+        const manifestValidationError = new ManifestValidationError(manifestErrorMessage, ['customworkflow1.workflowstate17.workflowaction33'])
+        mockSdfDeploy.mockRejectedValueOnce(manifestValidationError)
+        const successChange = toChange({
+          after: new InstanceElement('instance', type, { scriptid: 'someObject' }),
+        })
+        const failedChange = toChange({
+          after: new InstanceElement('failedInstance', type, { scriptid: 'scriptid', bad_ref: '[scriptid=customworkflow1.workflowstate17.workflowaction33]' }),
+        })
+        expect(await client.deploy(
+          [successChange, failedChange],
+          SDF_CHANGE_GROUP_ID,
+          ...deployParams
+        )).toEqual({
+          errors: [manifestValidationError],
+          appliedChanges: [successChange],
+        })
+        expect(mockSdfDeploy).toHaveBeenCalledTimes(2)
+      })
+
+      it('should not apply any changes if failed scriptid cant be extracted from error message', async () => {
+        const type = new ObjectType({ elemID: new ElemID(NETSUITE, 'type') })
         const manifestErrorMessage = 'Details: The manifest contains a dependency on some_id'
         const manifestValidationError = new ManifestValidationError(manifestErrorMessage, ['some_id'])
         mockSdfDeploy.mockRejectedValueOnce(manifestValidationError)
         const successChange = toChange({
-          after: new InstanceElement('instance', successType, { scriptid: 'someObject' }),
+          after: new InstanceElement('instance', type, { scriptid: 'someObject', ref: '[scriptid=some_ref]' }),
         })
         const failedChange = toChange({
-          after: new InstanceElement(ElemID.CONFIG_NAME, failType, { scriptid: 'scriptid', bad_ref: '[scriptid=failed_scriptid]' }),
+          after: new InstanceElement('failedInstance', type, { scriptid: 'scriptid', bad_ref: '[scriptid=failed_scriptid]' }),
+        })
+        expect(await client.deploy(
+          [successChange, failedChange],
+          SDF_CHANGE_GROUP_ID,
+          ...deployParams
+        )).toEqual({
+          errors: [manifestValidationError],
+          appliedChanges: [],
+        })
+        expect(mockSdfDeploy).toHaveBeenCalledTimes(1)
+      })
+
+      it('should not apply any changes if failed salto reference cant be extracted from error message', async () => {
+        const type = new ObjectType({ elemID: new ElemID(NETSUITE, 'center') })
+        const manifestErrorMessage = 'Details: The manifest contains a dependency on netsuite.center.instance.custcenter1.scriptid'
+        const manifestValidationError = new ManifestValidationError(manifestErrorMessage, ['netsuite.center.instance.custcenter1.scriptid'])
+        mockSdfDeploy.mockRejectedValueOnce(manifestValidationError)
+        const successChange = toChange({
+          after: new InstanceElement('instance', type, { scriptid: 'someObject' }),
+        })
+        const tempInstance = new InstanceElement('name', type, { scriptid: 'custcenter1' }, [
+          'netsuite',
+          'Records',
+          'center',
+          'custcenter1',
+        ])
+        const saltoRefExp = new ReferenceExpression(
+          new ElemID(NETSUITE, 'center').createNestedID('instance', 'custcenter1', SCRIPT_ID),
+          tempInstance.value.scriptid,
+          tempInstance
+        )
+        const failedChange = toChange({
+          after: new InstanceElement('failInstance', type, { scriptid: 'otherObject', ref: saltoRefExp }),
         })
         expect(await client.deploy(
           [successChange, failedChange],

--- a/packages/netsuite-adapter/test/client/client.test.ts
+++ b/packages/netsuite-adapter/test/client/client.test.ts
@@ -164,7 +164,7 @@ describe('NetsuiteClient', () => {
         const manifestValidationError = new ManifestValidationError(manifestErrorMessage, ['customworkflow1.workflowstate17.workflowaction33'])
         mockSdfDeploy.mockRejectedValueOnce(manifestValidationError)
         const successChange = toChange({
-          after: new InstanceElement('instance', type, { scriptid: 'someObject' }),
+          after: new InstanceElement('instance', type, { scriptid: 'someObject', ref: '[scriptid=customworkflow1]' }),
         })
         const failedChange = toChange({
           after: new InstanceElement('failedInstance', type, { scriptid: 'scriptid', bad_ref: '[scriptid=customworkflow1.workflowstate17.workflowaction33]' }),
@@ -212,7 +212,7 @@ describe('NetsuiteClient', () => {
         })
         const centerInstance = new InstanceElement('name', type, { scriptid: 'custcenter1' })
         const saltoRefExp = new ReferenceExpression(
-          centerInstance.elemID.createNestedID('instance', 'custcenter1', SCRIPT_ID),
+          centerInstance.elemID.createNestedID(SCRIPT_ID),
           centerInstance.value.scriptid,
           centerInstance
         )

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -1805,7 +1805,7 @@ File: ~/AccountConfiguration/features.xml`
       })
       it('should throw ManifestValidationError', async () => {
         let errorMessage: string
-        const errorReferenceName = 'someRefName'
+        const errorReferenceName = 'some_scriptid'
         const manifestErrorMessage = `Details: The manifest contains a dependency on ${errorReferenceName} object, but it is not in the account.`
         mockExecuteAction.mockImplementation(context => {
           if (context.commandName === COMMANDS.VALIDATE_PROJECT) {
@@ -1845,6 +1845,7 @@ Details: The manifest contains a dependency on ${errorReferenceName} object, but
         } catch (e) {
           expect(e instanceof ManifestValidationError).toBeTruthy()
           expect(e.message).toContain(manifestErrorMessage)
+          expect(e.errorScriptIds).toContain(errorReferenceName)
         }
       })
       it('should throw error', async () => {

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -1845,7 +1845,7 @@ Details: The manifest contains a dependency on ${errorReferenceName} object, but
         } catch (e) {
           expect(e instanceof ManifestValidationError).toBeTruthy()
           expect(e.message).toContain(manifestErrorMessage)
-          expect(e.errorScriptIds).toContain(errorReferenceName)
+          expect(e.missingDependencyScriptIds).toContain(errorReferenceName)
         }
       })
       it('should throw error', async () => {


### PR DESCRIPTION
_manifestValidationError will not fail the entire deploy_

---

_Additional context for reviewer_

* The first PR out of two for this ticket, the second PR will handle removing all dependencies the first time we encounter manifestValidationError instead of removing it with validation iterations.
---
_Release Notes_: 
_Netsuite_:
* encountering a manifest validation error due to objects which do not appear in target account will not fail deployment, the elements will be removed to allow deployment of all other elements

---
_User Notifications_: 
_None_
