### PR TITLE
SALTO-3796 Support omitting settings/data values with fieldsToOmit

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -130,7 +130,6 @@ export default class NetsuiteAdapter implements AdapterOperations {
     filtersCreators = [
       customRecordTypesType,
       omitSdfUntypedValues,
-      omitFieldsFilter,
       dataInstancesIdentifiers,
       dataInstancesDiff,
       // addParentFolder must run before replaceInstanceReferencesFilter
@@ -167,6 +166,8 @@ export default class NetsuiteAdapter implements AdapterOperations {
       customRecordsFilter,
       // serviceUrls must run after suiteAppInternalIds filter
       serviceUrls,
+      // omitFieldsFilter should be the last onFetch filter to run
+      omitFieldsFilter,
       // additionalChanges should be the first preDeploy filter to run
       additionalChanges,
     ],


### PR DESCRIPTION
The `omitFields` filter should run last so the user will be able to omit values that were added/transformed in other filters.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Support omitting settings/data values with fieldsToOmit

---
_User Notifications_: 
None
