### PR TITLE
SALTO-4397: Salesforce Additions Data Deployment Bugfix

### DIFF
--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -941,16 +941,17 @@ const transformCompoundValues = async (
 const toRecord = async (
   instance: InstanceElement,
   fieldAnnotationToFilterBy: string,
+  withNulls: boolean
 ): Promise<SalesforceRecord> => {
   const instanceType = await instance.getType()
-  const valsWithNulls = {
-    ..._.mapValues(instanceType.fields, () => null),
+  const values = {
+    ...withNulls ? _.mapValues(instanceType.fields, () => null) : {},
     ...instance.value,
   }
   const filteredRecordValues = {
     [CUSTOM_OBJECT_ID_FIELD]: instance.value[CUSTOM_OBJECT_ID_FIELD],
     ..._.pickBy(
-      valsWithNulls,
+      values,
       (_v, k) => (instanceType).fields[k]?.annotations[fieldAnnotationToFilterBy]
     ),
   }
@@ -960,12 +961,12 @@ const toRecord = async (
 export const instancesToUpdateRecords = async (
   instances: InstanceElement[]
 ): Promise<SalesforceRecord[]> =>
-  Promise.all(instances.map(instance => toRecord(instance, FIELD_ANNOTATIONS.UPDATEABLE)))
+  Promise.all(instances.map(instance => toRecord(instance, FIELD_ANNOTATIONS.UPDATEABLE, false)))
 
 export const instancesToCreateRecords = (
   instances: InstanceElement[]
 ): Promise<SalesforceRecord[]> =>
-  Promise.all(instances.map(instance => toRecord(instance, FIELD_ANNOTATIONS.CREATABLE)))
+  Promise.all(instances.map(instance => toRecord(instance, FIELD_ANNOTATIONS.CREATABLE, true)))
 
 export const instancesToDeleteRecords = (instances: InstanceElement[]): SalesforceRecord[] =>
   instances.map(instance => ({ Id: instance.value[CUSTOM_OBJECT_ID_FIELD] }))

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -961,12 +961,12 @@ const toRecord = async (
 export const instancesToUpdateRecords = async (
   instances: InstanceElement[]
 ): Promise<SalesforceRecord[]> =>
-  Promise.all(instances.map(instance => toRecord(instance, FIELD_ANNOTATIONS.UPDATEABLE, false)))
+  Promise.all(instances.map(instance => toRecord(instance, FIELD_ANNOTATIONS.UPDATEABLE, true)))
 
 export const instancesToCreateRecords = (
   instances: InstanceElement[]
 ): Promise<SalesforceRecord[]> =>
-  Promise.all(instances.map(instance => toRecord(instance, FIELD_ANNOTATIONS.CREATABLE, true)))
+  Promise.all(instances.map(instance => toRecord(instance, FIELD_ANNOTATIONS.CREATABLE, false)))
 
 export const instancesToDeleteRecords = (instances: InstanceElement[]): SalesforceRecord[] =>
   instances.map(instance => ({ Id: instance.value[CUSTOM_OBJECT_ID_FIELD] }))

--- a/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
@@ -454,7 +454,7 @@ describe('Custom Object Instances CRUD', () => {
             expect(updateCall[3][0].NotCreatable).toBeDefined()
             expect(updateCall[3][0].NotCreatable).toEqual('DontSendMeOnCreate')
             // Should deploy fields with no values as null
-            expect(updateCall[3][0].FieldWithNoValue).toBeNull()
+            expect(updateCall[3][0].FieldWithNoValue).toBeUndefined()
           })
 
           it('Should call load operation with insert for the "new" record', () => {

--- a/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
@@ -469,7 +469,6 @@ describe('Custom Object Instances CRUD', () => {
             expect(insertCall[3][0].NotCreatable).toBeUndefined()
             expect(insertCall[3][0].AnotherField).toBeDefined()
             expect(insertCall[3][0].AnotherField).toEqual('Type')
-            // Should deploy fields with no values as null
             expect(insertCall[3][0].FieldWithNoValue).toBeUndefined()
           })
 

--- a/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
@@ -454,7 +454,7 @@ describe('Custom Object Instances CRUD', () => {
             expect(updateCall[3][0].NotCreatable).toBeDefined()
             expect(updateCall[3][0].NotCreatable).toEqual('DontSendMeOnCreate')
             // Should deploy fields with no values as null
-            expect(updateCall[3][0].FieldWithNoValue).toBeUndefined()
+            expect(updateCall[3][0].FieldWithNoValue).toBeNull()
           })
 
           it('Should call load operation with insert for the "new" record', () => {
@@ -470,7 +470,7 @@ describe('Custom Object Instances CRUD', () => {
             expect(insertCall[3][0].AnotherField).toBeDefined()
             expect(insertCall[3][0].AnotherField).toEqual('Type')
             // Should deploy fields with no values as null
-            expect(insertCall[3][0].FieldWithNoValue).toBeNull()
+            expect(insertCall[3][0].FieldWithNoValue).toBeUndefined()
           })
 
           it('Should have result with 2 applied changes, add 2 instances with new Id', async () => {


### PR DESCRIPTION
Fixed data deployment bug due to regression in changes to Salesforce System Fields annotations.

---
_Release Notes_: 
Salesforce Adapter:
- Fixed a bug when attempting to deploy new Data Record instances.

---
_User Notifications_: 
_None_
