### PR TITLE
SALTO-3600, SALTO-3393: Add missing references to Okta

### DIFF
--- a/packages/adapter-components/src/references/field_references.ts
+++ b/packages/adapter-components/src/references/field_references.ts
@@ -14,8 +14,8 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { Field, Element, isInstanceElement, Value, Values, ReferenceExpression, InstanceElement, ElemID, cloneDeepWithoutRefs, isElement, ObjectType } from '@salto-io/adapter-api'
-import { GetLookupNameFunc, GetLookupNameFuncArgs, TransformFunc, transformValues, safeJsonStringify, resolvePath, naclCase } from '@salto-io/adapter-utils'
+import { Field, Element, isInstanceElement, Value, Values, ReferenceExpression, InstanceElement, ElemID, cloneDeepWithoutRefs, isElement } from '@salto-io/adapter-api'
+import { GetLookupNameFunc, GetLookupNameFuncArgs, TransformFunc, transformValues, safeJsonStringify, resolvePath } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { values as lowerDashValues, collections, multiIndex } from '@salto-io/lowerdash'
 import {
@@ -27,6 +27,7 @@ import {
   ReferenceSourceTransformation,
 } from './reference_mapping'
 import { ContextFunc } from './context'
+import { checkMissingRef } from './missing_references'
 
 const { awu } = collections.asynciterable
 
@@ -36,26 +37,6 @@ const { isDefined } = lowerDashValues
 const doNothing: ContextFunc = async () => undefined
 
 const emptyContextStrategyLookup: Record<string, ContextFunc> = {}
-
-export const MISSING_ANNOTATION = 'salto_missing_ref'
-const MISSING_REF_PREFIX = 'missing_'
-
-const checkMissingRef = (element: Element): boolean =>
-  element.annotations?.[MISSING_ANNOTATION] === true
-
-export const createMissingInstance = (
-  adapter: string,
-  typeName: string,
-  refName: string
-): InstanceElement => (
-  new InstanceElement(
-    naclCase(`${MISSING_REF_PREFIX}${refName}`),
-    new ObjectType({ elemID: new ElemID(adapter, typeName) }),
-    {},
-    undefined,
-    { [MISSING_ANNOTATION]: true },
-  )
-)
 
 const isRelativeSerializer = (serializer: ReferenceSerializationStrategy)
   : serializer is ReferenceSerializationStrategy & { getReferenceId: GetReferenceIdFunc } =>

--- a/packages/adapter-components/src/references/field_references.ts
+++ b/packages/adapter-components/src/references/field_references.ts
@@ -14,8 +14,8 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { Field, Element, isInstanceElement, Value, Values, ReferenceExpression, InstanceElement, ElemID, cloneDeepWithoutRefs, isElement } from '@salto-io/adapter-api'
-import { GetLookupNameFunc, GetLookupNameFuncArgs, TransformFunc, transformValues, safeJsonStringify, resolvePath } from '@salto-io/adapter-utils'
+import { Field, Element, isInstanceElement, Value, Values, ReferenceExpression, InstanceElement, ElemID, cloneDeepWithoutRefs, isElement, ObjectType } from '@salto-io/adapter-api'
+import { GetLookupNameFunc, GetLookupNameFuncArgs, TransformFunc, transformValues, safeJsonStringify, resolvePath, naclCase } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { values as lowerDashValues, collections, multiIndex } from '@salto-io/lowerdash'
 import {
@@ -38,8 +38,24 @@ const doNothing: ContextFunc = async () => undefined
 const emptyContextStrategyLookup: Record<string, ContextFunc> = {}
 
 export const MISSING_ANNOTATION = 'salto_missing_ref'
+const MISSING_REF_PREFIX = 'missing_'
+
 const checkMissingRef = (element: Element): boolean =>
   element.annotations?.[MISSING_ANNOTATION] === true
+
+export const createMissingInstance = (
+  adapter: string,
+  typeName: string,
+  refName: string
+): InstanceElement => (
+  new InstanceElement(
+    naclCase(`${MISSING_REF_PREFIX}${refName}`),
+    new ObjectType({ elemID: new ElemID(adapter, typeName) }),
+    {},
+    undefined,
+    { [MISSING_ANNOTATION]: true },
+  )
+)
 
 const isRelativeSerializer = (serializer: ReferenceSerializationStrategy)
   : serializer is ReferenceSerializationStrategy & { getReferenceId: GetReferenceIdFunc } =>

--- a/packages/adapter-components/src/references/index.ts
+++ b/packages/adapter-components/src/references/index.ts
@@ -14,7 +14,8 @@
 * limitations under the License.
 */
 export { neighborContextGetter, ContextFunc, ContextValueMapperFunc, findParentPath } from './context'
-export { addReferences, replaceReferenceValues, generateLookupFunc, createMissingInstance } from './field_references'
+export { addReferences, replaceReferenceValues, generateLookupFunc } from './field_references'
+export { createMissingInstance } from './missing_references'
 export {
   ReferenceSerializationStrategy,
   ReferenceSerializationStrategyName,

--- a/packages/adapter-components/src/references/index.ts
+++ b/packages/adapter-components/src/references/index.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 export { neighborContextGetter, ContextFunc, ContextValueMapperFunc, findParentPath } from './context'
-export { addReferences, replaceReferenceValues, generateLookupFunc, MISSING_ANNOTATION } from './field_references'
+export { addReferences, replaceReferenceValues, generateLookupFunc, createMissingInstance } from './field_references'
 export {
   ReferenceSerializationStrategy,
   ReferenceSerializationStrategyName,

--- a/packages/adapter-components/src/references/missing_references.ts
+++ b/packages/adapter-components/src/references/missing_references.ts
@@ -1,0 +1,37 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Element, ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import { naclCase } from '@salto-io/adapter-utils'
+
+export const MISSING_ANNOTATION = 'salto_missing_ref'
+const MISSING_REF_PREFIX = 'missing_'
+
+export const checkMissingRef = (element: Element): boolean =>
+  element.annotations?.[MISSING_ANNOTATION] === true
+
+export const createMissingInstance = (
+  adapter: string,
+  typeName: string,
+  refName: string
+): InstanceElement => (
+  new InstanceElement(
+    naclCase(`${MISSING_REF_PREFIX}${refName}`),
+    new ObjectType({ elemID: new ElemID(adapter, typeName) }),
+    {},
+    undefined,
+    { [MISSING_ANNOTATION]: true },
+  )
+)

--- a/packages/adapter-components/src/references/reference_mapping.ts
+++ b/packages/adapter-components/src/references/reference_mapping.ts
@@ -101,7 +101,7 @@ ReferenceSourceTransformation
 export type MissingReferenceStrategy = {
   create: CreateMissingRefFunc
 }
-export type MissingReferenceStrategyName = 'typeAndValue' | 'startsWith'
+export type MissingReferenceStrategyName = 'typeAndValue'
 
 type MetadataTypeArgs<T extends string> = {
   type: string

--- a/packages/adapter-components/test/references/field_references.test.ts
+++ b/packages/adapter-components/test/references/field_references.test.ts
@@ -15,7 +15,7 @@
 */
 import { ElemID, InstanceElement, ObjectType, ReferenceExpression, Element, BuiltinTypes, isInstanceElement, ListType, createRefToElmWithValue, Field } from '@salto-io/adapter-api'
 import { GetLookupNameFunc } from '@salto-io/adapter-utils'
-import { addReferences, generateLookupFunc } from '../../src/references/field_references'
+import { addReferences, createMissingInstance, generateLookupFunc, MISSING_ANNOTATION } from '../../src/references/field_references'
 import { FieldReferenceDefinition, FieldReferenceResolver, ReferenceSerializationStrategy, ReferenceSerializationStrategyLookup, ReferenceSerializationStrategyName } from '../../src/references/reference_mapping'
 import { ContextValueMapperFunc, ContextFunc, neighborContextGetter } from '../../src/references'
 
@@ -728,6 +728,15 @@ describe('Field references', () => {
         e => isInstanceElement(e) && e.elemID.name === 'inst1'
       )[0] as InstanceElement
       expect(inst.value.value).toEqual('fail')
+    })
+  })
+
+  describe('createMissingInstance', () => {
+    it('should create missing instance with the correct elemID, type and annotations', () => {
+      const result = createMissingInstance('adapterTest', 'someType', '123456')
+      expect(result.elemID.getFullName()).toEqual('adapterTest.someType.instance.missing_123456')
+      expect(result.refType.elemID.typeName).toEqual('someType')
+      expect(result.annotations[MISSING_ANNOTATION]).toEqual(true)
     })
   })
 })

