### PR TITLE
SALTO-3634: Some fixes to Scriptrunner

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -119,6 +119,7 @@ import commonFilters from './filters/common'
 import accountInfoFilter from './filters/account_info'
 import deployPermissionSchemeFilter from './filters/permission_scheme/deploy_permission_scheme_filter'
 import scriptRunnerWorkflowFilter from './filters/script_runner/workflow_filter'
+import scriptRunnerWorkflowOrFilter from './filters/script_runner/workflow_ors'
 
 const {
   generateTypes,
@@ -224,6 +225,8 @@ export const DEFAULT_FILTERS = [
   allowedPermissionsSchemeFilter,
   deployPermissionSchemeFilter,
   scriptRunnerWorkflowFilter,
+  // must run after scriptRunnerWorkflowFilter
+  scriptRunnerWorkflowOrFilter,
   // Must run after user filter
   accountIdFilter,
   // Must run after accountIdFilter

--- a/packages/jira-adapter/src/filters/script_runner/workflow_dc.ts
+++ b/packages/jira-adapter/src/filters/script_runner/workflow_dc.ts
@@ -78,7 +78,7 @@ const fieldToDecodeMap: FieldToCodeFuncMap = new Map([
   ['FIELD_EMAIL_SUBJECT_TEMPLATE', decodeBase64],
   ['FIELD_CONDITION', decodeScriptObject],
   ['FIELD_SCRIPT_FILE_OR_SCRIPT', decodeScriptObject],
-  ['FIELD_ADDITIONAL_SCRIPT', decodeBase64],
+  ['FIELD_ADDITIONAL_SCRIPT', decodeScriptObject],
   ['FIELD_COMMENT', decodeBase64],
 ])
 
@@ -90,13 +90,19 @@ const fieldToEncodeMap: FieldToCodeFuncMap = new Map([
   ['FIELD_EMAIL_SUBJECT_TEMPLATE', encodeBase64],
   ['FIELD_CONDITION', encodeScriptObject],
   ['FIELD_SCRIPT_FILE_OR_SCRIPT', encodeScriptObject],
-  ['FIELD_ADDITIONAL_SCRIPT', encodeBase64],
+  ['FIELD_ADDITIONAL_SCRIPT', encodeScriptObject],
   ['FIELD_COMMENT', encodeBase64],
 ])
 
 const transformConfigFields = (funcMap: FieldToCodeFuncMap): WalkOnFunc => (
   ({ value }): WALK_NEXT_STEP => {
     if (SCRIPT_RUNNER_DC_TYPES.includes(value.type) && value.configuration !== undefined) {
+      // remove empty fields
+      Object.entries(value.configuration).forEach(([fieldName, fieldValue]) => {
+        if (fieldValue === '') {
+          delete value.configuration[fieldName]
+        }
+      })
       funcMap.forEach((_value, fieldName) => {
         // Field comment is base64 encoded only in some cases. In others the field is plain text
         if (value.configuration[fieldName] !== undefined

--- a/packages/jira-adapter/src/filters/script_runner/workflow_dc.ts
+++ b/packages/jira-adapter/src/filters/script_runner/workflow_dc.ts
@@ -19,7 +19,7 @@ import { safeJsonStringify, WalkOnFunc, WALK_NEXT_STEP } from '@salto-io/adapter
 import { Value } from '@salto-io/adapter-api'
 
 const log = logger(module)
-const SCRIPT_RUNNER_DC_TYPES = ['com.onresolve.jira.groovy.GroovyFunctionPlugin',
+export const SCRIPT_RUNNER_DC_TYPES = ['com.onresolve.jira.groovy.GroovyFunctionPlugin',
   'com.onresolve.jira.groovy.GroovyValidator',
   'com.onresolve.jira.groovy.GroovyCondition']
 const DC_ENCODE_PREFIX = '`!`'
@@ -72,6 +72,10 @@ const encodeScriptObject = (value: Value): string => {
 type FieldToCodeFuncMap = Map<string, Value>
 const fieldToDecodeMap: FieldToCodeFuncMap = new Map([
   ['FIELD_NOTES', decodeBase64],
+  ['FIELD_MESSAGE', decodeBase64],
+  ['FIELD_INCLUDE_ATTACHMENTS_CALLBACK', decodeBase64],
+  ['FIELD_EMAIL_TEMPLATE', decodeBase64],
+  ['FIELD_EMAIL_SUBJECT_TEMPLATE', decodeBase64],
   ['FIELD_CONDITION', decodeScriptObject],
   ['FIELD_SCRIPT_FILE_OR_SCRIPT', decodeScriptObject],
   ['FIELD_ADDITIONAL_SCRIPT', decodeBase64],
@@ -80,6 +84,10 @@ const fieldToDecodeMap: FieldToCodeFuncMap = new Map([
 
 const fieldToEncodeMap: FieldToCodeFuncMap = new Map([
   ['FIELD_NOTES', encodeBase64],
+  ['FIELD_MESSAGE', encodeBase64],
+  ['FIELD_INCLUDE_ATTACHMENTS_CALLBACK', encodeBase64],
+  ['FIELD_EMAIL_TEMPLATE', encodeBase64],
+  ['FIELD_EMAIL_SUBJECT_TEMPLATE', encodeBase64],
   ['FIELD_CONDITION', encodeScriptObject],
   ['FIELD_SCRIPT_FILE_OR_SCRIPT', encodeScriptObject],
   ['FIELD_ADDITIONAL_SCRIPT', encodeBase64],

--- a/packages/jira-adapter/src/filters/script_runner/workflow_ors.ts
+++ b/packages/jira-adapter/src/filters/script_runner/workflow_ors.ts
@@ -22,10 +22,24 @@ import { WORKFLOW_TYPE_NAME } from '../../constants'
 import { SCRIPT_RUNNER_DC_TYPES } from './workflow_dc'
 
 const SCRIPT_RUNNER_OR = '|||'
+export const OR_FIELDS = [
+  'FIELD_TRANSITION_OPTIONS',
+  'FIELD_SELECTED_FIELDS',
+  'FIELD_LINK_DIRECTION',
+  'FIELD_FIELD_IDS',
+  'FIELD_REQUIRED_FIELDS',
+  'FIELD_USER_IN_FIELDS',
+  'FIELD_GROUP_NAMES',
+  'FIELD_LINKED_ISSUE_RESOLUTION',
+  'FIELD_PROJECT_ROLE_IDS',
+  'FIELD_USER_IDS',
+  'FIELD_LINKED_ISSUE_STATUS',
+]
 
 const returnOr: WalkOnFunc = ({ value }): WALK_NEXT_STEP => {
   if (typeof value === 'object' && value !== null) {
     Object.entries(value)
+      .filter(([key]) => OR_FIELDS.includes(key))
       .filter((entry): entry is [string, string[]] => Array.isArray(entry[1]))
       .forEach(([key, val]) => {
         value[key] = val.join(SCRIPT_RUNNER_OR)
@@ -37,7 +51,8 @@ const returnOr: WalkOnFunc = ({ value }): WALK_NEXT_STEP => {
 const replaceOr: WalkOnFunc = ({ value }): WALK_NEXT_STEP => {
   if (_.isPlainObject(value)) {
     Object.entries(value)
-      .filter((entry): entry is [string, string] => typeof entry[1] === 'string' && entry[1].includes(SCRIPT_RUNNER_OR))
+      .filter(([key]) => OR_FIELDS.includes(key))
+      .filter((entry): entry is [string, string] => typeof entry[1] === 'string')
       .forEach(([key, val]) => {
         value[key] = val.split(SCRIPT_RUNNER_OR)
       })

--- a/packages/jira-adapter/src/filters/script_runner/workflow_ors.ts
+++ b/packages/jira-adapter/src/filters/script_runner/workflow_ors.ts
@@ -16,6 +16,7 @@
 
 import { WalkOnFunc, walkOnValue, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
 import { isInstanceElement, Element, isInstanceChange, isAdditionOrModificationChange, getChangeData, Value } from '@salto-io/adapter-api'
+import _ from 'lodash'
 import { FilterCreator } from '../../filter'
 import { WORKFLOW_TYPE_NAME } from '../../constants'
 import { SCRIPT_RUNNER_DC_TYPES } from './workflow_dc'
@@ -34,7 +35,7 @@ const returnOr: WalkOnFunc = ({ value }): WALK_NEXT_STEP => {
 }
 
 const replaceOr: WalkOnFunc = ({ value }): WALK_NEXT_STEP => {
-  if (typeof value === 'object' && value !== null) {
+  if (_.isPlainObject(value)) {
     Object.entries(value)
       .filter((entry): entry is [string, string] => typeof entry[1] === 'string' && entry[1].includes(SCRIPT_RUNNER_OR))
       .forEach(([key, val]) => {
@@ -55,6 +56,9 @@ const findScriptRunnerDC = (func: Value): WalkOnFunc => (
     return WALK_NEXT_STEP.RECURSE
   })
 
+// Changes script runners strings that represent several values and are split by '|||' to an array
+// for example:
+// FIELD_TRANSITION_OPTIONS = "FIELD_SKIP_PERMISSIONS|||FIELD_SKIP_VALIDATORS|||FIELD_SKIP_CONDITIONS"
 const filter: FilterCreator = ({ client, config }) => ({
   name: 'scriptRunnerWorkflowOrFilter',
   onFetch: async (elements: Element[]) => {

--- a/packages/jira-adapter/src/filters/script_runner/workflow_ors.ts
+++ b/packages/jira-adapter/src/filters/script_runner/workflow_ors.ts
@@ -1,0 +1,105 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { WalkOnFunc, walkOnValue, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
+import { isInstanceElement, Element, isInstanceChange, isAdditionOrModificationChange, getChangeData, Value } from '@salto-io/adapter-api'
+import { FilterCreator } from '../../filter'
+import { WORKFLOW_TYPE_NAME } from '../../constants'
+import { SCRIPT_RUNNER_DC_TYPES } from './workflow_dc'
+
+const SCRIPT_RUNNER_OR = '|||'
+
+const returnOr: WalkOnFunc = ({ value }): WALK_NEXT_STEP => {
+  if (typeof value === 'object' && value !== null) {
+    Object.entries(value)
+      .filter((entry): entry is [string, string[]] => Array.isArray(entry[1]))
+      .forEach(([key, val]) => {
+        value[key] = val.join(SCRIPT_RUNNER_OR)
+      })
+  }
+  return WALK_NEXT_STEP.RECURSE
+}
+
+const replaceOr: WalkOnFunc = ({ value }): WALK_NEXT_STEP => {
+  if (typeof value === 'object' && value !== null) {
+    Object.entries(value)
+      .filter((entry): entry is [string, string] => typeof entry[1] === 'string' && entry[1].includes(SCRIPT_RUNNER_OR))
+      .forEach(([key, val]) => {
+        value[key] = val.split(SCRIPT_RUNNER_OR)
+      })
+  }
+  return WALK_NEXT_STEP.RECURSE
+}
+
+const findScriptRunnerDC = (func: Value): WalkOnFunc => (
+  ({ value, path }): WALK_NEXT_STEP => {
+    if (SCRIPT_RUNNER_DC_TYPES.includes(value.type) && value.configuration !== undefined) {
+      walkOnValue({ elemId: path.createNestedID('configuration'),
+        value: value.configuration,
+        func })
+      return WALK_NEXT_STEP.SKIP
+    }
+    return WALK_NEXT_STEP.RECURSE
+  })
+
+const filter: FilterCreator = ({ client, config }) => ({
+  name: 'scriptRunnerWorkflowOrFilter',
+  onFetch: async (elements: Element[]) => {
+    if (!config.fetch.enableScriptRunnerAddon || !client.isDataCenter) {
+      return
+    }
+    elements
+      .filter(isInstanceElement)
+      .filter(instance => instance.elemID.typeName === WORKFLOW_TYPE_NAME)
+      .forEach(instance => {
+        walkOnValue({ elemId: instance.elemID.createNestedID('transitions'),
+          value: instance.value.transitions,
+          func: findScriptRunnerDC(replaceOr) })
+      })
+  },
+  preDeploy: async changes => {
+    if (!config.fetch.enableScriptRunnerAddon || !client.isDataCenter) {
+      return
+    }
+    changes
+      .filter(isAdditionOrModificationChange)
+      .filter(isInstanceChange)
+      .map(getChangeData)
+      .filter(instance => instance.elemID.typeName === WORKFLOW_TYPE_NAME)
+      .forEach(instance => {
+        walkOnValue({ elemId: instance.elemID.createNestedID('transitions'),
+          value: instance.value.transitions,
+          func: findScriptRunnerDC(returnOr) })
+      })
+  },
+  onDeploy: async changes => {
+    if (!config.fetch.enableScriptRunnerAddon || !client.isDataCenter) {
+      return
+    }
+    changes
+      .filter(isAdditionOrModificationChange)
+      .filter(isInstanceChange)
+      .map(getChangeData)
+      .filter(instance => instance.elemID.typeName === WORKFLOW_TYPE_NAME)
+      .forEach(instance => {
+        walkOnValue({ elemId: instance.elemID.createNestedID('transitions'),
+          value: instance.value.transitions,
+          func: findScriptRunnerDC(replaceOr) })
+      })
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/test/filters/script_runner/workflow_cloud.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/workflow_cloud.test.ts
@@ -36,7 +36,7 @@ const compareScripts = (script1: string, script2: string): void => {
   expect(zipBuffer1).toEqual(zipBuffer2)
 }
 
-describe('Cloud Workflow post functions', () => {
+describe('ScriptRunner cloud Workflow', () => {
   let filter: filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
   let filterOff: filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
   let instance: InstanceElement

--- a/packages/jira-adapter/test/filters/script_runner/workflow_dc.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/workflow_dc.test.ts
@@ -40,8 +40,8 @@ describe('Scriptrunner DC Workflow', () => {
   const objectNoNullsBase64 = 'YCFgeyJhIjoxfQ==' // YCFg followed by base64 of '{"a":1}'
   const objectScriptOnlyBase64 = 'YCFgeyJzY3JpcHQiOjEsInNjcmlwdFBhdGgiOm51bGx9' // YCFg followed by base64 of '{"script":1,"scriptPath":null}'
   const objectPathOnlyBase64 = 'YCFgeyJzY3JpcHQiOm51bGwsInNjcmlwdFBhdGgiOjF9'
-  const FIELD_NAMES_STRINGS = ['FIELD_NOTES', 'FIELD_ADDITIONAL_SCRIPT', 'FIELD_MESSAGE', 'FIELD_INCLUDE_ATTACHMENTS_CALLBACK', 'FIELD_EMAIL_TEMPLATE', 'FIELD_EMAIL_SUBJECT_TEMPLATE']
-  const FIELD_NAMES_OBJECTS = ['FIELD_CONDITION', 'FIELD_SCRIPT_FILE_OR_SCRIPT']
+  const FIELD_NAMES_STRINGS = ['FIELD_NOTES', 'FIELD_MESSAGE', 'FIELD_INCLUDE_ATTACHMENTS_CALLBACK', 'FIELD_EMAIL_TEMPLATE', 'FIELD_EMAIL_SUBJECT_TEMPLATE']
+  const FIELD_NAMES_OBJECTS = ['FIELD_CONDITION', 'FIELD_ADDITIONAL_SCRIPT', 'FIELD_SCRIPT_FILE_OR_SCRIPT']
 
 
   beforeEach(() => {
@@ -157,6 +157,14 @@ describe('Scriptrunner DC Workflow', () => {
         instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_CONDITION = goodBase64
         await filter.onFetch([instance])
         expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_CONDITION).toEqual(goodBase64)
+      })
+      it('should delete empty fields', async () => {
+        instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_NOTES = ''
+        instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_SCRIPT_FILE_OR_SCRIPT = ''
+        await filter.onFetch([instance])
+        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_NOTES).toBeUndefined()
+        expect(instance.value.transitions[0].rules.postFunctions[0]
+          .configuration.FIELD_SCRIPT_FILE_OR_SCRIPT).toBeUndefined()
       })
     })
     describe('pre deploy', () => {

--- a/packages/jira-adapter/test/filters/script_runner/workflow_dc.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/workflow_dc.test.ts
@@ -28,7 +28,7 @@ const compareScriptObjectsBase64 = (obj1: string, obj2: string): void => {
 }
 
 
-describe('DC Workflow post functions', () => {
+describe('Scriptrunner DC Workflow', () => {
   let filter: filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
   let filterOff: filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
   let instance: InstanceElement
@@ -40,7 +40,7 @@ describe('DC Workflow post functions', () => {
   const objectNoNullsBase64 = 'YCFgeyJhIjoxfQ==' // YCFg followed by base64 of '{"a":1}'
   const objectScriptOnlyBase64 = 'YCFgeyJzY3JpcHQiOjEsInNjcmlwdFBhdGgiOm51bGx9' // YCFg followed by base64 of '{"script":1,"scriptPath":null}'
   const objectPathOnlyBase64 = 'YCFgeyJzY3JpcHQiOm51bGwsInNjcmlwdFBhdGgiOjF9'
-  const FIELD_NAMES_STRINGS = ['FIELD_NOTES', 'FIELD_ADDITIONAL_SCRIPT']
+  const FIELD_NAMES_STRINGS = ['FIELD_NOTES', 'FIELD_ADDITIONAL_SCRIPT', 'FIELD_MESSAGE', 'FIELD_INCLUDE_ATTACHMENTS_CALLBACK', 'FIELD_EMAIL_TEMPLATE', 'FIELD_EMAIL_SUBJECT_TEMPLATE']
   const FIELD_NAMES_OBJECTS = ['FIELD_CONDITION', 'FIELD_SCRIPT_FILE_OR_SCRIPT']
 
 

--- a/packages/jira-adapter/test/filters/script_runner/workflow_ors.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/workflow_ors.test.ts
@@ -17,7 +17,7 @@ import { filterUtils } from '@salto-io/adapter-components'
 import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { getFilterParams, mockClient } from '../../utils'
-import orFilter from '../../../src/filters/script_runner/workflow_ors'
+import orFilter, { OR_FIELDS } from '../../../src/filters/script_runner/workflow_ors'
 import { WORKFLOW_TYPE_NAME } from '../../../src/constants'
 import { getDefaultConfig } from '../../../src/config/config'
 
@@ -76,56 +76,62 @@ describe('ScriptRunner ors in DC', () => {
     )
   })
   describe('fetch', () => {
-    it('should replace ors to arrays', async () => {
-      instance.value.transitions[0].rules.postFunctions[0].configuration.a = 'reporter|||assignee'
-      instance.value.transitions[0].rules.postFunctions[0].configuration.a2 = 'reporter|||assignee'
-      instance.value.transitions[0].rules.conditions[0].configuration.b = 'reporter|||assignee'
-      instance.value.transitions[0].rules.validators[0].configuration.c = 'reporter|||assignee'
+    it('should replace all field ors to arrays', async () => {
+      OR_FIELDS.forEach(field => {
+        instance.value.transitions[0].rules.postFunctions[0].configuration[field] = 'reporter|||assignee'
+      })
       await filter.onFetch([instance])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.a).toEqual(['reporter', 'assignee'])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.a2).toEqual(['reporter', 'assignee'])
-      expect(instance.value.transitions[0].rules.conditions[0].configuration.b).toEqual(['reporter', 'assignee'])
-      expect(instance.value.transitions[0].rules.validators[0].configuration.c).toEqual(['reporter', 'assignee'])
+      OR_FIELDS.forEach(field => {
+        expect(instance.value.transitions[0].rules.postFunctions[0].configuration[field]).toEqual(['reporter', 'assignee'])
+      })
+    })
+    it('should insert single value to array', async () => {
+      instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_SELECTED_FIELDS = 'reporter'
+      await filter.onFetch([instance])
+      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_SELECTED_FIELDS).toEqual(['reporter'])
+    })
+    it('should not replace ors on non Or fields', async () => {
+      instance.value.transitions[0].rules.postFunctions[0].configuration.a = 'reporter|||assignee'
+      await filter.onFetch([instance])
+      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.a).toEqual('reporter|||assignee')
     })
     it('should not decode if script runner not supported', async () => {
-      instance.value.transitions[0].rules.postFunctions[0].configuration.a = 'reporter|||assignee'
+      instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_SELECTED_FIELDS = 'reporter|||assignee'
       await filterOff.onFetch([instance])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.a).toEqual('reporter|||assignee')
+      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_SELECTED_FIELDS).toEqual('reporter|||assignee')
     })
     it('should not decode if not data center', async () => {
-      instance.value.transitions[0].rules.postFunctions[0].configuration.a = 'reporter|||assignee'
+      instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_SELECTED_FIELDS = 'reporter|||assignee'
       await filterCloud.onFetch([instance])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.a).toEqual('reporter|||assignee')
+      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_SELECTED_FIELDS).toEqual('reporter|||assignee')
     })
     it('should not decode if wrong type', async () => {
       instance.value.transitions[0].rules.postFunctions[1] = {
         type: 'other',
         configuration: {
-          a: 'reporter|||assignee',
+          FIELD_SELECTED_FIELDS: 'reporter|||assignee',
         },
       }
       await filter.onFetch([instance])
-      expect(instance.value.transitions[0].rules.postFunctions[1].configuration.a).toEqual('reporter|||assignee')
+      expect(instance.value.transitions[0].rules.postFunctions[1].configuration.FIELD_SELECTED_FIELDS).toEqual('reporter|||assignee')
     })
   })
   describe('pre deploy', () => {
     it('should replace arrays to ors', async () => {
-      instance.value.transitions[0].rules.postFunctions[0].configuration.a = ['reporter', 'assignee']
-      instance.value.transitions[0].rules.postFunctions[0].configuration.a2 = ['reporter', 'assignee']
-      instance.value.transitions[0].rules.conditions[0].configuration.b = ['reporter', 'assignee']
-      instance.value.transitions[0].rules.validators[0].configuration.c = ['reporter', 'assignee']
+      OR_FIELDS.forEach(field => {
+        instance.value.transitions[0].rules.postFunctions[0].configuration[field] = ['reporter', 'assignee']
+      })
       await filter.preDeploy([toChange({ after: instance })])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.a).toEqual('reporter|||assignee')
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.a2).toEqual('reporter|||assignee')
-      expect(instance.value.transitions[0].rules.conditions[0].configuration.b).toEqual('reporter|||assignee')
-      expect(instance.value.transitions[0].rules.validators[0].configuration.c).toEqual('reporter|||assignee')
+      OR_FIELDS.forEach(field => {
+        expect(instance.value.transitions[0].rules.postFunctions[0].configuration[field]).toEqual('reporter|||assignee')
+      })
     })
   })
   describe('on deploy', () => {
     it('should replace ors to arrays', async () => {
-      instance.value.transitions[0].rules.postFunctions[0].configuration.a = 'reporter|||assignee'
+      instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_SELECTED_FIELDS = 'reporter|||assignee'
       await filter.onDeploy([toChange({ after: instance })])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.a).toEqual(['reporter', 'assignee'])
+      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_SELECTED_FIELDS).toEqual(['reporter', 'assignee'])
     })
   })
 })

--- a/packages/jira-adapter/test/filters/script_runner/workflow_ors.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/workflow_ors.test.ts
@@ -1,0 +1,131 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { filterUtils } from '@salto-io/adapter-components'
+import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { getFilterParams, mockClient } from '../../utils'
+import orFilter from '../../../src/filters/script_runner/workflow_ors'
+import { WORKFLOW_TYPE_NAME } from '../../../src/constants'
+import { getDefaultConfig } from '../../../src/config/config'
+
+
+describe('ScriptRunner ors in DC', () => {
+  let filter: filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
+  let filterOff: filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
+  let filterCloud: filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
+  let instance: InstanceElement
+
+  const workflowType = new ObjectType({
+    elemID: new ElemID('jira', WORKFLOW_TYPE_NAME),
+  })
+
+  beforeEach(() => {
+    const config = _.cloneDeep(getDefaultConfig({ isDataCenter: true }))
+    const configOff = _.cloneDeep(getDefaultConfig({ isDataCenter: true }))
+    const { client } = mockClient(true)
+    const { client: clientCloud } = mockClient()
+    config.fetch.enableScriptRunnerAddon = true
+    filter = orFilter(getFilterParams({ client, config })) as filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
+    filterOff = orFilter(getFilterParams({ client, config: configOff })) as filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
+    filterCloud = orFilter(getFilterParams({ client: clientCloud, config })) as filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
+    instance = new InstanceElement(
+      'instance',
+      workflowType,
+      {
+        transitions: [
+          {
+            rules: {
+              postFunctions: [
+                {
+                  type: 'com.onresolve.jira.groovy.GroovyFunctionPlugin',
+                  configuration: {
+                  },
+                },
+              ],
+              conditions: [
+                {
+                  type: 'com.onresolve.jira.groovy.GroovyCondition',
+                  configuration: {
+                  },
+                },
+              ],
+              validators: [
+                {
+                  type: 'com.onresolve.jira.groovy.GroovyValidator',
+                  configuration: {
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      }
+    )
+  })
+  describe('fetch', () => {
+    it('should replace ors to arrays', async () => {
+      instance.value.transitions[0].rules.postFunctions[0].configuration.a = 'reporter|||assignee'
+      instance.value.transitions[0].rules.postFunctions[0].configuration.a2 = 'reporter|||assignee'
+      instance.value.transitions[0].rules.conditions[0].configuration.b = 'reporter|||assignee'
+      instance.value.transitions[0].rules.validators[0].configuration.c = 'reporter|||assignee'
+      await filter.onFetch([instance])
+      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.a).toEqual(['reporter', 'assignee'])
+      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.a2).toEqual(['reporter', 'assignee'])
+      expect(instance.value.transitions[0].rules.conditions[0].configuration.b).toEqual(['reporter', 'assignee'])
+      expect(instance.value.transitions[0].rules.validators[0].configuration.c).toEqual(['reporter', 'assignee'])
+    })
+    it('should not decode if script runner not supported', async () => {
+      instance.value.transitions[0].rules.postFunctions[0].configuration.a = 'reporter|||assignee'
+      await filterOff.onFetch([instance])
+      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.a).toEqual('reporter|||assignee')
+    })
+    it('should not decode if not data center', async () => {
+      instance.value.transitions[0].rules.postFunctions[0].configuration.a = 'reporter|||assignee'
+      await filterCloud.onFetch([instance])
+      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.a).toEqual('reporter|||assignee')
+    })
+    it('should not decode if wrong type', async () => {
+      instance.value.transitions[0].rules.postFunctions[1] = {
+        type: 'other',
+        configuration: {
+          a: 'reporter|||assignee',
+        },
+      }
+      await filter.onFetch([instance])
+      expect(instance.value.transitions[0].rules.postFunctions[1].configuration.a).toEqual('reporter|||assignee')
+    })
+  })
+  describe('pre deploy', () => {
+    it('should replace arrays to ors', async () => {
+      instance.value.transitions[0].rules.postFunctions[0].configuration.a = ['reporter', 'assignee']
+      instance.value.transitions[0].rules.postFunctions[0].configuration.a2 = ['reporter', 'assignee']
+      instance.value.transitions[0].rules.conditions[0].configuration.b = ['reporter', 'assignee']
+      instance.value.transitions[0].rules.validators[0].configuration.c = ['reporter', 'assignee']
+      await filter.preDeploy([toChange({ after: instance })])
+      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.a).toEqual('reporter|||assignee')
+      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.a2).toEqual('reporter|||assignee')
+      expect(instance.value.transitions[0].rules.conditions[0].configuration.b).toEqual('reporter|||assignee')
+      expect(instance.value.transitions[0].rules.validators[0].configuration.c).toEqual('reporter|||assignee')
+    })
+  })
+  describe('on deploy', () => {
+    it('should replace ors to arrays', async () => {
+      instance.value.transitions[0].rules.postFunctions[0].configuration.a = 'reporter|||assignee'
+      await filter.onDeploy([toChange({ after: instance })])
+      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.a).toEqual(['reporter', 'assignee'])
+    })
+  })
+})


### PR DESCRIPTION
In script runner multiple values are brought as a single string with '|||' in between, we want to make them arrays
Also added support for email and slack post functions in DC
---
_Release Notes_: 
None

---
_User Notifications_: 
None