### PR TITLE
SALTO-3811: improve fetch changes calculation performance by filtering the plan

### DIFF
--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -590,11 +590,19 @@ export const calcFetchChanges = async (
     'calculate service-state changes',
   )
 
+  // We only care about conflicts with changes from the service, so for the next two comparisons
+  // we only need to check elements for which we have service changes
+  const serviceChangesTopLevelIDs = new Set(
+    wu(serviceChanges.values())
+      .map(changes => changes[0].change.id.createTopLevelParentID().parent.getFullName())
+  )
+  const serviceChangeIdsFilter: IDFilter = id => serviceChangesTopLevelIDs.has(id.getFullName())
+
   const pendingChanges = await log.time(
     () => getDetailedChangeTree(
       stateElements,
       workspaceElements,
-      [accountFetchFilter, partialFetchFilter],
+      [accountFetchFilter, partialFetchFilter, serviceChangeIdsFilter],
       'workspace',
     ),
     'calculate pending changes',
@@ -603,7 +611,7 @@ export const calcFetchChanges = async (
     () => getDetailedChangeTree(
       workspaceElements,
       partialFetchElementSource,
-      [accountFetchFilter, partialFetchFilter],
+      [accountFetchFilter, partialFetchFilter, serviceChangeIdsFilter],
       'service',
     ),
     'calculate service-workspace changes',


### PR DESCRIPTION
Only comparing elements that were changed in the service yields a noticeable performance improvement in the common fetch scenario where only a few elements change

---



---
_Release Notes_: 
Salto Core:
- Performance improvements in processing time after fetching elements

---
_User Notifications_: 
_None_