### PR TITLE
SALTO-3966: Remove vm2 dependency by upgrading SDF version

### DIFF
--- a/packages/netsuite-adapter/package.json
+++ b/packages/netsuite-adapter/package.json
@@ -36,7 +36,7 @@
     "@salto-io/file": "0.3.36",
     "@salto-io/logging": "0.3.36",
     "@salto-io/lowerdash": "0.3.36",
-    "@salto-io/suitecloud-cli": "1.6.2-salto-1",
+    "@salto-io/suitecloud-cli": "1.6.2-salto-2",
     "ajv": "^7.1.1",
     "async-lock": "^1.2.4",
     "axios": "^0.21.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3007,17 +3007,16 @@
     napi-macros "^2.0.0"
     node-gyp-build "^4.3.0"
 
-"@salto-io/suitecloud-cli@1.6.2-salto-1":
-  version "1.6.2-salto-1"
-  resolved "https://registry.yarnpkg.com/@salto-io/suitecloud-cli/-/suitecloud-cli-1.6.2-salto-1.tgz#e9cd3906818390036d304f9992bb550efaf8ac5d"
-  integrity sha512-vkaybRqnIz/1diKKEH/oKH0Tq2hx9gIw6g6Z1C2DBOnmWHBba+Bm0oszIJj4FUjlcpG9YUmLxTB6qL64InVp6A==
+"@salto-io/suitecloud-cli@1.6.2-salto-2":
+  version "1.6.2-salto-2"
+  resolved "https://registry.yarnpkg.com/@salto-io/suitecloud-cli/-/suitecloud-cli-1.6.2-salto-2.tgz#34396cbc9ac8b84ff5df49d14297e10cd6dc9b2d"
+  integrity sha512-x2Nbay/n5NY4k6Yxi/qcArH9NZE2wbbCkRBaD/nTVfNWQpjb/6wNF/wvKp9SFo6+d/FY6aGkjUGBxcNd6NIClg==
   dependencies:
     "@salto-io/logging" "<0.4.0"
     chalk "4.1.2"
     cli-spinner "0.2.10"
     commander "9.4.0"
     inquirer "8.2.2"
-    vm2 "3.9.11"
     xml2js "0.4.23"
 
 "@sideway/address@^4.1.3":
@@ -4046,17 +4045,12 @@ acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
-acorn-walk@^8.2.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
-  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
-
 acorn@^7.1.1:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.2.0.tgz#17ea7e40d7c8640ff54a694c889c26f31704effe"
   integrity sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==
 
-acorn@^8.2.4, acorn@^8.5.0, acorn@^8.7.0, acorn@^8.7.1:
+acorn@^8.2.4, acorn@^8.5.0, acorn@^8.7.1:
   version "8.8.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.1.tgz#0a3f9cbecc4ec3bea6f0a80b66ae8dd2da250b73"
   integrity sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==
@@ -12814,14 +12808,6 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
-
-vm2@3.9.11:
-  version "3.9.11"
-  resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.9.11.tgz#a880f510a606481719ec3f9803b940c5805a06fe"
-  integrity sha512-PFG8iJRSjvvBdisowQ7iVF580DXb1uCIiGaXgm7tynMR1uTBlv7UJlB1zdv5KJ+Tmq1f0Upnj3fayoEOPpCBKg==
-  dependencies:
-    acorn "^8.7.0"
-    acorn-walk "^8.2.0"
 
 vsce@^2.9.2:
   version "2.9.2"


### PR DESCRIPTION
Based on our new SDF release: https://github.com/salto-io/netsuite-suitecloud-sdk/commit/32bce130b7b73ab2450bb0a1710213a76b0d82c4

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None