### PR TITLE
SALTO-4193: Suppress 404 on AppUserSchema

### DIFF
--- a/packages/okta-adapter/src/client/client.ts
+++ b/packages/okta-adapter/src/client/client.ts
@@ -39,6 +39,7 @@ const DEFAULT_PAGE_SIZE: Required<clientUtils.ClientPageSizeConfig> = {
   get: 50,
 }
 
+// The expression match AppUserSchema endpoint used for fetch
 const APP_USER_SCHEMA_URL = /(\/api\/v1\/meta\/schemas\/apps\/[a-zA-Z0-9]+\/default)/
 
 export default class OktaClient extends clientUtils.AdapterHTTPClient<

--- a/packages/okta-adapter/src/client/client.ts
+++ b/packages/okta-adapter/src/client/client.ts
@@ -16,6 +16,7 @@
 import _ from 'lodash'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { Values } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
 import { createConnection } from './connection'
 import { OKTA } from '../constants'
 import { Credentials } from '../auth'
@@ -24,6 +25,7 @@ import { LINK_HEADER_NAME } from './pagination'
 const {
   RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS, DEFAULT_RETRY_OPTS,
 } = clientUtils
+const log = logger(module)
 
 const DEFAULT_MAX_CONCURRENT_API_REQUESTS: Required<clientUtils.ClientRateLimitConfig> = {
   total: RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,
@@ -36,6 +38,8 @@ const DEFAULT_MAX_REQUESTS_PER_MINUTE = 700
 const DEFAULT_PAGE_SIZE: Required<clientUtils.ClientPageSizeConfig> = {
   get: 50,
 }
+
+const APP_USER_SCHEMA_URL = /(\/api\/v1\/meta\/schemas\/apps\/[a-zA-Z0-9]+\/default)/
 
 export default class OktaClient extends clientUtils.AdapterHTTPClient<
   Credentials, clientUtils.ClientRateLimitConfig
@@ -60,6 +64,22 @@ export default class OktaClient extends clientUtils.AdapterHTTPClient<
 
   public get baseUrl(): string {
     return this.credentials.baseUrl
+  }
+
+  public async getSinglePage(
+    args: clientUtils.ClientBaseParams,
+  ): Promise<clientUtils.Response<clientUtils.ResponseValue | clientUtils.ResponseValue[]>> {
+    try {
+      return await super.getSinglePage(args)
+    } catch (e) {
+      const status = e.response?.status
+      // Okta returns 404 when trying fetch AppUserSchema for built-in apps
+      if (status === 404 && args.url.match(APP_USER_SCHEMA_URL)) {
+        log.debug('Suppressing %d error %o for AppUserSchema', status, e)
+        return { data: [], status }
+      }
+      throw e
+    }
   }
 
   /**

--- a/packages/okta-adapter/test/client/client.test.ts
+++ b/packages/okta-adapter/test/client/client.test.ts
@@ -37,7 +37,8 @@ describe('client', () => {
     let result: clientUtils.ResponseValue
     beforeEach(async () => {
       // The first replyOnce with 200 is for the client authentication
-      mockAxios.onGet('/api/v1/org').replyOnce(200, { id: 1 }).onGet('/myPath').replyOnce(200, { response: 'asd' })
+      mockAxios.onGet('/api/v1/org').replyOnce(200, { id: 1 })
+        .onGet('/myPath').replyOnce(200, { response: 'asd' })
       result = await client.getSinglePage({ url: '/myPath' })
     })
     it('should return the response', () => {
@@ -48,6 +49,13 @@ describe('client', () => {
       expect(request.headers.Authorization).toEqual('SSWS token')
       expect(request.baseURL).toEqual('http://my.okta.net')
       expect(request.url).toEqual('/myPath')
+    })
+    it('should return empty array for 404 on AppUserSchema api call', async () => {
+      mockAxios
+        .onGet('/api/v1/meta/schemas/apps/0oa6e1b1916fcAiWq5d7/default')
+        .replyOnce(404)
+      result = await client.getSinglePage({ url: '/api/v1/meta/schemas/apps/0oa6e1b1916fcAiWq5d7/default' })
+      expect(result.data).toEqual([])
     })
   })
 


### PR DESCRIPTION
Fix bug causing built in apps to disappear from fetch as they don't have AppUserSchema which caused 404 when trying to fetch those

---
_Release Notes_: 
_Okta adapter_:
- Fix a bug in built-in applications fetch

---
_User Notifications_: 

_Okta adapter_:
- Built-in Application will be added on the next fetch