### PR TITLE
SALTO-3649: sla_policy does not have missing reference expression

### DIFF
--- a/packages/zendesk-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-adapter/src/filters/field_references.ts
@@ -990,6 +990,7 @@ const secondIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition
     },
     serializationStrategy: 'id',
     target: { typeContext: 'neighborReferenceTicketField' },
+    zendeskMissingRefStrategy: 'typeAndValue',
   },
   {
     src: {
@@ -1001,6 +1002,7 @@ const secondIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition
     },
     serializationStrategy: 'id',
     target: { typeContext: 'neighborReferenceUserAndOrgField' },
+    zendeskMissingRefStrategy: 'typeAndValue',
   },
   {
     src: { field: 'group_ids', parentTypes: ['user_segment'] },


### PR DESCRIPTION
 sla_policy does not have missing reference expression for types `ticket_field__custom_field_options`, `user_field__custom_field_options` and `organization_field__custom_field_options`

---

_Additional context for reviewer_
none

---
_Release Notes_: 
zendesk:
* add missing reference in sla_policy for types: `ticket_field__custom_field_options`, `user_field__custom_field_options` and `organization_field__custom_field_options`

---
_User Notifications_: 
zendesk:
* add missing reference in sla_policy for types: `ticket_field__custom_field_options`, `user_field__custom_field_options` and `organization_field__custom_field_options`
