### PR TITLE
SALTO-3143: Deploy config for missing users & handle missing users in Zendesk

### DIFF
--- a/packages/adapter-components/src/config/index.ts
+++ b/packages/adapter-components/src/config/index.ts
@@ -15,7 +15,7 @@
 */
 export { createDucktypeAdapterApiConfigType, AdapterDuckTypeApiConfig, DuckTypeTransformationConfig, DuckTypeTransformationDefaultConfig, TypeDuckTypeConfig, TypeDuckTypeDefaultsConfig, validateApiDefinitionConfig as validateDuckTypeApiDefinitionConfig, validateFetchConfig as validateDuckTypeFetchConfig } from './ducktype'
 export { createRequestConfigs, validateRequestConfig, FetchRequestConfig, DeployRequestConfig, UrlParams, DeploymentRequestsByAction, RecurseIntoCondition, isRecurseIntoConditionByField } from './request'
-export { createAdapterApiConfigType, getConfigWithDefault, AdapterApiConfig, UserFetchConfig, TypeConfig, createUserFetchConfigType, DEPLOYER_FALLBACK_VALUE, UserDeployConfig, createUserDeployConfigType } from './shared'
+export { createAdapterApiConfigType, getConfigWithDefault, AdapterApiConfig, UserFetchConfig, TypeConfig, createUserFetchConfigType, DEPLOYER_FALLBACK_VALUE, UserDeployConfig, createUserDeployConfigType, validateDeployConfig } from './shared'
 export { mergeWithDefaultConfig } from './merge'
 export { createTypeNameOverrideConfigType, createSwaggerAdapterApiConfigType, AdapterSwaggerApiConfig, RequestableAdapterSwaggerApiConfig, TypeSwaggerConfig, RequestableTypeSwaggerConfig, TypeSwaggerDefaultConfig, TypeNameOverrideConfig, validateApiDefinitionConfig as validateSwaggerApiDefinitionConfig, validateFetchConfig as validateSwaggerFetchConfig } from './swagger'
 export { createTransformationConfigTypes, validateTransoformationConfig, TransformationDefaultConfig, TransformationConfig, StandaloneFieldConfigType, FieldToOmitType, FieldToHideType, getTransformationConfigByType, dereferenceFieldName, isReferencedIdField, NameMappingOptions, DATA_FIELD_ENTIRE_OBJECT } from './transformation'

--- a/packages/adapter-components/src/config/shared.ts
+++ b/packages/adapter-components/src/config/shared.ts
@@ -221,3 +221,20 @@ export const validateSupportedTypes = (
     throw Error(`Invalid type names in ${fetchConfigPath}: ${invalidIncludedTypes} does not match any of the supported types.`)
   }
 }
+
+/**
+ * Verify defaultMissingUserFallback value in deployConfig is valid
+ */
+export const validateDeployConfig = (
+  deployConfigPath: string,
+  userDeployConfig: UserDeployConfig,
+  userValidationFunc: (userValue: string) => boolean
+): void => {
+  const { defaultMissingUserFallback } = userDeployConfig
+  if (defaultMissingUserFallback !== undefined && defaultMissingUserFallback !== DEPLOYER_FALLBACK_VALUE) {
+    const isValidUserValue = userValidationFunc(defaultMissingUserFallback)
+    if (!isValidUserValue) {
+      throw Error(`Invalid user value in ${deployConfigPath}.defaultMissingUserFallback: ${defaultMissingUserFallback}. Value can be either ${DEPLOYER_FALLBACK_VALUE} or a valid user name`)
+    }
+  }
+}

--- a/packages/adapter-components/test/config/shared.test.ts
+++ b/packages/adapter-components/test/config/shared.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { createUserDeployConfigType, createUserFetchConfigType, getConfigWithDefault } from '../../src/config'
+import { createUserDeployConfigType, createUserFetchConfigType, getConfigWithDefault, validateDeployConfig } from '../../src/config'
 
 describe('config_shared', () => {
   describe('createUserFetchConfigType', () => {
@@ -52,6 +52,23 @@ describe('config_shared', () => {
         undefined,
         { idFields: ['a', 'b'], standaloneFields: [{ fieldName: 'default' }] },
       )).toEqual({ idFields: ['a', 'b'], standaloneFields: [{ fieldName: 'default' }] })
+    })
+  })
+  describe('validateDeployConfig', () => {
+    it('should not throw if defaultMissingUserFallback is ##DEPLOYER##', () => {
+      expect(() => validateDeployConfig(
+        'deploy',
+        { defaultMissingUserFallback: '##DEPLOYER##' },
+        (): boolean => true,
+      )).not.toThrow()
+    })
+
+    it('should throw if validateUserFunc returns false', async () => {
+      expect(() => validateDeployConfig(
+        'deploy',
+        { defaultMissingUserFallback: 'invalid@user.name' },
+        (): boolean => false,
+      )).toThrow(new Error('Invalid user value in deploy.defaultMissingUserFallback: invalid@user.name. Value can be either ##DEPLOYER## or a valid user name'))
     })
   })
 })

--- a/packages/zendesk-adapter/config_doc.md
+++ b/packages/zendesk-adapter/config_doc.md
@@ -80,4 +80,4 @@ zendesk {
 
 | Name                                                          | Default when undefined   | Description
 |---------------------------------------------------------------|--------------------------|------------
-| [defaultMissingUserFallback]                                  | ""                       | Configure replacement for missing users during deploy, can be user email or ##DEPLOYER## to fallback o deployer's user 
+| [defaultMissingUserFallback]                                  | ""                       | Configure replacement for missing users during deploy, can be user email or ##DEPLOYER## to fallback to deployer's user 

--- a/packages/zendesk-adapter/config_doc.md
+++ b/packages/zendesk-adapter/config_doc.md
@@ -27,6 +27,9 @@ zendesk {
       brands = [".*"]
     }
   }
