### PR TITLE
SAAS-6953 add quickFetch to adapter-api and make Netsuite implementing it

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -110,6 +110,7 @@ export type AdapterOperations = {
   fetch: (opts: FetchOptions) => Promise<FetchResult>
   deploy: (opts: DeployOptions) => Promise<DeployResult>
   validate?: (opts: DeployOptions) => Promise<DeployResult>
+  fetchWithChangeDetection?: (opts: FetchOptions) => Promise<FetchResult>
   postFetch?: (opts: PostFetchOptions) => Promise<void>
   deployModifiers?: DeployModifiers
   validationModifiers?: ValidationModifiers

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -221,6 +221,7 @@ export type FetchFunc = (
   progressEmitter?: EventEmitter<FetchProgressEvents>,
   accounts?: string[],
   ignoreStateElemIdMapping?: boolean,
+  withChangeDetection?: boolean,
 ) => Promise<FetchResult>
 
 export type FetchFromWorkspaceFuncParams = {
@@ -256,6 +257,7 @@ export const fetch: FetchFunc = async (
   progressEmitter?,
   accounts?,
   ignoreStateElemIdMapping?,
+  ChangeDetection?,
 ) => {
   log.debug('fetch starting..')
   const fetchAccounts = accounts ?? workspace.accounts()
@@ -285,6 +287,7 @@ export const fetch: FetchFunc = async (
       accountToServiceNameMap,
       currentConfigs,
       progressEmitter,
+      ChangeDetection,
     )
     log.debug(`${elements.length} elements were fetched [mergedErrors=${mergeErrors.length}]`)
     await updateStateWithFetchResults(workspace, elements, unmergedElements, fetchAccounts)

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -257,7 +257,7 @@ export const fetch: FetchFunc = async (
   progressEmitter?,
   accounts?,
   ignoreStateElemIdMapping?,
-  ChangeDetection?,
+  withChangeDetection?,
 ) => {
   log.debug('fetch starting..')
   const fetchAccounts = accounts ?? workspace.accounts()
@@ -287,7 +287,7 @@ export const fetch: FetchFunc = async (
       accountToServiceNameMap,
       currentConfigs,
       progressEmitter,
-      ChangeDetection,
+      withChangeDetection,
     )
     log.debug(`${elements.length} elements were fetched [mergedErrors=${mergeErrors.length}]`)
     await updateStateWithFetchResults(workspace, elements, unmergedElements, fetchAccounts)

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import wu from 'wu'
-import _, { isUndefined } from 'lodash'
+import _ from 'lodash'
 import { EventEmitter } from 'pietile-eventemitter'
 import {
   Element, ElemID, AdapterOperations, Values, ServiceIds, ObjectType,
@@ -445,7 +445,7 @@ const fetchAndProcessMergeErrors = async (
         ([accountName, withChangeDetection ? adapter.fetchWithChangeDetection : adapter.fetch]))
     )
     const adapterWithoutFetchFunction = Object.entries(accountNameToFetchFunction)
-      .filter(([, fetchFunction]) => isUndefined(fetchFunction))
+      .filter(([, fetchFunction]) => !isDefined(fetchFunction))
       .map(([accountName]) => accountToServiceNameMap[accountName])
     if (adapterWithoutFetchFunction.length > 0) {
       throw new Error(`${adapterWithoutFetchFunction.join(', ')} adapters do not support quick fetch operation`)

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -444,11 +444,11 @@ const fetchAndProcessMergeErrors = async (
       Object.entries(accountsToAdapters).map(([accountName, adapter]) =>
         ([accountName, withChangeDetection ? adapter.fetchWithChangeDetection : adapter.fetch]))
     )
-    const adapterWithoutFetchFunction = Object.entries(accountNameToFetchFunction)
+    const adaptersWithoutFetchFunction = Object.entries(accountNameToFetchFunction)
       .filter(([, fetchFunction]) => !isDefined(fetchFunction))
       .map(([accountName]) => accountToServiceNameMap[accountName])
-    if (adapterWithoutFetchFunction.length > 0) {
-      throw new Error(`${adapterWithoutFetchFunction.join(', ')} adapters do not support quick fetch operation`)
+    if (adaptersWithoutFetchFunction.length > 0) {
+      throw new Error(`${adaptersWithoutFetchFunction.join(', ')} adapters do not support quick fetch operation`)
     }
 
     const fetchResults = await Promise.all(

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -445,10 +445,10 @@ const fetchAndProcessMergeErrors = async (
         ([accountName, withChangeDetection ? adapter.fetchWithChangeDetection : adapter.fetch]))
     )
     const adaptersWithoutFetchFunction = Object.entries(accountNameToFetchFunction)
-      .filter(([, fetchFunction]) => !isDefined(fetchFunction))
+      .filter(([, fetchFunction]) => fetchFunction === undefined)
       .map(([accountName]) => accountToServiceNameMap[accountName])
     if (adaptersWithoutFetchFunction.length > 0) {
-      throw new Error(`${adaptersWithoutFetchFunction.join(', ')} adapters do not support quick fetch operation`)
+      throw new Error(`Adapters: ${adaptersWithoutFetchFunction.join(', ')} do not support fetch with change detection operation`)
     }
 
     const fetchResults = await Promise.all(

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -1159,13 +1159,21 @@ describe('fetch', () => {
           fetch: mockFetch,
           deploy: mockDeploy,
         },
+        adapter3WithoutFetchWithChangeDetection: {
+          fetch: mockFetch,
+          deploy: mockDeploy,
+        },
       }
       it('should throw an error when run fetchWithChangeDetection with unsupported adapters', async () => {
         await expect(fetchChanges(
           adapters,
           createElementSource([]),
           createElementSource([]),
-          { adapterWithoutFetchWithChangeDetection: 'adapter1', adapter2WithoutFetchWithChangeDetection: 'adapter2' },
+          {
+            adapterWithoutFetchWithChangeDetection: 'adapter1',
+            adapter2WithoutFetchWithChangeDetection: 'adapter1',
+            adapter3WithoutFetchWithChangeDetection: 'adapter2',
+          },
           [],
           undefined,
           true,
@@ -1175,10 +1183,14 @@ describe('fetch', () => {
         mockFetch.mockClear()
         mockFetchWithChangeDetection.mockClear()
         await fetchChanges(
-          _.omit(adapters, ['adapterWithoutFetchWithChangeDetection', 'adapter2WithoutFetchWithChangeDetection']),
+          _.pick(adapters, 'adapterWithQuickFetch'),
           createElementSource([]),
           createElementSource([]),
-          { adapterWithoutFetchWithChangeDetection: 'adapter1', adapter2WithoutFetchWithChangeDetection: 'adapter2' },
+          {
+            adapterWithoutFetchWithChangeDetection: 'adapter1',
+            adapter2WithoutFetchWithChangeDetection: 'adapter1',
+            adapter3WithoutFetchWithChangeDetection: 'adapter2',
+          },
           [],
           undefined,
           true,

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -1169,7 +1169,7 @@ describe('fetch', () => {
           [],
           undefined,
           true,
-        )).rejects.toThrow('adapter1, adapter2 adapters do not support quick fetch operation')
+        )).rejects.toThrow('Adapters: adapter1, adapter2 do not support fetch with change detection operation')
       })
       it('should call fetchWithChangeDetection function', async () => {
         mockFetch.mockClear()

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -269,7 +269,7 @@ describe('fetch', () => {
         })
       })
 
-      it('should use the existing elements to resolve the fetched elements when calculcating changes', async () => {
+      it('should use the existing elements to resolve the fetched elements when calculating changes', async () => {
         const beforeElement = new InstanceElement(
           'name',
           new ObjectType({
@@ -1137,6 +1137,54 @@ describe('fetch', () => {
           .refType)
         expectedHiddenInstanceAlternateId.refType.type = expect.anything()
         expect(passed).toEqual([expectedHiddenInstanceAlternateId])
+      })
+    })
+
+    describe('when call with withChangeDetection true', () => {
+      const mockFetch = jest.fn()
+      const mockDeploy = jest.fn()
+      const mockFetchWithChangeDetection = jest.fn()
+        .mockResolvedValue({ elements: [] })
+      const adapters = {
+        adapterWithQuickFetch: {
+          fetch: mockFetch,
+          deploy: mockDeploy,
+          fetchWithChangeDetection: mockFetchWithChangeDetection,
+        },
+        adapterWithoutFetchWithChangeDetection: {
+          fetch: mockFetch,
+          deploy: mockDeploy,
+        },
+        adapter2WithoutFetchWithChangeDetection: {
+          fetch: mockFetch,
+          deploy: mockDeploy,
+        },
+      }
+      it('should throw an error when run fetchWithChangeDetection with unsupported adapters', async () => {
+        await expect(fetchChanges(
+          adapters,
+          createElementSource([]),
+          createElementSource([]),
+          { adapterWithoutFetchWithChangeDetection: 'adapter1', adapter2WithoutFetchWithChangeDetection: 'adapter2' },
+          [],
+          undefined,
+          true,
+        )).rejects.toThrow('adapter1, adapter2 adapters do not support quick fetch operation')
+      })
+      it('should call fetchWithChangeDetection function', async () => {
+        mockFetch.mockClear()
+        mockFetchWithChangeDetection.mockClear()
+        await fetchChanges(
+          _.omit(adapters, ['adapterWithoutFetchWithChangeDetection', 'adapter2WithoutFetchWithChangeDetection']),
+          createElementSource([]),
+          createElementSource([]),
+          { adapterWithoutFetchWithChangeDetection: 'adapter1', adapter2WithoutFetchWithChangeDetection: 'adapter2' },
+          [],
+          undefined,
+          true,
+        )
+        expect(mockFetchWithChangeDetection).toHaveBeenCalled()
+        expect(mockFetch).not.toHaveBeenCalled()
       })
     })
   })

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -249,7 +249,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
       ? await getOrCreateServerTimeElements(
         serverTime,
         this.elementsSource,
-        this.isPartialFetch(),
+        isPartial,
       )
       : undefined
 

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -120,7 +120,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
   private readonly lockedElements?: QueryParams
   private readonly fetchTarget?: NetsuiteQueryParameters
   private readonly skipList?: NetsuiteQueryParameters // old version
-  private readonly useChangesDetection: boolean // TODO remove this from configuration https://salto-io.atlassian.net/browse/SAAS-6953
+  private readonly useChangesDetection: boolean // TODO remove this from configuration SALTO-3676
   private elementsSourceIndex: LazyElementsSourceIndexes
   private createFiltersRunner: (params: {
     isPartial: boolean

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -120,7 +120,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
   private readonly lockedElements?: QueryParams
   private readonly fetchTarget?: NetsuiteQueryParameters
   private readonly skipList?: NetsuiteQueryParameters // old version
-  private readonly useChangesDetection: boolean
+  private readonly useChangesDetection: boolean // TODO remove this from configuration https://salto-io.atlassian.net/browse/SAAS-6953
   private elementsSourceIndex: LazyElementsSourceIndexes
   private createFiltersRunner: (params: {
     isPartial: boolean
@@ -239,6 +239,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
     } = await this.runSuiteAppOperations(
       fetchQuery,
       useChangesDetection,
+      isPartial,
     )
     const updatedFetchQuery = changedObjectsQuery !== undefined
       ? andQuery(changedObjectsQuery, fetchQuery)
@@ -340,12 +341,19 @@ export default class NetsuiteAdapter implements AdapterOperations {
     }
   }
 
-  /**
-   * Fetch configuration elements: objects, types and instances for the given Netsuite account.
-   * Account credentials were given in the constructor.
-   */
-
-  public async fetch({ progressReporter }: FetchOptions): Promise<FetchResult> {
+  private async innerFetch(
+    {
+      fetchOptions,
+      useChangesDetection,
+      isPartial,
+    }:
+    {
+      fetchOptions: FetchOptions
+      useChangesDetection: boolean
+      isPartial: boolean
+    }
+  ): Promise<FetchResult> {
+    const { progressReporter } = fetchOptions
     const explicitIncludeTypeList = [REPORT_DEFINITION, FINANCIAL_LAYOUT]
       .filter(typeName => !this.fetchInclude?.types.some(type => type.name === typeName))
     const deprecatedSkipList = buildNetsuiteQuery(convertToQueryParams({
@@ -361,14 +369,13 @@ export default class NetsuiteAdapter implements AdapterOperations {
       notQuery(deprecatedSkipList),
     ].filter(values.isDefined).reduce(andQuery)
 
-    const isPartial = this.isPartialFetch()
 
     const {
       failedToFetchAllAtOnce,
       failedFilePaths,
       failedTypes,
       elements,
-    } = await this.fetchByQuery(fetchQuery, progressReporter, this.useChangesDetection, isPartial)
+    } = await this.fetchByQuery(fetchQuery, progressReporter, useChangesDetection, isPartial)
 
     const updatedConfig = getConfigFromConfigChanges(
       failedToFetchAllAtOnce, failedFilePaths, failedTypes, this.userConfig
@@ -380,9 +387,31 @@ export default class NetsuiteAdapter implements AdapterOperations {
     return { elements, updatedConfig, isPartial }
   }
 
+  /**
+   * Fetch configuration elements: objects, types and instances for the given Netsuite account.
+   * Account credentials were given in the constructor.
+   */
+
+  public async fetch(fetchOptions: FetchOptions): Promise<FetchResult> {
+    return this.innerFetch({
+      fetchOptions,
+      useChangesDetection: this.useChangesDetection,
+      isPartial: this.isPartialFetch(),
+    })
+  }
+
+  public async fetchWithChangeDetection(fetchOptions: FetchOptions): Promise<FetchResult> {
+    return this.innerFetch({
+      fetchOptions,
+      useChangesDetection: true,
+      isPartial: true,
+    })
+  }
+
   private async runSuiteAppOperations(
     fetchQuery: NetsuiteQuery,
     useChangesDetection: boolean,
+    isPartial: boolean,
   ):
     Promise<{
       changedObjectsQuery?: NetsuiteQuery
@@ -394,7 +423,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
       return {}
     }
 
-    if (!this.isPartialFetch()) {
+    if (!isPartial) {
       return {
         serverTime: sysInfo.time,
       }

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -84,7 +84,7 @@ export type NetsuiteConfig = {
   fetch?: FetchParams
   fetchTarget?: NetsuiteQueryParameters
   skipList?: NetsuiteQueryParameters
-  useChangesDetection?: boolean // TODO remove this from config https://salto-io.atlassian.net/browse/SAAS-6953
+  useChangesDetection?: boolean // TODO remove this from config SALTO-3676
   deployReferencedElements?: boolean
 }
 

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -84,7 +84,7 @@ export type NetsuiteConfig = {
   fetch?: FetchParams
   fetchTarget?: NetsuiteQueryParameters
   skipList?: NetsuiteQueryParameters
-  useChangesDetection?: boolean
+  useChangesDetection?: boolean // TODO remove this from config https://salto-io.atlassian.net/browse/SAAS-6953
   deployReferencedElements?: boolean
 }
 


### PR DESCRIPTION
As part of https://salto-io.atlassian.net/browse/SAAS-6953?focusedCommentId=67080&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-67080
In this PR:
- Adding a new function to adapter-api 'quickFetch' this function is not mandatory and each adapter can implement it or not.
- Make Netsuite adapter to implement quickFetch, with the same logic that it has done with 'useChangesDetection' from the config file.

Note, for now I didn't remove 'useChangesDetection' from the config, since I want to support the old way to run quick fetch
 
---

---
_Release Notes_: 
Core:
Allow adapters to expose a fetchWithChangeDetection function that only fetches changes since the last fetch

Netsuite adapter:
Implement fetchWithChangeDetection to allow fetching only changes since the last fetch
---
_User Notifications_: 
None
