### PR TITLE
SALTO-3586: Replace organization IDs with name only when resolveOrganizationIDs config flag enabled

### DIFF
--- a/packages/zendesk-adapter/config_doc.md
+++ b/packages/zendesk-adapter/config_doc.md
@@ -68,7 +68,8 @@ zendesk {
 |---------------------------------------------|-----------------------------------|------------
 | [include](#fetch-entry-options)             | [{ type = ".*" }]                 | List of entries to determine what instances to include in the fetch
 | [exclude](#fetch-entry-options)             | []                                | List of entries to determine what instances to exclude in the fetch
-| [guide](#fetch-entry-options)               | undefined (Guide will be disabled)| Configuration for defining which brands will be included in Zendesk Guide fetch
+| [guide]                                     | undefined (Guide will be disabled)| Configuration for defining which brands will be included in Zendesk Guide fetch
+| [resolveOrganizationIDs]                    | false                             | When enabled, organization IDs will be replaced with organization names
 
 ## Fetch entry options
 

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -79,6 +79,7 @@ export type ZendeskFetchConfig = configUtils.UserFetchConfig
   greedyAppReferences?: boolean
   appReferenceLocators?: IdLocator[]
   guide?: Guide
+  resolveOrganizationIDs?: boolean
 }
 export type ZedneskDeployConfig = configUtils.UserDeployConfig
 export type ZendeskApiConfig = configUtils.AdapterApiConfig<
@@ -2508,6 +2509,7 @@ export const DEFAULT_CONFIG: ZendeskConfig = {
     ],
     hideTypes: true,
     enableMissingReferences: true,
+    resolveOrganizationIDs: false,
   },
   [API_DEFINITIONS_CONFIG]: {
     typeDefaults: {
@@ -2583,6 +2585,7 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
           greedyAppReferences: { refType: BuiltinTypes.BOOLEAN },
           appReferenceLocators: { refType: IdLocatorType },
           guide: { refType: GuideType },
+          resolveOrganizationIDs: { refType: BuiltinTypes.BOOLEAN },
         },
       ),
     },
@@ -2600,6 +2603,7 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
       `${FETCH_CONFIG}.hideTypes`,
       `${FETCH_CONFIG}.enableMissingReferences`,
       `${FETCH_CONFIG}.guide`,
+      `${FETCH_CONFIG}.resolveOrganizationIDs`,
       DEPLOY_CONFIG,
     ),
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/zendesk-adapter/src/filters/organizations.ts
+++ b/packages/zendesk-adapter/src/filters/organizations.ts
@@ -24,6 +24,7 @@ import { FilterCreator } from '../filter'
 import { ValueReplacer, deployModificationFunc, replaceConditionsAndActionsCreator, fieldReplacer } from '../replacers_utils'
 import ZendeskClient from '../client/client'
 import { paginate } from '../client/pagination'
+import { FETCH_CONFIG } from '../config'
 
 const log = logger(module)
 const { isDefined } = lowerDashValues
@@ -140,13 +141,18 @@ const getOrganizationsByNames = async (
 }
 
 /**
- * Replaces organization ids with organization names
+ * Replaces organization ids with organization names when 'resolveOrganizationIDs' config flag is enabled
  */
