### PR TITLE
SALTO-4000: fix fetch error for one category in a brand and no articles

### DIFF
--- a/packages/adapter-components/src/elements/ducktype/transformer.ts
+++ b/packages/adapter-components/src/elements/ducktype/transformer.ts
@@ -179,7 +179,7 @@ const getEntriesForType = async (
       return awu(makeArray(entry[nestedFieldDetails.field.name])).map(
         (nestedEntry, nesteIndex) => {
           if (!isObjectType(nestedFieldDetails.type)) {
-            log.error('type is not objectType returning undefined')
+            log.error(`for typeName ${typeName} in adapter ${adapterName} nestedFieldDetails.type is not objectType returning undefined`)
             return undefined
           }
           return toInstance({

--- a/packages/adapter-components/src/elements/ducktype/transformer.ts
+++ b/packages/adapter-components/src/elements/ducktype/transformer.ts
@@ -177,15 +177,21 @@ const getEntriesForType = async (
   const instances = await awu(entriesValues).flatMap(async (entry, index) => {
     if (nestedFieldDetails !== undefined) {
       return awu(makeArray(entry[nestedFieldDetails.field.name])).map(
-        (nestedEntry, nesteIndex) => toInstance({
-          entry: nestedEntry,
-          type: nestedFieldDetails.type,
-          transformationConfigByType,
-          transformationDefaultConfig,
-          defaultName: `unnamed_${index}_${nesteIndex}`, // TODO improve
-          hasDynamicFields,
-          getElemIdFunc,
-        })
+        (nestedEntry, nesteIndex) => {
+          if (!isObjectType(nestedFieldDetails.type)) {
+            log.error('type is not objectType returning undefined')
+            return undefined
+          }
+          return toInstance({
+            entry: nestedEntry,
+            type: nestedFieldDetails.type,
+            transformationConfigByType,
+            transformationDefaultConfig,
+            defaultName: `unnamed_${index}_${nesteIndex}`, // TODO improve
+            hasDynamicFields,
+            getElemIdFunc,
+          })
+        }
       ).filter(isDefined).toArray()
     }
 

--- a/packages/adapter-components/src/elements/field_finder.ts
+++ b/packages/adapter-components/src/elements/field_finder.ts
@@ -94,6 +94,7 @@ export const findDataField: FindNestedFieldFunc = async (type, fieldsToIgnore, d
     ? await nestedFieldType.getInnerType()
     // map type currently cannot be returned from nested fields
     : nestedFieldType
+  // this can happen when a dataField is specified but no entries are returned
   if (isPrimitiveType(nestedType) && nestedType.elemID.isEqual(BuiltinTypes.UNKNOWN.elemID)) {
     return {
       field: nestedField,

--- a/packages/adapter-components/test/elements/ducktype/transformer.test.ts
+++ b/packages/adapter-components/test/elements/ducktype/transformer.test.ts
@@ -157,8 +157,8 @@ describe('ducktype_transformer', () => {
         yield [{
           meta: { has_more: false },
           links: {
-            first: 'https://salto87.zendesk.com/api/v2/help_center/categories/15828521533331/articles?include=translations&page%5Bsize%5D=100&sort_by=updated_at',
-            last: 'https://salto87.zendesk.com/api/v2/help_center/categories/15828521533331/articles?include=translations&page%5Bbefore%5D=bGFzdF9wYWdl&page%5Bsize%5D=100&sort_by=updated_at',
+            first: 'one',
+            last: 'two',
           },
           articles: [],
         }]


### PR DESCRIPTION
_fix fetch error for one category in a brand and no articles_

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* fix fetch error for one category in a brand and no articles

---
_User Notifications_: 
None
