### PR TITLE
SALTO-3929: Allow modifications of custom apps in status INACTIVE

### DIFF
--- a/packages/okta-adapter/src/filters/app_deployment.ts
+++ b/packages/okta-adapter/src/filters/app_deployment.ts
@@ -15,15 +15,15 @@
 */
 import _ from 'lodash'
 import Joi from 'joi'
-import { Change, InstanceElement, Element, isInstanceChange, getChangeData, isAdditionOrModificationChange, isAdditionChange, AdditionChange, isInstanceElement, ElemID, ReadOnlyElementsSource, Values, isModificationChange } from '@salto-io/adapter-api'
+import { Change, InstanceElement, Element, isInstanceChange, getChangeData, isAdditionOrModificationChange, isAdditionChange, AdditionChange, isInstanceElement, ElemID, ReadOnlyElementsSource, Values, isModificationChange, ModificationChange } from '@salto-io/adapter-api'
 import { config as configUtils } from '@salto-io/adapter-components'
 import { logger } from '@salto-io/logging'
 import { createSchemeGuard } from '@salto-io/adapter-utils'
-import { APPLICATION_TYPE_NAME, INACTIVE_STATUS, OKTA, ORG_SETTING_TYPE_NAME, CUSTOM_NAME_FIELD } from '../constants'
+import { APPLICATION_TYPE_NAME, INACTIVE_STATUS, OKTA, ORG_SETTING_TYPE_NAME, CUSTOM_NAME_FIELD, ACTIVE_STATUS } from '../constants'
 import OktaClient from '../client/client'
 import { OktaConfig, API_DEFINITIONS_CONFIG } from '../config'
 import { FilterCreator } from '../filter'
-import { deployChanges, defaultDeployChange, deployEdges, isActivationChange, isDeactivationChange, deployStatusChange, getOktaError } from '../deployment'
+import { deployChanges, defaultDeployChange, deployEdges, deployStatusChange, getOktaError, isActivationChange, isDeactivationChange } from '../deployment'
 
 const log = logger(module)
 
@@ -99,6 +99,12 @@ const getSubdomainFromElementsSource = async (elementsSource: ReadOnlyElementsSo
   return orgSettingInstance.value.subdomain
 }
 
+export const isInactiveCustomAppChange = (change: ModificationChange<InstanceElement>): boolean =>
+  change.data.before.value.status === INACTIVE_STATUS
+    && change.data.after.value.status === INACTIVE_STATUS
+    // customName field only exist in custom applications
+    && getChangeData(change).value[CUSTOM_NAME_FIELD] !== undefined
+
 const deployApp = async (
   change: Change<InstanceElement>,
   client: OktaClient,
@@ -115,9 +121,13 @@ const deployApp = async (
   ]
 
   try {
-    // Custom app must be activated before applying any other changes
     if (isModificationChange(change)
-      && isActivationChange({ before: change.data.before.value.status, after: change.data.after.value.status })) {
+      && (
+        isActivationChange({ before: change.data.before.value.status, after: change.data.after.value.status })
+        // Custom app must be activated before applying any other changes
+        || isInactiveCustomAppChange(change)
+      )) {
+      log.debug(`Changing status to ${ACTIVE_STATUS}, for instance ${getChangeData(change).elemID.getFullName()}`)
       await deployStatusChange(change, client, apiDefinitions, 'activate')
     }
 
@@ -131,7 +141,11 @@ const deployApp = async (
     )
 
     if (isModificationChange(change)
-      && isDeactivationChange({ before: change.data.before.value.status, after: change.data.after.value.status })) {
+      && (
+        isDeactivationChange({ before: change.data.before.value.status, after: change.data.after.value.status })
+        || isInactiveCustomAppChange(change)
+      )) {
+      log.debug(`Changing status to ${INACTIVE_STATUS}, for instance ${getChangeData(change).elemID.getFullName()}`)
       await deployStatusChange(change, client, apiDefinitions, 'deactivate')
     }
 

--- a/packages/okta-adapter/test/change_validators/custom_application_status.test.ts
+++ b/packages/okta-adapter/test/change_validators/custom_application_status.test.ts
@@ -30,7 +30,7 @@ describe('customApplicationStatusValidator', () => {
     { customName: 'oktaSubdomain_saml_link', signOnMode: 'SAML_2_0', status: INACTIVE_STATUS }
   )
 
-  it('should return change error when modifying custom app in status INACTIVE', async () => {
+  it('should return warning when modifying custom app in status INACTIVE', async () => {
     const errors = await customApplicationStatusValidator([
       toChange({ before: customAppInstance, after: customAppInstance }),
     ])
@@ -38,13 +38,13 @@ describe('customApplicationStatusValidator', () => {
     expect(errors).toEqual([
       {
         elemID: customAppInstance.elemID,
-        severity: 'Error',
-        message: 'Cannot change custom application in status INACTIVE',
-        detailedMessage: 'Modifications of custom applications in status INACTIVE is not supported via the Okta API. Please make this change in Okta and fetch, or activate the application and try again.',
+        severity: 'Warning',
+        message: 'Application will be activated in order to apply those changes',
+        detailedMessage: `Modifications of custom applications in status ${INACTIVE_STATUS} are not supported via the Okta API. Therefore, Salto will activate the application in order to apply changes, and deactivate it afterwards. Alternatively, you can make this change in Okta and fetch.`,
       },
     ])
   })
-  it('should not return change error when modifying regular app in status INACTIVE', async () => {
+  it('should not return warning when modifying regular app in status INACTIVE', async () => {
     const errors = await customApplicationStatusValidator([
       toChange({ before: appInstance, after: appInstance }),
     ])


### PR DESCRIPTION
Okta's API doesn't support changes of custom apps in status `INACTIVE`, in order to allow it, we activate the app, make the relevant changes and deactivate it 

---
_Release Notes_: 
None

---
_User Notifications_: 
None