### PR TITLE
SALTO-3705: isCondition schema validation should allow values to be references

### DIFF
--- a/packages/zendesk-adapter/src/change_validators/automation_all_conditions.ts
+++ b/packages/zendesk-adapter/src/change_validators/automation_all_conditions.ts
@@ -17,11 +17,12 @@
 
 import {
   ChangeValidator, getChangeData, InstanceElement,
-  isAdditionOrModificationChange, isInstanceElement,
+  isAdditionOrModificationChange, isInstanceElement, ReferenceExpression,
 } from '@salto-io/adapter-api'
 
 import { resolveValues } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
+import _ from 'lodash'
 import { isConditions } from '../filters/utils'
 import { lookupFunc } from '../filters/field_references'
 import { AUTOMATION_TYPE_NAME } from '../constants'
@@ -29,8 +30,8 @@ import { AUTOMATION_TYPE_NAME } from '../constants'
 
 const { awu } = collections.asynciterable
 
-const fieldExist = (field: string): boolean =>
-  ['status', 'type', 'group_id', 'assignee_id', 'requester_id'].includes(field)
+const fieldExist = (field: string | ReferenceExpression): boolean =>
+  _.isString(field) && ['status', 'type', 'group_id', 'assignee_id', 'requester_id'].includes(field)
 
 
 const isNotValidData = (instance: InstanceElement): boolean => {

--- a/packages/zendesk-adapter/src/change_validators/automation_all_conditions.ts
+++ b/packages/zendesk-adapter/src/change_validators/automation_all_conditions.ts
@@ -30,14 +30,15 @@ import { AUTOMATION_TYPE_NAME } from '../constants'
 
 const { awu } = collections.asynciterable
 
-const fieldExist = (field: string | ReferenceExpression): boolean =>
+const fieldExists = (field: string | ReferenceExpression): boolean =>
+  // these are standard fields so they will never be references + this may change in SALTO-2283
   _.isString(field) && ['status', 'type', 'group_id', 'assignee_id', 'requester_id'].includes(field)
 
 
 const isNotValidData = (instance: InstanceElement): boolean => {
   const allConditions = instance.value.conditions?.all ?? []
   return !(isConditions(allConditions)
-      && allConditions.some(condition => fieldExist(condition.field)))
+      && allConditions.some(condition => fieldExists(condition.field)))
 }
 
 export const automationAllConditionsValidator: ChangeValidator = async changes => {

--- a/packages/zendesk-adapter/src/filters/tag.ts
+++ b/packages/zendesk-adapter/src/filters/tag.ts
@@ -77,7 +77,9 @@ const replaceTagsWithReferences = (instance: InstanceElement): string[] => {
         return
       }
       conditions.forEach(condition => {
-        if (RELEVANT_FIELD_NAMES.includes(condition.field) && _.isString(condition.value)) {
+        if (_.isString(condition.field)
+          && RELEVANT_FIELD_NAMES.includes(condition.field)
+          && _.isString(condition.value)) {
           const conditionTags = extractTags(condition.value)
           conditionTags.forEach(tag => { tags.push(tag) })
           condition.value = conditionTags
@@ -111,7 +113,7 @@ const serializeReferencesToTags = (instance: InstanceElement): void => {
         return
       }
       conditions.forEach(condition => {
-        if (RELEVANT_FIELD_NAMES.includes(condition.field)) {
+        if (_.isString(condition.field) && RELEVANT_FIELD_NAMES.includes(condition.field)) {
           if (_.isArray(condition.value) && condition.value.every(_.isString)) {
             condition.value = condition.value.join(TAG_SEPERATOR)
           } else {

--- a/packages/zendesk-adapter/src/replacers_utils.ts
+++ b/packages/zendesk-adapter/src/replacers_utils.ts
@@ -16,7 +16,7 @@
 import _ from 'lodash'
 import { applyFunctionToChangeData } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
-import { Change, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { Change, ElemID, InstanceElement, isReferenceExpression } from '@salto-io/adapter-api'
 import { conditionFieldValue, isCorrectConditions } from './filters/utils'
 
 const { awu } = collections.asynciterable
@@ -44,7 +44,7 @@ export const replaceConditionsAndActionsCreator = (
       .flatMap((condition, i) => {
         const fieldNamesToReplace = replacerParams.fieldsToReplace.map(f => f.name)
         const conditionValue = conditionFieldValue(condition, typeName)
-        if (!fieldNamesToReplace.includes(conditionValue)) {
+        if (isReferenceExpression(conditionValue) || !fieldNamesToReplace.includes(conditionValue)) {
           return []
         }
         const valueRelativePath = replacerParams.fieldsToReplace

--- a/packages/zendesk-adapter/src/replacers_utils.ts
+++ b/packages/zendesk-adapter/src/replacers_utils.ts
@@ -44,6 +44,7 @@ export const replaceConditionsAndActionsCreator = (
       .flatMap((condition, i) => {
         const fieldNamesToReplace = replacerParams.fieldsToReplace.map(f => f.name)
         const conditionValue = conditionFieldValue(condition, typeName)
+        // these are standard fields so they will never be references + this may change in SALTO-2283
         if (isReferenceExpression(conditionValue) || !fieldNamesToReplace.includes(conditionValue)) {
           return []
         }

--- a/packages/zendesk-adapter/test/change_validators/automation_all_conditions.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/automation_all_conditions.test.ts
@@ -62,10 +62,16 @@ describe('automationAllConditionsValidator', () => {
       id: 2,
       title: 'Test',
       active: true,
-      actions: [{
-        field: 'Test',
-        value: 'Test',
-      }],
+      actions: [
+        {
+          field: 'Test',
+          value: 'Test',
+        },
+        {
+          field: new ReferenceExpression(validAutomation.elemID),
+          value: 'Test',
+        },
+      ],
       conditions: {
         all: [
           {

--- a/packages/zendesk-adapter/test/filters/tag.test.ts
+++ b/packages/zendesk-adapter/test/filters/tag.test.ts
@@ -70,6 +70,11 @@ describe('tags filter', () => {
             operator: 'includes',
             value: '',
           },
+          {
+            field: new ReferenceExpression(triggerType.elemID),
+            operator: 'includes',
+            value: '',
+          },
         ],
         any: [
           {
@@ -198,6 +203,7 @@ describe('tags filter', () => {
         conditions: {
           all: [
             { field: 'current_tags', operator: 'includes', value: [] },
+            { field: new ReferenceExpression(triggerType.elemID), operator: 'includes', value: '' },
           ],
           any: [
             { field: 'current_tags', operator: 'includes', value: [tagRef('t5'), tagRef('t6')] },


### PR DESCRIPTION
isCondition schema validation should allow values to be references

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
