### PR TITLE
SALTO-4095: Add CheckDeploymentBasedOnConfigValidator to Okta

### DIFF
--- a/packages/adapter-components/src/deployment/change_validators/check_deployment_based_on_config.ts
+++ b/packages/adapter-components/src/deployment/change_validators/check_deployment_based_on_config.ts
@@ -18,7 +18,7 @@ import { Change, ChangeError, ChangeValidator, getChangeData, Element, ElemID, i
   isReferenceExpression, ActionName } from '@salto-io/adapter-api'
 import { getParents } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
-import { AdapterApiConfig, DeploymentRequestsByAction, DeployRequestConfig } from '../../config'
+import { DeploymentRequestsByAction, DeployRequestConfig, TypeConfig } from '../../config'
 
 const { awu } = collections.asynciterable
 
@@ -48,9 +48,9 @@ const createChangeErrors = (
 }
 
 export const createCheckDeploymentBasedOnConfigValidator = ({
-  apiConfig, typesDeployedViaParent = [], typesWithNoDeploy = [],
+  typesConfig, typesDeployedViaParent = [], typesWithNoDeploy = [],
 }: {
-  apiConfig: AdapterApiConfig
+  typesConfig: Record<string, TypeConfig>
   typesDeployedViaParent?: string[]
   typesWithNoDeploy?: string[]
 }): ChangeValidator => async changes => (
@@ -61,7 +61,7 @@ export const createCheckDeploymentBasedOnConfigValidator = ({
         return []
       }
       const getChangeErrorsByTypeName = (typeName: string): ChangeError[] => {
-        const typeConfig = apiConfig?.types?.[typeName]?.deployRequests ?? {}
+        const typeConfig = typesConfig[typeName]?.deployRequests ?? {}
         return createChangeErrors(typeConfig, element.elemID, change.action)
       }
       if (typesWithNoDeploy.includes(element.elemID.typeName)) {

--- a/packages/adapter-components/test/deployment/change_validators/check_deployment.test.ts
+++ b/packages/adapter-components/test/deployment/change_validators/check_deployment.test.ts
@@ -14,35 +14,27 @@
 * limitations under the License.
 */
 import { CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
-import { AdapterApiConfig } from '../../../src/config/shared'
+import { TypeConfig } from '../../../src/config/shared'
 import { createCheckDeploymentBasedOnConfigValidator } from '../../../src/deployment/change_validators/check_deployment_based_on_config'
 
 describe('checkDeploymentBasedOnConfigValidator', () => {
   let type: ObjectType
-  const apiConfig: AdapterApiConfig = {
-    typeDefaults: {
-      transformation: {
-        idFields: ['id'],
-      },
-    },
-    types: {
-      test: {
-        deployRequests: {
-          add: {
-            url: '/test',
-            method: 'post',
-          },
+  const typesConfig: Record<string, TypeConfig> = {
+    test: {
+      deployRequests: {
+        add: {
+          url: '/test',
+          method: 'post',
         },
       },
     },
-    supportedTypes: {},
   }
   beforeEach(() => {
     type = new ObjectType({ elemID: new ElemID('dum', 'test') })
   })
 
   it('should not return an error when the changed element is not an instance', async () => {
-    const errors = await createCheckDeploymentBasedOnConfigValidator({ apiConfig })([
+    const errors = await createCheckDeploymentBasedOnConfigValidator({ typesConfig })([
       toChange({ after: type }),
     ])
     expect(errors).toEqual([])
@@ -53,7 +45,7 @@ describe('checkDeploymentBasedOnConfigValidator', () => {
       'test2',
       new ObjectType({ elemID: new ElemID('dum', 'test2') }),
     )
-    const errors = await createCheckDeploymentBasedOnConfigValidator({ apiConfig })(
+    const errors = await createCheckDeploymentBasedOnConfigValidator({ typesConfig })(
       [toChange({ after: instance })],
     )
     expect(errors).toEqual([{
@@ -66,7 +58,7 @@ describe('checkDeploymentBasedOnConfigValidator', () => {
 
   it('should return an error when type does not support specific method', async () => {
     const instance = new InstanceElement('test', type)
-    const errors = await createCheckDeploymentBasedOnConfigValidator({ apiConfig })(
+    const errors = await createCheckDeploymentBasedOnConfigValidator({ typesConfig })(
       [toChange({ before: instance })],
     )
     expect(errors).toEqual([{
@@ -79,7 +71,7 @@ describe('checkDeploymentBasedOnConfigValidator', () => {
 
   it('should not return an error when operation is supported', async () => {
     const instance = new InstanceElement('test', type)
-    const errors = await createCheckDeploymentBasedOnConfigValidator({ apiConfig })(
+    const errors = await createCheckDeploymentBasedOnConfigValidator({ typesConfig })(
       [toChange({ after: instance })],
     )
     expect(errors).toEqual([])
@@ -95,7 +87,7 @@ describe('checkDeploymentBasedOnConfigValidator', () => {
       { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(parentInst.elemID, parentInst)] },
     )
     const errors = await createCheckDeploymentBasedOnConfigValidator({
-      apiConfig, typesDeployedViaParent: [childTypeName],
+      typesConfig, typesDeployedViaParent: [childTypeName],
     })(
       [toChange({ after: instance })],
     )
@@ -112,7 +104,7 @@ describe('checkDeploymentBasedOnConfigValidator', () => {
       { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(parentInst.elemID, parentInst)] },
     )
     const errors = await createCheckDeploymentBasedOnConfigValidator({
-      apiConfig, typesDeployedViaParent: [childTypeName],
+      typesConfig, typesDeployedViaParent: [childTypeName],
     })(
       [toChange({ before: instance })],
     )
@@ -130,7 +122,7 @@ describe('checkDeploymentBasedOnConfigValidator', () => {
       new ObjectType({ elemID: new ElemID('dum', typeName) }),
     )
     const errors = await createCheckDeploymentBasedOnConfigValidator({
-      apiConfig, typesDeployedViaParent: [], typesWithNoDeploy: [typeName],
+      typesConfig, typesDeployedViaParent: [], typesWithNoDeploy: [typeName],
     })(
       [toChange({ after: instance })],
     )

--- a/packages/okta-adapter/src/change_validators/index.ts
+++ b/packages/okta-adapter/src/change_validators/index.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import _ from 'lodash'
 import { ChangeValidator } from '@salto-io/adapter-api'
 import { deployment } from '@salto-io/adapter-components'
 import { createChangeValidator } from '@salto-io/adapter-utils'
@@ -31,7 +32,12 @@ import { enabledAuthenticatorsValidator } from './enabled_authenticators'
 import { roleAssignmentValidator } from './role_assignment'
 import { usersValidator } from './user'
 import OktaClient from '../client/client'
-import { OktaConfig } from '../config'
+import { API_DEFINITIONS_CONFIG, OktaConfig, PRIVATE_API_DEFINITIONS_CONFIG } from '../config'
+
+const {
+  createCheckDeploymentBasedOnConfigValidator,
+  getDefaultChangeValidators,
+} = deployment.changeValidators
 
 export default ({
   client,
@@ -41,7 +47,10 @@ export default ({
   config: OktaConfig
 }): ChangeValidator => {
   const validators: ChangeValidator[] = [
-    ...deployment.changeValidators.getDefaultChangeValidators(),
+    ...getDefaultChangeValidators(),
+    createCheckDeploymentBasedOnConfigValidator({
+      typesConfig: _.merge(config[API_DEFINITIONS_CONFIG].types, config[PRIVATE_API_DEFINITIONS_CONFIG].types),
+    }),
     applicationValidator,
     appGroupValidator,
     groupRuleStatusValidator,

--- a/packages/zendesk-adapter/src/change_validator.ts
+++ b/packages/zendesk-adapter/src/change_validator.ts
@@ -93,7 +93,7 @@ export default ({
     ...getDefaultChangeValidators(),
     deployTypesNotSupportedValidator,
     createCheckDeploymentBasedOnConfigValidator(
-      { apiConfig, typesDeployedViaParent, typesWithNoDeploy }
+      { typesConfig: apiConfig.types, typesDeployedViaParent, typesWithNoDeploy }
     ),
     accountSettingsValidator,
     emptyCustomFieldOptionsValidator,


### PR DESCRIPTION
Add CheckDeploymentBasedOnConfigValidator to Okta

---

I merged the swagger types config with the ducktype types config so the validator would work on both

---
_Release Notes_: 
None

---
_User Notifications_: 
None