### PR TITLE
SALTO-3997: Change typeNameOverrides validations

### DIFF
--- a/packages/adapter-components/src/config/swagger.ts
+++ b/packages/adapter-components/src/config/swagger.ts
@@ -166,13 +166,12 @@ const validateTypeNameOverrides = (
   typeNames: string[]
 ): void => {
   const allRenamedTypes = typeNameOverrides.flat()
-  const originalNames = allRenamedTypes.map(t => t.originalName)
   const newNames = allRenamedTypes.map(t => t.newName)
   const newNameDuplicates = findDuplicates(newNames)
   if (newNameDuplicates.length > 0) {
     throw new Error(`Duplicate type names in ${apiDefinitionConfigPath}.typeNameOverrides: ${newNameDuplicates}`)
   }
-  const originalNameDuplicates = findDuplicates(originalNames)
+  const originalNameDuplicates = findDuplicates(allRenamedTypes.map(t => t.originalName))
   if (originalNameDuplicates.length > 0) {
     throw new Error(`Duplicate type names in ${apiDefinitionConfigPath}.typeNameOverrides: ${originalNameDuplicates}`)
   }

--- a/packages/adapter-components/src/config/swagger.ts
+++ b/packages/adapter-components/src/config/swagger.ts
@@ -165,21 +165,21 @@ const validateTypeNameOverrides = (
   typeNameOverrides: TypeNameOverrideConfig[],
   typeNames: string[]
 ): void => {
-  const allRenamedTypes = typeNameOverrides.flat()
-  const newNames = allRenamedTypes.map(t => t.newName)
+  const newNames = typeNameOverrides.map(t => t.newName)
   const newNameDuplicates = findDuplicates(newNames)
   if (newNameDuplicates.length > 0) {
     throw new Error(`Duplicate type names in ${apiDefinitionConfigPath}.typeNameOverrides: ${newNameDuplicates}`)
   }
-  const originalNameDuplicates = findDuplicates(allRenamedTypes.map(t => t.originalName))
+  const originalNames = typeNameOverrides.map(t => t.originalName)
+  const originalNameDuplicates = findDuplicates(originalNames)
   if (originalNameDuplicates.length > 0) {
     throw new Error(`Duplicate type names in ${apiDefinitionConfigPath}.typeNameOverrides: ${originalNameDuplicates}`)
   }
   const newTypeNames = new Set(newNames)
   const invalidTypeNames = new Set(
-    typeNameOverrides.map(t => t.originalName).filter(originalName => !newTypeNames.has(originalName))
+    originalNames.filter(originalName => !newTypeNames.has(originalName))
   )
-  const invalidTypes = typeNames.filter(r => invalidTypeNames.has(r))
+  const invalidTypes = typeNames.filter(t => invalidTypeNames.has(t))
   if (invalidTypes.length > 0) {
     throw new Error(`Invalid type names in ${apiDefinitionConfigPath}: ${[...invalidTypes].sort()} were renamed in ${apiDefinitionConfigPath}.typeNameOverrides`)
   }

--- a/packages/adapter-components/test/config/swagger.test.ts
+++ b/packages/adapter-components/test/config/swagger.test.ts
@@ -101,6 +101,7 @@ describe('config_swagger', () => {
             ],
             typeNameOverrides: [
               { newName: 'aaa', originalName: 'bbb' },
+              { newName: 'ccc', originalName: 'aaa' },
             ],
           },
           typeDefaults: {
@@ -189,6 +190,36 @@ describe('config_swagger', () => {
           supportedTypes: {},
         },
       )).toThrow(new Error('Duplicate type names in PATH.typeNameOverrides: bbb,eee'))
+    })
+    it('should throw when multiple types have the same overrides', () => {
+      expect(() => validateSwaggerApiDefinitionConfig(
+        'PATH',
+        {
+          swagger: {
+            url: '/a/b/c',
+            additionalTypes: [
+              { typeName: 'abc', cloneFrom: 'def' },
+            ],
+            typeNameOverrides: [
+              { newName: 'ccc', originalName: 'aaa' },
+              { newName: 'ccc', originalName: 'bbb' },
+            ],
+          },
+          typeDefaults: {
+            transformation: {
+              idFields: ['a', 'b'],
+            },
+          },
+          types: {
+            abc: {
+              transformation: {
+                idFields: ['something', 'else'],
+              },
+            },
+          },
+          supportedTypes: {},
+        },
+      )).toThrow(new Error('Duplicate type names in PATH.typeNameOverrides: ccc'))
     })
     it('should not throw when supportedTypes is non-empty', () => {
       expect(() => validateSwaggerApiDefinitionConfig(

--- a/packages/adapter-components/test/elements/swagger/petstore_swagger.v2.yaml
+++ b/packages/adapter-components/test/elements/swagger/petstore_swagger.v2.yaml
@@ -597,6 +597,13 @@ paths:
           description: successful operation
           schema:
             $ref: '#/definitions/Food'
+  /newPet/all:
+    get:
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/NewPet'       
 securityDefinitions:
   petstore_auth:
     type: oauth2
@@ -766,6 +773,28 @@ definitions:
           - sold
     xml:
       name: Pet
+  NewPet:
+    type: object
+    required:
+      - name
+    properties:
+      id:
+        type: integer
+        format: int64
+      category:
+        $ref: '#/definitions/Category'
+      name:
+        type: string
+        example: doggie
+      status:
+        type: string
+        description: pet status in the store
+        enum:
+          - available
+          - pending
+          - sold
+    xml:
+      name: NewPet
   ApiResponse:
     type: object
     properties:

--- a/packages/adapter-components/test/elements/swagger/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/type_elements.test.ts
@@ -191,7 +191,7 @@ describe('swagger_type_elements', () => {
       }
 
       it('should generate the right types for swagger v2 yaml', async () => {
-        await validateV2(`${BASE_DIR}/petstore_swagger.v2.yaml`)
+        await validateV2(`${BASE_DIR}/petstore_swagger.v2.yaml`, [], { NewPet: { request: { url: '/newPet/all' } } })
       })
       it('should generate the right types for swagger v2 json', async () => {
         await validateV2(`${BASE_DIR}/petstore_swagger.v2.json`)
@@ -219,6 +219,7 @@ describe('swagger_type_elements', () => {
               ],
               typeNameOverrides: [
                 { originalName: 'pet__findByTags', newName: 'PetByTag' },
+                { originalName: 'NewPet', newName: 'Pet' },
                 { originalName: 'Pet', newName: 'Pet__new' },
               ],
             },
@@ -258,6 +259,7 @@ describe('swagger_type_elements', () => {
               Food: ['Food'],
               FoodAndCategory: ['FoodAndCategory'],
               Order: ['Order'],
+              Pet: ['Pet'],
               Pet2: ['Pet2'],
               Pet3: ['Pet3'],
               PetByTag: ['PetByTag'],
@@ -274,11 +276,12 @@ describe('swagger_type_elements', () => {
         parsedConfigs = res.parsedConfigs
       })
       it('should generate the right types', () => {
-        const updatedExpectedTypes = ['AdditionalType', 'Category', 'Food', 'FoodAndCategory', 'NestedType', 'Order', 'Pet2', 'Pet3', 'PetByTag', 'Pet__new', 'Tag', 'User', 'foodDetails', 'pet__findByStatus', 'store__inventory']
+        const updatedExpectedTypes = ['AdditionalType', 'Category', 'Food', 'FoodAndCategory', 'NestedType', 'Order', 'Pet', 'Pet2', 'Pet3', 'PetByTag', 'Pet__new', 'Tag', 'User', 'foodDetails', 'pet__findByStatus', 'store__inventory']
         expect(Object.keys(allTypes).sort()).toEqual(updatedExpectedTypes)
         // no Pet2 because it does not have a request config
         const updatedExpectedParsedConfigs = {
           Order: { request: { url: '/store/order/{orderId}' } },
+          Pet: { request: { url: '/newPet/all' } },
           // eslint-disable-next-line camelcase
           Pet__new: { request: { url: '/pet/{petId}' } },
           // eslint-disable-next-line camelcase
@@ -299,7 +302,7 @@ describe('swagger_type_elements', () => {
       })
 
       it('should not have anything under the original typenames', () => {
-        expect(allTypes.Pet).toBeUndefined()
+        expect(allTypes.NewPet).toBeUndefined()
         expect(allTypes.pet__findByTags).toBeUndefined()
       })
 


### PR DESCRIPTION
 Change typeNameOverrides validations

---

duplicates across `originalName` and `newName` are supported by the infra so in this PR I changed the validation to validate there are no dups in `newName` and `originalName` separately

---
_Release Notes_: 
None

---
_User Notifications_: 
None
