### PR TITLE
SALTO-3050: Clear secrets from response data before writing to log (adapter-components changes)

### DIFF
--- a/packages/adapter-components/src/client/http_client.ts
+++ b/packages/adapter-components/src/client/http_client.ts
@@ -17,6 +17,7 @@ import _ from 'lodash'
 import { ResponseType } from 'axios'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { values } from '@salto-io/lowerdash'
+import { Values } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { Connection, ConnectionCreator, createRetryOptions, createClientConnection, ResponseValue, Response } from './http_connection'
 import { AdapterClientBase } from './base'
@@ -125,6 +126,14 @@ export abstract class AdapterHTTPClient<
     }
   }
 
+  // eslint-disable-next-line class-methods-use-this
+  protected clearValuesFromResponseData(
+    responseData: Values,
+    _url: string,
+  ): Values {
+    return responseData
+  }
+
   /**
    * Get a single response
    */
@@ -199,7 +208,11 @@ export abstract class AdapterHTTPClient<
         )
       log.debug('Received response for %s on %s (%s) with status %d', method.toUpperCase(), url, safeJsonStringify({ url, queryParams }), res.status)
       log.trace('Full HTTP response for %s on %s: %s', method.toUpperCase(), url, safeJsonStringify({
-        url, queryParams, response: res.data, headers: res.headers, method: method.toUpperCase(),
+        url,
+        queryParams,
+        response: this.clearValuesFromResponseData(res.data, url),
+        headers: res.headers,
+        method: method.toUpperCase(),
       }))
       const { data, status, headers: responseHeaders } = res
       return {

--- a/packages/adapter-components/test/client/http_client.test.ts
+++ b/packages/adapter-components/test/client/http_client.test.ts
@@ -28,6 +28,7 @@ describe('client_http_client', () => {
   let mockCreateConnection: jest.MockedFunction<ConnectionCreator<Credentials>>
 
   beforeEach(() => {
+    jest.clearAllMocks()
     mockAxiosAdapter = new MockAdapter(axios, { delayResponse: 1, onNoMatch: 'throwException' })
     mockCreateConnection = jest.fn(createConnection)
   })
@@ -60,6 +61,8 @@ describe('client_http_client', () => {
     it('should make the right request', async () => {
       expect(mockCreateConnection).not.toHaveBeenCalled()
       const client = new MyCustomClient({ credentials: { username: 'user', password: 'password' } })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const clearValuesFromResponseDataFunc = jest.spyOn(MyCustomClient.prototype as any, 'clearValuesFromResponseData')
       expect(mockCreateConnection).toHaveBeenCalledTimes(1)
 
       mockAxiosAdapter.onGet('/users/me').reply(200, {
@@ -72,6 +75,9 @@ describe('client_http_client', () => {
       const getRes2 = await client.getSinglePage({ url: '/ep2', queryParams: { a: 'AAA' } })
       expect(getRes).toEqual({ data: { a: 'b' }, status: 200, headers: { h: '123' } })
       expect(getRes2).toEqual({ data: { c: 'd' }, status: 200, headers: { hh: 'header' } })
+      expect(clearValuesFromResponseDataFunc).toHaveBeenCalledTimes(2)
+      expect(clearValuesFromResponseDataFunc).toHaveBeenNthCalledWith(1, { a: 'b' }, '/ep')
+      expect(clearValuesFromResponseDataFunc).toHaveBeenNthCalledWith(2, { c: 'd' }, '/ep2')
     })
 
     it('should throw Unauthorized on login 401', async () => {
@@ -118,6 +124,8 @@ describe('client_http_client', () => {
       expect(mockCreateConnection).not.toHaveBeenCalled()
       const client = new MyCustomClient({ credentials: { username: 'user', password: 'password' } })
       expect(mockCreateConnection).toHaveBeenCalledTimes(1)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const clearValuesFromResponseDataFunc = jest.spyOn(MyCustomClient.prototype as any, 'clearValuesFromResponseData')
 
       mockAxiosAdapter.onGet('/users/me').reply(200, {
         accountId: 'ACCOUNT_ID',
@@ -126,6 +134,8 @@ describe('client_http_client', () => {
 
       const postRes = await client.post({ url: '/ep', data: 'someData' })
       expect(postRes).toEqual({ data: { a: 'b' }, status: 200 })
+      expect(clearValuesFromResponseDataFunc).toHaveBeenCalledTimes(1)
+      expect(clearValuesFromResponseDataFunc).toHaveBeenCalledWith({ a: 'b' }, '/ep')
     })
     it('should retry on given status codes', async () => {
       // The first replyOnce with 200 is for the client authentication
@@ -144,6 +154,8 @@ describe('client_http_client', () => {
       expect(mockCreateConnection).not.toHaveBeenCalled()
       const client = new MyCustomClient({ credentials: { username: 'user', password: 'password' } })
       expect(mockCreateConnection).toHaveBeenCalledTimes(1)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const clearValuesFromResponseDataFunc = jest.spyOn(MyCustomClient.prototype as any, 'clearValuesFromResponseData')
 
       mockAxiosAdapter.onGet('/users/me').reply(200, {
         accountId: 'ACCOUNT_ID',
@@ -152,6 +164,8 @@ describe('client_http_client', () => {
 
       const putRes = await client.put({ url: '/ep', data: 'someData' })
       expect(putRes).toEqual({ data: { a: 'b' }, status: 200 })
+      expect(clearValuesFromResponseDataFunc).toHaveBeenCalledTimes(1)
+      expect(clearValuesFromResponseDataFunc).toHaveBeenCalledWith({ a: 'b' }, '/ep')
     })
   })
 
@@ -160,6 +174,8 @@ describe('client_http_client', () => {
       expect(mockCreateConnection).not.toHaveBeenCalled()
       const client = new MyCustomClient({ credentials: { username: 'user', password: 'password' } })
       expect(mockCreateConnection).toHaveBeenCalledTimes(1)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const clearValuesFromResponseDataFunc = jest.spyOn(MyCustomClient.prototype as any, 'clearValuesFromResponseData')
 
       mockAxiosAdapter.onGet('/users/me').reply(200, {
         accountId: 'ACCOUNT_ID',
@@ -168,6 +184,8 @@ describe('client_http_client', () => {
 
       const getRes = await client.delete({ url: '/ep' })
       expect(getRes).toEqual({ data: { a: 'b' }, status: 200 })
+      expect(clearValuesFromResponseDataFunc).toHaveBeenCalledTimes(1)
+      expect(clearValuesFromResponseDataFunc).toHaveBeenCalledWith({ a: 'b' }, '/ep')
     })
   })
 


### PR DESCRIPTION
Just the adapter-components changes from https://github.com/salto-io/salto/pull/3997

---
_Release Notes_: 
None

---
_User Notifications_: 
None
