### PR TITLE
SALTO-3928: 403 when fetching a dashboard fails the entire fetch

### DIFF
--- a/packages/jira-adapter/src/filters/dashboard/dashboard_layout.ts
+++ b/packages/jira-adapter/src/filters/dashboard/dashboard_layout.ts
@@ -81,14 +81,19 @@ const filter: FilterCreator = ({ client, config }) => ({
       .filter(isInstanceElement)
       .filter(instance => instance.elemID.typeName === DASHBOARD_TYPE)
       .map(async instance => {
-        const response = await client.getSinglePage({
-          url: `/rest/dashboards/1.0/${instance.value.id}`,
-        })
-        if (Array.isArray(response.data)) {
-          log.error(`Invalid response from server when fetching dashboard layout for ${instance.elemID.getFullName()}: ${safeJsonStringify(response.data)}`)
-          return
+        try {
+          const response = await client.getSinglePage({
+            url: `/rest/dashboards/1.0/${instance.value.id}`,
+          })
+
+          if (Array.isArray(response.data)) {
+            log.error(`Invalid response from server when fetching dashboard layout for ${instance.elemID.getFullName()}: ${safeJsonStringify(response.data)}`)
+            return
+          }
+          instance.value.layout = response.data.layout
+        } catch (err) {
+          log.warn(`Failed to fetch dashboard layout for ${instance.elemID.getFullName()}: ${err}`)
         }
-        instance.value.layout = response.data.layout
       }))
   },
 })

--- a/packages/jira-adapter/test/filters/dashboard/dashboard_layout.test.ts
+++ b/packages/jira-adapter/test/filters/dashboard/dashboard_layout.test.ts
@@ -102,5 +102,12 @@ describe('dashboardLayoutFilter', () => {
 
       expect(instance.value.layout).toBeUndefined()
     })
+
+    it('should not add layout if request threw an error', async () => {
+      connection.get.mockRejectedValue(new Error('error'))
+      await filter.onFetch([instance])
+
+      expect(instance.value.layout).toBeUndefined()
+    })
   })
 })


### PR DESCRIPTION
Fixed a bug that when we fail to fetch a certain dashboard layout value the entire fetch would fail

---
_Release Notes_: 
__Jira Adapter__:
- Fixed a bug that when we fail to fetch a certain dashboard layout value the entire fetch would fail

---
_User Notifications_: 
None