### PR TITLE
SALTO-4090/batch context options

### DIFF
--- a/packages/jira-adapter/src/filters/fields/context_options.ts
+++ b/packages/jira-adapter/src/filters/fields/context_options.ts
@@ -200,12 +200,12 @@ const reorderContextOptions = async (
       },
     }]
   ) : optionsGroups.map(group =>
-    chunkArray(group).map(chunk =>
+    chunkArray(group).map((chunk, index) =>
       ({
         url: `${baseUrl}/move`,
         data: {
           customFieldOptionIds: chunk.map(option => option.id),
-          position: 'First',
+          position: index === 0 ? 'First' : 'Last',
         },
       })))
   await awu(requestBodies).map(async bodies => awu(bodies).map(body => client.put(body)).toArray()).toArray()

--- a/packages/jira-adapter/src/filters/fields/context_options.ts
+++ b/packages/jira-adapter/src/filters/fields/context_options.ts
@@ -200,12 +200,12 @@ const reorderContextOptions = async (
       },
     }]
   ) : optionsGroups.map(group =>
-    chunkArray(group).map((chunk, index) =>
+    chunkArray(group).map(chunk =>
       ({
         url: `${baseUrl}/move`,
         data: {
           customFieldOptionIds: chunk.map(option => option.id),
-          position: index === 0 ? 'First' : 'Last',
+          position: 'First',
         },
       })))
   await awu(requestBodies).map(async bodies => awu(bodies).map(body => client.put(body)).toArray()).toArray()

--- a/packages/jira-adapter/src/filters/fields/context_options.ts
+++ b/packages/jira-adapter/src/filters/fields/context_options.ts
@@ -19,7 +19,6 @@ import { getParents, naclCase, resolveValues } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
-import JiraClient from '../../client/client'
 import { getLookUpName } from '../../reference_mapping'
 import { setFieldDeploymentAnnotations } from '../../utils'
 
@@ -171,7 +170,7 @@ const updateContextOptions = async ({
 
 const reorderContextOptions = async (
   contextChange: AdditionChange<InstanceElement> | ModificationChange<InstanceElement>,
-  client: JiraClient,
+  client: clientUtils.HTTPWriteClientInterface,
   baseUrl: string,
   elementsSource?: ReadOnlyElementsSource,
 ): Promise<void> => {
@@ -190,24 +189,7 @@ const reorderContextOptions = async (
   }
 
   const optionsGroups = _(afterOptions).groupBy(option => option.optionId).values().value()
-  await Promise.all(optionsGroups.map(
-    group => client.put({
-      url: `${baseUrl}/move`,
-      data: {
-        customFieldOptionIds: group.map(option => option.id),
-        position: 'First',
-      },
-    })
-  ))
-  const requestBodies = client.isDataCenter ? optionsGroups.map(
-    group => [{
-      url: `${baseUrl}/move`,
-      data: {
-        customFieldOptionIds: group.map(option => option.id),
-        position: 'First',
-      },
-    }]
-  ) : optionsGroups.map(group =>
+  const requestBodies = optionsGroups.map(group =>
     chunkArray(group).map((chunk, index) =>
       ({
         url: `${baseUrl}/move`,
@@ -221,7 +203,7 @@ const reorderContextOptions = async (
 
 export const setContextOptions = async (
   contextChange: Change<InstanceElement>,
-  client: JiraClient,
+  client: clientUtils.HTTPWriteClientInterface,
   elementsSource?: ReadOnlyElementsSource
 ): Promise<void> => {
   if (isRemovalChange(contextChange)) {

--- a/packages/jira-adapter/src/filters/fields/context_options.ts
+++ b/packages/jira-adapter/src/filters/fields/context_options.ts
@@ -200,7 +200,7 @@ const reorderContextOptions = async (
           position: index === 0 ? 'First' : 'Last',
         },
       })))
-  await awu(requestBodies).map(async bodies => awu(bodies).map(body => client.put(body)).toArray()).toArray()
+  await awu(requestBodies).flat().forEach(async body => client.put(body))
 }
 
 export const setContextOptions = async (

--- a/packages/jira-adapter/src/filters/fields/context_options.ts
+++ b/packages/jira-adapter/src/filters/fields/context_options.ts
@@ -190,15 +190,7 @@ const reorderContextOptions = async (
   }
 
   const optionsGroups = _(afterOptions).groupBy(option => option.optionId).values().value()
-  await Promise.all(optionsGroups.map(
-    group => client.put({
-      url: `${baseUrl}/move`,
-      data: {
-        customFieldOptionIds: group.map(option => option.id),
-        position: 'First',
-      },
-    })
-  ))
+  // Data center plugin expects all options in one request.
   const requestBodies = client.isDataCenter ? optionsGroups.map(
     group => [{
       url: `${baseUrl}/move`,

--- a/packages/jira-adapter/test/filters/fields/context_options.test.ts
+++ b/packages/jira-adapter/test/filters/fields/context_options.test.ts
@@ -303,7 +303,7 @@ describe('context options', () => {
         )
       })
 
-      it('should call post twice with only 1000 or less batches', () => {
+      it('should call put with only 1000 or less batches', () => {
         expect(client.put).toHaveBeenCalledTimes(4)
         expect(client.put).toHaveBeenNthCalledWith(2, {
           url: '/rest/api/3/field/2/context/3/option',
@@ -314,6 +314,16 @@ describe('context options', () => {
                 value: 'p1000',
               }),
             ],
+          },
+        })
+        // check reorder is also using up to 1000 options at a time.
+        expect(client.put).toHaveBeenNthCalledWith(4, {
+          url: '/rest/api/3/field/2/context/3/option/move',
+          data: {
+            customFieldOptionIds: [
+              undefined,
+            ],
+            position: 'Last',
           },
         })
       })

--- a/packages/jira-adapter/test/filters/fields/context_options.test.ts
+++ b/packages/jira-adapter/test/filters/fields/context_options.test.ts
@@ -300,7 +300,7 @@ describe('context options', () => {
           }
           return {
             data: {
-              options: Object.entries(largeCascadingOptions).map(([key, value], index) => ({
+              options: Object.entries(largeCascadingOptions).map(([_, value], index) => ({
                 id: `${index + 4}`,
                 value: (value as {value: unknown}).value,
                 optionId: '10047',

--- a/packages/jira-adapter/test/filters/fields/context_options.test.ts
+++ b/packages/jira-adapter/test/filters/fields/context_options.test.ts
@@ -326,7 +326,7 @@ describe('context options', () => {
           position: 0,
         },
       }
-      client.post.mockResolvedValue({
+      connection.post.mockResolvedValue({
         data: {
           options: [
             {
@@ -342,9 +342,9 @@ describe('context options', () => {
         client,
         elementSource
       )
-      expect(client.post).toHaveBeenCalledWith({
-        url: '/rest/api/3/field/2/context/3/option',
-        data: {
+      expect(connection.post).toHaveBeenCalledWith(
+        '/rest/api/3/field/2/context/3/option',
+        {
           options: [
             expect.objectContaining({
               value: 'p2',
@@ -352,7 +352,8 @@ describe('context options', () => {
             }),
           ],
         },
-      })
+        undefined
+      )
       expect(contextInstance.value.options.p1.id).toEqual('10')
     })
 
@@ -369,7 +370,7 @@ describe('context options', () => {
           position: 0,
         },
       }
-      client.post.mockResolvedValue({
+      connection.post.mockResolvedValue({
         data: {
           options: [
             {
@@ -389,9 +390,9 @@ describe('context options', () => {
         client,
         elementSource
       )
-      expect(client.post).toHaveBeenCalledWith({
-        url: '/rest/api/3/field/2/context/3/option',
-        data: {
+      expect(connection.post).toHaveBeenCalledWith(
+        '/rest/api/3/field/2/context/3/option',
+        {
           options: [
             expect.objectContaining({
               value: 'p2',
@@ -403,7 +404,8 @@ describe('context options', () => {
             }),
           ],
         },
-      })
+        undefined
+      )
       expect(contextInstance.value.options.p1.id).toEqual('10')
       expect(contextInstance.value.options.p2.id).toEqual('20')
     })

--- a/packages/jira-adapter/test/filters/fields/context_options.test.ts
+++ b/packages/jira-adapter/test/filters/fields/context_options.test.ts
@@ -153,12 +153,13 @@ describe('context options', () => {
       })
 
       it('should call the add endpoint with all of the options', () => {
-        expect(client.post).toHaveBeenCalledWith({
+        expect(client.post).toHaveBeenCalledTimes(2)
+        expect(client.post).toHaveBeenNthCalledWith(2, {
           url: '/rest/api/3/field/2/context/3/option',
           data: {
             options: [
               expect.objectContaining({
-                value: 'p1',
+                value: 'p1000',
                 disabled: false,
               }),
             ],

--- a/packages/jira-adapter/test/filters/fields/context_options.test.ts
+++ b/packages/jira-adapter/test/filters/fields/context_options.test.ts
@@ -77,7 +77,6 @@ describe('context options', () => {
 
     it('if change is removal, should do nothing', async () => {
       await setContextOptions(toChange({ before: contextInstance }), client, elementSource)
-      // expect(client.post).toHaveBeenCalledWith(undefined)
       expect(connection.post).not.toHaveBeenCalled()
       expect(connection.put).not.toHaveBeenCalled()
       expect(connection.delete).not.toHaveBeenCalled()


### PR DESCRIPTION
set context options batch sizes to 1000 at the time,
added tests to mock the behavior of jira's servers but i wasnt able to system test it myself.

---

_Additional context for reviewer_

---
_Release Notes_: 
jira_adapter:
* fixed bug with context options failing to update because there were over 1000 updating at the same request.

---
_User Notifications_: 
