### PR TITLE
SALTO-2818 Add Worflow references to EntitlementProcess

### DIFF
--- a/packages/adapter-components/src/references/context.ts
+++ b/packages/adapter-components/src/references/context.ts
@@ -27,6 +27,7 @@ export type ContextFunc = ({ instance, elemByElemID, field, fieldPath }: {
   elemByElemID: multiIndex.Index<[string], Element>
   field: Field
   fieldPath?: ElemID
+  levelsUp?: number
 }) => Promise<string | undefined>
 
 export const findParentPath = (currentFieldPath: ElemID, numLevels = 0): ElemID => {
@@ -52,7 +53,7 @@ export const findParentPath = (currentFieldPath: ElemID, numLevels = 0): ElemID 
  *
  * @param contextFieldName    The name of the neighboring field (same level)
  * @param levelsUp            How many levels to go up in the instance's type definition before
- *                            looking for the neighbor.
+ *                            looking for the neighbor or "top" for top-level element
  * @param contextValueMapper  An additional function to use to convert the value before the lookup
  */
 export const neighborContextGetter = ({
@@ -62,7 +63,7 @@ export const neighborContextGetter = ({
   getLookUpName,
 }: {
   contextFieldName: string
-  levelsUp?: number
+  levelsUp?: number | 'top'
   contextValueMapper?: ContextValueMapperFunc
   getLookUpName: GetLookupNameFunc
 }): ContextFunc => (async ({ instance, elemByElemID, fieldPath }) => {
@@ -86,7 +87,7 @@ export const neighborContextGetter = ({
   }
 
   try {
-    const parent = findParentPath(fieldPath, levelsUp)
+    const parent = levelsUp === 'top' ? fieldPath.createTopLevelParentID().parent : findParentPath(fieldPath, levelsUp)
     if (parent.isConfigType()) {
       // went up too many levels, the current rule is irrelevant for this potential reference
       return undefined

--- a/packages/salesforce-adapter/src/filters/field_references.ts
+++ b/packages/salesforce-adapter/src/filters/field_references.ts
@@ -66,7 +66,7 @@ const shareToMapper: referenceUtils.ContextValueMapperFunc = (val: string) => {
 
 const neighborContextFunc = (args: {
   contextFieldName: string
-  levelsUp?: number
+  levelsUp?: number | 'top'
   contextValueMapper?: referenceUtils.ContextValueMapperFunc
 }): referenceUtils.ContextFunc => neighborContextGetter({ ...args, getLookUpName })
 
@@ -97,7 +97,7 @@ const contextStrategyLookup: Record<
   neighborCaseOwnerTypeLookup: neighborContextFunc({ contextFieldName: 'caseOwnerType' }),
   neighborAssignedToTypeLookup: neighborContextFunc({ contextFieldName: 'assignedToType' }),
   neighborRelatedEntityTypeLookup: neighborContextFunc({ contextFieldName: 'relatedEntityType' }),
-
+  parentSObjectTypeLookupTopLevel: neighborContextFunc({ contextFieldName: 'SObjectType', levelsUp: 'top' }),
 }
 
 

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -123,6 +123,7 @@ export type ReferenceContextStrategyName = (
   | 'neighborTypeLookup' | 'neighborActionTypeFlowLookup' | 'neighborActionTypeLookup' | 'parentObjectLookup'
   | 'parentInputObjectLookup' | 'parentOutputObjectLookup' | 'neighborSharedToTypeLookup' | 'neighborTableLookup'
   | 'neighborCaseOwnerTypeLookup' | 'neighborAssignedToTypeLookup' | 'neighborRelatedEntityTypeLookup'
+  | 'parentSObjectTypeLookupTopLevel'
 )
 
 type SourceDef = {
@@ -633,6 +634,11 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     src: { field: 'elementReference', parentTypes: ['FlowElementReferenceOrValue'] },
     serializationStrategy: 'customLabel',
     target: { type: CUSTOM_LABEL_METADATA_TYPE },
+  },
+  {
+    src: { field: 'name', parentTypes: ['WorkflowActionReference'] },
+    serializationStrategy: 'relativeApiName',
+    target: { parentContext: 'parentSObjectTypeLookupTopLevel', typeContext: 'neighborTypeWorkflow' },
   },
   {
     src: { field: 'milestoneName', parentTypes: ['EntitlementProcessMilestoneItem'] },


### PR DESCRIPTION
Add missing references to EntitlementProcess

---

Do not merge without noise suppression!

Workspace diff: 
https://github.com/salto-io/adi-ws/commit/e18e0a8b67111620af8a37d51832200ac2a64361

---
_Release Notes_: 
Salesforce Adapter:
- Add missing workflow references to EntitlementProcess
---
_User Notifications_: _None_