### PR TITLE
SALTO-3537 Add a dependency when reference target is a modified non-element value

### DIFF
--- a/packages/core/src/core/plan/dependency/reference_dependency.ts
+++ b/packages/core/src/core/plan/dependency/reference_dependency.ts
@@ -34,7 +34,7 @@ const getChangeElemId = (change: Change<ChangeDataType>): string => (
 )
 
 const isReferenceValueChanged = (change: Change<ChangeDataType>, refElemId: ElemID): boolean => {
-  if (!isModificationChange(change) || refElemId.createBaseID().path.length === 0) {
+  if (!isModificationChange(change) || refElemId.isBaseID()) {
     return false
   }
   const beforeTopLevel = isField(change.data.before) ? change.data.before.parent : change.data.before

--- a/packages/core/src/core/plan/dependency/reference_dependency.ts
+++ b/packages/core/src/core/plan/dependency/reference_dependency.ts
@@ -14,13 +14,13 @@
 * limitations under the License.
 */
 import wu from 'wu'
-import { collections } from '@salto-io/lowerdash'
+import { collections, values } from '@salto-io/lowerdash'
 import {
   getChangeData, isReferenceExpression, ChangeDataType, Change, ChangeEntry, DependencyChange,
   addReferenceDependency, addParentDependency, isDependentAction, DependencyChanger, isObjectType,
-  ElemID,
+  ElemID, isModificationChange, isField, isEqualValues, dependencyChange,
 } from '@salto-io/adapter-api'
-import { getAllReferencedIds, getParents } from '@salto-io/adapter-utils'
+import { getAllReferencedIds, getParents, resolvePath } from '@salto-io/adapter-utils'
 
 const { awu } = collections.asynciterable
 
@@ -32,6 +32,19 @@ const getParentIds = (elem: ChangeDataType): Set<string> => new Set(
 const getChangeElemId = (change: Change<ChangeDataType>): string => (
   getChangeData(change).elemID.getFullName()
 )
+
+const isReferenceValueChanged = (change: Change<ChangeDataType>, refElemId: ElemID): boolean => {
+  if (!isModificationChange(change) || refElemId.createBaseID().path.length === 0) {
+    return false
+  }
+  const beforeTopLevel = isField(change.data.before) ? change.data.before.parent : change.data.before
+  const afterTopLevel = isField(change.data.after) ? change.data.after.parent : change.data.after
+  return !isEqualValues(
+    resolvePath(beforeTopLevel, refElemId),
+    resolvePath(afterTopLevel, refElemId),
+    { compareReferencesByValue: true }
+  )
+}
 
 export const addReferencesDependency: DependencyChanger = async changes => {
   const changesById = collections.iterable.groupBy(
@@ -50,15 +63,30 @@ export const addReferencesDependency: DependencyChanger = async changes => {
     const onlyAnnotations = isObjectType(elem)
     // Not using ElementsSource here is legit because it's ran
     // after resolve
-    return (wu(getAllReferencedIds(elem, onlyAnnotations))
-      .map(targetId => ElemID.fromFullName(targetId).createBaseID().parent.getFullName())
-      .filter(targetId => targetId !== elemId) // Ignore self references
-      .map(targetId => changesById.get(targetId) ?? [])
-      .flatten(true) as wu.WuIterable<ChangeEntry>)
-      .filter(([_id, targetChange]) => isDependentAction(change.action, targetChange.action))
-      .map(([targetId, targetChange]) => (parents.has(getChangeElemId(targetChange))
-        ? addParentDependency(id, targetId)
-        : addReferenceDependency(targetChange.action, id, targetId)))
+    return wu(getAllReferencedIds(elem, onlyAnnotations))
+      .map(targetRefIdFullName => {
+        const targetRefId = ElemID.fromFullName(targetRefIdFullName)
+        const targetElemId = targetRefId.createBaseID().parent.getFullName()
+        // Ignore self references
+        if (targetElemId === elemId) {
+          return undefined
+        }
+        const [targetChangeEntry] = changesById.get(targetElemId) ?? []
+        if (targetChangeEntry === undefined) {
+          return undefined
+        }
+        const [targetId, targetChange] = targetChangeEntry
+        if (isDependentAction(change.action, targetChange.action)) {
+          return parents.has(getChangeElemId(targetChange))
+            ? addParentDependency(id, targetId)
+            : addReferenceDependency(targetChange.action, id, targetId)
+        }
+        if (isReferenceValueChanged(targetChange, targetRefId)) {
+          return dependencyChange('add', id, targetId)
+        }
+        return undefined
+      })
+      .filter(values.isDefined)
   }
 
   return awu(changes).flatMap(addChangeDependency).toArray()

--- a/packages/core/test/core/plan/dependency.test.ts
+++ b/packages/core/test/core/plan/dependency.test.ts
@@ -396,5 +396,63 @@ describe('dependency changers', () => {
         )
       })
     })
+    describe('when reference target is a modified non-element value', () => {
+      beforeEach(async () => {
+        const testTypeAfter = testType.clone()
+        const testInstanceAfter = testInstance.clone()
+        testType.annotations.bla = 'value'
+        testTypeAfter.annotations.bla = 'updated'
+        testInstance.value.ref = new ReferenceExpression(testTypeId.createNestedID('attr', 'bla'), 'value')
+        testInstanceAfter.value.ref = new ReferenceExpression(testTypeId.createNestedID('attr', 'bla'), 'updated')
+        const inputChanges = new Map<number, Change>([
+          [0, toChange({ before: testType, after: testTypeAfter })],
+          [1, toChange({ before: testInstance, after: testInstanceAfter })],
+        ])
+        dependencyChanges = [...await addReferencesDependency(inputChanges, new Map())]
+      })
+      it('should add dependency to the referenced element', () => {
+        expect(dependencyChanges).toEqual([
+          { action: 'add', dependency: { source: 1, target: 0 } },
+        ])
+      })
+    })
+    describe('when reference target is a modified non-element value in a field', () => {
+      beforeEach(async () => {
+        const testTypeAfter = testType.clone()
+        const testInstanceAfter = testInstance.clone()
+        testType.fields.ref.annotations.bla = 'value'
+        testTypeAfter.fields.ref.annotations.bla = 'updated'
+        testInstance.value.ref = new ReferenceExpression(testTypeId.createNestedID('field', 'ref', 'bla'), 'value')
+        testInstanceAfter.value.ref = new ReferenceExpression(testTypeId.createNestedID('field', 'ref', 'bla'), 'updated')
+        const inputChanges = new Map<number, Change>([
+          [0, toChange({ before: testType.fields.ref, after: testTypeAfter.fields.ref })],
+          [1, toChange({ before: testInstance, after: testInstanceAfter })],
+        ])
+        dependencyChanges = [...await addReferencesDependency(inputChanges, new Map())]
+      })
+      it('should add dependency to the referenced element', () => {
+        expect(dependencyChanges).toEqual([
+          { action: 'add', dependency: { source: 1, target: 0 } },
+        ])
+      })
+    })
+    describe('when reference target is a modified element', () => {
+      beforeEach(async () => {
+        const testTypeAfter = testType.clone()
+        const testInstanceAfter = testInstance.clone()
+        testType.annotations.bla = 'value'
+        testTypeAfter.annotations.bla = 'updated'
+        testInstance.value.ref = new ReferenceExpression(testTypeId)
+        testInstanceAfter.value.ref = new ReferenceExpression(testTypeId)
+        const inputChanges = new Map<number, Change>([
+          [0, toChange({ before: testType, after: testTypeAfter })],
+          [1, toChange({ before: testInstance, after: testInstanceAfter })],
+        ])
+        dependencyChanges = [...await addReferencesDependency(inputChanges, new Map())]
+      })
+      it('should add dependency to the referenced element', () => {
+        expect(dependencyChanges).toHaveLength(0)
+      })
+    })
   })
 })


### PR DESCRIPTION
On deploy, when a referenced value is changed, the plan will include the element that was changed (lets call it A) and the element with a reference to that value (B) (because we need to deploy the referencing element with the new value).
In that case, we want to have a dependency from B to A, so that if A has a changeError we won't deploy B (also that A will be deployed before B).

---

_Additional context for reviewer_

---
_Release Notes_: 
Core:
 - Add a dependency when reference target is a modified non-element value

---
_User Notifications_: 
None