### PR TITLE
SALTO-3708: zendesk typeError cannot read property toString of undefined

### DIFF
--- a/packages/zendesk-adapter/src/filters/view.ts
+++ b/packages/zendesk-adapter/src/filters/view.ts
@@ -24,7 +24,7 @@ import { applyforInstanceChangesOfType } from './utils'
 
 export const VIEW_TYPE_NAME = 'view'
 
-const valToString = (val: Value): string | string[] => (_.isArray(val) ? val.map(String) : val.toString())
+const valToString = (val: Value): string | string[] => (_.isArray(val) ? val.map(String) : val?.toString())
 
 /**
  * Deploys views

--- a/packages/zendesk-adapter/test/filters/view.test.ts
+++ b/packages/zendesk-adapter/test/filters/view.test.ts
@@ -114,6 +114,10 @@ describe('views filter', () => {
             operator: 'includes',
             value: [5, 6],
           },
+          {
+            field: 'custom_fields_1500009152882',
+            operator: 'not_present',
+          },
         ],
         any: [
           {
@@ -153,6 +157,7 @@ describe('views filter', () => {
         { field: 'status', operator: 'is', value: 'open' },
         { field: 'brand_id', operator: 'is', value: '3' },
         { field: 'custom_status_id', operator: 'includes', value: ['5', '6'] },
+        { field: 'custom_fields_1500009152882', operator: 'not_present' },
       ])
     })
     it('should add output', async () => {


### PR DESCRIPTION
_zendesk typeError cannot read property toString of undefined_

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* fix error of cannot read property toString of undefined in view filter

---
_User Notifications_: 
None
