### PR TITLE
SALTO-3576: Support Device Assurance policies in Okta

### DIFF
--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -1227,6 +1227,42 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
       fieldsToHide: [{ fieldName: 'uiSchemaId' }],
     },
   },
+  DevicePolicyRuleCondition: {
+    transformation: {
+      fieldTypeOverrides: [
+        { fieldName: 'registered', fieldType: 'boolean' },
+        { fieldName: 'managed', fieldType: 'boolean' },
+        { fieldName: 'assurance', fieldType: 'DeviceCondition' },
+      ],
+    },
+  },
+  DeviceAssurance: {
+    transformation: {
+      fieldTypeOverrides: [{ fieldName: 'lastUpdate', fieldType: 'string' }],
+      fieldsToHide: [{ fieldName: 'id' }],
+      fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat([{ fieldName: 'createdDate' }, { fieldName: 'lastUpdate' }, { fieldName: '_links' }]),
+    },
+    deployRequests: {
+      add: {
+        url: '/api/v1/device-assurances',
+        method: 'post',
+      },
+      modify: {
+        url: '/api/v1/device-assurances/{deviceAssuranceId}',
+        method: 'put',
+        urlParamsToFields: {
+          deviceAssuranceId: 'id',
+        },
+      },
+      remove: {
+        url: '/api/v1/device-assurances/{deviceAssuranceId}',
+        method: 'delete',
+        urlParamsToFields: {
+          deviceAssuranceId: 'id',
+        },
+      },
+    },
+  },
 }
 
 const DEFAULT_SWAGGER_CONFIG: OktaSwaggerApiConfig['swagger'] = {
@@ -1243,6 +1279,7 @@ const DEFAULT_SWAGGER_CONFIG: OktaSwaggerApiConfig['swagger'] = {
     { typeName: 'AppUserSchema', cloneFrom: 'UserSchema' },
     // This is not the right type to cloneFrom, but a workaround to define type for Group__source with 'id' field
     { typeName: 'Group__source', cloneFrom: 'AppAndInstanceConditionEvaluatorAppOrInstance' },
+    { typeName: 'DeviceCondition', cloneFrom: 'PolicyNetworkCondition' },
   ],
   typeNameOverrides: [
     { originalName: 'DomainResponse', newName: 'Domain' },
@@ -1290,6 +1327,7 @@ export const SUPPORTED_TYPES = {
   PerClientRateLimit: ['PerClientRateLimitSettings'],
   RateLimitAdmin: ['RateLimitAdminNotifications'],
   ResourceSet: ['ResourceSets'],
+  DeviceAssurance: ['api__v1__device_assurances@uuuub'],
 }
 
 const DUCKTYPE_TYPES: OktaDuckTypeApiConfig['types'] = {

--- a/packages/okta-adapter/src/reference_mapping.ts
+++ b/packages/okta-adapter/src/reference_mapping.ts
@@ -209,6 +209,9 @@ export const referencesRules: OktaFieldReferenceDefinition[] = [
     serializationStrategy: 'id',
     target: { type: APPLICATION_TYPE_NAME },
   },
+  { src: { field: 'include', parentTypes: ['DeviceCondition'] },
+    serializationStrategy: 'id',
+    target: { type: 'DeviceAssurance' } },
 ]
 
 // Resolve references to userSchema fields references to field name instead of full value


### PR DESCRIPTION
Support Device Assurance policies in Okta

---

Added fetch, deploy, and reference from `AccessPolicyRule` to the new type 

---
_Release Notes_: 
None

---
_User Notifications_: 
None
