### PR TITLE
SALTO-4202: Improve SharePermissions filter's performance

### DIFF
--- a/packages/jira-adapter/src/constants.ts
+++ b/packages/jira-adapter/src/constants.ts
@@ -87,5 +87,6 @@ export const ISSUE_LINK_TYPE_NAME = 'IssueLinkType'
 export const USERS_TYPE_NAME = 'Users'
 export const USERS_INSTANCE_NAME = 'users'
 export const MAIL_LIST_TYPE_NAME = 'MailList'
+export const FILTER_TYPE_NAME = 'Filter'
 // almost constant functions
 export const fetchFailedWarnings = (name :string):string => `Salto could not access the ${name} resource. Elements from that type were not fetched. Please make sure that this type is enabled in your service, and that the supplied user credentials have sufficient permissions to access this data. You can also exclude this data from Salto's fetches by changing the environment configuration. Learn more at https://help.salto.io/en/articles/6947061-salto-could-not-access-the-resource`

--- a/packages/jira-adapter/src/filters/share_permission.ts
+++ b/packages/jira-adapter/src/filters/share_permission.ts
@@ -24,6 +24,7 @@ import { setFieldDeploymentAnnotations } from '../utils'
 const log = logger(module)
 
 const SHARE_PERMISSION_FIELDS = ['sharePermissions', 'editPermissions']
