### PR TITLE
SALTO-3535/priority scheme migration

### DIFF
--- a/packages/jira-adapter/src/change_validators/active_scheme_change.ts
+++ b/packages/jira-adapter/src/change_validators/active_scheme_change.ts
@@ -49,7 +49,7 @@ const getChangeErrorForChange = (change: ModificationChange<InstanceElement>): C
     elemID: getChangeData(change).elemID,
     severity: 'Error',
     message: `Can’t replace non-empty project ${changedFields.join(', ')}`,
-    detailedMessage: 'Salto cannot change the workflow scheme for a project with existing issues. To perform this action manually, you can use the Jira interface. This will allow you to migrate the necessary issues.',
+    detailedMessage: `Salto cannot change ${changedFields.join(', ')} for a project with existing issues. To perform this action manually, you can use the Jira interface. This will allow you to migrate the necessary issues.`,
   }
 }
 

--- a/packages/jira-adapter/src/change_validators/active_scheme_change.ts
+++ b/packages/jira-adapter/src/change_validators/active_scheme_change.ts
@@ -22,8 +22,13 @@ import { doesProjectHaveIssues } from './project_deletion'
 const { awu } = collections.asynciterable
 
 const RELEVANT_FIELDS = ['priorityScheme', 'workflowScheme']
+type RelevantField = typeof RELEVANT_FIELDS[number]
+const FIELD_FORMATS: Record<RelevantField, string> = {
+  priorityScheme: 'priority scheme',
+  workflowScheme: 'workflow scheme',
+}
 
