### PR TITLE
SALTO-4067: Consolidate FieldConfigurationItem into FieldConfiguration

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/cloud/fieldConfiguration.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/fieldConfiguration.ts
@@ -13,22 +13,18 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Values, Element, ElemID } from '@salto-io/adapter-api'
-import { createReference } from '../../utils'
-import { JIRA } from '../../../src/constants'
+import { Values } from '@salto-io/adapter-api'
 
 export const createFieldConfigurationValues = (
   name: string,
 ): Values => ({
   name,
   description: name,
-})
-
-export const createFieldConfigurationItemValues = (
-  allElements: Element[],
-): Values => ({
-  id: createReference(new ElemID(JIRA, 'Field', 'instance', 'Assignee__user'), allElements),
-  description: 'For example operating system, software platform and/or hardware specifications (include as appropriate for the issue).',
-  isHidden: false,
-  isRequired: false,
+  fields: {
+    Assignee__user: {
+      description: 'For example operating system, software platform and/or hardware specifications (include as appropriate for the issue).',
+      isHidden: false,
+      isRequired: false,
+    },
+  },
 })

--- a/packages/jira-adapter/e2e_test/instances/cloud/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/index.ts
@@ -21,7 +21,7 @@ import { createIssueTypeSchemeValues } from './issueTypeScheme'
 import { createDashboardValues, createGadget1Values, createGadget2Values } from './dashboard'
 import { findType } from '../../utils'
 import { createWorkflowValues } from './workflow'
-import { createFieldConfigurationItemValues, createFieldConfigurationValues } from './fieldConfiguration'
+import { createFieldConfigurationValues } from './fieldConfiguration'
 import { createNotificationSchemeValues } from './notificationScheme'
 import { createAutomationValues } from './automation'
 import { createKanbanBoardValues, createScrumBoardValues } from './board'
