### PR TITLE
SALTO-4340: skip querying bundleable if SuiteBundles feature is disabled

### DIFF
--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_file_cabinet.ts
@@ -264,6 +264,7 @@ SuiteAppFileCabinetOperations => {
       const foldersResults = await suiteAppClient.runSuiteQL(foldersQuery, THROW_ON_MISSING_FEATURE_ERROR)
       return { folderResults: validateFoldersResults(foldersResults), isSuiteBundlesEnabled: true }
     } catch (e) {
+      console.log(e.message)
       if (e.message === SUITEBUNDLES_DISABLED_ERROR) {
         const noBundleableQuery = foldersQuery.replace(', bundleable', '')
         const queryResult = await suiteAppClient.runSuiteQL(noBundleableQuery, THROW_ON_MISSING_FEATURE_ERROR)

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_file_cabinet.ts
@@ -166,8 +166,7 @@ export const SUITEBUNDLES_DISABLED_ERROR = 'Failed to list folders. Please verif
 
 
 export const THROW_ON_MISSING_FEATURE_ERROR: Record<string, string> = {
-  'Search error occurred: Unknown identifier \'bundleable\'':
-    'Failed to list folders. Please verify that the "Create bundles with SuiteBundler" feature is enabled in the account.',
+  'Search error occurred: Unknown identifier \'bundleable\'': SUITEBUNDLES_DISABLED_ERROR,
 }
 
 export type SuiteAppFileCabinetOperations = {

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_file_cabinet.ts
@@ -264,7 +264,6 @@ SuiteAppFileCabinetOperations => {
       const foldersResults = await suiteAppClient.runSuiteQL(foldersQuery, THROW_ON_MISSING_FEATURE_ERROR)
       return { folderResults: validateFoldersResults(foldersResults), isSuiteBundlesEnabled: true }
     } catch (e) {
-      console.log(e.message)
       if (e.message === SUITEBUNDLES_DISABLED_ERROR) {
         const noBundleableQuery = foldersQuery.replace(', bundleable', '')
         const queryResult = await suiteAppClient.runSuiteQL(noBundleableQuery, THROW_ON_MISSING_FEATURE_ERROR)

--- a/packages/netsuite-adapter/test/client/suiteapp_client/suiteapp_file_cabinet.test.ts
+++ b/packages/netsuite-adapter/test/client/suiteapp_client/suiteapp_file_cabinet.test.ts
@@ -537,7 +537,7 @@ describe('suiteapp_file_cabinet', () => {
 
     it('should remove \'bundleable\' from query and try again if SuiteBundles ins\'t enabled', async () => {
       mockSuiteAppClient.runSuiteQL.mockImplementation(async suiteQlQuery => {
-        if (suiteQlQuery.includes('hidebundle', 'bundleabe')) {
+        if (suiteQlQuery.includes('bundleable') || suiteQlQuery.includes('hideinbundle')) {
           throw new Error(SUITEBUNDLES_DISABLED_ERROR)
         }
         if (suiteQlQuery.includes('FROM file')) {
@@ -545,7 +545,6 @@ describe('suiteapp_file_cabinet', () => {
         }
         return getFoldersResponse(suiteQlQuery)
       })
-      mockSuiteAppClient.runSuiteQL.mockRejectedValueOnce(Error(SUITEBUNDLES_DISABLED_ERROR))
       await createSuiteAppFileCabinetOperations(suiteAppClient).importFileCabinet(query, maxFileCabinetSizeInGB)
       expect(suiteAppClient.runSuiteQL).toHaveBeenNthCalledWith(1, "SELECT name, id, bundleable, isinactive, isprivate, description, parent FROM mediaitemfolder WHERE istoplevel = 'T' ORDER BY id ASC", THROW_ON_MISSING_FEATURE_ERROR)
       expect(suiteAppClient.runSuiteQL).toHaveBeenNthCalledWith(2, "SELECT name, id, isinactive, isprivate, description, parent FROM mediaitemfolder WHERE istoplevel = 'T' ORDER BY id ASC", THROW_ON_MISSING_FEATURE_ERROR)

--- a/packages/netsuite-adapter/test/client/suiteapp_client/suiteapp_file_cabinet.test.ts
+++ b/packages/netsuite-adapter/test/client/suiteapp_client/suiteapp_file_cabinet.test.ts
@@ -545,7 +545,9 @@ describe('suiteapp_file_cabinet', () => {
         }
         return getFoldersResponse(suiteQlQuery)
       })
-      await createSuiteAppFileCabinetOperations(suiteAppClient).importFileCabinet(query, maxFileCabinetSizeInGB)
+      const { elements } = await createSuiteAppFileCabinetOperations(suiteAppClient)
+        .importFileCabinet(query, maxFileCabinetSizeInGB)
+      expect(elements).toEqual(expectedResults)
       expect(suiteAppClient.runSuiteQL).toHaveBeenNthCalledWith(1, "SELECT name, id, bundleable, isinactive, isprivate, description, parent FROM mediaitemfolder WHERE istoplevel = 'T' ORDER BY id ASC", THROW_ON_MISSING_FEATURE_ERROR)
       expect(suiteAppClient.runSuiteQL).toHaveBeenNthCalledWith(2, "SELECT name, id, isinactive, isprivate, description, parent FROM mediaitemfolder WHERE istoplevel = 'T' ORDER BY id ASC", THROW_ON_MISSING_FEATURE_ERROR)
       expect(suiteAppClient.runSuiteQL).toHaveBeenNthCalledWith(3, "SELECT name, id, isinactive, isprivate, description, parent FROM mediaitemfolder WHERE istoplevel = 'F' AND (appfolder LIKE 'folder5%') ORDER BY id ASC", THROW_ON_MISSING_FEATURE_ERROR)


### PR DESCRIPTION
_skip querying bundleable if SuiteBundles feature is disabled_

---

_None_

---
_Release Notes_: 
_Netsuite Adapter_:
* If the SuiteBundles feature is disabled skip querying the bundleable field

---
_User Notifications_: 
_None_
