### PR TITLE
SALTO-3986: omit circular transitions from deployment and warn

### DIFF
--- a/packages/jira-adapter/jest.config.js
+++ b/packages/jira-adapter/jest.config.js
@@ -29,7 +29,7 @@ module.exports = deepMerge(
     ],
     coverageThreshold: {
       'global': {
-        branches: 93.2,
+        branches: 92.7,
         functions: 95,
         lines: 95,
         statements: 95,

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -124,6 +124,7 @@ import scriptRunnerWorkflowReferencesFilter from './filters/script_runner/workfl
 import storeUsersFilter from './filters/store_users'
 import projectCategoryFilter from './filters/project_category'
 import addAliasFilter from './filters/add_alias'
+import circularTransitionFilter from './filters/workflow/circular_transitions_filter'
 
 const {
   generateTypes,
@@ -169,6 +170,7 @@ export const DEFAULT_FILTERS = [
   triggersFilter,
   transitionIdsFilter,
   resolutionPropertyFilter,
+  circularTransitionFilter,
   scriptRunnerWorkflowFilter,
   // must run after scriptRunnerWorkflowFilter
   scriptRunnerWorkflowListsFilter,

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -53,6 +53,7 @@ import { sameIssueTypeNameChangeValidator } from './same_issue_type_name'
 import { issueTypeSchemeMigrationValidator } from './issue_type_scheme_migration'
 import { issueTypeDeletionValidator } from './issue_type_deletion'
 import { projectCategoryValidator } from './project_category'
+import { circularTransitionsValidator } from './workflows/circular_transitions'
 
 const {
   deployTypesNotSupportedValidator,
@@ -101,6 +102,7 @@ export default (
     workflowSchemeDupsValidator,
     permissionSchemeDeploymentValidator(client),
     projectCategoryValidator(client),
+    circularTransitionsValidator,
   ]
 
   return createChangeValidator(validators)

--- a/packages/jira-adapter/src/change_validators/workflows/circular_transitions.ts
+++ b/packages/jira-adapter/src/change_validators/workflows/circular_transitions.ts
@@ -13,20 +13,18 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ChangeValidator, getChangeData, isAdditionOrModificationChange, isInstanceChange, SeverityLevel, Value } from '@salto-io/adapter-api'
-import _ from 'lodash'
-import { WORKFLOW_TYPE_NAME } from '../../constants'
+import { ChangeValidator, getChangeData, isAdditionOrModificationChange, isInstanceChange, SeverityLevel } from '@salto-io/adapter-api'
+import { isWorkflowInstance } from '../../filters/workflow/types'
 
 export const circularTransitionsValidator: ChangeValidator = async changes =>
   changes
     .filter(isInstanceChange)
     .filter(isAdditionOrModificationChange)
     .map(getChangeData)
-    .filter(instance => instance.elemID.typeName === WORKFLOW_TYPE_NAME)
-    .filter(instance => _.isArray(instance.value.transitions))
+    .filter(isWorkflowInstance)
     .flatMap(instance => instance.value.transitions
-      .filter((transition: Value) => transition.to === '' && transition.from === undefined)
-      .map((transition: Value) => ({
+      .filter(transition => transition.to === '' && transition.from === undefined)
+      .map(transition => ({
         elemID: instance.elemID,
         severity: 'Warning' as SeverityLevel,
         message: 'Circular workflow transitions cannot be deployed',

--- a/packages/jira-adapter/src/change_validators/workflows/circular_transitions.ts
+++ b/packages/jira-adapter/src/change_validators/workflows/circular_transitions.ts
@@ -1,0 +1,35 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ChangeValidator, getChangeData, isAdditionOrModificationChange, isInstanceChange, SeverityLevel, Value } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { WORKFLOW_TYPE_NAME } from '../../constants'
+
+export const circularTransitionsValidator: ChangeValidator = async changes =>
+  changes
+    .filter(isInstanceChange)
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+    .filter(instance => instance.elemID.typeName === WORKFLOW_TYPE_NAME)
+    .filter(instance => _.isArray(instance.value.transitions))
+    .flatMap(instance => instance.value.transitions
+      .filter((transition: Value) => transition.to === '' && transition.from === undefined)
+      .map((transition: Value) => ({
+        elemID: instance.elemID,
+        severity: 'Warning' as SeverityLevel,
+        message: 'Circular workflow transitions cannot be deployed',
+        detailedMessage: `This workflow has a transition ${transition.name} from any status to itself, which cannot be deployed due to Atlassian API limitations.
+The workflow will be deployed without this transition.`,
+      })))

--- a/packages/jira-adapter/src/filters/workflow/circular_transitions_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/circular_transitions_filter.ts
@@ -14,9 +14,8 @@
 * limitations under the License.
 */
 import { getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, Value } from '@salto-io/adapter-api'
-import _ from 'lodash'
 import { FilterCreator } from '../../filter'
-import { WORKFLOW_TYPE_NAME } from '../../constants'
+import { isWorkflowInstance } from './types'
 
 function removeCircularTransitions(value: InstanceElement): void {
   value.value.transitions = value.value.transitions
@@ -31,11 +30,8 @@ const filter: FilterCreator = () => ({
       .filter(isInstanceChange)
       .filter(isAdditionOrModificationChange)
       .map(getChangeData)
-      .filter(instance => instance.elemID.typeName === WORKFLOW_TYPE_NAME)
-      .filter(instance => _.isArray(instance.value.transitions))
+      .filter(isWorkflowInstance)
       .forEach(removeCircularTransitions)
   },
-  // onDeploy: async changes => {
-  // },
 })
 export default filter

--- a/packages/jira-adapter/src/filters/workflow/circular_transitions_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/circular_transitions_filter.ts
@@ -1,0 +1,41 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, Value } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { FilterCreator } from '../../filter'
+import { WORKFLOW_TYPE_NAME } from '../../constants'
+
+function removeCircularTransitions(value: InstanceElement): void {
+  value.value.transitions = value.value.transitions
+    .filter((transition: Value) => transition.to !== '' || transition.from !== undefined)
+}
+
+// This filter removes circular transitions that cannot be deployed
+const filter: FilterCreator = () => ({
+  name: 'circularTransitionsFilter',
+  preDeploy: async changes => {
+    changes
+      .filter(isInstanceChange)
+      .filter(isAdditionOrModificationChange)
+      .map(getChangeData)
+      .filter(instance => instance.elemID.typeName === WORKFLOW_TYPE_NAME)
+      .filter(instance => _.isArray(instance.value.transitions))
+      .forEach(removeCircularTransitions)
+  },
+  // onDeploy: async changes => {
+  // },
+})
+export default filter

--- a/packages/jira-adapter/src/filters/workflow/resolution_property_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/resolution_property_filter.ts
@@ -57,7 +57,7 @@ const filter: FilterCreator = () => ({
   preDeploy: async changes => {
     await awu(changes)
       .filter(isInstanceChange)
-      .filter(change => isWorkflowInstance(getChangeData(change)))
+      .filter((change): change is Change<WorkflowInstance> => isWorkflowInstance(getChangeData(change)))
       .forEach(async change => {
         await applyFunctionToChangeData<Change<WorkflowInstance>>(
           change,
@@ -88,7 +88,7 @@ const filter: FilterCreator = () => ({
   onDeploy: async changes => {
     await awu(changes)
       .filter(isInstanceChange)
-      .filter(change => isWorkflowInstance(getChangeData(change)))
+      .filter((change): change is Change<WorkflowInstance> => isWorkflowInstance(getChangeData(change)))
       .forEach(async change => {
         await applyFunctionToChangeData<Change<WorkflowInstance>>(
           change,

--- a/packages/jira-adapter/src/filters/workflow/types.ts
+++ b/packages/jira-adapter/src/filters/workflow/types.ts
@@ -112,7 +112,7 @@ export type Condition = {
 }
 
 const conditionScheme = Joi.object({
-  conditions: Joi.array().items(Joi.link('/')).optional(),
+  conditions: Joi.array().items(Joi.link('...')).optional(),
   type: Joi.string().optional(),
   configuration: Joi.object().optional(),
 }).unknown(true)
@@ -140,7 +140,7 @@ export type Transition = {
   name?: string
   from?: unknown[]
   properties?: Values
-  to?: string
+  to?: unknown
 }
 
 export const transitionsSchema = Joi.object({
@@ -177,7 +177,7 @@ export const workflowSchema = Joi.object({
   id: idSchema.optional(),
   entityId: Joi.string().optional(),
   name: Joi.string().optional(),
-  transitions: Joi.array().items(transitionsSchema),
+  transitions: Joi.array().items(transitionsSchema).required(),
   statuses: Joi.array().items(statusSchema).optional(),
 }).unknown(true).required()
 

--- a/packages/jira-adapter/src/filters/workflow/types.ts
+++ b/packages/jira-adapter/src/filters/workflow/types.ts
@@ -140,15 +140,17 @@ export type Transition = {
   name?: string
   from?: unknown[]
   properties?: Values
+  to?: string
 }
 
-const transitionsSchema = Joi.object({
+export const transitionsSchema = Joi.object({
   id: Joi.string().optional(),
   type: Joi.string().optional(),
   rules: rulesSchema.optional(),
   name: Joi.string().optional(),
   from: Joi.array().items(Joi.any()).optional(),
   properties: Joi.alternatives(Joi.object(), Joi.array()).optional(),
+  to: Joi.any().optional(),
 }).unknown(true)
 
 export type Status = {
@@ -167,7 +169,7 @@ export type Workflow = {
   id?: Id
   entityId?: string
   name?: string
-  transitions?: Transition[]
+  transitions: Transition[]
   statuses?: Status[]
 }
 
@@ -175,7 +177,7 @@ export const workflowSchema = Joi.object({
   id: idSchema.optional(),
   entityId: Joi.string().optional(),
   name: Joi.string().optional(),
-  transitions: Joi.array().items(transitionsSchema).optional(),
+  transitions: Joi.array().items(transitionsSchema),
   statuses: Joi.array().items(statusSchema).optional(),
 }).unknown(true).required()
 
@@ -205,6 +207,9 @@ export const isPostFetchWorkflowInstance = (instance: InstanceElement)
 : instance is PostFetchWorkflowInstance => isWorkflowValues(instance.value)
   && instance.value.name !== undefined
 
+export const isPostFetchWorkflowChange = (change: Change<Element>): change is Change<PostFetchWorkflowInstance> =>
+  isInstanceChange(change) && isPostFetchWorkflowInstance(getChangeData(change))
+
 export const getWorkflowChanges = (changes: Change<Element>[]): Change<WorkflowInstance>[] => changes
   .filter(isInstanceChange)
-  .filter(change => isWorkflowInstance(getChangeData(change)))
+  .filter((change): change is Change<WorkflowInstance> => isWorkflowInstance(getChangeData(change)))

--- a/packages/jira-adapter/src/filters/workflow/workflow_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_deploy_filter.ts
@@ -116,7 +116,8 @@ export const deployWorkflow = async (
       await deployTriggers(resolvedChange, client)
       // No need to run in DC since the main deployment requests already supports deploying steps
       if (!client.isDataCenter) {
-        await deploySteps(instance, client)
+        // as is done since it was already verified on the resolved change
+        await deploySteps(getChangeData(change) as WorkflowInstance, client)
       }
     }
   }

--- a/packages/jira-adapter/test/change_validators/workflows/circular_transitions.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflows/circular_transitions.test.ts
@@ -47,7 +47,7 @@ describe('circularTransitionsValidator', () => {
           },
           {
             name: 'reg2',
-            from: 'from',
+            from: ['from'],
             to: 'to',
           },
           {
@@ -60,7 +60,7 @@ describe('circularTransitionsValidator', () => {
           },
           {
             name: 'reg5',
-            from: 'from',
+            from: ['from'],
             to: '',
           },
         ],
@@ -88,7 +88,7 @@ describe('circularTransitionsValidator', () => {
           {
             name: 'reg1',
             to: 'to',
-            from: 'from',
+            from: ['from'],
           },
         ],
       },

--- a/packages/jira-adapter/test/change_validators/workflows/circular_transitions.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflows/circular_transitions.test.ts
@@ -1,0 +1,135 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { toChange, ObjectType, ElemID, InstanceElement, ChangeError } from '@salto-io/adapter-api'
+import { WORKFLOW_TYPE_NAME } from '../../../src/constants'
+import { circularTransitionsValidator } from '../../../src/change_validators/workflows/circular_transitions'
+import { createEmptyType } from '../../utils'
+
+const message = 'Circular workflow transitions cannot be deployed'
+const detailedMessage = (transitionName: string): string => `This workflow has a transition ${transitionName} from any status to itself, which cannot be deployed due to Atlassian API limitations.
+The workflow will be deployed without this transition.`
+const validatorMessage = (elemID: ElemID, transitionName: string): ChangeError => ({
+  elemID,
+  severity: 'Warning',
+  message,
+  detailedMessage: detailedMessage(transitionName),
+})
+
+describe('circularTransitionsValidator', () => {
+  let type: ObjectType
+  let instances: InstanceElement[]
+
+  beforeEach(() => {
+    type = createEmptyType(WORKFLOW_TYPE_NAME)
+    instances = []
+    instances[0] = new InstanceElement(
+      'instance1',
+      type,
+      {
+        name: 'instance1',
+        transitions: [
+          {
+            name: 'self1',
+            to: '',
+          },
+          {
+            name: 'reg2',
+            from: 'from',
+            to: 'to',
+          },
+          {
+            name: 'self3',
+            to: '',
+          },
+          {
+            name: 'reg4',
+            to: 'to',
+          },
+          {
+            name: 'reg5',
+            from: 'from',
+            to: '',
+          },
+        ],
+      },
+    )
+    instances[1] = new InstanceElement(
+      'instance2',
+      type,
+      {
+        name: 'instance2',
+        transitions: [
+          {
+            name: 'self1',
+            to: '',
+          },
+        ],
+      },
+    )
+    instances[2] = new InstanceElement(
+      'instance3',
+      type,
+      {
+        name: 'instance3',
+        transitions: [
+          {
+            name: 'reg1',
+            to: 'to',
+            from: 'from',
+          },
+        ],
+      },
+    )
+  })
+  it('should return a warning if element contains circular transition', async () => {
+    expect(await circularTransitionsValidator([
+      toChange({
+        before: instances[1],
+        after: instances[1],
+      }),
+    ])).toEqual([
+      validatorMessage(instances[1].elemID, 'self1'),
+    ])
+  })
+  it('should not return a warning if element does not contain circular transition', async () => {
+    expect(await circularTransitionsValidator([
+      toChange({
+        before: instances[2],
+        after: instances[2],
+      }),
+    ])).toEqual([])
+  })
+  it('should return warnings in complex situations', async () => {
+    expect(await circularTransitionsValidator([
+      toChange({
+        before: instances[0],
+        after: instances[0],
+      }),
+      toChange({
+        before: instances[1],
+        after: instances[1],
+      }),
+      toChange({
+        before: instances[2],
+        after: instances[2],
+      }),
+    ])).toEqual([
+      validatorMessage(instances[0].elemID, 'self1'),
+      validatorMessage(instances[0].elemID, 'self3'),
+      validatorMessage(instances[1].elemID, 'self1'),
+    ])
+  })
+})

--- a/packages/jira-adapter/test/filters/workflow/circular_transitions_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/circular_transitions_filter.test.ts
@@ -40,7 +40,7 @@ describe('circular transitions filter', () => {
           },
           {
             name: 'reg2',
-            from: 'from',
+            from: ['from'],
             to: 'to',
           },
           {
@@ -53,7 +53,7 @@ describe('circular transitions filter', () => {
           },
           {
             name: 'reg5',
-            from: 'from',
+            from: ['from'],
             to: '',
           },
         ],
@@ -81,7 +81,7 @@ describe('circular transitions filter', () => {
           {
             name: 'reg1',
             to: 'to',
-            from: 'from',
+            from: ['from'],
           },
         ],
       },
@@ -106,7 +106,7 @@ describe('circular transitions filter', () => {
         [
           {
             name: 'reg2',
-            from: 'from',
+            from: ['from'],
             to: 'to',
           },
           {
@@ -115,7 +115,7 @@ describe('circular transitions filter', () => {
           },
           {
             name: 'reg5',
-            from: 'from',
+            from: ['from'],
             to: '',
           },
         ]

--- a/packages/jira-adapter/test/filters/workflow/circular_transitions_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/circular_transitions_filter.test.ts
@@ -21,7 +21,7 @@ import { createEmptyType, getFilterParams } from '../../utils'
 import circularTransitionsFilter from '../../../src/filters/workflow/circular_transitions_filter'
 
 describe('circular transitions filter', () => {
-  let filter: filterUtils.FilterWith<'preDeploy'>
+  let filter: filterUtils.FilterWith<'preDeploy' | 'onDeploy'>
   let type: ObjectType
   let instances: InstanceElement[]
   let changes: Change<InstanceElement>[]
@@ -122,6 +122,14 @@ describe('circular transitions filter', () => {
       )
       expect(getChangeData(changes[1]).value.transitions.length).toEqual(0)
       expect(getChangeData(changes[2]).value.transitions.length).toEqual(1)
+    })
+  })
+  describe('onDeploy', () => {
+    it('should not change the changes', async () => {
+      const changesCopy = changes.map(change => ({ ...change }))
+      await filter.preDeploy(changes) // to fill the cache
+      await filter.onDeploy(changes)
+      expect(changes).toEqual(changesCopy)
     })
   })
 })

--- a/packages/jira-adapter/test/filters/workflow/circular_transitions_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/circular_transitions_filter.test.ts
@@ -1,0 +1,127 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { Change, InstanceElement, ObjectType, getChangeData } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import { WORKFLOW_TYPE_NAME } from '../../../src/constants'
+import { createEmptyType, getFilterParams } from '../../utils'
+import circularTransitionsFilter from '../../../src/filters/workflow/circular_transitions_filter'
+
+describe('circular transitions filter', () => {
+  let filter: filterUtils.FilterWith<'preDeploy'>
+  let type: ObjectType
+  let instances: InstanceElement[]
+  let changes: Change<InstanceElement>[]
+  beforeEach(async () => {
+    type = createEmptyType(WORKFLOW_TYPE_NAME)
+    instances = []
+    instances[0] = new InstanceElement(
+      'instance1',
+      type,
+      {
+        name: 'instance1',
+        transitions: [
+          {
+            name: 'self1',
+            to: '',
+          },
+          {
+            name: 'reg2',
+            from: 'from',
+            to: 'to',
+          },
+          {
+            name: 'self3',
+            to: '',
+          },
+          {
+            name: 'reg4',
+            to: 'to',
+          },
+          {
+            name: 'reg5',
+            from: 'from',
+            to: '',
+          },
+        ],
+      },
+    )
+    instances[1] = new InstanceElement(
+      'instance2',
+      type,
+      {
+        name: 'instance2',
+        transitions: [
+          {
+            name: 'self1',
+            to: '',
+          },
+        ],
+      },
+    )
+    instances[2] = new InstanceElement(
+      'instance3',
+      type,
+      {
+        name: 'instance3',
+        transitions: [
+          {
+            name: 'reg1',
+            to: 'to',
+            from: 'from',
+          },
+        ],
+      },
+    )
+    filter = circularTransitionsFilter(getFilterParams()) as typeof filter
+    changes = instances.map(instance => ({ action: 'add', data: { after: instance } }))
+  })
+
+  describe('preDeploy', () => {
+    it('should remove circular transitions', async () => {
+      await filter.preDeploy([changes[1]])
+      expect(getChangeData(changes[1]).value.transitions.length).toEqual(0)
+    })
+
+    it('should not remove regular transitions', async () => {
+      await filter.preDeploy([changes[2]])
+      expect(getChangeData(changes[2]).value.transitions.length).toEqual(1)
+    })
+    it('should handle complex objects correctly', async () => {
+      await filter.preDeploy(changes)
+      expect(getChangeData(changes[0]).value.transitions).toEqual(
+        [
+          {
+            name: 'reg2',
+            from: 'from',
+            to: 'to',
+          },
+          {
+            name: 'reg4',
+            to: 'to',
+          },
+          {
+            name: 'reg5',
+            from: 'from',
+            to: '',
+          },
+        ]
+      )
+      expect(getChangeData(changes[1]).value.transitions.length).toEqual(0)
+      expect(getChangeData(changes[2]).value.transitions.length).toEqual(1)
+    })
+  })
+})

--- a/packages/jira-adapter/test/filters/workflow/steps_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/steps_deployment.test.ts
@@ -21,6 +21,7 @@ import { JIRA, WORKFLOW_TYPE_NAME } from '../../../src/constants'
 import { mockClient } from '../../utils'
 import { deploySteps } from '../../../src/filters/workflow/steps_deployment'
 import { JSP_API_HEADERS } from '../../../src/client/headers'
+import { WorkflowInstance } from '../../../src/filters/workflow/types'
 
 describe('steps_deployment', () => {
   let workflowType: ObjectType
@@ -48,6 +49,7 @@ describe('steps_deployment', () => {
             id: '3',
           },
         ],
+        transitions: [],
       }
     )
 
@@ -79,7 +81,7 @@ describe('steps_deployment', () => {
   })
 
   it('should call the deploy steps endpoint', async () => {
-    await deploySteps(instance, client)
+    await deploySteps(instance as WorkflowInstance, client)
 
     expect(mockConnection.post).toHaveBeenCalledWith(
       '/secure/admin/workflows/EditWorkflowStep.jspa',
@@ -115,17 +117,17 @@ describe('steps_deployment', () => {
 
   it('should throw if workflow does not have a name', async () => {
     delete instance.value.name
-    await expect(deploySteps(instance, client)).rejects.toThrow()
+    await expect(deploySteps(instance as WorkflowInstance, client)).rejects.toThrow()
   })
 
   it('should throw if status does not have a name', async () => {
     delete instance.value.statuses[0].name
-    await expect(deploySteps(instance, client)).rejects.toThrow()
+    await expect(deploySteps(instance as WorkflowInstance, client)).rejects.toThrow()
   })
 
   it('should throw if status does not have an id', async () => {
     delete instance.value.statuses[0].id
-    await expect(deploySteps(instance, client)).rejects.toThrow()
+    await expect(deploySteps(instance as WorkflowInstance, client)).rejects.toThrow()
   })
 
   it('should throw if there are no step ids', async () => {
@@ -138,6 +140,6 @@ describe('steps_deployment', () => {
       },
     })
 
-    await expect(deploySteps(instance, client)).rejects.toThrow()
+    await expect(deploySteps(instance as WorkflowInstance, client)).rejects.toThrow()
   })
 })

--- a/packages/jira-adapter/test/filters/workflow/triggers_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/triggers_deployment.test.ts
@@ -21,6 +21,7 @@ import JiraClient from '../../../src/client/client'
 import { JIRA, WORKFLOW_TYPE_NAME } from '../../../src/constants'
 import { mockClient } from '../../utils'
 import { PRIVATE_API_HEADERS } from '../../../src/client/headers'
+import { WorkflowInstance } from '../../../src/filters/workflow/types'
 
 describe('triggersDeployment', () => {
   let workflowType: ObjectType
@@ -68,7 +69,7 @@ describe('triggersDeployment', () => {
   })
 
   it('should call the deploy triggers endpoint', async () => {
-    await deployTriggers(toChange({ after: instance }) as AdditionChange<InstanceElement>, client)
+    await deployTriggers(toChange({ after: instance }) as AdditionChange<WorkflowInstance>, client)
 
     expect(mockConnection.put).toHaveBeenCalledWith(
       '/rest/triggers/1.0/workflow/config',
@@ -89,7 +90,7 @@ describe('triggersDeployment', () => {
   it('should throw when workflow does not have a name', async () => {
     delete instance.value.name
     await expect(
-      deployTriggers(toChange({ after: instance }) as AdditionChange<InstanceElement>, client)
+      deployTriggers(toChange({ after: instance }) as AdditionChange<WorkflowInstance>, client)
     ).rejects.toThrow()
   })
 })

--- a/packages/jira-adapter/test/filters/workflow/workflow_deploy_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_deploy_filter.test.ts
@@ -181,7 +181,7 @@ describe('workflowDeployFilter', () => {
           .apiDefinitions.types.Workflow.deployRequests,
         fieldsToIgnore: expect.toBeFunction(),
       })
-    }, 100000)
+    })
 
     it('should add operations value', async () => {
       const change = toChange({

--- a/packages/jira-adapter/test/filters/workflow/workflow_deploy_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_deploy_filter.test.ts
@@ -131,9 +131,9 @@ describe('workflowDeployFilter', () => {
                     },
                     conditions: [
                       {
-                        configuration: [{
+                        configuration: {
                           id: 2,
-                        }],
+                        },
                       },
                     ],
                   },
@@ -164,9 +164,9 @@ describe('workflowDeployFilter', () => {
                       },
                       conditions: [
                         {
-                          configuration: [{
+                          configuration: {
                             id: '2',
-                          }],
+                          },
                         },
                       ],
                     },
@@ -181,7 +181,7 @@ describe('workflowDeployFilter', () => {
           .apiDefinitions.types.Workflow.deployRequests,
         fieldsToIgnore: expect.toBeFunction(),
       })
-    })
+    }, 100000)
 
     it('should add operations value', async () => {
       const change = toChange({
@@ -204,6 +204,7 @@ describe('workflowDeployFilter', () => {
           workflowType,
           {
             name: 'name',
+            transitions: [],
           }
         ),
       })
@@ -217,6 +218,7 @@ describe('workflowDeployFilter', () => {
             workflowType,
             {
               name: 'name',
+              transitions: [],
             },
           ),
         }),

--- a/packages/jira-adapter/test/filters/workflow/workflow_properties_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_properties_filter.test.ts
@@ -79,6 +79,7 @@ describe('workflowPropertiesFilter', () => {
               },
             },
           ],
+          transitions: [],
         }
       )
       await filter.onFetch([instance])
@@ -97,6 +98,7 @@ describe('workflowPropertiesFilter', () => {
             ],
           },
         ],
+        transitions: [],
       })
     })
 
@@ -161,6 +163,7 @@ describe('workflowPropertiesFilter', () => {
               ],
             },
           ],
+          transitions: [],
         }
       )
       const changes = [toChange({ after: instance })]
@@ -182,6 +185,7 @@ describe('workflowPropertiesFilter', () => {
             },
           },
         ],
+        transitions: [],
       })
 
       await filter.onDeploy?.(changes)

--- a/packages/jira-adapter/test/filters/workflow/workflow_structure_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_structure_filter.test.ts
@@ -141,12 +141,14 @@ describe('workflowStructureFilter', () => {
             entityId: 'id',
             name: 'name',
           },
+          transitions: [],
         }
       )
       await filter.onFetch([instance])
       expect(instance.value).toEqual({
         entityId: 'id',
         name: 'name',
+        transitions: [],
       })
     })
 
@@ -174,6 +176,7 @@ describe('workflowStructureFilter', () => {
             },
             {},
           ],
+          transitions: [],
         }
       )
       await filter.onFetch([instance])


### PR DESCRIPTION
added a change validator to warn about circular transitions and a filter to prevent their deployment

---
_Release Notes_: 
* Jira Adapter:
Fixed a bug where circular workflow transitions prevented deployment

---
_User Notifications_: 
None
