### PR TITLE
SALTO-2824 DataCategoryGroup CV

### DIFF
--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -264,3 +264,4 @@ For more details see the DeployOptions section in the [salesforce documentation 
 | multipleDefaults      | true                   | Check for multiple default values in picklists and other places where only one default is allowed |
 | picklistPromote       | true                   | Disallow promoting picklist value-set to global since it cannot be done with the API              |
 | validateOnlyFlag      | true                   | Disallow deploying data records in a validation only deploy                                       |
+| dataCategoryGroup     | true                   | Warn when deploying additions or changes to DataCategoryGroup elements                            |

--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -44,6 +44,7 @@ import lastLayoutRemoval from './change_validators/last_layout_removal'
 import currencyIsoCodes from './change_validators/currency_iso_codes'
 import unknownPicklistValues from './change_validators/unknown_picklist_values'
 import accountSettings from './change_validators/account_settings'
+import dataCategoryGroupValidator from './change_validators/data_category_group'
 import SalesforceClient from './client/client'
 import { ChangeValidatorName, SalesforceConfig } from './types'
 
@@ -86,6 +87,7 @@ export const changeValidators: Record<ChangeValidatorName, ChangeValidatorDefini
   lastLayoutRemoval: { creator: () => lastLayoutRemoval, ...defaultAlwaysRun },
   accountSettings: { creator: () => accountSettings(), ...defaultAlwaysRun },
   unknownPicklistValues: { creator: () => unknownPicklistValues, ...defaultAlwaysRun },
+  dataCategoryGroup: { creator: () => dataCategoryGroupValidator, ...defaultAlwaysRun },
 }
 
 const createSalesforceChangeValidator = ({ config, isSandbox, checkOnly, client }: {

--- a/packages/salesforce-adapter/src/change_validators/data_category_group.ts
+++ b/packages/salesforce-adapter/src/change_validators/data_category_group.ts
@@ -1,0 +1,48 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ChangeError, ChangeValidator, getChangeData, InstanceElement, isAdditionOrModificationChange,
+  isInstanceElement } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { isInstanceOfType } from '../filters/utils'
+
+const { awu } = collections.asynciterable
+
+const destructiveDataCategoryGroupDeployError = (instance: InstanceElement): ChangeError => (
+  {
+    elemID: instance.elemID,
+    severity: 'Warning',
+    message: 'DataCategoryGroup deployments may be destructive',
+    detailedMessage: 'Deploying category changes from one environment to another may permanently remove some categories and record categorizations. It is recommended to manually create data categories and record associations via the Salesforce UI from ‘Setup’ by entering ‘Data Categories’ in the Quick Find box, then selecting ‘Data Categories’.',
+  }
+)
+
+/*
+Changes in DataCategoryGroup can be destructive (remove elements from the current environment).
+Issue a warning on all such changes
+*/
+function changeValidator(): ChangeValidator {
+  return async changes => (
+    awu(changes)
+      .filter(isAdditionOrModificationChange)
+      .map(getChangeData)
+      .filter(isInstanceElement)
+      .filter(isInstanceOfType('DataCategoryGroup'))
+      .map(destructiveDataCategoryGroupDeployError)
+      .toArray()
+  )
+}
+
+export default changeValidator()

--- a/packages/salesforce-adapter/src/change_validators/data_category_group.ts
+++ b/packages/salesforce-adapter/src/change_validators/data_category_group.ts
@@ -14,9 +14,10 @@
 * limitations under the License.
 */
 import { ChangeError, ChangeValidator, getChangeData, InstanceElement, isAdditionOrModificationChange,
-  isInstanceElement } from '@salto-io/adapter-api'
+  isInstanceChange } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
-import { isInstanceOfType } from '../filters/utils'
+import { DATA_CATEGORY_GROUP_METADATA_TYPE } from '../constants'
+import { isInstanceOfTypeChange } from '../filters/utils'
 
 const { awu } = collections.asynciterable
 
