### PR TITLE
SALTO-3602/issue type scheme migration

### DIFF
--- a/packages/jira-adapter/src/change_validators/active_scheme_change.ts
+++ b/packages/jira-adapter/src/change_validators/active_scheme_change.ts
@@ -21,11 +21,12 @@ import { doesProjectHaveIssues } from './project_deletion'
 
 const { awu } = collections.asynciterable
 
-const RELEVANT_FIELDS = ['priorityScheme', 'workflowScheme']
+const RELEVANT_FIELDS = ['priorityScheme', 'workflowScheme', 'issueTypeScheme']
 type RelevantField = typeof RELEVANT_FIELDS[number]
 const FIELD_FORMATS: Record<RelevantField, string> = {
   priorityScheme: 'priority scheme',
   workflowScheme: 'workflow scheme',
+  issueTypeScheme: 'issue type scheme',
 }
 
 const projectSchemeChanged = (change : ModificationChange<InstanceElement>): RelevantField[] => {

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -51,6 +51,7 @@ import { activeSchemeDeletionValidator } from './active_scheme_deletion'
 import { automationProjectUnresolvedReferenceValidator } from './automation_unresolved_references'
 import { unresolvedReferenceValidator } from './unresolved_references'
 import { sameIssueTypeNameChangeValidator } from './same_issue_type_name'
+import { issueTypeSchemeMigrationValidator } from './issue_type_scheme_migration'
 
 const {
   deployTypesNotSupportedValidator,
@@ -84,6 +85,7 @@ export default (
     statusMigrationChangeValidator,
     // Must run after statusMigrationChangeValidator
     workflowSchemeMigrationValidator(client, config, paginator),
+    issueTypeSchemeMigrationValidator(client),
     activeSchemeChangeValidator(client),
     maskingValidator(client),
     lockedFieldsValidator,

--- a/packages/jira-adapter/src/change_validators/issue_type_scheme_migration.ts
+++ b/packages/jira-adapter/src/change_validators/issue_type_scheme_migration.ts
@@ -98,7 +98,8 @@ export const issueTypeSchemeMigrationValidator = (
       .map(id => elementSource.get(id))
       .toArray()
     const issueTypeSchemesToProjects = _.groupBy(
-      projects.filter(project => project.value.issueTypeScheme !== undefined),
+      projects.filter(project => project.value.issueTypeScheme !== undefined
+        && isReferenceExpression(project.value.issueTypeScheme)),
       project => project.value.issueTypeScheme.elemID.getFullName(),
     )
     const errors = await awu(relevantChanges).map(async change => {

--- a/packages/jira-adapter/src/change_validators/issue_type_scheme_migration.ts
+++ b/packages/jira-adapter/src/change_validators/issue_type_scheme_migration.ts
@@ -17,10 +17,13 @@ import { Change, ChangeError, ChangeValidator, getChangeData, InstanceElement, i
 import _ from 'lodash'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { collections, values } from '@salto-io/lowerdash'
+import { logger } from '@salto-io/logging'
+import { safeJsonStringify } from '@salto-io/adapter-utils'
 import JiraClient from '../client/client'
 import { ISSUE_TYPE_SCHEMA_NAME, PROJECT_TYPE } from '../constants'
 
 const { awu } = collections.asynciterable
+const log = logger(module)
 const { isDefined } = values
 
 const isSameRef = (ref1: ReferenceExpression, ref2: ReferenceExpression): boolean =>
@@ -69,9 +72,12 @@ const areIssueTypesUsed = async (
       },
     })
   } catch (e) {
+    log.error(`Received an error Jira search API, ${e.message}. Assuming issue type "${issueType}" has issues.`)
     return true
   }
+
   if (Array.isArray(response.data) || response.data.total === undefined) {
+    log.error(`Received invalid response from Jira search API, ${safeJsonStringify(response.data, undefined, 2)}. Assuming issue type "${issueType}" has issues.`)
     return true
   }
   return response.data.total !== 0

--- a/packages/jira-adapter/src/change_validators/issue_type_scheme_migration.ts
+++ b/packages/jira-adapter/src/change_validators/issue_type_scheme_migration.ts
@@ -1,0 +1,101 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Change, ChangeValidator, getChangeData, InstanceElement, isInstanceChange, isModificationChange, isReferenceExpression, ModificationChange, ReferenceExpression, SeverityLevel } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { client as clientUtils } from '@salto-io/adapter-components'
+import { collections, values } from '@salto-io/lowerdash'
+import JiraClient from '../client/client'
+import { ISSUE_TYPE_SCHEMA_NAME, PROJECT_TYPE } from '../constants'
+
+const { awu } = collections.asynciterable
+const { isDefined } = values
+
+const isSameRef = (ref1: ReferenceExpression, ref2: ReferenceExpression): boolean =>
+  ref1.elemID.isEqual(ref2.elemID)
+
+const getRemovedIssueTypeIds = (change: ModificationChange<InstanceElement>): ReferenceExpression[] => {
+  const { before, after } = change.data
+  const beforeIssueIds = before.value.issueTypeIds.filter(isReferenceExpression)
+  const afterIssueIds = after.value.issueTypeIds.filter(isReferenceExpression)
+  return _.differenceWith(beforeIssueIds, afterIssueIds, isSameRef)
+}
+
+const getRelevantChanges = (changes: ReadonlyArray<Change>): ModificationChange<InstanceElement>[] =>
+  changes
+    .filter(isModificationChange)
+    .filter(isInstanceChange)
+    .filter(change => getChangeData(change).elemID.typeName === ISSUE_TYPE_SCHEMA_NAME)
+    .filter(change => getRemovedIssueTypeIds(change).length > 0)
+
+const areIssueTypesUsed = async (
+  client: JiraClient,
+  issueTypes: string[],
+  linkedProjectNames: string[],
+): Promise<boolean> => {
+  const jql = `project in (${linkedProjectNames.join(',')}) AND issuetype in (${issueTypes.join(',')})`
+  let response: clientUtils.Response<clientUtils.ResponseValue | clientUtils.ResponseValue[]>
+  try {
+    response = await client.getSinglePage({
+      url: '/rest/api/3/search',
+      queryParams: {
+        jql,
+        maxResults: '0',
+      },
+    })
+  } catch (e) {
+    return true
+  }
+  if (Array.isArray(response.data) || response.data.total === undefined) {
+    return true
+  }
+  return response.data.total !== 0
+}
+export const issueTypeSchemeValidator = (
+  client: JiraClient,
+): ChangeValidator =>
+  async (changes, elementSource) => {
+    const relevantChanges = getRelevantChanges(changes)
+    if (elementSource === undefined || relevantChanges.length === 0) {
+      return []
+    }
+    const idsIterator = awu(await elementSource.list())
+    const projects = await awu(idsIterator)
+      .filter(id => id.typeName === PROJECT_TYPE)
+      .filter(id => id.idType === 'instance')
+      .map(id => elementSource.get(id))
+      .toArray()
+    const issueTypeSchemesToProjects = _.groupBy(
+      projects.filter(project => project.value.issueTypeScheme !== undefined),
+      project => project.value.issueTypeScheme.elemID.getFullName(),
+    )
+    const errors = await awu(relevantChanges).map(async change => {
+      const removedIssueTypeIds = getRemovedIssueTypeIds(change)
+        .map(issueTypeId => issueTypeId.elemID.name)
+      const issueTypeScheme = getChangeData(change)
+      const linkedProjectNames = issueTypeSchemesToProjects[issueTypeScheme.elemID.getFullName()]
+        .map(project => project.value.name)
+      if (await areIssueTypesUsed(client, removedIssueTypeIds, linkedProjectNames)) {
+        return {
+          elemID: issueTypeScheme.elemID,
+          severity: 'Error' as SeverityLevel,
+          message: 'Issue type is used in a project',
+          detailedMessage: `The issue type ${removedIssueTypeIds.join(', ')} is used in the following projects: ${linkedProjectNames.join(', ')}`,
+        }
+      }
+      return undefined
+    }).filter(isDefined).toArray()
+    return errors
+  }

--- a/packages/jira-adapter/src/change_validators/issue_type_scheme_migration.ts
+++ b/packages/jira-adapter/src/change_validators/issue_type_scheme_migration.ts
@@ -72,13 +72,13 @@ const areIssueTypesUsed = async (
       },
     })
   } catch (e) {
-    log.error(`Received an error Jira search API, ${e.message}. Assuming issue type "${issueType}" has issues.`)
-    return true
+    log.error(`Received an error Jira search API, ${e.message}. Assuming issue type "${issueType}" has no issues.`)
+    return false
   }
 
   if (Array.isArray(response.data) || response.data.total === undefined) {
-    log.error(`Received invalid response from Jira search API, ${safeJsonStringify(response.data, undefined, 2)}. Assuming issue type "${issueType}" has issues.`)
-    return true
+    log.error(`Received invalid response from Jira search API, ${safeJsonStringify(response.data, undefined, 2)}. Assuming issue type "${issueType}" has no issues.`)
+    return false
   }
   return response.data.total !== 0
 }
