### PR TITLE
SALTO-5821: Get fetch warning for 401

### DIFF
--- a/packages/adapter-components/src/elements/ducktype/transformer.ts
+++ b/packages/adapter-components/src/elements/ducktype/transformer.ts
@@ -403,7 +403,7 @@ export const getAllElements = async ({
           })
           return { elements: [], errors: [] }
         }
-        if (e.response?.status === 403) {
+        if (e.response?.status === 403 || e.response?.status === 401) {
           const newError: SaltoError = {
             message: `Salto could not access the ${args.typeName} resource. Elements from that type were not fetched. Please make sure that this type is enabled in your service, and that the supplied user credentials have sufficient permissions to access this data. You can also exclude this data from Salto's fetches by changing the environment configuration. Learn more at https://help.salto.io/en/articles/6947061-salto-could-not-access-the-resource`,
             severity: 'Warning',

--- a/packages/adapter-components/src/elements/swagger/instance_elements.ts
+++ b/packages/adapter-components/src/elements/swagger/instance_elements.ts
@@ -467,7 +467,7 @@ const getInstancesForType = async (params: GetEntriesParams): Promise<InstanceEl
       || e instanceof InvalidTypeConfig
       || e instanceof TimeoutError
       || e instanceof InvalidSingletonType
-      || (e instanceof HTTPError && e.response.status === 403)) {
+      || (e instanceof HTTPError && (e.response.status === 403 || e.response.status === 401))) {
       throw e
     }
     return []
@@ -528,7 +528,7 @@ export const getAllInstances = async ({
           errors: [],
         }
       } catch (e) {
-        if (e.response?.status === 403) {
+        if (e.response?.status === 403 || e.response?.status === 401) {
           const newError: SaltoError = {
             message: `Salto could not access the ${args.typeName} resource. Elements from that type were not fetched. Please make sure that this type is enabled in your service, and that the supplied user credentials have sufficient permissions to access this data. You can also exclude this data from Salto's fetches by changing the environment configuration. Learn more at https://help.salto.io/en/articles/6947061-salto-could-not-access-the-resource`,
             severity: 'Warning',

--- a/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
@@ -72,6 +72,12 @@ describe('swagger_instance_elements', () => {
           name: { refType: BuiltinTypes.STRING },
         },
       })
+      const Fail401 = new ObjectType({
+        elemID: new ElemID(ADAPTER_NAME, 'Fail401'),
+        fields: {
+          id: { refType: BuiltinTypes.STRING },
+        },
+      })
       const Singleton = new ObjectType({
         elemID: new ElemID(ADAPTER_NAME, 'Singleton'),
         fields: {
@@ -85,6 +91,7 @@ describe('swagger_instance_elements', () => {
         Food,
         Status,
         Fail,
+        Fail401,
         Singleton,
       }
     }
@@ -139,7 +146,10 @@ describe('swagger_instance_elements', () => {
           if (getParams.url === '/fail') {
             throw new HTTPError('failed', { data: {}, status: 403 })
           }
-        }
+          if (getParams.url === '/fail401') {
+            throw new HTTPError('401', { data: {}, status: 401 })
+          }
+        },
       )
     })
 
@@ -147,7 +157,7 @@ describe('swagger_instance_elements', () => {
       jest.clearAllMocks()
     })
 
-    it('should return an error on 403', async () => {
+    it('should return an error on 403 or 401', async () => {
       const objectTypes = generateObjectTypes()
       const res = await getAllInstances({
         paginator: mockPaginator,
@@ -166,16 +176,22 @@ describe('swagger_instance_elements', () => {
                 idFields: ['name'],
               },
             },
+            Fail401: {
+              request: {
+                url: '/fail401',
+              },
+            },
           },
         },
         fetchQuery: createElementQuery({
           include: [
-            { type: 'Fail' },
+            { type: '.*' },
           ],
           exclude: [],
         }),
         supportedTypes: {
           Fail: ['Fail'],
+          Fail401: ['Fail401'],
         },
         objectTypes,
         computeGetArgs: simpleGetArgs,
@@ -185,6 +201,10 @@ describe('swagger_instance_elements', () => {
         {
           severity: 'Warning',
           message: "Salto could not access the Fail resource. Elements from that type were not fetched. Please make sure that this type is enabled in your service, and that the supplied user credentials have sufficient permissions to access this data. You can also exclude this data from Salto's fetches by changing the environment configuration. Learn more at https://help.salto.io/en/articles/6947061-salto-could-not-access-the-resource",
+        },
+        {
+          severity: 'Warning',
+          message: "Salto could not access the Fail401 resource. Elements from that type were not fetched. Please make sure that this type is enabled in your service, and that the supplied user credentials have sufficient permissions to access this data. You can also exclude this data from Salto's fetches by changing the environment configuration. Learn more at https://help.salto.io/en/articles/6947061-salto-could-not-access-the-resource",
         },
       ])
     })

--- a/packages/okta-adapter/e2e_test/adapter.test.ts
+++ b/packages/okta-adapter/e2e_test/adapter.test.ts
@@ -275,6 +275,7 @@ describe('Okta adapter E2E', () => {
       })
       elements = fetchResult.elements
       expect(fetchResult.errors).toHaveLength(1)
+      // The feature is disabled in our account
       expect(fetchResult.errors).toEqual([
         {
           severity: 'Warning',

--- a/packages/okta-adapter/e2e_test/adapter.test.ts
+++ b/packages/okta-adapter/e2e_test/adapter.test.ts
@@ -274,7 +274,13 @@ describe('Okta adapter E2E', () => {
           { reportProgress: () => null },
       })
       elements = fetchResult.elements
-      expect(fetchResult.errors).toHaveLength(0)
+      expect(fetchResult.errors).toHaveLength(1)
+      expect(fetchResult.errors).toEqual([
+        {
+          severity: 'Warning',
+          message: "Salto could not access the api__v1__mappings resource. Elements from that type were not fetched. Please make sure that this type is enabled in your service, and that the supplied user credentials have sufficient permissions to access this data. You can also exclude this data from Salto's fetches by changing the environment configuration. Learn more at https://help.salto.io/en/articles/6947061-salto-could-not-access-the-resource",
+        },
+      ])
       adapterAttr = realAdapter(
         { credentials: credLease.value,
           elementsSource: buildElementsSourceFromElements(elements) },


### PR DESCRIPTION
Get fetch warning for 401

---

Fix some inconsistency in handling 401 on simple adapters, the user will now get a fetch warning

---
_Release Notes_: 

_Zendesk adapter_:
- On 401 error, the user will get fetch warning instead of fetch failure

_Jira adapter_:
- On 401 error, the user will get fetch warning

_Okta adapter_:
- On 401 error, the user will get fetch warning instead of fetch failure

_Workato adapter_:
- On 401 error, the user will get fetch warning instead of fetch failure

_Zuora adapter_:
- On 401 error, the user will get fetch warning

_Stripe adapter_:
- On 401 error, the user will get fetch warning

---
_User Notifications_: 
None