### PR TITLE
SALTO-3453 Add a 'DataChangeValidator' in SF that yields info message when data …

### DIFF
--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -26,6 +26,7 @@ import mapKeysValidator from './change_validators/map_keys'
 import multipleDefaultsValidator from './change_validators/multiple_defaults'
 import picklistPromoteValidator from './change_validators/picklist_promote'
 import omitDataValidator from './change_validators/omit_data'
+import dataChangeValidator from './change_validators/data_change'
 import cpqValidator from './change_validators/cpq_trigger'
 import sbaaApprovalRulesCustomCondition from './change_validators/sbaa_approval_rules_custom_condition'
 import recordTypeDeletionValidator from './change_validators/record_type_deletion'
@@ -71,6 +72,7 @@ export const changeValidators: Record<ChangeValidatorName, ChangeValidatorDefini
   invalidListViewFilterScope: { creator: () => invalidListViewFilterScope, ...defaultAlwaysRun },
   caseAssignmentRulesValidator: { creator: () => caseAssignmentRulesValidator, ...defaultAlwaysRun },
   omitData: { creator: omitDataValidator, defaultInDeploy: false, defaultInValidate: true },
+  dataChange: { creator: () => dataChangeValidator, defaultInDeploy: true, defaultInValidate: false },
   unknownUser: { creator: (_config, _isSandbox, client) => unknownUser(client), ...defaultAlwaysRun },
   animationRuleRecordType: { creator: () => animationRuleRecordType, ...defaultAlwaysRun },
   currencyIsoCodes: { creator: () => currencyIsoCodes, ...defaultAlwaysRun },

--- a/packages/salesforce-adapter/src/change_validators/data_change.ts
+++ b/packages/salesforce-adapter/src/change_validators/data_change.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ChangeValidator, ElemID, getChangeData, ChangeError, InstanceElement } from '@salto-io/adapter-api'
+import { ChangeValidator, ElemID, getChangeData, ChangeError } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { isInstanceOfCustomObjectChange } from '../custom_object_instances_deploy'
 
