### PR TITLE
SAAS-7003: invalid nacl files are not returned from config source

### DIFF
--- a/packages/workspace/src/workspace/adapters_config_source.ts
+++ b/packages/workspace/src/workspace/adapters_config_source.ts
@@ -233,9 +233,8 @@ export const buildAdaptersConfigSource = async ({
       }
       await updateValidationErrorsCache(validationErrorsMap, elementsSource, naclSource)
     },
-    getElementNaclFiles: async adapter => naclSource.getElementNaclFiles(
-      new ElemID(adapter, ElemID.CONFIG_NAME, 'instance', ElemID.CONFIG_NAME)
-    ),
+    getElementNaclFiles: async adapter => (await naclSource.listNaclFiles())
+      .filter(filePath => filePath.startsWith(path.join(...CONFIG_PATH, adapter) + path.sep)),
 
     getErrors: async () => {
       const validationErrors = await awu(validationErrorsMap.values()).flat().toArray()

--- a/packages/workspace/src/workspace/adapters_config_source.ts
+++ b/packages/workspace/src/workspace/adapters_config_source.ts
@@ -234,7 +234,7 @@ export const buildAdaptersConfigSource = async ({
       await updateValidationErrorsCache(validationErrorsMap, elementsSource, naclSource)
     },
     getElementNaclFiles: async adapter => (await naclSource.listNaclFiles())
-      .filter(filePath => filePath.startsWith(path.join(...CONFIG_PATH, adapter) + path.sep)),
+      .filter(filePath => filePath.startsWith(path.join(...CONFIG_PATH, adapter).concat(path.sep))),
 
     getErrors: async () => {
       const validationErrors = await awu(validationErrorsMap.values()).flat().toArray()

--- a/packages/workspace/test/workspace/adapters_config.test.ts
+++ b/packages/workspace/test/workspace/adapters_config.test.ts
@@ -215,9 +215,9 @@ describe('adapters config', () => {
   })
 
   it('getElementNaclFiles should return the configuration files', async () => {
-    mockNaclFilesSource.getElementNaclFiles.mockResolvedValue(['salto.config/adapters/a/b', 'salto.config/adapters/c'])
+    mockNaclFilesSource.listNaclFiles.mockResolvedValue(['salto.config/adapters/salesforce/a/b', 'salto.config/adapters/salesforce/c', 'salto.config/adapters/dummy/d'])
     const paths = await configSource.getElementNaclFiles('salesforce')
-    expect(paths).toEqual(['salto.config/adapters/a/b', 'salto.config/adapters/c'])
+    expect(paths).toEqual(['salto.config/adapters/salesforce/a/b', 'salto.config/adapters/salesforce/c'])
   })
 
   describe('configOverrides', () => {


### PR DESCRIPTION
Fixed a bug were updating a config files to be invalid would make them to not be returned from `getElementNaclFiles` (resulting them being gone from the SaaS UI(

---
_Release Notes_: 
None (does not affect OSS)

---
_User Notifications_: 
None