### PR TITLE
SALTO-3766 Use elementSource in remove_sdf_elements

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -485,7 +485,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
         filtersRunner: changesGroupId => this.createFiltersRunner({
           changesGroupId,
         }),
-        elementsSourceIndex: this.elementsSourceIndex,
+        elementsSource: this.elementsSource,
       }),
       getChangeGroupIds: getChangeGroupIdsFunc(this.client.isSuiteAppConfigured()),
     }

--- a/packages/netsuite-adapter/src/change_validators/types.ts
+++ b/packages/netsuite-adapter/src/change_validators/types.ts
@@ -13,11 +13,10 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, ChangeError } from '@salto-io/adapter-api'
-import { LazyElementsSourceIndexes } from '../elements_source_index/types'
+import { Change, ChangeError, ReadOnlyElementsSource } from '@salto-io/adapter-api'
 
 export type NetsuiteChangeValidator = (
     changes: ReadonlyArray<Change>,
     deployReferencedElements?: boolean,
-    elementsSourceIndex?: LazyElementsSourceIndexes,
+    elementsSource?: ReadOnlyElementsSource,
   ) => Promise<ReadonlyArray<ChangeError>>

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -904,9 +904,10 @@ describe('Adapter', () => {
           deploy: {
           },
         }
+        const elementsSource = buildElementsSourceFromElements([])
         const adapter = new NetsuiteAdapter({
           client: new NetsuiteClient(client),
-          elementsSource: buildElementsSourceFromElements([]),
+          elementsSource,
           filtersCreators: [firstDummyFilter, secondDummyFilter],
           config: configWithoutWarnStaleData,
           getElemIdFunc: mockGetElemIdFunc,
@@ -924,7 +925,7 @@ describe('Adapter', () => {
           validate: expect.anything(),
           filtersRunner: expect.anything(),
           additionalDependencies: expect.anything(),
-          elementsSourceIndex: expect.anything(),
+          elementsSource,
         })
       })
 
@@ -936,9 +937,10 @@ describe('Adapter', () => {
             warnOnStaleWorkspaceData: false,
           },
         }
+        const elementsSource = buildElementsSourceFromElements([])
         const adapter = new NetsuiteAdapter({
           client: new NetsuiteClient(client),
-          elementsSource: buildElementsSourceFromElements([]),
+          elementsSource,
           filtersCreators: [firstDummyFilter, secondDummyFilter],
           config: configWithoutWarnStaleData,
           getElemIdFunc: mockGetElemIdFunc,
@@ -956,7 +958,7 @@ describe('Adapter', () => {
           deployReferencedElements: expect.anything(),
           validate: expect.anything(),
           additionalDependencies: expect.anything(),
-          elementsSourceIndex: expect.anything(),
+          elementsSource,
         })
       })
 
@@ -968,9 +970,10 @@ describe('Adapter', () => {
             warnOnStaleWorkspaceData: true,
           },
         }
+        const elementsSource = buildElementsSourceFromElements([])
         const adapter = new NetsuiteAdapter({
           client: new NetsuiteClient(client),
-          elementsSource: buildElementsSourceFromElements([]),
+          elementsSource,
           filtersCreators: [firstDummyFilter, secondDummyFilter],
           config: configWithoutWarnStaleData,
           getElemIdFunc: mockGetElemIdFunc,
@@ -988,7 +991,7 @@ describe('Adapter', () => {
           deployReferencedElements: expect.anything(),
           validate: expect.anything(),
           additionalDependencies: expect.anything(),
-          elementsSourceIndex: expect.anything(),
+          elementsSource,
         })
       })
     })

--- a/packages/netsuite-adapter/test/change_validator.test.ts
+++ b/packages/netsuite-adapter/test/change_validator.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, ChangeError, ElemID, InstanceElement, ObjectType, ProgressReporter, toChange, getChangeData, SeverityLevel } from '@salto-io/adapter-api'
+import { Change, ChangeError, ElemID, InstanceElement, ObjectType, ProgressReporter, toChange, getChangeData, SeverityLevel, ReadOnlyElementsSource } from '@salto-io/adapter-api'
 import { Filter } from '../src/filter'
 import { fileType } from '../src/types/file_cabinet_types'
 import getChangeValidator from '../src/change_validator'
@@ -21,7 +21,6 @@ import netsuiteClientValidation from '../src/change_validators/client_validation
 import { FetchByQueryFunc, FetchByQueryReturnType } from '../src/change_validators/safe_deploy'
 import { NetsuiteQuery } from '../src/query'
 import NetsuiteClient from '../src/client/client'
