### PR TITLE
SALTO-3766 improve suiteapp-file-cabinet deploy

### DIFF
--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -20,7 +20,8 @@ import { CredsLease } from '@salto-io/e2e-credentials-store'
 import {
   toChange, FetchResult, InstanceElement, ReferenceExpression, isReferenceExpression,
   Element, DeployResult, Values, isStaticFile, StaticFile, FetchOptions, Change,
-  ChangeId, ChangeGroupId, ElemID, ChangeError, getChangeData, ObjectType, BuiltinTypes, isInstanceElement,
+  ChangeId, ChangeGroupId, ElemID, ChangeError, getChangeData, ObjectType, BuiltinTypes,
+  isInstanceElement, CORE_ANNOTATIONS,
 } from '@salto-io/adapter-api'
 import { findElement, naclCase } from '@salto-io/adapter-utils'
 import { MockInterface } from '@salto-io/test-utils'
@@ -197,6 +198,14 @@ describe('Netsuite adapter E2E with real account', () => {
         ...(withSuiteApp ? { [PATH]: '/Images' } : {}),
       }
     )
+
+    fileToCreate.annotate({
+      [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(
+        folderToModify.elemID,
+        undefined,
+        folderToModify,
+      )],
+    })
 
     const roleToCreateThatDependsOnCustomRecord = createInstanceElement(
       ROLE,

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -452,7 +452,6 @@ export default class NetsuiteAdapter implements AdapterOperations {
       changesToDeploy,
       groupID,
       this.additionalDependencies,
-      this.elementsSourceIndex,
     )
 
     const ids = new Set(deployResult.appliedChanges.map(

--- a/packages/netsuite-adapter/src/change_validator.ts
+++ b/packages/netsuite-adapter/src/change_validator.ts
@@ -41,6 +41,7 @@ import workflowAccountSpecificValuesValidator from './change_validators/workflow
 import exchangeRateValidator from './change_validators/currency_exchange_rate'
 import netsuiteClientValidation from './change_validators/client_validation'
 import currencyUndeployableFieldsValidator from './change_validators/currency_undeployable_fields'
+import fileCabinetInternalIdsValidator from './change_validators/file_cabinet_internal_ids'
 import NetsuiteClient from './client/client'
 import { AdditionalDependencies } from './config'
 import { Filter } from './filter'
@@ -75,6 +76,10 @@ const netsuiteChangeValidators: NetsuiteChangeValidator[] = [
 const nonSuiteAppValidators: NetsuiteChangeValidator[] = [
   removeFileCabinetValidator,
   removeStandardTypesValidator,
+]
+
+const onlySuiteAppValidators: NetsuiteChangeValidator[] = [
+  fileCabinetInternalIdsValidator,
 ]
 
 const changeErrorsToElementIDs = (changeErrors: readonly ChangeError[]): readonly string[] =>
@@ -140,7 +145,7 @@ const getChangeValidator: ({
   ) =>
     async (changes, elementSource) => {
       const validators = withSuiteApp
-        ? [...netsuiteChangeValidators]
+        ? [...netsuiteChangeValidators, ...onlySuiteAppValidators]
         : [...netsuiteChangeValidators, ...nonSuiteAppValidators]
 
       const validatorChangeErrors: ChangeError[] = _.flatten(await Promise.all([

--- a/packages/netsuite-adapter/src/change_validators/file_cabinet_internal_ids.ts
+++ b/packages/netsuite-adapter/src/change_validators/file_cabinet_internal_ids.ts
@@ -1,0 +1,142 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import path from 'path'
+import { ChangeError, CORE_ANNOTATIONS, getChangeData, InstanceElement, isAdditionChange, isInstanceElement, isReferenceExpression } from '@salto-io/adapter-api'
+import { FOLDER, INTERNAL_ID, PATH } from '../constants'
+import { isFileCabinetInstance } from '../types'
+import { NetsuiteChangeValidator } from './types'
+
+const missingParentMessage = 'Missing parent folder reference'
+const parentMismatchMessage = `Mismatch between path and "${CORE_ANNOTATIONS.PARENT}" annotation`
+
+export const getParentInternalId = (
+  instance: InstanceElement,
+  addedFolders?: Set<string>
+): { id?: number; error?: Pick<ChangeError, 'message' | 'detailedMessage'> } => {
+  const parentDirectory = path.dirname(instance.value[PATH])
+  const isTopLevelFolderPath = parentDirectory === '/'
+  const parentAnnotation = instance.annotations[CORE_ANNOTATIONS.PARENT]
+
+  if (parentAnnotation === undefined) {
+    if (!isTopLevelFolderPath) {
+      return {
+        error: {
+          message: missingParentMessage,
+          detailedMessage: `Parent folder is required (in "${CORE_ANNOTATIONS.PARENT}") `
+          + 'when trying to deploy a non top level folder or a file.',
+        },
+      }
+    }
+    return {}
+  }
+  if (isTopLevelFolderPath) {
+    return {
+      error: {
+        message: parentMismatchMessage,
+        detailedMessage: `Top level folder should not have a "${CORE_ANNOTATIONS.PARENT}" annotation. `
+        + `Change the folder path to a non top level folder path or remove the "${CORE_ANNOTATIONS.PARENT}" annotation.`,
+      },
+    }
+  }
+  if (!Array.isArray(parentAnnotation) || parentAnnotation.length !== 1) {
+    return {
+      error: {
+        message: missingParentMessage,
+        detailedMessage: `The "${CORE_ANNOTATIONS.PARENT}" annotation should be a list with one item.`,
+      },
+    }
+  }
+  const [parentRef] = parentAnnotation
+  if (
+    !isReferenceExpression(parentRef)
+    || !isInstanceElement(parentRef.topLevelParent)
+    || parentRef.elemID.typeName !== FOLDER
+  ) {
+    return {
+      error: {
+        message: missingParentMessage,
+        detailedMessage: `Parent folder (in "${CORE_ANNOTATIONS.PARENT}") must be a reference to a folder`
+        + `${typeof parentRef === 'string' ? ' , and not a path' : ''}. `
+        + 'Make sure that the parent folder is included in the fetch config, then fetch, '
+        + 'then try to deploy again.',
+      },
+    }
+  }
+  if (parentDirectory !== parentRef.topLevelParent.value[PATH]) {
+    return {
+      error: {
+        message: parentMismatchMessage,
+        detailedMessage: `The path folder (${parentDirectory}) doesn't match the path of the folder in `
+        + `"${CORE_ANNOTATIONS.PARENT}" (${parentRef.topLevelParent.value[PATH]}).`,
+      },
+    }
+  }
+  const internalId = parentRef.topLevelParent.value[INTERNAL_ID]
+  if (internalId === undefined) {
+    if (addedFolders && !addedFolders.has(parentDirectory)) {
+      return {
+        error: {
+          message: missingParentMessage,
+          detailedMessage: `The parent folder (in "${CORE_ANNOTATIONS.PARENT}") has no intenal ID. `
+          + 'Try fetching and deploying again.',
+        },
+      }
+    }
+    return {}
+  }
+  return { id: parseInt(internalId, 10) }
+}
+
+const changeValidator: NetsuiteChangeValidator = async changes => {
+  const [additionChanges, removalsOrModifications] = _.partition(changes, isAdditionChange)
+
+  const addedFolders = new Set(
+    additionChanges
+      .map(getChangeData)
+      .filter(isInstanceElement)
+      .filter(instance => instance.elemID.typeName === FOLDER)
+      .map(instance => instance.value[PATH])
+  )
+
+  const parentFolderChangeErrors = additionChanges
+    .map(getChangeData)
+    .filter(isFileCabinetInstance)
+    .map(instance => ({ instance, ...getParentInternalId(instance, addedFolders) }))
+    .filter(({ error }) => error !== undefined)
+    .map(({ instance, error }): ChangeError => ({
+      elemID: instance.elemID,
+      severity: 'Error',
+      message: error?.message ?? '',
+      detailedMessage: error?.detailedMessage ?? '',
+    }))
+
+  const missingInternalIdChangeErrors = removalsOrModifications
+    .map(getChangeData)
+    .filter(isFileCabinetInstance)
+    .filter(instance => instance.value[INTERNAL_ID] === undefined)
+    .map((instance): ChangeError => ({
+      elemID: instance.elemID,
+      severity: 'Error',
+      message: 'Missing FileCabinet item ID',
+      detailedMessage: 'This FileCabinet instance has no intenal ID. '
+      + 'Try fetching and deploying again, or edit it in Netsuite UI.',
+    }))
+
+  return parentFolderChangeErrors.concat(missingInternalIdChangeErrors)
+}
+
+export default changeValidator

--- a/packages/netsuite-adapter/src/change_validators/file_cabinet_internal_ids.ts
+++ b/packages/netsuite-adapter/src/change_validators/file_cabinet_internal_ids.ts
@@ -139,7 +139,7 @@ const changeValidator: NetsuiteChangeValidator = async changes => {
       elemID: instance.elemID,
       severity: 'Error',
       message: 'Missing FileCabinet item ID',
-      detailedMessage: 'This FileCabinet instance has no intenal ID. '
+      detailedMessage: 'This FileCabinet instance has no internal ID. '
       + 'Try fetching and deploying again, or edit it in Netsuite UI.',
     }))
 

--- a/packages/netsuite-adapter/src/change_validators/file_cabinet_internal_ids.ts
+++ b/packages/netsuite-adapter/src/change_validators/file_cabinet_internal_ids.ts
@@ -21,9 +21,6 @@ import { FILE_CABINET_PATH_SEPARATOR, FOLDER, INTERNAL_ID, PATH } from '../const
 import { isFileCabinetInstance } from '../types'
 import { NetsuiteChangeValidator } from './types'
 
-const missingParentMessage = 'Missing parent folder reference'
-const parentMismatchMessage = `Mismatch between path and "${CORE_ANNOTATIONS.PARENT}" annotation`
-
 export const getParentInternalId = (
   instance: InstanceElement,
   addedFolders?: Set<string>
@@ -38,9 +35,9 @@ export const getParentInternalId = (
         error: {
           elemID: instance.elemID,
           severity: 'Error',
-          message: missingParentMessage,
-          detailedMessage: `Parent folder is required (in "${CORE_ANNOTATIONS.PARENT}") `
-          + 'when trying to deploy a non top level folder or a file.',
+          message: 'Missing a reference to the parent folder',
+          detailedMessage: `The parent folder (under '${CORE_ANNOTATIONS.PARENT}') is required`
+          + ' when trying to deploy a non-top-level folder or file.',
         },
       }
     }
@@ -51,9 +48,9 @@ export const getParentInternalId = (
       error: {
         elemID: instance.elemID,
         severity: 'Error',
-        message: parentMismatchMessage,
-        detailedMessage: `Top level folder should not have a "${CORE_ANNOTATIONS.PARENT}" annotation. `
-        + `Change the folder path to a non top level folder path or remove the "${CORE_ANNOTATIONS.PARENT}" annotation.`,
+        message: `Mismatch between the path folder and the '${CORE_ANNOTATIONS.PARENT}'`,
+        detailedMessage: 'Top-level folders should not have a parent.'
+        + ` Change the folder path to a non-top-level folder path or remove the '${CORE_ANNOTATIONS.PARENT}'.`,
       },
     }
   }
@@ -62,8 +59,8 @@ export const getParentInternalId = (
       error: {
         elemID: instance.elemID,
         severity: 'Error',
-        message: missingParentMessage,
-        detailedMessage: `The "${CORE_ANNOTATIONS.PARENT}" annotation should be a list with one item.`,
+        message: `Invalid '${CORE_ANNOTATIONS.PARENT}'`,
+        detailedMessage: `'${CORE_ANNOTATIONS.PARENT}' should be a list of one item.`,
       },
     }
   }
@@ -77,11 +74,10 @@ export const getParentInternalId = (
       error: {
         elemID: instance.elemID,
         severity: 'Error',
-        message: missingParentMessage,
-        detailedMessage: `Parent folder (in "${CORE_ANNOTATIONS.PARENT}") must be a reference to a folder`
-        + `${typeof parentRef === 'string' ? ' , and not a path' : ''}. `
-        + 'Make sure that the parent folder is included in the fetch config, then fetch, '
-        + 'then try to deploy again.',
+        message: 'Can\'t resolve the reference to the parent folder',
+        detailedMessage: `The parent folder (under '${CORE_ANNOTATIONS.PARENT}') must be a valid reference to a folder${
+          typeof parentRef === 'string' ? ' - not a path' : ''
+        }. Include the parent folder in the environment configuration, then fetch and deploy again.`,
       },
     }
   }
@@ -90,9 +86,9 @@ export const getParentInternalId = (
       error: {
         elemID: instance.elemID,
         severity: 'Error',
-        message: parentMismatchMessage,
-        detailedMessage: `The path folder (${parentDirectory}) doesn't match the path of the folder in `
-        + `"${CORE_ANNOTATIONS.PARENT}" (${parentRef.topLevelParent.value[PATH]}).`,
+        message: `Mismatch between the path folder and the '${CORE_ANNOTATIONS.PARENT}'`,
+        detailedMessage: `The path folder (${parentDirectory}) doesn't match the path of the`
+        + ` '${CORE_ANNOTATIONS.PARENT}' (${parentRef.topLevelParent.value[PATH]}).`,
       },
     }
   }
@@ -103,9 +99,9 @@ export const getParentInternalId = (
         error: {
           elemID: instance.elemID,
           severity: 'Error',
-          message: missingParentMessage,
-          detailedMessage: `The parent folder (in "${CORE_ANNOTATIONS.PARENT}") has no internal ID. `
-          + 'Try fetching and deploying again.',
+          message: 'Invalid parent folder',
+          detailedMessage: `The parent folder (under '${CORE_ANNOTATIONS.PARENT}') is missing its internal ID.`
+          + ' Fetch and deploy again.',
         },
       }
     }
@@ -138,9 +134,9 @@ const changeValidator: NetsuiteChangeValidator = async changes => {
     .map((instance): ChangeError => ({
       elemID: instance.elemID,
       severity: 'Error',
-      message: 'Missing FileCabinet item ID',
-      detailedMessage: 'This FileCabinet instance has no internal ID. '
-      + 'Try fetching and deploying again, or edit it in Netsuite UI.',
+      message: `Invalid FileCabinet ${instance.elemID.typeName}`,
+      detailedMessage: `This FileCabinet ${instance.elemID.typeName} is missing its internal ID.`
+      + ' Fetch and deploy again, or edit it in Netsuite UI.',
     }))
 
   return parentFolderChangeErrors.concat(missingInternalIdChangeErrors)

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -32,7 +32,6 @@ import { toCustomizationInfo } from '../transformer'
 import { isSdfCreateOrUpdateGroupId, isSdfDeleteGroupId, isSuiteAppCreateRecordsGroupId, isSuiteAppDeleteRecordsGroupId, isSuiteAppUpdateRecordsGroupId, SUITEAPP_CREATING_FILES_GROUP_ID, SUITEAPP_DELETING_FILES_GROUP_ID, SUITEAPP_FILE_CABINET_GROUPS, SUITEAPP_UPDATING_CONFIG_GROUP_ID, SUITEAPP_UPDATING_FILES_GROUP_ID } from '../group_changes'
 import { DeployResult, getElementValueOrAnnotations, isFileCabinetInstance } from '../types'
 import { APPLICATION_ID, PATH, SCRIPT_ID } from '../constants'
-import { LazyElementsSourceIndexes } from '../elements_source_index/types'
 import { toConfigDeployResult, toSetConfigTypes } from '../suiteapp_config_elements'
 import { FeaturesDeployError, MissingManifestFeaturesError, getChangesElemIdsToRemove, toFeaturesDeployPartialSuccessResult } from './errors'
 import { Graph, GraphNode, SDFObjectNode } from './graph_utils'
@@ -383,7 +382,6 @@ export default class NetsuiteClient {
     changes: Change[],
     groupID: string,
     additionalSdfDependencies: AdditionalDependencies,
-    elementsSourceIndex: LazyElementsSourceIndexes,
   ): Promise<DeployResult> {
     if (isSdfCreateOrUpdateGroupId(groupID)) {
       return this.sdfDeploy({
@@ -398,7 +396,6 @@ export default class NetsuiteClient {
         ? this.suiteAppFileCabinet.deploy(
           instancesChanges,
           GROUP_TO_DEPLOY_TYPE[groupID],
-          elementsSourceIndex
         )
         : { errors: [new Error(`Salto SuiteApp is not configured and therefore changes group "${groupID}" cannot be deployed`)], appliedChanges: [] }
     }
@@ -473,11 +470,6 @@ export default class NetsuiteClient {
 
   public isSuiteAppConfigured(): boolean {
     return this.suiteAppClient !== undefined
-  }
-
-  public getPathInternalId(path: string): number | undefined {
-    const pathToId = this.suiteAppFileCabinet?.getPathToIdMap() ?? {}
-    return pathToId[path]
   }
 
   private static logDecorator = decorators.wrapMethodWith(

--- a/packages/netsuite-adapter/src/elements_source_index/elements_source_index.ts
+++ b/packages/netsuite-adapter/src/elements_source_index/elements_source_index.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import { CORE_ANNOTATIONS, InstanceElement, isInstanceElement, ReadOnlyElementsSource, ElemID, Element, isObjectType, Value, ObjectType } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
-import { getElementValueOrAnnotations, isCustomRecordType, isFileCabinetInstance } from '../types'
+import { getElementValueOrAnnotations, isCustomRecordType } from '../types'
 import { ElementsSourceIndexes, LazyElementsSourceIndexes, ServiceIdRecords } from './types'
 import { getFieldInstanceTypes } from '../data_elements/custom_fields'
 import { getElementServiceIdRecords } from '../filters/element_references'
@@ -87,7 +87,6 @@ const createIndexes = async (elementsSource: ReadOnlyElementsSource):
   const serviceIdRecordsIndex: ServiceIdRecords = {}
   const internalIdsIndex: Record<string, ElemID> = {}
   const customFieldsIndex: Record<string, InstanceElement[]> = {}
-  const pathToInternalIdsIndex: Record<string, number> = {}
   const elemIdToChangeByIndex: Record<string, string> = {}
   const mapKeyFieldsIndex: Record<string, string | string[]> = {}
   const elemIdToChangeAtIndex: Record<string, string> = {}
@@ -104,15 +103,6 @@ const createIndexes = async (elementsSource: ReadOnlyElementsSource):
         }
         customFieldsIndex[type].push(element)
       })
-  }
-
-  const updatePathToInternalIdsIndex = (element: InstanceElement): void => {
-    if (!isFileCabinetInstance(element)) return
-
-    const { path, internalId } = element.value
-    if (path === undefined || internalId === undefined) return
-
-    pathToInternalIdsIndex[path] = parseInt(internalId, 10)
   }
 
   const updateElemIdToChangedByIndex = (element: Element): void => {
@@ -148,7 +138,6 @@ const createIndexes = async (elementsSource: ReadOnlyElementsSource):
         await updateServiceIdRecordsIndex(element)
         await updateInternalIdsIndex(element)
         updateCustomFieldsIndex(element)
-        updatePathToInternalIdsIndex(element)
         updateElemIdToChangedByIndex(element)
         updateElemIdToChangedAtIndex(element)
       }
@@ -167,7 +156,6 @@ const createIndexes = async (elementsSource: ReadOnlyElementsSource):
     serviceIdRecordsIndex,
     internalIdsIndex,
     customFieldsIndex,
-    pathToInternalIdsIndex,
     elemIdToChangeByIndex,
     mapKeyFieldsIndex,
     elemIdToChangeAtIndex,

--- a/packages/netsuite-adapter/src/elements_source_index/types.ts
+++ b/packages/netsuite-adapter/src/elements_source_index/types.ts
@@ -21,7 +21,6 @@ export type ElementsSourceIndexes = {
   serviceIdRecordsIndex: ServiceIdRecords
   internalIdsIndex: Record<string, ElemID>
   customFieldsIndex: Record<string, InstanceElement[]>
-  pathToInternalIdsIndex: Record<string, number>
   elemIdToChangeByIndex: Record<string, string>
   mapKeyFieldsIndex: Record<string, string | string[]>
   elemIdToChangeAtIndex: Record<string, string>

--- a/packages/netsuite-adapter/src/filters/add_parent_folder.ts
+++ b/packages/netsuite-adapter/src/filters/add_parent_folder.ts
@@ -18,7 +18,7 @@ import path from 'path'
 import { isFileCabinetInstance } from '../types'
 import { FilterCreator } from '../filter'
 import { SUITEAPP_CREATING_FILES_GROUP_ID } from '../group_changes'
-import { PARENT } from '../constants'
+import { FILE_CABINET_PATH_SEPARATOR, PARENT } from '../constants'
 import { getParentInternalId } from '../change_validators/file_cabinet_internal_ids'
 
 const filterCreator: FilterCreator = ({ changesGroupId }) => ({
@@ -26,7 +26,7 @@ const filterCreator: FilterCreator = ({ changesGroupId }) => ({
   onFetch: async elements => {
     elements
       .filter(isFileCabinetInstance)
-      .filter(instance => path.dirname(instance.value.path) !== '/')
+      .filter(instance => path.dirname(instance.value.path) !== FILE_CABINET_PATH_SEPARATOR)
       .forEach(instance => {
         instance.annotations[CORE_ANNOTATIONS.PARENT] = [`[${path.dirname(instance.value.path)}]`]
       })

--- a/packages/netsuite-adapter/src/service_url/file_cabinet.ts
+++ b/packages/netsuite-adapter/src/service_url/file_cabinet.ts
@@ -18,12 +18,12 @@ import { CORE_ANNOTATIONS, InstanceElement } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { ServiceUrlSetter } from './types'
 import { isFileCabinetInstance, isFileInstance } from '../types'
-import NetsuiteClient from '../client/client'
+import { INTERNAL_ID } from '../constants'
 
 const log = logger(module)
 
-const generateUrl = (element: InstanceElement, client: NetsuiteClient): string | undefined => {
-  const id = element.value.internalId ?? client.getPathInternalId(element.value.path)
+const generateUrl = (element: InstanceElement): string | undefined => {
+  const id = element.value[INTERNAL_ID]
   if (id === undefined) {
     log.warn(`Did not find the internal id of ${element.elemID.getFullName()}`)
     return undefined
@@ -36,7 +36,7 @@ const generateUrl = (element: InstanceElement, client: NetsuiteClient): string |
 
 const setServiceUrl: ServiceUrlSetter = (elements, client) => {
   elements.filter(isFileCabinetInstance).forEach(element => {
-    const url = generateUrl(element, client)
+    const url = generateUrl(element)
     if (url !== undefined) {
       element.annotations[CORE_ANNOTATIONS.SERVICE_URL] = new URL(url, client.url).href
     }

--- a/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
@@ -608,7 +608,7 @@ SuiteAppFileCabinetOperations => {
         const failedInstance = getChangeData(failedChange)
         const children = changesByParentDirectory[failedInstance.value.path] ?? []
         if (children.length > 0) {
-          log.debug('adding %s internal id as parent for %d childern files/folders', failedInstance.value.path, children.length)
+          log.debug('skipping %d childern files/folders of %s that failed the deploy', children.length, failedInstance.value.path)
         }
         children.forEach(change => {
           pathsToSkip.add(getChangeData(change).value.path)

--- a/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
@@ -13,10 +13,10 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, isStaticFile } from '@salto-io/adapter-api'
+import { Element, Change, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, isStaticFile, StaticFile } from '@salto-io/adapter-api'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
-import { chunks, collections, promises, values } from '@salto-io/lowerdash'
+import { chunks, promises, values } from '@salto-io/lowerdash'
 import Ajv from 'ajv'
 import _ from 'lodash'
 import path from 'path'
@@ -24,16 +24,40 @@ import { ReadFileEncodingError, ReadFileInsufficientPermissionError, RetryableEr
 import SuiteAppClient from './client/suiteapp_client/suiteapp_client'
 import { ExistingFileCabinetInstanceDetails, FileCabinetInstanceDetails } from './client/suiteapp_client/types'
 import { ImportFileCabinetResult } from './client/types'
-import { INTERNAL_ID } from './constants'
-import { LazyElementsSourceIndexes } from './elements_source_index/types'
+import { INTERNAL_ID, PARENT, PATH } from './constants'
 import { NetsuiteQuery } from './query'
 import { DeployResult, isFileCabinetType, isFileInstance } from './types'
-
-const { awu } = collections.asynciterable
 
 const log = logger(module)
 
 export type DeployType = 'add' | 'update' | 'delete'
+
+type WithPath = Record<typeof PATH, string>
+type WithInternalId = Record<typeof INTERNAL_ID, string>
+type WithParent = Partial<Record<typeof PARENT, number>>
+type FileCabinetInstance = Element & Omit<InstanceElement, 'value'> & {
+  value: WithPath & WithInternalId & WithParent & {
+    bundleable?: boolean
+    isinactive?: boolean
+    description?: string
+    availablewithoutlogin?: boolean
+    hideinbundle?: boolean
+    link?: string
+    content?: StaticFile | string
+    isprivate?: boolean
+  }
+}
+
+type ChangeWithId = Change<FileCabinetInstance> & { id: number }
+type FileCabinetDeployResult = {
+  appliedChanges: ChangeWithId[]
+  failedChanges: Change<FileCabinetInstance>[]
+  errors: Error[]
+}
+
+type DeployFunction = (
+  changes: ReadonlyArray<Change<FileCabinetInstance>>
+) => Promise<DeployResult>
 
 const FOLDERS_SCHEMA = {
   type: 'array',
@@ -126,11 +150,9 @@ const MAX_ITEMS_IN_WHERE_QUERY = 200
 
 export type SuiteAppFileCabinetOperations = {
   importFileCabinet: (query: NetsuiteQuery) => Promise<ImportFileCabinetResult>
-  getPathToIdMap: () => Record<string, number>
   deploy: (
     changes: ReadonlyArray<Change<InstanceElement>>,
     type: DeployType,
-    elementsSourceIndex: LazyElementsSourceIndexes
   ) => Promise<DeployResult>
 }
 
@@ -177,10 +199,17 @@ export const isChangeDeployable = async (
   return true
 }
 
+const groupChangeyDepth = (
+  changes: ReadonlyArray<Change<FileCabinetInstance>>
+): [string, Change<FileCabinetInstance>[]][] => _(changes)
+  .groupBy(change => getChangeData(change).value.path.split('/').length)
+  .entries()
+  .sortBy(([depth]) => depth)
+  .value()
+
 export const createSuiteAppFileCabinetOperations = (suiteAppClient: SuiteAppClient):
 SuiteAppFileCabinetOperations => {
   let fileCabinetResults: FileCabinetResults
-  let pathToIdResults: Record<string, number>
 
   const queryFolders = (
     whereQuery: string
@@ -438,81 +467,45 @@ SuiteAppFileCabinetOperations => {
     }
   }
 
-  const getPathToIdMap = (): Record<string, number> => {
-    if (pathToIdResults === undefined) {
-      log.debug('creating pathToId mapping')
-      if (fileCabinetResults === undefined) {
-        throw new Error('missing fileCabinet results cache')
-      }
-      const { foldersResults, filesResults } = fileCabinetResults
-      const idToFolder = _.keyBy(foldersResults, folder => folder.id)
-      pathToIdResults = Object.fromEntries([
-        ...filesResults.map(file => [
-          `/${[...getFullPath(idToFolder[file.folder], idToFolder), file.name].join('/')}`,
-          parseInt(file.id, 10),
-        ]),
-        ...foldersResults.map(folder => [
-          `/${getFullPath(folder, idToFolder).join('/')}`,
-          parseInt(folder.id, 10),
-        ]),
-      ])
-    }
-    return pathToIdResults
-  }
+  const convertToFileCabinetDetails = async (
+    change: Change<FileCabinetInstance>,
+    type: DeployType,
+  ): Promise<FileCabinetInstanceDetails> => {
+    const instance = getChangeData(change)
 
-  const convertToFileCabinetDetails = async (params: {
-    change: Change<InstanceElement>
-  } & ({
-    type: 'delete' | 'update'
-  } | {
-    type: 'add'
-    pathToId: Record<string, number>
-  })): Promise<FileCabinetInstanceDetails | Error> => {
-    const instance = getChangeData(params.change)
-    const dirname = path.dirname(instance.value.path)
-    if (dirname !== '/' && params.type === 'add' && !(dirname in params.pathToId)) {
-      return new Error(`Directory ${dirname} was not found when attempting to deploy a file with path ${instance.value.path}`)
+    const id = type !== 'add'
+      ? parseInt(getChangeData(change).value.internalId, 10)
+      : undefined
+
+    const parentFolderInternalId = type === 'add'
+      ? instance.value.parent
+      : undefined
+
+    const base = {
+      id,
+      path: instance.value.path,
+      bundleable: instance.value.bundleable ?? false,
+      isInactive: instance.value.isinactive ?? false,
+      description: instance.value.description ?? '',
     }
 
     return isFileInstance(instance)
       ? {
+        ...base,
         type: 'file',
-        path: instance.value.path,
-        folder: params.type === 'add' ? params.pathToId[dirname] : undefined,
-        bundleable: instance.value.bundleable ?? false,
-        isInactive: instance.value.isinactive ?? false,
+        folder: parentFolderInternalId,
         isOnline: instance.value.availablewithoutlogin ?? false,
         hideInBundle: instance.value.hideinbundle ?? false,
-        description: instance.value.description ?? '',
         ...instance.value.link === undefined
           ? { content: await getContent(instance.value.content) }
           : { url: instance.value.link },
       }
       : {
+        ...base,
         type: 'folder',
-        path: instance.value.path,
-        parent: dirname !== '/' && params.type === 'add' ? params.pathToId[dirname] : undefined,
-        bundleable: instance.value.bundleable ?? false,
-        isInactive: instance.value.isinactive ?? false,
+        parent: parentFolderInternalId,
         isPrivate: instance.value.isprivate ?? false,
-        description: instance.value.description ?? '',
       }
-  }
-
-  const convertToExistingFileCabinetDetails = async (
-    change: Change<InstanceElement>,
-    type: 'delete' | 'update'
-  ): Promise<ExistingFileCabinetInstanceDetails | Error> => {
-    const details = await convertToFileCabinetDetails({ change, type })
-    if (details instanceof Error) {
-      return details
-    }
-    const instance = getChangeData(change)
-    if (instance.value[INTERNAL_ID] === undefined) {
-      log.warn(`Failed to find the internal id of the file ${instance.value.path}`)
-      return new Error(`Failed to find the internal id of the file ${instance.value.path}`)
-    }
-    return { ...details, id: parseInt(instance.value[INTERNAL_ID], 10) }
   }
 
   const deployInstances = async (
@@ -533,132 +526,148 @@ SuiteAppFileCabinetOperations => {
   }
 
   const deployChunk = async (
-    chunk: ReadonlyArray<Change<InstanceElement>>,
-    pathToId: Record<string, number>,
-    type: DeployType
-  ): Promise<DeployResult> => {
+    chunk: ReadonlyArray<Change<FileCabinetInstance>>,
+    type: DeployType,
+  ): Promise<FileCabinetDeployResult> => {
     log.debug(`Deploying chunk of ${chunk.length} file changes`)
 
-    const instancesDetails = await awu(chunk).map(
+    const changes = await Promise.all(chunk.map(
       async change => ({
-        details: type === 'add'
-          ? await convertToFileCabinetDetails({ change, type, pathToId })
-          : await convertToExistingFileCabinetDetails(change, type),
+        details: await convertToFileCabinetDetails(change, type),
         change,
       })
-    ).toArray()
-
-    const [errorsInstances, validInstances] = _.partition(
-      instancesDetails,
-      ({ details }) => details instanceof Error,
-    )
+    ))
 
     try {
-      const deployResults = validInstances.length > 0 ? await deployInstances(validInstances.map(
-        ({ details }) => details as FileCabinetInstanceDetails
-      ), type) : []
+      const deployResults = await deployInstances(
+        changes.map(({ details }) => details),
+        type
+      )
 
       log.debug(`Deployed chunk of ${chunk.length} file changes`)
 
-      const [deployErrors, deployChanges] = _(deployResults)
-        .map((res, index) => ({ res, change: validInstances[index].change }))
-        .partition(({ res }) => res instanceof Error)
-        .value()
-
-      deployChanges.forEach(deployedChange => {
-        pathToId[getChangeData(deployedChange.change).value.path] = deployedChange.res as number
-      })
+      const [deployErrors, deployChanges] = _.partition(
+        deployResults.map((res, index) => ({ res, change: changes[index].change })),
+        ({ res }) => res instanceof Error
+      )
 
       return {
-        errors: [
-          ...deployErrors.map(({ res }) => res as Error),
-          ...errorsInstances.map(({ details }) => details as Error),
-        ],
-        appliedChanges: deployChanges.map(({ change }) => change),
+        appliedChanges: deployChanges.map(({ change, res }) => ({ ...change, id: res as number })),
+        failedChanges: deployErrors.map(({ change }) => change),
+        errors: deployErrors.map(({ res }) => res as Error),
       }
     } catch (e) {
       return {
-        errors: [
-          e,
-          ...errorsInstances.map(({ details }) => details as Error),
-        ],
+        errors: [e],
         appliedChanges: [],
+        failedChanges: [...chunk],
       }
     }
   }
 
   const deployChanges = async (
-    changes: ReadonlyArray<Change<InstanceElement>>,
-    pathToId: Record<string, number>,
-    type: DeployType): Promise<DeployResult> => {
+    changes: ReadonlyArray<Change<FileCabinetInstance>>,
+    type: DeployType,
+  ): Promise<FileCabinetDeployResult> => {
     const deployChunkResults = await Promise.all(
       _.chunk(changes, DEPLOY_CHUNK_SIZE)
-        .map(chunk => deployChunk(chunk, pathToId, type))
+        .map(chunk => deployChunk(chunk, type))
     )
     return {
-      appliedChanges: deployChunkResults
-        .flatMap(deployChunkResult => deployChunkResult.appliedChanges),
-      errors: deployChunkResults.flatMap(deployChunkResult => deployChunkResult.errors),
-      ...type === 'add' ? {
-        elemIdToInternalId: _(changes)
-          .map(getChangeData)
-          .filter(change => pathToId[change.value.path] !== undefined)
-          .keyBy(change => change.elemID.getFullName())
-          .mapValues(change => pathToId[change.value.path].toString())
-          .value(),
-      } : {},
+      appliedChanges: deployChunkResults.flatMap(res => res.appliedChanges),
+      failedChanges: deployChunkResults.flatMap(res => res.failedChanges),
+      errors: deployChunkResults.flatMap(res => res.errors),
     }
   }
 
-  const deployAdditionsOrDeletions = async (
-    changes: ReadonlyArray<Change<InstanceElement>>,
-    pathToId: Record<string, number>,
-    type: 'add' | 'delete'
-  ): Promise<DeployResult> => {
-    const changesGroups = _(changes)
-      .groupBy(change => getChangeData(change).value.path.split('/').length)
-      .entries()
-      .sortBy(([depth]) => depth)
-      .value()
+  const deployAdditions: DeployFunction = async allChanges => {
+    const changesByParentDirectory = _.groupBy(
+      allChanges,
+      change => path.dirname(getChangeData(change).value.path)
+    )
+    const pathsToSkip = new Set<string>()
+    const elemIdToInternalId: Record<string, string> = {}
 
-    const orderedChangesGroups = type === 'delete' ? changesGroups.reverse() : changesGroups
-
-    const deployResults = await promises.array.series(orderedChangesGroups
-      .map(([depth, group]) => () => {
-        if (type === 'delete') {
-          log.debug(`Deleting ${group.length} files with depth of ${depth}`)
-        } else {
-          log.debug(`Deploying ${group.length} new files with depth of ${depth}`)
+    const deployGroup = async (changes: Change<FileCabinetInstance>[]): Promise<DeployResult> => {
+      const { appliedChanges, failedChanges, errors } = await deployChanges(
+        changes.filter(change => !pathsToSkip.has(getChangeData(change).value.path)),
+        'add'
+      )
+      appliedChanges.forEach(({ id, ...appliedChange }) => {
+        const appliedInstance = getChangeData(appliedChange)
+        elemIdToInternalId[appliedInstance.elemID.getFullName()] = id.toString()
+        const children = changesByParentDirectory[appliedInstance.value.path] ?? []
+        if (children.length > 0) {
+          log.debug('adding %s internal id as parent for %d childern files/folders', appliedInstance.value.path, children.length)
         }
-
-        return deployChanges(group, pathToId, type)
-      }))
-    return {
-      appliedChanges: deployResults.flatMap(deployResult => deployResult.appliedChanges),
-      errors: deployResults.flatMap(deployResult => deployResult.errors),
-      elemIdToInternalId: deployResults
-        .map(deployResult => deployResult.elemIdToInternalId)
-        .reduce((val1, val2) => ({ ...val1, ...val2 })),
+        children.forEach(change => {
+          getChangeData(change).value.parent = id
+        })
+      })
+      failedChanges.forEach(failedChange => {
+        const failedInstance = getChangeData(failedChange)
+        const children = changesByParentDirectory[failedInstance.value.path] ?? []
+        if (children.length > 0) {
+          log.debug('adding %s internal id as parent for %d childern files/folders', failedInstance.value.path, children.length)
+        }
+        children.forEach(change => {
+          pathsToSkip.add(getChangeData(change).value.path)
+        })
+      })
+      return {
+        appliedChanges,
+        errors,
+      }
     }
+
+    const orderedChangesGroups = groupChangeyDepth(allChanges)
+    const deployResults = await promises.array.series(orderedChangesGroups
+      .map(([depth, group]) => async () => {
+        log.debug(`Deploying ${group.length} new files with depth of ${depth}`)
+        return deployGroup(group)
+      }))
+
+    const dependenciesError = pathsToSkip.size > 0
+      ? new Error(`Can't deploy the following files/folders because their parent folders deploy failed:\n${
+        Array.from(pathsToSkip).map(failedPath => `- ${failedPath}`).join('\n')}`)
+      : []
+
+    return {
+      appliedChanges: deployResults.flatMap(res => res.appliedChanges),
+      errors: deployResults.flatMap(res => res.errors).concat(dependenciesError),
+      elemIdToInternalId,
+    }
+  }
+
+  const deployDeletions: DeployFunction = async changes => {
+    const orderedChangesGroups = groupChangeyDepth(changes).reverse()
+    const deployResults = await promises.array.series(orderedChangesGroups
+      .map(([depth, group]) => async () => {
+        log.debug(`Deleting ${group.length} files with depth of ${depth}`)
+        return deployChanges(group, 'delete')
+      }))
+
+    return {
+      appliedChanges: deployResults.flatMap(res => res.appliedChanges),
+      errors: deployResults.flatMap(res => res.errors),
+    }
+  }
+
+  const deployUpdates: DeployFunction = changes => deployChanges(changes, 'update')
+
+  const typeToDeployFunction: Record<DeployType, DeployFunction> = {
+    add: deployAdditions,
+    delete: deployDeletions,
+    update: deployUpdates,
   }
 
   const deploy = async (
     changes: ReadonlyArray<Change<InstanceElement>>,
     type: DeployType,
-    elementsSourceIndex: LazyElementsSourceIndexes
-  ): Promise<DeployResult> => {
-    const { pathToInternalIdsIndex = {} } = type === 'add'
-      ? await elementsSourceIndex.getIndexes()
-      : {}
-
-    return type === 'update'
-      ? deployChanges(changes, pathToInternalIdsIndex, 'update')
-      : deployAdditionsOrDeletions(changes, pathToInternalIdsIndex, type)
-  }
+  ): Promise<DeployResult> => typeToDeployFunction[type](changes as ReadonlyArray<Change<FileCabinetInstance>>)
 
   return {
     importFileCabinet,
-    getPathToIdMap,
     deploy,
   }
 }

--- a/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
@@ -547,13 +547,13 @@ SuiteAppFileCabinetOperations => {
       log.debug(`Deployed chunk of ${chunk.length} file changes`)
 
       const [deployErrors, deployChanges] = _.partition(
-        deployResults.map((res, index) => ({ res, change: changes[index].change })),
+        deployResults.map((res, index) => ({ res, ...changes[index].change })),
         ({ res }) => res instanceof Error
       )
 
       return {
-        appliedChanges: deployChanges.map(({ change, res }) => ({ ...change, id: res as number })),
-        failedChanges: deployErrors.map(({ change }) => change),
+        appliedChanges: deployChanges.map(({ res, ...change }) => ({ ...change, id: res as number })),
+        failedChanges: deployErrors,
         errors: deployErrors.map(({ res }) => res as Error),
       }
     } catch (e) {

--- a/packages/netsuite-adapter/test/change_validators/file_cabinet_internal_ids.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/file_cabinet_internal_ids.test.ts
@@ -1,0 +1,163 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { CORE_ANNOTATIONS, InstanceElement, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { INTERNAL_ID, PATH } from '../../src/constants'
+import fileCabinetInternalIdsValidator from '../../src/change_validators/file_cabinet_internal_ids'
+import { fileType, folderType } from '../../src/types/file_cabinet_types'
+
+describe('suiteapp file cabinet internal ids validator', () => {
+  const file = fileType()
+  const folder = folderType()
+  describe('removals/modifications', () => {
+    let removedFile: InstanceElement
+    let updatedBefore: InstanceElement
+    let updatedAfter: InstanceElement
+    beforeEach(() => {
+      removedFile = new InstanceElement('someFile', file)
+      updatedBefore = new InstanceElement('someFolder', folder)
+      updatedAfter = new InstanceElement('someFolder', folder, { description: 'updated' })
+    })
+    it('should not have change errors when there are internal ids', async () => {
+      removedFile.value[INTERNAL_ID] = '101'
+      updatedBefore.value[INTERNAL_ID] = '2'
+      updatedAfter.value[INTERNAL_ID] = '2'
+      const result = await fileCabinetInternalIdsValidator([
+        toChange({ before: removedFile }),
+        toChange({ before: updatedBefore, after: updatedAfter }),
+      ])
+      expect(result).toHaveLength(0)
+    })
+    it('should have change errors when there are no internal ids', async () => {
+      const result = await fileCabinetInternalIdsValidator([
+        toChange({ before: removedFile }),
+        toChange({ before: updatedBefore, after: updatedAfter }),
+      ])
+      expect(result).toHaveLength(2)
+    })
+  })
+  describe('additions', () => {
+    let addedFile: InstanceElement
+    let addedFolder: InstanceElement
+    let existingFolder: InstanceElement
+    beforeEach(() => {
+      addedFile = new InstanceElement('someFile', file)
+      addedFolder = new InstanceElement('someFolder1', folder)
+      existingFolder = new InstanceElement('someFolder', folder)
+    })
+    it('should not have change errors', async () => {
+      existingFolder.value[PATH] = '/someFolder'
+      existingFolder.value[INTERNAL_ID] = '2'
+      addedFolder.value[PATH] = '/someFolder/someFolder1'
+      addedFolder.annotations[CORE_ANNOTATIONS.PARENT] = [new ReferenceExpression(
+        existingFolder.elemID,
+        undefined,
+        existingFolder
+      )]
+      addedFile.value[PATH] = '/someFolder/someFolder1/someFile'
+      addedFile.annotations[CORE_ANNOTATIONS.PARENT] = [new ReferenceExpression(
+        addedFolder.elemID,
+        undefined,
+        addedFolder
+      )]
+      const result = await fileCabinetInternalIdsValidator([
+        toChange({ after: addedFile }),
+        toChange({ after: addedFolder }),
+      ])
+      expect(result).toHaveLength(0)
+    })
+    it('should not have change errors when path is top level', async () => {
+      addedFolder.value[PATH] = '/someFolder1'
+      const result = await fileCabinetInternalIdsValidator([
+        toChange({ after: addedFolder }),
+      ])
+      expect(result).toHaveLength(0)
+    })
+    it('should have change error when path is not top level and _parent is undefined', async () => {
+      addedFolder.value[PATH] = '/someFolder/someFolder1'
+      const result = await fileCabinetInternalIdsValidator([
+        toChange({ after: addedFolder }),
+      ])
+      expect(result).toHaveLength(1)
+    })
+    it('should have change error when path is top level and _parent is not undefined', async () => {
+      addedFolder.value[PATH] = '/someFolder1'
+      addedFolder.annotations[CORE_ANNOTATIONS.PARENT] = [new ReferenceExpression(
+        existingFolder.elemID,
+        undefined,
+        existingFolder
+      )]
+      const result = await fileCabinetInternalIdsValidator([
+        toChange({ after: addedFolder }),
+      ])
+      expect(result).toHaveLength(1)
+    })
+    it('should have change error when _parent is not a one item list', async () => {
+      addedFile.value[PATH] = '/someFolder/someFile'
+      addedFile.annotations[CORE_ANNOTATIONS.PARENT] = '/someFolder'
+      addedFolder.value[PATH] = '/someFolder/someFolder1'
+      addedFolder.annotations[CORE_ANNOTATIONS.PARENT] = [
+        '/',
+        '/someFolder',
+      ]
+      const result = await fileCabinetInternalIdsValidator([
+        toChange({ after: addedFile }),
+        toChange({ after: addedFolder }),
+      ])
+      expect(result).toHaveLength(2)
+    })
+    it('should have change error when _parent is not a reference to a folder', async () => {
+      addedFile.value[PATH] = '/someFolder/someFile'
+      addedFile.annotations[CORE_ANNOTATIONS.PARENT] = ['[/someFolder]']
+      addedFolder.value[PATH] = '/someFolder/someFolder1'
+      addedFolder.annotations[CORE_ANNOTATIONS.PARENT] = [new ReferenceExpression(
+        addedFile.elemID,
+        undefined,
+        addedFile
+      )]
+      const result = await fileCabinetInternalIdsValidator([
+        toChange({ after: addedFile }),
+        toChange({ after: addedFolder }),
+      ])
+      expect(result).toHaveLength(2)
+    })
+    it('should have change error when path does not match _parent', async () => {
+      addedFolder.value[PATH] = '/someFolder/someFolder1'
+      existingFolder.value[PATH] = '/someFolder2'
+      addedFolder.annotations[CORE_ANNOTATIONS.PARENT] = [new ReferenceExpression(
+        existingFolder.elemID,
+        undefined,
+        existingFolder
+      )]
+      const result = await fileCabinetInternalIdsValidator([
+        toChange({ after: addedFolder }),
+      ])
+      expect(result).toHaveLength(1)
+    })
+    it('should have change error when the parent folder has no internal id', async () => {
+      existingFolder.value[PATH] = '/someFolder'
+      addedFolder.value[PATH] = '/someFolder/someFolder1'
+      addedFolder.annotations[CORE_ANNOTATIONS.PARENT] = [new ReferenceExpression(
+        existingFolder.elemID,
+        undefined,
+        existingFolder
+      )]
+      const result = await fileCabinetInternalIdsValidator([
+        toChange({ after: addedFolder }),
+      ])
+      expect(result).toHaveLength(1)
+    })
+  })
+})

--- a/packages/netsuite-adapter/test/elements_source_index.test.ts
+++ b/packages/netsuite-adapter/test/elements_source_index.test.ts
@@ -16,7 +16,6 @@
 import { collections } from '@salto-io/lowerdash'
 import { CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, ReadOnlyElementsSource } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { getFileCabinetTypes } from '../src/types/file_cabinet_types'
 import { entitycustomfieldType } from '../src/autogen/types/standard_types/entitycustomfield'
 import { CUSTOM_RECORD_TYPE, INTERNAL_ID, METADATA_TYPE, NETSUITE, SCRIPT_ID } from '../src/constants'
 import { createElementsSourceIndex } from '../src/elements_source_index/elements_source_index'
@@ -33,8 +32,6 @@ describe('createElementsSourceIndex', () => {
     get: getMock,
   } as unknown as ReadOnlyElementsSource
   const entitycustomfield = entitycustomfieldType().type
-
-  const { file, folder } = getFileCabinetTypes()
 
   beforeEach(() => {
     getAllMock.mockReset()
@@ -99,21 +96,6 @@ describe('createElementsSourceIndex', () => {
 
     expect(index.Employee.map(e => e.elemID.getFullName()))
       .toEqual([instance1.elemID.getFullName()])
-  })
-
-  it('should create the right pathToInternalIds index', async () => {
-    const folderInstance = new InstanceElement('folder1', folder, { path: '/folder1', internalId: 0 })
-    const fileInstance = new InstanceElement('file1', file, { path: '/folder1/file1', internalId: 1 })
-    getAllMock.mockImplementation(buildElementsSourceFromElements([
-      folderInstance,
-      fileInstance,
-    ]).getAll)
-
-    expect((await createElementsSourceIndex(elementsSource).getIndexes()).pathToInternalIdsIndex)
-      .toEqual({
-        '/folder1': 0,
-        '/folder1/file1': 1,
-      })
   })
 
   it('should create the right elemIdToChangeByIndex index', async () => {

--- a/packages/netsuite-adapter/test/filters/service_urls.test.ts
+++ b/packages/netsuite-adapter/test/filters/service_urls.test.ts
@@ -19,14 +19,12 @@ import { fileType } from '../../src/types/file_cabinet_types'
 import NetsuiteClient from '../../src/client/client'
 import serviceUrls from '../../src/filters/service_urls'
 import { createEmptyElementsSourceIndexes, getDefaultAdapterConfig } from '../utils'
-import { NETSUITE } from '../../src/constants'
+import { INTERNAL_ID, NETSUITE } from '../../src/constants'
 
 describe('serviceUrls', () => {
   describe('onFetch', () => {
-    const getPathInternalIdMock = jest.fn()
     const isSuiteAppConfiguredMock = jest.fn()
     const client = {
-      getPathInternalId: getPathInternalIdMock,
       isSuiteAppConfigured: isSuiteAppConfiguredMock,
       url: 'https://accountid.app.netsuite.com',
     } as unknown as NetsuiteClient
@@ -35,10 +33,9 @@ describe('serviceUrls', () => {
 
     beforeEach(() => {
       jest.resetAllMocks()
-      getPathInternalIdMock.mockReturnValue(1)
       isSuiteAppConfiguredMock.mockReturnValue(true)
       elements = [
-        new InstanceElement('A', fileType(), { path: '/path/A' }),
+        new InstanceElement('A', fileType(), { path: '/path/A', [INTERNAL_ID]: '1' }),
       ]
     })
 

--- a/packages/netsuite-adapter/test/service_url/file_cabinet.test.ts
+++ b/packages/netsuite-adapter/test/service_url/file_cabinet.test.ts
@@ -17,26 +17,19 @@ import { CORE_ANNOTATIONS, InstanceElement } from '@salto-io/adapter-api'
 import { getFileCabinetTypes } from '../../src/types/file_cabinet_types'
 import NetsuiteClient from '../../src/client/client'
 import setServiceUrl from '../../src/service_url/file_cabinet'
+import { INTERNAL_ID } from '../../src/constants'
 
 describe('setFileCabinetUrls', () => {
-  const getPathInternalIdMock = jest.fn()
   const client = {
-    getPathInternalId: getPathInternalIdMock,
     url: 'https://accountid.app.netsuite.com',
   } as unknown as NetsuiteClient
   const { file, folder } = getFileCabinetTypes()
 
   const elements = [
-    new InstanceElement('A', file, { path: '/path/A' }),
-    new InstanceElement('B', folder, { path: '/path/B' }),
+    new InstanceElement('A', file, { path: '/path/A', [INTERNAL_ID]: '1' }),
+    new InstanceElement('B', folder, { path: '/path/B', [INTERNAL_ID]: '2' }),
     new InstanceElement('C', folder, { path: '/path/C' }),
   ]
-
-  beforeEach(() => {
-    jest.resetAllMocks()
-    getPathInternalIdMock.mockReturnValueOnce(1)
-    getPathInternalIdMock.mockReturnValueOnce(2)
-  })
 
   it('should set the right url', async () => {
     await setServiceUrl(elements, client)

--- a/packages/netsuite-adapter/test/utils.ts
+++ b/packages/netsuite-adapter/test/utils.ts
@@ -31,7 +31,6 @@ export const createEmptyElementsSourceIndexes = (): ElementsSourceIndexes => ({
   serviceIdRecordsIndex: {},
   internalIdsIndex: {},
   customFieldsIndex: {},
-  pathToInternalIdsIndex: {},
   elemIdToChangeByIndex: {},
   mapKeyFieldsIndex: {},
   elemIdToChangeAtIndex: {},


### PR DESCRIPTION
Some changes in deployment of FileCabinet instances using suiteapp:
- Remove the `pathToInternalIds` index.
- Use the `_parent` annotation to get the parent folder `internalId` instead of `pathToInternalIds` index.
- Add change validator for missing `internalId` on removals/modifications, and missing parent folder `internalId` on additions.
- Remove the `getPathToIdMap` & `getPathInternalId` functions.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Improve deployment of FileCabinet instances using SuiteApp

---
_User Notifications_: 
None