### PR TITLE
SALTO-3825 - CLI: Deprecation message is shown when using the account command

### DIFF
--- a/packages/cli/src/commands/account.ts
+++ b/packages/cli/src/commands/account.ts
@@ -375,7 +375,7 @@ const serviceGroupDef = createCommandGroupDef({
   subCommands: [
     serviceAddDef,
     serviceListDef,
-    accountLoginDef,
+    serviceLoginDef,
   ],
 })
 
@@ -387,7 +387,7 @@ const accountGroupDef = createCommandGroupDef({
   subCommands: [
     accountAddDef,
     accountListDef,
-    serviceLoginDef,
+    accountLoginDef,
   ],
 })
 


### PR DESCRIPTION
Flipped the account and service actions for some reason.

---


---
_Release Notes_: 
CLI: 'account' command will no longer show a deprecation warning.

---
_User Notifications_: 
N/A
