### PR TITLE
SALTO-3827 - Refactor remote map DB connection pool

### DIFF
--- a/packages/core/src/local-workspace/remote_map/counters.ts
+++ b/packages/core/src/local-workspace/remote_map/counters.ts
@@ -37,6 +37,10 @@ export const counterInc = (location: string, counter: CounterType): void => {
   counters[location][counter] += 1
 }
 
+export const counterValue = (location: string, counter: CounterType): number => (
+  counters[location][counter]
+)
+
 export const countersInit = (location: string): void => {
   counters[location] = Object.fromEntries(
     COUNTER_TYPES.map(counterName => [counterName, 0])

--- a/packages/core/src/local-workspace/remote_map/counters.ts
+++ b/packages/core/src/local-workspace/remote_map/counters.ts
@@ -1,0 +1,49 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { logger } from '@salto-io/logging'
+
+const log = logger(module)
+
+const COUNTER_TYPES = [
+  'LocationCacheCreated',
+  'LocationCacheReuse',
+  'LocationCacheHit',
+  'LocationCacheMiss',
+  'RemoteMapCreated',
+  'RemoteMapHit',
+  'RemoteMapMiss',
+  'PersistentDbConnectionCreated',
+  'PersistentDbConnectionReuse',
+  'TmpDbConnectionReuse',
+] as const
+type CounterType = typeof COUNTER_TYPES[number]
+export const counters: Record<string, Record<CounterType, number>> = {}
+
+export const counterInc = (location: string, counter: CounterType): void => {
+  counters[location][counter] += 1
+}
+
+export const countersInit = (location: string): void => {
+  counters[location] = Object.fromEntries(
+    COUNTER_TYPES.map(counterName => [counterName, 0])
+  ) as Record<CounterType, number>
+}
+
+export const countersDumpAndClose = (location: string): void => {
+  log.debug('Remote Map Stats for location \'%s\': %o', location, counters[location])
+  delete counters[location]
+}

--- a/packages/core/src/local-workspace/remote_map/db_connection_pool.ts
+++ b/packages/core/src/local-workspace/remote_map/db_connection_pool.ts
@@ -1,0 +1,296 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import path from 'path'
+import { promisify } from 'util'
+import { logger } from '@salto-io/logging'
+import * as fileUtils from '@salto-io/file'
+import rocksdb from '@salto-io/rocksdb'
+import { collections } from '@salto-io/lowerdash'
+import { counters } from './counters'
+
+const log = logger(module)
+const { awu } = collections.asynciterable
+
+export const TMP_DB_DIR = 'tmp-dbs'
+
+export const MAX_CONNECTIONS = 1000
+let currentConnectionsCount = 0
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let rocksdbImpl: any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const getRemoteDbImpl = (): any => {
+  if (rocksdbImpl === undefined) {
+    // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+    rocksdbImpl = require('./rocksdb').default
+  }
+  return rocksdbImpl
+}
+
+export const closeDanglingConnection = async (connection: Promise<rocksdb>): Promise<void> => {
+  const dbConnection = await connection
+  if (dbConnection.status === 'open') {
+    await promisify(dbConnection.close.bind(dbConnection))()
+    currentConnectionsCount -= 1
+  }
+}
+
+export const getOpenReadOnlyDBConnection = async (
+  loc: string
+): Promise<rocksdb> => {
+  log.debug('opening read-only connection to %s', loc)
+  if (currentConnectionsCount >= MAX_CONNECTIONS) {
+    throw new Error(`Failed to open rocksdb connection - too many open connections already (${currentConnectionsCount} connections)`)
+  }
+  const newDb = getRemoteDbImpl()(loc)
+  await promisify(newDb.open.bind(newDb, { readOnly: true }))()
+  currentConnectionsCount += 1
+  return newDb
+}
+
+const isDBLockErr = (error: Error): boolean =>
+  error.message.includes('LOCK: Resource temporarily unavailable')
+  || error.message.includes('lock hold by current process')
+  || error.message.includes('LOCK: The process cannot access the file because it is being used by another process')
+
+class DBLockError extends Error {
+  constructor() {
+    super('Salto local database locked. Could another Salto process '
+      + 'or a process using Salto be open?')
+  }
+}
+
+export const getDBTmpDir = (location: string): string => path.join(location, TMP_DB_DIR)
+
+const isDBNotExistErr = (error: Error): boolean => (
+  error.message.includes('LOCK: No such file or directory')
+)
+
+const deleteLocation = async (location: string): Promise<void> => {
+  try {
+    await promisify(getRemoteDbImpl().destroy.bind(getRemoteDbImpl(), location))()
+  } catch (e) {
+    // If the DB does not exist, we don't want to throw error upon destroy
+    if (!isDBNotExistErr(e)) {
+      throw e
+    }
+  }
+}
+
+
+const createDBIfNotExist = async (loc: string, persistent: boolean): Promise<void> => {
+  const newDb: rocksdb = getRemoteDbImpl()(loc)
+  const readOnly = !persistent
+  try {
+    await promisify(newDb.open.bind(newDb, { readOnly }))()
+    await promisify(newDb.close.bind(newDb))()
+  } catch (e) {
+    if (newDb.status === 'new' && readOnly) {
+      log.info('DB does not exist. Creating on %s', loc)
+      try {
+        await promisify(newDb.open.bind(newDb))()
+        await promisify(newDb.close.bind(newDb))()
+      } catch (err) {
+        throw new Error(`Failed to open DB in write mode - ${loc}. Error: ${err}`)
+      }
+    } else {
+      throw e
+    }
+  }
+}
+
+
+type DbType = 'main-persistent' | 'main-ephemeral' | 'temporary'
+type DbAttributes = {
+  location: string
+  type: DbType
+}
+export type DbConnection = {
+  dbConn: rocksdb
+  attributes: DbAttributes
+}
+const createDbConnection = async (attributes: DbAttributes, readonly: boolean): Promise<DbConnection> => {
+  const openRocksDBConnection = async (loc: string, isReadOnly: boolean): Promise<rocksdb> => {
+    log.debug('opening connection to %s, read-only=%s', loc, isReadOnly)
+    if (currentConnectionsCount >= MAX_CONNECTIONS) {
+      throw new Error(`Failed to open rocksdb connection - too many open connections already (${currentConnectionsCount} connections)`)
+    }
+    const newDb = getRemoteDbImpl()(loc)
+    await promisify(newDb.open.bind(newDb, { readOnly: isReadOnly }))()
+    currentConnectionsCount += 1
+    return newDb
+  }
+
+  return {
+    dbConn: await openRocksDBConnection(attributes.location, readonly),
+    attributes,
+  }
+}
+type DBConnectionPool = {
+  get: (attributes: DbAttributes) => Promise<DbConnection>
+  put: (connection: DbConnection) => Promise<void>
+  destroyAll: () => Promise<void>
+
+  // These methods are temporary to allow the implementation of closeRemoteMapsOfLocation.
+  // Once we remove closeRemoteMapOfLocation, these methods should be removed.
+  primaryDbLocations: () => string[]
+  putAll: (location: string, type?: DbType) => Promise<void>
+  // ---
+}
+const createDBConnectionPool = (): DBConnectionPool => {
+  const discoverAllTmpDbs = async (dbLocation: string): Promise<string[]> => {
+    const tmpDir = getDBTmpDir(dbLocation)
+    return fileUtils.readDir(tmpDir)
+  }
+  const deleteDb = async (dbDir: string, force?: boolean): Promise<void> => {
+    try {
+      log.debug('cleaning db %s', dbDir)
+      await deleteLocation(dbDir)
+    } catch (e) {
+      if (isDBLockErr(e)) {
+        log.debug('caught a rocksdb lock error while cleaning tmp db: %s', e.message)
+      } else {
+        log.warn('caught an unexpected error while cleaning tmp db: %s', e.message)
+      }
+
+      if (!force) {
+        throw isDBLockErr(e) ? new DBLockError() : e
+      }
+    }
+  }
+
+  const deleteAllTmpDBs = async (location: string, force?: boolean): Promise<void> => {
+    await awu(await discoverAllTmpDbs(location))
+      .forEach(async tmpDbDir => deleteDb(path.join(getDBTmpDir(location), tmpDbDir), force))
+  }
+
+  const prepareAndOpenDB = async ({ location, type }: DbAttributes): Promise<DbConnection> => {
+    try {
+      log.debug('Creating %s DB at %s', type, location)
+      switch (type) {
+        case 'main-persistent':
+          // Make sure there are no leftovers from previous runs
+          await deleteAllTmpDBs(location, true)
+          break
+        case 'main-ephemeral':
+          // This is an ephemeral DB, so we create a new one every time we need one
+          await createDBIfNotExist(location, false)
+          break
+        case 'temporary':
+          break
+        default:
+          throw new Error('Unexpected DB type')
+      }
+
+      const readOnly = (type === 'main-ephemeral')
+      return await createDbConnection({ location, type }, readOnly)
+    } catch (e) {
+      if (isDBLockErr(e)) {
+        throw new DBLockError()
+      }
+      throw e
+    }
+  }
+
+  type PoolEntry = { conn: DbConnection; refcnt: number }
+  const pool: Record<string, PoolEntry> = {}
+  const primaryDbLocations: string[] = []
+
+  const connectionKey = (attributes: DbAttributes): string => (
+    `${attributes.type}@@${attributes.location}`
+  )
+  const getPoolEntry = (attributes: DbAttributes): PoolEntry | undefined => (
+    pool[connectionKey(attributes)]
+  )
+  const newPoolEntry = (attributes: DbAttributes, connection: DbConnection): void => {
+    pool[connectionKey(attributes)] = { conn: connection, refcnt: 1 }
+  }
+  const deletePoolEntry = (attributes: DbAttributes): void => {
+    delete pool[connectionKey(attributes)]
+  }
+  const putImpl = async (connection: DbConnection): Promise<void> => {
+    const poolEntry = getPoolEntry(connection.attributes)
+    if (!poolEntry) {
+      throw new Error('Closing a DB connection that was never opened')
+    }
+    poolEntry.refcnt -= 1
+    if (poolEntry.refcnt === 0) {
+      await closeDanglingConnection(Promise.resolve(poolEntry.conn.dbConn))
+      if (connection.attributes.type === 'temporary') {
+        await deleteDb(poolEntry.conn.attributes.location)
+      } else {
+        _.pull(primaryDbLocations, connection.attributes.location)
+      }
+      deletePoolEntry(connection.attributes)
+    }
+  }
+  return {
+    get: async (attributes): Promise<DbConnection> => {
+      const poolEntry = getPoolEntry(attributes)
+      if (poolEntry) {
+        if (attributes.type === 'temporary') {
+          log.error('Two temporary DBs are sharing the same location')
+        }
+        poolEntry.refcnt += 1
+        counters.locationCounters(attributes.location).PersistentDbConnectionReuse.inc()
+        return poolEntry.conn
+      }
+
+      const conn = await prepareAndOpenDB(attributes)
+      newPoolEntry(attributes, conn)
+      if (attributes.type !== 'temporary') {
+        primaryDbLocations.push(attributes.location)
+      }
+      counters.locationCounters(attributes.location).PersistentDbConnectionCreated.inc()
+      return conn
+    },
+    put: putImpl,
+    destroyAll: async () => {
+      if (pool.size) {
+        log.error('Destroying DBs without closing all connections')
+      }
+      await awu(primaryDbLocations)
+        .forEach(location => deleteAllTmpDBs(location))
+
+      await awu(primaryDbLocations)
+        .forEach(primaryDbDir => deleteDb(primaryDbDir))
+
+      primaryDbLocations.length = 0
+    },
+    primaryDbLocations: (): string[] => (
+      primaryDbLocations
+    ),
+    putAll: async (locationToClose, dbType?) => {
+      const removeFromPool = async (conn: DbConnection): Promise<void> => {
+        const poolEntry = getPoolEntry(conn.attributes)
+        if (!poolEntry) {
+          return
+        }
+        poolEntry.refcnt = 1
+        await putImpl(conn)
+      }
+
+      await Promise.all(
+        Object.values(pool)
+          .filter(({ conn }) => (conn.attributes.location.startsWith(locationToClose)))
+          .filter(({ conn }) => (!dbType || conn.attributes.type === dbType))
+          .map(({ conn }) => removeFromPool(conn)),
+      )
+    },
+  }
+}
+export const dbConnectionPool = createDBConnectionPool()

--- a/packages/core/src/local-workspace/remote_map/index.ts
+++ b/packages/core/src/local-workspace/remote_map/index.ts
@@ -1,0 +1,23 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+export {
+  createRemoteMapCreator,
+  createReadOnlyRemoteMapCreator,
+  closeAllRemoteMaps,
+  closeRemoteMapsOfLocation,
+  cleanDatabases,
+  replicateDB,
+} from './remote_map'

--- a/packages/core/src/local-workspace/remote_map/location_cache.ts
+++ b/packages/core/src/local-workspace/remote_map/location_cache.ts
@@ -31,7 +31,7 @@ export class LocationCache extends LRU<string, unknown> {
 }
 
 export type LocationCachePool = {
-  get: (location: string, cacheSize: number) => LocationCache
+  get: (location: string) => LocationCache
 
   // The 'string' overload is temporary to allow the implementation of closeRemoteMapsOfLocation.
   // Once we remove closeRemoteMapOfLocation, the 'string' overload should be removed.
@@ -40,12 +40,17 @@ export type LocationCachePool = {
 
 export type LocationCachePoolContents = Map<string, { cache: LocationCache; refcnt: number }>
 
-export const createLocationCachePool = (initialContents?: LocationCachePoolContents): LocationCachePool => {
+const DEFAULT_LOCATION_CACHE_SIZE = 5000
+
+export const createLocationCachePool = (
+  initialContents?: LocationCachePoolContents,
+  cacheSize: number = DEFAULT_LOCATION_CACHE_SIZE
+): LocationCachePool => {
   // TODO: LRU if we determine too many locationCaches are created.
   const pool: LocationCachePoolContents = initialContents ?? new Map<string, { cache: LocationCache; refcnt: number }>()
   let poolSizeWatermark = 0
   return {
-    get: (location, cacheSize) => {
+    get: location => {
       const cachePoolEntry = pool.get(location)
       if (cachePoolEntry !== undefined) {
         counters.locationCounters(location).LocationCacheReuse.inc()

--- a/packages/core/src/local-workspace/remote_map/location_cache.ts
+++ b/packages/core/src/local-workspace/remote_map/location_cache.ts
@@ -30,14 +30,14 @@ class LocationCache extends LRU<string, any> {
   }
 }
 
-type LocationCachePool = {
+export type LocationCachePool = {
   get: (location: string, cacheSize: number) => LocationCache
 
   // The 'string' overload is temporary to allow the implementation of closeRemoteMapsOfLocation.
   // Once we remove closeRemoteMapOfLocation, the 'string' overload should be removed.
   put: (cache: LocationCache | string) => void
 }
-const createLocationCachePool = (): LocationCachePool => {
+export const createLocationCachePool = (): LocationCachePool => {
   // TODO: LRU if we determine too many locationCaches are created.
   const pool = new Map<string, { cache: LocationCache; refcnt: number }>()
   return {

--- a/packages/core/src/local-workspace/remote_map/location_cache.ts
+++ b/packages/core/src/local-workspace/remote_map/location_cache.ts
@@ -1,0 +1,72 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { logger } from '@salto-io/logging'
+import LRU from 'lru-cache'
+import { counterInc } from './counters'
+
+const log = logger(module)
+
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+class LocationCache extends LRU<string, any> {
+  readonly location: string
+
+  constructor(location: string, cacheSize: number) {
+    super({ max: cacheSize })
+    this.location = location
+  }
+}
+
+type LocationCachePool = {
+  get: (location: string, cacheSize: number) => LocationCache
+
+  // The 'string' overload is temporary to allow the implementation of closeRemoteMapsOfLocation.
+  // Once we remove closeRemoteMapOfLocation, the 'string' overload should be removed.
+  put: (cache: LocationCache | string) => void
+}
+const createLocationCachePool = (): LocationCachePool => {
+  // TODO: LRU if we determine too many locationCaches are created.
+  const pool = new Map<string, { cache: LocationCache; refcnt: number }>()
+  return {
+    get: (location, cacheSize) => {
+      const cachePoolEntry = pool.get(location)
+      if (cachePoolEntry) {
+        counterInc(location, 'LocationCacheReuse')
+        cachePoolEntry.refcnt += 1
+        return cachePoolEntry.cache
+      }
+      counterInc(location, 'LocationCacheCreated')
+      const newCache: LocationCache = new LocationCache(location, cacheSize)
+      pool.set(location, { cache: newCache, refcnt: 1 })
+      return newCache
+    },
+    put: cacheOrLocation => {
+      const location = _.isString(cacheOrLocation) ? cacheOrLocation : cacheOrLocation.location
+      const poolEntry = pool.get(location)
+      if (!poolEntry || poolEntry.refcnt === 0) {
+        log.error('Bug in LocationCachePool refcounting!')
+        return
+      }
+      poolEntry.refcnt -= 1
+
+      if (poolEntry.refcnt === 0) {
+        pool.delete(location)
+      }
+    },
+  }
+}
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+export const locationCaches = createLocationCachePool()

--- a/packages/core/src/local-workspace/remote_map/location_cache.ts
+++ b/packages/core/src/local-workspace/remote_map/location_cache.ts
@@ -21,7 +21,7 @@ import { counters } from './counters'
 const log = logger(module)
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-class LocationCache extends LRU<string, unknown> {
+export class LocationCache extends LRU<string, unknown> {
   readonly location: string
 
   constructor(location: string, cacheSize: number) {
@@ -37,9 +37,12 @@ export type LocationCachePool = {
   // Once we remove closeRemoteMapOfLocation, the 'string' overload should be removed.
   release: (cache: LocationCache | string) => void
 }
-export const createLocationCachePool = (): LocationCachePool => {
+
+export type LocationCachePoolContents = Map<string, { cache: LocationCache; refcnt: number }>
+
+export const createLocationCachePool = (initialContents?: LocationCachePoolContents): LocationCachePool => {
   // TODO: LRU if we determine too many locationCaches are created.
-  const pool = new Map<string, { cache: LocationCache; refcnt: number }>()
+  const pool: LocationCachePoolContents = initialContents ?? new Map<string, { cache: LocationCache; refcnt: number }>()
   let poolSizeWatermark = 0
   return {
     get: (location, cacheSize) => {

--- a/packages/core/src/local-workspace/remote_map/location_cache.ts
+++ b/packages/core/src/local-workspace/remote_map/location_cache.ts
@@ -16,7 +16,7 @@
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import LRU from 'lru-cache'
-import { counterInc } from './counters'
+import { counters } from './counters'
 
 const log = logger(module)
 
@@ -45,11 +45,11 @@ export const createLocationCachePool = (): LocationCachePool => {
     get: (location, cacheSize) => {
       const cachePoolEntry = pool.get(location)
       if (cachePoolEntry) {
-        counterInc(location, 'LocationCacheReuse')
+        counters.locationCounters(location).LocationCacheReuse.inc()
         cachePoolEntry.refcnt += 1
         return cachePoolEntry.cache
       }
-      counterInc(location, 'LocationCacheCreated')
+      counters.locationCounters(location).LocationCacheCreated.inc()
       const newCache: LocationCache = new LocationCache(location, cacheSize)
       pool.set(location, { cache: newCache, refcnt: 1 })
       if (pool.size > maxPoolSize) {

--- a/packages/core/src/local-workspace/remote_map/location_cache.ts
+++ b/packages/core/src/local-workspace/remote_map/location_cache.ts
@@ -57,7 +57,7 @@ export const createLocationCachePool = (): LocationCachePool => {
       const location = _.isString(cacheOrLocation) ? cacheOrLocation : cacheOrLocation.location
       const poolEntry = pool.get(location)
       if (!poolEntry || poolEntry.refcnt === 0) {
-        log.error('Bug in LocationCachePool refcounting!')
+        log.error('Returning a locationCache for an unknown location %s. poolEntry=%o', location, poolEntry)
         return
       }
       poolEntry.refcnt -= 1

--- a/packages/core/src/local-workspace/remote_map/remote_map.ts
+++ b/packages/core/src/local-workspace/remote_map/remote_map.ts
@@ -429,12 +429,11 @@ ReadIterator => {
 }
 
 export const createRemoteMapCreator = (location: string,
-  persistentDefaultValue = false,
-  cacheSize = 5000):
+  persistentDefaultValue = false):
 remoteMap.RemoteMapCreator => {
   const statCounters = counters.locationCounters(location)
 
-  const locationCache = locationCaches.get(location, cacheSize)
+  const locationCache = locationCaches.get(location)
 
   let persistentDB: rocksdb
   let tmpDB: rocksdb

--- a/packages/core/src/local-workspace/remote_map/remote_map.ts
+++ b/packages/core/src/local-workspace/remote_map/remote_map.ts
@@ -57,7 +57,7 @@ let rocksdbImpl: any
 const getRemoteDbImpl = (): any => {
   if (rocksdbImpl === undefined) {
     // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
-    rocksdbImpl = require('./rocksdb').default
+    rocksdbImpl = require('../rocksdb').default
   }
   return rocksdbImpl
 }

--- a/packages/core/src/local-workspace/remote_map/remote_map.ts
+++ b/packages/core/src/local-workspace/remote_map/remote_map.ts
@@ -58,7 +58,7 @@ let rocksdbImpl: any
 const getRemoteDbImpl = (): any => {
   if (rocksdbImpl === undefined) {
     // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
-    rocksdbImpl = require('../rocksdb').default
+    rocksdbImpl = require('./rocksdb').default
   }
   return rocksdbImpl
 }
@@ -273,7 +273,7 @@ export const closeRemoteMapsOfLocation = async (location: string): Promise<void>
     delete readonlyDBConnectionsPerRemoteMap[location]
     log.debug('closed read-only connections per remote map of location %s', location)
   }
-  locationCaches.put(location)
+  locationCaches.release(location)
   counters.locationCounters(location).dump()
   counters.deleteLocation(location)
 }

--- a/packages/core/src/local-workspace/remote_map/rocksdb.ts
+++ b/packages/core/src/local-workspace/remote_map/rocksdb.ts
@@ -16,7 +16,7 @@
 import rimraf from 'rimraf'
 import fsExtra from 'fs-extra'
 import path from 'path'
-import { getSaltoHome } from '../app_config'
+import { getSaltoHome } from '../../app_config'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const requireOrExtract = (externalsLocation: string): any => {

--- a/packages/core/test/workspace/local/remote_map/location_cache.test.ts
+++ b/packages/core/test/workspace/local/remote_map/location_cache.test.ts
@@ -1,0 +1,70 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import _ from 'lodash'
+import { LocationCachePool, createLocationCachePool } from '../../../../src/local-workspace/remote_map/location_cache'
+import { countersDumpAndClose, countersInit, counterValue } from '../../../../src/local-workspace/remote_map/counters'
+
+describe('remote map location cache pool', () => {
+  let pool: LocationCachePool
+  const LOCATION1 = 'SomeLocation'
+  const LOCATION2 = 'SomeOtherLocation'
+
+  beforeEach(() => {
+    [LOCATION1, LOCATION2].forEach(loc => countersInit(loc))
+    pool = createLocationCachePool()
+  })
+
+  afterEach(() => {
+    [LOCATION1, LOCATION2].forEach(loc => countersDumpAndClose(loc))
+  })
+
+  it('should create a location cache for the right location', () => {
+    const cache = pool.get(LOCATION1, 5000)
+    expect(cache.location).toEqual(LOCATION1)
+    expect(counterValue(LOCATION1, 'LocationCacheCreated')).toEqual(1)
+    expect(counterValue(LOCATION1, 'LocationCacheReuse')).toEqual(0)
+    pool.put(cache)
+  })
+
+  it('should reuse caches where possible', () => {
+    const caches = _.times(10, () => pool.get(LOCATION1, 5000))
+    expect(counterValue(LOCATION1, 'LocationCacheCreated')).toEqual(1)
+    expect(counterValue(LOCATION1, 'LocationCacheReuse')).toEqual(caches.length - 1)
+    caches.forEach(cache => pool.put(cache))
+  })
+
+  it('should not reuse caches of a different location', () => {
+    const cache = pool.get(LOCATION1, 5000)
+    const anotherCache = pool.get(LOCATION2, 5000)
+    expect(cache.location).toEqual(LOCATION1)
+    expect(anotherCache.location).toEqual(LOCATION2)
+    expect(counterValue(LOCATION1, 'LocationCacheCreated')).toEqual(1)
+    expect(counterValue(LOCATION2, 'LocationCacheCreated')).toEqual(1)
+    expect(counterValue(LOCATION1, 'LocationCacheReuse')).toEqual(0)
+    pool.put(cache)
+    pool.put(anotherCache)
+  })
+
+  it('should destroy cache when the last reference to it is returned', () => {
+    const cache = pool.get(LOCATION1, 5000)
+    pool.put(cache)
+    const anotherCache = pool.get(LOCATION1, 5000)
+    expect(counterValue(LOCATION1, 'LocationCacheCreated')).toEqual(2)
+    expect(counterValue(LOCATION1, 'LocationCacheReuse')).toEqual(0)
+    pool.put(anotherCache)
+  })
+})

--- a/packages/core/test/workspace/local/remote_map/location_cache.test.ts
+++ b/packages/core/test/workspace/local/remote_map/location_cache.test.ts
@@ -33,7 +33,7 @@ describe('remote map location cache pool', () => {
   })
 
   it('should create a location cache for the right location', () => {
-    const cache = pool.get(LOCATION1, 5000)
+    const cache = pool.get(LOCATION1)
     expect(cache.location).toEqual(LOCATION1)
     expect(poolContents.size).toEqual(1)
     expect(poolContents.get(LOCATION1)).toBeDefined()
@@ -41,14 +41,14 @@ describe('remote map location cache pool', () => {
   })
 
   it('should reuse caches where possible', () => {
-    _.times(10, () => pool.get(LOCATION1, 5000))
+    _.times(10, () => pool.get(LOCATION1))
     expect(poolContents.size).toEqual(1)
     expect(poolContents.get(LOCATION1)?.refcnt).toEqual(10)
   })
 
   it('should not reuse caches of a different location', () => {
-    const cache = pool.get(LOCATION1, 5000)
-    const anotherCache = pool.get(LOCATION2, 5000)
+    const cache = pool.get(LOCATION1)
+    const anotherCache = pool.get(LOCATION2)
     expect(cache.location).toEqual(LOCATION1)
     expect(anotherCache.location).toEqual(LOCATION2)
     expect(poolContents.size).toEqual(2)
@@ -57,10 +57,10 @@ describe('remote map location cache pool', () => {
   })
 
   it('should destroy cache when the last reference to it is returned', () => {
-    const cache = pool.get(LOCATION1, 5000)
+    const cache = pool.get(LOCATION1)
     pool.release(cache)
     expect(poolContents.size).toEqual(0)
-    pool.get(LOCATION1, 5000)
+    pool.get(LOCATION1)
     expect(poolContents.size).toEqual(1)
     expect(poolContents.get(LOCATION1)?.refcnt).toEqual(1)
   })

--- a/packages/core/test/workspace/local/remote_map/location_cache.test.ts
+++ b/packages/core/test/workspace/local/remote_map/location_cache.test.ts
@@ -36,14 +36,14 @@ describe('remote map location cache pool', () => {
     expect(cache.location).toEqual(LOCATION1)
     expect(counters.locationCounters(LOCATION1).LocationCacheCreated.value()).toEqual(1)
     expect(counters.locationCounters(LOCATION1).LocationCacheReuse.value()).toEqual(0)
-    pool.put(cache)
+    pool.release(cache)
   })
 
   it('should reuse caches where possible', () => {
     const caches = _.times(10, () => pool.get(LOCATION1, 5000))
     expect(counters.locationCounters(LOCATION1).LocationCacheCreated.value()).toEqual(1)
     expect(counters.locationCounters(LOCATION1).LocationCacheReuse.value()).toEqual(caches.length - 1)
-    caches.forEach(cache => pool.put(cache))
+    caches.forEach(cache => pool.release(cache))
   })
 
   it('should not reuse caches of a different location', () => {
@@ -54,16 +54,16 @@ describe('remote map location cache pool', () => {
     expect(counters.locationCounters(LOCATION1).LocationCacheCreated.value()).toEqual(1)
     expect(counters.locationCounters(LOCATION2).LocationCacheCreated.value()).toEqual(1)
     expect(counters.locationCounters(LOCATION1).LocationCacheReuse.value()).toEqual(0)
-    pool.put(cache)
-    pool.put(anotherCache)
+    pool.release(cache)
+    pool.release(anotherCache)
   })
 
   it('should destroy cache when the last reference to it is returned', () => {
     const cache = pool.get(LOCATION1, 5000)
-    pool.put(cache)
+    pool.release(cache)
     const anotherCache = pool.get(LOCATION1, 5000)
     expect(counters.locationCounters(LOCATION1).LocationCacheCreated.value()).toEqual(2)
     expect(counters.locationCounters(LOCATION1).LocationCacheReuse.value()).toEqual(0)
-    pool.put(anotherCache)
+    pool.release(anotherCache)
   })
 })

--- a/packages/core/test/workspace/local/remote_map/location_cache.test.ts
+++ b/packages/core/test/workspace/local/remote_map/location_cache.test.ts
@@ -15,35 +15,35 @@
 */
 
 import _ from 'lodash'
-import { LocationCachePool, createLocationCachePool } from '../../../../src/local-workspace/remote_map/location_cache'
-import { counters } from '../../../../src/local-workspace/remote_map/counters'
+import {
+  LocationCachePool,
+  createLocationCachePool,
+  LocationCachePoolContents, LocationCache,
+} from '../../../../src/local-workspace/remote_map/location_cache'
 
 describe('remote map location cache pool', () => {
+  let poolContents: LocationCachePoolContents
   let pool: LocationCachePool
   const LOCATION1 = 'SomeLocation'
   const LOCATION2 = 'SomeOtherLocation'
 
   beforeEach(() => {
-    pool = createLocationCachePool()
-  })
-
-  afterEach(() => {
-    [LOCATION1, LOCATION2].forEach(loc => counters.deleteLocation(loc))
+    poolContents = new Map<string, { cache: LocationCache; refcnt: number }>()
+    pool = createLocationCachePool(poolContents)
   })
 
   it('should create a location cache for the right location', () => {
     const cache = pool.get(LOCATION1, 5000)
     expect(cache.location).toEqual(LOCATION1)
-    expect(counters.locationCounters(LOCATION1).LocationCacheCreated.value()).toEqual(1)
-    expect(counters.locationCounters(LOCATION1).LocationCacheReuse.value()).toEqual(0)
-    pool.release(cache)
+    expect(poolContents.size).toEqual(1)
+    expect(poolContents.get(LOCATION1)).toBeDefined()
+    expect(poolContents.get(LOCATION1)?.refcnt).toEqual(1)
   })
 
   it('should reuse caches where possible', () => {
-    const caches = _.times(10, () => pool.get(LOCATION1, 5000))
-    expect(counters.locationCounters(LOCATION1).LocationCacheCreated.value()).toEqual(1)
-    expect(counters.locationCounters(LOCATION1).LocationCacheReuse.value()).toEqual(caches.length - 1)
-    caches.forEach(cache => pool.release(cache))
+    _.times(10, () => pool.get(LOCATION1, 5000))
+    expect(poolContents.size).toEqual(1)
+    expect(poolContents.get(LOCATION1)?.refcnt).toEqual(10)
   })
 
   it('should not reuse caches of a different location', () => {
@@ -51,19 +51,17 @@ describe('remote map location cache pool', () => {
     const anotherCache = pool.get(LOCATION2, 5000)
     expect(cache.location).toEqual(LOCATION1)
     expect(anotherCache.location).toEqual(LOCATION2)
-    expect(counters.locationCounters(LOCATION1).LocationCacheCreated.value()).toEqual(1)
-    expect(counters.locationCounters(LOCATION2).LocationCacheCreated.value()).toEqual(1)
-    expect(counters.locationCounters(LOCATION1).LocationCacheReuse.value()).toEqual(0)
-    pool.release(cache)
-    pool.release(anotherCache)
+    expect(poolContents.size).toEqual(2)
+    expect(poolContents.get(LOCATION1)?.refcnt).toEqual(1)
+    expect(poolContents.get(LOCATION2)?.refcnt).toEqual(1)
   })
 
   it('should destroy cache when the last reference to it is returned', () => {
     const cache = pool.get(LOCATION1, 5000)
     pool.release(cache)
-    const anotherCache = pool.get(LOCATION1, 5000)
-    expect(counters.locationCounters(LOCATION1).LocationCacheCreated.value()).toEqual(2)
-    expect(counters.locationCounters(LOCATION1).LocationCacheReuse.value()).toEqual(0)
-    pool.release(anotherCache)
+    expect(poolContents.size).toEqual(0)
+    pool.get(LOCATION1, 5000)
+    expect(poolContents.size).toEqual(1)
+    expect(poolContents.get(LOCATION1)?.refcnt).toEqual(1)
   })
 })

--- a/packages/core/test/workspace/local/remote_map/remote_map.test.ts
+++ b/packages/core/test/workspace/local/remote_map/remote_map.test.ts
@@ -26,10 +26,10 @@ import {
   createRemoteMapCreator,
   createReadOnlyRemoteMapCreator,
   RocksDBValue,
-  TMP_DB_DIR,
   closeRemoteMapsOfLocation,
   cleanDatabases,
 } from '../../../../src/local-workspace/remote_map/remote_map'
+import { getDBTmpDir } from '../../../../src/local-workspace/remote_map/db_connection_pool'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const rocksdbImpl = require('../../../../src/local-workspace/remote_map/rocksdb').default
@@ -773,7 +773,7 @@ describe('test operations on remote db', () => {
 
 describe('tmp db deletion', () => {
   const DB_LOCATION_TMP = path.join(DB_LOCATION, 'tmp')
-  const TMP_DIR = path.join(DB_LOCATION_TMP, TMP_DB_DIR)
+  const TMP_DIR = getDBTmpDir(DB_LOCATION_TMP)
   const EXISTING_LOCATION = path.join(TMP_DIR, 'existing')
   it('should delete existing tmp dbs on startup', async () => {
     // Ensure no leftovers from previous tests.
@@ -804,7 +804,7 @@ describe('non persistent mode', () => {
   })
 
   it('should destroy the tmp storage dirs after the connection is closed', async () => {
-    const tmpDir = path.join(DB_LOCATION_TMP, TMP_DB_DIR)
+    const tmpDir = getDBTmpDir(DB_LOCATION_TMP)
     await createMap(DB_LOCATION_TMP, false, DB_LOCATION_TMP)
     expect(readdirSync(tmpDir)).not.toEqual([])
     await closeRemoteMapsOfLocation(DB_LOCATION_TMP)

--- a/packages/core/test/workspace/local/remote_map/remote_map.test.ts
+++ b/packages/core/test/workspace/local/remote_map/remote_map.test.ts
@@ -32,7 +32,7 @@ import {
 } from '../../../../src/local-workspace/remote_map/remote_map'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const rocksdbImpl = require('../../../../src/local-workspace/rocksdb').default
+const rocksdbImpl = require('../../../../src/local-workspace/remote_map/rocksdb').default
 
 const { serialize, deserialize } = serialization
 const { awu } = collections.asynciterable

--- a/packages/core/test/workspace/local/remote_map/remote_map.test.ts
+++ b/packages/core/test/workspace/local/remote_map/remote_map.test.ts
@@ -29,10 +29,10 @@ import {
   TMP_DB_DIR,
   closeRemoteMapsOfLocation,
   cleanDatabases,
-} from '../../../src/local-workspace/remote_map'
+} from '../../../../src/local-workspace/remote_map/remote_map'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const rocksdbImpl = require('../../../src/local-workspace/rocksdb').default
+const rocksdbImpl = require('../../../../src/local-workspace/rocksdb').default
 
 const { serialize, deserialize } = serialization
 const { awu } = collections.asynciterable

--- a/packages/core/test/workspace/local/remote_map/remote_map_connection.test.ts
+++ b/packages/core/test/workspace/local/remote_map/remote_map_connection.test.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import { remoteMap as rm } from '@salto-io/workspace'
-import { createRemoteMapCreator, createReadOnlyRemoteMapCreator, MAX_CONNECTIONS, closeAllRemoteMaps } from '../../../src/local-workspace/remote_map'
+import { createRemoteMapCreator, createReadOnlyRemoteMapCreator, MAX_CONNECTIONS, closeAllRemoteMaps } from '../../../../src/local-workspace/remote_map/remote_map'
 
 describe('connection creation', () => {
   const DB_LOCATION = '/tmp/test_db'
@@ -29,7 +29,7 @@ describe('connection creation', () => {
       status: 'open',
     })
     mockedRocksdb.destroy = jest.fn().mockImplementation((_loc, cb) => { cb() })
-    jest.mock('../../../src/local-workspace/rocksdb', () => ({
+    jest.mock('../../../../src/local-workspace/rocksdb', () => ({
       default: mockedRocksdb,
     }))
 

--- a/packages/core/test/workspace/local/remote_map/remote_map_connection.test.ts
+++ b/packages/core/test/workspace/local/remote_map/remote_map_connection.test.ts
@@ -29,7 +29,7 @@ describe('connection creation', () => {
       status: 'open',
     })
     mockedRocksdb.destroy = jest.fn().mockImplementation((_loc, cb) => { cb() })
-    jest.mock('../../../../src/local-workspace/rocksdb', () => ({
+    jest.mock('../../../../src/local-workspace/remote_map/rocksdb', () => ({
       default: mockedRocksdb,
     }))
 

--- a/packages/core/test/workspace/local/remote_map/remote_map_connection.test.ts
+++ b/packages/core/test/workspace/local/remote_map/remote_map_connection.test.ts
@@ -15,7 +15,8 @@
 */
 import _ from 'lodash'
 import { remoteMap as rm } from '@salto-io/workspace'
-import { createRemoteMapCreator, createReadOnlyRemoteMapCreator, MAX_CONNECTIONS, closeAllRemoteMaps } from '../../../../src/local-workspace/remote_map/remote_map'
+import { createRemoteMapCreator, createReadOnlyRemoteMapCreator, closeAllRemoteMaps } from '../../../../src/local-workspace/remote_map/remote_map'
+import { MAX_CONNECTIONS } from '../../../../src/local-workspace/remote_map/db_connection_pool'
 
 describe('connection creation', () => {
   const DB_LOCATION = '/tmp/test_db'


### PR DESCRIPTION
Replace global records with refcounted pool

---

This is a step in our journey towards proper resource management in the RemoteMap implementation.
We refrain from touching the global pools associated with read-only maps for now, to minimize the change. Note that read-only maps have proper close() function.
ref: https://www.notion.so/saltoio/Notes-SALTO-2490-34a1b434f10a4eacb74a441d8339e6ea

---
_Release Notes_: 
N/A

---
_User Notifications_: 
N/A
