### PR TITLE
SALTO-3978 Avoid stopping pagination on empty filtered page

### DIFF
--- a/packages/adapter-components/src/client/pagination.ts
+++ b/packages/adapter-components/src/client/pagination.ts
@@ -127,12 +127,15 @@ export const traverseRequests: (
         ? response.data.items
         : makeArray(response.data)
     ).flatMap(extractPageEntries)
-    const page = customEntryExtractor ? entries.flatMap(customEntryExtractor) : entries
 
-    if (page.length === 0) {
+    // checking original entries and not the ones that passed the custom extractor, because even if all entries are
+    // filtered out we should still continue querying
+    if (entries.length === 0) {
       // eslint-disable-next-line no-continue
       continue
     }
+    const page = customEntryExtractor ? entries.flatMap(customEntryExtractor) : entries
+
     yield page
     numResults += page.length
 


### PR DESCRIPTION
Fix bug in the pagination logic, where we would stop pagination not only if a page was empty, but also if the filtered results of the page (when using a custom entry extractor) were empty. this can cause pagination to stop mid-way (e.g. in jira - if a full page of project-scope entries is received).

---

This only impacted Jira, since this is currently the only adapter using a `customEntryExtractor`.

---
_Release Notes_: 
_Jira Adapter_:
* Fix bug where in some cases not all instances would be returned during fetch, when a full page of project-scoped items was returned.

---
_User Notifications_: 
_Jira Adapter_:
* Fix bug where in some cases not all instances would be returned during fetch
