### PR TITLE
SALTO-4408 - Salesforce: Add more types to unknown_users change validator

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/unknown_users.ts
+++ b/packages/salesforce-adapter/src/change_validators/unknown_users.ts
@@ -41,6 +41,13 @@ const TYPES_WITH_USER_FIELDS = [
   'FolderShare',
   'WorkflowAlert',
   'WorkflowTask',
+  'WorkflowOutboundMessage',
+  'RuleEntry',
+  'Approver',
+  'CustomSite',
+  'EmailServicesAddress',
+  'PresenceConfigUserAssignments',
+  'Users',
 ] as const
 type TypeWithUserFields = typeof TYPES_WITH_USER_FIELDS[number]
 
@@ -112,6 +119,28 @@ const USER_GETTERS: TypesWithUserFields = {
   ],
   WorkflowTask: [
     userField('assignedTo', getUserDependingOnType('assignedToType')),
+  ],
+  WorkflowOutboundMessage: [
+    userField('integrationUser', userFieldValue),
+  ],
+  RuleEntry: [
+    userField('assignedTo', getUserDependingOnType('assignedToType')),
+  ],
+  Approver: [
+    userField('name', getUserDependingOnType('type')),
+  ],
+  CustomSite: [
+    userField('siteAdmin', userFieldValue),
+    userField('siteGuestRecordDefaultOwner', userFieldValue),
+  ],
+  EmailServicesAddress: [
+    userField('runAsUser', userFieldValue),
+  ],
+  PresenceConfigUserAssignments: [
+    userField('user', userFieldValue),
+  ],
+  Users: [
+    userField('user', userFieldValue),
   ],
 }
 

--- a/packages/salesforce-adapter/src/change_validators/unknown_users.ts
+++ b/packages/salesforce-adapter/src/change_validators/unknown_users.ts
@@ -46,7 +46,7 @@ const TYPES_WITH_USER_FIELDS = [
   'Approver',
   'CustomSite',
   'EmailServicesAddress',
-  'PresenceConfigUserAssignments',
+  'PresenceConfigAssignments',
   'Users',
 ] as const
 type TypeWithUserFields = typeof TYPES_WITH_USER_FIELDS[number]
@@ -136,7 +136,7 @@ const USER_GETTERS: TypesWithUserFields = {
   EmailServicesAddress: [
     userField('runAsUser', userFieldValue),
   ],
-  PresenceConfigUserAssignments: [
+  PresenceConfigAssignments: [
     userField('user', userFieldValue),
   ],
   Users: [


### PR DESCRIPTION
@pgonzaleznetwork noticed a few more fields we can validate. So let's validate them.

---


---
_Release Notes_: 
Salesforce: Additional fields are now validated for unknown users

---
_User Notifications_: 
N/A