### PR TITLE
SALTO-3987: Converts BrandTheme favicon url to TemplateExpression

### DIFF
--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -43,6 +43,7 @@ import privateApiDeployFilter from './filters/private_api_deploy'
 import profileEnrollmentAttributesFilter from './filters/profile_enrollment_attributes'
 import groupRolesFilter from './filters/group_roles'
 import userFilter from './filters/user'
+import templateUrlsFilter from './filters/template_urls'
 import { OKTA } from './constants'
 import { getLookUpName } from './reference_mapping'
 import serviceUrlFilter from './filters/service_url'
@@ -72,8 +73,9 @@ export const DEFAULT_FILTERS = [
   userFilter,
   oktaExpressionLanguageFilter,
   profileEnrollmentAttributesFilter,
+  templateUrlsFilter,
   fieldReferencesFilter,
-  // should run before appDeploymentFilter and after after userSchemaFilter
+  // should run before appDeploymentFilter and after userSchemaFilter
   serviceUrlFilter,
   appDeploymentFilter,
   defaultPolicyRuleDeployment,

--- a/packages/okta-adapter/src/filters/template_urls.ts
+++ b/packages/okta-adapter/src/filters/template_urls.ts
@@ -38,7 +38,7 @@ const filter: FilterCreator = () => ({
     if (!_.isString(subdomain)) {
       log.warn('Could not find subdomain, skipping templateUrlsFilter')
     }
-    const subdomainRegString = `://${subdomain}`
+    const subdomainRegString = `://${subdomain}.`
     const subdomainReg = new RegExp(`(${subdomainRegString})`)
 
     const brandThemeInstance = instances.find(instance => instance.elemID.typeName === 'BrandTheme')
@@ -52,7 +52,7 @@ const filter: FilterCreator = () => ({
       [subdomainReg],
       expression => {
         if (expression === `${subdomainRegString}`) {
-          return ['://', new ReferenceExpression(orgSettingsInstance.elemID.createNestedID('subdomain'), subdomain)]
+          return ['://', new ReferenceExpression(orgSettingsInstance.elemID.createNestedID('subdomain'), subdomain), '.']
         }
         return expression
       },

--- a/packages/okta-adapter/src/filters/template_urls.ts
+++ b/packages/okta-adapter/src/filters/template_urls.ts
@@ -1,0 +1,60 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { Element, isInstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
+import { extractTemplate } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+import { FilterCreator } from '../filter'
+import { ORG_SETTING_TYPE_NAME } from '../constants'
+
+const log = logger(module)
+
+/**
+ * Create template expressions for url in BrandTheme type
+ */
+const filter: FilterCreator = () => ({
+  name: 'templateUrlsFilter',
+  onFetch: async (elements: Element[]) => {
+    const instances = elements.filter(isInstanceElement)
+    const orgSettingsInstance = instances.find(instance => instance.elemID.typeName === ORG_SETTING_TYPE_NAME)
+    if (orgSettingsInstance === undefined) {
+      log.warn(`Could not find ${ORG_SETTING_TYPE_NAME} instance, skipping templateUrlsFilter`)
+      return
+    }
+    const subdomain = orgSettingsInstance?.value?.subdomain
+    const subdomainReg = new RegExp(`(${subdomain})`)
+
+    const brandThemeInstance = instances.find(instance => instance.elemID.typeName === 'BrandTheme')
+    const faviconUrl = brandThemeInstance?.value?.favicon
+    if (brandThemeInstance === undefined || !_.isString(faviconUrl)) {
+      log.warn('Could not change favicon field in BrandTheme with TemplateExpression')
+      return
+    }
+    const template = extractTemplate(
+      faviconUrl,
+      [subdomainReg],
+      expression => {
+        if (expression === subdomain) {
+          return new ReferenceExpression(orgSettingsInstance.elemID.createNestedID('subdomain'), subdomain)
+        }
+        return expression
+      },
+    )
+    brandThemeInstance.value.favicon = template
+  },
+})
+
+export default filter

--- a/packages/okta-adapter/src/filters/template_urls.ts
+++ b/packages/okta-adapter/src/filters/template_urls.ts
@@ -34,8 +34,12 @@ const filter: FilterCreator = () => ({
       log.warn(`Could not find ${ORG_SETTING_TYPE_NAME} instance, skipping templateUrlsFilter`)
       return
     }
-    const subdomain = orgSettingsInstance?.value?.subdomain
-    const subdomainReg = new RegExp(`(${subdomain})`)
+    const { subdomain } = orgSettingsInstance.value
+    if (!_.isString(subdomain)) {
+      log.warn('Could not find subdomain, skipping templateUrlsFilter')
+    }
+    const subdomainRegString = `://${subdomain}`
+    const subdomainReg = new RegExp(`(${subdomainRegString})`)
 
     const brandThemeInstance = instances.find(instance => instance.elemID.typeName === 'BrandTheme')
     const faviconUrl = brandThemeInstance?.value?.favicon
@@ -47,8 +51,8 @@ const filter: FilterCreator = () => ({
       faviconUrl,
       [subdomainReg],
       expression => {
-        if (expression === subdomain) {
-          return new ReferenceExpression(orgSettingsInstance.elemID.createNestedID('subdomain'), subdomain)
+        if (expression === `${subdomainRegString}`) {
+          return ['://', new ReferenceExpression(orgSettingsInstance.elemID.createNestedID('subdomain'), subdomain)]
         }
         return expression
       },

--- a/packages/okta-adapter/test/filters/template_urls.test.ts
+++ b/packages/okta-adapter/test/filters/template_urls.test.ts
@@ -62,5 +62,20 @@ describe('templateUrlsFilter', () => {
           const theme = elements.filter(isInstanceElement).find(i => i.elemID.typeName === 'BrandTheme')
           expect(theme?.value?.favicon).toEqual('https://myOkta.oktapreview.com/favicon.ico')
         })
+
+        it('should not create referene if subdomain exist somewhere else in the url', async () => {
+          const themeWithSub = themeInstance.clone()
+          themeWithSub.value.favicon = 'https://myOkta.oktapreview.com/myOkta/favicon.ico'
+          const elements = [orgType, orgInst, themeWithSub, themeType]
+          await filter.onFetch(elements)
+          const theme = elements.filter(isInstanceElement).find(i => i.elemID.typeName === 'BrandTheme')
+          expect(theme?.value?.favicon).toEqual(new TemplateExpression({
+            parts: [
+              'https://',
+              new ReferenceExpression(orgInst.elemID.createNestedID('subdomain'), orgInst.value.subdomain),
+              '.oktapreview.com/myOkta/favicon.ico',
+            ],
+          }))
+        })
       })
 })

--- a/packages/okta-adapter/test/filters/template_urls.test.ts
+++ b/packages/okta-adapter/test/filters/template_urls.test.ts
@@ -1,0 +1,66 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { ElemID, InstanceElement, ObjectType, ReferenceExpression, TemplateExpression, isInstanceElement } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import { getFilterParams } from '../utils'
+import templateUrlsFilter from '../../src/filters/template_urls'
+import { OKTA, ORG_SETTING_TYPE_NAME } from '../../src/constants'
+
+describe('templateUrlsFilter', () => {
+      type FilterType = filterUtils.FilterWith<'onFetch'>
+      let filter: FilterType
+      const orgType = new ObjectType({ elemID: new ElemID(OKTA, ORG_SETTING_TYPE_NAME) })
+      const themeType = new ObjectType({ elemID: new ElemID(OKTA, 'BrandTheme') })
+      const orgInst = new InstanceElement(
+        ElemID.CONFIG_NAME,
+        orgType,
+        { subdomain: 'myOkta', companyName: 'comp', status: 'ACTIVE' },
+      )
+      const themeInstance = new InstanceElement(
+        ElemID.CONFIG_NAME,
+        themeType,
+        { id: '111', favicon: 'https://myOkta.oktapreview.com/favicon.ico' },
+      )
+
+      const faviconTemplate = new TemplateExpression({
+        parts: [
+          'https://',
+          new ReferenceExpression(orgInst.elemID.createNestedID('subdomain'), orgInst.value.subdomain),
+          '.oktapreview.com/favicon.ico',
+        ],
+      })
+
+      beforeEach(() => {
+        filter = templateUrlsFilter(getFilterParams()) as typeof filter
+      })
+
+      describe('onFetch', () => {
+        it('should resolve templates in urls', async () => {
+          const elements = [orgType, orgInst, themeInstance.clone(), themeType]
+          await filter.onFetch(elements)
+          const theme = elements.filter(isInstanceElement).find(i => i.elemID.typeName === 'BrandTheme')
+          expect(theme?.value?.favicon).toEqual(faviconTemplate)
+        })
+
+        it('should not create reference for org settings if org settings instance does not exist', async () => {
+          const elements = [orgType, themeInstance.clone(), themeType]
+          await filter.onFetch(elements)
+          const theme = elements.filter(isInstanceElement).find(i => i.elemID.typeName === 'BrandTheme')
+          expect(theme?.value?.favicon).toEqual('https://myOkta.oktapreview.com/favicon.ico')
+        })
+      })
+})


### PR DESCRIPTION
Converts BrandTheme favicon url to TemplateExpression
Added fetch only cause `BrandTheme` deploy is not supported yet

---
_Release Notes_: 
None

---
_User Notifications_: 
None