### PR TITLE
SALTO-3866: fix deploy of custom_role modification

### DIFF
--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -134,6 +134,7 @@ import sideConversationsFilter from './filters/side_conversation'
 import { isCurrentUserResponse } from './user_utils'
 import addAliasFilter from './filters/add_alias'
 import macroFilter from './filters/macro'
+import customRoleDeployFilter from './filters/custom_role_deploy'
 
 const { makeArray } = collections.array
 const log = logger(module)
@@ -188,6 +189,7 @@ export const DEFAULT_FILTERS = [
   macroFilter,
   macroAttachmentsFilter,
   ticketFormDeploy,
+  customRoleDeployFilter,
   sideConversationsFilter,
   brandLogoFilter,
   // removeBrandLogoFilter should be after brandLogoFilter

--- a/packages/zendesk-adapter/src/filters/custom_role_deploy.ts
+++ b/packages/zendesk-adapter/src/filters/custom_role_deploy.ts
@@ -1,0 +1,80 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  Change, DeployResult, getChangeData,
+  InstanceElement, isInstanceChange, isModificationChange, ModificationChange,
+} from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { applyDetailedChanges, detailedCompare } from '@salto-io/adapter-utils'
+import { FilterCreator } from '../filter'
+import { CUSTOM_ROLE_TYPE_NAME } from '../constants'
+import { deployChange, deployChanges } from '../deployment'
+
+
+const returnEditedInstanceFromChange = (change: ModificationChange<InstanceElement>): InstanceElement => {
+  const relevantChangesInstance = change.data.after.clone()
+  relevantChangesInstance.value = {}
+  // we need to keep the id for the api call
+  relevantChangesInstance.value.id = change.data.after.value.id
+  const detailedChanges = detailedCompare(change.data.before, change.data.after)
+  applyDetailedChanges(relevantChangesInstance, detailedChanges)
+  return relevantChangesInstance
+}
+
+const editCustomRoleModificationChange = (change: ModificationChange<InstanceElement>)
+  : ModificationChange<InstanceElement> => ({
+  ...change,
+  data: {
+    before: change.data.before,
+    after: returnEditedInstanceFromChange(change),
+  },
+})
+
+
+/**
+ * This filter makes sure that only the modified fields in custom role modification changes are sent in the request.
+ */
+const filterCreator: FilterCreator = ({ client, config }) => ({
+  name: 'customRoleFilter',
+  deploy: async (changes: Change<InstanceElement>[]) => {
+    const [customRoleModificationChanges, leftoverChanges] = _.partition(
+      changes,
+      change => isModificationChange(change) && isInstanceChange(change)
+        && getChangeData(change).elemID.typeName === CUSTOM_ROLE_TYPE_NAME,
+    )
+
+    const editedCustomRoleModificationChanges = customRoleModificationChanges
+      .filter(isModificationChange)
+      .map(editCustomRoleModificationChange)
+
+    const tempDeployResult = await deployChanges(
+      editedCustomRoleModificationChanges,
+      async change => {
+        await deployChange(change, client, config.apiDefinitions)
+      }
+    )
+    const deployedChangesElemId = new Set(tempDeployResult.appliedChanges
+      .map(change => getChangeData(change).elemID.getFullName()))
+
+    const deployResult: DeployResult = {
+      appliedChanges: customRoleModificationChanges
+        .filter(change => deployedChangesElemId.has(getChangeData(change).elemID.getFullName())),
+      errors: tempDeployResult.errors,
+    }
+    return { deployResult, leftoverChanges }
+  },
+})
+export default filterCreator

