### PR TITLE
SALTO- 4008 - Move FetchDiffToWorkspace to core + add loadElementsFromFolder to the adapter api

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -143,6 +143,11 @@ export type ConfigCreator = {
     => Promise<InstanceElement>
 }
 
+export type LoadElementsFromFolderArgs = {
+  baseDir: string
+  elementSource: ReadOnlyElementsSource
+}
+
 export type Adapter = {
   operations: (context: AdapterOperationsContext) => AdapterOperations
   validateCredentials: (config: Readonly<InstanceElement>) => Promise<AccountId>
@@ -150,6 +155,7 @@ export type Adapter = {
   configType?: ObjectType
   configCreator?: ConfigCreator
   install?: () => Promise<AdapterInstallResult>
+  loadElementsFromFolder?: (args: LoadElementsFromFolderArgs) => Promise<FetchResult>
 }
 
 export const OBJECT_SERVICE_ID = 'object_service_id'

--- a/packages/cli/src/commands/apply_patch.ts
+++ b/packages/cli/src/commands/apply_patch.ts
@@ -97,7 +97,7 @@ const applyPatchToWorkspace = async (
   }
   if (fetchErrors.length > 0) {
     // We currently assume all fetchErrors are warnings
-    log.debug(`fetch-diff had ${fetchErrors.length} warnings`)
+    log.debug(`apply-patch had ${fetchErrors.length} warnings`)
     outputLine(
       formatFetchWarnings(fetchErrors.map(fetchError => fetchError.message)),
       output,

--- a/packages/cli/src/commands/apply_patch.ts
+++ b/packages/cli/src/commands/apply_patch.ts
@@ -14,38 +14,21 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { DetailedChange, Element, getChangeData, isAdditionChange, isRemovalChange } from '@salto-io/adapter-api'
+import { DetailedChange, getChangeData, isAdditionChange, isRemovalChange } from '@salto-io/adapter-api'
 import { applyDetailedChanges } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
+import { State, Workspace } from '@salto-io/workspace'
 import { collections } from '@salto-io/lowerdash'
-import { expressions, elementSource, Workspace, merger, State } from '@salto-io/workspace'
-import { loadElementsFromFolder } from '@salto-io/salesforce-adapter'
-import { calcFetchChanges } from '@salto-io/core'
+import { calculatePatch } from '@salto-io/core'
 import { WorkspaceCommandAction, createWorkspaceCommand } from '../command_builder'
 import { outputLine, errorOutputLine } from '../outputer'
 import { validateWorkspace, formatWorkspaceErrors } from '../workspace/workspace'
 import { CliExitCode, CliOutput } from '../types'
 import { UpdateModeArg, UPDATE_MODE_OPTION } from './common/update_mode'
+import { formatFetchWarnings } from '../formatter'
 
 const log = logger(module)
 const { awu } = collections.asynciterable
-
-const mergeElements = async (
-  workspace: Workspace,
-  elements: Element[],
-  output: CliOutput,
-): Promise<{ elements: Element[]; success: boolean }> => {
-  const result = await merger.mergeElements(awu(elements))
-  const errors = await awu(result.errors.values()).flat().toArray()
-  if (errors.length > 0) {
-    errorOutputLine('Encountered merge errors in elements:', output)
-    errorOutputLine(await formatWorkspaceErrors(workspace, errors), output)
-  }
-  return {
-    elements: await awu(result.merged.values()).toArray(),
-    success: errors.length === 0,
-  }
-}
 
 const updateStateElements = async (
   state: State,
@@ -72,7 +55,7 @@ const updateStateElements = async (
   })
 }
 
-type FetchDiffArgs = {
+type ApplyPatchArgs = {
   fromDir: string
   toDir: string
   accountName: 'salesforce'
@@ -80,52 +63,25 @@ type FetchDiffArgs = {
   updateStateInEnvs?: string[]
 } & UpdateModeArg
 
-const fetchDiffToWorkspace = async (
+const applyPatchToWorkspace = async (
   workspace: Workspace,
-  input: FetchDiffArgs,
+  input: ApplyPatchArgs,
   updateState: boolean,
   output: CliOutput,
 ): Promise<boolean> => {
-  outputLine(`Loading elements from workspace env ${workspace.currentEnv()}`, output)
-  const wsElements = await workspace.elements()
-  const resolvedWSElements = await expressions.resolve(
-    await awu(await wsElements.getAll()).toArray(),
-    wsElements,
-  )
-  const resolvedWSElementSource = elementSource.createInMemoryElementSource(resolvedWSElements)
-
-  outputLine(`Loading elements from ${input.fromDir}`, output)
-  const beforeElements = await loadElementsFromFolder(input.fromDir, resolvedWSElementSource)
-  const { elements: mergedBeforeElements, success: beforeMergeSuccess } = await mergeElements(
+  const { fromDir, toDir, accountName } = input
+  const { changes, fetchErrors, mergeErrors } = await calculatePatch({
     workspace,
-    beforeElements,
-    output,
-  )
-  if (!beforeMergeSuccess) {
+    fromDir,
+    toDir,
+    accountName,
+  })
+  if (mergeErrors.length > 0) {
+    const mergeErrorsValues = await awu(mergeErrors.values()).flat().toArray()
+    errorOutputLine('Encountered merge errors in elements:', output)
+    errorOutputLine(await formatWorkspaceErrors(workspace, mergeErrorsValues), output)
     return false
   }
-
-  outputLine(`Loading elements from ${input.toDir}`, output)
-  const afterElements = await loadElementsFromFolder(input.toDir, resolvedWSElementSource)
-  const { elements: mergedAfterElements, success: afterMergeSuccess } = await mergeElements(
-    workspace,
-    afterElements,
-    output,
-  )
-  if (!afterMergeSuccess) {
-    return false
-  }
-
-  outputLine(`Calculating difference between ${input.fromDir} and ${input.toDir}`, output)
-  const changes = await calcFetchChanges(
-    afterElements,
-    elementSource.createInMemoryElementSource(mergedAfterElements),
-    elementSource.createInMemoryElementSource(mergedBeforeElements),
-    resolvedWSElementSource,
-    new Set([input.accountName]),
-    new Set([input.accountName]),
-  )
-
   outputLine(`Found ${changes.length} changes to apply`, output)
   const conflicts = changes.filter(change => !_.isEmpty(change.pendingChanges))
   conflicts.forEach(change => {
@@ -138,6 +94,14 @@ const fetchDiffToWorkspace = async (
   if (conflicts.length > 0) {
     errorOutputLine(`Failed to update env ${workspace.currentEnv()} because there are ${conflicts.length} conflicting changes`, output)
     return false
+  }
+  if (fetchErrors.length > 0) {
+    // We currently assume all fetchErrors are warnings
+    log.debug(`fetch-diff had ${fetchErrors.length} warnings`)
+    outputLine(
+      formatFetchWarnings(fetchErrors.map(fetchError => fetchError.message)),
+      output,
+    )
   }
   if (updateState) {
     outputLine(`Updating state for environment ${workspace.currentEnv()}`, output)
@@ -155,7 +119,7 @@ const fetchDiffToWorkspace = async (
 }
 
 
-export const fetchDiffAction: WorkspaceCommandAction<FetchDiffArgs> = async ({
+export const applyPatchAction: WorkspaceCommandAction<ApplyPatchArgs> = async ({
   workspace,
   input,
   output,
@@ -176,7 +140,7 @@ export const fetchDiffAction: WorkspaceCommandAction<FetchDiffArgs> = async ({
     }
     await workspace.setCurrentEnv(env, false)
     const updateState = input.updateStateInEnvs?.includes(env) ?? false
-    success = await fetchDiffToWorkspace(workspace, input, updateState, output)
+    success = await applyPatchToWorkspace(workspace, input, updateState, output)
   })
 
   if (success) {
@@ -186,9 +150,9 @@ export const fetchDiffAction: WorkspaceCommandAction<FetchDiffArgs> = async ({
   return success ? CliExitCode.Success : CliExitCode.AppError
 }
 
-const fetchDiffCmd = createWorkspaceCommand({
+const ApplyPatchCmd = createWorkspaceCommand({
   properties: {
-    name: 'fetch-diff',
+    name: 'apply-patch',
     description: 'Calculate the difference between two SFDX folders and apply it to the workspace',
     keyedOptions: [
       {
@@ -229,7 +193,7 @@ const fetchDiffCmd = createWorkspaceCommand({
       },
     ],
   },
-  action: fetchDiffAction,
+  action: applyPatchAction,
 })
 
-export default fetchDiffCmd
+export default ApplyPatchCmd

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import fetchDef from './fetch'
-import fetchDiffDef from './fetch_diff'
+import fetchDiffDef from './apply_patch'
 import envGroupDef from './env'
 import { accountGroupDef, serviceGroupDef } from './account'
 import deployDef from './deploy'

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import fetchDef from './fetch'
-import fetchDiffDef from './apply_patch'
+import applyPatchDef from './apply_patch'
 import envGroupDef from './env'
 import { accountGroupDef, serviceGroupDef } from './account'
 import deployDef from './deploy'
@@ -30,7 +30,7 @@ export default [
   accountGroupDef,
   serviceGroupDef, // Deprecated. Maintained for backward compatibility.
   fetchDef,
-  fetchDiffDef,
+  applyPatchDef,
   deployDef,
   restoreDef,
   elementGroupDef,

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 export { Plan, PlanItem } from './src/core/plan'
-export { FetchChange, FetchProgressEvents, StepEmitter, FetchChangeMetadata, calcFetchChanges } from './src/core/fetch'
+export { FetchChange, FetchProgressEvents, StepEmitter, FetchChangeMetadata } from './src/core/fetch'
 export * from './src/api'
 export { ItemStatus, summarizeDeployChanges, DeploySummaryResult, DetailedChangeDeploySummaryResult } from './src/core/deploy'
 export { getAdaptersCredentialsTypes, getDefaultAdapterConfig, getAdaptersConfigTypes } from './src/core/adapters/adapters'

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -390,7 +390,7 @@ export const calculatePatch = async (
   const accountToServiceNameMap = getAccountToServiceNameMap(workspace, workspace.accounts())
   const { loadElementsFromFolder } = adapterCreators[accountToServiceNameMap[accountName]]
   if (loadElementsFromFolder === undefined) {
-    throw new Error(`Account ${accountName}'s adapter ${accountToServiceNameMap[accountName]} does not support fetch diff`)
+    throw new Error(`Account ${accountName}'s adapter ${accountToServiceNameMap[accountName]} does not support calculate patch`)
   }
 
   const wsElements = await workspace.elements()

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -755,7 +755,7 @@ describe('api.ts', () => {
     })
   })
 
-  describe('fetchDiffToWorkspace', () => {
+  describe('calculatePatch', () => {
     const type = new ObjectType({
       elemID: new ElemID('salesforce', 'type'),
       fields: {

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -865,6 +865,14 @@ describe('api.ts', () => {
         expect(firstChange.pendingChanges).toHaveLength(1)
       })
     })
+
+    describe('when used with an account that does not support loadElementsFromFolder', () => {
+      it('Should throw an error', async () => {
+        await expect(
+          api.calculatePatch({ workspace: ws, fromDir: 'before', toDir: 'after', accountName: 'notSalesforce' }),
+        ).rejects.toThrow()
+      })
+    })
   })
 
   describe('rename', () => {

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -18,6 +18,7 @@ import { AdapterOperations, BuiltinTypes, CORE_ANNOTATIONS, Element, ElemID, Ins
 import * as workspace from '@salto-io/workspace'
 import { collections } from '@salto-io/lowerdash'
 import { mockFunction } from '@salto-io/test-utils'
+import { loadElementsFromFolder, adapter as salesforceAdapter } from '@salto-io/salesforce-adapter'
 import * as api from '../src/api'
 import * as plan from '../src/core/plan/plan'
 import * as fetch from '../src/core/fetch'
@@ -76,6 +77,21 @@ jest.mock('../src/core/diff', () => ({
       : detailedChanges
   }),
 }))
+
+jest.mock('@salto-io/salesforce-adapter', () => {
+  const actual = jest.requireActual('@salto-io/salesforce-adapter')
+  return {
+    ...actual,
+    adapter: {
+      ...actual.adapter,
+      loadElementsFromFolder: jest.fn().mockImplementation(actual.adapter.loadElementsFromFolder),
+    },
+  }
+})
+
+const mockLoadElementsFromFolder = (
+  salesforceAdapter.loadElementsFromFolder as jest.MockedFunction<typeof loadElementsFromFolder>
+)
 
 describe('api.ts', () => {
   const mockAdapterOps = {
@@ -738,6 +754,119 @@ describe('api.ts', () => {
       })
     })
   })
+
+  describe('fetchDiffToWorkspace', () => {
+    const type = new ObjectType({
+      elemID: new ElemID('salesforce', 'type'),
+      fields: {
+        f: { refType: BuiltinTypes.STRING },
+      },
+    })
+
+    const instance = new InstanceElement('instance', type, { f: 'v' })
+    const instanceState = new InstanceElement('instanceState', type, { f: 'v' })
+    const instanceNacl = instanceState.clone()
+    instanceNacl.value.f = 'v2'
+
+    const ws = mockWorkspace({
+      elements: [type, instance, instanceNacl],
+      stateElements: [type, instance, instanceState],
+      name: 'workspace',
+      accounts: ['salesforce'],
+      accountToServiceName: { salesforce: 'salesforce' },
+    })
+
+    adapterCreators.salesforce = salesforceAdapter
+
+    beforeEach(() => {
+      mockLoadElementsFromFolder.mockClear()
+    })
+
+    describe('when there is a difference between the folders', () => {
+      it('should return the changes with no errors', async () => {
+        const afterModifyInstance = instance.clone()
+        afterModifyInstance.value.f = 'v3'
+        const afterNewInstance = new InstanceElement('instance2', type, { f: 'v' })
+        const beforeElements = [instance]
+        const afterElements = [afterModifyInstance, afterNewInstance]
+        mockLoadElementsFromFolder
+          .mockResolvedValueOnce({ elements: beforeElements })
+          .mockResolvedValueOnce({ elements: afterElements })
+        const res = await api.calculatePatch({ workspace: ws, fromDir: 'before', toDir: 'after', accountName: 'salesforce' })
+        expect(res.success).toBeTruthy()
+        expect(res.fetchErrors).toHaveLength(0)
+        expect(res.mergeErrors).toHaveLength(0)
+        expect(res.changes).toHaveLength(2)
+      })
+    })
+
+    describe('when there is no difference between the folders', () => {
+      it('should return with no changes and no errors', async () => {
+        const beforeElements = [instance]
+        const afterElements = [instance]
+        mockLoadElementsFromFolder
+          .mockResolvedValueOnce({ elements: beforeElements })
+          .mockResolvedValueOnce({ elements: afterElements })
+        const res = await api.calculatePatch({ workspace: ws, fromDir: 'before', toDir: 'after', accountName: 'salesforce' })
+        expect(res.success).toBeTruthy()
+        expect(res.fetchErrors).toHaveLength(0)
+        expect(res.mergeErrors).toHaveLength(0)
+        expect(res.changes).toHaveLength(0)
+      })
+    })
+
+    describe('when there is a merge error', () => {
+      it('should return with merge error and success false', async () => {
+        const beforeElements = [instance, instance]
+        mockLoadElementsFromFolder
+          .mockResolvedValueOnce({ elements: beforeElements })
+        const res = await api.calculatePatch({ workspace: ws, fromDir: 'before', toDir: 'after', accountName: 'salesforce' })
+        expect(res.success).toBeFalsy()
+        expect(res.fetchErrors).toHaveLength(0)
+        expect(res.changes).toHaveLength(0)
+        expect(res.mergeErrors).toHaveLength(1)
+      })
+    })
+
+    describe('when there is a fetch error', () => {
+      it('should return with changes and fetch errors', async () => {
+        const afterModifyInstance = instance.clone()
+        afterModifyInstance.value.f = 'v3'
+        const beforeElements = [instance]
+        const afterElements = [afterModifyInstance]
+        mockLoadElementsFromFolder
+          .mockResolvedValueOnce({ elements: beforeElements })
+          .mockResolvedValueOnce({ elements: afterElements, errors: [{ message: 'err', severity: 'Warning' }] })
+        const res = await api.calculatePatch({ workspace: ws, fromDir: 'before', toDir: 'after', accountName: 'salesforce' })
+        expect(res.success).toBeTruthy()
+        expect(res.changes).toHaveLength(1)
+        expect(res.mergeErrors).toHaveLength(0)
+        expect(res.fetchErrors).toHaveLength(1)
+      })
+    })
+
+    describe('when there are conflicts', () => {
+      it('should return the changes with pendingChanges', async () => {
+        const beforeConflictInstance = instanceState.clone()
+        beforeConflictInstance.value.f = 'v5'
+        const afterConflictInstance = instanceState.clone()
+        afterConflictInstance.value.f = 'v4'
+        const beforeElements = [beforeConflictInstance]
+        const afterElements = [afterConflictInstance]
+        mockLoadElementsFromFolder
+          .mockResolvedValueOnce({ elements: beforeElements })
+          .mockResolvedValueOnce({ elements: afterElements })
+        const res = await api.calculatePatch({ workspace: ws, fromDir: 'before', toDir: 'after', accountName: 'salesforce' })
+        expect(res.success).toBeTruthy()
+        expect(res.fetchErrors).toHaveLength(0)
+        expect(res.mergeErrors).toHaveLength(0)
+        expect(res.changes).toHaveLength(1)
+        const firstChange = (await awu(res.changes).toArray())[0]
+        expect(firstChange.pendingChanges).toHaveLength(1)
+      })
+    })
+  })
+
   describe('rename', () => {
     let expectedChanges: DetailedChange[]
     let changes: DetailedChange[]

--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -35,6 +35,7 @@ import createChangeValidator, { changeValidators } from './change_validator'
 import { getChangeGroupIds } from './group_changes'
 import { ConfigChange } from './config_change'
 import { configCreator } from './config_creator'
+import { loadElementsFromFolder } from './sfdx_parser/sfdx_parser'
 
 const log = logger(module)
 
@@ -230,4 +231,5 @@ export const adapter: Adapter = {
   },
   configType,
   configCreator,
+  loadElementsFromFolder,
 }

--- a/packages/salesforce-adapter/src/sfdx_parser/sfdx_parser.ts
+++ b/packages/salesforce-adapter/src/sfdx_parser/sfdx_parser.ts
@@ -19,7 +19,7 @@ import readdirp from 'readdirp'
 import { logger } from '@salto-io/logging'
 import { collections, promises } from '@salto-io/lowerdash'
 import { filter } from '@salto-io/adapter-utils'
-import { ObjectType, StaticFile, isObjectType, ReadOnlyElementsSource, ElemID, Element } from '@salto-io/adapter-api'
+import { ObjectType, StaticFile, isObjectType, ReadOnlyElementsSource, ElemID, Element, FetchResult, LoadElementsFromFolderArgs } from '@salto-io/adapter-api'
 import { readTextFile, readFile } from '@salto-io/file'
 import { SYSTEM_FIELDS, allFilters, UNSUPPORTED_SYSTEM_FIELDS } from '../adapter'
 import { xmlToValues, isComplexType, complexTypesMap, PACKAGE } from '../transformers/xml_transformer'
@@ -215,13 +215,15 @@ const getDXPackageDirs = async (baseDir: string): Promise<string[]> => {
     .map(packageDir => path.join(baseDir, packageDir.path))
 }
 
-export const loadElementsFromFolder = async (
-  dxBaseDir: string,
-  elementSource: ReadOnlyElementsSource,
-): Promise<Element[]> => {
-  const packages = await getDXPackageDirs(dxBaseDir)
+export const loadElementsFromFolder = async ({
+  baseDir,
+  elementSource,
+}: LoadElementsFromFolderArgs): Promise<FetchResult> => {
+  const packages = await getDXPackageDirs(baseDir)
   const types = await getElementTypesForSFDX(elementSource)
-  return awu(packages)
-    .flatMap(pkg => getElementsFromDXFolder(pkg, elementSource, types))
-    .toArray()
+  return {
+    elements: await awu(packages)
+      .flatMap(pkg => getElementsFromDXFolder(pkg, elementSource, types))
+      .toArray(),
+  }
 }

--- a/packages/salesforce-adapter/test/sfdx_parser/sfdx_parser.test.ts
+++ b/packages/salesforce-adapter/test/sfdx_parser/sfdx_parser.test.ts
@@ -25,10 +25,11 @@ describe('loadElementsFromFolder', () => {
   let elements: Element[]
   beforeAll(async () => {
     const elementSource = buildElementsSourceFromElements(Object.values(mockTypes))
-    elements = await loadElementsFromFolder(
-      path.join(__dirname, 'test_sfdx_project'),
+    const loadElementsRes = await loadElementsFromFolder({
+      baseDir: path.join(__dirname, 'test_sfdx_project'),
       elementSource,
-    )
+    })
+    elements = loadElementsRes.elements
   })
   describe('layout elements', () => {
     let layout: InstanceElement


### PR DESCRIPTION
What's here? 

CLI - 
* Renamed `fetch-diff` to `apply-patch`
* Moved the Changes calculation logic to be a core api to extracted a lot of the logic outside of the CLI

Core - 
* Added `loadElementsFromFolder` to the adapter api (not under operations cause it doesn't require the context)
* Created a new `calculatePatch` api that gets a workspace and 2 folders with SFDX content (this is currently restricted only to salesforce) and returns a "FetchResult" to apply to the workspace

---

TODO:
- [x]  Add unit tests to the new core api
- [x]  Decide if to change the tests logic of the command
- [x]  Manually test that this doesn't break anything

---
_Release Notes_: 

*Core*:
* Add calculatePatch to the core api. It gets a workspace and two path directories with external service format (ie. SFDX) content, calculates the diff between them, translates them to Changes and returns "FetchResult" to be applied to the Workspace.

*CLI*:
* Rename the `fetch-diff` command to `apply-patch`

---
_User Notifications_: 
None
