### PR TITLE
SALTO-3463: Delete security level that fails with 500 shown as success

### DIFF
--- a/packages/jira-adapter/src/deployment/jsp_deployment.ts
+++ b/packages/jira-adapter/src/deployment/jsp_deployment.ts
@@ -78,7 +78,13 @@ const deployChange = async (
         },
       })
     } catch (err) {
-      log.debug(`Received error ${err.message} for ${instance.elemID.getFullName()}. Could be because the element is already removed`)
+      if (err instanceof clientUtils.HTTPError
+        && err.response.status === 404
+        && isRemovalChange(change)) {
+        log.debug(`Received error ${err.message} for ${instance.elemID.getFullName()}. The element is already removed`)
+        return
+      }
+      throw err
     }
   }
 }

--- a/packages/jira-adapter/test/deployment/jsp_deployment.test.ts
+++ b/packages/jira-adapter/test/deployment/jsp_deployment.test.ts
@@ -419,7 +419,10 @@ describe('jsp_deployment', () => {
     })
 
     it('Should not throw when the request fail and the instance is already deleted', async () => {
-      mockConnection.post.mockRejectedValue(new Error('some error'))
+      mockConnection.post.mockRejectedValue(new clientUtils.HTTPError('message', {
+        status: 404,
+        data: {},
+      }))
       mockConnection.get.mockResolvedValueOnce({
         status: 200,
         data: [],
@@ -431,6 +434,23 @@ describe('jsp_deployment', () => {
       })
       expect(results.errors).toHaveLength(0)
       expect(results.appliedChanges).toHaveLength(1)
+    })
+    it('Should throw when the request fail with 500', async () => {
+      mockConnection.post.mockRejectedValue(new clientUtils.HTTPError('message', {
+        status: 500,
+        data: {},
+      }))
+      mockConnection.get.mockResolvedValueOnce({
+        status: 200,
+        data: [],
+      })
+      const results = await deployWithJspEndpoints({
+        changes: [toChange({ before: instance })],
+        client,
+        urls,
+      })
+      expect(results.errors).toHaveLength(1)
+      expect(results.appliedChanges).toHaveLength(0)
     })
   })
 })


### PR DESCRIPTION
_Happens on cloud only_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
