### PR TITLE
SALTO-4109 Add TransferOrder to the in-consist values in the transaction form

### DIFF
--- a/packages/netsuite-adapter/src/filters/consistent_values.ts
+++ b/packages/netsuite-adapter/src/filters/consistent_values.ts
@@ -70,13 +70,13 @@ const entryFormServiceItemRecordType = {
   consistentValue: 'SERVICEITEM',
 }
 
-const transactionFormRecordType = {
+const transactionFormJournalEntryRecordType = {
   fieldElemID: new ElemID(NETSUITE, TRANSACTION_FORM, 'field', RECORD_TYPE),
   inconsistentValues: ['JOURNALENTRY', 'INTERCOMPANYJOURNALENTRY', 'ADVINTERCOMPANYJOURNALENTRY', 'STATISTICALJOURNALENTRY'],
   consistentValue: 'JOURNALENTRY',
 }
 
-const transactionFormRecordTypeTransferOrder = {
+const transactionFormTransferOrderRecordType = {
   fieldElemID: new ElemID(NETSUITE, TRANSACTION_FORM, 'field', RECORD_TYPE),
   inconsistentValues: ['TRANSFERORDER', 'INTERCOMPANYTRANSFERORDER'],
   consistentValue: 'TRANSFERORDER',
@@ -95,7 +95,7 @@ const typeToFieldMappings: Record<string, InconsistentFieldMapping[]> = {
     entryFormJobRecordType,
     entryFormServiceItemRecordType,
   ],
-  [TRANSACTION_FORM]: [transactionFormRecordType, transactionFormRecordTypeTransferOrder],
+  [TRANSACTION_FORM]: [transactionFormJournalEntryRecordType, transactionFormTransferOrderRecordType],
 }
 
 const setConsistentValues = async (element: Element): Promise<void> => {

--- a/packages/netsuite-adapter/src/filters/consistent_values.ts
+++ b/packages/netsuite-adapter/src/filters/consistent_values.ts
@@ -76,6 +76,12 @@ const transactionFormRecordType = {
   consistentValue: 'JOURNALENTRY',
 }
 
+const transactionFormRecordTypeTransferOrder = {
+  fieldElemID: new ElemID(NETSUITE, TRANSACTION_FORM, 'field', RECORD_TYPE),
+  inconsistentValues: ['TRANSFERORDER', 'INTERCOMPANYTRANSFERORDER'],
+  consistentValue: 'TRANSFERORDER',
+}
+
 const customRecordTypeFieldMappings: InconsistentFieldMapping[] = [
   customRecordTypeApClerkPermittedRole,
   customRecordTypeCeoHandsOffPermittedRole,
@@ -89,7 +95,7 @@ const typeToFieldMappings: Record<string, InconsistentFieldMapping[]> = {
     entryFormJobRecordType,
     entryFormServiceItemRecordType,
   ],
-  [TRANSACTION_FORM]: [transactionFormRecordType],
+  [TRANSACTION_FORM]: [transactionFormRecordType, transactionFormRecordTypeTransferOrder],
 }
 
 const setConsistentValues = async (element: Element): Promise<void> => {

--- a/packages/netsuite-adapter/test/filters/consistent_values.test.ts
+++ b/packages/netsuite-adapter/test/filters/consistent_values.test.ts
@@ -31,7 +31,7 @@ describe('consistent_values filter', () => {
       transactionFormType().type,
       {
         name: instanceName,
-        [RECORD_TYPE]: 'INTERCOMPANYJOURNALENTRY',
+        [RECORD_TYPE]: 'INTERCOMPANYTRANSFERORDER',
       })
     customRecordType = new ObjectType({
       elemID: new ElemID(NETSUITE, 'customrecord1'),
@@ -52,7 +52,7 @@ describe('consistent_values filter', () => {
   it('should modify field with inconsistent value', async () => {
     await filterCreator({} as LocalFilterOpts).onFetch?.([instance, customRecordType])
     expect(instance.value.name).toEqual(instanceName)
-    expect(instance.value[RECORD_TYPE]).toEqual('JOURNALENTRY')
+    expect(instance.value[RECORD_TYPE]).toEqual('TRANSFERORDER')
   })
 
   it('should modify custom record type annotations with inconsistent value', async () => {

--- a/packages/netsuite-adapter/test/filters/consistent_values.test.ts
+++ b/packages/netsuite-adapter/test/filters/consistent_values.test.ts
@@ -31,7 +31,7 @@ describe('consistent_values filter', () => {
       transactionFormType().type,
       {
         name: instanceName,
-        [RECORD_TYPE]: 'INTERCOMPANYTRANSFERORDER',
+        [RECORD_TYPE]: 'INTERCOMPANYJOURNALENTRY',
       })
     customRecordType = new ObjectType({
       elemID: new ElemID(NETSUITE, 'customrecord1'),
@@ -52,7 +52,7 @@ describe('consistent_values filter', () => {
   it('should modify field with inconsistent value', async () => {
     await filterCreator({} as LocalFilterOpts).onFetch?.([instance, customRecordType])
     expect(instance.value.name).toEqual(instanceName)
-    expect(instance.value[RECORD_TYPE]).toEqual('TRANSFERORDER')
+    expect(instance.value[RECORD_TYPE]).toEqual('JOURNALENTRY')
   })
 
   it('should modify custom record type annotations with inconsistent value', async () => {


### PR DESCRIPTION
_Add TransferOrder to the in-consist values in the transaction form_

---

_There are some fields with in-consist values, we choose one of the values to be our default between the in-consistent ones to hide the changes from the user._

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
