### PR TITLE
SALTO-3619: Added jest flags to UTs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
 
       - run:
           name: Run unit tests
-          command: yarn test -w 4 --reporters=default --reporters=jest-junit
+          command: yarn test -w 4 --reporters=default --reporters=jest-junit --forceExit --detectOpenHandles
           environment:
             JEST_JUNIT_OUTPUT: "reports/unittests/test-results.xml"
             # https://github.com/pinojs/koa-pino-logger/issues/16


### PR DESCRIPTION
In https://github.com/salto-io/salto/pull/3960 I reverted https://github.com/salto-io/salto/commit/c3e977a5de74bd28f70c7d2cbe5984d780d7205f since the flags made the E2E tests take 2 hours.
Here I added the flags back but only in the UTs

---
_Release Notes_: 
None

---
_User Notifications_: 
None