### PR TITLE
SALTO-3971: Increase axios timeout and make it configurable

### DIFF
--- a/packages/netsuite-adapter/config_doc.md
+++ b/packages/netsuite-adapter/config_doc.md
@@ -49,6 +49,7 @@ netsuite {
   }
   suiteAppClient = {
    suiteAppConcurrencyLimit = 4 
+   httpTimeoutLimitInSeconds = 1200
   }
 }
 ```
@@ -130,6 +131,7 @@ netsuite {
 | Name                           | Default when undefined  | Description
 | -------------------------------| ------------------------| -----------
 | suiteAppConcurrencyLimit            | 4                       | Limits the max number of concurrent Salto SuiteApp API calls. The number should not exceed the concurrency limit enforced by the upstream service.
+| httpTimeoutLimitInSeconds           | 1200 (20 minutes)       | Set a timeout, in seconds, for HTTP calls. Restricted to a value greater than 1.
 
 
 ### Skip list configuration options

--- a/packages/netsuite-adapter/config_doc.md
+++ b/packages/netsuite-adapter/config_doc.md
@@ -49,7 +49,7 @@ netsuite {
   }
   suiteAppClient = {
    suiteAppConcurrencyLimit = 4 
-   httpTimeoutLimitInSeconds = 1200
+   httpTimeoutLimitInMinutes = 20
   }
 }
 ```
@@ -131,7 +131,7 @@ netsuite {
 | Name                           | Default when undefined  | Description
 | -------------------------------| ------------------------| -----------
 | suiteAppConcurrencyLimit            | 4                       | Limits the max number of concurrent Salto SuiteApp API calls. The number should not exceed the concurrency limit enforced by the upstream service.
-| httpTimeoutLimitInSeconds           | 1200 (20 minutes)       | Set a timeout, in seconds, for HTTP calls. Restricted to a value greater than 1.
+| httpTimeoutLimitInMinutes           | 20                      | Set a timeout, in minutes, for HTTP calls. Restricted to a value greater than 1.
 
 
 ### Skip list configuration options

--- a/packages/netsuite-adapter/src/adapter_creator.ts
+++ b/packages/netsuite-adapter/src/adapter_creator.ts
@@ -19,7 +19,7 @@ import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { SdkDownloadService } from '@salto-io/suitecloud-cli'
 import Bottleneck from 'bottleneck'
-import { CLIENT_CONFIG, CONFIG, configType, DEFAULT_CONCURRENCY, NetsuiteConfig, validateDeployParams, validateFetchConfig } from './config'
+import { CLIENT_CONFIG, CONFIG, configType, DEFAULT_CONCURRENCY, NetsuiteConfig, validateDeployParams, validateFetchConfig, validateSuiteAppClientParams } from './config'
 import { NETSUITE } from './constants'
 import { validateFetchParameters, convertToQueryParams, validateNetsuiteQueryParameters, validateArrayOfStrings, validatePlainObject, FETCH_PARAMS } from './query'
 import { Credentials, isSdfCredentialsOnly, isSuiteAppCredentials, toCredentialsAccountId } from './client/credentials'
@@ -99,6 +99,7 @@ function validateConfig(config: Record<string, unknown>): asserts config is Nets
     client,
     filePathRegexSkipList,
     typesToSkip,
+    suiteAppClient,
   } = _.pick(config, Object.values(CONFIG))
 
   if (filePathRegexSkipList !== undefined) {
@@ -145,6 +146,11 @@ function validateConfig(config: Record<string, unknown>): asserts config is Nets
   if (deploy !== undefined) {
     validatePlainObject(deploy, CONFIG.deploy)
     validateDeployParams(deploy)
+  }
+
+  if (suiteAppClient !== undefined) {
+    validatePlainObject(suiteAppClient, CONFIG.suiteAppClient)
+    validateSuiteAppClientParams(suiteAppClient)
   }
 }
 

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
@@ -36,7 +36,7 @@ import { CallsLimiter, ConfigRecord, ConfigRecordData, GetConfigResult, CONFIG_R
   SYSTEM_INFORMATION_SCHEME, FileCabinetInstanceDetails, ConfigFieldDefinition, CONFIG_FIELD_DEFINITION_SCHEMA, SetConfigType, SET_CONFIG_RESULT_SCHEMA, SetConfigRecordsValuesResult, SetConfigResult } from './types'
 import { SuiteAppCredentials, toUrlAccountId } from '../credentials'
 import { SUITEAPP_CONFIG_RECORD_TYPES } from '../../types'
