### PR TITLE
SALTO-3688: Add fetch warning if talking to an old version of Jira DC Plugin

### DIFF
--- a/packages/jira-adapter/package.json
+++ b/packages/jira-adapter/package.json
@@ -40,6 +40,7 @@
     "joi": "^17.4.0",
     "lodash": "^4.17.21",
     "pako": "^1.0.11",
+    "semver": "^7.3.2",
     "uuid": "^8.3.0",
     "wu": "^2.1.0",
     "xml-js": "^1.6.11"
@@ -50,6 +51,7 @@
     "@types/jest": "^27.4.0",
     "@types/lodash": "^4.14.168",
     "@types/pako": "^1.0.1",
+    "@types/semver": "^7.3.3",
     "@typescript-eslint/eslint-plugin": "4.22.1",
     "@typescript-eslint/parser": "4.22.1",
     "axios": "^0.21.3",

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -119,6 +119,7 @@ import commonFilters from './filters/common'
 import accountInfoFilter from './filters/account_info'
 import deployPermissionSchemeFilter from './filters/permission_scheme/deploy_permission_scheme_filter'
 import scriptRunnerWorkflowFilter from './filters/script_runner/workflow_filter'
+import pluginVersionFliter from './filters/data_center/plugin_version'
 import scriptRunnerWorkflowOrFilter from './filters/script_runner/workflow_ors'
 import storeUsersFilter from './filters/store_users'
 
