### PR TITLE
SALTO-4104 Move Local & Remote Filter Creator Definitions to adapter-utils

### DIFF
--- a/packages/adapter-utils/src/filter.ts
+++ b/packages/adapter-utils/src/filter.ts
@@ -59,6 +59,38 @@ export type FilterCreator<
   DeployInfo=void,
 > = (opts: T) => Filter<R, DeployInfo>
 
+export type LocalFilterCreatorDefinition<
+  R extends FilterResult | void,
+  T,
+  DeployInfo=void,
+> = {
+  creator: FilterCreator<R, T, DeployInfo>
+  addsNewInformation?: false
+}
+
+export type RemoteFilterCreatorDefinition<
+  R extends FilterResult | void,
+  T,
+  DeployInfo=void,
+> = {
+  creator: FilterCreator<R, T, DeployInfo>
+  addsNewInformation: true
+}
+
+export const isLocalFilterCreator = <
+  RLocal extends FilterResult | void,
+  RRemote extends FilterResult | void,
+  TLocal,
+  TRemote,
+  DLocal=void,
+  DRemote=void,
+>(
+    filterDef: LocalFilterCreatorDefinition<RLocal, TLocal, DLocal>
+      | RemoteFilterCreatorDefinition<RRemote, TRemote, DRemote>
+  ): filterDef is LocalFilterCreatorDefinition<RLocal, TLocal, DLocal> => (
+    filterDef.addsNewInformation !== true
+  )
+
 export const filtersRunner = <
   R extends FilterResult | void,
   T,

--- a/packages/salesforce-adapter/src/filter.ts
+++ b/packages/salesforce-adapter/src/filter.ts
@@ -51,27 +51,18 @@ export type FilterWith<M extends keyof Filter> = filter.FilterWith<FilterResult,
 
 // Local filters only use information in existing elements
 // They can change the format of elements, but cannot use external sources of information
-export type LocalFilterCreator = filter.FilterCreator<FilterResult, Pick<FilterOpts, 'config'>>
+type LocalFilterOpts = Pick<FilterOpts, 'config'>
+export type LocalFilterCreator = filter.FilterCreator<FilterResult, LocalFilterOpts>
 
 // Remote filters can add more information to existing elements
 // They should not change the format of existing elements, they should focus only on adding
 // the new information
-export type RemoteFilterCreator = filter.FilterCreator<FilterResult, Pick<FilterOpts, 'config' | 'client'>>
+type RemoteFilterOpts = Pick<FilterOpts, 'config' | 'client'>
+export type RemoteFilterCreator = filter.FilterCreator<FilterResult, RemoteFilterOpts>
 
 // Files filters can run on folders and get additional context from the list of available files
-export type FilesFilterCreator = filter.FilterCreator<FilterResult, Pick<FilterOpts, 'config' | 'files'>>
+type FilesFilterOpts = Pick<FilterOpts, 'config' | 'files'>
+export type FilesFilterCreator = filter.FilterCreator<FilterResult, FilesFilterOpts>
 
-export type RemoteFilterCreatorDefinition = {
-  creator: RemoteFilterCreator
-  addsNewInformation: true
-}
-export type LocalFilterCreatorDefinition = {
-  creator: LocalFilterCreator
-  addsNewInformation?: false
-}
-
-export const isLocalFilterCreator = (
-  filterDef: LocalFilterCreatorDefinition | RemoteFilterCreatorDefinition
-): filterDef is LocalFilterCreatorDefinition => (
-  filterDef.addsNewInformation !== true
-)
+export type LocalFilterCreatorDefinition = filter.LocalFilterCreatorDefinition<FilterResult, LocalFilterOpts>
+export type RemoteFilterCreatorDefinition = filter.RemoteFilterCreatorDefinition<FilterResult, RemoteFilterOpts>

--- a/packages/salesforce-adapter/src/sfdx_parser/sfdx_parser.ts
+++ b/packages/salesforce-adapter/src/sfdx_parser/sfdx_parser.ts
@@ -26,7 +26,6 @@ import { xmlToValues, isComplexType, complexTypesMap, PACKAGE } from '../transfo
 import { METADATA_TYPES_TO_RENAME, createInstanceElement, createMetadataObjectType, MetadataValues } from '../transformers/transformer'
 import { buildFetchProfile } from '../fetch_profile/fetch_profile'
 import { CUSTOM_OBJECT, METADATA_CONTENT_FIELD, SALESFORCE, RECORDS_PATH } from '../constants'
-import { isLocalFilterCreator } from '../filter'
 import { sfdxFilters } from './filters'
 
 
@@ -140,7 +139,7 @@ const getElementsFromDXFolder = async (
     .toArray()
 
   const localFilters = allFilters
-    .filter(isLocalFilterCreator)
+    .filter(filter.isLocalFilterCreator)
     .map(({ creator }) => creator)
   const filtersToRun = sfdxFilters.concat(localFilters)
   const filterRunner = filter.filtersRunner(


### PR DESCRIPTION
Moved `LocalFilterCreatorDefinition`, `RemoteFilterCreatorDefinition`, `isLocalFilterCreator` from SF adapter to adapter-utils in order to share it in NS adapter.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
