### PR TITLE
SALTO-3822: Allow excluding by field type in Jira

### DIFF
--- a/packages/jira-adapter/config_doc.md
+++ b/packages/jira-adapter/config_doc.md
@@ -100,3 +100,4 @@ jira {
 | Name                                        | Default when undefined            | Description
 |---------------------------------------------|-----------------------------------|------------
 | name                                        | .*                                | A regex used to filter instances by matching the regex to their name value
+| type                                        | .*                                | A regex used to filter field instances by matching the regex to their type value

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -52,6 +52,7 @@ type JiraDeployConfig = configUtils.UserDeployConfig & {
 
 type JiraFetchFilters = {
   name?: string
+  type?: string
 }
 
 type JiraFetchConfig = configUtils.UserFetchConfig<JiraFetchFilters> & {
@@ -179,6 +180,7 @@ const fetchFiltersType = createMatchingObjectType<JiraFetchFilters>({
   elemID: new ElemID(JIRA, 'FetchFilters'),
   fields: {
     name: { refType: BuiltinTypes.STRING },
+    type: { refType: BuiltinTypes.STRING },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/jira-adapter/src/fetch_criteria.ts
+++ b/packages/jira-adapter/src/fetch_criteria.ts
@@ -21,6 +21,12 @@ const nameCriterion: elementUtils.query.QueryCriterion = ({
   value,
 }): boolean => regex.isFullRegexMatch(instance.value.name, value)
 
+const typeCriterion: elementUtils.query.QueryCriterion = ({
+  instance,
+  value,
+}): boolean => regex.isFullRegexMatch(instance.value.schema?.custom ?? instance.value.schema?.type, value)
+
 export default {
   name: nameCriterion,
+  type: typeCriterion,
 }

--- a/packages/jira-adapter/test/fetch_criteria.test.ts
+++ b/packages/jira-adapter/test/fetch_criteria.test.ts
@@ -31,4 +31,35 @@ describe('fetch_criteria', () => {
       expect(fetchCriteria.name({ instance, value: 'ame' })).toBeFalsy()
     })
   })
+  describe('type', () => {
+    it('should match custom field type', () => {
+      const instance = new InstanceElement(
+        'instance',
+        new ObjectType({ elemID: new ElemID('adapter', 'type') }),
+        {
+          schema: {
+            custom: 'type',
+          },
+        }
+      )
+
+      expect(fetchCriteria.type({ instance, value: '.ype' })).toBeTruthy()
+      expect(fetchCriteria.type({ instance, value: 'ype' })).toBeFalsy()
+    })
+
+    it('should match standard field type', () => {
+      const instance = new InstanceElement(
+        'instance',
+        new ObjectType({ elemID: new ElemID('adapter', 'type') }),
+        {
+          schema: {
+            type: 'type',
+          },
+        }
+      )
+
+      expect(fetchCriteria.type({ instance, value: '.ype' })).toBeTruthy()
+      expect(fetchCriteria.type({ instance, value: 'ype' })).toBeFalsy()
+    })
+  })
 })


### PR DESCRIPTION
Allow excluding a specific field type from the workspace

---
_Release Notes_: 
_Jira Adapter_:
- Allow excluding a specific field type from the workspace

---
_User Notifications_: 
None