### PR TITLE
Salto-3577: Add user account id changes for multi user picker field

### DIFF
--- a/packages/jira-adapter/src/filters/account_id/account_id_filter.ts
+++ b/packages/jira-adapter/src/filters/account_id/account_id_filter.ts
@@ -24,6 +24,7 @@ import { FilterCreator } from '../../filter'
 import { accountIdInfoType, accountIdInfoListType } from './types'
 
 const { awu } = collections.asynciterable
+const { makeArray } = collections.array
 
 export const OWNER_STYLE_TYPES = ['Filter', 'Dashboard']
 export const NON_DEPLOYABLE_TYPES = ['Board']
@@ -103,11 +104,10 @@ const accountIdsScenarios = (
     }
   })
   // main scenario, sub branch of multiple account ids
-  if (_.isArray(value.accountIds)) {
-    _.range(value[ACCOUNT_IDS].length).forEach(index => {
+  makeArray(value[ACCOUNT_IDS])
+    .forEach((_value, index) => {
       callback({ value: value[ACCOUNT_IDS], path: path.createNestedID(ACCOUNT_IDS), fieldName: index.toString() })
     })
-  }
   // second scenario: the type has ACCOUNT_ID_STRING and the value holds the actual account id
   if (value.type === ACCOUNT_ID_STRING) {
     callback({ value, path, fieldName: VALUE_FIELD })

--- a/packages/jira-adapter/src/filters/account_id/account_id_filter.ts
+++ b/packages/jira-adapter/src/filters/account_id/account_id_filter.ts
@@ -18,7 +18,7 @@ import { BuiltinTypes, ElemID, getChangeData, InstanceElement, isAdditionOrModif
   isInstanceElement, isListType, isObjectType, ObjectType, TypeReference, Value } from '@salto-io/adapter-api'
 import { walkOnElement, WALK_NEXT_STEP, WalkOnFunc, setPath, walkOnValue } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
-import _, { isArray } from 'lodash'
+import _ from 'lodash'
 import { ACCOUNT_ID_STRING, ACCOUNT_IDS_FIELDS_NAMES, AUTOMATION_TYPE, BOARD_TYPE_NAME } from '../../constants'
 import { FilterCreator } from '../../filter'
 import { accountIdInfoType, accountIdInfoListType } from './types'
@@ -73,7 +73,7 @@ const callbackValueOrValues = (
   { value, path, callback }
   : { value: Value; path: ElemID; callback: WalkOnUsersCallback }
 ): void => {
-  if (isArray(value.values)) {
+  if (_.isArray(value.values)) {
     _.range(value.values.length).forEach(index => {
       callback({ value: value.values, path: path.createNestedID(VALUES_FIELD), fieldName: index.toString() })
     })
@@ -103,8 +103,7 @@ const accountIdsScenarios = (
     }
   })
   // main scenario, sub branch of multiple account ids
-  if (Object.prototype.hasOwnProperty.call(value, ACCOUNT_IDS)
-    && isArray(value[ACCOUNT_IDS])) {
+  if (_.isArray(value.accountIds)) {
     _.range(value[ACCOUNT_IDS].length).forEach(index => {
       callback({ value: value[ACCOUNT_IDS], path: path.createNestedID(ACCOUNT_IDS), fieldName: index.toString() })
     })
@@ -213,8 +212,7 @@ const convertType = async (objectType: ObjectType): Promise<void> => {
       )
     }
   })
-  if (Object.prototype.hasOwnProperty.call(objectType.fields, ACCOUNT_IDS)
-    && isListType(await objectType.fields.accountIds.getType())) {
+  if (isListType(await objectType.fields.accountIds?.getType())) {
     objectType.fields.accountIds.refType = new TypeReference(
       accountIdInfoListType.elemID,
       accountIdInfoListType

--- a/packages/jira-adapter/src/filters/account_id/types.ts
+++ b/packages/jira-adapter/src/filters/account_id/types.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, ObjectType } from '@salto-io/adapter-api'
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, ListType, ObjectType } from '@salto-io/adapter-api'
 import { elements } from '@salto-io/adapter-components'
 import { ACCOUNT_ID_INFO_TYPE, JIRA } from '../../constants'
 
@@ -38,3 +38,5 @@ export const accountIdInfoType = new ObjectType({
   },
   path: [JIRA, elements.TYPES_PATH, elements.SUBTYPES_PATH, ACCOUNT_ID_INFO_TYPE],
 })
+
+export const accountIdInfoListType = new ListType(accountIdInfoType)

--- a/packages/jira-adapter/test/change_validators/account_id.test.ts
+++ b/packages/jira-adapter/test/change_validators/account_id.test.ts
@@ -129,6 +129,26 @@ describe('accountIdValidator', () => {
       displayName: 'disp1list2',
       locale: 'en_US',
       emailAddress: 'email1list2',
+    }, {
+      accountId: '0Ids1',
+      displayName: 'disp0Ids1',
+      locale: 'en_US',
+      emailAddress: 'email0Ids1',
+    }, {
+      accountId: '0Ids2',
+      displayName: 'disp0Ids2',
+      locale: 'en_US',
+      emailAddress: 'email0Ids2',
+    }, {
+      accountId: '1Ids1',
+      displayName: 'disp1Ids1',
+      locale: 'en_US',
+      emailAddress: 'email1Ids1',
+    }, {
+      accountId: '1Ids2',
+      displayName: 'disp1Ids2',
+      locale: 'en_US',
+      emailAddress: 'email1Ids2',
     }],
   })
 

--- a/packages/jira-adapter/test/filters/account_id/account_id_common.ts
+++ b/packages/jira-adapter/test/filters/account_id/account_id_common.ts
@@ -46,6 +46,7 @@ export const createObjectedType = (
       accountId: { refType: accountIdInfoType },
       leadAccountId: { refType: accountIdInfoType },
       authorAccountId: { refType: accountIdInfoType },
+      accountIds: { refType: new ListType(BuiltinTypes.STRING) },
       nested: { refType: nestedType },
     },
   })
