### PR TITLE
SALTO-3611: Fix type mismatch in fields

### DIFF
--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -398,6 +398,18 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
       },
     },
   },
+  sla_policy__filter__all: {
+    transformation: {
+      // value can be number or string
+      fieldTypeOverrides: [{ fieldName: 'value', fieldType: 'unknown' }],
+    },
+  },
+  sla_policy__filter__any: {
+    transformation: {
+      // value can be number or string
+      fieldTypeOverrides: [{ fieldName: 'value', fieldType: 'unknown' }],
+    },
+  },
   sla_policy_order: {
     deployRequests: {
       modify: {
@@ -2322,7 +2334,10 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
       fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
       fieldTypeOverrides: [
         { fieldName: 'id', fieldType: 'number' },
-        { fieldName: 'added_user_ids', fieldType: 'unknown' },
+        // list items can be user IDs (number) or user email (string)
+        { fieldName: 'added_user_ids', fieldType: 'List<unknown>' },
+        // list items can be organization IDs (number) or organization names (email)
+        { fieldName: 'organization_ids', fieldType: 'List<unknown>' },
         // everyone user type is added as a type we created for user_segment
         {
           fieldName: 'user_type',

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -443,6 +443,7 @@ describe('adapter', () => {
           'zendesk.sla_policy.instance.SLA_502@s',
           'zendesk.sla_policy__filter',
           'zendesk.sla_policy__filter__all',
+          'zendesk.sla_policy__filter__any',
           'zendesk.sla_policy__policy_metrics',
           'zendesk.sla_policy_definition',
           'zendesk.sla_policy_order',


### PR DESCRIPTION
Fix type mismatch in fields

---

By converting organization ids to organization names, fields with type number caused type mismatch when receiving strings (org name)

---
_Release Notes_: 
None

---
_User Notifications_: 
None
