### PR TITLE
SALTO-3783 Avoid logging unneeded data in client

### DIFF
--- a/packages/adapter-components/src/client/http_client.ts
+++ b/packages/adapter-components/src/client/http_client.ts
@@ -141,7 +141,7 @@ export abstract class AdapterHTTPClient<
   protected extractHeaders(headers: Record<string, string> | undefined): Record<string, string> | undefined {
     return headers !== undefined
       // include headers related to rate limits
-      ? _.pickBy(headers, (_val, key) => key.toLowerCase().includes('rate-'))
+      ? _.pickBy(headers, (_val, key) => key.toLowerCase().startsWith('rate-') || key.toLowerCase().startsWith('x-rate-'))
       : undefined
   }
 

--- a/packages/adapter-components/src/client/http_client.ts
+++ b/packages/adapter-components/src/client/http_client.ts
@@ -138,8 +138,11 @@ export abstract class AdapterHTTPClient<
    * Extract headers needed by the adapter
    */
   // eslint-disable-next-line class-methods-use-this
-  protected extractHeaders(_headers: Record<string, string> | undefined): Record<string, string> | undefined {
-    return undefined
+  protected extractHeaders(headers: Record<string, string> | undefined): Record<string, string> | undefined {
+    return headers !== undefined
+      // include headers related to rate limits
+      ? _.pickBy(headers, (_val, key) => key.toLowerCase().includes('rate-'))
+      : undefined
   }
 
   /**

--- a/packages/adapter-components/src/client/http_client.ts
+++ b/packages/adapter-components/src/client/http_client.ts
@@ -135,6 +135,14 @@ export abstract class AdapterHTTPClient<
   }
 
   /**
+   * Extract headers needed by the adapter
+   */
+  // eslint-disable-next-line class-methods-use-this
+  protected extractHeaders(_headers: Record<string, string> | undefined): Record<string, string> | undefined {
+    return undefined
+  }
+
+  /**
    * Get a single response
    */
   @throttle<TRateLimitConfig>({ bucketName: 'get', keys: ['url', 'queryParams'] })
@@ -207,14 +215,15 @@ export abstract class AdapterHTTPClient<
           requestConfig,
         )
       log.debug('Received response for %s on %s (%s) with status %d', method.toUpperCase(), url, safeJsonStringify({ url, queryParams }), res.status)
+      const responseHeaders = this.extractHeaders(res.headers)
       log.trace('Full HTTP response for %s on %s: %s', method.toUpperCase(), url, safeJsonStringify({
         url,
         queryParams,
-        response: this.clearValuesFromResponseData(res.data, url),
-        headers: res.headers,
+        response: Buffer.isBuffer(res.data) ? `<omitted buffer of length ${res.data.length}>` : this.clearValuesFromResponseData(res.data, url),
+        headers: responseHeaders,
         method: method.toUpperCase(),
       }))
