### PR TITLE
SALTO-3613 Allow idFields to reference template expressions

### DIFF
--- a/packages/adapter-components/src/filters/referenced_instance_names.ts
+++ b/packages/adapter-components/src/filters/referenced_instance_names.ts
@@ -58,11 +58,6 @@ const createInstanceReferencedNameParts = (
       return _.get(instance.value, fieldName)
     }
     const dereferenceFieldValue = (fieldValue: ReferenceExpression): string => {
-      if (!fieldValue.elemID.isTopLevel()) {
-        log.warn(`In instance: ${instance.elemID.getFullName()},
-          the reference expression: ${fieldValue.elemID.getFullName()},
-          of field ${fieldName} doesn't point to an element`)
-      }
       const { parent, path } = fieldValue.elemID.createTopLevelParentID()
       return [parent.name, ...path].join('.')
     }


### PR DESCRIPTION
* Extend the simple-adapters referenced-id-fields logic (which allows ids to be created based on reference expressions) to also correctly support template expressions (see examples in the tests)
* Change some existing fallbacks to be more robust - specifically, allow references to nested ids and to other elements

---
_Release Notes_: 
None (not user-facing)

---
_User Notifications_: 
None