### PR TITLE
SALTO-3669/user list permission failure

### DIFF
--- a/packages/jira-adapter/.vscode/launch.json
+++ b/packages/jira-adapter/.vscode/launch.json
@@ -13,7 +13,9 @@
         "${workspaceRoot}/node_modules/.bin/jest",
         "--runInBand",
         "--config",
-        "${workspaceRoot}/jest.config.js"
+        "${workspaceRoot}/jest.config.js",
+        "-t",
+        "issue type scheme validator"
       ],
       "outFiles": [],
       "console": "integratedTerminal",

--- a/packages/jira-adapter/.vscode/launch.json
+++ b/packages/jira-adapter/.vscode/launch.json
@@ -13,9 +13,7 @@
         "${workspaceRoot}/node_modules/.bin/jest",
         "--runInBand",
         "--config",
-        "${workspaceRoot}/jest.config.js",
-        "-t",
-        "issue type scheme validator"
+        "${workspaceRoot}/jest.config.js"
       ],
       "outFiles": [],
       "console": "integratedTerminal",

--- a/packages/jira-adapter/src/change_validators/account_id.ts
+++ b/packages/jira-adapter/src/change_validators/account_id.ts
@@ -255,7 +255,6 @@ export const accountIdValidator: (
         userMap = getUsersMapByVisibleId(await getUserMapFunc(), client.isDataCenter)
       } catch (e) {
         if (e instanceof MissingUsersPermissionError) {
-          config.fetch.convertUsersIds = false
           return []
         }
         throw e

--- a/packages/jira-adapter/src/change_validators/account_id.ts
+++ b/packages/jira-adapter/src/change_validators/account_id.ts
@@ -20,7 +20,7 @@ import { logger } from '@salto-io/logging'
 import { walkOnElement } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { isDeployableAccountIdType, walkOnUsers, WalkOnUsersCallback } from '../filters/account_id/account_id_filter'
-import { getUserIdFromEmail, GetUserMapFunc, getUsersMapByVisibleId, JiraClientError, UserMap } from '../users'
+import { getUserIdFromEmail, GetUserMapFunc, getUsersMapByVisibleId, MissingUsersPermissionError, UserMap } from '../users'
 import { JiraConfig } from '../config/config'
 import JiraClient from '../client/client'
 import { JIRA_USERS_PAGE, PERMISSION_SCHEME_TYPE_NAME } from '../constants'
@@ -254,7 +254,7 @@ export const accountIdValidator: (
       try {
         userMap = getUsersMapByVisibleId(await getUserMapFunc(), client.isDataCenter)
       } catch (e) {
-        if (e instanceof JiraClientError) {
+        if (e instanceof MissingUsersPermissionError) {
           config.fetch.convertUsersIds = false
           return []
         }

--- a/packages/jira-adapter/src/change_validators/account_id.ts
+++ b/packages/jira-adapter/src/change_validators/account_id.ts
@@ -20,7 +20,7 @@ import { logger } from '@salto-io/logging'
 import { walkOnElement } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { isDeployableAccountIdType, walkOnUsers, WalkOnUsersCallback } from '../filters/account_id/account_id_filter'
-import { getUserIdFromEmail, GetUserMapFunc, getUsersMapByVisibleId, UserMap } from '../users'
+import { getUserIdFromEmail, GetUserMapFunc, getUsersMapByVisibleId, JiraClientError, UserMap } from '../users'
 import { JiraConfig } from '../config/config'
 import JiraClient from '../client/client'
 import { JIRA_USERS_PAGE, PERMISSION_SCHEME_TYPE_NAME } from '../constants'
@@ -246,11 +246,20 @@ export const accountIdValidator: (
 ) =>
   ChangeValidator = (client, config, getUserMapFunc) => async changes =>
     log.time(async () => {
+      let userMap: UserMap
       if (!(config.fetch.convertUsersIds ?? true)) {
         return []
       }
       const { baseUrl, isDataCenter } = client
-      const userMap = getUsersMapByVisibleId(await getUserMapFunc(), client.isDataCenter)
+      try {
+        userMap = getUsersMapByVisibleId(await getUserMapFunc(), client.isDataCenter)
+      } catch (e) {
+        if (e instanceof JiraClientError) {
+          config.fetch.convertUsersIds = false
+          return []
+        }
+        throw e
+      }
 
       const defaultUserExist = doesDefaultUserExist(config.deploy.defaultMissingUserFallback, userMap, isDataCenter)
       return changes

--- a/packages/jira-adapter/src/change_validators/wrong_user_permission_scheme.ts
+++ b/packages/jira-adapter/src/change_validators/wrong_user_permission_scheme.ts
@@ -19,7 +19,7 @@ import { JIRA_USERS_PAGE, PERMISSION_SCHEME_TYPE_NAME } from '../constants'
 import JiraClient from '../client/client'
 import { JiraConfig } from '../config/config'
 import { wrongUserPermissionSchemePredicateCreator } from '../filters/permission_scheme/wrong_user_permission_scheme_filter'
-import { GetUserMapFunc, getUsersMapByVisibleId } from '../users'
+import { GetUserMapFunc, getUsersMapByVisibleId, JiraClientError, UserMap } from '../users'
 
 
 const createChangeError = (
@@ -47,11 +47,20 @@ export const wrongUserPermissionSchemeValidator: (
   config: JiraConfig,
   getUserMapFunc: GetUserMapFunc
   ) => ChangeValidator = (client, config, getUserMapFunc) => async changes => {
+    let userMap: UserMap
     if (!(config.fetch.convertUsersIds ?? true)) {
       return []
     }
     const { baseUrl } = client
-    const userMap = getUsersMapByVisibleId(await getUserMapFunc(), client.isDataCenter)
+    try {
+      userMap = getUsersMapByVisibleId(await getUserMapFunc(), client.isDataCenter)
+    } catch (e) {
+      if (e instanceof JiraClientError) {
+        config.fetch.convertUsersIds = false
+        return []
+      }
+      throw e
+    }
 
     const wrongUserPermissionSchemePredicate = wrongUserPermissionSchemePredicateCreator(userMap)
     return changes

--- a/packages/jira-adapter/src/change_validators/wrong_user_permission_scheme.ts
+++ b/packages/jira-adapter/src/change_validators/wrong_user_permission_scheme.ts
@@ -56,7 +56,6 @@ export const wrongUserPermissionSchemeValidator: (
       userMap = getUsersMapByVisibleId(await getUserMapFunc(), client.isDataCenter)
     } catch (e) {
       if (e instanceof MissingUsersPermissionError) {
-        config.fetch.convertUsersIds = false
         return []
       }
       throw e

--- a/packages/jira-adapter/src/change_validators/wrong_user_permission_scheme.ts
+++ b/packages/jira-adapter/src/change_validators/wrong_user_permission_scheme.ts
@@ -19,7 +19,7 @@ import { JIRA_USERS_PAGE, PERMISSION_SCHEME_TYPE_NAME } from '../constants'
 import JiraClient from '../client/client'
 import { JiraConfig } from '../config/config'
 import { wrongUserPermissionSchemePredicateCreator } from '../filters/permission_scheme/wrong_user_permission_scheme_filter'
-import { GetUserMapFunc, getUsersMapByVisibleId, JiraClientError, UserMap } from '../users'
+import { GetUserMapFunc, getUsersMapByVisibleId, MissingUsersPermissionError, UserMap } from '../users'
 
 
 const createChangeError = (
@@ -55,7 +55,7 @@ export const wrongUserPermissionSchemeValidator: (
     try {
       userMap = getUsersMapByVisibleId(await getUserMapFunc(), client.isDataCenter)
     } catch (e) {
-      if (e instanceof JiraClientError) {
+      if (e instanceof MissingUsersPermissionError) {
         config.fetch.convertUsersIds = false
         return []
       }

--- a/packages/jira-adapter/src/filters/account_id/user_fallback_filter.ts
+++ b/packages/jira-adapter/src/filters/account_id/user_fallback_filter.ts
@@ -63,7 +63,6 @@ const filter: FilterCreator = ({ client, config, getUserMapFunc }) => {
         userMap = getUsersMapByVisibleId(await getUserMapFunc(), client.isDataCenter)
       } catch (e) {
         if (e instanceof MissingUsersPermissionError) {
-          config.fetch.convertUsersIds = false
           return
         }
         throw e

--- a/packages/jira-adapter/src/filters/account_id/user_fallback_filter.ts
+++ b/packages/jira-adapter/src/filters/account_id/user_fallback_filter.ts
@@ -21,7 +21,7 @@ import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { FilterCreator } from '../../filter'
 import { walkOnUsers } from './account_id_filter'
-import { getCurrentUserInfo, getUserIdFromEmail, getUsersMapByVisibleId, JiraClientError, UserMap } from '../../users'
+import { getCurrentUserInfo, getUserIdFromEmail, getUsersMapByVisibleId, MissingUsersPermissionError, UserMap } from '../../users'
 import JiraClient from '../../client/client'
 
 const log = logger(module)
@@ -62,7 +62,7 @@ const filter: FilterCreator = ({ client, config, getUserMapFunc }) => {
       try {
         userMap = getUsersMapByVisibleId(await getUserMapFunc(), client.isDataCenter)
       } catch (e) {
-        if (e instanceof JiraClientError) {
+        if (e instanceof MissingUsersPermissionError) {
           config.fetch.convertUsersIds = false
           return
         }

--- a/packages/jira-adapter/src/filters/account_id/user_fallback_filter.ts
+++ b/packages/jira-adapter/src/filters/account_id/user_fallback_filter.ts
@@ -56,7 +56,7 @@ const filter: FilterCreator = ({ client, config, getUserMapFunc }) => {
     name: 'userFallbackFilter',
     preDeploy: async changes => {
       let userMap: UserMap
-      if (config.deploy.defaultMissingUserFallback === undefined || (config.fetch.convertUsersIds ?? true)) {
+      if (config.deploy.defaultMissingUserFallback === undefined) {
         return
       }
       try {

--- a/packages/jira-adapter/src/filters/account_id/user_id_filter.ts
+++ b/packages/jira-adapter/src/filters/account_id/user_id_filter.ts
@@ -64,7 +64,6 @@ const filter: FilterCreator = ({ client, config, getUserMapFunc }) => ({
       fetchUserMap = await getUserMapFunc()
     } catch (e) {
       if (e instanceof MissingUsersPermissionError) {
-        config.fetch.convertUsersIds = false
         return
       }
       throw e
@@ -92,7 +91,6 @@ const filter: FilterCreator = ({ client, config, getUserMapFunc }) => ({
       )
     } catch (e) {
       if (e instanceof MissingUsersPermissionError) {
-        config.fetch.convertUsersIds = false
         return
       }
       throw e
@@ -117,7 +115,6 @@ const filter: FilterCreator = ({ client, config, getUserMapFunc }) => ({
       deployUserMap = await getUserMapFunc()
     } catch (e) {
       if (e instanceof MissingUsersPermissionError) {
-        config.fetch.convertUsersIds = false
         return
       }
       throw e

--- a/packages/jira-adapter/src/filters/account_id/user_id_filter.ts
+++ b/packages/jira-adapter/src/filters/account_id/user_id_filter.ts
@@ -20,7 +20,7 @@ import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { FilterCreator } from '../../filter'
 import { walkOnUsers, WalkOnUsersCallback } from './account_id_filter'
-import { JiraClientError, UserMap } from '../../users'
+import { MissingUsersPermissionError, UserMap } from '../../users'
 import { PROJECT_TYPE } from '../../constants'
 
 const { awu } = collections.asynciterable
@@ -63,7 +63,7 @@ const filter: FilterCreator = ({ client, config, getUserMapFunc }) => ({
     try {
       fetchUserMap = await getUserMapFunc()
     } catch (e) {
-      if (e instanceof JiraClientError) {
+      if (e instanceof MissingUsersPermissionError) {
         config.fetch.convertUsersIds = false
         return
       }
@@ -91,7 +91,7 @@ const filter: FilterCreator = ({ client, config, getUserMapFunc }) => ({
         userInfo => userInfo.username as string
       )
     } catch (e) {
-      if (e instanceof JiraClientError) {
+      if (e instanceof MissingUsersPermissionError) {
         config.fetch.convertUsersIds = false
         return
       }
@@ -116,7 +116,7 @@ const filter: FilterCreator = ({ client, config, getUserMapFunc }) => ({
     try {
       deployUserMap = await getUserMapFunc()
     } catch (e) {
-      if (e instanceof JiraClientError) {
+      if (e instanceof MissingUsersPermissionError) {
         config.fetch.convertUsersIds = false
         return
       }

--- a/packages/jira-adapter/src/filters/permission_scheme/wrong_user_permission_scheme_filter.ts
+++ b/packages/jira-adapter/src/filters/permission_scheme/wrong_user_permission_scheme_filter.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { Change, ChangeDataType } from '@salto-io/adapter-api'
-import { getUsersMapByVisibleId, JiraClientError, UserMap } from '../../users'
+import { getUsersMapByVisibleId, MissingUsersPermissionError, UserMap } from '../../users'
 import { FilterCreator } from '../../filter'
 import { omitChanges, OmitChangesPredicate, addBackPermissions, PermissionHolder } from './omit_permissions_common'
 
@@ -46,7 +46,7 @@ const filter: FilterCreator = ({ config, client, getUserMapFunc }) => {
       try {
         userMap = getUsersMapByVisibleId(await getUserMapFunc(), client.isDataCenter)
       } catch (e) {
-        if (e instanceof JiraClientError) {
+        if (e instanceof MissingUsersPermissionError) {
           config.fetch.convertUsersIds = false
           return
         }

--- a/packages/jira-adapter/src/filters/permission_scheme/wrong_user_permission_scheme_filter.ts
+++ b/packages/jira-adapter/src/filters/permission_scheme/wrong_user_permission_scheme_filter.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { Change, ChangeDataType } from '@salto-io/adapter-api'
-import { getUsersMapByVisibleId, UserMap } from '../../users'
+import { getUsersMapByVisibleId, JiraClientError, UserMap } from '../../users'
 import { FilterCreator } from '../../filter'
 import { omitChanges, OmitChangesPredicate, addBackPermissions, PermissionHolder } from './omit_permissions_common'
 
@@ -39,10 +39,19 @@ const filter: FilterCreator = ({ config, client, getUserMapFunc }) => {
   return ({
     name: 'wrongUserPermissionSchemeFilter',
     preDeploy: async (changes: Change<ChangeDataType>[]) => {
+      let userMap: UserMap
       if (!(config.fetch.convertUsersIds ?? true)) {
         return
       }
-      const userMap = getUsersMapByVisibleId(await getUserMapFunc(), client.isDataCenter)
+      try {
+        userMap = getUsersMapByVisibleId(await getUserMapFunc(), client.isDataCenter)
+      } catch (e) {
+        if (e instanceof JiraClientError) {
+          config.fetch.convertUsersIds = false
+          return
+        }
+        throw e
+      }
 
       erroneousPermissionSchemes = omitChanges(
         changes,

--- a/packages/jira-adapter/src/filters/permission_scheme/wrong_user_permission_scheme_filter.ts
+++ b/packages/jira-adapter/src/filters/permission_scheme/wrong_user_permission_scheme_filter.ts
@@ -47,7 +47,6 @@ const filter: FilterCreator = ({ config, client, getUserMapFunc }) => {
         userMap = getUsersMapByVisibleId(await getUserMapFunc(), client.isDataCenter)
       } catch (e) {
         if (e instanceof MissingUsersPermissionError) {
-          config.fetch.convertUsersIds = false
           return
         }
         throw e

--- a/packages/jira-adapter/src/users.ts
+++ b/packages/jira-adapter/src/users.ts
@@ -16,7 +16,7 @@
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { createSchemeGuard } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
-import { collections, decorators } from '@salto-io/lowerdash'
+import { collections } from '@salto-io/lowerdash'
 import Joi from 'joi'
 import _ from 'lodash'
 import JiraClient from './client/client'

--- a/packages/jira-adapter/src/users.ts
+++ b/packages/jira-adapter/src/users.ts
@@ -136,6 +136,7 @@ export const getUserMapFuncCreator = (paginator: clientUtils.Paginator, isDataCe
           .map(userInfo => [userInfo.userId, userInfo]))
       } catch (e) {
         if (isMissingUserPermissionError(e)) {
+          log.error('Failed to get users map due to missing permissions.')
           throw new MissingUsersPermissionError(e)
         }
         throw e

--- a/packages/jira-adapter/test/change_validators/account_id.test.ts
+++ b/packages/jira-adapter/test/change_validators/account_id.test.ts
@@ -13,25 +13,144 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { toChange, InstanceElement, ElemID, ChangeError, ChangeValidator } from '@salto-io/adapter-api'
-import { config as configUtils, client as clientUtils } from '@salto-io/adapter-components'
+import { toChange, InstanceElement, ElemID, ChangeError } from '@salto-io/adapter-api'
+import { config as configUtils } from '@salto-io/adapter-components'
 import _ from 'lodash'
-import { MockInterface } from '@salto-io/test-utils'
-import JiraClient from '../../src/client/client'
 import { mockClient } from '../utils'
 import { accountIdValidator } from '../../src/change_validators/account_id'
 import * as common from '../filters/account_id/account_id_common'
 import { getDefaultConfig } from '../../src/config/config'
-import { GetUserMapFunc } from '../../src/users'
 
 describe('accountIdValidator', () => {
-  let connection: MockInterface<clientUtils.APIConnection>
-  let validator: ChangeValidator
-  let instances: InstanceElement[] = []
-  let url: string
-  let client: JiraClient
-  let getUserMapFunc: GetUserMapFunc
+  const { client, connection, getUserMapFunc } = mockClient()
   const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+  const validator = accountIdValidator(client, config, getUserMapFunc)
+  const url = `${client.baseUrl}jira/people/search`
+  let instances: InstanceElement[] = []
+  connection.get.mockResolvedValue({
+    status: 200,
+    data: [{
+      accountId: '0',
+      displayName: 'disp0',
+      locale: 'en_US',
+      emailAddress: 'email0',
+    }, {
+      accountId: '0n',
+      displayName: 'disp0n',
+      locale: 'en_US',
+      emailAddress: 'email0n',
+    }, {
+      accountId: '00',
+      displayName: 'disp00',
+      locale: 'en_US',
+      emailAddress: 'email00',
+    }, {
+      accountId: '00n',
+      displayName: 'disp00n',
+      locale: 'en_US',
+      emailAddress: 'email00n',
+    }, {
+      accountId: '0l',
+      displayName: 'disp0l',
+      locale: 'en_US',
+      emailAddress: 'email0l',
+    }, {
+      accountId: '0an',
+      displayName: 'disp0an',
+      locale: 'en_US',
+      emailAddress: 'email0an',
+    }, {
+      accountId: '0h',
+      displayName: 'disp0h',
+      locale: 'en_US',
+      emailAddress: 'email0h',
+    }, {
+      accountId: '0list1',
+      displayName: 'disp0list1',
+      locale: 'en_US',
+      emailAddress: 'email0list1',
+    }, {
+      accountId: '0list2',
+      displayName: 'disp0list2',
+      locale: 'en_US',
+      emailAddress: 'email0list2',
+    }, {
+      accountId: '1',
+      displayName: 'disp1',
+      locale: 'en_US',
+      emailAddress: 'email1',
+    }, {
+      accountId: '1n',
+      displayName: 'disp1n',
+      locale: 'en_US',
+      emailAddress: 'email1n',
+    }, {
+      accountId: '11',
+      displayName: 'disp11',
+      locale: 'en_US',
+      emailAddress: 'email11',
+    }, {
+      accountId: '11n',
+      displayName: 'disp11n',
+      locale: 'en_US',
+      emailAddress: 'email11n',
+    }, {
+      accountId: '1l',
+      displayName: 'disp1l',
+      locale: 'en_US',
+      emailAddress: 'email1l',
+    }, {
+      accountId: '1an',
+      displayName: 'disp1an',
+      locale: 'en_US',
+      emailAddress: 'email1an',
+    }, {
+      accountId: '1h',
+      displayName: 'disp1h',
+      locale: 'en_US',
+      emailAddress: 'email1h',
+    }, {
+      accountId: '1list1',
+      displayName: 'disp1list1',
+      locale: 'en_US',
+      emailAddress: 'email1list1',
+    }, {
+      accountId: '1list2',
+      displayName: 'disp1list2',
+      locale: 'en_US',
+      emailAddress: 'email1list2',
+    }, {
+      accountId: '0owner',
+      displayName: 'disp0owner',
+      locale: 'en_US',
+      emailAddress: 'email0owner',
+    }, {
+      accountId: '1list2',
+      displayName: 'disp1list2',
+      locale: 'en_US',
+      emailAddress: 'email1list2',
+    }, {
+      accountId: '0Ids1',
+      displayName: 'disp0Ids1',
+      locale: 'en_US',
+      emailAddress: 'email0Ids1',
+    }, {
+      accountId: '0Ids2',
+      displayName: 'disp0Ids2',
+      locale: 'en_US',
+      emailAddress: 'email0Ids2',
+    }, {
+      accountId: '1Ids1',
+      displayName: 'disp1Ids1',
+      locale: 'en_US',
+      emailAddress: 'email1Ids1',
+    }, {
+      accountId: '1Ids2',
+      displayName: 'disp1Ids2',
+      locale: 'en_US',
+      emailAddress: 'email1Ids2',
+    }],
+  })
 
   const createInfo = (elemId: ElemID):ChangeError => ({
     elemID: elemId,
@@ -62,137 +181,6 @@ Go to ${url} to see valid users and account IDs.`,
   })
 
   beforeEach(() => {
-    jest.clearAllMocks()
-    const { client: mockedClient, connection: mockedConnection, getUserMapFunc: mockedUserMapFunc } = mockClient()
-    getUserMapFunc = mockedUserMapFunc
-    client = mockedClient
-    connection = mockedConnection
-    validator = accountIdValidator(client, config, getUserMapFunc)
-    url = `${client.baseUrl}jira/people/search`
-    connection.get.mockResolvedValue({
-      status: 200,
-      data: [{
-        accountId: '0',
-        displayName: 'disp0',
-        locale: 'en_US',
-        emailAddress: 'email0',
-      }, {
-        accountId: '0n',
-        displayName: 'disp0n',
-        locale: 'en_US',
-        emailAddress: 'email0n',
-      }, {
-        accountId: '00',
-        displayName: 'disp00',
-        locale: 'en_US',
-        emailAddress: 'email00',
-      }, {
-        accountId: '00n',
-        displayName: 'disp00n',
-        locale: 'en_US',
-        emailAddress: 'email00n',
-      }, {
-        accountId: '0l',
-        displayName: 'disp0l',
-        locale: 'en_US',
-        emailAddress: 'email0l',
-      }, {
-        accountId: '0an',
-        displayName: 'disp0an',
-        locale: 'en_US',
-        emailAddress: 'email0an',
-      }, {
-        accountId: '0h',
-        displayName: 'disp0h',
-        locale: 'en_US',
-        emailAddress: 'email0h',
-      }, {
-        accountId: '0list1',
-        displayName: 'disp0list1',
-        locale: 'en_US',
-        emailAddress: 'email0list1',
-      }, {
-        accountId: '0list2',
-        displayName: 'disp0list2',
-        locale: 'en_US',
-        emailAddress: 'email0list2',
-      }, {
-        accountId: '1',
-        displayName: 'disp1',
-        locale: 'en_US',
-        emailAddress: 'email1',
-      }, {
-        accountId: '1n',
-        displayName: 'disp1n',
-        locale: 'en_US',
-        emailAddress: 'email1n',
-      }, {
-        accountId: '11',
-        displayName: 'disp11',
-        locale: 'en_US',
-        emailAddress: 'email11',
-      }, {
-        accountId: '11n',
-        displayName: 'disp11n',
-        locale: 'en_US',
-        emailAddress: 'email11n',
-      }, {
-        accountId: '1l',
-        displayName: 'disp1l',
-        locale: 'en_US',
-        emailAddress: 'email1l',
-      }, {
-        accountId: '1an',
-        displayName: 'disp1an',
-        locale: 'en_US',
-        emailAddress: 'email1an',
-      }, {
-        accountId: '1h',
-        displayName: 'disp1h',
-        locale: 'en_US',
-        emailAddress: 'email1h',
-      }, {
-        accountId: '1list1',
-        displayName: 'disp1list1',
-        locale: 'en_US',
-        emailAddress: 'email1list1',
-      }, {
-        accountId: '1list2',
-        displayName: 'disp1list2',
-        locale: 'en_US',
-        emailAddress: 'email1list2',
-      }, {
-        accountId: '0owner',
-        displayName: 'disp0owner',
-        locale: 'en_US',
-        emailAddress: 'email0owner',
-      }, {
-        accountId: '1list2',
-        displayName: 'disp1list2',
-        locale: 'en_US',
-        emailAddress: 'email1list2',
-      }, {
-        accountId: '0Ids1',
-        displayName: 'disp0Ids1',
-        locale: 'en_US',
-        emailAddress: 'email0Ids1',
-      }, {
-        accountId: '0Ids2',
-        displayName: 'disp0Ids2',
-        locale: 'en_US',
-        emailAddress: 'email0Ids2',
-      }, {
-        accountId: '1Ids1',
-        displayName: 'disp1Ids1',
-        locale: 'en_US',
-        emailAddress: 'email1Ids1',
-      }, {
-        accountId: '1Ids2',
-        displayName: 'disp1Ids2',
-        locale: 'en_US',
-        emailAddress: 'email1Ids2',
-      }],
-    })
     const objectType = common.createObjectedType('NotificationScheme') // passes all conditions
     instances = common.createInstanceElementArrayWithDisplayNames(2, objectType)
   })
@@ -394,16 +382,16 @@ Go to ${url} to see valid users and account IDs.`,
     let validUserInstance: InstanceElement
     let invalidUserInstance: InstanceElement
     const objectType = common.createObjectedType('NotificationScheme') // passes all conditions
+    connectionDC.get.mockResolvedValue({
+      status: 200,
+      data: [{
+        key: 'JIRAUSER10000',
+        name: 'firstAccount',
+        displayName: 'firstAccountDisplayName',
+      }],
+    })
 
     beforeEach(() => {
-      connectionDC.get.mockResolvedValue({
-        status: 200,
-        data: [{
-          key: 'JIRAUSER10000',
-          name: 'firstAccount',
-          displayName: 'firstAccountDisplayName',
-        }],
-      })
       validUserInstance = new InstanceElement(
         'instance',
         objectType,
@@ -443,22 +431,6 @@ Go to ${url} to see valid users and account IDs.`,
         },
       )
     })
-    // it('should not raise an error on missing user permission', async () => {
-    //   connectionDC.get.mockResolvedValue({
-    //     status: 403,
-    //     data: [{
-    //       key: 'JIRAUSER10000',
-    //       name: 'firstAccount',
-    //       displayName: 'firstAccountDisplayName',
-    //     }],
-    //   })
-    //   const changeErrors = await validatorDC([
-    //     toChange({
-    //       after: validUserInstance,
-    //     }),
-    //   ])
-    //   expect(changeErrors).toEqual([])
-    // })
     it('should not raise an error when instance does not have DisplayName', async () => {
       const changeErrors = await validatorDC([
         toChange({

--- a/packages/jira-adapter/test/change_validators/account_id.test.ts
+++ b/packages/jira-adapter/test/change_validators/account_id.test.ts
@@ -20,7 +20,6 @@ import { mockClient } from '../utils'
 import { accountIdValidator } from '../../src/change_validators/account_id'
 import * as common from '../filters/account_id/account_id_common'
 import { getDefaultConfig } from '../../src/config/config'
-import { MissingUsersPermissionError } from '../../src/users'
 
 describe('accountIdValidator', () => {
   const { client, connection, getUserMapFunc } = mockClient()
@@ -193,16 +192,10 @@ Go to ${url} to see valid users and account IDs.`,
     expect(connection.get).toHaveBeenCalledOnce()
   })
 
-  it('should not fail on missing permission error', async () => {
-    const mockedGetUserMapFunc = jest.fn().mockRejectedValue(new MissingUsersPermissionError('Missing permission'))
+  it('should not fail on when user map func returned undefined', async () => {
+    const mockedGetUserMapFunc = jest.fn().mockResolvedValue(undefined)
     const validator2 = accountIdValidator(client, config, mockedGetUserMapFunc)
     await expect(validator2([toChange({ after: instances[1] })])).resolves.not.toThrow()
-  })
-
-  it('should fail on other errors', async () => {
-    const mockedGetUserMapFunc = jest.fn().mockRejectedValue(new Error('Missing permission'))
-    const validator2 = accountIdValidator(client, config, mockedGetUserMapFunc)
-    await expect(validator2([toChange({ after: instances[1] })])).rejects.toThrow()
   })
 
   it('should return an info when there is no display name', async () => {
@@ -452,15 +445,10 @@ Go to ${url} to see valid users and account IDs.`,
       ])
       expect(changeErrors).toEqual([])
     })
-    it('should not fail on missing permission error', async () => {
-      const mockedGetUserMapFunc = jest.fn().mockRejectedValue(new MissingUsersPermissionError('Missing permission'))
+    it('should not fail when user map func returns undefined', async () => {
+      const mockedGetUserMapFunc = jest.fn().mockResolvedValue(undefined)
       const validator2 = accountIdValidator(clientDC, configDC, mockedGetUserMapFunc)
       await expect(validator2([toChange({ after: instances[1] })])).resolves.not.toThrow()
-    })
-    it('should fail on other errors', async () => {
-      const mockedGetUserMapFunc = jest.fn().mockRejectedValue(new Error('Missing permission'))
-      const validator2 = accountIdValidator(clientDC, configDC, mockedGetUserMapFunc)
-      await expect(validator2([toChange({ after: instances[1] })])).rejects.toThrow()
     })
     it('should raise an error when accountId does not exist in the target environment', async () => {
       const changeErrors = await validatorDC([

--- a/packages/jira-adapter/test/change_validators/wrong_user_permission_scheme.test.ts
+++ b/packages/jira-adapter/test/change_validators/wrong_user_permission_scheme.test.ts
@@ -19,7 +19,6 @@ import { mockClient } from '../utils'
 import { getDefaultConfig } from '../../src/config/config'
 import { JIRA, PERMISSION_SCHEME_TYPE_NAME } from '../../src/constants'
 import { wrongUserPermissionSchemeValidator } from '../../src/change_validators/wrong_user_permission_scheme'
-import { MissingUsersPermissionError } from '../../src/users'
 
 describe('wrongUsersPermissionSchemeValidator', () => {
   const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
@@ -124,15 +123,9 @@ Check ${url} to see valid users and account IDs.`,
       changes
     )).toEqual([])
   })
-  it('should not fail on missing permission error', async () => {
-    const mockedGetUserMapFunc = jest.fn().mockRejectedValue(new MissingUsersPermissionError('Missing permission'))
+  it('should not fail when users map func returns undefined', async () => {
+    const mockedGetUserMapFunc = jest.fn().mockResolvedValue(undefined)
     const validator2 = wrongUserPermissionSchemeValidator(client, config, mockedGetUserMapFunc)
     await expect(validator2(changes)).resolves.not.toThrow()
-  })
-
-  it('should fail on other errors', async () => {
-    const mockedGetUserMapFunc = jest.fn().mockRejectedValue(new Error('Missing permission'))
-    const validator2 = wrongUserPermissionSchemeValidator(client, config, mockedGetUserMapFunc)
-    await expect(validator2(changes)).rejects.toThrow()
   })
 })

--- a/packages/jira-adapter/test/change_validators/wrong_user_permission_scheme.test.ts
+++ b/packages/jira-adapter/test/change_validators/wrong_user_permission_scheme.test.ts
@@ -19,6 +19,7 @@ import { mockClient } from '../utils'
 import { getDefaultConfig } from '../../src/config/config'
 import { JIRA, PERMISSION_SCHEME_TYPE_NAME } from '../../src/constants'
 import { wrongUserPermissionSchemeValidator } from '../../src/change_validators/wrong_user_permission_scheme'
+import { MissingUsersPermissionError } from '../../src/users'
 
 describe('wrongUsersPermissionSchemeValidator', () => {
   const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
@@ -122,5 +123,16 @@ Check ${url} to see valid users and account IDs.`,
     expect(await validatorOff(
       changes
     )).toEqual([])
+  })
+  it('should not fail on missing permission error', async () => {
+    const mockedGetUserMapFunc = jest.fn().mockRejectedValue(new MissingUsersPermissionError('Missing permission'))
+    const validator2 = wrongUserPermissionSchemeValidator(client, config, mockedGetUserMapFunc)
+    await expect(validator2(changes)).resolves.not.toThrow()
+  })
+
+  it('should fail on other errors', async () => {
+    const mockedGetUserMapFunc = jest.fn().mockRejectedValue(new Error('Missing permission'))
+    const validator2 = wrongUserPermissionSchemeValidator(client, config, mockedGetUserMapFunc)
+    await expect(validator2(changes)).rejects.toThrow()
   })
 })

--- a/packages/jira-adapter/test/filters/account_id/user_fallback_filter.test.ts
+++ b/packages/jira-adapter/test/filters/account_id/user_fallback_filter.test.ts
@@ -21,9 +21,7 @@ import { getFilterParams, mockClient } from '../../utils'
 import { getDefaultConfig, JiraConfig } from '../../../src/config/config'
 import userFallbackFilter from '../../../src/filters/account_id/user_fallback_filter'
 import { JIRA } from '../../../src/constants'
-import { MissingUsersPermissionError } from '../../../src/users'
 
-jest.setTimeout(1111111)
 describe('user_fallback_filter', () => {
   let mockConnection: MockInterface<clientUtils.APIConnection>
   let filter: filterUtils.FilterWith<'preDeploy' | 'onDeploy'>

--- a/packages/jira-adapter/test/filters/account_id/user_id_filter.test.ts
+++ b/packages/jira-adapter/test/filters/account_id/user_id_filter.test.ts
@@ -497,11 +497,31 @@ describe('convert userId to key in Jira DC', () => {
     })
     it('should not raise error when user permission is missing', async () => {
       mockConnection.get.mockRejectedValue(new clientUtils.HTTPError('failed', { data: {}, status: 403 }))
+      await expect(filter.onFetch([])).resolves.not.toThrow()
+    })
+    it('should raise error on any other error', async () => {
+      mockConnection.get.mockRejectedValue(new Error('failed'))
+      await expect(filter.onFetch([])).rejects.toThrow()
+    })
+  })
+  describe('pre deploy', () => {
+    it('should not raise error when user permission is missing', async () => {
+      mockConnection.get.mockRejectedValue(new clientUtils.HTTPError('failed', { data: {}, status: 403 }))
       await expect(filter.preDeploy([])).resolves.not.toThrow()
     })
     it('should raise error on any other error', async () => {
       mockConnection.get.mockRejectedValue(new Error('failed'))
       await expect(filter.preDeploy([])).rejects.toThrow()
+    })
+  })
+  describe('deploy', () => {
+    it('should not raise error when user permission is missing', async () => {
+      mockConnection.get.mockRejectedValue(new clientUtils.HTTPError('failed', { data: {}, status: 403 }))
+      await expect(filter.onDeploy([])).resolves.not.toThrow()
+    })
+    it('should raise error on any other error', async () => {
+      mockConnection.get.mockRejectedValue(new Error('failed'))
+      await expect(filter.onDeploy([])).rejects.toThrow()
     })
   })
 })

--- a/packages/jira-adapter/test/filters/account_id/user_id_filter.test.ts
+++ b/packages/jira-adapter/test/filters/account_id/user_id_filter.test.ts
@@ -495,5 +495,13 @@ describe('convert userId to key in Jira DC', () => {
       await filter.onDeploy([toChange({ after: instance })])
       common.checkInstanceUserIds(instance, '2', EMPTY_STRING)
     })
+    it('should not raise error when user permission is missing', async () => {
+      mockConnection.get.mockRejectedValue(new clientUtils.HTTPError('failed', { data: {}, status: 403 }))
+      await expect(filter.preDeploy([])).resolves.not.toThrow()
+    })
+    it('should raise error on any other error', async () => {
+      mockConnection.get.mockRejectedValue(new Error('failed'))
+      await expect(filter.preDeploy([])).rejects.toThrow()
+    })
   })
 })

--- a/packages/jira-adapter/test/filters/permission_scheme/wrong_user_permission_scheme_filter.test.ts
+++ b/packages/jira-adapter/test/filters/permission_scheme/wrong_user_permission_scheme_filter.test.ts
@@ -15,23 +15,30 @@
 */
 import { ElemID, InstanceElement, ObjectType, toChange, Change, Value } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { filterUtils } from '@salto-io/adapter-components'
+import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
+import { MockInterface } from '@salto-io/test-utils'
 import { getFilterParams, mockClient } from '../../utils'
 import wrongUserPermissionSchemeFilter from '../../../src/filters/permission_scheme/wrong_user_permission_scheme_filter'
 import { getDefaultConfig } from '../../../src/config/config'
 import { JIRA, PERMISSION_SCHEME_TYPE_NAME } from '../../../src/constants'
+import { GetUserMapFunc } from '../../../src/users'
 
 describe('wrongUsersPermissionSchemeFilter', () => {
   let instances: InstanceElement[]
   let changes: Change[]
-  const { getUserMapFunc, connection } = mockClient()
+  let filter: filterUtils.FilterWith<'preDeploy' | 'onDeploy'>
+  let mockConnection: MockInterface<clientUtils.APIConnection>
+  let mockUserMapFunc: GetUserMapFunc
   const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
-  const filter = wrongUserPermissionSchemeFilter(getFilterParams({
-    getUserMapFunc,
-    config,
-  })) as filterUtils.FilterWith<'preDeploy' | 'onDeploy'>
-
   beforeEach(async () => {
+    jest.clearAllMocks()
+    const { getUserMapFunc, connection } = mockClient()
+    mockConnection = connection
+    mockUserMapFunc = getUserMapFunc
+    filter = wrongUserPermissionSchemeFilter(getFilterParams({
+      getUserMapFunc: mockUserMapFunc,
+      config,
+    })) as filterUtils.FilterWith<'preDeploy' | 'onDeploy'>
     const type = new ObjectType({
       elemID: new ElemID(JIRA, PERMISSION_SCHEME_TYPE_NAME),
     })
@@ -92,11 +99,21 @@ describe('wrongUsersPermissionSchemeFilter', () => {
     expect(instances[0].value.permissions[1].holder.parameter.id).toEqual('id4')
     expect(instances[0].value.permissions[2].holder.parameter.id).toEqual('id5')
     expect(instances[0].value.permissions[3].wrong.anotherWrong).toEqual('anotherWrong')
-    expect(connection.get).toHaveBeenCalledOnce()
+    expect(mockConnection.get).toHaveBeenCalledOnce()
     expect(instances[1].value.permissions.length).toEqual(3)
     expect(instances[1].value.permissions[2].holder.parameter.id).toEqual('id1')
     expect(instances[1].value.permissions[1].holder.parameter.id).toEqual('id4')
     expect(instances[1].value.permissions[0].holder.parameter.id).toEqual('id5')
+  })
+  it('should not raise error on missing user permission', async () => {
+    config.deploy.defaultMissingUserFallback = 'name2'
+    mockConnection.get.mockRejectedValue(new clientUtils.HTTPError('failed', { data: {}, status: 403 }))
+    await expect(filter.preDeploy(changes)).resolves.not.toThrow()
+  })
+  it('should raise error on any other error', async () => {
+    config.deploy.defaultMissingUserFallback = 'name2'
+    mockConnection.get.mockRejectedValue(new Error('failed'))
+    await expect(filter.preDeploy(changes)).rejects.toThrow()
   })
   it('should return removed permissions in the right order', async () => {
     await filter.preDeploy(changes)

--- a/packages/jira-adapter/test/filters/permission_scheme/wrong_user_permission_scheme_filter.test.ts
+++ b/packages/jira-adapter/test/filters/permission_scheme/wrong_user_permission_scheme_filter.test.ts
@@ -106,12 +106,10 @@ describe('wrongUsersPermissionSchemeFilter', () => {
     expect(instances[1].value.permissions[0].holder.parameter.id).toEqual('id5')
   })
   it('should not raise error on missing user permission', async () => {
-    config.deploy.defaultMissingUserFallback = 'name2'
     mockConnection.get.mockRejectedValue(new clientUtils.HTTPError('failed', { data: {}, status: 403 }))
     await expect(filter.preDeploy(changes)).resolves.not.toThrow()
   })
   it('should raise error on any other error', async () => {
-    config.deploy.defaultMissingUserFallback = 'name2'
     mockConnection.get.mockRejectedValue(new Error('failed'))
     await expect(filter.preDeploy(changes)).rejects.toThrow()
   })


### PR DESCRIPTION
users without permission to view other members in the service will fail running "getUserMapFuncCreator"
this change will make this function throw a specific error when it happens and everywhere that uses this code is now expecting this error and fail gracefully

added a log when it happens.

---

_Additional context for reviewer_


---
_Release Notes_: 
jira adapter:
* Fixed bug where missing permissions to view other users will fail deploy/fetch

---
_User Notifications_: 

