### PR TITLE
SAAS-7316: Add validate capability to the dummy-adapter

### DIFF
--- a/packages/dummy-adapter/src/adapter.ts
+++ b/packages/dummy-adapter/src/adapter.ts
@@ -42,6 +42,14 @@ export default class DummyAdapter implements AdapterOperations {
     }
   }
 
+  // eslint-disable-next-line class-methods-use-this
+  public async validate({ changeGroup }: DeployOptions): Promise<DeployResult> {
+    return {
+      appliedChanges: changeGroup.changes,
+      errors: [],
+    }
+  }
+
 
   public deployModifiers: DeployModifiers =
   {

--- a/packages/dummy-adapter/test/adapter.test.ts
+++ b/packages/dummy-adapter/test/adapter.test.ts
@@ -47,6 +47,17 @@ describe('dummy adapter', () => {
       })
     })
   })
+  describe('validate', () => {
+    it('should be defined', () => {
+      expect(adapter.validate).toBeDefined()
+    })
+    it('should do nothing', async () => {
+      expect(await adapter.validate({ changeGroup: { changes: [], groupID: ':)' } })).toEqual({
+        appliedChanges: [],
+        errors: [],
+      })
+    })
+  })
 
   describe('fetch', () => {
     const progressReportMock = {


### PR DESCRIPTION
Add `validate` capability to the dummy-adapter

I'm not 100% sure I'm doing this right, or if this is the right approach, so this is WIP.

---

None

---

_Release Notes_: 
None

---

_User Notifications_: 
None