### PR TITLE
SALTO-4370: Don't fail fetch for 410 errors

### DIFF
--- a/packages/okta-adapter/src/client/client.ts
+++ b/packages/okta-adapter/src/client/client.ts
@@ -82,6 +82,11 @@ export default class OktaClient extends clientUtils.AdapterHTTPClient<
         log.debug('Suppressing %d error %o for AppUserSchema', status, e)
         return { data: [], status }
       }
+      // Okta returns 410 for deprecated endpoints
+      if (status === 410) {
+        log.warn('Suppressing %d error %o for endpoint: %s', status, e, args.url)
+        return { data: [], status }
+      }
       throw e
     }
   }

--- a/packages/okta-adapter/test/client/client.test.ts
+++ b/packages/okta-adapter/test/client/client.test.ts
@@ -57,6 +57,13 @@ describe('client', () => {
       result = await client.getSinglePage({ url: '/api/v1/meta/schemas/apps/0oa6e1b1916fcAiWq5d7/default' })
       expect(result.data).toEqual([])
     })
+    it('should return empty array for 410 errors', async () => {
+      mockAxios
+        .onGet('/api/v1/deprecated')
+        .replyOnce(410)
+      result = await client.getSinglePage({ url: '/api/v1/deprecated' })
+      expect(result.data).toEqual([])
+    })
   })
 
   describe('clearValuesFromResponseData + extractHeaders', () => {


### PR DESCRIPTION
Suppress 410 https errors

---

Okta returns 410 for deprecated endpoints, this shouldn't fail fetch
Didn't excluded the type that caused it because in our accounts it works.

---
_Release Notes_: 
None

---
_User Notifications_: 
None