### PR TITLE
SALTO-3509: Hide account_features instance in Zendesk

### DIFF
--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -115,6 +115,7 @@ import ticketFormDeploy from './filters/ticket_form'
 import supportAddress from './filters/support_address'
 import customStatus from './filters/custom_statuses'
 import organizationsFilter from './filters/organizations'
+import hideAccountFeatures from './filters/hide_account_features'
 
 const { makeArray } = collections.array
 const log = logger(module)
@@ -203,6 +204,7 @@ export const DEFAULT_FILTERS = [
   collisionErrorsFilter, // needs to be after referencedIdFieldsFilter (which is part of the common filters)
   deployBrandedGuideTypesFilter,
   guideArrangePaths,
+  hideAccountFeatures,
   fetchCategorySection, // need to be after arrange paths as it uses the 'name'/'title' field
   // defaultDeployFilter should be last!
   defaultDeployFilter,

--- a/packages/zendesk-adapter/src/filters/hide_account_features.ts
+++ b/packages/zendesk-adapter/src/filters/hide_account_features.ts
@@ -1,0 +1,40 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { logger } from '@salto-io/logging'
+import { CORE_ANNOTATIONS, isInstanceElement } from '@salto-io/adapter-api'
+import { FilterCreator } from '../filter'
+import { ACCOUNT_FEATURES_TYPE_NAME } from '../constants'
+
+const log = logger(module)
+
+/**
+ * Hide account_features settings instance
+ */
+const filterCreator: FilterCreator = () => ({
+  name: 'hideAccountFeaturesInstance',
+  onFetch: async elements => {
+    const accountFeaturesInstance = elements
+      .filter(isInstanceElement)
+      .find(i => i.elemID.typeName === ACCOUNT_FEATURES_TYPE_NAME)
+    if (accountFeaturesInstance === undefined) {
+      log.warn('Could not find account_features instance')
+      return
+    }
+    accountFeaturesInstance.annotations[CORE_ANNOTATIONS.HIDDEN] = true
+  },
+})
+
+export default filterCreator

--- a/packages/zendesk-adapter/src/filters/hide_account_features.ts
+++ b/packages/zendesk-adapter/src/filters/hide_account_features.ts
@@ -14,26 +14,26 @@
 * limitations under the License.
 */
 import { logger } from '@salto-io/logging'
-import { CORE_ANNOTATIONS, isInstanceElement } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, isObjectType } from '@salto-io/adapter-api'
 import { FilterCreator } from '../filter'
 import { ACCOUNT_FEATURES_TYPE_NAME } from '../constants'
 
 const log = logger(module)
 
 /**
- * Hide account_features settings instance
+ * Hide account_features settings
  */
 const filterCreator: FilterCreator = () => ({
-  name: 'hideAccountFeaturesInstance',
+  name: 'hideAccountFeatures',
   onFetch: async elements => {
-    const accountFeaturesInstance = elements
-      .filter(isInstanceElement)
-      .find(i => i.elemID.typeName === ACCOUNT_FEATURES_TYPE_NAME)
-    if (accountFeaturesInstance === undefined) {
-      log.warn('Could not find account_features instance')
+    const accountFeaturesType = elements
+      .filter(isObjectType)
+      .find(t => t.elemID.typeName === ACCOUNT_FEATURES_TYPE_NAME)
+    if (accountFeaturesType === undefined) {
+      log.warn('Could not find account_features type')
       return
     }
-    accountFeaturesInstance.annotations[CORE_ANNOTATIONS.HIDDEN] = true
+    accountFeaturesType.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE] = true
   },
 })
 

