### PR TITLE
SAAS-7602: Skip all workspace updates on ignoreFileChanges

### DIFF
--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -456,6 +456,13 @@ export const loadWorkspace = async (
     const stateToBuild = workspaceState !== undefined
       ? await workspaceState
       : await initState()
+
+    if (ignoreFileChanges) {
+      // Skip all updates to the state since this flag means we are operating under the assumption
+      // that everything is already up to date and no action is required
+      return stateToBuild
+    }
+
     const updateWorkspace = async (envName: string): Promise<void> => {
       const source = naclFilesSource
       const getElementsDependents = async (


### PR DESCRIPTION
When the ignoreFileChanges flag to loadWorkspace is set to true, skip all calculations Before this change there was a case where workspace indices would still be calculated in order to make sure the workspace state is valid once it is loaded.

however, the meaning of ignoreFileChanges is now extended to ignore all changes, including cache invalidation in that case, there is no need to check anything when the workspace is loaded

---

No release notes because no flow in the OSS uses this flag

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_