### PR TITLE
SALTO-3520: Allow and handle broken references from automations to projects - Jira

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -38,6 +38,7 @@ import boardColumnsFilter from './filters/board/board_columns'
 import boardSubQueryFilter from './filters/board/board_subquery'
 import boardEstimationFilter from './filters/board/board_estimation'
 import boardDeploymentFilter from './filters/board/board_deployment'
+import automationBrokenReferenceFilter from './filters/automation/automation_project_broken_reference'
 import automationDeploymentFilter from './filters/automation/automation_deployment'
 import smartValueReferenceFilter from './filters/automation/smart_values/smart_value_reference_filter'
 import webhookFilter from './filters/webhook/webhook'
@@ -133,6 +134,8 @@ export const DEFAULT_FILTERS = [
   automationLabelDeployFilter,
   automationFetchFilter,
   automationStructureFilter,
+  // Should run before automationDeploymentFilter
+  automationBrokenReferenceFilter,
   automationDeploymentFilter,
   webhookFilter,
   // Should run before duplicateIdsFilter

--- a/packages/jira-adapter/src/change_validators/automation_unresolved_references.ts
+++ b/packages/jira-adapter/src/change_validators/automation_unresolved_references.ts
@@ -1,0 +1,58 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { isAdditionOrModificationChange, ChangeValidator, getChangeData, isInstanceChange, SeverityLevel, isReferenceExpression, UnresolvedReference, ReferenceExpression } from '@salto-io/adapter-api'
+import { AUTOMATION_TYPE } from '../constants'
+
+
+export type ProjectType = { projectId: ReferenceExpression }
+
+
+export const isProjectReferenceBroken = (project: ProjectType): boolean =>
+  project.projectId !== undefined
+    && isReferenceExpression(project.projectId)
+    && project.projectId.value instanceof UnresolvedReference
+
+
+export const automationProjectUnresolvedReferenceValidator: ChangeValidator = async changes =>
+  changes
+    .filter(isInstanceChange)
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+    .filter(instance => instance.elemID.typeName === AUTOMATION_TYPE)
+    .filter(instance => instance.value.projects !== undefined)
+    .map(instance => ({
+      instance,
+      brokenReferencesNames: instance.value.projects.filter(isProjectReferenceBroken)
+        .map((project: ProjectType) => project.projectId.elemID.name),
+    }))
+    .filter(({ brokenReferencesNames }) => brokenReferencesNames.length > 0)
+    .map(({ instance, brokenReferencesNames }) => {
+    // automation must have at least one project to be valid
+      if (brokenReferencesNames.length === instance.value.projects.length) {
+        return {
+          elemID: instance.elemID,
+          severity: 'Error' as SeverityLevel,
+          message: 'Automation isn’t attached to any existing project',
+          detailedMessage: `All projects attached to this automation do not exist in the target environment: ${brokenReferencesNames}. The automation can’t be deployed. To solve this, go back and include at least one attached project in your deployment.`,
+        }
+      } return {
+        elemID: instance.elemID,
+        severity: 'Warning' as SeverityLevel,
+        message: 'Automation won’t be attached to some projects',
+        detailedMessage: `The automation is attached to some projects which do not exist in the target environment: ${brokenReferencesNames}. If you continue, the automation will be deployed without them. Alternatively, you can go back and include these projects in your deployment.`,
+      }
+    })

--- a/packages/jira-adapter/src/change_validators/automation_unresolved_references.ts
+++ b/packages/jira-adapter/src/change_validators/automation_unresolved_references.ts
@@ -15,18 +15,19 @@
 */
 
 import { isAdditionOrModificationChange, ChangeValidator, getChangeData, isInstanceChange, SeverityLevel, isReferenceExpression, UnresolvedReference, ReferenceExpression } from '@salto-io/adapter-api'
+import _ from 'lodash'
 import { AUTOMATION_TYPE } from '../constants'
 
 
 export type ProjectType = { projectId: ReferenceExpression }
 
-const isProjectType = (element: unknown): element is ProjectType =>
-  (element as ProjectType).projectId !== undefined
+export const isProjectType = (element: unknown): element is ProjectType => {
+  const projectId = _.get(element, 'projectId')
+  return projectId !== undefined && isReferenceExpression(projectId)
+}
 
 export const isProjectReferenceBroken = (project: ProjectType): boolean =>
-  project.projectId !== undefined
-    && isReferenceExpression(project.projectId)
-    && project.projectId.value instanceof UnresolvedReference
+  project.projectId.value instanceof UnresolvedReference
 
 
 export const automationProjectUnresolvedReferenceValidator: ChangeValidator = async changes =>

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -46,6 +46,8 @@ import { fieldContextValidator } from './field_contexts/field_contexts'
 import { workflowSchemeMigrationValidator } from './workflow_scheme_migration'
 import { permissionSchemeDeploymentValidator } from './permission_scheme'
 import { statusMigrationChangeValidator } from './status_migration'
+import { automationProjectUnresolvedReferenceValidator } from './automation_unresolved_references'
+import { unresolvedReferenceValidator } from './unresolved_references'
 
 const {
   deployTypesNotSupportedValidator,
@@ -56,7 +58,9 @@ export default (
   client: JiraClient, config: JiraConfig, getUserMapFunc: GetUserMapFunc, paginator: clientUtils.Paginator
 ): ChangeValidator => {
   const validators: ChangeValidator[] = [
-    ...deployment.changeValidators.getDefaultChangeValidators(),
+    ...deployment.changeValidators.getDefaultChangeValidators(['unresolvedReferencesValidator']),
+    unresolvedReferenceValidator,
+    automationProjectUnresolvedReferenceValidator,
     deployTypesNotSupportedValidator,
     readOnlyProjectRoleChangeValidator,
     defaultFieldConfigurationValidator,

--- a/packages/jira-adapter/src/change_validators/unresolved_references.ts
+++ b/packages/jira-adapter/src/change_validators/unresolved_references.ts
@@ -1,0 +1,33 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { ChangeValidator, ElemID } from '@salto-io/adapter-api'
+import { deployment } from '@salto-io/adapter-components'
+import { AUTOMATION_TYPE } from '../constants'
+
+// for example: 'jira.Automation.instance.projects.123.projectId'
+const AUTOMATION_PROJECT_REFERENCE_REG = new RegExp('^jira\\.Automation\\..+\\.projects\\.\\d+\\.projectId$')
+
+export const automationProjectReferenceDetector = (id: ElemID): boolean => {
+  if (id.typeName === AUTOMATION_TYPE) {
+    const elemIdFullName = id.getFullName()
+    return AUTOMATION_PROJECT_REFERENCE_REG.test(elemIdFullName)
+  }
+  return false
+}
+
+export const unresolvedReferenceValidator: ChangeValidator = deployment.changeValidators
+  .createUnresolvedReferencesValidator(automationProjectReferenceDetector)

--- a/packages/jira-adapter/src/change_validators/unresolved_references.ts
+++ b/packages/jira-adapter/src/change_validators/unresolved_references.ts
@@ -14,17 +14,18 @@
 * limitations under the License.
 */
 
-import { ChangeValidator, ElemID } from '@salto-io/adapter-api'
+import { ChangeValidator, ElemID, isIndexPathPart } from '@salto-io/adapter-api'
 import { deployment } from '@salto-io/adapter-components'
 import { AUTOMATION_TYPE } from '../constants'
 
-// for example: 'jira.Automation.instance.projects.123.projectId'
-const AUTOMATION_PROJECT_REFERENCE_REG = new RegExp('^jira\\.Automation\\..+\\.projects\\.\\d+\\.projectId$')
 
-export const automationProjectReferenceDetector = (id: ElemID): boolean => {
-  if (id.typeName === AUTOMATION_TYPE) {
-    const elemIdFullName = id.getFullName()
-    return AUTOMATION_PROJECT_REFERENCE_REG.test(elemIdFullName)
+export const automationProjectReferenceDetector = (elemId: ElemID): boolean => {
+  if (elemId.typeName === AUTOMATION_TYPE) {
+    const nameParts = elemId.getFullNameParts()
+    return nameParts.length === 7
+      && nameParts[4] === 'projects'
+      && isIndexPathPart(nameParts[5])
+      && nameParts[6] === 'projectId'
   }
   return false
 }

--- a/packages/jira-adapter/src/filters/automation/automation_project_broken_reference.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_project_broken_reference.ts
@@ -15,11 +15,12 @@
 */
 
 import { Change, ChangeDataType, getChangeData, isAdditionOrModificationChange, isInstanceChange } from '@salto-io/adapter-api'
-import { isProjectReferenceBroken, ProjectType } from '../../change_validators/automation_unresolved_references'
+import { isProjectReferenceBroken, ProjectType, isProjectType } from '../../change_validators/automation_unresolved_references'
 import { AUTOMATION_TYPE } from '../../constants'
 import { FilterCreator } from '../../filter'
 
-
+// we allow broken references between Automation to Project,
+// so in this filter we remove those broken references in preDeploy and add them back in onDeploy
 export const filter: FilterCreator = () => {
   const preDeployProjects: Record<string, ProjectType[]> = {}
   return {
@@ -32,6 +33,7 @@ export const filter: FilterCreator = () => {
         .forEach(change => {
           preDeployProjects[getChangeData(change).elemID.getFullName()] = change.data.after.value.projects
           change.data.after.value.projects = change.data.after.value.projects
+            .filter(isProjectType)
             .filter((project: ProjectType) => !isProjectReferenceBroken(project))
         })
     },

--- a/packages/jira-adapter/src/filters/automation/automation_project_broken_reference.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_project_broken_reference.ts
@@ -1,0 +1,52 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { Change, ChangeDataType, getChangeData, isAdditionOrModificationChange, isInstanceChange } from '@salto-io/adapter-api'
+import { isProjectReferenceBroken, ProjectType } from '../../change_validators/automation_unresolved_references'
+import { AUTOMATION_TYPE } from '../../constants'
+import { FilterCreator } from '../../filter'
+
+
+export const filter: FilterCreator = () => {
+  const preDeployProjects: Record<string, ProjectType[]> = {}
+  return {
+    preDeploy: async (changes: Change<ChangeDataType>[]) => {
+      changes.filter(isInstanceChange)
+        .filter(isAdditionOrModificationChange)
+        .filter(change => getChangeData(change).elemID.typeName === AUTOMATION_TYPE)
+        .filter(change => getChangeData(change).value.projects !== undefined) // todo check if needed
+        .forEach(change => {
+          preDeployProjects[getChangeData(change).elemID.getFullName()] = change.data.after.value.projects
+          change.data.after.value.projects = change.data.after.value.projects
+            .filter((project: ProjectType) => !isProjectReferenceBroken(project))
+        })
+    },
+
+    onDeploy: async (changes: Change<ChangeDataType>[]) => {
+      changes.filter(isInstanceChange)
+        .filter(isAdditionOrModificationChange)
+        .filter(change => getChangeData(change).elemID.typeName === AUTOMATION_TYPE)
+        .filter(change => getChangeData(change).value.projects !== undefined) // todo check if needed
+        .forEach(change => {
+          if (preDeployProjects[getChangeData(change).elemID.getFullName()] !== undefined) {
+            change.data.after.value.projects = preDeployProjects[getChangeData(change).elemID.getFullName()]
+          }
+        })
+    },
+  }
+}
+
+export default filter

--- a/packages/jira-adapter/src/filters/automation/automation_project_broken_reference.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_project_broken_reference.ts
@@ -15,17 +15,10 @@
 */
 
 import { Change, ChangeDataType, getChangeData, isAdditionOrModificationChange, isInstanceChange } from '@salto-io/adapter-api'
-import _ from 'lodash'
 import { isProjectReferenceBroken, ProjectType, isProjectType } from '../../change_validators/automation_unresolved_references'
 import { AUTOMATION_TYPE } from '../../constants'
 import { FilterCreator } from '../../filter'
 
-type projectTypeKey = { projectTypeKey: string }
-
-export const isProjectTypeKey = (element: unknown): element is projectTypeKey => {
-  const projectTypeKey = _.get(element, 'projectTypeKey')
-  return projectTypeKey !== undefined && _.isString(projectTypeKey)
-}
 
 // we allow broken references between Automation to Project,
 // so in this filter we remove those broken references in preDeploy and add them back in onDeploy
@@ -40,11 +33,8 @@ export const filter: FilterCreator = () => {
         .filter(change => getChangeData(change).value.projects !== undefined)
         .forEach(change => {
           preDeployProjects[getChangeData(change).elemID.getFullName()] = change.data.after.value.projects
-          const projectTypeKeys = change.data.after.value.projects.filter(isProjectTypeKey)
           change.data.after.value.projects = change.data.after.value.projects
-            .filter(isProjectType)
-            .filter((project: ProjectType) => !isProjectReferenceBroken(project))
-            .concat(projectTypeKeys)
+            .filter((project: unknown) => !isProjectType(project) || !isProjectReferenceBroken(project))
         })
     },
 

--- a/packages/jira-adapter/src/filters/automation/automation_project_broken_reference.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_project_broken_reference.ts
@@ -27,7 +27,7 @@ export const filter: FilterCreator = () => {
       changes.filter(isInstanceChange)
         .filter(isAdditionOrModificationChange)
         .filter(change => getChangeData(change).elemID.typeName === AUTOMATION_TYPE)
-        .filter(change => getChangeData(change).value.projects !== undefined) // todo check if needed
+        .filter(change => getChangeData(change).value.projects !== undefined)
         .forEach(change => {
           preDeployProjects[getChangeData(change).elemID.getFullName()] = change.data.after.value.projects
           change.data.after.value.projects = change.data.after.value.projects
@@ -39,7 +39,7 @@ export const filter: FilterCreator = () => {
       changes.filter(isInstanceChange)
         .filter(isAdditionOrModificationChange)
         .filter(change => getChangeData(change).elemID.typeName === AUTOMATION_TYPE)
-        .filter(change => getChangeData(change).value.projects !== undefined) // todo check if needed
+        .filter(change => getChangeData(change).value.projects !== undefined)
         .forEach(change => {
           if (preDeployProjects[getChangeData(change).elemID.getFullName()] !== undefined) {
             change.data.after.value.projects = preDeployProjects[getChangeData(change).elemID.getFullName()]

--- a/packages/jira-adapter/src/filters/automation/automation_project_broken_reference.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_project_broken_reference.ts
@@ -23,6 +23,7 @@ import { FilterCreator } from '../../filter'
 export const filter: FilterCreator = () => {
   const preDeployProjects: Record<string, ProjectType[]> = {}
   return {
+    name: 'automationProjectBrokenReferenceFilter',
     preDeploy: async (changes: Change<ChangeDataType>[]) => {
       changes.filter(isInstanceChange)
         .filter(isAdditionOrModificationChange)

--- a/packages/jira-adapter/test/change_validators/automation_unresolved_reference.test.ts
+++ b/packages/jira-adapter/test/change_validators/automation_unresolved_reference.test.ts
@@ -1,0 +1,96 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, ElemID, InstanceElement, toChange, UnresolvedReference, ReferenceExpression } from '@salto-io/adapter-api'
+import { automationProjectUnresolvedReferenceValidator } from '../../src/change_validators/automation_unresolved_references'
+import { AUTOMATION_TYPE, JIRA, PROJECT_TYPE } from '../../src/constants'
+
+describe('automationProjectUnresolvedReferenceValidator', () => {
+  let automationType: ObjectType
+  let projectType: ObjectType
+  let automationInstance: InstanceElement
+  let projectInstance: InstanceElement
+  let unresolvedElemId: ElemID
+
+  beforeEach(() => {
+    automationType = new ObjectType({ elemID: new ElemID(JIRA, AUTOMATION_TYPE) })
+    projectType = new ObjectType({ elemID: new ElemID(JIRA, PROJECT_TYPE) })
+    projectInstance = new InstanceElement(
+      'ProjectInstance',
+      projectType,
+    )
+    unresolvedElemId = new ElemID(JIRA, 'unresolved')
+    automationInstance = new InstanceElement(
+      'AutomationInstance',
+      automationType,
+      {
+        projects: [
+          {
+            projectId: new ReferenceExpression(projectType.elemID,
+              { projectId: projectInstance }),
+          },
+          {
+            projectId: new ReferenceExpression(projectType.elemID,
+              new UnresolvedReference(unresolvedElemId)),
+          },
+        ],
+      },
+    )
+  })
+
+  it('should return a warning when project reference is unresolved', async () => {
+    expect(await automationProjectUnresolvedReferenceValidator(
+      [toChange({ after: automationInstance })]
+    )).toEqual([
+      {
+        elemID: automationInstance.elemID,
+        severity: 'Warning',
+        message: 'Automation won’t be attached to some projects',
+        detailedMessage: 'The automation is attached to some projects which do not exist in the target environment: Project. If you continue, the automation will be deployed without them. Alternatively, you can go back and include these projects in your deployment.',
+      },
+    ])
+  })
+  it('should not return a warning when there is not a project reference that is unresolved', async () => {
+    automationInstance.value.projects = [
+      {
+        projectId: new ReferenceExpression(projectType.elemID,
+          { projectId: projectInstance }),
+      },
+    ]
+
+    expect(await automationProjectUnresolvedReferenceValidator(
+      [toChange({ after: automationInstance })]
+    )).toEqual([])
+  })
+  it('should return an error when all the projects references are unresolved', async () => {
+    automationInstance.value.projects = [
+      {
+        projectId: new ReferenceExpression(projectType.elemID,
+          new UnresolvedReference(unresolvedElemId)),
+      },
+    ]
+
+    expect(await automationProjectUnresolvedReferenceValidator(
+      [toChange({ after: automationInstance })]
+    )).toEqual([
+      {
+        elemID: automationInstance.elemID,
+        severity: 'Error',
+        message: 'Automation isn’t attached to any existing project',
+        detailedMessage: 'All projects attached to this automation do not exist in the target environment: Project. The automation can’t be deployed. To solve this, go back and include at least one attached project in your deployment.',
+      },
+    ])
+  })
+})

--- a/packages/jira-adapter/test/change_validators/automation_unresolved_reference.test.ts
+++ b/packages/jira-adapter/test/change_validators/automation_unresolved_reference.test.ts
@@ -31,7 +31,7 @@ describe('automationProjectUnresolvedReferenceValidator', () => {
       'ProjectInstance',
       projectType,
     )
-    unresolvedElemId = new ElemID(JIRA, 'unresolved')
+    unresolvedElemId = new ElemID(JIRA, 'unresolvedProject')
     automationInstance = new InstanceElement(
       'AutomationInstance',
       automationType,
@@ -58,7 +58,7 @@ describe('automationProjectUnresolvedReferenceValidator', () => {
         elemID: automationInstance.elemID,
         severity: 'Warning',
         message: 'Automation won’t be attached to some projects',
-        detailedMessage: 'The automation is attached to some projects which do not exist in the target environment: Project. If you continue, the automation will be deployed without them. Alternatively, you can go back and include these projects in your deployment.',
+        detailedMessage: 'The automation is attached to some projects which do not exist in the target environment: unresolvedProject. If you continue, the automation will be deployed without them. Alternatively, you can go back and include these projects in your deployment.',
       },
     ])
   })
@@ -89,7 +89,7 @@ describe('automationProjectUnresolvedReferenceValidator', () => {
         elemID: automationInstance.elemID,
         severity: 'Error',
         message: 'Automation isn’t attached to any existing project',
-        detailedMessage: 'All projects attached to this automation do not exist in the target environment: Project. The automation can’t be deployed. To solve this, go back and include at least one attached project in your deployment.',
+        detailedMessage: 'All projects attached to this automation do not exist in the target environment: unresolvedProject. The automation can’t be deployed. To solve this, go back and include at least one attached project in your deployment.',
       },
     ])
   })

--- a/packages/jira-adapter/test/change_validators/unresolved_references.test.ts
+++ b/packages/jira-adapter/test/change_validators/unresolved_references.test.ts
@@ -1,0 +1,50 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { ElemID } from '@salto-io/adapter-api'
+import { automationProjectReferenceDetector } from '../../src/change_validators/unresolved_references'
+import { AUTOMATION_TYPE, JIRA } from '../../src/constants'
+
+describe('automationProjectUnresolvedReferenceValidator', () => {
+  let elemId: ElemID
+
+  beforeEach(() => {
+    elemId = new ElemID(JIRA, AUTOMATION_TYPE, 'instance', 'projects', '0', 'projectId')
+  })
+
+  it('should return true when the elemId fit automationProjectId  ', async () => {
+    expect(automationProjectReferenceDetector(elemId))
+      .toBeTrue()
+  })
+
+  it('should return false when the elemId not fit automationProjectId  ', async () => {
+    elemId = new ElemID(JIRA, AUTOMATION_TYPE, 'instance', 'projects', '0', 'projectIds')
+    expect(automationProjectReferenceDetector(elemId))
+      .toBeFalse()
+    elemId = new ElemID(JIRA, AUTOMATION_TYPE, 'instance', 'projects', 'notNumber', 'projectId')
+    expect(automationProjectReferenceDetector(elemId))
+      .toBeFalse()
+    elemId = new ElemID(JIRA, AUTOMATION_TYPE, 'instance', 'project', '0', 'projectId')
+    expect(automationProjectReferenceDetector(elemId))
+      .toBeFalse()
+    elemId = new ElemID(JIRA, 'anotherType', 'instance', 'project', '0', 'projectId')
+    expect(automationProjectReferenceDetector(elemId))
+      .toBeFalse()
+    elemId = new ElemID('anotherAdapter', AUTOMATION_TYPE, 'instance', 'project', '0', 'projectId')
+    expect(automationProjectReferenceDetector(elemId))
+      .toBeFalse()
+  })
+})

--- a/packages/jira-adapter/test/change_validators/unresolved_references.test.ts
+++ b/packages/jira-adapter/test/change_validators/unresolved_references.test.ts
@@ -22,7 +22,7 @@ describe('automationProjectUnresolvedReferenceValidator', () => {
   let elemId: ElemID
 
   beforeEach(() => {
-    elemId = new ElemID(JIRA, AUTOMATION_TYPE, 'instance', 'projects', '0', 'projectId')
+    elemId = new ElemID(JIRA, AUTOMATION_TYPE, 'instance', 'ruleName', 'projects', '0', 'projectId')
   })
 
   it('should return true when the elemId fit automationProjectId  ', async () => {
@@ -31,16 +31,19 @@ describe('automationProjectUnresolvedReferenceValidator', () => {
   })
 
   it('should return false when the elemId not fit automationProjectId  ', async () => {
-    elemId = new ElemID(JIRA, AUTOMATION_TYPE, 'instance', 'projects', '0', 'projectIds')
+    elemId = new ElemID(JIRA, AUTOMATION_TYPE, 'instance', 'ruleName', 'projects', '0', 'projectIds')
     expect(automationProjectReferenceDetector(elemId))
       .toBeFalse()
-    elemId = new ElemID(JIRA, AUTOMATION_TYPE, 'instance', 'projects', 'notNumber', 'projectId')
+    elemId = new ElemID(JIRA, AUTOMATION_TYPE, 'instance', 'ruleName', 'projects', 'notNumber', 'projectId')
     expect(automationProjectReferenceDetector(elemId))
       .toBeFalse()
-    elemId = new ElemID(JIRA, AUTOMATION_TYPE, 'instance', 'project', '0', 'projectId')
+    elemId = new ElemID(JIRA, AUTOMATION_TYPE, 'instance', 'ruleName', 'project', '0', 'projectId')
     expect(automationProjectReferenceDetector(elemId))
       .toBeFalse()
-    elemId = new ElemID(JIRA, 'anotherType', 'instance', 'project', '0', 'projectId')
+    elemId = new ElemID(JIRA, 'anotherType', 'instance', 'ruleName', 'project', '0', 'projectId')
+    expect(automationProjectReferenceDetector(elemId))
+      .toBeFalse()
+    elemId = new ElemID('anotherAdapter', AUTOMATION_TYPE, 'instance', 'ruleName', 'project', '0', 'projectId')
     expect(automationProjectReferenceDetector(elemId))
       .toBeFalse()
     elemId = new ElemID('anotherAdapter', AUTOMATION_TYPE, 'instance', 'project', '0', 'projectId')

--- a/packages/jira-adapter/test/filters/automation/automation_project_broken_reference.test.ts
+++ b/packages/jira-adapter/test/filters/automation/automation_project_broken_reference.test.ts
@@ -1,0 +1,177 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { ElemID, InstanceElement, ObjectType, toChange, ReferenceExpression, UnresolvedReference } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import { ProjectType } from '../../../src/change_validators/automation_unresolved_references'
+import { getFilterParams } from '../../utils'
+import automationProjectBrokenReferenceFilter from '../../../src/filters/automation/automation_project_broken_reference'
+import { AUTOMATION_TYPE, JIRA, PROJECT_TYPE } from '../../../src/constants'
+
+describe('automationProjectBrokenReferenceFilter', () => {
+  let filter: filterUtils.FilterWith<'preDeploy' | 'onDeploy'>
+  let automationType: ObjectType
+  let projectType: ObjectType
+  let automationInstance: InstanceElement
+  let projectInstance: InstanceElement
+  let unresolvedElemId: ElemID
+  let unresolvedProject: ProjectType
+  let resolvedProject: ProjectType
+
+
+  beforeEach(async () => {
+    filter = automationProjectBrokenReferenceFilter(getFilterParams()) as filterUtils.FilterWith<'preDeploy' | 'onDeploy'>
+    automationType = new ObjectType({ elemID: new ElemID(JIRA, AUTOMATION_TYPE) })
+    unresolvedElemId = new ElemID(JIRA, 'unresolved')
+    projectType = new ObjectType({ elemID: new ElemID(JIRA, PROJECT_TYPE) })
+    unresolvedProject = {
+      projectId: new ReferenceExpression(projectType.elemID,
+        new UnresolvedReference(unresolvedElemId)),
+    }
+    resolvedProject = {
+      projectId: new ReferenceExpression(projectType.elemID,
+        { projectId: projectInstance }),
+    }
+    projectInstance = new InstanceElement(
+      'ProjectInstance',
+      projectType,
+    )
+    automationInstance = new InstanceElement(
+      'AutomationInstance',
+      automationType,
+      {
+        projects: [
+          resolvedProject,
+          unresolvedProject,
+        ],
+      },
+    )
+  })
+
+  describe('preDeploy', () => {
+    it('should remove unresolved project from the instance for adding and modification', async () => {
+      expect(automationInstance.value.projects).toHaveLength(2)
+      const modificationInstance = automationInstance.clone()
+      const deletedInstance = automationInstance.clone()
+      await filter.preDeploy([
+        toChange({ after: automationInstance }),
+        toChange({ before: automationInstance, after: modificationInstance }),
+        toChange({ before: deletedInstance })])
+
+      expect(automationInstance.value.projects).toHaveLength(1)
+      expect(modificationInstance.value.projects).toHaveLength(1)
+      expect(deletedInstance.value.projects).toHaveLength(2)
+
+      expect(automationInstance.value.projects[0])
+        .toEqual(resolvedProject)
+      expect(modificationInstance.value.projects[0])
+        .toEqual(resolvedProject,)
+      expect(deletedInstance.value.projects)
+        .toEqual([resolvedProject, unresolvedProject])
+    })
+
+    it('should not remove project resolved references from the instance', async () => {
+      automationInstance.value.projects = [
+        resolvedProject,
+        resolvedProject,
+      ]
+      expect(automationInstance.value.projects).toHaveLength(2)
+      const modificationInstance = automationInstance.clone()
+      const deletedInstance = automationInstance.clone()
+      await filter.preDeploy([
+        toChange({ after: automationInstance }),
+        toChange({ before: automationInstance, after: modificationInstance }),
+        toChange({ before: deletedInstance })])
+
+      expect(automationInstance.value.projects).toHaveLength(2)
+      expect(modificationInstance.value.projects).toHaveLength(2)
+      expect(deletedInstance.value.projects).toHaveLength(2)
+
+      expect(automationInstance.value.projects)
+        .toEqual([resolvedProject, resolvedProject])
+      expect(modificationInstance.value.projects)
+        .toEqual([resolvedProject, resolvedProject])
+      expect(deletedInstance.value.projects)
+        .toEqual([resolvedProject, resolvedProject])
+    })
+  })
+
+  describe('onDeploy', () => {
+    it('should add back unresolved project references to the instance when adding or modifying', async () => {
+      expect(automationInstance.value.projects).toHaveLength(2)
+      const modificationInstance = automationInstance.clone()
+      const deletedInstance = automationInstance.clone()
+
+      await filter.preDeploy([
+        toChange({ after: automationInstance }),
+        toChange({ before: automationInstance, after: modificationInstance }),
+        toChange({ before: deletedInstance })])
+
+      expect(automationInstance.value.projects).toHaveLength(1)
+      expect(modificationInstance.value.projects).toHaveLength(1)
+      expect(deletedInstance.value.projects).toHaveLength(2)
+      await filter.onDeploy([
+        toChange({ after: automationInstance }),
+        toChange({ before: automationInstance, after: modificationInstance }),
+        toChange({ before: deletedInstance })])
+
+      expect(automationInstance.value.projects).toHaveLength(2)
+      expect(modificationInstance.value.projects).toHaveLength(2)
+      expect(deletedInstance.value.projects).toHaveLength(2)
+
+      expect(automationInstance.value.projects)
+        .toEqual([resolvedProject, unresolvedProject])
+      expect(modificationInstance.value.projects)
+        .toEqual([resolvedProject, unresolvedProject])
+      expect(deletedInstance.value.projects)
+        .toEqual([resolvedProject, unresolvedProject])
+    })
+    it('should not add nothing when all project references are resolved', async () => {
+      automationInstance.value.projects = [
+        resolvedProject,
+        resolvedProject,
+      ]
+      expect(automationInstance.value.projects).toHaveLength(2)
+      const modificationInstance = automationInstance.clone()
+      const deletedInstance = automationInstance.clone()
+
+      await filter.preDeploy([
+        toChange({ after: automationInstance }),
+        toChange({ before: automationInstance, after: modificationInstance }),
+        toChange({ before: deletedInstance })])
+
+      expect(automationInstance.value.projects).toHaveLength(2)
+      expect(modificationInstance.value.projects).toHaveLength(2)
+      expect(deletedInstance.value.projects).toHaveLength(2)
+
+      await filter.onDeploy([
+        toChange({ after: automationInstance }),
+        toChange({ before: automationInstance, after: modificationInstance }),
+        toChange({ before: deletedInstance })])
+
+      expect(automationInstance.value.projects).toHaveLength(2)
+      expect(modificationInstance.value.projects).toHaveLength(2)
+      expect(deletedInstance.value.projects).toHaveLength(2)
+
+      expect(automationInstance.value.projects)
+        .toEqual([resolvedProject, resolvedProject],)
+      expect(modificationInstance.value.projects)
+        .toEqual([resolvedProject, resolvedProject],)
+      expect(deletedInstance.value.projects)
+        .toEqual([resolvedProject, resolvedProject],)
+    })
+  })
+})

--- a/packages/jira-adapter/test/filters/automation/automation_project_broken_reference.test.ts
+++ b/packages/jira-adapter/test/filters/automation/automation_project_broken_reference.test.ts
@@ -107,6 +107,32 @@ describe('automationProjectBrokenReferenceFilter', () => {
       expect(deletedInstance.value.projects)
         .toEqual([resolvedProject, resolvedProject])
     })
+    it('should not remove project type key elements', async () => {
+      const projectTypeKey = { projectTypeKey: 'business' }
+      automationInstance.value.projects = [
+        resolvedProject,
+        unresolvedProject,
+        projectTypeKey,
+      ]
+      expect(automationInstance.value.projects).toHaveLength(3)
+      const modificationInstance = automationInstance.clone()
+      const deletedInstance = automationInstance.clone()
+      await filter.preDeploy([
+        toChange({ after: automationInstance }),
+        toChange({ before: automationInstance, after: modificationInstance }),
+        toChange({ before: deletedInstance })])
+
+      expect(automationInstance.value.projects).toHaveLength(2)
+      expect(modificationInstance.value.projects).toHaveLength(2)
+      expect(deletedInstance.value.projects).toHaveLength(3)
+
+      expect(automationInstance.value.projects)
+        .toEqual([resolvedProject, projectTypeKey])
+      expect(modificationInstance.value.projects)
+        .toEqual([resolvedProject, projectTypeKey])
+      expect(deletedInstance.value.projects)
+        .toEqual([resolvedProject, unresolvedProject, projectTypeKey])
+    })
   })
 
   describe('onDeploy', () => {


### PR DESCRIPTION
_Allow and handle broken references from automations to projects_

---

_Additional context for reviewer_

* add a predicate function to make `unresolvedReferencesValidator` ignore automation projects
* add change validator to raise error or warning for those unresolved references
* add filter to remove the unresolved references in preDeploy and add them back in onDeploy
* add unit tests for all the above

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
