### PR TITLE
SALTO-3620 add filter to remove unix time zero (1/1/1970) from created and modified dates

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -79,6 +79,7 @@ import fetchFlowsFilter from './filters/fetch_flows'
 import customMetadataToObjectTypeFilter from './filters/custom_metadata_to_object_type'
 import addDefaultActivateRSSFilter from './filters/add_default_activate_rss'
 import formulaDepsFilter from './filters/formula_deps'
+import removeUnixTimeZeroFilter from './filters/remove_unix_time_zero'
 import { FetchElements, SalesforceConfig } from './types'
 import { getConfigFromConfigChanges } from './config_change'
 import { LocalFilterCreator, Filter, FilterResult, RemoteFilterCreator, LocalFilterCreatorDefinition, RemoteFilterCreatorDefinition } from './filter'
@@ -167,6 +168,7 @@ export const allFilters: Array<LocalFilterCreatorDefinition | RemoteFilterCreato
   { creator: extraDependenciesFilter, addsNewInformation: true },
   { creator: customTypeSplit },
   { creator: profileInstanceSplitFilter },
+  { creator: removeUnixTimeZeroFilter },
 ]
 
 // By default we run all filters and provide a client

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -168,6 +168,7 @@ export const allFilters: Array<LocalFilterCreatorDefinition | RemoteFilterCreato
   { creator: extraDependenciesFilter, addsNewInformation: true },
   { creator: customTypeSplit },
   { creator: profileInstanceSplitFilter },
+  // Any filter that relies on _created_at or _changed_at should run after removeUnixTimeZero
   { creator: removeUnixTimeZeroFilter },
 ]
 

--- a/packages/salesforce-adapter/src/filters/remove_unix_time_zero.ts
+++ b/packages/salesforce-adapter/src/filters/remove_unix_time_zero.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Element, isElement } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, Element, isElement } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import { LocalFilterCreator } from '../filter'
@@ -31,17 +31,13 @@ const removeUnixTimeZero = async (
   await awu(elements)
     .filter(isElement)
     .forEach(async e => {
-      // eslint-disable-next-line no-underscore-dangle
-      if (e.annotations._changed_at === UNIX_TIME_ZERO_STRING) {
-        // eslint-disable-next-line no-underscore-dangle
-        delete e.annotations._changed_at
-        log.debug(`Removed unix time 0 last modified of ${await apiName(e)}`)
+      if (e.annotations[CORE_ANNOTATIONS.CHANGED_AT] === UNIX_TIME_ZERO_STRING) {
+        delete e.annotations[CORE_ANNOTATIONS.CHANGED_AT]
+        log.trace('Removed unix time 0 last modified of %s', await apiName(e))
       }
-      // eslint-disable-next-line no-underscore-dangle
-      if (e.annotations._created_at === UNIX_TIME_ZERO_STRING) {
-        // eslint-disable-next-line no-underscore-dangle
-        delete e.annotations._created_at
-        log.debug(`Removed unix time 0 create time of ${await apiName(e)}`)
+      if (e.annotations[CORE_ANNOTATIONS.CREATED_AT] === UNIX_TIME_ZERO_STRING) {
+        delete e.annotations[CORE_ANNOTATIONS.CREATED_AT]
+        log.trace('Removed unix time 0 create time of %s', await apiName(e))
       }
     })
 }

--- a/packages/salesforce-adapter/src/filters/remove_unix_time_zero.ts
+++ b/packages/salesforce-adapter/src/filters/remove_unix_time_zero.ts
@@ -1,0 +1,59 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Element, isElement } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { collections } from '@salto-io/lowerdash'
+import { LocalFilterCreator } from '../filter'
+import { apiName } from '../transformers/transformer'
+
+const { awu } = collections.asynciterable
+
+const log = logger(module)
+
+const UNIX_TIME_ZERO_STRING = '1970-01-01T00:00:00.000Z'
+
+const removeUnixTimeZero = async (
+  elements: Element[],
+): Promise<void> => {
+  await awu(elements)
+    .filter(isElement)
+    .forEach(async e => {
+      // eslint-disable-next-line no-underscore-dangle
+      if (e.annotations._changed_at === UNIX_TIME_ZERO_STRING) {
+        // eslint-disable-next-line no-underscore-dangle
+        delete e.annotations._changed_at
+        log.debug(`Removed unix time 0 last modified of ${await apiName(e)}`)
+      }
+      // eslint-disable-next-line no-underscore-dangle
+      if (e.annotations._created_at === UNIX_TIME_ZERO_STRING) {
+        // eslint-disable-next-line no-underscore-dangle
+        delete e.annotations._created_at
+        log.debug(`Removed unix time 0 create time of ${await apiName(e)}`)
+      }
+    })
+}
+
+/**
+ * Replace specific field values that are fetched as ids, to their names.
+ */
+const filter: LocalFilterCreator = () => ({
+  name: 'removeUnixTimeZero',
+  onFetch: async (elements: Element[]) => {
+    await removeUnixTimeZero(elements)
+  },
+})
+
+export default filter

--- a/packages/salesforce-adapter/test/filters/remove_unix_time_zero.test.ts
+++ b/packages/salesforce-adapter/test/filters/remove_unix_time_zero.test.ts
@@ -66,7 +66,7 @@ beforeEach(() => {
   ]
 })
 
