### PR TITLE
Do not remove additional SOAP types

### DIFF
--- a/packages/netsuite-adapter/src/data_elements/data_elements.ts
+++ b/packages/netsuite-adapter/src/data_elements/data_elements.ts
@@ -21,7 +21,7 @@ import { naclCase, pathNaclCase, transformValues } from '@salto-io/adapter-utils
 import { collections, strings } from '@salto-io/lowerdash'
 import { NETSUITE, RECORDS_PATH, SOAP } from '../constants'
 import { NetsuiteQuery } from '../query'
-import { getTypeIdentifier, TYPE_TO_IDENTIFIER } from './types'
+import { getTypeIdentifier, SUPPORTED_TYPES } from './types'
 import NetsuiteClient from '../client/client'
 import { castFieldValue } from './custom_fields'
 import { addIdentifierToValues, addIdentifierToType } from './multi_fields_identifiers'
@@ -139,7 +139,7 @@ export const getDataElements = async (
 ): Promise<(ObjectType | InstanceElement)[]> => {
   const types = await getDataTypes(client)
 
-  const typesToFetch = Object.keys(TYPE_TO_IDENTIFIER).filter(query.isTypeMatch)
+  const typesToFetch = SUPPORTED_TYPES.filter(query.isTypeMatch)
   if (typesToFetch.length === 0) {
     return types
   }

--- a/packages/netsuite-adapter/src/filters/remove_unsupported_types.ts
+++ b/packages/netsuite-adapter/src/filters/remove_unsupported_types.ts
@@ -19,7 +19,7 @@ import { isObjectType } from '@salto-io/adapter-api'
 import { NETSUITE } from '../constants'
 import { FilterCreator, FilterWith } from '../filter'
 import { getMetadataTypes, isCustomRecordType, isDataObjectType, metadataTypesToList } from '../types'
-import { SUPPORTED_TYPES } from '../data_elements/types'
+import { SUPPORTED_TYPES, TYPES_TO_INTERNAL_ID } from '../data_elements/types'
 
 
 const filterCreator: FilterCreator = ({ client }): FilterWith<'onFetch'> => ({
@@ -33,8 +33,16 @@ const filterCreator: FilterCreator = ({ client }): FilterWith<'onFetch'> => ({
         .map(e => e.elemID.getFullName().toLowerCase())
     )
     const dataTypes = elements.filter(isObjectType).filter(isDataObjectType)
-    const supportedTypeNames = SUPPORTED_TYPES
-      .concat(dataTypes.filter(isCustomRecordType).map(({ elemID }) => elemID.name))
+    const supportedFetchedInstancesTypeNames = SUPPORTED_TYPES
+    // types we fetch without their instances
+    const additionalFetchedTypes = Object.keys(TYPES_TO_INTERNAL_ID)
+    const customRecordTypeNames = dataTypes.filter(isCustomRecordType).map(({ elemID }) => elemID.name)
+
+    const supportedTypeNames = _.uniq(
+      supportedFetchedInstancesTypeNames
+        .concat(additionalFetchedTypes)
+        .concat(customRecordTypeNames)
+    )
 
     const supportedDataTypes = (await elementUtils.filterTypes(NETSUITE, dataTypes, supportedTypeNames))
       .filter(e => !sdfTypeNames.has(e.elemID.getFullName().toLowerCase()))

--- a/packages/netsuite-adapter/test/filters/remove_unsupported_types.test.ts
+++ b/packages/netsuite-adapter/test/filters/remove_unsupported_types.test.ts
@@ -27,6 +27,7 @@ describe('remove_unsupported_types', () => {
   let elements: TypeElement[]
   const sdfType = customrecordtypeType().type
   const supportedSoapType = new ObjectType({ elemID: new ElemID(NETSUITE, 'subsidiary'), annotations: { source: 'soap' } })
+  const additionlaSupportedSoapType = new ObjectType({ elemID: new ElemID(NETSUITE, 'salesOrder'), annotations: { source: 'soap' } })
   const unsupportedSoapType = new ObjectType({ elemID: new ElemID(NETSUITE, 'someType'), annotations: { source: 'soap' } })
   const sdfSoapType = new ObjectType({ elemID: new ElemID(NETSUITE, 'CustomRecordType'), annotations: { source: 'soap' } })
   const customRecordType = new ObjectType({
@@ -39,7 +40,14 @@ describe('remove_unsupported_types', () => {
   const isSuiteAppConfiguredMock = jest.fn()
 
   beforeEach(async () => {
-    elements = [sdfType, supportedSoapType, unsupportedSoapType, sdfSoapType, customRecordType]
+    elements = [
+      sdfType,
+      supportedSoapType,
+      additionlaSupportedSoapType,
+      unsupportedSoapType,
+      sdfSoapType,
+      customRecordType,
+    ]
     isSuiteAppConfiguredMock.mockReset()
     isSuiteAppConfiguredMock.mockReturnValue(true)
     filterOpts = {
@@ -55,7 +63,7 @@ describe('remove_unsupported_types', () => {
 
   it('should remove the unsupported types', async () => {
     await filterCreator(filterOpts).onFetch?.(elements)
-    expect(elements.map(e => e.elemID.name)).toEqual(['customrecordtype', 'custrecord', 'subsidiary'])
+    expect(elements.map(e => e.elemID.name)).toEqual(['customrecordtype', 'custrecord', 'subsidiary', 'salesOrder'])
   })
 
   it('should not add custom record types that are field types but not in elements (partial fetch)', async () => {
@@ -81,6 +89,6 @@ describe('remove_unsupported_types', () => {
   it('should do nothing if suiteApp is not installed', async () => {
     isSuiteAppConfiguredMock.mockReturnValue(false)
     await filterCreator(filterOpts).onFetch?.(elements)
-    expect(elements.map(e => e.elemID.name)).toEqual(['customrecordtype', 'subsidiary', 'someType', 'CustomRecordType', 'custrecord'])
+    expect(elements.map(e => e.elemID.name)).toEqual(['customrecordtype', 'subsidiary', 'salesOrder', 'someType', 'CustomRecordType', 'custrecord'])
   })
 })


### PR DESCRIPTION
There are some SOAP types that we fetch without their instances. We should not remove them in "Remove Unsupported Types" filter.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Do not remove additional SOAP types

---
_User Notifications_: 
None