### PR TITLE
SALTO-3523: Okta - ProfileMapping type config

### DIFF
--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -733,6 +733,19 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
       fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),
     },
   },
+  ProfileMapping: {
+    transformation: {
+      idFields: ['source.name', 'target.name'],
+      serviceIdField: 'id',
+      fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),
+      fieldsToHide: [{ fieldName: 'id' }],
+    },
+  },
+  ProfileMappingSource: {
+    transformation: {
+      fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),
+    },
+  },
 }
 
 const DEFAULT_SWAGGER_CONFIG: OktaApiConfig['swagger'] = {


### PR DESCRIPTION
Transformation config for ProfileMapping type in Okta

---

The default `idFields` (`name`) was missing in `ProfileMapping` type
I also added `serviceId` and `fieldsToHide` and `fieldsToOmit`  that were missing too.

---
_Release Notes_: 
None

---
_User Notifications_: 
None
