### PR TITLE
SALTO-4120 - Change getFromPathIndex to not return multiple hints for elemIDs that do not exist in the pathIndex

### DIFF
--- a/packages/workspace/src/workspace/path_index.ts
+++ b/packages/workspace/src/workspace/path_index.ts
@@ -246,15 +246,21 @@ export const getFromPathIndex = async (
 ): Promise<Path[]> => {
   const idParts = elemID.getFullNameParts()
   const topLevelKey = elemID.createTopLevelParentID().parent.getFullName()
+  let isExactMatch = true
   let key: string
   do {
     key = idParts.join('.')
     // eslint-disable-next-line no-await-in-loop
     const pathHints = await index.get(key)
-    if (pathHints !== undefined) {
-      return pathHints
+    if (pathHints !== undefined && pathHints.length > 0) {
+      // If we found this elemID in the pathIndex we want to return all the hints.
+      // If this is not an exact match we want to return a single hint
+      // because otherwise, splitElementByPath will make it appear in multiple fragments
+      // and cause merge errors.
+      return isExactMatch ? pathHints : [pathHints[0]]
     }
     idParts.pop()
+    isExactMatch = false
   } while (idParts.length > 0 && key !== topLevelKey)
   return []
 }

--- a/packages/workspace/test/workspace/path_index.test.ts
+++ b/packages/workspace/test/workspace/path_index.test.ts
@@ -279,6 +279,8 @@ describe('getFromPathIndex', () => {
   const index: PathIndex = new InMemoryRemoteMap<Path[]>()
   const parentID = new ElemID('salto.parent')
   const nestedID = parentID.createNestedID('attr', 'one')
+  const nestedWithNoPathID = parentID.createNestedID('attr', 'two')
+  const nestedOfNestedWithNoPathID = nestedID.createNestedID('stam', 'something')
   const nestedPath = ['salto', 'one']
   const parentPath = ['salto', 'two']
   beforeAll(async () => {
@@ -293,15 +295,14 @@ describe('getFromPathIndex', () => {
     expect(await getFromPathIndex(parentID, index)).toEqual([nestedPath, parentPath])
   })
 
-  it('should get the closest parent of the elemID if no exact match', async () => {
+  it('should get the closest parent of the elemID if no exact match, but only a single hint if parent has multiple', async () => {
     expect(await getFromPathIndex(
-      nestedID.createNestedID('stam', 'something'),
+      nestedOfNestedWithNoPathID,
       index
     )).toEqual([nestedPath])
-    expect(await getFromPathIndex(
-      parentID.createNestedID('attr', 'something'),
-      index
-    )).toEqual([nestedPath, parentPath])
+    const parentMissPaths = await getFromPathIndex(nestedWithNoPathID, index)
+    expect(parentMissPaths).toHaveLength(1)
+    expect([[nestedPath], [parentPath]]).toContainEqual(parentMissPaths)
   })
 
   it('should return an empty array if no parent matches are found', async () => {


### PR DESCRIPTION
We have an issue when using `splitElementByPath` and using a pathIndex that does not have information for all the elemIDs that are being split. For example splitting an Object type and one if the fields does not exist in the pathIndex.
This is caused by the fact that `getFromPathIndex` returns the hints of the "closest" parent, even if that parent has multiple hints.
This changes the logic so that for elemIDs that exist in the pathIndex, we will still return all the relevant hints, but for those who do not, we will still use the closest parent's hints, but only one of them and not all the hints cause returning multiple will eventually cause merge errors for this element since the part that does not exist in the pathIndex will appear in multiple fragments.

---
_Release Notes_: 

*Core*:
* Fix a bug in Restore and Fetch From Workspace when used when there are parts of the Elements that exist in the Workspace/State but were not fetched yet (ie. Fields inside ObjectType that are split across multiple files that were Deployed and then Fetched From) would cause a Merge Error after the Restore/Fetch From since the parts would appear in multiple files.

---
_User Notifications_: 
None
