### PR TITLE
SALTO-2678: Support fetching and deploying workflow diagrams - Jira

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/cloud/workflow.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/workflow.ts
@@ -97,6 +97,10 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
       description: '',
       to: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'backlog'), allElements),
       type: 'initial',
+      from: [{
+        sourceAngle: 33.45,
+        targetAngle: 99.89,
+      }],
       rules: {
         validators: [
           {
@@ -391,7 +395,7 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
         key: 'jira.issue.editable',
         value: 'true',
       }],
-      direction: {
+      location: {
         x: 12.34,
         y: 56.78,
       },
@@ -403,7 +407,7 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
         key: 'jira.issue.editable',
         value: 'true',
       }],
-      direction: {
+      location: {
         x: 67.89,
         y: 20.78,
       },

--- a/packages/jira-adapter/e2e_test/instances/cloud/workflow.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/workflow.ts
@@ -176,9 +176,11 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
     {
       name: 'TransitionToShared',
       description: '',
-      from: [
-        createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'done'), allElements),
-      ],
+      from: [{
+        id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'done'), allElements),
+        sourceAngle: 12.45,
+        targetAngle: 67.89,
+      }],
       to: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'backlog'), allElements),
       type: 'directed',
       rules: {
@@ -389,6 +391,10 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
         key: 'jira.issue.editable',
         value: 'true',
       }],
+      direction: {
+        x: 12.34,
+        y: 56.78,
+      },
     },
     {
       id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'done'), allElements),
@@ -397,6 +403,10 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
         key: 'jira.issue.editable',
         value: 'true',
       }],
+      direction: {
+        x: 67.89,
+        y: 20.78,
+      },
     },
   ],
 })

--- a/packages/jira-adapter/e2e_test/instances/datacenter/workflow.ts
+++ b/packages/jira-adapter/e2e_test/instances/datacenter/workflow.ts
@@ -99,9 +99,11 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
     {
       name: 'TransitionToShared',
       description: '',
-      from: [
-        createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'done'), allElements),
-      ],
+      from: [{
+        id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'done'), allElements),
+        sourceAngle: 12.45,
+        targetAngle: 67.89,
+      }],
       to: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'backlog'), allElements),
       type: 'common',
       rules: {
@@ -199,6 +201,10 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
         key: 'jira.issue.editable',
         value: 'true',
       }],
+      direction: {
+        x: 12.34,
+        y: 56.78,
+      },
     },
     {
       id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'done'), allElements),
@@ -207,6 +213,10 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
         key: 'jira.issue.editable',
         value: 'true',
       }],
+      direction: {
+        x: 67.89,
+        y: 20.78,
+      },
     },
   ],
 })

--- a/packages/jira-adapter/e2e_test/instances/datacenter/workflow.ts
+++ b/packages/jira-adapter/e2e_test/instances/datacenter/workflow.ts
@@ -44,6 +44,10 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
       description: '',
       to: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'backlog'), allElements),
       type: 'initial',
+      from: [{
+        sourceAngle: 33.45,
+        targetAngle: 99.89,
+      }],
       rules: {
         validators: [
           {
@@ -201,7 +205,7 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
         key: 'jira.issue.editable',
         value: 'true',
       }],
-      direction: {
+      location: {
         x: 12.34,
         y: 56.78,
       },
@@ -213,7 +217,7 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
         key: 'jira.issue.editable',
         value: 'true',
       }],