@@ -110,7 +110,7 @@ export const issueTypeSchemeMigrationValidator = (
         return undefined
       }
       const removedIssueTypeNames = getRemovedIssueTypeIds(change)
-        .map(issueTypeId => issueTypeId.elemID.name)
+        .map(issueTypeId => issueTypeId.value.value.name)
       const removedTypesWithIssues = await awu(removedIssueTypeNames).filter(async issueType => (
         areIssueTypesUsed(client, issueType, linkedProjectNames)
       )).toArray()

--- a/packages/jira-adapter/src/change_validators/issue_type_scheme_migration.ts
+++ b/packages/jira-adapter/src/change_validators/issue_type_scheme_migration.ts
@@ -96,11 +96,14 @@ export const issueTypeSchemeMigrationValidator = (
       project => project.value.issueTypeScheme.elemID.getFullName(),
     )
     const errors = await awu(relevantChanges).map(async change => {
-      const removedIssueTypeNames = getRemovedIssueTypeIds(change)
-        .map(issueTypeId => issueTypeId.elemID.name)
       const issueTypeScheme = getChangeData(change)
       const linkedProjectNames = issueTypeSchemesToProjects[issueTypeScheme.elemID.getFullName()]
-        .map(project => project.value.name)
+        ?.map(project => project.value.name) ?? []
+      if (linkedProjectNames.length === 0) {
+        return undefined
+      }
+      const removedIssueTypeNames = getRemovedIssueTypeIds(change)
+        .map(issueTypeId => issueTypeId.elemID.name)
       const removedTypesWithIssues = await awu(removedIssueTypeNames).filter(async issueType => (
         areIssueTypesUsed(client, issueType, linkedProjectNames)
       )).toArray()

--- a/packages/jira-adapter/test/change_validators/issue_type_scheme_migration.test.ts
+++ b/packages/jira-adapter/test/change_validators/issue_type_scheme_migration.test.ts
@@ -22,10 +22,10 @@ import { issueTypeSchemeMigrationValidator } from '../../src/change_validators/i
 import { ISSUE_TYPE_NAME, ISSUE_TYPE_SCHEMA_NAME, JIRA, PROJECT_TYPE } from '../../src/constants'
 
 describe('issue type scheme migration validator', () => {
-  const issueTypeReference = new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'issueType1'))
-  const issueTypeReference2 = new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'issueType2'))
-  const issueTypeReference3 = new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'issueType3'))
-  const issueTypeReference4 = new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'issueType4'))
+  const issueTypeReference = new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'issueType1'), new InstanceElement('issueType1', new ObjectType({ elemID: new ElemID(JIRA, ISSUE_TYPE_NAME) }), { name: 'issueType1' }))
+  const issueTypeReference2 = new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'issueType2'), new InstanceElement('issueType2', new ObjectType({ elemID: new ElemID(JIRA, ISSUE_TYPE_NAME) }), { name: 'issueType2' }))
+  const issueTypeReference3 = new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'issueType3'), new InstanceElement('issueType3', new ObjectType({ elemID: new ElemID(JIRA, ISSUE_TYPE_NAME) }), { name: 'issueType3' }))
+  const issueTypeReference4 = new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'issueType4'), new InstanceElement('issueType4', new ObjectType({ elemID: new ElemID(JIRA, ISSUE_TYPE_NAME) }), { name: 'issueType4' }))
   const projectType = new ObjectType({ elemID: new ElemID(JIRA, PROJECT_TYPE) })
   let projectInstance: InstanceElement
   let secondProjectInstance: InstanceElement
