### PR TITLE
SALTO-4403 - Warn the user on activation of a feature - small changes

### DIFF
--- a/packages/zendesk-adapter/test/change_validators/feature_activation.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/feature_activation.test.ts
@@ -39,6 +39,7 @@ describe('featureActivationValidator', () => {
       b: true,
       c: false,
       d: true,
+      e: true,
     }
 
     const errors = await featureActivationValidator([toChange({ before, after })])
@@ -46,7 +47,7 @@ describe('featureActivationValidator', () => {
       elemID: accountSetting.elemID,
       severity: 'Info',
       message: 'Activating new features may include additional cost',
-      detailedMessage: 'Features a, b are marked for activation and may require additional cost in order to operate',
+      detailedMessage: 'Features a, b, e are marked for activation and may require additional cost in order to operate',
     }])
   })
 


### PR DESCRIPTION
Some changes according to [CR](https://github.com/salto-io/salto/pull/4536#discussion_r1242136160) 

---

None

---
_Release Notes_: 
None

---
_User Notifications_: 
None