### PR TITLE
SALTO-4263: Do not override properties for system fields

### DIFF
--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -1334,8 +1334,6 @@ export const getSObjectFieldElement = (
   // Name is an exception because it can be editable and visible to the user
   if (!field.nameField && systemFields.includes(field.name)) {
     annotations[CORE_ANNOTATIONS.HIDDEN_VALUE] = true
-    annotations[FIELD_ANNOTATIONS.UPDATEABLE] = false
-    annotations[FIELD_ANNOTATIONS.CREATABLE] = false
     delete annotations[CORE_ANNOTATIONS.REQUIRED]
   }
 

--- a/packages/salesforce-adapter/test/filters/custom_object_instances_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_object_instances_references.test.ts
@@ -168,6 +168,20 @@ describe('Custom Object Instances References filter', () => {
             ],
           },
         },
+        HiddenValueField: {
+          refType: Types.primitiveDataTypes.MasterDetail,
+          annotations: {
+            [CORE_ANNOTATIONS.REQUIRED]: true,
+            [LABEL]: 'hiddenValueField',
+            [API_NAME]: 'HiddenValueField',
+            [FIELD_ANNOTATIONS.CREATABLE]: true,
+            [FIELD_ANNOTATIONS.UPDATEABLE]: true,
+            [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,
+            referenceTo: [
+              masterName,
+            ],
+          },
+        },
       },
     }
   )
@@ -197,6 +211,7 @@ describe('Custom Object Instances References filter', () => {
       LookupExample: 'refToId',
       MasterDetailExample: 'masterToId',
       NonDeployableLookup: 'ToNothing',
+      HiddenValueField: 'ToNothing',
       RefToUser: 'aaa',
     }
     const refToInstanceName = 'refToInstance'
@@ -319,15 +334,18 @@ describe('Custom Object Instances References filter', () => {
     })
 
     it('should replace lookup and master values with reference and not replace ref to user', () => {
-      const afterFilterRefToInst = elements.find(e => e.elemID.isEqual(refFromInstance.elemID))
+      const afterFilterRefToInst = elements
+        .filter(isInstanceElement)
+        .find(e => e.elemID.isEqual(refFromInstance.elemID)) as InstanceElement
       expect(afterFilterRefToInst).toBeDefined()
-      expect(isInstanceElement(afterFilterRefToInst)).toBeTruthy()
-      expect((afterFilterRefToInst as InstanceElement).value.LookupExample)
-        .toEqual(new ReferenceExpression(refToInstance.elemID))
-      expect((afterFilterRefToInst as InstanceElement).value.MasterDetailExample)
-        .toEqual(new ReferenceExpression(masterToInstance.elemID))
-      expect((afterFilterRefToInst as InstanceElement).value.RefToUser)
-        .toEqual('aaa')
+      expect(afterFilterRefToInst.value).toEqual({
+        Id: '1234',
+        LookupExample: new ReferenceExpression(refToInstance.elemID),
+        MasterDetailExample: new ReferenceExpression(masterToInstance.elemID),
+        NonDeployableLookup: 'ToNothing',
+        RefToUser: 'aaa',
+        HiddenValueField: 'ToNothing',
+      })
     })
 
     it('should drop the referencing instance if ref is to non existing instance', () => {


### PR DESCRIPTION
For all the **System Fields** we overridden their `createable | updatable` annotation values to false with the values returned from the API.

---

Workspace Diff: https://github.com/salto-io/tamir-sf/commit/af0b2b6743d8ada7491f7c4378ab8ac99ca4d045

---
_Release Notes_: 
_Salesforce Adapter_:
- Correct createable and updateable annotation values for Salesforce System Fields.

---
_User Notifications_: 
Salesforce:
- Changes to the values of the annotations **createable** and **updateable** of System Fields in existing nacls.
