### PR TITLE
SALTO-4338 Support adding alias to ObjectTypes

### DIFF
--- a/packages/adapter-components/src/add_alias.ts
+++ b/packages/adapter-components/src/add_alias.ts
@@ -14,9 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { InstanceElement, CORE_ANNOTATIONS,
-  ElemID, INSTANCE_ANNOTATIONS,
-  isReferenceExpression } from '@salto-io/adapter-api'
+import { InstanceElement, CORE_ANNOTATIONS, ElemID, INSTANCE_ANNOTATIONS, isReferenceExpression, ObjectType, isInstanceElement, Value } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 
 const log = logger(module)
@@ -34,98 +32,101 @@ export type AliasData = {
   separator?: string
 }
 
-const isInstanceAnnotation = (field: string): boolean =>
-  Object.values(INSTANCE_ANNOTATIONS).includes(field?.split(ElemID.NAMESPACE_SEPARATOR)[0])
+type SupportedElement = ObjectType | InstanceElement
 
-const isValidAlias = (aliasParts: (string | undefined)[], instance: InstanceElement): boolean =>
+const isInstanceAnnotation = (field: string): boolean =>
+  Object.values(INSTANCE_ANNOTATIONS).includes(field.split(ElemID.NAMESPACE_SEPARATOR)[0])
+
+const isValidAlias = (aliasParts: (string | undefined)[], element: SupportedElement): boolean =>
   aliasParts.every((val, index) => {
     if (val === undefined) {
-      log.debug(`for instance ${instance.elemID.getFullName()}, component number ${index} in the alias map resulted in undefined`)
+      log.debug(`for element ${element.elemID.getFullName()}, component number ${index} in the alias map resulted in undefined`)
       return false
     }
     return true
   })
 
