### PR TITLE
SALTO-4343: Account id changes for automation groups fix

### DIFF
--- a/packages/jira-adapter/src/filters/account_id/account_id_filter.ts
+++ b/packages/jira-adapter/src/filters/account_id/account_id_filter.ts
@@ -93,6 +93,17 @@ const walkOnAutomationValue = (regexPath: string, callback: WalkOnUsersCallback)
   return WALK_NEXT_STEP.RECURSE
 }
 
+const walkOnUserCondition = (callback: WalkOnUsersCallback)
+: WalkOnFunc => ({ value, path }): WALK_NEXT_STEP => {
+  if (value !== undefined
+    && typeof value.check === 'string'
+    && value.check.startsWith('USER_')) {
+    walkOnValue({ value: value.criteria, elemId: path.createNestedID('criteria'), func: walkOnAutomationValue('value\\.conditions\\.\\d+\\.criteria\\.\\d+', callback) })
+    return WALK_NEXT_STEP.SKIP
+  }
+  return WALK_NEXT_STEP.RECURSE
+}
+
 const accountIdsScenarios = (
   value: Value,
   path: ElemID,
@@ -167,8 +178,7 @@ const accountIdsScenarios = (
     }
     // user condition
     if (value.type === 'jira.user.condition') {
-      walkOnValue({ value, elemId: path, func: walkOnAutomationValue('value\\.conditions\\.\\d+\\.criteria\\.\\d+', callback) })
-      return WALK_NEXT_STEP.SKIP
+      walkOnValue({ value: value.value?.conditions, elemId: path.createNestedID('value', 'conditions'), func: walkOnUserCondition(callback) })
     }
     // assign action
     if (value.type === 'jira.issue.assign') {

--- a/packages/jira-adapter/test/filters/account_id/account_id_common.ts
+++ b/packages/jira-adapter/test/filters/account_id/account_id_common.ts
@@ -260,25 +260,31 @@ export const createInstance = (
     },
     automation7: {
       type: 'jira.user.condition',
-      compareFieldValue: [
-        {
-          value: {
-            conditions: [
+      value: {
+        conditions: [
+          {
+            nothing: 'else',
+          },
+          {
+            check: 'USER_IS',
+            criteria: [
               {
-                nothing: 'else',
-              },
-              {
-                criteria: [
-                  {
-                    type: 'ID',
-                    value: `${id}automation7`,
-                  },
-                ],
+                type: 'ID',
+                value: `${id}automation7`,
               },
             ],
           },
-        },
-      ],
+          {
+            check: 'GROUP_IS',
+            criteria: [
+              {
+                type: 'ID',
+                value: `${id}automation7X`,
+              },
+            ],
+          },
+        ],
+      },
     },
     automation8: {
       type: 'jira.issue.assign',
@@ -462,27 +468,33 @@ export const createObjectedInstance = (id: string, objectType: ObjectType): Inst
     },
     automation7: {
       type: 'jira.user.condition',
-      compareFieldValue: [
-        {
-          value: {
-            conditions: [
+      value: {
+        conditions: [
+          {
+            nothing: 'else',
+          },
+          {
+            check: 'USER_IS',
+            criteria: [
               {
-                nothing: 'else',
-              },
-              {
-                criteria: [
-                  {
-                    type: 'ID',
-                    value: {
-                      id: `${id}automation7`,
-                    },
-                  },
-                ],
+                type: 'ID',
+                value: {
+                  id: `${id}automation7`,
+                },
               },
             ],
           },
-        },
-      ],
+          {
+            check: 'GROUP_IS',
+            criteria: [
+              {
+                type: 'ID',
+                value: `${id}automation7X`,
+              },
+            ],
+          },
+        ],
+      },
     },
     automation8: {
       type: 'jira.issue.assign',
@@ -540,7 +552,8 @@ export const checkObjectedInstanceIds = (
     expect(objInstance.value.automation5.compareFieldValue.value.id).toEqual(`${id}automation5`)
     expect(objInstance.value.automation9.compareFieldValue.value.id).toEqual(`${id}automation9`)
     expect(objInstance.value.automation6.compareFieldValue.value.operations[0].value[0].value.id).toEqual(`${id}automation6`)
-    expect(objInstance.value.automation7.compareFieldValue[0].value.conditions[1].criteria[0].value.id).toEqual(`${id}automation7`)
+    expect(objInstance.value.automation7.value.conditions[1].criteria[0].value.id).toEqual(`${id}automation7`)
+    expect(objInstance.value.automation7.value.conditions[2].criteria[0].value).toEqual(`${id}automation7X`)
     expect(objInstance.value.automation8.compareFieldValue[0].value.assignee.values[0].id).toEqual(`${id}automation8a`)
     expect(objInstance.value.automation8.compareFieldValue[0].value.assignee.values[1].id).toEqual(`${id}automation8b`)
     expect(objInstance.value.accountIds[0].id).toEqual(`${id}Ids1`)
@@ -571,7 +584,7 @@ export const checkSimpleInstanceIds = (
     expect(objInstance.value.automation5.compareFieldValue.value).toEqual(`${id}automation5`)
     expect(objInstance.value.automation9.compareFieldValue.value).toEqual(`${id}automation9`)
     expect(objInstance.value.automation6.compareFieldValue.value.operations[0].value[0].value).toEqual(`${id}automation6`)
-    expect(objInstance.value.automation7.compareFieldValue[0].value.conditions[1].criteria[0].value).toEqual(`${id}automation7`)
+    expect(objInstance.value.automation7.value.conditions[1].criteria[0].value).toEqual(`${id}automation7`)
     expect(objInstance.value.automation8.compareFieldValue[0].value.assignee.values[0]).toEqual(`${id}automation8a`)
     expect(objInstance.value.automation8.compareFieldValue[0].value.assignee.values[1]).toEqual(`${id}automation8b`)
     expect(objInstance.value.accountIds[0]).toEqual(`${id}Ids1`)
@@ -610,7 +623,7 @@ export const checkDisplayNames = (
     expect(instance.value.automation5.compareFieldValue.value.displayName).toEqual(`disp${id}automation5`)
     expect(instance.value.automation9.compareFieldValue.value.displayName).toEqual(`disp${id}automation9`)
     expect(instance.value.automation6.compareFieldValue.value.operations[0].value[0].value.displayName).toEqual(`disp${id}automation6`)
-    expect(instance.value.automation7.compareFieldValue[0].value.conditions[1].criteria[0].value.displayName).toEqual(`disp${id}automation7`)
+    expect(instance.value.automation7.value.conditions[1].criteria[0].value.displayName).toEqual(`disp${id}automation7`)
     expect(instance.value.automation8.compareFieldValue[0].value.assignee.values[0].displayName).toEqual(`disp${id}automation8a`)
     expect(instance.value.automation8.compareFieldValue[0].value.assignee.values[1].displayName).toEqual(`disp${id}automation8b`)
   }


### PR DESCRIPTION
Fixed a bug in which for automation with user condition we would treat groups and roles as users in some cases, causing the automations to fail deployment
---
Will also open Noise reduction

---
_Release Notes_: 
Jira Adapter: 
* Fixed a bug that prevented deployment of automations with user conditions of "is in group"/"Is in role"

---
_User Notifications_: 
Jira Adapter:
* In automations with user condition and "is in group"/"Is in role" the reference to  the group/role will be in the `value` field instead of the `id` field
