### PR TITLE
SALTO-4252: add workflow diagram transition initial source

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/cloud/workflow.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/workflow.ts
@@ -413,4 +413,8 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
       },
     },
   ],
+  diagramInitialEntry: {
+    x: 12.34,
+    y: 34.12,
+  },
 })

--- a/packages/jira-adapter/e2e_test/instances/datacenter/workflow.ts
+++ b/packages/jira-adapter/e2e_test/instances/datacenter/workflow.ts
@@ -223,4 +223,8 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
       },
     },
   ],
+  diagramInitialEntry: {
+    x: 12.34,
+    y: 34.12,
+  },
 })

--- a/packages/jira-adapter/src/filters/workflow/types.ts
+++ b/packages/jira-adapter/src/filters/workflow/types.ts
@@ -183,6 +183,7 @@ export type Workflow = {
   name?: string
   transitions: Transition[]
   statuses?: Status[]
+  diagramInitialEntry?: StatusLocation
 }
 
 export const workflowSchema = Joi.object({

--- a/packages/jira-adapter/src/filters/workflow/workflow_diagrams.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_diagrams.ts
@@ -289,8 +289,8 @@ const insertWorkflowDiagramFields = (workflow: WorkflowInstance,
     }
   })
   workflow.value.diagramInitialEntry = {
-    x: statusIdToStatus?.initial.x,
-    y: statusIdToStatus?.initial.y,
+    x: statusIdToStatus.initial?.x,
+    y: statusIdToStatus.initial?.y,
   }
   workflow.value.transitions.forEach(transition => {
     const transitionName = transition.name

--- a/packages/jira-adapter/src/filters/workflow/workflow_diagrams.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_diagrams.ts
@@ -182,8 +182,8 @@ const buildStatusDiagramFields = (workflow: WorkflowInstance, statusIdToStepId: 
         x: status.location?.x,
         y: status.location?.y }
     })
-  if (workflow.value.diagramInitialEntry) {
-    statuses?.push({
+  if (workflow.value.diagramInitialEntry && statuses) {
+    statuses.push({
       id: statusIdToStepId.initial,
       x: workflow.value.diagramInitialEntry.x,
       y: workflow.value.diagramInitialEntry.y,

--- a/packages/jira-adapter/src/filters/workflow/workflow_diagrams.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_diagrams.ts
@@ -20,7 +20,7 @@ import Joi from 'joi'
 import { logger } from '@salto-io/logging'
 import { createSchemeGuard } from '@salto-io/adapter-utils'
 import { addAnnotationRecursively, findObject, setFieldDeploymentAnnotations } from '../../utils'
-import { JIRA, WORKFLOW_STATUS_TYPE_NAME, WORKFLOW_TRANSITION_TYPE_NAME } from '../../constants'
+import { JIRA, WORKFLOW_STATUS_TYPE_NAME, WORKFLOW_TRANSITION_TYPE_NAME, WORKFLOW_TYPE_NAME } from '../../constants'
 import { FilterCreator } from '../../filter'
 import { isWorkflowInstance, TransitionFrom, WorkflowInstance } from './types'
 import JiraClient from '../../client/client'
@@ -168,11 +168,12 @@ export const removeWorkflowDiagramFields = (element: WorkflowInstance): void => 
           : from))
       }
     })
+  delete element.value.diagramInitialEntry
 }
 
 const buildStatusDiagramFields = (workflow: WorkflowInstance, statusIdToStepId: Record<string, string>)
-  :StatusDiagramDeploy[] | undefined =>
-  workflow.value.statuses
+  :StatusDiagramDeploy[] | undefined => {
+  const statuses = workflow.value.statuses
     ?.map(status => {
       if (typeof status.id !== 'string') {
         throw new Error(`Fail to deploy Workflow ${workflow.value.name} Status ${status.name} Diagram values`)
@@ -181,7 +182,15 @@ const buildStatusDiagramFields = (workflow: WorkflowInstance, statusIdToStepId: 
         x: status.location?.x,
         y: status.location?.y }
     })
-
+  if (workflow.value.diagramInitialEntry) {
+    statuses?.push({
+      id: statusIdToStepId.initial,
+      x: workflow.value.diagramInitialEntry.x,
+      y: workflow.value.diagramInitialEntry.y,
+    })
+  }
+  return statuses
+}
 
 const buildTransitionsDiagramFields = (workflow: WorkflowInstance, statusIdToStepId: Record<string, string>,
   actionKeyToTransition: Record<string, TransitionDiagramFields>)
@@ -249,7 +258,11 @@ const buildDiagramMaps = async ({ client, workflow }:
   }
   const { layout } = response.data
   layout.statuses.forEach(status => {
-    statusIdToStatus[status.statusId] = status
+    if (status.initial) {
+      statusIdToStatus.initial = status
+    } else {
+      statusIdToStatus[status.statusId] = status
+    }
   })
   layout.transitions.forEach(transition => {
     actionKeyToTransition[getTransitionKey(transition.sourceId, transition.name)] = transition
@@ -275,6 +288,10 @@ const insertWorkflowDiagramFields = (workflow: WorkflowInstance,
         y: statusIdToStatus[status.id as string].y }
     }
   })
