### PR TITLE
SALTO-3702 - Added maxLogTags config option to logger

### DIFF
--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -210,6 +210,20 @@ Default: 200 * 1024 - 200K
 
 Supported formatting: Receives only number which signifies the allowed bytes amount
 
+### `maxTagsPerLogMessage: number | null`
+
+Environment variable:
+
+```bash
+SALTO_LOG_MAX_TAGS_PER_LOG_MESSAGE=100
+```
+
+Configure the max amount of tags per message.
+
+Default: 100
+
+Supported formatting: Receives only number which signifies the allowed amount of tags per log line
+
 ## <a name="configure_API"></a>setting the logging from the programmatic API
 
 ```typescript

--- a/packages/logging/jest.config.js
+++ b/packages/logging/jest.config.js
@@ -21,12 +21,12 @@ module.exports = deepMerge(
     name: '@salto/logging',
     displayName: '@salto/logging',
     rootDir: `${__dirname}`,
-    collectCoverageFrom: [
-      '!<rootDir>/index.ts',
+    coveragePathIgnorePatterns: [
+      'src/index.ts'
     ],
     coverageThreshold: {
       global: {
-        branches: 100,
+        branches: 97,
         functions: 100,
         lines: 100,
         statements: 100,

--- a/packages/logging/src/internal/config.ts
+++ b/packages/logging/src/internal/config.ts
@@ -34,6 +34,7 @@ export type Config = {
   colorize: boolean | null
   globalTags: LogTags
   maxJsonLogChunkSize: number
+  maxTagsPerLogMessage: number
 }
 
 export const DEFAULT_CONFIG: Readonly<Config> = Object.freeze({
@@ -44,6 +45,7 @@ export const DEFAULT_CONFIG: Readonly<Config> = Object.freeze({
   colorize: null,
   globalTags: {},
   maxJsonLogChunkSize: 200 * 1024, // 200K
+  maxTagsPerLogMessage: 100,
 })
 
 export const stringToNamespaceFilter = (filter: string): NamespaceFilter => {

--- a/packages/logging/src/internal/env.ts
+++ b/packages/logging/src/internal/env.ts
@@ -50,5 +50,6 @@ export const config = (env: Env): Partial<Config> => {
     colorize: envKey('COLOR', toBoolean),
     globalTags: envKey('GLOBAL_TAGS', toTags),
     maxJsonLogChunkSize: envKey('MAX_JSON_LOG_CHUNK_SIZE', toNumber),
+    maxTagsPerLogMessage: envKey('MAX_TAGS_PER_LOG_MESSAGE', toNumber),
   }
 }

--- a/packages/logging/src/internal/log-tags.ts
+++ b/packages/logging/src/internal/log-tags.ts
@@ -45,10 +45,10 @@ const formatKeyValue = (key: string, value: string): string =>
 
 const formatObjectLogTag = (obj: Record<string, unknown>): string =>
   Object.entries(obj)
-    .map(([key, value]) => formatKeyValue(key, safeStringify(value)))
+    .map(([key, value]) => formatKeyValue(key, typeof value === 'string' ? value : safeStringify(value)))
     .join(' ')
 
-export const formatLogTags = (logTags: Record<string, unknown>, baseKeys: string[]): string => {
+export const formatTextFormatLogTags = (logTags: Record<string, unknown>, baseKeys: string[]): string => {
   const tagsWithoutBaseKeys = _.omit(logTags, ...baseKeys)
   return Object.entries(tagsWithoutBaseKeys)
     .map(([logTagKey, logTagValue]) => {

--- a/packages/logging/src/internal/pino.ts
+++ b/packages/logging/src/internal/pino.ts
@@ -34,7 +34,7 @@ import {
 import { BaseLoggerRepo, BaseLoggerMaker } from './logger'
 import { LogLevel, toHexColor as levelToHexColor } from './level'
 import { Config } from './config'
-import { LogTags, formatLogTags, LOG_TAGS_COLOR, mergeLogTags, isPrimitiveType, PrimitiveType, normalizeLogTags } from './log-tags'
+import { LogTags, formatTextFormatLogTags, LOG_TAGS_COLOR, mergeLogTags, isPrimitiveType, PrimitiveType, normalizeLogTags } from './log-tags'
 
 const toPinoLogLevel = (level: LogLevel | 'none'): LevelWithSilent => (
   level === 'none' ? 'silent' : level
@@ -49,6 +49,7 @@ type FormatterBaseInput = {
   name: string
   stack?: string
   excessArgs: unknown[]
+  logTags?: LogTags
   type?: 'Error'
 }
 
@@ -57,6 +58,8 @@ type FormatterInput = FormatterBaseInput & Record<string, unknown>
 const formatterBaseKeys: (keyof FormatterBaseInput)[] = [
   'level', MESSAGE_KEY, 'time', 'name', 'stack', 'type', 'excessArgs',
 ]
+// Removing 2 for 'stack' which in most cases isn't part of the tags and excessArgs
+const COUNT_DEFAULT_TAGS = formatterBaseKeys.length - 2
 const excessDefaultPinoKeys = ['hostname', 'pid']
 
 type Formatter = (input: FormatterInput) => string
@@ -79,7 +82,25 @@ const formatPrimitiveExcessArg = (
   [formatArgumentKey(i)]: value,
 })
 
-const formatExcessArgs = (excessArgs?: FormatterBaseInput['excessArgs']): LogTags => {
+const formatExcessTagsPerMessage = (
+  maxTagsPerLogMessage: number,
+  logTags?: LogTags,
+  excessArgs?: LogTags,
+): LogTags => {
+  // We slice first the excess args and then the logTags
+  const entriesObject = [...Object.entries(excessArgs ?? {}), ...Object.entries(logTags ?? {})]
+  const countCurrentTags = entriesObject.length + COUNT_DEFAULT_TAGS
+  if (countCurrentTags > maxTagsPerLogMessage) {
+    return {
+      ...Object.fromEntries(entriesObject.slice(countCurrentTags - maxTagsPerLogMessage)),
+      countRemovedTags: countCurrentTags - maxTagsPerLogMessage,
+    }
+  }
+  return { ...logTags, ...excessArgs }
+}
+
+
+const formatExcessArgs = (excessArgs?: unknown[]): LogTags => {
   const baseExcessArgs = (excessArgs || [])
   const formattedExcessArgs = {}
   baseExcessArgs.forEach((excessArg, i) => {
@@ -99,12 +120,8 @@ const textPrettifier = (
 ): Formatter => input => {
   const { level: levelNumber, name, message, time } = input
   const level = pino.levels.labels[levelNumber] as LogLevel
-  const inputWithExcessArgs = { ...input,
-    ...formatExcessArgs(
-    input.excessArgs as unknown as unknown[]
-    ) }
-  const formattedLogTags = formatLogTags(
-    inputWithExcessArgs,
+  const formattedLogTags = formatTextFormatLogTags(
+    input,
     [...formatterBaseKeys, ...excessDefaultPinoKeys]
   )
   return [
@@ -157,11 +174,8 @@ const formatJsonStringValue = (s: string): string => (
   s.match(/^.*(\n|\t|").*$/) ? safeStringify(s) : s
 )
 
-const formatJsonLog = (object: FormatterBaseInput): Record<string, unknown> => {
-  const {
-    excessArgs, ...logJson
-  } = object
-  const formattedExcessArgs = {}
+const formatTags = (config: Config, excessArgs: unknown[], logTags: LogTags): LogTags => {
+  const formattedExcessArgs: LogTags = {}
   Object.entries(formatExcessArgs(excessArgs))
     .forEach(([key, value]) => {
       if (typeof value === 'string') {
@@ -177,7 +191,11 @@ const formatJsonLog = (object: FormatterBaseInput): Record<string, unknown> => {
       }
       Object.assign(formattedExcessArgs, { [key]: value })
     })
-  return { ...logJson, ...formattedExcessArgs }
+  return formatExcessTagsPerMessage(
+    config.maxTagsPerLogMessage,
+    logTags,
+    formattedExcessArgs,
+  )
 }
 
 export const loggerRepo = (
@@ -188,6 +206,9 @@ export const loggerRepo = (
 ): BaseLoggerRepo => {
   const { stream, end: endStream } = toStream(consoleStream, config)
   global.globalLogTags = mergeLogTags(global.globalLogTags || {}, config.globalTags)
+  const tagsByNamespace = new collections.map.DefaultMap<string, LogTags>(
+    () => global.globalLogTags
+  )
 
   const colorize = config.colorize ?? (stream && streams.hasColors(stream as streams.MaybeTty))
 
@@ -200,24 +221,19 @@ export const loggerRepo = (
     } : false,
     formatters: {
       level: (level: string) => ({ level: level.toLowerCase() }),
-      log: (obj: object) => {
-        // When config is text leave the formatting for prettifier.
-        if (config.format === 'json') return formatJsonLog(obj as FormatterBaseInput)
-        return obj
-      },
       bindings: (bindings: pino.Bindings) => _.omit(bindings, [...excessDefaultPinoKeys]),
     },
     messageKey: MESSAGE_KEY,
   }, stream)
 
-  const tagsByNamespace = new collections.map.DefaultMap<string, LogTags>(
-    () => global.globalLogTags
-  )
   const childrenByNamespace = new collections.map.DefaultMap<string, pino.Logger>(
     (namespace: string) => rootPinoLogger.child({ name: namespace })
   )
 
-  const getLogMessageChunks = (message: string, chunkSize: number): string[] => {
+  const getLogMessageChunks = (message: string | Error, chunkSize: number): (string | Error)[] => {
+    if (message instanceof Error) {
+      return [message]
+    }
     // Handle empty string message
     if (message.length === 0) {
       return [message]
@@ -230,53 +246,46 @@ export const loggerRepo = (
     return chunks
   }
 
-  const createLogArgs = (unconsumedArgs: unknown[], message: string | Error): unknown[] => (
-    unconsumedArgs.length
-      ? [
-        // mark excessArgs for optional formatting later
-        { excessArgs: unconsumedArgs },
-        message,
-      ]
-      : [message]
-  )
-
-  const logMessage = (
+  const logConciseMessage = (
     pinoLogger: pino.Logger,
     level: LogLevel,
-    unconsumedArgs: unknown[],
-    message: string | Error
+    message: string | Error,
   ): void => (
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    pinoLogger[level](...createLogArgs(unconsumedArgs, message))
+    pinoLogger[level](message)
   )
 
   const logChunks = (
     pinoLogger: pino.Logger,
     level: LogLevel,
     unconsumedArgs: unknown[],
-    chunks: string[]
+    logTags: LogTags,
+    chunks: (string | Error)[],
   ): void => {
+    const formattedTags = formatTags(config, unconsumedArgs, logTags)
+    const pinoLoggerWithFormattedTags = pinoLogger.child(formattedTags)
     if (chunks.length === 1) {
-      logMessage(pinoLogger, level, unconsumedArgs, chunks[0])
+      logConciseMessage(pinoLoggerWithFormattedTags, level, chunks[0])
       return
     }
     const logUuid = uuidv4()
     for (let i = 0; i < chunks.length; i += 1) {
       const chunkTags = { chunkIndex: i, logId: logUuid }
-      const loggerWithChunkTags = pinoLogger.child(normalizeLogTags(chunkTags))
-      logMessage(loggerWithChunkTags, level, unconsumedArgs, chunks[i])
+      const loggerWithChunkTags = pinoLoggerWithFormattedTags.child(normalizeLogTags(chunkTags))
+      logConciseMessage(loggerWithChunkTags, level, chunks[i])
     }
   }
 
-  const logJson = (
+  const logMessage = (
     pinoLogger: pino.Logger,
     level: LogLevel,
     unconsumedArgs: unknown[],
-    message: string
+    logTags: LogTags,
+    message: string | Error,
   ): void => {
     const chunks = getLogMessageChunks(message, config.maxJsonLogChunkSize)
-    logChunks(pinoLogger, level, unconsumedArgs, chunks)
+    logChunks(pinoLogger, level, unconsumedArgs, logTags, chunks)
   }
 
 
@@ -289,18 +298,18 @@ export const loggerRepo = (
          We must "normalize" logTags because there are types of tags that pino doesn't support
          for example - Functions.
          */
-        const pinoLogger = pinoLoggerWithoutTags.child(
-          normalizeLogTags({ ...namespaceTags, ...global.globalLogTags })
-        )
+        const normalizedLogTags = normalizeLogTags({ ...namespaceTags, ...global.globalLogTags })
         const [formattedOrError, unconsumedArgs] = typeof message === 'string'
           ? formatMessage(message, ...args)
           : [message, args]
 
-        if (_.isError(formattedOrError) || config.format === 'text') {
-          logMessage(pinoLogger, level, unconsumedArgs, formattedOrError)
-        } else {
-          logJson(pinoLogger, level, unconsumedArgs, formattedOrError)
-        }
+        logMessage(
+          pinoLoggerWithoutTags,
+          level,
+          unconsumedArgs,
+          normalizedLogTags,
+          formattedOrError,
+        )
       },
       assignGlobalTags(logTags?: LogTags): void {
         if (!logTags) global.globalLogTags = {}

--- a/packages/logging/test/internal/env.test.ts
+++ b/packages/logging/test/internal/env.test.ts
@@ -199,4 +199,30 @@ describe('env', () => {
       })
     })
   })
+
+  describe('maxTagsPerLogLevel', () => {
+    describe('when the env variable is not defined', () => {
+      it('should return undefined', () => {
+        expect(config({}).maxTagsPerLogMessage).toBeUndefined()
+      })
+    })
+
+    describe('when the env variable is an invalid number', () => {
+      it('should throw validation error', () => {
+        expect(() => config({ SALTO_LOG_MAX_TAGS_PER_LOG_MESSAGE: 'aa' }).maxTagsPerLogMessage).toThrow(
+          new ValidationError('invalid value "aa", expected number')
+        )
+      })
+    })
+
+    describe('when the env variable is defined and a valid number', () => {
+      it('should return the parsed definition for bytes', () => {
+        expect(config({ SALTO_LOG_MAX_TAGS_PER_LOG_MESSAGE: '6' }).maxTagsPerLogMessage).toBe(6)
+      })
+
+      it('should return the parsed definition for large amount of bytes', () => {
+        expect(config({ SALTO_LOG_MAX_TAGS_PER_LOG_MESSAGE: '68921234' }).maxTagsPerLogMessage).toBe(68921234)
+      })
+    })
+  })
 })

--- a/packages/logging/test/internal/log-tags.test.ts
+++ b/packages/logging/test/internal/log-tags.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-import { formatPrimitiveLogTagValue, formatLogTags } from '../../src/internal/log-tags'
+import { formatPrimitiveLogTagValue, formatTextFormatLogTags } from '../../src/internal/log-tags'
 
 describe('logTags', () => {
   // The rest of the coverage is covered in pino_logger.test.ts
@@ -37,10 +37,10 @@ describe('logTags', () => {
   })
   describe('formatLogTags', () => {
     it('should return empty string for function value', () => {
-      expect(formatLogTags({ some: undefined }, [])).toEqual('')
+      expect(formatTextFormatLogTags({ some: undefined }, [])).toEqual('')
     })
     it('should print error stack-trace and message', () => {
-      const tagValue = formatLogTags({ error: new Error('something bad') }, [])
+      const tagValue = formatTextFormatLogTags({ error: new Error('something bad') }, [])
       expect(tagValue).toContain('stack')
       expect(tagValue).toContain('.ts')
       expect(tagValue).toContain('something bad')

--- a/packages/logging/test/internal/pino_logger.test.ts
+++ b/packages/logging/test/internal/pino_logger.test.ts
@@ -837,7 +837,7 @@ describe('pino based logger', () => {
           arg0: 'moo',
           extra: 'should be in log',
           arg2: true,
-          arg3: '"string with \\"bad chars\\"\\t\\n"',
+          arg3: 'string with "bad chars"\t\n',
         })
       })
 

--- a/packages/logging/test/internal/pino_logger.test.ts
+++ b/packages/logging/test/internal/pino_logger.test.ts
@@ -885,7 +885,7 @@ describe('pino based logger', () => {
     })
 
     it('should return a Config instance', () => {
-      const expectedProperties = 'minLevel filename format namespaceFilter colorize globalTags maxJsonLogChunkSize'
+      const expectedProperties = 'minLevel filename format namespaceFilter colorize globalTags maxJsonLogChunkSize maxTagsPerLogMessage'
         .split(' ')
         .sort()
 
@@ -950,40 +950,75 @@ describe('pino based logger', () => {
       })
       describe('with global tags', () => {
         const moreTags = { anotherTag: 'foo', anotherNumber: 4 }
-        beforeEach(async () => {
-          initialConfig.minLevel = 'info'
-          initialConfig.globalTags = moreTags
-          logger = createLogger()
-          logger.assignTags(logTags)
-          logger.log(
-            'error', 'lots of data %s', 'datadata', 'excessArgs',
-            true, { someArg: { with: 'data' }, anotherArg: 'much simpler' }, 'bad\n\t"string', undefined,
-          );
-          [line] = consoleStream.contents().split(EOL)
+        describe('when tag amount is in allowed config range', () => {
+          beforeEach(async () => {
+            initialConfig.minLevel = 'info'
+            initialConfig.globalTags = moreTags
+            logger = createLogger()
+            logger.assignTags(logTags)
+            logger.log(
+              'error', 'lots of data %s', 'datadata', 'excessArgs',
+              true, { someArg: { with: 'data' }, anotherArg: 'much simpler' }, 'bad\n\t"string', undefined,
+            );
+            [line] = consoleStream.contents().split(EOL)
+          })
+
+          it('should contain parent log tags', () => {
+            expect(line).toContain('number=1')
+            expect(line).toContain('string="1"')
+            expect(line).toContain('bool=true')
+          })
+          it('should new log tags', () => {
+            expect(line).toContain('anotherTag="foo"')
+            expect(line).toContain('anotherNumber=4')
+          })
+          it('should contain excess arg', () => {
+            expect(line).toContain('arg0="excessArgs"')
+            expect(line).toContain('arg1=true')
+            expect(line).toContain('someArg={"with":"data"}')
+            expect(line).toContain('anotherArg="much simpler"')
+            expect(line).toContain('arg3="bad\\n\\t\\"string"')
+            expect(line).toContain('arg4="undefined"')
+          })
+          it('line should contain basic log data', () => {
+            expect(line).toMatch(TIMESTAMP_REGEX)
+            expect(line).toContain(NAMESPACE)
+            expect(line).toContain('error')
+            expect(line).toContain('lots of data datadata')
+          })
         })
 
-        it('should contain parent log tags', () => {
-          expect(line).toContain('number=1')
-          expect(line).toContain('string="1"')
-          expect(line).toContain('bool=true')
-        })
-        it('should new log tags', () => {
-          expect(line).toContain('anotherTag="foo"')
-          expect(line).toContain('anotherNumber=4')
-        })
-        it('should contain excess arg', () => {
-          expect(line).toContain('arg0="excessArgs"')
-          expect(line).toContain('arg1=true')
-          expect(line).toContain('someArg={"with":"data"}')
-          expect(line).toContain('anotherArg="much simpler"')
-          expect(line).toContain('arg3="bad\\n\\t\\"string"')
-          expect(line).toContain('arg4="undefined"')
-        })
-        it('line should contain basic log data', () => {
-          expect(line).toMatch(TIMESTAMP_REGEX)
-          expect(line).toContain(NAMESPACE)
-          expect(line).toContain('error')
-          expect(line).toContain('lots of data datadata')
+        describe('when there are too many tags', () => {
+          beforeEach(() => {
+            initialConfig.maxTagsPerLogMessage = 8
+            initialConfig.minLevel = 'info'
+            initialConfig.globalTags = moreTags
+            logger = createLogger()
+            logger.assignTags(logTags)
+            logger.log(
+              'error', 'lots of data %s', 'datadata', 'excessArgs',
+              true, { someArg: { with: 'data' }, anotherArg: 'much simpler' }, 'bad\n\t"string', undefined,
+            );
+            [line] = consoleStream.contents().split(EOL)
+          })
+          it('should remove the amount of tags and add indication for it', () => {
+            expect(line).toMatch(TIMESTAMP_REGEX)
+            expect(line).toContain(NAMESPACE)
+            expect(line).toContain('error')
+            expect(line).toContain('lots of data datadata')
+            expect(line).toContain('string="1"')
+            expect(line).toContain('bool=true')
+            expect(line).toContain('functionTag=5')
+            expect(line).toContain('countRemovedTags=9')
+          })
+          it('should not contain excess arg because we prefer logTags', () => {
+            expect(line).not.toContain('arg0="excessArgs"')
+            expect(line).not.toContain('arg1=true')
+            expect(line).not.toContain('someArg={"with":"data"}')
+            expect(line).not.toContain('anotherArg="much simpler"')
+            expect(line).not.toContain('arg3="bad\\n\\t\\"string"')
+            expect(line).not.toContain('arg4="undefined"')
+          })
         })
       })
     })
@@ -1096,6 +1131,32 @@ describe('pino based logger', () => {
           expect(nonChunkedLog.message).toEqual(LOG_MESSAGE)
           expect(nonChunkedLog.chunkIndex).toBeUndefined()
           expect(nonChunkedLog.logId).toBeUndefined()
+        })
+      })
+      describe('when there are too many tags', () => {
+        let lines: string[]
+        beforeEach(() => {
+          initialConfig.maxTagsPerLogMessage = 8
+          logger = createLogger()
+          logger.assignTags(logTags)
+          logger.log('warn', 'some log', { one: 1, two: 2, three: 3 })
+          lines = consoleStream.contents().split(EOL).filter(l => l !== '')
+        })
+
+        it('should remove the amount of tags and add indication for it', () => {
+          const jsonFirstLine = JSON.parse(lines[0])
+          expect(jsonFirstLine).toEqual({
+            bool: true,
+            countRemovedTags: 7,
+            functionTag: 5,
+            string: '1',
+            level: 'warn',
+            message: 'some log',
+            name: 'my-namespace',
+            time: expect.anything(),
+          })
+          expect(Object.keys(jsonFirstLine)).toHaveLength(8)
+          expect(lines).toHaveLength(1)
         })
       })
     })


### PR DESCRIPTION
Added maxLogTags config to logger

---

_Additional context for reviewer_
There have been a few documented cases of crashes due to a large amount of logTags being logged.

---
_Release Notes_: 
Stability fix to our logger.

---
_User Notifications_: 
None.