### PR TITLE
SALTO-3524 Changing all docs links to new help center

### DIFF
--- a/packages/adapter-components/src/deployment/change_validators/check_deployment_based_on_config.ts
+++ b/packages/adapter-components/src/deployment/change_validators/check_deployment_based_on_config.ts
@@ -25,7 +25,7 @@ const { awu } = collections.asynciterable
 const ERROR_MESSAGE = 'Operation not supported'
 
 const detailedErrorMessage = (action: Change['action'], path: ElemID): string =>
-  `Salto does not support "${action}" of ${path.getFullName()}. Please see your business app FAQ at https://docs.salto.io/docs/supported-bizapps for a list of supported elements.`
+  `Salto does not support "${action}" of ${path.getFullName()}. Please see your business app FAQ at https://help.salto.io/en/articles/6927118-supported-business-applications for a list of supported elements.`
 
 const isDeploymentSupported = (
   action: Change['action'], config: DeploymentRequestsByAction

--- a/packages/adapter-components/src/deployment/change_validators/deploy_not_supported.ts
+++ b/packages/adapter-components/src/deployment/change_validators/deploy_not_supported.ts
@@ -20,6 +20,6 @@ export const deployNotSupportedValidator: ChangeValidator = async changes => (
     elemID: getChangeData(change).elemID,
     severity: 'Error',
     message: `Salto does not support ${getChangeData(change).elemID.adapter} deployments.`,
-    detailedMessage: `Salto does not support ${getChangeData(change).elemID.adapter} deployments. Please see https://docs.salto.io/docs/supported-bizapps for more details.`,
+    detailedMessage: `Salto does not support ${getChangeData(change).elemID.adapter} deployments. Please see https://help.salto.io/en/articles/6927118-supported-business-applications for more details.`,
   }))
 )

--- a/packages/adapter-components/src/deployment/change_validators/deploy_types_not_supported.ts
+++ b/packages/adapter-components/src/deployment/change_validators/deploy_types_not_supported.ts
@@ -23,6 +23,6 @@ export const deployTypesNotSupportedValidator: ChangeValidator = async changes =
       elemID: objectType.elemID,
       severity: 'Error',
       message: `Deployment of non-instance elements is not supported in adapter ${objectType.elemID.adapter}`,
-      detailedMessage: `Deployment of non-instance elements is not supported in adapter ${objectType.elemID.adapter}. Please see your business app FAQ at https://docs.salto.io/docs/supported-bizapps for a list of supported elements.`,
+      detailedMessage: `Deployment of non-instance elements is not supported in adapter ${objectType.elemID.adapter}. Please see your business app FAQ at https://help.salto.io/en/articles/6927118-supported-business-applications for a list of supported elements.`,
     }))
 )

--- a/packages/adapter-components/src/elements/ducktype/transformer.ts
+++ b/packages/adapter-components/src/elements/ducktype/transformer.ts
@@ -389,7 +389,7 @@ export const getAllElements = async ({
         }
         if (e.response?.status === 403) {
           const newError: SaltoError = {
-            message: `Salto was forbidden from accessing the ${args.typeName} resource. Elements from that type were not fetched. Please make sure that the supplied user credentials have sufficient permissions to access this data, and try again. Learn more at https://docs.salto.io/docs/fetch-error-forbidden-access`,
+            message: `Salto was forbidden from accessing the ${args.typeName} resource. Elements from that type were not fetched. Please make sure that the supplied user credentials have sufficient permissions to access this data, and try again. Learn more at https://help.salto.io/en/articles/6947061-salto-was-forbidden-from-accessing-the-resource`,
             severity: 'Warning',
           }
           return { elements: [], errors: [newError] }

--- a/packages/adapter-components/src/elements/swagger/instance_elements.ts
+++ b/packages/adapter-components/src/elements/swagger/instance_elements.ts
@@ -503,7 +503,7 @@ export const getAllInstances = async ({
       } catch (e) {
         if (e.response?.status === 403) {
           const newError: SaltoError = {
-            message: `Salto was forbidden from accessing the ${args.typeName} resource. Elements from that type were not fetched. Please make sure that the supplied user credentials have sufficient permissions to access this data, and try again. Learn more at https://docs.salto.io/docs/fetch-error-forbidden-access`,
+            message: `Salto was forbidden from accessing the ${args.typeName} resource. Elements from that type were not fetched. Please make sure that the supplied user credentials have sufficient permissions to access this data, and try again. Learn more at https://help.salto.io/en/articles/6947061-salto-was-forbidden-from-accessing-the-resource`,
             severity: 'Warning',
           }
           return { elements: [], errors: [newError] }

--- a/packages/adapter-components/test/deployment/change_validators/check_deployment.test.ts
+++ b/packages/adapter-components/test/deployment/change_validators/check_deployment.test.ts
@@ -60,7 +60,7 @@ describe('checkDeploymentBasedOnConfigValidator', () => {
       elemID: instance.elemID,
       severity: 'Error',
       message: 'Operation not supported',
-      detailedMessage: `Salto does not support "add" of ${instance.elemID.getFullName()}. Please see your business app FAQ at https://docs.salto.io/docs/supported-bizapps for a list of supported elements.`,
+      detailedMessage: `Salto does not support "add" of ${instance.elemID.getFullName()}. Please see your business app FAQ at https://help.salto.io/en/articles/6927118-supported-business-applications for a list of supported elements.`,
     }])
   })
 
@@ -73,7 +73,7 @@ describe('checkDeploymentBasedOnConfigValidator', () => {
       elemID: instance.elemID,
       severity: 'Error',
       message: 'Operation not supported',
-      detailedMessage: `Salto does not support "remove" of ${instance.elemID.getFullName()}. Please see your business app FAQ at https://docs.salto.io/docs/supported-bizapps for a list of supported elements.`,
+      detailedMessage: `Salto does not support "remove" of ${instance.elemID.getFullName()}. Please see your business app FAQ at https://help.salto.io/en/articles/6927118-supported-business-applications for a list of supported elements.`,
     }])
   })
 
