### PR TITLE
SALTO-4083/standlone field bug

### DIFF
--- a/packages/adapter-components/src/elements/instance_elements.ts
+++ b/packages/adapter-components/src/elements/instance_elements.ts
@@ -251,8 +251,10 @@ export const toBasicInstance = async ({
     isSettingType: type.isSettings,
     nameMapping,
     adapterName,
-    nestedPaths:
-    shouldNestFiles(transformationDefaultConfig, transformationConfigByType[type.elemID.name]) ? nestedPath : undefined,
+    nestedPaths: parent && shouldNestFiles(
+      transformationDefaultConfig,
+      transformationConfigByType[parent.elemID.typeName]
+    ) ? nestedPath : undefined,
   })
   if (transformationConfigByType[type.elemID.name]?.standaloneFields !== undefined
     && shouldNestFiles(transformationDefaultConfig, transformationConfigByType[type.elemID.name])) {

--- a/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
@@ -409,7 +409,7 @@ describe('swagger_instance_elements', () => {
         [ADAPTER_NAME, 'Records', 'Owner', 'cat__o2'],
         [ADAPTER_NAME, 'Records', 'Pet', 'mouse'],
         [ADAPTER_NAME, 'Records', 'Owner', 'mouse__o3'],
-      ]))
+      ])
     })
     it('should extract standalone fields', async () => {
       const objectTypes = generateObjectTypes()


### PR DESCRIPTION
fixed bug causing us to look at the standalone field type transformation and not the parent when writing the standalone instance.
causing us to ignore the parent's  "nestStandaloneInstances: false" and nesting the instance anyway.

---

_Additional context for reviewer_
I added a test to simulate a case with true default nestStandaloneInstances and false on specific type.


---
_Release Notes_: 


---
_User Notifications_: 
