### PR TITLE
SALTO-3563: GroupRule deployment and deploy Okta expression language

### DIFF
--- a/packages/okta-adapter/src/change_validators/group_rule_actions.ts
+++ b/packages/okta-adapter/src/change_validators/group_rule_actions.ts
@@ -1,0 +1,47 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { ChangeValidator, getChangeData, isInstanceChange, InstanceElement, ChangeError, isModificationChange, ModificationChange } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { GROUP_RULE_TYPE_NAME } from '../constants'
+
+const { awu } = collections.asynciterable
+
+const isGroupRuleActionsChange = (
+  change: ModificationChange<InstanceElement>
+): boolean => {
+  const { before, after } = change.data
+  return !_.isEqual(before.value.actions, after.value.actions)
+}
+
+/**
+ * Verifies GroupRule actions object did not change
+ */
+export const groupRuleActionsValidator: ChangeValidator = async changes => (
+  awu(changes)
+    .filter(isInstanceChange)
+    .filter(isModificationChange)
+    .filter(change => getChangeData(change).elemID.typeName === GROUP_RULE_TYPE_NAME)
+    .filter(isGroupRuleActionsChange)
+    .map(getChangeData)
+    .map((instance: InstanceElement): ChangeError => ({
+      elemID: instance.elemID,
+      severity: 'Error',
+      message: `Cannot change ${GROUP_RULE_TYPE_NAME} actions`,
+      detailedMessage: `Cannot change ${GROUP_RULE_TYPE_NAME} because actions section can not be changed for existing rules.`,
+    }))
+    .toArray()
+)

--- a/packages/okta-adapter/src/change_validators/group_rule_actions.ts
+++ b/packages/okta-adapter/src/change_validators/group_rule_actions.ts
@@ -13,8 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import _ from 'lodash'
-import { ChangeValidator, getChangeData, isInstanceChange, InstanceElement, ChangeError, isModificationChange, ModificationChange } from '@salto-io/adapter-api'
+import { ChangeValidator, getChangeData, isInstanceChange, InstanceElement, ChangeError, isModificationChange, ModificationChange, isEqualValues } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { GROUP_RULE_TYPE_NAME } from '../constants'
 
@@ -24,7 +23,7 @@ const isGroupRuleActionsChange = (
   change: ModificationChange<InstanceElement>
 ): boolean => {
   const { before, after } = change.data
-  return !_.isEqual(before.value.actions, after.value.actions)
+  return !isEqualValues(before.value.actions, after.value.actions)
 }
 
 /**

--- a/packages/okta-adapter/src/change_validators/group_rule_status.ts
+++ b/packages/okta-adapter/src/change_validators/group_rule_status.ts
@@ -1,0 +1,70 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ChangeValidator, getChangeData, isInstanceChange, InstanceElement, ChangeError, isAdditionOrModificationChange, isModificationChange, AdditionChange, ModificationChange } from '@salto-io/adapter-api'
+import { collections, values } from '@salto-io/lowerdash'
+import { GROUP_RULE_TYPE_NAME } from '../constants'
+
+const { awu } = collections.asynciterable
+const ACTIVE_STATUS = 'ACTIVE'
+const INVALID_STATUS = 'INVALID'
+const INACTIVE_STATUS = 'INACTIVE'
+
+const getGroupRuleStatusError = (
+  change: AdditionChange<InstanceElement> | ModificationChange<InstanceElement>
+): ChangeError | undefined => {
+  const instance = getChangeData(change)
+  if (isModificationChange(change)) {
+    const { before, after } = change.data
+    if (before.value.status === INVALID_STATUS) {
+      return {
+        elemID: instance.elemID,
+        severity: 'Error',
+        message: `Cannot change group rule with status ${INVALID_STATUS}`,
+        detailedMessage: `Cannot deploy group rule: ${instance.elemID.name}, because group rules with status ${INVALID_STATUS} can not be changed`,
+      }
+    }
+    if (before.value.status !== after.value.status) {
+      return {
+        elemID: instance.elemID,
+        severity: 'Error',
+        message: 'Cannot change status of group rule',
+        detailedMessage: `Cannot deploy group rule: ${instance.elemID.name}, because group rule status cannot be changed using salto`,
+      }
+    }
+  }
+  // AdditionChange
+  if (instance.value.status === ACTIVE_STATUS) {
+    return {
+      elemID: instance.elemID,
+      severity: 'Error',
+      message: `Cannot add group rule with status ${ACTIVE_STATUS}`,
+      detailedMessage: `Cannot deploy group rule: ${instance.elemID.name}, group rule status must be set to ${INACTIVE_STATUS} when created`,
+    }
+  }
+  return undefined
+}
+/**
+ * Validate GroupRule status before deployment
+ */
+export const groupRuleStatusValidator: ChangeValidator = async changes => (
+  awu(changes)
+    .filter(isInstanceChange)
+    .filter(isAdditionOrModificationChange)
+    .filter(change => getChangeData(change).elemID.typeName === GROUP_RULE_TYPE_NAME)
+    .map(getGroupRuleStatusError)
+    .filter(values.isDefined)
+    .toArray()
+)

