### PR TITLE
salto-2883 netsuite partial fetch

### DIFF
--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -190,7 +190,7 @@ const queryConfigType = createMatchingObjectType<NetsuiteQueryParameters>({
       refType: new MapType(new ListType(BuiltinTypes.STRING)),
       annotations: {
         [CORE_ANNOTATIONS.DEFAULT]: {},
-        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ regex: '^customrecord[0-9a-z_]+', enforce_value: false }),
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ regex: '^customrecord[0-9a-z_]+$', enforce_value: false }),
       },
     },
   },


### PR DESCRIPTION
Changes in Netsuite partial fetch:
Quick fetch false by default
Don't allow partial fetch for first fetch

---

_Additional context for reviewer_
_None_

---
_Release Notes_: 
Netsuite Fetches will not be "quick" fetches by default, but only if quick fetch was requested.
Partial fetch as first fetch is not supported

---
_User Notifications_: 
_None_
