### PR TITLE
Salto-2865: Order the objects in deploy.xml according to ref level

### DIFF
--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -201,7 +201,7 @@ export default class NetsuiteClient {
           currSet.add(serviceIdInfo.serviceId)
           const startNode = dependencyGraph.findNodeByField('serviceid', serviceIdInfo.serviceId)
           if (startNode && endNode && startNode.value.changeType === 'addition') {
-            startNode.addEdge(endNode)
+            startNode.addEdge(dependencyGraph.key, endNode)
           }
         })
       })

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -63,15 +63,6 @@ const getServiceIdFromElement = (changeData: ChangeDataType): string => {
 const getChangeType = (change: Change): 'addition' | 'modification' =>
   (isAdditionChange(change) ? 'addition' : 'modification')
 
-type SDFObjectNode = {
-  elemIdFullName: string
-  scriptid: string
-  changeType: 'addition' | 'modification'
-  customizationInfos: CustomizationInfo[]
-}
-const isSubsetOfArray = (subsetArray: unknown[], setArray: unknown[]):boolean =>
-  subsetArray.length === _.intersection(subsetArray, setArray).length
-
 type DependencyInfo = {
   dependencyMap: Map<string, Set<string>>
   dependencyGraph: Graph<SDFObjectNode>

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -35,7 +35,7 @@ import { APPLICATION_ID, SCRIPT_ID } from '../constants'
 import { LazyElementsSourceIndexes } from '../elements_source_index/types'
 import { toConfigDeployResult, toSetConfigTypes } from '../suiteapp_config_elements'
 import { FeaturesDeployError, MissingManifestFeaturesError, getChangesElemIdsToRemove, toFeaturesDeployPartialSuccessResult } from './errors'
-import { Graph, GraphNode } from './graph_utils'
+import { Graph, GraphNode, SDFObjectNode } from './graph_utils'
 import { AdditionalDependencies, isRequiredFeature, removeRequiredFeatureSuffix } from '../config'
 
 const { isDefined } = values
@@ -66,6 +66,8 @@ type SDFObjectNode = {
   changeType: 'addition' | 'modification'
   customizationInfos: CustomizationInfo[]
 }
+const isSubsetOfArray = (subsetArray: unknown[], setArray: unknown[]):boolean =>
+  subsetArray.length === _.intersection(subsetArray, setArray).length
 
 type DependencyInfo = {
   dependencyMap: Map<string, Set<string>>
@@ -319,7 +321,8 @@ export default class NetsuiteClient {
           () => this.sdfClient.deploy(
             customizationInfos,
             suiteAppId,
-            { manifestDependencies, validateOnly }
+            { manifestDependencies, validateOnly },
+            dependencyGraph
           ),
           'sdfDeploy'
         )

--- a/packages/netsuite-adapter/src/client/deploy_xml_utils.ts
+++ b/packages/netsuite-adapter/src/client/deploy_xml_utils.ts
@@ -1,0 +1,35 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import xmlParser from 'fast-xml-parser'
+import { Graph, SDFObjectNode } from './graph_utils'
+
+
+export const reorderDeployXml = (
+  deployContent: string,
+  dependencyGraph: Graph<SDFObjectNode>,
+): string => {
+  const nodesInTopologicalOrder = dependencyGraph.getTopologicalOrder()
+  const deployXml = xmlParser.parse(deployContent, { ignoreAttributes: false })
+  const { objects } = deployXml.deploy
+  objects.path = nodesInTopologicalOrder.map(node => `~/Objects/${node.value.scriptid}.xml`)
+
+  // eslint-disable-next-line new-cap
+  return new xmlParser.j2xParser({
+    ignoreAttributes: false,
+    format: true,
+  }).parse(deployXml)
+}

--- a/packages/netsuite-adapter/src/client/deploy_xml_utils.ts
+++ b/packages/netsuite-adapter/src/client/deploy_xml_utils.ts
@@ -15,17 +15,30 @@
 */
 
 import xmlParser from 'fast-xml-parser'
+import _ from 'lodash'
 import { Graph, SDFObjectNode } from './graph_utils'
+import { CustomizationInfo } from './types'
+import { isFileCustomizationInfo, isFolderCustomizationInfo } from './utils'
 
+const isFileOrFolder = (customizationInfo: CustomizationInfo): boolean =>
+  isFileCustomizationInfo(customizationInfo) || isFolderCustomizationInfo(customizationInfo)
 
 export const reorderDeployXml = (
   deployContent: string,
   dependencyGraph: Graph<SDFObjectNode>,
 ): string => {
   const nodesInTopologicalOrder = dependencyGraph.getTopologicalOrder()
+  const orderedFileCabinetNodes = _.remove(
+    nodesInTopologicalOrder, node => isFileOrFolder(node.value.customizationInfo)
+  )
   const deployXml = xmlParser.parse(deployContent, { ignoreAttributes: false })
-  const { objects } = deployXml.deploy
-  objects.path = nodesInTopologicalOrder.map(node => `~/Objects/${node.value.scriptid}.xml`)
+  const { objects, files } = deployXml.deploy
+  if (nodesInTopologicalOrder.length > 0) {
+    objects.path = nodesInTopologicalOrder.map(node => `~/Objects/${node.value.serviceid}.xml`)
+  }
+  if (orderedFileCabinetNodes.length > 0) {
+    files.path = orderedFileCabinetNodes.map(node => `~/FileCabinet${node.value.serviceid}`)
+  }
 
   // eslint-disable-next-line new-cap
   return new xmlParser.j2xParser({

--- a/packages/netsuite-adapter/src/client/graph_utils.ts
+++ b/packages/netsuite-adapter/src/client/graph_utils.ts
@@ -20,9 +20,9 @@ import { CustomizationInfo } from './types'
 
 export type SDFObjectNode = {
   elemIdFullName: string
-  scriptid: string | undefined
+  serviceid: string
   changeType: 'addition' | 'modification'
-  customizationInfos: CustomizationInfo[]
+  customizationInfo: CustomizationInfo
 }
 
 export class GraphNode<T> {

--- a/packages/netsuite-adapter/src/client/graph_utils.ts
+++ b/packages/netsuite-adapter/src/client/graph_utils.ts
@@ -26,16 +26,16 @@ export type SDFObjectNode = {
 }
 
 export class GraphNode<T> {
-  edges: GraphNode<T>[]
+  edges: Map<T[keyof T], GraphNode<T>>
   value: T
 
   constructor(value: T) {
     this.value = value
-    this.edges = []
+    this.edges = new Map<T[keyof T], GraphNode<T>>()
   }
 
-  addEdge(node: GraphNode<T>): void {
-    this.edges.push(node)
+  addEdge(key: keyof T, node: GraphNode<T>): void {
+    this.edges.set(node.value[key], node)
   }
 }
 
@@ -103,9 +103,7 @@ export class Graph<T> {
     const node = this.nodes.get(key)
     if (node) {
       Array.from(this.nodes.values()).forEach(otherNode => {
-        if (otherNode.edges.includes(node)) {
-          _.remove(otherNode.edges, edgeNode => _.isEqual(node, edgeNode))
-        }
+        otherNode.edges.delete(key)
       })
       this.nodes.delete(key)
     }

--- a/packages/netsuite-adapter/src/client/graph_utils.ts
+++ b/packages/netsuite-adapter/src/client/graph_utils.ts
@@ -20,7 +20,7 @@ import { CustomizationInfo } from './types'
 
 export type SDFObjectNode = {
   elemIdFullName: string
-  scriptid: string
+  scriptid: string | undefined
   changeType: 'addition' | 'modification'
   customizationInfos: CustomizationInfo[]
 }

--- a/packages/netsuite-adapter/src/client/graph_utils.ts
+++ b/packages/netsuite-adapter/src/client/graph_utils.ts
@@ -57,7 +57,7 @@ export class Graph<T> {
     })
   }
 
-  dfs(node: GraphNode<T>, visited: Map<T[keyof T], GraphNode<T>>, resultArray: GraphNode<T>[]): void {
+  private dfs(node: GraphNode<T>, visited: Map<T[keyof T], GraphNode<T>>, resultArray: GraphNode<T>[]): void {
     visited.set(node.value[this.key], node)
     node.edges.forEach(dependency => {
       if (!visited.has(dependency.value[this.key])) {

--- a/packages/netsuite-adapter/src/client/graph_utils.ts
+++ b/packages/netsuite-adapter/src/client/graph_utils.ts
@@ -16,6 +16,14 @@
 
 import _ from 'lodash'
 import wu from 'wu'
+import { CustomizationInfo } from './types'
+
+export type SDFObjectNode = {
+  elemIdFullName: string
+  scriptid: string
+  changeType: 'addition' | 'modification'
+  customizationInfos: CustomizationInfo[]
+}
 
 export class GraphNode<T> {
   edges: GraphNode<T>[]
@@ -43,19 +51,31 @@ export class Graph<T> {
 
   addNodes(nodes: GraphNode<T>[]): void {
     nodes.forEach(node => {
-      if (!this.nodes.get(node.value[this.key])) {
+      if (!this.nodes.has(node.value[this.key])) {
         this.nodes.set(node.value[this.key], node)
       }
     })
   }
 
-  private dfs(node: GraphNode<T>, visited: Map<T[keyof T], GraphNode<T>>): void {
+  dfs(node: GraphNode<T>, visited: Map<T[keyof T], GraphNode<T>>, resultArray: GraphNode<T>[]): void {
     visited.set(node.value[this.key], node)
     node.edges.forEach(dependency => {
-      if (!visited.get(dependency.value[this.key])) {
-        this.dfs(dependency, visited)
+      if (!visited.has(dependency.value[this.key])) {
+        this.dfs(dependency, visited, resultArray)
       }
     })
+    resultArray.push(node)
+  }
+
+  getTopologicalOrder(): GraphNode<T>[] {
+    const visited = new Map<T[keyof T], GraphNode<T>>()
+    const sortedNodes:GraphNode<T>[] = []
+    Array.from(this.nodes.values()).forEach(node => {
+      if (!visited.has(node.value[this.key])) {
+        this.dfs(node, visited, sortedNodes)
+      }
+    })
+    return sortedNodes.reverse()
   }
 
   getNodeDependencies(startNode: GraphNode<T>): GraphNode<T>[] {
@@ -63,8 +83,9 @@ export class Graph<T> {
       return [startNode]
     }
     const visited = new Map<T[keyof T], GraphNode<T>>()
-    this.dfs(startNode, visited)
-    return Array.from(visited.values())
+    const dependencies: GraphNode<T>[] = []
+    this.dfs(startNode, visited, dependencies)
+    return dependencies
   }
 
   findNode(value: T): GraphNode<T> | undefined {

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -965,13 +965,14 @@ export default class SdfClient {
 
   private static async fixDeployXml(
     dependencyGraph: Graph<SDFObjectNode>,
-    projectName: string
+    projectName: string,
+    customizationInfos: CustomizationInfo[]
   ): Promise<void> {
     const deployFilePath = SdfClient.getDeployFilePath(projectName)
     const deployXmlContent = (await readFile(deployFilePath)).toString()
     await writeFile(
       deployFilePath,
-      reorderDeployXml(deployXmlContent, dependencyGraph)
+      reorderDeployXml(deployXmlContent, dependencyGraph, customizationInfos)
     )
   }
 
@@ -984,6 +985,7 @@ export default class SdfClient {
   ): Promise<void> {
     await this.executeProjectAction(COMMANDS.ADD_PROJECT_DEPENDENCIES, {}, executor)
     await SdfClient.fixManifest(projectName, customizationInfos, manifestDependencies)
+    await SdfClient.fixDeployXml(dependencyGraph, projectName, customizationInfos)
     try {
       const custCommandArguments = {
         ...(type === 'AccountCustomization' ? { accountspecificvalues: 'WARNING' } : {}),

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -172,7 +172,6 @@ export const convertToXmlContent = (customizationInfo: CustomizationInfo): strin
 const writeFileInFolder = async (folderPath: string, filename: string, content: string | Buffer):
   Promise<void> => {
   await mkdirp(folderPath)
-  osPath.resolve(folderPath, filename)
   await writeFile(osPath.resolve(folderPath, filename), content)
 }
 

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -56,7 +56,7 @@ import {
 import { fixManifest } from './manifest_utils'
 import { detectLanguage, FEATURE_NAME, fetchLockedObjectErrorRegex, fetchUnexpectedErrorRegex, multiLanguageErrorDetectors, OBJECT_ID } from './language_utils'
 import { Graph, SDFObjectNode } from './graph_utils'
-import { reorderDeployXml } from './deploy_xml_utils'
+import { reorderDeployXml, getCustomTypeInfoPath, getFileCabinetTypesPath, OBJECTS_DIR, FILE_CABINET_DIR, ATTRIBUTES_FOLDER_NAME, FOLDER_ATTRIBUTES_FILE_SUFFIX, ATTRIBUTES_FILE_SUFFIX, XML_FILE_SUFFIX } from './deploy_xml_utils'
 
 const { makeArray } = collections.array
 const { withLimitedConcurrency } = promises.array
@@ -90,12 +90,6 @@ export const COMMANDS = {
   IMPORT_CONFIGURATION: 'configuration:import',
 }
 
-
-export const ATTRIBUTES_FOLDER_NAME = '.attributes'
-export const ATTRIBUTES_FILE_SUFFIX = '.attr.xml'
-export const FOLDER_ATTRIBUTES_FILE_SUFFIX = '.folder.attr.xml'
-const FILE_CABINET_DIR = 'FileCabinet'
-const OBJECTS_DIR = 'Objects'
 const SRC_DIR = 'src'
 const FILE_SEPARATOR = '.'
 const ALL = 'ALL'
@@ -874,14 +868,14 @@ export default class SdfClient {
 
   @SdfClient.logDecorator
   async deploy(
-    customizationInfos: CustomizationInfo[],
     suiteAppId: string | undefined,
     { manifestDependencies, validateOnly = false }: SdfDeployParams,
     dependencyGraph: Graph<SDFObjectNode>
   ): Promise<void> {
     const project = await this.initProject(suiteAppId)
-    const objectsDirPath = SdfClient.getObjectsDirPath(project.projectName)
+    const srcDirPath = SdfClient.getSrcDirPath(project.projectName)
     const fileCabinetDirPath = SdfClient.getFileCabinetDirPath(project.projectName)
+    const customizationInfos = Array.from(dependencyGraph.nodes.values()).map(node => node.value.customizationInfo)
     // Delete the default FileCabinet folder to prevent permissions error
     await rm(fileCabinetDirPath)
     await Promise.all(customizationInfos.map(async customizationInfo => {
@@ -889,13 +883,13 @@ export default class SdfClient {
         return SdfClient.addFeaturesObjectToProject(customizationInfo, project.projectName)
       }
       if (isCustomTypeInfo(customizationInfo)) {
-        return SdfClient.addCustomTypeInfoToProject(customizationInfo, objectsDirPath)
+        return SdfClient.addCustomTypeInfoToProject(customizationInfo, srcDirPath)
       }
       if (isFileCustomizationInfo(customizationInfo)) {
-        return SdfClient.addFileInfoToProject(customizationInfo, fileCabinetDirPath)
+        return SdfClient.addFileInfoToProject(customizationInfo, srcDirPath)
       }
       if (isFolderCustomizationInfo(customizationInfo)) {
-        return SdfClient.addFolderInfoToProject(customizationInfo, fileCabinetDirPath)
+        return SdfClient.addFolderInfoToProject(customizationInfo, srcDirPath)
       }
       throw new Error(`Failed to deploy invalid customizationInfo: ${customizationInfo}`)
     }))
@@ -966,13 +960,12 @@ export default class SdfClient {
   private static async fixDeployXml(
     dependencyGraph: Graph<SDFObjectNode>,
     projectName: string,
-    customizationInfos: CustomizationInfo[]
   ): Promise<void> {
     const deployFilePath = SdfClient.getDeployFilePath(projectName)
     const deployXmlContent = (await readFile(deployFilePath)).toString()
     await writeFile(
       deployFilePath,
-      reorderDeployXml(deployXmlContent, dependencyGraph, customizationInfos)
+      reorderDeployXml(deployXmlContent, dependencyGraph)
     )
   }
 
@@ -985,7 +978,7 @@ export default class SdfClient {
   ): Promise<void> {
     await this.executeProjectAction(COMMANDS.ADD_PROJECT_DEPENDENCIES, {}, executor)
     await SdfClient.fixManifest(projectName, customizationInfos, manifestDependencies)
-    await SdfClient.fixDeployXml(dependencyGraph, projectName, customizationInfos)
+    await SdfClient.fixDeployXml(dependencyGraph, projectName)
     try {
       const custCommandArguments = {
         ...(type === 'AccountCustomization' ? { accountspecificvalues: 'WARNING' } : {}),
@@ -1004,14 +997,14 @@ export default class SdfClient {
   }
 
   private static async addCustomTypeInfoToProject(customTypeInfo: CustomTypeInfo,
-    objectsDirPath: string): Promise<void> {
+    srcDirPath: string): Promise<void> {
     await writeFile(
-      osPath.resolve(objectsDirPath, `${customTypeInfo.scriptId}.xml`),
+      `${getCustomTypeInfoPath(srcDirPath, customTypeInfo.scriptId, XML_FILE_SUFFIX)}`,
       convertToXmlContent(customTypeInfo)
     )
     if (isTemplateCustomTypeInfo(customTypeInfo)) {
-      await writeFile(osPath.resolve(objectsDirPath,
-        `${customTypeInfo.scriptId}${ADDITIONAL_FILE_PATTERN}${customTypeInfo.fileExtension}`),
+      await writeFile(getCustomTypeInfoPath(srcDirPath,
+        `${customTypeInfo.scriptId}${ADDITIONAL_FILE_PATTERN}${customTypeInfo.fileExtension}`, ''),
       customTypeInfo.fileContent)
     }
   }
@@ -1031,15 +1024,13 @@ export default class SdfClient {
   }
 
   private static async addFileInfoToProject(fileCustomizationInfo: FileCustomizationInfo,
-    fileCabinetDirPath: string): Promise<void> {
+    srcDirPath: string): Promise<void> {
     const attrsFilename = fileCustomizationInfo.path.slice(-1)[0] + ATTRIBUTES_FILE_SUFFIX
-    const attrsFolderPath = osPath.resolve(fileCabinetDirPath,
-      ...fileCustomizationInfo.path.slice(0, -1), ATTRIBUTES_FOLDER_NAME)
-
+    const attrsFolderPath = osPath.resolve(
+      getFileCabinetTypesPath(srcDirPath, fileCustomizationInfo), ATTRIBUTES_FOLDER_NAME
+    )
     const filename = fileCustomizationInfo.path.slice(-1)[0]
-    const fileFolderPath = osPath.resolve(fileCabinetDirPath,
-      ...fileCustomizationInfo.path.slice(0, -1))
-
+    const fileFolderPath = getFileCabinetTypesPath(srcDirPath, fileCustomizationInfo)
     await Promise.all([
       writeFileInFolder(fileFolderPath, filename, fileCustomizationInfo.fileContent),
       writeFileInFolder(attrsFolderPath, attrsFilename, convertToXmlContent(fileCustomizationInfo)),
@@ -1047,15 +1038,20 @@ export default class SdfClient {
   }
 
   private static async addFolderInfoToProject(folderCustomizationInfo: FolderCustomizationInfo,
-    fileCabinetDirPath: string): Promise<void> {
-    const attrsFolderPath = osPath.resolve(fileCabinetDirPath, ...folderCustomizationInfo.path,
-      ATTRIBUTES_FOLDER_NAME)
+    srcDirPath: string): Promise<void> {
+    const attrsFolderPath = osPath.resolve(
+      getFileCabinetTypesPath(srcDirPath, folderCustomizationInfo), ATTRIBUTES_FOLDER_NAME
+    )
     await writeFileInFolder(attrsFolderPath, FOLDER_ATTRIBUTES_FILE_SUFFIX,
       convertToXmlContent(folderCustomizationInfo))
   }
 
   private static getProjectPath(projectName: string): string {
     return osPath.resolve(baseExecutionPath, projectName)
+  }
+
+  private static getSrcDirPath(projectName: string): string {
+    return osPath.resolve(SdfClient.getProjectPath(projectName), SRC_DIR)
   }
 
   private static getObjectsDirPath(projectName: string): string {

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -56,7 +56,7 @@ import {
 import { fixManifest } from './manifest_utils'
 import { detectLanguage, FEATURE_NAME, fetchLockedObjectErrorRegex, fetchUnexpectedErrorRegex, multiLanguageErrorDetectors, OBJECT_ID } from './language_utils'
 import { Graph, SDFObjectNode } from './graph_utils'
-import { reorderDeployXml, getCustomTypeInfoPath, getFileCabinetTypesPath, OBJECTS_DIR, FILE_CABINET_DIR, ATTRIBUTES_FOLDER_NAME, FOLDER_ATTRIBUTES_FILE_SUFFIX, ATTRIBUTES_FILE_SUFFIX, XML_FILE_SUFFIX } from './deploy_xml_utils'
+import { reorderDeployXml, getCustomTypeInfoPath, getFileCabinetTypesPath, OBJECTS_DIR, FILE_CABINET_DIR, ATTRIBUTES_FOLDER_NAME, FOLDER_ATTRIBUTES_FILE_SUFFIX, ATTRIBUTES_FILE_SUFFIX } from './deploy_xml_utils'
 
 const { makeArray } = collections.array
 const { withLimitedConcurrency } = promises.array
@@ -998,12 +998,12 @@ export default class SdfClient {
   private static async addCustomTypeInfoToProject(customTypeInfo: CustomTypeInfo,
     srcDirPath: string): Promise<void> {
     await writeFile(
-      `${getCustomTypeInfoPath(srcDirPath, customTypeInfo.scriptId, XML_FILE_SUFFIX)}`,
+      getCustomTypeInfoPath(srcDirPath, customTypeInfo),
       convertToXmlContent(customTypeInfo)
     )
     if (isTemplateCustomTypeInfo(customTypeInfo)) {
       await writeFile(getCustomTypeInfoPath(srcDirPath,
-        `${customTypeInfo.scriptId}${ADDITIONAL_FILE_PATTERN}${customTypeInfo.fileExtension}`, ''),
+        customTypeInfo, `${ADDITIONAL_FILE_PATTERN}${customTypeInfo.fileExtension}`),
       customTypeInfo.fileContent)
     }
   }
@@ -1025,11 +1025,11 @@ export default class SdfClient {
   private static async addFileInfoToProject(fileCustomizationInfo: FileCustomizationInfo,
     srcDirPath: string): Promise<void> {
     const attrsFilename = fileCustomizationInfo.path.slice(-1)[0] + ATTRIBUTES_FILE_SUFFIX
+    const fileFolderPath = getFileCabinetTypesPath(srcDirPath, fileCustomizationInfo)
     const attrsFolderPath = osPath.resolve(
-      getFileCabinetTypesPath(srcDirPath, fileCustomizationInfo), ATTRIBUTES_FOLDER_NAME
+      fileFolderPath, ATTRIBUTES_FOLDER_NAME
     )
     const filename = fileCustomizationInfo.path.slice(-1)[0]
-    const fileFolderPath = getFileCabinetTypesPath(srcDirPath, fileCustomizationInfo)
     await Promise.all([
       writeFileInFolder(fileFolderPath, filename, fileCustomizationInfo.fileContent),
       writeFileInFolder(attrsFolderPath, attrsFilename, convertToXmlContent(fileCustomizationInfo)),

--- a/packages/netsuite-adapter/src/constants.ts
+++ b/packages/netsuite-adapter/src/constants.ts
@@ -75,7 +75,6 @@ export const PARENT = 'parent'
 export const CUSTOM_FIELD_PREFIX = 'custom_'
 export const EXCHANGE_RATE = 'exchangeRate'
 export const PERMISSIONS = 'permissions'
-export const SERVICE_ID = 'serviceid'
 
 // Field Annotations
 export const SOAP = 'soap'

--- a/packages/netsuite-adapter/src/constants.ts
+++ b/packages/netsuite-adapter/src/constants.ts
@@ -75,6 +75,7 @@ export const PARENT = 'parent'
 export const CUSTOM_FIELD_PREFIX = 'custom_'
 export const EXCHANGE_RATE = 'exchangeRate'
 export const PERMISSIONS = 'permissions'
+export const SERVICE_ID = 'serviceid'
 
 // Field Annotations
 export const SOAP = 'soap'

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -647,7 +647,6 @@ describe('Adapter', () => {
         testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', serviceid: 'custentity_my_script_id', changeType: 'addition', customizationInfo })])
         expect(client.deploy)
           .toHaveBeenCalledWith(
-            [customizationInfo],
             undefined,
             DEFAULT_SDF_DEPLOY_PARAMS,
             testGraph
@@ -664,7 +663,6 @@ describe('Adapter', () => {
         const serviceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder/content.html'
         testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.file.instance.fileInstance', serviceid: serviceId, changeType: 'addition', customizationInfo })])
         expect(client.deploy).toHaveBeenCalledWith(
-          [customizationInfo],
           undefined,
           DEFAULT_SDF_DEPLOY_PARAMS,
           testGraph
@@ -681,7 +679,6 @@ describe('Adapter', () => {
         const serviceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder'
         testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.folder.instance.folderInstance', serviceid: serviceId, changeType: 'addition', customizationInfo })])
         expect(client.deploy).toHaveBeenCalledWith(
-          [customizationInfo],
           undefined,
           DEFAULT_SDF_DEPLOY_PARAMS,
           testGraph,
@@ -708,9 +705,6 @@ describe('Adapter', () => {
           new GraphNode({ elemIdFullName: 'netsuite.folder.instance.folderInstance', serviceid: folderServiceId, changeType: 'addition', customizationInfo: folderCustInfo }),
         ])
         expect(client.deploy).toHaveBeenCalledWith(
-          expect.arrayContaining(
-            [folderCustInfo, fileCustInfo]
-          ),
           undefined,
           DEFAULT_SDF_DEPLOY_PARAMS,
           testGraph
@@ -740,9 +734,6 @@ describe('Adapter', () => {
           new GraphNode({ elemIdFullName: 'netsuite.folder.instance.folderInstance', serviceid: folderServiceId, changeType: 'addition', customizationInfo: folderCustInfo }),
         ])
         expect(client.deploy).toHaveBeenCalledWith(
-          expect.arrayContaining(
-            [folderCustInfo, fileCustInfo]
-          ),
           undefined,
           DEFAULT_SDF_DEPLOY_PARAMS,
           testGraph,
@@ -779,7 +770,6 @@ describe('Adapter', () => {
         testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', serviceid: 'custentity_my_script_id', changeType: 'modification', customizationInfo })])
         expect(client.deploy)
           .toHaveBeenCalledWith(
-            [customizationInfo],
             undefined,
             DEFAULT_SDF_DEPLOY_PARAMS,
             testGraph,
@@ -796,7 +786,6 @@ describe('Adapter', () => {
         const serviceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder/content.html'
         testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.file.instance.fileInstance', serviceid: serviceId, changeType: 'modification', customizationInfo })])
         expect(client.deploy).toHaveBeenCalledWith(
-          [await toCustomizationInfo(fileInstance)],
           undefined,
           DEFAULT_SDF_DEPLOY_PARAMS,
           testGraph,
@@ -813,7 +802,6 @@ describe('Adapter', () => {
         const serviceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder'
         testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.folder.instance.folderInstance', serviceid: serviceId, changeType: 'modification', customizationInfo })])
         expect(client.deploy).toHaveBeenCalledWith(
-          [await toCustomizationInfo(folderInstance)],
           undefined,
           DEFAULT_SDF_DEPLOY_PARAMS,
           testGraph,
@@ -838,7 +826,6 @@ describe('Adapter', () => {
         testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', serviceid: 'custentity_my_script_id', changeType: 'modification', customizationInfo })])
         expect(client.deploy)
           .toHaveBeenCalledWith(
-            [customizationInfo],
             undefined,
             DEFAULT_SDF_DEPLOY_PARAMS,
             testGraph,
@@ -885,7 +872,6 @@ describe('Adapter', () => {
         })
         testGraph.addNodes([new GraphNode({ serviceid: 'custentity_my_script_id', elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', changeType: 'addition', customizationInfo: custInfo })])
         expect(client.deploy).toHaveBeenCalledWith(
-          [custInfo],
           undefined,
           {
             ...DEFAULT_SDF_DEPLOY_PARAMS,
@@ -903,7 +889,6 @@ describe('Adapter', () => {
         await adapterAdd(instance)
         testGraph.addNodes([new GraphNode({ serviceid: 'custentity_my_script_id', elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', changeType: 'addition', customizationInfo: custInfo })])
         expect(client.deploy).toHaveBeenCalledWith(
-          [custInfo],
           undefined,
           DEFAULT_SDF_DEPLOY_PARAMS,
           testGraph

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -838,48 +838,15 @@ describe('Adapter', () => {
         expect(post).toEqual(after)
       })
     })
-
-    describe('deployReferencedElements', () => {
-      beforeEach(() => {
-        testGraph.nodes.clear()
-      })
-      it('should call getReferencedInstances with deployReferencedElements=true', async () => {
-        const configWithDeployReferencedElements = {
-          typesToSkip: [SAVED_SEARCH, TRANSACTION_FORM],
-          fetchAllTypesAtOnce: true,
-          deploy: {
-            deployReferencedElements: true,
-          },
-        }
-        const netsuiteAdapterWithDeployReferencedElements = new NetsuiteAdapter({
-          client: new NetsuiteClient(client),
-          elementsSource: buildElementsSourceFromElements([]),
-          filtersCreators: [firstDummyFilter, secondDummyFilter],
-          config: configWithDeployReferencedElements,
-          getElemIdFunc: mockGetElemIdFunc,
-        })
-
-        await netsuiteAdapterWithDeployReferencedElements.deploy({
-          changeGroup: {
-            groupID: SDF_CHANGE_GROUP_ID,
-            changes: [{ action: 'add', data: { after: instance } }],
-          },
-        })
-
-        expect(getReferencedInstancesMock).toHaveBeenCalledWith([instance], true)
-      })
-
-      it('should call getReferencedInstances with deployReferencedElements=false', async () => {
-        await adapterAdd(instance)
-        expect(getReferencedInstancesMock).toHaveBeenCalledWith([instance], false)
-      })
-    })
     describe('additional sdf dependencies', () => {
       let custInfo: CustomizationInfo
       beforeAll(async () => {
         const expectedResolvedInstance = instance.clone()
         expectedResolvedInstance.value.description = 'description value'
         custInfo = await toCustomizationInfo(expectedResolvedInstance)
+      })
+      beforeEach(() => {
+        testGraph.nodes.clear()
       })
       it('should call deploy with additional dependencies', async () => {
         const configWithAdditionalSdfDependencies = {

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -644,7 +644,7 @@ describe('Adapter', () => {
         const expectedResolvedInstance = instance.clone()
         expectedResolvedInstance.value.description = 'description value'
         const customizationInfo = await toCustomizationInfo(expectedResolvedInstance)
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', serviceid: 'custentity_my_script_id', changeType: 'addition', customizationInfo })])
+        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', serviceid: 'custentity_my_script_id', changeType: 'addition', customizationInfo } as SDFObjectNode)])
         expect(client.deploy)
           .toHaveBeenCalledWith(
             undefined,
@@ -661,7 +661,7 @@ describe('Adapter', () => {
         const post = getChangeData(result.appliedChanges[0]) as InstanceElement
         const customizationInfo = await toCustomizationInfo(fileInstance)
         const serviceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder/content.html'
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.file.instance.fileInstance', serviceid: serviceId, changeType: 'addition', customizationInfo })])
+        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.file.instance.fileInstance', serviceid: serviceId, changeType: 'addition', customizationInfo } as SDFObjectNode)])
         expect(client.deploy).toHaveBeenCalledWith(
           undefined,
           DEFAULT_SDF_DEPLOY_PARAMS,
@@ -677,7 +677,7 @@ describe('Adapter', () => {
         const post = getChangeData(result.appliedChanges[0]) as InstanceElement
         const customizationInfo = await toCustomizationInfo(folderInstance)
         const serviceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder'
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.folder.instance.folderInstance', serviceid: serviceId, changeType: 'addition', customizationInfo })])
+        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.folder.instance.folderInstance', serviceid: serviceId, changeType: 'addition', customizationInfo } as SDFObjectNode)])
         expect(client.deploy).toHaveBeenCalledWith(
           undefined,
           DEFAULT_SDF_DEPLOY_PARAMS,
@@ -701,8 +701,8 @@ describe('Adapter', () => {
         const folderServiceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder'
         const fileServiceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder/content.html'
         testGraph.addNodes([
-          new GraphNode({ elemIdFullName: 'netsuite.file.instance.fileInstance', serviceid: fileServiceId, changeType: 'addition', customizationInfo: fileCustInfo }),
-          new GraphNode({ elemIdFullName: 'netsuite.folder.instance.folderInstance', serviceid: folderServiceId, changeType: 'addition', customizationInfo: folderCustInfo }),
+          new GraphNode({ elemIdFullName: 'netsuite.file.instance.fileInstance', serviceid: fileServiceId, changeType: 'addition', customizationInfo: fileCustInfo } as SDFObjectNode),
+          new GraphNode({ elemIdFullName: 'netsuite.folder.instance.folderInstance', serviceid: folderServiceId, changeType: 'addition', customizationInfo: folderCustInfo } as SDFObjectNode),
         ])
         expect(client.deploy).toHaveBeenCalledWith(
           undefined,
@@ -730,8 +730,8 @@ describe('Adapter', () => {
         const folderServiceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder'
         const fileServiceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder/content.html'
         testGraph.addNodes([
-          new GraphNode({ elemIdFullName: 'netsuite.file.instance.fileInstance', serviceid: fileServiceId, changeType: 'addition', customizationInfo: fileCustInfo }),
-          new GraphNode({ elemIdFullName: 'netsuite.folder.instance.folderInstance', serviceid: folderServiceId, changeType: 'addition', customizationInfo: folderCustInfo }),
+          new GraphNode({ elemIdFullName: 'netsuite.file.instance.fileInstance', serviceid: fileServiceId, changeType: 'addition', customizationInfo: fileCustInfo } as SDFObjectNode),
+          new GraphNode({ elemIdFullName: 'netsuite.folder.instance.folderInstance', serviceid: folderServiceId, changeType: 'addition', customizationInfo: folderCustInfo } as SDFObjectNode),
         ])
         expect(client.deploy).toHaveBeenCalledWith(
           undefined,
@@ -767,7 +767,7 @@ describe('Adapter', () => {
         const expectedResolvedInstance = instance.clone()
         expectedResolvedInstance.value.description = 'description value'
         const customizationInfo = await toCustomizationInfo(expectedResolvedInstance)
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', serviceid: 'custentity_my_script_id', changeType: 'modification', customizationInfo })])
+        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', serviceid: 'custentity_my_script_id', changeType: 'modification', customizationInfo } as SDFObjectNode)])
         expect(client.deploy)
           .toHaveBeenCalledWith(
             undefined,
@@ -784,7 +784,7 @@ describe('Adapter', () => {
         const post = getChangeData(result.appliedChanges[0]) as InstanceElement
         const customizationInfo = await toCustomizationInfo(fileInstance)
         const serviceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder/content.html'
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.file.instance.fileInstance', serviceid: serviceId, changeType: 'modification', customizationInfo })])
+        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.file.instance.fileInstance', serviceid: serviceId, changeType: 'modification', customizationInfo } as SDFObjectNode)])
         expect(client.deploy).toHaveBeenCalledWith(
           undefined,
           DEFAULT_SDF_DEPLOY_PARAMS,
@@ -800,7 +800,7 @@ describe('Adapter', () => {
         const post = getChangeData(result.appliedChanges[0]) as InstanceElement
         const customizationInfo = await toCustomizationInfo(folderInstance)
         const serviceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder'
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.folder.instance.folderInstance', serviceid: serviceId, changeType: 'modification', customizationInfo })])
+        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.folder.instance.folderInstance', serviceid: serviceId, changeType: 'modification', customizationInfo } as SDFObjectNode)])
         expect(client.deploy).toHaveBeenCalledWith(
           undefined,
           DEFAULT_SDF_DEPLOY_PARAMS,
@@ -823,7 +823,7 @@ describe('Adapter', () => {
         const expectedResolvedAfter = after.clone()
         expectedResolvedAfter.value.description = 'edited description value'
         const customizationInfo = await toCustomizationInfo(expectedResolvedAfter)
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', serviceid: 'custentity_my_script_id', changeType: 'modification', customizationInfo })])
+        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', serviceid: 'custentity_my_script_id', changeType: 'modification', customizationInfo } as SDFObjectNode)])
         expect(client.deploy)
           .toHaveBeenCalledWith(
             undefined,
@@ -870,7 +870,7 @@ describe('Adapter', () => {
             changes: [{ action: 'add', data: { after: instance } }],
           },
         })
-        testGraph.addNodes([new GraphNode({ serviceid: 'custentity_my_script_id', elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', changeType: 'addition', customizationInfo: custInfo })])
+        testGraph.addNodes([new GraphNode({ serviceid: 'custentity_my_script_id', elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', changeType: 'addition', customizationInfo: custInfo } as SDFObjectNode)])
         expect(client.deploy).toHaveBeenCalledWith(
           undefined,
           {
@@ -887,7 +887,7 @@ describe('Adapter', () => {
 
       it('should call deploy without additional dependencies', async () => {
         await adapterAdd(instance)
-        testGraph.addNodes([new GraphNode({ serviceid: 'custentity_my_script_id', elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', changeType: 'addition', customizationInfo: custInfo })])
+        testGraph.addNodes([new GraphNode({ serviceid: 'custentity_my_script_id', elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', changeType: 'addition', customizationInfo: custInfo } as SDFObjectNode)])
         expect(client.deploy).toHaveBeenCalledWith(
           undefined,
           DEFAULT_SDF_DEPLOY_PARAMS,

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -644,7 +644,7 @@ describe('Adapter', () => {
         const expectedResolvedInstance = instance.clone()
         expectedResolvedInstance.value.description = 'description value'
         const customizationInfo = await toCustomizationInfo(expectedResolvedInstance)
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', scriptid: 'custentity_my_script_id', changeType: 'addition', customizationInfos: [customizationInfo] })])
+        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', serviceid: 'custentity_my_script_id', changeType: 'addition', customizationInfo })])
         expect(client.deploy)
           .toHaveBeenCalledWith(
             [customizationInfo],
@@ -661,7 +661,8 @@ describe('Adapter', () => {
         expect(result.appliedChanges).toHaveLength(1)
         const post = getChangeData(result.appliedChanges[0]) as InstanceElement
         const customizationInfo = await toCustomizationInfo(fileInstance)
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.file.instance.fileInstance', scriptid: undefined, changeType: 'addition', customizationInfos: [customizationInfo] })])
+        const serviceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder/content.html'
+        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.file.instance.fileInstance', serviceid: serviceId, changeType: 'addition', customizationInfo })])
         expect(client.deploy).toHaveBeenCalledWith(
           [customizationInfo],
           undefined,
@@ -677,7 +678,8 @@ describe('Adapter', () => {
         expect(result.appliedChanges).toHaveLength(1)
         const post = getChangeData(result.appliedChanges[0]) as InstanceElement
         const customizationInfo = await toCustomizationInfo(folderInstance)
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.folder.instance.folderInstance', scriptid: undefined, changeType: 'addition', customizationInfos: [customizationInfo] })])
+        const serviceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder'
+        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.folder.instance.folderInstance', serviceid: serviceId, changeType: 'addition', customizationInfo })])
         expect(client.deploy).toHaveBeenCalledWith(
           [customizationInfo],
           undefined,
@@ -699,9 +701,11 @@ describe('Adapter', () => {
         })
         const folderCustInfo = await toCustomizationInfo(folderInstance)
         const fileCustInfo = await toCustomizationInfo(fileInstance)
+        const folderServiceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder'
+        const fileServiceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder/content.html'
         testGraph.addNodes([
-          new GraphNode({ elemIdFullName: 'netsuite.folder.instance.folderInstance', scriptid: undefined, changeType: 'addition', customizationInfos: [folderCustInfo] }),
-          new GraphNode({ elemIdFullName: 'netsuite.file.instance.fileInstance', scriptid: undefined, changeType: 'addition', customizationInfos: [fileCustInfo] }),
+          new GraphNode({ elemIdFullName: 'netsuite.file.instance.fileInstance', serviceid: fileServiceId, changeType: 'addition', customizationInfo: fileCustInfo }),
+          new GraphNode({ elemIdFullName: 'netsuite.folder.instance.folderInstance', serviceid: folderServiceId, changeType: 'addition', customizationInfo: folderCustInfo }),
         ])
         expect(client.deploy).toHaveBeenCalledWith(
           expect.arrayContaining(
@@ -729,9 +733,11 @@ describe('Adapter', () => {
         })
         const folderCustInfo = await toCustomizationInfo(folderInstance)
         const fileCustInfo = await toCustomizationInfo(fileInstance)
+        const folderServiceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder'
+        const fileServiceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder/content.html'
         testGraph.addNodes([
-          new GraphNode({ elemIdFullName: 'netsuite.folder.instance.folderInstance', scriptid: undefined, changeType: 'addition', customizationInfos: [folderCustInfo] }),
-          new GraphNode({ elemIdFullName: 'netsuite.file.instance.fileInstance', scriptid: undefined, changeType: 'addition', customizationInfos: [fileCustInfo] }),
+          new GraphNode({ elemIdFullName: 'netsuite.file.instance.fileInstance', serviceid: fileServiceId, changeType: 'addition', customizationInfo: fileCustInfo }),
+          new GraphNode({ elemIdFullName: 'netsuite.folder.instance.folderInstance', serviceid: folderServiceId, changeType: 'addition', customizationInfo: folderCustInfo }),
         ])
         expect(client.deploy).toHaveBeenCalledWith(
           expect.arrayContaining(
@@ -770,7 +776,7 @@ describe('Adapter', () => {
         const expectedResolvedInstance = instance.clone()
         expectedResolvedInstance.value.description = 'description value'
         const customizationInfo = await toCustomizationInfo(expectedResolvedInstance)
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', scriptid: 'custentity_my_script_id', changeType: 'modification', customizationInfos: [customizationInfo] })])
+        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', serviceid: 'custentity_my_script_id', changeType: 'modification', customizationInfo })])
         expect(client.deploy)
           .toHaveBeenCalledWith(
             [customizationInfo],
@@ -787,7 +793,8 @@ describe('Adapter', () => {
         expect(result.appliedChanges).toHaveLength(1)
         const post = getChangeData(result.appliedChanges[0]) as InstanceElement
         const customizationInfo = await toCustomizationInfo(fileInstance)
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.file.instance.fileInstance', scriptid: undefined, changeType: 'modification', customizationInfos: [customizationInfo] })])
+        const serviceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder/content.html'
+        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.file.instance.fileInstance', serviceid: serviceId, changeType: 'modification', customizationInfo })])
         expect(client.deploy).toHaveBeenCalledWith(
           [await toCustomizationInfo(fileInstance)],
           undefined,
@@ -803,7 +810,8 @@ describe('Adapter', () => {
         expect(result.appliedChanges).toHaveLength(1)
         const post = getChangeData(result.appliedChanges[0]) as InstanceElement
         const customizationInfo = await toCustomizationInfo(folderInstance)
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.folder.instance.folderInstance', scriptid: undefined, changeType: 'modification', customizationInfos: [customizationInfo] })])
+        const serviceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder'
+        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.folder.instance.folderInstance', serviceid: serviceId, changeType: 'modification', customizationInfo })])
         expect(client.deploy).toHaveBeenCalledWith(
           [await toCustomizationInfo(folderInstance)],
           undefined,
@@ -827,7 +835,7 @@ describe('Adapter', () => {
         const expectedResolvedAfter = after.clone()
         expectedResolvedAfter.value.description = 'edited description value'
         const customizationInfo = await toCustomizationInfo(expectedResolvedAfter)
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', scriptid: 'custentity_my_script_id', changeType: 'modification', customizationInfos: [customizationInfo] })])
+        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', serviceid: 'custentity_my_script_id', changeType: 'modification', customizationInfo })])
         expect(client.deploy)
           .toHaveBeenCalledWith(
             [customizationInfo],
@@ -875,7 +883,7 @@ describe('Adapter', () => {
             changes: [{ action: 'add', data: { after: instance } }],
           },
         })
-        testGraph.addNodes([new GraphNode({ scriptid: 'custentity_my_script_id', elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', changeType: 'addition', customizationInfos: [custInfo] })])
+        testGraph.addNodes([new GraphNode({ serviceid: 'custentity_my_script_id', elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', changeType: 'addition', customizationInfo: custInfo })])
         expect(client.deploy).toHaveBeenCalledWith(
           [custInfo],
           undefined,
@@ -893,7 +901,7 @@ describe('Adapter', () => {
 
       it('should call deploy without additional dependencies', async () => {
         await adapterAdd(instance)
-        testGraph.addNodes([new GraphNode({ scriptid: 'custentity_my_script_id', elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', changeType: 'addition', customizationInfos: [custInfo] })])
+        testGraph.addNodes([new GraphNode({ serviceid: 'custentity_my_script_id', elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', changeType: 'addition', customizationInfo: custInfo })])
         expect(client.deploy).toHaveBeenCalledWith(
           [custInfo],
           undefined,

--- a/packages/netsuite-adapter/test/client/client.test.ts
+++ b/packages/netsuite-adapter/test/client/client.test.ts
@@ -646,7 +646,7 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
           values: { scriptid: 'someObject' },
         }
         testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.type.instance.instance', scriptid: 'someObject', changeType: 'addition', customizationInfos: [customizationInfo] })])
-        await client.validate([change], SDF_CHANGE_GROUP_ID, ...deployParams)
+        await client.validate([change], SDF_CREATE_OR_UPDATE_GROUP_ID, deployParams[0])
         expect(mockSdfDeploy).toHaveBeenCalledWith(
           [{
             scriptId: 'someObject',

--- a/packages/netsuite-adapter/test/client/client.test.ts
+++ b/packages/netsuite-adapter/test/client/client.test.ts
@@ -456,7 +456,7 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
               },
             }),
           })
-          testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.customrecord1', serviceid: 'customrecord1', changeType: 'addition', customizationInfo })])
+          testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.customrecord1', serviceid: 'customrecord1', changeType: 'addition', customizationInfo } as SDFObjectNode)])
           expect(await client.deploy(
             [change],
             SDF_CREATE_OR_UPDATE_GROUP_ID,
@@ -644,7 +644,7 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
           typeName: 'type',
           values: { scriptid: 'someObject' },
         }
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.type.instance.instance', serviceid: 'someObject', changeType: 'addition', customizationInfo })])
+        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.type.instance.instance', serviceid: 'someObject', changeType: 'addition', customizationInfo } as SDFObjectNode)])
         await client.validate([change], SDF_CREATE_OR_UPDATE_GROUP_ID, deployParams[0])
         expect(mockSdfDeploy).toHaveBeenCalledWith(
           undefined,

--- a/packages/netsuite-adapter/test/client/client.test.ts
+++ b/packages/netsuite-adapter/test/client/client.test.ts
@@ -26,6 +26,7 @@ import { featuresType } from '../../src/types/configuration_types'
 import { FeaturesDeployError, ManifestValidationError, MissingManifestFeaturesError, ObjectsDeployError, SettingsDeployError } from '../../src/client/errors'
 import { LazyElementsSourceIndexes } from '../../src/elements_source_index/types'
 import { AdditionalDependencies } from '../../src/config'
+import { Graph, SDFObjectNode } from '../../src/client/graph_utils'
 
 describe('NetsuiteClient', () => {
   describe('with SDF client', () => {
@@ -49,6 +50,8 @@ describe('NetsuiteClient', () => {
       },
       mockElementsSourceIndex,
     ]
+
+    const testGraph = new Graph<SDFObjectNode>('elemIdFullName')
     describe('deploy', () => {
       beforeEach(() => {
         jest.resetAllMocks()
@@ -435,6 +438,9 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
       })
 
       describe('custom record types', () => {
+        beforeEach(() => {
+          testGraph.nodes.clear()
+        })
         it('should transform type to customrecordtype instance', async () => {
           const change = toChange({
             after: new ObjectType({

--- a/packages/netsuite-adapter/test/client/client.test.ts
+++ b/packages/netsuite-adapter/test/client/client.test.ts
@@ -456,7 +456,7 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
               },
             }),
           })
-          testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.customrecord1', scriptid: 'customrecord1', changeType: 'addition', customizationInfos: [customizationInfo] })])
+          testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.customrecord1', serviceid: 'customrecord1', changeType: 'addition', customizationInfo })])
           expect(await client.deploy(
             [change],
             SDF_CREATE_OR_UPDATE_GROUP_ID,
@@ -645,7 +645,7 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
           typeName: 'type',
           values: { scriptid: 'someObject' },
         }
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.type.instance.instance', scriptid: 'someObject', changeType: 'addition', customizationInfos: [customizationInfo] })])
+        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.type.instance.instance', serviceid: 'someObject', changeType: 'addition', customizationInfo })])
         await client.validate([change], SDF_CREATE_OR_UPDATE_GROUP_ID, deployParams[0])
         expect(mockSdfDeploy).toHaveBeenCalledWith(
           [{

--- a/packages/netsuite-adapter/test/client/client.test.ts
+++ b/packages/netsuite-adapter/test/client/client.test.ts
@@ -466,7 +466,6 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
             appliedChanges: [change],
           })
           expect(mockSdfDeploy).toHaveBeenCalledWith(
-            [customizationInfo],
             undefined,
             {
               additionalDependencies: {
@@ -648,11 +647,6 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
         testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.type.instance.instance', serviceid: 'someObject', changeType: 'addition', customizationInfo })])
         await client.validate([change], SDF_CREATE_OR_UPDATE_GROUP_ID, deployParams[0])
         expect(mockSdfDeploy).toHaveBeenCalledWith(
-          [{
-            scriptId: 'someObject',
-            typeName: 'type',
-            values: { scriptid: 'someObject' },
-          }],
           undefined,
           {
             manifestDependencies: {

--- a/packages/netsuite-adapter/test/client/deploy_xml_utils.test.ts
+++ b/packages/netsuite-adapter/test/client/deploy_xml_utils.test.ts
@@ -16,23 +16,23 @@
 
 import { reorderDeployXml } from '../../src/client/deploy_xml_utils'
 import { Graph, GraphNode, SDFObjectNode } from '../../src/client/graph_utils'
+import { FILE, FOLDER } from '../../src/constants'
 
 describe('deploy xml utils tests', () => {
+  const emptyCustInfo = { typeName: '', values: {} }
   const testNode1 = new GraphNode<SDFObjectNode>(
-    { elemIdFullName: 'fullName1', scriptid: 'scriptid1', changeType: 'addition', customizationInfos: [] }
+    { elemIdFullName: 'fullName1', serviceid: 'scriptid1', changeType: 'addition', customizationInfo: emptyCustInfo }
   )
   const testNode2 = new GraphNode<SDFObjectNode>(
-    { elemIdFullName: 'fullName2', scriptid: 'scriptid2', changeType: 'addition', customizationInfos: [] }
+    { elemIdFullName: 'fullName2', serviceid: 'scriptid2', changeType: 'addition', customizationInfo: emptyCustInfo }
   )
   const testNode3 = new GraphNode<SDFObjectNode>(
-    { elemIdFullName: 'fullName3', scriptid: 'scriptid3', changeType: 'addition', customizationInfos: [] }
+    { elemIdFullName: 'fullName3', serviceid: 'scriptid3', changeType: 'addition', customizationInfo: emptyCustInfo }
   )
   testNode1.addEdge(testNode2)
   testNode3.addEdge(testNode1)
   const testGraph = new Graph<SDFObjectNode>('elemIdFullName', [testNode1, testNode2, testNode3])
-
-  it('should add objects to deploy xml according to reference level', async () => {
-    const originalDeployXml = `<deploy>
+  const originalDeployXml = `<deploy>
     <configuration>
         <path>~/AccountConfiguration/*</path>
     </configuration>
@@ -47,12 +47,40 @@ describe('deploy xml utils tests', () => {
     </translationimports>
   </deploy>
   `
+
+  it('should add objects to deploy xml according to reference level', async () => {
     const fixedDeployXml = `<deploy>
   <configuration>
     <path>~/AccountConfiguration/*</path>
   </configuration>
   <files>
     <path>~/FileCabinet/*</path>
+  </files>
+  <objects>
+    <path>~/Objects/scriptid3.xml</path>
+    <path>~/Objects/scriptid1.xml</path>
+    <path>~/Objects/scriptid2.xml</path>
+  </objects>
+  <translationimports>
+    <path>~/Translations/*</path>
+  </translationimports>
+</deploy>
+`
+    expect(reorderDeployXml(originalDeployXml, testGraph)).toEqual(fixedDeployXml)
+  })
+
+  it('should write files and folders to deploy xml according to ref level', async () => {
+    const fileTestNode = new GraphNode<SDFObjectNode>({ elemIdFullName: 'fullFileName', serviceid: '/SuiteScripts/shalomTest.js', customizationInfo: { typeName: FILE, values: {} }, changeType: 'addition' })
+    const folderTestNode = new GraphNode<SDFObjectNode>({ elemIdFullName: 'fullFolderName', serviceid: '/SuiteScripts/InnerFolder', customizationInfo: { typeName: FOLDER, values: {} }, changeType: 'addition' })
+    fileTestNode.addEdge(folderTestNode)
+    testGraph.addNodes([fileTestNode, folderTestNode])
+    const fixedDeployXml = `<deploy>
+  <configuration>
+    <path>~/AccountConfiguration/*</path>
+  </configuration>
+  <files>
+    <path>~/FileCabinet/SuiteScripts/shalomTest.js</path>
+    <path>~/FileCabinet/SuiteScripts/InnerFolder</path>
   </files>
   <objects>
     <path>~/Objects/scriptid3.xml</path>

--- a/packages/netsuite-adapter/test/client/deploy_xml_utils.test.ts
+++ b/packages/netsuite-adapter/test/client/deploy_xml_utils.test.ts
@@ -1,0 +1,69 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { reorderDeployXml } from '../../src/client/deploy_xml_utils'
+import { Graph, GraphNode, SDFObjectNode } from '../../src/client/graph_utils'
+
+describe('deploy xml utils tests', () => {
+  const testNode1 = new GraphNode<SDFObjectNode>(
+    { elemIdFullName: 'fullName1', scriptid: 'scriptid1', changeType: 'addition', customizationInfos: [] }
+  )
+  const testNode2 = new GraphNode<SDFObjectNode>(
+    { elemIdFullName: 'fullName2', scriptid: 'scriptid2', changeType: 'addition', customizationInfos: [] }
+  )
+  const testNode3 = new GraphNode<SDFObjectNode>(
+    { elemIdFullName: 'fullName3', scriptid: 'scriptid3', changeType: 'addition', customizationInfos: [] }
+  )
+  testNode1.addEdge(testNode2)
+  testNode3.addEdge(testNode1)
+  const testGraph = new Graph<SDFObjectNode>('elemIdFullName', [testNode1, testNode2, testNode3])
+
+  it('should add objects to deploy xml according to reference level', async () => {
+    const originalDeployXml = `<deploy>
+    <configuration>
+        <path>~/AccountConfiguration/*</path>
+    </configuration>
+    <files>
+      <path>~/FileCabinet/*</path>
+    </files>
+    <objects>
+        <path>~/Objects/*</path>
+    </objects>
+    <translationimports>
+        <path>~/Translations/*</path>
+    </translationimports>
+  </deploy>
+  `
+    const fixedDeployXml = `<deploy>
+  <configuration>
+    <path>~/AccountConfiguration/*</path>
+  </configuration>
+  <files>
+    <path>~/FileCabinet/*</path>
+  </files>
+  <objects>
+    <path>~/Objects/scriptid3.xml</path>
+    <path>~/Objects/scriptid1.xml</path>
+    <path>~/Objects/scriptid2.xml</path>
+  </objects>
+  <translationimports>
+    <path>~/Translations/*</path>
+  </translationimports>
+</deploy>
+`
+    expect(reorderDeployXml(originalDeployXml, testGraph)).toEqual(fixedDeployXml)
+  })
+})

--- a/packages/netsuite-adapter/test/client/deploy_xml_utils.test.ts
+++ b/packages/netsuite-adapter/test/client/deploy_xml_utils.test.ts
@@ -20,18 +20,21 @@ import { FILE, FOLDER } from '../../src/constants'
 
 describe('deploy xml utils tests', () => {
   const emptyCustInfo = { typeName: '', values: {} }
-  const testNode1 = new GraphNode<SDFObjectNode>(
-    { elemIdFullName: 'fullName1', serviceid: 'scriptid1', changeType: 'addition', customizationInfo: emptyCustInfo }
-  )
-  const testNode2 = new GraphNode<SDFObjectNode>(
-    { elemIdFullName: 'fullName2', serviceid: 'scriptid2', changeType: 'addition', customizationInfo: emptyCustInfo }
-  )
-  const testNode3 = new GraphNode<SDFObjectNode>(
-    { elemIdFullName: 'fullName3', serviceid: 'scriptid3', changeType: 'addition', customizationInfo: emptyCustInfo }
-  )
-  testNode1.addEdge(testNode2)
-  testNode3.addEdge(testNode1)
-  const testGraph = new Graph<SDFObjectNode>('elemIdFullName', [testNode1, testNode2, testNode3])
+  let testGraph: Graph<SDFObjectNode>
+  beforeEach(() => {
+    const testNode1 = new GraphNode<SDFObjectNode>(
+      { elemIdFullName: 'fullName1', serviceid: 'scriptid1', changeType: 'addition', customizationInfo: emptyCustInfo }
+    )
+    const testNode2 = new GraphNode<SDFObjectNode>(
+      { elemIdFullName: 'fullName2', serviceid: 'scriptid2', changeType: 'addition', customizationInfo: emptyCustInfo }
+    )
+    const testNode3 = new GraphNode<SDFObjectNode>(
+      { elemIdFullName: 'fullName3', serviceid: 'scriptid3', changeType: 'addition', customizationInfo: emptyCustInfo }
+    )
+    testNode1.addEdge(testNode2)
+    testNode3.addEdge(testNode1)
+    testGraph = new Graph<SDFObjectNode>('elemIdFullName', [testNode1, testNode2, testNode3])
+  })
   const originalDeployXml = `<deploy>
     <configuration>
         <path>~/AccountConfiguration/*</path>
@@ -67,12 +70,12 @@ describe('deploy xml utils tests', () => {
   </translationimports>
 </deploy>
 `
-    expect(reorderDeployXml(originalDeployXml, testGraph, [emptyCustInfo])).toEqual(fixedDeployXml)
+    expect(reorderDeployXml(originalDeployXml, testGraph)).toEqual(fixedDeployXml)
   })
 
   it('should write files and folders to deploy xml according to ref level', async () => {
-    const emptyFileCustInfo = { typeName: FILE, values: {} }
-    const emptyFolderCustInfo = { typeName: FOLDER, values: {} }
+    const emptyFileCustInfo = { typeName: FILE, values: {}, path: ['SuiteScripts', 'shalomTest.js'], content: '' }
+    const emptyFolderCustInfo = { typeName: FOLDER, values: {}, path: ['SuiteScripts', 'InnerFolder'] }
     const fileTestNode = new GraphNode<SDFObjectNode>({ elemIdFullName: 'fullFileName', serviceid: '/SuiteScripts/shalomTest.js', customizationInfo: emptyFileCustInfo, changeType: 'addition' })
     const folderTestNode = new GraphNode<SDFObjectNode>({ elemIdFullName: 'fullFolderName', serviceid: '/SuiteScripts/InnerFolder', customizationInfo: emptyFolderCustInfo, changeType: 'addition' })
     fileTestNode.addEdge(folderTestNode)
@@ -96,8 +99,6 @@ describe('deploy xml utils tests', () => {
   </translationimports>
 </deploy>
 `
-    expect(reorderDeployXml(
-      originalDeployXml, testGraph, [emptyCustInfo, emptyFileCustInfo, emptyFolderCustInfo]
-    )).toEqual(fixedDeployXml)
+    expect(reorderDeployXml(originalDeployXml, testGraph)).toEqual(fixedDeployXml)
   })
 })

--- a/packages/netsuite-adapter/test/client/deploy_xml_utils.test.ts
+++ b/packages/netsuite-adapter/test/client/deploy_xml_utils.test.ts
@@ -60,18 +60,21 @@ describe('deploy xml utils tests', () => {
     <path>~/Objects/scriptid3.xml</path>
     <path>~/Objects/scriptid1.xml</path>
     <path>~/Objects/scriptid2.xml</path>
+    <path>~/Objects/*</path>
   </objects>
   <translationimports>
     <path>~/Translations/*</path>
   </translationimports>
 </deploy>
 `
-    expect(reorderDeployXml(originalDeployXml, testGraph)).toEqual(fixedDeployXml)
+    expect(reorderDeployXml(originalDeployXml, testGraph, [emptyCustInfo])).toEqual(fixedDeployXml)
   })
 
   it('should write files and folders to deploy xml according to ref level', async () => {
-    const fileTestNode = new GraphNode<SDFObjectNode>({ elemIdFullName: 'fullFileName', serviceid: '/SuiteScripts/shalomTest.js', customizationInfo: { typeName: FILE, values: {} }, changeType: 'addition' })
-    const folderTestNode = new GraphNode<SDFObjectNode>({ elemIdFullName: 'fullFolderName', serviceid: '/SuiteScripts/InnerFolder', customizationInfo: { typeName: FOLDER, values: {} }, changeType: 'addition' })
+    const emptyFileCustInfo = { typeName: FILE, values: {} }
+    const emptyFolderCustInfo = { typeName: FOLDER, values: {} }
+    const fileTestNode = new GraphNode<SDFObjectNode>({ elemIdFullName: 'fullFileName', serviceid: '/SuiteScripts/shalomTest.js', customizationInfo: emptyFileCustInfo, changeType: 'addition' })
+    const folderTestNode = new GraphNode<SDFObjectNode>({ elemIdFullName: 'fullFolderName', serviceid: '/SuiteScripts/InnerFolder', customizationInfo: emptyFolderCustInfo, changeType: 'addition' })
     fileTestNode.addEdge(folderTestNode)
     testGraph.addNodes([fileTestNode, folderTestNode])
     const fixedDeployXml = `<deploy>
@@ -80,18 +83,21 @@ describe('deploy xml utils tests', () => {
   </configuration>
   <files>
     <path>~/FileCabinet/SuiteScripts/shalomTest.js</path>
-    <path>~/FileCabinet/SuiteScripts/InnerFolder</path>
+    <path>~/FileCabinet/SuiteScripts/InnerFolder/*</path>
   </files>
   <objects>
     <path>~/Objects/scriptid3.xml</path>
     <path>~/Objects/scriptid1.xml</path>
     <path>~/Objects/scriptid2.xml</path>
+    <path>~/Objects/*</path>
   </objects>
   <translationimports>
     <path>~/Translations/*</path>
   </translationimports>
 </deploy>
 `
-    expect(reorderDeployXml(originalDeployXml, testGraph)).toEqual(fixedDeployXml)
+    expect(reorderDeployXml(
+      originalDeployXml, testGraph, [emptyCustInfo, emptyFileCustInfo, emptyFolderCustInfo]
+    )).toEqual(fixedDeployXml)
   })
 })

--- a/packages/netsuite-adapter/test/client/deploy_xml_utils.test.ts
+++ b/packages/netsuite-adapter/test/client/deploy_xml_utils.test.ts
@@ -14,25 +14,25 @@
 * limitations under the License.
 */
 
+import { CustomizationInfo } from '../../src/client/types'
 import { reorderDeployXml } from '../../src/client/deploy_xml_utils'
 import { Graph, GraphNode, SDFObjectNode } from '../../src/client/graph_utils'
 import { FILE, FOLDER } from '../../src/constants'
 
 describe('deploy xml utils tests', () => {
-  const emptyCustInfo = { typeName: '', values: {} }
   let testGraph: Graph<SDFObjectNode>
   beforeEach(() => {
     const testNode1 = new GraphNode<SDFObjectNode>(
-      { elemIdFullName: 'fullName1', serviceid: 'scriptid1', changeType: 'addition', customizationInfo: emptyCustInfo }
+      { elemIdFullName: 'fullName1', serviceid: 'scriptid1', changeType: 'addition', customizationInfo: { scriptId: 'scriptid1', typeName: '', values: {} } as CustomizationInfo }
     )
     const testNode2 = new GraphNode<SDFObjectNode>(
-      { elemIdFullName: 'fullName2', serviceid: 'scriptid2', changeType: 'addition', customizationInfo: emptyCustInfo }
+      { elemIdFullName: 'fullName2', serviceid: 'scriptid2', changeType: 'addition', customizationInfo: { scriptId: 'scriptid2', typeName: '', values: {} } as CustomizationInfo }
     )
     const testNode3 = new GraphNode<SDFObjectNode>(
-      { elemIdFullName: 'fullName3', serviceid: 'scriptid3', changeType: 'addition', customizationInfo: emptyCustInfo }
+      { elemIdFullName: 'fullName3', serviceid: 'scriptid3', changeType: 'addition', customizationInfo: { scriptId: 'scriptid3', typeName: '', values: {} } as CustomizationInfo }
     )
-    testNode1.addEdge(testNode2)
-    testNode3.addEdge(testNode1)
+    testNode3.addEdge('elemIdFullName', testNode1)
+    testNode1.addEdge('elemIdFullName', testNode2)
     testGraph = new Graph<SDFObjectNode>('elemIdFullName', [testNode1, testNode2, testNode3])
   })
   const originalDeployXml = `<deploy>
@@ -78,7 +78,7 @@ describe('deploy xml utils tests', () => {
     const emptyFolderCustInfo = { typeName: FOLDER, values: {}, path: ['SuiteScripts', 'InnerFolder'] }
     const fileTestNode = new GraphNode<SDFObjectNode>({ elemIdFullName: 'fullFileName', serviceid: '/SuiteScripts/shalomTest.js', customizationInfo: emptyFileCustInfo, changeType: 'addition' })
     const folderTestNode = new GraphNode<SDFObjectNode>({ elemIdFullName: 'fullFolderName', serviceid: '/SuiteScripts/InnerFolder', customizationInfo: emptyFolderCustInfo, changeType: 'addition' })
-    fileTestNode.addEdge(folderTestNode)
+    fileTestNode.addEdge(testGraph.key, folderTestNode)
     testGraph.addNodes([fileTestNode, folderTestNode])
     const fixedDeployXml = `<deploy>
   <configuration>

--- a/packages/netsuite-adapter/test/client/graph_utils.test.ts
+++ b/packages/netsuite-adapter/test/client/graph_utils.test.ts
@@ -32,7 +32,7 @@ describe('graph utils tests', () => {
 
 
   it('should find the nodes dependencies', async () => {
-    expect(testGraph.getNodeDependencies(testNode1)).toEqual([testNode1, testNode2, testNode3])
+    expect(testGraph.getNodeDependencies(testNode1)).toEqual([testNode2, testNode3, testNode1])
   })
 
   it('should find the node through its value', async () => {
@@ -50,5 +50,9 @@ describe('graph utils tests', () => {
 
   it('should find node by field', async () => {
     expect(testGraph.findNodeByField('name', 'node3')).toEqual(testNode3)
+  })
+
+  it('should return nodes in topological sort', async () => {
+    expect(testGraph.getTopologicalOrder()).toEqual([testNode1, testNode3, testNode2])
   })
 })

--- a/packages/netsuite-adapter/test/client/graph_utils.test.ts
+++ b/packages/netsuite-adapter/test/client/graph_utils.test.ts
@@ -26,9 +26,9 @@ describe('graph utils tests', () => {
   const testNode2 = new GraphNode({ name: 'node2', num: 2 })
   const testNode3 = new GraphNode({ name: 'node3', num: 3 })
   const testGraph = new Graph<testNode>('name', [testNode1, testNode2, testNode3])
-  testNode1.addEdge(testNode2)
-  testNode1.addEdge(testNode3)
-  testNode2.addEdge(testNode1)
+  testNode1.addEdge(testGraph.key, testNode2)
+  testNode1.addEdge(testGraph.key, testNode3)
+  testNode2.addEdge(testGraph.key, testNode1)
 
 
   it('should find the nodes dependencies', async () => {

--- a/packages/netsuite-adapter/test/client/graph_utils.test.ts
+++ b/packages/netsuite-adapter/test/client/graph_utils.test.ts
@@ -32,7 +32,9 @@ describe('graph utils tests', () => {
 
 
   it('should find the nodes dependencies', async () => {
-    expect(testGraph.getNodeDependencies(testNode1)).toEqual([testNode2, testNode3, testNode1])
+    const result = testGraph.getNodeDependencies(testNode1)
+    expect(result).toHaveLength(3)
+    expect(result).toEqual(expect.arrayContaining([testNode2, testNode3, testNode1]))
   })
 
   it('should find the node through its value', async () => {
@@ -54,5 +56,11 @@ describe('graph utils tests', () => {
 
   it('should return nodes in topological sort', async () => {
     expect(testGraph.getTopologicalOrder()).toEqual([testNode1, testNode3, testNode2])
+  })
+
+  it('should remove node from graph and edges from nodes', async () => {
+    testGraph.removeNode('node1')
+    expect(testGraph.nodes.get('node1')).toBeUndefined()
+    expect(testNode2.edges).not.toContain(testNode1)
   })
 })

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -29,7 +29,7 @@ import SdfClient, {
 import { CustomizationInfo, CustomTypeInfo, FileCustomizationInfo, FolderCustomizationInfo, SdfDeployParams, TemplateCustomTypeInfo } from '../../src/client/types'
 import { fileCabinetTopLevelFolders } from '../../src/client/constants'
 import { DEFAULT_COMMAND_TIMEOUT_IN_MINUTES } from '../../src/config'
-import { FeaturesDeployError, ManifestValidationError, MissingManifestFeaturesError, ObjectsDeployError, SettingsDeployError } from '../../src/errors'
+import { FeaturesDeployError, ManifestValidationError, MissingManifestFeaturesError, ObjectsDeployError, SettingsDeployError } from '../../src/client/errors'
 import { Graph, SDFObjectNode } from '../../src/client/graph_utils'
 
 const DEFAULT_DEPLOY_PARAMS: [undefined, SdfDeployParams] = [

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -1268,6 +1268,7 @@ describe('sdf client', () => {
     let client: SdfClient
     const testGraph = DEFAULT_DEPLOY_PARAMS[2]
     let customTypeInfo: CustomTypeInfo
+    let testSDFNode: SDFObjectNode
     beforeEach(() => {
       client = mockClient()
       testGraph.nodes.clear()
@@ -1278,6 +1279,7 @@ describe('sdf client', () => {
         },
         scriptId: 'scriptId',
       } as CustomTypeInfo
+      testSDFNode = { serviceid: 'scriptId', elemIdFullName: 'name', changeType: 'addition', customizationInfo: customTypeInfo }
     })
     describe('deployCustomObject', () => {
       it('should succeed for CustomTypeInfo', async () => {
@@ -1410,7 +1412,7 @@ File: ~/Objects/custform_114_t1441298_782.xml
           return { isSuccess: () => true }
         })
         let isRejected: boolean
-        testGraph.addNodes([new GraphNode({ serviceid: 'scriptId', elemIdFullName: 'name', changeType: 'addition', customizationInfo: customTypeInfo })])
+        testGraph.addNodes([new GraphNode(testSDFNode)])
         try {
           await client.deploy(...DEFAULT_DEPLOY_PARAMS)
           isRejected = false
@@ -1505,7 +1507,7 @@ File: ~/Objects/custform_15_t1049933_143.xml
           return { isSuccess: () => true }
         })
         let isRejected: boolean
-        testGraph.addNodes([new GraphNode({ serviceid: 'scriptId', elemIdFullName: 'name', changeType: 'addition', customizationInfo: customTypeInfo })])
+        testGraph.addNodes([new GraphNode(testSDFNode)])
         try {
           await client.deploy(...DEFAULT_DEPLOY_PARAMS)
           isRejected = false
@@ -1555,7 +1557,7 @@ File: ~/Objects/custform_15_t1049933_143.xml
           return { isSuccess: () => true }
         })
         let isRejected: boolean
-        testGraph.addNodes([new GraphNode({ serviceid: 'scriptId', elemIdFullName: 'name', changeType: 'addition', customizationInfo: customTypeInfo })])
+        testGraph.addNodes([new GraphNode(testSDFNode)])
         try {
           await client.deploy(...DEFAULT_DEPLOY_PARAMS)
           isRejected = false
@@ -1606,7 +1608,7 @@ Object: customrecord_flo_customization.custrecord_flo_custz_link (customrecordcu
           return { isSuccess: () => true }
         })
         let isRejected: boolean
-        testGraph.addNodes([new GraphNode({ serviceid: 'scriptId', elemIdFullName: 'name', changeType: 'addition', customizationInfo: customTypeInfo })])
+        testGraph.addNodes([new GraphNode(testSDFNode)])
         try {
           await client.deploy(...DEFAULT_DEPLOY_PARAMS)
           isRejected = false
@@ -1658,7 +1660,7 @@ Object: customrecord_flo_customization.custrecord_flo_custz_link (customrecordcu
           return { isSuccess: () => true }
         })
         let isRejected: boolean
-        testGraph.addNodes([new GraphNode({ serviceid: 'scriptId', elemIdFullName: 'name', changeType: 'addition', customizationInfo: customTypeInfo })])
+        testGraph.addNodes([new GraphNode(testSDFNode)])
         try {
           await client.deploy(...DEFAULT_DEPLOY_PARAMS)
           isRejected = false
@@ -1712,7 +1714,7 @@ File: ~/AccountConfiguration/features.xml`
           return { isSuccess: () => true }
         })
         let isRejected: boolean
-        testGraph.addNodes([new GraphNode({ serviceid: 'scriptId', elemIdFullName: 'name', changeType: 'addition', customizationInfo: customTypeInfo })])
+        testGraph.addNodes([new GraphNode(testSDFNode)])
         try {
           await client.deploy(...DEFAULT_DEPLOY_PARAMS)
           isRejected = false
@@ -1735,7 +1737,7 @@ File: ~/AccountConfiguration/features.xml`
           },
           path: ['Templates', 'E-mail Templates', 'InnerFolder'],
         }
-        testGraph.addNodes([new GraphNode({ serviceid: 'Templates/E-mail Templates/InnerFolder', elemIdFullName: 'name', changeType: 'addition', customizationInfo: folderCustomizationInfo })])
+        testGraph.addNodes([new GraphNode({ serviceid: 'Templates/E-mail Templates/InnerFolder', elemIdFullName: 'name', changeType: 'addition', customizationInfo: folderCustomizationInfo } as SDFObjectNode)])
         await client.deploy(...DEFAULT_DEPLOY_PARAMS)
         expect(mkdirpMock).toHaveBeenCalledTimes(1)
         expect(mkdirpMock)
@@ -1764,7 +1766,7 @@ File: ~/AccountConfiguration/features.xml`
           path: ['Templates', 'E-mail Templates', 'InnerFolder', 'content.html'],
           fileContent: dummyFileContent,
         }
-        testGraph.addNodes([new GraphNode({ serviceid: 'Templates/E-mail Templates/InnerFolder/content.html', elemIdFullName: 'name', changeType: 'addition', customizationInfo: fileCustomizationInfo })])
+        testGraph.addNodes([new GraphNode({ serviceid: 'Templates/E-mail Templates/InnerFolder/content.html', elemIdFullName: 'name', changeType: 'addition', customizationInfo: fileCustomizationInfo } as SDFObjectNode)])
         await client.deploy(...DEFAULT_DEPLOY_PARAMS)
         expect(mkdirpMock).toHaveBeenCalledTimes(2)
         expect(mkdirpMock)
@@ -1798,7 +1800,7 @@ File: ~/AccountConfiguration/features.xml`
         },
       }
       it('should succeed', async () => {
-        testGraph.addNodes([new GraphNode({ serviceid: '', elemIdFullName: 'name', changeType: 'addition', customizationInfo: featuresCustomizationInfo })])
+        testGraph.addNodes([new GraphNode({ serviceid: '', elemIdFullName: 'name', changeType: 'addition', customizationInfo: featuresCustomizationInfo } as SDFObjectNode)])
         mockExecuteAction.mockResolvedValue({ isSuccess: () => true, data: ['Configure feature -- The SUITEAPPCONTROLCENTER(Departments) feature has been DISABLED'] })
         await client.deploy(...DEFAULT_DEPLOY_PARAMS)
         expect(writeFileMock).toHaveBeenCalledTimes(3)
@@ -1813,7 +1815,7 @@ File: ~/AccountConfiguration/features.xml`
 
       it('should throw FeaturesDeployError on failed features deploy', async () => {
         const errorMessage = 'Configure feature -- Enabling of the SUITEAPPCONTROLCENTER(SuiteApp Control Center) feature has FAILED'
-        testGraph.addNodes([new GraphNode({ serviceid: '', elemIdFullName: 'name', changeType: 'addition', customizationInfo: featuresCustomizationInfo })])
+        testGraph.addNodes([new GraphNode({ serviceid: '', elemIdFullName: 'name', changeType: 'addition', customizationInfo: featuresCustomizationInfo } as SDFObjectNode)])
         mockExecuteAction.mockResolvedValue({ isSuccess: () => true, data: [errorMessage] })
         await expect(client.deploy(...DEFAULT_DEPLOY_PARAMS))
           .rejects.toThrow(new FeaturesDeployError(errorMessage, ['SUITEAPPCONTROLCENTER']))
@@ -1845,8 +1847,8 @@ File: ~/AccountConfiguration/features.xml`
         scriptId: scriptId2,
       }
       testGraph.addNodes([
-        new GraphNode({ serviceid: scriptId1, elemIdFullName: 'name1', changeType: 'addition', customizationInfo: customTypeInfo1 }),
-        new GraphNode({ serviceid: scriptId2, elemIdFullName: 'name2', changeType: 'addition', customizationInfo: customTypeInfo2 }),
+        new GraphNode({ serviceid: scriptId1, elemIdFullName: 'name1', changeType: 'addition', customizationInfo: customTypeInfo1 } as SDFObjectNode),
+        new GraphNode({ serviceid: scriptId2, elemIdFullName: 'name2', changeType: 'addition', customizationInfo: customTypeInfo2 } as SDFObjectNode),
       ])
       await client.deploy(...DEFAULT_DEPLOY_PARAMS)
       expect(writeFileMock).toHaveBeenCalledTimes(4)
@@ -1864,8 +1866,8 @@ File: ~/AccountConfiguration/features.xml`
     describe('validate only', () => {
       const failObject = 'fail_object'
       testGraph.addNodes([
-        new GraphNode({ serviceid: failObject, elemIdFullName: 'name2', changeType: 'addition', customizationInfo: { typeName: 'typeName', values: { key: 'val' }, scriptId: failObject } }),
-        new GraphNode({ serviceid: 'successObject', elemIdFullName: 'name2', changeType: 'addition', customizationInfo: { typeName: 'typeName', values: { key: 'val' }, scriptId: 'successObject' } }),
+        new GraphNode({ serviceid: failObject, elemIdFullName: 'name2', changeType: 'addition', customizationInfo: { typeName: 'typeName', values: { key: 'val' }, scriptId: failObject } } as SDFObjectNode),
+        new GraphNode({ serviceid: 'successObject', elemIdFullName: 'name2', changeType: 'addition', customizationInfo: { typeName: 'typeName', values: { key: 'val' }, scriptId: 'successObject' } } as SDFObjectNode),
       ])
       const deployParams: [undefined, SdfDeployParams, Graph<SDFObjectNode>] = [
         undefined,

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -1366,14 +1366,7 @@ describe('sdf client', () => {
           'some error',
         ]
         mockExecuteAction.mockResolvedValue({ isSuccess: () => true, data: sdfResult })
-        const customTypeInfo = {
-          typeName: 'typeName',
-          values: {
-            key: 'val',
-          },
-          scriptId: 'some_id',
-        } as CustomTypeInfo
-        await expect(client.deploy([customTypeInfo], ...DEFAULT_DEPLOY_PARAMS)).rejects
+        await expect(client.deploy(...DEFAULT_DEPLOY_PARAMS)).rejects
           .toThrow(new Error(
             'Starting deploy\n'
             + '*** ERREUR ***\n'
@@ -1451,13 +1444,7 @@ File: ~/Objects/custform_114_t1441298_782.xml
         mockExecuteAction.mockResolvedValue({ isSuccess: () => true, data: errorMessage.split('\n') })
         let isRejected: boolean
         try {
-          await client.deploy([{
-            typeName: 'typeName',
-            values: {
-              key: 'val',
-            },
-            scriptId: 'scriptId',
-          } as CustomTypeInfo], ...DEFAULT_DEPLOY_PARAMS)
+          await client.deploy(...DEFAULT_DEPLOY_PARAMS)
           isRejected = false
         } catch (e) {
           isRejected = true
@@ -1827,7 +1814,7 @@ File: ~/AccountConfiguration/features.xml`
           'Configurer la fonction -- La d.sactivation de la fonction SUITEAPPCONTROLCENTER(SuiteApp Control Center) a .chou.',
         ]
         mockExecuteAction.mockResolvedValue({ isSuccess: () => true, data: errorMessages })
-        await expect(client.deploy([featuresCustomizationInfo], ...DEFAULT_DEPLOY_PARAMS))
+        await expect(client.deploy(...DEFAULT_DEPLOY_PARAMS))
           .rejects.toThrow(new FeaturesDeployError(errorMessages[1], ['SUITEAPPCONTROLCENTER']))
       })
     })


### PR DESCRIPTION
_Before deploying, we now edit the deploy.xml and sort the objects in the deployment according to their reference levels_

---

_None_

---
_Release Notes_: 
_Netsuite Adapter_:
* Objects in the deploy.xml will be ordered according to their reference level

---
_User Notifications_: 
_None_
