### PR TITLE
SALTO-4009: Source App reference

### DIFF
--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -266,8 +266,8 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
   Group: {
     transformation: {
       fieldTypeOverrides: [
-        { fieldName: 'apps', fieldType: 'list<Application>' },
         { fieldName: 'roles', fieldType: 'list<RoleAssignment>' },
+        { fieldName: 'source', fieldType: 'Group__source' },
       ],
       fieldsToHide: [
         { fieldName: 'id' },
@@ -1236,6 +1236,8 @@ const DEFAULT_SWAGGER_CONFIG: OktaSwaggerApiConfig['swagger'] = {
     { typeName: 'MultifactorEnrollmentPolicyRule', cloneFrom: 'PolicyRule' },
     // AppUserSchema returns UserSchema items, but we separate types because the endpoints for deploy are different
     { typeName: 'AppUserSchema', cloneFrom: 'UserSchema' },
+    // This is not the right type to cloneFrom, but a workaround to define type for Group__source with 'id' field
+    { typeName: 'Group__source', cloneFrom: 'AppAndInstanceConditionEvaluatorAppOrInstance' },
   ],
   typeNameOverrides: [
     { originalName: 'DomainResponse', newName: 'Domain' },

--- a/packages/okta-adapter/src/reference_mapping.ts
+++ b/packages/okta-adapter/src/reference_mapping.ts
@@ -204,6 +204,11 @@ export const referencesRules: OktaFieldReferenceDefinition[] = [
     serializationStrategy: 'id',
     target: { type: APPLICATION_TYPE_NAME },
   },
+  {
+    src: { field: 'id', parentTypes: ['Group__source'] },
+    serializationStrategy: 'id',
+    target: { type: APPLICATION_TYPE_NAME },
+  },
 ]
 
 // Resolve references to userSchema fields references to field name instead of full value


### PR DESCRIPTION
Add reference from `Group` of type `APP_GROUP` to `Application`

---

field `source` is missing from `Group` schema in swagger, so I used `cloneFrom` to create `Group__source` type

---
_Release Notes_: 
None

---

_User Notifications_: 
None