### PR TITLE
SALTO-3766 improve convert-lists-to-maps preDeploy filter

### DIFF
--- a/packages/netsuite-adapter/src/elements_source_index/elements_source_index.ts
+++ b/packages/netsuite-adapter/src/elements_source_index/elements_source_index.ts
@@ -14,14 +14,14 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { CORE_ANNOTATIONS, InstanceElement, isInstanceElement, ReadOnlyElementsSource, ElemID, Element, isObjectType, Value, ObjectType } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, InstanceElement, isInstanceElement, ReadOnlyElementsSource, ElemID, Element, isObjectType, Value } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import { getElementValueOrAnnotations, isCustomRecordType, isFileCabinetInstance } from '../types'
 import { ElementsSourceIndexes, LazyElementsSourceIndexes, ServiceIdRecords } from './types'
 import { getFieldInstanceTypes } from '../data_elements/custom_fields'
 import { getElementServiceIdRecords } from '../filters/element_references'
-import { CUSTOM_LIST, CUSTOM_RECORD_TYPE, INTERNAL_ID, IS_SUB_INSTANCE, LIST_MAPPED_BY_FIELD } from '../constants'
+import { CUSTOM_LIST, CUSTOM_RECORD_TYPE, INTERNAL_ID, IS_SUB_INSTANCE } from '../constants'
 import { TYPES_TO_INTERNAL_ID } from '../data_elements/types'
 
 const { awu } = collections.asynciterable
@@ -89,7 +89,6 @@ const createIndexes = async (elementsSource: ReadOnlyElementsSource):
   const customFieldsIndex: Record<string, InstanceElement[]> = {}
   const pathToInternalIdsIndex: Record<string, number> = {}
   const elemIdToChangeByIndex: Record<string, string> = {}
-  const mapKeyFieldsIndex: Record<string, string | string[]> = {}
   const elemIdToChangeAtIndex: Record<string, string> = {}
 
   const updateInternalIdsIndex = async (element: Element): Promise<void> => {
@@ -127,13 +126,6 @@ const createIndexes = async (elementsSource: ReadOnlyElementsSource):
     _.assign(serviceIdRecordsIndex, serviceIdRecords)
   }
 
-  const updateMapKeyFieldsIndex = (type: ObjectType): void => {
-    Object.values(type.fields).forEach(field => {
-      if (field.annotations[LIST_MAPPED_BY_FIELD]) {
-        mapKeyFieldsIndex[field.elemID.getFullName()] = field.annotations[LIST_MAPPED_BY_FIELD]
-      }
-    })
-  }
   const updateElemIdToChangedAtIndex = (element: Element): void => {
     const changeAt = element.annotations[CORE_ANNOTATIONS.CHANGED_AT]
     if (changeAt !== undefined) {
@@ -158,9 +150,6 @@ const createIndexes = async (elementsSource: ReadOnlyElementsSource):
         updateElemIdToChangedByIndex(element)
         updateElemIdToChangedAtIndex(element)
       }
-      if (isObjectType(element)) {
-        updateMapKeyFieldsIndex(element)
-      }
     })
 
   return {
@@ -169,7 +158,6 @@ const createIndexes = async (elementsSource: ReadOnlyElementsSource):
     customFieldsIndex,
     pathToInternalIdsIndex,
     elemIdToChangeByIndex,
-    mapKeyFieldsIndex,
     elemIdToChangeAtIndex,
   }
 }

--- a/packages/netsuite-adapter/src/elements_source_index/types.ts
+++ b/packages/netsuite-adapter/src/elements_source_index/types.ts
@@ -23,7 +23,6 @@ export type ElementsSourceIndexes = {
   customFieldsIndex: Record<string, InstanceElement[]>
   pathToInternalIdsIndex: Record<string, number>
   elemIdToChangeByIndex: Record<string, string>
-  mapKeyFieldsIndex: Record<string, string | string[]>
   elemIdToChangeAtIndex: Record<string, string>
 }
 

--- a/packages/netsuite-adapter/src/filters/convert_lists_to_maps.ts
+++ b/packages/netsuite-adapter/src/filters/convert_lists_to_maps.ts
@@ -30,10 +30,7 @@ const shouldTransformDataInstance = async (instance: InstanceElement): Promise<b
   Object.values((await instance.getType()).fields)
     .some(field => dataTypesToConvert.has(field.refType.elemID.name))
 