@@ -120,7 +120,7 @@ describe('checkDeploymentBasedOnConfigValidator', () => {
       elemID: instance.elemID,
       severity: 'Error',
       message: 'Operation not supported',
-      detailedMessage: `Salto does not support "remove" of ${instance.elemID.getFullName()}. Please see your business app FAQ at https://docs.salto.io/docs/supported-bizapps for a list of supported elements.`,
+      detailedMessage: `Salto does not support "remove" of ${instance.elemID.getFullName()}. Please see your business app FAQ at https://help.salto.io/en/articles/6927118-supported-business-applications for a list of supported elements.`,
     }])
   })
   it('should not return an error when operation deployed type in in the skipped list', async () => {

--- a/packages/adapter-components/test/deployment/change_validators/deploy_not_supported.test.ts
+++ b/packages/adapter-components/test/deployment/change_validators/deploy_not_supported.test.ts
@@ -32,13 +32,13 @@ describe('change validator creator', () => {
           elemID: new ElemID('myAdapter', 'obj'),
           severity: 'Error',
           message: 'Salto does not support myAdapter deployments.',
-          detailedMessage: 'Salto does not support myAdapter deployments. Please see https://docs.salto.io/docs/supported-bizapps for more details.',
+          detailedMessage: 'Salto does not support myAdapter deployments. Please see https://help.salto.io/en/articles/6927118-supported-business-applications for more details.',
         },
         {
           elemID: new ElemID('myAdapter', 'obj2'),
           severity: 'Error',
           message: 'Salto does not support myAdapter deployments.',
-          detailedMessage: 'Salto does not support myAdapter deployments. Please see https://docs.salto.io/docs/supported-bizapps for more details.',
+          detailedMessage: 'Salto does not support myAdapter deployments. Please see https://help.salto.io/en/articles/6927118-supported-business-applications for more details.',
         },
       ])
     })

--- a/packages/adapter-components/test/deployment/change_validators/deploy_types_not_supported.test.ts
+++ b/packages/adapter-components/test/deployment/change_validators/deploy_types_not_supported.test.ts
@@ -27,7 +27,7 @@ describe('deployTypesNotSupportedValidator', () => {
       elemID: type.elemID,
       severity: 'Error',
       message: `Deployment of non-instance elements is not supported in adapter ${type.elemID.adapter}`,
-      detailedMessage: `Deployment of non-instance elements is not supported in adapter ${type.elemID.adapter}. Please see your business app FAQ at https://docs.salto.io/docs/supported-bizapps for a list of supported elements.`,
+      detailedMessage: `Deployment of non-instance elements is not supported in adapter ${type.elemID.adapter}. Please see your business app FAQ at https://help.salto.io/en/articles/6927118-supported-business-applications for a list of supported elements.`,
     }])
   })
 })

--- a/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
@@ -177,7 +177,7 @@ describe('swagger_instance_elements', () => {
       expect(res.errors).toEqual([
         {
           severity: 'Warning',
-          message: 'Salto was forbidden from accessing the Fail resource. Elements from that type were not fetched. Please make sure that the supplied user credentials have sufficient permissions to access this data, and try again. Learn more at https://docs.salto.io/docs/fetch-error-forbidden-access',
+          message: 'Salto was forbidden from accessing the Fail resource. Elements from that type were not fetched. Please make sure that the supplied user credentials have sufficient permissions to access this data, and try again. Learn more at https://help.salto.io/en/articles/6947061-salto-was-forbidden-from-accessing-the-resource',
         },
       ])
     })

