### PR TITLE
SALTO-3779 Always add remaining types on fetch

### DIFF
--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -502,7 +502,7 @@ export default class ZendeskAdapter implements AdapterOperations {
       ? _.omit(allSupportedTypes, ...Object.keys(GUIDE_SUPPORTED_TYPES))
       : _.omit(allSupportedTypes, ...Object.keys(GUIDE_BRAND_SPECIFIC_TYPES))
     // Zendesk Support and (if enabled) global Zendesk Guide types
-    const defaultSubdomainElements = await getAllElements({
+    const defaultSubdomainResult = await getAllElements({
       adapterName: ZENDESK,
       types: this.userConfig.apiDefinitions.types,
       shouldAddRemainingTypes: isGuideDisabled,
@@ -516,11 +516,17 @@ export default class ZendeskAdapter implements AdapterOperations {
     })
 
     if (isGuideDisabled || _.isEmpty(this.userConfig[FETCH_CONFIG].guide?.brands)) {
-      return defaultSubdomainElements
+      return defaultSubdomainResult
+    }
+
+    const combinedRes = {
+      configChanges: (defaultSubdomainResult.configChanges ?? []),
+      elements: defaultSubdomainResult.elements,
+      errors: (defaultSubdomainResult.errors ?? []),
     }
 
     const brandsList = getBrandsForGuide(
-      defaultSubdomainElements.elements.filter(isInstanceElement),
+      defaultSubdomainResult.elements.filter(isInstanceElement),
       this.userConfig[FETCH_CONFIG]
     )
 
@@ -528,54 +534,45 @@ export default class ZendeskAdapter implements AdapterOperations {
       const brandPatterns = Array.from(this.userConfig[FETCH_CONFIG].guide?.brands ?? []).join(', ')
       const message = `Could not find any brands matching the included patterns: [${brandPatterns}]. Please update the configuration under fetch.guide.brands in the configuration file`
       log.warn(message)
-      return {
-        configChanges: defaultSubdomainElements.configChanges,
-        elements: defaultSubdomainElements.elements,
-        errors: (defaultSubdomainElements.errors ?? []).concat([
-          {
-            message,
-            severity: 'Warning',
-          },
-        ]),
-      }
+      combinedRes.errors = (combinedRes.errors).concat([{
+        message,
+        severity: 'Warning',
+      }])
+    } else {
+      const brandToPaginator = Object.fromEntries(brandsList.map(brandInstance => (
+        [
+          brandInstance.elemID.name,
+          createPaginator({
+            client: this.createClientBySubdomain(brandInstance.value.subdomain),
+            paginationFuncCreator: paginate,
+          }),
+        ]
+      )))
+
+      const zendeskGuideElements = await getGuideElements({
+        brandsList,
+        brandToPaginator,
+        apiDefinitions: this.userConfig[API_DEFINITIONS_CONFIG],
+        fetchQuery: this.fetchQuery,
+        getElemIdFunc: this.getElemIdFunc,
+      })
+
+      combinedRes.configChanges = combinedRes.configChanges.concat(zendeskGuideElements.configChanges ?? [])
+      combinedRes.elements = combinedRes.elements.concat(zendeskGuideElements.elements)
+      combinedRes.errors = combinedRes.errors.concat(zendeskGuideElements.errors ?? [])
     }
-
-    const brandToPaginator = Object.fromEntries(brandsList.map(brandInstance => (
-      [
-        brandInstance.elemID.name,
-        createPaginator({
-          client: this.createClientBySubdomain(brandInstance.value.subdomain),
-          paginationFuncCreator: paginate,
-        }),
-      ]
-    )))
-
-    const zendeskGuideElements = await getGuideElements({
-      brandsList,
-      brandToPaginator,
-      apiDefinitions: this.userConfig[API_DEFINITIONS_CONFIG],
-      fetchQuery: this.fetchQuery,
-      getElemIdFunc: this.getElemIdFunc,
-    })
 
     // Remaining types should be added once to avoid overlaps between the generated elements,
     // so we add them once after all elements are generated
-    const zendeskElements = defaultSubdomainElements.elements.concat(zendeskGuideElements.elements)
     addRemainingTypes({
       adapterName: ZENDESK,
-      elements: zendeskElements,
+      elements: combinedRes.elements,
       typesConfig: this.userConfig.apiDefinitions.types,
       supportedTypes: _.merge(supportedTypes, GUIDE_BRAND_SPECIFIC_TYPES),
       typeDefaultConfig: this.userConfig.apiDefinitions.typeDefaults,
     })
 
-    return {
-      configChanges: (defaultSubdomainElements.configChanges ?? [])
-        .concat(zendeskGuideElements.configChanges ?? []),
-      elements: zendeskElements,
-      errors: (defaultSubdomainElements.errors ?? [])
-        .concat(zendeskGuideElements.errors ?? []),
-    }
+    return combinedRes
   }
 
   private async isLocaleEnUs(): Promise<SaltoError | undefined> {


### PR DESCRIPTION
Fix bug in Zendesk where we would sometimes run into merge conflicts on deploy, due to the `id` values not being hidden properly.

The scenario is very specific:
1. The fetch config has Guide enabled, but no matching brand has Guide enabled in the service
2. An instance is added during deploy for a type that has 0 existing instances (and has an `id` field)

---

The reason this happens is that we use `addRemainingTypes` to ensure all hidden fields are defined properly - and this function did not run in this scenario due to an early return. 

---
_Release Notes_: 
_Zendesk Adapter_:
* Fix bug where deploying the first instance of its kind might result in merge errors, for environments with Guide enabled but without Guide elements

---
_User Notifications_: 
None