### PR TITLE
SALTO-4027 - Salesforce: verify another user reference

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/unknown_users.ts
+++ b/packages/salesforce-adapter/src/change_validators/unknown_users.ts
@@ -14,7 +14,6 @@
 * limitations under the License.
 */
 import { collections } from '@salto-io/lowerdash'
-import { logger } from '@salto-io/logging'
 import {
   ChangeError, isAdditionOrModificationChange, isInstanceChange, ChangeValidator,
   InstanceElement, getChangeData, Values,
@@ -25,7 +24,6 @@ import { isInstanceOfType, buildSelectQueries, queryClient } from '../filters/ut
 import SalesforceClient from '../client/client'
 
 const { awu } = collections.asynciterable
-const log = logger(module)
 
 // cf. 'Statement Character Limit' in https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_select.htm
 const SALESFORCE_MAX_QUERY_LEN = 100000
@@ -65,7 +63,6 @@ const getUserDependingOnType = (typeField: string): GetUserField => (
   (instance: InstanceElement, userField: string) => {
     const type = instance.value[typeField]
     if (!type || type.toLocaleLowerCase() !== 'user') {
-      log.trace('%s is `%s`, not `user`. Skipping.', typeField, type)
       return []
     }
     return [instance.value[userField]]

--- a/packages/salesforce-adapter/src/change_validators/unknown_users.ts
+++ b/packages/salesforce-adapter/src/change_validators/unknown_users.ts
@@ -54,18 +54,6 @@ type MissingUser = {
   userName: string
 }
 
-const getCaseSettingsOwner: GetUserField = (instance, fieldName) => {
-  if (fieldName !== 'defaultCaseOwner') {
-    log.error(`Unexpected field name: ${fieldName}.`)
-    return []
-  }
-  if (instance.value.defaultCaseOwnerType !== 'User') {
-    log.debug('defaultCaseOwnerType is not User. Skipping.')
-    return []
-  }
-  return [instance.value.defaultCaseOwner]
-}
-
 const userFieldValue = (expectedFieldName: string): GetUserField => (
   (instance, fieldName) => {
     if (fieldName !== expectedFieldName) {
@@ -125,7 +113,7 @@ const USER_GETTERS: TypesWithUserFields = {
     },
     {
       field: 'defaultCaseOwner',
-      getter: (instance, fieldName) => getCaseSettingsOwner(instance, fieldName),
+      getter: getUserDependingOnType('defaultCaseOwnerType', 'User', 'defaultCaseOwner'),
     },
   ],
   FolderShare: [

--- a/packages/salesforce-adapter/test/change_validators/unknown_users.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/unknown_users.test.ts
@@ -15,11 +15,13 @@
 */
 import {
   BuiltinTypes,
-  Change, ChangeError,
+  Change,
+  ChangeError,
   ChangeValidator,
   ElemID,
   getChangeData,
-  InstanceElement, ObjectType,
+  InstanceElement,
+  ObjectType,
   toChange,
 } from '@salto-io/adapter-api'
 import mockAdapter from '../adapter'

--- a/packages/salesforce-adapter/test/change_validators/unknown_users.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/unknown_users.test.ts
@@ -19,7 +19,7 @@ import {
   ChangeValidator,
   ElemID,
   getChangeData,
-  InstanceElement,
+  InstanceElement, ObjectType,
   toChange,
 } from '@salto-io/adapter-api'
 import mockAdapter from '../adapter'
@@ -96,18 +96,40 @@ describe('unknown user change validator', () => {
       expect(changeErrors).toBeEmpty()
     })
   })
-  describe('when the username is in a FolderShare instance', () => {
+  describe('when the username should be retrieved depending on a type field', () => {
     let change: Change
+    const instanceElementWithTypeAndUser = (
+      type: ObjectType,
+      userField: string,
+      typeField: string,
+    ): InstanceElement => createInstanceElement({
+      fullName: 'someFullName',
+      [userField]: IRRELEVANT_USERNAME,
+      [typeField]: 'User',
+    }, type)
 
-    describe('when the username exists', () => {
+    describe.each([
+      {
+        type: mockTypes.FolderShare,
+        userField: 'sharedTo',
+        typeField: 'sharedToType',
+      },
+      {
+        type: mockTypes.WorkflowTask,
+        userField: 'assignedTo',
+        typeField: 'assignedToType',
+      },
+      {
+        type: mockTypes.CaseSettings,
+        userField: 'defaultCaseOwner',
+        typeField: 'defaultCaseOwnerType',
+      },
+    ])('when the username exists [$type.elemID.typeName]', ({ type, userField, typeField }) => {
       beforeEach(() => {
-        const beforeRecord = createInstanceElement({
-          fullName: 'someName',
-          sharedTo: IRRELEVANT_USERNAME,
-          sharedToType: 'User',
-        }, mockTypes.FolderShare)
-        const afterRecord = beforeRecord.clone()
-        afterRecord.value.sharedTo = TEST_USERNAME
+        const instanceElement = instanceElementWithTypeAndUser(type, userField, typeField)
+        const beforeRecord = instanceElement
+        const afterRecord = instanceElement.clone()
+        afterRecord.value[userField] = TEST_USERNAME
         change = toChange({ before: beforeRecord, after: afterRecord })
 
         setupClientMock([TEST_USERNAME])
@@ -118,22 +140,67 @@ describe('unknown user change validator', () => {
         expect(changeErrors).toBeEmpty()
       })
     })
-    describe('when the username doesn\'t exist but sharedToType is not \'User\'', () => {
+    describe.each([
+      {
+        type: mockTypes.FolderShare,
+        userField: 'sharedTo',
+        typeField: 'sharedToType',
+      },
+      {
+        type: mockTypes.WorkflowTask,
+        userField: 'assignedTo',
+        typeField: 'assignedToType',
+      },
+      {
+        type: mockTypes.CaseSettings,
+        userField: 'defaultCaseOwner',
+        typeField: 'defaultCaseOwnerType',
+      },
+    ])('when the username doesn\'t exist but type is not \'User\' [$type.elemID.typeName]', ({ type, userField, typeField }) => {
       beforeEach(() => {
-        const beforeRecord = createInstanceElement({
-          fullName: 'someName',
-          sharedTo: IRRELEVANT_USERNAME,
-          sharedToType: 'Role',
-        }, mockTypes.FolderShare)
-        const afterRecord = beforeRecord.clone()
-        afterRecord.value.sharedTo = TEST_USERNAME
+        const instanceElement = instanceElementWithTypeAndUser(type, userField, typeField)
+        const beforeRecord = instanceElement
+        const afterRecord = instanceElement.clone()
+        afterRecord.value[typeField] = 'Role'
+        afterRecord.value[userField] = TEST_USERNAME
         change = toChange({ before: beforeRecord, after: afterRecord })
 
         setupClientMock([])
       })
-      it('should pass validation', async () => {
+      it('should also pass validation', async () => {
         const changeErrors = await validator([change])
         expect(changeErrors).toBeEmpty()
+      })
+    })
+    describe.each([
+      {
+        type: mockTypes.FolderShare,
+        userField: 'sharedTo',
+        typeField: 'sharedToType',
+      },
+      {
+        type: mockTypes.WorkflowTask,
+        userField: 'assignedTo',
+        typeField: 'assignedToType',
+      },
+      {
+        type: mockTypes.CaseSettings,
+        userField: 'defaultCaseOwner',
+        typeField: 'defaultCaseOwnerType',
+      },
+    ])('when the username doesn\'t exist [$type.elemID.typeName]', ({ type, userField, typeField }) => {
+      beforeEach(() => {
+        const instanceElement = instanceElementWithTypeAndUser(type, userField, typeField)
+        const beforeRecord = instanceElement
+        const afterRecord = instanceElement.clone()
+        afterRecord.value[userField] = TEST_USERNAME
+        change = toChange({ before: beforeRecord, after: afterRecord })
+
+        setupClientMock([])
+      })
+      it('should fail validation', async () => {
+        const changeErrors = await validator([change])
+        expect(changeErrors[0].elemID).toEqual(getChangeData(change).elemID)
       })
     })
   })

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -29,7 +29,7 @@ import {
   CPQ_QUOTE,
   DUPLICATE_RULE_METADATA_TYPE,
   INSTALLED_PACKAGE_METADATA,
-  PATH_ASSISTANT_METADATA_TYPE,
+  PATH_ASSISTANT_METADATA_TYPE, WORKFLOW_TASK_METADATA_TYPE,
 } from '../src/constants'
 import { createInstanceElement, createMetadataObjectType } from '../src/transformers/transformer'
 import { allMissingSubTypes } from '../src/transformers/salesforce_types'
@@ -149,6 +149,13 @@ export const mockTypes = {
         )),
       }),
     ),
+  }),
+  WorkflowTask: createMetadataObjectType({
+    annotations: {
+      metadataType: WORKFLOW_TASK_METADATA_TYPE,
+      dirName: 'workflows',
+      suffix: 'workflow',
+    },
   }),
   TestSettings: createMetadataObjectType({
     annotations: {

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -29,7 +29,8 @@ import {
   CPQ_QUOTE,
   DUPLICATE_RULE_METADATA_TYPE,
   INSTALLED_PACKAGE_METADATA,
-  PATH_ASSISTANT_METADATA_TYPE, WORKFLOW_TASK_METADATA_TYPE,
+  PATH_ASSISTANT_METADATA_TYPE,
+  WORKFLOW_TASK_METADATA_TYPE,
 } from '../src/constants'
 import { createInstanceElement, createMetadataObjectType } from '../src/transformers/transformer'
 import { allMissingSubTypes } from '../src/transformers/salesforce_types'


### PR DESCRIPTION
Another field with a user ID we can validate

---

The logic here is similar to `FolderShare.sharedTo`, so I merged the logic of the two fields into a single function

---
_Release Notes_: 
Salesforce: The user referenced in WorkflowTask.assignedTo is now verified

---
_User Notifications_: 
N/A