--- a/packages/adapter-utils/test/collisions.test.ts
+++ b/packages/adapter-utils/test/collisions.test.ts
@@ -73,7 +73,7 @@ Alternatively, you can exclude obj from the default configuration in salto.nacl`
     })
 
     it('should return the correct warning messages when docsUrl is provided', async () => {
-      const docsUrl = 'https://docs.salto.io/docs/salesforce-cpq'
+      const docsUrl = 'https://help.salto.io/en/articles/6927217-salto-for-salesforce-cpq-support'
       const errors = await getAndLogCollisionWarnings({
         instances: [instance, instance.clone()],
         adapterName: 'salto',

--- a/packages/core/src/core/plan/change_validators/check_deployment_annotations.ts
+++ b/packages/core/src/core/plan/change_validators/check_deployment_annotations.ts
@@ -33,7 +33,7 @@ const detailedNestedElementErrorMessage = (
 }
 
 const detailedTopLevelErrorMessage = (action: Change['action'], path: ElemID): string =>
-  `Salto does not support "${action}" of ${path.getFullName()}. Please see your business app FAQ at https://docs.salto.io/docs/supported-bizapps for a list of supported elements.`
+  `Salto does not support "${action}" of ${path.getFullName()}. Please see your business app FAQ at https://help.salto.io/en/articles/6927118-supported-business-applications for a list of supported elements.`
 
 const isDeploymentSupported = (element: Element, action: Change['action']): boolean =>
   element.annotations[OPERATION_TO_ANNOTATION[action]]

--- a/packages/core/test/core/plan/change_validators/check_deployment_annotations.test.ts
+++ b/packages/core/test/core/plan/change_validators/check_deployment_annotations.test.ts
@@ -71,7 +71,7 @@ describe('checkDeploymentAnnotationsValidator', () => {
       elemID: instance.elemID,
       severity: 'Error',
       message: 'Operation not supported',
-      detailedMessage: `Salto does not support "add" of ${instance.elemID.getFullName()}. Please see your business app FAQ at https://docs.salto.io/docs/supported-bizapps for a list of supported elements.`,
+      detailedMessage: `Salto does not support "add" of ${instance.elemID.getFullName()}. Please see your business app FAQ at https://help.salto.io/en/articles/6927118-supported-business-applications for a list of supported elements.`,
     }])
   })
 

