### PR TITLE
SALTO-4071: Hide UISchemaId Field

### DIFF
--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -1146,7 +1146,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
     transformation: {
       // TODO: should change to reference in SALTO-3806
       fieldTypeOverrides: [{ fieldName: 'uiSchemaId', fieldType: 'string' }],
-      fieldsToOmit: [{ fieldName: 'uiSchemaId' }],
+      fieldsToHide: [{ fieldName: 'uiSchemaId' }],
     },
   },
 }

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -1142,6 +1142,13 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
       fieldsToHide: [{ fieldName: 'id' }],
     },
   },
+  ProfileEnrollmentPolicyRuleAction: {
+    transformation: {
+      // TODO: should change to reference in SALTO-3806
+      fieldTypeOverrides: [{ fieldName: 'uiSchemaId', fieldType: 'string' }],
+      fieldsToOmit: [{ fieldName: 'uiSchemaId' }],
+    },
+  },
 }
 
 const DEFAULT_SWAGGER_CONFIG: OktaSwaggerApiConfig['swagger'] = {


### PR DESCRIPTION
Until we'll fetch `UISchema` type, we should hide `uiSchemaId` field from `ProfileEnrollmentRule` type to avoid diffs when comparing envs

---
_Release Notes_: 
None

---
_User Notifications_: 
None
