### PR TITLE
SALTO-3791 Support deletion in partial fetch - core side

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -23,12 +23,20 @@ import { DependencyChanger } from './dependency_changer'
 import { SaltoElementError, SaltoError } from './error'
 import { ChangeGroup, ChangeGroupIdFunction } from './change_group'
 
+export type PartialFetchData = {
+  isPartial: true
+  deletedElements?: ElemID[]
+}
+
+export const setPartialFetchData = (isPartial: boolean, deletedElements?: ElemID[]): PartialFetchData | undefined => (
+  isPartial ? { isPartial, deletedElements } : undefined
+)
+
 export interface FetchResult {
   elements: Element[]
-  deletedElements?: ElemID[]
   errors?: SaltoError[]
   updatedConfig?: { config: InstanceElement[]; message: string }
-  isPartial?: boolean
+  partialFetchData?: PartialFetchData
 }
 
 export type Group = {

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -461,7 +461,7 @@ export const calculatePatch = async (
     mergedAfterElements,
     elementSource.createInMemoryElementSource(mergedBeforeElements),
     adapterContext.elementsSource,
-    new Set([accountName]),
+    new Map([[accountName, {}]]),
     new Set([accountName]),
   )
   return {

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -33,7 +33,7 @@ import { mockWorkspace } from '../common/workspace'
 import {
   fetchChanges, FetchChange, generateServiceIdToStateElemId,
   FetchChangesResult, FetchProgressEvents, getAdaptersFirstFetchPartial,
-  fetchChangesFromWorkspace, createElemIdGetter,
+  fetchChangesFromWorkspace, createElemIdGetter, calcFetchChanges,
 } from '../../src/core/fetch'
 import { getPlan, Plan } from '../../src/core/plan'
 import { createElementSource } from '../common/helpers'
@@ -210,7 +210,7 @@ describe('fetch', () => {
       describe('fetch is partial', () => {
         it('should ignore deletions', async () => {
           mockAdapters[newTypeDifferentAdapterID.adapter].fetch.mockResolvedValueOnce(
-            { elements: [newTypeBaseModified], isPartial: true },
+            { elements: [newTypeBaseModified], partialFetchData: { isPartial: true } },
           )
           const fetchChangesResult = await fetchChanges(
             mockAdapters,
@@ -224,7 +224,7 @@ describe('fetch', () => {
 
         it('should return the state elements with the account elements', async () => {
           mockAdapters[newTypeDifferentAdapterID.adapter].fetch.mockResolvedValueOnce(
-            { elements: [newTypeBaseModified], isPartial: true },
+            { elements: [newTypeBaseModified], partialFetchData: { isPartial: true } },
           )
           const fetchChangesResult = await fetchChanges(
             mockAdapters,
@@ -236,11 +236,26 @@ describe('fetch', () => {
           expect(fetchChangesResult.elements).toEqual([newTypeBaseModifiedDifferentId,
             typeWithFieldDifferentID])
         })
+
+        it('should return the elements without the deleted elements', async () => {
+          mockAdapters[newTypeDifferentAdapterID.adapter].fetch.mockResolvedValueOnce({
+            elements: [newTypeBaseModified],
+            partialFetchData: { isPartial: true, deletedElements: [typeWithFieldDifferentID.elemID] },
+          })
+          const fetchChangesResult = await fetchChanges(
+            mockAdapters,
+            createInMemoryElementSource([]),
+            createInMemoryElementSource([newTypeBaseDifferentAdapterID, typeWithFieldDifferentID]),
+            { [newTypeDifferentAdapterID.adapter]: 'dummy' },
+            [],
+          )
+          expect(fetchChangesResult.elements).toEqual([newTypeBaseModifiedDifferentId])
+        })
       })
       describe('fetch is not partial', () => {
         it('should not ignore deletions', async () => {
           mockAdapters[newTypeDifferentAdapterID.adapter].fetch.mockResolvedValueOnce(
-            { elements: [newTypeBaseModified], isPartial: false },
+            { elements: [newTypeBaseModified] },
           )
           const fetchChangesResult = await fetchChanges(
             mockAdapters,
@@ -256,7 +271,7 @@ describe('fetch', () => {
 
         it('should return only the account elements', async () => {
           mockAdapters[newTypeDifferentAdapterID.adapter].fetch.mockResolvedValueOnce(
-            { elements: [newTypeBaseModified], isPartial: false },
+            { elements: [newTypeBaseModified] },
           )
           const fetchChangesResult = await fetchChanges(
             mockAdapters,
@@ -299,7 +314,7 @@ describe('fetch', () => {
         afterElement.value.field = 4
 
         mockAdapters[newTypeDifferentAdapterID.adapter].fetch.mockResolvedValueOnce(
-          { elements: [afterElement], isPartial: true },
+          { elements: [afterElement], partialFetchData: { isPartial: true } },
         )
         const fetchChangesResult = await fetchChanges(
           mockAdapters,
@@ -330,11 +345,11 @@ describe('fetch', () => {
       describe('multiple adapters', () => {
         const adapters = {
           dummy1AccountName: {
-            fetch: mockFunction<AdapterOperations['fetch']>().mockResolvedValue({ elements: [], isPartial: true }),
+            fetch: mockFunction<AdapterOperations['fetch']>().mockResolvedValue({ elements: [], partialFetchData: { isPartial: true } }),
             deploy: mockFunction<AdapterOperations['deploy']>(),
           },
           dummy2: {
-            fetch: mockFunction<AdapterOperations['fetch']>().mockResolvedValue({ elements: [], isPartial: false }),
+            fetch: mockFunction<AdapterOperations['fetch']>().mockResolvedValue({ elements: [] }),
             deploy: mockFunction<AdapterOperations['deploy']>(),
           },
         }
@@ -1168,7 +1183,7 @@ describe('fetch', () => {
     describe('fetch is partial', () => {
       it('should call postFetch with the state and account elements combined in elementsByAccount, but only the fetched elements in currentAdapterElements', async () => {
         mockAdapters[newTypeDifferentAdapterID.adapter].fetch.mockResolvedValueOnce(
-          Promise.resolve({ elements: [newTypeBaseModified], isPartial: true }),
+          Promise.resolve({ elements: [newTypeBaseModified], partialFetchData: { isPartial: true } }),
         )
         const fetchChangesResult = await fetchChanges(
           mockAdapters,
@@ -1195,11 +1210,39 @@ describe('fetch', () => {
           progressReporter: expect.anything(),
         })
       })
+      it('should call postFetch with the state and account elements combined in elementsByAccount, but only the fetched elements in currentAdapterElements, without the deleted elements', async () => {
+        mockAdapters[newTypeDifferentAdapterID.adapter].fetch.mockResolvedValueOnce({
+          elements: [newTypeBaseModified],
+          partialFetchData: { isPartial: true, deletedElements: [typeWithFieldDifferentID.elemID] },
+        })
+        const fetchChangesResult = await fetchChanges(
+          mockAdapters,
+          createElementSource([typeWithFieldDifferentID]),
+          createElementSource([newTypeBaseDifferentAdapterID, typeWithFieldDifferentID]),
+          { [newTypeDifferentAdapterID.adapter]: 'dummy' },
+          [],
+        )
+        expect(fetchChangesResult.elements).toEqual([newTypeBaseModifiedDifferentId])
+        expect(mockAdapters[newTypeDifferentAdapterID.adapter].postFetch).toHaveBeenCalledWith({
+          currentAdapterElements: expect.arrayContaining([
+            newTypeBaseModifiedDifferentId,
+          ]),
+          elementsByAccount: {
+            [newTypeDifferentAdapterID.adapter]: expect.arrayContaining([
+              newTypeBaseModifiedDifferentId,
+            ]),
+          },
+          accountToServiceNameMap: {
+            [newTypeDifferentAdapterID.adapter]: 'dummy',
+          },
+          progressReporter: expect.anything(),
+        })
+      })
     })
     describe('fetch is not partial', () => {
       it('should call postFetch with only the account elements', async () => {
         mockAdapters[newTypeDifferentAdapterID.adapter].fetch.mockResolvedValueOnce(
-          { elements: [newTypeBaseModified], isPartial: false },
+          { elements: [newTypeBaseModified] },
         )
         const fetchChangesResult = await fetchChanges(
           mockAdapters,
@@ -1264,16 +1307,16 @@ describe('fetch', () => {
 
       const adapters = {
         [expectedDummy1.elemID.adapter]: {
-          fetch: mockFunction<AdapterOperations['fetch']>().mockResolvedValue({ elements: [dummy1Type1], isPartial: true }),
+          fetch: mockFunction<AdapterOperations['fetch']>().mockResolvedValue({ elements: [dummy1Type1], partialFetchData: { isPartial: true } }),
           deploy: mockFunction<AdapterOperations['deploy']>(),
         },
         dummy2: {
-          fetch: mockFunction<AdapterOperations['fetch']>().mockResolvedValue({ elements: [dummy2Type1], isPartial: false }),
+          fetch: mockFunction<AdapterOperations['fetch']>().mockResolvedValue({ elements: [dummy2Type1] }),
           deploy: mockFunction<AdapterOperations['deploy']>(),
           postFetch: mockFunction<Required<AdapterOperations>['postFetch']>().mockResolvedValue(),
         },
         dummy3: {
-          fetch: mockFunction<AdapterOperations['fetch']>().mockResolvedValue({ elements: [dummy3Type1, dummy2PrimStr], isPartial: false }),
+          fetch: mockFunction<AdapterOperations['fetch']>().mockResolvedValue({ elements: [dummy3Type1, dummy2PrimStr] }),
           deploy: mockFunction<AdapterOperations['deploy']>(),
           postFetch: mockFunction<Required<AdapterOperations>['postFetch']>().mockResolvedValue(),
         },
@@ -1978,11 +2021,45 @@ describe('fetch from workspace', () => {
     it('translated id to new account name', async () => {
       const objID = new ElemID('salesforce', 'obj')
       const obj = new ObjectType({
-        elemID: new ElemID('salesforceaccountName', 'obj'),
+        elemID: new ElemID('salesforceAccountName', 'obj'),
       })
       const idGetter = await createElemIdGetter(awu([obj]), createElementSource([]))
       expect(idGetter('salesforce', { [OBJECT_SERVICE_ID]: objID.getFullName() },
         'obj')).toEqual(objID)
     })
+  })
+})
+
+// TODO: SALTO-4460 only deletion scenarios are covered here. The rest should be moved from under “fetchChanges”
+describe('calc fetch changes', () => {
+  const existingElement = new ObjectType({
+    elemID: new ElemID('salto', 'existing'),
+    path: ['salto', 'existing', 'all'],
+  })
+  const instanceA = new InstanceElement('instanceA', existingElement)
+  const instanceB = new InstanceElement('instanceB', existingElement)
+  it('should calculate a remove change when instanceA was deleted in service', async () => {
+    const { changes, serviceToStateChanges } = await calcFetchChanges(
+      [existingElement],
+      [existingElement],
+      createInMemoryElementSource([existingElement, instanceA, instanceB]),
+      createInMemoryElementSource([existingElement, instanceA, instanceB]),
+      new Map([['salto', { deletedElements: new Set([instanceA.elemID.getFullName()]) }]]),
+      new Set(['salto']),
+    )
+
+    expect(changes).toHaveLength(1)
+    expect(changes[0].change.action).toEqual('remove')
+    expect(changes[0].change.id.getFullName()).toEqual(instanceA.elemID.getFullName())
+
+    expect(changes[0].serviceChanges).toHaveLength(1)
+    expect(changes[0].serviceChanges[0].action).toEqual('remove')
+    expect(changes[0].serviceChanges[0].id.getFullName()).toEqual(instanceA.elemID.getFullName())
+
+    expect(changes[0].pendingChanges ?? []).toHaveLength(0)
+
+    expect(serviceToStateChanges).toHaveLength(1)
+    expect(serviceToStateChanges[0].action).toEqual('remove')
+    expect(serviceToStateChanges[0].id.getFullName()).toEqual(instanceA.elemID.getFullName())
   })
 })

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -206,8 +206,8 @@ describe('Adapter', () => {
           failedToFetchAllAtOnce: false,
           failedTypes: { lockedError: {}, unexpectedError: {}, excludedTypes: [] },
         })
-      const { elements, isPartial } = await netsuiteAdapter.fetch(mockFetchOpts)
-      expect(isPartial).toBeFalsy()
+      const { elements, partialFetchData } = await netsuiteAdapter.fetch(mockFetchOpts)
+      expect(partialFetchData?.isPartial).toBeFalsy()
       const customObjectsQuery = (client.getCustomObjects as jest.Mock).mock.calls[0][1].updatedFetchQuery
       const typesToSkip = [SAVED_SEARCH, TRANSACTION_FORM, INTEGRATION, REPORT_DEFINITION, FINANCIAL_LAYOUT]
       expect(_.pull(getStandardTypesNames(), ...typesToSkip)
@@ -288,8 +288,8 @@ describe('Adapter', () => {
         })
       it('should fetch all types and instances when fetch config is undefined', async () => {
         const adapter = createAdapter(configWithoutFetch)
-        const { elements, isPartial } = await adapter.fetch(mockFetchOpts)
-        expect(isPartial).toBeFalsy()
+        const { elements, partialFetchData } = await adapter.fetch(mockFetchOpts)
+        expect(partialFetchData?.isPartial).toBeFalsy()
         expect(elements).toHaveLength(metadataTypes.length)
         const customObjectsQuery = (client.getCustomObjects as jest.Mock).mock.calls[0][1].updatedFetchQuery
         expect(customObjectsQuery.isTypeMatch('any kind of type')).toBeTruthy()
@@ -302,8 +302,8 @@ describe('Adapter', () => {
           fetch: {},
         }
         const adapter = createAdapter(configWithEmptyDefinedFetch)
-        const { elements, isPartial } = await adapter.fetch(mockFetchOpts)
-        expect(isPartial).toBeFalsy()
+        const { elements, partialFetchData } = await adapter.fetch(mockFetchOpts)
+        expect(partialFetchData?.isPartial).toBeFalsy()
         expect(elements).toHaveLength(metadataTypes.length)
         const customObjectsQuery = (client.getCustomObjects as jest.Mock).mock.calls[0][1].updatedFetchQuery
         expect(customObjectsQuery.isTypeMatch('any kind of type')).toBeTruthy()
@@ -322,8 +322,8 @@ describe('Adapter', () => {
           },
         }
         const adapter = createAdapter(configWithIncludeButNoExclude)
-        const { isPartial } = await adapter.fetch(mockFetchOpts)
-        expect(isPartial).toBeFalsy()
+        const { partialFetchData } = await adapter.fetch(mockFetchOpts)
+        expect(partialFetchData?.isPartial).toBeFalsy()
         const customObjectsQuery = (client.getCustomObjects as jest.Mock).mock.calls[0][1].updatedFetchQuery
         expect(customObjectsQuery.isTypeMatch('any kind of type')).toBeFalsy()
         expect(customObjectsQuery.isTypeMatch('someType')).toBeTruthy()
@@ -344,8 +344,8 @@ describe('Adapter', () => {
           },
         }
         const adapter = createAdapter(configWithExcludeButNoInclude)
-        const { isPartial } = await adapter.fetch(mockFetchOpts)
-        expect(isPartial).toBeFalsy()
+        const { partialFetchData } = await adapter.fetch(mockFetchOpts)
+        expect(partialFetchData?.isPartial).toBeFalsy()
         const customObjectsQuery = (client.getCustomObjects as jest.Mock).mock.calls[0][1].updatedFetchQuery
         expect(customObjectsQuery.isTypeMatch('any kind of type')).toBeTruthy()
         expect(customObjectsQuery.isTypeMatch('someTypeToSkip')).toBeFalsy()
@@ -366,8 +366,8 @@ describe('Adapter', () => {
           typesToSkip: ['skipThisType'],
         }
         const adapter = createAdapter(configWithSkipListAndTypesToSkip)
-        const { isPartial } = await adapter.fetch(mockFetchOpts)
-        expect(isPartial).toBeFalsy()
+        const { partialFetchData } = await adapter.fetch(mockFetchOpts)
+        expect(partialFetchData?.isPartial).toBeFalsy()
         const customObjectsQuery = (client.getCustomObjects as jest.Mock).mock.calls[0][1].updatedFetchQuery
         expect(customObjectsQuery.isTypeMatch('any kind of type')).toBeTruthy()
         expect(customObjectsQuery.isTypeMatch('typeToSkip')).toBeFalsy()
@@ -388,8 +388,8 @@ describe('Adapter', () => {
           typesToSkip: ['skipThisType'],
         }
         const adapter = createAdapter(configWithAllFormats)
-        const { isPartial } = await adapter.fetch(mockFetchOpts)
-        expect(isPartial).toBeFalsy()
+        const { partialFetchData } = await adapter.fetch(mockFetchOpts)
+        expect(partialFetchData?.isPartial).toBeFalsy()
         const customObjectsQuery = (client.getCustomObjects as jest.Mock).mock.calls[0][1].updatedFetchQuery
         expect(customObjectsQuery.isTypeMatch('any kind of type')).toBeTruthy()
         expect(customObjectsQuery.isTypeMatch('typeToSkip')).toBeFalsy()
@@ -428,8 +428,8 @@ describe('Adapter', () => {
       })
 
       it('isPartial should be true', async () => {
-        const { isPartial } = await adapter.fetch({ ...mockFetchOpts, withChangesDetection })
-        expect(isPartial).toBeTruthy()
+        const { partialFetchData } = await adapter.fetch({ ...mockFetchOpts, withChangesDetection })
+        expect(partialFetchData?.isPartial).toBeTruthy()
       })
     })
 
@@ -481,8 +481,8 @@ describe('Adapter', () => {
         })
 
         it('isPartial should be true', async () => {
-          const { isPartial } = await adapter.fetch(mockFetchOpts)
-          expect(isPartial).toBeTruthy()
+          const { partialFetchData } = await adapter.fetch(mockFetchOpts)
+          expect(partialFetchData?.isPartial).toBeTruthy()
         })
 
         it('should match the types that match fetchTarget and exclude', async () => {
@@ -1509,9 +1509,9 @@ describe('Adapter', () => {
       })
 
       it('check call getDeletedElements and verify return value', async () => {
-        const { deletedElements } = await adapter.fetch({ ...mockFetchOpts, withChangesDetection: true })
+        const { partialFetchData } = await adapter.fetch({ ...mockFetchOpts, withChangesDetection: true })
         expect(getDeletedElementsMock).toHaveBeenCalled()
-        expect(deletedElements).toEqual([elemId])
+        expect(partialFetchData?.deletedElements).toEqual([elemId])
         expect(spy).toHaveBeenCalledWith(expect.anything(), true, [elemId])
       })
     })
@@ -1526,9 +1526,9 @@ describe('Adapter', () => {
       })
 
       it('check call getDeletedElements and verify return value', async () => {
-        const { deletedElements } = await adapter.fetch({ ...mockFetchOpts })
+        const { partialFetchData } = await adapter.fetch({ ...mockFetchOpts })
         expect(getDeletedElementsMock).not.toHaveBeenCalled()
-        expect(deletedElements).toEqual(undefined)
+        expect(partialFetchData?.deletedElements).toEqual(undefined)
         expect(spy).toHaveBeenCalledWith(expect.anything(), false, undefined)
       })
     })

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -17,6 +17,7 @@ import {
   TypeElement, ObjectType, InstanceElement, isAdditionChange, getChangeData, Change,
   ElemIdGetter, FetchResult, AdapterOperations, DeployResult, FetchOptions, DeployOptions,
   ReadOnlyElementsSource,
+  setPartialFetchData,
 } from '@salto-io/adapter-api'
 import { filter, logDuration, resolveChangeElement, restoreChangeElement } from '@salto-io/adapter-utils'
 import { MetadataObject } from 'jsforce'
@@ -442,7 +443,7 @@ export default class SalesforceAdapter implements AdapterOperations {
       elements,
       errors: onFetchFilterResult.errors ?? [],
       updatedConfig,
-      isPartial: this.userConfig.fetch?.target !== undefined,
+      partialFetchData: setPartialFetchData(this.userConfig.fetch?.target !== undefined),
     }
   }
 


### PR DESCRIPTION
Support deletion in partial fetch - core side (NetSuite side was done already)

---

_Additional context for reviewer_
None

---
_Release Notes_: 
Support deletion in partial fetch (**NetSuite** only currently)
Support deletion of standard instances, custom types and custom records. **No** support for file cabinet

---
_User Notifications_: 
None