--- a/packages/jira-adapter/src/change_validators/field_contexts/unreferenced_context.ts
+++ b/packages/jira-adapter/src/change_validators/field_contexts/unreferenced_context.ts
@@ -22,14 +22,14 @@ const getUnreferencedContextError = (id: ElemID): ChangeError => ({
   elemID: id,
   severity: 'Error' as const,
   message: 'Non-global field context not referenced by any project.',
-  detailedMessage: 'This field context is not global and isn’t referenced by any project, and can’t be deployed. In order to deploy this context, either make it global, or include the Project which references it in your deployment. Learn more: https://docs.salto.io/docs/non-global-field-context-not-referenced-by-any-project-and-cant-be-deployed',
+  detailedMessage: 'This field context is not global and isn’t referenced by any project, and can’t be deployed. In order to deploy this context, either make it global, or include the Project which references it in your deployment. Learn more: https://help.salto.io/en/articles/6947372-non-global-field-context-not-referenced-by-any-project',
 })
 
 const getUnreferencedContextErrorWithOtherValidContexts = (id: ElemID): ChangeError => ({
   elemID: id,
   severity: 'Error' as const,
   message: 'Non-global field context not referenced by any project. There are other valid contexts.',
-  detailedMessage: 'This field context is not global and isn’t referenced by any project, and can’t be deployed. However, the field has other valid contexts, so it’s probably safe to continue without this context. Learn more: https://docs.salto.io/docs/non-global-field-context-not-referenced-by-any-project-and-cant-be-deployed',
+  detailedMessage: 'This field context is not global and isn’t referenced by any project, and can’t be deployed. However, the field has other valid contexts, so it’s probably safe to continue without this context. Learn more: https://help.salto.io/en/articles/6947372-non-global-field-context-not-referenced-by-any-project',
 })
 
 export const getUnreferencedContextErrors = (

--- a/packages/jira-adapter/src/change_validators/masking.ts
+++ b/packages/jira-adapter/src/change_validators/masking.ts
@@ -22,8 +22,8 @@ import JiraClient from '../client/client'
 import { MASK_VALUE } from '../filters/masking'
 
 const log = logger(module)
-export const DETAILED_MESSAGE = 'This element will be deployed with masked values instead of the intended values. It will not operate correctly until manually fixing this after deployment. Learn more at https://docs.salto.io/docs/masked-data-will-be-deployed-to-the-service'
-export const DOCUMENTATION_URL = 'https://docs.salto.io/docs/masked-data-will-be-deployed-to-the-service'
+export const DETAILED_MESSAGE = 'This element will be deployed with masked values instead of the intended values. It will not operate correctly until manually fixing this after deployment. Learn more at https://help.salto.io/en/articles/6933977-masked-data-will-be-deployed-to-the-service'
+export const DOCUMENTATION_URL = 'https://help.salto.io/en/articles/6933977-masked-data-will-be-deployed-to-the-service'
 export const createChangeError = (
   change: Change<InstanceElement>,
   client: JiraClient,

--- a/packages/jira-adapter/src/filters/duplicate_ids.ts
+++ b/packages/jira-adapter/src/filters/duplicate_ids.ts
@@ -65,7 +65,7 @@ const filter: FilterCreator = ({ config }) => ({
         errors: [
           {
             message: `The following elements had duplicate names in Jira: ${Array.from(duplicateIds).join(', ')}. It is strongly recommended to rename these instances so they are unique in Jira, then re-fetch.
-If changing the names is not possible, you can add the fetch.fallbackToInternalId option to the configuration file; that will add their internal ID to their names and fetch them. Read more here: https://docs.salto.io/docs/jira-faq`,
+If changing the names is not possible, you can add the fetch.fallbackToInternalId option to the configuration file; that will add their internal ID to their names and fetch them. Read more here: https://help.salto.io/en/articles/6927157-salto-id-collisions`,
             severity: 'Warning',
           },
         ],
@@ -92,7 +92,7 @@ If changing the names is not possible, you can add the fetch.fallbackToInternalI
     return {
       errors: [
         {
-          message: `The following elements had duplicate names in Jira and therefore their internal id was added to their names: ${newNames.join(', ')}. It is strongly recommended to rename these instances so they are unique in Jira, then re-fetch with the "Regenerate Salto IDs" fetch option. Read more here: https://docs.salto.io/docs/jira-faq.`,
+          message: `The following elements had duplicate names in Jira and therefore their internal id was added to their names: ${newNames.join(', ')}. It is strongly recommended to rename these instances so they are unique in Jira, then re-fetch with the "Regenerate Salto IDs" fetch option. Read more here: https://help.salto.io/en/articles/6927157-salto-id-collisions.`,
           severity: 'Warning',
         },
       ],

--- a/packages/jira-adapter/test/change_validators/change_validator.test.ts
+++ b/packages/jira-adapter/test/change_validators/change_validator.test.ts
@@ -42,13 +42,13 @@ describe('change validator creator', () => {
           elemID: new ElemID(JIRA, 'obj'),
           severity: 'Error',
           message: 'Deployment of non-instance elements is not supported in adapter jira',
-          detailedMessage: 'Deployment of non-instance elements is not supported in adapter jira. Please see your business app FAQ at https://docs.salto.io/docs/supported-bizapps for a list of supported elements.',
+          detailedMessage: 'Deployment of non-instance elements is not supported in adapter jira. Please see your business app FAQ at https://help.salto.io/en/articles/6927118-supported-business-applications for a list of supported elements.',
         },
         {
           elemID: new ElemID(JIRA, 'obj2'),
           severity: 'Error',
           message: 'Deployment of non-instance elements is not supported in adapter jira',
-          detailedMessage: 'Deployment of non-instance elements is not supported in adapter jira. Please see your business app FAQ at https://docs.salto.io/docs/supported-bizapps for a list of supported elements.',
+          detailedMessage: 'Deployment of non-instance elements is not supported in adapter jira. Please see your business app FAQ at https://help.salto.io/en/articles/6927118-supported-business-applications for a list of supported elements.',
         },
       ])
     })

--- a/packages/jira-adapter/test/change_validators/field_contexts/field_contexts.test.ts
+++ b/packages/jira-adapter/test/change_validators/field_contexts/field_contexts.test.ts
@@ -123,7 +123,7 @@ describe('Field contexts', () => {
         elemID: contextInstance.elemID,
         severity: 'Error',
         message: 'Non-global field context not referenced by any project.',
-        detailedMessage: 'This field context is not global and isn’t referenced by any project, and can’t be deployed. In order to deploy this context, either make it global, or include the Project which references it in your deployment. Learn more: https://docs.salto.io/docs/non-global-field-context-not-referenced-by-any-project-and-cant-be-deployed',
+        detailedMessage: 'This field context is not global and isn’t referenced by any project, and can’t be deployed. In order to deploy this context, either make it global, or include the Project which references it in your deployment. Learn more: https://help.salto.io/en/articles/6947372-non-global-field-context-not-referenced-by-any-project',
       },
     ])
   })
@@ -138,7 +138,7 @@ describe('Field contexts', () => {
         elemID: contextInstance.elemID,
         severity: 'Error',
         message: 'Non-global field context not referenced by any project. There are other valid contexts.',
-        detailedMessage: 'This field context is not global and isn’t referenced by any project, and can’t be deployed. However, the field has other valid contexts, so it’s probably safe to continue without this context. Learn more: https://docs.salto.io/docs/non-global-field-context-not-referenced-by-any-project-and-cant-be-deployed',
+        detailedMessage: 'This field context is not global and isn’t referenced by any project, and can’t be deployed. However, the field has other valid contexts, so it’s probably safe to continue without this context. Learn more: https://help.salto.io/en/articles/6947372-non-global-field-context-not-referenced-by-any-project',
       },
     ])
   })

