### PR TITLE
SALTO-3619: use --forceExit when running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build-ts": "lerna run build-ts",
     "build-all": "lerna run build",
     "clean": "lerna run --parallel clean",
-    "test": "jest",
+    "test": "jest --forceExit --detectOpenHandles",
     "generate-notices-file": "./build_utils/generate_notices.sh",
     "lerna-version": "lerna version --no-git-tag-version --exact",
     "lerna-version-pr": "./build_utils/create_version_pr.sh",


### PR DESCRIPTION
Since the Node.js v18 upgrade our tests all pass successfully but jest never finishes. `--detectOpenHandles` is no help, and the issue only repros on CircleCI. 
For now, let's have jest force-terminate after all the tests are done.

---



---
_Release Notes_: 
N/A

---
_User Notifications_: 
N/A
