### PR TITLE
SAAS-7196: CPQ config based on Salesforce Ids

### DIFF
--- a/packages/salesforce-adapter/src/config_creator.ts
+++ b/packages/salesforce-adapter/src/config_creator.ts
@@ -19,7 +19,7 @@ import { createDefaultInstanceFromType, createMatchingObjectType } from '@salto-
 import { logger } from '@salto-io/logging'
 import { configType } from './types'
 import * as constants from './constants'
-import { CPQ_NAMESPACE } from './constants'
+import { CPQ_NAMESPACE, CUSTOM_OBJECT_ID_FIELD } from './constants'
 
 const log = logger(module)
 
@@ -149,148 +149,7 @@ export const configWithCPQ = new InstanceElement(
         ],
         saltoIDSettings: {
           defaultIdFields: [
-            '##allMasterDetailFields##',
-            'Name',
-          ],
-          overrides: [
-            {
-              objectsRegex: 'SBQQ__CustomAction__c',
-              idFields: [
-                'SBQQ__Location__c',
-                'SBQQ__DisplayOrder__c',
-                'SBQQ__Type__c',
-                'Name',
-              ],
-            },
-            {
-              objectsRegex: 'SBQQ__ProductFeature__c',
-              idFields: [
-                '##allMasterDetailFields##',
-                'SBQQ__ConfiguredSKU__c',
-                'SBQQ__Category__c',
-                'SBQQ__Number__c',
-                'Name',
-              ],
-            },
-            {
-              objectsRegex: 'SBQQ__ConfigurationAttribute__c',
-              idFields: [
-                '##allMasterDetailFields##',
-                'SBQQ__Product__c',
-                'SBQQ__Feature__c',
-                'SBQQ__TargetField__c',
-                'Name',
-              ],
-            },
-            {
-              objectsRegex: 'SBQQ__FavoriteProduct__c',
-              idFields: [
-                '##allMasterDetailFields##',
-                'SBQQ__DynamicOptionId__c',
-                'Name',
-              ],
-            },
-            {
-              objectsRegex: 'SBQQ__LineColumn__c',
-              idFields: [
-                '##allMasterDetailFields##',
-                'SBQQ__FieldName__c',
-                'Name',
-              ],
-            },
-            {
-              objectsRegex: 'SBQQ__LookupQuery__c',
-              idFields: [
-                '##allMasterDetailFields##',
-                'SBQQ__PriceRule2__c',
-                'Name',
-              ],
-            },
-            {
-              objectsRegex: 'SBQQ__TemplateContent__c',
-              idFields: [
-                '##allMasterDetailFields##',
-                'SBQQ__Type__c',
-                'Name',
-              ],
-            },
-            {
-              objectsRegex: 'SBQQ__Dimension__c',
-              idFields: [
-                '##allMasterDetailFields##',
-                'SBQQ__Product__c',
-                'Name',
-              ],
-            },
-            {
-              objectsRegex: 'PricebookEntry',
-              idFields: [
-                'Pricebook2Id',
-                'Name',
-              ],
-            },
-            {
-              objectsRegex: 'Product2',
-              idFields: [
-                'Name',
-                'ProductCode',
-                'Family',
-              ],
-            },
-            {
-              objectsRegex: 'sbaa__ApprovalRule__c',
-              idFields: [
-                'Name',
-                'sbaa__TargetObject__c',
-                'sbaa__ApprovalChain__c',
-                'sbaa__Approver__c',
-                'sbaa__ApproverField__c',
-              ],
-            },
-            {
-              objectsRegex: 'sbaa__Approver__c',
-              idFields: [
-                'Name',
-              ],
-            },
-            {
-              objectsRegex: 'sbaa__EmailTemplate__c',
-              idFields: [
-                'Name',
-                'sbaa__TemplateId__c',
-              ],
-            },
-            {
-              objectsRegex: 'sbaa__ApprovalCondition__c',
-              idFields: [
-                'sbaa__ApprovalRule__c',
-                'sbaa__Index__c',
-              ],
-            },
-            {
-              objectsRegex: 'sbaa__ApprovalChain__c',
-              idFields: [
-                'sbaa__TargetObject__c',
-                'Name',
-              ],
-            },
-            {
-              objectsRegex: 'sbaa__ApprovalVariable__c',
-              idFields: [
-                'sbaa__TargetObject__c',
-                'Name',
-              ],
-            },
-            {
-              objectsRegex: 'sbaa__TrackedField__c',
-              idFields: [
-                'sbaa__ApprovalRule__c',
-                'sbaa__RecordField__c',
-                'sbaa__TrackedField__c',
-                'sbaa__TrackedObject__c',
-                'sbaa__TrackingType__c',
-              ],
-            },
+            CUSTOM_OBJECT_ID_FIELD,
           ],
         },
       },


### PR DESCRIPTION
Changed the default config file of CPQ to rely on SF IDs instead of value-based IDs.

---

Although I've changed the default config for CPQ, I did not update any documentations. The documentations should be updated as part of [SALTO-4130](https://salto-io.atlassian.net/browse/SALTO-4130) after we officially support self-serve CPQ.

---
_Release Notes_: 
Salesforce Adapter:
- Changed the default config file of CPQ to rely on SF IDs instead of value-based IDs.

---
_User Notifications_: 
_None_


[SALTO-4130]: https://salto-io.atlassian.net/browse/SALTO-4130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