--- a/packages/jira-adapter/test/filters/duplicate_ids.test.ts
+++ b/packages/jira-adapter/test/filters/duplicate_ids.test.ts
@@ -71,7 +71,7 @@ describe('duplicateIdsFilter', () => {
       expect(elements.map(e => e.elemID.name)).toEqual(['notDup', 'dup_1', 'dup_2'])
       expect(filterRes).toEqual({
         errors: [{
-          message: 'The following elements had duplicate names in Jira and therefore their internal id was added to their names: dup_1, dup_2. It is strongly recommended to rename these instances so they are unique in Jira, then re-fetch with the "Regenerate Salto IDs" fetch option. Read more here: https://docs.salto.io/docs/jira-faq.',
+          message: 'The following elements had duplicate names in Jira and therefore their internal id was added to their names: dup_1, dup_2. It is strongly recommended to rename these instances so they are unique in Jira, then re-fetch with the "Regenerate Salto IDs" fetch option. Read more here: https://help.salto.io/en/articles/6927157-salto-id-collisions.',
           severity: 'Warning',
         }],
       })
@@ -149,7 +149,7 @@ describe('duplicateIdsFilter', () => {
     expect(filterRes).toEqual({
       errors: [{
         message: `The following elements had duplicate names in Jira: jira.Status.instance.dup. It is strongly recommended to rename these instances so they are unique in Jira, then re-fetch.
-If changing the names is not possible, you can add the fetch.fallbackToInternalId option to the configuration file; that will add their internal ID to their names and fetch them. Read more here: https://docs.salto.io/docs/jira-faq`,
+If changing the names is not possible, you can add the fetch.fallbackToInternalId option to the configuration file; that will add their internal ID to their names and fetch them. Read more here: https://help.salto.io/en/articles/6927157-salto-id-collisions`,
         severity: 'Warning',
       }],
     })

--- a/packages/netsuite-adapter/src/change_validators/currency_exchange_rate.ts
+++ b/packages/netsuite-adapter/src/change_validators/currency_exchange_rate.ts
@@ -28,7 +28,7 @@ const changeValidator: NetsuiteChangeValidator = async changes => (
       elemID: instance.elemID,
       severity: 'Warning',
       message: `Currency ${EXCHANGE_RATE} is set with a default value`,
-      detailedMessage: `'${EXCHANGE_RATE}' is omitted from fetch configuration by default. As this field has to be created in the target environment for this deployment to succeed, it will be deployed with a default value of ${DEFAULT_EXCHANGE_RATE}. Please make sure this value is set to your desired value in the NetSuite UI of the target environment after deploying. See https://docs.salto.io/docs/netsuite#overriding-configuration-values for more details.`,
+      detailedMessage: `'${EXCHANGE_RATE}' is omitted from fetch configuration by default. As this field has to be created in the target environment for this deployment to succeed, it will be deployed with a default value of ${DEFAULT_EXCHANGE_RATE}. Please make sure this value is set to your desired value in the NetSuite UI of the target environment after deploying. See https://help.salto.io/en/articles/6927221-salto-for-netsuite-overview#h_c2860cccee for more details.`,
     } as ChangeError))
     .filter(isDefined)
 )

--- a/packages/netsuite-adapter/src/change_validators/currency_undeployable_fields.ts
+++ b/packages/netsuite-adapter/src/change_validators/currency_undeployable_fields.ts
@@ -42,7 +42,7 @@ const validateModificationChange = (
       elemID: before.elemID,
       severity: 'Error',
       message: 'Editing of \'currencyPrecision\' is not supported',
-      detailedMessage: 'Cannot deploy currency - currency precision is a read-only field in NetSuite. Please see https://docs.salto.io/docs/deploying-a-currency-between-environments for instructions',
+      detailedMessage: 'Cannot deploy currency - currency precision is a read-only field in NetSuite. Please see https://help.salto.io/en/articles/6845062-deploying-a-currency-between-environments for instructions',
     }
   }
   if ((before.value.displaySymbol !== after.value.displaySymbol
@@ -53,7 +53,7 @@ const validateModificationChange = (
       elemID: before.elemID,
       severity: 'Error',
       message: 'Currency contains a field that cannot be edited.',
-      detailedMessage: `Cannot deploy currency - field ${changedField} cannot be edited. To enable editing this field, enable override currency format and try again. Please see https://docs.salto.io/docs/deploying-a-currency-between-environments for instructions`,
+      detailedMessage: `Cannot deploy currency - field ${changedField} cannot be edited. To enable editing this field, enable override currency format and try again. Please see https://help.salto.io/en/articles/6845062-deploying-a-currency-between-environments for instructions`,
     }
   }
   return undefined
@@ -66,7 +66,7 @@ const validateAdditionChange = (additionChange: AdditionChange<InstanceElement>)
       elemID: instance.elemID,
       severity: 'Error',
       message: 'Currency contains a field that cannot be deployed.',
-      detailedMessage: 'Cannot deploy currency - override currency format is disabled. Please see https://docs.salto.io/docs/deploying-a-currency-between-environments for instructions',
+      detailedMessage: 'Cannot deploy currency - override currency format is disabled. Please see https://help.salto.io/en/articles/6845062-deploying-a-currency-between-environments for instructions',
     }
   }
   return {

--- a/packages/netsuite-adapter/src/change_validators/not_yet_supported_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/not_yet_supported_values.ts
@@ -37,7 +37,7 @@ const changeValidator: NetsuiteChangeValidator = async changes => (
       elemID: element.elemID,
       severity: 'Error',
       message: 'Elements with values set to \'NOT_YET_SUPPORTED\' cannot be deployed',
-      detailedMessage: 'Elements with values set to \'NOT_YET_SUPPORTED\' cannot be deployed. Please see https://docs.salto.io/docs/deploying-elements-containing-not-yet-supported-values for more details.',
+      detailedMessage: 'Elements with values set to \'NOT_YET_SUPPORTED\' cannot be deployed. Please see https://help.salto.io/en/articles/6845063-deploying-elements-containing-not-yet-supported-values for more details.',
     } as ChangeError))
     .toArray()
 )

