### PR TITLE
SALTO-1889 - Salesforce: Improve modelling of salesforce track history and enable history attributes

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -83,6 +83,7 @@ import formulaDepsFilter from './filters/formula_deps'
 import removeUnixTimeZeroFilter from './filters/remove_unix_time_zero'
 import organizationWideDefaults from './filters/organization_wide_sharing_defaults'
 import { FetchElements, FETCH_CONFIG, SalesforceConfig } from './types'
+import historyTrackingFilter from './filters/history_tracking'
 import { getConfigFromConfigChanges } from './config_change'
 import { LocalFilterCreator, Filter, FilterResult, RemoteFilterCreator, LocalFilterCreatorDefinition, RemoteFilterCreatorDefinition } from './filter'
 import { addDefaults } from './filters/utils'
@@ -154,6 +155,8 @@ export const allFilters: Array<LocalFilterCreatorDefinition | RemoteFilterCreato
   { creator: xmlAttributesFilter },
   { creator: minifyDeployFilter },
   { creator: formulaDepsFilter },
+  // historyTrackingFilter depends on customObjectsToObjectTypeFilter and must run before customTypeSplit
+  { creator: historyTrackingFilter },
   // The following filters should remain last in order to make sure they fix all elements
   { creator: convertListsFilter },
   { creator: convertTypeFilter },

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -156,6 +156,7 @@ export const IS_ATTRIBUTE = 'isAttribute'
 export const FOLDER_CONTENT_TYPE = 'folderContentType'
 // must have the same name as INTERNAL_ID_FIELD
 export const INTERNAL_ID_ANNOTATION = INTERNAL_ID_FIELD
+export const HISTORY_TRACKED_FIELDS = 'historyTrackedFields'
 
 // Salesforce annotations
 export const LABEL = 'label'
@@ -171,8 +172,6 @@ export const SECURITY_CLASSIFICATION = 'securityClassification'
 export const COMPLIANCE_GROUP = 'complianceGroup'
 export const KEY_PREFIX = 'keyPrefix'
 export const OBJECT_HISTORY_TRACKING_ENABLED = 'enableHistory'