+  deploy = {
+    defaultMissingUserFallback = "##DEPLOYER##"
+  }
 }
 ```
 
@@ -72,3 +75,9 @@ zendesk {
 | Name                                        | Default when undefined            | Description
 |---------------------------------------------|-----------------------------------|------------
 | type                                        | ""                                | A regex of the Salto type name to include in the entry
+
+### Deploy configuration options
+
+| Name                                                          | Default when undefined   | Description
+|---------------------------------------------------------------|--------------------------|------------
+| [defaultMissingUserFallback]                                  | ""                       | Configure replacement for missing users during deploy, can be user email or ##DEPLOYER## to fallback o deployer's user 

--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -36,7 +36,7 @@ import {
   ZendeskConfig,
   CLIENT_CONFIG,
   GUIDE_TYPES_TO_HANDLE_BY_BRAND,
-  GUIDE_BRAND_SPECIFIC_TYPES, GUIDE_SUPPORTED_TYPES, isGuideEnabled,
+  GUIDE_BRAND_SPECIFIC_TYPES, GUIDE_SUPPORTED_TYPES, isGuideEnabled, DEPLOY_CONFIG,
 } from './config'
 import {
   ZENDESK,
@@ -452,6 +452,7 @@ export default class ZendeskAdapter implements AdapterOperations {
           paginator: paginator ?? this.paginator,
           config: {
             fetch: config.fetch,
+            deploy: config.deploy,
             apiDefinitions: config.apiDefinitions,
           },
           getElemIdFunc,
@@ -694,6 +695,7 @@ export default class ZendeskAdapter implements AdapterOperations {
       changeValidator: createChangeValidator({
         client: this.client,
         apiConfig: this.userConfig[API_DEFINITIONS_CONFIG],
+        deployConfig: this.userConfig[DEPLOY_CONFIG],
         typesDeployedViaParent: ['organization_field__custom_field_options', 'macro_attachment', BRAND_LOGO_TYPE_NAME],
         // article_attachment additions supported in a filter
         typesWithNoDeploy: ['tag', ARTICLE_ATTACHMENT_TYPE_NAME, ...GUIDE_ORDER_TYPES, DEFAULT_CUSTOM_STATUSES_TYPE_NAME],

--- a/packages/zendesk-adapter/src/adapter_creator.ts
+++ b/packages/zendesk-adapter/src/adapter_creator.ts
@@ -29,6 +29,7 @@ import {
   ZendeskFetchConfig,
   validateGuideTypesConfig,
   GUIDE_SUPPORTED_TYPES,
+  DEPLOY_CONFIG,
 } from './config'
 import ZendeskClient from './client/client'
 import { createConnection, instanceUrl } from './client/connection'
@@ -36,7 +37,7 @@ import { configCreator } from './config_creator'
 
 const log = logger(module)
 const { validateCredentials, validateClientConfig } = clientUtils
-const { validateDuckTypeApiDefinitionConfig } = configUtils
+const { validateDuckTypeApiDefinitionConfig, validateDeployConfig } = configUtils
 
 /*
 
@@ -59,6 +60,7 @@ see https://support.zendesk.com/hc/en-us/articles/4408845965210 for more informa
 
 */
 
+const EMAIL_REGEX = /^[\w+]+([.-]?[\w+]+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/
 const credentialsFromConfig = (config: Readonly<InstanceElement>): Credentials => {
   const domain = config.value.domain === undefined || config.value.domain === ''
     ? undefined
@@ -88,6 +90,8 @@ const createOAuthRequest = (userInput: InstanceElement): OAuthRequestParameters 
   oauthRequiredFields: ['access_token'],
 })
 
+const isValidUser = (user: string): boolean => (EMAIL_REGEX.test(user))
+
 const adapterConfigFromConfig = (config: Readonly<InstanceElement> | undefined): ZendeskConfig => {
   const configValue = config?.value ?? {}
   const isGuideDisabled = config?.value.fetch.guide === undefined
@@ -115,6 +119,9 @@ const adapterConfigFromConfig = (config: Readonly<InstanceElement> | undefined):
   validateFetchConfig(FETCH_CONFIG, adapterConfig.fetch, apiDefinitions)
   validateDuckTypeApiDefinitionConfig(API_DEFINITIONS_CONFIG, apiDefinitions)
   validateGuideTypesConfig(apiDefinitions)
+  if (adapterConfig.deploy !== undefined) {
+    validateDeployConfig(DEPLOY_CONFIG, adapterConfig.deploy, isValidUser)
+  }
 
   Object.keys(configValue)
     .filter(k => !Object.keys(adapterConfig).includes(k))

--- a/packages/zendesk-adapter/src/adapter_creator.ts
+++ b/packages/zendesk-adapter/src/adapter_creator.ts
@@ -29,7 +29,6 @@ import {
   ZendeskFetchConfig,
   validateGuideTypesConfig,
   GUIDE_SUPPORTED_TYPES,
-  ZedneskDeployConfig,
 } from './config'
 import ZendeskClient from './client/client'
 import { createConnection, instanceUrl } from './client/connection'
@@ -105,15 +104,10 @@ const adapterConfigFromConfig = (config: Readonly<InstanceElement> | undefined):
     config?.value.fetch
   ) as ZendeskFetchConfig
 
-  const deploy = configUtils.mergeWithDefaultConfig(
-    DEFAULT_CONFIG.deploy,
-    config?.value.deploy,
-  ) as ZedneskDeployConfig
-
   const adapterConfig: { [K in keyof Required<ZendeskConfig>]: ZendeskConfig[K] } = {
     client: configValue.client,
     fetch,
-    deploy,
+    deploy: configValue.deploy,
     apiDefinitions,
   }
 

--- a/packages/zendesk-adapter/src/adapter_creator.ts
+++ b/packages/zendesk-adapter/src/adapter_creator.ts
@@ -29,6 +29,7 @@ import {
   ZendeskFetchConfig,
   validateGuideTypesConfig,
   GUIDE_SUPPORTED_TYPES,
+  ZedneskDeployConfig,
 } from './config'
 import ZendeskClient from './client/client'
 import { createConnection, instanceUrl } from './client/connection'
@@ -104,9 +105,15 @@ const adapterConfigFromConfig = (config: Readonly<InstanceElement> | undefined):
     config?.value.fetch
   ) as ZendeskFetchConfig
 
+  const deploy = configUtils.mergeWithDefaultConfig(
+    DEFAULT_CONFIG.deploy,
+    config?.value.deploy,
+  ) as ZedneskDeployConfig
+
   const adapterConfig: { [K in keyof Required<ZendeskConfig>]: ZendeskConfig[K] } = {
     client: configValue.client,
     fetch,
+    deploy,
     apiDefinitions,
   }
 

--- a/packages/zendesk-adapter/src/change_validator.ts
+++ b/packages/zendesk-adapter/src/change_validator.ts
@@ -61,6 +61,7 @@ import {
   customStatusActiveDefaultValidator, defaultGroupChangeValidator,
 } from './change_validators'
 import ZendeskClient from './client/client'
+import { ZedneskDeployConfig } from './config'
 
 const {
   deployTypesNotSupportedValidator,
@@ -72,11 +73,13 @@ const {
 export default ({
   client,
   apiConfig,
+  deployConfig,
   typesDeployedViaParent,
   typesWithNoDeploy,
 }: {
   client: ZendeskClient
   apiConfig: configUtils.AdapterDuckTypeApiConfig
+  deployConfig: ZedneskDeployConfig
   typesDeployedViaParent: string[]
   typesWithNoDeploy: string[]
 }): ChangeValidator => {
@@ -113,7 +116,7 @@ export default ({
     defaultCustomStatusesValidator,
     customRoleRemovalValidator(client),
     sideConversationsValidator,
-    missingUsersValidator(client),
+    missingUsersValidator(client, deployConfig),
     requiredAppOwnedParametersValidator,
     oneTranslationPerLocaleValidator,
     articleRemovalValidator,

--- a/packages/zendesk-adapter/src/change_validator.ts
+++ b/packages/zendesk-adapter/src/change_validator.ts
@@ -79,7 +79,7 @@ export default ({
 }: {
   client: ZendeskClient
   apiConfig: configUtils.AdapterDuckTypeApiConfig
-  deployConfig: ZedneskDeployConfig
+  deployConfig?: ZedneskDeployConfig
   typesDeployedViaParent: string[]
   typesWithNoDeploy: string[]
 }): ChangeValidator => {

--- a/packages/zendesk-adapter/src/change_validators/missing_users.ts
+++ b/packages/zendesk-adapter/src/change_validators/missing_users.ts
@@ -86,7 +86,7 @@ const getFallbackUserIsMissingError = (
     elemID: instance.elemID,
     severity: 'Error',
     message: MISSING_USERS_ERROR_MSG,
-    detailedMessage: `The following users are referenced by this element, but do not exist in the target environment: ${missingUsers}.\nIn addition, the defined fallback user ${userFallbackValue} was not found in the target environment. In order to deploy this element, add these users to your target environment, edit this element to use valid usernames, or set the target environment's user fallback options. Learn more: ${MISSING_USERS_DOC_LINK}`,
+    detailedMessage: `The following users are referenced by this element, but do not exist in the target environment: ${missingUsers.join(', ')}.\nIn addition, the defined fallback user ${userFallbackValue} was not found in the target environment. In order to deploy this element, add these users to your target environment, edit this element to use valid usernames, or set the target environment's user fallback options. Learn more: ${MISSING_USERS_DOC_LINK}`,
   }
 }
 

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -2600,6 +2600,7 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
       `${FETCH_CONFIG}.hideTypes`,
       `${FETCH_CONFIG}.enableMissingReferences`,
       `${FETCH_CONFIG}.guide`,
+      DEPLOY_CONFIG,
     ),
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -29,6 +29,7 @@ import {
 const { createClientConfigType } = clientUtils
 const {
   createUserFetchConfigType,
+  createUserDeployConfigType,
   createDucktypeAdapterApiConfigType,
   validateDuckTypeFetchConfig,
 } = configUtils
@@ -56,6 +57,7 @@ export const CURSOR_BASED_PAGINATION_FIELD = 'links.next'
 
 export const CLIENT_CONFIG = 'client'
 export const FETCH_CONFIG = 'fetch'
+export const DEPLOY_CONFIG = 'deploy'
 
 export const API_DEFINITIONS_CONFIG = 'apiDefinitions'
 
@@ -78,6 +80,7 @@ export type ZendeskFetchConfig = configUtils.UserFetchConfig
   appReferenceLocators?: IdLocator[]
   guide?: Guide
 }
+export type ZedneskDeployConfig = configUtils.UserDeployConfig
 export type ZendeskApiConfig = configUtils.AdapterApiConfig<
   configUtils.DuckTypeTransformationConfig & { omitInactive?: boolean }
   >
