### PR TITLE
SALTO-3656 Fix field parents resolving

### DIFF
--- a/packages/workspace/src/expressions.ts
+++ b/packages/workspace/src/expressions.ts
@@ -265,7 +265,7 @@ const getClonedElements = (elements: Element[]): Element[] => {
     const fieldFromClonedParent = clonedTypesMap.get(field.parent.elemID.getFullName())?.fields[field.name]
       ?? clonedMissingParentsMap.get(field.parent.elemID.getFullName())?.fields[field.name]
     if (fieldFromClonedParent === undefined) {
-      log.error(
+      log.warn(
         'field %s does not exists on its parent type %s (fields: %o)',
         field.name,
         field.parent.elemID.getFullName(),

--- a/packages/workspace/test/core/expressions.test.ts
+++ b/packages/workspace/test/core/expressions.test.ts
@@ -512,6 +512,59 @@ describe('Test Salto Expressions', () => {
     })
   })
 
+  describe('with field and type input', () => {
+    let objectType: ObjectType
+    let fieldType: ObjectType
+    let referencedType: ObjectType
+    let resolvedField: Field
+    let resolvedType: ObjectType
+    beforeEach(async () => {
+      fieldType = new ObjectType({ elemID: new ElemID('salto', 'field') })
+      referencedType = new ObjectType({
+        elemID: new ElemID('salto', 'referenced'),
+        annotations: { value: 'value' },
+      })
+      objectType = new ObjectType({
+        elemID: new ElemID('salto', 'obj'),
+        fields: {
+          field: {
+            refType: fieldType,
+            annotations: { ref: refTo(referencedType, 'attr', 'value') },
+          },
+        },
+        annotations: {
+          ref: refTo(referencedType),
+        },
+      })
+      const fieldToResolve = objectType.fields.field
+      const resolved = await resolve(
+        [objectType, fieldToResolve],
+        createInMemoryElementSource(
+          [fieldType, referencedType, objectType]
+        )
+      )
+      expect(resolved).toHaveLength(2)
+      expect(resolved[0]).toBeInstanceOf(ObjectType)
+      expect(resolved[1]).toBeInstanceOf(Field)
+      resolvedType = resolved[0] as ObjectType
+      resolvedField = resolved[1] as Field
+    })
+    it('should resolve field type', () => {
+      // We can compare to the unresolved field type because there is nothing to resolve in it
+      expect(resolvedField.refType.type).toEqual(fieldType)
+    })
+    it('should resolve references in the field', () => {
+      expect(resolvedField.annotations.ref.value).toEqual(referencedType.annotations.value)
+    })
+    it('should resolve the fields parent', () => {
+      expect(resolvedField.parent.annotations.ref).toBeInstanceOf(ReferenceExpression)
+      expect(resolvedField.parent.annotations.ref.value).toEqual(referencedType)
+    })
+    it('resolve field parent should be the resolved type', () => {
+      expect(resolvedField.parent).toBe(resolvedType)
+    })
+  })
+
   describe('Template Expression', () => {
     it('Should evaluate a template with reference', async () => {
       const refType = new ObjectType({


### PR DESCRIPTION
Today we assume that if we got a field and its parent type in the same resolve call, the field's parent will point to the same object type that we got to resolve, so we don't need to resolve both.

The problem is that we clone the elements before we resolve them, so the field’s parent don’t point to the same object type that we got to resolve.

---

_Additional context for reviewer_

---
_Release Notes_: 
Workspace:
- Fix field parents resolving

---
_User Notifications_: 
None