### PR TITLE
SALTO-4392: fix logs for missing guide_language_settings

### DIFF
--- a/packages/zendesk-adapter/src/filters/guide_locale.ts
+++ b/packages/zendesk-adapter/src/filters/guide_locale.ts
@@ -56,6 +56,7 @@ const filterCreator: FilterCreator = ({ config }) => ({
       brandToLocale[settings.value.brand] = brandToLocale[settings.value.brand] ?? {} // Init inner dict if needed
       brandToLocale[settings.value.brand][settings.value.locale] = settings
     })
+    const logsSet = new Set<string>()
 
     instancesWithLocale.forEach(instance => {
       const brandLocales = brandToLocale[instance.value.brand] ?? {}
@@ -65,7 +66,7 @@ const filterCreator: FilterCreator = ({ config }) => ({
       if (locale !== undefined) {
         instance.value.locale = new ReferenceExpression(locale.elemID, locale)
       } else {
-        log.error(`Could not find '${instance.value.locale}' ${GUIDE_LANGUAGE_SETTINGS_TYPE_NAME} of brand ${brandName}`)
+        logsSet.add(`Could not find locale'${instance.value.locale}' ${GUIDE_LANGUAGE_SETTINGS_TYPE_NAME} of brand ${brandName}`)
       }
 
       if (TYPES_WITH_SOURCE_LOCALE.includes(instance.elemID.typeName)) {
@@ -73,10 +74,11 @@ const filterCreator: FilterCreator = ({ config }) => ({
         if (sourceLocale !== undefined) {
           instance.value.source_locale = new ReferenceExpression(sourceLocale.elemID, sourceLocale)
         } else {
-          log.error(`Could not find '${instance.value.source_locale}' ${GUIDE_LANGUAGE_SETTINGS_TYPE_NAME} of brand ${brandName}`)
+          logsSet.add(`Could not find source_locale'${instance.value.source_locale}' ${GUIDE_LANGUAGE_SETTINGS_TYPE_NAME} of brand ${brandName}`)
         }
       }
     })
+    logsSet.forEach(message => log.error(message))
   },
 })
 

--- a/packages/zendesk-adapter/src/filters/guide_locale.ts
+++ b/packages/zendesk-adapter/src/filters/guide_locale.ts
@@ -66,7 +66,7 @@ const filterCreator: FilterCreator = ({ config }) => ({
       if (locale !== undefined) {
         instance.value.locale = new ReferenceExpression(locale.elemID, locale)
       } else {
-        logsSet.add(`Could not find locale'${instance.value.locale}' ${GUIDE_LANGUAGE_SETTINGS_TYPE_NAME} of brand ${brandName}`)
+        logsSet.add(`Could not find locale '${instance.value.locale}' ${GUIDE_LANGUAGE_SETTINGS_TYPE_NAME} of brand ${brandName}`)
       }
 
       if (TYPES_WITH_SOURCE_LOCALE.includes(instance.elemID.typeName)) {
@@ -74,7 +74,7 @@ const filterCreator: FilterCreator = ({ config }) => ({
         if (sourceLocale !== undefined) {
           instance.value.source_locale = new ReferenceExpression(sourceLocale.elemID, sourceLocale)
         } else {
-          logsSet.add(`Could not find source_locale'${instance.value.source_locale}' ${GUIDE_LANGUAGE_SETTINGS_TYPE_NAME} of brand ${brandName}`)
+          logsSet.add(`Could not find source_locale '${instance.value.source_locale}' ${GUIDE_LANGUAGE_SETTINGS_TYPE_NAME} of brand ${brandName}`)
         }
       }
     })


### PR DESCRIPTION
fix logs for missing guide_language_settings

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