@@ -127,16 +127,16 @@ describe('issue type scheme migration validator', () => {
     elementSource = buildElementsSourceFromElements([])
     expect(await callValidator()).toEqual([])
   })
-  it('should assume there are issues if error is returned from server', async () => {
+  it("should assume there aren't issues if error is returned from server", async () => {
     mockConnection.get.mockImplementation(async url => {
       if (url === '/rest/api/3/search') {
         throw new Error('error')
       }
       throw new Error(`Unexpected url ${url}`)
     })
-    expect(await callValidator()).toHaveLength(1)
+    expect(await callValidator()).toHaveLength(0)
   })
-  it('should assume there are issues bad response from server', async () => {
+  it("should assume there aren't issues bad response from server", async () => {
     mockConnection.get.mockResolvedValueOnce({
       status: 200,
       data: [],
@@ -148,9 +148,7 @@ describe('issue type scheme migration validator', () => {
       },
     })
     const errors = await callValidator()
-    expect(errors).toHaveLength(1)
-    expect(errors[0].message).toEqual('Cannot remove issue types from scheme')
-    expect(errors[0].detailedMessage).toEqual('The issue types issueType2, issueType3 have assigned issues and cannot be removed from this issue type scheme')
+    expect(errors).toHaveLength(0)
   })
   it('should return a error if there are linked issues', async () => {
     const errors = await callValidator()

--- a/packages/jira-adapter/test/change_validators/issue_type_scheme_migration.test.ts
+++ b/packages/jira-adapter/test/change_validators/issue_type_scheme_migration.test.ts
@@ -1,0 +1,163 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, ElemID, InstanceElement, ReferenceExpression, ChangeValidator, toChange, ReadOnlyElementsSource, ChangeError } from '@salto-io/adapter-api'
+import { MockInterface } from '@salto-io/test-utils'
+import { client as clientUtils } from '@salto-io/adapter-components'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { mockClient } from '../utils'
+import { issueTypeSchemeMigrationValidator } from '../../src/change_validators/issue_type_scheme_migration'
+import { ISSUE_TYPE_NAME, ISSUE_TYPE_SCHEMA_NAME, JIRA, PROJECT_TYPE } from '../../src/constants'
+
+describe('issue type scheme migration validator', () => {
+  const issueTypeReference = new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'issueType1'))
+  const issueTypeReference2 = new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'issueType2'))
+  const issueTypeReference3 = new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'issueType3'))
+  const issueTypeReference4 = new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'issueType4'))
+  const projectType = new ObjectType({ elemID: new ElemID(JIRA, PROJECT_TYPE) })
+  let projectInstance: InstanceElement
+  let secondProjectInstance: InstanceElement
+  let issueTypeScheme: InstanceElement
+  let modifiedIssueTypeScheme: InstanceElement
+  let validator: ChangeValidator
+  let elementSource: ReadOnlyElementsSource
+  let mockConnection: MockInterface<clientUtils.APIConnection>
+  let numberOfIssues: number
+  const callValidator = async (): Promise<readonly ChangeError[]> => {
+    const changes = [
+      toChange({ before: issueTypeScheme, after: modifiedIssueTypeScheme }),
+    ]
+    return validator(changes, elementSource)
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    const { client, connection } = mockClient()
+    mockConnection = connection
+    numberOfIssues = 100
+    const issueTypeSchemeType = new ObjectType({ elemID: new ElemID(JIRA, ISSUE_TYPE_SCHEMA_NAME) })
+    projectInstance = new InstanceElement(
+      'instance',
+      projectType,
+      {
+        name: 'instance',
+        workflowScheme: new ReferenceExpression(new ElemID(JIRA, 'WorkflowScheme', 'instance', 'workflow')),
+        issueTypeScheme: new ReferenceExpression(new ElemID(JIRA, 'IssueTypeScheme', 'instance', 'issueTypeScheme')),
+      }
+    )
+    secondProjectInstance = new InstanceElement(
+      'instance2',
+      projectType,
+      {
+        name: 'instance',
+        workflowScheme: new ReferenceExpression(new ElemID(JIRA, 'WorkflowScheme', 'instance', 'workflow')),
+        issueTypeScheme: new ReferenceExpression(new ElemID(JIRA, 'IssueTypeScheme', 'instance', 'issueTypeScheme')),
+      }
+    )
+    issueTypeScheme = new InstanceElement(
+      'issueTypeScheme',
+      issueTypeSchemeType,
+      {
+        defaultIssueTypeId: new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'issueType1')),
+        issueTypeIds: [
+          issueTypeReference,
+          issueTypeReference2,
+          issueTypeReference3,
+        ],
+      }
+    )
+    modifiedIssueTypeScheme = new InstanceElement(
+      'issueTypeScheme',
+      issueTypeSchemeType,
+      {
+        defaultIssueTypeId: new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'issueType1')),
+        issueTypeIds: [
+          issueTypeReference,
+          issueTypeReference4,
+        ],
+      }
+    )
+    elementSource = buildElementsSourceFromElements([projectInstance, secondProjectInstance])
+    mockConnection.get.mockImplementation(async url => {
+      if (url === '/rest/api/3/search') {
+        return {
+          status: 200,
+          data: {
+            total: numberOfIssues,
+          },
+        }
+      }
+      throw new Error(`Unexpected url ${url}`)
+    })
+    validator = issueTypeSchemeMigrationValidator(client)
+  })
+
+  it('should not return an error if no issue types were removed', async () => {
+    modifiedIssueTypeScheme.value.issueTypeIds = [
+      ...issueTypeScheme.value.issueTypeIds,
+      issueTypeReference4,
+    ]
+    expect(await callValidator()).toEqual([])
+  })
+
+  it('should not return an error on removal/addition changes', async () => {
+    expect(await validator([toChange({ before: issueTypeScheme })], elementSource)).toEqual([])
+    expect(await validator([toChange({ after: issueTypeScheme })], elementSource)).toEqual([])
+  })
+  it('should not return an error if element source is undefined', async () => {
+    expect(await validator([toChange({ before: issueTypeScheme, after: modifiedIssueTypeScheme })])).toEqual([])
+  })
+  it('should not return an error if there are no linked issues', async () => {
+    numberOfIssues = 0
+    expect(await callValidator()).toEqual([])
+  })
+  it('should not return an error if changed issue type scheme is not used by projects', async () => {
+    elementSource = buildElementsSourceFromElements([])
+    expect(await callValidator()).toEqual([])
+  })
+  it('should assume there are issues if error is returned from server', async () => {
+    mockConnection.get.mockImplementation(async url => {
+      if (url === '/rest/api/3/search') {
+        throw new Error('error')
+      }
+      throw new Error(`Unexpected url ${url}`)
+    })
+    expect(await callValidator()).toHaveLength(1)
+  })
+  it('should return a error if there are linked issues', async () => {
+    const errors = await callValidator()
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toEqual('Cannot remove issue types from scheme')
+    expect(errors[0].detailedMessage).toEqual('The issue types issueType2, issueType3 have assigned issues and cannot be removed from this issue type scheme')
+  })
+  it('should only include issue type with assigned issues in error', async () => {
+    numberOfIssues = 0
+    mockConnection.get.mockImplementationOnce(async url => {
+      if (url === '/rest/api/3/search') {
+        return {
+          status: 200,
+          data: {
+            total: 100,
+          },
+        }
+      }
+      throw new Error(`Unexpected url ${url}`)
+    })
+    const errors = await callValidator()
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toEqual('Cannot remove issue type from scheme')
+    expect(errors[0].detailedMessage).toEqual('The issue type issueType2 have assigned issues and cannot be removed from this issue type scheme')
+  })
+})

