### PR TITLE
SALTO-3109 - Salesforce: validate account settings against org wide defaults

### DIFF
--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -42,6 +42,7 @@ import animationRuleRecordType from './change_validators/animation_rule_recordty
 import duplicateRulesSortOrder from './change_validators/duplicate_rules_sort_order'
 import lastLayoutRemoval from './change_validators/last_layout_removal'
 import currencyIsoCodes from './change_validators/currency_iso_codes'
+import accountSettings from './change_validators/account_settings'
 import SalesforceClient from './client/client'
 import { ChangeValidatorName, SalesforceConfig } from './types'
 
@@ -82,6 +83,7 @@ export const changeValidators: Record<ChangeValidatorName, ChangeValidatorDefini
   duplicateRulesSortOrder: { creator: () => duplicateRulesSortOrder, ...defaultAlwaysRun },
   currencyIsoCodes: { creator: () => currencyIsoCodes, ...defaultAlwaysRun },
   lastLayoutRemoval: { creator: () => lastLayoutRemoval, ...defaultAlwaysRun },
+  accountSettings: { creator: () => accountSettings(), ...defaultAlwaysRun },
 }
 
 const createSalesforceChangeValidator = ({ config, isSandbox, checkOnly, client }: {

--- a/packages/salesforce-adapter/src/change_validators/account_settings.ts
+++ b/packages/salesforce-adapter/src/change_validators/account_settings.ts
@@ -1,0 +1,64 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { logger } from '@salto-io/logging'
+import { collections } from '@salto-io/lowerdash'
+import { ChangeError, ChangeValidator, getChangeData, InstanceElement, isAdditionOrModificationChange,
+  isInstanceElement } from '@salto-io/adapter-api'
+import { buildSelectQueries, isInstanceOfType, queryClient } from '../filters/utils'
+import { SalesforceRecord } from '../client/types'
+import SalesforceClient from '../client/client'
+
+const { awu } = collections.asynciterable
+const log = logger(module)
+
+const isRecordTypeInvalid = (globalSharingSettings: SalesforceRecord, instance: InstanceElement): boolean => (
+  globalSharingSettings.DefaultAccountAccess !== 'Read'
+  && instance.value.enableAccountOwnerReport !== undefined
+)
+
+const invalidRecordTypeError = (instance: InstanceElement): ChangeError => (
+  {
+    elemID: instance.elemID,
+    severity: 'Error',
+    message: 'You cannot set a value for AccountSettings.enableAccountOwnerReport unless your organization-wide sharing access level for Accounts is set to Private',
+    detailedMessage: `In ${instance.elemID.getFullName()}, enableAccountOwnerReport is set to '${instance.value.enableAccountOwnerReport}' but the organization-wide sharing access level for Accounts is not set to 'Private'.`,
+  }
+)
+
+const changeValidator = (client: SalesforceClient): ChangeValidator => async changes => {
+  const query = await buildSelectQueries('Organization', ['DefaultAccountAccess'])
+  const queryResult = await queryClient(client, query)
+
+  if (queryResult.length !== 1) {
+    log.error(`Expected a single Organization instance. Found ${queryResult ? queryResult.length : 0} instead`)
+    log.error('Unexpected Organization instances: %o', queryResult)
+    return []
+  }
+
+  const changedInstances = changes
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+    .filter(isInstanceElement)
+
+  return awu(changedInstances)
+    .filter(isInstanceOfType('AccountSettings'))
+    .filter(accountSettingsInstance => isRecordTypeInvalid(queryResult[0], accountSettingsInstance))
+    .map(invalidRecordTypeError)
+    .toArray()
+}
+
+export default changeValidator

--- a/packages/salesforce-adapter/src/change_validators/account_settings.ts
+++ b/packages/salesforce-adapter/src/change_validators/account_settings.ts
@@ -35,8 +35,9 @@ const invalidRecordTypeError = (instance: InstanceElement): ChangeError => (
   {
     elemID: instance.elemID,
     severity: 'Error',
-    message: 'You cannot set a value for AccountSettings.enableAccountOwnerReport unless your organization-wide sharing access level for Accounts is set to Private',
-    detailedMessage: `In ${instance.elemID.getFullName()}, enableAccountOwnerReport is set to '${instance.value.enableAccountOwnerReport}' but the organization-wide sharing access level for Accounts is not set to 'Private'.`,
+    message: 'Cannot set a value for \'enableAccountOwnerReport\' unless your organization-wide sharing access level for Accounts is set to Private',
+    detailedMessage: `enableAccountOwnerReport is set to '${instance.value.enableAccountOwnerReport}' but the organization-wide sharing access level for Accounts is not set to 'Private'.
+See https://help.salesforce.com/s/articleView?id=sf.admin_sharing.htm for instruction on how to change the organization-wide sharing defaults, or remove the 'enableAccountOwnerReport' value from ${instance.value.fullName}.`,
   }
 )
 

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -369,6 +369,7 @@ export const EMAIL_TEMPLATE_METADATA_TYPE = 'EmailTemplate'
 export const CUSTOM_METADATA = 'CustomMetadata'
 export const FLOW_DEFINITION_METADATA_TYPE = 'FlowDefinition'
 export const INSTALLED_PACKAGE_METADATA = 'InstalledPackage'
+export const ACCOUNT_SETTINGS_METADATA_TYPE = 'AccountSettings'
 export const ACTIVATE_RSS = 'activateRSS'
 
 // Artifitial Types

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -104,6 +104,7 @@ export type ChangeValidatorName = (
   | 'dataChange'
   | 'duplicateRulesSortOrder'
   | 'lastLayoutRemoval'
+  | 'accountSettings'
 )
 
 export type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
@@ -598,6 +599,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     currencyIsoCodes: { refType: BuiltinTypes.BOOLEAN },
     duplicateRulesSortOrder: { refType: BuiltinTypes.BOOLEAN },
     lastLayoutRemoval: { refType: BuiltinTypes.BOOLEAN },
+    accountSettings: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/salesforce-adapter/test/change_validators/account_settings.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/account_settings.test.ts
@@ -1,0 +1,84 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { toChange } from '@salto-io/adapter-api'
+import * as filterUtilsModule from '../../src/filters/utils'
+import { CUSTOM_OBJECT_ID_FIELD } from '../../src/constants'
+import { mockTypes } from '../mock_elements'
+import { createInstanceElement } from '../../src/transformers/transformer'
+import changeValidatorCreator from '../../src/change_validators/account_settings'
+import mockAdapter from '../adapter'
+
+jest.mock('../../src/filters/utils', () => ({
+  ...jest.requireActual('../../src/filters/utils'),
+  queryClient: jest.fn(),
+}))
+
+const mockedFilterUtils = jest.mocked(filterUtilsModule)
+
+const setMockQueryResult = (defaultAccountAccess: string): void => {
+  mockedFilterUtils.queryClient.mockResolvedValue([{
+    [CUSTOM_OBJECT_ID_FIELD]: 'SomeId',
+    DefaultAccountAccess: defaultAccountAccess,
+  }])
+}
+
+describe('Account settings validator', () => {
+  const instanceBefore = createInstanceElement({ fullName: 'whatever' }, mockTypes.AccountSettings)
+  const { client } = mockAdapter({})
+  const changeValidator = changeValidatorCreator(client)
+
+  describe('When the global setting is \'Private\'', () => {
+    beforeEach(() => {
+      setMockQueryResult('Read')
+    })
+
+    it('Should pass validation if enableAccountOwnerReport exists', async () => {
+      const instanceAfter = instanceBefore.clone()
+      instanceAfter.value.enableAccountOwnerReport = true
+      const change = toChange({ before: instanceBefore, after: instanceAfter })
+      const errors = await changeValidator([change])
+      expect(errors).toBeEmpty()
+    })
+    it('Should pass validation if enableAccountOwnerReport does not exist', async () => {
+      const instanceAfter = instanceBefore.clone()
+      const change = toChange({ before: instanceBefore, after: instanceAfter })
+      const errors = await changeValidator([change])
+      expect(errors).toBeEmpty()
+    })
+  })
+
+  describe('When the global setting is not \'Private\'', () => {
+    beforeEach(() => {
+      setMockQueryResult('Edit')
+    })
+
+    it('Should fail validation if enableAccountOwnerReport exists', async () => {
+      const instanceAfter = instanceBefore.clone()
+      instanceAfter.value.enableAccountOwnerReport = true
+      const change = toChange({ before: instanceBefore, after: instanceAfter })
+      const errors = await changeValidator([change])
+      expect(errors).toHaveLength(1)
+      expect(errors).toIncludeAllPartialMembers([{ elemID: instanceBefore.elemID }])
+    })
+    it('Should pass validation if enableAccountOwnerReport does not exist', async () => {
+      const instanceAfter = instanceBefore.clone()
+      const change = toChange({ before: instanceBefore, after: instanceAfter })
+      const errors = await changeValidator([change])
+      expect(errors).toBeEmpty()
+    })
+  })
+})

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -419,6 +419,18 @@ export const mockTypes = {
       },
     },
   }),
