### PR TITLE
SALTO-3534 Clarify unresolved reference validator message

### DIFF
--- a/packages/core/src/core/plan/change_validators/incoming_unresolved_references.ts
+++ b/packages/core/src/core/plan/change_validators/incoming_unresolved_references.ts
@@ -39,7 +39,7 @@ export const incomingUnresolvedReferencesValidator = (validationErrors: Readonly
       return {
         elemID,
         severity: 'Warning',
-        message: `Unresolved references to a ${changeType} element.`,
+        message: `Some elements contain references to this ${changeType} element`,
         detailedMessage: `${group.length} other elements contain references to this ${changeType} element, which are no longer valid.`
             + ' You may continue with deploying this change, but the deployment might fail.',
       }


### PR DESCRIPTION
_Clarify unresolved reference validator message_

---

_Additional context for reviewer_

---
_Release Notes_: 
_Clarify unresolved reference validator message_

---
_User Notifications_: 
