### PR TITLE
SALTO-4278 Add parser support for unicode newline

### DIFF
--- a/packages/workspace/src/parser/internal/native/lexer.ts
+++ b/packages/workspace/src/parser/internal/native/lexer.ts
@@ -50,7 +50,7 @@ export const TOKEN_TYPES = {
 
 const WORD_PART = '[a-zA-Z_][\\w.@]*'
 const NEWLINE = '[(\r\n)(\n)\u2028\u2029]'
-const MULTILINE_CONTENT = new RegExp(`.*\\\\$\{.*${NEWLINE}|.*?(?=\\$\{)|.*${NEWLINE}`)
+const MULTILINE_CONTENT = new RegExp(`.*\\\\\\$\\{.*${NEWLINE}|.*?(?=\\$\\{)|.*${NEWLINE}`)
 const REFERENCE = new RegExp(`\\$\\{[ \\t]*${WORD_PART}[ \\t]*\\}`)
 
 export const rules: Record<string, moo.Rules> = {

--- a/packages/workspace/src/parser/internal/native/lexer.ts
+++ b/packages/workspace/src/parser/internal/native/lexer.ts
@@ -49,6 +49,9 @@ export const TOKEN_TYPES = {
 }
 
 const WORD_PART = '[a-zA-Z_][\\w.@]*'
+const NEWLINE = '[(\r\n)(\n)\u2028\u2029]'
+const MULTILINE_CONTENT = new RegExp(`.*\\\\$\{.*${NEWLINE}|.*?(?=\\$\{)|.*${NEWLINE}`)
+const REFERENCE = new RegExp(`\\$\\{[ \\t]*${WORD_PART}[ \\t]*\\}`)
 
 export const rules: Record<string, moo.Rules> = {
   // Regarding ERROR tokens: Each section in the state must have an error token.
@@ -57,7 +60,7 @@ export const rules: Record<string, moo.Rules> = {
   // We throw our own error with the token and reflect this to the user.
   main: {
     [TOKEN_TYPES.MERGE_CONFLICT]: { match: '<<<<<<<', push: 'mergeConflict' },
-    [TOKEN_TYPES.MULTILINE_START]: { match: /'''[ \t]*[(\r\n)(\n)]/, lineBreaks: true, push: 'multilineString' },
+    [TOKEN_TYPES.MULTILINE_START]: { match: new RegExp(`'''[ \t]*${NEWLINE}`), lineBreaks: true, push: 'multilineString' },
     [TOKEN_TYPES.DOUBLE_QUOTES]: { match: '"', push: 'string' },
     [TOKEN_TYPES.NUMBER]: /-?(?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][+-]?\d+)?/,
     [TOKEN_TYPES.LEFT_PAREN]: '(',
@@ -71,32 +74,32 @@ export const rules: Record<string, moo.Rules> = {
     [TOKEN_TYPES.WORD]: new RegExp(WORD_PART, 's'),
     [TOKEN_TYPES.COMMENT]: /\/\//,
     [TOKEN_TYPES.WHITESPACE]: { match: /[ \t]+/ },
-    [TOKEN_TYPES.NEWLINE]: { match: /[\r\n]+/, lineBreaks: true },
+    [TOKEN_TYPES.NEWLINE]: { match: new RegExp(`${NEWLINE}+`), lineBreaks: true },
     // The Invalid token is matched when the syntax is not critical - for example in comment content.
     // The parser disregards this token and continues to the next match.
-    [TOKEN_TYPES.INVALID]: { match: /[^ \n]+/ },
+    [TOKEN_TYPES.INVALID]: { match: /[^ \n\r\u2028\u2029]+/ },
     [TOKEN_TYPES.ERROR]: moo.error,
   },
   string: {
-    [TOKEN_TYPES.REFERENCE]: { match: new RegExp(`\\$\\{[ \\t]*${WORD_PART}[ \\t]*\\}`), value: s => s.slice(2, -1).trim() },
+    [TOKEN_TYPES.REFERENCE]: { match: REFERENCE, value: s => s.slice(2, -1).trim() },
     [TOKEN_TYPES.DOUBLE_QUOTES]: { match: '"', pop: 1 },
     // This handles regular escapes, unicode escapes and escaped template markers ('\${')
     [TOKEN_TYPES.ESCAPE]: { match: /\\[^$u]|\\u[0-9a-fA-F]{4}|\\\$\{?/ },
     // Template markers are added to prevent incorrect parsing of user created strings that look like Salto references.
     [TOKEN_TYPES.CONTENT]: { match: /[^\r\n\\]+?(?=\$\{|["\n\r\\])/, lineBreaks: false },
-    [TOKEN_TYPES.NEWLINE]: { match: /[\r\n]+/, lineBreaks: true, pop: 1 },
+    [TOKEN_TYPES.NEWLINE]: { match: new RegExp(`${NEWLINE}+`), lineBreaks: true, pop: 1 },
     [TOKEN_TYPES.ERROR]: moo.error,
   },
   multilineString: {
-    [TOKEN_TYPES.REFERENCE]: { match: new RegExp(`\\$\\{[ \\t]*${WORD_PART}[ \\t]*\\}`), value: s => s.slice(2, -1).trim() },
+    [TOKEN_TYPES.REFERENCE]: { match: REFERENCE, value: s => s.slice(2, -1).trim() },
     [TOKEN_TYPES.MULTILINE_END]: { match: /^[ \t]*'''/, pop: 1 },
-    [TOKEN_TYPES.CONTENT]: { match: /.*\\\$\{.*[(\r\n)(\n)]|.*?(?=\$\{)|.*[(\r\n)(\n)]/, lineBreaks: true },
+    [TOKEN_TYPES.CONTENT]: { match: MULTILINE_CONTENT, lineBreaks: true },
     [TOKEN_TYPES.ERROR]: moo.error,
   },
   mergeConflict: {
     [TOKEN_TYPES.MERGE_CONFLICT_MID]: '=======',
     [TOKEN_TYPES.MERGE_CONFLICT_END]: { match: '>>>>>>>', pop: 1 },
-    [TOKEN_TYPES.CONFLICT_CONTENT]: { match: /.*\\\$\{.*[(\r\n)(\n)]|.*?(?=\$\{)|.*[(\r\n)(\n)]/, lineBreaks: true },
+    [TOKEN_TYPES.CONFLICT_CONTENT]: { match: MULTILINE_CONTENT, lineBreaks: true },
     [TOKEN_TYPES.ERROR]: moo.error,
   },
 }

--- a/packages/workspace/src/parser/internal/native/lexer.ts
+++ b/packages/workspace/src/parser/internal/native/lexer.ts
@@ -49,7 +49,7 @@ export const TOKEN_TYPES = {
 }
 
 const WORD_PART = '[a-zA-Z_][\\w.@]*'
-const NEWLINE = '[(\r\n)(\n)\u2028\u2029]'
+const NEWLINE = '[\r\n\u2028\u2029]'
 const MULTILINE_CONTENT = new RegExp(`.*\\\\\\$\\{.*${NEWLINE}|.*?(?=\\$\\{)|.*${NEWLINE}`)
 const REFERENCE = new RegExp(`\\$\\{[ \\t]*${WORD_PART}[ \\t]*\\}`)
 

--- a/packages/workspace/test/parser/parse.test.ts
+++ b/packages/workspace/test/parser/parse.test.ts
@@ -958,6 +958,7 @@ value
     beforeAll(async () => {
       const body = `
       type salesforce.unicodeLines {\u2028
+        // comment\u2028
         multi = '''\u2028
         end with unicode line separator\u2028
         end with unicode paragraph separator\u2029

--- a/packages/workspace/test/parser/parse.test.ts
+++ b/packages/workspace/test/parser/parse.test.ts
@@ -23,7 +23,7 @@ import { registerTestFunction, registerThrowingFunction } from '../utils'
 import {
   Functions,
 } from '../../src/parser/functions'
-import { SourceRange, parse, SourceMap, tokenizeContent } from '../../src/parser'
+import { SourceRange, parse, SourceMap, tokenizeContent, ParseResult } from '../../src/parser'
 import { LexerErrorTokenReachedError } from '../../src/parser/internal/native/lexer'
 
 const { awu } = collections.asynciterable
@@ -953,18 +953,45 @@ value
     })
   })
 
-  it('should fail gracefully with unicode line separators in multiline strings', async () => {
-    const body = `
-    type salesforce.unicodeLines {
-      str = '''
-      Line that ends with unicode line break\u2028
-      '''
-    }
-    `
-    const result = await parse(Buffer.from(body), 'none', functions)
-    expect(result.errors).toHaveLength(1)
-    expect(result.elements).toEqual([])
+  describe('parse unicode line terminators', () => {
+    let parsed: ParseResult
+    beforeAll(async () => {
+      const body = `
+      type salesforce.unicodeLines {\u2028
+        multi = '''\u2028
+        end with unicode line separator\u2028
+        end with unicode paragraph separator\u2029
+        '''\u2028
+        single = "end single with unicode"\u2028
+      }\u2028
+      `.replace(/\n/g, '')
+      parsed = await parse(Buffer.from(body), 'none', functions)
+    })
+
+    it('should not have errors', () => {
+      expect(parsed.errors).toHaveLength(0)
+    })
+
+    describe('multiline strings', () => {
+      it('should parse unicode line separators', () => {
+        const parsedValue = (parsed.elements as InstanceElement[])[0].annotations.multi
+        expect(parsedValue).toContain('end with unicode line separator')
+      })
+
+      it('should parse unicode paragraph separators', () => {
+        const parsedValue = (parsed.elements as InstanceElement[])[0].annotations.multi
+        expect(parsedValue).toContain('end with unicode paragraph separator')
+      })
+    })
+
+    describe('single line strings', () => {
+      it('should parse unicode line separators', () => {
+        const parsedValue = (parsed.elements as InstanceElement[])[0].annotations.single
+        expect(parsedValue).toContain('end single with unicode')
+      })
+    })
   })
+
 
   describe('tokenizeContent', () => {
     it('separate and token each part of a line correctly', () => {


### PR DESCRIPTION
_Add support for unicode line terminator parsing_

---

_Additional context for reviewer_
* Javascript has 2 unicode line terminators (\u2028 and \u2029)

---
_Release Notes_: 
_Core_
* Unicode line terminators will no longer throw parse errors.

---
_User Notifications_: 
