### PR TITLE
SALTO-4029 correctly support async lookup functions

### DIFF
--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -17,6 +17,7 @@ import _ from 'lodash'
 import { isInstanceElement, isReferenceExpression } from '@salto-io/adapter-api'
 import { references as referenceUtils } from '@salto-io/adapter-components'
 import { GetLookupNameFunc } from '@salto-io/adapter-utils'
+import { collections } from '@salto-io/lowerdash'
 import { AUTOMATION_PROJECT_TYPE, AUTOMATION_FIELD, AUTOMATION_COMPONENT_VALUE_TYPE,
   BOARD_ESTIMATION_TYPE, ISSUE_TYPE_NAME, ISSUE_TYPE_SCHEMA_NAME, AUTOMATION_STATUS,
   AUTOMATION_CONDITION, AUTOMATION_CONDITION_CRITERIA, AUTOMATION_SUBTASK,
@@ -26,6 +27,7 @@ import { getFieldsLookUpName } from './filters/fields/field_type_references_filt
 import { getRefType } from './references/workflow_properties'
 import { FIELD_TYPE_NAME } from './filters/fields/constants'
 
+const { awu } = collections.asynciterable
 const { neighborContextGetter, basicLookUp } = referenceUtils
 
 const neighborContextFunc = (args: {
@@ -757,7 +759,7 @@ const lookupNameFuncs: GetLookupNameFunc[] = [
 ]
 
 export const getLookUpName: GetLookupNameFunc = async args => (
-  lookupNameFuncs
+  awu(lookupNameFuncs)
     .map(lookupFunc => lookupFunc(args))
     .find(res => !isReferenceExpression(res))
 )

--- a/packages/okta-adapter/src/reference_mapping.ts
+++ b/packages/okta-adapter/src/reference_mapping.ts
@@ -17,7 +17,10 @@ import _ from 'lodash'
 import { isReferenceExpression } from '@salto-io/adapter-api'
 import { references as referenceUtils } from '@salto-io/adapter-components'
 import { GetLookupNameFunc } from '@salto-io/adapter-utils'
+import { collections } from '@salto-io/lowerdash'
 import { APPLICATION_TYPE_NAME, GROUP_TYPE_NAME, IDENTITY_PROVIDER_TYPE_NAME, USERTYPE_TYPE_NAME, FEATURE_TYPE_NAME, NETWORK_ZONE_TYPE_NAME, ROLE_TYPE_NAME, ACCESS_POLICY_TYPE_NAME, PROFILE_ENROLLMENT_POLICY_TYPE_NAME, INLINE_HOOK_TYPE_NAME, AUTHENTICATOR_TYPE_NAME, BEHAVIOR_RULE_TYPE_NAME } from './constants'
+
+const { awu } = collections.asynciterable
 
 export const OktaMissingReferenceStrategyLookup: Record<
 referenceUtils.MissingReferenceStrategyName, referenceUtils.MissingReferenceStrategy
@@ -190,7 +193,7 @@ const lookupNameFuncs: GetLookupNameFunc[] = [
 ]
 
 export const getLookUpName: GetLookupNameFunc = async args => (
-  lookupNameFuncs
+  awu(lookupNameFuncs)
     .map(lookupFunc => lookupFunc(args))
     .find(res => !isReferenceExpression(res))
 )


### PR DESCRIPTION
Fix for a theoretical bug - we were assuming all lookup functions were sync (which they currently are, but are not required to be)

---
_Release Notes_: 
None

---
_User Notifications_: 
None