### PR TITLE
SALTO-4259: Change dashboard gadget properties to a list

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/cloud/dashboard.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/dashboard.ts
@@ -32,17 +32,44 @@ export const createGadget1Values = (name: string): Values => ({
     column: 2,
   },
   title: `${name}-1`,
-  properties: {
-    bubbleType: 'participants',
-    id: 10024,
-    isConfigured: true,
-    name: 'AlonCompanyProject',
-    recentCommentsPeriod: 7,
-    refresh: 15,
-    type: 'project',
-    useLogarithmicScale: false,
-    useRelativeColoring: true,
-  },
+  properties: [
+    {
+      key: 'bubbleType',
+      value: 'participants',
+    },
+    {
+      key: 'id',
+      value: 10024,
+    },
+    {
+      key: 'isConfigured',
+      value: true,
+    },
+    {
+      key: 'name',
+      value: 'AlonCompanyProject',
+    },
+    {
+      key: 'recentCommentsPeriod',
+      value: 7,
+    },
+    {
+      key: 'refresh',
+      value: 15,
+    },
+    {
+      key: 'type',
+      value: 'project',
+    },
+    {
+      key: 'useLogarithmicScale',
+      value: false,
+    },
+    {
+      key: 'useRelativeColoring',
+      value: true,
+    },
+  ],
 })
 
 export const createGadget2Values = (name: string): Values => ({
@@ -53,15 +80,42 @@ export const createGadget2Values = (name: string): Values => ({
     column: 2,
   },
   title: `${name}-2`,
-  properties: {
-    bubbleType: 'participants',
-    id: 10024,
-    isConfigured: true,
-    name: 'AlonCompanyProject',
-    recentCommentsPeriod: 7,
-    refresh: 15,
-    type: 'project',
-    useLogarithmicScale: false,
-    useRelativeColoring: true,
-  },
+  properties: [
+    {
+      key: 'bubbleType',
+      value: 'participants',
+    },
+    {
+      key: 'id',
+      value: 10024,
+    },
+    {
+      key: 'isConfigured',
+      value: true,
+    },
+    {
+      key: 'name',
+      value: 'AlonCompanyProject',
+    },
+    {
+      key: 'recentCommentsPeriod',
+      value: 7,
+    },
+    {
+      key: 'refresh',
+      value: 15,
+    },
+    {
+      key: 'type',
+      value: 'project',
+    },
+    {
+      key: 'useLogarithmicScale',
+      value: false,
+    },
+    {
+      key: 'useRelativeColoring',
+      value: true,
+    },
+  ],
 })

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -58,6 +58,7 @@ import fieldConfigurationSchemeFilter from './filters/field_configurations_schem
 import dashboardFilter from './filters/dashboard/dashboard_deployment'
 import dashboardLayoutFilter from './filters/dashboard/dashboard_layout'
 import gadgetFilter from './filters/dashboard/gadget'
+import gadgetPropertiesFilter from './filters/dashboard/gadget_properties'
 import hiddenValuesInListsFilter from './filters/hidden_value_in_lists'
 import projectFilter from './filters/project'
 import projectComponentFilter from './filters/project_component'
@@ -207,6 +208,7 @@ export const DEFAULT_FILTERS = [
   dashboardFilter,
   dashboardLayoutFilter,
   gadgetFilter,
+  gadgetPropertiesFilter,
   projectCategoryFilter,
   projectFilter,
   projectComponentFilter,

--- a/packages/jira-adapter/src/filters/dashboard/gadget_properties.ts
+++ b/packages/jira-adapter/src/filters/dashboard/gadget_properties.ts
@@ -1,0 +1,115 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ListType, ObjectType, Values, isAdditionOrModificationChange, isInstanceChange, isInstanceElement } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { FilterCreator } from '../../filter'
+import { DASHBOARD_GADGET_TYPE, JIRA } from '../../constants'
+import { findObject } from '../../utils'
+
+const convertMapToList = (map: Record<string, unknown>): Values[] => Object.entries(map)
+  // The reason to separate `value` and `values` is because when the value is an object,
+  // we want to create references to values inside it, so we it must have a field with a type.
+  // If we put the value in the same field whether it is a plainObject or not,
+  // there wouldn't be an appropriate type we could use.
+  .map(([key, value]) => (_.isPlainObject(value) ? { key, values: value } : { key, value }))
+
+const convertListToMap = (list: Values[]): Record<string, unknown> => Object.fromEntries(list
+  .map(({ key, value, values }) => [key, value ?? values]))
+
+const filter: FilterCreator = () => ({
+  name: 'gadgetPropertiesFilter',
+  onFetch: async elements => {
+    elements
+      .filter(isInstanceElement)
+      .filter(instance => instance.elemID.typeName === DASHBOARD_GADGET_TYPE)
+      .filter(instance => _.isPlainObject(instance.value.properties))
+      .map(async instance => {
+        instance.value.properties = convertMapToList(instance.value.properties)
+        instance.value.properties
+          .filter((property: Values) => _.isPlainObject(property.values))
+          .forEach((property: Values) => {
+            property.values = convertMapToList(property.values)
+          })
+      })
+
+    const gadgetPropertyType = new ObjectType({
+      elemID: new ElemID(JIRA, 'DashboardGadgetProperty'),
+      fields: {
+        key: {
+          refType: BuiltinTypes.STRING,
+          annotations: { [CORE_ANNOTATIONS.CREATABLE]: true, [CORE_ANNOTATIONS.UPDATABLE]: true },
+        },
+        value: {
+          refType: BuiltinTypes.UNKNOWN,
+          annotations: { [CORE_ANNOTATIONS.CREATABLE]: true, [CORE_ANNOTATIONS.UPDATABLE]: true },
+        },
+      },
+    })
+    gadgetPropertyType.fields.values = new Field(
+      gadgetPropertyType,
+      'values',
+      new ListType(gadgetPropertyType),
+      { [CORE_ANNOTATIONS.CREATABLE]: true, [CORE_ANNOTATIONS.UPDATABLE]: true },
+    )
+
+    const gadgetType = findObject(elements, DASHBOARD_GADGET_TYPE)
+    if (gadgetType === undefined) {
+      return
+    }
+
+    gadgetType.fields.properties = new Field(
+      gadgetType,
+      'properties',
+      new ListType(gadgetPropertyType),
+      { [CORE_ANNOTATIONS.CREATABLE]: true, [CORE_ANNOTATIONS.UPDATABLE]: true },
+    )
+    elements.push(gadgetPropertyType)
+  },
+
+  preDeploy: async changes => {
+    changes
+      .filter(isInstanceChange)
+      .filter(isAdditionOrModificationChange)
+      .filter(change => change.data.after.elemID.typeName === DASHBOARD_GADGET_TYPE)
+      .filter(change => Array.isArray(change.data.after.value.properties))
+      .forEach(change => {
+        change.data.after.value.properties
+          .filter((property: Values) => Array.isArray(property.values))
+          .forEach((property: Values) => {
+            property.values = convertListToMap(property.values)
+          })
+        change.data.after.value.properties = convertListToMap(change.data.after.value.properties)
+      })
+  },
+
+  onDeploy: async changes => {
+    changes
+      .filter(isInstanceChange)
+      .filter(isAdditionOrModificationChange)
+      .filter(change => change.data.after.elemID.typeName === DASHBOARD_GADGET_TYPE)
+      .filter(change => _.isPlainObject(change.data.after.value.properties))
+      .forEach(change => {
+        change.data.after.value.properties = convertMapToList(change.data.after.value.properties)
+        change.data.after.value.properties
+          .filter((property: Values) => _.isPlainObject(property.values))
+          .forEach((property: Values) => {
+            property.values = convertMapToList(property.values)
+          })
+      })
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -596,6 +596,7 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     serializationStrategy: 'id',
     target: { type: 'Priority' },
   },
+  // TODO: this is left for backward compatibility, we should remove it
   {
     src: { field: 'statType', parentTypes: ['GadgetConfig'] },
     serializationStrategy: 'id',

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -54,8 +54,13 @@ export const resolutionAndPriorityToTypeName: referenceUtils.ContextValueMapperF
   return undefined
 }
 
+export const getGadgetPropertyRefType = (key: string): string | undefined => (
+  key === 'statType' ? FIELD_TYPE_NAME : undefined
+)
+
+
 export type ReferenceContextStrategyName = 'parentSelectedFieldType' | 'parentFieldType' | 'workflowStatusPropertiesContext'
-| 'parentFieldId'
+| 'parentFieldId' | 'gadgetPropertyValue'
 
 export const contextStrategyLookup: Record<
   ReferenceContextStrategyName, referenceUtils.ContextFunc
@@ -64,6 +69,7 @@ export const contextStrategyLookup: Record<
   parentFieldType: neighborContextFunc({ contextFieldName: 'fieldType', levelsUp: 1, contextValueMapper: toTypeName }),
   workflowStatusPropertiesContext: neighborContextFunc({ contextFieldName: 'key', contextValueMapper: getRefType }),
   parentFieldId: neighborContextFunc({ contextFieldName: 'fieldId', contextValueMapper: resolutionAndPriorityToTypeName }),
+  gadgetPropertyValue: neighborContextFunc({ contextFieldName: 'key', contextValueMapper: getGadgetPropertyRefType }),
 }
 
 const groupNameSerialize: GetLookupNameFunc = ({ ref }) =>
@@ -594,6 +600,11 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     src: { field: 'statType', parentTypes: ['GadgetConfig'] },
     serializationStrategy: 'id',
     target: { type: 'Field' },
+  },
+  {
+    src: { field: 'value', parentTypes: ['DashboardGadgetProperty'] },
+    serializationStrategy: 'id',
+    target: { typeContext: 'gadgetPropertyValue' },
   },
   {
     src: { field: 'groups', parentTypes: ['UserFilter'] },

--- a/packages/jira-adapter/test/filters/dashboard/gadget_properties.test.ts
+++ b/packages/jira-adapter/test/filters/dashboard/gadget_properties.test.ts
@@ -1,0 +1,122 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import { getFilterParams } from '../../utils'
+import gadgetPropertiesFilter from '../../../src/filters/dashboard/gadget_properties'
+import { DASHBOARD_GADGET_TYPE, JIRA } from '../../../src/constants'
+
+
+describe('gadgetPropertiesFilter', () => {
+  let filter: filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
+  let dashboardGadgetType: ObjectType
+  let instance: InstanceElement
+
+
+  beforeEach(async () => {
+    filter = gadgetPropertiesFilter(getFilterParams({})) as filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
+
+    dashboardGadgetType = new ObjectType({
+      elemID: new ElemID(JIRA, DASHBOARD_GADGET_TYPE),
+      fields: {
+        properties: {
+          refType: BuiltinTypes.STRING,
+        },
+      },
+    })
+
+    instance = new InstanceElement(
+      'instance',
+      dashboardGadgetType,
+      {
+        properties: {
+          key1: 'value1',
+          key2: {
+            innerKey: 'value2',
+          },
+        },
+      },
+    )
+  })
+
+  describe('onFetch', () => {
+    it('should return the dashboard properties type', async () => {
+      const elements = [dashboardGadgetType]
+      await filter.onFetch(elements)
+      expect(dashboardGadgetType.fields.properties.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
+
+      const propertiesType = elements[1] as ObjectType
+
+      expect(propertiesType.fields.key.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
+
+      expect(propertiesType.fields.value.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
+
+      expect(propertiesType.fields.values.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
+    })
+
+    it('should convert properties from map to list', async () => {
+      await filter.onFetch([instance])
+      expect(instance.value.properties).toEqual([
+        { key: 'key1', value: 'value1' },
+        { key: 'key2', values: [{ key: 'innerKey', value: 'value2' }] },
+      ])
+    })
+  })
+
+  describe('preDeploy', () => {
+    it('should convert properties from map to list', async () => {
+      instance.value.properties = [
+        { key: 'key1', value: 'value1' },
+        { key: 'key2', values: [{ key: 'innerKey', value: 'value2' }] },
+      ]
+      await filter.preDeploy([toChange({ after: instance })])
+      expect(instance.value.properties).toEqual({
+        key1: 'value1',
+        key2: {
+          innerKey: 'value2',
+        },
+      })
+    })
+  })
+
+  describe('onDeploy', () => {
+    it('should convert properties from map to list', async () => {
+      instance.value.properties = {
+        key1: 'value1',
+        key2: {
+          innerKey: 'value2',
+        },
+      }
+      await filter.onDeploy([toChange({ after: instance })])
+      expect(instance.value.properties).toEqual([
+        { key: 'key1', value: 'value1' },
+        { key: 'key2', values: [{ key: 'innerKey', value: 'value2' }] },
+      ])
+    })
+  })
+})


### PR DESCRIPTION
Change dashboard gadget properties to a list, since the keys there might cause syntax errors in the nacl

---
_Release Notes_: 
__Jira Adapter__:
- Change dashboard gadget properties to a list, since the keys there might cause syntax errors in the nacl

---
_User Notifications_: 
__Jira Adapter__:
- Properties in dashboard gadgets will be converted from maps to lists
