### PR TITLE
SALTO-4301 update static file path

### DIFF
--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -32,7 +32,7 @@ export interface Values {
 }
 
 export type CompareOptions = {
-  compareReferencesByValue?: boolean
+  compareByValue?: boolean
 }
 
 export const calculateStaticFileHash = (content: Buffer): string =>
@@ -250,7 +250,7 @@ const shouldCompareByValue = (
   first: Value,
   second: Value,
   options?: CompareOptions,
-): boolean => Boolean(options?.compareReferencesByValue)
+): boolean => Boolean(options?.compareByValue)
   && shouldResolve(first)
   && shouldResolve(second)
 
@@ -261,7 +261,9 @@ export const compareSpecialValues = (
 ): boolean | undefined => {
   if (isStaticFile(first) && isStaticFile(second)) {
     return first.isEqual(second)
-      && (options?.compareReferencesByValue !== true ? first.filepath === second.filepath : true)
+      && (options?.compareByValue
+        ? true
+        : first.filepath === second.filepath)
   }
   if (isReferenceExpression(first) || isReferenceExpression(second)) {
     if (shouldCompareByValue(first, second, options)) {

--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
+import path from 'path'
 import { inspect } from 'util'
 import { hash as hashUtils } from '@salto-io/lowerdash'
 // import { ElementsSource } from '@salto-io/workspace'
@@ -57,7 +58,7 @@ export class StaticFile {
   public readonly encoding: BufferEncoding
   private internalContent?: Buffer
   constructor(params: StaticFileParameters) {
-    this.filepath = params.filepath
+    this.filepath = path.normalize(params.filepath)
     this.encoding = params.encoding ?? DEFAULT_STATIC_FILE_ENCODING
     if (!Buffer.isEncoding(this.encoding)) {
       throw Error(`Cannot create StaticFile at path - ${this.filepath} due to invalid encoding - ${this.encoding}`)

--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -261,6 +261,7 @@ export const compareSpecialValues = (
 ): boolean | undefined => {
   if (isStaticFile(first) && isStaticFile(second)) {
     return first.isEqual(second)
+      && (options?.compareReferencesByValue ? first.filepath === second.filepath : true)
   }
   if (isReferenceExpression(first) || isReferenceExpression(second)) {
     if (shouldCompareByValue(first, second, options)) {

--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -261,7 +261,7 @@ export const compareSpecialValues = (
 ): boolean | undefined => {
   if (isStaticFile(first) && isStaticFile(second)) {
     return first.isEqual(second)
-      && (options?.compareReferencesByValue ? first.filepath === second.filepath : true)
+      && (options?.compareReferencesByValue !== true ? first.filepath === second.filepath : true)
   }
   if (isReferenceExpression(first) || isReferenceExpression(second)) {
     if (shouldCompareByValue(first, second, options)) {

--- a/packages/adapter-api/test/values.test.ts
+++ b/packages/adapter-api/test/values.test.ts
@@ -148,7 +148,7 @@ describe('Values', () => {
   describe('StaticFile', () => {
     describe('equality (direct)', () => {
       it('equals', () => {
-        const fileFunc1 = new StaticFile({ filepath: 'some/path.ext', content: Buffer.from('ZOMG') })
+        const fileFunc1 = new StaticFile({ filepath: 'somepath.ext', content: Buffer.from('ZOMG') })
         const fileFunc2 = new StaticFile({ filepath: 'some/path.ext', content: Buffer.from('ZOMG') })
         expect(fileFunc1.isEqual(fileFunc2)).toEqual(true)
       })
@@ -170,7 +170,7 @@ describe('Values', () => {
         expect(isEqualValues(fileFunc1, fileFunc2, { compareByValue: true })).toEqual(true)
       })
       it('equals with flag false', () => {
-        const fileFunc1 = new StaticFile({ filepath: 'some/path.ext', content: Buffer.from('ZOMG') })
+        const fileFunc1 = new StaticFile({ filepath: 'some//path.ext', content: Buffer.from('ZOMG') })
         const fileFunc2 = new StaticFile({ filepath: 'some/path.ext', content: Buffer.from('ZOMG') })
         expect(isEqualValues(fileFunc1, fileFunc2, { compareByValue: false })).toEqual(true)
       })

--- a/packages/adapter-api/test/values.test.ts
+++ b/packages/adapter-api/test/values.test.ts
@@ -146,6 +146,12 @@ describe('Values', () => {
   })
 
   describe('StaticFile', () => {
+    describe('constructor', () => {
+      it('should normalize the file path', () => {
+        const SFile = new StaticFile({ filepath: 'some//path.ext', content: Buffer.from('ZOMG') })
+        expect(SFile.filepath).toEqual('some/path.ext')
+      })
+    })
     describe('equality (direct)', () => {
       it('equals', () => {
         const fileFunc1 = new StaticFile({ filepath: 'somepath.ext', content: Buffer.from('ZOMG') })
@@ -170,7 +176,7 @@ describe('Values', () => {
         expect(isEqualValues(fileFunc1, fileFunc2, { compareByValue: true })).toEqual(true)
       })
       it('equals with flag false', () => {
-        const fileFunc1 = new StaticFile({ filepath: 'some//path.ext', content: Buffer.from('ZOMG') })
+        const fileFunc1 = new StaticFile({ filepath: 'some/path.ext', content: Buffer.from('ZOMG') })
         const fileFunc2 = new StaticFile({ filepath: 'some/path.ext', content: Buffer.from('ZOMG') })
         expect(isEqualValues(fileFunc1, fileFunc2, { compareByValue: false })).toEqual(true)
       })

--- a/packages/adapter-api/test/values.test.ts
+++ b/packages/adapter-api/test/values.test.ts
@@ -159,6 +159,26 @@ describe('Values', () => {
       })
     })
     describe('equality (via isEqualValues)', () => {
+      it('unequals by path with flag false', () => {
+        const fileFunc1 = new StaticFile({ filepath: 'some/path.txt', content: Buffer.from('ZOMG') })
+        const fileFunc2 = new StaticFile({ filepath: 'some/path.ext', content: Buffer.from('ZOMG') })
+        expect(isEqualValues(fileFunc1, fileFunc2, { compareByValue: false })).toEqual(false)
+      })
+      it('unequals by path with flag true', () => {
+        const fileFunc1 = new StaticFile({ filepath: 'some/path.txt', content: Buffer.from('ZOMG') })
+        const fileFunc2 = new StaticFile({ filepath: 'some/path.ext', content: Buffer.from('ZOMG') })
+        expect(isEqualValues(fileFunc1, fileFunc2, { compareByValue: true })).toEqual(true)
+      })
+      it('equals with flag false', () => {
+        const fileFunc1 = new StaticFile({ filepath: 'some/path.ext', content: Buffer.from('ZOMG') })
+        const fileFunc2 = new StaticFile({ filepath: 'some/path.ext', content: Buffer.from('ZOMG') })
+        expect(isEqualValues(fileFunc1, fileFunc2, { compareByValue: false })).toEqual(true)
+      })
+      it('equals with flag true', () => {
+        const fileFunc1 = new StaticFile({ filepath: 'some/path.ext', content: Buffer.from('ZOMG') })
+        const fileFunc2 = new StaticFile({ filepath: 'some/path.ext', content: Buffer.from('ZOMG') })
+        expect(isEqualValues(fileFunc1, fileFunc2, { compareByValue: true })).toEqual(true)
+      })
       it('equals by hash', () => {
         const fileFunc1 = new StaticFile({ filepath: 'some/path.ext', content: Buffer.from('ZOMG') })
         const fileFunc2 = new StaticFile({ filepath: 'some/path.ext', content: Buffer.from('ZOMG') })
@@ -184,19 +204,19 @@ describe('Values', () => {
       it('References to inner properties with the same should not be equal when compareReferencesByValue is true', () => {
         const ref1 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val1'), 1)
         const ref2 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val1'), 2)
-        expect(isEqualValues(ref1, ref2, { compareReferencesByValue: true })).toBeFalsy()
+        expect(isEqualValues(ref1, ref2, { compareByValue: true })).toBeFalsy()
       })
 
       it('References to inner properties with the same should not be equal', () => {
         const ref1 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val1'), 1)
         const ref2 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val1'), 1)
-        expect(isEqualValues(ref1, ref2, { compareReferencesByValue: true })).toBeTruthy()
+        expect(isEqualValues(ref1, ref2, { compareByValue: true })).toBeTruthy()
       })
 
       it('References to different inner properties with the same value should be equal', () => {
         const ref1 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val1'), 1)
         const ref2 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val2'), 1)
-        expect(isEqualValues(ref1, ref2, { compareReferencesByValue: true })).toBeTruthy()
+        expect(isEqualValues(ref1, ref2, { compareByValue: true })).toBeTruthy()
       })
 
       it('Reference should not be equal to its resolved value by default', () => {
@@ -206,7 +226,7 @@ describe('Values', () => {
 
       it('Reference should not be equal to its resolved value when compareReferencesByValue is true', () => {
         const ref1 = new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'inst', 'val1'), 1)
-        expect(isEqualValues(ref1, 1, { compareReferencesByValue: true })).toBeTruthy()
+        expect(isEqualValues(ref1, 1, { compareByValue: true })).toBeTruthy()
       })
     })
     it('calculate hash', () => {

--- a/packages/adapter-api/test/values.test.ts
+++ b/packages/adapter-api/test/values.test.ts
@@ -154,7 +154,7 @@ describe('Values', () => {
     })
     describe('equality (direct)', () => {
       it('equals', () => {
-        const fileFunc1 = new StaticFile({ filepath: 'somepath.ext', content: Buffer.from('ZOMG') })
+        const fileFunc1 = new StaticFile({ filepath: 'some/path.ext', content: Buffer.from('ZOMG') })
         const fileFunc2 = new StaticFile({ filepath: 'some/path.ext', content: Buffer.from('ZOMG') })
         expect(fileFunc1.isEqual(fileFunc2)).toEqual(true)
       })

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -130,7 +130,7 @@ export const preview = async (
     dependencyChangers: defaultDependencyChangers.concat(getAdapterDependencyChangers(adapters)),
     customGroupIdFunctions: getAdapterChangeGroupIdFunctions(adapters),
     topLevelFilters: [shouldElementBeIncluded(accounts)],
-    compareOptions: { compareReferencesByValue: true },
+    compareOptions: { compareByValue: true },
   })
 }
 

--- a/packages/core/src/core/plan/dependency/reference_dependency.ts
+++ b/packages/core/src/core/plan/dependency/reference_dependency.ts
@@ -42,7 +42,7 @@ const isReferenceValueChanged = (change: Change<ChangeDataType>, refElemId: Elem
   return !isEqualValues(
     resolvePath(beforeTopLevel, refElemId),
     resolvePath(afterTopLevel, refElemId),
-    { compareReferencesByValue: true }
+    { compareByValue: true }
   )
 }
 

--- a/packages/core/src/core/plan/plan.ts
+++ b/packages/core/src/core/plan/plan.ts
@@ -84,7 +84,7 @@ const areReferencesEqual = async (
   secondVisitedReferences: Set<string>,
   compareOptions?: CompareOptions,
 ): Promise<ReferenceCompareReturnValue> => {
-  if (compareOptions?.compareReferencesByValue && shouldResolve(first) && shouldResolve(second)) {
+  if (compareOptions?.compareByValue && shouldResolve(first) && shouldResolve(second)) {
     const shouldResolveFirst = isReferenceExpression(first)
 
     const firstValue = shouldResolveFirst

--- a/packages/core/test/core/plan/plan.test.ts
+++ b/packages/core/test/core/plan/plan.test.ts
@@ -311,7 +311,7 @@ describe('getPlan', () => {
       after: createElementSource(
         [secondInstance1, secondInstance2, secondInstance3, secondInstance4, type, innerType]
       ),
-      compareOptions: { compareReferencesByValue: true },
+      compareOptions: { compareByValue: true },
     })
     expect(plan.size).toBe(0)
   })
@@ -348,7 +348,7 @@ describe('getPlan', () => {
     const plan = await getPlan({
       before: createElementSource([stateInstance, type]),
       after: createElementSource([instance, type, variableObject]),
-      compareOptions: { compareReferencesByValue: true },
+      compareOptions: { compareByValue: true },
     })
     expect(plan.size).toBe(0)
   })
@@ -477,7 +477,7 @@ describe('getPlan', () => {
       const plan = await getPlan({
         before: createElementSource([instanceBefore, referencedBefore, type]),
         after: createElementSource([instanceAfter, referencedAfter, type]),
-        compareOptions: { compareReferencesByValue: true },
+        compareOptions: { compareByValue: true },
       })
       expect(plan.size).toBe(2)
 
@@ -507,7 +507,7 @@ describe('getPlan', () => {
       const plan = await getPlan({
         before: createElementSource([instanceBefore, referencedBefore, type]),
         after: createElementSource([instanceAfter, referencedAfter, type]),
-        compareOptions: { compareReferencesByValue: true },
+        compareOptions: { compareByValue: true },
       })
       expect(plan.size).toBe(1)
 
@@ -549,7 +549,7 @@ describe('getPlan', () => {
       const plan = await getPlan({
         before: createElementSource([instanceBefore, referencedBefore, type]),
         after: createElementSource([instanceAfter, referencedAfter, type]),
-        compareOptions: { compareReferencesByValue: true },
+        compareOptions: { compareByValue: true },
       })
       expect(plan.size).toBe(2)
 
@@ -578,7 +578,7 @@ describe('getPlan', () => {
       const plan = await getPlan({
         before: createElementSource([instanceBefore, referencedBefore, type]),
         after: createElementSource([instanceAfter, referencedAfter, type]),
-        compareOptions: { compareReferencesByValue: true },
+        compareOptions: { compareByValue: true },
       })
       expect(plan.size).toBe(0)
 

--- a/packages/okta-adapter/src/change_validators/group_schema_modify_base_fields.ts
+++ b/packages/okta-adapter/src/change_validators/group_schema_modify_base_fields.ts
@@ -23,7 +23,7 @@ const isBaseFieldModified = (
   const { before, after } = change.data
   const beforeBase = before.value.definitions?.base
   const afterBase = after.value.definitions?.base
-  return !isEqualValues(beforeBase, afterBase, { compareReferencesByValue: true })
+  return !isEqualValues(beforeBase, afterBase, { compareByValue: true })
 }
 
 export const groupSchemaModifyBaseValidator: ChangeValidator = async changes => (

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -586,22 +586,20 @@ const logNaclFileUpdateErrorContext = (
 
 // Returns a list of all static files that existed in the changes 'before' and doesn't exist in the 'after'
 export const getDanglingStaticFiles = (fileChanges: DetailedChange[]): StaticFile[] => {
-  const modificationAndAdditionAfterFilesIds = new Set<string>(
+  // Using filepath is currently enough because all implementations of static files have unique file paths
+  // The only exception is 'buildHistoryStateStaticFilesSource' but it doesn't support deletion at the moment
+  const afterFilePaths = new Set<string>(
     fileChanges
       .filter(isAdditionOrModificationChange)
       .map(change => change.data.after)
-      .map(getNestedStaticFiles)
-      .flat()
+      .flatMap(getNestedStaticFiles)
       .map(file => file.filepath)
   )
   return fileChanges
     .filter(isRemovalOrModificationChange)
     .map(change => change.data.before)
-    .map(getNestedStaticFiles)
-    .flat()
-    // Using filepath is currently enough because all implementations of static files have unique file paths
-    // The only exception is 'buildHistoryStateStaticFilesSource' but it doesn't support deletion at the moment
-    .filter(file => !modificationAndAdditionAfterFilesIds.has(file.filepath))
+    .flatMap(getNestedStaticFiles)
+    .filter(file => !afterFilePaths.has(file.filepath))
 }
 
 const buildNaclFilesSource = (

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -828,6 +828,15 @@ const buildNaclFilesSource = (
         .map(getNestedStaticFiles)
         .flat()
         .forEach(file => staticFilesSource.delete(file))
+
+      fileChanges
+        .filter(isModificationChange)
+        .filter(change => isStaticFile(change.data.after) && isStaticFile(change.data.before))
+        .filter(change => change.data.after.filepath !== change.data.before.filepath)
+        .map(change => change.data.before)
+        .map(getNestedStaticFiles)
+        .flat()
+        .forEach(file => staticFilesSource.delete(file))
     }
 
     const changesByFileName = await groupChangesByFilename(changes)

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -831,8 +831,11 @@ const buildNaclFilesSource = (
 
       fileChanges
         .filter(isModificationChange)
-        .filter(change => isStaticFile(change.data.after) && isStaticFile(change.data.before))
-        .filter(change => change.data.after.filepath !== change.data.before.filepath)
+        .filter(change => isStaticFile(change.data.before))
+        .filter(change => (
+          (isStaticFile(change.data.after) && change.data.before.filepath !== change.data.after.filepath)
+          || !isStaticFile(change.data.after)
+        ))
         .map(change => change.data.before)
         .map(getNestedStaticFiles)
         .flat()

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -16,10 +16,12 @@
 import wu from 'wu'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
-import { Element, ElemID, Value, DetailedChange, isElement, getChangeData, isObjectType,
+import {
+  Element, ElemID, Value, DetailedChange, isElement, getChangeData, isObjectType,
   isInstanceElement, isIndexPathPart, isReferenceExpression, isContainerType, isVariable, Change,
   placeholderReadonlyElementsSource, isModificationChange,
-  isObjectTypeChange, toChange, isAdditionChange, StaticFile, isStaticFile } from '@salto-io/adapter-api'
+  isObjectTypeChange, toChange, isAdditionChange, StaticFile, isStaticFile,
+} from '@salto-io/adapter-api'
 import {
   resolvePath,
   TransformFuncArgs,

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -17,35 +17,58 @@ import wu from 'wu'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import {
-  Element, ElemID, Value, DetailedChange, isElement, getChangeData, isObjectType,
-  isInstanceElement, isIndexPathPart, isReferenceExpression, isContainerType, isVariable, Change,
-  placeholderReadonlyElementsSource, isModificationChange,
-  isObjectTypeChange, toChange, isAdditionChange, StaticFile, isStaticFile, isRemovalChange,
+  Change,
+  DetailedChange,
+  Element,
+  ElemID,
+  isAdditionChange,
+  isAdditionOrModificationChange,
+  isContainerType,
+  isElement,
+  isIndexPathPart,
+  isInstanceElement,
+  isModificationChange,
+  isObjectType,
+  isObjectTypeChange,
+  isReferenceExpression,
+  isRemovalOrModificationChange,
+  isStaticFile,
+  isVariable,
+  placeholderReadonlyElementsSource,
+  StaticFile,
+  toChange,
+  Value,
 } from '@salto-io/adapter-api'
 import {
-  resolvePath,
-  TransformFuncArgs,
-  transformElement,
-  safeJsonStringify,
   getRelevantNamesFromChange,
+  resolvePath,
+  safeJsonStringify,
+  transformElement,
+  TransformFuncArgs,
 } from '@salto-io/adapter-utils'
-import { promises, values, collections } from '@salto-io/lowerdash'
+import { collections, promises, values } from '@salto-io/lowerdash'
 import { AdditionDiff } from '@salto-io/dag'
 import osPath from 'path'
-import { MergeError, mergeElements } from '../../merger'
-import { getChangeLocations, updateNaclFileData, getChangesToUpdate, DetailedChangeWithSource, getNestedStaticFiles } from './nacl_file_update'
-import { parse, SourceRange, ParseResult, SourceMap } from '../../parser'
+import { mergeElements, MergeError } from '../../merger'
+import {
+  DetailedChangeWithSource,
+  getChangeLocations,
+  getChangesToUpdate,
+  getNestedStaticFiles,
+  updateNaclFileData,
+} from './nacl_file_update'
+import { parse, ParseResult, SourceMap, SourceRange } from '../../parser'
 import { ElementsSource, RemoteElementSource } from '../elements_source'
 import { DirectoryStore } from '../dir_store'
 import { Errors } from '../errors'
 import { StaticFilesSource } from '../static_files'
 import { getStaticFilesFunctions } from '../static_files/functions'
 import { buildNewMergedElementsAndErrors, ChangeSet } from './elements_cache'
-import { serialize, deserializeMergeErrors, deserializeSingleElement } from '../../serializer/elements'
+import { deserializeMergeErrors, deserializeSingleElement, serialize } from '../../serializer/elements'
 import { Functions } from '../../parser/functions'
 import { RemoteMap, RemoteMapCreator } from '../remote_map'
 import { ParsedNaclFile } from './parsed_nacl_file'
-import { ParsedNaclFileCache, createParseResultCache } from './parsed_nacl_files_cache'
+import { createParseResultCache, ParsedNaclFileCache } from './parsed_nacl_files_cache'
 import { isInvalidStaticFile } from '../static_files/common'
 
 const { awu } = collections.asynciterable
@@ -563,18 +586,22 @@ const logNaclFileUpdateErrorContext = (
 
 // Returns a list of all static files that existed in the changes 'before' and doesn't exist in the 'after'
 export const getDanglingStaticFiles = (fileChanges: DetailedChange[]): StaticFile[] => {
-  const removalFiles = fileChanges.filter(isRemovalChange).map(getChangeData).map(getNestedStaticFiles).flat()
-
-  const modifications = fileChanges.filter(isModificationChange)
-  const modificationAfterFilesIds = new Set<string>(
-    modifications.map(change => change.data.after).map(getNestedStaticFiles).flat().map(file => file.filepath)
+  const modificationAndAdditionAfterFilesIds = new Set<string>(
+    fileChanges
+      .filter(isAdditionOrModificationChange)
+      .map(change => change.data.after)
+      .map(getNestedStaticFiles)
+      .flat()
+      .map(file => file.filepath)
   )
-  const modificationRemovedFiles = modifications.map(change => change.data.before).map(getNestedStaticFiles).flat()
+  return fileChanges
+    .filter(isRemovalOrModificationChange)
+    .map(change => change.data.before)
+    .map(getNestedStaticFiles)
+    .flat()
     // Using filepath is currently enough because all implementations of static files have unique file paths
     // The only exception is 'buildHistoryStateStaticFilesSource' but it doesn't support deletion at the moment
-    .filter(file => !modificationAfterFilesIds.has(file.filepath))
-
-  return removalFiles.concat(modificationRemovedFiles)
+    .filter(file => !modificationAndAdditionAfterFilesIds.has(file.filepath))
 }
 
 const buildNaclFilesSource = (

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
@@ -17,6 +17,7 @@ import { Element, ElemID, ObjectType, DetailedChange, StaticFile, SaltoError, Va
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { MockInterface, mockFunction } from '@salto-io/test-utils'
+import { detailedCompare } from '@salto-io/adapter-utils'
 import { DirectoryStore } from '../../../src/workspace/dir_store'
 
 import { naclFilesSource, NaclFilesSource } from '../../../src/workspace/nacl_files'
@@ -29,6 +30,7 @@ import { InMemoryRemoteMap, RemoteMapCreator, RemoteMap, CreateRemoteMapParams }
 import { ParsedNaclFile } from '../../../src/workspace/nacl_files/parsed_nacl_file'
 import * as naclFileSourceModule from '../../../src/workspace/nacl_files/nacl_files_source'
 import { mockDirStore as createMockDirStore } from '../../common/nacl_file_store'
+import { getDanglingStaticFiles } from '../../../src/workspace/nacl_files/nacl_files_source'
 
 const { awu } = collections.asynciterable
 
@@ -697,6 +699,48 @@ describe('Nacl Files Source', () => {
       expect(Array.from(res.entries())).toEqual([
         ['salesforce.new_elem', ['file']],
       ])
+    })
+  })
+  describe('getDanglingStaticFiles', () => {
+    let beforeElem: InstanceElement
+    let afterElem: InstanceElement
+    let result: StaticFile[] = []
+    const staticFile1 = new StaticFile({ filepath: 'path1', hash: 'hash1' })
+    const staticFile2 = new StaticFile({ filepath: 'path2', hash: 'hash2' })
+    const staticFile3 = new StaticFile({ filepath: 'path3', hash: 'hash3' })
+    const staticFile4 = new StaticFile({ filepath: 'path4', hash: 'hash4' })
+    beforeAll(() => {
+      beforeElem = new InstanceElement(
+        'elem',
+        new ObjectType({ elemID: new ElemID('salesforce', 'type') }),
+        {
+          f1: staticFile1, // To modify
+          f2: staticFile2, // To remove
+          a: { f3: staticFile3 }, // To modify
+          b: { f4: staticFile4 }, // To remove
+        }
+      )
+      afterElem = beforeElem.clone()
+
+      afterElem.value.f1 = staticFile2
+      delete afterElem.value.f2
+      afterElem.value.a = 's'
+      delete afterElem.value.b
+
+      result = getDanglingStaticFiles(detailedCompare(beforeElem, afterElem))
+      expect(result).toHaveLength(4)
+    })
+    it('should return static file that was modified', () => {
+      expect(result).toContain(staticFile1)
+    })
+    it('should return static file that was removed', () => {
+      expect(result).toContain(staticFile2)
+    })
+    it('should return static file nested inside modification of another field', () => {
+      expect(result).toContain(staticFile3)
+    })
+    it('should return static file nested inside removal of another field', () => {
+      expect(result).toContain(staticFile4)
     })
   })
 })

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
@@ -709,6 +709,10 @@ describe('Nacl Files Source', () => {
     const staticFile2 = new StaticFile({ filepath: 'path2', hash: 'hash2' })
     const staticFile3 = new StaticFile({ filepath: 'path3', hash: 'hash3' })
     const staticFile4 = new StaticFile({ filepath: 'path4', hash: 'hash4' })
+    const staticFile5 = new StaticFile({ filepath: 'path5', hash: 'hash5' })
+    const staticFile6 = new StaticFile({ filepath: 'path6', hash: 'hash6' })
+
+
     beforeAll(() => {
       beforeElem = new InstanceElement(
         'elem',
@@ -716,14 +720,17 @@ describe('Nacl Files Source', () => {
         {
           f1: staticFile1, // To modify
           f2: staticFile2, // To remove
+          f3: staticFile5, // To change location
           a: { f3: staticFile3 }, // To modify
           b: { f4: staticFile4 }, // To remove
         }
       )
       afterElem = beforeElem.clone()
 
-      afterElem.value.f1 = staticFile2
+      afterElem.value.f1 = staticFile6
+      afterElem.value.f5 = staticFile5
       delete afterElem.value.f2
+      delete afterElem.value.f3
       afterElem.value.a = 's'
       delete afterElem.value.b
 
@@ -741,6 +748,9 @@ describe('Nacl Files Source', () => {
     })
     it('should return static file nested inside removal of another field', () => {
       expect(result).toContain(staticFile4)
+    })
+    it('should not return static file if the path in element has changed', () => {
+      expect(result).not.toContain(staticFile5)
     })
   })
 })

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
@@ -405,6 +405,7 @@ describe('Nacl Files Source', () => {
   describe('removing static files', () => {
     const elemID = new ElemID('salesforce', 'new_elem')
     const filepath = 'to/the/superbowl'
+    const afterFilePath = 'to/the/superbowl2'
     const sfile = new StaticFile({ filepath, hash: 'XI' })
     let src: NaclFilesSource
     beforeEach(async () => {
@@ -426,6 +427,36 @@ describe('Nacl Files Source', () => {
       } as DetailedChange
       await src.updateNaclFiles([change])
       expect(mockedStaticFilesSource.delete).toHaveBeenCalledWith(sfile)
+    })
+    it('should delete before file when path is changed', async () => {
+      const change = {
+        id: elemID,
+        action: 'modify',
+        data: { before: sfile, after: new StaticFile({ filepath: afterFilePath, hash: 'XI' }) },
+        path: ['new', 'file'],
+      } as DetailedChange
+      await src.updateNaclFiles([change])
+      expect(mockedStaticFilesSource.delete).toHaveBeenCalledWith(sfile)
+    })
+    it('should delete before file when it is no longer a static file', async () => {
+      const change = {
+        id: elemID,
+        action: 'modify',
+        data: { before: sfile, after: '' },
+        path: ['new', 'file'],
+      } as DetailedChange
+      await src.updateNaclFiles([change])
+      expect(mockedStaticFilesSource.delete).toHaveBeenCalledWith(sfile)
+    })
+    it('should not delete static file if the change is only in content and not in path', async () => {
+      const change = {
+        id: elemID,
+        action: 'modify',
+        data: { before: sfile, after: new StaticFile({ filepath, hash: 'XII' }) },
+        path: ['new', 'file'],
+      } as DetailedChange
+      await src.updateNaclFiles([change])
+      expect(mockedStaticFilesSource.delete).toHaveBeenCalledTimes(0)
     })
   })
 


### PR DESCRIPTION
update static file path.
until now, static files whose path changed but content didn't would remain in their old location, after this PR, static files whose path changed will be created in their new location and the old files will be deleted.

---

_Additional context for reviewer_

---
_Release Notes_: 
core:
* static file path changes will be referred to as a change in fetch

---
_User Notifications_: 
* some static files might move location
