### PR TITLE
SALTO-2961 - Zendesk Adapter - Retry on more responses statuses

### DIFF
--- a/packages/adapter-components/src/client/config.ts
+++ b/packages/adapter-components/src/client/config.ts
@@ -30,6 +30,7 @@ export type ClientPageSizeConfig = Partial<{
 export type ClientRetryConfig = Partial<{
   maxAttempts: number
   retryDelay: number
+  additionalStatusCodesToRetry: number[]
 }>
 
 export type ClientBaseConfig<RateLimitConfig extends ClientRateLimitConfig> = Partial<{

--- a/packages/adapter-components/src/client/config.ts
+++ b/packages/adapter-components/src/client/config.ts
@@ -30,6 +30,7 @@ export type ClientPageSizeConfig = Partial<{
 export type ClientRetryConfig = Partial<{
   maxAttempts: number
   retryDelay: number
+  // This is not included in clientRetryConfigType because currently we don't want to allow the user to change it
   additionalStatusCodesToRetry: number[]
 }>
 

--- a/packages/adapter-components/src/client/constants.ts
+++ b/packages/adapter-components/src/client/constants.ts
@@ -19,6 +19,7 @@ import { ClientRetryConfig } from './config'
 export const DEFAULT_RETRY_OPTS: Required<ClientRetryConfig> = {
   maxAttempts: 5, // try 5 times
   retryDelay: 5000, // wait for 5s before trying again
+  additionalStatusCodesToRetry: [],
 }
 
 export const RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS = -1

--- a/packages/adapter-components/src/client/http_connection.ts
+++ b/packages/adapter-components/src/client/http_connection.ts
@@ -115,9 +115,7 @@ const getRetryDelay = (retryOptions: Required<ClientRetryConfig>, error: AxiosEr
 const shouldRetryStatusCode = (statusCode?: number, additionalStatusesToRetry: number[] = []): boolean =>
   statusCode !== undefined && [429, ...additionalStatusesToRetry].includes(statusCode)
 
-export const createRetryOptions = (
-  retryOptions: Required<ClientRetryConfig>,
-): RetryOptions => ({
+export const createRetryOptions = (retryOptions: Required<ClientRetryConfig>): RetryOptions => ({
   retries: retryOptions.maxAttempts,
   retryDelay: (retryCount, err) => {
     const retryDelay = getRetryDelay(retryOptions, err)

--- a/packages/adapter-components/src/client/http_connection.ts
+++ b/packages/adapter-components/src/client/http_connection.ts
@@ -112,9 +112,12 @@ const getRetryDelay = (retryOptions: Required<ClientRetryConfig>, error: AxiosEr
   return retryDelay
 }
 
+const shouldRetryStatusCode = (statusCode?: number, additionalStatusCodesToRetry: number[] = []): boolean =>
+  statusCode !== undefined && [429, ...additionalStatusCodesToRetry].includes(statusCode)
+
 export const createRetryOptions = (
   retryOptions: Required<ClientRetryConfig>,
-  additionalStatusesToRetry: number[] = []
+  additionalStatusCodesToRetry: number[] = []
 ): RetryOptions => ({
   retries: retryOptions.maxAttempts,
   retryDelay: (retryCount, err) => {
@@ -129,7 +132,7 @@ export const createRetryOptions = (
     return retryDelay
   },
   retryCondition: err => axiosRetry.isNetworkOrIdempotentRequestError(err)
-    || (err.response?.status !== undefined && [429, ...additionalStatusesToRetry].includes(err.response.status)),
+    || shouldRetryStatusCode(err.response?.status, additionalStatusCodesToRetry),
 })
 
 type ConnectionParams<TCredentials> = {

--- a/packages/adapter-components/src/client/http_connection.ts
+++ b/packages/adapter-components/src/client/http_connection.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2023 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with
@@ -112,7 +112,10 @@ const getRetryDelay = (retryOptions: Required<ClientRetryConfig>, error: AxiosEr
   return retryDelay
 }
 
-export const createRetryOptions = (retryOptions: Required<ClientRetryConfig>): RetryOptions => ({
+export const createRetryOptions = (
+  retryOptions: Required<ClientRetryConfig>,
+  additionalStatusesToRetry: number[] = []
+): RetryOptions => ({
   retries: retryOptions.maxAttempts,
   retryDelay: (retryCount, err) => {
     const retryDelay = getRetryDelay(retryOptions, err)
@@ -126,7 +129,7 @@ export const createRetryOptions = (retryOptions: Required<ClientRetryConfig>): R
     return retryDelay
   },
   retryCondition: err => axiosRetry.isNetworkOrIdempotentRequestError(err)
-    || err.response?.status === 429,
+    || (err.response?.status !== undefined && [429, ...additionalStatusesToRetry].includes(err.response.status)),
 })
 
 type ConnectionParams<TCredentials> = {

--- a/packages/adapter-components/src/client/http_connection.ts
+++ b/packages/adapter-components/src/client/http_connection.ts
@@ -112,12 +112,11 @@ const getRetryDelay = (retryOptions: Required<ClientRetryConfig>, error: AxiosEr
   return retryDelay
 }
 
-const shouldRetryStatusCode = (statusCode?: number, additionalStatusCodesToRetry: number[] = []): boolean =>
-  statusCode !== undefined && [429, ...additionalStatusCodesToRetry].includes(statusCode)
+const shouldRetryStatusCode = (statusCode?: number, additionalStatusesToRetry: number[] = []): boolean =>
+  statusCode !== undefined && [429, ...additionalStatusesToRetry].includes(statusCode)
 
 export const createRetryOptions = (
   retryOptions: Required<ClientRetryConfig>,
-  additionalStatusCodesToRetry: number[] = []
 ): RetryOptions => ({
   retries: retryOptions.maxAttempts,
   retryDelay: (retryCount, err) => {
@@ -132,7 +131,7 @@ export const createRetryOptions = (
     return retryDelay
   },
   retryCondition: err => axiosRetry.isNetworkOrIdempotentRequestError(err)
-    || shouldRetryStatusCode(err.response?.status, additionalStatusCodesToRetry),
+    || shouldRetryStatusCode(err.response?.status, retryOptions.additionalStatusCodesToRetry),
 })
 
 type ConnectionParams<TCredentials> = {

--- a/packages/adapter-components/src/client/http_connection.ts
+++ b/packages/adapter-components/src/client/http_connection.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2022 Salto Labs Ltd.
+*                      Copyright 2023 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/client/http_client.test.ts
+++ b/packages/adapter-components/test/client/http_client.test.ts
@@ -48,7 +48,7 @@ describe('client_http_client', () => {
           pageSize: { get: 123 },
           rateLimit: { total: -1, get: 3, deploy: 4 },
           maxRequestsPerMinute: -1,
-          retry: { maxAttempts: 3, retryDelay: 123 },
+          retry: { maxAttempts: 3, retryDelay: 123, additionalStatusCodesToRetry: [] },
         }
       )
     }

--- a/packages/adapter-components/test/client/http_connection.test.ts
+++ b/packages/adapter-components/test/client/http_connection.test.ts
@@ -75,7 +75,7 @@ describe('client_http_connection', () => {
     let retryOptions: RetryOptions
 
     beforeEach(() => {
-      retryOptions = createRetryOptions({ maxAttempts: 3, retryDelay: 100 })
+      retryOptions = createRetryOptions({ maxAttempts: 3, retryDelay: 100, additionalStatusCodesToRetry: [] })
     })
     it('should retry error code 429', () => {
       expect(retryOptions.retryCondition?.({

--- a/packages/okta-adapter/src/client/client.ts
+++ b/packages/okta-adapter/src/client/client.ts
@@ -47,13 +47,9 @@ export default class OktaClient extends clientUtils.AdapterHTTPClient<
       {
         pageSize: DEFAULT_PAGE_SIZE,
         rateLimit: DEFAULT_MAX_CONCURRENT_API_REQUESTS,
-        // TODO SALTO-2649: add better handling for rate limits
         maxRequestsPerMinute: DEFAULT_MAX_REQUESTS_PER_MINUTE,
-        retry: {
-          maxAttempts: 5, // try 5 times
-          retryDelay: 10000, // wait for 10s before trying again, change after SALTO-2649
-          additionalStatusCodesToRetry: DEFAULT_RETRY_OPTS.additionalStatusCodesToRetry,
-        },
+        // TODO SALTO-2649: add better handling for rate limits
+        retry: { ...DEFAULT_RETRY_OPTS, retryDelay: 10000 },
       }
     )
   }

--- a/packages/okta-adapter/src/client/client.ts
+++ b/packages/okta-adapter/src/client/client.ts
@@ -49,6 +49,7 @@ export default class OktaClient extends clientUtils.AdapterHTTPClient<
         rateLimit: DEFAULT_MAX_CONCURRENT_API_REQUESTS,
         // TODO SALTO-2649: add better handling for rate limits
         maxRequestsPerMinute: DEFAULT_MAX_REQUESTS_PER_MINUTE,
+        // wait for 10s before trying again, change after SALTO-2649
         retry: { ...DEFAULT_RETRY_OPTS, retryDelay: 10000 },
       }
     )

--- a/packages/okta-adapter/src/client/client.ts
+++ b/packages/okta-adapter/src/client/client.ts
@@ -47,8 +47,8 @@ export default class OktaClient extends clientUtils.AdapterHTTPClient<
       {
         pageSize: DEFAULT_PAGE_SIZE,
         rateLimit: DEFAULT_MAX_CONCURRENT_API_REQUESTS,
-        maxRequestsPerMinute: DEFAULT_MAX_REQUESTS_PER_MINUTE,
         // TODO SALTO-2649: add better handling for rate limits
+        maxRequestsPerMinute: DEFAULT_MAX_REQUESTS_PER_MINUTE,
         retry: { ...DEFAULT_RETRY_OPTS, retryDelay: 10000 },
       }
     )

--- a/packages/okta-adapter/src/client/client.ts
+++ b/packages/okta-adapter/src/client/client.ts
@@ -19,7 +19,7 @@ import { OKTA } from '../constants'
 import { Credentials } from '../auth'
 
 const {
-  RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,
+  RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS, DEFAULT_RETRY_OPTS,
 } = clientUtils
 
 const DEFAULT_MAX_CONCURRENT_API_REQUESTS: Required<clientUtils.ClientRateLimitConfig> = {
@@ -52,6 +52,7 @@ export default class OktaClient extends clientUtils.AdapterHTTPClient<
         retry: {
           maxAttempts: 5, // try 5 times
           retryDelay: 10000, // wait for 10s before trying again, change after SALTO-2649
+          additionalStatusCodesToRetry: DEFAULT_RETRY_OPTS.additionalStatusCodesToRetry,
         },
       }
     )

--- a/packages/zendesk-adapter/src/client/client.ts
+++ b/packages/zendesk-adapter/src/client/client.ts
@@ -60,13 +60,13 @@ export default class ZendeskClient extends clientUtils.AdapterHTTPClient<
         pageSize: DEFAULT_PAGE_SIZE,
         rateLimit: DEFAULT_MAX_CONCURRENT_API_REQUESTS,
         maxRequestsPerMinute: RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,
-        retry: DEFAULT_RETRY_OPTS,
+        // These statuses are returned by Zendesk and are not related to our data, a retry should solve them
+        retry: Object.assign(DEFAULT_RETRY_OPTS, { additionalStatusCodesToRetry: [409, 503] }),
       },
     )
     this.resourceConn = clientUtils.createClientConnection({
       retryOptions: clientUtils.createRetryOptions(
         _.defaults({}, this.config?.retry, DEFAULT_RETRY_OPTS),
-        [409, 503] // These statuses are returned by Zendesk and are not related to our data, a retry should solve them
       ),
       createConnection: createResourceConnection,
     })

--- a/packages/zendesk-adapter/src/client/client.ts
+++ b/packages/zendesk-adapter/src/client/client.ts
@@ -65,7 +65,8 @@ export default class ZendeskClient extends clientUtils.AdapterHTTPClient<
     )
     this.resourceConn = clientUtils.createClientConnection({
       retryOptions: clientUtils.createRetryOptions(
-        _.defaults({}, this.config?.retry, DEFAULT_RETRY_OPTS)
+        _.defaults({}, this.config?.retry, DEFAULT_RETRY_OPTS),
+        [409, 503] // These statuses are returned by Zendesk and are not related to our data, a retry should solve them
       ),
       createConnection: createResourceConnection,
     })

--- a/packages/zendesk-adapter/src/client/client.ts
+++ b/packages/zendesk-adapter/src/client/client.ts
@@ -66,7 +66,7 @@ export default class ZendeskClient extends clientUtils.AdapterHTTPClient<
     )
     this.resourceConn = clientUtils.createClientConnection({
       retryOptions: clientUtils.createRetryOptions(
-        _.defaults({}, this.config?.retry, DEFAULT_RETRY_OPTS),
+        _.defaults({}, this.config?.retry, DEFAULT_RETRY_OPTS)
       ),
       createConnection: createResourceConnection,
     })

--- a/packages/zendesk-adapter/test/client/client.test.ts
+++ b/packages/zendesk-adapter/test/client/client.test.ts
@@ -63,7 +63,7 @@ describe('client', () => {
         .replyOnce(503)
         .onPost()
         .replyOnce(200)
-      await client.post({ url: '/api/v2/routing/attributes' })
+      await client.post({ url: '/api/v2/routing/attributes', data: {} })
       expect(mockAxios.history.post.length).toEqual(4)
     })
   })


### PR DESCRIPTION
Zendesk adapter will also retry the request if the status code is 409 or 503

---

None

---
_Release Notes_: 
None

---
_User Notifications_: 
None
