### PR TITLE
SALTO-4333: Removed group from e2e due to Jira bug

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/index.ts
@@ -117,13 +117,13 @@ export const createInstances = (fetchedElements: Element[], isDataCenter: boolea
     createWebhookValues(randomString, fetchedElements),
   )
 
-  const group = new InstanceElement(
-    randomString,
-    findType('Group', fetchedElements),
-    {
-      name: randomString,
-    },
-  )
+  // const group = new InstanceElement(
+  //   randomString,
+  //   findType('Group', fetchedElements),
+  //   {
+  //     name: randomString,
+  //   },
+  // )
 
   const status = new InstanceElement(
     randomString.toLowerCase(),
@@ -148,7 +148,7 @@ export const createInstances = (fetchedElements: Element[], isDataCenter: boolea
     [issueLinkType],
     [projectRole],
     [webhook],
-    [group],
+    // [group],
     [status],
   ]
 }


### PR DESCRIPTION
Removing group from e2e until the Jira related incident will be over

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
