### PR TITLE
SALTO-4040: Fix attribution NOTICES file workflow

### DIFF
--- a/.github/workflows/notices.yml
+++ b/.github/workflows/notices.yml
@@ -19,7 +19,7 @@ jobs:
 
     - run: |
         npm i -g synp yarn@1.22.0
-        yarn
+        yarn || yarn || yarn
         synp --source-file yarn.lock
 
     - name: ClearlyNoticed Action


### PR DESCRIPTION
Retry "yarn" command

---

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_