### PR TITLE
SALTO-4092: Fix bug causing removals of instances with templates containing missing refs to fail

### DIFF
--- a/packages/okta-adapter/src/filters/expression_language.ts
+++ b/packages/okta-adapter/src/filters/expression_language.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { Change, Element, getChangeData, InstanceElement, isInstanceElement, isTemplateExpression, ReferenceExpression, TemplateExpression, TemplatePart } from '@salto-io/adapter-api'
+import { Change, Element, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceElement, isTemplateExpression, ReferenceExpression, TemplateExpression, TemplatePart } from '@salto-io/adapter-api'
 import { extractTemplate, replaceTemplatesWithValues, resolvePath, resolveTemplates } from '@salto-io/adapter-utils'
 import { references as referenceUtils } from '@salto-io/adapter-components'
 import { logger } from '@salto-io/logging'
@@ -206,6 +206,7 @@ const filter: FilterCreator = () => {
 
     preDeploy: async (changes: Change<InstanceElement>[]) => {
       changes
+        .filter(isAdditionOrModificationChange)
         .map(getChangeData)
         .filter(isInstanceElement)
         .filter(instance => Object.keys(TYPE_TO_DEF).includes(instance.elemID.typeName))
@@ -245,6 +246,7 @@ const filter: FilterCreator = () => {
 
     onDeploy: async (changes: Change<InstanceElement>[]) => {
       changes
+        .filter(isAdditionOrModificationChange)
         .map(getChangeData)
         .filter(isInstanceElement)
         .filter(instance => Object.keys(TYPE_TO_DEF).includes(instance.elemID.typeName))


### PR DESCRIPTION
Fix bug causing removals of instances with templates containing missing refs to fail

---

What happened is that when trying to resolve references for templates with missing refs during pre deploy, we got an error because the reference wasn't resolved
To fix this I filtered  the changes for the `TemplateExpression` filter to be addition of modification changes only, cause there's no point to resolve templates for removals changes (Okta ignores data on `delete` method)

---
_Release Notes_: 
None

---
_User Notifications_: 
None