--- a/packages/adapter-components/test/references/field_references.test.ts
+++ b/packages/adapter-components/test/references/field_references.test.ts
@@ -15,7 +15,7 @@
 */
 import { ElemID, InstanceElement, ObjectType, ReferenceExpression, Element, BuiltinTypes, isInstanceElement, ListType, createRefToElmWithValue, Field } from '@salto-io/adapter-api'
 import { GetLookupNameFunc } from '@salto-io/adapter-utils'
-import { addReferences, createMissingInstance, generateLookupFunc, MISSING_ANNOTATION } from '../../src/references/field_references'
+import { addReferences, generateLookupFunc } from '../../src/references/field_references'
 import { FieldReferenceDefinition, FieldReferenceResolver, ReferenceSerializationStrategy, ReferenceSerializationStrategyLookup, ReferenceSerializationStrategyName } from '../../src/references/reference_mapping'
 import { ContextValueMapperFunc, ContextFunc, neighborContextGetter } from '../../src/references'
 
@@ -728,15 +728,6 @@ describe('Field references', () => {
         e => isInstanceElement(e) && e.elemID.name === 'inst1'
       )[0] as InstanceElement
       expect(inst.value.value).toEqual('fail')
-    })
-  })
-
-  describe('createMissingInstance', () => {
-    it('should create missing instance with the correct elemID, type and annotations', () => {
-      const result = createMissingInstance('adapterTest', 'someType', '123456')
-      expect(result.elemID.getFullName()).toEqual('adapterTest.someType.instance.missing_123456')
-      expect(result.refType.elemID.typeName).toEqual('someType')
-      expect(result.annotations[MISSING_ANNOTATION]).toEqual(true)
     })
   })
 })

