### PR TITLE
SALTO-3371: files referenced in SDF are not written as dependencies in the manifest

### DIFF
--- a/packages/netsuite-adapter/config_doc.md
+++ b/packages/netsuite-adapter/config_doc.md
@@ -75,11 +75,11 @@ netsuite {
 | -------------------------------| ------------------------| -----------
 | deploy.additionalDependencies.include.features              | []                      | Feature dependencies list (string[]) to be included in the manifest passed to SDF when deploying
 | deploy.additionalDependencies.include.objects               | []                      | Object dependencies list (string[]) to be included in the manifest passed to SDF when deploying
+| deploy.additionalDependencies.include.files                 | []                      | File dependencies list (string[]) to be included in the manifest passed to SDF when deploying
 | deploy.additionalDependencies.exclude.features              | []                      | Feature dependencies list (string[]) to be excluded from the manifest passed to SDF when deploying
 | deploy.additionalDependencies.exclude.objects               | []                      | Object dependencies list (string[]) to be excluded from the manifest passed to SDF when deploying
-| deploy.additionalDependencies.include.files                 | []                      | File dependencies list (string[]) to be included in the manifest passed to SDF when deploying
 | deploy.additionalDependencies.exclude.files                 | []                      | Files dependencies list (string[]) to be 
-excludrd from the manifest passed to SDF when deploying
+excluded from the manifest passed to SDF when deploying
 Features are included as optional by default. In order to include a required feature add the `":required"` suffix to it.
 Example:
 ```

--- a/packages/netsuite-adapter/config_doc.md
+++ b/packages/netsuite-adapter/config_doc.md
@@ -77,7 +77,9 @@ netsuite {
 | deploy.additionalDependencies.include.objects               | []                      | Object dependencies list (string[]) to be included in the manifest passed to SDF when deploying
 | deploy.additionalDependencies.exclude.features              | []                      | Feature dependencies list (string[]) to be excluded from the manifest passed to SDF when deploying
 | deploy.additionalDependencies.exclude.objects               | []                      | Object dependencies list (string[]) to be excluded from the manifest passed to SDF when deploying
-
+| deploy.additionalDependencies.include.files                 | []                      | File dependencies list (string[]) to be included in the manifest passed to SDF when deploying
+| deploy.additionalDependencies.exclude.files                 | []                      | Files dependencies list (string[]) to be 
+excludrd from the manifest passed to SDF when deploying
 Features are included as optional by default. In order to include a required feature add the `":required"` suffix to it.
 Example:
 ```

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -202,10 +202,12 @@ export default class NetsuiteAdapter implements AdapterOperations {
       include: {
         features: config.deploy?.additionalDependencies?.include?.features ?? [],
         objects: config.deploy?.additionalDependencies?.include?.objects ?? [],
+        files: config.deploy?.additionalDependencies?.include?.files ?? [],
       },
       exclude: {
         features: config.deploy?.additionalDependencies?.exclude?.features ?? [],
         objects: config.deploy?.additionalDependencies?.exclude?.objects ?? [],
+        files: config.deploy?.additionalDependencies?.exclude?.files ?? [],
       },
     }
     this.createFiltersRunner = ({ isPartial = false, changesGroupId }) => filter.filtersRunner(

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -211,6 +211,8 @@ export default class NetsuiteClient {
       excludedFeatures: excluded.map(feature => feature.name),
       includedObjects: additionalDependencies.include.objects,
       excludedObjects: additionalDependencies.exclude.objects,
+      includedFiles: additionalDependencies.include.files,
+      excludedFiles: additionalDependencies.exclude.files,
     }
   }
 

--- a/packages/netsuite-adapter/src/client/manifest_utils.ts
+++ b/packages/netsuite-adapter/src/client/manifest_utils.ts
@@ -133,7 +133,7 @@ const getRequiredObjects = (customizationInfos: CustomizationInfo[]): string[] =
 
 const getRequiredFiles = (customizationInfos: CustomizationInfo[]): string[] => {
   const fileNames = new Set(customizationInfos.filter(isFileCustomizationInfo).map(fileCustInfo =>
-    fileCustInfo.path.join(FILE_CABINET_PATH_SEPARATOR)))
+    `${FILE_CABINET_PATH_SEPARATOR}${fileCustInfo.path.join(FILE_CABINET_PATH_SEPARATOR)}`))
 
   return _.uniq(customizationInfos.flatMap(custInfo => {
     const requiredFiles: string[] = []

--- a/packages/netsuite-adapter/src/client/manifest_utils.ts
+++ b/packages/netsuite-adapter/src/client/manifest_utils.ts
@@ -18,7 +18,7 @@ import { Value } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import xmlParser from 'fast-xml-parser'
 import _ from 'lodash'
-import { FILE_CABINET_PATH_SEPARATOR, FINANCIAL_LAYOUT, PATH, REPORT_DEFINITION, SCRIPT_ID, WORKFLOW } from '../constants'
+import { FILE_CABINET_PATH_SEPARATOR, FINANCIAL_LAYOUT, REPORT_DEFINITION, SCRIPT_ID, WORKFLOW } from '../constants'
 import { captureServiceIdInfo, ServiceIdInfo } from '../service_id_info'
 import { ManifestDependencies, CustomizationInfo } from './types'
 import { ATTRIBUTE_PREFIX } from './constants'
@@ -116,7 +116,7 @@ const isRequiredObjects = (serviceIdInfo: ServiceIdInfo, objNames: Set<string>):
   && !objNames.has(serviceIdInfo.serviceId.split('.')[0])
 
 const isRequiredFile = (serviceIdInfo: ServiceIdInfo, fileNames: Set<string>): boolean =>
-  serviceIdInfo.serviceIdType === PATH && !fileNames.has(serviceIdInfo.serviceId)
+  serviceIdInfo.serviceIdType === 'path' && !fileNames.has(serviceIdInfo.serviceId)
 
 const getRequiredObjectsAndFiles = (customizationInfos: CustomizationInfo[]): RequiredObjectsAndFiles => {
   const fileNames = new Set(customizationInfos.filter(isFileCustomizationInfo).map(fileCustInfo =>

--- a/packages/netsuite-adapter/src/client/types.ts
+++ b/packages/netsuite-adapter/src/client/types.ts
@@ -91,6 +91,8 @@ export type ManifestDependencies = {
   excludedFeatures: string[]
   includedObjects: string[]
   excludedObjects: string[]
+  includedFiles: string[]
+  excludedFiles: string[]
 }
 
 export type SdfDeployParams = {

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -403,12 +403,15 @@ function validateAdditionalSdfDeployDependencies(
   input: Partial<Record<keyof AdditionalSdfDeployDependencies, unknown>>,
   configName: string
 ): asserts input is Partial<AdditionalSdfDeployDependencies> {
-  const { features, objects } = input
+  const { features, objects, files } = input
   if (features !== undefined) {
     validateArrayOfStrings(features, additionalDependenciesConfigPath.concat(configName, 'features'))
   }
   if (objects !== undefined) {
     validateArrayOfStrings(objects, additionalDependenciesConfigPath.concat(configName, 'objects'))
+  }
+  if (files !== undefined) {
+    validateArrayOfStrings(files, additionalDependenciesConfigPath.concat(configName, 'files'))
   }
 }
 

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -46,6 +46,7 @@ export const removeRequiredFeatureSuffix = (featureName: string): string =>
 type AdditionalSdfDeployDependencies = {
   features: string[]
   objects: string[]
+  files: string[]
 }
 
 export type AdditionalDependencies = {
@@ -360,6 +361,7 @@ Partial<AdditionalSdfDeployDependencies>
   fields: {
     features: { refType: new ListType(BuiltinTypes.STRING) },
     objects: { refType: new ListType(BuiltinTypes.STRING) },
+    files: { refType: new ListType(BuiltinTypes.STRING) },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
@@ -438,6 +440,12 @@ const validateAdditionalDependencies = (
     const conflictedObjects = _.intersection(include.objects, exclude.objects)
     if (conflictedObjects.length > 0) {
       throw new Error(`Additional objects cannot be both included and excluded. The following objects are conflicted: ${conflictedObjects.join(', ')}`)
+    }
+  }
+  if (include?.files && exclude?.files) {
+    const conflictedFiles = _.intersection(include.objects, exclude.objects)
+    if (conflictedFiles.length > 0) {
+      throw new Error(`Additional objects cannot be both included and excluded. The following objects are conflicted: ${conflictedFiles.join(', ')}`)
     }
   }
 }

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -445,7 +445,7 @@ const validateAdditionalDependencies = (
   if (include?.files && exclude?.files) {
     const conflictedFiles = _.intersection(include.files, exclude.files)
     if (conflictedFiles.length > 0) {
-      throw new Error(`Additional objects cannot be both included and excluded. The following objects are conflicted: ${conflictedFiles.join(', ')}`)
+      throw new Error(`Additional files cannot be both included and excluded. The following files are conflicted: ${conflictedFiles.join(', ')}`)
     }
   }
 }

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -443,7 +443,7 @@ const validateAdditionalDependencies = (
     }
   }
   if (include?.files && exclude?.files) {
-    const conflictedFiles = _.intersection(include.objects, exclude.objects)
+    const conflictedFiles = _.intersection(include.files, exclude.files)
     if (conflictedFiles.length > 0) {
       throw new Error(`Additional objects cannot be both included and excluded. The following objects are conflicted: ${conflictedFiles.join(', ')}`)
     }

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -50,6 +50,8 @@ const DEFAULT_SDF_DEPLOY_PARAMS = {
     excludedFeatures: [],
     includedObjects: [],
     excludedObjects: [],
+    includedFiles: [],
+    excludedFiles: [],
   },
   validateOnly: false,
 }

--- a/packages/netsuite-adapter/test/adapter_creator.test.ts
+++ b/packages/netsuite-adapter/test/adapter_creator.test.ts
@@ -695,7 +695,7 @@ describe('NetsuiteAdapter creator', () => {
           ).toThrow()
         })
 
-        it('should throw and Error when additionalDependencies has conflicting files', () => {
+        it('should throw an Error when additionalDependencies has conflicting files', () => {
           const invalidConfig = new InstanceElement(
             ElemID.CONFIG_NAME,
             adapter.configType as ObjectType,

--- a/packages/netsuite-adapter/test/adapter_creator.test.ts
+++ b/packages/netsuite-adapter/test/adapter_creator.test.ts
@@ -547,10 +547,12 @@ describe('NetsuiteAdapter creator', () => {
                   include: {
                     features: ['feature1'],
                     objects: ['object1'],
+                    files: ['file1'],
                   },
                   exclude: {
                     features: ['feature2'],
                     objects: ['object2'],
+                    files: ['fil2'],
                   },
                 },
               },
@@ -679,6 +681,29 @@ describe('NetsuiteAdapter creator', () => {
                 additionalDependencies: {
                   include: { objects: ['script_id'] },
                   exclude: { objects: ['script_id'] },
+                },
+              },
+            }
+          )
+          expect(
+            () => adapter.operations({
+              credentials,
+              config: invalidConfig,
+              getElemIdFunc: mockGetElemIdFunc,
+              elementsSource: buildElementsSourceFromElements([]),
+            })
+          ).toThrow()
+        })
+
+        it('should throw and Error when additionalDependencies has conflicting files', () => {
+          const invalidConfig = new InstanceElement(
+            ElemID.CONFIG_NAME,
+            adapter.configType as ObjectType,
+            {
+              deploy: {
+                additionalDependencies: {
+                  include: { files: ['/Folder/filePath'] },
+                  exclude: { files: ['/Folder/filePath'] },
                 },
               },
             }

--- a/packages/netsuite-adapter/test/adapter_creator.test.ts
+++ b/packages/netsuite-adapter/test/adapter_creator.test.ts
@@ -607,6 +607,27 @@ describe('NetsuiteAdapter creator', () => {
             })
           ).toThrow()
         })
+        it('should throw an error when files in additionalDependencies is invalid', () => {
+          const invalidConfig = new InstanceElement(
+            ElemID.CONFIG_NAME,
+            adapter.configType as ObjectType,
+            {
+              deploy: {
+                additionalDependencies: {
+                  include: { files: ['should be list of strings', 1] },
+                },
+              },
+            }
+          )
+          expect(
+            () => adapter.operations({
+              credentials,
+              config: invalidConfig,
+              getElemIdFunc: mockGetElemIdFunc,
+              elementsSource: buildElementsSourceFromElements([]),
+            })
+          ).toThrow()
+        })
         it('should throw an error when additionalDependencies.exclude is invalid', () => {
           const invalidConfig = new InstanceElement(
             ElemID.CONFIG_NAME,

--- a/packages/netsuite-adapter/test/change_validator.test.ts
+++ b/packages/netsuite-adapter/test/change_validator.test.ts
@@ -29,8 +29,8 @@ const DEFAULT_OPTIONS = {
   warnStaleData: false,
   validate: false,
   additionalDependencies: {
-    include: { features: [], objects: [] },
-    exclude: { features: [], objects: [] },
+    include: { features: [], objects: [], files: [] },
+    exclude: { features: [], objects: [], files: [] },
   },
   deployReferencedElements: false,
   filtersRunner: () => ({

--- a/packages/netsuite-adapter/test/client/client.test.ts
+++ b/packages/netsuite-adapter/test/client/client.test.ts
@@ -40,8 +40,8 @@ describe('NetsuiteClient', () => {
       AdditionalDependencies,
     ] = [
       {
-        include: { features: [], objects: [] },
-        exclude: { features: [], objects: [] },
+        include: { features: [], objects: [], files: [] },
+        exclude: { features: [], objects: [], files: [] },
       },
     ]
 
@@ -265,12 +265,14 @@ describe('NetsuiteClient', () => {
                 'required:required',
               ],
               objects: [],
+              files: [],
             },
             exclude: {
               features: [
                 'excluded',
               ],
               objects: [],
+              files: [],
             },
           },
         )
@@ -283,6 +285,8 @@ describe('NetsuiteClient', () => {
               excludedFeatures: ['excluded'],
               includedObjects: [],
               excludedObjects: [],
+              includedFiles: [],
+              excludedFiles: [],
             },
             validateOnly: false,
           },
@@ -308,10 +312,12 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
             include: {
               features: [],
               objects: [],
+              files: [],
             },
             exclude: {
               features: ['SUBSCRIPTIONBILLING'],
               objects: [],
+              files: [],
             },
           },
         )).toEqual({
@@ -331,6 +337,8 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
               excludedFeatures: ['SUBSCRIPTIONBILLING'],
               includedObjects: [],
               excludedObjects: [],
+              includedFiles: [],
+              excludedFiles: [],
             },
             validateOnly: false,
           },
@@ -344,6 +352,8 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
               excludedFeatures: [],
               includedObjects: [],
               excludedObjects: [],
+              includedFiles: [],
+              excludedFiles: [],
             },
             validateOnly: false,
           },
@@ -379,6 +389,8 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
               excludedFeatures: [],
               includedObjects: [],
               excludedObjects: [],
+              includedFiles: [],
+              excludedFiles: [],
             },
             validateOnly: false,
           },
@@ -392,6 +404,8 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
               excludedFeatures: [],
               includedObjects: [],
               excludedObjects: [],
+              includedFiles: [],
+              excludedFiles: [],
             },
             validateOnly: false,
           },
@@ -405,6 +419,8 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
               excludedFeatures: [],
               includedObjects: [],
               excludedObjects: [],
+              includedFiles: [],
+              excludedFiles: [],
             },
             validateOnly: false,
           },
@@ -448,6 +464,8 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
                 excludedFeatures: [],
                 includedObjects: [],
                 excludedObjects: [],
+                includedFiles: [],
+                excludedFiles: [],
               },
               validateOnly: false,
             },
