### PR TITLE
SALTO-3724: zendesk revert nacl case from channel name

### DIFF
--- a/packages/zendesk-adapter/src/filters/hardcoded_channel.ts
+++ b/packages/zendesk-adapter/src/filters/hardcoded_channel.ts
@@ -90,7 +90,7 @@ const filterCreator: FilterCreator = () => ({
       return new InstanceElement(
         instanceName,
         channelType,
-        { id: channel.value, name: instanceName },
+        { id: channel.value, name: channel.title },
         [ZENDESK, RECORDS_PATH, CHANNEL_TYPE_NAME, instanceName],
       )
     })

--- a/packages/zendesk-adapter/test/filters/hardcoded_channel.test.ts
+++ b/packages/zendesk-adapter/test/filters/hardcoded_channel.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ObjectType, ElemID, InstanceElement, isObjectType } from '@salto-io/adapter-api'
+import { ObjectType, ElemID, InstanceElement, isObjectType, isInstanceElement } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import { ZENDESK } from '../../src/constants'
 import filterCreator, { TRIGGER_DEFINITION_TYPE_NAME, CHANNEL_TYPE_NAME } from '../../src/filters/hardcoded_channel'
@@ -71,6 +71,9 @@ describe('hardcoded channel filter', () => {
           'zendesk.trigger_definition',
           'zendesk.trigger_definition.instance',
         ])
+      const webFormChannel = elements.filter(isInstanceElement).find(e => e.elemID.getFullName() === 'zendesk.channel.instance.Web_form@s')
+      expect(webFormChannel).toBeDefined()
+      expect(webFormChannel?.value?.name).toEqual('Web form')
       const channelType = elements
         .filter(isObjectType)
         .find(e => e.elemID.typeName === CHANNEL_TYPE_NAME)


### PR DESCRIPTION
zendesk revert nacl case from channel name

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* in channel, name will no longer be in nacl case

---
_User Notifications_: 
zendesk:
* in channel, name will no longer be in nacl case
