### PR TITLE
SALTO-4073 Modified guide_disabled_validator

### DIFF
--- a/packages/zendesk-adapter/src/change_validator.ts
+++ b/packages/zendesk-adapter/src/change_validator.ts
@@ -137,7 +137,7 @@ export default ({
     defaultGroupChangeValidator,
     organizationExistenceValidator(client, fetchConfig),
     badFormatWebhookActionValidator,
-    guideDisabledValidator,
+    guideDisabledValidator(fetchConfig),
     // *** Guide Order Validators ***
     childInOrderValidator,
     childrenReferencesValidator,

--- a/packages/zendesk-adapter/src/change_validators/guide_disabled.ts
+++ b/packages/zendesk-adapter/src/change_validators/guide_disabled.ts
@@ -14,72 +14,52 @@
 * limitations under the License.
 */
 
-import { ChangeValidator, isInstanceChange, getChangeData, isAdditionChange, InstanceElement, isReferenceExpression, isInstanceElement } from '@salto-io/adapter-api'
+import { ChangeValidator, isInstanceChange, getChangeData, isAdditionChange, isInstanceElement, isReferenceExpression } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { collections, values as lowerDashValues } from '@salto-io/lowerdash'
+import { collections } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
+import { getBrandsForGuide } from '../filters/utils'
 import { BRAND_TYPE_NAME } from '../constants'
-import { GUIDE_TYPES_TO_HANDLE_BY_BRAND } from '../config'
+import { GUIDE_TYPES_TO_HANDLE_BY_BRAND, ZendeskFetchConfig } from '../config'
 
-const { isDefined } = lowerDashValues
 const log = logger(module)
 const { awu } = collections.asynciterable
 
-const getBrandsWithoutGuideByInstanceId = (
-  instances: InstanceElement[], BrandsByBrandsId: Record<string, InstanceElement>
-):
-Record<string, InstanceElement> => {
-  const BrandsWithoutGuideByInstanceId = instances.map(instance => {
-    const brandRef = instance.value.brand
-    if (!isReferenceExpression(brandRef)) {
-      log.debug('brand is not a reference expression')
-      return undefined
-    }
-    const brand = BrandsByBrandsId[brandRef.elemID.getFullName()]
-    if (brand === undefined) {
-      log.debug('brand is not found in the element source')
-      return undefined
-    }
-    if (brand.value.has_help_center === false) {
-      return [instance.elemID.getFullName(), brand]
-    }
-    return undefined
-  }).filter(isDefined)
-  return Object.fromEntries(BrandsWithoutGuideByInstanceId)
-}
+export const guideDisabledValidator: (fetchConfig: ZendeskFetchConfig)
+ => ChangeValidator = fetchConfig => async (changes, elementSource) => {
+   const relevantInstances = changes
+     .filter(isInstanceChange)
+     .filter(isAdditionChange)
+     .map(getChangeData)
+     .filter(instance => GUIDE_TYPES_TO_HANDLE_BY_BRAND.includes(instance.elemID.typeName))
+   if (_.isEmpty(relevantInstances)) {
+     return []
+   }
+   if (elementSource === undefined) {
+     log.error('Failed to run guideDisabledValidator because no element source was provided')
+     return []
+   }
 
-export const guideDisabledValidator: ChangeValidator = async (changes, elementSource) => {
-  const relevantInstances = changes
-    .filter(isInstanceChange)
-    .filter(isAdditionChange)
-    .map(getChangeData)
-    .filter(instance => GUIDE_TYPES_TO_HANDLE_BY_BRAND.includes(instance.elemID.typeName))
-  if (_.isEmpty(relevantInstances)) {
-    return []
-  }
-  if (elementSource === undefined) {
-    log.error('Failed to run guideDisabledValidator because no element source was provided')
-    return []
-  }
+   const brandsInstances = await awu(await elementSource.list())
+     .filter(id => id.typeName === BRAND_TYPE_NAME)
+     .map(id => elementSource.get(id))
+     .filter(isInstanceElement)
+     .toArray()
 
-  const BrandsByBrandId = Object.fromEntries((await awu(await elementSource.list())
-    .filter(id => id.typeName === BRAND_TYPE_NAME)
-    .map(id => elementSource.get(id))
-    .filter(isInstanceElement)
-    .toArray())
-    .map(instance => [instance.elemID.getFullName(), instance]))
-  if (_.isEmpty(BrandsByBrandId)) {
-    return []
-  }
+   const brandsWithGuide = new Set(getBrandsForGuide(brandsInstances, fetchConfig)
+     .map(brand => brand.elemID.getFullName()))
 
-  const brandsWithoutGuideByInstanceId = getBrandsWithoutGuideByInstanceId(relevantInstances, BrandsByBrandId)
+   if (brandsWithGuide === undefined) {
+     return []
+   }
 
-  return relevantInstances
-    .filter(instance => instance.elemID.getFullName() in brandsWithoutGuideByInstanceId)
-    .map(instance => ({
-      elemID: instance.elemID,
-      severity: 'Error',
-      message: 'Cannot add this element because help center is not enabled for its associated brand.',
-      detailedMessage: `please enable help center for brand "${brandsWithoutGuideByInstanceId[instance.elemID.getFullName()].elemID.name}" in order to add this element.`,
-    }))
-}
+   return relevantInstances
+     .filter(instance => isReferenceExpression(instance.value.brand))
+     .filter(instance => !brandsWithGuide.has(instance.value.brand.elemID.getFullName()))
+     .map(instance => ({
+       elemID: instance.elemID,
+       severity: 'Error',
+       message: 'Cannot add this element because help center is not enabled for its associated brand, or the brand itself may not be enabled in the configuration.',
+       detailedMessage: `please enable help center for brand "${instance.value.brand.elemID.name}" or enable the brand in the configuration in order to add this element.`,
+     }))
+ }

--- a/packages/zendesk-adapter/test/change_validators/guide_disabled.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/guide_disabled.test.ts
@@ -18,12 +18,13 @@ import { ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } fr
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { guideDisabledValidator } from '../../src/change_validators/guide_disabled'
 import { ZENDESK, CATEGORY_TYPE_NAME } from '../../src/constants'
+import { DEFAULT_CONFIG, FETCH_CONFIG } from '../../src/config'
 
+const msg = 'Cannot add this element because help center is not enabled for its associated brand, or the brand itself may not be enabled in the configuration.'
 
 describe('guideDisabledValidator', () => {
   const categoryType = new ObjectType({ elemID: new ElemID(ZENDESK, CATEGORY_TYPE_NAME) })
   const brandType = new ObjectType({ elemID: new ElemID(ZENDESK, 'brand') })
-
   const brandWithHelpCenterFalse = new InstanceElement(
     'brandWithHelpCenterFalse',
     brandType,
@@ -59,37 +60,36 @@ describe('guideDisabledValidator', () => {
   it('should return errors because the brand has no help center', async () => {
     const clonedBrandWithHelpCenterFalse = brandWithHelpCenterFalse.clone()
     const changes = [toChange({ after: categoryToBrandWithHelpCenterFalse })]
-    const changesErrors = await guideDisabledValidator(changes,
+    const fetchConfig = { ...DEFAULT_CONFIG[FETCH_CONFIG], guide: { brands: ['.*'] } }
+    const validtor = guideDisabledValidator(fetchConfig)
+    const changesErrors = await validtor(changes,
       buildElementsSourceFromElements([clonedBrandWithHelpCenterFalse]))
     expect(changesErrors).toHaveLength(1)
     expect(changesErrors).toEqual([{
       elemID: categoryToBrandWithHelpCenterFalse.elemID,
       severity: 'Error',
-      message: 'Cannot add this element because help center is not enabled for its associated brand.',
-      detailedMessage: `please enable help center for brand "${brandWithHelpCenterFalse.elemID.name}" in order to add this element.`,
+      message: msg,
+      detailedMessage: `please enable help center for brand "${brandWithHelpCenterFalse.elemID.name}" or enable the brand in the configuration in order to add this element.`,
     }])
   })
 
   it('should not return errors because the brand has help center', async () => {
     const clonedBrandWithHelpCenterTrue = brandWithHelpCenterTrue.clone()
     const changes = [toChange({ after: categoryToBrandWithHelpCenterTrue })]
-    const changesErrors = await guideDisabledValidator(changes,
+    const fetchConfig = { ...DEFAULT_CONFIG[FETCH_CONFIG], guide: { brands: ['.*'] } }
+    const validtor = guideDisabledValidator(fetchConfig)
+    const changesErrors = await validtor(changes,
       buildElementsSourceFromElements([clonedBrandWithHelpCenterTrue]))
     expect(changesErrors).toHaveLength(0)
   })
   it('should not return errors for edge cases', async () => {
+    const fetchConfig = { ...DEFAULT_CONFIG[FETCH_CONFIG], guide: { brands: ['.*'] } }
     const brandWitouthHelpCenter = new InstanceElement(
       'brandWitouthHelpCenter',
       brandType,
       {},
     )
-    const categoryToBrandWitouthHelpCenter = new InstanceElement(
-      'categoryToBrandWitouthHelpCenter',
-      categoryType,
-      {
-        brand: new ReferenceExpression(brandWitouthHelpCenter.elemID, brandWitouthHelpCenter),
-      }
-    )
+
     const categoryWithoutRefExpression = new InstanceElement(
       'categoryWithoutRefExpression',
       categoryType,
@@ -104,10 +104,40 @@ describe('guideDisabledValidator', () => {
       },
     )
     const clonedBrandWitouthHelpCenter = brandWitouthHelpCenter.clone()
-    const changes = [toChange({ after: categoryToBrandWitouthHelpCenter }),
-      toChange({ after: categoryWithoutRefExpression }), toChange({ after: categoryWithoutBrand })]
-    const changesErrors = await guideDisabledValidator(changes,
+    const validator = guideDisabledValidator(fetchConfig)
+    const changes = [toChange({ after: categoryWithoutRefExpression }), toChange({ after: categoryWithoutBrand })]
+    const changesErrors = await validator(changes,
       buildElementsSourceFromElements([clonedBrandWitouthHelpCenter]))
     expect(changesErrors).toHaveLength(0)
+  })
+  it('should return errors because the brand is not include in the config', async () => {
+    const clonedBrandWithHelpCenterTrue = brandWithHelpCenterTrue.clone()
+    const changes = [toChange({ after: categoryToBrandWithHelpCenterTrue })]
+    const fetchConfig = { ...DEFAULT_CONFIG[FETCH_CONFIG], guide: { brands: ['.L'] } }
+    const validtor = guideDisabledValidator(fetchConfig)
+    const changesErrors = await validtor(changes,
+      buildElementsSourceFromElements([clonedBrandWithHelpCenterTrue]))
+    expect(changesErrors).toHaveLength(1)
+    expect(changesErrors).toEqual([{
+      elemID: categoryToBrandWithHelpCenterTrue.elemID,
+      severity: 'Error',
+      message: msg,
+      detailedMessage: `please enable help center for brand "${brandWithHelpCenterTrue.elemID.name}" or enable the brand in the configuration in order to add this element.`,
+    }])
+  })
+  it('should return errors because there is no guide in the config', async () => {
+    const clonedBrandWithHelpCenterTrue = brandWithHelpCenterTrue.clone()
+    const changes = [toChange({ after: categoryToBrandWithHelpCenterTrue })]
+    const fetchConfig = { ...DEFAULT_CONFIG[FETCH_CONFIG] }
+    const validtor = guideDisabledValidator(fetchConfig)
+    const changesErrors = await validtor(changes,
+      buildElementsSourceFromElements([clonedBrandWithHelpCenterTrue]))
+    expect(changesErrors).toHaveLength(1)
+    expect(changesErrors).toEqual([{
+      elemID: categoryToBrandWithHelpCenterTrue.elemID,
+      severity: 'Error',
+      message: msg,
+      detailedMessage: `please enable help center for brand "${brandWithHelpCenterTrue.elemID.name}" or enable the brand in the configuration in order to add this element.`,
+    }])
   })
 })

--- a/packages/zendesk-adapter/test/change_validators/guide_disabled.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/guide_disabled.test.ts
@@ -20,8 +20,8 @@ import { guideDisabledValidator } from '../../src/change_validators/guide_disabl
 import { ZENDESK, CATEGORY_TYPE_NAME } from '../../src/constants'
 import { DEFAULT_CONFIG, FETCH_CONFIG } from '../../src/config'
 
-const msg = 'Cannot add this element because help center is not enabled for its associated brand, or the brand itself may not be enabled in the configuration.'
-
+const msgForNoHelpCenter = 'Cannot add this element because help center is not enabled for its associated brand.'
+const msgNotInConfig = 'Cannot add this element because its associated brand is not enabled in the configuration.'
 describe('guideDisabledValidator', () => {
   const categoryType = new ObjectType({ elemID: new ElemID(ZENDESK, CATEGORY_TYPE_NAME) })
   const brandType = new ObjectType({ elemID: new ElemID(ZENDESK, 'brand') })
@@ -68,8 +68,8 @@ describe('guideDisabledValidator', () => {
     expect(changesErrors).toEqual([{
       elemID: categoryToBrandWithHelpCenterFalse.elemID,
       severity: 'Error',
-      message: msg,
-      detailedMessage: `please enable help center for brand "${brandWithHelpCenterFalse.elemID.name}" or enable the brand in the configuration in order to add this element.`,
+      message: msgForNoHelpCenter,
+      detailedMessage: `Please enable help center for brand "${brandWithHelpCenterFalse.elemID.name}" in order to add this element.`,
     }])
   })
 
@@ -121,8 +121,8 @@ describe('guideDisabledValidator', () => {
     expect(changesErrors).toEqual([{
       elemID: categoryToBrandWithHelpCenterTrue.elemID,
       severity: 'Error',
-      message: msg,
-      detailedMessage: `please enable help center for brand "${brandWithHelpCenterTrue.elemID.name}" or enable the brand in the configuration in order to add this element.`,
+      message: msgNotInConfig,
+      detailedMessage: `Please enable the brand "${brandWithHelpCenterTrue.elemID.name}" in the configuration in order to add this element.`,
     }])
   })
   it('should return errors because there is no guide in the config', async () => {
@@ -136,8 +136,8 @@ describe('guideDisabledValidator', () => {
     expect(changesErrors).toEqual([{
       elemID: categoryToBrandWithHelpCenterTrue.elemID,
       severity: 'Error',
-      message: msg,
-      detailedMessage: `please enable help center for brand "${brandWithHelpCenterTrue.elemID.name}" or enable the brand in the configuration in order to add this element.`,
+      message: msgNotInConfig,
+      detailedMessage: `Please enable the brand "${brandWithHelpCenterTrue.elemID.name}" in the configuration in order to add this element.`,
     }])
   })
 })


### PR DESCRIPTION
__In this PR__ 
1. I modified the guide_disabled validator that validates that the user Cannot add instance when its associated brand has help center disabled or its associated brand is not include in the config. I found a great function that checks both in `utils` so I changed a lot in this CV. 
2. I added test for this CV.

---

_Additional context for reviewer_
In Order to test the code manually - do as follows:
1. Create two environments in Zendesk.
2. Check\create two brands with the same name. 
3. Make sure that one brand has help center enabled and one brand has help center disabled. 
Or make sure the one brand is part of the config and the other one isn't. 
5. clone a sub guide element from the brand in the env with help center enabled to the env with help center disabled. 
Example `salto element clone zendesk.article.instance.Sample_article__Stellar_Skyonomy_refund_policies_Announcements_General_My_company_s_uum_uuuum@sfssssuuuuuum -e prod --to-envs sandbox`
6. try to deploy the new env. 

---
_Release Notes_: 
None

---
_User Notifications_: 
None
