### PR TITLE
SALTO-3148 add SDF french support

### DIFF
--- a/packages/netsuite-adapter/src/change_validators/client_validation.ts
+++ b/packages/netsuite-adapter/src/change_validators/client_validation.ts
@@ -16,18 +16,18 @@
 import _ from 'lodash'
 import { collections } from '@salto-io/lowerdash'
 import { Change, ChangeError, changeId, getChangeData, ChangeDataType, isField, isFieldChange, isInstanceChange, isObjectTypeChange, InstanceElement, ObjectType } from '@salto-io/adapter-api'
-import { getGroupItemFromRegex, objectValidationErrorRegex, OBJECT_ID } from '../client/sdf_client'
+import { getGroupItemFromRegex } from '../client/sdf_client'
 import NetsuiteClient from '../client/client'
 import { AdditionalDependencies } from '../client/types'
 import { getChangeGroupIdsFunc } from '../group_changes'
 import { ManifestValidationError, ObjectsDeployError, SettingsDeployError } from '../client/errors'
+import { detectLanguage, multiLanguageErrorDetectors, OBJECT_ID } from '../client/language_utils'
 import { SCRIPT_ID } from '../constants'
 import { getElementValueOrAnnotations } from '../types'
 import { Filter } from '../filter'
 import { cloneChange } from './utils'
 
 const { awu } = collections.asynciterable
