### PR TITLE
SALTO-3518: downgrade node version back to 14.15

### DIFF
--- a/packages/cli/package_native.js
+++ b/packages/cli/package_native.js
@@ -49,13 +49,13 @@ const BUILD_NODE_EXECUTABLE = false
 const TARGET_FILE_BASENAME = 'salto'
 const TARGET_DIR = 'pkg'
 const TARGET_ARCH = BUILD_NODE_EXECUTABLE ? os.arch() : 'x64'
-const TARGET_NODE_VERSION = '18.12.1'
+const TARGET_NODE_VERSION = '14.15.3'
 const TARGET_PLATFORMS = {
   win: { ext: '.exe' },
   linux: {},
   mac: {},
 } // alpine not included for now
-const PREBUILT_REMOTE_URL = 'https://salto-cli-releases.s3.eu-central-1.amazonaws.com/build_artifacts/'
+const PREBUILT_REMOTE_URL = 'https://github.com/nexe/nexe/releases/download/v3.3.3/'
 
 const resources = [
   ...fontFiles.values(),


### PR DESCRIPTION
Following the PR where we downgraded the unit tests back to running on node 14 (#4007) we should probably not package with a node version that isn't tested...

---


---
_Release Notes_: 
cli:
- Go back to packaging the cli with node version 14.15 because that is the version being tested in unit tests

---
_User Notifications_: 
_None_