### PR TITLE
SALTO-3716 create core fetch config as input to core fetch

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -58,6 +58,7 @@ export type ProgressReporter = {
 
 export type FetchOptions = {
   progressReporter: ProgressReporter
+  withChangesDetection?: boolean
 }
 
 export type DeployOptions = {

--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -110,7 +110,6 @@ export type AdapterOperations = {
   fetch: (opts: FetchOptions) => Promise<FetchResult>
   deploy: (opts: DeployOptions) => Promise<DeployResult>
   validate?: (opts: DeployOptions) => Promise<DeployResult>
-  fetchWithChangeDetection?: (opts: FetchOptions) => Promise<FetchResult>
   postFetch?: (opts: PostFetchOptions) => Promise<void>
   deployModifiers?: DeployModifiers
   validationModifiers?: ValidationModifiers

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -221,6 +221,7 @@ export type FetchFunc = (
   progressEmitter?: EventEmitter<FetchProgressEvents>,
   accounts?: string[],
   ignoreStateElemIdMapping?: boolean,
+  withChangeDetection?: boolean
 ) => Promise<FetchResult>
 
 export type FetchFromWorkspaceFuncParams = {
@@ -256,6 +257,7 @@ export const fetch: FetchFunc = async (
   progressEmitter?,
   accounts?,
   ignoreStateElemIdMapping?,
+  withChangeDetection?,
 ) => {
   log.debug('fetch starting..')
   const fetchAccounts = accounts ?? workspace.accounts()
@@ -285,6 +287,7 @@ export const fetch: FetchFunc = async (
       accountToServiceNameMap,
       currentConfigs,
       progressEmitter,
+      withChangeDetection,
     )
     log.debug(`${elements.length} elements were fetched [mergedErrors=${mergeErrors.length}]`)
     await updateStateWithFetchResults(workspace, elements, unmergedElements, fetchAccounts)

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -221,7 +221,6 @@ export type FetchFunc = (
   progressEmitter?: EventEmitter<FetchProgressEvents>,
   accounts?: string[],
   ignoreStateElemIdMapping?: boolean,
-  withChangeDetection?: boolean,
 ) => Promise<FetchResult>
 
 export type FetchFromWorkspaceFuncParams = {
@@ -257,7 +256,6 @@ export const fetch: FetchFunc = async (
   progressEmitter?,
   accounts?,
   ignoreStateElemIdMapping?,
-  withChangeDetection?,
 ) => {
   log.debug('fetch starting..')
   const fetchAccounts = accounts ?? workspace.accounts()
@@ -287,7 +285,6 @@ export const fetch: FetchFunc = async (
       accountToServiceNameMap,
       currentConfigs,
       progressEmitter,
-      withChangeDetection,
     )
     log.debug(`${elements.length} elements were fetched [mergedErrors=${mergeErrors.length}]`)
     await updateStateWithFetchResults(workspace, elements, unmergedElements, fetchAccounts)

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -22,7 +22,7 @@ import {
   FIELD_NAME, INSTANCE_NAME, OBJECT_NAME, ElemIdGetter, DetailedChange, SaltoError,
   isSaltoElementError, ProgressReporter, ReadOnlyElementsSource, TypeMap, isServiceId,
   CORE_ANNOTATIONS, AdapterOperationsContext, FetchResult, isAdditionChange, isStaticFile,
-  isAdditionOrModificationChange, Value, StaticFile, isElement, FetchOptions,
+  isAdditionOrModificationChange, Value, StaticFile, isElement,
 } from '@salto-io/adapter-api'
 import { applyInstancesDefaults, resolvePath, flattenElementStr, buildElementsSourceFromElements, safeJsonStringify, walkOnElement, WalkOnFunc, WALK_NEXT_STEP, setPath, walkOnValue } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
@@ -377,6 +377,7 @@ const fetchAndProcessMergeErrors = async (
   accountToServiceNameMap: Record<string, string>,
   getChangesEmitter: StepEmitter,
   progressEmitter?: EventEmitter<FetchProgressEvents>,
+  withChangesDetection?: boolean
 ):
   Promise<{
     accountElements: Element[]
@@ -444,6 +445,7 @@ const fetchAndProcessMergeErrors = async (
         .map(async ([accountName, adapter]) => {
           const fetchResult = await adapter.fetch({
             progressReporter: progressReporters[accountName],
+            withChangesDetection,
           })
           const { updatedConfig, errors } = fetchResult
           if (
@@ -714,7 +716,8 @@ export const fetchChanges = async (
   // As part of SALTO-1661, parameters here should be replaced with named parameters
   accountToServiceNameMap: Record<string, string>,
   currentConfigs: InstanceElement[],
-  progressEmitter?: EventEmitter<FetchProgressEvents>
+  progressEmitter?: EventEmitter<FetchProgressEvents>,
+  withChangesDetection?: boolean
 ): Promise<FetchChangesResult> => {
   const accountNames = _.keys(accountsToAdapters)
   const getChangesEmitter = new StepEmitter()
@@ -728,7 +731,8 @@ export const fetchChanges = async (
     stateElements,
     accountToServiceNameMap,
     getChangesEmitter,
-    progressEmitter
+    progressEmitter,
+    withChangesDetection
   )
 
   const adaptersFirstFetchPartial = await getAdaptersFirstFetchPartial(

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -269,7 +269,7 @@ describe('fetch', () => {
         })
       })
 
-      it('should use the existing elements to resolve the fetched elements when calculating changes', async () => {
+      it('should use the existing elements to resolve the fetched elements when calculcating changes', async () => {
         const beforeElement = new InstanceElement(
           'name',
           new ObjectType({
@@ -1137,54 +1137,6 @@ describe('fetch', () => {
           .refType)
         expectedHiddenInstanceAlternateId.refType.type = expect.anything()
         expect(passed).toEqual([expectedHiddenInstanceAlternateId])
-      })
-    })
-
-    describe('when call with withChangeDetection true', () => {
-      const mockFetch = jest.fn()
-      const mockDeploy = jest.fn()
-      const mockFetchWithChangeDetection = jest.fn()
-        .mockResolvedValue({ elements: [] })
-      const adapters = {
-        adapterWithQuickFetch: {
-          fetch: mockFetch,
-          deploy: mockDeploy,
-          fetchWithChangeDetection: mockFetchWithChangeDetection,
-        },
-        adapterWithoutFetchWithChangeDetection: {
-          fetch: mockFetch,
-          deploy: mockDeploy,
-        },
-      }
-      it('should throw an error when run fetchWithChangeDetection with unsupported adapters', async () => {
-        await expect(fetchChanges(
-          adapters,
-          createElementSource([]),
-          createElementSource([]),
-          {
-            adapterWithoutFetchWithChangeDetection: 'adapter1',
-          },
-          [],
-          undefined,
-          true,
-        )).rejects.toThrow('Adapter: adapter1 does not support fetch with change detection operation')
-      })
-      it('should call fetchWithChangeDetection function', async () => {
-        mockFetch.mockClear()
-        mockFetchWithChangeDetection.mockClear()
-        await fetchChanges(
-          _.pick(adapters, 'adapterWithQuickFetch'),
-          createElementSource([]),
-          createElementSource([]),
-          {
-            adapterWithoutFetchWithChangeDetection: 'adapter1',
-          },
-          [],
-          undefined,
-          true,
-        )
-        expect(mockFetchWithChangeDetection).toHaveBeenCalled()
-        expect(mockFetch).not.toHaveBeenCalled()
       })
     })
   })

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -120,7 +120,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
   private readonly lockedElements?: QueryParams
   private readonly fetchTarget?: NetsuiteQueryParameters
   private readonly skipList?: NetsuiteQueryParameters // old version
-  private readonly useChangesDetection: boolean
+  private readonly useChangesDetection: boolean // TODO remove this from config SALTO-3676
   private elementsSourceIndex: LazyElementsSourceIndexes
   private createFiltersRunner: (params: {
     isPartial?: boolean

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -120,7 +120,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
   private readonly lockedElements?: QueryParams
   private readonly fetchTarget?: NetsuiteQueryParameters
   private readonly skipList?: NetsuiteQueryParameters // old version
-  private readonly useChangesDetection: boolean // TODO remove this from configuration SALTO-3676
+  private readonly useChangesDetection: boolean
   private elementsSourceIndex: LazyElementsSourceIndexes
   private createFiltersRunner: (params: {
     isPartial: boolean
@@ -239,7 +239,6 @@ export default class NetsuiteAdapter implements AdapterOperations {
     } = await this.runSuiteAppOperations(
       fetchQuery,
       useChangesDetection,
-      isPartial,
     )
     const updatedFetchQuery = changedObjectsQuery !== undefined
       ? andQuery(changedObjectsQuery, fetchQuery)
@@ -249,7 +248,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
       ? await getOrCreateServerTimeElements(
         serverTime,
         this.elementsSource,
-        isPartial,
+        this.isPartialFetch(),
       )
       : undefined
 
@@ -341,19 +340,12 @@ export default class NetsuiteAdapter implements AdapterOperations {
     }
   }
 
-  private async innerFetch(
-    {
-      fetchOptions,
-      useChangesDetection,
-      isPartial,
-    }:
-    {
-      fetchOptions: FetchOptions
-      useChangesDetection: boolean
-      isPartial: boolean
-    }
-  ): Promise<FetchResult> {
-    const { progressReporter } = fetchOptions
+  /**
+   * Fetch configuration elements: objects, types and instances for the given Netsuite account.
+   * Account credentials were given in the constructor.
+   */
+
+  public async fetch({ progressReporter }: FetchOptions): Promise<FetchResult> {
     const explicitIncludeTypeList = [REPORT_DEFINITION, FINANCIAL_LAYOUT]
       .filter(typeName => !this.fetchInclude?.types.some(type => type.name === typeName))
     const deprecatedSkipList = buildNetsuiteQuery(convertToQueryParams({
@@ -369,13 +361,14 @@ export default class NetsuiteAdapter implements AdapterOperations {
       notQuery(deprecatedSkipList),
     ].filter(values.isDefined).reduce(andQuery)
 
+    const isPartial = this.isPartialFetch()
 
     const {
       failedToFetchAllAtOnce,
       failedFilePaths,
       failedTypes,
       elements,
-    } = await this.fetchByQuery(fetchQuery, progressReporter, useChangesDetection, isPartial)
+    } = await this.fetchByQuery(fetchQuery, progressReporter, this.useChangesDetection, isPartial)
 
     const updatedConfig = getConfigFromConfigChanges(
       failedToFetchAllAtOnce, failedFilePaths, failedTypes, this.userConfig
@@ -387,31 +380,9 @@ export default class NetsuiteAdapter implements AdapterOperations {
     return { elements, updatedConfig, isPartial }
   }
 
-  /**
-   * Fetch configuration elements: objects, types and instances for the given Netsuite account.
-   * Account credentials were given in the constructor.
-   */
-
-  public async fetch(fetchOptions: FetchOptions): Promise<FetchResult> {
-    return this.innerFetch({
-      fetchOptions,
-      useChangesDetection: this.useChangesDetection,
-      isPartial: this.isPartialFetch(),
-    })
-  }
-
-  public async fetchWithChangeDetection(fetchOptions: FetchOptions): Promise<FetchResult> {
-    return this.innerFetch({
-      fetchOptions,
-      useChangesDetection: true,
-      isPartial: true,
-    })
-  }
-
   private async runSuiteAppOperations(
     fetchQuery: NetsuiteQuery,
     useChangesDetection: boolean,
-    isPartial: boolean,
   ):
     Promise<{
       changedObjectsQuery?: NetsuiteQuery
@@ -423,7 +394,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
       return {}
     }
 
-    if (!isPartial) {
+    if (!this.isPartialFetch()) {
       return {
         serverTime: sysInfo.time,
       }

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -85,7 +85,7 @@ export type NetsuiteConfig = {
   fetch?: FetchParams
   fetchTarget?: NetsuiteQueryParameters
   skipList?: NetsuiteQueryParameters
-  useChangesDetection?: boolean
+  useChangesDetection?: boolean // TODO remove this from config SALTO-3676
   deployReferencedElements?: boolean
 }
 

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -85,7 +85,7 @@ export type NetsuiteConfig = {
   fetch?: FetchParams
   fetchTarget?: NetsuiteQueryParameters
   skipList?: NetsuiteQueryParameters
-  useChangesDetection?: boolean // TODO remove this from config SALTO-3676
+  useChangesDetection?: boolean
   deployReferencedElements?: boolean
 }
 

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -550,50 +550,6 @@ describe('Adapter', () => {
       expect(fetchResult.updatedConfig?.config[0].isEqual(updatedConfig)).toBe(true)
     })
   })
-  describe('fetchWithChangeDetection', () => {
-    const conf = {
-      fetch: {
-        exclude: {
-          types: [
-            { name: SAVED_SEARCH },
-            { name: TRANSACTION_FORM },
-          ],
-          fileCabinet: ['Some/File/Regex'],
-          customRecords: [],
-        },
-      },
-    }
-    const adapter = new NetsuiteAdapter({
-      client: new NetsuiteClient(client),
-      elementsSource: buildElementsSourceFromElements([]),
-      filtersCreators: [firstDummyFilter, secondDummyFilter],
-      config: conf,
-      getElemIdFunc: mockGetElemIdFunc,
-    })
-
-    it('isPartial should be true', async () => {
-      const { isPartial } = await adapter.fetchWithChangeDetection(mockFetchOpts)
-      expect(isPartial).toBeTruthy()
-    })
-
-    it('should match the types but the ones in exclude', async () => {
-      await adapter.fetchWithChangeDetection(mockFetchOpts)
-
-      const customObjectsQuery = (client.getCustomObjects as jest.Mock).mock.calls[0][1]
-      expect(customObjectsQuery.isTypeMatch('addressForm')).toBeTruthy()
-      expect(customObjectsQuery.isTypeMatch(SAVED_SEARCH)).toBeFalsy()
-      expect(customObjectsQuery.isTypeMatch(TRANSACTION_FORM)).toBeFalsy()
-    })
-
-    it('should match the files that not in filePathRegexSkipList', async () => {
-      await adapter.fetchWithChangeDetection(mockFetchOpts)
-
-      const fileCabinetQuery = (client.importFileCabinetContent as jest.Mock).mock.calls[0][0]
-      expect(fileCabinetQuery.isFileMatch('Some/AnotherFile/another')).toBeTruthy()
-      expect(fileCabinetQuery.isFileMatch('Some/File/another')).toBeTruthy()
-      expect(fileCabinetQuery.isFileMatch('Some/File/Regex')).toBeFalsy()
-    })
-  })
 
 
   describe('deploy', () => {


### PR DESCRIPTION
- Reverting https://github.com/salto-io/salto/pull/3963
- Introduce new flag for core fetch 'withChangeDetection'
- Make Netsuite adapter use 'withChangeDetection' received from core to run quick fetch
---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite_adapter:
When receiving 'withChangeDetection' from core on fetch, will run quick fetch. (not supported on the CLI yet)

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. None
