### PR TITLE
SALTO-3805: Profile attribute references

### DIFF
--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -41,6 +41,7 @@ import defaultPolicyRuleDeployment from './filters/default_rule_deployment'
 import policyRuleRemoval from './filters/policy_rule_removal'
 import authorizationRuleFilter from './filters/authorization_server_rule'
 import privateApiDeployFilter from './filters/private_api_deploy'
+import profileEnrollmentAttributesFilter from './filters/profile_enrollment_attributes'
 import userFilter from './filters/user'
 import { OKTA } from './constants'
 import { getLookUpName } from './reference_mapping'
@@ -68,6 +69,7 @@ export const DEFAULT_FILTERS = [
   replaceObjectWithIdFilter,
   userFilter,
   oktaExpressionLanguageFilter,
+  profileEnrollmentAttributesFilter,
   fieldReferencesFilter,
   groupDeploymentFilter,
   // should run before appDeploymentFilter and after after userSchemaFilter

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -1076,6 +1076,11 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
       },
     },
   },
+  ProfileEnrollmentPolicyRuleProfileAttribute: {
+    transformation: {
+      fieldTypeOverrides: [{ fieldName: 'name', fieldType: 'unknown' }],
+    },
+  },
 }
 
 const DEFAULT_SWAGGER_CONFIG: OktaSwaggerApiConfig['swagger'] = {

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -1078,7 +1078,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
   },
   ProfileEnrollmentPolicyRuleProfileAttribute: {
     transformation: {
-      fieldTypeOverrides: [{ fieldName: 'name', fieldType: 'unknown' }],
+      fieldTypeOverrides: [{ fieldName: 'name', fieldType: 'UserSchemaAttribute' }],
     },
   },
 }

--- a/packages/okta-adapter/src/filters/expression_language.ts
+++ b/packages/okta-adapter/src/filters/expression_language.ts
@@ -84,10 +84,7 @@ export const resolveUserSchemaRef = (ref: ReferenceExpression): string | undefin
     (topLevelParentId.createNestedID(...USER_SCHEMA_CUSTOM_PATH).isEqual(parentId))
       || (topLevelParentId.createNestedID(...USER_SCHEMA_BASE_PATH).isEqual(parentId))
   ) {
-    const userSchemaField = ref.elemID.getFullNameParts().pop()
-    if (_.isString(userSchemaField)) {
-      return userSchemaField
-    }
+    return ref.elemID.name
   }
   log.error(`Received an invalid reference for ${USER_SCHEMA_TYPE_NAME} attribute: ${ref.elemID.getFullName()}`)
   return undefined

--- a/packages/okta-adapter/src/filters/expression_language.ts
+++ b/packages/okta-adapter/src/filters/expression_language.ts
@@ -77,7 +77,7 @@ export const getUserSchemaReference = (
   return undefined
 }
 