-import { LazyElementsSourceIndexes } from '../src/elements_source_index/types'
 import * as dependencies from '../src/change_validators/dependencies'
 
 const DEFAULT_OPTIONS = {
@@ -36,7 +35,7 @@ const DEFAULT_OPTIONS = {
   filtersRunner: () => ({
     preDeploy: jest.fn(),
   }) as unknown as Required<Filter>,
-  elementsSourceIndex: jest.fn() as unknown as LazyElementsSourceIndexes,
+  elementsSource: jest.fn() as unknown as ReadOnlyElementsSource,
   fetchByQuery: jest.fn(),
 }
 

--- a/packages/netsuite-adapter/test/change_validators/remove_sdf_elements.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/remove_sdf_elements.test.ts
@@ -13,13 +13,12 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { ElemID, Field, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
 import { workflowType } from '../../src/autogen/types/standard_types/workflow'
 import { entitycustomfieldType } from '../../src/autogen/types/standard_types/entitycustomfield'
 import removeSdfElementsValidator from '../../src/change_validators/remove_sdf_elements'
 import { CUSTOM_RECORD_TYPE, INTERNAL_ID, METADATA_TYPE, NETSUITE } from '../../src/constants'
-import { createEmptyElementsSourceIndexes } from '../utils'
-
 
 describe('remove sdf object change validator', () => {
   const customRecordType = new ObjectType({
@@ -27,9 +26,7 @@ describe('remove sdf object change validator', () => {
     annotations: { [METADATA_TYPE]: CUSTOM_RECORD_TYPE, [INTERNAL_ID]: '1' },
   })
   const customRecordTypeInstance = new InstanceElement('test', customRecordType)
-  const elementsSourceIndex = {
-    getIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
-  }
+  const elementsSource = buildElementsSourceFromElements([])
 
   describe('remove instance of standard type', () => {
     it('should have change error when removing an instance of an unsupported standard type', async () => {
@@ -37,7 +34,7 @@ describe('remove sdf object change validator', () => {
 
       const changeErrors = await removeSdfElementsValidator([
         toChange({ before: standardInstanceNoInternalId }),
-      ], undefined, elementsSourceIndex)
+      ], undefined, elementsSource)
       expect(changeErrors).toHaveLength(1)
       expect(changeErrors[0].severity).toEqual('Error')
       expect(changeErrors[0].elemID).toEqual(standardInstanceNoInternalId.elemID)
@@ -49,7 +46,7 @@ describe('remove sdf object change validator', () => {
 
       const changeErrors = await removeSdfElementsValidator([
         toChange({ before: standardInstanceNoInternalId }),
-      ], undefined, elementsSourceIndex)
+      ], undefined, elementsSource)
       expect(changeErrors).toHaveLength(1)
       expect(changeErrors[0].severity).toEqual('Error')
       expect(changeErrors[0].elemID).toEqual(standardInstanceNoInternalId.elemID)
@@ -61,7 +58,7 @@ describe('remove sdf object change validator', () => {
 
       const changeErrors = await removeSdfElementsValidator([
         toChange({ before: standardInstance }),
-      ], undefined, elementsSourceIndex)
+      ], undefined, elementsSource)
       expect(changeErrors).toHaveLength(0)
     })
   })
@@ -70,7 +67,7 @@ describe('remove sdf object change validator', () => {
     it('should not have change error when removing an instance with non standard type', async () => {
       const changeErrors = await removeSdfElementsValidator([
         toChange({ before: customRecordTypeInstance }),
-      ], undefined, elementsSourceIndex)
+      ], undefined, elementsSource)
       expect(changeErrors).toHaveLength(0)
     })
   })
@@ -84,7 +81,7 @@ describe('remove sdf object change validator', () => {
 
       const changeErrors = await removeSdfElementsValidator([
         toChange({ before: customRecordTypeNoInternalID }),
-      ], undefined, elementsSourceIndex)
+      ], undefined, elementsSource)
       expect(changeErrors).toHaveLength(1)
       expect(changeErrors[0].severity).toEqual('Error')
       expect(changeErrors[0].elemID).toEqual(customRecordTypeNoInternalID.elemID)
@@ -99,25 +96,18 @@ describe('remove sdf object change validator', () => {
       const changeErrors = await removeSdfElementsValidator([
         toChange({ before: customRecordType }),
         toChange({ before: instanceOfAnotherType }),
-      ], undefined, elementsSourceIndex)
+      ], undefined, elementsSource)
       expect(changeErrors).toHaveLength(1)
       expect(changeErrors[0].severity).toEqual('Warning')
       expect(changeErrors[0].elemID).toEqual(customRecordType.elemID)
     })
 
     it('should have change error when removing a custom record type with internal id when instances exists in the index', async () => {
-      const elementsSourceIndexWithInstance = {
-        getIndexes: () => Promise.resolve({
-          ...createEmptyElementsSourceIndexes(),
-          internalIdsIndex: {
-            'customrecord1-1': customRecordTypeInstance.elemID,
-          },
-        }),
-      }
+      const elementsSourceInstance = buildElementsSourceFromElements([customRecordTypeInstance])
 
       const changeErrors = await removeSdfElementsValidator([
         toChange({ before: customRecordType }),
-      ], undefined, elementsSourceIndexWithInstance)
+      ], undefined, elementsSourceInstance)
       expect(changeErrors).toHaveLength(1)
       expect(changeErrors[0].severity).toEqual('Error')
       expect(changeErrors[0].elemID).toEqual(customRecordType.elemID)
@@ -136,7 +126,7 @@ describe('remove sdf object change validator', () => {
       const changeErrors = await removeSdfElementsValidator([
         toChange({ before: field }),
         toChange({ before: anotherCustomRecordType }),
-      ], undefined, elementsSourceIndex)
+      ], undefined, elementsSource)
       expect(changeErrors).toHaveLength(2)
       expect(changeErrors[0].severity).toEqual('Error')
       expect(changeErrors[0].elemID).toEqual(field.elemID)
@@ -148,7 +138,7 @@ describe('remove sdf object change validator', () => {
       const changeErrors = await removeSdfElementsValidator([
         toChange({ before: field }),
         toChange({ before: customRecordType }),
-      ], undefined, elementsSourceIndex)
+      ], undefined, elementsSource)
       expect(changeErrors).toHaveLength(1)
       expect(changeErrors[0].severity).toEqual('Warning')
       expect(changeErrors[0].elemID).toEqual(customRecordType.elemID)


### PR DESCRIPTION
Use `elementSource.list()` instead of `elementSourceIndex` to see if there are existing instances for removed custom record type.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Use elementSource in remove_sdf_elements

---
_User Notifications_: 
None