### PR TITLE
SALTO-4127: Fix bug in missing users validator

### DIFF
--- a/packages/okta-adapter/src/change_validators/user.ts
+++ b/packages/okta-adapter/src/change_validators/user.ts
@@ -42,6 +42,9 @@ export const usersValidator: (client: OktaClient, config: OktaConfig) =>
         .filter(isInstanceChange)
         .map(getChangeData)
         .filter(instance => Object.keys(USER_MAPPING).includes(instance.elemID.typeName))
+        .filter(instance =>
+          USER_MAPPING[instance.elemID.typeName]
+            .some(path => resolvePath(instance, instance.elemID.createNestedID(...path)) !== undefined))
 
       if (_.isEmpty(relevantInstances)) {
         return []
@@ -60,6 +63,7 @@ export const usersValidator: (client: OktaClient, config: OktaConfig) =>
         const userPaths = USER_MAPPING[instance.elemID.typeName]
         const missingUsers = userPaths
           .flatMap(path => resolvePath(instance, instance.elemID.createNestedID(...path)))
+          .filter(user => user !== undefined)
           .filter(user => !existingUsers.has(user))
         if (!_.isEmpty(missingUsers)) {
           return [instance.elemID.getFullName(), missingUsers]

--- a/packages/okta-adapter/test/change_validators/users.test.ts
+++ b/packages/okta-adapter/test/change_validators/users.test.ts
@@ -107,7 +107,7 @@ describe('usersValidator', () => {
     ])
     expect(changeErrors).toHaveLength(0)
   })
-  it('should not return error if there are no users in instance', async () => {
+  it('should not return error if users path does not exist', async () => {
     mockGet.mockResolvedValue(
       {
         status: 200,

--- a/packages/okta-adapter/test/change_validators/users.test.ts
+++ b/packages/okta-adapter/test/change_validators/users.test.ts
@@ -107,4 +107,24 @@ describe('usersValidator', () => {
     ])
     expect(changeErrors).toHaveLength(0)
   })
+  it('should not return error if there are no users in instance', async () => {
+    mockGet.mockResolvedValue(
+      {
+        status: 200,
+        data: [
+          { id: '1', profile: { login: 'a@a' } },
+        ],
+      }
+    )
+    const changeValidator = usersValidator(client, DEFAULT_CONFIG)
+    const instance = new InstanceElement(
+      'no users',
+      accessRuleType,
+      { name: 'policy', conditions: { people: { groups: { include: ['groupId'] } } } },
+    )
+    const changeErrors = await changeValidator([
+      toChange({ after: instance }),
+    ])
+    expect(changeErrors).toEqual([])
+  })
 })


### PR DESCRIPTION
Fix bug in missing users validator causing users to get errors for changes in instances that don't have users path

---
_Release Notes_: 
None

---
_User Notifications_: 
None
