### PR TITLE
SALTO-4266: delete empty accountIds in scriptRunner

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -126,6 +126,7 @@ import pluginVersionFliter from './filters/data_center/plugin_version'
 import scriptRunnerWorkflowListsFilter from './filters/script_runner/workflow/workflow_lists_parsing'
 import scriptRunnerWorkflowReferencesFilter from './filters/script_runner/workflow/workflow_references'
 import scriptRunnerTemplateExpressionFilter from './filters/script_runner/script_template_expressions'
+import scriptRunnerEmptyAccountIdsFilter from './filters/script_runner/workflow/empty_account_ids'
 import storeUsersFilter from './filters/store_users'
 import projectCategoryFilter from './filters/project_category'
 import addAliasFilter from './filters/add_alias'
@@ -185,6 +186,7 @@ export const DEFAULT_FILTERS = [
   // must run after scriptRunnerWorkflowListsFilter
   scriptRunnerWorkflowReferencesFilter,
   scriptRunnerTemplateExpressionFilter,
+  scriptRunnerEmptyAccountIdsFilter,
   workflowPropertiesFilter,
   workflowDeployFilter,
   workflowModificationFilter,

--- a/packages/jira-adapter/src/filters/script_runner/workflow/empty_account_ids.ts
+++ b/packages/jira-adapter/src/filters/script_runner/workflow/empty_account_ids.ts
@@ -1,0 +1,93 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { isInstanceElement, Element, isAdditionOrModificationChange, getChangeData, isInstanceChange, Value } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { FilterCreator } from '../../../filter'
+import { WorkflowInstance, isWorkflowInstance } from '../../workflow/types'
+import { SCRIPT_RUNNER_POST_FUNCTION_TYPE, SCRIPT_RUNNER_SEND_NOTIFICATIONS } from './workflow_cloud'
+
+const { makeArray } = collections.array
+
+const changeAccountIds = (func: (scriptRunner: Value) => Value):
+((workflowInstance: WorkflowInstance) => void) => (workflowInstance: WorkflowInstance): void => {
+  workflowInstance.value.transitions.forEach(transition => {
+    makeArray(transition.rules?.postFunctions).forEach(postFunction => {
+      if (postFunction.type === SCRIPT_RUNNER_POST_FUNCTION_TYPE
+          && postFunction.configuration?.scriptRunner !== undefined
+          && postFunction.configuration.scriptRunner.className === SCRIPT_RUNNER_SEND_NOTIFICATIONS) {
+        postFunction.configuration.scriptRunner = func(postFunction.configuration.scriptRunner)
+      }
+    })
+  })
+}
+
+const deleteEmptyAccountsId = (scriptRunner: Value): Value => {
+  if (Array.isArray(scriptRunner.accountIds)
+    && scriptRunner.accountIds.length === 1
+    && scriptRunner.accountIds[0] === '') {
+    delete scriptRunner.accountIds
+  }
+  return scriptRunner
+}
+
+const addEmptyAccountsId = (scriptRunner: Value): Value => {
+  if (scriptRunner.accountIds === undefined) {
+    scriptRunner.accountIds = ['']
+  }
+  return scriptRunner
+}
+
+// Removes and returns the account ids for scriptRunner workflow instance, with post function of send notifications
+// It prevents change validator errors on deployment
+const filter: FilterCreator = ({ client, config }) => ({
+  name: 'emptyAccountIdsFilter',
+  onFetch: async (elements: Element[]) => {
+    if (client.isDataCenter || !config.fetch.enableScriptRunnerAddon) {
+      return
+    }
+
+    elements
+      .filter(isInstanceElement)
+      .filter(isWorkflowInstance)
+      .forEach(changeAccountIds(deleteEmptyAccountsId))
+  },
+  preDeploy: async changes => {
+    if (client.isDataCenter || !config.fetch.enableScriptRunnerAddon) {
+      return
+    }
+
+    changes
+      .filter(isAdditionOrModificationChange)
+      .filter(isInstanceChange)
+      .map(getChangeData)
+      .filter(isWorkflowInstance)
+      .forEach(changeAccountIds(addEmptyAccountsId))
+  },
+  onDeploy: async changes => {
+    if (client.isDataCenter || !config.fetch.enableScriptRunnerAddon) {
+      return
+    }
+
+    changes
+      .filter(isAdditionOrModificationChange)
+      .filter(isInstanceChange)
+      .map(getChangeData)
+      .filter(isWorkflowInstance)
+      .forEach(changeAccountIds(deleteEmptyAccountsId))
+  },
+})
+export default filter

--- a/packages/jira-adapter/src/filters/script_runner/workflow/empty_account_ids.ts
+++ b/packages/jira-adapter/src/filters/script_runner/workflow/empty_account_ids.ts
@@ -22,13 +22,11 @@ import { SCRIPT_RUNNER_POST_FUNCTION_TYPE, SCRIPT_RUNNER_SEND_NOTIFICATIONS } fr
 
 const { makeArray } = collections.array
 
-const changeAccountIds = (func: (scriptRunner: Value) => Value):
-((workflowInstance: WorkflowInstance) => void) => (workflowInstance: WorkflowInstance): void => {
+const changeAccountIds = (workflowInstance: WorkflowInstance, func: (scriptRunner: Value) => Value): void => {
   workflowInstance.value.transitions.forEach(transition => {
     makeArray(transition.rules?.postFunctions).forEach(postFunction => {
       if (postFunction.type === SCRIPT_RUNNER_POST_FUNCTION_TYPE
-          && postFunction.configuration?.scriptRunner !== undefined
-          && postFunction.configuration.scriptRunner.className === SCRIPT_RUNNER_SEND_NOTIFICATIONS) {
+          && postFunction.configuration?.scriptRunner?.className === SCRIPT_RUNNER_SEND_NOTIFICATIONS) {
         postFunction.configuration.scriptRunner = func(postFunction.configuration.scriptRunner)
       }
     })
@@ -63,7 +61,7 @@ const filter: FilterCreator = ({ client, config }) => ({
     elements
       .filter(isInstanceElement)
       .filter(isWorkflowInstance)
-      .forEach(changeAccountIds(deleteEmptyAccountsId))
+      .forEach(workflowInstance => changeAccountIds(workflowInstance, deleteEmptyAccountsId))
   },
   preDeploy: async changes => {
     if (client.isDataCenter || !config.fetch.enableScriptRunnerAddon) {
@@ -75,7 +73,7 @@ const filter: FilterCreator = ({ client, config }) => ({
       .filter(isInstanceChange)
       .map(getChangeData)
       .filter(isWorkflowInstance)
-      .forEach(changeAccountIds(addEmptyAccountsId))
+      .forEach(workflowInstance => changeAccountIds(workflowInstance, addEmptyAccountsId))
   },
   onDeploy: async changes => {
     if (client.isDataCenter || !config.fetch.enableScriptRunnerAddon) {
@@ -87,7 +85,7 @@ const filter: FilterCreator = ({ client, config }) => ({
       .filter(isInstanceChange)
       .map(getChangeData)
       .filter(isWorkflowInstance)
-      .forEach(changeAccountIds(deleteEmptyAccountsId))
+      .forEach(workflowInstance => changeAccountIds(workflowInstance, deleteEmptyAccountsId))
   },
 })
 export default filter

--- a/packages/jira-adapter/src/filters/script_runner/workflow/workflow_cloud.ts
+++ b/packages/jira-adapter/src/filters/script_runner/workflow/workflow_cloud.ts
@@ -22,10 +22,10 @@ import { Value } from '@salto-io/adapter-api'
 import { renameKey } from '../../../utils'
 
 const log = logger(module)
-const SCRIPT_RUNNER_POST_FUNCTION_TYPE = 'com.onresolve.jira.groovy.groovyrunner__script-postfunction'
+export const SCRIPT_RUNNER_POST_FUNCTION_TYPE = 'com.onresolve.jira.groovy.groovyrunner__script-postfunction'
 const SCRIPT_RUNNER_VALIDATOR_TYPE = 'com.onresolve.jira.groovy.groovyrunner__script-workflow-validators'
 const SCRIPT_RUNNER_CONDITION_TYPE = 'com.onresolve.jira.groovy.groovyrunner__script-workflow-conditions'
-const SCRIPT_RUNNER_SEND_NOTIFICATIONS = 'com.adaptavist.sr.cloud.workflow.SendNotification'
+export const SCRIPT_RUNNER_SEND_NOTIFICATIONS = 'com.adaptavist.sr.cloud.workflow.SendNotification'
 export const SCRIPT_RUNNER_FIELD = 'scriptRunner'
 const VALUE = 'value'
 export const SCRIPT_RUNNER_CLOUD_TYPES = [

--- a/packages/jira-adapter/src/filters/workflow/types.ts
+++ b/packages/jira-adapter/src/filters/workflow/types.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, getChangeData, InstanceElement, isInstanceChange, Values, Element } from '@salto-io/adapter-api'
+import { Change, getChangeData, InstanceElement, isInstanceChange, Values, Element, Value } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import Joi from 'joi'
 import { WORKFLOW_TYPE_NAME } from '../../constants'
@@ -68,6 +68,7 @@ type PostFunctionConfiguration = {
   projectRole?: ConfigRef
   event?: ConfigRef
   id?: unknown
+  scriptRunner?: Value
 }
 
 const postFunctionConfigurationSchema = Joi.object({

--- a/packages/jira-adapter/test/filters/script_runner/empty_account_ids.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/empty_account_ids.test.ts
@@ -1,0 +1,227 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { filterUtils } from '@salto-io/adapter-components'
+import { InstanceElement, toChange } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { createEmptyType, getFilterParams, mockClient } from '../../utils'
+import { SCRIPT_RUNNER_POST_FUNCTION_TYPE, SCRIPT_RUNNER_SEND_NOTIFICATIONS } from '../../../src/filters/script_runner/workflow/workflow_cloud'
+import emptyAccountIds from '../../../src/filters/script_runner/workflow/empty_account_ids'
+import { WORKFLOW_TYPE_NAME } from '../../../src/constants'
+import { getDefaultConfig } from '../../../src/config/config'
+
+describe('ScriptRunner cloud empty account id', () => {
+  let filter: filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
+  let filterOff: filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
+  let filterDC: filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
+  let instance: InstanceElement
+  let wrongStructureInstance: InstanceElement
+
+  const workflowType = createEmptyType(WORKFLOW_TYPE_NAME)
+  beforeEach(() => {
+    const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+    const configOff = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+    config.fetch.enableScriptRunnerAddon = true
+    const { client } = mockClient(true)
+    filter = emptyAccountIds(getFilterParams({ config })) as filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
+    filterOff = emptyAccountIds(getFilterParams({ config: configOff })) as filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
+    filterDC = emptyAccountIds(getFilterParams({ client })) as filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
+  })
+  describe('fetch', () => {
+    beforeEach(() => {
+      instance = new InstanceElement(
+        'instance',
+        workflowType,
+        {
+          transitions: [
+            {
+              rules: {
+                postFunctions: [
+                  {
+                    type: SCRIPT_RUNNER_POST_FUNCTION_TYPE,
+                    configuration: {
+                      scriptRunner: {
+                        className: SCRIPT_RUNNER_SEND_NOTIFICATIONS,
+                        accountIds: [''],
+                      },
+                    },
+                  },
+                  {
+                    type: SCRIPT_RUNNER_POST_FUNCTION_TYPE,
+                    configuration: {
+                      scriptRunner: {
+                        className: SCRIPT_RUNNER_SEND_NOTIFICATIONS,
+                        accountIds: ['1'],
+                      },
+                    },
+                  },
+                  {
+                    type: SCRIPT_RUNNER_POST_FUNCTION_TYPE,
+                    configuration: {
+                      scriptRunner: {
+                        className: SCRIPT_RUNNER_SEND_NOTIFICATIONS,
+                        accountIds: [''],
+                      },
+                    },
+                  },
+
+                ],
+              },
+            },
+            {
+              rules: {
+                postFunctions: [
+                  {
+                    type: SCRIPT_RUNNER_POST_FUNCTION_TYPE,
+                    configuration: {
+                      scriptRunner: {
+                        className: SCRIPT_RUNNER_SEND_NOTIFICATIONS,
+                        accountIds: [''],
+                      },
+                    },
+                  },
+                  {
+                    type: SCRIPT_RUNNER_POST_FUNCTION_TYPE,
+                    configuration: {
+                      scriptRunner: {
+                        className: SCRIPT_RUNNER_SEND_NOTIFICATIONS,
+                        accountIds: ['1', '2'],
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        }
+      )
+      wrongStructureInstance = new InstanceElement(
+        'instance',
+        workflowType,
+        {
+          transitions: [
+            {
+              postFunctions: [
+                {
+                  type: SCRIPT_RUNNER_POST_FUNCTION_TYPE,
+                  configuration: {
+                    scriptRunner: {
+                      className: SCRIPT_RUNNER_SEND_NOTIFICATIONS,
+                      accountIds: [''],
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              rules: {
+                postFunctions: [
+                  {
+                    type: SCRIPT_RUNNER_POST_FUNCTION_TYPE,
+                    scriptRunner: {
+                      className: SCRIPT_RUNNER_SEND_NOTIFICATIONS,
+                      accountIds: [''],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        }
+      )
+    })
+    it('should remove empty account ids', async () => {
+      await filter.onFetch([instance])
+      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.scriptRunner.accountIds).toBeUndefined()
+      expect(instance.value.transitions[0].rules.postFunctions[2].configuration.scriptRunner.accountIds).toBeUndefined()
+      expect(instance.value.transitions[1].rules.postFunctions[0].configuration.scriptRunner.accountIds).toBeUndefined()
+    })
+    it('should not remove account ids that are not empty', async () => {
+      await filter.onFetch([instance])
+      expect(instance.value.transitions[0].rules.postFunctions[1].configuration.scriptRunner.accountIds).toEqual(['1'])
+      expect(instance.value.transitions[1].rules.postFunctions[1].configuration.scriptRunner.accountIds).toEqual(['1', '2'])
+    })
+    it('should not remove account ids when scriptRunner is not enabled', async () => {
+      await filterOff.onFetch([instance])
+      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.scriptRunner.accountIds).toEqual([''])
+    })
+    it('should not remove account ids when on dc', async () => {
+      await filterDC.onFetch([instance])
+      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.scriptRunner.accountIds).toEqual([''])
+    })
+    it('should not remove account ids when the structure is wrong', async () => {
+      await filter.onFetch([wrongStructureInstance])
+      expect(wrongStructureInstance.value.transitions[0].postFunctions[0].configuration.scriptRunner.accountIds).toEqual([''])
+      expect(wrongStructureInstance.value.transitions[1].rules.postFunctions[0].scriptRunner.accountIds).toEqual([''])
+    })
+  })
+  describe('pre deploy', () => {
+    beforeEach(() => {
+      instance = new InstanceElement(
+        'instance',
+        workflowType,
+        {
+          transitions: [
+            {
+              rules: {
+                postFunctions: [
+                  {
+                    type: SCRIPT_RUNNER_POST_FUNCTION_TYPE,
+                    configuration: {
+                      scriptRunner: {
+                        className: SCRIPT_RUNNER_SEND_NOTIFICATIONS,
+                      },
+                    },
+                  },
+                  {
+                    type: SCRIPT_RUNNER_POST_FUNCTION_TYPE,
+                    configuration: {
+                      scriptRunner: {
+                        className: SCRIPT_RUNNER_SEND_NOTIFICATIONS,
+                        accountIds: ['1'],
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        }
+      )
+    })
+    it('should return the accountIds empty field', async () => {
+      await filter.preDeploy([toChange({ after: instance })])
+      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.scriptRunner.accountIds).toEqual([''])
+    })
+    it('should not change accountIds that are not empty', async () => {
+      await filter.preDeploy([toChange({ after: instance })])
+      expect(instance.value.transitions[0].rules.postFunctions[1].configuration.scriptRunner.accountIds).toEqual(['1'])
+    })
+    it('should not return account ids when the structure is wrong', async () => {
+      wrongStructureInstance.value.transitions[0].postFunctions[0].configuration.scriptRunner.accountIds = undefined
+      wrongStructureInstance.value.transitions[1].rules.postFunctions[0].scriptRunner.accountIds = undefined
+      await filter.preDeploy([toChange({ after: wrongStructureInstance })])
+      expect(wrongStructureInstance.value.transitions[0].postFunctions[0].configuration.scriptRunner.accountIds)
+        .toBeUndefined()
+      expect(wrongStructureInstance.value.transitions[1].rules.postFunctions[0].scriptRunner.accountIds).toBeUndefined()
+    })
+  })
+  describe('on deploy', () => {
+    it('should remove empty accountIds', async () => {
+      await filter.onDeploy([toChange({ after: instance })])
+      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.scriptRunner.accountIds).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
_Removed empty accountIds to avoid errors during deployment_

---

_Not adding noise reduction as we do not have customers with enabled scriptrunner, except maybe Convex_

---
_Release Notes_: 
Jira Adapter:
* Fixed a bug in scriptRunner that prevented deployment of notification post functions without users

---
_User Notifications_: 
None
