### PR TITLE
SALTO-3999 - Salesforce: add retry to fetch in case of UNABLE_TO_LOCK_ROW

### DIFF
--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -128,6 +128,7 @@ const errorMessagesToRetry = [
   'An unexpected connection error occurred',
   'ECONNREFUSED',
   'Internal_Error',
+  'UNABLE_TO_LOCK_ROW', // we saw this in both fetch and deploy
 ]
 
 type RateLimitBucketName = keyof ClientRateLimitConfig


### PR DESCRIPTION
We've seen this error in both fetch and deploy. Per [Salesforce docs](https://help.salesforce.com/s/articleView?id=000387767&type=1) it can happen due to user interaction with Salesforce at the time of the fetch/deploy.

---

`requestWithRetry` seems to be used by both the fetch and the deploy flows. LMK if there's anywhere else I should check for this error to ensure fetch is covered.

---
_Release Notes_: 
Salesforce: Fetch and deploy operations will be retried if they receive an UNABLE_TO_LOCK_ROW error

---
_User Notifications_: 
N/A
