### PR TITLE
SALTO-4120 - Change the order of the paths in CustomObject split

### DIFF
--- a/packages/salesforce-adapter/src/filters/custom_type_split.ts
+++ b/packages/salesforce-adapter/src/filters/custom_type_split.ts
@@ -71,7 +71,7 @@ const splitFields = async (
       ],
     }
   )
-  return [standardFieldsObject, customFieldsObject]
+  return [customFieldsObject, standardFieldsObject]
 }
 
 const customObjectToSplitElements = async (


### PR DESCRIPTION
I am not proud of this. But after https://github.com/salto-io/salto/pull/4348 this will actually matter a bit and fit our use-case better.

---
_Release Notes_: 
None

---
_User Notifications_: 
None
