### PR TITLE
SALTO-3786 Add change validator to check that guide is enabled when changing guide elements

### DIFF
--- a/packages/zendesk-adapter/src/change_validator.ts
+++ b/packages/zendesk-adapter/src/change_validator.ts
@@ -62,6 +62,7 @@ import {
   defaultGroupChangeValidator,
   organizationExistenceValidator,
   badFormatWebhookActionValidator,
+  guideDisabledValidator,
 } from './change_validators'
 import ZendeskClient from './client/client'
 import { ZedneskDeployConfig, ZendeskFetchConfig } from './config'
@@ -136,6 +137,7 @@ export default ({
     defaultGroupChangeValidator,
     organizationExistenceValidator(client, fetchConfig),
     badFormatWebhookActionValidator,
+    guideDisabledValidator,
     // *** Guide Order Validators ***
     childInOrderValidator,
     childrenReferencesValidator,

--- a/packages/zendesk-adapter/src/change_validators/guide_disabled.ts
+++ b/packages/zendesk-adapter/src/change_validators/guide_disabled.ts
@@ -25,9 +25,10 @@ const { isDefined } = lowerDashValues
 const log = logger(module)
 const { awu } = collections.asynciterable
 
-const getBrandsWithoutGuideByInstanceId = async (
-  instances: InstanceElement[], BrandsByBrandsId: Record<string, InstanceElement>):
-Promise<Record<string, InstanceElement>> => {
+const getBrandsWithoutGuideByInstanceId = (
+  instances: InstanceElement[], BrandsByBrandsId: Record<string, InstanceElement>
+):
+Record<string, InstanceElement> => {
   const BrandsWithoutGuideByInstanceId = instances.map(instance => {
     const brandRef = instance.value.brand
     if (!isReferenceExpression(brandRef)) {
@@ -71,7 +72,7 @@ export const guideDisabledValidator: ChangeValidator = async (changes, elementSo
     return []
   }
 
-  const brandsWithoutGuideByInstanceId = await getBrandsWithoutGuideByInstanceId(relevantInstances, BrandsByBrandId)
+  const brandsWithoutGuideByInstanceId = getBrandsWithoutGuideByInstanceId(relevantInstances, BrandsByBrandId)
 
   return relevantInstances
     .filter(instance => instance.elemID.getFullName() in brandsWithoutGuideByInstanceId)

--- a/packages/zendesk-adapter/src/change_validators/guide_disabled.ts
+++ b/packages/zendesk-adapter/src/change_validators/guide_disabled.ts
@@ -1,0 +1,59 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { ChangeValidator, isInstanceChange, getChangeData, isAdditionChange, InstanceElement, isReferenceExpression } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { values as lowerDashValues } from '@salto-io/lowerdash'
+import { GUIDE_TYPES_TO_HANDLE_BY_BRAND } from '../config'
+
+const { isDefined } = lowerDashValues
+
+const getBrandsWithGuideByInstanceId = async (instances: InstanceElement[]):
+Promise<Record<string, InstanceElement>> => {
+  const BrandsWithGuideByInstanceId = (await Promise.all(instances.map(async instance => {
+    const brandRef = instance.value.brand
+    if (!isReferenceExpression(brandRef)) {
+      return undefined
+    }
+    const brand = await brandRef.getResolvedValue()
+    if (brand.value.has_help_center === false) {
+      return [instance.elemID.getFullName(), brand]
+    }
+    return undefined
+  }))).filter(isDefined)
+  return Object.fromEntries(BrandsWithGuideByInstanceId)
+}
+
+export const guideDisabledValidator: ChangeValidator = async changes => {
+  const relevantInstances = changes
+    .filter(isInstanceChange)
+    .filter(isAdditionChange)
+    .map(getChangeData)
+    .filter(instance => GUIDE_TYPES_TO_HANDLE_BY_BRAND.includes(instance.elemID.typeName))
+  if (_.isEmpty(relevantInstances)) {
+    return []
+  }
+
+  const brandsWithGuideByInstanceId = await getBrandsWithGuideByInstanceId(relevantInstances)
+
+  return relevantInstances.filter(instance =>
+    instance.elemID.getFullName() in brandsWithGuideByInstanceId).map(instance => ({
+    elemID: instance.elemID,
+    severity: 'Error',
+    message: 'Cannot add instance because its associated brand has help center disabled.',
+    detailedMessage: `The brand "${brandsWithGuideByInstanceId[instance.elemID.getFullName()].elemID.name}" associated with this instance has help center disabled.`,
+  }))
+}

--- a/packages/zendesk-adapter/src/change_validators/index.ts
+++ b/packages/zendesk-adapter/src/change_validators/index.ts
@@ -60,3 +60,4 @@ export { customStatusActiveDefaultValidator } from './custom_status_active_defau
 export { defaultGroupChangeValidator } from './default_group_change'
 export { organizationExistenceValidator } from './organization_existence'
 export { badFormatWebhookActionValidator } from './bad_format_webhook_action'
+export { guideDisabledValidator } from './guide_disabled'

--- a/packages/zendesk-adapter/test/change_validators/guide_disabled.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/guide_disabled.test.ts
@@ -65,8 +65,8 @@ describe('guideDisabledValidator', () => {
     expect(changesErrors).toEqual([{
       elemID: categoryToBrandWithHelpCenterFalse.elemID,
       severity: 'Error',
-      message: 'Cannot add instance because its associated brand has help center disabled.',
-      detailedMessage: `The brand "${brandWithHelpCenterFalse.elemID.name}" associated with this instance has help center disabled.`,
+      message: 'Cannot add this element because help center is not enabled for its associated brand.',
+      detailedMessage: `please enable help center for brand "${brandWithHelpCenterFalse.elemID.name}" in order to add this element.`,
     }])
   })
 

--- a/packages/zendesk-adapter/test/change_validators/guide_disabled.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/guide_disabled.test.ts
@@ -1,0 +1,75 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { guideDisabledValidator } from '../../src/change_validators/guide_disabled'
+import { ZENDESK, CATEGORY_TYPE_NAME } from '../../src/constants'
+
+
+describe('guideDisabledValidator', () => {
+  const categoryType = new ObjectType({ elemID: new ElemID(ZENDESK, CATEGORY_TYPE_NAME) })
+  const brandType = new ObjectType({ elemID: new ElemID(ZENDESK, 'brand') })
+
+  const brandWithHelpCenterFalse = new InstanceElement(
+    'brandWithHelpCenterFalse',
+    brandType,
+    {
+      has_help_center: false,
+    }
+  )
+
+  const brandWithHelpCenterTrue = new InstanceElement(
+    'brandWithHelpCenterTrue',
+    brandType,
+    {
+      has_help_center: true,
+    }
+  )
+
+  const categoryToBrandWithHelpCenterFalse = new InstanceElement(
+    'category',
+    categoryType,
+    {
+      brand: new ReferenceExpression(brandWithHelpCenterFalse.elemID, brandWithHelpCenterFalse),
+    }
+  )
+
+  const categoryToBrandWithHelpCenterTrue = new InstanceElement(
+    'category',
+    categoryType,
+    {
+      brand: new ReferenceExpression(brandWithHelpCenterTrue.elemID, brandWithHelpCenterTrue),
+    }
+  )
+
+  it('should return errors because the brand has no help center', async () => {
+    const changes = [toChange({ after: categoryToBrandWithHelpCenterFalse })]
+    const changesErrors = await guideDisabledValidator(changes)
+    expect(changesErrors).toHaveLength(1)
+    expect(changesErrors).toEqual([{
+      elemID: categoryToBrandWithHelpCenterFalse.elemID,
+      severity: 'Error',
+      message: 'Cannot add instance because its associated brand has help center disabled.',
+      detailedMessage: `The brand "${brandWithHelpCenterFalse.elemID.name}" associated with this instance has help center disabled.`,
+    }])
+  })
+
+  it('should not return errors because the brand has help center', async () => {
+    const changes = [toChange({ after: categoryToBrandWithHelpCenterTrue })]
+    const changesErrors = await guideDisabledValidator(changes)
+    expect(changesErrors).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
1. In this PR I added a change validator that validates that the user Cannot add instance when its associated brand has help center disabled.
2. I added test for this CV.
---

_Additional context for reviewer_
In Order to test the code manually - do as follows:
1. Create two environments in Zendesk.
2. Check\create two brands with the same name. 
3. Make sure that one brand has help center enabled and one brand has help center disabled. 
4. clone a sub guide element from the brand in the env with help center enabled to the env with help center disabled. 
5. try to deploy the new env. 
---
_Release Notes_: 
I added change validator to validate that it is not possible to add instance when its associated brand has help center disabled.

---
_User Notifications_: 
None