### PR TITLE
SALTO-3990: Omit Custom Object instances with empty Salto ID

### DIFF
--- a/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
@@ -23,13 +23,14 @@ import {
   getInstancesDetailsMsg,
   createWarningFromMsg,
   getInstancesWithCollidingElemID,
+  safeJsonStringify,
 } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
-import { Element, Values, Field, InstanceElement, ReferenceExpression, SaltoError } from '@salto-io/adapter-api'
+import { Element, Values, Field, InstanceElement, ReferenceExpression, SaltoError, ElemID } from '@salto-io/adapter-api'
 import { FilterResult, RemoteFilterCreator } from '../filter'
 import { apiName, isInstanceOfCustomObject, isCustomObject } from '../transformers/transformer'
 import { FIELD_ANNOTATIONS, KEY_PREFIX, KEY_PREFIX_LENGTH, SALESFORCE } from '../constants'
-import { isLookupField, isMasterDetailField } from './utils'
+import { isLookupField, isMasterDetailField, safeApiName } from './utils'
 import { DataManagement } from '../fetch_profile/data_management'
 
 const { makeArray } = collections.array
@@ -69,6 +70,7 @@ const deserializeInternalID = (internalID: string): RefOrigin => {
 
 const createWarnings = async (
   instancesWithCollidingElemID: InstanceElement[],
+  instancesWithEmptyIds: InstanceElement[],
   missingRefs: MissingRef[],
   illegalRefSources: Set<string>,
   customObjectPrefixKeyMap: Record<string, string>,
@@ -86,6 +88,20 @@ const createWarnings = async (
     getInstanceName: instance => apiName(instance),
     docsUrl: 'https://help.salto.io/en/articles/6927217-salto-for-salesforce-cpq-support',
   })
+  const instanceWithEmptyIdWarnings = await awu(instancesWithEmptyIds)
+    // In case of collisions, there's already a warning on the Element
+    .filter(instance => !instancesWithCollidingElemID.includes(instance))
+    .map(async instance => {
+      const typeName = await safeApiName(await instance.getType()) ?? 'Unknown'
+      return createWarningFromMsg(
+        [
+          `Omitted Instance of type ${typeName} due to empty Salto ID.`,
+          `Current Salto ID configuration for ${typeName} is defined as ${safeJsonStringify(dataManagement.getObjectIdsFields(typeName))}`,
+          `Instance Service Url: ${getInstanceDesc(await serializeInstanceInternalID(instance), baseUrl)}`,
+        ].join('\n')
+      )
+    })
+    .toArray()
 
   const typeToInstanceIdToMissingRefs = _.mapValues(
     _.groupBy(
@@ -128,6 +144,7 @@ const createWarnings = async (
 
   return [
     ...collisionWarnings,
+    ...instanceWithEmptyIdWarnings,
     ...missingRefsWarnings,
     ...illegalOriginsWarnings,
   ]
@@ -274,6 +291,7 @@ const filter: RemoteFilterCreator = ({ client, config }) => ({
       dataManagement,
     )
     const instancesWithCollidingElemID = getInstancesWithCollidingElemID(customObjectInstances)
+    const instancesWithEmptyId = customObjectInstances.filter(instance => instance.elemID.name === ElemID.CONFIG_NAME)
     const missingRefOriginInternalIDs = new Set(
       missingRefs
         .map(missingRef => serializeInternalID(missingRef.origin.type, missingRef.origin.id))
@@ -281,9 +299,12 @@ const filter: RemoteFilterCreator = ({ client, config }) => ({
     const instWithDupElemIDInterIDs = new Set(
       await Promise.all(instancesWithCollidingElemID.map(serializeInstanceInternalID))
     )
+    const instancesWithEmptyIdInternalIDs = new Set(
+      await Promise.all(instancesWithEmptyId.map(serializeInstanceInternalID))
+    )
     const illegalRefTargets = new Set(
       [
-        ...missingRefOriginInternalIDs, ...instWithDupElemIDInterIDs,
+        ...missingRefOriginInternalIDs, ...instWithDupElemIDInterIDs, ...instancesWithEmptyIdInternalIDs,
       ]
     )
     const illegalRefSources = getIllegalRefSources(illegalRefTargets, reverseReferencesMap)
@@ -304,6 +325,7 @@ const filter: RemoteFilterCreator = ({ client, config }) => ({
     return {
       errors: await createWarnings(
         instancesWithCollidingElemID,
+        instancesWithEmptyId,
         missingRefs,
         illegalRefSources,
         customObjectPrefixKeyMap,


### PR DESCRIPTION
When a single instance of a certain type had empty Salto ID, we didn't omit the instance but treated it as it was a **Settings Instance**.

---

I've added additional handling in [customObjectInstancesReferences](https://github.com/salto-io/salto/blob/main/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts) for this edge case. I've tried to make the fetch warning as similar as possible to the collision warning.

---

### Collision Warning

Omitted 13 instances of Account due to Salto ID collisions.
Current Salto ID configuration for Account is defined as [UniqueField__c].

Breakdown per colliding Salto ID:
- Instances with empty name (Due to no values in any of the provided ID fields):
        * https://salto68-dev-ed.develop.my.salesforce.com/0018d00000Q8k44AAB
        * https://salto68-dev-ed.develop.my.salesforce.com/0018d00000Q8k4AAAR
        * https://salto68-dev-ed.develop.my.salesforce.com/0018d00000PxfVvAAJ
        * 10 more instances

To resolve these collisions please take one of the following actions and fetch again:
        1. Change Account's saltoIDSettings to include all fields that uniquely identify the type's instances.
        2. Delete duplicate instances from your salesforce account.

Alternatively, you can exclude Account from the data management configuration in salesforce.nacl

Learn more at: https://help.salto.io/en/articles/6927217-salto-for-salesforce-cpq-support

---

### Instance With Empty ID Warning

Omitted Instance of type Account due to empty Salto ID.
Current Salto ID configuration for Account is defined as ["UniqueField__c"]
Instance Service Url: https://salto68-dev-ed.develop.my.salesforce.com/Account$0018d00000Q8k44AAB

---
_Release Notes_: 
Salesforce Adapter:
- Data instances with empty Salto ID will be omitted with indicative fetch warning.

---
_User Notifications_: 
_None_
