### PR TITLE
SALTO-3490: Add ticket form check to the custom statuses enabled validator

### DIFF
--- a/packages/zendesk-adapter/src/change_validators/custom_statuses_enabled.ts
+++ b/packages/zendesk-adapter/src/change_validators/custom_statuses_enabled.ts
@@ -15,7 +15,7 @@
 */
 import { Change, ChangeDataType, ChangeError, ChangeValidator, ElemID, getChangeData, isInstanceElement, ReadOnlyElementsSource } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
-import { Condition, TicketForm } from '../filters/ticket_form'
+import { Condition, isTicketFormInstance } from '../filters/ticket_form'
 import { ACCOUNT_FEATURES_TYPE_NAME, CUSTOM_STATUS_TYPE_NAME, TICKET_FORM_TYPE_NAME, ZENDESK } from '../constants'
 
 const log = logger(module)
@@ -83,12 +83,13 @@ const hasConditionWithCustomStatuses = (conditions: Condition[]): boolean =>
 
 const isTicketFormWithCustomStatus = (change: Change<ChangeDataType>): boolean => {
   const data = getChangeData(change)
-  if (data.elemID.typeName !== TICKET_FORM_TYPE_NAME || !isInstanceElement(data)) {
+  if (data.elemID.typeName !== TICKET_FORM_TYPE_NAME
+    || !isInstanceElement(data)
+    || !isTicketFormInstance(data)) {
     return false
   }
 
-  const ticketValue = data.value as TicketForm
-  return hasConditionWithCustomStatuses(ticketValue.agent_conditions ?? [])
+  return hasConditionWithCustomStatuses(data.value.agent_conditions ?? [])
 }
 
 const createErrorsForTicketFormsWithCustomStatuses = (

--- a/packages/zendesk-adapter/src/change_validators/custom_statuses_enabled.ts
+++ b/packages/zendesk-adapter/src/change_validators/custom_statuses_enabled.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, ChangeDataType, ChangeError, ChangeValidator, ElemID, getChangeData, InstanceElement, isInstanceElement, ReadOnlyElementsSource } from '@salto-io/adapter-api'
+import { Change, ChangeDataType, ChangeError, ChangeValidator, ElemID, getChangeData, isInstanceElement, ReadOnlyElementsSource } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { Condition, TicketForm } from '../filters/ticket_form'
 import { ACCOUNT_FEATURES_TYPE_NAME, CUSTOM_STATUS_TYPE_NAME, TICKET_FORM_TYPE_NAME, ZENDESK } from '../constants'
@@ -87,11 +87,8 @@ const isTicketFormWithCustomStatus = (change: Change<ChangeDataType>): boolean =
     return false
   }
 
-  const ticketInstance = data as InstanceElement
-  const ticketValue = ticketInstance.value as TicketForm
-
+  const ticketValue = data.value as TicketForm
   return hasConditionWithCustomStatuses(ticketValue.agent_conditions ?? [])
