### PR TITLE
SALTO-4407: Add chunkByEvenly function to lowerdash

### DIFF
--- a/packages/lowerdash/src/chunks.ts
+++ b/packages/lowerdash/src/chunks.ts
@@ -33,3 +33,15 @@ export const weightedChunks = <T>(
   }, 0)
   return chunks
 }
+
+export const chunkByEvenly = <T>(
+  values: T[],
+  size: number,
+  weightFunc: (val: T) => number,
+): T[][] => {
+  const totalSize = values.reduce((sum, change) => sum + weightFunc(change), 0)
+  const avgChunkSize = totalSize / Math.ceil(totalSize / size)
+  const avgItemSize = totalSize / values.length
+  const desiredChunkSize = Math.min(size, avgChunkSize + (avgItemSize / 2))
+  return weightedChunks(values, desiredChunkSize, weightFunc)
+}

--- a/packages/lowerdash/test/chunks.test.ts
+++ b/packages/lowerdash/test/chunks.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { weightedChunks } from '../src/chunks'
+import { chunkByEvenly, weightedChunks } from '../src/chunks'
 
 describe('weightedChunks', () => {
   it('should split chunks correctly when first chunk is smaller than max size', () => {
@@ -23,5 +23,21 @@ describe('weightedChunks', () => {
   it('should split chunks correctly when first chunk is larger than max size', () => {
     const chunks = weightedChunks(['eeeeeeeeee', 'dddddd', 'cccc', 'bb', 'a'], 7, val => val.length)
     expect(chunks).toEqual([['eeeeeeeeee'], ['dddddd'], ['cccc', 'bb', 'a']])
+  })
+})
+
+describe('chunkByEvenly', () => {
+  const sum = (items: number[]): number => items.reduce((partialSum, next) => partialSum + next, 0)
+  it('should not surpass the hard limit when all items are below the limit', () => {
+    const limit = 6
+    const chunks = chunkByEvenly([1, 6, 3, 4, 1, 5, 2, 4, 6], limit, item => item)
+    chunks.map(sum).forEach(chunkSize => {
+      expect(chunkSize).toBeLessThanOrEqual(limit)
+    })
+  })
+  it('should chunk such that all groups are roughly the same size if possible', () => {
+    const limit = 12
+    const chunks = chunkByEvenly([1, 2, 3, 2, 3, 5, 2, 6, 1], limit, item => item)
+    expect(chunks.map(sum)).toEqual([8, 8, 9])
   })
 })


### PR DESCRIPTION
This function is like weightedChunks but attempts to split the chunks into roughly equal sizes.

---

This can be useful as part of SAAS-8289

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_