### PR TITLE
SALTO-2692: Block additions or modifications of APP_GROUP in Okta

### DIFF
--- a/packages/okta-adapter/src/change_validators/app_group.ts
+++ b/packages/okta-adapter/src/change_validators/app_group.ts
@@ -1,0 +1,39 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ChangeValidator, getChangeData, isInstanceChange, isAdditionOrModificationChange } from '@salto-io/adapter-api'
+import { GROUP_TYPE_NAME } from '../constants'
+
+const APP_GROUP_TYPE = 'APP_GROUP'
+
+/**
+ * Groups of type APP_GROUP are groups imported to Okta from an external app.
+ * Okta API does not support modifications or additions of such groups,
+ * as application import oprerations adds and modify those groups.
+ */
+export const appGroupValidator: ChangeValidator = async changes => (
+  changes
+    .filter(isInstanceChange)
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+    .filter(instance => instance.elemID.typeName === GROUP_TYPE_NAME)
+    .filter(instance => instance.value.type === APP_GROUP_TYPE)
+    .map(instance => ({
+      elemID: instance.elemID,
+      severity: 'Error',
+      message: `Cannot add or modify group of type ${APP_GROUP_TYPE}`,
+      detailedMessage: `Groups of type ${APP_GROUP_TYPE} cannot be updated through Okta API. Application import operations are responsible for syncing Groups of type ${APP_GROUP_TYPE}.`,
+    }))
+)

--- a/packages/okta-adapter/src/change_validators/index.ts
+++ b/packages/okta-adapter/src/change_validators/index.ts
@@ -22,6 +22,7 @@ import { groupRuleActionsValidator } from './group_rule_actions'
 import { defaultPoliciesValidator } from './default_policies'
 import { groupRuleAdministratorValidator } from './group_rule_administrator'
 import { customApplicationStatusValidator } from './custom_application_status'
+import { appGroupValidator } from './app_group'
 import { userTypeAndSchemaValidator } from './user_type_and_schema'
 import { appIntegrationSetupValidator } from './app_integration_setup'
 import { assignedAccessPoliciesValidator } from './assigned_policies'
@@ -38,6 +39,7 @@ export default ({
   const validators: ChangeValidator[] = [
     ...deployment.changeValidators.getDefaultChangeValidators(),
     applicationValidator,
+    appGroupValidator,
     groupRuleStatusValidator,
     groupRuleActionsValidator,
     defaultPoliciesValidator,

--- a/packages/okta-adapter/test/change_validators/app_group.test.ts
+++ b/packages/okta-adapter/test/change_validators/app_group.test.ts
@@ -1,0 +1,62 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { toChange, ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { appGroupValidator } from '../../src/change_validators/app_group'
+import { OKTA, GROUP_TYPE_NAME } from '../../src/constants'
+
+describe('appGroupValidator', () => {
+  const type = new ObjectType({ elemID: new ElemID(OKTA, GROUP_TYPE_NAME) })
+  const appGroup = new InstanceElement(
+    'group',
+    type,
+    { label: 'group1', profile: { name: 'group' }, type: 'APP_GROUP' },
+  )
+  const appGroup2 = new InstanceElement(
+    'group2',
+    type,
+    { label: 'group2', profile: { name: 'group2' }, type: 'APP_GROUP' },
+  )
+  const oktaGroup = new InstanceElement(
+    'oktaGroup',
+    type,
+    { label: 'group1', profile: { name: 'group' }, type: 'OKTA_GROUP' }
+  )
+  it('should return an error if when APP_GROUP is added or changed', async () => {
+    const changeErrors = await appGroupValidator([
+      toChange({ before: appGroup, after: appGroup }), toChange({ after: appGroup2 }),
+    ])
+    expect(changeErrors).toEqual([
+      {
+        elemID: appGroup.elemID,
+        severity: 'Error',
+        message: 'Cannot add or modify group of type APP_GROUP',
+        detailedMessage: 'Groups of type APP_GROUP cannot be updated through Okta API. Application import operations are responsible for syncing Groups of type APP_GROUP.',
+      },
+      {
+        elemID: appGroup2.elemID,
+        severity: 'Error',
+        message: 'Cannot add or modify group of type APP_GROUP',
+        detailedMessage: 'Groups of type APP_GROUP cannot be updated through Okta API. Application import operations are responsible for syncing Groups of type APP_GROUP.',
+      },
+    ])
+  })
+  it('should not return error for changes in okta groups or removals of APP_GROUP', async () => {
+    const changeErrors = await appGroupValidator([
+      toChange({ after: oktaGroup }), toChange({ before: appGroup }),
+    ])
+    expect(changeErrors).toEqual([])
+  })
+})


### PR DESCRIPTION
Block additions or modifications of APP_GROUP in Okta

---

it is not supported through the API

---
_Release Notes_: 
None

---
_User Notifications_: 
None
