### PR TITLE
SALTO-4044/retry on status deployment error

### DIFF
--- a/packages/jira-adapter/src/filters/statuses/status_deployment.ts
+++ b/packages/jira-adapter/src/filters/statuses/status_deployment.ts
@@ -75,6 +75,7 @@ const retry = async <T>(
       if (retries === 1) {
         throw error
       }
+      log.warn(`Request to update statuses failed, retrying ${retries} more times.`)
       return retry(fn, retries - 1)
     }
     throw error

--- a/packages/jira-adapter/src/filters/statuses/status_deployment.ts
+++ b/packages/jira-adapter/src/filters/statuses/status_deployment.ts
@@ -75,7 +75,7 @@ const retry = async <T>(
       if (retries === 1) {
         throw error
       }
-      log.warn(`Request to update statuses failed, retrying ${retries} more times.`)
+      log.debug(`Request to update statuses failed, retrying ${retries} more times.`)
       return retry(fn, retries - 1)
     }
     throw error

--- a/packages/jira-adapter/src/filters/statuses/status_deployment.ts
+++ b/packages/jira-adapter/src/filters/statuses/status_deployment.ts
@@ -18,6 +18,7 @@ import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { createSchemeGuard } from '@salto-io/adapter-utils'
 import Joi from 'joi'
+import { client as clientUtils } from '@salto-io/adapter-components'
 import { deployChanges } from '../../deployment/standard_deployment'
 import { findObject, setFieldDeploymentAnnotations } from '../../utils'
 import { FilterCreator } from '../../filter'
@@ -25,6 +26,7 @@ import { STATUS_TYPE_NAME } from '../../constants'
 import JiraClient from '../../client/client'
 
 const log = logger(module)
+const MAX_RETRIES = 3
 const STATUS_CATEGORY_NAME_TO_ID : Record<string, number> = {
   TODO: 2,
   DONE: 3,
@@ -61,31 +63,52 @@ const createDeployableStatusValues = (
   return deployableValue
 }
 
+const retry = async <T>(
+  fn: () => Promise<T>,
+  retries: number = MAX_RETRIES,
+): Promise<T> => {
+  try {
+    return await fn()
+  } catch (error) {
+    if (error instanceof clientUtils.HTTPError && Array.isArray(error.response.data.errorMessages)
+      && error.response?.data?.errorMessages?.some((message: string) => message.includes('Failed to acquire lock'))) {
+      if (retries === 1) {
+        throw error
+      }
+      return retry(fn, retries - 1)
+    }
+    throw error
+  }
+}
+
 const modifyStatus = async (
   modificationChange: ModificationChange<InstanceElement>,
   client: JiraClient,
 ): Promise<void> => {
-  await client.put({
-    url: '/rest/api/3/statuses',
-    data: {
-      statuses: [createDeployableStatusValues(modificationChange)],
-    },
-  })
+  await retry(async () =>
+    client.put({
+      url: '/rest/api/3/statuses',
+      data: {
+        statuses: [createDeployableStatusValues(modificationChange)],
+      },
+    }))
 }
 
 const addStatus = async (
   additionChange: AdditionChange<InstanceElement>,
   client: JiraClient,
 ): Promise<void> => {
-  const response = await client.post({
-    url: '/rest/api/3/statuses',
-    data: {
-      scope: {
-        type: 'GLOBAL',
+  const response = await retry(async () =>
+    client.post({
+      url: '/rest/api/3/statuses',
+      data: {
+        scope: {
+          type: 'GLOBAL',
+        },
+        statuses: [createDeployableStatusValues(additionChange)],
       },
-      statuses: [createDeployableStatusValues(additionChange)],
-    },
-  })
+    }))
+
   if (!isStatusResponse(response.data)) {
     throw new Error(`Received an invalid status response when attempting to create status: ${additionChange.data.after.elemID.getFullName()}`)
   }

--- a/packages/jira-adapter/test/filters/statuses/status_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/statuses/status_deployment.test.ts
@@ -23,7 +23,6 @@ import { getDefaultConfig, JiraConfig } from '../../../src/config/config'
 import { JIRA, STATUS_TYPE_NAME } from '../../../src/constants'
 import JiraClient from '../../../src/client/client'
 
-jest.setTimeout(111111)
 describe('statusDeploymentFilter', () => {
   let filter: filterUtils.FilterWith<'onFetch' | 'deploy'>
   let mockConnection: MockInterface<clientUtils.APIConnection>


### PR DESCRIPTION
add retry for status deployment when we receive a specific error from the service with "Failed to acquire lock"


---

_Additional context for reviewer_
since i was not able to reproduce the error myself i found the specific log that had the request error in it and made a unit test that mocks that error.

---
_Release Notes_: 
jira adapter:
* add retry to specific deployment bug for statuses.

---
_User Notifications_: 

