### PR TITLE
INCIDENT-5618: fixed 'getFullName' of undefined when missing a reference

### DIFF
--- a/packages/jira-adapter/src/dependency_changers/workflow.ts
+++ b/packages/jira-adapter/src/dependency_changers/workflow.ts
@@ -23,7 +23,8 @@ const getWorkflowSchemeReferences = (instance: InstanceElement): string[] => [
   ...(instance.value.items
     ?.map((item: Values) => item.workflow) ?? []),
   instance.value.defaultWorkflow,
-].filter(isReferenceExpression).map(ref => ref.elemID.getFullName())
+].filter(isReferenceExpression)
+  .map(ref => ref.elemID.getFullName())
 
 /**
  * We modify workflows by deleting and re-creating them. To do so we need to modify

--- a/packages/jira-adapter/src/dependency_changers/workflow.ts
+++ b/packages/jira-adapter/src/dependency_changers/workflow.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, dependencyChange, DependencyChanger, getAllChangeData, getChangeData, InstanceElement, isInstanceChange, isModificationChange, Values } from '@salto-io/adapter-api'
+import { Change, dependencyChange, DependencyChanger, getAllChangeData, getChangeData, InstanceElement, isInstanceChange, isModificationChange, isReferenceExpression, Values } from '@salto-io/adapter-api'
 import { deployment } from '@salto-io/adapter-components'
 import { values } from '@salto-io/lowerdash'
 import _ from 'lodash'
@@ -21,9 +21,9 @@ import { WORKFLOW_SCHEME_TYPE_NAME, WORKFLOW_TYPE_NAME } from '../constants'
 
 const getWorkflowSchemeReferences = (instance: InstanceElement): string[] => [
   ...(instance.value.items
-    ?.map((item: Values) => item.workflow?.elemID.getFullName()) ?? []),
-  instance.value.defaultWorkflow?.elemID.getFullName(),
-].filter(values.isDefined)
+    ?.map((item: Values) => item.workflow) ?? []),
+  instance.value.defaultWorkflow,
+].filter(isReferenceExpression).map(ref => ref.elemID.getFullName())
 
 /**
  * We modify workflows by deleting and re-creating them. To do so we need to modify

--- a/packages/jira-adapter/test/dependency_changers/workflow.test.ts
+++ b/packages/jira-adapter/test/dependency_changers/workflow.test.ts
@@ -100,4 +100,20 @@ describe('workflowDependencyChanger', () => {
     expect(dependencyChanges[1].dependency.source).toEqual(2)
     expect(dependencyChanges[1].dependency.target).toEqual(0)
   })
+
+  it('should ignore workflow string ids', async () => {
+    workflowSchemeInstance1.value.defaultWorkflow = '5'
+    workflowSchemeInstance2.value.items[0].workflow = '5'
+    const inputChanges = new Map([
+      [0, toChange({ before: workflowInstance, after: workflowInstance })],
+      [1, toChange({ before: workflowSchemeInstance1, after: workflowSchemeInstance1 })],
+      [2, toChange({ before: workflowSchemeInstance2, after: workflowSchemeInstance2 })],
+      [3, toChange({ before: workflowSchemeInstance3, after: workflowSchemeInstance3 })],
+    ])
+
+    const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([])
+
+    const dependencyChanges = [...await workflowDependencyChanger(inputChanges, inputDeps)]
+    expect(dependencyChanges).toHaveLength(0)
+  })
 })


### PR DESCRIPTION
Fixed 'getFullName' of undefined when a string value in a workflow scheme was not converted to a reference

---
_Release Notes_: 
__Jira Adapter__:
- Fixed 'getFullName' of undefined when a string value in a workflow scheme was not converted to a reference

---
_User Notifications_: 
None