### PR TITLE
SALTO-4352: Don't log errors when there are no authenticator changes

### DIFF
--- a/packages/okta-adapter/src/change_validators/enabled_authenticators.ts
+++ b/packages/okta-adapter/src/change_validators/enabled_authenticators.ts
@@ -84,6 +84,9 @@ export const enabledAuthenticatorsValidator: ChangeValidator = async (changes, e
       isDeactivationChange({ before: change.data.before.value.status, after: change.data.after.value.status }))
     .map(getChangeData)
 
+  if (_.isEmpty(deactivatedAuthenticators)) {
+    return []
+  }
 
   const mfaPolicies = await awu(await elementSource.list())
     .filter(id => id.typeName === MFA_POLICY_TYPE_NAME)


### PR DESCRIPTION
Don't log errors when there are no authenticator changes

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
