### PR TITLE
SALTO-3521: Project ids are not converted to reference in JQLs

### DIFF
--- a/packages/jira-adapter/test/filters/jql/template_expression_generator.test.ts
+++ b/packages/jira-adapter/test/filters/jql/template_expression_generator.test.ts
@@ -67,7 +67,7 @@ describe('generateTemplateExpression', () => {
 
     instances.push(issueTypeField)
 
-    const jql = 'status IN (Done, "To Do") AND otherfield = 2 AND issuetype = 3'
+    const jql = 'status IN (Done, "To Do", 1) AND otherfield = 2 AND issuetype = 3'
     const expression = generateTemplateExpression(jql, generateJqlContext(instances))
     expect(expression).toEqual({
       template: new TemplateExpression({ parts: [
@@ -76,7 +76,9 @@ describe('generateTemplateExpression', () => {
         new ReferenceExpression(doneInstance.elemID.createNestedID('name'), doneInstance.value.name),
         ', "',
         new ReferenceExpression(todoInstance.elemID.createNestedID('name'), todoInstance.value.name),
-        '") AND otherfield = 2 AND ',
+        '", ',
+        new ReferenceExpression(doneInstance.elemID, doneInstance),
+        ') AND otherfield = 2 AND ',
         new ReferenceExpression(issueTypeField.elemID, issueTypeField),
         ' = 3',
       ] }),


### PR DESCRIPTION
Values in JQLs can be either name/key or and id, until now we covered only name/key. This PR adds support for id values

---
_Release Notes_: 
_Jira Adapter_:
- Increased references coverage in JQLs

---
_User Notifications_: 
_Jira Adapter_:
- After the next fetch, values in JQLs might be converted to references