@@ -204,6 +205,7 @@ export const DEFAULT_FILTERS = [
   jqlReferencesFilter,
   removeEmptyValuesFilter,
   maskingFilter,
+  pluginVersionFliter,
   referenceBySelfLinkFilter,
   // Must run after referenceBySelfLinkFilter
   removeSelfFilter,

--- a/packages/jira-adapter/src/filters/data_center/plugin_version.ts
+++ b/packages/jira-adapter/src/filters/data_center/plugin_version.ts
@@ -62,7 +62,7 @@ const filter: FilterCreator = ({ client }) => ({
         return {
           errors: [
             {
-              message: `Your Jira instance is running an old version ${response.data.version} of Salto Configuration Manager for Jira Data Center. Please update the app by setting up automatic updates, or visit https://marketplace.atlassian.com/apps/1225356/salto-configuration-manager-for-jira to download the latest version.`,
+              message: `Your Jira instance is running an old version ${response.data.version} of Salto Configuration Manager for Jira Data Center. Please update the app to the latest version from https://marketplace.atlassian.com/apps/1225356/salto-configuration-manager-for-jira.`,
               severity: 'Warning',
             },
           ],

--- a/packages/jira-adapter/src/filters/data_center/plugin_version.ts
+++ b/packages/jira-adapter/src/filters/data_center/plugin_version.ts
@@ -1,0 +1,100 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import Joi from 'joi'
+import { logger } from '@salto-io/logging'
+import { createSchemeGuard } from '@salto-io/adapter-utils'
+import { FilterCreator } from '../../filter'
+
+const log = logger(module)
+export const PLUGIN_VERSION_NUMBER = '1.0.4'
+
+const versionNumberCompare = (version1: string, version2: string): number => {
+  const version1Parts = version1.split('.')
+  const version2Parts = version2.split('.')
+  const maxParts = Math.max(version1Parts.length, version2Parts.length)
+  for (let i = 0; i < maxParts; i += 1) {
+    const version1Part = version1Parts[i] ?? '0'
+    const version2Part = version2Parts[i] ?? '0'
+    if (version1Part !== version2Part) {
+      return parseInt(version1Part, 10) - parseInt(version2Part, 10)
+    }
+  }
+  return 0
+}
+
+type InfoResponse = {
+  version: string
+}
+
+const INFO_RESPONSE_SCHEME = Joi.object({
+  version: Joi.string().required(),
+}).required()
+
+const isInfoResonse = createSchemeGuard<InfoResponse>(INFO_RESPONSE_SCHEME, 'Failed to get plugin info')
+
+/**
+ * Filter to verfiy plugin version is up to date
+ */
+const filter: FilterCreator = ({ client }) => ({
+  name: 'jiraDcPluginVerionNumberFilter',
+  onFetch: async () => {
+    if (!client.isDataCenter) {
+      return undefined
+    }
+    try {
+      const response = await client.getSinglePage({
+        url: '/rest/api/3/plugininfo',
+      })
+      if (!isInfoResonse(response.data)) {
+        throw new Error('Invalid pluginInfo response')
+      }
+      const compareResult = versionNumberCompare(response.data.version, PLUGIN_VERSION_NUMBER)
+      if (compareResult > 0) {
+        return {
+          errors: [
+            {
+              message: 'The Salto for Jira DC addon version number is higher than expected. You may be running an outdated Salto CLI; please update it to the latest version from https://github.com/salto-io/salto/releases',
+              severity: 'Info',
+            },
+          ],
+        }
+      }
+      if (compareResult < 0) {
+        return {
+          errors: [
+            {
+              message: `Your Jira instance is running an old version ${response.data.version} of Salto Configuration Manager for Jira Data Center. Please update the app by setting up automatic updates, or visit https://marketplace.atlassian.com/apps/1225356/salto-configuration-manager-for-jira to download the latest version.`,
+              severity: 'Warning',
+            },
+          ],
+        }
+      }
+      return undefined
+    } catch (e) {
+      log.error('Failed to verify plugin version number, error is %o', e)
+      return {
+        errors: [
+          {
+            message: 'Could not verify version number for Salto for Jira DC addon. Please make sure you are using the latest version of Salto Configuration Manager for Jira Data Center. You can download it from the Jira Marketplace: https://marketplace.atlassian.com/apps/1225356/salto-configuration-manager-for-jira?tab=overview&hosting=datacenter',
+            severity: 'Warning',
+          },
+        ],
+      }
+    }
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/src/product_settings/data_center/data_center.ts
+++ b/packages/jira-adapter/src/product_settings/data_center/data_center.ts
@@ -346,6 +346,10 @@ const PLUGIN_URL_PATTERNS: UrlPattern[] = [
     httpMethods: ['get', 'put'],
     url: '/rest/api/3/field/.+/context/defaultValue',
   },
+  {
+    httpMethods: ['get'],
+    url: '/rest/api/3/plugininfo',
+  },
 ]
 
 const replaceRestVersion = (url: string): string => url.replace(

--- a/packages/jira-adapter/src/product_settings/data_center/data_center.ts
+++ b/packages/jira-adapter/src/product_settings/data_center/data_center.ts
@@ -346,10 +346,6 @@ const PLUGIN_URL_PATTERNS: UrlPattern[] = [
     httpMethods: ['get', 'put'],
     url: '/rest/api/3/field/.+/context/defaultValue',
   },
-  {
-    httpMethods: ['get'],
-    url: '/rest/api/3/plugininfo',
-  },
 ]
 
 const replaceRestVersion = (url: string): string => url.replace(

--- a/packages/jira-adapter/test/filters/data_center/plugin_version.test.ts
+++ b/packages/jira-adapter/test/filters/data_center/plugin_version.test.ts
@@ -1,0 +1,129 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
+import { MockInterface } from '@salto-io/test-utils'
+import { getFilterParams, mockClient } from '../../utils'
+import pluginVersionFilter, { PLUGIN_VERSION_NUMBER } from '../../../src/filters/data_center/plugin_version'
+
+const changeVersion = (version: string, addition: number): string => {
+  const versionParts = version.split('.')
+  const lastPart = parseInt(versionParts[versionParts.length - 1], 10)
+  versionParts[versionParts.length - 1] = (lastPart + addition).toString()
+  return versionParts.join('.')
+}
+
+describe('plugin_version', () => {
+  let filter: filterUtils.FilterWith<'onFetch'>
+  let mockConnection: MockInterface<clientUtils.APIConnection>
+
+  beforeEach(async () => {
+    const { client, connection } = mockClient(true)
+    mockConnection = connection
+    filter = pluginVersionFilter(getFilterParams({
+      client,
+    })) as filterUtils.FilterWith<'onFetch'>
+  })
+  it('should not raise a warning if plugin version is the same', async () => {
+    mockConnection.get.mockResolvedValueOnce({
+      status: 200,
+      data: {
+        version: PLUGIN_VERSION_NUMBER,
+      },
+    })
+    const errors = await filter.onFetch([])
+    expect(errors).toEqual(undefined)
+  })
+  it('should raise a warning if plugin version is older', async () => {
+    mockConnection.get.mockResolvedValueOnce({
+      status: 200,
+      data: {
+        version: changeVersion(PLUGIN_VERSION_NUMBER, -1),
+      },
+    })
+    const errors = await filter.onFetch([])
+    expect(errors).toEqual({
+      errors: [{
+        message: `Your Jira instance is running an old version ${changeVersion(PLUGIN_VERSION_NUMBER, -1)} of Salto Configuration Manager for Jira Data Center. Please update the app by setting up automatic updates, or visit https://marketplace.atlassian.com/apps/1225356/salto-configuration-manager-for-jira to download the latest version.`,
+        severity: 'Warning',
+      }],
+    })
+  })
+  it('should raise an info if plugin version is newer', async () => {
+    const newerVersion = changeVersion(PLUGIN_VERSION_NUMBER, 1)
+    mockConnection.get.mockResolvedValueOnce({
+      status: 200,
+      data: {
+        version: newerVersion,
+      },
+    })
+    const errors = await filter.onFetch([])
+    expect(errors).toEqual({
+      errors: [{
+        message: 'The Salto for Jira DC addon version number is higher than expected. You may be running an outdated Salto CLI; please update it to the latest version from https://github.com/salto-io/salto/releases',
+        severity: 'Info',
+      }],
+    })
+  })
+  it('should raise a warning if server answer is not in the correct format', async () => {
+    mockConnection.get.mockResolvedValueOnce({
+      status: 200,
+      data: {
+        notVersion: 'not a valid version',
+      },
+    })
+    const errors = await filter.onFetch([])
+    expect(errors).toEqual({
+      errors: [{
+        message: 'Could not verify version number for Salto for Jira DC addon. Please make sure you are using the latest version of Salto Configuration Manager for Jira Data Center. You can download it from the Jira Marketplace: https://marketplace.atlassian.com/apps/1225356/salto-configuration-manager-for-jira?tab=overview&hosting=datacenter',
+        severity: 'Warning',
+      }],
+    })
+  })
+  it('should act correctly when versions length are different', async () => {
+    const versionParts = PLUGIN_VERSION_NUMBER.split('.')
+    versionParts.push('1')
+    const versionMore = versionParts.join('.')
+    mockConnection.get.mockResolvedValueOnce({
+      status: 200,
+      data: {
+        version: versionMore,
+      },
+    })
+    const errors = await filter.onFetch([])
+    expect(errors).toEqual({
+      errors: [{
+        message: 'The Salto for Jira DC addon version number is higher than expected. You may be running an outdated Salto CLI; please update it to the latest version from https://github.com/salto-io/salto/releases',
+        severity: 'Info',
+      }],
+    })
+    versionParts.pop()
+    versionParts.pop()
+    const versionLess = versionParts.join('.')
+    mockConnection.get.mockResolvedValueOnce({
+      status: 200,
+      data: {
+        version: versionLess,
+      },
+    })
+    const errors2 = await filter.onFetch([])
+    expect(errors2).toEqual({
+      errors: [{
+        message: `Your Jira instance is running an old version ${versionLess} of Salto Configuration Manager for Jira Data Center. Please update the app by setting up automatic updates, or visit https://marketplace.atlassian.com/apps/1225356/salto-configuration-manager-for-jira to download the latest version.`,
+        severity: 'Warning',
+      }],
+    })
+  })
+})

--- a/packages/jira-adapter/test/filters/data_center/plugin_version.test.ts
+++ b/packages/jira-adapter/test/filters/data_center/plugin_version.test.ts
@@ -92,38 +92,4 @@ describe('plugin_version', () => {
       }],
     })
   })
-  it('should act correctly when versions length are different', async () => {
-    const versionParts = PLUGIN_VERSION_NUMBER.split('.')
-    versionParts.push('1')
-    const versionMore = versionParts.join('.')
-    mockConnection.get.mockResolvedValueOnce({
-      status: 200,
-      data: {
-        version: versionMore,
-      },
-    })
-    const errors = await filter.onFetch([])
-    expect(errors).toEqual({
-      errors: [{
-        message: 'The Salto for Jira DC addon version number is higher than expected. You may be running an outdated Salto CLI; please update it to the latest version from https://github.com/salto-io/salto/releases',
-        severity: 'Info',
-      }],
-    })
-    versionParts.pop()
-    versionParts.pop()
-    const versionLess = versionParts.join('.')
-    mockConnection.get.mockResolvedValueOnce({
-      status: 200,
-      data: {
-        version: versionLess,
-      },
-    })
-    const errors2 = await filter.onFetch([])
-    expect(errors2).toEqual({
-      errors: [{
-        message: `Your Jira instance is running an old version ${versionLess} of Salto Configuration Manager for Jira Data Center. Please update the app by setting up automatic updates, or visit https://marketplace.atlassian.com/apps/1225356/salto-configuration-manager-for-jira to download the latest version.`,
-        severity: 'Warning',
-      }],
-    })
-  })
 })

--- a/packages/jira-adapter/test/filters/data_center/plugin_version.test.ts
+++ b/packages/jira-adapter/test/filters/data_center/plugin_version.test.ts
@@ -56,7 +56,7 @@ describe('plugin_version', () => {
     const errors = await filter.onFetch([])
     expect(errors).toEqual({
       errors: [{
-        message: `Your Jira instance is running an old version ${changeVersion(PLUGIN_VERSION_NUMBER, -1)} of Salto Configuration Manager for Jira Data Center. Please update the app by setting up automatic updates, or visit https://marketplace.atlassian.com/apps/1225356/salto-configuration-manager-for-jira to download the latest version.`,
+        message: `Your Jira instance is running an old version ${changeVersion(PLUGIN_VERSION_NUMBER, -1)} of Salto Configuration Manager for Jira Data Center. Please update the app to the latest version from https://marketplace.atlassian.com/apps/1225356/salto-configuration-manager-for-jira.`,
         severity: 'Warning',
       }],
     })


### PR DESCRIPTION
relevant PR in the plugin:  https://github.com/salto-io/jira-dc-app/pull/95


---
_Release Notes_: 
Jira adapter:
Warn in DC if the plugin and OSS versions do no fit

---
_User Notifications_: 
None
