### PR TITLE
SALTO-4219: fix deployment in ticket_form when custom statuses are disabled

### DIFF
--- a/packages/zendesk-adapter/src/filters/ticket_form.ts
+++ b/packages/zendesk-adapter/src/filters/ticket_form.ts
@@ -14,19 +14,25 @@
 * limitations under the License.
 */
 import {
-  Change, DeployResult,
+  Change, DeployResult, ElemID,
   getChangeData,
-  InstanceElement, isAdditionOrModificationChange, isInstanceChange,
+  InstanceElement, isAdditionOrModificationChange, isInstanceChange, isInstanceElement, ReadOnlyElementsSource,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
+import { logger } from '@salto-io/logging'
 import { applyFunctionToChangeData } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { FilterCreator } from '../filter'
 import { deployChange, deployChanges } from '../deployment'
-import { TICKET_FORM_TYPE_NAME } from '../constants'
+import {
+  ACCOUNT_FEATURES_TYPE_NAME,
+  TICKET_FORM_TYPE_NAME,
+  ZENDESK,
+} from '../constants'
 
 const { awu } = collections.asynciterable
 const SOME_STATUSES = 'SOME_STATUSES'
+const log = logger(module)
 
 
 type Child = {
@@ -47,27 +53,59 @@ type TicketForm = {
   }[]
 }
 
+const isCustomStatusesEnabled = async (elementSource?: ReadOnlyElementsSource): Promise<boolean> => {
+  if (elementSource === undefined) {
+    log.error('Returning that customStatuses is disabled since no element source was provided')
+    return false
+  }
+
+  const accountFeatures = await elementSource.get(
+    new ElemID(
+      ZENDESK,
+      ACCOUNT_FEATURES_TYPE_NAME,
+      'instance',
+      ElemID.CONFIG_NAME
+    )
+  )
+
+  if (!isInstanceElement(accountFeatures)) {
+    log.warn('Returning that customStatuses is disabled since accountFeatures is not an instance')
+    return false
+  }
+  const customStatusesEnabled = accountFeatures.value.custom_statuses_enabled
+  if (customStatusesEnabled === undefined) {
+    log.warn('Returning that customStatuses is disabled since custom_statuses_enabled does not exist')
+    return false
+  }
+  return accountFeatures.value.custom_statuses_enabled.enabled
+}
+
 /**
- * checks if both statuses and custom_statuses are defined
+ * checks if both statuses and custom_statuses are defined and if custom_statuses is enabled
  */
-const isInvalidTicketForm = (instanceValue: Record<string, unknown>): instanceValue is TicketForm =>
-  _.isArray(instanceValue.agent_conditions)
-  && instanceValue.agent_conditions.some(condition =>
-    _.isArray(condition.child_fields)
+const isInvalidTicketForm = (instanceValue: Record<string, unknown>, hasCustomStatusesEnabled: boolean)
+  : instanceValue is TicketForm =>
+  hasCustomStatusesEnabled
+  && _.isArray(instanceValue.agent_conditions)
+    && instanceValue.agent_conditions.some(condition =>
+      _.isArray(condition.child_fields)
       && condition.child_fields.some((child: Child) =>
         _.isObject(child.required_on_statuses)
         && child.required_on_statuses.type === SOME_STATUSES
         && (child.required_on_statuses.custom_statuses !== undefined
-        && !_.isEmpty(child.required_on_statuses.custom_statuses))))
+          && !_.isEmpty(child.required_on_statuses.custom_statuses))))
 
-const invalidTicketFormChange = (change: Change<InstanceElement>): boolean =>
+
+const invalidTicketFormChange = (change: Change<InstanceElement>, hasCustomStatusesEnabled: boolean): boolean =>
   isAdditionOrModificationChange(change)
   && isInstanceChange(change)
