### PR TITLE
Salto-3334: Tell users when missing dependencies are from locked elements

### DIFF
--- a/packages/netsuite-adapter/src/change_validators/client_validation.ts
+++ b/packages/netsuite-adapter/src/change_validators/client_validation.ts
@@ -135,12 +135,14 @@ const changeValidator: ClientChangeValidator = async (
             const failedChangesWithDependencies = getFailedChangesWithDependencies(
               groupChanges, dependencyMap, error
             )
+            const lockedElemsMessage = `The missing dependencies might be locked elements in the source environment which does exist in the target environment. Moreover, the dependencies might be a part of a 3rd party bundle or SuiteApp. 
+If so, please make sure that all the bundles from the source account are installed and updated in the target account.`
             if (failedChangesWithDependencies.length === 0) {
               return groupChanges.map(change => ({
                 message: 'Some elements in this deployment have missing dependencies',
                 severity: 'Error' as const,
                 elemID: getChangeData(change).elemID,
-                detailedMessage: `Cannot deploy elements because of missing dependencies: ${error.missingDependencyScriptIds.join(', ')}. Please make sure that all the bundles from the source account are installed and updated in the target account.`,
+                detailedMessage: `Cannot deploy elements because of missing dependencies: ${error.missingDependencyScriptIds.join(', ')}. ${lockedElemsMessage}`,
               }))
             }
             return failedChangesWithDependencies
@@ -148,7 +150,7 @@ const changeValidator: ClientChangeValidator = async (
                 message: 'This element depends on missing elements',
                 severity: 'Error' as const,
                 elemID: getChangeData(changeAndMissingDependencies.change).elemID,
-                detailedMessage: `This element depends on the following missing elements: ${changeAndMissingDependencies.dependencies.join(', ')}. Please make sure that all the bundles from the source account are installed and updated in the target account.`,
+                detailedMessage: `This element depends on the following missing elements: ${changeAndMissingDependencies.dependencies.join(', ')}. ${lockedElemsMessage}`,
               }))
           }
           return groupChanges

--- a/packages/netsuite-adapter/src/change_validators/client_validation.ts
+++ b/packages/netsuite-adapter/src/change_validators/client_validation.ts
@@ -135,7 +135,7 @@ const changeValidator: ClientChangeValidator = async (
             const failedChangesWithDependencies = getFailedChangesWithDependencies(
               groupChanges, dependencyMap, error
             )
-            const lockedElemsMessage = `The missing dependencies might be locked elements in the source environment which does exist in the target environment. Moreover, the dependencies might be a part of a 3rd party bundle or SuiteApp. 
+            const lockedElemsMessage = `The missing dependencies might be locked elements in the source environment which do not exist in the target environment. Moreover, the dependencies might be part of a 3rd party bundle or SuiteApp.
 If so, please make sure that all the bundles from the source account are installed and updated in the target account.`
             if (failedChangesWithDependencies.length === 0) {
               return groupChanges.map(change => ({

--- a/packages/netsuite-adapter/src/change_validators/client_validation.ts
+++ b/packages/netsuite-adapter/src/change_validators/client_validation.ts
@@ -142,7 +142,7 @@ If so, please make sure that all the bundles from the source account are install
                 message: 'Some elements in this deployment have missing dependencies',
                 severity: 'Error' as const,
                 elemID: getChangeData(change).elemID,
-                detailedMessage: `Cannot deploy elements because of missing dependencies: ${error.missingDependencyScriptIds.join(', ')}. ${lockedElemsMessage}`,
+                detailedMessage: `Cannot deploy elements because of missing dependencies: (${error.missingDependencyScriptIds.join(', ')}).\n${lockedElemsMessage}`,
               }))
             }
             return failedChangesWithDependencies
@@ -150,7 +150,7 @@ If so, please make sure that all the bundles from the source account are install
                 message: 'This element depends on missing elements',
                 severity: 'Error' as const,
                 elemID: getChangeData(changeAndMissingDependencies.change).elemID,
-                detailedMessage: `This element depends on the following missing elements: ${changeAndMissingDependencies.dependencies.join(', ')}. ${lockedElemsMessage}`,
+                detailedMessage: `This element depends on the following missing elements: (${changeAndMissingDependencies.dependencies.join(', ')}).\n${lockedElemsMessage}`,
               }))
           }
           return groupChanges

--- a/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
@@ -165,7 +165,8 @@ File: ~/Objects/customrecord1.xml`
     )
     expect(changeErrors).toHaveLength(1)
     expect(changeErrors[0]).toEqual({
-      detailedMessage: 'This element depends on the following missing elements: some_scriptid. Please make sure that all the bundles from the source account are installed and updated in the target account.',
+      detailedMessage: `This element depends on the following missing elements: some_scriptid. The missing dependencies might be locked elements in the source environment which does exist in the target environment. Moreover, the dependencies might be a part of a 3rd party bundle or SuiteApp. 
+If so, please make sure that all the bundles from the source account are installed and updated in the target account.`,
       elemID: getChangeData(changes[0]).elemID,
       message: 'This element depends on missing elements',
       severity: 'Error',

--- a/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
@@ -165,7 +165,7 @@ File: ~/Objects/customrecord1.xml`
     )
     expect(changeErrors).toHaveLength(1)
     expect(changeErrors[0]).toEqual({
-      detailedMessage: `This element depends on the following missing elements: some_scriptid. The missing dependencies might be locked elements in the source environment which does exist in the target environment. Moreover, the dependencies might be a part of a 3rd party bundle or SuiteApp. 
+      detailedMessage: `This element depends on the following missing elements: some_scriptid. The missing dependencies might be locked elements in the source environment which do not exist in the target environment. Moreover, the dependencies might be part of a 3rd party bundle or SuiteApp.
 If so, please make sure that all the bundles from the source account are installed and updated in the target account.`,
       elemID: getChangeData(changes[0]).elemID,
       message: 'This element depends on missing elements',

--- a/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
@@ -165,7 +165,8 @@ File: ~/Objects/customrecord1.xml`
     )
     expect(changeErrors).toHaveLength(1)
     expect(changeErrors[0]).toEqual({
-      detailedMessage: `This element depends on the following missing elements: some_scriptid. The missing dependencies might be locked elements in the source environment which do not exist in the target environment. Moreover, the dependencies might be part of a 3rd party bundle or SuiteApp.
+      detailedMessage: `This element depends on the following missing elements: (some_scriptid).
+The missing dependencies might be locked elements in the source environment which do not exist in the target environment. Moreover, the dependencies might be part of a 3rd party bundle or SuiteApp.
 If so, please make sure that all the bundles from the source account are installed and updated in the target account.`,
       elemID: getChangeData(changes[0]).elemID,
       message: 'This element depends on missing elements',


### PR DESCRIPTION
_client_validation.ts manifest error message changed to address locked elements_

---

_None_

---
_Release Notes_: 
_Netsuite Adapter_:
* client_validation.ts manifest error message updated address locked elements 

---
_User Notifications_: 
_None_
