### PR TITLE
SALTO-3473: EntitlementProcess MilestoneType Reference

### DIFF
--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -634,6 +634,10 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     serializationStrategy: 'customLabel',
     target: { type: CUSTOM_LABEL_METADATA_TYPE },
   },
+  {
+    src: { field: 'milestoneName', parentTypes: ['EntitlementProcessMilestoneItem'] },
+    target: { type: 'MilestoneType' },
+  },
 ]
 
 // Optional reference that should not be used if enumFieldPermissions config is on


### PR DESCRIPTION
Added missing references in `EntitlementProcess` instances

---

Noise Suppression:  https://github.com/salto-io/salto_private/pull/5412
Workspace Diff: https://github.com/salto-io/tamir-sf/commit/518fbf28905338dd6052bc6eb24d7c966e81e17a

---
_Release Notes_: 
Salesforce Adapter:
- Added references to `MilestoneType` on `EntitlementProcess` instances

---
_User Notifications_: 
Salesforce:
- The field `milestoneName` will be converted to Reference on each `EntitlementProcessMilestoneItem`
