### PR TITLE
SALTO-3016 skip NS validation when there are only file cabinet instances

### DIFF
--- a/packages/netsuite-adapter/src/change_validators/client_validation.ts
+++ b/packages/netsuite-adapter/src/change_validators/client_validation.ts
@@ -83,20 +83,28 @@ const changeValidator: ClientChangeValidator = async (
   additionalDependencies,
   filtersRunner,
 ) => {
+  const changesMap = new Map(changes.map(change => [changeId(change), change]))
   // SALTO-3016 we can validate only SDF elements because
   // we need FileCabinet references to be included in the SDF project
-  const getChangeGroupIds = getChangeGroupIdsFunc(false)
-  const { changeGroupIdMap } = await getChangeGroupIds(
-    new Map(changes.map(change => [changeId(change), change]))
-  )
+  const { changeGroupIdMap } = await getChangeGroupIdsFunc(false)(changesMap)
   const changesByGroupId = _(changes)
     .filter(change => changeGroupIdMap.has(changeId(change)))
     .groupBy(change => changeGroupIdMap.get(changeId(change)))
     .entries()
     .value()
 
+  const {
+    changeGroupIdMap: realChangesGroupIdMap,
+  } = await getChangeGroupIdsFunc(client.isSuiteAppConfigured())(changesMap)
+
   return awu(changesByGroupId)
     .flatMap(async ([groupId, groupChanges]) => {
+      // SALTO-3016 if the real change group of all changes is different than the one used for validation
+      // (e.g. only FileCabinet instances) we should skip the validation.
+      if (groupChanges.every(change => realChangesGroupIdMap.get(changeId(change)) !== groupId)) {
+        return []
+      }
+
       const clonedChanges = groupChanges.map(cloneChange)
       await filtersRunner(groupId).preDeploy(clonedChanges)
       const errors = await client.validate(

--- a/packages/netsuite-adapter/src/client/deploy_xml_utils.ts
+++ b/packages/netsuite-adapter/src/client/deploy_xml_utils.ts
@@ -73,7 +73,11 @@ export const reorderDeployXml = (
   const { objects, files } = deployXml.deploy
 
   if (customTypeInfos.length > 0) {
-    log.debug('Deploying %d objects in the following order: %o', customTypeInfos.length, customTypeInfos.filter(isCustomTypeInfo).map(custTypeInfo => custTypeInfo.scriptId))
+    log.debug(
+      'Deploying %d objects in the following order: %o',
+      customTypeInfos.length,
+      customTypeInfos.filter(isCustomTypeInfo).map(custTypeInfo => custTypeInfo.scriptId)
+    )
     objects.path = customTypeInfos
       .filter(isCustomTypeInfo)
       .map(custTypeInfo => getCustomTypeInfoPath(PROJECT_ROOT_TILDE_PREFIX, custTypeInfo))
@@ -81,7 +85,11 @@ export const reorderDeployXml = (
     objects.path.push(['~', OBJECTS_DIR, '*'].join(osPath.sep))
   }
   if (fileCabinetCustInfos.length > 0) {
-    log.debug('Deploying %d file cabinet objects in the following order: %o', fileCabinetCustInfos.length, fileCabinetCustInfos.map(custTypeInfo => custTypeInfo.path))
+    log.debug(
+      'Deploying %d file cabinet objects in the following order: %o',
+      fileCabinetCustInfos.length,
+      fileCabinetCustInfos.map(custTypeInfo => custTypeInfo.path.join(osPath.sep))
+    )
     files.path = fileCabinetCustInfos
       .map(custInfo => getFileOrFolderString(custInfo))
       .map(path => path.slice(1))


### PR DESCRIPTION
When there are SDF objects being deployed we validate them with the file cabinet instances, but when there are only file cabinet instances being deploy we shouldn't run NS validation using SDF.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Skip NS validation when there are only file cabinet instances

---
_User Notifications_: 
None