@@ -36,10 +37,10 @@ Issue a warning on all such changes
 function changeValidator(): ChangeValidator {
   return async changes => (
     awu(changes)
+      .filter(isInstanceChange)
       .filter(isAdditionOrModificationChange)
+      .filter(isInstanceOfTypeChange(DATA_CATEGORY_GROUP_METADATA_TYPE))
       .map(getChangeData)
-      .filter(isInstanceElement)
-      .filter(isInstanceOfType('DataCategoryGroup'))
       .map(destructiveDataCategoryGroupDeployError)
       .toArray()
   )

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -374,6 +374,7 @@ export const FLOW_DEFINITION_METADATA_TYPE = 'FlowDefinition'
 export const INSTALLED_PACKAGE_METADATA = 'InstalledPackage'
 export const ACCOUNT_SETTINGS_METADATA_TYPE = 'AccountSettings'
 export const PERMISSION_SET_TYPE_ID_METADATA_TYPE = 'PermissionSet'
+export const DATA_CATEGORY_GROUP_METADATA_TYPE = 'DataCategoryGroup'
 
 // Artifitial Types
 export const CURRENCY_CODE_TYPE_NAME = 'CurrencyIsoCodes'

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -106,6 +106,7 @@ export type ChangeValidatorName = (
   | 'lastLayoutRemoval'
   | 'accountSettings'
   | 'unknownPicklistValues'
+  | 'dataCategoryGroup'
 )
 
 export type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
@@ -603,6 +604,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     lastLayoutRemoval: { refType: BuiltinTypes.BOOLEAN },
     accountSettings: { refType: BuiltinTypes.BOOLEAN },
     unknownPicklistValues: { refType: BuiltinTypes.BOOLEAN },
+    dataCategoryGroup: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/salesforce-adapter/test/change_validators/data_category_group.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/data_category_group.test.ts
@@ -18,16 +18,18 @@ import changeValidator from '../../src/change_validators/data_category_group'
 import { mockTypes } from '../mock_elements'
 import { createInstanceElement } from '../../src/transformers/transformer'
 
-describe('data category group addition or modification change validator', () => {
+describe('DataCategoryGroup ChangeValidator', () => {
   const afterRecord = createInstanceElement({ fullName: 'obj__c.record' }, mockTypes.DataCategoryGroup)
 
   it('should have warning when trying to add a new data category group', async () => {
     const changeErrors = await changeValidator(
       [toChange({ after: afterRecord })]
     )
-    expect(changeErrors).toHaveLength(1)
-    const [changeError] = changeErrors
-    expect(changeError.elemID).toEqual(afterRecord.elemID)
-    expect(changeError.severity).toEqual('Warning')
+    expect(changeErrors).toEqual([
+      expect.objectContaining({
+        elemID: afterRecord.elemID,
+        severity: 'Warning',
+      }),
+    ])
   })
 })

--- a/packages/salesforce-adapter/test/change_validators/data_category_group.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/data_category_group.test.ts
@@ -1,0 +1,33 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { toChange } from '@salto-io/adapter-api'
+import changeValidator from '../../src/change_validators/data_category_group'
+import { mockTypes } from '../mock_elements'
+import { createInstanceElement } from '../../src/transformers/transformer'
+
+describe('data category group addition or modification change validator', () => {
+  const afterRecord = createInstanceElement({ fullName: 'obj__c.record' }, mockTypes.DataCategoryGroup)
+
+  it('should have warning when trying to add a new data category group', async () => {
+    const changeErrors = await changeValidator(
+      [toChange({ after: afterRecord })]
+    )
+    expect(changeErrors).toHaveLength(1)
+    const [changeError] = changeErrors
+    expect(changeError.elemID).toEqual(afterRecord.elemID)
+    expect(changeError.severity).toEqual('Warning')
+  })
+})

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -606,14 +606,6 @@ export const mockDefaultValues = {
   },
   DataCategoryGroup: {
     [INSTANCE_FULL_NAME_FIELD]: 'TestDataCategoryGroup',
-    dataCategory: {
-      label: 'test label',
-      name: 'test name',
-    },
-    objectUsage: {
-      object: 'KnowledgeArticleVersion',
-    },
-    label: 'Test Data Cateogry Group Description',
   },
 }
 

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -448,6 +448,11 @@ export const mockTypes = {
       },
     },
   }),
+  DataCategoryGroup: createMetadataObjectType({
+    annotations: {
+      [METADATA_TYPE]: 'DataCategoryGroup',
+    },
+  }),
 }
 
 export const lwcJsResourceContent = "import { LightningElement } from 'lwc';\nexport default class BikeCard extends LightningElement {\n   name = 'Electra X4';\n   description = 'A sweet bike built for comfort.';\n   category = 'Mountain';\n   material = 'Steel';\n   price = '$2,700';\n   pictureUrl = 'https://s3-us-west-1.amazonaws.com/sfdc-demo/ebikes/electrax4.jpg';\n }"
@@ -598,6 +603,17 @@ export const mockDefaultValues = {
     contentType: 'text/xml',
     description: 'Test Static Resource Description',
     content: Buffer.from('<xml/>'),
+  },
+  DataCategoryGroup: {
+    [INSTANCE_FULL_NAME_FIELD]: 'TestDataCategoryGroup',
+    dataCategory: {
+      label: 'test label',
+      name: 'test name',
+    },
+    objectUsage: {
+      object: 'KnowledgeArticleVersion',
+    },
+    label: 'Test Data Cateogry Group Description',
   },
 }
 


### PR DESCRIPTION
add CV for DataCategoryGroup addition or modification, since it could be destructive 

---


---
_Release Notes_: 
Salesforce Adapter:
- Add ChangeValidator for addition or modification of DataCategoryGroup, since metadata changes may be destructive

---
_User Notifications_: 
_None_