--- a/packages/zendesk-adapter/src/filters/hide_account_features.ts
+++ b/packages/zendesk-adapter/src/filters/hide_account_features.ts
@@ -30,7 +30,7 @@ const filterCreator: FilterCreator = () => ({
       .filter(isObjectType)
       .find(t => t.elemID.typeName === ACCOUNT_FEATURES_TYPE_NAME)
     if (accountFeaturesType === undefined) {
-      log.warn('Could not find account_features type')
+      log.warn(`Could not find ${ACCOUNT_FEATURES_TYPE_NAME} type`)
       return
     }
     accountFeaturesType.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE] = true

--- a/packages/zendesk-adapter/test/filters/hide_account_features.test.ts
+++ b/packages/zendesk-adapter/test/filters/hide_account_features.test.ts
@@ -1,0 +1,55 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { CORE_ANNOTATIONS, ElemID, InstanceElement, isInstanceElement, ObjectType } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import { ZENDESK, ACCOUNT_FEATURES_TYPE_NAME } from '../../src/constants'
+import hideAccountFeatureInstanceFilter from '../../src/filters/hide_account_features'
+import { createFilterCreatorParams } from '../utils'
+
+
+describe('hideAccountFeatureInstanceFilter', () => {
+  type FilterType = filterUtils.FilterWith<'onFetch'>
+  const filter = hideAccountFeatureInstanceFilter(createFilterCreatorParams({}))as FilterType
+  const featureType = new ObjectType({ elemID: new ElemID(ZENDESK, ACCOUNT_FEATURES_TYPE_NAME) })
+  const featureInstance = new InstanceElement(
+    ElemID.CONFIG_NAME,
+    featureType,
+    {
+      macro_preview: {
+        enabled: true,
+      },
+      side_conversations_email: {
+        enabled: false,
+      },
+      side_conversations_slack: {
+        enabled: false,
+      },
+      side_conversations_tickets: {
+        enabled: false,
+      },
+    },
+  )
+
+  it('should add "_hidden" annotation to account_features instance', async () => {
+    const elements = [featureInstance, featureInstance]
+    await filter.onFetch(elements)
+    const featureInstanceAfterFilter = elements
+      .filter(isInstanceElement)
+      .find(i => i.elemID.typeName === ACCOUNT_FEATURES_TYPE_NAME)
+    expect(featureInstanceAfterFilter).toBeDefined()
+    expect(featureInstanceAfterFilter?.annotations[CORE_ANNOTATIONS.HIDDEN]).toEqual(true)
+  })
+})

--- a/packages/zendesk-adapter/test/filters/hide_account_features.test.ts
+++ b/packages/zendesk-adapter/test/filters/hide_account_features.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { CORE_ANNOTATIONS, ElemID, InstanceElement, isInstanceElement, ObjectType } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, ElemID, ObjectType } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import { ZENDESK, ACCOUNT_FEATURES_TYPE_NAME } from '../../src/constants'
 import hideAccountFeatureInstanceFilter from '../../src/filters/hide_account_features'
@@ -24,32 +24,11 @@ describe('hideAccountFeatureInstanceFilter', () => {
   type FilterType = filterUtils.FilterWith<'onFetch'>
   const filter = hideAccountFeatureInstanceFilter(createFilterCreatorParams({}))as FilterType
   const featureType = new ObjectType({ elemID: new ElemID(ZENDESK, ACCOUNT_FEATURES_TYPE_NAME) })
-  const featureInstance = new InstanceElement(
-    ElemID.CONFIG_NAME,
-    featureType,
-    {
-      macro_preview: {
-        enabled: true,
-      },
-      side_conversations_email: {
-        enabled: false,
-      },
-      side_conversations_slack: {
-        enabled: false,
-      },
-      side_conversations_tickets: {
-        enabled: false,
-      },
-    },
-  )
 
-  it('should add "_hidden" annotation to account_features instance', async () => {
-    const elements = [featureInstance, featureInstance]
+  it('should add "_hidden_value" annotation to account_features type', async () => {
+    const elements = [featureType]
     await filter.onFetch(elements)
-    const featureInstanceAfterFilter = elements
-      .filter(isInstanceElement)
-      .find(i => i.elemID.typeName === ACCOUNT_FEATURES_TYPE_NAME)
-    expect(featureInstanceAfterFilter).toBeDefined()
-    expect(featureInstanceAfterFilter?.annotations[CORE_ANNOTATIONS.HIDDEN]).toEqual(true)
+    expect(elements[0]).toBeDefined()
+    expect(elements[0]?.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE]).toEqual(true)
   })
 })


### PR DESCRIPTION
Hide account_features instance in Zendesk

---

We're hiding account_features instance as it's changes a lot and its noisy.
We hide it rather than delete it because the instance is being used in change validaotrs.

---
_Release Notes_: 
None

---
_User Notifications_: 
None
