### PR TITLE
SALTO-3856 improve NS quickFetch changed-objects queries

### DIFF
--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/custom_record_type.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/custom_record_type.ts
@@ -16,7 +16,7 @@
 */
 import { logger } from '@salto-io/logging'
 import { removeCustomRecordTypePrefix } from '../../types'
-import { convertSuiteQLStringToDate, SUITEQL_DATE_FORMAT } from '../date_formats'
+import { convertSuiteQLStringToDate, toSuiteQLSelectDateString } from '../date_formats'
 import { ChangedObject, TypeChangesDetector } from '../types'
 
 const log = logger(module)
@@ -26,7 +26,7 @@ const changesDetector: TypeChangesDetector = {
     const [startDate, endDate] = dateRange.toSuiteQLRange()
 
     const results = await client.runSuiteQL(`
-        SELECT scriptid, TO_CHAR(lastmodifieddate, '${SUITEQL_DATE_FORMAT}') AS lastmodifieddate
+        SELECT scriptid, ${toSuiteQLSelectDateString('lastmodifieddate')} AS time
         FROM customrecordtype
         WHERE lastmodifieddate BETWEEN ${startDate} AND ${endDate}
         ORDER BY scriptid ASC
@@ -38,8 +38,8 @@ const changesDetector: TypeChangesDetector = {
     }
 
     const changes: ChangedObject[] = results
-      .filter((res): res is { scriptid: string; lastmodifieddate: string } => {
-        if ([res.scriptid, res.lastmodifieddate].some(val => typeof val !== 'string')) {
+      .filter((res): res is { scriptid: string; time: string } => {
+        if ([res.scriptid, res.time].some(val => typeof val !== 'string')) {
           log.warn('Got invalid result from customrecordtype query, %o', res)
           return false
         }
@@ -47,15 +47,15 @@ const changesDetector: TypeChangesDetector = {
       })
       .map(res => ({
         type: 'object',
-        externalId: res.scriptid,
-        time: convertSuiteQLStringToDate(res.lastmodifieddate),
+        objectId: res.scriptid,
+        time: convertSuiteQLStringToDate(res.time, dateRange.end),
       }))
 
     // the script ids of the custom segments that are returned from the SDF
     // are returned without the 'customrecord_' prefix.
     const changesForCustomSegments: ChangedObject[] = changes.map(change => ({
       type: 'object',
-      externalId: removeCustomRecordTypePrefix(change.externalId),
+      objectId: removeCustomRecordTypePrefix(change.objectId),
       time: change.time,
     }))
 

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/savedsearch.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/savedsearch.ts
@@ -42,8 +42,8 @@ const changesDetector: TypeChangesDetector = {
       })
       .map(res => ({
         type: 'object',
-        externalId: res.id,
-        time: convertSavedSearchStringToDate(res.datemodified),
+        objectId: res.id,
+        time: convertSavedSearchStringToDate(res.datemodified, dateRange.end),
       }))
   },
   getTypes: () => ([

--- a/packages/netsuite-adapter/src/changes_detector/date_formats.ts
+++ b/packages/netsuite-adapter/src/changes_detector/date_formats.ts
@@ -16,49 +16,42 @@
 import { logger } from '@salto-io/logging'
 import { DateRange } from './types'
 
-const SUITEQL_DATE_PATTERN = /(?<month>\d+)\/(?<day>\d+)\/(?<year>\d+)/
-const SAVED_SEARCH_DATE_PATTERN = /(?<month>\d+)\/(?<day>\d+)\/(?<year>\d+) (?<hour>\d+):(?<minute>\d+) (?<ampm>\w+)/
-export const SUITEQL_DATE_FORMAT = 'MM/DD/YYYY'
 const log = logger(module)
 
-const formatSuiteQLDate = (date: Date): string => `TO_DATE('${date.getUTCMonth() + 1}/${date.getUTCDate()}/${date.getUTCFullYear()}', '${SUITEQL_DATE_FORMAT}')`
+export const SUITEQL_DATE_FORMAT = 'YYYY-MM-DD'
+export const SUITEQL_TIME_FORMAT = 'HH:MI:SS'
+const suiteQLDateFormatRegex = /(?<year>\d+)-(?<month>\d+)-(?<day>\d+) (?<hour>\d+):(?<minute>\d+):(?<second>\d+)/
+const savedSearchDateFormatRegex = /(?<month>\d+)\/(?<day>\d+)\/(?<year>\d+) (?<hour>\d+):(?<minute>\d+) (?<ampm>\w+)/
 
-const formatSavedSearchDate = (date: Date): string => {
+export const toSuiteQLWhereDateString = (date: Date): string =>
+  `TO_DATE('${date.getUTCFullYear()}-${date.getUTCMonth() + 1}-${date.getUTCDate()}', '${SUITEQL_DATE_FORMAT}')`
+
+export const toSuiteQLSelectDateString = (param: string): string =>
+  `TO_CHAR(${param}, '${SUITEQL_DATE_FORMAT} ${SUITEQL_TIME_FORMAT}')`
+
+export const convertSuiteQLStringToDate = (rawDate: string, fallback: Date): Date => {
+  const match = suiteQLDateFormatRegex.exec(rawDate)
+  if (match === null || match.groups === undefined) {
+    log.error(`Failed to parse SuiteQL date: ${rawDate}`)
+    return fallback
+  }
+  return new Date(Date.UTC(
+    parseInt(match.groups.year, 10),
+    parseInt(match.groups.month, 10) - 1,
+    parseInt(match.groups.day, 10),
+    parseInt(match.groups.hour, 10),
+    parseInt(match.groups.minute, 10),
+    parseInt(match.groups.second, 10),
+  ))
+}
+
+const toSavedSearchWhereDateString = (date: Date): string => {
   const hour = date.getUTCHours() > 12 ? date.getUTCHours() - 12 : date.getUTCHours()
   const dayTime = date.getUTCHours() >= 12 ? 'pm' : 'am'
   return `${date.getUTCMonth() + 1}/${date.getUTCDate()}/${date.getUTCFullYear()} ${hour}:${date.getUTCMinutes()} ${dayTime}`
 }
 
-
-export const createDateRange = (start: Date, end: Date): DateRange => ({
-  start,
-  end,
-  toSuiteQLRange: () => {
-    const endDate = new Date(end)
-    endDate.setDate(endDate.getDate() + 1)
-    return [formatSuiteQLDate(start), formatSuiteQLDate(endDate)]
-  },
-  toSavedSearchRange: () => {
-    const endDate = new Date(end)
-    endDate.setMinutes(endDate.getMinutes() + 1)
-    return [formatSavedSearchDate(start), formatSavedSearchDate(endDate)]
-  },
-})
-
-export const convertSuiteQLStringToDate = (rawDate: string): Date | undefined => {
-  const match = SUITEQL_DATE_PATTERN.exec(rawDate)
-  if (match === null || match.groups === undefined) {
-    log.error(`Failed to parse SuiteQL date: ${rawDate}`)
-    return undefined
-  }
-  return new Date(Date.UTC(
-    parseInt(match.groups.year, 10),
-    parseInt(match.groups.month, 10) - 1,
-    parseInt(match.groups.day, 10) + 1,
-  ))
-}
-
-export const parseHour = (groups: Record<string, string>): number => {
+const parseHour = (groups: Record<string, string>): number => {
   const rawHour = parseInt(groups.hour, 10)
   if (groups.ampm === 'pm' && rawHour !== 12) {
     return rawHour + 12
@@ -70,11 +63,11 @@ export const parseHour = (groups: Record<string, string>): number => {
   return rawHour
 }
 
-export const convertSavedSearchStringToDate = (rawDate: string): Date | undefined => {
-  const match = SAVED_SEARCH_DATE_PATTERN.exec(rawDate)
+export const convertSavedSearchStringToDate = (rawDate: string, fallback: Date): Date => {
+  const match = savedSearchDateFormatRegex.exec(rawDate)
   if (match === null || match.groups === undefined) {
     log.error(`Failed to parse Saved Search date: ${rawDate}`)
-    return undefined
+    return fallback
   }
 
   return new Date(Date.UTC(
@@ -85,3 +78,18 @@ export const convertSavedSearchStringToDate = (rawDate: string): Date | undefine
     parseInt(match.groups.minute, 10) + 1,
   ))
 }
+
+export const createDateRange = (start: Date, end: Date): DateRange => ({
+  start,
+  end,
+  toSuiteQLRange: () => {
+    const endDate = new Date(end)
+    endDate.setDate(endDate.getDate() + 1)
+    return [toSuiteQLWhereDateString(start), toSuiteQLWhereDateString(endDate)]
+  },
+  toSavedSearchRange: () => {
+    const endDate = new Date(end)
+    endDate.setMinutes(endDate.getMinutes() + 1)
+    return [toSavedSearchWhereDateString(start), toSavedSearchWhereDateString(endDate)]
+  },
+})

--- a/packages/netsuite-adapter/src/changes_detector/types.ts
+++ b/packages/netsuite-adapter/src/changes_detector/types.ts
@@ -17,9 +17,8 @@ import NetsuiteClient from '../client/client'
 
 export type ChangedObject = {
   type: 'object'
-  externalId: string
-  internalId?: number
-  time?: Date
+  objectId: string
+  time: Date
 }
 
 export type ChangedType = {
@@ -47,5 +46,7 @@ export type TypeChangesDetector = {
   getTypes: () => string[]
 }
 
-export type FileCabinetChangesDetector = (client: NetsuiteClient, dateRange: DateRange) =>
-  Promise<(ChangedObject & { internalId: number })[]>
+export type FileCabinetChangesDetector = (
+  client: NetsuiteClient,
+  dateRange: DateRange
+) => Promise<ChangedObject[]>

--- a/packages/netsuite-adapter/test/changes_detector/custom_field.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/custom_field.test.ts
@@ -18,7 +18,7 @@ import { customFieldDetector as detector } from '../../src/changes_detector/chan
 import { Change } from '../../src/changes_detector/types'
 import NetsuiteClient from '../../src/client/client'
 import mockSdfClient from '../client/sdf_client'
-import { createDateRange } from '../../src/changes_detector/date_formats'
+import { createDateRange, toSuiteQLSelectDateString } from '../../src/changes_detector/date_formats'
 
 describe('custom_field', () => {
   const runSuiteQLMock = jest.fn()
@@ -32,8 +32,8 @@ describe('custom_field', () => {
     beforeEach(async () => {
       runSuiteQLMock.mockReset()
       runSuiteQLMock.mockResolvedValue([
-        { scriptid: 'a', lastmodifieddate: '03/15/2021' },
-        { scriptid: 'b', lastmodifieddate: '03/16/2021' },
+        { scriptid: 'a', time: '2021-03-15 00:00:00' },
+        { scriptid: 'b', time: '2021-03-16 00:00:00' },
       ])
       results = await detector.getChanges(
         client,
@@ -42,16 +42,16 @@ describe('custom_field', () => {
     })
     it('should return the changes', () => {
       expect(results).toEqual([
-        { type: 'object', externalId: 'a', time: new Date('2021-03-16T00:00:00.000Z') },
-        { type: 'object', externalId: 'b', time: new Date('2021-03-17T00:00:00.000Z') },
+        { type: 'object', objectId: 'a', time: new Date('2021-03-15T00:00:00.000Z') },
+        { type: 'object', objectId: 'b', time: new Date('2021-03-16T00:00:00.000Z') },
       ])
     })
 
     it('should make the right query', () => {
       expect(runSuiteQLMock).toHaveBeenCalledWith(`
-      SELECT scriptid, TO_CHAR(lastmodifieddate, 'MM/DD/YYYY') AS lastmodifieddate
+      SELECT scriptid, ${toSuiteQLSelectDateString('lastmodifieddate')} AS time
       FROM customfield
-      WHERE lastmodifieddate BETWEEN TO_DATE('1/11/2021', 'MM/DD/YYYY') AND TO_DATE('2/23/2021', 'MM/DD/YYYY')
+      WHERE lastmodifieddate BETWEEN TO_DATE('2021-1-11', 'YYYY-MM-DD') AND TO_DATE('2021-2-23', 'YYYY-MM-DD')
       ORDER BY scriptid ASC
     `)
     })
@@ -62,8 +62,8 @@ describe('custom_field', () => {
     beforeEach(async () => {
       runSuiteQLMock.mockReset()
       runSuiteQLMock.mockResolvedValue([
-        { scriptid: 'a', lastmodifieddate: '03/15/2021' },
-        { scriptid: 'b', lastmodifieddate: '03/16/2021' },
+        { scriptid: 'a', time: '2021-03-15 00:00:00' },
+        { scriptid: 'b', time: '2021-03-16 00:00:00' },
         { qqq: 'b' },
         { scriptid: {} },
       ])
@@ -74,8 +74,8 @@ describe('custom_field', () => {
     })
     it('should return the changes without the invalid results', () => {
       expect(results).toEqual([
-        { type: 'object', externalId: 'a', time: new Date('2021-03-16T00:00:00.000Z') },
-        { type: 'object', externalId: 'b', time: new Date('2021-03-17T00:00:00.000Z') },
+        { type: 'object', objectId: 'a', time: new Date('2021-03-15T00:00:00.000Z') },
+        { type: 'object', objectId: 'b', time: new Date('2021-03-16T00:00:00.000Z') },
       ])
     })
   })

--- a/packages/netsuite-adapter/test/changes_detector/custom_list.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/custom_list.test.ts
@@ -18,7 +18,7 @@ import { customListDetector as detector } from '../../src/changes_detector/chang
 import { Change } from '../../src/changes_detector/types'
 import mockSdfClient from '../client/sdf_client'
 import NetsuiteClient from '../../src/client/client'
-import { createDateRange } from '../../src/changes_detector/date_formats'
+import { createDateRange, toSuiteQLSelectDateString } from '../../src/changes_detector/date_formats'
 
 describe('custom_list', () => {
   const runSuiteQLMock = jest.fn()
@@ -33,8 +33,8 @@ describe('custom_list', () => {
     beforeEach(async () => {
       runSuiteQLMock.mockReset()
       runSuiteQLMock.mockResolvedValue([
-        { scriptid: 'a', lastmodifieddate: '03/15/2021' },
-        { scriptid: 'b', lastmodifieddate: '03/16/2021' },
+        { scriptid: 'a', time: '2021-03-15 00:00:00' },
+        { scriptid: 'b', time: '2021-03-16 00:00:00' },
       ])
       results = await detector.getChanges(
         client,
@@ -43,16 +43,16 @@ describe('custom_list', () => {
     })
     it('should return the changes', () => {
       expect(results).toEqual([
-        { type: 'object', externalId: 'a', time: new Date('2021-03-16T00:00:00.000Z') },
-        { type: 'object', externalId: 'b', time: new Date('2021-03-17T00:00:00.000Z') },
+        { type: 'object', objectId: 'a', time: new Date('2021-03-15T00:00:00.000Z') },
+        { type: 'object', objectId: 'b', time: new Date('2021-03-16T00:00:00.000Z') },
       ])
     })
 
     it('should make the right query', () => {
       expect(runSuiteQLMock).toHaveBeenCalledWith(`
-      SELECT scriptid, TO_CHAR(lastmodifieddate, 'MM/DD/YYYY') AS lastmodifieddate
+      SELECT scriptid, ${toSuiteQLSelectDateString('lastmodifieddate')} AS time
       FROM customlist
-      WHERE lastmodifieddate BETWEEN TO_DATE('1/11/2021', 'MM/DD/YYYY') AND TO_DATE('2/23/2021', 'MM/DD/YYYY')
+      WHERE lastmodifieddate BETWEEN TO_DATE('2021-1-11', 'YYYY-MM-DD') AND TO_DATE('2021-2-23', 'YYYY-MM-DD')
       ORDER BY scriptid ASC
     `)
     })
@@ -63,8 +63,8 @@ describe('custom_list', () => {
     beforeEach(async () => {
       runSuiteQLMock.mockReset()
       runSuiteQLMock.mockResolvedValue([
-        { scriptid: 'a', lastmodifieddate: '03/15/2021' },
-        { scriptid: 'b', lastmodifieddate: '03/16/2021' },
+        { scriptid: 'a', time: '2021-03-15 00:00:00' },
+        { scriptid: 'b', time: '2021-03-16 00:00:00' },
         { qqq: 'b' },
         { scriptid: {} },
       ])
@@ -75,8 +75,8 @@ describe('custom_list', () => {
     })
     it('should return the changes without the invalid results', () => {
       expect(results).toEqual([
-        { type: 'object', externalId: 'a', time: new Date('2021-03-16T00:00:00.000Z') },
-        { type: 'object', externalId: 'b', time: new Date('2021-03-17T00:00:00.000Z') },
+        { type: 'object', objectId: 'a', time: new Date('2021-03-15T00:00:00.000Z') },
+        { type: 'object', objectId: 'b', time: new Date('2021-03-16T00:00:00.000Z') },
       ])
     })
   })

--- a/packages/netsuite-adapter/test/changes_detector/custom_record_type.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/custom_record_type.test.ts
@@ -18,7 +18,7 @@ import detector from '../../src/changes_detector/changes_detectors/custom_record
 import { Change } from '../../src/changes_detector/types'
 import mockSdfClient from '../client/sdf_client'
 import NetsuiteClient from '../../src/client/client'
-import { createDateRange } from '../../src/changes_detector/date_formats'
+import { createDateRange, toSuiteQLSelectDateString } from '../../src/changes_detector/date_formats'
 
 describe('custom_record_type', () => {
   const runSuiteQLMock = jest.fn()
@@ -33,8 +33,8 @@ describe('custom_record_type', () => {
     beforeEach(async () => {
       runSuiteQLMock.mockReset()
       runSuiteQLMock.mockResolvedValue([
-        { scriptid: 'customrecord_a', lastmodifieddate: '03/15/2021' },
-        { scriptid: 'customrecord_b', lastmodifieddate: '03/16/2021' },
+        { scriptid: 'customrecord_a', time: '2021-03-15 00:00:00' },
+        { scriptid: 'customrecord_b', time: '2021-03-16 00:00:00' },
       ])
       results = await detector.getChanges(
         client,
@@ -43,18 +43,18 @@ describe('custom_record_type', () => {
     })
     it('should return the changes', () => {
       expect(results).toEqual([
-        { type: 'object', externalId: 'customrecord_a', time: new Date('2021-03-16T00:00:00.000Z') },
-        { type: 'object', externalId: 'customrecord_b', time: new Date('2021-03-17T00:00:00.000Z') },
-        { type: 'object', externalId: 'a', time: new Date('2021-03-16T00:00:00.000Z') },
-        { type: 'object', externalId: 'b', time: new Date('2021-03-17T00:00:00.000Z') },
+        { type: 'object', objectId: 'customrecord_a', time: new Date('2021-03-15T00:00:00.000Z') },
+        { type: 'object', objectId: 'customrecord_b', time: new Date('2021-03-16T00:00:00.000Z') },
+        { type: 'object', objectId: 'a', time: new Date('2021-03-15T00:00:00.000Z') },
+        { type: 'object', objectId: 'b', time: new Date('2021-03-16T00:00:00.000Z') },
       ])
     })
 
     it('should make the right query', () => {
       expect(runSuiteQLMock).toHaveBeenCalledWith(`
-        SELECT scriptid, TO_CHAR(lastmodifieddate, 'MM/DD/YYYY') AS lastmodifieddate
+        SELECT scriptid, ${toSuiteQLSelectDateString('lastmodifieddate')} AS time
         FROM customrecordtype
-        WHERE lastmodifieddate BETWEEN TO_DATE('1/11/2021', 'MM/DD/YYYY') AND TO_DATE('2/23/2021', 'MM/DD/YYYY')
+        WHERE lastmodifieddate BETWEEN TO_DATE('2021-1-11', 'YYYY-MM-DD') AND TO_DATE('2021-2-23', 'YYYY-MM-DD')
         ORDER BY scriptid ASC
       `)
     })
@@ -65,8 +65,8 @@ describe('custom_record_type', () => {
     beforeEach(async () => {
       runSuiteQLMock.mockReset()
       runSuiteQLMock.mockResolvedValue([
-        { scriptid: 'customrecord_a', lastmodifieddate: '03/15/2021' },
-        { scriptid: 'customrecord_b', lastmodifieddate: '03/16/2021' },
+        { scriptid: 'customrecord_a', time: '2021-03-15 00:00:00' },
+        { scriptid: 'customrecord_b', time: '2021-03-16 00:00:00' },
         { qqq: 'b' },
         { scriptid: {} },
       ])
@@ -77,10 +77,10 @@ describe('custom_record_type', () => {
     })
     it('should return the changes without the invalid results', () => {
       expect(results).toEqual([
-        { type: 'object', externalId: 'customrecord_a', time: new Date('2021-03-16T00:00:00.000Z') },
-        { type: 'object', externalId: 'customrecord_b', time: new Date('2021-03-17T00:00:00.000Z') },
-        { type: 'object', externalId: 'a', time: new Date('2021-03-16T00:00:00.000Z') },
-        { type: 'object', externalId: 'b', time: new Date('2021-03-17T00:00:00.000Z') },
+        { type: 'object', objectId: 'customrecord_a', time: new Date('2021-03-15T00:00:00.000Z') },
+        { type: 'object', objectId: 'customrecord_b', time: new Date('2021-03-16T00:00:00.000Z') },
+        { type: 'object', objectId: 'a', time: new Date('2021-03-15T00:00:00.000Z') },
+        { type: 'object', objectId: 'b', time: new Date('2021-03-16T00:00:00.000Z') },
       ])
     })
   })

--- a/packages/netsuite-adapter/test/changes_detector/custom_records.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/custom_records.test.ts
@@ -55,7 +55,7 @@ describe('custom records', () => {
     it('should make the right query', () => {
       expect(runSuiteQLMock).toHaveBeenCalledTimes(2)
       expect(runSuiteQLMock).toHaveBeenNthCalledWith(1, 'SELECT scriptid FROM customrecordtype  ORDER BY scriptid ASC')
-      expect(runSuiteQLMock).toHaveBeenNthCalledWith(2, 'SELECT scriptid FROM customrecord1 WHERE lastmodified BETWEEN TO_DATE(\'1/11/2021\', \'MM/DD/YYYY\') AND TO_DATE(\'2/23/2021\', \'MM/DD/YYYY\') ORDER BY scriptid ASC')
+      expect(runSuiteQLMock).toHaveBeenNthCalledWith(2, 'SELECT scriptid FROM customrecord1 WHERE lastmodified BETWEEN TO_DATE(\'2021-1-11\', \'YYYY-MM-DD\') AND TO_DATE(\'2021-2-23\', \'YYYY-MM-DD\') ORDER BY scriptid ASC')
     })
   })
   it('return nothing when custom record types query fails', async () => {

--- a/packages/netsuite-adapter/test/changes_detector/date_formats.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/date_formats.test.ts
@@ -15,25 +15,27 @@
 */
 import { convertSavedSearchStringToDate, convertSuiteQLStringToDate } from '../../src/changes_detector/date_formats'
 
+const fallback = new Date(Date.UTC(2023, 2, 2, 13, 6))
+
 describe('convertSavedSearchStringToDate', () => {
   it('convert correctly', () => {
-    expect(convertSavedSearchStringToDate('03/02/2020 1:05 pm')).toEqual(new Date(Date.UTC(2020, 2, 2, 13, 6)))
-    expect(convertSavedSearchStringToDate('03/02/2020 12:05 pm')).toEqual(new Date(Date.UTC(2020, 2, 2, 12, 6)))
-    expect(convertSavedSearchStringToDate('03/02/2020 8:05 am')).toEqual(new Date(Date.UTC(2020, 2, 2, 8, 6)))
-    expect(convertSavedSearchStringToDate('03/02/2020 12:05 am')).toEqual(new Date(Date.UTC(2020, 2, 2, 0, 6)))
+    expect(convertSavedSearchStringToDate('03/02/2020 1:05 pm', fallback)).toEqual(new Date(Date.UTC(2020, 2, 2, 13, 6)))
+    expect(convertSavedSearchStringToDate('03/02/2020 12:05 pm', fallback)).toEqual(new Date(Date.UTC(2020, 2, 2, 12, 6)))
+    expect(convertSavedSearchStringToDate('03/02/2020 8:05 am', fallback)).toEqual(new Date(Date.UTC(2020, 2, 2, 8, 6)))
+    expect(convertSavedSearchStringToDate('03/02/2020 12:05 am', fallback)).toEqual(new Date(Date.UTC(2020, 2, 2, 0, 6)))
   })
 
   it('should return undefined for invalid date', () => {
-    expect(convertSavedSearchStringToDate('invalid')).toBeUndefined()
+    expect(convertSavedSearchStringToDate('invalid', fallback)).toEqual(fallback)
   })
 })
 
 describe('convertSuiteQLStringToDate', () => {
   it('convert correctly', () => {
-    expect(convertSuiteQLStringToDate('03/02/2020')).toEqual(new Date(Date.UTC(2020, 2, 3)))
+    expect(convertSuiteQLStringToDate('2020-03-02 13:05:20', fallback)).toEqual(new Date(Date.UTC(2020, 2, 2, 13, 5, 20)))
   })
 
   it('should return undefined for invalid date', () => {
-    expect(convertSuiteQLStringToDate('invalid')).toBeUndefined()
+    expect(convertSuiteQLStringToDate('invalid', fallback)).toEqual(fallback)
   })
 })

--- a/packages/netsuite-adapter/test/changes_detector/savedsearch.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/savedsearch.test.ts
@@ -44,8 +44,8 @@ describe('savedsearch', () => {
     })
     it('should return the changes', () => {
       expect(results).toEqual([
-        { type: 'object', externalId: 'a', time: new Date('2021-03-15T15:05:00.000Z') },
-        { type: 'object', externalId: 'b', time: new Date('2021-03-15T15:06:00.000Z') },
+        { type: 'object', objectId: 'a', time: new Date('2021-03-15T15:05:00.000Z') },
+        { type: 'object', objectId: 'b', time: new Date('2021-03-15T15:06:00.000Z') },
       ])
     })
 

--- a/packages/netsuite-adapter/test/filters/author_information/system_note.test.ts
+++ b/packages/netsuite-adapter/test/filters/author_information/system_note.test.ts
@@ -15,7 +15,7 @@
 */
 import { CORE_ANNOTATIONS, Element, ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import filterCreator, { FILE_FIELD_IDENTIFIER, FOLDER_FIELD_IDENTIFIER, QUERY_DATE_FORMAT } from '../../../src/filters/author_information/system_note'
+import filterCreator, { FILE_FIELD_IDENTIFIER, FOLDER_FIELD_IDENTIFIER } from '../../../src/filters/author_information/system_note'
 import { CUSTOM_RECORD_TYPE, FILE, FOLDER, METADATA_TYPE, NETSUITE } from '../../../src/constants'
 import { createServerTimeElements } from '../../../src/server_time'
 import NetsuiteClient from '../../../src/client/client'
@@ -24,6 +24,7 @@ import SuiteAppClient from '../../../src/client/suiteapp_client/suiteapp_client'
 import mockSdfClient from '../../client/sdf_client'
 import { EMPLOYEE_NAME_QUERY } from '../../../src/filters/author_information/constants'
 import { createEmptyElementsSourceIndexes, getDefaultAdapterConfig } from '../../utils'
+import { toSuiteQLSelectDateString, toSuiteQLWhereDateString } from '../../../src/changes_detector/date_formats'
 
 describe('netsuite system note author information', () => {
   let filterOpts: FilterOpts
@@ -107,8 +108,8 @@ describe('netsuite system note author information', () => {
 
   it('should query information from api', async () => {
     await filterCreator(filterOpts).onFetch?.(elements)
-    const fieldSystemNotesQuery = `SELECT name, field, recordid, date from (SELECT name, field, recordid, TO_CHAR(MAX(date), '${QUERY_DATE_FORMAT}') AS date FROM (SELECT name, REGEXP_SUBSTR(field, '^(MEDIAITEMFOLDER.|MEDIAITEM.)') AS field, recordid, date FROM systemnote WHERE date >= TO_DATE('2022-01-01', '${QUERY_DATE_FORMAT}') AND (field LIKE 'MEDIAITEM.%' OR field LIKE 'MEDIAITEMFOLDER.%')) GROUP BY name, field, recordid) ORDER BY name, field, recordid ASC`
-    const recordTypeSystemNotesQuery = `SELECT name, recordid, recordtypeid, date FROM (SELECT name, recordid, recordtypeid, TO_CHAR(MAX(date), '${QUERY_DATE_FORMAT}') as date FROM systemnote WHERE date >= TO_DATE('2022-01-01', '${QUERY_DATE_FORMAT}') AND (recordtypeid = '-112' OR recordtypeid = '1' OR recordtypeid = '-123') GROUP BY name, recordid, recordtypeid) ORDER BY name, recordid, recordtypeid ASC`
+    const fieldSystemNotesQuery = `SELECT name, field, recordid, date from (SELECT name, field, recordid, ${toSuiteQLSelectDateString('MAX(date)')} AS date FROM (SELECT name, REGEXP_SUBSTR(field, '^(MEDIAITEMFOLDER.|MEDIAITEM.)') AS field, recordid, date FROM systemnote WHERE date >= ${toSuiteQLWhereDateString(new Date('2022-01-01'))} AND (field LIKE 'MEDIAITEM.%' OR field LIKE 'MEDIAITEMFOLDER.%')) GROUP BY name, field, recordid) ORDER BY name, field, recordid ASC`
+    const recordTypeSystemNotesQuery = `SELECT name, recordid, recordtypeid, date FROM (SELECT name, recordid, recordtypeid, ${toSuiteQLSelectDateString('MAX(date)')} as date FROM systemnote WHERE date >= ${toSuiteQLWhereDateString(new Date('2022-01-01'))} AND (recordtypeid = '-112' OR recordtypeid = '1' OR recordtypeid = '-123') GROUP BY name, recordid, recordtypeid) ORDER BY name, recordid, recordtypeid ASC`
     expect(runSuiteQLMock).toHaveBeenNthCalledWith(1, EMPLOYEE_NAME_QUERY)
     expect(runSuiteQLMock).toHaveBeenNthCalledWith(2, fieldSystemNotesQuery)
     expect(runSuiteQLMock).toHaveBeenNthCalledWith(3, recordTypeSystemNotesQuery)
@@ -119,7 +120,7 @@ describe('netsuite system note author information', () => {
     await filterCreator(filterOpts).onFetch?.(
       [accountInstance, customRecordType, customRecord, customRecordTypeWithNoInstances, missingInstance]
     )
-    const systemNotesQuery = `SELECT name, recordid, recordtypeid, date FROM (SELECT name, recordid, recordtypeid, TO_CHAR(MAX(date), '${QUERY_DATE_FORMAT}') as date FROM systemnote WHERE date >= TO_DATE('2022-01-01', '${QUERY_DATE_FORMAT}') AND (recordtypeid = '-112' OR recordtypeid = '1' OR recordtypeid = '-123') GROUP BY name, recordid, recordtypeid) ORDER BY name, recordid, recordtypeid ASC`
+    const systemNotesQuery = `SELECT name, recordid, recordtypeid, date FROM (SELECT name, recordid, recordtypeid, ${toSuiteQLSelectDateString('MAX(date)')} as date FROM systemnote WHERE date >= ${toSuiteQLWhereDateString(new Date('2022-01-01'))} AND (recordtypeid = '-112' OR recordtypeid = '1' OR recordtypeid = '-123') GROUP BY name, recordid, recordtypeid) ORDER BY name, recordid, recordtypeid ASC`
     expect(runSuiteQLMock).toHaveBeenNthCalledWith(1, EMPLOYEE_NAME_QUERY)
     expect(runSuiteQLMock).toHaveBeenNthCalledWith(2, systemNotesQuery)
     expect(runSuiteQLMock).toHaveBeenCalledTimes(2)


### PR DESCRIPTION
Should not query system notes specifically in order to know which objects have been changed - we can get the info from the queries of each type.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Improve NS quickFetch changed-objects queries

---
_User Notifications_: 
None