### PR TITLE
SALTO-3817: Add postAction.showOnFailure flag

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -79,7 +79,7 @@ export type DeployAction = {
 }
 
 export type PostDeployAction = DeployAction & {
-  showOnFailure: boolean
+  showOnFailure?: boolean
 }
 
 export type DeployActions = {

--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -78,9 +78,13 @@ export type DeployAction = {
   documentationURL?: string
 }
 
+export type PostDeployAction = DeployAction & {
+  showOnFailure: boolean
+}
+
 export type DeployActions = {
   preAction?: DeployAction
-  postAction?: DeployAction
+  postAction?: PostDeployAction
 }
 
 export type ChangeError = SaltoElementError & {

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -19,6 +19,7 @@ import { promises } from '@salto-io/lowerdash'
 import { PlanItem, Plan, preview, DeployResult, ItemStatus, deploy } from '@salto-io/core'
 import { logger } from '@salto-io/logging'
 import { Workspace } from '@salto-io/workspace'
+import { Change, ChangeDataType, ChangeError, getChangeData } from '@salto-io/adapter-api'
 import { WorkspaceCommandAction, createWorkspaceCommand } from '../command_builder'
 import { AccountsArg, ACCOUNTS_OPTION, getAndValidateActiveAccounts, getTagsForAccounts } from './common/accounts'
 import { CliOutput, CliExitCode, CliTelemetry } from '../types'
@@ -84,6 +85,17 @@ export const shouldDeploy = async (
     return false
   }
   return getUserBooleanInput(Prompts.SHOULD_EXECUTE_DEPLOY_PLAN(checkOnly))
+}
+
+const shouldShowPostDeployActionMessage = (
+  changeError: ChangeError,
+  appliedChanges: Change<ChangeDataType>[]
+): boolean => {
+  const isSuccessful = appliedChanges.find(
+    change => getChangeData(change).elemID.getFullName() === changeError.elemID.getFullName()
+  ) !== undefined
+
+  return isSuccessful || (changeError.deployActions?.postAction?.showOnFailure ?? false)
 }
 
 type DeployArgs = {
@@ -242,12 +254,12 @@ export const action: WorkspaceCommandAction<DeployArgs> = async ({
       cliExitCode = CliExitCode.AppError
     }
   }
-  const postDeployActionsOutput = formatDeployActions(
-    {
-      wsChangeErrors: actionPlan.changeErrors,
-      isPreDeploy: false,
-    }
-  )
+
+  const postDeployActionsOutput = formatDeployActions({
+    wsChangeErrors: actionPlan.changeErrors.filter(change =>
+      shouldShowPostDeployActionMessage(change, result.appliedChanges || [])),
+    isPreDeploy: false,
+  })
   outputLine(postDeployActionsOutput.join('\n'), output)
   if (result.extraProperties?.groups !== undefined) {
     outputLine(formatGroups(result.extraProperties?.groups, checkOnly), output)

--- a/packages/cli/test/commands/deploy.test.ts
+++ b/packages/cli/test/commands/deploy.test.ts
@@ -274,6 +274,10 @@ describe('deploy command', () => {
       if (userBooleanInput) {
         expect(output.stdout.content).not.toContain('Cancelling deploy')
         expect(output.stdout.content).toContain('Deployment succeeded')
+        expect(output.stdout.content).toContain('Successful change - postDeployAction with showOnFailure=true')
+        expect(output.stdout.content).toContain('Successful change - postDeployAction with showOnFailure=false')
+        expect(output.stdout.content).toContain('Failed change - postDeployAction with showOnFailure=true')
+        expect(output.stdout.content).not.toContain('Failed change - postDeployAction with showOnFailure=false')
       } else {
         expect(output.stdout.content).toContain('Cancelling deploy')
         expect(output.stdout.content).not.toContain('Deployment succeeded')

--- a/packages/cli/test/formatter.test.ts
+++ b/packages/cli/test/formatter.test.ts
@@ -103,7 +103,7 @@ describe('formatter', () => {
       expect(output).toMatch(/|[^\n]+salesforce.lead.*|[^\n]+how_many_sales_people.*M[^\n]+label/s)
     })
     it('should return the number of impacted types and instances', () => {
-      expect(output).toMatch(`${chalk.bold('Impacts:')} 3 types and 1 instance.`)
+      expect(output).toMatch(`${chalk.bold('Impacts:')} 7 types and 1 instance.`)
     })
     it('should return pre deploy action suggestions', () => {
       expect(output).toMatch(`${chalk.bold(Prompts.DEPLOY_PRE_ACTION_HEADER)}`)

--- a/packages/jira-adapter/src/change_validators/masking.ts
+++ b/packages/jira-adapter/src/change_validators/masking.ts
@@ -38,6 +38,7 @@ export const createChangeError = (
       postAction: {
         title: 'Update deployed masked data',
         description: `Please update the masked values that were deployed to Jira in ${getChangeData(change).elemID.getFullName()}`,
+        showOnFailure: false,
         subActions: [
           serviceUrl !== undefined
             ? `Go to ${serviceUrl}`

--- a/packages/jira-adapter/src/change_validators/workflow_scheme_migration.ts
+++ b/packages/jira-adapter/src/change_validators/workflow_scheme_migration.ts
@@ -218,6 +218,7 @@ const getErrorMessageForStatusMigration = (
       postAction: serviceUrl ? {
         title: 'Finalize workflow scheme change',
         description: `Salto pushed the ${instance.elemID.name} workflow scheme changes, but did not publish it. Please follow these steps to complete this change and migrate affected issues`,
+        showOnFailure: false,
         subActions: [
           `Go to ${serviceUrl}`,
           'Click on "Publish"',

--- a/packages/jira-adapter/test/change_validators/masking.test.ts
+++ b/packages/jira-adapter/test/change_validators/masking.test.ts
@@ -63,6 +63,7 @@ describe('maskingValidator', () => {
           postAction: {
             title: 'Update deployed masked data',
             description: 'Please update the masked values that were deployed to Jira in jira.Automation.instance.instance',
+            showOnFailure: false,
             subActions: [
               'Go to http://url',
               'Search for masked values (which contain <SECRET_TOKEN>) and set them to the correct value',
@@ -91,6 +92,7 @@ describe('maskingValidator', () => {
           postAction: {
             title: 'Update deployed masked data',
             description: 'Please update the masked values that were deployed to Jira in jira.Automation.instance.instance',
+            showOnFailure: false,
             subActions: [
               'Go to https://ori-salto-test.atlassian.net/ and open the relevant page for jira.Automation.instance.instance',
               'Search for masked values (which contain <SECRET_TOKEN>) and set them to the correct value',

--- a/packages/netsuite-adapter/src/change_validators/currency_undeployable_fields.ts
+++ b/packages/netsuite-adapter/src/change_validators/currency_undeployable_fields.ts
@@ -78,6 +78,7 @@ const validateAdditionChange = (additionChange: AdditionChange<InstanceElement>)
       postAction: {
         title: 'Edit \'locale\' field',
         description: 'Set the \'locale\' of the newly created currency to the desired value',
+        showOnFailure: false,
         subActions: [
           'Within the NetSuite UI, navigate to Lists > Accounting > Currencies',
           `Choose the newly created currency (${instance.value.name})`,

--- a/packages/okta-adapter/src/change_validators/app_integration_setup.ts
+++ b/packages/okta-adapter/src/change_validators/app_integration_setup.ts
@@ -31,6 +31,7 @@ const createAppSetupMsg = (instance: InstanceElement, baseUrl: string | undefine
       postAction: {
         title: 'New application integration setup required',
         description: 'To complete the setup of the new app integration in Okta, follow these steps:',
+        showOnFailure: false,
         subActions: [
           `Go to application page at ${url ?? 'Okta Admin console'}`,
           `Click on ${instance.value.label ?? 'the application'}.`,

--- a/packages/okta-adapter/test/change_validators/app_integration_setup.test.ts
+++ b/packages/okta-adapter/test/change_validators/app_integration_setup.test.ts
@@ -58,6 +58,7 @@ describe('appIntegrationSetupValidator', () => {
         postAction: {
           title: 'New application integration setup required',
           description: 'To complete the setup of the new app integration in Okta, follow these steps:',
+          showOnFailure: false,
           subActions: [
             `Go to application page at ${getAdminUrl(client.baseUrl)}/admin/apps/active`,
             `Click on ${appInstance.value.name}.`,
@@ -86,6 +87,7 @@ describe('appIntegrationSetupValidator', () => {
         postAction: {
           title: 'New application integration setup required',
           description: 'To complete the setup of the new app integration in Okta, follow these steps:',
+          showOnFailure: false,
           subActions: [
             `Go to application page at ${getAdminUrl(client.baseUrl)}/admin/apps/active`,
             'Click on the application.',

--- a/packages/salesforce-adapter/src/change_validators/cpq_trigger.ts
+++ b/packages/salesforce-adapter/src/change_validators/cpq_trigger.ts
@@ -42,6 +42,7 @@ const getCpqError = (
     postAction: {
       title: 'Re-enable CPQ Triggers',
       description: 'CPQ triggers should now be re-enabled:',
+      showOnFailure: true,
       subActions: [
         'In Salesforce, navigate to Setup > Installed Packages > Salesforce CPQ > Configure > Additional Settings tab',
         'Uncheck the "Triggers Disabled" checkbox',

--- a/packages/salesforce-adapter/src/change_validators/flows.ts
+++ b/packages/salesforce-adapter/src/change_validators/flows.ts
@@ -92,6 +92,7 @@ export const isActivatingChangeOnly = (change: ModificationChange<InstanceElemen
 const testCoveragePostDeploy = (instance: InstanceElement): DeployActions => ({
   postAction: {
     title: 'Flows test coverage',
+    showOnFailure: true,
     subActions: [
       `Please make sure that activation of the new flow version was not blocked due to insufficient test coverage and manually activate it if needed. Flow name: ${instance.elemID.getFullName()}`,
     ],
@@ -105,6 +106,7 @@ const deployAsInactivePostDeploy = (instance: InstanceElement, baseUrl?: URL): D
       postAction: {
         title: 'Deploying flows as inactive',
         description: 'Your Salesforce is configured to deploy flows as inactive, please make sure to manually activate them after the deployment completes',
+        showOnFailure: true,
         subActions: [
           `Go to: ${url}`,
           'Activate it by clicking “Activate”',
@@ -117,6 +119,7 @@ const deployAsInactivePostDeploy = (instance: InstanceElement, baseUrl?: URL): D
       postAction: {
         title: 'Deploying flows as inactive',
         description: 'Your Salesforce is configured to deploy flows as inactive, please make sure to manually activate them after the deployment completes',
+        showOnFailure: true,
         subActions: [
           `Go to: ${baseUrl}${FLOW_URL_SUFFIX}`,
           `Search for the ${instance.elemID.getFullName()} flow and click on it`,
@@ -129,6 +132,7 @@ const deployAsInactivePostDeploy = (instance: InstanceElement, baseUrl?: URL): D
     postAction: {
       title: 'Deploying flows as inactive',
       description: 'Your Salesforce is configured to deploy flows as inactive, please make sure to manually activate them after the deployment completes',
+      showOnFailure: true,
       subActions: [
         'Go to the flow set up page in your org',
         `Search for the ${instance.elemID.getFullName()} flow and click on it`,

--- a/packages/salesforce-adapter/src/change_validators/flows.ts
+++ b/packages/salesforce-adapter/src/change_validators/flows.ts
@@ -92,7 +92,7 @@ export const isActivatingChangeOnly = (change: ModificationChange<InstanceElemen
 const testCoveragePostDeploy = (instance: InstanceElement): DeployActions => ({
   postAction: {
     title: 'Flows test coverage',
-    showOnFailure: true,
+    showOnFailure: false,
     subActions: [
       `Please make sure that activation of the new flow version was not blocked due to insufficient test coverage and manually activate it if needed. Flow name: ${instance.elemID.getFullName()}`,
     ],
@@ -106,7 +106,7 @@ const deployAsInactivePostDeploy = (instance: InstanceElement, baseUrl?: URL): D
       postAction: {
         title: 'Deploying flows as inactive',
         description: 'Your Salesforce is configured to deploy flows as inactive, please make sure to manually activate them after the deployment completes',
-        showOnFailure: true,
+        showOnFailure: false,
         subActions: [
           `Go to: ${url}`,
           'Activate it by clicking “Activate”',
@@ -119,7 +119,7 @@ const deployAsInactivePostDeploy = (instance: InstanceElement, baseUrl?: URL): D
       postAction: {
         title: 'Deploying flows as inactive',
         description: 'Your Salesforce is configured to deploy flows as inactive, please make sure to manually activate them after the deployment completes',
-        showOnFailure: true,
+        showOnFailure: false,
         subActions: [
           `Go to: ${baseUrl}${FLOW_URL_SUFFIX}`,
           `Search for the ${instance.elemID.getFullName()} flow and click on it`,
@@ -132,7 +132,7 @@ const deployAsInactivePostDeploy = (instance: InstanceElement, baseUrl?: URL): D
     postAction: {
       title: 'Deploying flows as inactive',
       description: 'Your Salesforce is configured to deploy flows as inactive, please make sure to manually activate them after the deployment completes',
-      showOnFailure: true,
+      showOnFailure: false,
       subActions: [
         'Go to the flow set up page in your org',
         `Search for the ${instance.elemID.getFullName()} flow and click on it`,

--- a/packages/zendesk-adapter/src/change_validators/target.ts
+++ b/packages/zendesk-adapter/src/change_validators/target.ts
@@ -36,6 +36,7 @@ You will have to re-enter it after deployment;  please make sure you have the ap
     postAction: {
       title: 'Change target authentication data',
       description: `Please change the authentication data for the target ${instanceElemId.name} in the service`,
+      showOnFailure: false,
       subActions: [
         `In Zendesk, open the Targets panel at ${baseUrl}${serviceUrl?.slice(1)}`,
         `Click on the edit button of the modified target, ${instanceTitle}`,

--- a/packages/zendesk-adapter/src/change_validators/webhook.ts
+++ b/packages/zendesk-adapter/src/change_validators/webhook.ts
@@ -34,6 +34,7 @@ export const createChangeError = (instanceElemId: ElemID, baseUrl: string): Chan
     postAction: {
       title: 'Set webhook authentication credentials',
       description: `Please manually set the authentication credentials for webhook ${instanceElemId.name} via the Zendesk UI`,
+      showOnFailure: false,
       subActions: [
         `Go to Zendesk Webhooks panel at ${baseUrl}${WEBHOOKS_SERVICE_URL}`,
         'Click on the modified webhook',


### PR DESCRIPTION
The post-deploy action messages for the salesforce adapter should be shown if the change failed but the other ones it should not.

To deal with this I've added a flag named `showOnFailure` to the `DeployAction` type (by creating a subtype called `PostDeployAction`).

When showing the post deploy messages I filter out ChangeError instances of failed changes where the `showOnFailure` flag is true.

Once this is merged the next step is to handle this flag in the SASS part.

_Replace me with a description of the changes in this PR_

---

_Additional context for reviewer_

---
_Release Notes_: 
CLI:
- Post-deploy actions of failed changes will no longer be shown to the user (except for Salesforce CPQ failures).

---
_User Notifications_: 
None