### PR TITLE
SAAS-7388: support ScriptRunner checkbox in UI

### DIFF
--- a/packages/jira-adapter/src/adapter_creator.ts
+++ b/packages/jira-adapter/src/adapter_creator.ts
@@ -26,6 +26,7 @@ import { configType, JiraConfig, getApiDefinitions, getDefaultConfig } from './c
 import { createConnection, validateCredentials } from './client/connection'
 import { AUTOMATION_TYPE, WEBHOOK_TYPE } from './constants'
 import { getProductSettings } from './product_settings'
+import { configCreator } from './config_creator'
 
 const log = logger(module)
 const { validateClientConfig, createRetryOptions, DEFAULT_RETRY_OPTS } = clientUtils
@@ -146,4 +147,5 @@ export const adapter: Adapter = {
     },
   },
   configType,
+  configCreator,
 }

--- a/packages/jira-adapter/src/config_creator.ts
+++ b/packages/jira-adapter/src/config_creator.ts
@@ -46,14 +46,8 @@ export const getConfig = async (
   options?: InstanceElement
 ): Promise<InstanceElement> => {
   const defaultConf = await createDefaultInstanceFromType(ElemID.CONFIG_NAME, configType)
-  if (options === undefined || !isOptionsTypeInstance(options)) {
-    return defaultConf
-  }
-  if (options.value.enableScripRunnerAddon === true) {
-    const configWithScriptRunner = defaultConf.clone()
-    configWithScriptRunner.value.fetch = { ...configWithScriptRunner.value.fetch,
-      enableScripRunnerAddon: true }
-    return configWithScriptRunner
+  if (options !== undefined && isOptionsTypeInstance(options) && options.value.enableScripRunnerAddon) {
+    defaultConf.value.fetch.enableScripRunnerAddon = true
   }
   return defaultConf
 }

--- a/packages/jira-adapter/src/config_creator.ts
+++ b/packages/jira-adapter/src/config_creator.ts
@@ -1,0 +1,64 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { BuiltinTypes, ConfigCreator, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { createDefaultInstanceFromType, createMatchingObjectType } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+import { configType } from './config/config'
+import * as constants from './constants'
+
+const log = logger(module)
+
+const optionsElemId = new ElemID(constants.JIRA, 'configOptionsType')
+
+type ConfigOptionsType = {
+  enableScripRunnerAddon?: boolean
+}
+export const optionsType = createMatchingObjectType<ConfigOptionsType>({
+  elemID: optionsElemId,
+  fields: {
+    enableScripRunnerAddon: { refType: BuiltinTypes.BOOLEAN },
+  },
+})
+const isOptionsTypeInstance = (instance: InstanceElement):
+  instance is InstanceElement & { value: ConfigOptionsType } => {
+  if (instance.refType.elemID.isEqual(optionsElemId)) {
+    return true
+  }
+  log.error(`Received an invalid instance for config options. Received instance with refType ElemId full name: ${instance.refType.elemID.getFullName()}`)
+  return false
+}
+
+export const getConfig = async (
+  options?: InstanceElement
+): Promise<InstanceElement> => {
+  const defaultConf = await createDefaultInstanceFromType(ElemID.CONFIG_NAME, configType)
+  if (options === undefined || !isOptionsTypeInstance(options)) {
+    return defaultConf
+  }
+  if (options.value.enableScripRunnerAddon === true) {
+    const configWithScriptRunner = defaultConf.clone()
+    configWithScriptRunner.value.fetch = { ...configWithScriptRunner.value.fetch,
+      enableScripRunnerAddon: true }
+    return configWithScriptRunner
+  }
+  return defaultConf
+}
+
+export const configCreator: ConfigCreator = {
+  optionsType,
+  getConfig,
+}

--- a/packages/jira-adapter/test/config_creator.test.ts
+++ b/packages/jira-adapter/test/config_creator.test.ts
@@ -1,0 +1,60 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { createDefaultInstanceFromType } from '@salto-io/adapter-utils'
+import { configType } from '../src/config/config'
+import { getConfig, configCreator, optionsType } from '../src/config_creator'
+import { createEmptyType } from './utils'
+
+describe('config creator', () => {
+  let options: InstanceElement
+  beforeEach(async () => {
+    options = new InstanceElement(
+      'instance',
+      optionsType,
+      { enableScripRunnerAddon: true }
+    )
+  })
+  it('should return config creator', async () => {
+    const config = configCreator
+    expect(config).toEqual({
+      optionsType,
+      getConfig,
+    })
+  })
+  it('get config should return default config', async () => {
+    const config = await getConfig()
+    expect(config).toEqual(await createDefaultInstanceFromType(ElemID.CONFIG_NAME, configType))
+  })
+  it('get config should return default config when false', async () => {
+    options.value.enableScripRunnerAddon = false
+    const config = await getConfig(options)
+    expect(config).toEqual(await createDefaultInstanceFromType(ElemID.CONFIG_NAME, configType))
+  })
+  it('get config should return default config when wrong type', async () => {
+    options = new InstanceElement(
+      'instance',
+      createEmptyType('empty'),
+      { enableScripRunnerAddon: true }
+    )
+    const config = await getConfig(options)
+    expect(config).toEqual(await createDefaultInstanceFromType(ElemID.CONFIG_NAME, configType))
+  })
+  it('get config should return return correctly when true', async () => {
+    const config = await getConfig(options)
+    expect(config.value.fetch.enableScripRunnerAddon).toBeTrue()
+  })
+})


### PR DESCRIPTION
Added support to receive the ScriptRunner configuration from the UI

---

_Same as zendesk and salesforce_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
