### PR TITLE
SALTO - 3380: support open in app for reportdefinition and financial layout

### DIFF
--- a/packages/netsuite-adapter/src/service_url/constant_urls.ts
+++ b/packages/netsuite-adapter/src/service_url/constant_urls.ts
@@ -72,6 +72,8 @@ const TYPE_TO_URL: Record<StandardType | 'file' | 'folder', string| undefined> =
   transactioncolumncustomfield: 'app/common/custom/columncustfields.nl',
   translationcollection: 'app/translations/ui/managetranslations.nl#/collections',
   workflow: 'app/common/workflow/setup/workflowlist.nl',
+  financiallayout: '/app/reporting/financiallayouts.nl',
+  reportdefinition: '/app/reporting/savedreports.nl',
   cmscontenttype: undefined,
   customrecordactionscript: undefined,
   dataset: undefined,
@@ -79,8 +81,6 @@ const TYPE_TO_URL: Record<StandardType | 'file' | 'folder', string| undefined> =
   promotionsplugin: undefined,
   publisheddashboard: undefined,
   workbook: undefined,
-  financiallayout: undefined,
-  reportdefinition: undefined,
 }
 
 const setServiceUrl: ServiceUrlSetter = (elements, client) => {


### PR DESCRIPTION
_support open in app for reportdefinitions and financiallayout_

---

_None_

---
_Release Notes_: 
_Netsuite Adapter_:
* Open in app is supported for `reportdefinition` and `financiallayout` types

---
_User Notifications_: 
_None_
