### PR TITLE
SALTO-3233: add second global context change validator - Jira

### DIFF
--- a/packages/jira-adapter/src/change_validators/field_contexts/field_contexts.ts
+++ b/packages/jira-adapter/src/change_validators/field_contexts/field_contexts.ts
@@ -26,7 +26,7 @@ import { getGlobalContextsUsedInProjectErrors } from './referenced_global_contex
 const { awu } = collections.asynciterable
 const log = logger(module)
 
-export const getFieldContexts = async (
+const getFieldContexts = async (
   field: InstanceElement,
   elementSource: ReadOnlyElementsSource,
 ): Promise<InstanceElement[]> =>

--- a/packages/jira-adapter/src/change_validators/field_contexts/field_contexts.ts
+++ b/packages/jira-adapter/src/change_validators/field_contexts/field_contexts.ts
@@ -26,7 +26,7 @@ import { getGlobalContextsUsedInProjectErrors } from './referenced_global_contex
 const { awu } = collections.asynciterable
 const log = logger(module)
 
-const getFieldContexts = async (
+export const getFieldContexts = async (
   field: InstanceElement,
   elementSource: ReadOnlyElementsSource,
 ): Promise<InstanceElement[]> =>

--- a/packages/jira-adapter/src/change_validators/field_contexts/second_global_context.ts
+++ b/packages/jira-adapter/src/change_validators/field_contexts/second_global_context.ts
@@ -1,0 +1,69 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ChangeValidator, getChangeData, isAdditionOrModificationChange, isInstanceChange, SeverityLevel } from '@salto-io/adapter-api'
+import { getParent } from '@salto-io/adapter-utils'
+import { collections } from '@salto-io/lowerdash'
+import { FIELD_CONTEXT_TYPE_NAME } from '../../filters/fields/constants'
+import { getFieldContexts } from './field_contexts'
+
+
+const { awu } = collections.asynciterable
+
+export const fieldSecondGlobalContextValidator: ChangeValidator = async (changes, elementSource) => {
+  if (elementSource === undefined) {
+    return []
+  }
+  const fieldToGlobalContextsCount: Record<string, number> = {}
+  await awu(changes).filter(isInstanceChange)
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+    .filter(instance => instance.elemID.typeName === FIELD_CONTEXT_TYPE_NAME)
+    .filter(instance => instance.value.isGlobalContext)
+    .map(instance => ({ context: instance, field: getParent(instance) }))
+    .forEach(instanceAndField => {
+      const key = instanceAndField.field.elemID.getFullName()
+      if (fieldToGlobalContextsCount[key] === undefined) {
+        fieldToGlobalContextsCount[key] = 1
+      } else {
+        fieldToGlobalContextsCount[instanceAndField.field.elemID.getFullName()] += 1
+      }
+    })
+
+  return awu(changes)
+    .filter(isInstanceChange)
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+    .filter(instance => instance.elemID.typeName === FIELD_CONTEXT_TYPE_NAME)
+    .map(instance => ({ context: instance, field: getParent(instance) }))
+    .filter(async contextAndField => {
+      const globalContexts = (await getFieldContexts(contextAndField.field, elementSource))
+        .filter(context => context.value.isGlobalContext)
+      const isNewContextIncluded = globalContexts
+        .filter(instance => instance.elemID === contextAndField.context.elemID)
+        .length === 0
+      const isTwoGlobalContextAdditions = fieldToGlobalContextsCount[contextAndField.field.elemID.getFullName()] > 1
+      return isTwoGlobalContextAdditions
+        || globalContexts.length > 1
+        || (globalContexts.length === 1 && isNewContextIncluded)
+    })
+    .map(async contextAndField => ({
+      elemID: contextAndField.context.elemID,
+      severity: 'Error' as SeverityLevel,
+      message: 'Can\'t deploy global field context that will be the second global context',
+      detailedMessage: `Can't deploy global field context ${contextAndField.context.elemID.getFullName()} because the field ${contextAndField.field.elemID.getFullName()} already has a global context.`,
+    }))
+    .toArray()
+}

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -54,6 +54,7 @@ import { issueTypeSchemeMigrationValidator } from './issue_type_scheme_migration
 import { issueTypeDeletionValidator } from './issue_type_deletion'
 import { projectCategoryValidator } from './project_category'
 import { unresolvedFieldConfigurationItemsValidator } from './unresolved_field_configuration_items'
+import { fieldSecondGlobalContextValidator } from './field_contexts/second_global_context'
 
 const {
   deployTypesNotSupportedValidator,
@@ -93,6 +94,7 @@ export default (
     issueTypeDeletionValidator(client),
     lockedFieldsValidator,
     fieldContextValidator,
+    fieldSecondGlobalContextValidator,
     systemFieldsValidator,
     workflowPropertiesValidator,
     permissionSchemeValidator,

--- a/packages/jira-adapter/test/change_validators/field_contexts/second_global_context.test.ts
+++ b/packages/jira-adapter/test/change_validators/field_contexts/second_global_context.test.ts
@@ -82,6 +82,22 @@ describe('Field second global contexts', () => {
       elementsSource
     )).toEqual([])
   })
+  it('should not return changes when its not global context change', async () => {
+    const notGlobalContextInstance = new InstanceElement(
+      'notGlobal',
+      contextType,
+      undefined,
+      undefined,
+      { _parent: [new ReferenceExpression(fieldInstance.elemID, fieldInstance)] }
+    )
+    elements = [notGlobalContextInstance]
+    elementsSource = buildElementsSourceFromElements(elements)
+    changes = [toChange({ after: notGlobalContextInstance })]
+    expect(await fieldSecondGlobalContextValidator(
+      changes,
+      elementsSource
+    )).toEqual([])
+  })
   it('should log error if elementSource is undefined', async () => {
     expect(await fieldSecondGlobalContextValidator(
       changes,

--- a/packages/jira-adapter/test/change_validators/field_contexts/second_global_context.test.ts
+++ b/packages/jira-adapter/test/change_validators/field_contexts/second_global_context.test.ts
@@ -13,22 +13,22 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ObjectType, ElemID, ReadOnlyElementsSource, InstanceElement, ReferenceExpression, toChange, Change, ChangeDataType } from '@salto-io/adapter-api'
+import { ObjectType, ElemID, ReadOnlyElementsSource, InstanceElement, ReferenceExpression, toChange, Change, ChangeDataType, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { FIELD_CONTEXT_TYPE_NAME, FIELD_TYPE_NAME } from '../../../src/filters/fields/constants'
 import { JIRA } from '../../../src/constants'
 import { fieldSecondGlobalContextValidator } from '../../../src/change_validators/field_contexts/second_global_context'
 
-const mockLogWarn = jest.fn()
+const mockLogError = jest.fn()
 jest.mock('@salto-io/logging', () => ({
   ...jest.requireActual<{}>('@salto-io/logging'),
   logger: jest.fn()
     .mockReturnValue({
-      warn: jest.fn((...args) => mockLogWarn(...args)),
+      error: jest.fn((...args) => mockLogError(...args)),
     }),
 }))
 
-describe('Field contexts', () => {
+describe('Field second global contexts', () => {
   let contextType: ObjectType
   let fieldType: ObjectType
   let elementsSource: ReadOnlyElementsSource
@@ -82,6 +82,12 @@ describe('Field contexts', () => {
       elementsSource
     )).toEqual([])
   })
+  it('should log error if elementSource is undefined', async () => {
+    expect(await fieldSecondGlobalContextValidator(
+      changes,
+    )).toEqual([])
+    expect(mockLogError).toHaveBeenCalledWith('Failed to run fieldSecondGlobalContextValidator because element source is undefined')
+  })
 
   it('should return error when setting two global contexts to a field', async () => {
     fieldInstance.value.contexts.push(
@@ -97,14 +103,40 @@ describe('Field contexts', () => {
       {
         elemID: firstGlobalContextInstance.elemID,
         severity: 'Error',
-        message: 'Can\'t deploy global field context that will be the second global context',
-        detailedMessage: 'Can\'t deploy global field context jira.CustomFieldContext.instance.instance because the field jira.Field.instance.field_name already has a global context.',
+        message: 'A field can only have a single global context',
+        detailedMessage: 'Can\'t deploy this global context because the deployment will result in more than a single global context for field jira.Field.instance.field_name.',
       },
       {
         elemID: secondGlobalContextInstance.elemID,
         severity: 'Error',
-        message: 'Can\'t deploy global field context that will be the second global context',
-        detailedMessage: 'Can\'t deploy global field context jira.CustomFieldContext.instance.instance2 because the field jira.Field.instance.field_name already has a global context.',
+        message: 'A field can only have a single global context',
+        detailedMessage: 'Can\'t deploy this global context because the deployment will result in more than a single global context for field jira.Field.instance.field_name.',
+      },
+    ])
+  })
+  it('should return error when setting two global contexts to a field with alias', async () => {
+    fieldInstance.annotations[CORE_ANNOTATIONS.ALIAS] = 'beautiful name'
+    fieldInstance.value.contexts.push(
+      new ReferenceExpression(secondGlobalContextInstance.elemID, secondGlobalContextInstance)
+    )
+    elements = [fieldInstance, firstGlobalContextInstance, secondGlobalContextInstance]
+    elementsSource = buildElementsSourceFromElements(elements)
+    changes = elements.map(element => toChange({ after: element }))
+    expect(await fieldSecondGlobalContextValidator(
+      changes,
+      elementsSource
+    )).toEqual([
+      {
+        elemID: firstGlobalContextInstance.elemID,
+        severity: 'Error',
+        message: 'A field can only have a single global context',
+        detailedMessage: 'Can\'t deploy this global context because the deployment will result in more than a single global context for field beautiful name.',
+      },
+      {
+        elemID: secondGlobalContextInstance.elemID,
+        severity: 'Error',
+        message: 'A field can only have a single global context',
+        detailedMessage: 'Can\'t deploy this global context because the deployment will result in more than a single global context for field beautiful name.',
       },
     ])
   })
@@ -120,14 +152,14 @@ describe('Field contexts', () => {
       {
         elemID: firstGlobalContextInstance.elemID,
         severity: 'Error',
-        message: 'Can\'t deploy global field context that will be the second global context',
-        detailedMessage: 'Can\'t deploy global field context jira.CustomFieldContext.instance.instance because the field jira.Field.instance.field_name already has a global context.',
+        message: 'A field can only have a single global context',
+        detailedMessage: 'Can\'t deploy this global context because the deployment will result in more than a single global context for field jira.Field.instance.field_name.',
       },
       {
         elemID: secondGlobalContextInstance.elemID,
         severity: 'Error',
-        message: 'Can\'t deploy global field context that will be the second global context',
-        detailedMessage: 'Can\'t deploy global field context jira.CustomFieldContext.instance.instance2 because the field jira.Field.instance.field_name already has a global context.',
+        message: 'A field can only have a single global context',
+        detailedMessage: 'Can\'t deploy this global context because the deployment will result in more than a single global context for field jira.Field.instance.field_name.',
       },
     ])
   })

--- a/packages/jira-adapter/test/change_validators/field_contexts/second_global_context.test.ts
+++ b/packages/jira-adapter/test/change_validators/field_contexts/second_global_context.test.ts
@@ -1,0 +1,134 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, ElemID, ReadOnlyElementsSource, InstanceElement, ReferenceExpression, toChange, Change, ChangeDataType } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { FIELD_CONTEXT_TYPE_NAME, FIELD_TYPE_NAME } from '../../../src/filters/fields/constants'
+import { JIRA } from '../../../src/constants'
+import { fieldSecondGlobalContextValidator } from '../../../src/change_validators/field_contexts/second_global_context'
+
+const mockLogWarn = jest.fn()
+jest.mock('@salto-io/logging', () => ({
+  ...jest.requireActual<{}>('@salto-io/logging'),
+  logger: jest.fn()
+    .mockReturnValue({
+      warn: jest.fn((...args) => mockLogWarn(...args)),
+    }),
+}))
+
+describe('Field contexts', () => {
+  let contextType: ObjectType
+  let fieldType: ObjectType
+  let elementsSource: ReadOnlyElementsSource
+  let elements: InstanceElement[]
+  let firstGlobalContextInstance: InstanceElement
+  let secondGlobalContextInstance: InstanceElement
+  let fieldInstance: InstanceElement
+  let changes: ReadonlyArray<Change<ChangeDataType>>
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    contextType = new ObjectType({ elemID: new ElemID(JIRA, FIELD_CONTEXT_TYPE_NAME) })
+    fieldType = new ObjectType({ elemID: new ElemID(JIRA, FIELD_TYPE_NAME) })
+
+    fieldInstance = new InstanceElement(
+      'field_name',
+      fieldType,
+    )
+
+    firstGlobalContextInstance = new InstanceElement(
+      'instance',
+      contextType,
+      {
+        isGlobalContext: true,
+      },
+      undefined,
+      { _parent: [new ReferenceExpression(fieldInstance.elemID, fieldInstance)] }
+    )
+    fieldInstance.value.contexts = [
+      new ReferenceExpression(firstGlobalContextInstance.elemID, firstGlobalContextInstance),
+    ]
+
+    secondGlobalContextInstance = new InstanceElement(
+      'instance2',
+      contextType,
+      {
+        isGlobalContext: true,
+      },
+      undefined,
+      { _parent: [new ReferenceExpression(fieldInstance.elemID, fieldInstance)] }
+    )
+
+    elements = [fieldInstance, firstGlobalContextInstance]
+    elementsSource = buildElementsSourceFromElements(elements)
+    changes = elements.map(element => toChange({ after: element }))
+  })
+
+  it('should not return error when setting one global context to the field', async () => {
+    expect(await fieldSecondGlobalContextValidator(
+      changes,
+      elementsSource
+    )).toEqual([])
+  })
+
+  it('should return error when setting two global contexts to a field', async () => {
+    fieldInstance.value.contexts.push(
+      new ReferenceExpression(secondGlobalContextInstance.elemID, secondGlobalContextInstance)
+    )
+    elements = [fieldInstance, firstGlobalContextInstance, secondGlobalContextInstance]
+    elementsSource = buildElementsSourceFromElements(elements)
+    changes = elements.map(element => toChange({ after: element }))
+    expect(await fieldSecondGlobalContextValidator(
+      changes,
+      elementsSource
+    )).toEqual([
+      {
+        elemID: firstGlobalContextInstance.elemID,
+        severity: 'Error',
+        message: 'Can\'t deploy global field context that will be the second global context',
+        detailedMessage: 'Can\'t deploy global field context jira.CustomFieldContext.instance.instance because the field jira.Field.instance.field_name already has a global context.',
+      },
+      {
+        elemID: secondGlobalContextInstance.elemID,
+        severity: 'Error',
+        message: 'Can\'t deploy global field context that will be the second global context',
+        detailedMessage: 'Can\'t deploy global field context jira.CustomFieldContext.instance.instance2 because the field jira.Field.instance.field_name already has a global context.',
+      },
+    ])
+  })
+  it('should return error when adding two global contexts to a field without global context', async () => {
+    fieldInstance.value.contexts = []
+    elements = [firstGlobalContextInstance, secondGlobalContextInstance]
+    elementsSource = buildElementsSourceFromElements(elements)
+    changes = elements.map(element => toChange({ after: element }))
+    expect(await fieldSecondGlobalContextValidator(
+      changes,
+      elementsSource
+    )).toEqual([
+      {
+        elemID: firstGlobalContextInstance.elemID,
+        severity: 'Error',
+        message: 'Can\'t deploy global field context that will be the second global context',
+        detailedMessage: 'Can\'t deploy global field context jira.CustomFieldContext.instance.instance because the field jira.Field.instance.field_name already has a global context.',
+      },
+      {
+        elemID: secondGlobalContextInstance.elemID,
+        severity: 'Error',
+        message: 'Can\'t deploy global field context that will be the second global context',
+        detailedMessage: 'Can\'t deploy global field context jira.CustomFieldContext.instance.instance2 because the field jira.Field.instance.field_name already has a global context.',
+      },
+    ])
+  })
+})


### PR DESCRIPTION
_add second global context change validator_

---


_Release Notes_: 
Jira Adapter:
* add validation that prevents the user from adding more than one global context to custom fields

---
_User Notifications_: 
_None_
