### PR TITLE
SALTO-4057: Add deploy for Authenticator type

### DIFF
--- a/packages/okta-adapter/src/change_validators/enabled_authenticators.ts
+++ b/packages/okta-adapter/src/change_validators/enabled_authenticators.ts
@@ -1,0 +1,90 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { collections } from '@salto-io/lowerdash'
+import { logger } from '@salto-io/logging'
+import { ChangeValidator, getChangeData, isInstanceChange, isModificationChange, isInstanceElement, isReferenceExpression, InstanceElement } from '@salto-io/adapter-api'
+import { AUTHENTICATOR_TYPE_NAME, MFA_POLICY_TYPE_NAME } from '../constants'
+import { isDeactivationChange } from '../deployment'
+
+const { awu } = collections.asynciterable
+const log = logger(module)
+
+type PolicyToAuthenticator = {
+  policyName: string
+  authenticatorId: string
+}
+
+// Options are taken from: https://developer.okta.com/docs/reference/api/policy/#policy-factor-enroll-object
+const ENABLED_AUTHENTICATORS = ['OPTIONAL', 'REQUIRED']
+
+const getAutheticatorsForPolicy = (instance: InstanceElement): PolicyToAuthenticator[] => {
+  const authenticators = instance.value.settings?.authenticators
+  if (!Array.isArray(authenticators)) {
+    return []
+  }
+  return authenticators
+    // Indicates the authenticator is enabled for this policy
+    .filter(authenticator => ENABLED_AUTHENTICATORS.includes(authenticator.enroll?.self))
+    .map(authenticator => authenticator.key)
+    .filter(isReferenceExpression)
+    .map(ref => ref.elemID.getFullName())
+    .map(authenticatorId => ({ policyName: instance.elemID.name, authenticatorId }))
+}
+
+/**
+ * Don't deactivate Authenticator if it's enabled in MFA policy
+ */
+export const enabledAuthenticatorsValidator: ChangeValidator = async (changes, elementSource) => {
+  if (elementSource === undefined) {
+    log.error('Failed to run enabledAuthenticatorsValidator because element source is undefined')
+    return []
+  }
+  const deactivatedAuthenticators = changes
+    .filter(isInstanceChange)
+    .filter(isModificationChange)
+    .filter(change => getChangeData(change).elemID.typeName === AUTHENTICATOR_TYPE_NAME)
+    .filter(change =>
+      isDeactivationChange({ before: change.data.before.value.status, after: change.data.after.value.status }))
+    .map(getChangeData)
+
+
+  const mfaPolicies = await awu(await elementSource.list())
+    .filter(id => id.typeName === MFA_POLICY_TYPE_NAME)
+    .filter(id => id.idType === 'instance')
+    .map(id => elementSource.get(id))
+    .filter(isInstanceElement)
+    .toArray()
+
+  const authenticatorToPolicies = _.groupBy(
+    mfaPolicies.flatMap(policy => getAutheticatorsForPolicy(policy)),
+    authenticatorToPolicy => authenticatorToPolicy.authenticatorId
+  )
+
+  return deactivatedAuthenticators
+    .filter(instance => authenticatorToPolicies[instance.elemID.getFullName()] !== undefined)
+    .map(
+      instance => {
+        const relevantPolicies = authenticatorToPolicies[instance.elemID.getFullName()].map(obj => obj.policyName)
+        return {
+          elemID: instance.elemID,
+          severity: 'Error',
+          message: 'Cannot deactivate authenticator because it is enabled in one or more MultifactorEnrollmentPolicy',
+          detailedMessage: `This authenticator is enabled in the following MultifactorEnrollmentPolicy elements: ${relevantPolicies.join(', ')}. Please disable the authenticator in these policies before deactivating it.`,
+        }
+      }
+    )
+}

--- a/packages/okta-adapter/src/change_validators/index.ts
+++ b/packages/okta-adapter/src/change_validators/index.ts
@@ -25,8 +25,9 @@ import { customApplicationStatusValidator } from './custom_application_status'
 import { userTypeAndSchemaValidator } from './user_type_and_schema'
 import { appIntegrationSetupValidator } from './app_integration_setup'
 import { assignedAccessPoliciesValidator } from './assigned_policies'
