### PR TITLE
SALTO-3141: Fix local warning message

### DIFF
--- a/packages/jira-adapter/src/filters/locale.ts
+++ b/packages/jira-adapter/src/filters/locale.ts
@@ -52,7 +52,7 @@ const filter: FilterCreator = ({ client }) => ({
         return {
           errors: [
             {
-              message: 'Your Jira Data Center instance is set to a non-English language. Salto currently only supports accessing Jira DC through users with their default language set to English. Please change the user’s language, or create another user with English as its Jira language, and change Salto\'s credentials to use it. After doing that, make sure you re-fetch your environment using an advanced fetch, with “Regenerate Salto IDs” turned on. You only need to do this once. For help on how to change Jira users\' language, go to https://confluence.atlassian.com/adminjiraserver/choosing-a-default-language-938847001.html',
+              message: 'Your Jira Data Center instance is not set to English-US language. Salto currently only supports accessing Jira DC through users with their default language set to English-US. Please change the user’s language, or create another user with English as its Jira language, and change Salto\'s credentials to use it. After doing that, make sure you re-fetch your environment using an advanced fetch, with “Regenerate Salto IDs” turned on. You only need to do this once. For help on how to change Jira users\' language, go to https://confluence.atlassian.com/adminjiraserver/choosing-a-default-language-938847001.html',
               severity: 'Warning',
             },
           ],

--- a/packages/jira-adapter/test/filters/locale.test.ts
+++ b/packages/jira-adapter/test/filters/locale.test.ts
@@ -46,7 +46,7 @@ describe('localeFilter', () => {
       const filterRes = await filter.onFetch([])
       expect(filterRes).toEqual({
         errors: [{
-          message: 'Your Jira Data Center instance is set to a non-English language. Salto currently only supports accessing Jira DC through users with their default language set to English. Please change the user’s language, or create another user with English as its Jira language, and change Salto\'s credentials to use it. After doing that, make sure you re-fetch your environment using an advanced fetch, with “Regenerate Salto IDs” turned on. You only need to do this once. For help on how to change Jira users\' language, go to https://confluence.atlassian.com/adminjiraserver/choosing-a-default-language-938847001.html',
+          message: 'Your Jira Data Center instance is not set to English-US language. Salto currently only supports accessing Jira DC through users with their default language set to English-US. Please change the user’s language, or create another user with English as its Jira language, and change Salto\'s credentials to use it. After doing that, make sure you re-fetch your environment using an advanced fetch, with “Regenerate Salto IDs” turned on. You only need to do this once. For help on how to change Jira users\' language, go to https://confluence.atlassian.com/adminjiraserver/choosing-a-default-language-938847001.html',
           severity: 'Warning',
         }],
       })


### PR DESCRIPTION
Fixed the warning message to be US specific

---
_Release Notes_: 
None

---
_User Notifications_: 
None
