### PR TITLE
SALTO-4253 fix escaped unicode letters parsing

### DIFF
--- a/packages/workspace/src/parser/internal/native/lexer.ts
+++ b/packages/workspace/src/parser/internal/native/lexer.ts
@@ -72,7 +72,8 @@ export const rules: Record<string, moo.Rules> = {
   string: {
     [TOKEN_TYPES.REFERENCE]: { match: new RegExp(`\\$\\{[ \\t]*${WORD_PART}[ \\t]*\\}`), value: s => s.slice(2, -1).trim() },
     [TOKEN_TYPES.DOUBLE_QUOTES]: { match: '"', pop: 1 },
-    [TOKEN_TYPES.ESCAPE]: /\\[^$]|\\\$\{?/, // This handles regular escapes and escaped template markers ('\${')
+    // This handles regular escapes, unicode escapes and escaped template markers ('\${')
+    [TOKEN_TYPES.ESCAPE]: { match: /\\[^$u]|\\u[0-9a-fA-F]{4}|\\\$\{?/ },
     // Template markers are added to prevent incorrect parsing of user created strings that look like Salto references.
     [TOKEN_TYPES.CONTENT]: { match: /[^\r\n\\]+?(?=\$\{|["\n\r\\])/, lineBreaks: false },
     [TOKEN_TYPES.NEWLINE]: { match: /[\r\n]+/, lineBreaks: true, pop: 1 },

--- a/packages/workspace/test/parser/parse.test.ts
+++ b/packages/workspace/test/parser/parse.test.ts
@@ -205,6 +205,7 @@ describe('Salto parser', () => {
       
       type salesforce.escapedDashBeforeQuote {
         str = "you can't run away \\\\"
+        unicodeStr = "this is \\u0061 basic thing"
       }
 
       type salesforce.templates {
@@ -742,6 +743,9 @@ value
 
       it('should parsed the double escaped string', () => {
         expect(escapeObj.annotations.str).toEqual('you can\'t run away \\')
+      })
+      it('should parse the unicode escaping', () => {
+        expect(escapeObj.annotations.unicodeStr).toEqual('this is a basic thing')
       })
     })
 


### PR DESCRIPTION
In case that there is an escaped Unicode letter in a string content (e.g `\u0065`) the parsing fails with `Invalid string character`.

---

_Additional context for reviewer_

---
_Release Notes_: 
Workspace:
- Fix escaped Unicode letters parsing

---
_User Notifications_: 
None