### PR TITLE
SALTO-3793: Log reasons of config suggestion

### DIFF
--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -448,6 +448,9 @@ const fetchAndProcessMergeErrors = async (
             withChangesDetection,
           })
           const { updatedConfig, errors } = fetchResult
+          if (updatedConfig !== undefined) {
+            log.debug(`Salto got config suggestions in ${accountName} account: ${updatedConfig.message}`)
+          }
           if (
             fetchResult.elements.length > 0 && accountName !== accountToServiceNameMap[accountName]
           ) {


### PR DESCRIPTION
**Log the reasons of Config Suggestions**

---

_Additional context for reviewer_ 
I added a log in `fetch.ts` in core that describes the reasons for config suggestions if needed. 

---
_Release Notes_: 
None

---
_User Notifications_: 
None
