### PR TITLE
SALTO-3469: New contexts of existing fields are created in the wrong locations

### DIFF
--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -233,6 +233,9 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
         { fieldName: 'contextIssueTypes', fieldType: 'list<IssueTypeToContextMapping>' },
         { fieldName: 'contextProjects', fieldType: 'list<CustomFieldContextProjectMapping>' },
       ],
+      fileNameFields: [
+        'name',
+      ],
     },
     deployRequests: {
       add: {


### PR DESCRIPTION
Fixed a bug where a new contexts of existing fields would be written not under the field folder

---

The issue was that in existing fields, their path in the element was their element name which is different than their real path. The `fileNameFields` makes the path be by the name value and not by the element name which fixes it

---
_Release Notes_: 
__Jira Adapter__:
- Fixed a bug where a new contexts of existing fields would be written not under the field folder

---
_User Notifications_: 
None
