### PR TITLE
Salto-2501 add the ability to delete SDF objects

### DIFF
--- a/packages/netsuite-adapter/src/change_validators/remove_sdf_elements.ts
+++ b/packages/netsuite-adapter/src/change_validators/remove_sdf_elements.ts
@@ -1,0 +1,93 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Change, isRemovalChange, getChangeData, Element, isInstanceElement, isObjectType, isField, ChangeError } from '@salto-io/adapter-api'
+import { values, collections } from '@salto-io/lowerdash'
+import { isCustomRecordType, isStandardType, hasInternalId } from '../types'
+import { LazyElementsSourceIndexes } from '../elements_source_index/types'
+import { NetsuiteChangeValidator } from './types'
+
+const { isDefined } = values
+const { awu } = collections.asynciterable
+
+const validateRemovableChange = async (
+  element: Element,
+  changes: ReadonlyArray<Change>,
+  elementsSourceIndex?: LazyElementsSourceIndexes
+): Promise<ChangeError | undefined> => {
+  if (isInstanceElement(element) && isStandardType(element.refType)) {
+    if (!hasInternalId(element)) {
+      return {
+        elemID: element.elemID,
+        severity: 'Error',
+        message: `Can't remove instances of type ${element.elemID.typeName}`,
+        detailedMessage: `Can't remove instance ${element.elemID.name} of type ${element.elemID.typeName}. NetSuite supports the removal of these instances only from their UI`,
+      }
+    }
+  } else if (isObjectType(element) && isCustomRecordType(element)) {
+    if (!hasInternalId(element)) {
+      return {
+        elemID: element.elemID,
+        severity: 'Error',
+        message: 'Removal of Custom Record Type failed. ID is missing',
+        detailedMessage: `Can't remove this Custom Record Type ${element.elemID.name}. The ID is missing, please try to refetch`,
+      }
+    }
+    // will be redundant once SALTO-3534 introduced
+    if (elementsSourceIndex !== undefined) {
+      const recordTypeIndexInstances = Object.keys((await elementsSourceIndex.getIndexes()).internalIdsIndex)
+        .some(elemInternalId => elemInternalId.startsWith(element.elemID.typeName.concat('-')))
+      if (recordTypeIndexInstances) {
+        return {
+          elemID: element.elemID,
+          severity: 'Error',
+          message: 'Can\'t remove Custom Record Type with existing instances',
+          detailedMessage: `Can't remove Custom Record Type ${element.elemID.name} with existing instances. Please delete those instances first`,
+        }
+      }
+    }
+    return {
+      elemID: element.elemID,
+      severity: 'Warning',
+      message: 'Removal of Custom Record Type will delete all existing instances',
+      detailedMessage: `Removal of Custom Record Type ${element.elemID.name} will delete all instances if such exist`,
+    }
+  } else if (isField(element) && isCustomRecordType(element.parent)) {
+    if (!changes
+      .filter(isRemovalChange)
+      .map(getChangeData)
+      .filter(isObjectType)
+      .some(elem => elem.elemID.isEqual(element.parent.elemID))) {
+      return {
+        elemID: element.elemID,
+        severity: 'Error',
+        message: 'Can\'t remove fields of Custom Record Types',
+        detailedMessage: `Can't remove field ${element.elemID.name} of Custom Record Type ${element.elemID.typeName}. NetSuite supports the removal of fields of Custom Record Types only from their UI`,
+      }
+    }
+  }
+  return undefined
+}
+
+const changeValidator: NetsuiteChangeValidator = async (changes, _deployReferencedElements, elementsSourceIndex) => (
+  awu(changes)
+    .filter(isRemovalChange)
+    .map(getChangeData)
+    .map(element => validateRemovableChange(element, changes, elementsSourceIndex))
+    .filter(isDefined)
+    .toArray()
+)
+
+export default changeValidator

--- a/packages/netsuite-adapter/src/change_validators/remove_standard_types.ts
+++ b/packages/netsuite-adapter/src/change_validators/remove_standard_types.ts
@@ -27,7 +27,7 @@ const changeValidator: NetsuiteChangeValidator = async changes => (
     .map(({ elemID }) => ({
       elemID,
       severity: 'Error',
-      message: `Removal of ${isStandardTypeName(elemID.typeName) ? 'standard' : 'custom record'} type ${elemID.idType}s is not supported via Salto`,
+      message: `Removal of ${isStandardTypeName(elemID.typeName) ? 'standard' : 'custom record'} type ${elemID.idType}s is only supported when Salto SuiteApp is configured`,
       detailedMessage: `${elemID.name} cannot be removed`,
     }))
 )

--- a/packages/netsuite-adapter/src/change_validators/types.ts
+++ b/packages/netsuite-adapter/src/change_validators/types.ts
@@ -14,9 +14,10 @@
 * limitations under the License.
 */
 import { Change, ChangeError } from '@salto-io/adapter-api'
-
+import { LazyElementsSourceIndexes } from '../elements_source_index/types'
 
 export type NetsuiteChangeValidator = (
     changes: ReadonlyArray<Change>,
-    deployReferencedElements?: boolean
+    deployReferencedElements?: boolean,
+    elementsSourceIndex?: LazyElementsSourceIndexes,
   ) => Promise<ReadonlyArray<ChangeError>>

--- a/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
@@ -31,7 +31,7 @@ import { CustomRecordTypeRecords, DeployListResults, GetAllResponse, GetResult, 
 import { DEPLOY_LIST_SCHEMA, GET_ALL_RESPONSE_SCHEMA, GET_RESULTS_SCHEMA, SEARCH_RESPONSE_SCHEMA, SEARCH_SUCCESS_SCHEMA } from './schemas'
 import { InvalidSuiteAppCredentialsError } from '../../types'
 import { isCustomRecordType } from '../../../types'
-import { INTERNAL_ID_TO_TYPES, ITEM_TYPE_ID, ITEM_TYPE_TO_SEARCH_STRING } from '../../../data_elements/types'
+import { INTERNAL_ID_TO_TYPES, ITEM_TYPE_ID, ITEM_TYPE_TO_SEARCH_STRING, TYPES_TO_INTERNAL_ID } from '../../../data_elements/types'
 import { XSI_TYPE } from '../../constants'
 
 const { awu } = collections.asynciterable
@@ -555,7 +555,22 @@ export default class SoapClient {
         })
       }).toArray(),
     }