-    || hasConditionWithCustomStatuses(ticketValue.end_user_conditions ?? [])
 }
 
 const createErrorsForTicketFormsWithCustomStatuses = (

--- a/packages/zendesk-adapter/src/change_validators/custom_statuses_enabled.ts
+++ b/packages/zendesk-adapter/src/change_validators/custom_statuses_enabled.ts
@@ -14,17 +14,20 @@
 * limitations under the License.
 */
 import { Change, ChangeDataType, ChangeError, ChangeValidator, ElemID, getChangeData, InstanceElement, isInstanceElement, ReadOnlyElementsSource } from '@salto-io/adapter-api'
-import { logger } from '@salto-io/logging'
 import { createSchemeGuardForInstance } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+import { collections } from '@salto-io/lowerdash'
 import Joi from 'joi'
 import { ACCOUNT_FEATURES_TYPE_NAME, CUSTOM_STATUS_TYPE_NAME, TICKET_FORM_TYPE_NAME, ZENDESK } from '../constants'
+
+const { makeArray } = collections.array
 
 const log = logger(module)
 const errorMsg = (reason: string): string => `Failed to run customStatusesEnabledValidator because ${reason}`
 
 type ChildField = {
   // eslint-disable-next-line camelcase
-  required_on_statuses: {
+  required_on_statuses?: {
     type: string
     statuses?: string[]
     // eslint-disable-next-line camelcase
@@ -37,7 +40,7 @@ const CHILD_FIELD_SCHEMA = Joi.object({
     type: Joi.string().required(),
     statuses: Joi.array().items(Joi.string()),
     custom_statuses: Joi.array(),
-  }).required(),
+  }),
 })
 
 type Condition = {
@@ -124,7 +127,7 @@ const createErrorsForCustomStatusTypes = (
 const hasConditionWithCustomStatuses = (conditions: Condition[]): boolean =>
   conditions.some((condition: Condition) =>
     condition.child_fields.some(
-      field => (field.required_on_statuses.custom_statuses?.length ?? 0) > 0
+      field => makeArray(field.required_on_statuses?.custom_statuses).length > 0
     ))
 
 const isTicketFormWithCustomStatus = (change: Change<ChangeDataType>): boolean => {

--- a/packages/zendesk-adapter/src/change_validators/custom_statuses_enabled.ts
+++ b/packages/zendesk-adapter/src/change_validators/custom_statuses_enabled.ts
@@ -65,10 +65,7 @@ const createErrorsForCustomStatusTypes = (
   changes: readonly Change<ChangeDataType>[]
 ): ChangeError[] =>
   changes
-    .filter(
-      change =>
-        getChangeData(change).elemID.typeName === CUSTOM_STATUS_TYPE_NAME
-    )
+    .filter(change => getChangeData(change).elemID.typeName === CUSTOM_STATUS_TYPE_NAME)
     .map(getChangeData)
     .map(instance => ({
       elemID: instance.elemID,
@@ -93,8 +90,8 @@ const isTicketFormWithCustomStatus = (change: Change<ChangeDataType>): boolean =
   const ticketInstance = data as InstanceElement
   const ticketValue = ticketInstance.value as TicketForm
 
-  return hasConditionWithCustomStatuses(ticketValue.agent_conditions || [])
-    || hasConditionWithCustomStatuses(ticketValue.end_user_conditions || [])
+  return hasConditionWithCustomStatuses(ticketValue.agent_conditions ?? [])
+    || hasConditionWithCustomStatuses(ticketValue.end_user_conditions ?? [])
 }
 
 const createErrorsForTicketFormsWithCustomStatuses = (
@@ -106,9 +103,11 @@ const createErrorsForTicketFormsWithCustomStatuses = (
     .map(instance => ({
       elemID: instance.elemID,
       severity: 'Warning',
-      message: 'Custom statuses are not enabled.',
+      message: 'Deploying ticket form with custom statuses while custom statuses are disabled',
       detailedMessage:
-        'Custom statuses are not enabled which which may cause some statuses to change their context',
+        'It seems this ticket form originates from another account that has custom statuses enabled. '
+        + 'Since custom statuses are disabled in the target account, '
+        + 'this ticket form will be deployed without the custom_statuses fields',
     }))
 
 /**

--- a/packages/zendesk-adapter/src/filters/ticket_form.ts
+++ b/packages/zendesk-adapter/src/filters/ticket_form.ts
@@ -28,8 +28,7 @@ import { TICKET_FORM_TYPE_NAME } from '../constants'
 const { awu } = collections.asynciterable
 const SOME_STATUSES = 'SOME_STATUSES'
 
-
-type Child = {
+export type Child = {
   // eslint-disable-next-line camelcase
   required_on_statuses: {
     type: string
@@ -39,12 +38,17 @@ type Child = {
   }
 }
 
-type TicketForm = {
+export type Condition = {
   // eslint-disable-next-line camelcase
-  agent_conditions: {
-    // eslint-disable-next-line camelcase
-    child_fields: Child[]
-  }[]
+  child_fields: Child[]
+}
+
+export type TicketForm = {
+  // eslint-disable-next-line camelcase
+  agent_conditions?: Condition[]
+
+  // eslint-disable-next-line camelcase
+  end_user_conditions?: Condition[]
 }
 
 /**
@@ -54,10 +58,10 @@ const isInvalidTicketForm = (instanceValue: Record<string, unknown>): instanceVa
   _.isArray(instanceValue.agent_conditions)
   && instanceValue.agent_conditions.some(condition =>
     _.isArray(condition.child_fields)
-      && condition.child_fields.some((child: Child) =>
-        _.isObject(child.required_on_statuses)
-        && child.required_on_statuses.type === SOME_STATUSES
-        && (child.required_on_statuses.custom_statuses !== undefined
+    && condition.child_fields.some((child: Child) =>
+      _.isObject(child.required_on_statuses)
+      && child.required_on_statuses.type === SOME_STATUSES
+      && (child.required_on_statuses.custom_statuses !== undefined
         && !_.isEmpty(child.required_on_statuses.custom_statuses))))
 
 const invalidTicketFormChange = (change: Change<InstanceElement>): boolean =>
@@ -68,15 +72,14 @@ const invalidTicketFormChange = (change: Change<InstanceElement>): boolean =>
 const returnValidInstance = (inst: InstanceElement): InstanceElement => {
   const clonedInst = inst.clone()
   if (isInvalidTicketForm(clonedInst.value)) {
-    clonedInst.value.agent_conditions
-      .forEach(condition => condition.child_fields
-        .forEach(child => {
-          if (child.required_on_statuses.type === SOME_STATUSES
-            && (child.required_on_statuses.custom_statuses !== undefined
-              && !_.isEmpty(child.required_on_statuses.custom_statuses))) {
-            delete child.required_on_statuses.statuses
-          }
-        }))
+    clonedInst.value.agent_conditions?.forEach(condition => condition.child_fields
+      .forEach(child => {
+        if (child.required_on_statuses.type === SOME_STATUSES
+          && (child.required_on_statuses.custom_statuses !== undefined
+            && !_.isEmpty(child.required_on_statuses.custom_statuses))) {
+          delete child.required_on_statuses.statuses
+        }
+      }))
   }
   return clonedInst
 }

--- a/packages/zendesk-adapter/src/filters/ticket_form.ts
+++ b/packages/zendesk-adapter/src/filters/ticket_form.ts
@@ -69,8 +69,6 @@ const TICKET_FORM_SCHEMA = Joi.object({
   agent_conditions: Joi.array().items(CONDITION_SCHEMA),
 })
 
-}
-
 export const isTicketFormInstance = createSchemeGuardForInstance<TicketFormInstance>(
   TICKET_FORM_SCHEMA,
   'Received an invalid value for TicketForm instance'

--- a/packages/zendesk-adapter/test/change_validators/custom_statuses_enabled.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/custom_statuses_enabled.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, ElemID, InstanceElement, ObjectType, ReadOnlyElementsSource, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { Change, ElemID, InstanceElement, ObjectType, ReadOnlyElementsSource, toChange } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { ACCOUNT_FEATURES_TYPE_NAME, CUSTOM_STATUS_TYPE_NAME, TICKET_FORM_TYPE_NAME, ZENDESK } from '../../src/constants'
 import { customStatusesEnabledValidator } from '../../src/change_validators'
@@ -103,7 +103,8 @@ describe(customStatusesEnabledValidator.name, () => {
               child_fields: [
                 {
                   required_on_statuses: {
-                    custom_statuses: [new ReferenceExpression(new ElemID('test'))],
+                    type: 'testType',
+                    custom_statuses: ['custom status 1'],
                   },
                 },
               ],

--- a/packages/zendesk-adapter/test/change_validators/custom_statuses_enabled.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/custom_statuses_enabled.test.ts
@@ -126,37 +126,6 @@ describe(customStatusesEnabledValidator.name, () => {
       })
     })
 
-    describe('when ticket form has end user condition with custom statuses', () => {
-      it('returns a warning', async () => {
-        const ticketFormInstance = new InstanceElement('test', ticketFormObjectType, {
-          end_user_conditions: [
-            {
-              child_fields: [
-                {
-                  required_on_statuses: {
-                    custom_statuses: [new ReferenceExpression(new ElemID('test'))],
-                  },
-                },
-              ],
-            },
-          ],
-        })
-        const ticketFormChange = toChange({ after: ticketFormInstance })
-
-        const errors = await customStatusesEnabledValidator([ticketFormChange], elementSource)
-        expect(errors).toHaveLength(1)
-        expect(errors[0]).toEqual({
-          elemID: ticketFormInstance.elemID,
-          severity: 'Warning',
-          message: 'Deploying ticket form with custom statuses while custom statuses are disabled',
-          detailedMessage:
-            'It seems this ticket form originates from another account that has custom statuses enabled. '
-            + 'Since custom statuses are disabled in the target account, '
-            + 'this ticket form will be deployed without the custom_statuses fields',
-        })
-      })
-    })
-
     describe('without custom status changes', () => {
       it('should not return an error', async () => {
         const errors = await customStatusesEnabledValidator([], elementSource)

--- a/packages/zendesk-adapter/test/change_validators/custom_statuses_enabled.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/custom_statuses_enabled.test.ts
@@ -13,9 +13,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, ElemID, InstanceElement, ObjectType, ReadOnlyElementsSource, toChange } from '@salto-io/adapter-api'
+import { Change, ElemID, InstanceElement, ObjectType, ReadOnlyElementsSource, ReferenceExpression, toChange } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { ACCOUNT_FEATURES_TYPE_NAME, CUSTOM_STATUS_TYPE_NAME, ZENDESK } from '../../src/constants'
+import { ACCOUNT_FEATURES_TYPE_NAME, CUSTOM_STATUS_TYPE_NAME, TICKET_FORM_TYPE_NAME, ZENDESK } from '../../src/constants'
 import { customStatusesEnabledValidator } from '../../src/change_validators'
 
 const mockLogError = jest.fn()
@@ -46,14 +46,14 @@ const createElementSource = ({ customStatusesEnabled }: { customStatusesEnabled:
 }
 
 describe(customStatusesEnabledValidator.name, () => {
-  let changeObjectType: ObjectType
-  let instance: InstanceElement
+  const changeObjectType = new ObjectType({ elemID: new ElemID(ZENDESK, CUSTOM_STATUS_TYPE_NAME) })
+  const ticketFormObjectType = new ObjectType({ elemID: new ElemID(ZENDESK, TICKET_FORM_TYPE_NAME) })
+  let customStatusInstance: InstanceElement
   let customStatusChange: Change<InstanceElement>
 
   beforeEach(() => {
-    changeObjectType = new ObjectType({ elemID: new ElemID(ZENDESK, CUSTOM_STATUS_TYPE_NAME) })
-    instance = new InstanceElement('test', changeObjectType)
-    customStatusChange = toChange({ after: instance })
+    customStatusInstance = new InstanceElement('test', changeObjectType)
+    customStatusChange = toChange({ after: customStatusInstance })
   })
 
   it('should not return an error when elementSource is undefined', async () => {
@@ -87,10 +87,66 @@ describe(customStatusesEnabledValidator.name, () => {
         const errors = await customStatusesEnabledValidator([customStatusChange], elementSource)
         expect(errors).toHaveLength(1)
         expect(errors[0]).toEqual({
-          elemID: instance.elemID,
+          elemID: customStatusInstance.elemID,
           severity: 'Error',
           message: 'Custom statuses are not enabled.',
           detailedMessage: 'Cannot deploy custom statuses when they are not enabled in the Zendesk account.',
+        })
+      })
+    })
+
+    describe('when ticket form has agent condition with custom statuses', () => {
+      it('returns a warning', async () => {
+        const ticketFormInstance = new InstanceElement('test', ticketFormObjectType, {
+          agent_conditions: [
+            {
+              child_fields: [
+                {
+                  required_on_statuses: {
+                    custom_statuses: [new ReferenceExpression(new ElemID('test'))],
+                  },
+                },
+              ],
+            },
+          ],
+        })
+        const ticketFormChange = toChange({ after: ticketFormInstance })
+
+        const errors = await customStatusesEnabledValidator([ticketFormChange], elementSource)
+        expect(errors).toHaveLength(1)
+        expect(errors[0]).toEqual({
+          elemID: ticketFormInstance.elemID,
+          severity: 'Warning',
+          message: 'Custom statuses are not enabled.',
+          detailedMessage: 'Custom statuses are not enabled which which may cause some statuses to change their context',
+        })
+      })
+    })
+
+    describe('when ticket form has end user condition with custom statuses', () => {
+      it('returns a warning', async () => {
+        const ticketFormInstance = new InstanceElement('test', ticketFormObjectType, {
+          end_user_conditions: [
+            {
+              child_fields: [
+                {
+                  required_on_statuses: {
+                    custom_statuses: [new ReferenceExpression(new ElemID('test'))],
+                  },
+                },
+              ],
+            },
+          ],
+        })
+        const ticketFormChange = toChange({ after: ticketFormInstance })
+
+        const errors = await customStatusesEnabledValidator([ticketFormChange], elementSource)
+        expect(errors).toHaveLength(1)
+        expect(errors[0]).toEqual({
+          elemID: ticketFormInstance.elemID,
+          severity: 'Warning',
+          message: 'Custom statuses are not enabled.',
+          detailedMessage: 'Custom statuses are not enabled which which may cause some statuses to change their context',
         })
       })
     })

--- a/packages/zendesk-adapter/test/change_validators/custom_statuses_enabled.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/custom_statuses_enabled.test.ts
@@ -117,8 +117,11 @@ describe(customStatusesEnabledValidator.name, () => {
         expect(errors[0]).toEqual({
           elemID: ticketFormInstance.elemID,
           severity: 'Warning',
-          message: 'Custom statuses are not enabled.',
-          detailedMessage: 'Custom statuses are not enabled which which may cause some statuses to change their context',
+          message: 'Deploying ticket form with custom statuses while custom statuses are disabled',
+          detailedMessage:
+            'It seems this ticket form originates from another account that has custom statuses enabled. '
+            + 'Since custom statuses are disabled in the target account, '
+            + 'this ticket form will be deployed without the custom_statuses fields',
         })
       })
     })
@@ -145,8 +148,11 @@ describe(customStatusesEnabledValidator.name, () => {
         expect(errors[0]).toEqual({
           elemID: ticketFormInstance.elemID,
           severity: 'Warning',
-          message: 'Custom statuses are not enabled.',
-          detailedMessage: 'Custom statuses are not enabled which which may cause some statuses to change their context',
+          message: 'Deploying ticket form with custom statuses while custom statuses are disabled',
+          detailedMessage:
+            'It seems this ticket form originates from another account that has custom statuses enabled. '
+            + 'Since custom statuses are disabled in the target account, '
+            + 'this ticket form will be deployed without the custom_statuses fields',
         })
       })
     })


### PR DESCRIPTION
…dator

The customStatusesEnabledValidator now shows a warning message when trying to change zendesk.ticket_form instances with `custom_statuses` specified in either `agent_conditions` or `end_user_conditions`.

_Replace me with a description of the changes in this PR_

---

_Additional context for reviewer_

---
_Release Notes_: 
ZenDesk adapter:

- Check that custom statuses are enabled when updating zendesk.ticket_form instances that include custom_statuses under agent_conditions or end_user_conditions.


---
_User Notifications_: 
None
