### PR TITLE
SALTO-3455: missing reference for ticket field in routing attribute value

### DIFF
--- a/packages/adapter-components/src/references/reference_mapping.ts
+++ b/packages/adapter-components/src/references/reference_mapping.ts
@@ -101,7 +101,7 @@ ReferenceSourceTransformation
 export type MissingReferenceStrategy = {
   create: CreateMissingRefFunc
 }
-export type MissingReferenceStrategyName = 'typeAndValue'
+export type MissingReferenceStrategyName = 'typeAndValue' | 'startsWith'
 
 type MetadataTypeArgs<T extends string> = {
   type: string

--- a/packages/zendesk-adapter/src/constants.ts
+++ b/packages/zendesk-adapter/src/constants.ts
@@ -46,6 +46,7 @@ export const PENDING_CATEGORY = 'pending'
 export const SOLVED_CATEGORY = 'solved'
 export const HOLD_CATEGORY = 'hold'
 export const OPEN_CATEGORY = 'open'
+export const ROUTING_ATTRIBUTE_VALUE_TYPE = 'routing_attribute_value'
 
 export const CATEGORY_ORDER_TYPE_NAME = 'category_order'
 export const SECTION_ORDER_TYPE_NAME = 'section_order'

--- a/packages/zendesk-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-adapter/src/filters/field_references.ts
@@ -542,6 +542,7 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
     },
     zendeskSerializationStrategy: 'ticketField',
     target: { type: TICKET_FIELD_TYPE_NAME },
+    zendeskMissingRefStrategy: 'edentest',
   },
   {
     src: {

--- a/packages/zendesk-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-adapter/src/filters/field_references.ts
@@ -542,7 +542,7 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
     },
     zendeskSerializationStrategy: 'ticketField',
     target: { type: TICKET_FIELD_TYPE_NAME },
-    zendeskMissingRefStrategy: 'edentest',
+    zendeskMissingRefStrategy: 'startsWith',
   },
   {
     src: {
@@ -584,6 +584,7 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
     },
     zendeskSerializationStrategy: 'orgField',
     target: { type: ORG_FIELD_TYPE_NAME },
+    zendeskMissingRefStrategy: 'startsWith',
   },
   {
     src: {
@@ -623,6 +624,7 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
     },
     zendeskSerializationStrategy: 'userField',
     target: { type: USER_FIELD_TYPE_NAME },
+    zendeskMissingRefStrategy: 'startsWith',
   },
   {
     src: { field: 'id', parentTypes: ['view__execution__columns'] },

--- a/packages/zendesk-adapter/src/filters/references/missing_references.ts
+++ b/packages/zendesk-adapter/src/filters/references/missing_references.ts
@@ -18,12 +18,17 @@ import _ from 'lodash'
 import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
 import { references as referenceUtils } from '@salto-io/adapter-components'
 import { naclCase } from '@salto-io/adapter-utils'
+import { TICKET_FIELD_TYPE_NAME } from '../../constants'
 
 const MISSING_REF_PREFIX = 'missing_'
 
 export const VALUES_TO_SKIP_BY_TYPE: Record<string, string[]> = {
   group: ['current_groups', 'group_id'],
   webhook: ['(Value no longer exists. Choose another.)'],
+}
+
+const VALUE_BY_TYPE: Record<string, string> = {
+  [TICKET_FIELD_TYPE_NAME]: 'custom_fields_',
 }
 
 export const createMissingInstance = (
@@ -49,6 +54,18 @@ referenceUtils.MissingReferenceStrategyName, referenceUtils.MissingReferenceStra
         return undefined
       }
       return createMissingInstance(adapter, typeName, value)
+    },
+  },
+  edentest: {
+    create: ({ value, adapter, typeName }) => {
+      if (_.isString(typeName)
+        && value
+        && !VALUES_TO_SKIP_BY_TYPE[typeName]?.includes(value)
+        && value.startsWith(VALUE_BY_TYPE[typeName])
+      ) {
+        createMissingInstance(adapter, typeName, value)
+      }
+      return undefined
     },
   },
 }

--- a/packages/zendesk-adapter/src/filters/references/missing_references.ts
+++ b/packages/zendesk-adapter/src/filters/references/missing_references.ts
@@ -18,7 +18,7 @@ import _ from 'lodash'
 import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
 import { references as referenceUtils } from '@salto-io/adapter-components'
 import { naclCase } from '@salto-io/adapter-utils'
-import { TICKET_FIELD_TYPE_NAME } from '../../constants'
+import { ORG_FIELD_TYPE_NAME, TICKET_FIELD_TYPE_NAME, USER_FIELD_TYPE_NAME } from '../../constants'
 
 const MISSING_REF_PREFIX = 'missing_'
 
@@ -29,6 +29,8 @@ export const VALUES_TO_SKIP_BY_TYPE: Record<string, string[]> = {
 
 const VALUE_BY_TYPE: Record<string, string> = {
   [TICKET_FIELD_TYPE_NAME]: 'custom_fields_',
+  [USER_FIELD_TYPE_NAME]: 'requester.custom_fields.',
+  [ORG_FIELD_TYPE_NAME]: 'organization.custom_fields.',
 }
 
 export const createMissingInstance = (
@@ -56,14 +58,14 @@ referenceUtils.MissingReferenceStrategyName, referenceUtils.MissingReferenceStra
       return createMissingInstance(adapter, typeName, value)
     },
   },
-  edentest: {
+  startsWith: {
     create: ({ value, adapter, typeName }) => {
       if (_.isString(typeName)
         && value
         && !VALUES_TO_SKIP_BY_TYPE[typeName]?.includes(value)
         && value.startsWith(VALUE_BY_TYPE[typeName])
       ) {
-        createMissingInstance(adapter, typeName, value)
+        return createMissingInstance(adapter, typeName, value)
       }
       return undefined
     },


### PR DESCRIPTION
_missing reference for ticket field in routing attribute value_

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk
* add missing reference for ticket_field, user_field, and organization_field in routing attribute value

---
_User Notifications_: 
zendesk
* add missing reference for ticket_field, user_field, and organization_field in routing attribute value
