### PR TITLE
Salto-4140: Avoid querying entire file cabinet

### DIFF
--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_file_cabinet.ts
@@ -379,6 +379,9 @@ SuiteAppFileCabinetOperations => {
         .map(folder => ({ path: fullPathParts(folder, idToFolder), ...folder }))
         // remove excluded folders before creating the query
         .filter(folder => query.isFileMatch(`${fullPath(folder.path)}${FILE_CABINET_PATH_SEPARATOR}`))
+      const removedFolders = _.differenceBy(foldersResults, filteredFolderResults, folder => folder.name)
+        .map(folder => folder.name)
+      log.debug('removed the following %d folder before querying files: %o', removedFolders.length, removedFolders)
       const filesResults = await queryFiles(
         filteredFolderResults.map(folder => folder.id)
       )

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_file_cabinet.ts
@@ -373,12 +373,12 @@ SuiteAppFileCabinetOperations => {
       const subFoldersResults = await querySubFolders(topLevelFoldersResults)
       const foldersResults = topLevelFoldersResults.concat(subFoldersResults)
       const idToFolder = _.keyBy(foldersResults, folder => folder.id)
-      const filteredFolderResults = removeResultsWithoutParentFolder(foldersResults)
-        .map(folder => ({ path: fullPathParts(folder, idToFolder), ...folder }))
+      const [filteredFolderResults, removedFolders] = _.partition(
+        removeResultsWithoutParentFolder(foldersResults)
+          .map(folder => ({ path: fullPathParts(folder, idToFolder), ...folder })),
         // remove excluded folders before creating the query
-        .filter(folder => query.isFileMatch(`${fullPath(folder.path)}${FILE_CABINET_PATH_SEPARATOR}`))
-      const removedFolders = _.differenceBy(foldersResults, filteredFolderResults, folder => folder.name)
-        .map(folder => folder.name)
+        folder => query.isFileMatch(`${fullPath(folder.path)}${FILE_CABINET_PATH_SEPARATOR}`)
+      )
       log.debug('removed the following %d folder before querying files: %o', removedFolders.length, removedFolders)
       const filesResults = filteredFolderResults.length > 0 ? await queryFiles(
         filteredFolderResults.map(folder => folder.id)


### PR DESCRIPTION
_In case there are no folders to query, Dont query files at all instead of querying the entire file cabinet._

---

_This is a first pr for - https://salto-io.atlassian.net/browse/SALTO-4140?focusedCommentId=81758&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-81758, The main target of it is to add logs for us to have better visibility to allow us find the underline cause_

---
_Release Notes_: 
_Netsuite Adapter:_
* When there are no folders to query we don't query files at all.

---
_User Notifications_: 
_None_
