### PR TITLE
SAAS-6976 only add errors to elements that failed to apply

### DIFF
--- a/packages/core/src/core/deploy/deploy_actions.ts
+++ b/packages/core/src/core/deploy/deploy_actions.ts
@@ -64,10 +64,13 @@ const deployOrValidate = async (
   }
   try {
     const result = await deployOrValidateFn(opts)
+    const failedChanges = opts.changeGroup.changes.filter(
+      change => !result.appliedChanges.some(c => getChangeData(c) === getChangeData(change))
+    )
     return {
       appliedChanges: result.appliedChanges,
       extraProperties: result.extraProperties,
-      errors: extractErrors(result, opts.changeGroup.changes),
+      errors: extractErrors(result, failedChanges),
     }
   } catch (error) {
     return {

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -432,13 +432,19 @@ describe('api.ts', () => {
         mockAdapterOps.deploy.mockClear()
         mockAdapterOps.deploy.mockImplementationOnce(async ({ changeGroup }) => ({
           appliedChanges: changeGroup.changes.filter(isModificationChange),
-          errors: [{ message: 'cannot add new employee', severity: 'Error' as SeverityLevel }],
+          errors: [
+            new Error('cannot add new employee'),
+            { message: 'cannot add new employee', severity: 'Error' as SeverityLevel },
+          ],
         }))
         result = await api.deploy(ws, actionPlan, jest.fn(), ACCOUNTS)
       })
 
-      it('should return error for the failed part', () => {
-        expect(result.errors).toHaveLength(1)
+      it('should return errors for the failed part', () => {
+        expect(result.errors).toHaveLength(2)
+        expect(result.errors[0]).toMatchObject(expect.objectContaining({
+          elemID: newEmployee.elemID,
+        }))
       })
       it('should return success false for the overall deploy', () => {
         expect(result.success).toBeFalsy()
@@ -495,7 +501,7 @@ describe('api.ts', () => {
         it('should fail with error', async () => {
           await executeDeploy()
           expect(mockAdapterOps.deploy).not.toHaveBeenCalled()
-          expect(result.errors).toHaveLength(1)
+          expect(result.errors).toHaveLength(2)
         })
       })
       describe('when adapter implements the validate method', () => {


### PR DESCRIPTION
Only add element IDs of elements that failed to deploy to `Error`s.

---
When a deploy returns errors of type `Error`, extract errors into `SaltoElementError` only for elements that were not successfully deployed (are not in `appliedChanges`)

---
_Release Notes_:
Core:
- On partial deploy failures, only add element IDs of elements that failed to deploy to errors.

---
