### PR TITLE
SALTO-3932: Add deploy for AuthorizationServerPolicy & AuthorizationServerPolicyRule

### DIFF
--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -39,6 +39,7 @@ import userSchemaFilter from './filters/user_schema'
 import oktaExpressionLanguageFilter from './filters/expression_language'
 import defaultPolicyRuleDeployment from './filters/default_rule_deployment'
 import policyRuleRemoval from './filters/policy_rule_removal'
+import authorizationRuleFilter from './filters/authorization_server_rule'
 import userFilter from './filters/user'
 import { OKTA } from './constants'
 import { getLookUpName } from './reference_mapping'
@@ -60,6 +61,7 @@ export const DEFAULT_FILTERS = [
   standardRolesFilter,
   userTypeFilter,
   userSchemaFilter,
+  authorizationRuleFilter,
   // should run before fieldReferencesFilter
   urlReferencesFilter,
   // should run before fieldReferencesFilter

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -537,6 +537,47 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
       fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),
       standaloneFields: [{ fieldName: 'policyRules' }],
     },
+    deployRequests: {
+      add: {
+        url: '/api/v1/authorizationServers/{authorizationServerId}/policies',
+        method: 'post',
+        urlParamsToFields: {
+          authorizationServerId: '_parent.0.id',
+        },
+      },
+      modify: {
+        url: '/api/v1/authorizationServers/{authorizationServerId}/policies/{policyId}',
+        method: 'put',
+        urlParamsToFields: {
+          authorizationServerId: '_parent.0.id',
+          policyId: 'id',
+        },
+      },
+      remove: {
+        url: '/api/v1/authorizationServers/{authorizationServerId}/policies/{policyId}',
+        method: 'put',
+        urlParamsToFields: {
+          authorizationServerId: '_parent.0.id',
+          policyId: 'id',
+        },
+      },
+      activate: {
+        url: '/api/v1/authorizationServers/{authorizationServerId}/policies/{policyId}/lifecycle/activate',
+        method: 'post',
+        urlParamsToFields: {
+          authorizationServerId: '_parent.0.id',
+          policyId: 'id',
+        },
+      },
+      deactivate: {
+        url: '/api/v1/authorizationServers/{authorizationServerId}/policies/{policyId}/lifecycle/deactivate',
+        method: 'post',
+        urlParamsToFields: {
+          authorizationServerId: '_parent.0.id',
+          policyId: 'id',
+        },
+      },
+    },
   },
   AuthorizationServerPolicyRule: {
     transformation: {
@@ -544,6 +585,52 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
       fieldsToHide: [{ fieldName: 'id' }],
       fieldTypeOverrides: [{ fieldName: '_links', fieldType: 'LinksSelf' }],
       fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),
+    },
+    deployRequests: {
+      add: {
+        url: '/api/v1/authorizationServers/{authorizationServerId}/policies/{policyId}/rules',
+        method: 'post',
+        urlParamsToFields: {
+          authorizationServerId: '_parent.1.id',
+          policyId: '_parent.0.id',
+        },
+      },
+      modify: {
+        url: '/api/v1/authorizationServers/{authorizationServerId}/policies/{policyId}/rules/{ruleId}',
+        method: 'put',
+        urlParamsToFields: {
+          authorizationServerId: '_parent.1.id',
+          policyId: '_parent.0.id',
+          ruleId: 'id',
+        },
+      },
+      remove: {
+        url: '/api/v1/authorizationServers/{authorizationServerId}/policies/{policyId}/rules/{ruleId}',
+        method: 'delete',
+        urlParamsToFields: {
+          authorizationServerId: '_parent.1.id',
+          policyId: '_parent.0.id',
+          ruleId: 'id',
+        },
+      },
+      activate: {
+        url: '/api/v1/authorizationServers/{authorizationServerId}/policies/{policyId}/rules/{ruleId}/lifecycle/activate',
+        method: 'post',
+        urlParamsToFields: {
+          authorizationServerId: '_parent.1.id',
+          policyId: '_parent.0.id',
+          ruleId: 'id',
+        },
+      },
+      deactivate: {
+        url: '/api/v1/authorizationServers/{authorizationServerId}/policies/{policyId}/rules/{ruleId}/lifecycle/deactivate',
+        method: 'post',
+        urlParamsToFields: {
+          authorizationServerId: '_parent.1.id',
+          policyId: '_parent.0.id',
+          ruleId: 'id',
+        },
+      },
     },
   },
   api__v1__brands: {

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -555,7 +555,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaApiConfig['types'] = {
       },
       remove: {
         url: '/api/v1/authorizationServers/{authorizationServerId}/policies/{policyId}',
-        method: 'put',
+        method: 'delete',
         urlParamsToFields: {
           authorizationServerId: '_parent.0.id',
           policyId: 'id',

--- a/packages/okta-adapter/src/constants.ts
+++ b/packages/okta-adapter/src/constants.ts
@@ -39,6 +39,7 @@ export const IDP_RULE_TYPE_NAME = 'IdentityProviderPolicyRule'
 export const MFA_RULE_TYPE_NAME = 'MultifactorEnrollmentPolicyRule'
 export const SIGN_ON_RULE_TYPE_NAME = 'OktaSignOnPolicyRule'
 export const PASSWORD_RULE_TYPE_NAME = 'PasswordPolicyRule'
+export const AUTHORIZATION_POLICY_RULE = 'AuthorizationServerPolicyRule'
 export const ACTIVE_STATUS = 'ACTIVE'
 export const INACTIVE_STATUS = 'INACTIVE'
 export const POLICY_TYPE_NAMES = [ACCESS_POLICY_TYPE_NAME, IDP_POLICY_TYPE_NAME, MFA_POLICY_TYPE_NAME,

--- a/packages/okta-adapter/src/filters/authorization_server_rule.ts
+++ b/packages/okta-adapter/src/filters/authorization_server_rule.ts
@@ -1,0 +1,48 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { logger } from '@salto-io/logging'
+import { getParent } from '@salto-io/adapter-utils'
+import { CORE_ANNOTATIONS, isInstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
+import { FilterCreator } from '../filter'
+import { AUTHORIZATION_POLICY_RULE } from '../constants'
+
+const log = logger(module)
+
+/**
+ * Add AuthorizationServer instance as a second parent to the associated AuthorizationServerPolicyRule instance
+ */
+const filter: FilterCreator = () => ({
+  name: 'authorizationServerPolicyRuleFilter',
+  onFetch: async elements => {
+    elements
+      .filter(isInstanceElement)
+      .filter(instance => instance.elemID.typeName === AUTHORIZATION_POLICY_RULE)
+      .forEach(instance => {
+        try {
+          const parentPolicy = getParent(instance)
+          const parentAuthorizationServerId = getParent(parentPolicy)
+          const parents = instance.annotations[CORE_ANNOTATIONS.PARENT]
+          if (Array.isArray(parents)) {
+            parents.push(new ReferenceExpression(parentAuthorizationServerId.elemID, parentAuthorizationServerId))
+          }
+        } catch (error) {
+          log.error(`Could not run authorizationServerPolicyRuleFilter for instance ${instance.elemID.getFullName()}, error: ${error}`)
+        }
+      })
+  },
+})
+
+export default filter

--- a/packages/okta-adapter/src/filters/user.ts
+++ b/packages/okta-adapter/src/filters/user.ts
@@ -21,7 +21,7 @@ import { collections } from '@salto-io/lowerdash'
 import { Change, getChangeData, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { FilterCreator } from '../filter'
-import { ACCESS_POLICY_RULE_TYPE_NAME, GROUP_RULE_TYPE_NAME, MFA_RULE_TYPE_NAME, PASSWORD_RULE_TYPE_NAME, SIGN_ON_RULE_TYPE_NAME } from '../constants'
+import { ACCESS_POLICY_RULE_TYPE_NAME, AUTHORIZATION_POLICY_RULE, GROUP_RULE_TYPE_NAME, MFA_RULE_TYPE_NAME, PASSWORD_RULE_TYPE_NAME, SIGN_ON_RULE_TYPE_NAME } from '../constants'
 import { FETCH_CONFIG } from '../config'
 
 const log = logger(module)
@@ -57,6 +57,7 @@ const USER_MAPPING: Record<string, string[][]> = {
   [PASSWORD_RULE_TYPE_NAME]: [EXCLUDE_USERS_PATH],
   [SIGN_ON_RULE_TYPE_NAME]: [EXCLUDE_USERS_PATH],
   [MFA_RULE_TYPE_NAME]: [EXCLUDE_USERS_PATH],
+  [AUTHORIZATION_POLICY_RULE]: [INCLUDE_USERS_PATH],
 }
 
 const isRelevantInstance = (instance: InstanceElement): boolean => (

--- a/packages/okta-adapter/test/filters/authorization_server_rule.test.ts
+++ b/packages/okta-adapter/test/filters/authorization_server_rule.test.ts
@@ -1,0 +1,87 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { ObjectType, ElemID, InstanceElement, CORE_ANNOTATIONS, ReferenceExpression, isInstanceElement } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import { AUTHORIZATION_POLICY_RULE, OKTA } from '../../src/constants'
+import authorizationServerPolicyRuleFilter from '../../src/filters/authorization_server_rule'
+import { getFilterParams } from '../utils'
+
+describe('authorizationServerPolicyRuleFilter', () => {
+  let filter: filterUtils.FilterWith<'onFetch'>
+  const authServerType = new ObjectType({ elemID: new ElemID(OKTA, 'AuthorizationServer') })
+  const authPolicyType = new ObjectType({ elemID: new ElemID(OKTA, 'AuthorizationServerPolicy') })
+  const authRuleType = new ObjectType({ elemID: new ElemID(OKTA, AUTHORIZATION_POLICY_RULE) })
+
+  const authServerInstance = new InstanceElement(
+    'server',
+    authServerType,
+    { id: '1', name: 'server' }
+  )
+
+  const authPolicyInstance = new InstanceElement(
+    'policy',
+    authPolicyType,
+    { id: '2', name: 'policy' },
+    undefined,
+    { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(authServerInstance.elemID, authServerInstance)] }
+  )
+
+  const authRuleInstance = new InstanceElement(
+    'rule',
+    authRuleType,
+    { id: '3', name: 'rule' },
+    undefined,
+    { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(authPolicyInstance.elemID, authPolicyInstance)] }
+  )
+
+  beforeEach(() => {
+    filter = authorizationServerPolicyRuleFilter(getFilterParams()) as typeof filter
+  })
+
+  describe('OnFetch', () => {
+    it('should add authorization server as another parent to auhorization server policy rule instance', async () => {
+      const elements = [authServerType, authPolicyType, authRuleType, authServerInstance,
+        authPolicyInstance, authRuleInstance.clone()]
+      await filter.onFetch(elements)
+      const rule = elements.filter(isInstanceElement).find(i => i.elemID.typeName === AUTHORIZATION_POLICY_RULE)
+      expect(rule?.annotations[CORE_ANNOTATIONS.PARENT]).toHaveLength(2)
+      expect((rule?.annotations[CORE_ANNOTATIONS.PARENT][1] as ReferenceExpression).elemID.getFullName())
+        .toEqual('okta.AuthorizationServer.instance.server')
+    })
+    it('should not add another parent if there was a problem with getting parent', async () => {
+      const authPolicyNoParent = new InstanceElement(
+        'test',
+        authPolicyType,
+        { id: '4', name: 'policy' },
+      )
+      const authRuleInstance2 = new InstanceElement(
+        'rule',
+        authRuleType,
+        { id: '3', name: 'rule' },
+        undefined,
+        { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(authPolicyNoParent.elemID, authPolicyNoParent)] }
+      )
+      const elements = [authServerType, authPolicyType, authRuleType, authServerInstance,
+        authPolicyNoParent, authRuleInstance2]
+      await filter.onFetch(elements)
+      const rule = elements.filter(isInstanceElement).find(i => i.elemID.typeName === AUTHORIZATION_POLICY_RULE)
+      expect(rule?.annotations[CORE_ANNOTATIONS.PARENT]).toHaveLength(1)
+      expect((rule?.annotations[CORE_ANNOTATIONS.PARENT][0] as ReferenceExpression).elemID.getFullName())
+        .toEqual('okta.AuthorizationServerPolicy.instance.test')
+    })
+  })
+})


### PR DESCRIPTION
Support deployment of `AuthorizationServerPolicy` and `AuthorizationServerPolicyRule` instances

---

In order to deploy `AuthorizationServerPolicyRule`, we need the `AuthorizationServerPolicy` id and the `AuthorizationServer` id, which is not a direct parent of `AuthorizationServerPolicyRule`. Therefore, during fetch we add for each `AuthorizationServerPolicyRule` the related `AuthorizationServer` as a second parent.

---
_Release Notes_: 
None

---
_User Notifications_: 
None