### PR TITLE
SALTO-4038 Changed dashboard gadget back to ReferenceExpression

### DIFF
--- a/packages/jira-adapter/src/change_validators/dashboard_gadgets.ts
+++ b/packages/jira-adapter/src/change_validators/dashboard_gadgets.ts
@@ -13,8 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ChangeValidator, ElemID, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, SeverityLevel } from '@salto-io/adapter-api'
-import { getParents, isResolvedReferenceExpression } from '@salto-io/adapter-utils'
+import { ChangeValidator, ElemID, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, isReferenceExpression, SeverityLevel } from '@salto-io/adapter-api'
+import { getParents } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import { DASHBOARD_GADGET_TYPE } from '../constants'
@@ -27,7 +27,7 @@ export const getGadgetKey = (parentId: ElemID, row: number, column: number): str
   `${parentId.name}-${row}-${column}`
 
 export const getGadgetInstanceKey = (instance: InstanceElement): string => {
-  if (!isResolvedReferenceExpression(getParents(instance)[0])
+  if (!isReferenceExpression(getParents(instance)[0])
   || instance.value.position?.row === undefined
   || instance.value.position.column === undefined) {
     throw new Error(`Received an invalid gadget ${instance.elemID.getFullName()}`)

--- a/packages/jira-adapter/test/change_validators/dashboard_gadgets.test.ts
+++ b/packages/jira-adapter/test/change_validators/dashboard_gadgets.test.ts
@@ -38,7 +38,7 @@ describe('dashboardGadgetsValidator', () => {
       undefined,
       {
         [CORE_ANNOTATIONS.PARENT]: [
-          new ReferenceExpression(new ElemID(JIRA, DASHBOARD_TYPE, 'instance', 'parent'), {}),
+          new ReferenceExpression(new ElemID(JIRA, DASHBOARD_TYPE, 'instance', 'parent')),
         ],
       },
     )
@@ -60,7 +60,7 @@ describe('dashboardGadgetsValidator', () => {
       undefined,
       {
         [CORE_ANNOTATIONS.PARENT]: [
-          new ReferenceExpression(new ElemID(JIRA, DASHBOARD_TYPE, 'instance', 'parent'), {}),
+          new ReferenceExpression(new ElemID(JIRA, DASHBOARD_TYPE, 'instance', 'parent')),
         ],
       },
     )
@@ -105,7 +105,7 @@ describe('dashboardGadgetsValidator', () => {
       undefined,
       {
         [CORE_ANNOTATIONS.PARENT]: [
-          new ReferenceExpression(new ElemID(JIRA, DASHBOARD_TYPE, 'instance', 'parent2'), {}),
+          new ReferenceExpression(new ElemID(JIRA, DASHBOARD_TYPE, 'instance', 'parent2')),
         ],
       },
     )


### PR DESCRIPTION
Changed dashboard gadget back to ReferenceExpression

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
