### PR TITLE
SALTO-4046 Add support for invalid static files for copying between accounts

### DIFF
--- a/packages/workspace/src/workspace/static_files/functions.ts
+++ b/packages/workspace/src/workspace/static_files/functions.ts
@@ -15,7 +15,7 @@
 */
 import { StaticFile, Value, isStaticFile, DEFAULT_STATIC_FILE_ENCODING } from '@salto-io/adapter-api'
 
-import { StaticFilesSource, InvalidStaticFile } from './common'
+import { StaticFilesSource, InvalidStaticFile, isInvalidStaticFile } from './common'
 import { Functions, FunctionExpression } from '../../parser/functions'
 
 export const getStaticFilesFunctions = (staticFilesSource: StaticFilesSource): Functions => ({
@@ -25,6 +25,10 @@ export const getStaticFilesFunctions = (staticFilesSource: StaticFilesSource): F
       return staticFilesSource.getStaticFile(filepath, encoding)
     },
     dump: async (val: Value): Promise<FunctionExpression> => {
+      if (isInvalidStaticFile(val)) {
+        return new FunctionExpression('file', [val.filepath])
+      }
+
       if (await val.getContent() !== undefined) {
         await staticFilesSource.persistStaticFile(val)
       }
@@ -35,6 +39,6 @@ export const getStaticFilesFunctions = (staticFilesSource: StaticFilesSource): F
         params,
       )
     },
-    isSerializedAsFunction: (val: Value) => isStaticFile(val),
+    isSerializedAsFunction: (val: Value) => isStaticFile(val) || isInvalidStaticFile(val),
   },
 })

--- a/packages/workspace/test/workspace/static_files/functions.test.ts
+++ b/packages/workspace/test/workspace/static_files/functions.test.ts
@@ -19,6 +19,7 @@ import { Functions } from '../../../src/parser/functions'
 import { getStaticFilesFunctions } from '../../../src/workspace/static_files/functions'
 import { StaticFilesSource } from '../../../src/workspace/static_files'
 import { mockStaticFilesSource } from '../../utils'
+import { MissingStaticFile } from '../../../src/workspace/static_files/common'
 
 describe('Functions', () => {
   let functions: Functions
@@ -31,6 +32,8 @@ describe('Functions', () => {
     expect(functions).toHaveProperty('file'))
   it('should identify static file values', () =>
     expect(functions.file.isSerializedAsFunction(new StaticFile({ filepath: 'aa', hash: 'hash', encoding: 'binary' }))).toBeTruthy())
+  it('should identify invalid static file values', () =>
+    expect(functions.file.isSerializedAsFunction(new MissingStaticFile('aa'))).toBeTruthy())
   it('should not identify for other values', () =>
     expect(functions.file.isSerializedAsFunction('a' as Value)).toBeFalsy())
   it('should convert valid function expression to valid static metadata', async () => {
@@ -55,5 +58,11 @@ describe('Functions', () => {
     expect(dumped).toHaveProperty('funcName', 'file')
     expect(dumped).toHaveProperty('parameters', ['filepath'])
     expect(mockedStaticFilesSource.persistStaticFile).toHaveBeenCalledTimes(1)
+  })
+  it('should not persist when dumping invalid static file', async () => {
+    const dumped = await functions.file.dump(new MissingStaticFile('filepath'))
+    expect(dumped).toHaveProperty('funcName', 'file')
+    expect(dumped).toHaveProperty('parameters', ['filepath'])
+    expect(mockedStaticFilesSource.persistStaticFile).toHaveBeenCalledTimes(0)
   })
 })


### PR DESCRIPTION
_Fix the dump of a Missing Static File which currently leads to a parse error_

---

_Additional context for reviewer_

---
_Release Notes_: 
_Core_
* Fix the dump of a Missing Static File which currently leads to a parse error

---
_User Notifications_: 
