### PR TITLE
SALTO-3508: no content for attachment after brand filter in zendesk guide

### DIFF
--- a/packages/zendesk-adapter/src/change_validators/article_attachment_size.ts
+++ b/packages/zendesk-adapter/src/change_validators/article_attachment_size.ts
@@ -15,9 +15,12 @@
 */
 import { ChangeValidator, getChangeData, isAdditionOrModificationChange, isInstanceElement } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
+import { logger } from '@salto-io/logging'
 import { ARTICLE_ATTACHMENT_TYPE_NAME } from '../constants'
 
 const { awu } = collections.asynciterable
+const log = logger(module)
+
 
 const SIZE_20_MB = 20 * 1024 * 1024
 export const articleAttachmentSizeValidator: ChangeValidator = async changes => {
@@ -27,6 +30,10 @@ export const articleAttachmentSizeValidator: ChangeValidator = async changes => 
     .filter(isInstanceElement)
     .filter(instance => instance.elemID.typeName === ARTICLE_ATTACHMENT_TYPE_NAME)
     .filter(async attachmentInstance => {
+      if (attachmentInstance.value.content === undefined) {
+        log.error(`the attachment ${attachmentInstance.elemID.getFullName()} does not have a content field`)
+        return false
+      }
       const internalContentLength = Buffer.byteLength(await attachmentInstance.value.content.getContent())
       return internalContentLength >= SIZE_20_MB
     })

--- a/packages/zendesk-adapter/src/filters/article/utils.ts
+++ b/packages/zendesk-adapter/src/filters/article/utils.ts
@@ -110,7 +110,7 @@ const getAttachmentContent = async ({
   attachmentType: ObjectType
 }): Promise<void> => {
   if (article === undefined) {
-    log.error(`could not att attachment ${attachment.elemID.getFullName()}, as could not find article for article_id ${attachment.value.article_id}`)
+    log.error(`could not add attachment ${attachment.elemID.getFullName()}, as could not find article for article_id ${attachment.value.article_id}`)
     return
   }
   const client = brandIdToClient[attachment.value.brand]
@@ -139,7 +139,7 @@ export const getArticleAttachments = async ({ brandIdToClient, articleById, atta
   apiDefinitions: ZendeskApiConfig
   attachments: Attachment[]
 }): Promise<void> => {
-  attachments.forEach(async attachment => {
+  await awu(attachments).forEach(async attachment => {
     const article = articleById[getParent(attachment).value.id]
     await getAttachmentContent({ brandIdToClient, attachment, article, attachmentType })
   })


### PR DESCRIPTION
_no content for attachment after brand filter in zendesk guide_

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
