### PR TITLE
SALTO-3143: Add shared deploy config to handle missing users

### DIFF
--- a/packages/adapter-components/src/config/index.ts
+++ b/packages/adapter-components/src/config/index.ts
@@ -15,7 +15,7 @@
 */
 export { createDucktypeAdapterApiConfigType, AdapterDuckTypeApiConfig, DuckTypeTransformationConfig, DuckTypeTransformationDefaultConfig, TypeDuckTypeConfig, TypeDuckTypeDefaultsConfig, validateApiDefinitionConfig as validateDuckTypeApiDefinitionConfig, validateFetchConfig as validateDuckTypeFetchConfig } from './ducktype'
 export { createRequestConfigs, validateRequestConfig, FetchRequestConfig, DeployRequestConfig, UrlParams, DeploymentRequestsByAction, RecurseIntoCondition, isRecurseIntoConditionByField } from './request'
-export { createAdapterApiConfigType, getConfigWithDefault, AdapterApiConfig, UserFetchConfig, TypeConfig, createUserFetchConfigType, UserDeployConfig, createUserDeployConfigType } from './shared'
+export { createAdapterApiConfigType, getConfigWithDefault, AdapterApiConfig, UserFetchConfig, TypeConfig, createUserFetchConfigType, DEPLOYER_FALLBACK_VALUE, UserDeployConfig, createUserDeployConfigType } from './shared'
 export { mergeWithDefaultConfig } from './merge'
 export { createTypeNameOverrideConfigType, createSwaggerAdapterApiConfigType, AdapterSwaggerApiConfig, RequestableAdapterSwaggerApiConfig, TypeSwaggerConfig, RequestableTypeSwaggerConfig, TypeSwaggerDefaultConfig, TypeNameOverrideConfig, validateApiDefinitionConfig as validateSwaggerApiDefinitionConfig, validateFetchConfig as validateSwaggerFetchConfig } from './swagger'
 export { createTransformationConfigTypes, validateTransoformationConfig, TransformationDefaultConfig, TransformationConfig, StandaloneFieldConfigType, FieldToOmitType, FieldToHideType, getTransformationConfigByType, dereferenceFieldName, isReferencedIdField, NameMappingOptions, DATA_FIELD_ENTIRE_OBJECT } from './transformation'

--- a/packages/adapter-components/src/config/index.ts
+++ b/packages/adapter-components/src/config/index.ts
@@ -15,7 +15,7 @@
 */
 export { createDucktypeAdapterApiConfigType, AdapterDuckTypeApiConfig, DuckTypeTransformationConfig, DuckTypeTransformationDefaultConfig, TypeDuckTypeConfig, TypeDuckTypeDefaultsConfig, validateApiDefinitionConfig as validateDuckTypeApiDefinitionConfig, validateFetchConfig as validateDuckTypeFetchConfig } from './ducktype'
 export { createRequestConfigs, validateRequestConfig, FetchRequestConfig, DeployRequestConfig, UrlParams, DeploymentRequestsByAction, RecurseIntoCondition, isRecurseIntoConditionByField } from './request'
-export { createAdapterApiConfigType, getConfigWithDefault, AdapterApiConfig, UserFetchConfig, TypeConfig, createUserFetchConfigType } from './shared'
+export { createAdapterApiConfigType, getConfigWithDefault, AdapterApiConfig, UserFetchConfig, TypeConfig, createUserFetchConfigType, UserDeployConfig, createUserDeployConfigType } from './shared'
 export { mergeWithDefaultConfig } from './merge'
 export { createTypeNameOverrideConfigType, createSwaggerAdapterApiConfigType, AdapterSwaggerApiConfig, RequestableAdapterSwaggerApiConfig, TypeSwaggerConfig, RequestableTypeSwaggerConfig, TypeSwaggerDefaultConfig, TypeNameOverrideConfig, validateApiDefinitionConfig as validateSwaggerApiDefinitionConfig, validateFetchConfig as validateSwaggerFetchConfig } from './swagger'
 export { createTransformationConfigTypes, validateTransoformationConfig, TransformationDefaultConfig, TransformationConfig, StandaloneFieldConfigType, FieldToOmitType, FieldToHideType, getTransformationConfigByType, dereferenceFieldName, isReferencedIdField, NameMappingOptions, DATA_FIELD_ENTIRE_OBJECT } from './transformation'

