### PR TITLE
SALTO-1714: zendek move includeAuditDetails flag to only control the addition of changed_by

### DIFF
--- a/packages/zendesk-adapter/src/filters/audit_logs.ts
+++ b/packages/zendesk-adapter/src/filters/audit_logs.ts
@@ -274,10 +274,6 @@ const addNewChangedBy = async ({
 const filterCreator: FilterCreator = ({ elementsSource, client, paginator, config }) => ({
   name: 'changeByAndChangedAt',
   onFetch: async (elements: Element[]): Promise<void> => {
-    if (config[FETCH_CONFIG].includeAuditDetails === false) { // temporary
-      log.info('not running changeByAndChangedAt filter as includeAuditDetails in the config is false')
-      return
-    }
     if (elementsSource === undefined) {
       log.error('Failed to run changeByAndChangedAt filter because no element source was provided')
       return
@@ -296,6 +292,11 @@ const filterCreator: FilterCreator = ({ elementsSource, client, paginator, confi
     }
     const newTimeElements = await createTimeElements(newLastAuditTime)
     elements.push(...newTimeElements)
+
+    if (config[FETCH_CONFIG].includeAuditDetails === false) {
+      log.info('not running changeByAndChangedAt filter as includeAuditDetails in the config is false')
+      return
+    }
 
     // if this is a second fetch the elementSource should have the time instance already
     const auditTimeInstance = await elementsSource.get(AUDIT_TIME_INSTANCE_ID)

--- a/packages/zendesk-adapter/test/filters/audit_logs.test.ts
+++ b/packages/zendesk-adapter/test/filters/audit_logs.test.ts
@@ -152,7 +152,7 @@ describe('audit_logs filter', () => {
     })
   })
   describe('onFetch', () => {
-    it('should do nothing when flag is false', async () => {
+    it('should only add changed_at correctly when flag is false', async () => {
       filter = filterCreator(createFilterCreatorParams({
         client,
         config: {
@@ -171,19 +171,6 @@ describe('audit_logs filter', () => {
         paginator: mockPaginator,
         elementsSource: buildElementsSourceFromElements([]),
       })) as FilterType
-      const elements = [
-        automationInstance,
-        ticketFieldInstance,
-        ticketFieldCustomOptionInstance,
-        articleTranslationInstance,
-      ].map(e => e.clone())
-      await filter.onFetch(elements)
-      expect(mockGet).toHaveBeenCalledTimes(0)
-      expect(elements).toHaveLength(4)
-      expect(elements
-        .filter(e => e.annotations[CORE_ANNOTATIONS.CHANGED_AT] === undefined)).toHaveLength(4)
-    })
-    it('should only add changed_at correctly', async () => {
       const elements = [
         automationInstance,
         ticketFieldInstance,


### PR DESCRIPTION
zendesk move includeAuditDetails flag to only control the addition of changed_by

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk: 
* move includeAuditDetails flag to only control the addition of changed_by

---
_User Notifications_: 
None
