### PR TITLE
do not run convert-lists filter on report types

### DIFF
--- a/packages/netsuite-adapter/src/filters/convert_lists.ts
+++ b/packages/netsuite-adapter/src/filters/convert_lists.ts
@@ -23,6 +23,7 @@ import _ from 'lodash'
 import { FilterWith } from '../filter'
 import { datasetType } from '../autogen/types/standard_types/dataset'
 import { isCustomRecordType, isFileCabinetInstance } from '../types'
+import { typeNameToParser } from '../change_validators/report_types_move_environment'
 
 const { awu } = collections.asynciterable
 
@@ -58,8 +59,9 @@ const filterCreator = (): FilterWith<'onFetch'> => ({
   onFetch: async elements => {
     await awu(elements)
       .filter(isInstanceElement)
+      // lists in report types instances are handled in parseReportTypes filter
       // file&folder instances have no list fields so we can skip them
-      .filter(inst => !isFileCabinetInstance(inst))
+      .filter(inst => !(inst.elemID.typeName in typeNameToParser) && !isFileCabinetInstance(inst))
       .forEach(async inst => {
         inst.value = await transformValues({
           values: inst.value,

--- a/packages/netsuite-adapter/src/filters/parse_report_types.ts
+++ b/packages/netsuite-adapter/src/filters/parse_report_types.ts
@@ -17,6 +17,7 @@
 import { getChangeData, InstanceElement, isInstanceChange, isInstanceElement, isObjectType, ObjectType } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { collections } from '@salto-io/lowerdash'
+import { resolvePath, setPath } from '@salto-io/adapter-utils'
 import { FINANCIAL_LAYOUT, REPORT_DEFINITION, SAVED_SEARCH } from '../constants'
 import { FilterCreator } from '../filter'
 import { savedsearchType } from '../type_parsers/saved_search_parsing/parsed_saved_search'
@@ -28,11 +29,30 @@ import { financiallayoutType as oldFinancialLayout } from '../autogen/types/stan
 import { reportdefinitionType as oldReportDefinition } from '../autogen/types/standard_types/reportdefinition'
 
 const { awu } = collections.asynciterable
+const { makeArray } = collections.array
 
 const typeNameToOldType: Record<string, ObjectType> = {
   [SAVED_SEARCH]: oldSavedSearch().type,
   [REPORT_DEFINITION]: oldReportDefinition().type,
   [FINANCIAL_LAYOUT]: oldFinancialLayout().type,
+}
+
+export const shouldBeList: Record<string, string[][]> = {
+  [SAVED_SEARCH]: [
+    ['dependencies', 'dependency'],
+  ],
+  [REPORT_DEFINITION]: [],
+  [FINANCIAL_LAYOUT]: [],
+}
+
+const transformLists = (instance: InstanceElement): void => {
+  shouldBeList[instance.elemID.typeName].forEach(path => {
+    const listElemId = instance.elemID.createNestedID(...path)
+    const value = resolvePath(instance, listElemId)
+    if (value !== undefined) {
+      setPath(instance, listElemId, makeArray(value))
+    }
+  })
 }
 
 const filterCreator: FilterCreator = ({ elementsSource }) => ({
@@ -75,6 +95,7 @@ const filterCreator: FilterCreator = ({ elementsSource }) => ({
           .map(instance => cloneReportInstance(instance, type))
           .map(async (instance: InstanceElement) => {
             await assignReportTypesValues(instance, await elementsSource.get(instance.elemID))
+            transformLists(instance)
             return instance
           })
       )

--- a/packages/netsuite-adapter/test/filters/parse_report_types.test.ts
+++ b/packages/netsuite-adapter/test/filters/parse_report_types.test.ts
@@ -13,9 +13,10 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { AdditionChange, ElemID, InstanceElement, isObjectType, ObjectType, toChange } from '@salto-io/adapter-api'
+import { AdditionChange, ElemID, InstanceElement, isListType, isObjectType, ObjectType, toChange } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import filterCreator from '../../src/filters/parse_report_types'
+import { collections } from '@salto-io/lowerdash'
+import filterCreator, { shouldBeList } from '../../src/filters/parse_report_types'
 import { savedsearchType } from '../../src/autogen/types/standard_types/savedsearch'
 import { reportdefinitionType } from '../../src/autogen/types/standard_types/reportdefinition'
 import { financiallayoutType } from '../../src/autogen/types/standard_types/financiallayout'
@@ -27,7 +28,11 @@ import { savedsearchType as newSavedSearchType } from '../../src/type_parsers/sa
 import { layoutDefinition, layoutDefinitionResult } from '../type_parsers/financial_layout_consts'
 import { emptyDefinition, emptyDefinitionOutcome } from '../type_parsers/saved_search_definition'
 import { simpleReportDefinitionResult, simpleReportDefinition } from '../type_parsers/report_definitions_consts'
+import { getInnerStandardTypes, getTopLevelStandardTypes } from '../../src/types'
+import { TypesMap } from '../../src/types/object_types'
+import { StandardType } from '../../src/autogen/types'
 
+const { awu } = collections.asynciterable
 
 describe('parse_report_types filter', () => {
   let savedSearchInstance: InstanceElement
@@ -88,61 +93,90 @@ describe('parse_report_types filter', () => {
     sourceFinancialLayoutInstance.value.layout = layoutDefinition
     sourceReportDefinitionInstance.value.definition = simpleReportDefinition
   })
-  it('test onFetch removes old object type and adds new type', async () => {
-    const savedSearchObject = new ObjectType({ elemID: new ElemID('netsuite', SAVED_SEARCH) })
-    const elements = [savedSearchObject]
-    await filterCreator(fetchOpts).onFetch?.(elements)
-    expect(elements.filter(isObjectType)
-      .filter(e => e.elemID.typeName === SAVED_SEARCH)[0])
-      .not.toEqual(savedSearchObject)
-    expect(elements.filter(isObjectType)
-      .filter(e => e.elemID.typeName === SAVED_SEARCH)[0])
-      .toEqual(newSavedSearchType().type)
+  describe('onFetch', () => {
+    it('should removes old object type and adds new type', async () => {
+      const savedSearchObject = new ObjectType({ elemID: new ElemID('netsuite', SAVED_SEARCH) })
+      const elements = [savedSearchObject]
+      await filterCreator(fetchOpts).onFetch?.(elements)
+      expect(elements.filter(isObjectType)
+        .filter(e => e.elemID.typeName === SAVED_SEARCH)[0])
+        .not.toEqual(savedSearchObject)
+      expect(elements.filter(isObjectType)
+        .filter(e => e.elemID.typeName === SAVED_SEARCH)[0])
+        .toEqual(newSavedSearchType().type)
+    })
+    it('should removes doubled dependency object type', async () => {
+      const dependencyObjectType = new ObjectType({ elemID: new ElemID(NETSUITE, 'savedsearch_dependencies'),
+        fields: {} })
+      const elements = [dependencyObjectType]
+      await filterCreator(fetchOpts).onFetch?.(elements)
+      expect(elements.filter(isObjectType)
+        .filter(e => e.elemID.typeName === SAVED_SEARCH)[0])
+        .not.toEqual(dependencyObjectType)
+    })
+    it('should adds definition values', async () => {
+      await filterCreator(fetchOpts).onFetch?.([savedSearchInstance, reportDefinitionInstance, financialLayoutInstance])
+      expect(savedSearchInstance.value).toEqual({ definition: emptyDefinition, ...emptyDefinitionOutcome })
+      expect(reportDefinitionInstance.value).toEqual(
+        { definition: simpleReportDefinition, ...simpleReportDefinitionResult }
+      )
+      expect(financialLayoutInstance.value).toEqual({ layout: layoutDefinition, ...layoutDefinitionResult })
+    })
+    it('should keeps old definition', async () => {
+      fetchOpts = {
+        client: {} as NetsuiteClient,
+        elementsSourceIndex: {
+          getIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+        },
+        elementsSource: buildElementsSourceFromElements([
+          sourceSavedSearchInstance,
+          sourceFinancialLayoutInstance,
+          sourceReportDefinitionInstance,
+        ]),
+        isPartial: false,
+        config: await getDefaultAdapterConfig(),
+      }
+      await filterCreator(fetchOpts).onFetch?.([savedSearchInstance])
+      expect(savedSearchInstance.value.definition).toEqual(emptyDefinition)
+      expect(reportDefinitionInstance.value.definition).toEqual(simpleReportDefinition)
+      expect(financialLayoutInstance.value.layout).toEqual(layoutDefinition)
+    })
+    it('should make list', async () => {
+      savedSearchInstance.value.dependencies = { dependency: 'some_dependency' }
+      await filterCreator(fetchOpts).onFetch?.([savedSearchInstance])
+      expect(savedSearchInstance.value.dependencies.dependency).toEqual(['some_dependency'])
+    })
+    it('validate fields that needs to be lists', async () => {
+      const typesAndInnerTypes = {
+        savedsearch: savedsearchType(),
+        financiallayout: financiallayoutType(),
+        reportdefinition: reportdefinitionType(),
+      } as TypesMap<StandardType>
+      const typesToCheck = getTopLevelStandardTypes(typesAndInnerTypes)
+        .concat(getInnerStandardTypes(typesAndInnerTypes))
+      const typesWithLists = await awu(typesToCheck)
+        .filter(type => awu(Object.values(type.fields))
+          .some(async field => isListType(await field.getType())))
+        .toArray()
+      expect(typesWithLists).toHaveLength(1)
+      expect(typesWithLists[0].elemID.getFullName()).toEqual('netsuite.savedsearch_dependencies')
+      expect(Object.values(shouldBeList).flatMap(perType => Object.values(perType))).toHaveLength(1)
+      expect(shouldBeList[SAVED_SEARCH][0]).toEqual(['dependencies', 'dependency'])
+      const dependenciesInnerType = await newSavedSearchType().type.fields[shouldBeList[SAVED_SEARCH][0][0]].getType()
+      expect(isObjectType(dependenciesInnerType)
+      && isListType(await dependenciesInnerType.fields[shouldBeList[SAVED_SEARCH][0][1]].getType())).toBeTruthy()
+    })
   })
-  it('test onFetch removes doubled dependency object type', async () => {
-    const dependencyObjectType = new ObjectType({ elemID: new ElemID(NETSUITE, 'savedsearch_dependencies'),
-      fields: {} })
-    const elements = [dependencyObjectType]
-    await filterCreator(fetchOpts).onFetch?.(elements)
-    expect(elements.filter(isObjectType)
-      .filter(e => e.elemID.typeName === SAVED_SEARCH)[0])
-      .not.toEqual(dependencyObjectType)
-  })
-  it('test onFetch adds definition values', async () => {
-    await filterCreator(fetchOpts).onFetch?.([savedSearchInstance, reportDefinitionInstance, financialLayoutInstance])
-    expect(savedSearchInstance.value).toEqual({ definition: emptyDefinition, ...emptyDefinitionOutcome })
-    expect(reportDefinitionInstance.value).toEqual(
-      { definition: simpleReportDefinition, ...simpleReportDefinitionResult }
-    )
-    expect(financialLayoutInstance.value).toEqual({ layout: layoutDefinition, ...layoutDefinitionResult })
-  })
-  it('test onFetch keeps old definition', async () => {
-    fetchOpts = {
-      client: {} as NetsuiteClient,
-      elementsSourceIndex: {
-        getIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
-      },
-      elementsSource: buildElementsSourceFromElements([
-        sourceSavedSearchInstance,
-        sourceFinancialLayoutInstance,
-        sourceReportDefinitionInstance,
-      ]),
-      isPartial: false,
-      config: await getDefaultAdapterConfig(),
-    }
-    await filterCreator(fetchOpts).onFetch?.([savedSearchInstance])
-    expect(savedSearchInstance.value.definition).toEqual(emptyDefinition)
-    expect(reportDefinitionInstance.value.definition).toEqual(simpleReportDefinition)
-    expect(financialLayoutInstance.value.layout).toEqual(layoutDefinition)
-  })
-  it('test preDeploy removes values', async () => {
-    savedSearchInstance.value.test = 'toBeRemoved'
-    financialLayoutInstance.value.test = 'toBeRemoved'
-    const savedSearchChange = toChange({ after: savedSearchInstance }) as AdditionChange<InstanceElement>
-    const financialLayoutChange = toChange({ after: financialLayoutInstance }) as AdditionChange<InstanceElement>
-    expect(savedSearchChange.data.after.value.test).toEqual('toBeRemoved')
-    await filterCreator(fetchOpts).preDeploy?.([savedSearchChange, financialLayoutChange])
-    expect(savedSearchChange.data.after.value.test).toBeUndefined()
-    expect(financialLayoutChange.data.after.value.test).toBeUndefined()
+  describe('preDeploy', () => {
+    it('should preDeploy removes values', async () => {
+      savedSearchInstance.value.test = 'toBeRemoved'
+      financialLayoutInstance.value.test = 'toBeRemoved'
+      const savedSearchChange = toChange({ after: savedSearchInstance }) as AdditionChange<InstanceElement>
+      const financialLayoutChange = toChange({ after: financialLayoutInstance }) as AdditionChange<InstanceElement>
+      expect(savedSearchChange.data.after.value.test).toEqual('toBeRemoved')
+      await filterCreator(fetchOpts).preDeploy?.([savedSearchChange, financialLayoutChange])
+      expect(savedSearchChange.data.after.value.test).toBeUndefined()
+      expect(financialLayoutChange.data.after.value.test).toBeUndefined()
+    })
   })
 })


### PR DESCRIPTION
Trying to reduce run time of `convertLists` filter - by not running it on report type instances, because they have parsers that take care of that.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Do not run convert-lists filter on report types

---
_User Notifications_: 
None