### PR TITLE
SALTO-3969 use safeJsonStringify in merge logs

### DIFF
--- a/packages/workspace/src/merger/internal/common.ts
+++ b/packages/workspace/src/merger/internal/common.ts
@@ -14,9 +14,9 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { inspect } from 'util'
 import { types } from '@salto-io/lowerdash'
 import { ElemID, SaltoElementError, SeverityLevel } from '@salto-io/adapter-api'
+import { safeJsonStringify, elementExpressionStringifyReplacer } from '@salto-io/adapter-utils'
 
 
 export abstract class MergeError extends types.Bean<Readonly<{
@@ -43,7 +43,7 @@ export class DuplicateAnnotationError extends MergeError {
     { elemID: ElemID; key: string; existingValue: unknown; newValue: unknown}) {
     super({
       elemID,
-      error: `duplicate annotation key ${key} (values - ${inspect(existingValue)} & ${inspect(newValue)})`,
+      error: `duplicate annotation key ${key} (values - ${safeJsonStringify(existingValue, elementExpressionStringifyReplacer, 2)} & ${safeJsonStringify(newValue, elementExpressionStringifyReplacer, 2)})`,
     })
     this.key = key
     this.existingValue = existingValue

--- a/packages/workspace/src/merger/internal/instances.ts
+++ b/packages/workspace/src/merger/internal/instances.ts
@@ -13,8 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { inspect } from 'util'
 import { InstanceElement, ElemID, TypeReference } from '@salto-io/adapter-api'
+import { safeJsonStringify, elementExpressionStringifyReplacer } from '@salto-io/adapter-utils'
 import {
   MergeResult, MergeError, mergeNoDuplicates, DuplicateAnnotationError,
 } from './common'
@@ -29,7 +29,7 @@ export class DuplicateInstanceKeyError extends MergeError {
     { elemID: ElemID; key: string; existingValue: unknown; newValue: unknown}) {
     super({
       elemID,
-      error: `duplicate key ${key} (values - ${inspect(existingValue)} & ${inspect(newValue)})`,
+      error: `duplicate key ${key} (values - ${safeJsonStringify(existingValue, elementExpressionStringifyReplacer, 2)} & ${safeJsonStringify(newValue, elementExpressionStringifyReplacer, 2)})`,
     })
     this.key = key
     this.existingValue = existingValue


### PR DESCRIPTION
Avoid logging inside reference expressions etc.

we lose _some_ information, but I think it is usually better than the current state.

---
_Release Notes_: 
None

---
_User Notifications_: 
None