### PR TITLE
SALTO-3705: schema validation for subject conditions should allow reference expression

### DIFF
--- a/packages/zendesk-adapter/src/filters/utils.ts
+++ b/packages/zendesk-adapter/src/filters/utils.ts
@@ -34,7 +34,7 @@ export type Condition = {
   value?: unknown
 }
 export type SubjectCondition = {
-  subject: string
+  subject: string | ReferenceExpression
   value?: unknown
 }
 

--- a/packages/zendesk-adapter/src/filters/utils.ts
+++ b/packages/zendesk-adapter/src/filters/utils.ts
@@ -81,7 +81,7 @@ const CONDITION_SCHEMA = Joi.array().items(Joi.object({
 }).unknown(true)).required()
 
 const CONDITION_SUBJECT_SCHEMA = Joi.array().items(Joi.object({
-  subject: Joi.string().required(),
+  subject: [Joi.string().required(), Joi.object().required()],
   value: Joi.optional(),
 }).unknown(true)).required()
 


### PR DESCRIPTION
schema validation for subject conditions should allow reference expression

---

_Additional context for reviewer_

---
_Release Notes_: 
none

---
_User Notifications_: 
none
