### PR TITLE
SALTO-2347/workflow scheme migration

### DIFF
--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -73,6 +73,7 @@ export default (
     permissionTypeValidator,
     automationsValidator,
     statusMigrationChangeValidator,
+    // Must run after statusMigrationChangeValidator
     workflowSchemeMigrationValidator(client, config, paginator),
     maskingValidator(client),
     lockedFieldsValidator,

--- a/packages/jira-adapter/src/change_validators/workflow_scheme_migration.ts
+++ b/packages/jira-adapter/src/change_validators/workflow_scheme_migration.ts
@@ -261,9 +261,12 @@ export const workflowSchemeMigrationValidator = (
         elementSource,
       )
       const statusMigrations = changedItems.flatMap(changedItem => getMigrationForChangedItem(changedItem))
-      const existingStatusMigrations = instance.value.statusMigrations ?? []
+      const existingStatusMigrations: StatusMigration[] = instance.value.statusMigrations ?? []
       const newStatusMigrations = _.differenceWith(statusMigrations, existingStatusMigrations, isSameStatusMigration)
-      return getErrorMessageForStatusMigration(instance, newStatusMigrations)
+      if (newStatusMigrations.length === 0) {
+        return undefined
+      }
+      return getErrorMessageForStatusMigration(instance, [...existingStatusMigrations, ...newStatusMigrations])
     }).filter(isDefined).toArray()
     return errors
   }


### PR DESCRIPTION
fixed nit from merged pr requiring the partial status migration to be part of the error message to the user.

---

_Additional context for reviewer_

---
_Release Notes_: 


---
_User Notifications_: 