--- a/packages/zendesk-adapter/test/filters/custom_role_deploy.test.ts
+++ b/packages/zendesk-adapter/test/filters/custom_role_deploy.test.ts
@@ -1,0 +1,152 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  ObjectType, ElemID, InstanceElement, toChange,
+} from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import { createFilterCreatorParams } from '../utils'
+import { CUSTOM_ROLE_TYPE_NAME, ZENDESK } from '../../src/constants'
+import filterCreator from '../../src/filters/custom_role_deploy'
+
+const mockDeployChange = jest.fn()
+jest.mock('@salto-io/adapter-components', () => {
+  const actual = jest.requireActual('@salto-io/adapter-components')
+  return {
+    ...actual,
+    deployment: {
+      ...actual.deployment,
+      deployChange: jest.fn((...args) => mockDeployChange(...args)),
+    },
+  }
+})
+
+describe('customRoleDeploy filter', () => {
+  type FilterType = filterUtils.FilterWith<'deploy'>
+  let filter: FilterType
+  const customRoleType = new ObjectType({ elemID: new ElemID(ZENDESK, CUSTOM_ROLE_TYPE_NAME) })
+  const customRoleBeforeInstnace1 = new InstanceElement(
+    'customRoleBefore1',
+    customRoleType,
+    {
+      id: 1337,
+      name: 'role1',
+      description: 'role1 description',
+      configuration: {
+        twitter_search_access: false,
+        forum_access_restricted_content: false,
+        end_user_list_access: 'full',
+        ticket_access: 'within-groups',
+        ticket_comment_access: 'none',
+      },
+    }
+  )
+  const customRoleAfterInstnace1 = new InstanceElement(
+    'customRoleBefore1',
+    customRoleType,
+    {
+      id: 1337,
+      name: 'role1 after',
+      description: 'role1 description after',
+      configuration: {
+        twitter_search_access: true,
+        forum_access_restricted_content: false,
+        end_user_list_access: 'full',
+        ticket_access: 'all',
+        ticket_comment_access: 'none',
+      },
+    }
+  )
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
+  })
+
+  describe('deploy', () => {
+    it('should pass the correct params to deployChange for modification change', async () => {
+      mockDeployChange.mockImplementation(async () => ({ [CUSTOM_ROLE_TYPE_NAME]: {
+        ...customRoleAfterInstnace1.value,
+      } }))
+      const res = await filter.deploy([
+        toChange({ before: customRoleBeforeInstnace1, after: customRoleAfterInstnace1 }),
+      ])
+      const newDataInstance = new InstanceElement(
+        'customRoleBefore1',
+        customRoleType,
+        {
+          id: 1337,
+          name: 'role1 after',
+          description: 'role1 description after',
+          configuration: {
+            twitter_search_access: true,
+            ticket_access: 'all',
+          },
+        }
+      )
+      expect(mockDeployChange).toHaveBeenCalledTimes(1)
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: toChange({ before: customRoleBeforeInstnace1, after: newDataInstance }),
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+      })
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.deployResult.appliedChanges).toHaveLength(1)
+      expect(res.deployResult.appliedChanges)
+        .toEqual([toChange({ before: customRoleBeforeInstnace1, after: customRoleAfterInstnace1 })])
+    })
+    it('should do nothing for addition and removal changes', async () => {
+      mockDeployChange.mockImplementation(async () => ({}))
+      const res = await filter
+        .deploy([
+          toChange({ before: customRoleBeforeInstnace1 }),
+          toChange({ after: customRoleAfterInstnace1 }),
+        ])
+      expect(mockDeployChange).toHaveBeenCalledTimes(0)
+      expect(res.leftoverChanges).toHaveLength(2)
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.deployResult.appliedChanges).toHaveLength(0)
+    })
+    it('should return an error iF the deploy did not work', async () => {
+      mockDeployChange.mockImplementation(async () => { throw new Error('ERR') })
+      const res = await filter.deploy([
+        toChange({ before: customRoleBeforeInstnace1, after: customRoleAfterInstnace1 }),
+      ])
+      const newDataInstance = new InstanceElement(
+        'customRoleBefore1',
+        customRoleType,
+        {
+          id: 1337,
+          name: 'role1 after',
+          description: 'role1 description after',
+          configuration: {
+            twitter_search_access: true,
+            ticket_access: 'all',
+          },
+        }
+      )
+      expect(mockDeployChange).toHaveBeenCalledTimes(1)
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: toChange({ before: customRoleBeforeInstnace1, after: newDataInstance }),
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+      })
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toHaveLength(1)
+      expect(res.deployResult.appliedChanges).toHaveLength(0)
+    })
+  })
+})


### PR DESCRIPTION
 fix deploy of custom_role modification

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* fix bug in the deployment of custom_role modification (specifically modifications in roles that cannot be fully edited such as `light_agent`)

---
_User Notifications_: 
None
