### PR TITLE
SALTO-3922: FieldContext projects and issue types are not paginated

### DIFF
--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -220,6 +220,18 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       ],
     },
   },
+  PageBeanIssueTypeToContextMapping: {
+    request: {
+      url: '/rest/api/3/field/{fieldId}/context/issuetypemapping',
+      paginationField: 'startAt',
+    },
+  },
+  PageBeanCustomFieldContextProjectMapping: {
+    request: {
+      url: '/rest/api/3/field/{fieldId}/context/projectmapping',
+      paginationField: 'startAt',
+    },
+  },
   Field: {
     transformation: {
       fieldsToHide: [


### PR DESCRIPTION
Fixed some projects and issue types of field contexts not being paginated and therefore limited to 50

---
_Release Notes_: 
__Jira Adapter__:
- Fixed a bug when fetching a field context projects and issue types that only the first 50 were fetched

---
_User Notifications_: 
__Jira Adapter__:
- Some additional projects and issue types of field contexts might be fetched (only if there a field contexts with more than 50 issue types or projects)