### PR TITLE
SAAS-7513 - Add some logs to workspace state initialization

### DIFF
--- a/packages/core/src/local-workspace/workspace.ts
+++ b/packages/core/src/local-workspace/workspace.ts
@@ -150,25 +150,28 @@ export const createEnvironmentSource = async ({
   remoteMapCreator: remoteMap.RemoteMapCreator
   stateStaticFilesSource?: staticFiles.StateStaticFilesSource
   persistent: boolean
-}): Promise<EnvironmentSource> => ({
-  naclFiles: await loadNaclFileSource(
-    baseDir,
-    path.resolve(localStorage, CACHE_DIR_NAME),
-    getLocalEnvName(env),
-    persistent,
-    remoteMapCreator,
-  ),
-  state: localState(
-    path.join(path.resolve(baseDir), CONFIG_DIR_NAME, STATES_DIR_NAME, env),
-    env,
-    remoteMapCreator,
-    stateStaticFilesSource ?? state.buildOverrideStateStaticFilesSource(localDirectoryStore({
-      baseDir: path.resolve(localStorage, STATIC_RESOURCES_FOLDER),
-      name: env,
-    })),
-    persistent
-  ),
-})
+}): Promise<EnvironmentSource> => {
+  log.debug('Creating environment source for %s at %s', env, baseDir)
+  return {
+    naclFiles: await loadNaclFileSource(
+      baseDir,
+      path.resolve(localStorage, CACHE_DIR_NAME),
+      getLocalEnvName(env),
+      persistent,
+      remoteMapCreator,
+    ),
+    state: localState(
+      path.join(path.resolve(baseDir), CONFIG_DIR_NAME, STATES_DIR_NAME, env),
+      env,
+      remoteMapCreator,
+      stateStaticFilesSource ?? state.buildOverrideStateStaticFilesSource(localDirectoryStore({
+        baseDir: path.resolve(localStorage, STATIC_RESOURCES_FOLDER),
+        name: env,
+      })),
+      persistent
+    ),
+  }
+}
 
 export const loadLocalElementsSources = async ({
   baseDir,

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -380,6 +380,7 @@ export const loadWorkspace = async (
     const initState = async (): Promise<WorkspaceState> => {
       const wsConfig = await config.getWorkspaceConfig()
       log.debug('initializing state for workspace %s/%s', wsConfig.uid, wsConfig.name)
+      log.debug('Full workspace config: %o', wsConfig)
       const states: Record<string, SingleState> = Object.fromEntries(await awu(envs())
         .map(async envName => [envName, {
           merged: new RemoteElementSource(

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -378,6 +378,8 @@ export const loadWorkspace = async (
     validate?: boolean
   }): Promise<WorkspaceState> => {
     const initState = async (): Promise<WorkspaceState> => {
+      const wsConfig = await config.getWorkspaceConfig()
+      log.debug('initializing state for workspace %s/%s', wsConfig.uid, wsConfig.name)
       const states: Record<string, SingleState> = Object.fromEntries(await awu(envs())
         .map(async envName => [envName, {
           merged: new RemoteElementSource(
@@ -758,6 +760,8 @@ export const loadWorkspace = async (
 
   const getWorkspaceState = async (): Promise<WorkspaceState> => {
     if (_.isUndefined(workspaceState)) {
+      const wsConfig = await config.getWorkspaceConfig()
+      log.debug('No workspace state for %s/%s. Building new workspace state.', wsConfig.uid, wsConfig.name)
       const workspaceChanges = await naclFilesSource.load({ ignoreFileChanges })
       workspaceState = buildWorkspaceState({
         workspaceChanges,


### PR DESCRIPTION
This issue has to do with way too many remote maps being opened. We don't know why, yet. Hopefully, adding some logs will point us in the right direction.

---

---
_Release Notes_: 
N/A

---
_User Notifications_: 
N/A