### PR TITLE
SALTO-3698/missing fields

### DIFF
--- a/packages/jira-adapter/src/change_validators/issue_type_scheme_migration.ts
+++ b/packages/jira-adapter/src/change_validators/issue_type_scheme_migration.ts
@@ -31,8 +31,8 @@ const isSameRef = (ref1: ReferenceExpression, ref2: ReferenceExpression): boolea
 
 const getRemovedIssueTypeIds = (change: ModificationChange<InstanceElement>): ReferenceExpression[] => {
   const { before, after } = change.data
-  const beforeIssueIds = before.value.issueTypeIds.filter(isReferenceExpression)
-  const afterIssueIds = after.value.issueTypeIds.filter(isReferenceExpression)
+  const beforeIssueIds = (before.value.issueTypeIds ?? []).filter(isReferenceExpression)
+  const afterIssueIds = (after.value.issueTypeIds ?? []).filter(isReferenceExpression)
   return _.differenceWith(beforeIssueIds, afterIssueIds, isSameRef)
 }
 

--- a/packages/jira-adapter/src/change_validators/workflow_scheme_migration.ts
+++ b/packages/jira-adapter/src/change_validators/workflow_scheme_migration.ts
@@ -170,8 +170,8 @@ const areStatusesEquals = (status1: ReferenceExpression, status2: ReferenceExpre
   status1.elemID.isEqual(status2.elemID)
 
 const getMissingStatuses = (before: InstanceElement, after: InstanceElement): ReferenceExpression[] => {
-  const beforeStatuses = before.value.statuses.map((status: {id: ReferenceExpression}) => status.id)
-  const afterStatuses = after.value.statuses.map((status: {id: ReferenceExpression}) => status.id)
+  const beforeStatuses = (before.value.statuses ?? []).map((status: {id: ReferenceExpression}) => status.id)
+  const afterStatuses = (after.value.statuses ?? []).map((status: {id: ReferenceExpression}) => status.id)
   return _.differenceWith(beforeStatuses, afterStatuses, areStatusesEquals)
 }
 

--- a/packages/jira-adapter/test/change_validators/issue_type_scheme_migration.test.ts
+++ b/packages/jira-adapter/test/change_validators/issue_type_scheme_migration.test.ts
@@ -134,6 +134,11 @@ describe('issue type scheme migration validator', () => {
     ]
     await expect(callValidator()).resolves.not.toThrow()
   })
