### PR TITLE
CV wording changes

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/cpq_trigger.ts
+++ b/packages/salesforce-adapter/src/change_validators/cpq_trigger.ts
@@ -28,7 +28,7 @@ const getCpqError = (
   elemID,
   severity: 'Info',
   message: 'CPQ data changes detected',
-  detailedMessage: 'CPQ data changes detected',
+  detailedMessage: '',
   deployActions: {
     preAction: {
       title: 'Disable CPQ Triggers',

--- a/packages/salesforce-adapter/src/change_validators/cpq_trigger.ts
+++ b/packages/salesforce-adapter/src/change_validators/cpq_trigger.ts
@@ -28,7 +28,7 @@ const getCpqError = (
   elemID,
   severity: 'Info',
   message: 'CPQ data changes detected',
-  detailedMessage: '',
+  detailedMessage: 'CPQ data changes detected',
   deployActions: {
     preAction: {
       title: 'Disable CPQ Triggers',

--- a/packages/salesforce-adapter/src/change_validators/custom_field_type.ts
+++ b/packages/salesforce-adapter/src/change_validators/custom_field_type.ts
@@ -42,8 +42,8 @@ const isInvalidTypeChange = async (change: Change<Field>): Promise<boolean> => {
 const createChangeError = (field: Field): ChangeError => ({
   elemID: field.elemID,
   severity: 'Warning',
-  message: `You cannot create or modify a custom field type to ${field.refType.elemID.typeName}. Field: ${field.name}`,
-  detailedMessage: `You cannot create or modify a custom field type to ${field.refType.elemID.typeName}. Valid types can be found at:\nhttps://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_field_types.htm#meta_type_fieldtype`,
+  message: 'Invalid custom field type',
+  detailedMessage: `Custom field type ${field.refType.elemID.typeName} is not valid.\nYou can edit the type in Salto and use a valid type, per the list at:\nhttps://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_field_types.htm#meta_type_fieldtype`,
 })
 
 /**

--- a/packages/salesforce-adapter/src/change_validators/custom_object_instances.ts
+++ b/packages/salesforce-adapter/src/change_validators/custom_object_instances.ts
@@ -40,8 +40,8 @@ const getUpdateErrorsForNonUpdateableFields = async (
         return {
           elemID: beforeResolved.elemID,
           severity: 'Warning',
-          message: `Unable to edit ${afterResolved.elemID.typeName}.${field.name} because it is a non-updateable field.`,
-          detailedMessage: `Unable to edit ${field.name} inside ${beforeResolved.elemID.getFullName()} because it is a non-updateable field.`,
+          message: 'Cannot modify the value of a non-updatable field',
+          detailedMessage: `Cannot modify ${field.name}’s value of ${beforeResolved.elemID.getFullName()} because its field is defined as non-updateable.`,
         } as ChangeError
       }
       return undefined
@@ -59,8 +59,8 @@ const getCreateErrorsForNonCreatableFields = async (
         return {
           elemID: afterResolved.elemID,
           severity: 'Warning',
-          message: `Unable to create ${afterResolved.elemID.typeName}.${field.name} because it is a non-creatable field.`,
-          detailedMessage: `Unable to create ${field.name} inside ${afterResolved.elemID.getFullName()} because it is a non-creatable field.`,
+          message: 'Cannot set a value to a non-creatable field',
+          detailedMessage: `Cannot set a value for ${field.name} of ${afterResolved.elemID.getFullName()} because its field is defined as non-creatable.`,
         } as ChangeError
       }
       return undefined

--- a/packages/salesforce-adapter/src/change_validators/data_change.ts
+++ b/packages/salesforce-adapter/src/change_validators/data_change.ts
@@ -23,8 +23,8 @@ const { isDefined } = values
 const createChangeError = (instanceElemID: ElemID): ChangeError => ({
   elemID: instanceElemID,
   severity: 'Info',
-  message: 'Data instances were changed in deployment.',
-  detailedMessage: 'Data instances were changed in this deployment.',
+  message: 'Data instances will be changed in deployment.',
+  detailedMessage: 'Data instances will be changed in this deployment.',
 })
 
 /**

--- a/packages/salesforce-adapter/src/change_validators/data_change.ts
+++ b/packages/salesforce-adapter/src/change_validators/data_change.ts
@@ -24,7 +24,7 @@ const createChangeError = (instanceElemID: ElemID): ChangeError => ({
   elemID: instanceElemID,
   severity: 'Info',
   message: 'Data instances will be changed in deployment.',
-  detailedMessage: 'Data instances will be changed in this deployment.',
+  detailedMessage: '',
 })
 
 /**

--- a/packages/salesforce-adapter/src/change_validators/multiple_defaults.ts
+++ b/packages/salesforce-adapter/src/change_validators/multiple_defaults.ts
@@ -70,8 +70,8 @@ const createInstanceChangeError = (field: Field, contexts: string[], instance: I
   return {
     elemID: instance.elemID,
     severity: 'Warning',
-    message: `There cannot be more than one 'default' field set to 'true'. Field name: ${field.name} in instance: ${instanceName} type ${field.parent.elemID.name}.`,
-    detailedMessage: `There cannot be more than one 'default' ${field.name} in instance: ${instanceName} type ${field.parent.elemID.name}. The following ${FIELD_NAME_TO_INNER_CONTEXT_FIELD[field.name]?.name ?? LABEL}s are set to default: ${contexts}`,
+    message: 'Instances cannot have more than one default',
+    detailedMessage: `There cannot be more than one 'default' ${field.name} in instance: ${instanceName} type ${field.parent.elemID.name}.\nThe following ${FIELD_NAME_TO_INNER_CONTEXT_FIELD[field.name] ?? LABEL}s are set to default: ${contexts}`,
   }
 }
 
@@ -79,8 +79,8 @@ const createFieldChangeError = (field: Field, contexts: string[]):
   ChangeError => ({
   elemID: field.elemID,
   severity: 'Warning',
-  message: `There cannot be more than one 'default' field set to 'true'. Field name: ${field.name} in type ${field.parent.elemID.name}.`,
-  detailedMessage: `There cannot be more than one 'default' ${field.name} in type ${field.parent.elemID.name}. The following ${FIELD_NAME_TO_INNER_CONTEXT_FIELD[field.name]?.name ?? LABEL}s are set to default: ${contexts}`,
+  message: 'Types cannot have more than one default',
+  detailedMessage: `There cannot be more than one 'default' ${field.name} in type ${field.parent.elemID.name}.\nThe following ${FIELD_NAME_TO_INNER_CONTEXT_FIELD[field.name] ?? LABEL}s are set to default: ${contexts}`,
 })
 
 const getPicklistMultipleDefaultsErrors = (field: FieldWithValueSet): ChangeError[] => {

--- a/packages/salesforce-adapter/src/change_validators/package.ts
+++ b/packages/salesforce-adapter/src/change_validators/package.ts
@@ -70,7 +70,7 @@ const packageChangeError = async (
   return ({
     elemID: element.elemID,
     severity: 'Error',
-    message: `Cannot change a managed package using Salto. Package namespace: ${packageNamespace}`,
+    message: `Element is part of a package namespace ${packageNamespace}`,
     detailedMessage: detailedMessage ?? `Cannot ${action} ${element.elemID.getFullName()} because it is part of a package namespace: ${packageNamespace}`,
   })
 }

--- a/packages/salesforce-adapter/src/change_validators/picklist_promote.ts
+++ b/packages/salesforce-adapter/src/change_validators/picklist_promote.ts
@@ -35,16 +35,16 @@ const createChangeErrors = ({ pickListField, gvsElemID }:
   const picklistErr: ChangeError = {
     elemID: pickListField.elemID,
     severity: 'Error',
-    message: 'Promoting a picklist value set to a global one cannot be done via API. Please promote via the service.',
-    detailedMessage: `Promoting a picklist value set to a global one cannot be done via API. Field: ${pickListField.name}`,
+    message: 'Cannot promote a picklist value set to a global value set via the API',
+    detailedMessage: `${pickListField.name} picklist value set cannot be promoted to a global value set via the API.\nYou can delete this change in Salto and do it directly in salesforce.`,
   }
   // picklistField valueSetName annotation points to a valid GVS
   if (gvsElemID) {
     const gvsErr: ChangeError = {
       elemID: gvsElemID,
       severity: 'Error',
-      message: 'Cannot create a global value set as a result of a picklist promote via API. Please promote via the service.',
-      detailedMessage: `Cannot create a global value set as a result of a picklist promote via API. Value list name: ${gvsElemID.name}`,
+      message: 'Cannot promote a picklist value set to a global value set via the API',
+      detailedMessage: `${gvsElemID.name} picklist value set cannot be promoted to a global value set via the API.\nYou can delete this change in Salto and do it directly in salesforce.`,
     }
     return [picklistErr, gvsErr]
   }

--- a/packages/salesforce-adapter/src/change_validators/picklist_standard_field.ts
+++ b/packages/salesforce-adapter/src/change_validators/picklist_standard_field.ts
@@ -39,8 +39,8 @@ const createChangeError = (field: Field): ChangeError =>
   ({
     elemID: field.elemID,
     severity: 'Error',
-    message: `You cannot define picklist, globalPicklist, or valueSet on a standard field. Use StandardValueSet instead. Field: ${field.name}`,
-    detailedMessage: 'You cannot define picklist, globalPicklist, or valueSet on a standard field. Use StandardValueSet instead.',
+    message: 'Standard fields cannot be defined a picklist, global picklist, or value set.',
+    detailedMessage: `Standard field ‘${field.name}’ cannot be defined with a picklist, global picklist or value set.\nYou can edit the field in Salto and use a StandardValueSet instead`,
   })
 
 /**

--- a/packages/salesforce-adapter/src/change_validators/sbaa_approval_rules_custom_condition.ts
+++ b/packages/salesforce-adapter/src/change_validators/sbaa_approval_rules_custom_condition.ts
@@ -66,8 +66,8 @@ const changeValidator: ChangeValidator = async changes => {
     ({
       elemID: idToRuleWithCustomAdditionInst[referencedInstanceElemID].elemID,
       severity: 'Warning' as SeverityLevel,
-      message: 'Cannot deploy an ApprovalRule with ConditionMet Custom that has a referencing ApprovalCondition if Triggers are on. Must change to All, deploy, change back and deploy again.',
-      detailedMessage: `Cannot deploy ApprovalRule ${referencedInstanceElemID} if Triggers are on cause it has ConditionMet Custom and is referenced by an ApprovalCondition. Must change to All, deploy, change back and deploy again.`,
+      message: 'Cannot deploy ApprovalRule with ConditionMet set to ‘Custom’',
+      detailedMessage: 'Cannot deploy an ApprovalRule with ConditionMet set to ‘Custom‘ that has a referencing ApprovalCondition.\nYou can edit ConditionMet in Salto and set it to ‘All’ and deploy. Then, change it back to ‘Custom’ and deploy again.',
     })).filter(values.isDefined)
 }
 

--- a/packages/salesforce-adapter/src/change_validators/standard_field_label.ts
+++ b/packages/salesforce-adapter/src/change_validators/standard_field_label.ts
@@ -38,8 +38,8 @@ const isLabelModification = (change: ModificationChange<Field>): boolean => {
 const createChangeError = (field: Field): ChangeError => ({
   elemID: field.elemID,
   severity: 'Error',
-  message: `You cannot modify labels of standard fields. This change will NOT be deployed. Field: ${field.name}`,
-  detailedMessage: `You cannot modify labels of standard fields. This change will NOT be deployed. Field: ${field.name}`,
+  message: 'Modification of standard field labels is not supported',
+  detailedMessage: `Standard field ‘${field.name}’ label cannot be modified`,
 })
 
 /**

--- a/packages/salesforce-adapter/src/change_validators/unknown_field.ts
+++ b/packages/salesforce-adapter/src/change_validators/unknown_field.ts
@@ -28,8 +28,8 @@ const createChangeError = (field: Field): ChangeError =>
   ({
     elemID: field.elemID,
     severity: 'Error',
-    message: `You cannot create or modify a field with unknown type. Field: ${field.name}`,
-    detailedMessage: 'You cannot create or modify a field with unknown type. Check your profile permissions on Salesforce to make sure your have access to the field.',
+    message: 'Cannot create or modify a field with unknown type',
+    detailedMessage: `You cannot create or modify the field ${field.name} of type ‘unknown’.\nIn Salto, fields are set with an unknown type in case the credentials used for fetch provides limited access rights to that field in salesforce.\nCheck your profile permissions on Salesforce to make sure you have access to the field.`,
   })
 
 /**


### PR DESCRIPTION
Wording changes for Salesforce change validators

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: _None_