--- a/packages/jira-adapter/test/change_validators/issue_type_scheme_migration.test.ts
+++ b/packages/jira-adapter/test/change_validators/issue_type_scheme_migration.test.ts
@@ -136,6 +136,22 @@ describe('issue type scheme migration validator', () => {
     })
     expect(await callValidator()).toHaveLength(1)
   })
+  it('should assume there are issues bad response from server', async () => {
+    mockConnection.get.mockResolvedValueOnce({
+      status: 200,
+      data: [],
+    })
+    mockConnection.get.mockResolvedValueOnce({
+      status: 200,
+      data: {
+        something: 'else',
+      },
+    })
+    const errors = await callValidator()
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toEqual('Cannot remove issue types from scheme')
+    expect(errors[0].detailedMessage).toEqual('The issue types issueType2, issueType3 have assigned issues and cannot be removed from this issue type scheme')
+  })
   it('should return a error if there are linked issues', async () => {
     const errors = await callValidator()
     expect(errors).toHaveLength(1)


### PR DESCRIPTION
handled a migration error for issue type schemes when we either change a project issue type scheme or when we remove an issue type from a scheme that is being used by a project with the same typed issues

---

_Additional context for reviewer_
added tests for the new validator.

---
_Release Notes_: 
jira adapter:
* Add change validator to block removal of issue type from a scheme if that issue type is being used in assigned projects.
* Block Issue type scheme changes in active projects.

---
_User Notifications_: 

