### PR TITLE
SAAS-7574: Paths of invalid config nacls are not returned

### DIFF
--- a/packages/workspace/src/workspace/adapters_config_source.ts
+++ b/packages/workspace/src/workspace/adapters_config_source.ts
@@ -23,6 +23,7 @@ import { mergeSingleElement } from '../merger'
 import { serialize } from '../serializer'
 import { deserializeValidationErrors } from '../serializer/elements'
 import { validateElements, ValidationError } from '../validator'
+import { DirectoryStore } from './dir_store'
 import { Errors } from './errors'
 import { NaclFilesSource } from './nacl_files'
 import { RemoteMap, RemoteMapCreator } from './remote_map'
@@ -68,6 +69,7 @@ const updateValidationErrorsCache = async (
 
 export type AdaptersConfigSourceArgs = {
   naclSource: NaclFilesSource
+  naclFilesStore: DirectoryStore<string>
   ignoreFileChanges: boolean
   remoteMapCreator: RemoteMapCreator
   persistent: boolean
@@ -99,6 +101,7 @@ export const calculateAdditionalConfigTypes = async (
 
 export const buildAdaptersConfigSource = async ({
   naclSource,
+  naclFilesStore,
   ignoreFileChanges,
   remoteMapCreator,
   persistent,
@@ -233,7 +236,7 @@ export const buildAdaptersConfigSource = async ({
       }
       await updateValidationErrorsCache(validationErrorsMap, elementsSource, naclSource)
     },
-    getElementNaclFiles: async adapter => (await naclSource.listNaclFiles())
+    getElementNaclFiles: async adapter => (await naclFilesStore.list())
       .filter(filePath => filePath.startsWith(path.join(...CONFIG_PATH, adapter).concat(path.sep))),
 
     getErrors: async () => {

--- a/packages/workspace/test/workspace/adapters_config.test.ts
+++ b/packages/workspace/test/workspace/adapters_config.test.ts
@@ -26,6 +26,8 @@ import { createMockNaclFileSource } from '../common/nacl_file_source'
 import { ParseError } from '../../src/parser'
 import { DuplicateAnnotationError } from '../../src/merger'
 import { Errors } from '../../src/errors'
+import { DirectoryStore } from '../../src/workspace/dir_store'
+import { mockDirStore } from '../common/nacl_file_store'
 
 const { awu } = collections.asynciterable
 
@@ -35,12 +37,15 @@ describe('adapters config', () => {
   let mockNaclFilesSource: MockInterface<NaclFilesSource>
   let configSource: AdaptersConfigSource
   let validationErrorsMap: MockInterface<RemoteMap<ValidationError[]>>
+  let mockNaclFilesStore: MockInterface<DirectoryStore<string>>
 
   const configType = new ObjectType({ elemID: new ElemID(SALESFORCE, ElemID.CONFIG_NAME) })
 
   beforeEach(async () => {
     jest.resetAllMocks()
     mockNaclFilesSource = createMockNaclFileSource([])
+
+    mockNaclFilesStore = mockDirStore()
 
     mockNaclFilesSource.get.mockResolvedValue(new InstanceElement(
       ElemID.CONFIG_NAME,
@@ -109,6 +114,7 @@ describe('adapters config', () => {
       ignoreFileChanges: false,
       remoteMapCreator: mockFunction<RemoteMapCreator>().mockResolvedValue(validationErrorsMap),
       persistent: true,
+      naclFilesStore: mockNaclFilesStore,
       configTypes: [configType],
       configOverrides,
     })
@@ -124,6 +130,7 @@ describe('adapters config', () => {
         ignoreFileChanges: true,
         remoteMapCreator: jest.fn().mockResolvedValue(validationErrorsMap),
         persistent: true,
+        naclFilesStore: mockNaclFilesStore,
         configTypes: [configType],
         configOverrides: [],
       })
@@ -138,6 +145,7 @@ describe('adapters config', () => {
         ignoreFileChanges: true,
         remoteMapCreator: jest.fn().mockResolvedValue(validationErrorsMap),
         persistent: true,
+        naclFilesStore: mockNaclFilesStore,
         configTypes: [configType],
         configOverrides: [],
       })
@@ -215,7 +223,7 @@ describe('adapters config', () => {
   })
 
   it('getElementNaclFiles should return the configuration files', async () => {
-    mockNaclFilesSource.listNaclFiles.mockResolvedValue(['salto.config/adapters/salesforce/a/b', 'salto.config/adapters/salesforce/c', 'salto.config/adapters/dummy/d'])
+    mockNaclFilesStore.list.mockResolvedValue(['salto.config/adapters/salesforce/a/b', 'salto.config/adapters/salesforce/c', 'salto.config/adapters/dummy/d'])
     const paths = await configSource.getElementNaclFiles('salesforce')
     expect(paths).toEqual(['salto.config/adapters/salesforce/a/b', 'salto.config/adapters/salesforce/c'])
   })


### PR DESCRIPTION
We have a problem in the `getElementNaclFiles` that if a user has a syntax error in his config nacl, he won't get its path.

---

Fixed to use the dirstore `list()` to get the config files so we will get also files with errors.
dirstore `list()` return all the files ends with`.nacl` and not only the valid ones

The changes in the signature of `buildAdaptersConfigSource` breaks the SaaS build so I will need to create a PR also in the SaaS.

---
_Release Notes_: 
__Core__:
- Fixed a bug where paths of config files in a syntax error would not be returned in `getElementNaclFiles`

---
_User Notifications_: 
None