### PR TITLE
Create dependency between custom record type and its fields

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -73,6 +73,7 @@ import { LazyElementsSourceIndexes } from './elements_source_index/types'
 import getChangeValidator from './change_validator'
 import { FetchByQueryFunc, FetchByQueryReturnType } from './change_validators/safe_deploy'
 import { getChangeGroupIdsFunc } from './group_changes'
+import { dependencyChanger } from './dependency_changer'
 import { getCustomRecords } from './custom_records/custom_records'
 import { getDataElements } from './data_elements/data_elements'
 import { getStandardTypesNames, isStandardTypeName } from './autogen/types'
@@ -470,6 +471,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
         elementsSourceIndex: this.elementsSourceIndex,
       }),
       getChangeGroupIds: getChangeGroupIdsFunc(this.client.isSuiteAppConfigured()),
+      dependencyChanger,
     }
   }
 }

--- a/packages/netsuite-adapter/src/dependency_changer.ts
+++ b/packages/netsuite-adapter/src/dependency_changer.ts
@@ -14,14 +14,14 @@
 * limitations under the License.
 */
 import _ from 'lodash'
+import wu from 'wu'
 import { DependencyChanger, isObjectTypeChange, isFieldChange, dependencyChange, getChangeData } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 
 const { awu } = collections.asynciterable
 
 const createDependencyBetweenTypeAndFields: DependencyChanger = async changes => {
-  const changesWithKeys = Array.from(changes.entries())
-    .map(([key, change]) => ({ key, change }))
+  const changesWithKeys = wu(changes.entries()).map(([key, change]) => ({ key, change })).toArray()
   const typeChanges = _.keyBy(
     changesWithKeys.filter(({ change }) => isObjectTypeChange(change)),
     ({ change }) => getChangeData(change).elemID.getFullName()

--- a/packages/netsuite-adapter/src/dependency_changer.ts
+++ b/packages/netsuite-adapter/src/dependency_changer.ts
@@ -1,0 +1,44 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { DependencyChanger, isObjectTypeChange, isFieldChange, dependencyChange, getChangeData } from '@salto-io/adapter-api'
+import { values, collections } from '@salto-io/lowerdash'
+
+const { awu } = collections.asynciterable
+
+const createDependencyBetweenTypeAndFields: DependencyChanger = async changes => {
+  const changesWithKeys = Array.from(changes.entries())
+    .map(([key, change]) => ({ key, change }))
+  const typeChanges = _.keyBy(
+    changesWithKeys.filter(({ change }) => isObjectTypeChange(change)),
+    ({ change }) => getChangeData(change).elemID.getFullName()
+  )
+  return changesWithKeys.map(({ key, change }) => {
+    const parentDependency = isFieldChange(change)
+      ? typeChanges[getChangeData(change).parent.elemID.getFullName()]
+      : undefined
+    return parentDependency
+      ? dependencyChange('add', parentDependency.key, key)
+      : undefined
+  }).filter(values.isDefined)
+}
+
+const changers = [
+  createDependencyBetweenTypeAndFields,
+]
+
+export const dependencyChanger: DependencyChanger = (changes, dependencies) =>
+  awu(changers).flatMap(changer => changer(changes, dependencies)).toArray()

--- a/packages/netsuite-adapter/test/dependency_changer.test.ts
+++ b/packages/netsuite-adapter/test/dependency_changer.test.ts
@@ -53,20 +53,20 @@ describe('dependency changer', () => {
         toDependencyChange('add', anotherType, anotherField),
       ])
     })