--- a/packages/netsuite-adapter/src/change_validators/workflow_account_specific_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/workflow_account_specific_values.ts
@@ -35,7 +35,7 @@ const toValidationError = (instance: InstanceElement, probField: string): Change
   elemID: instance.elemID,
   severity: 'Error',
   message: 'Workflow contains fields which cannot be deployed',
-  detailedMessage: `The Workflow contains a '${probField}' field with an ACCOUNT_SPECIFIC_VALUE which cannot be deployed due to NetSuite constraints. Please refer to https://docs.salto.io/docs/deploying-workflows-actions-with-account-specific-value for more information.`,
+  detailedMessage: `The Workflow contains a '${probField}' field with an ACCOUNT_SPECIFIC_VALUE which cannot be deployed due to NetSuite constraints. Please refer to https://help.salto.io/en/articles/6845061-deploying-workflows-actions-with-account-specific-value for more information.`,
 })
 
 

--- a/packages/netsuite-adapter/test/change_validators/currency_undeployable_fields.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/currency_undeployable_fields.test.ts
@@ -84,7 +84,7 @@ describe('Currency changes change  validator', () => {
       expect(changeErrors).toHaveLength(1)
       expect(changeErrors[0].severity).toEqual('Error')
       expect(changeErrors[0].elemID).toEqual(instance.elemID)
-      expect(changeErrors[0].detailedMessage).toContain('Cannot deploy currency - override currency format is disabled. Please see https://docs.salto.io/docs/deploying-a-currency-between-environments for instructions')
+      expect(changeErrors[0].detailedMessage).toContain('Cannot deploy currency - override currency format is disabled. Please see https://help.salto.io/en/articles/6845062-deploying-a-currency-between-environments for instructions')
     })
 
     it('shoud have changeError when deploying a new currency with \'overrideCurrencyFormat\' enabled.', async () => {
@@ -129,7 +129,7 @@ describe('Currency changes change  validator', () => {
       expect(changeErrors).toHaveLength(1)
       expect(changeErrors[0].severity).toEqual('Error')
       expect(changeErrors[0].elemID).toEqual(instance.elemID)
-      expect(changeErrors[0].detailedMessage).toContain('Cannot deploy currency - field display symbol cannot be edited. To enable editing this field, enable override currency format and try again. Please see https://docs.salto.io/docs/deploying-a-currency-between-environments for instructions')
+      expect(changeErrors[0].detailedMessage).toContain('Cannot deploy currency - field display symbol cannot be edited. To enable editing this field, enable override currency format and try again. Please see https://help.salto.io/en/articles/6845062-deploying-a-currency-between-environments for instructions')
     })
 
     it('should have changeError when modifying currencyPrecision', async () => {
@@ -141,7 +141,7 @@ describe('Currency changes change  validator', () => {
       expect(changeErrors).toHaveLength(1)
       expect(changeErrors[0].severity).toEqual('Error')
       expect(changeErrors[0].elemID).toEqual(instance.elemID)
-      expect(changeErrors[0].detailedMessage).toContain('Cannot deploy currency - currency precision is a read-only field in NetSuite. Please see https://docs.salto.io/docs/deploying-a-currency-between-environments for instructions')
+      expect(changeErrors[0].detailedMessage).toContain('Cannot deploy currency - currency precision is a read-only field in NetSuite. Please see https://help.salto.io/en/articles/6845062-deploying-a-currency-between-environments for instructions')
     })
   })
 })

