### PR TITLE
SALTO-4285: Open Aliases to Salesforce Data Records

### DIFF
--- a/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
@@ -173,7 +173,6 @@ const recordToInstance = async (
 const typesRecordsToInstances = async (
   recordByIdAndType: RecordsByTypeAndId,
   customObjectFetchSetting: Record<TypeName, CustomObjectFetchSetting>,
-  skipAliases: boolean,
 ): Promise<{ instances: InstanceElement[]; configChangeSuggestions: ConfigChangeSuggestion[] }> => {
   const typesToUnresolvedRefFields = {} as Record<TypeName, Set<string>>
   const addUnresolvedRefFieldByType = (typeName: string, unresolvedFieldName: string): void => {
@@ -283,7 +282,7 @@ const typesRecordsToInstances = async (
           type: customObjectFetchSetting[typeName].objectType,
           record,
           instanceSaltoName: await getRecordSaltoName(typeName, record),
-          instanceAlias: skipAliases ? undefined : await getRecordAlias(typeName, record),
+          instanceAlias: await getRecordAlias(typeName, record),
         }))
         .filter(async recToInstanceParams =>
           !Object.keys(typesToUnresolvedRefFields).includes(
@@ -374,7 +373,6 @@ const getReferencedRecords = async (
 export const getAllInstances = async (
   client: SalesforceClient,
   customObjectFetchSetting: Record<TypeName, CustomObjectFetchSetting>,
-  skipAliases: boolean,
 ): Promise<{ instances: InstanceElement[]; configChangeSuggestions: ConfigChangeSuggestion[] }> => {
   const baseTypesSettings = _.pickBy(
     customObjectFetchSetting,
@@ -394,7 +392,7 @@ export const getAllInstances = async (
     ...referencedRecordsByTypeAndId,
     ...baseRecordByTypeAndId,
   }
-  return typesRecordsToInstances(mergedRecords, customObjectFetchSetting, skipAliases)
+  return typesRecordsToInstances(mergedRecords, customObjectFetchSetting)
 }
 
 const getParentFieldNames = (fields: Field[]): string[] =>
@@ -525,7 +523,6 @@ const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
     const { instances, configChangeSuggestions } = await getAllInstances(
       client,
       filteredChangesFetchSettings,
-      config.fetchProfile.isFeatureEnabled('skipAliases')
     )
     instances.forEach(instance => elements.push(instance))
     log.debug(`Fetched ${instances.length} instances of Custom Objects`)

--- a/packages/salesforce-adapter/src/filters/custom_settings_filter.ts
+++ b/packages/salesforce-adapter/src/filters/custom_settings_filter.ts
@@ -66,7 +66,7 @@ const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
     )
     await logInvalidCustomSettings(invalidFetchSettings)
     const customSettingsMap = await keyByAsync(validFetchSettings, obj => apiName(obj.objectType))
-    const { instances, configChangeSuggestions } = await getAllInstances(client, customSettingsMap, config.fetchProfile.isFeatureEnabled('skipAliases'))
+    const { instances, configChangeSuggestions } = await getAllInstances(client, customSettingsMap)
     elements.push(...instances)
     return {
       configSuggestions: [...configChangeSuggestions],

--- a/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
@@ -1181,33 +1181,11 @@ describe('Custom Object Instances filter', () => {
         await filter.onFetch(elements)
         instances = elements.filter(isInstanceElement)
       })
-
-      describe('when skipAliases feature is enabled', () => {
-        beforeEach(async () => {
-          const elements: Element[] = [mockTypes[MASTER_DETAIL_TYPE], mockTypes[INSTANCE_TYPE]]
-          await createFilterForAliases(true).onFetch(elements)
-          instances = elements.filter(isInstanceElement)
-        })
-        it('should not create aliases', () => {
-          expect(instances).toHaveLength(2)
-          instances.forEach(instance => {
-            expect(instance.annotations).not.toContainKey(CORE_ANNOTATIONS.ALIAS)
-          })
-        })
-      })
-
-      describe('when skipAliases feature is disabled', () => {
-        beforeEach(async () => {
-          const elements: Element[] = [mockTypes[MASTER_DETAIL_TYPE], mockTypes[INSTANCE_TYPE]]
-          await createFilterForAliases(false).onFetch(elements)
-          instances = elements.filter(isInstanceElement)
-        })
-        it('should create correct aliases', () => {
-          expect(instances).toEqual([
-            expect.objectContaining({ annotations: expect.objectContaining({ [CORE_ANNOTATIONS.ALIAS]: 'ParentName' }) }),
-            expect.objectContaining({ annotations: expect.objectContaining({ [CORE_ANNOTATIONS.ALIAS]: 'ParentName TestField InstanceName' }) }),
-          ])
-        })
+      it('should create correct aliases', () => {
+        expect(instances).toEqual([
+          expect.objectContaining({ annotations: expect.objectContaining({ [CORE_ANNOTATIONS.ALIAS]: 'ParentName' }) }),
+          expect.objectContaining({ annotations: expect.objectContaining({ [CORE_ANNOTATIONS.ALIAS]: 'ParentName TestField InstanceName' }) }),
+        ])
       })
     })
 

--- a/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
@@ -1168,6 +1168,20 @@ describe('Custom Object Instances filter', () => {
       }
 
       beforeEach(async () => {
+        filter = filterCreator({
+          client,
+          config: {
+            ...defaultFilterContext,
+            fetchProfile: buildFetchProfile({
+              data: {
+                includeObjects: ['.*'],
+                saltoIDSettings: {
+                  defaultIdFields: ['Id'],
+                },
+              },
+            }),
+          },
+        }) as FilterType
         connection.query = jest.fn().mockImplementation(((query: string) => {
           if (query.includes(`FROM ${MASTER_DETAIL_TYPE}`)) {
             return Promise.resolve({ records: [MASTER_DETAIL_RECORD] })
@@ -1181,6 +1195,7 @@ describe('Custom Object Instances filter', () => {
         await filter.onFetch(elements)
         instances = elements.filter(isInstanceElement)
       })
+
       it('should create correct aliases', () => {
         expect(instances).toEqual([
           expect.objectContaining({ annotations: expect.objectContaining({ [CORE_ANNOTATIONS.ALIAS]: 'ParentName' }) }),


### PR DESCRIPTION
Aliases to Data Records in Salesforce are available by default.

---

_Additional context for reviewer_
_None_

---
_Release Notes_: 
_None_

---
_User Notifications_: 
Salesforce:
- Existing Data Records `nacls` will have a new `_alias` annotation.