+  it('should not throw on missing issue type ids ', async () => {
+    issueTypeScheme.value.issueTypeIds = undefined
+    modifiedIssueTypeScheme.value.issueTypeIds = undefined
+    await expect(callValidator()).resolves.not.toThrow()
+  })
 
   it('should not return an error on removal/addition changes', async () => {
     expect(await validator([toChange({ before: issueTypeScheme })], elementSource)).toEqual([])

--- a/packages/jira-adapter/test/change_validators/workflow_scheme_migration.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflow_scheme_migration.test.ts
@@ -230,6 +230,14 @@ describe('workflow scheme migration', () => {
     const errorsPromise = validator([toChange({ before: workflowInstance, after: modifiedInstance })], elementSource)
     await expect(errorsPromise).resolves.not.toThrow()
   })
+  it('should not throw if workflow has no statuses', async () => {
+    workflow1.value.value.statuses = undefined
+    workflow2.value.value.statuses = undefined
+    workflow3.value.value.statuses = undefined
+    workflow4.value.value.statuses = undefined
+    const errorsPromise = validator([toChange({ before: workflowInstance, after: modifiedInstance })], elementSource)
+    await expect(errorsPromise).resolves.not.toThrow()
+  })
   it('should not return an error for active workflow scheme with no issues in assigned projects', async () => {
     numberOfIssues = 0
     const errors = await validator([toChange({ before: workflowInstance, after: modifiedInstance })], elementSource)

--- a/packages/jira-adapter/test/change_validators/workflow_scheme_migration.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflow_scheme_migration.test.ts
@@ -82,15 +82,15 @@ describe('workflow scheme migration', () => {
   const status2 = new ReferenceExpression(status2Id, new InstanceElement('status2', new ObjectType({ elemID: statusID }), { id: '2' }))
   const status3 = new ReferenceExpression(status3Id, new InstanceElement('status3', new ObjectType({ elemID: statusID }), { id: '3' }))
   const status4 = new ReferenceExpression(status4Id, new InstanceElement('status4', new ObjectType({ elemID: statusID }), { id: '4' }))
-  const workflow1 = new ReferenceExpression(new ElemID(JIRA, 'workflow1'), new InstanceElement('workflow1', new ObjectType({ elemID: new ElemID(JIRA, 'workflow') }), { id: '1', statuses: [{ id: status1 }, { id: status2 }] }))
-  const workflow2 = new ReferenceExpression(new ElemID(JIRA, 'workflow2'), new InstanceElement('workflow2', new ObjectType({ elemID: new ElemID(JIRA, 'workflow') }), { id: '2', statuses: [{ id: status3 }, { id: status4 }] }))
-  const workflow3 = new ReferenceExpression(new ElemID(JIRA, 'workflow3'), new InstanceElement('workflow3', new ObjectType({ elemID: new ElemID(JIRA, 'workflow') }), { id: '3', statuses: [{ id: status1 }, { id: status2 }] }))
-  const workflow4 = new ReferenceExpression(new ElemID(JIRA, 'workflow4'), new InstanceElement('workflow4', new ObjectType({ elemID: new ElemID(JIRA, 'workflow') }), { id: '4', statuses: [{ id: status1 }, { id: status4 }] }))
   const issueType1Id = new ElemID(JIRA, 'IssueType', 'instance', 'issueType1')
   const issueType2Id = new ElemID(JIRA, 'IssueType', 'instance', 'issueType2')
   const issueType3Id = new ElemID(JIRA, 'IssueType', 'instance', 'issueType3')
   const issueType4Id = new ElemID(JIRA, 'IssueType', 'instance', 'issueType4')
   const issueType5Id = new ElemID(JIRA, 'IssueType', 'instance', 'issueType5')
+  let workflow1: InstanceElement
+  let workflow2: InstanceElement
+  let workflow3: InstanceElement
+  let workflow4: InstanceElement
   let workflowSchemeType: ObjectType
   let mockConnection: MockInterface<clientUtils.APIConnection>
   let projectType: ObjectType
@@ -111,6 +111,10 @@ describe('workflow scheme migration', () => {
     numberOfIssues = 100
     workflowSchemeType = new ObjectType({ elemID: new ElemID(JIRA, 'WorkflowScheme') })
     issueTypeSchemeType = new ObjectType({ elemID: new ElemID(JIRA, 'IssueTypeScheme') })
+    workflow1 = new ReferenceExpression(new ElemID(JIRA, 'workflow1'), new InstanceElement('workflow1', new ObjectType({ elemID: new ElemID(JIRA, 'workflow') }), { id: '1', statuses: [{ id: status1 }, { id: status2 }] }))
+    workflow2 = new ReferenceExpression(new ElemID(JIRA, 'workflow2'), new InstanceElement('workflow2', new ObjectType({ elemID: new ElemID(JIRA, 'workflow') }), { id: '2', statuses: [{ id: status3 }, { id: status4 }] }))
+    workflow3 = new ReferenceExpression(new ElemID(JIRA, 'workflow3'), new InstanceElement('workflow3', new ObjectType({ elemID: new ElemID(JIRA, 'workflow') }), { id: '3', statuses: [{ id: status1 }, { id: status2 }] }))
+    workflow4 = new ReferenceExpression(new ElemID(JIRA, 'workflow4'), new InstanceElement('workflow4', new ObjectType({ elemID: new ElemID(JIRA, 'workflow') }), { id: '4', statuses: [{ id: status1 }, { id: status4 }] }))
     issueTypeSchemeInstance = new InstanceElement(
       'issueTypeScheme',
       issueTypeSchemeType,

--- a/packages/jira-adapter/test/change_validators/workflow_scheme_migration.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflow_scheme_migration.test.ts
@@ -87,10 +87,10 @@ describe('workflow scheme migration', () => {
   const issueType3Id = new ElemID(JIRA, 'IssueType', 'instance', 'issueType3')
   const issueType4Id = new ElemID(JIRA, 'IssueType', 'instance', 'issueType4')
   const issueType5Id = new ElemID(JIRA, 'IssueType', 'instance', 'issueType5')
-  let workflow1: InstanceElement
-  let workflow2: InstanceElement
-  let workflow3: InstanceElement
-  let workflow4: InstanceElement
+  let workflow1: ReferenceExpression
+  let workflow2: ReferenceExpression
+  let workflow3: ReferenceExpression
+  let workflow4: ReferenceExpression
   let workflowSchemeType: ObjectType
   let mockConnection: MockInterface<clientUtils.APIConnection>
   let projectType: ObjectType


### PR DESCRIPTION
fixed potential bug with workflow scheme migration change validator potentially using workflow statuses when its undefined 
and another one in issue type scheme that might not have issue type ids.

---

_Additional context for reviewer_

---
_Release Notes_: 
jira adapter:
* Fixed cases in some change validators that failed on missing fields in instances.

---
_User Notifications_: 

