### PR TITLE
Add logs for all PermissionSet elements before and after each filter,…

### DIFF
--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -258,9 +258,14 @@ export const fetchMetadataInstances = async ({
   )
 
   const filePropertiesMap = _.keyBy(fileProps, getFullName)
-  const elements = metadataInfos
+  const nonEmptyElements = metadataInfos
     .filter(m => !_.isEmpty(m))
+  const unnamedElements = nonEmptyElements
+    .filter(m => m.fullName === undefined)
+  log.debug(`Elements with no full name: ${unnamedElements}`)
+  const namedElements = nonEmptyElements
     .filter(m => m.fullName !== undefined)
+  const elements = namedElements
     .map(m => getInstanceFromMetadataInformation(m, filePropertiesMap, metadataType))
   return {
     elements,


### PR DESCRIPTION
… as well as a log after readMetadata finishes for all elements with no full name


---

This is a specific build for Sweep, not planning to add this to codebase


---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
