### PR TITLE
SALTO-3030: better handling email addresses in zendesk

### DIFF
--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -112,6 +112,7 @@ import guideArrangePaths from './filters/guide_arrange_paths'
 import guideDefaultLanguage from './filters/guide_default_language_settings'
 import guideAddBrandToArticleTranslation from './filters/guide_add_brand_to_translation'
 import ticketFormDeploy from './filters/ticket_form'
+import supportAddress from './filters/support_address'
 
 const { makeArray } = collections.array
 const log = logger(module)
@@ -154,6 +155,7 @@ export const DEFAULT_FILTERS = [
   removeDefinitionInstancesFilter,
   usersFilter,
   tagsFilter,
+  supportAddress,
   guideAddBrandToArticleTranslation,
   macroAttachmentsFilter,
   ticketFormDeploy,

--- a/packages/zendesk-adapter/src/constants.ts
+++ b/packages/zendesk-adapter/src/constants.ts
@@ -39,6 +39,7 @@ export const ACCOUNT_FEATURES_TYPE_NAME = 'account_features'
 export const EVERYONE_USER_TYPE = 'Everyone'
 export const TICKET_FORM_TYPE_NAME = 'ticket_form'
 export const TICKET_FORM_ORDER_TYPE_NAME = 'ticket_form_order'
+export const SUPPORT_ADDRESS_TYPE_NAME = 'support_address'
 
 
 export const CATEGORY_ORDER_TYPE_NAME = 'category_order'

--- a/packages/zendesk-adapter/src/filters/support_address.ts
+++ b/packages/zendesk-adapter/src/filters/support_address.ts
@@ -1,0 +1,139 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  Change,
+  Element, getChangeData,
+  InstanceElement, isAdditionOrModificationChange, isInstanceChange,
+  isInstanceElement,
+  ReferenceExpression,
+  TemplateExpression,
+  TemplatePart,
+} from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { extractTemplate } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+import { collections } from '@salto-io/lowerdash'
+import { FilterCreator } from '../filter'
+import { BRAND_TYPE_NAME, SUPPORT_ADDRESS_TYPE_NAME } from '../constants'
+
+const log = logger(module)
+const { awu } = collections.asynciterable
+
+
+const referenceEmail = ({ emailPart, brandInstances }: {
+  emailPart: string
+  brandInstances: Record<string, InstanceElement>
+}): TemplatePart[] => {
+  // emailPart should be of the form {local-part}@{subdomain}.zendesk.com.
+  const splitLocalPart = emailPart.split(/@/).filter(v => !_.isEmpty(v))
+  if (splitLocalPart.length !== 2) {
+    return [emailPart]
+  }
+  const [localPart, rest] = splitLocalPart
+  // zendesk subdomain cannot have a dot (.) in it.
+  const splitRest = rest.split(/\./).filter(v => !_.isEmpty(v))
+  if (splitRest.length < 1) {
+    return [emailPart]
+  }
+  const subdomain = splitRest[0]
+  splitRest.shift()
+  const elem = brandInstances[subdomain]
+  if (elem) {
+    return [
+      localPart,
+      '@',
+      new ReferenceExpression(elem.elemID.createNestedID('subdomain'), elem.value.subdomain),
+      '.',
+      splitRest.join('.'),
+    ]
+  }
+  return [emailPart]
+}
+
+
+const getTemplateEmail = ({
+  supportAddressInstance,
+  brandList,
+} : {
+  supportAddressInstance: InstanceElement
+  brandList: Record<string, InstanceElement>
+}): TemplateExpression | string | undefined => {
+  const originalEmail = supportAddressInstance.value.email
+  if (!_.isString(originalEmail)) {
+    log.error(`email of ${supportAddressInstance.elemID.getFullName()} is not a string`)
+    return undefined
+  }
+  return extractTemplate(
+    originalEmail,
+    [],
+    emailPart => referenceEmail({
+      emailPart,
+      brandInstances: brandList,
+    })
+  )
+}
+
+const turnEmailToTemplateExpression = (
+  supportAddressInstances: InstanceElement[],
+  brandBySubdomains: Record<string, InstanceElement>
+): void => {
+  supportAddressInstances
+    .forEach(supportInstance => {
+      const newEmail = getTemplateEmail({
+        supportAddressInstance: supportInstance,
+        brandList: brandBySubdomains,
+      })
+      supportInstance.value.email = newEmail
+    })
+}
+
+const filterCreator: FilterCreator = ({ elementsSource }) => ({
+  onFetch: async (elements: Element[]): Promise<void> => {
+    const instances = elements
+      .filter(isInstanceElement)
+    const supportAddressInstances = instances
+      .filter(inst => inst.elemID.typeName === SUPPORT_ADDRESS_TYPE_NAME)
+    const brandBySubdomains: Record<string, InstanceElement> = _.keyBy(
+      (instances
+        .filter(inst => inst.elemID.typeName === BRAND_TYPE_NAME)
+        .filter(inst => inst.value.subdomain !== undefined)),
+      (inst: InstanceElement): string => inst.value.subdomain
+    )
+    turnEmailToTemplateExpression(supportAddressInstances, brandBySubdomains)
+  },
+  onDeploy: async (changes: Change<InstanceElement>[]): Promise<void> => {
+    const supportAddressInstances = changes
+      .filter(isAdditionOrModificationChange)
+      .filter(isInstanceChange)
+      .filter(change => getChangeData(change).elemID.typeName === SUPPORT_ADDRESS_TYPE_NAME)
+      .map(getChangeData)
+    if (_.isEmpty(supportAddressInstances)) {
+      return
+    }
+    const brandInstances = await awu(await elementsSource.getAll())
+      .filter(isInstanceElement)
+      .filter(inst => inst.elemID.typeName === BRAND_TYPE_NAME)
+      .filter(inst => inst.value.subdomain !== undefined)
+      .toArray()
+    const brandBySubdomains: Record<string, InstanceElement> = _.keyBy(
+      brandInstances,
+      (inst: InstanceElement): string => inst.value.subdomain
+    )
+    turnEmailToTemplateExpression(supportAddressInstances, brandBySubdomains)
+  },
+})
+
+export default filterCreator

