### PR TITLE
INCIDENT-2811 - Omit results for the runTestResults that are logged

### DIFF
--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -317,7 +317,14 @@ export const deployMetadata = async (
 
   const sfDeployRes = await client.deploy(pkgData, { checkOnly })
 
-  log.debug('deploy result: %s', safeJsonStringify(sfDeployRes, undefined, 2))
+  log.debug('deploy result: %s', safeJsonStringify({
+    ...sfDeployRes,
+    details: sfDeployRes.details?.map(detail => ({
+      ...detail,
+      // The test result can be VERY long
+      runTestResult: safeJsonStringify(detail.runTestResult, undefined, 2).slice(100),
+    })),
+  }, undefined, 2))
 
   const { errors, successfulFullNames } = processDeployResponse(
     sfDeployRes, pkg.getDeletionsPackageName(), checkOnly ?? false

--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -322,7 +322,9 @@ export const deployMetadata = async (
     details: sfDeployRes.details?.map(detail => ({
       ...detail,
       // The test result can be VERY long
-      runTestResult: safeJsonStringify(detail.runTestResult, undefined, 2).slice(100),
+      runTestResult: detail.runTestResult
+        ? safeJsonStringify(detail.runTestResult, undefined, 2).slice(100)
+        : undefined,
     })),
   }, undefined, 2))
 


### PR DESCRIPTION
Omit results for the runTestResults that are logged.

---

_Additional context for reviewer_

---
_Release Notes_: 
Stability on SF deploy with large results of test coverage.

---
_User Notifications_: 
None.