### PR TITLE
SALTO-4085: prevent deploy of routing attribute value to happen in parallel

### DIFF
--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -135,6 +135,7 @@ import { isCurrentUserResponse } from './user_utils'
 import addAliasFilter from './filters/add_alias'
 import macroFilter from './filters/macro'
 import customRoleDeployFilter from './filters/custom_role_deploy'
+import routingAttributeValueDeployFilter from './filters/routing_attribute_value'
 
 const { makeArray } = collections.array
 const log = logger(module)
@@ -216,6 +217,7 @@ export const DEFAULT_FILTERS = [
   appOwnedConvertListToMapFilter,
   slaPolicyFilter,
   routingAttributeFilter,
+  routingAttributeValueDeployFilter,
   addFieldOptionsFilter,
   webhookFilter,
   targetFilter,

--- a/packages/zendesk-adapter/src/deployment.ts
+++ b/packages/zendesk-adapter/src/deployment.ts
@@ -166,7 +166,7 @@ export const deployChanges = async <T extends Change<ChangeDataType>>(
   return { errors, appliedChanges }
 }
 
-export const deployChangesSynchronously = async <T extends Change<ChangeDataType>>(
+export const deployChangesSequentially = async <T extends Change<ChangeDataType>>(
   changes: T[],
   deployChangeFunc: (change: T) => Promise<void | T[]>
 ): Promise<DeployResult> => {

--- a/packages/zendesk-adapter/src/deployment.ts
+++ b/packages/zendesk-adapter/src/deployment.ts
@@ -166,6 +166,26 @@ export const deployChanges = async <T extends Change<ChangeDataType>>(
   return { errors, appliedChanges }
 }
 
+export const deployChangesSynchronously = async <T extends Change<ChangeDataType>>(
+  changes: T[],
+  deployChangeFunc: (change: T) => Promise<void | T[]>
+): Promise<DeployResult> => {
+  const result = await awu(changes).map(async change => {
+    try {
+      const res = await deployChangeFunc(change)
+      return res !== undefined ? res : change
+    } catch (err) {
+      if (!_.isError(err)) {
+        throw err
+      }
+      return err
+    }
+  }).toArray()
+
+  const [errors, appliedChanges] = _.partition(result.flat(), _.isError)
+  return { errors, appliedChanges }
+}
+
 export const deployChangesByGroups = async <T extends Change<ChangeDataType>>(
   changeGroups: T[][],
   deployChangeFunc: (change: T) => Promise<void | T[]>

--- a/packages/zendesk-adapter/src/filters/routing_attribute_value.ts
+++ b/packages/zendesk-adapter/src/filters/routing_attribute_value.ts
@@ -1,0 +1,48 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import {
+  Change, getChangeData, InstanceElement,
+} from '@salto-io/adapter-api'
+import { FilterCreator } from '../filter'
+import { deployChange, deployChangesSynchronously } from '../deployment'
+import { ROUTING_ATTRIBUTE_VALUE_TYPE } from '../constants'
+
+
+/**
+ * Deploys routing attribute value one by one as zendesk does not support parallel deploy
+ */
+const filterCreator: FilterCreator = ({ config, client }) => ({
+  name: 'routingAttributeValueFilter',
+  deploy: async (changes: Change<InstanceElement>[]) => {
+    const [relevantChanges, leftoverChanges] = _.partition(
+      changes,
+      change =>
+        getChangeData(change).elemID.typeName === ROUTING_ATTRIBUTE_VALUE_TYPE,
+    )
+    const deployResult = await deployChangesSynchronously(
+      relevantChanges,
+      async change => {
+        await deployChange(
+          change, client, config.apiDefinitions, ['values'],
+        )
+      },
+    )
+    return { deployResult, leftoverChanges }
+  },
+})
+
+export default filterCreator

--- a/packages/zendesk-adapter/src/filters/routing_attribute_value.ts
+++ b/packages/zendesk-adapter/src/filters/routing_attribute_value.ts
@@ -37,7 +37,7 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
       relevantChanges,
       async change => {
         await deployChange(
-          change, client, config.apiDefinitions, ['values'],
+          change, client, config.apiDefinitions,
         )
       },
     )

--- a/packages/zendesk-adapter/src/filters/routing_attribute_value.ts
+++ b/packages/zendesk-adapter/src/filters/routing_attribute_value.ts
@@ -18,7 +18,7 @@ import {
   Change, getChangeData, InstanceElement,
 } from '@salto-io/adapter-api'
 import { FilterCreator } from '../filter'
-import { deployChange, deployChangesSynchronously } from '../deployment'
+import { deployChange, deployChangesSequentially } from '../deployment'
 import { ROUTING_ATTRIBUTE_VALUE_TYPE } from '../constants'
 
 
@@ -33,7 +33,7 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
       change =>
         getChangeData(change).elemID.typeName === ROUTING_ATTRIBUTE_VALUE_TYPE,
     )
-    const deployResult = await deployChangesSynchronously(
+    const deployResult = await deployChangesSequentially(
       relevantChanges,
       async change => {
         await deployChange(

--- a/packages/zendesk-adapter/test/deployment.test.ts
+++ b/packages/zendesk-adapter/test/deployment.test.ts
@@ -1,0 +1,70 @@
+
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+
+import { makeResolvablePromise, Resolvable } from '@salto-io/test-utils'
+
+import { Change, ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import { promises } from '@salto-io/lowerdash'
+import { ZENDESK } from '../src/constants'
+import { deployChangesSynchronously } from '../src/deployment'
+
+const { sleep } = promises.timeout
+const mockDeployChangeFunc = jest.fn()
+
+
+describe('deployChangesSynchronously', () => {
+  let p: Resolvable<number>
+  const routingAttribute1 = new InstanceElement(
+    'Test1',
+    new ObjectType({ elemID: new ElemID(ZENDESK, 'routing_attribute') }),
+    { name: 'Test', values: [] },
+  )
+  const routingAttribute2 = new InstanceElement(
+    'Test2',
+    new ObjectType({ elemID: new ElemID(ZENDESK, 'routing_attribute') }),
+    { name: 'Test', values: [] },
+  )
+
+  beforeEach(async () => {
+    p = makeResolvablePromise(0)
+    jest.clearAllMocks()
+    mockDeployChangeFunc.mockImplementation(async (_change: Change): Promise<void> => {
+      await p.promise
+    })
+  })
+  it('should work correctly', async () => {
+    const change1: Change = { action: 'add', data: { after: routingAttribute1 } }
+    const change2: Change = { action: 'add', data: { after: routingAttribute2 } }
+    const res = deployChangesSynchronously([change1, change2], mockDeployChangeFunc)
+    await sleep(1)
+    expect(mockDeployChangeFunc).toHaveBeenCalledTimes(1)
+    expect(mockDeployChangeFunc).toHaveBeenCalledWith({ action: 'add', data: { after: routingAttribute1 } })
+    p.resolve()
+    await p.promise
+    await sleep(1)
+    expect(mockDeployChangeFunc).toHaveBeenCalledTimes(2)
+    expect(mockDeployChangeFunc).toHaveBeenLastCalledWith({ action: 'add', data: { after: routingAttribute2 } })
+    expect(await res).toEqual({
+      appliedChanges: [
+        { action: 'add', data: { after: routingAttribute1 } },
+        { action: 'add', data: { after: routingAttribute2 } },
+      ],
+      errors: [],
+    })
+  })
+})

--- a/packages/zendesk-adapter/test/deployment.test.ts
+++ b/packages/zendesk-adapter/test/deployment.test.ts
@@ -21,13 +21,13 @@ import { makeResolvablePromise, Resolvable } from '@salto-io/test-utils'
 import { Change, ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
 import { promises } from '@salto-io/lowerdash'
 import { ZENDESK } from '../src/constants'
-import { deployChangesSynchronously } from '../src/deployment'
+import { deployChangesSequentially } from '../src/deployment'
 
 const { sleep } = promises.timeout
 const mockDeployChangeFunc = jest.fn()
 
 
-describe('deployChangesSynchronously', () => {
+describe('deployChangesSequentially', () => {
   let p: Resolvable<number>
   const routingAttribute1 = new InstanceElement(
     'Test1',
@@ -50,7 +50,7 @@ describe('deployChangesSynchronously', () => {
   it('should work correctly', async () => {
     const change1: Change = { action: 'add', data: { after: routingAttribute1 } }
     const change2: Change = { action: 'add', data: { after: routingAttribute2 } }
-    const res = deployChangesSynchronously([change1, change2], mockDeployChangeFunc)
+    const res = deployChangesSequentially([change1, change2], mockDeployChangeFunc)
     await sleep(1)
     expect(mockDeployChangeFunc).toHaveBeenCalledTimes(1)
     expect(mockDeployChangeFunc).toHaveBeenCalledWith({ action: 'add', data: { after: routingAttribute1 } })

--- a/packages/zendesk-adapter/test/filters/routing_attribute_value.test.ts
+++ b/packages/zendesk-adapter/test/filters/routing_attribute_value.test.ts
@@ -1,0 +1,86 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  ObjectType, ElemID, InstanceElement,
+} from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import { ROUTING_ATTRIBUTE_VALUE_TYPE, ZENDESK } from '../../src/constants'
+import filterCreator from '../../src/filters/routing_attribute_value'
+import { createFilterCreatorParams } from '../utils'
+
+const mockDeployChange = jest.fn()
+jest.mock('@salto-io/adapter-components', () => {
+  const actual = jest.requireActual('@salto-io/adapter-components')
+  return {
+    ...actual,
+    deployment: {
+      ...actual.deployment,
+      deployChange: jest.fn((...args) => mockDeployChange(...args)),
+    },
+  }
+})
+
+describe('routing attribute value filter', () => {
+  type FilterType = filterUtils.FilterWith<'deploy'>
+  let filter: FilterType
+  const routingAttributeValue = new InstanceElement(
+    'Test',
+    new ObjectType({ elemID: new ElemID(ZENDESK, ROUTING_ATTRIBUTE_VALUE_TYPE) }),
+    { name: 'Test', values: [] },
+  )
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
+  })
+
+  describe('deploy', () => {
+    it('should pass the correct params to deployChange', async () => {
+      const id = 2
+      const clonedAttributeValue = routingAttributeValue.clone()
+      mockDeployChange.mockImplementation(async () => ({ attribute: { id } }))
+      const res = await filter.deploy([{ action: 'add', data: { after: clonedAttributeValue } }])
+      expect(mockDeployChange).toHaveBeenCalledTimes(1)
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'add', data: { after: clonedAttributeValue } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+      })
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.deployResult.appliedChanges).toHaveLength(1)
+      expect(res.deployResult.appliedChanges)
+        .toEqual([{ action: 'add', data: { after: clonedAttributeValue } }])
+    })
+
+    it('should return error if deployChange failed', async () => {
+      const clonedAttributeValue = routingAttributeValue.clone()
+      mockDeployChange.mockImplementation(async () => {
+        throw new Error('err')
+      })
+      const res = await filter.deploy([{ action: 'add', data: { after: clonedAttributeValue } }])
+      expect(mockDeployChange).toHaveBeenCalledTimes(1)
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'add', data: { after: clonedAttributeValue } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+      })
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toHaveLength(1)
+      expect(res.deployResult.appliedChanges).toHaveLength(0)
+    })
+  })
+})


### PR DESCRIPTION
prevent deploy of routing attribute value to happen in parallel

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* Fix issue that prevented deploying multiple values under the same routing attribute

---
_User Notifications_: 
None
