### PR TITLE
SALTO-3766 improve elementSourceIndexes

### DIFF
--- a/packages/netsuite-adapter/src/change_validators/types.ts
+++ b/packages/netsuite-adapter/src/change_validators/types.ts
@@ -13,11 +13,10 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, ChangeError } from '@salto-io/adapter-api'
-import { LazyElementsSourceIndexes } from '../elements_source_index/types'
+import { Change, ChangeError, ReadOnlyElementsSource } from '@salto-io/adapter-api'
 
 export type NetsuiteChangeValidator = (
     changes: ReadonlyArray<Change>,
     deployReferencedElements?: boolean,
-    elementsSourceIndex?: LazyElementsSourceIndexes,
+    elementsSource?: ReadOnlyElementsSource,
   ) => Promise<ReadonlyArray<ChangeError>>

--- a/packages/netsuite-adapter/src/elements_source_index/types.ts
+++ b/packages/netsuite-adapter/src/elements_source_index/types.ts
@@ -17,16 +17,20 @@ import { ElemID, InstanceElement } from '@salto-io/adapter-api'
 
 export type ServiceIdRecords = Record<string, { elemID: ElemID; serviceID: string }>
 
-export type ElementsSourceIndexes = {
+export type FetchElementsSourceIndexes = {
   serviceIdRecordsIndex: ServiceIdRecords
   internalIdsIndex: Record<string, ElemID>
   customFieldsIndex: Record<string, InstanceElement[]>
-  pathToInternalIdsIndex: Record<string, number>
   elemIdToChangeByIndex: Record<string, string>
-  mapKeyFieldsIndex: Record<string, string | string[]>
   elemIdToChangeAtIndex: Record<string, string>
 }
 
+export type DeployElementsSourceIndexes = {
+  pathToInternalIdsIndex: Record<string, number>
+  mapKeyFieldsIndex: Record<string, string | string[]>
+}
+
 export type LazyElementsSourceIndexes = {
-  getIndexes: () => Promise<ElementsSourceIndexes>
+  getFetchIndexes: () => Promise<FetchElementsSourceIndexes>
+  getDeployIndexes: () => Promise<DeployElementsSourceIndexes>
 }

--- a/packages/netsuite-adapter/src/filters/author_information/system_note.ts
+++ b/packages/netsuite-adapter/src/filters/author_information/system_note.ts
@@ -270,7 +270,7 @@ const filterCreator: FilterCreator = ({ client, config, elementsSource, elements
     const systemNotes = !_.isEmpty(employeeNames)
       ? await fetchSystemNotes(client, queryIds, lastFetchTime, timeZone)
       : {}
-    const { elemIdToChangeByIndex, elemIdToChangeAtIndex } = await elementsSourceIndex.getIndexes()
+    const { elemIdToChangeByIndex, elemIdToChangeAtIndex } = await elementsSourceIndex.getFetchIndexes()
     if (_.isEmpty(systemNotes) && _.isEmpty(elemIdToChangeByIndex)
     && _.isEmpty(elemIdToChangeAtIndex)) {
       return

--- a/packages/netsuite-adapter/src/filters/custom_record_types.ts
+++ b/packages/netsuite-adapter/src/filters/custom_record_types.ts
@@ -59,7 +59,7 @@ const getElementsSourceCustomRecordTypes = async (
   elementsSourceIndex: LazyElementsSourceIndexes,
   isPartial: boolean
 ): Promise<ObjectType[]> => (
-  isPartial ? Object.values((await elementsSourceIndex.getIndexes()).serviceIdRecordsIndex)
+  isPartial ? Object.values((await elementsSourceIndex.getFetchIndexes()).serviceIdRecordsIndex)
     .map(({ elemID, serviceID }) => ({ ...elemID.createTopLevelParentID(), serviceID }))
     .filter(({ parent, path }) => parent.idType === 'type' && path.length === 1 && path[0] === SCRIPT_ID)
     .map(({ serviceID, parent }) => new ObjectType({

--- a/packages/netsuite-adapter/src/filters/data_instances_references.ts
+++ b/packages/netsuite-adapter/src/filters/data_instances_references.ts
@@ -100,7 +100,7 @@ const filterCreator: FilterCreator = ({ elementsSourceIndex, isPartial }): Filte
   name: 'dataInstancesReferences',
   onFetch: async elements => {
     const elementsMap: Record<string, ElemID> = isPartial ? _.clone(
-      (await elementsSourceIndex.getIndexes()).internalIdsIndex ?? {}
+      (await elementsSourceIndex.getFetchIndexes()).internalIdsIndex ?? {}
     ) : {}
 
     await awu(elements).forEach(async element => {

--- a/packages/netsuite-adapter/src/filters/data_types_custom_fields.ts
+++ b/packages/netsuite-adapter/src/filters/data_types_custom_fields.ts
@@ -143,7 +143,7 @@ const filterCreator: FilterCreator = ({ isPartial, elementsSourceIndex }) => ({
         .filter(isInstanceElement)
         .map(instance => instance.elemID.getFullName()))
 
-      Object.entries((await elementsSourceIndex.getIndexes()).customFieldsIndex)
+      Object.entries((await elementsSourceIndex.getFetchIndexes()).customFieldsIndex)
         .filter(([type]) => type in nameToType)
         .forEach(([typeName, fields]) => {
           fields

--- a/packages/netsuite-adapter/src/filters/element_references.ts
+++ b/packages/netsuite-adapter/src/filters/element_references.ts
@@ -172,7 +172,7 @@ const createElementsSourceServiceIdToElemID = async (
   isPartial: boolean,
 ): Promise<ServiceIdRecords> => (
   isPartial
-    ? (await elementsSourceIndex.getIndexes()).serviceIdRecordsIndex
+    ? (await elementsSourceIndex.getFetchIndexes()).serviceIdRecordsIndex
     : {}
 )
 

--- a/packages/netsuite-adapter/src/mapped_lists/utils.ts
+++ b/packages/netsuite-adapter/src/mapped_lists/utils.ts
@@ -278,7 +278,7 @@ export const createConvertStandardElementMapsToLists = async (
   // using hardcoded types so the transformed elements will have fields with List<> ref types.
   const standardTypes = getStandardTypes()
   const customRecordTypeAnnotationRefTypes = toAnnotationRefTypes(standardTypes.customrecordtype.type)
-  const { mapKeyFieldsIndex } = await elementsSourceIndexes.getIndexes()
+  const { mapKeyFieldsIndex } = await elementsSourceIndexes.getDeployIndexes()
 
   const convertToList: TransformFunc = async ({ value, field }) => (
     field !== undefined && await isMappedList(value, field, mapKeyFieldsIndex)

--- a/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
@@ -648,7 +648,7 @@ SuiteAppFileCabinetOperations => {
     elementsSourceIndex: LazyElementsSourceIndexes
   ): Promise<DeployResult> => {
     const { pathToInternalIdsIndex = {} } = type === 'add'
-      ? await elementsSourceIndex.getIndexes()
+      ? await elementsSourceIndex.getDeployIndexes()
       : {}
 
     return type === 'update'

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -862,9 +862,10 @@ describe('Adapter', () => {
           deploy: {
           },
         }
+        const elementsSource = buildElementsSourceFromElements([])
         const adapter = new NetsuiteAdapter({
           client: new NetsuiteClient(client),
-          elementsSource: buildElementsSourceFromElements([]),
+          elementsSource,
           filtersCreators: [firstDummyFilter, secondDummyFilter],
           config: configWithoutWarnStaleData,
           getElemIdFunc: mockGetElemIdFunc,
@@ -882,7 +883,7 @@ describe('Adapter', () => {
           validate: expect.anything(),
           filtersRunner: expect.anything(),
           additionalDependencies: expect.anything(),
-          elementsSourceIndex: expect.anything(),
+          elementsSource,
         })
       })
 
@@ -894,9 +895,10 @@ describe('Adapter', () => {
             warnOnStaleWorkspaceData: false,
           },
         }
+        const elementsSource = buildElementsSourceFromElements([])
         const adapter = new NetsuiteAdapter({
           client: new NetsuiteClient(client),
-          elementsSource: buildElementsSourceFromElements([]),
+          elementsSource,
           filtersCreators: [firstDummyFilter, secondDummyFilter],
           config: configWithoutWarnStaleData,
           getElemIdFunc: mockGetElemIdFunc,
@@ -914,7 +916,7 @@ describe('Adapter', () => {
           deployReferencedElements: expect.anything(),
           validate: expect.anything(),
           additionalDependencies: expect.anything(),
-          elementsSourceIndex: expect.anything(),
+          elementsSource,
         })
       })
 
@@ -926,9 +928,10 @@ describe('Adapter', () => {
             warnOnStaleWorkspaceData: true,
           },
         }
+        const elementsSource = buildElementsSourceFromElements([])
         const adapter = new NetsuiteAdapter({
           client: new NetsuiteClient(client),
-          elementsSource: buildElementsSourceFromElements([]),
+          elementsSource,
           filtersCreators: [firstDummyFilter, secondDummyFilter],
           config: configWithoutWarnStaleData,
           getElemIdFunc: mockGetElemIdFunc,
@@ -946,7 +949,7 @@ describe('Adapter', () => {
           deployReferencedElements: expect.anything(),
           validate: expect.anything(),
           additionalDependencies: expect.anything(),
-          elementsSourceIndex: expect.anything(),
+          elementsSource,
         })
       })
     })

--- a/packages/netsuite-adapter/test/change_validator.test.ts
+++ b/packages/netsuite-adapter/test/change_validator.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, ChangeError, ElemID, InstanceElement, ObjectType, ProgressReporter, toChange, getChangeData, SeverityLevel } from '@salto-io/adapter-api'
+import { Change, ChangeError, ElemID, InstanceElement, ObjectType, ProgressReporter, toChange, getChangeData, SeverityLevel, ReadOnlyElementsSource } from '@salto-io/adapter-api'
 import { Filter } from '../src/filter'
 import { fileType } from '../src/types/file_cabinet_types'
 import getChangeValidator from '../src/change_validator'
@@ -21,7 +21,6 @@ import netsuiteClientValidation from '../src/change_validators/client_validation
 import { FetchByQueryFunc, FetchByQueryReturnType } from '../src/change_validators/safe_deploy'
 import { NetsuiteQuery } from '../src/query'
 import NetsuiteClient from '../src/client/client'
-import { LazyElementsSourceIndexes } from '../src/elements_source_index/types'
 import * as dependencies from '../src/change_validators/dependencies'
 
 const DEFAULT_OPTIONS = {
@@ -36,7 +35,7 @@ const DEFAULT_OPTIONS = {
   filtersRunner: () => ({
     preDeploy: jest.fn(),
   }) as unknown as Required<Filter>,
-  elementsSourceIndex: jest.fn() as unknown as LazyElementsSourceIndexes,
+  elementsSource: jest.fn() as unknown as ReadOnlyElementsSource,
   fetchByQuery: jest.fn(),
 }
 

--- a/packages/netsuite-adapter/test/change_validators/remove_sdf_elements.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/remove_sdf_elements.test.ts
@@ -13,13 +13,12 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { ElemID, Field, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
 import { workflowType } from '../../src/autogen/types/standard_types/workflow'
 import { entitycustomfieldType } from '../../src/autogen/types/standard_types/entitycustomfield'
 import removeSdfElementsValidator from '../../src/change_validators/remove_sdf_elements'
 import { CUSTOM_RECORD_TYPE, INTERNAL_ID, METADATA_TYPE, NETSUITE } from '../../src/constants'
-import { createEmptyElementsSourceIndexes } from '../utils'
-
 
 describe('remove sdf object change validator', () => {
   const customRecordType = new ObjectType({
@@ -27,9 +26,7 @@ describe('remove sdf object change validator', () => {
     annotations: { [METADATA_TYPE]: CUSTOM_RECORD_TYPE, [INTERNAL_ID]: '1' },
   })
   const customRecordTypeInstance = new InstanceElement('test', customRecordType)
-  const elementsSourceIndex = {
-    getIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
-  }
+  const elementsSource = buildElementsSourceFromElements([])
 
   describe('remove instance of standard type', () => {
     it('should have change error when removing an instance of an unsupported standard type', async () => {
@@ -37,7 +34,7 @@ describe('remove sdf object change validator', () => {
 
       const changeErrors = await removeSdfElementsValidator([
         toChange({ before: standardInstanceNoInternalId }),
-      ], undefined, elementsSourceIndex)
+      ], undefined, elementsSource)
       expect(changeErrors).toHaveLength(1)
       expect(changeErrors[0].severity).toEqual('Error')
       expect(changeErrors[0].elemID).toEqual(standardInstanceNoInternalId.elemID)
@@ -49,7 +46,7 @@ describe('remove sdf object change validator', () => {
 
       const changeErrors = await removeSdfElementsValidator([
         toChange({ before: standardInstanceNoInternalId }),
-      ], undefined, elementsSourceIndex)
+      ], undefined, elementsSource)
       expect(changeErrors).toHaveLength(1)
       expect(changeErrors[0].severity).toEqual('Error')
       expect(changeErrors[0].elemID).toEqual(standardInstanceNoInternalId.elemID)
@@ -61,7 +58,7 @@ describe('remove sdf object change validator', () => {
 
       const changeErrors = await removeSdfElementsValidator([
         toChange({ before: standardInstance }),
-      ], undefined, elementsSourceIndex)
+      ], undefined, elementsSource)
       expect(changeErrors).toHaveLength(0)
     })
   })
@@ -70,7 +67,7 @@ describe('remove sdf object change validator', () => {
     it('should not have change error when removing an instance with non standard type', async () => {
       const changeErrors = await removeSdfElementsValidator([
         toChange({ before: customRecordTypeInstance }),
-      ], undefined, elementsSourceIndex)
+      ], undefined, elementsSource)
       expect(changeErrors).toHaveLength(0)
     })
   })
@@ -84,7 +81,7 @@ describe('remove sdf object change validator', () => {
 
       const changeErrors = await removeSdfElementsValidator([
         toChange({ before: customRecordTypeNoInternalID }),
-      ], undefined, elementsSourceIndex)
+      ], undefined, elementsSource)
       expect(changeErrors).toHaveLength(1)
       expect(changeErrors[0].severity).toEqual('Error')
       expect(changeErrors[0].elemID).toEqual(customRecordTypeNoInternalID.elemID)
@@ -99,25 +96,18 @@ describe('remove sdf object change validator', () => {
       const changeErrors = await removeSdfElementsValidator([
         toChange({ before: customRecordType }),
         toChange({ before: instanceOfAnotherType }),
-      ], undefined, elementsSourceIndex)
+      ], undefined, elementsSource)
       expect(changeErrors).toHaveLength(1)
       expect(changeErrors[0].severity).toEqual('Warning')
       expect(changeErrors[0].elemID).toEqual(customRecordType.elemID)
     })
 
     it('should have change error when removing a custom record type with internal id when instances exists in the index', async () => {
-      const elementsSourceIndexWithInstance = {
-        getIndexes: () => Promise.resolve({
-          ...createEmptyElementsSourceIndexes(),
-          internalIdsIndex: {
-            'customrecord1-1': customRecordTypeInstance.elemID,
-          },
-        }),
-      }
+      const elementsSourceInstance = buildElementsSourceFromElements([customRecordTypeInstance])
 
       const changeErrors = await removeSdfElementsValidator([
         toChange({ before: customRecordType }),
-      ], undefined, elementsSourceIndexWithInstance)
+      ], undefined, elementsSourceInstance)
       expect(changeErrors).toHaveLength(1)
       expect(changeErrors[0].severity).toEqual('Error')
       expect(changeErrors[0].elemID).toEqual(customRecordType.elemID)
@@ -136,7 +126,7 @@ describe('remove sdf object change validator', () => {
       const changeErrors = await removeSdfElementsValidator([
         toChange({ before: field }),
         toChange({ before: anotherCustomRecordType }),
-      ], undefined, elementsSourceIndex)
+      ], undefined, elementsSource)
       expect(changeErrors).toHaveLength(2)
       expect(changeErrors[0].severity).toEqual('Error')
       expect(changeErrors[0].elemID).toEqual(field.elemID)
@@ -148,7 +138,7 @@ describe('remove sdf object change validator', () => {
       const changeErrors = await removeSdfElementsValidator([
         toChange({ before: field }),
         toChange({ before: customRecordType }),
-      ], undefined, elementsSourceIndex)
+      ], undefined, elementsSource)
       expect(changeErrors).toHaveLength(1)
       expect(changeErrors[0].severity).toEqual('Warning')
       expect(changeErrors[0].elemID).toEqual(customRecordType.elemID)

--- a/packages/netsuite-adapter/test/client/client.test.ts
+++ b/packages/netsuite-adapter/test/client/client.test.ts
@@ -35,7 +35,7 @@ describe('NetsuiteClient', () => {
       deploy: mockSdfDeploy,
     } as unknown as SdfClient
     const mockElementsSourceIndex = {
-      getIndexes: () => ({ mapKeyFieldsIndex: {} }),
+      getFetchIndexes: () => ({ mapKeyFieldsIndex: {} }),
     } as unknown as LazyElementsSourceIndexes
     const client = new NetsuiteClient(sdfClient)
 

--- a/packages/netsuite-adapter/test/filters/author_information/saved_searches.test.ts
+++ b/packages/netsuite-adapter/test/filters/author_information/saved_searches.test.ts
@@ -67,7 +67,8 @@ describe('netsuite saved searches author information tests', () => {
     filterOpts = {
       client,
       elementsSourceIndex: {
-        getIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+        getFetchIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+        getDeployIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
       },
       elementsSource: buildElementsSourceFromElements([]),
       isPartial: false,
@@ -190,7 +191,8 @@ describe('netsuite saved searches author information tests', () => {
       filterOpts = {
         client: clientWithoutSuiteApp,
         elementsSourceIndex: {
-          getIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getFetchIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getDeployIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
         },
         elementsSource: buildElementsSourceFromElements([]),
         isPartial: false,
@@ -210,7 +212,8 @@ describe('netsuite saved searches author information tests', () => {
       filterOpts = {
         client,
         elementsSourceIndex: {
-          getIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getFetchIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getDeployIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
         },
         elementsSource: buildElementsSourceFromElements([]),
         isPartial: false,

--- a/packages/netsuite-adapter/test/filters/author_information/system_note.test.ts
+++ b/packages/netsuite-adapter/test/filters/author_information/system_note.test.ts
@@ -97,7 +97,8 @@ describe('netsuite system note author information', () => {
     filterOpts = {
       client,
       elementsSourceIndex: {
-        getIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+        getFetchIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+        getDeployIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
       },
       elementsSource: buildElementsSourceFromElements([serverTimeType, serverTimeInstance]),
       isPartial: false,
@@ -163,7 +164,7 @@ describe('netsuite system note author information', () => {
     const opts = {
       client,
       elementsSourceIndex: {
-        getIndexes: () => Promise.resolve({
+        getFetchIndexes: () => Promise.resolve({
           ...createEmptyElementsSourceIndexes(),
           elemIdToChangeByIndex: {
             [missingInstance.elemID.getFullName()]: 'another user name',
@@ -172,6 +173,7 @@ describe('netsuite system note author information', () => {
             [missingInstance.elemID.getFullName()]: '2022-08-19',
           },
         }),
+        getDeployIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
       },
       elementsSource: buildElementsSourceFromElements([serverTimeType, serverTimeInstance]),
       isPartial: false,
@@ -186,7 +188,7 @@ describe('netsuite system note author information', () => {
     const opts = {
       client,
       elementsSourceIndex: {
-        getIndexes: () => Promise.resolve({
+        getFetchIndexes: () => Promise.resolve({
           ...createEmptyElementsSourceIndexes(),
           elemIdToChangeByIndex: {
             [missingInstance.elemID.getFullName()]: 'another user name',
@@ -195,6 +197,7 @@ describe('netsuite system note author information', () => {
             [missingInstance.elemID.getFullName()]: '8/19/2022',
           },
         }),
+        getDeployIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
       },
       elementsSource: buildElementsSourceFromElements([serverTimeType, serverTimeInstance]),
       isPartial: false,
@@ -261,7 +264,8 @@ describe('netsuite system note author information', () => {
       filterOpts = {
         client: clientWithoutSuiteApp,
         elementsSourceIndex: {
-          getIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getFetchIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getDeployIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
         },
         elementsSource: buildElementsSourceFromElements([]),
         isPartial: false,
@@ -285,7 +289,8 @@ describe('netsuite system note author information', () => {
       filterOpts = {
         client,
         elementsSourceIndex: {
-          getIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getFetchIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getDeployIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
         },
         elementsSource: buildElementsSourceFromElements([]),
         isPartial: false,
@@ -309,7 +314,8 @@ describe('netsuite system note author information', () => {
       filterOpts = {
         client,
         elementsSourceIndex: {
-          getIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getFetchIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getDeployIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
         },
         elementsSource: buildElementsSourceFromElements([]),
         isPartial: false,

--- a/packages/netsuite-adapter/test/filters/convert_lists_to_maps.test.ts
+++ b/packages/netsuite-adapter/test/filters/convert_lists_to_maps.test.ts
@@ -397,7 +397,7 @@ describe('convert lists to maps filter', () => {
         ),
       })
       const elementsSourceIndex = {
-        getIndexes: () => ({
+        getDeployIndexes: () => ({
           mapKeyFieldsIndex: {
             'netsuite.workflow_workflowcustomfields.field.workflowcustomfield': 'scriptid',
             'netsuite.workflow_workflowstates.field.workflowstate': 'scriptid',

--- a/packages/netsuite-adapter/test/filters/custom_record_types.test.ts
+++ b/packages/netsuite-adapter/test/filters/custom_record_types.test.ts
@@ -27,8 +27,8 @@ describe('custom record types filter', () => {
     config: {},
     isPartial: false,
     elementsSourceIndex: {
-      getIndexes: () => {
-        throw new Error('should not call getIndexes')
+      getFetchIndexes: () => {
+        throw new Error('should not call getFetchIndexes')
       },
     },
   } as unknown as FilterOpts
@@ -87,7 +87,7 @@ describe('custom record types filter', () => {
       ...filterOpts,
       isPartial: true,
       elementsSourceIndex: ({
-        getIndexes: () => Promise.resolve({
+        getFetchIndexes: () => Promise.resolve({
           serviceIdRecordsIndex: {
             customrecord2: {
               elemID: new ElemID(NETSUITE, 'customrecord2', 'attr', 'scriptid'),

--- a/packages/netsuite-adapter/test/filters/data_instances_references.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_instances_references.test.ts
@@ -56,7 +56,8 @@ describe('data_instances_references', () => {
       const filterOpts = {
         client: {} as NetsuiteClient,
         elementsSourceIndex: {
-          getIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getFetchIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getDeployIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
         },
         elementsSource: buildElementsSourceFromElements([]),
         isPartial: false,
@@ -78,7 +79,8 @@ describe('data_instances_references', () => {
         elements: [instance],
         client: {} as NetsuiteClient,
         elementsSourceIndex: {
-          getIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getFetchIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getDeployIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
         },
         elementsSource: buildElementsSourceFromElements([]),
         isPartial: false,
@@ -104,12 +106,13 @@ describe('data_instances_references', () => {
       const fetchOpts = {
         client: {} as NetsuiteClient,
         elementsSourceIndex: {
-          getIndexes: () => Promise.resolve({
+          getFetchIndexes: () => Promise.resolve({
             ...createEmptyElementsSourceIndexes(),
             internalIdsIndex: {
               'firstType-1': referencedInstance.elemID,
             },
           }),
+          getDeployIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
         },
         elementsSource: buildElementsSourceFromElements([]),
         isPartial: true,
@@ -136,7 +139,8 @@ describe('data_instances_references', () => {
       const fetchOpts = {
         client: {} as NetsuiteClient,
         elementsSourceIndex: {
-          getIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getFetchIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getDeployIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
         },
         elementsSource: buildElementsSourceFromElements([]),
         isPartial: false,
@@ -165,7 +169,8 @@ describe('data_instances_references', () => {
       const fetchOpts = {
         client: {} as NetsuiteClient,
         elementsSourceIndex: {
-          getIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getFetchIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getDeployIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
         },
         elementsSource: buildElementsSourceFromElements([]),
         isPartial: false,
@@ -195,7 +200,8 @@ describe('data_instances_references', () => {
       const fetchOpts = {
         client: {} as NetsuiteClient,
         elementsSourceIndex: {
-          getIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getFetchIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getDeployIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
         },
         elementsSource: buildElementsSourceFromElements([]),
         isPartial: false,

--- a/packages/netsuite-adapter/test/filters/data_types_custom_fields.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_types_custom_fields.test.ts
@@ -36,7 +36,8 @@ describe('data_types_custom_fields', () => {
     filterOpts = {
       client: {} as NetsuiteClient,
       elementsSourceIndex: {
-        getIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+        getFetchIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+        getDeployIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
       },
       elementsSource: buildElementsSourceFromElements([]),
       isPartial: false,
@@ -87,10 +88,11 @@ describe('data_types_custom_fields', () => {
       filterOpts = {
         client: {} as NetsuiteClient,
         elementsSourceIndex: {
-          getIndexes: () => Promise.resolve({
+          getFetchIndexes: () => Promise.resolve({
             ...createEmptyElementsSourceIndexes(),
             customFieldsIndex: { Customer: [instance] },
           }),
+          getDeployIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
         },
         elementsSource: buildElementsSourceFromElements([]),
         isPartial: true,
@@ -110,10 +112,11 @@ describe('data_types_custom_fields', () => {
       filterOpts = {
         client: {} as NetsuiteClient,
         elementsSourceIndex: {
-          getIndexes: () => Promise.resolve({
+          getFetchIndexes: () => Promise.resolve({
             ...createEmptyElementsSourceIndexes(),
             customFieldsIndex: { Customer: [instance] },
           }),
+          getDeployIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
         },
         elementsSource: buildElementsSourceFromElements([]),
         isPartial: true,

--- a/packages/netsuite-adapter/test/filters/element_references.test.ts
+++ b/packages/netsuite-adapter/test/filters/element_references.test.ts
@@ -41,7 +41,8 @@ describe('instance_references filter', () => {
 
     const getIndexesMock = jest.fn()
     const elementsSourceIndex = {
-      getIndexes: getIndexesMock,
+      getFetchIndexes: getIndexesMock,
+      getDeployIndexes: getIndexesMock,
     }
 
     beforeEach(async () => {

--- a/packages/netsuite-adapter/test/filters/internal_ids/sdf_internal_ids.test.ts
+++ b/packages/netsuite-adapter/test/filters/internal_ids/sdf_internal_ids.test.ts
@@ -76,7 +76,8 @@ describe('sdf internal ids tests', () => {
     filterOpts = {
       client,
       elementsSourceIndex: {
-        getIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+        getFetchIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+        getDeployIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
       },
       elementsSource: buildElementsSourceFromElements([]),
       isPartial: false,
@@ -89,7 +90,8 @@ describe('sdf internal ids tests', () => {
       filterOpts = {
         client: clientWithoutSuiteApp,
         elementsSourceIndex: {
-          getIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getFetchIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getDeployIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
         },
         elementsSource: buildElementsSourceFromElements([]),
         isPartial: false,
@@ -109,7 +111,8 @@ describe('sdf internal ids tests', () => {
       filterOpts = {
         client: clientWithoutSuiteApp,
         elementsSourceIndex: {
-          getIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getFetchIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getDeployIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
         },
         elementsSource: buildElementsSourceFromElements([]),
         isPartial: false,
@@ -127,7 +130,8 @@ describe('sdf internal ids tests', () => {
       filterOpts = {
         client: clientWithoutSuiteApp,
         elementsSourceIndex: {
-          getIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getFetchIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getDeployIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
         },
         elementsSource: buildElementsSourceFromElements([]),
         isPartial: false,

--- a/packages/netsuite-adapter/test/filters/parse_report_types.test.ts
+++ b/packages/netsuite-adapter/test/filters/parse_report_types.test.ts
@@ -47,7 +47,8 @@ describe('parse_report_types filter', () => {
     fetchOpts = {
       client: {} as NetsuiteClient,
       elementsSourceIndex: {
-        getIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+        getFetchIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+        getDeployIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
       },
       elementsSource: buildElementsSourceFromElements([]),
       isPartial: false,
@@ -128,7 +129,8 @@ describe('parse_report_types filter', () => {
       fetchOpts = {
         client: {} as NetsuiteClient,
         elementsSourceIndex: {
-          getIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getFetchIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getDeployIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
         },
         elementsSource: buildElementsSourceFromElements(sourceElements),
         isPartial: false,

--- a/packages/netsuite-adapter/test/filters/remove_unsupported_types.test.ts
+++ b/packages/netsuite-adapter/test/filters/remove_unsupported_types.test.ts
@@ -53,7 +53,8 @@ describe('remove_unsupported_types', () => {
     filterOpts = {
       client: { isSuiteAppConfigured: isSuiteAppConfiguredMock } as unknown as NetsuiteClient,
       elementsSourceIndex: {
-        getIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+        getFetchIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+        getDeployIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
       },
       elementsSource: buildElementsSourceFromElements([]),
       isPartial: false,

--- a/packages/netsuite-adapter/test/filters/service_urls.test.ts
+++ b/packages/netsuite-adapter/test/filters/service_urls.test.ts
@@ -46,7 +46,8 @@ describe('serviceUrls', () => {
       await serviceUrls({
         client,
         elementsSourceIndex: {
-          getIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getFetchIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getDeployIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
         },
         elementsSource: buildElementsSourceFromElements([]),
         isPartial: false,
@@ -59,7 +60,8 @@ describe('serviceUrls', () => {
       await serviceUrls({
         client,
         elementsSourceIndex: {
-          getIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getFetchIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getDeployIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
         },
         elementsSource: buildElementsSourceFromElements([]),
         isPartial: false,
@@ -90,7 +92,8 @@ describe('serviceUrls', () => {
       await serviceUrls({
         client: {} as unknown as NetsuiteClient,
         elementsSourceIndex: {
-          getIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getFetchIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+          getDeployIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
         },
         elementsSource: buildElementsSourceFromElements([]),
         isPartial: false,

--- a/packages/netsuite-adapter/test/mapped_lists/utils.test.ts
+++ b/packages/netsuite-adapter/test/mapped_lists/utils.test.ts
@@ -19,7 +19,6 @@ import { convertFieldsTypesFromListToMap, createConvertStandardElementMapsToList
 import { getStandardTypes } from '../../src/autogen/types'
 import { LIST_MAPPED_BY_FIELD, NETSUITE, SCRIPT_ID } from '../../src/constants'
 import { getInnerStandardTypes, getTopLevelStandardTypes } from '../../src/types'
-import { LazyElementsSourceIndexes } from '../../src/elements_source_index/types'
 import { toAnnotationRefTypes } from '../../src/custom_records/custom_record_type'
 
 const { awu } = collections.asynciterable
@@ -189,15 +188,21 @@ describe('mapped lists', () => {
     transformedDataInstance = dataInstance.clone()
     transformedDataInstance.value = await convertInstanceListsToMaps(dataInstance) ?? {}
 
-    const convertElementMapsToLists = await createConvertStandardElementMapsToLists({ getIndexes: () => ({
-      mapKeyFieldsIndex: {
-        'netsuite.workflow_workflowcustomfields.field.workflowcustomfield': 'scriptid',
-        'netsuite.workflow_workflowstates.field.workflowstate': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate.field.workflowactions': 'triggertype',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions.field.setfieldvalueaction': 'scriptid',
-        'netsuite.customrecordtype_permissions.field.permission': 'permittedrole',
+    const convertElementMapsToLists = await createConvertStandardElementMapsToLists({
+      getFetchIndexes: () => {
+        throw new Error('should not call getFetchIndexes')
       },
-    }) } as unknown as LazyElementsSourceIndexes)
+      getDeployIndexes: async () => ({
+        pathToInternalIdsIndex: {},
+        mapKeyFieldsIndex: {
+          'netsuite.workflow_workflowcustomfields.field.workflowcustomfield': 'scriptid',
+          'netsuite.workflow_workflowstates.field.workflowstate': 'scriptid',
+          'netsuite.workflow_workflowstates_workflowstate.field.workflowactions': 'triggertype',
+          'netsuite.workflow_workflowstates_workflowstate_workflowactions.field.setfieldvalueaction': 'scriptid',
+          'netsuite.customrecordtype_permissions.field.permission': 'permittedrole',
+        },
+      }),
+    })
     transformedBackInstance = await convertElementMapsToLists(transformedInstance) as InstanceElement
     transformedBackCustomRecordType = await convertElementMapsToLists(transformedCustomRecordType) as ObjectType
     transformedBackDataInstance = await convertDataInstanceMapsToLists(transformedDataInstance)

--- a/packages/netsuite-adapter/test/suiteapp_file_cabinet.test.ts
+++ b/packages/netsuite-adapter/test/suiteapp_file_cabinet.test.ts
@@ -24,7 +24,7 @@ import { ReadFileEncodingError, ReadFileError, ReadFileInsufficientPermissionErr
 import { customtransactiontypeType } from '../src/autogen/types/standard_types/customtransactiontype'
 import { ExistingFileCabinetInstanceDetails, FileCabinetInstanceDetails } from '../src/client/suiteapp_client/types'
 import { getFileCabinetTypes } from '../src/types/file_cabinet_types'
-import { ElementsSourceIndexes, LazyElementsSourceIndexes } from '../src/elements_source_index/types'
+import { LazyElementsSourceIndexes } from '../src/elements_source_index/types'
 
 const { awu } = collections.asynciterable
 
@@ -563,8 +563,11 @@ describe('suiteapp_file_cabinet', () => {
 
     describe('modifications', () => {
       const elementsSourceIndexes: LazyElementsSourceIndexes = {
-        getIndexes: () => {
-          throw new Error('getIndexes should not be called!')
+        getFetchIndexes: () => {
+          throw new Error('getFetchIndexes should not be called!')
+        },
+        getDeployIndexes: () => {
+          throw new Error('getDeployIndexes should not be called!')
         },
       }
 
@@ -677,13 +680,17 @@ describe('suiteapp_file_cabinet', () => {
     })
 
     describe('additions', () => {
-      const elementsSourceIndexes = {
-        getIndexes: async () => ({
+      const elementsSourceIndexes: LazyElementsSourceIndexes = {
+        getFetchIndexes: () => {
+          throw new Error('getFetchIndexes should not be called!')
+        },
+        getDeployIndexes: async () => ({
           pathToInternalIdsIndex: {
             ...Object.fromEntries(_.range(100).map(i => [`/instance${i}`, i])),
             '/instance1/instance101': 101,
           },
-        } as unknown as ElementsSourceIndexes),
+          mapKeyFieldsIndex: {},
+        }),
       }
 
       it('should split by depths', async () => {
@@ -770,8 +777,11 @@ describe('suiteapp_file_cabinet', () => {
 
     describe('deletions', () => {
       const elementsSourceIndexes: LazyElementsSourceIndexes = {
-        getIndexes: () => {
-          throw new Error('getIndexes should not be called!')
+        getFetchIndexes: () => {
+          throw new Error('getFetchIndexes should not be called!')
+        },
+        getDeployIndexes: () => {
+          throw new Error('getDeployIndexes should not be called!')
         },
       }
       it('should split by depths', async () => {

--- a/packages/netsuite-adapter/test/utils.ts
+++ b/packages/netsuite-adapter/test/utils.ts
@@ -15,7 +15,7 @@
 */
 import { ElemID, ServiceIds } from '@salto-io/adapter-api'
 import { createDefaultInstanceFromType } from '@salto-io/adapter-utils'
-import { ElementsSourceIndexes } from '../src/elements_source_index/types'
+import { FetchElementsSourceIndexes, DeployElementsSourceIndexes } from '../src/elements_source_index/types'
 import { configType, NetsuiteConfig } from '../src/config'
 import { NETSUITE } from '../src/constants'
 
@@ -27,6 +27,7 @@ export const getDefaultAdapterConfig = async (): Promise<NetsuiteConfig> => {
   return defaultConfigInstance.value as NetsuiteConfig
 }
 
+type ElementsSourceIndexes = FetchElementsSourceIndexes & DeployElementsSourceIndexes
 export const createEmptyElementsSourceIndexes = (): ElementsSourceIndexes => ({
   serviceIdRecordsIndex: {},
   internalIdsIndex: {},


### PR DESCRIPTION
Improve the running time of `elementSourceIndexes` indexes creation:
- Separate to fetch/deploy indexes
- In full fetch - calculate only changedBy/changedAt indexes

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Improve elementSourceIndexes

---
_User Notifications_: 
None