### PR TITLE
SALTO-4038 Added checks for undefined values in refs in Jira

### DIFF
--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -159,11 +159,6 @@ export const isReferenceExpression = (value: any): value is ReferenceExpression 
   value instanceof ReferenceExpression
 )
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const isResolvedReferenceExpression = (value: any): value is ReferenceExpression => (
-  value instanceof ReferenceExpression && value.value !== undefined
-)
-
 export class VariableExpression extends ReferenceExpression {
   constructor(
     elemID: ElemID,

--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -159,6 +159,11 @@ export const isReferenceExpression = (value: any): value is ReferenceExpression 
   value instanceof ReferenceExpression
 )
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const isResolvedReferenceExpression = (value: any): value is ReferenceExpression => (
+  value instanceof ReferenceExpression && value.value !== undefined
+)
+
 export class VariableExpression extends ReferenceExpression {
   constructor(
     elemID: ElemID,

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -38,6 +38,7 @@ import {
   getPath,
   getSubtypes,
   formatConfigSuggestionsReasons,
+  isResolvedReferenceExpression,
 } from '../src/utils'
 import { buildElementsSourceFromElements } from '../src/element_source'
 
@@ -2540,6 +2541,15 @@ describe('Test utils.ts', () => {
     it('should return a formatted reasons list', () => {
       const message = formatConfigSuggestionsReasons(['reason A', 'reason B'])
       expect(message).toEqual('    * reason A\n    * reason B')
+    })
+  })
+  describe('isResolvedReferenceExpression', () => {
+    const inst = new InstanceElement('inst', new ObjectType({ elemID: new ElemID('test', 'type') }))
+    it('should return false for a reference expression with undefind value', () => {
+      expect(isResolvedReferenceExpression(new ReferenceExpression(inst.elemID))).toBeFalsy()
+    })
+    it('should return true for a resolved reference expression', () => {
+      expect(isResolvedReferenceExpression(new ReferenceExpression(inst.elemID, inst))).toBeTruthy()
     })
   })
 })

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -20,7 +20,8 @@ import {
   isListType, ListType, BuiltinTypes, StaticFile, isPrimitiveType,
   Element, isReferenceExpression, isPrimitiveValue, CORE_ANNOTATIONS, FieldMap, AdditionChange,
   RemovalChange, ModificationChange, isInstanceElement, isObjectType, MapType, isMapType,
-  ContainerType, TypeReference, createRefToElmWithValue, VariableExpression, getChangeData, PlaceholderObjectType,
+  ContainerType, TypeReference, createRefToElmWithValue, VariableExpression, getChangeData,
+  PlaceholderObjectType, UnresolvedReference,
 } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { mockFunction } from '@salto-io/test-utils'
@@ -2547,6 +2548,10 @@ describe('Test utils.ts', () => {
     const inst = new InstanceElement('inst', new ObjectType({ elemID: new ElemID('test', 'type') }))
     it('should return false for a reference expression with undefind value', () => {
       expect(isResolvedReferenceExpression(new ReferenceExpression(inst.elemID))).toBeFalsy()
+    })
+    it('should return false for a reference with uresolvedReference as value', () => {
+      expect(isResolvedReferenceExpression(new ReferenceExpression(inst.elemID, new UnresolvedReference(inst.elemID))))
+        .toBeFalsy()
     })
     it('should return true for a resolved reference expression', () => {
       expect(isResolvedReferenceExpression(new ReferenceExpression(inst.elemID, inst))).toBeTruthy()

--- a/packages/jira-adapter/src/change_validators/automation_unresolved_references.ts
+++ b/packages/jira-adapter/src/change_validators/automation_unresolved_references.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-import { isAdditionOrModificationChange, ChangeValidator, getChangeData, isInstanceChange, SeverityLevel, UnresolvedReference, ReferenceExpression } from '@salto-io/adapter-api'
+import { isAdditionOrModificationChange, ChangeValidator, getChangeData, isInstanceChange, SeverityLevel, ReferenceExpression, isReferenceExpression } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { AUTOMATION_TYPE } from '../constants'
@@ -24,11 +24,11 @@ export type ProjectType = { projectId: ReferenceExpression }
 
 export const isProjectType = (element: unknown): element is ProjectType => {
   const projectId = _.get(element, 'projectId')
-  return projectId !== undefined && isResolvedReferenceExpression(projectId)
+  return projectId !== undefined && isReferenceExpression(projectId)
 }
 
 export const isProjectReferenceBroken = (project: ProjectType): boolean =>
-  project.projectId.value instanceof UnresolvedReference
+  isResolvedReferenceExpression(project.projectId.value)
 
 
 export const automationProjectUnresolvedReferenceValidator: ChangeValidator = async changes =>

--- a/packages/jira-adapter/src/change_validators/automation_unresolved_references.ts
+++ b/packages/jira-adapter/src/change_validators/automation_unresolved_references.ts
@@ -14,9 +14,8 @@
 * limitations under the License.
 */
 
-import { isAdditionOrModificationChange, ChangeValidator, getChangeData, isInstanceChange, SeverityLevel, ReferenceExpression, isReferenceExpression } from '@salto-io/adapter-api'
+import { isAdditionOrModificationChange, ChangeValidator, getChangeData, isInstanceChange, SeverityLevel, isReferenceExpression, UnresolvedReference, ReferenceExpression } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { AUTOMATION_TYPE } from '../constants'
 
 
@@ -28,7 +27,7 @@ export const isProjectType = (element: unknown): element is ProjectType => {
 }
 
 export const isProjectReferenceBroken = (project: ProjectType): boolean =>
-  isResolvedReferenceExpression(project.projectId.value)
+  project.projectId.value instanceof UnresolvedReference
 
 
 export const automationProjectUnresolvedReferenceValidator: ChangeValidator = async changes =>

--- a/packages/jira-adapter/src/change_validators/automation_unresolved_references.ts
+++ b/packages/jira-adapter/src/change_validators/automation_unresolved_references.ts
@@ -14,8 +14,9 @@
 * limitations under the License.
 */
 
-import { isAdditionOrModificationChange, ChangeValidator, getChangeData, isInstanceChange, SeverityLevel, isReferenceExpression, UnresolvedReference, ReferenceExpression } from '@salto-io/adapter-api'
+import { isAdditionOrModificationChange, ChangeValidator, getChangeData, isInstanceChange, SeverityLevel, isReferenceExpression, ReferenceExpression } from '@salto-io/adapter-api'
 import _ from 'lodash'
+import { isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { AUTOMATION_TYPE } from '../constants'
 
 
@@ -27,8 +28,7 @@ export const isProjectType = (element: unknown): element is ProjectType => {
 }
 
 export const isProjectReferenceBroken = (project: ProjectType): boolean =>
-  project.projectId.value instanceof UnresolvedReference
-
+  !isResolvedReferenceExpression(project.projectId)
 
 export const automationProjectUnresolvedReferenceValidator: ChangeValidator = async changes =>
   changes

--- a/packages/jira-adapter/src/change_validators/automation_unresolved_references.ts
+++ b/packages/jira-adapter/src/change_validators/automation_unresolved_references.ts
@@ -14,8 +14,9 @@
 * limitations under the License.
 */
 
-import { isAdditionOrModificationChange, ChangeValidator, getChangeData, isInstanceChange, SeverityLevel, isReferenceExpression, UnresolvedReference, ReferenceExpression } from '@salto-io/adapter-api'
+import { isAdditionOrModificationChange, ChangeValidator, getChangeData, isInstanceChange, SeverityLevel, UnresolvedReference, ReferenceExpression } from '@salto-io/adapter-api'
 import _ from 'lodash'
+import { isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { AUTOMATION_TYPE } from '../constants'
 
 
@@ -23,7 +24,7 @@ export type ProjectType = { projectId: ReferenceExpression }
 
 export const isProjectType = (element: unknown): element is ProjectType => {
   const projectId = _.get(element, 'projectId')
-  return projectId !== undefined && isReferenceExpression(projectId)
+  return projectId !== undefined && isResolvedReferenceExpression(projectId)
 }
 
 export const isProjectReferenceBroken = (project: ProjectType): boolean =>

--- a/packages/jira-adapter/src/change_validators/dashboard_gadgets.ts
+++ b/packages/jira-adapter/src/change_validators/dashboard_gadgets.ts
@@ -13,8 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ChangeValidator, ElemID, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, isReferenceExpression, SeverityLevel } from '@salto-io/adapter-api'
-import { getParents } from '@salto-io/adapter-utils'
+import { ChangeValidator, ElemID, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, SeverityLevel } from '@salto-io/adapter-api'
+import { getParents, isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import { DASHBOARD_GADGET_TYPE } from '../constants'
@@ -27,7 +27,7 @@ export const getGadgetKey = (parentId: ElemID, row: number, column: number): str
   `${parentId.name}-${row}-${column}`
 
 export const getGadgetInstanceKey = (instance: InstanceElement): string => {
-  if (!isReferenceExpression(getParents(instance)[0])
+  if (!isResolvedReferenceExpression(getParents(instance)[0])
   || instance.value.position?.row === undefined
   || instance.value.position.column === undefined) {
     throw new Error(`Received an invalid gadget ${instance.elemID.getFullName()}`)

--- a/packages/jira-adapter/src/change_validators/dashboard_layout.ts
+++ b/packages/jira-adapter/src/change_validators/dashboard_layout.ts
@@ -13,8 +13,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ChangeValidator, getChangeData, isInstanceChange, isInstanceElement, isModificationChange, isResolvedReferenceExpression, ReferenceExpression, SeverityLevel } from '@salto-io/adapter-api'
+import { ChangeValidator, getChangeData, isInstanceChange, isInstanceElement, isModificationChange, ReferenceExpression, SeverityLevel } from '@salto-io/adapter-api'
 import { collections, values } from '@salto-io/lowerdash'
+import { isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { DASHBOARD_TYPE } from '../constants'
 
 const { awu } = collections.asynciterable

--- a/packages/jira-adapter/src/change_validators/dashboard_layout.ts
+++ b/packages/jira-adapter/src/change_validators/dashboard_layout.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ChangeValidator, getChangeData, isInstanceChange, isInstanceElement, isModificationChange, isReferenceExpression, ReferenceExpression, SeverityLevel } from '@salto-io/adapter-api'
+import { ChangeValidator, getChangeData, isInstanceChange, isInstanceElement, isModificationChange, isResolvedReferenceExpression, ReferenceExpression, SeverityLevel } from '@salto-io/adapter-api'
 import { collections, values } from '@salto-io/lowerdash'
 import { DASHBOARD_TYPE } from '../constants'
 
@@ -29,7 +29,7 @@ export const dashboardLayoutValidator: ChangeValidator = async changes =>
     .filter(instance => instance.elemID.typeName === DASHBOARD_TYPE)
     .map(instance => {
       const invalidGadgets = (instance.value.gadgets ?? [])
-        .filter(isReferenceExpression)
+        .filter(isResolvedReferenceExpression)
         .filter((gadget: ReferenceExpression) => isInstanceElement(gadget.value))
         .filter((gadget: ReferenceExpression) =>
           gadget.value.value.position.column >= instance.value.layout.length)

--- a/packages/jira-adapter/src/change_validators/field_contexts/field_contexts.ts
+++ b/packages/jira-adapter/src/change_validators/field_contexts/field_contexts.ts
@@ -13,9 +13,10 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ChangeValidator, getChangeData, InstanceElement, isInstanceElement, isReferenceExpression, ReadOnlyElementsSource, ReferenceExpression } from '@salto-io/adapter-api'
+import { ChangeValidator, getChangeData, InstanceElement, isInstanceElement, ReadOnlyElementsSource, ReferenceExpression } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
+import { isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { PROJECT_CONTEXTS_FIELD } from '../../filters/fields/contexts_projects_filter'
 import { PROJECT_TYPE } from '../../constants'
 import { FIELD_CONTEXT_TYPE_NAME } from '../../filters/fields/constants'
@@ -31,7 +32,7 @@ const getFieldContexts = async (
 ): Promise<InstanceElement[]> =>
   awu(field.value.contexts)
     .filter((ref): ref is ReferenceExpression => {
-      if (!isReferenceExpression(ref)) {
+      if (!isResolvedReferenceExpression(ref)) {
         log.warn(`Found a non reference expression in field ${field.elemID.getFullName()}`)
         return false
       }
@@ -83,7 +84,7 @@ export const fieldContextValidator: ChangeValidator = async (changes, elementSou
     .map(project => [
       project.elemID.name,
       new Set(project.value[PROJECT_CONTEXTS_FIELD].filter((ref: ReferenceExpression) => {
-        if (!isReferenceExpression(ref)) {
+        if (!isResolvedReferenceExpression(ref)) {
           log.warn(`Found a non reference expression in project ${project.elemID.getFullName()}`)
           return false
         }

--- a/packages/jira-adapter/src/change_validators/issue_type_scheme_default_type.ts
+++ b/packages/jira-adapter/src/change_validators/issue_type_scheme_default_type.ts
@@ -13,7 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ChangeValidator, getChangeData, isAdditionOrModificationChange, isInstanceChange, isReferenceExpression, ReferenceExpression, SeverityLevel } from '@salto-io/adapter-api'
+import { ChangeValidator, getChangeData, isAdditionOrModificationChange, isInstanceChange, ReferenceExpression, SeverityLevel } from '@salto-io/adapter-api'
+import { isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { ISSUE_TYPE_SCHEMA_NAME } from '../constants'
 
 export const issueTypeSchemeDefaultTypeValidator: ChangeValidator = async changes =>
@@ -22,9 +23,9 @@ export const issueTypeSchemeDefaultTypeValidator: ChangeValidator = async change
     .filter(isAdditionOrModificationChange)
     .map(getChangeData)
     .filter(instance => instance.elemID.typeName === ISSUE_TYPE_SCHEMA_NAME)
-    .filter(instance => isReferenceExpression(instance.value.defaultIssueTypeId))
+    .filter(instance => isResolvedReferenceExpression(instance.value.defaultIssueTypeId))
     .filter(instance => (instance.value.issueTypeIds ?? [])
-      .filter(isReferenceExpression)
+      .filter(isResolvedReferenceExpression)
       .every((issueType: ReferenceExpression) => !issueType.elemID.isEqual(instance.value.defaultIssueTypeId.elemID)))
     .map(instance => ({
       elemID: instance.elemID,

--- a/packages/jira-adapter/src/change_validators/permission_scheme.ts
+++ b/packages/jira-adapter/src/change_validators/permission_scheme.ts
@@ -14,9 +14,10 @@
 * limitations under the License.
 */
 import { AdditionChange, ChangeError, ChangeValidator, ElemID, getChangeData, InstanceElement,
-  isAdditionChange, isAdditionOrModificationChange, isInstanceChange, isModificationChange, isReferenceExpression, ModificationChange, SeverityLevel } from '@salto-io/adapter-api'
+  isAdditionChange, isAdditionOrModificationChange, isInstanceChange, isModificationChange, ModificationChange, SeverityLevel } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
+import { isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { isFreeLicense } from '../utils'
 import JiraClient from '../client/client'
 import { PERMISSION_SCHEME_TYPE_NAME, PROJECT_TYPE } from '../constants'
@@ -55,10 +56,10 @@ const schemeWarning = (elemID: ElemID): ChangeError => ({
 const isPermissionSchemeAssociationChange = (
   change: AdditionChange<InstanceElement> | ModificationChange<InstanceElement>
 ): boolean => {
-  const elemBefore = isModificationChange(change) && isReferenceExpression(change.data.before.value.permissionScheme)
+  const elemBefore = isModificationChange(change) && isResolvedReferenceExpression(change.data.before.value.permissionScheme)
     ? change.data.before.value.permissionScheme.elemID.getFullName()
     : undefined
-  const elemAfter = isReferenceExpression(change.data.after.value.permissionScheme)
+  const elemAfter = isResolvedReferenceExpression(change.data.after.value.permissionScheme)
     ? change.data.after.value.permissionScheme.elemID.getFullName()
     : undefined
   return (elemBefore !== elemAfter)
@@ -94,7 +95,7 @@ export const permissionSchemeDeploymentValidator = (client: JiraClient): ChangeV
         projectAndSchemeChanges
           .filter(change => getChangeData(change).elemID.typeName === PROJECT_TYPE)
           .filter(isAdditionChange)
-          .filter(change => isReferenceExpression(getChangeData(change).value.permissionScheme))
+          .filter(change => isResolvedReferenceExpression(getChangeData(change).value.permissionScheme))
           .map(change => getChangeData(change).value.permissionScheme.elemID.getFullName())
       )
 
@@ -102,7 +103,7 @@ export const permissionSchemeDeploymentValidator = (client: JiraClient): ChangeV
         projectAndSchemeChanges
           .filter(change => getChangeData(change).elemID.typeName === PROJECT_TYPE)
           .filter(isModificationChange)
-          .filter(change => isReferenceExpression(change.data.before.value.permissionScheme))
+          .filter(change => isResolvedReferenceExpression(change.data.before.value.permissionScheme))
           .map(change => change.data.before.value.permissionScheme.elemID.getFullName())
       )
 

--- a/packages/jira-adapter/src/change_validators/permission_scheme.ts
+++ b/packages/jira-adapter/src/change_validators/permission_scheme.ts
@@ -56,7 +56,8 @@ const schemeWarning = (elemID: ElemID): ChangeError => ({
 const isPermissionSchemeAssociationChange = (
   change: AdditionChange<InstanceElement> | ModificationChange<InstanceElement>
 ): boolean => {
-  const elemBefore = isModificationChange(change) && isResolvedReferenceExpression(change.data.before.value.permissionScheme)
+  const elemBefore = isModificationChange(change)
+  && isResolvedReferenceExpression(change.data.before.value.permissionScheme)
     ? change.data.before.value.permissionScheme.elemID.getFullName()
     : undefined
   const elemAfter = isResolvedReferenceExpression(change.data.after.value.permissionScheme)

--- a/packages/jira-adapter/src/change_validators/screen.ts
+++ b/packages/jira-adapter/src/change_validators/screen.ts
@@ -13,7 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ChangeValidator, getChangeData, isAdditionOrModificationChange, isInstanceChange, isReferenceExpression, SeverityLevel, Values } from '@salto-io/adapter-api'
+import { ChangeValidator, getChangeData, isAdditionOrModificationChange, isInstanceChange, SeverityLevel, Values } from '@salto-io/adapter-api'
+import { isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { collections, values } from '@salto-io/lowerdash'
 import _ from 'lodash'
 
@@ -30,7 +31,7 @@ export const screenValidator: ChangeValidator = async changes => (
         .flatMap(tab => tab.fields ?? [])
 
       const duplicateFields = _(usedFields)
-        .map(field => (isReferenceExpression(field) ? field.elemID.getFullName() : field))
+        .map(field => (isResolvedReferenceExpression(field) ? field.elemID.getFullName() : field))
         .countBy()
         .pickBy(count => count > 1)
         .keys()

--- a/packages/jira-adapter/src/change_validators/status.ts
+++ b/packages/jira-adapter/src/change_validators/status.ts
@@ -13,8 +13,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ChangeValidator, getChangeData, isAdditionOrModificationChange, isInstanceChange, SeverityLevel, isReferenceExpression, isInstanceElement } from '@salto-io/adapter-api'
+import { ChangeValidator, getChangeData, isAdditionOrModificationChange, isInstanceChange, SeverityLevel, isInstanceElement } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
+import { isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { STATUS_TYPE_NAME } from '../constants'
 
 const { awu } = collections.asynciterable
@@ -27,7 +28,7 @@ export const statusValidator: ChangeValidator = async changes => (
     .map(getChangeData)
     .filter(instance => instance.elemID.typeName === STATUS_TYPE_NAME)
     .filter(instance =>
-      isReferenceExpression(instance.value.statusCategory)
+      isResolvedReferenceExpression(instance.value.statusCategory)
       && isInstanceElement(instance.value.statusCategory.value)
       && instance.value.statusCategory.value.value.name === NO_CATEGORY_STATUS)
     .map(async instance => ({

--- a/packages/jira-adapter/src/change_validators/workflow_scheme_migration.ts
+++ b/packages/jira-adapter/src/change_validators/workflow_scheme_migration.ts
@@ -13,11 +13,12 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, ChangeDataType, ChangeError, ChangeValidator, CORE_ANNOTATIONS, getChangeData, InstanceElement, isInstanceChange, isInstanceElement, isModificationChange, isReferenceExpression, ModificationChange, ReadOnlyElementsSource, ReferenceExpression } from '@salto-io/adapter-api'
+import { Change, ChangeDataType, ChangeError, ChangeValidator, CORE_ANNOTATIONS, getChangeData, InstanceElement, isInstanceChange, isInstanceElement, isModificationChange, ModificationChange, ReadOnlyElementsSource, ReferenceExpression } from '@salto-io/adapter-api'
 import { values, collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { filters, client as clientUtils } from '@salto-io/adapter-components'
 import os from 'os'
+import { isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { updateSchemeId } from '../filters/workflow_scheme'
 import JiraClient from '../client/client'
 import { JiraConfig } from '../config/config'
@@ -77,14 +78,14 @@ const getAllIssueTypesForWorkflowScheme = async (
 ): Promise<ReferenceExpression[]> => {
   const issueTypeSchemes: InstanceElement[] = await awu(assignedProjects)
     .map(instance => instance.value.issueTypeScheme)
-    .filter(isReferenceExpression)
+    .filter(isResolvedReferenceExpression)
     .map(ref => elementSource.get(ref.elemID))
     .filter(isInstanceElement)
     .toArray()
   const issueTypes: ReferenceExpression[] = issueTypeSchemes
     .filter(issueTypeScheme => Array.isArray(issueTypeScheme.value.issueTypeIds))
     .flatMap(issueTypeScheme => issueTypeScheme.value.issueTypeIds)
-    .filter(isReferenceExpression)
+    .filter(isResolvedReferenceExpression)
   return _.uniqBy(
     issueTypes,
     issueType => issueType.elemID.getFullName()

--- a/packages/jira-adapter/src/dependency_changers/workflow.ts
+++ b/packages/jira-adapter/src/dependency_changers/workflow.ts
@@ -13,17 +13,18 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, dependencyChange, DependencyChanger, getAllChangeData, getChangeData, InstanceElement, isInstanceChange, isModificationChange, isReferenceExpression, Values } from '@salto-io/adapter-api'
+import { Change, dependencyChange, DependencyChanger, getAllChangeData, getChangeData, InstanceElement, isInstanceChange, isModificationChange, Values } from '@salto-io/adapter-api'
 import { deployment } from '@salto-io/adapter-components'
 import { values } from '@salto-io/lowerdash'
 import _ from 'lodash'
+import { isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { WORKFLOW_SCHEME_TYPE_NAME, WORKFLOW_TYPE_NAME } from '../constants'
 
 const getWorkflowSchemeReferences = (instance: InstanceElement): string[] => [
   ...(instance.value.items
     ?.map((item: Values) => item.workflow) ?? []),
   instance.value.defaultWorkflow,
-].filter(isReferenceExpression)
+].filter(isResolvedReferenceExpression)
   .map(ref => ref.elemID.getFullName())
 
 /**

--- a/packages/jira-adapter/src/filters/archived_project_components.ts
+++ b/packages/jira-adapter/src/filters/archived_project_components.ts
@@ -13,8 +13,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Element, isInstanceElement, isReferenceExpression } from '@salto-io/adapter-api'
+import { Element, isInstanceElement } from '@salto-io/adapter-api'
 import _ from 'lodash'
+import { isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../filter'
 import { PROJECT_COMPONENT_TYPE, PROJECT_TYPE } from '../constants'
 
@@ -39,7 +40,7 @@ const filter: FilterCreator = () => ({
       .forEach(instance => {
         _.remove(
           instance.value.components,
-          ref => isReferenceExpression(ref) && removedComponentsIds.has(ref.elemID.getFullName())
+          ref => isResolvedReferenceExpression(ref) && removedComponentsIds.has(ref.elemID.getFullName())
         )
       })
 

--- a/packages/jira-adapter/src/filters/field_configuration/field_configuration_dependencies.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/field_configuration_dependencies.ts
@@ -38,7 +38,6 @@ const getProjectUsedFields = (instance: InstanceElement): InstanceElement[] => {
     .flatMap((screenRef: ReferenceExpression) => Object.values(screenRef.value.value.tabs ?? {}))
     .flatMap((tab: Values) => tab.fields)
     .filter(isReferenceExpression)
-    .filter((fieldRef: ReferenceExpression) => fieldRef.value !== undefined)
     .map((fieldRef: ReferenceExpression) => fieldRef.value) ?? []
 }
 

--- a/packages/jira-adapter/src/filters/field_configuration/field_configuration_dependencies.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/field_configuration_dependencies.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { InstanceElement, isInstanceElement, isReferenceExpression, ReferenceExpression, Values } from '@salto-io/adapter-api'
+import { InstanceElement, isInstanceElement, isReferenceExpression, isResolvedReferenceExpression, ReferenceExpression, Values } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { extendGeneratedDependencies, getParents } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
@@ -23,14 +23,12 @@ import { FIELD_CONFIGURATION_ITEM_TYPE_NAME, PROJECT_TYPE } from '../../constant
 const log = logger(module)
 
 const getProjectUsedFields = (instance: InstanceElement): InstanceElement[] => {
-  if (!isReferenceExpression(instance.value.issueTypeScreenScheme)
-       || instance.value.issueTypeScreenScheme.value === undefined) {
+  if (!isResolvedReferenceExpression(instance.value.issueTypeScreenScheme)) {
     return []
   }
   return instance.value.issueTypeScreenScheme.value.value.issueTypeMappings
     ?.map((item: Values) => item.screenSchemeId)
-    .filter(isReferenceExpression)
-    .filter((screenSchemeRef: ReferenceExpression) => screenSchemeRef.value !== undefined)
+    .filter(isResolvedReferenceExpression)
     .flatMap((screenSchemeRef: ReferenceExpression) => Object.values(
       screenSchemeRef.value.value.screens ?? {}
     ))
@@ -43,7 +41,7 @@ const getProjectUsedFields = (instance: InstanceElement): InstanceElement[] => {
 
 const getProjectFieldConfigurations = (instance: InstanceElement): InstanceElement[] => {
   const fieldConfigurationRef = instance.value.fieldConfigurationScheme
-  if (!isReferenceExpression(fieldConfigurationRef) || fieldConfigurationRef.value === undefined) {
+  if (!isResolvedReferenceExpression(fieldConfigurationRef)) {
     if (fieldConfigurationRef !== undefined) {
       log.warn(`${instance.elemID.getFullName()} has a field configuration scheme value that is not a reference so we can't calculate the _generated_dependencies`)
     }

--- a/packages/jira-adapter/src/filters/field_configuration/field_configuration_dependencies.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/field_configuration_dependencies.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { InstanceElement, isInstanceElement, isReferenceExpression, isResolvedReferenceExpression, ReferenceExpression, Values } from '@salto-io/adapter-api'
+import { InstanceElement, isInstanceElement, isResolvedReferenceExpression, ReferenceExpression, Values } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { extendGeneratedDependencies, getParents } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
@@ -32,10 +32,10 @@ const getProjectUsedFields = (instance: InstanceElement): InstanceElement[] => {
     .flatMap((screenSchemeRef: ReferenceExpression) => Object.values(
       screenSchemeRef.value.value.screens ?? {}
     ))
-    .filter(isReferenceExpression)
+    .filter(isResolvedReferenceExpression)
     .flatMap((screenRef: ReferenceExpression) => Object.values(screenRef.value.value.tabs ?? {}))
     .flatMap((tab: Values) => tab.fields)
-    .filter(isReferenceExpression)
+    .filter(isResolvedReferenceExpression)
     .map((fieldRef: ReferenceExpression) => fieldRef.value) ?? []
 }
 
@@ -49,7 +49,7 @@ const getProjectFieldConfigurations = (instance: InstanceElement): InstanceEleme
   }
   return fieldConfigurationRef.value.value.items
     ?.map((item: Values) => item.fieldConfigurationId)
-    .filter(isReferenceExpression)
+    .filter(isResolvedReferenceExpression)
     .map((fieldConfigRef: ReferenceExpression) => fieldConfigRef.value) ?? []
 }
 

--- a/packages/jira-adapter/src/filters/field_configuration/field_configuration_dependencies.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/field_configuration_dependencies.ts
@@ -13,9 +13,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { InstanceElement, isInstanceElement, isResolvedReferenceExpression, ReferenceExpression, Values } from '@salto-io/adapter-api'
+import { InstanceElement, isInstanceElement, ReferenceExpression, Values } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { extendGeneratedDependencies, getParents } from '@salto-io/adapter-utils'
+import { extendGeneratedDependencies, getParents, isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../../filter'
 import { FIELD_CONFIGURATION_ITEM_TYPE_NAME, PROJECT_TYPE } from '../../constants'

--- a/packages/jira-adapter/src/filters/field_configuration/field_configuration_dependencies.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/field_configuration_dependencies.ts
@@ -23,12 +23,14 @@ import { FIELD_CONFIGURATION_ITEM_TYPE_NAME, PROJECT_TYPE } from '../../constant
 const log = logger(module)
 
 const getProjectUsedFields = (instance: InstanceElement): InstanceElement[] => {
-  if (!isReferenceExpression(instance.value.issueTypeScreenScheme)) {
+  if (!isReferenceExpression(instance.value.issueTypeScreenScheme)
+       || instance.value.issueTypeScreenScheme.value === undefined) {
     return []
   }
   return instance.value.issueTypeScreenScheme.value.value.issueTypeMappings
     ?.map((item: Values) => item.screenSchemeId)
     .filter(isReferenceExpression)
+    .filter((screenSchemeRef: ReferenceExpression) => screenSchemeRef.value !== undefined)
     .flatMap((screenSchemeRef: ReferenceExpression) => Object.values(
       screenSchemeRef.value.value.screens ?? {}
     ))
@@ -36,12 +38,13 @@ const getProjectUsedFields = (instance: InstanceElement): InstanceElement[] => {
     .flatMap((screenRef: ReferenceExpression) => Object.values(screenRef.value.value.tabs ?? {}))
     .flatMap((tab: Values) => tab.fields)
     .filter(isReferenceExpression)
+    .filter((fieldRef: ReferenceExpression) => fieldRef.value !== undefined)
     .map((fieldRef: ReferenceExpression) => fieldRef.value) ?? []
 }
 
 const getProjectFieldConfigurations = (instance: InstanceElement): InstanceElement[] => {
   const fieldConfigurationRef = instance.value.fieldConfigurationScheme
-  if (!isReferenceExpression(fieldConfigurationRef)) {
+  if (!isReferenceExpression(fieldConfigurationRef) || fieldConfigurationRef.value === undefined) {
     if (fieldConfigurationRef !== undefined) {
       log.warn(`${instance.elemID.getFullName()} has a field configuration scheme value that is not a reference so we can't calculate the _generated_dependencies`)
     }

--- a/packages/jira-adapter/src/filters/field_configuration/field_configuration_deployment.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/field_configuration_deployment.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, getChangeData, InstanceElement, isInstanceChange, isModificationChange, isReferenceExpression, isRemovalChange, Values } from '@salto-io/adapter-api'
+import { Change, getChangeData, InstanceElement, isInstanceChange, isModificationChange, isRemovalChange, isResolvedReferenceExpression, Values } from '@salto-io/adapter-api'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
@@ -31,8 +31,7 @@ const deployFieldConfigurationItems = async (
   config: JiraConfig
 ): Promise<void> => {
   const fields = (instance.value.fields ?? [])
-    .filter((fieldConf: Values) => isReferenceExpression(fieldConf.id))
-    .filter((fieldConf: Values) => fieldConf.id.value !== undefined)
+    .filter((fieldConf: Values) => isResolvedReferenceExpression(fieldConf.id))
     .map((fieldConf: Values) => ({ ...fieldConf, id: fieldConf.id.value.value.id }))
 
   if (fields.length === 0) {

--- a/packages/jira-adapter/src/filters/field_configuration/field_configuration_deployment.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/field_configuration_deployment.ts
@@ -13,10 +13,11 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, getChangeData, InstanceElement, isInstanceChange, isModificationChange, isRemovalChange, isResolvedReferenceExpression, Values } from '@salto-io/adapter-api'
+import { Change, getChangeData, InstanceElement, isInstanceChange, isModificationChange, isRemovalChange, Values } from '@salto-io/adapter-api'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
+import { isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { JiraConfig } from '../../config/config'
 import { FilterCreator } from '../../filter'
 import { defaultDeployChange, deployChanges } from '../../deployment/standard_deployment'

--- a/packages/jira-adapter/src/filters/field_configuration/field_configuration_deployment.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/field_configuration_deployment.ts
@@ -32,6 +32,7 @@ const deployFieldConfigurationItems = async (
 ): Promise<void> => {
   const fields = (instance.value.fields ?? [])
     .filter((fieldConf: Values) => isReferenceExpression(fieldConf.id))
+    .filter((fieldConf: Values) => fieldConf.id.value !== undefined)
     .map((fieldConf: Values) => ({ ...fieldConf, id: fieldConf.id.value.value.id }))
 
   if (fields.length === 0) {

--- a/packages/jira-adapter/src/filters/field_configuration/field_configuration_irrelevant_fields.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/field_configuration_irrelevant_fields.ts
@@ -13,9 +13,10 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { isInstanceElement, isResolvedReferenceExpression } from '@salto-io/adapter-api'
+import { isInstanceElement } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
+import { isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../../filter'
 import { FIELD_TYPE_NAME } from '../fields/constants'
 

--- a/packages/jira-adapter/src/filters/field_configuration/field_configuration_irrelevant_fields.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/field_configuration_irrelevant_fields.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { isInstanceElement, isReferenceExpression } from '@salto-io/adapter-api'
+import { isInstanceElement, isReferenceExpression, isResolvedReferenceExpression } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { FilterCreator } from '../../filter'
@@ -36,8 +36,7 @@ const filter: FilterCreator = ({ fetchQuery }) => ({
       .forEach(instance => {
         const [fields, trashedFields] = _.partition(
           instance.value.fields,
-          field => isReferenceExpression(field.id)
-           && field.id.value !== undefined
+          field => isResolvedReferenceExpression(field.id)
            && !field.id.value.value.isLocked
         )
         instance.value.fields = fields

--- a/packages/jira-adapter/src/filters/field_configuration/field_configuration_irrelevant_fields.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/field_configuration_irrelevant_fields.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { isInstanceElement, isReferenceExpression, isResolvedReferenceExpression } from '@salto-io/adapter-api'
+import { isInstanceElement, isResolvedReferenceExpression } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { FilterCreator } from '../../filter'
@@ -41,7 +41,7 @@ const filter: FilterCreator = ({ fetchQuery }) => ({
         )
         instance.value.fields = fields
         if (trashedFields.length !== 0) {
-          log.debug(`Removed from ${instance.elemID.getFullName()} fields with ids: ${trashedFields.map(field => (isReferenceExpression(field.id) ? field.id.elemID.getFullName() : field.id)).join(', ')}`)
+          log.debug(`Removed from ${instance.elemID.getFullName()} fields with ids: ${trashedFields.map(field => (isResolvedReferenceExpression(field.id) ? field.id.elemID.getFullName() : field.id)).join(', ')}`)
         }
       })
   },

--- a/packages/jira-adapter/src/filters/field_configuration/field_configuration_irrelevant_fields.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/field_configuration_irrelevant_fields.ts
@@ -37,7 +37,8 @@ const filter: FilterCreator = ({ fetchQuery }) => ({
         const [fields, trashedFields] = _.partition(
           instance.value.fields,
           field => isReferenceExpression(field.id)
-            && !field.id.value.value.isLocked
+           && field.id.value !== undefined
+           && !field.id.value.value.isLocked
         )
         instance.value.fields = fields
         if (trashedFields.length !== 0) {

--- a/packages/jira-adapter/src/filters/field_configuration/missing_field_descriptions.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/missing_field_descriptions.ts
@@ -13,8 +13,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Element, isInstanceElement, isResolvedReferenceExpression } from '@salto-io/adapter-api'
+import { Element, isInstanceElement } from '@salto-io/adapter-api'
 import _ from 'lodash'
+import { isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { FIELD_CONFIGURATION_ITEM_TYPE_NAME } from '../../constants'
 import { FilterCreator } from '../../filter'
 

--- a/packages/jira-adapter/src/filters/field_configuration/missing_field_descriptions.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/missing_field_descriptions.ts
@@ -27,7 +27,7 @@ const filter: FilterCreator = () => ({
       .filter(instance => instance.elemID.typeName === FIELD_CONFIGURATION_ITEM_TYPE_NAME)
       .filter(instance => _.isEmpty(instance.value.description))
       .filter(instance => isReferenceExpression(instance.value.id)
-        && isInstanceElement(instance.value.id?.value))
+        && isInstanceElement(instance.value.id.value))
       .forEach(instance => {
         instance.value.description = instance.value.id.value.value.description ?? ''
       })

--- a/packages/jira-adapter/src/filters/field_configuration/missing_field_descriptions.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/missing_field_descriptions.ts
@@ -27,7 +27,7 @@ const filter: FilterCreator = () => ({
       .filter(instance => instance.elemID.typeName === FIELD_CONFIGURATION_ITEM_TYPE_NAME)
       .filter(instance => _.isEmpty(instance.value.description))
       .filter(instance => isReferenceExpression(instance.value.id)
-        && isInstanceElement(instance.value.id.value))
+        && isInstanceElement(instance.value.id?.value))
       .forEach(instance => {
         instance.value.description = instance.value.id.value.value.description ?? ''
       })

--- a/packages/jira-adapter/src/filters/field_configuration/missing_field_descriptions.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/missing_field_descriptions.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Element, isInstanceElement, isReferenceExpression } from '@salto-io/adapter-api'
+import { Element, isInstanceElement, isResolvedReferenceExpression } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { FIELD_CONFIGURATION_ITEM_TYPE_NAME } from '../../constants'
 import { FilterCreator } from '../../filter'
@@ -26,7 +26,7 @@ const filter: FilterCreator = () => ({
       .filter(isInstanceElement)
       .filter(instance => instance.elemID.typeName === FIELD_CONFIGURATION_ITEM_TYPE_NAME)
       .filter(instance => _.isEmpty(instance.value.description))
-      .filter(instance => isReferenceExpression(instance.value.id)
+      .filter(instance => isResolvedReferenceExpression(instance.value.id)
         && isInstanceElement(instance.value.id.value))
       .forEach(instance => {
         instance.value.description = instance.value.id.value.value.description ?? ''

--- a/packages/jira-adapter/src/filters/field_configuration/replace_field_configuration_references.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/replace_field_configuration_references.ts
@@ -14,10 +14,11 @@
 * limitations under the License.
 */
 
-import { CORE_ANNOTATIONS, ElemID, Field, getChangeData, InstanceElement, isInstanceElement, isReferenceExpression, MapType, ReadOnlyElementsSource, ReferenceExpression, Value, Values } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, ElemID, Field, getChangeData, InstanceElement, isInstanceElement, MapType, ReadOnlyElementsSource, ReferenceExpression, Value, Values } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { collections, values } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
+import { isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { findObject } from '../../utils'
 import { FilterCreator } from '../../filter'
 import { FIELD_CONFIGURATION_TYPE_NAME, JIRA } from '../../constants'
@@ -29,7 +30,7 @@ const { awu } = collections.asynciterable
 
 const replaceToMap = (instance: InstanceElement): void => {
   instance.value.fields = Object.fromEntries(instance.value.fields
-    .filter((field: Values) => isReferenceExpression(field.id))
+    .filter((field: Values) => isResolvedReferenceExpression(field.id))
     .map((field: Values) => [
       field.id.elemID.name,
       _.omit(field, 'id'),

--- a/packages/jira-adapter/src/filters/field_configuration/replace_field_configuration_references.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/replace_field_configuration_references.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-import { CORE_ANNOTATIONS, ElemID, Field, getChangeData, InstanceElement, isInstanceElement, isResolvedReferenceExpression, MapType, ReadOnlyElementsSource, ReferenceExpression, Value, Values } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, ElemID, Field, getChangeData, InstanceElement, isInstanceElement, isReferenceExpression, MapType, ReadOnlyElementsSource, ReferenceExpression, Value, Values } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { collections, values } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
@@ -29,7 +29,7 @@ const { awu } = collections.asynciterable
 
 const replaceToMap = (instance: InstanceElement): void => {
   instance.value.fields = Object.fromEntries(instance.value.fields
-    .filter((field: Values) => isResolvedReferenceExpression(field.id))
+    .filter((field: Values) => isReferenceExpression(field.id))
     .map((field: Values) => [
       field.id.elemID.name,
       _.omit(field, 'id'),

--- a/packages/jira-adapter/src/filters/field_configuration/replace_field_configuration_references.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/replace_field_configuration_references.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-import { CORE_ANNOTATIONS, ElemID, Field, getChangeData, InstanceElement, isInstanceElement, isReferenceExpression, MapType, ReadOnlyElementsSource, ReferenceExpression, Value, Values } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, ElemID, Field, getChangeData, InstanceElement, isInstanceElement, isResolvedReferenceExpression, MapType, ReadOnlyElementsSource, ReferenceExpression, Value, Values } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { collections, values } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
@@ -29,7 +29,7 @@ const { awu } = collections.asynciterable
 
 const replaceToMap = (instance: InstanceElement): void => {
   instance.value.fields = Object.fromEntries(instance.value.fields
-    .filter((field: Values) => isReferenceExpression(field.id))
+    .filter((field: Values) => isResolvedReferenceExpression(field.id))
     .map((field: Values) => [
       field.id.elemID.name,
       _.omit(field, 'id'),

--- a/packages/jira-adapter/src/filters/fields/contexts_projects_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/contexts_projects_filter.ts
@@ -13,8 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, ElemID, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, isInstanceElement, isRemovalOrModificationChange, isResolvedReferenceExpression, ReadOnlyElementsSource, ReferenceExpression, toChange } from '@salto-io/adapter-api'
-import { applyFunctionToChangeData } from '@salto-io/adapter-utils'
+import { Change, ElemID, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, isInstanceElement, isRemovalOrModificationChange, ReadOnlyElementsSource, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { applyFunctionToChangeData, isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { collections, values } from '@salto-io/lowerdash'
 import { PROJECT_TYPE } from '../../constants'
 import { FilterCreator } from '../../filter'

--- a/packages/jira-adapter/src/filters/fields/contexts_projects_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/contexts_projects_filter.ts
@@ -107,6 +107,7 @@ const filter: FilterCreator = ({ elementsSource, adapterContext }) => {
           instance.value.projectIds
             ?.filter(isReferenceExpression)
             .filter((ref: ReferenceExpression) => ref.elemID.typeName === 'Project')
+            .filter((ref: ReferenceExpression) => ref.value !== undefined)
             .forEach((ref: ReferenceExpression) => {
               appendReference(
                 ref.value.value,

--- a/packages/jira-adapter/src/filters/fields/contexts_projects_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/contexts_projects_filter.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, ElemID, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, isInstanceElement, isReferenceExpression, isRemovalOrModificationChange, ReadOnlyElementsSource, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { Change, ElemID, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, isInstanceElement, isRemovalOrModificationChange, isResolvedReferenceExpression, ReadOnlyElementsSource, ReferenceExpression, toChange } from '@salto-io/adapter-api'
 import { applyFunctionToChangeData } from '@salto-io/adapter-utils'
 import { collections, values } from '@salto-io/lowerdash'
 import { PROJECT_TYPE } from '../../constants'
@@ -105,9 +105,8 @@ const filter: FilterCreator = ({ elementsSource, adapterContext }) => {
         .filter(instance => instance.elemID.typeName === FIELD_CONTEXT_TYPE_NAME)
         .forEach(instance => {
           instance.value.projectIds
-            ?.filter(isReferenceExpression)
+            ?.filter(isResolvedReferenceExpression)
             .filter((ref: ReferenceExpression) => ref.elemID.typeName === 'Project')
-            .filter((ref: ReferenceExpression) => ref.value !== undefined)
             .forEach((ref: ReferenceExpression) => {
               appendReference(
                 ref.value.value,

--- a/packages/jira-adapter/src/filters/fields/default_values.ts
+++ b/packages/jira-adapter/src/filters/fields/default_values.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-import { Change, CORE_ANNOTATIONS, getChangeData, InstanceElement, isAdditionOrModificationChange, isEqualValues, isObjectType, isRemovalChange, isRemovalOrModificationChange, isResolvedReferenceExpression, ObjectType, ReadOnlyElementsSource, Value } from '@salto-io/adapter-api'
+import { Change, CORE_ANNOTATIONS, getChangeData, InstanceElement, isAdditionOrModificationChange, isEqualValues, isObjectType, isRemovalChange, isRemovalOrModificationChange, isReferenceExpression, ObjectType, ReadOnlyElementsSource, Value } from '@salto-io/adapter-api'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { applyFunctionToChangeData, getParents, resolveChangeElement, resolvePath, resolveValues } from '@salto-io/adapter-utils'
 import _ from 'lodash'
@@ -31,7 +31,7 @@ const resolveDefaultOption = (
       const clonedInstance = instance.clone();
 
       ['optionId', 'cascadingOptionId']
-        .filter(fieldName => isResolvedReferenceExpression(clonedInstance.value.defaultValue?.[fieldName]))
+        .filter(fieldName => isReferenceExpression(clonedInstance.value.defaultValue?.[fieldName]))
         .forEach(fieldName => {
           // We resolve this values like this and not with resolveChangeElement
           // is because if we just created these options, the options under instance.value will

--- a/packages/jira-adapter/src/filters/fields/default_values.ts
+++ b/packages/jira-adapter/src/filters/fields/default_values.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-import { Change, CORE_ANNOTATIONS, getChangeData, InstanceElement, isAdditionOrModificationChange, isEqualValues, isObjectType, isReferenceExpression, isRemovalChange, isRemovalOrModificationChange, ObjectType, ReadOnlyElementsSource, Value } from '@salto-io/adapter-api'
+import { Change, CORE_ANNOTATIONS, getChangeData, InstanceElement, isAdditionOrModificationChange, isEqualValues, isObjectType, isRemovalChange, isRemovalOrModificationChange, isResolvedReferenceExpression, ObjectType, ReadOnlyElementsSource, Value } from '@salto-io/adapter-api'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { applyFunctionToChangeData, getParents, resolveChangeElement, resolvePath, resolveValues } from '@salto-io/adapter-utils'
 import _ from 'lodash'
@@ -31,7 +31,7 @@ const resolveDefaultOption = (
       const clonedInstance = instance.clone();
 
       ['optionId', 'cascadingOptionId']
-        .filter(fieldName => isReferenceExpression(clonedInstance.value.defaultValue?.[fieldName]))
+        .filter(fieldName => isResolvedReferenceExpression(clonedInstance.value.defaultValue?.[fieldName]))
         .forEach(fieldName => {
           // We resolve this values like this and not with resolveChangeElement
           // is because if we just created these options, the options under instance.value will

--- a/packages/jira-adapter/src/filters/fields/default_values.ts
+++ b/packages/jira-adapter/src/filters/fields/default_values.ts
@@ -14,9 +14,9 @@
 * limitations under the License.
 */
 
-import { Change, CORE_ANNOTATIONS, getChangeData, InstanceElement, isAdditionOrModificationChange, isEqualValues, isObjectType, isRemovalChange, isRemovalOrModificationChange, isReferenceExpression, ObjectType, ReadOnlyElementsSource, Value } from '@salto-io/adapter-api'
+import { Change, CORE_ANNOTATIONS, getChangeData, InstanceElement, isAdditionOrModificationChange, isEqualValues, isObjectType, isRemovalChange, isRemovalOrModificationChange, ObjectType, ReadOnlyElementsSource, Value } from '@salto-io/adapter-api'
 import { client as clientUtils } from '@salto-io/adapter-components'
-import { applyFunctionToChangeData, getParents, resolveChangeElement, resolvePath, resolveValues } from '@salto-io/adapter-utils'
+import { applyFunctionToChangeData, getParents, isResolvedReferenceExpression, resolveChangeElement, resolvePath, resolveValues } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { getLookUpName } from '../../reference_mapping'
 import { addAnnotationRecursively, setFieldDeploymentAnnotations } from '../../utils'
@@ -31,7 +31,7 @@ const resolveDefaultOption = (
       const clonedInstance = instance.clone();
 
       ['optionId', 'cascadingOptionId']
-        .filter(fieldName => isReferenceExpression(clonedInstance.value.defaultValue?.[fieldName]))
+        .filter(fieldName => isResolvedReferenceExpression(clonedInstance.value.defaultValue?.[fieldName]))
         .forEach(fieldName => {
           // We resolve this values like this and not with resolveChangeElement
           // is because if we just created these options, the options under instance.value will

--- a/packages/jira-adapter/src/filters/jql/jql_references.ts
+++ b/packages/jira-adapter/src/filters/jql/jql_references.ts
@@ -13,8 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, ElemID, InstanceElement, isInstanceChange, isInstanceElement, isResolvedReferenceExpression, isTemplateExpression, TemplateExpression } from '@salto-io/adapter-api'
-import { applyFunctionToChangeData, setPath, walkOnElement, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
+import { Change, ElemID, InstanceElement, isInstanceChange, isInstanceElement, isTemplateExpression, TemplateExpression } from '@salto-io/adapter-api'
+import { applyFunctionToChangeData, setPath, walkOnElement, WALK_NEXT_STEP, isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections, values } from '@salto-io/lowerdash'
 import _ from 'lodash'

--- a/packages/jira-adapter/src/filters/jql/jql_references.ts
+++ b/packages/jira-adapter/src/filters/jql/jql_references.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, ElemID, InstanceElement, isInstanceChange, isInstanceElement, isReferenceExpression, isTemplateExpression, TemplateExpression } from '@salto-io/adapter-api'
+import { Change, ElemID, InstanceElement, isInstanceChange, isInstanceElement, isResolvedReferenceExpression, isTemplateExpression, TemplateExpression } from '@salto-io/adapter-api'
 import { applyFunctionToChangeData, setPath, walkOnElement, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections, values } from '@salto-io/lowerdash'
@@ -158,7 +158,7 @@ const filter: FilterCreator = ({ config }) => {
                   isTemplateExpression(jql.jql))
                 .forEach(jql => {
                   const resolvedJql = jql.jql.parts.map(part => {
-                    if (!isReferenceExpression(part) || part.value === undefined) {
+                    if (!isResolvedReferenceExpression(part)) {
                       return part
                     }
 

--- a/packages/jira-adapter/src/filters/jql/jql_references.ts
+++ b/packages/jira-adapter/src/filters/jql/jql_references.ts
@@ -158,7 +158,7 @@ const filter: FilterCreator = ({ config }) => {
                   isTemplateExpression(jql.jql))
                 .forEach(jql => {
                   const resolvedJql = jql.jql.parts.map(part => {
-                    if (!isReferenceExpression(part)) {
+                    if (!isReferenceExpression(part) || part.value === undefined) {
                       return part
                     }
 

--- a/packages/jira-adapter/src/filters/project_category.ts
+++ b/packages/jira-adapter/src/filters/project_category.ts
@@ -13,7 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, Element, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, isModificationChange, isReferenceExpression } from '@salto-io/adapter-api'
+import { Change, Element, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, isModificationChange } from '@salto-io/adapter-api'
+import { isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../filter'
 import { PROJECT_TYPE } from '../constants'
 
@@ -31,7 +32,7 @@ const convertProjectCategoryToCategoryId = async (
   if (instance.value.projectCategory === undefined) {
     return
   }
-  instance.value.categoryId = isReferenceExpression(instance.value.projectCategory)
+  instance.value.categoryId = isResolvedReferenceExpression(instance.value.projectCategory)
     ? (await instance.value.projectCategory.getResolvedValue()).value.id
     : instance.value.projectCategory
   projectIdToCategory[instance.value.id] = instance.value.projectCategory

--- a/packages/jira-adapter/src/filters/security_scheme/security_scheme.ts
+++ b/packages/jira-adapter/src/filters/security_scheme/security_scheme.ts
@@ -329,7 +329,7 @@ const filter: FilterCreator = ({ client, config }) => ({
 
     if (
       isReferenceExpression(securitySchemeInstance.value.defaultLevel)
-      && isInstanceElement(securitySchemeInstance.value.defaultLevel.value)
+      && isInstanceElement(securitySchemeInstance.value.defaultLevel?.value)
       && securitySchemeInstance.value.defaultLevel.value.value.id === undefined
     ) {
       const defaultLevelId = securitySchemeInstance.value.defaultLevel.elemID

--- a/packages/jira-adapter/src/filters/security_scheme/security_scheme.ts
+++ b/packages/jira-adapter/src/filters/security_scheme/security_scheme.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, Change, CORE_ANNOTATIONS, DeployResult, Element, Field, getChangeData, InstanceElement, isAdditionChange, isAdditionOrModificationChange, isInstanceChange, isInstanceElement, isReferenceExpression, isRemovalChange, MapType, toChange, Values } from '@salto-io/adapter-api'
+import { BuiltinTypes, Change, CORE_ANNOTATIONS, DeployResult, Element, Field, getChangeData, InstanceElement, isAdditionChange, isAdditionOrModificationChange, isInstanceChange, isInstanceElement, isRemovalChange, isResolvedReferenceExpression, MapType, toChange, Values } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { objects } from '@salto-io/lowerdash'
@@ -328,7 +328,7 @@ const filter: FilterCreator = ({ client, config }) => ({
     const securitySchemeInstance = getChangeData(securitySchemeChange)
 
     if (
-      isReferenceExpression(securitySchemeInstance.value.defaultLevel)
+      isResolvedReferenceExpression(securitySchemeInstance.value.defaultLevel)
       && isInstanceElement(securitySchemeInstance.value.defaultLevel.value)
       && securitySchemeInstance.value.defaultLevel.value.value.id === undefined
     ) {

--- a/packages/jira-adapter/src/filters/security_scheme/security_scheme.ts
+++ b/packages/jira-adapter/src/filters/security_scheme/security_scheme.ts
@@ -13,11 +13,11 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, Change, CORE_ANNOTATIONS, DeployResult, Element, Field, getChangeData, InstanceElement, isAdditionChange, isAdditionOrModificationChange, isInstanceChange, isInstanceElement, isRemovalChange, isResolvedReferenceExpression, MapType, toChange, Values } from '@salto-io/adapter-api'
+import { BuiltinTypes, Change, CORE_ANNOTATIONS, DeployResult, Element, Field, getChangeData, InstanceElement, isAdditionChange, isAdditionOrModificationChange, isInstanceChange, isInstanceElement, isRemovalChange, MapType, toChange, Values } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { objects } from '@salto-io/lowerdash'
-import { getParents, safeJsonStringify } from '@salto-io/adapter-utils'
+import { getParents, isResolvedReferenceExpression, safeJsonStringify } from '@salto-io/adapter-utils'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { findObject, getFilledJspUrls, setFieldDeploymentAnnotations, setTypeDeploymentAnnotations } from '../../utils'
 import { FilterCreator } from '../../filter'

--- a/packages/jira-adapter/src/filters/security_scheme/security_scheme.ts
+++ b/packages/jira-adapter/src/filters/security_scheme/security_scheme.ts
@@ -329,7 +329,7 @@ const filter: FilterCreator = ({ client, config }) => ({
 
     if (
       isReferenceExpression(securitySchemeInstance.value.defaultLevel)
-      && isInstanceElement(securitySchemeInstance.value.defaultLevel?.value)
+      && isInstanceElement(securitySchemeInstance.value.defaultLevel.value)
       && securitySchemeInstance.value.defaultLevel.value.value.id === undefined
     ) {
       const defaultLevelId = securitySchemeInstance.value.defaultLevel.elemID

--- a/packages/jira-adapter/src/filters/sort_lists.ts
+++ b/packages/jira-adapter/src/filters/sort_lists.ts
@@ -13,8 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { InstanceElement, isInstanceElement, isReferenceExpression, Value } from '@salto-io/adapter-api'
-import { transformValues } from '@salto-io/adapter-utils'
+import { InstanceElement, isInstanceElement, Value } from '@salto-io/adapter-api'
+import { isResolvedReferenceExpression, transformValues } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { AUTOMATION_TYPE, DASHBOARD_TYPE, NOTIFICATION_EVENT_TYPE_NAME, NOTIFICATION_SCHEME_TYPE_NAME, PROJECT_ROLE_TYPE, WORKFLOW_RULES_TYPE_NAME, WORKFLOW_STATUS_TYPE_NAME, WORKFLOW_TRANSITION_TYPE_NAME, WORKFLOW_TYPE_NAME } from '../constants'
@@ -84,7 +84,7 @@ const VALUES_TO_SORT: Record<string, Record<string, string[]>> = {
 }
 
 const getValue = (value: Value): Value => (
-  isReferenceExpression(value) ? value.elemID.getFullName() : value
+  isResolvedReferenceExpression(value) ? value.elemID.getFullName() : value
 )
 
 const sortLists = async (instance: InstanceElement): Promise<void> => {

--- a/packages/jira-adapter/src/filters/statuses/status_deployment.ts
+++ b/packages/jira-adapter/src/filters/statuses/status_deployment.ts
@@ -13,10 +13,10 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { CORE_ANNOTATIONS, Element, isInstanceElement, isInstanceChange, getChangeData, Change, InstanceElement, isAdditionOrModificationChange, isModificationChange, AdditionChange, ModificationChange, Values, isResolvedReferenceExpression } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, Element, isInstanceElement, isInstanceChange, getChangeData, Change, InstanceElement, isAdditionOrModificationChange, isModificationChange, AdditionChange, ModificationChange, Values } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
-import { createSchemeGuard } from '@salto-io/adapter-utils'
+import { createSchemeGuard, isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import Joi from 'joi'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { deployChanges } from '../../deployment/standard_deployment'

--- a/packages/jira-adapter/src/filters/statuses/status_deployment.ts
+++ b/packages/jira-adapter/src/filters/statuses/status_deployment.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { CORE_ANNOTATIONS, Element, isInstanceElement, isInstanceChange, getChangeData, Change, InstanceElement, isAdditionOrModificationChange, isModificationChange, AdditionChange, ModificationChange, Values, isReferenceExpression } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, Element, isInstanceElement, isInstanceChange, getChangeData, Change, InstanceElement, isAdditionOrModificationChange, isModificationChange, AdditionChange, ModificationChange, Values, isResolvedReferenceExpression } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { createSchemeGuard } from '@salto-io/adapter-utils'
@@ -53,7 +53,7 @@ const createDeployableStatusValues = (
 ): Values => {
   const { value } = getChangeData(statusChange)
   const deployableValue = _.clone(value)
-  if (isReferenceExpression(value.statusCategory) && value.statusCategory.value !== undefined) {
+  if (isResolvedReferenceExpression(value.statusCategory)) {
     // resolve statusCategory value before deploy
     const resolvedCategory = INVERTED_STATUS_CATEGORY_NAME_TO_ID[
       value.statusCategory.value.value.id

--- a/packages/jira-adapter/src/filters/statuses/status_deployment.ts
+++ b/packages/jira-adapter/src/filters/statuses/status_deployment.ts
@@ -53,7 +53,7 @@ const createDeployableStatusValues = (
 ): Values => {
   const { value } = getChangeData(statusChange)
   const deployableValue = _.clone(value)
-  if (isReferenceExpression(value.statusCategory)) {
+  if (isReferenceExpression(value.statusCategory) && value.statusCategory.value !== undefined) {
     // resolve statusCategory value before deploy
     const resolvedCategory = INVERTED_STATUS_CATEGORY_NAME_TO_ID[
       value.statusCategory.value.value.id

--- a/packages/jira-adapter/src/filters/workflow/steps_deployment.ts
+++ b/packages/jira-adapter/src/filters/workflow/steps_deployment.ts
@@ -95,7 +95,8 @@ export const deploySteps = async (
         throw new Error(`status name is missing in ${instance.elemID.getFullName()}`)
       }
 
-      const statusId = isReferenceExpression(status.id) ? status.id.value.value.id : status.id
+      const statusId = isReferenceExpression(status.id)
+      && status.id.value !== undefined ? status.id.value.value.id : status.id
       if (statusId === undefined) {
         throw new Error(`status id is missing for ${status.name} in ${instance.elemID.getFullName()}`)
       }

--- a/packages/jira-adapter/src/filters/workflow/steps_deployment.ts
+++ b/packages/jira-adapter/src/filters/workflow/steps_deployment.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { isReferenceExpression } from '@salto-io/adapter-api'
+import { isReferenceExpression, isResolvedReferenceExpression } from '@salto-io/adapter-api'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
@@ -95,8 +95,7 @@ export const deploySteps = async (
         throw new Error(`status name is missing in ${instance.elemID.getFullName()}`)
       }
 
-      const statusId = isReferenceExpression(status.id)
-      && status.id.value !== undefined ? status.id.value.value.id : status.id
+      const statusId = isResolvedReferenceExpression(status.id) ? status.id.value.value.id : status.id
       if (statusId === undefined) {
         throw new Error(`status id is missing for ${status.name} in ${instance.elemID.getFullName()}`)
       }

--- a/packages/jira-adapter/src/filters/workflow/steps_deployment.ts
+++ b/packages/jira-adapter/src/filters/workflow/steps_deployment.ts
@@ -13,8 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { isResolvedReferenceExpression } from '@salto-io/adapter-api'
-import { safeJsonStringify } from '@salto-io/adapter-utils'
+import { isResolvedReferenceExpression, safeJsonStringify } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import Joi from 'joi'

--- a/packages/jira-adapter/src/filters/workflow/steps_deployment.ts
+++ b/packages/jira-adapter/src/filters/workflow/steps_deployment.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { isReferenceExpression, isResolvedReferenceExpression } from '@salto-io/adapter-api'
+import { isResolvedReferenceExpression } from '@salto-io/adapter-api'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
@@ -88,7 +88,7 @@ export const deploySteps = async (
   const statusIdToStepId = await getStatusIdToStepId(workflowName, client)
 
   await awu(statuses)
-    .filter(status => !isReferenceExpression(status.id)
+    .filter(status => !isResolvedReferenceExpression(status.id)
       || status.name !== status.id.value.value.name)
     .forEach(async status => {
       if (status.name === undefined) {

--- a/packages/jira-adapter/src/filters/workflow/workflow_modification_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_modification_filter.ts
@@ -14,11 +14,11 @@
 * limitations under the License.
 */
 import { logger } from '@salto-io/logging'
-import { AdditionChange, CORE_ANNOTATIONS, getChangeData, InstanceElement, isInstanceChange, isModificationChange, isReferenceExpression, ModificationChange, ReadOnlyElementsSource, ReferenceExpression, RemovalChange, toChange } from '@salto-io/adapter-api'
+import { AdditionChange, CORE_ANNOTATIONS, getChangeData, InstanceElement, isInstanceChange, isModificationChange, ModificationChange, ReadOnlyElementsSource, ReferenceExpression, RemovalChange, toChange } from '@salto-io/adapter-api'
 import { collections, values } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { v4 as uuidv4 } from 'uuid'
-import { transformElement } from '@salto-io/adapter-utils'
+import { isResolvedReferenceExpression, transformElement } from '@salto-io/adapter-utils'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { WORKFLOW_SCHEME_TYPE_NAME, WORKFLOW_TYPE_NAME } from '../../constants'
 import { addAnnotationRecursively, findObject } from '../../utils'
@@ -47,7 +47,7 @@ const replaceWorkflowInScheme = async (
     allowEmpty: true,
     elementsSource,
     transformFunc: ({ value }) => {
-      if (isReferenceExpression(value) && value.elemID.isEqual(beforeWorkflow.elemID)) {
+      if (isResolvedReferenceExpression(value) && value.elemID.isEqual(beforeWorkflow.elemID)) {
         wasChanged = true
         return new ReferenceExpression(afterWorkflow.elemID, afterWorkflow)
       }

--- a/packages/jira-adapter/src/group_change.ts
+++ b/packages/jira-adapter/src/group_change.ts
@@ -14,8 +14,8 @@
 * limitations under the License.
 */
 import { collections, values } from '@salto-io/lowerdash'
-import { ChangeGroupIdFunction, getChangeData, ChangeGroupId, ChangeId, isModificationChange, Change, isAdditionChange, isReferenceExpression } from '@salto-io/adapter-api'
-import { getParent, getParents } from '@salto-io/adapter-utils'
+import { ChangeGroupIdFunction, getChangeData, ChangeGroupId, ChangeId, isModificationChange, Change, isAdditionChange } from '@salto-io/adapter-api'
+import { getParent, getParents, isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { FIELD_CONFIGURATION_ITEM_TYPE_NAME, SECURITY_LEVEL_TYPE, WORKFLOW_TYPE_NAME } from './constants'
 
 const { awu } = collections.asynciterable
@@ -38,7 +38,7 @@ export const getSecurityLevelGroup: ChangeIdFunction = async change => {
   }
 
   const parents = getParents(instance)
-  if (parents.length !== 1 || !isReferenceExpression(parents[0])) {
+  if (parents.length !== 1 || !isResolvedReferenceExpression(parents[0])) {
     throw new Error(`${instance.elemID.getFullName()} must have exactly one reference expression parent`)
   }
 

--- a/packages/jira-adapter/test/change_validators/dashboard_gadgets.test.ts
+++ b/packages/jira-adapter/test/change_validators/dashboard_gadgets.test.ts
@@ -38,7 +38,7 @@ describe('dashboardGadgetsValidator', () => {
       undefined,
       {
         [CORE_ANNOTATIONS.PARENT]: [
-          new ReferenceExpression(new ElemID(JIRA, DASHBOARD_TYPE, 'instance', 'parent')),
+          new ReferenceExpression(new ElemID(JIRA, DASHBOARD_TYPE, 'instance', 'parent'), {}),
         ],
       },
     )
@@ -60,7 +60,7 @@ describe('dashboardGadgetsValidator', () => {
       undefined,
       {
         [CORE_ANNOTATIONS.PARENT]: [
-          new ReferenceExpression(new ElemID(JIRA, DASHBOARD_TYPE, 'instance', 'parent')),
+          new ReferenceExpression(new ElemID(JIRA, DASHBOARD_TYPE, 'instance', 'parent'), {}),
         ],
       },
     )
@@ -105,7 +105,7 @@ describe('dashboardGadgetsValidator', () => {
       undefined,
       {
         [CORE_ANNOTATIONS.PARENT]: [
-          new ReferenceExpression(new ElemID(JIRA, DASHBOARD_TYPE, 'instance', 'parent2')),
+          new ReferenceExpression(new ElemID(JIRA, DASHBOARD_TYPE, 'instance', 'parent2'), {}),
         ],
       },
     )

--- a/packages/jira-adapter/test/change_validators/issue_type_scheme_default_type.test.ts
+++ b/packages/jira-adapter/test/change_validators/issue_type_scheme_default_type.test.ts
@@ -28,10 +28,10 @@ describe('issueTypeSchemeDefaultTypeValidator', () => {
         'instance',
         issueTypeSchemeType,
         {
-          defaultIssueTypeId: new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'issueType1')),
+          defaultIssueTypeId: new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'issueType1'), {}),
           issueTypeIds: [
-            new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'issueType1')),
-            new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'issueType2')),
+            new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'issueType1'), {}),
+            new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'issueType2'), {}),
           ],
         }
       ),
@@ -40,7 +40,7 @@ describe('issueTypeSchemeDefaultTypeValidator', () => {
 
   it('should return an error if the default type is not included in issueTypeIds', async () => {
     getChangeData(issueTypeSchemeChange).value.issueTypeIds = [
-      new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'issueType2')),
+      new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'issueType2'), {}),
     ]
     expect(await issueTypeSchemeDefaultTypeValidator([issueTypeSchemeChange])).toEqual([
       {

--- a/packages/jira-adapter/test/change_validators/issue_type_scheme_migration.test.ts
+++ b/packages/jira-adapter/test/change_validators/issue_type_scheme_migration.test.ts
@@ -58,8 +58,8 @@ describe('issue type scheme migration validator', () => {
       projectType,
       {
         name: 'instance',
-        workflowScheme: new ReferenceExpression(new ElemID(JIRA, 'WorkflowScheme', 'instance', 'workflow')),
-        issueTypeScheme: new ReferenceExpression(new ElemID(JIRA, 'IssueTypeScheme', 'instance', 'issueTypeScheme')),
+        workflowScheme: new ReferenceExpression(new ElemID(JIRA, 'WorkflowScheme', 'instance', 'workflow'), {}),
+        issueTypeScheme: new ReferenceExpression(new ElemID(JIRA, 'IssueTypeScheme', 'instance', 'issueTypeScheme'), {}),
       }
     )
     secondProjectInstance = new InstanceElement(
@@ -67,15 +67,15 @@ describe('issue type scheme migration validator', () => {
       projectType,
       {
         name: 'instance',
-        workflowScheme: new ReferenceExpression(new ElemID(JIRA, 'WorkflowScheme', 'instance', 'workflow')),
-        issueTypeScheme: new ReferenceExpression(new ElemID(JIRA, 'IssueTypeScheme', 'instance', 'issueTypeScheme')),
+        workflowScheme: new ReferenceExpression(new ElemID(JIRA, 'WorkflowScheme', 'instance', 'workflow'), {}),
+        issueTypeScheme: new ReferenceExpression(new ElemID(JIRA, 'IssueTypeScheme', 'instance', 'issueTypeScheme'), {}),
       }
     )
     issueTypeScheme = new InstanceElement(
       'issueTypeScheme',
       issueTypeSchemeType,
       {
-        defaultIssueTypeId: new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'issueType1')),
+        defaultIssueTypeId: new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'issueType1'), {}),
         issueTypeIds: [
           issueTypeReference1,
           issueTypeReference2,
@@ -87,7 +87,7 @@ describe('issue type scheme migration validator', () => {
       'issueTypeScheme',
       issueTypeSchemeType,
       {
-        defaultIssueTypeId: new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'issueType1')),
+        defaultIssueTypeId: new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'issueType1'), {}),
         issueTypeIds: [
           issueTypeReference1,
           issueTypeReference4,
@@ -128,7 +128,7 @@ describe('issue type scheme migration validator', () => {
 
   it('should not throw on unresolved issue type reference', async () => {
     issueTypeScheme.value.issueTypeIds = [
-      new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'issueType5')),
+      new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'issueType5'), {}),
     ]
     modifiedIssueTypeScheme.value.issueTypeIds = [
     ]

--- a/packages/jira-adapter/test/change_validators/permission_scheme.test.ts
+++ b/packages/jira-adapter/test/change_validators/permission_scheme.test.ts
@@ -74,7 +74,7 @@ describe('permissionSchemeDeploymentValidator', () => {
       `project${index}`,
       projectType,
       {
-        permissionScheme: new ReferenceExpression(permissionInstances[index].elemID),
+        permissionScheme: new ReferenceExpression(permissionInstances[index].elemID, {}),
       }
     ))
     project3NoScheme = new InstanceElement(
@@ -86,7 +86,7 @@ describe('permissionSchemeDeploymentValidator', () => {
       'project0',
       projectType,
       {
-        permissionScheme: new ReferenceExpression(permissionInstances[0].elemID),
+        permissionScheme: new ReferenceExpression(permissionInstances[0].elemID, {}),
         description: 'test',
       }
     )

--- a/packages/jira-adapter/test/change_validators/workflow_scheme_migration.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflow_scheme_migration.test.ts
@@ -119,11 +119,11 @@ describe('workflow scheme migration', () => {
       issueTypeSchemeType,
       {
         issueTypeIds: [
-          new ReferenceExpression(issueType1Id),
-          new ReferenceExpression(issueType2Id),
-          new ReferenceExpression(issueType3Id),
-          new ReferenceExpression(issueType4Id),
-          new ReferenceExpression(issueType5Id),
+          new ReferenceExpression(issueType1Id, {}),
+          new ReferenceExpression(issueType2Id, {}),
+          new ReferenceExpression(issueType3Id, {}),
+          new ReferenceExpression(issueType4Id, {}),
+          new ReferenceExpression(issueType5Id, {}),
         ],
       }
     )
@@ -133,8 +133,8 @@ describe('workflow scheme migration', () => {
       projectType,
       {
         name: 'instance',
-        workflowScheme: new ReferenceExpression(new ElemID(JIRA, 'WorkflowScheme', 'instance', 'workflow')),
-        issueTypeScheme: new ReferenceExpression(new ElemID(JIRA, 'IssueTypeScheme', 'instance', 'issueTypeScheme')),
+        workflowScheme: new ReferenceExpression(new ElemID(JIRA, 'WorkflowScheme', 'instance', 'workflow'), {}),
+        issueTypeScheme: new ReferenceExpression(new ElemID(JIRA, 'IssueTypeScheme', 'instance', 'issueTypeScheme'), {}),
       }
     )
     workflowInstance = new InstanceElement(
@@ -147,15 +147,15 @@ describe('workflow scheme migration', () => {
         items: [
           {
             workflow: workflow2,
-            issueType: new ReferenceExpression(new ElemID(JIRA, 'IssueType', 'instance', 'issueType1')),
+            issueType: new ReferenceExpression(new ElemID(JIRA, 'IssueType', 'instance', 'issueType1'), {}),
           },
           {
             workflow: workflow3,
-            issueType: new ReferenceExpression(new ElemID(JIRA, 'IssueType', 'instance', 'issueType2')),
+            issueType: new ReferenceExpression(new ElemID(JIRA, 'IssueType', 'instance', 'issueType2'), {}),
           },
           {
             workflow: workflow4,
-            issueType: new ReferenceExpression(new ElemID(JIRA, 'IssueType', 'instance', 'issueType3')),
+            issueType: new ReferenceExpression(new ElemID(JIRA, 'IssueType', 'instance', 'issueType3'), {}),
           },
         ],
       }

--- a/packages/jira-adapter/test/dependency_changers/dashboard_gadgets.test.ts
+++ b/packages/jira-adapter/test/dependency_changers/dashboard_gadgets.test.ts
@@ -102,7 +102,7 @@ describe('dashboardGadgetsDependencyChanger', () => {
       undefined,
       {
         [CORE_ANNOTATIONS.PARENT]: [
-          new ReferenceExpression(new ElemID(JIRA, DASHBOARD_TYPE, 'instance', 'other')),
+          new ReferenceExpression(new ElemID(JIRA, DASHBOARD_TYPE, 'instance', 'other'), {}),
         ],
       },
     )

--- a/packages/jira-adapter/test/filters/archived_project_components.test.ts
+++ b/packages/jira-adapter/test/filters/archived_project_components.test.ts
@@ -57,8 +57,8 @@ describe('archivedProjectComponentsFilter', () => {
       projectType,
       {
         components: [
-          new ReferenceExpression(projectComponent1.elemID),
-          new ReferenceExpression(projectComponent2.elemID),
+          new ReferenceExpression(projectComponent1.elemID, {}),
+          new ReferenceExpression(projectComponent2.elemID, {}),
         ],
       }
     )
@@ -72,7 +72,7 @@ describe('archivedProjectComponentsFilter', () => {
       expect(elements[0].elemID.getFullName()).toBe(project.elemID.getFullName())
       expect(elements[1].elemID.getFullName()).toBe(projectComponent1.elemID.getFullName())
       expect(project.value.components).toEqual([
-        new ReferenceExpression(projectComponent1.elemID),
+        new ReferenceExpression(projectComponent1.elemID, {}),
       ])
     })
 

--- a/packages/jira-adapter/test/filters/field_configuration/field_configuration_dependencies.test.ts
+++ b/packages/jira-adapter/test/filters/field_configuration/field_configuration_dependencies.test.ts
@@ -247,5 +247,17 @@ describe('fieldConfigurationItemsFilter', () => {
       ])
       expect(projectInstance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeUndefined()
     })
+    it('should not add generated dependencies if issueTypeScreenScheme is not a valid reference', async () => {
+      projectInstance.value.issueTypeScreenScheme = new ReferenceExpression(
+        new ElemID(JIRA, 'IssueTypeScreenScheme', 'instance', 'issueTypeScreenScheme'),
+      )
+      await filter.onFetch([
+        projectInstance,
+        ...fieldConfigurationItems,
+        fieldInstance,
+        fieldConfigurationInstance,
+      ])
+      expect(projectInstance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeUndefined()
+    })
   })
 })

--- a/packages/jira-adapter/test/filters/field_configuration/field_configuration_irrelevant_fields.test.ts
+++ b/packages/jira-adapter/test/filters/field_configuration/field_configuration_irrelevant_fields.test.ts
@@ -43,7 +43,7 @@ describe('fieldConfigurationIrrelevantFields', () => {
   })
 
   describe('onFetch', () => {
-    it('should remove fields that are not references', async () => {
+    it('should remove fields that are not references with values', async () => {
       const instance = new InstanceElement(
         'instance',
         fieldConfigurationType,
@@ -54,6 +54,9 @@ describe('fieldConfigurationIrrelevantFields', () => {
             },
             {
               id: '2',
+            },
+            {
+              id: new ReferenceExpression(fieldInstance.elemID),
             },
           ],
         }

--- a/packages/jira-adapter/test/filters/field_configuration/replace_field_configuration_references.test.ts
+++ b/packages/jira-adapter/test/filters/field_configuration/replace_field_configuration_references.test.ts
@@ -58,6 +58,7 @@ describe('replaceFieldConfigurationReferencesFilter', () => {
           {
             id: new ReferenceExpression(
               new ElemID(JIRA, FIELD_TYPE_NAME, 'instance', 'fieldInstance'),
+              {}
             ),
             isRequired: true,
           },

--- a/packages/jira-adapter/test/filters/fields/contexts_projects_filter.test.ts
+++ b/packages/jira-adapter/test/filters/fields/contexts_projects_filter.test.ts
@@ -99,6 +99,16 @@ describe('contexts_projects_filter', () => {
 
       expect(contextInstance.value.projectIds).toBeUndefined()
     })
+    it('should not add the context to the project, if it is not a valid reference', async () => {
+      delete projectInstance.value[PROJECT_CONTEXTS_FIELD]
+      contextInstance.value.projectIds = [
+        new ReferenceExpression(projectInstance.elemID),
+      ]
+
+      await filter.onFetch([projectInstance, contextInstance])
+
+      expect(projectInstance.value[PROJECT_CONTEXTS_FIELD]).toBeUndefined()
+    })
   })
 
   describe('preDeploy', () => {

--- a/packages/jira-adapter/test/filters/fields/default_values.test.ts
+++ b/packages/jira-adapter/test/filters/fields/default_values.test.ts
@@ -53,7 +53,7 @@ describe('default values', () => {
           },
           defaultValue: {
             type: 'float',
-            optionId: new ReferenceExpression(type.elemID.createNestedID('instance', 'instance', 'options', 'p1')),
+            optionId: new ReferenceExpression(type.elemID.createNestedID('instance', 'instance', 'options', 'p1'), {}),
           },
         }
       )
@@ -74,7 +74,7 @@ describe('default values', () => {
           },
           defaultValue: {
             type: 'float',
-            optionId: new ReferenceExpression(type.elemID.createNestedID('instance', 'instance', 'options', 'p2')),
+            optionId: new ReferenceExpression(type.elemID.createNestedID('instance', 'instance', 'options', 'p2'), {}),
           },
         },
         undefined,

--- a/packages/jira-adapter/test/filters/sort_lists.test.ts
+++ b/packages/jira-adapter/test/filters/sort_lists.test.ts
@@ -116,14 +116,14 @@ describe('sortListsFilter', () => {
             permission: 'C',
             holder: {
               type: 'A',
-              parameter: new ReferenceExpression(new ElemID(JIRA, 'B')),
+              parameter: new ReferenceExpression(new ElemID(JIRA, 'B'), {}),
             },
           },
           {
             permission: 'C',
             holder: {
               type: 'A',
-              parameter: new ReferenceExpression(new ElemID(JIRA, 'A')),
+              parameter: new ReferenceExpression(new ElemID(JIRA, 'A'), {}),
             },
           },
           {
@@ -157,14 +157,14 @@ describe('sortListsFilter', () => {
           permission: 'C',
           holder: {
             type: 'A',
-            parameter: new ReferenceExpression(new ElemID(JIRA, 'A')),
+            parameter: new ReferenceExpression(new ElemID(JIRA, 'A'), {}),
           },
         },
         {
           permission: 'C',
           holder: {
             type: 'A',
-            parameter: new ReferenceExpression(new ElemID(JIRA, 'B')),
+            parameter: new ReferenceExpression(new ElemID(JIRA, 'B'), {}),
           },
         },
       ],


### PR DESCRIPTION
In this PR, I added filters and extended if statements in all the places in Jira's filters that I thought are suitable.  In order to check if reference expressions have undefined values. 

---
##### What I did to check that I didn't broke anything:
1. I ran all Jira's test and everything worked great. 
2. I fetched and depllyed Ori-testing env and everything worked great.
3. I rebased `SALTO-4038-EnableMissingReferencesInJira` over this branch and fetched everything and now it works great. 

##### followup:
After confirming the places where I wrote the checks, I will also add logs.

---
_Release Notes_: 
1. This changes won't affect Salto users, but they will be good infrastructure to add the missing reference filter. 

---
_User Notifications_: 
None
