### PR TITLE
SALTO-3551/same issuetype name validator

### DIFF
--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -48,6 +48,7 @@ import { permissionSchemeDeploymentValidator } from './permission_scheme'
 import { statusMigrationChangeValidator } from './status_migration'
 import { automationProjectUnresolvedReferenceValidator } from './automation_unresolved_references'
 import { unresolvedReferenceValidator } from './unresolved_references'
+import { sameIssueTypeNameChangeValidator } from './same_issue_type_name'
 
 const {
   deployTypesNotSupportedValidator,
@@ -76,6 +77,7 @@ export default (
     dashboardLayoutValidator,
     permissionTypeValidator,
     automationsValidator,
+    sameIssueTypeNameChangeValidator,
     statusMigrationChangeValidator,
     // Must run after statusMigrationChangeValidator
     workflowSchemeMigrationValidator(client, config, paginator),

--- a/packages/jira-adapter/src/change_validators/same_issue_type_name.ts
+++ b/packages/jira-adapter/src/change_validators/same_issue_type_name.ts
@@ -29,7 +29,7 @@ const getSameIssueTypeNameError = (
   elemID: getChangeData(change).elemID,
   severity: 'Error' as SeverityLevel,
   message: 'Issue type must have unique name',
-  detailedMessage: `The issue type ${existingIssueType.elemID.getFullName()} is already using the name "${existingIssueType.value.name}", please use a different one.`,
+  detailedMessage: `This issue type name ${existingIssueType.value.name} is already being used by another issue type ${existingIssueType.elemID.getFullName()}, and can not be deployed.`,
 })
 
 const getRelevantChanges = (

--- a/packages/jira-adapter/src/change_validators/same_issue_type_name.ts
+++ b/packages/jira-adapter/src/change_validators/same_issue_type_name.ts
@@ -1,0 +1,65 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { AdditionChange, Change, ChangeDataType, ChangeError, ChangeValidator, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, ModificationChange, SeverityLevel } from '@salto-io/adapter-api'
+import { collections, values } from '@salto-io/lowerdash'
+import _ from 'lodash'
+import { ISSUE_TYPE_NAME } from '../constants'
+
+
+const { awu } = collections.asynciterable
+const { isDefined } = values
+
+const getSameIssueTypeNameError = (
+  change: ModificationChange<InstanceElement> | AdditionChange<InstanceElement>,
+  existingIssueType: InstanceElement,
+): ChangeError => ({
+  elemID: getChangeData(change).elemID,
+  severity: 'Error' as SeverityLevel,
+  message: 'Issue type must have unique name',
+  detailedMessage: `The issue type ${existingIssueType.elemID.getFullName()} is already using the name "${existingIssueType.value.name}", please use a different one.`,
+})
+
+const getRelevantChanges = (
+  changes: ReadonlyArray<Change<ChangeDataType>>
+): (ModificationChange<InstanceElement> | AdditionChange<InstanceElement>
+)[] =>
+  changes
+    .filter(isAdditionOrModificationChange)
+    .filter(change => getChangeData(change).elemID.typeName === ISSUE_TYPE_NAME)
+    .filter(isInstanceChange)
+
+export const sameIssueTypeNameChangeValidator: ChangeValidator = async (changes, elementSource) => {
+  const relevantChanges = getRelevantChanges(changes)
+  if (elementSource === undefined || relevantChanges.length === 0) {
+    return []
+  }
+  const idsIterator = awu(await elementSource.list())
+  const issueTypes: InstanceElement[] = await awu(idsIterator)
+    .filter(id => id.typeName === ISSUE_TYPE_NAME)
+    .filter(id => id.idType === 'instance')
+    .map(id => elementSource.get(id))
+    .toArray()
+  const issuesByNames = _.groupBy(issueTypes, issueType => issueType.value.name)
+  return relevantChanges
+    .map(change => {
+      const otherInstance = issuesByNames[getChangeData(change).value.name].find(
+        issueType => !issueType.elemID.isEqual(getChangeData(change).elemID)
+      )
+      if (otherInstance !== undefined) {
+        return getSameIssueTypeNameError(change, otherInstance)
+      }
+    }).filter(isDefined)
+}

--- a/packages/jira-adapter/src/change_validators/same_issue_type_name.ts
+++ b/packages/jira-adapter/src/change_validators/same_issue_type_name.ts
@@ -52,10 +52,13 @@ export const sameIssueTypeNameChangeValidator: ChangeValidator = async (changes,
     .filter(id => id.idType === 'instance')
     .map(id => elementSource.get(id))
     .toArray()
-  const issuesByNames = _.groupBy(issueTypes, issueType => issueType.value.name)
+  const issuesByNames = _.groupBy(
+    [...issueTypes, ...relevantChanges.map(getChangeData)],
+    issueType => issueType.value.name,
+  )
   return relevantChanges
     .map(change => {
-      const otherInstance = issuesByNames[getChangeData(change).value.name].find(
+      const otherInstance = issuesByNames[getChangeData(change).value.name]?.find(
         issueType => !issueType.elemID.isEqual(getChangeData(change).elemID)
       )
       if (otherInstance === undefined) {

--- a/packages/jira-adapter/src/change_validators/same_issue_type_name.ts
+++ b/packages/jira-adapter/src/change_validators/same_issue_type_name.ts
@@ -58,8 +58,9 @@ export const sameIssueTypeNameChangeValidator: ChangeValidator = async (changes,
       const otherInstance = issuesByNames[getChangeData(change).value.name].find(
         issueType => !issueType.elemID.isEqual(getChangeData(change).elemID)
       )
-      if (otherInstance !== undefined) {
-        return getSameIssueTypeNameError(change, otherInstance)
+      if (otherInstance === undefined) {
+        return undefined
       }
+      return getSameIssueTypeNameError(change, otherInstance)
     }).filter(isDefined)
 }

--- a/packages/jira-adapter/test/change_validators/same_issue_type_name.test.ts
+++ b/packages/jira-adapter/test/change_validators/same_issue_type_name.test.ts
@@ -50,10 +50,29 @@ describe('workflow scheme migration', () => {
     expect(deletionErrors).toHaveLength(0)
   })
   it('should return an error for same issue type names', async () => {
+    const issueTypeInstance4 = new InstanceElement('issueType4', issueTypeObject, {
+      name: 'issueType3',
+    })
     const deletionErrors = await sameIssueTypeNameChangeValidator(
-      [toChange({ after: issueTypeInstance3 })],
+      [toChange({ after: issueTypeInstance4 })],
       elementSource,
     )
     expect(deletionErrors).toHaveLength(1)
+  })
+  it('should return an error for multiple changes for the same name', async () => {
+    const issueTypeInstance4 = new InstanceElement('issueType4', issueTypeObject, {
+      name: 'issueType3',
+    })
+    const issueTypeInstance5 = new InstanceElement('issueType5', issueTypeObject, {
+      name: 'issueType3',
+    })
+    const deletionErrors = await sameIssueTypeNameChangeValidator(
+      [
+        toChange({ before: issueTypeInstance1, after: issueTypeInstance4 }),
+        toChange({ before: issueTypeInstance2, after: issueTypeInstance5 }),
+      ],
+      elementSource,
+    )
+    expect(deletionErrors).toHaveLength(2)
   })
 })

--- a/packages/jira-adapter/test/change_validators/same_issue_type_name.test.ts
+++ b/packages/jira-adapter/test/change_validators/same_issue_type_name.test.ts
@@ -13,8 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { toChange, ObjectType, ElemID, InstanceElement, ReferenceExpression,, ReadOnlyElementsSource } from '@salto-io/adapter-api'
-import _ from 'lodash'
+import { toChange, ObjectType, ElemID, InstanceElement, ReadOnlyElementsSource } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { sameIssueTypeNameChangeValidator } from '../../src/change_validators/same_issue_type_name'
 import { JIRA } from '../../src/constants'
@@ -36,16 +35,25 @@ describe('workflow scheme migration', () => {
     elementSource = buildElementsSourceFromElements([issueTypeInstance1, issueTypeInstance2, issueTypeInstance3])
   })
   it('should not return error for removal changes', async () => {
-    const deletionErrors = await sameIssueTypeNameChangeValidator([toChange({ before: issueTypeInstance1 })], elementSource)
+    const deletionErrors = await sameIssueTypeNameChangeValidator(
+      [toChange({ before: issueTypeInstance1 })],
+      elementSource,
+    )
     expect(deletionErrors).toHaveLength(0)
   })
   it('should not return error for unique issue type names', async () => {
     elementSource = buildElementsSourceFromElements([issueTypeInstance1, issueTypeInstance2])
-    const deletionErrors = await sameIssueTypeNameChangeValidator([toChange({ after: issueTypeInstance3 })], elementSource)
+    const deletionErrors = await sameIssueTypeNameChangeValidator(
+      [toChange({ after: issueTypeInstance3 })],
+      elementSource,
+    )
     expect(deletionErrors).toHaveLength(0)
   })
   it('should return an error for same issue type names', async () => {
-    const deletionErrors = await sameIssueTypeNameChangeValidator([toChange({ after: issueTypeInstance3 })], elementSource)
+    const deletionErrors = await sameIssueTypeNameChangeValidator(
+      [toChange({ after: issueTypeInstance3 })],
+      elementSource,
+    )
     expect(deletionErrors).toHaveLength(1)
   })
 })

--- a/packages/jira-adapter/test/change_validators/same_issue_type_name.test.ts
+++ b/packages/jira-adapter/test/change_validators/same_issue_type_name.test.ts
@@ -40,9 +40,12 @@ describe('workflow scheme migration', () => {
     expect(deletionErrors).toHaveLength(0)
   })
   it('should not return error for unique issue type names', async () => {
-    const deletionErrors = await sameIssueTypeNameChangeValidator([toChange({ before: issueTypeInstance1 })], elementSource)
+    elementSource = buildElementsSourceFromElements([issueTypeInstance1, issueTypeInstance2])
+    const deletionErrors = await sameIssueTypeNameChangeValidator([toChange({ after: issueTypeInstance3 })], elementSource)
     expect(deletionErrors).toHaveLength(0)
   })
   it('should return an error for same issue type names', async () => {
+    const deletionErrors = await sameIssueTypeNameChangeValidator([toChange({ after: issueTypeInstance3 })], elementSource)
+    expect(deletionErrors).toHaveLength(1)
   })
 })

