### PR TITLE
SALTO-3384 - Salesforce: Missing reference from AnimationRule.recordTypeName

### DIFF
--- a/packages/salesforce-adapter/src/filters/field_references.ts
+++ b/packages/salesforce-adapter/src/filters/field_references.ts
@@ -88,6 +88,7 @@ const contextStrategyLookup: Record<
   neighborCPQRuleLookup: neighborContextFunc({ contextFieldName: CPQ_RULE_LOOKUP_OBJECT_FIELD }),
   neighborLookupValueTypeLookup: neighborContextFunc({ contextFieldName: 'lookupValueType' }),
   neighborObjectLookup: neighborContextFunc({ contextFieldName: 'object' }),
+  neighborSobjectLookup: neighborContextFunc({ contextFieldName: 'sobjectType' }),
   parentObjectLookup: neighborContextFunc({ contextFieldName: 'object', levelsUp: 1 }),
   parentInputObjectLookup: neighborContextFunc({ contextFieldName: 'inputObject', levelsUp: 1 }),
   parentOutputObjectLookup: neighborContextFunc({ contextFieldName: 'outputObject', levelsUp: 1 }),

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -656,6 +656,10 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     src: { field: 'recordTypeName', parentTypes: ['AnimationRule'] },
     target: { typeContext: 'neighborSobjectLookup' },
   },
+  {
+    src: { field: 'sobjectType', parentTypes: ['AnimationRule'] },
+    target: { type: CUSTOM_OBJECT },
+  },
 ]
 
 // Optional reference that should not be used if enumFieldPermissions config is on

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -658,6 +658,11 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     target: { parentContext: 'neighborSobjectLookup', type: 'RecordType' },
   },
   {
+    src: { field: 'targetField', parentTypes: ['AnimationRule'] },
+    serializationStrategy: 'relativeApiName',
+    target: { parentContext: 'neighborSobjectLookup', type: CUSTOM_FIELD },
+  },
+  {
     src: { field: 'sobjectType', parentTypes: ['AnimationRule'] },
     target: { type: CUSTOM_OBJECT },
   },

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -119,7 +119,7 @@ const ReferenceSerializationStrategyLookup: Record<
 
 export type ReferenceContextStrategyName = (
   'instanceParent' | 'neighborTypeWorkflow' | 'neighborCPQLookup' | 'neighborCPQRuleLookup'
-  | 'neighborLookupValueTypeLookup' | 'neighborObjectLookup' | 'neighborPicklistObjectLookup'
+  | 'neighborLookupValueTypeLookup' | 'neighborObjectLookup' | 'neighborSobjectLookup' | 'neighborPicklistObjectLookup'
   | 'neighborTypeLookup' | 'neighborActionTypeFlowLookup' | 'neighborActionTypeLookup' | 'parentObjectLookup'
   | 'parentInputObjectLookup' | 'parentOutputObjectLookup' | 'neighborSharedToTypeLookup' | 'neighborTableLookup'
   | 'neighborCaseOwnerTypeLookup' | 'neighborAssignedToTypeLookup' | 'neighborRelatedEntityTypeLookup'
@@ -651,6 +651,10 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
   {
     src: { field: 'links', parentTypes: ['HomePageComponent'] },
     target: { type: 'CustomPageWebLink' },
+  },
+  {
+    src: { field: 'recordTypeName', parentTypes: ['AnimationRule'] },
+    target: { typeContext: 'neighborSobjectLookup' },
   },
 ]
 

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -654,7 +654,8 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
   },
   {
     src: { field: 'recordTypeName', parentTypes: ['AnimationRule'] },
-    target: { typeContext: 'neighborSobjectLookup' },
+    serializationStrategy: 'relativeApiName',
+    target: { parentContext: 'neighborSobjectLookup', type: 'RecordType' },
   },
   {
     src: { field: 'sobjectType', parentTypes: ['AnimationRule'] },


### PR DESCRIPTION
Ain't no party like a reference party cuz a reference party don't
 - [x] Merge [Noise Suppression PR](https://github.com/salto-io/salto_private/pull/5533)
---

Note that the reference is to a RecordType object. I'm not 100% sure I did this the right way so please verify.

[WS Diff](https://github.com/salto-io/tomsellek-sf/pull/6)


---
_Release Notes_: 
Salesforce: AnimationRule.recordTypeName references now work as expected

---
_User Notifications_: 
N/A
