### PR TITLE
SALTO-3953: Validate users exists in target env validator for Okta

### DIFF
--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -292,6 +292,7 @@ export default class OktaAdapter implements AdapterOperations {
     return {
       changeValidator: changeValidator({
         client: this.client,
+        config: this.userConfig,
       }),
       dependencyChanger,
     }

--- a/packages/okta-adapter/src/change_validators/index.ts
+++ b/packages/okta-adapter/src/change_validators/index.ts
@@ -27,13 +27,17 @@ import { appIntegrationSetupValidator } from './app_integration_setup'
 import { assignedAccessPoliciesValidator } from './assigned_policies'
 import { groupSchemaModifyBaseValidator } from './group_schema_modify_base_fields'
 import { enabledAuthenticatorsValidator } from './enabled_authenticators'
-import OktaClient from '../client/client'
 import { roleAssignmentValidator } from './role_assignment'
+import { usersValidator } from './user'
+import OktaClient from '../client/client'
+import { OktaConfig } from '../config'
 
 export default ({
   client,
+  config,
 }: {
   client: OktaClient
+  config: OktaConfig
 }): ChangeValidator => {
   const validators: ChangeValidator[] = [
     ...deployment.changeValidators.getDefaultChangeValidators(),
@@ -49,6 +53,7 @@ export default ({
     groupSchemaModifyBaseValidator,
     enabledAuthenticatorsValidator,
     roleAssignmentValidator,
+    usersValidator(client, config),
   ]
 
   return createChangeValidator(validators)

--- a/packages/okta-adapter/src/change_validators/user.ts
+++ b/packages/okta-adapter/src/change_validators/user.ts
@@ -1,0 +1,78 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { ChangeValidator, getChangeData, isAdditionOrModificationChange, isInstanceChange } from '@salto-io/adapter-api'
+import { resolvePath } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+import { client as clientUtils } from '@salto-io/adapter-components'
+import { values } from '@salto-io/lowerdash'
+import { paginate } from '../client/pagination'
+import OktaClient from '../client/client'
+import { OktaConfig, FETCH_CONFIG } from '../config'
+import { USER_MAPPING, getUsers } from '../filters/user'
+
+const { isDefined } = values
+const { createPaginator } = clientUtils
+const log = logger(module)
+
+/**
+* Verifies users exist in the environement before deployment of an instance with user references
+*/
+export const usersValidator: (client: OktaClient, config: OktaConfig) =>
+    ChangeValidator = (client, config) => async changes => {
+      if (!(config[FETCH_CONFIG]?.convertUsersIds ?? true)) {
+        log.debug('Skipped usersValidator because convertUsersIds config flag is disabled')
+        return []
+      }
+      const relevantInstances = changes
+        .filter(isAdditionOrModificationChange)
+        .filter(isInstanceChange)
+        .map(getChangeData)
+        .filter(instance => Object.keys(USER_MAPPING).includes(instance.elemID.typeName))
+
+      if (_.isEmpty(relevantInstances)) {
+        return []
+      }
+
+      const paginator = createPaginator({
+        client,
+        paginationFuncCreator: paginate,
+      })
+
+      const users = await getUsers(paginator)
+
+      const existingUsers = new Set(users.map(user => user.profile.login))
+
+      const missingUsersByInstanceId = Object.fromEntries(relevantInstances.map(instance => {
+        const userPaths = USER_MAPPING[instance.elemID.typeName]
+        const missingUsers = userPaths
+          .flatMap(path => resolvePath(instance, instance.elemID.createNestedID(...path)))
+          .filter(user => !existingUsers.has(user))
+        if (!_.isEmpty(missingUsers)) {
+          return [instance.elemID.getFullName(), missingUsers]
+        }
+        return undefined
+      }).filter(isDefined))
+
+      return relevantInstances
+        .filter(instance => missingUsersByInstanceId[instance.elemID.getFullName()] !== undefined)
+        .map(instance => ({
+          elemID: instance.elemID,
+          severity: 'Error',
+          message: 'Instance references users which don\'t exist in target environment',
+          detailedMessage: `The following users are referenced by this instance, but do not exist in the target environment: ${missingUsersByInstanceId[instance.elemID.getFullName()].join(', ')}.\nIn order to deploy this instance, add these users to your target environment or edit this instance to use valid usernames.`,
+        }))
+    }

--- a/packages/okta-adapter/src/filters/user.ts
+++ b/packages/okta-adapter/src/filters/user.ts
@@ -51,7 +51,7 @@ const areUsers = createSchemeGuard<User[]>(
 const EXCLUDE_USERS_PATH = ['conditions', 'people', 'users', 'exclude']
 const INCLUDE_USERS_PATH = ['conditions', 'people', 'users', 'include']
 
-const USER_MAPPING: Record<string, string[][]> = {
+export const USER_MAPPING: Record<string, string[][]> = {
   [GROUP_RULE_TYPE_NAME]: [EXCLUDE_USERS_PATH],
   [ACCESS_POLICY_RULE_TYPE_NAME]: [EXCLUDE_USERS_PATH, INCLUDE_USERS_PATH],
   [PASSWORD_RULE_TYPE_NAME]: [EXCLUDE_USERS_PATH],
@@ -65,7 +65,7 @@ const isRelevantInstance = (instance: InstanceElement): boolean => (
   Object.keys(USER_MAPPING).includes(instance.elemID.typeName)
 )
 
-const getUsers = async (paginator: clientUtils.Paginator): Promise<User[]> => {
+export const getUsers = async (paginator: clientUtils.Paginator): Promise<User[]> => {
   const paginationArgs = {
     url: '/api/v1/users',
     paginationField: 'after',

--- a/packages/okta-adapter/test/change_validators/users.test.ts
+++ b/packages/okta-adapter/test/change_validators/users.test.ts
@@ -1,0 +1,110 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { toChange, ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { DEFAULT_CONFIG } from '../../src/config'
+import { usersValidator } from '../../src/change_validators/user'
+import { OKTA, GROUP_RULE_TYPE_NAME, ACCESS_POLICY_RULE_TYPE_NAME } from '../../src/constants'
+import OktaClient from '../../src/client/client'
+
+describe('usersValidator', () => {
+  const client = new OktaClient({
+    credentials: { baseUrl: 'a.okta.com', token: 'token' },
+  })
+  const mockGet = jest.spyOn(client, 'getSinglePage')
+  const ruleType = new ObjectType({ elemID: new ElemID(OKTA, GROUP_RULE_TYPE_NAME) })
+  const accessRuleType = new ObjectType({ elemID: new ElemID(OKTA, ACCESS_POLICY_RULE_TYPE_NAME) })
+  const policyInstance = new InstanceElement(
+    'somePolicy',
+    accessRuleType,
+    { name: 'policy', conditions: { people: { users: { exclude: ['a@a', 'e@e'], include: ['z@z'] } } } },
+  )
+  const ruleInstance = new InstanceElement(
+    'groupRule',
+    ruleType,
+    { name: 'rule', conditions: { people: { users: { exclude: ['e@e', 'b@b'] } }, expression: { value: 'something' } } },
+  )
+  const message = 'Instance references users which don\'t exist in target environment'
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+  })
+
+  it('should return error when change include users that does not exist', async () => {
+    mockGet.mockResolvedValue(
+      {
+        status: 200,
+        data: [
+          { id: '1', profile: { login: 'a@a' } },
+          { id: '2', profile: { login: 'b@b' } },
+          { id: '3', profile: { login: 'c@c' } },
+          { id: '4', profile: { login: 'd@d' } },
+        ],
+      }
+    )
+    const changeValidator = usersValidator(client, DEFAULT_CONFIG)
+    const changeErrors = await changeValidator([
+      toChange({ before: policyInstance, after: policyInstance }),
+      toChange({ after: ruleInstance }),
+    ])
+    expect(changeErrors).toHaveLength(2)
+    expect(changeErrors).toEqual([
+      {
+        elemID: policyInstance.elemID,
+        severity: 'Error',
+        message,
+        detailedMessage: 'The following users are referenced by this instance, but do not exist in the target environment: e@e, z@z.\nIn order to deploy this instance, add these users to your target environment or edit this instance to use valid usernames.',
+      },
+      {
+        elemID: ruleInstance.elemID,
+        severity: 'Error',
+        message,
+        detailedMessage: 'The following users are referenced by this instance, but do not exist in the target environment: e@e.\nIn order to deploy this instance, add these users to your target environment or edit this instance to use valid usernames.',
+      },
+    ])
+  })
+  it('should not return errors if all users in instance exists', async () => {
+    mockGet.mockResolvedValue(
+      {
+        status: 200,
+        data: [
+          { id: '1', profile: { login: 'a@a' } },
+          { id: '2', profile: { login: 'b@b' } },
+          { id: '3', profile: { login: 'c@c' } },
+          { id: '4', profile: { login: 'd@d' } },
+          { id: '5', profile: { login: 'e@e' } },
+          { id: '6', profile: { login: 'z@z' } },
+        ],
+      }
+    )
+    const changeValidator = usersValidator(client, DEFAULT_CONFIG)
+    const changeErrors = await changeValidator([
+      toChange({ before: policyInstance, after: policyInstance }),
+      toChange({ after: ruleInstance }),
+    ])
+    expect(changeErrors).toHaveLength(0)
+  })
+  it('should do nothing if convertUsersIds config flag is disabled', async () => {
+    const changeValidator = usersValidator(
+      client,
+      { ...DEFAULT_CONFIG, fetch: { include: [], exclude: [], convertUsersIds: false } }
+    )
+    const changeErrors = await changeValidator([
+      toChange({ before: policyInstance, after: policyInstance }),
+      toChange({ after: ruleInstance }),
+    ])
+    expect(changeErrors).toHaveLength(0)
+  })
+})

--- a/packages/okta-adapter/test/filters/user.test.ts
+++ b/packages/okta-adapter/test/filters/user.test.ts
@@ -18,7 +18,7 @@ import { client as clientUtils, filterUtils } from '@salto-io/adapter-components
 import { mockFunction } from '@salto-io/test-utils'
 import { DEFAULT_CONFIG, FETCH_CONFIG } from '../../src/config'
 import { ACCESS_POLICY_RULE_TYPE_NAME, GROUP_RULE_TYPE_NAME, OKTA } from '../../src/constants'
-import userFilter from '../../src/filters/user'
+import userFilter, { getUsers } from '../../src/filters/user'
 import { getFilterParams } from '../utils'
 
 describe('user filter', () => {
@@ -245,6 +245,41 @@ describe('user filter', () => {
           people: { users: { exclude: ['b@a.com'], include: ['a@a.com', 'c@a.com', 'd@a.com'] } },
         },
       })
+    })
+  })
+  describe('getUsers', () => {
+    const mockPaginator = mockFunction<clientUtils.Paginator>()
+      .mockImplementationOnce(async function *get() {
+        yield [
+          { id: '111', profile: { login: 'a@a.com', name: 'a' } },
+          { id: '222', profile: { login: 'b@a.com' } },
+        ]
+      })
+      .mockImplementationOnce(async function *get() {
+        yield [
+          { id: '111', profile: { name: 'a' } },
+          { id: '222', profile: { name: 'b' } },
+        ]
+      })
+    it('it should return a list of users', async () => {
+      const users = await getUsers(mockPaginator)
+      expect(users).toEqual([
+        { id: '111', profile: { login: 'a@a.com', name: 'a' } },
+        { id: '222', profile: { login: 'b@a.com' } },
+      ])
+      expect(mockPaginator).toHaveBeenNthCalledWith(
+        1,
+        {
+          url: '/api/v1/users',
+          headers: { 'Content-Type': 'application/json; okta-response=omitCredentials,omitCredentialsLinks' },
+          paginationField: 'after',
+        },
+        expect.anything()
+      )
+    })
+    it('it should return an empty list if response is invalid', async () => {
+      const users = await getUsers(mockPaginator)
+      expect(users).toEqual([])
     })
   })
 })


### PR DESCRIPTION
Add missing users validator for Okta

---

Similar to what we have in Zendesk & Jira

---
_Release Notes_: 
None

---

_User Notifications_: 
None