-export const resolveUserSchemaRef = (ref: ReferenceExpression): string => {
+export const resolveUserSchemaRef = (ref: ReferenceExpression): string | undefined => {
   const topLevelParentId = ref.elemID.createTopLevelParentID().parent
   const parentId = ref.elemID.createParentID()
   if (
@@ -89,14 +89,17 @@ export const resolveUserSchemaRef = (ref: ReferenceExpression): string => {
       return userSchemaField
     }
   }
-  throw new Error(`Received an invalid reference for ${USER_SCHEMA_TYPE_NAME} attribute: ${ref.elemID.getFullName()}`)
+  log.error(`Received an invalid reference for ${USER_SCHEMA_TYPE_NAME} attribute: ${ref.elemID.getFullName()}`)
+  return undefined
 }
 
 const createPrepRefFunc = (isIdentityEngine: boolean):(part: ReferenceExpression) => TemplatePart => {
   const prepRef = (part: ReferenceExpression): TemplatePart => {
     if (part.elemID.typeName === USER_SCHEMA_TYPE_NAME) {
       const userSchemaField = resolveUserSchemaRef(part)
-      return `${isIdentityEngine ? USER_SCHEMA_IE_PREFIX : USER_SCHEMA_PREFIX}${userSchemaField}`
+      if (userSchemaField !== undefined) {
+        return `${isIdentityEngine ? USER_SCHEMA_IE_PREFIX : USER_SCHEMA_PREFIX}${userSchemaField}`
+      }
     }
     if (part.elemID.typeName === BEHAVIOR_RULE_TYPE_NAME) {
       // references to BehaviorRule are by name

--- a/packages/okta-adapter/src/filters/profile_enrollment_attributes.ts
+++ b/packages/okta-adapter/src/filters/profile_enrollment_attributes.ts
@@ -1,0 +1,70 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Element, ReferenceExpression, isInstanceElement } from '@salto-io/adapter-api'
+import { resolvePath } from '@salto-io/adapter-utils'
+import { references as referencesUtils } from '@salto-io/adapter-components'
+import _ from 'lodash'
+import { logger } from '@salto-io/logging'
+import { FilterCreator } from '../filter'
+import { OKTA, PROFILE_ENROLLMENT_RULE_TYPE_NAME, USER_SCHEMA_TYPE_NAME } from '../constants'
+import { getUserSchemaReference } from './expression_language'
+
+const log = logger(module)
+const { createMissingInstance } = referencesUtils
+
+const PROFILE_ATTRIBUTES_PATH = ['actions', 'profileEnrollment', 'profileAttributes']
+
+/**
+* Add references for UserSchema attributes from ProfileEnrollmentPolicyRule
+*/
+const filterCreator: FilterCreator = () => ({
+  name: 'profileEnrollmentAttributesFilter',
+  onFetch: async (elements: Element[]) => {
+    const instances = elements.filter(isInstanceElement)
+    const profileEnrollmentRules = instances
+      .filter(instance => instance.elemID.typeName === PROFILE_ENROLLMENT_RULE_TYPE_NAME)
+    const defaultUserSchema = instances
+      .filter(instance => instance.elemID.typeName === USER_SCHEMA_TYPE_NAME)
+      .find(instance => instance.elemID.name === 'user')
+    if (defaultUserSchema === undefined) {
+      log.error('Could not find the default UserSchema instance, skipping profileEnrollmentAttributesFilter')
+      return
+    }
+
+    profileEnrollmentRules.forEach(rule => {
+      const profileAttributes = resolvePath(rule, rule.elemID.createNestedID(...PROFILE_ATTRIBUTES_PATH))
+      if (!Array.isArray(profileAttributes)) {
+        return
+      }
+      profileAttributes.forEach(att => {
+        const { name } = att
+        if (!_.isString(name)) {
+          return
+        }
+        const userSchemaRef = getUserSchemaReference(name, defaultUserSchema)
+        if (userSchemaRef !== undefined) {
+          att.name = userSchemaRef
+        } else {
+          // create missing reference
+          const missingInstance = createMissingInstance(OKTA, USER_SCHEMA_TYPE_NAME, name)
+          att.name = new ReferenceExpression(missingInstance.elemID, missingInstance)
+        }
+      })
+    })
+  },
+})
+
+export default filterCreator

--- a/packages/okta-adapter/src/filters/profile_enrollment_attributes.ts
+++ b/packages/okta-adapter/src/filters/profile_enrollment_attributes.ts
@@ -13,17 +13,15 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Element, ReferenceExpression, isInstanceElement } from '@salto-io/adapter-api'
+import { Element, isInstanceElement } from '@salto-io/adapter-api'
 import { resolvePath } from '@salto-io/adapter-utils'
-import { references as referencesUtils } from '@salto-io/adapter-components'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
-import { OKTA, PROFILE_ENROLLMENT_RULE_TYPE_NAME, USER_SCHEMA_TYPE_NAME } from '../constants'
+import { PROFILE_ENROLLMENT_RULE_TYPE_NAME, USER_SCHEMA_TYPE_NAME } from '../constants'
 import { getUserSchemaReference } from './expression_language'
 
 const log = logger(module)
-const { createMissingInstance } = referencesUtils
 
 const PROFILE_ATTRIBUTES_PATH = ['actions', 'profileEnrollment', 'profileAttributes']
 
@@ -53,15 +51,12 @@ const filterCreator: FilterCreator = () => ({
       profileAttributes.forEach(att => {
         const { name } = att
         if (!_.isString(name)) {
+          log.warn(`Unexpected name field in profileAttributes for instance: ${rule.elemID.getFullName()}`)
           return
         }
         const userSchemaRef = getUserSchemaReference(name, defaultUserSchema)
         if (userSchemaRef !== undefined) {
           att.name = userSchemaRef
-        } else {
-          // create missing reference
-          const missingInstance = createMissingInstance(OKTA, USER_SCHEMA_TYPE_NAME, name)
-          att.name = new ReferenceExpression(missingInstance.elemID, missingInstance)
         }
       })
     })

--- a/packages/okta-adapter/src/filters/profile_enrollment_attributes.ts
+++ b/packages/okta-adapter/src/filters/profile_enrollment_attributes.ts
@@ -47,6 +47,7 @@ const filterCreator: FilterCreator = () => ({
     profileEnrollmentRules.forEach(rule => {
       const profileAttributes = resolvePath(rule, rule.elemID.createNestedID(...PROFILE_ATTRIBUTES_PATH))
       if (!Array.isArray(profileAttributes)) {
+        log.warn(`Can not create references from instance ${rule.elemID.getFullName()} to user schema attributes`)
         return
       }
       profileAttributes.forEach(att => {

--- a/packages/okta-adapter/src/reference_mapping.ts
+++ b/packages/okta-adapter/src/reference_mapping.ts
@@ -196,12 +196,8 @@ const userSchemaLookUpFunc: GetLookupNameFunc = async ({ ref }) => {
   if (ref.elemID.typeName !== USER_SCHEMA_TYPE_NAME) {
     return ref
   }
-  try {
-    const userSchemaField = resolveUserSchemaRef(ref)
-    return userSchemaField
-  } catch (e) {
-    return undefined
-  }
+  const userSchemaField = resolveUserSchemaRef(ref)
+  return userSchemaField ?? ref
 }
 
 const lookupNameFuncs: GetLookupNameFunc[] = [

--- a/packages/okta-adapter/src/reference_mapping.ts
+++ b/packages/okta-adapter/src/reference_mapping.ts
@@ -18,7 +18,8 @@ import { isReferenceExpression } from '@salto-io/adapter-api'
 import { references as referenceUtils } from '@salto-io/adapter-components'
 import { GetLookupNameFunc } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
-import { APPLICATION_TYPE_NAME, GROUP_TYPE_NAME, IDENTITY_PROVIDER_TYPE_NAME, USERTYPE_TYPE_NAME, FEATURE_TYPE_NAME, NETWORK_ZONE_TYPE_NAME, ROLE_TYPE_NAME, ACCESS_POLICY_TYPE_NAME, PROFILE_ENROLLMENT_POLICY_TYPE_NAME, INLINE_HOOK_TYPE_NAME, AUTHENTICATOR_TYPE_NAME, BEHAVIOR_RULE_TYPE_NAME } from './constants'
+import { APPLICATION_TYPE_NAME, GROUP_TYPE_NAME, IDENTITY_PROVIDER_TYPE_NAME, USERTYPE_TYPE_NAME, FEATURE_TYPE_NAME, NETWORK_ZONE_TYPE_NAME, ROLE_TYPE_NAME, ACCESS_POLICY_TYPE_NAME, PROFILE_ENROLLMENT_POLICY_TYPE_NAME, INLINE_HOOK_TYPE_NAME, AUTHENTICATOR_TYPE_NAME, BEHAVIOR_RULE_TYPE_NAME, USER_SCHEMA_TYPE_NAME } from './constants'
+import { resolveUserSchemaRef } from './filters/expression_language'
 
 const { awu } = collections.asynciterable
 
@@ -190,7 +191,21 @@ export const referencesRules: OktaFieldReferenceDefinition[] = [
   },
 ]
 
+// Resolve references to userSchema fields references to field name instead of full value
+const userSchemaLookUpFunc: GetLookupNameFunc = async ({ ref }) => {
+  if (ref.elemID.typeName !== USER_SCHEMA_TYPE_NAME) {
+    return ref
+  }
+  try {
+    const userSchemaField = resolveUserSchemaRef(ref)
+    return userSchemaField
+  } catch (e) {
+    return undefined
+  }
+}
+
 const lookupNameFuncs: GetLookupNameFunc[] = [
+  userSchemaLookUpFunc,
   // The second param is needed to resolve references by oktaSerializationStrategy
   referenceUtils.generateLookupFunc(referencesRules, defs => new OktaFieldReferenceResolver(defs)),
 ]

--- a/packages/okta-adapter/test/filters/expression_language.test.ts
+++ b/packages/okta-adapter/test/filters/expression_language.test.ts
@@ -28,7 +28,7 @@ describe('expression language filter', () => {
       const groupRuleType = new ObjectType({ elemID: new ElemID(OKTA, GROUP_RULE_TYPE_NAME) })
       const policyRuleType = new ObjectType({ elemID: new ElemID(OKTA, ACCESS_POLICY_RULE_TYPE_NAME) })
       const behaviorType = new ObjectType({ elemID: new ElemID(OKTA, BEHAVIOR_RULE_TYPE_NAME) })
-      const customPath = ['definitions', 'custom', 'properties', 'additionalProperties', 'saltoDepartment']
+      const customPath = ['definitions', 'custom', 'properties', 'saltoDepartment']
       const basePath = ['definitions', 'base', 'properties', 'department']
       const groupRuleWithExpression = new InstanceElement(
         'groupRuleTest',
@@ -54,11 +54,9 @@ describe('expression language filter', () => {
           definitions: {
             custom: {
               properties: {
-                additionalProperties: {
-                  saltoDepartment: {
-                    title: 'salto',
-                    type: 'string',
-                  },
+                saltoDepartment: {
+                  title: 'salto',
+                  type: 'string',
                 },
               },
             },

--- a/packages/okta-adapter/test/filters/profile_enrollment_attributes.test.ts
+++ b/packages/okta-adapter/test/filters/profile_enrollment_attributes.test.ts
@@ -1,0 +1,116 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { ObjectType, ElemID, InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
+import { filterUtils, references as referencesUtils } from '@salto-io/adapter-components'
+import { OKTA, PROFILE_ENROLLMENT_RULE_TYPE_NAME, USER_SCHEMA_TYPE_NAME } from '../../src/constants'
+import profileEnrollmentAttributeFilter from '../../src/filters/profile_enrollment_attributes'
+import { getFilterParams } from '../utils'
+
+describe('profileEnrollmentAttributeFilter', () => {
+  let filter: filterUtils.FilterWith<'onFetch'>
+  const schemaType = new ObjectType({ elemID: new ElemID(OKTA, USER_SCHEMA_TYPE_NAME) })
+  const profileEnrollType = new ObjectType({ elemID: new ElemID(OKTA, PROFILE_ENROLLMENT_RULE_TYPE_NAME) })
+
+  const schemaInst = new InstanceElement(
+    'user',
+    schemaType,
+    {
+      name: 'user',
+      definitions: {
+        custom: {
+          properties: {
+            saltoDepartment: {
+              title: 'salto',
+              type: 'string',
+            },
+          },
+        },
+        base: {
+          properties: {
+            department: {
+              title: 'Department',
+              type: 'string',
+            },
+          },
+        },
+      },
+    }
+  )
+  const departmentRef = new ReferenceExpression(
+    schemaInst.elemID.createNestedID('definitions', 'base', 'properties', 'department'),
+    _.get(schemaInst.value, ['definitions', 'base', 'properties', 'department'])
+  )
+  const saltoDepRef = new ReferenceExpression(
+    schemaInst.elemID.createNestedID('definitions', 'custom', 'properties', 'saltoDepartment'),
+    _.get(schemaInst.value, ['definitions', 'custom', 'properties', 'saltoDepartment'])
+  )
+  const profileInst = new InstanceElement(
+    'profile',
+    profileEnrollType,
+    {
+      name: 'someRule',
+      actions: {
+        profileEnrollment: {
+          profileAttributes: [
+            { name: 'saltoDepartment', label: 'salto' },
+            { name: 'department', label: 'salto' },
+          ],
+        },
+      },
+    },
+  )
+  beforeEach(() => {
+    filter = profileEnrollmentAttributeFilter(getFilterParams()) as typeof filter
+  })
+
+  describe('onFetch', () => {
+    it('should replace profile enrollment attributes with references to user schema attributes', async () => {
+      const profile = profileInst.clone()
+      await filter.onFetch?.([schemaInst, schemaType, profileEnrollType, profile])
+      const atts = profile.value.actions?.profileEnrollment?.profileAttributes
+      expect(atts).toEqual([
+        { name: saltoDepRef, label: 'salto' },
+        { name: departmentRef, label: 'salto' },
+      ])
+    })
+    it('should create a missing reference for attributes that does not exist in the user schema', async () => {
+      const profileWithMissing = new InstanceElement(
+        'missing',
+        profileEnrollType,
+        {
+          name: 'someRule',
+          actions: {
+            profileEnrollment: {
+              profileAttributes: [
+                { name: 'saltoDepartment', label: 'salto' },
+                { name: 'missingProp', label: 'missing' },
+              ],
+            },
+          },
+        },
+      )
+      const missingAtt = referencesUtils.createMissingInstance(OKTA, USER_SCHEMA_TYPE_NAME, 'missingProp')
+
+      await filter.onFetch?.([schemaInst, schemaType, profileEnrollType, profileWithMissing])
+      const atts = profileWithMissing.value.actions?.profileEnrollment?.profileAttributes
+      expect(atts).toEqual([
+        { name: saltoDepRef, label: 'salto' },
+        { name: new ReferenceExpression(missingAtt.elemID, missingAtt), label: 'salto' },
+      ])
+    })
+  })
+})

--- a/packages/okta-adapter/test/filters/profile_enrollment_attributes.test.ts
+++ b/packages/okta-adapter/test/filters/profile_enrollment_attributes.test.ts
@@ -112,5 +112,30 @@ describe('profileEnrollmentAttributeFilter', () => {
         { name: new ReferenceExpression(missingAtt.elemID, missingAtt), label: 'missing' },
       ])
     })
+    it('should skip the filter for a rule with no profile attributes', async () => {
+      const profileNoAtt = new InstanceElement(
+        'missing',
+        profileEnrollType,
+        {
+          name: 'someRule',
+          actions: {
+            profileEnrollment: {
+              targetGroupIds: ['123', '234'],
+              unknownUserAction: 'DENY',
+            },
+          },
+        },
+      )
+      await filter.onFetch?.([schemaInst, schemaType, profileEnrollType, profileNoAtt])
+      expect(profileNoAtt.value).toEqual({
+        name: 'someRule',
+        actions: {
+          profileEnrollment: {
+            targetGroupIds: ['123', '234'],
+            unknownUserAction: 'DENY',
+          },
+        },
+      })
+    })
   })
 })

--- a/packages/okta-adapter/test/filters/profile_enrollment_attributes.test.ts
+++ b/packages/okta-adapter/test/filters/profile_enrollment_attributes.test.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import { ObjectType, ElemID, InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
-import { filterUtils, references as referencesUtils } from '@salto-io/adapter-components'
+import { filterUtils } from '@salto-io/adapter-components'
 import { OKTA, PROFILE_ENROLLMENT_RULE_TYPE_NAME, USER_SCHEMA_TYPE_NAME } from '../../src/constants'
 import profileEnrollmentAttributeFilter from '../../src/filters/profile_enrollment_attributes'
 import { getFilterParams } from '../utils'
@@ -85,31 +85,6 @@ describe('profileEnrollmentAttributeFilter', () => {
       expect(atts).toEqual([
         { name: saltoDepRef, label: 'salto' },
         { name: departmentRef, label: 'salto' },
-      ])
-    })
-    it('should create a missing reference for attributes that does not exist in the user schema', async () => {
-      const profileWithMissing = new InstanceElement(
-        'missing',
-        profileEnrollType,
-        {
-          name: 'someRule',
-          actions: {
-            profileEnrollment: {
-              profileAttributes: [
-                { name: 'saltoDepartment', label: 'salto' },
-                { name: 'missingProp', label: 'missing' },
-              ],
-            },
-          },
-        },
-      )
-      const missingAtt = referencesUtils.createMissingInstance(OKTA, USER_SCHEMA_TYPE_NAME, 'missingProp')
-
-      await filter.onFetch?.([schemaInst, schemaType, profileEnrollType, profileWithMissing])
-      const atts = profileWithMissing.value.actions?.profileEnrollment?.profileAttributes
-      expect(atts).toEqual([
-        { name: saltoDepRef, label: 'salto' },
-        { name: new ReferenceExpression(missingAtt.elemID, missingAtt), label: 'missing' },
       ])
     })
     it('should skip the filter for a rule with no profile attributes', async () => {

--- a/packages/okta-adapter/test/filters/profile_enrollment_attributes.test.ts
+++ b/packages/okta-adapter/test/filters/profile_enrollment_attributes.test.ts
@@ -109,7 +109,7 @@ describe('profileEnrollmentAttributeFilter', () => {
       const atts = profileWithMissing.value.actions?.profileEnrollment?.profileAttributes
       expect(atts).toEqual([
         { name: saltoDepRef, label: 'salto' },
-        { name: new ReferenceExpression(missingAtt.elemID, missingAtt), label: 'salto' },
+        { name: new ReferenceExpression(missingAtt.elemID, missingAtt), label: 'missing' },
       ])
     })
   })


### PR DESCRIPTION
Add references from `ProfileEnrollmentPolicyRule` to `UserSchema`

---

`ProfileEnrollmentPolicyRule` have a list of attributes required from the user in order to login. those attributes are taken from the default user `UserSchema`. Also, user can provide attributes that doesn't exist in the schema, Okta will allow it but Okta's UI will show an error, so in this case we add a missing reference.

This PR also fixes a bug in references to custom attributes in expression_language.ts filter 

---
_Release Notes_: 
None

---
_User Notifications_: 
None