### PR TITLE
SALTO-3489/issue type deletion

### DIFF
--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -51,6 +51,7 @@ import { activeSchemeDeletionValidator } from './active_scheme_deletion'
 import { automationProjectUnresolvedReferenceValidator } from './automation_unresolved_references'
 import { unresolvedReferenceValidator } from './unresolved_references'
 import { sameIssueTypeNameChangeValidator } from './same_issue_type_name'
+import { issueTypeDeletionValidator } from './issue_type_deletion'
 
 const {
   deployTypesNotSupportedValidator,
@@ -86,6 +87,7 @@ export default (
     workflowSchemeMigrationValidator(client, config, paginator),
     activeSchemeChangeValidator(client),
     maskingValidator(client),
+    issueTypeDeletionValidator(client),
     lockedFieldsValidator,
     fieldContextValidator,
     systemFieldsValidator,

--- a/packages/jira-adapter/src/change_validators/issue_type_deletion.ts
+++ b/packages/jira-adapter/src/change_validators/issue_type_deletion.ts
@@ -61,8 +61,8 @@ const getRelevantChanges = (changes: ReadonlyArray<Change>): RemovalChange<Insta
 const getRemovedIssueTypeUsedError = (instance: InstanceElement): ChangeError => ({
   elemID: instance.elemID,
   severity: 'Error' as SeverityLevel,
-  message: 'Cannot remove used issue type.',
-  detailedMessage: 'Cannot remove issue type that has issues.',
+  message: 'Cannot remove issue type with existing issues.',
+  detailedMessage: 'This issue type has existing issues across all projects. You must delete all issues of this type before you can delete the issue type.',
 })
 
 export const issueTypeDeletionValidator: (client: JiraClient) =>

--- a/packages/jira-adapter/src/change_validators/issue_type_deletion.ts
+++ b/packages/jira-adapter/src/change_validators/issue_type_deletion.ts
@@ -48,7 +48,7 @@ export const isIssueTypeUsed = async (
     return false
   }
 
-  log.debug(`Project ${instance.elemID.getFullName()} has ${response.data.total} issues.`)
+  log.debug(`Issue type ${instance.elemID.getFullName()} has ${response.data.total} issues.`)
 
   return response.data.total !== 0
 }

--- a/packages/jira-adapter/src/change_validators/issue_type_deletion.ts
+++ b/packages/jira-adapter/src/change_validators/issue_type_deletion.ts
@@ -39,13 +39,13 @@ export const isIssueTypeUsed = async (
       },
     })
   } catch (e) {
-    log.error(`Received an error Jira search API, ${e.message}. Assuming issue type ${instance.elemID.getFullName()} has issues.`)
-    return true
+    log.error(`Received an error Jira search API, ${e.message}. Assuming issue type ${instance.elemID.getFullName()} has no issues.`)
+    return false
   }
 
   if (Array.isArray(response.data) || response.data.total === undefined) {
-    log.error(`Received invalid response from Jira search API, ${safeJsonStringify(response.data, undefined, 2)}. Assuming issue type ${instance.elemID.getFullName()} has issues.`)
-    return true
+    log.error(`Received invalid response from Jira search API, ${safeJsonStringify(response.data, undefined, 2)}. Assuming issue type ${instance.elemID.getFullName()} has no issues.`)
+    return false
   }
 
   log.debug(`Project ${instance.elemID.getFullName()} has ${response.data.total} issues.`)
@@ -62,7 +62,7 @@ const getRemovedIssueTypeUsedError = (instance: InstanceElement): ChangeError =>
   elemID: instance.elemID,
   severity: 'Error' as SeverityLevel,
   message: 'Cannot remove issue type with existing issues.',
-  detailedMessage: 'This issue type has existing issues across all projects. You must delete all issues of this type before you can delete the issue type.',
+  detailedMessage: 'There are existing issues of this issue type. You must delete them before you can delete the issue type itself.',
 })
 
 export const issueTypeDeletionValidator: (client: JiraClient) =>

--- a/packages/jira-adapter/src/change_validators/issue_type_deletion.ts
+++ b/packages/jira-adapter/src/change_validators/issue_type_deletion.ts
@@ -20,7 +20,6 @@ import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import { ISSUE_TYPE_NAME } from '../constants'
 import JiraClient from '../client/client'
-import { JiraConfig } from '../config/config'
 
 const { awu } = collections.asynciterable
 
@@ -66,7 +65,7 @@ const getRemovedIssueTypeUsedError = (instance: InstanceElement): ChangeError =>
   detailedMessage: 'Cannot remove issue type that has issues.',
 })
 
