### PR TITLE
SALTO-4087: Remove policyRules field from policies

### DIFF
--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -162,7 +162,6 @@ const getPolicyConfig = (): OktaSwaggerApiConfig['types'] => {
       add: {
         url: '/api/v1/policies',
         method: 'post',
-        fieldsToIgnore: ['policyRules'],
       },
       modify: {
         url: '/api/v1/policies/{policyId}',
@@ -170,7 +169,6 @@ const getPolicyConfig = (): OktaSwaggerApiConfig['types'] => {
         urlParamsToFields: {
           policyId: 'id',
         },
-        fieldsToIgnore: ['policyRules'],
       },
       remove: {
         url: '/api/v1/policies/{policyId}',

--- a/packages/okta-adapter/src/filters/delete_fields.ts
+++ b/packages/okta-adapter/src/filters/delete_fields.ts
@@ -15,11 +15,13 @@
 */
 import { Element, isInstanceElement } from '@salto-io/adapter-api'
 import { FilterCreator } from '../filter'
-import { APPLICATION_TYPE_NAME, GROUP_TYPE_NAME } from '../constants'
+import { APPLICATION_TYPE_NAME, AUTHORIZATION_POLICY_RULE, GROUP_TYPE_NAME, POLICY_TYPE_NAMES } from '../constants'
 
 const TYPES_TO_FIELDS: Record<string, string[]> = {
   [GROUP_TYPE_NAME]: ['roles'],
   [APPLICATION_TYPE_NAME]: ['appUserSchema'],
+  [AUTHORIZATION_POLICY_RULE]: ['policyRules'],
+  ...Object.fromEntries(POLICY_TYPE_NAMES.map(typeName => [typeName, ['policyRules']])),
 }
 
 /**


### PR DESCRIPTION
Remove policyRules field from policies

---

The field is added during `recurseInto` so it must be removed with filter

---
_Release Notes_: 
None

---
_User Notifications_: 
None