### PR TITLE
SALTO-4318 - Salesforce: use retrieve API for PermissionSet and CustomObject

### DIFF
--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -149,15 +149,16 @@ salesforce {
 
 ## Optional Features
 
-| Name              | Default when undefined | Description                                                                                                                            |
-|-------------------|------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
-| extraDependencies | true                   | Find additional dependencies between configuration elements by using the salesforce tooling API                                        |
-| elementsUrls      | true                   | Populate URLs for your salesforce configuration elements and enable quick navigation from Salto to the corresponding salesforce screen |
-| addMissingIds     | true                   | Populate Salesforce internal ids for a few types that require special handling                                                         |
-| profilePaths      | true                   | Update file names for profiles whose API name is different from their display name                                                     |
-| authorInformation | true                   | Populate Salesforce author information about who and when last changed Salesforce configuration elements.                              |
-| describeSObjects  | true                   | Fetch additional information about CustomObjects from the soap API                                                                     |
-| formulaDeps       | true                   | Parse formula fields in custom objects for additional dependencies beyond those provided by the tooling API                            |
+| Name                              | Default when undefined | Description                                                                                                                                                 |
+|-----------------------------------|------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| extraDependencies                 | true                   | Find additional dependencies between configuration elements by using the salesforce tooling API                                                             |
+| elementsUrls                      | true                   | Populate URLs for your salesforce configuration elements and enable quick navigation from Salto to the corresponding salesforce screen                      |
+| addMissingIds                     | true                   | Populate Salesforce internal ids for a few types that require special handling                                                                              |
+| profilePaths                      | true                   | Update file names for profiles whose API name is different from their display name                                                                          |
+| authorInformation                 | true                   | Populate Salesforce author information about who and when last changed Salesforce configuration elements.                                                   |
+| describeSObjects                  | true                   | Fetch additional information about CustomObjects from the soap API                                                                                          |
+| formulaDeps                       | true                   | Parse formula fields in custom objects for additional dependencies beyond those provided by the tooling API                                                 |
+| fetchCustomObjectUsingRetrieveApi | true                   | Use the Salesforce Metadata Retrieve API to fetch CustomObjects. This should improve reliability and data accuracy, but may have a small performance impact | 
 
 ### Data management configuration options
 

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -230,6 +230,7 @@ const METADATA_TO_RETRIEVE = [
   'Certificate', // contains encoded zip content
   'ContentAsset', // contains encoded zip content
   'CustomMetadata', // For the XML attributes
+  'CustomObject',
   'Dashboard', // contains encoded zip content, is under a folder
   'DashboardFolder',
   'Document', // contains encoded zip content, is under a folder
@@ -239,6 +240,7 @@ const METADATA_TO_RETRIEVE = [
   'EmailTemplate', // contains encoded zip content, is under a folder
   'LightningComponentBundle', // Has several fields with base64Binary encoded content
   'NetworkBranding', // contains encoded zip content
+  'PermissionSet',
   'Report', // contains encoded zip content, is under a folder
   'ReportFolder',
   'ReportType',

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -351,7 +351,7 @@ export default class SalesforceAdapter implements AdapterOperations {
 
     const fetchProfile = buildFetchProfile(config.fetch ?? {})
     this.fetchProfile = fetchProfile
-    if (this.fetchProfile.isFeatureEnabled('fetchCustomObjectUsingReadApi')) {
+    if (this.fetchProfile.isFeatureEnabled('fetchCustomObjectUsingRetrieveApi')) {
       _.pull(this.metadataToRetrieve, CUSTOM_OBJECT)
     }
     this.createFiltersRunner = () => filter.filtersRunner(

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -92,7 +92,7 @@ import { isCustomObjectInstanceChanges, deployCustomObjectInstancesGroup } from 
 import { getLookUpName } from './transformers/reference_mapping'
 import { deployMetadata, NestedMetadataTypeInfo } from './metadata_deploy'
 import { FetchProfile, buildFetchProfile } from './fetch_profile/fetch_profile'
-import { FLOW_DEFINITION_METADATA_TYPE, FLOW_METADATA_TYPE } from './constants'
+import { CUSTOM_OBJECT, FLOW_DEFINITION_METADATA_TYPE, FLOW_METADATA_TYPE } from './constants'
 
 const { awu } = collections.asynciterable
 const { partition } = promises.array
@@ -351,6 +351,9 @@ export default class SalesforceAdapter implements AdapterOperations {
 
     const fetchProfile = buildFetchProfile(config.fetch ?? {})
     this.fetchProfile = fetchProfile
+    if (this.fetchProfile.isFeatureEnabled('fetchCustomObjectUsingReadApi')) {
+      _.pull(this.metadataToRetrieve, CUSTOM_OBJECT)
+    }
     this.createFiltersRunner = () => filter.filtersRunner(
       {
         client,

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -351,7 +351,7 @@ export default class SalesforceAdapter implements AdapterOperations {
 
     const fetchProfile = buildFetchProfile(config.fetch ?? {})
     this.fetchProfile = fetchProfile
-    if (this.fetchProfile.isFeatureEnabled('fetchCustomObjectUsingRetrieveApi')) {
+    if (!this.fetchProfile.isFeatureEnabled('fetchCustomObjectUsingRetrieveApi')) {
       _.pull(this.metadataToRetrieve, CUSTOM_OBJECT)
     }
     this.createFiltersRunner = () => filter.filtersRunner(

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -78,6 +78,7 @@ export type OptionalFeatures = {
   describeSObjects?: boolean
   skipAliases?: boolean
   formulaDeps?: boolean
+  fetchCustomObjectUsingReadApi?: boolean
 }
 
 export type ChangeValidatorName = (
@@ -572,6 +573,7 @@ const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
     describeSObjects: { refType: BuiltinTypes.BOOLEAN },
     skipAliases: { refType: BuiltinTypes.BOOLEAN },
     formulaDeps: { refType: BuiltinTypes.BOOLEAN },
+    fetchCustomObjectUsingReadApi: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -78,7 +78,7 @@ export type OptionalFeatures = {
   describeSObjects?: boolean
   skipAliases?: boolean
   formulaDeps?: boolean
-  fetchCustomObjectUsingReadApi?: boolean
+  fetchCustomObjectUsingRetrieveApi?: boolean
 }
 
 export type ChangeValidatorName = (
@@ -573,7 +573,7 @@ const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
     describeSObjects: { refType: BuiltinTypes.BOOLEAN },
     skipAliases: { refType: BuiltinTypes.BOOLEAN },
     formulaDeps: { refType: BuiltinTypes.BOOLEAN },
-    fetchCustomObjectUsingReadApi: { refType: BuiltinTypes.BOOLEAN },
+    fetchCustomObjectUsingRetrieveApi: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,


### PR DESCRIPTION
Add PermissionSet and CustomObject to the list of types we fetch using the retrieve API.

 - [x] [PROD ticket](https://salto-io.atlassian.net/browse/PROD-140)

---

We want to eventually use the retrieve API for all types because it provides better data, behaves better in regards to rate limits and is more similar to SFDX. As part of our work to improve our support for Salesforce Profiles, we need to use retrieve to fetch these two types.

[WS Diff](https://github.com/salto-io/tomsellek-sf/pull/9)

---
_Release Notes_: 
Salesforce: Use a different API to fetch custom objects.

---
_User Notifications_: 
Salesforce: Changing the API used for fetching custom objects will result in several changes across all custom object types, including additional data as well as changes to existing fields.
