### PR TITLE
SALTO-3148 throw on SDF deploy error in other languages

### DIFF
--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -315,10 +315,12 @@ export default class SdfClient {
       return
     }
 
-    const dataLines = data.filter(_.isString)
+    const dataLines = data.map(String.toString)
 
     if (dataLines.some(line => fatalErrorMessageRegex.test(line))) {
-      throw new Error(dataLines.join(os.EOL))
+      const errorMessage = dataLines.join(os.EOL)
+      log.error('non-thrown sdf error was detected: %o', errorMessage)
+      throw new Error(errorMessage)
     }
 
     const featureDeployFailes = dataLines.filter(line => configureFeatureFailRegex.test(line))

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -315,7 +315,7 @@ export default class SdfClient {
       return
     }
 
-    const dataLines = data.map(String.toString)
+    const dataLines = data.map(line => String(line))
 
     if (dataLines.some(line => fatalErrorMessageRegex.test(line))) {
       const errorMessage = dataLines.join(os.EOL)

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -1334,6 +1334,27 @@ describe('sdf client', () => {
         await expect(client.deploy([{} as CustomTypeInfo], ...DEFAULT_DEPLOY_PARAMS)).rejects
           .toThrow(new Error(errorMessage))
       })
+      it('should throw error when sdf result contain error in other language', async () => {
+        const sdfResult = [
+          'Starting deploy',
+          '*** ERREUR ***',
+          'some error',
+        ]
+        mockExecuteAction.mockResolvedValue({ isSuccess: () => true, data: sdfResult })
+        const customTypeInfo = {
+          typeName: 'typeName',
+          values: {
+            key: 'val',
+          },
+          scriptId: 'some_id',
+        } as CustomTypeInfo
+        await expect(client.deploy([customTypeInfo], ...DEFAULT_DEPLOY_PARAMS)).rejects
+          .toThrow(new Error(
+            'Starting deploy\n'
+            + '*** ERREUR ***\n'
+            + 'some error'
+          ))
+      })
       it('should throw ObjectsDeployError when deploy failed on object validation', async () => {
         const errorMessage = `
 The deployment process has encountered an error.
@@ -1878,6 +1899,20 @@ Details: The manifest contains a dependency on ${errorReferenceName} object, but
         })
         await expect(client.deploy(...deployParams)).rejects.toThrow(errorMessage)
         expect(mockExecuteAction).toHaveBeenCalledWith(validateProjectCommandMatcher)
+      })
+      it('should throw error when sdf result contain error in other language', async () => {
+        const sdfResult = [
+          'Starting validation',
+          '*** ERREUR ***',
+          'some error',
+        ]
+        mockExecuteAction.mockResolvedValue({ isSuccess: () => true, data: sdfResult })
+        await expect(client.deploy(...deployParams)).rejects
+          .toThrow(new Error(
+            'Starting validation\n'
+            + '*** ERREUR ***\n'
+            + 'some error'
+          ))
       })
     })
   })


### PR DESCRIPTION
In case that SDF deploy failed on an non-english NS account, no error is thrown from SDF so we need to look for the error format of `***<error in any language>***` and throw an exception.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Throw on SDF deploy error in other languages

---
_User Notifications_: 
None