### PR TITLE
SALTO-3608: Replace user ids with usernames in Okta

### DIFF
--- a/packages/adapter-components/src/client/pagination.ts
+++ b/packages/adapter-components/src/client/pagination.ts
@@ -96,7 +96,7 @@ export const traverseRequests: (
   pageSize,
   getParams,
 }) {
-  const { url, queryParams, recursiveQueryParams } = getParams
+  const { url, queryParams, recursiveQueryParams, headers } = getParams
   const requestQueryArgs: Record<string, string>[] = [{}]
   const usedParams = new Set<string>()
   let numResults = 0
@@ -114,6 +114,7 @@ export const traverseRequests: (
     const response = await client.getSinglePage({
       url,
       queryParams: Object.keys(params).length > 0 ? params : undefined,
+      headers,
     })
 
     if (response.status !== 200) {

--- a/packages/okta-adapter/config_doc.md
+++ b/packages/okta-adapter/config_doc.md
@@ -62,14 +62,9 @@ okta {
 
 | Name                                        | Default when undefined            | Description
 |---------------------------------------------|-----------------------------------|------------
-| [include](#fetch-entry-options)               | [{ type = ".*" }]                 | List of entries to determine what instances to include in the fetch
-| [exclude](#fetch-entry-options)               | []                                | List of entries to determine what instances to exclude in the fetch
-
-## Masking configuration options
-| Name                                        | Default when undefined            | Description
-|---------------------------------------------|-----------------------------------|------------
-| automationHeaders                           | []                                | List of regexes of header keys in Automations to mask their values
-| secretRegexps                               | []                                | List of regexes of strings to mask all across the workspace
+| [include](#fetch-entry-options)             | [{ type = ".*" }]                 | List of entries to determine what instances to include in the fetch
+| [exclude](#fetch-entry-options)             | []                                | List of entries to determine what instances to exclude in the fetch
+| convertUsersIds                             | true                              | When enabled, user IDs will be replaced with user login names
 
 ## Fetch entry options
 

--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -36,6 +36,7 @@ import standardRolesFilter from './filters/standard_roles'
 import fetchUserSchemaFilter from './filters/user_schema'
 import oktaExpressionLanguageFilter from './filters/expression_language'
 import defaultPolicyRuleDeployment from './filters/default_rule_deployment'
+import userFilter from './filters/user'
 import { OKTA } from './constants'
 import { getLookUpName } from './reference_mapping'
 
@@ -56,6 +57,7 @@ export const DEFAULT_FILTERS = [
   urlReferencesFilter,
   // should run before fieldReferencesFilter
   replaceObjectWithIdFilter,
+  userFilter,
   oktaExpressionLanguageFilter,
   fieldReferencesFilter,
   groupDeploymentFilter,

--- a/packages/okta-adapter/src/client/pagination.ts
+++ b/packages/okta-adapter/src/client/pagination.ts
@@ -37,7 +37,7 @@ export const getWithCursorHeaderPagination = (): clientUtils.PaginationFunc => {
   const nextPageCursorPagesByHeader: clientUtils.PaginationFunc = ({
     responseHeaders, getParams, currentParams,
   }) => {
-    const { url } = getParams
+    const { url, headers } = getParams
     if (responseHeaders !== undefined) {
       const linkHeader = _.get(responseHeaders, LINK_HEADER_NAME)
       if (_.isString(linkHeader)) {
@@ -50,6 +50,7 @@ export const getWithCursorHeaderPagination = (): clientUtils.PaginationFunc => {
           return [{
             ...currentParams,
             ...Object.fromEntries(nextPage.searchParams.entries()),
+            ...headers,
           }]
         }
       }

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { ElemID, CORE_ANNOTATIONS, ActionName } from '@salto-io/adapter-api'
+import { ElemID, CORE_ANNOTATIONS, ActionName, BuiltinTypes } from '@salto-io/adapter-api'
 import { createMatchingObjectType } from '@salto-io/adapter-utils'
 import { client as clientUtils, config as configUtils, elements } from '@salto-io/adapter-components'
 import { ACCESS_POLICY_TYPE_NAME, CUSTOM_NAME_FIELD, IDP_POLICY_TYPE_NAME, MFA_POLICY_TYPE_NAME, OKTA, PASSWORD_POLICY_TYPE_NAME, PROFILE_ENROLLMENT_POLICY_TYPE_NAME, SIGN_ON_POLICY_TYPE_NAME } from './constants'
@@ -28,7 +28,9 @@ export const API_DEFINITIONS_CONFIG = 'apiDefinitions'
 
 export type OktaClientConfig = clientUtils.ClientBaseConfig<clientUtils.ClientRateLimitConfig>
 export type OktaActionName = ActionName | 'activate' | 'deactivate'
-export type OktaFetchConfig = configUtils.UserFetchConfig
+export type OktaFetchConfig = configUtils.UserFetchConfig & {
+  convertUsersIds?: boolean
+}
 export type OktaApiConfig = configUtils.AdapterSwaggerApiConfig<OktaActionName>
 
 export type OktaConfig = {
@@ -916,6 +918,7 @@ export const DEFAULT_CONFIG: OktaConfig = {
   [FETCH_CONFIG]: {
     ...elements.query.INCLUDE_ALL_CONFIG,
     hideTypes: true,
+    convertUsersIds: true,
   },
   [API_DEFINITIONS_CONFIG]: DEFAULT_API_DEFINITIONS,
 }
@@ -929,6 +932,9 @@ export const configType = createMatchingObjectType<Partial<OktaConfig>>({
     [FETCH_CONFIG]: {
       refType: createUserFetchConfigType(
         OKTA,
+        {
+          convertUsersIds: { refType: BuiltinTypes.BOOLEAN },
+        }
       ),
     },
     [API_DEFINITIONS_CONFIG]: {
@@ -938,7 +944,12 @@ export const configType = createMatchingObjectType<Partial<OktaConfig>>({
     },
   },
   annotations: {
-    [CORE_ANNOTATIONS.DEFAULT]: _.omit(DEFAULT_CONFIG, API_DEFINITIONS_CONFIG, `${FETCH_CONFIG}.hideTypes`),
+    [CORE_ANNOTATIONS.DEFAULT]: _.omit(
+      DEFAULT_CONFIG,
+      API_DEFINITIONS_CONFIG,
+      `${FETCH_CONFIG}.hideTypes`,
+      `${FETCH_CONFIG}.convertUsersIds`
+    ),
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },
 })

--- a/packages/okta-adapter/src/filters/user.ts
+++ b/packages/okta-adapter/src/filters/user.ts
@@ -21,11 +21,9 @@ import { collections } from '@salto-io/lowerdash'
 import { Change, getChangeData, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { FilterCreator } from '../filter'
-import { paginate } from '../client/pagination'
 import { ACCESS_POLICY_RULE_TYPE_NAME, GROUP_RULE_TYPE_NAME, MFA_RULE_TYPE_NAME, PASSWORD_RULE_TYPE_NAME, SIGN_ON_RULE_TYPE_NAME } from '../constants'
 
 const log = logger(module)
-const { createPaginator } = clientUtils
 const { toArrayAsync, awu } = collections.asynciterable
 const { makeArray } = collections.array
 
@@ -119,15 +117,11 @@ export const replaceValuesForChanges = async (
 /**
  * Replaces user ids with user login
  */
-const filterCreator: FilterCreator = ({ client }) => {
+const filterCreator: FilterCreator = ({ paginator }) => {
   let userIdToLogin: Record<string, string> = {}
   return {
     name: 'usersFilter',
     onFetch: async elements => {
-      const paginator = createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      })
       const users = await getUsers(paginator)
       if (_.isEmpty(users)) {
         log.warn('In users filter onFetch, could not find any users')
@@ -147,10 +141,6 @@ const filterCreator: FilterCreator = ({ client }) => {
       if (_.isEmpty(relevantChanges)) {
         return
       }
-      const paginator = createPaginator({
-        client,
-        paginationFuncCreator: paginate,
-      })
       const users = await getUsers(paginator)
       if (_.isEmpty(users)) {
         log.warn('In users filter preDeploy, could not find any users')

--- a/packages/okta-adapter/src/filters/user.ts
+++ b/packages/okta-adapter/src/filters/user.ts
@@ -1,0 +1,179 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import Joi from 'joi'
+import { logger } from '@salto-io/logging'
+import { applyFunctionToChangeData, resolvePath, setPath } from '@salto-io/adapter-utils'
+import { collections } from '@salto-io/lowerdash'
+import { Change, getChangeData, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
+import { client as clientUtils } from '@salto-io/adapter-components'
+import { FilterCreator } from '../filter'
+import { paginate } from '../client/pagination'
+import { ACCESS_POLICY_RULE_TYPE_NAME, GROUP_RULE_TYPE_NAME, MFA_RULE_TYPE_NAME, PASSWORD_RULE_TYPE_NAME, SIGN_ON_RULE_TYPE_NAME } from '../constants'
+
+const log = logger(module)
+const { createPaginator } = clientUtils
+const { toArrayAsync, awu } = collections.asynciterable
+const { makeArray } = collections.array
+
+type User = {
+  id: string
+  profile: {
+    login: string
+  }
+}
+
+const USER_SCHEMA = Joi.object({
+  id: Joi.string().required(),
+  profile: Joi.object({
+    login: Joi.string().required(),
+  }).unknown(true),
+}).unknown(true)
+
+const USERS_RESPONSE_SCHEMA = Joi.array().items(USER_SCHEMA).required()
+
+const areUsers = (values: unknown): values is User[] => {
+  const { error } = USERS_RESPONSE_SCHEMA.validate(values)
+  if (error !== undefined) {
+    log.warn(`Received an invalid response for the users: ${error.message}`)
+    return false
+  }
+  return true
+}
+
+const EXCLUDE_USERS_PATH = ['conditions', 'people', 'users', 'exclude']
+const INCLUDE_USES_PATH = ['conditions', 'people', 'users', 'include']
+
+const USER_MAPPING: Record<string, string[][]> = {
+  [GROUP_RULE_TYPE_NAME]: [EXCLUDE_USERS_PATH],
+  [ACCESS_POLICY_RULE_TYPE_NAME]: [EXCLUDE_USERS_PATH, INCLUDE_USES_PATH],
+  [PASSWORD_RULE_TYPE_NAME]: [EXCLUDE_USERS_PATH],
+  [SIGN_ON_RULE_TYPE_NAME]: [EXCLUDE_USERS_PATH],
+  [MFA_RULE_TYPE_NAME]: [EXCLUDE_USERS_PATH],
+}
+
+const isRelevantInstance = (instance: InstanceElement): boolean => (
+  Object.keys(USER_MAPPING).includes(instance.elemID.typeName)
+)
+
+const getUsers = async (paginator: clientUtils.Paginator): Promise<User[]> => {
+  const paginationArgs = {
+    url: '/api/v1/users',
+    paginationField: 'after',
+    // omit credentials and other unnecessary fields from the response
+    headers: { 'Content-Type': 'application/json; okta-response=omitCredentials,omitCredentialsLinks' },
+  }
+  const users = (await toArrayAsync(
+    paginator(paginationArgs, page => makeArray(page) as clientUtils.ResponseValue[])
+  )).flat()
+  if (!areUsers(users)) {
+    return []
+  }
+  return users
+}
+
+const replaceValues = (instance: InstanceElement, mapping: Record<string, string>): void => {
+  const paths = USER_MAPPING[instance.elemID.typeName]
+  paths.forEach(
+    path => {
+      const valuesPath = instance.elemID.createNestedID(...path)
+      const values = resolvePath(instance, valuesPath) ?? []
+      values.forEach((value: string, i: number) => {
+        const newValue = Object.prototype.hasOwnProperty.call(mapping, value) ? mapping[value] : undefined
+        if (newValue !== undefined) {
+          setPath(instance, valuesPath.createNestedID(i.toString()), newValue)
+        }
+      })
+    }
+  )
+}
+
+export const replaceValuesForChanges = async (
+  changes: Change<InstanceElement>[],
+  mapping: Record<string, string>,
+): Promise<void> => {
+  await awu(changes).forEach(async change => {
+    await applyFunctionToChangeData<Change<InstanceElement>>(
+      change,
+      instance => {
+        replaceValues(instance, mapping)
+        return instance
+      }
+    )
+  })
+}
+
+/**
+ * Replaces user ids with user login
+ */
+const filterCreator: FilterCreator = ({ client }) => {
+  let userIdToLogin: Record<string, string> = {}
+  return {
+    name: 'usersFilter',
+    onFetch: async elements => {
+      const paginator = createPaginator({
+        client,
+        paginationFuncCreator: paginate,
+      })
+      const users = await getUsers(paginator)
+      if (_.isEmpty(users)) {
+        log.warn('In users filter onFetch, could not find any users')
+        return
+      }
+      const mapping = Object.fromEntries(
+        users.map(user => [user.id, user.profile.login])
+      )
+      const instances = elements.filter(isInstanceElement).filter(isRelevantInstance)
+      instances.forEach(instance => {
+        replaceValues(instance, mapping)
+      })
+    },
+    preDeploy: async (changes: Change<InstanceElement>[]) => {
+      const relevantChanges = changes
+        .filter(change => isRelevantInstance(getChangeData(change)))
+      if (_.isEmpty(relevantChanges)) {
+        return
+      }
+      const paginator = createPaginator({
+        client,
+        paginationFuncCreator: paginate,
+      })
+      const users = await getUsers(paginator)
+      if (_.isEmpty(users)) {
+        log.warn('In users filter preDeploy, could not find any users')
+        return
+      }
+
+      userIdToLogin = Object.fromEntries(
+        users.map(user => [user.id, user.profile.login])
+      )
+      const loginToUserId = Object.fromEntries(
+        users.map(user => [user.profile.login, user.id])
+      ) as Record<string, string>
+      await replaceValuesForChanges(changes, loginToUserId)
+    },
+    onDeploy: async (changes: Change<InstanceElement>[]) => {
+      const relevantChanges = changes
+        .filter(change => isRelevantInstance(getChangeData(change)))
+      if (_.isEmpty(relevantChanges)) {
+        return
+      }
+      await replaceValuesForChanges(changes, userIdToLogin)
+    },
+  }
+}
+
+export default filterCreator

--- a/packages/okta-adapter/src/filters/user.ts
+++ b/packages/okta-adapter/src/filters/user.ts
@@ -16,7 +16,7 @@
 import _ from 'lodash'
 import Joi from 'joi'
 import { logger } from '@salto-io/logging'
-import { applyFunctionToChangeData, resolvePath, setPath } from '@salto-io/adapter-utils'
+import { applyFunctionToChangeData, createSchemeGuard, resolvePath, setPath } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { Change, getChangeData, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
 import { client as clientUtils } from '@salto-io/adapter-components'
@@ -44,21 +44,16 @@ const USER_SCHEMA = Joi.object({
 
 const USERS_RESPONSE_SCHEMA = Joi.array().items(USER_SCHEMA).required()
 
-const areUsers = (values: unknown): values is User[] => {
-  const { error } = USERS_RESPONSE_SCHEMA.validate(values)
-  if (error !== undefined) {
-    log.warn(`Received an invalid response for the users: ${error.message}`)
-    return false
-  }
-  return true
-}
+const areUsers = createSchemeGuard<User[]>(
+  USERS_RESPONSE_SCHEMA, 'Received an invalid response for the users'
+)
 
 const EXCLUDE_USERS_PATH = ['conditions', 'people', 'users', 'exclude']
-const INCLUDE_USES_PATH = ['conditions', 'people', 'users', 'include']
+const INCLUDE_USERS_PATH = ['conditions', 'people', 'users', 'include']
 
 const USER_MAPPING: Record<string, string[][]> = {
   [GROUP_RULE_TYPE_NAME]: [EXCLUDE_USERS_PATH],
-  [ACCESS_POLICY_RULE_TYPE_NAME]: [EXCLUDE_USERS_PATH, INCLUDE_USES_PATH],
+  [ACCESS_POLICY_RULE_TYPE_NAME]: [EXCLUDE_USERS_PATH, INCLUDE_USERS_PATH],
   [PASSWORD_RULE_TYPE_NAME]: [EXCLUDE_USERS_PATH],
   [SIGN_ON_RULE_TYPE_NAME]: [EXCLUDE_USERS_PATH],
   [MFA_RULE_TYPE_NAME]: [EXCLUDE_USERS_PATH],

--- a/packages/okta-adapter/test/adapter.test.ts
+++ b/packages/okta-adapter/test/adapter.test.ts
@@ -16,6 +16,8 @@
 import { AdapterOperations, ElemID, FetchResult, ElemIdGetter, ServiceIds, ObjectType, InstanceElement } from '@salto-io/adapter-api'
 import { elements } from '@salto-io/adapter-components'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import MockAdapter from 'axios-mock-adapter'
+import axios from 'axios'
 import { adapter as adapterCreator } from '../src/adapter_creator'
 import { DEFAULT_CONFIG } from '../src/config'
 import { OKTA } from '../src/constants'
@@ -69,6 +71,7 @@ describe('Okta adapter', () => {
     let result: FetchResult
     let oktaTestType: ObjectType
     let testInstance: InstanceElement
+    let mockAxiosAdapter: MockAdapter
 
     beforeEach(async () => {
       oktaTestType = new ObjectType({
@@ -83,7 +86,9 @@ describe('Okta adapter', () => {
         });
       (getAllInstances as jest.MockedFunction<typeof getAllInstances>)
         .mockResolvedValue({ elements: [testInstance] })
-
+      mockAxiosAdapter = new MockAdapter(axios)
+      // mock as there are gets of users during fetch
+      mockAxiosAdapter.onGet().reply(200, { })
       result = await adapter.fetch({ progressReporter: { reportProgress: () => null } })
     })
 

--- a/packages/okta-adapter/test/filters/user.test.ts
+++ b/packages/okta-adapter/test/filters/user.test.ts
@@ -1,0 +1,200 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, ElemID, InstanceElement, isInstanceElement, toChange, getChangeData } from '@salto-io/adapter-api'
+import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { mockFunction } from '@salto-io/test-utils'
+import { ACCESS_POLICY_RULE_TYPE_NAME, GROUP_RULE_TYPE_NAME, OKTA } from '../../src/constants'
+import userFilter from '../../src/filters/user'
+import { getFilterParams } from '../utils'
+
+describe('user filter', () => {
+  type FilterType = filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
+  let filter: FilterType
+  const groupRuleType = new ObjectType({ elemID: new ElemID(OKTA, GROUP_RULE_TYPE_NAME) })
+  const accessPolicyRuleType = new ObjectType({ elemID: new ElemID(OKTA, ACCESS_POLICY_RULE_TYPE_NAME) })
+
+  const groupRuleInstance = new InstanceElement(
+    'groupRuleTest',
+    groupRuleType,
+    {
+      name: 'test',
+      conditions: {
+        people: { users: { exclude: ['111', '222'] } },
+      },
+    }
+  )
+  const accessRuleInstance = new InstanceElement(
+    'accessPolicyRuleTest',
+    accessPolicyRuleType,
+    {
+      name: 'test',
+      conditions: {
+        people: { users: { exclude: ['222'], include: ['111', '333', '555'] } },
+      },
+    }
+  )
+  const afterFetchInstances = [
+    new InstanceElement(
+      'group',
+      groupRuleType,
+      {
+        name: 'test',
+        conditions: { people: { users: { exclude: ['a@a.com', 'b@a.com'] } } },
+      }
+    ),
+    new InstanceElement(
+      'accessPolicy',
+      accessPolicyRuleType,
+      {
+        name: 'test',
+        conditions: {
+          people: { users: { exclude: ['b@a.com'], include: ['a@a.com', 'c@a.com', 'd@a.com'] } },
+        },
+      }
+    ),
+  ]
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+  })
+
+  describe('onFetch', () => {
+    it('should change user ids to user login', async () => {
+      const mockPaginator = mockFunction<clientUtils.Paginator>().mockImplementation(async function *get() {
+        yield [
+          { id: '111', profile: { login: 'a@a.com' } },
+          { id: '222', profile: { login: 'b@a.com' } },
+          { id: '333', profile: { login: 'c@a.com' } },
+          { id: '555', profile: { login: 'd@a.com' } },
+        ]
+      })
+      filter = userFilter(getFilterParams({ paginator: mockPaginator })) as FilterType
+      const elements = [groupRuleType, groupRuleInstance, accessPolicyRuleType, accessRuleInstance].map(e => e.clone())
+      await filter.onFetch(elements)
+      const instances = elements.filter(isInstanceElement)
+      const groupRule = instances.find(e => e.elemID.typeName === GROUP_RULE_TYPE_NAME)
+      expect(groupRule?.value).toEqual({
+        name: 'test',
+        conditions: {
+          people: { users: { exclude: ['a@a.com', 'b@a.com'] } },
+        },
+      })
+      const accessRule = instances.find(e => e.elemID.typeName === ACCESS_POLICY_RULE_TYPE_NAME)
+      expect(accessRule?.value).toEqual({
+        name: 'test',
+        conditions: {
+          people: {
+            users: {
+              exclude: ['b@a.com'],
+              include: ['a@a.com', 'c@a.com', 'd@a.com'],
+            },
+          },
+        },
+      })
+      expect(mockPaginator).toHaveBeenNthCalledWith(
+        1,
+        {
+          url: '/api/v1/users',
+          headers: { 'Content-Type': 'application/json; okta-response=omitCredentials,omitCredentialsLinks' },
+          paginationField: 'after',
+        },
+        expect.anything(),
+      )
+    })
+    it('should not replace anything if the users response is invalid', async () => {
+      const mockPaginator = mockFunction<clientUtils.Paginator>().mockImplementation(async function *get() {
+        yield [
+          { id: '111', profile: { login: 'a@a.com' } },
+          { id: '222', profile: { login: 'b@a.com' } },
+        ]
+      })
+      filter = userFilter(getFilterParams({ paginator: mockPaginator })) as FilterType
+      const elements = [accessRuleInstance.clone(), accessPolicyRuleType.clone()]
+      await filter.onFetch(elements)
+      const instances = elements.filter(isInstanceElement)
+      const accessPolicy = instances.find(e => e.elemID.name === 'accessPolicyRuleTest')
+      expect(accessPolicy?.value).toEqual({
+        name: 'test',
+        conditions: {
+          people: {
+            users: {
+              exclude: ['b@a.com'],
+              include: ['a@a.com', '333', '555'],
+            },
+          },
+        },
+      })
+    })
+  })
+  describe('preDeploy', () => {
+    it('should change the logins to user ids', async () => {
+      const mockPaginator = mockFunction<clientUtils.Paginator>().mockImplementationOnce(async function *get() {
+        yield [
+          { id: '111', profile: { login: 'a@a.com' } },
+          { id: '222', profile: { login: 'b@a.com' } },
+          { id: '333', profile: { login: 'c@a.com' } },
+          { id: '555', profile: { login: 'd@a.com' } },
+        ]
+      })
+      filter = userFilter(getFilterParams({ paginator: mockPaginator })) as FilterType
+      const changes = afterFetchInstances.map(instance => toChange({ after: instance.clone() }))
+      await filter.preDeploy(changes)
+      const changedInstances = changes.map(getChangeData)
+      const groupRule = changedInstances.find(inst => inst.elemID.name === 'group')
+      expect(groupRule?.value).toEqual({
+        name: 'test',
+        conditions: { people: { users: { exclude: ['111', '222'] } } },
+      })
+      const accessRule = changedInstances.find(inst => inst.elemID.name === 'accessPolicy')
+      expect(accessRule?.value).toEqual({
+        name: 'test',
+        conditions: {
+          people: { users: { exclude: ['222'], include: ['111', '333', '555'] } },
+        },
+      })
+    })
+  })
+  describe('onDeploy', () => {
+    it('should change the user ids to login based on mapping created preDeploy', async () => {
+      const mockPaginator = mockFunction<clientUtils.Paginator>().mockImplementationOnce(async function *get() {
+        yield [
+          { id: '111', profile: { login: 'a@a.com' } },
+          { id: '222', profile: { login: 'b@a.com' } },
+          { id: '333', profile: { login: 'c@a.com' } },
+          { id: '555', profile: { login: 'd@a.com' } },
+        ]
+      })
+      filter = userFilter(getFilterParams({ paginator: mockPaginator })) as FilterType
+      const changes = afterFetchInstances.map(instance => toChange({ after: instance.clone() }))
+      // preDeploy sets the mappings
+      await filter.preDeploy(changes)
+      await filter.onDeploy(changes)
+      const changedInstances = changes.map(getChangeData)
+      const groupRule = changedInstances.find(inst => inst.elemID.name === 'group')
+      expect(groupRule?.value).toEqual({
+        name: 'test',
+        conditions: { people: { users: { exclude: ['a@a.com', 'b@a.com'] } } },
+      })
+      const accessRule = changedInstances.find(inst => inst.elemID.name === 'accessPolicy')
+      expect(accessRule?.value).toEqual({
+        name: 'test',
+        conditions: {
+          people: { users: { exclude: ['b@a.com'], include: ['a@a.com', 'c@a.com', 'd@a.com'] } },
+        },
+      })
+    })
+  })
+})


### PR DESCRIPTION
Replace user ids with usernames in Okta

---

Replace user ids in Okta's instances with user login which is a unique identifier for users in Okta.

---
_Release Notes_: 
None

---
_User Notifications_: 
None
