### PR TITLE
Revert "SALTO-4301: add test for normalize path in static file"

### DIFF
--- a/packages/adapter-api/test/values.test.ts
+++ b/packages/adapter-api/test/values.test.ts
@@ -146,12 +146,6 @@ describe('Values', () => {
   })
 
   describe('StaticFile', () => {
-    describe('constructor', () => {
-      it('should normalize the file path', () => {
-        const SFile = new StaticFile({ filepath: 'some//path.ext', content: Buffer.from('ZOMG') })
-        expect(SFile.filepath).toEqual('some/path.ext')
-      })
-    })
     describe('equality (direct)', () => {
       it('equals', () => {
         const fileFunc1 = new StaticFile({ filepath: 'somepath.ext', content: Buffer.from('ZOMG') })
@@ -176,7 +170,7 @@ describe('Values', () => {
         expect(isEqualValues(fileFunc1, fileFunc2, { compareByValue: true })).toEqual(true)
       })
       it('equals with flag false', () => {
-        const fileFunc1 = new StaticFile({ filepath: 'some/path.ext', content: Buffer.from('ZOMG') })
+        const fileFunc1 = new StaticFile({ filepath: 'some//path.ext', content: Buffer.from('ZOMG') })
         const fileFunc2 = new StaticFile({ filepath: 'some/path.ext', content: Buffer.from('ZOMG') })
         expect(isEqualValues(fileFunc1, fileFunc2, { compareByValue: false })).toEqual(true)
       })


### PR DESCRIPTION
Reverts salto-io/salto#4496