### PR TITLE
SALTO-3835/partial fetch path index bug

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -239,7 +239,8 @@ const updateStateWithFetchResults = async (
   workspace: Workspace,
   mergedElements: Element[],
   unmergedElements: Element[],
-  fetchedAccounts: string[]
+  fetchedAccounts: string[],
+  partiallyFetchedAccounts: string[],
 ): Promise<void> => {
   const fetchElementsFilter = shouldElementBeIncluded(fetchedAccounts)
   const stateElementsNotCoveredByFetch = await awu(await workspace.state().getAll())
@@ -247,8 +248,11 @@ const updateStateWithFetchResults = async (
   await workspace.state()
     .override(awu(mergedElements)
       .concat(stateElementsNotCoveredByFetch), fetchedAccounts)
-  await workspace.state().updatePathIndex(unmergedElements,
-    (await workspace.state().existingAccounts()).filter(key => !fetchedAccounts.includes(key)))
+  const accountsToMaintain = [
+    ...(await workspace.state().existingAccounts()).filter(key => !fetchedAccounts.includes(key)),
+    ...partiallyFetchedAccounts,
+  ]
+  await workspace.state().updatePathIndex(unmergedElements, accountsToMaintain)
   log.debug(`finish to override state with ${mergedElements.length} elements`)
 }
 
@@ -280,6 +284,7 @@ export const fetch: FetchFunc = async (
     const {
       changes, elements, mergeErrors, errors, updatedConfig,
       configChanges, accountNameToConfigMessage, unmergedElements,
+      partiallyFetchedAccounts,
     } = await fetchChanges(
       accountToAdapter,
       await workspace.elements(),
@@ -290,7 +295,13 @@ export const fetch: FetchFunc = async (
       withChangeDetection,
     )
     log.debug(`${elements.length} elements were fetched [mergedErrors=${mergeErrors.length}]`)
-    await updateStateWithFetchResults(workspace, elements, unmergedElements, fetchAccounts)
+    await updateStateWithFetchResults(
+      workspace,
+      elements,
+      unmergedElements,
+      fetchAccounts,
+      Array.from(partiallyFetchedAccounts),
+    )
     return {
       changes,
       fetchErrors: errors,
@@ -347,7 +358,7 @@ export const fetchFromWorkspace: FetchFromWorkspaceFunc = async ({
   )
 
   log.debug(`${elements.length} elements were fetched from a remote workspace [mergedErrors=${mergeErrors.length}]`)
-  await updateStateWithFetchResults(workspace, elements, unmergedElements, fetchAccounts)
+  await updateStateWithFetchResults(workspace, elements, unmergedElements, fetchAccounts, [])
   return {
     changes,
     fetchErrors: errors,

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -248,10 +248,8 @@ const updateStateWithFetchResults = async (
   await workspace.state()
     .override(awu(mergedElements)
       .concat(stateElementsNotCoveredByFetch), fetchedAccounts)
-  const accountsToMaintain = [
-    ...(await workspace.state().existingAccounts()).filter(key => !fetchedAccounts.includes(key)),
-    ...partiallyFetchedAccounts,
-  ]
+  const accountsToMaintain = partiallyFetchedAccounts
+    .concat((await workspace.state().existingAccounts()).filter(key => !fetchedAccounts.includes(key)))
   await workspace.state().updatePathIndex(unmergedElements, accountsToMaintain)
   log.debug(`finish to override state with ${mergedElements.length} elements`)
 }

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -726,7 +726,7 @@ export const fetchChanges = async (
   currentConfigs: InstanceElement[],
   progressEmitter?: EventEmitter<FetchProgressEvents>,
   withChangesDetection?: boolean
-): Promise<FetchChangesResult> => {
+): Promise<FetchChangesResult & { partiallyFetchedAccounts: Set<string>} > => {
   const accountNames = _.keys(accountsToAdapters)
   const getChangesEmitter = new StepEmitter()
   if (progressEmitter) {
@@ -750,19 +750,22 @@ export const fetchChanges = async (
   adaptersFirstFetchPartial.forEach(
     adapter => log.warn('Received partial results from %s before full fetch', adapter)
   )
-  return createFetchChanges({
-    unmergedElements: accountElements,
-    adapterNames: Object.keys(accountsToAdapters),
-    workspaceElements,
-    stateElements,
-    currentConfigs,
-    getChangesEmitter,
-    progressEmitter,
-    processErrorsResult,
-    errors,
-    updatedConfigs,
+  return {
+    ...(await createFetchChanges({
+      unmergedElements: accountElements,
+      adapterNames: Object.keys(accountsToAdapters),
+      workspaceElements,
+      stateElements,
+      currentConfigs,
+      getChangesEmitter,
+      progressEmitter,
+      processErrorsResult,
+      errors,
+      updatedConfigs,
+      partiallyFetchedAccounts,
+    })),
     partiallyFetchedAccounts,
-  })
+  }
 }
 
 const createEmptyFetchChangeDueToError = (errMsg: string): FetchChangesResult => {

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -209,8 +209,6 @@ describe('api.ts', () => {
         ws = mockWorkspace({ stateElements })
         mockPartiallyFetchedAccounts.mockReturnValueOnce(new Set([mockService]))
         mockStateUpdatePathIndex = jest.spyOn(ws.state(), 'updatePathIndex').mockResolvedValue(undefined)
-      })
-      beforeEach(async () => {
         await api.fetch(ws, undefined, [mockService])
       })
       it('should maintain path index entries', async () => {

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -162,9 +162,6 @@ describe('api.ts', () => {
         partiallyFetchedAccounts: mockPartiallyFetchedAccounts(),
       }))
     })
-    beforeEach(() => {
-      mockPartiallyFetchedAccounts.mockReturnValue(new Set())
-    })
 
     describe('Full fetch', () => {
       let ws: workspace.Workspace
@@ -210,10 +207,10 @@ describe('api.ts', () => {
           new InstanceElement('old_instance2', new ObjectType({ elemID: new ElemID(emptyMockService, 'test') }), {}),
         ]
         ws = mockWorkspace({ stateElements })
+        mockPartiallyFetchedAccounts.mockReturnValueOnce(new Set([mockService]))
         mockStateUpdatePathIndex = jest.spyOn(ws.state(), 'updatePathIndex').mockResolvedValue(undefined)
       })
       beforeEach(async () => {
-        mockPartiallyFetchedAccounts.mockReturnValue(new Set([mockService]))
         await api.fetch(ws, undefined, [mockService])
       })
       it('should maintain path index entries', async () => {

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -647,6 +647,7 @@ describe('api.ts', () => {
         mergeErrors: [],
         updatedConfig: {},
         accountNameToConfigMessage: {},
+        partiallyFetchedAccounts: new Set(),
       })
     })
 

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -157,6 +157,7 @@ describe('api.ts', () => {
         elements: fetchedElements,
         mergeErrors: [],
         accountNameToConfigMessage: {},
+        partiallyFetchedAccounts: new Set(),
       })
     })
 

--- a/packages/workspace/src/workspace/path_index.ts
+++ b/packages/workspace/src/workspace/path_index.ts
@@ -198,7 +198,7 @@ export const overrideTopLevelPathIndex = async (
   await current.setAll(entries)
 }
 
-type UpdateIndexParms = {
+type UpdateIndexParams = {
   index: PathIndex
   elements: Element[]
   accountsToMaintain: string[]
@@ -209,7 +209,7 @@ export const updatePathIndex = async (
   { index,
     elements,
     accountsToMaintain,
-    isTopLevel }: UpdateIndexParms
+    isTopLevel }: UpdateIndexParams
 ): Promise<void> => {
   if (accountsToMaintain.length === 0) {
     if (isTopLevel) {
@@ -222,10 +222,10 @@ export const updatePathIndex = async (
   const entries = isTopLevel ? getTopLevelPathHints(elements) : getElementsPathHints(elements)
   const oldPathHintsToMaintain = await awu(index.entries())
     .filter(e => accountsToMaintain.includes(ElemID.fromFullName(e.key).adapter))
-    .concat(entries)
     .toArray()
+  const updatedEntries = _.unionBy(entries, oldPathHintsToMaintain, e => e.key)
   await index.clear()
-  await index.setAll(awu(oldPathHintsToMaintain))
+  await index.setAll(awu(updatedEntries))
 }
 
 export const loadPathIndex = (parsedEntries: [string, Path[]][]): RemoteMapEntry<Path[], string>[] =>

--- a/packages/workspace/test/workspace/path_index.test.ts
+++ b/packages/workspace/test/workspace/path_index.test.ts
@@ -186,8 +186,8 @@ describe('topLevelPathIndex', () => {
         multiPathFieldsObj,
         multiPathInstanceA,
         multiPathInstanceB,
-        // when there is a partial fetch, the adapter name will be in accountsToMaintain
-        // but there will also be elements of that adapter in the elements array
+        // when there is a partial fetch, the account name will be in accountsToMaintain
+        // but there will also be elements of that account in the elements array
         updatedPartiallyFetchedObject,
       ],
       accountsToMaintain: ['salto'],
@@ -222,8 +222,8 @@ describe('updatePathIndex', () => {
         multiPathFieldsObj,
         multiPathInstanceA,
         multiPathInstanceB,
-        // when there is a partial fetch, the adapter name will be in accountsToMaintain
-        // but there will also be elements of that adapter in the elements array
+        // when there is a partial fetch, the account name will be in accountsToMaintain
+        // but there will also be elements of that account in the elements array
         updatedPartiallyFetchedObject,
       ],
       accountsToMaintain: ['salto'],
@@ -265,7 +265,7 @@ describe('updatePathIndex', () => {
     ])
   })
 
-  it('should maintatin old elements', async () => {
+  it('should maintain old elements', async () => {
     expect(await index.get(singlePathObject.elemID.getFullName()))
       .toEqual([singlePathObject.path])
   })


### PR DESCRIPTION
on partial fetches there was a bug that removed the path index and top level path index entries that were not fetched in the partial fetch.
we already had a logic to maintain accounts not fetched that collected all of their elements and then pushed them back inside the index after we cleared it.
I used the same logic to update the partially fetched accounts with a slight change to how we merge the old entires and new entries so we enforce that the new changes make it into the index.

---

_Additional context for reviewer_
tested manually, looking into adding a ut.

---
_Release Notes_: 
core
* fixed bug with partial fetches removing entries from path index.

---
_User Notifications_: 
