### PR TITLE
SALTO-3988 - Handle unresolved references in handle_template_expressions

### DIFF
--- a/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
@@ -287,8 +287,10 @@ const replaceFormulasWithTemplates = async (
 }
 
 export const prepRef = (part: ReferenceExpression): TemplatePart => {
-  // There are cases where part is not resolved, which means that it has no value
+  // In some cases this function may run on the .before value of a Change, which may contain unresolved references.
+  // .after values are always resolved because unresolved references are dropped by unresolved_references validator
   // This case should be handled more generic but at the moment this is a quick fix to avoid crashing (SALTO-3988)
+  // This fix is enough since the .before value is not used in the deployment process
   if (part.value instanceof UnresolvedReference) {
     log.debug('prepRef received a part as unresolved reference, returning an empty string, instance fullName: %s ', part.elemID.getFullName())
     return ''

--- a/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
@@ -15,7 +15,7 @@
 */
 import {
   Change, Element, getChangeData, InstanceElement, isInstanceElement,
-  ReferenceExpression, TemplateExpression, TemplatePart, Values,
+  ReferenceExpression, TemplateExpression, TemplatePart, UnresolvedReference, Values,
 } from '@salto-io/adapter-api'
 import { extractTemplate, TemplateContainer, replaceTemplatesWithValues, resolveTemplates } from '@salto-io/adapter-utils'
 import { references as referencesUtils } from '@salto-io/adapter-components'
@@ -287,6 +287,13 @@ const replaceFormulasWithTemplates = async (
 }
 
 export const prepRef = (part: ReferenceExpression): TemplatePart => {
+  // TODO: test on something else, and add to tests
+  // There are cases where part is not resolved, which means that it has no value
+  // This case should be handled more generic but at the moment this is a quick fix to avoid crashing (SALTO-3988)
+  if (part.value.value instanceof UnresolvedReference) {
+    log.debug('prepRef received a part as unresolved reference, returning an empty string, instance fullName: %s ', part.elemID.getFullName())
+    return ''
+  }
   if (Object.values(ZENDESK_REFERENCE_TYPE_TO_SALTO_TYPE).includes(part.elemID.typeName)) {
     return `${part.value.value[ZENDESK_TYPE_TO_FIELD[part.elemID.typeName]]}`
   }

--- a/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
@@ -287,10 +287,9 @@ const replaceFormulasWithTemplates = async (
 }
 
 export const prepRef = (part: ReferenceExpression): TemplatePart => {
-  // TODO: test on something else, and add to tests
   // There are cases where part is not resolved, which means that it has no value
   // This case should be handled more generic but at the moment this is a quick fix to avoid crashing (SALTO-3988)
-  if (part.value.value instanceof UnresolvedReference) {
+  if (part.value instanceof UnresolvedReference) {
     log.debug('prepRef received a part as unresolved reference, returning an empty string, instance fullName: %s ', part.elemID.getFullName())
     return ''
   }

--- a/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
+++ b/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
@@ -458,7 +458,7 @@ describe('handle templates filter', () => {
   })
 
   describe('prepRef', () => {
-    it('zendeskReferenceTypes', () => {
+    it('should return \'key\' field or \'undefined\' on ZENDESK_REFERENCE_TYPE_TO_SALTO_TYPE', () => {
       const validOrg = new InstanceElement('instance', orgTypeName, { key: 'test' })
       const invalidOrg = new InstanceElement('instance', orgTypeName, { noKey: 'test' })
       const invalidOrgRef = new ReferenceExpression(invalidOrg.elemID, invalidOrg)
@@ -469,7 +469,7 @@ describe('handle templates filter', () => {
       expect(validPrepRef).toEqual('test')
       expect(invalidPrepRef).toEqual('undefined')
     })
-    it('dynamic_content_item', () => {
+    it('should return \'placeholder\' field or the instance reference on dynamic_content_item type', () => {
       const validDynamicContent = new InstanceElement('instance', dynamicContentType, { placeholder: '{{dc.test}}' })
       const invalidDynamicContent = new InstanceElement('instance', dynamicContentType, { placeholder: 'invalid' })
       const invalidDynamicContentRef = new ReferenceExpression(invalidDynamicContent.elemID, invalidDynamicContent)
@@ -480,7 +480,7 @@ describe('handle templates filter', () => {
       expect(validPrepRef).toEqual('dc.test')
       expect(invalidPrepRef).toEqual(invalidDynamicContentRef)
     })
-    it('group', () => {
+    it('should return \'id\' field or the instance reference on group type', () => {
       const validGroup = new InstanceElement('instance', groupType, { id: 123 })
       const invalidGroup = new InstanceElement('instance', groupType, { noId: 123 })
       const invalidGroupRef = new ReferenceExpression(invalidGroup.elemID, invalidGroup)
@@ -491,7 +491,7 @@ describe('handle templates filter', () => {
       expect(validPrepRef).toEqual('123')
       expect(invalidPrepRef).toEqual(invalidGroupRef)
     })
-    it('unresolvedReference', () => {
+    it('should return an empty string on UnresolvedReference', () => {
       const elemId = new ElemID(ZENDESK, 'test')
       const unresolvedRef = new UnresolvedReference(elemId)
       const unresolvedPrepRef = prepRef(new ReferenceExpression(elemId, unresolvedRef))


### PR DESCRIPTION
If an instance that is being handled by handle_template_expression contains an unresolved reference, convert it to an empty string instead of crashing

---

None

---
_Release Notes_: 
Zendesk Adapter:
* Fixed deploy crashing with a modification of an instance with removal of a reference that contains an unresolved reference

---
_User Notifications_: 
None
