### PR TITLE
SALTO-3858: unknown picklist values Change Validator bugfix

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/unknown_picklist_values.ts
+++ b/packages/salesforce-adapter/src/change_validators/unknown_picklist_values.ts
@@ -29,10 +29,14 @@ import { isPicklistField } from '../filters/value_set'
 const { isDefined } = values
 const { awu } = collections.asynciterable
 
-const createUnknownPicklistValueChangeError = ({ elemID, annotations }: Field, unknownValue: string): ChangeError => ({
-  elemID,
-  message: `Unknown picklist value ${unknownValue}`,
-  detailedMessage: `Supported values are ${annotations[CORE_ANNOTATIONS.RESTRICTION]?.values}`,
+const createUnknownPicklistValueChangeError = (
+  instance: InstanceElement,
+  field: Field,
+  unknownValue: string
+): ChangeError => ({
+  elemID: instance.elemID,
+  message: `Unknown picklist value ${unknownValue} on field ${field.elemID.name} of instance `,
+  detailedMessage: `Supported values are ${field.annotations[CORE_ANNOTATIONS.RESTRICTION]?.values}`,
   severity: 'Error',
 })
 
@@ -46,9 +50,9 @@ const createUnknownPicklistValueChangeErrors = async (instance: InstanceElement)
       const field = fields[picklistFieldName]
       const fieldValue = instance.value[picklistFieldName]
       const allowedValues = field.annotations[CORE_ANNOTATIONS.RESTRICTION]?.values
-      return !_.isArray(allowedValues) || allowedValues.includes(fieldValue)
+      return fieldValue === undefined || !_.isArray(allowedValues) || allowedValues.includes(fieldValue)
         ? undefined
-        : createUnknownPicklistValueChangeError(field, fieldValue)
+        : createUnknownPicklistValueChangeError(instance, field, fieldValue)
     })
     .filter(isDefined)
 }

--- a/packages/salesforce-adapter/src/change_validators/unknown_picklist_values.ts
+++ b/packages/salesforce-adapter/src/change_validators/unknown_picklist_values.ts
@@ -23,6 +23,7 @@ import {
 } from '@salto-io/adapter-api'
 import { collections, values } from '@salto-io/lowerdash'
 import _ from 'lodash'
+import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { isPicklistField } from '../filters/value_set'
 
 
@@ -35,8 +36,8 @@ const createUnknownPicklistValueChangeError = (
   unknownValue: string
 ): ChangeError => ({
   elemID: instance.elemID,
-  message: `Unknown picklist value ${unknownValue} on field ${field.elemID.name} of instance `,
-  detailedMessage: `Supported values are ${field.annotations[CORE_ANNOTATIONS.RESTRICTION]?.values}`,
+  message: `Unknown picklist value "${unknownValue}" on field ${field.elemID.name} of instance ${instance.elemID.getFullName()}`,
+  detailedMessage: `Supported values are ${safeJsonStringify(field.annotations[CORE_ANNOTATIONS.RESTRICTION]?.values)}`,
   severity: 'Error',
 })
 

--- a/packages/salesforce-adapter/test/change_validators/unknown_picklist_values.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/unknown_picklist_values.test.ts
@@ -87,4 +87,15 @@ describe('unknownPicklistValues ChangeValidator', () => {
       expect(changeErrors).toBeEmpty()
     })
   })
+
+  describe('when picklist field has no value', () => {
+    beforeEach(async () => {
+      const instance = createInstanceWithPicklistValues('knownValue1', 'knownValue2')
+      delete instance.value.field1__c
+      changeErrors = await changeValidator([toChange({ after: instance })], ELEMENTS_SOURCE)
+    })
+    it('should not create errors', async () => {
+      expect(changeErrors).toBeEmpty()
+    })
+  })
 })


### PR DESCRIPTION
Fixed two issues in this PR:
- The `Change Validator` won't error on optional picklist fields that have no value.
- The `ChangeError` will be attached to the instance instead of the field.

---

This is how the Change Error looks like:
```
Unknown picklist value "Unknown Value" on field SBQQ__Action__c of instance salesforce.SBQQ__CustomAction__c.instance.Add_Favorites@s
    envs/sf11/salesforce/InstalledPackages/SBQQ/Records/SBQQ__CustomAction__c/Add_Favorites.nacl(line: 1)
    Error: Supported values are ["Add Products","Add Favorites","Upgrade Assets","Renew Subscriptions","Amend Subscriptions","Add Recommendations","Save","Quick Save","Cancel","Calculate","Delete Lines","Add Group","Ungroup","Add Solution Group","Reset Discounts","Optional: All","Optional: None","Clone Group","Delete Group","Add To Favorites","Remove From Favorites","Delete Line","Clone Line","Reconfigure Line","Desegment Line","Resegment Line","View Discount Schedule","View Consumption Schedule","Launch External","Apply Edit Rules","Clone with Related","Create Order","Edit Lines","Generate Document","Import Lines","Modify Quote Terms","Include Document","Preview Document","Refresh Prices","Amend Assets","Renew Assets","Amend","Renew Contracts","Amend Contract","Edit Order Products","View","Email","Save and Navigate","View Pricing Guidance"]
```

---

_Release Notes_: 
_None_

---

_User Notifications_: 
_None_
