### PR TITLE
Fix date format for future dates validation in saved searches

### DIFF
--- a/packages/netsuite-adapter/src/filters/author_information/constants.ts
+++ b/packages/netsuite-adapter/src/filters/author_information/constants.ts
@@ -110,6 +110,9 @@ export const SAVED_SEARCH_RESULT_SCHEMA = {
       id: {
         type: 'string',
       },
+      datemodified: {
+        type: 'string',
+      },
       modifiedby: {
         items: {
           properties: {
@@ -132,6 +135,7 @@ export const SAVED_SEARCH_RESULT_SCHEMA = {
     required: [
       'id',
       'modifiedby',
+      'datemodified',
     ],
     type: 'object',
   },
@@ -150,8 +154,8 @@ export type SavedSearchesResult = {
 }
 
 export type ModificationInformation = {
-  name: string
-  date: string
+  lastModifiedBy: string
+  lastModifiedAt: string
 }
 
 export type DateKeys = 'YYYY' | 'M' | 'D'

--- a/packages/netsuite-adapter/src/filters/author_information/saved_searches.ts
+++ b/packages/netsuite-adapter/src/filters/author_information/saved_searches.ts
@@ -167,14 +167,15 @@ const filterCreator: FilterCreator = ({ client, config, elementsSource, isPartia
       return
     }
     const timeZoneAndFormat = await getZoneAndFormat(elements, elementsSource, isPartial)
+    const { elemIdToChangeByIndex, elemIdToChangeAtIndex } = await elementsSourceIndex.getIndexes()
     if (timeZoneAndFormat.format === undefined) {
+      savedSearchesInstances.forEach(instance => {
+        instance.annotate({ [CORE_ANNOTATIONS.CHANGED_BY]: elemIdToChangeByIndex[instance.elemID.getFullName()] })
+        instance.annotate({ [CORE_ANNOTATIONS.CHANGED_AT]: elemIdToChangeAtIndex[instance.elemID.getFullName()] })
+      })
       return
     }
     const savedSearchesMap = await getSavedSearchesMap(client, timeZoneAndFormat)
-    const { elemIdToChangeByIndex, elemIdToChangeAtIndex } = await elementsSourceIndex.getIndexes()
-    if (_.isEmpty(savedSearchesMap) && _.isEmpty(elemIdToChangeByIndex) && _.isEmpty(elemIdToChangeAtIndex)) {
-      return
-    }
     savedSearchesInstances.forEach(instance => {
       const result = savedSearchesMap[instance.value[SCRIPT_ID]]
       if (result !== undefined) {

--- a/packages/netsuite-adapter/src/filters/author_information/system_note.ts
+++ b/packages/netsuite-adapter/src/filters/author_information/system_note.ts
@@ -17,7 +17,7 @@
 import { CORE_ANNOTATIONS, InstanceElement, isInstanceElement, Element, isObjectType, ObjectType } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
-import { values as lowerDashValues, collections } from '@salto-io/lowerdash'
+import { collections } from '@salto-io/lowerdash'
 import Ajv from 'ajv'
 import moment from 'moment-timezone'
 import { TYPES_TO_INTERNAL_ID as ORIGINAL_TYPES_TO_INTERNAL_ID } from '../../data_elements/types'
@@ -27,10 +27,9 @@ import { getLastServerTime } from '../../server_time'
 import { EmployeeResult, EMPLOYEE_NAME_QUERY, EMPLOYEE_SCHEMA, SystemNoteResult, SYSTEM_NOTE_SCHEMA, ModificationInformation } from './constants'
 import { getInternalId, hasInternalId, isCustomRecordType } from '../../types'
 import { CUSTOM_RECORD_TYPE } from '../../constants'
-import { changeDateFormat, getZoneAndFormat } from './saved_searches'
-import { SUITEQL_DATE_FORMAT, SUITEQL_TIME_FORMAT, toSuiteQLSelectDateString, toSuiteQLWhereDateString } from '../../changes_detector/date_formats'
+import { getZoneAndFormat, toMomentDate } from './saved_searches'
+import { toSuiteQLSelectDateString, toSuiteQLWhereDateString } from '../../changes_detector/date_formats'
 
-const { isDefined } = lowerDashValues
 const { awu } = collections.asynciterable
 const log = logger(module)
 const UNDERSCORE = '_'
@@ -177,17 +176,18 @@ const distinctSortedSystemNotes = (
 const indexSystemNotes = (
   systemNotes: SystemNoteResult[]
 ): Record<string, ModificationInformation> =>
-  Object.fromEntries(systemNotes.map(
-    systemnote => [getKeyForNote(systemnote), { name: systemnote.name, date: systemnote.date }]
-  ))
+  Object.fromEntries(systemNotes.map(systemnote => [
+    getKeyForNote(systemnote),
+    { lastModifiedBy: systemnote.name, lastModifiedAt: systemnote.date },
+  ]))
 
 const fetchSystemNotes = async (
   client: NetsuiteClient,
   queryIds: string[],
   lastFetchTime: Date,
-  timeZone: string,
+  employeeNames: Record<string, string>,
+  timeZone: string | undefined
 ): Promise<Record<string, ModificationInformation>> => {
-  const now = moment.tz(timeZone)
   const systemNotes = await log.time(
     () => querySystemNotes(client, queryIds, lastFetchTime),
     'querySystemNotes'
@@ -196,11 +196,20 @@ const fetchSystemNotes = async (
     log.warn('System note query failed')
     return {}
   }
+  const now = timeZone ? moment.tz(timeZone).utc() : moment().utc()
   return indexSystemNotes(
     distinctSortedSystemNotes(
-      systemNotes.filter(
-        systemNote => isDefined(systemNote.date) && !now.isBefore(moment.tz(systemNote.date, timeZone))
-      )
+      systemNotes
+        .map(({ date, name, ...item }) => ({
+          ...item,
+          name: employeeNames[name],
+          date: toMomentDate(date, { format: moment.ISO_8601, timeZone }),
+        }))
+        .filter(({ date, name }) => !now.isBefore(date) && name !== undefined)
+        .map(({ date, ...item }) => ({
+          ...item,
+          date: date.format(),
+        }))
     )
   )
 }
@@ -266,68 +275,46 @@ const filterCreator: FilterCreator = ({ client, config, elementsSource, elements
     const employeeNames = await fetchEmployeeNames(client)
     const { timeZone } = await getZoneAndFormat(elements, elementsSource, isPartial)
     const systemNotes = !_.isEmpty(employeeNames)
-      ? await fetchSystemNotes(client, queryIds, lastFetchTime, timeZone)
+      ? await fetchSystemNotes(client, queryIds, lastFetchTime, employeeNames, timeZone)
       : {}
     const { elemIdToChangeByIndex, elemIdToChangeAtIndex } = await elementsSourceIndex.getIndexes()
-    if (_.isEmpty(systemNotes) && _.isEmpty(elemIdToChangeByIndex)
-    && _.isEmpty(elemIdToChangeAtIndex)) {
+    if (_.isEmpty(systemNotes) && _.isEmpty(elemIdToChangeByIndex) && _.isEmpty(elemIdToChangeAtIndex)) {
       return
     }
 
-    const setChangedBy = (element: Element, employeeId: string): void => {
-      if (isDefined(employeeId) && isDefined(employeeNames[employeeId])) {
-        element.annotate(
-          { [CORE_ANNOTATIONS.CHANGED_BY]: employeeNames[employeeId] }
-        )
+    const setAuthorInformation = (
+      element: Element,
+      info: ModificationInformation | undefined
+    ): void => {
+      if (info !== undefined) {
+        element.annotate({ [CORE_ANNOTATIONS.CHANGED_BY]: info.lastModifiedBy })
+        element.annotate({ [CORE_ANNOTATIONS.CHANGED_AT]: info.lastModifiedAt })
       } else {
-        const changedBy = elemIdToChangeByIndex[element.elemID.getFullName()]
-        if (isDefined(changedBy)) {
-          element.annotate(
-            { [CORE_ANNOTATIONS.CHANGED_BY]: changedBy }
-          )
-        }
+        element.annotate({ [CORE_ANNOTATIONS.CHANGED_BY]: elemIdToChangeByIndex[element.elemID.getFullName()] })
+        element.annotate({ [CORE_ANNOTATIONS.CHANGED_AT]: elemIdToChangeAtIndex[element.elemID.getFullName()] })
       }
     }
 
-    const setChangedAt = async (element: Element, lastModifiedDate: string): Promise<void> => {
-      if (isDefined(lastModifiedDate)) {
-        const formatedDate = changeDateFormat(
-          lastModifiedDate, { dateFormat: SUITEQL_DATE_FORMAT, timeZone, timeFormat: SUITEQL_TIME_FORMAT }
-        )
-        element.annotate({ [CORE_ANNOTATIONS.CHANGED_AT]: formatedDate })
-      } else {
-        const changedAt = elemIdToChangeAtIndex[element.elemID.getFullName()]
-        if (isDefined(changedAt)) {
-          element.annotate(
-            { [CORE_ANNOTATIONS.CHANGED_AT]: changedAt }
-          )
-        }
-      }
-    }
-
-    instancesWithInternalId.forEach(async instance => {
-      const { name: employeeId, date: lastModifiedDate } = systemNotes[getRecordIdAndTypeStringKey(
+    instancesWithInternalId.forEach(instance => {
+      const info = systemNotes[getRecordIdAndTypeStringKey(
         instance.value.internalId,
         TYPES_TO_INTERNAL_ID[instance.elemID.typeName.toLowerCase()]
-      )] ?? {}
-      setChangedBy(instance, employeeId)
-      await setChangedAt(instance, lastModifiedDate)
+      )]
+      setAuthorInformation(instance, info)
     })
-    customRecordTypesWithInternalIds.forEach(async type => {
-      const { name: employeeId, date: lastModifiedDate } = systemNotes[getRecordIdAndTypeStringKey(
+    customRecordTypesWithInternalIds.forEach(type => {
+      const info = systemNotes[getRecordIdAndTypeStringKey(
         type.annotations.internalId,
         TYPES_TO_INTERNAL_ID[CUSTOM_RECORD_TYPE]
-      )] ?? {}
-      setChangedBy(type, employeeId)
-      await setChangedAt(type, lastModifiedDate)
+      )]
+      setAuthorInformation(type, info)
     })
     await awu(customRecordsWithInternalIds).forEach(async instance => {
-      const { name: employeeId, date: lastModifiedDate } = systemNotes[getRecordIdAndTypeStringKey(
+      const info = systemNotes[getRecordIdAndTypeStringKey(
         getInternalId(instance),
         getInternalId(await instance.getType())
-      )] ?? {}
-      setChangedBy(instance, employeeId)
-      await setChangedAt(instance, lastModifiedDate)
+      )]
+      setAuthorInformation(instance, info)
     })
   },
 })

--- a/packages/netsuite-adapter/src/filters/author_information/system_note.ts
+++ b/packages/netsuite-adapter/src/filters/author_information/system_note.ts
@@ -203,9 +203,20 @@ const fetchSystemNotes = async (
         .map(({ date, name, ...item }) => ({
           ...item,
           name: employeeNames[name],
+          dateString: date,
           date: toMomentDate(date, { format: moment.ISO_8601, timeZone }),
         }))
-        .filter(({ date, name }) => !now.isBefore(date) && name !== undefined)
+        .filter(({ date, dateString, name }) => {
+          if (!date.isValid()) {
+            log.warn('dropping invalid date: %s', dateString)
+            return false
+          }
+          if (now.isBefore(date)) {
+            log.warn('dropping future date: %s > %s (now)', date.format(), now.format())
+            return false
+          }
+          return name !== undefined
+        })
         .map(({ date, ...item }) => ({
           ...item,
           date: date.format(),

--- a/packages/netsuite-adapter/test/filters/author_information/saved_searches.test.ts
+++ b/packages/netsuite-adapter/test/filters/author_information/saved_searches.test.ts
@@ -158,7 +158,7 @@ describe('netsuite saved searches author information tests', () => {
   it('elements will stay the same if they were not found by the search', async () => {
     runSavedSearchQueryMock.mockReset()
     await filterCreator(filterOpts).onFetch?.(elements)
-    expect(Object.values(savedSearch.annotations)).toHaveLength(0)
+    expect(savedSearch.annotations).toEqual({})
   })
   it('elements will stay the same if a modified by was empty in search', async () => {
     runSavedSearchQueryMock.mockReset()
@@ -166,7 +166,7 @@ describe('netsuite saved searches author information tests', () => {
       { id: '1', modifiedby: [] },
     ])
     await filterCreator(filterOpts).onFetch?.(elements)
-    expect(Object.values(savedSearch.annotations)).toHaveLength(0)
+    expect(savedSearch.annotations).toEqual({})
   })
   describe('failure', () => {
     it('undefined saved search result', async () => {

--- a/packages/netsuite-adapter/test/filters/author_information/system_note.test.ts
+++ b/packages/netsuite-adapter/test/filters/author_information/system_note.test.ts
@@ -51,19 +51,19 @@ describe('netsuite system note author information', () => {
   beforeEach(async () => {
     runSuiteQLMock.mockReset()
     runSuiteQLMock.mockResolvedValueOnce([
-      { id: '1', entityid: 'user 1 name', date: '2022-01-01' },
-      { id: '2', entityid: 'user 2 name', date: '2022-01-01' },
-      { id: '3', entityid: 'user 3 name', date: '2022-01-01' },
+      { id: '1', entityid: 'user 1 name', date: '2022-01-01 00:00:00' },
+      { id: '2', entityid: 'user 2 name', date: '2022-01-01 00:00:00' },
+      { id: '3', entityid: 'user 3 name', date: '2022-01-01 00:00:00' },
     ])
     runSuiteQLMock.mockResolvedValueOnce([
-      { recordid: '1', recordtypeid: '-112', field: '', name: '1', date: '2022-01-01' },
+      { recordid: '1', recordtypeid: '-112', field: '', name: '1', date: '2022-01-01 00:00:00' },
       // Should ignore this record because it has a date in the future
-      { recordid: '1', recordtypeid: '-112', field: '', name: '1', date: '3022-03-01' },
-      { recordid: '1', recordtypeid: '-123', field: '', name: '2', date: '2022-01-01' },
-      { recordid: '2', recordtypeid: '-112', field: '', name: '3', date: '2022-01-01' },
-      { recordid: '123', recordtypeid: '1', field: '', name: '3', date: '2022-01-01' },
-      { recordid: '2', field: FOLDER_FIELD_IDENTIFIER, name: '3', date: '2022-01-01' },
-      { recordid: '2', field: FILE_FIELD_IDENTIFIER, name: '3', date: '2022-01-01' },
+      { recordid: '1', recordtypeid: '-112', field: '', name: '1', date: '3022-03-01 00:00:00' },
+      { recordid: '1', recordtypeid: '-123', field: '', name: '2', date: '2022-01-01 00:00:00' },
+      { recordid: '2', recordtypeid: '-112', field: '', name: '3', date: '2022-01-01 00:00:00' },
+      { recordid: '123', recordtypeid: '1', field: '', name: '3', date: '2022-01-01 00:00:00' },
+      { recordid: '2', field: FOLDER_FIELD_IDENTIFIER, name: '3', date: '2022-01-01 00:00:00' },
+      { recordid: '2', field: FILE_FIELD_IDENTIFIER, name: '3', date: '2022-01-01 00:00:00' },
     ])
     accountInstance = new InstanceElement('account', new ObjectType({ elemID: new ElemID(NETSUITE, 'account') }))
     accountInstance.value.internalId = '1'
@@ -136,7 +136,7 @@ describe('netsuite system note author information', () => {
     expect(accountInstance.annotations[CORE_ANNOTATIONS.CHANGED_BY] === 'user 1 name').toBeTruthy()
     expect(customRecordType.annotations[CORE_ANNOTATIONS.CHANGED_BY] === 'user 2 name').toBeTruthy()
     expect(customRecord.annotations[CORE_ANNOTATIONS.CHANGED_BY] === 'user 3 name').toBeTruthy()
-    expect(Object.values(missingInstance.annotations)).toHaveLength(0)
+    expect(missingInstance.annotations).toEqual({})
     expect(fileInstance.annotations[CORE_ANNOTATIONS.CHANGED_BY] === 'user 3 name').toBeTruthy()
     expect(folderInstance.annotations[CORE_ANNOTATIONS.CHANGED_BY] === 'user 3 name').toBeTruthy()
   })
@@ -145,7 +145,7 @@ describe('netsuite system note author information', () => {
     await filterCreator(filterOpts).onFetch?.(elements)
     expect(accountInstance.annotations[CORE_ANNOTATIONS.CHANGED_AT]).toEqual('2022-01-01T00:00:00Z')
     expect(customRecordType.annotations[CORE_ANNOTATIONS.CHANGED_AT] === '2022-01-01T00:00:00Z').toBeTruthy()
-    expect(Object.values(missingInstance.annotations)).toHaveLength(0)
+    expect(missingInstance.annotations).toEqual({})
     expect(fileInstance.annotations[CORE_ANNOTATIONS.CHANGED_AT] === '2022-01-01T00:00:00Z').toBeTruthy()
     expect(folderInstance.annotations[CORE_ANNOTATIONS.CHANGED_AT] === '2022-01-01T00:00:00Z').toBeTruthy()
   })


### PR DESCRIPTION
Refactor & use the account's date&time format to check if a date is a future date.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Fix date format for future dates validation in saved searches

---
_User Notifications_: 
None