### PR TITLE
SALTO-2162: Replace organization ids with organization names in Zendesk

### DIFF
--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -114,6 +114,7 @@ import guideAddBrandToArticleTranslation from './filters/guide_add_brand_to_tran
 import ticketFormDeploy from './filters/ticket_form'
 import supportAddress from './filters/support_address'
 import customStatus from './filters/custom_statuses'
+import organizationsFilter from './filters/organizations'
 
 const { makeArray } = collections.array
 const log = logger(module)
@@ -155,6 +156,7 @@ export const DEFAULT_FILTERS = [
   // removeDefinitionInstancesFilter should be after hardcodedChannelFilter
   removeDefinitionInstancesFilter,
   usersFilter,
+  organizationsFilter,
   tagsFilter,
   supportAddress,
   customStatus,

--- a/packages/zendesk-adapter/src/filters/organizations.ts
+++ b/packages/zendesk-adapter/src/filters/organizations.ts
@@ -1,0 +1,230 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import Joi from 'joi'
+import { logger } from '@salto-io/logging'
+import { resolvePath, setPath } from '@salto-io/adapter-utils'
+import { client as clientUtils } from '@salto-io/adapter-components'
+import { collections, values as lowerDashValues } from '@salto-io/lowerdash'
+import { Change, getChangeData, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
+import { FilterCreator } from '../filter'
+import { ValueReplacer, deployModificationFunc, replaceConditionsAndActionsCreator, fieldReplacer } from '../replacers_utils'
+import ZendeskClient from '../client/client'
+import { paginate } from '../client/pagination'
+
+const log = logger(module)
+const { isDefined } = lowerDashValues
+const { toArrayAsync } = collections.asynciterable
+const { makeArray } = collections.array
+
+const DEFAULT_ORGANIZATION_FIELDS = [{ name: 'organization_id' }]
+
+type Organization = {
+  id: number
+  name: string
+}
+
+type OrganizationResponse = {
+  organizations: Organization[]
+}
+
+const ORGANIZATIONS_SCHEMA = Joi.array().items(Joi.object({
+  id: Joi.number().required(),
+  name: Joi.string().required(),
+}).unknown(true)).required()
+
+const EXPECTED_ORGANIZATION_RESPONSE_SCHEMA = Joi.object({
+  organizations: ORGANIZATIONS_SCHEMA,
+}).unknown(true)
+
+const isOrganizationsResponse = (response: unknown): response is OrganizationResponse => {
+  const { error } = EXPECTED_ORGANIZATION_RESPONSE_SCHEMA.validate(response)
+  if (error !== undefined) {
+    log.warn(`Received an invalid response for the organization request: ${error.message}`)
+    return false
+  }
+  return true
+}
+
+const areOrganizations = (values: unknown): values is Organization[] => {
+  const { error } = ORGANIZATIONS_SCHEMA.validate(values)
+  if (error !== undefined) {
+    log.warn(`Received invalid organizations: ${error.message}`)
+    return false
+  }
+  return true
+}
+
+const TYPE_NAME_TO_REPLACER: Record<string, ValueReplacer> = {
+  automation: replaceConditionsAndActionsCreator([
+    { fieldName: ['conditions', 'all'], fieldsToReplace: DEFAULT_ORGANIZATION_FIELDS },
+    { fieldName: ['conditions', 'any'], fieldsToReplace: DEFAULT_ORGANIZATION_FIELDS },
+  ]),
+  routing_attribute_value: replaceConditionsAndActionsCreator([
+    { fieldName: ['conditions', 'all'], fieldsToReplace: DEFAULT_ORGANIZATION_FIELDS },
+    { fieldName: ['conditions', 'any'], fieldsToReplace: DEFAULT_ORGANIZATION_FIELDS },
+  ]),
+  sla_policy: replaceConditionsAndActionsCreator([
+    { fieldName: ['filter', 'all'], fieldsToReplace: DEFAULT_ORGANIZATION_FIELDS },
+    { fieldName: ['filter', 'any'], fieldsToReplace: DEFAULT_ORGANIZATION_FIELDS },
+  ], true),
+  trigger: replaceConditionsAndActionsCreator([
+    { fieldName: ['conditions', 'all'], fieldsToReplace: DEFAULT_ORGANIZATION_FIELDS },
+    { fieldName: ['conditions', 'any'], fieldsToReplace: DEFAULT_ORGANIZATION_FIELDS },
+  ]),
+  workspace: replaceConditionsAndActionsCreator([
+    { fieldName: ['conditions', 'all'], fieldsToReplace: DEFAULT_ORGANIZATION_FIELDS },
+    { fieldName: ['conditions', 'any'], fieldsToReplace: DEFAULT_ORGANIZATION_FIELDS },
+  ], true),
+  ticket_field: replaceConditionsAndActionsCreator([
+    { fieldName: ['relationship_filter', 'all'], fieldsToReplace: DEFAULT_ORGANIZATION_FIELDS },
+    { fieldName: ['relationship_filter', 'any'], fieldsToReplace: DEFAULT_ORGANIZATION_FIELDS },
+  ]),
+  user_segment: fieldReplacer(['organization_ids']),
+}
+
+const isRelevantChange = (change: Change<InstanceElement>): boolean => (
+  Object.keys(TYPE_NAME_TO_REPLACER).includes(getChangeData(change).elemID.typeName)
+)
+
+const getOrganizationsByIds = async (
+  organizationIds: string[],
+  client: ZendeskClient,
+): Promise<Organization[]> => {
+  const results = (await Promise.all(
+    _.chunk(organizationIds, 100) // The api limits to 100 ids in each request
+      .map(async organizationChunk => {
+        const url = `/api/v2/organizations/show_many?ids=${organizationChunk.join(',')}`
+        const result = await client.getSinglePage({ url })
+        if (!isOrganizationsResponse(result.data)) {
+          log.error('Invalid organizations response')
+          return undefined
+        }
+        return result.data
+      })
+  )).filter(isDefined)
+
+  return results.flatMap(orgResponse => orgResponse.organizations)
+}
+
+const getOrganizationsByNames = async (
+  organizationNames: string[],
+  paginator: clientUtils.Paginator,
+): Promise<Organization[]> => {
+  const paginationArgs = {
+    url: '/api/v2/organizations/autocomplete',
+    paginationField: 'next_page',
+  }
+  const organizations = (await Promise.all(
+    organizationNames
+      .map(async organizationName => {
+        _.set(paginationArgs, 'queryParams', { name: organizationName })
+        const res = (await toArrayAsync(paginator(
+          paginationArgs,
+          page => makeArray(page) as clientUtils.ResponseValue[],
+        ))).flat().flatMap(response => response.organizations)
+        if (!areOrganizations(res)) {
+          log.error('invalid organization response')
+          return undefined
+        }
+        // the endpoint returns all organizations with names matching the wildcard `organizationName`
+        const organization = res.find(org => org.name === organizationName)
+        if (organization === undefined) {
+          log.error(`could not find any organization with name ${organizationName}`)
+          return undefined
+        }
+        return organization
+      })
+  )).filter(isDefined)
+
+  return organizations
+}
+
+/**
+ * Replaces organization ids with organization names
+ */
+const filterCreator: FilterCreator = ({ client }) => {
+  let organizationIdToName: Record<string, string> = {}
+  return {
+    onFetch: async elements => log.time(async () => {
+      const relevantInstances = elements.filter(isInstanceElement)
+        .filter(instance => Object.keys(TYPE_NAME_TO_REPLACER).includes(instance.elemID.typeName))
+
+      const organizationPathsEntries = relevantInstances.flatMap(instance => {
+        const organizationPaths = TYPE_NAME_TO_REPLACER[instance.elemID.typeName]?.(instance)
+        return organizationPaths
+          .map(path => {
+            const orgId = resolvePath(instance, path)
+            const stringOrgId = !_.isString(orgId) ? orgId.toString() : orgId
+            return { id: stringOrgId, instance, path }
+          })
+      })
+        .filter(entry => entry.id !== '') // organization id value might be an empty string
+
+      const pathEntriesByOrgId = _.groupBy(organizationPathsEntries, entry => entry.id)
+      const organizationIds = _.uniq(Object.keys(pathEntriesByOrgId))
+
+      const organizations = await getOrganizationsByIds(organizationIds, client)
+      const mapping = Object.fromEntries(
+        organizations.map(org => [org.id.toString(), org.name])
+      )
+      organizations.forEach(org => {
+        const relevantEntries = pathEntriesByOrgId[org.id.toString()] ?? []
+        const orgName = mapping[org.id.toString()]
+        relevantEntries.forEach(entry => setPath(entry.instance, entry.path, orgName))
+      })
+    }, 'Organizations filter'),
+    preDeploy: async (changes: Change<InstanceElement>[]) => {
+      const relevantChanges = changes.filter(isRelevantChange)
+      if (_.isEmpty(relevantChanges)) {
+        return
+      }
+      const organizationNames = _.uniq(relevantChanges.flatMap(change => {
+        const instance = getChangeData(change)
+        const organizationPaths = TYPE_NAME_TO_REPLACER[instance.elemID.typeName]?.(instance)
+        return organizationPaths.map(path => resolvePath(instance, path))
+      })).filter(name => name !== '') // filter out empty strings
+      if (_.isEmpty(organizationNames)) {
+        return
+      }
+
+      const paginator = clientUtils.createPaginator({
+        client,
+        paginationFuncCreator: paginate,
+      })
+      const organizations = await getOrganizationsByNames(organizationNames, paginator)
+      if (_.isEmpty(organizations)) {
+        return
+      }
+      organizationIdToName = Object.fromEntries(
+        organizations.map(org => [org.id.toString(), org.name])
+      ) as Record<string, string>
+      const organizationNameToId = Object.fromEntries(
+        organizations.map(org => [org.name, org.id.toString()])
+      ) as Record<string, string>
+      await deployModificationFunc(changes, organizationNameToId, TYPE_NAME_TO_REPLACER)
+    },
+    onDeploy: async (changes: Change<InstanceElement>[]) => {
+      const relevantChanges = changes.filter(isRelevantChange)
+      if (_.isEmpty(relevantChanges)) {
+        return
+      }
+      await deployModificationFunc(changes, organizationIdToName, TYPE_NAME_TO_REPLACER)
+    },
+  }
+}
+
+export default filterCreator

--- a/packages/zendesk-adapter/src/replacers_utils.ts
+++ b/packages/zendesk-adapter/src/replacers_utils.ts
@@ -1,0 +1,113 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { applyFunctionToChangeData } from '@salto-io/adapter-utils'
+import { collections } from '@salto-io/lowerdash'
+import { Change, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { conditionFieldValue, isCorrectConditions } from './filters/utils'
+
+const { awu } = collections.asynciterable
+
+export type ValueReplacer = (instance: InstanceElement, mapping?: Record<string, string>) => ElemID[]
+
+type FieldsParams = {
+  fieldName: string[]
+  fieldsToReplace: { name: string; valuePath?: string[] }[]
+}
+
+export const replaceConditionsAndActionsCreator = (
+  params: FieldsParams[],
+  isIdNumber = false,
+): ValueReplacer => (instance, mapping) => (
+  params.flatMap(replacerParams => {
+    const conditions = _.get(instance.value, replacerParams.fieldName)
+    const { typeName } = instance.elemID
+    // Coditions can be undefined - in that case, we don't want to log a warning
+    if (conditions === undefined
+      || !isCorrectConditions(conditions, typeName)) {
+      return []
+    }
+    return conditions
+      .flatMap((condition, i) => {
+        const fieldNamesToReplace = replacerParams.fieldsToReplace.map(f => f.name)
+        const conditionValue = conditionFieldValue(condition, typeName)
+        if (!fieldNamesToReplace.includes(conditionValue)) {
+          return []
+        }
+        const valueRelativePath = replacerParams.fieldsToReplace
+          .find(f => f.name === conditionValue)?.valuePath ?? ['value']
+        const value = _.get(condition, valueRelativePath)?.toString()
+        if (value === undefined) {
+          return []
+        }
+        const valuePath = instance.elemID
+          .createNestedID(...replacerParams.fieldName, i.toString(), ...valueRelativePath)
+        if (mapping !== undefined) {
+          const newValue = Object.prototype.hasOwnProperty.call(mapping, value) ? mapping[value] : undefined
+          if (newValue !== undefined) {
+            _.set(condition, valueRelativePath, (isIdNumber && Number.isInteger(Number(newValue)))
+              ? Number(newValue)
+              : newValue)
+          }
+        }
+        return [valuePath]
+      })
+  })
+)
+
+export const fieldReplacer = (fields: string[]): ValueReplacer => (instance, mapping) => (
+  fields
+    .flatMap(field => {
+      const fieldValue = _.get(instance.value, field)
+      if (fieldValue === undefined) {
+        return []
+      }
+      const fieldValuePath = instance.elemID.createNestedID(field)
+      const values = (_.isArray(fieldValue) ? fieldValue : [fieldValue])
+        .map(v => v.toString())
+      if (mapping !== undefined) {
+        values.forEach((value, i) => {
+          const newValue = Object.prototype.hasOwnProperty.call(mapping, value) ? mapping[value] : undefined
+          if (newValue !== undefined) {
+            _.set(
+              instance.value,
+              _.isArray(fieldValue) ? [field, i] : field,
+              (Number.isInteger(Number(newValue))) ? Number(newValue) : newValue
+            )
+          }
+        })
+      }
+      return _.isArray(fieldValue)
+        ? values.map((_value, i) => fieldValuePath.createNestedID(i.toString()))
+        : [fieldValuePath]
+    })
+)
+
+export const deployModificationFunc = async (
+  changes: Change<InstanceElement>[],
+  mapping: Record<string, string>,
+  typeNameToReplacer: Record<string, ValueReplacer>
+): Promise<void> => {
+  await awu(changes).forEach(async change => {
+    await applyFunctionToChangeData<Change<InstanceElement>>(
+      change,
+      instance => {
+        typeNameToReplacer[instance.elemID.typeName]?.(instance, mapping)
+        return instance
+      }
+    )
+  })
+}

--- a/packages/zendesk-adapter/test/filters/organizations.test.ts
+++ b/packages/zendesk-adapter/test/filters/organizations.test.ts
@@ -1,0 +1,215 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, ElemID, InstanceElement, isInstanceElement, toChange } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import { ZENDESK } from '../../src/constants'
+import filterCreator from '../../src/filters/organizations'
+import { createFilterCreatorParams } from '../utils'
+import ZendeskClient from '../../src/client/client'
+
+describe('organizations filter', () => {
+  type FilterType = filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
+  let filter: FilterType
+  const triggerType = new ObjectType({ elemID: new ElemID(ZENDESK, 'trigger') })
+  const userSegmentType = new ObjectType({ elemID: new ElemID(ZENDESK, 'user_segment') })
+
+  const userSegmentInstance = new InstanceElement(
+    'test',
+    userSegmentType,
+    {
+      title: 'test',
+      organization_ids: [1, 2, 3],
+    }
+  )
+
+  const triggerInstance = new InstanceElement(
+    'test',
+    triggerType,
+    {
+      title: 'test',
+      actions: [
+        { field: 'status', value: 'closed' },
+      ],
+      conditions: {
+        all: [
+          { field: 'organization_id', operator: 'is', value: '3' },
+          { field: 'assignee_id', operator: 'is', value: '3' },
+        ],
+        any: [
+          { field: 'SOLVED', operator: 'greater_than', value: '96' },
+          { field: 'organization_id', operator: 'is_not', value: '2' },
+        ],
+      },
+    },
+  )
+
+  describe('onFetch', () => {
+    let client: ZendeskClient
+    let mockGet: jest.SpyInstance
+
+    beforeEach(async () => {
+      jest.clearAllMocks()
+      client = new ZendeskClient({
+        credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
+      })
+      mockGet = jest.spyOn(client, 'getSinglePage')
+      mockGet.mockResolvedValue({
+        status: 200,
+        data: {
+          organizations: [
+            { id: 1, name: 'org1' },
+            { id: 2, name: 'org2' },
+            { id: 3, name: 'org3' },
+            { id: 4, name: 'org4' },
+            { id: 5, name: 'org5' },
+          ],
+        },
+      })
+      filter = filterCreator(
+        createFilterCreatorParams({ client })
+      ) as FilterType
+    })
+    it('should replace all organization ids with names', async () => {
+      const elements = [userSegmentType, userSegmentInstance, triggerType, triggerInstance]
+        .map(e => e.clone())
+      await filter.onFetch(elements)
+      const instances = elements.filter(isInstanceElement)
+      const trigger = instances.find(e => e.elemID.typeName === 'trigger')
+      expect(trigger?.value).toEqual({
+        title: 'test',
+        actions: [
+          { field: 'status', value: 'closed' },
+        ],
+        conditions: {
+          all: [
+            { field: 'organization_id', operator: 'is', value: 'org3' },
+            { field: 'assignee_id', operator: 'is', value: '3' },
+          ],
+          any: [
+            { field: 'SOLVED', operator: 'greater_than', value: '96' },
+            { field: 'organization_id', operator: 'is_not', value: 'org2' },
+          ],
+        },
+      },)
+      const userSegment = instances.find(e => e.elemID.typeName === 'user_segment')
+      expect(userSegment?.value).toEqual({
+        title: 'test',
+        organization_ids: ['org1', 'org2', 'org3'],
+      })
+    })
+  })
+  describe('preDeploy', () => {
+    let client: ZendeskClient
+    let mockGet: jest.SpyInstance
+    beforeEach(async () => {
+      jest.clearAllMocks()
+      client = new ZendeskClient({
+        credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
+      })
+      mockGet = jest.spyOn(client, 'getSinglePage')
+      filter = filterCreator(
+        createFilterCreatorParams({ client })
+      ) as FilterType
+    })
+    it('should repalce organizaion names with emails', async () => {
+      mockGet
+        .mockResolvedValueOnce({
+          status: 200,
+          data: {
+            organizations: [
+              { id: 1, name: 'org1' },
+              { id: 2, name: 'org11' },
+              { id: 3, name: 'org1111' },
+            ],
+          },
+        })
+        .mockResolvedValueOnce({
+          status: 200,
+          data: {
+            organizations: [
+              { id: 2, name: 'org11' },
+              { id: 3, name: 'org1111' },
+            ],
+          },
+        })
+      const userSegAfterFetch = new InstanceElement(
+        'test',
+        userSegmentType,
+        {
+          title: 'test',
+          organization_ids: ['org1', 'org11'],
+        }
+      )
+      await filter.preDeploy([toChange({ after: userSegAfterFetch })])
+      expect(userSegAfterFetch.value).toEqual({
+        title: 'test',
+        organization_ids: [1, 2],
+      })
+    })
+  })
+  describe('onDeploy', () => {
+    let client: ZendeskClient
+    let mockGet: jest.SpyInstance
+    beforeEach(async () => {
+      jest.clearAllMocks()
+      client = new ZendeskClient({
+        credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
+      })
+      mockGet = jest.spyOn(client, 'getSinglePage')
+      filter = filterCreator(
+        createFilterCreatorParams({ client })
+      ) as FilterType
+    })
+    it('should change back organization ids to names', async () => {
+      mockGet
+        .mockResolvedValueOnce({
+          status: 200,
+          data: {
+            organizations: [
+              { id: 1, name: 'org1' },
+              { id: 2, name: 'org11' },
+              { id: 3, name: 'org1111' },
+            ],
+          },
+        })
+        .mockResolvedValueOnce({
+          status: 200,
+          data: {
+            organizations: [
+              { id: 2, name: 'org11' },
+              { id: 3, name: 'org1111' },
+            ],
+          },
+        })
+      const userSegAfterFetch = new InstanceElement(
+        'test',
+        userSegmentType,
+        {
+          title: 'test',
+          organization_ids: ['org1', 'org11'],
+        }
+      )
+      const changes = [toChange({ after: userSegAfterFetch })]
+      // We call preDeploy here because it sets the mappings
+      await filter.preDeploy(changes)
+      await filter.onDeploy(changes)
+      expect(userSegAfterFetch.value).toEqual({
+        title: 'test',
+        organization_ids: ['org1', 'org11'],
+      })
+    })
+  })
+})

--- a/packages/zendesk-adapter/test/replacers_utils.test.ts
+++ b/packages/zendesk-adapter/test/replacers_utils.test.ts
@@ -1,0 +1,81 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import { ZENDESK } from '../src/constants'
+import { fieldReplacer } from '../src/replacers_utils'
+
+describe('replacers utils', () => {
+  describe('fieldReplacer', () => {
+    const userSegmentType = new ObjectType({ elemID: new ElemID(ZENDESK, 'user_segment') })
+    const userSegmentInstance1 = new InstanceElement(
+      'test',
+      userSegmentType,
+      { title: 'test', added_user_ids: 1, best_user: 2 }
+    )
+    const userSegmentInstance2 = new InstanceElement(
+      'test',
+      userSegmentType,
+      { title: 'test', added_user_ids: [1, 2, 3] }
+    )
+    const userSegmentElemId = new ElemID(ZENDESK, userSegmentType.elemID.typeName, 'instance', 'test')
+    const valueReplacerFunc = fieldReplacer(['added_user_ids', 'best_user'])
+    it('should return the correct ElemIds', () => {
+      const userSegment1 = valueReplacerFunc(userSegmentInstance1)
+      const userSegment2 = valueReplacerFunc(userSegmentInstance2)
+      expect(userSegment1).toEqual([
+        userSegmentElemId.createNestedID('added_user_ids'),
+        userSegmentElemId.createNestedID('best_user'),
+      ])
+      expect(userSegment2).toEqual([
+        userSegmentElemId.createNestedID('added_user_ids', '0'),
+        userSegmentElemId.createNestedID('added_user_ids', '1'),
+        userSegmentElemId.createNestedID('added_user_ids', '2'),
+      ])
+    })
+    it('should replace values based on mapping', () => {
+      const usersMapping = Object.fromEntries([
+        ['1', 'a'],
+        ['2', 'b'],
+        ['3', 'c'],
+      ])
+      valueReplacerFunc(userSegmentInstance1, usersMapping)
+      valueReplacerFunc(userSegmentInstance2, usersMapping)
+      expect(userSegmentInstance1.value).toEqual(
+        { title: 'test', added_user_ids: 'a', best_user: 'b' }
+      )
+      expect(userSegmentInstance2.value).toEqual(
+        { title: 'test', added_user_ids: ['a', 'b', 'c'] }
+      )
+    })
+
+    it('should not replace value if it is missing from mapping', () => {
+      const usersMapping = Object.fromEntries([
+        ['1', 'a'],
+        ['2', 'b'],
+        ['3', 'c'],
+      ])
+      const userSegmentMissingValue = new InstanceElement(
+        'test',
+        userSegmentType,
+        { title: 'test', added_user_ids: [1, 4], best_user: 5 },
+      )
+      valueReplacerFunc(userSegmentMissingValue, usersMapping)
+      expect(userSegmentMissingValue.value).toEqual(
+        { title: 'test', added_user_ids: ['a', 4], best_user: 5 }
+      )
+    })
+  })
+})


### PR DESCRIPTION
Replace organization ids with organization names in Zendesk

---

Changes: 
- Add filter which replaces organization ids with a multienv value (unique organization name)
- As most of the code is shared with user filter, I moved shared code to `replacement_utils.ts`.
- `fieldReplacer` func now supports values replacement in arrays as well. This addition also fixes a bug causing field `added_user_ids` (array field) in `user_segment` with one element to be replaced with value + arrays with multiple elements were not replaced
bug fix pics - 
<img width="417" alt="image" src="https://user-images.githubusercontent.com/74004474/214537881-61b1ef13-790c-4d02-a8e4-8b7bad0686eb.png">
<img width="255" alt="image" src="https://user-images.githubusercontent.com/74004474/214537937-3896d769-0350-4927-9170-667541c1551b.png">


Will add noise reduction for orgIds changes
Added only basic tests that i'll improve later

---
_Release Notes_: 

_Zendesk-adapter_
- References to organization ids will be replaced with organization names

---
_User Notifications_: 

_Zendesk-adapter_
- References to organization ids will be replaced with organization names
