### PR TITLE
SAAS-7296 deprecate deploymentUrls from coreResult.extraProperties

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -38,7 +38,6 @@ export type Group = {
 }
 
 export type DeployExtraProperties = {
-  deploymentUrls?: string[]
   groups?: Group[]
 }
 

--- a/packages/core/src/core/deploy/deploy_actions.ts
+++ b/packages/core/src/core/deploy/deploy_actions.ts
@@ -102,7 +102,6 @@ export const deployActions = async (
   checkOnly: boolean
 ): Promise<DeployActionResult> => {
   const appliedChanges: Change[] = []
-  const deploymentUrls: string[] = []
   const groups: Group[] = []
   try {
     await deployPlan.walkAsync(async (itemId: PlanItemId): Promise<void> => {
@@ -111,9 +110,6 @@ export const deployActions = async (
       try {
         const result = await deployAction(item, adapters, checkOnly)
         result.appliedChanges.forEach(appliedChange => appliedChanges.push(appliedChange))
-        if (result.extraProperties?.deploymentUrls !== undefined) {
-          deploymentUrls.push(...result.extraProperties.deploymentUrls)
-        }
         if (result.extraProperties?.groups !== undefined) {
           groups.push(...result.extraProperties.groups)
         }
@@ -138,7 +134,7 @@ export const deployActions = async (
         throw error
       }
     })
-    return { errors: [], appliedChanges, extraProperties: { groups, deploymentUrls } }
+    return { errors: [], appliedChanges, extraProperties: { groups } }
   } catch (error) {
     const deployErrors: DeployError[] = []
     if (error instanceof WalkError) {
@@ -159,6 +155,6 @@ export const deployActions = async (
         })
       }
     }
-    return { errors: deployErrors, appliedChanges, extraProperties: { groups, deploymentUrls } }
+    return { errors: deployErrors, appliedChanges, extraProperties: { groups } }
   }
 }

--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -377,7 +377,6 @@ export const deployMetadata = async (
     appliedChanges: validChanges.filter(isSuccessfulChange),
     errors: [...validationErrors, ...errors],
     extraProperties: {
-      deploymentUrls: deploymentUrl ? [deploymentUrl] : undefined,
       groups: isQuickDeployable(sfDeployRes)
         ? [{ id: groupId, requestId: sfDeployRes.id, hash: planHash, url: deploymentUrl }]
         : [{ id: groupId, url: deploymentUrl }],

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -1036,9 +1036,7 @@ describe('SalesforceAdapter CRUD', () => {
           })
         })
         it('should return deployment URL containing the deployment ID in the extra properties', async () => {
-          const receivedUrls = result.extraProperties?.deploymentUrls
-          const receivedUrl = receivedUrls?.[0]
-          expect(receivedUrls).toHaveLength(1)
+          const receivedUrl = (result.extraProperties?.groups ?? [])[0].url
           expect(receivedUrl).toContain(DEPLOYMENT_ID)
         })
       })


### PR DESCRIPTION
SAAS-7296 deprecate deploymentUrls from coreResult.extraProperties

---
_Additional context for reviewer_:
None

---
_Release Notes_: 
None
---

_User Notifications_: 
None