### PR TITLE
SALTO-3538 Fix filterInvalidChanges (in plan)

### DIFF
--- a/packages/core/src/core/plan/filter.ts
+++ b/packages/core/src/core/plan/filter.ts
@@ -51,7 +51,7 @@ const createValidType = (
   return new ObjectType({
     elemID: typeToClone.elemID,
     fields: fieldsForAfter,
-    annotationRefsOrTypes: _.mapValues(typeToClone.annotationRefTypes, type => type.clone()),
+    annotationRefsOrTypes: _.clone(typeToClone.annotationRefTypes),
     annotations: cloneDeepWithoutRefs(typeToClone.annotations),
     isSettings: typeToClone.isSettings,
   })

--- a/packages/core/src/core/plan/filter.ts
+++ b/packages/core/src/core/plan/filter.ts
@@ -17,7 +17,7 @@ import wu from 'wu'
 import _ from 'lodash'
 
 import { DataNodeMap, DiffGraph, DiffNode } from '@salto-io/dag'
-import { ChangeError, ChangeValidator, getChangeData, ElemID, ObjectType, ChangeDataType, isField, isObjectType, ReadOnlyElementsSource, SeverityLevel, DependencyError, Change, isAdditionChange, isRemovalChange, toChange, isFieldChange, Field, isObjectTypeChange } from '@salto-io/adapter-api'
+import { ChangeError, ChangeValidator, getChangeData, ElemID, ObjectType, ChangeDataType, isField, isObjectType, ReadOnlyElementsSource, SeverityLevel, DependencyError, Change, isAdditionChange, isRemovalChange, toChange, isFieldChange, Field, isObjectTypeChange, cloneDeepWithoutRefs } from '@salto-io/adapter-api'
 import { values, collections } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 
@@ -30,155 +30,159 @@ type FilterResult = {
   replacedGraph: boolean
 }
 
+const createValidType = (
+  typeChange: Change<ObjectType>,
+  invalidChangesElemIds: ElemID[]
+): ObjectType | undefined => {
+  const elementsToOmit = new Set(invalidChangesElemIds.map(elemId => elemId.createBaseID().parent.getFullName()))
+  const isTypeAnnotationsInvalid = elementsToOmit.has(getChangeData(typeChange).elemID.getFullName())
+  if (isRemovalChange(typeChange) || (isAdditionChange(typeChange) && isTypeAnnotationsInvalid)) {
+    return undefined
+  }
+  const beforeObj = isAdditionChange(typeChange) ? undefined : typeChange.data.before
+  const afterObj = typeChange.data.after
+
+  const beforeFieldsForAfter = _.pickBy(beforeObj?.fields, field => elementsToOmit.has(field.elemID.getFullName()))
+  const afterFieldsForAfter = _.pickBy(afterObj.fields, field => !elementsToOmit.has(field.elemID.getFullName()))
+  const fieldsForAfter = { ...beforeFieldsForAfter, ...afterFieldsForAfter }
+
+  // revert the invalid changes in type annotations if there are.
+  const typeToClone = beforeObj !== undefined && isTypeAnnotationsInvalid ? beforeObj : afterObj
+  return new ObjectType({
+    elemID: typeToClone.elemID,
+    fields: fieldsForAfter,
+    annotationRefsOrTypes: _.mapValues(typeToClone.annotationRefTypes, type => type.clone()),
+    annotations: cloneDeepWithoutRefs(typeToClone.annotations),
+    isSettings: typeToClone.isSettings,
+  })
+}
+
+const createValidAfterOfInvalidTypesMap = async (
+  beforeElements: ReadOnlyElementsSource,
+  afterElements: ReadOnlyElementsSource,
+  changeErrors: ChangeError[]
+): Promise<Map<string, ObjectType>> => {
+  const changeErrorIdsByTopLevelId = Object.entries(_.groupBy(
+    changeErrors.map(changeError => changeError.elemID),
+    elemId => elemId.createTopLevelParentID().parent.getFullName()
+  ))
+
+  const validTypes = await awu(changeErrorIdsByTopLevelId)
+    .map(async ([topLevelId, invalidChangesElemIds]) => {
+      const elemID = ElemID.fromFullName(topLevelId)
+      const beforeElem = await beforeElements.get(elemID)
+      const afterElem = await afterElements.get(elemID)
+      if (!isObjectType(beforeElem) && !isObjectType(afterElem)) {
+        return undefined
+      }
+      const typeChange = toChange({
+        before: isObjectType(beforeElem) ? beforeElem : undefined,
+        after: isObjectType(afterElem) ? afterElem : undefined,
+      })
+      return createValidType(typeChange, invalidChangesElemIds)
+    })
+    .filter(values.isDefined)
+    .toArray()
+
+  return new Map(validTypes.map(type => [type.elemID.getFullName(), type]))
+}
+
+const createDependencyErr = (causeID: ElemID, droppedID: ElemID): DependencyError => ({
+  causeID,
+  elemID: droppedID,
+  message: 'Element cannot be deployed due to an error in its dependency',
+  detailedMessage: `${droppedID.getFullName()} cannot be deployed due to an error in its dependency ${causeID.getFullName()}. Please resolve that error and try again.`,
+  severity: 'Error' as SeverityLevel,
+})
+
+const buildValidDiffGraph = (
+  diffGraph: DiffGraph<ChangeDataType>,
+  invalidChanges: ChangeError[],
+  validAfterOfInvalidTypesMap: Map<string, ObjectType>
+): {
+  validDiffGraph: DiffGraph<ChangeDataType>
+  dependencyErrors: DependencyError[]
+} => {
+  const getValidAfterOfInvalidElement = (element: ObjectType | Field): ObjectType | Field => {
+    if (isField(element)) {
+      const validParent = validAfterOfInvalidTypesMap.get(element.parent.elemID.getFullName())
+      // if the field parent is not in validAfterOfInvalidTypesMap, it means that the original field is valid
+      return validParent !== undefined ? validParent.fields[element.name] : element
+    }
+    const validType = validAfterOfInvalidTypesMap.get(element.elemID.getFullName())
+    // if the type is not in validAfterOfInvalidTypesMap, it means that the original type is valid
+    return validType !== undefined ? validType : element
+  }
+
+  const getValidChange = (
+    { originalId, ...change }: DiffNode<ChangeDataType>
+  ): DiffNode<ChangeDataType> => {
+    if ((!isObjectTypeChange(change) && !isFieldChange(change)) || isRemovalChange(change)) {
+      return { originalId, ...change }
+    }
+    const before = isAdditionChange(change) ? undefined : change.data.before
+    // In case of a type/field change we want to take only the valid changes in the after element
+    const after = getValidAfterOfInvalidElement(change.data.after)
+    return { originalId, ...toChange({ before, after }) }
+  }
+
+  const elemIdsToOmit = new Set(
+    invalidChanges.map(change => change.elemID.createBaseID().parent.getFullName())
+  )
+  const nodeIdsToOmit = wu(diffGraph.keys()).filter(nodeId => {
+    const change = diffGraph.getData(nodeId)
+    const changeElem = getChangeData(change)
+    return elemIdsToOmit.has(changeElem.elemID.getFullName())
+  }).toArray()
+
+  const dependenciesMap = Object.fromEntries(wu(nodeIdsToOmit)
+    .map(id => [id, diffGraph.getComponent({ roots: [id], reverse: true })]))
+
+  const nodesToOmitWithDependents = Object.values(dependenciesMap)
+    .flatMap(nodeIds => [...nodeIds])
+
+  const dependencyErrors = Object.entries(dependenciesMap)
+    .map(([causeNodeId, nodeIds]) => [
+      getChangeData(diffGraph.getData(causeNodeId)).elemID,
+      wu(nodeIds.keys()).map(id => getChangeData(diffGraph.getData(id)).elemID).toArray(),
+    ] as [ElemID, ElemID[]])
+    .map(([causeID, elemIds]) => [
+      causeID,
+      elemIds.filter(elemId => !elemId.isEqual(causeID)),
+    ] as [ElemID, ElemID[]]).flatMap(
+      ([causeID, elemIDs]) => elemIDs.map(elemID => createDependencyErr(causeID, elemID))
+    )
+
+  const allNodeIdsToOmit = new Set(nodesToOmitWithDependents)
+  const nodesToInclude = new Set(wu(diffGraph.keys()).filter(
+    id => !allNodeIdsToOmit.has(id)
+  ))
+
+  log.warn(
+    'removing the following changes from plan: %o',
+    wu(allNodeIdsToOmit.keys()).map(nodeId => diffGraph.getData(nodeId).originalId).toArray()
+  )
+
+  const validDiffGraph = new DataNodeMap<DiffNode<ChangeDataType>>()
+  wu(nodesToInclude.keys()).forEach(nodeId => {
+    const change = diffGraph.getData(nodeId)
+    const validChange = getValidChange(change)
+    validDiffGraph.addNode(
+      nodeId,
+      wu(diffGraph.get(nodeId)).filter(id => nodesToInclude.has(id)),
+      validChange
+    )
+  })
+
+  return { validDiffGraph, dependencyErrors }
+}
+
 export const filterInvalidChanges = (
   beforeElements: ReadOnlyElementsSource,
   afterElements: ReadOnlyElementsSource,
   diffGraph: DiffGraph<ChangeDataType>,
   changeValidators: Record<string, ChangeValidator>,
 ): Promise<FilterResult> => log.time(async () => {
-  const createValidType = (
-    typeChange: Change<ObjectType>,
-    invalidChangesElemIds: ElemID[]
-  ): ObjectType | undefined => {
-    const elementsToOmit = new Set(invalidChangesElemIds.map(elemId => elemId.createBaseID().parent.getFullName()))
-    const onlyInvalidFields = !elementsToOmit.has(getChangeData(typeChange).elemID.getFullName())
-    if (isRemovalChange(typeChange) || (isAdditionChange(typeChange) && !onlyInvalidFields)) {
-      return undefined
-    }
-    const beforeObj = isAdditionChange(typeChange) ? undefined : typeChange.data.before
-    const afterObj = typeChange.data.after
-
-    const beforeFieldsForAfter = _.pickBy(beforeObj?.fields, field => elementsToOmit.has(field.elemID.getFullName()))
-    const afterFieldsForAfter = _.pickBy(afterObj.fields, field => !elementsToOmit.has(field.elemID.getFullName()))
-    const fieldsForAfter = _.mapValues(
-      { ...beforeFieldsForAfter, ...afterFieldsForAfter },
-      field => ({ refType: field.refType, annotations: field.annotations })
-    )
-    // revert the invalid changes in type annotations if there are.
-    const typeToClone = beforeObj === undefined || onlyInvalidFields ? afterObj : beforeObj
-    return new ObjectType({
-      elemID: typeToClone.elemID,
-      fields: fieldsForAfter,
-      annotationRefsOrTypes: _.clone(typeToClone.annotationRefTypes),
-      annotations: _.cloneDeep(typeToClone.annotations),
-      isSettings: typeToClone.isSettings,
-    })
-  }
-
-  const createValidAfterOfInvalidTypesMap = async (
-    invalidChanges: ChangeError[]
-  ): Promise<Map<string, ObjectType>> =>
-    new Map(await awu(Object.entries(_.groupBy(
-      invalidChanges.map(changeError => changeError.elemID),
-      elemId => elemId.createTopLevelParentID().parent.getFullName()
-    )))
-      .map(async ([topLevelId, invalidChangesElemIds]): Promise<[string, ObjectType] | undefined> => {
-        const elemID = ElemID.fromFullName(topLevelId)
-        const beforeElem = await beforeElements.get(elemID)
-        const afterElem = await afterElements.get(elemID)
-        if (!isObjectType(beforeElem) && !isObjectType(afterElem)) {
-          return undefined
-        }
-        const typeChange = toChange({
-          before: isObjectType(beforeElem) ? beforeElem : undefined,
-          after: isObjectType(afterElem) ? afterElem : undefined,
-        })
-        const validType = createValidType(typeChange, invalidChangesElemIds)
-        if (validType === undefined) {
-          return undefined
-        }
-        return [topLevelId, validType]
-      })
-      .filter(values.isDefined).toArray())
-
-  const buildValidDiffGraph = (
-    invalidChanges: ChangeError[],
-    validAfterOfInvalidTypesMap: Map<string, ObjectType>
-  ): {
-    validDiffGraph: DiffGraph<ChangeDataType>
-    dependencyErrors: DependencyError[]
-  } => {
-    const getValidAfterOfInvalidElement = (element: ObjectType | Field): ObjectType | Field => {
-      if (isField(element)) {
-        const validParent = validAfterOfInvalidTypesMap.get(element.parent.elemID.getFullName())
-        // if the field parent is not in validAfterOfInvalidTypesMap, it means that the original field is valid
-        return validParent !== undefined ? validParent.fields[element.name] : element
-      }
-      const validType = validAfterOfInvalidTypesMap.get(element.elemID.getFullName())
-      // if the type is not in validAfterOfInvalidTypesMap, it means that the original type is valid
-      return validType !== undefined ? validType : element
-    }
-    const replaceAfterIfInvalid = (
-      { originalId, ...change }: DiffNode<ChangeDataType>
-    ): DiffNode<ChangeDataType> => {
-      if (!isObjectTypeChange(change) && !isFieldChange(change)) {
-        return { originalId, ...change }
-      }
-      const before = isAdditionChange(change) ? undefined : change.data.before
-      // In case of a type/field change we want to take only the valid changes in the after element
-      const after = isRemovalChange(change) ? undefined : getValidAfterOfInvalidElement(change.data.after)
-      return { originalId, ...toChange({ before, after }) }
-    }
-
-    const createDependencyErr = (causeID: ElemID, droppedID: ElemID): DependencyError => ({
-      causeID,
-      elemID: droppedID,
-      message: 'Element cannot be deployed due to an error in its dependency',
-      detailedMessage: `${droppedID.getFullName()} cannot be deployed due to an error in its dependency ${causeID.getFullName()}. Please resolve that error and try again.`,
-      severity: 'Error' as SeverityLevel,
-    })
-
-    const elemIdsToOmit = new Set(
-      invalidChanges.map(change => change.elemID.createBaseID().parent.getFullName())
-    )
-    const nodeIdsToOmit = wu(diffGraph.keys()).filter(nodeId => {
-      const change = diffGraph.getData(nodeId)
-      const changeElem = getChangeData(change)
-      return elemIdsToOmit.has(changeElem.elemID.getFullName())
-    }).toArray()
-
-    const dependenciesMap = Object.fromEntries(wu(nodeIdsToOmit)
-      .map(id => [id, diffGraph.getComponent({ roots: [id], reverse: true })]))
-
-    const nodesToOmitWithDependents = Object.values(dependenciesMap)
-      .flatMap(nodeIds => [...nodeIds])
-
-    const dependencyErrors = Object.entries(dependenciesMap)
-      .map(([causeNodeId, nodeIds]) => [
-        getChangeData(diffGraph.getData(causeNodeId)).elemID,
-        wu(nodeIds.keys()).map(id => getChangeData(diffGraph.getData(id)).elemID).toArray(),
-      ] as [ElemID, ElemID[]])
-      .map(([causeID, elemIds]) => [
-        causeID,
-        elemIds.filter(elemId => !elemId.isEqual(causeID)),
-      ] as [ElemID, ElemID[]]).flatMap(
-        ([causeID, elemIDs]) => elemIDs.map(elemID => createDependencyErr(causeID, elemID))
-      )
-
-    const allNodeIdsToOmit = new Set(nodesToOmitWithDependents)
-    const nodesToInclude = new Set(wu(diffGraph.keys()).filter(
-      id => !allNodeIdsToOmit.has(id)
-    ))
-
-    log.warn(
-      'removing the following changes from plan: %o',
-      wu(allNodeIdsToOmit.keys()).map(nodeId => diffGraph.getData(nodeId).originalId).toArray()
-    )
-
-    const validDiffGraph = new DataNodeMap<DiffNode<ChangeDataType>>()
-    wu(nodesToInclude.keys()).forEach(nodeId => {
-      const change = diffGraph.getData(nodeId)
-      const validChange = replaceAfterIfInvalid(change)
-      validDiffGraph.addNode(
-        nodeId,
-        wu(diffGraph.get(nodeId)).filter(id => nodesToInclude.has(id)),
-        validChange
-      )
-    })
-
-    return { validDiffGraph, dependencyErrors }
-  }
-
   if (Object.keys(changeValidators).length === 0) {
     // Shortcut to avoid grouping all changes if there are no validators to run
     return { changeErrors: [], validDiffGraph: diffGraph, replacedGraph: false }
@@ -199,11 +203,18 @@ export const filterInvalidChanges = (
     // Shortcut to avoid replacing the graph if there are no errors
     return { changeErrors, validDiffGraph: diffGraph, replacedGraph: false }
   }
-  const validAfterTypeElementsMap = await createValidAfterOfInvalidTypesMap(invalidChanges)
+
+  const validAfterTypeElementsMap = await createValidAfterOfInvalidTypesMap(
+    beforeElements,
+    afterElements,
+    invalidChanges
+  )
   const { validDiffGraph, dependencyErrors } = buildValidDiffGraph(
+    diffGraph,
     invalidChanges,
     validAfterTypeElementsMap
   )
+
   return {
     changeErrors: [...changeErrors, ...dependencyErrors],
     validDiffGraph,

--- a/packages/core/src/core/plan/plan.ts
+++ b/packages/core/src/core/plan/plan.ts
@@ -543,7 +543,7 @@ export const getPlan = async ({
       addNodeDependencies(dependencyChangers),
     )
     const filterResult = await filterInvalidChanges(
-      before, after, diffGraph, changeValidators, compareOptions
+      before, after, diffGraph, changeValidators,
     )
 
     // If the graph was replaced during filtering we need to resolve the graph again to account

--- a/packages/core/src/core/plan/plan.ts
+++ b/packages/core/src/core/plan/plan.ts
@@ -543,7 +543,7 @@ export const getPlan = async ({
       addNodeDependencies(dependencyChangers),
     )
     const filterResult = await filterInvalidChanges(
-      before, after, diffGraph, changeValidators,
+      before, after, diffGraph, changeValidators, compareOptions
     )
 
     // If the graph was replaced during filtering we need to resolve the graph again to account

--- a/packages/core/test/core/plan/filter.test.ts
+++ b/packages/core/test/core/plan/filter.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { getChangeData, ChangeValidator, ObjectType, ElemID, InstanceElement, Field, BuiltinTypes, ChangeDataType, Change, createRefToElmWithValue, isDependencyError, isType, isField } from '@salto-io/adapter-api'
+import { getChangeData, ChangeValidator, ObjectType, ElemID, InstanceElement, Field, BuiltinTypes, ChangeDataType, Change, createRefToElmWithValue, isDependencyError, isField } from '@salto-io/adapter-api'
 import wu, { WuIterable } from 'wu'
 import { mockFunction } from '@salto-io/test-utils'
 import * as mock from '../../common/elements'
@@ -24,20 +24,18 @@ import { createElementSource } from '../../common/helpers'
 describe('filterInvalidChanges', () => {
   const allElements = mock.getAllElements()
 
-  const mockChangeValidator = (wholeTypeError = true): ChangeValidator =>
-    mockFunction<ChangeValidator>().mockImplementation(
-      async changes => changes
-        .map(getChangeData)
-        .filter(elem => elem.elemID.name.includes('invalid'))
-        .map(elem => (isType(elem) && !wholeTypeError ? elem.elemID.createNestedID('attr', 'invalid') : elem.elemID))
-        .map(elemID => ({ elemID, severity: 'Error', message: 'msg', detailedMessage: '' }))
-    )
+  const mockChangeValidator = mockFunction<ChangeValidator>().mockImplementation(
+    async changes => changes
+      .map(getChangeData)
+      .filter(elem => elem.elemID.name.includes('invalid'))
+      .map(({ elemID }) => ({ elemID, severity: 'Error', message: 'msg', detailedMessage: '' }))
+  )
 
   it('should have no change errors when having no diffs', async () => {
     const planResult = await getPlan({
       before: createElementSource(allElements),
       after: createElementSource(allElements),
-      changeValidators: { salto: mockChangeValidator() },
+      changeValidators: { salto: mockChangeValidator },
     })
     expect(planResult.changeErrors).toHaveLength(0)
     expect(planResult.size).toBe(0)
@@ -54,7 +52,7 @@ describe('filterInvalidChanges', () => {
     const planResult = await getPlan({
       before: createElementSource(allElements),
       after: createElementSource([...allElements, ...newElements]),
-      changeValidators: { salto: mockChangeValidator() },
+      changeValidators: { salto: mockChangeValidator },
     })
     expect(planResult.changeErrors).toHaveLength(0)
     expect(planResult.size).toBe(2)
@@ -81,7 +79,7 @@ describe('filterInvalidChanges', () => {
     const planResult = await getPlan({
       before: createElementSource(allElements),
       after: createElementSource([...allElements, newInvalidObj, newInvalidInst]),
-      changeValidators: { salto: mockChangeValidator() },
+      changeValidators: { salto: mockChangeValidator },
     })
     expect(planResult.changeErrors.filter(err => !isDependencyError(err))).toHaveLength(3)
     expect(planResult.changeErrors.filter(err => isDependencyError(err))).toHaveLength(4)
@@ -107,7 +105,7 @@ describe('filterInvalidChanges', () => {
     const planResult = await getPlan({
       before: createElementSource(allElements),
       after: createElementSource([...allElements, newValidObj]),
-      changeValidators: { salto: mockChangeValidator() },
+      changeValidators: { salto: mockChangeValidator },
     })
     expect(planResult.changeErrors.filter(err => !isDependencyError(err))).toHaveLength(1)
     expect(planResult.changeErrors.filter(err => isDependencyError(err))).toHaveLength(0)
@@ -130,7 +128,7 @@ describe('filterInvalidChanges', () => {
     const planResult = await getPlan({
       before: createElementSource(allElements),
       after: createElementSource(afterElements),
-      changeValidators: { salto: mockChangeValidator() },
+      changeValidators: { salto: mockChangeValidator },
     })
     expect(planResult.changeErrors.filter(err => !isDependencyError(err))).toHaveLength(1)
     expect(planResult.changeErrors.filter(err => isDependencyError(err))).toHaveLength(0)
@@ -148,7 +146,7 @@ describe('filterInvalidChanges', () => {
     const planResult = await getPlan({
       before: createElementSource(allElements),
       after: createElementSource(afterElements),
-      changeValidators: { salto: mockChangeValidator() },
+      changeValidators: { salto: mockChangeValidator },
     })
     expect(planResult.changeErrors.filter(err => !isDependencyError(err))).toHaveLength(1)
     expect(planResult.changeErrors.filter(err => isDependencyError(err))).toHaveLength(0)
@@ -176,12 +174,12 @@ describe('filterInvalidChanges', () => {
     const planResult = await getPlan({
       before: createElementSource([...allElements, beforeInvalidObj]),
       after: createElementSource([...allElements, afterInvalidObj]),
-      changeValidators: { salto: mockChangeValidator(false) },
+      changeValidators: { salto: mockChangeValidator },
     })
     expect(planResult.changeErrors.filter(err => !isDependencyError(err))).toHaveLength(1)
     expect(planResult.changeErrors.filter(err => isDependencyError(err))).toHaveLength(0)
     expect(planResult.changeErrors[0].severity).toEqual('Error')
-    expect(afterInvalidObj.elemID.isParentOf(planResult.changeErrors[0].elemID)).toBeTruthy()
+    expect(planResult.changeErrors[0].elemID.isEqual(afterInvalidObj.elemID)).toBeTruthy()
     expect(planResult.size).toBe(1)
     const planItem = getFirstPlanItem(planResult)
     expect(planItem.items.size).toBe(1)
@@ -193,27 +191,25 @@ describe('filterInvalidChanges', () => {
     expect(isField(changeData) && changeData.parent.isEqual(afterValidObj)).toBeTruthy()
   })
 
-  it('should have onUpdate change error when modifying invalid object as a whole and dependency errors for the creation of valid field', async () => {
-    const invalidObjElemId = new ElemID('salto', 'invalid')
-    const beforeInvalidObj = new ObjectType({ elemID: invalidObjElemId })
-    const afterInvalidObj = beforeInvalidObj.clone()
-    afterInvalidObj.annotations.new = 'value'
-    afterInvalidObj.annotationRefTypes.new = createRefToElmWithValue(BuiltinTypes.STRING)
-    afterInvalidObj.fields.valid = new Field(afterInvalidObj, 'valid', BuiltinTypes.STRING)
+  it('should have onUpdate change errors when only some elements are invalid', async () => {
+    const afterElements = mock.getAllElements()
+    const saltoAddr = afterElements[1]
+    saltoAddr.annotate({ valid: true })
+    const saltoOffice = afterElements[2]
+    saltoOffice.fields.invalid = new Field(saltoOffice, 'invalid', BuiltinTypes.STRING)
+    const saltoEmployeeInstance = afterElements[4]
+    saltoEmployeeInstance.value.valid = true
     const planResult = await getPlan({
-      before: createElementSource([...allElements, beforeInvalidObj]),
-      after: createElementSource([...allElements, afterInvalidObj]),
-      changeValidators: { salto: mockChangeValidator() },
+      before: createElementSource(allElements),
+      after: createElementSource(afterElements),
+      changeValidators: { salto: mockChangeValidator },
     })
     expect(planResult.changeErrors.filter(err => !isDependencyError(err))).toHaveLength(1)
-    expect(planResult.changeErrors.filter(err => isDependencyError(err))).toHaveLength(1)
+    expect(planResult.changeErrors.filter(err => isDependencyError(err))).toHaveLength(0)
     expect(planResult.changeErrors[0].severity).toEqual('Error')
-    expect(afterInvalidObj.elemID.isEqual(planResult.changeErrors[0].elemID)).toBeTruthy()
-    const depErr = planResult.changeErrors.find(isDependencyError)
-    expect(depErr?.severity).toEqual('Error')
-    expect(depErr && afterInvalidObj.fields.valid.elemID.isEqual(depErr.elemID)).toBeTruthy()
-    expect(depErr && afterInvalidObj.elemID.isEqual(depErr.causeID)).toBeTruthy()
-    expect(planResult.size).toBe(0)
+    expect(planResult.changeErrors[0].elemID.isEqual(saltoOffice.fields.invalid.elemID))
+      .toBeTruthy()
+    expect(planResult.size).toBe(2)
   })
 
   it('should have onUpdate change errors when only some field removals are invalid', async () => {
@@ -224,7 +220,7 @@ describe('filterInvalidChanges', () => {
     const planResult = await getPlan({
       before: createElementSource(beforeElements),
       after: createElementSource(allElements),
-      changeValidators: { salto: mockChangeValidator() },
+      changeValidators: { salto: mockChangeValidator },
     })
     expect(planResult.changeErrors.filter(err => !isDependencyError(err))).toHaveLength(1)
     expect(planResult.changeErrors.filter(err => isDependencyError(err))).toHaveLength(0)
@@ -251,7 +247,7 @@ describe('filterInvalidChanges', () => {
     const planResult = await getPlan({
       before: createElementSource(beforeElements),
       after: createElementSource(afterElements),
-      changeValidators: { salto: mockChangeValidator() },
+      changeValidators: { salto: mockChangeValidator },
     })
     expect(planResult.changeErrors.filter(err => !isDependencyError(err))).toHaveLength(1)
     expect(planResult.changeErrors.filter(err => isDependencyError(err))).toHaveLength(0)
@@ -304,7 +300,7 @@ describe('filterInvalidChanges', () => {
         [...allElements, beforeInvalidObj, beforeInvalidInst]
       ),
       after: createElementSource(allElements),
-      changeValidators: { salto: mockChangeValidator() },
+      changeValidators: { salto: mockChangeValidator },
     })
     expect(planResult.changeErrors.filter(err => !isDependencyError(err))).toHaveLength(3)
     expect(planResult.changeErrors.filter(err => isDependencyError(err))).toHaveLength(3)
@@ -319,10 +315,8 @@ describe('filterInvalidChanges', () => {
   })
 
   it('should include nodes that were dropped due to a dependency to an error node', async () => {
-    const invalidObjElemId = new ElemID('salto', 'new_invalid_obj')
-    const beforeInvalidObj = new ObjectType({ elemID: invalidObjElemId })
     const newInvalidObj = new ObjectType({
-      elemID: invalidObjElemId,
+      elemID: new ElemID('salto', 'new_invalid_obj'),
       fields: {
         valid: { refType: BuiltinTypes.STRING },
       },
@@ -330,15 +324,15 @@ describe('filterInvalidChanges', () => {
     })
     const newDependentInst = new InstanceElement('valid', newInvalidObj, {})
     const planResult = await getPlan({
-      before: createElementSource([...allElements, beforeInvalidObj]),
+      before: createElementSource(allElements),
       after: createElementSource([...allElements, newInvalidObj, newDependentInst]),
-      changeValidators: { salto: mockChangeValidator(false) },
+      changeValidators: { salto: mockChangeValidator },
       dependencyChangers: [async () => wu([
         {
           action: 'add',
           dependency: {
             source: `${newDependentInst.elemID.getFullName()}/add`,
-            target: `${newInvalidObj.elemID.getFullName()}/modify`,
+            target: `${newInvalidObj.elemID.getFullName()}/add`,
           },
         },
       ])],
@@ -347,7 +341,7 @@ describe('filterInvalidChanges', () => {
     expect(planResult.changeErrors.filter(err => isDependencyError(err))).toHaveLength(1)
     const objErr = planResult.changeErrors.filter(err => !isDependencyError(err))[0]
     const depErr = planResult.changeErrors.filter(err => isDependencyError(err))[0]
-    expect(newInvalidObj.elemID.isParentOf(objErr.elemID))
+    expect(objErr.elemID.isEqual(newInvalidObj.elemID))
       .toBeTruthy()
     expect(depErr.severity === 'Error').toBeTruthy()
     expect(depErr.elemID.isEqual(newDependentInst.elemID))
@@ -360,10 +354,8 @@ describe('filterInvalidChanges', () => {
   })
 
   it('should include dependency error and actual error if a change has both', async () => {
-    const invalidObjElemId = new ElemID('salto', 'new_invalid_obj')
-    const beforeInvalidObj = new ObjectType({ elemID: invalidObjElemId })
     const newInvalidObj = new ObjectType({
-      elemID: invalidObjElemId,
+      elemID: new ElemID('salto', 'new_invalid_obj'),
       fields: {
         valid: { refType: BuiltinTypes.STRING },
       },
@@ -371,15 +363,15 @@ describe('filterInvalidChanges', () => {
     })
     const newInvalidDependentInst = new InstanceElement('invalid', newInvalidObj, {})
     const planResult = await getPlan({
-      before: createElementSource([...allElements, beforeInvalidObj]),
+      before: createElementSource(allElements),
       after: createElementSource([...allElements, newInvalidObj, newInvalidDependentInst]),
-      changeValidators: { salto: mockChangeValidator(false) },
+      changeValidators: { salto: mockChangeValidator },
       dependencyChangers: [async () => wu([
         {
           action: 'add',
           dependency: {
             source: `${newInvalidDependentInst.elemID.getFullName()}/add`,
-            target: `${newInvalidObj.elemID.getFullName()}/modify`,
+            target: `${newInvalidObj.elemID.getFullName()}/add`,
           },
         },
       ])],
@@ -388,7 +380,7 @@ describe('filterInvalidChanges', () => {
     expect(planResult.changeErrors.filter(err => isDependencyError(err))).toHaveLength(1)
     const [objErr, instErr] = planResult.changeErrors.filter(err => !isDependencyError(err))
     const depErr = planResult.changeErrors.filter(err => isDependencyError(err))[0]
-    expect(newInvalidObj.elemID.isParentOf(objErr.elemID))
+    expect(objErr.elemID.isEqual(newInvalidObj.elemID))
       .toBeTruthy()
     expect(instErr.elemID.isEqual(newInvalidDependentInst.elemID))
       .toBeTruthy()


### PR DESCRIPTION
Fix some cases in plan/filter.ts:
- If there's a change error on a type annotation and a valid field change, we should return the valid field change with the before version of the type as a parent.
- If there's a change error on a field and a valid type change, we should return the valid type change with the before version of the field that had change error.

---

_Additional context for reviewer_

---
_Release Notes_: 
Core:
- Fix filterInvalidChanges (in plan)

---
_User Notifications_: 
None