### PR TITLE
SALTO-3872: fix default alias for instances with config name

### DIFF
--- a/packages/adapter-api/src/element_id.ts
+++ b/packages/adapter-api/src/element_id.ts
@@ -187,8 +187,12 @@ export class ElemID {
       .filter((part, idx) => idx !== nameParts.length - 1 || part !== ElemID.CONFIG_NAME)
   }
 
-  isConfig(): boolean {
+  isConfigType(): boolean {
     return this.typeName === ElemID.CONFIG_NAME
+  }
+
+  isConfigInstance(): boolean {
+    return this.name === ElemID.CONFIG_NAME && this.idType === 'instance'
   }
 
   isTopLevel(): boolean {

--- a/packages/adapter-api/test/elements.test.ts
+++ b/packages/adapter-api/test/elements.test.ts
@@ -288,6 +288,8 @@ describe('Test elements.ts', () => {
     const typeAttrId = typeId.createNestedID('attr', 'anno')
     const configTypeId = new ElemID('adapter')
     const configInstId = configTypeId.createNestedID('instance', ElemID.CONFIG_NAME)
+    const configInstIdNormalType = typeId.createNestedID('instance', ElemID.CONFIG_NAME)
+    const instId = typeId.createNestedID('instance', 'someName')
     const variableId = new ElemID(ElemID.VARIABLES_NAMESPACE, 'varName')
     const listId = new ListType(new TypeReference(typeId)).elemID
     const mapId = new MapType(new TypeReference(typeId)).elemID
@@ -506,17 +508,29 @@ describe('Test elements.ts', () => {
       })
     })
 
-    describe('isConfig', () => {
+    describe('isConfigType', () => {
       it('should return true for config type ID', () => {
-        expect(configTypeId.isConfig()).toBeTruthy()
+        expect(configTypeId.isConfigType()).toBeTruthy()
       })
 
       it('should return true for config instance ID', () => {
-        expect(configInstId.isConfig()).toBeTruthy()
+        expect(configInstId.isConfigType()).toBeTruthy()
       })
 
       it('should return false for other IDs', () => {
-        expect(typeId.isConfig()).toBeFalsy()
+        expect(typeId.isConfigType()).toBeFalsy()
+      })
+    })
+
+    describe('isConfigInstance', () => {
+      it('should return true for config instance ID', () => {
+        expect(configInstId.isConfigInstance()).toBeTruthy()
+      })
+      it('should return true for config instance ID when type is not config', () => {
+        expect(configInstIdNormalType.isConfigInstance()).toBeTruthy()
+      })
+      it('should return false for other IDs', () => {
+        expect(instId.isConfigInstance()).toBeFalsy()
       })
     })
 

--- a/packages/adapter-components/src/references/context.ts
+++ b/packages/adapter-components/src/references/context.ts
@@ -87,7 +87,7 @@ export const neighborContextGetter = ({
 
   try {
     const parent = findParentPath(fieldPath, levelsUp)
-    if (parent.isConfig()) {
+    if (parent.isConfigType()) {
       // went up too many levels, the current rule is irrelevant for this potential reference
       return undefined
     }

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -661,7 +661,7 @@ const createFetchChanges = async ({
   }
   const isFirstFetch = await awu(await workspaceElements.list())
     .concat(await stateElements.list())
-    .filter(e => !e.isConfig())
+    .filter(e => !e.isConfigType())
     .isEmpty()
   const changes = isFirstFetch
     ? unmergedElements.map(toAddFetchChange)

--- a/packages/lang-server/src/usage.ts
+++ b/packages/lang-server/src/usage.ts
@@ -61,7 +61,7 @@ const getElemIDUsages = async (
 const isTokenElemID = (token: string): boolean => {
   try {
     const refID = ElemID.fromFullName(token)
-    return !refID.isConfig() || !refID.isTopLevel()
+    return !refID.isConfigType() || !refID.isTopLevel()
   } catch (e) {
     return false
   }

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -352,7 +352,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
    */
 
   public async fetch({ progressReporter, withChangesDetection = false }: FetchOptions): Promise<FetchResult> {
-    const isFirstFetch = !(await awu(await this.elementsSource.list()).find(e => !e.isConfig()))
+    const isFirstFetch = !(await awu(await this.elementsSource.list()).find(e => !e.isConfigType()))
     const hasFetchTarget = this.fetchTarget !== undefined
     if (hasFetchTarget && isFirstFetch) {
       throw new Error('Can\'t define fetchTarget for the first fetch. Remove fetchTarget from adapter config file')

--- a/packages/workspace/src/parser/dump.ts
+++ b/packages/workspace/src/parser/dump.ts
@@ -47,7 +47,7 @@ const getPrimitiveTypeName = (primitiveType: PrimitiveTypes): string => {
 }
 
 export const dumpElemID = (id: ElemID): string => {
-  if (id.isConfig()) {
+  if (id.isConfigType()) {
     return id.adapter
   }
   if (id.idType === 'instance') {
@@ -154,7 +154,7 @@ const dumpElementBlock = (
   if (isInstanceElement(elem)) {
     return {
       type: dumpElemID(elem.refType.elemID),
-      labels: elem.elemID.isConfig() || elem.refType.elemID.isConfig()
+      labels: elem.elemID.isConfigType() || elem.refType.elemID.isConfigType()
       || elem.elemID.name === '_config' // TODO: should inject the correct type
         ? []
         : [elem.elemID.name],

--- a/packages/workspace/src/workspace/alias_index.ts
+++ b/packages/workspace/src/workspace/alias_index.ts
@@ -37,8 +37,8 @@ export const ALIAS_INDEX_VERSION = 2
 const ALIAS_INDEX_KEY = 'alias_index'
 
 
-const calcAlias = (elem: Element): string => elem.annotations[CORE_ANNOTATIONS.ALIAS]
-  ?? prettifyName(elem.elemID?.isConfigInstance() ? elem.elemID.typeName : elem.elemID.name)
+const getAlias = (element: Element): string => element.annotations[CORE_ANNOTATIONS.ALIAS]
+  ?? prettifyName(element.elemID.isConfigInstance() ? element.elemID.typeName : element.elemID.name)
 
 const getChangedFields = (change: ModificationChange<ObjectType>): Change<Element>[] => {
   const afterFields = Object.values(change.data.after.fields)
@@ -50,7 +50,7 @@ const getChangedFields = (change: ModificationChange<ObjectType>): Change<Elemen
   const removedFields = beforeFields.filter(beforeField => !afterFieldsNamesSet.has(beforeField.name))
   const aliasModifiedFields = afterFields.filter(afterField => {
     const field = change.data.before.fields[afterField.name]
-    return isField(field) && (calcAlias(afterField) !== calcAlias(field))
+    return isField(field) && (getAlias(afterField) !== getAlias(field))
   })
   return (addedFields.map(field => toChange({ after: field })))
     .concat(aliasModifiedFields.map(field => toChange({ after: field })))
@@ -62,13 +62,13 @@ const getAllRelevantChanges = (changes: Change<Element>[]): Change<Element>[] =>
     if (isModificationChange(change)) {
       if (isObjectTypeChange(change)) {
         const changedFields = getChangedFields(change)
-        const objAliasModification = calcAlias(change.data.before) !== calcAlias(change.data.after)
+        const objAliasModification = getAlias(change.data.before) !== getAlias(change.data.after)
           ? [toChange({ after: change.data.after })]
           : []
         return changedFields.concat(objAliasModification)
       }
       if (isInstanceChange(change)) {
-        if (calcAlias(change.data.before) !== calcAlias(change.data.after)) {
+        if (getAlias(change.data.before) !== getAlias(change.data.after)) {
           return toChange({ after: change.data.after })
         }
       }
@@ -98,7 +98,7 @@ const getInfoForIndex = (changes: Change<Element>[]):
   const { additions, removals } = getRemovalsAndAdditions(changes)
   const additionsIdsToAlias = _.mapValues(
     _.keyBy(additions.map(getChangeData), elem => elem.elemID.getFullName()),
-    elem => calcAlias(elem)
+    elem => getAlias(elem)
   )
   const removalNames = removals.flatMap(getRelevantNamesFromChange)
   return { removalNames, additionsIdsToAlias }

--- a/packages/workspace/src/workspace/alias_index.ts
+++ b/packages/workspace/src/workspace/alias_index.ts
@@ -21,7 +21,7 @@ import {
   CORE_ANNOTATIONS,
   isAdditionChange,
   isModificationChange,
-  ObjectType, isObjectTypeChange, ModificationChange, isField, isInstanceChange, ElemID,
+  ObjectType, isObjectTypeChange, ModificationChange, isField, isInstanceChange,
 } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
@@ -36,11 +36,9 @@ const log = logger(module)
 export const ALIAS_INDEX_VERSION = 2
 const ALIAS_INDEX_KEY = 'alias_index'
 
-const isSetting = (elemId: ElemID | undefined): boolean =>
-  elemId?.name === ElemID.CONFIG_NAME
 
 const calcAlias = (elem: Element): string => elem.annotations[CORE_ANNOTATIONS.ALIAS]
-  ?? prettifyName(isSetting(elem.elemID) ? elem.elemID.typeName : elem.elemID.name)
+  ?? prettifyName(elem.elemID?.isConfigInstance() ? elem.elemID.typeName : elem.elemID.name)
 
 const getChangedFields = (change: ModificationChange<ObjectType>): Change<Element>[] => {
   const afterFields = Object.values(change.data.after.fields)

--- a/packages/workspace/src/workspace/alias_index.ts
+++ b/packages/workspace/src/workspace/alias_index.ts
@@ -21,7 +21,7 @@ import {
   CORE_ANNOTATIONS,
   isAdditionChange,
   isModificationChange,
-  ObjectType, isObjectTypeChange, ModificationChange, isField, isInstanceChange,
+  ObjectType, isObjectTypeChange, ModificationChange, isField, isInstanceChange, ElemID,
 } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
@@ -33,10 +33,14 @@ import { RemoteMap } from './remote_map'
 
 const { isDefined } = lowerdashValues
 const log = logger(module)
-export const ALIAS_INDEX_VERSION = 1
+export const ALIAS_INDEX_VERSION = 2
 const ALIAS_INDEX_KEY = 'alias_index'
 
-const calcAlias = (elem: Element): string => elem.annotations[CORE_ANNOTATIONS.ALIAS] ?? prettifyName(elem.elemID.name)
+const isSetting = (elemId: ElemID | undefined): boolean =>
+  elemId?.name === ElemID.CONFIG_NAME
+
+const calcAlias = (elem: Element): string => elem.annotations[CORE_ANNOTATIONS.ALIAS]
+  ?? prettifyName(isSetting(elem.elemID) ? elem.elemID.typeName : elem.elemID.name)
 
 const getChangedFields = (change: ModificationChange<ObjectType>): Change<Element>[] => {
   const afterFields = Object.values(change.data.after.fields)

--- a/packages/workspace/test/workspace/alias_index.test.ts
+++ b/packages/workspace/test/workspace/alias_index.test.ts
@@ -98,6 +98,11 @@ describe('alias index', () => {
       },
     },
   })
+  const settingInstanceWithAlias = new InstanceElement(
+    ElemID.CONFIG_NAME,
+    objectWithAnnotation,
+    {},
+  )
   const firstInstanceWithAlias = new InstanceElement(
     'instance1',
     objectWithAnnotation,
@@ -159,6 +164,7 @@ describe('alias index', () => {
     beforeEach(async () => {
       const changes = [
         toChange({ after: firstInstanceWithAlias }),
+        toChange({ after: settingInstanceWithAlias }),
         toChange({ after: secondInstanceNoAlias }),
         toChange({ before: thirdInstance, after: thirdInstance }),
         toChange({ after: objectWithAnnotation }),
@@ -178,6 +184,9 @@ describe('alias index', () => {
     it('should add all addition and alias modification elements to index', () => {
       expect(aliasIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining(
         [{ key: firstInstanceWithAlias.elemID.getFullName(), value: 'instance alias' }]
+      ))
+      expect(aliasIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining(
+        [{ key: settingInstanceWithAlias.elemID.getFullName(), value: 'Object' }]
       ))
       expect(aliasIndex.setAll).toHaveBeenCalledWith(expect.arrayContaining(
         [{ key: secondInstanceNoAlias.elemID.getFullName(), value: 'Instance2' }]


### PR DESCRIPTION
fix default alias for instances with config name

---

_Additional context for reviewer_
currently when no alias is provided we calculate the alias from the prettified name. however for setting instances for which their name is `_config` the default alias received is `config` and we don’t want that. So I am changing the default to be the type.

---
_Release Notes_: 
None

---
_User Notifications_: 
None
