### PR TITLE
SALTO-4201: publish netsuite adapter test utils

### DIFF
--- a/packages/netsuite-adapter/package.json
+++ b/packages/netsuite-adapter/package.json
@@ -11,7 +11,8 @@
     "types",
     "dist/src",
     "dist/index.*",
-    "dist/e2e_test"
+    "dist/e2e_test",
+    "dist/test/utils.*"
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
---

_Additional context for reviewer_
Following #4412 
Turns out files in netsuite e2e import utils from the tests folder, so we need to include that in the files we publish to npm as well

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_