### PR TITLE
SALTO-3847: PermissionSet instances deployment bugfix

### DIFF
--- a/packages/salesforce-adapter/src/filters/minify_deploy.ts
+++ b/packages/salesforce-adapter/src/filters/minify_deploy.ts
@@ -29,7 +29,7 @@ import _ from 'lodash'
 import { detailedCompare, getPath } from '@salto-io/adapter-utils'
 import { LocalFilterCreator } from '../filter'
 import { isInstanceOfTypeChange } from './utils'
-import { PROFILE_METADATA_TYPE, PERMISSION_SET_METADATA_TYPE, INSTANCE_FULL_NAME_FIELD, LABEL } from '../constants'
+import { PROFILE_METADATA_TYPE, INSTANCE_FULL_NAME_FIELD } from '../constants'
 import { apiName, metadataType } from '../transformers/transformer'
 
 export const LOGIN_IP_RANGES_FIELD = 'loginIpRanges'
@@ -42,10 +42,6 @@ const typeToRemainingFields: Record<string, Record<string, { default?: Value }>>
   [PROFILE_METADATA_TYPE]: {
     [INSTANCE_FULL_NAME_FIELD]: {},
     [LOGIN_IP_RANGES_FIELD]: { default: [] },
-  },
-  [PERMISSION_SET_METADATA_TYPE]: {
-    [INSTANCE_FULL_NAME_FIELD]: {},
-    [LABEL]: {},
   },
 }
 


### PR DESCRIPTION
Fixed a bug upon deployment of `PermissionSet` instances.
 
---

As part of our previous work on [SALTO-2770](https://salto-io.atlassian.net/browse/SALTO-2770), we implemented support on minifying the deployed PermissionSet instances, similarly to what we do with `Profile` instances. This logic caused the rest of the stuff that were not modified to be completely removed.

I've ran the following scenario:
- Adding `objectPermissions` on my `PermissionSet` instance.
- Deploying.
- Fetching post deploy.

You can see how the rest of the properties were removed from the instance (Which means were deleted in the service)
Here is the workspace diff to demonstrate that: https://github.com/salto-io/tamir-sf/compare/66e1655c4e5690e70a57170f8c995bf96cc0d64a..dbc0e96b64487f5356a305fc07ed6c2137379518

---
_Release Notes_: 
Salesforce Adapter:
- Fixed a bug upon deployment of `PermissionSet` instances.

---
_User Notifications_: 
_None_


[SALTO-2770]: https://salto-io.atlassian.net/browse/SALTO-2770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