### PR TITLE
SALTO-3768: store users during fetch in a hidden NaCl

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -120,6 +120,7 @@ import accountInfoFilter from './filters/account_info'
 import deployPermissionSchemeFilter from './filters/permission_scheme/deploy_permission_scheme_filter'
 import scriptRunnerWorkflowFilter from './filters/script_runner/workflow_filter'
 import scriptRunnerWorkflowOrFilter from './filters/script_runner/workflow_ors'
+import storeUsersFilter from './filters/store_users'
 
 const {
   generateTypes,
@@ -132,6 +133,7 @@ const log = logger(module)
 
 export const DEFAULT_FILTERS = [
   accountInfoFilter,
+  storeUsersFilter,
   automationLabelFetchFilter,
   automationLabelDeployFilter,
   automationFetchFilter,
@@ -263,6 +265,7 @@ export default class JiraAdapter implements AdapterOperations {
   private getElemIdFunc?: ElemIdGetter
   private fetchQuery: elementUtils.query.ElementQuery
   private getUserMapFunc: GetUserMapFunc
+  private elementsSource: ReadOnlyElementsSource
 
   public constructor({
     filterCreators = DEFAULT_FILTERS,
@@ -287,6 +290,7 @@ export default class JiraAdapter implements AdapterOperations {
 
     this.paginator = paginator
     this.getUserMapFunc = getUserMapFuncCreator(paginator, client.isDataCenter)
+    this.elementsSource = elementsSource
 
     const filterContext = {}
     this.createFiltersRunner = () => (
@@ -420,7 +424,7 @@ export default class JiraAdapter implements AdapterOperations {
 
   get deployModifiers(): AdapterOperations['deployModifiers'] {
     return {
-      changeValidator: changeValidator(this.client, this.userConfig, this.getUserMapFunc, this.paginator),
+      changeValidator: changeValidator(this.client, this.userConfig, this.elementsSource, this.paginator),
       dependencyChanger,
       getChangeGroupIds,
     }

--- a/packages/jira-adapter/src/change_validators/account_id.ts
+++ b/packages/jira-adapter/src/change_validators/account_id.ts
@@ -14,13 +14,13 @@
 * limitations under the License.
 */
 import { ChangeError, ChangeValidator, ElemID, getChangeData, InstanceElement,
-  isAdditionOrModificationChange, isInstanceChange } from '@salto-io/adapter-api'
+  isAdditionOrModificationChange, isInstanceChange, ReadOnlyElementsSource } from '@salto-io/adapter-api'
 import { config as configUtils } from '@salto-io/adapter-components'
 import { logger } from '@salto-io/logging'
 import { walkOnElement } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { isDeployableAccountIdType, walkOnUsers, WalkOnUsersCallback } from '../filters/account_id/account_id_filter'
-import { getUserIdFromEmail, GetUserMapFunc, getUsersMapByVisibleId, UserMap } from '../users'
+import { getUserIdFromEmail, getUserMapFunc, getUsersMapByVisibleId, UserMap } from '../users'
 import { JiraConfig } from '../config/config'
 import JiraClient from '../client/client'
 import { JIRA_USERS_PAGE, PERMISSION_SCHEME_TYPE_NAME } from '../constants'
@@ -242,15 +242,15 @@ const createChangeErrorsForAccountIdIssues = (
 export const accountIdValidator: (
   client: JiraClient,
   config: JiraConfig,
-  getUserMapFunc: GetUserMapFunc
+  elementsSource: ReadOnlyElementsSource,
 ) =>
-  ChangeValidator = (client, config, getUserMapFunc) => async changes =>
+  ChangeValidator = (client, config, elementsSource) => async changes =>
     log.time(async () => {
       if (!(config.fetch.convertUsersIds ?? true)) {
         return []
       }
       const { baseUrl, isDataCenter } = client
-      const rawUserMap = await getUserMapFunc()
+      const rawUserMap = await getUserMapFunc(elementsSource)
       if (rawUserMap === undefined) {
         return []
       }

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ChangeValidator } from '@salto-io/adapter-api'
+import { ChangeValidator, ReadOnlyElementsSource } from '@salto-io/adapter-api'
 import { deployment, client as clientUtils } from '@salto-io/adapter-components'
 import { createChangeValidator } from '@salto-io/adapter-utils'
 import { readOnlyProjectRoleChangeValidator } from './read_only_project_role'
@@ -36,7 +36,6 @@ import { systemFieldsValidator } from './system_fields'
 import { workflowPropertiesValidator } from './workflows/workflow_properties'
 import { permissionSchemeValidator } from './sd_portals_permission_scheme'
 import { wrongUserPermissionSchemeValidator } from './wrong_user_permission_scheme'
-import { GetUserMapFunc } from '../users'
 import { accountIdValidator } from './account_id'
 import { screenSchemeDefaultValidator } from './screen_scheme_default'
 import { workflowSchemeDupsValidator } from './workflows/workflow_scheme_dups'
@@ -60,7 +59,7 @@ const {
 
 
 export default (
-  client: JiraClient, config: JiraConfig, getUserMapFunc: GetUserMapFunc, paginator: clientUtils.Paginator
+  client: JiraClient, config: JiraConfig, elementsSource: ReadOnlyElementsSource, paginator: clientUtils.Paginator
 ): ChangeValidator => {
   const validators: ChangeValidator[] = [
     ...deployment.changeValidators.getDefaultChangeValidators(['unresolvedReferencesValidator']),
@@ -96,8 +95,8 @@ export default (
     workflowPropertiesValidator,
     permissionSchemeValidator,
     screenSchemeDefaultValidator,
-    wrongUserPermissionSchemeValidator(client, config, getUserMapFunc),
-    accountIdValidator(client, config, getUserMapFunc),
+    wrongUserPermissionSchemeValidator(client, config, elementsSource),
+    accountIdValidator(client, config, elementsSource),
     workflowSchemeDupsValidator,
     permissionSchemeDeploymentValidator(client),
   ]

--- a/packages/jira-adapter/src/change_validators/wrong_user_permission_scheme.ts
+++ b/packages/jira-adapter/src/change_validators/wrong_user_permission_scheme.ts
@@ -13,13 +13,13 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ChangeError, ChangeValidator, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange } from '@salto-io/adapter-api'
+import { ChangeError, ChangeValidator, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, ReadOnlyElementsSource } from '@salto-io/adapter-api'
 import { isPermissionSchemeStructure, PermissionHolder } from '../filters/permission_scheme/omit_permissions_common'
 import { JIRA_USERS_PAGE, PERMISSION_SCHEME_TYPE_NAME } from '../constants'
 import JiraClient from '../client/client'
 import { JiraConfig } from '../config/config'
 import { wrongUserPermissionSchemePredicateCreator } from '../filters/permission_scheme/wrong_user_permission_scheme_filter'
-import { GetUserMapFunc, getUsersMapByVisibleId } from '../users'
+import { getUserMapFunc, getUsersMapByVisibleId } from '../users'
 
 
 const createChangeError = (
@@ -45,13 +45,13 @@ Check ${new URL(JIRA_USERS_PAGE, url).href} to see valid users and account IDs.`
 export const wrongUserPermissionSchemeValidator: (
   client: JiraClient,
   config: JiraConfig,
-  getUserMapFunc: GetUserMapFunc
-  ) => ChangeValidator = (client, config, getUserMapFunc) => async changes => {
+  elementsSource: ReadOnlyElementsSource,
+  ) => ChangeValidator = (client, config, elementsSource) => async changes => {
     if (!(config.fetch.convertUsersIds ?? true)) {
       return []
     }
     const { baseUrl } = client
-    const rawUserMap = await getUserMapFunc()
+    const rawUserMap = await getUserMapFunc(elementsSource)
     if (rawUserMap === undefined) {
       return []
     }

--- a/packages/jira-adapter/src/filters/store_users.ts
+++ b/packages/jira-adapter/src/filters/store_users.ts
@@ -1,0 +1,71 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { logger } from '@salto-io/logging'
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, MapType, ObjectType } from '@salto-io/adapter-api'
+import { FilterCreator } from '../filter'
+import { JIRA } from '../constants'
+import { UserMap } from '../users'
+
+const log = logger(module)
+
+const userInfoType = new ObjectType({
+  elemID: new ElemID(JIRA, 'UserInfo'),
+  fields: {
+    locale: { refType: BuiltinTypes.STRING },
+    displayName: { refType: BuiltinTypes.STRING },
+    email: { refType: BuiltinTypes.STRING },
+    username: { refType: BuiltinTypes.STRING },
+  },
+  annotations: {
+    [CORE_ANNOTATIONS.HIDDEN]: true,
+  },
+})
+
+const usersType = new ObjectType({
+  elemID: new ElemID(JIRA, 'Users'),
+  fields: {
+    users: { refType: new MapType(userInfoType) },
+  },
+  annotations: {
+    [CORE_ANNOTATIONS.HIDDEN]: true,
+  },
+})
+
+const getUsers = (userMap: UserMap | undefined): InstanceElement =>
+  new InstanceElement(
+    'users',
+    usersType,
+    { users: userMap },
+    undefined,
+    { [CORE_ANNOTATIONS.HIDDEN]: true },
+  )
+
+
+/*
+ * stores the fetched users to an hidden nacl
+*/
+const filter: FilterCreator = ({ getUserMapFunc }) => ({
+  name: 'storeUsers',
+  onFetch: async elements => log.time(async () => {
+    try {
+      const usersMap = await getUserMapFunc()
+      elements.push(userInfoType, usersType, getUsers(usersMap))
+    } catch (e) {
+      log.error('failed to fetch users', e)
+    }
+  }, 'store users filter'),
+})
+export default filter

--- a/packages/jira-adapter/src/users.ts
+++ b/packages/jira-adapter/src/users.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import { ElemID, ReadOnlyElementsSource } from '@salto-io/adapter-api'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { createSchemeGuard } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
@@ -138,6 +139,13 @@ export const getUserMapFuncCreator = (paginator: clientUtils.Paginator, isDataCe
     }
     return idMap
   }
+}
+
+export const getUserMapFunc = async (
+  elementSource: ReadOnlyElementsSource
+): Promise<UserMap | undefined> => {
+  const usersElement = await elementSource.get(new ElemID('jira', 'Users', 'instance', 'users'))
+  return usersElement?.value?.users as (UserMap | undefined)
 }
 
 export const getCurrentUserInfo = async (client: JiraClient): Promise<UserInfo | undefined> => {

--- a/packages/jira-adapter/test/change_validators/account_id.test.ts
+++ b/packages/jira-adapter/test/change_validators/account_id.test.ts
@@ -13,144 +13,172 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { toChange, InstanceElement, ElemID, ChangeError } from '@salto-io/adapter-api'
+import { toChange, InstanceElement, ElemID, ChangeError, ObjectType } from '@salto-io/adapter-api'
 import { config as configUtils } from '@salto-io/adapter-components'
 import _ from 'lodash'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { mockClient } from '../utils'
 import { accountIdValidator } from '../../src/change_validators/account_id'
 import * as common from '../filters/account_id/account_id_common'
 import { getDefaultConfig } from '../../src/config/config'
+import { JIRA } from '../../src/constants'
 
 describe('accountIdValidator', () => {
-  const { client, connection, getUserMapFunc } = mockClient()
+  const usersType = new ObjectType({
+    elemID: new ElemID(JIRA, 'Users'),
+  })
+  const usersElements = new InstanceElement(
+    'users',
+    usersType,
+    {
+      users: {
+        0: {
+          userId: '0',
+          displayName: 'disp0',
+          locale: 'en_US',
+          email: 'email0',
+        },
+        '0n': {
+          userId: '0n',
+          displayName: 'disp0n',
+          locale: 'en_US',
+          email: 'email0n',
+        },
+        '00': {
+          userId: '00',
+          displayName: 'disp00',
+          locale: 'en_US',
+          email: 'email00',
+        },
+        '00n': {
+          userId: '00n',
+          displayName: 'disp00n',
+          locale: 'en_US',
+          email: 'email00n',
+        },
+        '0l': {
+          userId: '0l',
+          displayName: 'disp0l',
+          locale: 'en_US',
+          email: 'email0l',
+        },
+        '0an': {
+          userId: '0an',
+          displayName: 'disp0an',
+          locale: 'en_US',
+          email: 'email0an',
+        },
+        '0h': {
+          userId: '0h',
+          displayName: 'disp0h',
+          locale: 'en_US',
+          email: 'email0h',
+        },
+        '0list1': {
+          userId: '0list1',
+          displayName: 'disp0list1',
+          locale: 'en_US',
+          email: 'email0list1',
+        },
+        '0list2': {
+          userId: '0list2',
+          displayName: 'disp0list2',
+          locale: 'en_US',
+          email: 'email0list2',
+        },
+        1: {
+          userId: '1',
+          displayName: 'disp1',
+          locale: 'en_US',
+          email: 'email1',
+        },
+        '1n': {
+          userId: '1n',
+          displayName: 'disp1n',
+          locale: 'en_US',
+          email: 'email1n',
+        },
+        11: {
+          userId: '11',
+          displayName: 'disp11',
+          locale: 'en_US',
+          email: 'email11',
+        },
+        '11n': {
+          userId: '11n',
+          displayName: 'disp11n',
+          locale: 'en_US',
+          email: 'email11n',
+        },
+        '1l': {
+          userId: '1l',
+          displayName: 'disp1l',
+          locale: 'en_US',
+          email: 'email1l',
+        },
+        '1an': {
+          userId: '1an',
+          displayName: 'disp1an',
+          locale: 'en_US',
+          email: 'email1an',
+        },
+        '1h': {
+          userId: '1h',
+          displayName: 'disp1h',
+          locale: 'en_US',
+          email: 'email1h',
+        },
+        '1list1': {
+          userId: '1list1',
+          displayName: 'disp1list1',
+          locale: 'en_US',
+          email: 'email1list1',
+        },
+        '1list2': {
+          userId: '1list2',
+          displayName: 'disp1list2',
+          locale: 'en_US',
+          email: 'email1list2',
+        },
+        '0owner': {
+          userId: '0owner',
+          displayName: 'disp0owner',
+          locale: 'en_US',
+          email: 'email0owner',
+        },
+        '0Ids1': {
+          userId: '0Ids1',
+          displayName: 'disp0Ids1',
+          locale: 'en_US',
+          email: 'email0Ids1',
+        },
+        '0Ids2': {
+          userId: '0Ids2',
+          displayName: 'disp0Ids2',
+          locale: 'en_US',
+          email: 'email0Ids2',
+        },
+        '1Ids1': {
+          userId: '1Ids1',
+          displayName: 'disp1Ids1',
+          locale: 'en_US',
+          email: 'email1Ids1',
+        },
+        '1Ids2': {
+          userId: '1Ids2',
+          displayName: 'disp1Ids2',
+          locale: 'en_US',
+          email: 'email1Ids2',
+        },
+      },
+    }
+  )
+  const elementsSource = buildElementsSourceFromElements([usersElements])
+  const { client } = mockClient()
   const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
-  const validator = accountIdValidator(client, config, getUserMapFunc)
+  const validator = accountIdValidator(client, config, elementsSource)
   const url = `${client.baseUrl}jira/people/search`
   let instances: InstanceElement[] = []
-  connection.get.mockResolvedValue({
-    status: 200,
-    data: [{
-      accountId: '0',
-      displayName: 'disp0',
-      locale: 'en_US',
-      emailAddress: 'email0',
-    }, {
-      accountId: '0n',
-      displayName: 'disp0n',
-      locale: 'en_US',
-      emailAddress: 'email0n',
-    }, {
-      accountId: '00',
-      displayName: 'disp00',
-      locale: 'en_US',
-      emailAddress: 'email00',
-    }, {
-      accountId: '00n',
-      displayName: 'disp00n',
-      locale: 'en_US',
-      emailAddress: 'email00n',
-    }, {
-      accountId: '0l',
-      displayName: 'disp0l',
-      locale: 'en_US',
-      emailAddress: 'email0l',
-    }, {
-      accountId: '0an',
-      displayName: 'disp0an',
-      locale: 'en_US',
-      emailAddress: 'email0an',
-    }, {
-      accountId: '0h',
-      displayName: 'disp0h',
-      locale: 'en_US',
-      emailAddress: 'email0h',
-    }, {
-      accountId: '0list1',
-      displayName: 'disp0list1',
-      locale: 'en_US',
-      emailAddress: 'email0list1',
-    }, {
-      accountId: '0list2',
-      displayName: 'disp0list2',
-      locale: 'en_US',
-      emailAddress: 'email0list2',
-    }, {
-      accountId: '1',
-      displayName: 'disp1',
-      locale: 'en_US',
-      emailAddress: 'email1',
-    }, {
-      accountId: '1n',
-      displayName: 'disp1n',
-      locale: 'en_US',
-      emailAddress: 'email1n',
-    }, {
-      accountId: '11',
-      displayName: 'disp11',
-      locale: 'en_US',
-      emailAddress: 'email11',
-    }, {
-      accountId: '11n',
-      displayName: 'disp11n',
-      locale: 'en_US',
-      emailAddress: 'email11n',
-    }, {
-      accountId: '1l',
-      displayName: 'disp1l',
-      locale: 'en_US',
-      emailAddress: 'email1l',
-    }, {
-      accountId: '1an',
-      displayName: 'disp1an',
-      locale: 'en_US',
-      emailAddress: 'email1an',
-    }, {
-      accountId: '1h',
-      displayName: 'disp1h',
-      locale: 'en_US',
-      emailAddress: 'email1h',
-    }, {
-      accountId: '1list1',
-      displayName: 'disp1list1',
-      locale: 'en_US',
-      emailAddress: 'email1list1',
-    }, {
-      accountId: '1list2',
-      displayName: 'disp1list2',
-      locale: 'en_US',
-      emailAddress: 'email1list2',
-    }, {
-      accountId: '0owner',
-      displayName: 'disp0owner',
-      locale: 'en_US',
-      emailAddress: 'email0owner',
-    }, {
-      accountId: '1list2',
-      displayName: 'disp1list2',
-      locale: 'en_US',
-      emailAddress: 'email1list2',
-    }, {
-      accountId: '0Ids1',
-      displayName: 'disp0Ids1',
-      locale: 'en_US',
-      emailAddress: 'email0Ids1',
-    }, {
-      accountId: '0Ids2',
-      displayName: 'disp0Ids2',
-      locale: 'en_US',
-      emailAddress: 'email0Ids2',
-    }, {
-      accountId: '1Ids1',
-      displayName: 'disp1Ids1',
-      locale: 'en_US',
-      emailAddress: 'email1Ids1',
-    }, {
-      accountId: '1Ids2',
-      displayName: 'disp1Ids2',
-      locale: 'en_US',
-      emailAddress: 'email1Ids2',
-    }],
-  })
 
   const createInfo = (elemId: ElemID):ChangeError => ({
     elemID: elemId,
@@ -185,16 +213,9 @@ Go to ${url} to see valid users and account IDs.`,
     instances = common.createInstanceElementArrayWithDisplayNames(2, objectType)
   })
 
-  it('should only call outside once', async () => {
-    await validator([toChange({ after: instances[0] })])
-    const validator2 = accountIdValidator(client, config, getUserMapFunc)
-    await validator2([toChange({ after: instances[1] })])
-    expect(connection.get).toHaveBeenCalledOnce()
-  })
-
-  it('should not fail on when user map func returned undefined', async () => {
-    const mockedGetUserMapFunc = jest.fn().mockResolvedValue(undefined)
-    const validator2 = accountIdValidator(client, config, mockedGetUserMapFunc)
+  it('should not fail on when user map func does not exist', async () => {
+    const emptyElementsSource = buildElementsSourceFromElements([])
+    const validator2 = accountIdValidator(client, config, emptyElementsSource)
     await expect(validator2([toChange({ after: instances[1] })])).resolves.not.toThrow()
   })
 
@@ -349,7 +370,7 @@ Go to ${url} to see valid users and account IDs.`,
     const validatorOff = accountIdValidator(
       client,
       configOff,
-      getUserMapFunc
+      elementsSource
     )
     const field1 = 'parameter'
     delete instances[0].value.holder[field1].displayName
@@ -382,20 +403,25 @@ Go to ${url} to see valid users and account IDs.`,
   })
 
   describe('Using Jira DC', () => {
-    const { client: clientDC, connection: connectionDC, getUserMapFunc: getUserMapFuncDC } = mockClient(true)
+    const { client: clientDC } = mockClient(true)
     const configDC = _.cloneDeep(getDefaultConfig({ isDataCenter: true }))
-    const validatorDC = accountIdValidator(clientDC, configDC, getUserMapFuncDC)
+    const dcUsersInstance = new InstanceElement(
+      'users',
+      usersType,
+      {
+        users: {
+          JIRAUSER10000: {
+            userId: 'JIRAUSER10000',
+            username: 'firstAccount',
+            displayName: 'firstAccountDisplayName',
+          },
+        },
+      },
+    )
+    const validatorDC = accountIdValidator(clientDC, configDC, buildElementsSourceFromElements([dcUsersInstance]))
     let validUserInstance: InstanceElement
     let invalidUserInstance: InstanceElement
     const objectType = common.createObjectedType('NotificationScheme') // passes all conditions
-    connectionDC.get.mockResolvedValue({
-      status: 200,
-      data: [{
-        key: 'JIRAUSER10000',
-        name: 'firstAccount',
-        displayName: 'firstAccountDisplayName',
-      }],
-    })
 
     beforeEach(() => {
       validUserInstance = new InstanceElement(
@@ -446,8 +472,7 @@ Go to ${url} to see valid users and account IDs.`,
       expect(changeErrors).toEqual([])
     })
     it('should not fail when user map func returns undefined', async () => {
-      const mockedGetUserMapFunc = jest.fn().mockResolvedValue(undefined)
-      const validator2 = accountIdValidator(clientDC, configDC, mockedGetUserMapFunc)
+      const validator2 = accountIdValidator(clientDC, configDC, buildElementsSourceFromElements([]))
       await expect(validator2([toChange({ after: instances[1] })])).resolves.not.toThrow()
     })
     it('should raise an error when accountId does not exist in the target environment', async () => {

--- a/packages/jira-adapter/test/change_validators/change_validator.test.ts
+++ b/packages/jira-adapter/test/change_validators/change_validator.test.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import { toChange, ObjectType, ElemID } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { mockClient } from '../utils'
 import changeValidator from '../../src/change_validators'
 import { JIRA } from '../../src/constants'
@@ -21,19 +22,20 @@ import { getDefaultConfig } from '../../src/config/config'
 
 describe('change validator creator', () => {
   describe('checkDeploymentAnnotationsValidator', () => {
-    const { client, getUserMapFunc, paginator } = mockClient()
+    const { client, paginator } = mockClient()
+    const elementsSource = buildElementsSourceFromElements([])
 
     it('should not fail if there are no deploy changes', async () => {
       expect(
         await changeValidator(
-          client, getDefaultConfig({ isDataCenter: false }), getUserMapFunc, paginator
+          client, getDefaultConfig({ isDataCenter: false }), elementsSource, paginator
         )([])
       ).toEqual([])
     })
 
     it('should fail each change individually', async () => {
       expect(await changeValidator(
-        client, getDefaultConfig({ isDataCenter: false }), getUserMapFunc, paginator
+        client, getDefaultConfig({ isDataCenter: false }), elementsSource, paginator
       )([
         toChange({ after: new ObjectType({ elemID: new ElemID(JIRA, 'obj') }) }),
         toChange({ before: new ObjectType({ elemID: new ElemID(JIRA, 'obj2') }) }),

--- a/packages/jira-adapter/test/change_validators/wrong_user_permission_scheme.test.ts
+++ b/packages/jira-adapter/test/change_validators/wrong_user_permission_scheme.test.ts
@@ -15,42 +15,57 @@
 */
 import { toChange, InstanceElement, ElemID, ChangeError, ObjectType, Change, Value } from '@salto-io/adapter-api'
 import _ from 'lodash'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { mockClient } from '../utils'
 import { getDefaultConfig } from '../../src/config/config'
 import { JIRA, PERMISSION_SCHEME_TYPE_NAME } from '../../src/constants'
 import { wrongUserPermissionSchemeValidator } from '../../src/change_validators/wrong_user_permission_scheme'
 
 describe('wrongUsersPermissionSchemeValidator', () => {
+  const usersType = new ObjectType({
+    elemID: new ElemID(JIRA, 'Users'),
+  })
+  const usersElements = new InstanceElement(
+    'users',
+    usersType,
+    {
+      users: {
+        id0: {
+          accountId: 'id0',
+          displayName: 'name0',
+          locale: 'en_US',
+        },
+        id2: {
+          accountId: 'id2',
+          displayName: 'name2',
+          locale: 'en_US',
+        },
+        id3: {
+          accountId: 'id3',
+          displayName: 'name3',
+          locale: 'en_US',
+        },
+        id4: {
+          accountId: 'id4',
+          displayName: 'name4',
+          locale: 'en_US',
+        },
+        id5: {
+          accountId: 'id5',
+          displayName: 'name5',
+          locale: 'en_US',
+        },
+      },
+    },
+  )
+  const elementsSource = buildElementsSourceFromElements([usersElements])
   const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
-  const { client, getUserMapFunc, connection } = mockClient()
-  const validator = wrongUserPermissionSchemeValidator(client, config, getUserMapFunc)
+  const { client } = mockClient()
+  const validator = wrongUserPermissionSchemeValidator(client, config, elementsSource)
   const url = `${client.baseUrl}jira/people/search`
   let instances: InstanceElement[]
   let changes: Change[]
-  connection.get.mockResolvedValue({
-    status: 200,
-    data: [{
-      accountId: 'id0',
-      displayName: 'name0',
-      locale: 'en_US',
-    }, {
-      accountId: 'id2',
-      displayName: 'name2',
-      locale: 'en_US',
-    }, {
-      accountId: 'id3',
-      displayName: 'name3',
-      locale: 'en_US',
-    }, {
-      accountId: 'id4',
-      displayName: 'name4',
-      locale: 'en_US',
-    }, {
-      accountId: 'id5',
-      displayName: 'name5',
-      locale: 'en_US',
-    }],
-  })
+
   const createWarning = (element: InstanceElement, parentName: string): ChangeError => ({
     elemID: element.elemID,
     severity: 'Warning',
@@ -118,14 +133,13 @@ Check ${url} to see valid users and account IDs.`,
   it('should not return a warning when the flag is off', async () => {
     const configOff = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
     configOff.fetch.convertUsersIds = false
-    const validatorOff = wrongUserPermissionSchemeValidator(client, configOff, getUserMapFunc)
+    const validatorOff = wrongUserPermissionSchemeValidator(client, configOff, elementsSource)
     expect(await validatorOff(
       changes
     )).toEqual([])
   })
-  it('should not fail when users map func returns undefined', async () => {
-    const mockedGetUserMapFunc = jest.fn().mockResolvedValue(undefined)
-    const validator2 = wrongUserPermissionSchemeValidator(client, config, mockedGetUserMapFunc)
+  it('should not fail when users map func returns empty', async () => {
+    const validator2 = wrongUserPermissionSchemeValidator(client, config, buildElementsSourceFromElements([]))
     await expect(validator2(changes)).resolves.not.toThrow()
   })
 })

--- a/packages/jira-adapter/test/filters/store_users.test.ts
+++ b/packages/jira-adapter/test/filters/store_users.test.ts
@@ -1,0 +1,121 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { InstanceElement } from '@salto-io/adapter-api'
+import { client as clientUtils } from '@salto-io/adapter-components'
+import { MockInterface } from '@salto-io/test-utils'
+import { getFilterParams, mockClient } from '../utils'
+import storeUsersFilter from '../../src/filters/store_users'
+import { Filter } from '../../src/filter'
+
+describe('storeUsersFilter', () => {
+  let filter: Filter
+  let mockConnection: MockInterface<clientUtils.APIConnection>
+  let elements: InstanceElement[]
+  describe('cloud', () => {
+    beforeEach(async () => {
+      const { connection, getUserMapFunc } = mockClient()
+      mockConnection = connection
+      filter = storeUsersFilter(getFilterParams({
+        getUserMapFunc,
+      })) as typeof filter
+      elements = []
+    })
+    it('should store users successfully', async () => {
+      mockConnection.get.mockResolvedValueOnce({
+        status: 200,
+        data: [{
+          accountId: '2',
+          displayName: 'disp2',
+          locale: 'en_US',
+        }, {
+          accountId: '2n',
+          displayName: 'disp2n',
+          locale: 'en_US',
+        }],
+      })
+      await filter.onFetch?.(elements)
+      expect(elements.length).toEqual(3)
+      expect(elements[0].elemID.getFullName()).toEqual('jira.UserInfo')
+      expect(elements[1].elemID.getFullName()).toEqual('jira.Users')
+      expect(elements[2].value).toEqual({ users: { 2: {
+        locale: 'en_US',
+        displayName: 'disp2',
+        email: undefined,
+        username: undefined,
+        userId: '2',
+      },
+      '2n': {
+        locale: 'en_US',
+        displayName: 'disp2n',
+        email: undefined,
+        username: undefined,
+        userId: '2n',
+      } } })
+    })
+    it('should not fail during error', async () => {
+      mockConnection.get.mockRejectedValueOnce({
+        status: 400,
+        error: 'some error',
+      })
+      await filter.onFetch?.(elements)
+      expect(elements.length).toEqual(0)
+    })
+  })
+  describe('dc', () => {
+    beforeEach(async () => {
+      const { connection, getUserMapFunc } = mockClient(true)
+      mockConnection = connection
+      filter = storeUsersFilter(getFilterParams({
+        getUserMapFunc,
+      })) as typeof filter
+      elements = []
+    })
+    it('should store users successfully', async () => {
+      mockConnection.get.mockResolvedValueOnce({
+        status: 200,
+        data: [{
+          key: '2',
+          name: 'name2',
+          locale: 'en_US',
+          displayName: 'name2',
+        }, {
+          key: '2l',
+          name: 'name2l',
+          locale: 'en_US',
+          displayName: 'name2l',
+        }],
+      })
+      await filter.onFetch?.(elements)
+      expect(elements.length).toEqual(3)
+      expect(elements[0].elemID.getFullName()).toEqual('jira.UserInfo')
+      expect(elements[1].elemID.getFullName()).toEqual('jira.Users')
+      expect(elements[2].value).toEqual({ users: { 2: {
+        locale: 'en_US',
+        displayName: 'name2',
+        email: undefined,
+        username: 'name2',
+        userId: '2',
+      },
+      '2l': {
+        locale: 'en_US',
+        displayName: 'name2l',
+        email: undefined,
+        username: 'name2l',
+        userId: '2l',
+      } } })
+    })
+  })
+})


### PR DESCRIPTION
Now storing users' info during fetch in a hidden NaCl.
On deploy we will no longer fetch the users.

---

I verified that we could handle the case in which the nacl does not exist- we simply do not issue CV errors

---
_Release Notes_: 
Jira Adapter:
Deploy plan will become faster thanks to a change in the way we handle users' data

---
_User Notifications_: 
None
