### PR TITLE
SALTO-3901: fix deployment of macro restriction modification

### DIFF
--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -133,6 +133,7 @@ import auditTimeFilter from './filters/audit_logs'
 import sideConversationsFilter from './filters/side_conversation'
 import { isCurrentUserResponse } from './user_utils'
 import addAliasFilter from './filters/add_alias'
+import macroFilter from './filters/macro'
 
 const { makeArray } = collections.array
 const log = logger(module)
@@ -184,6 +185,7 @@ export const DEFAULT_FILTERS = [
   supportAddress,
   customStatus,
   guideAddBrandToArticleTranslation,
+  macroFilter,
   macroAttachmentsFilter,
   ticketFormDeploy,
   sideConversationsFilter,

--- a/packages/zendesk-adapter/src/filters/macro.ts
+++ b/packages/zendesk-adapter/src/filters/macro.ts
@@ -1,0 +1,45 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  Change,
+  getChangeData,
+  InstanceElement, isInstanceChange,
+} from '@salto-io/adapter-api'
+import { FilterCreator } from '../filter'
+import { MACRO_TYPE_NAME } from '../constants'
+
+/**
+ * This filter adds the restriction field as null to a macro with no restriction field.
+ */
+const filterCreator: FilterCreator = () => ({
+  name: 'macroFilter',
+  preDeploy: async (changes: Change<InstanceElement>[]): Promise<void> => {
+    changes
+      .filter(isInstanceChange)
+      .filter(change => getChangeData(change).elemID.typeName === MACRO_TYPE_NAME)
+      .filter(change => getChangeData(change).value.restriction === undefined)
+      .forEach(change => { getChangeData(change).value.restriction = null })
+  },
+  onDeploy: async (changes: Change<InstanceElement>[]): Promise<void> => {
+    changes
+      .filter(isInstanceChange)
+      .filter(change => getChangeData(change).elemID.typeName === MACRO_TYPE_NAME)
+      .filter(change => getChangeData(change).value.restriction === null)
+      .forEach(change => { delete getChangeData(change).value.restriction })
+  },
+})
+
+export default filterCreator

--- a/packages/zendesk-adapter/test/filters/macro.test.ts
+++ b/packages/zendesk-adapter/test/filters/macro.test.ts
@@ -1,0 +1,88 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { filterUtils } from '@salto-io/adapter-components'
+import {
+  ElemID,
+  InstanceElement,
+  ObjectType, ReferenceExpression,
+  toChange,
+} from '@salto-io/adapter-api'
+import filterCreator from '../../src/filters/macro'
+
+
+import { MACRO_TYPE_NAME, ZENDESK } from '../../src/constants'
+import { createFilterCreatorParams } from '../utils'
+
+describe('macro filter', () => {
+  type FilterType = filterUtils.FilterWith<'preDeploy' | 'onDeploy'>
+  let filter: FilterType
+
+  const macroType = new ObjectType({ elemID: new ElemID(ZENDESK, MACRO_TYPE_NAME) })
+
+  const macroNoRestrictionInstance = new InstanceElement(
+    'no restriction',
+    macroType,
+    {}
+  )
+  const macroRestrictionInstance = new InstanceElement(
+    'restriction',
+    macroType,
+    {
+      restriction: {
+        type: 'User',
+        id: 1234,
+      },
+    }
+  )
+
+  beforeEach(async () => {
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
+  })
+
+  describe('preDeploy', () => {
+    it('should add restriction as null for macro with no restriction deploy', async () => {
+      const macroNoRestrictionInstanceCopy = macroNoRestrictionInstance.clone()
+      await filter.preDeploy([
+        toChange({ before: macroNoRestrictionInstanceCopy, after: macroNoRestrictionInstanceCopy }),
+        toChange({ after: macroRestrictionInstance }),
+      ])
+      expect(macroNoRestrictionInstanceCopy.value.restriction).toBeDefined()
+      expect(macroNoRestrictionInstanceCopy.value.restriction).toEqual(null)
+      expect(macroRestrictionInstance.value.restriction).toEqual({ type: 'User', id: 1234 })
+    })
+  })
+
+  describe('onDeploy', () => {
+    const macroNullRestrictionInstance = new InstanceElement(
+      'restriction',
+      macroType,
+      {
+        restriction: null,
+      }
+    )
+    it('should omit restriction if it is equal null', async () => {
+      await filter.onDeploy([
+        toChange({ after: macroNullRestrictionInstance }),
+        toChange({ after: macroRestrictionInstance }),
+        toChange({ after: macroNoRestrictionInstance }),
+      ])
+      expect(macroNullRestrictionInstance.value.restriction).not.toBeDefined()
+      expect(macroNoRestrictionInstance.value.restriction).not.toBeDefined()
+      expect(macroRestrictionInstance.value.restriction).toEqual({ type: 'User', id: 1234 })
+    })
+  })
+})

--- a/packages/zendesk-adapter/test/filters/macro.test.ts
+++ b/packages/zendesk-adapter/test/filters/macro.test.ts
@@ -18,7 +18,7 @@ import { filterUtils } from '@salto-io/adapter-components'
 import {
   ElemID,
   InstanceElement,
-  ObjectType, ReferenceExpression,
+  ObjectType,
   toChange,
 } from '@salto-io/adapter-api'
 import filterCreator from '../../src/filters/macro'


### PR DESCRIPTION
fix deployment of macro restriction modification

---

_Additional context for reviewer_
To modify the macro restriction to all agents we need to pass in the request `restriction = null`

---
_Release Notes_: 
zendesk: 
* fix bug where restrictions were not removed from macros that already had restrictions defined

---
_User Notifications_: 
None