@@ -32,11 +32,9 @@ const createChangeError = (instanceElemID: ElemID): ChangeError => ({
  */
 const createDataChangeValidator: ChangeValidator = async changes => {
   const dataChange = await awu(changes)
-    .filter(isInstanceOfCustomObjectChange)
-    .map(change => getChangeData(change) as InstanceElement)
-    .find(Boolean)
+    .find(isInstanceOfCustomObjectChange)
 
-  return dataChange !== undefined ? [createChangeError(dataChange.elemID)] : []
+  return dataChange !== undefined ? [createChangeError(getChangeData(dataChange).elemID)] : []
 }
 
 export default createDataChangeValidator

--- a/packages/salesforce-adapter/src/change_validators/data_change.ts
+++ b/packages/salesforce-adapter/src/change_validators/data_change.ts
@@ -1,0 +1,42 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ChangeValidator, ElemID, getChangeData, ChangeError, InstanceElement } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { isInstanceOfCustomObjectChange } from '../custom_object_instances_deploy'
+
+const { awu } = collections.asynciterable
+
+const createChangeError = (instanceElemID: ElemID): ChangeError => ({
+  elemID: instanceElemID,
+  severity: 'Info',
+  message: 'Data instances were changed in deployment.',
+  detailedMessage: 'Data instances were changed in this deployment.',
+})
+
+/**
+ * Note that data (CustomObject instances) is deployed
+ * This changeValidator will return none or a single changeError
+ */
+const createDataChangeValidator: ChangeValidator = async changes => {
+  const dataChange = await awu(changes)
+    .filter(isInstanceOfCustomObjectChange)
+    .map(change => getChangeData(change) as InstanceElement)
+    .find(Boolean)
+
+  return dataChange !== undefined ? [createChangeError(dataChange.elemID)] : []
+}
+
+export default createDataChangeValidator

--- a/packages/salesforce-adapter/src/change_validators/data_change.ts
+++ b/packages/salesforce-adapter/src/change_validators/data_change.ts
@@ -14,10 +14,11 @@
 * limitations under the License.
 */
 import { ChangeValidator, ElemID, getChangeData, ChangeError } from '@salto-io/adapter-api'
-import { collections } from '@salto-io/lowerdash'
+import { collections, values } from '@salto-io/lowerdash'
 import { isInstanceOfCustomObjectChange } from '../custom_object_instances_deploy'
 
 const { awu } = collections.asynciterable
+const { isDefined } = values
 
 const createChangeError = (instanceElemID: ElemID): ChangeError => ({
   elemID: instanceElemID,
@@ -27,14 +28,15 @@ const createChangeError = (instanceElemID: ElemID): ChangeError => ({
 })
 
 /**
- * Note that data (CustomObject instances) is deployed
- * This changeValidator will return none or a single changeError
+ * Creates a ChangeError of type Info when one of the changes is on a data instance.
  */
 const createDataChangeValidator: ChangeValidator = async changes => {
   const dataChange = await awu(changes)
     .find(isInstanceOfCustomObjectChange)
 
-  return dataChange !== undefined ? [createChangeError(getChangeData(dataChange).elemID)] : []
+  return isDefined(dataChange)
+    ? [createChangeError(getChangeData(dataChange).elemID)]
+    : []
 }
 
 export default createDataChangeValidator

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -99,6 +99,7 @@ export type ChangeValidatorName = (
   | 'unknownUser'
   | 'animationRuleRecordType'
   | 'currencyIsoCodes'
+  | 'dataChange'
 )
 
 export type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
@@ -586,6 +587,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     invalidListViewFilterScope: { refType: BuiltinTypes.BOOLEAN },
     caseAssignmentRulesValidator: { refType: BuiltinTypes.BOOLEAN },
     omitData: { refType: BuiltinTypes.BOOLEAN },
+    dataChange: { refType: BuiltinTypes.BOOLEAN },
     unknownUser: { refType: BuiltinTypes.BOOLEAN },
     animationRuleRecordType: { refType: BuiltinTypes.BOOLEAN },
     currencyIsoCodes: { refType: BuiltinTypes.BOOLEAN },

--- a/packages/salesforce-adapter/test/change_validator.test.ts
+++ b/packages/salesforce-adapter/test/change_validator.test.ts
@@ -147,7 +147,7 @@ describe('createSalesforceChangeValidator', () => {
           Object.values(changeValidators).filter(cv => cv.defaultInValidate).length
           + Object.values(deployment.changeValidators.getDefaultChangeValidators()).length
         ),
-        expect.toBeArrayOfSize(Object.values(changeValidators).filter(cv => !cv.defaultInValidate).length)
+        []
       )
     })
   })

--- a/packages/salesforce-adapter/test/change_validator.test.ts
+++ b/packages/salesforce-adapter/test/change_validator.test.ts
@@ -112,7 +112,7 @@ describe('createSalesforceChangeValidator', () => {
               Object.values(changeValidators).filter(cv => cv.defaultInValidate).length
               + Object.values(deployment.changeValidators.getDefaultChangeValidators()).length
             ),
-            expect.toBeArrayOfSize(Object.values(changeValidators).filter(cv => !cv.defaultInValidate).length)
+            []
           )
         })
       })

--- a/packages/salesforce-adapter/test/change_validators/data_change.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/data_change.test.ts
@@ -18,24 +18,19 @@ import {
 } from '@salto-io/adapter-api'
 import changeValidator from '../../src/change_validators/data_change'
 import { mockTypes } from '../mock_elements'
-// import { CUSTOM_OBJECT } from '../../src/constants'
 