--- a/packages/adapter-components/test/references/missing_references.test.ts
+++ b/packages/adapter-components/test/references/missing_references.test.ts
@@ -1,0 +1,38 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import { createMissingInstance, MISSING_ANNOTATION, checkMissingRef } from '../../src/references/missing_references'
+
+describe('missingReferences', () => {
+  describe('createMissingInstance', () => {
+    it('should create missing instance with the correct elemID, type and annotations', () => {
+      const result = createMissingInstance('adapterTest', 'someType', '123456')
+      expect(result.elemID.getFullName()).toEqual('adapterTest.someType.instance.missing_123456')
+      expect(result.refType.elemID.typeName).toEqual('someType')
+      expect(result.annotations[MISSING_ANNOTATION]).toEqual(true)
+    })
+  })
+
+  describe('checkMissingRef', () => {
+    const type = new ObjectType({ elemID: new ElemID('adapter', 'type') })
+    type.annotations[MISSING_ANNOTATION] = true
+    const instance = new InstanceElement('inst', type, {}, undefined, { [MISSING_ANNOTATION]: true })
+    it('should check missing ref annotation', () => {
+      expect(checkMissingRef(instance)).toEqual(true)
+      expect(checkMissingRef(type)).toEqual(true)
+    })
+  })
+})

--- a/packages/zendesk-adapter/src/filters/article/article_body.ts
+++ b/packages/zendesk-adapter/src/filters/article/article_body.ts
@@ -19,6 +19,7 @@ import { Change, Element, getChangeData, InstanceElement, isAdditionOrModificati
   isInstanceChange, isInstanceElement, isReferenceExpression, ReferenceExpression,
   SaltoError, TemplateExpression, TemplatePart } from '@salto-io/adapter-api'
 import { applyFunctionToChangeData, extractTemplate, getParent, replaceTemplatesWithValues, resolveTemplates, safeJsonStringify } from '@salto-io/adapter-utils'
+import { references as referencesUtils } from '@salto-io/adapter-components'
 import { collections, values as lowerDashValues } from '@salto-io/lowerdash'
 import wu from 'wu'
 import { FilterCreator } from '../../filter'
@@ -31,13 +32,13 @@ import {
   CATEGORY_TYPE_NAME,
   SECTION_TYPE_NAME, SECTIONS_FIELD, ZENDESK,
 } from '../../constants'
