### PR TITLE
PROD-76: enable fetching reports and layouts by default for all users

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -26,7 +26,7 @@ import {
   createInstanceElement,
 } from './transformer'
 import { getMetadataTypes, getTopLevelStandardTypes, metadataTypesToList } from './types'
-import { INTEGRATION, APPLICATION_ID, CUSTOM_RECORD_TYPE, REPORT_DEFINITION, FINANCIAL_LAYOUT } from './constants'
+import { INTEGRATION, APPLICATION_ID, CUSTOM_RECORD_TYPE } from './constants'
 import convertListsToMaps from './filters/convert_lists_to_maps'
 import replaceElementReferences from './filters/element_references'
 import parseReportTypes from './filters/parse_report_types'
@@ -358,10 +358,8 @@ export default class NetsuiteAdapter implements AdapterOperations {
       throw new Error('Can\'t define fetchTarget for the first fetch. Remove fetchTarget from adapter config file')
     }
 
-    const explicitIncludeTypeList = [REPORT_DEFINITION, FINANCIAL_LAYOUT]
-      .filter(typeName => !this.fetchInclude?.types.some(type => type.name === typeName))
     const deprecatedSkipList = buildNetsuiteQuery(convertToQueryParams({
-      types: Object.fromEntries(this.typesToSkip.concat(explicitIncludeTypeList).map(typeName => [typeName, ['.*']])),
+      types: Object.fromEntries(this.typesToSkip.map(typeName => [typeName, ['.*']])),
       filePaths: this.filePathRegexSkipList.map(reg => `.*${reg}.*`),
     }))
     const fetchQuery = [


### PR DESCRIPTION
_enable fetching reports and layouts by default for all users_

---

_None_

---
_Release Notes_: 
_Netsuite Adapter_:
* reportDefinitions and financialLayouts will be fetched by default and no longer need to be specified explicitly in the config

---
_User Notifications_: 
_reportDefinitions and financialLayouts nacls will be added to the WS/Env_
