### PR TITLE
INCIDENT-3157 - Handle trigger & automations notifications value not being an array

### DIFF
--- a/packages/zendesk-adapter/src/filters/references/list_values_missing_references.ts
+++ b/packages/zendesk-adapter/src/filters/references/list_values_missing_references.ts
@@ -82,6 +82,7 @@ const filter: FilterCreator = ({ config }) => ({
           if (fieldRefTypes.includes(obj.field)
             && !isReferenceExpression(valueToRedefine)
             && !VALUES_TO_SKIP_BY_TYPE[valueType]?.includes(valueToRedefine)
+            && _.isArray(obj.value) // INCIDENT-3157, Handle cases when for some reason the value is a string
             && (isNumberStr(valueToRedefine)
               || NON_NUMERIC_MISSING_VALUES_TYPES.includes(valueType)
             )) {

--- a/packages/zendesk-adapter/test/filters/references/list_values_missing_references.test.ts
+++ b/packages/zendesk-adapter/test/filters/references/list_values_missing_references.test.ts
@@ -58,6 +58,7 @@ describe('list values missing references filter', () => {
           { field: 'notification_sms_group', value: ['123456789', '+123456678', 'sms message'] },
           { field: 'notification_sms_grouwp', value: ['group_id', '+123456678', 'sms message'] },
           { field: 'notification_webhook', value: ['01GB7WWYD3QM8G7BWTR7A28XWR', ['one', 'two']] },
+          { field: 'notification_webhook', value: "['01GB7WWYD3QM8G7BWTR7A28XWR', ['one', 'two']]" },
           { field: 'notification_target', value: ['01GB7WWYD3QM8G7BWTR7A28XWR', 'target'] },
         ],
       },
@@ -77,7 +78,7 @@ describe('list values missing references filter', () => {
         const brokenTrigger = elements.filter(
           e => isInstanceElement(e) && e.elemID.name === 'trigger1'
         )[0] as InstanceElement
-        expect(brokenTrigger.value.actions).toHaveLength(4)
+        expect(brokenTrigger.value.actions).toHaveLength(5)
         const triggerFirstAction = brokenTrigger.value.actions[0].value
         expect(triggerFirstAction[0]).toBeInstanceOf(ReferenceExpression)
         expect(triggerFirstAction[0].value.elemID.name)
@@ -100,8 +101,8 @@ describe('list values missing references filter', () => {
         const brokenTrigger = elements.filter(
           e => isInstanceElement(e) && e.elemID.name === 'trigger1'
         )[0] as InstanceElement
-        expect(brokenTrigger.value.actions[3].field).toBe('notification_target')
-        const targetAction = brokenTrigger.value.actions[3].value
+        expect(brokenTrigger.value.actions[4].field).toBe('notification_target')
+        const targetAction = brokenTrigger.value.actions[4].value
         expect(targetAction[0]).not.toBeInstanceOf(ReferenceExpression)
         expect(targetAction[0]).toEqual('01GB7WWYD3QM8G7BWTR7A28XWR')
         expect(targetAction[1]).not.toBeInstanceOf(ReferenceExpression)


### PR DESCRIPTION
When trying to create a missing reference and the notification value is unexpected, do nothing

---

None

---
_Release Notes_: 
None

---
_User Notifications_: 
None