--- a/packages/jira-adapter/test/change_validators/same_issue_type_name.test.ts
+++ b/packages/jira-adapter/test/change_validators/same_issue_type_name.test.ts
@@ -1,0 +1,48 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { toChange, ObjectType, ElemID, InstanceElement, ReferenceExpression,, ReadOnlyElementsSource } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { sameIssueTypeNameChangeValidator } from '../../src/change_validators/same_issue_type_name'
+import { JIRA } from '../../src/constants'
+
+describe('workflow scheme migration', () => {
+  const issueTypeObject = new ObjectType({ elemID: new ElemID(JIRA, 'IssueType') })
+  const issueTypeInstance1 = new InstanceElement('issueType1', issueTypeObject, {
+    name: 'issueType1',
+  })
+  const issueTypeInstance2 = new InstanceElement('issueType1', issueTypeObject, {
+    name: 'issueType2',
+  })
+  const issueTypeInstance3 = new InstanceElement('issueType1', issueTypeObject, {
+    name: 'issueType3',
+  })
+  let elementSource: ReadOnlyElementsSource
+
+  beforeEach(() => {
+    elementSource = buildElementsSourceFromElements([issueTypeInstance1, issueTypeInstance2, issueTypeInstance3])
+  })
+  it('should not return error for removal changes', async () => {
+    const deletionErrors = await sameIssueTypeNameChangeValidator([toChange({ before: issueTypeInstance1 })], elementSource)
+    expect(deletionErrors).toHaveLength(0)
+  })
+  it('should not return error for unique issue type names', async () => {
+    const deletionErrors = await sameIssueTypeNameChangeValidator([toChange({ before: issueTypeInstance1 })], elementSource)
+    expect(deletionErrors).toHaveLength(0)
+  })
+  it('should return an error for same issue type names', async () => {
+  })
+})


### PR DESCRIPTION
_Replace me with a description of the changes in this PR_

---

_Additional context for reviewer_

---
_Release Notes_: 
jira adapter:
* add change validator to block deployment of issue types with non unique names.

---
_User Notifications_: 
