### PR TITLE
SALTO-4050 fix more namespace errors and edit log to show full filePr…

### DIFF
--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -178,7 +178,7 @@ const getFullName = (obj: FileProperties, addNamespacePrefixToFullName?: boolean
     return obj.fullName
   }
 
-  // Managed package names should exactly match obj.namespacePrefix
+  // Instances of type InstalledPackage fullNames should never include the namespace prefix
   if (obj.type === INSTALLED_PACKAGE_METADATA) {
     return obj.fullName
   }
@@ -205,7 +205,8 @@ const getFullName = (obj: FileProperties, addNamespacePrefixToFullName?: boolean
   // obj.namespacePrefix is defined. In these cases, we want to add the prefix manually
     if (obj.fullName.includes(API_NAME_SEPARATOR)) {
     // Case for API name with an object <Object>.X where it should be <Object>.<namespace>__X
-      return obj.fullName.replace(API_NAME_SEPARATOR, `${API_NAME_SEPARATOR}${namePrefix}`)
+      const [parentName, instanceName] = obj.fullName.split(API_NAME_SEPARATOR)
+      return `${parentName}${API_NAME_SEPARATOR}${namePrefix}${instanceName}`
     }
     return `${namePrefix}${obj.fullName}`
   }

--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -31,6 +31,7 @@ import {
   UNLIMITED_INSTANCES_VALUE,
   FOLDER_CONTENT_TYPE,
   API_NAME_SEPARATOR,
+  INSTALLED_PACKAGE_METADATA,
 } from './constants'
 import SalesforceClient, { ErrorFilter } from './client/client'
 import {
@@ -178,7 +179,7 @@ const getFullName = (obj: FileProperties, addNamespacePrefixToFullName?: boolean
   }
 
   // Managed package names should exactly match obj.namespacePrefix
-  if (obj.fullName === obj.namespacePrefix) {
+  if (obj.type === INSTALLED_PACKAGE_METADATA) {
     return obj.fullName
   }
 
@@ -204,8 +205,7 @@ const getFullName = (obj: FileProperties, addNamespacePrefixToFullName?: boolean
   // obj.namespacePrefix is defined. In these cases, we want to add the prefix manually
     if (obj.fullName.includes(API_NAME_SEPARATOR)) {
     // Case for API name with an object <Object>.X where it should be <Object>.<namespace>__X
-      const [nameWithoutNamespace, nameParts] = obj.fullName.split(API_NAME_SEPARATOR).reverse()
-      return `${makeArray(nameParts).reverse().join(API_NAME_SEPARATOR)}${API_NAME_SEPARATOR}${namePrefix}${nameWithoutNamespace}`
+      return obj.fullName.replace(API_NAME_SEPARATOR, `${API_NAME_SEPARATOR}${namePrefix}`)
     }
     return `${namePrefix}${obj.fullName}`
   }

--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -178,11 +178,6 @@ const getFullName = (obj: FileProperties, addNamespacePrefixToFullName?: boolean
     return obj.fullName
   }
 
-  // Instances of type InstalledPackage fullNames should never include the namespace prefix
-  if (obj.type === INSTALLED_PACKAGE_METADATA) {
-    return obj.fullName
-  }
-
   const namePrefix = `${obj.namespacePrefix}${NAMESPACE_SEPARATOR}`
 
   if (obj.type === LAYOUT_TYPE_ID_METADATA_TYPE) {
@@ -201,8 +196,13 @@ const getFullName = (obj: FileProperties, addNamespacePrefixToFullName?: boolean
     return obj.fullName
   }
   if (addNamespacePrefixToFullName) {
-  // In some cases, obj.fullName does not contain the namespace prefix even though
-  // obj.namespacePrefix is defined. In these cases, we want to add the prefix manually
+    // Instances of type InstalledPackage fullNames should never include the namespace prefix
+    if (obj.type === INSTALLED_PACKAGE_METADATA) {
+      return obj.fullName
+    }
+
+    // In some cases, obj.fullName does not contain the namespace prefix even though
+    // obj.namespacePrefix is defined. In these cases, we want to add the prefix manually
     if (obj.fullName.includes(API_NAME_SEPARATOR)) {
     // Case for API name with an object <Object>.X where it should be <Object>.<namespace>__X
       const [parentName, instanceName] = obj.fullName.split(API_NAME_SEPARATOR)

--- a/packages/salesforce-adapter/test/fetch_installed_packages.test.ts
+++ b/packages/salesforce-adapter/test/fetch_installed_packages.test.ts
@@ -15,6 +15,7 @@
 */
 import { ObjectType, isInstanceElement, InstanceElement } from '@salto-io/adapter-api'
 import { makeArray } from '@salto-io/lowerdash/src/collections/array'
+import { INSTALLED_PACKAGE_METADATA, INSTANCE_FULL_NAME_FIELD, PERMISSION_SET_METADATA_TYPE } from '../src/constants'
 import mockClient from './client'
 import { fetchMetadataInstances } from '../src/fetch'
 import { buildMetadataQuery } from '../src/fetch_profile/metadata_query'
@@ -52,7 +53,7 @@ describe('Test fetching installed package metadata', () => {
     return elements.filter(isInstanceElement)[0]
   }
 
-  describe('Test fetching PermissionSets of installed packages', () => {
+  describe('when fetching PermissionSets of installed packages', () => {
     describe('if the API name already includes namespacePrefix', () => {
       it('should not add prefix to PermissionSet', async () => {
         const fullNameFromList = 'Test__TestPermissionSet'
@@ -92,8 +93,8 @@ describe('Test fetching installed package metadata', () => {
       })
     })
   })
-  describe('Test fetching objects with complicated API names', () => {
-    describe('addNamespacePrefixToFullName is true', () => {
+  describe('when fetching instances with fullNames that include API_NAME_SEPARATOR', () => {
+    describe('when addNamespacePrefixToFullName is true', () => {
       it('should add prefix to the object\'s name correctly', async () => {
         const fullNameFromList = 'Account.TestObject'
         const expectedFullName = 'Account.Test__TestObject'
@@ -105,19 +106,32 @@ describe('Test fetching installed package metadata', () => {
         expect(instance?.value).toHaveProperty('fullName', expectedFullName)
       })
     })
-    describe('addNamespacePrefixToFullName is false', () => {
+    describe('when addNamespacePrefixToFullName is false', () => {
       it('should not add prefix to the object\'s name', async () => {
         const fullNameFromList = 'TestPermissionSet'
-        const expectedFullName = 'TestPermissionSet'
         const addNamespacePrefixToFullName = false
-        const fileProp = mockFileProperties({ fullName: fullNameFromList, type: 'PermissionSet', namespacePrefix: 'Test' })
+        const fileProp = mockFileProperties({ fullName: fullNameFromList, type: PERMISSION_SET_METADATA_TYPE, namespacePrefix: 'Test' })
         const instance = await fetch({ fileProp, mockType: mockTypes.PermissionSet, addNamespacePrefixToFullName })
 
-        expect(instance).toBeDefined()
-        expect(instance?.value).toHaveProperty('fullName', expectedFullName)
+        expect(instance).toEqual(expect.objectContaining({
+          value: expect.objectContaining({ [INSTANCE_FULL_NAME_FIELD]: fullNameFromList }),
+        }))
       })
     })
   })
+  describe('when fetching instances of installed packages', () => {
+    it('should return the name of the managed package without any changes', async () => {
+      const fullNameFromList = 'TestNamespace'
+      const addNamespacePrefixToFullName = true
+      const fileProp = mockFileProperties({ fullName: fullNameFromList, type: INSTALLED_PACKAGE_METADATA })
+      const instance = await fetch({ fileProp, mockType: mockTypes.PermissionSet, addNamespacePrefixToFullName })
+
+      expect(instance).toEqual(expect.objectContaining({
+        value: expect.objectContaining({ [INSTANCE_FULL_NAME_FIELD]: fullNameFromList }),
+      }))
+    })
+  })
+
   describe('Test fetching layouts of installed packages', () => {
     describe('if the API name already includes namespacePrefix', () => {
       describe('if layout name does not include prefix', () => {

--- a/packages/salesforce-adapter/test/fetch_installed_packages.test.ts
+++ b/packages/salesforce-adapter/test/fetch_installed_packages.test.ts
@@ -92,6 +92,32 @@ describe('Test fetching installed package metadata', () => {
       })
     })
   })
+  describe('Test fetching objects with complicated API names', () => {
+    describe('addNamespacePrefixToFullName is true', () => {
+      it('should add prefix to the object\'s name correctly', async () => {
+        const fullNameFromList = 'Account.TestObject'
+        const expectedFullName = 'Account.Test__TestObject'
+        const addNamespacePrefixToFullName = true
+        const fileProp = mockFileProperties({ fullName: fullNameFromList, type: 'Account', namespacePrefix: 'Test' })
+        const instance = await fetch({ fileProp, mockType: mockTypes.PermissionSet, addNamespacePrefixToFullName })
+
+        expect(instance).toBeDefined()
+        expect(instance?.value).toHaveProperty('fullName', expectedFullName)
+      })
+    })
+    describe('addNamespacePrefixToFullName is false', () => {
+      it('should not add prefix to the object\'s name', async () => {
+        const fullNameFromList = 'TestPermissionSet'
+        const expectedFullName = 'TestPermissionSet'
+        const addNamespacePrefixToFullName = false
+        const fileProp = mockFileProperties({ fullName: fullNameFromList, type: 'PermissionSet', namespacePrefix: 'Test' })
+        const instance = await fetch({ fileProp, mockType: mockTypes.PermissionSet, addNamespacePrefixToFullName })
+
+        expect(instance).toBeDefined()
+        expect(instance?.value).toHaveProperty('fullName', expectedFullName)
+      })
+    })
+  })
   describe('Test fetching layouts of installed packages', () => {
     describe('if the API name already includes namespacePrefix', () => {
       describe('if layout name does not include prefix', () => {

--- a/packages/salesforce-adapter/test/fetch_installed_packages.test.ts
+++ b/packages/salesforce-adapter/test/fetch_installed_packages.test.ts
@@ -57,13 +57,13 @@ describe('Test fetching installed package metadata', () => {
     describe('if the API name already includes namespacePrefix', () => {
       it('should not add prefix to PermissionSet', async () => {
         const fullNameFromList = 'Test__TestPermissionSet'
-        const expectedFullName = 'Test__TestPermissionSet'
         const addNamespacePrefixToFullName = true
         const fileProp = mockFileProperties({ fullName: fullNameFromList, type: 'PermissionSet', namespacePrefix: 'Test' })
         const instance = await fetch({ fileProp, mockType: mockTypes.PermissionSet, addNamespacePrefixToFullName })
 
-        expect(instance).toBeDefined()
-        expect(instance?.value).toHaveProperty('fullName', expectedFullName)
+        expect(instance).toEqual(expect.objectContaining({
+          value: expect.objectContaining({ [INSTANCE_FULL_NAME_FIELD]: fullNameFromList }),
+        }))
       })
     })
     describe('if the API name does not include namespacePrefix', () => {
@@ -75,42 +75,56 @@ describe('Test fetching installed package metadata', () => {
           const fileProp = mockFileProperties({ fullName: fullNameFromList, type: 'PermissionSet', namespacePrefix: 'Test' })
           const instance = await fetch({ fileProp, mockType: mockTypes.PermissionSet, addNamespacePrefixToFullName })
 
-          expect(instance).toBeDefined()
-          expect(instance?.value).toHaveProperty('fullName', expectedFullName)
+          expect(instance).toEqual(expect.objectContaining({
+            value: expect.objectContaining({ [INSTANCE_FULL_NAME_FIELD]: expectedFullName }),
+          }))
         })
       })
       describe('addNamespacePrefixToFullName is false', () => {
         it('should not add prefix to PermissionSet', async () => {
           const fullNameFromList = 'TestPermissionSet'
-          const expectedFullName = 'TestPermissionSet'
           const addNamespacePrefixToFullName = false
           const fileProp = mockFileProperties({ fullName: fullNameFromList, type: 'PermissionSet', namespacePrefix: 'Test' })
           const instance = await fetch({ fileProp, mockType: mockTypes.PermissionSet, addNamespacePrefixToFullName })
 
-          expect(instance).toBeDefined()
-          expect(instance?.value).toHaveProperty('fullName', expectedFullName)
+          expect(instance).toEqual(expect.objectContaining({
+            value: expect.objectContaining({ [INSTANCE_FULL_NAME_FIELD]: fullNameFromList }),
+          }))
         })
       })
     })
-  })
-  describe('when fetching instances with fullNames that include API_NAME_SEPARATOR', () => {
-    describe('when addNamespacePrefixToFullName is true', () => {
-      it('should add prefix to the object\'s name correctly', async () => {
-        const fullNameFromList = 'Account.TestObject'
-        const expectedFullName = 'Account.Test__TestObject'
-        const addNamespacePrefixToFullName = true
-        const fileProp = mockFileProperties({ fullName: fullNameFromList, type: 'Account', namespacePrefix: 'Test' })
-        const instance = await fetch({ fileProp, mockType: mockTypes.PermissionSet, addNamespacePrefixToFullName })
+    describe('when fetching instances with fullNames that include API_NAME_SEPARATOR', () => {
+      describe('when addNamespacePrefixToFullName is true', () => {
+        it('should add prefix to the object\'s name correctly', async () => {
+          const fullNameFromList = 'Account.TestObject'
+          const expectedFullName = 'Account.Test__TestObject'
+          const addNamespacePrefixToFullName = true
+          const fileProp = mockFileProperties({ fullName: fullNameFromList, type: 'Account', namespacePrefix: 'Test' })
+          const instance = await fetch({ fileProp, mockType: mockTypes.PermissionSet, addNamespacePrefixToFullName })
 
-        expect(instance).toBeDefined()
-        expect(instance?.value).toHaveProperty('fullName', expectedFullName)
+          expect(instance).toEqual(expect.objectContaining({
+            value: expect.objectContaining({ [INSTANCE_FULL_NAME_FIELD]: expectedFullName }),
+          }))
+        })
+      })
+      describe('when addNamespacePrefixToFullName is false', () => {
+        it('should not add prefix to the object\'s name', async () => {
+          const fullNameFromList = 'TestPermissionSet'
+          const addNamespacePrefixToFullName = false
+          const fileProp = mockFileProperties({ fullName: fullNameFromList, type: PERMISSION_SET_METADATA_TYPE, namespacePrefix: 'Test' })
+          const instance = await fetch({ fileProp, mockType: mockTypes.PermissionSet, addNamespacePrefixToFullName })
+
+          expect(instance).toEqual(expect.objectContaining({
+            value: expect.objectContaining({ [INSTANCE_FULL_NAME_FIELD]: fullNameFromList }),
+          }))
+        })
       })
     })
-    describe('when addNamespacePrefixToFullName is false', () => {
-      it('should not add prefix to the object\'s name', async () => {
-        const fullNameFromList = 'TestPermissionSet'
-        const addNamespacePrefixToFullName = false
-        const fileProp = mockFileProperties({ fullName: fullNameFromList, type: PERMISSION_SET_METADATA_TYPE, namespacePrefix: 'Test' })
+    describe('when fetching instances of installed packages', () => {
+      it('should return the name of the managed package without any changes', async () => {
+        const fullNameFromList = 'TestNamespace'
+        const addNamespacePrefixToFullName = true
+        const fileProp = mockFileProperties({ fullName: fullNameFromList, type: INSTALLED_PACKAGE_METADATA })
         const instance = await fetch({ fileProp, mockType: mockTypes.PermissionSet, addNamespacePrefixToFullName })
 
         expect(instance).toEqual(expect.objectContaining({
@@ -119,19 +133,6 @@ describe('Test fetching installed package metadata', () => {
       })
     })
   })
-  describe('when fetching instances of installed packages', () => {
-    it('should return the name of the managed package without any changes', async () => {
-      const fullNameFromList = 'TestNamespace'
-      const addNamespacePrefixToFullName = true
-      const fileProp = mockFileProperties({ fullName: fullNameFromList, type: INSTALLED_PACKAGE_METADATA })
-      const instance = await fetch({ fileProp, mockType: mockTypes.PermissionSet, addNamespacePrefixToFullName })
-
-      expect(instance).toEqual(expect.objectContaining({
-        value: expect.objectContaining({ [INSTANCE_FULL_NAME_FIELD]: fullNameFromList }),
-      }))
-    })
-  })
-
   describe('Test fetching layouts of installed packages', () => {
     describe('if the API name already includes namespacePrefix', () => {
       describe('if layout name does not include prefix', () => {


### PR DESCRIPTION
Fix errors in namespace when API name is complex (has a `.` in the full name). Also edit log so that when the namespace prefix isn't added on purpose the log shows the full fileProps

---



---
_Release Notes_: _None_

---
_User Notifications_:  _None_