### PR TITLE
SALTO-3888: Resolve organizationIDs for views in Zendesk

### DIFF
--- a/packages/zendesk-adapter/src/filters/organizations.ts
+++ b/packages/zendesk-adapter/src/filters/organizations.ts
@@ -86,6 +86,10 @@ export const TYPE_NAME_TO_REPLACER: Record<string, ValueReplacer> = {
     { fieldName: ['relationship_filter', 'all'], fieldsToReplace: DEFAULT_ORGANIZATION_FIELDS },
     { fieldName: ['relationship_filter', 'any'], fieldsToReplace: DEFAULT_ORGANIZATION_FIELDS },
   ]),
+  view: replaceConditionsAndActionsCreator([
+    { fieldName: ['conditions', 'all'], fieldsToReplace: DEFAULT_ORGANIZATION_FIELDS },
+    { fieldName: ['conditions', 'any'], fieldsToReplace: DEFAULT_ORGANIZATION_FIELDS },
+  ]),
   user_segment: fieldReplacer(['organization_ids']),
 }
 


### PR DESCRIPTION
Resolve organizationIDs for views in Zendesk

---
_Release Notes_: 

_Zendesk_:

- Fix a bug causing unresolved organization IDs in views when `resolveOrganizationIDs` is enabled

---
_User Notifications_: 

_Zendesk_:

- If `resolveOrganizationIDs` flag is enabled, organization IDs in views will be replaced with organization names