### PR TITLE
SALTO-4019 throw on missing SuiteBundler feature in SuiteApp FileCabinet fetch

### DIFF
--- a/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
@@ -159,9 +159,9 @@ const MAX_DEPLOYABLE_FILE_SIZE = 10 * 1024 * 1024
 const DEPLOY_CHUNK_SIZE = 50
 const MAX_ITEMS_IN_WHERE_QUERY = 200
 
-export const THROW_ON_MISSING_FEATURE_ERROR = {
-  'Search error occurred: Unknown identifier \'bundleable\'': 'Failed to list folders.'
-    + ' Please verify that the "Create bundles with SuiteBundler" feature is enabled in the account.',
+export const THROW_ON_MISSING_FEATURE_ERROR: Record<string, string> = {
+  'Search error occurred: Unknown identifier \'bundleable\'':
+    'Failed to list folders. Please verify that the "Create bundles with SuiteBundler" feature is enabled in the account.',
 }
 
 export type SuiteAppFileCabinetOperations = {

--- a/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
@@ -159,6 +159,11 @@ const MAX_DEPLOYABLE_FILE_SIZE = 10 * 1024 * 1024
 const DEPLOY_CHUNK_SIZE = 50
 const MAX_ITEMS_IN_WHERE_QUERY = 200
 
+export const THROW_ON_MISSING_FEATURE_ERROR = {
+  'Search error occurred: Unknown identifier \'bundleable\'': 'Failed to list folders.'
+    + ' Please verify that the "Create bundles with SuiteBundler" feature is enabled in the account.',
+}
+
 export type SuiteAppFileCabinetOperations = {
   importFileCabinet: (query: NetsuiteQuery) => Promise<ImportFileCabinetResult>
   deploy: (
@@ -231,7 +236,8 @@ SuiteAppFileCabinetOperations => {
   ): Promise<FolderResult[]> => retryOnRetryableError(async () => {
     const foldersResults = await suiteAppClient.runSuiteQL(
       'SELECT name, id, bundleable, isinactive, isprivate, description, parent'
-      + ` FROM mediaitemfolder WHERE ${whereQuery} ORDER BY id ASC`
+      + ` FROM mediaitemfolder WHERE ${whereQuery} ORDER BY id ASC`,
+      THROW_ON_MISSING_FEATURE_ERROR,
     )
 
     if (foldersResults === undefined) {

--- a/packages/netsuite-adapter/test/client/suiteapp_client.test.ts
+++ b/packages/netsuite-adapter/test/client/suiteapp_client.test.ts
@@ -112,6 +112,16 @@ describe('SuiteAppClient', () => {
           mockAxiosAdapter.onPost().reply(() => [])
           expect(await client.runSuiteQL('')).toBeUndefined()
         })
+        it('should throw customize error', async () => {
+          mockAxiosAdapter.onPost().reply(400, {
+            code: 'SOME_CODE',
+            'o:errorDetails': [{
+              detail: 'some error',
+            }],
+          })
+          await expect(client.runSuiteQL('query', { 'some err': 'custom error1' })).rejects.toThrow('custom error1')
+          await expect(client.runSuiteQL('query', { 'other error': 'custom error2' })).resolves.not.toThrow()
+        })
         it('with concurrency error retry', async () => {
           jest.spyOn(global, 'setTimeout').mockImplementation((cb: TimerHandler) => (_.isFunction(cb) ? cb() : undefined))
           mockAxiosAdapter

--- a/packages/netsuite-adapter/test/suiteapp_file_cabinet.test.ts
+++ b/packages/netsuite-adapter/test/suiteapp_file_cabinet.test.ts
@@ -19,7 +19,7 @@ import { MockInterface } from '@salto-io/test-utils'
 import { collections } from '@salto-io/lowerdash'
 import { NetsuiteQuery } from '../src/query'
 import SuiteAppClient from '../src/client/suiteapp_client/suiteapp_client'
-import { createSuiteAppFileCabinetOperations, isChangeDeployable } from '../src/suiteapp_file_cabinet'
+import { THROW_ON_MISSING_FEATURE_ERROR, createSuiteAppFileCabinetOperations, isChangeDeployable } from '../src/suiteapp_file_cabinet'
 import { ReadFileEncodingError, ReadFileError, ReadFileInsufficientPermissionError } from '../src/client/suiteapp_client/errors'
 import { customtransactiontypeType } from '../src/autogen/types/standard_types/customtransactiontype'
 import { ExistingFileCabinetInstanceDetails, FileCabinetInstanceDetails } from '../src/client/suiteapp_client/types'
@@ -367,6 +367,14 @@ describe('suiteapp_file_cabinet', () => {
         expectedResults[4],
         expectedResults[5],
       ])
+    })
+
+    it('should call suiteql with missing feature error param', async () => {
+      await createSuiteAppFileCabinetOperations(suiteAppClient).importFileCabinet(query)
+      expect(mockSuiteAppClient.runSuiteQL).toHaveBeenCalledWith(
+        expect.stringContaining('SELECT name, id, bundleable'),
+        THROW_ON_MISSING_FEATURE_ERROR
+      )
     })
 
     it('return empty result when no top level folder matches the adapter\'s query', async () => {


### PR DESCRIPTION
Throw an indicative error instead of throwing a generic "Failed to list folders" error.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Throw indicative error on missing SuiteBundler feature in SuiteApp FileCabinet fetch

---
_User Notifications_: 
None
