### PR TITLE
SALTO-3643: zendesk ensure the fetching user's locale is set to en us

### DIFF
--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -568,18 +568,20 @@ export default class ZendeskAdapter implements AdapterOperations {
       const res = (await this.client.getSinglePage({
         url: '/api/v2/users/me',
       })).data
-      if (isCurrentUserResponse(res) && res.user.locale !== 'en-US') {
-        return {
-          message: 'You are fetching zendesk with a user whose local is set to a non-English language. This may affect Salto\'s behavior in some cases. Therefore, its highly recommended to set the user language to English or create another user with English as its Zendesk language and change Salto‘s credentials to use it. For help on how to change Zendesk users’ language, go to https://support.zendesk.com/hc/en-us/articles/4408835022490-Viewing-and-editing-your-user-profile-in-Zendesk-Support',
-          severity: 'Warning',
+      if (isCurrentUserResponse(res)) {
+        if (res.user.locale !== 'en-US') {
+          return {
+            message: 'You are fetching zendesk with a user whose local is set to a non-English language. This may affect Salto\'s behavior in some cases. Therefore, its highly recommended to set the user language to English or create another user with English as its Zendesk language and change Salto‘s credentials to use it. For help on how to change Zendesk users’ language, go to https://support.zendesk.com/hc/en-us/articles/4408835022490-Viewing-and-editing-your-user-profile-in-Zendesk-Support',
+            severity: 'Warning',
+          }
         }
+        return undefined
       }
-      log.error('could not verify fetching users locale is set to en-US. received invalid response ')
-      return undefined
+      log.error('could not verify fetching users locale is set to en-US. received invalid response')
     } catch (e) {
       log.error(`could not verify fetching user's locale is set to en-US'. error: ${e}`)
-      return undefined
     }
+    return undefined
   }
 
   /**

--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -570,7 +570,7 @@ export default class ZendeskAdapter implements AdapterOperations {
       })).data
       if (isCurrentUserResponse(res) && res.user.locale !== 'en-US') {
         return {
-          message: 'Your Zendesk instance is set to a non-English language. This may affect Salto\'s behavior in some cases. Therefore, its highly recommended to set the user language to English or create another user with English as its Zendesk language and change Salto‘s credentials to use it. For help on how to change Zendesk users’ language, go to https://support.zendesk.com/hc/en-us/articles/4408835022490-Viewing-and-editing-your-user-profile-in-Zendesk-Support',
+          message: 'You are fetching zendesk with a user whose local is set to a non-English language. This may affect Salto\'s behavior in some cases. Therefore, its highly recommended to set the user language to English or create another user with English as its Zendesk language and change Salto‘s credentials to use it. For help on how to change Zendesk users’ language, go to https://support.zendesk.com/hc/en-us/articles/4408835022490-Viewing-and-editing-your-user-profile-in-Zendesk-Support',
           severity: 'Warning',
         }
       }

--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -571,13 +571,13 @@ export default class ZendeskAdapter implements AdapterOperations {
       if (isCurrentUserResponse(res)) {
         if (res.user.locale !== 'en-US') {
           return {
-            message: 'You are fetching zendesk with a user whose local is set to a non-English language. This may affect Salto\'s behavior in some cases. Therefore, its highly recommended to set the user language to English or create another user with English as its Zendesk language and change Salto‘s credentials to use it. For help on how to change Zendesk users’ language, go to https://support.zendesk.com/hc/en-us/articles/4408835022490-Viewing-and-editing-your-user-profile-in-Zendesk-Support',
+            message: 'You are fetching zendesk with a user whose locale is set to a language different than US English. This may affect Salto\'s behavior in some cases. Therefore, it is highly recommended to set the user\'s language to "English (United States)" or to create another user with English as its Zendesk language and change Salto‘s credentials to use it. For help on how to change a Zendesk user\'s language, go to https://support.zendesk.com/hc/en-us/articles/4408835022490-Viewing-and-editing-your-user-profile-in-Zendesk-Support',
             severity: 'Warning',
           }
         }
         return undefined
       }
-      log.error('could not verify fetching users locale is set to en-US. received invalid response')
+      log.error('could not verify fetching user\'s locale is set to en-US. received invalid response')
     } catch (e) {
       log.error(`could not verify fetching user's locale is set to en-US'. error: ${e}`)
     }

--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -570,11 +570,11 @@ export default class ZendeskAdapter implements AdapterOperations {
       })).data
       if (isCurrentUserResponse(res) && res.user.locale !== 'en-US') {
         return {
-          message: `the user locale is set to ${res.user.locale} please change it to en-US`,
-          severity: 'Warning', // maybe we want it to be an error?
+          message: 'Your Zendesk instance is set to a non-English language. This may affect Salto\'s behavior in some cases. Therefore, its highly recommended to set the user language to English or create another user with English as its Zendesk language and change Salto‘s credentials to use it. For help on how to change Zendesk users’ language, go to https://support.zendesk.com/hc/en-us/articles/4408835022490-Viewing-and-editing-your-user-profile-in-Zendesk-Support',
+          severity: 'Warning',
         }
       }
-      log.error('could not verify fetching users locale is set to en-US. received invalid response ') // maybe we want to return a warning?
+      log.error('could not verify fetching users locale is set to en-US. received invalid response ')
       return undefined
     } catch (e) {
       log.error(`could not verify fetching user's locale is set to en-US'. error: ${e}`)

--- a/packages/zendesk-adapter/src/user_utils.ts
+++ b/packages/zendesk-adapter/src/user_utils.ts
@@ -38,6 +38,7 @@ export type User = {
   role: string
   // eslint-disable-next-line camelcase
   custom_role_id: number
+  locale: string
 }
 
 type CurrentUserResponse = {
@@ -50,6 +51,7 @@ const EXPECTED_USER_SCHEMA = Joi.object({
   email: Joi.string().required(),
   role: Joi.string(),
   custom_role_id: Joi.number(),
+  locale: Joi.string().required(),
 }).unknown(true)
 
 const EXPECTED_USERS_SCHEMA = Joi.array().items(EXPECTED_USER_SCHEMA).required()
@@ -58,7 +60,7 @@ const CURRENT_USER_RESPONSE_SCHEME = Joi.object({
   user: EXPECTED_USER_SCHEMA,
 }).required()
 
-const isCurrentUserResponse = createSchemeGuard<CurrentUserResponse>(CURRENT_USER_RESPONSE_SCHEME, 'Received an invalid current user response')
+export const isCurrentUserResponse = createSchemeGuard<CurrentUserResponse>(CURRENT_USER_RESPONSE_SCHEME, 'Received an invalid current user response')
 
 const areUsers = (values: unknown): values is User[] => {
   const { error } = EXPECTED_USERS_SCHEMA.validate(values)

--- a/packages/zendesk-adapter/test/change_validators/custom_role_removal.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/custom_role_removal.test.ts
@@ -50,11 +50,11 @@ describe('customRoleRemovalValidator', () => {
         status: 200,
         data: {
           users: [
-            { id: 1, email: '1@1', role: 'agent', custom_role_id: 123, name: '1' },
-            { id: 2, email: '2@2', role: 'agent', custom_role_id: 234, name: '2' },
-            { id: 3, email: '3@3', role: 'admin', custom_role_id: 234, name: '2' },
-            { id: 4, email: '4@4', role: 'agent', name: '2' },
-            { id: 5, email: '5@5', role: 'agent', custom_role_id: 123, name: '2' },
+            { id: 1, email: '1@1', role: 'agent', custom_role_id: 123, name: '1', locale: 'en-US' },
+            { id: 2, email: '2@2', role: 'agent', custom_role_id: 234, name: '2', locale: 'en-US' },
+            { id: 3, email: '3@3', role: 'admin', custom_role_id: 234, name: '2', locale: 'en-US' },
+            { id: 4, email: '4@4', role: 'agent', name: '2', locale: 'en-US' },
+            { id: 5, email: '5@5', role: 'agent', custom_role_id: 123, name: '2', locale: 'en-US' },
           ],
         },
       }

--- a/packages/zendesk-adapter/test/change_validators/users.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/users.test.ts
@@ -98,13 +98,13 @@ describe('usersValidator', () => {
         status: 200,
         data: {
           users: [
-            { id: 1, email: '1@salto.io', name: '1', role: 'agent', custom_role_id: 1 },
-            { id: 2, email: '2@salto.io', name: '2', role: 'agent', custom_role_id: 1 },
-            { id: 3, email: '3@salto.io', name: '3', role: 'admin', custom_role_id: 1 },
-            { id: 4, email: '4@salto.io', name: '4', role: 'agent', custom_role_id: 1 },
-            { id: 5, email: '5@salto.io', name: '5', role: 'agent', custom_role_id: 1 },
-            { id: 6, email: '6@salto.io', name: '6', role: 'agent', custom_role_id: 2 },
-            { id: 7, email: '7@salto.io', name: '7', role: 'agent', custom_role_id: 2 },
+            { id: 1, email: '1@salto.io', name: '1', role: 'agent', custom_role_id: 1, locale: 'en-US' },
+            { id: 2, email: '2@salto.io', name: '2', role: 'agent', custom_role_id: 1, locale: 'en-US' },
+            { id: 3, email: '3@salto.io', name: '3', role: 'admin', custom_role_id: 1, locale: 'en-US' },
+            { id: 4, email: '4@salto.io', name: '4', role: 'agent', custom_role_id: 1, locale: 'en-US' },
+            { id: 5, email: '5@salto.io', name: '5', role: 'agent', custom_role_id: 1, locale: 'en-US' },
+            { id: 6, email: '6@salto.io', name: '6', role: 'agent', custom_role_id: 2, locale: 'en-US' },
+            { id: 7, email: '7@salto.io', name: '7', role: 'agent', custom_role_id: 2, locale: 'en-US' },
           ],
         },
       }

--- a/packages/zendesk-adapter/test/filters/user.test.ts
+++ b/packages/zendesk-adapter/test/filters/user.test.ts
@@ -203,9 +203,9 @@ describe('user filter', () => {
       ) as FilterType
       getUsersMock
         .mockResolvedValue([
-          { id: 1, email: 'a@a.com', role: 'admin', custom_role_id: 123, name: 'a' },
-          { id: 2, email: 'b@b.com', role: 'admin', custom_role_id: 123, name: 'b' },
-          { id: 3, email: 'c@c.com', role: 'admin', custom_role_id: 123, name: 'c' },
+          { id: 1, email: 'a@a.com', role: 'admin', custom_role_id: 123, name: 'a', locale: 'en-US' },
+          { id: 2, email: 'b@b.com', role: 'admin', custom_role_id: 123, name: 'b', locale: 'en-US' },
+          { id: 3, email: 'c@c.com', role: 'admin', custom_role_id: 123, name: 'c', locale: 'en-US' },
         ])
       getIdByEmailMock
         .mockResolvedValue({ 1: 'a@a.com',
@@ -247,9 +247,9 @@ describe('user filter', () => {
       })) as FilterType
       getUsersMock
         .mockResolvedValue([
-          { id: 2, email: 'b@b.com', role: 'admin', custom_role_id: 123, name: 'b' },
-          { id: 3, email: 'c@c.com', role: 'admin', custom_role_id: 123, name: 'c' },
-          { id: 4, email: 'fallback@.com', role: 'agent', custom_role_id: 12, name: 'fallback' },
+          { id: 2, email: 'b@b.com', role: 'admin', custom_role_id: 123, name: 'b', locale: 'en-US' },
+          { id: 3, email: 'c@c.com', role: 'admin', custom_role_id: 123, name: 'c', locale: 'en-US' },
+          { id: 4, email: 'fallback@.com', role: 'agent', custom_role_id: 12, name: 'fallback', locale: 'en-US' },
         ])
       const instances2 = [macroInstance, articleInstance].map(e => e.clone())
       await filter.onFetch(instances2)
@@ -279,9 +279,9 @@ describe('user filter', () => {
     it('should change the user ids to emails', async () => {
       getUsersMock
         .mockResolvedValue([
-          { id: 1, email: 'a@a.com', role: 'admin', custom_role_id: 123, name: 'a' },
-          { id: 2, email: 'b@b.com', role: 'admin', custom_role_id: 123, name: 'b' },
-          { id: 3, email: 'c@c.com', role: 'admin', custom_role_id: 123, name: 'c' },
+          { id: 1, email: 'a@a.com', role: 'admin', custom_role_id: 123, name: 'a', locale: 'en-US' },
+          { id: 2, email: 'b@b.com', role: 'admin', custom_role_id: 123, name: 'b', locale: 'en-US' },
+          { id: 3, email: 'c@c.com', role: 'admin', custom_role_id: 123, name: 'c', locale: 'en-US' },
         ])
       getIdByEmailMock
         .mockResolvedValue({ 1: 'a@a.com',

--- a/packages/zendesk-adapter/test/user_utils.test.ts
+++ b/packages/zendesk-adapter/test/user_utils.test.ts
@@ -47,9 +47,9 @@ describe('userUtils', () => {
         .mockImplementation(async function *get() {
           yield [
             { users: [
-              { id: 1, email: 'a@a.com', name: 'a' },
-              { id: 2, email: 'b@b.com', name: 'b' },
-              { id: 2, email: 'c@c.com', role: 'agent', custom_role_id: '123', name: 'c' },
+              { id: 1, email: 'a@a.com', name: 'a', locale: 'en-US' },
+              { id: 2, email: 'b@b.com', name: 'b', locale: 'en-US' },
+              { id: 2, email: 'c@c.com', role: 'agent', custom_role_id: '123', name: 'c', locale: 'en-US' },
             ] },
           ]
         })
@@ -57,9 +57,9 @@ describe('userUtils', () => {
       const users = await userUtils.getUsers(mockPaginator)
       expect(users).toEqual(
         [
-          { id: 1, email: 'a@a.com', name: 'a' },
-          { id: 2, email: 'b@b.com', name: 'b' },
-          { id: 2, email: 'c@c.com', role: 'agent', custom_role_id: '123', name: 'c' },
+          { id: 1, email: 'a@a.com', name: 'a', locale: 'en-US' },
+          { id: 2, email: 'b@b.com', name: 'b', locale: 'en-US' },
+          { id: 2, email: 'c@c.com', role: 'agent', custom_role_id: '123', name: 'c', locale: 'en-US' },
         ]
       )
     })
@@ -68,23 +68,23 @@ describe('userUtils', () => {
         .mockImplementation(async function *get() {
           yield [
             { users: [
-              { id: 1, email: 'a@a.com', name: 'a' },
-              { id: 2, email: 'b@b.com', name: 'b' },
+              { id: 1, email: 'a@a.com', name: 'a', locale: 'en-US' },
+              { id: 2, email: 'b@b.com', name: 'b', locale: 'en-US' },
             ] },
           ]
         })
       const users = await userUtils.getUsers(mockPaginator)
       expect(users).toEqual(
         [
-          { id: 1, email: 'a@a.com', name: 'a' },
-          { id: 2, email: 'b@b.com', name: 'b' },
+          { id: 1, email: 'a@a.com', name: 'a', locale: 'en-US' },
+          { id: 2, email: 'b@b.com', name: 'b', locale: 'en-US' },
         ]
       )
       const getUsersAfterCache = await userUtils.getUsers(mockPaginator)
       expect(getUsersAfterCache).toEqual(
         [
-          { id: 1, email: 'a@a.com', name: 'a' },
-          { id: 2, email: 'b@b.com', name: 'b' },
+          { id: 1, email: 'a@a.com', name: 'a', locale: 'en-US' },
+          { id: 2, email: 'b@b.com', name: 'b', locale: 'en-US' },
         ]
       )
       await userUtils.getUsers(mockPaginator)
@@ -120,9 +120,9 @@ describe('userUtils', () => {
         .mockImplementation(async function *get() {
           yield [
             { users: [
-              { id: 1, email: 'a@a.com', name: 'a' },
-              { id: 2, email: 'b@b.com', name: 'b' },
-              { id: 3, email: 'c@c.com', role: 'agent', custom_role_id: '123', name: 'c' },
+              { id: 1, email: 'a@a.com', name: 'a', locale: 'en-US' },
+              { id: 2, email: 'b@b.com', name: 'b', locale: 'en-US' },
+              { id: 3, email: 'c@c.com', role: 'agent', custom_role_id: '123', name: 'c', locale: 'en-US' },
             ] },
           ]
         })
@@ -139,8 +139,8 @@ describe('userUtils', () => {
         .mockImplementation(async function *get() {
           yield [
             { users: [
-              { id: 1, email: 'a@a.com', name: 'a' },
-              { id: 2, email: 'b@b.com', name: 'b' },
+              { id: 1, email: 'a@a.com', name: 'a', locale: 'en-US' },
+              { id: 2, email: 'b@b.com', name: 'b', locale: 'en-US' },
             ] },
           ]
         })
@@ -187,9 +187,9 @@ describe('userUtils', () => {
         .mockImplementation(async function *get() {
           yield [
             { users: [
-              { id: 1, email: 'a@a.com', name: 'a' },
-              { id: 2, email: 'b@b.com', name: 'b' },
-              { id: 3, email: 'c@c.com', role: 'agent', custom_role_id: '123', name: 'c' },
+              { id: 1, email: 'a@a.com', name: 'a', locale: 'en-US' },
+              { id: 2, email: 'b@b.com', name: 'b', locale: 'en-US' },
+              { id: 3, email: 'c@c.com', role: 'agent', custom_role_id: '123', name: 'c', locale: 'en-US' },
             ] },
           ]
         })
@@ -206,8 +206,8 @@ describe('userUtils', () => {
         .mockImplementation(async function *get() {
           yield [
             { users: [
-              { id: 1, email: 'a@a.com', name: 'a' },
-              { id: 2, email: 'b@b.com', name: 'b' },
+              { id: 1, email: 'a@a.com', name: 'a', locale: 'en-US' },
+              { id: 2, email: 'b@b.com', name: 'b', locale: 'en-US' },
             ] },
           ]
         })
@@ -787,7 +787,7 @@ describe('userUtils', () => {
     })
     it('should return deployer user email', async () => {
       mockGet
-        .mockResolvedValueOnce({ status: 200, data: { user: { id: 1, email: 'saltoo@io', role: 'admin', custom_role_id: '234234', name: 'saltoo' } } })
+        .mockResolvedValueOnce({ status: 200, data: { user: { id: 1, email: 'saltoo@io', role: 'admin', custom_role_id: '234234', name: 'saltoo', locale: 'en-US' } } })
       deployConfig = {
         defaultMissingUserFallback: '##DEPLOYER##',
       }


### PR DESCRIPTION
zendesk ensure the fetching user's locale is set to en us

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* Ensure the fetching user's locale is set to en us

---
_User Notifications_: 
None
