### PR TITLE
Incident-3894: Improve file cabinet long query

### DIFF
--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -419,7 +419,7 @@ describe('Netsuite adapter E2E with real account', () => {
           // we need to get the folder internalId
           ? await realAdapter(
             { credentials: credentialsLease.value, withSuiteApp },
-            { fetch: { include: { types: [], fileCabinet: ['/Images'], customRecords: [] } } }
+            { fetch: { include: { types: [], fileCabinet: ['/Images/'], customRecords: [] } } }
           ).adapter.fetch({
             progressReporter: { reportProgress: jest.fn() },
           })

--- a/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
@@ -271,7 +271,7 @@ SuiteAppFileCabinetOperations => {
     const fileCriteria = 'hideinbundle = \'F\''
     const whereQueries = folderIdsToQuery.length > 0
       ? _.chunk(folderIdsToQuery, MAX_ITEMS_IN_WHERE_QUERY).map(foldersToQueryChunk =>
-        `${fileCriteria} AND folder IN(${foldersToQueryChunk.join(', ')})`)
+        `${fileCriteria} AND folder IN (${foldersToQueryChunk.join(', ')})`)
       : [fileCriteria]
     const results = await Promise.all(whereQueries.map(async whereQuery => {
       const filesResults = await suiteAppClient.runSuiteQL(

--- a/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
@@ -358,13 +358,18 @@ SuiteAppFileCabinetOperations => {
 
       const subFoldersResults = await querySubFolders(topLevelFoldersResults)
       const foldersResults = topLevelFoldersResults.concat(subFoldersResults)
+      // console.log(foldersResults)
       const idToFolder = _.keyBy(foldersResults, folder => folder.id)
+      // console.log(idToFolder)
       const folderIdAndPaths = foldersResults
-        .map(folderResult => ({ path: getFullPath(folderResult, idToFolder).join(FILE_CABINET_PATH_SEPARATOR),
-          id: folderResult.id }))
-        // .filter(folderIdAndPath => query.isFileMatch(folderIdAndPath.path))
+        .map(folderResult => ({
+          path: getFullPath(folderResult, idToFolder).join(FILE_CABINET_PATH_SEPARATOR),
+          id: folderResult.id,
+        }))
+        .filter(folderIdAndPath => query.isFileMatch(`/${folderIdAndPath.path}`))
+      // TODO: remove this timer when done
       const filesResults = await log.time(() => queryFiles(
-        folderIdAndPaths.filter(folder => query.isFileMatch(`${folder.path}/`)).map(folder => folder.id)
+        folderIdAndPaths.filter(folder => query.isFileMatch(`/${folder.path}/`)).map(folder => folder.id)
       ), 'shulikTest')
 
 
@@ -381,7 +386,7 @@ SuiteAppFileCabinetOperations => {
 
     const { foldersResults, filesResults } = await queryFileCabinet(query)
     const idToFolder = _.keyBy(foldersResults, folder => folder.id)
-
+    console.log('got here1')
     const foldersCustomizationInfo = foldersResults.map(folder => ({
       path: getFullPath(folder, idToFolder),
       typeName: 'folder',
@@ -393,6 +398,7 @@ SuiteAppFileCabinetOperations => {
         internalId: folder.id,
       },
     })).filter(folder => query.isFileMatch(`/${folder.path.join(FILE_CABINET_PATH_SEPARATOR)}`))
+    console.log('###### got here #######')
 
     const filesCustomizations = filesResults.map(file => ({
       path: [...getFullPath(idToFolder[file.folder], idToFolder), file.name],
@@ -410,7 +416,7 @@ SuiteAppFileCabinetOperations => {
       id: file.id,
       size: parseInt(file.filesize, 10),
     })).filter(file => query.isFileMatch(`/${file.path.join(FILE_CABINET_PATH_SEPARATOR)}`))
-
+    // console.log(filesCustomizations)
     const [
       filesCustomizationWithoutContent,
       filesCustomizationsLinks,

--- a/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
@@ -368,12 +368,13 @@ SuiteAppFileCabinetOperations => {
       const filteredFolderResults = removeResultsWithoutParentFolder(foldersResults)
         .map(folder => ({ path: getFullPath(folder, idToFolder), ...folder }))
         // remove excluded folders before creating the query
-        .filter(folder => query.isFileMatch(`${FILE_CABINET_PATH_SEPARATOR}${folder.path.join(FILE_CABINET_PATH_SEPARATOR)}`))
+        .filter(folder => query.isFileMatch(`${FILE_CABINET_PATH_SEPARATOR}${folder.path.join(FILE_CABINET_PATH_SEPARATOR)}${FILE_CABINET_PATH_SEPARATOR}`))
       const filesResults = await queryFiles(
         filteredFolderResults.map(folder => folder.id)
       )
       const filteredFilesResults = removeFilesWithoutParentFolder(filesResults, filteredFolderResults)
         .map(file => ({ path: [...getFullPath(idToFolder[file.folder], idToFolder), file.name], ...file }))
+        .filter(file => query.isFileMatch(`${FILE_CABINET_PATH_SEPARATOR}${file.path.join(FILE_CABINET_PATH_SEPARATOR)}`))
       fileCabinetResults = { filesResults: filteredFilesResults, foldersResults: filteredFolderResults }
     }
     return fileCabinetResults

--- a/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
@@ -486,7 +486,7 @@ SuiteAppFileCabinetOperations => {
           typeName: 'file',
           values: file.values,
         })),
-      ].filter(file => query.isFileMatch(`/${file.path.join(FILE_CABINET_PATH_SEPARATOR)}`)),
+      ],
       failedPaths: {
         otherError: failedPaths.map(fileCabinetPath => `/${fileCabinetPath.join(FILE_CABINET_PATH_SEPARATOR)}`),
         lockedError: lockedPaths.map(fileCabinetPath => `/${fileCabinetPath.join(FILE_CABINET_PATH_SEPARATOR)}`),

--- a/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
@@ -358,16 +358,13 @@ SuiteAppFileCabinetOperations => {
 
       const subFoldersResults = await querySubFolders(topLevelFoldersResults)
       const foldersResults = topLevelFoldersResults.concat(subFoldersResults)
-      // console.log(foldersResults)
       const idToFolder = _.keyBy(foldersResults, folder => folder.id)
-      // console.log(idToFolder)
       const folderIdAndPaths = foldersResults
         .map(folderResult => ({
           path: getFullPath(folderResult, idToFolder).join(FILE_CABINET_PATH_SEPARATOR),
           id: folderResult.id,
         }))
         .filter(folderIdAndPath => query.isFileMatch(`/${folderIdAndPath.path}`))
-      // TODO: remove this timer when done
       const filesResults = await log.time(() => queryFiles(
         folderIdAndPaths.filter(folder => query.isFileMatch(`/${folder.path}/`)).map(folder => folder.id)
       ), 'shulikTest')
@@ -386,7 +383,6 @@ SuiteAppFileCabinetOperations => {
 
     const { foldersResults, filesResults } = await queryFileCabinet(query)
     const idToFolder = _.keyBy(foldersResults, folder => folder.id)
-    console.log('got here1')
     const foldersCustomizationInfo = foldersResults.map(folder => ({
       path: getFullPath(folder, idToFolder),
       typeName: 'folder',
@@ -398,7 +394,6 @@ SuiteAppFileCabinetOperations => {
         internalId: folder.id,
       },
     })).filter(folder => query.isFileMatch(`/${folder.path.join(FILE_CABINET_PATH_SEPARATOR)}`))
-    console.log('###### got here #######')
 
     const filesCustomizations = filesResults.map(file => ({
       path: [...getFullPath(idToFolder[file.folder], idToFolder), file.name],

--- a/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
@@ -362,12 +362,13 @@ SuiteAppFileCabinetOperations => {
 
       const subFoldersResults = await querySubFolders(topLevelFoldersResults)
       const foldersResults = topLevelFoldersResults.concat(subFoldersResults)
+
       const folderIdsSet = new Set(foldersResults.map(folder => folder.id))
       const idToFolder = _.keyBy(foldersResults, folder => folder.id)
       const filteredFolderResults = removeResultsWithoutParentFolder(foldersResults, folderIdsSet)
         .map(folder => ({ path: getFullPath(folder, idToFolder), ...folder }))
         // remove excluded folders before creating the query
-        .filter(folder => query.isFileMatch(`${FILE_CABINET_PATH_SEPARATOR}${folder.path.join(FILE_CABINET_PATH_SEPARATOR)}${FILE_CABINET_PATH_SEPARATOR}`))
+        .filter(folder => query.isFileMatch(`${FILE_CABINET_PATH_SEPARATOR}${folder.path.join(FILE_CABINET_PATH_SEPARATOR)}`))
       const filesResults = await queryFiles(
         filteredFolderResults.map(folder => folder.id)
       )

--- a/packages/netsuite-adapter/test/suiteapp_file_cabinet.test.ts
+++ b/packages/netsuite-adapter/test/suiteapp_file_cabinet.test.ts
@@ -465,6 +465,17 @@ describe('suiteapp_file_cabinet', () => {
       await expect(createSuiteAppFileCabinetOperations(suiteAppClient)
         .importFileCabinet(query)).rejects.toThrow()
     })
+
+    it('should remove excluded folder before creating the file cabinet query', async () => {
+      query.isFileMatch.mockImplementation(path => !path.includes('folder4'))
+      const { elements } = await createSuiteAppFileCabinetOperations(suiteAppClient)
+        .importFileCabinet(query)
+      expect(elements).toEqual([
+        expectedResults[0],
+        expectedResults[1],
+        expectedResults[3],
+      ])
+    })
   })
 
   describe('isChangeDeployable', () => {

--- a/packages/netsuite-adapter/test/suiteapp_file_cabinet.test.ts
+++ b/packages/netsuite-adapter/test/suiteapp_file_cabinet.test.ts
@@ -471,6 +471,11 @@ describe('suiteapp_file_cabinet', () => {
       query.isFileMatch.mockImplementation(path => !path.includes('folder4'))
       const { elements } = await createSuiteAppFileCabinetOperations(suiteAppClient)
         .importFileCabinet(query)
+      const testWhereQuery = 'hideinbundle = \'F\' AND folder IN (5, 3)'
+      const suiteQlQuery = 'SELECT name, id, filesize, bundleable, isinactive, isonline,'
+      + ' addtimestamptourl, hideinbundle, description, folder, islink, url'
+      + ` FROM file WHERE ${testWhereQuery} ORDER BY id ASC`
+      expect(suiteAppClient.runSuiteQL).toHaveBeenNthCalledWith(3, suiteQlQuery)
       expect(elements).toEqual([
         expectedResults[0],
         expectedResults[1],

--- a/packages/netsuite-adapter/test/suiteapp_file_cabinet.test.ts
+++ b/packages/netsuite-adapter/test/suiteapp_file_cabinet.test.ts
@@ -358,12 +358,13 @@ describe('suiteapp_file_cabinet', () => {
     })
 
     it('should filter files with query', async () => {
-      query.isFileMatch.mockImplementation(path => path !== '/folder5/folder4' && path !== '/folder5/folder3/file1')
+      query.isFileMatch.mockImplementation(path => path !== '/folder5/folder3/file1')
       const { elements } = await createSuiteAppFileCabinetOperations(suiteAppClient)
         .importFileCabinet(query)
       expect(elements).toEqual([
         expectedResults[0],
         expectedResults[1],
+        expectedResults[2],
         expectedResults[4],
         expectedResults[5],
       ])


### PR DESCRIPTION
_File cabinet query will not contain paths excluded in the adapter config_

---

_None_

---
_Release Notes_: 
__Netsuite Adapter__:
* Paths excluded in the adapter config will be filtered out before creating the file cabinet query and will not be queried
---
_User Notifications_: 
_None_