+    return this.runDeployAction(instances, body, 'deleteList')
+  }
 
+  public async deleteSdfInstances(instances: InstanceElement[]):
+  Promise<(number | Error)[]> {
+    const body = {
+      baseRef: await awu(instances).map(async instance => {
+        const instanceTypeFromMap = Object.keys(TYPES_TO_INTERNAL_ID)
+          .find(key => key.toLowerCase() === instance.elemID.typeName.toLowerCase())
+        return SoapClient.convertToDeletionRecord({
+          id: instance.value.internalId,
+          type: instanceTypeFromMap ?? instance.elemID.typeName,
+          isCustomRecord: false,
+        })
+      }).toArray(),
+    }
     return this.runDeployAction(instances, body, 'deleteList')
   }
 

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
@@ -569,4 +569,8 @@ export default class SuiteAppClient {
   public async deleteInstances(instances: InstanceElement[]): Promise<(number | Error)[]> {
     return this.soapClient.deleteInstances(instances)
   }
+
+  public async deleteSdfInstances(instances: InstanceElement[]): Promise<(number | Error)[]> {
+    return this.soapClient.deleteSdfInstances(instances)
+  }
 }

--- a/packages/netsuite-adapter/src/client/types.ts
+++ b/packages/netsuite-adapter/src/client/types.ts
@@ -13,7 +13,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Values } from '@salto-io/adapter-api'
+import { ChangeDataType, InstanceElement, isInstanceElement, isObjectType, Values } from '@salto-io/adapter-api'
+import { toCustomRecordTypeInstance } from '../custom_records/custom_record_type'
+import { isCustomRecordType } from '../types'
 import { NetsuiteFilePathsQueryParams, NetsuiteTypesQueryParams } from '../query'
 
 export interface CustomizationInfo {
@@ -97,4 +99,14 @@ export class InvalidSuiteAppCredentialsError extends Error {
   constructor(message?: string) {
     super(message || 'Invalid SuiteApp credentials')
   }
+}
+
+export const getOrTransformCustomRecordTypeToInstance = (element: ChangeDataType): InstanceElement | undefined => {
+  if (isInstanceElement(element)) {
+    return element
+  }
+  if (isObjectType(element) && isCustomRecordType(element)) {
+    return toCustomRecordTypeInstance(element)
+  }
+  return undefined
 }

--- a/packages/netsuite-adapter/src/data_elements/types.ts
+++ b/packages/netsuite-adapter/src/data_elements/types.ts
@@ -209,6 +209,7 @@ const MANUALLY_MAPPED_TYPES_TO_INTERNAL_IDS: Record<string, string> = {
   restlet: SCRIPT_TYPE,
   massupdatescript: SCRIPT_TYPE,
   mapreducescript: SCRIPT_TYPE,
+  customSegment: FIELD_TYPE,
   customsegment: FIELD_TYPE,
   usereventscript: SCRIPT_TYPE,
   sdfinstallationscript: SCRIPT_TYPE,

--- a/packages/netsuite-adapter/src/filters/author_information/system_note.ts
+++ b/packages/netsuite-adapter/src/filters/author_information/system_note.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-import { CORE_ANNOTATIONS, InstanceElement, isInstanceElement, Element, isObjectType, ObjectType, Value } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, InstanceElement, isInstanceElement, Element, isObjectType, ObjectType } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { values as lowerDashValues, collections } from '@salto-io/lowerdash'
@@ -24,8 +24,8 @@ import NetsuiteClient from '../../client/client'
 import { FilterCreator, FilterWith } from '../../filter'
 import { getLastServerTime } from '../../server_time'
 import { EmployeeResult, EMPLOYEE_NAME_QUERY, EMPLOYEE_SCHEMA, SystemNoteResult, SYSTEM_NOTE_SCHEMA, ModificationInformation } from './constants'
-import { getElementValueOrAnnotations, isCustomRecordType } from '../../types'
-import { CUSTOM_RECORD_TYPE, INTERNAL_ID } from '../../constants'
+import { getInternalId, hasInternalId, isCustomRecordType } from '../../types'
+import { CUSTOM_RECORD_TYPE } from '../../constants'
 import { changeDateFormat, getZoneAndFormat } from './saved_searches'
 
 const { isDefined } = lowerDashValues
@@ -197,12 +197,6 @@ const fetchSystemNotes = async (
   }
   return indexSystemNotes(distinctSortedSystemNotes(systemNotes))
 }
-
-const getInternalId = (element: Element): Value =>
-  getElementValueOrAnnotations(element)[INTERNAL_ID]
-
-const hasInternalId = (element: Element): boolean =>
-  isDefined(getInternalId(element))
 
 const getInstancesWithInternalIds = (elements: Element[]): InstanceElement[] =>
   elements

