### PR TITLE
SALTO-4430 - Salesforce: Add support for arrays and nested fields to unknown_users CV (v2)

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/unknown_users.ts
+++ b/packages/salesforce-adapter/src/change_validators/unknown_users.ts
@@ -167,7 +167,7 @@ const USER_GETTERS: TypesWithUserFields = {
     userNestedField('Users', 'user', userFieldValue),
   ],
   EscalationRules: [
-    userNestedField('RuleEntry', 'assignedTo', getUserDependingOnType('assignedToType')),
+    userNestedField('EscalationAction', 'assignedTo', getUserDependingOnType('assignedToType')),
   ],
 }
 

--- a/packages/salesforce-adapter/src/change_validators/unknown_users.ts
+++ b/packages/salesforce-adapter/src/change_validators/unknown_users.ts
@@ -149,13 +149,12 @@ const USER_GETTERS: TypesWithUserFields = {
   ],
 }
 
-const userFieldGettersForType = async (defMapping: TypesWithUserFields, type: string)
-  : Promise<UserFieldGetter[]> => {
-  const instanceTypeAsTypeWithUserFields = async (): Promise<TypeWithUserFields | undefined> => (
+const userFieldGettersForType = (defMapping: TypesWithUserFields, type: string): UserFieldGetter[] => {
+  const instanceTypeAsTypeWithUserFields = (): TypeWithUserFields | undefined => (
     TYPES_WITH_USER_FIELDS.find(t => t === type)
   )
 
-  const instanceType = await instanceTypeAsTypeWithUserFields()
+  const instanceType = instanceTypeAsTypeWithUserFields()
   return instanceType ? defMapping[instanceType] : []
 }
 
@@ -165,7 +164,7 @@ const getUsersFromInstance = async (instance: InstanceElement, getterDefs: Types
   const extractUsers = async ({ value, path, field }: TransformFuncArgs): Promise<Value> => {
     const type = (field === undefined) ? instance.elemID.typeName : (await field.getType()).elemID.typeName
     if (path && value && Object.keys(getterDefs).includes(type)) {
-      const getters = await userFieldGettersForType(getterDefs, type)
+      const getters = userFieldGettersForType(getterDefs, type)
       const userRefs: UserRef[] = getters
         .flatMap(getterDef => (
           getterDef.getter(value)


### PR DESCRIPTION
The previous PR for this CV was... painfully naive. It assumed we will get changes to instances as changes to the specific type of the inner field of the instance that was actually changed. This not being the case, we need to support validation of nested fields and arrays.

---

This is a rework of https://github.com/salto-io/salto/pull/4554 . Instead of manually implementing access to nested fields, arrays, etc. we use `transformElement` to recursively walk through every instance. When we find a field of a type that we care about we extract users from it. 
It also allows us to simplify the code a bit and remove the duplicate iteration in `getUnknownUsers`.
Thanks @tamtamirr !

Tests:

- Deployed AssignmentRules, EscalationRules with correct and incorrect users

---
_Release Notes_: 
Salesforce: The unknown_users change validator is now faster and more accurate

---
_User Notifications_: 
N/A