-export const projectDeletionValidator: (client: JiraClient, config: JiraConfig) =>
+export const issueTypeDeletionValidator: (client: JiraClient) =>
   ChangeValidator = client => async changes => {
     const relevantChanges = getRelevantChanges(changes)
     return awu(relevantChanges)

--- a/packages/jira-adapter/src/change_validators/issue_type_deletion.ts
+++ b/packages/jira-adapter/src/change_validators/issue_type_deletion.ts
@@ -1,0 +1,77 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Change, ChangeError, ChangeValidator, getChangeData, InstanceElement, isInstanceChange, isRemovalChange, RemovalChange, SeverityLevel } from '@salto-io/adapter-api'
+import { safeJsonStringify } from '@salto-io/adapter-utils'
+import { client as clientUtils } from '@salto-io/adapter-components'
+import { logger } from '@salto-io/logging'
+import { collections } from '@salto-io/lowerdash'
+import { ISSUE_TYPE_NAME } from '../constants'
+import JiraClient from '../client/client'
+import { JiraConfig } from '../config/config'
+
+const { awu } = collections.asynciterable
+
+const log = logger(module)
+
+export const isIssueTypeUsed = async (
+  instance: InstanceElement,
+  client: JiraClient
+): Promise<boolean> => {
+  let response: clientUtils.Response<clientUtils.ResponseValue | clientUtils.ResponseValue[]>
+  try {
+    response = await client.getSinglePage({
+      url: '/rest/api/3/search',
+      queryParams: {
+        jql: `issuetype = "${instance.value.name}"`,
+        maxResults: '0',
+      },
+    })
+  } catch (e) {
+    log.error(`Received an error Jira search API, ${e.message}. Assuming issue type ${instance.elemID.getFullName()} has issues.`)
+    return true
+  }
+
+  if (Array.isArray(response.data) || response.data.total === undefined) {
+    log.error(`Received invalid response from Jira search API, ${safeJsonStringify(response.data, undefined, 2)}. Assuming issue type ${instance.elemID.getFullName()} has issues.`)
+    return true
+  }
+
+  log.debug(`Project ${instance.elemID.getFullName()} has ${response.data.total} issues.`)
+
+  return response.data.total !== 0
+}
+const getRelevantChanges = (changes: ReadonlyArray<Change>): RemovalChange<InstanceElement>[] =>
+  changes
+    .filter(isInstanceChange)
+    .filter(isRemovalChange)
+    .filter(change => getChangeData(change).elemID.typeName === ISSUE_TYPE_NAME)
+
+const getRemovedIssueTypeUsedError = (instance: InstanceElement): ChangeError => ({
+  elemID: instance.elemID,
+  severity: 'Error' as SeverityLevel,
+  message: 'Cannot remove used issue type.',
+  detailedMessage: 'Cannot remove issue type that has issues.',
+})
+
+export const projectDeletionValidator: (client: JiraClient, config: JiraConfig) =>
+  ChangeValidator = client => async changes => {
+    const relevantChanges = getRelevantChanges(changes)
+    return awu(relevantChanges)
+      .map(getChangeData)
+      .filter(instance => isIssueTypeUsed(instance, client))
+      .map(getRemovedIssueTypeUsedError)
+      .toArray()
+  }

--- a/packages/jira-adapter/test/change_validators/issue_type_deletion.test.ts
+++ b/packages/jira-adapter/test/change_validators/issue_type_deletion.test.ts
@@ -1,0 +1,93 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, ElemID, InstanceElement, ChangeValidator, toChange } from '@salto-io/adapter-api'
+import { MockInterface } from '@salto-io/test-utils'
+import { client as clientUtils } from '@salto-io/adapter-components'
+import { mockClient } from '../utils'
+import { issueTypeDeletionValidator } from '../../src/change_validators/issue_type_deletion'
+import { ISSUE_TYPE_NAME, JIRA } from '../../src/constants'
+
+describe('issue type deletion validator', () => {
+  let validator: ChangeValidator
+  let mockConnection: MockInterface<clientUtils.APIConnection>
+  let numberOfIssues: number
+  let instance: InstanceElement
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    const { client, connection } = mockClient()
+    mockConnection = connection
+    numberOfIssues = 100
+    instance = new InstanceElement(
+      'instance',
+      new ObjectType({ elemID: new ElemID(JIRA, ISSUE_TYPE_NAME) }),
+      {
+        name: 'instance',
+      },
+    )
+    mockConnection.get.mockImplementation(async url => {
+      if (url === '/rest/api/3/search') {
+        return {
+          status: 200,
+          data: {
+            total: numberOfIssues,
+          },
+        }
+      }
+      throw new Error(`Unexpected url ${url}`)
+    })
+    validator = issueTypeDeletionValidator(client)
+  })
+
+  it('should not return an error on modification/addition changes', async () => {
+    expect(await validator([toChange({ before: instance, after: instance })])).toEqual([])
+    expect(await validator([toChange({ after: instance })])).toEqual([])
+  })
+  it('should not return an error if there are no linked issues', async () => {
+    numberOfIssues = 0
+    expect(await validator([toChange({ before: instance })])).toEqual([])
+  })
+  it('should assume there are issues if error is returned from server', async () => {
+    mockConnection.get.mockImplementation(async url => {
+      if (url === '/rest/api/3/search') {
+        throw new Error('error')
+      }
+      throw new Error(`Unexpected url ${url}`)
+    })
+    expect(await validator([toChange({ before: instance })])).toHaveLength(1)
+  })
+  it('should assume there are issues bad response from server', async () => {
+    mockConnection.get.mockResolvedValueOnce({
+      status: 200,
+      data: [],
+    })
+    mockConnection.get.mockResolvedValueOnce({
+      status: 200,
+      data: {
+        something: 'else',
+      },
+    })
+    expect(await validator([toChange({ before: instance })])).toHaveLength(1)
+    expect(await validator([toChange({ before: instance })])).toHaveLength(1)
+    // check for logs??
+  })
+  it('should return a error if there are linked issues', async () => {
+    const errors = await validator([toChange({ before: instance })])
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toEqual('Cannot remove used issue type.')
+    expect(errors[0].detailedMessage).toEqual('Cannot remove issue type that has issues.')
+  })
+})