-import OktaClient from '../client/client'
 import { groupSchemaModifyBaseValidator } from './group_schema_modify_base_fields'
+import { enabledAuthenticatorsValidator } from './enabled_authenticators'
+import OktaClient from '../client/client'
 
 export default ({
   client,
@@ -45,6 +46,7 @@ export default ({
     appIntegrationSetupValidator(client),
     assignedAccessPoliciesValidator,
     groupSchemaModifyBaseValidator,
+    enabledAuthenticatorsValidator,
   ]
 
   return createChangeValidator(validators)

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -771,6 +771,34 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
       fieldsToHide: [{ fieldName: 'id' }],
       serviceUrl: '/admin/access/multifactor#policies',
     },
+    deployRequests: {
+      add: {
+        url: '/api/v1/authenticators',
+        method: 'post',
+      },
+      modify: {
+        url: '/api/v1/authenticators/{authenticatorId}',
+        method: 'put',
+        urlParamsToFields: {
+          authenticatorId: 'id',
+        },
+      },
+      activate: {
+        url: '/api/v1/authenticators/{authenticatorId}/lifecycle/activate',
+        method: 'post',
+        urlParamsToFields: {
+          authenticatorId: 'id',
+        },
+      },
+      // There is no endpoint for remove, deactivating authenticator removes it
+      deactivate: {
+        url: '/api/v1/authenticators/{authenticatorId}/lifecycle/deactivate',
+        method: 'post',
+        urlParamsToFields: {
+          authenticatorId: 'id',
+        },
+      },
+    },
   },
   EventHook: {
     transformation: {

--- a/packages/okta-adapter/src/reference_mapping.ts
+++ b/packages/okta-adapter/src/reference_mapping.ts
@@ -199,6 +199,11 @@ export const referencesRules: OktaFieldReferenceDefinition[] = [
     serializationStrategy: 'id',
     target: { typeContext: 'neighborField' },
   },
+  {
+    src: { field: 'appInstanceId', parentTypes: ['AuthenticatorSettings'] },
+    serializationStrategy: 'id',
+    target: { type: APPLICATION_TYPE_NAME },
+  },
 ]
 
 // Resolve references to userSchema fields references to field name instead of full value

--- a/packages/okta-adapter/test/change_validators/enabled_authenticators.test.ts
+++ b/packages/okta-adapter/test/change_validators/enabled_authenticators.test.ts
@@ -1,0 +1,120 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { toChange, ObjectType, ElemID, InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { enabledAuthenticatorsValidator } from '../../src/change_validators/enabled_authenticators'
+import { OKTA, MFA_POLICY_TYPE_NAME, AUTHENTICATOR_TYPE_NAME } from '../../src/constants'
+
+describe('enabledAuthenticatorsValidator', () => {
+  const message = 'Cannot deactivate authenticator because it is enabled in one or more MultifactorEnrollmentPolicy'
+  const policyType = new ObjectType({ elemID: new ElemID(OKTA, MFA_POLICY_TYPE_NAME) })
+  const authType = new ObjectType({ elemID: new ElemID(OKTA, AUTHENTICATOR_TYPE_NAME) })
+  const auth1 = new InstanceElement('a', authType, { key: 'google_otp', status: 'ACTIVE' })
+  const auth2 = new InstanceElement('b', authType, { key: 'security_question', status: 'ACTIVE' })
+  const auth3 = new InstanceElement('c', authType, { key: 'okta_verify', status: 'ACTIVE' })
+  const auth4 = new InstanceElement('d', authType, { key: 'phone_number', status: 'ACTIVE' })
+  const MFA1 = new InstanceElement(
+    'mfa1',
+    policyType,
+    {
+      name: 'policy',
+      status: 'ACTIVE',
+      system: false,
+      type: 'MFA_POLICY',
+      settings: {
+        authenticators: [
+          { key: new ReferenceExpression(auth1.elemID, auth1), enroll: { self: 'OPTIONAL' } },
+          { key: new ReferenceExpression(auth2.elemID, auth2), enroll: { self: 'NOT_ALLOWED' } },
+          { key: new ReferenceExpression(auth3.elemID, auth3), enroll: { self: 'REQUIRED' } },
+        ],
+      },
+    },
+  )
+  const MFA2 = new InstanceElement(
+    'mfa2',
+    policyType,
+    {
+      name: 'policy',
+      status: 'ACTIVE',
+      system: true,
+      type: 'MFA_POLICY',
+      settings: {
+        authenticators: [
+          { key: new ReferenceExpression(auth1.elemID, auth1), enroll: { self: 'REQUIRED' } },
+          { key: new ReferenceExpression(auth2.elemID, auth2), enroll: { self: 'NOT_ALLOWED' } },
+        ],
+      },
+    },
+  )
+  const auth1After = auth1.clone()
+  auth1After.value.status = 'INACTIVE'
+  const auth2After = auth2.clone()
+  auth2After.value.status = 'INACTIVE'
+  const auth3After = auth3.clone()
+  auth3After.value.status = 'INACTIVE'
+  const elementSource = buildElementsSourceFromElements([policyType, authType, MFA1, MFA2, auth1, auth2, auth3, auth4])
+
+  it('should return an error for enabled authenticators', async () => {
+    const changeErrors = await enabledAuthenticatorsValidator(
+      [
+        toChange({ before: auth1, after: auth1After }),
+        toChange({ before: auth2, after: auth2After }),
+        toChange({ before: auth3, after: auth3After }),
+      ],
+      elementSource
+    )
+    expect(changeErrors).toHaveLength(2)
+    expect(changeErrors).toEqual([
+      {
+        elemID: auth1.elemID,
+        severity: 'Error',
+        message,
+        detailedMessage: 'This authenticator is enabled in the following MultifactorEnrollmentPolicy elements: mfa1, mfa2. Please disable the authenticator in these policies before deactivating it.',
+      },
+      {
+        elemID: auth3.elemID,
+        severity: 'Error',
+        message,
+        detailedMessage: 'This authenticator is enabled in the following MultifactorEnrollmentPolicy elements: mfa1. Please disable the authenticator in these policies before deactivating it.',
+      },
+    ])
+  })
+  it('should not return an error if the authenticator is disabled in all policies', async () => {
+    const auth4After = auth4.clone()
+    auth4After.value.status = 'INACTIVE'
+    const changeErrors = await enabledAuthenticatorsValidator(
+      [toChange({ before: auth2, after: auth2After }), toChange({ before: auth4, after: auth4After })],
+      elementSource
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
+  it('should do nothing if there are no MFA policies', async () => {
+    const changeErrors = await enabledAuthenticatorsValidator(
+      [toChange({ before: auth1, after: auth1After })],
+      buildElementsSourceFromElements(
+        [policyType, authType, auth1, auth2, auth3, auth4]
+      )
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
+  it('should do nothing when element source is missing', async () => {
+    const changeErrors = await enabledAuthenticatorsValidator(
+      [toChange({ before: auth1, after: auth1After })],
+      undefined
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
+})

--- a/packages/okta-adapter/test/change_validators/enabled_authenticators.test.ts
+++ b/packages/okta-adapter/test/change_validators/enabled_authenticators.test.ts
@@ -37,8 +37,8 @@ describe('enabledAuthenticatorsValidator', () => {
       settings: {
         authenticators: [
           { key: new ReferenceExpression(auth1.elemID, auth1), enroll: { self: 'OPTIONAL' } },
-          { key: new ReferenceExpression(auth2.elemID, auth2), enroll: { self: 'NOT_ALLOWED' } },
-          { key: new ReferenceExpression(auth3.elemID, auth3), enroll: { self: 'REQUIRED' } },
+          { key: new ReferenceExpression(auth2.elemID, auth2), enroll: { self: 'NOT_ALLOWED' }, extraField: 'field' },
+          { key: new ReferenceExpression(auth3.elemID, auth3), enroll: { self: 'REQUIRED', something: 'some' } },
         ],
       },
     },


### PR DESCRIPTION
Support deployment of authenticators

---

- There is not endpoint for `remove`, deactivating `Authenticator` removes it from the admin console
- I added a CV that verifies `Authenticator` is not being used in MFA policy before its deactivation
- added ref

---
_Release Notes_: 
None

---
_User Notifications_: 
None