### PR TITLE
SALTO-4125 Update parser to support very long string contents

### DIFF
--- a/packages/workspace/src/parser/internal/native/consumers/values.ts
+++ b/packages/workspace/src/parser/internal/native/consumers/values.ts
@@ -118,7 +118,7 @@ const createStringValue = (
     ? [...tokens.slice(0, -1), trimToken(tokens[tokens.length - 1])]
     : tokens
 
-  const simpleString = _.every(trimmedTokens, token => token.type === TOKEN_TYPES.CONTENT)
+  const simpleString = _.every(trimmedTokens, token => [TOKEN_TYPES.CONTENT, TOKEN_TYPES.ESCAPE].includes(token.type))
   return simpleString
     ? createSimpleStringValue(context, trimmedTokens, transformFunc)
     : createTemplateExpressions(context, trimmedTokens, transformFunc)

--- a/packages/workspace/src/parser/internal/native/lexer.ts
+++ b/packages/workspace/src/parser/internal/native/lexer.ts
@@ -24,6 +24,7 @@ export const TOKEN_TYPES = {
   OCURLY: 'oCurly',
   CCURLY: 'cCurly',
   DOUBLE_QUOTES: 'dq',
+  ESCAPE: 'escape',
   WHITESPACE: 'whitespace',
   EQUAL: 'equal',
   NUMBER: 'number',
@@ -71,7 +72,8 @@ export const rules: Record<string, moo.Rules> = {
   string: {
     [TOKEN_TYPES.REFERENCE]: { match: new RegExp(`\\$\\{[ \\t]*${WORD_PART}[ \\t]*\\}`), value: s => s.slice(2, -1).trim() },
     [TOKEN_TYPES.DOUBLE_QUOTES]: { match: '"', pop: 1 },
-    [TOKEN_TYPES.CONTENT]: { match: /(?:[^"\\\r\n]|\\.)+?(?="|\r|\n|\$\{)/, lineBreaks: false },
+    [TOKEN_TYPES.ESCAPE]: /\\[^$]|\\\$\{?/, // This handles regular escapes and escaped template markers ('\${')
+    [TOKEN_TYPES.CONTENT]: { match: /[^\r\n\\]+?(?=\$\{|["\n\r\\])/, lineBreaks: false },
     [TOKEN_TYPES.NEWLINE]: { match: /[\r\n]+/, lineBreaks: true, pop: 1 },
   },
   multilineString: {

--- a/packages/workspace/src/parser/internal/native/lexer.ts
+++ b/packages/workspace/src/parser/internal/native/lexer.ts
@@ -73,6 +73,7 @@ export const rules: Record<string, moo.Rules> = {
     [TOKEN_TYPES.REFERENCE]: { match: new RegExp(`\\$\\{[ \\t]*${WORD_PART}[ \\t]*\\}`), value: s => s.slice(2, -1).trim() },
     [TOKEN_TYPES.DOUBLE_QUOTES]: { match: '"', pop: 1 },
     [TOKEN_TYPES.ESCAPE]: /\\[^$]|\\\$\{?/, // This handles regular escapes and escaped template markers ('\${')
+    // Template markers are added to prevent incorrect parsing of user created strings that look like Salto references.
     [TOKEN_TYPES.CONTENT]: { match: /[^\r\n\\]+?(?=\$\{|["\n\r\\])/, lineBreaks: false },
     [TOKEN_TYPES.NEWLINE]: { match: /[\r\n]+/, lineBreaks: true, pop: 1 },
   },

--- a/packages/workspace/test/parser/parse.test.ts
+++ b/packages/workspace/test/parser/parse.test.ts
@@ -218,7 +218,10 @@ template {{$\{te@mp.late.instance.multiline_stuff@us}}}
 value
 '''
       }
-
+      
+      type salesforce.escaped_templates {
+        tmpl = ">>>\\\${a.b}<<<"
+      }
       `
     beforeAll(async () => {
       const parsed = await parse(Buffer.from(body), 'none', functions)
@@ -232,7 +235,7 @@ value
 
     describe('parse result', () => {
       it('should have all types', () => {
-        expect(elements.length).toBe(24)
+        expect(elements.length).toBe(25)
         expect(genericTypes.length).toBe(2)
       })
     })
@@ -684,7 +687,7 @@ value
     })
 
     describe('escaped quotes', () => {
-      it('should parse a string value with escaped qoutes', () => {
+      it('should parse a string value with escaped quotes', () => {
         const element = elements[19]
         expect(isObjectType(element)).toBeTruthy()
         const obj = element as ObjectType
@@ -741,6 +744,31 @@ value
         expect(escapeObj.annotations.str).toEqual('you can\'t run away \\')
       })
     })
+
+    describe('escaped templates', () => {
+      let escapeTemplateObj: ObjectType
+      beforeAll(() => {
+        escapeTemplateObj = elements[24] as ObjectType
+      })
+
+      it('does not parse escaped references', () => {
+        // eslint-disable-next-line no-template-curly-in-string
+        expect(escapeTemplateObj.annotations.tmpl).toEqual('>>>${a.b}<<<')
+      })
+    })
+  })
+
+  it('parses loooong content strings', async () => {
+    const stringLength = 8498737
+    const body = `
+    type salesforce.escapedQuotes {
+      str = "${'a'.repeat(stringLength)}"
+    }
+    `
+    const parsed = await parse(Buffer.from(body), 'none', functions)
+    const elements = await awu(parsed.elements).filter(element => !isContainerType(element))
+      .toArray()
+    expect(elements[0].annotations.str.length).toEqual(stringLength)
   })
 
   describe('simple error tests', () => {


### PR DESCRIPTION
_Update parser (lexer) to support very long string contents_

---

_Additional context for reviewer_

* The previous version of the single line string content was using a complex regex, which cause errors for extremely long strings.
This fix optimizes it by splitting the way the lexer tokenizes string parts.
---
_Release Notes_: 
_Parser_
* Update parser to support very long string contents
---
_User Notifications_: 
