### PR TITLE
salto-2883 netsuite partial fetch

### DIFF
--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -26,6 +26,7 @@ import {
 import { NetsuiteQueryParameters, FetchParams, convertToQueryParams, QueryParams, FetchTypeQueryParams, FieldToOmitParams, validateArrayOfStrings, validatePlainObject, validateFetchParameters, FETCH_PARAMS, validateFieldsToOmitConfig } from './query'
 import { ITEM_TYPE_TO_SEARCH_STRING, TYPES_TO_INTERNAL_ID } from './data_elements/types'
 import { AdditionalDependencies, AdditionalSdfDeployDependencies, FailedFiles, FailedTypes } from './client/types'
+import { netsuiteSupportedTypes } from './types'
 
 // in small Netsuite accounts the concurrency limit per integration can be between 1-4
 export const DEFAULT_CONCURRENCY = 4
@@ -176,6 +177,7 @@ const queryConfigType = createMatchingObjectType<NetsuiteQueryParameters>({
       refType: new MapType(new ListType(BuiltinTypes.STRING)),
       annotations: {
         [CORE_ANNOTATIONS.DEFAULT]: {},
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values: netsuiteSupportedTypes, enforce_value: false }),
       },
     },
     filePaths: {
@@ -188,6 +190,7 @@ const queryConfigType = createMatchingObjectType<NetsuiteQueryParameters>({
       refType: new MapType(new ListType(BuiltinTypes.STRING)),
       annotations: {
         [CORE_ANNOTATIONS.DEFAULT]: {},
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ regex: '^customrecord[0-9a-z_]+', enforce_value: false }),
       },
     },
   },

--- a/packages/netsuite-adapter/src/data_elements/types.ts
+++ b/packages/netsuite-adapter/src/data_elements/types.ts
@@ -286,4 +286,4 @@ export const getTypeIdentifier = (type: ObjectType): string => (
     : TYPE_TO_IDENTIFIER[type.elemID.name]
 )
 
-export const SUPPORTED_TYPES = Object.keys(TYPES_TO_INTERNAL_ID)
+export const SUPPORTED_TYPES = Object.keys(TYPE_TO_IDENTIFIER)

--- a/packages/netsuite-adapter/src/query.ts
+++ b/packages/netsuite-adapter/src/query.ts
@@ -15,10 +15,9 @@
 */
 import _ from 'lodash'
 import { collections, regex, strings, types as lowerdashTypes } from '@salto-io/lowerdash'
-import { getStandardTypesNames } from './autogen/types'
-import { CONFIG_FEATURES, CUSTOM_RECORD_TYPE, CUSTOM_SEGMENT } from './constants'
-import { SUPPORTED_TYPES, TYPES_TO_INTERNAL_ID } from './data_elements/types'
-import { removeCustomRecordTypePrefix, SUITEAPP_CONFIG_TYPE_NAMES } from './types'
+import { CUSTOM_RECORD_TYPE, CUSTOM_SEGMENT } from './constants'
+import { TYPES_TO_INTERNAL_ID } from './data_elements/types'
+import { netsuiteSupportedTypes, removeCustomRecordTypePrefix } from './types'
 
 const { makeArray } = collections.array
 
@@ -159,12 +158,7 @@ export const validateFetchParameters = ({
   if (corruptedCustomRecordsIds.length !== 0) {
     throw new Error(`${ERROR_MESSAGE_PREFIX} Expected custom record ids to be an array of strings, but found:\n${JSON.stringify(corruptedCustomRecordsIds, null, 4)}}.`)
   }
-  const existingTypes = [
-    ...getStandardTypesNames(),
-    ...SUPPORTED_TYPES,
-    ...SUITEAPP_CONFIG_TYPE_NAMES,
-    CONFIG_FEATURES,
-  ]
+
   const receivedTypes = types.map(obj => obj.name)
   const receivedCustomRecords = customRecords.map(obj => obj.name)
   const idsRegexes = types.concat(customRecords)
@@ -183,7 +177,7 @@ export const validateFetchParameters = ({
 
   const invalidTypes = receivedTypes
     .filter(recivedTypeName =>
-      !existingTypes
+      !netsuiteSupportedTypes
         .some(existTypeName => checkTypeNameRegMatch({ name: recivedTypeName }, existTypeName)
           // This is to support the adapter configuration before the migration of
           // the SuiteApp type names from PascalCase to camelCase

--- a/packages/netsuite-adapter/src/types.ts
+++ b/packages/netsuite-adapter/src/types.ts
@@ -17,11 +17,12 @@ import { DeployResult as AdapterApiDeployResult, Element, InstanceElement, isFie
 import { values as lowerDashValues } from '@salto-io/lowerdash'
 import { fieldTypes } from './types/field_types'
 import { enums } from './autogen/types/enums'
-import { StandardType, getStandardTypes, isStandardTypeName } from './autogen/types'
+import { StandardType, getStandardTypes, isStandardTypeName, getStandardTypesNames } from './autogen/types'
 import { TypesMap } from './types/object_types'
 import { fileCabinetTypesNames, getFileCabinetTypes } from './types/file_cabinet_types'
 import { getConfigurationTypes } from './types/configuration_types'
 import { CONFIG_FEATURES, CUSTOM_FIELD_PREFIX, CUSTOM_RECORD_TYPE, CUSTOM_RECORD_TYPE_PREFIX, METADATA_TYPE, SOAP, INTERNAL_ID } from './constants'
+import { SUPPORTED_TYPES } from './data_elements/types'
 
 const { isDefined } = lowerDashValues
 
@@ -179,3 +180,10 @@ export const getInternalId = (element: Element): Value =>
 
 export const hasInternalId = (element: Element): boolean =>
   isDefined(getInternalId(element))
+
+export const netsuiteSupportedTypes = [
+  ...getStandardTypesNames(),
+  ...SUPPORTED_TYPES,
+  ...SUITEAPP_CONFIG_TYPE_NAMES,
+  CONFIG_FEATURES,
+]


### PR DESCRIPTION
return a list of supported types for NetSuite partial fetch., in order to support autocomplete and "fetch all" in quick fetch.
(extra work in SaaS has to be done in order to support this)

---

_Additional context for reviewer_
_None_

---
_Release Notes_: 
When choosing partial fetch in NetSuite, a list of supported types will be shown, allowing autocomplete and easy configuration

---
_User Notifications_: 
_None_