--- a/packages/okta-adapter/src/change_validators/group_rule_status.ts
+++ b/packages/okta-adapter/src/change_validators/group_rule_status.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ChangeValidator, getChangeData, isInstanceChange, InstanceElement, ChangeError, isAdditionOrModificationChange, isModificationChange, AdditionChange, ModificationChange } from '@salto-io/adapter-api'
+import { ChangeValidator, getChangeData, isInstanceChange, InstanceElement, ChangeError, isModificationChange, Change, isRemovalChange } from '@salto-io/adapter-api'
 import { collections, values } from '@salto-io/lowerdash'
 import { GROUP_RULE_TYPE_NAME } from '../constants'
 
@@ -23,25 +23,40 @@ const INVALID_STATUS = 'INVALID'
 const INACTIVE_STATUS = 'INACTIVE'
 
 const getGroupRuleStatusError = (
-  change: AdditionChange<InstanceElement> | ModificationChange<InstanceElement>
+  change: Change<InstanceElement>
 ): ChangeError | undefined => {
   const instance = getChangeData(change)
+  const statusActiveChange: ChangeError = {
+    elemID: instance.elemID,
+    severity: 'Error',
+    message: `Cannot change ${GROUP_RULE_TYPE_NAME} with status ${ACTIVE_STATUS}`,
+    detailedMessage: `Cannot change ${GROUP_RULE_TYPE_NAME} with status ${ACTIVE_STATUS}. Please change instance status to ${INACTIVE_STATUS} and try again.`,
+  }
+
+  if (isRemovalChange(change)) {
+    return instance.value.status === ACTIVE_STATUS ? statusActiveChange : undefined
+  }
   if (isModificationChange(change)) {
     const { before, after } = change.data
-    if (before.value.status === INVALID_STATUS) {
+    const { status } = before.value
+    if (before.value.status !== after.value.status) {
+      // TODO remove after SALTO-3591
       return {
         elemID: instance.elemID,
         severity: 'Error',
-        message: `Cannot change group rule with status ${INVALID_STATUS}`,
-        detailedMessage: `Cannot deploy group rule: ${instance.elemID.name}, because group rules with status ${INVALID_STATUS} can not be changed`,
+        message: `Cannot change ${GROUP_RULE_TYPE_NAME} status`,
+        detailedMessage: `Cannot change ${GROUP_RULE_TYPE_NAME} status, please make this change in Okta.`,
       }
     }
-    if (before.value.status !== after.value.status) {
+    if (before.value.status === ACTIVE_STATUS) {
+      return statusActiveChange
+    }
+    if (status === INVALID_STATUS) {
       return {
         elemID: instance.elemID,
         severity: 'Error',
-        message: 'Cannot change status of group rule',
-        detailedMessage: `Cannot deploy group rule: ${instance.elemID.name}, because group rule status cannot be changed using salto`,
+        message: `Cannot change ${GROUP_RULE_TYPE_NAME} with status ${INVALID_STATUS}`,
+        detailedMessage: `Cannot modify ${GROUP_RULE_TYPE_NAME} with status ${INVALID_STATUS}. You can remove this instance and create a new one.`,
       }
     }
   }
@@ -50,19 +65,19 @@ const getGroupRuleStatusError = (
     return {
       elemID: instance.elemID,
       severity: 'Error',
-      message: `Cannot add group rule with status ${ACTIVE_STATUS}`,
-      detailedMessage: `Cannot deploy group rule: ${instance.elemID.name}, group rule status must be set to ${INACTIVE_STATUS} when created`,
+      message: `Cannot add ${GROUP_RULE_TYPE_NAME} with status ${ACTIVE_STATUS}`,
+      detailedMessage: `${GROUP_RULE_TYPE_NAME} must be craeted with status ${INACTIVE_STATUS}`,
     }
   }
   return undefined
 }
+
 /**
  * Validate GroupRule status before deployment
  */
 export const groupRuleStatusValidator: ChangeValidator = async changes => (
   awu(changes)
     .filter(isInstanceChange)
-    .filter(isAdditionOrModificationChange)
     .filter(change => getChangeData(change).elemID.typeName === GROUP_RULE_TYPE_NAME)
     .map(getGroupRuleStatusError)
     .filter(values.isDefined)

--- a/packages/okta-adapter/src/change_validators/index.ts
+++ b/packages/okta-adapter/src/change_validators/index.ts
@@ -18,6 +18,8 @@ import { deployment } from '@salto-io/adapter-components'
 import { createChangeValidator } from '@salto-io/adapter-utils'
 import { applicationValidator } from './application'
 import { applicationFieldsValidator } from './application_addition_fields'
+import { groupRuleStatusValidator } from './group_rule_status'
+import { groupRuleActionsValidator } from './group_rule_actions'
 
 export default (
 ): ChangeValidator => {
@@ -25,6 +27,8 @@ export default (
     ...deployment.changeValidators.getDefaultChangeValidators(),
     applicationValidator,
     applicationFieldsValidator,
+    groupRuleStatusValidator,
+    groupRuleActionsValidator,
   ]
 
   return createChangeValidator(validators)

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -598,6 +598,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
       add: {
         url: '/api/v1/groups/rules',
         method: 'post',
+        // status update is not supported in this endpoint
         fieldsToIgnore: ['status', 'allGroupsValid'],
       },
       modify: {
@@ -606,6 +607,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
         urlParamsToFields: {
           ruleId: 'id',
         },
+        // status update is not supported in this endpoint
         fieldsToIgnore: ['status', 'allGroupsValid'],
       },
       remove: {

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -594,6 +594,28 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
       serviceIdField: 'id',
       fieldsToHide: [{ fieldName: 'id' }],
     },
+    deployRequests: {
+      add: {
+        url: '/api/v1/groups/rules',
+        method: 'post',
+        fieldsToIgnore: ['status', 'allGroupsValid'],
+      },
+      modify: {
+        url: '/api/v1/groups/rules/{ruleId}',
+        method: 'put',
+        urlParamsToFields: {
+          ruleId: 'id',
+        },
+        fieldsToIgnore: ['status', 'allGroupsValid'],
+      },
+      remove: {
+        url: '/api/v1/groups/rules/{ruleId}',
+        method: 'delete',
+        urlParamsToFields: {
+          ruleId: 'id',
+        },
+      },
+    },
   },
   InlineHook: {
     transformation: {

--- a/packages/okta-adapter/src/filters/expression_language.ts
+++ b/packages/okta-adapter/src/filters/expression_language.ts
@@ -14,10 +14,13 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { Element, InstanceElement, isInstanceElement, isTemplateExpression, ReferenceExpression, TemplateExpression } from '@salto-io/adapter-api'
-import { extractTemplate, resolvePath } from '@salto-io/adapter-utils'
+import { Change, Element, getChangeData, InstanceElement, isInstanceElement, isTemplateExpression, ReferenceExpression, TemplateExpression, TemplatePart } from '@salto-io/adapter-api'
+import { extractTemplate, replaceTemplatesWithValues, resolvePath, resolveTemplates, safeJsonStringify } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
 import { GROUP_RULE_TYPE_NAME, GROUP_TYPE_NAME, POLICY_RULE_TYPE_NAME, USER_SCHEMA_TYPE_NAME } from '../constants'
+
+const log = logger(module)
 
 const USER_SCHEMA_REGEX = /(user\.[a-zA-Z0-9_]+)/g // pattern: user.someString
 const USER_SCHEMA_IE_REGEX = /(user\.profile\.[a-zA-Z0-9_]+)/g // pattern: user.profile.someString
@@ -31,6 +34,7 @@ type ExpressionLanguageDef = {
   pathToContainer: string[]
   fieldName: string
   patterns: RegExp[]
+  isIdentityEngine: boolean
 }
 
 const TYPE_TO_DEF: Record<string, ExpressionLanguageDef> = {
@@ -38,11 +42,13 @@ const TYPE_TO_DEF: Record<string, ExpressionLanguageDef> = {
     pathToContainer: ['conditions', 'expression'],
     fieldName: 'value',
     patterns: [ID_REGEX, USER_SCHEMA_REGEX],
+    isIdentityEngine: false,
   },
   [POLICY_RULE_TYPE_NAME]: {
     pathToContainer: ['conditions', 'additionalProperties', 'elCondition'],
     fieldName: 'condition',
     patterns: [ID_REGEX, USER_SCHEMA_IE_REGEX],
+    isIdentityEngine: true,
   },
 }
 
@@ -67,6 +73,23 @@ const getUserSchemaReference = (
     )
   }
   return undefined
+}
+
+const createPrepRefFunc = (isIdentityEngine: boolean):(part: ReferenceExpression) => TemplatePart => {
+  const prepRef = (part: ReferenceExpression): TemplatePart => {
+    if (part.elemID.typeName === USER_SCHEMA_TYPE_NAME) {
+      const userSchemaField = part.elemID.getFullNameParts().pop()
+      if (!_.isString(userSchemaField)) {
+        throw new Error(`Received an invalid value inside a template expression ${part.elemID.getFullName()}: ${safeJsonStringify(part.value)}`)
+      }
+      return `${isIdentityEngine ? USER_SCHEMA_IE_PREFIX : USER_SCHEMA_PREFIX}${userSchemaField}`
+    }
+    if (part.elemID.isTopLevel()) {
+      return `"${part.value.value.id}"`
+    }
+    return part
+  }
+  return prepRef
 }
 
 /**
@@ -110,28 +133,78 @@ const stringToTemplate = (
 /**
  * Create template expressions for okta expression language references
  */
-const filter: FilterCreator = () => ({
-  name: 'oktaExpressionLanguageFilter',
-  onFetch: async (elements: Element[]) => {
-    const instances = elements.filter(isInstanceElement)
-    const potentialExpressionInstances = instances
-      .filter(instance => Object.keys(TYPE_TO_DEF).includes(instance.elemID.typeName))
-    const potentialTargetInstances = instances
-      .filter(instance => [GROUP_TYPE_NAME, USER_SCHEMA_TYPE_NAME].includes(instance.elemID.typeName))
+const filter: FilterCreator = () => {
+  const changeToTemplateMapping: Record<string, TemplateExpression> = {}
+  return ({
+    name: 'oktaExpressionLanguageFilter',
+    onFetch: async (elements: Element[]) => {
+      const instances = elements.filter(isInstanceElement)
+      const potentialExpressionInstances = instances
+        .filter(instance => Object.keys(TYPE_TO_DEF).includes(instance.elemID.typeName))
+      const potentialTargetInstances = instances
+        .filter(instance => [GROUP_TYPE_NAME, USER_SCHEMA_TYPE_NAME].includes(instance.elemID.typeName))
 
-    potentialExpressionInstances
-      .forEach(instance => {
-        const { pathToContainer, fieldName, patterns } = TYPE_TO_DEF[instance.elemID.typeName]
-        const container = resolvePath(instance, instance.elemID.createNestedID(...pathToContainer))
-        const expressionValue = container?.[fieldName]
-        if (_.isString(expressionValue)) {
-          const template = stringToTemplate(expressionValue, patterns, potentialTargetInstances)
-          if (isTemplateExpression(template)) {
-            _.set(container, fieldName, template)
+      potentialExpressionInstances
+        .forEach(instance => {
+          const { pathToContainer, fieldName, patterns } = TYPE_TO_DEF[instance.elemID.typeName]
+          const container = resolvePath(instance, instance.elemID.createNestedID(...pathToContainer))
+          const expressionValue = container?.[fieldName]
+          if (_.isString(expressionValue)) {
+            const template = stringToTemplate(expressionValue, patterns, potentialTargetInstances)
+            if (isTemplateExpression(template)) {
+              _.set(container, fieldName, template)
+            }
           }
-        }
-      })
-  },
-})
+        })
+    },
+
+    preDeploy: async (changes: Change<InstanceElement>[]) => {
+      changes
+        .map(getChangeData)
+        .filter(isInstanceElement)
+        .filter(instance => Object.keys(TYPE_TO_DEF).includes(instance.elemID.typeName))
+        .forEach(
+          async instance => {
+            const { pathToContainer, fieldName, isIdentityEngine } = TYPE_TO_DEF[instance.elemID.typeName]
+            const container = resolvePath(instance, instance.elemID.createNestedID(...pathToContainer))
+            const expressionValue = container?.[fieldName]
+            if (isTemplateExpression(expressionValue)) {
+              try {
+                replaceTemplatesWithValues(
+                  { values: [container], fieldName },
+                  changeToTemplateMapping,
+                  createPrepRefFunc(isIdentityEngine),
+                )
+              } catch (e) {
+                log.error(`Error parsing templates in instance ${instance.elemID.getFullName()} before deployment`, e)
+              }
+            }
+          }
+        )
+    },
+
+
+    onDeploy: async (changes: Change<InstanceElement>[]) => {
+      changes
+        .map(getChangeData)
+        .filter(isInstanceElement)
+        .filter(instance => Object.keys(TYPE_TO_DEF).includes(instance.elemID.typeName))
+        .forEach(
+          async instance => {
+            const { pathToContainer, fieldName } = TYPE_TO_DEF[instance.elemID.typeName]
+            const container = resolvePath(instance, instance.elemID.createNestedID(...pathToContainer))
+            const expressionValue = container?.[fieldName]
+            if (_.isString(expressionValue)) {
+              try {
+                resolveTemplates({ values: [container], fieldName }, changeToTemplateMapping)
+              } catch (e) {
+                log.error(`Error restoring templates in instance ${instance.elemID.getFullName()} after deployment`, e)
+              }
+            }
+          }
+        )
+    },
+  })
+}
 
 export default filter

--- a/packages/okta-adapter/test/change_validators/group_rule_actions.test.ts
+++ b/packages/okta-adapter/test/change_validators/group_rule_actions.test.ts
@@ -1,0 +1,93 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { toChange, ObjectType, ElemID, InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
+import { groupRuleActionsValidator } from '../../src/change_validators/group_rule_actions'
+import { OKTA, GROUP_RULE_TYPE_NAME, GROUP_TYPE_NAME } from '../../src/constants'
+
+describe('groupRuleActionsValidator', () => {
+  const groupRuleType = new ObjectType({ elemID: new ElemID(OKTA, GROUP_RULE_TYPE_NAME) })
+  const groupType = new ObjectType({ elemID: new ElemID(OKTA, GROUP_TYPE_NAME) })
+  const group1 = new InstanceElement(
+    'group1',
+    groupType,
+    { type: 'OKTA_GROUP', profile: { name: 'group1' } },
+  )
+  const group2 = new InstanceElement(
+    'group2',
+    groupType,
+    { type: 'OKTA_GROUP', profile: { name: 'group2' } },
+  )
+  const groupRule1 = new InstanceElement(
+    'groupRule1',
+    groupRuleType,
+    {
+      name: 'rule',
+      status: 'ACTIVE',
+      conditions: {},
+      actions: { assignUserToGroups: { groupIds: [new ReferenceExpression(group1.elemID, group1)] } },
+    },
+  )
+
+  const groupRule2 = new InstanceElement(
+    'groupRule1',
+    groupRuleType,
+    {
+      name: 'rule',
+      status: 'ACTIVE',
+      actions: { assignUserToGroups: { groupIds: [new ReferenceExpression(group1.elemID, group1)] } },
+    },
+  )
+
+  it('should return an error if actions object changed', async () => {
+    const changedGroupRule1 = groupRule1.clone()
+    changedGroupRule1.value.actions.assignUserToGroups.groupIds = [
+      new ReferenceExpression(group1.elemID, group1),
+      new ReferenceExpression(group2.elemID, group2),
+    ]
+    const changedGroupRule2 = groupRule1.clone()
+    changedGroupRule2.value.actions.assignUserToGroups.groupIds = [new ReferenceExpression(group2.elemID, group2)]
+    const changeErrors = await groupRuleActionsValidator(
+      [
+        toChange({ before: groupRule1, after: changedGroupRule1 }),
+        toChange({ before: groupRule2, after: changedGroupRule1 }),
+      ]
+    )
+    expect(changeErrors).toHaveLength(2)
+    expect(changeErrors).toEqual([
+      {
+        elemID: changedGroupRule1.elemID,
+        severity: 'Error',
+        message: `Cannot change ${GROUP_RULE_TYPE_NAME} actions`,
+        detailedMessage: `Cannot change ${GROUP_RULE_TYPE_NAME} because actions section can not be changed for existing rules.`,
+      },
+      {
+        elemID: changedGroupRule2.elemID,
+        severity: 'Error',
+        message: `Cannot change ${GROUP_RULE_TYPE_NAME} actions`,
+        detailedMessage: `Cannot change ${GROUP_RULE_TYPE_NAME} because actions section can not be changed for existing rules.`,
+      },
+    ])
+  })
+
+  it('should return no error if actions object did not changed', async () => {
+    const changedGroupRule1 = groupRule1.clone()
+    changedGroupRule1.value.name = 'ruleee'
+    const changeErrors = await groupRuleActionsValidator(
+      [toChange({ before: groupRule1, after: changedGroupRule1 })]
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
+})

--- a/packages/okta-adapter/test/change_validators/group_rule_status.test.ts
+++ b/packages/okta-adapter/test/change_validators/group_rule_status.test.ts
@@ -1,0 +1,118 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { toChange, ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { groupRuleStatusValidator } from '../../src/change_validators/group_rule_status'
+import { OKTA, GROUP_RULE_TYPE_NAME } from '../../src/constants'
+
+describe('groupRuleStatusValidator', () => {
+  const groupRuleType = new ObjectType({ elemID: new ElemID(OKTA, GROUP_RULE_TYPE_NAME) })
+  const groupRule1 = new InstanceElement(
+    'groupRule1',
+    groupRuleType,
+    {
+      name: 'rule',
+      status: 'ACTIVE',
+      conditions: {},
+    },
+  )
+  const groupRule2 = new InstanceElement(
+    'groupRule2',
+    groupRuleType,
+    {
+      name: 'rule',
+      status: 'ACTIVE',
+      conditions: {},
+    },
+  )
+  const groupRule3 = new InstanceElement(
+    'groupRule3',
+    groupRuleType,
+    {
+      name: 'rule',
+      status: 'INVALID',
+      conditions: {},
+    },
+  )
+
+  it('should return an error in case of change of group rule in status ACTIVE', async () => {
+    const changeErrors = await groupRuleStatusValidator(
+      [
+        toChange({ before: groupRule1 }),
+        toChange({ before: groupRule2, after: groupRule2 }),
+      ]
+    )
+    expect(changeErrors).toHaveLength(2)
+    expect(changeErrors).toEqual([
+      {
+        elemID: groupRule1.elemID,
+        severity: 'Error',
+        message: `Cannot change ${GROUP_RULE_TYPE_NAME} with status ACTIVE`,
+        detailedMessage: `Cannot change ${GROUP_RULE_TYPE_NAME} with status ACTIVE. Please change instance status to INACTIVE and try again.`,
+      },
+      {
+        elemID: groupRule2.elemID,
+        severity: 'Error',
+        message: `Cannot change ${GROUP_RULE_TYPE_NAME} with status ACTIVE`,
+        detailedMessage: `Cannot change ${GROUP_RULE_TYPE_NAME} with status ACTIVE. Please change instance status to INACTIVE and try again.`,
+      },
+    ])
+  })
+  it('should return an error when trying to change group rule in status INVALID', async () => {
+    const changeErrors = await groupRuleStatusValidator(
+      [toChange({ before: groupRule3, after: groupRule3 })]
+    )
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors).toEqual([
+      {
+        elemID: groupRule3.elemID,
+        severity: 'Error',
+        message: `Cannot change ${GROUP_RULE_TYPE_NAME} with status INVALID`,
+        detailedMessage: `Cannot modify ${GROUP_RULE_TYPE_NAME} with status INVALID. You can remove this instance and create a new one.`,
+      },
+    ])
+  })
+  it('should return an when add a new group rule with status ACTIVE', async () => {
+    const changeErrors = await groupRuleStatusValidator(
+      [toChange({ after: groupRule1 })]
+    )
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors).toEqual([
+      {
+        elemID: groupRule1.elemID,
+        severity: 'Error',
+        message: `Cannot add ${GROUP_RULE_TYPE_NAME} with status ACTIVE`,
+        detailedMessage: `${GROUP_RULE_TYPE_NAME} must be craeted with status INACTIVE`,
+      },
+    ])
+  })
+  // TODO remove test after SALTO-3591
+  it('should return an error when trying to change group rule status', async () => {
+    const groupRule1WithNewStatus = groupRule1.clone()
+    groupRule1WithNewStatus.value.status = 'INACTIVE'
+    const changeErrors = await groupRuleStatusValidator(
+      [toChange({ before: groupRule1, after: groupRule1WithNewStatus })]
+    )
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors).toEqual([
+      {
+        elemID: groupRule1.elemID,
+        severity: 'Error',
+        message: `Cannot change ${GROUP_RULE_TYPE_NAME} status`,
+        detailedMessage: `Cannot change ${GROUP_RULE_TYPE_NAME} status, please make this change in Okta.`,
+      },
+    ])
+  })
+})

--- a/packages/okta-adapter/test/change_validators/group_rule_status.test.ts
+++ b/packages/okta-adapter/test/change_validators/group_rule_status.test.ts
@@ -59,14 +59,14 @@ describe('groupRuleStatusValidator', () => {
       {
         elemID: groupRule1.elemID,
         severity: 'Error',
-        message: `Cannot change ${GROUP_RULE_TYPE_NAME} with status ACTIVE`,
-        detailedMessage: `Cannot change ${GROUP_RULE_TYPE_NAME} with status ACTIVE. Please change instance status to INACTIVE and try again.`,
+        message: `Cannot remove ${GROUP_RULE_TYPE_NAME} with status ACTIVE`,
+        detailedMessage: `Cannot remove ${GROUP_RULE_TYPE_NAME} with status ACTIVE. Please change instance status to INACTIVE and try again.`,
       },
       {
         elemID: groupRule2.elemID,
         severity: 'Error',
-        message: `Cannot change ${GROUP_RULE_TYPE_NAME} with status ACTIVE`,
-        detailedMessage: `Cannot change ${GROUP_RULE_TYPE_NAME} with status ACTIVE. Please change instance status to INACTIVE and try again.`,
+        message: `Cannot modify ${GROUP_RULE_TYPE_NAME} with status ACTIVE`,
+        detailedMessage: `Cannot modify ${GROUP_RULE_TYPE_NAME} with status ACTIVE. Please change instance status to INACTIVE and try again.`,
       },
     ])
   })
@@ -79,7 +79,7 @@ describe('groupRuleStatusValidator', () => {
       {
         elemID: groupRule3.elemID,
         severity: 'Error',
-        message: `Cannot change ${GROUP_RULE_TYPE_NAME} with status INVALID`,
+        message: `Cannot modify ${GROUP_RULE_TYPE_NAME} with status INVALID`,
         detailedMessage: `Cannot modify ${GROUP_RULE_TYPE_NAME} with status INVALID. You can remove this instance and create a new one.`,
       },
     ])
@@ -94,7 +94,7 @@ describe('groupRuleStatusValidator', () => {
         elemID: groupRule1.elemID,
         severity: 'Error',
         message: `Cannot add ${GROUP_RULE_TYPE_NAME} with status ACTIVE`,
-        detailedMessage: `${GROUP_RULE_TYPE_NAME} must be craeted with status INACTIVE`,
+        detailedMessage: `${GROUP_RULE_TYPE_NAME} must be created with status INACTIVE`,
       },
     ])
   })
@@ -110,8 +110,8 @@ describe('groupRuleStatusValidator', () => {
       {
         elemID: groupRule1.elemID,
         severity: 'Error',
-        message: `Cannot change ${GROUP_RULE_TYPE_NAME} status`,
-        detailedMessage: `Cannot change ${GROUP_RULE_TYPE_NAME} status, please make this change in Okta.`,
+        message: `Cannot modify ${GROUP_RULE_TYPE_NAME} status`,
+        detailedMessage: `Cannot modify ${GROUP_RULE_TYPE_NAME} status, please make this change in Okta.`,
       },
     ])
   })

