### PR TITLE
Salto-3868: reorder deploy xml only for elements not in cycle

### DIFF
--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -178,7 +178,7 @@ export default class NetsuiteClient {
           const startNode = dependencyGraph.findNodeByField(
             'serviceid', (serviceIdInfo.serviceIdType === PATH ? serviceIdInfo.serviceId : serviceIdInfo.serviceId.split('.')[0])
           )
-          if (startNode && endNode && startNode.value.changeType === 'addition' && !_.isEqual(startNode, endNode)) {
+          if (startNode && endNode && startNode.value.changeType === 'addition' && (startNode.value[dependencyGraph.key] !== endNode.value[dependencyGraph.key])) {
             startNode.addEdge(dependencyGraph.key, endNode)
           }
         })

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -178,7 +178,7 @@ export default class NetsuiteClient {
           const startNode = dependencyGraph.findNodeByField(
             'serviceid', (serviceIdInfo.serviceIdType === PATH ? serviceIdInfo.serviceId : serviceIdInfo.serviceId.split('.')[0])
           )
-          if (startNode && endNode && startNode.value.changeType === 'addition') {
+          if (startNode && endNode && startNode.value.changeType === 'addition' && !_.isEqual(startNode, endNode)) {
             startNode.addEdge(dependencyGraph.key, endNode)
           }
         })

