### PR TITLE
SALTO-4014: Don't fail fetch for singleton config error

### DIFF
--- a/packages/adapter-components/src/config/shared.ts
+++ b/packages/adapter-components/src/config/shared.ts
@@ -23,6 +23,8 @@ import { createRequestConfigs, DeploymentRequestsByAction, FetchRequestConfig, F
 
 export const DEPLOYER_FALLBACK_VALUE = '##DEPLOYER##'
 
+export class InvalidSingletonType extends Error {}
+
 export type TypeConfig<T extends TransformationConfig = TransformationConfig, A extends string = ActionName> = {
   request?: FetchRequestConfig
   deployRequests?: DeploymentRequestsByAction<A>

--- a/packages/adapter-components/src/elements/ducktype/transformer.ts
+++ b/packages/adapter-components/src/elements/ducktype/transformer.ts
@@ -30,6 +30,7 @@ import { extractStandaloneFields } from './standalone_field_extractor'
 import { shouldRecurseIntoEntry } from '../instance_elements'
 import { addRemainingTypes } from './add_remaining_types'
 import { ElementQuery } from '../query'
+import { InvalidSingletonType } from '../../config/shared'
 
 const { makeArray } = collections.array
 const { toArrayAsync, awu } = collections.asynciterable
@@ -208,7 +209,7 @@ const getEntriesForType = async (
 
   if (type.isSettings && instances.length > 1) {
     log.warn(`Expected one instance for singleton type: ${type.elemID.name} but received: ${instances.length}`)
-    throw new Error(`Could not fetch type ${type.elemID.name}, singleton types should not have more than one instance`)
+    throw new InvalidSingletonType(`Could not fetch type ${type.elemID.name}, singleton types should not have more than one instance`)
   }
 
   const { recurseInto } = requestWithDefaults
@@ -399,6 +400,9 @@ export const getAllElements = async ({
             severity: 'Warning',
           }
           return { elements: [], errors: [newError] }
+        }
+        if (e instanceof InvalidSingletonType) {
+          return { elements: [], errors: [{ message: e.message, severity: 'Warning' }] }
         }
         throw e
       }

--- a/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
@@ -72,6 +72,12 @@ describe('swagger_instance_elements', () => {
           name: { refType: BuiltinTypes.STRING },
         },
       })
+      const Singleton = new ObjectType({
+        elemID: new ElemID(ADAPTER_NAME, 'Singleton'),
+        fields: {
+          id: { refType: BuiltinTypes.STRING },
+        },
+      })
 
       return {
         Owner,
@@ -79,6 +85,7 @@ describe('swagger_instance_elements', () => {
         Food,
         Status,
         Fail,
+        Singleton,
       }
     }
 
@@ -1628,9 +1635,9 @@ describe('swagger_instance_elements', () => {
         ],
       ])
     })
-    it('should fail if singleton type have more than one instance', async () => {
+    it('should return fetch error if singleton type have more than one instance', async () => {
       const objectTypes = generateObjectTypes()
-      await expect(getAllInstances({
+      const result = await getAllInstances({
         paginator: mockPaginator,
         apiConfig: {
           typeDefaults: {
@@ -1664,7 +1671,12 @@ describe('swagger_instance_elements', () => {
         objectTypes,
         computeGetArgs: simpleGetArgs,
         nestedFieldFinder: returnFullEntry,
-      })).rejects.toThrow()
+      })
+      expect(result.errors).toHaveLength(1)
+      expect(result.errors?.[0]).toEqual({
+        message: 'Could not fetch type Pet, singleton types should not have more than one instance',
+        severity: 'Warning',
+      })
     })
   })
 })


### PR DESCRIPTION
Until now the entire fetch was failing if a type defined as `singleton` had more than one entry. From now on user will get this as a fetch warning.

---
_Release Notes_: 
None

---
_User Notifications_: 
None