### PR TITLE
SALTO-4081/orphan contexts

### DIFF
--- a/packages/jira-adapter/src/dependency_changers/global_field_contexts.ts
+++ b/packages/jira-adapter/src/dependency_changers/global_field_contexts.ts
@@ -34,7 +34,7 @@ export const globalFieldContextsDependencyChanger: DependencyChanger = async cha
 
   const filteredGlobalContextChanges = globalContextChanges.filter(({ change }) => {
     try {
-      return getParent(getChangeData(change)).elemID.getFullName() !== undefined
+      return getParent(getChangeData(change)) !== undefined
     } catch {
       return false
     }

--- a/packages/jira-adapter/src/dependency_changers/global_field_contexts.ts
+++ b/packages/jira-adapter/src/dependency_changers/global_field_contexts.ts
@@ -16,6 +16,7 @@
 import { Change, dependencyChange, DependencyChanger, getChangeData, InstanceElement, isAdditionChange, isAdditionOrRemovalChange, isInstanceChange, isRemovalChange } from '@salto-io/adapter-api'
 import { getParent } from '@salto-io/adapter-utils'
 import _ from 'lodash'
+import { isThereValidParent } from '../utils'
 import { FIELD_CONTEXT_TYPE_NAME } from '../filters/fields/constants'
 import { ChangeWithKey } from './types'
 
@@ -32,13 +33,8 @@ export const globalFieldContextsDependencyChanger: DependencyChanger = async cha
     .filter(({ change }) => _.isEmpty(getChangeData(change).value.projectIds)
       || _.isEmpty(getChangeData(change).value.issueTypeIds))
 
-  const filteredGlobalContextChanges = globalContextChanges.filter(({ change }) => {
-    try {
-      return getParent(getChangeData(change)) !== undefined
-    } catch {
-      return false
-    }
-  })
+  const filteredGlobalContextChanges = globalContextChanges
+    .filter(({ change }) => isThereValidParent(getChangeData(change)))
 
   const fieldToContexts = _.groupBy(
     filteredGlobalContextChanges,

--- a/packages/jira-adapter/src/dependency_changers/global_field_contexts.ts
+++ b/packages/jira-adapter/src/dependency_changers/global_field_contexts.ts
@@ -32,8 +32,16 @@ export const globalFieldContextsDependencyChanger: DependencyChanger = async cha
     .filter(({ change }) => _.isEmpty(getChangeData(change).value.projectIds)
       || _.isEmpty(getChangeData(change).value.issueTypeIds))
 
+  const filteredGlobalContextChanges = globalContextChanges.filter(({ change }) => {
+    try {
+      return getParent(getChangeData(change)).elemID.getFullName() !== undefined
+    } catch {
+      return false
+    }
+  })
+
   const fieldToContexts = _.groupBy(
-    globalContextChanges,
+    filteredGlobalContextChanges,
     ({ change }) => getParent(getChangeData(change)).elemID.getFullName()
   )
 

--- a/packages/jira-adapter/src/filters/fields/context_deployment_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/context_deployment_filter.ts
@@ -13,22 +13,13 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, Element, getChangeData, InstanceElement, isInstanceChange, isRemovalChange } from '@salto-io/adapter-api'
+import { Element, getChangeData, isInstanceChange, isRemovalChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { getParent } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../../filter'
 import { deployContextChange, setContextDeploymentAnnotations } from './contexts'
 import { deployChanges } from '../../deployment/standard_deployment'
 import { FIELD_CONTEXT_TYPE_NAME, FIELD_TYPE_NAME } from './constants'
-import { findObject, setFieldDeploymentAnnotations } from '../../utils'
-
-const contextChangeHasValidParent = (change: Change<InstanceElement>): boolean => {
-  try {
-    return getParent(getChangeData(change)) !== undefined
-  } catch {
-    return false
-  }
-}
+import { findObject, isThereValidParent, setFieldDeploymentAnnotations } from '../../utils'
 
 const filter: FilterCreator = ({ client, config, elementsSource }) => ({
   name: 'contextDeploymentFilter',
@@ -56,7 +47,7 @@ const filter: FilterCreator = ({ client, config, elementsSource }) => ({
       async change => {
         // field contexts without fields cant be removed because they don't exist,
         // modification changes are also not allowed but will not crash.
-        if (contextChangeHasValidParent(change) || !isRemovalChange(change)) {
+        if (isThereValidParent(getChangeData(change)) || !isRemovalChange(change)) {
           await deployContextChange(change, client, config.apiDefinitions, elementsSource)
         }
       }

--- a/packages/jira-adapter/src/filters/fields/context_deployment_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/context_deployment_filter.ts
@@ -24,7 +24,7 @@ import { findObject, setFieldDeploymentAnnotations } from '../../utils'
 
 const contextChangeHasValidParent = (change: Change<InstanceElement>): boolean => {
   try {
-    return getParent(getChangeData(change)) !== undefined && isRemovalChange(change)
+    return getParent(getChangeData(change)) !== undefined
   } catch {
     return false
   }
@@ -54,7 +54,9 @@ const filter: FilterCreator = ({ client, config, elementsSource }) => ({
     const deployResult = await deployChanges(
       relevantChanges.filter(isInstanceChange),
       async change => {
-        if (contextChangeHasValidParent(change)) {
+        // field contexts without fields cant be removed because they don't exist,
+        // modification changes are also not allowed but will not crash.
+        if (contextChangeHasValidParent(change) || !isRemovalChange(change)) {
           await deployContextChange(change, client, config.apiDefinitions, elementsSource)
         }
       }

--- a/packages/jira-adapter/src/filters/fields/context_deployment_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/context_deployment_filter.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, Element, getChangeData, InstanceElement, isInstanceChange } from '@salto-io/adapter-api'
+import { Change, Element, getChangeData, InstanceElement, isInstanceChange, isRemovalChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { getParent } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../../filter'
@@ -24,7 +24,7 @@ import { findObject, setFieldDeploymentAnnotations } from '../../utils'
 
 const contextChangeHasValidParent = (change: Change<InstanceElement>): boolean => {
   try {
-    return getParent(getChangeData(change)) !== undefined
+    return getParent(getChangeData(change)) !== undefined && isRemovalChange(change)
   } catch {
     return false
   }

--- a/packages/jira-adapter/src/utils.ts
+++ b/packages/jira-adapter/src/utils.ts
@@ -19,6 +19,7 @@ import { elements as elementUtils } from '@salto-io/adapter-components'
 import { collections } from '@salto-io/lowerdash'
 import { JiraConfig, JspUrls } from './config/config'
 import { ACCOUNT_INFO_ELEM_ID, JIRA_FREE_PLAN } from './constants'
+import { getParent } from '@salto-io/adapter-utils'
 
 const log = logger(module)
 
@@ -108,5 +109,13 @@ export const renameKey = (object: Value, { from, to }: { from: string; to: strin
   if (object[from] !== undefined) {
     object[to] = object[from]
     delete object[from]
+  }
+}
+
+export const isThereValidParent = (element: Element): boolean => {
+  try {
+    return getParent(element) !== undefined
+  } catch {
+    return false
   }
 }

--- a/packages/jira-adapter/src/utils.ts
+++ b/packages/jira-adapter/src/utils.ts
@@ -17,9 +17,9 @@ import { CORE_ANNOTATIONS, ObjectType, Element, isObjectType, getDeepInnerType, 
 import { logger } from '@salto-io/logging'
 import { elements as elementUtils } from '@salto-io/adapter-components'
 import { collections } from '@salto-io/lowerdash'
+import { getParent } from '@salto-io/adapter-utils'
 import { JiraConfig, JspUrls } from './config/config'
 import { ACCOUNT_INFO_ELEM_ID, JIRA_FREE_PLAN } from './constants'
-import { getParent } from '@salto-io/adapter-utils'
 
 const log = logger(module)
 

--- a/packages/jira-adapter/test/dependency_changers/global_field_contexts.test.ts
+++ b/packages/jira-adapter/test/dependency_changers/global_field_contexts.test.ts
@@ -89,4 +89,19 @@ describe('globalFieldContextsDependencyChanger', () => {
     ]
     expect(dependencyChanges).toHaveLength(0)
   })
+  it('should not add dependency if the parent field is deleted', async () => {
+    const deletedParentInstance = instance.clone()
+    deletedParentInstance.annotations[CORE_ANNOTATIONS.PARENT] = [
+    ]
+    const inputChanges = new Map([
+      [0, toChange({ after: deletedParentInstance })],
+      [1, toChange({ before: deletedParentInstance })],
+    ])
+    const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([])
+
+    const dependencyChanges = [
+      ...await globalFieldContextsDependencyChanger(inputChanges, inputDeps),
+    ]
+    expect(dependencyChanges).toHaveLength(0)
+  })
 })

--- a/packages/jira-adapter/test/filters/fields/field_context_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_context_deployment.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, ListType, MapType, ObjectType, toChange } from '@salto-io/adapter-api'
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, ListType, MapType, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
 import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
 import { getFilterParams, mockClient } from '../../utils'
 import { getDefaultConfig } from '../../../src/config/config'
@@ -146,20 +146,76 @@ describe('fieldContextDeployment', () => {
       })
     })
   })
-  it('should call deployContextChange', async () => {
-    const instance = new InstanceElement(
-      'instance',
-      contextType,
-      {},
-    )
-
-    const change = toChange({ after: instance })
-    await filter.deploy([change])
-    expect(deployContextChangeMock).toHaveBeenCalledWith(
-      change,
-      client,
-      getDefaultConfig({ isDataCenter: false }).apiDefinitions,
-      expect.anything(),
-    )
+  describe('onDeploy', () => {
+    it('should call deployContextChange on addition', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        contextType,
+        {},
+      )
+      const change = toChange({ after: instance })
+      await filter.deploy([change])
+      expect(deployContextChangeMock).toHaveBeenCalledWith(
+        change,
+        client,
+        getDefaultConfig({ isDataCenter: false }).apiDefinitions,
+        expect.anything(),
+      )
+    })
+    it('should call deployContextChange on modification', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        contextType,
+        {}
+      )
+      const change = toChange({ after: instance, before: instance })
+      await filter.deploy([change])
+      expect(deployContextChangeMock).toHaveBeenCalledWith(
+        change,
+        client,
+        getDefaultConfig({ isDataCenter: false }).apiDefinitions,
+        expect.anything(),
+      )
+    })
+    it.only('should call deployContextChange on removal', async () => {
+      fieldType = new ObjectType({
+        elemID: new ElemID(JIRA, 'Field'),
+        fields: {
+          contexts: { refType: new ListType(contextType) },
+        },
+      })
+      const fieldInstance = new InstanceElement(
+        'field',
+        fieldType,
+        {},
+      )
+      const instance = new InstanceElement(
+        'instance',
+        contextType,
+        {},
+        undefined,
+        {
+          [CORE_ANNOTATIONS.PARENT]: new ReferenceExpression(fieldInstance.elemID, fieldInstance),
+        }
+      )
+      const change = toChange({ before: instance })
+      await filter.deploy([change])
+      expect(deployContextChangeMock).toHaveBeenCalledWith(
+        change,
+        client,
+        getDefaultConfig({ isDataCenter: false }).apiDefinitions,
+        expect.anything(),
+      )
+    })
+    it('should not call deployContextChange on removal without parent', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        contextType,
+        {},
+      )
+      const change = toChange({ before: instance })
+      await filter.deploy([change])
+      expect(deployContextChangeMock).not.toHaveBeenCalled()
+    })
   })
 })

--- a/packages/jira-adapter/test/filters/fields/field_context_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_context_deployment.test.ts
@@ -177,7 +177,7 @@ describe('fieldContextDeployment', () => {
         expect.anything(),
       )
     })
-    it.only('should call deployContextChange on removal', async () => {
+    it('should call deployContextChange on removal', async () => {
       fieldType = new ObjectType({
         elemID: new ElemID(JIRA, 'Field'),
         fields: {


### PR DESCRIPTION
fixed bug causing us to try and remove an already removed context (which happens when a user removes a field but keeps the nacls of the contexts and then removes them before the next fetch.


---

_Additional context for reviewer_

---
_Release Notes_: 
jira adapter:
* fixed bug with removing field contexts after the field was already removed.

---
_User Notifications_: 

