### PR TITLE
SALTO-4080 - Change the return type of calcFetchChanges to array instead of iterator

### DIFF
--- a/packages/cli/src/commands/fetch_diff.ts
+++ b/packages/cli/src/commands/fetch_diff.ts
@@ -125,10 +125,9 @@ const fetchDiffToWorkspace = async (
     new Set([input.accountName]),
     new Set([input.accountName]),
   )
-  const allChanges = Array.from(changes)
 
-  outputLine(`Found ${allChanges.length} changes to apply`, output)
-  const conflicts = allChanges.filter(change => !_.isEmpty(change.pendingChanges))
+  outputLine(`Found ${changes.length} changes to apply`, output)
+  const conflicts = changes.filter(change => !_.isEmpty(change.pendingChanges))
   conflicts.forEach(change => {
     log.info(
       'Conflict between pending change IDs %s and incoming IDs %s',
@@ -142,10 +141,10 @@ const fetchDiffToWorkspace = async (
   }
   if (updateState) {
     outputLine(`Updating state for environment ${workspace.currentEnv()}`, output)
-    await updateStateElements(workspace.state(), allChanges.map(change => change.change))
+    await updateStateElements(workspace.state(), changes.map(change => change.change))
   }
   outputLine(`Updating NaCl for environment ${workspace.currentEnv()}`, output)
-  await workspace.updateNaclFiles(allChanges.map(change => change.change), input.mode)
+  await workspace.updateNaclFiles(changes.map(change => change.change), input.mode)
   const { status, errors } = await validateWorkspace(workspace)
   if (status === 'Error') {
     const formattedErrors = await formatWorkspaceErrors(workspace, errors)

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -208,7 +208,7 @@ export const deploy = async (
 export type FillConfigFunc = (configType: ObjectType) => Promise<InstanceElement>
 
 export type FetchResult = {
-  changes: Iterable<FetchChange>
+  changes: FetchChange[]
   mergeErrors: MergeErrorWithElements[]
   fetchErrors: SaltoError[]
   success: boolean

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -254,7 +254,7 @@ const toFetchChanges = (
 }
 
 export type FetchChangesResult = {
-  changes: Iterable<FetchChange>
+  changes: FetchChange[]
   elements: Element[]
   errors: SaltoError[]
   unmergedElements: Element[]
@@ -564,7 +564,7 @@ export const calcFetchChanges = async (
   workspaceElements: elementSource.ElementsSource,
   partiallyFetchedAccounts: Set<string>,
   allFetchedAccounts: Set<string>
-): Promise<Iterable<FetchChange>> => {
+): Promise<FetchChange[]> => {
   const partialFetchFilter: IDFilter = id => (
     !partiallyFetchedAccounts.has(id.adapter)
     || mergedAccountElements.has(id)
@@ -814,7 +814,7 @@ const fixStaticFilesForFromStateChanges = async (
   env: string,
 ): Promise<FetchChangesResult> => {
   const invalidChangeIDs: Set<string> = new Set()
-  const filteredChanges = wu(fetchChangesResult.changes)
+  const filteredChanges = fetchChangesResult.changes
     .map(fetchChange => fetchChange.change)
     .filter(isAdditionOrModificationChange)
   await awu(filteredChanges)
@@ -855,7 +855,7 @@ const fixStaticFilesForFromStateChanges = async (
     })
   return {
     ...fetchChangesResult,
-    changes: wu(fetchChangesResult.changes)
+    changes: fetchChangesResult.changes
       .filter(change => !invalidChangeIDs.has(change.change.id.getFullName())),
     errors: fetchChangesResult.errors.concat(
       Array.from(invalidChangeIDs).map(invalidChangeElemID => ({


### PR DESCRIPTION
calcFetchChanges returns an array instead of iterator

---

There is no change of the logic, it was always an array that was returned as an iterator

---
_Release Notes_: 
None

---
_User Notifications_: 
None