### PR TITLE
SALTO-3502: Jira increase workflow deployment robustness

### DIFF
--- a/packages/jira-adapter/src/filters/workflow/workflow_modification_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_modification_filter.ts
@@ -150,7 +150,8 @@ const deployWorkflowModification = async ({
     })
   } catch (err) {
     await cleanTempInstance()
-    if (err.response?.data?.errorMessages?.some((message: string) => message.includes('is missing the mappings required for statuses with'))) {
+    if (err instanceof clientUtils.HTTPError && Array.isArray(err.response.data.errorMessages)
+      && err.response?.data?.errorMessages?.some((message: string) => message.includes('is missing the mappings required for statuses with'))) {
       throw new Error(`Modification to an active workflow ${getChangeData(change).elemID.getFullName()} is not backward compatible`)
     }
     throw err
@@ -165,7 +166,7 @@ const deployWorkflowModification = async ({
   } catch (err) {
     await cleanTempInstance()
     // if the workflow is active it means the env is not updated, as we remove known active associations
-    if (err.response?.data?.errorMessages?.some((message: string) => message.includes('Cannot delete an active workflow'))) {
+    if (err instanceof clientUtils.HTTPError && Array.isArray(err.response.data.errorMessages)) {
       throw new Error(`The environment is not synced to the Jira Service for ${getChangeData(change).elemID.getFullName()}, run fetch and try again`)
     }
     throw err

--- a/packages/jira-adapter/src/filters/workflow/workflow_modification_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_modification_filter.ts
@@ -76,6 +76,7 @@ const deployWorkflowModification = async ({
   const originalInstance = getChangeData(change)
   const tempInstance = originalInstance.clone()
   tempInstance.value.name = `${tempInstance.value.name}-${uuidv4()}`
+  delete tempInstance.value.entityId
 
   const idToWorkflowSchemes = _.keyBy(
     workflowSchemes,
@@ -93,22 +94,24 @@ const deployWorkflowModification = async ({
     .filter(values.isDefined)
     .toArray()
 
-  const cleanTempInstance = async (): Promise<void> => {
-    await awu(workflowSchemesWithTemp).forEach(async schemeWithTemp => {
-      const scheme = idToWorkflowSchemes[schemeWithTemp.elemID.getFullName()]
-      await preDeployWorkflowScheme(scheme, 'modify', elementsSource)
-      try {
-        await deployWorkflowScheme(
-          toChange({ before: schemeWithTemp, after: scheme }),
-          client,
-          paginator,
-          config,
-          elementsSource,
-        )
-      } catch (err) {
-        log.error(`Error while cleaning up temp workflow ${tempInstance.elemID.getFullName()} from workflow scheme ${scheme.elemID.getFullName()}: ${err}`)
-      }
-    })
+  const cleanTempInstance = async (cleanSchemes = true): Promise<void> => {
+    if (cleanSchemes) {
+      await awu(workflowSchemesWithTemp).forEach(async schemeWithTemp => {
+        const scheme = idToWorkflowSchemes[schemeWithTemp.elemID.getFullName()]
+        await preDeployWorkflowScheme(scheme, 'modify', elementsSource)
+        try {
+          await deployWorkflowScheme(
+            toChange({ before: schemeWithTemp, after: scheme }),
+            client,
+            paginator,
+            config,
+            elementsSource,
+          )
+        } catch (err) {
+          log.error(`Error while cleaning up temp workflow ${tempInstance.elemID.getFullName()} from workflow scheme ${scheme.elemID.getFullName()}: ${err}`)
+        }
+      })
+    }
 
     try {
       await deployWorkflow(
@@ -121,11 +124,17 @@ const deployWorkflowModification = async ({
     }
   }
 
-  await deployWorkflow(
-    toChange({ after: tempInstance }) as AdditionChange<InstanceElement>,
-    client,
-    config
-  )
+  try {
+    await deployWorkflow(
+      toChange({ after: tempInstance }) as AdditionChange<InstanceElement>,
+      client,
+      config
+    )
+  } catch (err) {
+    // adding a temp workflow can fail in the deploy triggers stage, after the workflow was created
+    await cleanTempInstance(false)
+    throw err
+  }
 
   try {
     await awu(workflowSchemesWithTemp).forEach(async schemeWithTemp => {
@@ -147,11 +156,20 @@ const deployWorkflowModification = async ({
     throw err
   }
 
-  await deployWorkflow(
-    toChange({ before: change.data.before }) as RemovalChange<InstanceElement>,
-    client,
-    config
-  )
+  try {
+    await deployWorkflow(
+      toChange({ before: change.data.before }) as RemovalChange<InstanceElement>,
+      client,
+      config
+    )
+  } catch (err) {
+    await cleanTempInstance()
+    // if the workflow is active it means the env is not updated, as we remove known active associations
+    if (err.response?.data?.errorMessages?.some((message: string) => message.includes('Cannot delete an active workflow'))) {
+      throw new Error(`The environment is not synced to the Jira Service for ${getChangeData(change).elemID.getFullName()}, run fetch and try again`)
+    }
+    throw err
+  }
 
   await deployWorkflow(
     toChange({ after: change.data.after }) as AdditionChange<InstanceElement>,

--- a/packages/jira-adapter/test/filters/workflow/workflow_modification_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_modification_filter.test.ts
@@ -287,13 +287,12 @@ describe('workflowModificationFilter', () => {
     })
 
     it('should throw when change is not backward compatible', async () => {
-      deployWorkflowSchemeMock.mockRejectedValueOnce({
-        response: {
-          data: {
-            errorMessages: ['is missing the mappings required for statuses with'],
-          },
+      deployWorkflowSchemeMock.mockRejectedValueOnce(new clientUtils.HTTPError('message', {
+        status: 400,
+        data: {
+          errorMessages: ['is missing the mappings required for statuses with'],
         },
-      })
+      }))
 
       deployWorkflowMock.mockResolvedValueOnce()
       deployWorkflowMock.mockRejectedValueOnce(new Error('error'))
@@ -309,13 +308,12 @@ describe('workflowModificationFilter', () => {
     })
 
     it('should clean when failure in deploy of temp instance', async () => {
-      deployWorkflowMock.mockRejectedValueOnce({
-        response: {
-          data: {
-            errorMessages: ['some error'],
-          },
+      deployWorkflowMock.mockRejectedValueOnce(new clientUtils.HTTPError('message', {
+        status: 400,
+        data: {
+          errorMessages: ['some error'],
         },
-      })
+      }))
       await filter.deploy([change])
 
       expectCreateOfTempWorkflow(1)
@@ -343,13 +341,12 @@ describe('workflowModificationFilter', () => {
 
     it('should clean when failure in deploy of the actual instance', async () => {
       deployWorkflowMock.mockResolvedValueOnce()
-      deployWorkflowMock.mockRejectedValueOnce({
-        response: {
-          data: {
-            errorMessages: ['Cannot delete an active workflow'],
-          },
+      deployWorkflowMock.mockRejectedValueOnce(new clientUtils.HTTPError('message', {
+        status: 400,
+        data: {
+          errorMessages: ['Cannot delete an active workflow'],
         },
-      })
+      }))
       const res = await filter.deploy([change])
 
       expect(res.deployResult.errors).toEqual([new Error('Deployment of jira.Workflow.instance.workflowInstance failed: Error: The environment is not synced to the Jira Service for jira.Workflow.instance.workflowInstance, run fetch and try again')])

--- a/packages/jira-adapter/test/filters/workflow/workflow_modification_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_modification_filter.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ElemID, InstanceElement, ObjectType, toChange, ReferenceExpression, ReadOnlyElementsSource, CORE_ANNOTATIONS, ListType, Field, BuiltinTypes } from '@salto-io/adapter-api'
+import { ElemID, InstanceElement, ObjectType, toChange, ReferenceExpression, ReadOnlyElementsSource, CORE_ANNOTATIONS, ListType, Field, BuiltinTypes, Change } from '@salto-io/adapter-api'
 import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import _ from 'lodash'
@@ -48,7 +48,9 @@ describe('workflowModificationFilter', () => {
   let workflowStatusType: ObjectType
   let workflowSchemeType: ObjectType
   let workflowInstance: InstanceElement
+  let workflowBeforeInstance: InstanceElement
   let workflowSchemeInstance: InstanceElement
+  let newWorkflowSchemeInstance: InstanceElement
   let client: JiraClient
   let config: JiraConfig
 
@@ -79,6 +81,13 @@ describe('workflowModificationFilter', () => {
         name: 'workflowName',
       }
     )
+    workflowBeforeInstance = new InstanceElement(
+      'workflowInstance',
+      workflowType,
+      {
+        name: 'workflowName2',
+      }
+    )
 
     workflowSchemeInstance = new InstanceElement(
       'workflowSchemeInstance',
@@ -92,10 +101,11 @@ describe('workflowModificationFilter', () => {
       }
     )
 
-    const newWorkflowSchemeInstance = new InstanceElement(
+    newWorkflowSchemeInstance = new InstanceElement(
       'newWorkflowSchemeInstance',
       workflowSchemeType,
       {
+        id: '2',
         defaultWorkflow: new ReferenceExpression(
           workflowInstance.elemID,
           workflowInstance,
@@ -140,85 +150,143 @@ describe('workflowModificationFilter', () => {
     const deployWorkflowSchemeMock = deployWorkflowScheme as jest.MockedFunction<
       typeof deployWorkflowScheme
     >
+    let change: Change<InstanceElement>
+    let tempInstance: InstanceElement
+    let tempSchemeInstance: InstanceElement
+    let tempNewSchemeInstance: InstanceElement
+    let schemeInstance: InstanceElement
+    let newSchemeInstance: InstanceElement
 
-    beforeEach(() => {
-      deployWorkflowMock.mockClear()
-      deployWorkflowSchemeMock.mockClear()
-    })
-    it('should deploy the modified workflow', async () => {
-      const change = toChange({
-        before: workflowInstance,
-        after: workflowInstance,
-      })
-
-      await filter.deploy([change])
-
-      const tempInstance = workflowInstance.clone()
-
-      tempInstance.value.name = 'workflowName-uuid'
-      expect(deployWorkflowMock).toHaveBeenNthCalledWith(
-        1,
-        toChange({ after: tempInstance }),
-        client,
-        config,
-      )
-
-      const tempSchemeInstance = workflowSchemeInstance.clone()
-      tempSchemeInstance.value.defaultWorkflow = new ReferenceExpression(
-        tempInstance.elemID,
-        tempInstance,
-      )
-      tempSchemeInstance.value.updateDraftIfNeeded = true
+    const expectSchemeChangeToTemp = (callNum: number): void => {
       expect(deployWorkflowSchemeMock).toHaveBeenNthCalledWith(
-        1,
+        callNum,
         toChange({ before: workflowSchemeInstance, after: tempSchemeInstance }),
         client,
         paginator,
         config,
         elementsSource,
       )
+    }
 
-      expect(deployWorkflowMock).toHaveBeenNthCalledWith(
-        2,
-        toChange({ before: workflowInstance }),
-        client,
-        config,
-      )
-
-      expect(deployWorkflowMock).toHaveBeenNthCalledWith(
-        3,
-        toChange({ after: workflowInstance }),
-        client,
-        config,
-      )
-
-      const schemeInstance = workflowSchemeInstance.clone()
-      schemeInstance.value.updateDraftIfNeeded = true
+    const expectNewSchemeChangeToTemp = (callNum: number): void => {
       expect(deployWorkflowSchemeMock).toHaveBeenNthCalledWith(
-        2,
+        callNum,
+        toChange({ before: newWorkflowSchemeInstance, after: tempNewSchemeInstance }),
+        client,
+        paginator,
+        config,
+        elementsSource,
+      )
+    }
+
+    const expectSchemeChangeBack = (callNum: number): void => {
+      expect(deployWorkflowSchemeMock).toHaveBeenNthCalledWith(
+        callNum,
         toChange({ before: tempSchemeInstance, after: schemeInstance }),
         client,
         paginator,
         config,
         elementsSource,
       )
+    }
 
-      expect(deployWorkflowSchemeMock).toHaveBeenCalledTimes(2)
+    const expectNewSchemeChangeBack = (callNum: number): void => {
+      expect(deployWorkflowSchemeMock).toHaveBeenNthCalledWith(
+        callNum,
+        toChange({ before: tempNewSchemeInstance, after: newSchemeInstance }),
+        client,
+        paginator,
+        config,
+        elementsSource,
+      )
+    }
 
+    const expectCreateOfTempWorkflow = (callNum: number): void => {
       expect(deployWorkflowMock).toHaveBeenNthCalledWith(
-        4,
+        callNum,
+        toChange({ after: tempInstance }),
+        client,
+        config,
+      )
+    }
+
+    const expectDeleteOfBeforeWorkflow = (callNum: number): void => {
+      expect(deployWorkflowMock).toHaveBeenNthCalledWith(
+        callNum,
+        toChange({ before: workflowBeforeInstance }),
+        client,
+        config,
+      )
+    }
+
+    const expectCreateOfNewWorkflow = (callNum: number): void => {
+      expect(deployWorkflowMock).toHaveBeenNthCalledWith(
+        callNum,
+        toChange({ after: workflowInstance }),
+        client,
+        config,
+      )
+    }
+
+    const expectDeleteOfTempWorkflow = (callNum: number): void => {
+      expect(deployWorkflowMock).toHaveBeenNthCalledWith(
+        callNum,
         toChange({ before: tempInstance }),
         client,
         config,
       )
+    }
+
+    beforeEach(() => {
+      deployWorkflowMock.mockClear()
+      deployWorkflowSchemeMock.mockClear()
+      change = toChange({
+        before: workflowBeforeInstance,
+        after: workflowInstance,
+      })
+      tempInstance = workflowInstance.clone()
+      tempInstance.value.name = 'workflowName-uuid'
+
+      schemeInstance = workflowSchemeInstance.clone()
+      schemeInstance.value.updateDraftIfNeeded = true
+      schemeInstance.value.issueTypeMappings = {}
+
+      newSchemeInstance = newWorkflowSchemeInstance.clone()
+      newSchemeInstance.value.updateDraftIfNeeded = true
+      newSchemeInstance.value.issueTypeMappings = {}
+
+      tempSchemeInstance = workflowSchemeInstance.clone()
+      tempSchemeInstance.value.defaultWorkflow = new ReferenceExpression(
+        tempInstance.elemID,
+        tempInstance,
+      )
+      tempSchemeInstance.value.updateDraftIfNeeded = true
+      tempSchemeInstance.value.issueTypeMappings = {}
+
+      tempNewSchemeInstance = newWorkflowSchemeInstance.clone()
+      tempNewSchemeInstance.value.defaultWorkflow = new ReferenceExpression(
+        tempInstance.elemID,
+        tempInstance,
+      )
+      tempNewSchemeInstance.value.updateDraftIfNeeded = true
+      tempNewSchemeInstance.value.issueTypeMappings = {}
+    })
+    it('should deploy the modified workflow', async () => {
+      await filter.deploy([change])
+      expectCreateOfTempWorkflow(1)
+      expectDeleteOfBeforeWorkflow(2)
+      expectCreateOfNewWorkflow(3)
+      expectDeleteOfTempWorkflow(4)
+      expectSchemeChangeToTemp(1)
+      expectNewSchemeChangeToTemp(2)
+      expectSchemeChangeBack(3)
+      expectNewSchemeChangeBack(4)
+
+      expect(deployWorkflowSchemeMock).toHaveBeenCalledTimes(4)
+      expect(deployWorkflowMock).toHaveBeenCalledTimes(4)
     })
 
     it('should throw when change is not backward compatible', async () => {
-      const change = toChange({
-        before: workflowInstance,
-        after: workflowInstance,
-      })
-
       deployWorkflowSchemeMock.mockRejectedValueOnce({
         response: {
           data: {
@@ -234,104 +302,81 @@ describe('workflowModificationFilter', () => {
 
       expect(res.deployResult.errors).toEqual([new Error('Deployment of jira.Workflow.instance.workflowInstance failed: Error: Modification to an active workflow jira.Workflow.instance.workflowInstance is not backward compatible')])
 
-      const tempInstance = workflowInstance.clone()
+      expectCreateOfTempWorkflow(1)
+      expectDeleteOfTempWorkflow(2)
+      expectSchemeChangeToTemp(1)
+      expectSchemeChangeBack(2)
+    })
 
-      tempInstance.value.name = 'workflowName-uuid'
-      expect(deployWorkflowMock).toHaveBeenNthCalledWith(
-        1,
-        toChange({ after: tempInstance }),
-        client,
-        config,
-      )
+    it('should clean when failure in deploy of temp instance', async () => {
+      deployWorkflowMock.mockRejectedValueOnce({
+        response: {
+          data: {
+            errorMessages: ['some error'],
+          },
+        },
+      })
+      await filter.deploy([change])
 
-      const tempSchemeInstance = workflowSchemeInstance.clone()
-      tempSchemeInstance.value.defaultWorkflow = new ReferenceExpression(
-        tempInstance.elemID,
-        tempInstance,
-      )
-      tempSchemeInstance.value.updateDraftIfNeeded = true
-      expect(deployWorkflowSchemeMock).toHaveBeenNthCalledWith(
-        1,
-        toChange({ before: workflowSchemeInstance, after: tempSchemeInstance }),
-        client,
-        paginator,
-        config,
-        elementsSource,
-      )
+      expectCreateOfTempWorkflow(1)
+      expectDeleteOfTempWorkflow(2)
+      expect(deployWorkflowMock).toHaveBeenCalledTimes(2)
+      expect(deployWorkflowSchemeMock).toHaveBeenCalledTimes(0)
+    })
+    it('should clean when failure in deploy of the actual instance not related to sync', async () => {
+      deployWorkflowMock.mockResolvedValueOnce()
+      deployWorkflowMock.mockRejectedValueOnce({
+        response: {
+          data: {
+            errorMessages: ['Other error'],
+          },
+        },
+      })
+      await filter.deploy([change])
+      expectDeleteOfTempWorkflow(3)
+      expectSchemeChangeBack(3)
+      expectNewSchemeChangeBack(4)
 
-      const schemeInstance = workflowSchemeInstance.clone()
-      schemeInstance.value.updateDraftIfNeeded = true
-      expect(deployWorkflowSchemeMock).toHaveBeenNthCalledWith(
-        2,
-        toChange({ before: tempSchemeInstance, after: schemeInstance }),
-        client,
-        paginator,
-        config,
-        elementsSource,
-      )
+      expect(deployWorkflowMock).toHaveBeenCalledTimes(3)
+      expect(deployWorkflowSchemeMock).toHaveBeenCalledTimes(4)
+    })
 
-      expect(deployWorkflowMock).toHaveBeenNthCalledWith(
-        2,
-        toChange({ before: tempInstance }),
-        client,
-        config,
-      )
+    it('should clean when failure in deploy of the actual instance', async () => {
+      deployWorkflowMock.mockResolvedValueOnce()
+      deployWorkflowMock.mockRejectedValueOnce({
+        response: {
+          data: {
+            errorMessages: ['Cannot delete an active workflow'],
+          },
+        },
+      })
+      const res = await filter.deploy([change])
+
+      expect(res.deployResult.errors).toEqual([new Error('Deployment of jira.Workflow.instance.workflowInstance failed: Error: The environment is not synced to the Jira Service for jira.Workflow.instance.workflowInstance, run fetch and try again')])
+
+      expectCreateOfTempWorkflow(1)
+      expectDeleteOfBeforeWorkflow(2)
+      expectDeleteOfTempWorkflow(3)
+      expectSchemeChangeToTemp(1)
+      expectNewSchemeChangeToTemp(2)
+      expectSchemeChangeBack(3)
+      expectNewSchemeChangeBack(4)
+
+      expect(deployWorkflowMock).toHaveBeenCalledTimes(3)
+      expect(deployWorkflowSchemeMock).toHaveBeenCalledTimes(4)
     })
 
     it('should cleanup when there was an error', async () => {
-      const change = toChange({
-        before: workflowInstance,
-        after: workflowInstance,
-      })
-
       deployWorkflowSchemeMock.mockRejectedValue(new Error('some error'))
 
       const res = await filter.deploy([change])
 
       expect(res.deployResult.errors).toHaveLength(1)
 
-      const tempInstance = workflowInstance.clone()
-
-      tempInstance.value.name = 'workflowName-uuid'
-      expect(deployWorkflowMock).toHaveBeenNthCalledWith(
-        1,
-        toChange({ after: tempInstance }),
-        client,
-        config,
-      )
-
-      const tempSchemeInstance = workflowSchemeInstance.clone()
-      tempSchemeInstance.value.defaultWorkflow = new ReferenceExpression(
-        tempInstance.elemID,
-        tempInstance,
-      )
-      tempSchemeInstance.value.updateDraftIfNeeded = true
-      expect(deployWorkflowSchemeMock).toHaveBeenNthCalledWith(
-        1,
-        toChange({ before: workflowSchemeInstance, after: tempSchemeInstance }),
-        client,
-        paginator,
-        config,
-        elementsSource,
-      )
-
-      const schemeInstance = workflowSchemeInstance.clone()
-      schemeInstance.value.updateDraftIfNeeded = true
-      expect(deployWorkflowSchemeMock).toHaveBeenNthCalledWith(
-        2,
-        toChange({ before: tempSchemeInstance, after: schemeInstance }),
-        client,
-        paginator,
-        config,
-        elementsSource,
-      )
-
-      expect(deployWorkflowMock).toHaveBeenNthCalledWith(
-        2,
-        toChange({ before: tempInstance }),
-        client,
-        config,
-      )
+      expectCreateOfTempWorkflow(1)
+      expectDeleteOfTempWorkflow(2)
+      expectSchemeChangeToTemp(1)
+      expectSchemeChangeBack(2)
     })
   })
 })


### PR DESCRIPTION
_Handled cases in which workflow deployment fails and were not properly handled_

---

_Additional context for reviewer_

As a general context  workflows cannot be edited in Jira’s API. We have to delete them and create new ones. Also, active workflows cannot be deleted, so we have to make changes to the scheme references.
We do it by
1. Creating a duplicate of the new workflow (a.k.a temp workflow)
2. Deploying the temp workflow
3.  Switching the relevant schemes to point to the temp workflow
4. Deleting the original old workflow (must be before stage 5 as they have the same name)
5. Deploying the new workflow
6. Switching back the schemes to point to the new workflow
7. deleting the temporary workflows

Failures to steps 2, 4 were not handled before
---
_Release Notes_: 
Jira Adapter:
Fixed a bug which could cause duplicate workflows in case of a deployment error

---
_User Notifications_: 
None
