### PR TITLE
SALTO-4070 - Salesforce: Replace Formulon package with a regex

### DIFF
--- a/packages/salesforce-adapter/package.json
+++ b/packages/salesforce-adapter/package.json
@@ -40,7 +40,6 @@
     "@salto-io/lowerdash": "0.3.37",
     "bottleneck": "^2.19.5",
     "fast-xml-parser": "^3.15.0",
-    "formulon": "^6.24.1",
     "he": "^1.2.0",
     "joi": "^17.4.0",
     "jsforce": "https://github.com/salto-io/jsforce.git#3e8adeb2b14f8e443852605729990fd978efc209",

--- a/packages/salesforce-adapter/src/filters/formula_deps.ts
+++ b/packages/salesforce-adapter/src/filters/formula_deps.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 
+import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import { ElemID, ElemIDType, Field, isObjectType, ReadOnlyElementsSource, ReferenceExpression } from '@salto-io/adapter-api'
@@ -23,11 +24,6 @@ import { isFormulaField } from '../transformers/transformer'
 import { CUSTOM_METADATA_SUFFIX, FORMULA, SALESFORCE } from '../constants'
 import { FormulaIdentifierInfo, IdentifierType, parseFormulaIdentifier } from './formula_utils/parse'
 import { buildElementsSourceForFetch, extractFlatCustomObjectFields } from './utils'
-
-/* eslint-disable-next-line @typescript-eslint/no-var-requires */
-const formulon = require('formulon')
-
-const { extract } = formulon
 
 const log = logger(module)
 const { awu, groupByAsync } = collections.asynciterable
@@ -73,6 +69,20 @@ const referencesFromIdentifiers = async (typeInfos: FormulaIdentifierInfo[]): Pr
         ...identifierTypeToElementName(identifierInfo).map(naclCase))
     ))
 )
+
+
+const IDENTIFIER_REGEX = /(?:^|[^'"\w$]+)([^\s'"()&|+/*=\-,]+)(?:[\s),]|$)/mgi
+const extractIdentifiers = (formula: string): string[] => {
+  formula.replace(/"[^"]"/g, '""')
+  formula.replace(/'[^']'/g, '\'\'')
+  const identifiers: string[] = []
+  let match = IDENTIFIER_REGEX.exec(formula)
+  while (match) {
+    identifiers.push(match[1])
+    match = IDENTIFIER_REGEX.exec(formula)
+  }
+  return _.uniq(identifiers)
+}
 
 const addDependenciesAnnotation = async (field: Field, allElements: ReadOnlyElementsSource): Promise<void> => {
   const isValidReference = async (elemId: ElemID): Promise<boolean> => {
@@ -123,7 +133,7 @@ const addDependenciesAnnotation = async (field: Field, allElements: ReadOnlyElem
 
   try {
     const formulaIdentifiers: string[] = log.time(
-      () => (extract(formula)),
+      () => (extractIdentifiers(formula)),
       `Parse formula '${formula.slice(0, 15)}'`
     )
 

--- a/packages/salesforce-adapter/test/filters/formula_deps.test.ts
+++ b/packages/salesforce-adapter/test/filters/formula_deps.test.ts
@@ -204,6 +204,37 @@ describe('Formula dependencies', () => {
       expect(deps).toHaveLength(1)
       expect(deps[0].reference.elemID.typeName).not.toEqual('GarbageType')
     })
+    it('should not return a reference if it is inside a string', async () => {
+      const typeUnderTest = typeWithFormula.clone()
+      typeUnderTest.fields.someFormulaField__c.annotations[FORMULA] = '"ISBLANK(someField__c)"'
+
+      await filter.onFetch([typeUnderTest])
+      // eslint-disable-next-line no-underscore-dangle
+      const deps1 = typeUnderTest.fields.someFormulaField__c.annotations._generated_dependencies
+      expect(deps1).not.toBeDefined()
+
+      typeUnderTest.fields.someFormulaField__c.annotations[FORMULA] = '\'ISBLANK(someField__c)\''
+      await filter.onFetch([typeUnderTest])
+      // eslint-disable-next-line no-underscore-dangle
+      const deps2 = typeUnderTest.fields.someFormulaField__c.annotations._generated_dependencies
+      expect(deps2).not.toBeDefined()
+    })
+
+    it('should not return a reference if it is inside a string with escaped quotes', async () => {
+      const typeUnderTest = typeWithFormula.clone()
+      typeUnderTest.fields.someFormulaField__c.annotations[FORMULA] = '"\\"ISBLANK(someField__c)"'
+
+      await filter.onFetch([typeUnderTest])
+      // eslint-disable-next-line no-underscore-dangle
+      const deps = typeUnderTest.fields.someFormulaField__c.annotations._generated_dependencies
+      expect(deps).not.toBeDefined()
+
+      typeUnderTest.fields.someFormulaField__c.annotations[FORMULA] = '\'\\\'ISBLANK(someField__c)\''
+      await filter.onFetch([typeUnderTest])
+      // eslint-disable-next-line no-underscore-dangle
+      const deps2 = typeUnderTest.fields.someFormulaField__c.annotations._generated_dependencies
+      expect(deps2).not.toBeDefined()
+    })
   })
 
   describe('When referencing RecordType', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5543,11 +5543,6 @@ decimal.js@^10.2.1:
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.3.1.tgz#d8c3a444a9c6774ba60ca6ad7261c3a94fd5e783"
   integrity sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==
 
-decimal.js@^10.3.1:
-  version "10.4.3"
-  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.3.tgz#1044092884d245d1b7f65725fa4ad4c6f781cc23"
-  integrity sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==
-
 decode-uri-component@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
@@ -6872,13 +6867,6 @@ formidable@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.2.tgz#bf69aea2972982675f00865342b982986f6b8dd9"
   integrity sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==
-
-formulon@^6.24.1:
-  version "6.24.2"
-  resolved "https://registry.yarnpkg.com/formulon/-/formulon-6.24.2.tgz#024cad2a4314c273b3ee9dba10b8a65a98d566c5"
-  integrity sha512-uEOO6dMGc9UfTzK+87n/rrGs6HepMBnsFwLChozp+pTGj/PzP1HDzdEdSFVw6d7K2xeh2x7GvC5BFe1PAGMv+g==
-  dependencies:
-    decimal.js "^10.3.1"
 
 forwarded@0.2.0:
   version "0.2.0"


### PR DESCRIPTION
Formulon is currently unusable due to https://github.com/leifg/formulon/issues/1015, and we don't need a proper syntactic analysis, just the list of identifiers in the formula

---
This solution probably only sort-of-works, but:
1. We filter out invalid references anyway
2. We don't need to extract all identifiers - worst case is we don't add anything over what the Tooling API gives us.

https://xkcd.com/1171/

---
_Release Notes_: 
N/A

---
_User Notifications_: 
N/A