### PR TITLE
SALTO-3425 Change SBAA AprovalRule CV from warning to error

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/sbaa_approval_rules_custom_condition.ts
+++ b/packages/salesforce-adapter/src/change_validators/sbaa_approval_rules_custom_condition.ts
@@ -65,7 +65,7 @@ const changeValidator: ChangeValidator = async changes => {
   return rulesReferencedFromAdditionConditions.map(referencedInstanceElemID =>
     ({
       elemID: idToRuleWithCustomAdditionInst[referencedInstanceElemID].elemID,
-      severity: 'Warning' as SeverityLevel,
+      severity: 'Error' as SeverityLevel,
       message: 'Cannot deploy ApprovalRule with ConditionMet set to ‘Custom’',
       detailedMessage: 'Cannot deploy an ApprovalRule with ConditionMet set to ‘Custom‘ that has a referencing ApprovalCondition.\nYou can edit ConditionMet in Salto and set it to ‘All’ and deploy. Then, change it back to ‘Custom’ and deploy again.',
     })).filter(values.isDefined)

--- a/packages/salesforce-adapter/test/change_validators/sbaa_approval_rules_custom_condition.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/sbaa_approval_rules_custom_condition.test.ts
@@ -94,7 +94,7 @@ describe('sbaa addition approval rules with custom condition met with incoming a
       ]
     )
     expect(changeErrors).toHaveLength(1)
-    expect(changeErrors[0].severity).toEqual('Warning')
+    expect(changeErrors[0].severity).toEqual('Error')
     expect(changeErrors[0].elemID).toEqual(approvalRuleInstCustomCond.elemID)
   })
 


### PR DESCRIPTION
Change SBAA AprovalRule CV from warning to error

---

No additional context 

---

_Release Notes_: 
Salesforce:
* Change validator for SBAA ApprovalRule now returns an error upon failure

---

_User Notifications_: _None_