### PR TITLE
SALTO-3591- Allow adding actions for deploy requests

### DIFF
--- a/packages/adapter-components/src/config/ducktype.ts
+++ b/packages/adapter-components/src/config/ducktype.ts
@@ -18,7 +18,7 @@ import { ObjectType, BuiltinTypes, FieldDefinition } from '@salto-io/adapter-api
 import { values as lowerDashValues } from '@salto-io/lowerdash'
 import { AdapterApiConfig, createAdapterApiConfigType, UserFetchConfig, TypeConfig, TypeDefaultsConfig, validateSupportedTypes } from './shared'
 import { TransformationConfig, TransformationDefaultConfig, createTransformationConfigTypes, validateTransoformationConfig, getTransformationConfigByType } from './transformation'
-import { createRequestConfigs, validateRequestConfig } from './request'
+import { validateRequestConfig } from './request'
 
 const { isDefined } = lowerDashValues
 
@@ -49,7 +49,6 @@ export const createDucktypeAdapterApiConfigType = ({
   additionalRequestFields?: Record<string, FieldDefinition>
   additionalTransformationFields?: Record<string, FieldDefinition>
 }): ObjectType => {
-  const requestTypes = createRequestConfigs(adapter, additionalRequestFields)
   const transformationTypes = createTransformationConfigTypes(adapter, {
     hasDynamicFields: { refType: BuiltinTypes.BOOLEAN },
     sourceTypeName: { refType: BuiltinTypes.STRING },
@@ -57,7 +56,7 @@ export const createDucktypeAdapterApiConfigType = ({
   })
   return createAdapterApiConfigType({
     adapter,
-    requestTypes,
+    additionalRequestFields,
     transformationTypes,
     additionalFields,
   })

--- a/packages/adapter-components/src/config/request.ts
+++ b/packages/adapter-components/src/config/request.ts
@@ -81,13 +81,14 @@ export type DeployRequestConfig = BaseRequestConfig & {
   fieldsToIgnore?: string[]
 }
 
-export type DeploymentRequestsByAction = Partial<Record<ActionName, DeployRequestConfig>>
+export type DeploymentRequestsByAction<A extends string = ActionName> = Partial<Record<A, DeployRequestConfig>>
 
 export type FetchRequestDefaultConfig = Partial<Omit<FetchRequestConfig, 'url'>>
 
 export const createRequestConfigs = (
   adapter: string,
   additionalFields?: Record<string, FieldDefinition>,
+  additionalActions?: string[],
 ): { fetch: { request: ObjectType; requestDefault: ObjectType }; deployRequests: ObjectType } => {
   const dependsOnFromConfig = new ObjectType({
     elemID: new ElemID(adapter, 'dependsOnFromConfig'),
@@ -282,6 +283,9 @@ export const createRequestConfigs = (
     },
   })
 
+  const additionalActionFields = Object.fromEntries(
+    additionalActions?.map(actionName => [actionName, { refType: deployRequestConfigType }]) ?? []
+  )
   const deployRequestsType = new ObjectType({
     elemID: new ElemID(adapter, 'deployRequests'),
     fields: {
@@ -294,6 +298,7 @@ export const createRequestConfigs = (
       remove: {
         refType: deployRequestConfigType,
       },
+      ...additionalActionFields,
     },
     annotations: {
       [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/adapter-components/src/config/swagger.ts
+++ b/packages/adapter-components/src/config/swagger.ts
@@ -14,11 +14,11 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { ObjectType, ElemID, BuiltinTypes, CORE_ANNOTATIONS, FieldDefinition, ListType } from '@salto-io/adapter-api'
+import { ObjectType, ElemID, BuiltinTypes, CORE_ANNOTATIONS, FieldDefinition, ListType, ActionName } from '@salto-io/adapter-api'
 import { types, collections, values as lowerDashValues } from '@salto-io/lowerdash'
 import { AdapterApiConfig, createAdapterApiConfigType, TypeConfig, TypeDefaultsConfig, UserFetchConfig, validateSupportedTypes } from './shared'
-import { createRequestConfigs, validateRequestConfig } from './request'
-import { createTransformationConfigTypes, getTransformationConfigByType, validateTransoformationConfig } from './transformation'
+import { validateRequestConfig } from './request'
+import { createTransformationConfigTypes, getTransformationConfigByType, TransformationConfig, TransformationDefaultConfig, validateTransoformationConfig } from './transformation'
 
 const { isDefined } = lowerDashValues
 const { findDuplicates } = collections.array
@@ -51,7 +51,8 @@ export type TypeSwaggerConfig = TypeConfig
 export type RequestableTypeSwaggerConfig = types.PickyRequired<TypeSwaggerConfig, 'request'>
 export type TypeSwaggerDefaultConfig = TypeDefaultsConfig
 
-export type AdapterSwaggerApiConfig = AdapterApiConfig & {
+export type AdapterSwaggerApiConfig<A extends string = ActionName> = AdapterApiConfig<
+ TransformationConfig, TransformationDefaultConfig, A> & {
   swagger: SwaggerDefinitionBaseConfig
 }
 export type RequestableAdapterSwaggerApiConfig = AdapterSwaggerApiConfig & {
@@ -131,21 +132,21 @@ export const createSwaggerAdapterApiConfigType = ({
   additionalTypeFields,
   additionalRequestFields,
   additionalTransformationFields,
+  additionalActions,
 }: {
   adapter: string
   additionalTypeFields?: Record<string, FieldDefinition>
   additionalFields?: Record<string, FieldDefinition>
   additionalRequestFields?: Record<string, FieldDefinition>
   additionalTransformationFields?: Record<string, FieldDefinition>
+  additionalActions?: string[]
 }): ObjectType => {
-  const requestTypes = createRequestConfigs(adapter, additionalRequestFields)
   const transformationTypes = createTransformationConfigTypes(
     adapter,
     additionalTransformationFields,
   )
   return createAdapterApiConfigType({
     adapter,
-    requestTypes,
     transformationTypes,
     additionalTypeFields,
     additionalFields: {
@@ -154,6 +155,8 @@ export const createSwaggerAdapterApiConfigType = ({
         refType: createSwaggerDefinitionsBaseConfigType(adapter),
       },
     },
+    additionalRequestFields,
+    additionalActions,
   })
 }
 

--- a/packages/adapter-components/test/config/request.test.ts
+++ b/packages/adapter-components/test/config/request.test.ts
@@ -76,6 +76,18 @@ describe('config_request', () => {
       expect(requestDefault.fields.a.refType.elemID.isEqual(BuiltinTypes.STRING.elemID))
         .toBeTruthy()
     })
+
+    it('should include additional actions when added', () => {
+      const { deployRequests } = createRequestConfigs(
+        'myAdapter',
+        undefined,
+        ['a', 'b']
+      )
+      expect(Object.keys(deployRequests.fields)).toHaveLength(5)
+      expect(Object.keys(deployRequests.fields).sort()).toEqual(['a', 'add', 'b', 'modify', 'remove'])
+      expect(deployRequests.fields.a.refType.elemID).toEqual(deployRequests.fields.add.refType.elemID)
+      expect(deployRequests.fields.b.refType.elemID).toEqual(deployRequests.fields.add.refType.elemID)
+    })
   })
 
   describe('validateRequestConfig', () => {


### PR DESCRIPTION
Allow adding actions for deploy requests

---

This PR is part of - https://github.com/salto-io/salto/pull/4036

---
_Release Notes_: 
None

---
_User Notifications_: 
None