--- a/packages/netsuite-adapter/src/filters/internal_ids/sdf_internal_ids.ts
+++ b/packages/netsuite-adapter/src/filters/internal_ids/sdf_internal_ids.ts
@@ -242,7 +242,7 @@ const filterCreator: FilterCreator = ({ client }) => ({
     if (!client.isSuiteAppConfigured()) {
       return
     }
-    const changesData = changes.map(getChangeData)
+    const changesData = changes.filter(isAdditionOrModificationChange).map(getChangeData)
     getSupportedInstances(changesData).forEach(inst => {
       delete inst.value[INTERNAL_ID]
     })

--- a/packages/netsuite-adapter/src/group_changes.ts
+++ b/packages/netsuite-adapter/src/group_changes.ts
@@ -17,7 +17,7 @@ import wu from 'wu'
 import {
   Change, ChangeGroupIdFunction, ChangeId, getChangeData, isAdditionChange,
   isInstanceElement, isModificationChange, isObjectType, isReferenceExpression,
-  isField, isRemovalChange, Element,
+  isField, isRemovalChange, Element, isAdditionOrModificationChange,
 } from '@salto-io/adapter-api'
 import { values, collections } from '@salto-io/lowerdash'
 import { walkOnElement, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
@@ -29,7 +29,8 @@ import { isPathAllowedBySdf } from './types/file_cabinet_types'
 
 const { awu } = collections.asynciterable
 
-export const SDF_CHANGE_GROUP_ID = 'SDF'
+export const SDF_CREATE_OR_UPDATE_GROUP_ID = 'SDF - create or update'
+export const SUITEAPP_SDF_DELETE_GROUP_ID = 'SDF - Delete'
 export const SUITEAPP_CREATING_FILES_GROUP_ID = 'Salto SuiteApp - File Cabinet - Creating Files'
 export const SUITEAPP_UPDATING_FILES_GROUP_ID = 'Salto SuiteApp - File Cabinet - Updating Files'
 export const SUITEAPP_DELETING_FILES_GROUP_ID = 'Salto SuiteApp - File Cabinet - Deleting Files'
@@ -47,23 +48,24 @@ export const SUITEAPP_FILE_CABINET_GROUPS = [
 const getSdfWithSuiteAppGroupName = (change: Change): string => {
   const element = getChangeData(change)
   if (isInstanceElement(element) && element.value[APPLICATION_ID] !== undefined) {
-    return `${SDF_CHANGE_GROUP_ID} - ${element.value[APPLICATION_ID]}`
+    return `${SDF_CREATE_OR_UPDATE_GROUP_ID} - ${element.value[APPLICATION_ID]}`
   }
   if (isObjectType(element) && element.annotations[APPLICATION_ID] !== undefined) {
-    return `${SDF_CHANGE_GROUP_ID} - ${element.annotations[APPLICATION_ID]}`
+    return `${SDF_CREATE_OR_UPDATE_GROUP_ID} - ${element.annotations[APPLICATION_ID]}`
   }
   if (isField(element) && element.parent.annotations[APPLICATION_ID] !== undefined) {
-    return `${SDF_CHANGE_GROUP_ID} - ${element.parent.annotations[APPLICATION_ID]}`
+    return `${SDF_CREATE_OR_UPDATE_GROUP_ID} - ${element.parent.annotations[APPLICATION_ID]}`
   }
-  return SDF_CHANGE_GROUP_ID
+  return SDF_CREATE_OR_UPDATE_GROUP_ID
 }
 
 const getChangeGroupIdsWithoutSuiteApp: ChangeGroupIdFunction = async changes => {
   const isSdfChange = (change: Change): boolean => {
     const changeData = getChangeData(change)
-    return isStandardInstanceOrCustomRecordType(changeData)
+    return isAdditionOrModificationChange(change)
+      && (isStandardInstanceOrCustomRecordType(changeData)
       || (isFileCabinetInstance(changeData) && isPathAllowedBySdf(changeData))
-      || isSDFConfigTypeName(changeData.elemID.typeName)
+      || isSDFConfigTypeName(changeData.elemID.typeName))
   }
   return {
     changeGroupIdMap: new Map(
@@ -138,12 +140,19 @@ const isSuiteAppFileCabinetDeletion = async (change: Change): Promise<boolean> =
   && isRemovalChange(change)
 }
 
-const isSdfChange = async (change: Change): Promise<boolean> => {
+const isSdfCreateOrUpdate = async (change: Change): Promise<boolean> => {
   const changeData = getChangeData(change)
-  return isStandardInstanceOrCustomRecordType(changeData)
-    || (isFileCabinetInstance(changeData)
-      && !await suiteAppFileCabinet.isChangeDeployable(change))
+  return isAdditionOrModificationChange(change)
+    && (
+      isStandardInstanceOrCustomRecordType(changeData)
+    || (isFileCabinetInstance(changeData) && !await suiteAppFileCabinet.isChangeDeployable(change))
     || isSDFConfigTypeName(changeData.elemID.typeName)
+    )
+}
+
+const isSdfDelete = async (change: Change): Promise<boolean> => {
+  const changeData = getChangeData(change)
+  return isRemovalChange(change) && isStandardInstanceOrCustomRecordType(changeData)
 }
 
 const isSuiteAppRecordChange = async (change: Change): Promise<boolean> => {
@@ -181,7 +190,8 @@ const getChangeGroupIdsWithSuiteApp: ChangeGroupIdFunction = async changes => {
     { condition: isSuiteAppRecordModification, group: SUITEAPP_UPDATING_RECORDS_GROUP_ID },
     { condition: isSuiteAppRecordDeletion, group: SUITEAPP_DELETING_RECORDS_GROUP_ID },
     { condition: isSuiteAppConfigChange, group: SUITEAPP_UPDATING_CONFIG_GROUP_ID },
-    { condition: isSdfChange, group: SDF_CHANGE_GROUP_ID },
+    { condition: isSdfCreateOrUpdate, group: SDF_CREATE_OR_UPDATE_GROUP_ID },
+    { condition: isSdfDelete, group: SUITEAPP_SDF_DELETE_GROUP_ID },
   ]
 
   const changesWithGroups = await awu(changes.entries())
@@ -195,7 +205,7 @@ const getChangeGroupIdsWithSuiteApp: ChangeGroupIdFunction = async changes => {
     .filter(values.isDefined)
     .map(change => ({
       ...change,
-      group: change.group === SDF_CHANGE_GROUP_ID
+      group: change.group === SDF_CREATE_OR_UPDATE_GROUP_ID
         ? getSdfWithSuiteAppGroupName(change.change)
         : change.group,
     }))

--- a/packages/netsuite-adapter/src/types.ts
+++ b/packages/netsuite-adapter/src/types.ts
@@ -13,14 +13,17 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { DeployResult as AdapterApiDeployResult, Element, InstanceElement, isField, isInstanceElement, isObjectType, ObjectType, PrimitiveType, TypeElement, TypeReference, Values } from '@salto-io/adapter-api'
+import { DeployResult as AdapterApiDeployResult, Element, InstanceElement, isField, isInstanceElement, isObjectType, ObjectType, PrimitiveType, TypeElement, TypeReference, Value, Values } from '@salto-io/adapter-api'
+import { values as lowerDashValues } from '@salto-io/lowerdash'
 import { fieldTypes } from './types/field_types'
 import { enums } from './autogen/types/enums'
 import { StandardType, getStandardTypes, isStandardTypeName } from './autogen/types'
 import { TypesMap } from './types/object_types'
 import { fileCabinetTypesNames, getFileCabinetTypes } from './types/file_cabinet_types'
 import { getConfigurationTypes } from './types/configuration_types'
-import { CONFIG_FEATURES, CUSTOM_FIELD_PREFIX, CUSTOM_RECORD_TYPE, CUSTOM_RECORD_TYPE_PREFIX, METADATA_TYPE, SOAP } from './constants'
+import { CONFIG_FEATURES, CUSTOM_FIELD_PREFIX, CUSTOM_RECORD_TYPE, CUSTOM_RECORD_TYPE_PREFIX, METADATA_TYPE, SOAP, INTERNAL_ID } from './constants'
+
+const { isDefined } = lowerDashValues
 
 export const getElementValueOrAnnotations = (element: Element): Values => (
   isInstanceElement(element) ? element.value : element.annotations
@@ -170,3 +173,9 @@ export const isSDFConfigTypeName = (typeName: string): boolean =>
 
 export const isSDFConfigType = (type: ObjectType | TypeReference): boolean =>
   isSDFConfigTypeName(type.elemID.name)
+
+export const getInternalId = (element: Element): Value =>
+  getElementValueOrAnnotations(element)[INTERNAL_ID]
+
+export const hasInternalId = (element: Element): boolean =>
+  isDefined(getInternalId(element))

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -35,7 +35,7 @@ import * as changesDetector from '../src/changes_detector/changes_detector'
 import SuiteAppClient from '../src/client/suiteapp_client/suiteapp_client'
 import { SERVER_TIME_TYPE_NAME } from '../src/server_time'
 import * as suiteAppFileCabinet from '../src/suiteapp_file_cabinet'
-import { SDF_CHANGE_GROUP_ID } from '../src/group_changes'
+import { SDF_CREATE_OR_UPDATE_GROUP_ID } from '../src/group_changes'
 import { SuiteAppFileCabinetOperations } from '../src/suiteapp_file_cabinet'
 import getChangeValidator from '../src/change_validator'
 import { FetchByQueryFunc } from '../src/change_validators/safe_deploy'
@@ -588,7 +588,7 @@ describe('Adapter', () => {
 
     const adapterAdd = (after: ChangeDataType): Promise<DeployResult> => netsuiteAdapter.deploy({
       changeGroup: {
-        groupID: SDF_CHANGE_GROUP_ID,
+        groupID: SDF_CREATE_OR_UPDATE_GROUP_ID,
         changes: [{ action: 'add', data: { after } }],
       },
     })
@@ -640,7 +640,7 @@ describe('Adapter', () => {
       it('should support deploying multiple changes at once', async () => {
         const result = await netsuiteAdapter.deploy({
           changeGroup: {
-            groupID: SDF_CHANGE_GROUP_ID,
+            groupID: SDF_CREATE_OR_UPDATE_GROUP_ID,
             changes: [
               { action: 'add', data: { after: fileInstance } },
               { action: 'add', data: { after: folderInstance } },
@@ -663,7 +663,7 @@ describe('Adapter', () => {
         client.deploy = jest.fn().mockRejectedValue(clientError)
         const result = await netsuiteAdapter.deploy({
           changeGroup: {
-            groupID: SDF_CHANGE_GROUP_ID,
+            groupID: SDF_CREATE_OR_UPDATE_GROUP_ID,
             changes: [
               { action: 'add', data: { after: fileInstance } },
               { action: 'add', data: { after: folderInstance } },
@@ -688,7 +688,7 @@ describe('Adapter', () => {
         before: ChangeDataType, after: ChangeDataType
       ): Promise<DeployResult> => netsuiteAdapter.deploy({
         changeGroup: {
-          groupID: SDF_CHANGE_GROUP_ID,
+          groupID: SDF_CREATE_OR_UPDATE_GROUP_ID,
           changes: [{ action: 'modify', data: { before, after } }],
         },
       })
@@ -778,7 +778,7 @@ describe('Adapter', () => {
 
         await netsuiteAdapterWithDeployReferencedElements.deploy({
           changeGroup: {
-            groupID: SDF_CHANGE_GROUP_ID,
+            groupID: SDF_CREATE_OR_UPDATE_GROUP_ID,
             changes: [{ action: 'add', data: { after: instance } }],
           },
         })
@@ -821,7 +821,7 @@ describe('Adapter', () => {
 
         await netsuiteAdapterWithAdditionalSdfDependencies.deploy({
           changeGroup: {
-            groupID: SDF_CHANGE_GROUP_ID,
+            groupID: SDF_CREATE_OR_UPDATE_GROUP_ID,
             changes: [{ action: 'add', data: { after: instance } }],
           },
         })

--- a/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
@@ -194,7 +194,7 @@ File: ~/Objects/customrecord1.xml`
     expect(changeErrors[0]).toEqual({
       detailedMessage,
       elemID: getChangeData(changes[0]).elemID,
-      message: 'Validation Error on SDF',
+      message: 'Validation Error on SDF - create or update',
       severity: 'Error',
     })
   })

--- a/packages/netsuite-adapter/test/change_validators/remove_sdf_elements.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/remove_sdf_elements.test.ts
@@ -1,0 +1,143 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, Field, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import { entitycustomfieldType } from '../../src/autogen/types/standard_types/entitycustomfield'
+import removeSdfElementsValidator from '../../src/change_validators/remove_sdf_elements'
+import { CUSTOM_RECORD_TYPE, INTERNAL_ID, METADATA_TYPE, NETSUITE } from '../../src/constants'
+import { createEmptyElementsSourceIndexes } from '../utils'
+
+
+describe('remove sdf object change validator', () => {
+  const customRecordType = new ObjectType({
+    elemID: new ElemID(NETSUITE, 'customrecord1'),
+    annotations: { [METADATA_TYPE]: CUSTOM_RECORD_TYPE, [INTERNAL_ID]: '1' },
+  })
+  const customRecordTypeInstance = new InstanceElement('test', customRecordType)
+  const elementsSourceIndex = {
+    getIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+  }
+
+  describe('remove instance of standard type', () => {
+    it('should have change error when removing an instance of standard type with no internal id', async () => {
+      const standardInstanceNoInternalId = new InstanceElement('test', entitycustomfieldType().type)
+
+      const changeErrors = await removeSdfElementsValidator([
+        toChange({ before: standardInstanceNoInternalId }),
+      ], undefined, elementsSourceIndex)
+      expect(changeErrors).toHaveLength(1)
+      expect(changeErrors[0].severity).toEqual('Error')
+      expect(changeErrors[0].elemID).toEqual(standardInstanceNoInternalId.elemID)
+    })
+
+    it('should not have change error when removing an instance of standard type with internal id', async () => {
+      const standardInstance = new InstanceElement('test', entitycustomfieldType().type, { [INTERNAL_ID]: '11' })
+
+      const changeErrors = await removeSdfElementsValidator([
+        toChange({ before: standardInstance }),
+      ], undefined, elementsSourceIndex)
+      expect(changeErrors).toHaveLength(0)
+    })
+  })
+
+  describe('remove instance of custom record type', () => {
+    it('should not have change error when removing an instance with non standard type', async () => {
+      const changeErrors = await removeSdfElementsValidator([
+        toChange({ before: customRecordTypeInstance }),
+      ], undefined, elementsSourceIndex)
+      expect(changeErrors).toHaveLength(0)
+    })
+  })
+
+  describe('remove custom record type', () => {
+    it('should have change error when removing a custom record type with no internal id', async () => {
+      const customRecordTypeNoInternalID = new ObjectType({
+        elemID: new ElemID(NETSUITE, 'customrecord2'),
+        annotations: { [METADATA_TYPE]: CUSTOM_RECORD_TYPE },
+      })
+
+      const changeErrors = await removeSdfElementsValidator([
+        toChange({ before: customRecordTypeNoInternalID }),
+      ], undefined, elementsSourceIndex)
+      expect(changeErrors).toHaveLength(1)
+      expect(changeErrors[0].severity).toEqual('Error')
+      expect(changeErrors[0].elemID).toEqual(customRecordTypeNoInternalID.elemID)
+    })
+
+    it('should have change warning when removing a custom record type with internal id', async () => {
+      const instanceOfAnotherType = new InstanceElement('test', new ObjectType({
+        elemID: new ElemID(NETSUITE, 'another_customrecord1'),
+        annotations: { [METADATA_TYPE]: CUSTOM_RECORD_TYPE, [INTERNAL_ID]: '1' },
+      }))
+
+      const changeErrors = await removeSdfElementsValidator([
+        toChange({ before: customRecordType }),
+        toChange({ before: instanceOfAnotherType }),
+      ], undefined, elementsSourceIndex)
+      expect(changeErrors).toHaveLength(1)
+      expect(changeErrors[0].severity).toEqual('Warning')
+      expect(changeErrors[0].elemID).toEqual(customRecordType.elemID)
+    })
+
+    it('should have change error when removing a custom record type with internal id when instances exists in the index', async () => {
+      const elementsSourceIndexWithInstance = {
+        getIndexes: () => Promise.resolve({
+          ...createEmptyElementsSourceIndexes(),
+          internalIdsIndex: {
+            'customrecord1-1': customRecordTypeInstance.elemID,
+          },
+        }),
+      }
+
+      const changeErrors = await removeSdfElementsValidator([
+        toChange({ before: customRecordType }),
+      ], undefined, elementsSourceIndexWithInstance)
+      expect(changeErrors).toHaveLength(1)
+      expect(changeErrors[0].severity).toEqual('Error')
+      expect(changeErrors[0].elemID).toEqual(customRecordType.elemID)
+    })
+  })
+
+  describe('remove fields', () => {
+    const field = new Field(customRecordType, 'internalId', customRecordType)
+
+    it('should have change error on the field when removing a field without its custom record type', async () => {
+      const anotherCustomRecordType = new ObjectType({
+        elemID: new ElemID(NETSUITE, 'another_customrecord1'),
+        annotations: { [METADATA_TYPE]: CUSTOM_RECORD_TYPE, [INTERNAL_ID]: '1' },
+      })
+
+      const changeErrors = await removeSdfElementsValidator([
+        toChange({ before: field }),
+        toChange({ before: anotherCustomRecordType }),
+      ], undefined, elementsSourceIndex)
+      expect(changeErrors).toHaveLength(2)
+      expect(changeErrors[0].severity).toEqual('Error')
+      expect(changeErrors[0].elemID).toEqual(field.elemID)
+      expect(changeErrors[1].severity).toEqual('Warning')
+      expect(changeErrors[1].elemID).toEqual(anotherCustomRecordType.elemID)
+    })
+
+    it('should have change warning on the custom record type when removing a field with its custom record type', async () => {
+      const changeErrors = await removeSdfElementsValidator([
+        toChange({ before: field }),
+        toChange({ before: customRecordType }),
+      ], undefined, elementsSourceIndex)
+      expect(changeErrors).toHaveLength(1)
+      expect(changeErrors[0].severity).toEqual('Warning')
+      expect(changeErrors[0].elemID).toEqual(customRecordType.elemID)
+    })
+  })
+})

--- a/packages/netsuite-adapter/test/change_validators/remove_standard_types.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/remove_standard_types.test.ts
@@ -17,7 +17,7 @@ import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter
 import { entitycustomfieldType } from '../../src/autogen/types/standard_types/entitycustomfield'
 import { fileType } from '../../src/types/file_cabinet_types'
 import removeStandardTypesValidator from '../../src/change_validators/remove_standard_types'
-import { CUSTOM_RECORD_TYPE, METADATA_TYPE, NETSUITE } from '../../src/constants'
+import { CUSTOM_RECORD_TYPE, INTERNAL_ID, METADATA_TYPE, NETSUITE } from '../../src/constants'
 
 
 describe('remove custom object change validator', () => {
@@ -33,7 +33,7 @@ describe('remove custom object change validator', () => {
     it('should have change error when removing a custom record type', async () => {
       const customRecordType = new ObjectType({
         elemID: new ElemID(NETSUITE, 'customrecord1'),
-        annotations: { [METADATA_TYPE]: CUSTOM_RECORD_TYPE },
+        annotations: { [METADATA_TYPE]: CUSTOM_RECORD_TYPE, [INTERNAL_ID]: '14' },
       })
       const changeErrors = await removeStandardTypesValidator([
         toChange({ before: customRecordType }),

--- a/packages/netsuite-adapter/test/client/client.test.ts
+++ b/packages/netsuite-adapter/test/client/client.test.ts
@@ -18,7 +18,7 @@ import SuiteAppClient from '../../src/client/suiteapp_client/suiteapp_client'
 import SdfClient from '../../src/client/sdf_client'
 import * as suiteAppFileCabinet from '../../src/suiteapp_file_cabinet'
 import NetsuiteClient from '../../src/client/client'
-import { SDF_CHANGE_GROUP_ID, SUITEAPP_CREATING_RECORDS_GROUP_ID, SUITEAPP_DELETING_RECORDS_GROUP_ID, SUITEAPP_UPDATING_CONFIG_GROUP_ID, SUITEAPP_UPDATING_RECORDS_GROUP_ID } from '../../src/group_changes'
+import { SDF_CREATE_OR_UPDATE_GROUP_ID, SUITEAPP_CREATING_RECORDS_GROUP_ID, SUITEAPP_DELETING_RECORDS_GROUP_ID, SUITEAPP_SDF_DELETE_GROUP_ID, SUITEAPP_UPDATING_CONFIG_GROUP_ID, SUITEAPP_UPDATING_RECORDS_GROUP_ID } from '../../src/group_changes'
 import { CUSTOM_RECORD_TYPE, METADATA_TYPE, NETSUITE, SCRIPT_ID } from '../../src/constants'
 import { SetConfigType } from '../../src/client/suiteapp_client/types'
 import { SUITEAPP_CONFIG_RECORD_TYPES, SUITEAPP_CONFIG_TYPES_TO_TYPE_NAMES } from '../../src/types'
@@ -26,7 +26,6 @@ import { featuresType } from '../../src/types/configuration_types'
 import { FeaturesDeployError, ManifestValidationError, ObjectsDeployError, SettingsDeployError } from '../../src/errors'
 import { LazyElementsSourceIndexes } from '../../src/elements_source_index/types'
 import { AdditionalDependencies } from '../../src/client/types'
-
 
 describe('NetsuiteClient', () => {
   describe('with SDF client', () => {
@@ -69,7 +68,7 @@ describe('NetsuiteClient', () => {
         })
         expect(await client.deploy(
           [successChange, failedChange],
-          SDF_CHANGE_GROUP_ID,
+          SDF_CREATE_OR_UPDATE_GROUP_ID,
           ...deployParams
         )).toEqual({
           errors: [objectsDeployError],
@@ -89,7 +88,7 @@ describe('NetsuiteClient', () => {
         })
         expect(await client.deploy(
           [successChange, failedChange],
-          SDF_CHANGE_GROUP_ID,
+          SDF_CREATE_OR_UPDATE_GROUP_ID,
           ...deployParams
         )).toEqual({
           errors: [objectsDeployError],
@@ -110,7 +109,7 @@ describe('NetsuiteClient', () => {
         })
         expect(await client.deploy(
           [successChange, failedChange],
-          SDF_CHANGE_GROUP_ID,
+          SDF_CREATE_OR_UPDATE_GROUP_ID,
           ...deployParams
         )).toEqual({
           errors: [settingsDeployError],
@@ -127,7 +126,7 @@ describe('NetsuiteClient', () => {
         })
         expect(await client.deploy(
           [change],
-          SDF_CHANGE_GROUP_ID,
+          SDF_CREATE_OR_UPDATE_GROUP_ID,
           ...deployParams
         )).toEqual({
           errors: [settingsDeployError],
@@ -149,7 +148,7 @@ describe('NetsuiteClient', () => {
         })
         expect(await client.deploy(
           [successChange, failedChange],
-          SDF_CHANGE_GROUP_ID,
+          SDF_CREATE_OR_UPDATE_GROUP_ID,
           ...deployParams
         )).toEqual({
           errors: [manifestValidationError],
@@ -171,7 +170,7 @@ describe('NetsuiteClient', () => {
         })
         expect(await client.deploy(
           [successChange, failedChange],
-          SDF_CHANGE_GROUP_ID,
+          SDF_CREATE_OR_UPDATE_GROUP_ID,
           ...deployParams
         )).toEqual({
           errors: [manifestValidationError],
@@ -193,7 +192,7 @@ describe('NetsuiteClient', () => {
         })
         expect(await client.deploy(
           [successChange, failedChange],
-          SDF_CHANGE_GROUP_ID,
+          SDF_CREATE_OR_UPDATE_GROUP_ID,
           ...deployParams
         )).toEqual({
           errors: [manifestValidationError],
@@ -221,7 +220,7 @@ describe('NetsuiteClient', () => {
         })
         expect(await client.deploy(
           [successChange, failedChange],
-          SDF_CHANGE_GROUP_ID,
+          SDF_CREATE_OR_UPDATE_GROUP_ID,
           ...deployParams
         )).toEqual({
           errors: [manifestValidationError],
@@ -243,7 +242,7 @@ describe('NetsuiteClient', () => {
           })
           expect(await client.deploy(
             [change],
-            SDF_CHANGE_GROUP_ID,
+            SDF_CREATE_OR_UPDATE_GROUP_ID,
             ...deployParams
           )).toEqual({
             errors: [],
@@ -280,7 +279,7 @@ describe('NetsuiteClient', () => {
           })
           expect(await client.deploy(
             [change],
-            SDF_CHANGE_GROUP_ID,
+            SDF_CREATE_OR_UPDATE_GROUP_ID,
             ...deployParams
           )).toEqual({
             errors: [],
@@ -326,7 +325,7 @@ describe('NetsuiteClient', () => {
           })
           expect(await client.deploy(
             [successChange, failedChange],
-            SDF_CHANGE_GROUP_ID,
+            SDF_CREATE_OR_UPDATE_GROUP_ID,
             ...deployParams
           )).toEqual({
             errors: [objectsDeployError],
@@ -366,7 +365,7 @@ describe('NetsuiteClient', () => {
           const change = toChange({ before, after })
           expect(await client.deploy(
             [change],
-            SDF_CHANGE_GROUP_ID,
+            SDF_CREATE_OR_UPDATE_GROUP_ID,
             ...deployParams
           )).toEqual({
             errors: [featuresDeployError],
@@ -397,7 +396,7 @@ describe('NetsuiteClient', () => {
           const change = toChange({ before, after })
           expect(await client.deploy(
             [change],
-            SDF_CHANGE_GROUP_ID,
+            SDF_CREATE_OR_UPDATE_GROUP_ID,
             ...deployParams
           )).toEqual({
             errors: [featuresDeployError],
@@ -417,7 +416,7 @@ describe('NetsuiteClient', () => {
         })
       })
       it('should call sdfValidate', async () => {
-        await client.validate([change], SDF_CHANGE_GROUP_ID, ...deployParams)
+        await client.validate([change], SDF_CREATE_OR_UPDATE_GROUP_ID, ...deployParams)
         expect(mockSdfDeploy).toHaveBeenCalledWith(
           [{
             scriptId: 'someObject',
@@ -429,7 +428,7 @@ describe('NetsuiteClient', () => {
         )
       })
       it('should skip validation', async () => {
-        await client.validate([change], SUITEAPP_UPDATING_CONFIG_GROUP_ID, ...deployParams)
+        await client.validate([change], SUITEAPP_SDF_DELETE_GROUP_ID, ...deployParams)
         expect(mockSdfDeploy).not.toHaveBeenCalled()
       })
     })
@@ -442,6 +441,7 @@ describe('NetsuiteClient', () => {
     const updateInstancesMock = jest.fn()
     const addInstancesMock = jest.fn()
     const deleteInstancesMock = jest.fn()
+    const deleteSdfInstancesMock = jest.fn()
     const getConfigRecordsMock = jest.fn()
     const setConfigRecordsValuesMock = jest.fn()
 
@@ -449,6 +449,7 @@ describe('NetsuiteClient', () => {
       updateInstances: updateInstancesMock,
       addInstances: addInstancesMock,
       deleteInstances: deleteInstancesMock,
+      deleteSdfInstances: deleteSdfInstancesMock,
       getConfigRecords: getConfigRecordsMock,
       setConfigRecordsValues: setConfigRecordsValuesMock,
     } as unknown as SuiteAppClient
@@ -526,6 +527,15 @@ describe('NetsuiteClient', () => {
           errors: [new Error(`Salto SuiteApp is not configured and therefore changes group "${SUITEAPP_UPDATING_CONFIG_GROUP_ID}" cannot be deployed`)],
           appliedChanges: [],
         })
+        expect(await clientWithoutSuiteApp.deploy(
+          [change1, change2],
+          SUITEAPP_SDF_DELETE_GROUP_ID,
+          ...deployParams
+        )).toEqual({
+          errors: [new Error(`Salto SuiteApp is not configured and therefore changes group "${SUITEAPP_SDF_DELETE_GROUP_ID}" cannot be deployed`)],
+          elemIdToInternalId: {},
+          appliedChanges: [],
+        })
       })
       it('should use updateInstances for data instances modifications', async () => {
         updateInstancesMock.mockResolvedValue([1, new Error('error')])
@@ -597,6 +607,20 @@ describe('NetsuiteClient', () => {
         )
         expect(results.appliedChanges.length).toEqual(1)
         expect(results.errors.length).toEqual(0)
+      })
+
+      it('should use deleteInstances for sdf instances deletions', async () => {
+        deleteSdfInstancesMock.mockResolvedValue([1, new Error('error')])
+        const results = await client.deploy(
+          [
+            toChange({ before: instance1 }),
+            toChange({ before: instance2 }),
+          ],
+          SUITEAPP_SDF_DELETE_GROUP_ID,
+          ...deployParams
+        )
+        expect(results.appliedChanges).toEqual([toChange({ before: instance1 })])
+        expect(results.errors).toEqual([new Error('error')])
       })
     })
   })

--- a/packages/netsuite-adapter/test/group_changes.test.ts
+++ b/packages/netsuite-adapter/test/group_changes.test.ts
@@ -14,8 +14,8 @@
 * limitations under the License.
 */
 import { ChangeGroupId, ChangeId, ElemID, InstanceElement, ObjectType, toChange, Change, StaticFile, ReferenceExpression, BuiltinTypes } from '@salto-io/adapter-api'
-import { getChangeGroupIdsFunc, SDF_CHANGE_GROUP_ID, SUITEAPP_CREATING_FILES_GROUP_ID, SUITEAPP_CREATING_RECORDS_GROUP_ID, SUITEAPP_DELETING_FILES_GROUP_ID, SUITEAPP_DELETING_RECORDS_GROUP_ID, SUITEAPP_UPDATING_CONFIG_GROUP_ID, SUITEAPP_UPDATING_FILES_GROUP_ID, SUITEAPP_UPDATING_RECORDS_GROUP_ID } from '../src/group_changes'
-import { APPLICATION_ID, CUSTOM_RECORD_TYPE, METADATA_TYPE, NETSUITE } from '../src/constants'
+import { getChangeGroupIdsFunc, SDF_CREATE_OR_UPDATE_GROUP_ID, SUITEAPP_CREATING_FILES_GROUP_ID, SUITEAPP_CREATING_RECORDS_GROUP_ID, SUITEAPP_DELETING_FILES_GROUP_ID, SUITEAPP_DELETING_RECORDS_GROUP_ID, SUITEAPP_SDF_DELETE_GROUP_ID, SUITEAPP_UPDATING_CONFIG_GROUP_ID, SUITEAPP_UPDATING_FILES_GROUP_ID, SUITEAPP_UPDATING_RECORDS_GROUP_ID } from '../src/group_changes'
+import { APPLICATION_ID, CUSTOM_RECORD_TYPE, INTERNAL_ID, METADATA_TYPE, NETSUITE } from '../src/constants'
 import { entitycustomfieldType } from '../src/autogen/types/standard_types/entitycustomfield'
 import { fileType } from '../src/types/file_cabinet_types'
 import { SUITEAPP_CONFIG_TYPE_NAMES } from '../src/types'
@@ -84,21 +84,21 @@ describe('Group Changes without Salto suiteApp', () => {
 
   it('should set correct group id for custom types instances', () => {
     expect(changeGroupIds.get(customFieldInstance.elemID.getFullName()))
-      .toEqual(SDF_CHANGE_GROUP_ID)
+      .toEqual(SDF_CREATE_OR_UPDATE_GROUP_ID)
   })
 
   it('should set correct group id for custom types elements from suiteapps', () => {
     expect(changeGroupIds.get(customFieldFromSuiteAppInstance.elemID.getFullName()))
-      .toEqual(`${SDF_CHANGE_GROUP_ID} - a.b.c`)
+      .toEqual(`${SDF_CREATE_OR_UPDATE_GROUP_ID} - a.b.c`)
     expect(changeGroupIds.get(customRecordTypeFromSuiteApp.elemID.getFullName()))
-      .toEqual(`${SDF_CHANGE_GROUP_ID} - a.b.c`)
+      .toEqual(`${SDF_CREATE_OR_UPDATE_GROUP_ID} - a.b.c`)
     expect(changeGroupIds.get(
       customRecordTypeFromSuiteApp.fields.custom_field.elemID.getFullName()
-    )).toEqual(`${SDF_CHANGE_GROUP_ID} - a.b.c`)
+    )).toEqual(`${SDF_CREATE_OR_UPDATE_GROUP_ID} - a.b.c`)
   })
 
   it('should set correct group id for file cabinet types instances', () => {
-    expect(changeGroupIds.get(fileInstance.elemID.getFullName())).toEqual(SDF_CHANGE_GROUP_ID)
+    expect(changeGroupIds.get(fileInstance.elemID.getFullName())).toEqual(SDF_CREATE_OR_UPDATE_GROUP_ID)
   })
 
   it('should not set group id for non SDF types instances', () => {
@@ -227,6 +227,13 @@ describe('Group Changes with Salto suiteApp', () => {
     subsidiaryType,
   )
 
+  const deletedCustomRecordType = new ObjectType({
+    elemID: new ElemID(NETSUITE, 'customrecord1'),
+    annotations: { [METADATA_TYPE]: CUSTOM_RECORD_TYPE, [INTERNAL_ID]: '1' },
+  })
+
+  const deletedStandardInstance = new InstanceElement('test', entitycustomfieldType().type, { [INTERNAL_ID]: '11' })
+
   const configType = new ObjectType({
     elemID: new ElemID(NETSUITE, SUITEAPP_CONFIG_TYPE_NAMES[0]),
   })
@@ -270,17 +277,19 @@ describe('Group Changes with Salto suiteApp', () => {
       })],
       [deletedDataInstance.elemID.getFullName(), toChange({ before: deletedDataInstance })],
       [configInstance.elemID.getFullName(), toChange({ after: configInstance })],
+      [deletedCustomRecordType.elemID.getFullName(), toChange({ before: deletedCustomRecordType })],
+      [deletedStandardInstance.elemID.getFullName(), toChange({ before: deletedStandardInstance })],
     ]))).changeGroupIdMap
   })
 
   it('should set correct group id for custom types instances', () => {
     expect(changeGroupIds.get(customFieldInstance.elemID.getFullName()))
-      .toEqual(SDF_CHANGE_GROUP_ID)
+      .toEqual(SDF_CREATE_OR_UPDATE_GROUP_ID)
   })
 
   it('should set correct group id for custom types instances from suiteapps', () => {
     expect(changeGroupIds.get(customFieldFromSuiteAppInstance.elemID.getFullName()))
-      .toEqual(`${SDF_CHANGE_GROUP_ID} - a.b.c`)
+      .toEqual(`${SDF_CREATE_OR_UPDATE_GROUP_ID} - a.b.c`)
   })
 
   it('should set correct group id for new suiteApp file instances', () => {
@@ -303,10 +312,10 @@ describe('Group Changes with Salto suiteApp', () => {
 
   it('should set correct group id for SDF file instances', () => {
     expect(changeGroupIds.get(sdfFileInstance1.elemID.getFullName()))
-      .toEqual(SDF_CHANGE_GROUP_ID)
+      .toEqual(SDF_CREATE_OR_UPDATE_GROUP_ID)
 
     expect(changeGroupIds.get(sdfFileInstance2.elemID.getFullName()))
-      .toEqual(SDF_CHANGE_GROUP_ID)
+      .toEqual(SDF_CREATE_OR_UPDATE_GROUP_ID)
   })
 
   it('should set correct group id for data instances', () => {
@@ -336,5 +345,15 @@ describe('Group Changes with Salto suiteApp', () => {
 
   it('should not set group id for non SDF types instances', () => {
     expect(changeGroupIds.has(nonSdfInstance.elemID.getFullName())).toBe(false)
+  })
+
+  it('should set correct group id for custom record type', () => {
+    expect(changeGroupIds.get(deletedCustomRecordType.elemID.getFullName()))
+      .toEqual(SUITEAPP_SDF_DELETE_GROUP_ID)
+  })
+
+  it('should set correct group id for instance with non custom object type', () => {
+    expect(changeGroupIds.get(deletedStandardInstance.elemID.getFullName()))
+      .toEqual(SUITEAPP_SDF_DELETE_GROUP_ID)
   })
 })


### PR DESCRIPTION
Add the ability to delete objects received by SDF through SuiteApp API:
custom record types, instances of standard types

---

_None_

---
_Release Notes_: 
_Now have the ability to delete custom record types and instances of standard types_

---
_User Notifications_: 
_None_
