### PR TITLE
SALTo-2793 - Fix default market email template exclusion

### DIFF
--- a/packages/salesforce-adapter/cpq-sbaa-config-doc.md
+++ b/packages/salesforce-adapter/cpq-sbaa-config-doc.md
@@ -89,7 +89,7 @@ salesforce {
         },
         {
           metadataType = "EmailTemplate"
-          name = "^MarketoEmailTemplates/*"
+          name = "MarketoEmailTemplates/.*"
         },
         {
           metadataType = "ContentAsset"

--- a/packages/salesforce-adapter/src/config_creator.ts
+++ b/packages/salesforce-adapter/src/config_creator.ts
@@ -79,7 +79,7 @@ export const configWithCPQ = new InstanceElement(
           },
           {
             metadataType: 'EmailTemplate',
-            name: '^MarketoEmailTemplates/*',
+            name: 'MarketoEmailTemplates/.*',
           },
           {
             metadataType: 'ContentAsset',

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -645,7 +645,7 @@ export const configType = createMatchingObjectType<SalesforceConfig>({
               { metadataType: 'SiteDotCom' },
               {
                 metadataType: 'EmailTemplate',
-                name: '^MarketoEmailTemplates/*',
+                name: 'MarketoEmailTemplates/.*',
               },
               { metadataType: 'ContentAsset' },
               { metadataType: 'CustomObjectTranslation' },


### PR DESCRIPTION
Fix default market email template exclusion
This is an example of a marketoEmailTemplate from a customer
![Screen Shot 2023-01-30 at 13 54 27](https://user-images.githubusercontent.com/62199348/215470125-f7dd35c1-7249-4793-a869-acb0c6a422b8.png)

---

_Additional context for reviewer_
The current implementation doesn't work, please

---
_Release Notes_: 
Fix default market email template exclusion.

---
_User Notifications_: 
None