-describe('on fetch', () => {
+describe('removeUnixTimeZero', () => {
     type FilterType = FilterWith<'onFetch'>
     let filter: FilterType
     beforeEach(async () => {
@@ -74,27 +74,29 @@ describe('on fetch', () => {
       await filter.onFetch(testElements)
     })
 
-    it('should remove invalid unix time 0 annotations', () => {
-      const testValueBothInvalidFields = testElements[0] as ObjectType
-      expect(testValueBothInvalidFields.annotations).not.toHaveProperty(CORE_ANNOTATIONS.CHANGED_AT)
-      expect(testValueBothInvalidFields.annotations).not.toHaveProperty(CORE_ANNOTATIONS.CREATED_AT)
+    describe('on fetch', () => {
+      it('should remove invalid unix time 0 annotations', () => {
+        const testValueBothInvalidFields = testElements[0] as ObjectType
+        expect(testValueBothInvalidFields.annotations).not.toHaveProperty(CORE_ANNOTATIONS.CHANGED_AT)
+        expect(testValueBothInvalidFields.annotations).not.toHaveProperty(CORE_ANNOTATIONS.CREATED_AT)
 
-      const testValueInvalidCreatedAt = testElements[1] as ObjectType
-      expect(testValueInvalidCreatedAt.annotations).not.toHaveProperty(CORE_ANNOTATIONS.CREATED_AT)
+        const testValueInvalidCreatedAt = testElements[1] as ObjectType
+        expect(testValueInvalidCreatedAt.annotations).not.toHaveProperty(CORE_ANNOTATIONS.CREATED_AT)
 
-      const testValueInvalidChangedAt = testElements[2] as ObjectType
-      expect(testValueInvalidChangedAt.annotations).not.toHaveProperty(CORE_ANNOTATIONS.CHANGED_AT)
-    })
+        const testValueInvalidChangedAt = testElements[2] as ObjectType
+        expect(testValueInvalidChangedAt.annotations).not.toHaveProperty(CORE_ANNOTATIONS.CHANGED_AT)
+      })
 
-    it('should not remove annotations with valid time', () => {
-      const testValueBothValidFields = testElements[3] as ObjectType
-      expect(testValueBothValidFields.annotations).toHaveProperty(CORE_ANNOTATIONS.CREATED_AT)
-      expect(testValueBothValidFields.annotations).toHaveProperty(CORE_ANNOTATIONS.CHANGED_AT)
+      it('should not remove annotations with valid time', () => {
+        const testValueBothValidFields = testElements[3] as ObjectType
+        expect(testValueBothValidFields.annotations).toHaveProperty(CORE_ANNOTATIONS.CREATED_AT)
+        expect(testValueBothValidFields.annotations).toHaveProperty(CORE_ANNOTATIONS.CHANGED_AT)
 
-      const testValueInvalidCreatedAt = testElements[1] as ObjectType
-      expect(testValueInvalidCreatedAt.annotations).toHaveProperty(CORE_ANNOTATIONS.CHANGED_AT)
+        const testValueInvalidCreatedAt = testElements[1] as ObjectType
+        expect(testValueInvalidCreatedAt.annotations).toHaveProperty(CORE_ANNOTATIONS.CHANGED_AT)
 
-      const testValueInvalidChangedAt = testElements[2] as ObjectType
-      expect(testValueInvalidChangedAt.annotations).toHaveProperty(CORE_ANNOTATIONS.CREATED_AT)
+        const testValueInvalidChangedAt = testElements[2] as ObjectType
+        expect(testValueInvalidChangedAt.annotations).toHaveProperty(CORE_ANNOTATIONS.CREATED_AT)
+      })
     })
 })

--- a/packages/salesforce-adapter/test/filters/remove_unix_time_zero.test.ts
+++ b/packages/salesforce-adapter/test/filters/remove_unix_time_zero.test.ts
@@ -1,0 +1,100 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Element, ElemID, ObjectType, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
+import { SALESFORCE } from '../../src/constants'
+import { FilterWith } from '../../src/filter'
+import filterCreator from '../../src/filters/remove_unix_time_zero'
+import { defaultFilterContext } from '../utils'
+
+const UNIX_TIME_ZERO_STRING = '1970-01-01T00:00:00.000Z'
+const RANDOM_TIME_STRING = '2023-01-05T12:13:14.000Z'
+
+const mockObjId = new ElemID(SALESFORCE, 'MockObject')
+const mockTypeWithUnixTimeZeroBothFields = new ObjectType({
+  elemID: mockObjId,
+  annotations: {
+    _created_at: UNIX_TIME_ZERO_STRING,
+    _changed_at: UNIX_TIME_ZERO_STRING,
+  },
+})
+
+const mockTypeWithUnixTimeZeroCreatedAtField = new ObjectType({
+  elemID: mockObjId,
+  annotations: {
+    _created_at: UNIX_TIME_ZERO_STRING,
+    _changed_at: RANDOM_TIME_STRING,
+  },
+})
+
+const mockTypeWithUnixTimeZeroChangedAtField = new ObjectType({
+  elemID: mockObjId,
+  annotations: {
+    _created_at: RANDOM_TIME_STRING,
+    _changed_at: UNIX_TIME_ZERO_STRING,
+  },
+})
+
+const mockTypeWithoutUnixTimeZero = new ObjectType({
+  elemID: mockObjId,
+  annotations: {
+    _created_at: RANDOM_TIME_STRING,
+    _changed_at: RANDOM_TIME_STRING,
+  },
+})
+
+let testElements: Element[]
+
+beforeEach(() => {
+  testElements = [
+    mockTypeWithUnixTimeZeroBothFields.clone(),
+    mockTypeWithUnixTimeZeroCreatedAtField.clone(),
+    mockTypeWithUnixTimeZeroChangedAtField.clone(),
+    mockTypeWithoutUnixTimeZero.clone(),
+  ]
+})
+
+describe('on fetch', () => {
+    type FilterType = FilterWith<'onFetch'>
+    let filter: FilterType
+    beforeEach(async () => {
+      filter = filterCreator({ config: defaultFilterContext }) as FilterType
+      await filter.onFetch(testElements)
+    })
+
+    it('should remove invalid unix time 0 annotations', () => {
+      const testValueBothInvalidFields = testElements[0] as ObjectType
+      expect(testValueBothInvalidFields.annotations).not.toHaveProperty(CORE_ANNOTATIONS.CHANGED_AT)
+      expect(testValueBothInvalidFields.annotations).not.toHaveProperty(CORE_ANNOTATIONS.CREATED_AT)
+
+      const testValueInvalidCreatedAt = testElements[1] as ObjectType
+      expect(testValueInvalidCreatedAt.annotations).not.toHaveProperty(CORE_ANNOTATIONS.CREATED_AT)
+
+      const testValueInvalidChangedAt = testElements[2] as ObjectType
+      expect(testValueInvalidChangedAt.annotations).not.toHaveProperty(CORE_ANNOTATIONS.CHANGED_AT)
+    })
+
+    it('should not remove annotations with valid time', () => {
+      const testValueBothValidFields = testElements[3] as ObjectType
+      expect(testValueBothValidFields.annotations).toHaveProperty(CORE_ANNOTATIONS.CREATED_AT)
+      expect(testValueBothValidFields.annotations).toHaveProperty(CORE_ANNOTATIONS.CHANGED_AT)
+
+      const testValueInvalidCreatedAt = testElements[1] as ObjectType
+      expect(testValueInvalidCreatedAt.annotations).toHaveProperty(CORE_ANNOTATIONS.CHANGED_AT)
+
+      const testValueInvalidChangedAt = testElements[2] as ObjectType
+      expect(testValueInvalidChangedAt.annotations).toHaveProperty(CORE_ANNOTATIONS.CREATED_AT)
+    })
+})


### PR DESCRIPTION
 add filter to remove unix time zero (1/1/1970) from created and modified dates

---

This does not change the workspace, since the annotations are hidden. 

element print before:
![image](https://user-images.githubusercontent.com/37732337/222417241-6b8f0741-1d59-44f9-9506-2e819cf6ebf8.png)

element print after:
![image](https://user-images.githubusercontent.com/37732337/222417289-4053e465-7f03-47c0-8a39-f5404d7ad784.png)

---
_Release Notes_: _None_
---
_User Notifications_: _None_