### PR TITLE
INCIDENT-3754: Add more logs when uploading files to S3

### DIFF
--- a/packages/core/src/local-workspace/s3_dir_store.ts
+++ b/packages/core/src/local-workspace/s3_dir_store.ts
@@ -81,13 +81,14 @@ export const buildS3DirectoryStore = (
 
     try {
       await bottleneck.schedule(
-        () => {
-          log.trace('Writing %s to S3 bucket %s', fullFilePath, bucketName)
-          return s3.putObject({
+        async () => {
+          log.trace('Writing %s with size of %d to S3 bucket %s', fullFilePath, file.buffer.length, bucketName)
+          await s3.putObject({
             Bucket: bucketName,
             Key: fullFilePath,
             Body: file.buffer,
           })
+          log.trace('Wrote %s to S3 bucket %s', fullFilePath, bucketName)
         }
       )
     } catch (err) {


### PR DESCRIPTION
Added  more logs when uploading files to S3 to help with an incident

---
_Release Notes_: 
None

---
_User Notifications_: 
None