### PR TITLE
SALTO-3873: Remove duplicates from listMetadataObjects in salesforce

### DIFF
--- a/packages/lowerdash/src/collections/array.ts
+++ b/packages/lowerdash/src/collections/array.ts
@@ -38,3 +38,12 @@ export const findDuplicates = (items: string[]): string[] => (
     .map(([str]) => str)
     .sort()
 )
+
+export const splitDuplicates = <T>(
+  array: T[],
+  keyFunc: (t: T) => string | number
+): { duplicates: T[][]; uniques: T[] } => {
+  const groupedInput = Object.values(_.groupBy(array, keyFunc))
+  const [duplicates, uniques] = _.partition(groupedInput, group => group.length > 1)
+  return { duplicates, uniques: uniques.flat() }
+}

--- a/packages/lowerdash/test/collections/array.test.ts
+++ b/packages/lowerdash/test/collections/array.test.ts
@@ -16,7 +16,7 @@
 import _ from 'lodash'
 import { collections } from '../../src'
 
-const { makeArray, arrayOf, findDuplicates } = collections.array
+const { makeArray, arrayOf, findDuplicates, splitDuplicates } = collections.array
 
 describe('array', () => {
   describe('makeArray', () => {
@@ -91,6 +91,21 @@ describe('array', () => {
 
     it('should return sorted array with each duplicate appearing once when duplicates are found', () => {
       expect(findDuplicates(['def', 'abc', 'def', 'abd', 'aaa', 'def', 'abc'])).toEqual(['abc', 'def'])
+    })
+  })
+
+  describe('splitDuplicates', () => {
+    describe('with input array that contains some duplicates', () => {
+      let res: ReturnType<typeof splitDuplicates>
+      beforeEach(() => {
+        res = splitDuplicates(['a', 'b', 'cc', 'ddd'], item => item.length)
+      })
+      it('should return unique values as unique', () => {
+        expect(res.uniques).toEqual(['cc', 'ddd'])
+      })
+      it('should place duplicate values in groups according to the key function', () => {
+        expect(res.duplicates).toEqual([['a', 'b']])
+      })
     })
   })
 })

--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -43,7 +43,7 @@ import { fromRetrieveResult, toRetrieveRequest, getManifestTypeName } from './tr
 import { MetadataQuery } from './fetch_profile/metadata_query'
 
 const { isDefined } = lowerDashValues
-const { makeArray } = collections.array
+const { makeArray, splitDuplicates } = collections.array
 const { awu, keyByAsync } = collections.asynciterable
 const log = logger(module)
 
@@ -99,12 +99,6 @@ const withFullPath = (props: FileProperties, folderPathByName: Record<string, st
       fileName: props.fileName.replace(folderName, fullPath),
     }
     : props
-}
-
-const splitDuplicates = <T>(array: T[], keyFunc: (t: T) => string | number): { duplicates: T[][]; uniques: T[] } => {
-  const groupedInput = Object.values(_.groupBy(array, keyFunc))
-  const [duplicates, uniques] = _.partition(groupedInput, group => group.length > 1)
-  return { duplicates, uniques: uniques.flat() }
 }
 
 const removeDuplicateFileProps = (files: FileProperties[]): FileProperties[] => {


### PR DESCRIPTION
For some reason, on rare occasions we get the same fullName from listMetadataObjects more than once This leads to duplicate instances which cause colisions and other problems down the line

There is no point to fetch the same fullName more than once, so removing the duplicates seems like the reasonable thing to do

---


---
_Release Notes_: 
_Salesforce Adapter_:
- Fix rare issue of fetch failing to return some elements due to merge errors

---
_User Notifications_: 
_None_