--- a/packages/zendesk-adapter/src/filters/support_address.ts
+++ b/packages/zendesk-adapter/src/filters/support_address.ts
@@ -41,13 +41,13 @@ const referenceEmail = ({ emailPart, brandInstances }: {
 }): TemplatePart[] => {
   // emailPart should be of the form {username}@{subdomain}.{domain} (usually zendesk.com)
   // zendesk subdomain cannot have a dot (.) in it.
-  const splitedEmail = emailPart.split(/^([^@]+)@([^.]+)\.(.+)$/).filter(v => !_.isEmpty(v))
-  if (splitedEmail.length !== 3) {
+  const splitEmail = emailPart.split(/^([^@]+)@([^.]+)\.(.+)$/).filter(v => !_.isEmpty(v))
+  if (splitEmail.length !== 3) {
     return [emailPart]
   }
-  const [username, subdomain, domain] = splitedEmail
+  const [username, subdomain, domain] = splitEmail
   const elem = brandInstances[subdomain]
-  if (elem) {
+  if (elem !== undefined) {
     return [
       username,
       '@',

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -27,7 +27,7 @@ import {
   BuiltinTypes,
   CORE_ANNOTATIONS,
   isRemovalChange,
-  getChangeData,
+  getChangeData, TemplateExpression,
 } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
@@ -622,12 +622,23 @@ describe('adapter', () => {
         ])
 
         const supportAddress = elements.filter(isInstanceElement).find(e => e.elemID.getFullName().startsWith('zendesk.support_address.instance.myBrand'))
+        const brand = elements.filter(isInstanceElement).find(e => e.elemID.getFullName().startsWith('zendesk.brand.instance.myBrand'))
+        expect(brand).toBeDefined()
+        if (brand === undefined) {
+          return
+        }
         expect(supportAddress).toBeDefined()
         expect(supportAddress?.value).toMatchObject({
           id: 1500000743022,
           default: true,
           name: 'myBrand',
-          email: 'support@myBrand.zendesk.com',
+          email: new TemplateExpression({
+            parts: [
+              'support@',
+              new ReferenceExpression(brand.elemID.createNestedID('subdomain'), brand.value.subdomain),
+              '.zendesk.com',
+            ],
+          }),
           // eslint-disable-next-line camelcase
           brand_id: expect.any(ReferenceExpression),
         })

--- a/packages/zendesk-adapter/test/filters/support_address.test.ts
+++ b/packages/zendesk-adapter/test/filters/support_address.test.ts
@@ -1,0 +1,120 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { filterUtils } from '@salto-io/adapter-components'
+import {
+  ElemID,
+  InstanceElement,
+  ObjectType,
+  ReferenceExpression,
+  TemplateExpression,
+  toChange,
+} from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { FilterResult } from '../../src/filter'
+import { BRAND_TYPE_NAME, SUPPORT_ADDRESS_TYPE_NAME, ZENDESK } from '../../src/constants'
+import filterCreator from '../../src/filters/support_address'
+import { createFilterCreatorParams } from '../utils'
+
+
+describe('article body filter', () => {
+  type FilterType = filterUtils.FilterWith<'onFetch' | 'onDeploy' | 'preDeploy', FilterResult>
+  let filter: FilterType
+
+  const brandType = new ObjectType({ elemID: new ElemID(ZENDESK, BRAND_TYPE_NAME) })
+  const supportAddressType = new ObjectType({ elemID: new ElemID(ZENDESK, SUPPORT_ADDRESS_TYPE_NAME) })
+
+  const brand1 = new InstanceElement('brand1', brandType, { subdomain: 'one' })
+  const brand2 = new InstanceElement('brand2', brandType, { subdomain: 'two' })
+
+  const supportAddressZendesk = new InstanceElement(
+    'address1',
+    supportAddressType,
+    {
+      email: 'support1@one.zendesk.com',
+    }
+  )
+  const supportAddressZendeskAfterFetch = new InstanceElement(
+    'address1',
+    supportAddressType,
+    {
+      email: new TemplateExpression({
+        parts: [
+          'support1@',
+          new ReferenceExpression(brand1.elemID.createNestedID('subdomain'), brand1.value.subdomain),
+          '.zendesk.com',
+        ],
+      }),
+    }
+  )
+  const supportAddressOther = new InstanceElement(
+    'address2',
+    supportAddressType,
+    {
+      email: 'support1@gmail.com',
+    }
+  )
+
+  beforeAll(() => {
+    const elementsSource = buildElementsSourceFromElements([supportAddressZendesk, supportAddressOther, brand1, brand2])
+
+    filter = filterCreator(createFilterCreatorParams({ elementsSource })) as FilterType
+  })
+  describe('onFetch', () => {
+    it('should turn zendesk emails to template expression', async () => {
+      const elements = [supportAddressZendesk, supportAddressOther, brand1, brand2].map(e => e.clone())
+      await filter.onFetch(elements)
+      const zendeskAddress = elements.find(e => e.elemID.name === 'address1')
+      const otherAddress = elements.find(e => e.elemID.name === 'address2')
+      expect(zendeskAddress).toBeDefined()
+      expect(otherAddress).toBeDefined()
+      if (zendeskAddress === undefined || otherAddress === undefined) {
+        return
+      }
+      expect(zendeskAddress).toEqual(supportAddressZendeskAfterFetch)
+      expect(otherAddress).toEqual(supportAddressOther)
+    })
+  })
+  describe('preDeploy', () => {
+    it('should turn zendesk emails from template expression to string', async () => {
+      const elements = [supportAddressZendeskAfterFetch, supportAddressOther].map(e => e.clone())
+      await filter.preDeploy(elements.map(elem => toChange({ after: elem })))
+      const zendeskAddress = elements.find(e => e.elemID.name === 'address1')
+      const otherAddress = elements.find(e => e.elemID.name === 'address2')
+      expect(zendeskAddress).toBeDefined()
+      expect(otherAddress).toBeDefined()
+      if (zendeskAddress === undefined || otherAddress === undefined) {
+        return
+      }
+      expect(zendeskAddress).toEqual(supportAddressZendesk)
+      expect(otherAddress).toEqual(supportAddressOther)
+    })
+  })
+  describe('onDeploy', () => {
+    it('should turn zendesk emails to template expression', async () => {
+      const elementsCloned = [supportAddressZendesk, supportAddressOther, brand1, brand2].map(e => e.clone())
+      await filter.onDeploy(elementsCloned.map(elem => toChange({ after: elem })))
+      const zendeskAddress = elementsCloned.find(e => e.elemID.name === 'address1')
+      const otherAddress = elementsCloned.find(e => e.elemID.name === 'address2')
+      expect(zendeskAddress).toBeDefined()
+      expect(otherAddress).toBeDefined()
+      if (zendeskAddress === undefined || otherAddress === undefined) {
+        return
+      }
+      expect(zendeskAddress).toEqual(supportAddressZendeskAfterFetch)
+      expect(otherAddress).toEqual(supportAddressOther)
+    })
+  })
+})


### PR DESCRIPTION
_better handling email addresses in zendesk_

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* zendesk emails in support_address will include a reference expression to the brand subdomain.

---
_User Notifications_: 
zendesk:
* zendesk emails in support_address will include a reference expression to the brand subdomain.