-  && isInvalidTicketForm(getChangeData(change).value)
+  && isInvalidTicketForm(getChangeData(change).value, hasCustomStatusesEnabled)
 
 const returnValidInstance = (inst: InstanceElement): InstanceElement => {
   const clonedInst = inst.clone()
-  if (isInvalidTicketForm(clonedInst.value)) {
+  // it is true because if we get to returnValidInstance function its after we got true from isInvalidTicketForm so
+  // custom_statuses is enabled
+  if (isInvalidTicketForm(clonedInst.value, true)) {
     clonedInst.value.agent_conditions
       .forEach(condition => condition.child_fields
         .forEach(child => {
@@ -85,16 +123,18 @@ const returnValidInstance = (inst: InstanceElement): InstanceElement => {
  * this filter deploys ticket_form changes. if the instance has both statuses and custom_statuses under
  * required_on_statuses then it removes the statuses field.
  */
-const filterCreator: FilterCreator = ({ config, client }) => ({
+const filterCreator: FilterCreator = ({ config, client, elementsSource }) => ({
   name: 'ticketFormDeploy',
   deploy: async (changes: Change<InstanceElement>[]) => {
     const [TicketFormChanges, leftoverChanges] = _.partition(
       changes,
       change => TICKET_FORM_TYPE_NAME === getChangeData(change).elemID.typeName,
     )
+    const hasCustomStatusesEnabled = await isCustomStatusesEnabled(elementsSource)
+
     const [invalidModificationAndAdditionChanges, otherTicketFormChanges] = _.partition(
       TicketFormChanges,
-      invalidTicketFormChange,
+      change => invalidTicketFormChange(change, hasCustomStatusesEnabled),
     )
 
     const fixedTicketFormChanges = await awu(invalidModificationAndAdditionChanges)

--- a/packages/zendesk-adapter/src/filters/ticket_form.ts
+++ b/packages/zendesk-adapter/src/filters/ticket_form.ts
@@ -77,14 +77,16 @@ const isCustomStatusesEnabled = async (elementSource?: ReadOnlyElementsSource): 
     log.warn('Returning that customStatuses is disabled since custom_statuses_enabled does not exist')
     return false
   }
-  return accountFeatures.value.custom_statuses_enabled.enabled
+  return customStatusesEnabled.enabled
 }
 
 /**
  * checks if both statuses and custom_statuses are defined and if custom_statuses is enabled
  */
-const isInvalidTicketForm = (instanceValue: Record<string, unknown>, hasCustomStatusesEnabled: boolean)
-  : instanceValue is TicketForm =>
+const isInvalidTicketForm = (
+  instanceValue: Record<string, unknown>,
+  hasCustomStatusesEnabled: boolean
+): instanceValue is TicketForm =>
   hasCustomStatusesEnabled
   && _.isArray(instanceValue.agent_conditions)
     && instanceValue.agent_conditions.some(condition =>

--- a/packages/zendesk-adapter/src/filters/ticket_form.ts
+++ b/packages/zendesk-adapter/src/filters/ticket_form.ts
@@ -39,13 +39,13 @@ type Child = {
   // eslint-disable-next-line camelcase
   required_on_statuses: {
     type: string
-    statuses?: string[]
+    statuses?: string[] // question mark to ba able to delete it later on
     // eslint-disable-next-line camelcase
     custom_statuses: number[]
   }
 }
 
-type TicketForm = {
+type InvalidTicketForm = {
   // eslint-disable-next-line camelcase
   agent_conditions: {
     // eslint-disable-next-line camelcase
@@ -86,7 +86,7 @@ const isCustomStatusesEnabled = async (elementSource?: ReadOnlyElementsSource): 
 const isInvalidTicketForm = (
   instanceValue: Record<string, unknown>,
   hasCustomStatusesEnabled: boolean
-): instanceValue is TicketForm =>
+): instanceValue is InvalidTicketForm =>
   hasCustomStatusesEnabled
   && _.isArray(instanceValue.agent_conditions)
     && instanceValue.agent_conditions.some(condition =>


### PR DESCRIPTION
fix deployment in ticket_form when custom statuses are disabled

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* fix bug where the deploy of a `ticket_form` with `custom_statuses` when  `custom_statuses` is disabled would delete all statuses in the form

---
_User Notifications_: 
None
