### PR TITLE
Change the changeError id of an immutable type annotation

### DIFF
--- a/packages/netsuite-adapter/src/change_validators/immutable_changes.ts
+++ b/packages/netsuite-adapter/src/change_validators/immutable_changes.ts
@@ -44,7 +44,7 @@ const toTypeErrors = async (change: ModificationChange<ObjectType>): Promise<Cha
     modifiedImmutableAnnotations.push(APPLICATION_ID)
   }
   return modifiedImmutableAnnotations.map(modifiedAnno => ({
-    elemID: after.elemID,
+    elemID: after.elemID.createNestedID('attr', modifiedAnno),
     severity: 'Error',
     message: 'Attempting to modify an immutable annotation',
     detailedMessage: `Annotation '${modifiedAnno}' is immutable`,

--- a/packages/netsuite-adapter/test/change_validators/immutable_changes.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/immutable_changes.test.ts
@@ -57,7 +57,7 @@ describe('customization type change validator', () => {
     )
     expect(changeErrors).toHaveLength(1)
     expect(changeErrors[0].severity).toEqual('Error')
-    expect(changeErrors[0].elemID).toEqual(type.elemID)
+    expect(changeErrors[0].elemID).toEqual(type.elemID.createNestedID('attr', SCRIPT_ID))
   })
 
   it('should have change error if field SCRIPT_ID annotation has been modified', async () => {
@@ -199,6 +199,6 @@ describe('customization type change validator', () => {
     )
     expect(changeErrors).toHaveLength(1)
     expect(changeErrors[0].severity).toEqual('Error')
-    expect(changeErrors[0].elemID).toEqual(after.elemID)
+    expect(changeErrors[0].elemID).toEqual(after.elemID.createNestedID('attr', 'application_id'))
   })
 })


### PR DESCRIPTION
Set the changeError id of an immutable type annotation to the annotation elemID (instead of the whole type).
The motivation for that is to be able to deploy modified/new fields in a custom record type even if there is a changeError on the parent type - which won't work if the changeError id is the type elemID.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Set the changeError id of an immutable type annotation to the annotation elemID

---
_User Notifications_: 
None