### PR TITLE
SALTO-4430 - Salesforce: Add support for arrays and nested fields to unknown_users CV

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/unknown_users.ts
+++ b/packages/salesforce-adapter/src/change_validators/unknown_users.ts
@@ -23,6 +23,7 @@ import {
   getChangeData,
   Values,
   Value,
+  isInstanceElement,
 } from '@salto-io/adapter-api'
 import { resolvePath } from '@salto-io/adapter-utils'
 import _ from 'lodash'
@@ -70,7 +71,7 @@ type MissingUser = {
 }
 
 const nestedFieldValue = (container: InstanceElement | Value, fieldName: string): Value => {
-  if (container instanceof InstanceElement) {
+  if (isInstanceElement(container)) {
     return resolvePath(container, container.elemID.createNestedID(...fieldName.split(NAMESPACE_SEPARATOR)))
   }
   return _.get(container, fieldName)

--- a/packages/salesforce-adapter/test/change_validators/unknown_users.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/unknown_users.test.ts
@@ -21,13 +21,23 @@ import {
   ElemID,
   getChangeData,
   InstanceElement,
+  ListType,
   ObjectType,
   toChange,
 } from '@salto-io/adapter-api'
 import mockAdapter from '../adapter'
 import changeValidator from '../../src/change_validators/unknown_users'
-import { createInstanceElement } from '../../src/transformers/transformer'
-import { CUSTOM_OBJECT, CUSTOM_OBJECT_ID_FIELD, INSTANCE_FULL_NAME_FIELD, SALESFORCE } from '../../src/constants'
+import {
+  createInstanceElement,
+  createMetadataObjectType,
+} from '../../src/transformers/transformer'
+import {
+  CUSTOM_OBJECT,
+  CUSTOM_OBJECT_ID_FIELD,
+  INSTANCE_FULL_NAME_FIELD,
+  METADATA_TYPE,
+  SALESFORCE,
+} from '../../src/constants'
 import { SalesforceRecord } from '../../src/client/types'
 import { mockTypes } from '../mock_elements'
 import { createCustomObjectType } from '../utils'
@@ -317,6 +327,153 @@ describe('unknown user change validator', () => {
       it('should not create errors', () => {
         expect(changeErrors).toBeEmpty()
       })
+    })
+  })
+  describe('when the user information is in a nested field', () => {
+    const approverType = createMetadataObjectType({
+      fields: {
+        name: {
+          refType: BuiltinTypes.STRING,
+        },
+        type: {
+          refType: BuiltinTypes.STRING,
+        },
+      },
+      annotations: {
+        [METADATA_TYPE]: 'Approver',
+      },
+    })
+    const approvalStepApproverType = createMetadataObjectType({
+      fields: {
+        approver: {
+          refType: approverType,
+        },
+      },
+      annotations: {
+        [METADATA_TYPE]: 'ApprovalStepApprover',
+      },
+    })
+    const approvalStepType = createMetadataObjectType({
+      fields: {
+        assignedApprover: {
+          refType: approvalStepApproverType,
+        },
+      },
+      annotations: {
+        [METADATA_TYPE]: 'ApprovalStep',
+      },
+    })
+    const approvalProcessType = createMetadataObjectType({
+      fields: {
+        approvalStep: {
+          refType: new ListType(approvalStepType),
+        },
+      },
+      annotations: {
+        [METADATA_TYPE]: 'ApprovalProcess',
+      },
+    })
+    let changeErrors: readonly ChangeError[]
+    beforeEach(async () => {
+      const newRecord = createInstanceElement({
+        [INSTANCE_FULL_NAME_FIELD]: 'SomeApprovalProcess',
+        approvalStep: [
+          {
+            assignedApprover: {
+              approver: {
+                name: TEST_USERNAME,
+                type: 'User',
+              },
+            },
+          },
+
+          {
+            assignedApprover: {
+              approver: {
+                name: ANOTHER_TEST_USERNAME,
+                type: 'User',
+              },
+            },
+          },
+        ],
+      },
+      approvalProcessType)
+      const change = toChange({ after: newRecord })
+      setupClientMock([IRRELEVANT_USERNAME])
+      changeErrors = await validator([change])
+    })
+    it('should fail if the users don`t exist', () => {
+      expect(changeErrors).toHaveLength(2)
+      expect(changeErrors[0]).toHaveProperty('elemID', new ElemID(SALESFORCE, 'ApprovalProcess', 'instance', 'SomeApprovalProcess'))
+      expect(changeErrors[1]).toHaveProperty('elemID', new ElemID(SALESFORCE, 'ApprovalProcess', 'instance', 'SomeApprovalProcess'))
+    })
+  })
+  describe('when the user information is in a nested array', () => {
+    const ruleEntryType = createMetadataObjectType({
+      fields: {
+        assignedTo: {
+          refType: BuiltinTypes.STRING,
+        },
+        assignedToType: {
+          refType: BuiltinTypes.STRING,
+        },
+      },
+      annotations: {
+        [METADATA_TYPE]: 'RuleEntry',
+      },
+    })
+    const assignmentRuleType = createMetadataObjectType({
+      fields: {
+        ruleEntry: {
+          refType: new ListType(ruleEntryType),
+        },
+      },
+      annotations: {
+        [METADATA_TYPE]: 'AssignmentRule',
+      },
+    })
+    const assignmentRulesType = createMetadataObjectType({
+      fields: {
+        assignmentRule: {
+          refType: new ListType(assignmentRuleType),
+        },
+      },
+      annotations: {
+        [METADATA_TYPE]: 'AssignmentRules',
+      },
+    })
+    let changeErrors: readonly ChangeError[]
+    beforeEach(async () => {
+      const newRecord = createInstanceElement({
+        fullName: 'SomeAssignmentRules',
+        assignmentRule: [
+          {
+            ruleEntry: [
+              {
+                assignedTo: TEST_USERNAME,
+                assignedToType: 'User',
+              },
+            ],
+          },
+          {
+            ruleEntry: [
+              {
+                assignedTo: ANOTHER_TEST_USERNAME,
+                assignedToType: 'User',
+              },
+            ],
+          },
+        ],
+      },
+      assignmentRulesType)
+      const change = toChange({ after: newRecord })
+      setupClientMock([IRRELEVANT_USERNAME])
+      changeErrors = await validator([change])
+    })
+    it('should fail if any of the users don`t exist', () => {
+      expect(changeErrors).toHaveLength(2)
+      expect(changeErrors[0]).toHaveProperty('elemID', new ElemID(SALESFORCE, 'AssignmentRules', 'instance', 'SomeAssignmentRules'))
+      expect(changeErrors[1]).toHaveProperty('elemID', new ElemID(SALESFORCE, 'AssignmentRules', 'instance', 'SomeAssignmentRules'))
     })
   })
 })


### PR DESCRIPTION
The previous PR for this CV was... painfully naive. It assumed we will get changes to instances as changes to the specific type of the inner field of the instance that was actually changed. This not being the case, we need to support validation of nested fields and arrays.

---


---
_Release Notes_: 
N/A

---
_User Notifications_: 
N/A