### PR TITLE
SAAS-7338: ScriptRunner UI re-revert typo

### DIFF
--- a/packages/jira-adapter/src/config_creator.ts
+++ b/packages/jira-adapter/src/config_creator.ts
@@ -25,12 +25,12 @@ const log = logger(module)
 const optionsElemId = new ElemID(constants.JIRA, 'configOptionsType')
 
 type ConfigOptionsType = {
-  enableScripRunnerAddon?: boolean
+  enableScriptRunnerAddon?: boolean
 }
 export const optionsType = createMatchingObjectType<ConfigOptionsType>({
   elemID: optionsElemId,
   fields: {
-    enableScripRunnerAddon: { refType: BuiltinTypes.BOOLEAN },
+    enableScriptRunnerAddon: { refType: BuiltinTypes.BOOLEAN },
   },
 })
 const isOptionsTypeInstance = (instance: InstanceElement):
@@ -46,8 +46,8 @@ export const getConfig = async (
   options?: InstanceElement
 ): Promise<InstanceElement> => {
   const defaultConf = await createDefaultInstanceFromType(ElemID.CONFIG_NAME, configType)
-  if (options !== undefined && isOptionsTypeInstance(options) && options.value.enableScripRunnerAddon) {
-    defaultConf.value.fetch.enableScripRunnerAddon = true
+  if (options !== undefined && isOptionsTypeInstance(options) && options.value.enableScriptRunnerAddon) {
+    defaultConf.value.fetch.enableScriptRunnerAddon = true
   }
   return defaultConf
 }

--- a/packages/jira-adapter/test/config_creator.test.ts
+++ b/packages/jira-adapter/test/config_creator.test.ts
@@ -25,7 +25,7 @@ describe('config creator', () => {
     options = new InstanceElement(
       'instance',
       optionsType,
-      { enableScripRunnerAddon: true }
+      { enableScriptRunnerAddon: true }
     )
   })
   it('should return config creator', async () => {
@@ -40,7 +40,7 @@ describe('config creator', () => {
     expect(config).toEqual(await createDefaultInstanceFromType(ElemID.CONFIG_NAME, configType))
   })
   it('get config should return default config when false', async () => {
-    options.value.enableScripRunnerAddon = false
+    options.value.enableScriptRunnerAddon = false
     const config = await getConfig(options)
     expect(config).toEqual(await createDefaultInstanceFromType(ElemID.CONFIG_NAME, configType))
   })
@@ -48,13 +48,13 @@ describe('config creator', () => {
     options = new InstanceElement(
       'instance',
       createEmptyType('empty'),
-      { enableScripRunnerAddon: true }
+      { enableScriptRunnerAddon: true }
     )
     const config = await getConfig(options)
     expect(config).toEqual(await createDefaultInstanceFromType(ElemID.CONFIG_NAME, configType))
   })
   it('get config should return return correctly when true', async () => {
     const config = await getConfig(options)
-    expect(config.value.fetch.enableScripRunnerAddon).toBeTrue()
+    expect(config.value.fetch.enableScriptRunnerAddon).toBeTrue()
   })
 })


### PR DESCRIPTION
This reverts commit 9a4bafc6cd7d57ca904e28bd1036bc1650c77ca4.

Returning the fix

---
_Release Notes_: 
None
---
_User Notifications_: 
None
