### PR TITLE
SALTO-3127: Fix supported values change validator message and severity

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/unknown_picklist_values.ts
+++ b/packages/salesforce-adapter/src/change_validators/unknown_picklist_values.ts
@@ -80,9 +80,9 @@ const createUnknownPicklistValueChangeError = (
   allowedValues: string[],
 ): ChangeError => ({
   elemID: instance.elemID,
-  message: `Unknown picklist value "${unknownValue}" on field ${field.elemID.name} of instance ${instance.elemID.getFullName()}`,
-  detailedMessage: `Supported values are ${safeJsonStringify(allowedValues)}`,
-  severity: 'Error',
+  message: `Unknown picklist value "${unknownValue}" on field ${field.elemID.name}`,
+  detailedMessage: `Unknown picklist value "${unknownValue}" on ${instance.elemID.getFullName()}.${field.elemID.name}, Supported values are ${safeJsonStringify(allowedValues)}`,
+  severity: 'Warning',
 })
 
 const createUnknownPicklistValueChangeErrors = async (instance: InstanceElement): Promise<ChangeError[]> => {

--- a/packages/salesforce-adapter/src/change_validators/unknown_picklist_values.ts
+++ b/packages/salesforce-adapter/src/change_validators/unknown_picklist_values.ts
@@ -25,8 +25,8 @@ import {
 import { collections, values } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
-import { isPicklistField } from '../filters/value_set'
 import { FIELD_ANNOTATIONS, INSTANCE_FULL_NAME_FIELD, VALUE_SET_FIELDS } from '../constants'
+import { Types } from '../transformers/transformer'
 
 
 const { isDefined } = values
@@ -88,7 +88,9 @@ const createUnknownPicklistValueChangeError = (
 const createUnknownPicklistValueChangeErrors = async (instance: InstanceElement): Promise<ChangeError[]> => {
   const { fields } = await instance.getType()
   const picklistFieldNames = Object.values(fields)
-    .filter(isPicklistField)
+    // Only checking picklist fields for now and not multi-picklist fields because multi-picklist
+    // fields require more manipulations
+    .filter(field => field.refType.elemID.isEqual(Types.primitiveDataTypes.Picklist.elemID))
     .map(field => field.name)
   return picklistFieldNames
     .map(picklistFieldName => {


### PR DESCRIPTION
Reduce severity to warning because of potential false positives Include details in the detailed message

---

Removed validation on multi-select picklist fields because the code did not handle those values
see SALTO-3936 for more details

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_