### PR TITLE
Add/warn about additional changes for SDF objects only

### DIFF
--- a/packages/netsuite-adapter/src/change_validators/extra_reference_dependencies.ts
+++ b/packages/netsuite-adapter/src/change_validators/extra_reference_dependencies.ts
@@ -14,8 +14,9 @@
 * limitations under the License.
 */
 
-import { ChangeDataType, ElemID, getChangeData } from '@salto-io/adapter-api'
+import { ChangeDataType, ElemID, getChangeData, isAdditionOrModificationChange } from '@salto-io/adapter-api'
 import { collections, values } from '@salto-io/lowerdash'
+import { isStandardInstanceOrCustomRecordType } from '../types'
 import { getReferencedElements } from '../reference_dependencies'
 import { NetsuiteChangeValidator } from './types'
 
@@ -55,8 +56,13 @@ export const getReferencedElementsForReferrers = async (
 }
 
 const changeValidator: NetsuiteChangeValidator = async (changes, deployReferencedElements = false) => {
+  const sdfChangesData = changes
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+    .filter(isStandardInstanceOrCustomRecordType)
+
   const refererToReferenceElements = await getReferencedElementsForReferrers(
-    changes.map(getChangeData), deployReferencedElements
+    sdfChangesData, deployReferencedElements
   )
 
   return refererToReferenceElements.map(refererToReferenceElement => {

--- a/packages/netsuite-adapter/src/filters/additional_changes.ts
+++ b/packages/netsuite-adapter/src/filters/additional_changes.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-import { getChangeData, isFieldChange, toChange, isAdditionOrModificationChange } from '@salto-io/adapter-api'
+import { getChangeData, toChange, isAdditionOrModificationChange, isField } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { getReferencedElements } from '../reference_dependencies'
 import { FilterCreator } from '../filter'
@@ -24,22 +24,22 @@ import { isStandardInstanceOrCustomRecordType } from '../types'
 const filterCreator: FilterCreator = ({ config }) => ({
   name: 'additionalChanges',
   preDeploy: async changes => {
-    const sdfChanges = changes
+    const sdfChangesData = changes
       // SDF objects deletions are handled by SOAP
       .filter(isAdditionOrModificationChange)
-      .filter(change => isStandardInstanceOrCustomRecordType(getChangeData(change)))
-
-    const [fieldChanges, typeAndInstanceChanges] = _.partition(sdfChanges, isFieldChange)
-    const elemIdSet = new Set(changes.map(getChangeData).map(elem => elem.elemID.getFullName()))
-    const fieldsParents = _(fieldChanges)
       .map(getChangeData)
+      .filter(isStandardInstanceOrCustomRecordType)
+
+    const [fields, typesAndInstances] = _.partition(sdfChangesData, isField)
+    const elemIdSet = new Set(changes.map(getChangeData).map(elem => elem.elemID.getFullName()))
+    const fieldsParents = _(fields)
       .map(field => field.parent)
       .filter(parent => !elemIdSet.has(parent.elemID.getFullName()))
       .uniqBy(parent => parent.elemID.getFullName())
       .value()
 
     const requiredElements = (await getReferencedElements(
-      typeAndInstanceChanges.map(getChangeData).concat(fieldsParents),
+      typesAndInstances.concat(fieldsParents),
       config.deploy?.deployReferencedElements ?? config.deployReferencedElements ?? DEFAULT_DEPLOY_REFERENCED_ELEMENTS
     )).map(elem => elem.clone())
 

--- a/packages/netsuite-adapter/test/change_validators/extra_reference_dependencies.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/extra_reference_dependencies.test.ts
@@ -14,17 +14,18 @@
 * limitations under the License.
 */
 import { ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
-import { fileType } from '../../src/types/file_cabinet_types'
 import { customsegmentType } from '../../src/autogen/types/standard_types/customsegment'
 import extraReferenceDependenciesValidator from '../../src/change_validators/extra_reference_dependencies'
-import { CUSTOM_RECORD_TYPE, METADATA_TYPE, NETSUITE, PATH, SCRIPT_ID } from '../../src/constants'
+import { CUSTOM_RECORD_TYPE, METADATA_TYPE, NETSUITE, SCRIPT_ID } from '../../src/constants'
+import { entitycustomfieldType } from '../../src/autogen/types/standard_types/entitycustomfield'
 
 
 describe('extra reference changes', () => {
   const customsegment = customsegmentType().type
+  const entitycustomfield = entitycustomfieldType().type
 
-  const fileInstance = new InstanceElement('file_instance', fileType(), {
-    [PATH]: 'Templates/E-mail Templates/Inner EmailTemplates Folder/content.html',
+  const entityFieldInstance = new InstanceElement('custentity_slt', entitycustomfield, {
+    [SCRIPT_ID]: 'custentity_slt',
   })
 
   const customRecordType = new ObjectType({
@@ -38,9 +39,9 @@ describe('extra reference changes', () => {
   const customSegmentInstance = new InstanceElement('custom_segment_instance', customsegment, {
     [SCRIPT_ID]: 'custom_segment_instance_script_id',
     description: new ReferenceExpression(
-      fileInstance.elemID.createNestedID(PATH),
-      fileInstance.value[PATH],
-      fileInstance
+      entityFieldInstance.elemID.createNestedID(SCRIPT_ID),
+      entityFieldInstance.value[SCRIPT_ID],
+      entityFieldInstance
     ),
   })
 
@@ -62,21 +63,21 @@ describe('extra reference changes', () => {
       customSegmentInstance
     ),
     description: new ReferenceExpression(
-      fileInstance.elemID.createNestedID(PATH),
-      fileInstance.value[PATH],
-      fileInstance
+      entityFieldInstance.elemID.createNestedID(SCRIPT_ID),
+      entityFieldInstance.value[SCRIPT_ID],
+      entityFieldInstance
     ),
   })
 
   // dependsOn2Instances ---> customSegmentInstance <---> customRecordType
   //        |                     |
-  //        '-->  fileInstance <--'
+  //        '-->  entityFieldInstance <--'
 
   it('should not have ChangeError when deploying an instance with its dependencies, when requesting to add only required references', async () => {
     const changeErrors = await extraReferenceDependenciesValidator([
       toChange({ before: customRecordType, after: customRecordType }),
       toChange({ after: customSegmentInstance }),
-      toChange({ before: fileInstance, after: fileInstance }),
+      toChange({ before: entityFieldInstance, after: entityFieldInstance }),
     ], false)
     expect(changeErrors).toHaveLength(0)
   })
@@ -85,7 +86,7 @@ describe('extra reference changes', () => {
     const changeErrors = await extraReferenceDependenciesValidator([
       toChange({ before: customRecordType, after: customRecordType }),
       toChange({ after: customSegmentInstance }),
-      toChange({ before: fileInstance, after: fileInstance }),
+      toChange({ before: entityFieldInstance, after: entityFieldInstance }),
     ], true)
     expect(changeErrors).toHaveLength(0)
   })
@@ -113,7 +114,7 @@ describe('extra reference changes', () => {
     ], true)
     expect(changeErrors).toHaveLength(2)
     const customSegmentInstanceElemId = customSegmentInstance.elemID.getFullName()
-    const fileInstanceElemId = fileInstance.elemID.getFullName()
+    const fileInstanceElemId = entityFieldInstance.elemID.getFullName()
     const missingReferences = `(.*${customSegmentInstanceElemId}, ${fileInstanceElemId}.*)|(.*${fileInstanceElemId}, ${customSegmentInstanceElemId}.*)`
     expect(changeErrors)
       .toEqual(expect.arrayContaining([

--- a/packages/netsuite-adapter/test/filters/additional_changes.test.ts
+++ b/packages/netsuite-adapter/test/filters/additional_changes.test.ts
@@ -118,5 +118,12 @@ describe('additional changes filter', () => {
       expect(requiredInstanceChange.action).toEqual('add')
       expect(getChangeData(requiredInstanceChange)).toBe(customSegmentInstance)
     })
+    it('should not add required referenced element if it\'s a deletion change', async () => {
+      const changes: Change[] = [
+        toChange({ before: customRecordType }),
+      ]
+      await filterCreator(noParams).preDeploy?.(changes)
+      expect(changes).toHaveLength(1)
+    })
   })
 })


### PR DESCRIPTION
We should add/warn about additional changes for SDF objects only.
There was a case now when we added additional changes for a file element, because it had generated dependencies for `translationcollection` instance that is required in SDF objects deploy - but for file elements we shouldn't add it.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Add/warn about additional changes for SDF objects only

---
_User Notifications_: 
None