@@ -590,6 +608,8 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
               excludedFeatures: [],
               includedObjects: [],
               excludedObjects: [],
+              includedFiles: [],
+              excludedFiles: [],
             },
             validateOnly: true,
           },
@@ -627,8 +647,8 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
       AdditionalDependencies,
     ] = [
       {
-        include: { features: [], objects: [] },
-        exclude: { features: [], objects: [] },
+        include: { features: [], objects: [], files: [] },
+        exclude: { features: [], objects: [], files: [] },
       },
     ]
 

--- a/packages/netsuite-adapter/test/client/manifest_utils.test.ts
+++ b/packages/netsuite-adapter/test/client/manifest_utils.test.ts
@@ -36,8 +36,6 @@ describe('manifest.xml utils', () => {
         key: '__STDRECORDSUBSIDIARYDEFAULTACCTCORPCARDEXP__',
         // 'somescriptid' should be added to the manifest
         ref: '[scriptid=somescriptid]',
-        // should be added to the manifest
-        ref2: '[/SuiteScripts/test.js]',
       },
     },
     {
@@ -54,7 +52,7 @@ describe('manifest.xml utils', () => {
         ref3: '[scriptid=workflow1.innerscriptid]',
         // 'external_script_id' shouldn't be added to the manifest since it has appid
         ref4: '[appid=com.salto, scriptid=external_script_id]',
-        // test.js file shouldn't be added to manifest since it is in the SDF project
+        // /SuiteScripts/test.js file shouldn't be added to manifest since it is in the SDF project
         fileRef: '[/SuiteScripts/test.js]',
         // /SuiteSCripts/test2.js should be added to manifest
         fileRef2: '[/SuiteScripts/test2.js]',
@@ -256,6 +254,7 @@ describe('manifest.xml utils', () => {
   </objects>
   <files>
     <file>/SuiteScripts/clientScript_2_0.js</file>
+    <file>/SuiteScripts/excludedTestScript.js</file>
   </files>
 </dependencies>
 </manifest>`
@@ -296,7 +295,7 @@ describe('manifest.xml utils', () => {
       includedObjects: ['addedObject'],
       excludedObjects: ['custentity2edited', 'somescriptid', 'secondscriptid'],
       includedFiles: ['/SuiteScripts/testScript.js'],
-      excludedFiles: ['/SuiteScripts/exludedTestScript.js'],
+      excludedFiles: ['/SuiteScripts/excludedTestScript.js'],
     }))
       .toEqual(fixedManifest)
   })

--- a/packages/netsuite-adapter/test/client/manifest_utils.test.ts
+++ b/packages/netsuite-adapter/test/client/manifest_utils.test.ts
@@ -23,6 +23,8 @@ const DEFAULT_ADDITIONAL_DEPS = {
   excludedFeatures: [],
   includedObjects: [],
   excludedObjects: [],
+  includedFiles: [],
+  excludedFiles: [],
 }
 
 describe('manifest.xml utils', () => {
@@ -50,7 +52,6 @@ describe('manifest.xml utils', () => {
         ref3: '[scriptid=workflow1.innerscriptid]',
         // 'external_script_id' shouldn't be added to the manifest since it has appid
         ref4: '[appid=com.salto, scriptid=external_script_id]',
-        // '/SuiteScripts/test.js' shouldn't be added to the manifest since we add only scriptids
         fileRef: '[/SuiteScripts/test.js]',
         // 'customrecord_test.cseg1' shouldn't be added to the manifest since
         // it is a wrong customsegment scriptid
@@ -82,6 +83,9 @@ describe('manifest.xml utils', () => {
       <object>somescriptid</object>
       <object>secondscriptid</object>
     </objects>
+    <files>
+      <file>/SuiteScripts/test.js</file>
+    </files>
   </dependencies>
 </manifest>
 `
@@ -115,6 +119,7 @@ describe('manifest.xml utils', () => {
   </objects>
   <files>
     <file>/SuiteScripts/clientScript_2_0.js</file>
+    <file>/SuiteScripts/test
   </files>
 </dependencies>
 </manifest>`
@@ -141,6 +146,7 @@ describe('manifest.xml utils', () => {
     </objects>
     <files>
       <file>/SuiteScripts/clientScript_2_0.js</file>
+      <file>/SuiteScripts/test</file>
     </files>
   </dependencies>
 </manifest>
@@ -205,6 +211,7 @@ describe('manifest.xml utils', () => {
     </objects>
     <files>
       <file>/SuiteScripts/clientScript_2_0.js</file>
+      <file>/SuiteScripts/test.js</file>
     </files>
   </dependencies>
 </manifest>
@@ -267,6 +274,8 @@ describe('manifest.xml utils', () => {
     </objects>
     <files>
       <file>/SuiteScripts/clientScript_2_0.js</file>
+      <file>/SuiteScripts/testScript.js</file>
+      <file>/SuiteScripts/test.js</file>
     </files>
   </dependencies>
 </manifest>
@@ -277,6 +286,8 @@ describe('manifest.xml utils', () => {
       excludedFeatures: ['RECEIVABLES'],
       includedObjects: ['addedObject'],
       excludedObjects: ['custentity2edited', 'somescriptid', 'secondscriptid'],
+      includedFiles: ['/SuiteScripts/testScript.js'],
+      excludedFiles: ['/SuiteScripts/exludedTestScript.js'],
     }))
       .toEqual(fixedManifest)
   })

--- a/packages/netsuite-adapter/test/client/manifest_utils.test.ts
+++ b/packages/netsuite-adapter/test/client/manifest_utils.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { WORKFLOW } from '../../src/constants'
+import { WORKFLOW, FILE } from '../../src/constants'
 import { fixManifest } from '../../src/client/manifest_utils'
 import { CustomizationInfo } from '../../src/client/types'
 
@@ -52,12 +52,19 @@ describe('manifest.xml utils', () => {
         ref3: '[scriptid=workflow1.innerscriptid]',
         // 'external_script_id' shouldn't be added to the manifest since it has appid
         ref4: '[appid=com.salto, scriptid=external_script_id]',
+        // test.js file shouldn't be added to manifest since it is in the SDF project
         fileRef: '[/SuiteScripts/test.js]',
         // 'customrecord_test.cseg1' shouldn't be added to the manifest since
         // it is a wrong customsegment scriptid
         customSegmentRef: '[scriptid=customrecord_test.cseg1]',
       },
     },
+    {
+      typeName: FILE,
+      path: ['SuiteScripts', 'test.js'],
+      values: {
+      },
+    } as CustomizationInfo,
   ]
 
   it('should return with no manifest tag', () => {
@@ -84,7 +91,6 @@ describe('manifest.xml utils', () => {
       <object>secondscriptid</object>
     </objects>
     <files>
-      <file>/SuiteScripts/test.js</file>
     </files>
   </dependencies>
 </manifest>
@@ -119,7 +125,6 @@ describe('manifest.xml utils', () => {
   </objects>
   <files>
     <file>/SuiteScripts/clientScript_2_0.js</file>
-    <file>/SuiteScripts/test
   </files>
 </dependencies>
 </manifest>`
@@ -146,7 +151,6 @@ describe('manifest.xml utils', () => {
     </objects>
     <files>
       <file>/SuiteScripts/clientScript_2_0.js</file>
-      <file>/SuiteScripts/test</file>
     </files>
   </dependencies>
 </manifest>
@@ -211,7 +215,6 @@ describe('manifest.xml utils', () => {
     </objects>
     <files>
       <file>/SuiteScripts/clientScript_2_0.js</file>
-      <file>/SuiteScripts/test.js</file>
     </files>
   </dependencies>
 </manifest>
@@ -275,7 +278,6 @@ describe('manifest.xml utils', () => {
     <files>
       <file>/SuiteScripts/clientScript_2_0.js</file>
       <file>/SuiteScripts/testScript.js</file>
-      <file>/SuiteScripts/test.js</file>
     </files>
   </dependencies>
 </manifest>

--- a/packages/netsuite-adapter/test/client/manifest_utils.test.ts
+++ b/packages/netsuite-adapter/test/client/manifest_utils.test.ts
@@ -36,6 +36,8 @@ describe('manifest.xml utils', () => {
         key: '__STDRECORDSUBSIDIARYDEFAULTACCTCORPCARDEXP__',
         // 'somescriptid' should be added to the manifest
         ref: '[scriptid=somescriptid]',
+        // should be added to the manifest
+        ref2: '[/SuiteScripts/test.js]',
       },
     },
     {
@@ -54,6 +56,8 @@ describe('manifest.xml utils', () => {
         ref4: '[appid=com.salto, scriptid=external_script_id]',
         // test.js file shouldn't be added to manifest since it is in the SDF project
         fileRef: '[/SuiteScripts/test.js]',
+        // /SuiteSCripts/test2.js should be added to manifest
+        fileRef2: '[/SuiteScripts/test2.js]',
         // 'customrecord_test.cseg1' shouldn't be added to the manifest since
         // it is a wrong customsegment scriptid
         customSegmentRef: '[scriptid=customrecord_test.cseg1]',
@@ -91,6 +95,7 @@ describe('manifest.xml utils', () => {
       <object>secondscriptid</object>
     </objects>
     <files>
+      <file>/SuiteScripts/test2.js</file>
     </files>
   </dependencies>
 </manifest>
@@ -215,6 +220,7 @@ describe('manifest.xml utils', () => {
     </objects>
     <files>
       <file>/SuiteScripts/clientScript_2_0.js</file>
+      <file>/SuiteScripts/test2.js</file>
     </files>
   </dependencies>
 </manifest>
@@ -278,6 +284,7 @@ describe('manifest.xml utils', () => {
     <files>
       <file>/SuiteScripts/clientScript_2_0.js</file>
       <file>/SuiteScripts/testScript.js</file>
+      <file>/SuiteScripts/test2.js</file>
     </files>
   </dependencies>
 </manifest>

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -39,6 +39,8 @@ const DEFAULT_DEPLOY_PARAMS: [undefined, SdfDeployParams, Graph<SDFObjectNode>] 
       excludedFeatures: [],
       includedObjects: [],
       excludedObjects: [],
+      includedFiles: [],
+      excludedFiles: [],
     },
   },
   new Graph<SDFObjectNode>('elemIdFullName'),


### PR DESCRIPTION
_files referenced in sdf and aren't deployed at the exact deployment will added as dependencies in the manifest_

---

_None_

---
_Release Notes_: 
_Netsuite Adapter_:
* All files referenced in SDF will be added as dependencies in the manifest

---
_User Notifications_: 
_None_
