### PR TITLE
SAAS-7820 - fixed naming of namespace

### DIFF
--- a/packages/workspace/src/workspace/reference_indexes.ts
+++ b/packages/workspace/src/workspace/reference_indexes.ts
@@ -35,7 +35,7 @@ import { getAllElementsChanges } from './index_utils'
 import { RemoteMap, RemoteMapEntry } from './remote_map'
 
 const log = logger(module)
-export const REFERENCE_INDEXES_VERSION = 3
+export const REFERENCE_INDEXES_VERSION = 4
 export const REFERENCE_INDEXES_KEY = 'reference_indexes'
 
 type ChangeReferences = {

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -445,7 +445,7 @@ export const loadWorkspace = async (
             persistent,
           }),
           referenceTargets: await remoteMapCreator<collections.treeMap.TreeMap<ElemID>>({
-            namespace: getRemoteMapNamespace('referenceTargetsTree', envName),
+            namespace: getRemoteMapNamespace('referenceTargets', envName),
             serialize: serializeReferenceTree,
             deserialize: deserializeReferenceTree,
             persistent,


### PR DESCRIPTION
Returned the namespace of referenceTargets to the orignal

---

Changing the name was a mistake and a bug that should be fixed

---
_Release Notes_: 
None

---
_User Notifications_: 
None