+  AccountSettings: new ObjectType({
+    elemID: new ElemID(SALESFORCE, 'AccountSettings'),
+    fields: {
+      enableAccountOwnerReport: {
+        refType: BuiltinTypes.BOOLEAN,
+      },
+    },
+    annotations: {
+      metadataType: 'AccountSettings',
+    },
+    isSettings: true,
+  }),
 }
 
 export const lwcJsResourceContent = "import { LightningElement } from 'lwc';\nexport default class BikeCard extends LightningElement {\n   name = 'Electra X4';\n   description = 'A sweet bike built for comfort.';\n   category = 'Mountain';\n   material = 'Steel';\n   price = '$2,700';\n   pictureUrl = 'https://s3-us-west-1.amazonaws.com/sfdc-demo/ebikes/electrax4.jpg';\n }"


### PR DESCRIPTION
Add a change validator for AccountSettings.enableAccountOwnerReport. This field may only exist if the global account sharing policy is 'Private'

- [x] Merge filter part (https://github.com/salto-io/salto/pull/3929)
- [x] Merge noise suppression (https://github.com/salto-io/salto_private/pull/5050)
---

The actual value of the global account sharing setting is 'Read', 'Edit', etc. It is never actually set to 'Private' in the API data, but rather translated to other values (including 'Private') in the Salesforce UI.

---
_Release Notes_: 
Salesforce: Improved pre-deploy validation of account settings.

---
_User Notifications_: 
N/A
