### PR TITLE
SALTO-3725 improve parse-report-types filter

### DIFF
--- a/packages/netsuite-adapter/src/filters/parse_report_types.ts
+++ b/packages/netsuite-adapter/src/filters/parse_report_types.ts
@@ -73,8 +73,8 @@ const filterCreator: FilterCreator = ({ elementsSource }) => ({
       const parsedInstance = await parser(instance.value[layoutOrDefinition])
       Object.assign(instance.value, parsedInstance)
       if (oldInstance?.value[layoutOrDefinition] !== undefined) {
-        if (_.isEqual(await parser(oldInstance.value[layoutOrDefinition]),
-          parsedInstance)) {
+        const oldParsedInstance = _.pick(oldInstance.value, Object.keys(parsedInstance))
+        if (_.isEqual(oldParsedInstance, parsedInstance)) {
           // In case the parsed definitions are equal that mean there is no reason
           // to change the definition string and create a change in the file.
           instance.value[layoutOrDefinition] = oldInstance.value[layoutOrDefinition]

--- a/packages/netsuite-adapter/src/filters/parse_report_types.ts
+++ b/packages/netsuite-adapter/src/filters/parse_report_types.ts
@@ -73,7 +73,8 @@ const filterCreator: FilterCreator = ({ elementsSource }) => ({
       const parsedInstance = await parser(instance.value[layoutOrDefinition])
       Object.assign(instance.value, parsedInstance)
       if (oldInstance?.value[layoutOrDefinition] !== undefined) {
-        const oldParsedInstance = _.pick(oldInstance.value, Object.keys(parsedInstance))
+        const oldType = typeNameToOldType[instance.elemID.typeName]
+        const oldParsedInstance = _.omitBy(oldInstance.value, (_val, key) => oldType.fields[key] !== undefined)
         if (_.isEqual(oldParsedInstance, parsedInstance)) {
           // In case the parsed definitions are equal that mean there is no reason
           // to change the definition string and create a change in the file.


### PR DESCRIPTION
Improve parse-report-types filter by not parsing the current `definition` from the nacl, but taking the already parsed values.
This improves the run time by 50%.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Improve parse-report-types filter

---
_User Notifications_: 
None