### PR TITLE
SALTO-3774 allow configuring idFields that only exist in some elements

### DIFF
--- a/packages/adapter-components/src/elements/instance_elements.ts
+++ b/packages/adapter-components/src/elements/instance_elements.ts
@@ -52,8 +52,17 @@ const getNameMapping = (
 }
 
 export const joinInstanceNameParts = (
-  nameParts: string[],
-): string | undefined => (nameParts.every(part => part !== undefined && part !== '') ? nameParts.map(String).join('_') : undefined)
+  nameParts: unknown[],
+): string | undefined => (
+  // if nameParts is empty, we assume it is intentional
+  (nameParts.length === 0 || nameParts.some(part => part !== undefined && part !== ''))
+    ? nameParts
+      .map(part => (part === undefined ? '' : part))
+      .map(String)
+      .filter((part, idx) => part !== '' || idx !== nameParts.length - 1) // if the last part is empty, avoid adding an extra '_'
+      .join('_')
+    : undefined
+)
 
 export const getInstanceName = (
   instanceValues: Values,
@@ -61,11 +70,12 @@ export const getInstanceName = (
   typeName: string,
 ): string | undefined => {
   const nameParts = idFields
-    .map(fieldName => _.get(instanceValues, dereferenceFieldName(fieldName)))
-  if (nameParts.includes(undefined)) {
-    log.warn(`could not find id for entry in type ${typeName} - expected id fields ${idFields}, available fields ${Object.keys(instanceValues)}`)
+    .map(fieldName => ({ fieldName, value: _.get(instanceValues, dereferenceFieldName(fieldName)) }))
+  const missingFieldNames = nameParts.filter(part => part.value === undefined).map(part => part.fieldName)
+  if (missingFieldNames.length > 0) {
+    log.debug(`Some instances of type ${typeName} did not contain the following id fields: ${missingFieldNames}`)
   }
-  return joinInstanceNameParts(nameParts)
+  return joinInstanceNameParts(nameParts.map(part => part.value))
 }
 
 export const getInstanceFilePath = ({
@@ -164,8 +174,8 @@ export const getInstanceNaclName = ({
   nameMapping?: NameMappingOptions
 }): string => {
   // If the name is empty, there is no reason to add the ID_SEPARATOR
-  const parentNameSuffix = !isEmpty(name) ? `${ID_SEPARATOR}${name}` : ''
-  const newName = parentName ? `${parentName}${parentNameSuffix}` : String(name)
+  const nameWithSeparator = !isEmpty(name) ? `${ID_SEPARATOR}${name}` : ''
+  const newName = parentName ? `${parentName}${nameWithSeparator}` : String(name)
   const naclName = naclCase(newName)
 
   const desiredName = nameMapping

--- a/packages/adapter-components/src/filters/referenced_instance_names.ts
+++ b/packages/adapter-components/src/filters/referenced_instance_names.ts
@@ -107,7 +107,7 @@ const createInstanceNameAndFilePath = (
   const { idFields, nameMapping } = idConfig
   const newNameParts = createInstanceReferencedNameParts(instance, idFields)
   const newName = joinInstanceNameParts(newNameParts) ?? instance.elemID.name
-  const parentName = getFirstParentElemId(instance)?.name
+  const parentName = idConfig.extendsParentId ? getFirstParentElemId(instance)?.name : undefined
   const { typeName, adapter } = instance.elemID
   const { fileNameFields, serviceIdField } = configByType[typeName]
 

--- a/packages/adapter-components/test/filters/referenced_instance_name.test.ts
+++ b/packages/adapter-components/test/filters/referenced_instance_name.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-
+import _ from 'lodash'
 import {
   ElemID,
   InstanceElement,
@@ -221,7 +221,7 @@ describe('referenced instances', () => {
         }
       ),
     ]
-    const noIdFieldsParent = new InstanceElement('no_idFieldsParent', noIdFieldsType)
+    const noIdFieldsParent = new InstanceElement('no_idFieldsParent', bookType)
     const noIdFieldsWithParent = new InstanceElement(
       'no_idFieldsWithParent',
       noIdFieldsType,
@@ -231,7 +231,8 @@ describe('referenced instances', () => {
     )
     return [recipeType, bookType, ...recipes, anotherBook, rootBook,
       sameRecipeOne, sameRecipeTwo, lastRecipe, groupType, ...groups,
-      folderType, folderOne, folderTwo, statusType, status, ...emailsWithTemplates, noIdFieldsWithParent]
+      folderType, folderOne, folderTwo, statusType, status, ...emailsWithTemplates,
+      noIdFieldsParent, noIdFieldsWithParent]
   }
   const lowercaseName : NameMappingOptions = 'lowercase'
   const config = {
@@ -307,15 +308,16 @@ describe('referenced instances', () => {
         .map(e => e.elemID.getFullName()).sort())
         .toEqual(['myAdapter.book.instance.123_ROOT',
           'myAdapter.book.instance.456_123_ROOT',
+          'myAdapter.book.instance.no_idFieldsParent',
           'myAdapter.email.instance.aaa_username_group1@um',
           'myAdapter.email.instance.aaa_username_group1_x_y@umvv',
-          'myAdapter.folder.instance.recipe123_123_ROOT__lastRecipe_456_123_ROOT__Desktop',
-          'myAdapter.folder.instance.recipe123_123_ROOT__lastRecipe_456_123_ROOT__Documents',
+          'myAdapter.folder.instance.lastRecipe_456_123_ROOT__Desktop',
+          'myAdapter.folder.instance.lastRecipe_456_123_ROOT__Documents',
           'myAdapter.group.instance.group1',
           'myAdapter.group.instance.group2',
           'myAdapter.noIdFields.instance.no_idFieldsParent',
+          'myAdapter.recipe.instance.lastRecipe_456_123_ROOT',
           'myAdapter.recipe.instance.recipe123_123_ROOT',
-          'myAdapter.recipe.instance.recipe123_123_ROOT__lastRecipe_456_123_ROOT',
           'myAdapter.recipe.instance.recipe456_456_123_ROOT',
           'myAdapter.recipe.instance.sameRecipe',
           'myAdapter.recipe.instance.sameRecipe',
@@ -343,17 +345,18 @@ describe('referenced instances', () => {
       const sortedResult = result
         .filter(isInstanceElement)
         .map(i => i.elemID.getFullName()).sort()
-      expect(result.length).toEqual(14)
+      expect(result.length).toEqual(15)
       expect(sortedResult)
         .toEqual(['myAdapter.book.instance.123_ROOT',
           'myAdapter.book.instance.456_123_ROOT',
-          'myAdapter.folder.instance.recipe123_123_ROOT__lastRecipe_456_123_ROOT__Desktop',
-          'myAdapter.folder.instance.recipe123_123_ROOT__lastRecipe_456_123_ROOT__Documents',
+          'myAdapter.book.instance.no_idFieldsParent',
+          'myAdapter.folder.instance.lastRecipe_456_123_ROOT__Desktop',
+          'myAdapter.folder.instance.lastRecipe_456_123_ROOT__Documents',
           'myAdapter.group.instance.group1',
           'myAdapter.group.instance.group2',
           'myAdapter.noIdFields.instance.no_idFieldsWithParent',
+          'myAdapter.recipe.instance.lastRecipe_456_123_ROOT',
           'myAdapter.recipe.instance.recipe123_123_ROOT',
-          'myAdapter.recipe.instance.recipe123_123_ROOT__lastRecipe_456_123_ROOT',
           'myAdapter.recipe.instance.recipe456_456_123_ROOT',
         ])
     })
@@ -386,19 +389,20 @@ describe('referenced instances', () => {
         transformationConfigByType,
         transformationDefaultConfig
       )
-      expect(result.length).toEqual(13)
+      expect(result.length).toEqual(14)
       expect(result
         .map(e => e.elemID.getFullName()).sort())
         .toEqual(['myAdapter.book',
           'myAdapter.book.instance.123_ROOT',
           'myAdapter.book.instance.456_123_ROOT',
+          'myAdapter.book.instance.no_idFieldsParent',
           'myAdapter.folder',
-          'myAdapter.folder.instance.recipe123_123_ROOT__lastRecipe_456_123_ROOT__Desktop',
-          'myAdapter.folder.instance.recipe123_123_ROOT__lastRecipe_456_123_ROOT__Documents',
+          'myAdapter.folder.instance.lastRecipe_456_123_ROOT__Desktop',
+          'myAdapter.folder.instance.lastRecipe_456_123_ROOT__Documents',
           'myAdapter.noIdFields.instance.no_idFieldsWithParent',
           'myAdapter.recipe',
+          'myAdapter.recipe.instance.lastRecipe_456_123_ROOT',
           'myAdapter.recipe.instance.recipe123_123_ROOT',
-          'myAdapter.recipe.instance.recipe123_123_ROOT__lastRecipe_456_123_ROOT',
           'myAdapter.recipe.instance.recipe456_456_123_ROOT',
           'myAdapter.recipe.instance.sameRecipe',
           'myAdapter.recipe.instance.sameRecipe',
@@ -411,15 +415,14 @@ describe('referenced instances', () => {
         .map(i => i.elemID.getFullName())
       const allIns = elements.filter(isInstanceElement)
       const res = createReferenceIndex(allIns, new Set(bookOrRecipeIns))
-      expect(Object.keys(res)).toEqual([
-        'myAdapter.book.instance.rootBook',
-        'myAdapter.book.instance.book',
-        'myAdapter.recipe.instance.recipe123',
-        'myAdapter.recipe.instance.last',
-        'myAdapter.recipe.instance.recipe456',
-      ])
-      expect(Object.values(res).map(n => n.length))
-        .toEqual([4, 3, 6, 2, 1])
+      expect(_.mapValues(res, val => val.length)).toEqual({
+        'myAdapter.book.instance.rootBook': 4,
+        'myAdapter.book.instance.book': 3,
+        'myAdapter.book.instance.no_idFieldsParent': 1,
+        'myAdapter.recipe.instance.recipe123': 6,
+        'myAdapter.recipe.instance.last': 2,
+        'myAdapter.recipe.instance.recipe456': 1,
+      })
     })
     it('should not have different results on the second fetch', async () => {
       elements = generateElements()

--- a/packages/workato-adapter/test/filters/referenced_id_fields.test.ts
+++ b/packages/workato-adapter/test/filters/referenced_id_fields.test.ts
@@ -200,9 +200,9 @@ describe('referenced id fields filter', () => {
     const instances = elements.filter(isInstanceElement)
     expect(instances.map(e => e.elemID.getFullName()).sort()).toEqual([
       'workato.folder.instance.Root',
-      'workato.folder.instance.folder11_55',
-      'workato.folder.instance.folder22_11',
-      'workato.folder.instance.folder33_55',
+      'workato.folder.instance.folder11',
+      'workato.folder.instance.folder22',
+      'workato.folder.instance.folder33',
       'workato.recipe.instance.recipe123',
       'workato.recipe__code.instance.recipe123_',
     ])

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -1465,6 +1465,7 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
       idFields: ['&locale_id'],
       fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
       fieldTypeOverrides: [{ fieldName: 'id', fieldType: 'number' }],
+      extendsParentId: true,
     },
     deployRequests: {
       add: {


### PR DESCRIPTION
Until now we assumed that if a field configured as an id field does not exist in an element, it is a bug and we should not attempt to generate the id based on the configuration at all. 
That behavior was not ideal - and we now have cases where we want to use id fields as differentiators even if they only exist in some elements (for example, in Zendesk views we may want to rely on restrictions even though they do not always exist).

---

The PR includes some fixes in specific adapters, and is not supposed to cause different ids to be generated in any of the existing element types (even when ids are regenerated) - so no upgrade is needed.

Still need to add some tests

---
_Release Notes_: 
None (not user facing)

---
_User Notifications_: 
None