### PR TITLE
SALTO-3923: fieldContextValidator can return errors on contexts that are not in the plan

### DIFF
--- a/packages/jira-adapter/src/change_validators/field_contexts/field_contexts.ts
+++ b/packages/jira-adapter/src/change_validators/field_contexts/field_contexts.ts
@@ -95,8 +95,10 @@ export const fieldContextValidator: ChangeValidator = async (changes, elementSou
     return acc
   }, new Set<string>())
 
+  const changesIds = new Set(changes.map(change => getChangeData(change).elemID.getFullName()))
+
   return [
     ...getUnreferencedContextErrors(fieldsToContexts, mergedContexts),
     ...getGlobalContextsUsedInProjectErrors(contexts, projectNamesToContexts),
-  ]
+  ].filter(change => changesIds.has(change.elemID.getFullName()))
 }

--- a/packages/jira-adapter/test/change_validators/field_contexts/field_contexts.test.ts
+++ b/packages/jira-adapter/test/change_validators/field_contexts/field_contexts.test.ts
@@ -142,6 +142,14 @@ describe('Field contexts', () => {
       },
     ])
   })
+
+  it('should not about a context if it is not in the changed elements', async () => {
+    projectInstance.value[PROJECT_CONTEXTS_FIELD] = []
+    expect(await fieldContextValidator(
+      [toChange({ after: projectInstance })],
+      elementsSource
+    )).toEqual([])
+  })
   it('should not throw when one of the contexts is unresolved', async () => {
     fieldInstance.value.contexts.push(new ReferenceExpression(new ElemID(JIRA, 'unresolved'), undefined))
     await expect(fieldContextValidator(


### PR DESCRIPTION
Fixed field contexts validator to not return errors about elements in the plan

---
_Release Notes_: 
__Jira Adapter__:
- Fixed field contexts validator to not return errors about elements in the plan

---
_User Notifications_: 
None