### PR TITLE
SALTO-4137: Update extension details before publishing to VS Code marketplace

### DIFF
--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -1,13 +1,7 @@
-<!-- markdownlint-disable -->
-<h1 align="center">
-  vscode-salto
-</h1>
+# Salto NACL Configuration Editor
+This VS Code extension adds rich support for NACL Configuration files, which represent a business application configuration. By utilizing NACL files, users can easily perform impact analysis on the business application configuration, as well as deploy changes between environments, document these changes using git commits and more. The extension includes syntax highlighting, auto-complete, code navigation, error and warning highlighting, and more!
 
----
-
-<h4 align="center"Configure, preview and deploy .<a href="https://www.salto.io/">Salto</a> patches in vscode.</h4>
-
----
+Check out Salto's OSS repository for documentation, the code for this extension and more.
 
 ## Features at a glance
 
@@ -23,7 +17,8 @@
 - Copy salto reference
 
 ## Installation
-Salto is still not registered in the marketplace. To install:
+Salto VS Code extension can be installed through marketplace or by downloading vsix file and manually add it to your VS Code.
+To install manually:
 - Download the latest vsix file from [here](https://github.com/salto-io/salto/releases/latest)
 - Open the extension menu
 - Select install from .vsix

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -1,7 +1,7 @@
 # Salto NACL Configuration Editor
-This [VS Code] (https://code.visualstudio.com/) extension adds rich support for [Salto] (https://salto.io) NACL Configuration files, which represent a business application configuration. By utilizing NACL files, users can easily perform impact analysis on the business application configuration, as well as deploy changes between environments, document these changes using git commits and more. The extension includes syntax highlighting, auto-complete, code navigation, error and warning highlighting, and more!
+This [VS Code](https://code.visualstudio.com/) extension adds rich support for [Salto](https://salto.io) NACL Configuration files, which represent a business application configuration. By utilizing NACL files, users can easily perform impact analysis on the business application configuration, as well as deploy changes between environments, document these changes using git commits and more. The extension includes syntax highlighting, auto-complete, code navigation, error and warning highlighting, and more!
 
-Check out [Salto's OSS repository] (https://github.com/salto-io/salto) for documentation, the code for this extension and more.
+Check out [Salto's OSS repository](https://github.com/salto-io/salto) for documentation, the code for this extension and more.
 
 ## Features at a glance
 

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -1,7 +1,7 @@
 # Salto NACL Configuration Editor
-This VS Code extension adds rich support for NACL Configuration files, which represent a business application configuration. By utilizing NACL files, users can easily perform impact analysis on the business application configuration, as well as deploy changes between environments, document these changes using git commits and more. The extension includes syntax highlighting, auto-complete, code navigation, error and warning highlighting, and more!
+This [VS Code] (https://code.visualstudio.com/) extension adds rich support for [Salto] (https://salto.io) NACL Configuration files, which represent a business application configuration. By utilizing NACL files, users can easily perform impact analysis on the business application configuration, as well as deploy changes between environments, document these changes using git commits and more. The extension includes syntax highlighting, auto-complete, code navigation, error and warning highlighting, and more!
 
-Check out Salto's OSS repository for documentation, the code for this extension and more.
+Check out [Salto's OSS repository] (https://github.com/salto-io/salto) for documentation, the code for this extension and more.
 
 ## Features at a glance
 

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,14 +1,14 @@
 {
     "name": "salto-vscode",
-    "displayName": "Salto",
-    "description": "Configure Salto patches in vscode.",
+    "displayName": "Salto NACL Configuration Editor",
+    "description": "Provides rich support for NACL Configuration files, including syntax highlighting, auto-complete, code navigation and more.",
     "version": "0.3.38",
     "publishConfig": {
         "access": "public"
     },
     "icon": "icons/images/file_type_salto_opaque.png",
     "galleryBanner": {
-        "color": "#C80000",
+        "color": "#4A5568",
         "theme": "dark"
     },
     "engines": {
@@ -50,35 +50,6 @@
                     "when": "resourceExtname == .nacl"
                 }
             ]
-        },
-        "configuration": {
-            "title": "Salto",
-            "properties": {
-                "salto.salto_exe_path": {
-                    "type": "string",
-                    "scope": "machine",
-                    "default": "/usr/local/bin/salto",
-                    "description": "Path to the salto executable"
-                },
-                "salto.additionalNaclFileDirs": {
-                    "type": "array",
-                    "default": [],
-                    "scope": "resource",
-                    "description": "Paths to additional NACL dirs that should be included"
-                },
-                "salto.additionalNaclFiles": {
-                    "type": "array",
-                    "default": [],
-                    "scope": "resource",
-                    "description": "Paths to additional NACL that should be included"
-                },
-                "salto.discover_output_dir": {
-                    "type": "string",
-                    "default": ".",
-                    "scope": "resource",
-                    "description": "Paths to discover output directory"
-                }
-            }
         },
         "languages": [
             {


### PR DESCRIPTION
Update extension's details before publishing to VS Code marketplace

---

<img width="791" alt="image" src="https://github.com/salto-io/salto/assets/74004474/98dcb026-b3a1-4c88-9c00-a0745a9fe5f5">

<img width="1480" alt="image" src="https://github.com/salto-io/salto/assets/74004474/a191e606-8ebc-44e6-baf6-d5048bcd25fe">

---

_Release Notes_: 

_VS Code_:
- Update texts for VS Code extension

---

_User Notifications_: 
None