### PR TITLE
SAAS-6749 support quick fetch when not selecting fetch target

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -62,7 +62,7 @@ import customRecordsFilter from './filters/custom_records'
 import currencyUndeployableFieldsFilter from './filters/currency_omit_fields'
 import additionalChanges from './filters/additional_changes'
 import { Filter, FilterCreator } from './filter'
-import { getConfigFromConfigChanges, NetsuiteConfig, DEFAULT_DEPLOY_REFERENCED_ELEMENTS, DEFAULT_WARN_STALE_DATA, DEFAULT_USE_CHANGES_DETECTION, DEFAULT_VALIDATE } from './config'
+import { getConfigFromConfigChanges, NetsuiteConfig, DEFAULT_DEPLOY_REFERENCED_ELEMENTS, DEFAULT_WARN_STALE_DATA, DEFAULT_VALIDATE } from './config'
 import { andQuery, buildNetsuiteQuery, NetsuiteQuery, NetsuiteQueryParameters, notQuery, QueryParams, convertToQueryParams, getFixedTargetFetch } from './query'
 import { getLastServerTime, getOrCreateServerTimeElements, getLastServiceIdToFetchTime } from './server_time'
 import { getChangedObjects } from './changes_detector/changes_detector'
@@ -120,7 +120,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
   private readonly lockedElements?: QueryParams
   private readonly fetchTarget?: NetsuiteQueryParameters
   private readonly skipList?: NetsuiteQueryParameters // old version
-  private readonly useChangesDetection: boolean // TODO remove this from config SALTO-3676
+  private readonly useChangesDetection: boolean | undefined // TODO remove this from config SALTO-3676
   private elementsSourceIndex: LazyElementsSourceIndexes
   private createFiltersRunner: (params: {
     isPartial?: boolean
@@ -195,7 +195,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
     this.lockedElements = config.fetch?.lockedElementsToExclude
     this.fetchTarget = getFixedTargetFetch(config.fetchTarget)
     this.skipList = config.skipList // old version
-    this.useChangesDetection = config.useChangesDetection ?? DEFAULT_USE_CHANGES_DETECTION
+    this.useChangesDetection = config.useChangesDetection
     this.deployReferencedElements = config.deploy?.deployReferencedElements
      ?? config.deployReferencedElements
     this.warnStaleData = config.deploy?.warnOnStaleWorkspaceData
@@ -237,7 +237,6 @@ export default class NetsuiteAdapter implements AdapterOperations {
     } = await this.runSuiteAppOperations(
       fetchQuery,
       useChangesDetection,
-      isPartial,
     )
     const updatedFetchQuery = changedObjectsQuery !== undefined
       ? andQuery(changedObjectsQuery, fetchQuery)
@@ -339,15 +338,27 @@ export default class NetsuiteAdapter implements AdapterOperations {
     }
   }
 
+  private shouldFetchWithChangesDetection(shouldFetchWithChangesDetectionParams : {
+    withChangesDetection: boolean
+    hasFetchTarget: boolean
+    isFirstFetch: boolean
+  }) : boolean {
+    return !shouldFetchWithChangesDetectionParams.isFirstFetch && (
+      this.useChangesDetection === true
+      || shouldFetchWithChangesDetectionParams.withChangesDetection
+      // by default when having fetch target we prefer to fetch with change detection (unless explicitly disabled)
+      || (shouldFetchWithChangesDetectionParams.hasFetchTarget && this.useChangesDetection !== false))
+  }
+
   /**
    * Fetch configuration elements: objects, types and instances for the given Netsuite account.
    * Account credentials were given in the constructor.
    */
 
   public async fetch({ progressReporter, withChangesDetection = false }: FetchOptions): Promise<FetchResult> {
-    const isFirstFetch = async () : Promise<boolean> =>
-      !(await awu(await this.elementsSource.list()).find(e => !e.isConfig()))
-    if (this.fetchTarget !== undefined && await isFirstFetch()) {
+    const isFirstFetch = !(await awu(await this.elementsSource.list()).find(e => !e.isConfig()))
+    const hasFetchTarget = this.fetchTarget !== undefined
+    if (hasFetchTarget && isFirstFetch) {
       throw new Error('Can\'t define fetchTarget for the first fetch. Remove fetchTarget from adapter config file')
     }
 
@@ -366,7 +377,10 @@ export default class NetsuiteAdapter implements AdapterOperations {
       notQuery(deprecatedSkipList),
     ].filter(values.isDefined).reduce(andQuery)
 
-    const isPartial = (withChangesDetection || this.fetchTarget !== undefined) && !(await isFirstFetch())
+    const fetchWithChangesDetection = this.shouldFetchWithChangesDetection({
+      withChangesDetection, hasFetchTarget, isFirstFetch,
+    })
+    const isPartial = fetchWithChangesDetection || hasFetchTarget
 
     const {
       failedToFetchAllAtOnce,
@@ -376,7 +390,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
     } = await this.fetchByQuery(
       fetchQuery,
       progressReporter,
-      (this.useChangesDetection || withChangesDetection),
+      fetchWithChangesDetection,
       isPartial,
     )
 
@@ -393,7 +407,6 @@ export default class NetsuiteAdapter implements AdapterOperations {
   private async runSuiteAppOperations(
     fetchQuery: NetsuiteQuery,
     useChangesDetection: boolean,
-    isPartial: boolean,
   ):
     Promise<{
       changedObjectsQuery?: NetsuiteQuery
@@ -403,12 +416,6 @@ export default class NetsuiteAdapter implements AdapterOperations {
     if (sysInfo === undefined) {
       log.debug('Did not get sysInfo, skipping SuiteApp operations')
       return {}
-    }
-
-    if (!isPartial) {
-      return {
-        serverTime: sysInfo.time,
-      }
     }
 
     if (!useChangesDetection) {

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -36,7 +36,6 @@ export const DEFAULT_MAX_ITEMS_IN_IMPORT_OBJECTS_REQUEST = 40
 export const DEFAULT_DEPLOY_REFERENCED_ELEMENTS = false
 export const DEFAULT_WARN_STALE_DATA = false
 export const DEFAULT_VALIDATE = true
-export const DEFAULT_USE_CHANGES_DETECTION = true
 
 export type DeployParams = {
   warnOnStaleWorkspaceData?: boolean

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -1125,6 +1125,22 @@ describe('Adapter', () => {
         await adapter.fetch(mockFetchOpts)
         expect(getChangedObjectsMock).not.toHaveBeenCalled()
       })
+
+      it('should call getChangedObjects even if fetchTarget is not defined', async () => {
+        adapter = new NetsuiteAdapter({
+          client: new NetsuiteClient(client, suiteAppClient),
+          elementsSource,
+          filtersCreators: [firstDummyFilter, secondDummyFilter],
+          config: {
+            ...config,
+            useChangesDetection: true,
+          },
+          getElemIdFunc: mockGetElemIdFunc,
+        })
+
+        await adapter.fetch(mockFetchOpts)
+        expect(getChangedObjectsMock).toHaveBeenCalled()
+      })
     })
   })
 })


### PR DESCRIPTION
support quick fetch when not selecting fetch target. remove the default value and use only explicit settings

---

_Additional context for reviewer_
https://github.com/salto-io/salto/pull/4035
https://github.com/salto-io/salto/pull/4022

---
_Release Notes_: 
Support quick fetch when not selecting fetch target

---
_User Notifications_: 
_None_
