### PR TITLE
SALTO-3664 - Jira: Remove redundant setTimeout in tests

### DIFF
--- a/packages/jira-adapter/test/filters/dashboard/gadget.test.ts
+++ b/packages/jira-adapter/test/filters/dashboard/gadget.test.ts
@@ -25,7 +25,6 @@ import { DASHBOARD_GADGET_TYPE, DASHBOARD_TYPE, JIRA } from '../../../src/consta
 import JiraClient from '../../../src/client/client'
 import { getLookUpName } from '../../../src/reference_mapping'
 
-jest.setTimeout(10000000)
 
 jest.mock('@salto-io/adapter-components', () => {
   const actual = jest.requireActual('@salto-io/adapter-components')

--- a/packages/jira-adapter/test/filters/statuses/status_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/statuses/status_deployment.test.ts
@@ -23,7 +23,6 @@ import { getDefaultConfig, JiraConfig } from '../../../src/config/config'
 import { JIRA, STATUS_TYPE_NAME } from '../../../src/constants'
 import JiraClient from '../../../src/client/client'
 
-jest.setTimeout(1000000)
 describe('statusDeploymentFilter', () => {
   let filter: filterUtils.FilterWith<'onFetch' | 'deploy'>
   let mockConnection: MockInterface<clientUtils.APIConnection>


### PR DESCRIPTION
These lines seem to be leftovers from debugging. Let's remove them.

---


---
_Release Notes_: 
N/A

---
_User Notifications_: 
N/A