### PR TITLE
SALTO-4065: Remove specific duplicate project roles

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -127,6 +127,7 @@ import storeUsersFilter from './filters/store_users'
 import projectCategoryFilter from './filters/project_category'
 import addAliasFilter from './filters/add_alias'
 import circularTransitionFilter from './filters/workflow/circular_transitions_filter'
+import projectRoleRemoveTeamManagedDuplicatesFilter from './filters/remove_specific_duplicate_roles'
 
 const {
   generateTypes,
@@ -155,6 +156,8 @@ export const DEFAULT_FILTERS = [
   workflowStructureFilter,
   // This should happen after workflowStructureFilter and before fieldStructureFilter
   queryFilter,
+  // This should run before duplicateIdsFilter
+  projectRoleRemoveTeamManagedDuplicatesFilter,
   // This should happen before any filter that creates references
   duplicateIdsFilter,
   fieldStructureFilter,

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -60,6 +60,7 @@ type JiraFetchConfig = configUtils.UserFetchConfig<JiraFetchFilters> & {
   convertUsersIds?: boolean
   parseTemplateExpressions?: boolean
   enableScriptRunnerAddon?: boolean
+  removeDuplicateProjectRoles?: boolean
   addAlias?: boolean
 }
 
@@ -194,6 +195,7 @@ const fetchConfigType = createUserFetchConfigType(
     addTypeToFieldName: { refType: BuiltinTypes.BOOLEAN },
     showUserDisplayNames: { refType: BuiltinTypes.BOOLEAN },
     enableScriptRunnerAddon: { refType: BuiltinTypes.BOOLEAN },
+    removeDuplicateProjectRoles: { refType: BuiltinTypes.BOOLEAN },
     // Default is true
     parseTemplateExpressions: { refType: BuiltinTypes.BOOLEAN },
     addAlias: { refType: BuiltinTypes.BOOLEAN },

--- a/packages/jira-adapter/src/filters/remove_specific_duplicate_roles.ts
+++ b/packages/jira-adapter/src/filters/remove_specific_duplicate_roles.ts
@@ -43,8 +43,7 @@ const filter: FilterCreator = ({ config }) => ({
       return
     }
     // as this is a built-in role, we assume that the one with the lowest id is the global one
-    const originalElementId = builtInProjectRoles
-      .reduce((minVal, instance) => Math.min(minVal, instance.value.id), builtInProjectRoles[0].value.id)
+    const originalElementId = _.minBy(builtInProjectRoles, instance => instance.value.id)?.value.id
     log.info(`Found ${builtInProjectRoles.length} instances of ${BUILT_IN_PROJECT_ROLE_NAME} role, keeping only lowest id ${originalElementId}`)
     _.remove(
       elements,

--- a/packages/jira-adapter/src/filters/remove_specific_duplicate_roles.ts
+++ b/packages/jira-adapter/src/filters/remove_specific_duplicate_roles.ts
@@ -1,0 +1,59 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Element, isInstanceElement } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { logger } from '@salto-io/logging'
+import { FilterCreator } from '../filter'
+import { PROJECT_ROLE_TYPE } from '../constants'
+
+const log = logger(module)
+
+const BUILT_IN_PROJECT_ROLE_NAME = 'atlassian-addons-project-access'
+// This is a bandage fix for a Jira bug.
+// When you create a team-managed project several project-scoped roles are created by default,
+//  including atlassian-addons-project-access
+// When you delete a team-managed project all its project-scope roles are not really deleted.
+// They keep appearing in the roles API answer, but without the project scope. They are not visible in the UI
+// This fix will only address atlassian-addons-project-access as it is a built-in role, will always be there
+// and the global role will (hopefully) always have the lower id
+const filter: FilterCreator = ({ config }) => ({
+  name: 'projectRoleRemoveTeamManagedDuplicatesFilter',
+  onFetch: async (elements: Element[]) => {
+    if (!config.fetch.removeDuplicateProjectRoles) {
+      return
+    }
+    const builtInProjectRoles = elements
+      .filter(isInstanceElement)
+      .filter(instance => instance.elemID.typeName === PROJECT_ROLE_TYPE
+        && instance.value.name === BUILT_IN_PROJECT_ROLE_NAME)
+    if (builtInProjectRoles.length <= 1) {
+      return
+    }
+    // as this is a built-in role, we assume that the one with the lowest id is the global one
+    const originalElementId = builtInProjectRoles
+      .reduce((minVal, instance) => Math.min(minVal, instance.value.id), builtInProjectRoles[0].value.id)
+    log.info(`Found ${builtInProjectRoles.length} instances of ${BUILT_IN_PROJECT_ROLE_NAME} role, keeping only lowest id ${originalElementId}`)
+    _.remove(
+      elements,
+      element => isInstanceElement(element)
+        && element.elemID.typeName === PROJECT_ROLE_TYPE
+        && element.value.name === BUILT_IN_PROJECT_ROLE_NAME
+        && element.value.id !== originalElementId
+    )
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/test/filters/remove_specific_duplicate_roles.test.ts
+++ b/packages/jira-adapter/test/filters/remove_specific_duplicate_roles.test.ts
@@ -1,0 +1,98 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { InstanceElement } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { createEmptyType, getFilterParams } from '../utils'
+import removeDuplicateProjectRoles from '../../src/filters/remove_specific_duplicate_roles'
+import { Filter } from '../../src/filter'
+import { getDefaultConfig } from '../../src/config/config'
+import { PROJECT_ROLE_TYPE } from '../../src/constants'
+
+const BUILT_IN_PROJECT_ROLE_NAME = 'atlassian-addons-project-access'
+
+const type = createEmptyType(PROJECT_ROLE_TYPE)
+const noBuiltIn = new InstanceElement(
+  'noBuiltIn',
+  type,
+  {
+    id: 10000,
+    name: 'noBuiltIn',
+  }
+)
+
+const builtIn1 = new InstanceElement(
+  'builtIn1',
+  type,
+  {
+    id: 10001,
+    name: BUILT_IN_PROJECT_ROLE_NAME,
+  }
+)
+
+const builtIn2 = new InstanceElement(
+  'builtIn2',
+  type,
+  {
+    id: 10002,
+    name: BUILT_IN_PROJECT_ROLE_NAME,
+  }
+)
+
+const builtIn3 = new InstanceElement(
+  'builtIn3',
+  type,
+  {
+    id: 10003,
+    name: BUILT_IN_PROJECT_ROLE_NAME,
+  }
+)
+
+describe('projectRoleRemoveTeamManagedDuplicatesFilter', () => {
+  let filter: Filter
+  beforeEach(async () => {
+    const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+    config.fetch.removeDuplicateProjectRoles = true
+    filter = removeDuplicateProjectRoles(getFilterParams({
+      config,
+    }))
+  })
+  it('should remove duplicate roles', async () => {
+    const elements = [noBuiltIn, builtIn3, builtIn2, builtIn1]
+    await filter.onFetch?.(elements)
+    expect(elements).toHaveLength(2)
+    expect(elements.map(e => e.elemID.name)).toEqual(['noBuiltIn', 'builtIn1'])
+  })
+  it('should not remove if single addOn role', async () => {
+    const elements = [noBuiltIn, builtIn1]
+    await filter.onFetch?.(elements)
+    expect(elements).toHaveLength(2)
+  })
+  it('should not remove if no addOn roles', async () => {
+    const elements = [noBuiltIn]
+    await filter.onFetch?.(elements)
+    expect(elements).toHaveLength(1)
+  })
+  it('should not remove duplicate roles if config is false', async () => {
+    const configOff = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+    configOff.fetch.removeDuplicateProjectRoles = false
+    filter = removeDuplicateProjectRoles(getFilterParams({
+      config: configOff,
+    }))
+    const elements = [noBuiltIn, builtIn3, builtIn2, builtIn1]
+    await filter.onFetch?.(elements)
+    expect(elements).toHaveLength(4)
+  })
+})


### PR DESCRIPTION
Omitting duplicate a specific built-in project role that can be caused by deleting team-managed project
---

See details in the Jira ticket
This is a bandage fix for a Jira bug.
When you create a team-managed project several project-scoped roles are created by default, including atlassian-addons-project-access
When you delete a team-managed project all its project-scope roles are not really deleted.
They keep appearing in the roles API answer, but without the project scope. They are not visible in the UI
This fix will only address atlassian-addons-project-access as it is a built-in role, will always be there
and the global role will (hopefully) always have the lower id

The entire feature is under a config flag: fetch->removeDuplicateProjectRoles 


---
_Release Notes_: 
Jira Adapter:
* Provided a workaround for a Jira bug that prevented fetching a built-in project role

---
_User Notifications_: 
Jira Adapter:
* Some users might see a new project role that was previously omitted due to a Jira bug
