### PR TITLE
SALTO-3681: `getPath` does not correctly when `rootElement` is a field

### DIFF
--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -647,6 +647,9 @@ export const getPath = (
   rootElement: Element,
   fullElemID: ElemID,
 ): string[] | undefined => {
+  // If rootElement is an objectType or an instance (i.e., a top level element),
+  // we want to compare the top level id of fullElemID.
+  // If it is a field we want to compare the base id.
   const { parent, path } = rootElement.elemID.isTopLevel()
     ? fullElemID.createTopLevelParentID()
     : fullElemID.createBaseID()

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -647,10 +647,14 @@ export const getPath = (
   rootElement: Element,
   fullElemID: ElemID,
 ): string[] | undefined => {
-  const { parent, path } = fullElemID.createTopLevelParentID()
+  const { parent, path } = rootElement.elemID.isTopLevel()
+    ? fullElemID.createTopLevelParentID()
+    : fullElemID.createBaseID()
+
   if (!parent.isEqual(rootElement.elemID)) return undefined
   if (_.isEmpty(path)) return []
-  if (fullElemID.isAttrID()) {
+  if (fullElemID.isAttrID()
+  || (fullElemID.idType === 'field' && fullElemID.getFullNameParts().length > 4)) {
     return ['annotations', ...path]
   }
   if (isInstanceElement(rootElement) && fullElemID.idType === 'instance') {

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -653,19 +653,19 @@ export const getPath = (
 
   if (!parent.isEqual(rootElement.elemID)) return undefined
   if (_.isEmpty(path)) return []
-  if (fullElemID.isAttrID()
-  || (fullElemID.idType === 'field' && fullElemID.getFullNameParts().length > 4)) {
+  if (fullElemID.isAttrID()) {
     return ['annotations', ...path]
   }
   if (isInstanceElement(rootElement) && fullElemID.idType === 'instance') {
     return ['value', ...path]
   }
 
-  if (isObjectType(rootElement) && fullElemID.idType === 'field') {
-    const fieldName = path[0]
-    const fieldAnnoPath = path.slice(1)
-    if (_.isEmpty(fieldAnnoPath)) return ['fields', fieldName]
-    return ['fields', fieldName, 'annotations', ...fieldAnnoPath]
+  if (fullElemID.idType === 'field') {
+    const fieldAnnotations = isObjectType(rootElement) ? path.slice(1) : path
+    const fieldAnnotationsPart = ['annotations', ...fieldAnnotations]
+    const objectPart = isObjectType(rootElement) ? ['fields', path[0]] : []
+
+    return _.isEmpty(fieldAnnotations) ? objectPart : [...objectPart, ...fieldAnnotationsPart]
   }
 
   if (isType(rootElement) && fullElemID.isAnnotationTypeID()) {

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -1534,6 +1534,12 @@ describe('Test utils.ts', () => {
       expect(clonedMockInstance.value.str).toEqual('new val')
     })
 
+    it('should set field annotation', () => {
+      const clonedMockField = new Field(mockType, 'field', BuiltinTypes.STRING)
+      setPath(clonedMockField, clonedMockField.elemID.createNestedID('str'), 'new val')
+      expect(clonedMockField.annotations.str).toEqual('new val')
+    })
+
     it('should unset an instance value path', () => {
       const clonedMockInstance = mockInstance.clone()
       setPath(clonedMockInstance, clonedMockInstance.elemID.createNestedID('str'), undefined)

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -35,6 +35,7 @@ import {
   elementExpressionStringifyReplacer,
   createSchemeGuard,
   getParent,
+  getPath,
 } from '../src/utils'
 import { buildElementsSourceFromElements } from '../src/element_source'
 
@@ -1489,6 +1490,14 @@ describe('Test utils.ts', () => {
         expect(transformedChange.data.before).toEqual('changed')
         expect(transformedChange.data.after).toEqual('changed')
       })
+    })
+  })
+
+  describe('getPath', () => {
+    it('should get annotations inside fields', () => {
+      const clonedMockField = new Field(mockType, 'field', BuiltinTypes.STRING, { str: 'val' })
+      const annoPath = getPath(clonedMockField, clonedMockField.elemID.createNestedID('str'))
+      expect(annoPath).toEqual(['annotations', 'str'])
     })
   })
 


### PR DESCRIPTION
Fixed getPath to work with fields and the rootElement

---
_Release Notes_: 
None (no effect on users currently)

---
_User Notifications_: 
None