### PR TITLE
SALTO-3969 Avoid logging inside references in merge logs

### DIFF
--- a/packages/adapter-api/src/element_id.ts
+++ b/packages/adapter-api/src/element_id.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
+import { inspect } from 'util'
 import { BUILTIN_TYPE_NAMES, CORE_ANNOTATIONS } from './constants'
 
 export type ElemIDType = 'type' | 'field' | 'instance' | 'attr' | 'annotation' | 'var'
@@ -178,6 +179,10 @@ export class ElemID {
 
   getFullName(): string {
     return this.fullName
+  }
+
+  [inspect.custom](): string {
+    return `ElemID(${this.getFullName()})`
   }
 
   getFullNameParts(): string[] {

--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -77,10 +77,6 @@ export class StaticFile {
   public isEqual(other: StaticFile): boolean {
     return this.hash === other.hash && this.encoding === other.encoding
   }
-
-  [inspect.custom](): string {
-    return `StaticFile(${this.filepath}, ${this.hash ? this.hash : '<unknown hash>'})`
-  }
 }
 
 type StaticFileMetadata = Pick<StaticFile, 'filepath' | 'hash'>

--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
+import { inspect } from 'util'
 import { hash as hashUtils } from '@salto-io/lowerdash'
 // import { ElementsSource } from '@salto-io/workspace'
 import { ElemID } from './element_id'
@@ -75,6 +76,10 @@ export class StaticFile {
 
   public isEqual(other: StaticFile): boolean {
     return this.hash === other.hash && this.encoding === other.encoding
+  }
+
+  [inspect.custom](): string {
+    return `StaticFile(${this.filepath}, ${this.hash ? this.hash : '<unknown hash>'})`
   }
 }
 
@@ -147,6 +152,10 @@ export class ReferenceExpression {
   async getResolvedValue(elementsSource?: ReadOnlyElementsSource): Promise<Value> {
     return getResolvedValue(this.elemID, elementsSource, this.value)
   }
+
+  [inspect.custom](): string {
+    return `ReferenceExpression(${this.elemID.getFullName()}, ${this.value ? '<omitted>' : '<no value>'})`
+  }
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -188,6 +197,10 @@ export class TypeReference {
 
   async getResolvedValue(elementsSource?: ReadOnlyElementsSource): Promise<TypeElement> {
     return getResolvedValue(this.elemID, elementsSource, this.type)
+  }
+
+  [inspect.custom](): string {
+    return `TypeReference(${this.elemID.getFullName()}, ${this.type ? '<omitted>' : '<no value>'})`
   }
 }
 

--- a/packages/workspace/src/merger/internal/common.ts
+++ b/packages/workspace/src/merger/internal/common.ts
@@ -14,9 +14,9 @@
 * limitations under the License.
 */
 import _ from 'lodash'
+import { inspect } from 'util'
 import { types } from '@salto-io/lowerdash'
 import { ElemID, SaltoElementError, SeverityLevel } from '@salto-io/adapter-api'
-import { safeJsonStringify, elementExpressionStringifyReplacer } from '@salto-io/adapter-utils'
 
 
 export abstract class MergeError extends types.Bean<Readonly<{
@@ -43,7 +43,7 @@ export class DuplicateAnnotationError extends MergeError {
     { elemID: ElemID; key: string; existingValue: unknown; newValue: unknown}) {
     super({
       elemID,
-      error: `duplicate annotation key ${key} (values - ${safeJsonStringify(existingValue, elementExpressionStringifyReplacer, 2)} & ${safeJsonStringify(newValue, elementExpressionStringifyReplacer, 2)})`,
+      error: `duplicate annotation key ${key} (values - ${inspect(existingValue)} & ${inspect(newValue)})`,
     })
     this.key = key
     this.existingValue = existingValue

--- a/packages/workspace/src/merger/internal/instances.ts
+++ b/packages/workspace/src/merger/internal/instances.ts
@@ -13,8 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import { inspect } from 'util'
 import { InstanceElement, ElemID, TypeReference } from '@salto-io/adapter-api'
-import { safeJsonStringify, elementExpressionStringifyReplacer } from '@salto-io/adapter-utils'
 import {
   MergeResult, MergeError, mergeNoDuplicates, DuplicateAnnotationError,
 } from './common'
@@ -29,7 +29,7 @@ export class DuplicateInstanceKeyError extends MergeError {
     { elemID: ElemID; key: string; existingValue: unknown; newValue: unknown}) {
     super({
       elemID,
-      error: `duplicate key ${key} (values - ${safeJsonStringify(existingValue, elementExpressionStringifyReplacer, 2)} & ${safeJsonStringify(newValue, elementExpressionStringifyReplacer, 2)})`,
+      error: `duplicate key ${key} (values - ${inspect(existingValue)} & ${inspect(newValue)})`,
     })
     this.key = key
     this.existingValue = existingValue


### PR DESCRIPTION
Alternative to https://github.com/salto-io/salto/pull/4215 (that also reverts it), since it seems using `safeJsonStringify` with a replacer here is not efficient enough (`inspect` truncates after a max depth / array length).

---

there was a problem with adding similar handling for static files that requires more debugging and is not critical to the fix, so starting without it

---
_Release Notes_: 
None

---
_User Notifications_: 
None