### PR TITLE
SALTO-3780 omit dependency nested errors

### DIFF
--- a/packages/core/src/core/plan/filter.ts
+++ b/packages/core/src/core/plan/filter.ts
@@ -148,7 +148,7 @@ const buildValidDiffGraph = (
     ] as [ElemID, ElemID[]])
     .map(([causeID, elemIds]) => [
       causeID,
-      elemIds.filter(elemId => !elemId.isEqual(causeID)),
+      elemIds.filter(elemId => !elemId.isEqual(causeID) && !causeID.isParentOf(elemId)),
     ] as [ElemID, ElemID[]]).flatMap(
       ([causeID, elemIDs]) => elemIDs.map(elemID => createDependencyErr(causeID, elemID))
     )

--- a/packages/core/test/core/plan/filter.test.ts
+++ b/packages/core/test/core/plan/filter.test.ts
@@ -82,7 +82,7 @@ describe('filterInvalidChanges', () => {
       changeValidators: { salto: mockChangeValidator },
     })
     expect(planResult.changeErrors.filter(err => !isDependencyError(err))).toHaveLength(3)
-    expect(planResult.changeErrors.filter(err => isDependencyError(err))).toHaveLength(4)
+    expect(planResult.changeErrors.filter(err => isDependencyError(err))).toHaveLength(2)
     expect(planResult.changeErrors.some(v => v.elemID.isEqual(newInvalidObj.elemID)))
       .toBeTruthy()
     expect(planResult.changeErrors.some(v => v.elemID.isEqual(newInvalidObj.fields.invalid.elemID)))
@@ -303,7 +303,7 @@ describe('filterInvalidChanges', () => {
       changeValidators: { salto: mockChangeValidator },
     })
     expect(planResult.changeErrors.filter(err => !isDependencyError(err))).toHaveLength(3)
-    expect(planResult.changeErrors.filter(err => isDependencyError(err))).toHaveLength(3)
+    expect(planResult.changeErrors.filter(err => isDependencyError(err))).toHaveLength(2)
     expect(planResult.changeErrors.some(v => v.elemID.isEqual(beforeInvalidObj.elemID)))
       .toBeTruthy()
     expect(planResult.changeErrors.some(v => v.elemID.isEqual(beforeInvalidField.elemID)))


### PR DESCRIPTION
Omit dependency errors for anything nested inside something that already has errors.

---

This should help solve the unreadability of errors when new objects/instances are added and all their fields have dependency errors because the parent has a dependency error

---
_Release Notes_: 
Core:
- Omit dependency errors for elements whose parent already failed due to dependency error

---
_User Notifications_: _None_
