### PR TITLE
SALTO-3711 - Zendesk Adapter - Filter organization names from the logs

### DIFF
--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -423,13 +423,11 @@ export default class ZendeskAdapter implements AdapterOperations {
         // Concurrent requests with Guide elements may cause 409 errors (SALTO-2961)
         Object.assign(clientConfig, { rateLimit: { deploy: 1 } })
       }
-      return new ZendeskClient(
-        {
-          credentials: { ...credentials, subdomain },
-          config: clientConfig,
-        },
-        { allowOrganizationNames: this.userConfig[FETCH_CONFIG].resolveOrganizationIDs },
-      )
+      return new ZendeskClient({
+        credentials: { ...credentials, subdomain },
+        config: clientConfig,
+        allowOrganizationNames: this.userConfig[FETCH_CONFIG].resolveOrganizationIDs,
+      })
     }
 
     const clientsBySubdomain: Record<string, ZendeskClient> = {}

--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -428,7 +428,7 @@ export default class ZendeskAdapter implements AdapterOperations {
           credentials: { ...credentials, subdomain },
           config: clientConfig,
         },
-        { filterOrganizationNames: !this.userConfig[FETCH_CONFIG].resolveOrganizationIDs },
+        { allowOrganizationNames: this.userConfig[FETCH_CONFIG].resolveOrganizationIDs },
       )
     }
 

--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -428,6 +428,7 @@ export default class ZendeskAdapter implements AdapterOperations {
           credentials: { ...credentials, subdomain },
           config: clientConfig,
         },
+        { filterOrganizationNames: !this.userConfig[FETCH_CONFIG].resolveOrganizationIDs },
       )
     }
 

