### PR TITLE
SALTO-3748 - Salesforce: Missing reference in HomePageComponent to CustomLink

### DIFF
--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -648,6 +648,10 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     serializationStrategy: 'relativeApiName',
     target: { type: CUSTOM_OBJECT },
   },
+  {
+    src: { field: 'links', parentTypes: ['HomePageComponent'] },
+    target: { type: 'CustomPageWebLink' },
+  },
 ]
 
 // Optional reference that should not be used if enumFieldPermissions config is on


### PR DESCRIPTION
Add the reference

- [x] [Noise Suppression](https://github.com/salto-io/salto_private/pull/5419)

---

WS Diff: https://github.com/salto-io/tomsellek-sf/pull/5

---
_Release Notes_: 
Salesforce: HomePageComponent.links will now correctly refer to the appropriate CustomPageWebLink records

---
_User Notifications_: 
N/A