-      direction: {
+      location: {
         x: 67.89,
         y: 20.78,
       },

--- a/packages/jira-adapter/jest.config.js
+++ b/packages/jira-adapter/jest.config.js
@@ -29,7 +29,7 @@ module.exports = deepMerge(
     ],
     coverageThreshold: {
       'global': {
-        branches: 92.7,
+        branches: 92.6,
         functions: 95,
         lines: 95,
         statements: 95,

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -62,6 +62,7 @@ import projectComponentFilter from './filters/project_component'
 import archivedProjectComponentsFilter from './filters/archived_project_components'
 import defaultInstancesDeployFilter from './filters/default_instances_deploy'
 import workflowStructureFilter from './filters/workflow/workflow_structure_filter'
+import workflowDiagramFilter from './filters/workflow/workflow_diagrams'
 import resolutionPropertyFilter from './filters/workflow/resolution_property_filter'
 import workflowPropertiesFilter from './filters/workflow/workflow_properties_filter'
 import transitionIdsFilter from './filters/workflow/transition_ids_filter'
@@ -185,6 +186,7 @@ export const DEFAULT_FILTERS = [
   groupNameFilter,
   workflowGroupsFilter,
   workflowSchemeFilter,
+  workflowDiagramFilter,
   issueTypeFilter,
   issueTypeSchemeReferences,
   issueTypeSchemeFilter,

--- a/packages/jira-adapter/src/change_validators/workflows/workflow_properties.ts
+++ b/packages/jira-adapter/src/change_validators/workflows/workflow_properties.ts
@@ -22,7 +22,7 @@ import { isWorkflowInstance, Status, Transition } from '../../filters/workflow/t
 
 const { awu } = collections.asynciterable
 
-const getPropertiesKeyGroups = (statusesOrTransitions: Status[]| Transition[]):
+const getPropertiesKeyGroups = (statusesOrTransitions: (Status| Transition)[]):
   string[][] => Array.from(statusesOrTransitions).map(param =>
   (param.properties ?? []).map(((property: Values) => property.key)))
 

--- a/packages/jira-adapter/src/filters/workflow/triggers_deployment.ts
+++ b/packages/jira-adapter/src/filters/workflow/triggers_deployment.ts
@@ -20,7 +20,7 @@ import { collections } from '@salto-io/lowerdash'
 import Joi from 'joi'
 import _ from 'lodash'
 import JiraClient from '../../client/client'
-import { Transition, Workflow, WorkflowInstance, workflowSchema } from './types'
+import { Transition, TransitionFrom, Workflow, WorkflowInstance, workflowSchema } from './types'
 
 const { awu } = collections.asynciterable
 
@@ -58,10 +58,12 @@ const getTransitionsFromService = async (
   return workflowValues.transitions ?? []
 }
 
-export const getTransitionKey = (transition: Transition): string => [
-  ..._.sortBy(transition.from ?? []),
-  transition.name ?? '',
-].join('-')
+export const getTransitionKey = (transition: Transition): string => {
+  const fromIds = _.sortBy(transition.from?.map((from:TransitionFrom | string) => (
+    typeof from === 'string' ? from : from.id
+  )) ?? [])
+  return [fromIds, transition.name ?? ''].join('-')
+}
 
 export const deployTriggers = async (
   change: AdditionChange<WorkflowInstance>,

--- a/packages/jira-adapter/src/filters/workflow/triggers_deployment.ts
+++ b/packages/jira-adapter/src/filters/workflow/triggers_deployment.ts
@@ -20,7 +20,7 @@ import { collections } from '@salto-io/lowerdash'
 import Joi from 'joi'
 import _ from 'lodash'
 import JiraClient from '../../client/client'
-import { Transition, TransitionFrom, Workflow, WorkflowInstance, workflowSchema } from './types'
+import { Transition, Workflow, WorkflowInstance, workflowSchema } from './types'
 
 const { awu } = collections.asynciterable
 
@@ -59,7 +59,7 @@ const getTransitionsFromService = async (
 }
 
 export const getTransitionKey = (transition: Transition): string => {
-  const fromIds = _.sortBy(transition.from?.map((from:TransitionFrom | string) => (
+  const fromIds = _.sortBy(transition.from?.map(from => (
     typeof from === 'string' ? from : from.id
   )) ?? [])
   return [fromIds, transition.name ?? ''].join('-')

--- a/packages/jira-adapter/src/filters/workflow/types.ts
+++ b/packages/jira-adapter/src/filters/workflow/types.ts
@@ -133,9 +133,9 @@ const rulesSchema = Joi.object({
   conditions: conditionScheme.optional(),
 }).unknown(true)
 
-export type StatusDirection ={
-  x: string
-  y: string
+export type StatusLocation ={
+  x?: string
+  y?: string
 }
 
 export type TransitionFrom = {
@@ -168,7 +168,7 @@ export type Status = {
   id?: string
   name?: string
   properties?: Values
-  direction?: StatusDirection
+  location?: StatusLocation
 }
 
 const statusSchema = Joi.object({
@@ -189,7 +189,7 @@ export const workflowSchema = Joi.object({
   id: idSchema.optional(),
   entityId: Joi.string().optional(),
   name: Joi.string().optional(),
-  transitions: Joi.array().items(transitionsSchema).optional(),
+  transitions: Joi.array().items(transitionsSchema).required(),
   statuses: Joi.array().items(statusSchema).optional(),
 }).unknown(true).required()
 

--- a/packages/jira-adapter/src/filters/workflow/types.ts
+++ b/packages/jira-adapter/src/filters/workflow/types.ts
@@ -133,12 +133,23 @@ const rulesSchema = Joi.object({
   conditions: conditionScheme.optional(),
 }).unknown(true)
 
+export type StatusDirection ={
+  x: string
+  y: string
+}
+
+export type TransitionFrom = {
+  id?: string
+  sourceAngle?: string
+  targetAngle?: string
+}
+
 export type Transition = {
   id?: string
   type?: string
   rules?: Rules
   name?: string
-  from?: unknown[]
+  from?: (TransitionFrom | string)[]
   properties?: Values
   to?: unknown
 }
@@ -154,9 +165,10 @@ export const transitionsSchema = Joi.object({
 }).unknown(true)
 
 export type Status = {
-  id?: unknown
+  id?: string
   name?: string
   properties?: Values
+  direction?: StatusDirection
 }
 
 const statusSchema = Joi.object({
@@ -177,7 +189,7 @@ export const workflowSchema = Joi.object({
   id: idSchema.optional(),
   entityId: Joi.string().optional(),
   name: Joi.string().optional(),
-  transitions: Joi.array().items(transitionsSchema).required(),
+  transitions: Joi.array().items(transitionsSchema).optional(),
   statuses: Joi.array().items(statusSchema).optional(),
 }).unknown(true).required()
 

--- a/packages/jira-adapter/src/filters/workflow/types.ts
+++ b/packages/jira-adapter/src/filters/workflow/types.ts
@@ -165,7 +165,7 @@ export const transitionsSchema = Joi.object({
 }).unknown(true)
 
 export type Status = {
-  id?: string
+  id?: unknown
   name?: string
   properties?: Values
   location?: StatusLocation

--- a/packages/jira-adapter/src/filters/workflow/workflow_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_deploy_filter.ts
@@ -111,10 +111,9 @@ export const deployWorkflow = async (
       // In DC we support passing the step name as part of the request
       || (!client.isDataCenter && path.name === 'name' && path.getFullNameParts().includes('statuses')),
   })
-
+  instance.value.entityId = instanceWithoutDiagram.value.entityId
   if (!isRemovalChange(resolvedChange) && hasDiagramFields(instance)) {
     try {
-      instance.value.entityId = instanceWithoutDiagram.value.entityId
       await deployWorkflowDiagram({ instance, client })
     } catch (e) {
       log.error(`Fail to deploy Workflow ${instance.value.name} diagram with the error: ${e.message}`)

--- a/packages/jira-adapter/src/filters/workflow/workflow_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_deploy_filter.ts
@@ -98,8 +98,7 @@ export const deployWorkflow = async (
 
   fixGroupNames(instance)
   const instanceCopy = instance.clone() as WorkflowInstance
-  const isNeedToDeployDiagram = !isRemovalChange(resolvedChange) && isHasDiagramFields(instance)
-  if (isNeedToDeployDiagram) {
+  if (!isRemovalChange(resolvedChange)) {
     removeWorkflowDiagramFields(instance)
   }
   await defaultDeployChange({
@@ -112,7 +111,7 @@ export const deployWorkflow = async (
       || (!client.isDataCenter && path.name === 'name' && path.getFullNameParts().includes('statuses')),
   })
 
-  if (isNeedToDeployDiagram) {
+  if (!isRemovalChange(resolvedChange) && isHasDiagramFields(instanceCopy)) {
     try {
       const workflowDiagramMaps = await buildDiagramMaps({ client, workflow: instanceCopy })
       await deployWorkflowDiagram(instanceCopy, client, workflowDiagramMaps)

--- a/packages/jira-adapter/src/filters/workflow/workflow_diagrams.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_diagrams.ts
@@ -1,0 +1,345 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import _ from 'lodash'
+import { BuiltinTypes, CORE_ANNOTATIONS, Element, ElemID, Field, isInstanceElement, ListType, ObjectType, Values } from '@salto-io/adapter-api'
+import { elements as adapterComponentsElements } from '@salto-io/adapter-components'
+import Joi from 'joi'
+import { logger } from '@salto-io/logging'
+import { addAnnotationRecursively, findObject } from '../../utils'
+import { JIRA, WORKFLOW_STATUS_TYPE_NAME, WORKFLOW_TRANSITION_TYPE_NAME } from '../../constants'
+import { FilterCreator } from '../../filter'
+import { isWorkflowInstance, TransitionFrom, WorkflowInstance } from './types'
+import JiraClient from '../../client/client'
+
+const log = logger(module)
+
+type StatusDiagramFields = {
+    id: string
+    name: string
+    x: string
+    y: string
+    statusId: string
+    initial?: boolean
+}
+
+type TransitionDiagramFields = {
+    id: string
+    name: string
+    sourceId: string
+    targetId: string
+    sourceAngle: string
+    targetAngle: string
+}
+
+type WorkflowLayout = {
+    statuses: StatusDiagramFields[]
+    transitions: TransitionDiagramFields[]
+}
+
+type WorkflowDiagramResponse = {
+  layout: WorkflowLayout
+}
+
+type StatusDiagramDeploy = {
+  id: string
+  x?: string
+  y?: string
+}
+
+type TransitionDiagramDeploy = {
+  id: string
+  sourceAngle?: string
+  targetAngle?: string
+  sourceId: string
+  targetId: string
+}
+
+export type WorkflowDiagramMaps = {
+  statusIdToStatus: Record<string, StatusDiagramFields>
+  statusIdToStepId: Record<string, string>
+  actionKeyToTransition: Record<string, TransitionDiagramFields>
+}
+
+const INITIAL_TRANSITION_TYPE = 'initial'
+
+const addObjectTypesAnnotation = async (objectTypes: ObjectType[]): Promise<void> => {
+  objectTypes.forEach(async objectType => {
+    await addAnnotationRecursively(objectType, CORE_ANNOTATIONS.CREATABLE)
+    await addAnnotationRecursively(objectType, CORE_ANNOTATIONS.UPDATABLE)
+    objectType.annotations[CORE_ANNOTATIONS.CREATABLE] = true
+    objectType.annotations[CORE_ANNOTATIONS.UPDATABLE] = true
+  })
+}
+
+const createWorkflowDiagramFieldsTypes = (): {
+  transitionFromType: ObjectType
+  statusDirectionType: ObjectType
+} => {
+  const transitionFromType = new ObjectType({
+    elemID: new ElemID(JIRA, 'TransitionFrom'),
+    fields: {
+      id: { refType: BuiltinTypes.STRING },
+      sourceAngle: { refType: BuiltinTypes.NUMBER },
+      targetAngle: { refType: BuiltinTypes.NUMBER },
+    },
+    path: [JIRA, adapterComponentsElements.TYPES_PATH, adapterComponentsElements.SUBTYPES_PATH, 'TransitionFrom'],
+  })
+  const statusDirectionType = new ObjectType({
+    elemID: new ElemID(JIRA, 'StatusDirection'),
+    fields: {
+      x: { refType: BuiltinTypes.NUMBER },
+      y: { refType: BuiltinTypes.NUMBER },
+    },
+    path: [JIRA, adapterComponentsElements.TYPES_PATH, adapterComponentsElements.SUBTYPES_PATH, 'StatusDirection'],
+  })
+  return { transitionFromType, statusDirectionType }
+}
+
+const isValidDiagramResponse = (response: unknown): response is WorkflowDiagramResponse => {
+  const { error } = Joi.object({
+    layout: Joi.object({
+      statuses: Joi.array().items(Joi.object({
+        statusId: Joi.number(),
+        id: Joi.string(),
+        x: Joi.number(),
+        y: Joi.number(),
+      }).unknown(true)),
+      transitions: Joi.array().items(Joi.object({
+        name: Joi.string(),
+        id: Joi.string(),
+        sourceId: Joi.string(),
+        targetId: Joi.string(),
+        sourceAngle: Joi.number(),
+        targetAngle: Joi.number(),
+      }).unknown(true)),
+    }).unknown(true).required(),
+  }).unknown(true).required().validate(response)
+
+  if (error !== undefined) {
+    return false
+  }
+  return true
+}
+
+const getTransitionKey = (from: string, name: string): string =>
+  [from, name].join('-')
+
+const convertTransitionKeyToActionKey = (key: string, statusIdToStepId: Record<string, string>):string => {
+  const splittedKey = key.split('-')
+  return [statusIdToStepId[splittedKey[0]], splittedKey.slice(1).join('-')].join('-')
+}
+
+const getTransitionFrom = (transitionName: string, statusIdToStepId: Record<string, string>,
+  actionKeyToTransition: Record<string, TransitionDiagramFields>, statusId?: string)
+  : TransitionFrom => {
+  const actionKey = convertTransitionKeyToActionKey(getTransitionKey(statusId ?? '', transitionName), statusIdToStepId)
+  if (actionKeyToTransition[actionKey] === undefined) {
+    throw new Error(`Fail to get Workflow Transition ${transitionName} Diagram values`)
+  }
+  return { id: statusId === INITIAL_TRANSITION_TYPE ? undefined : statusId,
+    sourceAngle: actionKeyToTransition[actionKey].sourceAngle,
+    targetAngle: actionKeyToTransition[actionKey].targetAngle }
+}
+
+export const removeWorkflowDiagramFields = (element: WorkflowInstance): void => {
+  element.value.statuses
+    ?.filter(status => status.direction !== undefined)
+    .forEach(status => {
+      delete status.direction
+    })
+  element.value.transitions
+    ?.filter((transition:Values) => transition.from !== undefined)
+    .forEach((transition: Values) => {
+      const { type } = transition
+      if (type === INITIAL_TRANSITION_TYPE) {
+        delete transition.from
+      } else {
+        transition.from = transition.from.map((from:TransitionFrom) => from.id)
+      }
+    })
+}
+
+const buildStatusDiagramFields = (workflow: WorkflowInstance, statusIdToStepId: Record<string, string>)
+  :StatusDiagramDeploy[] | undefined =>
+  workflow.value.statuses
+    ?.map(status => (
+      { id: statusIdToStepId[status.id as string],
+        x: status.direction?.x,
+        y: status.direction?.y }
+    ))
+
+const buildTransitionsDiagramFields = (workflow: WorkflowInstance, statusIdToStepId: Record<string, string>,
+  actionKeyToTransition: Record<string, TransitionDiagramFields>)
+  : (TransitionDiagramDeploy | undefined)[] | undefined =>
+  workflow.value.transitions
+    ?.flatMap(transition => {
+      const { name, type } = transition
+      return transition.from
+        ?.map((from: TransitionFrom | string) => {
+          if (typeof from !== 'string') {
+            // transition type may be 'initial' or 'directed' in here
+            const fromId = type === INITIAL_TRANSITION_TYPE ? INITIAL_TRANSITION_TYPE : from.id
+            if (fromId === undefined || name === undefined) {
+              throw new Error(`Fail to deploy Workflow ${workflow.value.name} Transition ${transition.name} diagram values`)
+            }
+            const transitionDiagramFields = actionKeyToTransition[getTransitionKey(statusIdToStepId[fromId], name)]
+            if (transitionDiagramFields === undefined) {
+              throw new Error(`Fail to deploy Workflow ${workflow.value.name} Transition ${transition.name} diagram values`)
+            }
+            return {
+              id: transitionDiagramFields.id,
+              sourceAngle: from.sourceAngle,
+              targetAngle: from.targetAngle,
+              sourceId: transitionDiagramFields.sourceId,
+              targetId: transitionDiagramFields.targetId,
+            }
+          }
+          return undefined
+        })
+    }).filter(val => !_.isUndefined(val))
+
+export const isHasDiagramFields = (instance: WorkflowInstance): boolean => {
+  const statusesDirections = instance.value.statuses
+    ?.map(status => status.direction)
+    .filter(direction => !_.isUndefined(direction))
+  const transitionsFrom = instance.value.transitions
+    .flatMap(transition => transition.from)
+    .filter(from => !_.isUndefined(from) && typeof from !== 'string'
+      && (!_.isUndefined(from.targetAngle) || !_.isUndefined(from.sourceAngle)))
+  return (!_.isUndefined(statusesDirections) && statusesDirections.length > 0)
+    || (!_.isUndefined(transitionsFrom) && transitionsFrom.length > 0)
+}
+
+
+export const deployWorkflowDiagram = async (workflow: WorkflowInstance, client: JiraClient,
+  { statusIdToStepId, actionKeyToTransition }
+  : WorkflowDiagramMaps): Promise<void> => {
+  const statuses = buildStatusDiagramFields(workflow, statusIdToStepId)
+  const transitions = buildTransitionsDiagramFields(workflow, statusIdToStepId, actionKeyToTransition)
+
+  const response = await client.postPrivate({
+    url: '/rest/workflowDesigner/latest/workflows',
+    data: {
+      draft: false,
+      name: workflow.value.name,
+      layout: { statuses, transitions },
+    },
+  })
+  if (response.status !== 200) {
+    throw new Error(`Fail to post Workflow ${workflow.value.name} diagram values with status ${response.status}`)
+  }
+}
+
+export const buildDiagramMaps = (async ({ client, workflow }:
+  {client: JiraClient
+    workflow: WorkflowInstance
+  }):Promise<WorkflowDiagramMaps> => {
+  const { name } = workflow.value
+  const statusIdToStatus: Record<string, StatusDiagramFields> = {}
+  const statusIdToStepId: Record<string, string> = {}
+  const actionKeyToTransition: Record<string, TransitionDiagramFields> = {}
+  if (name === undefined) {
+    throw new Error('Fail to get workflow diagram values because it\'s name is undefined')
+  }
+  const response = await client.getPrivate({
+    url: '/rest/workflowDesigner/1.0/workflows',
+    queryParams: {
+      name,
+    },
+  })
+  if (!isValidDiagramResponse(response.data)) {
+    throw new Error(`Fail to get the workflow ${workflow.value.name} diagram values due to an invalid response`)
+  }
+  const { layout } = response.data
+  layout.statuses.forEach(status => {
+    statusIdToStatus[status.statusId] = status
+  })
+  layout.transitions.forEach(transition => {
+    actionKeyToTransition[getTransitionKey(transition.sourceId, transition.name)] = transition
+  })
+  workflow.value.statuses?.forEach(status => {
+    if (status.id !== undefined) {
+      statusIdToStepId[status.id as string] = statusIdToStatus[status.id].id
+    }
+  })
+  const initialStepId = layout.statuses
+    .filter(status => status.initial) // there is always only one initial status
+    .map(status => status.id)[0]
+  statusIdToStepId.initial = initialStepId
+  return { statusIdToStatus, statusIdToStepId, actionKeyToTransition }
+})
+
+export const insertWorkflowDiagramFields = (workflow: WorkflowInstance,
+  { statusIdToStatus, statusIdToStepId, actionKeyToTransition }: WorkflowDiagramMaps)
+  : void => {
+  workflow.value.statuses?.forEach(status => {
+    if (status.id !== undefined) {
+      status.direction = { x: statusIdToStatus[status.id].x,
+        y: statusIdToStatus[status.id].y }
+    }
+  })
+  workflow.value.transitions?.forEach(transition => {
+    if (transition.type === INITIAL_TRANSITION_TYPE) {
+      transition.from = [getTransitionFrom(transition.name ?? '', statusIdToStepId, actionKeyToTransition, INITIAL_TRANSITION_TYPE)]
+    } else {
+      transition.from = transition
+        .from?.map(from => (
+          typeof from === 'string'
+            ? getTransitionFrom(transition.name ?? '', statusIdToStepId, actionKeyToTransition, from)
+            : from
+        ))
+    }
+  })
+}
+
+const filter: FilterCreator = ({ client }) => ({
+  name: 'workflowDiagramFilter',
+  onFetch: async (elements: Element[]) => {
+    const { transitionFromType, statusDirectionType } = createWorkflowDiagramFieldsTypes()
+    await addObjectTypesAnnotation([transitionFromType, statusDirectionType])
+
+    const transitionType = findObject(elements, WORKFLOW_TRANSITION_TYPE_NAME)
+    if (transitionType !== undefined) {
+      transitionType.fields.from = new Field(transitionType, 'transitionFrom', new ListType(transitionFromType))
+      transitionType.fields.from.annotations[CORE_ANNOTATIONS.UPDATABLE] = true
+      transitionType.fields.from.annotations[CORE_ANNOTATIONS.CREATABLE] = true
+    }
+    const workflowStatusType = findObject(elements, WORKFLOW_STATUS_TYPE_NAME)
+    if (workflowStatusType !== undefined) {
+      workflowStatusType.fields.direction = new Field(workflowStatusType, 'direction', statusDirectionType)
+      workflowStatusType.fields.direction.annotations[CORE_ANNOTATIONS.UPDATABLE] = true
+      workflowStatusType.fields.direction.annotations[CORE_ANNOTATIONS.CREATABLE] = true
+    }
+    elements.push(transitionFromType)
+    elements.push(statusDirectionType)
+
+    await Promise.all(elements
+      .filter(isInstanceElement)
+      .filter(isWorkflowInstance)
+      .map(async workflow => {
+        try {
+          const workflowDiagramMaps = await buildDiagramMaps(
+            { client, workflow }
+          )
+          insertWorkflowDiagramFields(workflow, workflowDiagramMaps)
+        } catch (e) {
+          log.error(e.message)
+        }
+      }))
+  },
+})
+export default filter

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -172,6 +172,11 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     target: { type: STATUS_TYPE_NAME },
   },
   {
+    src: { field: 'id', parentTypes: ['TransitionFrom'] },
+    serializationStrategy: 'id',
+    target: { type: STATUS_TYPE_NAME },
+  },
+  {
     src: { field: 'id', parentTypes: ['ProjectRoleConfig'] },
     serializationStrategy: 'id',
     target: { type: 'ProjectRole' },

--- a/packages/jira-adapter/test/filters/workflow/workflow_deploy_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_deploy_filter.test.ts
@@ -456,7 +456,7 @@ describe('workflowDeployFilter', () => {
               {
                 name: 'Resolved',
                 id: '5',
-                direction: {
+                location: {
                   x: -33,
                   y: 3,
                 },
@@ -464,7 +464,7 @@ describe('workflowDeployFilter', () => {
               {
                 name: 'Open',
                 id: '1',
-                direction: {
+                location: {
                   x: -3,
                   y: 3,
                 },
@@ -472,7 +472,7 @@ describe('workflowDeployFilter', () => {
               {
                 name: 'The best name',
                 id: '10007',
-                direction: {
+                location: {
                   x: 3,
                   y: -3,
                 },
@@ -480,7 +480,7 @@ describe('workflowDeployFilter', () => {
               {
                 name: 'Create',
                 id: '5',
-                direction: {
+                location: {
                   x: 3,
                   y: 33,
                 },
@@ -488,13 +488,13 @@ describe('workflowDeployFilter', () => {
               {
                 name: 'Building',
                 id: '400',
-                direction: {
+                location: {
                   x: 33,
                   y: 3,
                 },
               },
               {
-                name: 'without direction',
+                name: 'without location',
                 id: '500',
               },
             ],
@@ -547,6 +547,14 @@ describe('workflowDeployFilter', () => {
                     sourceAngle: 111,
                     targetAngle: 1,
                   },
+                ],
+                to: '10007',
+                type: 'directed',
+              },
+              {
+                name: 'with from as string',
+                from: [
+                  '5',
                 ],
                 to: '10007',
                 type: 'directed',
@@ -646,6 +654,14 @@ describe('workflowDeployFilter', () => {
                   targetId: 'S<4>',
                   sourceAngle: -78.11,
                   targetAngle: 173.58,
+                },
+                {
+                  id: 'A<51:S<3>:S<4>>',
+                  name: 'with from as string',
+                  sourceId: 'S<4>',
+                  targetId: 'S<2>',
+                  sourceAngle: 78.11,
+                  targetAngle: 122.58,
                 },
                 {
                   id: 'A<11:S<1>:S<1>>',
@@ -759,9 +775,15 @@ describe('workflowDeployFilter', () => {
         )])
         expect(logErrorSpy).toHaveBeenCalledWith('Fail to deploy Workflow workflowName diagram with the error: Fail to post Workflow workflowName diagram values with status 400')
       })
-      it('should work ok with no statuses and no transitions', async () => {
-        instance.value.statuses = undefined
-        instance.value.transitions = undefined
+      it('should log error when status does not have id ', async () => {
+        instance.value.statuses[2].id = undefined
+        await filter.deploy([toChange(
+          { after: instance }
+        )])
+        expect(logErrorSpy).toHaveBeenCalledWith('Fail to deploy Workflow workflowName diagram with the error: Fail to deploy Workflow workflowName Status The best name Diagram values')
+      })
+      it('should work ok with partial transition from values', async () => {
+        instance.value.transitions[2].from[0].targetAngle = undefined
         await filter.deploy([toChange(
           { after: instance }
         )])

--- a/packages/jira-adapter/test/filters/workflow/workflow_diagrams.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_diagrams.test.ts
@@ -216,10 +216,10 @@ describe('workflowDiagramFilter', () => {
       jest.clearAllMocks()
     })
 
-    it('should set the direction field in WorkflowStatus', async () => {
+    it('should set the location field in WorkflowStatus', async () => {
       const elements = [workflowStatusType]
       await filter.onFetch(elements)
-      expect(workflowStatusType.fields.direction).toBeDefined()
+      expect(workflowStatusType.fields.location).toBeDefined()
       expect(elements).toHaveLength(3)
     })
 
@@ -230,7 +230,7 @@ describe('workflowDiagramFilter', () => {
       expect(elements).toHaveLength(3)
     })
 
-    it('should add direction fields to the statuses', async () => {
+    it('should add location fields to the statuses', async () => {
       const elements = [instance]
       await filter.onFetch(elements)
       expect(mockConnection.get).toHaveBeenCalledWith(
@@ -241,9 +241,9 @@ describe('workflowDiagramFilter', () => {
         },
       )
       expect(elements).toHaveLength(3)
-      expect(instance.value.statuses[0].direction).toBeDefined()
-      expect(instance.value.statuses[0].direction.x).toEqual(-3)
-      expect(instance.value.statuses[0].direction.y).toEqual(6)
+      expect(instance.value.statuses[0].location).toBeDefined()
+      expect(instance.value.statuses[0].location.x).toEqual(-3)
+      expect(instance.value.statuses[0].location.y).toEqual(6)
     })
 
     it('should add angles to from values in transitions', async () => {
@@ -307,13 +307,13 @@ describe('workflowDiagramFilter', () => {
         client,
       })) as typeof filter
       await filter.onFetch(elements)
-      expect(logErrorSpy).toHaveBeenCalledWith('Fail to get the workflow workflowName diagram values due to an invalid response')
+      expect(logErrorSpy).toHaveBeenCalledWith('Failed to get the workflow diagram of jira.Workflow.instance.instance: Fail to get the workflow workflowName diagram values due to an invalid response')
     })
     it('should log error when workflow does not have a name', async () => {
       instance.value.name = undefined
       const elements = [instance]
       await filter.onFetch(elements)
-      expect(logErrorSpy).toHaveBeenCalledWith('Fail to get workflow diagram values because it\'s name is undefined')
+      expect(logErrorSpy).toHaveBeenCalledWith('Failed to get the workflow diagram of jira.Workflow.instance.instance: Fail to get workflow diagram values because its name is undefined')
     })
   })
 })

--- a/packages/jira-adapter/test/filters/workflow/workflow_diagrams.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_diagrams.test.ts
@@ -1,0 +1,319 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ListType, ObjectType } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
+import { MockInterface } from '@salto-io/test-utils'
+import JiraClient from '../../../src/client/client'
+import { JIRA, WORKFLOW_TYPE_NAME } from '../../../src/constants'
+import workflowDiagramsFilter from '../../../src/filters/workflow/workflow_diagrams'
+import { getFilterParams, mockClient } from '../../utils'
+
+const logging = logger('jira-adapter/src/filters/workflow/workflow_diagrams')
+const logErrorSpy = jest.spyOn(logging, 'error')
+
+describe('workflowDiagramFilter', () => {
+  let filter: filterUtils.FilterWith<'onFetch'>
+  let workflowType: ObjectType
+  let workflowStatusType: ObjectType
+  let workflowTransitionType: ObjectType
+  let instance: InstanceElement
+  let client: JiraClient
+  let mockConnection: MockInterface<clientUtils.APIConnection>
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    workflowStatusType = new ObjectType({
+      elemID: new ElemID(JIRA, 'WorkflowStatus'),
+    })
+    workflowTransitionType = new ObjectType({
+      elemID: new ElemID(JIRA, 'Transition'),
+    })
+
+    workflowType = new ObjectType({
+      elemID: new ElemID(JIRA, WORKFLOW_TYPE_NAME),
+      fields: {
+        statuses: { refType: new ListType(workflowStatusType) },
+        transitions: { refType: new ListType(workflowTransitionType) },
+      },
+    })
+
+    instance = new InstanceElement(
+      'instance',
+      workflowType,
+      {
+        name: 'workflowName',
+        statuses: [
+          {
+            name: 'Resolved',
+            id: '5',
+          },
+          {
+            name: 'Open',
+            id: '1',
+          },
+          {
+            name: 'The best name',
+            id: '10007',
+          },
+          {
+            name: 'Create',
+            id: '5',
+          },
+          {
+            name: 'Building',
+            id: '400',
+          },
+        ],
+        transitions: [
+          {
+            name: 'Building',
+            to: '400',
+            type: 'global',
+          },
+          {
+            name: 'Create',
+            to: '1',
+            type: 'initial',
+          },
+          {
+            name: 'hey',
+            from: ['1'],
+            to: '5',
+            type: 'directed',
+          },
+          {
+            name: 'super',
+            from: ['10007'],
+            to: '400',
+            type: 'directed',
+          },
+          {
+            name: 'yey',
+            from: ['5'],
+            to: '10007',
+            type: 'directed',
+          },
+        ],
+      }
+    )
+
+    const { client: cli, connection } = mockClient()
+    client = cli
+    mockConnection = connection
+
+    mockConnection.get.mockResolvedValue({
+      status: 200,
+      data: {
+        isDraft: false,
+        layout: {
+          statuses: [
+            {
+              id: 'S<3>',
+              name: 'Open',
+              stepId: '3',
+              statusId: '1',
+              x: 3,
+              y: 6,
+            },
+            {
+              id: 'I<1>',
+              name: 'Create',
+              stepId: '1',
+              x: 33,
+              y: 66,
+              initial: true,
+            },
+            {
+              id: 'S<4>',
+              name: 'Resolved',
+              stepId: '4',
+              statusId: '5',
+              x: -3,
+              y: 6,
+            },
+            {
+              id: 'S<1>',
+              name: 'Building',
+              stepId: '1',
+              statusId: '400',
+              x: 3,
+              y: -66,
+            },
+            {
+              id: 'S<2>',
+              name: 'The best name',
+              stepId: '2',
+              statusId: '10007',
+              x: 33,
+              y: -66,
+            },
+          ],
+          transitions: [
+            {
+              id: 'A<31:S<2>:S<1>>',
+              name: 'super',
+              sourceId: 'S<2>',
+              targetId: 'S<1>',
+              sourceAngle: 34.11,
+              targetAngle: 173.58,
+            },
+            {
+              id: 'IA<1:I<1>:S<3>>',
+              name: 'Create',
+              sourceId: 'I<1>',
+              targetId: 'S<3>',
+              sourceAngle: 99.11,
+              targetAngle: 173.58,
+            },
+            {
+              id: 'A<41:S<4>:S<2>>',
+              name: 'yey',
+              sourceId: 'S<4>',
+              targetId: 'S<2>',
+              sourceAngle: 78.11,
+              targetAngle: 122.58,
+            },
+            {
+              id: 'A<21:S<3>:S<4>>',
+              name: 'hey',
+              sourceId: 'S<3>',
+              targetId: 'S<4>',
+              sourceAngle: -78.11,
+              targetAngle: 173.58,
+            },
+            {
+              id: 'A<11:S<1>:S<1>>',
+              name: 'Building',
+              sourceId: 'S<1>',
+              targetId: 'S<1>',
+              sourceAngle: 78.11,
+              targetAngle: -173.58,
+            },
+          ],
+        },
+      },
+    })
+    filter = workflowDiagramsFilter(getFilterParams({
+      client,
+    })) as typeof filter
+  })
+
+  describe('onFetch', () => {
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it('should set the direction field in WorkflowStatus', async () => {
+      const elements = [workflowStatusType]
+      await filter.onFetch(elements)
+      expect(workflowStatusType.fields.direction).toBeDefined()
+      expect(elements).toHaveLength(3)
+    })
+
+    it('should set the from field in Transition', async () => {
+      const elements = [workflowTransitionType]
+      await filter.onFetch(elements)
+      expect(workflowTransitionType.fields.from).toBeDefined()
+      expect(elements).toHaveLength(3)
+    })
+
+    it('should add direction fields to the statuses', async () => {
+      const elements = [instance]
+      await filter.onFetch(elements)
+      expect(mockConnection.get).toHaveBeenCalledWith(
+        '/rest/workflowDesigner/1.0/workflows',
+        {
+          headers: { 'X-Atlassian-Token': 'no-check' },
+          params: { name: 'workflowName' },
+        },
+      )
+      expect(elements).toHaveLength(3)
+      expect(instance.value.statuses[0].direction).toBeDefined()
+      expect(instance.value.statuses[0].direction.x).toEqual(-3)
+      expect(instance.value.statuses[0].direction.y).toEqual(6)
+    })
+
+    it('should add angles to from values in transitions', async () => {
+      const elements = [instance]
+      await filter.onFetch(elements)
+      expect(mockConnection.get).toHaveBeenCalledWith(
+        '/rest/workflowDesigner/1.0/workflows',
+        {
+          headers: { 'X-Atlassian-Token': 'no-check' },
+          params: { name: 'workflowName' },
+        },
+      )
+      expect(elements).toHaveLength(3)
+      expect(instance.value.transitions[2].from).toBeDefined()
+      expect(instance.value.transitions[2].from[0].id).toEqual('1')
+      expect(instance.value.transitions[2].from[0].sourceAngle).toEqual(-78.11)
+      expect(instance.value.transitions[2].from[0].targetAngle).toEqual(173.58)
+    })
+    it('should add angles to from of initial transitions with undefined id', async () => {
+      const elements = [instance]
+      await filter.onFetch(elements)
+      expect(mockConnection.get).toHaveBeenCalledWith(
+        '/rest/workflowDesigner/1.0/workflows',
+        {
+          headers: { 'X-Atlassian-Token': 'no-check' },
+          params: { name: 'workflowName' },
+        },
+      )
+      expect(elements).toHaveLength(3)
+      expect(instance.value.transitions[1].from).toBeDefined()
+      expect(instance.value.transitions[1].from[0].id).toBeUndefined()
+      expect(instance.value.transitions[1].from[0].sourceAngle).toEqual(99.11)
+      expect(instance.value.transitions[1].from[0].targetAngle).toEqual(173.58)
+    })
+    it('from should not be undefined in global transitions', async () => {
+      const elements = [instance]
+      await filter.onFetch(elements)
+      expect(mockConnection.get).toHaveBeenCalledWith(
+        '/rest/workflowDesigner/1.0/workflows',
+        {
+          headers: { 'X-Atlassian-Token': 'no-check' },
+          params: { name: 'workflowName' },
+        },
+      )
+      expect(elements).toHaveLength(3)
+      expect(instance.value.transitions[0].from).toBeUndefined()
+    })
+
+    it('should log error when response is not valid', async () => {
+      const elements = [instance]
+      mockConnection.get.mockResolvedValue({
+        status: 200,
+        data: {
+          isDraft: false,
+          layout: {
+            statuses: 'not an array',
+          },
+        },
+      })
+      filter = workflowDiagramsFilter(getFilterParams({
+        client,
+      })) as typeof filter
+      await filter.onFetch(elements)
+      expect(logErrorSpy).toHaveBeenCalledWith('Fail to get the workflow workflowName diagram values due to an invalid response')
+    })
+    it('should log error when workflow does not have a name', async () => {
+      instance.value.name = undefined
+      const elements = [instance]
+      await filter.onFetch(elements)
+      expect(logErrorSpy).toHaveBeenCalledWith('Fail to get workflow diagram values because it\'s name is undefined')
+    })
+  })
+})


### PR DESCRIPTION
_Add support in fetching and deploying workflow diagrams_

---
Noise suppression can be found [here](https://github.com/salto-io/salto_private/pull/5587)

The statuses will have a new 'direction' field with its diagram coordinates: 

<img width="586" alt="Screen Shot 2023-04-27 at 19 15 50" src="https://user-images.githubusercontent.com/77064001/234926694-0f4ce07e-d383-4fb9-b2b8-5c4f70b61b46.png">

The transition 'from' field will contain the source and the target angles of the related statuses in the diagram, in addition to the 'from status' id:
 
<img width="1182" alt="Screen Shot 2023-04-27 at 19 18 04" src="https://user-images.githubusercontent.com/77064001/234927312-cbbe6327-3a87-45d3-86fe-a09bedd3624d.png">

---
_Release Notes_: 
_Jira Adapter_:
* add support in fetching and deploying workflow diagrams

---
_User Notifications_: 

_Jira Adapter_:
* workflow statuses will have 'direction' field that represents its diagram coordinates
* workflow transitions 'from' field will include the angles of the source and the target of the related statuses in the diagram.