--- a/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
@@ -84,7 +84,7 @@ const createWarnings = async (
     getTypeName: async instance => apiName(await instance.getType(), true),
     idFieldsName: 'saltoIDSettings',
     getInstanceName: instance => apiName(instance),
-    docsUrl: 'https://docs.salto.io/docs/salesforce-cpq',
+    docsUrl: 'https://help.salto.io/en/articles/6927217-salto-for-salesforce-cpq-support',
   })
 
   const typeToInstanceIdToMissingRefs = _.mapValues(

--- a/packages/stripe-adapter/test/change_validator.test.ts
+++ b/packages/stripe-adapter/test/change_validator.test.ts
@@ -32,13 +32,13 @@ describe('change validator creator', () => {
           elemID: new ElemID(STRIPE, 'obj'),
           severity: 'Error',
           message: 'Salto does not support stripe deployments.',
-          detailedMessage: 'Salto does not support stripe deployments. Please see https://docs.salto.io/docs/supported-bizapps for more details.',
+          detailedMessage: 'Salto does not support stripe deployments. Please see https://help.salto.io/en/articles/6927118-supported-business-applications for more details.',
         },
         {
           elemID: new ElemID(STRIPE, 'obj2'),
           severity: 'Error',
           message: 'Salto does not support stripe deployments.',
-          detailedMessage: 'Salto does not support stripe deployments. Please see https://docs.salto.io/docs/supported-bizapps for more details.',
+          detailedMessage: 'Salto does not support stripe deployments. Please see https://help.salto.io/en/articles/6927118-supported-business-applications for more details.',
         },
       ])
     })

--- a/packages/workato-adapter/test/change_validator.test.ts
+++ b/packages/workato-adapter/test/change_validator.test.ts
@@ -32,13 +32,13 @@ describe('change validator creator', () => {
           elemID: new ElemID(WORKATO, 'obj'),
           severity: 'Error',
           message: 'Salto does not support workato deployments.',
-          detailedMessage: 'Salto does not support workato deployments. Please see https://docs.salto.io/docs/supported-bizapps for more details.',
+          detailedMessage: 'Salto does not support workato deployments. Please see https://help.salto.io/en/articles/6927118-supported-business-applications for more details.',
         },
         {
           elemID: new ElemID(WORKATO, 'obj2'),
           severity: 'Error',
           message: 'Salto does not support workato deployments.',
-          detailedMessage: 'Salto does not support workato deployments. Please see https://docs.salto.io/docs/supported-bizapps for more details.',
+          detailedMessage: 'Salto does not support workato deployments. Please see https://help.salto.io/en/articles/6927118-supported-business-applications for more details.',
         },
       ])
     })

