### PR TITLE
SALTO-3696/workflow schemes without items

### DIFF
--- a/packages/jira-adapter/test/change_validators/workflow_scheme_migration.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflow_scheme_migration.test.ts
@@ -214,7 +214,6 @@ describe('workflow scheme migration', () => {
     const errors = await validator([toChange({ before: workflowInstance, after: modifiedInstance })], elementSource)
     expect(errors).toHaveLength(0)
   })
-<<<<<<< Updated upstream
   it('should not throw on unresolved reference', async () => {
     modifiedInstance.value.items.push(
       {
@@ -222,11 +221,12 @@ describe('workflow scheme migration', () => {
         issueType: new ReferenceExpression(new ElemID(JIRA, 'IssueType', 'instance', 'issueType5')),
       },
     )
-=======
+    const errorsPromise = validator([toChange({ before: workflowInstance, after: modifiedInstance })], elementSource)
+    await expect(errorsPromise).resolves.not.toThrow()
+  })
   it('should not throw if there are no items at all', async () => {
     workflowInstance.value.items = undefined
     modifiedInstance.value.items = undefined
->>>>>>> Stashed changes
     const errorsPromise = validator([toChange({ before: workflowInstance, after: modifiedInstance })], elementSource)
     await expect(errorsPromise).resolves.not.toThrow()
   })

--- a/packages/jira-adapter/test/change_validators/workflow_scheme_migration.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflow_scheme_migration.test.ts
@@ -214,6 +214,7 @@ describe('workflow scheme migration', () => {
     const errors = await validator([toChange({ before: workflowInstance, after: modifiedInstance })], elementSource)
     expect(errors).toHaveLength(0)
   })
+<<<<<<< Updated upstream
   it('should not throw on unresolved reference', async () => {
     modifiedInstance.value.items.push(
       {
@@ -221,6 +222,11 @@ describe('workflow scheme migration', () => {
         issueType: new ReferenceExpression(new ElemID(JIRA, 'IssueType', 'instance', 'issueType5')),
       },
     )
+=======
+  it('should not throw if there are no items at all', async () => {
+    workflowInstance.value.items = undefined
+    modifiedInstance.value.items = undefined
+>>>>>>> Stashed changes
     const errorsPromise = validator([toChange({ before: workflowInstance, after: modifiedInstance })], elementSource)
     await expect(errorsPromise).resolves.not.toThrow()
   })


### PR DESCRIPTION
Fixed bug with workflow scheme change validator that assums that items field is always populated 

---

_Additional context for reviewer_

---
_Release Notes_: 
Jira adapter:
* bug fix for failing deployments over workflow schemes with no items. 

---
_User Notifications_: 

