### PR TITLE
SALTO-4133: Failed on null values in scripts

### DIFF
--- a/packages/jira-adapter/src/filters/script_runner/script_template_expressions.ts
+++ b/packages/jira-adapter/src/filters/script_runner/script_template_expressions.ts
@@ -63,7 +63,9 @@ const referenceCustomFields = (script: string, fieldInstancesById: Map<string, I
 
 export const addTemplateReferences = (fieldInstancesById: Map<string, InstanceElement>)
   : referenceFunc => (value: Value, fieldName: string): void => {
-  value[fieldName] = referenceCustomFields(value[fieldName], fieldInstancesById)
+  if (typeof value[fieldName] === 'string') {
+    value[fieldName] = referenceCustomFields(value[fieldName], fieldInstancesById)
+  }
 }
 
 // This filter is used to add and remove template expressions in scriptRunner scripts

--- a/packages/jira-adapter/src/filters/script_runner/workflow/walk_on_scripts.ts
+++ b/packages/jira-adapter/src/filters/script_runner/workflow/walk_on_scripts.ts
@@ -27,16 +27,16 @@ const SCRIPT_CLOUD_FIELDS = ['expression', 'additionalCode', 'emailCode', 'condi
 export type referenceFunc = (value: Value, fieldName: string) => void
 
 const isCloudScriptRunnerItem = (value: Value): boolean =>
-  SCRIPT_RUNNER_CLOUD_TYPES.includes(value.type) && value.configuration.scriptRunner !== undefined
+  SCRIPT_RUNNER_CLOUD_TYPES.includes(value.type) && value.configuration?.scriptRunner != null
 
 const walkOnCloudScripts = (func: (value: string, fieldName: string) => void)
   : WalkOnFunc => ({ value }): WALK_NEXT_STEP => {
-  if (value === undefined) {
+  if (value == null) {
     return WALK_NEXT_STEP.SKIP
   }
   if (isCloudScriptRunnerItem(value)) {
     SCRIPT_CLOUD_FIELDS.forEach(fieldName => {
-      if (value.configuration.scriptRunner[fieldName] !== undefined) {
+      if (value.configuration.scriptRunner[fieldName] != null) {
         func(value.configuration.scriptRunner, fieldName)
       }
     })
@@ -46,16 +46,16 @@ const walkOnCloudScripts = (func: (value: string, fieldName: string) => void)
 }
 
 const isDCScriptRunnerItem = (value: Value): boolean =>
-  SCRIPT_RUNNER_DC_TYPES.includes(value.type) && value.configuration !== undefined
+  SCRIPT_RUNNER_DC_TYPES.includes(value.type) && value.configuration != null
 
 const walkOnDcScripts = (func: referenceFunc)
   : WalkOnFunc => ({ value }): WALK_NEXT_STEP => {
-  if (value === undefined) {
+  if (value == null) {
     return WALK_NEXT_STEP.SKIP
   }
   if (isDCScriptRunnerItem(value)) {
     SCRIPT_DC_FIELDS.forEach(fieldName => {
-      if (value.configuration[fieldName]?.script !== undefined) {
+      if (value.configuration[fieldName]?.script != null) {
         func(value.configuration[fieldName], 'script')
       }
     })

--- a/packages/jira-adapter/test/filters/script_runner/script_template_expressions.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/script_template_expressions.test.ts
@@ -171,6 +171,19 @@ describe('workflow_script_references', () => {
       await filter.onFetch(elements)
       checkValues(elements[0])
     })
+    it('fetch should not fail if a script is null', async () => {
+      const elements = [instance, ...fields]
+      elements[0].value.transitions[0].rules.postFunctions[0].configuration.scriptRunner.expression = null
+      await filter.onFetch(elements)
+      expect(elements[0].value.transitions[0].rules.postFunctions[0].configuration.scriptRunner.expression)
+        .toBeNull()
+    })
+    it('fetch should not fail if a scriptRunner object is null', async () => {
+      const elements = [instance, ...fields]
+      elements[0].value.transitions[0].rules.postFunctions[0].configuration.scriptRunner = null
+      await filter.onFetch(elements)
+      expect(elements[0].value.transitions[0].rules.postFunctions[0].configuration.scriptRunner).toBeNull()
+    })
     it('pre-deploy should not remove references when script runner is disabled', async () => {
       await filter.onFetch([instance, ...fields])
       await filterOff.preDeploy([toChange({ after: instance })])
@@ -290,6 +303,19 @@ describe('workflow_script_references', () => {
       const elements = [instance, ...fields]
       await filter.onFetch(elements)
       checkDcValues(elements[0])
+    })
+    it('fetch should not fail if a script is null', async () => {
+      const elements = [instance, ...fields]
+      elements[0].value.transitions[0].rules.postFunctions[0].configuration.FIELD_CONDITION = null
+      await filter.onFetch(elements)
+      expect(elements[0].value.transitions[0].rules.postFunctions[0].configuration.FIELD_CONDITION)
+        .toBeNull()
+    })
+    it('fetch should not fail if a scriptRunner object is null', async () => {
+      const elements = [instance, ...fields]
+      elements[0].value.transitions[0].rules.postFunctions[0].configuration = null
+      await filter.onFetch(elements)
+      expect(elements[0].value.transitions[0].rules.postFunctions[0].configuration).toBeNull()
     })
     it('pre-deploy should not remove references when script runner is disabled', async () => {
       await filter.onFetch([instance, ...fields])


### PR DESCRIPTION
If a script field of scriptrunner is null the fetch fails. Added to the undefined checks also null checks

---
_Release Notes_: 
Jira Adatper:
* Fixed a bug that caused null scripts in scriptrunner to fail the fetch

---
_User Notifications_: 
None