### PR TITLE
Saas 6976 - Only allow deployment errors of type SaltoError or SaltoElementError

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -41,11 +41,11 @@ export type DeployExtraProperties = {
   groups?: Group[]
 }
 
-type SaltoDeploymentErrors = {
+type SaltoDeployErrors = {
   errors: ReadonlyArray<SaltoError | SaltoElementError>
 }
 
-type AdapterDeploymentErrors = {
+type AdapterDeployErrors = {
   errors: ReadonlyArray<SaltoError | SaltoElementError | Error>
 }
 
@@ -54,9 +54,9 @@ type BaseDeployResult = {
   extraProperties?: DeployExtraProperties
 }
 
-export type AdapterDeployResult = SaltoDeploymentErrors & BaseDeployResult
+export type AdapterDeployResult = SaltoDeployErrors & BaseDeployResult
 
-export type DeployResult = AdapterDeploymentErrors & BaseDeployResult
+export type DeployResult = AdapterDeployErrors & BaseDeployResult
 
 export type Progress = {
   message: string

--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -41,11 +41,22 @@ export type DeployExtraProperties = {
   groups?: Group[]
 }
 
-export type DeployResult = {
+type SaltoDeploymentErrors = {
+  errors: ReadonlyArray<SaltoError | SaltoElementError>
+}
+
+type AdapterDeploymentErrors = {
+  errors: ReadonlyArray<SaltoError | SaltoElementError | Error>
+}
+
+type BaseDeployResult = {
   appliedChanges: ReadonlyArray<Change>
-  errors: ReadonlyArray<Error>
   extraProperties?: DeployExtraProperties
 }
+
+export type AdapterDeployResult = SaltoDeploymentErrors & BaseDeployResult
+
+export type DeployResult = AdapterDeploymentErrors & BaseDeployResult
 
 export type Progress = {
   message: string

--- a/packages/adapter-utils/src/filter.ts
+++ b/packages/adapter-utils/src/filter.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Element, Change, PostFetchOptions, DeployResult } from '@salto-io/adapter-api'
+import { Element, Change, PostFetchOptions, DeployResult, SaltoElementError, SaltoError } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { types, promises, values, collections, objects } from '@salto-io/lowerdash'
 
@@ -145,7 +145,7 @@ export const filtersRunner = <
         {
           deployResult: {
             appliedChanges: [] as ReadonlyArray<Change>,
-            errors: [] as ReadonlyArray<Error>,
+            errors: [] as ReadonlyArray<SaltoError | SaltoElementError | Error>,
           },
           leftoverChanges: changes,
         }

--- a/packages/adapter-utils/test/filter.test.ts
+++ b/packages/adapter-utils/test/filter.test.ts
@@ -83,7 +83,7 @@ describe('filtersRunner', () => {
         deploy: async changes => ({
           deployResult: {
             appliedChanges: [changes[0]],
-            errors: [new Error(changes.length.toString())],
+            errors: [{ message: changes.length.toString(), severity: 'Error' }],
           },
           leftoverChanges: changes.slice(1),
         }),
@@ -100,7 +100,16 @@ describe('filtersRunner', () => {
 
     it('should return the merged deploy results', () => {
       expect(filterRes.deployResult.appliedChanges).toHaveLength(2)
-      expect(filterRes.deployResult.errors).toEqual([new Error('3'), new Error('2')])
+      expect(filterRes.deployResult.errors).toEqual([
+        expect.objectContaining({
+          message: expect.stringContaining('3'),
+          severity: 'Error',
+        }),
+        expect.objectContaining({
+          message: expect.stringContaining('2'),
+          severity: 'Error',
+        }),
+      ])
     })
   })
 })

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -170,7 +170,7 @@ const deployPlan = async (
     ) : { success: true, errors: [] }
   const nonErroredActions = Object.keys(actions)
     .filter(action =>
-      !result.errors.map(error => error !== undefined && error.elementId).includes(action))
+      !result.errors.map(error => error !== undefined && error.groupId).includes(action))
   outputLine(deployPhaseEpilogue(
     nonErroredActions.length,
     result.errors.length,

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -37,6 +37,7 @@ import {
   formatStateRecencies,
   formatDeployActions,
   formatGroups,
+  deployErrorsOutput,
 } from '../formatter'
 import Prompts from '../prompts'
 import { getUserBooleanInput } from '../callbacks'
@@ -171,6 +172,9 @@ const deployPlan = async (
   const nonErroredActions = Object.keys(actions)
     .filter(action =>
       !result.errors.map(error => error !== undefined && error.groupId).includes(action))
+  outputLine(deployErrorsOutput(
+    result.errors,
+  ), output)
   outputLine(deployPhaseEpilogue(
     nonErroredActions.length,
     result.errors.length,

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -27,6 +27,7 @@ import { Plan, PlanItem, FetchChange, FetchResult, LocalChange, getSupportedServ
 import { errors, SourceLocation, WorkspaceComponents, StateRecency } from '@salto-io/workspace'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { collections, values } from '@salto-io/lowerdash'
+import { DeployError } from '@salto-io/core/src/core/deploy'
 import Prompts from './prompts'
 
 const { awu } = collections.asynciterable
@@ -348,7 +349,21 @@ export const cancelDeployOutput = (checkOnly: boolean): string => [
   emptyLine(),
 ].join('\n')
 
-export const deployPhaseEpilogue = (numChanges: number, numErrors: number, checkOnly: boolean): string => {
+export const deployErrorsOutput = (deployErrors: DeployError[]): string => {
+  const errorOutputLines = [
+    emptyLine(),
+  ]
+  if (deployErrors.length > 0) {
+    errorOutputLines.push(error('Errors:'))
+    errorOutputLines.push(...deployErrors.map(deployError => error(`${deployError.message}`)))
+    errorOutputLines.push(emptyLine())
+    return errorOutputLines.join('\n')
+  }
+  return ''
+}
+
+export const deployPhaseEpilogue = (numChanges: number,
+  numErrors: number, checkOnly: boolean,): string => {
   const hadChanges = numChanges > 0
   const hadErrors = numErrors > 0
   if (hadChanges || hadErrors) {

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -349,15 +349,30 @@ export const cancelDeployOutput = (checkOnly: boolean): string => [
   emptyLine(),
 ].join('\n')
 
-export const deployErrorsOutput = (deployErrors: DeployError[]): string => {
+export const deployErrorsOutput = (allErrors: DeployError[]): string => {
   const errorOutputLines = [
     emptyLine(),
   ]
-  if (deployErrors.length > 0) {
-    errorOutputLines.push(error('Errors:'))
-    errorOutputLines.push(...deployErrors.map(deployError => error(`${deployError.message}`)))
-    errorOutputLines.push(emptyLine())
-    return errorOutputLines.join('\n')
+  if (allErrors.length > 0) {
+    const warnings = allErrors.filter(warning => warning.severity === 'Warning')
+    const infos = allErrors.filter(info => info.severity === 'Info')
+    const deployErrors = allErrors.filter(err => err.severity === 'Error')
+    if (!_.isEmpty(deployErrors)) {
+      errorOutputLines.push(error('Errors:'))
+      errorOutputLines.push(...deployErrors.map(deployError => error(`${deployError.message}`)))
+      errorOutputLines.push(emptyLine())
+    }
+    if (!_.isEmpty(warnings)) {
+      errorOutputLines.push(warn('Warnings:'))
+      errorOutputLines.push(...warnings.map(warning => warn(`${warning.message}`)))
+      errorOutputLines.push(emptyLine())
+    }
+    if (!_.isEmpty(infos)) {
+      errorOutputLines.push(header('Info:'))
+      errorOutputLines.push(...infos.map(info => header(`${info.message}`)))
+      errorOutputLines.push(emptyLine())
+    }
+    return errorOutputLines.join(EOL)
   }
   return ''
 }

--- a/packages/cli/test/formatter.test.ts
+++ b/packages/cli/test/formatter.test.ts
@@ -78,7 +78,7 @@ describe('formatter', () => {
     detailedMessage: '',
     severity: 'Info',
   }
-  const workspaceDeployErrors: DeployError[] = [{
+  const workspaceDeployProblems: DeployError[] = [{
     elemID: new ElemID('salesforce', 'TestType'),
     message: 'my error message 1',
     severity: 'Error',
@@ -88,6 +88,18 @@ describe('formatter', () => {
     elemID: new ElemID('salesforce', 'TestType'),
     message: 'my error message 2',
     severity: 'Error',
+    groupId: 'test group',
+  },
+  {
+    elemID: new ElemID('salesforce', 'TestType'),
+    message: 'my warning message',
+    severity: 'Warning',
+    groupId: 'test group',
+  },
+  {
+    elemID: new ElemID('salesforce', 'TestType'),
+    message: 'my info message',
+    severity: 'Info',
     groupId: 'test group',
   }]
 
@@ -557,11 +569,13 @@ describe('formatter', () => {
   describe('deployErrorsOutput', () => {
     let formattedErrors: string
     beforeEach(() => {
-      formattedErrors = deployErrorsOutput(workspaceDeployErrors)
+      formattedErrors = deployErrorsOutput(workspaceDeployProblems)
     })
     it('should have both error messages', () => {
       expect(formattedErrors).toContain('my error message 1')
       expect(formattedErrors).toContain('my error message 2')
+      expect(formattedErrors).toContain('my warning message')
+      expect(formattedErrors).toContain('my info message')
     })
   })
 })

--- a/packages/cli/test/formatter.test.ts
+++ b/packages/cli/test/formatter.test.ts
@@ -21,9 +21,10 @@ import { EOL } from 'os'
 import { FetchChange } from '@salto-io/core'
 import { errors as wsErrors } from '@salto-io/workspace'
 import chalk from 'chalk'
+import { DeployError } from '@salto-io/core/src/core/deploy'
 import { formatExecutionPlan, formatChange,
   formatFetchChangeForApproval, formatWorkspaceError,
-  formatChangeErrors, formatConfigChangeNeeded, formatShouldChangeFetchModeToAlign } from '../src/formatter'
+  formatChangeErrors, formatConfigChangeNeeded, formatShouldChangeFetchModeToAlign, deployErrorsOutput } from '../src/formatter'
 import { elements, preview, detailedChange } from './mocks'
 import Prompts from '../src/prompts'
 
@@ -77,6 +78,18 @@ describe('formatter', () => {
     detailedMessage: '',
     severity: 'Info',
   }
+  const workspaceDeployErrors: DeployError[] = [{
+    elemID: new ElemID('salesforce', 'TestType'),
+    message: 'my error message 1',
+    severity: 'Error',
+    groupId: 'test group',
+  },
+  {
+    elemID: new ElemID('salesforce', 'TestType'),
+    message: 'my error message 2',
+    severity: 'Error',
+    groupId: 'test group',
+  }]
 
   describe('createPlanOutput', () => {
     const plan = preview()
@@ -538,6 +551,17 @@ describe('formatter', () => {
     })
     it('should print the error', () => {
       expect(formattedErrors).toContain('This is my error')
+    })
+  })
+
+  describe('deployErrorsOutput', () => {
+    let formattedErrors: string
+    beforeEach(() => {
+      formattedErrors = deployErrorsOutput(workspaceDeployErrors)
+    })
+    it('should have both error messages', () => {
+      expect(formattedErrors).toContain('my error message 1')
+      expect(formattedErrors).toContain('my error message 2')
     })
   })
 })

--- a/packages/core/src/core/deploy/deploy_actions.ts
+++ b/packages/core/src/core/deploy/deploy_actions.ts
@@ -181,11 +181,11 @@ export const deployActions = async (
         const item = deployPlan.getItem(key) as PlanItem
         if (nodeError instanceof NodeSkippedError) {
           reportProgress(item, 'cancelled', deployPlan.getItem(nodeError.causingNode).groupKey)
-          deployErrors.push({
-            groupId: item.groupKey,
-            message: `Element ${key} was not deployed, as it depends on element ${nodeError.causingNode} which failed to deploy`,
-            severity: 'Error' as SeverityLevel,
-          })
+          deployErrors.push(...[...item.changes()].map(change =>
+            ({ elemID: getChangeData(change).elemID,
+              groupId: item.groupKey,
+              message: `Element ${key} was not deployed, as it depends on element ${nodeError.causingNode} which failed to deploy`,
+              severity: 'Error' as SeverityLevel })))
         } else if (nodeError instanceof WalkDeployError) {
           deployErrors.push(...nodeError.errors.map(deployError => ({ ...deployError, groupId: item.groupKey })))
         } else {

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { AdapterOperations, BuiltinTypes, CORE_ANNOTATIONS, Element, ElemID, InstanceElement, ObjectType, PrimitiveType, PrimitiveTypes, Adapter, isObjectType, isEqualElements, isAdditionChange, ChangeDataType, AdditionChange, isInstanceElement, isModificationChange, DetailedChange, ReferenceExpression, Field, CredentialError, getChangeData, toChange } from '@salto-io/adapter-api'
+import { AdapterOperations, BuiltinTypes, CORE_ANNOTATIONS, Element, ElemID, InstanceElement, ObjectType, PrimitiveType, PrimitiveTypes, Adapter, isObjectType, isEqualElements, isAdditionChange, ChangeDataType, AdditionChange, isInstanceElement, isModificationChange, DetailedChange, ReferenceExpression, Field, CredentialError, getChangeData, toChange, SeverityLevel } from '@salto-io/adapter-api'
 import * as workspace from '@salto-io/workspace'
 import { collections } from '@salto-io/lowerdash'
 import { mockFunction, MockInterface } from '@salto-io/test-utils'
@@ -431,7 +431,7 @@ describe('api.ts', () => {
         mockAdapterOps.deploy.mockClear()
         mockAdapterOps.deploy.mockImplementationOnce(async ({ changeGroup }) => ({
           appliedChanges: changeGroup.changes.filter(isModificationChange),
-          errors: [new Error('cannot add new employee')],
+          errors: [{ message: 'cannot add new employee', severity: 'Error' as SeverityLevel }],
         }))
         result = await api.deploy(ws, actionPlan, jest.fn(), ACCOUNTS)
       })

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-import { AccountId, Change, getChangeData, InstanceElement, isInstanceChange, isModificationChange, CredentialError, isAdditionChange, isAdditionOrModificationChange, isFieldChange, ElemID, ChangeData } from '@salto-io/adapter-api'
+import { AccountId, Change, getChangeData, InstanceElement, isInstanceChange, isModificationChange, CredentialError, isAdditionChange, isAdditionOrModificationChange, isFieldChange, ElemID, ChangeData, SaltoElementError, SaltoError } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { decorators, collections, values } from '@salto-io/lowerdash'
 import { elements as elementUtils } from '@salto-io/adapter-components'
@@ -362,7 +362,7 @@ export default class NetsuiteClient {
     changes: Change[],
     groupID: string,
     additionalSdfDependencies: AdditionalDependencies,
-  ): Promise<ReadonlyArray<Error>> {
+  ): Promise<ReadonlyArray<Error | SaltoError | SaltoElementError>> {
     if (isSdfCreateOrUpdateGroupId(groupID)) {
       return (await this.sdfDeploy({
         changes,

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -434,7 +434,7 @@ export default class SalesforceAdapter implements AdapterOperations {
       if (checkOnly) {
         return {
           appliedChanges: [],
-          errors: [new Error('Cannot deploy CustomObject Records as part of check-only deployment')],
+          errors: [{ message: 'Cannot deploy CustomObject Records as part of check-only deployment', severity: 'Error' }],
         }
       }
       deployResult = await deployCustomObjectInstancesGroup(

--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -17,9 +17,7 @@ import _ from 'lodash'
 import util from 'util'
 import { collections, values, hash as hashUtils } from '@salto-io/lowerdash'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
-import { logger } from '@salto-io/logging'
-
-import {
+import { SaltoError,
   DeployResult,
   Change,
   getChangeData,
@@ -28,7 +26,12 @@ import {
   isInstanceChange,
   isContainerType,
   isAdditionChange,
-} from '@salto-io/adapter-api'
+  SaltoElementError,
+  SeverityLevel,
+  ElemID } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+
+
 import { DeployResult as SFDeployResult, DeployMessage } from 'jsforce'
 
 import SalesforceClient from './client/client'
@@ -195,37 +198,39 @@ const isUnFoundDelete = (message: DeployMessage, deletionsPackageName: string): 
 const processDeployResponse = (
   result: SFDeployResult,
   deletionsPackageName: string,
-  checkOnly: boolean,
-): { successfulFullNames: ReadonlyArray<MetadataId>; errors: ReadonlyArray<Error> } => {
+): { successfulFullNames: ReadonlyArray<MetadataId>; errors: ReadonlyArray<SaltoError | SaltoElementError> } => {
   const allFailureMessages = makeArray(result.details)
     .flatMap(detail => makeArray(detail.componentFailures))
 
   const testFailures = makeArray(result.details)
     .flatMap(detail => makeArray((detail.runTestResult as RunTestsResult)?.failures))
-  const testErrors = testFailures
-    .map(failure => new Error(util.format(
-      'Test failed for class %s method %s with error:\n%s\n%s',
-      failure.name,
-      failure.methodName,
-      failure.message,
-      failure.stackTrace
-    )))
+  const testErrors: SaltoError[] = testFailures
+    .map(failure => ({
+      message: util.format(
+        'Test failed for class %s method %s with error:\n%s\n%s',
+        failure.name,
+        failure.methodName,
+        failure.message,
+        failure.stackTrace
+      ),
+      severity: 'Error' as SeverityLevel,
+    }))
   const componentErrors = allFailureMessages
     .filter(failure => !isUnFoundDelete(failure, deletionsPackageName))
     .map(getUserFriendlyDeployMessage)
-    .map(failure => new Error(
-      `Failed to ${checkOnly ? 'validate' : 'deploy'} ${failure.fullName} with error: ${failure.problem} (${failure.problemType})`
+    .map(failure => (
+      { elemID: ElemID.fromFullName(failure.fullName), message: `${failure.problem} (${failure.problemType})`, severity: 'Error' as SeverityLevel }
     ))
   const codeCoverageWarningErrors = makeArray(result.details)
     .map(detail => detail.runTestResult as RunTestsResult | undefined)
     .flatMap(runTestResult => makeArray(runTestResult?.codeCoverageWarnings))
     .map(codeCoverageWarning => codeCoverageWarning.message)
-    .map(message => new Error(message))
+    .map(message => ({ message, severity: 'Error' as SeverityLevel }))
 
   const errors = [...testErrors, ...componentErrors, ...codeCoverageWarningErrors]
 
   if (isDefined(result.errorMessage)) {
-    errors.push(Error(result.errorMessage))
+    errors.push({ message: result.errorMessage, severity: 'Error' as SeverityLevel })
   }
 
   // In checkOnly none of the changes are actually applied
@@ -251,20 +256,20 @@ const processDeployResponse = (
   return { successfulFullNames, errors }
 }
 
-const getChangeError = async (change: Change): Promise<string | undefined> => {
+const getChangeError = async (change: Change): Promise<SaltoElementError | undefined> => {
   const changeElem = getChangeData(change)
   if (await apiName(changeElem) === undefined) {
-    return `Cannot ${change.action} element because it has no api name`
+    return { elemID: changeElem.elemID, message: `Cannot ${change.action} element because it has no api name`, severity: 'Error' }
   }
   if (isModificationChange(change)) {
     const beforeName = await apiName(change.data.before)
     const afterName = await apiName(change.data.after)
     if (beforeName !== afterName) {
-      return `Failed to update element because api names prev=${beforeName} and new=${afterName} are different`
+      return { elemID: changeElem.elemID, message: `Failed to update element because api names prev=${beforeName} and new=${afterName} are different`, severity: 'Error' }
     }
   }
   if (!isInstanceChange(change) || !await isMetadataInstanceElement(changeElem)) {
-    return 'Cannot deploy because it is not a metadata instance'
+    return { elemID: changeElem.elemID, message: 'Cannot deploy because it is not a metadata instance', severity: 'Error' }
   }
   return undefined
 }
@@ -273,7 +278,7 @@ const validateChanges = async (
   changes: ReadonlyArray<Change>
 ): Promise<{
     validChanges: ReadonlyArray<Change<MetadataInstanceElement>>
-    errors: Error[]
+    errors: (SaltoError | SaltoElementError)[]
   }> => {
   const changesAndValidation = await awu(changes)
     .map(async change => ({ change, error: await getChangeError(change) }))
@@ -285,9 +290,8 @@ const validateChanges = async (
   )
 
   const errors = invalidChanges
-    .map(({ change, error }) => (
-      new Error(`${getChangeData(change).elemID.getFullName()}: ${error}}`)
-    ))
+    .filter(change => isDefined(change.error))
+    .map(({ error }) => error) as SaltoElementError[]
 
   return {
     // We can cast to MetadataInstanceElement here because we will have an error for changes that
@@ -355,7 +359,7 @@ export const deployMetadata = async (
     if (quickDeployParams.hash !== planHash) {
       return {
         appliedChanges: [],
-        errors: [new Error('Quick deploy option is not available because the current deploy plan is different than the validated one')],
+        errors: [{ message: 'Quick deploy option is not available because the current deploy plan is different than the validated one', severity: 'Error' }],
       }
     }
   }
@@ -374,7 +378,7 @@ export const deployMetadata = async (
   }, undefined, 2))
 
   const { errors, successfulFullNames } = processDeployResponse(
-    sfDeployRes, pkg.getDeletionsPackageName(), checkOnly ?? false
+    sfDeployRes, pkg.getDeletionsPackageName()
   )
   const isSuccessfulChange = (change: Change<MetadataInstanceElement>): boolean => {
     const changeElem = getChangeData(change)

--- a/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
@@ -194,10 +194,7 @@ describe('Custom Object Instances CRUD', () => {
     let connection: MockInterface<Connection>
     let mockBulkLoad: jest.Mock
     let partialBulkLoad: jest.Mock
-    const errorMsgs = [
-      'Error message1',
-      'Error message2',
-    ]
+    const errorMsgs = ['Error message1', 'Error message2']
     const getBulkLoadMock = (mode: string): jest.Mock<Batch> =>
       (jest.fn().mockImplementation(
         (_type: string, _operation: BulkLoadOperation, _opt?: BulkOptions, input?: SfRecord[]) => {
@@ -227,12 +224,6 @@ describe('Custom Object Instances CRUD', () => {
         }
       ))
 
-    // Should include the error msgs and the instance name
-    const validateErrorMsg = (errMsg: string, instName: string): void => {
-      expect(errMsg.includes(instName)).toBeTruthy()
-      errorMsgs.forEach(msg =>
-        expect(errMsg.includes(msg)))
-    }
     beforeEach(() => {
       ({ connection, adapter } = mockAdapter({
         adapterParams: {
@@ -716,11 +707,41 @@ describe('Custom Object Instances CRUD', () => {
           expect(updateCall).toBeDefined()
         })
 
-        it('Should have three errors (1 for update and 2 for add)', () => {
-          expect(result.errors).toHaveLength(3)
-          validateErrorMsg(result.errors[0].message, 'newInstanceWithRef')
-          validateErrorMsg(result.errors[1].message, 'newInstanceWithRef')
-          validateErrorMsg(result.errors[2].message, 'Instance')
+        it('Should have six errors (2 for update and 4 for add)', () => {
+          expect(result.errors).toBeArrayOfSize(6)
+          expect(result.errors).toEqual([
+            expect.objectContaining({
+              elemID: newInstanceWithRef.elemID,
+              message: expect.stringContaining(errorMsgs[0]),
+              severity: 'Error',
+            }),
+            expect.objectContaining({
+              elemID: newInstanceWithRef.elemID,
+              message: expect.stringContaining(errorMsgs[1]),
+              severity: 'Error',
+            }),
+            expect.objectContaining({
+              elemID: newInstanceWithRef.elemID,
+              message: expect.stringContaining(errorMsgs[0]),
+              severity: 'Error',
+            }),
+            expect.objectContaining({
+              elemID: newInstanceWithRef.elemID,
+              message: expect.stringContaining(errorMsgs[1]),
+              severity: 'Error',
+            }),
+            expect.objectContaining({
+              elemID: existingInstance.elemID,
+              message: expect.stringContaining(errorMsgs[0]),
+              severity: 'Error',
+            }),
+            expect.objectContaining({
+              elemID: existingInstance.elemID,
+              message: expect.stringContaining(errorMsgs[1]),
+              severity: 'Error',
+            }),
+
+          ])
         })
 
         it('Should have three applied add change with the right ids', () => {
@@ -782,8 +803,19 @@ describe('Custom Object Instances CRUD', () => {
         })
 
         it('should return one error and one applied change', async () => {
-          expect(result.errors).toHaveLength(1)
-          validateErrorMsg(result.errors[0].message, 'Instance')
+          expect(result.errors).toEqual([
+            expect.objectContaining({
+              elemID: existingInstance.elemID,
+              message: expect.stringContaining(errorMsgs[0]),
+              severity: 'Error',
+            }),
+            expect.objectContaining({
+              elemID: existingInstance.elemID,
+              message: expect.stringContaining(errorMsgs[1]),
+              severity: 'Error',
+            }),
+          ])
+
           expect(result.appliedChanges).toHaveLength(1)
           expect(isModificationChange(result.appliedChanges[0])).toBeTruthy()
           const changeData = getChangeData(result.appliedChanges[0])
@@ -799,9 +831,29 @@ describe('Custom Object Instances CRUD', () => {
         })
 
         it('should return only errors', async () => {
-          expect(result.errors).toHaveLength(2)
-          validateErrorMsg(result.errors[0].message, 'Instance')
-          validateErrorMsg(result.errors[1].message, 'AnotherInstance')
+          expect(result.errors).toEqual([
+            expect.objectContaining({
+              elemID: existingInstance.elemID,
+              message: expect.stringContaining(errorMsgs[0]),
+              severity: 'Error',
+            }),
+            expect.objectContaining({
+              elemID: existingInstance.elemID,
+              message: expect.stringContaining(errorMsgs[1]),
+              severity: 'Error',
+            }),
+            expect.objectContaining({
+              elemID: anotherExistingInstance.elemID,
+              message: expect.stringContaining(errorMsgs[0]),
+              severity: 'Error',
+            }),
+            expect.objectContaining({
+              elemID: anotherExistingInstance.elemID,
+              message: expect.stringContaining(errorMsgs[1]),
+              severity: 'Error',
+            }),
+          ])
+
           expect(result.appliedChanges).toHaveLength(0)
         })
       })
@@ -845,9 +897,19 @@ describe('Custom Object Instances CRUD', () => {
             result = await adapter.deploy({ changeGroup: removeChangeGroup })
           })
 
-          it('should return one error', () => {
-            expect(result.errors).toHaveLength(1)
-            validateErrorMsg(result.errors[0].message, 'Instance')
+          it('should return two error', () => {
+            expect(result.errors).toEqual([
+              expect.objectContaining({
+                elemID: existingInstance.elemID,
+                message: expect.stringContaining(errorMsgs[0]),
+                severity: 'Error',
+              }),
+              expect.objectContaining({
+                elemID: existingInstance.elemID,
+                message: expect.stringContaining(errorMsgs[1]),
+                severity: 'Error',
+              }),
+            ])
           })
 
           it('should return one applied change', () => {
@@ -866,9 +928,28 @@ describe('Custom Object Instances CRUD', () => {
           })
 
           it('should return only errors', () => {
-            expect(result.errors).toHaveLength(2)
-            validateErrorMsg(result.errors[1].message, 'Instance')
-            validateErrorMsg(result.errors[1].message, 'AnotherInstance')
+            expect(result.errors).toEqual([
+              expect.objectContaining({
+                elemID: existingInstance.elemID,
+                message: expect.stringContaining(errorMsgs[0]),
+                severity: 'Error',
+              }),
+              expect.objectContaining({
+                elemID: existingInstance.elemID,
+                message: expect.stringContaining(errorMsgs[1]),
+                severity: 'Error',
+              }),
+              expect.objectContaining({
+                elemID: anotherExistingInstance.elemID,
+                message: expect.stringContaining(errorMsgs[0]),
+                severity: 'Error',
+              }),
+              expect.objectContaining({
+                elemID: anotherExistingInstance.elemID,
+                message: expect.stringContaining(errorMsgs[1]),
+                severity: 'Error',
+              }),
+            ])
             expect(result.appliedChanges).toHaveLength(0)
           })
         })
@@ -925,8 +1006,12 @@ describe('Custom Object Instances CRUD', () => {
           })
         })
         afterEach(() => {
-          expect(result.errors).toHaveLength(1)
-          expect(result.errors[0]).toEqual(new Error('Custom Object Instances change group should have a single type but got: Type,anotherType'))
+          expect(result.errors).toEqual([
+            expect.objectContaining({
+              message: expect.stringContaining('Custom Object Instances change group should have a single type but got: Type,anotherType'),
+              severity: 'Error',
+            }),
+          ])
         })
       })
 
@@ -944,8 +1029,13 @@ describe('Custom Object Instances CRUD', () => {
               ],
             },
           })
-          expect(result.errors).toHaveLength(1)
-          expect(result.errors[0]).toEqual(new Error('Failed to update as api name prev=modifyId and new=anotherModifyId are different'))
+          expect(result.errors).toEqual([
+            expect.objectContaining({
+              elemID: instanceToModify.elemID,
+              message: expect.stringContaining('Failed to update as api name prev=modifyId and new=anotherModifyId are different'),
+              severity: 'Error',
+            }),
+          ])
         })
       })
 
@@ -960,8 +1050,12 @@ describe('Custom Object Instances CRUD', () => {
               ],
             },
           })
-          expect(result.errors).toHaveLength(1)
-          expect(result.errors[0]).toEqual(new Error('Custom Object Instances change group must have one action'))
+          expect(result.errors).toEqual(([
+            expect.objectContaining({
+              severity: 'Error',
+              message: expect.stringContaining('Custom Object Instances change group must have one action'),
+            }),
+          ]))
         })
       })
     })
@@ -995,8 +1089,12 @@ describe('Custom Object Instances CRUD', () => {
           ],
         },
       })
-      expect(result.errors).toHaveLength(1)
-      expect(result.errors[0]).toEqual(new Error('Failed to add instances of type Type due to invalid SaltoIdFields - NonExistingFields'))
+      expect(result.errors).toEqual(([
+        expect.objectContaining({
+          severity: 'Error',
+          message: expect.stringContaining('Failed to add instances of type Type due to invalid SaltoIdFields - NonExistingFields'),
+        }),
+      ]))
     })
   })
 
@@ -1050,8 +1148,12 @@ describe('Custom Object Instances CRUD', () => {
     })
 
     afterEach(() => {
-      expect(result.errors).toHaveLength(1)
-      expect(result.errors[0]).toEqual(new Error('dataManagement must be defined in the salesforce.nacl config to deploy Custom Object instances'))
+      expect(result.errors).toEqual(([
+        expect.objectContaining({
+          severity: 'Error',
+          message: expect.stringContaining('dataManagement must be defined in the salesforce.nacl config to deploy Custom Object instances'),
+        }),
+      ]))
     })
   })
 })

--- a/packages/salesforce-adapter/test/custom_object_instances_deploy.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances_deploy.test.ts
@@ -56,7 +56,7 @@ describe('Custom Object Deploy', () => {
         ]
       )
       const res = await retryFlow(clientOp, { typeName: 'typtyp', instances: instanceElements, client }, retries)
-      expect(res).toEqual({ successInstances: [inst1, inst2], errorMessages: [] })
+      expect(res).toEqual({ successInstances: [inst1, inst2], errorInstances: [] })
       expect(clientBulkOpSpy).toHaveBeenCalledTimes(1)
     })
 
@@ -77,7 +77,7 @@ describe('Custom Object Deploy', () => {
       const res = await retryFlow(clientOp, { typeName: 'typtyp', instances: instanceElements, client }, retries)
       expect(res).toEqual(
         expect.objectContaining({
-          errorMessages: [expect.objectContaining({
+          errorInstances: [expect.objectContaining({
             elemID: inst2.elemID,
             message: expect.stringContaining('err555'),
             severity: 'Error',
@@ -108,7 +108,7 @@ describe('Custom Object Deploy', () => {
       const res = await retryFlow(clientOp, { typeName: 'typtyp', instances: instanceElements, client }, retries)
       expect(res).toEqual(
         expect.objectContaining({
-          errorMessages: [
+          errorInstances: [
             expect.objectContaining({
               elemID: inst2.elemID,
               message: expect.stringContaining('err1'),
@@ -158,7 +158,7 @@ describe('Custom Object Deploy', () => {
       const res = await retryFlow(clientOp, { typeName: 'typtyp', instances: instanceElements, client }, retries)
       expect(res).toEqual(
         expect.objectContaining({
-          errorMessages: [
+          errorInstances: [
             expect.objectContaining({
               elemID: inst2.elemID,
               message: expect.stringContaining('err1 bla bla bla'),
@@ -200,7 +200,7 @@ describe('Custom Object Deploy', () => {
 
       )
       const res = await retryFlow(clientOp, { typeName: 'typtyp', instances: instanceElements, client }, retries)
-      expect(res).toEqual({ successInstances: [inst1, inst2], errorMessages: [] })
+      expect(res).toEqual({ successInstances: [inst1, inst2], errorInstances: [] })
       expect(clientBulkOpSpy).toHaveBeenCalledTimes(2)
     })
 
@@ -232,7 +232,7 @@ describe('Custom Object Deploy', () => {
       const res = await retryFlow(clientOp, { typeName: 'typtyp', instances: instanceElements, client }, retries)
       expect(res).toEqual(
         expect.objectContaining({
-          errorMessages: [expect.objectContaining({
+          errorInstances: [expect.objectContaining({
             elemID: inst2.elemID,
             message: expect.stringContaining('err1'),
             severity: 'Error',

--- a/packages/salesforce-adapter/test/custom_object_instances_deploy.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances_deploy.test.ts
@@ -75,7 +75,19 @@ describe('Custom Object Deploy', () => {
         ]
       )
       const res = await retryFlow(clientOp, { typeName: 'typtyp', instances: instanceElements, client }, retries)
-      expect(res).toEqual({ successInstances: [inst1], errorMessages: ['inst2:\n    \terr555'] })
+      expect(res).toEqual(
+        expect.objectContaining({
+          errorMessages: [expect.objectContaining({
+            elemID: inst2.elemID,
+            message: expect.stringContaining('err555'),
+            severity: 'Error',
+          })],
+          successInstances: [expect.objectContaining({
+            elemID: inst1.elemID,
+          })],
+        }),
+      )
+
       expect(clientBulkOpSpy).toHaveBeenCalledTimes(1)
     })
 
@@ -94,7 +106,26 @@ describe('Custom Object Deploy', () => {
         ]
       )
       const res = await retryFlow(clientOp, { typeName: 'typtyp', instances: instanceElements, client }, retries)
-      expect(res).toEqual({ successInstances: [inst1], errorMessages: ['inst2:\n    \terr1\n\tbla bla bla'] })
+      expect(res).toEqual(
+        expect.objectContaining({
+          errorMessages: [
+            expect.objectContaining({
+              elemID: inst2.elemID,
+              message: expect.stringContaining('err1'),
+              severity: 'Error',
+            }),
+            expect.objectContaining({
+              elemID: inst2.elemID,
+              message: expect.stringContaining('bla bla bla'),
+              severity: 'Error',
+            }),
+          ],
+          successInstances: [expect.objectContaining({
+            elemID: inst1.elemID,
+          })],
+        }),
+      )
+
       expect(clientBulkOpSpy).toHaveBeenCalledTimes(1)
     })
 
@@ -125,7 +156,21 @@ describe('Custom Object Deploy', () => {
 
       )
       const res = await retryFlow(clientOp, { typeName: 'typtyp', instances: instanceElements, client }, retries)
-      expect(res).toEqual({ successInstances: [inst1], errorMessages: ['inst2:\n    \terr1 bla bla bla'] })
+      expect(res).toEqual(
+        expect.objectContaining({
+          errorMessages: [
+            expect.objectContaining({
+              elemID: inst2.elemID,
+              message: expect.stringContaining('err1 bla bla bla'),
+              severity: 'Error',
+            }),
+          ],
+          successInstances: [expect.objectContaining({
+            elemID: inst1.elemID,
+          })],
+        }),
+      )
+
       expect(clientBulkOpSpy).toHaveBeenCalledTimes(4)
     })
 
@@ -185,7 +230,19 @@ describe('Custom Object Deploy', () => {
         }
       )
       const res = await retryFlow(clientOp, { typeName: 'typtyp', instances: instanceElements, client }, retries)
-      expect(res).toEqual({ successInstances: [inst1], errorMessages: ['inst2:\n    \terr1'] })
+      expect(res).toEqual(
+        expect.objectContaining({
+          errorMessages: [expect.objectContaining({
+            elemID: inst2.elemID,
+            message: expect.stringContaining('err1'),
+            severity: 'Error',
+          })],
+          successInstances: [expect.objectContaining({
+            elemID: inst1.elemID,
+          })],
+        }),
+      )
+
       expect(clientBulkOpSpy).toHaveBeenCalledTimes(4)
     })
   })


### PR DESCRIPTION
Alter the way we return errors from deployments, so that instead of returning one bulk error, we return multiple errors with their errors and ElemIDs (if relevant)

---

This is the beginnings of a PR to separate errors out in deployment. The way to look at this is as so:
commit 1: changes to core, adapter-api, and adapter-utils to allow this change
commit 2: Salesforce specific changes to make the adapter work

---

_Release Notes_: 
Core:
- Receive ElemIDs in deploy errors related to specific elements
Salesforce Adapter:
- Change deploy errors from `Error` type to `SaltoError` or `SaltoElementError`
---

_User Notifications_: _None_