### PR TITLE
SALTO-3766 improve elementsSourceIndexes

### DIFF
--- a/packages/netsuite-adapter/test/elements_source_index.test.ts
+++ b/packages/netsuite-adapter/test/elements_source_index.test.ts
@@ -34,7 +34,7 @@ describe('createElementsSourceIndex', () => {
     getAllMock.mockImplementation(buildElementsSourceFromElements([]).getAll)
   })
   it('should create the index only once and cache it', async () => {
-    const elementsSourceIndex = createElementsSourceIndex(elementsSource)
+    const elementsSourceIndex = createElementsSourceIndex(elementsSource, true)
     const index = await elementsSourceIndex.getIndexes()
     const anotherIndex = await elementsSourceIndex.getIndexes()
     expect(index).toBe(anotherIndex)
@@ -67,13 +67,44 @@ describe('createElementsSourceIndex', () => {
       }),
     ]).getAll)
 
-    const elementsSourceIndex = createElementsSourceIndex(elementsSource)
+    const elementsSourceIndex = createElementsSourceIndex(elementsSource, true)
     const index = (await elementsSourceIndex.getIndexes()).internalIdsIndex
     expect(index).toEqual({
       'someType-4': new ElemID(NETSUITE, 'someType', 'instance', 'name'),
       'customrecordtype-2': new ElemID(NETSUITE, 'customrecord1'),
       '-123-2': new ElemID(NETSUITE, 'customrecord1'),
     })
+  })
+  it('should not create internal ids index on full fetch', async () => {
+    const type = new ObjectType({ elemID: new ElemID(NETSUITE, 'someType') })
+    getMock.mockImplementation(buildElementsSourceFromElements([
+      type,
+    ]).get)
+    getAllMock.mockImplementation(buildElementsSourceFromElements([
+      new InstanceElement(
+        'name',
+        type,
+        { internalId: '4' },
+      ),
+      new InstanceElement(
+        'name2',
+        type,
+        { internalId: '5', isSubInstance: true },
+      ),
+      type,
+      new ObjectType({
+        elemID: new ElemID(NETSUITE, 'customrecord1'),
+        annotations: {
+          [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
+          [SCRIPT_ID]: 'customrecord1',
+          [INTERNAL_ID]: '2',
+        },
+      }),
+    ]).getAll)
+
+    const elementsSourceIndex = createElementsSourceIndex(elementsSource, false)
+    const index = (await elementsSourceIndex.getIndexes()).internalIdsIndex
+    expect(index).toEqual({})
   })
 
   it('should create the right custom fields index', async () => {
@@ -84,13 +115,25 @@ describe('createElementsSourceIndex', () => {
       instance2,
     ]).getAll)
 
-    const elementsSourceIndex = createElementsSourceIndex(elementsSource)
+    const elementsSourceIndex = createElementsSourceIndex(elementsSource, true)
     const index = (await elementsSourceIndex.getIndexes()).customFieldsIndex
     expect(index.Contact.map(e => e.elemID.getFullName())).toEqual([instance1, instance2]
       .map(e => e.elemID.getFullName()))
 
     expect(index.Employee.map(e => e.elemID.getFullName()))
       .toEqual([instance1.elemID.getFullName()])
+  })
+  it('should not create custom fields index on full fetch', async () => {
+    const instance1 = new InstanceElement('name1', entitycustomfield, { appliestocontact: true, appliestocustomer: false, appliestoemployee: true })
+    const instance2 = new InstanceElement('name2', entitycustomfield, { appliestocontact: true, appliestocustomer: false, appliestoemployee: false })
+    getAllMock.mockImplementation(buildElementsSourceFromElements([
+      instance1,
+      instance2,
+    ]).getAll)
+
+    const elementsSourceIndex = createElementsSourceIndex(elementsSource, false)
+    const index = (await elementsSourceIndex.getIndexes()).customFieldsIndex
+    expect(index).toEqual({})
   })
 
   it('should create the right elemIdToChangeByIndex index', async () => {
@@ -112,7 +155,12 @@ describe('createElementsSourceIndex', () => {
       }),
     ]).getAll)
 
-    expect((await createElementsSourceIndex(elementsSource).getIndexes()).elemIdToChangeByIndex)
+    expect((await createElementsSourceIndex(elementsSource, true).getIndexes()).elemIdToChangeByIndex)
+      .toEqual({
+        'netsuite.someType.instance.inst': 'user name',
+        'netsuite.customrecord1': 'user name2',
+      })
+    expect((await createElementsSourceIndex(elementsSource, false).getIndexes()).elemIdToChangeByIndex)
       .toEqual({
         'netsuite.someType.instance.inst': 'user name',
         'netsuite.customrecord1': 'user name2',
@@ -137,7 +185,12 @@ describe('createElementsSourceIndex', () => {
       }),
     ]).getAll)
 
-    expect((await createElementsSourceIndex(elementsSource).getIndexes()).elemIdToChangeAtIndex)
+    expect((await createElementsSourceIndex(elementsSource, true).getIndexes()).elemIdToChangeAtIndex)
+      .toEqual({
+        'netsuite.someType.instance.inst': '03/23/2022',
+        'netsuite.customrecord1': '05/26/2022',
+      })
+    expect((await createElementsSourceIndex(elementsSource, false).getIndexes()).elemIdToChangeAtIndex)
       .toEqual({
         'netsuite.someType.instance.inst': '03/23/2022',
         'netsuite.customrecord1': '05/26/2022',


### PR DESCRIPTION
Calculate only `changeAt` & `changedBy` indexes in full fetch, and the rest on partial fetch only.

---

_Additional context for reviewer_
This PR is rebased on https://github.com/salto-io/salto/pull/4079, https://github.com/salto-io/salto/pull/4087, https://github.com/salto-io/salto/pull/4088,
Please review only the last commit of this PR.

---
_Release Notes_: 
Netsuite Adapter:
- Calculate only `changeAt` & `changedBy` indexes in full fetch, and the rest on partial fetch only.

---
_User Notifications_: 
None
