### PR TITLE
SALTO-3059 use inspect instead of safeJsonStringify with replacer

### DIFF
--- a/eslint/adapter-api.rules.js
+++ b/eslint/adapter-api.rules.js
@@ -18,7 +18,11 @@ module.exports = {
         'no-restricted-syntax': [
             {
                 selector: "CallExpression[callee.object.name='JSON'][callee.property.name='stringify'][arguments.length=1]",
-                message: 'JSON.stringify usage without a replacer is disallowed. Use safeJsonStringify instead.',
+                message: 'JSON.stringify usage without a replacer is disallowed. Use inspectValue (or safeJsonStringify for small objects) instead',
+            },
+            {
+                selector: "CallExpression[callee.property.name='safeJsonStringify'][arguments[2] !== undefined]",
+                message: 'safeJsonStringify usage with a replacer is is inefficient. Use inspectValue instead for large objects or long arrays',
             }
         ]
     }

--- a/eslint/adapter-api.rules.js
+++ b/eslint/adapter-api.rules.js
@@ -19,10 +19,6 @@ module.exports = {
             {
                 selector: "CallExpression[callee.object.name='JSON'][callee.property.name='stringify'][arguments.length=1]",
                 message: 'JSON.stringify usage without a replacer is disallowed. Use inspectValue (or safeJsonStringify for small objects) instead',
-            },
-            {
-                selector: "CallExpression[callee.property.name='safeJsonStringify'][arguments[2] !== undefined]",
-                message: 'safeJsonStringify usage with a replacer is is inefficient. Use inspectValue instead for large objects or long arrays',
             }
         ]
     }

--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -78,6 +78,10 @@ export class StaticFile {
   public isEqual(other: StaticFile): boolean {
     return this.hash === other.hash && this.encoding === other.encoding
   }
+
+  [inspect.custom](): string {
+    return `StaticFile(${this.filepath}, ${this.hash ? this.hash : '<unknown hash>'})`
+  }
 }
 
 type StaticFileMetadata = Pick<StaticFile, 'filepath' | 'hash'>

--- a/packages/adapter-components/src/deployment/deployment.ts
+++ b/packages/adapter-components/src/deployment/deployment.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import { ActionName, Change, ElemID, getChangeData, InstanceElement, ReadOnlyElementsSource, isAdditionOrModificationChange } from '@salto-io/adapter-api'
-import { elementExpressionStringifyReplacer, safeJsonStringify, transformElement } from '@salto-io/adapter-utils'
+import { transformElement, safeStringifyLimited } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { createUrl } from '../elements/request_parameters'
 import { HTTPWriteClientInterface } from '../client/http_client'
