### PR TITLE
Return only added elements in getReferencedElements

### DIFF
--- a/packages/netsuite-adapter/src/filters/additional_changes.ts
+++ b/packages/netsuite-adapter/src/filters/additional_changes.ts
@@ -34,12 +34,12 @@ const filterCreator: FilterCreator = ({ config }) => ({
       .uniqBy(parent => parent.elemID.getFullName())
       .value()
 
-    const allElementsToDeploy = await getReferencedElements(
+    const requiredElements = (await getReferencedElements(
       typeAndInstanceChanges.map(getChangeData).concat(fieldsParents),
       config.deploy?.deployReferencedElements ?? config.deployReferencedElements ?? DEFAULT_DEPLOY_REFERENCED_ELEMENTS
-    )
-    const additionalChanges = allElementsToDeploy
-      .filter(elem => !elemIdSet.has(elem.elemID.getFullName()))
+    )).map(elem => elem.clone())
+
+    const additionalChanges = requiredElements.concat(fieldsParents)
       .map(elem => toChange({ before: elem, after: elem }))
 
     changes.push(...additionalChanges)

--- a/packages/netsuite-adapter/test/filters/additional_changes.test.ts
+++ b/packages/netsuite-adapter/test/filters/additional_changes.test.ts
@@ -93,7 +93,7 @@ describe('additional changes filter', () => {
       expect(changes).toHaveLength(2)
       const [requiredInstanceChange] = changes.filter(isInstanceChange)
       expect(requiredInstanceChange.action).toEqual('modify')
-      expect(getChangeData(requiredInstanceChange)).toBe(customSegmentInstance)
+      expect(getChangeData(requiredInstanceChange)).toEqual(customSegmentInstance)
     })
     it('should add field parent and required referenced element', async () => {
       const changes: Change[] = [

--- a/packages/netsuite-adapter/test/reference_dependencies.test.ts
+++ b/packages/netsuite-adapter/test/reference_dependencies.test.ts
@@ -71,7 +71,7 @@ describe('reference dependencies', () => {
   describe('getAllReferencedInstances', () => {
     it('should return all depending instances', async () => {
       const result = await getReferencedElements([instanceWithManyRefs], true)
-      expect(result).toEqual([instanceWithManyRefs, dependsOn1Instance, fileInstance])
+      expect(result).toEqual([dependsOn1Instance, fileInstance])
     })
   })
   describe('getRequiredReferencedInstances', () => {
@@ -119,29 +119,29 @@ describe('reference dependencies', () => {
 
     it('should not add dependencies that are not required', async () => {
       const result = await getReferencedElements([instanceWithManyRefs], false)
-      expect(result).toEqual([instanceWithManyRefs])
+      expect(result).toEqual([])
     })
 
     it('should add CUSTOM_SEGMENT dependency of CUSTOM_RECORD_TYPE', async () => {
       const result = await getReferencedElements([customRecordType], false)
-      expect(result).toEqual([customRecordType, customSegmentInstance])
+      expect(result).toEqual([customSegmentInstance])
     })
 
     it('should add CUSTOM_RECORD_TYPE dependency of CUSTOM_SEGMENT', async () => {
       const result = await getReferencedElements([customSegmentInstance], false)
-      expect(result).toEqual([customSegmentInstance, customRecordType])
+      expect(result).toEqual([customRecordType])
     })
 
     it('should add DATASET dependency of WORKBOOK', async () => {
       const result = await getReferencedElements([workbookInstance], false)
-      expect(result).toEqual([workbookInstance, datasetInstance])
+      expect(result).toEqual([datasetInstance])
     })
 
     it('should not add dependencies that already exist', async () => {
       const input = [customRecordType, customSegmentInstance, workbookInstance,
         datasetInstance, instance]
       const result = await getReferencedElements(input, false)
-      expect(result).toEqual(input)
+      expect(result).toEqual([])
     })
 
     it('should not add new dependencies more then once', async () => {
@@ -161,7 +161,7 @@ describe('reference dependencies', () => {
         false
       )
       expect(result)
-        .toEqual([customRecordType, customRecordType2, customSegmentInstance])
+        .toEqual([customSegmentInstance])
     })
 
     it('should add translation collection instances when referenced', async () => {
@@ -182,9 +182,8 @@ describe('reference dependencies', () => {
       )
 
       const result = await getReferencedElements([customRecordType], false)
-      expect(result).toHaveLength(4)
+      expect(result).toHaveLength(3)
       expect(result).toEqual(expect.arrayContaining([
-        customRecordType,
         customSegmentInstance,
         translationCollectionInstanceReferencedInInstance,
         translationCollectionInstanceReferencedInType,


### PR DESCRIPTION
Instead of returning the referenced elements with the input elements, we should return only the referenced elements.
That let us control the return type of the function (it can be `ObjectType | InstanceElement`), and avoid a case of returning an equivalent to an input element but not the exact same object (if it is also referenced, and we return the referenced element instead of the input element).
The thought behind that change is that we want to use a cloned version of the added changes in `additional_changes.ts` - but we don't want to clone the added field parents, because it will separate the `field.parent` property from the added field parent.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Return only added elements in getReferencedElements

---
_User Notifications_: 
None
