### PR TITLE
Revert "SALTO-3619: use --forceExit when running tests(workaround)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build-ts": "lerna run build-ts",
     "build-all": "lerna run build",
     "clean": "lerna run --parallel clean",
-    "test": "jest --forceExit --detectOpenHandles",
+    "test": "jest",
     "generate-notices-file": "./build_utils/generate_notices.sh",
     "lerna-version": "lerna version --no-git-tag-version --exact",
     "lerna-version-pr": "./build_utils/create_version_pr.sh",


### PR DESCRIPTION
It looks like the flags making the E2E to run for 2 hours

---
_Release Notes_: 
None

---
_User Notifications_: 
None