### PR TITLE
SALTO-1730 - Salesforce: Enable formula parsing by default

### DIFF
--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -157,6 +157,7 @@ salesforce {
 | profilePaths      | true                   | Update file names for profiles whose API name is different from their display name                                                     |
 | authorInformation | true                   | Populate Salesforce author information about who and when last changed Salesforce configuration elements.                              |
 | describeSObjects  | true                   | Fetch additional information about CustomObjects from the soap API                                                                     |
+| formulaDeps       | true                   | Parse formula fields in custom objects for additional dependencies beyond those provided by the tooling API                            |
 
 ### Data management configuration options
 

--- a/packages/salesforce-adapter/src/filters/formula_deps.ts
+++ b/packages/salesforce-adapter/src/filters/formula_deps.ts
@@ -164,10 +164,6 @@ const addDependenciesAnnotation = async (field: Field, allElements: ReadOnlyElem
 const filter: LocalFilterCreator = ({ config }) => ({
   name: 'formula_deps',
   onFetch: async fetchedElements => {
-    if (config.fetchProfile.isFeatureEnabled('skipParsingFormulas')) {
-      log.info('Formula parsing is disabled. Skipping formula_deps filter.')
-      return
-    }
     const fetchedObjectTypes = fetchedElements.filter(isObjectType)
     const fetchedFormulaFields = await awu(fetchedObjectTypes)
       .flatMap(extractFlatCustomObjectFields) // Get the types + their fields

--- a/packages/salesforce-adapter/src/filters/formula_deps.ts
+++ b/packages/salesforce-adapter/src/filters/formula_deps.ts
@@ -154,6 +154,7 @@ const addDependenciesAnnotation = async (field: Field, allElements: ReadOnlyElem
   }
 }
 
+const FILTER_NAME = 'formulaDeps'
 /**
  * Extract references from formulas
  * Formulas appear in the field definitions of types and may refer to fields in their parent type or in another type.
@@ -162,8 +163,12 @@ const addDependenciesAnnotation = async (field: Field, allElements: ReadOnlyElem
  * Note: Currently (pending a fix to SALTO-3176) we only look at formula fields in custom objects.
  */
 const filter: LocalFilterCreator = ({ config }) => ({
-  name: 'formula_deps',
+  name: FILTER_NAME,
   onFetch: async fetchedElements => {
+    if (!config.fetchProfile.isFeatureEnabled(FILTER_NAME)) {
+      log.info('Formula parsing is disabled. Skipping formula_deps filter.')
+      return
+    }
     const fetchedObjectTypes = fetchedElements.filter(isObjectType)
     const fetchedFormulaFields = await awu(fetchedObjectTypes)
       .flatMap(extractFlatCustomObjectFields) // Get the types + their fields

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -76,8 +76,6 @@ export type OptionalFeatures = {
   addMissingIds?: boolean
   authorInformation?: boolean
   describeSObjects?: boolean
-  skipParsingFormulas?: boolean // Negative flag because we want it disabled by default and optional features are
-                                // enabled by default
   skipAliases?: boolean
 }
 
@@ -571,7 +569,6 @@ const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
     addMissingIds: { refType: BuiltinTypes.BOOLEAN },
     authorInformation: { refType: BuiltinTypes.BOOLEAN },
     describeSObjects: { refType: BuiltinTypes.BOOLEAN },
-    skipParsingFormulas: { refType: BuiltinTypes.BOOLEAN },
     skipAliases: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -77,6 +77,7 @@ export type OptionalFeatures = {
   authorInformation?: boolean
   describeSObjects?: boolean
   skipAliases?: boolean
+  formulaDeps?: boolean
 }
 
 export type ChangeValidatorName = (
@@ -570,6 +571,7 @@ const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
     authorInformation: { refType: BuiltinTypes.BOOLEAN },
     describeSObjects: { refType: BuiltinTypes.BOOLEAN },
     skipAliases: { refType: BuiltinTypes.BOOLEAN },
+    formulaDeps: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/salesforce-adapter/test/filters/formula_deps.test.ts
+++ b/packages/salesforce-adapter/test/filters/formula_deps.test.ts
@@ -53,11 +53,9 @@ describe('Formula dependencies', () => {
   let typeWithFormula: ObjectType
   let referredTypes: ObjectType[]
   let referredInstances: InstanceElement[]
-  let featureEnabledQuery: jest.SpyInstance
 
   beforeAll(() => {
     const config = { ...defaultFilterContext }
-    featureEnabledQuery = jest.spyOn(config.fetchProfile, 'isFeatureEnabled')
     filter = formulaDepsFilter({ config }) as FilterWith<'onFetch'>
 
     typeWithFormula = createCustomObjectType('Account',
@@ -140,21 +138,6 @@ describe('Formula dependencies', () => {
 
   afterAll(() => {
     jest.restoreAllMocks()
-  })
-
-  beforeEach(() => {
-    featureEnabledQuery.mockReturnValue(false)
-  })
-
-  describe('When the feature is disabled in adapter config', () => {
-    it('Should not run', async () => {
-      featureEnabledQuery.mockReturnValue(true)
-      const elements = [typeWithFormula.clone()]
-      await filter.onFetch(elements)
-      // eslint-disable-next-line no-underscore-dangle
-      const deps = elements[0].fields.someFormulaField__c.annotations._generated_dependencies
-      expect(deps).not.toBeDefined()
-    })
   })
 
   describe('When the formula has a reference', () => {

--- a/packages/salesforce-adapter/test/filters/formula_deps.test.ts
+++ b/packages/salesforce-adapter/test/filters/formula_deps.test.ts
@@ -53,11 +53,9 @@ describe('Formula dependencies', () => {
   let typeWithFormula: ObjectType
   let referredTypes: ObjectType[]
   let referredInstances: InstanceElement[]
-  let featureEnabledQuery: jest.SpyInstance
 
   beforeAll(() => {
     const config = { ...defaultFilterContext }
-    featureEnabledQuery = jest.spyOn(config.fetchProfile, 'isFeatureEnabled')
     filter = formulaDepsFilter({ config }) as FilterWith<'onFetch'>
 
     typeWithFormula = createCustomObjectType('Account',
@@ -136,25 +134,6 @@ describe('Formula dependencies', () => {
       createInstanceElement({ fullName: 'Trigger_Context_Status.by_class' }, someCustomMetadataType),
       createInstanceElement({ fullName: 'Trigger_Context_Status.by_handler' }, someCustomMetadataType),
     ]
-  })
-
-  beforeEach(() => {
-    featureEnabledQuery.mockReturnValue(true)
-  })
-
-  afterAll(() => {
-    jest.restoreAllMocks()
-  })
-
-  describe('When the feature is disabled in adapter config', () => {
-    it('Should not run', async () => {
-      featureEnabledQuery.mockReturnValue(false)
-      const elements = [typeWithFormula.clone()]
-      await filter.onFetch(elements)
-      // eslint-disable-next-line no-underscore-dangle
-      const deps = elements[0].fields.someFormulaField__c.annotations._generated_dependencies
-      expect(deps).not.toBeDefined()
-    })
   })
 
   describe('When the formula has a reference', () => {


### PR DESCRIPTION
The feature is currently behind a default-disabled config flag. Eliminate the flag and enable the feature by default.

 - [x] [Noise suppression](https://github.com/salto-io/salto_private/pull/5426)
 - [x] [Ignore self-references](https://github.com/salto-io/salto/pull/4196)
 - [x] [Customer communication](https://salto-io.atlassian.net/browse/PROD-129)

---

[WS Diff](https://github.com/salto-io/tomsellek-sf/pull/3)
[WS Diff without self-references](https://github.com/salto-io/tomsellek-sf/pull/7) (cf. https://github.com/salto-io/salto/pull/4196)

---
_Release Notes_: 
Salesforce: more dependencies are now extracted from formula fields

---
_User Notifications_: 
N/A
