### PR TITLE
SALTO-4420: add global looped transition to workflow diagrams - Jira

### DIFF
--- a/packages/jira-adapter/src/filters/workflow/types.ts
+++ b/packages/jira-adapter/src/filters/workflow/types.ts
@@ -184,6 +184,7 @@ export type Workflow = {
   transitions: Transition[]
   statuses?: Status[]
   diagramInitialEntry?: StatusLocation
+  globalLoopedTransition?: StatusLocation
 }
 
 export const workflowSchema = Joi.object({

--- a/packages/jira-adapter/src/filters/workflow/types.ts
+++ b/packages/jira-adapter/src/filters/workflow/types.ts
@@ -184,7 +184,7 @@ export type Workflow = {
   transitions: Transition[]
   statuses?: Status[]
   diagramInitialEntry?: StatusLocation
-  globalLoopedTransition?: StatusLocation
+  diagramGlobalLoopedTransition?: StatusLocation
 }
 
 export const workflowSchema = Joi.object({

--- a/packages/jira-adapter/src/filters/workflow/workflow_diagrams.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_diagrams.ts
@@ -175,7 +175,7 @@ export const removeWorkflowDiagramFields = (element: WorkflowInstance): void => 
       }
     })
   delete element.value.diagramInitialEntry
-  delete element.value.globalLoopedTransition
+  delete element.value.diagramGlobalLoopedTransition
 }
 
 const buildStatusDiagramFields = (workflow: WorkflowInstance, statusIdToStepId: Record<string, string>)
@@ -300,7 +300,7 @@ const insertWorkflowDiagramFields = (workflow: WorkflowInstance,
     x: statusIdToStatus.initial?.x,
     y: statusIdToStatus.initial?.y,
   }
