### PR TITLE
SALTO-4107: add check for null on account id

### DIFF
--- a/packages/jira-adapter/src/filters/account_id/account_id_filter.ts
+++ b/packages/jira-adapter/src/filters/account_id/account_id_filter.ts
@@ -186,7 +186,7 @@ export const walkOnUsers = (callback: WalkOnUsersCallback, config: JiraConfig): 
         ? accountIdsScenarios(value.value, path, callback, config)
         : WALK_NEXT_STEP.EXIT
     }
-    if (value !== undefined) {
+    if (value != null) { // null or undefined
       return accountIdsScenarios(value, path, callback, config)
     }
     return WALK_NEXT_STEP.SKIP

--- a/packages/jira-adapter/test/filters/account_id/account_id_filter.test.ts
+++ b/packages/jira-adapter/test/filters/account_id/account_id_filter.test.ts
@@ -164,6 +164,11 @@ describe('account_id_filter', () => {
       await filter.onFetch([currentObjectType])
       expect(await currentObjectType.fields.fakeAccountId.getType()).toEqual(BuiltinTypes.STRING)
     })
+    it('does not fail with a null value', async () => {
+      simpleInstances[1].value.nullValue = null
+      await filter.onFetch([simpleInstances[1]])
+      common.checkObjectedInstanceIds(simpleInstances[1], '1')
+    })
   })
   describe('deploy', () => {
     it('returns account id structure to a simple and correct string on pre deploy on all 5 types', async () => {


### PR DESCRIPTION
Came from an incident, hard to verify this is the cause but it makes sense and recreates

---

_Additional context for reviewer_
None

---
_Release Notes_: 
Jira Adapter:
* Fixed a bug that caused null values to fail the fetch 

---
_User Notifications_: 
None