### PR TITLE
SALTO-4254 Return a lexer error token and add a better catch

### DIFF
--- a/packages/workspace/src/parser/internal/native/errors.ts
+++ b/packages/workspace/src/parser/internal/native/errors.ts
@@ -18,7 +18,7 @@ import { ParseError } from '../../types'
 import { SourceRange } from '../types'
 
 
-export const createError = (range: SourceRange, summary: string, message?: string): ParseError => ({
+const createError = (range: SourceRange, summary: string, message?: string): ParseError => ({
   summary,
   subject: range,
   context: range,
@@ -176,6 +176,12 @@ export const contentMergeConflict = (range: SourceRange): ParseError => createEr
   range,
   'Unresolved merge conflict',
 )
+
+export const invalidSyntax = (range: SourceRange): ParseError =>
+  createError(range, 'Invalid syntax',)
+
+export const unknownParsingError = (range: SourceRange, message: string): ParseError =>
+  createError(range, message)
 
 export const invalidStringChar = (stringRange: SourceRange, errMsg: string): ParseError => {
   const errMsgPosition = Number.parseInt(_.last(errMsg.split(' ')) || '', 10)

--- a/packages/workspace/src/parser/internal/native/errors.ts
+++ b/packages/workspace/src/parser/internal/native/errors.ts
@@ -18,7 +18,7 @@ import { ParseError } from '../../types'
 import { SourceRange } from '../types'
 
 
-const createError = (range: SourceRange, summary: string, message?: string): ParseError => ({
+export const createError = (range: SourceRange, summary: string, message?: string): ParseError => ({
   summary,
   subject: range,
   context: range,

--- a/packages/workspace/src/parser/internal/native/lexer.ts
+++ b/packages/workspace/src/parser/internal/native/lexer.ts
@@ -52,8 +52,9 @@ const WORD_PART = '[a-zA-Z_][\\w.@]*'
 
 export const rules: Record<string, moo.Rules> = {
   // Regarding ERROR tokens: Each section in the state must have an error token.
-  // When there is no lexer match, the error token is returned with the rest of the buffer.
-  // If there is no error token in a section, an Error is thrown from the lexer.
+  // If there is no error token in a section, an Error is thrown from the lexer, with missing information.
+  // With an error token - when there is no lexer match, the error token is returned with the rest of the buffer.
+  // We throw our own error with the token and reflect this to the user.
   main: {
     [TOKEN_TYPES.MERGE_CONFLICT]: { match: '<<<<<<<', push: 'mergeConflict' },
     [TOKEN_TYPES.MULTILINE_START]: { match: /'''[ \t]*[(\r\n)(\n)]/, lineBreaks: true, push: 'multilineString' },

--- a/packages/workspace/src/parser/internal/native/lexer.ts
+++ b/packages/workspace/src/parser/internal/native/lexer.ts
@@ -99,7 +99,7 @@ export type LexerToken = Required<moo.Token>
 
 export class NoSuchElementError extends Error {
   constructor(public lastValidToken?: LexerToken) {
-    super('All lexerֿֿֿ tokens have already been consumed.')
+    super('All lexer tokens have already been consumed.')
   }
 }
 

--- a/packages/workspace/src/parser/internal/native/lexer.ts
+++ b/packages/workspace/src/parser/internal/native/lexer.ts
@@ -51,6 +51,9 @@ export const TOKEN_TYPES = {
 const WORD_PART = '[a-zA-Z_][\\w.@]*'
 
 export const rules: Record<string, moo.Rules> = {
+  // Regarding ERROR tokens: Each section in the state must have an error token.
+  // When there is no lexer match, the error token is returned with the rest of the buffer.
+  // If there is no error token in a section, an Error is thrown from the lexer.
   main: {
     [TOKEN_TYPES.MERGE_CONFLICT]: { match: '<<<<<<<', push: 'mergeConflict' },
     [TOKEN_TYPES.MULTILINE_START]: { match: /'''[ \t]*[(\r\n)(\n)]/, lineBreaks: true, push: 'multilineString' },
@@ -68,6 +71,8 @@ export const rules: Record<string, moo.Rules> = {
     [TOKEN_TYPES.COMMENT]: /\/\//,
     [TOKEN_TYPES.WHITESPACE]: { match: /[ \t]+/ },
     [TOKEN_TYPES.NEWLINE]: { match: /[\r\n]+/, lineBreaks: true },
+    // The Invalid token is matched when the syntax is not critical - for example in comment content.
+    // The parser disregards this token and continues to the next match.
     [TOKEN_TYPES.INVALID]: { match: /[^ \n]+/ },
     [TOKEN_TYPES.ERROR]: moo.error,
   },

--- a/packages/workspace/src/parser/internal/native/lexer.ts
+++ b/packages/workspace/src/parser/internal/native/lexer.ts
@@ -45,6 +45,7 @@ export const TOKEN_TYPES = {
   MERGE_CONFLICT_MID: 'mergeConflictMid',
   MERGE_CONFLICT_END: 'mergeConflictEnd',
   CONFLICT_CONTENT: 'mergeConflictContent',
+  ERROR: 'error',
 }
 
 const WORD_PART = '[a-zA-Z_][\\w.@]*'
@@ -67,7 +68,8 @@ export const rules: Record<string, moo.Rules> = {
     [TOKEN_TYPES.COMMENT]: /\/\//,
     [TOKEN_TYPES.WHITESPACE]: { match: /[ \t]+/ },
     [TOKEN_TYPES.NEWLINE]: { match: /[\r\n]+/, lineBreaks: true },
-    [TOKEN_TYPES.INVALID]: { match: /[^ \n]+/, error: true },
+    [TOKEN_TYPES.INVALID]: { match: /[^ \n]+/ },
+    [TOKEN_TYPES.ERROR]: moo.error,
   },
   string: {
     [TOKEN_TYPES.REFERENCE]: { match: new RegExp(`\\$\\{[ \\t]*${WORD_PART}[ \\t]*\\}`), value: s => s.slice(2, -1).trim() },
@@ -77,16 +79,19 @@ export const rules: Record<string, moo.Rules> = {
     // Template markers are added to prevent incorrect parsing of user created strings that look like Salto references.
     [TOKEN_TYPES.CONTENT]: { match: /[^\r\n\\]+?(?=\$\{|["\n\r\\])/, lineBreaks: false },
     [TOKEN_TYPES.NEWLINE]: { match: /[\r\n]+/, lineBreaks: true, pop: 1 },
+    [TOKEN_TYPES.ERROR]: moo.error,
   },
   multilineString: {
     [TOKEN_TYPES.REFERENCE]: { match: new RegExp(`\\$\\{[ \\t]*${WORD_PART}[ \\t]*\\}`), value: s => s.slice(2, -1).trim() },
     [TOKEN_TYPES.MULTILINE_END]: { match: /^[ \t]*'''/, pop: 1 },
     [TOKEN_TYPES.CONTENT]: { match: /.*\\\$\{.*[(\r\n)(\n)]|.*?(?=\$\{)|.*[(\r\n)(\n)]/, lineBreaks: true },
+    [TOKEN_TYPES.ERROR]: moo.error,
   },
   mergeConflict: {
     [TOKEN_TYPES.MERGE_CONFLICT_MID]: '=======',
     [TOKEN_TYPES.MERGE_CONFLICT_END]: { match: '>>>>>>>', pop: 1 },
     [TOKEN_TYPES.CONFLICT_CONTENT]: { match: /.*\\\$\{.*[(\r\n)(\n)]|.*?(?=\$\{)|.*[(\r\n)(\n)]/, lineBreaks: true },
+    [TOKEN_TYPES.ERROR]: moo.error,
   },
 }
 
@@ -94,13 +99,19 @@ export type LexerToken = Required<moo.Token>
 
 export class NoSuchElementError extends Error {
   constructor(public lastValidToken?: LexerToken) {
-    super("All of the lexer's token has already been consumed.")
+    super('All lexerֿֿֿ tokens have already been consumed.')
   }
 }
 
 class InvalidLexerTokenError extends Error {
   constructor() {
     super('All lexer tokens must have a type.')
+  }
+}
+
+export class LexerErrorTokenReachedError extends Error {
+  constructor(public lastValidToken?: LexerToken) {
+    super('Invalid syntax')
   }
 }
 
@@ -124,6 +135,8 @@ const validateToken = (token?: moo.Token): token is LexerToken => {
     } else {
       throw new InvalidLexerTokenError()
     }
+  } else if (token.type === TOKEN_TYPES.ERROR) {
+    throw new LexerErrorTokenReachedError(token as LexerToken)
   }
   return true
 }

--- a/packages/workspace/test/parser/errors.test.ts
+++ b/packages/workspace/test/parser/errors.test.ts
@@ -16,14 +16,11 @@
 
 import { PrimitiveType, PrimitiveTypes, InstanceElement, ObjectType, ElemID } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
-import { logger } from '@salto-io/logging'
 import { parse, ParseResult } from '../../src/parser'
 import { IllegalReference } from '../../src/parser/internal/types'
 import { MISSING_VALUE } from '../../src/parser/internal/native/consumers/values'
-import { NoSuchElementError } from '../../src/parser/internal/native/lexer'
 
 const { awu } = collections.asynciterable
-const logging = logger('workspace/src/parser/internal/native/parse')
 
 describe('parsing errors', () => {
   describe('general element block structure', () => {
@@ -67,9 +64,7 @@ describe('parsing errors', () => {
       ]
       `
       let res: ParseResult
-      let log: jest.SpyInstance<void, [message: string | Error, ...args: unknown[]]>
       beforeAll(async () => {
-        log = jest.spyOn(logging, 'error')
         res = await parse(Buffer.from(nacl), 'file.nacl', {})
       })
 
@@ -89,14 +84,6 @@ describe('parsing errors', () => {
           .toBe('Invalid block item')
         expect(res.errors[3].summary)
           .toBe('Invalid block item')
-      })
-
-      it('should log an error not added to the errors', () => {
-        expect(log).toHaveBeenCalledWith(
-          expect.stringContaining('Unexpected error while parsing'),
-          'file.nacl',
-          expect.any(NoSuchElementError)
-        )
       })
     })
   })

--- a/packages/workspace/test/parser/parse.test.ts
+++ b/packages/workspace/test/parser/parse.test.ts
@@ -910,8 +910,21 @@ value
     })
   })
 
+  it('should fail gracefully with unicode line separators in multiline strings', async () => {
+    const body = `
+    type salesforce.unicodeLines {
+      str = '''
+      Line that ends with unicode line break\u2028
+      '''
+    }
+    `
+    const result = await parse(Buffer.from(body), 'none', functions)
+    expect(result.errors).toHaveLength(1)
+    expect(result.elements).toEqual([])
+  })
+
   describe('tokenizeContent', () => {
-    it('seperate and token each part of a line correctly', () => {
+    it('separate and token each part of a line correctly', () => {
       expect(Array.from(tokenizeContent('aaa   bbb ccc.ddd   "eee fff  ggg.hhh"'))).toEqual([
         { value: 'aaa', type: 'word', line: 1, col: 1 },
         { value: 'bbb', type: 'word', line: 1, col: 7 },

--- a/packages/workspace/test/parser/parse.test.ts
+++ b/packages/workspace/test/parser/parse.test.ts
@@ -18,10 +18,8 @@ import {
   isObjectType, InstanceElement, BuiltinTypes, isListType, isVariable,
   isType, isPrimitiveType, ListType, ReferenceExpression, VariableExpression, TemplateExpression,
 } from '@salto-io/adapter-api'
-
-// import each from 'jest-each'
 import { collections } from '@salto-io/lowerdash'
-import { registerTestFunction } from '../utils'
+import { registerTestFunction, registerThrowingFunction } from '../utils'
 import {
   Functions,
 } from '../../src/parser/functions'
@@ -825,6 +823,17 @@ value
       const result = await parse(Buffer.from(body), 'none', functions)
       expect(result.errors).not.toHaveLength(0)
       expect(result.errors[0].summary).toEqual('Invalid attribute definition')
+    })
+
+    it('fails', async () => {
+      const body = `
+      adapter_id.some_asset {
+        content                                 = funcush("some.png")
+      `
+      const throwingFunctions = registerThrowingFunction(funcName, () => { throw new Error('unexpected') })
+      const result = await parse(Buffer.from(body), 'none', throwingFunctions)
+      expect(result.errors).toHaveLength(1)
+      expect(result.errors[0].message).toEqual('unexpected')
     })
 
     it('fails on invalid object item with unexpected eof', async () => {

--- a/packages/workspace/test/utils.ts
+++ b/packages/workspace/test/utils.ts
@@ -62,6 +62,17 @@ export const registerTestFunction = (
   )
 )
 
+export const registerThrowingFunction = (
+  funcName: string, parse: () => Promise<void>
+): Functions => registerFunction(
+  funcName,
+  {
+    parse,
+    dump: () => Promise.reject(),
+    isSerializedAsFunction: () => true,
+  },
+)
+
 export const mockStaticFilesSource = (staticFiles: StaticFile[] = []): StaticFilesSource => ({
   load: jest.fn().mockResolvedValue([]),
   getStaticFile: jest.fn().mockImplementation((filepath: string, _encoding: BufferEncoding) => (


### PR DESCRIPTION
_Currently when the parser crashes with an unexpected error, that error is logged, but the parse result doesn’t contain any error so the rest of the code doesn’t know that something failed._

---

_Additional context for reviewer_

---
_Release Notes_: 
_Workspace_
* Update the parse result with caught errors

---
_User Notifications_: 
