### PR TITLE
SALTO-4431: Changed retrieve visible error message

### DIFF
--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -398,7 +398,7 @@ export const retrieveMetadataInstances = async ({
         'retrieve request for types %s failed, zipFile is %o, Result is %o',
         typesToRetrieve, result.zipFile, result,
       )
-      throw new Error(`Retrieve request for ${typesToRetrieve} failed. messages: ${safeJsonStringify(result.messages)}`)
+      throw new Error(`Retrieve request for ${typesToRetrieve} failed. messages: ${makeArray(safeJsonStringify(result.messages)).concat(result.errorMessage ?? [])}`)
     }
     const allValues = await fromRetrieveResult(
       result,


### PR DESCRIPTION
Changed retrieve visible error message to include the **errorMessage** property that wasn't previously defined.

---

_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