@@ -85,6 +88,7 @@ export type ZendeskApiConfig = configUtils.AdapterApiConfig<
 export type ZendeskConfig = {
   [CLIENT_CONFIG]?: ZendeskClientConfig
   [FETCH_CONFIG]: ZendeskFetchConfig
+  [DEPLOY_CONFIG]: ZedneskDeployConfig
   [API_DEFINITIONS_CONFIG]: ZendeskApiConfig
 }
 
@@ -2505,6 +2509,9 @@ export const DEFAULT_CONFIG: ZendeskConfig = {
     hideTypes: true,
     enableMissingReferences: true,
   },
+  [DEPLOY_CONFIG]: {
+    fallbackToDeployerOnMissingUsers: true,
+  },
   [API_DEFINITIONS_CONFIG]: {
     typeDefaults: {
       request: {
@@ -2582,6 +2589,9 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
         },
       ),
     },
+    [DEPLOY_CONFIG]: {
+      refType: createUserDeployConfigType(ZENDESK),
+    },
     [API_DEFINITIONS_CONFIG]: {
       refType: createDucktypeAdapterApiConfigType({ adapter: ZENDESK }),
     },
@@ -2600,6 +2610,7 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
 
 export type FilterContext = {
   [FETCH_CONFIG]: ZendeskFetchConfig
+  [DEPLOY_CONFIG]: ZedneskDeployConfig
   [API_DEFINITIONS_CONFIG]: ZendeskApiConfig
 }
 

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -88,7 +88,7 @@ export type ZendeskApiConfig = configUtils.AdapterApiConfig<
 export type ZendeskConfig = {
   [CLIENT_CONFIG]?: ZendeskClientConfig
   [FETCH_CONFIG]: ZendeskFetchConfig
-  [DEPLOY_CONFIG]: ZedneskDeployConfig
+  [DEPLOY_CONFIG]?: ZedneskDeployConfig
   [API_DEFINITIONS_CONFIG]: ZendeskApiConfig
 }
 
@@ -2509,9 +2509,6 @@ export const DEFAULT_CONFIG: ZendeskConfig = {
     hideTypes: true,
     enableMissingReferences: true,
   },