-      const { data, status, headers: responseHeaders } = res
+      const { data, status } = res
       return {
         data,
         status,

--- a/packages/adapter-components/test/client/http_client.test.ts
+++ b/packages/adapter-components/test/client/http_client.test.ts
@@ -65,25 +65,23 @@ describe('client_http_client', () => {
       const clearValuesFromResponseDataFunc = jest.spyOn(MyCustomClient.prototype as any, 'clearValuesFromResponseData')
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const extractHeadersFunc = jest.spyOn(MyCustomClient.prototype as any, 'extractHeaders')
-        .mockImplementationOnce(() => ({ a: 'b' }))
-        .mockImplementationOnce(x => x)
       expect(mockCreateConnection).toHaveBeenCalledTimes(1)
 
       mockAxiosAdapter.onGet('/users/me').reply(200, {
         accountId: 'ACCOUNT_ID',
       })
-      mockAxiosAdapter.onGet('/ep').replyOnce(200, { a: 'b' }, { h: '123' })
+      mockAxiosAdapter.onGet('/ep').replyOnce(200, { a: 'b' }, { h: '123', 'X-Rate-Limit': '456' })
       mockAxiosAdapter.onGet('/ep2', { a: 'AAA' }).replyOnce(200, { c: 'd' }, { hh: 'header' })
 
       const getRes = await client.getSinglePage({ url: '/ep' })
       const getRes2 = await client.getSinglePage({ url: '/ep2', queryParams: { a: 'AAA' } })
-      expect(getRes).toEqual({ data: { a: 'b' }, status: 200, headers: { a: 'b' } })
-      expect(getRes2).toEqual({ data: { c: 'd' }, status: 200, headers: { hh: 'header' } })
+      expect(getRes).toEqual({ data: { a: 'b' }, status: 200, headers: { 'X-Rate-Limit': '456' } })
+      expect(getRes2).toEqual({ data: { c: 'd' }, status: 200, headers: {} })
       expect(clearValuesFromResponseDataFunc).toHaveBeenCalledTimes(2)
       expect(clearValuesFromResponseDataFunc).toHaveBeenNthCalledWith(1, { a: 'b' }, '/ep')
       expect(clearValuesFromResponseDataFunc).toHaveBeenNthCalledWith(2, { c: 'd' }, '/ep2')
       expect(extractHeadersFunc).toHaveBeenCalledTimes(2)
-      expect(extractHeadersFunc).toHaveBeenNthCalledWith(1, { h: '123' })
+      expect(extractHeadersFunc).toHaveBeenNthCalledWith(1, { h: '123', 'X-Rate-Limit': '456' })
       expect(extractHeadersFunc).toHaveBeenNthCalledWith(2, { hh: 'header' })
     })
 

--- a/packages/adapter-components/test/client/http_client.test.ts
+++ b/packages/adapter-components/test/client/http_client.test.ts
@@ -63,6 +63,10 @@ describe('client_http_client', () => {
       const client = new MyCustomClient({ credentials: { username: 'user', password: 'password' } })
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const clearValuesFromResponseDataFunc = jest.spyOn(MyCustomClient.prototype as any, 'clearValuesFromResponseData')
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const extractHeadersFunc = jest.spyOn(MyCustomClient.prototype as any, 'extractHeaders')
+        .mockImplementationOnce(() => ({ a: 'b' }))
+        .mockImplementationOnce(x => x)
       expect(mockCreateConnection).toHaveBeenCalledTimes(1)
 
       mockAxiosAdapter.onGet('/users/me').reply(200, {
@@ -73,11 +77,14 @@ describe('client_http_client', () => {
 
       const getRes = await client.getSinglePage({ url: '/ep' })
       const getRes2 = await client.getSinglePage({ url: '/ep2', queryParams: { a: 'AAA' } })
-      expect(getRes).toEqual({ data: { a: 'b' }, status: 200, headers: { h: '123' } })
+      expect(getRes).toEqual({ data: { a: 'b' }, status: 200, headers: { a: 'b' } })
       expect(getRes2).toEqual({ data: { c: 'd' }, status: 200, headers: { hh: 'header' } })
       expect(clearValuesFromResponseDataFunc).toHaveBeenCalledTimes(2)
       expect(clearValuesFromResponseDataFunc).toHaveBeenNthCalledWith(1, { a: 'b' }, '/ep')
       expect(clearValuesFromResponseDataFunc).toHaveBeenNthCalledWith(2, { c: 'd' }, '/ep2')
+      expect(extractHeadersFunc).toHaveBeenCalledTimes(2)
+      expect(extractHeadersFunc).toHaveBeenNthCalledWith(1, { h: '123' })
+      expect(extractHeadersFunc).toHaveBeenNthCalledWith(2, { hh: 'header' })
     })
 
     it('should throw Unauthorized on login 401', async () => {

--- a/packages/okta-adapter/src/client/client.ts
+++ b/packages/okta-adapter/src/client/client.ts
@@ -19,6 +19,7 @@ import { Values } from '@salto-io/adapter-api'
 import { createConnection } from './connection'
 import { OKTA } from '../constants'
 import { Credentials } from '../auth'
+import { LINK_HEADER_NAME } from './pagination'
 
 const {
   RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS, DEFAULT_RETRY_OPTS,
@@ -79,5 +80,13 @@ export default class OktaClient extends clientUtils.AdapterHTTPClient<
         : undefined
     ))
     return res
+  }
+
+  /**
+   * Extract the pagination header
+   */
+  // eslint-disable-next-line class-methods-use-this
+  protected extractHeaders(headers: Record<string, string> | undefined): Record<string, string> | undefined {
+    return headers !== undefined ? _.pick(headers, LINK_HEADER_NAME) : undefined
   }
 }

--- a/packages/okta-adapter/src/client/client.ts
+++ b/packages/okta-adapter/src/client/client.ts
@@ -87,6 +87,11 @@ export default class OktaClient extends clientUtils.AdapterHTTPClient<
    */
   // eslint-disable-next-line class-methods-use-this
   protected extractHeaders(headers: Record<string, string> | undefined): Record<string, string> | undefined {
-    return headers !== undefined ? _.pick(headers, LINK_HEADER_NAME) : undefined
+    return headers !== undefined
+      ? {
+        ...super.extractHeaders(headers),
+        ..._.pickBy(headers, (_val, key) => key.toLowerCase() === LINK_HEADER_NAME),
+      }
+      : undefined
   }
 }

--- a/packages/okta-adapter/src/client/pagination.ts
+++ b/packages/okta-adapter/src/client/pagination.ts
@@ -19,7 +19,7 @@ import * as parse from 'parse-link-header'
 import { logger } from '@salto-io/logging'
 
 const log = logger(module)
-const LINK_HEADER_NAME = 'link'
+export const LINK_HEADER_NAME = 'link'
 
 const getNextPage = (link: string): URL | undefined => {
   const parsedLinkHeader = parse.default(link)

--- a/packages/okta-adapter/test/client/client.test.ts
+++ b/packages/okta-adapter/test/client/client.test.ts
@@ -76,13 +76,13 @@ describe('client', () => {
         .onGet('/api/v1/org').replyOnce(200, { id: 1 })
         .onGet('/api/v1/idps').replyOnce(200, idpsResponse, { h: '123' })
         .onGet('/api/v1/authenticators')
-        .replyOnce(200, autheticatorsRes, { h: '123', link: 'aaa' })
+        .replyOnce(200, autheticatorsRes, { h: '123', link: 'aaa', 'x-rate-limit': '456', 'x-rate-limit-remaining': '456' })
     })
     it('should return response data with no secrets and only the relevant headers', async () => {
       const firstRes = await client.getSinglePage({ url: '/api/v1/idps' })
       expect(firstRes).toEqual({ status: 200, data: idpsResponse, headers: { } })
       const secondRes = await client.getSinglePage({ url: '/api/v1/authenticators' })
-      expect(secondRes).toEqual({ status: 200, data: autheticatorsRes, headers: { link: 'aaa' } })
+      expect(secondRes).toEqual({ status: 200, data: autheticatorsRes, headers: { link: 'aaa', 'x-rate-limit': '456', 'x-rate-limit-remaining': '456' } })
       expect(clearValuesFromResponseDataFunc).toHaveBeenCalledTimes(2)
       expect(clearValuesFromResponseDataFunc).toHaveNthReturnedWith(1,
         {
@@ -100,7 +100,7 @@ describe('client', () => {
         ])
       expect(extractHeadersFunc).toHaveBeenCalledTimes(2)
       expect(extractHeadersFunc).toHaveNthReturnedWith(1, {})
-      expect(extractHeadersFunc).toHaveNthReturnedWith(2, { link: 'aaa' })
+      expect(extractHeadersFunc).toHaveNthReturnedWith(2, { link: 'aaa', 'x-rate-limit': '456', 'x-rate-limit-remaining': '456' })
     })
   })
 })


### PR DESCRIPTION
* Avoid logging headers except where needed (currently only Okta)
* Avoid logging large buffer data

---
_Release Notes_: 
None

---
_User Notifications_: 
None