### PR TITLE
SALTO-4141: Salesforce CustomObjects Aliases

### DIFF
--- a/packages/salesforce-adapter/src/filters/custom_metadata_to_object_type.ts
+++ b/packages/salesforce-adapter/src/filters/custom_metadata_to_object_type.ts
@@ -41,9 +41,14 @@ const { awu, groupByAsync } = collections.asynciterable
 const createCustomMetadataRecordType = async (
   instance: InstanceElement,
   customMetadataType: ObjectType,
+  skipAliases: boolean
 )
   : Promise<ObjectType> => {
-  const objectType = await createCustomTypeFromCustomObjectInstance({ instance, metadataType: CUSTOM_METADATA })
+  const objectType = await createCustomTypeFromCustomObjectInstance({
+    instance,
+    metadataType: CUSTOM_METADATA,
+    skipAliases,
+  })
   objectType.fields = {
     ...objectType.fields,
     // We omit the "values" field, since it will be destructed in the instances later.
@@ -84,7 +89,7 @@ const filterCreator: LocalFilterCreator = ({ config }) => {
         .filter(e => e.elemID.name.endsWith(CUSTOM_METADATA_SUFFIX))
 
       const customMetadataRecordTypes = await awu(customMetadataInstances)
-        .map(instance => createCustomMetadataRecordType(instance, customMetadataType))
+        .map(instance => createCustomMetadataRecordType(instance, customMetadataType, config.fetchProfile.isFeatureEnabled('skipAliases')))
         .toArray()
       _.pullAll(elements, customMetadataInstances)
       customMetadataRecordTypes.forEach(e => elements.push(e))

--- a/packages/salesforce-adapter/test/filters/custom_metadata_to_object_type.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_metadata_to_object_type.test.ts
@@ -24,7 +24,7 @@ import {
   Change,
   toChange,
   isInstanceChange,
-  Field, getChangeData,
+  Field, getChangeData, CORE_ANNOTATIONS,
 } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import filterCreator from '../../src/filters/custom_metadata_to_object_type'
@@ -42,6 +42,7 @@ import { mockTypes } from '../mock_elements'
 import { apiName, Types } from '../../src/transformers/transformer'
 import { isInstanceOfTypeChange } from '../../src/filters/utils'
 import { FilterWith } from './mocks'
+import { buildFetchProfile } from '../../src/fetch_profile/fetch_profile'
 
 const { awu } = collections.asynciterable
 
@@ -52,7 +53,12 @@ describe('customMetadataToObjectTypeFilter', () => {
   const CHECKBOX_FIELD_NAME = 'checkBox__c'
   const PICKLIST_FIELD_NAME = 'picklist__c'
   const filter = filterCreator({
-    config: defaultFilterContext,
+    config: {
+      ...defaultFilterContext,
+      fetchProfile: buildFetchProfile({
+        optionalFeatures: { skipAliases: false },
+      }),
+    },
   }) as FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
 
 
@@ -125,6 +131,7 @@ describe('customMetadataToObjectTypeFilter', () => {
         [API_NAME]: CUSTOM_METADATA_RECORD_TYPE_NAME,
         [LABEL]: CUSTOM_METADATA_RECORD_LABEL,
         [PLURAL_LABEL]: `${CUSTOM_METADATA_RECORD_LABEL}s`,
+        [CORE_ANNOTATIONS.ALIAS]: CUSTOM_METADATA_RECORD_LABEL,
       })
     })
     it('should create type with both the RecordType fields and CustomMetadata metadata type fields', () => {

--- a/packages/salesforce-adapter/test/filters/custom_objects_to_object_type.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects_to_object_type.test.ts
@@ -124,6 +124,9 @@ describe('Custom Objects to Object Type filter', () => {
       filter = filterCreator({
         config: {
           ...defaultFilterContext,
+          fetchProfile: buildFetchProfile({
+            optionalFeatures: { skipAliases: false },
+          }),
           unsupportedSystemFields: ['UnsupportedField'],
           systemFields: ['SystemField', 'NameSystemField'],
         },
@@ -135,6 +138,7 @@ describe('Custom Objects to Object Type filter', () => {
         customObjectType,
         {
           [INSTANCE_FULL_NAME_FIELD]: 'Case',
+          [LABEL]: 'Case',
           fields: [
             {
               [INSTANCE_FULL_NAME_FIELD]: 'ExtraSalt',
@@ -355,7 +359,7 @@ describe('Custom Objects to Object Type filter', () => {
         expect(field.refType.type).toBe(Types.primitiveDataTypes.Unknown)
       })
 
-      it('should fetch sobject with apiName and metadataType service ids', async () => {
+      it('should fetch sobject with correct annotations', async () => {
         await filter.onFetch(result)
         const caseObj = findElements(result, 'Case').pop() as ObjectType
         expect(isServiceId((await caseObj.getAnnotationTypes())[API_NAME]))
@@ -364,6 +368,12 @@ describe('Custom Objects to Object Type filter', () => {
           .toEqual(true)
         expect(caseObj.annotations[API_NAME]).toEqual('Case')
         expect(caseObj.annotations[METADATA_TYPE]).toEqual(CUSTOM_OBJECT)
+        expect(caseObj.annotations).toEqual(expect.objectContaining({
+          [API_NAME]: 'Case',
+          [METADATA_TYPE]: CUSTOM_OBJECT,
+          [LABEL]: 'Case',
+          [CORE_ANNOTATIONS.ALIAS]: 'Case',
+        }))
       })
 
       it('should keep internal annotations if they appear in a field', async () => {


### PR DESCRIPTION
Add Aliases to Salesforce CustomObjects.

---

Covers **CustomSettings**, **CustomMetadata types** and **CustomObjects**

Workspace diff: https://github.com/salto-io/tamir-sf/commit/dc123103190ddc96fc6ae019ef65a373cb2a722d

---
_Release Notes_: 
Salesforce Adapter:
- Added aliases to Salesforce Custom Objects. 

---
_User Notifications_: 
_None_
