### PR TITLE
SALTO-3795: Add change validator to validate inactive parent assignment.

### DIFF
--- a/packages/netsuite-adapter/src/change_validator.ts
+++ b/packages/netsuite-adapter/src/change_validator.ts
@@ -17,6 +17,7 @@ import _ from 'lodash'
 
 import { ChangeError, getChangeData, ChangeValidator, Change, ChangeDataType, isFieldChange, isAdditionOrRemovalChange, ReadOnlyElementsSource } from '@salto-io/adapter-api'
 import { deployment } from '@salto-io/adapter-components'
+import inactiveParent from './change_validators/inactive_parent'
 import accountSpecificValuesValidator from './change_validators/account_specific_values'
 import dataAccountSpecificValuesValidator from './change_validators/data_account_specific_values'
 import removeStandardTypesValidator from './change_validators/remove_standard_types'
@@ -61,6 +62,7 @@ const netsuiteChangeValidators: NetsuiteChangeValidator[] = [
   instanceChangesValidator,
   reportTypesMoveEnvironment,
   immutableChangesValidator,
+  inactiveParent,
   removeListItemValidator,
   fileValidator,
   uniqueFieldsValidator,

--- a/packages/netsuite-adapter/src/change_validators/inactive_parent.ts
+++ b/packages/netsuite-adapter/src/change_validators/inactive_parent.ts
@@ -15,7 +15,7 @@
 */
 
 import { AdditionChange, Change, ChangeError, InstanceElement, ModificationChange, getChangeData,
-  isAdditionOrModificationChange, isInstanceChange, isModificationChange, isReferenceExpression } from '@salto-io/adapter-api'
+  isAdditionOrModificationChange, isInstanceChange, isInstanceElement, isModificationChange, isReferenceExpression } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { isDataObjectType, isCustomRecordType } from '../types'
 import { NetsuiteChangeValidator } from './types'
@@ -48,7 +48,8 @@ const hasInactiveParent = async (
   instance: InstanceElement,
 ): Promise<boolean> => (
   isReferenceExpression(instance.value[PARENT])
-    ? (instance.value[PARENT].value.value?.[IS_INACTIVE_FIELD] === true)
+    && isInstanceElement(instance.value[PARENT].value)
+    ? (instance.value[PARENT].value.value[IS_INACTIVE_FIELD] === true)
     : false
 )
 

--- a/packages/netsuite-adapter/src/change_validators/inactive_parent.ts
+++ b/packages/netsuite-adapter/src/change_validators/inactive_parent.ts
@@ -16,7 +16,7 @@
 
 import { AdditionChange, Change, ChangeError, InstanceElement, ModificationChange, ReadOnlyElementsSource, getChangeData, isAdditionOrModificationChange, isInstanceChange, isModificationChange } from '@salto-io/adapter-api'
 import { collections, values } from '@salto-io/lowerdash'
-import { isUndefined } from 'lodash'
+import _ from 'lodash'
 import { isDataObjectType, isCustomRecordType } from '../types'
 import { NetsuiteChangeValidator } from './types'
 
