### PR TITLE
move workspace errors formatting to workspace package

### DIFF
--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -20,11 +20,11 @@ import wu, { WuIterable } from 'wu'
 import {
   Element, isInstanceElement, Values, Change, Value, getChangeData, ElemID,
   isObjectType, isField, isPrimitiveType, Field, PrimitiveTypes, ReferenceExpression,
-  ActionName, ChangeError, SaltoError, isElement, TypeMap, DetailedChange, ChangeDataType,
-  isStaticFile, Group,
+  ActionName, ChangeError, isElement, TypeMap, DetailedChange, ChangeDataType,
+  isStaticFile, Group, SaltoError,
 } from '@salto-io/adapter-api'
 import { Plan, PlanItem, FetchChange, FetchResult, LocalChange, getSupportedServiceAdapterNames } from '@salto-io/core'
-import { errors, SourceLocation, WorkspaceComponents, StateRecency } from '@salto-io/workspace'
+import { errors, WorkspaceComponents, StateRecency } from '@salto-io/workspace'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { collections, values } from '@salto-io/lowerdash'
 import Prompts from './prompts'
@@ -56,20 +56,15 @@ export const formatWordsSeries = (words: string[]): string => (words.length > 1
   ? `${words.slice(0, -1).join(', ')} and ${_.last(words)}`
   : words[0])
 
-/**
-  * Format workspace errors
-  */
-
-const formatSourceLocation = (sl: Readonly<SourceLocation>): string =>
-  `${chalk.underline(sl.sourceRange.filename)}(${chalk.cyan(`line: ${sl.sourceRange.start.line}`)})`
-
-const formatSourceLocations = (sourceLocations: ReadonlyArray<SourceLocation>): string =>
-  `${sourceLocations.map(formatSourceLocation).join(EOL)}`
-
-export const formatWorkspaceError = (we: Readonly<errors.WorkspaceError<SaltoError>>): string => {
-  const possibleEOL = we.sourceLocations.length > 0 ? EOL : ''
-  return `${formatError(we)}${possibleEOL}${formatSourceLocations(we.sourceLocations)}`
+export const workspaceErrorStringFormatters = {
+  header,
+  filename: chalk.underline,
+  lineNum: chalk.cyan,
 }
+
+export const formatWorkspaceError = (
+  we: Readonly<errors.WorkspaceError<SaltoError>>
+): string => errors.formatWorkspaceError(we, workspaceErrorStringFormatters)
 
 const indent = (text: string, level: number): string => {
   const indentText = _.repeat('  ', level)

--- a/packages/workspace/src/errors.ts
+++ b/packages/workspace/src/errors.ts
@@ -16,3 +16,4 @@
 export { ValidationError, UnresolvedReferenceValidationError } from './validator'
 export { WorkspaceError } from './workspace/workspace'
 export { Errors, UnknownEnvError, InvalidEnvNameError } from './workspace/errors'
+export { formatWorkspaceError, formatWorkspaceErrors } from './formatter'

--- a/packages/workspace/src/formatter.ts
+++ b/packages/workspace/src/formatter.ts
@@ -1,0 +1,69 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import wu from 'wu'
+import { EOL } from 'os'
+import { SaltoError } from '@salto-io/adapter-api'
+import { SourceLocation, Workspace, WorkspaceError } from './workspace/workspace'
+
+type StringFormatter = (txt: string) => string
+
+type WorkspaceErrorStringFormatters = {
+  header?: StringFormatter
+  filename?: StringFormatter
+  lineNum?: StringFormatter
+}
+
+const noFormat: StringFormatter = txt => txt
+
+export const formatWorkspaceError = (
+  we: Readonly<WorkspaceError<SaltoError>>,
+  formatters?: WorkspaceErrorStringFormatters
+): string => {
+  const {
+    header = noFormat,
+    filename = noFormat,
+    lineNum = noFormat,
+  } = formatters ?? {}
+
+  const formatSourceLocation = (
+    sl: Readonly<SourceLocation>,
+  ): string =>
+    `${filename(sl.sourceRange.filename)}(${lineNum(`line: ${sl.sourceRange.start.line}`)})`
+
+  const formatSourceLocations = (sourceLocations: ReadonlyArray<SourceLocation>): string =>
+    `${sourceLocations.map(formatSourceLocation).join(EOL)}`
+
+  const possibleEOL = we.sourceLocations.length > 0 ? EOL : ''
+  return `${header(we.message)}${possibleEOL}${formatSourceLocations(we.sourceLocations)}`
+}
+
+export const formatWorkspaceErrors = async (
+  workspace: Workspace,
+  errors: Iterable<SaltoError>,
+  stringFormatters?: WorkspaceErrorStringFormatters,
+  maxErrorsToLog?: number
+): Promise<string> => {
+  const errorsIterable = wu(errors)
+  const errorsToLog = maxErrorsToLog !== undefined
+    ? errorsIterable.slice(0, maxErrorsToLog)
+    : errorsIterable
+
+  return (await Promise.all(
+    errorsToLog
+      .map(err => workspace.transformError(err))
+      .map(async err => formatWorkspaceError(await err, stringFormatters))
+  )).join(EOL)
+}


### PR DESCRIPTION
In order to format workspace errors from other places then CLI.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
