### PR TITLE
SALTO-3809: Deploy addition change of instance in different status from the default status

### DIFF
--- a/packages/okta-adapter/src/change_validators/group_rule_status.ts
+++ b/packages/okta-adapter/src/change_validators/group_rule_status.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ChangeValidator, getChangeData, isInstanceChange, InstanceElement, ChangeError, isModificationChange, Change, isRemovalChange, isAdditionChange } from '@salto-io/adapter-api'
+import { ChangeValidator, getChangeData, isInstanceChange, InstanceElement, ChangeError, isModificationChange, Change, isRemovalChange } from '@salto-io/adapter-api'
 import { collections, values } from '@salto-io/lowerdash'
 import { ACTIVE_STATUS, GROUP_RULE_TYPE_NAME, INACTIVE_STATUS } from '../constants'
 
@@ -49,16 +49,6 @@ const getGroupRuleStatusError = (
         severity: 'Error',
         message: `Cannot modify ${GROUP_RULE_TYPE_NAME} with status ${ACTIVE_STATUS}`,
         detailedMessage: `Cannot modify ${GROUP_RULE_TYPE_NAME} with status ${ACTIVE_STATUS}. Please change instance status to ${INACTIVE_STATUS} and try again.`,
-      }
-    }
-  }
-  if (isAdditionChange(change)) {
-    if (instance.value.status === ACTIVE_STATUS) {
-      return {
-        elemID: instance.elemID,
-        severity: 'Warning',
-        message: `Cannot add ${GROUP_RULE_TYPE_NAME} with status ${ACTIVE_STATUS}`,
-        detailedMessage: `${GROUP_RULE_TYPE_NAME} will be created with status ${INACTIVE_STATUS}`,
       }
     }
   }

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -27,7 +27,8 @@ export const FETCH_CONFIG = 'fetch'
 export const API_DEFINITIONS_CONFIG = 'apiDefinitions'
 
 export type OktaClientConfig = clientUtils.ClientBaseConfig<clientUtils.ClientRateLimitConfig>
-export type OktaActionName = ActionName | 'activate' | 'deactivate'
+export type OktaStatusActionName = 'activate' | 'deactivate'
+export type OktaActionName = ActionName | OktaStatusActionName
 export type OktaFetchConfig = configUtils.UserFetchConfig & {
   convertUsersIds?: boolean
 }

--- a/packages/okta-adapter/src/filters/app_deployment.ts
+++ b/packages/okta-adapter/src/filters/app_deployment.ts
@@ -116,8 +116,9 @@ const deployApp = async (
 
   try {
     // Custom app must be activated before applying any other changes
-    if (isModificationChange(change) && isActivationChange(change)) {
-      await deployStatusChange(change, client, apiDefinitions)
+    if (isModificationChange(change)
+      && isActivationChange({ before: change.data.before.value.status, after: change.data.after.value.status })) {
+      await deployStatusChange(change, client, apiDefinitions, 'activate')
     }
 
     const response = await defaultDeployChange(
@@ -129,8 +130,9 @@ const deployApp = async (
       isAdditionChange(change) && getChangeData(change).value?.status === INACTIVE_STATUS ? { activate: 'false' } : undefined
     )
 
-    if (isModificationChange(change) && isDeactivationChange(change)) {
-      await deployStatusChange(change, client, apiDefinitions)
+    if (isModificationChange(change)
+      && isDeactivationChange({ before: change.data.before.value.status, after: change.data.after.value.status })) {
+      await deployStatusChange(change, client, apiDefinitions, 'deactivate')
     }
 
     if (isAdditionOrModificationChange(change)) {

--- a/packages/okta-adapter/src/filters/default_rule_deployment.ts
+++ b/packages/okta-adapter/src/filters/default_rule_deployment.ts
@@ -23,7 +23,7 @@ import { ACCESS_POLICY_RULE_TYPE_NAME, PROFILE_ENROLLMENT_RULE_TYPE_NAME } from 
 import OktaClient from '../client/client'
 import { OktaConfig, API_DEFINITIONS_CONFIG } from '../config'
 import { FilterCreator } from '../filter'
-import { deployChanges, defaultDeployChange } from '../deployment'
+import { deployChanges, defaultDeployWithStatus } from '../deployment'
 
 const log = logger(module)
 
@@ -100,7 +100,7 @@ const deployDefaultPolicy = async (
   // Assign the id created by the service to the default policy rule
   defaultRuleInstance.value.id = createdPolicyRuleEntry.id
   const createdPolicyRuleInstance = getCreatedPolicyRuleInstance(createdPolicyRuleEntry, defaultRuleInstance, config)
-  await defaultDeployChange(
+  await defaultDeployWithStatus(
     toChange({ before: createdPolicyRuleInstance, after: defaultRuleInstance }),
     client,
     config[API_DEFINITIONS_CONFIG]

--- a/packages/okta-adapter/test/change_validators/group_rule_status.test.ts
+++ b/packages/okta-adapter/test/change_validators/group_rule_status.test.ts
@@ -86,20 +86,6 @@ describe('groupRuleStatusValidator', () => {
       },
     ])
   })
-  it('should return an when add a new group rule with status ACTIVE', async () => {
-    const changeErrors = await groupRuleStatusValidator(
-      [toChange({ after: groupRule1 })]
-    )
-    expect(changeErrors).toHaveLength(1)
-    expect(changeErrors).toEqual([
-      {
-        elemID: groupRule1.elemID,
-        severity: 'Warning',
-        message: `Cannot add ${GROUP_RULE_TYPE_NAME} with status ACTIVE`,
-        detailedMessage: `${GROUP_RULE_TYPE_NAME} will be created with status INACTIVE`,
-      },
-    ])
-  })
   it('should not return errors when group rule status changed', async () => {
     const groupRule1After = groupRule1.clone()
     groupRule1After.value.status = 'INACTIVE'


### PR DESCRIPTION
Allow creating instances in any status

---

In Okta, each type has its default status when created. For example `GroupRule` instances are created in status `INACTIVE` by default, and `AccessPolicyRule` created in status `ACTIVE`.
Until now, instances were created with their default status. This PR add the option to created instance in a different status from the default one.

---
_Release Notes_: 
None

---
_User Notifications_: 
None
