### PR TITLE
SALTO-3479: Bugfix

### DIFF
--- a/packages/lowerdash/src/types.ts
+++ b/packages/lowerdash/src/types.ts
@@ -99,3 +99,4 @@ export const isNonEmptyArray = <T> (array: T[]): array is NonEmptyArray<T> => (
 
 export type AllowOnly<T, K extends keyof T> = Pick<T, K> & { [P in keyof Omit<T, K>]?: never };
 export type OneOf<T, K = keyof T> = K extends keyof T ? AllowOnly<T, K> : never
+export type ArrayOrSingle<T> = T | T[]

--- a/packages/salesforce-adapter/src/filters/global_value_sets.ts
+++ b/packages/salesforce-adapter/src/filters/global_value_sets.ts
@@ -78,7 +78,7 @@ const addRefAndRestrict = (
   if (isRestrictableField(field)) {
     field.annotations[CORE_ANNOTATIONS.RESTRICTION] = createRestriction({
       enforce_value: isRequired(field),
-      values: makeArray(globalValueSetValue).customValue.map(entry => entry[INSTANCE_FULL_NAME_FIELD]),
+      values: makeArray(globalValueSetValue.customValue).map(entry => entry[INSTANCE_FULL_NAME_FIELD]),
     })
   }
 }

--- a/packages/salesforce-adapter/src/filters/global_value_sets.ts
+++ b/packages/salesforce-adapter/src/filters/global_value_sets.ts
@@ -75,7 +75,7 @@ const addRefAndRestrict = (
     log.warn('Could not create restriction for GlobalValueSet %s, due to unknown value format: %o', valueSetName, globalValueSetValue)
     return
   }
-  if (isRestrictableField(field)) {
+  if (isRestrictableField(field) && _.isArray(globalValueSetValue.customValue)) {
     field.annotations[CORE_ANNOTATIONS.RESTRICTION] = createRestriction({
       enforce_value: isRequired(field),
       values: globalValueSetValue.customValue.map(entry => entry[INSTANCE_FULL_NAME_FIELD]),

--- a/packages/salesforce-adapter/src/filters/global_value_sets.ts
+++ b/packages/salesforce-adapter/src/filters/global_value_sets.ts
@@ -24,7 +24,7 @@ import {
   isInstanceElement,
   Values,
 } from '@salto-io/adapter-api'
-import { collections, multiIndex } from '@salto-io/lowerdash'
+import { collections, multiIndex, types } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { isRequired } from '@salto-io/adapter-utils'
@@ -46,9 +46,9 @@ export const MASTER_LABEL = 'master_label'
 
 
 type GlobalValueSetValue = InstanceElement['value'] & {
-  [FIELD_ANNOTATIONS.CUSTOM_VALUE]: {
+  [FIELD_ANNOTATIONS.CUSTOM_VALUE]: types.ArrayOrSingle<{
     [INSTANCE_FULL_NAME_FIELD]: string
-  }[]
+  }>
 }
 
 const isGlobalValueSetValue = (value: Values): value is GlobalValueSetValue => (
@@ -75,10 +75,10 @@ const addRefAndRestrict = (
     log.warn('Could not create restriction for GlobalValueSet %s, due to unknown value format: %o', valueSetName, globalValueSetValue)
     return
   }
-  if (isRestrictableField(field) && _.isArray(globalValueSetValue.customValue)) {
+  if (isRestrictableField(field)) {
     field.annotations[CORE_ANNOTATIONS.RESTRICTION] = createRestriction({
       enforce_value: isRequired(field),
-      values: globalValueSetValue.customValue.map(entry => entry[INSTANCE_FULL_NAME_FIELD]),
+      values: makeArray(globalValueSetValue).customValue.map(entry => entry[INSTANCE_FULL_NAME_FIELD]),
     })
   }
 }


### PR DESCRIPTION
The code assumed that `GlobalValueSet.customValue` is an array, even though it can return as single value (When only 1 value exists in the permission set)