### PR TITLE
skip convert-lists for file-cabinet instances

### DIFF
--- a/packages/netsuite-adapter/src/filters/convert_lists.ts
+++ b/packages/netsuite-adapter/src/filters/convert_lists.ts
@@ -22,7 +22,7 @@ import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { FilterWith } from '../filter'
 import { datasetType } from '../autogen/types/standard_types/dataset'
-import { isCustomRecordType } from '../types'
+import { isCustomRecordType, isFileCabinetInstance } from '../types'
 
 const { awu } = collections.asynciterable
 
@@ -58,6 +58,8 @@ const filterCreator = (): FilterWith<'onFetch'> => ({
   onFetch: async elements => {
     await awu(elements)
       .filter(isInstanceElement)
+      // file&folder instances have no list fields so we can skip them
+      .filter(inst => !isFileCabinetInstance(inst))
       .forEach(async inst => {
         inst.value = await transformValues({
           values: inst.value,


### PR DESCRIPTION
file&folder instances have no list fields so we can skip them

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Skip convert-lists for file-cabinet instances

---
_User Notifications_: 
None