+const SHARE_PERMISSION_TYPES = [DASHBOARD_TYPE, FILTER_TYPE_NAME]
 
 const transformType = (elements: Element[]): void => {
   const sharePermissionType = elements.filter(isObjectType).find((type => type.elemID.typeName === 'SharePermission'))
@@ -83,8 +84,7 @@ const transformSharedPermissions = (instance: InstanceElement, func: (sharedPerm
 }
 
 const isSharePermissionType = (instance: InstanceElement): boolean =>
-  instance.elemID.typeName === DASHBOARD_TYPE
-  || instance.elemID.typeName === FILTER_TYPE_NAME
+  SHARE_PERMISSION_TYPES.includes(instance.elemID.typeName)
 
 /**
  * Change SharePermission structure to fit the deployment endpoint

--- a/packages/jira-adapter/test/filters/share_permission.test.ts
+++ b/packages/jira-adapter/test/filters/share_permission.test.ts
@@ -13,17 +13,18 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, ElemID, Field, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import { BuiltinTypes, ElemID, InstanceElement, ListType, ObjectType, toChange } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { JIRA } from '../../src/constants'
+import { FILTER_TYPE_NAME, JIRA } from '../../src/constants'
 import sharePermissionFilter from '../../src/filters/share_permission'
-import { getFilterParams } from '../utils'
+import { createEmptyType, getFilterParams } from '../utils'
 
 describe('sharePermissionFilter', () => {
   let filter: filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
+  let instances: InstanceElement[]
   let instance: InstanceElement
-  let type: ObjectType
+  let dashboardType: ObjectType
   let sharePermissionType: ObjectType
   beforeEach(async () => {
     sharePermissionType = new ObjectType({
@@ -34,82 +35,104 @@ describe('sharePermissionFilter', () => {
       },
     })
 
-    type = new ObjectType({
-      elemID: new ElemID(JIRA, 'someType'),
-      fields: { permissions: { refType: sharePermissionType } },
+    dashboardType = new ObjectType({
+      elemID: new ElemID(JIRA, 'Dashboard'),
+      fields: { sharePermissions: { refType: new ListType(sharePermissionType) } },
     })
+
+    const filterType = createEmptyType(FILTER_TYPE_NAME)
 
     instance = new InstanceElement(
       'instance',
-      type,
+      dashboardType,
       {
-        permissions: {
+        sharePermissions: [{
           type: 'loggedin',
-        },
+        }],
       }
     )
 
-    const elementsSource = buildElementsSourceFromElements([type])
+    const instance2 = new InstanceElement(
+      'instance2',
+      filterType,
+      {
+        sharePermissions: [{
+          type: 'loggedin',
+        },
+        {
+          type: 'loggedin',
+        }],
+        editPermissions: [{
+          type: 'loggedin',
+        },
+        {
+          type: 'loggedin',
+        },
+        {
+          type: 'loggedin',
+        }],
+      }
+    )
+
+    instances = [instance, instance2]
+
+    const elementsSource = buildElementsSourceFromElements([dashboardType])
     filter = sharePermissionFilter(getFilterParams({ elementsSource })) as typeof filter
   })
 
   it('should replace SharePermission.type from "loggedin" to "authenticated"', async () => {
-    await filter.onFetch([instance])
-    expect(instance.value).toEqual({ permissions: { type: 'authenticated' } })
+    await filter.onFetch(instances)
+    expect(instance.value).toEqual({ sharePermissions: [{ type: 'authenticated' }] })
+    expect(instances[1].value.sharePermissions).toEqual([{ type: 'authenticated' }, { type: 'authenticated' }])
+    expect(instances[1].value.editPermissions).toEqual([{ type: 'authenticated' }, { type: 'authenticated' }, { type: 'authenticated' }])
   })
   it('should not replace when SharePermission.type is not "loggedin"', async () => {
-    instance.value.permissions.type = 'notLoggedIn'
+    instance.value.sharePermissions[0].type = 'notLoggedIn'
     await filter.onFetch([instance])
-    expect(instance.value).toEqual({ permissions: { type: 'notLoggedIn' } })
-  })
-
-  it('should not replace when field type isnt SharePermission', async () => {
-    type.fields.permissions = new Field(type, 'permissions', BuiltinTypes.UNKNOWN)
-    await filter.onFetch([instance])
-    expect(instance.value).toEqual({ permissions: { type: 'loggedin' } })
+    expect(instance.value).toEqual({ sharePermissions: [{ type: 'notLoggedIn' }] })
   })
 
   it('should not replace when field name isnt "type"', async () => {
-    instance.value.permissions.type = 'notLoggedIn'
-    instance.value.permissions.other = 'loggedIn'
+    instance.value.sharePermissions[0].type = 'notLoggedIn'
+    instance.value.sharePermissions[0].other = 'loggedIn'
     await filter.onFetch([instance])
-    expect(instance.value).toEqual({ permissions: {
+    expect(instance.value).toEqual({ sharePermissions: [{
       type: 'notLoggedIn',
       other: 'loggedIn',
-    } })
+    }] })
   })
 
   it('should remove everything but the id in project', async () => {
-    instance.value.permissions.type = 'project'
-    instance.value.permissions.project = {
+    instance.value.sharePermissions[0].type = 'project'
+    instance.value.sharePermissions[0].project = {
       id: 1,
       other: 2,
     }
     await filter.onFetch([instance])
     expect(instance.value).toEqual({
-      permissions: {
+      sharePermissions: [{
         type: 'project',
         project: {
           id: 1,
         },
-      },
+      }],
     })
   })
 
   it('should remove everything but the id in projectRole', async () => {
-    instance.value.permissions.type = 'role'
-    instance.value.permissions.role = {
+    instance.value.sharePermissions[0].type = 'role'
+    instance.value.sharePermissions[0].role = {
       id: 1,
       other: 2,
     }
     await filter.onFetch([instance])
     expect(instance.value).toEqual({
-      permissions: {
+      sharePermissions: [{
         type: 'role',
         role: {
           id: 1,
         },
-      },
+      }],
     })
   })
 
@@ -122,65 +145,139 @@ describe('sharePermissionFilter', () => {
   })
 
   it('if there is role should change type to projectRole', async () => {
-    instance.value.permissions.type = 'project'
-    instance.value.permissions.role = {
+    instance.value.sharePermissions[0].type = 'project'
+    instance.value.sharePermissions[0].role = {
       id: 1,
     }
-    await filter.preDeploy([toChange({ after: instance })])
+    instances[1].value.sharePermissions[0].type = 'project'
+    instances[1].value.sharePermissions[0].role = {
+      id: 2,
+    }
+    instances[1].value.sharePermissions[1].type = 'project'
+    instances[1].value.sharePermissions[1].role = {
+      id: 3,
+    }
+    instances[1].value.editPermissions[0].type = 'project'
+    instances[1].value.editPermissions[0].role = {
+      id: 4,
+    }
+    instances[1].value.editPermissions[1].type = 'project'
+    instances[1].value.editPermissions[1].role = {
+      id: 5,
+    }
+    instances[1].value.editPermissions[2].type = 'project'
+    instances[1].value.editPermissions[2].role = {
+      id: 6,
+    }
+    await filter.preDeploy([toChange({ after: instance }), toChange({ before: instance, after: instances[1] })])
     expect(instance.value).toEqual({
-      permissions: {
+      sharePermissions: [{
         type: 'projectRole',
         role: {
           id: 1,
         },
+      }],
+    })
+    expect(instances[1].value).toEqual({
+      sharePermissions: [{
+        type: 'projectRole',
+        role: {
+          id: 2,
+        },
       },
+      {
+        type: 'projectRole',
+        role: {
+          id: 3,
+        },
+      }],
+      editPermissions: [{
+        type: 'projectRole',
+        role: {
+          id: 4,
+        },
+      },
+      {
+        type: 'projectRole',
+        role: {
+          id: 5,
+        },
+      },
+      {
+        type: 'projectRole',
+        role: {
+          id: 6,
+        },
+      }],
     })
   })
 
   it('Should work for unresolved type', async () => {
     delete instance.refType.type
-    instance.value.permissions.type = 'project'
-    instance.value.permissions.role = {
+    instance.value.sharePermissions[0].type = 'project'
+    instance.value.sharePermissions[0].role = {
       id: 1,
     }
     await filter.preDeploy([toChange({ after: instance })])
     expect(instance.value).toEqual({
-      permissions: {
+      sharePermissions: [{
         type: 'projectRole',
         role: {
           id: 1,
         },
-      },
+      }],
     })
   })
 
   it('if there is no role should not change type to projectRole', async () => {
-    instance.value.permissions.type = 'project'
+    instance.value.sharePermissions[0].type = 'project'
     await filter.preDeploy([toChange({ after: instance })])
     expect(instance.value).toEqual({
-      permissions: {
+      sharePermissions: [{
         type: 'project',
-      },
+      }],
     })
   })
 
   it('should change projectRole to project on deploy', async () => {
-    instance.value.permissions.type = 'projectRole'
-    await filter.onDeploy([toChange({ after: instance })])
+    instance.value.sharePermissions[0].type = 'projectRole'
+    instances[1].value.sharePermissions[0].type = 'projectRole'
+    instances[1].value.sharePermissions[1].type = 'projectRole'
+    instances[1].value.editPermissions[0].type = 'projectRole'
+    instances[1].value.editPermissions[1].type = 'projectRole'
+    instances[1].value.editPermissions[2].type = 'projectRole'
+    await filter.onDeploy([toChange({ after: instance }), toChange({ before: instance, after: instances[1] })])
     expect(instance.value).toEqual({
-      permissions: {
+      sharePermissions: [{
+        type: 'project',
+      }],
+    })
+    expect(instances[1].value).toEqual({
+      sharePermissions: [{
         type: 'project',
       },
+      {
+        type: 'project',
+      }],
+      editPermissions: [{
+        type: 'project',
+      },
+      {
+        type: 'project',
+      },
+      {
+        type: 'project',
+      }],
     })
   })
 
   it('should not change non projectRole types on deploy', async () => {
-    instance.value.permissions.type = 'user'
+    instance.value.sharePermissions[0].type = 'user'
     await filter.onDeploy([toChange({ after: instance })])
     expect(instance.value).toEqual({
-      permissions: {
+      sharePermissions: [{
         type: 'user',
-      },
+      }],
     })
   })
 })


### PR DESCRIPTION
Improved the performance of Share Permission Filter
---

The existing filter was one of the most time-consuming.
There was no need for a transformValue, the share permissions exist on two types and into static locations

---
_Release Notes_: 
Jira Adatper:
* Improved fetch performance

---
_User Notifications_: 
None
