### PR TITLE
SALTO-2915: Netsuite - add change validator for a unique title field in saved search instance

### DIFF
--- a/packages/netsuite-adapter/src/change_validator.ts
+++ b/packages/netsuite-adapter/src/change_validator.ts
@@ -27,6 +27,7 @@ import removeSdfElementsValidator from './change_validators/remove_sdf_elements'
 import reportTypesMoveEnvironment from './change_validators/report_types_move_environment'
 import fileValidator from './change_validators/file_changes'
 import immutableChangesValidator from './change_validators/immutable_changes'
+import uniqueFieldsValidator from './change_validators/unique_fields'
 import subInstancesValidator from './change_validators/subinstances'
 import standardTypesInvalidValuesValidator from './change_validators/standard_types_invalid_values'
 import safeDeployValidator, { FetchByQueryFunc } from './change_validators/safe_deploy'
@@ -62,6 +63,7 @@ const netsuiteChangeValidators: NetsuiteChangeValidator[] = [
   immutableChangesValidator,
   removeListItemValidator,
   fileValidator,
+  uniqueFieldsValidator,
   subInstancesValidator,
   standardTypesInvalidValuesValidator,
   mappedListsIndexesValidator,

--- a/packages/netsuite-adapter/src/change_validators/unique_fields.ts
+++ b/packages/netsuite-adapter/src/change_validators/unique_fields.ts
@@ -1,0 +1,207 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, getChangeData, isAdditionOrModificationChange, ChangeError,
+  ReadOnlyElementsSource, ChangeDataType, isObjectType } from '@salto-io/adapter-api'
+import { values, collections, promises } from '@salto-io/lowerdash'
+import _ from 'lodash'
+import { resolvePath } from '@salto-io/adapter-utils'
+import { isCustomFieldName, isCustomRecordType } from '../types'
+import { NAME_FIELD, FINANCIAL_LAYOUT, SAVED_SEARCH, SCRIPT_ID } from '../constants'
+import { NetsuiteChangeValidator } from './types'
+
+const { awu } = collections.asynciterable
+const { isDefined } = values
+const { mapValuesAsync } = promises.object
+
+
+const FIELD_DEFAULT_NAME = 'FIELD_DEFAULT_NAME'
+const CUSTOM_RECORD_TYPE_NAME_PREFIX = 'customrecord'
+
+type RestrictedType = 'savedSearch' | 'financialLayout' | 'customRecordField'
+
+type GetterParams = {
+  elemID: ElemID
+  elementsSource: ReadOnlyElementsSource
+}
+
+type ElementGetter = (params: GetterParams) => Promise<string[]>
+type ChangeGetter = (change: ChangeDataType) => string
+
+type RestrictedTypeGetters = {
+  getChangeRestrictedField: ChangeGetter
+  getSourceRestrictedFields: ElementGetter
+  getMessage: () => string
+  getDetailedMessage: (field: string) => string
+}
+
+const getNestedField = async ({ elemID, elementsSource }: GetterParams, field: string) : Promise<string[]> =>
+  [await elementsSource.get(elemID.createNestedID(field))]
+
+const getChangeNestedField = (
+  change: ChangeDataType,
+  field: string
+) : string => resolvePath(change, change.elemID.createNestedID(field))
+
+const getCustomRecordRestrictedData = async ({ elemID, elementsSource }: GetterParams
+): Promise<string[]> => {
+  const element = await elementsSource.get(elemID)
+  if (!isObjectType(element) || !isCustomRecordType(element)) {
+    return []
+  }
+
+  return Object.keys(element.fields)
+    .filter(field => isCustomFieldName(field))
+    .map(field => element.fields[field].annotations[SCRIPT_ID])
+}
+
+
+const savedSearchGetters: RestrictedTypeGetters = {
+  getChangeRestrictedField: change => getChangeNestedField(change, FIELD_DEFAULT_NAME),
+  getSourceRestrictedFields: params => getNestedField(params, FIELD_DEFAULT_NAME),
+  getMessage: () => 'A Saved Search with that title already exists',
+  getDetailedMessage: title => `Can't deploy this Saved Search because there is already a Saved Search with the title "${title}" in the target account.`
+    + ' To deploy it, change its title to a unique one.',
+}
+
+const financialLayoutGetters: RestrictedTypeGetters = {
+  getChangeRestrictedField: change => getChangeNestedField(change, NAME_FIELD),
+  getSourceRestrictedFields: params => getNestedField(params, NAME_FIELD),
+  getMessage: () => 'A Financial Layout with that name already exists',
+  getDetailedMessage: name => `Can't deploy this Financial Layout because there is already a Financial Layout with the name "${name}" in the target account.`
+    + ' To deploy it, change its name to a unique one.',
+}
+
+const customRecordGetters: RestrictedTypeGetters = {
+  getChangeRestrictedField: change => getChangeNestedField(change, SCRIPT_ID),
+  getSourceRestrictedFields: getCustomRecordRestrictedData,
+  getMessage: () => 'A Custom Record Type Field with that ID already exists',
+  getDetailedMessage: scriptID => `Can't deploy this Custom Record Type Field because there is already a Custom Record Type Field with the ID "${scriptID}" in the target account.`
+    + ' To deploy it, change its ID to a unique one.',
+}
+
+const restrictedTypeGettersMap: Record<RestrictedType, RestrictedTypeGetters> = {
+  savedSearch: savedSearchGetters,
+  financialLayout: financialLayoutGetters,
+  customRecordField: customRecordGetters,
+}
+
+const getRestrictedType = (elemID: ElemID, includeFieldElements: boolean): RestrictedType | undefined => {
+  if (elemID.idType === 'instance') {
+    if (elemID.typeName === SAVED_SEARCH) {
+      return 'savedSearch'
+    }
+
+    if (elemID.typeName === FINANCIAL_LAYOUT) {
+      return 'financialLayout'
+    }
+  } else if ((includeFieldElements && elemID.idType === 'field') || (!includeFieldElements && elemID.idType === 'type')) {
+    if (elemID.typeName.startsWith(CUSTOM_RECORD_TYPE_NAME_PREFIX)) {
+      return 'customRecordField'
+    }
+  }
+
+  return undefined
+}
+
+const getEmptyRestrictedTypeRecord = <T>() : Record<RestrictedType, T[]> => ({
+  savedSearch: [],
+  financialLayout: [],
+  customRecordField: [],
+})
+
+const getTypeToDataRecord = <T> (
+  elements: T[],
+  getElemID: (element: T) => ElemID,
+  includeFieldElements = true,
+  typesToInclude?: Set<RestrictedType>,
+): Record<RestrictedType, T[]> => {
+  const typeToDataRecord = getEmptyRestrictedTypeRecord<T>()
+
+  const addToGroup = (elem: T): void => {
+    const elemID = getElemID(elem)
+    const restrictedType = getRestrictedType(elemID, includeFieldElements)
+    if (isDefined(restrictedType)
+      && (_.isUndefined(typesToInclude) || typesToInclude.has(restrictedType))) {
+      typeToDataRecord[restrictedType].push(elem)
+    }
+  }
+
+  elements.forEach(addToGroup)
+
+  return typeToDataRecord
+}
+
+const getTypeToRestrictedFields = (
+  elementsSource: ReadOnlyElementsSource,
+  typeToElementsRecord: Record<RestrictedType, ElemID[]>
+): Promise<Record<RestrictedType, string[]>> =>
+  mapValuesAsync(typeToElementsRecord,
+    (elemIDs, type) =>
+      awu(elemIDs)
+        .flatMap(elemID => restrictedTypeGettersMap[type as RestrictedType]
+          .getSourceRestrictedFields({ elemID, elementsSource }))
+        .toArray())
+
+const validateDuplication = (
+  changesData: ChangeDataType[],
+  uniqueFieldToID: Record<string, number>,
+  type: RestrictedType
+): Promise<Array<ChangeError>> => {
+  const getters = restrictedTypeGettersMap[type]
+
+  return awu(changesData)
+    .map(change => ({
+      elemID: change.elemID,
+      field: getters.getChangeRestrictedField(change),
+    }))
+    .filter(({ field }) => (uniqueFieldToID[field] ?? 0) > 1)
+    .map(({ elemID, field }): ChangeError => ({
+      elemID,
+      severity: 'Error',
+      message: getters.getMessage(),
+      detailedMessage: getters.getDetailedMessage(field),
+    }))
+    .toArray()
+}
+
+const changeValidator: NetsuiteChangeValidator = async (changes, _deployReferencedElements, elementsSource) => {
+  const changeElements = changes
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+
+  const typesToChanges = getTypeToDataRecord(changeElements, element => element.elemID)
+  const relevantTypes = new Set(
+    Object.keys(_.pickBy(typesToChanges, mappedChanges => mappedChanges.length > 0)) as RestrictedType[]
+  )
+
+  if (!elementsSource || relevantTypes.size === 0) {
+    return []
+  }
+
+  const typeToElements = getTypeToDataRecord(
+    (await awu(await elementsSource.list()).toArray()), elem => elem, false, relevantTypes
+  )
+  const typeToRestrictedFields = await getTypeToRestrictedFields(elementsSource, typeToElements)
+
+  const getErrors = (type: RestrictedType, changesSingleType: ChangeDataType[]): Promise<Array<ChangeError>> =>
+    validateDuplication(changesSingleType, _.countBy(typeToRestrictedFields[type]), type)
+
+  return awu(Object.entries(typesToChanges))
+    .flatMap(([type, changesOfType]) => getErrors(type as RestrictedType, changesOfType))
+    .toArray()
+}
+
+export default changeValidator