@@ -297,6 +298,10 @@ export const createInstance = (
         },
       ],
     },
+    accountIds: [
+      `${id}Ids1`,
+      `${id}Ids2`,
+    ],
     ...overrides,
   }
 )
@@ -501,6 +506,14 @@ export const createObjectedInstance = (id: string, objectType: ObjectType): Inst
         },
       ],
     },
+    accountIds: [
+      {
+        id: `${id}Ids1`,
+      },
+      {
+        id: `${id}Ids2`,
+      },
+    ],
   })
   return object
 }
@@ -532,6 +545,8 @@ export const checkObjectedInstanceIds = (
     expect(objInstance.value.automation7.compareFieldValue[0].value.conditions[1].criteria[0].value.id).toEqual(`${id}automation7`)
     expect(objInstance.value.automation8.compareFieldValue[0].value.assignee.values[0].id).toEqual(`${id}automation8a`)
     expect(objInstance.value.automation8.compareFieldValue[0].value.assignee.values[1].id).toEqual(`${id}automation8b`)
+    expect(objInstance.value.accountIds[0].id).toEqual(`${id}Ids1`)
+    expect(objInstance.value.accountIds[1].id).toEqual(`${id}Ids2`)
   }
 }
 
@@ -561,6 +576,8 @@ export const checkSimpleInstanceIds = (
     expect(objInstance.value.automation7.compareFieldValue[0].value.conditions[1].criteria[0].value).toEqual(`${id}automation7`)
     expect(objInstance.value.automation8.compareFieldValue[0].value.assignee.values[0]).toEqual(`${id}automation8a`)
     expect(objInstance.value.automation8.compareFieldValue[0].value.assignee.values[1]).toEqual(`${id}automation8b`)
+    expect(objInstance.value.accountIds[0]).toEqual(`${id}Ids1`)
+    expect(objInstance.value.accountIds[1]).toEqual(`${id}Ids2`)
   }
 }
 export const checkDisplayNames = (
@@ -599,6 +616,8 @@ export const checkDisplayNames = (
     expect(instance.value.automation8.compareFieldValue[0].value.assignee.values[0].displayName).toEqual(`disp${id}automation8a`)
     expect(instance.value.automation8.compareFieldValue[0].value.assignee.values[1].displayName).toEqual(`disp${id}automation8b`)
   }
+  expect(instance.value.accountIds[0].displayName).toEqual(`disp${id}Ids1`)
+  expect(instance.value.accountIds[1].displayName).toEqual(`disp${id}Ids2`)
 }
 export const checkInstanceUserIds = (
   instance: InstanceElement,
@@ -618,6 +637,8 @@ export const checkInstanceUserIds = (
     expect(instance.value.holder.parameter.id).toEqual(`${prefix}${id}h`)
   }
   expect(instance.value.value.operations[3].value.value.id).toEqual(`${id}operations1`)
+  expect(instance.value.accountIds[0].id).toEqual(`${prefix}${id}Ids1`)
+  expect(instance.value.accountIds[1].id).toEqual(`${prefix}${id}Ids2`)
 }
 
 export const createInstanceElementArrayWithDisplayNames = (
@@ -640,6 +661,8 @@ export const createInstanceElementArrayWithDisplayNames = (
     elements[i].value.owner.displayName = `disp${i}owner`
     elements[i].value.users[0].displayName = `disp${i}users1`
     elements[i].value.users[1].displayName = `disp${i}users2`
+    elements[i].value.accountIds[0].displayName = `disp${i}Ids1`
+    elements[i].value.accountIds[1].displayName = `disp${i}Ids2`
   }
   return elements
 }

