### PR TITLE
SALTO-3583: make sources.list configurable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,6 +169,11 @@ jobs:
           at: .
 
       - run:
+          name: configure sources.list
+          command: |
+            curl -sL https://salto-cli-releases.s3.eu-central-1.amazonaws.com/build_artifacts/apt/sources.list -o /etc/apt/sources.list
+            apt update
+      - run:
           name: Install java
           command: sudo apt update && sudo apt install -y openjdk-17-jdk --no-install-recommends
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,9 +171,15 @@ jobs:
       - run:
           name: configure sources.list
           command: |
-            curl -sL https://salto-cli-releases.s3.eu-central-1.amazonaws.com/build_artifacts/apt/sources.list -o /tmp/sources.list
-            sudo mv /tmp/sources.list /etc/apt/sources.list
-            sudo apt update
+            if curl -sL https://salto-cli-releases.s3.eu-central-1.amazonaws.com/build_artifacts/apt/sources.list -o /tmp/sources.list; then
+              echo "found sources.list file"
+              sudo mv /tmp/sources.list /etc/apt/sources.list
+              sudo apt update
+            else
+              echo "did not find sources.list file, using the default one"
+            fi
+            echo "using sources.list:"
+            cat /etc/apt/sources.list
       - run:
           name: Install java
           command: sudo apt update && sudo apt install -y openjdk-17-jdk --no-install-recommends

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,8 +171,9 @@ jobs:
       - run:
           name: configure sources.list
           command: |
-            curl -sL https://salto-cli-releases.s3.eu-central-1.amazonaws.com/build_artifacts/apt/sources.list -o /etc/apt/sources.list
-            apt update
+            curl -sL https://salto-cli-releases.s3.eu-central-1.amazonaws.com/build_artifacts/apt/sources.list -o /tmp/sources.list
+            sudo mv /tmp/sources.list /etc/apt/sources.list
+            sudo apt update
       - run:
           name: Install java
           command: sudo apt update && sudo apt install -y openjdk-17-jdk --no-install-recommends


### PR DESCRIPTION
archive.ubuntu.com is ultra slow, using [apt-select](https://github.com/jblakeman/apt-select) (which takes mirrors from [launchpad](https://launchpad.net/ubuntu/+archivemirrors)) we can configure it so it won't block us from running CI/CD pipelines.


---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
