### PR TITLE
Fixed jira DC E2E

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/datacenter/fieldConfiguration.ts
+++ b/packages/jira-adapter/e2e_test/instances/datacenter/fieldConfiguration.ts
@@ -27,9 +27,9 @@ export const createFieldConfigurationValues = (
 export const createFieldConfigurationItemValues = (
   allElements: Element[],
 ): Values => ({
-  id: createReference(new ElemID(JIRA, 'Field', 'instance', 'Assignee__user'), allElements),
+  id: createReference(new ElemID(JIRA, 'Field', 'instance', 'Component_s__array@duu'), allElements),
   description: 'For example operating system, software platform and/or hardware specifications (include as appropriate for the issue).',
-  renderer: 'jira-text-renderer',
+  renderer: 'frother-control-renderer',
   isHidden: false,
   isRequired: false,
 })

--- a/packages/jira-adapter/e2e_test/instances/datacenter/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/datacenter/index.ts
@@ -31,7 +31,7 @@ export const createInstances = (randomString: string, fetchedElements: Element[]
   )
 
   const fieldConfigurationItem = new InstanceElement(
-    `${randomString}_Assignee__user`,
+    `${randomString}_Component_s__array_duu@uuuum`,
     findType('FieldConfigurationItem', fetchedElements),
     createFieldConfigurationItemValues(fetchedElements),
     undefined,


### PR DESCRIPTION
Updating the plugin in our e2e account broke the tests

---

The error was that `Assignee__user` can have a render so I changed it to a different field

---
_Release Notes_: 
None

---
_User Notifications_: 
None