### PR TITLE
SALTO-3728: zendesk guide - make get of article attachment content run in parallel

### DIFF
--- a/packages/zendesk-adapter/src/filters/article/utils.ts
+++ b/packages/zendesk-adapter/src/filters/article/utils.ts
@@ -139,10 +139,11 @@ export const getArticleAttachments = async ({ brandIdToClient, articleById, atta
   apiDefinitions: ZendeskApiConfig
   attachments: Attachment[]
 }): Promise<void> => {
-  await awu(attachments).forEach(async attachment => {
+  log.debug(`there are ${attachments.length} attachments, going to get their content`)
+  await Promise.all(attachments.map(async attachment => {
     const article = articleById[getParent(attachment).value.id]
     await getAttachmentContent({ brandIdToClient, attachment, article, attachmentType })
-  })
+  }))
 }
 
 export const createUnassociatedAttachment = async (


### PR DESCRIPTION
zendesk guide - make get of article attachment content run in parallel
---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* fix long fetch for environments with a large amount of attachments

---
_User Notifications_: 
None
