### PR TITLE
SALTO-4112 fix error catching in SOAP client

### DIFF
--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -51,7 +51,7 @@ import {
 import { ATTRIBUTE_PREFIX, CDATA_TAG_NAME, fileCabinetTopLevelFolders } from './constants'
 import {
   isCustomTypeInfo, isFileCustomizationInfo, isFolderCustomizationInfo, isTemplateCustomTypeInfo,
-  mergeTypeToInstances, getGroupItemFromRegex,
+  mergeTypeToInstances, getGroupItemFromRegex, toError,
 } from './utils'
 import { fixManifest } from './manifest_utils'
 import { detectLanguage, FEATURE_NAME, fetchLockedObjectErrorRegex, fetchUnexpectedErrorRegex, multiLanguageErrorDetectors, OBJECT_ID } from './language_utils'
@@ -114,8 +114,6 @@ const XML_PARSE_OPTIONS: xmlParser.J2xOptionsOptional = {
   ignoreAttributes: false,
   tagValueProcessor: val => he.decode(val),
 }
-
-const toError = (e: unknown): Error => (e instanceof Error ? e : new Error(String(e)))
 
 const safeQuoteArgument = (argument: unknown): unknown => {
   if (typeof argument === 'string') {

--- a/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
@@ -75,7 +75,7 @@ const retryOnBadResponseWithDelay = (
       call: decorators.OriginalCall,
     ): Promise<unknown> => {
       const shouldRetry = (e: Value): boolean =>
-        retryableMessages.some(message => e?.message?.toUpperCase?.()?.includes?.(message)
+        retryableMessages.some(message => toError(e).message.toUpperCase().includes(message)
           || e?.code?.toUpperCase?.()?.includes?.(message))
         || retryableStatuses.some(status => String(e?.response?.status).startsWith(status))
 
@@ -374,11 +374,10 @@ export default class SoapClient {
       )
     } catch (e) {
       log.warn('Received error from NetSuite SuiteApp Soap request: operation - %s, body - %o, error - %o', operation, body, e)
-      const error = toError(e)
-      if (error.message.includes('Invalid login attempt.')) {
+      if (toError(e).message.includes('Invalid login attempt.')) {
         throw new InvalidSuiteAppCredentialsError()
       }
-      throw error
+      throw e
     }
   }
 

--- a/packages/netsuite-adapter/src/client/utils.ts
+++ b/packages/netsuite-adapter/src/client/utils.ts
@@ -22,6 +22,7 @@ import { NetsuiteTypesQueryParams } from '../query'
 const { matchAll } = strings
 const { isDefined } = values
 
+export const toError = (e: unknown): Error => (e instanceof Error ? e : new Error(String(e)))
 
 export const isCustomTypeInfo = (customizationInfo: CustomizationInfo):
   customizationInfo is CustomTypeInfo => 'scriptId' in customizationInfo


### PR DESCRIPTION
The thrown value can be different from an `Error` object so `e.message.includes` can fail on `Cannot read property 'includes' of undefined`.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Fix error catching in SOAP client

---
_User Notifications_: 
None
