### PR TITLE
SALTO-4333: Added group back to e2e

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/index.ts
@@ -117,13 +117,13 @@ export const createInstances = (fetchedElements: Element[], isDataCenter: boolea
     createWebhookValues(randomString, fetchedElements),
   )
 
-  // const group = new InstanceElement(
-  //   randomString,
-  //   findType('Group', fetchedElements),
-  //   {
-  //     name: randomString,
-  //   },
-  // )
+  const group = new InstanceElement(
+    randomString,
+    findType('Group', fetchedElements),
+    {
+      name: randomString,
+    },
+  )
 
   const status = new InstanceElement(
     randomString.toLowerCase(),
@@ -148,7 +148,7 @@ export const createInstances = (fetchedElements: Element[], isDataCenter: boolea
     [issueLinkType],
     [projectRole],
     [webhook],
-    // [group],
+    [group],
     [status],
   ]
 }


### PR DESCRIPTION
This reverts commit 5e5826df45a4924cd47edbfce60c0c956838c112.

We removed the group from the e2e due to a Jira bug, now it seems to work

---
_Release Notes_: 
None

---
_User Notifications_: 
None