### PR TITLE
SALTO-3050: Clear secrets from response data before writing to log

### DIFF
--- a/packages/okta-adapter/src/client/client.ts
+++ b/packages/okta-adapter/src/client/client.ts
@@ -13,7 +13,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import _ from 'lodash'
 import { client as clientUtils } from '@salto-io/adapter-components'
+import { Values } from '@salto-io/adapter-api'
 import { createConnection } from './connection'
 import { OKTA } from '../constants'
 import { Credentials } from '../auth'
@@ -32,6 +34,34 @@ const DEFAULT_MAX_REQUESTS_PER_MINUTE = 700
 
 const DEFAULT_PAGE_SIZE: Required<clientUtils.ClientPageSizeConfig> = {
   get: 50,
+}
+
+/**
+ * Clear response data values might contain secrets, returns a new object
+ */
+const clearSecrets = (
+  object: Values,
+  secretFieldNames: string[]
+): Values => {
+  const SECRET_PLACEHOLER = '<SECRET>'
+  const replaceValuesInplace = (values: Values): void => {
+    if (_.isPlainObject(values)) {
+      Object.keys(values).forEach(key => {
+        if (secretFieldNames.includes(key)) {
+          values[key] = SECRET_PLACEHOLER
+        } else if (_.isPlainObject(values[key]) || Array.isArray(values[key])) {
+          replaceValuesInplace(values[key])
+        }
+      })
+    }
+    if (Array.isArray(values)) {
+      values.forEach(item => replaceValuesInplace(item))
+    }
+  }
+
+  const clonedObject = _.cloneDeep(object)
+  replaceValuesInplace(clonedObject)
+  return clonedObject
 }
 
 export default class OktaClient extends clientUtils.AdapterHTTPClient<
@@ -53,5 +83,20 @@ export default class OktaClient extends clientUtils.AdapterHTTPClient<
         retry: { ...DEFAULT_RETRY_OPTS, retryDelay: 10000 },
       }
     )
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  protected clearValuesFromResponseData(
+    responseData: Values,
+    url: string
+  ): Values {
+    const URL_TO_SECRET_FIELDS: Record<string, string[]> = {
+      '/api/v1/idps': ['credentials'],
+      '/api/v1/authenticators': ['sharedSecret, secretKey'],
+    }
+    if (!Object.keys(URL_TO_SECRET_FIELDS).includes(url)) {
+      return responseData
+    }
+    return clearSecrets(responseData, URL_TO_SECRET_FIELDS[url])
   }
 }

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -623,14 +623,6 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
       ],
     },
   },
-  IdentityProviderCredentialsClient: {
-    transformation: {
-      fieldsToOmit: [
-        // we are not managing secrets
-        { fieldName: 'client_secret' },
-      ],
-    },
-  },
   AuthenticatorProviderConfiguration: {
     transformation: {
       fieldsToOmit: [


### PR DESCRIPTION
Clear secrets from response data before writing to log

---
_Release Notes_: 
None

---
_User Notifications_: 
None
