### PR TITLE
SALTO-4132 Support JSON files in file-cabinet

### DIFF
--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
@@ -61,6 +61,8 @@ const NON_BINARY_FILETYPES = new Set([
   'SMS',
   'STYLESHEET',
   'XMLDOC',
+  'JSON',
+  'FREEMARKER',
 ])
 
 const REQUEST_HEADERS = {


### PR DESCRIPTION
Change Json encoding

---

_Additional context for reviewer_
None

---
_Release Notes_: 
Now we support Json files in file cabinet. fetch, deploy and preview

---
_User Notifications_: 
None
