### PR TITLE
SALTO-3801 add missing references to DuplicateRuleFilterItem

### DIFF
--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -638,6 +638,16 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     src: { field: 'milestoneName', parentTypes: ['EntitlementProcessMilestoneItem'] },
     target: { type: 'MilestoneType' },
   },
+  {
+    src: { field: 'field', parentTypes: ['DuplicateRuleFilterItem'] },
+    serializationStrategy: 'relativeApiName',
+    target: { parentContext: 'neighborTableLookup', type: CUSTOM_FIELD },
+  },
+  {
+    src: { field: 'table', parentTypes: ['DuplicateRuleFilterItem'] },
+    serializationStrategy: 'relativeApiName',
+    target: { type: CUSTOM_OBJECT },
+  },
 ]
 
 // Optional reference that should not be used if enumFieldPermissions config is on


### PR DESCRIPTION
Do not merge without noise reduction
---

[workspace diff](https://github.com/salto-io/adi-ws/commit/f4416ae56d93263c34830b4142fc698ae31ed0a3)

---
_Release Notes_: 
Salesforce:
* Add references to table and field in DuplicateRuleFilterItem
---
_User Notifications_:  _None_