### PR TITLE
add specific error for sdf instance removal with missing internalId

### DIFF
--- a/packages/netsuite-adapter/src/change_validators/remove_sdf_elements.ts
+++ b/packages/netsuite-adapter/src/change_validators/remove_sdf_elements.ts
@@ -18,6 +18,7 @@ import { values, collections } from '@salto-io/lowerdash'
 import { isCustomRecordType, isStandardType, hasInternalId } from '../types'
 import { LazyElementsSourceIndexes } from '../elements_source_index/types'
 import { NetsuiteChangeValidator } from './types'
+import { isSupportedInstance } from '../filters/internal_ids/sdf_internal_ids'
 
 const { isDefined } = values
 const { awu } = collections.asynciterable
@@ -28,12 +29,20 @@ const validateRemovableChange = async (
   elementsSourceIndex?: LazyElementsSourceIndexes
 ): Promise<ChangeError | undefined> => {
   if (isInstanceElement(element) && isStandardType(element.refType)) {
-    if (!hasInternalId(element)) {
+    if (!isSupportedInstance(element)) {
       return {
         elemID: element.elemID,
         severity: 'Error',
         message: `Can't remove instances of type ${element.elemID.typeName}`,
         detailedMessage: `Can't remove this ${element.elemID.typeName}. Remove it in NetSuite UI`,
+      }
+    }
+    if (!hasInternalId(element)) {
+      return {
+        elemID: element.elemID,
+        severity: 'Error',
+        message: `Can't remove instance of ${element.elemID.typeName}`,
+        detailedMessage: `Can't remove this ${element.elemID.typeName}. Try fetching and deploying again, or remove it in Netsuite UI`,
       }
     }
   } else if (isObjectType(element) && isCustomRecordType(element)) {

--- a/packages/netsuite-adapter/src/change_validators/remove_sdf_elements.ts
+++ b/packages/netsuite-adapter/src/change_validators/remove_sdf_elements.ts
@@ -41,7 +41,7 @@ const validateRemovableChange = async (
       return {
         elemID: element.elemID,
         severity: 'Error',
-        message: `Can't remove instance of ${element.elemID.typeName}`,
+        message: `Can't remove instance of type ${element.elemID.typeName}`,
         detailedMessage: `Can't remove this ${element.elemID.typeName}. Try fetching and deploying again, or remove it in Netsuite UI`,
       }
     }

--- a/packages/netsuite-adapter/src/filters/internal_ids/sdf_internal_ids.ts
+++ b/packages/netsuite-adapter/src/filters/internal_ids/sdf_internal_ids.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, Change, CORE_ANNOTATIONS, Element, Field, getChangeData, InstanceElement, isAdditionChange, isAdditionOrModificationChange, isInstanceElement, isObjectType, TypeReference } from '@salto-io/adapter-api'
+import { BuiltinTypes, Change, CORE_ANNOTATIONS, Element, Field, getChangeData, InstanceElement, isAdditionChange, isAdditionOrModificationChange, isInstanceChange, isInstanceElement, isObjectType, TypeReference } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import Ajv from 'ajv'
 import { logger } from '@salto-io/logging'
@@ -147,16 +147,15 @@ const createRecordIdsMap = async (
   )
 
 
-const getSupportedInstances = (elements: Element[]): InstanceElement[] =>
-  elements
-    .filter(isInstanceElement)
-    .filter(elem => getTableName(elem) in TABLE_NAME_TO_ID_PARAMETER_MAP)
-
+export const isSupportedInstance = (instance: InstanceElement): boolean =>
+  getTableName(instance) in TABLE_NAME_TO_ID_PARAMETER_MAP
 
 const getAdditionInstances = (changes: Change[]): InstanceElement[] =>
-  getSupportedInstances(changes
+  changes
     .filter(isAdditionChange)
-    .map(getChangeData))
+    .filter(isInstanceChange)
+    .map(getChangeData)
+    .filter(isSupportedInstance)
 
 const addInternalIdToInstances = async (
   client: NetsuiteClient,
@@ -229,7 +228,7 @@ const filterCreator: FilterCreator = ({ client }) => ({
     addInternalIdFieldToSupportedType(elements)
     addInternalIdAnnotationToCustomRecordTypes(elements)
 
-    const instances = getSupportedInstances(elements)
+    const instances = elements.filter(isInstanceElement).filter(isSupportedInstance)
     await addInternalIdToInstances(client, instances)
     await addInternalIdToCustomRecordTypes(client, elements)
     await addInternalIdToCustomListValues(client, elements)
@@ -243,7 +242,7 @@ const filterCreator: FilterCreator = ({ client }) => ({
       return
     }
     const changesData = changes.filter(isAdditionOrModificationChange).map(getChangeData)
-    getSupportedInstances(changesData).forEach(inst => {
+    changesData.filter(isInstanceElement).filter(isSupportedInstance).forEach(inst => {
       delete inst.value[INTERNAL_ID]
     })
     changesData.filter(isObjectType).filter(isCustomRecordType).forEach(type => {

--- a/packages/netsuite-adapter/test/change_validators/remove_sdf_elements.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/remove_sdf_elements.test.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import { ElemID, Field, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import { workflowType } from '../../src/autogen/types/standard_types/workflow'
 import { entitycustomfieldType } from '../../src/autogen/types/standard_types/entitycustomfield'
 import removeSdfElementsValidator from '../../src/change_validators/remove_sdf_elements'
 import { CUSTOM_RECORD_TYPE, INTERNAL_ID, METADATA_TYPE, NETSUITE } from '../../src/constants'
@@ -31,6 +32,18 @@ describe('remove sdf object change validator', () => {
   }
 
   describe('remove instance of standard type', () => {
+    it('should have change error when removing an instance of an unsupported standard type', async () => {
+      const standardInstanceNoInternalId = new InstanceElement('test', workflowType().type)
+
+      const changeErrors = await removeSdfElementsValidator([
+        toChange({ before: standardInstanceNoInternalId }),
+      ], undefined, elementsSourceIndex)
+      expect(changeErrors).toHaveLength(1)
+      expect(changeErrors[0].severity).toEqual('Error')
+      expect(changeErrors[0].elemID).toEqual(standardInstanceNoInternalId.elemID)
+      expect(changeErrors[0].message).toEqual('Can\'t remove instances of type workflow')
+    })
+
     it('should have change error when removing an instance of standard type with no internal id', async () => {
       const standardInstanceNoInternalId = new InstanceElement('test', entitycustomfieldType().type)
 
@@ -40,6 +53,7 @@ describe('remove sdf object change validator', () => {
       expect(changeErrors).toHaveLength(1)
       expect(changeErrors[0].severity).toEqual('Error')
       expect(changeErrors[0].elemID).toEqual(standardInstanceNoInternalId.elemID)
+      expect(changeErrors[0].message).toEqual('Can\'t remove instance of type entitycustomfield')
     })
 
     it('should not have change error when removing an instance of standard type with internal id', async () => {


### PR DESCRIPTION
Return different change errors for the cases that instance doesn't have an `internalId`:
- When we don't fetch internalIds for that type
- When we do fetch internalIds for that type, but for some reason that specific instance doesn't have an internalId

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Add specific error for sdf instance removal with missing internalId

---
_User Notifications_: 
None