### PR TITLE
SALTO-4396: Support multi brands in Okta

### DIFF
--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -729,11 +729,18 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
   api__v1__brands: {
     request: {
       url: '/api/v1/brands',
-      recurseInto: [{
-        type: 'api__v1__brands___brandId___themes@uuuuuu_00123_00125uu',
-        toField: 'theme',
-        context: [{ name: 'brandId', fromField: 'id' }],
-      }],
+      recurseInto: [
+        {
+          type: 'api__v1__brands___brandId___themes@uuuuuu_00123_00125uu',
+          toField: 'theme',
+          context: [{ name: 'brandId', fromField: 'id' }],
+        },
+        {
+          type: 'api__v1__brands___brandId___templates__email@uuuuuu_00123_00125uuuu',
+          toField: 'emailTemplates',
+          context: [{ name: 'brandId', fromField: 'id' }],
+        },
+      ],
     },
     transformation: {
       dataField: '.',
@@ -750,7 +757,6 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
   'api__v1__brands___brandId___templates__email@uuuuuu_00123_00125uuuu': {
     request: {
       url: '/api/v1/brands/{brandId}/templates/email',
-      dependsOn: [{ pathParam: 'brandId', from: { type: 'api__v1__brands', field: 'id' } }],
     },
     transformation: {
       dataField: '.',
@@ -775,7 +781,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
   },
   Domain: {
     transformation: {
-      isSingleton: true,
+      idFields: ['domain'],
       serviceIdField: 'id',
       fieldsToHide: [{ fieldName: 'id' }],
       fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),
@@ -817,13 +823,15 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
   },
   Brand: {
     transformation: {
-      isSingleton: true,
       serviceIdField: 'id',
       fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),
       fieldsToHide: [{ fieldName: 'id' }],
-      standaloneFields: [{ fieldName: 'theme' }],
+      standaloneFields: [{ fieldName: 'theme' }, { fieldName: 'emailTemplates' }],
       nestStandaloneInstances: false,
-      fieldTypeOverrides: [{ fieldName: 'theme', fieldType: 'list<BrandTheme>' }],
+      fieldTypeOverrides: [
+        { fieldName: 'theme', fieldType: 'list<BrandTheme>' },
+        { fieldName: 'emailTemplates', fieldType: 'list<EmailTemplate>' },
+      ],
       serviceUrl: '/admin/customizations/footer',
     },
     deployRequests: {
@@ -838,7 +846,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
   },
   BrandTheme: {
     transformation: {
-      isSingleton: true,
+      idFields: [],
       serviceIdField: 'id',
       fieldsToHide: [
         { fieldName: 'id' },
@@ -921,6 +929,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
   },
   EmailTemplate: {
     transformation: {
+      idFields: [],
       serviceIdField: 'name',
       fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),
     },

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -399,6 +399,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
     },
     transformation: {
       idFields: [],
+      extendsParentId: true,
       dataField: '.',
       fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat(
         { fieldName: '$schema' },
@@ -862,6 +863,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
   BrandTheme: {
     transformation: {
       idFields: [],
+      extendsParentId: true,
       serviceIdField: 'id',
       fieldsToHide: [
         { fieldName: 'id' },
@@ -945,6 +947,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
   EmailTemplate: {
     transformation: {
       idFields: [],
+      extendsParentId: true,
       serviceIdField: 'name',
       fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),
     },

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -946,7 +946,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
   },
   EmailTemplate: {
     transformation: {
-      idFields: [],
+      idFields: ['name'],
       extendsParentId: true,
       serviceIdField: 'name',
       fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -787,6 +787,21 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
       fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),
     },
   },
+  'api__v1__email_domains@uuuub': {
+    request: {
+      url: '/api/v1/email-domains',
+    },
+    transformation: {
+      dataField: '.',
+    },
+  },
+  EmailDomain: {
+    transformation: {
+      idFields: ['displayName'],
+      serviceIdField: 'id',
+      fieldsToHide: [{ fieldName: 'id' }],
+    },
+  },
   OrgSetting: {
     request: {
       url: '/api/v1/org',
@@ -1439,6 +1454,7 @@ const DEFAULT_SWAGGER_CONFIG: OktaSwaggerApiConfig['swagger'] = {
   ],
   typeNameOverrides: [
     { originalName: 'DomainResponse', newName: 'Domain' },
+    { originalName: 'EmailDomainResponse', newName: 'EmailDomain' },
     { originalName: 'ThemeResponse', newName: 'BrandTheme' },
     { originalName: 'Role', newName: 'RoleAssignment' },
     { originalName: 'IamRole', newName: 'Role' },
@@ -1478,6 +1494,7 @@ export const SUPPORTED_TYPES = {
   TrustedOrigin: ['api__v1__trustedOrigins'],
   NetworkZone: ['api__v1__zones'],
   Domain: ['DomainListResponse'],
+  EmailDomain: ['api__v1__email_domains@uuuub'],
   Role: ['IamRoles'],
   BehaviorRule: ['api__v1__behaviors'],
   PerClientRateLimit: ['PerClientRateLimitSettings'],

--- a/packages/okta-adapter/src/filters/app_logo.ts
+++ b/packages/okta-adapter/src/filters/app_logo.ts
@@ -23,7 +23,7 @@ import Joi from 'joi'
 import { OktaConfig } from '../config'
 import { APPLICATION_TYPE_NAME, APP_LOGO_TYPE_NAME, LINKS_FIELD } from '../constants'
 import { FilterCreator } from '../filter'
-import { createLogoType, deployLogo, getLogo } from '../logo'
+import { createFileType, deployLogo, getLogo } from '../logo'
 import OktaClient from '../client/client'
 
 const log = logger(module)
@@ -99,7 +99,7 @@ const appLogoFilter: FilterCreator = ({ client, config }) => ({
       .filter(isInstanceElement)
       .filter(instance => instance.elemID.typeName === APPLICATION_TYPE_NAME)
       .filter(instance => isAppInstance(instance))
-    const appLogoType = createLogoType(APP_LOGO_TYPE_NAME)
+    const appLogoType = createFileType(APP_LOGO_TYPE_NAME)
     elements.push(appLogoType)
 
     const allInstances = (await Promise.all(appsWithLogo

--- a/packages/okta-adapter/src/filters/brand_theme_files.ts
+++ b/packages/okta-adapter/src/filters/brand_theme_files.ts
@@ -19,7 +19,7 @@ import { getParents } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { BRAND_LOGO_TYPE_NAME, BRAND_THEME_TYPE_NAME, FAV_ICON_TYPE_NAME } from '../constants'
 import { FilterCreator } from '../filter'
-import { LOGO_TYPES_TO_VALUES, createLogoType, deployLogo, getLogo } from '../logo'
+import { LOGO_TYPES_TO_VALUES, createFileType, deployLogo, getLogo } from '../logo'
 import OktaClient from '../client/client'
 
 const logoTypeNames = [BRAND_LOGO_TYPE_NAME, FAV_ICON_TYPE_NAME]
@@ -86,7 +86,8 @@ const brandThemeFilesFilter: FilterCreator = ({ client }) => ({
       .filter(isInstanceElement)
       .filter(instance => instance.elemID.typeName === BRAND_THEME_TYPE_NAME)
 
-    const [logoType, faviconType] = [createLogoType(BRAND_LOGO_TYPE_NAME), createLogoType(FAV_ICON_TYPE_NAME)]
+    const [logoType, faviconType] = [createFileType(BRAND_LOGO_TYPE_NAME), createFileType(FAV_ICON_TYPE_NAME)]
+    elements.push(logoType, faviconType)
 
     const brandLogosInstances = await Promise.all(brandThemes.map(async brand => {
       const logoInstance = await getBrandThemeFile(client, brand, logoType)

--- a/packages/okta-adapter/src/filters/brand_theme_files.ts
+++ b/packages/okta-adapter/src/filters/brand_theme_files.ts
@@ -15,15 +15,13 @@
 */
 
 import { Change, InstanceElement, ObjectType, isInstanceElement, DeployResult, getChangeData, SaltoError } from '@salto-io/adapter-api'
-import { logger } from '@salto-io/logging'
 import { getParents } from '@salto-io/adapter-utils'
 import _ from 'lodash'
-import { BRAND_LOGO_TYPE_NAME, BRAND_THEME_TYPE_NAME, BRAND_TYPE_NAME, FAV_ICON_TYPE_NAME } from '../constants'
+import { BRAND_LOGO_TYPE_NAME, BRAND_THEME_TYPE_NAME, FAV_ICON_TYPE_NAME } from '../constants'
 import { FilterCreator } from '../filter'
 import { LOGO_TYPES_TO_VALUES, createLogoType, deployLogo, getLogo } from '../logo'
 import OktaClient from '../client/client'
 
-const log = logger(module)
 const logoTypeNames = [BRAND_LOGO_TYPE_NAME, FAV_ICON_TYPE_NAME]
 
 const getBrandThemeFile = async (
@@ -33,9 +31,16 @@ const getBrandThemeFile = async (
 ): Promise<InstanceElement | Error> => {
   const parents = getParents(brandTheme)
   const instances = [brandTheme, parents[0].value]
-  const { fileType, fileName, urlSuffix } = LOGO_TYPES_TO_VALUES[logoType.elemID.typeName]
+  const { fileType, urlSuffix } = LOGO_TYPES_TO_VALUES[logoType.elemID.typeName]
   const link = brandTheme.value?.[urlSuffix]
-  return getLogo({ client, parents: instances, logoType, contentType: fileType, link, logoName: fileName })
+  return getLogo({
+    client,
+    parents: instances,
+    logoType,
+    contentType: fileType,
+    link,
+    logoName: brandTheme.elemID.name,
+  })
 }
 
 const deployBrandThemeFiles = async (
@@ -77,24 +82,19 @@ const toSaltoError = (err: Error): SaltoError => ({
 const brandThemeFilesFilter: FilterCreator = ({ client }) => ({
   name: 'brandThemeFilesFilter',
   onFetch: async elements => {
-    const brandTheme = elements
+    const brandThemes = elements
       .filter(isInstanceElement)
-      .find(instance => instance.elemID.typeName === BRAND_THEME_TYPE_NAME)
-    if (brandTheme === undefined || getParents(brandTheme)[0].value.elemID.typeName !== BRAND_TYPE_NAME) {
-      log.warn('No valid BrandTheme was found, skipping BrandLogo and BrandFavicon fetch')
-      const saltoErr: SaltoError = {
-        message: 'No valid BrandTheme was found, skipping BrandLogo and BrandFavicon fetch',
-        severity: 'Warning',
-      }
-      return { errors: [saltoErr] }
-    }
-    const logoTypes = logoTypeNames.map(logoTypeName => createLogoType(logoTypeName))
-    logoTypes.forEach(logoType => elements.push(logoType))
+      .filter(instance => instance.elemID.typeName === BRAND_THEME_TYPE_NAME)
 
-    const allInstances = await Promise.all(logoTypes.map(async logoType =>
-      getBrandThemeFile(client, brandTheme, logoType)))
+    const [logoType, faviconType] = [createLogoType(BRAND_LOGO_TYPE_NAME), createLogoType(FAV_ICON_TYPE_NAME)]
 
-    const [fetchErrors, instances] = _.partition(allInstances, _.isError)
+    const brandLogosInstances = await Promise.all(brandThemes.map(async brand => {
+      const logoInstance = await getBrandThemeFile(client, brand, logoType)
+      const faviconInstance = await getBrandThemeFile(client, brand, faviconType)
+      return [logoInstance, faviconInstance]
+    }))
+
+    const [fetchErrors, instances] = _.partition(brandLogosInstances.flat(), _.isError)
     instances.forEach(instance => elements.push(instance))
     const err = fetchErrors.map(toSaltoError)
     return { errors: err }

--- a/packages/okta-adapter/src/filters/delete_fields.ts
+++ b/packages/okta-adapter/src/filters/delete_fields.ts
@@ -22,7 +22,7 @@ const TYPES_TO_FIELDS: Record<string, string[]> = {
   [APPLICATION_TYPE_NAME]: ['appUserSchema'],
   [AUTHORIZATION_POLICY_RULE]: ['policyRules'],
   ...Object.fromEntries(POLICY_TYPE_NAMES.map(typeName => [typeName, ['policyRules']])),
-  Brand: ['theme'],
+  Brand: ['theme', 'emailTemplates'],
 }
 
 /**

--- a/packages/okta-adapter/src/logo.ts
+++ b/packages/okta-adapter/src/logo.ts
@@ -111,7 +111,7 @@ export const deployLogo = async (
   }
 }
 
-export const createLogoType = (objectTypeName: string): ObjectType =>
+export const createFileType = (objectTypeName: string): ObjectType =>
   new ObjectType({
     elemID: new ElemID(OKTA, objectTypeName),
     fields: {

--- a/packages/okta-adapter/src/logo.ts
+++ b/packages/okta-adapter/src/logo.ts
@@ -27,7 +27,6 @@ import { extractIdFromUrl } from './utils'
 const { SUBTYPES_PATH, TYPES_PATH, RECORDS_PATH } = elementsUtils
 
 type BrandFileValues = {
-  fileName: string
   fileType: string
   urlSuffix: string
 }
@@ -35,12 +34,10 @@ type BrandFileValues = {
 // https://developer.okta.com/docs/reference/api/brands/#response-10
 export const LOGO_TYPES_TO_VALUES: Record<string, BrandFileValues> = {
   [BRAND_LOGO_TYPE_NAME]: {
-    fileName: 'brandLogo',
     fileType: 'png',
     urlSuffix: 'logo',
   },
   [FAV_ICON_TYPE_NAME]: {
-    fileName: 'favicon',
     fileType: 'ico',
     urlSuffix: 'favicon',
   },

--- a/packages/okta-adapter/src/reference_mapping.ts
+++ b/packages/okta-adapter/src/reference_mapping.ts
@@ -18,7 +18,7 @@ import { isReferenceExpression } from '@salto-io/adapter-api'
 import { references as referenceUtils } from '@salto-io/adapter-components'
 import { GetLookupNameFunc } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
-import { APPLICATION_TYPE_NAME, GROUP_TYPE_NAME, IDENTITY_PROVIDER_TYPE_NAME, USERTYPE_TYPE_NAME, FEATURE_TYPE_NAME, NETWORK_ZONE_TYPE_NAME, ROLE_TYPE_NAME, ACCESS_POLICY_TYPE_NAME, PROFILE_ENROLLMENT_POLICY_TYPE_NAME, INLINE_HOOK_TYPE_NAME, AUTHENTICATOR_TYPE_NAME, BEHAVIOR_RULE_TYPE_NAME, USER_SCHEMA_TYPE_NAME, ROLE_ASSIGNMENT_TYPE_NAME } from './constants'
+import { APPLICATION_TYPE_NAME, GROUP_TYPE_NAME, IDENTITY_PROVIDER_TYPE_NAME, USERTYPE_TYPE_NAME, FEATURE_TYPE_NAME, NETWORK_ZONE_TYPE_NAME, ROLE_TYPE_NAME, ACCESS_POLICY_TYPE_NAME, PROFILE_ENROLLMENT_POLICY_TYPE_NAME, INLINE_HOOK_TYPE_NAME, AUTHENTICATOR_TYPE_NAME, BEHAVIOR_RULE_TYPE_NAME, USER_SCHEMA_TYPE_NAME, ROLE_ASSIGNMENT_TYPE_NAME, BRAND_TYPE_NAME } from './constants'
 import { resolveUserSchemaRef } from './filters/expression_language'
 
 const { awu } = collections.asynciterable
@@ -212,6 +212,22 @@ export const referencesRules: OktaFieldReferenceDefinition[] = [
   { src: { field: 'include', parentTypes: ['DeviceCondition'] },
     serializationStrategy: 'id',
     target: { type: 'DeviceAssurance' } },
+  // TODO figure out type
+  // {
+  //   src: { field: 'emailDomainId', parentTypes: ['Brand'] },
+  //   serializationStrategy: 'id',
+  //   target: { type:  },
+  // },
+  {
+    src: { field: 'appInstanceId', parentTypes: ['DefaultApp'] },
+    serializationStrategy: 'id',
+    target: { type: APPLICATION_TYPE_NAME },
+  },
+  {
+    src: { field: 'brandId', parentTypes: ['Domain'] },
+    serializationStrategy: 'id',
+    target: { type: BRAND_TYPE_NAME },
+  },
 ]
 
 // Resolve references to userSchema fields references to field name instead of full value

--- a/packages/okta-adapter/src/reference_mapping.ts
+++ b/packages/okta-adapter/src/reference_mapping.ts
@@ -212,12 +212,11 @@ export const referencesRules: OktaFieldReferenceDefinition[] = [
   { src: { field: 'include', parentTypes: ['DeviceCondition'] },
     serializationStrategy: 'id',
     target: { type: 'DeviceAssurance' } },
-  // TODO figure out type
-  // {
-  //   src: { field: 'emailDomainId', parentTypes: ['Brand'] },
-  //   serializationStrategy: 'id',
-  //   target: { type:  },
-  // },
+  {
+    src: { field: 'emailDomainId', parentTypes: ['Brand'] },
+    serializationStrategy: 'id',
+    target: { type: 'EmailDomain' },
+  },
   {
     src: { field: 'appInstanceId', parentTypes: ['DefaultApp'] },
     serializationStrategy: 'id',

--- a/packages/okta-adapter/test/filters/brand_theme_files.test.ts
+++ b/packages/okta-adapter/test/filters/brand_theme_files.test.ts
@@ -78,14 +78,14 @@ describe('brand files filter', () => {
       expect(elements.map(e => e.elemID.getFullName()).sort())
         .toEqual([
           'okta.BrandLogo',
-          'okta.BrandLogo.instance.brandLogo',
+          'okta.BrandLogo.instance.brandTheme1',
           'okta.BrandTheme',
           'okta.BrandTheme.instance.brandTheme1',
           'okta.FavIcon',
-          'okta.FavIcon.instance.favicon',
+          'okta.FavIcon.instance.brandTheme1',
         ])
     })
-    it('check that barndLogo instance and the favicon instance have the correct values', async () => {
+    it('check that brandLogo instance and the favicon instance have the correct values', async () => {
       const elements = [brandThemeType, brandThemeInstance].map(e => e.clone())
       await filter.onFetch(elements)
       const instances = elements.filter(isInstanceElement)
@@ -93,18 +93,18 @@ describe('brand files filter', () => {
       const favicon = instances.find(e => e.elemID.typeName === FAV_ICON_TYPE_NAME)
       expect(logo?.value).toEqual({
         id: '111',
-        fileName: 'brandLogo.png',
+        fileName: 'brandTheme1.png',
         contentType: 'png',
         content: new StaticFile({
-          filepath: 'okta/BrandLogo/brandLogo.png', encoding: 'binary', content,
+          filepath: 'okta/BrandLogo/brandTheme1.png', encoding: 'binary', content,
         }),
       })
       expect(favicon?.value).toEqual({
         id: '111',
-        fileName: 'favicon.ico',
+        fileName: 'brandTheme1.ico',
         contentType: 'ico',
         content: new StaticFile({
-          filepath: 'okta/FavIcon/favicon.ico', encoding: 'binary', content,
+          filepath: 'okta/FavIcon/brandTheme1.ico', encoding: 'binary', content,
         }),
       })
     })
@@ -116,15 +116,6 @@ describe('brand files filter', () => {
       expect(res.errors).toHaveLength(1)
       expect(res.errors?.[0]).toEqual({
         message: 'Failed to fetch brandTheme file. Failed to fetch attachment content from Okta API',
-        severity: 'Warning',
-      })
-    })
-    it('should return errors for not finding brandTheme instance', async () => {
-      const elements = [brandThemeType]
-      const res = await filter.onFetch(elements) as FilterResult
-      expect(res.errors).toHaveLength(1)
-      expect(res.errors?.[0]).toEqual({
-        message: 'No valid BrandTheme was found, skipping BrandLogo and BrandFavicon fetch',
         severity: 'Warning',
       })
     })

--- a/packages/okta-adapter/test/logo.test.ts
+++ b/packages/okta-adapter/test/logo.test.ts
@@ -18,7 +18,7 @@ import { ElemID, BuiltinTypes, CORE_ANNOTATIONS, ObjectType, InstanceElement, Re
 import { TYPES_PATH, SUBTYPES_PATH } from '@salto-io/adapter-components/src/elements'
 import OktaClient from '../src/client/client'
 import { APPLICATION_TYPE_NAME, APP_LOGO_TYPE_NAME, LINKS_FIELD, OKTA } from '../src/constants'
-import { createLogoType, deployLogo, getLogo } from '../src/logo'
+import { createFileType, deployLogo, getLogo } from '../src/logo'
 import { mockClient } from './utils'
 
 describe('logo filter', () => {
@@ -47,9 +47,9 @@ describe('logo filter', () => {
   const fileName = 'app1'
   const link = 'https://ok12static.oktacdn.com/fs/bco/4/111'
   const appLogoType = new ObjectType({ elemID: new ElemID(OKTA, APP_LOGO_TYPE_NAME) })
-  describe('createLogoType', () => {
+  describe('createFileType', () => {
     it('should create logo type', () => {
-      const logoType = createLogoType(APP_LOGO_TYPE_NAME)
+      const logoType = createFileType(APP_LOGO_TYPE_NAME)
       expect(logoType.elemID.name).toEqual(APP_LOGO_TYPE_NAME)
       expect(logoType).toEqual(new ObjectType({
         elemID: new ElemID(OKTA, APP_LOGO_TYPE_NAME),


### PR DESCRIPTION
Okta made a change and they now support more than one brand per org

---

Okta now supports defining more than one brand per org.
This means that on dependent types are no longer singletons.
Also, they added some references to the API response of `Domain` and `Brand`
(Still missing one more ref that I need to resolve)

---
_Release Notes_: 

_Okta_adapter_:
- Support multibrand customizations
- Support fetch of 'EmailDomain' instances

---
_User Notifications_: 

_Okta_adapter_:
- Changes to `Brand`, `BrandTheme`, `BrandLogo` and `Domain` instances due to recent changes in Okta
- 'EmailDomain' instances will be added
