### PR TITLE
SALTO-3247: Increased Salesforce data default retry attempts

### DIFF
--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -239,7 +239,7 @@ For more details see the DeployOptions section in the [salesforce documentation 
 
 | Name              | Default when undefined                                  | Description                           |
 |-------------------|---------------------------------------------------------|---------------------------------------|
-| maxAttempts       | `3`                                                     | Max attempts to deploy data instances |
+| maxAttempts       | `5`                                                     | Max attempts to deploy data instances |
 | retryDelay        | `1000`                                                  | Delay (in millis) between each retry  |
 | retryableFailures | `FIELD_CUSTOM_VALIDATION_EXCEPTION, UNABLE_TO_LOCK_ROW` | Error messages for which to retry     |
 | 

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -311,7 +311,7 @@ export const MAXIMUM_MAX_ITEMS_IN_RETRIEVE_REQUEST = 10000
 export const MAX_QUERY_LENGTH = 2000
 export const DEFAULT_ENUM_FIELD_PERMISSIONS = true
 export const DEFAULT_CUSTOM_OBJECTS_DEFAULT_RETRY_OPTIONS = {
-  maxAttempts: 3,
+  maxAttempts: 5,
   retryDelay: 1000,
   retryableFailures: [
     'FIELD_CUSTOM_VALIDATION_EXCEPTION',


### PR DESCRIPTION
Increased maxAttempts from 3 to 5. Updated docs.

---

_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
