### PR TITLE
SALTO-3541 - Zendesk Adapter - Cache deploy clients by subdomain and use them globally

### DIFF
--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -375,7 +375,6 @@ export interface ZendeskAdapterParams {
 
 export default class ZendeskAdapter implements AdapterOperations {
   private client: ZendeskClient
-  private clientsBySubdomain: Record<string, ZendeskClient>
   private paginator: clientUtils.Paginator
   private userConfig: ZendeskConfig
   private getElemIdFunc?: ElemIdGetter
@@ -407,7 +406,6 @@ export default class ZendeskAdapter implements AdapterOperations {
     this.configInstance = configInstance
     this.getElemIdFunc = getElemIdFunc
     this.client = client
-    this.clientsBySubdomain = {}
     this.elementsSource = elementsSource
     this.paginator = createPaginator({
       client: this.client,
@@ -428,11 +426,12 @@ export default class ZendeskAdapter implements AdapterOperations {
       )
     }
 
+    const clientsBySubdomain: Record<string, ZendeskClient> = {}
     this.getClientBySubdomain = (subdomain: string, deployRateLimit = false): ZendeskClient => {
-      if (!this.clientsBySubdomain[subdomain]) {
-        this.clientsBySubdomain[subdomain] = this.createClientBySubdomain(subdomain, deployRateLimit)
+      if (clientsBySubdomain[subdomain] === undefined) {
+        clientsBySubdomain[subdomain] = this.createClientBySubdomain(subdomain, deployRateLimit)
       }
-      return this.clientsBySubdomain[subdomain]
+      return clientsBySubdomain[subdomain]
     }
 
 

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -1288,45 +1288,80 @@ describe('adapter', () => {
         toChange({ before: new InstanceElement('inst', groupType) }),
       ])
     })
-    it('should rate limit guide requests to 1, and not limit support requests', async () => {
+    describe('clients tests', () => {
       const { client } = createFilterCreatorParams({})
-      const brand1 = new InstanceElement('brand1', new ObjectType({ elemID: new ElemID(ZENDESK, BRAND_TYPE_NAME) }), { subdomain: 'domain1', id: 1 })
-      const brand2 = new InstanceElement('brand2', new ObjectType({ elemID: new ElemID(ZENDESK, BRAND_TYPE_NAME) }), { subdomain: 'domain2', id: 2 })
+      const brand1 = new InstanceElement('brand1', new ObjectType({ elemID: new ElemID(ZENDESK, BRAND_TYPE_NAME) }), {
+        subdomain: 'domain1',
+        id: 1,
+      })
+      const brand2 = new InstanceElement('brand2', new ObjectType({ elemID: new ElemID(ZENDESK, BRAND_TYPE_NAME) }), {
+        subdomain: 'domain2',
+        id: 2,
+      })
       const settings1 = new InstanceElement('guide_language_settings1', new ObjectType({ elemID: new ElemID(ZENDESK, GUIDE_LANGUAGE_SETTINGS_TYPE_NAME) }), { brand: 1 })
       const settings2 = new InstanceElement('guide_language_settings2', new ObjectType({ elemID: new ElemID(ZENDESK, GUIDE_LANGUAGE_SETTINGS_TYPE_NAME) }), { brand: 2 })
-      const zendeskAdapter = new ZendeskAdapter({
-        config: DEFAULT_CONFIG,
-        client,
-        credentials: { accessToken: '', subdomain: '' },
-        elementsSource: buildElementsSourceFromElements([brand1, brand2, settings1, settings2]),
-      })
-      // any is needed to be able to spy on private method
-      // eslint-disable-next-line
-      const createClientSpy = jest.spyOn(zendeskAdapter as any, 'createClientBySubdomain')
-      // eslint-disable-next-line
-      const createFiltersRunnerSpy = jest.spyOn(zendeskAdapter as any, 'createFiltersRunner')
-      await zendeskAdapter.deploy({
-        changeGroup: {
-          groupID: '1',
-          changes: [toChange({ after: settings1 }), toChange({ after: settings2 })],
-        },
-      })
-
-      const guideFilterRunnerCall = expect.objectContaining({
-        filterRunnerClient: expect.objectContaining({
-          config: {
-            rateLimit: {
-              deploy: 1,
-            },
+      it('should rate limit guide requests to 1, and not limit support requests', async () => {
+        const zendeskAdapter = new ZendeskAdapter({
+          config: DEFAULT_CONFIG,
+          client,
+          credentials: { accessToken: '', subdomain: '' },
+          elementsSource: buildElementsSourceFromElements([brand1, brand2, settings1, settings2]),
+        })
+        // any is needed to be able to spy on private method
+        // eslint-disable-next-line
+        const createClientSpy = jest.spyOn(zendeskAdapter as any, 'createClientBySubdomain')
+        // eslint-disable-next-line
+        const createFiltersRunnerSpy = jest.spyOn(zendeskAdapter as any, 'createFiltersRunner')
+        await zendeskAdapter.deploy({
+          changeGroup: {
+            groupID: '1',
+            changes: [toChange({ after: settings1 }), toChange({ after: settings2 })],
           },
-        }),
-      })
+        })
+        const guideFilterRunnerCall = expect.objectContaining({
+          filterRunnerClient: expect.objectContaining({
+            config: {
+              rateLimit: {
+                deploy: 1,
+              },
+            },
+          }),
+        })
 
-      expect(createClientSpy).toHaveBeenCalledTimes(2)
-      expect(createFiltersRunnerSpy).toHaveBeenCalledTimes(3)
-      expect(createFiltersRunnerSpy).toHaveBeenNthCalledWith(1, {}) // Regular deploy
-      expect(createFiltersRunnerSpy).toHaveBeenNthCalledWith(2, guideFilterRunnerCall) // guide deploy
-      expect(createFiltersRunnerSpy).toHaveBeenNthCalledWith(3, guideFilterRunnerCall) // guide deploy
+        expect(createClientSpy).toHaveBeenCalledTimes(2)
+        expect(createFiltersRunnerSpy).toHaveBeenCalledTimes(3)
+        expect(createFiltersRunnerSpy).toHaveBeenNthCalledWith(1, {}) // Regular deploy
+        expect(createFiltersRunnerSpy).toHaveBeenNthCalledWith(2, guideFilterRunnerCall) // guide deploy
+        expect(createFiltersRunnerSpy).toHaveBeenNthCalledWith(3, guideFilterRunnerCall) // guide deploy
+      })
+      it('should use the same client for all guide requests of the same subdomain', async () => {
+        const zendeskAdapter = new ZendeskAdapter({
+          config: DEFAULT_CONFIG,
+          client,
+          credentials: { accessToken: '', subdomain: '' },
+          elementsSource: buildElementsSourceFromElements([brand1, brand2, settings1, settings2]),
+        })
+        // any is needed to be able to spy on private method
+        // eslint-disable-next-line
+        const getClientSpy = jest.spyOn(zendeskAdapter as any, 'getClientBySubdomain')
+        // eslint-disable-next-line
+        const createClientSpy = jest.spyOn(zendeskAdapter as any, 'createClientBySubdomain')
+
+        await zendeskAdapter.deploy({
+          changeGroup: {
+            groupID: '1',
+            changes: [toChange({ after: settings1 })],
+          },
+        })
+        await zendeskAdapter.deploy({
+          changeGroup: {
+            groupID: '2',
+            changes: [toChange({ before: settings1 })],
+          },
+        })
+        expect(getClientSpy).toHaveBeenCalledTimes(2)
+        expect(createClientSpy).toHaveBeenCalledTimes(1)
+      })
     })
   })
 })


### PR DESCRIPTION
Cache the clients create in the deploy by subdomain, so that all change groups will use the same client, and the same rate limit

---

None

---
_Release Notes_: 
None

---
_User Notifications_: 
None