### PR TITLE
SALTO-4301: update static file path

### DIFF
--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -32,7 +32,7 @@ export interface Values {
 }
 
 export type CompareOptions = {
-  compareReferencesByValue?: boolean
+  compareByValue?: boolean
 }
 
 export const calculateStaticFileHash = (content: Buffer): string =>
@@ -250,7 +250,7 @@ const shouldCompareByValue = (
   first: Value,
   second: Value,
   options?: CompareOptions,
-): boolean => Boolean(options?.compareReferencesByValue)
+): boolean => Boolean(options?.compareByValue)
   && shouldResolve(first)
   && shouldResolve(second)
 
@@ -261,7 +261,9 @@ export const compareSpecialValues = (
 ): boolean | undefined => {
   if (isStaticFile(first) && isStaticFile(second)) {
     return first.isEqual(second)
-      && (options?.compareReferencesByValue !== true ? first.filepath === second.filepath : true)
+      && (options?.compareByValue
+        ? true
+        : first.filepath === second.filepath)
   }
   if (isReferenceExpression(first) || isReferenceExpression(second)) {
     if (shouldCompareByValue(first, second, options)) {

--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
+import path from 'path'
 import { inspect } from 'util'
 import { hash as hashUtils } from '@salto-io/lowerdash'
 // import { ElementsSource } from '@salto-io/workspace'
@@ -57,7 +58,7 @@ export class StaticFile {
   public readonly encoding: BufferEncoding
   private internalContent?: Buffer
   constructor(params: StaticFileParameters) {
-    this.filepath = params.filepath
+    this.filepath = path.normalize(params.filepath)
     this.encoding = params.encoding ?? DEFAULT_STATIC_FILE_ENCODING
     if (!Buffer.isEncoding(this.encoding)) {
       throw Error(`Cannot create StaticFile at path - ${this.filepath} due to invalid encoding - ${this.encoding}`)

--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -261,6 +261,7 @@ export const compareSpecialValues = (
 ): boolean | undefined => {
   if (isStaticFile(first) && isStaticFile(second)) {
     return first.isEqual(second)
+      && (options?.compareReferencesByValue ? first.filepath === second.filepath : true)
   }
   if (isReferenceExpression(first) || isReferenceExpression(second)) {
     if (shouldCompareByValue(first, second, options)) {

--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -261,7 +261,7 @@ export const compareSpecialValues = (
 ): boolean | undefined => {
   if (isStaticFile(first) && isStaticFile(second)) {
     return first.isEqual(second)
-      && (options?.compareReferencesByValue ? first.filepath === second.filepath : true)
+      && (options?.compareReferencesByValue !== true ? first.filepath === second.filepath : true)
   }
   if (isReferenceExpression(first) || isReferenceExpression(second)) {
     if (shouldCompareByValue(first, second, options)) {

--- a/packages/adapter-api/test/values.test.ts
+++ b/packages/adapter-api/test/values.test.ts
@@ -148,7 +148,7 @@ describe('Values', () => {
   describe('StaticFile', () => {
     describe('equality (direct)', () => {
       it('equals', () => {
-        const fileFunc1 = new StaticFile({ filepath: 'some/path.ext', content: Buffer.from('ZOMG') })
+        const fileFunc1 = new StaticFile({ filepath: 'somepath.ext', content: Buffer.from('ZOMG') })
         const fileFunc2 = new StaticFile({ filepath: 'some/path.ext', content: Buffer.from('ZOMG') })
         expect(fileFunc1.isEqual(fileFunc2)).toEqual(true)
       })
@@ -170,7 +170,7 @@ describe('Values', () => {
         expect(isEqualValues(fileFunc1, fileFunc2, { compareByValue: true })).toEqual(true)
       })
       it('equals with flag false', () => {
-        const fileFunc1 = new StaticFile({ filepath: 'some/path.ext', content: Buffer.from('ZOMG') })
+        const fileFunc1 = new StaticFile({ filepath: 'some//path.ext', content: Buffer.from('ZOMG') })
         const fileFunc2 = new StaticFile({ filepath: 'some/path.ext', content: Buffer.from('ZOMG') })
         expect(isEqualValues(fileFunc1, fileFunc2, { compareByValue: false })).toEqual(true)
       })

--- a/packages/adapter-api/test/values.test.ts
+++ b/packages/adapter-api/test/values.test.ts
@@ -159,6 +159,26 @@ describe('Values', () => {
       })
     })
     describe('equality (via isEqualValues)', () => {
+      it('unequals by path with flag false', () => {
+        const fileFunc1 = new StaticFile({ filepath: 'some/path.txt', content: Buffer.from('ZOMG') })
+        const fileFunc2 = new StaticFile({ filepath: 'some/path.ext', content: Buffer.from('ZOMG') })
+        expect(isEqualValues(fileFunc1, fileFunc2, { compareByValue: false })).toEqual(false)
+      })
+      it('unequals by path with flag true', () => {
+        const fileFunc1 = new StaticFile({ filepath: 'some/path.txt', content: Buffer.from('ZOMG') })
+        const fileFunc2 = new StaticFile({ filepath: 'some/path.ext', content: Buffer.from('ZOMG') })
+        expect(isEqualValues(fileFunc1, fileFunc2, { compareByValue: true })).toEqual(true)
+      })
+      it('equals with flag false', () => {
+        const fileFunc1 = new StaticFile({ filepath: 'some/path.ext', content: Buffer.from('ZOMG') })
+        const fileFunc2 = new StaticFile({ filepath: 'some/path.ext', content: Buffer.from('ZOMG') })
+        expect(isEqualValues(fileFunc1, fileFunc2, { compareByValue: false })).toEqual(true)
+      })
+      it('equals with flag true', () => {
+        const fileFunc1 = new StaticFile({ filepath: 'some/path.ext', content: Buffer.from('ZOMG') })
+        const fileFunc2 = new StaticFile({ filepath: 'some/path.ext', content: Buffer.from('ZOMG') })
+        expect(isEqualValues(fileFunc1, fileFunc2, { compareByValue: true })).toEqual(true)
+      })
       it('equals by hash', () => {
         const fileFunc1 = new StaticFile({ filepath: 'some/path.ext', content: Buffer.from('ZOMG') })
         const fileFunc2 = new StaticFile({ filepath: 'some/path.ext', content: Buffer.from('ZOMG') })
@@ -184,19 +204,19 @@ describe('Values', () => {
       it('References to inner properties with the same should not be equal when compareReferencesByValue is true', () => {
         const ref1 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val1'), 1)
         const ref2 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val1'), 2)
-        expect(isEqualValues(ref1, ref2, { compareReferencesByValue: true })).toBeFalsy()
+        expect(isEqualValues(ref1, ref2, { compareByValue: true })).toBeFalsy()
       })
 
       it('References to inner properties with the same should not be equal', () => {
         const ref1 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val1'), 1)
         const ref2 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val1'), 1)
-        expect(isEqualValues(ref1, ref2, { compareReferencesByValue: true })).toBeTruthy()
+        expect(isEqualValues(ref1, ref2, { compareByValue: true })).toBeTruthy()
       })
 
       it('References to different inner properties with the same value should be equal', () => {
         const ref1 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val1'), 1)
         const ref2 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val2'), 1)
-        expect(isEqualValues(ref1, ref2, { compareReferencesByValue: true })).toBeTruthy()
+        expect(isEqualValues(ref1, ref2, { compareByValue: true })).toBeTruthy()
       })
 
       it('Reference should not be equal to its resolved value by default', () => {
@@ -206,7 +226,7 @@ describe('Values', () => {
 
       it('Reference should not be equal to its resolved value when compareReferencesByValue is true', () => {
         const ref1 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val1'), 1)
-        expect(isEqualValues(ref1, 1, { compareReferencesByValue: true })).toBeTruthy()
+        expect(isEqualValues(ref1, 1, { compareByValue: true })).toBeTruthy()
       })
     })
     it('calculate hash', () => {

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -130,7 +130,7 @@ export const preview = async (
     dependencyChangers: defaultDependencyChangers.concat(getAdapterDependencyChangers(adapters)),
     customGroupIdFunctions: getAdapterChangeGroupIdFunctions(adapters),
     topLevelFilters: [shouldElementBeIncluded(accounts)],
-    compareOptions: { compareReferencesByValue: true },
+    compareOptions: { compareByValue: true },
   })
 }
 

--- a/packages/core/src/core/plan/dependency/reference_dependency.ts
+++ b/packages/core/src/core/plan/dependency/reference_dependency.ts
@@ -42,7 +42,7 @@ const isReferenceValueChanged = (change: Change<ChangeDataType>, refElemId: Elem
   return !isEqualValues(
     resolvePath(beforeTopLevel, refElemId),
     resolvePath(afterTopLevel, refElemId),
-    { compareReferencesByValue: true }
+    { compareByValue: true }
   )
 }
 

--- a/packages/core/src/core/plan/plan.ts
+++ b/packages/core/src/core/plan/plan.ts
@@ -84,7 +84,7 @@ const areReferencesEqual = async (
   secondVisitedReferences: Set<string>,
   compareOptions?: CompareOptions,
 ): Promise<ReferenceCompareReturnValue> => {
-  if (compareOptions?.compareReferencesByValue && shouldResolve(first) && shouldResolve(second)) {
+  if (compareOptions?.compareByValue && shouldResolve(first) && shouldResolve(second)) {
     const shouldResolveFirst = isReferenceExpression(first)
 
     const firstValue = shouldResolveFirst

--- a/packages/core/test/core/plan/plan.test.ts
+++ b/packages/core/test/core/plan/plan.test.ts
@@ -311,7 +311,7 @@ describe('getPlan', () => {
       after: createElementSource(
         [secondInstance1, secondInstance2, secondInstance3, secondInstance4, type, innerType]
       ),
-      compareOptions: { compareReferencesByValue: true },
+      compareOptions: { compareByValue: true },
     })
     expect(plan.size).toBe(0)
   })
@@ -348,7 +348,7 @@ describe('getPlan', () => {
     const plan = await getPlan({
       before: createElementSource([stateInstance, type]),
       after: createElementSource([instance, type, variableObject]),
-      compareOptions: { compareReferencesByValue: true },
+      compareOptions: { compareByValue: true },
     })
     expect(plan.size).toBe(0)
   })
@@ -477,7 +477,7 @@ describe('getPlan', () => {
       const plan = await getPlan({
         before: createElementSource([instanceBefore, referencedBefore, type]),
         after: createElementSource([instanceAfter, referencedAfter, type]),
-        compareOptions: { compareReferencesByValue: true },
+        compareOptions: { compareByValue: true },
       })
       expect(plan.size).toBe(2)
 
@@ -507,7 +507,7 @@ describe('getPlan', () => {
       const plan = await getPlan({
         before: createElementSource([instanceBefore, referencedBefore, type]),
         after: createElementSource([instanceAfter, referencedAfter, type]),
-        compareOptions: { compareReferencesByValue: true },
+        compareOptions: { compareByValue: true },
       })
       expect(plan.size).toBe(1)
 
@@ -549,7 +549,7 @@ describe('getPlan', () => {
       const plan = await getPlan({
         before: createElementSource([instanceBefore, referencedBefore, type]),
         after: createElementSource([instanceAfter, referencedAfter, type]),
-        compareOptions: { compareReferencesByValue: true },
+        compareOptions: { compareByValue: true },
       })
       expect(plan.size).toBe(2)
 
@@ -578,7 +578,7 @@ describe('getPlan', () => {
       const plan = await getPlan({
         before: createElementSource([instanceBefore, referencedBefore, type]),
         after: createElementSource([instanceAfter, referencedAfter, type]),
-        compareOptions: { compareReferencesByValue: true },
+        compareOptions: { compareByValue: true },
       })
       expect(plan.size).toBe(0)
 

--- a/packages/okta-adapter/src/change_validators/group_schema_modify_base_fields.ts
+++ b/packages/okta-adapter/src/change_validators/group_schema_modify_base_fields.ts
@@ -23,7 +23,7 @@ const isBaseFieldModified = (
   const { before, after } = change.data
   const beforeBase = before.value.definitions?.base
   const afterBase = after.value.definitions?.base
-  return !isEqualValues(beforeBase, afterBase, { compareReferencesByValue: true })
+  return !isEqualValues(beforeBase, afterBase, { compareByValue: true })
 }
 
 export const groupSchemaModifyBaseValidator: ChangeValidator = async changes => (

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -828,6 +828,15 @@ const buildNaclFilesSource = (
         .map(getNestedStaticFiles)
         .flat()
         .forEach(file => staticFilesSource.delete(file))
+
+      fileChanges
+        .filter(isModificationChange)
+        .filter(change => isStaticFile(change.data.after) && isStaticFile(change.data.before))
+        .filter(change => change.data.after.filepath !== change.data.before.filepath)
+        .map(change => change.data.before)
+        .map(getNestedStaticFiles)
+        .flat()
+        .forEach(file => staticFilesSource.delete(file))
     }
 
     const changesByFileName = await groupChangesByFilename(changes)

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -831,8 +831,11 @@ const buildNaclFilesSource = (
 
       fileChanges
         .filter(isModificationChange)
-        .filter(change => isStaticFile(change.data.after) && isStaticFile(change.data.before))
-        .filter(change => change.data.after.filepath !== change.data.before.filepath)
+        .filter(change => isStaticFile(change.data.before))
+        .filter(change => (
+          (isStaticFile(change.data.after) && change.data.before.filepath !== change.data.after.filepath)
+          || !isStaticFile(change.data.after)
+        ))
         .map(change => change.data.before)
         .map(getNestedStaticFiles)
         .flat()

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
@@ -405,6 +405,7 @@ describe('Nacl Files Source', () => {
   describe('removing static files', () => {
     const elemID = new ElemID('salesforce', 'new_elem')
     const filepath = 'to/the/superbowl'
+    const afterFilePath = 'to/the/superbowl2'
     const sfile = new StaticFile({ filepath, hash: 'XI' })
     let src: NaclFilesSource
     beforeEach(async () => {
@@ -426,6 +427,36 @@ describe('Nacl Files Source', () => {
       } as DetailedChange
       await src.updateNaclFiles([change])
       expect(mockedStaticFilesSource.delete).toHaveBeenCalledWith(sfile)
+    })
+    it('should delete before file when path is changed', async () => {
+      const change = {
+        id: elemID,
+        action: 'modify',
+        data: { before: sfile, after: new StaticFile({ filepath: afterFilePath, hash: 'XI' }) },
+        path: ['new', 'file'],
+      } as DetailedChange
+      await src.updateNaclFiles([change])
+      expect(mockedStaticFilesSource.delete).toHaveBeenCalledWith(sfile)
+    })
+    it('should delete before file when it is no longer a static file', async () => {
+      const change = {
+        id: elemID,
+        action: 'modify',
+        data: { before: sfile, after: '' },
+        path: ['new', 'file'],
+      } as DetailedChange
+      await src.updateNaclFiles([change])
+      expect(mockedStaticFilesSource.delete).toHaveBeenCalledWith(sfile)
+    })
+    it('should not delete static file if the change is only in content and not in path', async () => {
+      const change = {
+        id: elemID,
+        action: 'modify',
+        data: { before: sfile, after: new StaticFile({ filepath, hash: 'XII' }) },
+        path: ['new', 'file'],
+      } as DetailedChange
+      await src.updateNaclFiles([change])
+      expect(mockedStaticFilesSource.delete).toHaveBeenCalledTimes(0)
     })
   })
 


### PR DESCRIPTION
update static file path.
until now, static files whose path changed but content didn't would remain in their old location, after this PR,  static files whose path changed will be created in their new location and the old files will be deleted.

---

_Additional context for reviewer_

---
_Release Notes_: 
core:
* static file path changes will be referred to as a change in fetch

---
_User Notifications_: 
* some static files might move location