-const getFieldVal = ({ instance, component, elementPart, instById }:{
-  instance: InstanceElement
+const getFieldValue = (element: SupportedElement, fieldName: string): Value => (
+  !isInstanceElement(element) || isInstanceAnnotation(fieldName)
+    ? _.get(element.annotations, fieldName)
+    : _.get(element.value, fieldName)
+)
+
+const getAliasFromField = ({ element, component, elementsById }:{
+  element: SupportedElement
   component: AliasComponent
-  elementPart: 'value'|'annotations'
-  instById: Record<string, InstanceElement>
+  elementsById: Record<string, SupportedElement>
 }): string | undefined => {
-  const fieldValue = _.get(instance[elementPart], component.fieldName)
-  if (component.referenceFieldName === undefined) {
+  const { fieldName, referenceFieldName } = component
+
+  const fieldValue = getFieldValue(element, fieldName)
+  if (referenceFieldName === undefined) {
     return _.isString(fieldValue) ? fieldValue : undefined
   }
   if (!isReferenceExpression(fieldValue)) {
-    log.error(`${component.fieldName} is treated as a reference expression but it is not`)
+    log.error(`${fieldName} is treated as a reference expression but it is not`)
     return undefined
   }
-  const referencedInstance = instById[fieldValue.elemID.getFullName()]
-  if (referencedInstance === undefined) {
-    log.error(`could not find ${fieldValue.elemID.getFullName()} in instById`)
+  const referencedElement = elementsById[fieldValue.elemID.getFullName()]
+  if (referencedElement === undefined) {
+    log.error(`could not find ${fieldValue.elemID.getFullName()} in elementById`)
     return undefined
   }
-  return isInstanceAnnotation(component.referenceFieldName)
-    ? _.get(referencedInstance.annotations, component.referenceFieldName)
-    : _.get(referencedInstance.value, component.referenceFieldName)
+  const referencedFieldValue = getFieldValue(referencedElement, referenceFieldName)
+  return _.isString(referencedFieldValue) ? referencedFieldValue : undefined
 }
 
-const isConstantComponent = (component: AliasComponent | ConstantComponent): component is ConstantComponent => 'constant' in component
+const isConstantComponent = (
+  component: AliasComponent | ConstantComponent
+): component is ConstantComponent => 'constant' in component
 
-const isAliasComponent = (component: AliasComponent | ConstantComponent): component is AliasComponent => 'fieldName' in component
-
-
-const calculateAlias = ({ instance, instById, aliasMap }: {
-  instance: InstanceElement
-  instById: Record<string, InstanceElement>
-  aliasMap: Record<string, AliasData>
+const calculateAlias = ({ element, elementsById, aliasData }: {
+  element: SupportedElement
+  elementsById: Record<string, SupportedElement>
+  aliasData: AliasData
 }): string | undefined => {
-  const currentType = instance.elemID.typeName
-  const { aliasComponents } = aliasMap[currentType]
-  const separator = aliasMap[currentType].separator ?? ' '
-  const aliasParts = aliasComponents
-    .map(component => {
-      if (isConstantComponent(component)) {
-        return component.constant
-      }
-      if (isAliasComponent(component) && isInstanceAnnotation(component.fieldName)) {
-        return getFieldVal({ instance, component, elementPart: 'annotations', instById })
-      }
-      return getFieldVal({ instance, component, elementPart: 'value', instById })
-    })
-  if (!isValidAlias(aliasParts, instance)) {
+  const { aliasComponents, separator = ' ' } = aliasData
+  const aliasParts = aliasComponents.map(component => (
+    isConstantComponent(component)
+      ? component.constant
+      : getAliasFromField({ element, component, elementsById })
+  ))
+  if (!isValidAlias(aliasParts, element)) {
     return undefined
   }
   return aliasParts.join(separator)
 }
 
 
-export const addAliasToInstance = ({ instances, aliasMap, secondIterationTypeNames }: {
-  instances: InstanceElement[]
+export const addAliasToElements = ({
+  elementsMap,
+  aliasMap,
+  secondIterationGroupNames = [],
+}: {
+  elementsMap: Record<string, SupportedElement[]>
   aliasMap: Record<string, AliasData>
-  secondIterationTypeNames: string[]
+  secondIterationGroupNames?: string[]
 }): void => {
-  const elementById = _.keyBy(instances, elem => elem.elemID.getFullName())
-  const relevantInstancesByType = _.groupBy(
-    instances.filter(inst => aliasMap[inst.elemID.typeName] !== undefined),
-    inst => inst.elemID.typeName
-  )
+  const allElements = Object.values(elementsMap).flat()
+  const elementsById = _.keyBy(allElements, elem => elem.elemID.getFullName())
+  const relevantElementsMap = _.pick(elementsMap, Object.keys(aliasMap))
 
-  const addAlias = (typeName: string): void => {
-    relevantInstancesByType[typeName].forEach(inst => {
-      const alias = calculateAlias({ instance: inst, instById: elementById, aliasMap })
+  const addAlias = (group: string): void => {
+    const aliasData = aliasMap[group]
+    relevantElementsMap[group].forEach(element => {
+      const alias = calculateAlias({ element, elementsById, aliasData })
       if (alias !== undefined) {
-        inst.annotations[CORE_ANNOTATIONS.ALIAS] = alias
+        element.annotations[CORE_ANNOTATIONS.ALIAS] = alias
       }
     })
   }
-  const [firstIterationTypes, secondIterationTypes] = _.partition(
-    Object.keys(relevantInstancesByType),
-    typeName => !secondIterationTypeNames.includes(typeName)
+  const [firstIterationGroups, secondIterationGroups] = _.partition(
+    Object.keys(relevantElementsMap),
+    group => !secondIterationGroupNames.includes(group)
   )
   // first iteration
-  firstIterationTypes.forEach(addAlias)
+  firstIterationGroups.forEach(addAlias)
 
   // second iteration
-  secondIterationTypes.forEach(addAlias)
+  secondIterationGroups.forEach(addAlias)
 }

--- a/packages/adapter-components/test/add_alias.test.ts
+++ b/packages/adapter-components/test/add_alias.test.ts
@@ -13,16 +13,19 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import _ from 'lodash'
 import {
   CORE_ANNOTATIONS,
   ElemID,
   InstanceElement,
   ObjectType, ReferenceExpression,
 } from '@salto-io/adapter-api'
-import { addAliasToInstance, AliasData } from '../src/add_alias'
+import { addAliasToElements, AliasData } from '../src/add_alias'
 
+const groupByTypeName = (instances: InstanceElement[]): Record<string, InstanceElement[]> =>
+  _.groupBy(instances, instance => instance.elemID.typeName)
 
-describe('addAliasToInstance', () => {
+describe('addAliasToElements', () => {
   const appInstallationTypeName = 'app_installation'
   const dynamicContentItemTypeName = 'dynamic_content_item'
   const dynamicContentItemVariantsTypeName = 'dynamic_content_item__variants'
@@ -31,7 +34,7 @@ describe('addAliasToInstance', () => {
   const categoryOrderTypeName = 'category_order'
   const categoryTranslationTypeName = 'category_translation'
   const ZENDESK = 'zendesk'
-  const secondIterationTypeNames = [
+  const secondIterationGroupNames = [
     dynamicContentItemVariantsTypeName,
     categoryOrderTypeName,
     categoryTranslationTypeName,
@@ -192,10 +195,10 @@ describe('addAliasToInstance', () => {
       categoryTranslationInstance,
       categoryTranslationInstanceInvalid,
     ]
-    addAliasToInstance({
-      instances: elements,
+    addAliasToElements({
+      elementsMap: groupByTypeName(elements),
       aliasMap,
-      secondIterationTypeNames,
+      secondIterationGroupNames,
     })
     expect(elements.map(e => e.annotations[CORE_ANNOTATIONS.ALIAS])).toEqual([
       'app installation name',
@@ -218,10 +221,10 @@ describe('addAliasToInstance', () => {
     const elements = [
       appInstallationInstanceInvalid,
     ]
-    addAliasToInstance({
-      instances: elements,
+    addAliasToElements({
+      elementsMap: groupByTypeName(elements),
       aliasMap,
-      secondIterationTypeNames,
+      secondIterationGroupNames,
     })
     expect(elements.map(e => e.annotations[CORE_ANNOTATIONS.ALIAS])).toEqual([undefined])
   })
@@ -237,10 +240,10 @@ describe('addAliasToInstance', () => {
     const elements = [
       categoryTranslationInstance,
     ]
-    addAliasToInstance({
-      instances: elements,
+    addAliasToElements({
+      elementsMap: groupByTypeName(elements),
       aliasMap,
-      secondIterationTypeNames,
+      secondIterationGroupNames,
     })
     expect(elements.map(e => e.annotations[CORE_ANNOTATIONS.ALIAS])).toEqual([undefined])
   })
@@ -259,10 +262,10 @@ describe('addAliasToInstance', () => {
     const elements = [
       categoryTranslationInstance,
     ]
-    addAliasToInstance({
-      instances: elements,
+    addAliasToElements({
+      elementsMap: groupByTypeName(elements),
       aliasMap,
-      secondIterationTypeNames,
+      secondIterationGroupNames,
     })
     expect(elements.map(e => e.annotations[CORE_ANNOTATIONS.ALIAS])).toEqual([undefined])
   })
@@ -277,11 +280,37 @@ describe('addAliasToInstance', () => {
     const elements = [
       dynamicContentItemInstance,
     ]
-    addAliasToInstance({
-      instances: elements,
+    addAliasToElements({
+      elementsMap: groupByTypeName(elements),
       aliasMap,
-      secondIterationTypeNames,
+      secondIterationGroupNames,
     })
     expect(elements.map(e => e.annotations[CORE_ANNOTATIONS.ALIAS])).toEqual([undefined])
+  })
+  it('should add alias to object type', () => {
+    const customRecordType = new ObjectType({
+      elemID: new ElemID('netsuite', 'customrecord_123'),
+      annotations: {
+        name: 'Custom Record 123',
+      },
+    })
+    const elementsMap = {
+      customrecordtype: [
+        customRecordType,
+      ],
+    }
+    const aliasMapWithType = {
+      customrecordtype: {
+        aliasComponents: [
+          {
+            fieldName: 'name',
+          },
+        ],
+      },
+    }
+    addAliasToElements({
+      elementsMap,
+      aliasMap: aliasMapWithType,
+    })
   })
 })

--- a/packages/jira-adapter/src/filters/add_alias.ts
+++ b/packages/jira-adapter/src/filters/add_alias.ts
@@ -13,11 +13,12 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import _ from 'lodash'
 import {
   Element,
   isInstanceElement,
 } from '@salto-io/adapter-api'
-import { addAliasToInstance, AliasData } from '@salto-io/adapter-components'
+import { addAliasToElements, AliasData } from '@salto-io/adapter-components'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
 
@@ -87,11 +88,14 @@ const filterCreator: FilterCreator = ({ config }) => ({
       log.info('not running addAlias filter as addAlias in the config is false')
       return
     }
-    const instances = elements.filter(isInstanceElement)
-    addAliasToInstance({
-      instances,
+    const elementsMap = _.groupBy(
+      elements.filter(isInstanceElement),
+      instance => instance.elemID.typeName,
+    )
+    addAliasToElements({
+      elementsMap,
       aliasMap,
-      secondIterationTypeNames: SECOND_ITERATION_TYPES,
+      secondIterationGroupNames: SECOND_ITERATION_TYPES,
     })
   },
 })

--- a/packages/zendesk-adapter/src/filters/add_alias.ts
+++ b/packages/zendesk-adapter/src/filters/add_alias.ts
@@ -13,12 +13,13 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import _ from 'lodash'
 import {
   Element,
   isInstanceElement,
 } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
-import { addAliasToInstance, AliasData } from '@salto-io/adapter-components'
+import { addAliasToElements, AliasData } from '@salto-io/adapter-components'
 import { FilterCreator } from '../filter'
 import { DYNAMIC_CONTENT_ITEM_VARIANT_TYPE_NAME } from './dynamic_content'
 import {
@@ -393,11 +394,14 @@ const filterCreator: FilterCreator = ({ config }) => ({
       log.info('not running addAlias filter as addAlias in the config is false')
       return
     }
-    const instances = elements.filter(isInstanceElement)
-    addAliasToInstance({
-      instances,
+    const elementsMap = _.groupBy(
+      elements.filter(isInstanceElement),
+      instance => instance.elemID.typeName,
+    )
+    addAliasToElements({
+      elementsMap,
       aliasMap,
-      secondIterationTypeNames: SECOND_ITERATION_TYPES,
+      secondIterationGroupNames: SECOND_ITERATION_TYPES,
     })
   },
 })


### PR DESCRIPTION
Today the add-alias utility in adapter-components supports only instances. It should support adding aliases to types too, because of the custom record types in netsuite.

---

_Additional context for reviewer_

---
_Release Notes_: 
Adapter Components:
- Support adding alias to ObjectTypes

---
_User Notifications_: 
None