### PR TITLE
SALTO-4047: fix FIELD_VALUE warning in reportdefinition criteria

### DIFF
--- a/packages/netsuite-adapter/src/type_parsers/report_definition_parsing/parsed_report_definition.ts
+++ b/packages/netsuite-adapter/src/type_parsers/report_definition_parsing/parsed_report_definition.ts
@@ -144,7 +144,7 @@ type ReportDefinitionInnerFields = {
 type ReportCriteriaValuesType = {
   FIELD_DATE_FILTER_INDEX?: number
   SEQ_NUMBER?: number
-  FIELD_VALUE?: string
+  FIELD_VALUE?: unknown
 }
 
 type ReportCriteriaDescriptor = {
@@ -288,7 +288,7 @@ export const reportdefinitionType = (): TypeAndInnerTypes => {
     fields: {
       FIELD_DATE_FILTER_INDEX: { refType: BuiltinTypes.NUMBER },
       SEQ_NUMBER: { refType: BuiltinTypes.NUMBER },
-      FIELD_VALUE: { refType: BuiltinTypes.STRING },
+      FIELD_VALUE: { refType: BuiltinTypes.UNKNOWN },
     },
     path: [constants.NETSUITE, constants.TYPES_PATH, reportDefinitionElemID.name],
   })


### PR DESCRIPTION
_FIELD_VALUE field in reportdefinition.criteria changed from string to unkown type_

---

_None_

---
_Release Notes_: 
_Netsuite Adapter:_
* FIELD_VALUE field in reportdefinition type is changed to from string to unknown type

---
_User Notifications_: 
 * FIELD_VALUE field in reportdefinition type is changed to from string to unknown type