-const VALIDATION_FAIL = 'Validation failed.'
 
 type FailedChangeWithDependencies = {
   change: Change<ChangeDataType>
@@ -36,8 +36,10 @@ type FailedChangeWithDependencies = {
 
 const mapObjectDeployErrorToInstance = (error: Error):
 { get: (changeData: ChangeDataType) => string | undefined } => {
+  const detectedLanguage = detectLanguage(error.message)
+  const { validationFailed, objectValidationErrorRegex } = multiLanguageErrorDetectors[detectedLanguage]
   const scriptIdToErrorRecord: Record<string, string> = {}
-  const errorMessageChunks = error.message.split(VALIDATION_FAIL)[1]?.split('\n\n')
+  const errorMessageChunks = error.message.split(validationFailed)[1]?.split('\n\n') ?? []
   errorMessageChunks.forEach(chunk => {
     const objectErrorScriptId = getGroupItemFromRegex(
       chunk, objectValidationErrorRegex, OBJECT_ID

--- a/packages/netsuite-adapter/src/client/language_utils.ts
+++ b/packages/netsuite-adapter/src/client/language_utils.ts
@@ -1,0 +1,75 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { logger } from '@salto-io/logging'
+
+const log = logger(module)
+
+export const OBJECT_ID = 'objectId'
+export const FEATURE_NAME = 'featureName'
+
+type SupportedLanguage = 'english' | 'french'
+
+type ErrorDetectors = {
+  deployStartMessageRegex: RegExp
+  settingsValidationErrorRegex: RegExp
+  objectValidationErrorRegex: RegExp
+  objectValidationFeatureErrorRegex: RegExp
+  deployedObjectRegex: RegExp
+  errorObjectRegex: RegExp
+  manifestErrorDetailsRegex: RegExp
+  configureFeatureFailRegex: RegExp
+  validationFailed: RegExp
+}
+
+export const multiLanguageErrorDetectors: Record<SupportedLanguage, ErrorDetectors> = {
+  english: {
+    deployStartMessageRegex: RegExp('^Begin deployment$', 'm'),
+    settingsValidationErrorRegex: RegExp('^Validation of account settings failed\\.$', 'm'),
+    objectValidationErrorRegex: RegExp(`^(An error occurred during custom object validation\\.|An error occured during validation of Custom Objects against the account) \\((?<${OBJECT_ID}>[a-z0-9_]+)\\)`, 'gm'),
+    objectValidationFeatureErrorRegex: RegExp(`Details: You must specify the (?<${FEATURE_NAME}>[A-Z_]+)\\(.*?\\) feature in the project manifest`, 'gm'),
+    deployedObjectRegex: RegExp(`^(Create|Update) object -- (?<${OBJECT_ID}>[a-z0-9_]+)`, 'gm'),
+    errorObjectRegex: RegExp(`^An unexpected error has occurred\\. \\((?<${OBJECT_ID}>[a-z0-9_]+)\\)`, 'm'),
+    manifestErrorDetailsRegex: RegExp(`Details: The manifest contains a dependency on (?<${OBJECT_ID}>[a-z0-9_]+(\\.[a-z0-9_]+)*)`, 'gm'),
+    configureFeatureFailRegex: RegExp(`Configure feature -- (Enabling|Disabling) of the (?<${FEATURE_NAME}>\\w+)\\(.*?\\) feature has FAILED`),
+    validationFailed: RegExp('^Validation failed\\.$', 'm'),
+  },
+  // NOTE: all non-english letters are replaced with a dot
+  french: {
+    deployStartMessageRegex: RegExp('^Commencer le d.ploiement$', 'm'),
+    settingsValidationErrorRegex: RegExp('^La validation des param.tres du compte a .chou.\\.$', 'm'),
+    objectValidationErrorRegex: RegExp(`^(Une erreur s'est produite lors de la validation de l'objet personnalis.\\.|An error occured during validation of Custom Objects against the account) \\((?<${OBJECT_ID}>[a-z0-9_]+)\\)`, 'gm'),
+    objectValidationFeatureErrorRegex: RegExp(`D.tails: Vous devez sp.cifier la fonctionnalit. (?<${FEATURE_NAME}>[A-Z_]+)\\(.*?\\) dans le manifeste du projet`, 'gm'),
+    deployedObjectRegex: RegExp(`^(Cr.er un objet|Mettre . jour l'objet) -- (?<${OBJECT_ID}>[a-z0-9_]+)`, 'gm'),
+    // TODO: find in french
+    errorObjectRegex: RegExp(`^An unexpected error has occurred\\. \\((?<${OBJECT_ID}>[a-z0-9_]+)\\)`, 'm'),
+    manifestErrorDetailsRegex: RegExp(`D.tails: Le manifeste comporte une d.pendance sur l'objet (?<${OBJECT_ID}>[a-z0-9_]+(\\.[a-z0-9_]+)*)`, 'gm'),
+    configureFeatureFailRegex: RegExp(`Configurer la fonction -- (L'activation|La d.sactivation) de la fonction (?<${FEATURE_NAME}>\\w+)\\(.*?\\) a .chou.`),
+    validationFailed: RegExp('^La validation a .chou.\\.$', 'm'),
+  },
+}
+
+const frenchRegexDetector = RegExp('(\\*\\*\\* ERREUR \\*\\*\\*|Commencer le d.ploiement)')
+
+export const detectLanguage = (errorMessage: string): SupportedLanguage => {
+  const detectedLanguage: SupportedLanguage = frenchRegexDetector.test(errorMessage)
+    ? 'french'
+    : 'english'
+
+  if (detectedLanguage !== 'english') {
+    log.debug('sdf language detected - %s', detectedLanguage)
+  }
+  return detectedLanguage
+}

--- a/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
@@ -151,6 +151,38 @@ File: ~/Objects/customrecord1.xml`
       severity: 'Error',
     })
   })
+  it('should have SDF Objects Validation Error - in other language', async () => {
+    const detailedMessage = `Une erreur s'est produite lors de la validation de l'objet personnalis.. (object_name)
+Details: The object field daterange is missing.
+Details: The object field kpi must not be OPENJOBS.
+Details: The object field periodrange is missing.
+Details: The object field compareperiodrange is missing.
+Details: The object field defaultgeneraltype must not be ENTITY_ENTITY_NAME.
+Details: The object field type must not be 449.
+File: ~/Objects/object_name.xml`
+    const fullErrorMessage = `
+*** ERREUR ***
+La validation a .chou..
+
+${detailedMessage}`
+
+    mockValidate.mockReturnValue([
+      new ObjectsDeployError(fullErrorMessage, new Set(['object_name'])),
+    ])
+    const changeErrors = await clientValidation(
+      changes,
+      client,
+      {} as unknown as AdditionalDependencies,
+      mockFiltersRunner,
+    )
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0]).toEqual({
+      detailedMessage,
+      elemID: getChangeData(changes[0]).elemID,
+      message: 'SDF Objects Validation Error',
+      severity: 'Error',
+    })
+  })
   it('should have SDF Manifest Validation Error and remove the element causing it', async () => {
     const detailedMessage = `Validation of account settings failed.
     

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -1403,6 +1403,49 @@ File: ~/Objects/custform_114_t1441298_782.xml
         }
         expect(isRejected).toBe(true)
       })
+      it('should throw ObjectsDeployError when deploy failed on object validation - in other language', async () => {
+        const errorMessage = `
+The deployment process has encountered an error.
+Deploying to TSTDRV2259448 - Salto Extended Dev - Administrator.
+2022-03-31 05:36:02 (PST) Installation started
+Info -- Account [(PRODUCTION) Salto Extended Dev]
+Info -- Account Customization Project [TempSdfProject-5492f41d-307d-4fc9-bc78-ef0834e9a197]
+Info -- Framework Version [1.0]
+Validate manifest -- Success
+Validate deploy file -- Success
+Validate configuration -- Success
+Validate objects -- Failed
+Validate files -- Success
+Validate folders -- Success
+Validate translation imports -- Success
+Validation of referenceability from custom objects to translations collection strings in progress. -- Success
+Validate preferences -- Success
+Validate flags -- Success
+Validate for circular dependencies -- Success
+*** ERREUR ***
+La validation a .chou..
+
+Une erreur s'est produite lors de la validation de l'objet personnalis.. (custform_114_t1441298_782)
+File: ~/Objects/custform_114_t1441298_782.xml
+        `
+        mockExecuteAction.mockResolvedValue({ isSuccess: () => true, data: errorMessage.split('\n') })
+        let isRejected: boolean
+        try {
+          await client.deploy([{
+            typeName: 'typeName',
+            values: {
+              key: 'val',
+            },
+            scriptId: 'scriptId',
+          } as CustomTypeInfo], ...DEFAULT_DEPLOY_PARAMS)
+          isRejected = false
+        } catch (e) {
+          isRejected = true
+          expect(e instanceof ObjectsDeployError).toBeTruthy()
+          expect(e instanceof ObjectsDeployError && e.failedObjects).toEqual(new Set(['custform_114_t1441298_782']))
+        }
+        expect(isRejected).toBe(true)
+      })
 
       it('should throw ObjectsDeployError when deploy failed with error object message', async () => {
         const errorMessage = `
@@ -1777,6 +1820,16 @@ File: ~/AccountConfiguration/features.xml`
         mockExecuteAction.mockResolvedValue({ isSuccess: () => true, data: [errorMessage] })
         await expect(client.deploy([featuresCustomizationInfo], ...DEFAULT_DEPLOY_PARAMS))
           .rejects.toThrow(new FeaturesDeployError(errorMessage, ['SUITEAPPCONTROLCENTER']))
+      })
+
+      it('should throw FeaturesDeployError on failed features deploy - in other language', async () => {
+        const errorMessages = [
+          'Commencer le d.ploiement',
+          'Configurer la fonction -- La d.sactivation de la fonction SUITEAPPCONTROLCENTER(SuiteApp Control Center) a .chou.',
+        ]
+        mockExecuteAction.mockResolvedValue({ isSuccess: () => true, data: errorMessages })
+        await expect(client.deploy([featuresCustomizationInfo], ...DEFAULT_DEPLOY_PARAMS))
+          .rejects.toThrow(new FeaturesDeployError(errorMessages[1], ['SUITEAPPCONTROLCENTER']))
       })
     })
 


### PR DESCRIPTION
When NS account is configured to other language than English the errors in SDF are in that language too.
We want to be able to detect that and extract the exact errors in that case.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Add SDF french support

---
_User Notifications_: 
None