### PR TITLE
SALTO-4199 fix reportdefinition's 'flags' field type

### DIFF
--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -861,10 +861,7 @@ describe('Netsuite adapter E2E with real account', () => {
             .concat(objectsToImport)
             .concat(filesToImport)
             .map(type => type.elemID.getFullName())
-        )
-          // TODO - remove on SALTO-4199
-          .concat('netsuite.reportdefinition_fields')
-          .sort()
+        ).sort()
 
         expect(loadedElements.map(e => e.elemID.getFullName()).sort()).toEqual(expectedElements)
       })

--- a/packages/netsuite-adapter/src/type_parsers/report_definition_parsing/parsed_report_definition.ts
+++ b/packages/netsuite-adapter/src/type_parsers/report_definition_parsing/parsed_report_definition.ts
@@ -216,8 +216,7 @@ export const reportdefinitionType = (): TypeAndInnerTypes => {
   const reportDefinitionUiPrefElemID = new ElemID(constants.NETSUITE, 'reportdefinition_uipreferences')
   const reportDefinitionLayoutsElemID = new ElemID(constants.NETSUITE, 'reportdefinition_layouts')
   const reportDefinitionParamsElemID = new ElemID(constants.NETSUITE, 'reportdefinition_parameters')
-  // TODO: SALTO-4199 change 'reportdefinition_fields' to 'reportdefinition_flags'
-  const reportDefinitionFlagsElemID = new ElemID(constants.NETSUITE, 'reportdefinition_fields')
+  const reportDefinitionFlagsElemID = new ElemID(constants.NETSUITE, 'reportdefinition_flags')
   const reportDefinitionAudienceElemID = new ElemID(constants.NETSUITE, 'reportdefinition_audience')
   const reportdefinitionAccessAudienceElemID = new ElemID(constants.NETSUITE, 'reportdefinition_accessaudience')
 


### PR DESCRIPTION

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Fix reportdefinition's "flags" field type

---
_User Notifications_: 
Netsuite Adapter:
- The field type of the "flags" field in "reportdefinition" type will be changed to "reportdefinition_flags":
```
type netsuite.reportdefinition {
  ...
  netsuite.reportdefinition_flags flags {
  }
}
```