@@ -47,7 +47,7 @@ const hasInactiveParent = async (
     ? ((await elementsSource.get(change.value.parent.elemID.createNestedID(IS_INACTIVE_FIELD))) ?? false) : false)
 
 const changeValidator: NetsuiteChangeValidator = async (changes, _deployReferencedElements, elementsSource) => {
-  if (isUndefined(elementsSource)) {
+  if (_.isUndefined(elementsSource)) {
     return []
   }
 

--- a/packages/netsuite-adapter/src/change_validators/inactive_parent.ts
+++ b/packages/netsuite-adapter/src/change_validators/inactive_parent.ts
@@ -1,0 +1,71 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { AdditionChange, Change, ChangeError, InstanceElement, ModificationChange, ReadOnlyElementsSource, getChangeData, isAdditionOrModificationChange, isInstanceChange, isModificationChange } from '@salto-io/adapter-api'
+import { collections, values } from '@salto-io/lowerdash'
+import { isUndefined } from 'lodash'
+import { isDataObjectType, isCustomRecordType } from '../types'
+import { NetsuiteChangeValidator } from './types'
+
+const { awu } = collections.asynciterable
+const { isDefined } = values
+
+const IS_INACTIVE_FIELD = 'isInactive'
+
+const isDataElement = async (change: Change<InstanceElement>): Promise<boolean> => {
+  const changeType = await getChangeData(change).getType()
+  return isDataObjectType(changeType) && !isCustomRecordType(changeType)
+}
+
+const getParentIdentifier = (elem: InstanceElement): string | undefined => elem.value.parent?.elemID.getFullName()
+
+const hasNewParent = (
+  change: AdditionChange<InstanceElement> | ModificationChange<InstanceElement>
+): boolean => {
+  const parentIdentifierBefore = isModificationChange(change) ? getParentIdentifier(change.data.before) : undefined
+  return parentIdentifierBefore !== getParentIdentifier(change.data.after)
+}
+
+const hasInactiveParent = async (
+  change: InstanceElement,
+  elementsSource: ReadOnlyElementsSource
+): Promise<boolean> =>
+  (isDefined(change.value.parent)
+    ? ((await elementsSource.get(change.value.parent.elemID.createNestedID(IS_INACTIVE_FIELD))) ?? false) : false)
+
+const changeValidator: NetsuiteChangeValidator = async (changes, _deployReferencedElements, elementsSource) => {
+  if (isUndefined(elementsSource)) {
+    return []
+  }
+
+  return awu(changes)
+    .filter(isAdditionOrModificationChange)
+    .filter(isInstanceChange)
+    .filter(isDataElement)
+    .filter(hasNewParent)
+    .map(getChangeData)
+    .filter(change => hasInactiveParent(change, elementsSource))
+    .map(({ elemID }): ChangeError => ({
+      elemID,
+      severity: 'Error',
+      message: 'Inactive parent assigned.',
+      detailedMessage: 'Can\'t deploy this element because its newly assigned parent is inactive.'
+        + ' To deploy it, activate its parent.',
+    }))
+    .toArray()
+}
+
+export default changeValidator

--- a/packages/netsuite-adapter/test/change_validators/inactive_parent.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/inactive_parent.test.ts
@@ -1,0 +1,245 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType, ReadOnlyElementsSource, ReferenceExpression, Values, toChange, Element } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { isDefined } from '@salto-io/lowerdash/src/values'
+import inactiveParent from '../../src/change_validators/inactive_parent'
+import { CUSTOM_RECORD_TYPE, METADATA_TYPE, NETSUITE, SOAP } from '../../src/constants'
+
+describe('Inactive parent validator', () => {
+  const dataElementType = new ObjectType({
+    elemID: new ElemID(NETSUITE, 'test'),
+    annotations: {
+      source: SOAP,
+    },
+  })
+
+  const getIDToIsInactive = (instances: readonly InstanceElement[]): Map<string, boolean> =>
+    new Map(instances
+      .map(instance =>
+        [instance.elemID.createNestedID('isInactive').getFullName(),
+          instance.value.isInactive]))
+
+  const buildMockElementsSource = (
+    elements: readonly Element[],
+    parents?: InstanceElement[]
+  ): ReadOnlyElementsSource => {
+    const idToIsInactive = isDefined(parents) ? getIDToIsInactive(parents) : new Map()
+    const elementSource = buildElementsSourceFromElements(elements)
+
+    const mockGet = jest.fn().mockImplementation((id: ElemID) =>
+      idToIsInactive.get(id.getFullName()) ?? elementSource.get(id))
+    const mockElementsSource = {
+      list: elementSource.list,
+      getAll: elementSource.getAll,
+      has: elementSource.has,
+      get: mockGet,
+    } as unknown as ReadOnlyElementsSource
+
+    return mockElementsSource
+  }
+
+  const getInstanceElement = (
+    type: ObjectType,
+    isInactive: boolean | undefined,
+    parent?: InstanceElement
+  ): InstanceElement => {
+    const value: Values = isDefined(parent) ? {
+      isInactive,
+      parent: new ReferenceExpression(parent.elemID, parent),
+    } : {
+      isInactive,
+    }
+
+    return new InstanceElement(`test ${isInactive}`, type, value)
+  }
+
+  describe('Add new element', () => {
+    it('Should not have a change error when adding a new element without a parent', async () => {
+      const element = getInstanceElement(dataElementType, true)
+      const changeErrors = await inactiveParent(
+        [toChange({ after: element })],
+        undefined,
+        buildMockElementsSource([element])
+      )
+      expect(changeErrors).toHaveLength(0)
+    })
+
+    it('Should not have a change error when adding a new element with an active parent', async () => {
+      const parentElement = getInstanceElement(dataElementType, false)
+      const childElement = getInstanceElement(dataElementType, false, parentElement)
+      const changeErrors = await inactiveParent(
+        [toChange({ after: childElement })],
+        undefined,
+        buildMockElementsSource(
+          [childElement, parentElement]
+        )
+      )
+      expect(changeErrors).toHaveLength(0)
+    })
+
+    it('Should have a change error when adding a new element with an inactive parent', async () => {
+      const parentElement = getInstanceElement(dataElementType, true)
+      const childElement = getInstanceElement(dataElementType, true, parentElement)
+      const changeErrors = await inactiveParent(
+        [toChange({ after: childElement })],
+        undefined,
+        buildMockElementsSource([parentElement, childElement], [parentElement])
+      )
+      expect(changeErrors).toHaveLength(1)
+      expect(changeErrors[0].severity).toEqual('Error')
+      expect(changeErrors[0].elemID).toBe(childElement.elemID)
+    })
+  })
+
+  describe('Modify existing element', () => {
+    describe('Modify isInactive field', () => {
+      it('Should not have a change error when modifying isInactive field of an element without a parent', async () => {
+        const elementBefore = getInstanceElement(dataElementType, false)
+        const elementAfter = getInstanceElement(dataElementType, true)
+        const changeErrors = await inactiveParent(
+          [toChange({ before: elementBefore, after: elementAfter })],
+          undefined,
+          buildMockElementsSource([elementAfter])
+        )
+        expect(changeErrors).toHaveLength(0)
+      })
+
+      it('Should not have a change error when modifying isInactive field of an element with an active parent', async () => {
+        const parentElement = getInstanceElement(dataElementType, false)
+        const childElementBefore = getInstanceElement(dataElementType, true, parentElement)
+        const childElementAfter = getInstanceElement(dataElementType, false, parentElement)
+        const changeErrors = await inactiveParent(
+          [toChange({ before: childElementBefore, after: childElementAfter })],
+          undefined,
+          buildMockElementsSource([parentElement, childElementAfter], [parentElement])
+        )
+        expect(changeErrors).toHaveLength(0)
+      })
+
+      it('Should not have a change error when modifying isInactive field of an element with an inactive parent', async () => {
+        const parentElement = getInstanceElement(dataElementType, true)
+        const childElementBefore = getInstanceElement(dataElementType, true, parentElement)
+        const childElementAfter = getInstanceElement(dataElementType, false, parentElement)
+        const changeErrors = await inactiveParent(
+          [toChange({ before: childElementBefore, after: childElementAfter })],
+          undefined,
+          buildMockElementsSource([parentElement, childElementAfter], [parentElement])
+        )
+        expect(changeErrors).toHaveLength(0)
+      })
+    })
+
+    describe('Modify parent field', () => {
+      it('Should not have a change error when removing parent field', async () => {
+        const parentElement = getInstanceElement(dataElementType, true)
+        const childElementBefore = getInstanceElement(dataElementType, true, parentElement)
+        const childElementAfter = getInstanceElement(dataElementType, true)
+        const changeErrors = await inactiveParent(
+          [toChange({ before: childElementBefore, after: childElementAfter })],
+          undefined,
+          buildMockElementsSource([parentElement, childElementAfter], [parentElement])
+        )
+        expect(changeErrors).toHaveLength(0)
+      })
+
+      it('Should not have a change error when modifying parent field to reference an active parent', async () => {
+        const parentElementActive = getInstanceElement(dataElementType, false)
+        const parentElementInactive = getInstanceElement(dataElementType, true)
+        const childElementBefore = getInstanceElement(dataElementType, true, parentElementInactive)
+        const childElementAfter = getInstanceElement(dataElementType, true, parentElementActive)
+        const changeErrors = await inactiveParent(
+          [toChange({ before: childElementBefore, after: childElementAfter })],
+          undefined,
+          buildMockElementsSource(
+            [parentElementActive, parentElementInactive, childElementAfter],
+            [parentElementActive, parentElementInactive]
+          )
+        )
+        expect(changeErrors).toHaveLength(0)
+      })
+
+      it('Should have a change error when modifying parent field to reference an inactive parent', async () => {
+        const parentElementActive = getInstanceElement(dataElementType, false)
+        const parentElementInactive = getInstanceElement(dataElementType, true)
+        const childElementBefore = getInstanceElement(dataElementType, true, parentElementActive)
+        const childElementAfter = getInstanceElement(dataElementType, true, parentElementInactive)
+        const changeErrors = await inactiveParent(
+          [toChange({ before: childElementBefore, after: childElementAfter })],
+          undefined,
+          buildMockElementsSource(
+            [parentElementActive, parentElementInactive, childElementAfter],
+            [parentElementActive, parentElementInactive]
+          )
+        )
+        expect(changeErrors).toHaveLength(1)
+        expect(changeErrors[0].severity).toEqual('Error')
+        expect(changeErrors[0].elemID).toBe(childElementAfter.elemID)
+      })
+    })
+  })
+
+  describe('Missing fields', () => {
+    it('Should not have a change error if isInactive field is undefined', async () => {
+      const parentElement = getInstanceElement(dataElementType, undefined)
+      const childElement = getInstanceElement(dataElementType, undefined, parentElement)
+      const changeErrors = await inactiveParent(
+        [toChange({ after: childElement })],
+        undefined,
+        buildMockElementsSource([parentElement, childElement], [parentElement])
+      )
+      expect(changeErrors).toHaveLength(0)
+    })
+  })
+
+  describe('Custom record instance', () => {
+    const customRecordType = new ObjectType({
+      elemID: new ElemID(NETSUITE, 'customrecord1'),
+      annotations: {
+        source: SOAP,
+        [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
+      },
+    })
+
+    it('Should not have a change error when adding parent field to custom record that references an inactive parent', async () => {
+      const parentElement = getInstanceElement(customRecordType, true)
+      const childElementBefore = getInstanceElement(customRecordType, true)
+      const childElementAfter = getInstanceElement(customRecordType, true, parentElement)
+      const changeErrors = await inactiveParent(
+        [toChange({ before: childElementBefore, after: childElementAfter })],
+        undefined,
+        buildMockElementsSource([parentElement, childElementAfter], [parentElement])
+      )
+      expect(changeErrors).toHaveLength(0)
+    })
+
+    it('Should not have a change error when modifying to custom record\'s parent field to reference an inactive parent', async () => {
+      const parentElementActive = getInstanceElement(customRecordType, false)
+      const parentElementInactive = getInstanceElement(customRecordType, true)
+      const childElementBefore = getInstanceElement(customRecordType, true, parentElementActive)
+      const childElementAfter = getInstanceElement(customRecordType, true, parentElementInactive)
+      const changeErrors = await inactiveParent(
+        [toChange({ before: childElementBefore, after: childElementAfter })],
+        undefined,
+        buildMockElementsSource(
+          [parentElementActive, parentElementInactive, childElementAfter],
+          [parentElementActive, parentElementInactive]
+        )
+      )
+      expect(changeErrors).toHaveLength(0)
+    })
+  })
+})

--- a/packages/netsuite-adapter/test/change_validators/inactive_parent.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/inactive_parent.test.ts
@@ -13,195 +13,159 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ElemID, InstanceElement, ObjectType, ReadOnlyElementsSource, ReferenceExpression, Values, toChange, Element } from '@salto-io/adapter-api'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { isDefined } from '@salto-io/lowerdash/src/values'
+import { ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
 import inactiveParent from '../../src/change_validators/inactive_parent'
 import { CUSTOM_RECORD_TYPE, METADATA_TYPE, NETSUITE, SOAP } from '../../src/constants'
 
 describe('Inactive parent validator', () => {
-  const dataElementType = new ObjectType({
-    elemID: new ElemID(NETSUITE, 'test'),
-    annotations: {
-      source: SOAP,
-    },
-  })
-
-  const getIDToIsInactive = (instances: readonly InstanceElement[]): Map<string, boolean> =>
-    new Map(instances
-      .map(instance =>
-        [instance.elemID.createNestedID('isInactive').getFullName(),
-          instance.value.isInactive]))
-
-  const buildMockElementsSource = (
-    elements: readonly Element[],
-    parents?: InstanceElement[]
-  ): ReadOnlyElementsSource => {
-    const idToIsInactive = isDefined(parents) ? getIDToIsInactive(parents) : new Map()
-    const elementSource = buildElementsSourceFromElements(elements)
-
-    const mockGet = jest.fn().mockImplementation((id: ElemID) =>
-      idToIsInactive.get(id.getFullName()) ?? elementSource.get(id))
-    const mockElementsSource = {
-      list: elementSource.list,
-      getAll: elementSource.getAll,
-      has: elementSource.has,
-      get: mockGet,
-    } as unknown as ReadOnlyElementsSource
-
-    return mockElementsSource
-  }
-
-  const getInstanceElement = (
-    type: ObjectType,
-    isInactive: boolean | undefined,
-    parent?: InstanceElement
-  ): InstanceElement => {
-    const value: Values = isDefined(parent) ? {
-      isInactive,
-      parent: new ReferenceExpression(parent.elemID, parent),
-    } : {
-      isInactive,
-    }
-
-    return new InstanceElement(`test ${isInactive}`, type, value)
-  }
-
-  describe('Add new element', () => {
-    it('Should not have a change error when adding a new element without a parent', async () => {
-      const element = getInstanceElement(dataElementType, true)
-      const changeErrors = await inactiveParent(
-        [toChange({ after: element })],
-        undefined,
-        buildMockElementsSource([element])
-      )
-      expect(changeErrors).toHaveLength(0)
+  describe('Data element type', () => {
+    const dataElementType = new ObjectType({
+      elemID: new ElemID(NETSUITE, 'test'),
+      annotations: {
+        source: SOAP,
+      },
     })
 
-    it('Should not have a change error when adding a new element with an active parent', async () => {
-      const parentElement = getInstanceElement(dataElementType, false)
-      const childElement = getInstanceElement(dataElementType, false, parentElement)
-      const changeErrors = await inactiveParent(
-        [toChange({ after: childElement })],
-        undefined,
-        buildMockElementsSource(
-          [childElement, parentElement]
-        )
-      )
-      expect(changeErrors).toHaveLength(0)
-    })
+    const inactiveInstanceWithoutParent = new InstanceElement('testInactiveInstanceWithoutParent', dataElementType, { isInactive: true })
+    const activeInstanceWithoutParent = new InstanceElement('testActiveInstanceWithoutParent', dataElementType, { isInactive: false })
+    const inactiveInstanceWithActiveParent = new InstanceElement(
+      'testInactiveInstanceWithoutParent',
+      dataElementType,
+      {
+        isInactive: true,
+        parent: new ReferenceExpression(activeInstanceWithoutParent.elemID, activeInstanceWithoutParent),
+      },
+    )
+    const inactiveInstanceWithInactiveParent = new InstanceElement(
+      'testInactiveInstanceWithoutParent',
+      dataElementType,
+      {
+        isInactive: true,
+        parent: new ReferenceExpression(inactiveInstanceWithoutParent.elemID, inactiveInstanceWithoutParent),
+      },
+    )
+    const activeInstanceWithActiveParent = new InstanceElement(
+      'testInactiveInstanceWithoutParent',
+      dataElementType,
+      {
+        isInactive: false,
+        parent: new ReferenceExpression(activeInstanceWithoutParent.elemID, activeInstanceWithoutParent),
+      },
+    )
+    const activeInstanceWithInactiveParent = new InstanceElement(
+      'testInactiveInstanceWithoutParent',
+      dataElementType,
+      {
+        isInactive: false,
+        parent: new ReferenceExpression(inactiveInstanceWithoutParent.elemID, inactiveInstanceWithoutParent),
+      },
+    )
 
-    it('Should have a change error when adding a new element with an inactive parent', async () => {
-      const parentElement = getInstanceElement(dataElementType, true)
-      const childElement = getInstanceElement(dataElementType, true, parentElement)
-      const changeErrors = await inactiveParent(
-        [toChange({ after: childElement })],
-        undefined,
-        buildMockElementsSource([parentElement, childElement], [parentElement])
-      )
-      expect(changeErrors).toHaveLength(1)
-      expect(changeErrors[0].severity).toEqual('Error')
-      expect(changeErrors[0].elemID).toBe(childElement.elemID)
-    })
-  })
-
-  describe('Modify existing element', () => {
-    describe('Modify isInactive field', () => {
-      it('Should not have a change error when modifying isInactive field of an element without a parent', async () => {
-        const elementBefore = getInstanceElement(dataElementType, false)
-        const elementAfter = getInstanceElement(dataElementType, true)
+    describe('Add new element', () => {
+      it('Should not have a change error when adding a new element without a parent', async () => {
         const changeErrors = await inactiveParent(
-          [toChange({ before: elementBefore, after: elementAfter })],
-          undefined,
-          buildMockElementsSource([elementAfter])
-        )
-        expect(changeErrors).toHaveLength(0)
-      })
-
-      it('Should not have a change error when modifying isInactive field of an element with an active parent', async () => {
-        const parentElement = getInstanceElement(dataElementType, false)
-        const childElementBefore = getInstanceElement(dataElementType, true, parentElement)
-        const childElementAfter = getInstanceElement(dataElementType, false, parentElement)
-        const changeErrors = await inactiveParent(
-          [toChange({ before: childElementBefore, after: childElementAfter })],
-          undefined,
-          buildMockElementsSource([parentElement, childElementAfter], [parentElement])
+          [toChange({ after: activeInstanceWithoutParent })]
         )
         expect(changeErrors).toHaveLength(0)
       })
 
-      it('Should not have a change error when modifying isInactive field of an element with an inactive parent', async () => {
-        const parentElement = getInstanceElement(dataElementType, true)
-        const childElementBefore = getInstanceElement(dataElementType, true, parentElement)
-        const childElementAfter = getInstanceElement(dataElementType, false, parentElement)
+      it('Should not have a change error when adding a new element with an active parent', async () => {
         const changeErrors = await inactiveParent(
-          [toChange({ before: childElementBefore, after: childElementAfter })],
-          undefined,
-          buildMockElementsSource([parentElement, childElementAfter], [parentElement])
-        )
-        expect(changeErrors).toHaveLength(0)
-      })
-    })
-
-    describe('Modify parent field', () => {
-      it('Should not have a change error when removing parent field', async () => {
-        const parentElement = getInstanceElement(dataElementType, true)
-        const childElementBefore = getInstanceElement(dataElementType, true, parentElement)
-        const childElementAfter = getInstanceElement(dataElementType, true)
-        const changeErrors = await inactiveParent(
-          [toChange({ before: childElementBefore, after: childElementAfter })],
-          undefined,
-          buildMockElementsSource([parentElement, childElementAfter], [parentElement])
+          [toChange({ after: activeInstanceWithActiveParent })]
         )
         expect(changeErrors).toHaveLength(0)
       })
 
-      it('Should not have a change error when modifying parent field to reference an active parent', async () => {
-        const parentElementActive = getInstanceElement(dataElementType, false)
-        const parentElementInactive = getInstanceElement(dataElementType, true)
-        const childElementBefore = getInstanceElement(dataElementType, true, parentElementInactive)
-        const childElementAfter = getInstanceElement(dataElementType, true, parentElementActive)
+      it('Should have a change error when adding a new element with an inactive parent', async () => {
         const changeErrors = await inactiveParent(
-          [toChange({ before: childElementBefore, after: childElementAfter })],
-          undefined,
-          buildMockElementsSource(
-            [parentElementActive, parentElementInactive, childElementAfter],
-            [parentElementActive, parentElementInactive]
-          )
-        )
-        expect(changeErrors).toHaveLength(0)
-      })
-
-      it('Should have a change error when modifying parent field to reference an inactive parent', async () => {
-        const parentElementActive = getInstanceElement(dataElementType, false)
-        const parentElementInactive = getInstanceElement(dataElementType, true)
-        const childElementBefore = getInstanceElement(dataElementType, true, parentElementActive)
-        const childElementAfter = getInstanceElement(dataElementType, true, parentElementInactive)
-        const changeErrors = await inactiveParent(
-          [toChange({ before: childElementBefore, after: childElementAfter })],
-          undefined,
-          buildMockElementsSource(
-            [parentElementActive, parentElementInactive, childElementAfter],
-            [parentElementActive, parentElementInactive]
-          )
+          [toChange({ after: inactiveInstanceWithInactiveParent })]
         )
         expect(changeErrors).toHaveLength(1)
         expect(changeErrors[0].severity).toEqual('Error')
-        expect(changeErrors[0].elemID).toBe(childElementAfter.elemID)
+        expect(changeErrors[0].elemID).toBe(inactiveInstanceWithInactiveParent.elemID)
       })
     })
-  })
 
-  describe('Missing fields', () => {
-    it('Should not have a change error if isInactive field is undefined', async () => {
-      const parentElement = getInstanceElement(dataElementType, undefined)
-      const childElement = getInstanceElement(dataElementType, undefined, parentElement)
-      const changeErrors = await inactiveParent(
-        [toChange({ after: childElement })],
-        undefined,
-        buildMockElementsSource([parentElement, childElement], [parentElement])
-      )
-      expect(changeErrors).toHaveLength(0)
+    describe('Modify existing element', () => {
+      describe('Modify isInactive field', () => {
+        it('Should not have a change error when modifying isInactive field of an element without a parent', async () => {
+          const changeErrors = await inactiveParent(
+            [toChange({ before: activeInstanceWithoutParent, after: inactiveInstanceWithoutParent })]
+          )
+          expect(changeErrors).toHaveLength(0)
+        })
+
+        it('Should not have a change error when modifying isInactive field of an element with an active parent', async () => {
+          const changeErrors = await inactiveParent(
+            [toChange({ before: inactiveInstanceWithActiveParent, after: activeInstanceWithActiveParent })]
+          )
+          expect(changeErrors).toHaveLength(0)
+        })
+
+        it('Should not have a change error when modifying isInactive field of an element with an inactive parent', async () => {
+          const changeErrors = await inactiveParent(
+            [toChange({ before: inactiveInstanceWithInactiveParent, after: activeInstanceWithInactiveParent })]
+          )
+          expect(changeErrors).toHaveLength(0)
+        })
+      })
+
+      describe('Modify parent field', () => {
+        it('Should not have a change error when removing parent field', async () => {
+          const changeErrors = await inactiveParent(
+            [toChange({ before: activeInstanceWithActiveParent, after: activeInstanceWithoutParent })]
+          )
+          expect(changeErrors).toHaveLength(0)
+        })
+
+        it('Should not have a change error when modifying parent field to reference an active parent', async () => {
+          const changeErrors = await inactiveParent(
+            [toChange({ before: inactiveInstanceWithoutParent, after: inactiveInstanceWithActiveParent })]
+          )
+          expect(changeErrors).toHaveLength(0)
+        })
+
+        it('Should have a change error when modifying parent field to reference an inactive parent', async () => {
+          const changeErrors = await inactiveParent(
+            [toChange({ before: inactiveInstanceWithoutParent, after: inactiveInstanceWithInactiveParent })]
+          )
+          expect(changeErrors).toHaveLength(1)
+          expect(changeErrors[0].severity).toEqual('Error')
+          expect(changeErrors[0].elemID).toBe(inactiveInstanceWithInactiveParent.elemID)
+        })
+      })
+    })
+
+    describe('Unexpected field value', () => {
+      it('Should not have a change error if isInactive field is undefined', async () => {
+        const parentElement = new InstanceElement('parentElement', dataElementType)
+        const childElement = new InstanceElement(
+          'testChildElement',
+          dataElementType,
+          {
+            parent: new ReferenceExpression(parentElement.elemID, parentElement),
+          },
+        )
+        const changeErrors = await inactiveParent(
+          [toChange({ after: childElement })]
+        )
+        expect(changeErrors).toHaveLength(0)
+      })
+
+      it('Sanity - Should not crash and should not have a change error if parent field is not a reference expression', async () => {
+        const childElement = new InstanceElement(
+          'testChildElement',
+          dataElementType,
+          {
+            isInactive: true,
+            parent: 'I Am Your Father.',
+          },
+        )
+        const changeErrors = await inactiveParent(
+          [toChange({ after: childElement })]
+        )
+        expect(changeErrors).toHaveLength(0)
+      })
     })
   })
 
@@ -214,30 +178,35 @@ describe('Inactive parent validator', () => {
       },
     })
 
+    const inactiveInstanceWithoutParent = new InstanceElement('testInactiveInstanceWithoutParent', customRecordType, { isInactive: true })
+    const activeInstanceWithoutParent = new InstanceElement('testActiveInstanceWithoutParent', customRecordType, { isInactive: false })
+    const inactiveInstanceWithActiveParent = new InstanceElement(
+      'testInactiveInstanceWithoutParent',
+      customRecordType,
+      {
+        isInactive: true,
+        parent: new ReferenceExpression(activeInstanceWithoutParent.elemID, activeInstanceWithoutParent),
+      },
+    )
+    const inactiveInstanceWithInactiveParent = new InstanceElement(
+      'testInactiveInstanceWithoutParent',
+      customRecordType,
+      {
+        isInactive: true,
+        parent: new ReferenceExpression(inactiveInstanceWithoutParent.elemID, inactiveInstanceWithoutParent),
+      },
+    )
+
     it('Should not have a change error when adding parent field to custom record that references an inactive parent', async () => {
-      const parentElement = getInstanceElement(customRecordType, true)
-      const childElementBefore = getInstanceElement(customRecordType, true)
-      const childElementAfter = getInstanceElement(customRecordType, true, parentElement)
       const changeErrors = await inactiveParent(
-        [toChange({ before: childElementBefore, after: childElementAfter })],
-        undefined,
-        buildMockElementsSource([parentElement, childElementAfter], [parentElement])
+        [toChange({ before: inactiveInstanceWithoutParent, after: inactiveInstanceWithInactiveParent })]
       )
       expect(changeErrors).toHaveLength(0)
     })
 
     it('Should not have a change error when modifying to custom record\'s parent field to reference an inactive parent', async () => {
-      const parentElementActive = getInstanceElement(customRecordType, false)
-      const parentElementInactive = getInstanceElement(customRecordType, true)
-      const childElementBefore = getInstanceElement(customRecordType, true, parentElementActive)
-      const childElementAfter = getInstanceElement(customRecordType, true, parentElementInactive)
       const changeErrors = await inactiveParent(
-        [toChange({ before: childElementBefore, after: childElementAfter })],
-        undefined,
-        buildMockElementsSource(
-          [parentElementActive, parentElementInactive, childElementAfter],
-          [parentElementActive, parentElementInactive]
-        )
+        [toChange({ before: inactiveInstanceWithActiveParent, after: inactiveInstanceWithInactiveParent })]
       )
       expect(changeErrors).toHaveLength(0)
     })


### PR DESCRIPTION
Add change validator to throw an error when assigning an inactive parent to data element.

---

_Additional context for reviewer_

Currently deployment fails on NetSuite when modifying a parent field to reference an inactive parent.
The new validator

---
_Release Notes_: 

NetSuite adapter:
- Change validator will throw an error when trying to deploy assignment of inactive parent to a data element.

---
_User Notifications_: 
None