--- a/packages/netsuite-adapter/src/client/deploy_xml_utils.ts
+++ b/packages/netsuite-adapter/src/client/deploy_xml_utils.ts
@@ -63,6 +63,7 @@ export const reorderDeployXml = (
   deployContent: string,
   dependencyGraph: Graph<SDFObjectNode>,
 ): string => {
+  dependencyGraph.findCycle().forEach(node => dependencyGraph.removeNode(node.value.elemIdFullName))
   const custInfosInTopologicalOrder = dependencyGraph.getTopologicalOrder()
     .map(node => node.value.customizationInfo)
 

--- a/packages/netsuite-adapter/src/client/deploy_xml_utils.ts
+++ b/packages/netsuite-adapter/src/client/deploy_xml_utils.ts
@@ -63,8 +63,10 @@ export const reorderDeployXml = (
   deployContent: string,
   dependencyGraph: Graph<SDFObjectNode>,
 ): string => {
-  dependencyGraph.findCycle().forEach(node => dependencyGraph.removeNode(node.value.elemIdFullName))
+  const nodesInCycle = new Set(dependencyGraph.findCycle())
+  log.debug('The following %d objects will not be written explicity in the deploy xml since they contain a cycle: %o', nodesInCycle.size, [...nodesInCycle])
   const custInfosInTopologicalOrder = dependencyGraph.getTopologicalOrder()
+    .filter(node => !nodesInCycle.has(node.id))
     .map(node => node.value.customizationInfo)
 
   const [fileCabinetCustInfos, customTypeInfos] = _.partition(

--- a/packages/netsuite-adapter/src/client/graph_utils.ts
+++ b/packages/netsuite-adapter/src/client/graph_utils.ts
@@ -69,10 +69,10 @@ export class Graph<T> {
   private dfs(dfsParams: DFSParameters<T>): void {
     const { node, visited, resultArray, path, cycle } = dfsParams
     if (visited.has(node.value[this.key])) {
-      if (path?.includes(node)) {
+      const cycleStartIndex = path?.indexOf(node)
+      if (cycleStartIndex !== -1) {
         // node is visited & in path mean its a cycle
-        const cycleStartIndex = path.indexOf(node)
-        cycle?.push(...path.slice(cycleStartIndex))
+        cycle?.push(...(path?.slice(cycleStartIndex) ?? []))
       }
       return
     }

--- a/packages/netsuite-adapter/src/client/graph_utils.ts
+++ b/packages/netsuite-adapter/src/client/graph_utils.ts
@@ -15,11 +15,9 @@
 */
 
 import _ from 'lodash'
-import { values as lowerDashValues } from '@salto-io/lowerdash'
 import wu from 'wu'
 import { CustomizationInfo } from './types'
 
-const { isDefined } = lowerDashValues
 
 export type SDFObjectNode = {
   elemIdFullName: string
@@ -31,10 +29,12 @@ export type SDFObjectNode = {
 export class GraphNode<T> {
   edges: Map<T[keyof T], GraphNode<T>>
   value: T
+  id: string
 
-  constructor(value: T) {
+  constructor(value: T, id: string) {
     this.value = value
     this.edges = new Map<T[keyof T], GraphNode<T>>()
+    this.id = id
   }
 
   addEdge(key: keyof T, node: GraphNode<T>): void {
@@ -75,7 +75,7 @@ export class Graph<T> {
       const cycleStartIndex = path.indexOf(node.value[this.key])
       if (cycleStartIndex !== -1) {
         // node is visited & in path mean its a cycle
-        cycle.push(...(path?.slice(cycleStartIndex) ?? []))
+        cycle.push(...(path.slice(cycleStartIndex)))
       }
       return
     }
@@ -127,18 +127,15 @@ export class Graph<T> {
     }
   }
 
-  findCycle(): GraphNode<T>[] {
+  findCycle(): T[keyof T][] {
     const visited = new Set<T[keyof T]>()
-    const path: T[keyof T][] = []
     const nodesInCycle: T[keyof T][] = []
 
     Array.from(this.nodes.values()).forEach(node => {
       if (!visited.has(node.value[this.key])) {
-        this.dfs({ node, visited, path, cycle: nodesInCycle })
+        this.dfs({ node, visited, cycle: nodesInCycle })
       }
     })
     return nodesInCycle
-      .map(nodeKey => this.findNodeByKey(nodeKey))
-      .filter(isDefined)
   }
 }

--- a/packages/netsuite-adapter/src/client/graph_utils.ts
+++ b/packages/netsuite-adapter/src/client/graph_utils.ts
@@ -44,7 +44,7 @@ type DFSParameters<T>= {
   visited: Set<T[keyof T]>
   resultArray: GraphNode<T>[]
   // optional parameters for cycle detection
-  stack?: GraphNode<T>[]
+  path?: GraphNode<T>[]
   cycle?: GraphNode<T>[]
 }
 
@@ -67,21 +67,23 @@ export class Graph<T> {
   }
 
   private dfs(dfsParams: DFSParameters<T>): void {
-    const { node, visited, resultArray, stack, cycle } = dfsParams
+    const { node, visited, resultArray, path, cycle } = dfsParams
     if (visited.has(node.value[this.key])) {
-      if (stack !== undefined) {
-        const cycleStartIndex = stack.indexOf(node)
-        cycle?.push(...stack.slice(cycleStartIndex))
+      if (path?.includes(node)) {
+        // node is visited & in path mean its a cycle
+        const cycleStartIndex = path.indexOf(node)
+        cycle?.push(...path.slice(cycleStartIndex))
       }
       return
     }
     visited.add(node.value[this.key])
-    stack?.push(node)
+    path?.push(node)
     node.edges.forEach(dependency => {
-      this.dfs({ node: dependency, visited, resultArray, stack, cycle })
+      this.dfs({ node: dependency, visited, resultArray, path, cycle })
     })
     resultArray.push(node)
-    stack?.pop()
+    //
+    path?.pop()
   }
 
   getTopologicalOrder(): GraphNode<T>[] {
@@ -127,12 +129,12 @@ export class Graph<T> {
 
   findCycle(): GraphNode<T>[] {
     const visited = new Set<T[keyof T]>()
-    const stack : GraphNode<T>[] = []
+    const path : GraphNode<T>[] = []
     const nodesInCycle: GraphNode<T>[] = []
 
     Array.from(this.nodes.values()).forEach(node => {
       if (!visited.has(node.value[this.key])) {
-        this.dfs({ node, visited, resultArray: [], stack, cycle: nodesInCycle })
+        this.dfs({ node, visited, resultArray: [], path, cycle: nodesInCycle })
       }
     })
     return nodesInCycle

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -646,7 +646,7 @@ describe('Adapter', () => {
         const expectedResolvedInstance = instance.clone()
         expectedResolvedInstance.value.description = 'description value'
         const customizationInfo = await toCustomizationInfo(expectedResolvedInstance)
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', serviceid: 'custentity_my_script_id', changeType: 'addition', customizationInfo } as SDFObjectNode)])
+        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', serviceid: 'custentity_my_script_id', changeType: 'addition', customizationInfo } as SDFObjectNode, 'netsuite.entitycustomfield.instance.elementName')])
         expect(client.deploy)
           .toHaveBeenCalledWith(
             undefined,
@@ -663,7 +663,7 @@ describe('Adapter', () => {
         const post = getChangeData(result.appliedChanges[0]) as InstanceElement
         const customizationInfo = await toCustomizationInfo(fileInstance)
         const serviceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder/content.html'
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.file.instance.fileInstance', serviceid: serviceId, changeType: 'addition', customizationInfo } as SDFObjectNode)])
+        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.file.instance.fileInstance', serviceid: serviceId, changeType: 'addition', customizationInfo } as SDFObjectNode, 'netsuite.file.instance.fileInstance')])
         expect(client.deploy).toHaveBeenCalledWith(
           undefined,
           DEFAULT_SDF_DEPLOY_PARAMS,
@@ -679,7 +679,7 @@ describe('Adapter', () => {
         const post = getChangeData(result.appliedChanges[0]) as InstanceElement
         const customizationInfo = await toCustomizationInfo(folderInstance)
         const serviceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder'
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.folder.instance.folderInstance', serviceid: serviceId, changeType: 'addition', customizationInfo } as SDFObjectNode)])
+        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.folder.instance.folderInstance', serviceid: serviceId, changeType: 'addition', customizationInfo } as SDFObjectNode, 'netsuite.folder.instance.folderInstance')])
         expect(client.deploy).toHaveBeenCalledWith(
           undefined,
           DEFAULT_SDF_DEPLOY_PARAMS,
@@ -703,8 +703,8 @@ describe('Adapter', () => {
         const folderServiceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder'
         const fileServiceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder/content.html'
         testGraph.addNodes([
-          new GraphNode({ elemIdFullName: 'netsuite.file.instance.fileInstance', serviceid: fileServiceId, changeType: 'addition', customizationInfo: fileCustInfo } as SDFObjectNode),
-          new GraphNode({ elemIdFullName: 'netsuite.folder.instance.folderInstance', serviceid: folderServiceId, changeType: 'addition', customizationInfo: folderCustInfo } as SDFObjectNode),
+          new GraphNode({ elemIdFullName: 'netsuite.file.instance.fileInstance', serviceid: fileServiceId, changeType: 'addition', customizationInfo: fileCustInfo } as SDFObjectNode, 'netsuite.file.instance.fileInstance'),
+          new GraphNode({ elemIdFullName: 'netsuite.folder.instance.folderInstance', serviceid: folderServiceId, changeType: 'addition', customizationInfo: folderCustInfo } as SDFObjectNode, 'netsuite.folder.instance.folderInstance'),
         ])
         expect(client.deploy).toHaveBeenCalledWith(
           undefined,
@@ -732,8 +732,8 @@ describe('Adapter', () => {
         const folderServiceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder'
         const fileServiceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder/content.html'
         testGraph.addNodes([
-          new GraphNode({ elemIdFullName: 'netsuite.file.instance.fileInstance', serviceid: fileServiceId, changeType: 'addition', customizationInfo: fileCustInfo } as SDFObjectNode),
-          new GraphNode({ elemIdFullName: 'netsuite.folder.instance.folderInstance', serviceid: folderServiceId, changeType: 'addition', customizationInfo: folderCustInfo } as SDFObjectNode),
+          new GraphNode({ elemIdFullName: 'netsuite.file.instance.fileInstance', serviceid: fileServiceId, changeType: 'addition', customizationInfo: fileCustInfo } as SDFObjectNode, 'netsuite.file.instance.fileInstance'),
+          new GraphNode({ elemIdFullName: 'netsuite.folder.instance.folderInstance', serviceid: folderServiceId, changeType: 'addition', customizationInfo: folderCustInfo } as SDFObjectNode, 'netsuite.folder.instance.folderInstance'),
         ])
         expect(client.deploy).toHaveBeenCalledWith(
           undefined,
@@ -769,7 +769,7 @@ describe('Adapter', () => {
         const expectedResolvedInstance = instance.clone()
         expectedResolvedInstance.value.description = 'description value'
         const customizationInfo = await toCustomizationInfo(expectedResolvedInstance)
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', serviceid: 'custentity_my_script_id', changeType: 'modification', customizationInfo } as SDFObjectNode)])
+        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', serviceid: 'custentity_my_script_id', changeType: 'modification', customizationInfo } as SDFObjectNode, 'netsuite.entitycustomfield.instance.elementName')])
         expect(client.deploy)
           .toHaveBeenCalledWith(
             undefined,
@@ -786,7 +786,7 @@ describe('Adapter', () => {
         const post = getChangeData(result.appliedChanges[0]) as InstanceElement
         const customizationInfo = await toCustomizationInfo(fileInstance)
         const serviceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder/content.html'
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.file.instance.fileInstance', serviceid: serviceId, changeType: 'modification', customizationInfo } as SDFObjectNode)])
+        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.file.instance.fileInstance', serviceid: serviceId, changeType: 'modification', customizationInfo } as SDFObjectNode, 'netsuite.file.instance.fileInstance')])
         expect(client.deploy).toHaveBeenCalledWith(
           undefined,
           DEFAULT_SDF_DEPLOY_PARAMS,
@@ -802,7 +802,7 @@ describe('Adapter', () => {
         const post = getChangeData(result.appliedChanges[0]) as InstanceElement
         const customizationInfo = await toCustomizationInfo(folderInstance)
         const serviceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder'
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.folder.instance.folderInstance', serviceid: serviceId, changeType: 'modification', customizationInfo } as SDFObjectNode)])
+        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.folder.instance.folderInstance', serviceid: serviceId, changeType: 'modification', customizationInfo } as SDFObjectNode, 'netsuite.folder.instance.folderInstance')])
         expect(client.deploy).toHaveBeenCalledWith(
           undefined,
           DEFAULT_SDF_DEPLOY_PARAMS,
@@ -825,7 +825,7 @@ describe('Adapter', () => {
         const expectedResolvedAfter = after.clone()
         expectedResolvedAfter.value.description = 'edited description value'
         const customizationInfo = await toCustomizationInfo(expectedResolvedAfter)
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', serviceid: 'custentity_my_script_id', changeType: 'modification', customizationInfo } as SDFObjectNode)])
+        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', serviceid: 'custentity_my_script_id', changeType: 'modification', customizationInfo } as SDFObjectNode, 'netsuite.entitycustomfield.instance.elementName')])
         expect(client.deploy)
           .toHaveBeenCalledWith(
             undefined,
@@ -872,7 +872,7 @@ describe('Adapter', () => {
             changes: [{ action: 'add', data: { after: instance } }],
           },
         })
-        testGraph.addNodes([new GraphNode({ serviceid: 'custentity_my_script_id', elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', changeType: 'addition', customizationInfo: custInfo } as SDFObjectNode)])
+        testGraph.addNodes([new GraphNode({ serviceid: 'custentity_my_script_id', elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', changeType: 'addition', customizationInfo: custInfo } as SDFObjectNode, 'netsuite.entitycustomfield.instance.elementName')])
         expect(client.deploy).toHaveBeenCalledWith(
           undefined,
           {
@@ -889,7 +889,7 @@ describe('Adapter', () => {
 
       it('should call deploy without additional dependencies', async () => {
         await adapterAdd(instance)
-        testGraph.addNodes([new GraphNode({ serviceid: 'custentity_my_script_id', elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', changeType: 'addition', customizationInfo: custInfo } as SDFObjectNode)])
+        testGraph.addNodes([new GraphNode({ serviceid: 'custentity_my_script_id', elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', changeType: 'addition', customizationInfo: custInfo } as SDFObjectNode, 'netsuite.entitycustomfield.instance.elementName')])
         expect(client.deploy).toHaveBeenCalledWith(
           undefined,
           DEFAULT_SDF_DEPLOY_PARAMS,

--- a/packages/netsuite-adapter/test/client/client.test.ts
+++ b/packages/netsuite-adapter/test/client/client.test.ts
@@ -254,7 +254,7 @@ describe('NetsuiteClient', () => {
         const change = toChange({
           after: new InstanceElement('instance', type, { scriptid: 'someObject' }),
         })
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.type.instance.instance', serviceid: 'someObject', changeType: 'addition', customizationInfo: { scriptId: 'someObject', typeName: 'type', values: { scriptid: 'someObject' } } } as SDFObjectNode)])
+        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.type.instance.instance', serviceid: 'someObject', changeType: 'addition', customizationInfo: { scriptId: 'someObject', typeName: 'type', values: { scriptid: 'someObject' } } } as SDFObjectNode, 'netsuite.type.instance.instance')])
         await client.deploy(
           [change],
           SDF_CREATE_OR_UPDATE_GROUP_ID,
@@ -304,7 +304,7 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
         const change = toChange({
           after: new InstanceElement('instance', type, { scriptid: 'someObject' }),
         })
-        testGraph.addNodes([new GraphNode({ serviceid: 'someObject', elemIdFullName: 'netsuite.type.instance.instance', changeType: 'addition', customizationInfo: { scriptId: 'someObject', typeName: 'type', values: { scriptid: 'someObject' } } } as SDFObjectNode)])
+        testGraph.addNodes([new GraphNode({ serviceid: 'someObject', elemIdFullName: 'netsuite.type.instance.instance', changeType: 'addition', customizationInfo: { scriptId: 'someObject', typeName: 'type', values: { scriptid: 'someObject' } } } as SDFObjectNode, 'netsuite.type.instance.instance')])
         expect(await client.deploy(
           [change],
           SDF_CREATE_OR_UPDATE_GROUP_ID,
@@ -370,7 +370,7 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
         const change = toChange({
           after: new InstanceElement('instance', type, { scriptid: 'someObject' }),
         })
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.type.instance.instance', serviceid: 'someObject', changeType: 'addition', customizationInfo: { scriptId: 'someObject', typeName: 'type', values: { scriptid: 'someObject' } } } as SDFObjectNode)])
+        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.type.instance.instance', serviceid: 'someObject', changeType: 'addition', customizationInfo: { scriptId: 'someObject', typeName: 'type', values: { scriptid: 'someObject' } } } as SDFObjectNode, 'netsuite.type.instance.instance')])
         expect(await client.deploy(
           [change],
           SDF_CREATE_OR_UPDATE_GROUP_ID,
@@ -446,7 +446,7 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
               },
             }),
           })
-          testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.customrecord1', serviceid: 'customrecord1', changeType: 'addition', customizationInfo } as SDFObjectNode)])
+          testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.customrecord1', serviceid: 'customrecord1', changeType: 'addition', customizationInfo } as SDFObjectNode, 'netsuite.customrecord1')])
           expect(await client.deploy(
             [change],
             SDF_CREATE_OR_UPDATE_GROUP_ID,
@@ -498,7 +498,7 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
           const successFieldChange = toChange({
             after: customRecordType.fields.custom_field,
           })
-          testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.customrecord1.field.custom_field', serviceid: 'customrecord1', changeType: 'addition', customizationInfo } as SDFObjectNode)])
+          testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.customrecord1.field.custom_field', serviceid: 'customrecord1', changeType: 'addition', customizationInfo } as SDFObjectNode, 'netsuite.customrecord1.field.custom_field')])
           expect(await client.deploy(
             [successTypeChange, successFieldChange, failedChange],
             SDF_CREATE_OR_UPDATE_GROUP_ID,
@@ -597,7 +597,7 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
           typeName: 'type',
           values: { scriptid: 'someObject' },
         }
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.type.instance.instance', serviceid: 'someObject', changeType: 'addition', customizationInfo } as SDFObjectNode)])
+        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.type.instance.instance', serviceid: 'someObject', changeType: 'addition', customizationInfo } as SDFObjectNode, 'netsuite.type.instance.instance')])
         await client.validate([change], SDF_CREATE_OR_UPDATE_GROUP_ID, deployParams[0])
         expect(mockSdfDeploy).toHaveBeenCalledWith(
           undefined,

--- a/packages/netsuite-adapter/test/client/deploy_xml_utils.test.ts
+++ b/packages/netsuite-adapter/test/client/deploy_xml_utils.test.ts
@@ -21,8 +21,9 @@ import { FILE, FOLDER } from '../../src/constants'
 
 describe('deploy xml utils tests', () => {
   let testGraph: Graph<SDFObjectNode>
+  let testNode1: GraphNode<SDFObjectNode>
   beforeEach(() => {
-    const testNode1 = new GraphNode<SDFObjectNode>(
+    testNode1 = new GraphNode<SDFObjectNode>(
       { elemIdFullName: 'fullName1', serviceid: 'scriptid1', changeType: 'addition', customizationInfo: { scriptId: 'scriptid1', typeName: '', values: {} } as CustomizationInfo }
     )
     const testNode2 = new GraphNode<SDFObjectNode>(
@@ -62,6 +63,35 @@ describe('deploy xml utils tests', () => {
   <objects>
     <path>~/Objects/scriptid3.xml</path>
     <path>~/Objects/scriptid1.xml</path>
+    <path>~/Objects/scriptid2.xml</path>
+    <path>~/Objects/*</path>
+  </objects>
+  <translationimports>
+    <path>~/Translations/*</path>
+  </translationimports>
+</deploy>
+`
+    expect(reorderDeployXml(originalDeployXml, testGraph)).toEqual(fixedDeployXml)
+  })
+
+  it('should only explictly add objects that dont have circular dependencies', async () => {
+    const testNode4 = new GraphNode<SDFObjectNode>(
+      { elemIdFullName: 'fullName4', serviceid: 'scriptid4', changeType: 'addition', customizationInfo: { scriptId: 'scriptid4', typeName: '', values: {} } as CustomizationInfo }
+    )
+    testGraph.removeNode('fullName1')
+    // creates cycle in graph
+    testNode4.addEdge('elemIdFullName', testNode1)
+    testNode1.addEdge('elemIdFullName', testNode4)
+    testGraph.addNodes([testNode4, testNode1])
+    const fixedDeployXml = `<deploy>
+  <configuration>
+    <path>~/AccountConfiguration/*</path>
+  </configuration>
+  <files>
+    <path>~/FileCabinet/*</path>
+  </files>
+  <objects>
+    <path>~/Objects/scriptid3.xml</path>
     <path>~/Objects/scriptid2.xml</path>
     <path>~/Objects/*</path>
   </objects>

--- a/packages/netsuite-adapter/test/client/deploy_xml_utils.test.ts
+++ b/packages/netsuite-adapter/test/client/deploy_xml_utils.test.ts
@@ -24,13 +24,16 @@ describe('deploy xml utils tests', () => {
   let testNode1: GraphNode<SDFObjectNode>
   beforeEach(() => {
     testNode1 = new GraphNode<SDFObjectNode>(
-      { elemIdFullName: 'fullName1', serviceid: 'scriptid1', changeType: 'addition', customizationInfo: { scriptId: 'scriptid1', typeName: '', values: {} } as CustomizationInfo }
+      { elemIdFullName: 'fullName1', serviceid: 'scriptid1', changeType: 'addition', customizationInfo: { scriptId: 'scriptid1', typeName: '', values: {} } as CustomizationInfo },
+      'fullName1',
     )
     const testNode2 = new GraphNode<SDFObjectNode>(
-      { elemIdFullName: 'fullName2', serviceid: 'scriptid2', changeType: 'addition', customizationInfo: { scriptId: 'scriptid2', typeName: '', values: {} } as CustomizationInfo }
+      { elemIdFullName: 'fullName2', serviceid: 'scriptid2', changeType: 'addition', customizationInfo: { scriptId: 'scriptid2', typeName: '', values: {} } as CustomizationInfo },
+      'fullName2',
     )
     const testNode3 = new GraphNode<SDFObjectNode>(
-      { elemIdFullName: 'fullName3', serviceid: 'scriptid3', changeType: 'addition', customizationInfo: { scriptId: 'scriptid3', typeName: '', values: {} } as CustomizationInfo }
+      { elemIdFullName: 'fullName3', serviceid: 'scriptid3', changeType: 'addition', customizationInfo: { scriptId: 'scriptid3', typeName: '', values: {} } as CustomizationInfo },
+      'fullName3',
     )
     testNode3.addEdge('elemIdFullName', testNode1)
     testNode1.addEdge('elemIdFullName', testNode2)
@@ -76,7 +79,8 @@ describe('deploy xml utils tests', () => {
 
   it('should only explictly add objects that dont have circular dependencies', async () => {
     const testNode4 = new GraphNode<SDFObjectNode>(
-      { elemIdFullName: 'fullName4', serviceid: 'scriptid4', changeType: 'addition', customizationInfo: { scriptId: 'scriptid4', typeName: '', values: {} } as CustomizationInfo }
+      { elemIdFullName: 'fullName4', serviceid: 'scriptid4', changeType: 'addition', customizationInfo: { scriptId: 'scriptid4', typeName: '', values: {} } as CustomizationInfo },
+      'fullName4'
     )
     testGraph.removeNode('fullName1')
     // creates cycle in graph
@@ -106,8 +110,8 @@ describe('deploy xml utils tests', () => {
   it('should write files and folders to deploy xml according to ref level', async () => {
     const emptyFileCustInfo = { typeName: FILE, values: {}, path: ['SuiteScripts', 'shalomTest.js'], content: '' }
     const emptyFolderCustInfo = { typeName: FOLDER, values: {}, path: ['SuiteScripts', 'InnerFolder'] }
-    const fileTestNode = new GraphNode<SDFObjectNode>({ elemIdFullName: 'fullFileName', serviceid: '/SuiteScripts/shalomTest.js', customizationInfo: emptyFileCustInfo, changeType: 'addition' })
-    const folderTestNode = new GraphNode<SDFObjectNode>({ elemIdFullName: 'fullFolderName', serviceid: '/SuiteScripts/InnerFolder', customizationInfo: emptyFolderCustInfo, changeType: 'addition' })
+    const fileTestNode = new GraphNode<SDFObjectNode>({ elemIdFullName: 'fullFileName', serviceid: '/SuiteScripts/shalomTest.js', customizationInfo: emptyFileCustInfo, changeType: 'addition' }, 'fullFileName')
+    const folderTestNode = new GraphNode<SDFObjectNode>({ elemIdFullName: 'fullFolderName', serviceid: '/SuiteScripts/InnerFolder', customizationInfo: emptyFolderCustInfo, changeType: 'addition' }, 'fullFolderName')
     fileTestNode.addEdge(testGraph.key, folderTestNode)
     testGraph.addNodes([fileTestNode, folderTestNode])
     const fixedDeployXml = `<deploy>

--- a/packages/netsuite-adapter/test/client/graph_utils.test.ts
+++ b/packages/netsuite-adapter/test/client/graph_utils.test.ts
@@ -22,13 +22,19 @@ type testNode = {
 }
 
 describe('graph utils tests', () => {
-  const testNode1 = new GraphNode({ name: 'node1', num: 1 })
-  const testNode2 = new GraphNode({ name: 'node2', num: 2 })
-  const testNode3 = new GraphNode({ name: 'node3', num: 3 })
-  const testGraph = new Graph<testNode>('name', [testNode1, testNode2, testNode3])
-  testNode1.addEdge(testGraph.key, testNode2)
-  testNode1.addEdge(testGraph.key, testNode3)
-  testNode2.addEdge(testGraph.key, testNode1)
+  let testGraph: Graph<testNode>
+  let testNode1: GraphNode<testNode>
+  let testNode2: GraphNode<testNode>
+  let testNode3: GraphNode<testNode>
+  beforeEach(() => {
+    testNode1 = new GraphNode({ name: 'node1', num: 1 }, 'node1')
+    testNode2 = new GraphNode({ name: 'node2', num: 2 }, 'node2')
+    testNode3 = new GraphNode({ name: 'node3', num: 3 }, 'node3')
+    testGraph = new Graph<testNode>('name', [testNode1, testNode2, testNode3])
+    testNode1.addEdge(testGraph.key, testNode2)
+    testNode1.addEdge(testGraph.key, testNode3)
+    testNode2.addEdge(testGraph.key, testNode1)
+  })
 
 
   it('should find the nodes dependencies', async () => {
@@ -60,7 +66,7 @@ describe('graph utils tests', () => {
   it('should find the cycle in the graph and return its nodes', async () => {
     const cycleNodes = testGraph.findCycle()
     expect(cycleNodes).toHaveLength(2)
-    expect(cycleNodes).toEqual([testNode1, testNode2])
+    expect(cycleNodes).toEqual([testNode1.value.name, testNode2.value.name])
   })
 
   it('should remove node from graph and edges from nodes', async () => {
@@ -69,6 +75,12 @@ describe('graph utils tests', () => {
     expect(testNode2.edges).not.toContain(testNode1)
   })
   it('should return an empty array if there is no cycle', async () => {
+    const testNode4 = new GraphNode({ name: 'node4', num: 1 }, 'node4')
+    const testNode5 = new GraphNode({ name: 'node5', num: 2 }, 'node5')
+    const testNode6 = new GraphNode({ name: 'node6', num: 3 }, 'node6')
+    testNode4.addEdge(testGraph.key, testNode5)
+    testNode4.addEdge(testGraph.key, testNode6)
+    testGraph = new Graph<testNode>('name', [testNode4, testNode5, testNode6])
     const cycleNodes = testGraph.findCycle()
     expect(cycleNodes).toHaveLength(0)
   })

--- a/packages/netsuite-adapter/test/client/graph_utils.test.ts
+++ b/packages/netsuite-adapter/test/client/graph_utils.test.ts
@@ -57,10 +57,19 @@ describe('graph utils tests', () => {
   it('should return nodes in topological sort', async () => {
     expect(testGraph.getTopologicalOrder()).toEqual([testNode1, testNode3, testNode2])
   })
+  it('should find the cycle in the graph and return its nodes', async () => {
+    const cycleNodes = testGraph.findCycle()
+    expect(cycleNodes).toHaveLength(2)
+    expect(cycleNodes).toEqual([testNode1, testNode2])
+  })
 
   it('should remove node from graph and edges from nodes', async () => {
     testGraph.removeNode('node1')
     expect(testGraph.nodes.get('node1')).toBeUndefined()
     expect(testNode2.edges).not.toContain(testNode1)
+  })
+  it('should return an empty array if there is no cycle', async () => {
+    const cycleNodes = testGraph.findCycle()
+    expect(cycleNodes).toHaveLength(0)
   })
 })

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -1299,7 +1299,7 @@ describe('sdf client', () => {
         mockExecuteAction.mockResolvedValue({ isSuccess: () => true })
         const scriptId = 'filename'
         customTypeInfo.scriptId = scriptId
-        testGraph.addNodes([new GraphNode<SDFObjectNode>({ serviceid: scriptId, elemIdFullName: 'name', changeType: 'addition', customizationInfo: customTypeInfo })])
+        testGraph.addNodes([new GraphNode<SDFObjectNode>({ serviceid: scriptId, elemIdFullName: 'name', changeType: 'addition', customizationInfo: customTypeInfo }, 'name')])
         await client.deploy(...DEFAULT_DEPLOY_PARAMS)
         expect(writeFileMock).toHaveBeenCalledTimes(3)
         expect(writeFileMock).toHaveBeenCalledWith(expect.stringContaining(`${scriptId}.xml`),
@@ -1316,7 +1316,7 @@ describe('sdf client', () => {
         mockExecuteAction.mockResolvedValue({ isSuccess: () => true })
         const scriptId = 'filename'
         customTypeInfo.scriptId = scriptId
-        testGraph.addNodes([new GraphNode<SDFObjectNode>({ serviceid: scriptId, elemIdFullName: scriptId, changeType: 'addition', customizationInfo: customTypeInfo })])
+        testGraph.addNodes([new GraphNode<SDFObjectNode>({ serviceid: scriptId, elemIdFullName: scriptId, changeType: 'addition', customizationInfo: customTypeInfo }, scriptId)])
         await client.deploy('a.b.c', DEFAULT_DEPLOY_PARAMS[1], DEFAULT_DEPLOY_PARAMS[2])
         expect(renameMock).toHaveBeenCalled()
         expect(writeFileMock).toHaveBeenCalledTimes(3)
@@ -1341,7 +1341,7 @@ describe('sdf client', () => {
           fileContent: MOCK_TEMPLATE_CONTENT,
           fileExtension: 'html',
         } as TemplateCustomTypeInfo
-        testGraph.addNodes([new GraphNode<SDFObjectNode>({ serviceid: scriptId, elemIdFullName: scriptId, changeType: 'addition', customizationInfo: templateCustomTypeInfo })])
+        testGraph.addNodes([new GraphNode<SDFObjectNode>({ serviceid: scriptId, elemIdFullName: scriptId, changeType: 'addition', customizationInfo: templateCustomTypeInfo }, scriptId)])
         await client.deploy(...DEFAULT_DEPLOY_PARAMS)
         expect(writeFileMock).toHaveBeenCalledTimes(4)
         expect(writeFileMock)
@@ -1418,7 +1418,7 @@ File: ~/Objects/custform_114_t1441298_782.xml
           return { isSuccess: () => true }
         })
         let isRejected: boolean
-        testGraph.addNodes([new GraphNode(testSDFNode)])
+        testGraph.addNodes([new GraphNode(testSDFNode, testSDFNode.elemIdFullName)])
         try {
           await client.deploy(...DEFAULT_DEPLOY_PARAMS)
           isRejected = false
@@ -1507,7 +1507,7 @@ File: ~/Objects/custform_15_t1049933_143.xml
           return { isSuccess: () => true }
         })
         let isRejected: boolean
-        testGraph.addNodes([new GraphNode(testSDFNode)])
+        testGraph.addNodes([new GraphNode(testSDFNode, testSDFNode.elemIdFullName)])
         try {
           await client.deploy(...DEFAULT_DEPLOY_PARAMS)
           isRejected = false
@@ -1557,7 +1557,7 @@ File: ~/Objects/custform_15_t1049933_143.xml
           return { isSuccess: () => true }
         })
         let isRejected: boolean
-        testGraph.addNodes([new GraphNode(testSDFNode)])
+        testGraph.addNodes([new GraphNode(testSDFNode, testSDFNode.elemIdFullName)])
         try {
           await client.deploy(...DEFAULT_DEPLOY_PARAMS)
           isRejected = false
@@ -1608,7 +1608,7 @@ Object: customrecord_flo_customization.custrecord_flo_custz_link (customrecordcu
           return { isSuccess: () => true }
         })
         let isRejected: boolean
-        testGraph.addNodes([new GraphNode(testSDFNode)])
+        testGraph.addNodes([new GraphNode(testSDFNode, testSDFNode.elemIdFullName)])
         try {
           await client.deploy(...DEFAULT_DEPLOY_PARAMS)
           isRejected = false
@@ -1660,7 +1660,7 @@ Object: customrecord_flo_customization.custrecord_flo_custz_link (customrecordcu
           return { isSuccess: () => true }
         })
         let isRejected: boolean
-        testGraph.addNodes([new GraphNode(testSDFNode)])
+        testGraph.addNodes([new GraphNode(testSDFNode, testSDFNode.elemIdFullName)])
         try {
           await client.deploy(...DEFAULT_DEPLOY_PARAMS)
           isRejected = false
@@ -1714,7 +1714,7 @@ File: ~/AccountConfiguration/features.xml`
           return { isSuccess: () => true }
         })
         let isRejected: boolean
-        testGraph.addNodes([new GraphNode(testSDFNode)])
+        testGraph.addNodes([new GraphNode(testSDFNode, testSDFNode.elemIdFullName)])
         try {
           await client.deploy(...DEFAULT_DEPLOY_PARAMS)
           isRejected = false
@@ -1737,7 +1737,7 @@ File: ~/AccountConfiguration/features.xml`
           },
           path: ['Templates', 'E-mail Templates', 'InnerFolder'],
         }
-        testGraph.addNodes([new GraphNode({ serviceid: 'Templates/E-mail Templates/InnerFolder', elemIdFullName: 'name', changeType: 'addition', customizationInfo: folderCustomizationInfo } as SDFObjectNode)])
+        testGraph.addNodes([new GraphNode({ serviceid: 'Templates/E-mail Templates/InnerFolder', elemIdFullName: 'name', changeType: 'addition', customizationInfo: folderCustomizationInfo } as SDFObjectNode, 'name')])
         await client.deploy(...DEFAULT_DEPLOY_PARAMS)
         expect(mkdirpMock).toHaveBeenCalledTimes(1)
         expect(mkdirpMock)
@@ -1766,7 +1766,7 @@ File: ~/AccountConfiguration/features.xml`
           path: ['Templates', 'E-mail Templates', 'InnerFolder', 'content.html'],
           fileContent: dummyFileContent,
         }
-        testGraph.addNodes([new GraphNode({ serviceid: 'Templates/E-mail Templates/InnerFolder/content.html', elemIdFullName: 'name', changeType: 'addition', customizationInfo: fileCustomizationInfo } as SDFObjectNode)])
+        testGraph.addNodes([new GraphNode({ serviceid: 'Templates/E-mail Templates/InnerFolder/content.html', elemIdFullName: 'name', changeType: 'addition', customizationInfo: fileCustomizationInfo } as SDFObjectNode, 'name')])
         await client.deploy(...DEFAULT_DEPLOY_PARAMS)
         expect(mkdirpMock).toHaveBeenCalledTimes(2)
         expect(mkdirpMock)
@@ -1800,7 +1800,7 @@ File: ~/AccountConfiguration/features.xml`
         },
       }
       it('should succeed', async () => {
-        testGraph.addNodes([new GraphNode({ serviceid: '', elemIdFullName: 'name', changeType: 'addition', customizationInfo: featuresCustomizationInfo } as SDFObjectNode)])
+        testGraph.addNodes([new GraphNode({ serviceid: '', elemIdFullName: 'name', changeType: 'addition', customizationInfo: featuresCustomizationInfo } as SDFObjectNode, 'name')])
         mockExecuteAction.mockResolvedValue({ isSuccess: () => true, data: ['Configure feature -- The SUITEAPPCONTROLCENTER(Departments) feature has been DISABLED'] })
         await client.deploy(...DEFAULT_DEPLOY_PARAMS)
         expect(writeFileMock).toHaveBeenCalledTimes(3)
@@ -1815,7 +1815,7 @@ File: ~/AccountConfiguration/features.xml`
 
       it('should throw FeaturesDeployError on failed features deploy', async () => {
         const errorMessage = 'Configure feature -- Enabling of the SUITEAPPCONTROLCENTER(SuiteApp Control Center) feature has FAILED'
-        testGraph.addNodes([new GraphNode({ serviceid: '', elemIdFullName: 'name', changeType: 'addition', customizationInfo: featuresCustomizationInfo } as SDFObjectNode)])
+        testGraph.addNodes([new GraphNode({ serviceid: '', elemIdFullName: 'name', changeType: 'addition', customizationInfo: featuresCustomizationInfo } as SDFObjectNode, 'name')])
         mockExecuteAction.mockResolvedValue({ isSuccess: () => true, data: [errorMessage] })
         await expect(client.deploy(...DEFAULT_DEPLOY_PARAMS))
           .rejects.toThrow(new FeaturesDeployError(errorMessage, ['SUITEAPPCONTROLCENTER']))
@@ -1847,8 +1847,8 @@ File: ~/AccountConfiguration/features.xml`
         scriptId: scriptId2,
       }
       testGraph.addNodes([
-        new GraphNode({ serviceid: scriptId1, elemIdFullName: 'name1', changeType: 'addition', customizationInfo: customTypeInfo1 } as SDFObjectNode),
-        new GraphNode({ serviceid: scriptId2, elemIdFullName: 'name2', changeType: 'addition', customizationInfo: customTypeInfo2 } as SDFObjectNode),
+        new GraphNode({ serviceid: scriptId1, elemIdFullName: 'name1', changeType: 'addition', customizationInfo: customTypeInfo1 } as SDFObjectNode, 'name1'),
+        new GraphNode({ serviceid: scriptId2, elemIdFullName: 'name2', changeType: 'addition', customizationInfo: customTypeInfo2 } as SDFObjectNode, 'name2'),
       ])
       await client.deploy(...DEFAULT_DEPLOY_PARAMS)
       expect(writeFileMock).toHaveBeenCalledTimes(4)
@@ -1866,8 +1866,8 @@ File: ~/AccountConfiguration/features.xml`
     describe('validate only', () => {
       const failObject = 'fail_object'
       testGraph.addNodes([
-        new GraphNode({ serviceid: failObject, elemIdFullName: 'name2', changeType: 'addition', customizationInfo: { typeName: 'typeName', values: { key: 'val' }, scriptId: failObject } } as SDFObjectNode),
-        new GraphNode({ serviceid: 'successObject', elemIdFullName: 'name2', changeType: 'addition', customizationInfo: { typeName: 'typeName', values: { key: 'val' }, scriptId: 'successObject' } } as SDFObjectNode),
+        new GraphNode({ serviceid: failObject, elemIdFullName: 'name2', changeType: 'addition', customizationInfo: { typeName: 'typeName', values: { key: 'val' }, scriptId: failObject } } as SDFObjectNode, 'name2'),
+        new GraphNode({ serviceid: 'successObject', elemIdFullName: 'name2', changeType: 'addition', customizationInfo: { typeName: 'typeName', values: { key: 'val' }, scriptId: 'successObject' } } as SDFObjectNode, 'name2'),
       ])
       const deployParams: [undefined, SdfDeployParams, Graph<SDFObjectNode>] = [
         undefined,

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -1301,7 +1301,7 @@ describe('sdf client', () => {
         customTypeInfo.scriptId = scriptId
         testGraph.addNodes([new GraphNode<SDFObjectNode>({ serviceid: scriptId, elemIdFullName: 'name', changeType: 'addition', customizationInfo: customTypeInfo })])
         await client.deploy(...DEFAULT_DEPLOY_PARAMS)
-        expect(writeFileMock).toHaveBeenCalledTimes(2)
+        expect(writeFileMock).toHaveBeenCalledTimes(3)
         expect(writeFileMock).toHaveBeenCalledWith(expect.stringContaining(`${scriptId}.xml`),
           '<typeName><key>val</key></typeName>')
         expect(writeFileMock).toHaveBeenCalledWith(expect.stringContaining('manifest.xml'), MOCK_MANIFEST_VALID_DEPENDENCIES)
@@ -1319,7 +1319,7 @@ describe('sdf client', () => {
         testGraph.addNodes([new GraphNode<SDFObjectNode>({ serviceid: scriptId, elemIdFullName: scriptId, changeType: 'addition', customizationInfo: customTypeInfo })])
         await client.deploy('a.b.c', DEFAULT_DEPLOY_PARAMS[1], DEFAULT_DEPLOY_PARAMS[2])
         expect(renameMock).toHaveBeenCalled()
-        expect(writeFileMock).toHaveBeenCalledTimes(2)
+        expect(writeFileMock).toHaveBeenCalledTimes(3)
         expect(writeFileMock).toHaveBeenCalledWith(expect.stringContaining(`${scriptId}.xml`),
           '<typeName><key>val</key></typeName>')
         expect(writeFileMock).toHaveBeenCalledWith(expect.stringContaining('manifest.xml'), MOCK_MANIFEST_VALID_DEPENDENCIES)
@@ -1343,7 +1343,7 @@ describe('sdf client', () => {
         } as TemplateCustomTypeInfo
         testGraph.addNodes([new GraphNode<SDFObjectNode>({ serviceid: scriptId, elemIdFullName: scriptId, changeType: 'addition', customizationInfo: templateCustomTypeInfo })])
         await client.deploy(...DEFAULT_DEPLOY_PARAMS)
-        expect(writeFileMock).toHaveBeenCalledTimes(3)
+        expect(writeFileMock).toHaveBeenCalledTimes(4)
         expect(writeFileMock)
           .toHaveBeenCalledWith(expect.stringContaining(`${scriptId}.xml`), '<typeName><key>val</key></typeName>')
         expect(writeFileMock)
@@ -1742,7 +1742,7 @@ File: ~/AccountConfiguration/features.xml`
         expect(mkdirpMock).toHaveBeenCalledTimes(1)
         expect(mkdirpMock)
           .toHaveBeenCalledWith(expect.stringContaining(`${osPath.sep}Templates${osPath.sep}E-mail Templates${osPath.sep}InnerFolder${osPath.sep}`))
-        expect(writeFileMock).toHaveBeenCalledTimes(2)
+        expect(writeFileMock).toHaveBeenCalledTimes(3)
         expect(writeFileMock).toHaveBeenCalledWith(expect.stringContaining(MOCK_FOLDER_ATTRS_PATH),
           '<folder><description>folder description</description></folder>')
         expect(writeFileMock).toHaveBeenCalledWith(expect.stringContaining('manifest.xml'), MOCK_MANIFEST_VALID_DEPENDENCIES)
@@ -1773,7 +1773,7 @@ File: ~/AccountConfiguration/features.xml`
           .toHaveBeenCalledWith(expect.stringContaining(`${osPath.sep}Templates${osPath.sep}E-mail Templates${osPath.sep}InnerFolder${osPath.sep}`))
         expect(mkdirpMock)
           .toHaveBeenCalledWith(expect.stringContaining(`${osPath.sep}Templates${osPath.sep}E-mail Templates${osPath.sep}InnerFolder${osPath.sep}${ATTRIBUTES_FOLDER_NAME}`))
-        expect(writeFileMock).toHaveBeenCalledTimes(3)
+        expect(writeFileMock).toHaveBeenCalledTimes(4)
         expect(writeFileMock).toHaveBeenCalledWith(expect.stringContaining(MOCK_FILE_ATTRS_PATH),
           '<file><description>file description</description></file>')
         expect(writeFileMock).toHaveBeenCalledWith(expect.stringContaining(MOCK_FILE_PATH),
@@ -1803,7 +1803,7 @@ File: ~/AccountConfiguration/features.xml`
         testGraph.addNodes([new GraphNode({ serviceid: '', elemIdFullName: 'name', changeType: 'addition', customizationInfo: featuresCustomizationInfo } as SDFObjectNode)])
         mockExecuteAction.mockResolvedValue({ isSuccess: () => true, data: ['Configure feature -- The SUITEAPPCONTROLCENTER(Departments) feature has been DISABLED'] })
         await client.deploy(...DEFAULT_DEPLOY_PARAMS)
-        expect(writeFileMock).toHaveBeenCalledTimes(2)
+        expect(writeFileMock).toHaveBeenCalledTimes(3)
         expect(writeFileMock).toHaveBeenCalledWith(expect.stringContaining('features.xml'), MOCK_FEATURES_XML)
         expect(writeFileMock).toHaveBeenCalledWith(expect.stringContaining('manifest.xml'), MOCK_MANIFEST_VALID_DEPENDENCIES)
         expect(rmMock).toHaveBeenCalledTimes(2)
@@ -1851,7 +1851,7 @@ File: ~/AccountConfiguration/features.xml`
         new GraphNode({ serviceid: scriptId2, elemIdFullName: 'name2', changeType: 'addition', customizationInfo: customTypeInfo2 } as SDFObjectNode),
       ])
       await client.deploy(...DEFAULT_DEPLOY_PARAMS)
-      expect(writeFileMock).toHaveBeenCalledTimes(3)
+      expect(writeFileMock).toHaveBeenCalledTimes(4)
       expect(writeFileMock).toHaveBeenCalledWith(expect.stringContaining(`${scriptId1}.xml`),
         '<typeName><key>val</key></typeName>')
       expect(writeFileMock).toHaveBeenCalledWith(expect.stringContaining(`${scriptId2}.xml`),


### PR DESCRIPTION
_do not list explicitly in the deploy.xml elements that have a circular dependeny_

---

_None_

---
_Release Notes_: 
_Netsuite Adapter_:
* Elements that have circular dependency will not be listed explicitly in deploy.xml to avoid circular dependency error

---
_User Notifications_: 
_None_
