### PR TITLE
SALTO-3651: fix getFullName of undefined in zendesk one_translation_per_locale validator

### DIFF
--- a/packages/zendesk-adapter/src/change_validators/one_translation_per_locale.ts
+++ b/packages/zendesk-adapter/src/change_validators/one_translation_per_locale.ts
@@ -77,54 +77,57 @@ const findDuplicateTranslations = async (
     return []
   }
   const locales = await awu(parent.value.translations)
-    .map(referenceExpression => referenceExpression.value)
+    .map(referenceExpression => (isReferenceExpression(referenceExpression)
+      ? referenceExpression.getResolvedValue(elementSource)
+      : referenceExpression))
     .filter(isTranslation)
     .map(translation => translation.value.locale)
     .map(async locale => (isReferenceExpression(locale) && locale.elemID.idType === 'instance'
-      ? (await elementSource.get(locale.elemID)).value.locale ?? ''
+      ? (await elementSource.get(locale.elemID))?.value.locale ?? ''
       : locale))
     .toArray()
   return findDuplicates(locales)
 }
 
-export const oneTranslationPerLocaleValidator: ChangeValidator = async (changes, elementSource) => {
-  if (elementSource === undefined) {
-    log.error('Failed to run oneTranslationPerLocale because no element source was provided')
-    return []
-  }
-  const relevantInstances = changes
-    .filter(isAdditionOrModificationChange)
-    .map(getChangeData)
-    .filter(isInstanceElement)
-    .filter(instance =>
-      [ARTICLE_TRANSLATION_TYPE_NAME,
-        CATEGORY_TRANSLATION_TYPE_NAME,
-        SECTION_TRANSLATION_TYPE_NAME].includes(instance.elemID.typeName))
+export const oneTranslationPerLocaleValidator: ChangeValidator = async (changes, elementSource) =>
+  log.time(async () => {
+    if (elementSource === undefined) {
+      log.error('Failed to run oneTranslationPerLocale because no element source was provided')
+      return []
+    }
+    const relevantInstances = changes
+      .filter(isAdditionOrModificationChange)
+      .map(getChangeData)
+      .filter(isInstanceElement)
+      .filter(instance =>
+        [ARTICLE_TRANSLATION_TYPE_NAME,
+          CATEGORY_TRANSLATION_TYPE_NAME,
+          SECTION_TRANSLATION_TYPE_NAME].includes(instance.elemID.typeName))
 
-  const parentInstanceIds = _.uniqBy(relevantInstances
-    .filter(instance => isTranslation(instance))
-    .flatMap(getParents)
-    .flatMap(parent => (isReferenceExpression(parent) ? parent.elemID : undefined))
-    .filter(isDefined), id => id.getFullName())
+    const parentInstanceIds = _.uniqBy(relevantInstances
+      .filter(instance => isTranslation(instance))
+      .flatMap(getParents)
+      .flatMap(parent => (isReferenceExpression(parent) ? parent.elemID : undefined))
+      .filter(isDefined), id => id.getFullName())
 
-  const parentInstances = await awu(parentInstanceIds)
-    .map(async id => elementSource.get(id))
-    .filter(isInstanceElement)
-    .toArray()
+    const parentInstances = await awu(parentInstanceIds)
+      .map(async id => elementSource.get(id))
+      .filter(isInstanceElement)
+      .toArray()
 
-  // it is a record to avoid duplicate of parents from translations which have the same parent
+    // it is a record to avoid duplicate of parents from translations which have the same parent
 
-  return awu(parentInstances)
-    .map(async parentInstance => ({
-      elemID: parentInstance.elemID,
-      duplicatedLocales: await findDuplicateTranslations(parentInstance, elementSource),
-    }))
-    .filter(instance => !_.isEmpty(instance.duplicatedLocales))
-    .map(({ elemID, duplicatedLocales }): ChangeError => ({
-      elemID,
-      severity: 'Error',
-      message: `Multiple translations with the same locale found in ${elemID.typeName} instance. Only one translation per locale is supported.`,
-      detailedMessage: `Instance ${elemID.getFullName()} has multiple translations for locales: ${duplicatedLocales}. Only one translation per locale is supported.`,
-    }))
-    .toArray()
-}
+    return awu(parentInstances)
+      .map(async parentInstance => ({
+        elemID: parentInstance.elemID,
+        duplicatedLocales: await findDuplicateTranslations(parentInstance, elementSource),
+      }))
+      .filter(instance => !_.isEmpty(instance.duplicatedLocales))
+      .map(({ elemID, duplicatedLocales }): ChangeError => ({
+        elemID,
+        severity: 'Error',
+        message: `Multiple translations with the same locale found in ${elemID.typeName} instance. Only one translation per locale is supported.`,
+        detailedMessage: `Instance ${elemID.getFullName()} has multiple translations for locales: ${duplicatedLocales}. Only one translation per locale is supported.`,
+      }))
+      .toArray()
+  }, 'one translation per locale validator')

--- a/packages/zendesk-adapter/test/change_validators/one_translation_per_locale.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/one_translation_per_locale.test.ts
@@ -141,7 +141,7 @@ describe('oneTranslationPerLocalValidator',
         },
       )
       enTranslation2.annotations[CORE_ANNOTATIONS.PARENT] = [new ReferenceExpression(
-        articleType.elemID.createNestedID('instance', 'Test2'), article
+        articleType.elemID.createNestedID('instance', 'Test2')
       )]
       enTranslation.annotations[CORE_ANNOTATIONS.PARENT] = [new ReferenceExpression(
         articleType.elemID.createNestedID('instance', 'Test2'), article

--- a/packages/zendesk-adapter/test/change_validators/one_translation_per_locale.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/one_translation_per_locale.test.ts
@@ -96,7 +96,7 @@ describe('oneTranslationPerLocalValidator',
 
       const errors = await oneTranslationPerLocaleValidator(
         [toChange({ after: heTranslation })],
-        elementSource.createInMemoryElementSource([esLocale])
+        elementSource.createInMemoryElementSource([esLocale, article])
       )
       expect(errors).toHaveLength(0)
     })
@@ -149,7 +149,7 @@ describe('oneTranslationPerLocalValidator',
 
       const errors = await oneTranslationPerLocaleValidator(
         [toChange({ after: enTranslation }), toChange({ after: enTranslation2 })],
-        elementSource.createInMemoryElementSource([enusLocale]),
+        elementSource.createInMemoryElementSource([enusLocale, article]),
       )
       expect(errors).toEqual([{
         elemID: article.elemID,


### PR DESCRIPTION
fix getFullName of undefined in zendesk one_translation_per_locale validator

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* fix issue in the validation of Guide translations that could cause failures in deployments.

---
_User Notifications_: 
None