--- a/packages/jira-adapter/test/filters/account_id/account_id_filter.test.ts
+++ b/packages/jira-adapter/test/filters/account_id/account_id_filter.test.ts
@@ -189,7 +189,7 @@ describe('account_id_filter', () => {
       common.checkDisplayNames((displayChanges[1] as ModificationChange<InstanceElement>).data.before, '1')
       common.checkObjectedInstanceIds((displayChanges[1] as ModificationChange<InstanceElement>).data.after, '2')
       common.checkDisplayNames((displayChanges[1] as ModificationChange<InstanceElement>).data.after, '2')
-    })
+    }, 1000000)
     it('returns even wrong structure instances on OnDeploy', async () => {
       const elementInstance = displayNamesInstances[0]
       elementInstance.value.accountId.wrong = 'wrong'

--- a/packages/jira-adapter/test/filters/account_id/account_id_filter.test.ts
+++ b/packages/jira-adapter/test/filters/account_id/account_id_filter.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, Change, ElemID, ElemIdGetter, Field, getChangeData, InstanceElement, ModificationChange, ObjectType, toChange } from '@salto-io/adapter-api'
+import { BuiltinTypes, Change, ElemID, ElemIdGetter, Field, getChangeData, InstanceElement, ListType, ModificationChange, ObjectType, toChange } from '@salto-io/adapter-api'
 import { mockFunction } from '@salto-io/test-utils'
 import { filterUtils } from '@salto-io/adapter-components'
 import { collections } from '@salto-io/lowerdash'
@@ -140,6 +140,11 @@ describe('account_id_filter', () => {
           BuiltinTypes.STRING
         )
       })
+      currentObjectType.fields.accountIds = new Field(
+        currentObjectType,
+        'accountIds',
+        new ListType(BuiltinTypes.STRING)
+      )
       await filter.onFetch([currentObjectType])
       await awu(ACCOUNT_IDS_FIELDS_NAMES).forEach(async fieldName => {
         const currentType = await currentObjectType.fields[fieldName].getType() as ObjectType
@@ -147,6 +152,7 @@ describe('account_id_filter', () => {
         expect(Object.prototype.hasOwnProperty.call(currentType.fields, 'displayName')).toBeTruthy()
         expect(currentType.elemID.getFullName()).toEqual('jira.AccountIdInfo')
       })
+      expect((await currentObjectType.fields.accountIds.getType()).elemID.getFullName()).toEqual('List<jira.AccountIdInfo>')
     })
     it('should not enhance types with account ids that are not part of the known types', async () => {
       const currentObjectType = new ObjectType({

--- a/packages/jira-adapter/test/filters/account_id/user_id_filter.test.ts
+++ b/packages/jira-adapter/test/filters/account_id/user_id_filter.test.ts
@@ -153,6 +153,14 @@ describe('add_display_name_filter', () => {
         accountId: '2users2',
         displayName: 'disp2users2',
         locale: 'en_US',
+      }, {
+        accountId: '2Ids1',
+        displayName: 'disp2Ids1',
+        locale: 'en_US',
+      }, {
+        accountId: '2Ids2',
+        displayName: 'disp2Ids2',
+        locale: 'en_US',
       }],
     })
   })


### PR DESCRIPTION
_Added to account id scenarios support in 'accountIds' which covers multi user picker default value_

---

Not sure if we should also add noise suppression, as it can show changes to existing users

---
_Release Notes_: 
Jira Adapter:
User account Ids in custom fields of multi user picker will now be added display names

---
_User Notifications_: 
Jira Adapter: 
User account ids in custom fields of multi user picker will now be added display names
