### PR TITLE
SALTO-3787 increase default concurrency

### DIFF
--- a/packages/zendesk-adapter/src/client/client.ts
+++ b/packages/zendesk-adapter/src/client/client.ts
@@ -41,8 +41,8 @@ type LogsFilterConfig = {
 const DEFAULT_MAX_CONCURRENT_API_REQUESTS: Required<clientUtils.ClientRateLimitConfig> = {
   total: RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,
   // this is arbitrary, could not find official limits
-  get: 20,
-  deploy: 20,
+  get: 100,
+  deploy: 100,
 }
 
 const DEFAULT_PAGE_SIZE: Required<clientUtils.ClientPageSizeConfig> = {


### PR DESCRIPTION
Optimize the default max concurrency for Guide fetches

---
_Release Notes_: 

_Zendesk adapter_
* Increase the default max concurrent requests

---
_User Notifications_: 
None