### PR TITLE
salto-3486/swagger retry all the time

### DIFF
--- a/packages/adapter-components/src/elements/swagger/swagger.ts
+++ b/packages/adapter-components/src/elements/swagger/swagger.ts
@@ -43,15 +43,11 @@ export const loadSwagger = async (
       parser,
     }
   } catch (err) {
-    if (err.status !== undefined) {
-      log.warn(`Failed to load swagger file ${swaggerPath} with error: ${err}. Retries left: ${numberOfRetries} (retrying in %ds)`, retryDelayMs / 1000)
-      if (numberOfRetries <= 0) {
-        throw err
-      }
-      await sleep(retryDelayMs)
-      return loadSwagger(swaggerPath, numberOfRetries - 1)
+    log.warn(`Failed to load swagger file ${swaggerPath} with error: ${err}. Retries left: ${numberOfRetries} (retrying in %ds)`, retryDelayMs / 1000)
+    if (numberOfRetries <= 0) {
+      throw err
     }
-    log.warn(`Failed to load swagger file ${swaggerPath} with error: ${err}`)
-    throw err
+    await sleep(retryDelayMs)
+    return loadSwagger(swaggerPath, numberOfRetries - 1)
   }
 }

--- a/packages/adapter-components/test/elements/swagger/swagger.test.ts
+++ b/packages/adapter-components/test/elements/swagger/swagger.test.ts
@@ -18,14 +18,6 @@ import { loadSwagger } from '../../../src/elements/swagger'
 
 const mockBundle = jest.fn()
 
-class ErrorWithStatus extends Error {
-  constructor(
-    message: string,
-    readonly status: number,
-  ) {
-    super(message)
-  }
-}
 jest.mock('@apidevtools/swagger-parser', () =>
   jest.fn().mockImplementation(
     () => ({ bundle: mockBundle })
@@ -37,20 +29,15 @@ describe('loadSwagger', () => {
   beforeEach(() => {
     mockBundle.mockClear()
   })
-  it('should retry when failing with status arg', async () => {
-    mockBundle.mockRejectedValueOnce(new ErrorWithStatus('Failed to load swagger', 400))
+
+  it('should retry when failing', async () => {
+    mockBundle.mockRejectedValueOnce(new Error('Failed to load swagger'))
     await loadSwagger('url', 3, 10)
     expect(mockBundle).toHaveBeenCalledTimes(2)
   })
 
-  it('should not retry when failing without status arg', async () => {
-    mockBundle.mockRejectedValueOnce(new Error('Failed to load swagger'))
-    await expect(loadSwagger('url', 3, 10)).rejects.toThrow()
-    expect(mockBundle).toHaveBeenCalledTimes(1)
-  })
-
   it('should throw if failed after retries', async () => {
-    mockBundle.mockRejectedValue(new ErrorWithStatus('Failed to load swagger', 400))
+    mockBundle.mockRejectedValue(new Error('Failed to load swagger'))
     await expect(loadSwagger('url', 3, 10)).rejects.toThrow()
     expect(mockBundle).toHaveBeenCalledTimes(4)
   })

--- a/packages/adapter-components/test/elements/swagger/swagger.test.ts
+++ b/packages/adapter-components/test/elements/swagger/swagger.test.ts
@@ -15,7 +15,14 @@
 */
 import { loadSwagger } from '../../../src/elements/swagger'
 
-
+class ErrorWithStatus extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message)
+  }
+}
 const mockBundle = jest.fn()
 
 jest.mock('@apidevtools/swagger-parser', () =>
@@ -29,7 +36,11 @@ describe('loadSwagger', () => {
   beforeEach(() => {
     mockBundle.mockClear()
   })
-
+  it('should retry when failing with status arg', async () => {
+    mockBundle.mockRejectedValueOnce(new ErrorWithStatus('Failed to load swagger', 400))
+    await loadSwagger('url', 3, 10)
+    expect(mockBundle).toHaveBeenCalledTimes(2)
+  })
   it('should retry when failing', async () => {
     mockBundle.mockRejectedValueOnce(new Error('Failed to load swagger'))
     await loadSwagger('url', 3, 10)

--- a/packages/adapter-components/test/elements/swagger/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/type_elements.test.ts
@@ -19,6 +19,20 @@ import { ObjectType, ElemID, ListType, TypeElement, BuiltinTypes, MapType } from
 import { generateTypes, toPrimitiveType } from '../../../src/elements/swagger'
 import { RequestableTypeSwaggerConfig } from '../../../src/config'
 
+jest.mock('@salto-io/lowerdash', () => {
+  const actual = jest.requireActual('@salto-io/lowerdash')
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      timeout: {
+        ...actual.promises.timeout,
+        sleep: () => undefined,
+      },
+    },
+  }
+})
+
 const ADAPTER_NAME = 'myAdapter'
 const BASE_DIR = __dirname.replace('/dist', '')
 


### PR DESCRIPTION
removed logic that only retried fetching swagger file if the error has status.
now we will retry as the full amount of "numberOfRetries"

---

_Additional context for reviewer_

---
_Release Notes_: 


---
_User Notifications_: 