-  workflow.value.globalLoopedTransition = loopedTransitionContainer
+  workflow.value.diagramGlobalLoopedTransition = loopedTransitionContainer
   workflow.value.transitions.forEach(transition => {
     const transitionName = transition.name
     if (transition.type === INITIAL_TRANSITION_TYPE && transitionName !== undefined) {
@@ -331,13 +331,15 @@ export const deployWorkflowDiagram = async (
   const { statusIdToStepId, actionKeyToTransition } = workflowDiagramMaps
   const statuses = buildStatusDiagramFields(instance, statusIdToStepId)
   const transitions = buildTransitionsDiagramFields(instance, statusIdToStepId, actionKeyToTransition)
-
+  const layout = instance.value.diagramGlobalLoopedTransition !== undefined
+    ? { statuses, transitions, loopedTransitionContainer: instance.value.diagramGlobalLoopedTransition }
+    : { statuses, transitions }
   const response = await client.postPrivate({
     url: '/rest/workflowDesigner/latest/workflows',
     data: {
       draft: false,
       name: instance.value.name,
-      layout: { statuses, transitions, loopedTransitionContainer: instance.value.globalLoopedTransition },
+      layout,
     },
   })
   if (response.status !== 200) {
@@ -365,8 +367,8 @@ const filter: FilterCreator = ({ client }) => ({
     if (workflowType !== undefined) {
       workflowType.fields.diagramInitialEntry = new Field(workflowType, 'diagramInitialEntry', statusLocationType)
       setFieldDeploymentAnnotations(workflowType, 'diagramInitialEntry')
-      workflowType.fields.globalLoopedTransition = new Field(workflowType, 'globalLoopedTransition', statusLocationType)
-      setFieldDeploymentAnnotations(workflowType, 'globalLoopedTransition')
+      workflowType.fields.diagramGlobalLoopedTransition = new Field(workflowType, 'diagramGlobalLoopedTransition', statusLocationType)
+      setFieldDeploymentAnnotations(workflowType, 'diagramGlobalLoopedTransition')
     }
     elements.push(transitionFromType)
     elements.push(statusLocationType)

--- a/packages/jira-adapter/test/filters/workflow/workflow_deploy_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_deploy_filter.test.ts
@@ -24,7 +24,6 @@ import workflowFilter, { INITIAL_VALIDATOR } from '../../../src/filters/workflow
 import { getFilterParams, mockClient } from '../../utils'
 import { WITH_PERMISSION_VALIDATORS } from './workflow_values'
 
-jest.setTimeout(99999999)
 
 jest.mock('@salto-io/adapter-components', () => {
   const actual = jest.requireActual('@salto-io/adapter-components')
@@ -504,7 +503,7 @@ describe('workflowDeployFilter', () => {
               x: 33,
               y: 66,
             },
-            globalLoopedTransition: {
+            diagramGlobalLoopedTransition: {
               x: -15.85,
               y: 109.40,
             },
@@ -571,6 +570,8 @@ describe('workflowDeployFilter', () => {
               },
               {
                 name: 'looped',
+                from: [],
+                to: '',
                 type: 'global',
               },
             ],

--- a/packages/jira-adapter/test/filters/workflow/workflow_deploy_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_deploy_filter.test.ts
@@ -24,6 +24,8 @@ import workflowFilter, { INITIAL_VALIDATOR } from '../../../src/filters/workflow
 import { getFilterParams, mockClient } from '../../utils'
 import { WITH_PERMISSION_VALIDATORS } from './workflow_values'
 
+jest.setTimeout(99999999)
+
 jest.mock('@salto-io/adapter-components', () => {
   const actual = jest.requireActual('@salto-io/adapter-components')
   return {
@@ -502,6 +504,10 @@ describe('workflowDeployFilter', () => {
               x: 33,
               y: 66,
             },
+            globalLoopedTransition: {
+              x: -15.85,
+              y: 109.40,
+            },
             transitions: [
               {
                 name: 'Building',
@@ -562,6 +568,10 @@ describe('workflowDeployFilter', () => {
                 ],
                 to: '10007',
                 type: 'directed',
+              },
+              {
+                name: 'looped',
+                type: 'global',
               },
             ],
           }
@@ -675,7 +685,19 @@ describe('workflowDeployFilter', () => {
                   sourceAngle: 78.11,
                   targetAngle: -173.58,
                 },
+                {
+                  id: 'A<51:S<-1>:S<-1>>',
+                  name: 'looped',
+                  sourceId: 'S<-1>',
+                  targetId: 'S<-1>',
+                  globalTransition: true,
+                  loopedTransition: true,
+                },
               ],
+              loopedTransitionContainer: {
+                x: -15.85,
+                y: 109.40,
+              },
             },
           },
         })
@@ -759,6 +781,10 @@ describe('workflowDeployFilter', () => {
                 targetAngle: 1,
               },
             ],
+            loopedTransitionContainer: {
+              x: -15.85,
+              y: 109.40,
+            },
           },
         },
         { headers: { 'X-Atlassian-Token': 'no-check' },

--- a/packages/jira-adapter/test/filters/workflow/workflow_diagrams.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_diagrams.test.ts
@@ -202,7 +202,19 @@ describe('workflowDiagramFilter', () => {
               sourceAngle: 78.11,
               targetAngle: -173.58,
             },
+            {
+              id: 'A<51:S<-1>:S<-1>>',
+              name: 'looped',
+              sourceId: 'S<-1>',
+              targetId: 'S<-1>',
+              globalTransition: true,
+              loopedTransition: true,
+            },
           ],
+          loopedTransitionContainer: {
+            x: -15.85,
+            y: 109.40,
+          },
         },
       },
     })
@@ -233,6 +245,12 @@ describe('workflowDiagramFilter', () => {
       const elements = [workflowType]
       await filter.onFetch(elements)
       expect(workflowType.fields.diagramInitialEntry).toBeDefined()
+      expect(elements).toHaveLength(3)
+    })
+    it('should set the globalLoopedTransition field in Workflow', async () => {
+      const elements = [workflowType]
+      await filter.onFetch(elements)
+      expect(workflowType.fields.globalLoopedTransition).toBeDefined()
       expect(elements).toHaveLength(3)
     })
 
@@ -299,6 +317,21 @@ describe('workflowDiagramFilter', () => {
       )
       expect(elements).toHaveLength(3)
       expect(instance.value.transitions[0].from).toBeUndefined()
+    })
+    it('should add globalLoopedTransition angles to the instance', async () => {
+      const elements = [instance]
+      await filter.onFetch(elements)
+      expect(mockConnection.get).toHaveBeenCalledWith(
+        '/rest/workflowDesigner/1.0/workflows',
+        {
+          headers: { 'X-Atlassian-Token': 'no-check' },
+          params: { name: 'workflowName' },
+        },
+      )
+      expect(elements).toHaveLength(3)
+      expect(instance.value.globalLoopedTransition).toBeDefined()
+      expect(instance.value.globalLoopedTransition.x).toEqual(-15.85)
+      expect(instance.value.globalLoopedTransition.y).toEqual(109.40)
     })
 
     it('should log error when response is not valid', async () => {

--- a/packages/jira-adapter/test/filters/workflow/workflow_diagrams.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_diagrams.test.ts
@@ -247,10 +247,10 @@ describe('workflowDiagramFilter', () => {
       expect(workflowType.fields.diagramInitialEntry).toBeDefined()
       expect(elements).toHaveLength(3)
     })
-    it('should set the globalLoopedTransition field in Workflow', async () => {
+    it('should set the diagramGlobalLoopedTransition field in Workflow', async () => {
       const elements = [workflowType]
       await filter.onFetch(elements)
-      expect(workflowType.fields.globalLoopedTransition).toBeDefined()
+      expect(workflowType.fields.diagramGlobalLoopedTransition).toBeDefined()
       expect(elements).toHaveLength(3)
     })
 
@@ -318,7 +318,7 @@ describe('workflowDiagramFilter', () => {
       expect(elements).toHaveLength(3)
       expect(instance.value.transitions[0].from).toBeUndefined()
     })
-    it('should add globalLoopedTransition angles to the instance', async () => {
+    it('should add diagramGlobalLoopedTransition angles to the instance', async () => {
       const elements = [instance]
       await filter.onFetch(elements)
       expect(mockConnection.get).toHaveBeenCalledWith(
@@ -329,9 +329,131 @@ describe('workflowDiagramFilter', () => {
         },
       )
       expect(elements).toHaveLength(3)
-      expect(instance.value.globalLoopedTransition).toBeDefined()
-      expect(instance.value.globalLoopedTransition.x).toEqual(-15.85)
-      expect(instance.value.globalLoopedTransition.y).toEqual(109.40)
+      expect(instance.value.diagramGlobalLoopedTransition).toBeDefined()
+      expect(instance.value.diagramGlobalLoopedTransition.x).toEqual(-15.85)
+      expect(instance.value.diagramGlobalLoopedTransition.y).toEqual(109.40)
+    })
+    it('should fetch diagram values without diagramGlobalLoopedTransition', async () => {
+      instance.value.diagramGlobalLoopedTransition = undefined
+      mockConnection.get.mockResolvedValue({
+        status: 200,
+        data: {
+          isDraft: false,
+          layout: {
+            statuses: [
+              {
+                id: 'S<3>',
+                name: 'Open',
+                stepId: '3',
+                statusId: '1',
+                x: 3,
+                y: 6,
+              },
+              {
+                id: 'I<1>',
+                name: 'Create',
+                stepId: '1',
+                x: 33,
+                y: 66,
+                initial: true,
+              },
+              {
+                id: 'S<4>',
+                name: 'Resolved',
+                stepId: '4',
+                statusId: '5',
+                x: -3,
+                y: 6,
+              },
+              {
+                id: 'S<1>',
+                name: 'Building',
+                stepId: '1',
+                statusId: '400',
+                x: 3,
+                y: -66,
+              },
+              {
+                id: 'S<2>',
+                name: 'The best name',
+                stepId: '2',
+                statusId: '10007',
+                x: 33,
+                y: -66,
+              },
+            ],
+            transitions: [
+              {
+                id: 'A<31:S<2>:S<1>>',
+                name: 'super',
+                sourceId: 'S<2>',
+                targetId: 'S<1>',
+                sourceAngle: 34.11,
+                targetAngle: 173.58,
+              },
+              {
+                id: 'IA<1:I<1>:S<3>>',
+                name: 'Create',
+                sourceId: 'I<1>',
+                targetId: 'S<3>',
+                sourceAngle: 99.11,
+                targetAngle: 173.58,
+              },
+              {
+                id: 'A<41:S<4>:S<2>>',
+                name: 'yey',
+                sourceId: 'S<4>',
+                targetId: 'S<2>',
+                sourceAngle: 78.11,
+                targetAngle: 122.58,
+              },
+              {
+                id: 'A<21:S<3>:S<4>>',
+                name: 'hey',
+                sourceId: 'S<3>',
+                targetId: 'S<4>',
+                sourceAngle: -78.11,
+                targetAngle: 173.58,
+              },
+              {
+                id: 'A<11:S<1>:S<1>>',
+                name: 'Building',
+                sourceId: 'S<1>',
+                targetId: 'S<1>',
+                sourceAngle: 78.11,
+                targetAngle: -173.58,
+              },
+              {
+                id: 'A<51:S<-1>:S<-1>>',
+                name: 'looped',
+                sourceId: 'S<-1>',
+                targetId: 'S<-1>',
+                globalTransition: true,
+                loopedTransition: true,
+              },
+            ],
+          },
+        },
+      })
+      const elements = [instance]
+      filter = workflowDiagramsFilter(getFilterParams({
+        client,
+      })) as typeof filter
+      await filter.onFetch(elements)
+      expect(mockConnection.get).toHaveBeenCalledWith(
+        '/rest/workflowDesigner/1.0/workflows',
+        {
+          headers: { 'X-Atlassian-Token': 'no-check' },
+          params: { name: 'workflowName' },
+        },
+      )
+      expect(instance.value.diagramGlobalLoopedTransition).toBeUndefined()
+      expect(instance.value.statuses[0].location).toBeDefined()
+      expect(instance.value.statuses[0].location.x).toEqual(-3)
+      expect(instance.value.statuses[0].location.y).toEqual(6)
+      expect(instance.value.transitions[2].from[0].id).toBeDefined()
+      expect(instance.value.transitions[2].from[0].sourceAngle).toEqual(-78.11)
+      expect(instance.value.transitions[2].from[0].targetAngle).toEqual(173.58)
     })
 
     it('should log error when response is not valid', async () => {


### PR DESCRIPTION
_add global looped transition location to workflow diagrams_

---
the addition will add diagramGlobalLoopedTransition to workflows
![Screen Shot 2023-06-27 at 9 16 20](https://github.com/salto-io/salto/assets/77064001/e9d43987-9551-4cd9-af9d-e7536563651b)


---
_Release Notes_: 
Jira Adapter:
* add support in global looped transition  in Workflow's diagram 

---
_User Notifications_: 
Jira Adapter:
* workflows will have a new field called  `diagramGlobalLoopedTransition` that represents a global transition location from any status to itself.
