### PR TITLE
SALTO-4124: deploy webhook with api_key as authentication

### DIFF
--- a/packages/zendesk-adapter/src/filters/webhook.ts
+++ b/packages/zendesk-adapter/src/filters/webhook.ts
@@ -29,6 +29,7 @@ import { WEBHOOK_TYPE_NAME } from '../constants'
 export const AUTH_TYPE_TO_PLACEHOLDER_AUTH_DATA: Record<string, unknown> = {
   bearer_token: { token: '123456' },
   basic_auth: { username: 'user@name.com', password: 'password' },
+  api_key: { name: 'tempHeader', value: 'tempValue' },
 }
 
 /**


### PR DESCRIPTION
deploy webhook with api_key as authentication

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* Fix deploy of webhook when authentication is  api_key

---
_User Notifications_: 
none