-import { DEFAULT_CONCURRENCY } from '../../config'
+import { DEFAULT_AXIOS_TIMEOUT_IN_SECONDS, DEFAULT_CONCURRENCY } from '../../config'
 import { CONSUMER_KEY, CONSUMER_SECRET } from './constants'
 import SoapClient from './soap_client/soap_client'
 import { CustomRecordTypeRecords, RecordValue } from './soap_client/types'
@@ -47,7 +47,6 @@ const { isDefined } = values
 const { DEFAULT_RETRY_OPTS, createRetryOptions } = clientUtils
 
 export const PAGE_SIZE = 1000
-const AXIOS_TIMEOUT = 1000 * 60 * 12 // 12 minutes timeout
 
 const log = logger(module)
 
@@ -122,7 +121,8 @@ export default class SuiteAppClient {
     this.ajv = new Ajv({ allErrors: true, strict: false })
     this.soapClient = new SoapClient(this.credentials, this.callsLimiter)
 
-    this.axiosClient = axios.create({ timeout: AXIOS_TIMEOUT })
+    this.axiosClient = axios.create({ timeout:
+      (params.config?.httpTimeoutLimitInSeconds ?? DEFAULT_AXIOS_TIMEOUT_IN_SECONDS) * 1000 })
     const retryOptions = createRetryOptions(DEFAULT_RETRY_OPTS)
     axiosRetry(
       this.axiosClient,

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
@@ -36,7 +36,7 @@ import { CallsLimiter, ConfigRecord, ConfigRecordData, GetConfigResult, CONFIG_R
   SYSTEM_INFORMATION_SCHEME, FileCabinetInstanceDetails, ConfigFieldDefinition, CONFIG_FIELD_DEFINITION_SCHEMA, SetConfigType, SET_CONFIG_RESULT_SCHEMA, SetConfigRecordsValuesResult, SetConfigResult } from './types'
 import { SuiteAppCredentials, toUrlAccountId } from '../credentials'
 import { SUITEAPP_CONFIG_RECORD_TYPES } from '../../types'
-import { DEFAULT_AXIOS_TIMEOUT_IN_SECONDS, DEFAULT_CONCURRENCY } from '../../config'
+import { DEFAULT_AXIOS_TIMEOUT_IN_MINUTES, DEFAULT_CONCURRENCY } from '../../config'
 import { CONSUMER_KEY, CONSUMER_SECRET } from './constants'
 import SoapClient from './soap_client/soap_client'
 import { CustomRecordTypeRecords, RecordValue } from './soap_client/types'
@@ -122,7 +122,7 @@ export default class SuiteAppClient {
     this.soapClient = new SoapClient(this.credentials, this.callsLimiter)
 
     this.axiosClient = axios.create({ timeout:
-      (params.config?.httpTimeoutLimitInSeconds ?? DEFAULT_AXIOS_TIMEOUT_IN_SECONDS) * 1000 })
+      (params.config?.httpTimeoutLimitInMinutes ?? DEFAULT_AXIOS_TIMEOUT_IN_MINUTES) * 60 * 1000 })
     const retryOptions = createRetryOptions(DEFAULT_RETRY_OPTS)
     axiosRetry(
       this.axiosClient,

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -37,7 +37,7 @@ export const DEFAULT_MAX_FILE_CABINET_SIZE_IN_GB = 1
 export const DEFAULT_DEPLOY_REFERENCED_ELEMENTS = false
 export const DEFAULT_WARN_STALE_DATA = false
 export const DEFAULT_VALIDATE = true
-export const DEFAULT_AXIOS_TIMEOUT_IN_SECONDS = 60 * 20
+export const DEFAULT_AXIOS_TIMEOUT_IN_MINUTES = 20
 
 
 const REQUIRED_FEATURE_SUFFIX = ':required'
@@ -94,7 +94,7 @@ export const CLIENT_CONFIG: lowerdashTypes.TypeKeysEnum<SdfClientConfig> = {
 
 export type SuiteAppClientConfig = {
   suiteAppConcurrencyLimit?: number
-  httpTimeoutLimitInSeconds?: number
+  httpTimeoutLimitInMinutes?: number
 }
 
 export type NetsuiteConfig = {
@@ -192,10 +192,10 @@ const suiteAppClientConfigType = createMatchingObjectType<SuiteAppClientConfig>(
         }),
       },
     },
-    httpTimeoutLimitInSeconds: {
+    httpTimeoutLimitInMinutes: {
       refType: BuiltinTypes.NUMBER,
       annotations: {
-        [CORE_ANNOTATIONS.DEFAULT]: DEFAULT_AXIOS_TIMEOUT_IN_SECONDS,
+        [CORE_ANNOTATIONS.DEFAULT]: DEFAULT_AXIOS_TIMEOUT_IN_MINUTES,
         [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({
           min: 1,
         }),
@@ -513,6 +513,22 @@ export const validateDeployParams = (
   if (additionalDependencies !== undefined) {
     validatePlainObject(additionalDependencies, additionalDependenciesConfigPath)
     validateAdditionalDependencies(additionalDependencies)
+  }
+}
+
+export const validateSuiteAppClientParams = (
+  {
+    suiteAppConcurrencyLimit,
+    httpTimeoutLimitInMinutes,
+  }: Record<keyof SuiteAppClientConfig, unknown>
+): void => {
+  if (suiteAppConcurrencyLimit !== undefined
+    && typeof suiteAppConcurrencyLimit !== 'number') {
+    throw new Error(`Expected "suiteAppConcurrencyLimit" to be a number or to be undefined, but received:\n ${suiteAppConcurrencyLimit}`)
+  }
+  if (httpTimeoutLimitInMinutes !== undefined
+    && typeof httpTimeoutLimitInMinutes !== 'number') {
+    throw new Error(`Expected "httpTimeoutLimitInMinutes" to be a boolean or to be undefined, but received:\n ${httpTimeoutLimitInMinutes}`)
   }
 }
 

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -37,6 +37,8 @@ export const DEFAULT_MAX_FILE_CABINET_SIZE_IN_GB = 1
 export const DEFAULT_DEPLOY_REFERENCED_ELEMENTS = false
 export const DEFAULT_WARN_STALE_DATA = false
 export const DEFAULT_VALIDATE = true
+export const DEFAULT_AXIOS_TIMEOUT_IN_SECONDS = 60 * 20
+
 
 const REQUIRED_FEATURE_SUFFIX = ':required'
 export const isRequiredFeature = (featureName: string): boolean =>
@@ -92,6 +94,7 @@ export const CLIENT_CONFIG: lowerdashTypes.TypeKeysEnum<SdfClientConfig> = {
 
 export type SuiteAppClientConfig = {
   suiteAppConcurrencyLimit?: number
+  httpTimeoutLimitInSeconds?: number
 }
 
 export type NetsuiteConfig = {
@@ -186,6 +189,15 @@ const suiteAppClientConfigType = createMatchingObjectType<SuiteAppClientConfig>(
         [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({
           min: 1,
           max: 50,
+        }),
+      },
+    },
+    httpTimeoutLimitInSeconds: {
+      refType: BuiltinTypes.NUMBER,
+      annotations: {
+        [CORE_ANNOTATIONS.DEFAULT]: DEFAULT_AXIOS_TIMEOUT_IN_SECONDS,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({
+          min: 1,
         }),
       },
     },

--- a/packages/netsuite-adapter/test/adapter_creator.test.ts
+++ b/packages/netsuite-adapter/test/adapter_creator.test.ts
@@ -232,7 +232,7 @@ describe('NetsuiteAdapter creator', () => {
         ...config.value,
         suiteAppClient: {
           suiteAppConcurrencyLimit: 5,
-          httpTimeoutLimitInSeconds: 60,
+          httpTimeoutLimitInMinutes: 20,
         },
       }
 
@@ -245,7 +245,7 @@ describe('NetsuiteAdapter creator', () => {
         credentials: { ...cred.value, accountId: 'FOO_A' },
         config: {
           suiteAppConcurrencyLimit: 5,
-          httpTimeoutLimitInSeconds: 60,
+          httpTimeoutLimitInMinutes: 20,
         },
         globalLimiter: expect.any(Bottleneck),
       })

--- a/packages/netsuite-adapter/test/adapter_creator.test.ts
+++ b/packages/netsuite-adapter/test/adapter_creator.test.ts
@@ -232,6 +232,7 @@ describe('NetsuiteAdapter creator', () => {
         ...config.value,
         suiteAppClient: {
           suiteAppConcurrencyLimit: 5,
+          httpTimeoutLimitInSeconds: 60,
         },
       }
 
@@ -244,6 +245,7 @@ describe('NetsuiteAdapter creator', () => {
         credentials: { ...cred.value, accountId: 'FOO_A' },
         config: {
           suiteAppConcurrencyLimit: 5,
+          httpTimeoutLimitInSeconds: 60,
         },
         globalLimiter: expect.any(Bottleneck),
       })


### PR DESCRIPTION
* Increase axios timeout (on SuiteApp) from 12 minutes to 20.
* Allow the user to control it through the config file.
* Add validation to the suitAppClient config.

---

_Additional context for reviewer_

---
_Release Notes_: 

---
_User Notifications_: 