-describe('dataChange deploy validator', () => {
+describe('dataChange ChangeValidator', () => {
   let changeErrors: ReadonlyArray<ChangeError>
   describe('with data instance change', () => {
     let change: Change
     beforeEach(async () => {
-      const customObj = mockTypes.Product2
       const beforeCustomObjInstance = new InstanceElement(
         'customObjInstance',
-        customObj,
+        mockTypes.Product2,
         { field: 'beforeValue' },
       )
-      const afterCustomObjInstance = new InstanceElement(
-        'customObjInstance',
-        customObj,
-        { field: 'afterValue' },
-      )
+      const afterCustomObjInstance = beforeCustomObjInstance.clone()
+      afterCustomObjInstance.value.field = 'afterValue'
       change = toChange({ before: beforeCustomObjInstance, after: afterCustomObjInstance })
       changeErrors = await changeValidator([
         change,
@@ -53,17 +48,13 @@ describe('dataChange deploy validator', () => {
 
   describe('with regular instance change', () => {
     beforeEach(async () => {
-      const typeObj = mockTypes.ApexClass
       const beforeInstance = new InstanceElement(
         'instance',
-        typeObj,
+        mockTypes.ApexClass,
         { field: 'beforeValue' }
       )
-      const afterInstance = new InstanceElement(
-        'instance',
-        typeObj,
-        { field: 'afterValue' }
-      )
+      const afterInstance = beforeInstance.clone()
+      afterInstance.value.field = 'afterValue'
       changeErrors = await changeValidator([
         toChange({ before: beforeInstance, after: afterInstance }),
       ])

--- a/packages/salesforce-adapter/test/change_validators/data_change.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/data_change.test.ts
@@ -1,0 +1,82 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  ChangeError, ElemID, InstanceElement, ObjectType, toChange, ChangeValidator,
+} from '@salto-io/adapter-api'
+import createDeployOnlyValidator from '../../src/change_validators/data_change'
+import { CUSTOM_OBJECT } from '../../src/constants'
+
+describe('dataChange deploy validator', () => {
+  const customObj = new ObjectType({
+    elemID: new ElemID('salesforce', 'customObj'),
+    annotations: { metadataType: CUSTOM_OBJECT, apiName: 'obj__c' },
+  })
+  const beforeCustomObjInstance = new InstanceElement(
+    'customObjInstance',
+    customObj,
+    { field: 'beforeValue' },
+  )
+  const afterCustomObjInstance = new InstanceElement(
+    'customObjInstance',
+    customObj,
+    { field: 'afterValue' },
+  )
+
+  const typeObj = new ObjectType({
+    elemID: new ElemID('salesforce', 'obj'),
+  })
+  const beforeInstance = new InstanceElement(
+    'instance',
+    typeObj,
+    { field: 'beforeValue' }
+  )
+  const afterInstance = new InstanceElement(
+    'instance',
+    typeObj,
+    { field: 'afterValue' }
+  )
+
+  let validator: ChangeValidator
+  beforeEach(() => {
+    validator = createDeployOnlyValidator
+  })
+  describe('with custom object instance change', () => {
+    let changeErrors: ReadonlyArray<ChangeError>
+    beforeEach(async () => {
+      changeErrors = await validator([
+        toChange({ before: beforeCustomObjInstance, after: afterCustomObjInstance }),
+      ])
+    })
+    it('should have Info for CustomObject instance modification', async () => {
+      expect(changeErrors).toHaveLength(1)
+      const [changeError] = changeErrors
+      expect(changeError.elemID).toEqual(beforeCustomObjInstance.elemID)
+      expect(changeError.severity).toEqual('Info')
+    })
+  })
+
+  describe('with regular instance change', () => {
+    let changeErrors: ReadonlyArray<ChangeError>
+    beforeEach(async () => {
+      changeErrors = await validator([
+        toChange({ before: beforeInstance, after: afterInstance }),
+      ])
+    })
+    it('should have no errors', () => {
+      expect(changeErrors).toHaveLength(0)
+    })
+  })
+})


### PR DESCRIPTION
Added a ChangeValidator that yields in informational message when data is altered in any way.


---

* This CV checks whether any of the changes are changes to instances of custom objects. If so, it shows a message with an info severity level

---
_Release Notes_: 
Salesforce Adapter:

* Added an informational message on any alteration of data
 
---
_User Notifications_: 
_None_