--- a/packages/jira-adapter/test/change_validators/issue_type_deletion.test.ts
+++ b/packages/jira-adapter/test/change_validators/issue_type_deletion.test.ts
@@ -60,33 +60,33 @@ describe('issue type deletion validator', () => {
     numberOfIssues = 0
     expect(await validator([toChange({ before: instance })])).toEqual([])
   })
-  it('should assume there are issues if error is returned from server', async () => {
+  it("should assume there aren't issues if error is returned from server", async () => {
     mockConnection.get.mockImplementation(async url => {
       if (url === '/rest/api/3/search') {
         throw new Error('error')
       }
       throw new Error(`Unexpected url ${url}`)
     })
-    expect(await validator([toChange({ before: instance })])).toHaveLength(1)
+    expect(await validator([toChange({ before: instance })])).toHaveLength(0)
   })
-  it('should assume there are issues bad response from server', async () => {
+  it("should assume there aren't issues on bad response from server", async () => {
     mockConnection.get.mockResolvedValueOnce({
       status: 200,
       data: [],
     })
-    expect(await validator([toChange({ before: instance })])).toHaveLength(1)
+    expect(await validator([toChange({ before: instance })])).toHaveLength(0)
     mockConnection.get.mockResolvedValueOnce({
       status: 200,
       data: {
         something: 'else',
       },
     })
-    expect(await validator([toChange({ before: instance })])).toHaveLength(1)
+    expect(await validator([toChange({ before: instance })])).toHaveLength(0)
   })
   it('should return a error if there are linked issues', async () => {
     const errors = await validator([toChange({ before: instance })])
     expect(errors).toHaveLength(1)
     expect(errors[0].message).toEqual('Cannot remove issue type with existing issues.')
-    expect(errors[0].detailedMessage).toEqual('This issue type has existing issues across all projects. You must delete all issues of this type before you can delete the issue type.')
+    expect(errors[0].detailedMessage).toEqual('There are existing issues of this issue type. You must delete them before you can delete the issue type itself.')
   })
 })

--- a/packages/jira-adapter/test/change_validators/issue_type_deletion.test.ts
+++ b/packages/jira-adapter/test/change_validators/issue_type_deletion.test.ts
@@ -74,6 +74,7 @@ describe('issue type deletion validator', () => {
       status: 200,
       data: [],
     })
+    expect(await validator([toChange({ before: instance })])).toHaveLength(1)
     mockConnection.get.mockResolvedValueOnce({
       status: 200,
       data: {
@@ -81,13 +82,11 @@ describe('issue type deletion validator', () => {
       },
     })
     expect(await validator([toChange({ before: instance })])).toHaveLength(1)
-    expect(await validator([toChange({ before: instance })])).toHaveLength(1)
-    // check for logs??
   })
   it('should return a error if there are linked issues', async () => {
     const errors = await validator([toChange({ before: instance })])
     expect(errors).toHaveLength(1)
-    expect(errors[0].message).toEqual('Cannot remove used issue type.')
-    expect(errors[0].detailedMessage).toEqual('Cannot remove issue type that has issues.')
+    expect(errors[0].message).toEqual('Cannot remove issue type with existing issues.')
+    expect(errors[0].detailedMessage).toEqual('This issue type has existing issues across all projects. You must delete all issues of this type before you can delete the issue type.')
   })
 })


### PR DESCRIPTION
add change validator to block removal of issue types when there are issues of that type in the service.

---

_Additional context for reviewer_


---
_Release Notes_: 
jira adapter:
* Add change validator to block removing issue types that are being used in projects

---
_User Notifications_: 
