### PR TITLE
SALTO-4163: Fix bug in adapter-components when using both dependsOn and recurseInto

### DIFF
--- a/packages/adapter-components/src/elements/request_parameters.ts
+++ b/packages/adapter-components/src/elements/request_parameters.ts
@@ -19,7 +19,7 @@ import { resolvePath, safeJsonStringify } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { values as lowerdashValues } from '@salto-io/lowerdash'
 import { ClientGetWithPaginationParams } from '../client'
-import { FetchRequestConfig, ARG_PLACEHOLDER_MATCHER, UrlParams } from '../config/request'
+import { FetchRequestConfig, ARG_PLACEHOLDER_MATCHER, UrlParams, DependsOnConfig } from '../config/request'
 
 const { isDefined } = lowerdashValues
 const log = logger(module)
@@ -30,6 +30,7 @@ export type ComputeGetArgsFunc = (
   request: FetchRequestConfig,
   contextElements?: Record<string, Element[]>,
   requestContext?: Record<string, unknown>,
+  reversedSupportedTypes?: Record<string, string[]>,
 ) => ClientGetWithPaginationParams[]
 
 /**
@@ -66,12 +67,27 @@ export const replaceUrlParams = (url: string, paramValues: Record<string, unknow
   )
 )
 
+const getContextInstances = (
+  referenceDetails: DependsOnConfig,
+  contextElements: Record<string, Element[]>,
+  reversedSupportedTypes?: Record<string, string[]>,
+): InstanceElement[] => {
+  const fromType = referenceDetails.from.type
+  const itemTypes = reversedSupportedTypes?.[fromType]
+  return (contextElements[fromType] ?? [])
+    .filter(isInstanceElement)
+    // Filter to context instances the "item" types of the "from" type,
+    // fallback to all instances if we can't find the "item" types
+    .filter(instance => (itemTypes !== undefined ? itemTypes.includes(instance.elemID.typeName) : true))
+}
+
 const computeDependsOnURLs = (
   {
     url,
     dependsOn,
   }: FetchRequestConfig,
   contextElements?: Record<string, Element[]>,
+  reversedSupportedTypes?: Record<string, string[]>,
 ): string[] => {
   if (!url.includes('{')) {
     return [url]
@@ -92,9 +108,7 @@ const computeDependsOnURLs = (
       log.error('could not resolve path param %s in url %s with dependsOn config %s', argName, url, safeJsonStringify(dependsOn))
       throw new Error(`could not resolve path param ${argName} in url ${url}`)
     }
-    const contextInstances = (contextElements[referenceDetails.from.type] ?? []).filter(
-      isInstanceElement
-    )
+    const contextInstances = getContextInstances(referenceDetails, contextElements, reversedSupportedTypes)
     if (contextInstances.length === 0) {
       log.warn(`no instances found for ${referenceDetails.from.type}, cannot call endpoint ${url}`)
     }
@@ -137,7 +151,8 @@ export const createUrl = ({
 export const computeGetArgs: ComputeGetArgsFunc = (
   args,
   contextElements,
-  requestContext
+  requestContext,
+  reversedSupportedTypes,
 ) => {
   // Replace known url params
   const baseUrl = requestContext !== undefined
@@ -147,6 +162,7 @@ export const computeGetArgs: ComputeGetArgsFunc = (
   const urls = computeDependsOnURLs(
     { url: baseUrl, dependsOn: args.dependsOn },
     contextElements,
+    reversedSupportedTypes,
   )
   return urls.flatMap(url => simpleGetArgs({ ...args, url }, contextElements))
 }

--- a/packages/adapter-components/src/elements/request_parameters.ts
+++ b/packages/adapter-components/src/elements/request_parameters.ts
@@ -76,8 +76,8 @@ const getContextInstances = (
   const itemTypes = reversedSupportedTypes?.[fromType]
   return (contextElements[fromType] ?? [])
     .filter(isInstanceElement)
-    // Filter to context instances the "item" types of the "from" type,
-    // fallback to all instances if we can't find the "item" types
+    // The relevant context instances are of the types correspond to the page type in SupportedTypes,
+    // fallback to all instances if the mapping is missing from SupportedTypess
     .filter(instance => (itemTypes !== undefined ? itemTypes.includes(instance.elemID.typeName) : true))
 }
 

--- a/packages/adapter-components/test/elements/ducktype/transformer.test.ts
+++ b/packages/adapter-components/test/elements/ducktype/transformer.test.ts
@@ -94,6 +94,7 @@ describe('ducktype_transformer', () => {
           },
         },
         nestedFieldFinder: returnFullEntry,
+        reversedSupportedTypes: { myTypes: ['myType'] },
       })
       expect(res).toHaveLength(5)
       expect(res.map(e => e.elemID.getFullName())).toEqual([
@@ -184,6 +185,7 @@ describe('ducktype_transformer', () => {
           },
         },
         nestedFieldFinder: findDataField,
+        reversedSupportedTypes: { myTypes: ['myType'] },
       })
       expect(res).toHaveLength(2)
       expect(res.map(e => e.elemID.getFullName())).toEqual([
@@ -219,6 +221,7 @@ describe('ducktype_transformer', () => {
           },
         },
         nestedFieldFinder: returnFullEntry,
+        reversedSupportedTypes: { myTypes: ['myType'] },
       })
       expect(res).toHaveLength(5)
       expect(res.map(e => e.elemID.getFullName())).toEqual([
@@ -302,6 +305,7 @@ describe('ducktype_transformer', () => {
           },
         },
         nestedFieldFinder: findDataField,
+        reversedSupportedTypes: { myTypes: ['myType'] },
       })
       expect(res).toHaveLength(5)
       expect(res.map(e => e.elemID.getFullName())).toEqual([
@@ -368,6 +372,7 @@ describe('ducktype_transformer', () => {
           },
         },
         nestedFieldFinder: findDataField,
+        reversedSupportedTypes: { myTypes: ['myType'] },
       })).rejects.toThrow(new Error('Invalid type config - type something.myType has no request config'))
     })
     it('should fail if type does not have request details', async () => {
@@ -394,6 +399,7 @@ describe('ducktype_transformer', () => {
           },
         },
         nestedFieldFinder: findDataField,
+        reversedSupportedTypes: { myTypes: ['myType'] },
       })).rejects.toThrow(new Error('could not find type missing'))
     })
     it('should fail if type is setting but there\'s more than one instance', async () => {
@@ -431,6 +437,7 @@ describe('ducktype_transformer', () => {
           },
         },
         nestedFieldFinder: returnFullEntry,
+        reversedSupportedTypes: { myTypes: ['myType'] },
       })).rejects.toThrow(new Error('Could not fetch type myType, singleton types should not have more than one instance'))
     })
     it('should returns recurseInto values in the instances', async () => {
@@ -483,6 +490,7 @@ describe('ducktype_transformer', () => {
           },
         },
         nestedFieldFinder: returnFullEntry,
+        reversedSupportedTypes: { folders: ['folder'], subfolder: ['subfolder'] },
       })
       expect(res).toHaveLength(6)
       expect(res.map(e => e.elemID.getFullName())).toEqual([
@@ -635,6 +643,7 @@ describe('ducktype_transformer', () => {
         computeGetArgs: simpleGetArgs,
         typesConfig,
         typeDefaultConfig,
+        reversedSupportedTypes: { folder: ['folder'], file: ['file'], permission: ['permission'] },
       })
       expect(transformer.getTypeAndInstances).toHaveBeenCalledWith({
         adapterName: 'something',
@@ -648,6 +657,7 @@ describe('ducktype_transformer', () => {
           folder: [expect.anything(), expect.anything()],
           permission: [expect.anything(), expect.anything()],
         },
+        reversedSupportedTypes: { folder: ['folder'], file: ['file'], permission: ['permission'] },
       })
       expect(transformer.getTypeAndInstances).toHaveBeenCalledWith({
         adapterName: 'something',
@@ -658,6 +668,7 @@ describe('ducktype_transformer', () => {
         typesConfig,
         typeDefaultConfig,
         contextElements: undefined,
+        reversedSupportedTypes: { folder: ['folder'], file: ['file'], permission: ['permission'] },
       })
     })
     it('should run a function to retrieve entries responses and not adding the remaining types', async () => {
@@ -696,6 +707,7 @@ describe('ducktype_transformer', () => {
         typesConfig,
         typeDefaultConfig,
         getEntriesResponseValuesFunc,
+        reversedSupportedTypes: { folder: ['folder'] },
       })
     })
     it('should return config changes', async () => {

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -1377,7 +1377,7 @@ export const SUPPORTED_TYPES = {
   UserType: ['api__v1__meta__types__user'],
   OrgSettings: ['OrgSetting'],
   ...Object.fromEntries(
-    Object.keys(POLICY_TYPE_NAME_TO_PARAMS).map(typeName => ([typeName, getPolicyItemsName(typeName)]))
+    Object.keys(POLICY_TYPE_NAME_TO_PARAMS).map(typeName => ([typeName, [getPolicyItemsName(typeName)]]))
   ),
   SmsTemplate: ['api__v1__templates__sms'],
   TrustedOrigin: ['api__v1__trustedOrigins'],


### PR DESCRIPTION
Fix bug in adapter-components that caused `EmailTemplate` type not to return during fetch

---

The bug happened when when using `recurseInto` in type A and `dependsOn` in type B (that depends on A)
This caused `contextElements` for type A to include all instances returned in `recurseInto` as well
and then, when fetching type B, we used instances returned from `recurseInto` and not just instances from type A

The solution was to create a reverse mapping for supported types (because dependsOn is using the page types but the context elements are from "items" types), and filter in `dependsOn` func to only for instances from the relevant types

---
_Release Notes_: 
None

---
_User Notifications_: 
None
