### PR TITLE
SALTO-4064 Fix circular dependencies in suitescript files deploy

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -70,6 +70,7 @@ import NetsuiteClient from './client/client'
 import { createDateRange } from './changes_detector/date_formats'
 import { createElementsSourceIndex } from './elements_source_index/elements_source_index'
 import getChangeValidator from './change_validator'
+import dependencyChanger from './dependency_changer'
 import { cloneChange } from './change_validators/utils'
 import { FetchByQueryFunc, FetchByQueryReturnType } from './change_validators/safe_deploy'
 import { getChangeGroupIdsFunc } from './group_changes'
@@ -487,6 +488,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
         elementsSource: this.elementsSource,
       }),
       getChangeGroupIds: getChangeGroupIdsFunc(this.client.isSuiteAppConfigured()),
+      dependencyChanger,
     }
   }
 }

--- a/packages/netsuite-adapter/src/dependency_changer.ts
+++ b/packages/netsuite-adapter/src/dependency_changer.ts
@@ -1,0 +1,56 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { values } from '@salto-io/lowerdash'
+import { CORE_ANNOTATIONS, ChangeDataType, DependencyChanger, ElemID, dependencyChange, getChangeData, isReferenceExpression } from '@salto-io/adapter-api'
+import { DetailedDependency } from '@salto-io/adapter-utils'
+import { isFileInstance } from './types'
+
+const { isDefined } = values
+
+const getFileGeneratedDependenciesToRemove = (element: ChangeDataType): ElemID[] => {
+  if (!isFileInstance(element)) {
+    return []
+  }
+  const generatedDependencies: DetailedDependency[] = element.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES] ?? []
+
+  const [parentFolder] = element.annotations[CORE_ANNOTATIONS.PARENT] ?? []
+  const parentFolderElemId = isReferenceExpression(parentFolder)
+    ? parentFolder.elemID.createBaseID().parent
+    : undefined
+
+  return generatedDependencies
+    .map(({ reference }) => reference.elemID.createBaseID().parent)
+    .filter(elemId => !parentFolderElemId?.isEqual(elemId))
+}
+
+const dependencyChanger: DependencyChanger = async changesMap => {
+  const changesWithIds = Array.from(changesMap.entries())
+    .map(([id, change]) => ({ change, id }))
+
+  const elemIdToChangeId = new Map(
+    changesWithIds.map(({ change, id }) => [getChangeData(change).elemID.getFullName(), id])
+  )
+
+  return changesWithIds.flatMap(
+    ({ change, id: sourceId }) =>
+      getFileGeneratedDependenciesToRemove(getChangeData(change))
+        .map(elemId => elemIdToChangeId.get(elemId.getFullName()))
+        .filter(isDefined)
+        .map(targetId => dependencyChange('remove', sourceId, targetId))
+  )
+}
+
+export default dependencyChanger

--- a/packages/netsuite-adapter/test/dependency_changer.test.ts
+++ b/packages/netsuite-adapter/test/dependency_changer.test.ts
@@ -1,0 +1,105 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { CORE_ANNOTATIONS, ChangeId, ElemID, InstanceElement, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { extendGeneratedDependencies } from '@salto-io/adapter-utils'
+import dependencyChanger from '../src/dependency_changer'
+import { fileType, folderType } from '../src/types/file_cabinet_types'
+import { NETSUITE, PATH, SCRIPT_ID } from '../src/constants'
+import { workflowType } from '../src/autogen/types/standard_types/workflow'
+
+describe('dependency changer', () => {
+  const emptyDeps: ReadonlyMap<ChangeId, ReadonlySet<ChangeId>> = new Map()
+  describe('remove file generated dependencies', () => {
+    let fileInstance: InstanceElement
+    let folderInstance: InstanceElement
+    let anotherInstance: InstanceElement
+    beforeEach(() => {
+      folderInstance = new InstanceElement(
+        'parentFolder',
+        folderType(),
+        { path: '/parentFolder' }
+      )
+      fileInstance = new InstanceElement(
+        'someFile',
+        fileType(),
+        { path: '/parentFolder/someFile' },
+      )
+      anotherInstance = new InstanceElement(
+        'someInstance',
+        workflowType().type,
+        { scriptid: 'custworkflow1' },
+      )
+    })
+    it('should remove dependencies to changes', async () => {
+      const changesMap = new Map([
+        [1, toChange({ after: fileInstance })],
+        [2, toChange({ after: folderInstance })],
+        [3, toChange({ after: anotherInstance })],
+      ])
+
+      extendGeneratedDependencies(fileInstance, [{
+        reference: new ReferenceExpression(folderInstance.elemID.createNestedID(PATH)),
+      }, {
+        reference: new ReferenceExpression(anotherInstance.elemID.createNestedID(SCRIPT_ID)),
+      }, {
+        reference: new ReferenceExpression(new ElemID(NETSUITE, 'workflow', 'instance', 'notChanged')),
+      }])
+
+      await expect(dependencyChanger(changesMap, emptyDeps)).resolves.toEqual([
+        { action: 'remove', dependency: { source: 1, target: 2 } },
+        { action: 'remove', dependency: { source: 1, target: 3 } },
+      ])
+    })
+    it('should not remove dependency to parent folder', async () => {
+      const changesMap = new Map([
+        [1, toChange({ after: fileInstance })],
+        [2, toChange({ after: folderInstance })],
+        [3, toChange({ after: anotherInstance })],
+      ])
+
+      fileInstance.annotations[CORE_ANNOTATIONS.PARENT] = [
+        new ReferenceExpression(folderInstance.elemID),
+      ]
+
+      extendGeneratedDependencies(fileInstance, [{
+        reference: new ReferenceExpression(folderInstance.elemID.createNestedID(PATH)),
+      }, {
+        reference: new ReferenceExpression(anotherInstance.elemID.createNestedID(SCRIPT_ID)),
+      }, {
+        reference: new ReferenceExpression(new ElemID(NETSUITE, 'workflow', 'instance', 'notChanged')),
+      }])
+
+      await expect(dependencyChanger(changesMap, emptyDeps)).resolves.toEqual([
+        { action: 'remove', dependency: { source: 1, target: 3 } },
+      ])
+    })
+    it('should not remove dependencies in non file instance', async () => {
+      const changesMap = new Map([
+        [1, toChange({ after: fileInstance })],
+        [2, toChange({ after: folderInstance })],
+        [3, toChange({ after: anotherInstance })],
+      ])
+
+      extendGeneratedDependencies(anotherInstance, [{
+        reference: new ReferenceExpression(folderInstance.elemID.createNestedID(PATH)),
+      }, {
+        reference: new ReferenceExpression(fileInstance.elemID.createNestedID(PATH)),
+      }])
+
+      await expect(dependencyChanger(changesMap, emptyDeps)).resolves.toEqual([])
+    })
+  })
+})


### PR DESCRIPTION
Suitescript files generated dependencies can cause a circular dependencies error between SDF deploy group and SuiteApp FileCabinet deploy group, although there is no real dependency between them (there is a real dependency between the script instance and the file instance, so the file instance should be deployed before).

In order to solve it, we remove the dependencies that file instances have. This should have no harm (as the file instance itself don’t really depend on anything but its parent folder).

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Fix circular dependencies in suitescript files deploy

---
_User Notifications_: 
None