-const filterCreator: FilterCreator = ({
-  elementsSourceIndex,
-  changesGroupId,
-}): FilterWith<'onFetch' | 'preDeploy'> => ({
+const filterCreator: FilterCreator = ({ changesGroupId }): FilterWith<'onFetch' | 'preDeploy'> => ({
   name: 'convertListsToMaps',
   /**
    * Upon fetch, do the following:
@@ -90,7 +87,7 @@ const filterCreator: FilterCreator = ({
    */
   preDeploy: async changes => {
     const convertElementMapsToLists = changesGroupId && isSdfCreateOrUpdateGroupId(changesGroupId)
-      ? await createConvertStandardElementMapsToLists(elementsSourceIndex)
+      ? await createConvertStandardElementMapsToLists()
       : undefined
 
     await awu(changes)

--- a/packages/netsuite-adapter/src/mapped_lists/utils.ts
+++ b/packages/netsuite-adapter/src/mapped_lists/utils.ts
@@ -266,6 +266,9 @@ export const convertDataInstanceMapsToLists = async (instance: InstanceElement):
   })
 }
 
+// We use hardcoded types when running transformMapsToLists,
+// so the fields don't have the `map_key_field` annotation.
+// Because of that, we add that annotation on the mapped list itself.
 const setListMappedByFieldToValue = <T extends ChangeDataType>(element: T): Promise<T> =>
   transformElement({
     element,
@@ -283,6 +286,7 @@ const transformMapsToLists = (element: ChangeDataType): Promise<ChangeDataType> 
     transformFunc: async ({ value, field }) => (
       field !== undefined && await isMappedList(value, field)
         ? _.sortBy(
+          // Removing the `map_key_field` annotation that was used to identify the mapped list.
           Object.values(_.omit(value, [LIST_MAPPED_BY_FIELD])),
           [INDEX, value[LIST_MAPPED_BY_FIELD]].flat()
         ).map(item => (_.isObject(item) ? _.omit(item, INDEX) : item))
@@ -294,7 +298,7 @@ const transformMapsToLists = (element: ChangeDataType): Promise<ChangeDataType> 
 export const createConvertStandardElementMapsToLists = async (): Promise<(
   element: ChangeDataType
 ) => Promise<ChangeDataType>> => {
-  // using hardcoded types so the transformed elements will have fields with List<> ref types.
+  // Using hardcoded types so the transformed elements will have fields with List<> ref types.
   const standardTypes = getStandardTypes()
   const customRecordTypeAnnotationRefTypes = toAnnotationRefTypes(standardTypes.customrecordtype.type)
 

--- a/packages/netsuite-adapter/src/mapped_lists/utils.ts
+++ b/packages/netsuite-adapter/src/mapped_lists/utils.ts
@@ -29,7 +29,6 @@ import { captureServiceIdInfo } from '../service_id_info'
 import { getStandardTypes, isStandardTypeName } from '../autogen/types'
 import { isCustomRecordType } from '../types'
 import { toAnnotationRefTypes } from '../custom_records/custom_record_type'
-import { LazyElementsSourceIndexes } from '../elements_source_index/types'
 
 const { mapValuesAsync } = promises.object
 const { awu } = collections.asynciterable
@@ -191,13 +190,10 @@ export const convertAnnotationListsToMaps = async (
 export const isMappedList = async (
   value: Value,
   field: Field,
-  mapKeyFieldsIndex?: Record<string, string | string[]>,
 ): Promise<boolean> =>
-  (mapKeyFieldsIndex === undefined
-    ? field.annotations[LIST_MAPPED_BY_FIELD]
-    : mapKeyFieldsIndex[field.elemID.getFullName()])
-  && _.isPlainObject(value)
+  _.isPlainObject(value)
   && isContainerType(await field.getType())
+  && (field.annotations[LIST_MAPPED_BY_FIELD] || value[LIST_MAPPED_BY_FIELD])
 
 export const getMappedLists = async (
   instance: InstanceElement
@@ -270,51 +266,53 @@ export const convertDataInstanceMapsToLists = async (instance: InstanceElement):
   })
 }
 
-export const createConvertStandardElementMapsToLists = async (
-  elementsSourceIndexes: LazyElementsSourceIndexes
-): Promise<(
+const setListMappedByFieldToValue = <T extends ChangeDataType>(element: T): Promise<T> =>
+  transformElement({
+    element,
+    transformFunc: async ({ value, field }) => (
+      field !== undefined && await isMappedList(value, field)
+        ? { ...value, [LIST_MAPPED_BY_FIELD]: field.annotations[LIST_MAPPED_BY_FIELD] }
+        : value
+    ),
+    strict: false,
+  })
+
+const transformMapsToLists = (element: ChangeDataType): Promise<ChangeDataType> =>
+  transformElement({
+    element,
+    transformFunc: async ({ value, field }) => (
+      field !== undefined && await isMappedList(value, field)
+        ? _.sortBy(
+          Object.values(_.omit(value, [LIST_MAPPED_BY_FIELD])),
+          [INDEX, value[LIST_MAPPED_BY_FIELD]].flat()
+        ).map(item => (_.isObject(item) ? _.omit(item, INDEX) : item))
+        : value
+    ),
+    strict: false,
+  })
+
+export const createConvertStandardElementMapsToLists = async (): Promise<(
   element: ChangeDataType
 ) => Promise<ChangeDataType>> => {
   // using hardcoded types so the transformed elements will have fields with List<> ref types.
   const standardTypes = getStandardTypes()
   const customRecordTypeAnnotationRefTypes = toAnnotationRefTypes(standardTypes.customrecordtype.type)
-  const { mapKeyFieldsIndex } = await elementsSourceIndexes.getIndexes()
 
-  const convertToList: TransformFunc = async ({ value, field }) => (
-    field !== undefined && await isMappedList(value, field, mapKeyFieldsIndex)
-      ? _.sortBy(
-        Object.values(value),
-        [INDEX, mapKeyFieldsIndex[field.elemID.getFullName()]].flat()
-      ).map(item => (_.isObject(item) ? _.omit(item, INDEX) : item))
-      : value
-  )
-
-  return element => {
-    if (isInstanceElement(element) && isStandardTypeName(element.refType.elemID.name)) {
-      return transformElement({
-        element: new InstanceElement(
-          element.elemID.name,
-          standardTypes[element.refType.elemID.name].type,
-          element.value,
-        ),
-        transformFunc: convertToList,
-        strict: false,
-      })
+  return async element => {
+    if (isInstanceElement(element) && isStandardTypeName(element.elemID.typeName)) {
+      return transformMapsToLists(new InstanceElement(
+        element.elemID.name,
+        standardTypes[element.elemID.typeName].type,
+        (await setListMappedByFieldToValue(element)).value,
+      ))
     }
     if (isObjectType(element) && isCustomRecordType(element)) {
-      return transformElement({
-        element: new ObjectType({
-          elemID: element.elemID,
-          fields: _.mapValues(
-            element.fields,
-            ({ refType, annotations }) => ({ refType, annotations })
-          ),
-          annotationRefsOrTypes: customRecordTypeAnnotationRefTypes,
-          annotations: element.annotations,
-        }),
-        transformFunc: convertToList,
-        strict: false,
-      })
+      return transformMapsToLists(new ObjectType({
+        elemID: element.elemID,
+        fields: element.fields,
+        annotationRefsOrTypes: customRecordTypeAnnotationRefTypes,
+        annotations: (await setListMappedByFieldToValue(element)).annotations,
+      }))
     }
     return Promise.resolve(element)
   }

--- a/packages/netsuite-adapter/test/elements_source_index.test.ts
+++ b/packages/netsuite-adapter/test/elements_source_index.test.ts
@@ -13,17 +13,12 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { collections } from '@salto-io/lowerdash'
 import { CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, ReadOnlyElementsSource } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { getFileCabinetTypes } from '../src/types/file_cabinet_types'
 import { entitycustomfieldType } from '../src/autogen/types/standard_types/entitycustomfield'
 import { CUSTOM_RECORD_TYPE, INTERNAL_ID, METADATA_TYPE, NETSUITE, SCRIPT_ID } from '../src/constants'
 import { createElementsSourceIndex } from '../src/elements_source_index/elements_source_index'
-import { workflowType } from '../src/autogen/types/standard_types/workflow'
-import { convertFieldsTypesFromListToMap } from '../src/mapped_lists/utils'
-
-const { awu } = collections.asynciterable
 
 describe('createElementsSourceIndex', () => {
   const getAllMock = jest.fn()
@@ -139,112 +134,6 @@ describe('createElementsSourceIndex', () => {
       .toEqual({
         'netsuite.someType.instance.inst': 'user name',
         'netsuite.customrecord1': 'user name2',
-      })
-  })
-  it('should create the right mapKeyFieldsIndex index', async () => {
-    const workflow = workflowType()
-    const types = [workflow.type].concat(Object.values(workflow.innerTypes))
-    await awu(types).forEach(async type => {
-      await convertFieldsTypesFromListToMap(type)
-    })
-    getAllMock.mockImplementation(buildElementsSourceFromElements(types).getAll)
-
-    expect((await createElementsSourceIndex(elementsSource).getIndexes()).mapKeyFieldsIndex)
-      .toEqual({
-        'netsuite.workflow_initcondition_parameters.field.parameter': 'name',
-        'netsuite.workflow_workflowcustomfields.field.workflowcustomfield': 'scriptid',
-        'netsuite.workflow_workflowcustomfields_workflowcustomfield_customfieldfilters.field.customfieldfilter': 'fldfilter',
-        'netsuite.workflow_workflowcustomfields_workflowcustomfield_roleaccesses.field.roleaccess': 'role',
-        'netsuite.workflow_workflowstates.field.workflowstate': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate.field.workflowactions': 'triggertype',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions.field.addbuttonaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions.field.confirmaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions.field.createlineaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions.field.createrecordaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions.field.customaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions.field.gotopageaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions.field.gotorecordaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions.field.initiateworkflowaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions.field.lockrecordaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions.field.removebuttonaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions.field.returnusererroraction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions.field.sendcampaignemailaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions.field.sendemailaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions.field.setdisplaylabelaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions.field.setdisplaytypeaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions.field.setfieldmandatoryaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions.field.setfieldvalueaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions.field.showmessageaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions.field.subscribetorecordaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions.field.transformrecordaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions.field.workflowactiongroup': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions.field.workflowsublistactiongroup': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_addbuttonaction_initcondition_parameters.field.parameter': 'name',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_confirmaction_initcondition_parameters.field.parameter': 'name',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_createlineaction_fieldsettings.field.fieldsetting': 'targetfield',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_createlineaction_initcondition_parameters.field.parameter': 'name',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_createrecordaction_fieldsettings.field.fieldsetting': 'targetfield',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_createrecordaction_initcondition_parameters.field.parameter': 'name',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_customaction_initcondition_parameters.field.parameter': 'name',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_customaction_parametersettings.field.parametersetting': 'targetparameter',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_gotopageaction_initcondition_parameters.field.parameter': 'name',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_fieldsettings.field.fieldsetting': 'targetfield',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_initcondition_parameters.field.parameter': 'name',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_initcondition_parameters.field.parameter': 'name',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_workflowfieldsettings.field.workflowfieldsetting': 'targetworkflowfield',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_lockrecordaction_initcondition_parameters.field.parameter': 'name',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_removebuttonaction_initcondition_parameters.field.parameter': 'name',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_returnusererroraction_initcondition_parameters.field.parameter': 'name',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailaction_initcondition_parameters.field.parameter': 'name',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_sendemailaction_initcondition_parameters.field.parameter': 'name',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelaction_initcondition_parameters.field.parameter': 'name',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeaction_initcondition_parameters.field.parameter': 'name',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryaction_initcondition_parameters.field.parameter': 'name',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_setfieldvalueaction_initcondition_parameters.field.parameter': 'name',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_showmessageaction_initcondition_parameters.field.parameter': 'name',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_subscribetorecordaction_initcondition_parameters.field.parameter': 'name',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_fieldsettings.field.fieldsetting': 'targetfield',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_initcondition_parameters.field.parameter': 'name',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup.field.addbuttonaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup.field.createlineaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup.field.createrecordaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup.field.customaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup.field.gotopageaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup.field.gotorecordaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup.field.initiateworkflowaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup.field.lockrecordaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup.field.removebuttonaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup.field.returnusererroraction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup.field.sendcampaignemailaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup.field.sendemailaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup.field.setdisplaylabelaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup.field.setdisplaytypeaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup.field.setfieldmandatoryaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup.field.setfieldvalueaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup.field.subscribetorecordaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup.field.transformrecordaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineaction_fieldsettings.field.fieldsetting': 'targetfield',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordaction_fieldsettings.field.fieldsetting': 'targetfield',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customaction_parametersettings.field.parametersetting': 'targetparameter',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordaction_fieldsettings.field.fieldsetting': 'targetfield',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initcondition_parameters.field.parameter': 'name',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initiateworkflowaction_workflowfieldsettings.field.workflowfieldsetting': 'targetworkflowfield',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordaction_fieldsettings.field.fieldsetting': 'targetfield',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup.field.createrecordaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup.field.returnusererroraction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup.field.sendemailaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup.field.setfieldvalueaction': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_fieldsettings.field.fieldsetting': 'targetfield',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_initcondition_parameters.field.parameter': 'name',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_initcondition_parameters.field.parameter': 'name',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroraction_initcondition_parameters.field.parameter': 'name',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailaction_initcondition_parameters.field.parameter': 'name',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueaction_initcondition_parameters.field.parameter': 'name',
-        'netsuite.workflow_workflowstates_workflowstate_workflowstatecustomfields.field.workflowstatecustomfield': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_customfieldfilters.field.customfieldfilter': 'fldfilter',
-        'netsuite.workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_roleaccesses.field.roleaccess': 'role',
-        'netsuite.workflow_workflowstates_workflowstate_workflowtransitions.field.workflowtransition': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate_workflowtransitions_workflowtransition_initcondition_parameters.field.parameter': 'name',
       })
   })
   it('should create the right elemIdToChangeAtIndex index', async () => {

--- a/packages/netsuite-adapter/test/mapped_lists/utils.test.ts
+++ b/packages/netsuite-adapter/test/mapped_lists/utils.test.ts
@@ -19,7 +19,6 @@ import { convertFieldsTypesFromListToMap, createConvertStandardElementMapsToList
 import { getStandardTypes } from '../../src/autogen/types'
 import { LIST_MAPPED_BY_FIELD, NETSUITE, SCRIPT_ID } from '../../src/constants'
 import { getInnerStandardTypes, getTopLevelStandardTypes } from '../../src/types'
-import { LazyElementsSourceIndexes } from '../../src/elements_source_index/types'
 import { toAnnotationRefTypes } from '../../src/custom_records/custom_record_type'
 
 const { awu } = collections.asynciterable
@@ -189,15 +188,7 @@ describe('mapped lists', () => {
     transformedDataInstance = dataInstance.clone()
     transformedDataInstance.value = await convertInstanceListsToMaps(dataInstance) ?? {}
 
-    const convertElementMapsToLists = await createConvertStandardElementMapsToLists({ getIndexes: () => ({
-      mapKeyFieldsIndex: {
-        'netsuite.workflow_workflowcustomfields.field.workflowcustomfield': 'scriptid',
-        'netsuite.workflow_workflowstates.field.workflowstate': 'scriptid',
-        'netsuite.workflow_workflowstates_workflowstate.field.workflowactions': 'triggertype',
-        'netsuite.workflow_workflowstates_workflowstate_workflowactions.field.setfieldvalueaction': 'scriptid',
-        'netsuite.customrecordtype_permissions.field.permission': 'permittedrole',
-      },
-    }) } as unknown as LazyElementsSourceIndexes)
+    const convertElementMapsToLists = await createConvertStandardElementMapsToLists()
     transformedBackInstance = await convertElementMapsToLists(transformedInstance) as InstanceElement
     transformedBackCustomRecordType = await convertElementMapsToLists(transformedCustomRecordType) as ObjectType
     transformedBackDataInstance = await convertDataInstanceMapsToLists(transformedDataInstance)

--- a/packages/netsuite-adapter/test/utils.ts
+++ b/packages/netsuite-adapter/test/utils.ts
@@ -33,6 +33,5 @@ export const createEmptyElementsSourceIndexes = (): ElementsSourceIndexes => ({
   customFieldsIndex: {},
   pathToInternalIdsIndex: {},
   elemIdToChangeByIndex: {},
-  mapKeyFieldsIndex: {},
   elemIdToChangeAtIndex: {},
 })


### PR DESCRIPTION
Do not use `elementSourceIndex` to transform maps back to lists.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Improve convert-lists-to-maps preDeploy filter

---
_User Notifications_: 
None