### PR TITLE
SALTO-4300: fix http connection to extract retry-after header correctly

### DIFF
--- a/packages/adapter-components/src/client/http_client.ts
+++ b/packages/adapter-components/src/client/http_client.ts
@@ -144,7 +144,7 @@ export abstract class AdapterHTTPClient<
       ? _.pickBy(headers, (_val, key) =>
         key.toLowerCase().startsWith('rate-')
         || key.toLowerCase().startsWith('x-rate-')
-        || key.toLowerCase().startsWith('Retry-'))
+        || key.toLowerCase().startsWith('retry-'))
       : undefined
   }
 

--- a/packages/adapter-components/src/client/http_client.ts
+++ b/packages/adapter-components/src/client/http_client.ts
@@ -141,7 +141,10 @@ export abstract class AdapterHTTPClient<
   protected extractHeaders(headers: Record<string, string> | undefined): Record<string, string> | undefined {
     return headers !== undefined
       // include headers related to rate limits
-      ? _.pickBy(headers, (_val, key) => key.toLowerCase().startsWith('rate-') || key.toLowerCase().startsWith('x-rate-'))
+      ? _.pickBy(headers, (_val, key) =>
+        key.toLowerCase().startsWith('rate-')
+        || key.toLowerCase().startsWith('x-rate-')
+        || key.toLowerCase().startsWith('Retry-'))
       : undefined
   }
 

--- a/packages/adapter-components/test/client/http_client.test.ts
+++ b/packages/adapter-components/test/client/http_client.test.ts
@@ -70,18 +70,18 @@ describe('client_http_client', () => {
       mockAxiosAdapter.onGet('/users/me').reply(200, {
         accountId: 'ACCOUNT_ID',
       })
-      mockAxiosAdapter.onGet('/ep').replyOnce(200, { a: 'b' }, { h: '123', 'X-Rate-Limit': '456' })
+      mockAxiosAdapter.onGet('/ep').replyOnce(200, { a: 'b' }, { h: '123', 'X-Rate-Limit': '456', 'Retry-After': '93' })
       mockAxiosAdapter.onGet('/ep2', { a: 'AAA' }).replyOnce(200, { c: 'd' }, { hh: 'header' })
 
       const getRes = await client.getSinglePage({ url: '/ep' })
       const getRes2 = await client.getSinglePage({ url: '/ep2', queryParams: { a: 'AAA' } })
-      expect(getRes).toEqual({ data: { a: 'b' }, status: 200, headers: { 'X-Rate-Limit': '456' } })
+      expect(getRes).toEqual({ data: { a: 'b' }, status: 200, headers: { 'X-Rate-Limit': '456', 'Retry-After': '93' } })
       expect(getRes2).toEqual({ data: { c: 'd' }, status: 200, headers: {} })
       expect(clearValuesFromResponseDataFunc).toHaveBeenCalledTimes(2)
       expect(clearValuesFromResponseDataFunc).toHaveBeenNthCalledWith(1, { a: 'b' }, '/ep')
       expect(clearValuesFromResponseDataFunc).toHaveBeenNthCalledWith(2, { c: 'd' }, '/ep2')
       expect(extractHeadersFunc).toHaveBeenCalledTimes(2)
-      expect(extractHeadersFunc).toHaveBeenNthCalledWith(1, { h: '123', 'X-Rate-Limit': '456' })
+      expect(extractHeadersFunc).toHaveBeenNthCalledWith(1, { h: '123', 'X-Rate-Limit': '456', 'Retry-After': '93' })
       expect(extractHeadersFunc).toHaveBeenNthCalledWith(2, { hh: 'header' })
     })
 


### PR DESCRIPTION
fix http_connection to extract retry-after header correctly

---

_Additional context for reviewer_

---
_Release Notes_: 
None


---
_User Notifications_: 
None
