### PR TITLE
SALTO-4319: cannot create two articles that reference each other

### DIFF
--- a/packages/zendesk-adapter/e2e_test/adapter.test.ts
+++ b/packages/zendesk-adapter/e2e_test/adapter.test.ts
@@ -143,6 +143,7 @@ const deployChanges = async (
         .filter(e => [
           ...Object.keys(GUIDE_BRAND_SPECIFIC_TYPES),
           PERMISSION_GROUP_TYPE_NAME,
+          ARTICLE_ATTACHMENT_TYPE_NAME,
         ].includes(e.elemID.typeName))
         .forEach(updatedElement => {
           const planElement = planElementById[updatedElement.elemID.getFullName()]
@@ -918,11 +919,11 @@ describe('Zendesk adapter E2E', () => {
         articleAttachment,
         articleInlineAttachment,
         articleInstance,
+        article2Instance,
+        article3Instance,
         articleTranslationEn,
         articleTranslationHe,
-        article2Instance,
         article2TranslationEn,
-        article3Instance,
         article3TranslationEn,
         articleOrder,
       ]

--- a/packages/zendesk-adapter/src/filters/article/article.ts
+++ b/packages/zendesk-adapter/src/filters/article/article.ts
@@ -305,8 +305,7 @@ const filterCreator: FilterCreator = ({ config, client, elementsSource, brandIdT
               (part: ReferenceExpression) => (
                 part.elemID.typeName === ARTICLE_ATTACHMENT_TYPE_NAME
                   ? addedArticleAttachments
-                    .find(attachment => attachment.elemID.isEqual(part.elemID))
-                    ?.value.id.toString()
+                    .find(attachment => attachment.elemID.isEqual(part.elemID))?.value.id.toString()
                   : prepRef(part)
               ),
             )

--- a/packages/zendesk-adapter/src/filters/article/article.ts
+++ b/packages/zendesk-adapter/src/filters/article/article.ts
@@ -72,6 +72,10 @@ const isAttachmentWithId = createSchemeGuard<AttachmentWithId>(
   EXPECTED_ATTACHMENT_SCHEMA, 'Received an invalid value for attachment id'
 )
 
+export const getGenericTitle = (title: string): string => `salto generic title for ${title}`
+
+export const getGenericBody = (title: string): string => `salto generic body for ${title}`
+
 const addTitleAndBodyValues = async (change: Change<InstanceElement>): Promise<void> => {
   const resolvedChange = await resolveChangeElement(change, lookupFunc)
   const currentLocale = getChangeData(resolvedChange).value.source_locale
@@ -79,8 +83,8 @@ const addTitleAndBodyValues = async (change: Change<InstanceElement>): Promise<v
     .filter(isTranslation)
     .find((tran: TranslationType) => tran.locale?.locale === currentLocale)
   if (translation !== undefined) {
-    getChangeData(change).value.title = `salto generic title for ${translation.title}`
-    getChangeData(change).value.body = 'salto generic body '
+    getChangeData(change).value.title = getGenericTitle(translation.title)
+    getChangeData(change).value.body = getGenericBody(translation.title)
   }
 }
 

--- a/packages/zendesk-adapter/src/filters/article/article.ts
+++ b/packages/zendesk-adapter/src/filters/article/article.ts
@@ -25,7 +25,6 @@ import {
 import {
   createSchemeGuard,
   getParents,
-  replaceTemplatesWithValues,
   resolveChangeElement,
 } from '@salto-io/adapter-utils'
 import Joi from 'joi'
@@ -41,7 +40,6 @@ import {
 import { addRemovalChangesId, isTranslation } from '../guide_section_and_category'
 import { lookupFunc } from '../field_references'
 import { removeTitleAndBody } from '../guide_fetch_article_section_and_category'
-import { prepRef } from './article_body'
 import ZendeskClient from '../../client/client'
 import {
   createUnassociatedAttachment,
@@ -74,15 +72,15 @@ const isAttachmentWithId = createSchemeGuard<AttachmentWithId>(
   EXPECTED_ATTACHMENT_SCHEMA, 'Received an invalid value for attachment id'
 )
 
-const addTranslationValues = async (change: Change<InstanceElement>): Promise<void> => {
+const addTitleAndBodyValues = async (change: Change<InstanceElement>): Promise<void> => {
   const resolvedChange = await resolveChangeElement(change, lookupFunc)
   const currentLocale = getChangeData(resolvedChange).value.source_locale
   const translation = getChangeData(resolvedChange).value.translations
     .filter(isTranslation)
     .find((tran: TranslationType) => tran.locale?.locale === currentLocale)
   if (translation !== undefined) {
-    getChangeData(change).value.title = translation.title
-    getChangeData(change).value.body = translation.body ?? ''
+    getChangeData(change).value.title = `salto generic title for ${translation.title}`
+    getChangeData(change).value.body = 'salto generic body '
   }
 }
 
@@ -288,30 +286,15 @@ const filterCreator: FilterCreator = ({ config, client, elementsSource, brandIdT
       })
     },
     preDeploy: async (changes: Change<InstanceElement>[]): Promise<void> => {
-      const addedArticleAttachments = await handleArticleAttachmentsPreDeploy(
+      await handleArticleAttachmentsPreDeploy(
         { changes, client, elementsSource, articleNameToAttachments }
       )
       await awu(changes)
         .filter(isAdditionChange)
         .filter(change => getChangeData(change).elemID.typeName === ARTICLE_TYPE_NAME)
         .forEach(async change => {
-          // We add the title and the resolved body values for articles creation
-          await addTranslationValues(change)
-          const instance = getChangeData(change)
-          try {
-            replaceTemplatesWithValues(
-              { values: [instance.value], fieldName: 'body' },
-              {},
-              (part: ReferenceExpression) => (
-                part.elemID.typeName === ARTICLE_ATTACHMENT_TYPE_NAME
-                  ? addedArticleAttachments
-                    .find(attachment => attachment.elemID.isEqual(part.elemID))?.value.id.toString()
-                  : prepRef(part)
-              ),
-            )
-          } catch (e) {
-            log.error(`Error serializing article body in deployment for ${instance.elemID.getFullName()}: ${e}, stack: ${e.stack}`)
-          }
+          // We add the title and the body values for articles creation
+          await addTitleAndBodyValues(change)
         })
     },
 

--- a/packages/zendesk-adapter/src/filters/article/article.ts
+++ b/packages/zendesk-adapter/src/filters/article/article.ts
@@ -72,11 +72,9 @@ const isAttachmentWithId = createSchemeGuard<AttachmentWithId>(
   EXPECTED_ATTACHMENT_SCHEMA, 'Received an invalid value for attachment id'
 )
 
-export const getGenericTitle = (title: string): string => `salto generic title for ${title}`
+export const getGenericTitle = (title: string): string => `salto temporary title for article with title: ${title}`
 
-export const getGenericBody = (title: string): string => `salto generic body for ${title}`
-
-const addTitleAndBodyValues = async (change: Change<InstanceElement>): Promise<void> => {
+const addPlaceholderTitleAndBodyValues = async (change: Change<InstanceElement>): Promise<void> => {
   const resolvedChange = await resolveChangeElement(change, lookupFunc)
   const currentLocale = getChangeData(resolvedChange).value.source_locale
   const translation = getChangeData(resolvedChange).value.translations
@@ -84,7 +82,7 @@ const addTitleAndBodyValues = async (change: Change<InstanceElement>): Promise<v
     .find((tran: TranslationType) => tran.locale?.locale === currentLocale)
   if (translation !== undefined) {
     getChangeData(change).value.title = getGenericTitle(translation.title)
-    getChangeData(change).value.body = getGenericBody(translation.title)
+    getChangeData(change).value.body = ''
   }
 }
 
@@ -298,7 +296,7 @@ const filterCreator: FilterCreator = ({ config, client, elementsSource, brandIdT
         .filter(change => getChangeData(change).elemID.typeName === ARTICLE_TYPE_NAME)
         .forEach(async change => {
           // We add the title and the body values for articles creation
-          await addTitleAndBodyValues(change)
+          await addPlaceholderTitleAndBodyValues(change)
         })
     },
 

--- a/packages/zendesk-adapter/src/filters/article/utils.ts
+++ b/packages/zendesk-adapter/src/filters/article/utils.ts
@@ -186,7 +186,7 @@ export const createUnassociatedAttachment = async (
       log.error(`Received an invalid response from Zendesk API, ${safeJsonStringify(res.data, undefined, 2).slice(0, RESULT_MAXIMUM_OUTPUT_SIZE)}. Not adding article attachments`)
       return
     }
-    const createdAttachment = [res.data.article_attachment] // why is this an array??
+    const createdAttachment = [res.data.article_attachment]
     if (!isAttachmentsResponse(createdAttachment)) {
       return
     }

--- a/packages/zendesk-adapter/src/filters/article/utils.ts
+++ b/packages/zendesk-adapter/src/filters/article/utils.ts
@@ -186,7 +186,7 @@ export const createUnassociatedAttachment = async (
       log.error(`Received an invalid response from Zendesk API, ${safeJsonStringify(res.data, undefined, 2).slice(0, RESULT_MAXIMUM_OUTPUT_SIZE)}. Not adding article attachments`)
       return
     }
-    const createdAttachment = [res.data.article_attachment]
+    const createdAttachment = [res.data.article_attachment] // why is this an array??
     if (!isAttachmentsResponse(createdAttachment)) {
       return
     }

--- a/packages/zendesk-adapter/src/filters/guide_translation.ts
+++ b/packages/zendesk-adapter/src/filters/guide_translation.ts
@@ -53,9 +53,11 @@ const needToOmit = (change: Change<InstanceElement>): boolean =>
   isDefaultTranslationAddition(change) || parentRemoved(change)
 
 /**
- * a different filter is needed for the default translation and translations for which the section
- * has been removed, as they are deployed during the deployment of the section itself. Therefore,
- * this filter marks these translations as successfully deployed without actually deploying them.
+ * a different filter is needed for the default translation and translations for which the parent
+ * has been removed, as they are deployed during the deployment of the parent itself. Therefore,
+ * this filter marks translations as successfully deployed without actually deploying them.
+ * For addition of default article translation, as we deploy the article with a temporary title and body,
+ * we transform the change to a modification change and deploy it in this way.
  * The rest of the translations will be deployed in the default deploy filter.
  */
 const filterCreator: FilterCreator = ({ config, client }) => ({

--- a/packages/zendesk-adapter/test/filters/article/article.test.ts
+++ b/packages/zendesk-adapter/test/filters/article/article.test.ts
@@ -24,7 +24,7 @@ import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { createFilterCreatorParams } from '../../utils'
 import ZendeskClient from '../../../src/client/client'
 import { ARTICLE_ATTACHMENT_TYPE_NAME, ARTICLE_TYPE_NAME, BRAND_TYPE_NAME, USER_SEGMENT_TYPE_NAME, ZENDESK } from '../../../src/constants'
-import filterCreator, { getGenericBody, getGenericTitle } from '../../../src/filters/article/article'
+import filterCreator, { getGenericTitle } from '../../../src/filters/article/article'
 import { DEFAULT_CONFIG, FETCH_CONFIG } from '../../../src/config'
 import { createEveryoneUserSegmentInstance } from '../../../src/filters/everyone_user_segment'
 import * as articleUtils from '../../../src/filters/article/utils'
@@ -341,7 +341,7 @@ describe('article filter', () => {
       ])
       const filteredArticle = getChangeData(articleAddition)
       expect(filteredArticle.value.title).toBe(getGenericTitle('The title of the article'))
-      expect(filteredArticle.value.body).toBe(getGenericBody('The title of the article'))
+      expect(filteredArticle.value.body).toBe('')
       expect(getChangeData(TranslationAddition)).toBe(clonedTranslation)
     })
     it('should run the creation of unassociated attachment', async () => {

--- a/packages/zendesk-adapter/test/filters/article/article.test.ts
+++ b/packages/zendesk-adapter/test/filters/article/article.test.ts
@@ -24,7 +24,7 @@ import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { createFilterCreatorParams } from '../../utils'
 import ZendeskClient from '../../../src/client/client'
 import { ARTICLE_ATTACHMENT_TYPE_NAME, ARTICLE_TYPE_NAME, BRAND_TYPE_NAME, USER_SEGMENT_TYPE_NAME, ZENDESK } from '../../../src/constants'
-import filterCreator from '../../../src/filters/article/article'
+import filterCreator, { getGenericBody, getGenericTitle } from '../../../src/filters/article/article'
 import { DEFAULT_CONFIG, FETCH_CONFIG } from '../../../src/config'
 import { createEveryoneUserSegmentInstance } from '../../../src/filters/everyone_user_segment'
 import * as articleUtils from '../../../src/filters/article/utils'
@@ -340,8 +340,8 @@ describe('article filter', () => {
         TranslationAddition,
       ])
       const filteredArticle = getChangeData(articleAddition)
-      expect(filteredArticle.value.title).toBe('The title of the article')
-      expect(filteredArticle.value.body).toBe('<p>ppppp</p>')
+      expect(filteredArticle.value.title).toBe(getGenericTitle('The title of the article'))
+      expect(filteredArticle.value.body).toBe(getGenericBody('The title of the article'))
       expect(getChangeData(TranslationAddition)).toBe(clonedTranslation)
     })
     it('should run the creation of unassociated attachment', async () => {

--- a/packages/zendesk-adapter/test/filters/guide_translation.test.ts
+++ b/packages/zendesk-adapter/test/filters/guide_translation.test.ts
@@ -21,6 +21,7 @@ import {
   InstanceElement,
   ObjectType, ReferenceExpression,
 } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import filterCreator from '../../src/filters/guide_translation'
 import { createFilterCreatorParams } from '../utils'
 import {
@@ -43,7 +44,7 @@ jest.mock('@salto-io/adapter-components', () => {
   }
 })
 
-describe('guild section translation filter', () => {
+describe('guide translation filter', () => {
   type FilterType = filterUtils.FilterWith<'deploy'>
   let filter: FilterType
 
@@ -63,7 +64,7 @@ describe('guild section translation filter', () => {
 
 
   const guideLanguageSettingsInstance = new InstanceElement(
-    'instance',
+    'test1',
     guideLanguageSettingsType,
     {
       locale: 'he',
@@ -103,7 +104,7 @@ describe('guild section translation filter', () => {
     {
       id: 2,
       source_locale: new ReferenceExpression(
-        guideLanguageSettingsType.elemID.createNestedID('instance', 'Test1'), guideLanguageSettingsInstance
+        guideLanguageSettingsInstance.elemID, guideLanguageSettingsInstance
       ),
       translations: [
         heArticleTranslationInstance.value,
@@ -121,7 +122,7 @@ describe('guild section translation filter', () => {
       name: 'name',
       description: 'description',
       source_locale: new ReferenceExpression(
-        guideLanguageSettingsType.elemID.createNestedID('instance', 'Test1'), guideLanguageSettingsInstance
+        guideLanguageSettingsInstance.elemID, guideLanguageSettingsInstance
       ),
       translations: [
         heSectionTranslationInstance.value,
@@ -135,7 +136,11 @@ describe('guild section translation filter', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks()
-    filter = filterCreator(createFilterCreatorParams({})) as FilterType
+    filter = filterCreator(createFilterCreatorParams({
+      elementsSource: buildElementsSourceFromElements([
+        guideLanguageSettingsInstance,
+      ]),
+    })) as FilterType
   })
 
   describe('deploy', () => {


### PR DESCRIPTION
fix bug that prevented the deploy of two articles that reference each other

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* fix bug that prevented the deploy of two articles that reference each other

---
_User Notifications_: 
None
