### PR TITLE
SALTO-3918 author information index

### DIFF
--- a/packages/adapter-api/src/author_information.ts
+++ b/packages/adapter-api/src/author_information.ts
@@ -23,7 +23,7 @@ export type AuthorInformation = {
   changedAt?: string
 }
 
-export const getAuthorInformationFromElement = (
+export const getAuthorInformation = (
   element: Element | undefined
 ): AuthorInformation => {
   if (!element) {

--- a/packages/adapter-api/src/author_information.ts
+++ b/packages/adapter-api/src/author_information.ts
@@ -13,15 +13,24 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-export * from './src/author_information'
-export * from './src/authentication_types'
-export * from './src/elements'
-export * from './src/element_id'
-export * from './src/values'
-export * from './src/builtins'
-export * from './src/adapter'
-export * from './src/dependency_changer'
-export * from './src/change'
-export * from './src/change_group'
-export * from './src/utils'
-export * from './src/error'
+import _ from 'lodash'
+import { values } from '@salto-io/lowerdash'
+import { Element } from './elements'
+import { CORE_ANNOTATIONS } from './constants'
+
+export type AuthorInformation = {
+  changedBy?: string
+  changedAt?: string
+}
+
+export const getAuthorInformationFromElement = (
+  element: Element | undefined
+): AuthorInformation => {
+  if (!element) {
+    return {}
+  }
+  return _.pickBy({
+    changedAt: element.annotations[CORE_ANNOTATIONS.CHANGED_AT],
+    changedBy: element.annotations[CORE_ANNOTATIONS.CHANGED_BY],
+  }, values.isDefined)
+}

--- a/packages/adapter-api/src/author_information.ts
+++ b/packages/adapter-api/src/author_information.ts
@@ -26,7 +26,7 @@ export type AuthorInformation = {
 export const getAuthorInformation = (
   element: Element | undefined
 ): AuthorInformation => {
-  if (!element) {
+  if (element === undefined) {
     return {}
   }
   return _.pickBy({

--- a/packages/adapter-api/test/author_information.test.ts
+++ b/packages/adapter-api/test/author_information.test.ts
@@ -1,0 +1,53 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType } from '../src/elements'
+import { getAuthorInformationFromElement } from '../src/author_information'
+import { ElemID } from '../src/element_id'
+import { CORE_ANNOTATIONS } from '../src/constants'
+
+describe('author information', () => {
+  describe('getAuthorInformationFromElement', () => {
+    it('should return author information', () => {
+      const element = new ObjectType({
+        elemID: new ElemID('salto', 'typeName'),
+        annotations: {
+          [CORE_ANNOTATIONS.CHANGED_AT]: '2023-03-18 10:00:00',
+          [CORE_ANNOTATIONS.CHANGED_BY]: 'Salto User',
+        },
+      })
+      expect(getAuthorInformationFromElement(element)).toEqual({
+        changedAt: '2023-03-18 10:00:00',
+        changedBy: 'Salto User',
+      })
+    })
+    it('should return only non-empty values', () => {
+      const element = new ObjectType({
+        elemID: new ElemID('salto', 'typeName'),
+        annotations: {
+          [CORE_ANNOTATIONS.CHANGED_AT]: '2023-03-18 10:00:00',
+        },
+      })
+      expect(Object.keys(getAuthorInformationFromElement(element))).toEqual(['changedAt'])
+    })
+    it('should return empty object for element with no author information', () => {
+      const element = new ObjectType({ elemID: new ElemID('salto', 'typeName') })
+      expect(Object.keys(getAuthorInformationFromElement(element))).toEqual([])
+    })
+    it('should return empty object for no element', () => {
+      expect(Object.keys(getAuthorInformationFromElement(undefined))).toEqual([])
+    })
+  })
+})

--- a/packages/adapter-api/test/author_information.test.ts
+++ b/packages/adapter-api/test/author_information.test.ts
@@ -14,12 +14,12 @@
 * limitations under the License.
 */
 import { ObjectType } from '../src/elements'
-import { getAuthorInformationFromElement } from '../src/author_information'
+import { getAuthorInformation } from '../src/author_information'
 import { ElemID } from '../src/element_id'
 import { CORE_ANNOTATIONS } from '../src/constants'
 
 describe('author information', () => {
-  describe('getAuthorInformationFromElement', () => {
+  describe('getAuthorInformation', () => {
     it('should return author information', () => {
       const element = new ObjectType({
         elemID: new ElemID('salto', 'typeName'),
@@ -28,7 +28,7 @@ describe('author information', () => {
           [CORE_ANNOTATIONS.CHANGED_BY]: 'Salto User',
         },
       })
-      expect(getAuthorInformationFromElement(element)).toEqual({
+      expect(getAuthorInformation(element)).toEqual({
         changedAt: '2023-03-18 10:00:00',
         changedBy: 'Salto User',
       })
@@ -40,14 +40,14 @@ describe('author information', () => {
           [CORE_ANNOTATIONS.CHANGED_AT]: '2023-03-18 10:00:00',
         },
       })
-      expect(Object.keys(getAuthorInformationFromElement(element))).toEqual(['changedAt'])
+      expect(Object.keys(getAuthorInformation(element))).toEqual(['changedAt'])
     })
     it('should return empty object for element with no author information', () => {
       const element = new ObjectType({ elemID: new ElemID('salto', 'typeName') })
-      expect(Object.keys(getAuthorInformationFromElement(element))).toEqual([])
+      expect(Object.keys(getAuthorInformation(element))).toEqual([])
     })
     it('should return empty object for no element', () => {
-      expect(Object.keys(getAuthorInformationFromElement(undefined))).toEqual([])
+      expect(Object.keys(getAuthorInformation(undefined))).toEqual([])
     })
   })
 })

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -352,6 +352,7 @@ export const mockWorkspace = ({
     getReferenceTargetsIndex: mockFunction<Workspace['getReferenceTargetsIndex']>(),
     getElementOutgoingReferences: mockFunction<Workspace['getElementOutgoingReferences']>().mockResolvedValue([]),
     getElementIncomingReferences: mockFunction<Workspace['getElementIncomingReferences']>().mockResolvedValue([]),
+    getElementAuthorInformation: mockFunction<Workspace['getElementAuthorInformation']>().mockResolvedValue({}),
     getElementNaclFiles: mockFunction<Workspace['getElementNaclFiles']>().mockResolvedValue([]),
     getElementIdsBySelectors: mockFunction<Workspace['getElementIdsBySelectors']>().mockResolvedValue(awu([])),
     getParsedNaclFile: mockFunction<Workspace['getParsedNaclFile']>(),

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -22,7 +22,7 @@ import {
   FIELD_NAME, INSTANCE_NAME, OBJECT_NAME, ElemIdGetter, DetailedChange, SaltoError,
   isSaltoElementError, ProgressReporter, ReadOnlyElementsSource, TypeMap, isServiceId,
   AdapterOperationsContext, FetchResult, isAdditionChange, isStaticFile,
-  isAdditionOrModificationChange, Value, StaticFile, isElement, AuthorInformation, getAuthorInformationFromElement,
+  isAdditionOrModificationChange, Value, StaticFile, isElement, AuthorInformation, getAuthorInformation,
 } from '@salto-io/adapter-api'
 import { applyInstancesDefaults, resolvePath, flattenElementStr, buildElementsSourceFromElements, safeJsonStringify, walkOnElement, WalkOnFunc, WALK_NEXT_STEP, setPath, walkOnValue } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
@@ -56,7 +56,7 @@ export type FetchChange = {
 }
 
 const getFetchChangeMetadata = (changedElement: Element | undefined): FetchChangeMetadata =>
-  getAuthorInformationFromElement(changedElement)
+  getAuthorInformation(changedElement)
 
 export const toAddFetchChange = (elem: Element): FetchChange => {
   const change: DetailedChange = {

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -21,8 +21,8 @@ import {
   toServiceIdsString, Field, OBJECT_SERVICE_ID, InstanceElement, isInstanceElement, isObjectType,
   FIELD_NAME, INSTANCE_NAME, OBJECT_NAME, ElemIdGetter, DetailedChange, SaltoError,
   isSaltoElementError, ProgressReporter, ReadOnlyElementsSource, TypeMap, isServiceId,
-  CORE_ANNOTATIONS, AdapterOperationsContext, FetchResult, isAdditionChange, isStaticFile,
-  isAdditionOrModificationChange, Value, StaticFile, isElement,
+  AdapterOperationsContext, FetchResult, isAdditionChange, isStaticFile,
+  isAdditionOrModificationChange, Value, StaticFile, isElement, AuthorInformation, getAuthorInformationFromElement,
 } from '@salto-io/adapter-api'
 import { applyInstancesDefaults, resolvePath, flattenElementStr, buildElementsSourceFromElements, safeJsonStringify, walkOnElement, WalkOnFunc, WALK_NEXT_STEP, setPath, walkOnValue } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
@@ -39,14 +39,10 @@ const { mapValuesAsync } = promises.object
 const { withLimitedConcurrency } = promises.array
 const { mergeElements } = merger
 const log = logger(module)
-const { isDefined } = values
 
 const MAX_SPLIT_CONCURRENCY = 2000
-type ChangeAuthorInformation = {
-  changedBy?: string
-  changedAt?: string
- }
-export type FetchChangeMetadata = ChangeAuthorInformation
+
+export type FetchChangeMetadata = AuthorInformation
 
 export type FetchChange = {
   // The actual change to apply to the workspace
@@ -57,16 +53,6 @@ export type FetchChange = {
   pendingChanges?: DetailedChange[]
   // Metadata information about the change.
   metadata?: FetchChangeMetadata
-}
-
-const getAuthorInformationFromElement = (
-  element: Element | undefined
-): ChangeAuthorInformation => {
-  if (!element) {
-    return {}
-  }
-  return _.pickBy({ changedAt: element.annotations?.[CORE_ANNOTATIONS.CHANGED_AT],
-    changedBy: element.annotations?.[CORE_ANNOTATIONS.CHANGED_BY] }, isDefined)
 }
 
 const getFetchChangeMetadata = (changedElement: Element | undefined): FetchChangeMetadata =>

--- a/packages/workspace/src/workspace/author_information_index.ts
+++ b/packages/workspace/src/workspace/author_information_index.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { Change, getChangeData, Element, isRemovalChange, AuthorInformation, isAdditionOrModificationChange, getAuthorInformationFromElement, isModificationChange } from '@salto-io/adapter-api'
+import { Change, getChangeData, Element, isRemovalChange, AuthorInformation, isAdditionOrModificationChange, getAuthorInformation, isModificationChange } from '@salto-io/adapter-api'
 import { ElementsSource } from './elements_source'
 import { getBaseChanges, updateIndex } from './index_utils'
 import { RemoteMap } from './remote_map'
@@ -32,10 +32,10 @@ const updateChanges = async (
     .filter(isAdditionOrModificationChange)
     .map(change => ({
       key: change.data.after.elemID.getFullName(),
-      before: getAuthorInformationFromElement(
+      before: getAuthorInformation(
         isModificationChange(change) ? change.data.before : undefined
       ),
-      after: getAuthorInformationFromElement(change.data.after),
+      after: getAuthorInformation(change.data.after),
     }))
     .filter(({ before, after }) => !_.isEqual(before, after))
     .map(({ key, after }) => ({ key, value: after }))

--- a/packages/workspace/src/workspace/author_information_index.ts
+++ b/packages/workspace/src/workspace/author_information_index.ts
@@ -32,9 +32,9 @@ const updateChanges = async (
     .filter(isAdditionOrModificationChange)
     .map(change => ({
       key: change.data.after.elemID.getFullName(),
-      before: isModificationChange(change)
-        ? getAuthorInformationFromElement(change.data.before)
-        : undefined,
+      before: getAuthorInformationFromElement(
+        isModificationChange(change) ? change.data.before : undefined
+      ),
       after: getAuthorInformationFromElement(change.data.after),
     }))
     .filter(({ before, after }) => !_.isEqual(before, after))

--- a/packages/workspace/src/workspace/author_information_index.ts
+++ b/packages/workspace/src/workspace/author_information_index.ts
@@ -1,0 +1,70 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { Change, getChangeData, Element, isRemovalChange, AuthorInformation, isAdditionOrModificationChange, getAuthorInformationFromElement } from '@salto-io/adapter-api'
+import { ElementsSource } from './elements_source'
+import { getBaseChanges, updateIndex } from './index_utils'
+import { RemoteMap } from './remote_map'
+
+export const AUTHOR_INFORMATION_INDEX_VERSION = 1
+const AUTHOR_INFORMATION_INDEX_KEY = 'author_information_index'
+
+const updateChanges = async (
+  changes: Change<Element>[],
+  index: RemoteMap<AuthorInformation>
+): Promise<void> => {
+  const allChanges = getBaseChanges(changes)
+
+  const entries = allChanges
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+    .map(elem => ({
+      key: elem.elemID.getFullName(),
+      value: getAuthorInformationFromElement(elem),
+    }))
+
+  const [entriesToSet, entriesWithEmptyValue] = _.partition(
+    entries,
+    ({ value }) => !_.isEmpty(value)
+  )
+
+  const keysToDelete = allChanges
+    .filter(isRemovalChange)
+    .map(getChangeData)
+    .map(elem => elem.elemID.getFullName())
+    .concat(entriesWithEmptyValue.map(e => e.key))
+
+  await index.setAll(entriesToSet)
+  await index.deleteAll(keysToDelete)
+}
+
+export const updateAuthorInformationIndex = async (
+  changes: Change<Element>[],
+  authorInformationIndex: RemoteMap<AuthorInformation>,
+  mapVersions: RemoteMap<number>,
+  elementsSource: ElementsSource,
+  isCacheValid: boolean
+): Promise<void> => updateIndex({
+  changes,
+  index: authorInformationIndex,
+  indexVersionKey: AUTHOR_INFORMATION_INDEX_KEY,
+  indexVersion: AUTHOR_INFORMATION_INDEX_VERSION,
+  indexName: 'author information',
+  mapVersions,
+  elementsSource,
+  isCacheValid,
+  updateChanges,
+})

--- a/packages/workspace/src/workspace/index_utils.ts
+++ b/packages/workspace/src/workspace/index_utils.ts
@@ -13,9 +13,13 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ReadOnlyElementsSource, Element, Change, toChange } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { ReadOnlyElementsSource, Element, Change, toChange, isObjectTypeChange, isAdditionOrRemovalChange, getChangeData, isAdditionChange, ObjectType, Field } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
+import { RemoteMap } from './remote_map'
+import { ElementsSource } from './elements_source'
 
+const log = logger(module)
 const { awu } = collections.asynciterable
 
 export const getAllElementsChanges = async (
@@ -26,3 +30,70 @@ export const getAllElementsChanges = async (
     .map(element => toChange({ after: element }))
     .concat(currentChanges)
     .toArray()
+
+const getFieldChangesFromTypeChange = (change: Change<ObjectType>): Change<Field>[] => {
+  if (isAdditionOrRemovalChange(change)) {
+    return Object.values(getChangeData(change).fields).map(field => (
+      isAdditionChange(change)
+        ? toChange({ after: field })
+        : toChange({ before: field })
+    ))
+  }
+  const { before, after } = change.data
+  const allFieldNames = Object.keys({ ...before.fields, ...after.fields })
+  return allFieldNames
+    .filter(fieldName =>
+      before.fields[fieldName] === undefined
+      || after.fields[fieldName] === undefined
+      || !before.fields[fieldName].isEqual(after.fields[fieldName]))
+    .map(fieldName => toChange({
+      before: before.fields[fieldName],
+      after: after.fields[fieldName],
+    }))
+}
+
+export const getBaseChanges = (changes: Change<Element>[]): Change<Element>[] =>
+  changes.flatMap(change => [change].concat(
+    isObjectTypeChange(change) ? getFieldChangesFromTypeChange(change) : []
+  ))
+
+export const updateIndex = async <T>({
+  changes,
+  index,
+  indexVersionKey,
+  indexVersion,
+  indexName,
+  mapVersions,
+  elementsSource,
+  isCacheValid,
+  updateChanges,
+}: {
+  changes: Change<Element>[]
+  index: RemoteMap<T>
+  indexVersionKey: string
+  indexVersion: number
+  indexName: string
+  mapVersions: RemoteMap<number>
+  elementsSource: ElementsSource
+  isCacheValid: boolean
+  updateChanges: (changes: Change<Element>[], index: RemoteMap<T>) => Promise<void>
+}): Promise<void> =>
+  log.time(async () => {
+    let relevantChanges = changes
+    const isVersionMatch = (await mapVersions.get(indexVersionKey)) === indexVersion
+    if (!isCacheValid || !isVersionMatch) {
+      if (!isVersionMatch) {
+        relevantChanges = await getAllElementsChanges(changes, elementsSource)
+        log.info(`${indexName} index map is out of date, re-indexing`)
+      }
+      if (!isCacheValid) {
+        // When cache is invalid, changes will include all of the elements in the workspace.
+        log.info(`cache is invalid, re-indexing ${indexName} index`)
+      }
+      await Promise.all([
+        index.clear(),
+        mapVersions.set(indexVersionKey, indexVersion),
+      ])
+    }
+    await updateChanges(relevantChanges, index)
+  }, `updating ${indexName} index`)

--- a/packages/workspace/src/workspace/index_utils.ts
+++ b/packages/workspace/src/workspace/index_utils.ts
@@ -53,9 +53,9 @@ const getFieldChangesFromTypeChange = (change: Change<ObjectType>): Change<Field
 }
 
 export const getBaseChanges = (changes: Change<Element>[]): Change<Element>[] =>
-  changes.flatMap(change => [change].concat(
-    isObjectTypeChange(change) ? getFieldChangesFromTypeChange(change) : []
-  ))
+  changes.concat(
+    changes.filter(isObjectTypeChange).flatMap(getFieldChangesFromTypeChange)
+  )
 
 export const updateIndex = async <T>({
   changes,

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -1055,17 +1055,6 @@ export const loadWorkspace = async (
     return currentWorkspaceState.states[env].changedBy.isEmpty()
   }
 
-  const validateBaseIdAndRunOnEnvState = async <T>(
-    id: ElemID,
-    envName: string,
-    call: (envState: SingleState) => T
-  ): Promise<T> => {
-    if (!id.isBaseID()) {
-      throw new Error(`only base ids are supported, received ${id.getFullName()}`)
-    }
-    return call((await getWorkspaceState()).states[envName])
-  }
-
   return {
     uid: workspaceConfig.uid,
     name: workspaceConfig.name,
@@ -1160,21 +1149,27 @@ export const loadWorkspace = async (
       .states[envName].referenceSources,
     getReferenceTargetsIndex: async (envName = currentEnv()) => (await getWorkspaceState())
       .states[envName].referenceTargets,
-    getElementOutgoingReferences: async (id, envName = currentEnv()) => validateBaseIdAndRunOnEnvState(
-      id,
-      envName,
-      async envState => await envState.referenceTargets.get(id.getFullName()) ?? []
-    ),
-    getElementIncomingReferences: async (id, envName = currentEnv()) => validateBaseIdAndRunOnEnvState(
-      id,
-      envName,
-      async envState => await envState.referenceSources.get(id.getFullName()) ?? []
-    ),
-    getElementAuthorInformation: async (id, envName = currentEnv()) => validateBaseIdAndRunOnEnvState(
-      id,
-      envName,
-      async envState => await envState.authorInformation.get(id.getFullName()) ?? {}
-    ),
+    getElementOutgoingReferences: async (id, envName = currentEnv()) => {
+      if (!id.isBaseID()) {
+        throw new Error(`getElementOutgoingReferences only support base ids, received ${id.getFullName()}`)
+      }
+      return await (await getWorkspaceState()).states[envName]
+        .referenceTargets.get(id.getFullName()) ?? []
+    },
+    getElementIncomingReferences: async (id, envName = currentEnv()) => {
+      if (!id.isBaseID()) {
+        throw new Error(`getElementIncomingReferences only support base ids, received ${id.getFullName()}`)
+      }
+      return await (await getWorkspaceState()).states[envName]
+        .referenceSources.get(id.getFullName()) ?? []
+    },
+    getElementAuthorInformation: async (id, envName = currentEnv()) => {
+      if (!id.isBaseID()) {
+        throw new Error(`getElementAuthorInformation only support base ids, received ${id.getFullName()}`)
+      }
+      return await (await getWorkspaceState()).states[envName]
+        .authorInformation.get(id.getFullName()) ?? {}
+    },
     getAllChangedByAuthors,
     getChangedElementsByAuthors,
     getElementNaclFiles: async id => (

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import path from 'path'
 import { Element, SaltoError, SaltoElementError, ElemID, InstanceElement, DetailedChange, Change,
   Value, toChange, isRemovalChange, getChangeData,
-  ReadOnlyElementsSource, isAdditionOrModificationChange, StaticFile, isInstanceElement } from '@salto-io/adapter-api'
+  ReadOnlyElementsSource, isAdditionOrModificationChange, StaticFile, isInstanceElement, AuthorInformation } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { applyDetailedChanges, naclCase, resolvePath, safeJsonStringify } from '@salto-io/adapter-utils'
 import { collections, promises, values } from '@salto-io/lowerdash'
@@ -47,6 +47,7 @@ import { updateChangedAtIndex } from './changed_at_index'
 import { updateReferencedStaticFilesIndex } from './static_files_index'
 import { resolve } from '../expressions'
 import { updateAliasIndex } from './alias_index'
+import { updateAuthorInformationIndex } from './author_information_index'
 
 const log = logger(module)
 
@@ -184,6 +185,7 @@ export type Workspace = {
   getReferenceTargetsIndex: (envName?: string) => Promise<ReadOnlyRemoteMap<ElemID[]>>
   getElementOutgoingReferences: (id: ElemID, envName?: string) => Promise<ElemID[]>
   getElementIncomingReferences: (id: ElemID, envName?: string) => Promise<ElemID[]>
+  getElementAuthorInformation: (id: ElemID, envName?: string) => Promise<AuthorInformation>
   getAllChangedByAuthors: (envName?: string) => Promise<Author[]>
   getChangedElementsByAuthors: (authors: Author[], envName?: string) => Promise<ElemID[]>
   getElementNaclFiles: (id: ElemID) => Promise<string[]>
@@ -269,6 +271,7 @@ type SingleState = {
   validationErrors: RemoteMap<ValidationError[]>
   changedBy: RemoteMap<ElemID[]>
   changedAt: RemoteMap<ElemID[]>
+  authorInformation: RemoteMap<AuthorInformation>
   alias: RemoteMap<string>
   referencedStaticFiles: RemoteMap<string[]>
   referenceSources: RemoteMap<ElemID[]>
@@ -391,6 +394,12 @@ export const loadWorkspace = async (
             namespace: getRemoteMapNamespace('changedAt', envName),
             serialize: async val => safeJsonStringify(val.map(id => id.getFullName())),
             deserialize: data => JSON.parse(data).map((id: string) => ElemID.fromFullName(id)),
+            persistent,
+          }),
+          authorInformation: await remoteMapCreator<AuthorInformation>({
+            namespace: getRemoteMapNamespace('authorInformation', envName),
+            serialize: async val => safeJsonStringify(val),
+            deserialize: data => JSON.parse(data),
             persistent,
           }),
           alias: await remoteMapCreator<string>({
@@ -650,6 +659,15 @@ export const loadWorkspace = async (
         stateToBuild.states[envName].merged,
         changeResult.cacheValid,
       )
+
+      await updateAuthorInformationIndex(
+        changes,
+        stateToBuild.states[envName].authorInformation,
+        stateToBuild.states[envName].mapVersions,
+        stateToBuild.states[envName].merged,
+        changeResult.cacheValid,
+      )
+
       await updateAliasIndex(
         changes,
         stateToBuild.states[envName].alias,
@@ -1037,6 +1055,13 @@ export const loadWorkspace = async (
     return currentWorkspaceState.states[env].changedBy.isEmpty()
   }
 
+  const validateBaseIdAndRun = <T>(id: ElemID, call: () => T): T => {
+    if (!id.isBaseID()) {
+      throw new Error(`only base ids are supported, received ${id.getFullName()}`)
+    }
+    return call()
+  }
+
   return {
     uid: workspaceConfig.uid,
     name: workspaceConfig.name,
@@ -1131,20 +1156,18 @@ export const loadWorkspace = async (
       .states[envName].referenceSources,
     getReferenceTargetsIndex: async (envName = currentEnv()) => (await getWorkspaceState())
       .states[envName].referenceTargets,
-    getElementOutgoingReferences: async (id, envName = currentEnv()) => {
-      if (!id.isBaseID()) {
-        throw new Error(`getElementOutgoingReferences only support base ids, received ${id.getFullName()}`)
-      }
-      return await (await getWorkspaceState()).states[envName]
-        .referenceTargets.get(id.getFullName()) ?? []
-    },
-    getElementIncomingReferences: async (id, envName = currentEnv()) => {
-      if (!id.isBaseID()) {
-        throw new Error(`getElementIncomingReferences only support base ids, received ${id.getFullName()}`)
-      }
-      return await (await getWorkspaceState()).states[envName]
-        .referenceSources.get(id.getFullName()) ?? []
-    },
+    getElementOutgoingReferences: async (id, envName = currentEnv()) => validateBaseIdAndRun(
+      id,
+      async () => await (await getWorkspaceState()).states[envName].referenceTargets.get(id.getFullName()) ?? []
+    ),
+    getElementIncomingReferences: async (id, envName = currentEnv()) => validateBaseIdAndRun(
+      id,
+      async () => await (await getWorkspaceState()).states[envName].referenceSources.get(id.getFullName()) ?? []
+    ),
+    getElementAuthorInformation: async (id, envName = currentEnv()) => validateBaseIdAndRun(
+      id,
+      async () => await (await getWorkspaceState()).states[envName].authorInformation.get(id.getFullName()) ?? {}
+    ),
     getAllChangedByAuthors,
     getChangedElementsByAuthors,
     getElementNaclFiles: async id => (

--- a/packages/workspace/test/workspace/author_information_index.test.ts
+++ b/packages/workspace/test/workspace/author_information_index.test.ts
@@ -1,0 +1,265 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { AdditionChange, AuthorInformation, BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, ModificationChange, ObjectType, RemovalChange, Value, getChangeData, toChange } from '@salto-io/adapter-api'
+import { MockInterface } from '@salto-io/test-utils'
+import { createInMemoryElementSource, ElementsSource } from '../../src/workspace/elements_source'
+import { RemoteMap } from '../../src/workspace/remote_map'
+import { createMockRemoteMap } from '../utils'
+import { AUTHOR_INFORMATION_INDEX_VERSION, updateAuthorInformationIndex } from '../../src/workspace/author_information_index'
+
+describe('author information index', () => {
+  let authorInformationIndex: MockInterface<RemoteMap<AuthorInformation>>
+  let mapVersions: MockInterface<RemoteMap<number>>
+  let elementsSource: ElementsSource
+  let modifiedObjectChange: ModificationChange<ObjectType>
+  let addedInstanceChange: AdditionChange<InstanceElement>
+  let modifiedInstanceChange: ModificationChange<InstanceElement>
+  let modifiedToEmptyChange: ModificationChange<InstanceElement>
+  let deletedInstanceChange: RemovalChange<InstanceElement>
+  let expectedSetAllCalledWith: Value[]
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    authorInformationIndex = createMockRemoteMap<AuthorInformation>()
+    mapVersions = createMockRemoteMap<number>()
+    mapVersions.get.mockResolvedValue(AUTHOR_INFORMATION_INDEX_VERSION)
+    elementsSource = createInMemoryElementSource()
+
+    modifiedObjectChange = {
+      action: 'modify',
+      data: {
+        before: new ObjectType({
+          elemID: new ElemID('test', 'object'),
+          fields: {
+            removedField: {
+              refType: BuiltinTypes.STRING,
+              annotations: {
+                [CORE_ANNOTATIONS.CHANGED_AT]: '2022-03-18 11:00:00',
+                [CORE_ANNOTATIONS.CHANGED_BY]: 'Old Salto User',
+              },
+            },
+            modifiedField: {
+              refType: BuiltinTypes.STRING,
+              annotations: {
+                [CORE_ANNOTATIONS.CHANGED_AT]: '2022-03-18 12:00:00',
+                [CORE_ANNOTATIONS.CHANGED_BY]: 'Old Salto User',
+              },
+            },
+          },
+          annotations: {
+            [CORE_ANNOTATIONS.CHANGED_AT]: '2022-03-18 10:00:00',
+            [CORE_ANNOTATIONS.CHANGED_BY]: 'Old Salto User',
+          },
+        }),
+        after: new ObjectType({
+          elemID: new ElemID('test', 'object'),
+          fields: {
+            modifiedField: {
+              refType: BuiltinTypes.STRING,
+              annotations: {
+                [CORE_ANNOTATIONS.CHANGED_AT]: '2023-03-18 12:00:00',
+                [CORE_ANNOTATIONS.CHANGED_BY]: 'Salto User',
+              },
+            },
+            addedField: {
+              refType: BuiltinTypes.STRING,
+              annotations: {
+                [CORE_ANNOTATIONS.CHANGED_AT]: '2023-03-18 13:00:00',
+                [CORE_ANNOTATIONS.CHANGED_BY]: 'Salto User',
+              },
+            },
+          },
+          annotations: {
+            [CORE_ANNOTATIONS.CHANGED_AT]: '2023-03-18 10:00:00',
+            [CORE_ANNOTATIONS.CHANGED_BY]: 'Salto User',
+          },
+        }),
+      },
+    }
+    addedInstanceChange = {
+      action: 'add',
+      data: {
+        after: new InstanceElement(
+          'instance1',
+          getChangeData(modifiedObjectChange),
+          {},
+          undefined,
+          {
+            [CORE_ANNOTATIONS.CHANGED_AT]: '2023-03-19 10:00:00',
+            [CORE_ANNOTATIONS.CHANGED_BY]: 'Salto User',
+          },
+        ),
+      },
+    }
+    modifiedInstanceChange = {
+      action: 'modify',
+      data: {
+        before: new InstanceElement(
+          'instance2',
+          getChangeData(modifiedObjectChange),
+          {},
+          undefined,
+          {
+            [CORE_ANNOTATIONS.CHANGED_AT]: '2022-03-20 10:00:00',
+            [CORE_ANNOTATIONS.CHANGED_BY]: 'Old Salto User',
+          },
+        ),
+        after: new InstanceElement(
+          'instance2',
+          getChangeData(modifiedObjectChange),
+          {},
+          undefined,
+          {
+            [CORE_ANNOTATIONS.CHANGED_AT]: '2023-03-20 10:00:00',
+            [CORE_ANNOTATIONS.CHANGED_BY]: 'Salto User',
+          },
+        ),
+      },
+    }
+    modifiedToEmptyChange = {
+      action: 'modify',
+      data: {
+        before: new InstanceElement(
+          'instance3',
+          getChangeData(modifiedObjectChange),
+          {},
+          undefined,
+          {
+            [CORE_ANNOTATIONS.CHANGED_AT]: '2022-03-21 10:00:00',
+            [CORE_ANNOTATIONS.CHANGED_BY]: 'Old Salto User',
+          },
+        ),
+        after: new InstanceElement(
+          'instance3',
+          getChangeData(modifiedObjectChange),
+          {},
+          undefined,
+          {},
+        ),
+      },
+    }
+    deletedInstanceChange = {
+      action: 'remove',
+      data: {
+        before: new InstanceElement(
+          'instance4',
+          getChangeData(modifiedObjectChange),
+          {},
+          undefined,
+          {
+            [CORE_ANNOTATIONS.CHANGED_AT]: '2022-03-22 10:00:00',
+            [CORE_ANNOTATIONS.CHANGED_BY]: 'Old Salto User',
+          },
+        ),
+      },
+    }
+    expectedSetAllCalledWith = [{
+      key: getChangeData(modifiedObjectChange).elemID.getFullName(),
+      value: { changedBy: 'Salto User', changedAt: '2023-03-18 10:00:00' },
+    }, {
+      key: getChangeData(modifiedObjectChange).elemID.createNestedID('field', 'modifiedField').getFullName(),
+      value: { changedBy: 'Salto User', changedAt: '2023-03-18 12:00:00' },
+    }, {
+      key: getChangeData(modifiedObjectChange).elemID.createNestedID('field', 'addedField').getFullName(),
+      value: { changedBy: 'Salto User', changedAt: '2023-03-18 13:00:00' },
+    }, {
+      key: getChangeData(addedInstanceChange).elemID.getFullName(),
+      value: { changedBy: 'Salto User', changedAt: '2023-03-19 10:00:00' },
+    }, {
+      key: getChangeData(modifiedInstanceChange).elemID.getFullName(),
+      value: { changedBy: 'Salto User', changedAt: '2023-03-20 10:00:00' },
+    }]
+  })
+
+
+  describe('mixed changes', () => {
+    beforeEach(async () => {
+      const changes = [
+        modifiedObjectChange,
+        addedInstanceChange,
+        modifiedInstanceChange,
+        modifiedToEmptyChange,
+        deletedInstanceChange,
+      ]
+      await updateAuthorInformationIndex(
+        changes,
+        authorInformationIndex,
+        mapVersions,
+        elementsSource,
+        true
+      )
+    })
+    it('should add the new instances changed by values to index', () => {
+      expect(authorInformationIndex.setAll).toHaveBeenCalledWith(expectedSetAllCalledWith)
+      expect(authorInformationIndex.deleteAll).toHaveBeenCalledWith([
+        getChangeData(modifiedObjectChange).elemID.createNestedID('field', 'removedField').getFullName(),
+        getChangeData(deletedInstanceChange).elemID.getFullName(),
+        getChangeData(modifiedToEmptyChange).elemID.getFullName(),
+      ])
+    })
+  })
+
+  describe('invalid indexes', () => {
+    describe('When cache is invalid', () => {
+      beforeEach(async () => {
+        await updateAuthorInformationIndex(
+          // all elements will be considered as new when cache is invalid
+          [
+            toChange({ after: getChangeData(modifiedObjectChange) }),
+            toChange({ after: getChangeData(addedInstanceChange) }),
+            toChange({ after: getChangeData(modifiedInstanceChange) }),
+            toChange({ after: getChangeData(modifiedToEmptyChange) }),
+          ],
+          authorInformationIndex,
+          mapVersions,
+          elementsSource,
+          false
+        )
+      })
+      it('should update changed by index with all additions', () => {
+        expect(authorInformationIndex.clear).toHaveBeenCalled()
+        expect(authorInformationIndex.setAll).toHaveBeenCalledWith(expectedSetAllCalledWith)
+        expect(authorInformationIndex.deleteAll).toHaveBeenCalledWith([
+          getChangeData(modifiedToEmptyChange).elemID.getFullName(),
+        ])
+      })
+    })
+
+    describe('When indexes are out of date', () => {
+      beforeEach(async () => {
+        await elementsSource.set(getChangeData(modifiedObjectChange))
+        await elementsSource.set(getChangeData(addedInstanceChange))
+        await elementsSource.set(getChangeData(modifiedInstanceChange))
+        await elementsSource.set(getChangeData(modifiedToEmptyChange))
+        mapVersions.get.mockResolvedValue(0)
+        await updateAuthorInformationIndex(
+          [],
+          authorInformationIndex,
+          mapVersions,
+          elementsSource,
+          true
+        )
+      })
+      it('should update changed by index using the element source', () => {
+        expect(authorInformationIndex.clear).toHaveBeenCalled()
+        expect(authorInformationIndex.setAll).toHaveBeenCalledWith(expectedSetAllCalledWith)
+        expect(authorInformationIndex.deleteAll).toHaveBeenCalledWith([
+          getChangeData(modifiedToEmptyChange).elemID.getFullName(),
+        ])
+      })
+    })
+  })
+})

--- a/packages/workspace/test/workspace/author_information_index.test.ts
+++ b/packages/workspace/test/workspace/author_information_index.test.ts
@@ -26,6 +26,7 @@ describe('author information index', () => {
   let elementsSource: ElementsSource
   let modifiedObjectChange: ModificationChange<ObjectType>
   let addedInstanceChange: AdditionChange<InstanceElement>
+  let addedInstanceWithoutAuthorChange: AdditionChange<InstanceElement>
   let modifiedInstanceChange: ModificationChange<InstanceElement>
   let modifiedInstanceWithoutAuthorChange: ModificationChange<InstanceElement>
   let modifiedInstanceWithSameAuthorChange: ModificationChange<InstanceElement>
@@ -106,11 +107,23 @@ describe('author information index', () => {
         ),
       },
     }
+    addedInstanceWithoutAuthorChange = {
+      action: 'add',
+      data: {
+        after: new InstanceElement(
+          'instance2',
+          getChangeData(modifiedObjectChange),
+          {},
+          undefined,
+          {},
+        ),
+      },
+    }
     modifiedInstanceChange = {
       action: 'modify',
       data: {
         before: new InstanceElement(
-          'instance2',
+          'instance3',
           getChangeData(modifiedObjectChange),
           {},
           undefined,
@@ -120,7 +133,7 @@ describe('author information index', () => {
           },
         ),
         after: new InstanceElement(
-          'instance2',
+          'instance3',
           getChangeData(modifiedObjectChange),
           {},
           undefined,
@@ -135,14 +148,14 @@ describe('author information index', () => {
       action: 'modify',
       data: {
         before: new InstanceElement(
-          'instance2',
+          'instance4',
           getChangeData(modifiedObjectChange),
           {},
           undefined,
           {},
         ),
         after: new InstanceElement(
-          'instance2',
+          'instance4',
           getChangeData(modifiedObjectChange),
           {},
           undefined,
@@ -154,7 +167,7 @@ describe('author information index', () => {
       action: 'modify',
       data: {
         before: new InstanceElement(
-          'instance2',
+          'instance5',
           getChangeData(modifiedObjectChange),
           {},
           undefined,
@@ -164,7 +177,7 @@ describe('author information index', () => {
           },
         ),
         after: new InstanceElement(
-          'instance2',
+          'instance5',
           getChangeData(modifiedObjectChange),
           {},
           undefined,
@@ -179,7 +192,7 @@ describe('author information index', () => {
       action: 'modify',
       data: {
         before: new InstanceElement(
-          'instance3',
+          'instance6',
           getChangeData(modifiedObjectChange),
           {},
           undefined,
@@ -189,7 +202,7 @@ describe('author information index', () => {
           },
         ),
         after: new InstanceElement(
-          'instance3',
+          'instance6',
           getChangeData(modifiedObjectChange),
           {},
           undefined,
@@ -201,7 +214,7 @@ describe('author information index', () => {
       action: 'remove',
       data: {
         before: new InstanceElement(
-          'instance4',
+          'instance7',
           getChangeData(modifiedObjectChange),
           {},
           undefined,
@@ -236,6 +249,7 @@ describe('author information index', () => {
       const changes = [
         modifiedObjectChange,
         addedInstanceChange,
+        addedInstanceWithoutAuthorChange,
         modifiedInstanceChange,
         modifiedInstanceWithoutAuthorChange,
         modifiedInstanceWithSameAuthorChange,
@@ -269,7 +283,7 @@ describe('author information index', () => {
             toChange({ after: getChangeData(modifiedObjectChange) }),
             toChange({ after: getChangeData(addedInstanceChange) }),
             toChange({ after: getChangeData(modifiedInstanceChange) }),
-            toChange({ after: getChangeData(modifiedToEmptyChange) }),
+            toChange({ after: getChangeData(addedInstanceWithoutAuthorChange) }),
           ],
           authorInformationIndex,
           mapVersions,
@@ -280,9 +294,7 @@ describe('author information index', () => {
       it('should update changed by index with all additions', () => {
         expect(authorInformationIndex.clear).toHaveBeenCalled()
         expect(authorInformationIndex.setAll).toHaveBeenCalledWith(expectedSetAllCalledWith)
-        expect(authorInformationIndex.deleteAll).toHaveBeenCalledWith([
-          getChangeData(modifiedToEmptyChange).elemID.getFullName(),
-        ])
+        expect(authorInformationIndex.deleteAll).toHaveBeenCalledWith([])
       })
     })
 
@@ -291,7 +303,7 @@ describe('author information index', () => {
         await elementsSource.set(getChangeData(modifiedObjectChange))
         await elementsSource.set(getChangeData(addedInstanceChange))
         await elementsSource.set(getChangeData(modifiedInstanceChange))
-        await elementsSource.set(getChangeData(modifiedToEmptyChange))
+        await elementsSource.set(getChangeData(addedInstanceWithoutAuthorChange))
         mapVersions.get.mockResolvedValue(0)
         await updateAuthorInformationIndex(
           [],
@@ -304,9 +316,7 @@ describe('author information index', () => {
       it('should update changed by index using the element source', () => {
         expect(authorInformationIndex.clear).toHaveBeenCalled()
         expect(authorInformationIndex.setAll).toHaveBeenCalledWith(expectedSetAllCalledWith)
-        expect(authorInformationIndex.deleteAll).toHaveBeenCalledWith([
-          getChangeData(modifiedToEmptyChange).elemID.getFullName(),
-        ])
+        expect(authorInformationIndex.deleteAll).toHaveBeenCalledWith([])
       })
     })
   })

--- a/packages/workspace/test/workspace/author_information_index.test.ts
+++ b/packages/workspace/test/workspace/author_information_index.test.ts
@@ -229,17 +229,17 @@ describe('author information index', () => {
       key: getChangeData(modifiedObjectChange).elemID.getFullName(),
       value: { changedBy: 'Salto User', changedAt: '2023-03-18 10:00:00' },
     }, {
-      key: getChangeData(modifiedObjectChange).elemID.createNestedID('field', 'modifiedField').getFullName(),
-      value: { changedBy: 'Salto User', changedAt: '2023-03-18 12:00:00' },
-    }, {
-      key: getChangeData(modifiedObjectChange).elemID.createNestedID('field', 'addedField').getFullName(),
-      value: { changedBy: 'Salto User', changedAt: '2023-03-18 13:00:00' },
-    }, {
       key: getChangeData(addedInstanceChange).elemID.getFullName(),
       value: { changedBy: 'Salto User', changedAt: '2023-03-19 10:00:00' },
     }, {
       key: getChangeData(modifiedInstanceChange).elemID.getFullName(),
       value: { changedBy: 'Salto User', changedAt: '2023-03-20 10:00:00' },
+    }, {
+      key: getChangeData(modifiedObjectChange).elemID.createNestedID('field', 'modifiedField').getFullName(),
+      value: { changedBy: 'Salto User', changedAt: '2023-03-18 12:00:00' },
+    }, {
+      key: getChangeData(modifiedObjectChange).elemID.createNestedID('field', 'addedField').getFullName(),
+      value: { changedBy: 'Salto User', changedAt: '2023-03-18 13:00:00' },
     }]
   })
 
@@ -267,8 +267,8 @@ describe('author information index', () => {
     it('should add the new instances changed by values to index', () => {
       expect(authorInformationIndex.setAll).toHaveBeenCalledWith(expectedSetAllCalledWith)
       expect(authorInformationIndex.deleteAll).toHaveBeenCalledWith([
-        getChangeData(modifiedObjectChange).elemID.createNestedID('field', 'removedField').getFullName(),
         getChangeData(deletedInstanceChange).elemID.getFullName(),
+        getChangeData(modifiedObjectChange).elemID.createNestedID('field', 'removedField').getFullName(),
         getChangeData(modifiedToEmptyChange).elemID.getFullName(),
       ])
     })

--- a/packages/workspace/test/workspace/author_information_index.test.ts
+++ b/packages/workspace/test/workspace/author_information_index.test.ts
@@ -27,6 +27,8 @@ describe('author information index', () => {
   let modifiedObjectChange: ModificationChange<ObjectType>
   let addedInstanceChange: AdditionChange<InstanceElement>
   let modifiedInstanceChange: ModificationChange<InstanceElement>
+  let modifiedInstanceWithoutAuthorChange: ModificationChange<InstanceElement>
+  let modifiedInstanceWithSameAuthorChange: ModificationChange<InstanceElement>
   let modifiedToEmptyChange: ModificationChange<InstanceElement>
   let deletedInstanceChange: RemovalChange<InstanceElement>
   let expectedSetAllCalledWith: Value[]
@@ -129,6 +131,50 @@ describe('author information index', () => {
         ),
       },
     }
+    modifiedInstanceWithoutAuthorChange = {
+      action: 'modify',
+      data: {
+        before: new InstanceElement(
+          'instance2',
+          getChangeData(modifiedObjectChange),
+          {},
+          undefined,
+          {},
+        ),
+        after: new InstanceElement(
+          'instance2',
+          getChangeData(modifiedObjectChange),
+          {},
+          undefined,
+          {},
+        ),
+      },
+    }
+    modifiedInstanceWithSameAuthorChange = {
+      action: 'modify',
+      data: {
+        before: new InstanceElement(
+          'instance2',
+          getChangeData(modifiedObjectChange),
+          {},
+          undefined,
+          {
+            [CORE_ANNOTATIONS.CHANGED_AT]: '2023-03-24 10:00:00',
+            [CORE_ANNOTATIONS.CHANGED_BY]: 'Salto User',
+          },
+        ),
+        after: new InstanceElement(
+          'instance2',
+          getChangeData(modifiedObjectChange),
+          {},
+          undefined,
+          {
+            [CORE_ANNOTATIONS.CHANGED_AT]: '2023-03-24 10:00:00',
+            [CORE_ANNOTATIONS.CHANGED_BY]: 'Salto User',
+          },
+        ),
+      },
+    }
     modifiedToEmptyChange = {
       action: 'modify',
       data: {
@@ -191,6 +237,8 @@ describe('author information index', () => {
         modifiedObjectChange,
         addedInstanceChange,
         modifiedInstanceChange,
+        modifiedInstanceWithoutAuthorChange,
+        modifiedInstanceWithSameAuthorChange,
         modifiedToEmptyChange,
         deletedInstanceChange,
       ]

--- a/packages/workspace/test/workspace/index_utils.test.ts
+++ b/packages/workspace/test/workspace/index_utils.test.ts
@@ -84,17 +84,17 @@ describe('index utils', () => {
       ]
       expect(getBaseChanges(changes)).toEqual([
         toChange({ after: addedObject }),
-        toChange({ after: addedObject.fields.field }),
         toChange({ before: deletedObject }),
-        toChange({ before: deletedObject.fields.field }),
         toChange({ before: modifiedObjectBefore, after: modifiedObjectAfter }),
+        toChange({ after: addedInstance }),
+        toChange({ after: addedObject.fields.field }),
+        toChange({ before: deletedObject.fields.field }),
         toChange({ before: modifiedObjectBefore.fields.deletedField }),
         toChange({
           before: modifiedObjectBefore.fields.modifiedField,
           after: modifiedObjectAfter.fields.modifiedField,
         }),
         toChange({ after: modifiedObjectAfter.fields.addedField }),
-        toChange({ after: addedInstance }),
       ])
     })
   })

--- a/packages/workspace/test/workspace/index_utils.test.ts
+++ b/packages/workspace/test/workspace/index_utils.test.ts
@@ -13,29 +13,161 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ElemID, ObjectType, toChange } from '@salto-io/adapter-api'
+import { BuiltinTypes, ElemID, InstanceElement, ObjectType, getChangeData, toChange } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { getAllElementsChanges } from '../../src/workspace/index_utils'
+import { MockInterface } from '@salto-io/test-utils'
+import { getAllElementsChanges, getBaseChanges, updateIndex } from '../../src/workspace/index_utils'
+import { RemoteMap } from '../../src/workspace/remote_map'
+import { ElementsSource, createInMemoryElementSource } from '../../src/workspace/elements_source'
+import { createMockRemoteMap } from '../utils'
 
-describe('getAllElementsChanges', () => {
-  const firstObject = new ObjectType({ elemID: new ElemID('adapter', 'type1') })
-  const secondObject = new ObjectType({ elemID: new ElemID('adapter', 'type2') })
-  const thirdObject = new ObjectType({ elemID: new ElemID('adapter', 'type3') })
-  const elements = [
-    firstObject,
-    secondObject,
-  ]
-  const elementsSource = buildElementsSourceFromElements(elements)
-  it('should return all elements', async () => {
-    const result = await getAllElementsChanges([], elementsSource)
-    expect(result).toEqual([toChange({ after: firstObject }), toChange({ after: secondObject })])
+describe('index utils', () => {
+  describe('getAllElementsChanges', () => {
+    const firstObject = new ObjectType({ elemID: new ElemID('adapter', 'type1') })
+    const secondObject = new ObjectType({ elemID: new ElemID('adapter', 'type2') })
+    const thirdObject = new ObjectType({ elemID: new ElemID('adapter', 'type3') })
+    const elements = [
+      firstObject,
+      secondObject,
+    ]
+    const elementsSource = buildElementsSourceFromElements(elements)
+    it('should return all elements', async () => {
+      const result = await getAllElementsChanges([], elementsSource)
+      expect(result).toEqual([toChange({ after: firstObject }), toChange({ after: secondObject })])
+    })
+    it('should merge current changes with all other element changes', async () => {
+      const result = await getAllElementsChanges([toChange({ after: thirdObject })], elementsSource)
+      expect(result).toEqual([
+        toChange({ after: firstObject }),
+        toChange({ after: secondObject }),
+        toChange({ after: thirdObject }),
+      ])
+    })
   })
-  it('should merge current changes with all other element changes', async () => {
-    const result = await getAllElementsChanges([toChange({ after: thirdObject })], elementsSource)
-    expect(result).toEqual([
-      toChange({ after: firstObject }),
-      toChange({ after: secondObject }),
-      toChange({ after: thirdObject }),
-    ])
+  describe('getBaseChanges', () => {
+    const addedObject = new ObjectType({
+      elemID: new ElemID('adapter', 'addedType'),
+      fields: {
+        field: { refType: BuiltinTypes.BOOLEAN },
+      },
+    })
+    const deletedObject = new ObjectType({
+      elemID: new ElemID('adapter', 'deletedType'),
+      fields: {
+        field: { refType: BuiltinTypes.BOOLEAN },
+      },
+    })
+    const modifiedObjectBefore = new ObjectType({
+      elemID: new ElemID('adapter', 'modifiedType'),
+      fields: {
+        deletedField: { refType: BuiltinTypes.BOOLEAN },
+        modifiedField: { refType: BuiltinTypes.BOOLEAN },
+        sameField: { refType: BuiltinTypes.BOOLEAN },
+      },
+    })
+    const modifiedObjectAfter = new ObjectType({
+      elemID: new ElemID('adapter', 'modifiedType'),
+      fields: {
+        addedField: { refType: BuiltinTypes.BOOLEAN },
+        modifiedField: { refType: BuiltinTypes.BOOLEAN, annotations: { new: true } },
+        sameField: { refType: BuiltinTypes.BOOLEAN },
+      },
+    })
+    const addedInstance = new InstanceElement('instance', addedObject)
+
+    it('should return all changes', () => {
+      const changes = [
+        toChange({ after: addedObject }),
+        toChange({ before: deletedObject }),
+        toChange({ before: modifiedObjectBefore, after: modifiedObjectAfter }),
+        toChange({ after: addedInstance }),
+      ]
+      expect(getBaseChanges(changes)).toEqual([
+        toChange({ after: addedObject }),
+        toChange({ after: addedObject.fields.field }),
+        toChange({ before: deletedObject }),
+        toChange({ before: deletedObject.fields.field }),
+        toChange({ before: modifiedObjectBefore, after: modifiedObjectAfter }),
+        toChange({ before: modifiedObjectBefore.fields.deletedField }),
+        toChange({
+          before: modifiedObjectBefore.fields.modifiedField,
+          after: modifiedObjectAfter.fields.modifiedField,
+        }),
+        toChange({ after: modifiedObjectAfter.fields.addedField }),
+        toChange({ after: addedInstance }),
+      ])
+    })
+  })
+  describe('updateIndex', () => {
+    const indexVersionKey = 'index-key'
+    const indexVersion = 1
+    const indexName = 'index'
+
+    let index: MockInterface<RemoteMap<string>>
+    let mapVersions: MockInterface<RemoteMap<number>>
+    let elementsSource: ElementsSource
+    const updateChangesMock = jest.fn()
+
+    const objectChange = toChange({
+      after: new ObjectType({ elemID: new ElemID('adapter', 'type') }),
+    })
+
+    beforeEach(() => {
+      jest.resetAllMocks()
+      index = createMockRemoteMap()
+      mapVersions = createMockRemoteMap()
+      mapVersions.get.mockResolvedValue(indexVersion)
+      elementsSource = createInMemoryElementSource()
+    })
+    it('should not clear index when cache is valid', async () => {
+      await updateIndex({
+        changes: [objectChange],
+        index,
+        indexVersionKey,
+        indexVersion,
+        indexName,
+        mapVersions,
+        elementsSource,
+        isCacheValid: true,
+        updateChanges: updateChangesMock,
+      })
+      expect(index.clear).not.toHaveBeenCalled()
+      expect(mapVersions.set).not.toHaveBeenCalled()
+      expect(updateChangesMock).toHaveBeenCalledWith([objectChange], index)
+    })
+    it('should clear index when cache is invalid', async () => {
+      await updateIndex({
+        changes: [objectChange],
+        index,
+        indexVersionKey,
+        indexVersion,
+        indexName,
+        mapVersions,
+        elementsSource,
+        isCacheValid: false,
+        updateChanges: updateChangesMock,
+      })
+      expect(index.clear).toHaveBeenCalled()
+      expect(mapVersions.set).toHaveBeenCalled()
+      expect(updateChangesMock).toHaveBeenCalledWith([objectChange], index)
+    })
+    it('should clear index when index version isn\'t updated', async () => {
+      mapVersions.get.mockResolvedValue(0)
+      await elementsSource.set(getChangeData(objectChange))
+      await updateIndex({
+        changes: [],
+        index,
+        indexVersionKey,
+        indexVersion,
+        indexName,
+        mapVersions,
+        elementsSource,
+        isCacheValid: true,
+        updateChanges: updateChangesMock,
+      })
+      expect(index.clear).toHaveBeenCalled()
+      expect(mapVersions.set).toHaveBeenCalledWith(indexVersionKey, indexVersion)
+      expect(updateChangesMock).toHaveBeenCalledWith([objectChange], index)
+    })
   })
 })

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -3293,6 +3293,22 @@ describe('workspace', () => {
     })
   })
 
+  describe('getElementAuthorInformation', () => {
+    let workspace: Workspace
+
+    beforeAll(async () => {
+      workspace = await createWorkspace()
+    })
+
+    it('None-base type should throw', async () => {
+      await expect(workspace.getElementAuthorInformation(new ElemID('adapter', 'type', 'attr', 'aaa'))).rejects.toThrow()
+    })
+
+    it('None-exist type should return empty object', async () => {
+      expect(await workspace.getElementAuthorInformation(new ElemID('adapter', 'notExists'))).toEqual({})
+    })
+  })
+
   describe('hasElementsInEnv', () => {
     let workspace: Workspace
     beforeEach(async () => {


### PR DESCRIPTION
Added author information index that maps element ids to author information (changedBy & changedAt).
Added `getElementAuthorInformation` function to workspace API.

---

_Additional context for reviewer_

---
_Release Notes_: 
Workspace:
- Added author information index that maps element ids to author information (changedBy & changedAt)
- Added `getElementAuthorInformation` function to workspace API

---
_User Notifications_: 
None
