### PR TITLE
SALTO-4040: allow manually running the notices workflow

### DIFF
--- a/.github/workflows/notices.yml
+++ b/.github/workflows/notices.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     # every saturday on 3 am
     - cron: '0 3 * * 6'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION


---



---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_