### PR TITLE
SALTO-4292: Safe resolveTypeShallow

### DIFF
--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -26,7 +26,7 @@ import {
   CORE_ANNOTATIONS, TypeElement, Change, isRemovalChange, isModificationChange, isListType,
   ChangeData, ListType, CoreAnnotationTypes, isMapType, MapType, isContainerType, isTypeReference,
   ReadOnlyElementsSource, ReferenceMap, TypeReference, createRefToElmWithValue, isElement,
-  compareSpecialValues, getChangeData, isTemplateExpression,
+  compareSpecialValues, getChangeData, isTemplateExpression, PlaceholderObjectType,
 } from '@salto-io/adapter-api'
 import Joi from 'joi'
 import { walkOnElement, WalkOnFunc, WALK_NEXT_STEP } from './walk_element'
@@ -1067,7 +1067,10 @@ const getResolvedRef = async (
   }
   const sourceVal = await elementsSource.get(ref.elemID)
   if (sourceVal === undefined) {
-    throw Error(`ElemID ${ref.elemID.getFullName()} does not exist on the refType and elementsSource`)
+    log.warn('ElemID %s does not exist on the refType and elementsSource. Returning PlaceholderObjectType instead.', ref.elemID.getFullName())
+    return createRefToElmWithValue(new PlaceholderObjectType({
+      elemID: ref.elemID,
+    }))
   }
   return createRefToElmWithValue(sourceVal)
 }

--- a/packages/adapter-utils/test/element_source.test.ts
+++ b/packages/adapter-utils/test/element_source.test.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import {
   ElemID,
   InstanceElement,
-  ObjectType,
+  ObjectType, PlaceholderObjectType,
   ReadOnlyElementsSource,
   TypeReference,
 } from '@salto-io/adapter-api'
@@ -42,7 +42,7 @@ describe('elementSource', () => {
           expect(receivedElements).toEqual(elements)
         })
 
-        it('should return the element with unresolved type of the type is not in the source', async () => {
+        it('should return the element with PlaceholderObjectType if the type is not in the source', async () => {
           const instance = new InstanceElement(
             'instance',
             new TypeReference(new ElemID('adapter', 'unknownType'))
@@ -51,7 +51,9 @@ describe('elementSource', () => {
           // are coming from the fallback source, so passing it in the first param as elements will test nothing
           const source = buildElementsSourceFromElements([], [buildElementsSourceFromElements([instance])])
           const receivedInstance = (await toArrayAsync(await source.getAll()))[0] as InstanceElement
-          expect(receivedInstance.refType.type).toBeUndefined()
+          expect(receivedInstance.refType.type).toMatchObject(new PlaceholderObjectType({
+            elemID: receivedInstance.refType.elemID,
+          }))
         })
       })
 

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -20,7 +20,7 @@ import {
   isListType, ListType, BuiltinTypes, StaticFile, isPrimitiveType,
   Element, isReferenceExpression, isPrimitiveValue, CORE_ANNOTATIONS, FieldMap, AdditionChange,
   RemovalChange, ModificationChange, isInstanceElement, isObjectType, MapType, isMapType,
-  ContainerType, TypeReference, createRefToElmWithValue, VariableExpression, getChangeData,
+  ContainerType, TypeReference, createRefToElmWithValue, VariableExpression, getChangeData, PlaceholderObjectType,
 } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { mockFunction } from '@salto-io/test-utils'
@@ -2475,6 +2475,21 @@ describe('Test utils.ts', () => {
       expect(clonedInst.refType.type).toBeUndefined()
       await resolveTypeShallow(clonedInst, elementsSource)
       expect(await clonedInst.getType()).toEqual(objWithResolvedWithAdditionalField)
+    })
+
+    it('should resolve to PlaceholderObjectType if the type is not in the source', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        new TypeReference(new ElemID('adapter', 'unknownType'))
+      )
+      // I pass an inner elements source here because we try to resolve only elements that
+      // are coming from the fallback source, so passing it in the first param as elements will test nothing
+      const source = buildElementsSourceFromElements([], [buildElementsSourceFromElements([instance])])
+      expect(instance.refType.type).toBeUndefined()
+      await resolveTypeShallow(instance, source)
+      expect(instance.refType.type).toMatchObject(new PlaceholderObjectType({
+        elemID: instance.refType.elemID,
+      }))
     })
   })
 


### PR DESCRIPTION
In cases where an ObjectType is deleted and there's still Instances of this type, **resolveTypeShallow** on that Instance will fail violently with Error. We've encountered weird Errors in scenarios where we attempted to get the elements in Salesforce CVs that requires the **elementsSource**.

---

_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
