### PR TITLE
SALTO-1857: Add logs to the deploy plan

### DIFF
--- a/packages/core/src/core/deploy/deploy_actions.ts
+++ b/packages/core/src/core/deploy/deploy_actions.ts
@@ -106,6 +106,12 @@ export const deployActions = async (
   try {
     await deployPlan.walkAsync(async (itemId: PlanItemId): Promise<void> => {
       const item = deployPlan.getItem(itemId) as PlanItem
+      log.info('Deploy item %s', item.groupKey)
+      for (const change of item.changes()) {
+        change.detailedChanges().forEach(detailedChange => {
+          log.info('Deploy change %s (action=%s)', detailedChange.id.getFullName(), detailedChange.action)
+        })
+      }
       reportProgress(item, 'started')
       try {
         const result = await deployAction(item, adapters, checkOnly)

--- a/packages/core/src/core/deploy/deploy_actions.ts
+++ b/packages/core/src/core/deploy/deploy_actions.ts
@@ -107,9 +107,9 @@ export const deployActions = async (
   try {
     await deployPlan.walkAsync(async (itemId: PlanItemId): Promise<void> => {
       const item = deployPlan.getItem(itemId) as PlanItem
-      log.info('Deploy item %s', item.groupKey)
+      log.debug('Deploy item %s', item.groupKey)
       wu(item.detailedChanges()).forEach(detailedChange => {
-        log.info('Deploy change %s (action=%s)', detailedChange.id.getFullName(), detailedChange.action)
+        log.debug('Deploy change %s (action=%s)', detailedChange.id.getFullName(), detailedChange.action)
       })
       reportProgress(item, 'started')
       try {

--- a/packages/core/src/core/deploy/deploy_actions.ts
+++ b/packages/core/src/core/deploy/deploy_actions.ts
@@ -21,6 +21,7 @@ import {
 import { detailedCompare, applyDetailedChanges } from '@salto-io/adapter-utils'
 import { WalkError, NodeSkippedError } from '@salto-io/dag'
 import { logger } from '@salto-io/logging'
+import wu from 'wu'
 import { Plan, PlanItem, PlanItemId } from '../plan'
 
 const log = logger(module)
@@ -107,11 +108,9 @@ export const deployActions = async (
     await deployPlan.walkAsync(async (itemId: PlanItemId): Promise<void> => {
       const item = deployPlan.getItem(itemId) as PlanItem
       log.info('Deploy item %s', item.groupKey)
-      for (const change of item.changes()) {
-        change.detailedChanges().forEach(detailedChange => {
-          log.info('Deploy change %s (action=%s)', detailedChange.id.getFullName(), detailedChange.action)
-        })
-      }
+      wu(item.detailedChanges()).forEach(detailedChange => {
+        log.info('Deploy change %s (action=%s)', detailedChange.id.getFullName(), detailedChange.action)
+      })
       reportProgress(item, 'started')
       try {
         const result = await deployAction(item, adapters, checkOnly)


### PR DESCRIPTION
We want to log the deploy plan of users so we can better understand on what types we should focus and to have better monitoring of deployment errors.

The new logs look likes this:

```
2023-05-21T08:03:08.958Z info core/core/deploy/deploy_actions Deploy item zendesk.ticket_field.instance.Ticket_status_custom_status@suu
2023-05-21T08:03:08.958Z info core/core/deploy/deploy_actions Deploy change zendesk.ticket_field.instance.Ticket_status_custom_status@suu.raw_title (action=modify)
2023-05-21T08:03:08.959Z info core/core/deploy/deploy_actions Deploy change zendesk.ticket_field.instance.Ticket_status_custom_status@suu.raw_description (action=modify)
```

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
