### PR TITLE
SALTO-3149 add back log export

### DIFF
--- a/packages/file/src/gzip.ts
+++ b/packages/file/src/gzip.ts
@@ -22,7 +22,7 @@ import getStream from 'get-stream'
 import { logger } from '@salto-io/logging'
 import { readFile } from './file'
 
-const log = logger(module)
+export const log = logger(module)
 
 export const createGZipReadStream = (
   zipFilename: string,

--- a/packages/file/test/gzip.test.ts
+++ b/packages/file/test/gzip.test.ts
@@ -22,6 +22,7 @@ import { Readable } from 'stream'
 import getStream from 'get-stream'
 import * as file from '../src/file'
 import * as gzip from '../src/gzip'
+import { log } from '../index'
 
 describe('gzip', () => {
   const expectRejectWithErrnoException = async <TResult>(
@@ -326,5 +327,9 @@ describe('gzip', () => {
         expect(contents).toEqual(await getStream(gzip.createGZipReadStream(dest)))
       })
     })
+  })
+
+  it('should have an exported log', () => {
+    expect(log.info).toBeDefined()
   })
 })


### PR DESCRIPTION
It seems the exported log from the`file` package that was removed in https://github.com/salto-io/salto/commit/3c88c15b224cf0f4abafc51f7264201ea9030398#diff-48f9c482fc5655b1e8fb83a284de4e694d0afff0d36fe26416c1a40ddf398eebL27 is needed in the SAAS, so adding it back (will try to remove it separately - this currently blocks a bump).

---
_Release Notes_: 
None

---
_User Notifications_: 
None