### PR TITLE
SALTO-4067: Added fieldsToOmit to dummy adapter

### DIFF
--- a/packages/dummy-adapter/src/adapter.ts
+++ b/packages/dummy-adapter/src/adapter.ts
@@ -41,7 +41,7 @@ export default class DummyAdapter implements AdapterOperations {
       .map(getChangeData)
       .filter(isInstanceElement)
       .forEach(instance => {
-        instance.value = _.omit(instance.value, this.genParams.fieldsToOmit ?? [])
+        instance.value = _.omit(instance.value, this.genParams.fieldsToOmitOnDeploy ?? [])
       })
 
     return {

--- a/packages/dummy-adapter/src/adapter.ts
+++ b/packages/dummy-adapter/src/adapter.ts
@@ -15,8 +15,9 @@
 */
 import {
   FetchResult, AdapterOperations, DeployResult, FetchOptions,
-  DeployOptions, DeployModifiers,
+  DeployOptions, DeployModifiers, getChangeData, isInstanceElement,
 } from '@salto-io/adapter-api'
+import _ from 'lodash'
 import { generateElements, GeneratorParams } from './generator'
 import { changeValidator } from './change_validator'
 
@@ -36,6 +37,13 @@ export default class DummyAdapter implements AdapterOperations {
 
   // eslint-disable-next-line class-methods-use-this
   public async deploy({ changeGroup }: DeployOptions): Promise<DeployResult> {
+    changeGroup.changes
+      .map(getChangeData)
+      .filter(isInstanceElement)
+      .forEach(instance => {
+        instance.value = _.omit(instance.value, this.genParams.fieldsToOmit ?? [])
+      })
+
     return {
       appliedChanges: changeGroup.changes,
       errors: [],

--- a/packages/dummy-adapter/src/adapter_creator.ts
+++ b/packages/dummy-adapter/src/adapter_creator.ts
@@ -32,7 +32,7 @@ export const configType = new ObjectType({
     changeErrors: { refType: new ListType(changeErrorType) },
     extraNaclPath: { refType: BuiltinTypes.STRING },
     generateEnvName: { refType: BuiltinTypes.STRING },
-    fieldsToOmit: { refType: new ListType(BuiltinTypes.STRING) },
+    fieldsToOmitOnDeploy: { refType: new ListType(BuiltinTypes.STRING) },
   },
 })
 

--- a/packages/dummy-adapter/src/adapter_creator.ts
+++ b/packages/dummy-adapter/src/adapter_creator.ts
@@ -20,17 +20,20 @@ import { GeneratorParams, DUMMY_ADAPTER, defaultParams, changeErrorType } from '
 
 export const configType = new ObjectType({
   elemID: new ElemID(DUMMY_ADAPTER),
-  fields: { ..._.mapValues(defaultParams, defValue => ({
-    refType: _.isBoolean(defValue)
-      ? BuiltinTypes.BOOLEAN
-      : BuiltinTypes.NUMBER,
-    annotations: {
-      [CORE_ANNOTATIONS.DEFAULT]: defValue,
-    },
-  })),
-  changeErrors: { refType: new ListType(changeErrorType) },
-  extraNaclPath: { refType: BuiltinTypes.STRING },
-  generateEnvName: { refType: BuiltinTypes.STRING } },
+  fields: {
+    ..._.mapValues(defaultParams, defValue => ({
+      refType: _.isBoolean(defValue)
+        ? BuiltinTypes.BOOLEAN
+        : BuiltinTypes.NUMBER,
+      annotations: {
+        [CORE_ANNOTATIONS.DEFAULT]: defValue,
+      },
+    })),
+    changeErrors: { refType: new ListType(changeErrorType) },
+    extraNaclPath: { refType: BuiltinTypes.STRING },
+    generateEnvName: { refType: BuiltinTypes.STRING },
+    fieldsToOmit: { refType: new ListType(BuiltinTypes.STRING) },
+  },
 })
 
 export const adapter: Adapter = {

--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -160,7 +160,7 @@ export type GeneratorParams = {
     changeErrors?: ChangeErrorFromConfigFile[]
     extraNaclPath?: string
     generateEnvName? : string
-    fieldsToOmit?: string[]
+    fieldsToOmitOnDeploy?: string[]
 }
 
 export const defaultParams: Omit<GeneratorParams, 'extraNaclPath'> = {

--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -160,6 +160,7 @@ export type GeneratorParams = {
     changeErrors?: ChangeErrorFromConfigFile[]
     extraNaclPath?: string
     generateEnvName? : string
+    fieldsToOmit?: string[]
 }
 
 export const defaultParams: Omit<GeneratorParams, 'extraNaclPath'> = {

--- a/packages/dummy-adapter/test/adapter.test.ts
+++ b/packages/dummy-adapter/test/adapter.test.ts
@@ -47,7 +47,7 @@ describe('dummy adapter', () => {
       })
     })
 
-    it('should omit fields from instances if defined in fieldsToOmit', async () => {
+    it('should omit fields from instances if defined in fieldsToOmitOnDeploy', async () => {
       const type = new ObjectType({
         elemID: new ElemID(DUMMY_ADAPTER, 'type'),
       })

--- a/packages/dummy-adapter/test/adapter.test.ts
+++ b/packages/dummy-adapter/test/adapter.test.ts
@@ -13,11 +13,11 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ElemID, ObjectType, toChange, InstanceElement } from '@salto-io/adapter-api'
+import { ElemID, ObjectType, toChange, InstanceElement, getChangeData } from '@salto-io/adapter-api'
 import DummyAdapter from '../src/adapter'
 import * as generator from '../src/generator'
 import testParams from './test_params'
-import { ChangeErrorFromConfigFile } from '../src/generator'
+import { ChangeErrorFromConfigFile, DUMMY_ADAPTER } from '../src/generator'
 
 const mockChangeError: ChangeErrorFromConfigFile = {
   elemID: 'dummy.Full.instance.myIns2',
@@ -45,6 +45,23 @@ describe('dummy adapter', () => {
         appliedChanges: [],
         errors: [],
       })
+    })
+
+    it('should omit fields from instances if defined in fieldsToOmit', async () => {
+      const type = new ObjectType({
+        elemID: new ElemID(DUMMY_ADAPTER, 'type'),
+      })
+
+      const instance = new InstanceElement(
+        'instance',
+        type,
+        { fieldToOmit: 'val1', field2: 'val2' }
+      )
+      const res = await adapter.deploy({ changeGroup: { changes: [toChange({ after: instance })], groupID: ':)' } })
+
+      const appliedInstance = getChangeData(res.appliedChanges[0]) as InstanceElement
+
+      expect(appliedInstance.value).toEqual({ field2: 'val2' })
     })
   })
   describe('validate', () => {

--- a/packages/dummy-adapter/test/adapter_creator.test.ts
+++ b/packages/dummy-adapter/test/adapter_creator.test.ts
@@ -22,7 +22,7 @@ import DummyAdapter from '../src/adapter'
 describe('adapter creator', () => {
   it('should return a config containing all of the generator params', () => {
     const config = adapter.configType as ObjectType
-    expect(Object.keys(config?.fields)).toEqual([...Object.keys(defaultParams), 'changeErrors', 'extraNaclPath', 'generateEnvName', 'fieldsToOmit'])
+    expect(Object.keys(config?.fields)).toEqual([...Object.keys(defaultParams), 'changeErrors', 'extraNaclPath', 'generateEnvName', 'fieldsToOmitOnDeploy'])
   })
   it('should return an empty creds type', () => {
     expect(Object.keys(adapter.authenticationMethods.basic.credentialsType.fields)).toHaveLength(0)

--- a/packages/dummy-adapter/test/adapter_creator.test.ts
+++ b/packages/dummy-adapter/test/adapter_creator.test.ts
@@ -22,7 +22,7 @@ import DummyAdapter from '../src/adapter'
 describe('adapter creator', () => {
   it('should return a config containing all of the generator params', () => {
     const config = adapter.configType as ObjectType
-    expect(Object.keys(config?.fields)).toEqual([...Object.keys(defaultParams), 'changeErrors', 'extraNaclPath', 'generateEnvName'])
+    expect(Object.keys(config?.fields)).toEqual([...Object.keys(defaultParams), 'changeErrors', 'extraNaclPath', 'generateEnvName', 'fieldsToOmit'])
   })
   it('should return an empty creds type', () => {
     expect(Object.keys(adapter.authenticationMethods.basic.credentialsType.fields)).toHaveLength(0)

--- a/packages/dummy-adapter/test/test_params.ts
+++ b/packages/dummy-adapter/test/test_params.ts
@@ -22,6 +22,7 @@ const testParams: GeneratorParams = {
   numOfProfiles: 10,
   numOfRecords: 10,
   numOfTypes: 10,
+  fieldsToOmit: ['fieldToOmit'],
 }
 
 export default testParams

--- a/packages/dummy-adapter/test/test_params.ts
+++ b/packages/dummy-adapter/test/test_params.ts
@@ -22,7 +22,7 @@ const testParams: GeneratorParams = {
   numOfProfiles: 10,
   numOfRecords: 10,
   numOfTypes: 10,
-  fieldsToOmit: ['fieldToOmit'],
+  fieldsToOmitOnDeploy: ['fieldToOmit'],
 }
 
 export default testParams


### PR DESCRIPTION
Added `fieldsToOmit` to dummy so it will be easier to test deploy that omit fields from instances

---
_Release Notes_: 
None

---
_User Notifications_: 
None