@@ -67,18 +67,6 @@ export const createInstances = (randomString: string, fetchedElements: Element[]
     randomString,
     findType('FieldConfiguration', fetchedElements),
     createFieldConfigurationValues(randomString),
-  )
-
-  const fieldConfigurationItem = new InstanceElement(
-    `${randomString}_Assignee__user`,
-    findType('FieldConfigurationItem', fetchedElements),
-    createFieldConfigurationItemValues(fetchedElements),
-    undefined,
-    {
-      [CORE_ANNOTATIONS.PARENT]: [
-        new ReferenceExpression(fieldConfiguration.elemID, fieldConfiguration),
-      ],
-    }
   )
 
   const securityLevel = new InstanceElement(
@@ -135,7 +123,6 @@ export const createInstances = (randomString: string, fetchedElements: Element[]
     [issueTypeScheme],
     [workflow],
     [fieldConfiguration],
-    [fieldConfigurationItem],
     [securityScheme, securityLevel],
     [notificationScheme],
     [automation],

--- a/packages/jira-adapter/e2e_test/instances/datacenter/fieldConfiguration.ts
+++ b/packages/jira-adapter/e2e_test/instances/datacenter/fieldConfiguration.ts
@@ -13,23 +13,19 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Values, Element, ElemID } from '@salto-io/adapter-api'
-import { createReference } from '../../utils'
-import { JIRA } from '../../../src/constants'
+import { Values } from '@salto-io/adapter-api'
 
 export const createFieldConfigurationValues = (
   name: string,
 ): Values => ({
   name,
   description: name,
-})
-
-export const createFieldConfigurationItemValues = (
-  allElements: Element[],
-): Values => ({
-  id: createReference(new ElemID(JIRA, 'Field', 'instance', 'Component_s__array@duu'), allElements),
-  description: 'For example operating system, software platform and/or hardware specifications (include as appropriate for the issue).',
-  renderer: 'frother-control-renderer',
-  isHidden: false,
-  isRequired: false,
+  fields: {
+    'Component_s__array@duu': {
+      description: 'For example operating system, software platform and/or hardware specifications (include as appropriate for the issue).',
+      renderer: 'frother-control-renderer',
+      isHidden: false,
+      isRequired: false,
+    },
+  },
 })

--- a/packages/jira-adapter/e2e_test/instances/datacenter/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/datacenter/index.ts
@@ -13,12 +13,12 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { InstanceElement, Element, ReferenceExpression, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
+import { InstanceElement, Element } from '@salto-io/adapter-api'
 import { AUTOMATION_TYPE, PRIORITY_SCHEME_TYPE_NAME, WORKFLOW_TYPE_NAME } from '../../../src/constants'
 import { findType } from '../../utils'
 import { createAutomationValues } from './automation'
 import { createKanbanBoardValues, createScrumBoardValues } from './board'
-import { createFieldConfigurationItemValues, createFieldConfigurationValues } from './fieldConfiguration'
+import { createFieldConfigurationValues } from './fieldConfiguration'
 import { createFilterValues } from './filter'
 import { createPrioritySchemeValues } from './priorityScheme'
 import { createWorkflowValues } from './workflow'
@@ -28,18 +28,6 @@ export const createInstances = (randomString: string, fetchedElements: Element[]
     randomString,
     findType('FieldConfiguration', fetchedElements),
     createFieldConfigurationValues(randomString),
-  )
-
-  const fieldConfigurationItem = new InstanceElement(
-    `${randomString}_Component_s__array_duu@uuuum`,
-    findType('FieldConfigurationItem', fetchedElements),
-    createFieldConfigurationItemValues(fetchedElements),
-    undefined,
-    {
-      [CORE_ANNOTATIONS.PARENT]: [
-        new ReferenceExpression(fieldConfiguration.elemID, fieldConfiguration),
-      ],
-    }
   )
 
   const automation = new InstanceElement(
@@ -80,7 +68,6 @@ export const createInstances = (randomString: string, fetchedElements: Element[]
 
   return [
     [fieldConfiguration],
-    [fieldConfigurationItem],
     [automation],
     [workflow],
     [kanbanBoard],

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -51,6 +51,8 @@ import fieldConfigurationSplitFilter from './filters/field_configuration/field_c
 import fieldConfigurationItemsFilter from './filters/field_configuration/field_configuration_items'
 import missingFieldDescriptionsFilter from './filters/field_configuration/missing_field_descriptions'
 import fieldConfigurationDependenciesFilter from './filters/field_configuration/field_configuration_dependencies'
+import replaceFieldConfigurationReferences from './filters/field_configuration/replace_field_configuration_references'
+import fieldConfigurationDeployment from './filters/field_configuration/field_configuration_deployment'
 import missingDescriptionsFilter from './filters/missing_descriptions'
 import fieldConfigurationSchemeFilter from './filters/field_configurations_scheme'
 import dashboardFilter from './filters/dashboard/dashboard_deployment'
@@ -231,6 +233,9 @@ export const DEFAULT_FILTERS = [
   fieldConfigurationIrrelevantFields,
   // Must run after fieldConfigurationIrrelevantFields
   fieldConfigurationSplitFilter,
+  // Must run after fieldReferencesFilter
+  replaceFieldConfigurationReferences,
+  fieldConfigurationDeployment,
   // Must run after fieldConfigurationSplitFilter
   fieldConfigurationDependenciesFilter,
   missingFieldDescriptionsFilter,

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -54,6 +54,7 @@ import { issueTypeSchemeMigrationValidator } from './issue_type_scheme_migration
 import { issueTypeDeletionValidator } from './issue_type_deletion'
 import { projectCategoryValidator } from './project_category'
 import { circularTransitionsValidator } from './workflows/circular_transitions'
+import { unresolvedFieldConfigurationItemsValidator } from './unresolved_field_configuration_items'
 
 const {
   deployTypesNotSupportedValidator,
@@ -103,6 +104,7 @@ export default (
     permissionSchemeDeploymentValidator(client),
     projectCategoryValidator(client),
     circularTransitionsValidator,
+    unresolvedFieldConfigurationItemsValidator,
   ]
 
   return createChangeValidator(validators)

--- a/packages/jira-adapter/src/change_validators/unresolved_field_configuration_items.ts
+++ b/packages/jira-adapter/src/change_validators/unresolved_field_configuration_items.ts
@@ -1,0 +1,51 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ChangeValidator, ElemID, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, ReadOnlyElementsSource, SeverityLevel } from '@salto-io/adapter-api'
+import { collections, values } from '@salto-io/lowerdash'
+import { FIELD_CONFIGURATION_TYPE_NAME, JIRA } from '../constants'
+import { FIELD_TYPE_NAME } from '../filters/fields/constants'
+
+const { awu } = collections.asynciterable
+
+const getUnresolvedFieldConfigurationItems = async (
+  instance: InstanceElement,
+  elementsSource: ReadOnlyElementsSource
+): Promise<string[]> => awu(Object.keys(instance.value.fields ?? {}))
+  .filter(async fieldName => !(await elementsSource.has(new ElemID(JIRA, FIELD_TYPE_NAME, 'instance', fieldName))))
+  .toArray()
+
+export const unresolvedFieldConfigurationItemsValidator: ChangeValidator = async (changes, elementsSource) => {
+  if (elementsSource === undefined) {
+    return []
+  }
+
+  return awu(changes)
+    .filter(isInstanceChange)
+    .filter(isAdditionOrModificationChange)
+    .filter(change => getChangeData(change).elemID.typeName === FIELD_CONFIGURATION_TYPE_NAME)
+    .map(getChangeData)
+    .map(async instance => {
+      const unresolvedFields = await getUnresolvedFieldConfigurationItems(instance, elementsSource)
+      return unresolvedFields.length > 0 ? {
+        elemID: instance.elemID,
+        severity: 'Warning' as SeverityLevel,
+        message: 'Field configuration has configuration about fields that do not exist in the account',
+        detailedMessage: `The following fields configuration items will not be deployed since their fields do not exist in the account: ${unresolvedFields.join(', ')}`,
+      } : undefined
+    })
+    .filter(values.isDefined)
+    .toArray()
+}

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -61,6 +61,7 @@ type JiraFetchConfig = configUtils.UserFetchConfig<JiraFetchFilters> & {
   parseTemplateExpressions?: boolean
   enableScriptRunnerAddon?: boolean
   addAlias?: boolean
+  splitFieldConfiguration?: boolean
 }
 
 export type MaskingConfig = {
@@ -197,6 +198,7 @@ const fetchConfigType = createUserFetchConfigType(
     // Default is true
     parseTemplateExpressions: { refType: BuiltinTypes.BOOLEAN },
     addAlias: { refType: BuiltinTypes.BOOLEAN },
+    splitFieldConfiguration: { refType: BuiltinTypes.BOOLEAN },
   },
   fetchFiltersType,
 )

--- a/packages/jira-adapter/src/dependency_changers/field_configuration.ts
+++ b/packages/jira-adapter/src/dependency_changers/field_configuration.ts
@@ -1,0 +1,76 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { dependencyChange, DependencyChanger, getChangeData, isAdditionChange, isAdditionOrModificationChange, isInstanceChange, isInstanceElement, isRemovalChange } from '@salto-io/adapter-api'
+import { values } from '@salto-io/lowerdash'
+import _ from 'lodash'
+import { FIELD_CONFIGURATION_TYPE_NAME } from '../constants'
+import { FIELD_TYPE_NAME } from '../filters/fields/constants'
+
+export const fieldConfigurationDependencyChanger: DependencyChanger = async changes => {
+  const fieldConfigChanges = Array.from(changes.entries())
+    .map(([key, change]) => ({ key, change }))
+    .filter(
+      change =>
+        isInstanceChange(change.change)
+        && isAdditionOrModificationChange(change.change)
+        && getChangeData(change.change).elemID.typeName === FIELD_CONFIGURATION_TYPE_NAME
+    )
+
+  const fieldAdditionChanges = _(Array.from(changes.entries()))
+    .map(([key, change]) => ({ key, change }))
+    .filter(change =>
+      isAdditionChange(change.change)
+      && getChangeData(change.change).elemID.typeName === FIELD_TYPE_NAME)
+    .keyBy(change => getChangeData(change.change).elemID.name)
+    .value()
+
+  const fieldRemovalChanges = _(Array.from(changes.entries()))
+    .map(([key, change]) => ({ key, change }))
+    .filter(change =>
+      isInstanceChange(change.change)
+      && isRemovalChange(change.change)
+      && getChangeData(change.change).elemID.typeName === FIELD_TYPE_NAME)
+    .keyBy(change => getChangeData(change.change).elemID.name)
+    .value()
+
+  return fieldConfigChanges
+    .flatMap(fieldConfigChange => {
+      const fieldConfigInstance = getChangeData(fieldConfigChange.change)
+      if (!isInstanceElement(fieldConfigInstance) || _.isEmpty(fieldConfigInstance.value.fields)) {
+        return []
+      }
+
+      const additionDeps = Object.keys(fieldConfigInstance.value.fields)
+        .map(key => fieldAdditionChanges[key])
+        .filter(values.isDefined)
+        .map(additionChange => dependencyChange(
+          'add',
+          fieldConfigChange.key,
+          additionChange.key
+        ))
+
+      const removalDeps = Object.keys(fieldConfigInstance.value.fields)
+        .map(key => fieldRemovalChanges[key])
+        .filter(values.isDefined)
+        .map(removalChange => dependencyChange(
+          'add',
+          removalChange.key,
+          fieldConfigChange.key,
+        ))
+
+      return additionDeps.concat(removalDeps)
+    })
+}

--- a/packages/jira-adapter/src/dependency_changers/index.ts
+++ b/packages/jira-adapter/src/dependency_changers/index.ts
@@ -23,6 +23,7 @@ import { projectContextsDependencyChanger } from './project_contexts'
 import { removalsDependencyChanger } from './removals'
 import { workflowDependencyChanger } from './workflow'
 import { fieldContextDependencyChanger } from './field_contexts'
+import { fieldConfigurationDependencyChanger } from './field_configuration'
 
 const { awu } = collections.asynciterable
 
@@ -35,6 +36,7 @@ const DEPENDENCY_CHANGERS: DependencyChanger[] = [
   globalFieldContextsDependencyChanger,
   projectContextsDependencyChanger,
   fieldContextDependencyChanger,
+  fieldConfigurationDependencyChanger,
 ]
 
 export const dependencyChanger: DependencyChanger = async (

--- a/packages/jira-adapter/src/filters/field_configuration/field_configuration_deployment.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/field_configuration_deployment.ts
@@ -1,0 +1,98 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Change, getChangeData, InstanceElement, isInstanceChange, isModificationChange, isReferenceExpression, isRemovalChange, Values } from '@salto-io/adapter-api'
+import { client as clientUtils } from '@salto-io/adapter-components'
+import _ from 'lodash'
+import { logger } from '@salto-io/logging'
+import { JiraConfig } from '../../config/config'
+import { FilterCreator } from '../../filter'
+import { defaultDeployChange, deployChanges } from '../../deployment/standard_deployment'
+
+const FIELD_CONFIGURATION_TYPE_NAME = 'FieldConfiguration'
+
+const log = logger(module)
+
+const deployFieldConfigurationItems = async (
+  change: Change<InstanceElement>,
+  client: clientUtils.HTTPWriteClientInterface,
+  config: JiraConfig
+): Promise<void> => {
+  const instance = getChangeData(change)
+  const fields = (instance.value.fields ?? [])
+    .filter((fieldConf: Values) => isReferenceExpression(fieldConf.id))
+    .map((fieldConf: Values) => ({ ...fieldConf, id: fieldConf.id.value.value.id }))
+
+  if (fields.length === 0) {
+    return
+  }
+
+  await Promise.all(
+    _.chunk(fields, config.client.fieldConfigurationItemsDeploymentLimit).map(async fieldsChunk =>
+      client.put({
+        url: `/rest/api/3/fieldconfiguration/${instance.value.id}/fields`,
+        data: {
+          fieldConfigurationItems: fieldsChunk,
+        },
+      }))
+  )
+}
+
+const filter: FilterCreator = ({ config, client }) => ({
+  name: 'fieldConfigurationDeployment',
+  deploy: async changes => {
+    if (config.fetch.splitFieldConfiguration) {
+      return {
+        leftoverChanges: changes,
+        deployResult: {
+          errors: [],
+          appliedChanges: [],
+        },
+      }
+    }
+
+    const [relevantChanges, leftoverChanges] = _.partition(
+      changes,
+      change => isInstanceChange(change)
+        && getChangeData(change).elemID.typeName === FIELD_CONFIGURATION_TYPE_NAME
+        && !isRemovalChange(change)
+    )
+
+
+    const deployResult = await deployChanges(
+      relevantChanges as Change<InstanceElement>[],
+      async change => {
+        if (getChangeData(change).value.isDefault && isModificationChange(change)) {
+          log.info(`Skipping default deploy for default ${FIELD_CONFIGURATION_TYPE_NAME} because it is not supported`)
+        } else {
+          await defaultDeployChange({
+            change,
+            client,
+            apiDefinitions: config.apiDefinitions,
+            fieldsToIgnore: ['fields'],
+          })
+        }
+        await deployFieldConfigurationItems(change, client, config)
+      }
+    )
+
+    return {
+      leftoverChanges,
+      deployResult,
+    }
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/src/filters/field_configuration/field_configuration_items.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/field_configuration_items.ts
@@ -56,6 +56,16 @@ const deployFieldConfigurationItems = async (
 const filter: FilterCreator = ({ client, config }) => ({
   name: 'fieldConfigurationItemsFilter',
   deploy: async changes => {
+    if (!config.fetch.splitFieldConfiguration) {
+      return {
+        leftoverChanges: changes,
+        deployResult: {
+          errors: [],
+          appliedChanges: [],
+        },
+      }
+    }
+
     const [relevantChanges, leftoverChanges] = _.partition(
       changes,
       change => isInstanceChange(change)

--- a/packages/jira-adapter/src/filters/field_configuration/field_configuration_split.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/field_configuration_split.ts
@@ -41,9 +41,13 @@ const createFieldItemInstance = (
   }
 )
 
-const filter: FilterCreator = () => ({
+const filter: FilterCreator = ({ config }) => ({
   name: 'fieldConfigurationSplitFilter',
   onFetch: async elements => {
+    if (!config.fetch.splitFieldConfiguration) {
+      return
+    }
+
     const fieldConfigurationType = findObject(elements, FIELD_CONFIGURATION_TYPE_NAME)
     const fieldConfigurationItemType = findObject(elements, FIELD_CONFIGURATION_ITEM_TYPE_NAME)
 

--- a/packages/jira-adapter/src/filters/field_configuration/replace_field_configuration_references.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/replace_field_configuration_references.ts
@@ -1,0 +1,121 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { CORE_ANNOTATIONS, ElemID, Field, getChangeData, InstanceElement, isInstanceElement, isReferenceExpression, MapType, ReadOnlyElementsSource, ReferenceExpression, Value, Values } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { collections, values } from '@salto-io/lowerdash'
+import { findObject } from '../../utils'
+import { FilterCreator } from '../../filter'
+import { FIELD_CONFIGURATION_TYPE_NAME, JIRA } from '../../constants'
+import { FIELD_TYPE_NAME } from '../fields/constants'
+
+const { awu } = collections.asynciterable
+
+const replaceToMap = (instance: InstanceElement): void => {
+  instance.value.fields = Object.fromEntries(instance.value.fields
+    .filter((field: Values) => isReferenceExpression(field.id))
+    .map((field: Values) => [
+      field.id.elemID.name,
+      _.omit(field, 'id'),
+    ]))
+}
+
+const replaceFromMap = async (
+  instance: InstanceElement,
+  elementSource: ReadOnlyElementsSource,
+): Promise<void> => {
+  instance.value.fields = await awu(Object.entries(instance.value.fields))
+    .map(async ([id, config]: [string, Value]) => {
+      const elemId = new ElemID(JIRA, FIELD_TYPE_NAME, 'instance', id)
+      const fieldInstance = await elementSource.get(elemId)
+      if (fieldInstance === undefined) {
+        return undefined
+      }
+      return {
+        id: new ReferenceExpression(elemId, fieldInstance),
+        ...config,
+      }
+    })
+    .filter(values.isDefined)
+    .toArray()
+}
+
+
+const filter: FilterCreator = ({ config, elementsSource }) => {
+  const instanceToFields: Record<string, Values> = {}
+  return {
+    name: 'replaceFieldConfigurationReferences',
+    onFetch: async elements => {
+      if (config.fetch.splitFieldConfiguration) {
+        return
+      }
+
+      const fieldConfigType = findObject(elements, FIELD_CONFIGURATION_TYPE_NAME)
+      if (fieldConfigType === undefined) {
+        return
+      }
+
+      fieldConfigType.fields.fields = new Field(
+        fieldConfigType,
+        'fields',
+        new MapType(fieldConfigType.fields.fields.refType),
+        {
+          [CORE_ANNOTATIONS.CREATABLE]: true,
+          [CORE_ANNOTATIONS.UPDATABLE]: true,
+        }
+      )
+
+      elements
+        .filter(isInstanceElement)
+        .filter(instance => instance.elemID.typeName === FIELD_CONFIGURATION_TYPE_NAME)
+        .filter(instance => Array.isArray(instance.value.fields))
+        .forEach(replaceToMap)
+    },
+
+    preDeploy: async changes => {
+      if (config.fetch.splitFieldConfiguration) {
+        return
+      }
+
+      await awu(changes)
+        .map(getChangeData)
+        .filter(isInstanceElement)
+        .filter(instance => instance.elemID.typeName === FIELD_CONFIGURATION_TYPE_NAME)
+        .filter(instance => instance.value.fields !== undefined)
+        .forEach(async instance => {
+          instanceToFields[instance.elemID.getFullName()] = instance.value.fields
+          await replaceFromMap(instance, elementsSource)
+        })
+    },
+
+    onDeploy: async changes => {
+      if (config.fetch.splitFieldConfiguration) {
+        return
+      }
+
+      changes
+        .map(getChangeData)
+        .filter(isInstanceElement)
+        .filter(instance => instance.elemID.typeName === FIELD_CONFIGURATION_TYPE_NAME)
+        .filter(instance => instance.value.fields !== undefined)
+        .forEach(instance => {
+          instance.value.fields = instanceToFields[instance.elemID.getFullName()]
+        })
+    },
+  }
+}
+
+export default filter

--- a/packages/jira-adapter/test/change_validators/unresolved_field_configuration_items.test.ts
+++ b/packages/jira-adapter/test/change_validators/unresolved_field_configuration_items.test.ts
@@ -1,0 +1,104 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { toChange, ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { unresolvedFieldConfigurationItemsValidator } from '../../src/change_validators/unresolved_field_configuration_items'
+import { FIELD_CONFIGURATION_TYPE_NAME, JIRA } from '../../src/constants'
+import { FIELD_TYPE_NAME } from '../../src/filters/fields/constants'
+
+describe('unresolvedFieldConfigurationItemsValidator', () => {
+  let type: ObjectType
+  let instance: InstanceElement
+  let fieldType: ObjectType
+  let fieldInstanceA: InstanceElement
+  let fieldInstanceB: InstanceElement
+  beforeEach(() => {
+    type = new ObjectType({ elemID: new ElemID(JIRA, FIELD_CONFIGURATION_TYPE_NAME) })
+    instance = new InstanceElement(
+      'instance',
+      type,
+      {
+        fields: {
+          a: {
+            isRequired: true,
+          },
+          b: {
+            isRequired: true,
+          },
+        },
+      }
+    )
+
+    fieldType = new ObjectType({ elemID: new ElemID(JIRA, FIELD_TYPE_NAME) })
+    fieldInstanceA = new InstanceElement(
+      'a',
+      fieldType,
+    )
+    fieldInstanceB = new InstanceElement(
+      'b',
+      fieldType,
+    )
+  })
+  it('should return a warning when field does not exist in element source', async () => {
+    const elementsSource = buildElementsSourceFromElements([
+      fieldInstanceA,
+    ])
+    expect(await unresolvedFieldConfigurationItemsValidator([
+      toChange({
+        after: instance,
+      }),
+    ], elementsSource)).toEqual([
+      {
+        elemID: instance.elemID,
+        severity: 'Warning',
+        message: 'Field configuration has configuration about fields that do not exist in the account',
+        detailedMessage: 'The following fields configuration items will not be deployed since their fields do not exist in the account: b',
+      },
+    ])
+  })
+
+  it('should not return a warning when there are no fields', async () => {
+    delete instance.value.fields
+    const elementsSource = buildElementsSourceFromElements([
+      fieldInstanceA,
+    ])
+    expect(await unresolvedFieldConfigurationItemsValidator([
+      toChange({
+        after: instance,
+      }),
+    ], elementsSource)).toEqual([])
+  })
+
+  it('should not return a warning when all fields exist in element source', async () => {
+    const elementsSource = buildElementsSourceFromElements([
+      fieldInstanceA,
+      fieldInstanceB,
+    ])
+    expect(await unresolvedFieldConfigurationItemsValidator([
+      toChange({
+        after: instance,
+      }),
+    ], elementsSource)).toEqual([])
+  })
+
+  it('should not return a warning when there is no element source', async () => {
+    expect(await unresolvedFieldConfigurationItemsValidator([
+      toChange({
+        after: instance,
+      }),
+    ])).toEqual([])
+  })
+})

--- a/packages/jira-adapter/test/dependency_changers/field_configuration.test.ts
+++ b/packages/jira-adapter/test/dependency_changers/field_configuration.test.ts
@@ -1,0 +1,100 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, InstanceElement, ElemID, toChange } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { fieldConfigurationDependencyChanger } from '../../src/dependency_changers/field_configuration'
+import { FIELD_CONFIGURATION_TYPE_NAME, JIRA } from '../../src/constants'
+import { FIELD_TYPE_NAME } from '../../src/filters/fields/constants'
+
+describe('fieldConfigurationDependencyChanger', () => {
+  let fieldType: ObjectType
+  let fieldInstance: InstanceElement
+
+  let fieldConfigurationType: ObjectType
+  let fieldConfigurationInstance: InstanceElement
+
+  beforeEach(() => {
+    fieldType = new ObjectType({
+      elemID: new ElemID(JIRA, FIELD_TYPE_NAME),
+    })
+    fieldInstance = new InstanceElement(
+      'fieldInst',
+      fieldType,
+    )
+    fieldConfigurationType = new ObjectType({
+      elemID: new ElemID(JIRA, FIELD_CONFIGURATION_TYPE_NAME),
+    })
+    fieldConfigurationInstance = new InstanceElement(
+      'fieldConfigInst',
+      fieldConfigurationType,
+      {
+        fields: {
+          [fieldInstance.elemID.name]: {
+            required: true,
+          },
+        },
+      }
+    )
+  })
+  it('should add a dependency between the field config and the field on field addition', async () => {
+    const inputChanges = new Map([
+      [0, toChange({ after: fieldInstance })],
+      [1, toChange({ after: fieldConfigurationInstance })],
+
+    ])
+    const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([])
+
+    const dependencyChanges = [
+      ...await fieldConfigurationDependencyChanger(inputChanges, inputDeps),
+    ]
+    expect(dependencyChanges).toHaveLength(1)
+    expect(dependencyChanges[0].action).toEqual('add')
+    expect(dependencyChanges[0].dependency.source).toEqual(1)
+    expect(dependencyChanges[0].dependency.target).toEqual(0)
+  })
+
+  it('should add a dependency between the field and the field config on field removal', async () => {
+    const inputChanges = new Map([
+      [0, toChange({ before: fieldInstance })],
+      [1, toChange({ after: fieldConfigurationInstance })],
+
+    ])
+    const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([])
+
+    const dependencyChanges = [
+      ...await fieldConfigurationDependencyChanger(inputChanges, inputDeps),
+    ]
+    expect(dependencyChanges).toHaveLength(1)
+    expect(dependencyChanges[0].action).toEqual('add')
+    expect(dependencyChanges[0].dependency.source).toEqual(0)
+    expect(dependencyChanges[0].dependency.target).toEqual(1)
+  })
+
+  it('should do nothing if field configuration does not have fields', async () => {
+    delete fieldConfigurationInstance.value.fields
+    const inputChanges = new Map([
+      [0, toChange({ after: fieldInstance })],
+      [1, toChange({ after: fieldConfigurationInstance })],
+
+    ])
+    const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([])
+
+    const dependencyChanges = [
+      ...await fieldConfigurationDependencyChanger(inputChanges, inputDeps),
+    ]
+    expect(dependencyChanges).toHaveLength(0)
+  })
+})

--- a/packages/jira-adapter/test/filters/field_configuration/field_configuration_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/field_configuration/field_configuration_deployment.test.ts
@@ -1,0 +1,149 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Change, ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { filterUtils, client as clientUtils, deployment } from '@salto-io/adapter-components'
+import { MockInterface } from '@salto-io/test-utils'
+import _ from 'lodash'
+import { JIRA } from '../../../src/constants'
+import fieldConfigurationDeploymentFilter from '../../../src/filters/field_configuration/field_configuration_deployment'
+import { JiraConfig, getDefaultConfig } from '../../../src/config/config'
+import { getFilterParams, mockClient } from '../../utils'
+
+const { deployChange } = deployment
+
+jest.mock('@salto-io/adapter-components', () => {
+  const actual = jest.requireActual('@salto-io/adapter-components')
+  return {
+    ...actual,
+    deployment: {
+      ...actual.deployment,
+      deployChange: jest.fn(),
+    },
+  }
+})
+
+describe('fieldConfigurationDeploymentFilter', () => {
+  let filter: filterUtils.FilterWith<'onFetch' | 'deploy'>
+  let fieldConfigurationType: ObjectType
+  let mockConnection: MockInterface<clientUtils.APIConnection>
+  let config: JiraConfig
+
+  beforeEach(async () => {
+    const { client, paginator, connection } = mockClient()
+    mockConnection = connection
+
+    config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+
+    filter = fieldConfigurationDeploymentFilter(getFilterParams({
+      client,
+      paginator,
+      config,
+    })) as typeof filter
+
+    fieldConfigurationType = new ObjectType({
+      elemID: new ElemID(JIRA, 'FieldConfiguration'),
+    })
+  })
+
+  describe('deploy', () => {
+    const supportedFields = _.range(0, 150).map(i => ({
+      id: new ReferenceExpression(
+        new ElemID(JIRA, 'Field', 'instance', `supported${i}`),
+        {
+          value: {
+            id: `supported${i}`,
+          },
+        }
+      ),
+    }))
+
+    let instance: InstanceElement
+    let change: Change<InstanceElement>
+
+    beforeEach(async () => {
+      (deployChange as jest.Mock).mockClear()
+      instance = new InstanceElement(
+        'instance',
+        fieldConfigurationType,
+        {
+          name: 'name',
+          id: 1,
+          fields: [
+            {
+              id: 'notSupported1',
+            },
+            ...supportedFields,
+          ],
+        }
+      )
+
+      const beforeInstance = instance.clone()
+      beforeInstance.value.description = 'before'
+
+      change = toChange({ before: beforeInstance, after: instance })
+    })
+
+    it('should deploy regular fields using deployChange in modification', async () => {
+      await filter.deploy([change])
+      expect(deployChange).toHaveBeenCalled()
+    })
+
+    it('should deploy regular fields using deployChange in creation', async () => {
+      await filter.deploy([toChange({ after: instance })])
+      expect(deployChange).toHaveBeenCalled()
+    })
+
+    it('should not deploy regular fields if is default and change is modification', async () => {
+      instance.value.isDefault = true
+      await filter.deploy([change])
+      expect(deployChange).not.toHaveBeenCalled()
+    })
+
+    it('should deploy supported fields configuration in chunks', async () => {
+      await filter.deploy([change])
+      expect(mockConnection.put).toHaveBeenCalledWith(
+        '/rest/api/3/fieldconfiguration/1/fields',
+        {
+          fieldConfigurationItems: supportedFields.slice(0, 100)
+            .map(field => ({ ...field, id: field.id.value.value.id })),
+        },
+        undefined,
+      )
+      expect(mockConnection.put).toHaveBeenCalledWith(
+        '/rest/api/3/fieldconfiguration/1/fields',
+        {
+          fieldConfigurationItems: supportedFields.slice(100, supportedFields.length)
+            .map(field => ({ ...field, id: field.id.value.value.id })),
+        },
+        undefined,
+      )
+    })
+
+    it('should not deploy fields configuration if empty', async () => {
+      delete instance.value.fields
+      await filter.deploy([change])
+      expect(mockConnection.put).not.toHaveBeenCalledWith()
+    })
+
+    it('should not deploy if splitFieldConfiguration is true', async () => {
+      config.fetch.splitFieldConfiguration = true
+      const res = await filter.deploy([change])
+      expect(res.deployResult.appliedChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.leftoverChanges).toHaveLength(1)
+    })
+  })
+})

--- a/packages/jira-adapter/test/filters/field_configuration/replace_field_configuration_references.test.ts
+++ b/packages/jira-adapter/test/filters/field_configuration/replace_field_configuration_references.test.ts
@@ -1,0 +1,161 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, MapType, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import _ from 'lodash'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { FIELD_CONFIGURATION_ITEM_TYPE_NAME, FIELD_CONFIGURATION_TYPE_NAME, JIRA } from '../../../src/constants'
+import replaceFieldConfigurationReferencesFilter from '../../../src/filters/field_configuration/replace_field_configuration_references'
+import { getDefaultConfig, JiraConfig } from '../../../src/config/config'
+import { FIELD_TYPE_NAME } from '../../../src/filters/fields/constants'
+
+import { getFilterParams } from '../../utils'
+
+describe('replaceFieldConfigurationReferencesFilter', () => {
+  let filter: filterUtils.FilterWith<'deploy'>
+  let fieldConfigType: ObjectType
+  let fieldConfigItemType: ObjectType
+  let fieldType: ObjectType
+  let instance: InstanceElement
+  let fieldInstance: InstanceElement
+  let config: JiraConfig
+
+  beforeEach(async () => {
+    config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+    config.fetch.splitFieldConfiguration = false
+
+    fieldConfigItemType = new ObjectType({
+      elemID: new ElemID(JIRA, FIELD_CONFIGURATION_ITEM_TYPE_NAME),
+    })
+
+    fieldConfigType = new ObjectType({
+      elemID: new ElemID(JIRA, FIELD_CONFIGURATION_TYPE_NAME),
+      fields: {
+        fields: {
+          refType: new MapType(fieldConfigItemType),
+        },
+      },
+    })
+
+    instance = new InstanceElement(
+      'instance',
+      fieldConfigType,
+      {
+        fields: [
+          {
+            id: new ReferenceExpression(
+              new ElemID(JIRA, FIELD_TYPE_NAME, 'instance', 'fieldInstance'),
+            ),
+            isRequired: true,
+          },
+        ],
+      },
+    )
+
+    fieldType = new ObjectType({
+      elemID: new ElemID(JIRA, FIELD_TYPE_NAME),
+    })
+
+    fieldInstance = new InstanceElement(
+      'fieldInstance',
+      fieldType,
+    )
+
+    const elementsSource = buildElementsSourceFromElements([fieldInstance])
+    filter = replaceFieldConfigurationReferencesFilter(getFilterParams({
+      config,
+      elementsSource,
+    })) as typeof filter
+  })
+
+  describe('fetch', () => {
+    it('should convert fields to a map', async () => {
+      await filter.onFetch?.([instance, fieldConfigType])
+      expect(instance.value.fields).toEqual({
+        fieldInstance: {
+          isRequired: true,
+        },
+      })
+    })
+
+    it('should do nothing if splitFieldConfiguration is true', async () => {
+      config.fetch.splitFieldConfiguration = true
+      await filter.onFetch?.([instance, fieldConfigType])
+      expect(instance.value.fields).toBeArray()
+    })
+  })
+
+  describe('preDeploy onDeploy', () => {
+    beforeEach(() => {
+      instance = new InstanceElement(
+        'instance',
+        fieldConfigType,
+        {
+          fields: {
+            fieldInstance: {
+              isRequired: true,
+            },
+          },
+        },
+      )
+    })
+    it('should convert fields to a list', async () => {
+      await filter.preDeploy?.([toChange({ after: instance })])
+      expect(instance.value.fields).toBeArrayOfSize(1)
+      await filter.onDeploy?.([toChange({ after: instance })])
+      expect(instance.value.fields).toEqual({
+        fieldInstance: {
+          isRequired: true,
+        },
+      })
+    })
+
+    it('should not add a field to the list if not in element source', async () => {
+      const elementsSource = buildElementsSourceFromElements([])
+      filter = replaceFieldConfigurationReferencesFilter(getFilterParams({
+        config,
+        elementsSource,
+      })) as typeof filter
+      await filter.preDeploy?.([toChange({ after: instance })])
+
+      expect(instance.value.fields).toBeArrayOfSize(0)
+
+      await filter.onDeploy?.([toChange({ after: instance })])
+      expect(instance.value.fields).toEqual({
+        fieldInstance: {
+          isRequired: true,
+        },
+      })
+    })
+
+    it('should do nothing if splitFieldConfiguration is true', async () => {
+      config.fetch.splitFieldConfiguration = true
+      await filter.preDeploy?.([toChange({ after: instance })])
+      expect(instance.value.fields).toEqual({
+        fieldInstance: {
+          isRequired: true,
+        },
+      })
+
+      await filter.onDeploy?.([toChange({ after: instance })])
+      expect(instance.value.fields).toEqual({
+        fieldInstance: {
+          isRequired: true,
+        },
+      })
+    })
+  })
+})


### PR DESCRIPTION
Combined all field configuration items to be part if the field configuration.
This is how the field configuration will look after this change:
```
jira.FieldConfiguration emptyConfig4 {
  name = "emptyConfig4"
  description = ""
  fields = {
    Approvers__multiuserpicker__c = {
      description = "Contains users needed for approval. This custom field was created by Jira Service Desk."
      isHidden = false
      isRequired = false
    }
    Impact__select__c = {
      description = ""
      isHidden = false
      isRequired = false
    }
...
}
```

---

In this PR there are:
- The filter that removes the references from the field configurations
- The dependency changer that adds dependency between the field configuration to its fields (since there aren't references and the dependency is not created automatically)
- A change validator that do a warning if a field is missing when deploying a field configuration with an item about the field

---
_Release Notes_: 
_Jira Adapter_:
- All field configuration items will now be a part of their field configuration instance

---
_User Notifications_: 
_Jira Adapter_:
- All field configuration items will now be a part of their field configuration instance
