### PR TITLE
SALTO-3800: Jira DC user scheme does not match a valid user

### DIFF
--- a/packages/jira-adapter/src/users.ts
+++ b/packages/jira-adapter/src/users.ts
@@ -95,7 +95,7 @@ const DATA_CENTER_USER_RESPONSE_SCHEME = Joi.object({
   locale: Joi.string(),
   key: Joi.string().required(),
   name: Joi.string().required().allow(''),
-  emailAddress: Joi.string(),
+  emailAddress: Joi.string().allow(''),
   displayName: Joi.string().required().allow(''),
 }).unknown(true)
 

--- a/packages/jira-adapter/test/filters/locale.test.ts
+++ b/packages/jira-adapter/test/filters/locale.test.ts
@@ -45,6 +45,26 @@ describe('localeFilter', () => {
       })
     })
 
+    it('should work when email is an empty string', async () => {
+      connection.get.mockResolvedValue({
+        status: 200,
+        data: {
+          key: 'key',
+          name: 'name',
+          displayName: 'displayName',
+          locale: 'es_ES',
+          emailAddress: '',
+        },
+      })
+      const filterRes = await filter.onFetch([])
+      expect(filterRes).toEqual({
+        errors: [{
+          message: 'Your Jira Data Center instance is not set to English-US language. Salto currently only supports accessing Jira DC through users with their default language set to English-US. Please change the user’s language, or create another user with English as its Jira language, and change Salto\'s credentials to use it. After doing that, make sure you re-fetch your environment using an advanced fetch, with “Regenerate Salto IDs” turned on. You only need to do this once. For help on how to change Jira users\' language, go to https://confluence.atlassian.com/adminjiraserver/choosing-a-default-language-938847001.html',
+          severity: 'Warning',
+        }],
+      })
+    })
+
     it('should raise error when language is not English', async () => {
       const filterRes = await filter.onFetch([])
       expect(filterRes).toEqual({


### PR DESCRIPTION
We got a user in a customer account with an empty emailAddress

---
_Release Notes_: 
_Jira Adapter_:
- Fixed failure in getting the current user in some cases

---
_User Notifications_: 
None