-    it('should create dependency between fields of the same type', async () => {
+    it('should not create dependency when type is modified', async () => {
       const changesMap = toChangeNodesMap([
         field,
-        secondField,
         anotherType,
         anotherField,
       ])
+      const afterType = type.clone()
+      afterType.annotate({ anno: 'test' })
+      changesMap.set(type.elemID.getFullName(), toChange({ before: type, after: afterType }))
       await expect(dependencyChanger(changesMap, defaultDependencies)).resolves.toEqual([
-        toDependencyChange('add', field, secondField),
-        toDependencyChange('add', secondField, field),
         toDependencyChange('add', anotherType, anotherField),
       ])
     })
-    it('should not create dependency for one field change', async () => {
+    it('should not create dependency for a field without type change', async () => {
       const changesMap = toChangeNodesMap([
         field,
         anotherType,

--- a/packages/netsuite-adapter/test/dependency_changer.test.ts
+++ b/packages/netsuite-adapter/test/dependency_changer.test.ts
@@ -53,7 +53,20 @@ describe('dependency changer', () => {
         toDependencyChange('add', anotherType, anotherField),
       ])
     })
-    it('should not create dependency if the type is not a change', async () => {
+    it('should create dependency between fields of the same type', async () => {
+      const changesMap = toChangeNodesMap([
+        field,
+        secondField,
+        anotherType,
+        anotherField,
+      ])
+      await expect(dependencyChanger(changesMap, defaultDependencies)).resolves.toEqual([
+        toDependencyChange('add', field, secondField),
+        toDependencyChange('add', secondField, field),
+        toDependencyChange('add', anotherType, anotherField),
+      ])
+    })
+    it('should not create dependency for one field change', async () => {
       const changesMap = toChangeNodesMap([
         field,
         anotherType,
@@ -63,7 +76,7 @@ describe('dependency changer', () => {
         toDependencyChange('add', anotherType, anotherField),
       ])
     })
-    it('should not create dependency if the field is not a change', async () => {
+    it('should not create dependency for a type without field changes', async () => {
       const changesMap = toChangeNodesMap([
         type,
         anotherType,

--- a/packages/netsuite-adapter/test/dependency_changer.test.ts
+++ b/packages/netsuite-adapter/test/dependency_changer.test.ts
@@ -1,0 +1,77 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Element, BuiltinTypes, Change, ChangeDataType, ChangeId, DependencyChange, dependencyChange, ElemID, Field, ObjectType, toChange } from '@salto-io/adapter-api'
+import { dependencyChanger } from '../src/dependency_changer'
+import { NETSUITE } from '../src/constants'
+
+const toChangeNodesMap = (elements: ChangeDataType[]): Map<ChangeId, Change> =>
+  new Map(elements.map((element): [ChangeId, Change] => [
+    element.elemID.getFullName(),
+    toChange({ after: element }),
+  ]))
+
+const toDependencyChange = (
+  action: 'add' | 'remove',
+  sourceElem: Element,
+  targetElement: Element
+): DependencyChange =>
+  dependencyChange(action, sourceElem.elemID.getFullName(), targetElement.elemID.getFullName())
+
+describe('dependency changer', () => {
+  const defaultDependencies = new Map()
+
+  describe('create dependency between type and fields', () => {
+    const type = new ObjectType({ elemID: new ElemID(NETSUITE, 'type') })
+    const field = new Field(type, 'field', BuiltinTypes.BOOLEAN)
+    const secondField = new Field(type, 'secondField', BuiltinTypes.BOOLEAN)
+    const anotherType = new ObjectType({ elemID: new ElemID(NETSUITE, 'anotherType') })
+    const anotherField = new Field(anotherType, 'anotherField', BuiltinTypes.BOOLEAN)
+    it('should create dependency from each type to its fields', async () => {
+      const changesMap = toChangeNodesMap([
+        type,
+        field,
+        secondField,
+        anotherType,
+        anotherField,
+      ])
+      await expect(dependencyChanger(changesMap, defaultDependencies)).resolves.toEqual([
+        toDependencyChange('add', type, field),
+        toDependencyChange('add', type, secondField),
+        toDependencyChange('add', anotherType, anotherField),
+      ])
+    })
+    it('should not create dependency if the type is not a change', async () => {
+      const changesMap = toChangeNodesMap([
+        field,
+        anotherType,
+        anotherField,
+      ])
+      await expect(dependencyChanger(changesMap, defaultDependencies)).resolves.toEqual([
+        toDependencyChange('add', anotherType, anotherField),
+      ])
+    })
+    it('should not create dependency if the field is not a change', async () => {
+      const changesMap = toChangeNodesMap([
+        type,
+        anotherType,
+        anotherField,
+      ])
+      await expect(dependencyChanger(changesMap, defaultDependencies)).resolves.toEqual([
+        toDependencyChange('add', anotherType, anotherField),
+      ])
+    })
+  })
+})


### PR DESCRIPTION
Force a custom record type and its fields to be deployed together in the same change group.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Create dependency between custom record type and its fields

---
_User Notifications_: 
None