### PR TITLE
SALTO-4105 - Salesforce: Discard multienv-unfriendly fields of OrganizationSettings

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -271,7 +271,6 @@ export const SYSTEM_FIELDS = [
   'LastViewedDate',
   'Name',
   'RecordTypeId',
-  'SystemModstamp',
   'OwnerId',
   'SetupOwnerId',
 ]

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -271,6 +271,7 @@ export const SYSTEM_FIELDS = [
   'LastViewedDate',
   'Name',
   'RecordTypeId',
+  'SystemModstamp',
   'OwnerId',
   'SetupOwnerId',
 ]

--- a/packages/salesforce-adapter/src/filters/organization_wide_sharing_defaults.ts
+++ b/packages/salesforce-adapter/src/filters/organization_wide_sharing_defaults.ts
@@ -55,7 +55,6 @@ const FIELDS_TO_IGNORE = [
   'WebToCaseAssignedEmailTemplateId',
   'WebToCaseCreatedEmailTemplateId',
   'WebToCaseDefaultCreatorId',
-  'SystemModstamp',
 ]
 
 const enrichTypeWithFields = async (

--- a/packages/salesforce-adapter/src/filters/organization_wide_sharing_defaults.ts
+++ b/packages/salesforce-adapter/src/filters/organization_wide_sharing_defaults.ts
@@ -60,7 +60,8 @@ const FIELDS_TO_IGNORE = [
 const enrichTypeWithFields = async (
   client: SalesforceClient,
   type: ObjectType,
-  fieldsToIgnore: Set<string>): Promise<void> => {
+  fieldsToIgnore: Set<string>
+): Promise<void> => {
   const typeApiName = await apiName(type)
   const describeSObjectsResult = await client.describeSObjects([typeApiName])
   if (describeSObjectsResult.errors.length !== 0 || describeSObjectsResult.result.length !== 1) {


### PR DESCRIPTION
We only really care about account sharing settings, and some fields of OrganizationSettings are noisy on fetches (change on every fetch) or across envs.

 - [x] [Noise Suppression](https://github.com/salto-io/salto_private/pull/5796)

---

N/A

---
_Release Notes_: 
Salesforce: remove some fields of OrganizationSettings

---
_User Notifications_: 
N/A