--- a/packages/adapter-components/src/config/shared.ts
+++ b/packages/adapter-components/src/config/shared.ts
@@ -55,6 +55,10 @@ export type UserFetchConfig<T extends Record<string, unknown> | undefined = unde
   hideTypes?: boolean
 }
 
+export type UserDeployConfig = {
+  defaultMissingUserFallback?: string
+}
+
 export const createAdapterApiConfigType = ({
   adapter,
   additionalFields,
@@ -168,6 +172,22 @@ export const createUserFetchConfigType = (
     },
   })
 }
+
+export const createUserDeployConfigType = (
+  adapter: string,
+  additionalFields?: Record<string, FieldDefinition>,
+): ObjectType => (
+  createMatchingObjectType<UserDeployConfig>({
+    elemID: new ElemID(adapter, 'userDeployConfig'),
+    fields: {
+      defaultMissingUserFallback: { refType: BuiltinTypes.STRING },
+      ...additionalFields,
+    },
+    annotations: {
+      [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+    },
+  })
+)
 
 export const getConfigWithDefault = <
   T extends TransformationConfig | FetchRequestConfig | undefined,

--- a/packages/adapter-components/src/config/shared.ts
+++ b/packages/adapter-components/src/config/shared.ts
@@ -58,6 +58,7 @@ export type UserFetchConfig<T extends Record<string, unknown> | undefined = unde
 }
 
 export type UserDeployConfig = {
+  // Replace references for missing users during deploy with defaultMissingUserFallback value
   defaultMissingUserFallback?: string
 }
 

--- a/packages/adapter-components/src/config/shared.ts
+++ b/packages/adapter-components/src/config/shared.ts
@@ -21,6 +21,8 @@ import { createMatchingObjectType } from '@salto-io/adapter-utils'
 import type { TransformationConfig, TransformationDefaultConfig } from './transformation'
 import { DeploymentRequestsByAction, FetchRequestConfig, FetchRequestDefaultConfig } from './request'
 
+export const DEPLOYER_FALLBACK_VALUE = '##DEPLOYER##'
+
 export type TypeConfig<T extends TransformationConfig = TransformationConfig> = {
   request?: FetchRequestConfig
   deployRequests?: DeploymentRequestsByAction

--- a/packages/adapter-components/test/config/shared.test.ts
+++ b/packages/adapter-components/test/config/shared.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { createUserFetchConfigType, getConfigWithDefault } from '../../src/config'
+import { createUserDeployConfigType, createUserFetchConfigType, getConfigWithDefault } from '../../src/config'
 
 describe('config_shared', () => {
   describe('createUserFetchConfigType', () => {
@@ -23,6 +23,13 @@ describe('config_shared', () => {
       expect(type.fields.include).toBeDefined()
       expect(type.fields.exclude).toBeDefined()
       expect(type.fields.hideTypes).toBeDefined()
+    })
+  })
+  describe('createUserDeployConfigType', () => {
+    it('should return default type when no custom fields were added', () => {
+      const type = createUserDeployConfigType('myAdapter')
+      expect(Object.keys(type.fields)).toHaveLength(1)
+      expect(type.fields.defaultMissingUserFallback).toBeDefined()
     })
   })
   describe('getConfigWithDefault', () => {


### PR DESCRIPTION
Add deploy config with user fallback strategy

---

This PR contains only the adapter-components changes, for full context see https://github.com/salto-io/salto/pull/3846/files

---
_Release Notes_: 
None

---
_User Notifications_: 
None
