### PR TITLE
SALTO-4275: Fix Automation Scopes

### DIFF
--- a/packages/jira-adapter/src/filters/automation/automation_deployment.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_deployment.ts
@@ -29,15 +29,10 @@ import { getLookUpName } from '../../reference_mapping'
 import { getCloudId } from './cloud_id'
 import { getAutomations } from './automation_fetch'
 import { JiraConfig } from '../../config/config'
+import { PROJECT_TYPE_TO_RESOURCE_TYPE } from './automation_structure'
 
 
 const log = logger(module)
-
-const PROJECT_TYPE_TO_RESOURCE_TYPE: Record<string, string> = {
-  software: 'jira-software',
-  service_desk: 'jira-servicedesk',
-  business: 'jira-core',
-}
 
 type AutomationResponse = {
   id: number

--- a/packages/jira-adapter/src/filters/automation/automation_structure.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_structure.ts
@@ -298,7 +298,7 @@ const getScope = (resource: string): { projectId?: string; projectTypeKey?: stri
   if (projectTypeScope) {
     const projectTypeKey = findKeyInRecordObject(PROJECT_TYPE_TO_RESOURCE_TYPE, projectTypeScope[1])
     if (projectTypeKey === undefined) {
-      log.error(`Failed to convert automation project type: ${resource.match(PROJECT_TYPE_SCOPE_REGEX)?.[1]}`)
+      log.error(`Failed to convert automation project type: ${projectTypeScope[1]}`)
     }
     return { projectTypeKey }
   }


### PR DESCRIPTION
Atlassian recently changed the structure of automation scopes, removing the `projects` object. It caused all new automation to be deployed as Global

---
_Release Notes_: 
Jira Adapter:
* Fixed a bug causing all automation to be deployed with global scope

---
_User Notifications_: 
Jira Adapter:
* Recently created automations with a non-global scope will be added scope in the projects field
