### PR TITLE
SALTO-2489: zendesk support templating for custom fields user and organization

### DIFF
--- a/packages/zendesk-adapter/src/filters/handle_app_installations.ts
+++ b/packages/zendesk-adapter/src/filters/handle_app_installations.ts
@@ -24,7 +24,6 @@ import { FilterCreator } from '../filter'
 import { FETCH_CONFIG, IdLocator } from '../config'
 import { APP_INSTALLATION_TYPE_NAME } from './app'
 import { TICKET_FIELD_TYPE_NAME } from '../constants'
-import { ZENDESK_REFERENCE_TYPE_TO_SALTO_TYPE } from './handle_template_expressions'
 
 const log = logger(module)
 
@@ -109,7 +108,7 @@ const filterCreator: FilterCreator = ({ config }) => {
     onFetch: async (elements: InstanceElement[]): Promise<void> => log.time(async () =>
       getAppInstallations(elements)
         .forEach(app => replaceFieldsWithTemplates(app, _.groupBy(elements.filter(
-          e => [...Object.values(ZENDESK_REFERENCE_TYPE_TO_SALTO_TYPE),
+          e => [TICKET_FIELD_TYPE_NAME,
             ...APP_INSTLLATION_SPECIFIC_TYPES]
             .includes((e.elemID.typeName))
         ), e => e.elemID.typeName), locators)),

--- a/packages/zendesk-adapter/src/filters/handle_app_installations.ts
+++ b/packages/zendesk-adapter/src/filters/handle_app_installations.ts
@@ -108,7 +108,7 @@ const filterCreator: FilterCreator = ({ config }) => {
     onFetch: async (elements: InstanceElement[]): Promise<void> => log.time(async () =>
       getAppInstallations(elements)
         .forEach(app => replaceFieldsWithTemplates(app, _.groupBy(elements.filter(
-          e => [TICKET_FIELD_TYPE_NAME,
+          e => [TICKET_FIELD_TYPE_NAME, // before it was the values of ZENDESK_REFERENCE_TYPE_TO_SALTO_TYPE
             ...APP_INSTLLATION_SPECIFIC_TYPES]
             .includes((e.elemID.typeName))
         ), e => e.elemID.typeName), locators)),

--- a/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
@@ -56,11 +56,17 @@ export const ZENDESK_REFERENCE_TYPE_TO_SALTO_TYPE: Record<string, string> = {
   [USER_FIELD]: USER_FIELD_TYPE_NAME,
 }
 
-const ZENDESK_TYPE_TO_FIELD: Record<string, string> = {
+const ZENDESK_TYPE_FIELD_TO_FIELD: Record<string, string> = {
   [TICKET_TICKET_FIELD]: ID,
   [TICKET_FIELD_OPTION_TITLE]: ID,
   [ORGANIZATION_FIELD]: KEY,
   [USER_FIELD]: KEY,
+}
+
+const ZENDESK_TYPE_TO_FIELD: Record<string, string> = {
+  [TICKET_FIELD_TYPE_NAME]: ID,
+  [ORG_FIELD_TYPE_NAME]: KEY,
+  [USER_FIELD_TYPE_NAME]: KEY,
 }
 
 const POTENTIAL_REFERENCE_TYPES = Object.keys(ZENDESK_REFERENCE_TYPE_TO_SALTO_TYPE)
@@ -175,7 +181,7 @@ const formulaToTemplate = (
     }
     const [type, innerId, title] = splitReference
     const elem = (instancesByType[ZENDESK_REFERENCE_TYPE_TO_SALTO_TYPE[type]] ?? [])
-      .find(instance => instance.value[ZENDESK_TYPE_TO_FIELD[type]]?.toString() === innerId)
+      .find(instance => instance.value[ZENDESK_TYPE_FIELD_TO_FIELD[type]]?.toString() === innerId)
     if (elem) {
       if (KEY_FIELDS.includes(type)) {
         return [
@@ -199,7 +205,7 @@ const formulaToTemplate = (
       ZENDESK_REFERENCE_TYPE_TO_SALTO_TYPE[type],
       innerId
     )
-    missingInstance.value[ZENDESK_TYPE_TO_FIELD[type]] = innerId
+    missingInstance.value[ZENDESK_TYPE_FIELD_TO_FIELD[type]] = innerId
     if (KEY_FIELDS.includes(type)) {
       return [
         `${type}.`,
@@ -280,7 +286,7 @@ const replaceFormulasWithTemplates = async (
 
 export const prepRef = (part: ReferenceExpression): TemplatePart => {
   if (Object.values(ZENDESK_REFERENCE_TYPE_TO_SALTO_TYPE).includes(part.elemID.typeName)) {
-    return `${part.value.value.id}`
+    return `${part.value.value[ZENDESK_TYPE_TO_FIELD[part.elemID.typeName]]}`
   }
   if (part.elemID.typeName === DYNAMIC_CONTENT_ITEM_TYPE_NAME
     && _.isString(part.value.value.placeholder)) {

--- a/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
@@ -49,7 +49,7 @@ export const ZENDESK_REFERENCE_TYPE_TO_SALTO_TYPE: Record<string, string> = {
   [TICKET_TICKET_FIELD]: TICKET_FIELD_TYPE_NAME,
   [TICKET_FIELD_OPTION_TITLE]: TICKET_FIELD_TYPE_NAME,
   [ORGANIZATION_FIELD]: ORG_FIELD_TYPE_NAME,
-  [c]: USER_FIELD_TYPE_NAME,
+  [USER_FIELD]: USER_FIELD_TYPE_NAME,
 }
 
 const ZENDESK_TYPE_TO_FIELD: Record<string, string> = {
@@ -175,7 +175,7 @@ const formulaToTemplate = (
         return [
           `${type}.`,
           new ReferenceExpression(elem.elemID, elem),
-          title !== undefined ? title : '',
+          title !== undefined ? `.${title}` : '',
         ]
       }
       return [
@@ -193,7 +193,14 @@ const formulaToTemplate = (
       ZENDESK_REFERENCE_TYPE_TO_SALTO_TYPE[type],
       innerId
     )
-    missingInstance.value.id = innerId
+    missingInstance.value[ZENDESK_TYPE_TO_FIELD[type]] = innerId
+    if (KEY_FIELDS.includes(type)) {
+      return [
+        `${type}.`,
+        new ReferenceExpression(missingInstance.elemID, missingInstance),
+        title !== undefined ? `.${title}` : '',
+      ]
+    }
     return [
       `${type}_`,
       new ReferenceExpression(missingInstance.elemID, missingInstance),

--- a/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
@@ -37,6 +37,10 @@ const log = logger(module)
 const BRACKETS = [['{{', '}}'], ['{%', '%}']]
 const REFERENCE_MARKER_REGEX = /\$\{(.+?)}/
 const DYNAMIC_CONTENT_REGEX = /(dc\.[\w-]+)/g
+const TICKET_FIELD_SPLIT = '(?:(ticket.ticket_field|ticket.ticket_field_option_title)_([\\d]+))'
+const KEY_SPLIT = '(?:([^ ]+\\.custom_fields)\\.)'
+const TITLE_SPLIT = '(?:([^ ]+)\\.(title))'
+const SPLIT_REGEX = `${TICKET_FIELD_SPLIT}|${KEY_SPLIT}|${TITLE_SPLIT}`
 export const TICKET_TICKET_FIELD = 'ticket.ticket_field'
 export const TICKET_FIELD_OPTION_TITLE = 'ticket.ticket_field_option_title'
 export const ORGANIZATION_FIELD = 'ticket.organization.custom_fields'
@@ -162,7 +166,9 @@ const formulaToTemplate = (
 ): TemplateExpression | string => {
   const handleZendeskReference = (expression: string, ref: RegExpMatchArray): TemplatePart[] => {
     const reference = ref.pop() ?? ''
-    const splitReference = reference.split(/(?:_([\d]+))|(?:([^ ]+\.custom_fields)\.)|(?:([^ ]+)\.(title))/).filter(v => !_.isEmpty(v))
+    // const splitReference = reference.split(/(?:(ticket.ticket_field|ticket.ticket_field_option_title)_([\d]+))|
+    // (?:([^ ]+\.custom_fields)\.)|(?:([^ ]+)\.(title))/).filter(v => !_.isEmpty(v))
+    const splitReference = reference.split(new RegExp(SPLIT_REGEX)).filter(v => !_.isEmpty(v))
     // should be exactly of the form TYPE_INNERID, so should contain exactly two parts
     if (splitReference.length !== 2 && splitReference.length !== 3) {
       return [expression]

--- a/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
+++ b/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
@@ -17,9 +17,9 @@ import { ElemID, InstanceElement, ObjectType, ReferenceExpression,
   BuiltinTypes, TemplateExpression, MapType, toChange, isInstanceElement } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import filterCreator, {
-  ORGANIZATION_FIELD,
-  TICKET_FIELD_OPTION_TITLE,
-  TICKET_TICKET_FIELD, USER_FIELD,
+  TICKET_ORGANIZATION_FIELD,
+  TICKET_TICKET_FIELD_OPTION_TITLE,
+  TICKET_TICKET_FIELD, TICKET_USER_FIELD,
 } from '../../src/filters/handle_template_expressions'
 import { ORG_FIELD_TYPE_NAME, USER_FIELD_TYPE_NAME, ZENDESK } from '../../src/constants'
 import { createMissingInstance } from '../../src/filters/references/missing_references'
@@ -274,7 +274,7 @@ describe('handle templates filter', () => {
         new TemplateExpression({ parts: [
           'dynamic content ref {{',
           new ReferenceExpression(dynamicContentRecord.elemID, dynamicContentRecord),
-          `}} and {{${TICKET_FIELD_OPTION_TITLE}_`,
+          `}} and {{${TICKET_TICKET_FIELD_OPTION_TITLE}_`,
           new ReferenceExpression(placeholder2.elemID, placeholder2),
           '}}'] })
       )
@@ -284,7 +284,7 @@ describe('handle templates filter', () => {
         new TemplateExpression({ parts: [
           'dynamic content ref {{',
           new ReferenceExpression(hyphenDynamicContentRecord.elemID, hyphenDynamicContentRecord),
-          `}} and {{${TICKET_FIELD_OPTION_TITLE}_`,
+          `}} and {{${TICKET_TICKET_FIELD_OPTION_TITLE}_`,
           new ReferenceExpression(placeholder2.elemID, placeholder2),
           '}}'] })
       )
@@ -315,7 +315,7 @@ describe('handle templates filter', () => {
         parts: [
           `multiple refs {{${TICKET_TICKET_FIELD}_`,
           new ReferenceExpression(placeholder1.elemID, placeholder1),
-          `}} and {{${TICKET_FIELD_OPTION_TITLE}_`,
+          `}} and {{${TICKET_TICKET_FIELD_OPTION_TITLE}_`,
           new ReferenceExpression(placeholder2.elemID, placeholder2),
           '}}',
         ],
@@ -328,14 +328,14 @@ describe('handle templates filter', () => {
         .filter(i => i.elemID.name === 'macroSideConvTicket')[0]
       expect(macroWithSideConv).toBeDefined()
       expect(macroWithSideConv.value.actions[0].value).toEqual([
-        new TemplateExpression({ parts: [`Improved needs for {{${TICKET_FIELD_OPTION_TITLE}_`, new ReferenceExpression(placeholder3.elemID, placeholder3), '}}'] }),
-        new TemplateExpression({ parts: [`<p>Improved needs for {{${TICKET_FIELD_OPTION_TITLE}_`, new ReferenceExpression(placeholder3.elemID, placeholder3), '}} due to something</p>'] }),
+        new TemplateExpression({ parts: [`Improved needs for {{${TICKET_TICKET_FIELD_OPTION_TITLE}_`, new ReferenceExpression(placeholder3.elemID, placeholder3), '}}'] }),
+        new TemplateExpression({ parts: [`<p>Improved needs for {{${TICKET_TICKET_FIELD_OPTION_TITLE}_`, new ReferenceExpression(placeholder3.elemID, placeholder3), '}} due to something</p>'] }),
         'hello',
         'text/html',
       ])
       expect(macroWithSideConv.value.actions[1].value).toEqual([
-        new TemplateExpression({ parts: [`Improved needs for {{${TICKET_FIELD_OPTION_TITLE}_`, new ReferenceExpression(placeholder3.elemID, placeholder3), '}}'] }),
-        new TemplateExpression({ parts: [`<p>Improved needs for {{${TICKET_FIELD_OPTION_TITLE}_`, new ReferenceExpression(placeholder3.elemID, placeholder3), '}} due to something</p>'] }),
+        new TemplateExpression({ parts: [`Improved needs for {{${TICKET_TICKET_FIELD_OPTION_TITLE}_`, new ReferenceExpression(placeholder3.elemID, placeholder3), '}}'] }),
+        new TemplateExpression({ parts: [`<p>Improved needs for {{${TICKET_TICKET_FIELD_OPTION_TITLE}_`, new ReferenceExpression(placeholder3.elemID, placeholder3), '}} due to something</p>'] }),
         'hello',
         'text/html',
       ])
@@ -359,11 +359,11 @@ describe('handle templates filter', () => {
       const fetchedMacro = elements.filter(isInstanceElement).find(i => i.elemID.name === 'macroOrg')
       expect(fetchedMacro?.value.actions[0].value).toEqual(new TemplateExpression({
         parts: [
-          `multiple refs {{${ORGANIZATION_FIELD}.`,
+          `multiple refs {{${TICKET_ORGANIZATION_FIELD}.`,
           new ReferenceExpression(placeholderOrganization2.elemID, placeholderOrganization2),
-          `}} and {{${ORGANIZATION_FIELD}.`,
+          `}} and {{${TICKET_ORGANIZATION_FIELD}.`,
           new ReferenceExpression(placeholderOrganization1.elemID, placeholderOrganization1),
-          `}} and {{${ORGANIZATION_FIELD}.`,
+          `}} and {{${TICKET_ORGANIZATION_FIELD}.`,
           new ReferenceExpression(placeholderOrganization2.elemID, placeholderOrganization2),
           '.title}}',
         ],
@@ -373,11 +373,11 @@ describe('handle templates filter', () => {
       const fetchedMacro = elements.filter(isInstanceElement).find(i => i.elemID.name === 'macroUser')
       expect(fetchedMacro?.value.actions[0].value).toEqual(new TemplateExpression({
         parts: [
-          `multiple refs {{${USER_FIELD}.`,
+          `multiple refs {{${TICKET_USER_FIELD}.`,
           new ReferenceExpression(placeholderUser2.elemID, placeholderUser2),
-          `}} and {{${USER_FIELD}.`,
+          `}} and {{${TICKET_USER_FIELD}.`,
           new ReferenceExpression(placeholderUser1.elemID, placeholderUser1),
-          `}} and {{${USER_FIELD}.`,
+          `}} and {{${TICKET_USER_FIELD}.`,
           new ReferenceExpression(placeholderUser2.elemID, placeholderUser2),
           '.title}}',
         ],
@@ -391,13 +391,13 @@ describe('handle templates filter', () => {
       missingUserInstance.value.key = 'user1'
       expect(fetchedMacro?.value.actions[0].value).toEqual(new TemplateExpression({
         parts: [
-          `multiple refs {{${USER_FIELD}.`,
+          `multiple refs {{${TICKET_USER_FIELD}.`,
           new ReferenceExpression(missingUserInstance.elemID, missingUserInstance),
-          `}} and {{${USER_FIELD}.`,
+          `}} and {{${TICKET_USER_FIELD}.`,
           new ReferenceExpression(missingUserInstance.elemID, missingUserInstance),
-          `.title}} and {{${ORGANIZATION_FIELD}.`,
+          `.title}} and {{${TICKET_ORGANIZATION_FIELD}.`,
           new ReferenceExpression(missingOrgInstance.elemID, missingOrgInstance),
-          `}} and {{${ORGANIZATION_FIELD}.`,
+          `}} and {{${TICKET_ORGANIZATION_FIELD}.`,
           new ReferenceExpression(missingOrgInstance.elemID, missingOrgInstance),
           '.title}}',
         ],


### PR DESCRIPTION
_zendesk support templating for custom fields user and organization_

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk: 
* zendesk support templating for custom fields user and organization

---
_User Notifications_: 
zendesk:
* placeholders that looked like this:
 `{{ticket.organization.custom_fields.<key>}}` ,` {{ticket.organization.custom_fields.<key>.title}}`, `{{ticket.requester.custom_fields.<key>}}`, `{{ticket.requester.custom_fields.<key>.title}}`
will now have a reference expression instead of the `<key>`.
