### PR TITLE
SALTO-4160/remove unknown fields on deploy

### DIFF
--- a/packages/jira-adapter/src/filters/field_configuration/replace_field_configuration_references.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/replace_field_configuration_references.ts
@@ -58,68 +58,60 @@ const replaceFromMap = async (
 }
 
 
-const filter: FilterCreator = ({ config, elementsSource }) => {
-  const instanceToFields: Record<string, Values> = {}
-  return {
-    name: 'replaceFieldConfigurationReferences',
-    onFetch: async elements => {
-      if (config.fetch.splitFieldConfiguration) {
-        return
+const filter: FilterCreator = ({ config, elementsSource }) => ({
+  name: 'replaceFieldConfigurationReferences',
+  onFetch: async elements => {
+    if (config.fetch.splitFieldConfiguration) {
+      return
+    }
+
+    const fieldConfigType = findObject(elements, FIELD_CONFIGURATION_TYPE_NAME)
+    if (fieldConfigType === undefined) {
+      return
+    }
+
+    fieldConfigType.fields.fields = new Field(
+      fieldConfigType,
+      'fields',
+      new MapType(fieldConfigType.fields.fields.refType),
+      {
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
       }
+    )
 
-      const fieldConfigType = findObject(elements, FIELD_CONFIGURATION_TYPE_NAME)
-      if (fieldConfigType === undefined) {
-        return
-      }
+    elements
+      .filter(isInstanceElement)
+      .filter(instance => instance.elemID.typeName === FIELD_CONFIGURATION_TYPE_NAME)
+      .filter(instance => Array.isArray(instance.value.fields))
+      .forEach(replaceToMap)
+  },
 
-      fieldConfigType.fields.fields = new Field(
-        fieldConfigType,
-        'fields',
-        new MapType(fieldConfigType.fields.fields.refType),
-        {
-          [CORE_ANNOTATIONS.CREATABLE]: true,
-          [CORE_ANNOTATIONS.UPDATABLE]: true,
-        }
-      )
+  preDeploy: async changes => {
+    if (config.fetch.splitFieldConfiguration) {
+      return
+    }
 
-      elements
-        .filter(isInstanceElement)
-        .filter(instance => instance.elemID.typeName === FIELD_CONFIGURATION_TYPE_NAME)
-        .filter(instance => Array.isArray(instance.value.fields))
-        .forEach(replaceToMap)
-    },
+    await awu(changes)
+      .map(getChangeData)
+      .filter(isInstanceElement)
+      .filter(instance => instance.elemID.typeName === FIELD_CONFIGURATION_TYPE_NAME)
+      .filter(instance => instance.value.fields !== undefined)
+      .forEach(async instance => replaceFromMap(instance, elementsSource))
+  },
 
-    preDeploy: async changes => {
-      if (config.fetch.splitFieldConfiguration) {
-        return
-      }
+  onDeploy: async changes => {
+    if (config.fetch.splitFieldConfiguration) {
+      return
+    }
 
-      await awu(changes)
-        .map(getChangeData)
-        .filter(isInstanceElement)
-        .filter(instance => instance.elemID.typeName === FIELD_CONFIGURATION_TYPE_NAME)
-        .filter(instance => instance.value.fields !== undefined)
-        .forEach(async instance => {
-          instanceToFields[instance.elemID.getFullName()] = instance.value.fields
-          await replaceFromMap(instance, elementsSource)
-        })
-    },
-
-    onDeploy: async changes => {
-      if (config.fetch.splitFieldConfiguration) {
-        return
-      }
-
-      changes
-        .map(getChangeData)
-        .filter(isInstanceElement)
-        .filter(instance => instance.elemID.typeName === FIELD_CONFIGURATION_TYPE_NAME)
-        .filter(instance => instance.value.fields !== undefined)
-        .forEach(instance => {
-          instance.value.fields = instanceToFields[instance.elemID.getFullName()]
-        })
-    },
-  }
-}
+    changes
+      .map(getChangeData)
+      .filter(isInstanceElement)
+      .filter(instance => instance.elemID.typeName === FIELD_CONFIGURATION_TYPE_NAME)
+      .filter(instance => instance.value.fields !== undefined)
+      .forEach(replaceToMap)
+  },
+})
 
 export default filter

--- a/packages/jira-adapter/test/filters/field_configuration/replace_field_configuration_references.test.ts
+++ b/packages/jira-adapter/test/filters/field_configuration/replace_field_configuration_references.test.ts
@@ -139,11 +139,7 @@ describe('replaceFieldConfigurationReferencesFilter', () => {
       expect(instance.value.fields).toBeArrayOfSize(0)
 
       await filter.onDeploy?.([toChange({ after: instance })])
-      expect(instance.value.fields).toEqual({
-        fieldInstance: {
-          isRequired: true,
-        },
-      })
+      expect(instance.value.fields).toEqual({})
     })
 
     it('should do nothing if splitFieldConfiguration is true', async () => {


### PR DESCRIPTION
made sure we dont put back field items that were not found in the element source (and deployed) after deploying field configurations.

---

_Additional context for reviewer_
there was a test literarily named according to what i need but the test did the opposite. i changed the test to actually work.
i didnt add any other tests.

---
_Release Notes_: 
jira_adapter:
* when deploying field configurations, if a field did not exist salto will remove it from the nacl on deploy.

---
_User Notifications_: 
