### PR TITLE
SALTO-3635: Salesforce `apiName` utility deprecation

### DIFF
--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -119,6 +119,9 @@ export const relativeApiName = (name: string): string => (
   _.last(name.split(API_NAME_SEPARATOR)) as string
 )
 
+/**
+ * @deprecated use {@link safeApiName} instead.
+ */
 export const apiName = async (elem: Readonly<Element>, relative = false): Promise<string> => {
   const name = await fullApiName(elem)
   return name && relative ? relativeApiName(name) : name


### PR DESCRIPTION
Marked the widely used `apiName` utility as deprecated (in favor of `safeApiName`)

This is how it looks like in my IDE:

![Screen Shot 2023-04-17 at 15 10 20](https://user-images.githubusercontent.com/92912659/232480454-1a62b01a-f60e-4c55-91bf-ca0e6fcc72ed.png)

---

_Release Notes_: 
_None_

---
_User Notifications_: 
_None_ 