### PR TITLE
SALTO-4150: Sanitize test failure output

### DIFF
--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -204,7 +204,7 @@ const processDeployResponse = (
     .flatMap(detail => makeArray((detail.runTestResult as RunTestsResult)?.failures))
   const testErrors = testFailures
     .map(failure => new Error(util.format(
-      'Test failed for class %s method %s with error:\n%s\n%o',
+      'Test failed for class %s method %s with error:\n%s\n%s',
       failure.name,
       failure.methodName,
       failure.message,


### PR DESCRIPTION
Salesforce test failures will not show the character `\n` and instead go down a line as required

---

before:
![image](https://github.com/salto-io/salto/assets/37732337/ceb9998f-bacc-483a-a908-c5028efe3af2)

after:
![image](https://github.com/salto-io/salto/assets/37732337/21a766a5-7696-40e9-9241-325f52eb47fe)

---
_Release Notes_: 
Salesforce adapter:
- Sanitize test failures to create newline instead of showing escaped character
---
_User Notifications_: _None_