### PR TITLE
SALTO-4241- Fix AppUserSchema idFields

### DIFF
--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -398,7 +398,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
       url: '/api/v1/meta/schemas/apps/{appId}/default',
     },
     transformation: {
-      idFields: ['title'],
+      idFields: [],
       dataField: '.',
       fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat(
         { fieldName: '$schema' },


### PR DESCRIPTION
Fix AppUserSchema idFields

---

Because we have one AppSchema to each app, elemID for `AppUserSchema` should depend on the parent app elemID.
Otherwise `AppUserSchema` instances of the same app would look as an addition and removal changes when comparing environments.

---
_Release Notes_: 

_Okta adapter_:
- Fix a bug causing non existing differences in `AppUserSchema` instances when comparing environments

---
_User Notifications_: 

_Okta adapter_:
- Element Ids for `AppUserSchema` instances will change