### PR TITLE
SALTO-4147: Add logs for ScriptRunner failures

### DIFF
--- a/packages/adapter-utils/src/walk_element.ts
+++ b/packages/adapter-utils/src/walk_element.ts
@@ -84,7 +84,7 @@ export const walkOnValue = (
     if (e instanceof ExitWalk) {
       return
     }
-    log.error(`Failed to walk on element ${elemId.getFullName()}: ${e}`)
+    log.warn(`Failed to walk on element ${elemId.getFullName()}: ${e}`)
     throw e
   }
 }

--- a/packages/adapter-utils/src/walk_element.ts
+++ b/packages/adapter-utils/src/walk_element.ts
@@ -14,9 +14,12 @@
 * limitations under the License.
 */
 import _ from 'lodash'
+import { logger } from '@salto-io/logging'
 import {
   ElemID, Values, Value, isInstanceElement, isType, isObjectType, isElement, Element, isVariable,
 } from '@salto-io/adapter-api'
+
+const log = logger(module)
 
 export enum WALK_NEXT_STEP {
   RECURSE, // Continue with the recursion
@@ -81,6 +84,7 @@ export const walkOnValue = (
     if (e instanceof ExitWalk) {
       return
     }
+    log.error(`Failed to walk on element ${elemId.getFullName()}: ${e}`)
     throw e
   }
 }


### PR DESCRIPTION
Add try-catch so in case we get another typescript error we will know in which element it happened 

---

---
_Release Notes_: 
None

---
_User Notifications_: 
None
