### PR TITLE
Refactor SDF dependencies graph

### DIFF
--- a/packages/netsuite-adapter/src/change_validators/client_validation.ts
+++ b/packages/netsuite-adapter/src/change_validators/client_validation.ts
@@ -15,11 +15,12 @@
 */
 import _ from 'lodash'
 import { collections } from '@salto-io/lowerdash'
-import { Change, ChangeError, changeId, getChangeData, ChangeDataType, isField, isFieldChange, isInstanceChange, isObjectTypeChange, InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import { Change, ChangeError, changeId, getChangeData, ChangeDataType, isField, isFieldChange } from '@salto-io/adapter-api'
 import { AdditionalDependencies } from '../config'
 import { getGroupItemFromRegex } from '../client/utils'
 import NetsuiteClient from '../client/client'
 import { getChangeGroupIdsFunc } from '../group_changes'
+import { getDeployableChanges } from '../client/types'
 import { ManifestValidationError, ObjectsDeployError, SettingsDeployError } from '../client/errors'
 import { detectLanguage, multiLanguageErrorDetectors, OBJECT_ID } from '../client/language_utils'
 import { SCRIPT_ID } from '../constants'
@@ -118,9 +119,7 @@ const changeValidator: ClientChangeValidator = async (
         additionalDependencies,
       )
       if (errors.length > 0) {
-        const topLevelChanges = groupChanges.filter(
-          change => isInstanceChange(change) || isObjectTypeChange(change)
-        ) as Change<InstanceElement | ObjectType>[]
+        const topLevelChanges = getDeployableChanges(groupChanges)
         const { dependencyMap } = await NetsuiteClient.createDependencyMapAndGraph(topLevelChanges)
         return awu(errors).flatMap(async error => {
           if (error instanceof ObjectsDeployError) {

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -27,7 +27,7 @@ import SuiteAppClient from './suiteapp_client/suiteapp_client'
 import { createSuiteAppFileCabinetOperations, SuiteAppFileCabinetOperations, DeployType } from './suiteapp_client/suiteapp_file_cabinet'
 import { ConfigRecord, SavedSearchQuery, SystemInformation } from './suiteapp_client/types'
 import { CustomRecordTypeRecords, RecordValue } from './suiteapp_client/soap_client/types'
-import { FeaturesMap, getChangeNodeId, GetCustomObjectsResult, getDeployableChanges, getElemIdNodeId, getOrTransformCustomRecordTypeToInstance, ImportFileCabinetResult, ManifestDependencies, SDFObjectNode } from './types'
+import { FeaturesMap, getChangeNodeId, GetCustomObjectsResult, getDeployableChanges, getNodeId, getOrTransformCustomRecordTypeToInstance, ImportFileCabinetResult, ManifestDependencies, SDFObjectNode } from './types'
 import { toCustomizationInfo } from '../transformer'
 import { isSdfCreateOrUpdateGroupId, isSdfDeleteGroupId, isSuiteAppCreateRecordsGroupId, isSuiteAppDeleteRecordsGroupId, isSuiteAppUpdateRecordsGroupId, SUITEAPP_CREATING_FILES_GROUP_ID, SUITEAPP_DELETING_FILES_GROUP_ID, SUITEAPP_FILE_CABINET_GROUPS, SUITEAPP_UPDATING_CONFIG_GROUP_ID, SUITEAPP_UPDATING_FILES_GROUP_ID } from '../group_changes'
 import { DeployResult, getElementValueOrAnnotations, isFileCabinetInstance } from '../types'
@@ -170,9 +170,8 @@ export default class NetsuiteClient {
     changes: Change<InstanceElement | ObjectType>[],
   ): Promise<DependencyInfo> {
     const dependencyMap = new DefaultMap<string, Set<string>>(() => new Set())
-    const nodes = await NetsuiteClient.getSDFObjectGraphNodes(changes)
-    const dependencyGraph = new Graph(nodes)
-    nodes.forEach(node => {
+    const dependencyGraph = new Graph(await NetsuiteClient.getSDFObjectGraphNodes(changes))
+    dependencyGraph.nodes.forEach(node => {
       const currSet = dependencyMap.get(node.id)
       lookupValue(node.value.customizationInfo.values, val => {
         if (!_.isString(val)) {
@@ -197,7 +196,7 @@ export default class NetsuiteClient {
     elemIds: ElemID[],
     dependencyGraph: Graph<SDFObjectNode>
   ): Set<string> {
-    return new Set(elemIds.map(id => dependencyGraph.getNode(getElemIdNodeId(id)))
+    return new Set(elemIds.map(id => dependencyGraph.getNode(getNodeId(id)))
       .filter(values.isDefined)
       .flatMap(node => dependencyGraph.getNodeDependencies(node))
       .map(node => node.id))

--- a/packages/netsuite-adapter/src/client/deploy_xml_utils.ts
+++ b/packages/netsuite-adapter/src/client/deploy_xml_utils.ts
@@ -18,8 +18,8 @@ import xmlParser from 'fast-xml-parser'
 import osPath from 'path'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
-import { Graph, SDFObjectNode } from './graph_utils'
-import { CustomizationInfo, CustomTypeInfo, FileCustomizationInfo, FolderCustomizationInfo } from './types'
+import { Graph } from './graph_utils'
+import { CustomizationInfo, CustomTypeInfo, FileCustomizationInfo, FolderCustomizationInfo, SDFObjectNode } from './types'
 import { isCustomTypeInfo, isFileCustomizationInfo, isFolderCustomizationInfo } from './utils'
 
 type FileCabinetCustomType = FileCustomizationInfo | FolderCustomizationInfo

--- a/packages/netsuite-adapter/src/client/errors.ts
+++ b/packages/netsuite-adapter/src/client/errors.ts
@@ -15,8 +15,9 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { Change, ElemID, getChangeData, InstanceElement, isInstanceChange, isInstanceElement, isModificationChange, ObjectType } from '@salto-io/adapter-api'
+import { Change, ElemID, getChangeData, isInstanceChange, isInstanceElement, isModificationChange } from '@salto-io/adapter-api'
 import { CONFIG_FEATURES, SCRIPT_ID } from '../constants'
+import { DeployableChange } from './types'
 
 export class FeaturesDeployError extends Error {
   ids: string[]
@@ -96,7 +97,7 @@ const getFailedManifestErrorElemIds = (
 
 const getFailedSdfDeployChangesElemIDs = (
   error: ObjectsDeployError,
-  changes: Change<InstanceElement | ObjectType>[],
+  changes: DeployableChange[],
 ): ElemID[] => changes
   .map(getChangeData)
   .filter(elem => (
@@ -108,7 +109,7 @@ const getFailedSdfDeployChangesElemIDs = (
 
 const getFailedSettingsErrorChanges = (
   error: SettingsDeployError,
-  changes: Change<InstanceElement | ObjectType>[],
+  changes: DeployableChange[],
 ): ElemID[] => changes
   .map(change => getChangeData(change).elemID)
   .filter(changeElemId => error.failedConfigTypes.has(changeElemId.typeName))
@@ -116,7 +117,7 @@ const getFailedSettingsErrorChanges = (
 export const getChangesElemIdsToRemove = (
   error: unknown,
   dependencyMap: Map<string, Set<string>>,
-  changes: Change<InstanceElement | ObjectType>[]
+  changes: DeployableChange[]
 ): ElemID[] => {
   if (error instanceof ManifestValidationError) {
     return getFailedManifestErrorElemIds(error, dependencyMap)

--- a/packages/netsuite-adapter/src/client/graph_utils.ts
+++ b/packages/netsuite-adapter/src/client/graph_utils.ts
@@ -16,78 +16,67 @@
 
 import _ from 'lodash'
 import wu from 'wu'
-import { CustomizationInfo } from './types'
-
-
-export type SDFObjectNode = {
-  elemIdFullName: string
-  serviceid: string
-  changeType: 'addition' | 'modification'
-  customizationInfo: CustomizationInfo
-}
 
 export class GraphNode<T> {
-  edges: Map<T[keyof T], GraphNode<T>>
+  edges: Map<string, GraphNode<T>>
   value: T
   id: string
 
-  constructor(value: T, id: string) {
+  constructor(id: string, value: T) {
     this.value = value
-    this.edges = new Map<T[keyof T], GraphNode<T>>()
+    this.edges = new Map<string, GraphNode<T>>()
     this.id = id
   }
 
-  addEdge(key: keyof T, node: GraphNode<T>): void {
-    this.edges.set(node.value[key], node)
+  addEdge(node: GraphNode<T>): void {
+    this.edges.set(node.id, node)
   }
 }
 
 type DFSParameters<T>= {
   node: GraphNode<T>
-  visited: Set<T[keyof T]>
+  visited: Set<string>
   resultArray?: GraphNode<T>[]
   // optional parameters for cycle detection
-  path?: T[keyof T][]
-  cycle?: T[keyof T][]
+  path?: string[]
+  cycle?: string[]
 }
 
 export class Graph<T> {
-  nodes: Map<T[keyof T], GraphNode<T>>
-  key: keyof T
+  nodes: Map<string, GraphNode<T>>
 
-  constructor(key: keyof T, nodes: GraphNode<T>[] = []) {
+  constructor(nodes: GraphNode<T>[] = []) {
     this.nodes = new Map()
-    this.key = key
-    nodes.forEach(node => this.nodes.set(node.value[key], node))
+    nodes.forEach(node => this.nodes.set(node.id, node))
   }
 
   addNodes(nodes: GraphNode<T>[]): void {
     nodes.forEach(node => {
-      if (!this.nodes.has(node.value[this.key])) {
-        this.nodes.set(node.value[this.key], node)
+      if (!this.nodes.has(node.id)) {
+        this.nodes.set(node.id, node)
       }
     })
   }
 
   private dfs(dfsParams: DFSParameters<T>): void {
     const { node, visited, resultArray = [], path = [], cycle = [] } = dfsParams
-    if (visited.has(node.value[this.key])) {
-      const cycleStartIndex = path.indexOf(node.value[this.key])
+    if (visited.has(node.id)) {
+      const cycleStartIndex = path.indexOf(node.id)
       if (cycleStartIndex !== -1) {
         // node is visited & in path mean its a cycle
         cycle.push(...(path.slice(cycleStartIndex)))
       }
       return
     }
-    visited.add(node.value[this.key])
+    visited.add(node.id)
     node.edges.forEach(dependency => {
-      this.dfs({ node: dependency, visited, resultArray, path: path.concat(node.value[this.key]), cycle })
+      this.dfs({ node: dependency, visited, resultArray, path: path.concat(node.id), cycle })
     })
     resultArray.push(node)
   }
 
   getTopologicalOrder(): GraphNode<T>[] {
-    const visited = new Set<T[keyof T]>()
+    const visited = new Set<string>()
     const sortedNodes: GraphNode<T>[] = []
     Array.from(this.nodes.values()).forEach(node => {
       this.dfs({ node, visited, resultArray: sortedNodes })
@@ -99,40 +88,36 @@ export class Graph<T> {
     if (_.isEmpty(startNode.edges)) {
       return [startNode]
     }
-    const visited = new Set<T[keyof T]>()
+    const visited = new Set<string>()
     const dependencies: GraphNode<T>[] = []
     this.dfs({ node: startNode, visited, resultArray: dependencies })
     return dependencies
   }
 
-  findNode(value: T): GraphNode<T> | undefined {
-    return this.nodes.get(value[this.key])
+  getNode(id: string): GraphNode<T> | undefined {
+    return this.nodes.get(id)
   }
 
-  findNodeByKey(key: T[keyof T]): GraphNode<T> | undefined {
-    return this.nodes.get(key)
-  }
-
-  findNodeByField(key: keyof T, value: T[keyof T]): GraphNode<T> | undefined {
+  findNodeByField<K extends keyof T>(key: K, value: T[K]): GraphNode<T> | undefined {
     return wu(this.nodes.values()).find(node => _.isEqual(node.value[key], value))
   }
 
-  removeNode(key: T[keyof T]): void {
-    const node = this.nodes.get(key)
+  removeNode(id: string): void {
+    const node = this.nodes.get(id)
     if (node) {
       Array.from(this.nodes.values()).forEach(otherNode => {
-        otherNode.edges.delete(key)
+        otherNode.edges.delete(id)
       })
-      this.nodes.delete(key)
+      this.nodes.delete(id)
     }
   }
 
-  findCycle(): T[keyof T][] {
-    const visited = new Set<T[keyof T]>()
-    const nodesInCycle: T[keyof T][] = []
+  findCycle(): string[] {
+    const visited = new Set<string>()
+    const nodesInCycle: string[] = []
 
     Array.from(this.nodes.values()).forEach(node => {
-      if (!visited.has(node.value[this.key])) {
+      if (!visited.has(node.id)) {
         this.dfs({ node, visited, cycle: nodesInCycle })
       }
     })

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -46,7 +46,7 @@ import { SdfCredentials } from './credentials'
 import {
   CustomizationInfo, CustomTypeInfo, FailedImport, FailedTypes, FileCustomizationInfo,
   FolderCustomizationInfo, GetCustomObjectsResult, ImportFileCabinetResult, ImportObjectsResult,
-  TemplateCustomTypeInfo, ManifestDependencies, SdfDeployParams,
+  TemplateCustomTypeInfo, ManifestDependencies, SdfDeployParams, SDFObjectNode,
 } from './types'
 import { ATTRIBUTE_PREFIX, CDATA_TAG_NAME, fileCabinetTopLevelFolders } from './constants'
 import {
@@ -55,7 +55,7 @@ import {
 } from './utils'
 import { fixManifest } from './manifest_utils'
 import { detectLanguage, FEATURE_NAME, fetchLockedObjectErrorRegex, fetchUnexpectedErrorRegex, multiLanguageErrorDetectors, OBJECT_ID } from './language_utils'
-import { Graph, SDFObjectNode } from './graph_utils'
+import { Graph } from './graph_utils'
 import { FileSize, largeFoldersToExclude } from './file_cabinet_utils'
 import { getCustomTypeInfoPath, getFileCabinetTypesPath, OBJECTS_DIR, FILE_CABINET_DIR, ATTRIBUTES_FOLDER_NAME, FOLDER_ATTRIBUTES_FILE_SUFFIX, ATTRIBUTES_FILE_SUFFIX, reorderDeployXml } from './deploy_xml_utils'
 

--- a/packages/netsuite-adapter/src/client/types.ts
+++ b/packages/netsuite-adapter/src/client/types.ts
@@ -116,10 +116,10 @@ export type SDFObjectNode = {
   customizationInfo: CustomizationInfo
 }
 
-export const getElemIdNodeId = (elemId: ElemID): string => elemId.getFullName()
+export const getNodeId = (elemId: ElemID): string => elemId.getFullName()
 
 export const getChangeNodeId = (change: DeployableChange): string =>
-  getElemIdNodeId(getChangeData(change).elemID)
+  getNodeId(getChangeData(change).elemID)
 
 export const getDeployableChanges = (
   changes: ReadonlyArray<Change>

--- a/packages/netsuite-adapter/src/client/types.ts
+++ b/packages/netsuite-adapter/src/client/types.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, InstanceElement, isInstanceChange, isObjectType, isObjectTypeChange, ObjectType, Values } from '@salto-io/adapter-api'
+import { Change, ChangeData, ElemID, getChangeData, InstanceElement, isInstanceChange, isObjectType, isObjectTypeChange, ObjectType, Values } from '@salto-io/adapter-api'
 import { toCustomRecordTypeInstance } from '../custom_records/custom_record_type'
 import { NetsuiteFilePathsQueryParams, NetsuiteTypesQueryParams } from '../query'
 
@@ -107,15 +107,29 @@ export class InvalidSuiteAppCredentialsError extends Error {
   }
 }
 
+type DeployableChange = Change<ObjectType | InstanceElement>
+
+export type SDFObjectNode = {
+  change: DeployableChange
+  serviceid: string
+  changeType: 'addition' | 'modification'
+  customizationInfo: CustomizationInfo
+}
+
+export const getElemIdNodeId = (elemId: ElemID): string => elemId.getFullName()
+
+export const getChangeNodeId = (change: DeployableChange): string =>
+  getElemIdNodeId(getChangeData(change).elemID)
+
 export const getDeployableChanges = (
   changes: ReadonlyArray<Change>
-): Change<ObjectType | InstanceElement>[] =>
+): DeployableChange[] =>
   changes.filter(
     change => isInstanceChange(change) || isObjectTypeChange(change)
-  ) as Change<InstanceElement | ObjectType>[]
+  ) as DeployableChange[]
 
 export const getOrTransformCustomRecordTypeToInstance = (
-  element: ObjectType | InstanceElement
+  element: ChangeData<DeployableChange>
 ): InstanceElement => (
   isObjectType(element)
     ? toCustomRecordTypeInstance(element)

--- a/packages/netsuite-adapter/src/client/types.ts
+++ b/packages/netsuite-adapter/src/client/types.ts
@@ -107,7 +107,7 @@ export class InvalidSuiteAppCredentialsError extends Error {
   }
 }
 
-type DeployableChange = Change<ObjectType | InstanceElement>
+export type DeployableChange = Change<ObjectType | InstanceElement>
 
 export type SDFObjectNode = {
   change: DeployableChange

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -15,7 +15,7 @@
 */
 
 import { ElemID, InstanceElement, StaticFile, ChangeDataType, DeployResult,
-  getChangeData, FetchOptions, ObjectType, Change, isObjectType } from '@salto-io/adapter-api'
+  getChangeData, FetchOptions, ObjectType, Change, isObjectType, toChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { mockFunction, MockInterface } from '@salto-io/test-utils'
@@ -30,7 +30,7 @@ import resolveValuesFilter from '../src/filters/element_references'
 import { CONFIG, configType, getConfigFromConfigChanges, NetsuiteConfig } from '../src/config'
 import { mockGetElemIdFunc } from './utils'
 import NetsuiteClient from '../src/client/client'
-import { CustomizationInfo, CustomTypeInfo, FileCustomizationInfo, FolderCustomizationInfo } from '../src/client/types'
+import { CustomizationInfo, CustomTypeInfo, FileCustomizationInfo, FolderCustomizationInfo, SDFObjectNode } from '../src/client/types'
 import * as changesDetector from '../src/changes_detector/changes_detector'
 import SuiteAppClient from '../src/client/suiteapp_client/suiteapp_client'
 import { SERVER_TIME_TYPE_NAME } from '../src/server_time'
@@ -41,7 +41,7 @@ import getChangeValidator from '../src/change_validator'
 import { FetchByQueryFunc } from '../src/change_validators/safe_deploy'
 import { getStandardTypesNames } from '../src/autogen/types'
 import { createCustomRecordTypes } from '../src/custom_records/custom_record_type'
-import { Graph, SDFObjectNode, GraphNode } from '../src/client/graph_utils'
+import { Graph, GraphNode } from '../src/client/graph_utils'
 
 const DEFAULT_SDF_DEPLOY_PARAMS = {
   manifestDependencies: {
@@ -619,11 +619,12 @@ describe('Adapter', () => {
     const folderInstance = new InstanceElement('folderInstance', additionalTypes[FOLDER], {
       [PATH]: 'Templates/E-mail Templates/Inner EmailTemplates Folder',
     })
-    const testGraph = new Graph<SDFObjectNode>('elemIdFullName')
+    let testGraph: Graph<SDFObjectNode>
 
     beforeEach(() => {
       instance = origInstance.clone()
       client.deploy = jest.fn().mockImplementation(() => Promise.resolve())
+      testGraph = new Graph()
     })
 
     const adapterAdd = (after: ChangeDataType): Promise<DeployResult> => netsuiteAdapter.deploy({
@@ -634,9 +635,6 @@ describe('Adapter', () => {
     })
 
     describe('add', () => {
-      beforeEach(() => {
-        testGraph.nodes.clear()
-      })
       it('should add custom type instance', async () => {
         const result = await adapterAdd(instance)
         expect(result.errors).toHaveLength(0)
@@ -644,9 +642,19 @@ describe('Adapter', () => {
         const post = getChangeData(result.appliedChanges[0]) as InstanceElement
 
         const expectedResolvedInstance = instance.clone()
-        expectedResolvedInstance.value.description = 'description value'
+        expectedResolvedInstance.value.description = Buffer.from('description value')
         const customizationInfo = await toCustomizationInfo(expectedResolvedInstance)
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', serviceid: 'custentity_my_script_id', changeType: 'addition', customizationInfo } as SDFObjectNode, 'netsuite.entitycustomfield.instance.elementName')])
+        testGraph.addNodes([
+          new GraphNode(
+            'netsuite.entitycustomfield.instance.elementName',
+            {
+              serviceid: 'custentity_my_script_id',
+              changeType: 'addition',
+              customizationInfo,
+              change: toChange({ after: expectedResolvedInstance }),
+            }
+          ),
+        ])
         expect(client.deploy)
           .toHaveBeenCalledWith(
             undefined,
@@ -663,7 +671,12 @@ describe('Adapter', () => {
         const post = getChangeData(result.appliedChanges[0]) as InstanceElement
         const customizationInfo = await toCustomizationInfo(fileInstance)
         const serviceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder/content.html'
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.file.instance.fileInstance', serviceid: serviceId, changeType: 'addition', customizationInfo } as SDFObjectNode, 'netsuite.file.instance.fileInstance')])
+        testGraph.addNodes([
+          new GraphNode(
+            'netsuite.file.instance.fileInstance',
+            { serviceid: serviceId, changeType: 'addition', customizationInfo, change: toChange({ after: fileInstance }) }
+          ),
+        ])
         expect(client.deploy).toHaveBeenCalledWith(
           undefined,
           DEFAULT_SDF_DEPLOY_PARAMS,
@@ -679,7 +692,12 @@ describe('Adapter', () => {
         const post = getChangeData(result.appliedChanges[0]) as InstanceElement
         const customizationInfo = await toCustomizationInfo(folderInstance)
         const serviceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder'
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.folder.instance.folderInstance', serviceid: serviceId, changeType: 'addition', customizationInfo } as SDFObjectNode, 'netsuite.folder.instance.folderInstance')])
+        testGraph.addNodes([
+          new GraphNode(
+            'netsuite.folder.instance.folderInstance',
+            { serviceid: serviceId, changeType: 'addition', customizationInfo, change: toChange({ after: folderInstance }) },
+          ),
+        ])
         expect(client.deploy).toHaveBeenCalledWith(
           undefined,
           DEFAULT_SDF_DEPLOY_PARAMS,
@@ -689,12 +707,14 @@ describe('Adapter', () => {
       })
 
       it('should support deploying multiple changes at once', async () => {
+        const fileChange = toChange({ after: fileInstance })
+        const folderChange = toChange({ after: folderInstance })
         const result = await netsuiteAdapter.deploy({
           changeGroup: {
             groupID: SDF_CREATE_OR_UPDATE_GROUP_ID,
             changes: [
-              { action: 'add', data: { after: fileInstance } },
-              { action: 'add', data: { after: folderInstance } },
+              fileChange,
+              folderChange,
             ],
           },
         })
@@ -703,8 +723,14 @@ describe('Adapter', () => {
         const folderServiceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder'
         const fileServiceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder/content.html'
         testGraph.addNodes([
-          new GraphNode({ elemIdFullName: 'netsuite.file.instance.fileInstance', serviceid: fileServiceId, changeType: 'addition', customizationInfo: fileCustInfo } as SDFObjectNode, 'netsuite.file.instance.fileInstance'),
-          new GraphNode({ elemIdFullName: 'netsuite.folder.instance.folderInstance', serviceid: folderServiceId, changeType: 'addition', customizationInfo: folderCustInfo } as SDFObjectNode, 'netsuite.folder.instance.folderInstance'),
+          new GraphNode(
+            'netsuite.file.instance.fileInstance',
+            { serviceid: fileServiceId, changeType: 'addition', customizationInfo: fileCustInfo, change: fileChange }
+          ),
+          new GraphNode(
+            'netsuite.folder.instance.folderInstance',
+            { serviceid: folderServiceId, changeType: 'addition', customizationInfo: folderCustInfo, change: folderChange }
+          ),
         ])
         expect(client.deploy).toHaveBeenCalledWith(
           undefined,
@@ -718,12 +744,14 @@ describe('Adapter', () => {
       it('should return correct DeployResult in case of failure', async () => {
         const clientError = new Error('some client error')
         client.deploy = jest.fn().mockRejectedValue(clientError)
+        const fileChange = toChange({ after: fileInstance })
+        const folderChange = toChange({ after: folderInstance })
         const result = await netsuiteAdapter.deploy({
           changeGroup: {
             groupID: SDF_CREATE_OR_UPDATE_GROUP_ID,
             changes: [
-              { action: 'add', data: { after: fileInstance } },
-              { action: 'add', data: { after: folderInstance } },
+              fileChange,
+              folderChange,
             ],
           },
         })
@@ -732,8 +760,14 @@ describe('Adapter', () => {
         const folderServiceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder'
         const fileServiceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder/content.html'
         testGraph.addNodes([
-          new GraphNode({ elemIdFullName: 'netsuite.file.instance.fileInstance', serviceid: fileServiceId, changeType: 'addition', customizationInfo: fileCustInfo } as SDFObjectNode, 'netsuite.file.instance.fileInstance'),
-          new GraphNode({ elemIdFullName: 'netsuite.folder.instance.folderInstance', serviceid: folderServiceId, changeType: 'addition', customizationInfo: folderCustInfo } as SDFObjectNode, 'netsuite.folder.instance.folderInstance'),
+          new GraphNode(
+            'netsuite.file.instance.fileInstance',
+            { serviceid: fileServiceId, changeType: 'addition', customizationInfo: fileCustInfo, change: fileChange },
+          ),
+          new GraphNode(
+            'netsuite.folder.instance.folderInstance',
+            { serviceid: folderServiceId, changeType: 'addition', customizationInfo: folderCustInfo, change: folderChange },
+          ),
         ])
         expect(client.deploy).toHaveBeenCalledWith(
           undefined,
@@ -756,10 +790,6 @@ describe('Adapter', () => {
         },
       })
 
-      beforeEach(() => {
-        testGraph.nodes.clear()
-      })
-
       it('should update custom type instance', async () => {
         const result = await adapterUpdate(instance, instance.clone())
         expect(result.errors).toHaveLength(0)
@@ -767,9 +797,22 @@ describe('Adapter', () => {
         const post = getChangeData(result.appliedChanges[0]) as InstanceElement
 
         const expectedResolvedInstance = instance.clone()
-        expectedResolvedInstance.value.description = 'description value'
+        expectedResolvedInstance.value.description = Buffer.from('description value')
         const customizationInfo = await toCustomizationInfo(expectedResolvedInstance)
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', serviceid: 'custentity_my_script_id', changeType: 'modification', customizationInfo } as SDFObjectNode, 'netsuite.entitycustomfield.instance.elementName')])
+        testGraph.addNodes([
+          new GraphNode(
+            'netsuite.entitycustomfield.instance.elementName',
+            {
+              serviceid: 'custentity_my_script_id',
+              changeType: 'modification',
+              customizationInfo,
+              change: toChange({
+                before: instance,
+                after: expectedResolvedInstance,
+              }),
+            },
+          ),
+        ])
         expect(client.deploy)
           .toHaveBeenCalledWith(
             undefined,
@@ -786,7 +829,17 @@ describe('Adapter', () => {
         const post = getChangeData(result.appliedChanges[0]) as InstanceElement
         const customizationInfo = await toCustomizationInfo(fileInstance)
         const serviceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder/content.html'
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.file.instance.fileInstance', serviceid: serviceId, changeType: 'modification', customizationInfo } as SDFObjectNode, 'netsuite.file.instance.fileInstance')])
+        testGraph.addNodes([
+          new GraphNode(
+            'netsuite.file.instance.fileInstance',
+            {
+              serviceid: serviceId,
+              changeType: 'modification',
+              customizationInfo,
+              change: toChange({ before: fileInstance, after: fileInstance }),
+            },
+          ),
+        ])
         expect(client.deploy).toHaveBeenCalledWith(
           undefined,
           DEFAULT_SDF_DEPLOY_PARAMS,
@@ -802,7 +855,17 @@ describe('Adapter', () => {
         const post = getChangeData(result.appliedChanges[0]) as InstanceElement
         const customizationInfo = await toCustomizationInfo(folderInstance)
         const serviceId = 'Templates/E-mail Templates/Inner EmailTemplates Folder'
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.folder.instance.folderInstance', serviceid: serviceId, changeType: 'modification', customizationInfo } as SDFObjectNode, 'netsuite.folder.instance.folderInstance')])
+        testGraph.addNodes([
+          new GraphNode(
+            'netsuite.folder.instance.folderInstance',
+            {
+              serviceid: serviceId,
+              changeType: 'modification',
+              customizationInfo,
+              change: toChange({ before: folderInstance, after: folderInstance }),
+            },
+          ),
+        ])
         expect(client.deploy).toHaveBeenCalledWith(
           undefined,
           DEFAULT_SDF_DEPLOY_PARAMS,
@@ -823,9 +886,22 @@ describe('Adapter', () => {
         const post = getChangeData(result.appliedChanges[0]) as InstanceElement
 
         const expectedResolvedAfter = after.clone()
-        expectedResolvedAfter.value.description = 'edited description value'
+        expectedResolvedAfter.value.description = Buffer.from('edited description value')
         const customizationInfo = await toCustomizationInfo(expectedResolvedAfter)
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', serviceid: 'custentity_my_script_id', changeType: 'modification', customizationInfo } as SDFObjectNode, 'netsuite.entitycustomfield.instance.elementName')])
+        testGraph.addNodes([
+          new GraphNode(
+            'netsuite.entitycustomfield.instance.elementName',
+            {
+              serviceid: 'custentity_my_script_id',
+              changeType: 'modification',
+              customizationInfo,
+              change: toChange({
+                before: instance,
+                after: expectedResolvedAfter,
+              }),
+            },
+          ),
+        ])
         expect(client.deploy)
           .toHaveBeenCalledWith(
             undefined,
@@ -836,14 +912,12 @@ describe('Adapter', () => {
       })
     })
     describe('additional sdf dependencies', () => {
+      let expectedResolvedInstance: InstanceElement
       let custInfo: CustomizationInfo
       beforeAll(async () => {
-        const expectedResolvedInstance = instance.clone()
-        expectedResolvedInstance.value.description = 'description value'
+        expectedResolvedInstance = instance.clone()
+        expectedResolvedInstance.value.description = Buffer.from('description value')
         custInfo = await toCustomizationInfo(expectedResolvedInstance)
-      })
-      beforeEach(() => {
-        testGraph.nodes.clear()
       })
       it('should call deploy with additional dependencies', async () => {
         const configWithAdditionalSdfDependencies = {
@@ -872,7 +946,17 @@ describe('Adapter', () => {
             changes: [{ action: 'add', data: { after: instance } }],
           },
         })
-        testGraph.addNodes([new GraphNode({ serviceid: 'custentity_my_script_id', elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', changeType: 'addition', customizationInfo: custInfo } as SDFObjectNode, 'netsuite.entitycustomfield.instance.elementName')])
+        testGraph.addNodes([
+          new GraphNode(
+            'netsuite.entitycustomfield.instance.elementName',
+            {
+              serviceid: 'custentity_my_script_id',
+              changeType: 'addition',
+              customizationInfo: custInfo,
+              change: toChange({ after: expectedResolvedInstance }),
+            },
+          ),
+        ])
         expect(client.deploy).toHaveBeenCalledWith(
           undefined,
           {
@@ -889,7 +973,18 @@ describe('Adapter', () => {
 
       it('should call deploy without additional dependencies', async () => {
         await adapterAdd(instance)
-        testGraph.addNodes([new GraphNode({ serviceid: 'custentity_my_script_id', elemIdFullName: 'netsuite.entitycustomfield.instance.elementName', changeType: 'addition', customizationInfo: custInfo } as SDFObjectNode, 'netsuite.entitycustomfield.instance.elementName')])
+
+        testGraph.addNodes([
+          new GraphNode(
+            'netsuite.entitycustomfield.instance.elementName',
+            {
+              serviceid: 'custentity_my_script_id',
+              changeType: 'addition',
+              customizationInfo: custInfo,
+              change: toChange({ after: expectedResolvedInstance }),
+            },
+          ),
+        ])
         expect(client.deploy).toHaveBeenCalledWith(
           undefined,
           DEFAULT_SDF_DEPLOY_PARAMS,

--- a/packages/netsuite-adapter/test/client/client.test.ts
+++ b/packages/netsuite-adapter/test/client/client.test.ts
@@ -24,7 +24,8 @@ import { SUITEAPP_CONFIG_RECORD_TYPES, SUITEAPP_CONFIG_TYPES_TO_TYPE_NAMES } fro
 import { featuresType } from '../../src/types/configuration_types'
 import { FeaturesDeployError, ManifestValidationError, MissingManifestFeaturesError, ObjectsDeployError, SettingsDeployError } from '../../src/client/errors'
 import { AdditionalDependencies } from '../../src/config'
-import { Graph, GraphNode, SDFObjectNode } from '../../src/client/graph_utils'
+import { Graph, GraphNode } from '../../src/client/graph_utils'
+import { SDFObjectNode } from '../../src/client/types'
 
 describe('NetsuiteClient', () => {
   describe('with SDF client', () => {
@@ -45,12 +46,14 @@ describe('NetsuiteClient', () => {
       },
     ]
 
-    const testGraph = new Graph<SDFObjectNode>('elemIdFullName')
+    let testGraph: Graph<SDFObjectNode>
+    beforeEach(() => {
+      testGraph = new Graph()
+    })
     describe('deploy', () => {
       beforeEach(() => {
         jest.resetAllMocks()
         deployParams[0].include.features = []
-        testGraph.nodes.clear()
       })
 
       it('should try again to deploy after ObjectsDeployError', async () => {
@@ -254,7 +257,17 @@ describe('NetsuiteClient', () => {
         const change = toChange({
           after: new InstanceElement('instance', type, { scriptid: 'someObject' }),
         })
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.type.instance.instance', serviceid: 'someObject', changeType: 'addition', customizationInfo: { scriptId: 'someObject', typeName: 'type', values: { scriptid: 'someObject' } } } as SDFObjectNode, 'netsuite.type.instance.instance')])
+        testGraph.addNodes([
+          new GraphNode(
+            'netsuite.type.instance.instance',
+            {
+              serviceid: 'someObject',
+              changeType: 'addition',
+              customizationInfo: { scriptId: 'someObject', typeName: 'type', values: { scriptid: 'someObject' } },
+              change,
+            },
+          ),
+        ])
         await client.deploy(
           [change],
           SDF_CREATE_OR_UPDATE_GROUP_ID,
@@ -304,7 +317,17 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
         const change = toChange({
           after: new InstanceElement('instance', type, { scriptid: 'someObject' }),
         })
-        testGraph.addNodes([new GraphNode({ serviceid: 'someObject', elemIdFullName: 'netsuite.type.instance.instance', changeType: 'addition', customizationInfo: { scriptId: 'someObject', typeName: 'type', values: { scriptid: 'someObject' } } } as SDFObjectNode, 'netsuite.type.instance.instance')])
+        testGraph.addNodes([
+          new GraphNode(
+            'netsuite.type.instance.instance',
+            {
+              serviceid: 'someObject',
+              changeType: 'addition',
+              customizationInfo: { scriptId: 'someObject', typeName: 'type', values: { scriptid: 'someObject' } },
+              change,
+            },
+          ),
+        ])
         expect(await client.deploy(
           [change],
           SDF_CREATE_OR_UPDATE_GROUP_ID,
@@ -370,7 +393,17 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
         const change = toChange({
           after: new InstanceElement('instance', type, { scriptid: 'someObject' }),
         })
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.type.instance.instance', serviceid: 'someObject', changeType: 'addition', customizationInfo: { scriptId: 'someObject', typeName: 'type', values: { scriptid: 'someObject' } } } as SDFObjectNode, 'netsuite.type.instance.instance')])
+        testGraph.addNodes([
+          new GraphNode(
+            'netsuite.type.instance.instance',
+            {
+              serviceid: 'someObject',
+              changeType: 'addition',
+              customizationInfo: { scriptId: 'someObject', typeName: 'type', values: { scriptid: 'someObject' } },
+              change,
+            },
+          ),
+        ])
         expect(await client.deploy(
           [change],
           SDF_CREATE_OR_UPDATE_GROUP_ID,
@@ -428,9 +461,6 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
       })
 
       describe('custom record types', () => {
-        beforeEach(() => {
-          testGraph.nodes.clear()
-        })
         const customizationInfo = {
           scriptId: 'customrecord1',
           typeName: 'customrecordtype',
@@ -446,7 +476,17 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
               },
             }),
           })
-          testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.customrecord1', serviceid: 'customrecord1', changeType: 'addition', customizationInfo } as SDFObjectNode, 'netsuite.customrecord1')])
+          testGraph.addNodes([
+            new GraphNode(
+              'netsuite.customrecord1',
+              {
+                serviceid: 'customrecord1',
+                changeType: 'addition',
+                customizationInfo,
+                change,
+              },
+            ),
+          ])
           expect(await client.deploy(
             [change],
             SDF_CREATE_OR_UPDATE_GROUP_ID,
@@ -498,7 +538,6 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
           const successFieldChange = toChange({
             after: customRecordType.fields.custom_field,
           })
-          testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.customrecord1.field.custom_field', serviceid: 'customrecord1', changeType: 'addition', customizationInfo } as SDFObjectNode, 'netsuite.customrecord1.field.custom_field')])
           expect(await client.deploy(
             [successTypeChange, successFieldChange, failedChange],
             SDF_CREATE_OR_UPDATE_GROUP_ID,
@@ -589,7 +628,6 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
         change = toChange({
           after: new InstanceElement('instance', type, { scriptid: 'someObject' }),
         })
-        testGraph.nodes.clear()
       })
       it('should call sdfValidate', async () => {
         const customizationInfo = {
@@ -597,7 +635,17 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
           typeName: 'type',
           values: { scriptid: 'someObject' },
         }
-        testGraph.addNodes([new GraphNode({ elemIdFullName: 'netsuite.type.instance.instance', serviceid: 'someObject', changeType: 'addition', customizationInfo } as SDFObjectNode, 'netsuite.type.instance.instance')])
+        testGraph.addNodes([
+          new GraphNode(
+            'netsuite.type.instance.instance',
+            {
+              serviceid: 'someObject',
+              changeType: 'addition',
+              customizationInfo,
+              change,
+            },
+          ),
+        ])
         await client.validate([change], SDF_CREATE_OR_UPDATE_GROUP_ID, deployParams[0])
         expect(mockSdfDeploy).toHaveBeenCalledWith(
           undefined,

--- a/packages/netsuite-adapter/test/client/graph_utils.test.ts
+++ b/packages/netsuite-adapter/test/client/graph_utils.test.ts
@@ -27,13 +27,13 @@ describe('graph utils tests', () => {
   let testNode2: GraphNode<testNode>
   let testNode3: GraphNode<testNode>
   beforeEach(() => {
-    testNode1 = new GraphNode({ name: 'node1', num: 1 }, 'node1')
-    testNode2 = new GraphNode({ name: 'node2', num: 2 }, 'node2')
-    testNode3 = new GraphNode({ name: 'node3', num: 3 }, 'node3')
-    testGraph = new Graph<testNode>('name', [testNode1, testNode2, testNode3])
-    testNode1.addEdge(testGraph.key, testNode2)
-    testNode1.addEdge(testGraph.key, testNode3)
-    testNode2.addEdge(testGraph.key, testNode1)
+    testNode1 = new GraphNode('node1', { name: 'node1', num: 1 })
+    testNode2 = new GraphNode('node2', { name: 'node2', num: 2 })
+    testNode3 = new GraphNode('node3', { name: 'node3', num: 3 })
+    testGraph = new Graph<testNode>([testNode1, testNode2, testNode3])
+    testNode1.addEdge(testNode2)
+    testNode1.addEdge(testNode3)
+    testNode2.addEdge(testNode1)
   })
 
 
@@ -43,17 +43,8 @@ describe('graph utils tests', () => {
     expect(result).toEqual(expect.arrayContaining([testNode2, testNode3, testNode1]))
   })
 
-  it('should find the node through its value', async () => {
-    const someNodeValue = { name: 'node2', num: 2 }
-    expect(testGraph.findNode(someNodeValue)).toEqual(testNode2)
-  })
-
-  it('should fail to find un-existing node', async () => {
-    expect(testGraph.findNode({ name: 'unexistingNode', num: 4 })).toBeUndefined()
-  })
-
   it('should find node by key', async () => {
-    expect(testGraph.findNodeByKey('node1')).toEqual(testNode1)
+    expect(testGraph.getNode('node1')).toEqual(testNode1)
   })
 
   it('should find node by field', async () => {
@@ -75,12 +66,12 @@ describe('graph utils tests', () => {
     expect(testNode2.edges).not.toContain(testNode1)
   })
   it('should return an empty array if there is no cycle', async () => {
-    const testNode4 = new GraphNode({ name: 'node4', num: 1 }, 'node4')
-    const testNode5 = new GraphNode({ name: 'node5', num: 2 }, 'node5')
-    const testNode6 = new GraphNode({ name: 'node6', num: 3 }, 'node6')
-    testNode4.addEdge(testGraph.key, testNode5)
-    testNode4.addEdge(testGraph.key, testNode6)
-    testGraph = new Graph<testNode>('name', [testNode4, testNode5, testNode6])
+    const testNode4 = new GraphNode('node4', { name: 'node4', num: 1 })
+    const testNode5 = new GraphNode('node5', { name: 'node5', num: 2 })
+    const testNode6 = new GraphNode('node6', { name: 'node6', num: 3 })
+    testNode4.addEdge(testNode5)
+    testNode4.addEdge(testNode6)
+    testGraph = new Graph<testNode>([testNode4, testNode5, testNode6])
     const cycleNodes = testGraph.findCycle()
     expect(cycleNodes).toHaveLength(0)
   })

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -23,11 +23,11 @@ import SdfClient, {
   COMMANDS,
   MINUTE_IN_MILLISECONDS,
 } from '../../src/client/sdf_client'
-import { CustomizationInfo, CustomTypeInfo, FileCustomizationInfo, FolderCustomizationInfo, SdfDeployParams, TemplateCustomTypeInfo } from '../../src/client/types'
+import { CustomizationInfo, CustomTypeInfo, FileCustomizationInfo, FolderCustomizationInfo, SdfDeployParams, SDFObjectNode, TemplateCustomTypeInfo } from '../../src/client/types'
 import { fileCabinetTopLevelFolders } from '../../src/client/constants'
 import { DEFAULT_COMMAND_TIMEOUT_IN_MINUTES } from '../../src/config'
 import { FeaturesDeployError, ManifestValidationError, MissingManifestFeaturesError, ObjectsDeployError, SettingsDeployError } from '../../src/client/errors'
-import { Graph, GraphNode, SDFObjectNode } from '../../src/client/graph_utils'
+import { Graph, GraphNode } from '../../src/client/graph_utils'
 import { ATTRIBUTES_FILE_SUFFIX, ATTRIBUTES_FOLDER_NAME, FOLDER_ATTRIBUTES_FILE_SUFFIX } from '../../src/client/deploy_xml_utils'
 
 const DEFAULT_DEPLOY_PARAMS: [undefined, SdfDeployParams, Graph<SDFObjectNode>] = [
@@ -43,7 +43,7 @@ const DEFAULT_DEPLOY_PARAMS: [undefined, SdfDeployParams, Graph<SDFObjectNode>] 
       excludedFiles: [],
     },
   },
-  new Graph<SDFObjectNode>('elemIdFullName'),
+  new Graph(),
 ]
 
 
@@ -1292,14 +1292,27 @@ describe('sdf client', () => {
         },
         scriptId: 'scriptId',
       } as CustomTypeInfo
-      testSDFNode = { serviceid: 'scriptId', elemIdFullName: 'name', changeType: 'addition', customizationInfo: customTypeInfo }
+      testSDFNode = {
+        serviceid: 'scriptId',
+        changeType: 'addition',
+        customizationInfo: customTypeInfo,
+      } as unknown as SDFObjectNode
     })
     describe('deployCustomObject', () => {
       it('should succeed for CustomTypeInfo', async () => {
         mockExecuteAction.mockResolvedValue({ isSuccess: () => true })
         const scriptId = 'filename'
         customTypeInfo.scriptId = scriptId
-        testGraph.addNodes([new GraphNode<SDFObjectNode>({ serviceid: scriptId, elemIdFullName: 'name', changeType: 'addition', customizationInfo: customTypeInfo }, 'name')])
+        testGraph.addNodes([
+          new GraphNode<SDFObjectNode>(
+            'name',
+            {
+              serviceid: scriptId,
+              changeType: 'addition',
+              customizationInfo: customTypeInfo,
+            } as unknown as SDFObjectNode,
+          ),
+        ])
         await client.deploy(...DEFAULT_DEPLOY_PARAMS)
         expect(writeFileMock).toHaveBeenCalledTimes(3)
         expect(writeFileMock).toHaveBeenCalledWith(expect.stringContaining(`${scriptId}.xml`),
@@ -1316,7 +1329,16 @@ describe('sdf client', () => {
         mockExecuteAction.mockResolvedValue({ isSuccess: () => true })
         const scriptId = 'filename'
         customTypeInfo.scriptId = scriptId
-        testGraph.addNodes([new GraphNode<SDFObjectNode>({ serviceid: scriptId, elemIdFullName: scriptId, changeType: 'addition', customizationInfo: customTypeInfo }, scriptId)])
+        testGraph.addNodes([
+          new GraphNode<SDFObjectNode>(
+            scriptId,
+            {
+              serviceid: scriptId,
+              changeType: 'addition',
+              customizationInfo: customTypeInfo,
+            } as unknown as SDFObjectNode,
+          ),
+        ])
         await client.deploy('a.b.c', DEFAULT_DEPLOY_PARAMS[1], DEFAULT_DEPLOY_PARAMS[2])
         expect(renameMock).toHaveBeenCalled()
         expect(writeFileMock).toHaveBeenCalledTimes(3)
@@ -1341,7 +1363,16 @@ describe('sdf client', () => {
           fileContent: MOCK_TEMPLATE_CONTENT,
           fileExtension: 'html',
         } as TemplateCustomTypeInfo
-        testGraph.addNodes([new GraphNode<SDFObjectNode>({ serviceid: scriptId, elemIdFullName: scriptId, changeType: 'addition', customizationInfo: templateCustomTypeInfo }, scriptId)])
+        testGraph.addNodes([
+          new GraphNode<SDFObjectNode>(
+            scriptId,
+            {
+              serviceid: scriptId,
+              changeType: 'addition',
+              customizationInfo: templateCustomTypeInfo,
+            } as unknown as SDFObjectNode,
+          ),
+        ])
         await client.deploy(...DEFAULT_DEPLOY_PARAMS)
         expect(writeFileMock).toHaveBeenCalledTimes(4)
         expect(writeFileMock)
@@ -1418,7 +1449,7 @@ File: ~/Objects/custform_114_t1441298_782.xml
           return { isSuccess: () => true }
         })
         let isRejected: boolean
-        testGraph.addNodes([new GraphNode(testSDFNode, testSDFNode.elemIdFullName)])
+        testGraph.addNodes([new GraphNode('name', testSDFNode)])
         try {
           await client.deploy(...DEFAULT_DEPLOY_PARAMS)
           isRejected = false
@@ -1507,7 +1538,7 @@ File: ~/Objects/custform_15_t1049933_143.xml
           return { isSuccess: () => true }
         })
         let isRejected: boolean
-        testGraph.addNodes([new GraphNode(testSDFNode, testSDFNode.elemIdFullName)])
+        testGraph.addNodes([new GraphNode('name', testSDFNode)])
         try {
           await client.deploy(...DEFAULT_DEPLOY_PARAMS)
           isRejected = false
@@ -1557,7 +1588,7 @@ File: ~/Objects/custform_15_t1049933_143.xml
           return { isSuccess: () => true }
         })
         let isRejected: boolean
-        testGraph.addNodes([new GraphNode(testSDFNode, testSDFNode.elemIdFullName)])
+        testGraph.addNodes([new GraphNode('name', testSDFNode)])
         try {
           await client.deploy(...DEFAULT_DEPLOY_PARAMS)
           isRejected = false
@@ -1608,7 +1639,7 @@ Object: customrecord_flo_customization.custrecord_flo_custz_link (customrecordcu
           return { isSuccess: () => true }
         })
         let isRejected: boolean
-        testGraph.addNodes([new GraphNode(testSDFNode, testSDFNode.elemIdFullName)])
+        testGraph.addNodes([new GraphNode('name', testSDFNode)])
         try {
           await client.deploy(...DEFAULT_DEPLOY_PARAMS)
           isRejected = false
@@ -1660,7 +1691,7 @@ Object: customrecord_flo_customization.custrecord_flo_custz_link (customrecordcu
           return { isSuccess: () => true }
         })
         let isRejected: boolean
-        testGraph.addNodes([new GraphNode(testSDFNode, testSDFNode.elemIdFullName)])
+        testGraph.addNodes([new GraphNode('name', testSDFNode)])
         try {
           await client.deploy(...DEFAULT_DEPLOY_PARAMS)
           isRejected = false
@@ -1714,7 +1745,7 @@ File: ~/AccountConfiguration/features.xml`
           return { isSuccess: () => true }
         })
         let isRejected: boolean
-        testGraph.addNodes([new GraphNode(testSDFNode, testSDFNode.elemIdFullName)])
+        testGraph.addNodes([new GraphNode('name', testSDFNode)])
         try {
           await client.deploy(...DEFAULT_DEPLOY_PARAMS)
           isRejected = false
@@ -1737,7 +1768,16 @@ File: ~/AccountConfiguration/features.xml`
           },
           path: ['Templates', 'E-mail Templates', 'InnerFolder'],
         }
-        testGraph.addNodes([new GraphNode({ serviceid: 'Templates/E-mail Templates/InnerFolder', elemIdFullName: 'name', changeType: 'addition', customizationInfo: folderCustomizationInfo } as SDFObjectNode, 'name')])
+        testGraph.addNodes([
+          new GraphNode(
+            'name',
+            {
+              serviceid: 'Templates/E-mail Templates/InnerFolder',
+              changeType: 'addition',
+              customizationInfo: folderCustomizationInfo,
+            } as unknown as SDFObjectNode,
+          ),
+        ])
         await client.deploy(...DEFAULT_DEPLOY_PARAMS)
         expect(mkdirpMock).toHaveBeenCalledTimes(1)
         expect(mkdirpMock)
@@ -1766,7 +1806,16 @@ File: ~/AccountConfiguration/features.xml`
           path: ['Templates', 'E-mail Templates', 'InnerFolder', 'content.html'],
           fileContent: dummyFileContent,
         }
-        testGraph.addNodes([new GraphNode({ serviceid: 'Templates/E-mail Templates/InnerFolder/content.html', elemIdFullName: 'name', changeType: 'addition', customizationInfo: fileCustomizationInfo } as SDFObjectNode, 'name')])
+        testGraph.addNodes([
+          new GraphNode(
+            'name',
+            {
+              serviceid: 'Templates/E-mail Templates/InnerFolder/content.html',
+              changeType: 'addition',
+              customizationInfo: fileCustomizationInfo,
+            } as unknown as SDFObjectNode,
+          ),
+        ])
         await client.deploy(...DEFAULT_DEPLOY_PARAMS)
         expect(mkdirpMock).toHaveBeenCalledTimes(2)
         expect(mkdirpMock)
@@ -1800,7 +1849,16 @@ File: ~/AccountConfiguration/features.xml`
         },
       }
       it('should succeed', async () => {
-        testGraph.addNodes([new GraphNode({ serviceid: '', elemIdFullName: 'name', changeType: 'addition', customizationInfo: featuresCustomizationInfo } as SDFObjectNode, 'name')])
+        testGraph.addNodes([
+          new GraphNode(
+            'name',
+            {
+              serviceid: '',
+              changeType: 'addition',
+              customizationInfo: featuresCustomizationInfo,
+            } as SDFObjectNode,
+          ),
+        ])
         mockExecuteAction.mockResolvedValue({ isSuccess: () => true, data: ['Configure feature -- The SUITEAPPCONTROLCENTER(Departments) feature has been DISABLED'] })
         await client.deploy(...DEFAULT_DEPLOY_PARAMS)
         expect(writeFileMock).toHaveBeenCalledTimes(3)
@@ -1815,7 +1873,16 @@ File: ~/AccountConfiguration/features.xml`
 
       it('should throw FeaturesDeployError on failed features deploy', async () => {
         const errorMessage = 'Configure feature -- Enabling of the SUITEAPPCONTROLCENTER(SuiteApp Control Center) feature has FAILED'
-        testGraph.addNodes([new GraphNode({ serviceid: '', elemIdFullName: 'name', changeType: 'addition', customizationInfo: featuresCustomizationInfo } as SDFObjectNode, 'name')])
+        testGraph.addNodes([
+          new GraphNode(
+            'name',
+            {
+              serviceid: '',
+              changeType: 'addition',
+              customizationInfo: featuresCustomizationInfo,
+            } as SDFObjectNode,
+          ),
+        ])
         mockExecuteAction.mockResolvedValue({ isSuccess: () => true, data: [errorMessage] })
         await expect(client.deploy(...DEFAULT_DEPLOY_PARAMS))
           .rejects.toThrow(new FeaturesDeployError(errorMessage, ['SUITEAPPCONTROLCENTER']))
@@ -1847,8 +1914,22 @@ File: ~/AccountConfiguration/features.xml`
         scriptId: scriptId2,
       }
       testGraph.addNodes([
-        new GraphNode({ serviceid: scriptId1, elemIdFullName: 'name1', changeType: 'addition', customizationInfo: customTypeInfo1 } as SDFObjectNode, 'name1'),
-        new GraphNode({ serviceid: scriptId2, elemIdFullName: 'name2', changeType: 'addition', customizationInfo: customTypeInfo2 } as SDFObjectNode, 'name2'),
+        new GraphNode(
+          'name1',
+          {
+            serviceid: scriptId1,
+            changeType: 'addition',
+            customizationInfo: customTypeInfo1,
+          } as unknown as SDFObjectNode,
+        ),
+        new GraphNode(
+          'name2',
+          {
+            serviceid: scriptId2,
+            changeType: 'addition',
+            customizationInfo: customTypeInfo2,
+          } as unknown as SDFObjectNode,
+        ),
       ])
       await client.deploy(...DEFAULT_DEPLOY_PARAMS)
       expect(writeFileMock).toHaveBeenCalledTimes(4)
@@ -1866,8 +1947,22 @@ File: ~/AccountConfiguration/features.xml`
     describe('validate only', () => {
       const failObject = 'fail_object'
       testGraph.addNodes([
-        new GraphNode({ serviceid: failObject, elemIdFullName: 'name2', changeType: 'addition', customizationInfo: { typeName: 'typeName', values: { key: 'val' }, scriptId: failObject } } as SDFObjectNode, 'name2'),
-        new GraphNode({ serviceid: 'successObject', elemIdFullName: 'name2', changeType: 'addition', customizationInfo: { typeName: 'typeName', values: { key: 'val' }, scriptId: 'successObject' } } as SDFObjectNode, 'name2'),
+        new GraphNode(
+          'name2',
+          {
+            serviceid: failObject,
+            changeType: 'addition',
+            customizationInfo: { typeName: 'typeName', values: { key: 'val' }, scriptId: failObject },
+          } as unknown as SDFObjectNode,
+        ),
+        new GraphNode(
+          'name2',
+          {
+            serviceid: 'successObject',
+            changeType: 'addition',
+            customizationInfo: { typeName: 'typeName', values: { key: 'val' }, scriptId: 'successObject' },
+          } as unknown as SDFObjectNode,
+        ),
       ])
       const deployParams: [undefined, SdfDeployParams, Graph<SDFObjectNode>] = [
         undefined,


### PR DESCRIPTION
- Remove the `graph.key` attribute and use `node.id` instead.
- Use the graph as the only SOT in SDF deploy iterations (instead of using also `changesToDeploy`)

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
