### PR TITLE
SALTO-3599 Extract AuthorizationServer scopes and claims to standalone fields

### DIFF
--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -505,7 +505,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
       fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),
       fieldsToHide: [{ fieldName: 'id' }],
       serviceIdField: 'id',
-      standaloneFields: [{ fieldName: 'policies' }],
+      standaloneFields: [{ fieldName: 'policies' }, { fieldName: 'scopes' }, { fieldName: 'claims' }],
     },
   },
   AuthorizationServerPolicy: {
@@ -788,6 +788,8 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
       fieldsToOmit: [
         { fieldName: '_links' },
       ],
+      serviceIdField: 'id',
+      fieldsToHide: [{ fieldName: 'id' }],
     },
   },
   OAuth2Claim: {
@@ -795,6 +797,8 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
       fieldsToOmit: [
         { fieldName: '_links' },
       ],
+      serviceIdField: 'id',
+      fieldsToHide: [{ fieldName: 'id' }],
     },
   },
   ProfileMapping: {


### PR DESCRIPTION
Extract AuthorizationServer scopes and claims to standalone fields
---

_Additional context for reviewer_
I didn't deleted `scopes` and `claims` from `fieldTypeOverrides`, because it is crucial for the standAlone field to work. 
---
_Release Notes_: 
None

---
_User Notifications_: 
None