### PR TITLE
SALTO-3776: add filter to support projectCategory deployment - Jira

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -123,6 +123,7 @@ import pluginVersionFliter from './filters/data_center/plugin_version'
 import scriptRunnerWorkflowListsFilter from './filters/script_runner/workflow_lists_parsing'
 import scriptRunnerWorkflowReferencesFilter from './filters/script_runner/workflow_references'
 import storeUsersFilter from './filters/store_users'
+import projectCategoryFilter from './filters/project_category'
 
 const {
   generateTypes,
@@ -188,6 +189,7 @@ export const DEFAULT_FILTERS = [
   dashboardFilter,
   dashboardLayoutFilter,
   gadgetFilter,
+  projectCategoryFilter,
   projectFilter,
   projectComponentFilter,
   archivedProjectComponentsFilter,

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -101,7 +101,6 @@ export default (
     workflowSchemeDupsValidator,
     permissionSchemeDeploymentValidator(client),
     projectCategoryValidator(client),
-
   ]
 
   return createChangeValidator(validators)

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -52,6 +52,7 @@ import { unresolvedReferenceValidator } from './unresolved_references'
 import { sameIssueTypeNameChangeValidator } from './same_issue_type_name'
 import { issueTypeSchemeMigrationValidator } from './issue_type_scheme_migration'
 import { issueTypeDeletionValidator } from './issue_type_deletion'
+import { projectCategoryValidator } from './project_category'
 
 const {
   deployTypesNotSupportedValidator,
@@ -99,6 +100,8 @@ export default (
     accountIdValidator(client, config),
     workflowSchemeDupsValidator,
     permissionSchemeDeploymentValidator(client),
+    projectCategoryValidator(client),
+
   ]
 
   return createChangeValidator(validators)

--- a/packages/jira-adapter/src/change_validators/project_category.ts
+++ b/packages/jira-adapter/src/change_validators/project_category.ts
@@ -15,11 +15,10 @@
 */
 
 import { ChangeValidator, getChangeData, isInstanceChange, isModificationChange, SeverityLevel } from '@salto-io/adapter-api'
-import { collections } from '@salto-io/lowerdash'
+import { PROJECT_TYPE } from '../constants'
 import JiraClient from '../client/client'
 import { isNeedToDeleteCategory } from '../filters/project_category'
 
-const { awu } = collections.asynciterable
 
 export const projectCategoryValidator: (client: JiraClient) =>
   ChangeValidator = client => async changes => {
@@ -27,17 +26,16 @@ export const projectCategoryValidator: (client: JiraClient) =>
       return []
     }
 
-    return awu(changes)
+    return changes
       .filter(isInstanceChange)
       .filter(isModificationChange)
-      .filter(change => change.data.after.elemID.typeName === 'Project')
+      .filter(change => change.data.after.elemID.typeName === PROJECT_TYPE)
       .filter(isNeedToDeleteCategory)
       .map(getChangeData)
       .map(instance => ({
         elemID: instance.elemID,
         severity: 'Warning' as SeverityLevel,
-        message: 'Changing project category to None is not supported',
-        detailedMessage: 'Changing project category to None is not supported and the project category will not be changed in the service',
+        message: 'Cannot remove project Category from a project',
+        detailedMessage: 'Removing a project category from a project is not supported, the project will retain its previous category in the service.',
       }))
-      .toArray()
   }

--- a/packages/jira-adapter/src/change_validators/project_category.ts
+++ b/packages/jira-adapter/src/change_validators/project_category.ts
@@ -1,0 +1,43 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { ChangeValidator, getChangeData, isInstanceChange, isModificationChange, SeverityLevel } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import JiraClient from '../client/client'
+import { isNeedToDeleteCategory } from '../filters/project_category'
+
+const { awu } = collections.asynciterable
+
+export const projectCategoryValidator: (client: JiraClient) =>
+  ChangeValidator = client => async changes => {
+    if (!client.isDataCenter) {
+      return []
+    }
+
+    return awu(changes)
+      .filter(isInstanceChange)
+      .filter(isModificationChange)
+      .filter(change => change.data.after.elemID.typeName === 'Project')
+      .filter(isNeedToDeleteCategory)
+      .map(getChangeData)
+      .map(instance => ({
+        elemID: instance.elemID,
+        severity: 'Warning' as SeverityLevel,
+        message: 'Changing project category to None is not supported',
+        detailedMessage: 'Changing project category to None is not supported and the project category will not be changed in the service',
+      }))
+      .toArray()
+  }

--- a/packages/jira-adapter/src/change_validators/project_category.ts
+++ b/packages/jira-adapter/src/change_validators/project_category.ts
@@ -35,7 +35,7 @@ export const projectCategoryValidator: (client: JiraClient) =>
       .map(instance => ({
         elemID: instance.elemID,
         severity: 'Warning' as SeverityLevel,
-        message: 'Cannot remove project Category from a project',
-        detailedMessage: 'Removing a project category from a project is not supported, the project will retain its previous category in the service.',
+        message: 'Can\'t remove an existing project\'s category',
+        detailedMessage: 'Jira Data Center does not support removing an existing project\'s category. The existing category will be retained.',
       }))
   }

--- a/packages/jira-adapter/src/filters/project.ts
+++ b/packages/jira-adapter/src/filters/project.ts
@@ -34,6 +34,7 @@ const FIELD_CONFIG_SCHEME_FIELD = 'fieldConfigurationScheme'
 const ISSUE_TYPE_SCHEME = 'issueTypeScheme'
 const PRIORITY_SCHEME = 'priorityScheme'
 const PERMISSION_SCHEME_FIELD = 'permissionScheme'
+const PROJECT_CATEGORY_FIELD = 'projectCategory'
 
 const log = logger(module)
 
@@ -192,6 +193,7 @@ const filter: FilterCreator = ({ config, client, elementsSource }) => ({
       setFieldDeploymentAnnotations(projectType, ISSUE_TYPE_SCHEME)
       setFieldDeploymentAnnotations(projectType, COMPONENTS_FIELD)
       setFieldDeploymentAnnotations(projectType, PROJECT_CONTEXTS_FIELD)
+      setFieldDeploymentAnnotations(projectType, PROJECT_CATEGORY_FIELD)
 
       if (client.isDataCenter) {
         setFieldDeploymentAnnotations(projectType, PRIORITY_SCHEME)

--- a/packages/jira-adapter/src/filters/project_category.ts
+++ b/packages/jira-adapter/src/filters/project_category.ts
@@ -19,7 +19,7 @@ import { FilterCreator } from '../filter'
 const PROJECT_TYPE_NAME = 'Project'
 export const DELETED_CATEGORY = -1
 
-const isNeedToDeleteCategory = (change: Change<InstanceElement>): boolean => {
+export const isNeedToDeleteCategory = (change: Change<InstanceElement>): boolean => {
   if (isModificationChange(change)
     && change.data.before.value.projectCategory !== undefined
     && change.data.after.value.projectCategory === undefined) {

--- a/packages/jira-adapter/src/filters/project_category.ts
+++ b/packages/jira-adapter/src/filters/project_category.ts
@@ -1,0 +1,71 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Change, Element, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, isModificationChange, ReferenceExpression } from '@salto-io/adapter-api'
+import { FilterCreator } from '../filter'
+
+const PROJECT_TYPE_NAME = 'Project'
+export const DELETED_CATEGORY = -1
+
+const isNeedToDeleteCategory = (change: Change<InstanceElement>): boolean => {
+  if (isModificationChange(change)
+    && change.data.before.value.projectCategory !== undefined
+    && change.data.after.value.projectCategory === undefined) {
+    return true
+  }
+  return false
+}
+
+/**
+ * Restructures ProjectCategory to fit the deployment endpoint
+ */
+const filter: FilterCreator = ({ client }) => {
+  const projectIdToCategory: Record<string, ReferenceExpression> = {}
+  return {
+    name: 'projectCategoryFilter',
+    preDeploy: async changes => {
+      changes
+        .filter(isAdditionOrModificationChange)
+        .filter(isInstanceChange)
+        .filter(change => change.data.after.elemID.typeName === PROJECT_TYPE_NAME)
+        .forEach(change => {
+          if (isNeedToDeleteCategory(change) && !client.isDataCenter) {
+            // Jira DC does not support removing projectCategory from a project
+            change.data.after.value.categoryId = DELETED_CATEGORY
+          } else if (change.data.after.value.projectCategory !== undefined) {
+            change.data.after.value.categoryId = change.data.after.value.projectCategory.resValue.value.id
+            projectIdToCategory[change.data.after.value.id] = change.data.after.value.projectCategory
+            delete change.data.after.value.projectCategory
+          }
+        })
+    },
+
+    onDeploy: async (changes: Change<Element>[]) => {
+      changes
+        .filter(isAdditionOrModificationChange)
+        .filter(isInstanceChange)
+        .map(getChangeData)
+        .filter(instance => instance.elemID.typeName === PROJECT_TYPE_NAME)
+        .forEach(instance => {
+          if (instance.value.categoryId !== undefined) {
+            instance.value.projectCategory = projectIdToCategory[instance.value.id]
+            delete instance.value.categoryId
+          }
+        })
+    },
+  }
+}
+
+export default filter

--- a/packages/jira-adapter/test/change_validators/project_category.test.ts
+++ b/packages/jira-adapter/test/change_validators/project_category.test.ts
@@ -74,8 +74,8 @@ describe('projectCategoryValidator', () => {
       {
         elemID: afterInstance.elemID,
         severity: 'Warning',
-        message: 'Cannot remove project Category from a project',
-        detailedMessage: 'Removing a project category from a project is not supported, the project will retain its previous category in the service.',
+        message: 'Can\'t remove an existing project\'s category',
+        detailedMessage: 'Jira Data Center does not support removing an existing project\'s category. The existing category will be retained.',
       },
     ])
   })

--- a/packages/jira-adapter/test/change_validators/project_category.test.ts
+++ b/packages/jira-adapter/test/change_validators/project_category.test.ts
@@ -1,0 +1,115 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { toChange, ObjectType, ElemID, InstanceElement, ChangeValidator, BuiltinTypes, ReferenceExpression } from '@salto-io/adapter-api'
+import { mockClient } from '../utils'
+import { projectCategoryValidator } from '../../src/change_validators/project_category'
+import { JIRA } from '../../src/constants'
+
+describe('projectCategoryValidator', () => {
+  let projectType: ObjectType
+  let projectCategoryType: ObjectType
+  let projectInstance: InstanceElement
+  let categoryInstance: InstanceElement
+  let changeValidator: ChangeValidator
+
+  beforeEach(() => {
+    const { client } = mockClient(true)
+    changeValidator = projectCategoryValidator(client)
+
+    projectCategoryType = new ObjectType({
+      elemID: new ElemID(JIRA, 'ProjectCategory'),
+      fields: {
+        id: { refType: BuiltinTypes.STRING },
+        name: { refType: BuiltinTypes.STRING },
+        description: { refType: BuiltinTypes.STRING },
+      },
+    })
+
+    projectType = new ObjectType({
+      elemID: new ElemID(JIRA, 'Project'),
+      fields: {
+        projectCategory: { refType: projectCategoryType },
+      },
+    })
+
+    categoryInstance = new InstanceElement(
+      'category',
+      projectCategoryType,
+      {
+        name: 'category',
+        description: 'first',
+        id: '10000',
+      }
+    )
+
+    projectInstance = new InstanceElement(
+      'project',
+      projectType,
+      {
+        projectCategory: new ReferenceExpression(categoryInstance.elemID, categoryInstance),
+      }
+    )
+  })
+  it('should return an error when removing a category from a project using DC', async () => {
+    const afterInstance = projectInstance.clone()
+    afterInstance.value.projectCategory = undefined
+    expect(await changeValidator([
+      toChange({
+        before: projectInstance, after: afterInstance,
+      }),
+    ])).toEqual([
+      {
+        elemID: afterInstance.elemID,
+        severity: 'Warning',
+        message: 'Changing project category to None is not supported',
+        detailedMessage: 'Changing project category to None is not supported and the project category will not be changed in the service',
+      },
+    ])
+  })
+  it('should do nothing for a regular change in the project category', async () => {
+    categoryInstance.value.name = 'new name'
+    const afterInstance = projectInstance.clone()
+    afterInstance.value.projectCategory = new ReferenceExpression(categoryInstance.elemID, categoryInstance)
+    expect(await changeValidator([
+      toChange({
+        before: projectInstance,
+        after: afterInstance,
+      }),
+    ])).toEqual([])
+
+    projectInstance.value.projectCategory = undefined
+    expect(await changeValidator([
+      toChange({
+        before: projectInstance,
+        after: afterInstance,
+      }),
+    ])).toEqual([])
+  })
+
+  it('should not return an error when using cloud', async () => {
+    const { client } = mockClient()
+    changeValidator = projectCategoryValidator(client)
+    const afterInstance = projectInstance.clone()
+    afterInstance.value.projectCategory = undefined
+
+    expect(await changeValidator([
+      toChange({
+        before: projectInstance,
+        after: afterInstance,
+      }),
+    ])).toEqual([])
+  })
+})

--- a/packages/jira-adapter/test/change_validators/project_category.test.ts
+++ b/packages/jira-adapter/test/change_validators/project_category.test.ts
@@ -74,8 +74,8 @@ describe('projectCategoryValidator', () => {
       {
         elemID: afterInstance.elemID,
         severity: 'Warning',
-        message: 'Changing project category to None is not supported',
-        detailedMessage: 'Changing project category to None is not supported and the project category will not be changed in the service',
+        message: 'Cannot remove project Category from a project',
+        detailedMessage: 'Removing a project category from a project is not supported, the project will retain its previous category in the service.',
       },
     ])
   })

--- a/packages/jira-adapter/test/filters/project_category.test.ts
+++ b/packages/jira-adapter/test/filters/project_category.test.ts
@@ -1,0 +1,155 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { filterUtils, deployment } from '@salto-io/adapter-components'
+import JiraClient from '../../src/client/client'
+import { JIRA } from '../../src/constants'
+import projectCategoryFilter from '../../src/filters/project_category'
+import { getFilterParams, mockClient } from '../utils'
+
+const DELETED_CATEGORY = -1
+
+jest.mock('@salto-io/adapter-components', () => {
+  const actual = jest.requireActual('@salto-io/adapter-components')
+  return {
+    ...actual,
+    deployment: {
+      ...actual.deployment,
+      deployChange: jest.fn(),
+    },
+  }
+})
+
+describe('projectCategoryFilter', () => {
+  let filter: filterUtils.FilterWith<'onDeploy' | 'preDeploy'>
+  let projectInstance: InstanceElement
+  let firstCategoryInstance: InstanceElement
+  let secondCategoryInstance: InstanceElement
+  let client: JiraClient
+  let projectType: ObjectType
+  let projectCategoryType: ObjectType
+  const deployChangeMock = deployment.deployChange as jest.MockedFunction<
+    typeof deployment.deployChange
+  >
+
+  beforeEach(async () => {
+    deployChangeMock.mockClear()
+    const { client: cli } = mockClient(false)
+    client = cli
+    filter = projectCategoryFilter(getFilterParams({ client })) as typeof filter
+
+    projectCategoryType = new ObjectType({
+      elemID: new ElemID(JIRA, 'ProjectCategory'),
+      fields: {
+        id: { refType: BuiltinTypes.STRING },
+        name: { refType: BuiltinTypes.STRING },
+        description: { refType: BuiltinTypes.STRING },
+      },
+    })
+
+    projectType = new ObjectType({
+      elemID: new ElemID(JIRA, 'Project'),
+      fields: {
+        projectCategory: { refType: projectCategoryType },
+      },
+    })
+
+    firstCategoryInstance = new InstanceElement(
+      'firstCategory',
+      projectCategoryType,
+      {
+        name: 'firstCategory',
+        description: 'first',
+        id: '10000',
+      }
+    )
+
+    secondCategoryInstance = new InstanceElement(
+      'secondCategory',
+      projectCategoryType,
+      {
+        name: 'secondCategory',
+        description: 'second',
+        id: '10001',
+      }
+    )
+
+    projectInstance = new InstanceElement(
+      'project',
+      projectType,
+      {
+        projectCategory: new ReferenceExpression(firstCategoryInstance.elemID, firstCategoryInstance),
+      }
+    )
+  })
+  describe('preDeploy', () => {
+    it('should convert projectCategory to categoryId while its an addition change', async () => {
+      await filter.preDeploy([toChange({ after: projectInstance })])
+      expect(projectInstance.value.categoryId).toEqual('10000')
+      expect(projectInstance.value.projectCategory).toBeUndefined()
+    })
+    it('should convert projectCategory to categoryId while its a modification change', async () => {
+      const afterInstance = projectInstance.clone()
+      afterInstance.value.projectCategory = new ReferenceExpression(
+        secondCategoryInstance.elemID,
+        secondCategoryInstance
+      )
+      await filter.preDeploy([toChange({ before: projectInstance, after: afterInstance })])
+      expect(afterInstance.value.categoryId).toEqual('10001')
+      expect(afterInstance.value.projectCategory).toBeUndefined()
+    })
+    it('should convert projectCategory to categoryId while deleting the category', async () => {
+      const afterInstance = projectInstance.clone()
+      afterInstance.value.projectCategory = undefined
+      await filter.preDeploy([toChange({ before: projectInstance, after: afterInstance })])
+      expect(afterInstance.value.categoryId).toEqual(DELETED_CATEGORY)
+      expect(afterInstance.value.projectCategory).toBeUndefined()
+    })
+    it('should do nothing while its a removing change', async () => {
+      await filter.preDeploy([toChange({ before: projectInstance })])
+      expect(projectInstance.value.categoryId).toBeUndefined()
+      expect(projectInstance.value.projectCategory)
+        .toEqual(new ReferenceExpression(firstCategoryInstance.elemID, firstCategoryInstance))
+    })
+    describe('onDeploy', () => {
+      it('should convert back categoryId to projectCategory while its an addition change', async () => {
+        await filter.preDeploy([toChange({ after: projectInstance })])
+        await filter.onDeploy([toChange({ after: projectInstance })])
+        expect(projectInstance.value.categoryId).toBeUndefined()
+        expect(projectInstance.value.projectCategory)
+          .toEqual(new ReferenceExpression(firstCategoryInstance.elemID, firstCategoryInstance))
+      })
+      it('should convert back categoryId to projectCategory while its a modification change', async () => {
+        const afterInstance = projectInstance.clone()
+        afterInstance.value.projectCategory = new ReferenceExpression(
+          secondCategoryInstance.elemID,
+          secondCategoryInstance
+        )
+        await filter.preDeploy([toChange({ before: projectInstance, after: afterInstance })])
+        await filter.onDeploy([toChange({ before: projectInstance, after: afterInstance })])
+        expect(afterInstance.value.categoryId).toBeUndefined()
+        expect(afterInstance.value.projectCategory)
+          .toEqual(new ReferenceExpression(secondCategoryInstance.elemID, secondCategoryInstance))
+      })
+      it('should do nothing while its a removing change', async () => {
+        await filter.preDeploy([toChange({ before: projectInstance })])
+        expect(projectInstance.value.categoryId).toBeUndefined()
+        expect(projectInstance.value.projectCategory)
+          .toEqual(new ReferenceExpression(firstCategoryInstance.elemID, firstCategoryInstance))
+      })
+    })
+  })
+})


### PR DESCRIPTION
_Add filter to support projectCategory deployment_

---

_Additional context for reviewer_

* as far as I know, DC API does not allow to remove projectCategory form a Project without assign new one to it.
* I added a change validator for the DC case as well.

---
_Release Notes_: 
Jira adapter:
* add support in deployment of assigning Project Category to a Project 

---
_User Notifications_: 
None
