### PR TITLE
SALTO-4089: Omit appLinks field from Application

### DIFF
--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -444,6 +444,12 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
       fieldsToHide: [{ fieldName: 'signing', fieldType: 'ApplicationCredentialsSigning' }],
     },
   },
+  ApplicationVisibility: {
+    transformation: {
+      // The field cannot be changed and might include non multienv values
+      fieldsToOmit: [{ fieldName: 'appLinks' }],
+    },
+  },
   api__v1__meta__types__user: {
     transformation: {
       // by default there is an unwanted traversal here


### PR DESCRIPTION
Omit appLinks field from Application

---

the field causes unwanted diffs between envs, its not visible in the UI and it doesn't change with API requests

---
_Release Notes_: 
None

---
_User Notifications_: 
None
