### PR TITLE
SALTO-4149: Increase default concurrent connections

### DIFF
--- a/packages/jira-adapter/src/client/client.ts
+++ b/packages/jira-adapter/src/client/client.ts
@@ -30,7 +30,7 @@ const {
 
 const DEFAULT_MAX_CONCURRENT_API_REQUESTS: Required<clientUtils.ClientRateLimitConfig> = {
   total: RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,
-  get: 20,
+  get: 60,
   deploy: 2,
 }
 


### PR DESCRIPTION
Increased the default concurrent connections from 20 to 60, which should improve the fetch performance


---
_Release Notes_: 
Jira Adapter:
* Increased the default concurrent connections limit, which significantly improves the fetch performance

---
_User Notifications_: 
None
