### PR TITLE
SALTO-3793: Log reasons of config suggestion

### DIFF
--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -450,7 +450,7 @@ const fetchAndProcessMergeErrors = async (
           })
           const { updatedConfig, errors } = fetchResult
           if (updatedConfig !== undefined) {
-            log.debug(`Salto got config suggestions in ${accountName} account: ${updatedConfig.message}`)
+            log.debug(`In account: ${accountName}, received config suggestions for the following reasons: ${updatedConfig.message}`)
           }
           if (
             fetchResult.elements.length > 0 && accountName !== accountToServiceNameMap[accountName]


### PR DESCRIPTION
Fixing a nit suggestion from Shir about log content. 

---
This is followup for https://github.com/salto-io/salto/pull/4135
---
_Release Notes_: 
None
---
_User Notifications_: 
None