-const projectSchemeChanged = (change : ModificationChange<InstanceElement>): string[] => {
+const projectSchemeChanged = (change : ModificationChange<InstanceElement>): RelevantField[] => {
   const { before, after } = change.data
   const changedFields = RELEVANT_FIELDS
     .filter(field => before.value[field] instanceof ReferenceExpression
@@ -43,14 +48,14 @@ const getRelevantChanges = async (
     .filter(async change => doesProjectHaveIssues(getChangeData(change), client))
     .toArray()
 
-const getChangeErrorForChange = (change: ModificationChange<InstanceElement>): ChangeError => {
+const getChangeErrorForChange = (change: ModificationChange<InstanceElement>): ChangeError[] => {
   const changedFields = projectSchemeChanged(change)
-  return {
+  return changedFields.map(field => ({
     elemID: getChangeData(change).elemID,
     severity: 'Error',
-    message: `Can’t replace non-empty project ${changedFields.join(', ')}`,
-    detailedMessage: `Salto cannot change ${changedFields.join(', ')} for a project with existing issues. To perform this action manually, you can use the Jira interface. This will allow you to migrate the necessary issues.`,
-  }
+    message: `Can’t replace non-empty project ${FIELD_FORMATS[field]}`,
+    detailedMessage: `Salto cannot change ${FIELD_FORMATS[field]} for a project with existing issues. To perform this action manually, you can use the Jira interface. This will allow you to migrate the necessary issues.`,
+  }))
 }
 
 export const activeSchemeChangeValidator = (
@@ -58,5 +63,5 @@ export const activeSchemeChangeValidator = (
 ): ChangeValidator =>
   async changes => {
     const relevantChanges = await getRelevantChanges(changes, client)
-    return relevantChanges.map(getChangeErrorForChange)
+    return relevantChanges.flatMap(getChangeErrorForChange)
   }

--- a/packages/jira-adapter/src/change_validators/active_scheme_change.ts
+++ b/packages/jira-adapter/src/change_validators/active_scheme_change.ts
@@ -26,9 +26,9 @@ const RELEVANT_TYPES = ['priorityScheme', 'workflowScheme']
 const projectSchemeChanged = (change : ModificationChange<InstanceElement>): string[] => {
   const { before, after } = change.data
   const changedFields = RELEVANT_TYPES
-    .filter(type => before.value[type] instanceof ReferenceExpression
-      && after.value[type] instanceof ReferenceExpression)
-    .filter(type => before.value[type].elemID.isEqual(after.value[type].elemID))
+    .filter(field => before.value[field] instanceof ReferenceExpression
+      && after.value[field] instanceof ReferenceExpression)
+    .filter(type => !before.value[type].elemID.isEqual(after.value[type].elemID))
   return changedFields
 }
 

--- a/packages/jira-adapter/src/change_validators/active_scheme_change.ts
+++ b/packages/jira-adapter/src/change_validators/active_scheme_change.ts
@@ -21,10 +21,16 @@ import { doesProjectHaveIssues } from './project_deletion'
 
 const { awu } = collections.asynciterable
 
-const projectWorkflowSchemeChanged = (change : ModificationChange<InstanceElement>): boolean =>
-  change.data.before.value.workflowScheme instanceof ReferenceExpression
-  && change.data.after.value.workflowScheme instanceof ReferenceExpression
-  && !change.data.before.value.workflowScheme.elemID.isEqual(change.data.after.value.workflowScheme.elemID)
+const RELEVANT_TYPES = ['priorityScheme', 'workflowScheme']
+
+const projectSchemeChanged = (change : ModificationChange<InstanceElement>): string[] => {
+  const { before, after } = change.data
+  const changedFields = RELEVANT_TYPES
+    .filter(type => before.value[type] instanceof ReferenceExpression
+      && after.value[type] instanceof ReferenceExpression)
+    .filter(type => before.value[type].elemID.isEqual(after.value[type].elemID))
+  return changedFields
+}
 
 const getRelevantChanges = async (
   changes: ReadonlyArray<Change<ChangeDataType>>, client: JiraClient,
@@ -33,19 +39,21 @@ const getRelevantChanges = async (
     .filter(isInstanceChange)
     .filter(isModificationChange)
     .filter(change => getChangeData(change).elemID.typeName === PROJECT_TYPE)
-    .filter(projectWorkflowSchemeChanged)
+    .filter(change => projectSchemeChanged(change).length > 0)
     .filter(async change => doesProjectHaveIssues(getChangeData(change), client))
     .toArray()
 
-const getChangeErrorForChange = (change: ModificationChange<InstanceElement>): ChangeError =>
-  ({
+const getChangeErrorForChange = (change: ModificationChange<InstanceElement>): ChangeError => {
+  const changedFields = projectSchemeChanged(change)
+  return {
     elemID: getChangeData(change).elemID,
     severity: 'Error',
-    message: 'Can’t replace non-empty project workflow scheme',
+    message: `Can’t replace non-empty project ${changedFields.join(', ')}`,
     detailedMessage: 'Salto cannot change the workflow scheme for a project with existing issues. To perform this action manually, you can use the Jira interface. This will allow you to migrate the necessary issues.',
-  })
+  }
+}
 
-export const activeWorkflowSchemeChangeValidator = (
+export const activeSchemeChangeValidator = (
   client: JiraClient,
 ): ChangeValidator =>
   async changes => {

--- a/packages/jira-adapter/src/change_validators/active_scheme_change.ts
+++ b/packages/jira-adapter/src/change_validators/active_scheme_change.ts
@@ -21,11 +21,11 @@ import { doesProjectHaveIssues } from './project_deletion'
 
 const { awu } = collections.asynciterable
 
-const RELEVANT_TYPES = ['priorityScheme', 'workflowScheme']
+const RELEVANT_FIELDS = ['priorityScheme', 'workflowScheme']
 
 const projectSchemeChanged = (change : ModificationChange<InstanceElement>): string[] => {
   const { before, after } = change.data
-  const changedFields = RELEVANT_TYPES
+  const changedFields = RELEVANT_FIELDS
     .filter(field => before.value[field] instanceof ReferenceExpression
       && after.value[field] instanceof ReferenceExpression)
     .filter(type => !before.value[type].elemID.isEqual(after.value[type].elemID))

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -46,7 +46,7 @@ import { fieldContextValidator } from './field_contexts/field_contexts'
 import { workflowSchemeMigrationValidator } from './workflow_scheme_migration'
 import { permissionSchemeDeploymentValidator } from './permission_scheme'
 import { statusMigrationChangeValidator } from './status_migration'
-import { activeWorkflowSchemeChangeValidator } from './active_workflow_scheme_change'
+import { activeSchemeChangeValidator } from './active_scheme_change'
 import { automationProjectUnresolvedReferenceValidator } from './automation_unresolved_references'
 import { unresolvedReferenceValidator } from './unresolved_references'
 import { sameIssueTypeNameChangeValidator } from './same_issue_type_name'
@@ -82,7 +82,7 @@ export default (
     statusMigrationChangeValidator,
     // Must run after statusMigrationChangeValidator
     workflowSchemeMigrationValidator(client, config, paginator),
-    activeWorkflowSchemeChangeValidator(client),
+    activeSchemeChangeValidator(client),
     maskingValidator(client),
     lockedFieldsValidator,
     fieldContextValidator,

--- a/packages/jira-adapter/test/change_validators/active_scheme_change.test.ts
+++ b/packages/jira-adapter/test/change_validators/active_scheme_change.test.ts
@@ -21,6 +21,10 @@ import { activeSchemeChangeValidator } from '../../src/change_validators/active_
 import { JIRA } from '../../src/constants'
 
 describe('active scheme change', () => {
+  const workflowSchemeReference1 = new ReferenceExpression(new ElemID(JIRA, 'WorkflowScheme', 'instance', 'workflow1'))
+  const workflowSchemeReference2 = new ReferenceExpression(new ElemID(JIRA, 'WorkflowScheme', 'instance', 'workflow2'))
+  const prioritySchemeReference1 = new ReferenceExpression(new ElemID(JIRA, 'PriorityScheme', 'instance', 'priority1'))
+  const prioritySchemeReference2 = new ReferenceExpression(new ElemID(JIRA, 'PriorityScheme', 'instance', 'priority2'))
   let mockConnection: MockInterface<clientUtils.APIConnection>
   let projectType: ObjectType
   let projectInstance: InstanceElement
@@ -39,7 +43,7 @@ describe('active scheme change', () => {
       projectType,
       {
         name: 'instance',
-        workflowScheme: new ReferenceExpression(new ElemID(JIRA, 'WorkflowScheme', 'instance', 'workflow1')),
+        workflowScheme: workflowSchemeReference1,
       }
     )
     modifiedInstance = new InstanceElement(
@@ -47,7 +51,7 @@ describe('active scheme change', () => {
       projectType,
       {
         name: 'instance',
-        workflowScheme: new ReferenceExpression(new ElemID(JIRA, 'WorkflowScheme', 'instance', 'workflow2')),
+        workflowScheme: workflowSchemeReference2,
       }
     )
     mockConnection.get.mockImplementation(async url => {
@@ -81,5 +85,12 @@ describe('active scheme change', () => {
   it('should return an error when there are issues', async () => {
     const errors = await validator([toChange({ before: projectInstance, after: modifiedInstance })])
     expect(errors).toHaveLength(1)
+  })
+  it('should return an error for both fields if both changed', async () => {
+    projectInstance.value.priorityScheme = prioritySchemeReference1
+    modifiedInstance.value.priorityScheme = prioritySchemeReference2
+    const errors = await validator([toChange({ before: projectInstance, after: modifiedInstance })])
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toEqual('Can’t replace non-empty project priorityScheme, workflowScheme')
   })
 })

--- a/packages/jira-adapter/test/change_validators/active_scheme_change.test.ts
+++ b/packages/jira-adapter/test/change_validators/active_scheme_change.test.ts
@@ -20,7 +20,7 @@ import { mockClient } from '../utils'
 import { activeSchemeChangeValidator } from '../../src/change_validators/active_scheme_change'
 import { JIRA } from '../../src/constants'
 
-describe('active workflow scheme change', () => {
+describe('active scheme change', () => {
   let mockConnection: MockInterface<clientUtils.APIConnection>
   let projectType: ObjectType
   let projectInstance: InstanceElement

--- a/packages/jira-adapter/test/change_validators/active_scheme_change.test.ts
+++ b/packages/jira-adapter/test/change_validators/active_scheme_change.test.ts
@@ -92,5 +92,6 @@ describe('active scheme change', () => {
     const errors = await validator([toChange({ before: projectInstance, after: modifiedInstance })])
     expect(errors).toHaveLength(1)
     expect(errors[0].message).toEqual('Can’t replace non-empty project priorityScheme, workflowScheme')
+    expect(errors[0].detailedMessage).toEqual('Salto cannot change priorityScheme, workflowScheme for a project with existing issues. To perform this action manually, you can use the Jira interface. This will allow you to migrate the necessary issues.')
   })
 })

--- a/packages/jira-adapter/test/change_validators/active_scheme_change.test.ts
+++ b/packages/jira-adapter/test/change_validators/active_scheme_change.test.ts
@@ -90,8 +90,10 @@ describe('active scheme change', () => {
     projectInstance.value.priorityScheme = prioritySchemeReference1
     modifiedInstance.value.priorityScheme = prioritySchemeReference2
     const errors = await validator([toChange({ before: projectInstance, after: modifiedInstance })])
-    expect(errors).toHaveLength(1)
-    expect(errors[0].message).toEqual('Can’t replace non-empty project priorityScheme, workflowScheme')
-    expect(errors[0].detailedMessage).toEqual('Salto cannot change priorityScheme, workflowScheme for a project with existing issues. To perform this action manually, you can use the Jira interface. This will allow you to migrate the necessary issues.')
+    expect(errors).toHaveLength(2)
+    expect(errors[0].message).toEqual('Can’t replace non-empty project priority scheme')
+    expect(errors[0].detailedMessage).toEqual('Salto cannot change priority scheme for a project with existing issues. To perform this action manually, you can use the Jira interface. This will allow you to migrate the necessary issues.')
+    expect(errors[1].message).toEqual('Can’t replace non-empty project workflow scheme')
+    expect(errors[1].detailedMessage).toEqual('Salto cannot change workflow scheme for a project with existing issues. To perform this action manually, you can use the Jira interface. This will allow you to migrate the necessary issues.')
   })
 })

--- a/packages/jira-adapter/test/change_validators/active_workflow_scheme_change.test.ts
+++ b/packages/jira-adapter/test/change_validators/active_workflow_scheme_change.test.ts
@@ -17,7 +17,7 @@ import { toChange, ObjectType, ElemID, InstanceElement, ReferenceExpression, Cha
 import { MockInterface } from '@salto-io/test-utils'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { mockClient } from '../utils'
-import { activeWorkflowSchemeChangeValidator } from '../../src/change_validators/active_workflow_scheme_change'
+import { activeSchemeChangeValidator } from '../../src/change_validators/active_scheme_change'
 import { JIRA } from '../../src/constants'
 
 describe('active workflow scheme change', () => {
@@ -61,7 +61,7 @@ describe('active workflow scheme change', () => {
       }
       throw new Error(`Unexpected url ${url}`)
     })
-    validator = activeWorkflowSchemeChangeValidator(client)
+    validator = activeSchemeChangeValidator(client)
   })
   it('should not return error for addition/removal changes', async () => {
     const deletionErrors = await validator([toChange({ before: projectInstance })])


### PR DESCRIPTION
modify existing behaviour of a change validator to check not for just changes of workflow schemes in projects that will cause migration but for priority scheme changes aswell

---

_Additional context for reviewer_
modified the tests and text accordingly 

---
_Release Notes_: 
jira_adapter:
* data center:
  - add change validator to block deployment of project changes to priority schemes when the project has issues.

---
_User Notifications_: 

