### PR TITLE
SALTO-3405 - test failure stack trace can be string or object

### DIFF
--- a/packages/salesforce-adapter/src/client/jsforce.ts
+++ b/packages/salesforce-adapter/src/client/jsforce.ts
@@ -101,7 +101,7 @@ export interface RunTestFailure {
   name: string
   namespace?: string
   seeAllData?: boolean
-  stackTrace: string
+  stackTrace: string | object
   time: number
 }
 

--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
+import util from 'util'
 import { collections, values, hash as hashUtils } from '@salto-io/lowerdash'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
@@ -188,9 +189,13 @@ const processDeployResponse = (
   const testFailures = makeArray(result.details)
     .flatMap(detail => makeArray((detail.runTestResult as RunTestsResult)?.failures))
   const testErrors = testFailures
-    .map(failure => new Error(
-      `Test failed for class ${failure.name} method ${failure.methodName} with error:\n${failure.message}\n${failure.stackTrace}`
-    ))
+    .map(failure => new Error(util.format(
+      'Test failed for class %s method %s with error:\n%s\n%o',
+      failure.name,
+      failure.methodName,
+      failure.message,
+      failure.stackTrace
+    )))
   const componentErrors = allFailureMessages
     .filter(failure => !isUnFoundDelete(failure, deletionsPackageName))
     .map(getUserFriendlyDeployMessage)


### PR DESCRIPTION
Apex test failure showed stack trace as [object Object], so changed stack trace interface to be `string | object`

---



---
_Release Notes_: 
Salesforce:
* Stack traces for apex test failures will no longer show as [object Object]

---
_User Notifications_: _None_