### PR TITLE
SALTO-4286: Add dockerfile for running cli without any dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:14.15.5-buster-slim
+WORKDIR /app
+
+RUN apt update && apt install -y openssl build-essential libgssapi-krb5-2 git ccache
+
+COPY . .
+RUN echo "Running yarn install" && yarn || yarn || yarn # run again if failing due to rimraf
+
+RUN \
+    echo "Running yarn build" && yarn pre-build && yarn build-ts
+
+ENTRYPOINT ["/usr/bin/env", "node", "./packages/cli/bin/salto"]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ There you'll find prebuilt binaries for major OSes (MacOS, Linux, Windows).
 
 See [the vscode package documentation](packages/vscode/README.md#installation)
 
+### Running using docker
+
+```bash
+docker build --tag salto-cli
+docker run salto-cli
+```
+
 ### Building from source
 
   1. Install Node.js 14 (for M1 Macs use 14.15). You can download it directly from [here](https://nodejs.org/en/download/releases/), or use [Node Version Manager (NVM)](https://github.com/nvm-sh/nvm) (simply run `nvm use`) to install it.


### PR DESCRIPTION
No dependencies but docker ofc.

Updates https://salto-io.atlassian.net/browse/SALTO-4286

---

_Additional context for reviewer_

---
_Release Notes_: 
There's now a possibility to run the CLI using a docker image

---
_User Notifications_: 
None