-import { createMissingInstance } from '../references/missing_references'
 import { FETCH_CONFIG } from '../../config'
 import { getBrandsForGuide } from '../utils'
 
 const log = logger(module)
 const { awu } = collections.asynciterable
 const { isDefined } = lowerDashValues
+const { createMissingInstance } = referencesUtils
 
 
 const BODY_FIELD = 'body'

--- a/packages/zendesk-adapter/src/filters/dynamic_content_references.ts
+++ b/packages/zendesk-adapter/src/filters/dynamic_content_references.ts
@@ -26,15 +26,16 @@ import {
   TemplatePart,
 } from '@salto-io/adapter-api'
 import { extractTemplate, transformValues } from '@salto-io/adapter-utils'
+import { references as referencesUtils } from '@salto-io/adapter-components'
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { FilterCreator } from '../filter'
 import { DYNAMIC_CONTENT_ITEM_TYPE_NAME } from './dynamic_content'
-import { createMissingInstance } from './references/missing_references'
 import { ZENDESK } from '../constants'
 import { FETCH_CONFIG } from '../config'
 
 const { awu } = collections.asynciterable
+const { createMissingInstance } = referencesUtils
 const PLACEHOLDER_REGEX = /({{.+?}})/g
 const INNER_PLACEHOLDER_REGEX = /{{(.+?)}}/g
 const OPEN_BRACKETS = '{{'

--- a/packages/zendesk-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-adapter/src/filters/field_references.ts
@@ -32,7 +32,7 @@ import {
   HOLD_CATEGORY, SOLVED_CATEGORY,
 } from '../constants'
 import { FETCH_CONFIG } from '../config'
-import { ZendeskMissingReferenceStrategyLookup } from './references/missing_references'
+import { ZendeskMissingReferenceStrategyLookup, ZendeskMissingReferenceStrategyName } from './references/missing_references'
 
 const { neighborContextGetter } = referenceUtils
 
@@ -274,7 +274,7 @@ type ZendeskFieldReferenceDefinition = referenceUtils.FieldReferenceDefinition<
 > & {
   zendeskSerializationStrategy?: ZendeskReferenceSerializationStrategyName
   // Strategy for non-list values. For list values please check listValuesMissingRefereces filter
-  zendeskMissingRefStrategy?: referenceUtils.MissingReferenceStrategyName
+  zendeskMissingRefStrategy?: ZendeskMissingReferenceStrategyName
 }
 
 export class ZendeskFieldReferenceResolver extends referenceUtils.FieldReferenceResolver<

--- a/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
@@ -18,12 +18,12 @@ import {
   ReferenceExpression, TemplateExpression, TemplatePart, Values,
 } from '@salto-io/adapter-api'
 import { extractTemplate, TemplateContainer, replaceTemplatesWithValues, resolveTemplates } from '@salto-io/adapter-utils'
+import { references as referencesUtils } from '@salto-io/adapter-components'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { FilterCreator } from '../filter'
 import { DYNAMIC_CONTENT_ITEM_TYPE_NAME } from './dynamic_content'