--- a/packages/zendesk-adapter/src/adapter_creator.ts
+++ b/packages/zendesk-adapter/src/adapter_creator.ts
@@ -144,10 +144,13 @@ export const adapter: Adapter = {
     const config = adapterConfigFromConfig(updatedConfig?.config[0] ?? context.config)
     const credentials = credentialsFromConfig(context.credentials)
     const adapterOperations = new ZendeskAdapter({
-      client: new ZendeskClient({
-        credentials,
-        config: config[CLIENT_CONFIG],
-      }),
+      client: new ZendeskClient(
+        {
+          credentials,
+          config: config[CLIENT_CONFIG],
+        },
+        { filterOrganizationNames: !config[FETCH_CONFIG].resolveOrganizationIDs }
+      ),
       credentials,
       config,
       getElemIdFunc: context.getElemIdFunc,

--- a/packages/zendesk-adapter/src/adapter_creator.ts
+++ b/packages/zendesk-adapter/src/adapter_creator.ts
@@ -144,13 +144,11 @@ export const adapter: Adapter = {
     const config = adapterConfigFromConfig(updatedConfig?.config[0] ?? context.config)
     const credentials = credentialsFromConfig(context.credentials)
     const adapterOperations = new ZendeskAdapter({
-      client: new ZendeskClient(
-        {
-          credentials,
-          config: config[CLIENT_CONFIG],
-        },
-        { allowOrganizationNames: config[FETCH_CONFIG].resolveOrganizationIDs }
-      ),
+      client: new ZendeskClient({
+        credentials,
+        config: config[CLIENT_CONFIG],
+        allowOrganizationNames: config[FETCH_CONFIG].resolveOrganizationIDs,
+      }),
       credentials,
       config,
       getElemIdFunc: context.getElemIdFunc,

--- a/packages/zendesk-adapter/src/adapter_creator.ts
+++ b/packages/zendesk-adapter/src/adapter_creator.ts
@@ -149,7 +149,7 @@ export const adapter: Adapter = {
           credentials,
           config: config[CLIENT_CONFIG],
         },
-        { filterOrganizationNames: !config[FETCH_CONFIG].resolveOrganizationIDs }
+        { allowOrganizationNames: config[FETCH_CONFIG].resolveOrganizationIDs }
       ),
       credentials,
       config,

--- a/packages/zendesk-adapter/src/client/client.ts
+++ b/packages/zendesk-adapter/src/client/client.ts
@@ -30,7 +30,7 @@ const {
 } = clientUtils
 const log = logger(module)
 
-const ORG_ENDPOINTS_TO_FILTER = ['/organizations/show_many', '/organizations/autocomplete', '/organizations']
+const ORG_ENDPOINT_TO_FILTER = '/organizations/'
 const OMIT_REPLACEMENT = '<OMITTED>'
 
 type LogsFilterConfig = {
@@ -166,7 +166,7 @@ export default class ZendeskClient extends clientUtils.AdapterHTTPClient<
     url: string
   ): Values {
     const cloneResponseData = _.cloneDeep(responseData)
-    if (!this.logsFilterConfig.allowOrganizationNames && ORG_ENDPOINTS_TO_FILTER.some(ep => url.includes(ep))) {
+    if (!this.logsFilterConfig.allowOrganizationNames && url.includes(ORG_ENDPOINT_TO_FILTER)) {
       cloneResponseData.organizations?.forEach((org: Values) => { org.name = OMIT_REPLACEMENT })
     }
     return cloneResponseData

--- a/packages/zendesk-adapter/src/client/client.ts
+++ b/packages/zendesk-adapter/src/client/client.ts
@@ -32,7 +32,7 @@ const log = logger(module)
 
 const OMIT_REPLACEMENT = '<OMITTED>'
 
-type FilterLogsConfig = {
+type LogsFilterConfig = {
   allowOrganizationNames?: boolean
 }
 
@@ -48,7 +48,7 @@ const DEFAULT_PAGE_SIZE: Required<clientUtils.ClientPageSizeConfig> = {
   get: PAGE_SIZE,
 }
 
-const DEFAULT_FILTER_LOGS_CONFIG: FilterLogsConfig = {
+const DEFAULT_FILTER_LOGS_CONFIG: LogsFilterConfig = {
   // It is safer to default filter out organization names
   allowOrganizationNames: false,
 }
@@ -62,10 +62,10 @@ export default class ZendeskClient extends clientUtils.AdapterHTTPClient<
   protected isResourceApiLoggedIn = false
   protected resourceLoginPromise?: Promise<clientUtils.APIConnection>
   protected resourceClient?: clientUtils.APIConnection<clientUtils.ResponseValue | clientUtils.ResponseValue[]>
-  private logsFilterConfig: FilterLogsConfig
+  private logsFilterConfig: LogsFilterConfig
 
   constructor(
-    clientOpts: clientUtils.ClientOpts<Credentials, clientUtils.ClientRateLimitConfig> & FilterLogsConfig,
+    clientOpts: clientUtils.ClientOpts<Credentials, clientUtils.ClientRateLimitConfig> & LogsFilterConfig,
   ) {
     super(
       ZENDESK,

--- a/packages/zendesk-adapter/src/client/client.ts
+++ b/packages/zendesk-adapter/src/client/client.ts
@@ -30,6 +30,7 @@ const {
 } = clientUtils
 const log = logger(module)
 
+const ORG_ENDPOINTS_TO_FILTER = ['/organizations/show_many', '/organizations/autocomplete', '/organizations']
 const OMIT_REPLACEMENT = '<OMITTED>'
 
 type LogsFilterConfig = {
@@ -165,7 +166,7 @@ export default class ZendeskClient extends clientUtils.AdapterHTTPClient<
     url: string
   ): Values {
     const cloneResponseData = _.cloneDeep(responseData)
-    if (!this.logsFilterConfig.allowOrganizationNames && url.includes('organization')) {
+    if (!this.logsFilterConfig.allowOrganizationNames && ORG_ENDPOINTS_TO_FILTER.some(ep => url.includes(ep))) {
       cloneResponseData.organizations?.forEach((org: Values) => { org.name = OMIT_REPLACEMENT })
     }
     return cloneResponseData

--- a/packages/zendesk-adapter/src/client/client.ts
+++ b/packages/zendesk-adapter/src/client/client.ts
@@ -30,6 +30,8 @@ const {
 } = clientUtils
 const log = logger(module)
 
+const ORG_ENDPOINTS_TO_FILTER = ['organizations/show_many', 'organizations/autocomplete']
+
 type FilterLogsConfig = {
   allowOrganizationNames?: boolean
 }
@@ -84,7 +86,7 @@ export default class ZendeskClient extends clientUtils.AdapterHTTPClient<
       ),
       createConnection: createResourceConnection,
     })
-    this.filterLogsConfig = filterLogsConfig ?? DEFAULT_FILTER_LOGS_CONFIG
+    this.filterLogsConfig = { ...DEFAULT_FILTER_LOGS_CONFIG, ...filterLogsConfig }
   }
 
   public getUrl(): URL {
@@ -163,7 +165,7 @@ export default class ZendeskClient extends clientUtils.AdapterHTTPClient<
     responseData: Values,
     url: string
   ): Values {
-    if (url.includes('organizations') && this.filterLogsConfig.allowOrganizationNames !== true) {
+    if (this.filterLogsConfig.allowOrganizationNames !== true && ORG_ENDPOINTS_TO_FILTER.some(ep => url.includes(ep))) {
       responseData.organizations?.forEach((org: Values) => { org.name = '***' })
     }
     return responseData

--- a/packages/zendesk-adapter/src/client/client.ts
+++ b/packages/zendesk-adapter/src/client/client.ts
@@ -30,7 +30,7 @@ const {
 } = clientUtils
 const log = logger(module)
 
-const ORG_ENDPOINT_TO_FILTER = '/organizations/'
+const ORG_ENDPOINT_TO_FILTER = 'organizations/'
 const OMIT_REPLACEMENT = '<OMITTED>'
 
 type LogsFilterConfig = {

--- a/packages/zendesk-adapter/src/client/client.ts
+++ b/packages/zendesk-adapter/src/client/client.ts
@@ -65,8 +65,7 @@ export default class ZendeskClient extends clientUtils.AdapterHTTPClient<
   private filterLogsConfig: FilterLogsConfig
 
   constructor(
-    clientOpts: clientUtils.ClientOpts<Credentials, clientUtils.ClientRateLimitConfig>,
-    filterLogsConfig?: FilterLogsConfig,
+    clientOpts: clientUtils.ClientOpts<Credentials, clientUtils.ClientRateLimitConfig> & FilterLogsConfig,
   ) {
     super(
       ZENDESK,
@@ -86,7 +85,7 @@ export default class ZendeskClient extends clientUtils.AdapterHTTPClient<
       ),
       createConnection: createResourceConnection,
     })
-    this.filterLogsConfig = { ...DEFAULT_FILTER_LOGS_CONFIG, ...filterLogsConfig }
+    this.filterLogsConfig = { ...DEFAULT_FILTER_LOGS_CONFIG, allowOrganizationNames: clientOpts.allowOrganizationNames }
   }
 
   public getUrl(): URL {

--- a/packages/zendesk-adapter/test/change_validators/organization_existence.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/organization_existence.test.ts
@@ -15,23 +15,14 @@
 */
 
 import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
 import { organizationExistenceValidator } from '../../src/change_validators'
 import { ZENDESK } from '../../src/constants'
 import { SLA_POLICY_TYPE_NAME } from '../../src/filters/sla_policy'
 import ZendeskClient from '../../src/client/client'
 import { DEFAULT_CONFIG, FETCH_CONFIG } from '../../src/config'
-
-const paginatorMock = jest.fn()
-jest.mock('@salto-io/adapter-components', () => {
-  const actual = jest.requireActual('@salto-io/adapter-components')
-  return {
-    ...actual,
-    client: {
-      ...actual.client,
-      createPaginator: () => paginatorMock,
-    },
-  }
-})
+import { getOrganizationsByIds } from '../../src/filters/organizations'
 
 describe('OrganizationExistence', () => {
   const slaType = new ObjectType({ elemID: new ElemID(ZENDESK, SLA_POLICY_TYPE_NAME) })
@@ -80,14 +71,25 @@ describe('OrganizationExistence', () => {
     { conditions: createOrgsList(ids) }
   )
 
-  const client = new ZendeskClient({ credentials: { username: 'a', password: 'b', subdomain: 'ignore' } })
-  const getSinglePageMock = jest.fn()
-  client.getSinglePage = getSinglePageMock
+  let mockAxios: MockAdapter
+  let client: ZendeskClient
+  beforeEach(() => {
+    mockAxios = new MockAdapter(axios)
+    client = new ZendeskClient({ credentials: { username: 'a', password: 'b', subdomain: 'ignore' } })
+  })
+
+  afterEach(() => {
+    mockAxios.restore()
+  })
 
   it('should return an error if the organization does not exist, with resolved Ids', async () => {
     const fetchConfig = { ...DEFAULT_CONFIG[FETCH_CONFIG], resolveOrganizationIDs: true }
-    const validator = organizationExistenceValidator(client, fetchConfig)
-    paginatorMock.mockReturnValue([{ organizations: [{ id: 1, name: 'one' }, { id: 2, name: 'two' }] }])
+    const resolvedIdsClient = new ZendeskClient({
+      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
+      allowOrganizationNames: true,
+    })
+    const validator = organizationExistenceValidator(resolvedIdsClient, fetchConfig)
+    mockAxios.onGet().reply(() => [200, { organizations: [{ id: 1, name: 'one' }, { id: 2, name: 'two' }] }])
 
     const slaInstance = createSlaInstance(false)
     const triggerInstance = createTriggerInstance(false)
@@ -117,7 +119,9 @@ describe('OrganizationExistence', () => {
 
   it('should return an error if the organization does not exist, and request all orgs in one request, with unresolved Ids', async () => {
     const validator = organizationExistenceValidator(client, DEFAULT_CONFIG[FETCH_CONFIG])
-    getSinglePageMock.mockReturnValue({ data: { organizations: [{ id: 1, name: 'one' }, { id: 2, name: 'two' }] } })
+    mockAxios.onGet().replyOnce(200).onGet().replyOnce(200, { organizations: [{ id: 1, name: 'one' }, { id: 2, name: 'two' }] })
+      .onGet()
+      .replyOnce(401) // Makes sure that there is only one request
 
     const slaInstance = createSlaInstance()
     const triggerInstance = createTriggerInstance()
@@ -143,16 +147,21 @@ describe('OrganizationExistence', () => {
         detailedMessage: 'The following referenced organizations do not exist: 3, 4',
       },
     ])
-    expect(getSinglePageMock).toHaveBeenCalledTimes(1)
   })
   it('should not crash if the request for organizations fails', async () => {
     const validator = organizationExistenceValidator(client, DEFAULT_CONFIG[FETCH_CONFIG])
-    getSinglePageMock.mockRejectedValueOnce('')
+    mockAxios.onGet().abortRequestOnce()
 
     const slaInstance = createSlaInstance()
     const changes = [toChange({ after: slaInstance })]
 
     const errors = await validator(changes)
     expect(errors.length).toBe(0)
+  })
+  it('should filter organization names with unresolved Ids', async () => {
+    mockAxios.onGet().reply(200, { organizations: [{ id: 1, name: 'one' }, { id: 2, name: 'two' }] })
+    const organizations = await getOrganizationsByIds(['1', '2'], client)
+
+    expect(organizations).toMatchObject([{ id: 1, name: '***' }, { id: 2, name: '***' }])
   })
 })

--- a/packages/zendesk-adapter/test/client/client.test.ts
+++ b/packages/zendesk-adapter/test/client/client.test.ts
@@ -47,9 +47,7 @@ describe('client', () => {
     })
     it('should throw if there is no status in the error', async () => {
       // The first replyOnce with 200 is for the client authentication
-      mockAxios.onGet().replyOnce(200).onGet().replyOnce(() => {
-        throw new Error('Err')
-      })
+      mockAxios.onGet().replyOnce(200).onGet().replyOnce(() => { throw new Error('Err') })
       await expect(
         client.getSinglePage({ url: '/api/v2/routing/attributes' })
       ).rejects.toThrow()
@@ -74,8 +72,7 @@ describe('client', () => {
       const filteredOrgsResponse = { organizations: [{ id: 1, name: '***' }, { id: 2, name: '***' }] }
       mockAxios.onGet().replyOnce(200).onGet().reply(() => [200, orgsResponse])
       const notFilteringClient = new ZendeskClient(
-        { credentials: { username: 'a', password: 'b', subdomain: 'ignore' } },
-        { allowOrganizationNames: true }
+        { credentials: { username: 'a', password: 'b', subdomain: 'ignore' }, allowOrganizationNames: true }
       )
       const notFilteredResults = [
         await notFilteringClient.getSinglePage({ url: 'organizations/show_many' }),


### PR DESCRIPTION
If resolveOrganizationIDs is false, we will filter the organization names before logging them, so we won't save them anywhere and we will keep the user's privacy requests

---

None

---
_Release Notes_: 
None

---
_User Notifications_: 
None