### PR TITLE
SALTO-3933 - Add XOR to lowerdash

### DIFF
--- a/packages/lowerdash/src/types.ts
+++ b/packages/lowerdash/src/types.ts
@@ -99,3 +99,4 @@ export const isNonEmptyArray = <T> (array: T[]): array is NonEmptyArray<T> => (
 
 export type AllowOnly<T, K extends keyof T> = Pick<T, K> & { [P in keyof Omit<T, K>]?: never };
 export type OneOf<T, K = keyof T> = K extends keyof T ? AllowOnly<T, K> : never
+export type XOR<A, B> = AllowOnly<A & B, keyof A> | AllowOnly<A & B, keyof B>


### PR DESCRIPTION
Add XOR to lowerdash to eventually get rid of all `ts-xor` imports in the code-base and use the better (written by @ori-moisis version)

---
_Release Notes_: 
None

---
_User Notifications_: 
None
