### PR TITLE
Adapter: README: Correct casing of "NetSuite"

### DIFF
--- a/packages/netsuite-adapter/README.md
+++ b/packages/netsuite-adapter/README.md
@@ -1,6 +1,6 @@
-# Netsuite adapter
+# NetSuite adapter
 
-Netsuite adapter for salto.io
+NetSuite adapter for salto.io
 
 ### Prerequisites
 ###### taken from https://github.com/oracle/netsuite-suitecloud-sdk/tree/master/packages/node-cli
@@ -21,7 +21,7 @@ yarn
 yarn build
 ```
 
-## Configure your Netsuite account to work with Salto
+## Configure your NetSuite account to work with Salto
 * Enable SDF in Your NetSuite Account (Admin Only) - follow the instructions under https://<ACCOUNT_ID>.app.netsuite.com/app/help/helpcenter.nl?fid=section_4724921034.html
 * Setup Your Role (prefer Administrator) for SDF Development - follow the instructions under https://<ACCOUNT_ID>.app.netsuite.com/app/help/helpcenter.nl?fid=subsect_1539287603.html
 


### PR DESCRIPTION
Changed "Netsuite" to "NetSuite" in the NetSuite Adapter README

---

This is the correct branding for Oracle NetSuite

---
_Release Notes_: 
No effect on usability

---
_User Notifications_: 
No effect on usability
