### PR TITLE
SALTO-3713: Hide Okta, Zuora and Stripe types by default

### DIFF
--- a/packages/okta-adapter/src/adapter_creator.ts
+++ b/packages/okta-adapter/src/adapter_creator.ts
@@ -60,7 +60,7 @@ const adapterConfigFromConfig = (config: Readonly<InstanceElement> | undefined):
 
   const adapterConfig: { [K in keyof Required<OktaConfig>]: OktaConfig[K] } = {
     client: config?.value?.client,
-    fetch: config?.value?.fetch,
+    fetch,
     apiDefinitions,
   }
   Object.keys(config?.value ?? {})

--- a/packages/stripe-adapter/src/adapter_creator.ts
+++ b/packages/stripe-adapter/src/adapter_creator.ts
@@ -56,7 +56,7 @@ const adapterConfigFromConfig = (config: Readonly<InstanceElement> | undefined):
 
   const adapterConfig: { [K in keyof Required<StripeConfig>]: StripeConfig[K] } = {
     client: config?.value?.client,
-    fetch: config?.value?.fetch,
+    fetch,
     apiDefinitions,
   }
   Object.keys(config?.value ?? {})

--- a/packages/zuora-billing-adapter/src/adapter_creator.ts
+++ b/packages/zuora-billing-adapter/src/adapter_creator.ts
@@ -68,7 +68,7 @@ const adapterConfigFromConfig = (config: Readonly<InstanceElement> | undefined):
 
   const adapterConfig: { [K in keyof Required<ZuoraConfig>]: ZuoraConfig[K] } = {
     client: config?.value?.client,
-    fetch: config?.value?.fetch,
+    fetch,
     apiDefinitions,
   }
   Object.keys(config?.value ?? {})


### PR DESCRIPTION
Hide Okta, Zuora and Stripe types by default

---
_Release Notes_: 

_Stripe adapter_:
* The types folder will be hidden by default

_Okta adapter_:
* The types folder will be hidden by default

_Zuora-Billing adapter_:
* The system types folder will be hidden by default. Standard and custom object definitions will still be visible.

---

_User Notifications_: 

_Stripe adapter_:
* The types folder will be hidden by default

_Okta adapter_:
* The types folder will be hidden by default

_Zuora-Billing adapter_:
* The system types folder will be hidden by default. Standard and custom object definitions will still be visible.
