### PR TITLE
SALTO-3148 add support for french fetch errors

### DIFF
--- a/packages/netsuite-adapter/src/client/language_utils.ts
+++ b/packages/netsuite-adapter/src/client/language_utils.ts
@@ -20,6 +20,9 @@ const log = logger(module)
 export const OBJECT_ID = 'objectId'
 export const FEATURE_NAME = 'featureName'
 
+export const fetchUnexpectedErrorRegex = new RegExp('(unexpected error|erreur inattendue)')
+export const fetchLockedObjectErrorRegex = new RegExp('You cannot download the XML file for this object because it is locked')
+
 type SupportedLanguage = 'english' | 'french'
 
 type ErrorDetectors = {

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -54,7 +54,7 @@ import {
   mergeTypeToInstances,
 } from './utils'
 import { fixManifest } from './manifest_utils'
-import { detectLanguage, FEATURE_NAME, multiLanguageErrorDetectors, OBJECT_ID } from './language_utils'
+import { detectLanguage, FEATURE_NAME, fetchLockedObjectErrorRegex, fetchUnexpectedErrorRegex, multiLanguageErrorDetectors, OBJECT_ID } from './language_utils'
 
 const { makeArray } = collections.array
 const { withLimitedConcurrency } = promises.array
@@ -700,7 +700,7 @@ export default class SdfClient {
 
     const unexpectedError = SdfClient.createFailedImportsMap(importResult.failedImports
       .filter(failedImport => {
-        if (failedImport.customObject.result.message.includes('unexpected error')) {
+        if (fetchUnexpectedErrorRegex.test(failedImport.customObject.result.message)) {
           log.debug('Failed to fetch (%s) instance with id (%s) due to SDF unexpected error',
             SdfClient.fixTypeName(failedImport.customObject.type), failedImport.customObject.id)
           return true
@@ -710,7 +710,7 @@ export default class SdfClient {
 
     const lockedError = SdfClient.createFailedImportsMap(importResult.failedImports
       .filter(failedImport => {
-        if (failedImport.customObject.result.message.includes('You cannot download the XML file for this object because it is locked')) {
+        if (fetchLockedObjectErrorRegex.test(failedImport.customObject.result.message)) {
           log.debug('Failed to fetch (%s) instance with id (%s) due to the instance being locked',
             SdfClient.fixTypeName(failedImport.customObject.type), failedImport.customObject.id)
           return true

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -763,7 +763,7 @@ describe('sdf client', () => {
                   type: 'csvimport',
                   result: {
                     code: 'FAILED',
-                    message: 'An unexpected error has occurred',
+                    message: 'Une erreur inattendue s\'est produite.',
                   },
                 },
               },


### PR DESCRIPTION
In order to identify errors for locked objects & unexpected errors.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Add support for french fetch errors

---
_User Notifications_: 
None