### PR TITLE
Salto-3671/validate saved searches dates

### DIFF
--- a/packages/netsuite-adapter/src/filters/author_information/saved_searches.ts
+++ b/packages/netsuite-adapter/src/filters/author_information/saved_searches.ts
@@ -60,14 +60,20 @@ const fetchSavedSearches = async (client: NetsuiteClient): Promise<SavedSearches
 
 const getSavedSearchesMap = async (
   client: NetsuiteClient,
+  timeZone: string,
 ): Promise<Record<string, ModificationInformation>> => {
   const savedSearches = await fetchSavedSearches(client)
-  return Object.fromEntries(savedSearches.map(savedSearch => [
-    savedSearch.id,
-    {
-      name: savedSearch.modifiedby[0]?.text, date: savedSearch.datemodified,
-    },
-  ]))
+  const now = moment.tz(timeZone)
+  return Object.fromEntries(savedSearches
+    .filter(savedSearch =>
+      savedSearch.datemodified !== undefined
+      && !now.isBefore(moment.tz(savedSearch.datemodified, timeZone)))
+    .map(savedSearch => [
+      savedSearch.id,
+      {
+        name: savedSearch.modifiedby[0]?.text, date: savedSearch.datemodified,
+      },
+    ]))
 }
 
 export const changeDateFormat = (date: string, timeAndFormat: TimeZoneAndFormat): string => {
@@ -138,14 +144,11 @@ const filterCreator: FilterCreator = ({ client, config, elementsSource, isPartia
     if (_.isEmpty(savedSearchesInstances)) {
       return
     }
-
-    const savedSearchesMap = await getSavedSearchesMap(client)
+    const { timeZone, timeFormat, dateFormat } = await getZoneAndFormat(elements, elementsSource, isPartial)
+    const savedSearchesMap = await getSavedSearchesMap(client, timeZone)
     if (_.isEmpty(savedSearchesMap)) {
       return
     }
-
-    const { timeZone, timeFormat, dateFormat } = await getZoneAndFormat(elements, elementsSource, isPartial)
-    const now = moment().tz(timeZone)
     savedSearchesInstances.forEach(search => {
       if (isDefined(savedSearchesMap[search.value.scriptid])) {
         const { name, date } = savedSearchesMap[search.value.scriptid]
@@ -155,10 +158,6 @@ const filterCreator: FilterCreator = ({ client, config, elementsSource, isPartia
           )
         }
         if (isDefined(date) && isDefined(dateFormat)) {
-          if (now.isBefore(moment.tz(date, timeZone))) {
-            // Check if the date is in the future.
-            return
-          }
           const annotationDate = changeDateFormat(date, { dateFormat, timeZone, timeFormat })
           search.annotate(
             { [CORE_ANNOTATIONS.CHANGED_AT]: annotationDate }

--- a/packages/netsuite-adapter/src/filters/author_information/saved_searches.ts
+++ b/packages/netsuite-adapter/src/filters/author_information/saved_searches.ts
@@ -145,7 +145,7 @@ const filterCreator: FilterCreator = ({ client, config, elementsSource, isPartia
     }
 
     const { timeZone, timeFormat, dateFormat } = await getZoneAndFormat(elements, elementsSource, isPartial)
-
+    const now = moment().tz(timeZone)
     savedSearchesInstances.forEach(search => {
       if (isDefined(savedSearchesMap[search.value.scriptid])) {
         const { name, date } = savedSearchesMap[search.value.scriptid]
@@ -155,6 +155,10 @@ const filterCreator: FilterCreator = ({ client, config, elementsSource, isPartia
           )
         }
         if (isDefined(date) && isDefined(dateFormat)) {
+          if (now.isBefore(moment.tz(date, timeZone))) {
+            // Check if the date is in the future.
+            return
+          }
           const annotationDate = changeDateFormat(date, { dateFormat, timeZone, timeFormat })
           search.annotate(
             { [CORE_ANNOTATIONS.CHANGED_AT]: annotationDate }

--- a/packages/netsuite-adapter/src/filters/author_information/saved_searches.ts
+++ b/packages/netsuite-adapter/src/filters/author_information/saved_searches.ts
@@ -66,7 +66,7 @@ const getSavedSearchesMap = async (
   const now = moment.tz(timeZone)
   return Object.fromEntries(savedSearches
     .filter(savedSearch =>
-      savedSearch.datemodified !== undefined
+      isDefined(savedSearch.datemodified)
       && !now.isBefore(moment.tz(savedSearch.datemodified, timeZone)))
     .map(savedSearch => [
       savedSearch.id,

--- a/packages/netsuite-adapter/src/filters/author_information/system_note.ts
+++ b/packages/netsuite-adapter/src/filters/author_information/system_note.ts
@@ -201,7 +201,7 @@ const fetchSystemNotes = async (
   return indexSystemNotes(
     distinctSortedSystemNotes(
       systemNotes.filter(
-        systemNote => systemNote.date !== null && !now.isBefore(moment.tz(systemNote.date, timeZone))
+        systemNote => isDefined(systemNote.date) && !now.isBefore(moment.tz(systemNote.date, timeZone))
       )
     )
   )

--- a/packages/netsuite-adapter/src/filters/author_information/system_note.ts
+++ b/packages/netsuite-adapter/src/filters/author_information/system_note.ts
@@ -19,6 +19,7 @@ import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { values as lowerDashValues, collections } from '@salto-io/lowerdash'
 import Ajv from 'ajv'
+import moment from 'moment'
 import { TYPES_TO_INTERNAL_ID as ORIGINAL_TYPES_TO_INTERNAL_ID } from '../../data_elements/types'
 import NetsuiteClient from '../../client/client'
 import { FilterCreator, FilterWith } from '../../filter'
@@ -185,8 +186,10 @@ const indexSystemNotes = (
 const fetchSystemNotes = async (
   client: NetsuiteClient,
   queryIds: string[],
-  lastFetchTime: Date
+  lastFetchTime: Date,
+  timeZone: string,
 ): Promise<Record<string, ModificationInformation>> => {
+  const now = moment.tz(timeZone)
   const systemNotes = await log.time(
     () => querySystemNotes(client, queryIds, lastFetchTime),
     'querySystemNotes'
@@ -195,7 +198,13 @@ const fetchSystemNotes = async (
     log.warn('System note query failed')
     return {}
   }
-  return indexSystemNotes(distinctSortedSystemNotes(systemNotes))
+  return indexSystemNotes(
+    distinctSortedSystemNotes(
+      systemNotes.filter(
+        systemNote => systemNote.date !== null && !now.isBefore(moment.tz(systemNote.date, timeZone))
+      )
+    )
+  )
 }
 
 const getInstancesWithInternalIds = (elements: Element[]): InstanceElement[] =>
@@ -257,8 +266,9 @@ const filterCreator: FilterCreator = ({ client, config, elementsSource, elements
       return
     }
     const employeeNames = await fetchEmployeeNames(client)
+    const { timeZone } = await getZoneAndFormat(elements, elementsSource, isPartial)
     const systemNotes = !_.isEmpty(employeeNames)
-      ? await fetchSystemNotes(client, queryIds, lastFetchTime)
+      ? await fetchSystemNotes(client, queryIds, lastFetchTime, timeZone)
       : {}
     const { elemIdToChangeByIndex, elemIdToChangeAtIndex } = await elementsSourceIndex.getIndexes()
     if (_.isEmpty(systemNotes) && _.isEmpty(elemIdToChangeByIndex)
@@ -280,8 +290,6 @@ const filterCreator: FilterCreator = ({ client, config, elementsSource, elements
         }
       }
     }
-
-    const { timeZone } = await getZoneAndFormat(elements, elementsSource, isPartial)
 
     const setChangedAt = async (element: Element, lastModifiedDate: string): Promise<void> => {
       if (isDefined(lastModifiedDate)) {

--- a/packages/netsuite-adapter/test/filters/author_information/saved_searches.test.ts
+++ b/packages/netsuite-adapter/test/filters/author_information/saved_searches.test.ts
@@ -118,6 +118,15 @@ describe('netsuite saved searches author information tests', () => {
     await filterCreator(filterOpts).onFetch?.(elements)
     expect(savedSearch.annotations[CORE_ANNOTATIONS.CHANGED_AT]).toEqual('1995-01-28T04:17:00Z')
   })
+  it('should not assign change at if the date is from the future', async () => {
+    userPreferenceInstance.value.configRecord.data.fields.DATEFORMAT = 'D Month, YYYY'
+    userPreferenceInstance.value.configRecord.data.fields.TIMEZONE = 'Asia/Jerusalem'
+    runSavedSearchQueryMock.mockResolvedValue([
+      { id: '1', modifiedby: [{ value: '1', text: 'user 1 name' }], datemodified: '28 January, 3995 6:17 am' },
+    ])
+    await filterCreator(filterOpts).onFetch?.(elements)
+    expect(savedSearch.annotations[CORE_ANNOTATIONS.CHANGED_AT]).toBeUndefined()
+  })
 
   it('should not add last modified date when the account date format isnt avaible', async () => {
     userPreferenceInstance.value.configRecord.data.fields = {}

--- a/packages/netsuite-adapter/test/filters/author_information/system_note.test.ts
+++ b/packages/netsuite-adapter/test/filters/author_information/system_note.test.ts
@@ -56,6 +56,8 @@ describe('netsuite system note author information', () => {
     ])
     runSuiteQLMock.mockResolvedValueOnce([
       { recordid: '1', recordtypeid: '-112', field: '', name: '1', date: '2022-01-01' },
+      // Should ignore this record because it has a date in the future
+      { recordid: '1', recordtypeid: '-112', field: '', name: '1', date: '3022-03-01' },
       { recordid: '1', recordtypeid: '-123', field: '', name: '2', date: '2022-01-01' },
       { recordid: '2', recordtypeid: '-112', field: '', name: '3', date: '2022-01-01' },
       { recordid: '123', recordtypeid: '1', field: '', name: '3', date: '2022-01-01' },


### PR DESCRIPTION
filter system note/ saved search query results to not include changes from the future.

---

_Additional context for reviewer_

---
_Release Notes_: 
netsuite adapter: 
* changed at annotations will no longer be able to be from the future.

---
_User Notifications_: 