-const filterCreator: FilterCreator = ({ client }) => {
+const filterCreator: FilterCreator = ({ client, config }) => {
   let organizationIdToName: Record<string, string> = {}
+  const resolveOrganizationIDs = config[FETCH_CONFIG].resolveOrganizationIDs ?? false
   return {
     name: 'organizationsFilter',
     onFetch: async elements => {
+      if (resolveOrganizationIDs === false) {
+        log.debug('Resolving organization IDs to organization names was disabled')
+        return
+      }
       const relevantInstances = elements.filter(isInstanceElement)
         .filter(instance => Object.keys(TYPE_NAME_TO_REPLACER).includes(instance.elemID.typeName))
 
@@ -175,6 +181,9 @@ const filterCreator: FilterCreator = ({ client }) => {
       })
     },
     preDeploy: async (changes: Change<InstanceElement>[]) => {
+      if (resolveOrganizationIDs === false) {
+        return
+      }
       const relevantChanges = changes.filter(isRelevantChange)
       if (_.isEmpty(relevantChanges)) {
         return
@@ -205,6 +214,9 @@ const filterCreator: FilterCreator = ({ client }) => {
       await deployModificationFunc(changes, organizationNameToId, TYPE_NAME_TO_REPLACER)
     },
     onDeploy: async (changes: Change<InstanceElement>[]) => {
+      if (resolveOrganizationIDs === false) {
+        return
+      }
       const relevantChanges = changes.filter(isRelevantChange)
       if (_.isEmpty(relevantChanges)) {
         return

--- a/packages/zendesk-adapter/src/filters/organizations.ts
+++ b/packages/zendesk-adapter/src/filters/organizations.ts
@@ -150,7 +150,7 @@ const filterCreator: FilterCreator = ({ client, config }) => {
     name: 'organizationsFilter',
     onFetch: async elements => {
       if (resolveOrganizationIDs === false) {
-        log.debug('Resolving organization IDs to organization names was disabled')
+        log.debug('Resolving organization IDs to organization names was disabled (onFetch)')
         return
       }
       const relevantInstances = elements.filter(isInstanceElement)
@@ -182,6 +182,7 @@ const filterCreator: FilterCreator = ({ client, config }) => {
     },
     preDeploy: async (changes: Change<InstanceElement>[]) => {
       if (resolveOrganizationIDs === false) {
+        log.debug('Resolving organization IDs to organization names was disabled (preDeploy)')
         return
       }
       const relevantChanges = changes.filter(isRelevantChange)
@@ -215,6 +216,7 @@ const filterCreator: FilterCreator = ({ client, config }) => {
     },
     onDeploy: async (changes: Change<InstanceElement>[]) => {
       if (resolveOrganizationIDs === false) {
+        log.debug('Resolving organization IDs to organization names was disabled (onDeploy)')
         return
       }
       const relevantChanges = changes.filter(isRelevantChange)

--- a/packages/zendesk-adapter/test/filters/organizations.test.ts
+++ b/packages/zendesk-adapter/test/filters/organizations.test.ts
@@ -19,12 +19,12 @@ import { ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/organizations'
 import { createFilterCreatorParams } from '../utils'
 import ZendeskClient from '../../src/client/client'
+import { FETCH_CONFIG, DEFAULT_CONFIG } from '../../src/config'
 
 describe('organizations filter', () => {
   let client: ZendeskClient
   let mockGet: jest.SpyInstance
   type FilterType = filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
-  let filter: FilterType
   const triggerType = new ObjectType({ elemID: new ElemID(ZENDESK, 'trigger') })
   const userSegmentType = new ObjectType({ elemID: new ElemID(ZENDESK, 'user_segment') })
 
@@ -57,137 +57,225 @@ describe('organizations filter', () => {
       },
     },
   )
-
-  beforeEach(async () => {
-    jest.clearAllMocks()
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
-    mockGet = jest.spyOn(client, 'getSinglePage')
-    filter = filterCreator(
-      createFilterCreatorParams({ client })
-    ) as FilterType
-  })
-  describe('onFetch', () => {
+  describe('when resolveOrganizationIDs config flag is true', () => {
+    let filter: FilterType
     beforeEach(async () => {
       jest.clearAllMocks()
-      mockGet.mockResolvedValue({
-        status: 200,
-        data: {
-          organizations: [
-            { id: 1, name: 'org1' },
-            { id: 2, name: 'org2' },
-            { id: 3, name: 'org3' },
-            { id: 4, name: 'org4' },
-            { id: 5, name: 'org5' },
-          ],
-        },
+      client = new ZendeskClient({
+        credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
       })
+      mockGet = jest.spyOn(client, 'getSinglePage')
+      const config = { ...DEFAULT_CONFIG }
+      config[FETCH_CONFIG].resolveOrganizationIDs = true
+      filter = filterCreator(
+        createFilterCreatorParams({ client, config })
+      ) as FilterType
     })
-    it('should replace all organization ids with names', async () => {
-      const elements = [userSegmentType, userSegmentInstance, triggerType, triggerInstance]
-        .map(e => e.clone())
-      await filter.onFetch(elements)
-      const instances = elements.filter(isInstanceElement)
-      const trigger = instances.find(e => e.elemID.typeName === 'trigger')
-      expect(trigger?.value).toEqual({
-        title: 'test',
-        actions: [
-          { field: 'status', value: 'closed' },
-        ],
-        conditions: {
-          all: [
-            { field: 'organization_id', operator: 'is', value: 'org3' },
-            { field: 'assignee_id', operator: 'is', value: '3' },
-          ],
-          any: [
-            { field: 'SOLVED', operator: 'greater_than', value: '96' },
-            { field: 'organization_id', operator: 'is_not', value: 'org2' },
-          ],
-        },
-      },)
-      const userSegment = instances.find(e => e.elemID.typeName === 'user_segment')
-      expect(userSegment?.value).toEqual({
-        title: 'test',
-        organization_ids: ['org1', 'org2', 'org3'],
-      })
-    })
-  })
-  describe('preDeploy', () => {
-    it('should repalce organizaion names with emails', async () => {
-      mockGet
-        .mockResolvedValueOnce({
+
+    describe('onFetch', () => {
+      beforeEach(async () => {
+        jest.clearAllMocks()
+        mockGet.mockResolvedValue({
           status: 200,
           data: {
             organizations: [
               { id: 1, name: 'org1' },
-              { id: 2, name: 'org11' },
-              { id: 3, name: 'org1111' },
+              { id: 2, name: 'org2' },
+              { id: 3, name: 'org3' },
+              { id: 4, name: 'org4' },
+              { id: 5, name: 'org5' },
             ],
           },
         })
-        .mockResolvedValueOnce({
-          status: 200,
-          data: {
-            organizations: [
-              { id: 2, name: 'org11' },
-              { id: 3, name: 'org1111' },
+      })
+      it('should replace all organization ids with names', async () => {
+        const elements = [userSegmentType, userSegmentInstance, triggerType, triggerInstance]
+          .map(e => e.clone())
+        await filter.onFetch(elements)
+        const instances = elements.filter(isInstanceElement)
+        const trigger = instances.find(e => e.elemID.typeName === 'trigger')
+        expect(trigger?.value).toEqual({
+          title: 'test',
+          actions: [
+            { field: 'status', value: 'closed' },
+          ],
+          conditions: {
+            all: [
+              { field: 'organization_id', operator: 'is', value: 'org3' },
+              { field: 'assignee_id', operator: 'is', value: '3' },
+            ],
+            any: [
+              { field: 'SOLVED', operator: 'greater_than', value: '96' },
+              { field: 'organization_id', operator: 'is_not', value: 'org2' },
             ],
           },
+        },)
+        const userSegment = instances.find(e => e.elemID.typeName === 'user_segment')
+        expect(userSegment?.value).toEqual({
+          title: 'test',
+          organization_ids: ['org1', 'org2', 'org3'],
         })
-      const userSegAfterFetch = new InstanceElement(
-        'test',
-        userSegmentType,
-        {
+      })
+    })
+    describe('preDeploy', () => {
+      it('should repalce organizaion names with emails', async () => {
+        mockGet
+          .mockResolvedValueOnce({
+            status: 200,
+            data: {
+              organizations: [
+                { id: 1, name: 'org1' },
+                { id: 2, name: 'org11' },
+                { id: 3, name: 'org1111' },
+              ],
+            },
+          })
+          .mockResolvedValueOnce({
+            status: 200,
+            data: {
+              organizations: [
+                { id: 2, name: 'org11' },
+                { id: 3, name: 'org1111' },
+              ],
+            },
+          })
+        const userSegAfterFetch = new InstanceElement(
+          'test',
+          userSegmentType,
+          {
+            title: 'test',
+            organization_ids: ['org1', 'org11'],
+          }
+        )
+        await filter.preDeploy([toChange({ after: userSegAfterFetch })])
+        expect(mockGet).toHaveBeenCalledTimes(2)
+        expect(userSegAfterFetch.value).toEqual({
+          title: 'test',
+          organization_ids: [1, 2],
+        })
+      })
+    })
+    describe('onDeploy', () => {
+      it('should change back organization ids to names', async () => {
+        mockGet
+          .mockResolvedValueOnce({
+            status: 200,
+            data: {
+              organizations: [
+                { id: 1, name: 'org1' },
+                { id: 2, name: 'org11' },
+                { id: 3, name: 'org1111' },
+              ],
+            },
+          })
+          .mockResolvedValueOnce({
+            status: 200,
+            data: {
+              organizations: [
+                { id: 2, name: 'org11' },
+                { id: 3, name: 'org1111' },
+              ],
+            },
+          })
+        const userSegAfterFetch = new InstanceElement(
+          'test',
+          userSegmentType,
+          {
+            title: 'test',
+            organization_ids: ['org1', 'org11'],
+          }
+        )
+        const changes = [toChange({ after: userSegAfterFetch })]
+        // We call preDeploy here because it sets the mappings
+        await filter.preDeploy(changes)
+        await filter.onDeploy(changes)
+        expect(userSegAfterFetch.value).toEqual({
           title: 'test',
           organization_ids: ['org1', 'org11'],
-        }
-      )
-      await filter.preDeploy([toChange({ after: userSegAfterFetch })])
-      expect(mockGet).toHaveBeenCalledTimes(2)
-      expect(userSegAfterFetch.value).toEqual({
-        title: 'test',
-        organization_ids: [1, 2],
+        })
       })
     })
   })
-  describe('onDeploy', () => {
-    it('should change back organization ids to names', async () => {
-      mockGet
-        .mockResolvedValueOnce({
-          status: 200,
-          data: {
-            organizations: [
-              { id: 1, name: 'org1' },
-              { id: 2, name: 'org11' },
-              { id: 3, name: 'org1111' },
-            ],
-          },
-        })
-        .mockResolvedValueOnce({
-          status: 200,
-          data: {
-            organizations: [
-              { id: 2, name: 'org11' },
-              { id: 3, name: 'org1111' },
-            ],
-          },
-        })
-      const userSegAfterFetch = new InstanceElement(
-        'test',
-        userSegmentType,
-        {
+
+  describe('it should do nothing if resolveOrganizationIDs config flag is false', () => {
+    let filter: FilterType
+    beforeEach(async () => {
+      jest.clearAllMocks()
+      client = new ZendeskClient({
+        credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
+      })
+      mockGet = jest.spyOn(client, 'getSinglePage')
+      const config = { ...DEFAULT_CONFIG }
+      config[FETCH_CONFIG].resolveOrganizationIDs = false
+      filter = filterCreator(
+        createFilterCreatorParams({ client, config })
+      ) as FilterType
+    })
+
+    describe('onFetch', () => {
+      it('should do nothing if resolveOrganizationIDs config flag is off', async () => {
+        const elements = [userSegmentType, userSegmentInstance, triggerType, triggerInstance]
+          .map(e => e.clone())
+        await filter.onFetch(elements)
+        const instances = elements.filter(isInstanceElement)
+        const trigger = instances.find(e => e.elemID.typeName === 'trigger')
+        expect(trigger?.value).toEqual({
           title: 'test',
-          organization_ids: ['org1', 'org11'],
-        }
-      )
-      const changes = [toChange({ after: userSegAfterFetch })]
-      // We call preDeploy here because it sets the mappings
-      await filter.preDeploy(changes)
-      await filter.onDeploy(changes)
-      expect(userSegAfterFetch.value).toEqual({
-        title: 'test',
-        organization_ids: ['org1', 'org11'],
+          actions: [
+            { field: 'status', value: 'closed' },
+          ],
+          conditions: {
+            all: [
+              { field: 'organization_id', operator: 'is', value: '3' },
+              { field: 'assignee_id', operator: 'is', value: '3' },
+            ],
+            any: [
+              { field: 'SOLVED', operator: 'greater_than', value: '96' },
+              { field: 'organization_id', operator: 'is_not', value: '2' },
+            ],
+          },
+        },)
+        const userSegment = instances.find(e => e.elemID.typeName === 'user_segment')
+        expect(userSegment?.value).toEqual({
+          title: 'test',
+          organization_ids: [1, 2, 3],
+        })
+      })
+    })
+
+    describe('preDeploy', () => {
+      it('should not not change organization values', async () => {
+        const userSegAfterFetch = new InstanceElement(
+          'test',
+          userSegmentType,
+          {
+            title: 'test',
+            organization_ids: [1, 2],
+          }
+        )
+        await filter.preDeploy([toChange({ after: userSegAfterFetch })])
+        expect(userSegAfterFetch.value).toEqual({
+          title: 'test',
+          organization_ids: [1, 2],
+        })
+      })
+    })
+
+    describe('onDeploy', () => {
+      it('should not change organization values', async () => {
+        const userSegAfterFetch = new InstanceElement(
+          'test',
+          userSegmentType,
+          {
+            title: 'test',
+            organization_ids: [1, 2],
+          }
+        )
+        await filter.onDeploy([toChange({ after: userSegAfterFetch })])
+        expect(userSegAfterFetch.value).toEqual({
+          title: 'test',
+          organization_ids: [1, 2],
+        })
       })
     })
   })


### PR DESCRIPTION
Replace organization IDs with name only when resolveOrganizationIDs config flag enabled

---

Changes:
- Add `resolveOrganizationIDs` config option, which will be false by default
- `organizations` filter will replace organization ids with names when `resolveOrganizationIDs` enabled

---
_Release Notes_: 

_Zendesk adapter_:
- Add `resolveOrganizationIDs` fetch config option, when set to `true` references to organization IDs will be replaced with organization names

---
_User Notifications_: 

_Zendesk adapter_:
- References to organizations will be replaced with organization IDs, to revert this change edit the `fetch` config options in the config file and set `resolveOrganizationIDs = true`   