-  [DEPLOY_CONFIG]: {
-    fallbackToDeployerOnMissingUsers: true,
-  },
   [API_DEFINITIONS_CONFIG]: {
     typeDefaults: {
       request: {
@@ -2610,7 +2607,7 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
 
 export type FilterContext = {
   [FETCH_CONFIG]: ZendeskFetchConfig
-  [DEPLOY_CONFIG]: ZedneskDeployConfig
+  [DEPLOY_CONFIG]?: ZedneskDeployConfig
   [API_DEFINITIONS_CONFIG]: ZendeskApiConfig
 }
 

--- a/packages/zendesk-adapter/src/filters/user.ts
+++ b/packages/zendesk-adapter/src/filters/user.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
+import { logger } from '@salto-io/logging'
 import { resolvePath, setPath } from '@salto-io/adapter-utils'
 import { Change, getChangeData, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
 import { client as clientUtils } from '@salto-io/adapter-components'
@@ -23,6 +24,7 @@ import { deployModificationFunc } from '../replacers_utils'
 import { paginate } from '../client/pagination'
 import { DEPLOY_CONFIG } from '../config'
 
+const log = logger(module)
 const { createPaginator } = clientUtils
 
 const isRelevantChange = (change: Change<InstanceElement>): boolean => (
@@ -55,6 +57,10 @@ const filterCreator: FilterCreator = ({ client, config }) => {
   return {
     name: 'usersFilter',
     onFetch: async elements => {
+      const paginator = createPaginator({
+        client,
+        paginationFuncCreator: paginate,
+      })
       const users = await getUsers(paginator)
       if (_.isEmpty(users)) {
         return

--- a/packages/zendesk-adapter/src/filters/user.ts
+++ b/packages/zendesk-adapter/src/filters/user.ts
@@ -84,13 +84,17 @@ const filterCreator: FilterCreator = ({ client, config }) => {
       const { defaultMissingUserFallback } = config[DEPLOY_CONFIG] ?? {}
       if (defaultMissingUserFallback !== undefined) {
         const userEmails = new Set(users.map(user => user.email))
-        const { fallbackValue } = await getUserFallbackValue(
-          defaultMissingUserFallback,
-          userEmails,
-          client
-        )
-        if (fallbackValue !== undefined) {
-          replaceMissingUsers(relevantChanges, userEmails, fallbackValue)
+        try {
+          const fallbackValue = await getUserFallbackValue(
+            defaultMissingUserFallback,
+            userEmails,
+            client
+          )
+          if (fallbackValue !== undefined) {
+            replaceMissingUsers(relevantChanges, userEmails, fallbackValue)
+          }
+        } catch (e) {
+          log.error('Error while trying to get defaultMissingUserFallback value')
         }
       }
 

--- a/packages/zendesk-adapter/src/filters/user.ts
+++ b/packages/zendesk-adapter/src/filters/user.ts
@@ -80,14 +80,18 @@ const filterCreator: FilterCreator = ({ client, config }) => {
       if (_.isEmpty(users)) {
         return
       }
-      const userEmails = new Set(users.map(user => user.email))
-      const { value } = await getUserFallbackValue(
-        config[DEPLOY_CONFIG],
-        userEmails,
-        client
-      )
-      if (value !== undefined) {
-        replaceMissingUsers(relevantChanges, userEmails, value)
+
+      const { defaultMissingUserFallback } = config[DEPLOY_CONFIG] ?? {}
+      if (defaultMissingUserFallback !== undefined) {
+        const userEmails = new Set(users.map(user => user.email))
+        const { fallbackValue } = await getUserFallbackValue(
+          defaultMissingUserFallback,
+          userEmails,
+          client
+        )
+        if (fallbackValue !== undefined) {
+          replaceMissingUsers(relevantChanges, userEmails, fallbackValue)
+        }
       }
 
       userIdToEmail = Object.fromEntries(

--- a/packages/zendesk-adapter/src/filters/user.ts
+++ b/packages/zendesk-adapter/src/filters/user.ts
@@ -14,20 +14,43 @@
 * limitations under the License.
 */
 import _ from 'lodash'
+import { resolvePath, setPath } from '@salto-io/adapter-utils'
 import { Change, getChangeData, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
+import { client as clientUtils } from '@salto-io/adapter-components'
 import { FilterCreator } from '../filter'
-import { getUsers, TYPE_NAME_TO_REPLACER } from '../user_utils'
+import { getUsers, TYPE_NAME_TO_REPLACER, User, VALID_USER_VALUES, getUserFallbackValue } from '../user_utils'
 import { deployModificationFunc } from '../replacers_utils'
+import { DEPLOY_CONFIG } from '../config'
+import { paginate } from '../client/pagination'
 
+const { createPaginator } = clientUtils
 
 const isRelevantChange = (change: Change<InstanceElement>): boolean => (
   Object.keys(TYPE_NAME_TO_REPLACER).includes(getChangeData(change).elemID.typeName)
 )
 
+// Replace missing user values with user fallback value provided in deploy config
+const replaceMissingUsers = (
+  changes: Change<InstanceElement>[],
+  users: User[],
+  fallbackUser: string
+): void => {
+  const instances = changes.map(change => getChangeData(change))
+  instances.forEach(instance => {
+    const userPaths = TYPE_NAME_TO_REPLACER[instance.elemID.typeName]?.(instance)
+    userPaths.forEach(path => {
+      const userValue = resolvePath(instance, path)
+      if (!VALID_USER_VALUES.includes(userValue) && !users.includes(userValue)) {
+        setPath(instance, path, fallbackUser)
+      }
+    })
+  })
+}
+
 /**
  * Replaces the user ids with emails
  */
-const filterCreator: FilterCreator = ({ paginator }) => {
+const filterCreator: FilterCreator = ({ client, config }) => {
   let userIdToEmail: Record<string, string> = {}
   return {
     name: 'usersFilter',
@@ -49,10 +72,24 @@ const filterCreator: FilterCreator = ({ paginator }) => {
       if (_.isEmpty(relevantChanges)) {
         return
       }
+      const paginator = createPaginator({
+        client,
+        paginationFuncCreator: paginate,
+      })
       const users = await getUsers(paginator)
       if (_.isEmpty(users)) {
         return
       }
+
+      const { value } = await getUserFallbackValue(
+        config[DEPLOY_CONFIG],
+        new Set(users.map(user => user.email)),
+        client
+      )
+      if (value !== undefined) {
+        replaceMissingUsers(relevantChanges, users, value)
+      }
+
       userIdToEmail = Object.fromEntries(
         users.map(user => [user.id.toString(), user.email])
       ) as Record<string, string>

--- a/packages/zendesk-adapter/src/filters/user.ts
+++ b/packages/zendesk-adapter/src/filters/user.ts
@@ -96,9 +96,7 @@ const filterCreator: FilterCreator = ({ client, config }) => {
             userEmails,
             client
           )
-          if (fallbackValue !== undefined) {
-            replaceMissingUsers(relevantChanges, userEmails, fallbackValue)
-          }
+          replaceMissingUsers(relevantChanges, userEmails, fallbackValue)
         } catch (e) {
           log.error('Error while trying to get defaultMissingUserFallback value')
         }

--- a/packages/zendesk-adapter/src/user_utils.ts
+++ b/packages/zendesk-adapter/src/user_utils.ts
@@ -16,10 +16,10 @@
 import _ from 'lodash'
 import Joi from 'joi'
 import { logger } from '@salto-io/logging'
-import { client as clientUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, config as configUtils } from '@salto-io/adapter-components'
 import { collections } from '@salto-io/lowerdash'
 import { createSchemeGuard } from '@salto-io/adapter-utils'
-import { ElemID, InstanceElement, Values } from '@salto-io/adapter-api'
+import { Values } from '@salto-io/adapter-api'
 import ZendeskClient from './client/client'
 import { ValueReplacer, replaceConditionsAndActionsCreator, fieldReplacer } from './replacers_utils'
 
@@ -27,7 +27,6 @@ const log = logger(module)
 const { toArrayAsync } = collections.asynciterable
 const { makeArray } = collections.array
 
-const DEPLOYER_FALLBACK_VALUE = '##DEPLOYER##'
 // system options that does not contain a specific user value
 export const VALID_USER_VALUES = ['current_user', 'all_agents', 'requester_id', 'assignee_id', 'requester_and_ccs', 'agent', 'end_user', '']
 
@@ -41,13 +40,6 @@ type User = {
 
 type CurrentUserResponse = {
   user: User
-}
-
-type UserReplacer = (instance: InstanceElement, mapping?: Record<string, string>) => ElemID[]
-
-type UserFieldsParams = {
-  fieldName: string[]
-  fieldsToReplace: { name: string; valuePath?: string[] }[]
 }
 
 const EXPECTED_USER_SCHEMA = Joi.object({
@@ -205,7 +197,7 @@ export const getUserFallbackValue = async (
   existingUsers: Set<string>,
   client: ZendeskClient
 ): Promise<{fallbackValue: string | undefined; isValidValue: boolean}> => {
-  if (defaultMissingUserFallback === DEPLOYER_FALLBACK_VALUE) {
+  if (defaultMissingUserFallback === configUtils.DEPLOYER_FALLBACK_VALUE) {
     try {
       const response = (await client.getSinglePage({
         url: '/api/v2/users/me',

--- a/packages/zendesk-adapter/src/user_utils.ts
+++ b/packages/zendesk-adapter/src/user_utils.ts
@@ -28,7 +28,7 @@ const { toArrayAsync } = collections.asynciterable
 const { makeArray } = collections.array
 
 const MISSING_DEPLOY_CONFIG_USER = 'User provided in defaultMissingUserFallback does not exist in the target environemt'
-// system options that does not contain a specific user value
+// system options that do not contain a specific user value
 export const VALID_USER_VALUES = ['current_user', 'all_agents', 'requester_id', 'assignee_id', 'requester_and_ccs', 'agent', 'end_user', '']
 
 type User = {
@@ -197,7 +197,7 @@ export const getUserFallbackValue = async (
   defaultMissingUserFallback: string,
   existingUsers: Set<string>,
   client: ZendeskClient
-): Promise<string | undefined> => {
+): Promise<string> => {
   if (defaultMissingUserFallback === configUtils.DEPLOYER_FALLBACK_VALUE) {
     try {
       const response = (await client.getSinglePage({
@@ -206,7 +206,8 @@ export const getUserFallbackValue = async (
       if (isCurrentUserResponse(response)) {
         return response.user.email
       }
-      return undefined
+      log.error('Received invalid response from endpoint \'/api/v2/users/me\'')
+      throw new Error('Received invalid user response')
     } catch (e) {
       log.error('Attempt to get current user details has failed with error: %o', e)
       throw new Error('Failed to get current user from endpoint \'/api/v2/users/me\'')

--- a/packages/zendesk-adapter/src/user_utils.ts
+++ b/packages/zendesk-adapter/src/user_utils.ts
@@ -31,7 +31,7 @@ const { makeArray } = collections.array
 // system options that does not contain a specific user value
 export const VALID_USER_VALUES = ['current_user', 'all_agents', 'requester_id', 'assignee_id', 'requester_and_ccs', 'agent', 'end_user', '']
 
-export type User = {
+type User = {
   id: number
   email: string
   role: string

--- a/packages/zendesk-adapter/test/adapter_creator.test.ts
+++ b/packages/zendesk-adapter/test/adapter_creator.test.ts
@@ -142,7 +142,7 @@ describe('adapter creator', () => {
     })).toBeDefined()
   })
 
-  it('should throw error on inconsistent configuration between fetch and apiDefinitions', () => {
+  it('should throw error when deploy config is invalid', () => {
     expect(() => adapter.operations({
       credentials: new InstanceElement(ZENDESK,
         adapter.authenticationMethods.basic.credentialsType),
@@ -180,10 +180,10 @@ describe('adapter creator', () => {
         },
       ),
       elementsSource: buildElementsSourceFromElements([]),
-    })).toThrow(new Error('Invalid user value in deploy.defaultMissingUserFallback: invalid@user. Value can be either ##DEPLOYER## or a valid user name'))
+    })).toThrow(new Error('Invalid user value in deploy.defaultMissingUserFallback: #DEPLOYER#. Value can be either ##DEPLOYER## or a valid user name'))
   })
 
-  it('should throw error when deploy config is invalid', () => {
+  it('should throw error on inconsistent configuration between fetch and apiDefinitions', () => {
     expect(() => adapter.operations({
       credentials: new InstanceElement(ZENDESK,
         adapter.authenticationMethods.basic.credentialsType),

--- a/packages/zendesk-adapter/test/adapter_creator.test.ts
+++ b/packages/zendesk-adapter/test/adapter_creator.test.ts
@@ -150,6 +150,47 @@ describe('adapter creator', () => {
         ZENDESK,
         adapter.configType as ObjectType,
         {
+          fetch: { include: [{ type: '.*' }], exclude: [] },
+          apiDefinitions: {
+            types: { c: { request: { url: '/api/v2/c' } } },
+            supportedTypes: { c: ['c'] },
+          },
+          deploy: {
+            defaultMissingUserFallback: 'invalid@user',
+          },
+        },
+      ),
+      elementsSource: buildElementsSourceFromElements([]),
+    })).toThrow(new Error('Invalid user value in deploy.defaultMissingUserFallback: invalid@user. Value can be either ##DEPLOYER## or a valid user name'))
+    expect(() => adapter.operations({
+      credentials: new InstanceElement(ZENDESK,
+        adapter.authenticationMethods.basic.credentialsType),
+      config: new InstanceElement(
+        ZENDESK,
+        adapter.configType as ObjectType,
+        {
+          fetch: { include: [{ type: '.*' }], exclude: [] },
+          apiDefinitions: {
+            types: { c: { request: { url: '/api/v2/c' } } },
+            supportedTypes: { c: ['c'] },
+          },
+          deploy: {
+            defaultMissingUserFallback: '#DEPLOYER#',
+          },
+        },
+      ),
+      elementsSource: buildElementsSourceFromElements([]),
+    })).toThrow(new Error('Invalid user value in deploy.defaultMissingUserFallback: invalid@user. Value can be either ##DEPLOYER## or a valid user name'))
+  })
+
+  it('should throw error when deploy config is invalid', () => {
+    expect(() => adapter.operations({
+      credentials: new InstanceElement(ZENDESK,
+        adapter.authenticationMethods.basic.credentialsType),
+      config: new InstanceElement(
+        ZENDESK,
+        adapter.configType as ObjectType,
+        {
           fetch: {
             include: [
               { type: 'a' },

--- a/packages/zendesk-adapter/test/change_validator.test.ts
+++ b/packages/zendesk-adapter/test/change_validator.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { toChange, ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
-import { API_DEFINITIONS_CONFIG, DEFAULT_CONFIG } from '../src/config'
+import { API_DEFINITIONS_CONFIG, DEFAULT_CONFIG, DEPLOY_CONFIG } from '../src/config'
 import createChangeValidator from '../src/change_validator'
 import { ZENDESK } from '../src/constants'
 import ZendeskClient from '../src/client/client'
@@ -26,6 +26,7 @@ describe('change validator creator', () => {
       expect(await createChangeValidator({
         client,
         apiConfig: DEFAULT_CONFIG[API_DEFINITIONS_CONFIG],
+        deployConfig: DEFAULT_CONFIG[DEPLOY_CONFIG],
         typesDeployedViaParent: [],
         typesWithNoDeploy: [],
       })([]))
@@ -36,6 +37,7 @@ describe('change validator creator', () => {
       expect(await createChangeValidator({
         client,
         apiConfig: DEFAULT_CONFIG[API_DEFINITIONS_CONFIG],
+        deployConfig: DEFAULT_CONFIG[DEPLOY_CONFIG],
         typesDeployedViaParent: [],
         typesWithNoDeploy: [],
       })([
@@ -63,6 +65,7 @@ describe('change validator creator', () => {
       expect(await createChangeValidator({
         client,
         apiConfig: DEFAULT_CONFIG[API_DEFINITIONS_CONFIG],
+        deployConfig: DEFAULT_CONFIG[DEPLOY_CONFIG],
         typesDeployedViaParent: [],
         typesWithNoDeploy: [],
       })([

--- a/packages/zendesk-adapter/test/change_validators/missing_users.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/missing_users.test.ts
@@ -17,10 +17,12 @@ import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter
 import { ZENDESK, ARTICLE_TYPE_NAME } from '../../src/constants'
 import { missingUsersValidator } from '../../src/change_validators/missing_users'
 import ZendeskClient from '../../src/client/client'
+import { ZedneskDeployConfig } from '../../src/config'
 
 describe('missingUsersValidator', () => {
   let client: ZendeskClient
   let mockGet: jest.SpyInstance
+  let deployConfig: ZedneskDeployConfig
   const articleType = new ObjectType({
     elemID: new ElemID(ZENDESK, ARTICLE_TYPE_NAME),
   })
@@ -57,6 +59,7 @@ describe('missingUsersValidator', () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
+    deployConfig = {}
     mockGet = jest.spyOn(client, 'getSinglePage')
     mockGet.mockImplementation(() => (
       {
@@ -76,7 +79,7 @@ describe('missingUsersValidator', () => {
 
   it('should return a warning if user in user field does not exist', async () => {
     const changes = [toChange({ after: articleInstance }), toChange({ after: macroInstance })]
-    const changeValidator = missingUsersValidator(client)
+    const changeValidator = missingUsersValidator(client, deployConfig)
     const errors = await changeValidator(changes)
     expect(errors).toHaveLength(2)
     expect(errors).toEqual([
@@ -101,7 +104,7 @@ describe('missingUsersValidator', () => {
       { author_id: '1@1', draft: false },
     )
     const changes = [toChange({ after: articleWithValidUser })]
-    const changeValidator = missingUsersValidator(client)
+    const changeValidator = missingUsersValidator(client, deployConfig)
     const errors = await changeValidator(changes)
     expect(errors).toHaveLength(0)
   })
@@ -144,7 +147,7 @@ describe('missingUsersValidator', () => {
       }
     )
     const changes = [toChange({ after: macroWithValidUserFields }), toChange({ after: triggerInstance })]
-    const changeValidator = missingUsersValidator(client)
+    const changeValidator = missingUsersValidator(client, deployConfig)
     const errors = await changeValidator(changes)
     expect(errors).toHaveLength(0)
   })

--- a/packages/zendesk-adapter/test/change_validators/missing_users.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/missing_users.test.ts
@@ -87,13 +87,13 @@ describe('missingUsersValidator', () => {
         elemID: articleInstance.elemID,
         severity: 'Error',
         message: 'Element references users which don\'t exist in target environment',
-        detailedMessage: 'The following users are referenced by this element, but do not exist in the target environment: article@salto.com.\nIn order to deploy this element, add these users to your target environment, edit this element to use valid usernames, or set the target environment\'s user fallback options. Learn more: https://docs.salto.io/docs/username-not-found-in-target-environment',
+        detailedMessage: 'The following users are referenced by this element, but do not exist in the target environment: article@salto.com.\nIn order to deploy this element, add these users to your target environment, edit this element to use valid usernames, or set the target environment\'s user fallback options. Learn more: https://help.salto.io/en/articles/6955302-element-references-users-which-don-t-exist-in-target-environment-zendesk',
       },
       {
         elemID: macroInstance.elemID,
         severity: 'Error',
         message: 'Element references users which don\'t exist in target environment',
-        detailedMessage: 'The following users are referenced by this element, but do not exist in the target environment: thisuserismissing@salto.com, thisuserismissing2@salto.com.\nIn order to deploy this element, add these users to your target environment, edit this element to use valid usernames, or set the target environment\'s user fallback options. Learn more: https://docs.salto.io/docs/username-not-found-in-target-environment',
+        detailedMessage: 'The following users are referenced by this element, but do not exist in the target environment: thisuserismissing@salto.com, thisuserismissing2@salto.com.\nIn order to deploy this element, add these users to your target environment, edit this element to use valid usernames, or set the target environment\'s user fallback options. Learn more: https://help.salto.io/en/articles/6955302-element-references-users-which-don-t-exist-in-target-environment-zendesk',
       },
     ])
   })
@@ -108,13 +108,13 @@ describe('missingUsersValidator', () => {
         elemID: articleInstance.elemID,
         severity: 'Warning',
         message: '1 usernames will be overridden to 4@4',
-        detailedMessage: 'The following users are referenced by this element, but do not exist in the target environment: article@salto.com.\nIf you continue, they will be set to 4@4 according to the environment\'s user fallback options. Learn more: https://docs.salto.io/docs/username-not-found-in-target-environment',
+        detailedMessage: 'The following users are referenced by this element, but do not exist in the target environment: article@salto.com.\nIf you continue, they will be set to 4@4 according to the environment\'s user fallback options. Learn more: https://help.salto.io/en/articles/6955302-element-references-users-which-don-t-exist-in-target-environment-zendesk',
       },
       {
         elemID: macroInstance.elemID,
         severity: 'Warning',
         message: '2 usernames will be overridden to 4@4',
-        detailedMessage: 'The following users are referenced by this element, but do not exist in the target environment: thisuserismissing@salto.com, thisuserismissing2@salto.com.\nIf you continue, they will be set to 4@4 according to the environment\'s user fallback options. Learn more: https://docs.salto.io/docs/username-not-found-in-target-environment',
+        detailedMessage: 'The following users are referenced by this element, but do not exist in the target environment: thisuserismissing@salto.com, thisuserismissing2@salto.com.\nIf you continue, they will be set to 4@4 according to the environment\'s user fallback options. Learn more: https://help.salto.io/en/articles/6955302-element-references-users-which-don-t-exist-in-target-environment-zendesk',
       },
     ])
   })
@@ -129,13 +129,36 @@ describe('missingUsersValidator', () => {
         elemID: articleInstance.elemID,
         severity: 'Error',
         message: 'Element references users which don\'t exist in target environment',
-        detailedMessage: 'The following users are referenced by this element, but do not exist in the target environment: article@salto.com.\nIn addition, the defined fallback user 9@9 was not found in the target environment. In order to deploy this element, add these users to your target environment, edit this element to use valid usernames, or set the target environment\'s user fallback options. Learn more: https://docs.salto.io/docs/username-not-found-in-target-environment',
+        detailedMessage: 'The following users are referenced by this element, but do not exist in the target environment: article@salto.com.\nIn addition, we could not get the defined fallback user 9@9. In order to deploy this element, add these users to your target environment, edit this element to use valid usernames, or set the target environment\'s user fallback options. Learn more: https://help.salto.io/en/articles/6955302-element-references-users-which-don-t-exist-in-target-environment-zendesk',
       },
       {
         elemID: macroInstance.elemID,
         severity: 'Error',
         message: 'Element references users which don\'t exist in target environment',
-        detailedMessage: 'The following users are referenced by this element, but do not exist in the target environment: thisuserismissing@salto.com, thisuserismissing2@salto.com.\nIn addition, the defined fallback user 9@9 was not found in the target environment. In order to deploy this element, add these users to your target environment, edit this element to use valid usernames, or set the target environment\'s user fallback options. Learn more: https://docs.salto.io/docs/username-not-found-in-target-environment',
+        detailedMessage: 'The following users are referenced by this element, but do not exist in the target environment: thisuserismissing@salto.com, thisuserismissing2@salto.com.\nIn addition, we could not get the defined fallback user 9@9. In order to deploy this element, add these users to your target environment, edit this element to use valid usernames, or set the target environment\'s user fallback options. Learn more: https://help.salto.io/en/articles/6955302-element-references-users-which-don-t-exist-in-target-environment-zendesk',
+      },
+    ])
+  })
+  it('should return error in case fallback value is to ##DEPLOYER## but we could not get its value', async () => {
+    const changes = [toChange({ after: articleInstance }), toChange({ after: macroInstance })]
+    deployConfig = { defaultMissingUserFallback: '##DEPLOYER##' }
+    jest.clearAllMocks()
+    mockGet.mockRejectedValue({ status: 400, data: {} })
+    const changeValidator = missingUsersValidator(client, deployConfig)
+    const errors = await changeValidator(changes)
+    expect(errors).toHaveLength(2)
+    expect(errors).toEqual([
+      {
+        elemID: articleInstance.elemID,
+        severity: 'Error',
+        message: 'Element references users which don\'t exist in target environment',
+        detailedMessage: 'The following users are referenced by this element, but do not exist in the target environment: article@salto.com.\nIn addition, we could not get the defined fallback user ##DEPLOYER##. In order to deploy this element, add these users to your target environment, edit this element to use valid usernames, or set the target environment\'s user fallback options. Learn more: https://help.salto.io/en/articles/6955302-element-references-users-which-don-t-exist-in-target-environment-zendesk',
+      },
+      {
+        elemID: macroInstance.elemID,
+        severity: 'Error',
+        message: 'Element references users which don\'t exist in target environment',
+        detailedMessage: 'The following users are referenced by this element, but do not exist in the target environment: thisuserismissing@salto.com, thisuserismissing2@salto.com.\nIn addition, we could not get the defined fallback user ##DEPLOYER##. In order to deploy this element, add these users to your target environment, edit this element to use valid usernames, or set the target environment\'s user fallback options. Learn more: https://help.salto.io/en/articles/6955302-element-references-users-which-don-t-exist-in-target-environment-zendesk',
       },
     ])
   })

--- a/packages/zendesk-adapter/test/change_validators/missing_users.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/missing_users.test.ts
@@ -45,7 +45,7 @@ describe('missingUsersValidator', () => {
         },
         {
           field: 'requester_id',
-          value: '1@1',
+          value: '1@salto.io',
         },
       ],
       restriction: {
@@ -66,11 +66,11 @@ describe('missingUsersValidator', () => {
         status: 200,
         data: {
           users: [
-            { id: 1, email: '1@1', role: 'agent', custom_role_id: 123 },
-            { id: 2, email: '2@2', role: 'agent', custom_role_id: 234 },
-            { id: 3, email: '3@3', role: 'admin', custom_role_id: 234 },
-            { id: 4, email: '4@4', role: 'agent' },
-            { id: 5, email: '5@5', role: 'agent', custom_role_id: 123 },
+            { id: 1, email: '1@salto.io', role: 'agent', custom_role_id: 123 },
+            { id: 2, email: '2@salto.io', role: 'agent', custom_role_id: 234 },
+            { id: 3, email: '3@salto.io', role: 'admin', custom_role_id: 234 },
+            { id: 4, email: '4@salto.io', role: 'agent' },
+            { id: 5, email: '5@salto.io', role: 'agent', custom_role_id: 123 },
           ],
         },
       }
@@ -86,20 +86,20 @@ describe('missingUsersValidator', () => {
       {
         elemID: articleInstance.elemID,
         severity: 'Error',
-        message: 'Element references users which don\'t exist in target environment',
-        detailedMessage: 'The following users are referenced by this element, but do not exist in the target environment: article@salto.com.\nIn order to deploy this element, add these users to your target environment, edit this element to use valid usernames, or set the target environment\'s user fallback options. Learn more: https://help.salto.io/en/articles/6955302-element-references-users-which-don-t-exist-in-target-environment-zendesk',
+        message: 'Instance references users which don\'t exist in target environment',
+        detailedMessage: 'The following users are referenced by this instance, but do not exist in the target environment: article@salto.com.\nIn order to deploy this instance, add these users to your target environment, edit this instance to use valid usernames, or set the target environment\'s user fallback options.\nLearn more: https://help.salto.io/en/articles/6955302-element-references-users-which-don-t-exist-in-target-environment-zendesk',
       },
       {
         elemID: macroInstance.elemID,
         severity: 'Error',
-        message: 'Element references users which don\'t exist in target environment',
-        detailedMessage: 'The following users are referenced by this element, but do not exist in the target environment: thisuserismissing@salto.com, thisuserismissing2@salto.com.\nIn order to deploy this element, add these users to your target environment, edit this element to use valid usernames, or set the target environment\'s user fallback options. Learn more: https://help.salto.io/en/articles/6955302-element-references-users-which-don-t-exist-in-target-environment-zendesk',
+        message: 'Instance references users which don\'t exist in target environment',
+        detailedMessage: 'The following users are referenced by this instance, but do not exist in the target environment: thisuserismissing@salto.com, thisuserismissing2@salto.com.\nIn order to deploy this instance, add these users to your target environment, edit this instance to use valid usernames, or set the target environment\'s user fallback options.\nLearn more: https://help.salto.io/en/articles/6955302-element-references-users-which-don-t-exist-in-target-environment-zendesk',
       },
     ])
   })
   it('should return warning in case of overriding missing users with user from deploy config', async () => {
     const changes = [toChange({ after: articleInstance }), toChange({ after: macroInstance })]
-    deployConfig = { defaultMissingUserFallback: '4@4' }
+    deployConfig = { defaultMissingUserFallback: '4@salto.io' }
     const changeValidator = missingUsersValidator(client, deployConfig)
     const errors = await changeValidator(changes)
     expect(errors).toHaveLength(2)
@@ -107,20 +107,20 @@ describe('missingUsersValidator', () => {
       {
         elemID: articleInstance.elemID,
         severity: 'Warning',
-        message: '1 usernames will be overridden to 4@4',
-        detailedMessage: 'The following users are referenced by this element, but do not exist in the target environment: article@salto.com.\nIf you continue, they will be set to 4@4 according to the environment\'s user fallback options. Learn more: https://help.salto.io/en/articles/6955302-element-references-users-which-don-t-exist-in-target-environment-zendesk',
+        message: '1 usernames will be overridden to 4@salto.io',
+        detailedMessage: 'The following users are referenced by this instance, but do not exist in the target environment: article@salto.com.\nIf you continue, they will be set to 4@salto.io according to the environment\'s user fallback options.\nLearn more: https://help.salto.io/en/articles/6955302-element-references-users-which-don-t-exist-in-target-environment-zendesk',
       },
       {
         elemID: macroInstance.elemID,
         severity: 'Warning',
-        message: '2 usernames will be overridden to 4@4',
-        detailedMessage: 'The following users are referenced by this element, but do not exist in the target environment: thisuserismissing@salto.com, thisuserismissing2@salto.com.\nIf you continue, they will be set to 4@4 according to the environment\'s user fallback options. Learn more: https://help.salto.io/en/articles/6955302-element-references-users-which-don-t-exist-in-target-environment-zendesk',
+        message: '2 usernames will be overridden to 4@salto.io',
+        detailedMessage: 'The following users are referenced by this instance, but do not exist in the target environment: thisuserismissing@salto.com, thisuserismissing2@salto.com.\nIf you continue, they will be set to 4@salto.io according to the environment\'s user fallback options.\nLearn more: https://help.salto.io/en/articles/6955302-element-references-users-which-don-t-exist-in-target-environment-zendesk',
       },
     ])
   })
   it('should return error in case of user provided in deploy config does not exist', async () => {
     const changes = [toChange({ after: articleInstance }), toChange({ after: macroInstance })]
-    deployConfig = { defaultMissingUserFallback: '9@9' }
+    deployConfig = { defaultMissingUserFallback: '9@salto.io' }
     const changeValidator = missingUsersValidator(client, deployConfig)
     const errors = await changeValidator(changes)
     expect(errors).toHaveLength(2)
@@ -128,14 +128,14 @@ describe('missingUsersValidator', () => {
       {
         elemID: articleInstance.elemID,
         severity: 'Error',
-        message: 'Element references users which don\'t exist in target environment',
-        detailedMessage: 'The following users are referenced by this element, but do not exist in the target environment: article@salto.com.\nIn addition, we could not get the defined fallback user 9@9. In order to deploy this element, add these users to your target environment, edit this element to use valid usernames, or set the target environment\'s user fallback options. Learn more: https://help.salto.io/en/articles/6955302-element-references-users-which-don-t-exist-in-target-environment-zendesk',
+        message: 'Instance references users which don\'t exist in target environment',
+        detailedMessage: 'The following users are referenced by this instance, but do not exist in the target environment: article@salto.com.\nIn addition, we could not get the defined fallback user 9@salto.io. In order to deploy this instance, add these users to your target environment, edit this instance to use valid usernames, or set the target environment\'s user fallback options.\nLearn more: https://help.salto.io/en/articles/6955302-element-references-users-which-don-t-exist-in-target-environment-zendesk',
       },
       {
         elemID: macroInstance.elemID,
         severity: 'Error',
-        message: 'Element references users which don\'t exist in target environment',
-        detailedMessage: 'The following users are referenced by this element, but do not exist in the target environment: thisuserismissing@salto.com, thisuserismissing2@salto.com.\nIn addition, we could not get the defined fallback user 9@9. In order to deploy this element, add these users to your target environment, edit this element to use valid usernames, or set the target environment\'s user fallback options. Learn more: https://help.salto.io/en/articles/6955302-element-references-users-which-don-t-exist-in-target-environment-zendesk',
+        message: 'Instance references users which don\'t exist in target environment',
+        detailedMessage: 'The following users are referenced by this instance, but do not exist in the target environment: thisuserismissing@salto.com, thisuserismissing2@salto.com.\nIn addition, we could not get the defined fallback user 9@salto.io. In order to deploy this instance, add these users to your target environment, edit this instance to use valid usernames, or set the target environment\'s user fallback options.\nLearn more: https://help.salto.io/en/articles/6955302-element-references-users-which-don-t-exist-in-target-environment-zendesk',
       },
     ])
   })
@@ -151,14 +151,14 @@ describe('missingUsersValidator', () => {
       {
         elemID: articleInstance.elemID,
         severity: 'Error',
-        message: 'Element references users which don\'t exist in target environment',
-        detailedMessage: 'The following users are referenced by this element, but do not exist in the target environment: article@salto.com.\nIn addition, we could not get the defined fallback user ##DEPLOYER##. In order to deploy this element, add these users to your target environment, edit this element to use valid usernames, or set the target environment\'s user fallback options. Learn more: https://help.salto.io/en/articles/6955302-element-references-users-which-don-t-exist-in-target-environment-zendesk',
+        message: 'Instance references users which don\'t exist in target environment',
+        detailedMessage: 'The following users are referenced by this instance, but do not exist in the target environment: article@salto.com.\nIn addition, we could not get the defined fallback user ##DEPLOYER##. In order to deploy this instance, add these users to your target environment, edit this instance to use valid usernames, or set the target environment\'s user fallback options.\nLearn more: https://help.salto.io/en/articles/6955302-element-references-users-which-don-t-exist-in-target-environment-zendesk',
       },
       {
         elemID: macroInstance.elemID,
         severity: 'Error',
-        message: 'Element references users which don\'t exist in target environment',
-        detailedMessage: 'The following users are referenced by this element, but do not exist in the target environment: thisuserismissing@salto.com, thisuserismissing2@salto.com.\nIn addition, we could not get the defined fallback user ##DEPLOYER##. In order to deploy this element, add these users to your target environment, edit this element to use valid usernames, or set the target environment\'s user fallback options. Learn more: https://help.salto.io/en/articles/6955302-element-references-users-which-don-t-exist-in-target-environment-zendesk',
+        message: 'Instance references users which don\'t exist in target environment',
+        detailedMessage: 'The following users are referenced by this instance, but do not exist in the target environment: thisuserismissing@salto.com, thisuserismissing2@salto.com.\nIn addition, we could not get the defined fallback user ##DEPLOYER##. In order to deploy this instance, add these users to your target environment, edit this instance to use valid usernames, or set the target environment\'s user fallback options.\nLearn more: https://help.salto.io/en/articles/6955302-element-references-users-which-don-t-exist-in-target-environment-zendesk',
       },
     ])
   })
@@ -166,7 +166,7 @@ describe('missingUsersValidator', () => {
     const articleWithValidUser = new InstanceElement(
       'article',
       articleType,
-      { author_id: '1@1', draft: false },
+      { author_id: '1@salto.io', draft: false },
     )
     const changes = [toChange({ after: articleWithValidUser })]
     const changeValidator = missingUsersValidator(client, deployConfig)

--- a/packages/zendesk-adapter/test/filters/referenced_id_fields.test.ts
+++ b/packages/zendesk-adapter/test/filters/referenced_id_fields.test.ts
@@ -15,7 +15,7 @@
 */
 import { ObjectType, ElemID, InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG, DEPLOY_CONFIG, FETCH_CONFIG, SUPPORTED_TYPES } from '../../src/config'
+import { DEFAULT_CONFIG, FETCH_CONFIG, SUPPORTED_TYPES } from '../../src/config'
 import { ZENDESK } from '../../src/constants'
 
 import { createFilterCreatorParams } from '../utils'
@@ -52,7 +52,6 @@ describe('referenced id fields filter', () => {
     filter = filterCreator(createFilterCreatorParams({
       config: {
         fetch: DEFAULT_CONFIG[FETCH_CONFIG],
-        deploy: DEFAULT_CONFIG[DEPLOY_CONFIG],
         apiDefinitions: {
           typeDefaults: {
             transformation: {

--- a/packages/zendesk-adapter/test/filters/referenced_id_fields.test.ts
+++ b/packages/zendesk-adapter/test/filters/referenced_id_fields.test.ts
@@ -15,7 +15,7 @@
 */
 import { ObjectType, ElemID, InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG, FETCH_CONFIG, SUPPORTED_TYPES } from '../../src/config'
+import { DEFAULT_CONFIG, DEPLOY_CONFIG, FETCH_CONFIG, SUPPORTED_TYPES } from '../../src/config'
 import { ZENDESK } from '../../src/constants'
 
 import { createFilterCreatorParams } from '../utils'
@@ -52,6 +52,7 @@ describe('referenced id fields filter', () => {
     filter = filterCreator(createFilterCreatorParams({
       config: {
         fetch: DEFAULT_CONFIG[FETCH_CONFIG],
+        deploy: DEFAULT_CONFIG[DEPLOY_CONFIG],
         apiDefinitions: {
           typeDefaults: {
             transformation: {

--- a/packages/zendesk-adapter/test/filters/user.test.ts
+++ b/packages/zendesk-adapter/test/filters/user.test.ts
@@ -20,6 +20,7 @@ import { ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/user'
 import { createFilterCreatorParams } from '../utils'
 import { getUsers } from '../../src/user_utils'
+import { DEFAULT_CONFIG } from '../../src/config'
 
 jest.mock('../../src/user_utils', () => ({
   ...jest.requireActual<{}>('../../src/user_utils'),
@@ -28,7 +29,6 @@ jest.mock('../../src/user_utils', () => ({
 
 describe('user filter', () => {
   type FilterType = filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
-  let filter: FilterType
   let getUsersMock: jest.MockedFunction<typeof getUsers>
   const macroType = new ObjectType({ elemID: new ElemID(ZENDESK, 'macro') })
   const userSegmentType = new ObjectType({ elemID: new ElemID(ZENDESK, 'user_segment') })
@@ -81,12 +81,12 @@ describe('user filter', () => {
   beforeEach(async () => {
     jest.clearAllMocks()
     getUsersMock = getUsers as jest.MockedFunction<typeof getUsers>
-    filter = filterCreator(
-      createFilterCreatorParams({ paginator: mockPaginator })
-    ) as FilterType
   })
 
   describe('onFetch', () => {
+    const filter = filterCreator(
+      createFilterCreatorParams({ paginator: mockPaginator })
+    ) as FilterType
     it('should change the user ids to emails', async () => {
       getUsersMock
         .mockResolvedValueOnce([
@@ -188,7 +188,16 @@ describe('user filter', () => {
     })
   })
   describe('preDeploy', () => {
+    let filter: FilterType
+
+    beforeEach(async () => {
+      jest.clearAllMocks()
+      getUsersMock = getUsers as jest.MockedFunction<typeof getUsers>
+    })
     it('should change the emails to user ids', async () => {
+      filter = filterCreator(
+        createFilterCreatorParams({ paginator: mockPaginator })
+      ) as FilterType
       getUsersMock
         .mockResolvedValue([
           { id: 1, email: 'a@a.com', role: 'admin', custom_role_id: 123 },
@@ -221,8 +230,45 @@ describe('user filter', () => {
         author_id: 1,
       })
     })
+    it('should replace missing user values with user from deploy config if provided', async () => {
+      filter = filterCreator(createFilterCreatorParams({
+        paginator: mockPaginator,
+        config: {
+          ...DEFAULT_CONFIG,
+          deploy: { defaultMissingUserFallback: 'fallback@.com' },
+        },
+      })) as FilterType
+      getUsersMock
+        .mockResolvedValue([
+          { id: 2, email: 'b@b.com', role: 'admin', custom_role_id: 123 },
+          { id: 3, email: 'c@c.com', role: 'admin', custom_role_id: 123 },
+          { id: 4, email: 'fallback@.com', role: 'agent', custom_role_id: 12 },
+        ])
+      const instances2 = [macroInstance, articleInstance].map(e => e.clone())
+      await filter.onFetch(instances2)
+      const changes2 = instances2.map(instance => toChange({ after: instance }))
+      await filter.preDeploy(changes2)
+      const macro = instances2.find(inst => inst.elemID.typeName === 'macro')
+      expect(macro?.value).toEqual({
+        title: 'test',
+        actions: [
+          { field: 'status', value: 'closed' },
+          { field: 'assignee_id', value: '2' },
+          { field: 'follower', value: '4' },
+        ],
+        restriction: { type: 'User', id: '3' },
+      })
+      const article = instances2.find(e => e.elemID.typeName === 'article')
+      expect(article?.value).toEqual({
+        title: 'test',
+        author_id: 4,
+      })
+    })
   })
   describe('onDeploy', () => {
+    const filter = filterCreator(
+      createFilterCreatorParams({ paginator: mockPaginator })
+    ) as FilterType
     it('should change the user ids to emails', async () => {
       getUsersMock
         .mockResolvedValueOnce([

--- a/packages/zendesk-adapter/test/user_utils.test.ts
+++ b/packages/zendesk-adapter/test/user_utils.test.ts
@@ -634,7 +634,7 @@ describe('userUtils', () => {
       expect(fallbackValue).toEqual('salto@io')
       expect(isValidValue).toEqual(true)
     })
-    it('should return not return specific user value if it is missing from target env', async () => {
+    it('should not return specific user value if it is missing from target env', async () => {
       deployConfig = {
         defaultMissingUserFallback: 'blabala',
       }

--- a/packages/zendesk-adapter/test/user_utils.test.ts
+++ b/packages/zendesk-adapter/test/user_utils.test.ts
@@ -656,20 +656,19 @@ describe('userUtils', () => {
       )
       expect(fallbackValue).toEqual('saltoo@io')
     })
-    it('should not return value in case of fallback to deployer and invalid user reponse', async () => {
+    it('should throw in case of fallback to deployer and invalid user reponse', async () => {
       mockGet
         .mockResolvedValueOnce({ status: 200, data: { users: [{ id: 1, email: 'saltoo@io', role: 'admin', custom_role_id: '234234' }] } })
       deployConfig = {
         defaultMissingUserFallback: '##DEPLOYER##',
       }
-      const fallbackValue = await getUserFallbackValue(
+      await expect(getUserFallbackValue(
         deployConfig.defaultMissingUserFallback as string,
         existingUsers,
         client
-      )
-      expect(fallbackValue).toBeUndefined()
+      )).rejects.toThrow(new Error('Failed to get current user from endpoint \'/api/v2/users/me\''))
     })
-    it('should not return value in case of an error in current user request', async () => {
+    it('should throw in case of an error in current user request', async () => {
       mockGet.mockRejectedValue({ status: 400, data: {} })
       deployConfig = {
         defaultMissingUserFallback: '##DEPLOYER##',

--- a/packages/zendesk-adapter/test/user_utils.test.ts
+++ b/packages/zendesk-adapter/test/user_utils.test.ts
@@ -626,25 +626,22 @@ describe('userUtils', () => {
       deployConfig = {
         defaultMissingUserFallback: 'salto@io',
       }
-      const { fallbackValue, isValidValue } = await getUserFallbackValue(
+      const fallbackValue = await getUserFallbackValue(
         deployConfig.defaultMissingUserFallback as string,
         existingUsers,
         client
       )
       expect(fallbackValue).toEqual('salto@io')
-      expect(isValidValue).toEqual(true)
     })
     it('should not return specific user value if it is missing from target env', async () => {
       deployConfig = {
-        defaultMissingUserFallback: 'blabala',
+        defaultMissingUserFallback: 'useruser@zendesk.com',
       }
-      const { fallbackValue, isValidValue } = await getUserFallbackValue(
+      await expect(getUserFallbackValue(
         deployConfig.defaultMissingUserFallback as string,
         existingUsers,
         client
-      )
-      expect(fallbackValue).toBeUndefined()
-      expect(isValidValue).toEqual(false)
+      )).rejects.toThrow(new Error('User provided in defaultMissingUserFallback does not exist in the target environemt'))
     })
     it('should return deployer user email', async () => {
       mockGet
@@ -652,13 +649,12 @@ describe('userUtils', () => {
       deployConfig = {
         defaultMissingUserFallback: '##DEPLOYER##',
       }
-      const { fallbackValue, isValidValue } = await getUserFallbackValue(
+      const fallbackValue = await getUserFallbackValue(
         deployConfig.defaultMissingUserFallback as string,
         existingUsers,
         client
       )
       expect(fallbackValue).toEqual('saltoo@io')
-      expect(isValidValue).toEqual(true)
     })
     it('should not return value in case of fallback to deployer and invalid user reponse', async () => {
       mockGet
@@ -666,7 +662,7 @@ describe('userUtils', () => {
       deployConfig = {
         defaultMissingUserFallback: '##DEPLOYER##',
       }
-      const { fallbackValue } = await getUserFallbackValue(
+      const fallbackValue = await getUserFallbackValue(
         deployConfig.defaultMissingUserFallback as string,
         existingUsers,
         client
@@ -674,17 +670,15 @@ describe('userUtils', () => {
       expect(fallbackValue).toBeUndefined()
     })
     it('should not return value in case of an error in current user request', async () => {
-      mockGet
-        .mockResolvedValueOnce({ status: 400, data: {} })
+      mockGet.mockRejectedValue({ status: 400, data: {} })
       deployConfig = {
         defaultMissingUserFallback: '##DEPLOYER##',
       }
-      const { fallbackValue } = await getUserFallbackValue(
+      await expect(getUserFallbackValue(
         deployConfig.defaultMissingUserFallback as string,
         existingUsers,
         client
-      )
-      expect(fallbackValue).toBeUndefined()
+      )).rejects.toThrow(new Error('Failed to get current user from endpoint \'/api/v2/users/me\''))
     })
   })
 })


### PR DESCRIPTION
Add deploy config option + handle missing users in Zendesk

---

Changes:

Adapter-components

- Add 'defaultMissingUserFallback' config option for fallback when users referenced from elements are missing

Zendesk
- Add deploy config to zendesk by default, and add this config as an optional param for filters & change validator
- Adjust `missingUsersValidator` to notify users in case missing users values are about to change
- Add filter that on `onDeploy` will change all missing users in changed elements to the user provided in deploy config

---
_Release Notes_: 

Zendesk
- Add the option to define fallback username for elements with references to missing users.

---
_User Notifications_: 
None
