### PR TITLE
SALTO-3612 Improve support address idFIelds to be multienv-friendly and unique

### DIFF
--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -158,6 +158,7 @@ export const DEFAULT_FILTERS = [
   usersFilter,
   organizationsFilter,
   tagsFilter,
+  // supportAddress should run before referencedIdFieldsFilter
   supportAddress,
   customStatus,
   guideAddBrandToArticleTranslation,

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -643,6 +643,7 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
   support_address: {
     transformation: {
       sourceTypeName: 'support_addresses__recipient_addresses',
+      idFields: ['name', '&email'],
       fieldTypeOverrides: [
         {
           fieldName: 'cname_status',

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -448,7 +448,7 @@ describe('adapter', () => {
           'zendesk.sla_policy_order',
           'zendesk.sla_policy_order.instance',
           'zendesk.support_address',
-          'zendesk.support_address.instance.myBrand',
+          'zendesk.support_address.instance.myBrand_support_myBrand_subdomain_zendesk_com@umvvv',
           'zendesk.support_addresses',
           'zendesk.tag',
           'zendesk.tag.instance.Social',
@@ -621,7 +621,7 @@ describe('adapter', () => {
           'zendesk.workspaces',
         ])
 
-        const supportAddress = elements.filter(isInstanceElement).find(e => e.elemID.getFullName().startsWith('zendesk.support_address.instance.myBrand'))
+        const supportAddress = elements.filter(isInstanceElement).find(e => e.elemID.getFullName().startsWith('zendesk.support_address.instance.myBrand_support_myBrand_subdomain_zendesk_com@umvvv'))
         const brand = elements.filter(isInstanceElement).find(e => e.elemID.getFullName().startsWith('zendesk.brand.instance.myBrand'))
         expect(brand).toBeDefined()
         if (brand === undefined) {


### PR DESCRIPTION
Change the default configuration for `support_address` so that it contains both the name and the email - while keeping the email multienv-friendly, since it often contains the brand's subdomain which is different per env.

---

For example, the following instance
```
zendesk.support_address <...> {
  name = "Salto"
  email = "support@${ zendesk.brand.instance.Salto.subdomain }.zendesk.com"
  ...
}
```
will be assigned the id `zendesk.support_address.instance.Salto_support_Salto_subdomain_zendesk_com@umvvv` - concatenating the name `Salto` and the email-with-template `support@Salto.subdomain.zendesk.com`

---
_Release Notes_: 
_Zendesk adapter_:
* Support address instance ids now also contain details from the email address, to reduce the chance of conflicting ids in cases where multiple addresses were given the same name

---
_User Notifications_: 
_Zendesk adapter_:
* `support_address` instance elem IDs will change to a better format (name + email), which is more likely to be unique, when fetching new environments / re-fetching existing environments with `regenerate Salto IDs`. no impact is expected on existing environments.