@@ -131,7 +131,7 @@ export const deployChange = async ({
   if (_.isEmpty(valuesToDeploy) && isAdditionOrModificationChange(change)) {
     return undefined
   }
-  log.trace(`deploying instance ${instance.elemID.getFullName()} with params ${safeJsonStringify({ method: endpoint.method, url, data, queryParams }, elementExpressionStringifyReplacer)}`)
+  log.trace(`deploying instance ${instance.elemID.getFullName()} with params ${safeStringifyLimited({ method: endpoint.method, url, data, queryParams }, { compact: true })}`)
   const response = await client[endpoint.method]({ url, data, queryParams })
   return response.data
 }

--- a/packages/adapter-components/src/deployment/deployment.ts
+++ b/packages/adapter-components/src/deployment/deployment.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import { ActionName, Change, ElemID, getChangeData, InstanceElement, ReadOnlyElementsSource, isAdditionOrModificationChange } from '@salto-io/adapter-api'
-import { transformElement, safeStringifyLimited } from '@salto-io/adapter-utils'
+import { transformElement, inspectValue } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { createUrl } from '../elements/request_parameters'
 import { HTTPWriteClientInterface } from '../client/http_client'
@@ -131,7 +131,7 @@ export const deployChange = async ({
   if (_.isEmpty(valuesToDeploy) && isAdditionOrModificationChange(change)) {
     return undefined
   }
-  log.trace(`deploying instance ${instance.elemID.getFullName()} with params ${safeStringifyLimited({ method: endpoint.method, url, data, queryParams }, { compact: true })}`)
+  log.trace(`deploying instance ${instance.elemID.getFullName()} with params ${inspectValue({ method: endpoint.method, url, data, queryParams }, { compact: true })}`)
   const response = await client[endpoint.method]({ url, data, queryParams })
   return response.data
 }

--- a/packages/adapter-utils/src/collisions.ts
+++ b/packages/adapter-utils/src/collisions.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import { ElemID, InstanceElement, SaltoError } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
-import { safeStringifyLimited } from './utils'
+import { inspectValue } from './utils'
 
 const { groupByAsync } = collections.asynciterable
 const log = logger(module)
@@ -81,7 +81,7 @@ const logInstancesWithCollidingElemID = async (
       const relevantInstanceValues = elemIDInstances
         .map(instance => _.pickBy(instance.value, val => val != null))
       const relevantInstanceValuesStr = relevantInstanceValues
-        .map(instValues => safeStringifyLimited(instValues)).join('\n')
+        .map(instValues => inspectValue(instValues)).join('\n')
       log.debug(`Omitted instances of type ${type} with colliding ElemID ${elemID} with values - 
   ${relevantInstanceValuesStr}`)
     })

--- a/packages/jira-adapter/src/filters/duplicate_ids.ts
+++ b/packages/jira-adapter/src/filters/duplicate_ids.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import { InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
-import { naclCase, safeStringifyLimited } from '@salto-io/adapter-utils'
+import { naclCase, inspectValue } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
 
@@ -58,7 +58,7 @@ const filter: FilterCreator = ({ config }) => ({
     duplicateInstances
       .filter(isInstanceElement)
       .forEach(instance => {
-        log.debug(`Found a duplicate instance ${instance.elemID.getFullName()} with values: ${safeStringifyLimited(instance.value)}`)
+        log.debug(`Found a duplicate instance ${instance.elemID.getFullName()} with values: ${inspectValue(instance.value)}`)
       })
 
     if (!config.fetch.fallbackToInternalId) {

--- a/packages/jira-adapter/src/filters/duplicate_ids.ts
+++ b/packages/jira-adapter/src/filters/duplicate_ids.ts
@@ -13,9 +13,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
-import { naclCase, elementExpressionStringifyReplacer, safeJsonStringify } from '@salto-io/adapter-utils'
 import _ from 'lodash'
+import { InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
+import { naclCase, safeStringifyLimited } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
 
@@ -58,7 +58,7 @@ const filter: FilterCreator = ({ config }) => ({
     duplicateInstances
       .filter(isInstanceElement)
       .forEach(instance => {
-        log.debug(`Found a duplicate instance ${instance.elemID.getFullName()} with values: ${safeJsonStringify(instance.value, elementExpressionStringifyReplacer, 2)}`)
+        log.debug(`Found a duplicate instance ${instance.elemID.getFullName()} with values: ${safeStringifyLimited(instance.value)}`)
       })
 
     if (!config.fetch.fallbackToInternalId) {

--- a/packages/jira-adapter/src/filters/workflow/workflow_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_deploy_filter.ts
@@ -13,9 +13,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { AdditionChange, ElemID, getChangeData, InstanceElement, isAdditionChange, isInstanceChange, isRemovalChange, RemovalChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { resolveChangeElement, safeJsonStringify, walkOnValue, WALK_NEXT_STEP, elementExpressionStringifyReplacer } from '@salto-io/adapter-utils'
+import { AdditionChange, ElemID, getChangeData, InstanceElement, isAdditionChange, isInstanceChange, isRemovalChange, RemovalChange } from '@salto-io/adapter-api'
+import { resolveChangeElement, walkOnValue, WALK_NEXT_STEP, safeStringifyLimited } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../../filter'
 import { isPostFetchWorkflowChange, WorkflowInstance } from './types'
@@ -91,7 +91,7 @@ export const deployWorkflow = async (
 
   if (!isPostFetchWorkflowChange(resolvedChange)) {
     const instance = getChangeData(resolvedChange)
-    log.error(`values ${safeJsonStringify(instance.value, elementExpressionStringifyReplacer)} of instance ${instance.elemID.getFullName} are invalid`)
+    log.error(`values ${safeStringifyLimited(instance.value)} of instance ${instance.elemID.getFullName} are invalid`)
     throw new Error(`instance ${instance.elemID.getFullName()} is not valid for deployment`)
   }
   const instance = getChangeData(resolvedChange)

--- a/packages/jira-adapter/src/filters/workflow/workflow_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_deploy_filter.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import { AdditionChange, ElemID, getChangeData, InstanceElement, isAdditionChange, isInstanceChange, isRemovalChange, RemovalChange } from '@salto-io/adapter-api'
-import { resolveChangeElement, walkOnValue, WALK_NEXT_STEP, safeStringifyLimited } from '@salto-io/adapter-utils'
+import { resolveChangeElement, walkOnValue, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../../filter'
 import { isPostFetchWorkflowChange, WorkflowInstance } from './types'
@@ -91,7 +91,7 @@ export const deployWorkflow = async (
 
   if (!isPostFetchWorkflowChange(resolvedChange)) {
     const instance = getChangeData(resolvedChange)
-    log.error(`values ${safeStringifyLimited(instance.value)} of instance ${instance.elemID.getFullName} are invalid`)
+    log.error(`values ${inspectValue(instance.value)} of instance ${instance.elemID.getFullName} are invalid`)
     throw new Error(`instance ${instance.elemID.getFullName()} is not valid for deployment`)
   }
   const instance = getChangeData(resolvedChange)

--- a/packages/jira-adapter/src/filters/workflow/workflow_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_deploy_filter.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import { AdditionChange, ElemID, getChangeData, InstanceElement, isAdditionChange, isInstanceChange, isRemovalChange, RemovalChange } from '@salto-io/adapter-api'
-import { resolveChangeElement, walkOnValue, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
+import { resolveChangeElement, walkOnValue, WALK_NEXT_STEP, inspectValue } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../../filter'
 import { isPostFetchWorkflowChange, WorkflowInstance } from './types'

--- a/packages/lowerdash/src/types.ts
+++ b/packages/lowerdash/src/types.ts
@@ -52,6 +52,9 @@ export type TypeGuard<T, S extends T> = (item: T) => item is S
 export type Predicate<T> = (item: T) => boolean
 export type AsyncPredicate<T> = (item: T) => Promise<boolean>
 
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type PickDataFields<T> = Omit<T, KeysOfType<T, Function>>
+
 /*
 
 --- Bean ---

--- a/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
+++ b/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
@@ -14,7 +14,6 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { inspect } from 'util'
 import { logger } from '@salto-io/logging'
 import { collections, hash, strings, promises, values } from '@salto-io/lowerdash'
 import {
@@ -27,7 +26,7 @@ import {
   SeverityLevel,
   isInstanceElement, isInstanceChange, toChange,
 } from '@salto-io/adapter-api'
-import { safeJsonStringify } from '@salto-io/adapter-utils'
+import { inspectValue, safeJsonStringify } from '@salto-io/adapter-utils'
 import { BatchResultInfo } from 'jsforce-types'
 import { EOL } from 'os'
 import {
@@ -70,7 +69,7 @@ const logErroredInstances = (instancesAndResults: InstanceAndResult[]): void => 
       log.error(`Instance ${instance.elemID.getFullName()} had deploy errors - ${['', ...result.errors].join('\n\t')}
 
 and values -
-${inspect(instance.value)}
+${inspectValue(instance.value)}
 `)
     }
   })

--- a/packages/workspace/src/merger/internal/common.ts
+++ b/packages/workspace/src/merger/internal/common.ts
@@ -16,7 +16,7 @@
 import _ from 'lodash'
 import { types } from '@salto-io/lowerdash'
 import { ElemID, SaltoElementError, SeverityLevel } from '@salto-io/adapter-api'
-import { safeStringifyLimited } from '@salto-io/adapter-utils'
+import { inspectValue } from '@salto-io/adapter-utils'
 
 
 export abstract class MergeError extends types.Bean<Readonly<{
@@ -43,7 +43,7 @@ export class DuplicateAnnotationError extends MergeError {
     { elemID: ElemID; key: string; existingValue: unknown; newValue: unknown}) {
     super({
       elemID,
-      error: `duplicate annotation key ${key} (values - ${safeStringifyLimited(existingValue)} & ${safeStringifyLimited(newValue)})`,
+      error: `duplicate annotation key ${key} (values - ${inspectValue(existingValue)} & ${inspectValue(newValue)})`,
     })
     this.key = key
     this.existingValue = existingValue

--- a/packages/workspace/src/merger/internal/common.ts
+++ b/packages/workspace/src/merger/internal/common.ts
@@ -14,9 +14,9 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { inspect } from 'util'
 import { types } from '@salto-io/lowerdash'
 import { ElemID, SaltoElementError, SeverityLevel } from '@salto-io/adapter-api'
+import { safeStringifyLimited } from '@salto-io/adapter-utils'
 
 
 export abstract class MergeError extends types.Bean<Readonly<{
@@ -43,7 +43,7 @@ export class DuplicateAnnotationError extends MergeError {
     { elemID: ElemID; key: string; existingValue: unknown; newValue: unknown}) {
     super({
       elemID,
-      error: `duplicate annotation key ${key} (values - ${inspect(existingValue)} & ${inspect(newValue)})`,
+      error: `duplicate annotation key ${key} (values - ${safeStringifyLimited(existingValue)} & ${safeStringifyLimited(newValue)})`,
     })
     this.key = key
     this.existingValue = existingValue

--- a/packages/workspace/src/merger/internal/instances.ts
+++ b/packages/workspace/src/merger/internal/instances.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { InstanceElement, ElemID, TypeReference } from '@salto-io/adapter-api'
-import { safeStringifyLimited } from '@salto-io/adapter-utils'
+import { inspectValue } from '@salto-io/adapter-utils'
 import {
   MergeResult, MergeError, mergeNoDuplicates, DuplicateAnnotationError,
 } from './common'
@@ -29,7 +29,7 @@ export class DuplicateInstanceKeyError extends MergeError {
     { elemID: ElemID; key: string; existingValue: unknown; newValue: unknown}) {
     super({
       elemID,
-      error: `duplicate key ${key} (values - ${safeStringifyLimited(existingValue)} & ${safeStringifyLimited(newValue)})`,
+      error: `duplicate key ${key} (values - ${inspectValue(existingValue)} & ${inspectValue(newValue)})`,
     })
     this.key = key
     this.existingValue = existingValue

--- a/packages/workspace/src/merger/internal/instances.ts
+++ b/packages/workspace/src/merger/internal/instances.ts
@@ -13,8 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { inspect } from 'util'
 import { InstanceElement, ElemID, TypeReference } from '@salto-io/adapter-api'
+import { safeStringifyLimited } from '@salto-io/adapter-utils'
 import {
   MergeResult, MergeError, mergeNoDuplicates, DuplicateAnnotationError,
 } from './common'
@@ -29,7 +29,7 @@ export class DuplicateInstanceKeyError extends MergeError {
     { elemID: ElemID; key: string; existingValue: unknown; newValue: unknown}) {
     super({
       elemID,
-      error: `duplicate key ${key} (values - ${inspect(existingValue)} & ${inspect(newValue)})`,
+      error: `duplicate key ${key} (values - ${safeStringifyLimited(existingValue)} & ${safeStringifyLimited(newValue)})`,
     })
     this.key = key
     this.existingValue = existingValue

--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -157,15 +157,20 @@ export const serializeStream = async <T = Element>(
       || nameToTypeEntries.find(([_name, type]) => e instanceof type)?.[0]
     return o
   }
-  const staticFileReplacer = (e: StaticFile): Omit<Omit<StaticFile & SerializedClass, 'internalContent'>, 'content'> => {
+  const staticFileReplacer = (e: StaticFile): Omit<types.PickDataFields<StaticFile> & SerializedClass, 'internalContent' | 'content'> => {
     if (storeStaticFile !== undefined) {
       promises.push(storeStaticFile(e))
     }
     return _.pick(saltoClassReplacer(e), SALTO_CLASS_FIELD, 'filepath', 'hash', 'encoding')
   }
 
-  const elemIdReplacer = (id: ElemID): Omit<Omit<StaticFile & SerializedClass, 'internalContent'>, 'content'> =>
-    _.pick(id, 'adapter', 'typeName', 'idType', 'nameParts')
+  const elemIdReplacer = (id: ElemID): Omit<types.PickDataFields<ElemID>, 'nestingLevel' | 'name'> & { readonly nameParts: ReadonlyArray<string> } =>
+    ({
+      adapter: id.adapter,
+      typeName: id.typeName,
+      idType: id.idType,
+      nameParts: _.get(id, 'nameParts'),
+    })
 
   const referenceExpressionReplacer = (e: ReferenceExpression):
     ReferenceExpression & SerializedClass => {

--- a/packages/zendesk-adapter/src/filters/app_installations.ts
+++ b/packages/zendesk-adapter/src/filters/app_installations.ts
@@ -21,8 +21,8 @@ import {
   getChangeData, InstanceElement, isAdditionChange,
   isAdditionOrModificationChange, isInstanceElement, ReferenceExpression,
 } from '@salto-io/adapter-api'
+import { safeStringifyLimited } from '@salto-io/adapter-utils'
 import { retry } from '@salto-io/lowerdash'
-import { safeJsonStringify, elementExpressionStringifyReplacer } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
 import { deployChange, deployChanges } from '../deployment'
@@ -49,7 +49,7 @@ const EXPECTED_APP_SCHEMA = Joi.object({
 const isJobStatus = (value: unknown): value is JobStatus => {
   const { error } = EXPECTED_APP_SCHEMA.validate(value)
   if (error !== undefined) {
-    log.error(`Received an invalid response for the job status: ${error.message}, ${safeJsonStringify(value, elementExpressionStringifyReplacer)}`)
+    log.error(`Received an invalid response for the job status: ${error.message}, ${safeStringifyLimited(value)}`)
     return false
   }
   return true

--- a/packages/zendesk-adapter/src/filters/app_installations.ts
+++ b/packages/zendesk-adapter/src/filters/app_installations.ts
@@ -21,7 +21,7 @@ import {
   getChangeData, InstanceElement, isAdditionChange,
   isAdditionOrModificationChange, isInstanceElement, ReferenceExpression,
 } from '@salto-io/adapter-api'
-import { safeStringifyLimited } from '@salto-io/adapter-utils'
+import { inspectValue } from '@salto-io/adapter-utils'
 import { retry } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
@@ -49,7 +49,7 @@ const EXPECTED_APP_SCHEMA = Joi.object({
 const isJobStatus = (value: unknown): value is JobStatus => {
   const { error } = EXPECTED_APP_SCHEMA.validate(value)
   if (error !== undefined) {
-    log.error(`Received an invalid response for the job status: ${error.message}, ${safeStringifyLimited(value)}`)
+    log.error(`Received an invalid response for the job status: ${error.message}, ${inspectValue(value)}`)
     return false
   }
   return true

--- a/packages/zendesk-adapter/src/filters/app_owned_convert_list_to_map.ts
+++ b/packages/zendesk-adapter/src/filters/app_owned_convert_list_to_map.ts
@@ -16,7 +16,7 @@
 import _ from 'lodash'
 import Joi from 'joi'
 import { InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
-import { safeStringifyLimited } from '@salto-io/adapter-utils'
+import { inspectValue } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
 import { APP_OWNED_TYPE_NAME } from '../constants'
@@ -37,7 +37,7 @@ const isParameters = (values: unknown): values is AppOwnedParameter[] => {
   }
   const { error } = EXPECTED_PARAMETERS_SCHEMA.validate(values)
   if (error !== undefined) {
-    log.error(`Received an invalid response for the app_owned parameters value: ${error.message}, ${safeStringifyLimited(values)}`)
+    log.error(`Received an invalid response for the app_owned parameters value: ${error.message}, ${inspectValue(values)}`)
     return false
   }
   return true

--- a/packages/zendesk-adapter/src/filters/app_owned_convert_list_to_map.ts
+++ b/packages/zendesk-adapter/src/filters/app_owned_convert_list_to_map.ts
@@ -15,8 +15,8 @@
 */
 import _ from 'lodash'
 import Joi from 'joi'
-import { safeJsonStringify, elementExpressionStringifyReplacer } from '@salto-io/adapter-utils'
 import { InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
+import { safeStringifyLimited } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
 import { APP_OWNED_TYPE_NAME } from '../constants'
@@ -37,7 +37,7 @@ const isParameters = (values: unknown): values is AppOwnedParameter[] => {
   }
   const { error } = EXPECTED_PARAMETERS_SCHEMA.validate(values)
   if (error !== undefined) {
-    log.error(`Received an invalid response for the app_owned parameters value: ${error.message}, ${safeJsonStringify(values, elementExpressionStringifyReplacer)}`)
+    log.error(`Received an invalid response for the app_owned parameters value: ${error.message}, ${safeStringifyLimited(values)}`)
     return false
   }
   return true

--- a/packages/zendesk-adapter/src/filters/article/utils.ts
+++ b/packages/zendesk-adapter/src/filters/article/utils.ts
@@ -22,7 +22,7 @@ import {
   normalizeFilePathPart,
   replaceTemplatesWithValues,
   safeJsonStringify,
-  safeStringifyLimited,
+  inspectValue,
 } from '@salto-io/adapter-utils'
 import { collections, promises, values as lowerDashValues } from '@salto-io/lowerdash'
 import {
@@ -88,7 +88,7 @@ const EXPECTED_ATTACHMENT_SCHEMA = Joi.array().items(Joi.object({
 export const isAttachments = (value: unknown): value is Attachment[] => {
   const { error } = EXPECTED_ATTACHMENT_SCHEMA.validate(value)
   if (error !== undefined) {
-    log.error(`Received an invalid response for the attachments values: ${error.message}, ${safeStringifyLimited((value))}`)
+    log.error(`Received an invalid response for the attachments values: ${error.message}, ${inspectValue((value))}`)
     return false
   }
   return true
@@ -105,7 +105,7 @@ const EXPECTED_ATTACHMENT_RESPONSE_SCHEMA = Joi.array().items(Joi.object({
 export const isAttachmentsResponse = (value: unknown): value is AttachmentResponse[] => {
   const { error } = EXPECTED_ATTACHMENT_RESPONSE_SCHEMA.validate(value)
   if (error !== undefined) {
-    log.error(`Received an invalid response for the attachments values: ${error.message}, ${safeStringifyLimited(value)}`)
+    log.error(`Received an invalid response for the attachments values: ${error.message}, ${inspectValue(value)}`)
     return false
   }
   return true
@@ -239,7 +239,7 @@ export const updateArticleTranslationBody = async ({
   const attachmentElementsNames = attachmentInstances.map(instance => instance.elemID.name)
   const articleTranslations = articleValues?.translations
   if (!Array.isArray(articleTranslations)) {
-    log.error(`Received an invalid translations value for attachment ${articleValues.name} - ${safeStringifyLimited(articleTranslations)}`)
+    log.error(`Received an invalid translations value for attachment ${articleValues.name} - ${inspectValue(articleTranslations)}`)
     return
   }
   await awu(articleTranslations)

--- a/packages/zendesk-adapter/src/filters/article/utils.ts
+++ b/packages/zendesk-adapter/src/filters/article/utils.ts
@@ -18,11 +18,11 @@ import Joi from 'joi'
 import FormData from 'form-data'
 import { logger } from '@salto-io/logging'
 import {
-  elementExpressionStringifyReplacer,
   getParent,
   normalizeFilePathPart,
   replaceTemplatesWithValues,
   safeJsonStringify,
+  safeStringifyLimited,
 } from '@salto-io/adapter-utils'
 import { collections, promises, values as lowerDashValues } from '@salto-io/lowerdash'
 import {
@@ -88,7 +88,7 @@ const EXPECTED_ATTACHMENT_SCHEMA = Joi.array().items(Joi.object({
 export const isAttachments = (value: unknown): value is Attachment[] => {
   const { error } = EXPECTED_ATTACHMENT_SCHEMA.validate(value)
   if (error !== undefined) {
-    log.error(`Received an invalid response for the attachments values: ${error.message}, ${safeJsonStringify(value, elementExpressionStringifyReplacer)}`)
+    log.error(`Received an invalid response for the attachments values: ${error.message}, ${safeStringifyLimited((value))}`)
     return false
   }
   return true
@@ -105,7 +105,7 @@ const EXPECTED_ATTACHMENT_RESPONSE_SCHEMA = Joi.array().items(Joi.object({
 export const isAttachmentsResponse = (value: unknown): value is AttachmentResponse[] => {
   const { error } = EXPECTED_ATTACHMENT_RESPONSE_SCHEMA.validate(value)
   if (error !== undefined) {
-    log.error(`Received an invalid response for the attachments values: ${error.message}, ${safeJsonStringify(value, elementExpressionStringifyReplacer)}`)
+    log.error(`Received an invalid response for the attachments values: ${error.message}, ${safeStringifyLimited(value)}`)
     return false
   }
   return true
@@ -239,7 +239,7 @@ export const updateArticleTranslationBody = async ({
   const attachmentElementsNames = attachmentInstances.map(instance => instance.elemID.name)
   const articleTranslations = articleValues?.translations
   if (!Array.isArray(articleTranslations)) {
-    log.error(`Received an invalid translations value for attachment ${articleValues.name} - ${safeJsonStringify(articleTranslations, elementExpressionStringifyReplacer)}`)
+    log.error(`Received an invalid translations value for attachment ${articleValues.name} - ${safeStringifyLimited(articleTranslations)}`)
     return
   }
   await awu(articleTranslations)

--- a/packages/zendesk-adapter/src/filters/brand_logo.ts
+++ b/packages/zendesk-adapter/src/filters/brand_logo.ts
@@ -21,7 +21,7 @@ import {
   ReferenceExpression, SaltoElementError, SaltoError, StaticFile,
 } from '@salto-io/adapter-api'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
-import { naclCase, safeJsonStringify, getParent, normalizeFilePathPart, pathNaclCase, elementExpressionStringifyReplacer } from '@salto-io/adapter-utils'
+import { naclCase, safeJsonStringify, getParent, normalizeFilePathPart, pathNaclCase, safeStringifyLimited } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import FormData from 'form-data'
 import { collections } from '@salto-io/lowerdash'
@@ -55,7 +55,7 @@ const EXPECTED_BRAND_SCHEMA = Joi.object({
 const isBrand = (value: unknown): value is Brand => {
   const { error } = EXPECTED_BRAND_SCHEMA.validate(value, { allowUnknown: true })
   if (error !== undefined) {
-    log.error(`Received an invalid response for the brand values: ${error.message}, ${safeJsonStringify(value, elementExpressionStringifyReplacer)}`)
+    log.error(`Received an invalid response for the brand values: ${error.message}, ${safeStringifyLimited(value)}`)
     return false
   }
   return true

--- a/packages/zendesk-adapter/src/filters/brand_logo.ts
+++ b/packages/zendesk-adapter/src/filters/brand_logo.ts
@@ -21,7 +21,7 @@ import {
   ReferenceExpression, SaltoElementError, SaltoError, StaticFile,
 } from '@salto-io/adapter-api'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
-import { naclCase, safeJsonStringify, getParent, normalizeFilePathPart, pathNaclCase, safeStringifyLimited } from '@salto-io/adapter-utils'
+import { naclCase, safeJsonStringify, getParent, normalizeFilePathPart, pathNaclCase, inspectValue } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import FormData from 'form-data'
 import { collections } from '@salto-io/lowerdash'
@@ -55,7 +55,7 @@ const EXPECTED_BRAND_SCHEMA = Joi.object({
 const isBrand = (value: unknown): value is Brand => {
   const { error } = EXPECTED_BRAND_SCHEMA.validate(value, { allowUnknown: true })
   if (error !== undefined) {
-    log.error(`Received an invalid response for the brand values: ${error.message}, ${safeStringifyLimited(value)}`)
+    log.error(`Received an invalid response for the brand values: ${error.message}, ${inspectValue(value)}`)
     return false
   }
   return true

--- a/packages/zendesk-adapter/src/filters/collision_errors.ts
+++ b/packages/zendesk-adapter/src/filters/collision_errors.ts
@@ -18,7 +18,7 @@ import { config as configUtils } from '@salto-io/adapter-components'
 import { getAndLogCollisionWarnings, getInstancesWithCollidingElemID } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../filter'
 import { ZENDESK } from '../constants'
-import { API_DEFINITIONS_CONFIG, FETCH_CONFIG, isGuideEnabled } from '../config'
+import { API_DEFINITIONS_CONFIG } from '../config'
 
 
 /**
@@ -39,8 +39,6 @@ const filterCreator: FilterCreator = ({ config }) => ({
         config[API_DEFINITIONS_CONFIG].typeDefaults.transformation,
       ).idFields,
       idFieldsName: 'idFields',
-      // Needed because 'safeJsonStringify' is really slow, which causes problems with articles stress test (SALTO-3059)
-      skipLogCollisionStringify: isGuideEnabled(config[FETCH_CONFIG]),
       docsUrl: 'https://help.salto.io/en/articles/6927157-salto-id-collisions',
     })
     return { errors: collistionWarnings }

--- a/packages/zendesk-adapter/src/filters/hardcoded_channel.ts
+++ b/packages/zendesk-adapter/src/filters/hardcoded_channel.ts
@@ -17,7 +17,7 @@ import Joi from 'joi'
 import {
   BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, isInstanceElement, ObjectType, Values,
 } from '@salto-io/adapter-api'
-import { naclCase, safeStringifyLimited } from '@salto-io/adapter-utils'
+import { naclCase, inspectValue } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
 import { FilterCreator } from '../filter'
@@ -45,7 +45,7 @@ const EXPECTED_CHANNELS_SCHEMA = Joi.array().items(Joi.object({
 const isChannels = (values: unknown): values is Channel[] => {
   const { error } = EXPECTED_CHANNELS_SCHEMA.validate(values)
   if (error !== undefined) {
-    log.error(`Received an invalid response for the channel values: ${error.message}, ${safeStringifyLimited(values)}`)
+    log.error(`Received an invalid response for the channel values: ${error.message}, ${inspectValue(values)}`)
     return false
   }
   return true
@@ -82,7 +82,7 @@ const filterCreator: FilterCreator = () => ({
       path: [ZENDESK, TYPES_PATH, SUBTYPES_PATH, CHANNEL_TYPE_NAME],
     })
     if (channels.length !== (new Set(channels.map(c => c.value))).size) {
-      log.warn(`Found duplicate ids in the channels - Not adding channel instances. ${safeStringifyLimited(channels)}`)
+      log.warn(`Found duplicate ids in the channels - Not adding channel instances. ${inspectValue(channels)}`)
       return
     }
     const instances = channels.map(channel => {

--- a/packages/zendesk-adapter/src/filters/hardcoded_channel.ts
+++ b/packages/zendesk-adapter/src/filters/hardcoded_channel.ts
@@ -17,7 +17,7 @@ import Joi from 'joi'
 import {
   BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, isInstanceElement, ObjectType, Values,
 } from '@salto-io/adapter-api'
-import { naclCase, safeJsonStringify, elementExpressionStringifyReplacer } from '@salto-io/adapter-utils'
+import { naclCase, safeStringifyLimited } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
 import { FilterCreator } from '../filter'
@@ -45,7 +45,7 @@ const EXPECTED_CHANNELS_SCHEMA = Joi.array().items(Joi.object({
 const isChannels = (values: unknown): values is Channel[] => {
   const { error } = EXPECTED_CHANNELS_SCHEMA.validate(values)
   if (error !== undefined) {
-    log.error(`Received an invalid response for the channel values: ${error.message}, ${safeJsonStringify(values, elementExpressionStringifyReplacer)}`)
+    log.error(`Received an invalid response for the channel values: ${error.message}, ${safeStringifyLimited(values)}`)
     return false
   }
   return true
@@ -82,7 +82,7 @@ const filterCreator: FilterCreator = () => ({
       path: [ZENDESK, TYPES_PATH, SUBTYPES_PATH, CHANNEL_TYPE_NAME],
     })
     if (channels.length !== (new Set(channels.map(c => c.value))).size) {
-      log.warn(`Found duplicate ids in the channels - Not adding channel instances. ${safeJsonStringify(channels)}`)
+      log.warn(`Found duplicate ids in the channels - Not adding channel instances. ${safeStringifyLimited(channels)}`)
       return
     }
     const instances = channels.map(channel => {

--- a/packages/zendesk-adapter/src/filters/macro_attachments.ts
+++ b/packages/zendesk-adapter/src/filters/macro_attachments.ts
@@ -33,8 +33,8 @@ import {
   SaltoElementError,
   StaticFile,
 } from '@salto-io/adapter-api'
-import { normalizeFilePathPart, naclCase, elementExpressionStringifyReplacer,
-  resolveChangeElement, safeJsonStringify, pathNaclCase, references } from '@salto-io/adapter-utils'
+import { normalizeFilePathPart, naclCase,
+  resolveChangeElement, safeJsonStringify, pathNaclCase, references, safeStringifyLimited } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
 import { values, collections } from '@salto-io/lowerdash'
@@ -75,7 +75,7 @@ const EXPECTED_ATTACHMENT_SCHEMA = Joi.array().items(Joi.object({
 const isAttachments = (value: unknown): value is Attachment[] => {
   const { error } = EXPECTED_ATTACHMENT_SCHEMA.validate(value)
   if (error !== undefined) {
-    log.error(`Received an invalid response for the attachments values: ${error.message}, ${safeJsonStringify(value, elementExpressionStringifyReplacer)}`)
+    log.error(`Received an invalid response for the attachments values: ${error.message}, ${safeStringifyLimited(value)}`)
     return false
   }
   return true
@@ -91,7 +91,7 @@ const replaceAttachmentId = (
   }
   if (!isArrayOfRefExprToInstances(attachments)) {
     log.error(`Failed to deploy macro because its attachment field has an invalid format: ${
-      safeJsonStringify(attachments, elementExpressionStringifyReplacer)}`)
+      safeStringifyLimited(attachments)}`)
     throw createSaltoElementError({ // caught in try block
       message: 'Failed to deploy macro because its attachment field has an invalid format',
       severity: 'Error',

--- a/packages/zendesk-adapter/src/filters/macro_attachments.ts
+++ b/packages/zendesk-adapter/src/filters/macro_attachments.ts
@@ -34,7 +34,7 @@ import {
   StaticFile,
 } from '@salto-io/adapter-api'
 import { normalizeFilePathPart, naclCase,
-  resolveChangeElement, safeJsonStringify, pathNaclCase, references, safeStringifyLimited } from '@salto-io/adapter-utils'
+  resolveChangeElement, safeJsonStringify, pathNaclCase, references, inspectValue } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
 import { values, collections } from '@salto-io/lowerdash'
@@ -75,7 +75,7 @@ const EXPECTED_ATTACHMENT_SCHEMA = Joi.array().items(Joi.object({
 const isAttachments = (value: unknown): value is Attachment[] => {
   const { error } = EXPECTED_ATTACHMENT_SCHEMA.validate(value)
   if (error !== undefined) {
-    log.error(`Received an invalid response for the attachments values: ${error.message}, ${safeStringifyLimited(value)}`)
+    log.error(`Received an invalid response for the attachments values: ${error.message}, ${inspectValue(value)}`)
     return false
   }
   return true
@@ -91,7 +91,7 @@ const replaceAttachmentId = (
   }
   if (!isArrayOfRefExprToInstances(attachments)) {
     log.error(`Failed to deploy macro because its attachment field has an invalid format: ${
-      safeStringifyLimited(attachments)}`)
+      inspectValue(attachments)}`)
     throw createSaltoElementError({ // caught in try block
       message: 'Failed to deploy macro because its attachment field has an invalid format',
       severity: 'Error',

--- a/packages/zendesk-adapter/src/filters/reorder/creator.ts
+++ b/packages/zendesk-adapter/src/filters/reorder/creator.ts
@@ -31,7 +31,7 @@ import {
   SaltoError, createSaltoElementError, isSaltoError,
 } from '@salto-io/adapter-api'
 import { elements as elementsUtils, config as configUtils } from '@salto-io/adapter-components'
-import { applyFunctionToChangeData, pathNaclCase, safeStringifyLimited } from '@salto-io/adapter-utils'
+import { applyFunctionToChangeData, pathNaclCase, inspectValue } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../../filter'
 import { ZENDESK } from '../../constants'
 import { deployChange } from '../../deployment'
@@ -195,7 +195,7 @@ export const deployFuncCreator = (fieldName: string): DeployFuncType =>
     const { ids } = instance.value
     if (!idsAreNumbers(ids)) {
       throw createSaltoElementError({ // caught in try block
-        message: `Not all the ids of ${instance.elemID.getFullName()} are numbers: ${safeStringifyLimited(ids, { maxArrayLength: null })}`,
+        message: `Not all the ids of ${instance.elemID.getFullName()} are numbers: ${inspectValue(ids, { maxArrayLength: null })}`,
         severity: 'Error',
         elemID: getChangeData(change).elemID,
       })

--- a/packages/zendesk-adapter/src/filters/reorder/creator.ts
+++ b/packages/zendesk-adapter/src/filters/reorder/creator.ts
@@ -31,7 +31,7 @@ import {
   SaltoError, createSaltoElementError, isSaltoError,
 } from '@salto-io/adapter-api'
 import { elements as elementsUtils, config as configUtils } from '@salto-io/adapter-components'
-import { applyFunctionToChangeData, pathNaclCase, safeJsonStringify, elementExpressionStringifyReplacer } from '@salto-io/adapter-utils'
+import { applyFunctionToChangeData, pathNaclCase, safeStringifyLimited } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../../filter'
 import { ZENDESK } from '../../constants'
 import { deployChange } from '../../deployment'
@@ -195,7 +195,7 @@ export const deployFuncCreator = (fieldName: string): DeployFuncType =>
     const { ids } = instance.value
     if (!idsAreNumbers(ids)) {
       throw createSaltoElementError({ // caught in try block
-        message: `Not all the ids of ${instance.elemID.getFullName()} are numbers: ${safeJsonStringify(ids, elementExpressionStringifyReplacer)}`,
+        message: `Not all the ids of ${instance.elemID.getFullName()} are numbers: ${safeStringifyLimited(ids, { maxArrayLength: null })}`,
         severity: 'Error',
         elemID: getChangeData(change).elemID,
       })


### PR DESCRIPTION
Switch to `inspect` for performance reasons.

---
_Release Notes_: 
None

---
_User Notifications_: 
None