### PR TITLE
SALTO-4314: invalid resolve prevents deletion

### DIFF
--- a/packages/zendesk-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-adapter/src/filters/field_references.ts
@@ -207,7 +207,8 @@ const ZendeskReferenceSerializationStrategyLookup: Record<
   },
   localeId: {
     serialize: ({ ref }) => (
-      isInstanceElement(ref.value) ? ref.value.value.locale_id.value.value.id : ref.value
+      // locale_id may be missing reference
+      isInstanceElement(ref.value) ? ref.value.value.locale_id?.value.value?.id : ref.value
     ),
     lookup: val => val,
     lookupIndexName: 'localeId',


### PR DESCRIPTION
invalid resolve prevents deletion

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* fix error when deleting a `dynamic_content_item_variant` with missing locale 

---
_User Notifications_: 
None
