### PR TITLE
SALTO-4325 reduce details in HTTPError

### DIFF
--- a/packages/adapter-components/src/client/http_client.ts
+++ b/packages/adapter-components/src/client/http_client.ts
@@ -241,7 +241,7 @@ export abstract class AdapterHTTPClient<
         throw new TimeoutError(`Failed to ${method} ${url} with error: ${e}`)
       }
       if (e.response !== undefined) {
-        throw new HTTPError(`Failed to ${method} ${url} with error: ${e}`, e.response)
+        throw new HTTPError(`Failed to ${method} ${url} with error: ${e}`, _.pick(e.response, ['status', 'data']))
       }
       throw new Error(`Failed to ${method} ${url} with error: ${e}`)
     }


### PR DESCRIPTION
Only include needed details in `HTTPError`s.

---
_Release Notes_: 
None

---
_User Notifications_: 
None