### PR TITLE
SALTO-2428 SDF Folder Loader

### DIFF
--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -55,8 +55,8 @@ const logging = (message: string): void => {
 describe('Netsuite adapter E2E with real account', () => {
   let adapter: NetsuiteAdapter
   let credentialsLease: CredsLease<Required<Credentials>>
-  const { standardTypes, enums, additionalTypes, fieldTypes } = getMetadataTypes()
-  const metadataTypes = metadataTypesToList({ standardTypes, enums, additionalTypes, fieldTypes })
+  const { standardTypes, additionalTypes } = getMetadataTypes()
+  const metadataTypes = metadataTypesToList({ standardTypes, additionalTypes })
 
   const createInstanceElement = (type: string, valuesOverride: Values): InstanceElement => {
     const instValues = {

--- a/packages/netsuite-adapter/e2e_test/sdf_executor.ts
+++ b/packages/netsuite-adapter/e2e_test/sdf_executor.ts
@@ -1,0 +1,120 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import os from 'os'
+import osPath from 'path'
+import { v4 as uuidv4 } from 'uuid'
+import { rm } from '@salto-io/file'
+import Bottleneck from 'bottleneck'
+import { SdfCredentials, toCredentialsAccountId } from '../src/client/credentials'
+import SdfClient, { ALL_FEATURES, COMMANDS, safeQuoteArgument } from '../src/client/sdf_client'
+import { DEFAULT_MAX_ITEMS_IN_IMPORT_OBJECTS_REQUEST } from '../src/config'
+import { FILE_CABINET_PATH_SEPARATOR } from '../src/constants'
+import { OBJECTS_DIR } from '../src/client/sdf_parser'
+
+export type ProjectInfo = {
+  projectPath: string
+  authId: string
+}
+type SDFExecutor = {
+  createProject: (credentials: SdfCredentials) => Promise<ProjectInfo>
+  importObjects: (projectPath: string, objectIds: Array<{ type: string; scriptid: string }>) => Promise<void>
+  importFiles: (projectPath: string, filePaths: string[]) => Promise<void>
+  importFeatures: (projectPath: string) => Promise<void>
+  deleteProject: (projectInfo: ProjectInfo) => Promise<void>
+}
+export const createSdfExecutor = (): SDFExecutor => {
+  const baseExecutionPath = os.tmpdir()
+  const baseCommandExecutor = SdfClient.initCommandActionExecutor(baseExecutionPath)
+  const limiter = new Bottleneck({ maxConcurrent: 4 })
+
+  return {
+    createProject: async credentials => {
+      const authId = uuidv4()
+      const projectName = `sdf-${authId}`
+      await baseCommandExecutor.executeAction({
+        commandName: COMMANDS.CREATE_PROJECT,
+        runInInteractiveMode: false,
+        arguments: {
+          projectname: projectName,
+          type: 'ACCOUNTCUSTOMIZATION',
+          parentdirectory: osPath.join(baseExecutionPath, projectName),
+        },
+      })
+      const projectPath = osPath.resolve(baseExecutionPath, projectName)
+      const executor = SdfClient.initCommandActionExecutor(projectPath)
+      const setupCommandArguments = {
+        authid: authId,
+        account: toCredentialsAccountId(credentials.accountId),
+        tokenid: credentials.tokenId,
+        tokensecret: credentials.tokenSecret,
+      }
+      await executor.executeAction({
+        commandName: COMMANDS.SAVE_TOKEN,
+        runInInteractiveMode: false,
+        arguments: _.mapValues(setupCommandArguments, safeQuoteArgument),
+      })
+      return { projectPath, authId }
+    },
+    importObjects: async (projectPath, objectIds) => {
+      const executor = SdfClient.initCommandActionExecutor(projectPath)
+      await Promise.all(objectIds.map(({ type, scriptid }) => limiter.schedule(
+        () => executor.executeAction({
+          commandName: COMMANDS.IMPORT_OBJECTS,
+          runInInteractiveMode: false,
+          arguments: {
+            destinationfolder: `${FILE_CABINET_PATH_SEPARATOR}${OBJECTS_DIR}`,
+            type,
+            scriptid,
+            maxItemsInImportObjectsRequest: DEFAULT_MAX_ITEMS_IN_IMPORT_OBJECTS_REQUEST,
+            excludefiles: true,
+            appid: undefined,
+          },
+        })
+      )))
+    },
+    importFiles: async (projectPath, filePaths) => {
+      const executor = SdfClient.initCommandActionExecutor(projectPath)
+      await limiter.schedule(() => executor.executeAction({
+        commandName: COMMANDS.IMPORT_FILES,
+        runInInteractiveMode: false,
+        arguments: {
+          paths: filePaths,
+        },
+      }))
+    },
+    importFeatures: async projectPath => {
+      const executor = SdfClient.initCommandActionExecutor(projectPath)
+      await limiter.schedule(() => executor.executeAction({
+        commandName: COMMANDS.IMPORT_CONFIGURATION,
+        runInInteractiveMode: false,
+        arguments: {
+          configurationid: ALL_FEATURES,
+        },
+      }))
+    },
+    deleteProject: async ({ projectPath, authId }) => {
+      await rm(projectPath)
+      await baseCommandExecutor.executeAction({
+        commandName: COMMANDS.MANAGE_AUTH,
+        runInInteractiveMode: false,
+        arguments: {
+          remove: authId,
+        },
+      })
+    },
+  }
+}

--- a/packages/netsuite-adapter/package.json
+++ b/packages/netsuite-adapter/package.json
@@ -46,6 +46,7 @@
     "compare-versions": "4.1.3",
     "crypto": "^1.0.1",
     "fast-xml-parser": "^3.15.0",
+    "readdirp": "^3.1.1",
     "he": "^1.2.0",
     "lodash": "^4.17.21",
     "moment": "^2.24.0",

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -59,6 +59,7 @@ import customRecordTypesType from './filters/custom_record_types'
 import customRecordsFilter from './filters/custom_records'
 import currencyUndeployableFieldsFilter from './filters/currency_omit_fields'
 import additionalChanges from './filters/additional_changes'
+import addInstancesFetchTime from './filters/add_instances_fetch_time'
 import { Filter, LocalFilterCreator, LocalFilterCreatorDefinition, RemoteFilterCreator, RemoteFilterCreatorDefinition } from './filter'
 import { getConfigFromConfigChanges, NetsuiteConfig, DEFAULT_DEPLOY_REFERENCED_ELEMENTS, DEFAULT_WARN_STALE_DATA, DEFAULT_VALIDATE, AdditionalDependencies, DEFAULT_MAX_FILE_CABINET_SIZE_IN_GB } from './config'
 import { andQuery, buildNetsuiteQuery, NetsuiteQuery, NetsuiteQueryParameters, notQuery, QueryParams, convertToQueryParams, getFixedTargetFetch } from './query'
@@ -119,6 +120,7 @@ export const allFilters: (LocalFilterCreatorDefinition | RemoteFilterCreatorDefi
   { creator: suiteAppConfigElementsFilter },
   { creator: configFeaturesFilter },
   { creator: customRecordsFilter },
+  { creator: addInstancesFetchTime },
   // serviceUrls must run after suiteAppInternalIds and SDFInternalIds filter
   { creator: serviceUrls, addsNewInformation: true },
   // omitFieldsFilter should be the last onFetch filter to run

--- a/packages/netsuite-adapter/src/adapter_creator.ts
+++ b/packages/netsuite-adapter/src/adapter_creator.ts
@@ -27,6 +27,7 @@ import SuiteAppClient from './client/suiteapp_client/suiteapp_client'
 import SdfClient from './client/sdf_client'
 import NetsuiteClient from './client/client'
 import NetsuiteAdapter from './adapter'
+import loadElementsFromFolder from './sdf_folder_loader'
 
 const log = logger(module)
 
@@ -256,4 +257,5 @@ export const adapter: Adapter = {
       return { success: false, errors: [err.message ?? err] }
     }
   },
+  loadElementsFromFolder,
 }

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -91,7 +91,7 @@ export const COMMANDS = {
 }
 
 const ALL = 'ALL'
-const ALL_FEATURES = 'FEATURES:ALL_FEATURES'
+export const ALL_FEATURES = 'FEATURES:ALL_FEATURES'
 
 // e.g. *** ERREUR ***
 const fatalErrorMessageRegex = RegExp('^\\*\\*\\*.+\\*\\*\\*$')
@@ -101,7 +101,7 @@ const SINGLE_OBJECT_RETRIES = 3
 
 const baseExecutionPath = os.tmpdir()
 
-const safeQuoteArgument = (argument: unknown): unknown => {
+export const safeQuoteArgument = (argument: unknown): unknown => {
   if (typeof argument === 'string') {
     return shellQuote.quote([argument])
   }
@@ -182,7 +182,7 @@ export default class SdfClient {
     return this.credentials
   }
 
-  private static initCommandActionExecutor(executionPath: string): CommandActionExecutor {
+  public static initCommandActionExecutor(executionPath: string): CommandActionExecutor {
     return new CommandActionExecutor({
       executionPath,
       cliConfigurationService: new CLIConfigurationService(),

--- a/packages/netsuite-adapter/src/filter.ts
+++ b/packages/netsuite-adapter/src/filter.ts
@@ -29,6 +29,7 @@ export type LocalFilterOpts = {
   isPartial: boolean
   config: NetsuiteConfig
   changesGroupId?: string
+  fetchTime?: Date
 }
 
 export type RemoteFilterOpts = LocalFilterOpts & {

--- a/packages/netsuite-adapter/src/filters/add_instances_fetch_time.ts
+++ b/packages/netsuite-adapter/src/filters/add_instances_fetch_time.ts
@@ -1,0 +1,60 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { logger } from '@salto-io/logging'
+import { isInstanceElement } from '@salto-io/adapter-api'
+import { LocalFilterCreator } from '../filter'
+import { SERVER_TIME_TYPE_NAME } from '../server_time'
+import { getServiceId, isStandardInstanceOrCustomRecordType, isFileCabinetInstance } from '../types'
+
+const log = logger(module)
+
+const filterCreator: LocalFilterCreator = ({ fetchTime }) => ({
+  name: 'addInstancesFetchTime',
+  /**
+   * Add fetchTime as the value in server_time instance's "instancesFetchTime" for all the fetched instances.
+   *
+   * NOTE: We only add sdf based instances & file cabinet instances - because changes_detector supports only them.
+   */
+  onFetch: async elements => {
+    if (fetchTime === undefined) {
+      return
+    }
+
+    const serverTimeInstance = elements.filter(isInstanceElement)
+      .find(inst => inst.elemID.typeName === SERVER_TIME_TYPE_NAME)
+
+    if (serverTimeInstance === undefined) {
+      return
+    }
+
+    if (serverTimeInstance.value.instancesFetchTime === undefined) {
+      serverTimeInstance.value.instancesFetchTime = {}
+    }
+
+    elements
+      .filter(elem => isStandardInstanceOrCustomRecordType(elem) || isFileCabinetInstance(elem))
+      .forEach(elem => {
+        const serviceId = getServiceId(elem)
+        if (serviceId !== undefined) {
+          serverTimeInstance.value.instancesFetchTime[serviceId] = fetchTime.toJSON()
+        } else {
+          log.warn('Element %s has no serviceId so cannot save it\'s fetchTime', elem.elemID.getFullName())
+        }
+      })
+  },
+})
+
+export default filterCreator

--- a/packages/netsuite-adapter/src/sdf_folder_loader.ts
+++ b/packages/netsuite-adapter/src/sdf_folder_loader.ts
@@ -1,0 +1,48 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { FetchResult, LoadElementsFromFolderArgs } from '@salto-io/adapter-api'
+import { filter } from '@salto-io/adapter-utils'
+import { allFilters } from './adapter'
+import { createElementsSourceIndex } from './elements_source_index/elements_source_index'
+import { parseSdfProjectDir } from './client/sdf_parser'
+import { createElements } from './transformer'
+
+const localFilters = allFilters
+  .filter(filter.isLocalFilterCreator)
+  .map(({ creator }) => creator)
+
+const loadElementsFromFolder = async (
+  { baseDir, elementSource }: LoadElementsFromFolderArgs,
+  filters = localFilters,
+): Promise<FetchResult> => {
+  const isPartial = true
+  const filtersRunner = filter.filtersRunner(
+    {
+      elementsSourceIndex: createElementsSourceIndex(elementSource, isPartial),
+      elementsSource: elementSource,
+      isPartial,
+      config: {},
+    },
+    filters,
+  )
+  const customizationInfos = await parseSdfProjectDir(baseDir)
+  const elements = await createElements(customizationInfos)
+  await filtersRunner.onFetch(elements)
+
+  return { elements }
+}
+
+export default loadElementsFromFolder

--- a/packages/netsuite-adapter/src/transformer.ts
+++ b/packages/netsuite-adapter/src/transformer.ts
@@ -50,6 +50,10 @@ const toXmlBoolean = (value: boolean): string => (value ? XML_TRUE_VALUE : XML_F
 // don't load hidden files to the workspace in the core.
 const removeDotPrefix = (name: string): string => name.replace(/^\.+/, '_')
 
+export const addApplicationIdToType = (type: ObjectType): void => {
+  type.fields[APPLICATION_ID] = new Field(type, APPLICATION_ID, BuiltinTypes.STRING)
+}
+
 export const createInstanceElement = async (
   customizationInfo: CustomizationInfo,
   type: ObjectType,
@@ -168,9 +172,7 @@ export const createElements = async (
   const { standardTypes, additionalTypes } = getMetadataTypes()
 
   getTopLevelStandardTypes(standardTypes).concat(Object.values(additionalTypes))
-    .forEach(type => {
-      type.fields[APPLICATION_ID] = new Field(type, APPLICATION_ID, BuiltinTypes.STRING)
-    })
+    .forEach(addApplicationIdToType)
 
   const customizationInfosWithTypes = customizationInfos
     .map(customizationInfo => ({

--- a/packages/netsuite-adapter/src/type_parsers/report_definition_parsing/parsed_report_definition.ts
+++ b/packages/netsuite-adapter/src/type_parsers/report_definition_parsing/parsed_report_definition.ts
@@ -216,7 +216,8 @@ export const reportdefinitionType = (): TypeAndInnerTypes => {
   const reportDefinitionUiPrefElemID = new ElemID(constants.NETSUITE, 'reportdefinition_uipreferences')
   const reportDefinitionLayoutsElemID = new ElemID(constants.NETSUITE, 'reportdefinition_layouts')
   const reportDefinitionParamsElemID = new ElemID(constants.NETSUITE, 'reportdefinition_parameters')
-  const reportDefinitionInnerFieldsElemID = new ElemID(constants.NETSUITE, 'reportdefinition_fields')
+  // TODO: SALTO-4199 change 'reportdefinition_fields' to 'reportdefinition_flags'
+  const reportDefinitionFlagsElemID = new ElemID(constants.NETSUITE, 'reportdefinition_fields')
   const reportDefinitionAudienceElemID = new ElemID(constants.NETSUITE, 'reportdefinition_audience')
   const reportdefinitionAccessAudienceElemID = new ElemID(constants.NETSUITE, 'reportdefinition_accessaudience')
 
@@ -429,8 +430,8 @@ export const reportdefinitionType = (): TypeAndInnerTypes => {
     path: [constants.NETSUITE, constants.TYPES_PATH, reportDefinitionElemID.name],
   })
 
-  const reportDefinitionInnerFields = createMatchingObjectType<ReportDefinitionInnerFields>({
-    elemID: reportDefinitionInnerFieldsElemID,
+  const reportDefinitionFlags = createMatchingObjectType<ReportDefinitionInnerFields>({
+    elemID: reportDefinitionFlagsElemID,
     annotations: {
     },
     fields: {
@@ -475,7 +476,7 @@ export const reportdefinitionType = (): TypeAndInnerTypes => {
   innerTypes.reportDefinitionCriteria = reportDefinitionCriteria
   innerTypes.reportDefinitionCriteriaDescriptor = reportCriteriaDescriptor
   innerTypes.reportDefinitionCriteriaValues = reportCriteriaValues
-  innerTypes.reportDefinitionInnerFields = reportDefinitionInnerFields
+  innerTypes.reportDefinitionFlags = reportDefinitionFlags
   innerTypes.reportdefinition_dependencies = reportDefinitionDependencies
   innerTypes.reportDefinitionFields = reportDefinitionFields
   innerTypes.reportDefinitionLayouts = reportDefinitionLayouts
@@ -540,7 +541,7 @@ export const reportdefinitionType = (): TypeAndInnerTypes => {
         refType: reportDefinitionUiPref,
       },
       flags: {
-        refType: reportDefinitionInnerFields,
+        refType: reportDefinitionFlags,
       },
     },
     annotations: {

--- a/packages/netsuite-adapter/src/types.ts
+++ b/packages/netsuite-adapter/src/types.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { DeployResult as AdapterApiDeployResult, Element, InstanceElement, isField, isInstanceElement, isObjectType, ObjectType, PrimitiveType, TypeElement, TypeReference, Value, Values } from '@salto-io/adapter-api'
+import { DeployResult as AdapterApiDeployResult, Element, InstanceElement, isField, isInstanceElement, isObjectType, ObjectType, TypeElement, TypeReference, Value, Values } from '@salto-io/adapter-api'
 import { values as lowerDashValues } from '@salto-io/lowerdash'
 import { fieldTypes } from './types/field_types'
 import { enums } from './autogen/types/enums'
@@ -21,7 +21,7 @@ import { StandardType, getStandardTypes, isStandardTypeName, getStandardTypesNam
 import { TypesMap } from './types/object_types'
 import { fileCabinetTypesNames, getFileCabinetTypes } from './types/file_cabinet_types'
 import { getConfigurationTypes } from './types/configuration_types'
-import { CONFIG_FEATURES, CUSTOM_FIELD_PREFIX, CUSTOM_RECORD_TYPE, CUSTOM_RECORD_TYPE_PREFIX, METADATA_TYPE, SOAP, INTERNAL_ID } from './constants'
+import { CONFIG_FEATURES, CUSTOM_FIELD_PREFIX, CUSTOM_RECORD_TYPE, CUSTOM_RECORD_TYPE_PREFIX, METADATA_TYPE, SOAP, INTERNAL_ID, SCRIPT_ID, PATH } from './constants'
 import { SUPPORTED_TYPES } from './data_elements/types'
 
 const { isDefined } = lowerDashValues
@@ -73,16 +73,12 @@ export const removeCustomRecordTypePrefix = (name: string): string =>
 
 type MetadataTypes = {
   standardTypes: TypesMap<StandardType>
-  enums: Readonly<Record<string, PrimitiveType>>
   additionalTypes: Readonly<Record<string, ObjectType>>
-  fieldTypes: Readonly<Record<string, PrimitiveType>>
 }
 
 export const getMetadataTypes = (): MetadataTypes => ({
   standardTypes: getStandardTypes(),
-  enums,
   additionalTypes: { ...getFileCabinetTypes(), ...getConfigurationTypes() },
-  fieldTypes,
 })
 
 export const getTopLevelStandardTypes = (standardTypes: TypesMap<StandardType>): ObjectType[] =>
@@ -180,6 +176,9 @@ export const getInternalId = (element: Element): Value =>
 
 export const hasInternalId = (element: Element): boolean =>
   isDefined(getInternalId(element))
+
+export const getServiceId = (element: Element): string =>
+  getElementValueOrAnnotations(element)[isFileCabinetInstance(element) ? PATH : SCRIPT_ID]
 
 export const netsuiteSupportedTypes = [
   ...getStandardTypesNames(),

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -130,8 +130,8 @@ describe('Adapter', () => {
     progressReporter: { reportProgress: jest.fn() },
   }
 
-  const { standardTypes, enums, additionalTypes, fieldTypes } = getMetadataTypes()
-  const metadataTypes = metadataTypesToList({ standardTypes, enums, additionalTypes, fieldTypes })
+  const { standardTypes, additionalTypes } = getMetadataTypes()
+  const metadataTypes = metadataTypesToList({ standardTypes, additionalTypes })
     .concat(createCustomRecordTypes([], standardTypes.customrecordtype.type))
 
   beforeEach(() => {

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -56,6 +56,7 @@ jest.mock('@salto-io/file', () => ({
   mkdirp: jest.fn(),
   rm: jest.fn(),
   stat: jest.fn().mockImplementation(path => statMockFunction(path)),
+  exists: jest.fn().mockResolvedValue(true),
 }))
 const readFileMock = readFile as unknown as jest.Mock
 const readDirMock = readDir as jest.Mock

--- a/packages/netsuite-adapter/test/filters/add_instances_fetch_time.test.ts
+++ b/packages/netsuite-adapter/test/filters/add_instances_fetch_time.test.ts
@@ -1,0 +1,104 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import filterCreator from '../../src/filters/add_instances_fetch_time'
+import { customsegmentType } from '../../src/autogen/types/standard_types/customsegment'
+import { fileType } from '../../src/types/file_cabinet_types'
+import { CUSTOM_RECORD_TYPE, METADATA_TYPE, NETSUITE, PATH, SCRIPT_ID } from '../../src/constants'
+import { SERVER_TIME_TYPE_NAME } from '../../src/server_time'
+import { LocalFilterOpts } from '../../src/filter'
+
+describe('add instances fetch time filter', () => {
+  const fetchTime = new Date('01/01/2024')
+  const serverTimeType = new ObjectType({ elemID: new ElemID(NETSUITE, SERVER_TIME_TYPE_NAME) })
+
+  let serverTimeInstance: InstanceElement
+  beforeEach(() => {
+    serverTimeInstance = new InstanceElement(ElemID.CONFIG_NAME, serverTimeType)
+  })
+  it('should add standard instance fetch time', async () => {
+    const instance = new InstanceElement(
+      'cseg1',
+      customsegmentType().type,
+      { [SCRIPT_ID]: 'cseg1' }
+    )
+    await filterCreator({ fetchTime } as LocalFilterOpts).onFetch?.([serverTimeInstance, instance])
+    expect(serverTimeInstance.value.instancesFetchTime).toEqual({
+      cseg1: fetchTime.toJSON(),
+    })
+  })
+  it('should add file instance fetch time', async () => {
+    const instance = new InstanceElement(
+      'someFile',
+      fileType(),
+      { [PATH]: '/SuiteScript/someFile' }
+    )
+    await filterCreator({ fetchTime } as LocalFilterOpts).onFetch?.([serverTimeInstance, instance])
+    expect(serverTimeInstance.value.instancesFetchTime).toEqual({
+      '/SuiteScript/someFile': fetchTime.toJSON(),
+    })
+  })
+  it('should add custom record type fetch time', async () => {
+    const customRecordType = new ObjectType({
+      elemID: new ElemID(NETSUITE, 'customrecord1'),
+      annotations: {
+        [SCRIPT_ID]: 'customrecord1',
+        [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
+      },
+    })
+    await filterCreator({ fetchTime } as LocalFilterOpts).onFetch?.([serverTimeInstance, customRecordType])
+    expect(serverTimeInstance.value.instancesFetchTime).toEqual({
+      customrecord1: fetchTime.toJSON(),
+    })
+  })
+  it('should not add data instance fetch time', async () => {
+    const dataType = new ObjectType({ elemID: new ElemID(NETSUITE, 'account') })
+    const instance = new InstanceElement(
+      'account1',
+      dataType,
+      { [SCRIPT_ID]: 'account1' }
+    )
+    await filterCreator({ fetchTime } as LocalFilterOpts).onFetch?.([serverTimeInstance, instance])
+    expect(serverTimeInstance.value.instancesFetchTime).toEqual({})
+  })
+  it('should not add without fetch time', async () => {
+    const instance = new InstanceElement(
+      'cseg1',
+      customsegmentType().type,
+      { [SCRIPT_ID]: 'cseg1' }
+    )
+    await filterCreator({} as LocalFilterOpts).onFetch?.([serverTimeInstance, instance])
+    expect(serverTimeInstance.value.instancesFetchTime).toBeUndefined()
+  })
+  it('should not add without server time instance', async () => {
+    const instance = new InstanceElement(
+      'cseg1',
+      customsegmentType().type,
+      { [SCRIPT_ID]: 'cseg1' }
+    )
+    await filterCreator({ fetchTime } as LocalFilterOpts).onFetch?.([instance])
+    expect(serverTimeInstance.value.instancesFetchTime).toBeUndefined()
+  })
+  it('should not add instance if service id is missing', async () => {
+    const instance = new InstanceElement(
+      'cseg1',
+      customsegmentType().type,
+      { name: 'cseg1' }
+    )
+    await filterCreator({ fetchTime } as LocalFilterOpts).onFetch?.([serverTimeInstance, instance])
+    expect(serverTimeInstance.value.instancesFetchTime).toEqual({})
+  })
+})

--- a/packages/netsuite-adapter/test/filters/author_information/system_note.test.ts
+++ b/packages/netsuite-adapter/test/filters/author_information/system_note.test.ts
@@ -46,7 +46,7 @@ describe('netsuite system note author information', () => {
   } as unknown as SuiteAppClient
 
   const client = new NetsuiteClient(SDFClient, suiteAppClient)
-  const { type: serverTimeType, instance: serverTimeInstance } = createServerTimeElements(new Date('2022-01-01'))
+  const [serverTimeType, serverTimeInstance] = createServerTimeElements(new Date('2022-01-01'))
 
   beforeEach(async () => {
     runSuiteQLMock.mockReset()

--- a/packages/netsuite-adapter/test/sdf_folder_loader.test.ts
+++ b/packages/netsuite-adapter/test/sdf_folder_loader.test.ts
@@ -1,0 +1,191 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, StaticFile, isInstanceElement, isObjectType } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements, naclCase } from '@salto-io/adapter-utils'
+import { mockFunction } from '@salto-io/test-utils'
+import { CustomTypeInfo, FileCustomizationInfo, FolderCustomizationInfo } from '../src/client/types'
+import { CONFIG_FEATURES, CUSTOM_RECORD_TYPE, ENTITY_CUSTOM_FIELD, FILE, FILE_CABINET_PATH, FOLDER, NETSUITE, PATH, RECORDS_PATH, SCRIPT_ID, SETTINGS_PATH } from '../src/constants'
+import loadElementsFromFolder from '../src/sdf_folder_loader'
+import { getMetadataTypes, isCustomRecordType, metadataTypesToList } from '../src/types'
+import { createCustomRecordTypes } from '../src/custom_records/custom_record_type'
+import { LocalFilterCreator } from '../src/filter'
+import { addApplicationIdToType } from '../src/transformer'
+import { createEmptyElementsSourceIndexes } from './utils'
+
+const parseSdfProjectDirMock = jest.fn()
+jest.mock('../src/client/sdf_parser', () => ({
+  parseSdfProjectDir: jest.fn().mockImplementation((...args) => parseSdfProjectDirMock(...args)),
+}))
+
+const createElementsSourceIndexMock = jest.fn()
+jest.mock('../src/elements_source_index/elements_source_index', () => ({
+  createElementsSourceIndex: jest.fn().mockImplementation((...args) => createElementsSourceIndexMock(...args)),
+}))
+
+describe('sdf folder loader', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+  it('should return elements', async () => {
+    const folderCustomizationInfo: FolderCustomizationInfo = {
+      typeName: FOLDER,
+      values: {
+      },
+      path: ['a', 'b'],
+    }
+
+    const fileCustomizationInfo: FileCustomizationInfo = {
+      typeName: FILE,
+      values: {
+      },
+      path: ['a', 'b', 'c'],
+      fileContent: Buffer.from('Dummy content'),
+    }
+
+    const featuresCustomTypeInfo: CustomTypeInfo = {
+      typeName: CONFIG_FEATURES,
+      scriptId: CONFIG_FEATURES,
+      values: {
+        feature: [
+          { id: 'feature', label: 'Feature', status: 'ENABLED' },
+        ],
+      },
+    }
+
+    const customTypeInfo: CustomTypeInfo = {
+      typeName: ENTITY_CUSTOM_FIELD,
+      values: {
+        '@_scriptid': 'custentity_my_script_id',
+        label: 'elementName',
+      },
+      scriptId: 'custentity_my_script_id',
+    }
+
+    const customRecordTypeCustInfo: CustomTypeInfo = {
+      typeName: CUSTOM_RECORD_TYPE,
+      values: {
+        '@_scriptid': 'customrecord1',
+        recordname: 'custom record 1',
+      },
+      scriptId: 'customrecord1',
+    }
+
+    parseSdfProjectDirMock.mockResolvedValue([
+      folderCustomizationInfo,
+      fileCustomizationInfo,
+      featuresCustomTypeInfo,
+      customTypeInfo,
+      customRecordTypeCustInfo,
+    ])
+
+    const elementsSourceIndex = createEmptyElementsSourceIndexes()
+    createElementsSourceIndexMock.mockReturnValue(elementsSourceIndex)
+    const filterMock = mockFunction<LocalFilterCreator>().mockReturnValue({
+      name: 'filter',
+      onFetch: () => Promise.resolve(undefined),
+    })
+    const elementSource = buildElementsSourceFromElements([])
+
+    const { elements } = await loadElementsFromFolder(
+      {
+        baseDir: 'projectDir',
+        elementSource,
+      },
+      [filterMock]
+    )
+
+    expect(createElementsSourceIndexMock).toHaveBeenCalledWith(elementSource, true)
+    expect(filterMock).toHaveBeenCalledWith({
+      elementsSourceIndex,
+      elementsSource: elementSource,
+      isPartial: true,
+      config: {},
+    })
+    expect(parseSdfProjectDirMock).toHaveBeenCalledWith('projectDir')
+
+    const { standardTypes, additionalTypes } = getMetadataTypes()
+    const metadataTypes = metadataTypesToList({ standardTypes, additionalTypes })
+      .concat(createCustomRecordTypes([], standardTypes.customrecordtype.type))
+
+    // metadataTypes + folderInstance + fileInstance + featuresInstance + customTypeInstance + customRecordType
+    expect(elements).toHaveLength(metadataTypes.length + 5)
+
+    const instance = elements.find(elem => isInstanceElement(elem) && elem.elemID.typeName === ENTITY_CUSTOM_FIELD)
+    addApplicationIdToType(standardTypes[ENTITY_CUSTOM_FIELD].type)
+    expect(instance).toEqual(new InstanceElement(
+      'custentity_my_script_id',
+      standardTypes[ENTITY_CUSTOM_FIELD].type,
+      {
+        [SCRIPT_ID]: 'custentity_my_script_id',
+        label: 'elementName',
+      },
+      [NETSUITE, RECORDS_PATH, ENTITY_CUSTOM_FIELD, 'custentity_my_script_id']
+    ))
+
+    const fileInstance = elements.find(elem => isInstanceElement(elem) && elem.elemID.typeName === FILE)
+    addApplicationIdToType(additionalTypes[FILE])
+    expect(fileInstance).toEqual(new InstanceElement(
+      naclCase('a/b/c'),
+      additionalTypes[FILE],
+      {
+        [PATH]: '/a/b/c',
+        content: new StaticFile({
+          filepath: 'netsuite/FileCabinet/a/b/c',
+          content: Buffer.from('Dummy content'),
+        }),
+      },
+      [NETSUITE, FILE_CABINET_PATH, 'a', 'b', 'c']
+    ))
+
+    const folderInstance = elements.find(elem => isInstanceElement(elem) && elem.elemID.typeName === FOLDER)
+    addApplicationIdToType(additionalTypes[FOLDER])
+    expect(folderInstance).toEqual(new InstanceElement(
+      naclCase('a/b'),
+      additionalTypes[FOLDER],
+      {
+        [PATH]: '/a/b',
+      },
+      [NETSUITE, FILE_CABINET_PATH, 'a', 'b', 'b']
+    ))
+
+    const featuresInstance = elements.find(elem => isInstanceElement(elem) && elem.elemID.typeName === CONFIG_FEATURES)
+    addApplicationIdToType(additionalTypes[CONFIG_FEATURES])
+    expect(featuresInstance).toEqual(new InstanceElement(
+      ElemID.CONFIG_NAME,
+      additionalTypes[CONFIG_FEATURES],
+      {
+        feature: [
+          { id: 'feature', label: 'Feature', status: 'ENABLED' },
+        ],
+      },
+      [NETSUITE, SETTINGS_PATH, CONFIG_FEATURES]
+    ))
+
+    const customRecordType = elements.find(elem => isObjectType(elem) && isCustomRecordType(elem))
+    addApplicationIdToType(standardTypes[CUSTOM_RECORD_TYPE].type)
+    expect(customRecordType).toEqual(createCustomRecordTypes(
+      [new InstanceElement(
+        'customrecord1',
+        standardTypes[CUSTOM_RECORD_TYPE].type,
+        {
+          [SCRIPT_ID]: 'customrecord1',
+          recordname: 'custom record 1',
+        }
+      )],
+      standardTypes[CUSTOM_RECORD_TYPE].type
+    )[0])
+  })
+})

--- a/packages/netsuite-adapter/test/types.test.ts
+++ b/packages/netsuite-adapter/test/types.test.ts
@@ -20,11 +20,12 @@ import _ from 'lodash'
 import { values, collections } from '@salto-io/lowerdash'
 import { ADDITIONAL_FILE_SUFFIX, SCRIPT_ID, PATH } from '../src/constants'
 import { getMetadataTypes, getTopLevelStandardTypes } from '../src/types'
+import { fieldTypes } from '../src/types/field_types'
 
 const { awu } = collections.asynciterable
 
 describe('Types', () => {
-  const { standardTypes, fieldTypes, additionalTypes } = getMetadataTypes()
+  const { standardTypes, additionalTypes } = getMetadataTypes()
   describe('StandardTypes', () => {
     it('should have a required SCRIPT_ID field with regex restriction for all custom types', () => {
       getTopLevelStandardTypes(standardTypes)


### PR DESCRIPTION
Support the `loadElementsFromFolder` API.

---

_Additional context for reviewer_
This PR contains several commits that can be reviewed separately:

commit a13f6426304749efa102a862448b3cbf353f3eef
SALTO-2428 add e2e test to NS loadElementsFromFolder

commit 85b083d873483751f73ae9c58588deefdf0446e6
SALTO-2428 add loadElementsFromFolder to netsuite adapter api

commit 6901a6cbc7cfb026b2fa9e47e4eebce3f93264eb
SALTO-2428 create add-instances-fetch-time filter

commit a2939db5a196c2298ee4e7533788137da72aeb6c
SALTO-2428 move SDF transformation code from adapter.ts to transformer.ts

commit 90ac26790d9cf814f2ae240faa4adcf052bf919d
SALTO-2428 added parseSdfProjectDir function

---
_Release Notes_: 
Netsuite Adapter:
- Support the `loadElementsFromFolder` API

---
_User Notifications_: 
None
