### PR TITLE
SALTO-4129: Fix error for fetch with no categories

### DIFF
--- a/packages/adapter-components/src/elements/request_parameters.ts
+++ b/packages/adapter-components/src/elements/request_parameters.ts
@@ -96,7 +96,7 @@ const computeDependsOnURLs = (
       isInstanceElement
     )
     if (contextInstances.length === 0) {
-      throw new Error(`no instances found for ${referenceDetails.from.type}, cannot call endpoint ${url}`)
+      log.warn(`no instances found for ${referenceDetails.from.type}, cannot call endpoint ${url}`)
     }
     const potentialParams = contextInstances
       .map(e => e.value[referenceDetails.from.field])


### PR DESCRIPTION
Fix error for fetch with no categories

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk: 
* Fix error for fetch of guide with no categories

---
_User Notifications_: 
None
