### PR TITLE
SALTO-3883: Verify user is not trying to deactivate assigned AccessPolicy instances

### DIFF
--- a/packages/okta-adapter/src/change_validators/assigned_policies.ts
+++ b/packages/okta-adapter/src/change_validators/assigned_policies.ts
@@ -1,0 +1,61 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { ChangeValidator, getChangeData, isInstanceChange, isAdditionOrModificationChange, isInstanceElement, isReferenceExpression, ReferenceExpression } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { logger } from '@salto-io/logging'
+import { ACCESS_POLICY_TYPE_NAME, APPLICATION_TYPE_NAME, INACTIVE_STATUS } from '../constants'
+
+const { awu } = collections.asynciterable
+const log = logger(module)
+
+/**
+ * Deactivation of AccessPolicy with assigned applications is not allowed
+ */
+export const assignedAccessPoliciesValidator: ChangeValidator = async (changes, elementSource) => {
+  if (elementSource === undefined) {
+    log.error('Failed to run usedAccessPoliciesValidator because element source is undefined')
+    return []
+  }
+  const accessPolicies = changes
+    .filter(isInstanceChange)
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+    .filter(instance => instance.elemID.typeName === ACCESS_POLICY_TYPE_NAME)
+    .filter(instance => instance.value.status === INACTIVE_STATUS)
+
+  const applications = await awu(await elementSource.list())
+    .filter(id => id.typeName === APPLICATION_TYPE_NAME)
+    .filter(id => id.idType === 'instance')
+    .map(id => elementSource.get(id))
+    .filter(isInstanceElement)
+    .toArray()
+
+  const accessPolicyToApplications = _.groupBy(
+    applications.filter(app => app.value.accessPolicy !== undefined && isReferenceExpression(app.value.accessPolicy)),
+    app => (app.value.accessPolicy as ReferenceExpression).elemID.getFullName()
+  )
+
+  const assignedPolicies = accessPolicies
+    .filter(policy => accessPolicyToApplications[policy.elemID.getFullName()] !== undefined)
+
+  return assignedPolicies.map(instance => ({
+    elemID: instance.elemID,
+    severity: 'Error',
+    message: 'Cannot deactivate an access policy with assigned applications',
+    detailedMessage: `Access policy is used by the following applications: ${accessPolicyToApplications[instance.elemID.getFullName()].map(app => app.elemID.name).join(', ')}.`,
+  }))
+}

--- a/packages/okta-adapter/src/change_validators/index.ts
+++ b/packages/okta-adapter/src/change_validators/index.ts
@@ -24,6 +24,7 @@ import { groupRuleAdministratorValidator } from './group_rule_administrator'
 import { customApplicationStatusValidator } from './custom_application_status'
 import { userTypeAndSchemaValidator } from './user_type_and_schema'
 import { appIntegrationSetupValidator } from './app_integration_setup'
+import { assignedAccessPoliciesValidator } from './assigned_policies'
 import OktaClient from '../client/client'
 
 export default ({
@@ -41,6 +42,7 @@ export default ({
     customApplicationStatusValidator,
     userTypeAndSchemaValidator,
     appIntegrationSetupValidator(client),
+    assignedAccessPoliciesValidator,
   ]
 
   return createChangeValidator(validators)

--- a/packages/okta-adapter/test/change_validators/assigned_policies.test.ts
+++ b/packages/okta-adapter/test/change_validators/assigned_policies.test.ts
@@ -1,0 +1,110 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { toChange, ObjectType, ElemID, InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { assignedAccessPoliciesValidator } from '../../src/change_validators/assigned_policies'
+import { OKTA, ACCESS_POLICY_TYPE_NAME, APPLICATION_TYPE_NAME } from '../../src/constants'
+
+describe('assignedAccessPoliciesValidator', () => {
+  const policyType = new ObjectType({ elemID: new ElemID(OKTA, ACCESS_POLICY_TYPE_NAME) })
+  const appType = new ObjectType({ elemID: new ElemID(OKTA, APPLICATION_TYPE_NAME) })
+  const policyInstance = new InstanceElement(
+    'somePolicy',
+    policyType,
+    { name: 'policy', status: 'INACTIVE', system: false, type: 'ACCESS_POLICY' },
+  )
+  const policyInstance2 = new InstanceElement(
+    'somePolicy2',
+    policyType,
+    { name: 'policy2', status: 'INACTIVE', system: false, type: 'ACCESS_POLICY' },
+  )
+  const app = new InstanceElement(
+    'someApp',
+    appType,
+    {
+      name: 'app',
+      status: 'ACTIVE',
+      accessPolicy: new ReferenceExpression(policyInstance.elemID, policyInstance),
+    },
+  )
+  const anotherApp = new InstanceElement(
+    'anotherApp',
+    appType,
+    {
+      name: 'app2',
+      status: 'INACTIVE',
+      accessPolicy: new ReferenceExpression(policyInstance.elemID, policyInstance),
+    },
+  )
+  const anotherApp2 = new InstanceElement(
+    'anotherApp2',
+    appType,
+    {
+      name: 'app3',
+      status: 'ACTIVE',
+      accessPolicy: new ReferenceExpression(policyInstance2.elemID, policyInstance2),
+    },
+  )
+  const elementSource = buildElementsSourceFromElements(
+    [appType, app, anotherApp, policyInstance, policyType, anotherApp2, policyInstance2]
+  )
+
+  it('should return an error when deactivating access policy that is used by an app', async () => {
+    const changeErrors = await assignedAccessPoliciesValidator(
+      [toChange({ before: policyInstance, after: policyInstance }), toChange({ after: policyInstance2 })],
+      elementSource
+    )
+    expect(changeErrors).toHaveLength(2)
+    expect(changeErrors).toEqual([
+      {
+        elemID: policyInstance.elemID,
+        severity: 'Error',
+        message: 'Cannot deactivate an access policy with assigned applications',
+        detailedMessage: 'Access policy is used by the following applications: someApp, anotherApp.',
+      },
+      {
+        elemID: policyInstance2.elemID,
+        severity: 'Error',
+        message: 'Cannot deactivate an access policy with assigned applications',
+        detailedMessage: 'Access policy is used by the following applications: anotherApp2.',
+      },
+    ])
+  })
+  it('should not return an error if no app is using the deactivated policy', async () => {
+    const newPolicy = new InstanceElement(
+      'newPolicy',
+      policyType,
+      {
+        name: 'policy',
+        status: 'INACTIVE',
+        system: false,
+        type: 'ACCESS_POLICY',
+      },
+    )
+    const changeErrors = await assignedAccessPoliciesValidator(
+      [toChange({ after: newPolicy })],
+      elementSource
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
+  it('should do nothing when element source is missing', async () => {
+    const changeErrors = await assignedAccessPoliciesValidator(
+      [toChange({ after: policyInstance })],
+      undefined
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Okta doesn't allow deactivation of `AccessPolicy` if the policy is used by `Application`

---
_Release Notes_: 
None

---
_User Notifications_: 
None
