### PR TITLE
SALTO-3689 fix broken fetch operation

### DIFF
--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -375,7 +375,7 @@ type RunAdapterFetchFunctionParams = {
   adapter: AdapterOperations
   fetchOptions: FetchOptions
   adapterName: string
-  withChangeDetection?: boolean
+  withChangeDetection: boolean | undefined
 }
 
 const runAdapterFetchFunction = ({
@@ -463,7 +463,7 @@ const fetchAndProcessMergeErrors = async (
       (_adapter, accountName) => createAdapterProgressReporter(accountName, 'fetch', progressEmitter)
     )
     const fetchResults = await Promise.all(
-      Object.entries((accountsToAdapters))
+      Object.entries(accountsToAdapters)
         .map(async ([accountName, adapter]) => {
           const fetchOptions = { progressReporter: progressReporters[accountName] }
           const fetchResult = await runAdapterFetchFunction({

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -1155,14 +1155,6 @@ describe('fetch', () => {
           fetch: mockFetch,
           deploy: mockDeploy,
         },
-        adapter2WithoutFetchWithChangeDetection: {
-          fetch: mockFetch,
-          deploy: mockDeploy,
-        },
-        adapter3WithoutFetchWithChangeDetection: {
-          fetch: mockFetch,
-          deploy: mockDeploy,
-        },
       }
       it('should throw an error when run fetchWithChangeDetection with unsupported adapters', async () => {
         await expect(fetchChanges(
@@ -1171,13 +1163,11 @@ describe('fetch', () => {
           createElementSource([]),
           {
             adapterWithoutFetchWithChangeDetection: 'adapter1',
-            adapter2WithoutFetchWithChangeDetection: 'adapter1',
-            adapter3WithoutFetchWithChangeDetection: 'adapter2',
           },
           [],
           undefined,
           true,
-        )).rejects.toThrow('Adapters: adapter1, adapter2 do not support fetch with change detection operation')
+        )).rejects.toThrow('Adapter: adapter1 does not support fetch with change detection operation')
       })
       it('should call fetchWithChangeDetection function', async () => {
         mockFetch.mockClear()
@@ -1188,8 +1178,6 @@ describe('fetch', () => {
           createElementSource([]),
           {
             adapterWithoutFetchWithChangeDetection: 'adapter1',
-            adapter2WithoutFetchWithChangeDetection: 'adapter1',
-            adapter3WithoutFetchWithChangeDetection: 'adapter2',
           },
           [],
           undefined,


### PR DESCRIPTION

---
The bug was: 
In the old code, core saved the fetchFunction as const and call it. If inside the fetch function there are references to some of the adapter propertise (e.g this.someAttribute) 'this' was undefined and thrown an error.
We should call the function directly from the adapter it self (adapter.fetch(...args))

Behavior change:
When calling fetchWithChange detection with adapter that do not support this operation
In the old code a single error were thrown, contains all the unsupported fetchWithChangeDetection adapter names.
In the new code a single error will be thrown, contains only the first unsupported adapter name.

IMO this is good enough since this case shouldn't happen, and if it does the odds that there are more than a single adapter that does not support the operation is even smaller.
---
_Release Notes_: 

---
_User Notifications_: 
None
