### PR TITLE
SALTO-3846 Add reference  from IdentityProviderPolicyRule to Application type in Okta

### DIFF
--- a/packages/okta-adapter/src/reference_mapping.ts
+++ b/packages/okta-adapter/src/reference_mapping.ts
@@ -131,6 +131,11 @@ export const referencesRules: OktaFieldReferenceDefinition[] = [
     serializationStrategy: 'id',
     target: { type: BEHAVIOR_RULE_TYPE_NAME },
   },
+  {
+    src: { field: 'id', parentTypes: ['AppAndInstanceConditionEvaluatorAppOrInstance'] },
+    serializationStrategy: 'id',
+    target: { type: APPLICATION_TYPE_NAME },
+  },
 ]
 
 const lookupNameFuncs: GetLookupNameFunc[] = [


### PR DESCRIPTION
Added reference from IdentityProviderPolicyRule to Application type in Okta
---

I added reference from conditions.app.include.id and conditions.app.exclude.id to application type in Okta. 
---
_Release Notes_: 
None

---
_User Notifications_: 
None
