### PR TITLE
SALTO-3823: fix a bug with Automation deployment - Jira

### DIFF
--- a/packages/jira-adapter/src/filters/automation/automation_deployment.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_deployment.ts
@@ -125,8 +125,13 @@ const importAutomation = async (
   })
 }
 
+const sortProjects = (projects: Values[]): Values[] => (
+  _.sortBy(projects, project => project.projectId)
+)
+
 const getAutomationIdentifier = (values: Values): string =>
-  [values.name, ...(values.projects ?? []).map((project: Values) => project.projectId)].join('_')
+  [values.name, ...(sortProjects(values.projects ?? [])).map((project: Values) => project.projectId)].join('_')
+
 
 const setInstanceId = async (
   instance: InstanceElement,


### PR DESCRIPTION
_fix a bug with Automation deployment_

---

_Additional context for reviewer_

The bug occur when the user add new Automation with projects. We use identifier in two places that got the projects in different order so the identifier was different and caused the failure. So I added sorting to prevent it.

---
_Release Notes_: 
None

---
_User Notifications_: 
None
