### PR TITLE
SALTO-4288 do not crash on inability to get full name for element ID and log all failures

### DIFF
--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -27,8 +27,7 @@ import { SaltoError,
   isContainerType,
   isAdditionChange,
   SaltoElementError,
-  SeverityLevel,
-  ElemID } from '@salto-io/adapter-api'
+  SeverityLevel } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 
 
@@ -219,11 +218,10 @@ const processDeployResponse = (
   const componentErrors = allFailureMessages
     .filter(failure => !isUnFoundDelete(failure, deletionsPackageName))
     .map(getUserFriendlyDeployMessage)
-    .map(failure => (
-      { elemID: ElemID.fromFullName(failure.fullName),
-        message: `Failed to ${checkOnly ? 'validate' : 'deploy'} ${failure.fullName} with error: ${failure.problem} (${failure.problemType})`,
-        severity: 'Error' as SeverityLevel }
-    ))
+    .map(failure => ({
+      message: `Failed to ${checkOnly ? 'validate' : 'deploy'} ${failure.fullName} with error: ${failure.problem} (${failure.problemType})`,
+      severity: 'Error' as SeverityLevel,
+    }))
   const codeCoverageWarningErrors = makeArray(result.details)
     .map(detail => detail.runTestResult as RunTestsResult | undefined)
     .flatMap(runTestResult => makeArray(runTestResult?.codeCoverageWarnings))


### PR DESCRIPTION
Only return `SaltoError`s on metadata deploy component failures


---

_Additional context for reviewer_

---
_Release Notes_: _None_

---
_User Notifications_: _None_