### PR TITLE
SALTO-3480: bring license information

### DIFF
--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1497,7 +1497,6 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
   ApplicationRole: {
     transformation: {
       fieldsToOmit: [
-        { fieldName: 'userCount' },
         { fieldName: 'remainingSeats' },
         { fieldName: 'groupDetails' },
         { fieldName: 'defaultGroupsDetails' },

--- a/packages/jira-adapter/src/filters/account_info.ts
+++ b/packages/jira-adapter/src/filters/account_info.ts
@@ -24,7 +24,10 @@ import JiraClient from '../client/client'
 
 const log = logger(module)
 
-const createAccountTypes = (): ObjectType[] => {
+const createAccountTypes = ():
+  {accountInfoType: ObjectType
+  licenseType: ObjectType
+  licensedApplications: ObjectType} => {
   const licensedApplications = new ObjectType({
     elemID: new ElemID(JIRA, LICENSED_APPLICATION_TYPE),
     isSettings: true,
@@ -56,7 +59,7 @@ const createAccountTypes = (): ObjectType[] => {
       [CORE_ANNOTATIONS.HIDDEN]: true,
     },
   })
-  return [accountInfoType, licenseType, licensedApplications]
+  return { accountInfoType, licenseType, licensedApplications }
 }
 
 type LicenseResponse = {
@@ -127,7 +130,7 @@ const getAccountInfo = async (client: JiraClient, accountInfoType: ObjectType): 
 const filter: FilterCreator = ({ client }) => ({
   name: 'accountInfo',
   onFetch: async elements => log.time(async () => {
-    const [accountInfoType, licenseType, licensedApplications] = createAccountTypes()
+    const { accountInfoType, licenseType, licensedApplications } = createAccountTypes()
     try {
       elements.push(licenseType, licensedApplications, accountInfoType, await getAccountInfo(client, accountInfoType))
     } catch (e) {
@@ -144,8 +147,7 @@ const filter: FilterCreator = ({ client }) => ({
       .filter(isInstanceElement)
     log.info('jira user count is: %s',
       applicationRoles
-        .filter(role => role.value.key === 'jira-software')
-        .map(role => role.value.userCount)[0] ?? 'unknown')
+        .find(role => role.value.key === 'jira-software')?.value.userCount ?? 'unknown')
     applicationRoles
       .forEach(role => {
         delete role.value.userCount

--- a/packages/jira-adapter/src/filters/account_info.ts
+++ b/packages/jira-adapter/src/filters/account_info.ts
@@ -93,6 +93,9 @@ const getDCLicense = async (client: JiraClient): Promise<Value> => {
     throw new Error('Received an invalid dc license response')
   }
   delete response.data.rawLicense
+  delete response.data.organizationName
+  delete response.data.supportEntitlementNumber
+
   log.info(`jira license (type dc) is: ${safeJsonStringify(response.data)}`)
   return {
     applications: [{

--- a/packages/jira-adapter/src/filters/account_info.ts
+++ b/packages/jira-adapter/src/filters/account_info.ts
@@ -17,45 +17,47 @@ import { logger } from '@salto-io/logging'
 import Joi from 'joi'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { createSchemeGuard, safeJsonStringify } from '@salto-io/adapter-utils'
-import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, isInstanceElement, ListType, ObjectType } from '@salto-io/adapter-api'
-import JiraClient from '../client/client'
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, isInstanceElement, ListType, ObjectType, Value } from '@salto-io/adapter-api'
 import { FilterCreator } from '../filter'
 import { ACCOUNT_INFO_TYPE, JIRA, LICENSED_APPLICATION_TYPE, LICENSE_TYPE } from '../constants'
+import JiraClient from '../client/client'
 
 const log = logger(module)
 
-const licensedApplications = new ObjectType({
-  elemID: new ElemID(JIRA, LICENSED_APPLICATION_TYPE),
-  isSettings: true,
-  fields: {
-    id: { refType: BuiltinTypes.STRING },
-    plan: { refType: BuiltinTypes.STRING },
-  },
-  annotations: {
-    [CORE_ANNOTATIONS.HIDDEN]: true,
-  },
-})
-const licenseType = new ObjectType({
-  elemID: new ElemID(JIRA, LICENSE_TYPE),
-  isSettings: true,
-  fields: {
-    applications: { refType: new ListType(licensedApplications) },
-  },
-  annotations: {
-    [CORE_ANNOTATIONS.HIDDEN]: true,
-  },
-})
-export const accountInfoType = new ObjectType({
-  elemID: new ElemID(JIRA, ACCOUNT_INFO_TYPE),
-  isSettings: true,
-  fields: {
-    license: { refType: new ListType(licenseType) },
-  },
-  annotations: {
-    [CORE_ANNOTATIONS.HIDDEN]: true,
-  },
-})
-
+const createAccountTypes = (): ObjectType[] => {
+  const licensedApplications = new ObjectType({
+    elemID: new ElemID(JIRA, LICENSED_APPLICATION_TYPE),
+    isSettings: true,
+    fields: {
+      id: { refType: BuiltinTypes.STRING },
+      plan: { refType: BuiltinTypes.STRING },
+    },
+    annotations: {
+      [CORE_ANNOTATIONS.HIDDEN]: true,
+    },
+  })
+  const licenseType = new ObjectType({
+    elemID: new ElemID(JIRA, LICENSE_TYPE),
+    isSettings: true,
+    fields: {
+      applications: { refType: new ListType(licensedApplications) },
+    },
+    annotations: {
+      [CORE_ANNOTATIONS.HIDDEN]: true,
+    },
+  })
+  const accountInfoType = new ObjectType({
+    elemID: new ElemID(JIRA, ACCOUNT_INFO_TYPE),
+    isSettings: true,
+    fields: {
+      license: { refType: new ListType(licenseType) },
+    },
+    annotations: {
+      [CORE_ANNOTATIONS.HIDDEN]: true,
+    },
+  })
+  return [accountInfoType, licenseType, licensedApplications]
+}
 
 type LicenseResponse = {
   applications: [{
@@ -73,29 +75,17 @@ const LICENSE_RESPONSE_SCHEME = Joi.object({
 
 const isLicenseResponse = createSchemeGuard<LicenseResponse>(LICENSE_RESPONSE_SCHEME, 'Received an invalid license response')
 
-const getCloudLicense = async (client: JiraClient): Promise<InstanceElement> => {
+const getCloudLicense = async (client: JiraClient): Promise<Value> => {
   const response = await client.getSinglePage({
     url: '/rest/api/3/instance/license',
   })
   if (!isLicenseResponse(response.data)) {
     throw new Error('Received an invalid license response')
   }
-  const accountInfoInstance = new InstanceElement(
-    ElemID.CONFIG_NAME,
-    accountInfoType,
-    {
-      license: {
-        applications: response.data.applications,
-      },
-    },
-    undefined,
-    { [CORE_ANNOTATIONS.HIDDEN]: true },
-  )
-  log.info(`jira license is: ${safeJsonStringify(response.data)}`)
-  return accountInfoInstance
+  log.info(`jira license (type cloud) is: ${safeJsonStringify(response.data)}`)
+  return { applications: response.data.applications }
 }
-
-const getDCLicense = async (client: JiraClient): Promise<InstanceElement> => {
+const getDCLicense = async (client: JiraClient): Promise<Value> => {
   const response = await client.getSinglePage({
     url: '/rest/plugins/applications/1.0/installed/jira-software/license',
   })
@@ -103,25 +93,29 @@ const getDCLicense = async (client: JiraClient): Promise<InstanceElement> => {
     throw new Error('Received an invalid dc license response')
   }
   delete response.data.rawLicense
+  log.info(`jira license (type dc) is: ${safeJsonStringify(response.data)}`)
+  return {
+    applications: [{
+      id: 'jira-software',
+      plan: response.data.licenseType,
+      raw: response.data,
+    }],
+  }
+}
+const getAccountInfo = async (client: JiraClient, accountInfoType: ObjectType): Promise<InstanceElement> => {
   const accountInfoInstance = new InstanceElement(
     ElemID.CONFIG_NAME,
     accountInfoType,
     {
-      license: {
-        applications: [{
-          id: 'jira-software',
-          plan: response.data.licenseType,
-          raw: response.data,
-        }],
-      },
+      license: client.isDataCenter
+        ? await getDCLicense(client)
+        : await getCloudLicense(client),
     },
     undefined,
     { [CORE_ANNOTATIONS.HIDDEN]: true },
   )
-  log.info(`jira dc license is: ${safeJsonStringify(response.data)}`)
   return accountInfoInstance
 }
-
 
 /*
  * Brings account info and stores it in an hidden nacl
@@ -130,11 +124,9 @@ const getDCLicense = async (client: JiraClient): Promise<InstanceElement> => {
 const filter: FilterCreator = ({ client }) => ({
   name: 'accountInfo',
   onFetch: async elements => log.time(async () => {
+    const [accountInfoType, licenseType, licensedApplications] = createAccountTypes()
     try {
-      const accountInfoInstance = client.isDataCenter
-        ? await getDCLicense(client)
-        : await getCloudLicense(client)
-      elements.push(licenseType, licensedApplications, accountInfoType, accountInfoInstance)
+      elements.push(licenseType, licensedApplications, accountInfoType, await getAccountInfo(client, accountInfoType))
     } catch (e) {
       if (e instanceof clientUtils.HTTPError && e.message !== undefined) {
         log.error(`Received an error when fetching jira license, ${e.message}.`)
@@ -143,13 +135,14 @@ const filter: FilterCreator = ({ client }) => ({
       }
     }
 
+    // take user count from application roles and delete it from the nacl
     const applicationRoles = elements
       .filter(element => element.elemID.typeName === 'ApplicationRole')
       .filter(isInstanceElement)
-    log.info('jira user count is: %d',
+    log.info('jira user count is: %s',
       applicationRoles
         .filter(role => role.value.key === 'jira-software')
-        .map(role => role.value.userCount) ?? 'unknown')
+        .map(role => role.value.userCount)[0] ?? 'unknown')
     applicationRoles
       .forEach(role => {
         delete role.value.userCount

--- a/packages/jira-adapter/test/filters/account_info.test.ts
+++ b/packages/jira-adapter/test/filters/account_info.test.ts
@@ -107,6 +107,8 @@ describe('accountInfoFilter', () => {
             licenseType: 'Developer',
             expired: false,
             rawLicense: 'should be removed',
+            organizationName: 'should be removed2',
+            supportEntitlementNumber: 'should be removed3',
           },
         })
         await filter.onFetch?.(elements)


### PR DESCRIPTION
Added the DC license, and logged the license details and the user count (taken from applicationRole)

---
_Release Notes_: 
None

---
_User Notifications_: 
None