### PR TITLE
SALTO-4167 pass adapter operations context to loadElementsFromFolder

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -121,12 +121,15 @@ export type ServiceIds = Record<string, string>
 
 export type ElemIdGetter = (adapterName: string, serviceIds: ServiceIds, name: string) => ElemID
 
-export type AdapterOperationsContext = {
-  credentials: InstanceElement
+type AdapterBaseContext = {
   config?: InstanceElement
   getElemIdFunc?: ElemIdGetter
   elementsSource: ReadOnlyElementsSource
 }
+
+export type AdapterOperationsContext = {
+  credentials: InstanceElement
+} & AdapterBaseContext
 
 export type AdapterSuccessInstallResult = { success: true; installedVersion: string }
 export type AdapterFailureInstallResult = { success: false; errors: string[] }
@@ -145,8 +148,7 @@ export type ConfigCreator = {
 
 export type LoadElementsFromFolderArgs = {
   baseDir: string
-  elementSource: ReadOnlyElementsSource
-}
+} & AdapterBaseContext
 
 export type Adapter = {
   operations: (context: AdapterOperationsContext) => AdapterOperations

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -274,6 +274,7 @@ export const fetch: FetchFunc = async (
     workspace,
     fetchAccounts,
     accountToServiceNameMap,
+    await workspace.elements(),
     ignoreStateElemIdMapping,
   )
   const accountToAdapter = initAdapters(adaptersCreatorConfigs, accountToServiceNameMap)
@@ -342,6 +343,7 @@ export const fetchFromWorkspace: FetchFromWorkspaceFunc = async ({
     workspace,
     fetchAccounts,
     getAccountToServiceNameMap(workspace, fetchAccounts),
+    await workspace.elements()
   )
 
   const {
@@ -403,8 +405,8 @@ export const calculatePatch = async (
     workspace,
     [accountName],
     accountToServiceNameMap,
-    ignoreStateElemIdMapping,
-    elementSource.createInMemoryElementSource(resolvedWSElements)
+    elementSource.createInMemoryElementSource(resolvedWSElements),
+    ignoreStateElemIdMapping
   )
   const adapterContext = adaptersCreatorConfigs[accountName]
 

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -553,9 +553,9 @@ export const getAdaptersFirstFetchPartial = async (
 // o/w all account elements should be consider as "add" changes.
 export const calcFetchChanges = async (
   accountElements: ReadonlyArray<Element>,
-  mergedAccountElements: elementSource.ElementsSource,
-  stateElements: elementSource.ElementsSource,
-  workspaceElements: elementSource.ElementsSource,
+  mergedAccountElements: ReadOnlyElementsSource,
+  stateElements: ReadOnlyElementsSource,
+  workspaceElements: ReadOnlyElementsSource,
   partiallyFetchedAccounts: Set<string>,
   allFetchedAccounts: Set<string>
 ): Promise<FetchChange[]> => {
@@ -1081,7 +1081,8 @@ export const getFetchAdapterAndServicesSetup = async (
   workspace: Workspace,
   fetchServices: string[],
   accountToServiceNameMap: Record<string, string>,
-  ignoreStateElemIdMapping?: boolean
+  ignoreStateElemIdMapping?: boolean,
+  elementsSource?: ReadOnlyElementsSource,
 ): Promise<{
   adaptersCreatorConfigs: Record<string, AdapterOperationsContext>
   currentConfigs: InstanceElement[]
@@ -1097,7 +1098,7 @@ export const getFetchAdapterAndServicesSetup = async (
     fetchServices,
     await workspace.accountCredentials(fetchServices),
     workspace.accountConfig.bind(workspace),
-    await workspace.elements(),
+    elementsSource ?? await workspace.elements(),
     accountToServiceNameMap,
     elemIDGetters,
   )

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -1081,8 +1081,8 @@ export const getFetchAdapterAndServicesSetup = async (
   workspace: Workspace,
   fetchServices: string[],
   accountToServiceNameMap: Record<string, string>,
+  elementsSource: ReadOnlyElementsSource,
   ignoreStateElemIdMapping?: boolean,
-  elementsSource?: ReadOnlyElementsSource,
 ): Promise<{
   adaptersCreatorConfigs: Record<string, AdapterOperationsContext>
   currentConfigs: InstanceElement[]
@@ -1091,14 +1091,14 @@ export const getFetchAdapterAndServicesSetup = async (
     ? {}
     : await mapValuesAsync(accountToServiceNameMap, async (_service, account) =>
       createElemIdGetter(
-        awu(await (await workspace.elements()).getAll()).filter(e => e.elemID.adapter === account),
+        awu(await elementsSource.getAll()).filter(e => e.elemID.adapter === account),
         workspace.state()
       ))
   const adaptersCreatorConfigs = await getAdaptersCreatorConfigs(
     fetchServices,
     await workspace.accountCredentials(fetchServices),
     workspace.accountConfig.bind(workspace),
-    elementsSource ?? await workspace.elements(),
+    elementsSource,
     accountToServiceNameMap,
     elemIDGetters,
   )

--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -842,7 +842,7 @@ describe('Netsuite adapter E2E with real account', () => {
         logMessage('loading elements from SDF project')
         const res = await adapterCreator.loadElementsFromFolder?.({
           baseDir: projectPath,
-          elementSource: buildElementsSourceFromElements([]),
+          elementsSource: buildElementsSourceFromElements([]),
         })
         loadedElements = res?.elements as Element[]
       })

--- a/packages/netsuite-adapter/src/adapter_creator.ts
+++ b/packages/netsuite-adapter/src/adapter_creator.ts
@@ -14,22 +14,16 @@
 * limitations under the License.
 */
 import { Adapter, BuiltinTypes, ElemID, InstanceElement, ObjectType, AdapterInstallResult, AdapterOperationsContext, AdapterOperations } from '@salto-io/adapter-api'
-import { regex } from '@salto-io/lowerdash'
-import { logger } from '@salto-io/logging'
-import _ from 'lodash'
 import { SdkDownloadService } from '@salto-io/suitecloud-cli'
 import Bottleneck from 'bottleneck'
-import { CONFIG, configType, DEFAULT_CONCURRENCY, instanceLimiterCreator, NetsuiteConfig, validateClientConfig, validateDeployParams, validateFetchConfig, validateSuiteAppClientParams } from './config'
+import { configType, DEFAULT_CONCURRENCY, instanceLimiterCreator, netsuiteConfigFromConfig } from './config'
 import { NETSUITE } from './constants'
-import { validateFetchParameters, convertToQueryParams, validateNetsuiteQueryParameters, validateArrayOfStrings, validatePlainObject, FETCH_PARAMS } from './query'
 import { Credentials, isSdfCredentialsOnly, isSuiteAppCredentials, toCredentialsAccountId } from './client/credentials'
 import SuiteAppClient from './client/suiteapp_client/suiteapp_client'
 import SdfClient from './client/sdf_client'
 import NetsuiteClient from './client/client'
 import NetsuiteAdapter from './adapter'
 import loadElementsFromFolder from './sdf_folder_loader'
-
-const log = logger(module)
 
 const configID = new ElemID(NETSUITE)
 
@@ -71,95 +65,6 @@ export const defaultCredentialsType = new ObjectType({
   annotationRefsOrTypes: {},
   annotations: {},
 })
-
-const validateRegularExpressions = (regularExpressions: string[]): void => {
-  const invalidRegularExpressions = regularExpressions
-    .filter(strRegex => !regex.isValidRegex(strRegex))
-  if (!_.isEmpty(invalidRegularExpressions)) {
-    const errMessage = `received an invalid ${CONFIG.filePathRegexSkipList} value. The following regular expressions are invalid: ${invalidRegularExpressions}`
-    throw new Error(errMessage)
-  }
-}
-
-function validateConfig(config: Record<string, unknown>): asserts config is NetsuiteConfig {
-  const {
-    fetch,
-    fetchTarget,
-    skipList, // support deprecated version
-    deploy,
-    client,
-    filePathRegexSkipList,
-    typesToSkip,
-    suiteAppClient,
-  } = _.pick(config, Object.values(CONFIG))
-
-  if (filePathRegexSkipList !== undefined) {
-    validateArrayOfStrings(filePathRegexSkipList, CONFIG.filePathRegexSkipList)
-    validateRegularExpressions(filePathRegexSkipList)
-  }
-  if (typesToSkip !== undefined) {
-    validateArrayOfStrings(typesToSkip, CONFIG.typesToSkip)
-  }
-
-  if (client !== undefined) {
-    validatePlainObject(client, CONFIG.client)
-    validateClientConfig(client, fetchTarget !== undefined)
-  }
-
-  if (fetchTarget !== undefined) {
-    validatePlainObject(fetchTarget, CONFIG.fetchTarget)
-    validateNetsuiteQueryParameters(fetchTarget, CONFIG.fetchTarget)
-    validateFetchParameters(convertToQueryParams(fetchTarget))
-  }
-
-  if (skipList !== undefined) {
-    validatePlainObject(skipList, CONFIG.skipList)
-    validateNetsuiteQueryParameters(skipList, CONFIG.skipList)
-    validateFetchParameters(convertToQueryParams(skipList))
-  }
-
-  if (fetch !== undefined) {
-    validatePlainObject(fetch, CONFIG.fetch)
-    validateFetchConfig(fetch)
-  }
-
-  if (deploy !== undefined) {
-    validatePlainObject(deploy, CONFIG.deploy)
-    validateDeployParams(deploy)
-  }
-
-  if (suiteAppClient !== undefined) {
-    validatePlainObject(suiteAppClient, CONFIG.suiteAppClient)
-    validateSuiteAppClientParams(suiteAppClient)
-  }
-}
-
-const netsuiteConfigFromConfig = (
-  configInstance: Readonly<InstanceElement> | undefined
-): NetsuiteConfig => {
-  try {
-    if (!configInstance) {
-      return {}
-    }
-    const { value: config } = configInstance
-    validateConfig(config)
-    log.debug('using netsuite adapter config: %o', {
-      ...config,
-      fetch: _.omit(config.fetch, FETCH_PARAMS.lockedElementsToExclude),
-    })
-    return _.pickBy(config, (_value, key) => {
-      if (key in CONFIG) {
-        return true
-      }
-      log.debug('Unknown config property was found: %s', key)
-      return false
-    })
-  } catch (e) {
-    e.message = `Failed to load Netsuite config: ${e.message}`
-    log.error(e.message)
-    throw e
-  }
-}
 
 const throwOnMissingSuiteAppLoginCreds = (credentials: Credentials): void => {
   if (isSdfCredentialsOnly(credentials)) {

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -24,7 +24,7 @@ import { logger } from '@salto-io/logging'
 import {
   CURRENCY, CUSTOM_RECORD_TYPE, CUSTOM_RECORD_TYPE_NAME_PREFIX, DATASET, EXCHANGE_RATE, NETSUITE, PERMISSIONS, WORKBOOK,
 } from './constants'
-import { NetsuiteQueryParameters, FetchParams, convertToQueryParams, QueryParams, FetchTypeQueryParams, FieldToOmitParams, validateArrayOfStrings, validatePlainObject, validateFetchParameters, FETCH_PARAMS, validateFieldsToOmitConfig, NetsuiteFilePathsQueryParams, NetsuiteTypesQueryParams, checkTypeNameRegMatch, noSupportedTypeMatch } from './query'
+import { NetsuiteQueryParameters, FetchParams, convertToQueryParams, QueryParams, FetchTypeQueryParams, FieldToOmitParams, validateArrayOfStrings, validatePlainObject, validateFetchParameters, FETCH_PARAMS, validateFieldsToOmitConfig, NetsuiteFilePathsQueryParams, NetsuiteTypesQueryParams, checkTypeNameRegMatch, noSupportedTypeMatch, validateNetsuiteQueryParameters } from './query'
 import { ITEM_TYPE_TO_SEARCH_STRING } from './data_elements/types'
 import { netsuiteSupportedTypes } from './types'
 import { FetchByQueryFailures } from './change_validators/safe_deploy'
@@ -914,4 +914,94 @@ export const getConfigFromConfigChanges = (
     config: splitConfig(config),
     message: formatConfigSuggestionsReasons(messages),
   } : undefined
+}
+
+
+const validateRegularExpressions = (regularExpressions: string[]): void => {
+  const invalidRegularExpressions = regularExpressions
+    .filter(strRegex => !regex.isValidRegex(strRegex))
+  if (!_.isEmpty(invalidRegularExpressions)) {
+    const errMessage = `received an invalid ${CONFIG.filePathRegexSkipList} value. The following regular expressions are invalid: ${invalidRegularExpressions}`
+    throw new Error(errMessage)
+  }
+}
+
+function validateConfig(config: Record<string, unknown>): asserts config is NetsuiteConfig {
+  const {
+    fetch,
+    fetchTarget,
+    skipList, // support deprecated version
+    deploy,
+    client,
+    filePathRegexSkipList,
+    typesToSkip,
+    suiteAppClient,
+  } = _.pick(config, Object.values(CONFIG))
+
+  if (filePathRegexSkipList !== undefined) {
+    validateArrayOfStrings(filePathRegexSkipList, CONFIG.filePathRegexSkipList)
+    validateRegularExpressions(filePathRegexSkipList)
+  }
+  if (typesToSkip !== undefined) {
+    validateArrayOfStrings(typesToSkip, CONFIG.typesToSkip)
+  }
+
+  if (client !== undefined) {
+    validatePlainObject(client, CONFIG.client)
+    validateClientConfig(client, fetchTarget !== undefined)
+  }
+
+  if (fetchTarget !== undefined) {
+    validatePlainObject(fetchTarget, CONFIG.fetchTarget)
+    validateNetsuiteQueryParameters(fetchTarget, CONFIG.fetchTarget)
+    validateFetchParameters(convertToQueryParams(fetchTarget))
+  }
+
+  if (skipList !== undefined) {
+    validatePlainObject(skipList, CONFIG.skipList)
+    validateNetsuiteQueryParameters(skipList, CONFIG.skipList)
+    validateFetchParameters(convertToQueryParams(skipList))
+  }
+
+  if (fetch !== undefined) {
+    validatePlainObject(fetch, CONFIG.fetch)
+    validateFetchConfig(fetch)
+  }
+
+  if (deploy !== undefined) {
+    validatePlainObject(deploy, CONFIG.deploy)
+    validateDeployParams(deploy)
+  }
+
+  if (suiteAppClient !== undefined) {
+    validatePlainObject(suiteAppClient, CONFIG.suiteAppClient)
+    validateSuiteAppClientParams(suiteAppClient)
+  }
+}
+
+export const netsuiteConfigFromConfig = (
+  configInstance: Readonly<InstanceElement> | undefined
+): NetsuiteConfig => {
+  try {
+    if (!configInstance) {
+      return {}
+    }
+    const { value: config } = configInstance
+    validateConfig(config)
+    log.debug('using netsuite adapter config: %o', {
+      ...config,
+      fetch: _.omit(config.fetch, FETCH_PARAMS.lockedElementsToExclude),
+    })
+    return _.pickBy(config, (_value, key) => {
+      if (key in CONFIG) {
+        return true
+      }
+      log.debug('Unknown config property was found: %s', key)
+      return false
+    })
+  } catch (e) {
+    e.message = `Failed to load Netsuite config: ${e.message}`
+    log.error(e.message)
+    throw e
+  }
 }

--- a/packages/netsuite-adapter/src/sdf_folder_loader.ts
+++ b/packages/netsuite-adapter/src/sdf_folder_loader.ts
@@ -26,7 +26,7 @@ const localFilters = allFilters
   .map(({ creator }) => creator)
 
 const loadElementsFromFolder = async (
-  { baseDir, elementsSource, config }: LoadElementsFromFolderArgs,
+  { baseDir, elementsSource, config, getElemIdFunc }: LoadElementsFromFolderArgs,
   filters = localFilters,
 ): Promise<FetchResult> => {
   const isPartial = true
@@ -40,7 +40,7 @@ const loadElementsFromFolder = async (
     filters,
   )
   const customizationInfos = await parseSdfProjectDir(baseDir)
-  const elements = await createElements(customizationInfos)
+  const elements = await createElements(customizationInfos, getElemIdFunc)
   await filtersRunner.onFetch(elements)
 
   return { elements }

--- a/packages/netsuite-adapter/src/sdf_folder_loader.ts
+++ b/packages/netsuite-adapter/src/sdf_folder_loader.ts
@@ -19,22 +19,23 @@ import { allFilters } from './adapter'
 import { createElementsSourceIndex } from './elements_source_index/elements_source_index'
 import { parseSdfProjectDir } from './client/sdf_parser'
 import { createElements } from './transformer'
+import { netsuiteConfigFromConfig } from './config'
 
 const localFilters = allFilters
   .filter(filter.isLocalFilterCreator)
   .map(({ creator }) => creator)
 
 const loadElementsFromFolder = async (
-  { baseDir, elementSource }: LoadElementsFromFolderArgs,
+  { baseDir, elementsSource, config }: LoadElementsFromFolderArgs,
   filters = localFilters,
 ): Promise<FetchResult> => {
   const isPartial = true
   const filtersRunner = filter.filtersRunner(
     {
-      elementsSourceIndex: createElementsSourceIndex(elementSource, isPartial),
-      elementsSource: elementSource,
+      elementsSourceIndex: createElementsSourceIndex(elementsSource, isPartial),
+      elementsSource,
       isPartial,
-      config: {},
+      config: netsuiteConfigFromConfig(config),
     },
     filters,
   )

--- a/packages/netsuite-adapter/test/sdf_folder_loader.test.ts
+++ b/packages/netsuite-adapter/test/sdf_folder_loader.test.ts
@@ -97,20 +97,20 @@ describe('sdf folder loader', () => {
       name: 'filter',
       onFetch: () => Promise.resolve(undefined),
     })
-    const elementSource = buildElementsSourceFromElements([])
+    const elementsSource = buildElementsSourceFromElements([])
 
     const { elements } = await loadElementsFromFolder(
       {
         baseDir: 'projectDir',
-        elementSource,
+        elementsSource,
       },
       [filterMock]
     )
 
-    expect(createElementsSourceIndexMock).toHaveBeenCalledWith(elementSource, true)
+    expect(createElementsSourceIndexMock).toHaveBeenCalledWith(elementsSource, true)
     expect(filterMock).toHaveBeenCalledWith({
       elementsSourceIndex,
-      elementsSource: elementSource,
+      elementsSource,
       isPartial: true,
       config: {},
     })

--- a/packages/salesforce-adapter/src/sfdx_parser/sfdx_parser.ts
+++ b/packages/salesforce-adapter/src/sfdx_parser/sfdx_parser.ts
@@ -216,13 +216,13 @@ const getDXPackageDirs = async (baseDir: string): Promise<string[]> => {
 
 export const loadElementsFromFolder = async ({
   baseDir,
-  elementSource,
+  elementsSource,
 }: LoadElementsFromFolderArgs): Promise<FetchResult> => {
   const packages = await getDXPackageDirs(baseDir)
-  const types = await getElementTypesForSFDX(elementSource)
+  const types = await getElementTypesForSFDX(elementsSource)
   return {
     elements: await awu(packages)
-      .flatMap(pkg => getElementsFromDXFolder(pkg, elementSource, types))
+      .flatMap(pkg => getElementsFromDXFolder(pkg, elementsSource, types))
       .toArray(),
   }
 }

--- a/packages/salesforce-adapter/test/sfdx_parser/sfdx_parser.test.ts
+++ b/packages/salesforce-adapter/test/sfdx_parser/sfdx_parser.test.ts
@@ -24,10 +24,10 @@ import { mockTypes } from '../mock_elements'
 describe('loadElementsFromFolder', () => {
   let elements: Element[]
   beforeAll(async () => {
-    const elementSource = buildElementsSourceFromElements(Object.values(mockTypes))
+    const elementsSource = buildElementsSourceFromElements(Object.values(mockTypes))
     const loadElementsRes = await loadElementsFromFolder({
       baseDir: path.join(__dirname, 'test_sfdx_project'),
-      elementSource,
+      elementsSource,
     })
     elements = loadElementsRes.elements
   })


### PR DESCRIPTION
The `loadElementsFromFolder` should get the adapter config in order to know the user’s configuration that effects the nacls (like `fieldsToOmit`). Also we should pass the `ElemIdGetter` function.

---

_Additional context for reviewer_

---
_Release Notes_: 
Core:
- Pass adapter operations context to loadElementsFromFolder

---
_User Notifications_: 
None
