### PR TITLE
SALTO-2939: add customFields default value plugin urls - Jira DC

### DIFF
--- a/packages/jira-adapter/src/product_settings/data_center/data_center.ts
+++ b/packages/jira-adapter/src/product_settings/data_center/data_center.ts
@@ -342,6 +342,10 @@ const PLUGIN_URL_PATTERNS: UrlPattern[] = [
     httpMethods: ['delete'],
     url: '/rest/api/3/securitylevel/.+',
   },
+  {
+    httpMethods: ['get', 'put'],
+    url: '/rest/api/3/field/.+/context/defaultValue',
+  },
 ]
 
 const replaceRestVersion = (url: string): string => url.replace(


### PR DESCRIPTION
_Add customFields default value plugin urls_

---

_Additional context for reviewer_

link to the plugin [PR](https://github.com/salto-io/jira-dc-app/pull/90)

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