+  workflow.value.diagramInitialEntry = {
+    x: statusIdToStatus.initial.x,
+    y: statusIdToStatus.initial.y,
+  }
   workflow.value.transitions.forEach(transition => {
     const transitionName = transition.name
     if (transition.type === INITIAL_TRANSITION_TYPE && transitionName !== undefined) {
@@ -334,6 +351,11 @@ const filter: FilterCreator = ({ client }) => ({
     if (workflowStatusType !== undefined) {
       workflowStatusType.fields.location = new Field(workflowStatusType, 'location', statusLocationType)
       setFieldDeploymentAnnotations(workflowStatusType, 'location')
+    }
+    const workflowType = findObject(elements, WORKFLOW_TYPE_NAME)
+    if (workflowType !== undefined) {
+      workflowType.fields.diagramInitialEntry = new Field(workflowType, 'diagramInitialEntry', statusLocationType)
+      setFieldDeploymentAnnotations(workflowType, 'diagramInitialEntry')
     }
     elements.push(transitionFromType)
     elements.push(statusLocationType)

--- a/packages/jira-adapter/src/filters/workflow/workflow_diagrams.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_diagrams.ts
@@ -289,8 +289,8 @@ const insertWorkflowDiagramFields = (workflow: WorkflowInstance,
     }
   })
   workflow.value.diagramInitialEntry = {
-    x: statusIdToStatus.initial.x,
-    y: statusIdToStatus.initial.y,
+    x: statusIdToStatus?.initial.x,
+    y: statusIdToStatus?.initial.y,
   }
   workflow.value.transitions.forEach(transition => {
     const transitionName = transition.name

--- a/packages/jira-adapter/test/filters/workflow/workflow_deploy_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_deploy_filter.test.ts
@@ -498,6 +498,10 @@ describe('workflowDeployFilter', () => {
                 id: '500',
               },
             ],
+            diagramInitialEntry: {
+              x: 33,
+              y: 66,
+            },
             transitions: [
               {
                 name: 'Building',
@@ -718,6 +722,11 @@ describe('workflowDeployFilter', () => {
               },
               {
                 id: 'S<22>',
+              },
+              {
+                id: 'I<1>',
+                x: 33,
+                y: 66,
               },
             ],
             transitions: [

--- a/packages/jira-adapter/test/filters/workflow/workflow_diagrams.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_diagrams.test.ts
@@ -229,8 +229,14 @@ describe('workflowDiagramFilter', () => {
       expect(workflowTransitionType.fields.from).toBeDefined()
       expect(elements).toHaveLength(3)
     })
+    it('should set the diagramInitialEntry field in Workflow', async () => {
+      const elements = [workflowType]
+      await filter.onFetch(elements)
+      expect(workflowType.fields.diagramInitialEntry).toBeDefined()
+      expect(elements).toHaveLength(3)
+    })
 
-    it('should add location fields to the statuses', async () => {
+    it('should add location fields to the statuses and to the initial entry', async () => {
       const elements = [instance]
       await filter.onFetch(elements)
       expect(mockConnection.get).toHaveBeenCalledWith(
@@ -244,6 +250,9 @@ describe('workflowDiagramFilter', () => {
       expect(instance.value.statuses[0].location).toBeDefined()
       expect(instance.value.statuses[0].location.x).toEqual(-3)
       expect(instance.value.statuses[0].location.y).toEqual(6)
+      expect(instance.value.diagramInitialEntry).toBeDefined()
+      expect(instance.value.diagramInitialEntry.x).toEqual(33)
+      expect(instance.value.diagramInitialEntry.y).toEqual(66)
     })
 
     it('should add angles to from values in transitions', async () => {


### PR DESCRIPTION
_add workflow diagram transition initial source_

---
I added a new field to workflows that is called `diagramInitialEntry`

<img width="289" alt="Screen Shot 2023-05-31 at 12 34 43" src="https://github.com/salto-io/salto/assets/77064001/83b3a9fd-b537-4220-8024-97dab0c70ea4">


---
_Release Notes_: 
Jira Adapter:
* fix a bug with workflow diagram initial transition source 

---
_User Notifications_: 
Jira Adapter:
* workflows have a new field called `diagramInitialEntry` that contains the location coordinates of the initial transition source in the workflow diagram

