### PR TITLE
SALTO-4417: Fix Workflow Deployment bug

### DIFF
--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -391,19 +391,16 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
   {
     src: { field: 'defaultWorkflow', parentTypes: ['WorkflowScheme'] },
     serializationStrategy: 'name',
-    jiraMissingRefStrategy: 'typeAndValue',
     target: { type: WORKFLOW_TYPE_NAME },
   },
   {
     src: { field: 'workflow', parentTypes: ['WorkflowSchemeItem'] },
     serializationStrategy: 'name',
-    jiraMissingRefStrategy: 'typeAndValue',
     target: { type: WORKFLOW_TYPE_NAME },
   },
   {
     src: { field: 'issueType', parentTypes: ['WorkflowSchemeItem'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
     target: { type: ISSUE_TYPE_NAME },
   },
   {


### PR DESCRIPTION
_Fixed a bug that prevented the deployment of a workflow if there is a workflow scheme with a reference to it and a missing reference_

---

Other solutions that I could think of were too complicated.
The best solution IMO remains to change the way we deploy workflow modifications

---
_Release Notes_: 
Jira Adapter: 
* Fixed a bug that prevented workflow modification deployment in some cases

---
_User Notifications_: 
None