--- a/packages/okta-adapter/test/filters/expression_language.test.ts
+++ b/packages/okta-adapter/test/filters/expression_language.test.ts
@@ -14,14 +14,14 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { ElemID, InstanceElement, ObjectType, ReferenceExpression, TemplateExpression, isInstanceElement } from '@salto-io/adapter-api'
+import { ElemID, InstanceElement, ObjectType, ReferenceExpression, TemplateExpression, isInstanceElement, toChange, getChangeData } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import { getFilterParams } from '../utils'
 import oktaExpressionLanguageFilter from '../../src/filters/expression_language'
 import { GROUP_RULE_TYPE_NAME, GROUP_TYPE_NAME, OKTA, POLICY_RULE_TYPE_NAME, USER_SCHEMA_TYPE_NAME } from '../../src/constants'
 
 describe('expression language filter', () => {
-      type FilterType = filterUtils.FilterWith<'onFetch'>
+      type FilterType = filterUtils.FilterWith<'onFetch' | 'onDeploy' | 'preDeploy'>
       let filter: FilterType
       const userSchemaType = new ObjectType({ elemID: new ElemID(OKTA, USER_SCHEMA_TYPE_NAME) })
       const groupType = new ObjectType({ elemID: new ElemID(OKTA, GROUP_TYPE_NAME) })
@@ -29,13 +29,13 @@ describe('expression language filter', () => {
       const policyRuleType = new ObjectType({ elemID: new ElemID(OKTA, POLICY_RULE_TYPE_NAME) })
       const customPath = ['definitions', 'custom', 'properties', 'additionalProperties', 'saltoDepartment']
       const basePath = ['definitions', 'base', 'properties', 'department']
-      const groupRuleWithTemplate = new InstanceElement(
+      const groupRuleWithExpression = new InstanceElement(
         'groupRuleTest',
         groupRuleType,
         {
           conditions: {
             expression: {
-              value: '(String.stringContains(user.department, "salto") OR isMemberOfGroupNameRegex("/.*admin.*")) AND isMemberOfAnyGroup("123A") AND !isMemberOfAnyGroup("234B", \'345C\')',
+              value: '(String.stringContains(user.department, "salto") OR isMemberOfGroupNameRegex("/.*admin.*")) AND isMemberOfAnyGroup("123A") AND !isMemberOfAnyGroup("234B", "345C")',
             },
           },
         }
@@ -72,7 +72,7 @@ describe('expression language filter', () => {
           },
         }
       )
-      const policyRuleInstance = new InstanceElement(
+      const policyRuleWithExpression = new InstanceElement(
         'policyRuleTest',
         policyRuleType,
         {
@@ -86,6 +86,35 @@ describe('expression language filter', () => {
           },
         }
       )
+      const groupRuleTemplate = new TemplateExpression({
+        parts: [
+          '(String.stringContains(',
+          new ReferenceExpression(
+            userSchemaInstance.elemID.createNestedID(...basePath),
+            _.get(userSchemaInstance.value, basePath)
+          ),
+          ', "salto") OR isMemberOfGroupNameRegex("/.*admin.*")) AND isMemberOfAnyGroup(',
+          new ReferenceExpression(groupInstances[0].elemID, groupInstances[0]),
+          ') AND !isMemberOfAnyGroup(',
+          new ReferenceExpression(groupInstances[1].elemID, groupInstances[1]),
+          ', ',
+          new ReferenceExpression(groupInstances[2].elemID, groupInstances[2]),
+          ')',
+        ],
+      })
+      const policyRuleTemplate = new TemplateExpression({
+        parts: [
+          new ReferenceExpression(
+            userSchemaInstance.elemID.createNestedID(...customPath),
+            _.get(userSchemaInstance.value, customPath)
+          ),
+          ' == \'salto\' AND user.isMemberOf({\'group.id\':{',
+          new ReferenceExpression(groupInstances[2].elemID, groupInstances[2]),
+          ', ',
+          new ReferenceExpression(groupInstances[0].elemID, groupInstances[0]),
+          '}})',
+        ],
+      })
 
       beforeEach(() => {
         filter = oktaExpressionLanguageFilter(getFilterParams()) as typeof filter
@@ -93,43 +122,16 @@ describe('expression language filter', () => {
 
       describe('onFetch', () => {
         it('should resolve templates in instances', async () => {
-          const elements = [userSchemaType, groupType, groupRuleType, policyRuleInstance, policyRuleType,
-            groupRuleWithTemplate, ...groupInstances, userSchemaInstance]
+          const elements = [userSchemaType, groupType, groupRuleType, policyRuleWithExpression, policyRuleType,
+            groupRuleWithExpression, ...groupInstances, userSchemaInstance]
           await filter.onFetch(elements)
           const groupRule = elements.filter(isInstanceElement).find(i => i.elemID.name === 'groupRuleTest')
           expect(groupRule).toBeDefined()
-          expect(groupRule?.value?.conditions?.expression?.value).toEqual(new TemplateExpression({
-            parts: [
-              '(String.stringContains(',
-              new ReferenceExpression(
-                userSchemaInstance.elemID.createNestedID(...basePath),
-                _.get(userSchemaInstance.value, basePath)
-              ),
-              ', "salto") OR isMemberOfGroupNameRegex("/.*admin.*")) AND isMemberOfAnyGroup(',
-              new ReferenceExpression(groupInstances[0].elemID, groupInstances[0]),
-              ') AND !isMemberOfAnyGroup(',
-              new ReferenceExpression(groupInstances[1].elemID, groupInstances[1]),
-              ', ',
-              new ReferenceExpression(groupInstances[2].elemID, groupInstances[2]),
-              ')',
-            ],
-          }))
+          expect(groupRule?.value?.conditions?.expression?.value).toEqual(groupRuleTemplate)
           const policyRule = elements.filter(isInstanceElement).find(i => i.elemID.name === 'policyRuleTest')
           expect(policyRule).toBeDefined()
           expect(policyRule?.value?.conditions?.additionalProperties?.elCondition?.condition)
-            .toEqual(new TemplateExpression({
-              parts: [
-                new ReferenceExpression(
-                  userSchemaInstance.elemID.createNestedID(...customPath),
-                  _.get(userSchemaInstance.value, customPath)
-                ),
-                ' == \'salto\' AND user.isMemberOf({\'group.id\':{',
-                new ReferenceExpression(groupInstances[2].elemID, groupInstances[2]),
-                ', ',
-                new ReferenceExpression(groupInstances[0].elemID, groupInstances[0]),
-                '}})',
-              ],
-            }))
+            .toEqual(policyRuleTemplate)
         })
 
         it('should not create references if there is no match', async () => {
@@ -199,6 +201,64 @@ describe('expression language filter', () => {
               },
             }
           )
+        })
+      })
+
+      describe('preDeploy and onDeploy', () => {
+        const groupRuleWithTemplate = new InstanceElement(
+          'groupRuleTest',
+          groupRuleType,
+          { conditions: { expression: { value: groupRuleTemplate } } }
+        )
+        const policyRuleWithTemplate = new InstanceElement(
+          'policyRuleTest',
+          policyRuleType,
+          {
+            conditions: {
+              additionalProperties: {
+                elCondition: {
+                  condition: policyRuleTemplate,
+                },
+              },
+            },
+          },
+        )
+
+        describe('preDeploy', () => {
+          it('should replace template expressions with strings', async () => {
+            const changes = [
+              toChange({ after: groupRuleWithTemplate.clone() }), toChange({ after: policyRuleWithTemplate.clone() }),
+            ]
+            await filter.preDeploy(changes)
+            const instances = changes.map(getChangeData).filter(isInstanceElement)
+            const groupRuleInstance = instances.find(i => i.elemID.name === 'groupRuleTest')
+            expect(groupRuleInstance).toBeDefined()
+            expect(groupRuleInstance?.value?.conditions?.expression?.value)
+              .toEqual('(String.stringContains(user.department, "salto") OR isMemberOfGroupNameRegex("/.*admin.*")) AND isMemberOfAnyGroup("123A") AND !isMemberOfAnyGroup("234B", "345C")')
+            const policyRuleInstance = instances.find(i => i.elemID.name === 'policyRuleTest')
+            expect(policyRuleInstance).toBeDefined()
+            expect(policyRuleInstance?.value?.conditions?.additionalProperties?.elCondition?.condition)
+              .toEqual('user.profile.saltoDepartment == \'salto\' AND user.isMemberOf({\'group.id\':{"345C", "123A"}})')
+          })
+        })
+        describe('onDeploy', () => {
+          it('should restore template expressions using the mapping', async () => {
+            const changes = [
+              toChange({ after: groupRuleWithTemplate.clone() }), toChange({ after: policyRuleWithTemplate.clone() }),
+            ]
+            // call preDeploy to set the mapping
+            await filter.preDeploy(changes)
+            await filter.onDeploy(changes)
+            const instances = changes.map(getChangeData).filter(isInstanceElement)
+            const groupRuleInstance = instances.find(i => i.elemID.name === 'groupRuleTest')
+            expect(groupRuleInstance).toBeDefined()
+            expect(groupRuleInstance?.value?.conditions?.expression?.value)
+              .toEqual(groupRuleTemplate)
+            const policyRuleInstance = instances.find(i => i.elemID.name === 'policyRuleTest')
+            expect(policyRuleInstance).toBeDefined()
+            expect(policyRuleInstance?.value?.conditions?.additionalProperties?.elCondition?.condition)
+              .toEqual(policyRuleTemplate)
+          })
         })
       })
 })


### PR DESCRIPTION
Support GroupRule deployment + restore template expression to Okta expression language before deployment

---

Changes:
- Add GroupRule deployment
- Add preDeploy and onDeploy for `oktaExpressionLanguageFilter` to restore expressions before deployment
- Add validator that checks GroupRule actions didn't change
- Add validator that checks the change action is allowed based on GroupRule status
  - addition / modification / removal of GroupRule with status active is not allowed
  - modification of GroupRule with status invalid is not allowed
  - changes to GroupRule status is not allowed (this is temporary and we'll support this in the future)
  
---
_Release Notes_: 
 None

---
_User Notifications_: 
None
