### PR TITLE
SALTO-3573 Validate target Group for GroupRule has no administrator role

### DIFF
--- a/packages/adapter-utils/src/references.ts
+++ b/packages/adapter-utils/src/references.ts
@@ -15,7 +15,8 @@
 */
 
 import { ElemID, Element,
-  isReferenceExpression, ReferenceExpression } from '@salto-io/adapter-api'
+  isReferenceExpression, ReferenceExpression, isInstanceElement } from '@salto-io/adapter-api'
+import _ from 'lodash'
 import { TransformFunc } from './utils'
 import { walkOnElement, WalkOnFunc, WALK_NEXT_STEP } from './walk_element'
 
@@ -59,3 +60,9 @@ export const getReferences = (
   walkOnElement({ element, func })
   return references
 }
+
+export const isArrayOfRefExprToInstances = (values: unknown): values is ReferenceExpression[] => (
+  _.isArray(values)
+  && values.every(isReferenceExpression)
+  && values.every(value => isInstanceElement(value.value))
+)

--- a/packages/adapter-utils/test/references.test.ts
+++ b/packages/adapter-utils/test/references.test.ts
@@ -88,11 +88,11 @@ describe('references functions', () => {
   describe('isArrayOfRefExprToInstances', () => {
     const bookRef = new ReferenceExpression(mainBook.elemID, mainBook)
     const otherBookRef = new ReferenceExpression(mainBook.elemID, mainBook)
-    it('should return True becsue its elements are references or its an empty lilst', async () => {
+    it('should return True because elements are references or an empty list', () => {
       expect(isArrayOfRefExprToInstances([bookRef, otherBookRef])).toBe(true)
       expect(isArrayOfRefExprToInstances([])).toBe(true)
     })
-    it('should return False becsue its elements are not only references or not references at all', async () => {
+    it('should return False because its elements are not only references or not references at all', () => {
       const newElemID = new ElemID(ADAPTER_NAME, 'book', 'instance', 'very_new_book')
       expect(isArrayOfRefExprToInstances([bookRef, newElemID])).toBe(false)
       expect(isArrayOfRefExprToInstances(['hello', 3])).toBe(false)

--- a/packages/adapter-utils/test/references.test.ts
+++ b/packages/adapter-utils/test/references.test.ts
@@ -15,7 +15,7 @@
 */
 import { ElemID, BuiltinTypes, ObjectType, InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
 import { transformElement } from '../src/utils'
-import { getUpdatedReference, getReferences, createReferencesTransformFunc } from '../src/references'
+import { getUpdatedReference, getReferences, createReferencesTransformFunc, isArrayOfRefExprToInstances } from '../src/references'
 
 const ADAPTER_NAME = 'myAdapter'
 
@@ -84,5 +84,18 @@ describe('references functions', () => {
       strict: false,
     })
     expect(updatedInstance.value.book_id.elemID).toEqual(newElemID)
+  })
+  describe('isArrayOfRefExprToInstances', () => {
+    const bookRef = new ReferenceExpression(mainBook.elemID, mainBook)
+    const otherBookRef = new ReferenceExpression(mainBook.elemID, mainBook)
+    it('should return True becsue its elements are references or its an empty lilst', async () => {
+      expect(isArrayOfRefExprToInstances([bookRef, otherBookRef])).toBe(true)
+      expect(isArrayOfRefExprToInstances([])).toBe(true)
+    })
+    it('should return False becsue its elements are not only references or not references at all', async () => {
+      const newElemID = new ElemID(ADAPTER_NAME, 'book', 'instance', 'very_new_book')
+      expect(isArrayOfRefExprToInstances([bookRef, newElemID])).toBe(false)
+      expect(isArrayOfRefExprToInstances(['hello', 3])).toBe(false)
+    })
   })
 })

--- a/packages/okta-adapter/src/change_validators/group_rule_administrator.ts
+++ b/packages/okta-adapter/src/change_validators/group_rule_administrator.ts
@@ -28,8 +28,8 @@ const log = logger(module)
 const getGroupsWithRoleByRuleId = async (groupRuleInstance: InstanceElement[]):
 Promise<Record<string, InstanceElement[]>> => {
   const groupsWithRoleByRuleId = (await Promise.all(groupRuleInstance.map(async instance => {
-    const elemID = instance.elemID.createNestedID(...GROUP_ID_PATH)
-    const TagetGroupReferences = resolvePath(instance, elemID)
+    const targetGroupsPath = instance.elemID.createNestedID(...GROUP_ID_PATH)
+    const TagetGroupReferences = resolvePath(instance, targetGroupsPath)
     if (!isArrayOfRefExprToInstances(TagetGroupReferences)) {
       log.debug('Could not find group references in %s', instance.elemID.getFullName())
       return undefined
@@ -46,7 +46,7 @@ Promise<Record<string, InstanceElement[]>> => {
 }
 
 /**
- * Verifies that Group target has no administrators.
+ * Verifies that the target groups for a GroupRule has no administrator roles.
  */
 export const groupRuleAdministratorValidator: ChangeValidator = async changes => {
   const groupRuleInstances = changes

--- a/packages/okta-adapter/src/change_validators/group_rule_administrator.ts
+++ b/packages/okta-adapter/src/change_validators/group_rule_administrator.ts
@@ -1,0 +1,73 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ChangeValidator, getChangeData, isInstanceChange, isAdditionChange, isInstanceElement, InstanceElement, ChangeError, ReferenceExpression } from '@salto-io/adapter-api'
+import { resolvePath, references as referenceUtils } from '@salto-io/adapter-utils'
+import _ from 'lodash'
+import { GROUP_RULE_TYPE_NAME } from '../constants'
+
+const GROUP_ID_PATH = ['actions', 'assignUserToGroups', 'groupIds']
+const { isArrayOfRefExprToInstances } = referenceUtils
+
+const groupRefToGroupWithRoles = async (references: ReferenceExpression[]): Promise<InstanceElement[]> => (
+  await Promise.all(references.map(async reference => reference.getResolvedValue())))
+  .filter(isInstanceElement)
+  .filter(target => {
+    const roles = target.value?.roles
+    if (roles !== undefined && !(_.isEmpty(roles))) {
+      return true
+    }
+    return false
+  })
+
+const groupRulesToGroupsRecord = async (instances: InstanceElement[]): Promise<Record<string, InstanceElement[]>> => {
+  const record: Record<string, InstanceElement[]> = {}
+  await Promise.all(instances.map(async instance => {
+    const elemID = instance.elemID.createNestedID(...GROUP_ID_PATH)
+    const references = resolvePath(instance, elemID)
+    if (!isArrayOfRefExprToInstances(references)) {
+      return
+    }
+    const targets = await groupRefToGroupWithRoles(references)
+    if (targets !== undefined && !(_.isEmpty(targets))) {
+      record[instance.elemID.getFullName()] = targets
+    }
+  }))
+  return record
+}
+
+/**
+ * Verifies that Group target has no administrators.
+ */
+export const groupRuleAdministratorValidator: ChangeValidator = async changes => {
+  const relevantInstances = changes
+    .filter(isInstanceChange)
+    .filter(isAdditionChange)
+    .map(getChangeData)
+    .filter(instance => instance.elemID.typeName === GROUP_RULE_TYPE_NAME)
+  if (_.isEmpty(relevantInstances)) {
+    return []
+  }
+
+  const record = await groupRulesToGroupsRecord(relevantInstances)
+
+  // eslint-disable-next-line max-len
+  return relevantInstances.filter(instance => instance.elemID.getFullName() in record).map((instance: InstanceElement): ChangeError => ({
+    elemID: instance.elemID,
+    severity: 'Error',
+    message: 'Group membership rules cannot be created for groups with administrator roles ',
+    detailedMessage: `This following groups contains administrator roles: ${(record[instance.elemID.getFullName()].map(group => group.elemID.name)).join(', ')}.`,
+  }))
+}

--- a/packages/okta-adapter/src/change_validators/group_rule_administrator.ts
+++ b/packages/okta-adapter/src/change_validators/group_rule_administrator.ts
@@ -29,12 +29,12 @@ const getGroupsWithRoleByRuleId = async (groupRuleInstance: InstanceElement[]):
 Promise<Record<string, InstanceElement[]>> => {
   const groupsWithRoleByRuleId = (await Promise.all(groupRuleInstance.map(async instance => {
     const targetGroupsPath = instance.elemID.createNestedID(...GROUP_ID_PATH)
-    const TagetGroupReferences = resolvePath(instance, targetGroupsPath)
-    if (!isArrayOfRefExprToInstances(TagetGroupReferences)) {
+    const targetGroupReferences = resolvePath(instance, targetGroupsPath)
+    if (!isArrayOfRefExprToInstances(targetGroupReferences)) {
       log.debug('Could not find group references in %s', instance.elemID.getFullName())
       return undefined
     }
-    const targetGroupWithRoles = TagetGroupReferences.map(groupReference => groupReference.value).filter(
+    const targetGroupWithRoles = targetGroupReferences.map(groupReference => groupReference.value).filter(
       targetGroupInstance => !(_.isEmpty(targetGroupInstance.value?.roles))
     )
     if (!(_.isEmpty(targetGroupWithRoles))) {

--- a/packages/okta-adapter/src/change_validators/index.ts
+++ b/packages/okta-adapter/src/change_validators/index.ts
@@ -20,6 +20,7 @@ import { applicationValidator } from './application'
 import { groupRuleStatusValidator } from './group_rule_status'
 import { groupRuleActionsValidator } from './group_rule_actions'
 import { defaultPoliciesValidator } from './default_policies'
+import { groupRuleAdministratorValidator } from './group_rule_administrator'
 import { customApplicationStatusValidator } from './custom_application_status'
 import { userTypeAndSchemaValidator } from './user_type_and_schema'
 
@@ -31,6 +32,7 @@ export default (
     groupRuleStatusValidator,
     groupRuleActionsValidator,
     defaultPoliciesValidator,
+    groupRuleAdministratorValidator,
     customApplicationStatusValidator,
     userTypeAndSchemaValidator,
   ]

--- a/packages/okta-adapter/test/change_validators/group_rule_administrator.test.ts
+++ b/packages/okta-adapter/test/change_validators/group_rule_administrator.test.ts
@@ -22,6 +22,7 @@ describe('groupRuleAdministratorValidator', () => {
   const groupRuleType = new ObjectType({ elemID: new ElemID(OKTA, GROUP_RULE_TYPE_NAME) })
   const groupType = new ObjectType({ elemID: new ElemID(OKTA, GROUP_TYPE_NAME) })
   const RoleType = new ObjectType({ elemID: new ElemID(OKTA, ROLE_TYPE_NAME) })
+  const msg = 'Group membership rules cannot be created for groups with administrator roles.'
 
   const role1 = new InstanceElement(
     'role1',
@@ -93,20 +94,20 @@ describe('groupRuleAdministratorValidator', () => {
     expect(changeErrors).toEqual([{
       elemID: groupRule1.elemID,
       severity: 'Error',
-      message: 'Group membership rules cannot be created for groups with administrator roles ',
-      detailedMessage: `This following groups contains administrator roles: ${[group1.elemID.name].join(', ')}.`,
+      message: msg,
+      detailedMessage: `Rules cannot assign users to groups with administrator roles. The following groups have administrator roles: ${[group1.elemID.name].join(', ')}.`,
     },
     {
       elemID: groupRule2.elemID,
       severity: 'Error',
-      message: 'Group membership rules cannot be created for groups with administrator roles ',
-      detailedMessage: `This following groups contains administrator roles: ${[group1.elemID.name, group2.elemID.name].join(', ')}.`,
+      message: msg,
+      detailedMessage: `Rules cannot assign users to groups with administrator roles. The following groups have administrator roles: ${[group1.elemID.name, group2.elemID.name].join(', ')}.`,
     },
     {
       elemID: groupRule4.elemID,
       severity: 'Error',
-      message: 'Group membership rules cannot be created for groups with administrator roles ',
-      detailedMessage: `This following groups contains administrator roles: ${[group1.elemID.name].join(', ')}.`,
+      message: msg,
+      detailedMessage: `Rules cannot assign users to groups with administrator roles. The following groups have administrator roles: ${[group1.elemID.name].join(', ')}.`,
     }])
   })
 

--- a/packages/okta-adapter/test/change_validators/group_rule_administrator.test.ts
+++ b/packages/okta-adapter/test/change_validators/group_rule_administrator.test.ts
@@ -1,0 +1,130 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { groupRuleAdministratorValidator } from '../../src/change_validators/group_rule_administrator'
+import { GROUP_RULE_TYPE_NAME, GROUP_TYPE_NAME, OKTA, ROLE_TYPE_NAME } from '../../src/constants'
+
+describe('groupRuleAdministratorValidator', () => {
+  const groupRuleType = new ObjectType({ elemID: new ElemID(OKTA, GROUP_RULE_TYPE_NAME) })
+  const groupType = new ObjectType({ elemID: new ElemID(OKTA, GROUP_TYPE_NAME) })
+  const RoleType = new ObjectType({ elemID: new ElemID(OKTA, ROLE_TYPE_NAME) })
+
+  const role1 = new InstanceElement(
+    'role1',
+    RoleType,
+  )
+
+  const group1 = new InstanceElement(
+    'group1',
+    groupType,
+    { type: 'OKTA_GROUP', profile: { name: 'group1' }, roles: [new ReferenceExpression(role1.elemID, role1)] },
+  )
+
+  const group3 = new InstanceElement(
+    'group3',
+    groupType,
+    { type: 'OKTA_GROUP', profile: { name: 'group3' } },
+  )
+  const group4 = new InstanceElement(
+    'group4',
+    groupType,
+    { type: 'OKTA_GROUP', profile: { name: 'group4' }, roles: [] },
+  )
+
+  it('should return errors because the groups associated has roles', async () => {
+    const group2 = new InstanceElement(
+      'group2',
+      groupType,
+      { type: 'OKTA_GROUP', profile: { name: 'group2' }, roles: [new ReferenceExpression(role1.elemID, role1)] },
+    )
+
+    const groupRule1 = new InstanceElement(
+      'groupRule1',
+      groupRuleType,
+      {
+        name: 'rule',
+        status: 'ACTIVE',
+        conditions: {},
+        actions: { assignUserToGroups: { groupIds: [new ReferenceExpression(group1.elemID, group1)] } },
+      },
+    )
+
+    const groupRule2 = new InstanceElement(
+      'groupRule2',
+      groupRuleType,
+      {
+        name: 'rule',
+        status: 'ACTIVE',
+        conditions: {},
+        actions: { assignUserToGroups: { groupIds: [new ReferenceExpression(group1.elemID, group1),
+          new ReferenceExpression(group2.elemID, group2)] } },
+      },
+    )
+
+    const groupRule4 = new InstanceElement(
+      'groupRule4',
+      groupRuleType,
+      {
+        name: 'rule',
+        status: 'ACTIVE',
+        conditions: {},
+        actions: { assignUserToGroups: { groupIds: [new ReferenceExpression(group3.elemID, group3),
+          new ReferenceExpression(group4.elemID, group4), new ReferenceExpression(group1.elemID, group1)] } },
+      },
+    )
+
+    const changes = [toChange({ after: groupRule1 }), toChange({ after: groupRule2 }), toChange({ after: groupRule4 })]
+    const changeErrors = await groupRuleAdministratorValidator(changes)
+    expect(changeErrors).toHaveLength(3)
+    expect(changeErrors).toEqual([{
+      elemID: groupRule1.elemID,
+      severity: 'Error',
+      message: 'Group membership rules cannot be created for groups with administrator roles ',
+      detailedMessage: `This following groups contains administrator roles: ${[group1.elemID.name].join(', ')}.`,
+    },
+    {
+      elemID: groupRule2.elemID,
+      severity: 'Error',
+      message: 'Group membership rules cannot be created for groups with administrator roles ',
+      detailedMessage: `This following groups contains administrator roles: ${[group1.elemID.name, group2.elemID.name].join(', ')}.`,
+    },
+    {
+      elemID: groupRule4.elemID,
+      severity: 'Error',
+      message: 'Group membership rules cannot be created for groups with administrator roles ',
+      detailedMessage: `This following groups contains administrator roles: ${[group1.elemID.name].join(', ')}.`,
+    }])
+  })
+
+  it('should not return errors because the groups associated has no roles or roles are empty', async () => {
+    const groupRule3 = new InstanceElement(
+      'groupRule3',
+      groupRuleType,
+      {
+        name: 'rule',
+        status: 'ACTIVE',
+        conditions: {},
+        actions: { assignUserToGroups: { groupIds: [new ReferenceExpression(group3.elemID, group3),
+          new ReferenceExpression(group4.elemID, group4)] } },
+      },
+    )
+
+    const changes = [toChange({ after: groupRule3 })]
+    const changeErrors = await groupRuleAdministratorValidator(changes)
+    expect(changeErrors).toHaveLength(0)
+  })
+})

--- a/packages/zendesk-adapter/src/change_validators/unique_locale_per_variant.ts
+++ b/packages/zendesk-adapter/src/change_validators/unique_locale_per_variant.ts
@@ -19,11 +19,12 @@ import {
   isAdditionOrModificationChange, isReferenceExpression,
 } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
-import { getParents } from '@salto-io/adapter-utils'
+import { getParents, references } from '@salto-io/adapter-utils'
 import { VARIANTS_FIELD_NAME, DYNAMIC_CONTENT_ITEM_VARIANT_TYPE_NAME } from '../filters/dynamic_content'
-import { isArrayOfRefExprToInstances } from '../filters/utils'
+
 
 const log = logger(module)
+const { isArrayOfRefExprToInstances } = references
 
 const createEmptyLocaleIdErrorMessage = (): string =>
   'Can’t change an instance with an invalid locale'

--- a/packages/zendesk-adapter/src/filters/macro_attachments.ts
+++ b/packages/zendesk-adapter/src/filters/macro_attachments.ts
@@ -21,7 +21,7 @@ import {
   isInstanceElement, isRemovalChange, isStaticFile, ObjectType, ReferenceExpression, StaticFile,
 } from '@salto-io/adapter-api'
 import { normalizeFilePathPart, naclCase, elementExpressionStringifyReplacer,
-  resolveChangeElement, safeJsonStringify, pathNaclCase } from '@salto-io/adapter-utils'
+  resolveChangeElement, safeJsonStringify, pathNaclCase, references } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
 import { values, collections } from '@salto-io/lowerdash'
@@ -31,10 +31,11 @@ import { addId, deployChange, deployChanges } from '../deployment'
 import { getZendeskError } from '../errors'
 import { lookupFunc } from './field_references'
 import ZendeskClient from '../client/client'
-import { createAdditionalParentChanges, isArrayOfRefExprToInstances } from './utils'
+import { createAdditionalParentChanges } from './utils'
 
 const log = logger(module)
 const { awu } = collections.asynciterable
+const { isArrayOfRefExprToInstances } = references
 
 const { RECORDS_PATH, SUBTYPES_PATH, TYPES_PATH } = elementsUtils
 

--- a/packages/zendesk-adapter/src/filters/utils.ts
+++ b/packages/zendesk-adapter/src/filters/utils.ts
@@ -16,9 +16,8 @@
 import _ from 'lodash'
 import Joi from 'joi'
 import { Change, ChangeDataType, getChangeData, InstanceElement,
-  isAdditionOrModificationChange, isInstanceChange, isInstanceElement, isReferenceExpression,
-  ReferenceExpression, toChange } from '@salto-io/adapter-api'
-import { applyFunctionToChangeData, createSchemeGuard, getParents, resolveChangeElement } from '@salto-io/adapter-utils'
+  isAdditionOrModificationChange, isInstanceChange, toChange } from '@salto-io/adapter-api'
+import { applyFunctionToChangeData, createSchemeGuard, getParents, resolveChangeElement, references } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import { lookupFunc } from './field_references'
@@ -27,7 +26,7 @@ import { BRAND_TYPE_NAME } from '../constants'
 
 const { awu } = collections.asynciterable
 const log = logger(module)
-
+const { isArrayOfRefExprToInstances } = references
 export type Condition = {
   field: string
   value?: unknown
@@ -53,12 +52,6 @@ export const applyforInstanceChangesOfType = async (
       func,
     ))
 }
-
-export const isArrayOfRefExprToInstances = (values: unknown): values is ReferenceExpression[] => (
-  _.isArray(values)
-  && values.every(isReferenceExpression)
-  && values.every(value => isInstanceElement(value.value))
-)
 
 export const createAdditionalParentChanges = async (
   childrenChanges: Change<InstanceElement>[],


### PR DESCRIPTION
1. In this PR I  added a change validator that validates that the target Group for GroupRule has no administrator role.
2. I added test for this CV. 
3. I changed the location of `isArrayOfRefExprToInstances` from zendesk adapter to adapter-utils. 
---

_Additional context for reviewer_
In Order to test the code manually - do as follows:
1. fetch an Okta env
2. Check for a group instance with roles filed or create one yourself. 
Example:
`okta.Group All_IL@s {
  objectClass = [
    "okta:user_group",
  ]
  type = "OKTA_GROUP"
  profile = {
    name = "All IL"
    description = "all the employees living in israel"
  }
  roles = [
    okta.Role.instance.API_Access_Management_Administrator@s,
  ]
}`
4. Create new groupRule that points to this group
Example:
`okta.GroupRule Me_to_All_IL {
  type = "group_rule"
  status = "INACTIVE"
  name = "Me to All IL"
  conditions = {
    expression = {
      value = "isMemberOfAnyGroup(${ okta.Group.instance.All_IL@s })"
      type = "urn:okta:expression:1.0"
    }
  }
  actions = {
    assignUserToGroups = {
      groupIds = [
        okta.Group.instance.All_IL@s,
      ]
    }
  }
  allGroupsValid = true
}`
5. Try to deploy and check for the CV message.  
---
_Release Notes_: 
None

---
_User Notifications_: 
None