--- a/packages/zendesk-adapter/e2e_test/adapter.test.ts
+++ b/packages/zendesk-adapter/e2e_test/adapter.test.ts
@@ -165,7 +165,7 @@ const cleanup = async (adapterAttr: Reals): Promise<void> => {
   expect(fetchResult.errors).toEqual([
     {
       severity: 'Warning',
-      message: 'Salto was forbidden from accessing the custom_statuses resource. Elements from that type were not fetched. Please make sure that the supplied user credentials have sufficient permissions to access this data, and try again. Learn more at https://docs.salto.io/docs/fetch-error-forbidden-access',
+      message: 'Salto was forbidden from accessing the custom_statuses resource. Elements from that type were not fetched. Please make sure that the supplied user credentials have sufficient permissions to access this data, and try again. Learn more at https://help.salto.io/en/articles/6947061-salto-was-forbidden-from-accessing-the-resource',
     },
   ])
   const { elements } = fetchResult
@@ -239,7 +239,7 @@ describe('Zendesk adapter E2E', () => {
       expect(fetchResult.errors).toEqual([
         {
           severity: 'Warning',
-          message: 'Salto was forbidden from accessing the custom_statuses resource. Elements from that type were not fetched. Please make sure that the supplied user credentials have sufficient permissions to access this data, and try again. Learn more at https://docs.salto.io/docs/fetch-error-forbidden-access',
+          message: 'Salto was forbidden from accessing the custom_statuses resource. Elements from that type were not fetched. Please make sure that the supplied user credentials have sufficient permissions to access this data, and try again. Learn more at https://help.salto.io/en/articles/6947061-salto-was-forbidden-from-accessing-the-resource',
         },
       ])
       adapterAttr = realAdapter(

--- a/packages/zendesk-adapter/src/filters/collision_errors.ts
+++ b/packages/zendesk-adapter/src/filters/collision_errors.ts
@@ -42,7 +42,7 @@ const filterCreator: FilterCreator = ({ config }) => ({
       idFieldsName: 'idFields',
       // Needed because 'safeJsonStringify' is really slow, which causes problems with articles stress test (SALTO-3059)
       skipLogCollisionStringify: isGuideEnabled(config[FETCH_CONFIG]),
-      docsUrl: 'https://docs.salto.io/docs/zendesk#zendesk-duplicate-names',
+      docsUrl: 'https://help.salto.io/en/articles/6927157-salto-id-collisions',
     })
     return { errors: collistionWarnings }
   }, 'collisionErrorsFilter'),

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -673,7 +673,7 @@ describe('adapter', () => {
         expect(errors).toEqual([
           {
             severity: 'Warning',
-            message: 'Salto was forbidden from accessing the custom_statuses resource. Elements from that type were not fetched. Please make sure that the supplied user credentials have sufficient permissions to access this data, and try again. Learn more at https://docs.salto.io/docs/fetch-error-forbidden-access',
+            message: 'Salto was forbidden from accessing the custom_statuses resource. Elements from that type were not fetched. Please make sure that the supplied user credentials have sufficient permissions to access this data, and try again. Learn more at https://help.salto.io/en/articles/6947061-salto-was-forbidden-from-accessing-the-resource',
           },
         ])
         const elementsNames = elements.map(e => e.elemID.getFullName())

--- a/packages/zendesk-adapter/test/change_validator.test.ts
+++ b/packages/zendesk-adapter/test/change_validator.test.ts
@@ -46,13 +46,13 @@ describe('change validator creator', () => {
           elemID: new ElemID(ZENDESK, 'obj'),
           severity: 'Error',
           message: 'Deployment of non-instance elements is not supported in adapter zendesk',
-          detailedMessage: 'Deployment of non-instance elements is not supported in adapter zendesk. Please see your business app FAQ at https://docs.salto.io/docs/supported-bizapps for a list of supported elements.',
+          detailedMessage: 'Deployment of non-instance elements is not supported in adapter zendesk. Please see your business app FAQ at https://help.salto.io/en/articles/6927118-supported-business-applications for a list of supported elements.',
         },
         {
           elemID: new ElemID(ZENDESK, 'obj2'),
           severity: 'Error',
           message: 'Deployment of non-instance elements is not supported in adapter zendesk',
-          detailedMessage: 'Deployment of non-instance elements is not supported in adapter zendesk. Please see your business app FAQ at https://docs.salto.io/docs/supported-bizapps for a list of supported elements.',
+          detailedMessage: 'Deployment of non-instance elements is not supported in adapter zendesk. Please see your business app FAQ at https://help.salto.io/en/articles/6927118-supported-business-applications for a list of supported elements.',
         },
       ])
     })
@@ -73,13 +73,13 @@ describe('change validator creator', () => {
           elemID: new ElemID(ZENDESK, 'obj', 'instance', 'inst1'),
           severity: 'Error',
           message: 'Operation not supported',
-          detailedMessage: 'Salto does not support "add" of zendesk.obj.instance.inst1. Please see your business app FAQ at https://docs.salto.io/docs/supported-bizapps for a list of supported elements.',
+          detailedMessage: 'Salto does not support "add" of zendesk.obj.instance.inst1. Please see your business app FAQ at https://help.salto.io/en/articles/6927118-supported-business-applications for a list of supported elements.',
         },
         {
           elemID: new ElemID(ZENDESK, 'obj', 'instance', 'inst2'),
           severity: 'Error',
           message: 'Operation not supported',
-          detailedMessage: 'Salto does not support "remove" of zendesk.obj.instance.inst2. Please see your business app FAQ at https://docs.salto.io/docs/supported-bizapps for a list of supported elements.',
+          detailedMessage: 'Salto does not support "remove" of zendesk.obj.instance.inst2. Please see your business app FAQ at https://help.salto.io/en/articles/6927118-supported-business-applications for a list of supported elements.',
         },
       ])
     })

--- a/packages/zendesk-adapter/test/filters/collision_errors.test.ts
+++ b/packages/zendesk-adapter/test/filters/collision_errors.test.ts
@@ -54,7 +54,7 @@ To resolve these collisions please take one of the following actions and fetch a
 
 Alternatively, you can exclude obj from the service configuration in zendesk.nacl
 
-Learn more at: https://docs.salto.io/docs/zendesk#zendesk-duplicate-names`,
+Learn more at: https://help.salto.io/en/articles/6927157-salto-id-collisions`,
       })
     })
     it('should return no errors if there were no collisions', async () => {

--- a/packages/zuora-billing-adapter/test/change_validator.test.ts
+++ b/packages/zuora-billing-adapter/test/change_validator.test.ts
@@ -32,13 +32,13 @@ describe('change validator creator', () => {
           elemID: new ElemID(ZUORA_BILLING, 'obj'),
           severity: 'Error',
           message: 'Salto does not support zuora_billing deployments.',
-          detailedMessage: 'Salto does not support zuora_billing deployments. Please see https://docs.salto.io/docs/supported-bizapps for more details.',
+          detailedMessage: 'Salto does not support zuora_billing deployments. Please see https://help.salto.io/en/articles/6927118-supported-business-applications for more details.',
         },
         {
           elemID: new ElemID(ZUORA_BILLING, 'obj2'),
           severity: 'Error',
           message: 'Salto does not support zuora_billing deployments.',
-          detailedMessage: 'Salto does not support zuora_billing deployments. Please see https://docs.salto.io/docs/supported-bizapps for more details.',
+          detailedMessage: 'Salto does not support zuora_billing deployments. Please see https://help.salto.io/en/articles/6927118-supported-business-applications for more details.',
         },
       ])
     })


### PR DESCRIPTION
Changed all documentation links from docs.salto.io to new help center at help.salto.io

---

_Additional context for reviewer_
N/A

---

_Release Notes_: 
Changed all documentation links to new Help Center at help.salto.io

---

_User Notifications_: 
N/A