--- a/packages/netsuite-adapter/test/change_validators/unique_fields.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/unique_fields.test.ts
@@ -1,0 +1,390 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { ElemID, InstanceElement, ObjectType, toChange, ReadOnlyElementsSource, Field, Element, ChangeDataType } from '@salto-io/adapter-api'
+import uniqueFields from '../../src/change_validators/unique_fields'
+import { CUSTOM_RECORD_TYPE, CUSTOM_RECORD_TYPE_PREFIX, FINANCIAL_LAYOUT, METADATA_TYPE, NAME_FIELD, NETSUITE, SAVED_SEARCH } from '../../src/constants'
+
+const DUPLICATED_FIELD = 'test uniqueness'
+const UNIQUE_FIELD = 'test uniqueness 2'
+
+const FIELD_DEFAULT_NAME = 'FIELD_DEFAULT_NAME'
+
+describe('unique fields validator', () => {
+  type TestElements = {
+    basic: ChangeDataType
+    sameField: ChangeDataType
+    diffField: ChangeDataType
+  }
+
+  const getTestElements = (
+    typeName: string,
+    createElem: (name: string, type: ObjectType, uniqueField: string) => ChangeDataType
+  ): TestElements => ({
+    basic: createElem(
+      'test',
+      new ObjectType({ elemID: new ElemID(NETSUITE, typeName) }),
+      DUPLICATED_FIELD
+    ),
+    sameField: createElem(
+      'test_same_title_diff_id',
+      new ObjectType({ elemID: new ElemID(NETSUITE, typeName) }),
+      DUPLICATED_FIELD
+    ),
+    diffField: createElem(
+      'test_diff_title_diff_id',
+      new ObjectType({ elemID: new ElemID(NETSUITE, typeName) }),
+      UNIQUE_FIELD
+    ),
+  })
+
+  const getIDToVal = (
+    testInstances: TestElements,
+    nestedField: string
+  ): Map<string, string> => new Map(Object.values(testInstances)
+    .map(elem =>
+      [elem.elemID.createNestedID(nestedField).getFullName(),
+        (elem as InstanceElement).value[nestedField]]))
+
+  const buildMockElementsSource = (
+    elementSource: ReadOnlyElementsSource,
+    idToVal: Map<string, string>
+  ): ReadOnlyElementsSource => {
+    const mockGet = jest.fn().mockImplementation((id: ElemID) => idToVal.get(id.getFullName()) ?? elementSource.get(id))
+    const mockElementsSource = {
+      list: elementSource.list,
+      getAll: elementSource.getAll,
+      has: elementSource.has,
+      get: mockGet,
+    } as unknown as ReadOnlyElementsSource
+
+    return mockElementsSource
+  }
+
+  const getSavedSearchElements = (): TestElements => getTestElements(SAVED_SEARCH,
+    (name: string, elemID: ObjectType, uniqueField: string) =>
+      new InstanceElement(name, elemID, { FIELD_DEFAULT_NAME: uniqueField }))
+
+  const getFinancialLayoutElements = (): TestElements => getTestElements(FINANCIAL_LAYOUT,
+    (name: string, elemID: ObjectType, uniqueField: string) =>
+      new InstanceElement(name, elemID, { name: uniqueField }))
+
+  const getCustomRecordElements = (): TestElements => getTestElements(CUSTOM_RECORD_TYPE_PREFIX,
+    (name: string, elemID: ObjectType, uniqueField: string) =>
+      new ObjectType({
+        elemID: new ElemID(elemID.elemID.adapter, elemID.elemID.typeName + uniqueField),
+        annotations: {
+          name,
+          [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
+        },
+        fields: {
+          custom_custrecord1: {
+            refType: elemID,
+            annotations: {
+              scriptid: uniqueField,
+            },
+          },
+        },
+      }))
+
+  const getCustomRecordChanges = (customRecordTestObjects: TestElements): TestElements => {
+    const getFieldFromElement = (element: ObjectType): Field =>
+      new Field(element, element.annotations.name, element, element.fields.custom_custrecord1.annotations)
+    return {
+      basic: getFieldFromElement(customRecordTestObjects.basic as ObjectType),
+      sameField: getFieldFromElement(customRecordTestObjects.sameField as ObjectType),
+      diffField: getFieldFromElement(customRecordTestObjects.diffField as ObjectType),
+    }
+  }
+
+  describe('Saved Search unique `title` field validator', () => {
+    const testElements = getSavedSearchElements()
+    const idToVal = getIDToVal(testElements, FIELD_DEFAULT_NAME)
+    const buildElementsSource = (elements: readonly Element[]): ReadOnlyElementsSource =>
+      buildMockElementsSource(buildElementsSourceFromElements(elements), idToVal)
+
+    describe('Saved Search with a unique title', () => {
+      it('Should not have a change error when adding a new Saved Search with a unique title', async () => {
+        const changeErrors = await uniqueFields(
+          [toChange({ after: testElements.basic })],
+          undefined,
+          buildElementsSource([
+            testElements.diffField,
+            testElements.basic])
+        )
+        expect(changeErrors).toHaveLength(0)
+      })
+
+      it('Should not have a change error when modifying a Saved Search with a unique title', async () => {
+        const changeErrors = await uniqueFields(
+          [toChange(
+            { before: testElements.basic,
+              after: testElements.sameField }
+          )],
+          undefined,
+          buildElementsSource([
+            testElements.diffField,
+            testElements.sameField])
+        )
+        expect(changeErrors).toHaveLength(0)
+      })
+    })
+
+    describe('Saved Search with an existing title', () => {
+      it('Should have a change error when adding a new Saved Search with an existing title', async () => {
+        const changeErrors = await uniqueFields(
+          [toChange({ after: testElements.sameField })],
+          undefined,
+          buildElementsSource([
+            testElements.basic,
+            testElements.sameField])
+        )
+        expect(changeErrors).toHaveLength(1)
+        expect(changeErrors[0].severity).toEqual('Error')
+        expect(changeErrors[0].elemID).toBe(testElements.sameField.elemID)
+        expect(changeErrors[0].detailedMessage).toContain(DUPLICATED_FIELD)
+      })
+
+      it('Should have a change error when modifying a Saved Search`s title to an existing one', async () => {
+        const changeErrors = await uniqueFields([
+          toChange(
+            { before: testElements.diffField,
+              after: testElements.sameField }
+          ),
+        ], undefined,
+        buildElementsSource([
+          testElements.basic,
+          testElements.sameField]))
+        expect(changeErrors).toHaveLength(1)
+        expect(changeErrors[0].severity).toEqual('Error')
+        expect(changeErrors[0].elemID).toBe(testElements.sameField.elemID)
+        expect(changeErrors[0].detailedMessage).toContain(DUPLICATED_FIELD)
+      })
+    })
+  })
+
+  describe('Financial Layout unique `name` field validator', () => {
+    const testElements = getFinancialLayoutElements()
+    const idToVal = getIDToVal(testElements, NAME_FIELD)
+    const buildElementsSource = (elements: readonly Element[]): ReadOnlyElementsSource =>
+      buildMockElementsSource(buildElementsSourceFromElements(elements), idToVal)
+
+    describe('Financial Layout with a unique name', () => {
+      it('Should not have a change error when adding a new Financial Layout with a unique name', async () => {
+        const changeErrors = await uniqueFields(
+          [toChange({ after: testElements.basic })],
+          undefined,
+          buildElementsSource([
+            testElements.diffField,
+            testElements.basic])
+        )
+        expect(changeErrors).toHaveLength(0)
+      })
+
+      it('Should not have a change error when modifying a Financial Layout with a unique name', async () => {
+        const changeErrors = await uniqueFields(
+          [toChange(
+            { before: testElements.basic,
+              after: testElements.sameField }
+          )],
+          undefined,
+          buildElementsSource([
+            testElements.diffField,
+            testElements.sameField])
+        )
+        expect(changeErrors).toHaveLength(0)
+      })
+    })
+
+    describe('Financial Layout with an existing name', () => {
+      it('Should have a change error when adding a new Financial Layout with an existing name', async () => {
+        const changeErrors = await uniqueFields(
+          [toChange({ after: testElements.sameField })],
+          undefined,
+          buildElementsSource([
+            testElements.basic,
+            testElements.sameField])
+        )
+        expect(changeErrors).toHaveLength(1)
+        expect(changeErrors[0].severity).toEqual('Error')
+        expect(changeErrors[0].elemID).toBe(testElements.sameField.elemID)
+        expect(changeErrors[0].detailedMessage).toContain(DUPLICATED_FIELD)
+      })
+
+      it('Should have a change error when modifying a Financial Layout`s name to an existing one', async () => {
+        const changeErrors = await uniqueFields([
+          toChange(
+            { before: testElements.diffField,
+              after: testElements.sameField }
+          ),
+        ], undefined,
+        buildElementsSource([
+          testElements.basic,
+          testElements.sameField]))
+        expect(changeErrors).toHaveLength(1)
+        expect(changeErrors[0].severity).toEqual('Error')
+        expect(changeErrors[0].elemID).toBe(testElements.sameField.elemID)
+        expect(changeErrors[0].detailedMessage).toContain(DUPLICATED_FIELD)
+      })
+    })
+  })
+
+  describe('Custom Record Type Field unique `scriptid` field validator', () => {
+    const testElements = getCustomRecordElements()
+    const testChanges = getCustomRecordChanges(testElements)
+
+    describe('Custom Record Type Field with a unique scriptid', () => {
+      it('Should not have a change error when adding a new Custom Record Type Field with a unique scriptid', async () => {
+        const changeErrors = await uniqueFields(
+          [toChange({ after: testChanges.basic })],
+          undefined,
+          buildElementsSourceFromElements([
+            testElements.diffField,
+            testElements.basic])
+        )
+        expect(changeErrors).toHaveLength(0)
+      })
+
+      it('Should not have a change error when modifying a Custom Record Type Field with a unique scriptid', async () => {
+        const changeErrors = await uniqueFields(
+          [toChange(
+            { before: testChanges.basic,
+              after: testChanges.sameField }
+          )],
+          undefined,
+          buildElementsSourceFromElements([
+            testElements.diffField,
+            testElements.sameField])
+        )
+        expect(changeErrors).toHaveLength(0)
+      })
+    })
+
+    describe('Custom Record Type Field with an existing scriptid', () => {
+      it('Should have a change error when adding a new Custom Record Type Field with an existing scriptid', async () => {
+        const changeErrors = await uniqueFields(
+          [toChange({ after: testChanges.sameField })],
+          undefined,
+          buildElementsSourceFromElements([
+            testElements.basic,
+            testElements.sameField])
+        )
+        expect(changeErrors).toHaveLength(1)
+        expect(changeErrors[0].severity).toEqual('Error')
+        expect(changeErrors[0].elemID).toBe(testChanges.sameField.elemID)
+        expect(changeErrors[0].detailedMessage).toContain(DUPLICATED_FIELD)
+      })
+
+      it('Should have a change error when modifying a Custom Record Type Field`s scriptid to an existing one', async () => {
+        const changeErrors = await uniqueFields([
+          toChange(
+            { before: testChanges.diffField,
+              after: testChanges.sameField }
+          ),
+        ], undefined,
+        buildElementsSourceFromElements([
+          testElements.basic,
+          testElements.sameField]))
+        expect(changeErrors).toHaveLength(1)
+        expect(changeErrors[0].severity).toEqual('Error')
+        expect(changeErrors[0].elemID).toBe(testChanges.sameField.elemID)
+        expect(changeErrors[0].detailedMessage).toContain(DUPLICATED_FIELD)
+      })
+    })
+  })
+
+  describe('Multiple types', () => {
+    const savedSearchTestInstances = getSavedSearchElements()
+    const financialLayoutTestInstances = getFinancialLayoutElements()
+    const customRecordTestObjects = getCustomRecordElements()
+    const customRecordTestChanges = getCustomRecordChanges(customRecordTestObjects)
+
+    const idToValSavedSearch = getIDToVal(savedSearchTestInstances, FIELD_DEFAULT_NAME)
+    const idToValFinancialLayout = getIDToVal(financialLayoutTestInstances, NAME_FIELD)
+    const idToVal = new Map([...idToValSavedSearch, ...idToValFinancialLayout])
+
+    const buildElementsSource = (elements: readonly Element[]): ReadOnlyElementsSource =>
+      buildMockElementsSource(buildElementsSourceFromElements(elements), idToVal)
+
+    describe('All types with a unique field', () => {
+      it('Should not have a change error when adding a new type element with a unique field', async () => {
+        const changeErrors = await uniqueFields([
+          toChange({ after: savedSearchTestInstances.basic }),
+          toChange({ after: financialLayoutTestInstances.basic }),
+          toChange({ after: customRecordTestChanges.basic }),
+        ], undefined, buildElementsSource(
+          [savedSearchTestInstances.diffField, savedSearchTestInstances.basic,
+            financialLayoutTestInstances.diffField, financialLayoutTestInstances.basic,
+            customRecordTestObjects.diffField, customRecordTestObjects.basic]
+        ))
+        expect(changeErrors).toHaveLength(0)
+      })
+
+      it('Should not have a change error when modifying a type element with a unique field', async () => {
+        const changeErrors = await uniqueFields([
+          toChange({ before: savedSearchTestInstances.basic, after: savedSearchTestInstances.sameField }),
+          toChange({ before: financialLayoutTestInstances.basic, after: financialLayoutTestInstances.sameField }),
+          toChange({ before: customRecordTestChanges.basic, after: customRecordTestChanges.sameField }),
+        ], undefined, buildElementsSource(
+          [savedSearchTestInstances.diffField, savedSearchTestInstances.sameField,
+            financialLayoutTestInstances.diffField, financialLayoutTestInstances.sameField,
+            customRecordTestObjects.diffField, customRecordTestObjects.sameField]
+        ))
+        expect(changeErrors).toHaveLength(0)
+      })
+    })
+
+    describe('All types with a duplicated field', () => {
+      it('Should have a change error when adding a new type element with an existing unique field', async () => {
+        const changeErrors = await uniqueFields([
+          toChange({ after: savedSearchTestInstances.sameField }),
+          toChange({ after: financialLayoutTestInstances.sameField }),
+          toChange({ after: customRecordTestChanges.sameField }),
+        ], undefined, buildElementsSource(
+          [savedSearchTestInstances.basic, savedSearchTestInstances.sameField,
+            financialLayoutTestInstances.basic, financialLayoutTestInstances.sameField,
+            customRecordTestObjects.basic, customRecordTestObjects.sameField]
+        ))
+        expect(changeErrors).toHaveLength(3)
+        expect(changeErrors.map(changeError => changeError.severity)).toEqual(['Error', 'Error', 'Error'])
+        expect(changeErrors.map(changeError => changeError.elemID)).toEqual(expect.arrayContaining([
+          savedSearchTestInstances.sameField.elemID,
+          financialLayoutTestInstances.sameField.elemID,
+          customRecordTestChanges.sameField.elemID,
+        ]))
+      })
+
+      it('Should have a change error when modifying a type element`s unique field to an existing one', async () => {
+        const changeErrors = await uniqueFields([
+          toChange({ before: savedSearchTestInstances.diffField, after: savedSearchTestInstances.sameField }),
+          toChange({ before: financialLayoutTestInstances.diffField, after: financialLayoutTestInstances.sameField }),
+          toChange({ before: customRecordTestChanges.diffField, after: customRecordTestChanges.sameField }),
+        ], undefined, buildElementsSource(
+          [savedSearchTestInstances.basic, savedSearchTestInstances.sameField,
+            financialLayoutTestInstances.basic, financialLayoutTestInstances.sameField,
+            customRecordTestObjects.basic, customRecordTestObjects.sameField]
+        ))
+        expect(changeErrors).toHaveLength(3)
+        expect(changeErrors.map(changeError => changeError.severity)).toEqual(['Error', 'Error', 'Error'])
+        expect(changeErrors.map(changeError => changeError.elemID)).toEqual(expect.arrayContaining([
+          savedSearchTestInstances.sameField.elemID,
+          financialLayoutTestInstances.sameField.elemID,
+          customRecordTestChanges.sameField.elemID,
+        ]))
+      })
+    })
+  })
+})


### PR DESCRIPTION
[Netsuite Adapter]
Add a new change validator to the Netsuite adapter.
This validator validates uniqueness of:
-  savedSearch titles (FIELD_DEFAULT_NAME in nacl files).
- financialLayout name
- customrecordtype fields scriptid 

---

Netsuite does not allow duplicated savedSearch titles, duplicated financiallayout name field and inner customrecordtype fields scriptids, even between different customrecordtypes.
Currently there isn't a validator for that and the deployment will fail.

---
_Release Notes_: 

Netsuite - validate unique title field in saved search instances, financial layout instances and custom record types during deployment.
