### PR TITLE
Support deserialization of Field elements

### DIFF
--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -277,10 +277,13 @@ const generalDeserialize = async <T>(
 
     const reviveFieldDefinitions = (v: Value): Record<string, FieldDefinition> => (
       _.isPlainObject(v)
-        ? _.mapValues(v, field => ({
-          refType: reviveRefTypeOfElement(field),
-          annotations: restoreClasses(field.annotations),
-        }))
+        ? _.mapValues(
+          _.pickBy(v, val => isSerializedClass(val) && val[SALTO_CLASS_FIELD] === 'Field'),
+          val => ({
+            refType: reviveRefTypeOfElement(val),
+            annotations: restoreClasses(val.annotations),
+          })
+        )
         : {}
     )
 

--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -21,7 +21,7 @@ import {
   ReferenceExpression, TemplateExpression, VariableExpression,
   isReferenceExpression, Variable, StaticFile, isStaticFile,
   isPrimitiveType, FieldDefinition, Value, TypeRefMap, TypeReference, isTypeReference,
-  isVariableExpression,
+  isVariableExpression, PlaceholderObjectType,
 } from '@salto-io/adapter-api'
 import { DuplicateAnnotationError, MergeError, isMergeError } from '../merger/internal/common'
 import { DuplicateInstanceKeyError } from '../merger/internal/instances'
@@ -321,7 +321,9 @@ const generalDeserialize = async <T>(
       Field: v => {
         const elemId = reviveElemID(v.elemID)
         return new Field(
-          new ObjectType({ elemID: new ElemID(elemId.adapter, elemId.typeName) }),
+          // when we deserialize a single field we don't have the context of its parent.
+          // in this case we set a placeholder object type so we're able to recognize it later.
+          new PlaceholderObjectType({ elemID: new ElemID(elemId.adapter, elemId.typeName) }),
           elemId.name,
           reviveRefTypeOfElement(v),
           restoreClasses(v.annotations),

--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -127,7 +127,7 @@ const ctorNameToSerializedName: Record<string, SerializedName> = _(NameToType).e
 
 type ReviverMap = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [K in SerializedName]: (v: any) => InstanceType<(typeof NameToType)[K]> | FieldDefinition
+  [K in SerializedName]: (v: any) => InstanceType<(typeof NameToType)[K]>
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -275,6 +275,15 @@ const generalDeserialize = async <T>(
       return restoreClasses(v.innerType)
     }
 
+    const reviveFieldDefinitions = (v: Value): Record<string, FieldDefinition> => (
+      _.isPlainObject(v)
+        ? _.mapValues(v, field => ({
+          refType: reviveRefTypeOfElement(field),
+          annotations: restoreClasses(field.annotations),
+        }))
+        : {}
+    )
+
     const revivers: ReviverMap = {
       InstanceElement: v => new InstanceElement(
         v.elemID.nameParts[0],
@@ -286,7 +295,7 @@ const generalDeserialize = async <T>(
       ObjectType: v => {
         const r = new ObjectType({
           elemID: reviveElemID(v.elemID),
-          fields: restoreClasses(v.fields),
+          fields: reviveFieldDefinitions(v.fields),
           annotationRefsOrTypes: reviveAnnotationRefTypes(v),
           annotations: restoreClasses(v.annotations),
           isSettings: v.isSettings,
@@ -306,10 +315,15 @@ const generalDeserialize = async <T>(
       }),
       ListType: v => new ListType(reviveRefInnerType(v)),
       MapType: v => new MapType(reviveRefInnerType(v)),
-      Field: v => ({
-        refType: reviveRefTypeOfElement(v),
-        annotations: restoreClasses(v.annotations),
-      }),
+      Field: v => {
+        const elemId = reviveElemID(v.elemID)
+        return new Field(
+          new ObjectType({ elemID: new ElemID(elemId.adapter, elemId.typeName) }),
+          elemId.name,
+          reviveRefTypeOfElement(v),
+          restoreClasses(v.annotations),
+        )
+      },
       TemplateExpression: v => (
         new TemplateExpression({ parts: restoreClasses(v.parts) })
       ),

--- a/packages/workspace/test/serializer/serializer.test.ts
+++ b/packages/workspace/test/serializer/serializer.test.ts
@@ -21,6 +21,7 @@ import {
   Element,
   isReferenceExpression,
   TypeReference,
+  Field,
 } from '@salto-io/adapter-api'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
@@ -204,9 +205,16 @@ describe('State/cache serialization', () => {
   }
   innerRefsInstance.value.a = new ReferenceExpression(innerRefsInstance.elemID.createNestedID('b'), innerRefsInstance.value.b, innerRefsInstance)
 
+  const standaloneField = new Field(
+    new ObjectType({ elemID: new ElemID('salesforce', 'test') }),
+    'field',
+    BuiltinTypes.BOOLEAN,
+    { anno: 'test' },
+  )
+
   const elements = [strType, numType, boolType, model, strListType, strMapType, variable,
     instance, subInstance, refInstance, refInstance2, refInstance3, templateRefInstance,
-    functionRefInstance, settings, config, innerRefsInstance]
+    functionRefInstance, settings, config, innerRefsInstance, standaloneField]
 
   it('should serialize and deserialize without relying on the constructor name', async () => {
     const serialized = await serialize([subInstance])
@@ -283,6 +291,25 @@ describe('State/cache serialization', () => {
     const shuffledDeserializedElements = await deserialize(await serialize(shuffledElements))
     expect(shuffledDeserializedElements.map(e => e.elemID.getFullName()))
       .toEqual(shuffledElements.map(e => e.elemID.getFullName()))
+  })
+
+  describe('validate deserialization', () => {
+    let deserializedElements: Element[]
+    beforeAll(async () => {
+      deserializedElements = await deserialize(await serialize(elements))
+    })
+    it('should deserialize type correctly', async () => {
+      expect(deserializedElements.find(elem => elem.elemID.isEqual(model.elemID))?.isEqual(model))
+        .toBeTruthy()
+    })
+    it('should deserialize field correctly', async () => {
+      expect(deserializedElements.find(elem => elem.elemID.isEqual(standaloneField.elemID))?.isEqual(standaloneField))
+        .toBeTruthy()
+    })
+    it('should deserialize instance correctly', async () => {
+      expect(deserializedElements.find(elem => elem.elemID.isEqual(instance.elemID))?.isEqual(instance))
+        .toBeTruthy()
+    })
   })
 
   it('should throw error if trying to deserialize a non element object', async () => {


### PR DESCRIPTION
Today, fields are serialized only as part of an `ObjectType` and deserialized to `FieldDefinition` instead of `Field` elements.
In this PR I added the support to deserialize standalone serialized fields, while inside `ObjectType` elements they are deserialized to `FieldDefinition` as it was before.

---

_Additional context for reviewer_

---
_Release Notes_: 
Workspace:
- Support deserialization of fields

---
_User Notifications_:
None
