### PR TITLE
SALTO-3571: Fix references of Some custom fields default values  - Jira

### DIFF
--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -144,6 +144,7 @@ export class ReferenceExpression {
     this.resValue = value
   }
 
+  // why the same name ?!
   async getResolvedValue(elementsSource?: ReadOnlyElementsSource): Promise<Value> {
     return getResolvedValue(this.elemID, elementsSource, this.value)
   }

--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -144,7 +144,6 @@ export class ReferenceExpression {
     this.resValue = value
   }
 
-  // why the same name ?!
   async getResolvedValue(elementsSource?: ReadOnlyElementsSource): Promise<Value> {
     return getResolvedValue(this.elemID, elementsSource, this.value)
   }

--- a/packages/jira-adapter/src/filters/field_references.ts
+++ b/packages/jira-adapter/src/filters/field_references.ts
@@ -26,7 +26,7 @@ const filter: FilterCreator = () => ({
   onFetch: async (elements: Element[]) => {
     await referenceUtils.addReferences({
       elements,
-      fieldsToGroupBy: ['id', 'name', 'originalName'],
+      fieldsToGroupBy: ['id', 'name', 'originalName', 'groupId'],
       defs: referencesRules,
       contextStrategyLookup,
       fieldReferenceResolverCreator: defs => new JiraFieldReferenceResolver(defs),

--- a/packages/jira-adapter/src/filters/fields/field_type_references_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/field_type_references_filter.ts
@@ -28,7 +28,7 @@ export const getFieldsLookUpName: GetLookupNameFunc = ({
 }) => {
   if (path !== undefined
     && (['optionId', 'cascadingOptionId'].includes(path.name)
-      || path.getFullNameParts()[path.getFullNameParts().length - 2] === 'optionIds')) {
+      || (path.typeName === 'CustomFieldContext' && path.getFullNameParts()[path.getFullNameParts().length - 2] === 'optionIds'))) {
     return ref.value.id
   }
   return ref

--- a/packages/jira-adapter/src/filters/fields/field_type_references_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/field_type_references_filter.ts
@@ -27,8 +27,9 @@ export const getFieldsLookUpName: GetLookupNameFunc = ({
   ref, path,
 }) => {
   if (path !== undefined
+    && path.typeName === 'CustomFieldContext'
     && (['optionId', 'cascadingOptionId'].includes(path.name)
-      || (path.typeName === 'CustomFieldContext' && path.getFullNameParts()[path.getFullNameParts().length - 2] === 'optionIds'))) {
+      || path.createParentID().name === 'optionIds')) {
     return ref.value.id
   }
   return ref
@@ -38,9 +39,9 @@ const getDefaultOptions = (instance: InstanceElement) : {
     referencedDefaultOptions: Values[]
     referencedCascadingDefaultOption?: Values } => {
   if (instance.value.defaultValue.optionIds !== undefined) {
-    const optionsById = _.keyBy(instance.value.defaultValue?.optionIds)
+    const optionsSet = new Set(instance.value.defaultValue?.optionIds)
     const referencedDefaultOptions = (Object.values(instance.value.options ?? {}) as Values[])
-      .filter((option: Values) => optionsById[option.id] !== undefined)
+      .filter((option: Values) => optionsSet.has(option.id))
     return { referencedDefaultOptions }
   }
   const referencedDefaultOptions = (Object.values(instance.value.options ?? {}) as Values[])

--- a/packages/jira-adapter/test/filters/fields/field_type_references.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_type_references.test.ts
@@ -49,6 +49,7 @@ describe('fields_references', () => {
           },
         },
         defaultValue: {
+          type: 'option.cascading',
           optionId: '1',
           cascadingOptionId: '3',
         },
@@ -62,6 +63,37 @@ describe('fields_references', () => {
     expect(instance.value.defaultValue.cascadingOptionId)
       .toBeInstanceOf(ReferenceExpression)
     expect(instance.value.defaultValue.cascadingOptionId.elemID.getFullName()).toBe('jira.CustomFieldContext.instance.instance.options.a1.cascadingOptions.c1')
+  })
+  it('should add references to multiple options', async () => {
+    const instance = new InstanceElement(
+      'instance',
+      fieldContextType,
+      {
+        name: 'name',
+        options: {
+          a1: {
+            id: '1',
+            value: 'a1',
+          },
+          b1: {
+            id: '2',
+            value: 'b1',
+          },
+        },
+        defaultValue: {
+          type: 'option.multiple',
+          optionIds: ['1', '2'],
+        },
+      },
+    )
+
+    await filter.onFetch([instance])
+
+    expect(instance.value.defaultValue.optionIds).toHaveLength(2)
+    expect(instance.value.defaultValue.optionIds[0]).toBeInstanceOf(ReferenceExpression)
+    expect(instance.value.defaultValue.optionIds[1]).toBeInstanceOf(ReferenceExpression)
+    expect(instance.value.defaultValue.optionIds[0].elemID.getFullName()).toBe('jira.CustomFieldContext.instance.instance.options.a1')
+    expect(instance.value.defaultValue.optionIds[1].elemID.getFullName()).toBe('jira.CustomFieldContext.instance.instance.options.b1')
   })
 
   it('should only change optionId if cascadingOptionId cannot be found', async () => {
@@ -77,6 +109,7 @@ describe('fields_references', () => {
           },
         },
         defaultValue: {
+          type: 'option.cascading',
           optionId: '1',
           cascadingOptionId: '3',
         },
@@ -96,6 +129,7 @@ describe('fields_references', () => {
       {
         name: 'name',
         defaultValue: {
+          type: 'option.cascading',
           optionId: '1',
           cascadingOptionId: '3',
         },
@@ -106,6 +140,114 @@ describe('fields_references', () => {
 
     expect(instance.value.defaultValue.optionId).toBe('1')
     expect(instance.value.defaultValue.cascadingOptionId).toBe('3')
+  })
+
+  it('should do nothing if all the optionIds references cannot be found - multiple options', async () => {
+    const instance = new InstanceElement(
+      'instance',
+      fieldContextType,
+      {
+        name: 'name',
+        defaultValue: {
+          type: 'option.multiple',
+          optionIds: ['3', '2'],
+        },
+      },
+    )
+
+    await filter.onFetch([instance])
+
+    expect(instance.value.defaultValue.optionIds).toHaveLength(2)
+    expect(instance.value.defaultValue.optionIds[0]).toBe('3')
+    expect(instance.value.defaultValue.optionIds[1]).toBe('2')
+  })
+
+  it('should do nothing if there is no options - multiple options', async () => {
+    const instance = new InstanceElement(
+      'instance',
+      fieldContextType,
+      {
+        name: 'name',
+        defaultValue: {
+          type: 'option.multiple',
+          // optionIds: ['3', '2'],
+        },
+      },
+    )
+
+    await filter.onFetch([instance])
+
+    expect(instance.value.defaultValue.optionIds).toBeUndefined()
+  })
+
+  it('should do nothing if there is no default optionsIds - multiple options', async () => {
+    const instance = new InstanceElement(
+      'instance',
+      fieldContextType,
+      {
+        name: 'name',
+        options: {
+          a1: {
+            id: '1',
+            value: 'a1',
+          },
+        },
+        defaultValue: {
+          type: 'option.multiple',
+        },
+      },
+    )
+
+    await filter.onFetch([instance])
+
+    expect(instance.value.defaultValue.optionIds).toBeUndefined()
+  })
+
+  it('should do nothing if there is no default optionsIds - cascading options', async () => {
+    const instance = new InstanceElement(
+      'instance',
+      fieldContextType,
+      {
+        name: 'name',
+        options: {
+          a1: {
+            id: '1',
+            value: 'a1',
+          },
+        },
+        defaultValue: {
+          type: 'option.cascading',
+        },
+      },
+    )
+
+    await filter.onFetch([instance])
+
+    expect(instance.value.defaultValue.optionIds).toBeUndefined()
+  })
+  it('should do nothing if there is no defaultValue', async () => {
+    const instance = new InstanceElement(
+      'instance',
+      fieldContextType,
+      {
+        name: 'name',
+        options: {
+          a1: {
+            id: '1',
+            value: 'a1',
+          },
+        },
+      },
+    )
+
+    await filter.onFetch([instance])
+
+    expect(instance.value.defaultValue).toBeUndefined()
+    expect(instance.value.options.a1)
+      .toEqual({
+        id: '1',
+        value: 'a1',
+      },)
   })
 
   it('Should do nothing when there are no contexts', async () => {

--- a/packages/jira-adapter/test/filters/fields/field_type_references.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_type_references.test.ts
@@ -162,6 +162,33 @@ describe('fields_references', () => {
     expect(instance.value.defaultValue.optionIds[1]).toBe('2')
   })
 
+  it('should convert only the optionIds that found to references - multiple options', async () => {
+    const instance = new InstanceElement(
+      'instance',
+      fieldContextType,
+      {
+        name: 'name',
+        options: {
+          a1: {
+            id: '1',
+            value: 'a1',
+          },
+        },
+        defaultValue: {
+          type: 'option.multiple',
+          optionIds: ['1', '2'],
+        },
+      },
+    )
+
+    await filter.onFetch([instance])
+
+    expect(instance.value.defaultValue.optionIds).toHaveLength(2)
+    expect(instance.value.defaultValue.optionIds[0]).toBeInstanceOf(ReferenceExpression)
+    expect(instance.value.defaultValue.optionIds[0].elemID.getFullName()).toBe('jira.CustomFieldContext.instance.instance.options.a1')
+    expect(instance.value.defaultValue.optionIds[1]).toBe('2')
+  })
+
   it('should do nothing if there is no options - multiple options', async () => {
     const instance = new InstanceElement(
       'instance',
@@ -170,7 +197,6 @@ describe('fields_references', () => {
         name: 'name',
         defaultValue: {
           type: 'option.multiple',
-          // optionIds: ['3', '2'],
         },
       },
     )


### PR DESCRIPTION

_Fix references of Some custom fields default values - Jira_

---

in this PR I added: 
* 4 references rules, 2 for cloud and 2 for DC (in DC there is no id for groups therefore the rules are different)
* refactored `fieldTypeReferencesFilter` so it will handle multiple options as well
---
_Release Notes_: 

Jira adapter:

* Added missing references in the default values of custom field context for the following types: select list (multiple), group picker (single and multiple) and project picker.

---
_User Notifications_: 

Jira adapter:
The default value of custom fields from the following types: select list (multiple), group picker (single and multiple) and project picker will convert to a reference expression.

