### PR TITLE
SALTO-3855: NaCls with invalid characters are ignored

### DIFF
--- a/packages/workspace/src/parser/internal/native/consumers/values.ts
+++ b/packages/workspace/src/parser/internal/native/consumers/values.ts
@@ -23,6 +23,7 @@ import { Value, TemplateExpression, ElemID, Values } from '@salto-io/adapter-api
 import _, { trimEnd } from 'lodash'
 import { Token } from 'moo'
 import { createTemplateExpression } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
 import { Consumer, ParseContext, ConsumerReturnType } from '../types'
 import { createReferenceExpresion, unescapeTemplateMarker, addValuePromiseWatcher,
   registerRange, positionAtStart, positionAtEnd } from '../helpers'
@@ -32,6 +33,16 @@ import { missingComma, unknownFunction, unterminatedString, invalidStringTemplat
 import { IllegalReference } from '../../types'
 
 export const MISSING_VALUE = '****dynamic****'
+
+const log = logger(module)
+
+export class UnknownCharacter extends Error {
+  constructor(
+    public readonly token: LexerToken,
+  ) {
+    super(`Unknown character: ${token.text}`)
+  }
+}
 
 const consumeWord: Consumer<string> = context => {
   const wordToken = context.lexer.next()
@@ -427,7 +438,8 @@ export const consumeValue = (
 ): ConsumerReturnType<Value> => {
   // We force the value to be in the same line if the seperator is a newline by
   // ignoring newlines if the seperator is not a new line...
-  switch (context.lexer.peek(valueSeperator !== TOKEN_TYPES.NEWLINE)?.type) {
+  const token = context.lexer.peek(valueSeperator !== TOKEN_TYPES.NEWLINE)
+  switch (token?.type) {
     case TOKEN_TYPES.OCURLY:
       return consumeObject(context, idPrefix)
     case TOKEN_TYPES.ARR_OPEN:
@@ -443,7 +455,10 @@ export const consumeValue = (
     case valueSeperator:
       return consumeMissingValue(context)
     default:
-      // Linter Mincha
+      if (token !== undefined) {
+        throw new UnknownCharacter(token)
+      }
+      log.error('Received an undefined token in `consumeValue`')
       throw new Error('Unknown value')
   }
 }

--- a/packages/workspace/src/parser/internal/native/parse.ts
+++ b/packages/workspace/src/parser/internal/native/parse.ts
@@ -15,6 +15,7 @@
 */
 import { Element } from '@salto-io/adapter-api'
 import { flattenElementStr } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
 import { ParseResult } from '../../types'
 import { Keywords } from '../../language'
 import { Functions } from '../../functions'
@@ -25,6 +26,8 @@ import { ParseContext } from './types'
 import { replaceValuePromises, positionAtStart, positionAtEnd } from './helpers'
 import { consumeVariableBlock, consumeElement } from './consumers/top_level'
 import { UnknownCharacter } from './consumers/values'
+
+const log = logger(module)
 
 const isVariableDef = (context: ParseContext): boolean => (
   context.lexer.peek()?.type === TOKEN_TYPES.WORD
@@ -112,6 +115,8 @@ export async function parseBuffer(
           e.message,
         ))
       }
+    } else {
+      log.error('Unexpected error while parsing %s: %o', filename, e)
     }
   }
 

--- a/packages/workspace/test/parser/parse.test.ts
+++ b/packages/workspace/test/parser/parse.test.ts
@@ -804,6 +804,17 @@ value
       expect(result.errors).not.toHaveLength(0)
       expect(result.errors[0].summary).toEqual('Invalid attribute key')
     })
+
+    it('fails on invalid character', async () => {
+      const body = `
+        salesforce.Type inst {
+          val = 'aaa"
+        }
+      `
+      const result = await parse(Buffer.from(body), 'none', functions)
+      expect(result.errors).toHaveLength(1)
+      expect(result.errors[0].summary).toEqual('Invalid string character')
+    })
   })
 
   it('fails on invalid top level syntax', async () => {


### PR DESCRIPTION
When there is an invalid character in a NaCl (e.g., `'`), the NaCl is ignored and no error is returned 

---
_Release Notes_: 
_Core_:
- Fixed a bug where no error would be returned when there is an invalid character in the NaCl (e.g., `'`)

---
_User Notifications_: 
None