### PR TITLE
SALTO-3893 - Convert url fields with reference expressions

### DIFF
--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -132,6 +132,7 @@ import hideAccountFeatures from './filters/hide_account_features'
 import auditTimeFilter from './filters/audit_logs'
 import { isCurrentUserResponse } from './user_utils'
 import addAliasFilter from './filters/add_alias'
+import urlReferenceExpressionFilter from './filters/url_reference_expression'
 
 const { makeArray } = collections.array
 const log = logger(module)
@@ -159,6 +160,7 @@ export const DEFAULT_FILTERS = [
   // omitInactiveFilter should be before:
   //  order filters, collisionErrorsFilter and fieldReferencesFilter
   omitInactiveFilter,
+  urlReferenceExpressionFilter,
   ticketFormOrderFilter,
   userFieldOrderFilter,
   organizationFieldOrderFilter,

--- a/packages/zendesk-adapter/src/filters/url_reference_expression.ts
+++ b/packages/zendesk-adapter/src/filters/url_reference_expression.ts
@@ -1,0 +1,72 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { isInstanceElement, ReferenceExpression, TemplateExpression } from '@salto-io/adapter-api'
+import { FilterCreator } from '../filter'
+import { BRAND_TYPE_NAME, ZENDESK } from '../constants'
+import { FETCH_CONFIG, ZendeskConfig } from '../config'
+import { createMissingInstance } from './references/missing_references'
+
+const urlRegex = /(?<brandUrl>.+.com)(?<path>.+\/)(?<id>\d+)(?<suffix>.+)/
+
+const createMissingBrand = (
+  { brandUrl, config }: { brandUrl: string; config: ZendeskConfig }
+): ReferenceExpression | string => {
+  if (config[FETCH_CONFIG].enableMissingReferences) {
+    const missingBrand = createMissingInstance(ZENDESK, BRAND_TYPE_NAME, brandUrl)
+    return new ReferenceExpression(missingBrand.elemID, missingBrand)
+  }
+  return brandUrl
+}
+
+/**
+ * Updates element's url to reference expressions of the brand and the instance
+ */
+const filterCreator: FilterCreator = ({ config }) => ({
+  name: 'urlReferenceExpression',
+  onFetch: async elements => {
+    const instances = elements.filter(isInstanceElement)
+    const brands = instances.filter(instance => instance.elemID.typeName === BRAND_TYPE_NAME)
+
+    instances.forEach(instance => {
+      const { url } = instance.value
+      // url is usually omitted, if it's not - we need to try and update it
+      if (!url) {
+        return
+      }
+      const { brandUrl, path, id, suffix } = url.match(urlRegex)?.groups ?? {}
+      // Don't do anything if the url doesn't match the expected format
+      if (!brandUrl || !path || !id) {
+        return
+      }
+      const brandInstance = brands.find(brand => brand.value.brand_url === brandUrl)
+
+      // Replace the brand and the instance id with reference expressions
+      instance.value.url = new TemplateExpression({
+        parts: [
+          brandInstance
+            ? new ReferenceExpression(brandInstance.elemID, brandInstance)
+            : createMissingBrand({ brandUrl, config }),
+          path,
+          new ReferenceExpression(instance.elemID, instance),
+          suffix,
+        ],
+      })
+    })
+  },
+})
+
+export default filterCreator

--- a/packages/zendesk-adapter/test/filters/url_reference_expression.test.ts
+++ b/packages/zendesk-adapter/test/filters/url_reference_expression.test.ts
@@ -1,0 +1,94 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import urlReferenceExpressionFilter from '../../src/filters/url_reference_expression'
+import { BRAND_TYPE_NAME, TARGET_TYPE_NAME, ZENDESK } from '../../src/constants'
+import { createFilterCreatorParams } from '../utils'
+import { DEFAULT_CONFIG, FETCH_CONFIG } from '../../src/config'
+import { createMissingInstance } from '../../src/filters/references/missing_references'
+
+const brandType = new ObjectType({ elemID: new ElemID(ZENDESK, BRAND_TYPE_NAME) })
+const targetType = new ObjectType({ elemID: new ElemID(ZENDESK, TARGET_TYPE_NAME) })
+
+describe('urlReferenceExpression', () => {
+  const brand = new InstanceElement('brand', brandType, { brand_url: 'https://testBrand.zendesk.com' })
+  const filter = urlReferenceExpressionFilter(createFilterCreatorParams({})) as filterUtils.FilterWith<'onFetch'>
+
+  it('should convert the url to the correct template expression', async () => {
+    const target = new InstanceElement('target', targetType,
+      {
+        url: 'https://testBrand.zendesk.com/api/v2/targets/123.json',
+      })
+
+    const elements = [brand, target]
+    await filter.onFetch(elements)
+
+    expect(target.value.url).toMatchObject({ parts: [
+      new ReferenceExpression(brand.elemID, brand),
+      '/api/v2/targets/',
+      new ReferenceExpression(target.elemID, target),
+      '.json',
+    ] })
+  })
+  it('should do nothing if url doesn\'t match the expected format', async () => {
+    const target = new InstanceElement('target', targetType,
+      {
+        url: 'badFormatUrl',
+      })
+
+    const elements = [brand, target]
+    await filter.onFetch(elements)
+
+    expect(target.value.url).toBe('badFormatUrl')
+  })
+  it('should create a missing reference if the brand is not found', async () => {
+    const target = new InstanceElement('target', targetType,
+      {
+        url: 'https://badBrand.zendesk.com/api/v2/targets/123.json',
+      })
+
+    const elements = [brand, target]
+    await filter.onFetch(elements)
+
+    const missingBrand = createMissingInstance(ZENDESK, BRAND_TYPE_NAME, 'https://badBrand.zendesk.com')
+    expect(target.value.url).toMatchObject({ parts: [
+      new ReferenceExpression(missingBrand.elemID, missingBrand),
+      '/api/v2/targets/',
+      new ReferenceExpression(target.elemID, target),
+      '.json',
+    ] })
+  })
+  it('should not create a missing reference if the brand is not found and enableMissingReferences is disabled', async () => {
+    const config = { ...DEFAULT_CONFIG }
+    config[FETCH_CONFIG].enableMissingReferences = false
+    const filterWithoutMissingReference = urlReferenceExpressionFilter(createFilterCreatorParams({ config })) as filterUtils.FilterWith<'onFetch'>
+    const target = new InstanceElement('target', targetType,
+      {
+        url: 'https://badBrand.zendesk.com/api/v2/targets/123.json',
+      })
+
+    const elements = [brand, target]
+    await filterWithoutMissingReference.onFetch(elements)
+
+    expect(target.value.url).toMatchObject({ parts: [
+      'https://badBrand.zendesk.com',
+      '/api/v2/targets/',
+      new ReferenceExpression(target.elemID, target),
+      '.json',
+    ] })
+  })
+})


### PR DESCRIPTION
If url is not omitted, replace the brand and the instance Id with reference expressions to support clone

---

None

---
_Release Notes_: 
None

---
_User Notifications_: 
Zendesk Adapter:
* Url fields that are not omitted will include reference expressions instead of strings only