### PR TITLE
SALTO-3788/top level element path index

### DIFF
--- a/packages/cli/test/commands/deploy.test.ts
+++ b/packages/cli/test/commands/deploy.test.ts
@@ -335,6 +335,7 @@ describe('deploy command', () => {
       return state.buildInMemState(async () => ({
         elements: createInMemoryElementSource(),
         pathIndex: new InMemoryRemoteMap<pathIndex.Path[]>(),
+        topLevelPathIndex: new InMemoryRemoteMap<pathIndex.Path[]>(),
         accountsUpdateDate: dateMap ?? new InMemoryRemoteMap(),
         saltoMetadata,
         staticFilesSource: mocks.mockStateStaticFilesSource(),

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -293,6 +293,7 @@ export const mockWorkspace = ({
   const mockStateData = async (): Promise<wsState.StateData> => ({
     elements: createInMemoryElementSource(getElements()),
     pathIndex: new InMemoryRemoteMap<pathIndex.Path[]>(),
+    topLevelPathIndex: new InMemoryRemoteMap<pathIndex.Path[]>(),
     accountsUpdateDate: new InMemoryRemoteMap(),
     saltoMetadata: new InMemoryRemoteMap([
       { key: 'version', value: currentVersion },

--- a/packages/core/test/common/state.ts
+++ b/packages/core/test/common/state.ts
@@ -51,5 +51,6 @@ export const mockState = (
     ),
     saltoMetadata: new remoteMap.InMemoryRemoteMap<string, 'version'>([{ key: 'version', value: '0.0.1' }]),
     staticFilesSource: mockStaticFilesSource(),
+    topLevelPathIndex: new remoteMap.InMemoryRemoteMap<pathIndex.Path[]>(index),
   }))
 )

--- a/packages/lang-server/test/workspace.ts
+++ b/packages/lang-server/test/workspace.ts
@@ -194,6 +194,7 @@ Promise<Workspace> => {
             await awu(await commonNaclFilesSource.getAll()).toArray()
           ),
           pathIndex: new InMemoryRemoteMap<pathIndex.Path[]>(),
+          topLevelPathIndex: new InMemoryRemoteMap<pathIndex.Path[]>(),
           accountsUpdateDate: new InMemoryRemoteMap(),
           saltoVersion: '0.0.1',
           saltoMetadata: new InMemoryRemoteMap(),
@@ -214,6 +215,7 @@ Promise<Workspace> => {
         state: state.buildInMemState(async () => ({
           elements: createInMemoryElementSource([]),
           pathIndex: new InMemoryRemoteMap<pathIndex.Path[]>(),
+          topLevelPathIndex: new InMemoryRemoteMap<pathIndex.Path[]>(),
           accountsUpdateDate: new InMemoryRemoteMap(),
           saltoVersion: '0.0.1',
           saltoMetadata: new InMemoryRemoteMap(),

--- a/packages/workspace/src/workspace/path_index.ts
+++ b/packages/workspace/src/workspace/path_index.ts
@@ -181,10 +181,8 @@ export const overridePathIndex = async (
 const getTopLevelPathHints = (unmergedElements: Element[]): PathHint[] => {
   const topLevelElementsWithPath = unmergedElements
     .filter(e => e.path !== undefined)
-    .filter(e => e.elemID.isTopLevel())
   const elementsByID = _.groupBy(topLevelElementsWithPath, e => e.elemID.getFullName())
   return Object.entries(elementsByID)
-    .filter(([_key, value]) => value.length > 0)
     .map(([key, value]) => ({
       key,
       value: value.map(e => e.path as Path),

--- a/packages/workspace/src/workspace/path_index.ts
+++ b/packages/workspace/src/workspace/path_index.ts
@@ -182,8 +182,16 @@ export const overrideTopLevelPathIndex = async (
   current: PathIndex,
   unmergedElements: Element[],
 ): Promise<void> => {
-  const entries = getElementsPathHints(unmergedElements)
-    .filter(e => ElemID.fromFullName(e.key).isTopLevel())
+  const topLevelElementsWithPath = unmergedElements
+    .filter(e => e.path !== undefined)
+    .filter(e => e.elemID.isTopLevel())
+  const elementsByID = _.groupBy(topLevelElementsWithPath, e => e.elemID.getFullName())
+  const entries = Object.entries(elementsByID)
+    .filter(([_key, value]) => value.length > 0)
+    .map(([key, value]) => ({
+      key,
+      value: value.map(e => e.path as Path),
+    }))
   await current.clear()
   await current.setAll(entries)
 }

--- a/packages/workspace/src/workspace/path_index.ts
+++ b/packages/workspace/src/workspace/path_index.ts
@@ -198,27 +198,34 @@ export const overrideTopLevelPathIndex = async (
   await current.setAll(entries)
 }
 
+type UpdateIndexParms = {
+  index: PathIndex
+  elements: Element[]
+  accountsToMaintain: string[]
+  isTopLevel: boolean
+}
+
 export const updatePathIndex = async (
-  current: PathIndex,
-  unmergedElements: Element[],
-  accountsToMaintain: string[],
-  isTopLevel: boolean,
+  { index,
+    elements,
+    accountsToMaintain,
+    isTopLevel }: UpdateIndexParms
 ): Promise<void> => {
   if (accountsToMaintain.length === 0) {
     if (isTopLevel) {
-      await overrideTopLevelPathIndex(current, unmergedElements)
+      await overrideTopLevelPathIndex(index, elements)
       return
     }
-    await overridePathIndex(current, unmergedElements)
+    await overridePathIndex(index, elements)
     return
   }
-  const entries = isTopLevel ? getTopLevelPathHints(unmergedElements) : getElementsPathHints(unmergedElements)
-  const oldPathHintsToMaintain = await awu(current.entries())
+  const entries = isTopLevel ? getTopLevelPathHints(elements) : getElementsPathHints(elements)
+  const oldPathHintsToMaintain = await awu(index.entries())
     .filter(e => accountsToMaintain.includes(ElemID.fromFullName(e.key).adapter))
     .concat(entries)
     .toArray()
-  await current.clear()
-  await current.setAll(awu(oldPathHintsToMaintain))
+  await index.clear()
+  await index.setAll(awu(oldPathHintsToMaintain))
 }
 
 export const loadPathIndex = (parsedEntries: [string, Path[]][]): RemoteMapEntry<Path[], string>[] =>

--- a/packages/workspace/src/workspace/path_index.ts
+++ b/packages/workspace/src/workspace/path_index.ts
@@ -178,7 +178,7 @@ export const overridePathIndex = async (
   await current.setAll(entries)
 }
 
-const getTopLevelPathHints = (unmergedElements: Element[]): PathHint[] => {
+export const getTopLevelPathHints = (unmergedElements: Element[]): PathHint[] => {
   const topLevelElementsWithPath = unmergedElements
     .filter(e => e.path !== undefined)
   const elementsByID = _.groupBy(topLevelElementsWithPath, e => e.elemID.getFullName())

--- a/packages/workspace/src/workspace/path_index.ts
+++ b/packages/workspace/src/workspace/path_index.ts
@@ -178,6 +178,16 @@ export const overridePathIndex = async (
   await current.setAll(entries)
 }
 
+export const overrideTopLevelPathIndex = async (
+  current: PathIndex,
+  unmergedElements: Element[],
+): Promise<void> => {
+  const entries = getElementsPathHints(unmergedElements)
+    .filter(e => ElemID.fromFullName(e.key).isTopLevel())
+  await current.clear()
+  await current.setAll(entries)
+}
+
 export const updatePathIndex = async (
   current: PathIndex,
   unmergedElements: Element[],

--- a/packages/workspace/src/workspace/state/in_mem.ts
+++ b/packages/workspace/src/workspace/state/in_mem.ts
@@ -22,7 +22,6 @@ import {
   overridePathIndex,
   PathIndex,
   overrideTopLevelPathIndex,
-  updateTopLevelPathIndex,
 } from '../path_index'
 import { RemoteMap } from '../remote_map'
 import { State, StateData } from './state'
@@ -120,10 +119,10 @@ export const buildInMemState = (
     ): Promise<void> => {
       const currentStateData = await stateData()
       await updatePathIndex(
-        currentStateData.pathIndex, unmergedElements, servicesNotToChange
+        currentStateData.pathIndex, unmergedElements, servicesNotToChange, false
       )
-      await updateTopLevelPathIndex(
-        currentStateData.topLevelPathIndex, unmergedElements, servicesNotToChange
+      await updatePathIndex(
+        currentStateData.topLevelPathIndex, unmergedElements, servicesNotToChange, true
       )
     },
     getPathIndex: async (): Promise<PathIndex> =>

--- a/packages/workspace/src/workspace/state/in_mem.ts
+++ b/packages/workspace/src/workspace/state/in_mem.ts
@@ -106,6 +106,7 @@ export const buildInMemState = (
     overridePathIndex: async (unmergedElements: Element[]): Promise<void> => {
       const currentStateData = await stateData()
       await overridePathIndex(currentStateData.pathIndex, unmergedElements)
+      await overridePathIndex(currentStateData.topLevelPathIndex, unmergedElements)
     },
     updatePathIndex: async (
       unmergedElements: Element[],
@@ -115,13 +116,19 @@ export const buildInMemState = (
       await updatePathIndex(
         currentStateData.pathIndex, unmergedElements, servicesNotToChange
       )
+      await updatePathIndex(
+        currentStateData.topLevelPathIndex, unmergedElements, servicesNotToChange
+      )
     },
     getPathIndex: async (): Promise<PathIndex> =>
       (await stateData()).pathIndex,
+    getTopLevelPathIndex: async (): Promise<PathIndex> =>
+      (await stateData()).topLevelPathIndex,
     clear: async () => {
       const currentStateData = await stateData()
       await currentStateData.elements.clear()
       await currentStateData.pathIndex.clear()
+      await currentStateData.topLevelPathIndex.clear()
       await getUpdateDate(currentStateData).clear()
       await currentStateData.saltoMetadata.clear()
       await currentStateData.staticFilesSource.clear()
@@ -133,6 +140,7 @@ export const buildInMemState = (
       const currentStateData = await stateData()
       await currentStateData.elements.flush()
       await currentStateData.pathIndex.flush()
+      await currentStateData.topLevelPathIndex.flush()
       await getUpdateDate(currentStateData).flush()
       await currentStateData.saltoMetadata.flush()
       await currentStateData.staticFilesSource.flush()

--- a/packages/workspace/src/workspace/state/in_mem.ts
+++ b/packages/workspace/src/workspace/state/in_mem.ts
@@ -106,7 +106,7 @@ export const buildInMemState = (
     overridePathIndex: async (unmergedElements: Element[]): Promise<void> => {
       const currentStateData = await stateData()
       await overridePathIndex(currentStateData.pathIndex, unmergedElements)
-      await overridePathIndex(currentStateData.topLevelPathIndex, unmergedElements)
+      await overrideTopLevelPathIndex(currentStateData.topLevelPathIndex, unmergedElements)
     },
     updatePathIndex: async (
       unmergedElements: Element[],

--- a/packages/workspace/src/workspace/state/in_mem.ts
+++ b/packages/workspace/src/workspace/state/in_mem.ts
@@ -17,7 +17,13 @@ import { Element, ElemID } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import { getNestedStaticFiles } from '../nacl_files/nacl_file_update'
-import { updatePathIndex, overridePathIndex, PathIndex, overrideTopLevelPathIndex } from '../path_index'
+import {
+  updatePathIndex,
+  overridePathIndex,
+  PathIndex,
+  overrideTopLevelPathIndex,
+  updateTopLevelPathIndex,
+} from '../path_index'
 import { RemoteMap } from '../remote_map'
 import { State, StateData } from './state'
 
@@ -116,8 +122,8 @@ export const buildInMemState = (
       await updatePathIndex(
         currentStateData.pathIndex, unmergedElements, servicesNotToChange
       )
-      await overrideTopLevelPathIndex(
-        currentStateData.topLevelPathIndex, unmergedElements
+      await updateTopLevelPathIndex(
+        currentStateData.topLevelPathIndex, unmergedElements, servicesNotToChange
       )
     },
     getPathIndex: async (): Promise<PathIndex> =>

--- a/packages/workspace/src/workspace/state/in_mem.ts
+++ b/packages/workspace/src/workspace/state/in_mem.ts
@@ -119,10 +119,20 @@ export const buildInMemState = (
     ): Promise<void> => {
       const currentStateData = await stateData()
       await updatePathIndex(
-        currentStateData.pathIndex, unmergedElements, servicesNotToChange, false
+        {
+          index: currentStateData.pathIndex,
+          elements: unmergedElements,
+          accountsToMaintain: servicesNotToChange,
+          isTopLevel: false,
+        }
       )
       await updatePathIndex(
-        currentStateData.topLevelPathIndex, unmergedElements, servicesNotToChange, true
+        {
+          index: currentStateData.topLevelPathIndex,
+          elements: unmergedElements,
+          accountsToMaintain: servicesNotToChange,
+          isTopLevel: true,
+        }
       )
     },
     getPathIndex: async (): Promise<PathIndex> =>

--- a/packages/workspace/src/workspace/state/in_mem.ts
+++ b/packages/workspace/src/workspace/state/in_mem.ts
@@ -116,8 +116,8 @@ export const buildInMemState = (
       await updatePathIndex(
         currentStateData.pathIndex, unmergedElements, servicesNotToChange
       )
-      await updatePathIndex(
-        currentStateData.topLevelPathIndex, unmergedElements, servicesNotToChange
+      await overridePathIndex(
+        currentStateData.topLevelPathIndex, unmergedElements
       )
     },
     getPathIndex: async (): Promise<PathIndex> =>

--- a/packages/workspace/src/workspace/state/in_mem.ts
+++ b/packages/workspace/src/workspace/state/in_mem.ts
@@ -17,7 +17,7 @@ import { Element, ElemID } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import { getNestedStaticFiles } from '../nacl_files/nacl_file_update'
-import { updatePathIndex, overridePathIndex, PathIndex } from '../path_index'
+import { updatePathIndex, overridePathIndex, PathIndex, overrideTopLevelPathIndex } from '../path_index'
 import { RemoteMap } from '../remote_map'
 import { State, StateData } from './state'
 
@@ -116,7 +116,7 @@ export const buildInMemState = (
       await updatePathIndex(
         currentStateData.pathIndex, unmergedElements, servicesNotToChange
       )
-      await overridePathIndex(
+      await overrideTopLevelPathIndex(
         currentStateData.topLevelPathIndex, unmergedElements
       )
     },

--- a/packages/workspace/src/workspace/state/state.ts
+++ b/packages/workspace/src/workspace/state/state.ts
@@ -61,7 +61,6 @@ export interface State extends ElementsSource {
   existingAccounts(): Promise<string[]>
   overridePathIndex(unmergedElements: Element[]): Promise<void>
   updatePathIndex(unmergedElements: Element[], accountsToMaintain: string[]): Promise<void>
-  updateTopLevelIndex(elements: Element[]): Promise<void>
   getPathIndex(): Promise<PathIndex>
   getTopLevelPathIndex(): Promise<PathIndex>
   getHash(): Promise<string | undefined>

--- a/packages/workspace/src/workspace/state/state.ts
+++ b/packages/workspace/src/workspace/state/state.ts
@@ -32,6 +32,7 @@ type OldStateData = {
   pathIndex: PathIndex
   saltoMetadata: RemoteMap<string, StateMetadataKey>
   staticFilesSource: StateStaticFilesSource
+  topLevelPathIndex: PathIndex
 }
 
 // This distinction is temporary for the transition to multiple services.
@@ -43,6 +44,7 @@ type NewStateData = {
   pathIndex: PathIndex
   saltoMetadata: RemoteMap<string, StateMetadataKey>
   staticFilesSource: StateStaticFilesSource
+  topLevelPathIndex: PathIndex
 }
 
 export type StateData = OldStateData | NewStateData
@@ -59,7 +61,9 @@ export interface State extends ElementsSource {
   existingAccounts(): Promise<string[]>
   overridePathIndex(unmergedElements: Element[]): Promise<void>
   updatePathIndex(unmergedElements: Element[], accountsToMaintain: string[]): Promise<void>
+  updateElementsIndex(elements: Element[]): Promise<void>
   getPathIndex(): Promise<PathIndex>
+  getTopLevelPathIndex(): Promise<PathIndex>
   getHash(): Promise<string | undefined>
   setHash(hash: string): Promise<void>
   calculateHash(): Promise<void>
@@ -96,6 +100,12 @@ Promise<StateData> => ({
   })),
   pathIndex: await remoteMapCreator<Path[]>({
     namespace: createStateNamespace(envName, 'path_index'),
+    serialize: async paths => safeJsonStringify(paths),
+    deserialize: async data => JSON.parse(data),
+    persistent,
+  }),
+  topLevelPathIndex: await remoteMapCreator<Path[]>({
+    namespace: createStateNamespace(envName, 'top_level_path_index'),
     serialize: async paths => safeJsonStringify(paths),
     deserialize: async data => JSON.parse(data),
     persistent,

--- a/packages/workspace/src/workspace/state/state.ts
+++ b/packages/workspace/src/workspace/state/state.ts
@@ -61,7 +61,7 @@ export interface State extends ElementsSource {
   existingAccounts(): Promise<string[]>
   overridePathIndex(unmergedElements: Element[]): Promise<void>
   updatePathIndex(unmergedElements: Element[], accountsToMaintain: string[]): Promise<void>
-  updateElementsIndex(elements: Element[]): Promise<void>
+  updateTopLevelIndex(elements: Element[]): Promise<void>
   getPathIndex(): Promise<PathIndex>
   getTopLevelPathIndex(): Promise<PathIndex>
   getHash(): Promise<string | undefined>

--- a/packages/workspace/test/common/state.ts
+++ b/packages/workspace/test/common/state.ts
@@ -26,6 +26,7 @@ export const mockState = (
   buildInMemState(async () => ({
     elements: createInMemoryElementSource(elements),
     pathIndex: new InMemoryRemoteMap<Path[]>(),
+    topLevelPathIndex: new InMemoryRemoteMap<Path[]>(),
     accountsUpdateDate: new InMemoryRemoteMap(),
     saltoVersion: '0.0.1',
     saltoMetadata: new InMemoryRemoteMap(),

--- a/packages/workspace/test/workspace/path_index.test.ts
+++ b/packages/workspace/test/workspace/path_index.test.ts
@@ -127,9 +127,33 @@ const multiPathInstanceFull = new InstanceElement(
   },
 )
 describe('topLevelPathIndex', () => {
-  let topLevelPathIndex: PathIndex
-  beforeAll(async () => {
-    topLevelPathIndex = new InMemoryRemoteMap<Path[]>()
+  it('get top level path hints should return correct path hints', () => {
+    expect(getTopLevelPathHints(
+      [
+        multiPathAnnoObj,
+        multiPathFieldsObj,
+        multiPathInstanceA,
+        multiPathInstanceB,
+      ]
+    )).toEqual([
+      {
+        key: 'salto.multiPathObj',
+        value: [
+          ['salto', 'obj', 'multi', 'anno'],
+          ['salto', 'obj', 'multi', 'fields'],
+        ],
+      },
+      {
+        key: 'salto.obj.instance.inst',
+        value: [
+          ['salto', 'inst', 'A'],
+          ['salto', 'inst', 'B'],
+        ],
+      },
+    ])
+  })
+  it('should only add new top level elements paths to index', async () => {
+    const topLevelPathIndex = new InMemoryRemoteMap<Path[]>()
     await topLevelPathIndex.setAll(getTopLevelPathHints([singlePathObject]))
     await updatePathIndex({
       index: topLevelPathIndex,
@@ -142,24 +166,16 @@ describe('topLevelPathIndex', () => {
       accountsToMaintain: ['salto'],
       isTopLevel: true,
     })
-  })
-  it('should add new elements with proper paths', async () => {
     expect(await awu(topLevelPathIndex.entries()).toArray()).toEqual(
       [
-        {
-          key: 'salto.multiPathObj',
-          value: [
-            ['salto', 'obj', 'multi', 'anno'],
-            ['salto', 'obj', 'multi', 'fields'],
-          ],
-        },
-        {
-          key: 'salto.obj.instance.inst',
-          value: [
-            ['salto', 'inst', 'A'],
-            ['salto', 'inst', 'B'],
-          ],
-        },
+        ...getTopLevelPathHints(
+          [
+            multiPathAnnoObj,
+            multiPathFieldsObj,
+            multiPathInstanceA,
+            multiPathInstanceB,
+          ]
+        ),
         {
           key: 'salto.singlePathObj',
           value: [

--- a/packages/workspace/test/workspace/path_index.test.ts
+++ b/packages/workspace/test/workspace/path_index.test.ts
@@ -14,9 +14,12 @@
 * limitations under the License.
 */
 import { ObjectType, ElemID, BuiltinTypes, ListType, InstanceElement, TypeReference, createRefToElmWithValue, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
 import { updatePathIndex, getElementsPathHints, PathIndex, getFromPathIndex, Path,
-  overridePathIndex, splitElementByPath } from '../../src/workspace/path_index'
+  overridePathIndex, splitElementByPath, getTopLevelPathHints } from '../../src/workspace/path_index'
 import { InMemoryRemoteMap } from '../../src/workspace/remote_map'
+
+const { awu } = collections.asynciterable
 
 const nestedType = new ObjectType({
   elemID: new ElemID('salto', 'nested'),
@@ -123,6 +126,50 @@ const multiPathInstanceFull = new InstanceElement(
     [CORE_ANNOTATIONS.CHANGED_BY]: 'Me',
   },
 )
+describe('topLevelPathIndex', () => {
+  let topLevelPathIndex: PathIndex
+  beforeAll(async () => {
+    topLevelPathIndex = new InMemoryRemoteMap<Path[]>()
+    await topLevelPathIndex.setAll(getTopLevelPathHints([singlePathObject]))
+    await updatePathIndex({
+      index: topLevelPathIndex,
+      elements: [
+        multiPathAnnoObj,
+        multiPathFieldsObj,
+        multiPathInstanceA,
+        multiPathInstanceB,
+      ],
+      accountsToMaintain: ['salto'],
+      isTopLevel: true,
+    })
+  })
+  it('should add new elements with proper paths', async () => {
+    expect(await awu(topLevelPathIndex.entries()).toArray()).toEqual(
+      [
+        {
+          key: 'salto.multiPathObj',
+          value: [
+            ['salto', 'obj', 'multi', 'anno'],
+            ['salto', 'obj', 'multi', 'fields'],
+          ],
+        },
+        {
+          key: 'salto.obj.instance.inst',
+          value: [
+            ['salto', 'inst', 'A'],
+            ['salto', 'inst', 'B'],
+          ],
+        },
+        {
+          key: 'salto.singlePathObj',
+          value: [
+            ['salto', 'obj', 'simple'],
+          ],
+        },
+      ]
+    )
+  })
+})
 
 describe('updatePathIndex', () => {
   let index: PathIndex

--- a/packages/workspace/test/workspace/path_index.test.ts
+++ b/packages/workspace/test/workspace/path_index.test.ts
@@ -134,7 +134,7 @@ describe('updatePathIndex', () => {
       multiPathFieldsObj,
       multiPathInstanceA,
       multiPathInstanceB,
-    ], ['salto'])
+    ], ['salto'], false)
   })
   it('should add new elements with proper paths', async () => {
     expect(await index.get(multiPathObjID.getFullName()))

--- a/packages/workspace/test/workspace/path_index.test.ts
+++ b/packages/workspace/test/workspace/path_index.test.ts
@@ -129,12 +129,17 @@ describe('updatePathIndex', () => {
   beforeAll(async () => {
     index = new InMemoryRemoteMap<Path[]>()
     await index.setAll(getElementsPathHints([singlePathObject]))
-    await updatePathIndex(index, [
-      multiPathAnnoObj,
-      multiPathFieldsObj,
-      multiPathInstanceA,
-      multiPathInstanceB,
-    ], ['salto'], false)
+    await updatePathIndex({
+      index,
+      elements: [
+        multiPathAnnoObj,
+        multiPathFieldsObj,
+        multiPathInstanceA,
+        multiPathInstanceB,
+      ],
+      accountsToMaintain: ['salto'],
+      isTopLevel: false,
+    })
   })
   it('should add new elements with proper paths', async () => {
     expect(await index.get(multiPathObjID.getFullName()))

--- a/packages/workspace/test/workspace/state.test.ts
+++ b/packages/workspace/test/workspace/state.test.ts
@@ -13,12 +13,12 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ObjectType, ElemID, StaticFile, Field } from '@salto-io/adapter-api'
+import { ObjectType, ElemID, StaticFile } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { mockFunction, MockInterface } from '@salto-io/test-utils'
 import { serialize } from '../../src/serializer'
 import { StateData, buildInMemState, buildStateData } from '../../src/workspace/state'
-import { PathIndex, getElementsPathHints } from '../../src/workspace/path_index'
+import { PathIndex, getElementsPathHints, getTopLevelPathHints } from '../../src/workspace/path_index'
 import { createInMemoryElementSource } from '../../src/workspace/elements_source'
 import { InMemoryRemoteMap, RemoteMapCreator } from '../../src/workspace/remote_map'
 import { StaticFilesSource } from '../../src/workspace/static_files/common'
@@ -41,7 +41,6 @@ describe('state', () => {
   let newElemID: ElemID
   let staticFile: StaticFile
   let newElem: ObjectType
-  let newField: Field
 
   beforeAll(async () => {
     pathIndex = new InMemoryRemoteMap(getElementsPathHints([elem]))
@@ -72,7 +71,6 @@ describe('state', () => {
         staticFile,
       },
     })
-    newField = new Field(newElem, 'field', newElem)
   })
 
   describe('buildStateData', () => {
@@ -164,23 +162,23 @@ describe('state', () => {
       expect(await state.getTopLevelPathIndex()).toEqual(topLevelPathIndex)
     })
     it('overridePathIndex', async () => {
-      const elements = [elem, newElem, newField]
+      const elements = [elem, newElem]
       await state.overridePathIndex(elements)
       const index = await awu((await state.getPathIndex()).entries()).toArray()
-      expect(index).toEqual(getElementsPathHints([newElem, elem, newField]))
+      expect(index).toEqual(getElementsPathHints([newElem, elem]))
       const topLevelIndex = await awu((await state.getTopLevelPathIndex()).entries()).toArray()
-      expect(topLevelIndex).toEqual(getElementsPathHints([newElem, elem]))
+      expect(topLevelIndex).toEqual(getTopLevelPathHints([newElem, elem]))
     })
 
     it('updatePathIndex', async () => {
       const elements = [elem, newElem]
       await state.overridePathIndex(elements)
-      const otherElements = [newElem, newField]
-      await state.updatePathIndex(otherElements, ['salesforce'])
+      const oneElement = [newElem]
+      await state.updatePathIndex(oneElement, ['salesforce'])
       const index = await awu((await state.getPathIndex()).entries()).toArray()
       const topLevelIndex = await awu((await state.getTopLevelPathIndex()).entries()).toArray()
       expect(index).toEqual(getElementsPathHints([newElem, elem]))
-      expect(topLevelIndex).toEqual(getElementsPathHints([newElem, elem]))
+      expect(topLevelIndex).toEqual(getTopLevelPathHints([newElem, elem]))
     })
 
     it('clear should clear all data', async () => {

--- a/packages/workspace/test/workspace/state.test.ts
+++ b/packages/workspace/test/workspace/state.test.ts
@@ -175,10 +175,12 @@ describe('state', () => {
     it('updatePathIndex', async () => {
       const elements = [elem, newElem]
       await state.overridePathIndex(elements)
-      const oneElement = [newElem]
+      const oneElement = [newElem, newField]
       await state.updatePathIndex(oneElement, ['salesforce'])
       const index = await awu((await state.getPathIndex()).entries()).toArray()
+      const topLevelIndex = await awu((await state.getTopLevelPathIndex()).entries()).toArray()
       expect(index).toEqual(getElementsPathHints([newElem, elem]))
+      expect(topLevelIndex).toEqual(getElementsPathHints([newElem]))
     })
 
     it('clear should clear all data', async () => {

--- a/packages/workspace/test/workspace/state.test.ts
+++ b/packages/workspace/test/workspace/state.test.ts
@@ -175,12 +175,12 @@ describe('state', () => {
     it('updatePathIndex', async () => {
       const elements = [elem, newElem]
       await state.overridePathIndex(elements)
-      const oneElement = [newElem, newField]
-      await state.updatePathIndex(oneElement, ['salesforce'])
+      const otherElements = [newElem, newField]
+      await state.updatePathIndex(otherElements, ['salesforce'])
       const index = await awu((await state.getPathIndex()).entries()).toArray()
       const topLevelIndex = await awu((await state.getTopLevelPathIndex()).entries()).toArray()
       expect(index).toEqual(getElementsPathHints([newElem, elem]))
-      expect(topLevelIndex).toEqual(getElementsPathHints([newElem]))
+      expect(topLevelIndex).toEqual(getElementsPathHints([newElem, elem]))
     })
 
     it('clear should clear all data', async () => {

--- a/packages/workspace/test/workspace/state.test.ts
+++ b/packages/workspace/test/workspace/state.test.ts
@@ -51,6 +51,7 @@ describe('state', () => {
       elements: createInMemoryElementSource([elem]),
       accountsUpdateDate: new InMemoryRemoteMap([{ key: adapter, value: updateDate }]),
       pathIndex,
+      topLevelPathIndex: pathIndex,
       saltoMetadata: new InMemoryRemoteMap([{ key: 'version', value: '0.0.1' }]),
       staticFilesSource: stateStaticFilesSource,
     })

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -133,6 +133,7 @@ const createState = (
 ): State => buildInMemState(async () => ({
   elements: createInMemoryElementSource(elements),
   pathIndex: new InMemoryRemoteMap<Path[]>(),
+  topLevelPathIndex: new InMemoryRemoteMap<Path[]>(),
   referenceSources: new InMemoryRemoteMap(),
   accountsUpdateDate: new InMemoryRemoteMap(),
   changedBy: new InMemoryRemoteMap([{ key: 'name@@account', value: ['elemId'] }]),


### PR DESCRIPTION
created a new index which is identical to path index apart from the fact that it only hold paths of elements that are top level.


---

_Additional context for reviewer_
current known issue that is not fixed here is that partial fetch will break the path index and the top level path index, 
it will be fixed in a different pr.

---
_Release Notes_: 
core:
* add a new index that will hold top level elements current paths.

---
_User Notifications_: 

