### PR TITLE
SAAS-6976 fix dummy adapter deploy due to code change in deployOrValidate

### DIFF
--- a/packages/core/src/core/deploy/deploy_actions.ts
+++ b/packages/core/src/core/deploy/deploy_actions.ts
@@ -58,22 +58,25 @@ const extractErrors = (
 const deployOrValidate = async (
   { adapter, adapterName, opts, checkOnly }: DeployOrValidateParams
 ): Promise<AdapterDeployResult> => {
-  try {
-    const deployOrValidateFn = checkOnly ? adapter.validate : adapter.deploy
-    if (deployOrValidateFn === undefined) {
-      throw new Error(`${checkOnly ? 'Check-Only deployment' : 'Deployment'} is not supported in adapter ${adapterName}`)
-    }
-    const result = await deployOrValidateFn(opts)
+  // NOTE: DRY-ing this code into something like
+  // const deployOrValidateFn = checkOnly ? adapter.validate : adapter.deploy
+  // can cause `this` to be undefined, causing problems within the adapters.
+  if (!checkOnly) {
+    const deployRes = await adapter.deploy(opts)
     return {
-      appliedChanges: result.appliedChanges,
-      extraProperties: result.extraProperties,
-      errors: extractErrors(result, opts.changeGroup.changes),
+      appliedChanges: deployRes.appliedChanges,
+      extraProperties: deployRes.extraProperties,
+      errors: extractErrors(deployRes, opts.changeGroup.changes),
     }
-  } catch (error) {
-    return {
-      appliedChanges: [],
-      errors: addElemIDsToError(opts.changeGroup.changes, error as Error),
-    }
+  }
+  if (_.isUndefined(adapter.validate)) {
+    throw new Error(`Check-Only deployment is not supported in adapter ${adapterName}`)
+  }
+  const validateRes = await adapter.validate(opts)
+  return {
+    appliedChanges: validateRes.appliedChanges,
+    extraProperties: validateRes.extraProperties,
+    errors: extractErrors(validateRes, opts.changeGroup.changes),
   }
 }
 


### PR DESCRIPTION


---

Because of code beautification change in `deployOrValidate`, when calling dummy adapter `this` might be undefined.

---

_Release Notes_: _None_

---

_User Notifications_: _None_