### PR TITLE
SALTO-3503 fix calculating changes hash as part of quick deploy

### DIFF
--- a/packages/adapter-utils/src/compare.ts
+++ b/packages/adapter-utils/src/compare.ts
@@ -21,9 +21,9 @@ import {
   CompareOptions,
   isIndexPathPart, Change, getChangeData,
 } from '@salto-io/adapter-api'
-import objectHash from 'object-hash'
 import { logger } from '@salto-io/logging'
-import { resolvePath, setPath } from './utils'
+import { hash as hashUtils } from '@salto-io/lowerdash'
+import { resolvePath, safeJsonStringify, setPath } from './utils'
 import { applyListChanges, getArrayIndexMapping } from './list_comparison'
 
 const log = logger(module)
@@ -370,6 +370,8 @@ export const applyDetailedChanges = (
     applyListChanges(element, changes)
   })
 }
+const sortChanges = (a: Change, b: Change): number =>
+  getChangeData(a).elemID.getFullName().localeCompare(getChangeData(b).elemID.getFullName())
 
 export const calculateChangesHash = (changes: ReadonlyArray<Change>): string =>
-  objectHash(_.keyBy(changes, change => getChangeData(change).elemID.getFullName()))
+  hashUtils.toMD5(safeJsonStringify(Array.from(changes).sort(sortChanges)))

--- a/packages/adapter-utils/test/compare.test.ts
+++ b/packages/adapter-utils/test/compare.test.ts
@@ -965,7 +965,7 @@ describe('applyDetailedChanges', () => {
 })
 
 describe('calculateChangesHash', () => {
-  const HASH_VALUE = '5d3c813c4f8bbd2620139772a1b9ac05a7c5e946'
+  const HASH_VALUE = '797c4b04aec0e7a2605a7a76eea686a4'
   const instType = new ObjectType({
     elemID: new ElemID('salto', 'obj'),
   })

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -346,7 +346,7 @@ describe('SalesforceAdapter CRUD', () => {
                     deploy: {
                       quickDeployParams: {
                         requestId: '1',
-                        hash: '05b65a169f36f640981b2ca17996ccc6195f7634',
+                        hash: 'ae603ec5f43ad6e8d4aaae0b44996ebd',
                       },
                     },
                   },
@@ -361,7 +361,7 @@ describe('SalesforceAdapter CRUD', () => {
               },
             })
           })
-          it('should fail the deploy', () => {
+          it('should deploy', () => {
             expect(result.appliedChanges).toHaveLength(1)
           })
         })


### PR DESCRIPTION
_fix calculating changes hash as part of quick deploy_

---
_Release Notes_: 
none
---
_User Notifications_: 
none
