### PR TITLE
Add reference mapping for user flows

### DIFF
--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -159,6 +159,14 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     target: { type: 'Flow' },
   },
   {
+    src: { field: 'lightningComponent', parentTypes: ['QuickAction'] },
+    target: { type: 'AuraDefinitionBundle' },
+  },
+  {
+    src: { field: 'lightningComponent', parentTypes: ['QuickAction'] },
+    target: { type: 'ApexPage' },
+  },
+  {
     src: { field: 'letterhead', parentTypes: ['EmailTemplate'] },
     target: { type: 'Letterhead' },
   },

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -485,6 +485,10 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     target: { type: 'ApexPage' },
   },
   {
+    src: { field: 'value', parentTypes: ['ComponentInstanceProperty'] },
+    target: { type: 'Flow' },
+  },
+  {
     src: { field: CPQ_LOOKUP_PRODUCT_FIELD, parentTypes: [CPQ_PRODUCT_RULE, CPQ_PRICE_RULE] },
     serializationStrategy: 'relativeApiName',
     target: { parentContext: 'neighborCPQLookup', type: CUSTOM_FIELD },

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -296,6 +296,10 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     target: { type: 'QuickAction' },
   },
   {
+    src: { field: 'content', parentTypes: ['AppActionOverride', 'ActionOverride'] },
+    target: { type: 'LightningPage' },
+  },
+  {
     src: { field: 'name', parentTypes: ['AppMenuItem'] },
     target: { typeContext: 'neighborTypeLookup' },
   },

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -155,6 +155,10 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     target: { type: 'Flow' },
   },
   {
+    src: { field: 'flowDefinition', parentTypes: ['QuickAction'] },
+    target: { type: 'Flow' },
+  },
+  {
     src: { field: 'letterhead', parentTypes: ['EmailTemplate'] },
     target: { type: 'Letterhead' },
   },


### PR DESCRIPTION
Please don't merge without noise suppression
---

Added missing reference in ComponentInstanceProperty as well as in QuickAction
[Reference for flowDefinition](https://github.com/salto-io/adi-ws/blob/master/envs/env1/salesforce/Objects/test_custom_object__c/QuickAction/test_custom_object__c_Test_Action.nacl)
[Reference for LightningComponent (and Visualforce component most likely)](https://github.com/salto-io/adi-ws/blob/master/envs/env1/salesforce/Objects/test_custom_object__c/QuickAction/test_custom_object__c_test_lightning_component.nacl)
[Reference in ComponentInstanceProperty (note the second one, we don't have references for standard flows)](https://github.com/salto-io/adi-ws/blob/master/envs/env1/salesforce/Records/LightningPage/test_page.nacl)

---

_Release Notes_: 
Salesforce Adapter:
* Added missing references in ComponentInstanceProperty and QuickAction

---
_User Notifications_:  _None_
