### PR TITLE
SALTO-3485: Add more valid user values for missing user change validator in Zendesk

### DIFF
--- a/packages/zendesk-adapter/src/change_validators/missing_users.ts
+++ b/packages/zendesk-adapter/src/change_validators/missing_users.ts
@@ -27,7 +27,7 @@ import { lookupFunc } from '../filters/field_references'
 const { awu } = collections.asynciterable
 const { createPaginator } = clientUtils
 // system options that does not contain a specific user value
-const VALID_USER_VALUES = ['current_user', 'all_agents', 'requester_id', 'assignee_id', 'requester_and_ccs']
+const VALID_USER_VALUES = ['current_user', 'all_agents', 'requester_id', 'assignee_id', 'requester_and_ccs', 'agent', 'end_user', '']
 
 const getMissingUsers = (instance: InstanceElement, existingUsers: Set<string>): string[] => {
   const userPaths = TYPE_NAME_TO_REPLACER[instance.elemID.typeName]?.(instance)

--- a/packages/zendesk-adapter/test/change_validators/missing_users.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/missing_users.test.ts
@@ -119,10 +119,31 @@ describe('missingUsersValidator', () => {
             field: 'requester_id',
             value: 'requester_id',
           },
+
         ],
       },
     )
-    const changes = [toChange({ after: macroWithValidUserFields })]
+    const triggerInstance = new InstanceElement(
+      'trigger',
+      new ObjectType({ elemID: new ElemID(ZENDESK, 'trigger') }),
+      {
+        conditions: {
+          all: [
+            {
+              field: 'assignee_id',
+              operator: 'is',
+              value: '',
+            },
+            {
+              field: 'role',
+              operator: 'is',
+              value: 'end_user',
+            },
+          ],
+        },
+      }
+    )
+    const changes = [toChange({ after: macroWithValidUserFields }), toChange({ after: triggerInstance })]
     const changeValidator = missingUsersValidator(client)
     const errors = await changeValidator(changes)
     expect(errors).toHaveLength(0)


### PR DESCRIPTION
Add more valid user values to fix a bug causing `missingUsersValidator` to prevent deployment of instances with those values.

---
_Release Notes_: 
None

---
_User Notifications_: 
None
