### PR TITLE
SALTO-3701: Get fieldTypeOverrides schemas

### DIFF
--- a/packages/adapter-components/src/elements/swagger/type_elements/swagger_parser.ts
+++ b/packages/adapter-components/src/elements/swagger/type_elements/swagger_parser.ts
@@ -161,7 +161,7 @@ export const getParsedDefs = async ({
 }:{
   swaggerPath: string
   loadedSwagger?: LoadedSwagger
-  additionalTypes?: string[]
+  additionalTypes?: Set<string>
 }):Promise<SchemasAndRefs> => {
   const swagger = loadedSwagger ?? await loadSwagger(swaggerPath)
 
@@ -173,11 +173,11 @@ export const getParsedDefs = async ({
   const additionalSchemas = isV3(swagger.document)
     ? _.pickBy(
       swagger.document.components?.schemas,
-      (_value, key) => additionalTypes?.includes(key)
+      (_value, key) => additionalTypes?.has(key)
     )
     : _.pickBy(
       swagger.document.definitions,
-      (_value, key) => additionalTypes?.includes(key)
+      (_value, key) => additionalTypes?.has(key)
     )
   return {
     schemas: { ...responseSchemas, ...additionalSchemas },

--- a/packages/adapter-components/src/elements/swagger/type_elements/swagger_parser.ts
+++ b/packages/adapter-components/src/elements/swagger/type_elements/swagger_parser.ts
@@ -154,8 +154,15 @@ export const toSchema = (
   swaggerVersion === SwaggerVersion.V2 ? toSchemaV2(def as V2Def) : toSchemaV3(def as V3Def)
 )
 
-export const getParsedDefs = async (swaggerPath: string, loadedSwagger?: LoadedSwagger):
-  Promise<SchemasAndRefs> => {
+export const getParsedDefs = async ({
+  swaggerPath,
+  loadedSwagger,
+  additionalTypes,
+}:{
+  swaggerPath: string
+  loadedSwagger?: LoadedSwagger
+  additionalTypes?: string[]
+}):Promise<SchemasAndRefs> => {
   const swagger = loadedSwagger ?? await loadSwagger(swaggerPath)
 
   const swaggerVersion = getSwaggerVersion(swagger)
@@ -163,8 +170,17 @@ export const getParsedDefs = async (swaggerPath: string, loadedSwagger?: LoadedS
     _.mapValues(swagger.document.paths, def => toSchema(swaggerVersion, def.get?.responses?.[200])),
     isDefined,
   )
+  const additionalSchemas = isV3(swagger.document)
+    ? _.pickBy(
+      swagger.document.components?.schemas,
+      (_value, key) => additionalTypes?.includes(key)
+    )
+    : _.pickBy(
+      swagger.document.definitions,
+      (_value, key) => additionalTypes?.includes(key)
+    )
   return {
-    schemas: responseSchemas,
+    schemas: { ...responseSchemas, ...additionalSchemas },
     refs: swagger.parser.$refs,
   }
 }

--- a/packages/adapter-components/src/elements/swagger/type_elements/type_config_override.ts
+++ b/packages/adapter-components/src/elements/swagger/type_elements/type_config_override.ts
@@ -13,7 +13,6 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import _ from 'lodash'
 import { ObjectType, ElemID, BuiltinTypes } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { values } from '@salto-io/lowerdash'
@@ -97,24 +96,24 @@ export const fixTypes = (
 }
 
 /**
- * Get additional schemas from from type names in FieldTypeOverrideType config
+ * Get additional schemas from type names in FieldTypeOverrideType config
  */
 export const getFieldTypeOverridesTypes = (
   typeConfig: Record<string, TypeSwaggerConfig>,
   typeDefaultConfig: TypeSwaggerDefaultConfig,
-): string[] => {
-  const primitiveTypeNames = Object.values(BuiltinTypes).map(type => type.elemID.name)
+): Set<string> => {
+  const primitiveTypeNames = new Set(Object.values(BuiltinTypes).map(type => type.elemID.name))
   const getInnerTypeName = (typeName: string): string => {
     const nestedTypeName = getContainerForType(typeName)
     return nestedTypeName === undefined ? typeName : getInnerTypeName(nestedTypeName.typeNameSubstring)
   }
 
-  return _.uniq(Object.values(typeConfig)
+  return new Set(Object.values(typeConfig)
     .map(config =>
       getConfigWithDefault(
         config.transformation, typeDefaultConfig.transformation
       ).fieldTypeOverrides)
     .filter(isDefined)
-    .flatMap(fieldTypeOverrides => fieldTypeOverrides.map(field => getInnerTypeName(field.fieldType))))
-    .filter(typeName => !primitiveTypeNames.includes(typeName))
+    .flatMap(fieldTypeOverrides => fieldTypeOverrides.map(field => getInnerTypeName(field.fieldType)))
+    .filter(typeName => !primitiveTypeNames.has(typeName)))
 }

--- a/packages/adapter-components/src/elements/type_elements.ts
+++ b/packages/adapter-components/src/elements/type_elements.ts
@@ -129,7 +129,7 @@ export const filterTypes = async (
  * This can be called recursively to generate the right type from existing types, potentially
  * wrapped in containers - such as List<Map<List<someTypeName>>>
  */
-const getContainerForType = (typeName: string): {
+export const getContainerForType = (typeName: string): {
   container: 'list' | 'map'
   typeNameSubstring: string
 } | undefined => {

--- a/packages/adapter-components/test/elements/swagger/petstore_swagger.v2.yaml
+++ b/packages/adapter-components/test/elements/swagger/petstore_swagger.v2.yaml
@@ -777,6 +777,22 @@ definitions:
       message:
         type: string
     additionalProperties: false
+  NestedType:
+    type: object
+    properties:
+      id:
+        type: string
+      name: 
+        type: string
+  AdditionalType:
+    type: object
+    properties:
+      id:
+        type: string
+      type: 
+        type: string
+      nestedtype:
+        $ref: '#/definitions/NestedType'
 externalDocs:
   description: Find out more about Swagger
   url: 'http://swagger.io'

--- a/packages/adapter-components/test/elements/swagger/type_config_override.test.ts
+++ b/packages/adapter-components/test/elements/swagger/type_config_override.test.ts
@@ -1,0 +1,48 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { getFieldTypeOverridesTypes } from '../../../src/elements/swagger/type_elements/type_config_override'
+
+describe('type_config_override', () => {
+  describe('getFieldTypeOverridesTypes', () => {
+    it('should return additional types from fieldTypeOverrides config', () => {
+      const typeConfig = {
+        Order: {
+          transformation: {
+            fieldTypeOverrides: [
+              { fieldName: 'petId', fieldType: 'list<number>' },
+              { fieldName: 'shipDate', fieldType: 'list<map<Type1>>' },
+              { fieldName: 'quantity', fieldType: 'map<Category>' },
+              { fieldName: 'newField', fieldType: 'list<Category>' },
+              { fieldName: 'newField2', fieldType: 'unknown' },
+            ],
+          },
+        },
+        NewType: {
+          transformation: {
+            fieldTypeOverrides: [
+              { fieldName: 'id', fieldType: 'string' },
+              { fieldName: 'id', fieldType: 'Type2' },
+              { fieldName: 'id', fieldType: 'list<list<list<Type3>>>' },
+            ],
+          },
+        },
+      }
+      const typeDefaults = { transformation: { idFields: ['name'] } }
+      const result = getFieldTypeOverridesTypes(typeConfig, typeDefaults)
+      expect(result).toEqual(['Type1', 'Category', 'Type2', 'Type3'])
+    })
+  })
+})

--- a/packages/adapter-components/test/elements/swagger/type_config_override.test.ts
+++ b/packages/adapter-components/test/elements/swagger/type_config_override.test.ts
@@ -39,6 +39,11 @@ describe('type_config_override', () => {
             ],
           },
         },
+        SomeType: {
+          transformation: {
+            idFields: ['name', 'parent'],
+          },
+        },
       }
       const typeDefaults = { transformation: { idFields: ['name'] } }
       const result = getFieldTypeOverridesTypes(typeConfig, typeDefaults)

--- a/packages/adapter-components/test/elements/swagger/type_config_override.test.ts
+++ b/packages/adapter-components/test/elements/swagger/type_config_override.test.ts
@@ -47,7 +47,7 @@ describe('type_config_override', () => {
       }
       const typeDefaults = { transformation: { idFields: ['name'] } }
       const result = getFieldTypeOverridesTypes(typeConfig, typeDefaults)
-      expect(result).toEqual(['Type1', 'Category', 'Type2', 'Type3'])
+      expect(result).toEqual(new Set(['Type1', 'Category', 'Type2', 'Type3']))
     })
   })
 })

--- a/packages/adapter-components/test/elements/swagger/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/type_elements.test.ts
@@ -232,6 +232,7 @@ describe('swagger_type_elements', () => {
                     { fieldName: 'quantity', fieldType: 'map<Category>' },
                     { fieldName: 'newField', fieldType: 'map<Category>' },
                     { fieldName: 'newHiddenField', fieldType: 'Category' },
+                    { fieldName: 'additionalTypes', fieldType: 'list<AdditionalType>' },
                   ],
                   fieldsToHide: [
                     { fieldName: 'petId' },
@@ -273,7 +274,7 @@ describe('swagger_type_elements', () => {
         parsedConfigs = res.parsedConfigs
       })
       it('should generate the right types', () => {
-        const updatedExpectedTypes = ['Category', 'Food', 'FoodAndCategory', 'Order', 'Pet2', 'Pet3', 'PetByTag', 'Pet__new', 'Tag', 'User', 'foodDetails', 'pet__findByStatus', 'store__inventory']
+        const updatedExpectedTypes = ['AdditionalType', 'Category', 'Food', 'FoodAndCategory', 'NestedType', 'Order', 'Pet2', 'Pet3', 'PetByTag', 'Pet__new', 'Tag', 'User', 'foodDetails', 'pet__findByStatus', 'store__inventory']
         expect(Object.keys(allTypes).sort()).toEqual(updatedExpectedTypes)
         // no Pet2 because it does not have a request config
         const updatedExpectedParsedConfigs = {
@@ -289,6 +290,7 @@ describe('swagger_type_elements', () => {
           User: { request: { url: '/user/{username}' } },
           Food: { request: { url: '/food/{foodId}' } },
           foodDetails: { request: { url: '/foodDetails' } },
+          AdditionalType: { request: { url: 'AdditionalType' } },
         }
         expect(parsedConfigs).toEqual(updatedExpectedParsedConfigs)
         // regular response type with reference
@@ -321,6 +323,11 @@ describe('swagger_type_elements', () => {
           .getInnerType()).toEqual(allTypes.Category)
         expect(order.fields.newHiddenField).toBeDefined()
         expect(await order.fields.newHiddenField.getType()).toEqual(allTypes.Category)
+        const additionalType = allTypes.AdditionalType as ObjectType
+        expect(additionalType).toBeInstanceOf(ObjectType)
+        expect(await order.fields.additionalTypes.getType()).toBeInstanceOf(ListType)
+        expect(await (await order.fields.additionalTypes.getType() as ListType)
+          .getInnerType()).toEqual(additionalType)
       })
       it('should annotate fields from fieldsToHide with _hidden_value=true', () => {
         const order = allTypes.Order as ObjectType

--- a/packages/adapter-components/test/elements/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/type_elements.test.ts
@@ -16,7 +16,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { FieldDefinition, BuiltinTypes, ObjectType, ElemID, createRefToElmWithValue } from '@salto-io/adapter-api'
 import { SUBTYPES_PATH, TYPES_PATH } from '../../src/elements/constants'
-import { filterTypes, hideFields, markServiceIdField } from '../../src/elements/type_elements'
+import { filterTypes, getContainerForType, hideFields, markServiceIdField } from '../../src/elements/type_elements'
 
 describe('type_elements', () => {
   describe('hideFields', () => {
@@ -155,6 +155,21 @@ describe('type_elements', () => {
         markServiceIdField('id', typeFields, 'test')
         expect(typeFields.id).not.toBeDefined()
       })
+    })
+  })
+
+  describe('getContainerForType', () => {
+    it('should return the correct container and type name substring', () => {
+      const listType = getContainerForType('list<SomeType>')
+      expect(listType?.container).toEqual('list')
+      expect(listType?.typeNameSubstring).toEqual('SomeType')
+      const mapType = getContainerForType('map<list<AnotherType>>')
+      expect(mapType?.container).toEqual('map')
+      expect(mapType?.typeNameSubstring).toEqual('list<AnotherType>')
+    })
+    it('should return undefined if there is no container', () => {
+      const result = getContainerForType('SomeType')
+      expect(result).toBeUndefined()
     })
   })
 })


### PR DESCRIPTION
Fetch swagger types defined in fieldTypeOverrides

tasks left
- [ ]  update `generateTypes` ut 
- [ ] test for swagger V2

---
_Release Notes_: 
None

---
_User Notifications_: 
None
