### PR TITLE
SALTO-4390 - Salesforce: reduce severity of logging in formula_deps

### DIFF
--- a/packages/salesforce-adapter/src/filters/formula_deps.ts
+++ b/packages/salesforce-adapter/src/filters/formula_deps.ts
@@ -98,13 +98,13 @@ const addDependenciesAnnotation = async (field: Field, allElements: ReadOnlyElem
     identifiersInfo: FormulaIdentifierInfo[][]
   ): void => {
     if (invalidReferences.length > 0) {
-      log.error('When parsing the formula %o in field %o, one or more of the identifiers %o was parsed to an invalid reference: ',
+      log.debug('When parsing the formula %o in field %o, one or more of the identifiers %o was parsed to an invalid reference: ',
         formula,
         field.elemID.getFullName(),
         identifiersInfo.flat().map(info => info.instance))
     }
     invalidReferences.forEach(refElemId => {
-      log.error(`Invalid reference: ${refElemId.getFullName()}`)
+      log.debug(`Invalid reference: ${refElemId.getFullName()}`)
     })
   }
 


### PR DESCRIPTION
Invalid references currently generate error-level logs, but we expect many invalid references because we don’t handle custom relations yet.

---

N/A

---
_Release Notes_: 
N/A

---
_User Notifications_: 
N/A