### PR TITLE
SALTO-3975 Deploy group schema [Ignore]

### DIFF
--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -45,6 +45,7 @@ import userFilter from './filters/user'
 import { OKTA } from './constants'
 import { getLookUpName } from './reference_mapping'
 import serviceUrlFilter from './filters/service_url'
+import groupSchemaAddNullFilter from './filters/group_schema_null_when_remove'
 
 const { awu } = collections.asynciterable
 
@@ -75,6 +76,7 @@ export const DEFAULT_FILTERS = [
   appDeploymentFilter,
   defaultPolicyRuleDeployment,
   policyRuleRemoval,
+  groupSchemaAddNullFilter,
   // should run after fieldReferences
   ...Object.values(otherCommonFilters),
   privateApiDeployFilter,

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -690,8 +690,14 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
     transformation: {
       idFields: ['title'],
       serviceIdField: 'id',
-      fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),
+      fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }, { fieldName: '$schema' }),
       fieldsToHide: [{ fieldName: 'id' }],
+    },
+    deployRequests: {
+      modify: {
+        url: '/api/v1/meta/schemas/group/default',
+        method: 'post',
+      },
     },
   },
   Domain: {

--- a/packages/okta-adapter/src/constants.ts
+++ b/packages/okta-adapter/src/constants.ts
@@ -49,3 +49,4 @@ export const POLICY_RULE_TYPE_NAMES = [ACCESS_POLICY_RULE_TYPE_NAME, IDP_RULE_TY
 export const CUSTOM_NAME_FIELD = 'customName'
 export const LINKS_FIELD = '_links'
 export const SAML_2_0_APP = 'SAML_2_0'
+export const GROUP_SCHEMA_TYPE_NAME = 'GroupSchema'

--- a/packages/okta-adapter/src/filters/group_schema_null_when_remove.ts
+++ b/packages/okta-adapter/src/filters/group_schema_null_when_remove.ts
@@ -1,0 +1,68 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { Change, InstanceElement, ModificationChange, getChangeData, isInstanceChange, isModificationChange } from '@salto-io/adapter-api'
+import { resolvePath } from '@salto-io/adapter-utils'
+import { FilterCreator } from '../filter'
+import { GROUP_SCHEMA_TYPE_NAME } from '../constants'
+
+const CUSTOM_ADDITONAL_PROPERTIES_PATH = ['definitions', 'custom', 'properties', 'additionalProperties']
+
+const addNullToRemovedFields = (change: ModificationChange<InstanceElement>): void => {
+  const { before, after } = change.data
+  const customAdditionalPropertiesPath = before.elemID.createNestedID(...CUSTOM_ADDITONAL_PROPERTIES_PATH)
+  const beforeCustomFields = resolvePath(before, customAdditionalPropertiesPath)
+  const afterCustomFields = resolvePath(after, customAdditionalPropertiesPath)
+  const fieldsToRemove = Object.keys(beforeCustomFields)
+    .filter(key => !(Object.keys(afterCustomFields).includes(key)))
+
+  fieldsToRemove.forEach(field => {
+    resolvePath(after, customAdditionalPropertiesPath)[field] = null
+  })
+}
+
+const deleteFieldsWithNull = (instance: InstanceElement): void => {
+  const customAdditionalPropertiesPath = instance.elemID.createNestedID(...CUSTOM_ADDITONAL_PROPERTIES_PATH)
+  const customFields = resolvePath(instance, customAdditionalPropertiesPath)
+
+  Object.keys(customFields).forEach(field => {
+    if (customFields[field] === null) {
+      delete customFields[field]
+    }
+  })
+}
+
+const groupSchemaAddNullFilter: FilterCreator = () => ({
+  name: 'groupSchemaAddNullFilter',
+  preDeploy: async (changes: Change<InstanceElement>[]) => {
+    changes
+      .filter(isModificationChange)
+      .filter(isInstanceChange)
+      .filter(change => getChangeData(change).elemID.typeName === GROUP_SCHEMA_TYPE_NAME)
+      .map(change => addNullToRemovedFields(change))
+  },
+  onDeploy: async (changes: Change<InstanceElement>[]) => {
+    changes
+      .filter(isModificationChange)
+      .filter(isInstanceChange)
+      .map(getChangeData)
+      .filter(instance => instance.elemID.typeName === GROUP_SCHEMA_TYPE_NAME)
+      .map(instance => deleteFieldsWithNull(instance))
+  },
+}
+)
+
+export default groupSchemaAddNullFilter

--- a/packages/okta-adapter/test/filters/group_schema_null_when_remove.test.ts
+++ b/packages/okta-adapter/test/filters/group_schema_null_when_remove.test.ts
@@ -1,0 +1,82 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { filterUtils } from '@salto-io/adapter-components'
+import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import groupSchemaAddNullFilter from '../../src/filters/group_schema_null_when_remove'
+import { getFilterParams } from '../utils'
+import { GROUP_SCHEMA_TYPE_NAME, OKTA } from '../../src/constants'
+
+describe('groupSchemaAddNullFilter', () => {
+    type FilterType = filterUtils.FilterWith< 'preDeploy' | 'onDeploy'>
+    let filter: FilterType
+
+    const groupSchemaType = new ObjectType({ elemID: new ElemID(OKTA, GROUP_SCHEMA_TYPE_NAME) })
+    const groupSchemaBeforeInstance = new InstanceElement(
+      'defualtGroupSchema',
+      groupSchemaType,
+      {
+        definitions: {
+          custom: {
+            properties: {
+              additionalProperties: {
+                field1: {},
+                field2: {},
+              },
+            },
+          },
+        },
+      },
+    )
+    const groupSchemaAfterInstance = new InstanceElement(
+      'defualtGroupSchema',
+      groupSchemaType,
+      {
+        definitions: {
+          custom: {
+            properties: {
+              additionalProperties: {
+                field1: {},
+              },
+            },
+          },
+        },
+      },
+    )
+
+    beforeEach(async () => {
+      filter = groupSchemaAddNullFilter(getFilterParams()) as typeof filter
+    })
+
+    describe('preDeploy', () => {
+      it('should add null to removed fields', async () => {
+        const groupSchemaBeforeInstanceCopy = groupSchemaBeforeInstance.clone()
+        const groupSchemaAfterInstanceCopy = groupSchemaAfterInstance.clone()
+        await filter.preDeploy([
+          toChange({ before: groupSchemaBeforeInstanceCopy, after: groupSchemaAfterInstanceCopy })])
+        expect(groupSchemaAfterInstanceCopy.value.definitions.custom.properties.additionalProperties.field2).toBeNull()
+      })
+    })
+    describe('onDeploy', () => {
+      it('should delete fields with null', async () => {
+        const groupSchemaAfterInstanceCopy = groupSchemaAfterInstance.clone()
+        await filter.onDeploy([
+          toChange({ before: groupSchemaBeforeInstance, after: groupSchemaAfterInstanceCopy })])
+        expect(groupSchemaAfterInstanceCopy.value.definitions.custom.properties.additionalProperties.field2)
+          .toBeUndefined()
+      })
+    })
+})


### PR DESCRIPTION
1. Created endpoint for groupSchema in the config file for modification. 
2. We noticed that the user cant simply delete attribute from group schema because of oOkta api demands.
3. So we created a filter that assign null value when the user delete a custom field in order for Okta to understand the field need to be deleted. 

---
To test the filter manually do as follows:
1. Delete a custom attribute from groupSchema instance. 
2. Do `salto deploy` and check that the changes occurred and that the nacl has no deleted field.
3. Try to add and modify custom fields as well.   

---
_Release Notes_: 
None

---
_User Notifications_: 
None
