### PR TITLE
Removed group from e2e due to Jira bug

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/index.ts
@@ -117,13 +117,13 @@ export const createInstances = (fetchedElements: Element[], isDataCenter: boolea
     createWebhookValues(randomString, fetchedElements),
   )
 
-  const group = new InstanceElement(
-    randomString,
-    findType('Group', fetchedElements),
-    {
-      name: randomString,
-    },
-  )
+  // const group = new InstanceElement(
+  //   randomString,
+  //   findType('Group', fetchedElements),
+  //   {
+  //     name: randomString,
+  //   },
+  // )
 
   const status = new InstanceElement(
     randomString.toLowerCase(),
@@ -148,7 +148,7 @@ export const createInstances = (fetchedElements: Element[], isDataCenter: boolea
     [issueLinkType],
     [projectRole],
     [webhook],
-    [group],
+    // [group],
     [status],
   ]
 }


### PR DESCRIPTION
Deploying groups now returns 500, looks like a jira bug.
For now to unblock the CI I removed it from the e2e


---
_Release Notes_: 
None

---
_User Notifications_: 
None
