### PR TITLE
SALTO-3475 - Build: fix Windows build

### DIFF
--- a/build_utils/verify_tsconfig_references.js
+++ b/build_utils/verify_tsconfig_references.js
@@ -60,7 +60,8 @@ const main = async () => {
   const tsConfigs = readTsConfigs(workspaces)
 
   const referenceToWorkspacePackage = ({ path: refPath }, { location: packageLocation }) => {
-    const refLocation = path.join(packageLocation, refPath)
+    const pathSepRegEx = new RegExp(path.sep, 'g')
+    const refLocation = path.join(packageLocation, refPath).replace(pathSepRegEx, '/')
     return findKey(workspaces, ({ location }) => location === refLocation)
   }
 


### PR DESCRIPTION
`yarn verify` fails on Windows because `tsconfic_references.js` does a string compare between workspace deps (that always use `/` as path separator) and paths (that use the OS-specific path separator). This works fine on POSIXy systems, but fails miserably on Windows.

---

_Additional context for reviewer_

---
_Release Notes_: 
Fix building the Salto project on Windows

---
_User Notifications_: 
N/A
