### PR TITLE
SALTO-2653: Okta - Fetch all UserSchema instances

### DIFF
--- a/packages/adapter-components/src/elements/index.ts
+++ b/packages/adapter-components/src/elements/index.ts
@@ -22,7 +22,7 @@ import { computeGetArgs, simpleGetArgs, createUrl, replaceUrlParams } from './re
 import { RECORDS_PATH, TYPES_PATH, SUBTYPES_PATH, SETTINGS_NESTED_PATH } from './constants'
 import { findDataField, returnFullEntry, FindNestedFieldFunc } from './field_finder'
 import { filterTypes } from './type_elements'
-import { getInstanceName, generateInstanceNameFromConfig, createServiceIds, removeNullValues } from './instance_elements'
+import { getInstanceName, generateInstanceNameFromConfig, createServiceIds, removeNullValues, toBasicInstance } from './instance_elements'
 import { FetchElements, ConfigChangeSuggestion } from './element_getter'
 
 export {
@@ -42,4 +42,5 @@ export {
   removeNullValues,
   query,
   FetchElements, ConfigChangeSuggestion,
+  toBasicInstance,
 }

--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -33,6 +33,7 @@ import groupDeploymentFilter from './filters/group_deployment'
 import appDeploymentFilter from './filters/app_deployment'
 import appStructureFilter from './filters/app_structure'
 import standardRolesFilter from './filters/standard_roles'
+import fetchUserSchemaFilter from './filters/user_schema'
 import { OKTA } from './constants'
 import { getLookUpName } from './reference_mapping'
 
@@ -48,6 +49,7 @@ const log = logger(module)
 
 export const DEFAULT_FILTERS = [
   standardRolesFilter,
+  fetchUserSchemaFilter,
   appStructureFilter,
   // should run before fieldReferencesFilter
   urlReferencesFilter,

--- a/packages/okta-adapter/src/filters/url_references.ts
+++ b/packages/okta-adapter/src/filters/url_references.ts
@@ -19,6 +19,7 @@ import Joi from 'joi'
 import { Element, isInstanceElement, InstanceElement } from '@salto-io/adapter-api'
 import { APPLICATION_TYPE_NAME } from '../constants'
 import { FilterCreator } from '../filter'
+import { extractIdFromUrl } from '../utils'
 
 type linkProperty = {
     href: string
@@ -32,11 +33,6 @@ const isLinkProperty = createSchemeGuard<linkProperty>(LINK_PROPERTY_SCHEME, 'Re
 
 const RELEVAT_FIELDS = ['profileEnrollment', 'accessPolicy']
 const INSTANCE_LINKS_PATH = ['_links', 'additionalProperties']
-
-const extractIdFromUrl = (url: string): string | undefined => {
-  const urlParts = url.split('/')
-  return urlParts.pop()
-}
 
 const extractIdsFromUrls = (instance: InstanceElement): void => {
   const linksObject = _.get(instance.value, INSTANCE_LINKS_PATH)

--- a/packages/okta-adapter/src/filters/user_schema.ts
+++ b/packages/okta-adapter/src/filters/user_schema.ts
@@ -33,10 +33,13 @@ const LINK_PATH = ['_links', 'additionalProperties', 'schema', 'href']
 
 const getUserSchemaId = (instance: InstanceElement): string | undefined => {
   const url = _.get(instance.value, LINK_PATH)
-  const id = extractIdFromUrl(url)
-  if (_.isString(id)) {
-    return id
+  if (url !== undefined) {
+    const id = extractIdFromUrl(url)
+    if (_.isString(id)) {
+      return id
+    }
   }
+  log.error(`could not find id for UserSchema instance in UserType ${instance.elemID.name}`)
   return undefined
 }
 
@@ -48,7 +51,7 @@ const getUserSchema = async (
 })).data as Values[]
 
 /**
- * Fetch the non-default user_schema types
+ * Fetch the non-default userSchema instances
  */
 const filter: FilterCreator = ({ client, config }) => ({
   onFetch: async elements => {
@@ -74,14 +77,14 @@ const filter: FilterCreator = ({ client, config }) => ({
       })
     )).filter(isDefined)
 
-    const userSchemaInstances = await Promise.all(userSchemaEntries.map(async entry => toBasicInstance({
+    const userSchemaInstances = await Promise.all(userSchemaEntries.map(async (entry, index) => toBasicInstance({
       entry,
       type: userSchemaType,
       transformationConfigByType: getTransformationConfigByType(config[API_DEFINITIONS_CONFIG].types),
       transformationDefaultConfig: config[API_DEFINITIONS_CONFIG].typeDefaults.transformation,
       nestName: undefined,
       parent: undefined,
-      defaultName: 'userSchema',
+      defaultName: `unnamed_${index}`,
       getElemIdFunc: undefined,
     })))
     elements.push(...userSchemaInstances)

--- a/packages/okta-adapter/src/filters/user_schema.ts
+++ b/packages/okta-adapter/src/filters/user_schema.ts
@@ -30,7 +30,6 @@ const { toBasicInstance } = elementUtils
 const { isDefined } = values
 const LINK_PATH = ['_links', 'additionalProperties', 'schema', 'href']
 
-
 const getUserSchemaId = (instance: InstanceElement): string | undefined => {
   const url = _.get(instance.value, LINK_PATH)
   if (url !== undefined) {

--- a/packages/okta-adapter/src/filters/user_schema.ts
+++ b/packages/okta-adapter/src/filters/user_schema.ts
@@ -57,14 +57,14 @@ const filter: FilterCreator = ({ client, config }) => ({
     const userTypeInstances = elements
       .filter(isInstanceElement)
       .filter(instance => instance.elemID.typeName === USERTYPE_TYPE_NAME)
-      // filter out the default user type because we already have it
+      // filter out the default user type because we already have the matching user schema
       .filter(instance => instance.value.default === false)
     const userSchemaType = elements.filter(isObjectType).find(type => type.elemID.name === USER_SCHEMA_TYPE_NAME)
     if (userSchemaType === undefined || _.isEmpty(userTypeInstances)) {
       return
     }
 
-    const userSchemaIds = userTypeInstances.map(userType => getUserSchemaId(userType)).filter(isDefined)
+    const userSchemaIds = userTypeInstances.map(getUserSchemaId).filter(isDefined)
     const userSchemaEntries = (await Promise.all(
       userSchemaIds.map(async userSchemaId => {
         try {

--- a/packages/okta-adapter/src/filters/user_schema.ts
+++ b/packages/okta-adapter/src/filters/user_schema.ts
@@ -1,0 +1,91 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { InstanceElement, isObjectType, isInstanceElement, Values } from '@salto-io/adapter-api'
+import { elements as elementUtils, config as configUtils } from '@salto-io/adapter-components'
+import { values } from '@salto-io/lowerdash'
+import { logger } from '@salto-io/logging'
+import { FilterCreator } from '../filter'
+import { USERTYPE_TYPE_NAME, USER_SCHEMA_TYPE_NAME } from '../constants'
+import OktaClient from '../client/client'
+import { API_DEFINITIONS_CONFIG } from '../config'
+import { extractIdFromUrl } from '../utils'
+
+const log = logger(module)
+const { getTransformationConfigByType } = configUtils
+const { toBasicInstance } = elementUtils
+const { isDefined } = values
+const LINK_PATH = ['_links', 'additionalProperties', 'schema', 'href']
+
+
+const getUserSchemaId = (instance: InstanceElement): string | undefined => {
+  const url = _.get(instance.value, LINK_PATH)
+  const id = extractIdFromUrl(url)
+  if (_.isString(id)) {
+    return id
+  }
+  return undefined
+}
+
+const getUserSchema = async (
+  userSchemaId: string,
+  client: OktaClient
+): Promise<Values> => (await client.getSinglePage({
+  url: `/api/v1/meta/schemas/user/${userSchemaId}`,
+})).data as Values[]
+
+/**
+ * Fetch the non-default user_schema types
+ */
+const filter: FilterCreator = ({ client, config }) => ({
+  onFetch: async elements => {
+    const userTypeInstances = elements
+      .filter(isInstanceElement)
+      .filter(instance => instance.elemID.typeName === USERTYPE_TYPE_NAME)
+      // filter out the default user type because we already have it
+      .filter(instance => instance.value.default === false)
+    const userSchemaType = elements.filter(isObjectType).find(type => type.elemID.name === USER_SCHEMA_TYPE_NAME)
+    if (userSchemaType === undefined || _.isEmpty(userTypeInstances)) {
+      return
+    }
+
+    const userSchemaIds = userTypeInstances.map(userType => getUserSchemaId(userType)).filter(isDefined)
+    const userSchemaEntries = (await Promise.all(
+      userSchemaIds.map(async userSchemaId => {
+        try {
+          return await getUserSchema(userSchemaId, client)
+        } catch (e) {
+          log.error('Error while trying to get userSchema entry with id: %s, error: %s', userSchemaId, e)
+        }
+        return undefined
+      })
+    )).filter(isDefined)
+
+    const userSchemaInstances = await Promise.all(userSchemaEntries.map(async entry => toBasicInstance({
+      entry,
+      type: userSchemaType,
+      transformationConfigByType: getTransformationConfigByType(config[API_DEFINITIONS_CONFIG].types),
+      transformationDefaultConfig: config[API_DEFINITIONS_CONFIG].typeDefaults.transformation,
+      nestName: undefined,
+      parent: undefined,
+      defaultName: 'userSchema',
+      getElemIdFunc: undefined,
+    })))
+    elements.push(...userSchemaInstances)
+  },
+})
+
+export default filter

--- a/packages/okta-adapter/src/utils.ts
+++ b/packages/okta-adapter/src/utils.ts
@@ -13,15 +13,15 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-export const OKTA = 'okta'
-export const APPLICATION_TYPE_NAME = 'Application'
-export const GROUP_TYPE_NAME = 'Group'
-export const USER_TYPE_NAME = 'User'
-export const IDENTITY_PROVIDER_TYPE_NAME = 'IdentityProvider'
-export const USERTYPE_TYPE_NAME = 'UserType'
-export const FEATURE_TYPE_NAME = 'Feature'
-export const POLICY_TYPE_NAME = 'Policy'
-export const APP_USER_TYPE_NAME = 'AppUser'
-export const NETWORK_ZONE_TYPE_NAME = 'NetworkZone'
-export const ROLE_TYPE_NAME = 'Role'
-export const USER_SCHEMA_TYPE_NAME = 'UserSchema'
+
+/**
+ * Extract id from okta's _links object urls
+ * Example url: https://subdomain.okta.com/api/v1/group/abc123
+ */
+export const extractIdFromUrl = (url: string): string | undefined => {
+  if (url.includes('/')) {
+    const urlParts = url.split('/')
+    return urlParts.pop()
+  }
+  return undefined
+}

--- a/packages/okta-adapter/src/utils.ts
+++ b/packages/okta-adapter/src/utils.ts
@@ -14,6 +14,10 @@
 * limitations under the License.
 */
 
+import { logger } from '@salto-io/logging'
+
+const log = logger(module)
+
 /**
  * Extract id from okta's _links object urls
  * Example url: https://subdomain.okta.com/api/v1/group/abc123
@@ -23,5 +27,6 @@ export const extractIdFromUrl = (url: string): string | undefined => {
     const urlParts = url.split('/')
     return urlParts.pop()
   }
+  log.warn(`Failed to extract id from url: ${url}`)
   return undefined
 }

--- a/packages/okta-adapter/test/filters/user_schema.test.ts
+++ b/packages/okta-adapter/test/filters/user_schema.test.ts
@@ -1,0 +1,169 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { ObjectType, ElemID, isInstanceElement, InstanceElement } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import OktaClient from '../../src/client/client'
+import { OKTA, USERTYPE_TYPE_NAME, USER_SCHEMA_TYPE_NAME } from '../../src/constants'
+import fetchUserSchemas from '../../src/filters/user_schema'
+import { getFilterParams } from '../utils'
+
+describe('fetchUserSchemaInstancesFilter', () => {
+  let filter: filterUtils.FilterWith<'onFetch'>
+  let client: OktaClient
+  let mockGet: jest.SpyInstance
+  const userSchemaType = new ObjectType({ elemID: new ElemID(OKTA, USER_SCHEMA_TYPE_NAME) })
+  const userTypeType = new ObjectType({ elemID: new ElemID(OKTA, USERTYPE_TYPE_NAME) })
+  const userTypeInstanceA = new InstanceElement(
+    'test',
+    userTypeType,
+    {
+      id: 123,
+      name: 'A',
+      _links: {
+        additionalProperties: {
+          schema: {
+            href: 'https://okta.com/api/v1/meta/schemas/user/A123',
+          },
+        },
+      },
+      default: false,
+    },
+  )
+  const userTypeInstanceB = new InstanceElement(
+    'test',
+    userTypeType,
+    {
+      id: 234,
+      name: 'B',
+      _links: {
+        additionalProperties: {
+          schema: {
+            href: 'https://okta.com/api/v1/meta/schemas/user/B123',
+          },
+        },
+      },
+      default: false,
+    },
+  )
+  const defaultUserTypeInstance = new InstanceElement(
+    'test',
+    userTypeType,
+    {
+      id: 345,
+      name: 'C',
+      _links: {
+        additionalProperties: {
+          schema: {
+            href: 'https://okta.com/api/v1/meta/schemas/user/C123',
+          },
+        },
+      },
+      default: true,
+    },
+  )
+
+  const UserSchemaResponse = {
+    status: 200,
+    data: {
+      id: 'A123',
+      name: 'userSchema123',
+      description: 'user schema',
+    },
+  }
+  const UserSchemaResponse2 = {
+    status: 200,
+    data: {
+      id: 'B123',
+      name: 'userSchema234',
+      description: 'user schema',
+    },
+  }
+  beforeEach(() => {
+    client = new OktaClient({
+      credentials: { baseUrl: 'https://okta.com/', token: 'token' },
+    })
+    mockGet = jest.spyOn(client, 'getSinglePage')
+    filter = fetchUserSchemas(getFilterParams({ client })) as typeof filter
+    jest.clearAllMocks()
+  })
+
+  it('should create userSchema instances', async () => {
+    mockGet.mockResolvedValueOnce(UserSchemaResponse)
+    mockGet.mockResolvedValueOnce(UserSchemaResponse2)
+    const elements = [userSchemaType, userTypeType, userTypeInstanceA, userTypeInstanceB, defaultUserTypeInstance]
+    await filter.onFetch?.(elements)
+    const createdInstance = elements
+      .filter(isInstanceElement)
+      .filter(inst => inst.elemID.typeName === USER_SCHEMA_TYPE_NAME)
+      .sort()
+    expect(createdInstance.length).toEqual(2)
+    expect(createdInstance.map(i => i.elemID.getFullName())).toEqual([
+      'okta.UserSchema.instance.userSchema123',
+      'okta.UserSchema.instance.userSchema234',
+    ])
+    expect(createdInstance.map(i => i.value)).toEqual([
+      { id: 'A123', name: 'userSchema123', description: 'user schema' },
+      { id: 'B123', name: 'userSchema234', description: 'user schema' },
+    ])
+  })
+  it('should skip userType instance if the matching userSchema id was not found', async () => {
+    mockGet.mockResolvedValueOnce(UserSchemaResponse)
+    const invalidUserTypeInst = new InstanceElement(
+      'test',
+      userTypeType,
+      {
+        id: 456,
+        name: 'D',
+        _links: {
+          additionalProperties: {
+            schema: {
+              href: 'https://okta.com/api/v1/meta/schemas/user/B123',
+            },
+          },
+        },
+        default: false,
+      },
+    )
+    const elements = [userSchemaType, userTypeType, userTypeInstanceA, invalidUserTypeInst, defaultUserTypeInstance]
+    await filter.onFetch?.(elements)
+    const createdInstance = elements
+      .filter(isInstanceElement)
+      .filter(inst => inst.elemID.typeName === USER_SCHEMA_TYPE_NAME)
+      .sort()
+    expect(createdInstance.length).toEqual(1)
+    expect(createdInstance[0].elemID.getFullName()).toEqual('okta.UserSchema.instance.userSchema123')
+  })
+  it('should do nothing if userSchema type is missing', async () => {
+    const elements = [userTypeType, userTypeInstanceA, userTypeInstanceB, defaultUserTypeInstance]
+    await filter.onFetch?.(elements)
+    const createdInstance = elements
+      .filter(isInstanceElement)
+      .filter(inst => inst.elemID.typeName === USER_SCHEMA_TYPE_NAME)
+      .sort()
+    expect(createdInstance.length).toEqual(0)
+  })
+
+  it('should do nothing if there are no UserType instances except for the default user type', async () => {
+    const elements = [userSchemaType, userTypeType, defaultUserTypeInstance]
+    await filter.onFetch?.(elements)
+    const createdInstance = elements
+      .filter(isInstanceElement)
+      .filter(inst => inst.elemID.typeName === USER_SCHEMA_TYPE_NAME)
+      .sort()
+    expect(createdInstance.length).toEqual(0)
+  })
+})

--- a/packages/okta-adapter/test/filters/user_schema.test.ts
+++ b/packages/okta-adapter/test/filters/user_schema.test.ts
@@ -93,17 +93,17 @@ describe('fetchUserSchemaInstancesFilter', () => {
     },
   }
   beforeEach(() => {
+    jest.clearAllMocks()
     client = new OktaClient({
       credentials: { baseUrl: 'https://okta.com/', token: 'token' },
     })
     mockGet = jest.spyOn(client, 'getSinglePage')
+    mockGet.mockResolvedValueOnce(UserSchemaResponse)
+    mockGet.mockResolvedValueOnce(UserSchemaResponse2)
     filter = fetchUserSchemas(getFilterParams({ client })) as typeof filter
-    jest.clearAllMocks()
   })
 
   it('should create userSchema instances', async () => {
-    mockGet.mockResolvedValueOnce(UserSchemaResponse)
-    mockGet.mockResolvedValueOnce(UserSchemaResponse2)
     const elements = [userSchemaType, userTypeType, userTypeInstanceA, userTypeInstanceB, defaultUserTypeInstance]
     await filter.onFetch?.(elements)
     const createdInstance = elements
@@ -121,7 +121,6 @@ describe('fetchUserSchemaInstancesFilter', () => {
     ])
   })
   it('should skip userType instance if the matching userSchema id was not found', async () => {
-    mockGet.mockResolvedValueOnce(UserSchemaResponse)
     const invalidUserTypeInst = new InstanceElement(
       'test',
       userTypeType,
@@ -129,10 +128,8 @@ describe('fetchUserSchemaInstancesFilter', () => {
         id: 456,
         name: 'D',
         _links: {
-          additionalProperties: {
-            schema: {
-              href: 'https://okta.com/api/v1/meta/schemas/user/B123',
-            },
+          schema: {
+            href: 'https://okta.com/api/v1/meta/schemas/user/B123',
           },
         },
         default: false,

--- a/packages/okta-adapter/test/filters/user_schema.test.ts
+++ b/packages/okta-adapter/test/filters/user_schema.test.ts
@@ -28,7 +28,7 @@ describe('fetchUserSchemaInstancesFilter', () => {
   const userSchemaType = new ObjectType({ elemID: new ElemID(OKTA, USER_SCHEMA_TYPE_NAME) })
   const userTypeType = new ObjectType({ elemID: new ElemID(OKTA, USERTYPE_TYPE_NAME) })
   const userTypeInstanceA = new InstanceElement(
-    'test',
+    'test1',
     userTypeType,
     {
       id: 123,
@@ -44,7 +44,7 @@ describe('fetchUserSchemaInstancesFilter', () => {
     },
   )
   const userTypeInstanceB = new InstanceElement(
-    'test',
+    'test2',
     userTypeType,
     {
       id: 234,
@@ -60,7 +60,7 @@ describe('fetchUserSchemaInstancesFilter', () => {
     },
   )
   const defaultUserTypeInstance = new InstanceElement(
-    'test',
+    'test3',
     userTypeType,
     {
       id: 345,
@@ -118,6 +118,16 @@ describe('fetchUserSchemaInstancesFilter', () => {
     expect(createdInstance.map(i => i.value)).toEqual([
       { id: 'A123', name: 'userSchema123', description: 'user schema' },
       { id: 'B123', name: 'userSchema234', description: 'user schema' },
+    ])
+    const userTypeInstances = elements
+      .filter(isInstanceElement)
+      .filter(inst => inst.elemID.typeName === USERTYPE_TYPE_NAME)
+      .sort()
+    expect(userTypeInstances.length).toEqual(3)
+    expect(userTypeInstances.map(i => i.elemID.getFullName())).toEqual([
+      'okta.UserType.instance.test1',
+      'okta.UserType.instance.test2',
+      'okta.UserType.instance.test3',
     ])
   })
   it('should skip userType instance if the matching userSchema id was not found', async () => {

--- a/packages/okta-adapter/test/utils.test.ts
+++ b/packages/okta-adapter/test/utils.test.ts
@@ -13,15 +13,17 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-export const OKTA = 'okta'
-export const APPLICATION_TYPE_NAME = 'Application'
-export const GROUP_TYPE_NAME = 'Group'
-export const USER_TYPE_NAME = 'User'
-export const IDENTITY_PROVIDER_TYPE_NAME = 'IdentityProvider'
-export const USERTYPE_TYPE_NAME = 'UserType'
-export const FEATURE_TYPE_NAME = 'Feature'
-export const POLICY_TYPE_NAME = 'Policy'
-export const APP_USER_TYPE_NAME = 'AppUser'
-export const NETWORK_ZONE_TYPE_NAME = 'NetworkZone'
-export const ROLE_TYPE_NAME = 'Role'
-export const USER_SCHEMA_TYPE_NAME = 'UserSchema'
+import { extractIdFromUrl } from '../src/utils'
+
+describe('okta utils', () => {
+  describe('extractIdFromUrl', () => {
+    it('should return correct id', () => {
+      const link = 'https://oktaDomain.okta.com/1/2/1234567'
+      const link2 = 'https://oktaDomain.okta.com/1/2/1234567/okta/a/abc123'
+      const invalidLink = '123123'
+      expect(extractIdFromUrl(link)).toEqual('1234567')
+      expect(extractIdFromUrl(link2)).toEqual('abc123')
+      expect(extractIdFromUrl(invalidLink)).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
Fetch all UserSchema instances

---

Until now, we fetched only the default `UserSchema` instance.
Okta's API doesn't have a an API to list all userSchema instances, and we have to get each `UserSchema` instance by its id.
We get the ids from the _links object from the matching `UserType` instance.
I added this in a filter as `dependsOn` or `recurseInto` does not support this case atm.

---
_Release Notes_: 
None

---
_User Notifications_: 
None
