### PR TITLE
add support of accountToServiceNameMap to deploy

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -62,6 +62,7 @@ export type FetchOptions = {
 
 export type DeployOptions = {
   changeGroup: ChangeGroup
+  accountToServiceNameMap?: Record<string, string>
 }
 
 export type PostFetchOptions = {

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -186,9 +186,14 @@ export const deploy = async (
     }))
   }
   const accountToServiceNameMap = getAccountToServiceNameMap(workspace, workspace.accounts())
-  const { errors, appliedChanges, extraProperties } = await deployActions(
-    actionPlan, adapters, reportProgress, postDeployAction, checkOnly, accountToServiceNameMap
-  )
+  const { errors, appliedChanges, extraProperties } = await deployActions({
+    deployPlan: actionPlan,
+    adapters,
+    reportProgress,
+    postDeployAction,
+    checkOnly,
+    accountToServiceNameMap,
+  })
 
   // Add workspace elements as an additional context for resolve so that we can resolve
   // variable expressions. Adding only variables is not enough for the case of a variable

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -185,8 +185,9 @@ export const deploy = async (
       }
     }))
   }
+  const accountToServiceNameMap = getAccountToServiceNameMap(workspace, workspace.accounts())
   const { errors, appliedChanges, extraProperties } = await deployActions(
-    actionPlan, adapters, reportProgress, postDeployAction, checkOnly
+    actionPlan, adapters, reportProgress, postDeployAction, checkOnly, accountToServiceNameMap
   )
 
   // Add workspace elements as an additional context for resolve so that we can resolve

--- a/packages/core/src/core/deploy/deploy_actions.ts
+++ b/packages/core/src/core/deploy/deploy_actions.ts
@@ -48,7 +48,8 @@ const deployOrValidate = (
 const deployAction = (
   planItem: PlanItem,
   adapters: Record<string, AdapterOperations>,
-  checkOnly: boolean
+  checkOnly: boolean,
+  accountToServiceNameMap: Record<string, string>
 ): Promise<DeployResult> => {
   const changes = [...planItem.changes()]
   const adapterName = getChangeData(changes[0]).elemID.adapter
@@ -56,7 +57,7 @@ const deployAction = (
   if (!adapter) {
     throw new Error(`Missing adapter for ${adapterName}`)
   }
-  const opts = { changeGroup: { groupID: planItem.groupKey, changes } }
+  const opts = { changeGroup: { groupID: planItem.groupKey, changes }, accountToServiceNameMap }
   return deployOrValidate({ adapter, adapterName, opts, checkOnly })
 }
 
@@ -100,7 +101,8 @@ export const deployActions = async (
   adapters: Record<string, AdapterOperations>,
   reportProgress: (item: PlanItem, status: ItemStatus, details?: string) => void,
   postDeployAction: (appliedChanges: ReadonlyArray<Change>) => Promise<void>,
-  checkOnly: boolean
+  checkOnly: boolean,
+  accountToServiceNameMap: Record<string, string>
 ): Promise<DeployActionResult> => {
   const appliedChanges: Change[] = []
   const groups: Group[] = []
@@ -113,7 +115,7 @@ export const deployActions = async (
       })
       reportProgress(item, 'started')
       try {
-        const result = await deployAction(item, adapters, checkOnly)
+        const result = await deployAction(item, adapters, checkOnly, accountToServiceNameMap)
         result.appliedChanges.forEach(appliedChange => appliedChanges.push(appliedChange))
         if (result.extraProperties?.groups !== undefined) {
           groups.push(...result.extraProperties.groups)

--- a/packages/core/src/core/deploy/deploy_actions.ts
+++ b/packages/core/src/core/deploy/deploy_actions.ts
@@ -96,14 +96,21 @@ const updatePlanElement = (item: PlanItem, appliedChanges: ReadonlyArray<Change>
     })
 }
 
-export const deployActions = async (
-  deployPlan: Plan,
-  adapters: Record<string, AdapterOperations>,
-  reportProgress: (item: PlanItem, status: ItemStatus, details?: string) => void,
-  postDeployAction: (appliedChanges: ReadonlyArray<Change>) => Promise<void>,
-  checkOnly: boolean,
+export const deployActions = async ({
+  deployPlan,
+  adapters,
+  reportProgress,
+  postDeployAction,
+  checkOnly,
+  accountToServiceNameMap,
+} : {
+  deployPlan: Plan
+  adapters: Record<string, AdapterOperations>
+  reportProgress: (item: PlanItem, status: ItemStatus, details?: string) => void
+  postDeployAction: (appliedChanges: ReadonlyArray<Change>) => Promise<void>
+  checkOnly: boolean
   accountToServiceNameMap: Record<string, string>
-): Promise<DeployActionResult> => {
+}): Promise<DeployActionResult> => {
   const appliedChanges: Change[] = []
   const groups: Group[] = []
   try {


### PR DESCRIPTION
add support of accountToServiceNameMap. now adapter deploy can use accountToServiceNameMap.
---