-export const FIELD_HISTORY_TRACKING_ENABLED = 'trackHistory'
-export const HISTORY_TRACKED_FIELDS = 'historyTrackedFields'
 
 export const FIELD_ANNOTATIONS = {
   UNIQUE: 'unique',

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -170,6 +170,9 @@ export const BUSINESS_STATUS = 'businessStatus'
 export const SECURITY_CLASSIFICATION = 'securityClassification'
 export const COMPLIANCE_GROUP = 'complianceGroup'
 export const KEY_PREFIX = 'keyPrefix'
+export const OBJECT_HISTORY_TRACKING_ENABLED = 'enableHistory'
+export const FIELD_HISTORY_TRACKING_ENABLED = 'trackHistory'
+export const HISTORY_TRACKED_FIELDS = 'historyTrackedFields'
 
 export const FIELD_ANNOTATIONS = {
   UNIQUE: 'unique',

--- a/packages/salesforce-adapter/src/filters/history_tracking.ts
+++ b/packages/salesforce-adapter/src/filters/history_tracking.ts
@@ -34,7 +34,7 @@ import { LocalFilterCreator } from '../filter'
 import { apiName, isCustomObject, isFieldOfCustomObject } from '../transformers/transformer'
 import { FIELD_ANNOTATIONS, HISTORY_TRACKED_FIELDS, OBJECT_HISTORY_TRACKING_ENABLED } from '../constants'
 
-const { awu } = collections.asynciterable
+const { awu, groupByAsync } = collections.asynciterable
 
 
 const isHistoryTrackingEnabled = (type: ObjectType): boolean => (
@@ -89,115 +89,140 @@ const createHistoryTrackingFieldChange = async (
  * Note: we assume this filter runs *after* custom objects are turned into types (custom_object_to_object_type) but
  * *before* these types are split up into different elements (custom_type_split)
  * */
-const filter: LocalFilterCreator = () => ({
-  name: 'history_tracking',
-  onFetch: async elements => {
-    elements
-      .filter(isObjectType)
-      .filter(isCustomObject)
-      .forEach(centralizeHistoryTrackingAnnotations)
-  },
-  preDeploy: async changes => {
-    const trackedFields = (type: ObjectType): string[] => (
-      // At this point the type will be resolved through getLookUpName so the annotation will have the apiName of the
-      // field instead of the reference
-      Object.values(type.annotations[HISTORY_TRACKED_FIELDS] ?? {})
-    )
+const filter: LocalFilterCreator = () => {
+  let objectTypesChangedInPreDeploy: Record<string, Change<ObjectType>[]> = {}
+  return {
+    name: 'history_tracking',
+    onFetch: async elements => {
+      elements
+        .filter(isObjectType)
+        .filter(isCustomObject)
+        .forEach(centralizeHistoryTrackingAnnotations)
+    },
+    preDeploy: async changes => {
+      const trackedFields = (type: ObjectType): string[] => (
+        // At this point the type will be resolved through getLookUpName so the annotation will have the apiName of the
+        // field instead of the reference
+        Object.values(type.annotations[HISTORY_TRACKED_FIELDS] ?? {})
+      )
 
-    const isHistoryTrackedField = async (field: Field): Promise<boolean> => (
-      (field.annotations[FIELD_ANNOTATIONS.TRACK_HISTORY] === true)
-      || trackedFields(field.parent).includes(await apiName(field))
-    )
+      const isHistoryTrackedField = async (field: Field): Promise<boolean> => (
+        (field.annotations[FIELD_ANNOTATIONS.TRACK_HISTORY] === true)
+        || trackedFields(field.parent).includes(await apiName(field))
+      )
 
-    const objectTypeChanges = await awu(changes)
-      .filter(isAdditionOrModificationChange)
-      .filter(isObjectTypeChange)
-      .filter(change => isCustomObject(getChangeData(change)))
-      .toArray()
+      const objectTypeChanges = await awu(changes)
+        .filter(isAdditionOrModificationChange)
+        .filter(isObjectTypeChange)
+        .filter(change => isCustomObject(getChangeData(change)))
+        .toArray()
 
-    // 1. For all CustomObjects, set the correct 'enableHistory' value
-    await awu(objectTypeChanges)
-      .map(getChangeData)
-      .forEach(async objType => {
-        objType.annotations[OBJECT_HISTORY_TRACKING_ENABLED] = isHistoryTrackingEnabled(objType)
-        await awu(Object.values(objType.fields))
-          .filter(isHistoryTrackedField)
-          .forEach(async field => {
-            field.annotations[FIELD_ANNOTATIONS.TRACK_HISTORY] = true
-          })
-      })
+      const actuallyChangedObjectTypes = objectTypeChanges
+        .filter(change => {
+          const before = isModificationChange(change) ? change.data.before : undefined
+          const after = getChangeData(change)
+          return before?.annotations[HISTORY_TRACKED_FIELDS] !== after.annotations[HISTORY_TRACKED_FIELDS]
+        })
+      objectTypesChangedInPreDeploy = await groupByAsync(actuallyChangedObjectTypes,
+        change => apiName(getChangeData(change)))
 
-    const changedCustomObjectFields = changes
-      .filter(isAdditionOrModificationChange)
-      .map(getChangeData)
-      .filter(isField)
-      .filter(isFieldOfCustomObject)
+      // 1. For all CustomObjects, set the correct 'enableHistory' value
+      await awu(objectTypeChanges)
+        .map(getChangeData)
+        .forEach(async objType => {
+          objType.annotations[OBJECT_HISTORY_TRACKING_ENABLED] = isHistoryTrackingEnabled(objType)
+          await awu(Object.values(objType.fields))
+            .filter(isHistoryTrackedField)
+            .forEach(async field => {
+              field.annotations[FIELD_ANNOTATIONS.TRACK_HISTORY] = true
+            })
+        })
 
-    // 2. For all changed fields, make sure they have the expected 'trackHistory' value
-    await awu(changedCustomObjectFields)
-      .forEach(async field => {
-        field.annotations[FIELD_ANNOTATIONS.TRACK_HISTORY] = await isHistoryTrackedField(field)
-      })
+      const changedCustomObjectFields = changes
+        .filter(isAdditionOrModificationChange)
+        .map(getChangeData)
+        .filter(isField)
+        .filter(isFieldOfCustomObject)
 
-    // 3. If an object's historyTrackedFields changed:
-    //  3.1 for every field that was added/removed in historyTrackedFields:
-    //    3.1.1 If there already is a change to the field, it was handled by (1)
-    //    3.1.2 Else if the field was added:
-    //      3.1.2.1 create a new change where the 'before' part is the field from the object and the 'after' part is
-    //              the same field with trackHistory=true
-    //    3.1.3 Else if the field was removed:
-    //    3.1.3.1 create a new change where the 'before' part is the field from the object with trackHistory=true and
-    //            the 'after' part is the field from the object
-    // Note: if an object was added we assume we'll get an AdditionChange for every one of its fields, so that case will
-    //       be handled in (1)
+      // 2. For all changed fields, make sure they have the expected 'trackHistory' value
+      await awu(changedCustomObjectFields)
+        .forEach(async field => {
+          field.annotations[FIELD_ANNOTATIONS.TRACK_HISTORY] = await isHistoryTrackedField(field)
+        })
 
-    const changedFieldNames = changedCustomObjectFields.map(field => field.elemID.getFullName())
+      // 3. If an object's historyTrackedFields changed:
+      //  3.1 for every field that was added/removed in historyTrackedFields:
+      //    3.1.1 If there already is a change to the field, it was handled by (1)
+      //    3.1.2 Else if the field was added:
+      //      3.1.2.1 create a new change where the 'before' part is the field from the object and the 'after' part is
+      //              the same field with trackHistory=true
+      //    3.1.3 Else if the field was removed:
+      //    3.1.3.1 create a new change where the 'before' part is the field from the object with trackHistory=true and
+      //            the 'after' part is the field from the object
+      // Note: if an object was added we assume we'll get an AdditionChange for every one of its fields, so that case
+      //       will be handled in (1)
 
-    const additionalChanges = await awu(objectTypeChanges)
-      .filter(isModificationChange)
-      .flatMap(change => awu(Object.values(getChangeData(change).fields))
-        .filter(field => !changedFieldNames.includes(field.elemID.getFullName()))
-        .map(field => createHistoryTrackingFieldChange(field, change))
-        .toArray())
-      .filter(valueUtils.isDefined)
-      .toArray()
+      const changedFieldNames = changedCustomObjectFields.map(field => field.elemID.getFullName())
 
-    // 4. Remove the 'historyTrackedFields' annotation from all objects
-    objectTypeChanges
-      .map(getChangeData)
-      .forEach(objType => {
-        delete objType.annotations[HISTORY_TRACKED_FIELDS]
-      })
-    additionalChanges.forEach(change => changes.push(change))
-  },
-  onDeploy: async changes => {
-    changes
-      .filter(isAdditionOrModificationChange)
-      .filter(isObjectTypeChange)
-      .map(getChangeData)
-      .filter(isCustomObject)
-      .forEach(centralizeHistoryTrackingAnnotations)
+      const additionalChanges = await awu(objectTypeChanges)
+        .filter(isModificationChange)
+        .flatMap(change => awu(Object.values(getChangeData(change).fields))
+          .filter(field => !changedFieldNames.includes(field.elemID.getFullName()))
+          .map(field => createHistoryTrackingFieldChange(field, change))
+          .toArray())
+        .filter(valueUtils.isDefined)
+        .toArray()
 
-    changes
-      .filter(isFieldChange)
-      .filter(change => isFieldOfCustomObject(getChangeData(change)))
-      .forEach(change => {
-        const [before, after] = getAllChangeData(change)
-        if (before !== undefined) {
-          delete before.annotations[FIELD_ANNOTATIONS.TRACK_HISTORY]
-        }
-        if (after !== undefined) {
-          delete after.annotations[FIELD_ANNOTATIONS.TRACK_HISTORY]
-        }
-      })
+      // 4. Remove the 'historyTrackedFields' annotation from all objects
+      objectTypeChanges
+        .map(getChangeData)
+        .forEach(objType => {
+          delete objType.annotations[HISTORY_TRACKED_FIELDS]
+        })
+      additionalChanges.forEach(change => changes.push(change))
+    },
+    onDeploy: async changes => {
+      const changedCustomObjects = changes
+        .filter(isAdditionOrModificationChange)
+        .filter(isObjectTypeChange)
+        .map(getChangeData)
+        .filter(isCustomObject)
 
-    _.remove(changes, change => (
-      isModificationChange(change)
-      && isFieldChange(change)
-      && isFieldOfCustomObject(getChangeData(change))
-      && change.data.before.isEqual(change.data.after)
-    ))
-  },
-})
+      const onDeployObjectTypes = await awu(changedCustomObjects)
+        .map(objType => apiName(objType))
+        .toArray()
+      const preDeployObjectTypes = Object.keys(objectTypesChangedInPreDeploy)
+
+      _.difference(preDeployObjectTypes, onDeployObjectTypes)
+        .forEach(objTypeApiName => {
+          changes.push(...objectTypesChangedInPreDeploy[objTypeApiName])
+          changedCustomObjects.push(...objectTypesChangedInPreDeploy[objTypeApiName].map(getChangeData))
+        })
+
+      changedCustomObjects
+        .forEach(centralizeHistoryTrackingAnnotations)
+
+      changes
+        .filter(isFieldChange)
+        .filter(change => isFieldOfCustomObject(getChangeData(change)))
+        .forEach(change => {
+          const [before, after] = getAllChangeData(change)
+          if (before !== undefined) {
+            delete before.annotations[FIELD_ANNOTATIONS.TRACK_HISTORY]
+          }
+          if (after !== undefined) {
+            delete after.annotations[FIELD_ANNOTATIONS.TRACK_HISTORY]
+          }
+        })
+
+      _.remove(changes, change => (
+        isModificationChange(change)
+        && isFieldChange(change)
+        && isFieldOfCustomObject(getChangeData(change))
+        && change.data.before.isEqual(change.data.after)
+      ))
+    },
+  }
+}
 
 export default filter

--- a/packages/salesforce-adapter/src/filters/history_tracking.ts
+++ b/packages/salesforce-adapter/src/filters/history_tracking.ts
@@ -32,10 +32,48 @@ import {
 } from '@salto-io/adapter-api'
 import { LocalFilterCreator } from '../filter'
 import { apiName, isCustomObject, isFieldOfCustomObject } from '../transformers/transformer'
-import { FIELD_ANNOTATIONS, HISTORY_TRACKED_FIELDS, OBJECT_HISTORY_TRACKING_ENABLED } from '../constants'
+import {
+  FIELD_ANNOTATIONS,
+  HISTORY_TRACKED_FIELDS,
+  OBJECT_HISTORY_TRACKING_ENABLED,
+  SALESFORCE_CUSTOM_SUFFIX,
+} from '../constants'
 
 const { awu, groupByAsync } = collections.asynciterable
 
+// https://help.salesforce.com/s/articleView?id=sf.tracking_field_history.htm&type=5
+const STANDARD_OBJECTS_THAT_SUPPORT_HISTORY_TRACKING = [
+  'Account',
+  'Article',
+  'Asset',
+  'Campaign',
+  'Case',
+  'Contact',
+  'Contract',
+  'ContractLineItem',
+  'Crisis',
+  'Employee',
+  'EmployeeCrisisAssessment',
+  'Entitlement',
+  'Event',
+  'Individual',
+  'InternalOrganizationUnit',
+  'Knowledge',
+  'Lead',
+  'Opportunity',
+  'Order',
+  'OrderItem',
+  'Product',
+  'PriceBookEntry',
+  'Quote',
+  'QuoteLineItem',
+  'ServiceAppointment',
+  'ServiceContract',
+  'Solution',
+  'Task',
+  'WorkOrder',
+  'WorkOrderLineItem',
+]
 
 const isHistoryTrackingEnabled = (type: ObjectType): boolean => (
   (type.annotations[OBJECT_HISTORY_TRACKING_ENABLED] === true)
@@ -122,6 +160,14 @@ const filter: LocalFilterCreator = () => {
       )
 
       const distributeTrackingInfo = async (objType: ObjectType): Promise<void> => {
+        const typeSupportsHistoryTracking = (typeName: string): boolean => (
+          typeName.endsWith(SALESFORCE_CUSTOM_SUFFIX)
+          || STANDARD_OBJECTS_THAT_SUPPORT_HISTORY_TRACKING.includes(typeName)
+        )
+
+        if (!typeSupportsHistoryTracking(objType.elemID.typeName)) {
+          return
+        }
         objType.annotations[OBJECT_HISTORY_TRACKING_ENABLED] = isHistoryTrackingEnabled(objType)
         await awu(Object.values(objType.fields))
           .filter(isHistoryTrackedField)

--- a/packages/salesforce-adapter/src/filters/history_tracking.ts
+++ b/packages/salesforce-adapter/src/filters/history_tracking.ts
@@ -160,8 +160,6 @@ const filter: LocalFilterCreator = () => {
       //    3.1.3 Else if the field was removed:
       //    3.1.3.1 create a new change where the 'before' part is the field from the object with trackHistory=true and
       //            the 'after' part is the field from the object
-      // Note: if an object was added we assume we'll get an AdditionChange for every one of its fields, so that case
-      //       will be handled in (1)
 
       const changedFieldNames = changedCustomObjectFields.map(field => field.elemID.getFullName())
 

--- a/packages/salesforce-adapter/src/filters/history_tracking.ts
+++ b/packages/salesforce-adapter/src/filters/history_tracking.ts
@@ -110,8 +110,8 @@ const filter: LocalFilterCreator = () => {
         .forEach(centralizeHistoryTrackingAnnotations)
     },
     preDeploy: async changes => {
-      const trackedFields = (type: ObjectType): string[] => (
-        Object.keys(type.annotations[HISTORY_TRACKED_FIELDS] ?? {})
+      const trackedFields = (type: ObjectType | undefined): string[] => (
+        Object.keys(type?.annotations[HISTORY_TRACKED_FIELDS] ?? {})
       )
 
       const isHistoryTrackedField = (field: Field): boolean => (
@@ -163,10 +163,7 @@ const filter: LocalFilterCreator = () => {
       // - and save the objects where the list of tracked fields changed, because if it's the *only* thing that changed
       //   we may not receive these changes in onDeploy (since we removed the HISTORY_TRACKED_FIELDS annotation).
       const actuallyModifiedObjectTypes = modifiedObjectTypes
-        .filter(change => {
-          const [before, after] = getAllChangeData(change)
-          return !_.isEqual(before?.annotations[HISTORY_TRACKED_FIELDS], after.annotations[HISTORY_TRACKED_FIELDS])
-        })
+        .filter(change => !_.isEqual(trackedFields(change.data.before), trackedFields(change.data.after)))
 
       //  - if the list of tracked fields changed, create field changes that represent the changes to the trackHistory
       //    annotations

--- a/packages/salesforce-adapter/src/filters/history_tracking.ts
+++ b/packages/salesforce-adapter/src/filters/history_tracking.ts
@@ -168,7 +168,7 @@ const filter: LocalFilterCreator = () => ({
       .forEach(objType => {
         delete objType.annotations[HISTORY_TRACKED_FIELDS]
       })
-    changes.push(...additionalChanges)
+    additionalChanges.forEach(change => changes.push(change))
   },
   onDeploy: async changes => {
     changes

--- a/packages/salesforce-adapter/src/filters/history_tracking.ts
+++ b/packages/salesforce-adapter/src/filters/history_tracking.ts
@@ -1,0 +1,127 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { Change, ElemID, Field, getChangeData, isAdditionOrModificationChange, isField, isModificationChange,
+  isObjectType, isObjectTypeChange, ObjectType, toChange } from '@salto-io/adapter-api'
+import { LocalFilterCreator } from '../filter'
+import { isCustomObject, isFieldOfCustomObject } from '../transformers/transformer'
+import { FIELD_HISTORY_TRACKING_ENABLED, HISTORY_TRACKED_FIELDS, OBJECT_HISTORY_TRACKING_ENABLED,
+  SALESFORCE } from '../constants'
+
+const trackedFields = (type: ObjectType): string[] => type.annotations[HISTORY_TRACKED_FIELDS] ?? []
+
+const centralizeHistoryTrackingAnnotations = (customObject: ObjectType): void => {
+  if (!customObject.annotations[OBJECT_HISTORY_TRACKING_ENABLED]) {
+    return
+  }
+
+  customObject.annotations[HISTORY_TRACKED_FIELDS] = Object.values(customObject.fields)
+    .filter(field => !!field.annotations.trackHistory)
+    .map(field => field.name)
+    .sort()
+
+  Object.values(customObject.fields).forEach(field => delete field.annotations.trackHistory)
+}
+
+const distributeHistoryTrackingAnnotations = (field: Field): void => {
+  if (!field.parent.annotations[OBJECT_HISTORY_TRACKING_ENABLED]) {
+    return
+  }
+
+  field.annotations[FIELD_HISTORY_TRACKING_ENABLED] = trackedFields(field.parent).includes(field.name)
+}
+
+const createFieldChanges = (objType: ObjectType,
+  addedTrackedFields: string[],
+  removedTrackedFields: string[],
+  fieldsToIgnore: ElemID[]): Change<Field>[] => {
+  const shouldProcessField = (fieldName: string): boolean => (
+    fieldsToIgnore.includes(new ElemID(SALESFORCE, objType.elemID.typeName, 'field', fieldName))
+  )
+  const historyTrackingAddedChange = (fieldName: string): Change<Field> => {
+    const before = objType.fields[fieldName].clone()
+    before.annotations[FIELD_HISTORY_TRACKING_ENABLED] = false
+    const after = objType.fields[fieldName].clone()
+    after.annotations[FIELD_HISTORY_TRACKING_ENABLED] = true
+    return toChange({ before, after })
+  }
+
+  const historyTrackingRemovedChange = (fieldName: string): Change<Field> => {
+    const before = objType.fields[fieldName].clone()
+    before.annotations[FIELD_HISTORY_TRACKING_ENABLED] = true
+    const after = objType.fields[fieldName].clone()
+    after.annotations[FIELD_HISTORY_TRACKING_ENABLED] = false
+    return toChange({ before, after })
+  }
+
+  return [
+    ...addedTrackedFields.filter(shouldProcessField).map(fieldName => historyTrackingAddedChange(fieldName)),
+    ...removedTrackedFields.filter(shouldProcessField).map(fieldName => historyTrackingRemovedChange(fieldName)),
+  ]
+}
+
+/**
+ * Note: we assume this filter runs *after* custom objects are turned into types (custom_object_to_object_type) but
+ * *before* these types are split up into different elements (custom_type_split)
+ * */
+const filter: LocalFilterCreator = () => ({
+  onFetch: async elements => {
+    elements
+      .filter(isObjectType)
+      .filter(isCustomObject)
+      .forEach(centralizeHistoryTrackingAnnotations)
+  },
+  preDeploy: async changes => {
+    const changedCustomObjectFields = changes
+      .filter(isAdditionOrModificationChange)
+      .map(getChangeData)
+      .filter(isField)
+      .filter(isFieldOfCustomObject)
+
+    // 1. If a field was changed, make sure it has the expected 'trackHistory' value
+    changedCustomObjectFields
+      .forEach(distributeHistoryTrackingAnnotations)
+    // 2. If an object's historyTrackedFields changed:
+    //  2.1 for every field that was added/removed in historyTrackedFields:
+    //    2.1.1 If there already is a change to the field, it was handled by (1)
+    //    2.1.2 Else if the field was added:
+    //      2.1.2.1 create a new change where the 'before' part is the field from the object and the 'after' part is
+    //              the same field with trackHistory=true
+    //    2.1.3 Else if the field was removed:
+    //    2.1.3.1 create a new change where the 'before' part is the field from the object with trackHistory=true and
+    //            the 'after' part is the field from the object
+    // Note: if an object was added we assume we'll get an AdditionChange for every one of its fields, so that case will
+    //       be handled in (1)
+    // Note: For now we don't handle the case where an object's enableHistory value changed but the appropriate change
+    //       was not made to its historyTrackedFields annotations. This will be handled in a change validator
+    const changedFieldNames = changedCustomObjectFields.map(field => field.elemID)
+    const additionalChanges = changes
+      .filter(isModificationChange)
+      .filter(isObjectTypeChange)
+      .map((change):{type: ObjectType; added: string[]; removed: string[]} => (
+        {
+          type: getChangeData(change),
+          added: _.difference(trackedFields(change.data.after), trackedFields(change.data.before)),
+          removed: _.difference(trackedFields(change.data.before), trackedFields(change.data.after)),
+        }
+      ))
+      .flatMap(({ type, added, removed }) => createFieldChanges(type, added, removed, changedFieldNames))
+
+    changes.push(...additionalChanges)
+  },
+})
+
+export default filter

--- a/packages/salesforce-adapter/src/filters/history_tracking.ts
+++ b/packages/salesforce-adapter/src/filters/history_tracking.ts
@@ -76,9 +76,8 @@ const fieldHistoryTrackingChanged = (
   const [typeBefore, typeAfter] = getAllChangeData(objectTypeChange)
   const trackedBefore = Object.keys(typeBefore.annotations[HISTORY_TRACKED_FIELDS] ?? {}).includes(field.name)
   const trackedAfter = Object.keys(typeAfter.annotations[HISTORY_TRACKED_FIELDS] ?? {}).includes(field.name)
-  const existedBefore = field.name in typeBefore.fields
-  const existedAfter = field.name in typeAfter.fields
-  return existedBefore && existedAfter && (trackedBefore !== trackedAfter)
+  const existsAfter = field.name in typeAfter.fields
+  return existsAfter && (trackedBefore !== trackedAfter)
 }
 
 const createHistoryTrackingFieldChange = (
@@ -180,7 +179,6 @@ const filter: LocalFilterCreator = () => {
       )
 
       additionalChanges.forEach(change => changes.push(change))
-
 
       // Finally, remove the 'historyTrackedFields' annotation from all object types (either added or changed)
       changes

--- a/packages/salesforce-adapter/src/filters/history_tracking.ts
+++ b/packages/salesforce-adapter/src/filters/history_tracking.ts
@@ -94,7 +94,7 @@ const filter: LocalFilterCreator = () => {
   return {
     name: 'history_tracking',
     onFetch: async elements => {
-      elements
+      await awu(elements)
         .filter(isObjectType)
         .filter(isCustomObject)
         .forEach(centralizeHistoryTrackingAnnotations)
@@ -121,7 +121,7 @@ const filter: LocalFilterCreator = () => {
         .filter(change => {
           const before = isModificationChange(change) ? change.data.before : undefined
           const after = getChangeData(change)
-          return before?.annotations[HISTORY_TRACKED_FIELDS] !== after.annotations[HISTORY_TRACKED_FIELDS]
+          return !_.isEqual(before?.annotations[HISTORY_TRACKED_FIELDS], after.annotations[HISTORY_TRACKED_FIELDS])
         })
       objectTypesChangedInPreDeploy = await groupByAsync(actuallyChangedObjectTypes,
         change => apiName(getChangeData(change)))
@@ -138,11 +138,12 @@ const filter: LocalFilterCreator = () => {
             })
         })
 
-      const changedCustomObjectFields = changes
+      const changedCustomObjectFields = await awu(changes)
         .filter(isAdditionOrModificationChange)
         .map(getChangeData)
         .filter(isField)
         .filter(isFieldOfCustomObject)
+        .toArray()
 
       // 2. For all changed fields, make sure they have the expected 'trackHistory' value
       await awu(changedCustomObjectFields)

--- a/packages/salesforce-adapter/src/filters/history_tracking.ts
+++ b/packages/salesforce-adapter/src/filters/history_tracking.ts
@@ -118,6 +118,7 @@ const filter: LocalFilterCreator = () => ({
           removed: _.difference(trackedFields(change.data.before), trackedFields(change.data.after)),
         }
       ))
+      .filter(({ added, removed }) => (added.length > 0 || removed.length > 0))
       .flatMap(({ type, added, removed }) => createFieldChanges(type, added, removed, changedFieldNames))
 
     changes.push(...additionalChanges)

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -1296,6 +1296,7 @@ describe('SalesforceAdapter CRUD', () => {
             unchanged: oldElement.fields.unchanged,
           },
           annotations: {
+            [constants.OBJECT_HISTORY_TRACKING_ENABLED]: false,
             label: 'test2 label',
             [constants.API_NAME]: 'Test__c',
             [constants.METADATA_TYPE]: constants.CUSTOM_OBJECT,
@@ -1524,6 +1525,7 @@ describe('SalesforceAdapter CRUD', () => {
             [constants.METADATA_TYPE]: constants.CUSTOM_OBJECT,
             label: 'test2 label',
             [constants.API_NAME]: 'Test__c',
+            [constants.OBJECT_HISTORY_TRACKING_ENABLED]: false,
           },
         })
 

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -1296,7 +1296,6 @@ describe('SalesforceAdapter CRUD', () => {
             unchanged: oldElement.fields.unchanged,
           },
           annotations: {
-            [constants.OBJECT_HISTORY_TRACKING_ENABLED]: false,
             label: 'test2 label',
             [constants.API_NAME]: 'Test__c',
             [constants.METADATA_TYPE]: constants.CUSTOM_OBJECT,
@@ -1525,7 +1524,6 @@ describe('SalesforceAdapter CRUD', () => {
             [constants.METADATA_TYPE]: constants.CUSTOM_OBJECT,
             label: 'test2 label',
             [constants.API_NAME]: 'Test__c',
-            [constants.OBJECT_HISTORY_TRACKING_ENABLED]: false,
           },
         })
 

--- a/packages/salesforce-adapter/test/filters/history_tracking.test.ts
+++ b/packages/salesforce-adapter/test/filters/history_tracking.test.ts
@@ -161,6 +161,13 @@ describe(filter.name, () => {
         expect(getChangeData(changes[0]).annotations).toHaveProperty(OBJECT_HISTORY_TRACKING_ENABLED, true)
         expect(getChangeData(changes[0]).annotations).not.toHaveProperty(HISTORY_TRACKED_FIELDS)
       })
+      it('should ignore unknown field names in the annotation', async () => {
+        const changes = [toChange({ before: typeForPreDeploy(), after: typeForPreDeploy(['Garbage']) })]
+        await filter.preDeploy(changes)
+        expect(changes).toHaveLength(1)
+        expect(getChangeData(changes[0]).annotations).toHaveProperty(OBJECT_HISTORY_TRACKING_ENABLED, true)
+        expect(getChangeData(changes[0]).annotations).not.toHaveProperty(HISTORY_TRACKED_FIELDS)
+      })
     })
 
     describe('when fields belong to an object that has history tracking disabled', () => {

--- a/packages/salesforce-adapter/test/filters/history_tracking.test.ts
+++ b/packages/salesforce-adapter/test/filters/history_tracking.test.ts
@@ -18,7 +18,7 @@ import { createCustomObjectType, defaultFilterContext } from '../utils'
 import { mockTypes } from '../mock_elements'
 import { FilterWith } from '../../src/filter'
 import { Types } from '../../src/transformers/transformer'
-import { HISTORY_TRACKED_FIELDS } from '../../src/constants'
+import { HISTORY_TRACKED_FIELDS, OBJECT_HISTORY_TRACKING_ENABLED } from '../../src/constants'
 
 describe('History tracking', () => {
   const filter = filterCreator({ config: defaultFilterContext }) as FilterWith<'onFetch'|'preDeploy'>
@@ -27,6 +27,7 @@ describe('History tracking', () => {
       const inputType = mockTypes.Account.clone()
       inputType.annotations.enableHistory = false
       const expectedOutput = inputType.clone()
+      delete expectedOutput.annotations[OBJECT_HISTORY_TRACKING_ENABLED]
       const elements = [inputType]
       await filter.onFetch(elements)
       expect(elements).toEqual([expectedOutput])
@@ -55,13 +56,15 @@ describe('History tracking', () => {
       },
     })
     it('Should update the object and field annotations correctly', async () => {
-      typeWithHistoryTrackedFields.annotations.enableHistory = true
-      await filter.onFetch([typeWithHistoryTrackedFields])
-      const trackedFieldNames = typeWithHistoryTrackedFields.annotations[HISTORY_TRACKED_FIELDS]
+      const elements = [typeWithHistoryTrackedFields.clone()]
+      elements[0].annotations.enableHistory = true
+      await filter.onFetch(elements)
+      const trackedFieldNames = elements[0].annotations[HISTORY_TRACKED_FIELDS]
       expect(trackedFieldNames).toBeDefined()
       expect(trackedFieldNames).toEqual(['fieldWithHistoryTracking'])
-      expect(typeWithHistoryTrackedFields.fields.fieldWithHistoryTracking.annotations.trackHistory).not.toBeDefined()
-      expect(typeWithHistoryTrackedFields.fields.fieldWithoutHistoryTracking.annotations.trackHistory).not.toBeDefined()
+      expect(elements[0].fields.fieldWithHistoryTracking.annotations.trackHistory).not.toBeDefined()
+      expect(elements[0].fields.fieldWithoutHistoryTracking.annotations.trackHistory).not.toBeDefined()
+      expect(elements[0].annotations[OBJECT_HISTORY_TRACKING_ENABLED]).not.toBeDefined()
     })
   })
 })

--- a/packages/salesforce-adapter/test/filters/history_tracking.test.ts
+++ b/packages/salesforce-adapter/test/filters/history_tracking.test.ts
@@ -109,7 +109,7 @@ describe('historyTracking', () => {
   describe('preDeploy', () => {
     const typeForPreDeploy = (trackedFields?: string[], fields: string[] = []): ObjectType => {
       const fieldApiName = (typeName: string, fieldName: string): string => `${typeName}.${fieldName}`
-      const typeName = 'SomeType'
+      const typeName = 'SomeType__c'
       const objectType = createCustomObjectType(typeName, {
         fields: Object.fromEntries(fields.map(fieldName => [fieldName, {
           refType: Types.primitiveDataTypes.Text,
@@ -122,6 +122,26 @@ describe('historyTracking', () => {
       }
       return objectType
     }
+
+    describe('when an object does not support history tracking', () => {
+      it('should not create any annotations', async () => {
+        const objectType = createCustomObjectType('SomeObject', {
+          fields: {
+            SomeField: {
+              refType: Types.primitiveDataTypes.Text,
+              annotations: {
+                apiName: 'SomeObject.SomeField',
+              },
+            },
+          },
+        })
+
+        const changes = [toChange({ after: objectType })]
+        await filter.preDeploy(changes)
+        expect(getChangeData(changes[0]).annotations).not.toHaveProperty(OBJECT_HISTORY_TRACKING_ENABLED)
+        expect(getChangeData(changes[0]).fields.SomeField).not.toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY)
+      })
+    })
 
     describe('when an object has no historyTrackedFields', () => {
       it('should add enableHistory=false annotation if the object type is new', async () => {

--- a/packages/salesforce-adapter/test/filters/history_tracking.test.ts
+++ b/packages/salesforce-adapter/test/filters/history_tracking.test.ts
@@ -55,7 +55,6 @@ describe('historyTracking', () => {
         const inputType = mockTypes.Account.clone()
         inputType.annotations.enableHistory = false
         const expectedOutput = inputType.clone()
-        delete expectedOutput.annotations[OBJECT_HISTORY_TRACKING_ENABLED]
         const elements = [inputType]
         await filter.onFetch(elements)
         expect(elements).toEqual([expectedOutput])
@@ -101,8 +100,7 @@ describe('historyTracking', () => {
           .not
           .toHaveProperty([FIELD_ANNOTATIONS.TRACK_HISTORY])
         expect(elements[0].annotations)
-          .not
-          .toHaveProperty(OBJECT_HISTORY_TRACKING_ENABLED)
+          .toHaveProperty(OBJECT_HISTORY_TRACKING_ENABLED, true)
       })
     })
   })
@@ -115,9 +113,14 @@ describe('historyTracking', () => {
 
       const typeName = 'SomeType__c'
       const objectType = createCustomObjectType(typeName, {
+        annotations: {
+          [OBJECT_HISTORY_TRACKING_ENABLED]: (trackedFields !== undefined),
+        },
         fields: Object.fromEntries(fields.map(fieldName => [fieldName, {
           refType: Types.primitiveDataTypes.Text,
-          annotations: { apiName: fieldApiName(typeName, fieldName) },
+          annotations: {
+            apiName: fieldApiName(typeName, fieldName),
+          },
         }])),
       })
       if (trackedFields !== undefined) {

--- a/packages/salesforce-adapter/test/filters/history_tracking.test.ts
+++ b/packages/salesforce-adapter/test/filters/history_tracking.test.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import _ from 'lodash'
 import {
   Change,
   Field,
@@ -20,7 +21,7 @@ import {
   isFieldChange,
   isModificationChange,
   ModificationChange,
-  ObjectType,
+  ObjectType, ReferenceExpression,
   toChange,
 } from '@salto-io/adapter-api'
 import filterCreator from '../../src/filters/history_tracking'
@@ -28,66 +29,81 @@ import { createCustomObjectType, createField, defaultFilterContext } from '../ut
 import { mockTypes } from '../mock_elements'
 import { FilterWith } from '../../src/filter'
 import { Types } from '../../src/transformers/transformer'
-import { FIELD_HISTORY_TRACKING_ENABLED, HISTORY_TRACKED_FIELDS, OBJECT_HISTORY_TRACKING_ENABLED } from '../../src/constants'
+import {
+  FIELD_HISTORY_TRACKING_ENABLED,
+  HISTORY_TRACKED_FIELDS,
+  OBJECT_HISTORY_TRACKING_ENABLED,
+} from '../../src/constants'
 
-describe('History tracking', () => {
+describe('History tracking filter', () => {
   const filter = filterCreator({ config: defaultFilterContext }) as FilterWith<'onFetch' | 'preDeploy'>
 
-  describe('When fetching an object with history tracking disabled', () => {
-    it('Should not modify the object', async () => {
-      const inputType = mockTypes.Account.clone()
-      inputType.annotations.enableHistory = false
-      const expectedOutput = inputType.clone()
-      delete expectedOutput.annotations[OBJECT_HISTORY_TRACKING_ENABLED]
-      const elements = [inputType]
-      await filter.onFetch(elements)
-      expect(elements).toEqual([expectedOutput])
-    })
-  })
-  describe('When fetching an object with history tracking enabled', () => {
-    const typeWithHistoryTrackedFields = createCustomObjectType('TypeWithHistoryTracking', {
-      annotations: {
-        [OBJECT_HISTORY_TRACKING_ENABLED]: true,
-      },
-      fields: {
-        fieldWithHistoryTracking: {
-          refType: Types.primitiveDataTypes.Text,
-          annotations: {
-            apiName: 'fieldWithHistoryTracking',
-            trackHistory: true,
-          },
-        },
-        fieldWithoutHistoryTracking: {
-          refType: Types.primitiveDataTypes.Text,
-          annotations: {
-            apiName: 'fieldWithoutHistoryTracking',
-            trackHistory: false,
-          },
-        },
-      },
-    })
-
-    it('Should update the object and field annotations correctly', async () => {
-      const elements = [typeWithHistoryTrackedFields.clone()]
-      await filter.onFetch(elements)
-      const trackedFieldNames = elements[0].annotations[HISTORY_TRACKED_FIELDS]
-      expect(trackedFieldNames).toBeDefined()
-      expect(trackedFieldNames).toEqual(['fieldWithHistoryTracking'])
-      expect(elements[0].fields.fieldWithHistoryTracking.annotations.trackHistory).not.toBeDefined()
-      expect(elements[0].fields.fieldWithoutHistoryTracking.annotations.trackHistory).not.toBeDefined()
-      expect(elements[0].annotations[OBJECT_HISTORY_TRACKING_ENABLED]).not.toBeDefined()
-    })
-  })
-  describe('on preDeploy', () => {
-    const typeForPreDeploy = (trackedFields?: string[], fields: string[] = []): ObjectType => (
-      createCustomObjectType('SomeType', {
-        annotations: {
-          ...((trackedFields !== undefined) ? { [HISTORY_TRACKED_FIELDS]: trackedFields } : {}),
-        },
-        fields: Object.fromEntries(fields.map(fieldName => [fieldName, { refType: Types.primitiveDataTypes.Text,
-          annotations: { apiName: fieldName } }])),
+  describe('onFetch', () => {
+    describe('When fetching an object with history tracking disabled', () => {
+      it('Should not modify the object', async () => {
+        const inputType = mockTypes.Account.clone()
+        inputType.annotations.enableHistory = false
+        const expectedOutput = inputType.clone()
+        delete expectedOutput.annotations[OBJECT_HISTORY_TRACKING_ENABLED]
+        const elements = [inputType]
+        await filter.onFetch(elements)
+        expect(elements).toEqual([expectedOutput])
       })
-    )
+    })
+    describe('When fetching an object with history tracking enabled', () => {
+      const typeWithHistoryTrackedFields = createCustomObjectType('TypeWithHistoryTracking', {
+        annotations: {
+          [OBJECT_HISTORY_TRACKING_ENABLED]: true,
+        },
+        fields: {
+          fieldWithHistoryTracking: {
+            refType: Types.primitiveDataTypes.Text,
+            annotations: {
+              apiName: 'fieldWithHistoryTracking',
+              trackHistory: true,
+            },
+          },
+          fieldWithoutHistoryTracking: {
+            refType: Types.primitiveDataTypes.Text,
+            annotations: {
+              apiName: 'fieldWithoutHistoryTracking',
+              trackHistory: false,
+            },
+          },
+        },
+      })
+      const referenceForField = (fieldName: string): ReferenceExpression => (
+        new ReferenceExpression(typeWithHistoryTrackedFields.elemID.createNestedID('field', fieldName))
+      )
+      it('Should update the object and field annotations correctly', async () => {
+        const elements = [typeWithHistoryTrackedFields.clone()]
+        await filter.onFetch(elements)
+        const trackedFieldNames = elements[0].annotations[HISTORY_TRACKED_FIELDS]
+        expect(trackedFieldNames).toBeDefined()
+        expect(trackedFieldNames).toEqual([referenceForField('fieldWithHistoryTracking')])
+        expect(elements[0].fields.fieldWithHistoryTracking.annotations.trackHistory).not.toBeDefined()
+        expect(elements[0].fields.fieldWithoutHistoryTracking.annotations.trackHistory).not.toBeDefined()
+        expect(elements[0].annotations[OBJECT_HISTORY_TRACKING_ENABLED]).not.toBeDefined()
+      })
+    })
+  })
+  describe('preDeploy', () => {
+    const typeForPreDeploy = (trackedFields?: string[], fields: string[] = []): ObjectType => {
+      const referenceToField = (objectType: ObjectType, fieldName: string): ReferenceExpression => (
+        new ReferenceExpression(objectType.elemID.createNestedID('field', fieldName))
+      )
+      const objectType = createCustomObjectType('SomeType', {
+        fields: Object.fromEntries(fields.map(fieldName => [fieldName, {
+          refType: Types.primitiveDataTypes.Text,
+          annotations: { apiName: _.upperFirst(fieldName) },
+        }])),
+      })
+      if (trackedFields !== undefined) {
+        objectType.annotations[HISTORY_TRACKED_FIELDS] = trackedFields
+          .map(fieldName => referenceToField(objectType, fieldName))
+      }
+      return objectType
+    }
 
     describe('when an object has no historyTrackedFields', () => {
       it('should add enableHistory=false annotation if the object type is new', async () => {
@@ -120,7 +136,7 @@ describe('History tracking', () => {
         expect(getChangeData(changes[0]).annotations).not.toHaveProperty(HISTORY_TRACKED_FIELDS)
       })
       it('should add the enableHistory annotation if historyTrackedFields was modified', async () => {
-        const before = typeForPreDeploy(['SomeField'], ['SomeField'])
+        const before = typeForPreDeploy(['someField'], ['someField'])
         const changes = [toChange({ before, after: typeForPreDeploy([]) })]
         await filter.preDeploy(changes)
         expect(getChangeData(changes[0]).annotations).toHaveProperty(OBJECT_HISTORY_TRACKING_ENABLED, true)
@@ -137,18 +153,18 @@ describe('History tracking', () => {
     describe('when fields belong to an object that has history tracking disabled', () => {
       const field = createField(typeForPreDeploy(), Types.primitiveDataTypes.Text, 'SomeField')
 
-      it('should not be modified if the field was modified', async () => {
+      it('should add \'trackHistory=false\' if the field was modified', async () => {
         const after = field.clone()
         after.annotations.someAnnotation = true
         const changes = [toChange({ before: field, after })]
         await filter.preDeploy(changes)
-        expect(getChangeData(changes[0]).annotations).not.toHaveProperty(FIELD_HISTORY_TRACKING_ENABLED)
+        expect(getChangeData(changes[0]).annotations).toHaveProperty(FIELD_HISTORY_TRACKING_ENABLED, false)
       })
-      it('should not be modified if the field was added', async () => {
+      it('should add \'trackHistory=false\' if the field was added', async () => {
         const after = field.clone()
         const changes = [toChange({ after })]
         await filter.preDeploy(changes)
-        expect(getChangeData(changes[0]).annotations).not.toHaveProperty(FIELD_HISTORY_TRACKING_ENABLED)
+        expect(getChangeData(changes[0]).annotations).toHaveProperty(FIELD_HISTORY_TRACKING_ENABLED, false)
       })
     })
 
@@ -171,8 +187,8 @@ describe('History tracking', () => {
         })
       })
       describe('when the field is tracked', () => {
-        const parentType = typeForPreDeploy(['SomeField'])
-        const field = createField(parentType, Types.primitiveDataTypes.Text, 'SomeField')
+        const parentType = typeForPreDeploy(['someField'])
+        const field = new Field(parentType, 'someField', Types.primitiveDataTypes.Text)
 
         it('should add trackHistory=true annotation if the field was modified', async () => {
           const after = field.clone()
@@ -204,8 +220,8 @@ describe('History tracking', () => {
       describe('When fields are added', () => {
         const expectFieldTrackingAdditionChange = (change: Change): void => expectFieldTrackingChange(change, false)
         it('should create new changes for newly tracked fields that existed before', async () => {
-          const before = typeForPreDeploy([], ['SomeField'])
-          const after = typeForPreDeploy(['SomeField'], ['SomeField'])
+          const before = typeForPreDeploy([], ['someField'])
+          const after = typeForPreDeploy(['someField'], ['someField'])
           const changes = [toChange({ before, after })]
           await filter.preDeploy(changes)
           expect(changes).toHaveLength(2)
@@ -214,14 +230,14 @@ describe('History tracking', () => {
 
         it('should not create new changes for newly tracked fields that are created', async () => {
           const before = typeForPreDeploy([], [])
-          const after = typeForPreDeploy(['SomeField'], ['SomeField'])
+          const after = typeForPreDeploy(['someField'], ['someField'])
           const changes = [toChange({ before, after })]
           await filter.preDeploy(changes)
           expect(changes).toHaveLength(1)
         })
         it('should create changes if the object\'s history tracking is enabled', async () => {
-          const before = typeForPreDeploy(undefined, ['SomeField'])
-          const after = typeForPreDeploy(['SomeField'], ['SomeField'])
+          const before = typeForPreDeploy(undefined, ['someField'])
+          const after = typeForPreDeploy(['someField'], ['someField'])
           const changes = [toChange({ before, after })]
           await filter.preDeploy(changes)
           expect(changes).toHaveLength(2)
@@ -233,23 +249,23 @@ describe('History tracking', () => {
         const expectFieldTrackingRemovalChange = (change: Change): void => expectFieldTrackingChange(change, true)
 
         it('should create new changes for removed fields that still exist', async () => {
-          const before = typeForPreDeploy(['SomeField'], ['SomeField'])
-          const after = typeForPreDeploy([], ['SomeField'])
+          const before = typeForPreDeploy(['someField'], ['someField'])
+          const after = typeForPreDeploy([], ['someField'])
           const changes = [toChange({ before, after })]
           await filter.preDeploy(changes)
           expect(changes).toHaveLength(2)
           expectFieldTrackingRemovalChange(changes[1])
         })
         it('should not create new changes for fields that are no longer tracked because they no longer exist', async () => {
-          const before = typeForPreDeploy(['SomeField'], ['SomeField'])
+          const before = typeForPreDeploy(['someField'], ['someField'])
           const after = typeForPreDeploy([], [])
           const changes = [toChange({ before, after })]
           await filter.preDeploy(changes)
           expect(changes).toHaveLength(1)
         })
         it('should create changes if the object\'s history tracking is disabled [SALTO-3378]', async () => {
-          const before = typeForPreDeploy(['SomeField'], ['SomeField'])
-          const after = typeForPreDeploy(undefined, ['SomeField'])
+          const before = typeForPreDeploy(['someField'], ['someField'])
+          const after = typeForPreDeploy(undefined, ['someField'])
           const changes = [toChange({ before, after })]
           await filter.preDeploy(changes)
           expect(changes).toHaveLength(2)

--- a/packages/salesforce-adapter/test/filters/history_tracking.test.ts
+++ b/packages/salesforce-adapter/test/filters/history_tracking.test.ts
@@ -37,14 +37,17 @@ import {
   OBJECT_HISTORY_TRACKING_ENABLED,
 } from '../../src/constants'
 
-const filter = filterCreator({ config: defaultFilterContext }) as FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
-
-describe(filter.name, () => {
+describe('historyTracking', () => {
+  let filter: FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
   const createField = (parentType: ObjectType, fieldName: string): Field => (
     new Field(parentType, fieldName, Types.primitiveDataTypes.Text, {
       [API_NAME]: `${parentType.elemID.typeName}.${fieldName}`,
     })
   )
+
+  beforeEach(() => {
+    filter = filterCreator({ config: defaultFilterContext }) as FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
+  })
 
   describe('onFetch', () => {
     describe('When fetching an object with history tracking disabled', () => {
@@ -361,8 +364,8 @@ describe(filter.name, () => {
       await filter.onFetch(elements)
 
       const after = elements[0].clone()
-      const fieldApiName = after.fields.fieldWithoutHistoryTracking.annotations[API_NAME]
-      after.annotations[HISTORY_TRACKED_FIELDS].fieldWithoutHistoryTracking = fieldApiName
+      after.annotations[HISTORY_TRACKED_FIELDS].fieldWithoutHistoryTracking = (
+        new ReferenceExpression(after.fields.fieldWithoutHistoryTracking.elemID))
       const changes = [toChange({ before: elements[0], after })]
       await filter.preDeploy(changes)
       await filter.onDeploy(changes)
@@ -374,7 +377,7 @@ describe(filter.name, () => {
       await filter.onFetch(elements)
 
       const after = elements[0].clone()
-      after.annotations[HISTORY_TRACKED_FIELDS] = []
+      after.annotations[HISTORY_TRACKED_FIELDS] = {}
       const changes = [toChange({ before: elements[0], after })]
       await filter.preDeploy(changes)
       await filter.onDeploy(changes)
@@ -402,9 +405,9 @@ describe(filter.name, () => {
       await filter.onFetch(elements)
 
       const after = elements[0].clone()
-      after.annotations[HISTORY_TRACKED_FIELDS] = [
-        new ReferenceExpression(typeWithHistoryTrackedFields.fields.fieldWithoutHistoryTracking.elemID),
-      ]
+      after.annotations[HISTORY_TRACKED_FIELDS] = {
+        fieldWithoutHistoryTracking: new ReferenceExpression(type.fields.fieldWithoutHistoryTracking.elemID),
+      }
 
       const changes = [toChange({ before: elements[0], after })]
       await filter.preDeploy(changes)

--- a/packages/salesforce-adapter/test/filters/history_tracking.test.ts
+++ b/packages/salesforce-adapter/test/filters/history_tracking.test.ts
@@ -1,0 +1,67 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import filterCreator from '../../src/filters/history_tracking'
+import { createCustomObjectType, defaultFilterContext } from '../utils'
+import { mockTypes } from '../mock_elements'
+import { FilterWith } from '../../src/filter'
+import { Types } from '../../src/transformers/transformer'
+import { HISTORY_TRACKED_FIELDS } from '../../src/constants'
+
+describe('History tracking', () => {
+  const filter = filterCreator({ config: defaultFilterContext }) as FilterWith<'onFetch'|'preDeploy'>
+  describe('When fetching an object with history tracking disabled', () => {
+    it('Should not modify the object', async () => {
+      const inputType = mockTypes.Account.clone()
+      inputType.annotations.enableHistory = false
+      const expectedOutput = inputType.clone()
+      const elements = [inputType]
+      await filter.onFetch(elements)
+      expect(elements).toEqual([expectedOutput])
+    })
+  })
+  describe('When fetching an object with history tracking enabled', () => {
+    const typeWithHistoryTrackedFields = createCustomObjectType('TypeWithHistoryTracking', {
+      // annotations: {
+      //   enableHistory: true,
+      // },
+      fields: {
+        fieldWithHistoryTracking: {
+          refType: Types.primitiveDataTypes.Text,
+          annotations: {
+            name: 'fieldWithHistoryTracking',
+            trackHistory: true,
+          },
+        },
+        fieldWithoutHistoryTracking: {
+          refType: Types.primitiveDataTypes.Text,
+          annotations: {
+            name: 'fieldWithoutHistoryTracking',
+            trackHistory: false,
+          },
+        },
+      },
+    })
+    it('Should update the object and field annotations correctly', async () => {
+      typeWithHistoryTrackedFields.annotations.enableHistory = true
+      await filter.onFetch([typeWithHistoryTrackedFields])
+      const trackedFieldNames = typeWithHistoryTrackedFields.annotations[HISTORY_TRACKED_FIELDS]
+      expect(trackedFieldNames).toBeDefined()
+      expect(trackedFieldNames).toEqual(['fieldWithHistoryTracking'])
+      expect(typeWithHistoryTrackedFields.fields.fieldWithHistoryTracking.annotations.trackHistory).not.toBeDefined()
+      expect(typeWithHistoryTrackedFields.fields.fieldWithoutHistoryTracking.annotations.trackHistory).not.toBeDefined()
+    })
+  })
+})

--- a/packages/salesforce-adapter/test/filters/history_tracking.test.ts
+++ b/packages/salesforce-adapter/test/filters/history_tracking.test.ts
@@ -95,8 +95,8 @@ describe('History tracking filter', () => {
   })
   describe('preDeploy', () => {
     const typeForPreDeploy = (trackedFields?: string[], fields: string[] = []): ObjectType => {
-      const referenceToField = (objectType: ObjectType, fieldName: string): ReferenceExpression => (
-        new ReferenceExpression(objectType.elemID.createNestedID('field', fieldName))
+      const referenceToField = (objectType: ObjectType, fieldName: string): string => (
+        objectType.elemID.createNestedID('field', fieldName).getFullName()
       )
       const objectType = createCustomObjectType('SomeType', {
         fields: Object.fromEntries(fields.map(fieldName => [fieldName, {

--- a/packages/salesforce-adapter/test/filters/history_tracking.test.ts
+++ b/packages/salesforce-adapter/test/filters/history_tracking.test.ts
@@ -15,14 +15,13 @@
 */
 import _ from 'lodash'
 import {
-  AdditionChange,
-  Change, ElemID,
+  Change, ChangeDataType, ElemID,
   Field,
-  getChangeData, isAdditionChange,
+  getChangeData,
   isFieldChange,
-  isModificationChange, isRemovalChange,
+  isModificationChange,
   ModificationChange,
-  ObjectType, ReferenceExpression, RemovalChange,
+  ObjectType, ReferenceExpression,
   toChange,
 } from '@salto-io/adapter-api'
 import filterCreator from '../../src/filters/history_tracking'
@@ -39,9 +38,10 @@ import { FilterWith } from './mocks'
 
 describe('historyTracking', () => {
   let filter: FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
-  const createField = (parentType: ObjectType, fieldName: string): Field => (
+  const createField = (parentType: ObjectType, fieldName: string, isTracked?: boolean): Field => (
     new Field(parentType, fieldName, Types.primitiveDataTypes.Text, {
       [API_NAME]: `${parentType.elemID.typeName}.${fieldName}`,
+      ...(isTracked === undefined ? {} : { [FIELD_ANNOTATIONS.TRACK_HISTORY]: isTracked }),
     })
   )
 
@@ -50,23 +50,34 @@ describe('historyTracking', () => {
   })
 
   describe('onFetch', () => {
+    let inputType: ObjectType
     describe('When fetching an object that does not support history tracking', () => {
-      it('Should not modify the object', async () => {
-        const inputType = mockTypes.Account.clone()
-        const expectedOutput = inputType.clone()
+      beforeEach(async () => {
+        inputType = mockTypes.Account.clone()
         const elements = [inputType]
         await filter.onFetch(elements)
-        expect(elements).toEqual([expectedOutput])
+      })
+      it('Should not add a trackHistory annotation', () => {
+        expect(inputType).not.toHaveProperty(OBJECT_HISTORY_TRACKING_ENABLED)
+      })
+      it('Should not add object-level trackedFields annotation', () => {
+        expect(inputType.annotations).not.toHaveProperty(HISTORY_TRACKED_FIELDS)
+      })
+      it('Should not add field-level annotation', () => {
+        Object.values(inputType.fields)
+          .forEach(field => expect(field.annotations).not.toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY))
       })
     })
     describe('When fetching an object with history tracking disabled', () => {
-      let inputType: ObjectType
       beforeEach(async () => {
         inputType = mockTypes.Account.clone()
         inputType.annotations.enableHistory = false
         Object.values(inputType.fields)
           .forEach(fieldDef => { fieldDef.annotations[FIELD_ANNOTATIONS.TRACK_HISTORY] = false })
         await filter.onFetch([inputType])
+      })
+      it('Should keep the existing trackHistory annotation', () => {
+        expect(inputType.annotations).toHaveProperty(OBJECT_HISTORY_TRACKING_ENABLED, false)
       })
       it('Should not add object-level trackedFields annotation', () => {
         expect(inputType.annotations).not.toHaveProperty(HISTORY_TRACKED_FIELDS)
@@ -101,26 +112,28 @@ describe('historyTracking', () => {
       const referenceForField = (fieldName: string): ReferenceExpression => (
         new ReferenceExpression(typeWithHistoryTrackedFields.elemID.createNestedID('field', fieldName))
       )
-      it('Should update the object and field annotations correctly', async () => {
-        const elements = [typeWithHistoryTrackedFields.clone()]
-        await filter.onFetch(elements)
-        const trackedFieldNames = elements[0].annotations[HISTORY_TRACKED_FIELDS]
+      beforeEach(async () => {
+        inputType = typeWithHistoryTrackedFields.clone()
+        await filter.onFetch([inputType])
+      })
+      it('Should keep the existing trackHistory annotation', () => {
+        expect(inputType.annotations).toHaveProperty(OBJECT_HISTORY_TRACKING_ENABLED, true)
+      })
+      it('Should remove field-level annotation', () => {
+        Object.values(inputType.fields)
+          .forEach(field => expect(field.annotations).not.toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY))
+      })
+      it('Should aggregate the tracked fields into a single annotation', () => {
+        const trackedFieldNames = inputType.annotations[HISTORY_TRACKED_FIELDS]
         expect(trackedFieldNames).toBeDefined()
         expect(trackedFieldNames).toEqual({
           fieldWithHistoryTracking: referenceForField('fieldWithHistoryTracking'),
         })
-        expect(elements[0].fields.fieldWithHistoryTracking.annotations)
-          .not
-          .toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY)
-        expect(elements[0].fields.fieldWithoutHistoryTracking.annotations)
-          .not
-          .toHaveProperty([FIELD_ANNOTATIONS.TRACK_HISTORY])
-        expect(elements[0].annotations)
-          .toHaveProperty(OBJECT_HISTORY_TRACKING_ENABLED, true)
       })
     })
   })
   describe('preDeploy', () => {
+    let inputType: ObjectType
     const typeForPreDeploy = (trackedFields?: string[], fields: string[] = []): ObjectType => {
       const fieldApiName = (typeName: string, fieldName: string): string => `${typeName}.${fieldName}`
       const refExprForField = (typeName: string, fieldName: string): ReferenceExpression => (
@@ -147,8 +160,8 @@ describe('historyTracking', () => {
     }
 
     describe('when an object does not support history tracking', () => {
-      it('should not create any annotations', async () => {
-        const objectType = createCustomObjectType('SomeObject', {
+      beforeEach(async () => {
+        const type = createCustomObjectType('SomeObject', {
           fields: {
             SomeField: {
               refType: Types.primitiveDataTypes.Text,
@@ -158,215 +171,321 @@ describe('historyTracking', () => {
             },
           },
         })
+        const change = toChange({ after: type })
 
-        const changes = [toChange({ after: objectType })]
-        await filter.preDeploy(changes)
-        expect(getChangeData(changes[0]).annotations).not.toHaveProperty(OBJECT_HISTORY_TRACKING_ENABLED)
-        expect(getChangeData(changes[0]).fields.SomeField).not.toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY)
+        await filter.preDeploy([change])
+
+        inputType = getChangeData(change)
+      })
+
+
+      it('Should not add a trackHistory annotation', () => {
+        expect(inputType).not.toHaveProperty(OBJECT_HISTORY_TRACKING_ENABLED)
+      })
+      it('Should not add object-level trackedFields annotation', () => {
+        expect(inputType.annotations).not.toHaveProperty(HISTORY_TRACKED_FIELDS)
+      })
+      it('Should not add field-level annotation', () => {
+        Object.values(inputType.fields)
+          .forEach(field => expect(field.annotations).not.toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY))
       })
     })
 
     describe('when an object has no historyTrackedFields', () => {
-      it('should add enableHistory=false annotation if the object type is new', async () => {
-        const changes = [toChange({ after: typeForPreDeploy() })]
-        await filter.preDeploy(changes)
-        expect(getChangeData(changes[0]).annotations).toHaveProperty(OBJECT_HISTORY_TRACKING_ENABLED, false)
-        expect(getChangeData(changes[0]).annotations).not.toHaveProperty(HISTORY_TRACKED_FIELDS)
+      describe('when history tracking is not supported', () => {
+        beforeEach(async () => {
+          const type = typeForPreDeploy()
+          delete type.annotations[OBJECT_HISTORY_TRACKING_ENABLED]
+          const change = toChange({ after: type })
+
+          await filter.preDeploy([change])
+
+          inputType = getChangeData(change)
+        })
+
+        it('should not crash', async () => {
+          expect(inputType.annotations).not.toHaveProperty(OBJECT_HISTORY_TRACKING_ENABLED)
+          expect(inputType.annotations).not.toHaveProperty(HISTORY_TRACKED_FIELDS)
+        })
       })
-      it('should add enableHistory=false annotation if the change is not related to history tracking', async () => {
-        const before = typeForPreDeploy()
-        before.annotations.unrelatedAnnotation = 'Something'
-        const changes = [toChange({ before, after: typeForPreDeploy() })]
-        await filter.preDeploy(changes)
-        expect(getChangeData(changes[0]).annotations).toHaveProperty(OBJECT_HISTORY_TRACKING_ENABLED, false)
-        expect(getChangeData(changes[0]).annotations).not.toHaveProperty(HISTORY_TRACKED_FIELDS)
+
+      describe('when history tracking is disabled', () => {
+        beforeEach(async () => {
+          const type = typeForPreDeploy()
+          const change = toChange({ after: type })
+
+          await filter.preDeploy([change])
+
+          inputType = getChangeData(change)
+        })
+
+        it('should not crash', async () => {
+          expect(inputType.annotations).toHaveProperty(OBJECT_HISTORY_TRACKING_ENABLED, false)
+          expect(inputType.annotations).not.toHaveProperty(HISTORY_TRACKED_FIELDS)
+        })
       })
-      it('should add enableHistory=false annotation if historyTrackedFields was removed', async () => {
-        const changes = [toChange({ before: typeForPreDeploy([]), after: typeForPreDeploy() })]
-        await filter.preDeploy(changes)
-        expect(getChangeData(changes[0]).annotations).toHaveProperty(OBJECT_HISTORY_TRACKING_ENABLED, false)
-        expect(getChangeData(changes[0]).annotations).not.toHaveProperty(HISTORY_TRACKED_FIELDS)
+
+      describe('when history tracking is enabled', () => {
+        // This is a contradiction that should be caught by a CV - SALTO-4178
+        beforeEach(async () => {
+          const type = typeForPreDeploy()
+          type.annotations[OBJECT_HISTORY_TRACKING_ENABLED] = true
+          const change = toChange({ after: type })
+
+          await filter.preDeploy([change])
+
+          inputType = getChangeData(change)
+        })
+
+        it('should not crash', async () => {
+          expect(inputType.annotations).toHaveProperty(OBJECT_HISTORY_TRACKING_ENABLED, true)
+          expect(inputType.annotations).not.toHaveProperty(HISTORY_TRACKED_FIELDS)
+        })
+        it('should set all field-level annotations to false', () => {
+          Object.values(inputType.fields)
+            .forEach(field => expect(field.annotations).toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY, false))
+        })
       })
     })
-
     describe('when an object type has a historyTrackedFields annotation', () => {
-      it('should add the enableHistory annotation if the object type is new', async () => {
-        const changes = [toChange({ after: typeForPreDeploy([]) })]
-        await filter.preDeploy(changes)
-        expect(getChangeData(changes[0]).annotations).toHaveProperty(OBJECT_HISTORY_TRACKING_ENABLED, true)
-        expect(getChangeData(changes[0]).annotations).not.toHaveProperty(HISTORY_TRACKED_FIELDS)
-      })
-      it('should add the trackHistory annotation to fields if the object type is new', async () => {
-        const changes = [toChange({ after: typeForPreDeploy(['SomeField'], ['SomeField', 'UntrackedField']) })]
-        await filter.preDeploy(changes)
-        expect(getChangeData(changes[0]).annotations).toHaveProperty(OBJECT_HISTORY_TRACKING_ENABLED, true)
-        expect(getChangeData(changes[0]).annotations).not.toHaveProperty(HISTORY_TRACKED_FIELDS)
-        expect(getChangeData(changes[0]).fields.SomeField.annotations).toHaveProperty('trackHistory', true)
-      })
-      it('should add the enableHistory annotation if historyTrackedFields was modified', async () => {
-        const before = typeForPreDeploy(['SomeField'], ['SomeField'])
-        const changes = [toChange({ before, after: typeForPreDeploy([]) })]
-        await filter.preDeploy(changes)
-        expect(getChangeData(changes[0]).annotations).toHaveProperty(OBJECT_HISTORY_TRACKING_ENABLED, true)
-        expect(getChangeData(changes[0]).annotations).not.toHaveProperty(HISTORY_TRACKED_FIELDS)
-      })
-      it('should add the enableHistory annotation if historyTrackedFields was added', async () => {
-        const changes = [toChange({ before: typeForPreDeploy(), after: typeForPreDeploy([]) })]
-        await filter.preDeploy(changes)
-        expect(getChangeData(changes[0]).annotations).toHaveProperty(OBJECT_HISTORY_TRACKING_ENABLED, true)
-        expect(getChangeData(changes[0]).annotations).not.toHaveProperty(HISTORY_TRACKED_FIELDS)
-      })
-      it('should ignore unknown field names in the annotation', async () => {
-        const changes = [toChange({ before: typeForPreDeploy(), after: typeForPreDeploy(['Garbage']) })]
-        await filter.preDeploy(changes)
-        expect(changes).toHaveLength(1)
-        expect(getChangeData(changes[0]).annotations).toHaveProperty(OBJECT_HISTORY_TRACKING_ENABLED, true)
-        expect(getChangeData(changes[0]).annotations).not.toHaveProperty(HISTORY_TRACKED_FIELDS)
-      })
-    })
+      describe('when the object type is new', () => {
+        describe('when there are no tracked fields', () => {
+          beforeEach(async () => {
+            const change = toChange({ after: typeForPreDeploy([]) })
+            await filter.preDeploy([change])
 
-    describe('when fields belong to an object that has history tracking disabled', () => {
-      const field = createField(typeForPreDeploy(), 'SomeField')
-
-      it('should add \'trackHistory=false\' if the field was modified', async () => {
-        const after = field.clone()
-        after.annotations.someAnnotation = true
-        const changes = [toChange({ before: field, after })]
-        await filter.preDeploy(changes)
-        expect(getChangeData(changes[0]).annotations).toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY, false)
-      })
-      it('should add \'trackHistory=false\' if the field was added', async () => {
-        const after = field.clone()
-        const changes = [toChange({ after })]
-        await filter.preDeploy(changes)
-        expect(getChangeData(changes[0]).annotations).toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY, false)
-      })
-    })
-
-    describe('when fields belong to an object that has history tracking enabled', () => {
-      describe('when the field is not tracked', () => {
-        const parentType = typeForPreDeploy(['NotMyField'])
-        const field = createField(parentType, 'SomeField')
-
-        it('should add trackHistory=false annotation if the field was modified', async () => {
-          const after = field.clone()
-          after.annotations.someAnnotation = true
-          const changes = [toChange({ before: field, after })]
-          await filter.preDeploy(changes)
-          expect(getChangeData(changes[0]).annotations).toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY, false)
+            inputType = getChangeData(change)
+          })
+          it('should remove the list of tracked fields', () => {
+            expect(inputType.annotations).not.toHaveProperty(HISTORY_TRACKED_FIELDS)
+          })
+          it('should add the enableHistory annotation', () => {
+            expect(inputType.annotations).toHaveProperty(OBJECT_HISTORY_TRACKING_ENABLED, true)
+          })
+          it('should set all field-level annotations to false', () => {
+            Object.values(inputType.fields)
+              .forEach(field => expect(field.annotations).toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY, false))
+          })
         })
-        it('should add trackHistory=false annotation if the field was added', async () => {
-          const changes = [toChange({ after: field.clone() })]
-          await filter.preDeploy(changes)
-          expect(getChangeData(changes[0]).annotations).toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY, false)
+        describe('when there are tracked fields', () => {
+          beforeEach(async () => {
+            const change = toChange({ after: typeForPreDeploy(['SomeField'], ['SomeField', 'UntrackedField']) })
+            await filter.preDeploy([change])
+            inputType = getChangeData(change)
+          })
+          it('should remove the list of tracked fields', () => {
+            expect(inputType.annotations).not.toHaveProperty(HISTORY_TRACKED_FIELDS)
+          })
+          it('should add the enableHistory annotation', () => {
+            expect(inputType.annotations).toHaveProperty(OBJECT_HISTORY_TRACKING_ENABLED, true)
+          })
+          it('should set all field-level annotations correctly', () => {
+            expect(inputType.fields.SomeField.annotations).toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY, true)
+            expect(inputType.fields.UntrackedField.annotations).toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY, false)
+          })
         })
       })
-      describe('when the field is tracked', () => {
-        const parentType = typeForPreDeploy(['SomeField'], ['SomeField'])
-        const field = createField(parentType, 'SomeField')
-
-        it('should add trackHistory=true annotation if the field was modified', async () => {
-          const after = field.clone()
-          after.annotations.someAnnotation = true
-          const changes = [toChange({ before: field, after })]
-          await filter.preDeploy(changes)
-          expect(getChangeData(changes[0]).annotations).toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY, true)
-        })
-        it('should add trackHistory=true annotation if the field was added', async () => {
-          const changes = [toChange({ after: field.clone() })]
-          await filter.preDeploy(changes)
-          expect(getChangeData(changes[0]).annotations).toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY, true)
-        })
-      })
-    })
-    describe('When tracked fields are changed but there are no explicit changes to the fields themselves', () => {
-      const isFieldModificationChange = <T extends Change<unknown>>(change: T)
-        : change is T & ModificationChange<Field> => (
-          isFieldChange(change) && isModificationChange(change)
-        )
-      const expectFieldTrackingChange = (change: Change, isRemoval: boolean): void => {
-        expect(isFieldModificationChange(change)).toBeTrue()
-        if (!isModificationChange(change)) {
-          return // just to make the compiler aware
+      describe('when the existing annotation was modified', () => {
+        const isFieldModificationChange = <T extends Change<unknown>>(change: T)
+          : change is T & ModificationChange<Field> => (
+            isFieldChange(change) && isModificationChange(change)
+          )
+        const expectFieldTrackingChange = (change: Change, isRemoval: boolean): void => {
+          expect(isFieldModificationChange(change)).toBeTrue()
+          if (!isModificationChange(change)) {
+            return // just to make the compiler aware
+          }
+          expect(change.data.before.annotations).toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY, isRemoval)
+          expect(change.data.after.annotations).toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY, !isRemoval)
         }
-        expect(change.data.before.annotations).toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY, isRemoval)
-        expect(change.data.after.annotations).toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY, !isRemoval)
-      }
-      describe('When fields are added', () => {
-        const expectFieldTrackingAdditionChange = (change: Change): void => expectFieldTrackingChange(change, false)
-        it('should create new changes for newly tracked fields that existed before', async () => {
-          const before = typeForPreDeploy([], ['SomeField'])
-          const after = typeForPreDeploy(['SomeField'], ['SomeField'])
-          const changes = [toChange({ before, after })]
-          await filter.preDeploy(changes)
-          expect(changes).toHaveLength(2)
-          expectFieldTrackingAdditionChange(changes[1])
-        })
 
-        it('should not create new changes for newly tracked fields that are created', async () => {
-          const before = typeForPreDeploy([], [])
-          const after = typeForPreDeploy(['SomeField'], ['SomeField'])
-          const changes = [toChange({ before, after }), toChange({ after: after.fields.SomeField })]
-          await filter.preDeploy(changes)
-          expect(changes).toHaveLength(2)
+        describe('fields are added', () => {
+          const expectFieldTrackingAdditionChange = (change: Change): void => expectFieldTrackingChange(change, false)
+
+          describe.each([
+            ['unknown fields',
+              typeForPreDeploy(),
+              typeForPreDeploy(['Garbage']),
+              false,
+              [],
+            ],
+            ['existing field, tracking is unchanged',
+              typeForPreDeploy([], ['SomeField']),
+              typeForPreDeploy(['SomeField'], ['SomeField']),
+              true,
+              ['SomeField'],
+            ],
+            ['new field, tracking is unchanged',
+              typeForPreDeploy([], []),
+              typeForPreDeploy(['SomeField'], ['SomeField']),
+              true,
+              ['SomeField'],
+            ],
+            ['existing field, tracking is enabled',
+              typeForPreDeploy(undefined, ['SomeField']),
+              typeForPreDeploy(['SomeField'], ['SomeField']),
+              true,
+              ['SomeField'],
+            ],
+            ['new field, tracking is enabled',
+              typeForPreDeploy(undefined, []),
+              typeForPreDeploy(['SomeField'], ['SomeField']),
+              true,
+              ['SomeField'],
+            ],
+          ])('%s', (_desc, before, after, shouldAddChanges, trackedFields: string[]) => {
+            let changes: Change<ObjectType>[]
+            beforeEach(async () => {
+              changes = [toChange({ before, after })]
+              await filter.preDeploy(changes)
+            })
+            it('should create new changes if needed', () => {
+              expect(changes).toHaveLength(shouldAddChanges ? 2 : 1)
+              if (shouldAddChanges) {
+                expectFieldTrackingAdditionChange(changes[1])
+              }
+            })
+            it('should remove the list of tracked fields', async () => {
+              const objType = getChangeData(changes[0])
+              expect(objType.annotations).not.toHaveProperty(HISTORY_TRACKED_FIELDS)
+            })
+            it('should set all field-level annotations correctly', () => {
+              const objType = getChangeData(changes[0])
+              Object.values(objType.fields)
+                .forEach(field => (
+                  expect(field.annotations)
+                    .toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY, trackedFields.includes(field.name))
+                ))
+            })
+          })
         })
-        it('should create changes if the object\'s history tracking is enabled', async () => {
-          const before = typeForPreDeploy(undefined, ['SomeField'])
-          const after = typeForPreDeploy(['SomeField'], ['SomeField'])
-          const changes = [toChange({ before, after })]
-          await filter.preDeploy(changes)
-          expect(changes).toHaveLength(2)
-          expectFieldTrackingAdditionChange(changes[1])
+        describe('fields are removed', () => {
+          const expectFieldTrackingRemovalChange = (change: Change): void => expectFieldTrackingChange(change, true)
+          describe.each([
+            ['field remains, tracking is unchanged',
+              typeForPreDeploy(['SomeField'], ['SomeField']),
+              typeForPreDeploy([], ['SomeField']),
+              true,
+              [],
+            ],
+            ['field is removed, tracking is unchanged',
+              typeForPreDeploy(['SomeField'], ['SomeField']),
+              typeForPreDeploy([]),
+              false,
+              [],
+            ],
+            //
+          ])('%s', (_desc, before, after, shouldAddChanges, trackedFields: string[]) => {
+            let changes: Change<ObjectType>[]
+            beforeEach(async () => {
+              changes = [toChange({ before, after })]
+              await filter.preDeploy(changes)
+            })
+
+            it('should not create new changes', () => {
+              expect(changes).toHaveLength(shouldAddChanges ? 2 : 1)
+              if (shouldAddChanges) {
+                expectFieldTrackingRemovalChange(changes[1])
+              }
+            })
+            it('should remove the list of tracked fields', async () => {
+              const objType = getChangeData(changes[0])
+              expect(objType.annotations).not.toHaveProperty(HISTORY_TRACKED_FIELDS)
+            })
+            it('should set all field-level annotations correctly', () => {
+              const objType = getChangeData(changes[0])
+              Object.values(objType.fields)
+                .forEach(field => (
+                  expect(field.annotations)
+                    .toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY, trackedFields.includes(field.name))
+                ))
+            })
+          })
+        })
+      })
+    })
+
+    describe('field changes', () => {
+      describe('parent has history tracking disabled', () => {
+        const parentType = typeForPreDeploy()
+        describe.each([
+          ['field was modified',
+            createField(parentType, 'SomeField'),
+            createField(parentType, 'SomeField'),
+          ],
+          ['field was added',
+            undefined,
+            createField(parentType, 'SomeField'),
+          ],
+        ])('%s', (_desc, before, after) => {
+          let field: Field
+          beforeEach(async () => {
+            const changes = [toChange({ before, after })]
+            await filter.preDeploy(changes)
+            field = getChangeData(changes[0])
+          })
+          it('should add \'trackHistory=false\'', async () => {
+            expect(field.annotations).toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY, false)
+          })
         })
       })
 
-      describe('When fields are removed', () => {
-        const expectFieldTrackingRemovalChange = (change: Change): void => expectFieldTrackingChange(change, true)
-
-        it('should create new changes for removed fields that still exist', async () => {
-          const before = typeForPreDeploy(['SomeField'], ['SomeField'])
-          const after = typeForPreDeploy([], ['SomeField'])
-          const changes = [toChange({ before, after })]
-          await filter.preDeploy(changes)
-          expect(changes).toHaveLength(2)
-          expectFieldTrackingRemovalChange(changes[1])
-        })
-        it('should not create new changes for fields that are no longer tracked because they no longer exist', async () => {
-          const before = typeForPreDeploy(['SomeField'], ['SomeField'])
-          const after = typeForPreDeploy([], [])
-          const changes = [toChange({ before, after })]
-          await filter.preDeploy(changes)
-          expect(changes).toHaveLength(1)
-        })
-        it('should create changes if the object\'s history tracking is disabled [SALTO-3378]', async () => {
-          const before = typeForPreDeploy(['SomeField'], ['SomeField'])
-          const after = typeForPreDeploy(undefined, ['SomeField'])
-          const changes = [toChange({ before, after })]
-          await filter.preDeploy(changes)
-          expect(changes).toHaveLength(2)
-          expectFieldTrackingRemovalChange(changes[1])
+      describe('parent has history tracking enabled', () => {
+        const parentType = typeForPreDeploy(['SomeField'])
+        describe.each([
+          ['untracked field was modified',
+            createField(parentType, 'NotSomeField'),
+            createField(parentType, 'NotSomeField'),
+            false,
+          ],
+          ['untracked field was added',
+            undefined,
+            createField(parentType, 'NotSomeField'),
+            false,
+          ],
+          ['tracked field was modified',
+            createField(parentType, 'SomeField'),
+            createField(parentType, 'SomeField'),
+            true,
+          ],
+          ['tracked field was added',
+            undefined,
+            createField(parentType, 'SomeField'),
+            true,
+          ],
+        ])('%s', (_desc, before, after, isTracked) => {
+          let field: Field
+          beforeEach(async () => {
+            const changes = [toChange({ before, after })]
+            await filter.preDeploy(changes)
+            field = getChangeData(changes[0])
+          })
+          it('should set the trackHistory annotation correctly', async () => {
+            expect(field.annotations).toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY, isTracked)
+          })
         })
       })
     })
   })
   describe('onDeploy', () => {
-    it('Should handle unrelated field changes', async () => {
-      const field = createField(mockTypes.Account, 'SomeField')
-      const expected = field.clone()
-      const changes = [
-        toChange({ before: field }),
-        toChange({ after: field }),
-        toChange({ before: field, after: field.clone() }),
-      ]
-      getChangeData(changes[2]).annotations.unrelatedAnnotation = 'Something'
-      await filter.onDeploy(changes)
-      expect(isRemovalChange(changes[0])).toBeTrue()
-      expect((changes[0] as RemovalChange<Field>).data.before).toEqual(expected)
-      expect(isAdditionChange(changes[1])).toBeTrue()
-      expect((changes[1] as AdditionChange<Field>).data.after).toEqual(expected)
-      expect(isModificationChange(changes[2])).toBeTrue()
-      expect((changes[2] as ModificationChange<Field>).data.before).toEqual(expected)
-      expect((changes[2] as ModificationChange<Field>).data.after.annotations).toHaveProperty('unrelatedAnnotation', 'Something')
+    describe('Unrelated field changes', () => {
+      let changes: Change[]
+      beforeEach(async () => {
+        const field = createField(mockTypes.Account, 'SomeField')
+        changes = [
+          toChange({ before: field }),
+          toChange({ after: field }),
+          toChange({ before: field, after: field.clone() }),
+        ]
+        getChangeData(changes[2]).annotations.unrelatedAnnotation = 'Something'
+        await filter.onDeploy(changes)
+      })
+      it('should not effect unrelated changes', () => {
+        expect(changes).toHaveLength(3)
+        changes.forEach(change => (
+          expect(getChangeData(change).annotations).not.toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY)
+        ))
+      })
     })
   })
   describe('End to end', () => {
@@ -397,75 +516,114 @@ describe('historyTracking', () => {
       },
     })
     describe('onFetch vs. preDeploy=>onDeploy', () => {
-      it('should have the same output between onFetch and preDeploy=>onDeploy when adding an object', async () => {
-        const elements = [typeWithHistoryTrackedFields.clone()]
-        await filter.onFetch(elements)
+      describe('when adding an object', () => {
+        let beforePreDeploy: ChangeDataType[]
+        let afterOnDeploy: Change[]
+        beforeEach(async () => {
+          const elements = [typeWithHistoryTrackedFields.clone()]
+          await filter.onFetch(elements)
+          beforePreDeploy = elements
 
-        const changes = [toChange({ after: elements[0] })]
-        getChangeData(changes[0]).annotations[HISTORY_TRACKED_FIELDS] = resolveRefs(getChangeData(changes[0])
-          .annotations[HISTORY_TRACKED_FIELDS])
+          afterOnDeploy = [toChange({ after: elements[0].clone() })]
+          const objectType = getChangeData(afterOnDeploy[0])
+          objectType.annotations[HISTORY_TRACKED_FIELDS] = resolveRefs(objectType.annotations[HISTORY_TRACKED_FIELDS])
 
-        await filter.preDeploy(changes)
-        await filter.onDeploy(changes)
-        expect(changes).toHaveLength(1)
-        expect(getChangeData(changes[0])).toEqual(elements[0])
+          await filter.preDeploy(afterOnDeploy)
+          await filter.onDeploy(afterOnDeploy)
+        })
+        it('should be equal', () => {
+          expect(afterOnDeploy).toHaveLength(1)
+          expect(getChangeData(afterOnDeploy[0])).toEqual(beforePreDeploy[0])
+        })
       })
-      it('should have the same output between onFetch and preDeploy=>onDeploy when adding a tracked field', async () => {
-        const elements = [typeWithHistoryTrackedFields.clone()]
-        await filter.onFetch(elements)
+      describe('when adding a tracked field', () => {
+        let beforePreDeploy: ChangeDataType[]
+        let afterOnDeploy: Change[]
+        beforeEach(async () => {
+          const elements = [typeWithHistoryTrackedFields.clone()]
+          await filter.onFetch(elements)
 
-        const after = elements[0].clone()
-        after.annotations[HISTORY_TRACKED_FIELDS].fieldWithoutHistoryTracking = (
-          new ReferenceExpression(after.fields.fieldWithoutHistoryTracking.elemID))
-        const changes = [toChange({ before: elements[0], after })]
-        await filter.preDeploy(changes)
-        expect(changes).toHaveLength(2)
-        await filter.onDeploy(changes)
-        expect(changes).toHaveLength(1)
-        expect(getChangeData(changes[0])).toEqual(after)
+          const after = elements[0].clone()
+          beforePreDeploy = [after]
+          after.annotations[HISTORY_TRACKED_FIELDS].fieldWithoutHistoryTracking = (
+            new ReferenceExpression(after.fields.fieldWithoutHistoryTracking.elemID))
+          const changes = [toChange({ before: elements[0], after })]
+          await filter.preDeploy(changes)
+          expect(changes).toHaveLength(2)
+          await filter.onDeploy(changes)
+          afterOnDeploy = changes
+        })
+        it('should be equal', () => {
+          expect(afterOnDeploy).toHaveLength(1)
+          expect(getChangeData(afterOnDeploy[0])).toEqual(beforePreDeploy[0])
+        })
       })
-      it('should have the same output between onFetch and preDeploy=>onDeploy when removing a tracked field', async () => {
-        const elements = [typeWithHistoryTrackedFields.clone()]
-        await filter.onFetch(elements)
+      describe('when removing a tacked field', () => {
+        let beforePreDeploy: ChangeDataType[]
+        let afterOnDeploy: Change[]
+        beforeEach(async () => {
+          const elements = [typeWithHistoryTrackedFields.clone()]
+          await filter.onFetch(elements)
 
-        const after = elements[0].clone()
-        after.annotations[HISTORY_TRACKED_FIELDS] = {}
-        const changes = [toChange({ before: elements[0], after })]
-        await filter.preDeploy(changes)
-        await filter.onDeploy(changes)
-        expect(changes).toHaveLength(1)
-        expect(getChangeData(changes[0])).toEqual(after)
+          const after = elements[0].clone()
+          after.annotations[HISTORY_TRACKED_FIELDS] = {}
+          beforePreDeploy = [after]
+          const changes = [toChange({ before: elements[0], after })]
+          await filter.preDeploy(changes)
+          await filter.onDeploy(changes)
+          afterOnDeploy = changes
+        })
+        it('should be equal', () => {
+          expect(afterOnDeploy).toHaveLength(1)
+          expect(getChangeData(afterOnDeploy[0])).toEqual(beforePreDeploy[0])
+        })
       })
-      it('should have the same output between onFetch and preDeploy=>onDeploy when disabling history tracking', async () => {
-        const elements = [typeWithHistoryTrackedFields.clone()]
-        await filter.onFetch(elements)
+      describe('when disabling history tracking', () => {
+        let beforePreDeploy: ChangeDataType[]
+        let afterOnDeploy: Change[]
+        beforeEach(async () => {
+          const elements = [typeWithHistoryTrackedFields.clone()]
+          await filter.onFetch(elements)
 
-        const after = elements[0].clone()
-        delete after.annotations[HISTORY_TRACKED_FIELDS]
-        const changes = [toChange({ before: elements[0], after })]
-        await filter.preDeploy(changes)
-        await filter.onDeploy(changes)
-        expect(changes).toHaveLength(1)
-        expect(getChangeData(changes[0])).toEqual(after)
+          const after = elements[0].clone()
+          after.annotations[OBJECT_HISTORY_TRACKING_ENABLED] = false
+          delete after.annotations[HISTORY_TRACKED_FIELDS]
+          beforePreDeploy = [after]
+          const changes = [toChange({ before: elements[0], after })]
+          await filter.preDeploy(changes)
+          await filter.onDeploy(changes)
+          afterOnDeploy = changes
+        })
+        it('should be equal', () => {
+          expect(afterOnDeploy).toHaveLength(1)
+          expect(getChangeData(afterOnDeploy[0])).toEqual(beforePreDeploy[0])
+        })
       })
+      describe('when enabling history tracking', () => {
+        let beforePreDeploy: ChangeDataType[]
+        let afterOnDeploy: Change[]
+        beforeEach(async () => {
+          const type = typeWithHistoryTrackedFields.clone()
+          type.annotations[OBJECT_HISTORY_TRACKING_ENABLED] = false
+          type.fields.fieldWithHistoryTracking.annotations[FIELD_ANNOTATIONS.TRACK_HISTORY] = false
+          const elements = [type]
+          await filter.onFetch(elements)
 
-      it('should have the same output between onFetch and preDeploy=>onDeploy when enabling history tracking', async () => {
-        const type = typeWithHistoryTrackedFields.clone()
-        type.annotations[OBJECT_HISTORY_TRACKING_ENABLED] = false
-        type.fields.fieldWithHistoryTracking.annotations[FIELD_ANNOTATIONS.TRACK_HISTORY] = false
-        const elements = [type]
-        await filter.onFetch(elements)
+          const after = elements[0].clone()
+          after.annotations[HISTORY_TRACKED_FIELDS] = {
+            fieldWithoutHistoryTracking: new ReferenceExpression(type.fields.fieldWithoutHistoryTracking.elemID),
+          }
 
-        const after = elements[0].clone()
-        after.annotations[HISTORY_TRACKED_FIELDS] = {
-          fieldWithoutHistoryTracking: new ReferenceExpression(type.fields.fieldWithoutHistoryTracking.elemID),
-        }
-
-        const changes = [toChange({ before: elements[0], after })]
-        await filter.preDeploy(changes)
-        await filter.onDeploy(changes)
-        expect(changes).toHaveLength(1)
-        expect(getChangeData(changes[0])).toEqual(after)
+          beforePreDeploy = [after]
+          const changes = [toChange({ before: elements[0], after })]
+          await filter.preDeploy(changes)
+          await filter.onDeploy(changes)
+          afterOnDeploy = changes
+        })
+        it('should be equal', () => {
+          expect(afterOnDeploy).toHaveLength(1)
+          expect(getChangeData(afterOnDeploy[0])).toEqual(beforePreDeploy[0])
+        })
       })
     })
   })

--- a/packages/salesforce-adapter/test/filters/history_tracking.test.ts
+++ b/packages/salesforce-adapter/test/filters/history_tracking.test.ts
@@ -35,9 +35,9 @@ describe('History tracking', () => {
   })
   describe('When fetching an object with history tracking enabled', () => {
     const typeWithHistoryTrackedFields = createCustomObjectType('TypeWithHistoryTracking', {
-      // annotations: {
-      //   enableHistory: true,
-      // },
+      annotations: {
+        enableHistory: true,
+      },
       fields: {
         fieldWithHistoryTracking: {
           refType: Types.primitiveDataTypes.Text,
@@ -57,7 +57,6 @@ describe('History tracking', () => {
     })
     it('Should update the object and field annotations correctly', async () => {
       const elements = [typeWithHistoryTrackedFields.clone()]
-      elements[0].annotations.enableHistory = true
       await filter.onFetch(elements)
       const trackedFieldNames = elements[0].annotations[HISTORY_TRACKED_FIELDS]
       expect(trackedFieldNames).toBeDefined()

--- a/packages/salesforce-adapter/test/filters/history_tracking.test.ts
+++ b/packages/salesforce-adapter/test/filters/history_tracking.test.ts
@@ -28,7 +28,6 @@ import {
 import filterCreator from '../../src/filters/history_tracking'
 import { createCustomObjectType, defaultFilterContext } from '../utils'
 import { mockTypes } from '../mock_elements'
-import { FilterWith } from '../../src/filter'
 import { Types } from '../../src/transformers/transformer'
 import {
   API_NAME,
@@ -36,6 +35,7 @@ import {
   HISTORY_TRACKED_FIELDS,
   OBJECT_HISTORY_TRACKING_ENABLED, SALESFORCE,
 } from '../../src/constants'
+import { FilterWith } from './mocks'
 
 describe('historyTracking', () => {
   let filter: FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>

--- a/packages/salesforce-adapter/test/filters/history_tracking.test.ts
+++ b/packages/salesforce-adapter/test/filters/history_tracking.test.ts
@@ -30,7 +30,7 @@ import { mockTypes } from '../mock_elements'
 import { FilterWith } from '../../src/filter'
 import { Types } from '../../src/transformers/transformer'
 import {
-  FIELD_HISTORY_TRACKING_ENABLED,
+  FIELD_ANNOTATIONS,
   HISTORY_TRACKED_FIELDS,
   OBJECT_HISTORY_TRACKING_ENABLED,
 } from '../../src/constants'
@@ -60,14 +60,14 @@ describe('History tracking filter', () => {
             refType: Types.primitiveDataTypes.Text,
             annotations: {
               apiName: 'fieldWithHistoryTracking',
-              [FIELD_HISTORY_TRACKING_ENABLED]: true,
+              [FIELD_ANNOTATIONS.TRACK_HISTORY]: true,
             },
           },
           fieldWithoutHistoryTracking: {
             refType: Types.primitiveDataTypes.Text,
             annotations: {
               apiName: 'fieldWithoutHistoryTracking',
-              [FIELD_HISTORY_TRACKING_ENABLED]: false,
+              [FIELD_ANNOTATIONS.TRACK_HISTORY]: false,
             },
           },
         },
@@ -83,10 +83,10 @@ describe('History tracking filter', () => {
         expect(trackedFieldNames).toEqual([referenceForField('fieldWithHistoryTracking')])
         expect(elements[0].fields.fieldWithHistoryTracking.annotations)
           .not
-          .toHaveProperty(FIELD_HISTORY_TRACKING_ENABLED)
+          .toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY)
         expect(elements[0].fields.fieldWithoutHistoryTracking.annotations)
           .not
-          .toHaveProperty([FIELD_HISTORY_TRACKING_ENABLED])
+          .toHaveProperty([FIELD_ANNOTATIONS.TRACK_HISTORY])
         expect(elements[0].annotations)
           .not
           .toHaveProperty(OBJECT_HISTORY_TRACKING_ENABLED)
@@ -164,13 +164,13 @@ describe('History tracking filter', () => {
         after.annotations.someAnnotation = true
         const changes = [toChange({ before: field, after })]
         await filter.preDeploy(changes)
-        expect(getChangeData(changes[0]).annotations).toHaveProperty(FIELD_HISTORY_TRACKING_ENABLED, false)
+        expect(getChangeData(changes[0]).annotations).toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY, false)
       })
       it('should add \'trackHistory=false\' if the field was added', async () => {
         const after = field.clone()
         const changes = [toChange({ after })]
         await filter.preDeploy(changes)
-        expect(getChangeData(changes[0]).annotations).toHaveProperty(FIELD_HISTORY_TRACKING_ENABLED, false)
+        expect(getChangeData(changes[0]).annotations).toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY, false)
       })
     })
 
@@ -184,12 +184,12 @@ describe('History tracking filter', () => {
           after.annotations.someAnnotation = true
           const changes = [toChange({ before: field, after })]
           await filter.preDeploy(changes)
-          expect(getChangeData(changes[0]).annotations).toHaveProperty(FIELD_HISTORY_TRACKING_ENABLED, false)
+          expect(getChangeData(changes[0]).annotations).toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY, false)
         })
         it('should add trackHistory=false annotation if the field was added', async () => {
           const changes = [toChange({ after: field.clone() })]
           await filter.preDeploy(changes)
-          expect(getChangeData(changes[0]).annotations).toHaveProperty(FIELD_HISTORY_TRACKING_ENABLED, false)
+          expect(getChangeData(changes[0]).annotations).toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY, false)
         })
       })
       describe('when the field is tracked', () => {
@@ -201,12 +201,12 @@ describe('History tracking filter', () => {
           after.annotations.someAnnotation = true
           const changes = [toChange({ before: field, after })]
           await filter.preDeploy(changes)
-          expect(getChangeData(changes[0]).annotations).toHaveProperty(FIELD_HISTORY_TRACKING_ENABLED, true)
+          expect(getChangeData(changes[0]).annotations).toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY, true)
         })
         it('should add trackHistory=true annotation if the field was added', async () => {
           const changes = [toChange({ after: field.clone() })]
           await filter.preDeploy(changes)
-          expect(getChangeData(changes[0]).annotations).toHaveProperty(FIELD_HISTORY_TRACKING_ENABLED, true)
+          expect(getChangeData(changes[0]).annotations).toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY, true)
         })
       })
     })
@@ -220,8 +220,8 @@ describe('History tracking filter', () => {
         if (!isModificationChange(change)) {
           return // just to make the compiler aware
         }
-        expect(change.data.before.annotations).toHaveProperty(FIELD_HISTORY_TRACKING_ENABLED, isRemoval)
-        expect(change.data.after.annotations).toHaveProperty(FIELD_HISTORY_TRACKING_ENABLED, !isRemoval)
+        expect(change.data.before.annotations).toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY, isRemoval)
+        expect(change.data.after.annotations).toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY, !isRemoval)
       }
       describe('When fields are added', () => {
         const expectFieldTrackingAdditionChange = (change: Change): void => expectFieldTrackingChange(change, false)
@@ -290,14 +290,14 @@ describe('History tracking filter', () => {
           refType: Types.primitiveDataTypes.Text,
           annotations: {
             apiName: 'FieldWithHistoryTracking',
-            [FIELD_HISTORY_TRACKING_ENABLED]: true,
+            [FIELD_ANNOTATIONS.TRACK_HISTORY]: true,
           },
         },
         fieldWithoutHistoryTracking: {
           refType: Types.primitiveDataTypes.Text,
           annotations: {
             apiName: 'FieldWithoutHistoryTracking',
-            [FIELD_HISTORY_TRACKING_ENABLED]: false,
+            [FIELD_ANNOTATIONS.TRACK_HISTORY]: false,
           },
         },
       },
@@ -353,7 +353,7 @@ describe('History tracking filter', () => {
     it('should have the same output between onFetch and preDeploy=>onDeploy when enabling history tracking', async () => {
       const type = typeWithHistoryTrackedFields.clone()
       type.annotations[OBJECT_HISTORY_TRACKING_ENABLED] = false
-      type.fields.fieldWithHistoryTracking.annotations[FIELD_HISTORY_TRACKING_ENABLED] = false
+      type.fields.fieldWithHistoryTracking.annotations[FIELD_ANNOTATIONS.TRACK_HISTORY] = false
       const elements = [type]
       await filter.onFetch(elements)
 

--- a/packages/salesforce-adapter/test/filters/history_tracking.test.ts
+++ b/packages/salesforce-adapter/test/filters/history_tracking.test.ts
@@ -153,6 +153,13 @@ describe('historyTracking', () => {
         expect(getChangeData(changes[0]).annotations).toHaveProperty(OBJECT_HISTORY_TRACKING_ENABLED, true)
         expect(getChangeData(changes[0]).annotations).not.toHaveProperty(HISTORY_TRACKED_FIELDS)
       })
+      it('should add the trackHistory annotation to fields if the object type is new', async () => {
+        const changes = [toChange({ after: typeForPreDeploy(['SomeField'], ['SomeField', 'UntrackedField']) })]
+        await filter.preDeploy(changes)
+        expect(getChangeData(changes[0]).annotations).toHaveProperty(OBJECT_HISTORY_TRACKING_ENABLED, true)
+        expect(getChangeData(changes[0]).annotations).not.toHaveProperty(HISTORY_TRACKED_FIELDS)
+        expect(getChangeData(changes[0]).fields.SomeField.annotations).toHaveProperty('trackHistory', true)
+      })
       it('should add the enableHistory annotation if historyTrackedFields was modified', async () => {
         const before = typeForPreDeploy(['SomeField'], ['SomeField'])
         const changes = [toChange({ before, after: typeForPreDeploy([]) })]

--- a/packages/salesforce-adapter/test/filters/history_tracking.test.ts
+++ b/packages/salesforce-adapter/test/filters/history_tracking.test.ts
@@ -236,7 +236,7 @@ describe('historyTracking', () => {
         })
       })
     })
-    describe('When tracked fields are changed but the fields are not changed', () => {
+    describe('When tracked fields are changed but there are no explicit changes to the fields themselves', () => {
       const isFieldModificationChange = <T extends Change<unknown>>(change: T)
         : change is T & ModificationChange<Field> => (
           isFieldChange(change) && isModificationChange(change)


### PR DESCRIPTION
Keep a list of fields whose history is tracked at the object level instead of keeping Salesforce's per-field annotation.

- [x] Remove enableHistory annotation from object and use just the array
- [x] Tests for the preDeploy case where we create new changes
- [x] https://github.com/salto-io/tamir-sf/compare/e0e2db6992b5dcb0e54016afbd9c113b628835e6..1f69a1a8b01e10f56c2a96d2469f0c52a7c3c6ba
- [x] Infer the changes we need to add in onDeploy from field changes
- [x] Fix handling of object types that don't support history tracking

---

Salesforce enables history tracking per field + an additional "master switch" per object. This causes a lot of noise when deploying objects between environments where history tracking is enabled to environments where it's disabled (basically every single field is marked as modified). We want to make it easier to determine what the actual change is, so we centralize the list of tracked field as an annotation in the object and remove the per-field annotation. We do keep the object-level annotation to distinguish between situations where history tracking is disabled and situations where it's not supported (some objects don't support history tracking. On these objects there's no annotation at all).

[Workspace diff](https://github.com/salto-io/tomsellek-sf/pull/1/files)

---
_Release Notes_: 
Salesforce Adapter:
* Improved modelling of history tracking for custom objects

---
_User Notifications_: 
Salesforce Adapter:

* The annotation historyTrackedFields will be added to existing custom objects with history tracking enabled.
* The annotation enableHistory will be removed from all custom objects
* The annotation trackHistory will be removed from all custom fields
