### PR TITLE
SALTO-4121: Update the element source between deploy items

### DIFF
--- a/packages/adapter-api/src/elements.ts
+++ b/packages/adapter-api/src/elements.ts
@@ -623,6 +623,10 @@ export type ReadOnlyElementsSource = {
   get(id: ElemID): Promise<Value>
 }
 
+export type WritableElementsSource = ReadOnlyElementsSource & {
+  set(element: Readonly<Element>): Promise<void>
+}
+
 // This is a hack for the places we don't really need types in
 // transformElement. We need to replace this with not using transformElement.
 export const placeholderReadonlyElementsSource = {

--- a/packages/adapter-utils/test/element_source.test.ts
+++ b/packages/adapter-utils/test/element_source.test.ts
@@ -69,6 +69,14 @@ describe('elementSource', () => {
           expect(await elementsSource.has(new ElemID('adapter', 'type3'))).toBeFalsy()
         })
       })
+
+      describe('set', () => {
+        it('should add the element', async () => {
+          const newElem = new ObjectType({ elemID: new ElemID('adapter', 'type3') })
+          await elementsSource.set(newElem)
+          expect(await elementsSource.get(newElem.elemID)).toBe(newElem)
+        })
+      })
     })
 
     describe('with fallback element source', () => {

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -25,6 +25,7 @@ import _ from 'lodash'
 import { promises, collections } from '@salto-io/lowerdash'
 import { Workspace, ElementSelector, elementSource, expressions, merger } from '@salto-io/workspace'
 import { EOL } from 'os'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { deployActions, DeployError, ItemStatus } from './core/deploy'
 import {
   adapterCreators, getAdaptersCredentialsTypes, getAdapters, getAdapterDependencyChangers,
@@ -149,11 +150,12 @@ export const deploy = async (
   checkOnly = false,
 ): Promise<DeployResult> => {
   const changedElements = elementSource.createInMemoryElementSource()
+  const adaptersElementSource = buildElementsSourceFromElements([], await workspace.elements())
   const adapters = await getAdapters(
     accounts,
     await workspace.accountCredentials(accounts),
     workspace.accountConfig.bind(workspace),
-    await workspace.elements(),
+    adaptersElementSource,
     getAccountToServiceNameMap(workspace, accounts)
   )
 
@@ -184,7 +186,7 @@ export const deploy = async (
     }))
   }
   const { errors, appliedChanges, extraProperties } = await deployActions(
-    actionPlan, adapters, reportProgress, postDeployAction, checkOnly,
+    actionPlan, adapters, reportProgress, postDeployAction, checkOnly, adaptersElementSource
   )
 
   // Add workspace elements as an additional context for resolve so that we can resolve

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -14,10 +14,10 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { AdapterOperations, BuiltinTypes, CORE_ANNOTATIONS, Element, ElemID, InstanceElement, ObjectType, PrimitiveType, PrimitiveTypes, Adapter, isObjectType, isEqualElements, isAdditionChange, ChangeDataType, AdditionChange, isInstanceElement, isModificationChange, DetailedChange, ReferenceExpression, Field, CredentialError } from '@salto-io/adapter-api'
+import { AdapterOperations, BuiltinTypes, CORE_ANNOTATIONS, Element, ElemID, InstanceElement, ObjectType, PrimitiveType, PrimitiveTypes, Adapter, isObjectType, isEqualElements, isAdditionChange, ChangeDataType, AdditionChange, isInstanceElement, isModificationChange, DetailedChange, ReferenceExpression, Field, CredentialError, getChangeData, toChange } from '@salto-io/adapter-api'
 import * as workspace from '@salto-io/workspace'
 import { collections } from '@salto-io/lowerdash'
-import { mockFunction } from '@salto-io/test-utils'
+import { mockFunction, MockInterface } from '@salto-io/test-utils'
 import { loadElementsFromFolder, adapter as salesforceAdapter } from '@salto-io/salesforce-adapter'
 import * as api from '../src/api'
 import * as plan from '../src/core/plan/plan'
@@ -512,6 +512,80 @@ describe('api.ts', () => {
           expect(mockAdapterOps.deploy).not.toHaveBeenCalled()
           expect(validateMock).toHaveBeenCalledTimes(1)
         })
+      })
+    })
+
+    describe('with element updates during deploy', () => {
+      let instance: InstanceElement
+      let adapterOps: MockInterface<AdapterOperations>
+      let adapter: Adapter
+      beforeAll(async () => {
+        adapterOps = {
+          fetch: mockFunction<AdapterOperations['fetch']>(),
+          deploy: mockFunction<AdapterOperations['deploy']>(),
+        }
+        adapter = {
+          operations: mockFunction<Adapter['operations']>().mockReturnValue(adapterOps as AdapterOperations),
+          authenticationMethods: { basic: { credentialsType: mockConfigType } },
+          validateCredentials: mockFunction<Adapter['validateCredentials']>().mockResolvedValue(''),
+        }
+        adapterCreators.test = adapter
+
+        instance = new InstanceElement(
+          'inst',
+          new ObjectType({ elemID: new ElemID('test', 'type') }),
+          { name: 'test' }
+        )
+
+        const mockWs = mockWorkspace({
+          elements: [instance],
+          stateElements: [],
+          accounts: ['test'],
+        })
+
+        mockWs.accountCredentials = mockFunction<workspace.Workspace['accountCredentials']>().mockResolvedValue({
+          test: new InstanceElement(
+            ElemID.CONFIG_NAME,
+            mockConfigType,
+            {
+              username: 'test@test',
+              password: 'test',
+              token: 'test',
+              sandbox: false,
+            }
+          ),
+        })
+
+        const actionPlan = mockPlan.createPlan([
+          [{ action: 'add', data: { after: instance.clone() } }],
+        ])
+
+        adapterOps.deploy.mockImplementationOnce(async ({ changeGroup }) => {
+          const changeInstance = getChangeData(changeGroup.changes[0]) as InstanceElement
+          changeInstance.value.id = 1
+          return {
+            appliedChanges: [toChange({ after: changeInstance })],
+            errors: [],
+          }
+        })
+
+        result = await api.deploy(mockWs, actionPlan, jest.fn(), ['test'])
+      })
+
+      it('should call adapter deploy function', () => {
+        expect(adapterOps.deploy).toHaveBeenCalledTimes(1)
+      })
+
+      it('should return the applied changes', () => {
+        expect(result.appliedChanges).toHaveLength(1)
+        const [addedChange] = result.appliedChanges ?? []
+        expect((getChangeData(addedChange) as InstanceElement).value.id).toBe(1)
+      })
+
+      it('should update element source', async () => {
+        const elementSource = (adapter.operations as jest.Mock).mock.calls[0][0].elementsSource
+        const instanceFromSource = await elementSource.get(instance.elemID) as InstanceElement
+        expect(instanceFromSource.value.id).toBe(1)
       })
     })
   })


### PR DESCRIPTION
Update the element source between deploy items with the applied change.

This is so that when we deploy a change that depends on an addition, we will be able to access the values that are added to that addition change (such as internal id)

---

This is required for https://salto-io.atlassian.net/browse/SALTO-4067

---
_Release Notes_: 
None

---
_User Notifications_: 
None