### PR TITLE
SALTO-4337: Increase default value for the number of concurrent requests in Okta

### DIFF
--- a/packages/okta-adapter/src/client/client.ts
+++ b/packages/okta-adapter/src/client/client.ts
@@ -29,8 +29,7 @@ const log = logger(module)
 
 const DEFAULT_MAX_CONCURRENT_API_REQUESTS: Required<clientUtils.ClientRateLimitConfig> = {
   total: RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,
-  // TODO SALTO-2649: add better handling for rate limits
-  get: 2,
+  get: 15,
   deploy: 2,
 }
 const DEFAULT_MAX_REQUESTS_PER_MINUTE = 700
@@ -55,9 +54,7 @@ export default class OktaClient extends clientUtils.AdapterHTTPClient<
       {
         pageSize: DEFAULT_PAGE_SIZE,
         rateLimit: DEFAULT_MAX_CONCURRENT_API_REQUESTS,
-        // TODO SALTO-2649: add better handling for rate limits
         maxRequestsPerMinute: DEFAULT_MAX_REQUESTS_PER_MINUTE,
-        // wait for 10s before trying again, change after SALTO-2649
         retry: { ...DEFAULT_RETRY_OPTS, retryDelay: 10000 },
       }
     )


### PR DESCRIPTION
Increase default value for the number of concurrent requests in Okta

---

Trying to make Okta fetch a little faster
I measured first fetch times (after workspace clean) with both configs
Fetch times improved a little but we did get more 429 (rate limit) with retries 

| test num| Before  | After |
|---| -------- |------- |
|1| 102700  | 77565 |
|2| 91408  |  76167  |
|3| 90754 | 78679 |

Update: 
-  When changing number of concurrent requests to be 14, we don't get 429 anymore
- Changed number of concurrent requests to be 34 (1 beneath the limit okta have on their website for the most simple paid accounts)

---
_Release Notes_: 
None

---
_User Notifications_: 
None