### PR TITLE
SALTO-3763: update system note query

### DIFF
--- a/packages/netsuite-adapter/src/filters/author_information/system_note.ts
+++ b/packages/netsuite-adapter/src/filters/author_information/system_note.ts
@@ -66,9 +66,6 @@ Promise<EmployeeResult[]> => {
 const toDateQuery = (lastFetchTime: Date): string =>
   `date >= ${toSuiteQLWhereDateString(lastFetchTime)}`
 
-const toRecordTypeWhereQuery = (recordType: string): string =>
-  `recordtypeid = '${recordType}'`
-
 // File and folder types have system notes without record type ids,
 // But they have a prefix in the field column.
 const toFieldWhereQuery = (recordType: string): string => (
@@ -82,10 +79,9 @@ const buildRecordTypeSystemNotesQuery = (
   lastFetchTime: Date
 ): string => {
   const whereQuery = recordTypeIds
-    .map(toRecordTypeWhereQuery)
-    .join(' OR ')
+    .join(', ')
   return 'SELECT name, recordid, recordtypeid, date FROM (SELECT name, recordid, recordtypeid,'
-    + ` ${toSuiteQLSelectDateString('MAX(date)')} as date FROM systemnote WHERE ${toDateQuery(lastFetchTime)} AND (${whereQuery})`
+    + ` ${toSuiteQLSelectDateString('MAX(date)')} as date FROM systemnote WHERE ${toDateQuery(lastFetchTime)} AND recordtypeid IN (${whereQuery})`
     + ' GROUP BY name, recordid, recordtypeid) ORDER BY name, recordid, recordtypeid ASC'
 }
 

--- a/packages/netsuite-adapter/src/filters/author_information/system_note.ts
+++ b/packages/netsuite-adapter/src/filters/author_information/system_note.ts
@@ -78,10 +78,9 @@ const buildRecordTypeSystemNotesQuery = (
   recordTypeIds: string[],
   lastFetchTime: Date
 ): string => {
-  const whereQuery = recordTypeIds
-    .join(', ')
+  const recordTypeMatchClause = `recordtypeid IN (${recordTypeIds.join(', ')})`
   return 'SELECT name, recordid, recordtypeid, date FROM (SELECT name, recordid, recordtypeid,'
-    + ` ${toSuiteQLSelectDateString('MAX(date)')} as date FROM systemnote WHERE ${toDateQuery(lastFetchTime)} AND recordtypeid IN (${whereQuery})`
+    + ` ${toSuiteQLSelectDateString('MAX(date)')} as date FROM systemnote WHERE ${toDateQuery(lastFetchTime)} AND ${recordTypeMatchClause}`
     + ' GROUP BY name, recordid, recordtypeid) ORDER BY name, recordid, recordtypeid ASC'
 }
 

--- a/packages/netsuite-adapter/test/filters/author_information/system_note.test.ts
+++ b/packages/netsuite-adapter/test/filters/author_information/system_note.test.ts
@@ -109,7 +109,7 @@ describe('netsuite system note author information', () => {
   it('should query information from api', async () => {
     await filterCreator(filterOpts).onFetch?.(elements)
     const fieldSystemNotesQuery = `SELECT name, field, recordid, date from (SELECT name, field, recordid, ${toSuiteQLSelectDateString('MAX(date)')} AS date FROM (SELECT name, REGEXP_SUBSTR(field, '^(MEDIAITEMFOLDER.|MEDIAITEM.)') AS field, recordid, date FROM systemnote WHERE date >= ${toSuiteQLWhereDateString(new Date('2022-01-01'))} AND (field LIKE 'MEDIAITEM.%' OR field LIKE 'MEDIAITEMFOLDER.%')) GROUP BY name, field, recordid) ORDER BY name, field, recordid ASC`
-    const recordTypeSystemNotesQuery = `SELECT name, recordid, recordtypeid, date FROM (SELECT name, recordid, recordtypeid, ${toSuiteQLSelectDateString('MAX(date)')} as date FROM systemnote WHERE date >= ${toSuiteQLWhereDateString(new Date('2022-01-01'))} AND (recordtypeid = '-112' OR recordtypeid = '1' OR recordtypeid = '-123') GROUP BY name, recordid, recordtypeid) ORDER BY name, recordid, recordtypeid ASC`
+    const recordTypeSystemNotesQuery = `SELECT name, recordid, recordtypeid, date FROM (SELECT name, recordid, recordtypeid, ${toSuiteQLSelectDateString('MAX(date)')} as date FROM systemnote WHERE date >= ${toSuiteQLWhereDateString(new Date('2022-01-01'))} AND recordtypeid IN (-112, 1, -123) GROUP BY name, recordid, recordtypeid) ORDER BY name, recordid, recordtypeid ASC`
     expect(runSuiteQLMock).toHaveBeenNthCalledWith(1, EMPLOYEE_NAME_QUERY)
     expect(runSuiteQLMock).toHaveBeenNthCalledWith(2, fieldSystemNotesQuery)
     expect(runSuiteQLMock).toHaveBeenNthCalledWith(3, recordTypeSystemNotesQuery)
@@ -120,7 +120,7 @@ describe('netsuite system note author information', () => {
     await filterCreator(filterOpts).onFetch?.(
       [accountInstance, customRecordType, customRecord, customRecordTypeWithNoInstances, missingInstance]
     )
-    const systemNotesQuery = `SELECT name, recordid, recordtypeid, date FROM (SELECT name, recordid, recordtypeid, ${toSuiteQLSelectDateString('MAX(date)')} as date FROM systemnote WHERE date >= ${toSuiteQLWhereDateString(new Date('2022-01-01'))} AND (recordtypeid = '-112' OR recordtypeid = '1' OR recordtypeid = '-123') GROUP BY name, recordid, recordtypeid) ORDER BY name, recordid, recordtypeid ASC`
+    const systemNotesQuery = `SELECT name, recordid, recordtypeid, date FROM (SELECT name, recordid, recordtypeid, ${toSuiteQLSelectDateString('MAX(date)')} as date FROM systemnote WHERE date >= ${toSuiteQLWhereDateString(new Date('2022-01-01'))} AND recordtypeid IN (-112, 1, -123) GROUP BY name, recordid, recordtypeid) ORDER BY name, recordid, recordtypeid ASC`
     expect(runSuiteQLMock).toHaveBeenNthCalledWith(1, EMPLOYEE_NAME_QUERY)
     expect(runSuiteQLMock).toHaveBeenNthCalledWith(2, systemNotesQuery)
     expect(runSuiteQLMock).toHaveBeenCalledTimes(2)


### PR DESCRIPTION
_Systemnotes recordtypes query changed to use IN instead of concatenation of OR's_

---

_None_

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
