### PR TITLE
SALTO-2975 add warning upon adding extra elements (references) to the…

### DIFF
--- a/packages/netsuite-adapter/src/change_validators/account_specific_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/account_specific_values.ts
@@ -14,15 +14,17 @@
 * limitations under the License.
 */
 import { values, collections } from '@salto-io/lowerdash'
-import { ChangeError, ChangeValidator, getChangeData, isAdditionOrModificationChange } from '@salto-io/adapter-api'
+import { ChangeError, getChangeData, isAdditionOrModificationChange } from '@salto-io/adapter-api'
 import { isStandardInstanceOrCustomRecordType } from '../types'
 import { ACCOUNT_SPECIFIC_VALUE } from '../constants'
 import { isElementContainsStringValue } from './utils'
+import { NetsuiteChangeValidator } from './types'
+
 
 const { awu } = collections.asynciterable
 const { isDefined } = values
 
-const changeValidator: ChangeValidator = async changes => (
+const changeValidator: NetsuiteChangeValidator = async changes => (
   awu(changes)
     .filter(isAdditionOrModificationChange)
     .map(async change => {

--- a/packages/netsuite-adapter/src/change_validators/config_changes.ts
+++ b/packages/netsuite-adapter/src/change_validators/config_changes.ts
@@ -15,9 +15,11 @@
 */
 import _ from 'lodash'
 import {
-  ChangeValidator, ElemID, getChangeData, InstanceElement, isInstanceChange, isModificationChange,
+  ElemID, getChangeData, InstanceElement, isInstanceChange, isModificationChange,
   ChangeError,
 } from '@salto-io/adapter-api'
+import { NetsuiteChangeValidator } from './types'
+
 
 const getDifferenceFieldsElemIDs = (
   instance: InstanceElement,
@@ -29,7 +31,7 @@ const getDifferenceFieldsElemIDs = (
     .map(fieldName => instance.elemID.createNestedID(fieldName))
 }
 
-const changeValidator: ChangeValidator = async changes => {
+const changeValidator: NetsuiteChangeValidator = async changes => {
   const [modificationChanges, invalidChanges] = _.partition(
     changes
       .filter(isInstanceChange)

--- a/packages/netsuite-adapter/src/change_validators/currency_exchange_rate.ts
+++ b/packages/netsuite-adapter/src/change_validators/currency_exchange_rate.ts
@@ -14,15 +14,15 @@
 * limitations under the License.
 */
 
-import { ChangeError, ChangeValidator } from '@salto-io/adapter-api'
+import { ChangeError } from '@salto-io/adapter-api'
 import { values } from '@salto-io/lowerdash'
 import { EXCHANGE_RATE } from '../constants'
 import { DEFAULT_EXCHANGE_RATE, getCurrencyAdditionsWithoutExchangeRate } from '../filters/currency_exchange_rate'
-
+import { NetsuiteChangeValidator } from './types'
 
 const { isDefined } = values
 
-const changeValidator: ChangeValidator = async changes => (
+const changeValidator: NetsuiteChangeValidator = async changes => (
   getCurrencyAdditionsWithoutExchangeRate(changes)
     .map(instance => ({
       elemID: instance.elemID,

--- a/packages/netsuite-adapter/src/change_validators/currency_undeployable_fields.ts
+++ b/packages/netsuite-adapter/src/change_validators/currency_undeployable_fields.ts
@@ -16,7 +16,6 @@
 import {
   AdditionChange,
   ChangeError,
-  ChangeValidator,
   getChangeData,
   InstanceElement,
   isAdditionOrModificationChange,
@@ -26,6 +25,8 @@ import {
 } from '@salto-io/adapter-api'
 import { values } from '@salto-io/lowerdash'
 import { CURRENCY } from '../constants'
+import { NetsuiteChangeValidator } from './types'
+
 
 const { isDefined } = values
 const DISPLAY_SYMBOL = 'display symbol'
@@ -87,7 +88,7 @@ const validateAdditionChange = (additionChange: AdditionChange<InstanceElement>)
   }
 }
 
-const changeValidator: ChangeValidator = async changes => (
+const changeValidator: NetsuiteChangeValidator = async changes => (
   changes
     .filter(isAdditionOrModificationChange)
     .filter(isInstanceChange)

--- a/packages/netsuite-adapter/src/change_validators/data_account_specific_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/data_account_specific_values.ts
@@ -16,7 +16,6 @@
 import { collections } from '@salto-io/lowerdash'
 import {
   ChangeError,
-  ChangeValidator,
   getChangeData,
   InstanceElement,
   isAdditionChange,
@@ -29,6 +28,8 @@ import { walkOnElement, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
 import { removeIdenticalValues } from '../filters/data_instances_diff'
 import { isDataObjectType } from '../types'
 import { ACCOUNT_SPECIFIC_VALUE, ID_FIELD, INTERNAL_ID } from '../constants'
+import { NetsuiteChangeValidator } from './types'
+
 
 const { awu } = collections.asynciterable
 
@@ -48,7 +49,7 @@ const hasUnresolvedAccountSpecificValue = (instance: InstanceElement): boolean =
   return foundAccountSpecificValue
 }
 
-const changeValidator: ChangeValidator = async changes => (
+const changeValidator: NetsuiteChangeValidator = async changes => (
   awu(changes)
     .filter(isAdditionOrModificationChange)
     .filter(isInstanceChange)

--- a/packages/netsuite-adapter/src/change_validators/extra_reference_dependencies.ts
+++ b/packages/netsuite-adapter/src/change_validators/extra_reference_dependencies.ts
@@ -1,0 +1,75 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { ChangeDataType, ElemID, getChangeData } from '@salto-io/adapter-api'
+import { collections, values } from '@salto-io/lowerdash'
+import { getReferencedElements } from '../reference_dependencies'
+import { NetsuiteChangeValidator } from './types'
+
+const { awu } = collections.asynciterable
+const { isDefined } = values
+
+type ElementToReferenceElements = {
+  sourceElementID: ElemID
+  references: string
+  referencesNumber: number
+}
+
+export const getReferencedElementsForReferrers = async (
+  elements: ChangeDataType[],
+  deployAllReferencedElements: boolean,
+): Promise<ElementToReferenceElements[]> => {
+  const sourceElemIdSet = new Set(elements.map(element => element.elemID.getFullName()))
+  return awu(elements)
+    .map(async element => {
+      const referencedElements = await getReferencedElements(
+        [element], deployAllReferencedElements
+      )
+      const references = referencedElements
+        .filter(referencedElement => !sourceElemIdSet.has(referencedElement.elemID.getFullName()))
+        .map(referencedElement => referencedElement.elemID.getFullName())
+      if (references.length === 0) {
+        return undefined
+      }
+      return {
+        sourceElementID: element.elemID,
+        references: references.join(', '),
+        referencesNumber: references.length,
+      }
+    })
+    .filter(isDefined)
+    .toArray()
+}
+
+const changeValidator: NetsuiteChangeValidator = async (changes, deployReferencedElements = false) => {
+  const refererToReferenceElements = await getReferencedElementsForReferrers(
+    changes.map(getChangeData), deployReferencedElements
+  )
+
+  return refererToReferenceElements.map(refererToReferenceElement => {
+    const pluralRefElement = refererToReferenceElement.referencesNumber > 1 ? 's' : ''
+    const pluralPronoun = refererToReferenceElement.referencesNumber > 1 ? 'them' : 'it'
+
+    return {
+      elemID: refererToReferenceElement.sourceElementID,
+      severity: 'Warning',
+      message: `This element requires additional element${pluralRefElement} to be deployed. Salto will automatically deploy ${pluralPronoun}`,
+      detailedMessage: `This element requires the following element${pluralRefElement} to be deployed as well: ${refererToReferenceElement.references}. Salto will automatically deploy ${pluralPronoun} as part of this deployment`,
+    }
+  })
+}
+
+export default changeValidator

--- a/packages/netsuite-adapter/src/change_validators/file_changes.ts
+++ b/packages/netsuite-adapter/src/change_validators/file_changes.ts
@@ -14,12 +14,14 @@
 * limitations under the License.
 */
 import {
-  ChangeValidator, getChangeData, Change, ChangeError,
+  getChangeData, Change, ChangeError,
 } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { fileCabinetTopLevelFolders } from '../client/constants'
 import { isFileCabinetInstance } from '../types'
 import * as suiteAppFileCabinet from '../suiteapp_file_cabinet'
+import { NetsuiteChangeValidator } from './types'
+
 
 const { awu } = collections.asynciterable
 
@@ -33,7 +35,7 @@ const isChangeSupported = async (change: Change): Promise<boolean> => {
 }
 
 
-const changeValidator: ChangeValidator = async changes => (
+const changeValidator: NetsuiteChangeValidator = async changes => (
   awu(changes)
     .filter(async change => !await isChangeSupported(change))
     .map(getChangeData)

--- a/packages/netsuite-adapter/src/change_validators/immutable_changes.ts
+++ b/packages/netsuite-adapter/src/change_validators/immutable_changes.ts
@@ -13,13 +13,15 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ChangeError, ChangeValidator, CORE_ANNOTATIONS, Field, InstanceElement, isFieldChange, isInstanceChange, isModificationChange, isObjectTypeChange, isReferenceExpression, isServiceId, ModificationChange, ObjectType } from '@salto-io/adapter-api'
+import { ChangeError, CORE_ANNOTATIONS, Field, InstanceElement, isFieldChange, isInstanceChange, isModificationChange, isObjectTypeChange, isReferenceExpression, isServiceId, ModificationChange, ObjectType } from '@salto-io/adapter-api'
 import { getParents } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { APPLICATION_ID, SCRIPT_ID } from '../constants'
 import { TYPE_TO_ID_FIELD_PATHS } from '../data_elements/types'
 import { isDataObjectType, isFileCabinetType } from '../types'
+import { NetsuiteChangeValidator } from './types'
+
 
 const { awu } = collections.asynciterable
 
@@ -104,7 +106,7 @@ const toInstanceErrors = async (
   } as ChangeError))
 }
 
-const changeValidator: ChangeValidator = async changes => (
+const changeValidator: NetsuiteChangeValidator = async changes => (
   awu(changes).filter(isModificationChange).flatMap(async change => {
     if (isObjectTypeChange(change)) {
       return toTypeErrors(change)

--- a/packages/netsuite-adapter/src/change_validators/mapped_lists_indexes.ts
+++ b/packages/netsuite-adapter/src/change_validators/mapped_lists_indexes.ts
@@ -16,10 +16,12 @@
 import _ from 'lodash'
 import { collections, values } from '@salto-io/lowerdash'
 import {
-  ChangeError, ChangeValidator, getChangeData, isInstanceChange, isMapType, isObjectType,
+  ChangeError, getChangeData, isInstanceChange, isMapType, isObjectType,
 } from '@salto-io/adapter-api'
 import { INDEX } from '../constants'
 import { getMappedLists, MappedList } from '../mapped_lists/utils'
+import { NetsuiteChangeValidator } from './types'
+
 
 const { isDefined } = values
 
@@ -62,7 +64,7 @@ const toChangeErrors = async (
     }))
 }
 
-const changeValidator: ChangeValidator = async changes => (
+const changeValidator: NetsuiteChangeValidator = async changes => (
   awu(changes)
     .filter(isInstanceChange)
     .map(getChangeData)

--- a/packages/netsuite-adapter/src/change_validators/not_yet_supported_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/not_yet_supported_values.ts
@@ -16,17 +16,18 @@
 import { collections } from '@salto-io/lowerdash'
 import {
   ChangeError,
-  ChangeValidator,
   getChangeData,
   isAdditionOrModificationChange,
 } from '@salto-io/adapter-api'
 import { isStandardInstanceOrCustomRecordType } from '../types'
 import { NOT_YET_SUPPORTED_VALUE } from '../constants'
 import { isElementContainsStringValue } from './utils'
+import { NetsuiteChangeValidator } from './types'
+
 
 const { awu } = collections.asynciterable
 
-const changeValidator: ChangeValidator = async changes => (
+const changeValidator: NetsuiteChangeValidator = async changes => (
   awu(changes)
     .filter(isAdditionOrModificationChange)
     .map(getChangeData)

--- a/packages/netsuite-adapter/src/change_validators/remove_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/change_validators/remove_file_cabinet.ts
@@ -13,10 +13,12 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ChangeValidator, isRemovalChange, getChangeData } from '@salto-io/adapter-api'
+import { isRemovalChange, getChangeData } from '@salto-io/adapter-api'
 import { isFileCabinetInstance } from '../types'
+import { NetsuiteChangeValidator } from './types'
 
-const changeValidator: ChangeValidator = async changes => (
+
+const changeValidator: NetsuiteChangeValidator = async changes => (
   changes
     .filter(isRemovalChange)
     .map(getChangeData)

--- a/packages/netsuite-adapter/src/change_validators/remove_list_item.ts
+++ b/packages/netsuite-adapter/src/change_validators/remove_list_item.ts
@@ -16,7 +16,7 @@
 import wu from 'wu'
 import _ from 'lodash'
 import {
-  ChangeValidator, getChangeData, isModificationChange, InstanceElement, isInstanceChange,
+  getChangeData, isModificationChange, InstanceElement, isInstanceChange,
   ModificationChange,
   ElemID,
   ChangeError,
@@ -24,6 +24,8 @@ import {
 import { walkOnElement, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { SCRIPT_ID } from '../constants'
+import { NetsuiteChangeValidator } from './types'
+
 
 const { awu } = collections.asynciterable
 
@@ -60,7 +62,7 @@ const getRemovedListItems = async (change: ModificationChange<InstanceElement>):
   return { removedListItems, elemID: getChangeData(change).elemID }
 }
 
-const changeValidator: ChangeValidator = async changes => {
+const changeValidator: NetsuiteChangeValidator = async changes => {
   const instanceChanges = await awu(changes)
     .filter(isModificationChange)
     .filter(isInstanceChange)

--- a/packages/netsuite-adapter/src/change_validators/remove_standard_types.ts
+++ b/packages/netsuite-adapter/src/change_validators/remove_standard_types.ts
@@ -13,11 +13,13 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ChangeValidator, isRemovalChange, getChangeData } from '@salto-io/adapter-api'
+import { isRemovalChange, getChangeData } from '@salto-io/adapter-api'
 import { isStandardTypeName } from '../autogen/types'
 import { isStandardInstanceOrCustomRecordType } from '../types'
+import { NetsuiteChangeValidator } from './types'
 
-const changeValidator: ChangeValidator = async changes => (
+
+const changeValidator: NetsuiteChangeValidator = async changes => (
   changes
     .filter(isRemovalChange)
     .map(getChangeData)

--- a/packages/netsuite-adapter/src/change_validators/report_types_move_environment.ts
+++ b/packages/netsuite-adapter/src/change_validators/report_types_move_environment.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { collections } from '@salto-io/lowerdash'
-import { ChangeValidator, getChangeData, InstanceElement,
+import { getChangeData, InstanceElement,
   isInstanceChange, ChangeError, isAdditionOrModificationChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { FINANCIAL_LAYOUT, REPORT_DEFINITION, SAVED_SEARCH } from '../constants'
@@ -24,6 +24,8 @@ import { parseDefinition as parseFinancialLayoutDefinition } from '../type_parse
 import { ParsedReportDefinition } from '../type_parsers/report_definition_parsing/parsed_report_definition'
 import { ParsedFinancialLayout } from '../type_parsers/financial_layout_parsing/parsed_financial_layout'
 import { ParsedSavedSearchType } from '../type_parsers/saved_search_parsing/parsed_saved_search'
+import { NetsuiteChangeValidator } from './types'
+
 
 const { awu } = collections.asynciterable
 
@@ -73,7 +75,7 @@ const getChangeError = async (instance: InstanceElement): Promise<ChangeError> =
 }
 
 
-const changeValidator: ChangeValidator = async changes => (
+const changeValidator: NetsuiteChangeValidator = async changes => (
   awu(changes)
     .filter(isAdditionOrModificationChange)
     .filter(isInstanceChange)

--- a/packages/netsuite-adapter/src/change_validators/standard_types_invalid_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/standard_types_invalid_values.ts
@@ -18,7 +18,6 @@ import { values } from '@salto-io/lowerdash'
 import {
   Change,
   ChangeError,
-  ChangeValidator,
   getChangeData,
   InstanceElement,
   isAdditionOrModificationChange,
@@ -28,6 +27,8 @@ import {
   Value,
 } from '@salto-io/adapter-api'
 import { isStandardType } from '../types'
+import { NetsuiteChangeValidator } from './types'
+
 
 const { isDefined } = values
 
@@ -77,7 +78,7 @@ const getInvalidValuesChangeErrors = (
   }).filter(isDefined)
 }
 
-const changeValidator: ChangeValidator = async changes => {
+const changeValidator: NetsuiteChangeValidator = async changes => {
   const instanceChanges = _.groupBy(
     changes
       .filter(isAdditionOrModificationChange)

--- a/packages/netsuite-adapter/src/change_validators/subinstances.ts
+++ b/packages/netsuite-adapter/src/change_validators/subinstances.ts
@@ -14,11 +14,13 @@
 * limitations under the License.
 */
 import {
-  ChangeValidator, isInstanceChange, isRemovalOrModificationChange,
+  isInstanceChange, isRemovalOrModificationChange,
 } from '@salto-io/adapter-api'
 import { IS_SUB_INSTANCE } from '../constants'
+import { NetsuiteChangeValidator } from './types'
 
-const changeValidator: ChangeValidator = async changes => (
+
+const changeValidator: NetsuiteChangeValidator = async changes => (
   changes
     .filter(isInstanceChange)
     .map(change => (isRemovalOrModificationChange(change) ? change.data.before : change.data.after))

--- a/packages/netsuite-adapter/src/change_validators/suiteapp_config_elements.ts
+++ b/packages/netsuite-adapter/src/change_validators/suiteapp_config_elements.ts
@@ -15,7 +15,7 @@
 */
 import { collections } from '@salto-io/lowerdash'
 import {
-  ChangeValidator, ElemID, getChangeData, InstanceElement, isInstanceChange, isModificationChange,
+  ElemID, getChangeData, InstanceElement, isInstanceChange, isModificationChange,
   ChangeError,
   ModificationChange,
   isEqualValues,
@@ -25,6 +25,8 @@ import {
 } from '@salto-io/adapter-api'
 import { isSuiteAppConfigInstance } from '../types'
 import { SELECT_OPTION } from '../constants'
+import { NetsuiteChangeValidator } from './types'
+
 
 const { awu } = collections.asynciterable
 const { makeArray } = collections.array
@@ -70,7 +72,7 @@ const getSelectOptionChangesElemIDs = async (
     .toArray()
 }
 
-const changeValidator: ChangeValidator = async changes =>
+const changeValidator: NetsuiteChangeValidator = async changes =>
   awu(changes)
     .filter(isInstanceChange)
     .filter(isModificationChange)

--- a/packages/netsuite-adapter/src/change_validators/types.ts
+++ b/packages/netsuite-adapter/src/change_validators/types.ts
@@ -13,21 +13,10 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { isInstanceElement, getChangeData } from '@salto-io/adapter-api'
-import { isStandardInstanceOrCustomRecordType } from '../types'
-import { NetsuiteChangeValidator } from './types'
+import { Change, ChangeError } from '@salto-io/adapter-api'
 
 
-const changeValidator: NetsuiteChangeValidator = async changes => (
-  changes
-    .map(getChangeData)
-    .filter(elem => !isInstanceElement(elem) && !isStandardInstanceOrCustomRecordType(elem))
-    .map(({ elemID }) => ({
-      elemID,
-      severity: 'Error',
-      message: 'Type definitions are read only',
-      detailedMessage: `Changing (${elemID.name}) is not supported`,
-    }))
-)
-
-export default changeValidator
+export type NetsuiteChangeValidator = (
+    changes: ReadonlyArray<Change>,
+    deployReferencedElements?: boolean
+  ) => Promise<ReadonlyArray<ChangeError>>

--- a/packages/netsuite-adapter/src/change_validators/undeployable_config_features.ts
+++ b/packages/netsuite-adapter/src/change_validators/undeployable_config_features.ts
@@ -14,10 +14,12 @@
 * limitations under the License.
 */
 import {
-  ChangeValidator, getChangeData, InstanceElement, isInstanceChange, isModificationChange,
+  getChangeData, InstanceElement, isInstanceChange, isModificationChange,
   ModificationChange,
 } from '@salto-io/adapter-api'
 import { CONFIG_FEATURES } from '../constants'
+import { NetsuiteChangeValidator } from './types'
+
 
 // These features cannot be configure using SDF
 // because they require a Terms of Service user agreement
@@ -60,7 +62,7 @@ const getDiffFeatureNames = (change: ModificationChange<InstanceElement>): strin
   Object.keys(change.data.after.value)
     .filter(fieldName => change.data.after.value[fieldName] !== change.data.before.value[fieldName])
 
-const changeValidator: ChangeValidator = async changes => {
+const changeValidator: NetsuiteChangeValidator = async changes => {
   const featuresChange = changes
     .filter(isInstanceChange)
     .filter(isModificationChange)

--- a/packages/netsuite-adapter/src/change_validators/workflow_account_specific_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/workflow_account_specific_values.ts
@@ -16,7 +16,6 @@
 import { values } from '@salto-io/lowerdash'
 import {
   ChangeError,
-  ChangeValidator,
   getChangeData,
   InstanceElement,
   isAdditionOrModificationChange,
@@ -24,6 +23,8 @@ import {
 } from '@salto-io/adapter-api'
 import { walkOnElement, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
 import { ACCOUNT_SPECIFIC_VALUE, WORKFLOW } from '../constants'
+import { NetsuiteChangeValidator } from './types'
+
 
 const { isDefined } = values
 const SENDER = 'sender'
@@ -38,7 +39,7 @@ const toValidationError = (instance: InstanceElement, probField: string): Change
 })
 
 
-const changeValidator: ChangeValidator = async changes => (
+const changeValidator: NetsuiteChangeValidator = async changes => (
   changes
     .filter(isAdditionOrModificationChange)
     .map(getChangeData)

--- a/packages/netsuite-adapter/test/change_validators/dependencies.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/dependencies.test.ts
@@ -95,6 +95,7 @@ describe('Required Dependencies Validator', () => {
     expect(changeErrors)
       .toEqual(expect.arrayContaining([
         expect.objectContaining({
+          severity: 'Error',
           elemID: dependsOn2Instances.elemID,
         })]))
     expect(changeErrors).toHaveLength(1)
@@ -105,9 +106,11 @@ describe('Required Dependencies Validator', () => {
     expect(changeErrors)
       .toEqual(expect.arrayContaining([
         expect.objectContaining({
+          severity: 'Error',
           elemID: customSegmentInstance.elemID,
         }),
         expect.objectContaining({
+          severity: 'Error',
           elemID: dependsOn2Instances.elemID,
         })]))
     expect(changeErrors).toHaveLength(2)

--- a/packages/netsuite-adapter/test/change_validators/extra_reference_dependencies.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/extra_reference_dependencies.test.ts
@@ -1,0 +1,133 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { fileType } from '../../src/types/file_cabinet_types'
+import { customsegmentType } from '../../src/autogen/types/standard_types/customsegment'
+import extraReferenceDependenciesValidator from '../../src/change_validators/extra_reference_dependencies'
+import { CUSTOM_RECORD_TYPE, METADATA_TYPE, NETSUITE, PATH, SCRIPT_ID } from '../../src/constants'
+
+
+describe('extra reference changes', () => {
+  const customsegment = customsegmentType().type
+
+  const fileInstance = new InstanceElement('file_instance', fileType(), {
+    [PATH]: 'Templates/E-mail Templates/Inner EmailTemplates Folder/content.html',
+  })
+
+  const customRecordType = new ObjectType({
+    elemID: new ElemID(NETSUITE, 'custom_record_type'),
+    annotations: {
+      [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
+      [SCRIPT_ID]: 'custom_record_type_script_id',
+    },
+  })
+
+  const customSegmentInstance = new InstanceElement('custom_segment_instance', customsegment, {
+    [SCRIPT_ID]: 'custom_segment_instance_script_id',
+    description: new ReferenceExpression(
+      fileInstance.elemID.createNestedID(PATH),
+      fileInstance.value[PATH],
+      fileInstance
+    ),
+  })
+
+  customSegmentInstance.value.recordtype = new ReferenceExpression(
+    customRecordType.elemID.createNestedID('attr', SCRIPT_ID), 'val', customRecordType
+  )
+
+  customRecordType.annotations.customsegment = new ReferenceExpression(
+    customSegmentInstance.elemID.createNestedID(SCRIPT_ID),
+    customSegmentInstance.value[SCRIPT_ID],
+    customSegmentInstance
+  )
+
+  const dependsOn2Instances = new InstanceElement('depends_on_2_instances', customsegment, {
+    [SCRIPT_ID]: 'depends_on_2_instances_script_id',
+    label: new ReferenceExpression(
+      customSegmentInstance.elemID.createNestedID(SCRIPT_ID),
+      customSegmentInstance.value[SCRIPT_ID],
+      customSegmentInstance
+    ),
+    description: new ReferenceExpression(
+      fileInstance.elemID.createNestedID(PATH),
+      fileInstance.value[PATH],
+      fileInstance
+    ),
+  })
+
+  // dependsOn2Instances ---> customSegmentInstance <---> customRecordType
+  //        |                     |
+  //        '-->  fileInstance <--'
+
+  it('should not have ChangeError when deploying an instance with its dependencies, when requesting to add only required references', async () => {
+    const changeErrors = await extraReferenceDependenciesValidator([
+      toChange({ before: customRecordType, after: customRecordType }),
+      toChange({ after: customSegmentInstance }),
+      toChange({ before: fileInstance, after: fileInstance }),
+    ], false)
+    expect(changeErrors).toHaveLength(0)
+  })
+
+  it('should not have ChangeError when deploying an instance with its dependencies, when requesting to add all references', async () => {
+    const changeErrors = await extraReferenceDependenciesValidator([
+      toChange({ before: customRecordType, after: customRecordType }),
+      toChange({ after: customSegmentInstance }),
+      toChange({ before: fileInstance, after: fileInstance }),
+    ], true)
+    expect(changeErrors).toHaveLength(0)
+  })
+
+  it('should have Warning ChangeError when deploying an instance without its required reference, when requesting to add only required references', async () => {
+    const changeErrors = await extraReferenceDependenciesValidator([
+      toChange({ after: customSegmentInstance }),
+      toChange({ before: dependsOn2Instances, after: dependsOn2Instances }),
+    ], false)
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors)
+      .toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          severity: 'Warning',
+          elemID: customSegmentInstance.elemID,
+          message: expect.stringMatching('This element requires additional element to be deployed. Salto will automatically deploy it'), // check singular inflection
+          detailedMessage: expect.stringMatching(customRecordType.elemID.getFullName()),
+        })]))
+  })
+
+  it('should have Warning ChangeErrors when deploying a instances without their dependencies, each instance with its relevant references', async () => {
+    const changeErrors = await extraReferenceDependenciesValidator([
+      toChange({ after: customRecordType }),
+      toChange({ before: dependsOn2Instances, after: dependsOn2Instances }),
+    ], true)
+    expect(changeErrors).toHaveLength(2)
+    const customSegmentInstanceElemId = customSegmentInstance.elemID.getFullName()
+    const fileInstanceElemId = fileInstance.elemID.getFullName()
+    const missingReferences = `(.*${customSegmentInstanceElemId}, ${fileInstanceElemId}.*)|(.*${fileInstanceElemId}, ${customSegmentInstanceElemId}.*)`
+    expect(changeErrors)
+      .toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          severity: 'Warning',
+          elemID: customRecordType.elemID,
+          message: expect.stringMatching('This element requires additional elements to be deployed. Salto will automatically deploy them'), // check plural inflection
+          detailedMessage: expect.stringMatching(missingReferences),
+        }),
+        expect.objectContaining({
+          severity: 'Warning',
+          elemID: dependsOn2Instances.elemID,
+          message: expect.stringMatching('This element requires additional elements to be deployed. Salto will automatically deploy them'), // check plural inflection
+          detailedMessage: expect.stringMatching(missingReferences),
+        })]))
+  })
+})


### PR DESCRIPTION
introducing a new warning in case a reference was added to the deployment by salto

---
_Additional context for reviewer_:
None

---
_Release Notes_: 
a warning message will be show on each change elements that contains unselected references. these references will be selected by salto deploy and will be part of the deployment

---
_User Notifications_: 
None