-import { createMissingInstance } from './references/missing_references'
 import {
   ZENDESK,
   TICKET_FIELD_TYPE_NAME,
@@ -33,6 +33,7 @@ import { FETCH_CONFIG } from '../config'
 
 
 const { awu } = collections.asynciterable
+const { createMissingInstance } = referencesUtils
 const log = logger(module)
 const BRACKETS = [['{{', '}}'], ['{%', '%}']]
 const REFERENCE_MARKER_REGEX = /\$\{(.+?)}/

--- a/packages/zendesk-adapter/src/filters/references/list_values_missing_references.ts
+++ b/packages/zendesk-adapter/src/filters/references/list_values_missing_references.ts
@@ -15,10 +15,12 @@
 */
 import _ from 'lodash'
 import { Element, isInstanceElement, isReferenceExpression, ReferenceExpression } from '@salto-io/adapter-api'
+import { references as referencesUtils } from '@salto-io/adapter-components'
 import { FETCH_CONFIG } from '../../config'
 import { FilterCreator } from '../../filter'
-import { createMissingInstance, VALUES_TO_SKIP_BY_TYPE } from './missing_references'
+import { VALUES_TO_SKIP_BY_TYPE } from './missing_references'
 
+const { createMissingInstance } = referencesUtils
 
 type FieldMissingReferenceDefinition = {
   instanceType: string

--- a/packages/zendesk-adapter/src/filters/references/missing_references.ts
+++ b/packages/zendesk-adapter/src/filters/references/missing_references.ts
@@ -15,12 +15,10 @@
 */
 
 import _ from 'lodash'
-import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
 import { references as referenceUtils } from '@salto-io/adapter-components'
-import { naclCase } from '@salto-io/adapter-utils'
 import { ORG_FIELD_TYPE_NAME, TICKET_FIELD_TYPE_NAME, USER_FIELD_TYPE_NAME } from '../../constants'
 
-const MISSING_REF_PREFIX = 'missing_'
+export type ZendeskMissingReferenceStrategyName = referenceUtils.MissingReferenceStrategyName | 'startsWith'
 
 export const VALUES_TO_SKIP_BY_TYPE: Record<string, string[]> = {
   group: ['current_groups', 'group_id'],
@@ -33,29 +31,15 @@ const VALUE_BY_TYPE: Record<string, string> = {
   [ORG_FIELD_TYPE_NAME]: 'organization.custom_fields.',
 }
 
-export const createMissingInstance = (
-  adapter: string,
-  typeName: string,
-  refName: string
-): InstanceElement => (
-  new InstanceElement(
-    naclCase(`${MISSING_REF_PREFIX}${refName}`),
-    new ObjectType({ elemID: new ElemID(adapter, typeName) }),
-    {},
-    undefined,
-    { [referenceUtils.MISSING_ANNOTATION]: true },
-  )
-)
-
 export const ZendeskMissingReferenceStrategyLookup: Record<
-referenceUtils.MissingReferenceStrategyName, referenceUtils.MissingReferenceStrategy
+ZendeskMissingReferenceStrategyName, referenceUtils.MissingReferenceStrategy
 > = {
   typeAndValue: {
     create: ({ value, adapter, typeName }) => {
       if (!_.isString(typeName) || !value || VALUES_TO_SKIP_BY_TYPE[typeName]?.includes(value)) {
         return undefined
       }
-      return createMissingInstance(adapter, typeName, value)
+      return referenceUtils.createMissingInstance(adapter, typeName, value)
     },
   },
   startsWith: {
@@ -65,7 +49,7 @@ referenceUtils.MissingReferenceStrategyName, referenceUtils.MissingReferenceStra
         && !VALUES_TO_SKIP_BY_TYPE[typeName]?.includes(value)
         && value.startsWith(VALUE_BY_TYPE[typeName])
       ) {
-        return createMissingInstance(adapter, typeName, value)
+        return referenceUtils.createMissingInstance(adapter, typeName, value)
       }
       return undefined
     },

--- a/packages/zendesk-adapter/src/filters/side_conversation.ts
+++ b/packages/zendesk-adapter/src/filters/side_conversation.ts
@@ -21,16 +21,17 @@ import {
   TemplateExpression,
   Value,
 } from '@salto-io/adapter-api'
+import { references as referencesUtils } from '@salto-io/adapter-components'
 import _ from 'lodash'
 import joi from 'joi'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
 import { GROUP_TYPE_NAME, ZENDESK } from '../constants'
-import { createMissingInstance } from './references/missing_references'
 import { FETCH_CONFIG } from '../config'
 import { TYPES_WITH_SIDE_CONVERSATIONS } from '../change_validators/side_conversation'
 
 const log = logger(module)
+const { createMissingInstance } = referencesUtils
 
 const SIDE_CONVERSATION_FIELD_NAME = 'side_conversation_ticket'
 const valueWithGroupRegex = /(?<prefix>.+\/group\/)(?<groupId>\d+)(?<suffix>.*)/

--- a/packages/zendesk-adapter/test/filters/article/article_body.test.ts
+++ b/packages/zendesk-adapter/test/filters/article/article_body.test.ts
@@ -15,7 +15,7 @@
 */
 import { ElemID, InstanceElement, ObjectType,
   BuiltinTypes, toChange, isInstanceElement, TemplateExpression, ReferenceExpression, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
-import { filterUtils } from '@salto-io/adapter-components'
+import { filterUtils, references as referencesUtils } from '@salto-io/adapter-components'
 import filterCreator from '../../../src/filters/article/article_body'
 import {
   ARTICLE_ATTACHMENT_TYPE_NAME, ARTICLE_ATTACHMENTS_FIELD,
@@ -28,8 +28,9 @@ import {
 } from '../../../src/constants'
 import { createFilterCreatorParams } from '../../utils'
 import { DEFAULT_CONFIG, FETCH_CONFIG } from '../../../src/config'
-import { createMissingInstance } from '../../../src/filters/references/missing_references'
 import { FilterResult } from '../../../src/filter'
+
+const { createMissingInstance } = referencesUtils
 
 describe('article body filter', () => {
   type FilterType = filterUtils.FilterWith<'onFetch' | 'onDeploy' | 'preDeploy', FilterResult>

--- a/packages/zendesk-adapter/test/filters/dynamic_content_references.test.ts
+++ b/packages/zendesk-adapter/test/filters/dynamic_content_references.test.ts
@@ -18,12 +18,13 @@ import {
   toChange,
   ListType,
 } from '@salto-io/adapter-api'
-import { filterUtils } from '@salto-io/adapter-components'
+import { filterUtils, references as referencesUtils } from '@salto-io/adapter-components'
 import { ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/dynamic_content_references'
 import { DYNAMIC_CONTENT_ITEM_TYPE_NAME } from '../../src/filters/dynamic_content'
-import { createMissingInstance } from '../../src/filters/references/missing_references'
 import { createFilterCreatorParams } from '../utils'
+
+const { createMissingInstance } = referencesUtils
 
 describe('dynamic content references filter', () => {
   type FilterType = filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>

--- a/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
+++ b/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
@@ -15,15 +15,16 @@
 */
 import { ElemID, InstanceElement, ObjectType, ReferenceExpression,
   BuiltinTypes, TemplateExpression, MapType, toChange, isInstanceElement } from '@salto-io/adapter-api'
-import { filterUtils } from '@salto-io/adapter-components'
+import { filterUtils, references as referencesUtils } from '@salto-io/adapter-components'
 import filterCreator, {
   TICKET_ORGANIZATION_FIELD,
   TICKET_TICKET_FIELD_OPTION_TITLE,
   TICKET_TICKET_FIELD, TICKET_USER_FIELD,
 } from '../../src/filters/handle_template_expressions'
 import { ORG_FIELD_TYPE_NAME, USER_FIELD_TYPE_NAME, ZENDESK } from '../../src/constants'
-import { createMissingInstance } from '../../src/filters/references/missing_references'
 import { createFilterCreatorParams } from '../utils'
+
+const { createMissingInstance } = referencesUtils
 
 describe('handle templates filter', () => {
   type FilterType = filterUtils.FilterWith<'onFetch' | 'onDeploy' | 'preDeploy'>

--- a/packages/zendesk-adapter/test/filters/side_conversation.test.ts
+++ b/packages/zendesk-adapter/test/filters/side_conversation.test.ts
@@ -13,13 +13,14 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { filterUtils } from '@salto-io/adapter-components'
+import { filterUtils, references as referencesUtils } from '@salto-io/adapter-components'
 import { ElemID, InstanceElement, ObjectType, ReferenceExpression, Value } from '@salto-io/adapter-api'
 import sideConversationFilter from '../../src/filters/side_conversation'
 import { createFilterCreatorParams } from '../utils'
 import { GROUP_TYPE_NAME, MACRO_TYPE_NAME, TRIGGER_TYPE_NAME, ZENDESK } from '../../src/constants'
-import { createMissingInstance } from '../../src/filters/references/missing_references'
 import { DEFAULT_CONFIG, FETCH_CONFIG } from '../../src/config'
+
+const { createMissingInstance } = referencesUtils
 
 const groupType = new ObjectType({ elemID: new ElemID(ZENDESK, GROUP_TYPE_NAME) })
 const triggerType = new ObjectType({ elemID: new ElemID(ZENDESK, TRIGGER_TYPE_NAME) })


### PR DESCRIPTION
Add missing references to Okta

---

Add missing references to Okta & move shared code from zendesk to adapter-components
Didn't add config flag as we have in zendesk, if u think it's necessary lmk

---
_Release Notes_: 
None

---
_User Notifications_: 
None
