### PR TITLE
SALTO-4192 log HTTP response on errors as well

### DIFF
--- a/packages/adapter-components/test/client/http_client.test.ts
+++ b/packages/adapter-components/test/client/http_client.test.ts
@@ -80,9 +80,11 @@ describe('client_http_client', () => {
       expect(clearValuesFromResponseDataFunc).toHaveBeenCalledTimes(2)
       expect(clearValuesFromResponseDataFunc).toHaveBeenNthCalledWith(1, { a: 'b' }, '/ep')
       expect(clearValuesFromResponseDataFunc).toHaveBeenNthCalledWith(2, { c: 'd' }, '/ep2')
-      expect(extractHeadersFunc).toHaveBeenCalledTimes(2)
+      expect(extractHeadersFunc).toHaveBeenCalledTimes(4)
       expect(extractHeadersFunc).toHaveBeenNthCalledWith(1, { h: '123', 'X-Rate-Limit': '456', 'Retry-After': '93' })
-      expect(extractHeadersFunc).toHaveBeenNthCalledWith(2, { hh: 'header' })
+      expect(extractHeadersFunc).toHaveBeenNthCalledWith(2, { h: '123', 'X-Rate-Limit': '456', 'Retry-After': '93' })
+      expect(extractHeadersFunc).toHaveBeenNthCalledWith(3, { hh: 'header' })
+      expect(extractHeadersFunc).toHaveBeenNthCalledWith(4, { hh: 'header' })
     })
 
     it('should throw Unauthorized on login 401', async () => {

--- a/packages/okta-adapter/test/client/client.test.ts
+++ b/packages/okta-adapter/test/client/client.test.ts
@@ -106,9 +106,11 @@ describe('client', () => {
           { id: 'a', type: 'google', methods: [{ google: { secretKey: '<SECRET>' } }, { sso: { secretKey: '<SECRET>' } }] },
           { id: 'b', type: 'password', credentials: { client: '123' }, methods: ['1', '2', '3'], sharedSecret: '<SECRET>' },
         ])
-      expect(extractHeadersFunc).toHaveBeenCalledTimes(2)
+      expect(extractHeadersFunc).toHaveBeenCalledTimes(4)
       expect(extractHeadersFunc).toHaveNthReturnedWith(1, {})
-      expect(extractHeadersFunc).toHaveNthReturnedWith(2, { link: 'aaa', 'x-rate-limit': '456', 'x-rate-limit-remaining': '456' })
+      expect(extractHeadersFunc).toHaveNthReturnedWith(2, {})
+      expect(extractHeadersFunc).toHaveNthReturnedWith(3, { link: 'aaa', 'x-rate-limit': '456', 'x-rate-limit-remaining': '456' })
+      expect(extractHeadersFunc).toHaveNthReturnedWith(4, { link: 'aaa', 'x-rate-limit': '456', 'x-rate-limit-remaining': '456' })
     })
   })
   describe('get baseurl', () => {

--- a/packages/zendesk-adapter/test/change_validators/organization_existence.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/organization_existence.test.ts
@@ -84,6 +84,7 @@ describe('OrganizationExistence', () => {
   beforeEach(() => {
     mockAxios = new MockAdapter(axios)
     client = new ZendeskClient({ credentials: { username: 'a', password: 'b', subdomain: 'ignore' } })
+    logTrace.mockReset()
   })
 
   afterEach(() => {
@@ -176,7 +177,7 @@ describe('OrganizationExistence', () => {
       'Full HTTP response for %s on %s: %s',
       'GET',
       '/api/v2/organizations/show_many?ids=1,2',
-      '{"url":"/api/v2/organizations/show_many?ids=1,2","response":{"organizations":[{"id":1,"name":"<OMITTED>"},{"id":2,"name":"<OMITTED>"}]},"method":"GET"}',
+      '{"url":"/api/v2/organizations/show_many?ids=1,2","method":"GET","status":200,"response":{"organizations":[{"id":1,"name":"<OMITTED>"},{"id":2,"name":"<OMITTED>"}]}}',
     ])
   })
 })

--- a/packages/zendesk-adapter/test/client/client.test.ts
+++ b/packages/zendesk-adapter/test/client/client.test.ts
@@ -32,6 +32,7 @@ describe('client', () => {
     let client: ZendeskClient
     beforeEach(() => {
       mockAxios = new MockAdapter(axios)
+      logTrace.mockReset()
       client = new ZendeskClient({
         credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
         config: { retry: { retryDelay: 0 } },
@@ -89,32 +90,32 @@ describe('client', () => {
       await client.getSinglePage({ url: 'organizations/show_many' })
       await client.getSinglePage({ url: 'organizations/autocomplete' })
 
-      expect(logTrace).toHaveBeenNthCalledWith(2, [
+      expect(logTrace).toHaveBeenNthCalledWith(1, [
         'Full HTTP response for %s on %s: %s',
         'GET',
         'organizations/show_many',
-        '{"url":"organizations/show_many","response":{"organizations":[{"id":1,"name":"org1"},{"id":2,"name":"org2"}]},"method":"GET"}',
+        '{"url":"organizations/show_many","method":"GET","status":200,"response":{"organizations":[{"id":1,"name":"org1"},{"id":2,"name":"org2"}]}}',
+      ])
+
+      expect(logTrace).toHaveBeenNthCalledWith(2, [
+        'Full HTTP response for %s on %s: %s',
+        'GET',
+        'organizations/autocomplete',
+        '{"url":"organizations/autocomplete","method":"GET","status":200,"response":{"organizations":[{"id":1,"name":"org1"},{"id":2,"name":"org2"}]}}',
       ])
 
       expect(logTrace).toHaveBeenNthCalledWith(3, [
         'Full HTTP response for %s on %s: %s',
         'GET',
-        'organizations/autocomplete',
-        '{"url":"organizations/autocomplete","response":{"organizations":[{"id":1,"name":"org1"},{"id":2,"name":"org2"}]},"method":"GET"}',
+        'organizations/show_many',
+        '{"url":"organizations/show_many","method":"GET","status":200,"response":{"organizations":[{"id":1,"name":"<OMITTED>"},{"id":2,"name":"<OMITTED>"}]}}',
       ])
 
       expect(logTrace).toHaveBeenNthCalledWith(4, [
         'Full HTTP response for %s on %s: %s',
         'GET',
-        'organizations/show_many',
-        '{"url":"organizations/show_many","response":{"organizations":[{"id":1,"name":"<OMITTED>"},{"id":2,"name":"<OMITTED>"}]},"method":"GET"}',
-      ])
-
-      expect(logTrace).toHaveBeenNthCalledWith(5, [
-        'Full HTTP response for %s on %s: %s',
-        'GET',
         'organizations/autocomplete',
-        '{"url":"organizations/autocomplete","response":{"organizations":[{"id":1,"name":"<OMITTED>"},{"id":2,"name":"<OMITTED>"}]},"method":"GET"}',
+        '{"url":"organizations/autocomplete","method":"GET","status":200,"response":{"organizations":[{"id":1,"name":"<OMITTED>"},{"id":2,"name":"<OMITTED>"}]}}',
       ])
     })
   })


### PR DESCRIPTION
Trace the HTTP responses even when there are HTTP errors

---
_Release Notes_: 
None

---
_User Notifications_: 
None