### PR TITLE
SALTO-3829: Add reference to workflow's transitions

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/cloud/workflow.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/workflow.ts
@@ -14,14 +14,15 @@
 * limitations under the License.
 */
 import { ElemID, Values, Element } from '@salto-io/adapter-api'
+import { naclCase } from '@salto-io/adapter-utils'
 import { createReference } from '../../utils'
 import { JIRA, STATUS_TYPE_NAME } from '../../../src/constants'
 
 export const createWorkflowValues = (name: string, allElements: Element[]): Values => ({
   name,
   description: name,
-  transitions: [
-    {
+  transitions: {
+    [naclCase('Build Broken::From: any status::Global')]: {
       name: 'Build Broken',
       description: '',
       to: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'backlog'), allElements),
@@ -92,7 +93,7 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
         ],
       },
     },
-    {
+    [naclCase('Create::From: none::Initial')]: {
       name: 'Create',
       description: '',
       to: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'backlog'), allElements),
@@ -177,7 +178,7 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
         ],
       },
     },
-    {
+    [naclCase('TransitionToShared::From: backlog, done::Directed')]: {
       name: 'TransitionToShared',
       description: '',
       from: [{
@@ -386,7 +387,7 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
         },
       },
     },
-  ],
+  },
   statuses: [
     {
       id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'backlog'), allElements),

--- a/packages/jira-adapter/e2e_test/instances/datacenter/workflow.ts
+++ b/packages/jira-adapter/e2e_test/instances/datacenter/workflow.ts
@@ -14,14 +14,15 @@
 * limitations under the License.
 */
 import { ElemID, Values, Element } from '@salto-io/adapter-api'
+import { naclCase } from '@salto-io/adapter-utils'
 import { createReference } from '../../utils'
 import { JIRA, STATUS_TYPE_NAME } from '../../../src/constants'
 
 export const createWorkflowValues = (name: string, allElements: Element[]): Values => ({
   name,
   description: name,
-  transitions: [
-    {
+  transitions: {
+    [naclCase('Build Broken::From: any status::Global')]: {
       name: 'Build Broken',
       description: '',
       to: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'backlog'), allElements),
@@ -39,7 +40,7 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
         ],
       },
     },
-    {
+    [naclCase('Create::From: none::Initial')]: {
       name: 'Create',
       description: '',
       to: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'backlog'), allElements),
@@ -100,7 +101,7 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
         ],
       },
     },
-    {
+    [naclCase('TransitionToShared::From: backlog, done::Directed')]: {
       name: 'TransitionToShared',
       description: '',
       from: [{
@@ -196,7 +197,7 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
         },
       },
     },
-  ],
+  },
   statuses: [
     {
       id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'backlog'), allElements),

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -180,12 +180,13 @@ export const DEFAULT_FILTERS = [
   scriptRunnerWorkflowFilter,
   // must run after scriptRunnerWorkflowFilter
   scriptRunnerWorkflowListsFilter,
-  // must run after scriptRunnerWorkflowListsFilter
-  scriptRunnerWorkflowReferencesFilter,
   scriptRunnerTemplateExpressionFilter,
   scriptRunnerEmptyAccountIdsFilter,
-  transitionIdsFilter,
+  // resolves references!
   workflowPropertiesFilter,
+  // must run after scriptRunnerWorkflowListsFilter and workflowPropertiesFilter
+  scriptRunnerWorkflowReferencesFilter,
+  transitionIdsFilter,
   workflowDeployFilter,
   workflowModificationFilter,
   emptyValidatorWorkflowFilter,

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -176,7 +176,6 @@ export const DEFAULT_FILTERS = [
   avatarsFilter,
   iconUrlFilter,
   triggersFilter,
-  transitionIdsFilter,
   resolutionPropertyFilter,
   scriptRunnerWorkflowFilter,
   // must run after scriptRunnerWorkflowFilter
@@ -185,6 +184,7 @@ export const DEFAULT_FILTERS = [
   scriptRunnerWorkflowReferencesFilter,
   scriptRunnerTemplateExpressionFilter,
   scriptRunnerEmptyAccountIdsFilter,
+  transitionIdsFilter,
   workflowPropertiesFilter,
   workflowDeployFilter,
   workflowModificationFilter,

--- a/packages/jira-adapter/src/change_validators/workflows/empty_validator_workflow.ts
+++ b/packages/jira-adapter/src/change_validators/workflows/empty_validator_workflow.ts
@@ -34,7 +34,7 @@ export const CONFIGURATION_VALIDATOR_TYPE = new Set([
 
 const workflowHasEmptyValidator = (instance: WorkflowInstance): Set<string> => {
   const invalidValidators = new Set<string>()
-  instance.value.transitions?.forEach(transition => {
+  Object.values(instance.value.transitions).forEach(transition => {
     transition.rules?.validators?.forEach(validator => {
       if (validator.type !== undefined && CONFIGURATION_VALIDATOR_TYPE.has(validator.type) && !('configuration' in validator)) {
         invalidValidators.add(validator.type)

--- a/packages/jira-adapter/src/change_validators/workflows/workflow_properties.ts
+++ b/packages/jira-adapter/src/change_validators/workflows/workflow_properties.ts
@@ -33,7 +33,7 @@ export const workflowPropertiesValidator: ChangeValidator = async changes =>
     .map(getChangeData)
     .filter(isWorkflowInstance)
     .filter(instance => {
-      const items = [...(instance.value.statuses ?? []), ...(instance.value.transitions ?? [])]
+      const items = [...(instance.value.statuses ?? []), ...(Object.values(instance.value.transitions) ?? [])]
       const countItemsKeys = getPropertiesKeyGroups(items).map(keyGroup => _.countBy(keyGroup))
       const duplicateItemsKeys = countItemsKeys.map(dictionary => _.values(dictionary))
         .flatMap(countList => countList.filter(count => count > 1))

--- a/packages/jira-adapter/src/filters/script_runner/workflow/empty_account_ids.ts
+++ b/packages/jira-adapter/src/filters/script_runner/workflow/empty_account_ids.ts
@@ -23,7 +23,7 @@ import { SCRIPT_RUNNER_POST_FUNCTION_TYPE, SCRIPT_RUNNER_SEND_NOTIFICATIONS } fr
 const { makeArray } = collections.array
 
 const changeAccountIds = (workflowInstance: WorkflowInstance, func: (scriptRunner: Value) => Value): void => {
-  workflowInstance.value.transitions.forEach(transition => {
+  Object.values(workflowInstance.value.transitions).forEach(transition => {
     makeArray(transition.rules?.postFunctions).forEach(postFunction => {
       if (postFunction.type === SCRIPT_RUNNER_POST_FUNCTION_TYPE
           && postFunction.configuration?.scriptRunner?.className === SCRIPT_RUNNER_SEND_NOTIFICATIONS) {

--- a/packages/jira-adapter/src/filters/script_runner/workflow/walk_on_scripts.ts
+++ b/packages/jira-adapter/src/filters/script_runner/workflow/walk_on_scripts.ts
@@ -18,7 +18,7 @@ import { walkOnValue, WalkOnFunc, WALK_NEXT_STEP } from '@salto-io/adapter-utils
 import { InstanceElement, Value } from '@salto-io/adapter-api'
 import { SCRIPT_RUNNER_DC_TYPES } from './workflow_dc'
 import { SCRIPT_RUNNER_CLOUD_TYPES } from './workflow_cloud'
-import { Transition, isWorkflowInstance } from '../../workflow/types'
+import { isWorkflowInstance } from '../../workflow/types'
 
 
 const SCRIPT_DC_FIELDS = ['FIELD_CONDITION', 'FIELD_ADDITIONAL_SCRIPT', 'FIELD_SCRIPT_FILE_OR_SCRIPT']
@@ -71,9 +71,9 @@ export const walkOnScripts = (
   instances
     .filter(isWorkflowInstance)
     .forEach(instance => {
-      instance.value.transitions.forEach((transition: Transition, index: number) => {
+      Object.entries(instance.value.transitions).forEach(([key, transition]) => {
         if (transition.rules !== undefined) {
-          walkOnValue({ elemId: instance.elemID.createNestedID('transitions', index.toString(), 'rules'),
+          walkOnValue({ elemId: instance.elemID.createNestedID('transitions', key, 'rules'),
             value: transition.rules,
             func: isDc
               ? walkOnDcScripts(func)

--- a/packages/jira-adapter/src/filters/script_runner/workflow/workflow_references.ts
+++ b/packages/jira-adapter/src/filters/script_runner/workflow/workflow_references.ts
@@ -15,30 +15,77 @@
 */
 
 import { resolveValues, restoreValues } from '@salto-io/adapter-utils'
-import { isInstanceChange, isAdditionOrModificationChange, getChangeData, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
+import { isAdditionOrModificationChange, getChangeData, InstanceElement, isInstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { FilterCreator } from '../../../filter'
 import { WORKFLOW_TYPE_NAME } from '../../../constants'
 import { getLookUpName } from '../../../reference_mapping'
+import { WorkflowInstance, isWorkflowInstance } from '../../workflow/types'
+import { transitionKeysToExpectedIds, walkOverTransitionIds } from '../../workflow/transition_structure'
+
 
 const { awu } = collections.asynciterable
+
+const getTransitionIdToKeyMap = (workflowInstance: WorkflowInstance): Map<string, string> =>
+  new Map(Object.entries(workflowInstance.value.transitions)
+    .map(([key, transition]) => [transition.id, key])
+    .filter((entry): entry is [string, string] => entry[0] !== undefined))
+
+const addTransitionReferences = (workflowInstance: WorkflowInstance): void => {
+  const transitionIdToKey = getTransitionIdToKeyMap(workflowInstance)
+  Object.values(workflowInstance.value.transitions).forEach(transition => {
+    walkOverTransitionIds(transition, scriptRunner => {
+      const transitionKey = transitionIdToKey.get(scriptRunner.transitionId)
+      scriptRunner.transitionId = transitionKey === undefined
+        ? scriptRunner.transitionId
+        : new ReferenceExpression(
+          workflowInstance.elemID.createNestedID('transitions', transitionKey),
+          workflowInstance.value.transitions[transitionKey],
+        )
+    })
+  })
+}
 
 
 // This filter is used to remove and return references in script runner workflows
 // As the references are encoded we cannot wait for the references filter to resolve them
-const filter: FilterCreator = ({ config }) => {
+const filter: FilterCreator = ({ config, client }) => {
   const originalInstances: Record<string, InstanceElement> = {}
   return {
     name: 'scriptRunnerWorkflowReferencesFilter',
+    onFetch: async elements => {
+      if (!config.fetch.enableScriptRunnerAddon || client.isDataCenter) {
+        return
+      }
+
+      elements
+        .filter(isInstanceElement)
+        .filter(isWorkflowInstance)
+        .forEach(addTransitionReferences)
+    },
     preDeploy: async changes => {
       if (!config.fetch.enableScriptRunnerAddon) {
         return
       }
-      await awu(changes)
+      const workflows = changes
         .filter(isAdditionOrModificationChange)
         .map(getChangeData)
         .filter(isInstanceElement)
-        .filter(instance => instance.elemID.typeName === WORKFLOW_TYPE_NAME)
+        .filter(isWorkflowInstance)
+
+      workflows
+        .forEach(workflow => {
+          const expectedIdsMap = transitionKeysToExpectedIds(workflow)
+          Object.values(workflow.value.transitions).forEach(transition => {
+            walkOverTransitionIds(transition, scriptRunner => {
+              scriptRunner.transitionId = (scriptRunner.transitionId instanceof ReferenceExpression)
+                ? expectedIdsMap.get(scriptRunner.transitionId.elemID.name) ?? scriptRunner.transitionId
+                : scriptRunner.transitionId
+            })
+          })
+        })
+
+      await awu(workflows)
         .forEach(async instance => {
           originalInstances[instance.elemID.getFullName()] = instance.clone()
           instance.value.transitions = (
@@ -50,15 +97,20 @@ const filter: FilterCreator = ({ config }) => {
       if (!config.fetch.enableScriptRunnerAddon) {
         return
       }
-      await awu(changes)
+      const workflows = changes
         .filter(isAdditionOrModificationChange)
-        .filter(isInstanceChange)
         .map(getChangeData)
+        .filter(isInstanceElement)
+        .filter(isWorkflowInstance)
+
+      workflows.forEach(addTransitionReferences)
+
+      await awu(workflows)
         .filter(instance => instance.elemID.typeName === WORKFLOW_TYPE_NAME)
         .forEach(async instance => {
           instance.value.transitions = (await restoreValues(
-            instance,
             originalInstances[instance.elemID.getFullName()],
+            instance,
             getLookUpName,
           )).value.transitions
         })

--- a/packages/jira-adapter/src/filters/sort_lists.ts
+++ b/packages/jira-adapter/src/filters/sort_lists.ts
@@ -41,7 +41,6 @@ const VALUES_TO_SORT: Record<string, Record<string, string[]>> = {
     projects: ['projectId.elemID.name', 'projectTypeKey'],
   },
   [WORKFLOW_TYPE_NAME]: {
-    transitions: ['name'],
     statuses: ['id.elemID.name'],
   },
   [NOTIFICATION_EVENT_TYPE_NAME]: {

--- a/packages/jira-adapter/src/filters/workflow/post_functions_types.ts
+++ b/packages/jira-adapter/src/filters/workflow/post_functions_types.ts
@@ -60,6 +60,7 @@ const scriptRunnerObjectType = new ObjectType({
     roleId: { refType: BuiltinTypes.STRING, annotations: { [CORE_ANNOTATIONS.CREATABLE]: true } },
     boardId: { refType: BuiltinTypes.STRING, annotations: { [CORE_ANNOTATIONS.CREATABLE]: true } },
     linkTypeId: { refType: BuiltinTypes.STRING, annotations: { [CORE_ANNOTATIONS.CREATABLE]: true } },
+    transitionId: { refType: BuiltinTypes.STRING, annotations: { [CORE_ANNOTATIONS.CREATABLE]: true } },
   },
   path: [JIRA, elements.TYPES_PATH, elements.SUBTYPES_PATH, SCRIPT_RUNNER_TYPE],
 })

--- a/packages/jira-adapter/src/filters/workflow/resolution_property_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/resolution_property_filter.ts
@@ -27,8 +27,8 @@ const { awu } = collections.asynciterable
 const log = logger(module)
 
 const splitResolutionProperties = (instance: WorkflowInstance): void => {
-  instance.value.transitions
-    ?.filter(transition => transition.properties !== undefined)
+  Object.values(instance.value.transitions)
+    .filter(transition => transition.properties !== undefined)
     ?.forEach(transition => {
       transition.properties = _.mapValues(
         transition.properties,
@@ -62,8 +62,8 @@ const filter: FilterCreator = () => ({
         await applyFunctionToChangeData<Change<WorkflowInstance>>(
           change,
           async instance => {
-            instance.value.transitions
-              ?.filter(transition => _.isPlainObject(transition.properties))
+            Object.values(instance.value.transitions)
+              .filter(transition => _.isPlainObject(transition.properties))
               ?.forEach(transition => {
                 transition.properties = _.mapValues(
                   transition.properties,

--- a/packages/jira-adapter/src/filters/workflow/transition_ids_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/transition_ids_filter.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Element, isInstanceElement } from '@salto-io/adapter-api'
+import { Element, getChangeData, isAdditionOrModificationChange, isInstanceElement } from '@salto-io/adapter-api'
 import { FilterCreator } from '../../filter'
 import { isWorkflowInstance } from './types'
 
@@ -26,6 +26,20 @@ const filter: FilterCreator = () => ({
   name: 'transitionIdsFilter',
   onFetch: async (elements: Element[]) => {
     elements
+      .filter(isInstanceElement)
+      .filter(isWorkflowInstance)
+      .forEach(instance => {
+        Object.values(instance.value.transitions).forEach(transition => {
+          // We don't need to id after this filter since
+          // in modification we remove and create a new workflow
+          delete transition.id
+        })
+      })
+  },
+  onDeploy: async changes => {
+    changes
+      .filter(isAdditionOrModificationChange)
+      .map(getChangeData)
       .filter(isInstanceElement)
       .filter(isWorkflowInstance)
       .forEach(instance => {

--- a/packages/jira-adapter/src/filters/workflow/transition_ids_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/transition_ids_filter.ts
@@ -29,7 +29,7 @@ const filter: FilterCreator = () => ({
       .filter(isInstanceElement)
       .filter(isWorkflowInstance)
       .forEach(instance => {
-        instance.value.transitions?.forEach(transition => {
+        Object.values(instance.value.transitions).forEach(transition => {
           // We don't need to id after this filter since
           // in modification we remove and create a new workflow
           delete transition.id

--- a/packages/jira-adapter/src/filters/workflow/transition_structure.ts
+++ b/packages/jira-adapter/src/filters/workflow/transition_structure.ts
@@ -1,0 +1,146 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { invertNaclCase, naclCase } from '@salto-io/adapter-utils'
+import { SaltoError, Value } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { Status, Transition, WorkflowInstance } from './types'
+import { SCRIPT_RUNNER_POST_FUNCTION_TYPE } from '../script_runner/workflow/workflow_cloud'
+
+const PARTS_SEPARATOR = '::'
+
+const TYPE_TO_FROM_MAP = new Map([
+  ['Initial', 'none'],
+  ['Global', 'any status'],
+  ['Circular', 'any status'],
+])
+
+type TransitionType = 'Directed' | 'Initial' | 'Global' | 'Circular'
+
+const getTransitionTypeFromKey = (key: string): string => {
+  const type = invertNaclCase(key).split(PARTS_SEPARATOR).pop() as string
+  return type === 'Circular' ? 'Global' : type
+}
+
+const getTransitionType = (transition: Transition): TransitionType => {
+  if (transition.type === 'initial') {
+    return 'Initial'
+  }
+  if (transition.from !== undefined
+    && transition.from.length !== 0) {
+    return 'Directed'
+  }
+  if ((transition.to ?? '') === '') {
+    return 'Circular'
+  }
+  return 'Global'
+}
+
+// returns a map of with the expected transition IDs after deployment for each transition key
+export const transitionKeysToExpectedIds = (workflowInstance: WorkflowInstance): Map<string, string> => {
+  const groupedKeys = _.groupBy(Object.keys(workflowInstance.value.transitions), getTransitionTypeFromKey)
+
+  const map = new Map<string, string>()
+
+  groupedKeys.Initial?.forEach(key => map.set(key, '1'))
+  let count = 0
+  groupedKeys.Global?.forEach(key => {
+    count += 1
+    map.set(key, (1 + count * 10).toString())
+  })
+  groupedKeys.Directed?.forEach(key => {
+    count += 1
+    map.set(key, (1 + count * 10).toString())
+  })
+
+
+  return map
+}
+
+export const createStatusMap = (statuses: Status[]): Map<string, string> => new Map(statuses
+  .filter((status): status is {id: string; name: string} => typeof status.id === 'string' && status.name !== undefined)
+  .map((status => [status.id, status.name])))
+
+export const getTransitionKey = (transition: Transition, statusesMap: Map<string, string>): string => {
+  const type = getTransitionType(transition)
+  const fromSorted = type === 'Directed'
+    ? (transition.from?.map(from => (
+      typeof from === 'string' ? from : from.id ?? ''
+    )) ?? [])
+      .map(from => statusesMap.get(from) ?? from)
+      .sort()
+      .join(',')
+    : TYPE_TO_FROM_MAP.get(type) ?? ''
+
+  return naclCase([transition.name ?? '', `From: ${fromSorted}`, type].join(PARTS_SEPARATOR))
+}
+
+export const transformTransitions = (value: Value): SaltoError[] => {
+  const statusesMap = createStatusMap(value.statuses ?? [])
+  const maxCounts: Record<string, number> = {}
+  value.transitions.forEach((transition: Transition) => {
+    const key = getTransitionKey(transition, statusesMap)
+    maxCounts[key] = (maxCounts[key] ?? 0) + 1
+  })
+
+  const counts: Record<string, number> = {}
+
+  value.transitions = Object.fromEntries(value.transitions
+    // This is Value and not the actual type as we change types
+    .map((transition: Value) => {
+      const key = getTransitionKey(transition, statusesMap)
+      counts[key] = (counts[key] ?? 0) + 1
+      if (maxCounts[key] > 1) {
+        return [naclCase(`${invertNaclCase(key)}${PARTS_SEPARATOR}${counts[key]}`), transition]
+      }
+      return [key, transition]
+    }))
+  const errorKeys = Object.entries(counts)
+    .filter(([, count]) => count > 1)
+    .map(([key]) => key)
+
+  return errorKeys.length === 0
+    ? []
+    : [{
+      message: `The following transitions of workflow ${value.name} have the same key: ${errorKeys.join(', ')}.
+It is strongly recommended to rename these transitions so they are unique in Jira, then re-fetch`,
+      severity: 'Warning',
+    }]
+}
+
+export const walkOverTransitionIds = (transition: Transition, func: (value: Value) => void): void => {
+  transition.rules?.postFunctions
+    ?.filter(postFunction => postFunction.type === SCRIPT_RUNNER_POST_FUNCTION_TYPE)
+    .forEach(postFunction => {
+      if (postFunction.configuration?.scriptRunner?.transitionId === undefined) {
+        return
+      }
+      func(postFunction.configuration.scriptRunner)
+    })
+}
+
+export const expectedToActualTransitionIds = ({ transitions, expectedTransitionIds, statusesMap }
+: { transitions: Transition[]
+  expectedTransitionIds: Map<string, string>
+  statusesMap: Map<string, string>
+}): Record<string, string> =>
+  Object.fromEntries(transitions
+    // create a map of [expectedId, actualId]
+    .map(transition => [
+      expectedTransitionIds.get(getTransitionKey(transition, statusesMap)),
+      transition.id] as [string | undefined, string | undefined])
+    .filter(([expectedId, actualId]) => expectedId !== undefined && actualId !== undefined)
+    .filter(([expectedId, actualId]) => expectedId !== actualId))

--- a/packages/jira-adapter/src/filters/workflow/triggers_deployment.ts
+++ b/packages/jira-adapter/src/filters/workflow/triggers_deployment.ts
@@ -17,55 +17,19 @@ import { AdditionChange, getChangeData } from '@salto-io/adapter-api'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
-import Joi from 'joi'
-import _ from 'lodash'
 import JiraClient from '../../client/client'
-import { Transition, WORKFLOW_RESPONSE_SCHEMA, WorkflowInstance, WorkflowResponse } from './types'
-import { createStatusMap, getTransitionKey } from './workflow_structure_filter'
+import { WorkflowInstance } from './types'
 
 
 const { awu } = collections.asynciterable
 
 const log = logger(module)
 
-const isValidTransitionResponse = (response: unknown): response is { values: [WorkflowResponse] } => {
-  const { error } = Joi.object({
-    values: Joi.array().min(1).max(1).items(WORKFLOW_RESPONSE_SCHEMA),
-  }).unknown(true).required().validate(response)
-
-  if (error !== undefined) {
-    log.warn(`Unexpected workflows response from Jira: ${error}. ${safeJsonStringify(response)}`)
-    return false
-  }
-  return true
-}
-
-const getTransitionsFromService = async (
-  client: JiraClient,
-  workflowName: string,
-): Promise<Transition[]> => {
-  const response = await client.getSinglePage({
-    url: '/rest/api/3/workflow/search',
-    queryParams: {
-      expand: 'transitions',
-      workflowName,
-    },
-  })
-
-  if (!isValidTransitionResponse(response.data)) {
-    return []
-  }
-
-  const workflowValues = response.data.values[0]
-  return workflowValues.transitions ?? []
-}
-
 export const deployTriggers = async (
   change: AdditionChange<WorkflowInstance>,
-  client: JiraClient
+  client: JiraClient,
 ): Promise<void> => {
   const instance = getChangeData(change)
-  const statusesMap = createStatusMap(instance.value.statuses ?? [])
 
   const workflowName = instance.value.name
   // We never supposed to get here
@@ -73,11 +37,8 @@ export const deployTriggers = async (
     throw new Error('Cannot deploy a workflow without a name')
   }
 
-  const transitions = await getTransitionsFromService(client, workflowName)
-  const keyToTransition = _.keyBy(transitions, transition => getTransitionKey(transition, statusesMap))
-
-  await awu(Object.entries(instance.value.transitions) ?? []).forEach(async ([key, transition]) => {
-    const transitionId = keyToTransition[key]?.id
+  await awu(Object.values(instance.value.transitions) ?? []).forEach(async transition => {
+    const transitionId = transition.id
 
     if (transitionId === undefined) {
       log.error(`Could not find the id of the transition ${transition.name} to deploy: ${safeJsonStringify(instance.value)}`)

--- a/packages/jira-adapter/src/filters/workflow/triggers_deployment.ts
+++ b/packages/jira-adapter/src/filters/workflow/triggers_deployment.ts
@@ -20,13 +20,13 @@ import { collections } from '@salto-io/lowerdash'
 import Joi from 'joi'
 import _ from 'lodash'
 import JiraClient from '../../client/client'
-import { Transition, Workflow, WorkflowInstance, workflowSchema } from './types'
+import { Transition, WorkflowInstance, WorkflowResponse, workflowSchema } from './types'
 
 const { awu } = collections.asynciterable
 
 const log = logger(module)
 
-const isValidTransitionResponse = (response: unknown): response is { values: [Workflow] } => {
+const isValidTransitionResponse = (response: unknown): response is { values: [WorkflowResponse] } => {
   const { error } = Joi.object({
     values: Joi.array().min(1).max(1).items(workflowSchema),
   }).unknown(true).required().validate(response)
@@ -80,7 +80,7 @@ export const deployTriggers = async (
   const transitions = await getTransitionsFromService(client, workflowName)
   const keyToTransition = _.keyBy(transitions, getTransitionKey)
 
-  await awu(instance.value.transitions ?? []).forEach(async transition => {
+  await awu(Object.values(instance.value.transitions) ?? []).forEach(async transition => {
     const transitionId = keyToTransition[getTransitionKey(transition)]?.id
 
     if (transitionId === undefined) {

--- a/packages/jira-adapter/src/filters/workflow/triggers_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/triggers_filter.ts
@@ -65,7 +65,7 @@ const filter: FilterCreator = ({ client, config }) => ({
       .map(async instance => {
         try {
           await Promise.all(
-            (instance.value.transitions ?? []).map(async transition => {
+            (Object.values(instance.value.transitions) ?? []).map(async transition => {
               if (transition.id === undefined) {
                 log.warn(`Did not find transition id of transition ${safeJsonStringify(transition)}`)
                 return

--- a/packages/jira-adapter/src/filters/workflow/types.ts
+++ b/packages/jira-adapter/src/filters/workflow/types.ts
@@ -193,7 +193,7 @@ export type WorkflowResponse = Omit<Workflow, 'transitions'> & {
   transitions: Transition[]
 }
 
-const WORKFLOW_RESPONSE_SCHEMA = Joi.object({
+export const WORKFLOW_RESPONSE_SCHEMA = Joi.object({
   id: idSchema.optional(),
   entityId: Joi.string().optional(),
   name: Joi.string().optional(),

--- a/packages/jira-adapter/src/filters/workflow/types.ts
+++ b/packages/jira-adapter/src/filters/workflow/types.ts
@@ -16,6 +16,7 @@
 import { Change, getChangeData, InstanceElement, isInstanceChange, Values, Element, Value } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import Joi from 'joi'
+import { createSchemeGuard } from '@salto-io/adapter-utils'
 import { WORKFLOW_TYPE_NAME } from '../../constants'
 
 const log = logger(module)
@@ -149,7 +150,7 @@ export type Transition = {
   id?: string
   type?: string
   rules?: Rules
-  name?: string
+  name: string
   from?: (TransitionFrom | string)[]
   properties?: Values
   to?: unknown
@@ -159,7 +160,7 @@ export const transitionsSchema = Joi.object({
   id: Joi.string().optional(),
   type: Joi.string().optional(),
   rules: rulesSchema.optional(),
-  name: Joi.string().optional(),
+  name: Joi.string().required(),
   from: Joi.array().items(Joi.any()).optional(),
   properties: Joi.alternatives(Joi.object(), Joi.array()).optional(),
   to: Joi.any().optional(),
@@ -182,13 +183,17 @@ export type Workflow = {
   id?: Id
   entityId?: string
   name?: string
-  transitions: Transition[]
+  transitions: Record<string, Transition>
   statuses?: Status[]
   diagramInitialEntry?: StatusLocation
   diagramGlobalLoopedTransition?: StatusLocation
 }
 
-export const workflowSchema = Joi.object({
+export type WorkflowResponse = Omit<Workflow, 'transitions'> & {
+  transitions: Transition[]
+}
+
+const WORKFLOW_RESPONSE_SCHEMA = Joi.object({
   id: idSchema.optional(),
   entityId: Joi.string().optional(),
   name: Joi.string().optional(),
@@ -196,7 +201,14 @@ export const workflowSchema = Joi.object({
   statuses: Joi.array().items(statusSchema).optional(),
 }).unknown(true).required()
 
+export const workflowSchema = WORKFLOW_RESPONSE_SCHEMA.keys({
+  transitions: Joi.object().pattern(Joi.string(), transitionsSchema).required(),
+})
+
 export type WorkflowInstance = InstanceElement & { value: InstanceElement['value'] & Workflow }
+export type WorkflowResponseInstance = InstanceElement & { value: InstanceElement['value'] & WorkflowResponse }
+
+const isWorkflowResponseValues = createSchemeGuard<WorkflowResponse>(WORKFLOW_RESPONSE_SCHEMA, 'Received unexpected workflow response from service')
 
 export const isWorkflowValues = (values: unknown): values is Workflow => {
   const { error } = workflowSchema.validate(values)
@@ -211,6 +223,9 @@ export const isWorkflowInstance = (instance: InstanceElement)
 : instance is WorkflowInstance =>
   instance.elemID.typeName === WORKFLOW_TYPE_NAME && isWorkflowValues(instance.value)
 
+export const isWorkflowResponseInstance = (instance: InstanceElement)
+: instance is WorkflowResponseInstance =>
+  instance.elemID.typeName === WORKFLOW_TYPE_NAME && isWorkflowResponseValues(instance.value)
 
 export type PostFetchWorkflow = Workflow & {
   name: string

--- a/packages/jira-adapter/src/filters/workflow/workflow_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_deploy_filter.ts
@@ -45,8 +45,8 @@ export const INITIAL_VALIDATOR = {
  * not create an additional one if one validator like that already appears in the nacl.
  */
 const removeCreateIssuePermissionValidator = (instance: WorkflowInstance): void => {
-  instance.value.transitions
-    ?.filter(transition => transition.type === 'initial')
+  Object.values(instance.value.transitions)
+    .filter(transition => transition.type === 'initial')
     .forEach(transition => {
       const createIssuePermissionValidatorIndex = _.findLastIndex(
         transition.rules?.validators ?? [],
@@ -92,7 +92,7 @@ export const deployWorkflow = async (
   }
   const instance = getChangeData(resolvedChange)
   removeCreateIssuePermissionValidator(instance)
-  instance.value.transitions.forEach(transition => {
+  Object.values(instance.value.transitions).forEach(transition => {
     changeIdsToString(transition.rules?.conditions ?? {})
   })
 

--- a/packages/jira-adapter/src/filters/workflow/workflow_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_deploy_filter.ts
@@ -13,12 +13,13 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { AdditionChange, ElemID, getChangeData, InstanceElement, isAdditionChange, isInstanceChange, isRemovalChange, RemovalChange } from '@salto-io/adapter-api'
+import { AdditionChange, Change, ElemID, getChangeData, InstanceElement, isAdditionChange, isInstanceChange, isRemovalChange, RemovalChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
+import Joi from 'joi'
 import { resolveChangeElement, safeJsonStringify, walkOnValue, WALK_NEXT_STEP, elementExpressionStringifyReplacer } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../../filter'
-import { isPostFetchWorkflowChange, WorkflowInstance } from './types'
+import { isPostFetchWorkflowChange, PostFetchWorkflowInstance, Transition, WORKFLOW_RESPONSE_SCHEMA, WorkflowInstance, WorkflowResponse } from './types'
 import JiraClient from '../../client/client'
 import { JiraConfig } from '../../config/config'
 import { getLookUpName } from '../../reference_mapping'
@@ -28,6 +29,8 @@ import { deployTriggers } from './triggers_deployment'
 import { deploySteps } from './steps_deployment'
 import { fixGroupNames } from './groups_filter'
 import { deployWorkflowDiagram, hasDiagramFields, removeWorkflowDiagramFields } from './workflow_diagrams'
+import { expectedToActualTransitionIds, createStatusMap, transitionKeysToExpectedIds, walkOverTransitionIds, getTransitionKey } from './transition_structure'
+import { decodeCloudFields, encodeCloudFields } from '../script_runner/workflow/workflow_cloud'
 
 const log = logger(module)
 
@@ -36,6 +39,53 @@ export const INITIAL_VALIDATOR = {
   configuration: {
     permissionKey: 'CREATE_ISSUES',
   },
+}
+
+const isValidTransitionResponse = (response: unknown): response is { values: [WorkflowResponse] } => {
+  const { error } = Joi.object({
+    values: Joi.array().min(1).max(1).items(WORKFLOW_RESPONSE_SCHEMA),
+  }).unknown(true).required().validate(response)
+
+  if (error !== undefined) {
+    log.warn(`Unexpected workflows response from Jira: ${error}. ${safeJsonStringify(response)}`)
+    return false
+  }
+  return true
+}
+
+// needed for transitionIds
+const getTransitionsFromService = async (
+  client: JiraClient,
+  workflowName: string,
+): Promise<Transition[]> => {
+  const response = await client.getSinglePage({
+    url: '/rest/api/3/workflow/search',
+    queryParams: {
+      expand: 'transitions',
+      workflowName,
+    },
+  })
+
+  if (!isValidTransitionResponse(response.data)) {
+    return []
+  }
+
+  const workflowValues = response.data.values[0]
+  return workflowValues.transitions ?? []
+}
+
+const sameTransitionIds = (
+  transitions: Transition[],
+  otherTransitions: Transition[],
+  statusesMap: Map<string, string>
+): boolean => {
+  const transitionIds = Object.fromEntries(transitions.map(
+    transition => [transition.id, getTransitionKey(transition, statusesMap)]
+  ))
+  const otherTransitionIds = Object.fromEntries(otherTransitions.map(
+    transition => [transition.id, getTransitionKey(transition, statusesMap)]
+  ))
+  return _.isEqual(transitionIds, otherTransitionIds)
 }
 
 /**
@@ -82,25 +132,24 @@ const workflowTransitionsToList = (workflowInstance: InstanceElement): void => {
   workflowInstance.value.transitions = Object.values(workflowInstance.value.transitions)
 }
 
-export const deployWorkflow = async (
-  change: AdditionChange<InstanceElement> | RemovalChange<InstanceElement>,
-  client: JiraClient,
-  config: JiraConfig,
-): Promise<void> => {
-  const resolvedChange = await resolveChangeElement(change, getLookUpName)
-
-  if (!isPostFetchWorkflowChange(resolvedChange)) {
-    const instance = getChangeData(resolvedChange)
-    log.error(`values ${safeJsonStringify(instance.value, elementExpressionStringifyReplacer)} of instance ${instance.elemID.getFullName} are invalid`)
-    throw new Error(`instance ${instance.elemID.getFullName()} is not valid for deployment`)
-  }
-  const instance = getChangeData(resolvedChange)
-  removeCreateIssuePermissionValidator(instance)
-  Object.values(instance.value.transitions).forEach(transition => {
-    changeIdsToString(transition.rules?.conditions ?? {})
+const addTransitionIdsToInstance = (
+  workflowInstance: WorkflowInstance,
+  transitions: Transition[],
+  statusesMap: Map<string, string>
+): void => {
+  const transitionIds = Object.fromEntries(transitions.map(
+    transition => [getTransitionKey(transition, statusesMap), transition.id]
+  ))
+  Object.entries(workflowInstance.value.transitions).forEach(([key, transition]) => {
+    transition.id = transitionIds[key]
   })
+}
 
-  fixGroupNames(instance)
+const deployWithClone = async (
+  resolvedChange: Change<PostFetchWorkflowInstance>,
+  client: JiraClient,
+  config: JiraConfig
+): Promise<void> => {
   const resolvedChangeForDeployment = _.cloneDeep(resolvedChange)
   const deployInstance = getChangeData(resolvedChangeForDeployment)
   if (!isRemovalChange(resolvedChange)) {
@@ -116,14 +165,115 @@ export const deployWorkflow = async (
       // In DC we support passing the step name as part of the request
       || (!client.isDataCenter && path.name === 'name' && path.getFullNameParts().includes('statuses')),
   })
-  instance.value.entityId = deployInstance.value.entityId
-  if (!isRemovalChange(resolvedChange) && hasDiagramFields(instance)) {
+  getChangeData(resolvedChange).value.entityId = deployInstance.value.entityId
+}
+
+const verifyAndFixTransitionReferences = async ({
+  transitions,
+  expectedTransitionIds,
+  statusesMap,
+  client,
+  config,
+  resolvedChange,
+} : {
+  transitions: Transition[]
+  expectedTransitionIds: Map<string, string>
+  statusesMap: Map<string, string>
+  client: JiraClient
+  config: JiraConfig
+  resolvedChange: Change<PostFetchWorkflowInstance>
+}): Promise<Transition[]> => {
+  const transitionIdsMap = expectedToActualTransitionIds({
+    transitions,
+    expectedTransitionIds,
+    statusesMap,
+  })
+  if (Object.keys(transitionIdsMap).length === 0) {
+    return transitions
+  }
+  const originalInstance = getChangeData(resolvedChange)
+  walkOnValue({ elemId: originalInstance.elemID.createNestedID('transitions'),
+    value: originalInstance.value.transitions,
+    func: decodeCloudFields })
+
+  // a function as the transitions changed type to an array
+  const updateTransitionReferenceIds = (
+    transitionsArray: Record<string, Transition>,
+  ): void => {
+    Object.values(transitionsArray).forEach((transition: Transition) => {
+      walkOverTransitionIds(transition, scriptRunner => {
+        scriptRunner.transitionId = transitionIdsMap[scriptRunner.transitionId] ?? scriptRunner.transitionId
+      })
+    })
+  }
+
+  updateTransitionReferenceIds(originalInstance.value.transitions)
+  walkOnValue({ elemId: originalInstance.elemID.createNestedID('transitions'),
+    value: originalInstance.value.transitions,
+    func: encodeCloudFields })
+
+  await deployWithClone(resolvedChange, client, config)
+
+  const newTransitions = await getTransitionsFromService(client, originalInstance.value.name)
+  if (!sameTransitionIds(transitions, newTransitions, statusesMap)) {
+    throw new Error('Failed to deploy workflow, transition ids changed')
+  }
+  return newTransitions
+}
+
+
+export const deployWorkflow = async (
+  change: AdditionChange<InstanceElement> | RemovalChange<InstanceElement>,
+  client: JiraClient,
+  config: JiraConfig,
+): Promise<void> => {
+  const resolvedChange = await resolveChangeElement(change, getLookUpName)
+
+  if (!isPostFetchWorkflowChange(resolvedChange)
+    || !isPostFetchWorkflowChange(change)) {
+    const instance = getChangeData(resolvedChange)
+    log.error(`values ${safeJsonStringify(instance.value, elementExpressionStringifyReplacer)} of instance ${instance.elemID.getFullName} are invalid`)
+    throw new Error(`instance ${instance.elemID.getFullName()} is not valid for deployment`)
+  }
+  const instance = getChangeData(resolvedChange)
+  removeCreateIssuePermissionValidator(instance)
+  Object.values(instance.value.transitions).forEach(transition => {
+    changeIdsToString(transition.rules?.conditions ?? {})
+  })
+
+  fixGroupNames(instance)
+  const expectedTransitionIds = transitionKeysToExpectedIds(instance)
+  // todo reduce to relevant only
+  await deployWithClone(resolvedChange, client, config)
+
+  if (isRemovalChange(resolvedChange)) {
+    return
+  }
+  let transitions = await getTransitionsFromService(client, instance.value.name)
+  const statusesMap = createStatusMap(instance.value.statuses ?? [])
+  if (config.fetch.enableScriptRunnerAddon
+    && !client.isDataCenter) {
+    transitions = await verifyAndFixTransitionReferences({
+      transitions,
+      expectedTransitionIds,
+      statusesMap,
+      client,
+      config,
+      resolvedChange,
+    })
+  }
+  // ids are added for trigger deployment and onDeploy filters, will be removed in the ids filter
+  [getChangeData(change), instance].forEach(instanceToChange => {
+    addTransitionIdsToInstance(instanceToChange, transitions, statusesMap)
+  })
+  if (hasDiagramFields(instance)) {
     try {
       await deployWorkflowDiagram({ instance, client })
     } catch (e) {
       log.error(`Fail to deploy Workflow ${instance.value.name} diagram with the error: ${e.message}`)
     }
   }
+
   if (isAdditionChange(resolvedChange)) {
     getChangeData(change).value.entityId = instance.value.entityId
     // If we created the workflow we can edit it

--- a/packages/jira-adapter/src/filters/workflow/workflow_diagrams.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_diagrams.ts
@@ -162,8 +162,8 @@ export const removeWorkflowDiagramFields = (element: WorkflowInstance): void => 
     .forEach(status => {
       delete status.location
     })
-  element.value.transitions
-    ?.filter(transition => transition.from !== undefined)
+  Object.values(element.value.transitions)
+    .filter(transition => transition.from !== undefined)
     .forEach(transition => {
       const { type } = transition
       if (type === INITIAL_TRANSITION_TYPE) {
@@ -202,8 +202,8 @@ const buildStatusDiagramFields = (workflow: WorkflowInstance, statusIdToStepId: 
 const buildTransitionsDiagramFields = (workflow: WorkflowInstance, statusIdToStepId: Record<string, string>,
   actionKeyToTransition: Record<string, TransitionDiagramFields>)
   : (TransitionDiagramDeploy | undefined)[] | undefined =>
-  workflow.value.transitions
-    ?.flatMap(transition => {
+  Object.values(workflow.value.transitions)
+    .flatMap(transition => {
       const { name, type } = transition
       return transition.from
         ?.map((from: TransitionFrom | string) => {
@@ -211,11 +211,11 @@ const buildTransitionsDiagramFields = (workflow: WorkflowInstance, statusIdToSte
             // transition type may be 'initial' or 'directed' in here
             const fromId = type === INITIAL_TRANSITION_TYPE ? INITIAL_TRANSITION_TYPE : from.id
             if (fromId === undefined || name === undefined) {
-              throw new Error(`Fail to deploy Workflow ${workflow.value.name} Transition ${transition.name} diagram values`)
+              throw new Error(`Fail to deploy Workflow ${workflow.value.name} Transition ${name} diagram values`)
             }
             const transitionDiagramFields = actionKeyToTransition[getTransitionKey(statusIdToStepId[fromId], name)]
             if (transitionDiagramFields === undefined) {
-              throw new Error(`Fail to deploy Workflow ${workflow.value.name} Transition ${transition.name} diagram values`)
+              throw new Error(`Fail to deploy Workflow ${workflow.value.name} Transition ${name} diagram values`)
             }
             return {
               id: transitionDiagramFields.id,
@@ -233,7 +233,7 @@ export const hasDiagramFields = (instance: WorkflowInstance): boolean => {
   const statusesLocations = instance.value.statuses
     ?.map(status => status.location)
     .filter(location => location !== undefined)
-  const transitionsFrom = instance.value.transitions
+  const transitionsFrom = Object.values(instance.value.transitions)
     .flatMap(transition => transition.from)
     .filter(from => from !== undefined && typeof from !== 'string'
       && (from.targetAngle !== undefined || from.sourceAngle !== undefined))
@@ -301,7 +301,7 @@ const insertWorkflowDiagramFields = (workflow: WorkflowInstance,
     y: statusIdToStatus.initial?.y,
   }
   workflow.value.diagramGlobalLoopedTransition = loopedTransitionContainer
-  workflow.value.transitions.forEach(transition => {
+  Object.values(workflow.value.transitions).forEach(transition => {
     const transitionName = transition.name
     if (transition.type === INITIAL_TRANSITION_TYPE && transitionName !== undefined) {
       transition.from = [getTransitionFrom(

--- a/packages/jira-adapter/src/filters/workflow/workflow_properties_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_properties_filter.ts
@@ -31,7 +31,7 @@ const { awu } = collections.asynciterable
 const convertPropertiesToList = (instance: WorkflowInstance): void => {
   [
     ...(instance.value.statuses ?? []),
-    ...(instance.value.transitions ?? []),
+    ...(Object.values(instance.value.transitions) ?? []),
   ].forEach(item => {
     if (item.properties !== undefined) {
       item.properties = Object.entries(item.properties)
@@ -43,7 +43,7 @@ const convertPropertiesToList = (instance: WorkflowInstance): void => {
 const convertPropertiesToMap = (instance: WorkflowInstance): void => {
   [
     ...(instance.value.statuses ?? []),
-    ...(instance.value.transitions ?? []),
+    ...(Object.values(instance.value.transitions) ?? []),
   ].forEach(item => {
     if (item.properties !== undefined) {
       item.properties = Object.fromEntries(

--- a/packages/jira-adapter/src/filters/workflow/workflow_structure_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_structure_filter.ts
@@ -46,7 +46,7 @@ const TYPE_TO_FROM_MAP = new Map([
 
 type TransitionType = 'Directed' | 'Initial' | 'Global' | 'Circular'
 
-const createStatusMap = (statuses: Status[]): Map<string, string> => new Map(statuses
+export const createStatusMap = (statuses: Status[]): Map<string, string> => new Map(statuses
   .filter((status): status is {id: string; name: string} => typeof status.id === 'string' && status.name !== undefined)
   .map((status => [status.id, status.name])))
 
@@ -249,6 +249,7 @@ const filter: FilterCreator = ({ config }) => ({
       workflowType.fields.operations.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE] = true
       if (workflowTransitionType !== undefined) {
         workflowType.fields.transitions = new Field(workflowType, 'transitions', new MapType(workflowTransitionType))
+        delete workflowTransitionType.fields.id
       }
     }
 

--- a/packages/jira-adapter/src/filters/workflow/workflow_structure_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_structure_filter.ts
@@ -13,9 +13,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, CORE_ANNOTATIONS, Element, ElemID, Field, isInstanceElement, ListType, MapType, SaltoError, Value } from '@salto-io/adapter-api'
+import { BuiltinTypes, CORE_ANNOTATIONS, Element, ElemID, Field, isInstanceElement, ListType, MapType, SaltoError } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { walkOnValue, WALK_NEXT_STEP, naclCase, invertNaclCase } from '@salto-io/adapter-utils'
+import { walkOnValue, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
 import { findObject } from '../../utils'
 import { FilterCreator } from '../../filter'
 import { postFunctionType, types as postFunctionTypes } from './post_functions_types'
@@ -23,6 +23,7 @@ import { createConditionConfigurationTypes } from './conditions_types'
 import { Condition, isWorkflowResponseInstance, Rules, WorkflowResponse, Status, Transition, Validator } from './types'
 import { validatorType, types as validatorTypes } from './validators_types'
 import { JIRA, WORKFLOW_RULES_TYPE_NAME, WORKFLOW_TRANSITION_TYPE_NAME, WORKFLOW_TYPE_NAME } from '../../constants'
+import { transformTransitions } from './transition_structure'
 
 const NOT_FETCHED_POST_FUNCTION_TYPES = [
   'GenerateChangeHistoryFunction',
@@ -36,52 +37,12 @@ const FETCHED_ONLY_INITIAL_POST_FUNCTION = [
   'IssueStoreFunction',
 ]
 
-const PARTS_SEPARATOR = '::'
-
-const TYPE_TO_FROM_MAP = new Map([
-  ['Initial', 'none'],
-  ['Global', 'any status'],
-  ['Circular', 'any status'],
-])
-
-type TransitionType = 'Directed' | 'Initial' | 'Global' | 'Circular'
-
-export const createStatusMap = (statuses: Status[]): Map<string, string> => new Map(statuses
-  .filter((status): status is {id: string; name: string} => typeof status.id === 'string' && status.name !== undefined)
-  .map((status => [status.id, status.name])))
-
-const getTransitionType = (transition: Transition): TransitionType => {
-  if (transition.type === 'initial') {
-    return 'Initial'
-  }
-  if (transition.from !== undefined
-    && transition.from.length !== 0) {
-    return 'Directed'
-  }
-  if ((transition.to ?? '') === '') {
-    return 'Circular'
-  }
-  return 'Global'
-}
-
 // The key will be in the format of {transition name}::From: {from name}::{transition type}
 // Transitions that were created from any in the UI will have From: any status
 // The initial transition will have From: none
 // In case the user has a status named none or any status there will still be no problem due to the type
 // The types can be Directed, Initial, Global, and Circular (which is global circular)
-export const getTransitionKey = (transition: Transition, statusesMap: Map<string, string>): string => {
-  const type = getTransitionType(transition)
-  const fromSorted = type === 'Directed'
-    ? (transition.from?.map(from => (
-      typeof from === 'string' ? from : from.id ?? ''
-    )) ?? [])
-      .map(from => statusesMap.get(from) ?? from)
-      .sort()
-      .join(',')
-    : TYPE_TO_FROM_MAP.get(type) ?? ''
 
-  return naclCase([transition.name ?? '', `From: ${fromSorted}`, type].join(PARTS_SEPARATOR))
-}
 
 const transformProperties = (item: Status | Transition): void => {
   item.properties = item.properties?.additionalProperties
@@ -186,38 +147,6 @@ const transformRules = (rules: Rules, transitionType?: string): void => {
   rules.validators?.forEach(transformValidator)
 }
 
-const transformTransitions = (value: Value): SaltoError[] => {
-  const statusesMap = createStatusMap(value.statuses ?? [])
-  const maxCounts: Record<string, number> = {}
-  value.transitions.forEach((transition: Transition) => {
-    const key = getTransitionKey(transition, statusesMap)
-    maxCounts[key] = (maxCounts[key] ?? 0) + 1
-  })
-
-  const counts: Record<string, number> = {}
-
-  value.transitions = Object.fromEntries(value.transitions
-    // This is Value and not the actual type as we change types
-    .map((transition: Value) => {
-      const key = getTransitionKey(transition, statusesMap)
-      counts[key] = (counts[key] ?? 0) + 1
-      if (maxCounts[key] > 1) {
-        return [naclCase(`${invertNaclCase(key)}${PARTS_SEPARATOR}${counts[key]}`), transition]
-      }
-      return [key, transition]
-    }))
-  const errorKeys = Object.entries(counts)
-    .filter(([, count]) => count > 1)
-    .map(([key]) => key)
-
-  return errorKeys.length === 0
-    ? []
-    : [{
-      message: `The following transitions of workflow ${value.name} have the same key: ${errorKeys.join(', ')}.
-It is strongly recommended to rename these transitions so they are unique in Jira, then re-fetch`,
-      severity: 'Warning',
-    }]
-}
 
 const transformWorkflowInstance = (workflowValues: WorkflowResponse): SaltoError[] => {
   workflowValues.entityId = workflowValues.id?.entityId
@@ -248,7 +177,12 @@ const filter: FilterCreator = ({ config }) => ({
       delete workflowType.fields.id
       workflowType.fields.operations.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE] = true
       if (workflowTransitionType !== undefined) {
-        workflowType.fields.transitions = new Field(workflowType, 'transitions', new MapType(workflowTransitionType))
+        workflowType.fields.transitions = new Field(
+          workflowType,
+          'transitions',
+          new MapType(workflowTransitionType),
+        )
+        workflowType.fields.transitions.annotations[CORE_ANNOTATIONS.CREATABLE] = true
         delete workflowTransitionType.fields.id
       }
     }

--- a/packages/jira-adapter/test/change_validators/workflows/empty_validator_workflow.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflows/empty_validator_workflow.test.ts
@@ -28,8 +28,9 @@ describe('workflowPropertiesValidator', () => {
       'instance',
       type,
       {
-        transitions: [
-          {
+        transitions: {
+          tran1: {
+            name: 'tran1',
             rules: {
               validators: [
                 {
@@ -47,7 +48,7 @@ describe('workflowPropertiesValidator', () => {
               ],
             },
           },
-        ],
+        },
       },
     )
     changes = [toChange({ after: instance })]
@@ -63,7 +64,7 @@ describe('workflowPropertiesValidator', () => {
     ])
   })
   it('should return an plural error if there are multiple invalid validators', async () => {
-    instance.value.transitions[0].rules.validators.push({
+    instance.value.transitions.tran1.rules.validators.push({
       type: 'PreviousStatusValidator',
     })
     expect(await emptyValidatorWorkflowChangeValidator(changes)).toEqual([
@@ -76,7 +77,7 @@ describe('workflowPropertiesValidator', () => {
     ])
   })
   it('should return an plural error if there are multiple invalid validators but only once per type', async () => {
-    instance.value.transitions[0].rules.validators.push({
+    instance.value.transitions.tran1.rules.validators.push({
       type: 'FieldHasSingleValueValidator',
     })
     expect(await emptyValidatorWorkflowChangeValidator(changes)).toEqual([
@@ -89,7 +90,7 @@ describe('workflowPropertiesValidator', () => {
     ])
   })
   it('should not return an error if workflow has only valid validator', async () => {
-    instance.value.transitions[0].rules.validators.pop()
+    instance.value.transitions.tran1.rules.validators.pop()
     expect(await emptyValidatorWorkflowChangeValidator([
       toChange({
         after: instance,
@@ -98,7 +99,7 @@ describe('workflowPropertiesValidator', () => {
   })
 
   it('should not return an error when there are no validators', async () => {
-    delete instance.value.transitions[0].rules
+    delete instance.value.transitions.tran1.rules
     expect(await emptyValidatorWorkflowChangeValidator([
       toChange({
         after: instance,
@@ -107,7 +108,7 @@ describe('workflowPropertiesValidator', () => {
   })
 
   it('should not return an error when there are no rules', async () => {
-    delete instance.value.transitions[0]
+    delete instance.value.transitions.tran1
     expect(await emptyValidatorWorkflowChangeValidator([
       toChange({
         after: instance,

--- a/packages/jira-adapter/test/change_validators/workflows/workflow_properties.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflows/workflow_properties.test.ts
@@ -28,14 +28,16 @@ describe('workflowPropertiesValidator', () => {
       'instance',
       type,
       {
-        transitions:
-        {
-          properties: [
-            {
-              key: 'key',
-              value: 'true',
-            },
-          ],
+        transitions: {
+          tran1: {
+            name: 'tran1',
+            properties: [
+              {
+                key: 'key',
+                value: 'true',
+              },
+            ],
+          },
         },
         statuses:
         {
@@ -53,14 +55,15 @@ describe('workflowPropertiesValidator', () => {
       type,
       {
         transitions:
-        [{
+        { tran1: {
+          name: 'tran1',
           properties: [
             {
               key: 'key',
               value: 'true',
             },
           ],
-        }],
+        } },
         statuses:
         [{
           properties: [
@@ -74,7 +77,8 @@ describe('workflowPropertiesValidator', () => {
     )
   })
   it('should return an error if there are transition properties with the same key', async () => {
-    afterInstance.value.transitions = [{
+    afterInstance.value.transitions = { tran1: {
+      name: 'tran1',
       properties: [
         {
           key: 'key',
@@ -85,7 +89,7 @@ describe('workflowPropertiesValidator', () => {
           value: 'false',
         },
       ],
-    }]
+    } }
     expect(await workflowPropertiesValidator([
       toChange({
         before: instance,

--- a/packages/jira-adapter/test/filters/account_id/account_id_filter.test.ts
+++ b/packages/jira-adapter/test/filters/account_id/account_id_filter.test.ts
@@ -200,7 +200,7 @@ describe('account_id_filter', () => {
       common.checkDisplayNames((displayChanges[1] as ModificationChange<InstanceElement>).data.before, '1')
       common.checkObjectedInstanceIds((displayChanges[1] as ModificationChange<InstanceElement>).data.after, '2')
       common.checkDisplayNames((displayChanges[1] as ModificationChange<InstanceElement>).data.after, '2')
-    }, 1000000)
+    })
     it('returns even wrong structure instances on OnDeploy', async () => {
       const elementInstance = displayNamesInstances[0]
       elementInstance.value.accountId.wrong = 'wrong'

--- a/packages/jira-adapter/test/filters/script_runner/empty_account_ids.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/empty_account_ids.test.ts
@@ -45,8 +45,9 @@ describe('ScriptRunner cloud empty account id', () => {
         'instance',
         workflowType,
         {
-          transitions: [
-            {
+          transitions: {
+            tran1: {
+              name: 'tran1',
               rules: {
                 postFunctions: [
                   {
@@ -80,7 +81,8 @@ describe('ScriptRunner cloud empty account id', () => {
                 ],
               },
             },
-            {
+            tran2: {
+              name: 'tran2',
               rules: {
                 postFunctions: [
                   {
@@ -104,15 +106,16 @@ describe('ScriptRunner cloud empty account id', () => {
                 ],
               },
             },
-          ],
+          },
         }
       )
       wrongStructureInstance = new InstanceElement(
         'instance',
         workflowType,
         {
-          transitions: [
-            {
+          transitions: {
+            tran1: {
+              name: 'tran1',
               postFunctions: [
                 {
                   type: SCRIPT_RUNNER_POST_FUNCTION_TYPE,
@@ -125,7 +128,8 @@ describe('ScriptRunner cloud empty account id', () => {
                 },
               ],
             },
-            {
+            tran2: {
+              name: 'tran2',
               rules: {
                 postFunctions: [
                   {
@@ -138,33 +142,36 @@ describe('ScriptRunner cloud empty account id', () => {
                 ],
               },
             },
-          ],
+          },
         }
       )
     })
     it('should remove empty account ids', async () => {
       await filter.onFetch([instance])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.scriptRunner.accountIds).toBeUndefined()
-      expect(instance.value.transitions[0].rules.postFunctions[2].configuration.scriptRunner.accountIds).toBeUndefined()
-      expect(instance.value.transitions[1].rules.postFunctions[0].configuration.scriptRunner.accountIds).toBeUndefined()
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner.accountIds)
+        .toBeUndefined()
+      expect(instance.value.transitions.tran1.rules.postFunctions[2].configuration.scriptRunner.accountIds)
+        .toBeUndefined()
+      expect(instance.value.transitions.tran2.rules.postFunctions[0].configuration.scriptRunner.accountIds)
+        .toBeUndefined()
     })
     it('should not remove account ids that are not empty', async () => {
       await filter.onFetch([instance])
-      expect(instance.value.transitions[0].rules.postFunctions[1].configuration.scriptRunner.accountIds).toEqual(['1'])
-      expect(instance.value.transitions[1].rules.postFunctions[1].configuration.scriptRunner.accountIds).toEqual(['1', '2'])
+      expect(instance.value.transitions.tran1.rules.postFunctions[1].configuration.scriptRunner.accountIds).toEqual(['1'])
+      expect(instance.value.transitions.tran2.rules.postFunctions[1].configuration.scriptRunner.accountIds).toEqual(['1', '2'])
     })
     it('should not remove account ids when scriptRunner is not enabled', async () => {
       await filterOff.onFetch([instance])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.scriptRunner.accountIds).toEqual([''])
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner.accountIds).toEqual([''])
     })
     it('should not remove account ids when on dc', async () => {
       await filterDC.onFetch([instance])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.scriptRunner.accountIds).toEqual([''])
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner.accountIds).toEqual([''])
     })
     it('should not remove account ids when the structure is wrong', async () => {
       await filter.onFetch([wrongStructureInstance])
-      expect(wrongStructureInstance.value.transitions[0].postFunctions[0].configuration.scriptRunner.accountIds).toEqual([''])
-      expect(wrongStructureInstance.value.transitions[1].rules.postFunctions[0].scriptRunner.accountIds).toEqual([''])
+      expect(wrongStructureInstance.value.transitions.tran1.postFunctions[0].configuration.scriptRunner.accountIds).toEqual([''])
+      expect(wrongStructureInstance.value.transitions.tran2.rules.postFunctions[0].scriptRunner.accountIds).toEqual([''])
     })
   })
   describe('pre deploy', () => {
@@ -173,8 +180,9 @@ describe('ScriptRunner cloud empty account id', () => {
         'instance',
         workflowType,
         {
-          transitions: [
-            {
+          transitions: {
+            tran1: {
+              name: 'tran1',
               rules: {
                 postFunctions: [
                   {
@@ -197,31 +205,33 @@ describe('ScriptRunner cloud empty account id', () => {
                 ],
               },
             },
-          ],
+          },
         }
       )
     })
     it('should return the accountIds empty field', async () => {
       await filter.preDeploy([toChange({ after: instance })])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.scriptRunner.accountIds).toEqual([''])
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner.accountIds).toEqual([''])
     })
     it('should not change accountIds that are not empty', async () => {
       await filter.preDeploy([toChange({ after: instance })])
-      expect(instance.value.transitions[0].rules.postFunctions[1].configuration.scriptRunner.accountIds).toEqual(['1'])
+      expect(instance.value.transitions.tran1.rules.postFunctions[1].configuration.scriptRunner.accountIds).toEqual(['1'])
     })
     it('should not return account ids when the structure is wrong', async () => {
-      wrongStructureInstance.value.transitions[0].postFunctions[0].configuration.scriptRunner.accountIds = undefined
-      wrongStructureInstance.value.transitions[1].rules.postFunctions[0].scriptRunner.accountIds = undefined
+      wrongStructureInstance.value.transitions.tran1.postFunctions[0].configuration.scriptRunner.accountIds = undefined
+      wrongStructureInstance.value.transitions.tran2.rules.postFunctions[0].scriptRunner.accountIds = undefined
       await filter.preDeploy([toChange({ after: wrongStructureInstance })])
-      expect(wrongStructureInstance.value.transitions[0].postFunctions[0].configuration.scriptRunner.accountIds)
+      expect(wrongStructureInstance.value.transitions.tran1.postFunctions[0].configuration.scriptRunner.accountIds)
         .toBeUndefined()
-      expect(wrongStructureInstance.value.transitions[1].rules.postFunctions[0].scriptRunner.accountIds).toBeUndefined()
+      expect(wrongStructureInstance.value.transitions.tran2.rules.postFunctions[0].scriptRunner.accountIds)
+        .toBeUndefined()
     })
   })
   describe('on deploy', () => {
     it('should remove empty accountIds', async () => {
       await filter.onDeploy([toChange({ after: instance })])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.scriptRunner.accountIds).toBeUndefined()
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner.accountIds)
+        .toBeUndefined()
     })
   })
 })

--- a/packages/jira-adapter/test/filters/script_runner/script_template_expressions.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/script_template_expressions.test.ts
@@ -23,22 +23,22 @@ import { getDefaultConfig } from '../../../src/config/config'
 type FilterType = filterUtils.FilterWith<'onFetch' | 'onDeploy' | 'preDeploy'>
 
 const checkValuesNoReference = (element: InstanceElement): void => {
-  const postFunction = element.value.transitions[0].rules.postFunctions[0].configuration.scriptRunner
-  const { conditions } = element.value.transitions[0].rules.conditions
+  const postFunction = element.value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner
+  const { conditions } = element.value.transitions.tran1.rules.conditions
   expect(postFunction.field).toEqual(1)
   expect(postFunction.field2).toEqual('no fields')
   expect(postFunction.expression).toEqual('test customfield_1 test2')
   expect(postFunction.additionalCode).toEqual('customfield_2')
   expect(postFunction.emailCode).toEqual('customfield_3 test customfield_4')
   expect(postFunction.condition).toEqual('customfield_5')
-  expect(element.value.transitions[0].rules.validators[0].configuration.scriptRunner.expression).toEqual('test customfield_1 test2')
+  expect(element.value.transitions.tran1.rules.validators[0].configuration.scriptRunner.expression).toEqual('test customfield_1 test2')
   expect(conditions[0].configuration.scriptRunner.expression).toEqual('test customfield_1 test2')
   expect(conditions[1].configuration.scriptRunner.expression).toEqual('test customfield_2 test2')
 }
 
 const checkValues = (element: InstanceElement): void => {
-  const postFunction = element.value.transitions[0].rules.postFunctions[0].configuration.scriptRunner
-  const { conditions } = element.value.transitions[0].rules.conditions
+  const postFunction = element.value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner
+  const { conditions } = element.value.transitions.tran1.rules.conditions
   expect(postFunction.field).toEqual(1)
   expect(postFunction.field2).toEqual('no fields')
   expect(postFunction.expression.parts[1].elemID.getFullName()).toEqual('jira.Field.instance.field_1')
@@ -46,34 +46,34 @@ const checkValues = (element: InstanceElement): void => {
   expect(postFunction.emailCode.parts[0].elemID.getFullName()).toEqual('jira.Field.instance.field_3')
   expect(postFunction.emailCode.parts[2].elemID.getFullName()).toEqual('jira.Field.instance.field_4')
   expect(postFunction.condition.parts[0].elemID.getFullName()).toEqual('jira.Field.instance.field_5')
-  expect(element.value.transitions[0].rules.validators[0].configuration.scriptRunner.expression.parts[1].elemID.getFullName()).toEqual('jira.Field.instance.field_1')
+  expect(element.value.transitions.tran1.rules.validators[0].configuration.scriptRunner.expression.parts[1].elemID.getFullName()).toEqual('jira.Field.instance.field_1')
   expect(conditions[0].configuration.scriptRunner.expression.parts[1].elemID.getFullName()).toEqual('jira.Field.instance.field_1')
   expect(conditions[1].configuration.scriptRunner.expression.parts[1].elemID.getFullName()).toEqual('jira.Field.instance.field_2')
 }
 
 const checkDcValuesNoReference = (element: InstanceElement): void => {
-  const postFunction = element.value.transitions[0].rules.postFunctions[0].configuration
-  const { conditions } = element.value.transitions[0].rules.conditions
+  const postFunction = element.value.transitions.tran1.rules.postFunctions[0].configuration
+  const { conditions } = element.value.transitions.tran1.rules.conditions
   expect(postFunction.field).toEqual(1)
   expect(postFunction.field2.script).toEqual('no fields')
   expect(postFunction.FIELD_CONDITION.script).toEqual('test customfield_1 test2')
   expect(postFunction.FIELD_ADDITIONAL_SCRIPT.script).toEqual('customfield_2')
   expect(postFunction.FIELD_SCRIPT_FILE_OR_SCRIPT.script).toEqual('customfield_3 test customfield_4')
-  expect(element.value.transitions[0].rules.validators[0].configuration.FIELD_CONDITION.script).toEqual('test customfield_1 test2')
+  expect(element.value.transitions.tran1.rules.validators[0].configuration.FIELD_CONDITION.script).toEqual('test customfield_1 test2')
   expect(conditions[0].configuration.FIELD_SCRIPT_FILE_OR_SCRIPT.script).toEqual('test customfield_1 test2')
   expect(conditions[1].configuration.FIELD_SCRIPT_FILE_OR_SCRIPT.script).toEqual('test customfield_2 test2')
 }
 
 const checkDcValues = (element: InstanceElement): void => {
-  const postFunction = element.value.transitions[0].rules.postFunctions[0].configuration
-  const { conditions } = element.value.transitions[0].rules.conditions
+  const postFunction = element.value.transitions.tran1.rules.postFunctions[0].configuration
+  const { conditions } = element.value.transitions.tran1.rules.conditions
   expect(postFunction.field).toEqual(1)
   expect(postFunction.field2.script).toEqual('no fields')
   expect(postFunction.FIELD_CONDITION.script.parts[1].elemID.getFullName()).toEqual('jira.Field.instance.field_1')
   expect(postFunction.FIELD_ADDITIONAL_SCRIPT.script.parts[0].elemID.getFullName()).toEqual('jira.Field.instance.field_2')
   expect(postFunction.FIELD_SCRIPT_FILE_OR_SCRIPT.script.parts[0].elemID.getFullName()).toEqual('jira.Field.instance.field_3')
   expect(postFunction.FIELD_SCRIPT_FILE_OR_SCRIPT.script.parts[2].elemID.getFullName()).toEqual('jira.Field.instance.field_4')
-  expect(element.value.transitions[0].rules.validators[0].configuration.FIELD_CONDITION.script.parts[1].elemID.getFullName()).toEqual('jira.Field.instance.field_1')
+  expect(element.value.transitions.tran1.rules.validators[0].configuration.FIELD_CONDITION.script.parts[1].elemID.getFullName()).toEqual('jira.Field.instance.field_1')
   expect(conditions[0].configuration.FIELD_SCRIPT_FILE_OR_SCRIPT.script.parts[1].elemID.getFullName()).toEqual('jira.Field.instance.field_1')
   expect(conditions[1].configuration.FIELD_SCRIPT_FILE_OR_SCRIPT.script.parts[1].elemID.getFullName()).toEqual('jira.Field.instance.field_2')
 }
@@ -105,8 +105,9 @@ describe('workflow_script_references', () => {
         'instance',
         workflowType,
         {
-          transitions: [
-            {
+          transitions: {
+            tran1: {
+              name: 'tran1',
               rules: {
                 undefined, // to test cases of undefined fields
                 postFunctions: [
@@ -157,7 +158,8 @@ describe('workflow_script_references', () => {
                   ],
                 },
               },
-            }],
+            },
+          },
         }
       )
     })
@@ -173,16 +175,16 @@ describe('workflow_script_references', () => {
     })
     it('fetch should not fail if a script is null', async () => {
       const elements = [instance, ...fields]
-      elements[0].value.transitions[0].rules.postFunctions[0].configuration.scriptRunner.expression = null
+      elements[0].value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner.expression = null
       await filter.onFetch(elements)
-      expect(elements[0].value.transitions[0].rules.postFunctions[0].configuration.scriptRunner.expression)
+      expect(elements[0].value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner.expression)
         .toBeNull()
     })
     it('fetch should not fail if a scriptRunner object is null', async () => {
       const elements = [instance, ...fields]
-      elements[0].value.transitions[0].rules.postFunctions[0].configuration.scriptRunner = null
+      elements[0].value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner = null
       await filter.onFetch(elements)
-      expect(elements[0].value.transitions[0].rules.postFunctions[0].configuration.scriptRunner).toBeNull()
+      expect(elements[0].value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner).toBeNull()
     })
     it('pre-deploy should not remove references when script runner is disabled', async () => {
       await filter.onFetch([instance, ...fields])
@@ -234,8 +236,9 @@ describe('workflow_script_references', () => {
         'instance',
         workflowType,
         {
-          transitions: [
-            {
+          transitions: {
+            tran1: {
+              name: 'tran1',
               rules: {
                 undefined, // to test cases of undefined fields
                 postFunctions: [
@@ -290,7 +293,8 @@ describe('workflow_script_references', () => {
                   ],
                 },
               },
-            }],
+            },
+          },
         }
       )
     })
@@ -306,16 +310,16 @@ describe('workflow_script_references', () => {
     })
     it('fetch should not fail if a script is null', async () => {
       const elements = [instance, ...fields]
-      elements[0].value.transitions[0].rules.postFunctions[0].configuration.FIELD_CONDITION = null
+      elements[0].value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_CONDITION = null
       await filter.onFetch(elements)
-      expect(elements[0].value.transitions[0].rules.postFunctions[0].configuration.FIELD_CONDITION)
+      expect(elements[0].value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_CONDITION)
         .toBeNull()
     })
     it('fetch should not fail if a scriptRunner object is null', async () => {
       const elements = [instance, ...fields]
-      elements[0].value.transitions[0].rules.postFunctions[0].configuration = null
+      elements[0].value.transitions.tran1.rules.postFunctions[0].configuration = null
       await filter.onFetch(elements)
-      expect(elements[0].value.transitions[0].rules.postFunctions[0].configuration).toBeNull()
+      expect(elements[0].value.transitions.tran1.rules.postFunctions[0].configuration).toBeNull()
     })
     it('pre-deploy should not remove references when script runner is disabled', async () => {
       await filter.onFetch([instance, ...fields])

--- a/packages/jira-adapter/test/filters/script_runner/workflow_cloud.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/workflow_cloud.test.ts
@@ -88,8 +88,8 @@ describe('ScriptRunner cloud Workflow', () => {
         'instance',
         workflowType,
         {
-          transitions: [
-            {
+          transitions: {
+            tran1: {
               rules: {
                 postFunctions: [
                   {
@@ -101,21 +101,21 @@ describe('ScriptRunner cloud Workflow', () => {
                 ],
               },
             },
-          ],
+          },
         }
       )
     })
     describe('fetch', () => {
       it('should change field name to scriptRunner', async () => {
         await filter.onFetch([instance])
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.scriptRunner).toBeDefined()
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.value).toBeUndefined()
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner).toBeDefined()
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.value).toBeUndefined()
       })
       it('should make array of accountIds and groups', async () => {
-        instance.value.transitions[0].rules.postFunctions[0].configuration.value = AccountAndGroupB64
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration.value = AccountAndGroupB64
         await filter.onFetch([instance])
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.scriptRunner.accountIds).toEqual(['1', '2', '3'])
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.scriptRunner.groupName).toEqual(['4', '5', '6'])
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner.accountIds).toEqual(['1', '2', '3'])
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner.groupName).toEqual(['4', '5', '6'])
       })
       it('should not make an array of groups if wrong class', async () => {
         const noGroup = {
@@ -123,53 +123,54 @@ describe('ScriptRunner cloud Workflow', () => {
           groupName: '4,5,6',
         }
         const base64OfNoGroup = encode(noGroup)
-        instance.value.transitions[0].rules.postFunctions[0].configuration.value = base64OfNoGroup
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration.value = base64OfNoGroup
         await filter.onFetch([instance])
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.scriptRunner.groupName).toEqual('4,5,6')
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner.groupName).toEqual('4,5,6')
       })
       it('should decode properly', async () => {
         await filter.onFetch([instance])
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.scriptRunner).toEqual({ a: 1 })
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner).toEqual({ a: 1 })
       })
       it('should not decode if not compressed', async () => {
-        instance.value.transitions[0].rules.postFunctions[0].configuration.value = notZippedBuffer
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration.value = notZippedBuffer
         await filter.onFetch([instance])
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.scriptRunner).toEqual(notZippedBuffer)
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner)
+          .toEqual(notZippedBuffer)
       })
       it('should not decode if not base64', async () => {
-        instance.value.transitions[0].rules.postFunctions[0].configuration.value = 'not base64'
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration.value = 'not base64'
         await filter.onFetch([instance])
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.scriptRunner).toEqual('not base64')
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner).toEqual('not base64')
       })
       it('should not decode if not valid json', async () => {
-        instance.value.transitions[0].rules.postFunctions[0].configuration.value = wrongInnerStructure
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration.value = wrongInnerStructure
         await filter.onFetch([instance])
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.scriptRunner)
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner)
           .toEqual(wrongInnerStructure)
       })
       it('should not fail if no value', async () => {
-        instance.value.transitions[0].rules.postFunctions[0].configuration.value = undefined
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration.value = undefined
         await filter.onFetch([instance])
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.scriptRunner).toBeUndefined()
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner).toBeUndefined()
       })
       it('should not decode if script runner not supported', async () => {
         await filterOff.onFetch([instance])
-        compareScripts(instance.value.transitions[0].rules.postFunctions[0].configuration.value, goodBase64)
+        compareScripts(instance.value.transitions.tran1.rules.postFunctions[0].configuration.value, goodBase64)
       })
     })
     describe('pre deploy', () => {
       beforeEach(() => {
-        renameKey(instance.value.transitions[0].rules.postFunctions[0].configuration, { from: 'value', to: 'scriptRunner' })
+        renameKey(instance.value.transitions.tran1.rules.postFunctions[0].configuration, { from: 'value', to: 'scriptRunner' })
       })
       it('should change field name to value', async () => {
         await filter.preDeploy([toChange({ after: instance })])
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.scriptRunner).toBeUndefined()
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.value).toBeDefined()
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner).toBeUndefined()
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.value).toBeDefined()
       })
       it('should return an array of accountIds and groups to strings', async () => {
-        instance.value.transitions[0].rules.postFunctions[0].configuration.scriptRunner = accountAndGroupArrayed
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner = accountAndGroupArrayed
         await filter.preDeploy([toChange({ after: instance })])
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.value).toEqual(AccountAndGroupB64)
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.value).toEqual(AccountAndGroupB64)
       })
       it('should not make an array of groups if wrong class', async () => {
         const noGroup = {
@@ -177,46 +178,46 @@ describe('ScriptRunner cloud Workflow', () => {
           groupName: '4,5,6',
         }
         const base64OfNoGroup = encode(noGroup)
-        instance.value.transitions[0].rules.postFunctions[0].configuration.value = base64OfNoGroup
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration.value = base64OfNoGroup
         await filter.onFetch([instance])
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.scriptRunner.groupName).toEqual('4,5,6')
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner.groupName).toEqual('4,5,6')
       })
       it('should encode properly', async () => {
-        instance.value.transitions[0].rules.postFunctions[0].configuration.scriptRunner = { a: 1 }
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner = { a: 1 }
         await filter.preDeploy([toChange({ after: instance })])
-        compareScripts(instance.value.transitions[0].rules.postFunctions[0].configuration.value, goodBase64)
+        compareScripts(instance.value.transitions.tran1.rules.postFunctions[0].configuration.value, goodBase64)
       })
       it('should not decode if undefined', async () => {
-        instance.value.transitions[0].rules.postFunctions[0].configuration.scriptRunner = undefined
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner = undefined
         await filter.preDeploy([toChange({ after: instance })])
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.value).toBeUndefined()
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.value).toBeUndefined()
       })
       it('should not encode if script runner not supported', async () => {
-        renameKey(instance.value.transitions[0].rules.postFunctions[0].configuration, { from: 'scriptRunner', to: 'value' })
-        instance.value.transitions[0].rules.postFunctions[0].configuration.value = { a: 1 }
+        renameKey(instance.value.transitions.tran1.rules.postFunctions[0].configuration, { from: 'scriptRunner', to: 'value' })
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration.value = { a: 1 }
         await filterOff.preDeploy([toChange({ after: instance })])
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.value).toEqual({ a: 1 })
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.value).toEqual({ a: 1 })
       })
     })
     describe('on deploy', () => {
       it('should change field name to scriptRunner', async () => {
         await filter.onDeploy([toChange({ after: instance })])
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.scriptRunner).toBeDefined()
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.value).toBeUndefined()
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner).toBeDefined()
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.value).toBeUndefined()
       })
       it('should make array of accountIds and groups', async () => {
-        instance.value.transitions[0].rules.postFunctions[0].configuration.value = accountAndGroupArrayed
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration.value = accountAndGroupArrayed
         await filter.onDeploy([toChange({ after: instance })])
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.scriptRunner.accountIds).toEqual(['1', '2', '3'])
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.scriptRunner.groupName).toEqual(['4', '5', '6'])
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner.accountIds).toEqual(['1', '2', '3'])
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner.groupName).toEqual(['4', '5', '6'])
       })
       it('should decode properly', async () => {
         await filter.onDeploy([toChange({ after: instance })])
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.scriptRunner).toEqual({ a: 1 })
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner).toEqual({ a: 1 })
       })
       it('should not decode if script runner not supported', async () => {
         await filterOff.onDeploy([toChange({ after: instance })])
-        compareScripts(instance.value.transitions[0].rules.postFunctions[0].configuration.value, goodBase64)
+        compareScripts(instance.value.transitions.tran1.rules.postFunctions[0].configuration.value, goodBase64)
       })
     })
   })
@@ -229,8 +230,8 @@ describe('ScriptRunner cloud Workflow', () => {
         'instance',
         workflowType,
         {
-          transitions: [
-            {
+          transitions: {
+            tran1: {
               rules: {
                 validators: [
                   {
@@ -242,60 +243,60 @@ describe('ScriptRunner cloud Workflow', () => {
                 ],
               },
             },
-          ],
+          },
         }
       )
     })
     describe('fetch', () => {
       it('should rename field name to scriptRunner', async () => {
         await filter.onFetch([instance])
-        expect(instance.value.transitions[0].rules.validators[0].configuration.scriptRunner).toBeDefined()
-        expect(instance.value.transitions[0].rules.validators[0].configuration.value).toBeUndefined()
+        expect(instance.value.transitions.tran1.rules.validators[0].configuration.scriptRunner).toBeDefined()
+        expect(instance.value.transitions.tran1.rules.validators[0].configuration.value).toBeUndefined()
       })
       it('should objectify properly', async () => {
         await filter.onFetch([instance])
-        expect(instance.value.transitions[0].rules.validators[0].configuration.scriptRunner).toEqual({ a: 1 })
+        expect(instance.value.transitions.tran1.rules.validators[0].configuration.scriptRunner).toEqual({ a: 1 })
       })
       it('should not objectify if not json object', async () => {
-        instance.value.transitions[0].rules.validators[0].configuration.value = wrongJsonObject
+        instance.value.transitions.tran1.rules.validators[0].configuration.value = wrongJsonObject
         await filter.onFetch([instance])
-        expect(instance.value.transitions[0].rules.validators[0].configuration.scriptRunner).toEqual(wrongJsonObject)
+        expect(instance.value.transitions.tran1.rules.validators[0].configuration.scriptRunner).toEqual(wrongJsonObject)
       })
       it('should not fail if no value', async () => {
-        instance.value.transitions[0].rules.validators[0].configuration.value = undefined
+        instance.value.transitions.tran1.rules.validators[0].configuration.value = undefined
         await filter.onFetch([instance])
-        expect(instance.value.transitions[0].rules.validators[0].configuration.scriptRunner).toBeUndefined()
+        expect(instance.value.transitions.tran1.rules.validators[0].configuration.scriptRunner).toBeUndefined()
       })
     })
     describe('pre deploy', () => {
       beforeEach(() => {
-        renameKey(instance.value.transitions[0].rules.validators[0].configuration, { from: 'value', to: 'scriptRunner' })
+        renameKey(instance.value.transitions.tran1.rules.validators[0].configuration, { from: 'value', to: 'scriptRunner' })
       })
       it('should rename field name to value', async () => {
         await filter.preDeploy([toChange({ after: instance })])
-        expect(instance.value.transitions[0].rules.validators[0].configuration.value).toBeDefined()
-        expect(instance.value.transitions[0].rules.validators[0].configuration.scriptRunner).toBeUndefined()
+        expect(instance.value.transitions.tran1.rules.validators[0].configuration.value).toBeDefined()
+        expect(instance.value.transitions.tran1.rules.validators[0].configuration.scriptRunner).toBeUndefined()
       })
       it('should stringify properly', async () => {
-        instance.value.transitions[0].rules.validators[0].configuration.scriptRunner = { a: 1 }
+        instance.value.transitions.tran1.rules.validators[0].configuration.scriptRunner = { a: 1 }
         await filter.preDeploy([toChange({ after: instance })])
-        expect(instance.value.transitions[0].rules.validators[0].configuration.value).toEqual(goodJsonObject)
+        expect(instance.value.transitions.tran1.rules.validators[0].configuration.value).toEqual(goodJsonObject)
       })
       it('should not fail if undefined', async () => {
-        instance.value.transitions[0].rules.validators[0].configuration.scriptRunner = undefined
+        instance.value.transitions.tran1.rules.validators[0].configuration.scriptRunner = undefined
         await filter.preDeploy([toChange({ after: instance })])
-        expect(instance.value.transitions[0].rules.validators[0].configuration.value).toBeUndefined()
+        expect(instance.value.transitions.tran1.rules.validators[0].configuration.value).toBeUndefined()
       })
     })
     describe('on deploy', () => {
       it('should rename field name to scriptRunner', async () => {
         await filter.onDeploy([toChange({ after: instance })])
-        expect(instance.value.transitions[0].rules.validators[0].configuration.scriptRunner).toBeDefined()
-        expect(instance.value.transitions[0].rules.validators[0].configuration.value).toBeUndefined()
+        expect(instance.value.transitions.tran1.rules.validators[0].configuration.scriptRunner).toBeDefined()
+        expect(instance.value.transitions.tran1.rules.validators[0].configuration.value).toBeUndefined()
       })
       it('should objectify properly', async () => {
         await filter.onDeploy([toChange({ after: instance })])
-        expect(instance.value.transitions[0].rules.validators[0].configuration.scriptRunner).toEqual({ a: 1 })
+        expect(instance.value.transitions.tran1.rules.validators[0].configuration.scriptRunner).toEqual({ a: 1 })
       })
     })
   })
@@ -308,8 +309,8 @@ describe('ScriptRunner cloud Workflow', () => {
         'instance',
         workflowType,
         {
-          transitions: [
-            {
+          transitions: {
+            tran1: {
               rules: {
                 conditions: [
                   {
@@ -321,55 +322,55 @@ describe('ScriptRunner cloud Workflow', () => {
                 ],
               },
             },
-          ],
+          },
         }
       )
     })
     describe('fetch', () => {
       it('should rename field name to scriptRunner', async () => {
         await filter.onFetch([instance])
-        expect(instance.value.transitions[0].rules.conditions[0].configuration.scriptRunner).toBeDefined()
-        expect(instance.value.transitions[0].rules.conditions[0].configuration.value).toBeUndefined()
+        expect(instance.value.transitions.tran1.rules.conditions[0].configuration.scriptRunner).toBeDefined()
+        expect(instance.value.transitions.tran1.rules.conditions[0].configuration.value).toBeUndefined()
       })
       it('should objectify properly', async () => {
         await filter.onFetch([instance])
-        expect(instance.value.transitions[0].rules.conditions[0].configuration.scriptRunner).toEqual({ b: 1 })
+        expect(instance.value.transitions.tran1.rules.conditions[0].configuration.scriptRunner).toEqual({ b: 1 })
       })
       it('should not objectify if not json object', async () => {
-        instance.value.transitions[0].rules.conditions[0].configuration.value = wrongJsonObject
+        instance.value.transitions.tran1.rules.conditions[0].configuration.value = wrongJsonObject
         await filter.onFetch([instance])
-        expect(instance.value.transitions[0].rules.conditions[0].configuration.scriptRunner).toEqual(wrongJsonObject)
+        expect(instance.value.transitions.tran1.rules.conditions[0].configuration.scriptRunner).toEqual(wrongJsonObject)
       })
       it('should not fail if no value', async () => {
-        instance.value.transitions[0].rules.conditions[0].configuration.value = undefined
+        instance.value.transitions.tran1.rules.conditions[0].configuration.value = undefined
         await filter.onFetch([instance])
-        expect(instance.value.transitions[0].rules.conditions[0].configuration.scriptRunner).toBeUndefined()
+        expect(instance.value.transitions.tran1.rules.conditions[0].configuration.scriptRunner).toBeUndefined()
       })
     })
     describe('pre deploy', () => {
       beforeEach(() => {
-        renameKey(instance.value.transitions[0].rules.conditions[0].configuration, { from: 'value', to: 'scriptRunner' })
+        renameKey(instance.value.transitions.tran1.rules.conditions[0].configuration, { from: 'value', to: 'scriptRunner' })
       })
       it('should rename field name to value', async () => {
         await filter.preDeploy([toChange({ after: instance })])
-        expect(instance.value.transitions[0].rules.conditions[0].configuration.value).toBeDefined()
-        expect(instance.value.transitions[0].rules.conditions[0].configuration.scriptRunner).toBeUndefined()
+        expect(instance.value.transitions.tran1.rules.conditions[0].configuration.value).toBeDefined()
+        expect(instance.value.transitions.tran1.rules.conditions[0].configuration.scriptRunner).toBeUndefined()
       })
       it('should stringify properly', async () => {
-        instance.value.transitions[0].rules.conditions[0].configuration.scriptRunner = { b: 1 }
+        instance.value.transitions.tran1.rules.conditions[0].configuration.scriptRunner = { b: 1 }
         await filter.preDeploy([toChange({ after: instance })])
-        expect(instance.value.transitions[0].rules.conditions[0].configuration.value).toEqual(goodJsonObject)
+        expect(instance.value.transitions.tran1.rules.conditions[0].configuration.value).toEqual(goodJsonObject)
       })
     })
     describe('on deploy', () => {
       it('should rename field name to scriptRunner', async () => {
         await filter.onDeploy([toChange({ after: instance })])
-        expect(instance.value.transitions[0].rules.conditions[0].configuration.scriptRunner).toBeDefined()
-        expect(instance.value.transitions[0].rules.conditions[0].configuration.value).toBeUndefined()
+        expect(instance.value.transitions.tran1.rules.conditions[0].configuration.scriptRunner).toBeDefined()
+        expect(instance.value.transitions.tran1.rules.conditions[0].configuration.value).toBeUndefined()
       })
       it('should objectify properly', async () => {
         await filter.onDeploy([toChange({ after: instance })])
-        expect(instance.value.transitions[0].rules.conditions[0].configuration.scriptRunner).toEqual({ b: 1 })
+        expect(instance.value.transitions.tran1.rules.conditions[0].configuration.scriptRunner).toEqual({ b: 1 })
       })
     })
   })

--- a/packages/jira-adapter/test/filters/script_runner/workflow_dc.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/workflow_dc.test.ts
@@ -55,8 +55,9 @@ describe('Scriptrunner DC Workflow', () => {
       'instance',
       workflowType,
       {
-        transitions: [
-          {
+        transitions: {
+          tran1: {
+            name: 'tran1',
             rules: {
               postFunctions: [
                 {
@@ -80,7 +81,7 @@ describe('Scriptrunner DC Workflow', () => {
               ],
             },
           },
-        ],
+        },
       }
     )
   })
@@ -89,212 +90,215 @@ describe('Scriptrunner DC Workflow', () => {
     const CANNED_SCRIPT = 'canned-script'
     const FIELD_COMMENT_TYPE = 'com.onresolve.scriptrunner.canned.jira.workflow.postfunctions.CommentIssue'
     beforeEach(() => {
-      instance.value.transitions[0].rules.postFunctions[0].type = scriptRunnerPostFunctionType
+      instance.value.transitions.tran1.rules.postFunctions[0].type = scriptRunnerPostFunctionType
     })
     describe('fetch', () => {
       beforeEach(() => {
-        instance.value.transitions[0].rules.postFunctions[0].configuration[CANNED_SCRIPT] = FIELD_COMMENT_TYPE
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration[CANNED_SCRIPT] = FIELD_COMMENT_TYPE
         FIELD_NAMES_STRINGS.forEach(fieldName => {
-          instance.value.transitions[0].rules.postFunctions[0].configuration[fieldName] = goodBase64
+          instance.value.transitions.tran1.rules.postFunctions[0].configuration[fieldName] = goodBase64
         })
         FIELD_NAMES_OBJECTS.forEach(fieldName => {
-          instance.value.transitions[0].rules.postFunctions[0].configuration[fieldName] = objectScriptOnlyBase64
+          instance.value.transitions.tran1.rules.postFunctions[0].configuration[fieldName] = objectScriptOnlyBase64
         })
       })
       it('should decode properly string fields', async () => {
         await filter.onFetch([instance])
         FIELD_NAMES_STRINGS.forEach(fieldName => {
-          expect(instance.value.transitions[0].rules.postFunctions[0].configuration[fieldName]).toEqual('demo string')
+          expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration[fieldName]).toEqual('demo string')
         })
         FIELD_NAMES_OBJECTS.forEach(fieldName => {
-          expect(instance.value.transitions[0].rules.postFunctions[0].configuration[fieldName]).toEqual(
+          expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration[fieldName]).toEqual(
             { script: 1 }
           )
         })
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_COMMENT).toEqual('demo string')
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_COMMENT).toEqual('demo string')
       })
       it('should decode properly different object field formations', async () => {
-        instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_CONDITION = objectPathOnlyBase64
-        instance.value.transitions[0].rules.postFunctions[0].configuration
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_CONDITION = objectPathOnlyBase64
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration
           .FIELD_SCRIPT_FILE_OR_SCRIPT = objectNoNullsBase64
         await filter.onFetch([instance])
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_CONDITION).toEqual(
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_CONDITION).toEqual(
           { scriptPath: 1 }
         )
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_SCRIPT_FILE_OR_SCRIPT).toEqual(
-          { a: 1 }
-        )
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_SCRIPT_FILE_OR_SCRIPT)
+          .toEqual(
+            { a: 1 }
+          )
       })
       it('should not decode if does not start with prefix', async () => {
-        instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_NOTES = 'ZGVtbyBzdHJpbmc='
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_NOTES = 'ZGVtbyBzdHJpbmc='
         await filter.onFetch([instance])
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_NOTES).toEqual('ZGVtbyBzdHJpbmc=')
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_NOTES).toEqual('ZGVtbyBzdHJpbmc=')
       })
       it('should not decode if not in the declared fields', async () => {
         await filter.onFetch([instance])
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.doNotDecode).toEqual(goodBase64)
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.doNotDecode).toEqual(goodBase64)
       })
       it('should not decode if not base64', async () => {
-        instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_NOTES = 'not base64'
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_NOTES = 'not base64'
         await filter.onFetch([instance])
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_NOTES).toEqual('not base64')
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_NOTES).toEqual('not base64')
       })
       it('should not decode if comment field did not match conditions', async () => {
-        instance.value.transitions[0].rules.postFunctions[0].configuration[CANNED_SCRIPT] = 'other.condition'
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration[CANNED_SCRIPT] = 'other.condition'
         await filter.onFetch([instance])
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_COMMENT).toEqual(goodBase64)
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_COMMENT).toEqual(goodBase64)
       })
       it('should not fail if no value', async () => {
-        instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_NOTES = undefined
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_NOTES = undefined
         await filter.onFetch([instance])
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_NOTES).toBeUndefined()
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_NOTES).toBeUndefined()
       })
       it('should not decode if script runner not supported', async () => {
         await filterOff.onFetch([instance])
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_NOTES).toEqual(goodBase64)
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_NOTES).toEqual(goodBase64)
       })
       it('should fail if script not in json format', async () => {
-        instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_CONDITION = goodBase64
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_CONDITION = goodBase64
         await filter.onFetch([instance])
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_CONDITION).toEqual(goodBase64)
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_CONDITION)
+          .toEqual(goodBase64)
       })
       it('should delete empty fields', async () => {
-        instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_NOTES = ''
-        instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_SCRIPT_FILE_OR_SCRIPT = ''
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_NOTES = ''
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_SCRIPT_FILE_OR_SCRIPT = ''
         await filter.onFetch([instance])
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_NOTES).toBeUndefined()
-        expect(instance.value.transitions[0].rules.postFunctions[0]
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_NOTES).toBeUndefined()
+        expect(instance.value.transitions.tran1.rules.postFunctions[0]
           .configuration.FIELD_SCRIPT_FILE_OR_SCRIPT).toBeUndefined()
       })
     })
     describe('pre deploy', () => {
       it('should encode properly', async () => {
-        instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_NOTES = 'demo string'
-        instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_CONDITION = { scriptPath: 1 }
-        instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_SCRIPT_FILE_OR_SCRIPT = { script: 1 }
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_NOTES = 'demo string'
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_CONDITION = { scriptPath: 1 }
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration
+          .FIELD_SCRIPT_FILE_OR_SCRIPT = { script: 1 }
         await filter.preDeploy([toChange({ after: instance })])
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_NOTES).toEqual(goodBase64)
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_NOTES).toEqual(goodBase64)
         compareScriptObjectsBase64(
-          instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_CONDITION,
+          instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_CONDITION,
           objectPathOnlyBase64
         )
         compareScriptObjectsBase64(
-          instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_SCRIPT_FILE_OR_SCRIPT,
+          instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_SCRIPT_FILE_OR_SCRIPT,
           objectScriptOnlyBase64
         )
       })
       it('should not encode if script runner not supported', async () => {
-        instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_NOTES = 'demo string'
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_NOTES = 'demo string'
         await filterOff.preDeploy([toChange({ after: instance })])
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_NOTES).toEqual('demo string')
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_NOTES).toEqual('demo string')
       })
     })
     describe('on deploy', () => {
       it('should decode properly', async () => {
-        instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_NOTES = goodBase64
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_NOTES = goodBase64
         await filter.onDeploy([toChange({ after: instance })])
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_NOTES).toEqual('demo string')
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_NOTES).toEqual('demo string')
       })
       it('should not decode if script runner not supported', async () => {
-        instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_NOTES = goodBase64
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_NOTES = goodBase64
         await filterOff.onDeploy([toChange({ after: instance })])
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_NOTES).toEqual(goodBase64)
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_NOTES).toEqual(goodBase64)
       })
     })
   })
   describe('validators', () => {
     const scriptRunnerValidatorType = 'com.onresolve.jira.groovy.GroovyValidator'
     beforeEach(() => {
-      instance.value.transitions[0].rules.validators[0].type = scriptRunnerValidatorType
+      instance.value.transitions.tran1.rules.validators[0].type = scriptRunnerValidatorType
     })
     describe('fetch', () => {
       it('should decode properly', async () => {
         FIELD_NAMES_STRINGS.forEach(fieldName => {
-          instance.value.transitions[0].rules.validators[0].configuration[fieldName] = goodBase64
+          instance.value.transitions.tran1.rules.validators[0].configuration[fieldName] = goodBase64
         })
-        instance.value.transitions[0].rules.validators[0].configuration.FIELD_CONDITION = objectPathOnlyBase64
-        instance.value.transitions[0].rules.validators[0].configuration
+        instance.value.transitions.tran1.rules.validators[0].configuration.FIELD_CONDITION = objectPathOnlyBase64
+        instance.value.transitions.tran1.rules.validators[0].configuration
           .FIELD_SCRIPT_FILE_OR_SCRIPT = objectScriptOnlyBase64
         await filter.onFetch([instance])
         FIELD_NAMES_STRINGS.forEach(fieldName => {
-          expect(instance.value.transitions[0].rules.validators[0].configuration[fieldName]).toEqual('demo string')
+          expect(instance.value.transitions.tran1.rules.validators[0].configuration[fieldName]).toEqual('demo string')
         })
-        expect(instance.value.transitions[0].rules.validators[0].configuration.FIELD_CONDITION).toEqual({
+        expect(instance.value.transitions.tran1.rules.validators[0].configuration.FIELD_CONDITION).toEqual({
           scriptPath: 1,
         })
-        expect(instance.value.transitions[0].rules.validators[0].configuration.FIELD_SCRIPT_FILE_OR_SCRIPT).toEqual({
+        expect(instance.value.transitions.tran1.rules.validators[0].configuration.FIELD_SCRIPT_FILE_OR_SCRIPT).toEqual({
           script: 1,
         })
       })
       it('should not fail if no value', async () => {
-        instance.value.transitions[0].rules.validators[0].configuration.FIELD_NOTES = undefined
+        instance.value.transitions.tran1.rules.validators[0].configuration.FIELD_NOTES = undefined
         await filter.onFetch([instance])
-        expect(instance.value.transitions[0].rules.validators[0].configuration.FIELD_NOTES).toBeUndefined()
+        expect(instance.value.transitions.tran1.rules.validators[0].configuration.FIELD_NOTES).toBeUndefined()
       })
     })
     describe('pre deploy', () => {
       it('should encode properly', async () => {
-        instance.value.transitions[0].rules.validators[0].configuration.FIELD_NOTES = 'demo string'
-        instance.value.transitions[0].rules.validators[0].configuration.FIELD_CONDITION = { scriptPath: 1 }
-        instance.value.transitions[0].rules.validators[0].configuration.FIELD_SCRIPT_FILE_OR_SCRIPT = { script: 1 }
+        instance.value.transitions.tran1.rules.validators[0].configuration.FIELD_NOTES = 'demo string'
+        instance.value.transitions.tran1.rules.validators[0].configuration.FIELD_CONDITION = { scriptPath: 1 }
+        instance.value.transitions.tran1.rules.validators[0].configuration.FIELD_SCRIPT_FILE_OR_SCRIPT = { script: 1 }
         await filter.preDeploy([toChange({ after: instance })])
-        expect(instance.value.transitions[0].rules.validators[0].configuration.FIELD_NOTES).toEqual(goodBase64)
+        expect(instance.value.transitions.tran1.rules.validators[0].configuration.FIELD_NOTES).toEqual(goodBase64)
         compareScriptObjectsBase64(
-          instance.value.transitions[0].rules.validators[0].configuration.FIELD_CONDITION,
+          instance.value.transitions.tran1.rules.validators[0].configuration.FIELD_CONDITION,
           objectPathOnlyBase64
         )
         compareScriptObjectsBase64(
-          instance.value.transitions[0].rules.validators[0].configuration.FIELD_SCRIPT_FILE_OR_SCRIPT,
+          instance.value.transitions.tran1.rules.validators[0].configuration.FIELD_SCRIPT_FILE_OR_SCRIPT,
           objectScriptOnlyBase64
         )
       })
       it('should not fail if undefined', async () => {
-        instance.value.transitions[0].rules.validators[0].configuration.FIELD_NOTES = undefined
+        instance.value.transitions.tran1.rules.validators[0].configuration.FIELD_NOTES = undefined
         await filter.preDeploy([toChange({ after: instance })])
-        expect(instance.value.transitions[0].rules.validators[0].configuration.FIELD_NOTES).toBeUndefined()
+        expect(instance.value.transitions.tran1.rules.validators[0].configuration.FIELD_NOTES).toBeUndefined()
       })
     })
     describe('on deploy', () => {
       it('should decode properly', async () => {
-        instance.value.transitions[0].rules.validators[0].configuration.FIELD_NOTES = goodBase64
+        instance.value.transitions.tran1.rules.validators[0].configuration.FIELD_NOTES = goodBase64
         await filter.onDeploy([toChange({ after: instance })])
-        expect(instance.value.transitions[0].rules.validators[0].configuration.FIELD_NOTES).toEqual('demo string')
+        expect(instance.value.transitions.tran1.rules.validators[0].configuration.FIELD_NOTES).toEqual('demo string')
       })
     })
   })
   describe('conditions', () => {
     const scriptRunnerConditionType = 'com.onresolve.jira.groovy.GroovyCondition'
     beforeEach(() => {
-      instance.value.transitions[0].rules.conditions[0].type = scriptRunnerConditionType
+      instance.value.transitions.tran1.rules.conditions[0].type = scriptRunnerConditionType
       FIELD_NAMES_STRINGS.forEach(fieldName => {
-        instance.value.transitions[0].rules.conditions[0].configuration[fieldName] = goodBase64
+        instance.value.transitions.tran1.rules.conditions[0].configuration[fieldName] = goodBase64
       })
     })
     describe('fetch', () => {
       it('should decode properly', async () => {
         await filter.onFetch([instance])
         FIELD_NAMES_STRINGS.forEach(fieldName => {
-          expect(instance.value.transitions[0].rules.conditions[0].configuration[fieldName]).toEqual('demo string')
+          expect(instance.value.transitions.tran1.rules.conditions[0].configuration[fieldName]).toEqual('demo string')
         })
       })
       it('should not fail if no value', async () => {
-        instance.value.transitions[0].rules.conditions[0].configuration.FIELD_NOTES = undefined
+        instance.value.transitions.tran1.rules.conditions[0].configuration.FIELD_NOTES = undefined
         await filter.onFetch([instance])
-        expect(instance.value.transitions[0].rules.conditions[0].configuration.FIELD_NOTES).toBeUndefined()
+        expect(instance.value.transitions.tran1.rules.conditions[0].configuration.FIELD_NOTES).toBeUndefined()
       })
     })
     describe('pre deploy', () => {
       it('should encode properly', async () => {
-        instance.value.transitions[0].rules.conditions[0].configuration.FIELD_NOTES = 'demo string'
+        instance.value.transitions.tran1.rules.conditions[0].configuration.FIELD_NOTES = 'demo string'
         await filter.preDeploy([toChange({ after: instance })])
-        expect(instance.value.transitions[0].rules.conditions[0].configuration.FIELD_NOTES).toEqual(goodBase64)
+        expect(instance.value.transitions.tran1.rules.conditions[0].configuration.FIELD_NOTES).toEqual(goodBase64)
       })
     })
     describe('on deploy', () => {
       it('should decode properly', async () => {
-        instance.value.transitions[0].rules.conditions[0].configuration.FIELD_NOTES = goodBase64
+        instance.value.transitions.tran1.rules.conditions[0].configuration.FIELD_NOTES = goodBase64
         await filter.onDeploy([toChange({ after: instance })])
-        expect(instance.value.transitions[0].rules.conditions[0].configuration.FIELD_NOTES).toEqual('demo string')
+        expect(instance.value.transitions.tran1.rules.conditions[0].configuration.FIELD_NOTES).toEqual('demo string')
       })
     })
   })

--- a/packages/jira-adapter/test/filters/script_runner/workflow_link_type.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/workflow_link_type.test.ts
@@ -36,8 +36,9 @@ describe('ScriptRunner linkTypes in DC', () => {
       'instance',
       workflowType,
       {
-        transitions: [
-          {
+        transitions: {
+          tran1: {
+            name: 'tran1',
             rules: {
               postFunctions: [
                 {
@@ -48,86 +49,86 @@ describe('ScriptRunner linkTypes in DC', () => {
               ],
             },
           },
-        ],
+        },
       }
     )
   })
   describe('fetch', () => {
     it('should replace FIELD_LINK_DIRECTION', async () => {
-      instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_LINK_DIRECTION = '10001-inward|||10003-outward'
+      instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_LINK_DIRECTION = '10001-inward|||10003-outward'
       await filter.onFetch([instance])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_LINK_DIRECTION).toEqual(
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_LINK_DIRECTION).toEqual(
         [{ linkType: '10001', direction: 'inward' },
           { linkType: '10003', direction: 'outward' },
         ]
       )
     })
     it('should not replace FIELD_LINK_DIRECTION if wrong format', async () => {
-      instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_LINK_DIRECTION = '10001|||10003-outward-wow'
+      instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_LINK_DIRECTION = '10001|||10003-outward-wow'
       await filter.onFetch([instance])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_LINK_DIRECTION).toEqual(['10003-outward-wow', { linkType: '10001' }])
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_LINK_DIRECTION).toEqual(['10003-outward-wow', { linkType: '10001' }])
     })
     it('should replace FIELD_LINK_TYPE', async () => {
-      instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_LINK_TYPE = '10002 inward'
+      instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_LINK_TYPE = '10002 inward'
       await filter.onFetch([instance])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_LINK_TYPE).toEqual(
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_LINK_TYPE).toEqual(
         { linkType: '10002', direction: 'inward' }
       )
     })
     it('should not replace FIELD_LINK_TYPE if wrong format', async () => {
-      instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_LINK_TYPE = '10001 inward wow'
+      instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_LINK_TYPE = '10001 inward wow'
       await filter.onFetch([instance])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_LINK_TYPE).toEqual('10001 inward wow')
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_LINK_TYPE).toEqual('10001 inward wow')
     })
     it('should use structure if no separator in FIELD_LINK_DIRECTION', async () => {
-      instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_LINK_DIRECTION = '10001'
+      instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_LINK_DIRECTION = '10001'
       await filter.onFetch([instance])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_LINK_DIRECTION).toEqual(
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_LINK_DIRECTION).toEqual(
         [{ linkType: '10001' }]
       )
     })
     it('should use outward direction in  FIELD_LINK_TYPE if not separator', async () => {
-      instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_LINK_TYPE = '10002'
+      instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_LINK_TYPE = '10002'
       await filter.onFetch([instance])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_LINK_TYPE).toEqual(
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_LINK_TYPE).toEqual(
         { linkType: '10002', direction: 'outward' }
       )
     })
   })
   describe('pre deploy', () => {
     it('should replace object to string in FIELD_LINK_DIRECTION', async () => {
-      instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_LINK_DIRECTION = [
+      instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_LINK_DIRECTION = [
         { linkType: '10001', direction: 'inward' },
         { linkType: '10003', direction: 'outward' },
       ]
       await filter.preDeploy([toChange({ after: instance })])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_LINK_DIRECTION).toEqual('10001-inward|||10003-outward')
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_LINK_DIRECTION).toEqual('10001-inward|||10003-outward')
     })
     it('should replace object to string in FIELD_LINK_TYPE', async () => {
-      instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_LINK_TYPE = { linkType: '10001', direction: 'inward' }
+      instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_LINK_TYPE = { linkType: '10001', direction: 'inward' }
       await filter.preDeploy([toChange({ after: instance })])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_LINK_TYPE).toEqual('10001 inward')
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_LINK_TYPE).toEqual('10001 inward')
     })
     it('should replace object if only linkType', async () => {
-      instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_LINK_DIRECTION = [{ linkType: '10001' }]
+      instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_LINK_DIRECTION = [{ linkType: '10001' }]
       await filter.preDeploy([toChange({ after: instance })])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_LINK_DIRECTION).toEqual('10001')
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_LINK_DIRECTION).toEqual('10001')
     })
   })
   describe('on deploy', () => {
     it('should replace FIELD_LINK_DIRECTION', async () => {
-      instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_LINK_DIRECTION = '10001-inward|||10003-outward'
+      instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_LINK_DIRECTION = '10001-inward|||10003-outward'
       await filter.onDeploy([toChange({ after: instance })])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_LINK_DIRECTION).toEqual(
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_LINK_DIRECTION).toEqual(
         [{ linkType: '10001', direction: 'inward' },
           { linkType: '10003', direction: 'outward' },
         ]
       )
     })
     it('should not replace FIELD_LINK_DIRECTION if wrong format', async () => {
-      instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_LINK_DIRECTION = '10001-inward-more|||10003'
+      instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_LINK_DIRECTION = '10001-inward-more|||10003'
       await filter.onDeploy([toChange({ after: instance })])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_LINK_DIRECTION).toEqual(['10001-inward-more', { linkType: '10003' }])
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_LINK_DIRECTION).toEqual(['10001-inward-more', { linkType: '10003' }])
     })
   })
 })

--- a/packages/jira-adapter/test/filters/script_runner/workflow_ors.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/workflow_ors.test.ts
@@ -43,8 +43,9 @@ describe('ScriptRunner ors in DC', () => {
       'instance',
       workflowType,
       {
-        transitions: [
-          {
+        transitions: {
+          tran1: {
+            name: 'tran1',
             rules: {
               postFunctions: [
                 {
@@ -69,72 +70,72 @@ describe('ScriptRunner ors in DC', () => {
               ],
             },
           },
-        ],
+        },
       }
     )
   })
   describe('fetch', () => {
     it('should replace all field ors to arrays', async () => {
       REDUCED_OR_FIELDS.forEach(field => {
-        instance.value.transitions[0].rules.postFunctions[0].configuration[field] = 'assignee|||reporter'
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration[field] = 'assignee|||reporter'
       })
       await filter.onFetch([instance])
       REDUCED_OR_FIELDS.forEach(field => {
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration[field]).toEqual(['assignee', 'reporter'])
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration[field]).toEqual(['assignee', 'reporter'])
       })
     })
     it('should sort the order of the fields', async () => {
-      instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_SELECTED_FIELDS = 'reporter|||assignee'
+      instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_SELECTED_FIELDS = 'reporter|||assignee'
       await filter.onFetch([instance])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_SELECTED_FIELDS).toEqual(['assignee', 'reporter'])
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_SELECTED_FIELDS).toEqual(['assignee', 'reporter'])
     })
     it('should insert single value to array', async () => {
-      instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_SELECTED_FIELDS = 'reporter'
+      instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_SELECTED_FIELDS = 'reporter'
       await filter.onFetch([instance])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_SELECTED_FIELDS).toEqual(['reporter'])
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_SELECTED_FIELDS).toEqual(['reporter'])
     })
     it('should not replace ors on non Or fields', async () => {
-      instance.value.transitions[0].rules.postFunctions[0].configuration.a = 'reporter|||assignee'
+      instance.value.transitions.tran1.rules.postFunctions[0].configuration.a = 'reporter|||assignee'
       await filter.onFetch([instance])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.a).toEqual('reporter|||assignee')
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.a).toEqual('reporter|||assignee')
     })
     it('should not replace if script runner not supported', async () => {
-      instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_SELECTED_FIELDS = 'reporter|||assignee'
+      instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_SELECTED_FIELDS = 'reporter|||assignee'
       await filterOff.onFetch([instance])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_SELECTED_FIELDS).toEqual('reporter|||assignee')
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_SELECTED_FIELDS).toEqual('reporter|||assignee')
     })
     it('should not replace if not data center', async () => {
-      instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_SELECTED_FIELDS = 'reporter|||assignee'
+      instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_SELECTED_FIELDS = 'reporter|||assignee'
       await filterCloud.onFetch([instance])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_SELECTED_FIELDS).toEqual('reporter|||assignee')
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_SELECTED_FIELDS).toEqual('reporter|||assignee')
     })
     it('should not replace if wrong type', async () => {
-      instance.value.transitions[0].rules.postFunctions[1] = {
+      instance.value.transitions.tran1.rules.postFunctions[1] = {
         type: 'other',
         configuration: {
           FIELD_SELECTED_FIELDS: 'reporter|||assignee',
         },
       }
       await filter.onFetch([instance])
-      expect(instance.value.transitions[0].rules.postFunctions[1].configuration.FIELD_SELECTED_FIELDS).toEqual('reporter|||assignee')
+      expect(instance.value.transitions.tran1.rules.postFunctions[1].configuration.FIELD_SELECTED_FIELDS).toEqual('reporter|||assignee')
     })
   })
   describe('pre deploy', () => {
     it('should replace arrays to ors', async () => {
       REDUCED_OR_FIELDS.forEach(field => {
-        instance.value.transitions[0].rules.postFunctions[0].configuration[field] = ['reporter', 'assignee']
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration[field] = ['reporter', 'assignee']
       })
       await filter.preDeploy([toChange({ after: instance })])
       REDUCED_OR_FIELDS.forEach(field => {
-        expect(instance.value.transitions[0].rules.postFunctions[0].configuration[field]).toEqual('reporter|||assignee')
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration[field]).toEqual('reporter|||assignee')
       })
     })
   })
   describe('on deploy', () => {
     it('should replace ors to arrays', async () => {
-      instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_SELECTED_FIELDS = 'reporter|||assignee'
+      instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_SELECTED_FIELDS = 'reporter|||assignee'
       await filter.onDeploy([toChange({ after: instance })])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.FIELD_SELECTED_FIELDS).toEqual(['assignee', 'reporter'])
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_SELECTED_FIELDS).toEqual(['assignee', 'reporter'])
     })
   })
 })

--- a/packages/jira-adapter/test/filters/script_runner/workflow_references.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/workflow_references.test.ts
@@ -26,8 +26,9 @@ const resolvedInstance = new InstanceElement(
   'instance',
   createEmptyType(WORKFLOW_TYPE_NAME),
   {
-    transitions: [
-      {
+    transitions: {
+      tran1: {
+        name: 'tran1',
         rules: {
           postFunctions: [
             {
@@ -38,7 +39,7 @@ const resolvedInstance = new InstanceElement(
           ],
         },
       },
-    ],
+    },
   }
 )
 
@@ -46,8 +47,9 @@ const restoredInstance = new InstanceElement(
   'instance',
   createEmptyType(WORKFLOW_TYPE_NAME),
   {
-    transitions: [
-      {
+    transitions: {
+      tran1: {
+        name: 'tran1',
         rules: {
           postFunctions: [
             {
@@ -58,7 +60,7 @@ const restoredInstance = new InstanceElement(
           ],
         },
       },
-    ],
+    },
   }
 )
 
@@ -92,8 +94,9 @@ describe('Scriptrunner references', () => {
       'instance',
       workflowType,
       {
-        transitions: [
-          {
+        transitions: {
+          tran1: {
+            name: 'tran1',
             rules: {
               postFunctions: [
                 {
@@ -104,40 +107,40 @@ describe('Scriptrunner references', () => {
               ],
             },
           },
-        ],
+        },
       }
     )
   })
   describe('pre deploy', () => {
     it('should store reference and replace correctly', async () => {
       await filter.preDeploy([toChange({ after: instance })])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.field).toEqual(1)
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.field).toEqual(1)
     })
     it('should store reference and replace correctly in modification', async () => {
       await filter.preDeploy([toChange({ before: instance, after: instance })])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.field).toEqual(1)
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.field).toEqual(1)
     })
     it('should not change if script runner not supported', async () => {
       await filterOff.preDeploy([toChange({ after: instance })])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.field).toEqual(reference)
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.field).toEqual(reference)
     })
     it('should change if cloud', async () => {
       await filterCloud.preDeploy([toChange({ after: instance })])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.field).toEqual(1)
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.field).toEqual(1)
     })
   })
   describe('on deploy', () => {
     it('should return reference', async () => {
       await filter.onDeploy([toChange({ after: instance })])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.field).toEqual(2)
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.field).toEqual(2)
     })
     it('should do nothing if scirptrunner not supported', async () => {
       await filterOff.onDeploy([toChange({ after: instance })])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.field).toEqual(reference)
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.field).toEqual(reference)
     })
     it('should return if cloud', async () => {
       await filterCloud.onDeploy([toChange({ after: instance })])
-      expect(instance.value.transitions[0].rules.postFunctions[0].configuration.field).toEqual(2)
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.field).toEqual(2)
     })
   })
 })

--- a/packages/jira-adapter/test/filters/script_runner/workflow_references.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/workflow_references.test.ts
@@ -20,6 +20,7 @@ import { createEmptyType, getFilterParams, mockClient } from '../../utils'
 import referencesFilter from '../../../src/filters/script_runner/workflow/workflow_references'
 import { WORKFLOW_TYPE_NAME } from '../../../src/constants'
 import { getDefaultConfig } from '../../../src/config/config'
+import { SCRIPT_RUNNER_POST_FUNCTION_TYPE } from '../../../src/filters/script_runner/workflow/workflow_cloud'
 
 
 const resolvedInstance = new InstanceElement(
@@ -73,9 +74,9 @@ jest.mock('@salto-io/adapter-utils', () => ({
 }))
 
 describe('Scriptrunner references', () => {
-  let filter: filterUtils.FilterWith<'preDeploy' | 'onDeploy'>
-  let filterOff: filterUtils.FilterWith<'preDeploy' | 'onDeploy'>
-  let filterCloud: filterUtils.FilterWith<'preDeploy' | 'onDeploy'>
+  let filter: filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
+  let filterOff: filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
+  let filterCloud: filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
   let instance: InstanceElement
   let reference: ReferenceExpression
   const workflowType = createEmptyType(WORKFLOW_TYPE_NAME)
@@ -86,9 +87,9 @@ describe('Scriptrunner references', () => {
     const configOff = _.cloneDeep(getDefaultConfig({ isDataCenter: true }))
     const { client } = mockClient(true)
     config.fetch.enableScriptRunnerAddon = true
-    filter = referencesFilter(getFilterParams({ client, config })) as filterUtils.FilterWith<'preDeploy' | 'onDeploy'>
-    filterOff = referencesFilter(getFilterParams({ client, config: configOff })) as filterUtils.FilterWith<'preDeploy' | 'onDeploy'>
-    filterCloud = referencesFilter(getFilterParams({ config })) as filterUtils.FilterWith<'preDeploy' | 'onDeploy'>
+    filter = referencesFilter(getFilterParams({ client, config })) as filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
+    filterOff = referencesFilter(getFilterParams({ client, config: configOff })) as filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
+    filterCloud = referencesFilter(getFilterParams({ config })) as filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
     reference = new ReferenceExpression(new ElemID('jira', 'temp', 'instance', 'reference'))
     instance = new InstanceElement(
       'instance',
@@ -110,6 +111,148 @@ describe('Scriptrunner references', () => {
         },
       }
     )
+  })
+  describe('on fetch', () => {
+    beforeEach(() => {
+      instance.value.transitions = {
+        tran1: {
+          id: '11',
+          name: 'tran1',
+          rules: {
+            postFunctions: [
+              {
+                type: SCRIPT_RUNNER_POST_FUNCTION_TYPE,
+                configuration: {
+                  scriptRunner: {
+                    transitionId: '21',
+                  },
+                },
+              },
+              {
+                type: SCRIPT_RUNNER_POST_FUNCTION_TYPE,
+                configuration: {
+                  scriptRunner: {
+                    transitionId: '11',
+                  },
+                },
+              },
+            ],
+          },
+        },
+        tran2: {
+          id: '21',
+          name: 'tran2',
+          rules: {
+            postFunctions: [
+              {
+                type: SCRIPT_RUNNER_POST_FUNCTION_TYPE,
+                configuration: {
+                  scriptRunner: {
+                    transitionId: '11',
+                  },
+                },
+              },
+            ],
+          },
+        },
+      }
+    })
+    it('should create references to transitions', async () => {
+      await filterCloud.onFetch([instance])
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner.transitionId)
+        .toBeInstanceOf(ReferenceExpression)
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner.transitionId
+        .elemID.getFullName()).toEqual('jira.Workflow.instance.instance.transitions.tran2')
+      expect(instance.value.transitions.tran1.rules.postFunctions[1].configuration.scriptRunner.transitionId)
+        .toBeInstanceOf(ReferenceExpression)
+      expect(instance.value.transitions.tran1.rules.postFunctions[1].configuration.scriptRunner.transitionId
+        .elemID.getFullName()).toEqual('jira.Workflow.instance.instance.transitions.tran1')
+      expect(instance.value.transitions.tran2.rules.postFunctions[0].configuration.scriptRunner.transitionId)
+        .toBeInstanceOf(ReferenceExpression)
+      expect(instance.value.transitions.tran2.rules.postFunctions[0].configuration.scriptRunner.transitionId
+        .elemID.getFullName()).toEqual('jira.Workflow.instance.instance.transitions.tran1')
+    })
+    it('should not fail if wrong structure', async () => {
+      instance.value.transitions = {
+        tran1: {
+          id: '11',
+          name: 'tran1',
+        },
+        tran2: {
+          id: '21',
+          name: 'tran2',
+          rules: {
+          },
+        },
+        tran3: {
+          id: '31',
+          name: 'tran3',
+          rules: {
+            postFunctions: [
+              {
+              },
+            ],
+          },
+        },
+        tran4: {
+          id: '41',
+          name: 'tran4',
+          rules: {
+            postFunctions: [
+              {
+                type: SCRIPT_RUNNER_POST_FUNCTION_TYPE,
+              },
+              {
+                type: SCRIPT_RUNNER_POST_FUNCTION_TYPE,
+                configuration: {
+                },
+              },
+              {
+                type: SCRIPT_RUNNER_POST_FUNCTION_TYPE,
+                configuration: {
+                  scriptRunner: {
+                  },
+                },
+              },
+            ],
+          },
+        },
+      }
+      await expect(filterCloud.onFetch([instance])).resolves.not.toThrow()
+    })
+    it('should not convert if transition id does not exists', async () => {
+      instance.value.transitions = {
+        tran1: {
+          id: '11',
+          name: 'tran1',
+          rules: {
+            postFunctions: [
+              {
+                type: SCRIPT_RUNNER_POST_FUNCTION_TYPE,
+                configuration: {
+                  scriptRunner: {
+                    transitionId: '21',
+                  },
+                },
+              },
+            ],
+          },
+        },
+      }
+      await filterCloud.onFetch([instance])
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner.transitionId)
+        .toEqual('21')
+    })
+    it('should not change anything if script runner is not enabled', async () => {
+      await filterOff.onFetch([instance])
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner.transitionId)
+        .toEqual('21')
+    })
+    it('should not change anything if dc', async () => {
+      await filter.onFetch([instance])
+      expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.scriptRunner.transitionId)
+        .toEqual('21')
+    })
   })
   describe('pre deploy', () => {
     it('should store reference and replace correctly', async () => {

--- a/packages/jira-adapter/test/filters/workflow/empty_validator_workflow.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/empty_validator_workflow.test.ts
@@ -34,8 +34,9 @@ describe('empty validator workflow', () => {
       'instance',
       workflowType,
       {
-        transitions: [
-          {
+        transitions: {
+          tran1: {
+            name: 'tran1',
             rules: {
               validators: [
                 {
@@ -53,7 +54,7 @@ describe('empty validator workflow', () => {
               ],
             },
           },
-        ],
+        },
       },
     )
 
@@ -69,7 +70,7 @@ describe('empty validator workflow', () => {
   describe('preDeploy', () => {
     it('should remove empty validators from workflow transitions but keep add on ones', async () => {
       await filter.preDeploy(changes)
-      expect(getChangeData(changes[0]).value.transitions[0].rules.validators).toEqual([
+      expect(getChangeData(changes[0]).value.transitions.tran1.rules.validators).toEqual([
         {
           type: 'FieldChangedValidator',
           configuration: {
@@ -83,8 +84,8 @@ describe('empty validator workflow', () => {
     })
 
     it('should not change valid validators', async () => {
-      workflowInstance.value.transitions[0].rules.validators.pop()
-      expect(getChangeData(changes[0]).value.transitions[0].rules.validators).toEqual([
+      workflowInstance.value.transitions.tran1.rules.validators.pop()
+      expect(getChangeData(changes[0]).value.transitions.tran1.rules.validators).toEqual([
         {
           type: 'FieldChangedValidator',
           configuration: {

--- a/packages/jira-adapter/test/filters/workflow/groups_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/groups_filter.test.ts
@@ -56,8 +56,9 @@ describe('workflowGroupsFilter', () => {
         'instance',
         workflowType,
         {
-          transitions: [
-            {
+          transitions: {
+            tran1: {
+              name: 'tran1',
               rules: {
                 conditions: {
                   type: 'UserInGroupCondition',
@@ -67,7 +68,8 @@ describe('workflowGroupsFilter', () => {
                 },
               },
             },
-            {
+            tran2: {
+              name: 'tran2',
               rules: {
                 conditions: {
                   type: 'UserInAnyGroupCondition',
@@ -77,13 +79,13 @@ describe('workflowGroupsFilter', () => {
                 },
               },
             },
-          ],
+          },
         }
       )
       await filter.onFetch([workflow, group])
-      expect(workflow.value.transitions[0].rules.conditions.configuration.group.elemID)
+      expect(workflow.value.transitions.tran1.rules.conditions.configuration.group.elemID)
         .toEqual(group.elemID.createNestedID('name'))
-      expect(workflow.value.transitions[1].rules.conditions.configuration.groups[0].elemID)
+      expect(workflow.value.transitions.tran2.rules.conditions.configuration.groups[0].elemID)
         .toEqual(group.elemID.createNestedID('name'))
     })
 
@@ -92,8 +94,9 @@ describe('workflowGroupsFilter', () => {
         'instance',
         workflowType,
         {
-          transitions: [
-            {
+          transitions: {
+            tran1: {
+              name: 'tran1',
               rules: {
                 conditions: {
                   type: 'UserInGroupCondition',
@@ -103,7 +106,8 @@ describe('workflowGroupsFilter', () => {
                 },
               },
             },
-            {
+            tran2: {
+              name: 'tran2',
               rules: {
                 conditions: {
                   type: 'UserInAnyGroupCondition',
@@ -113,13 +117,13 @@ describe('workflowGroupsFilter', () => {
                 },
               },
             },
-          ],
+          },
         }
       )
       await filter.onFetch([workflow])
-      expect(workflow.value.transitions[0].rules.conditions.configuration.group)
+      expect(workflow.value.transitions.tran1.rules.conditions.configuration.group)
         .toBe('abc')
-      expect(workflow.value.transitions[1].rules.conditions.configuration.groups[0])
+      expect(workflow.value.transitions.tran2.rules.conditions.configuration.groups[0])
         .toBe('abc')
     })
 
@@ -128,8 +132,9 @@ describe('workflowGroupsFilter', () => {
         'instance',
         workflowType,
         {
-          transitions: [
-            {
+          transitions: {
+            tran1: {
+              name: 'tran1',
               rules: {
                 conditions: {
                   type: 'UserInGroupCondition',
@@ -138,7 +143,8 @@ describe('workflowGroupsFilter', () => {
                 },
               },
             },
-            {
+            tran2: {
+              name: 'tran2',
               rules: {
                 conditions: {
                   type: 'UserInAnyGroupCondition',
@@ -147,13 +153,13 @@ describe('workflowGroupsFilter', () => {
                 },
               },
             },
-          ],
+          },
         }
       )
       await filter.onFetch([workflow])
-      expect(workflow.value.transitions[0].rules.conditions.configuration.group)
+      expect(workflow.value.transitions.tran1.rules.conditions.configuration.group)
         .toBeUndefined()
-      expect(workflow.value.transitions[1].rules.conditions.configuration.groups)
+      expect(workflow.value.transitions.tran2.rules.conditions.configuration.groups)
         .toBeUndefined()
     })
   })

--- a/packages/jira-adapter/test/filters/workflow/resolution_property_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/resolution_property_filter.test.ts
@@ -33,15 +33,18 @@ describe('resolutionPropertyFilter', () => {
       'instance',
       workflowType,
       {
-        transitions: [
-          {
+        transitions: {
+          tran1: {
+            name: 'tran1',
             properties: {
               'jira.field.resolution.include': '1,2',
               b: '3,4',
             },
           },
-          {},
-        ],
+          tran2: {
+            name: 'tran2',
+          },
+        },
       }
     )
     const { client: cli, paginator } = mockClient()
@@ -56,15 +59,18 @@ describe('resolutionPropertyFilter', () => {
     it('should split the resolution property', async () => {
       await filter.onFetch([instance])
       expect(instance.value).toEqual({
-        transitions: [
-          {
+        transitions: {
+          tran1: {
+            name: 'tran1',
             properties: {
               'jira.field.resolution.include': ['1', '2'],
               b: '3,4',
             },
           },
-          {},
-        ],
+          tran2: {
+            name: 'tran2',
+          },
+        },
       })
     })
 
@@ -77,19 +83,22 @@ describe('resolutionPropertyFilter', () => {
 
   describe('preDeploy', () => {
     it('should join the resolution property', async () => {
-      instance.value.transitions[0].properties['jira.field.resolution.include'] = ['1', '2']
+      instance.value.transitions.tran1.properties['jira.field.resolution.include'] = ['1', '2']
       await filter.preDeploy([toChange({ after: instance })])
 
       expect(instance.value).toEqual({
-        transitions: [
-          {
+        transitions: {
+          tran1: {
+            name: 'tran1',
             properties: {
               'jira.field.resolution.include': '1,2',
               b: '3,4',
             },
           },
-          {},
-        ],
+          tran2: {
+            name: 'tran2',
+          },
+        },
       })
     })
 
@@ -105,15 +114,18 @@ describe('resolutionPropertyFilter', () => {
       await filter.onDeploy([toChange({ after: instance })])
 
       expect(instance.value).toEqual({
-        transitions: [
-          {
+        transitions: {
+          tran1: {
+            name: 'tran1',
             properties: {
               'jira.field.resolution.include': ['1', '2'],
               b: '3,4',
             },
           },
-          {},
-        ],
+          tran2: {
+            name: 'tran2',
+          },
+        },
       })
     })
   })

--- a/packages/jira-adapter/test/filters/workflow/transition_ids_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/transition_ids_filter.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import JiraClient from '../../../src/client/client'
 import { JIRA, WORKFLOW_TYPE_NAME } from '../../../src/constants'
@@ -67,6 +67,29 @@ describe('transitionIdsFilter', () => {
       )
       await filter.onFetch([instance])
       expect(instance.value).toEqual({})
+    })
+  })
+  describe('onDeploy', () => {
+    it('should add transition ids', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowType,
+        {
+          transitions: {
+            tran1: { id: '1', name: 'transition1', from: ['4', '5'] },
+            tran2: { id: '2', name: 'transition2' },
+            tran3: { name: 'tran3', id: '3', from: ['7', '6'] },
+          },
+        },
+      )
+      await filter.onDeploy([toChange({ after: instance })])
+      expect(instance.value).toEqual({
+        transitions: {
+          tran1: { name: 'transition1', from: ['4', '5'] },
+          tran2: { name: 'transition2' },
+          tran3: { name: 'tran3', from: ['7', '6'] },
+        },
+      })
     })
   })
 })

--- a/packages/jira-adapter/test/filters/workflow/transition_ids_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/transition_ids_filter.test.ts
@@ -42,20 +42,20 @@ describe('transitionIdsFilter', () => {
         'instance',
         workflowType,
         {
-          transitions: [
-            { id: '1', name: 'transition1', from: ['4', '5'] },
-            { id: '2', name: 'transition2' },
-            { id: '3', from: ['7', '6'] },
-          ],
+          transitions: {
+            tran1: { id: '1', name: 'transition1', from: ['4', '5'] },
+            tran2: { id: '2', name: 'transition2' },
+            tran3: { name: 'tran3', id: '3', from: ['7', '6'] },
+          },
         },
       )
       await filter.onFetch([instance])
       expect(instance.value).toEqual({
-        transitions: [
-          { name: 'transition1', from: ['4', '5'] },
-          { name: 'transition2' },
-          { from: ['7', '6'] },
-        ],
+        transitions: {
+          tran1: { name: 'transition1', from: ['4', '5'] },
+          tran2: { name: 'transition2' },
+          tran3: { name: 'tran3', from: ['7', '6'] },
+        },
       })
     })
 

--- a/packages/jira-adapter/test/filters/workflow/transition_structure.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/transition_structure.test.ts
@@ -1,0 +1,83 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { InstanceElement } from '@salto-io/adapter-api'
+import { naclCase } from '@salto-io/adapter-utils'
+import { WorkflowInstance } from '../../../src/filters/workflow/types'
+import { createEmptyType } from '../../utils'
+import { transitionKeysToExpectedIds } from '../../../src/filters/workflow/transition_structure'
+
+const keys = {
+  t1: naclCase('transition1::From: Open::Directed'),
+  t2: naclCase('transition2::From: none::Initial'),
+  t3: naclCase('transition3::From: any status::Circular'),
+  t4: naclCase('transition4::From: Closed::Directed'),
+  t5: naclCase('transition5::From: any status::Global'),
+}
+
+describe('transitionKeysToExpectedIds', () => {
+  it('should return a map with expected transition IDs for each transition key', () => {
+    const workflowInstance: WorkflowInstance = new InstanceElement(
+      'instance',
+      createEmptyType('Workflow'),
+      {
+        transitions: {
+          [keys.t1]: { name: 'transition1' },
+          [keys.t2]: { name: 'transition2' },
+          [keys.t3]: { name: 'transition3' },
+          [keys.t4]: { name: 'transition4' },
+          [keys.t5]: { name: 'transition5' },
+        },
+      }
+    ) as WorkflowInstance
+    const result = transitionKeysToExpectedIds(workflowInstance)
+    expect(result.get(keys.t1)).toEqual('31')
+    expect(result.get(keys.t2)).toEqual('1')
+    expect(result.get(keys.t3)).toEqual('11')
+    expect(result.get(keys.t4)).toEqual('41')
+    expect(result.get(keys.t5)).toEqual('21')
+  })
+
+  it('should handle empty transition groups', () => {
+    const workflowInstance: WorkflowInstance = new InstanceElement(
+      'instance',
+      createEmptyType('Workflow'),
+      {
+        transitions: {
+        },
+      }
+    ) as WorkflowInstance
+
+    const result = transitionKeysToExpectedIds(workflowInstance)
+
+    expect(result).toEqual(new Map())
+  })
+  it('should handle wrong transition keys', () => {
+    const workflowInstance: WorkflowInstance = new InstanceElement(
+      'instance',
+      createEmptyType('Workflow'),
+      {
+        transitions: {
+          '': { name: 'transition1' },
+        },
+      }
+    ) as WorkflowInstance
+
+    const result = transitionKeysToExpectedIds(workflowInstance)
+
+    expect(result).toEqual(new Map())
+  })
+})

--- a/packages/jira-adapter/test/filters/workflow/triggers_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/triggers_deployment.test.ts
@@ -37,6 +37,7 @@ describe('triggersDeployment', () => {
         name: 'workflowName',
         transitions: {
           'name__From__any_status__Circular@fffssff': {
+            id: '1',
             name: 'name',
             rules: {
               triggers: [{
@@ -52,22 +53,6 @@ describe('triggersDeployment', () => {
     const { client: cli, connection } = mockClient()
     client = cli
     mockConnection = connection
-
-    mockConnection.get.mockResolvedValue({
-      status: 200,
-      data: {
-        values: [
-          {
-            transitions: [
-              {
-                name: 'name',
-                id: '1',
-              },
-            ],
-          },
-        ],
-      },
-    })
   })
 
   it('should call the deploy triggers endpoint', async () => {

--- a/packages/jira-adapter/test/filters/workflow/triggers_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/triggers_deployment.test.ts
@@ -35,15 +35,17 @@ describe('triggersDeployment', () => {
       workflowType,
       {
         name: 'workflowName',
-        transitions: [{
-          name: 'name',
-          rules: {
-            triggers: [{
-              key: 'key',
-              configuration: { a: 'b' },
-            }],
+        transitions: {
+          name: {
+            name: 'name',
+            rules: {
+              triggers: [{
+                key: 'key',
+                configuration: { a: 'b' },
+              }],
+            },
           },
-        }],
+        },
       }
     )
 

--- a/packages/jira-adapter/test/filters/workflow/triggers_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/triggers_deployment.test.ts
@@ -36,7 +36,7 @@ describe('triggersDeployment', () => {
       {
         name: 'workflowName',
         transitions: {
-          name: {
+          'name__From__any_status__Circular@fffssff': {
             name: 'name',
             rules: {
               triggers: [{

--- a/packages/jira-adapter/test/filters/workflow/triggers_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/triggers_filter.test.ts
@@ -63,9 +63,9 @@ describe('triggersFilter', () => {
         {
           name: 'name',
           transitionIds: { '4-5-transition1': '1' },
-          transitions: [
-            { id: '1', name: 'transition1', from: ['4', '5'] },
-          ],
+          transitions: {
+            tran1: { id: '1', name: 'transition1', from: ['4', '5'] },
+          },
         },
       )
 
@@ -91,7 +91,7 @@ describe('triggersFilter', () => {
           headers: PRIVATE_API_HEADERS,
         }
       )
-      expect(instance.value.transitions[0].rules.triggers).toEqual([
+      expect(instance.value.transitions.tran1.rules.triggers).toEqual([
         {
           key: 'key',
           configuration: {},
@@ -106,9 +106,9 @@ describe('triggersFilter', () => {
         {
           name: 'name',
           transitionIds: { '4-5-transition1': '1' },
-          transitions: [
-            { id: '1', name: 'transition1', from: ['4', '5'] },
-          ],
+          transitions: {
+            tran1: { id: '1', name: 'transition1', from: ['4', '5'] },
+          },
         },
       )
 

--- a/packages/jira-adapter/test/filters/workflow/workflow_deploy_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_deploy_filter.test.ts
@@ -83,8 +83,8 @@ describe('workflowDeployFilter', () => {
             workflowType,
             {
               name: 'name',
-              transitions: {
-                tran1: {
+              transitions: [
+                {
                   name: 'tran1',
                   type: 'initial',
                   rules: {
@@ -108,7 +108,7 @@ describe('workflowDeployFilter', () => {
                     ],
                   },
                 },
-              },
+              ],
             }
           ),
         }),
@@ -127,7 +127,7 @@ describe('workflowDeployFilter', () => {
           {
             name: 'name',
             transitions: {
-              tran1: {
+              'tran1__From__none__Initial@fffsff': {
                 name: 'tran1',
                 type: 'initial',
                 rules: {
@@ -160,8 +160,8 @@ describe('workflowDeployFilter', () => {
             workflowType,
             {
               name: 'name',
-              transitions: {
-                tran1: {
+              transitions: [
+                {
                   name: 'tran1',
                   type: 'initial',
                   rules: {
@@ -180,7 +180,7 @@ describe('workflowDeployFilter', () => {
                     },
                   },
                 },
-              },
+              ],
             },
           ),
         }),
@@ -245,7 +245,7 @@ describe('workflowDeployFilter', () => {
           {
             name: 'name',
             transitions: {
-              tran1: {
+              'tran1__From__none__Initial@fffsff': {
                 name: 'tran1',
                 type: 'initial',
               },
@@ -265,6 +265,7 @@ describe('workflowDeployFilter', () => {
               name: 'name',
               transitions: [
                 {
+                  name: 'tran1',
                   type: 'initial',
                 },
               ],
@@ -451,6 +452,7 @@ describe('workflowDeployFilter', () => {
     })
     describe('workflow diagrams', () => {
       let instance: InstanceElement
+      const TRANSITION_KEY_3 = 'hey__From__Open__Directed@fffsff'
       beforeEach(() => {
         instance = new InstanceElement(
           'instance',
@@ -511,13 +513,13 @@ describe('workflowDeployFilter', () => {
               x: -15.85,
               y: 109.40,
             },
-            transitions: [
-              {
+            transitions: {
+              'Building__From__any_status__Global@fffssff': {
                 name: 'Building',
                 to: '400',
                 type: 'global',
               },
-              {
+              'Create__From__none__Initial@fffsff': {
                 name: 'Create',
                 to: '1',
                 type: 'initial',
@@ -528,7 +530,7 @@ describe('workflowDeployFilter', () => {
                   },
                 ],
               },
-              {
+              [TRANSITION_KEY_3]: {
                 name: 'hey',
                 to: '5',
                 type: 'directed',
@@ -540,7 +542,7 @@ describe('workflowDeployFilter', () => {
                   },
                 ],
               },
-              {
+              'super__From__the_best_name__Directed@fffsssff': {
                 name: 'super',
                 from: [
                   {
@@ -552,7 +554,7 @@ describe('workflowDeployFilter', () => {
                 to: '400',
                 type: 'directed',
               },
-              {
+              'yey__From__Resolved__Directed@fffsff': {
                 name: 'yey',
                 from: [
                   {
@@ -564,7 +566,7 @@ describe('workflowDeployFilter', () => {
                 to: '10007',
                 type: 'directed',
               },
-              {
+              'with_from_a_string__From__Resolved__Directed@sssfffssff': {
                 name: 'with from as string',
                 from: [
                   '5',
@@ -578,7 +580,7 @@ describe('workflowDeployFilter', () => {
                 to: '',
                 type: 'global',
               },
-            ],
+            },
           }
         )
         mockConnection.post.mockResolvedValue({
@@ -797,7 +799,7 @@ describe('workflowDeployFilter', () => {
           responseType: undefined },)
       })
       it('should log error when transition from id is undefined', async () => {
-        instance.value.transitions[2].from[0].id = undefined
+        instance.value.transitions[TRANSITION_KEY_3].from[0].id = undefined
         await filter.deploy([toChange(
           { after: instance }
         )])
@@ -823,7 +825,7 @@ describe('workflowDeployFilter', () => {
         expect(logErrorSpy).toHaveBeenCalledWith('Fail to deploy Workflow workflowName diagram with the error: Fail to deploy Workflow workflowName Status The best name Diagram values')
       })
       it('should work ok with partial transition from values', async () => {
-        instance.value.transitions[2].from[0].targetAngle = undefined
+        instance.value.transitions[TRANSITION_KEY_3].from[0].targetAngle = undefined
         await filter.deploy([toChange(
           { after: instance }
         )])

--- a/packages/jira-adapter/test/filters/workflow/workflow_deploy_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_deploy_filter.test.ts
@@ -83,8 +83,9 @@ describe('workflowDeployFilter', () => {
             workflowType,
             {
               name: 'name',
-              transitions: [
-                {
+              transitions: {
+                tran1: {
+                  name: 'tran1',
                   type: 'initial',
                   rules: {
                     validators: [
@@ -107,7 +108,7 @@ describe('workflowDeployFilter', () => {
                     ],
                   },
                 },
-              ],
+              },
             }
           ),
         }),
@@ -125,8 +126,9 @@ describe('workflowDeployFilter', () => {
           workflowType,
           {
             name: 'name',
-            transitions: [
-              {
+            transitions: {
+              tran1: {
+                name: 'tran1',
                 type: 'initial',
                 rules: {
                   conditions: {
@@ -144,7 +146,7 @@ describe('workflowDeployFilter', () => {
                   },
                 },
               },
-            ],
+            },
           },
         ),
       })
@@ -158,8 +160,9 @@ describe('workflowDeployFilter', () => {
             workflowType,
             {
               name: 'name',
-              transitions: [
-                {
+              transitions: {
+                tran1: {
+                  name: 'tran1',
                   type: 'initial',
                   rules: {
                     conditions: {
@@ -177,7 +180,7 @@ describe('workflowDeployFilter', () => {
                     },
                   },
                 },
-              ],
+              },
             },
           ),
         }),
@@ -209,7 +212,7 @@ describe('workflowDeployFilter', () => {
           workflowType,
           {
             name: 'name',
-            transitions: [],
+            transitions: {},
           }
         ),
       })
@@ -241,11 +244,12 @@ describe('workflowDeployFilter', () => {
           workflowType,
           {
             name: 'name',
-            transitions: [
-              {
+            transitions: {
+              tran1: {
+                name: 'tran1',
                 type: 'initial',
               },
-            ],
+            },
           }
         ),
       })

--- a/packages/jira-adapter/test/filters/workflow/workflow_deploy_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_deploy_filter.test.ts
@@ -13,16 +13,19 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ElemID, getChangeData, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import { ElemID, getChangeData, InstanceElement, ObjectType, toChange, Value } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { deployment, filterUtils, client as clientUtils } from '@salto-io/adapter-components'
 import { MockInterface } from '@salto-io/test-utils'
+import _ from 'lodash'
+import { walkOnValue } from '@salto-io/adapter-utils'
 import JiraClient from '../../../src/client/client'
 import { getDefaultConfig } from '../../../src/config/config'
 import { JIRA, WORKFLOW_TYPE_NAME } from '../../../src/constants'
 import workflowFilter, { INITIAL_VALIDATOR } from '../../../src/filters/workflow/workflow_deploy_filter'
 import { getFilterParams, mockClient } from '../../utils'
 import { WITH_PERMISSION_VALIDATORS } from './workflow_values'
+import { encodeCloudFields, SCRIPT_RUNNER_POST_FUNCTION_TYPE } from '../../../src/filters/script_runner/workflow/workflow_cloud'
 
 
 jest.mock('@salto-io/adapter-components', () => {
@@ -303,12 +306,12 @@ describe('workflowDeployFilter', () => {
             workflowType,
             {
               name: 'workflowName',
-              transitions: [
-                {
+              transitions: {
+                'name__From__none__Initial@fffsff': {
                   name: 'name',
                   type: 'initial',
                 },
-              ],
+              },
             },
           ),
         })
@@ -332,12 +335,12 @@ describe('workflowDeployFilter', () => {
             workflowType,
             {
               name: 'workflowName',
-              transitions: [
-                {
+              transitions: {
+                'name__From__none__Initial@fffsff': {
                   name: 'name',
                   type: 'initial',
                 },
-              ],
+              },
             },
           ),
         })
@@ -361,12 +364,12 @@ describe('workflowDeployFilter', () => {
             workflowType,
             {
               name: 'workflowName',
-              transitions: [
-                {
+              transitions: {
+                'name__From__none__Initial@fffsff': {
                   name: 'name',
                   type: 'initial',
                 },
-              ],
+              },
             },
           ),
         })
@@ -394,12 +397,12 @@ describe('workflowDeployFilter', () => {
             workflowType,
             {
               name: 'workflowName',
-              transitions: [
-                {
+              transitions: {
+                'name__From__none__Initial@fffsff': {
                   name: 'name',
                   type: 'initial',
                 },
-              ],
+              },
             },
           ),
         })
@@ -418,6 +421,288 @@ describe('workflowDeployFilter', () => {
         const { deployResult } = await filter.deploy([change])
 
         expect(deployResult.errors).toHaveLength(1)
+      })
+      it('should add transitionIds to the workflow', async () => {
+        const INITIAL_KEY = 'name__From__none__Initial@fffsff'
+        const change = toChange({
+          after: new InstanceElement(
+            'instance',
+            workflowType,
+            {
+              name: 'workflowName',
+              transitions: {
+                [INITIAL_KEY]: {
+                  name: 'name',
+                  type: 'initial',
+                },
+              },
+            },
+          ),
+        })
+        mockConnection.get.mockResolvedValueOnce({
+          status: 200,
+          data: {
+            values: [
+              {
+                transitions: [
+                  {
+                    name: 'name',
+                    id: '1',
+                    type: 'initial',
+                  },
+                ],
+              },
+            ],
+          },
+        })
+        await filter.deploy([change])
+        expect(getChangeData(change).value.transitions[INITIAL_KEY].id).toEqual('1')
+      })
+    })
+
+    describe('transitionIds references', () => {
+      const INITIAL_KEY = 'name__From__none__Initial@fffsff'
+      const TRANSITION_KEY_2 = 'name2__From__any_status__Global@fffssff'
+      const scriptRunnerWithRef = (id: string): Value => {
+        const result = {
+          type: SCRIPT_RUNNER_POST_FUNCTION_TYPE,
+          configuration: {
+            scriptRunner: {
+              transitionId: id,
+            },
+          },
+        }
+        walkOnValue({ elemId: new ElemID(JIRA, 'none'),
+          value: result,
+          func: encodeCloudFields })
+        return result
+      }
+
+      let instance: InstanceElement
+      let filterSR: filterUtils.FilterWith<'onFetch' | 'deploy'>
+      let clientSR: JiraClient
+      let mockConnectionSR: MockInterface<clientUtils.APIConnection>
+      beforeEach(async () => {
+        const { client: cli, paginator, connection } = mockClient()
+        clientSR = cli
+        mockConnectionSR = connection
+        const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+        config.fetch.enableScriptRunnerAddon = true
+        filterSR = workflowFilter(getFilterParams({
+          client: clientSR,
+          paginator,
+          config,
+        })) as typeof filter
+        instance = new InstanceElement(
+          'instance',
+          workflowType,
+          {
+            name: 'workflowName',
+            transitions: {
+              [INITIAL_KEY]: {
+                name: 'name',
+                type: 'initial',
+                rules: {
+                  postFunctions: [
+                    scriptRunnerWithRef('1'),
+                  ],
+                },
+              },
+              [TRANSITION_KEY_2]: {
+                name: 'name2',
+                type: 'global',
+                to: [1],
+                rules: {
+                  postFunctions: [
+                    scriptRunnerWithRef('11'),
+                  ],
+                },
+              },
+            },
+          },
+        )
+      })
+      it('should deploy once if the transitionId is expected', async () => {
+        mockConnectionSR.get.mockResolvedValueOnce({
+          status: 200,
+          data: {
+            values: [
+              {
+                transitions: [
+                  {
+                    name: 'name',
+                    id: '1',
+                    type: 'initial',
+                  },
+                  {
+                    name: 'name2',
+                    id: '11',
+                    type: 'global',
+                    to: [1],
+                  },
+                ],
+              },
+            ],
+          },
+        })
+        await filterSR.deploy([toChange({ after: instance })])
+        expect(deployChangeMock).toHaveBeenCalledOnce()
+        // two calls, one for transitions, one for step deployment
+        expect(mockConnectionSR.get).toHaveBeenCalledTimes(2)
+      })
+      it('should deploy twice if the transitionId was not expected', async () => {
+        mockConnectionSR.get.mockResolvedValue({
+          status: 200,
+          data: {
+            values: [
+              {
+                transitions: [
+                  {
+                    name: 'name',
+                    id: '11',
+                    type: 'initial',
+                  },
+                  {
+                    name: 'name2',
+                    id: '1',
+                    type: 'global',
+                    to: [1],
+                  },
+                ],
+              },
+            ],
+          },
+        })
+        await filterSR.deploy([toChange({ after: instance })])
+        expect(deployChangeMock).toHaveBeenCalledTimes(2)
+        expect(deployChangeMock).toHaveBeenCalledWith({
+          change: toChange({
+            after: new InstanceElement(
+              'instance',
+              workflowType,
+              {
+                name: 'workflowName',
+                transitions: [
+                  {
+                    name: 'name',
+                    type: 'initial',
+                    rules: {
+                      postFunctions: [
+                        scriptRunnerWithRef('1'),
+                      ],
+                    },
+                  },
+                  {
+                    name: 'name2',
+                    type: 'global',
+                    to: [1],
+                    rules: {
+                      postFunctions: [
+                        scriptRunnerWithRef('11'),
+                      ],
+                    },
+                  },
+                ],
+              },
+            ),
+          }),
+          client: clientSR,
+          endpointDetails: getDefaultConfig({ isDataCenter: false })
+            .apiDefinitions.types.Workflow.deployRequests,
+          fieldsToIgnore: expect.toBeFunction(),
+        })
+        expect(deployChangeMock).toHaveBeenCalledWith({
+          change: toChange({
+            after: new InstanceElement(
+              'instance',
+              workflowType,
+              {
+                name: 'workflowName',
+                transitions: [
+                  {
+                    name: 'name',
+                    type: 'initial',
+                    rules: {
+                      postFunctions: [
+                        scriptRunnerWithRef('11'),
+                      ],
+                    },
+                  },
+                  {
+                    name: 'name2',
+                    type: 'global',
+                    to: [1],
+                    rules: {
+                      postFunctions: [
+                        scriptRunnerWithRef('1'),
+                      ],
+                    },
+                  },
+                ],
+              },
+            ),
+          }),
+          client: clientSR,
+          endpointDetails: getDefaultConfig({ isDataCenter: false })
+            .apiDefinitions.types.Workflow.deployRequests,
+          fieldsToIgnore: expect.toBeFunction(),
+        })
+        // three calls, two for transitions, one for step deployment
+        expect(mockConnectionSR.get).toHaveBeenCalledTimes(3)
+      })
+      it('should throw if two deployments are not enough', async () => {
+        mockConnectionSR.get.mockResolvedValueOnce({
+          status: 200,
+          data: {
+            values: [
+              {
+                transitions: [
+                  {
+                    name: 'name',
+                    id: '11',
+                    type: 'initial',
+                  },
+                  {
+                    name: 'name2',
+                    id: '1',
+                    type: 'global',
+                    to: [1],
+                  },
+                ],
+              },
+            ],
+          },
+        })
+        mockConnectionSR.get.mockResolvedValueOnce({
+          status: 200,
+          data: {
+            values: [
+              {
+                transitions: [
+                  {
+                    name: 'name',
+                    id: '21',
+                    type: 'initial',
+                  },
+                  {
+                    name: 'name2',
+                    id: '1',
+                    type: 'global',
+                    to: [1],
+                  },
+                ],
+              },
+            ],
+          },
+        })
+        const { deployResult } = await filterSR.deploy([toChange({ after: instance })])
+        expect(deployResult.errors).toHaveLength(1)
+        expect(deployResult.errors[0].message).toEqual(
+          'Deployment of jira.Workflow.instance.instance failed: Error: Failed to deploy workflow, transition ids changed'
+        )
+        expect(deployChangeMock).toHaveBeenCalledTimes(2)
+        // two calls for transitions
+        expect(mockConnectionSR.get).toHaveBeenCalledTimes(2)
       })
     })
 
@@ -438,9 +723,7 @@ describe('workflowDeployFilter', () => {
         ),
       })
 
-
       const { client: cli, paginator, connection } = mockClient(true)
-
       filter = workflowFilter(getFilterParams({
         client: cli,
         paginator,
@@ -574,7 +857,7 @@ describe('workflowDeployFilter', () => {
                 to: '10007',
                 type: 'directed',
               },
-              {
+              'looped__From__any_status__Circular@fffssff': {
                 name: 'looped',
                 from: [],
                 to: '',
@@ -586,6 +869,21 @@ describe('workflowDeployFilter', () => {
         mockConnection.post.mockResolvedValue({
           status: 200,
           data: {
+          },
+        })
+        mockConnection.get.mockResolvedValueOnce({
+          status: 200,
+          data: {
+            values: [
+              {
+                transitions: [
+                  {
+                    name: 'name',
+                    id: '1',
+                  },
+                ],
+              },
+            ],
           },
         })
         mockConnection.get.mockResolvedValue({

--- a/packages/jira-adapter/test/filters/workflow/workflow_diagrams.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_diagrams.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ElemID, InstanceElement, ListType, ObjectType } from '@salto-io/adapter-api'
+import { ElemID, InstanceElement, ListType, MapType, ObjectType } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
 import { MockInterface } from '@salto-io/test-utils'
@@ -46,7 +46,7 @@ describe('workflowDiagramFilter', () => {
       elemID: new ElemID(JIRA, WORKFLOW_TYPE_NAME),
       fields: {
         statuses: { refType: new ListType(workflowStatusType) },
-        transitions: { refType: new ListType(workflowTransitionType) },
+        transitions: { refType: new MapType(workflowTransitionType) },
       },
     })
 
@@ -77,36 +77,36 @@ describe('workflowDiagramFilter', () => {
             id: '400',
           },
         ],
-        transitions: [
-          {
+        transitions: {
+          tran1: {
             name: 'Building',
             to: '400',
             type: 'global',
           },
-          {
+          tran2: {
             name: 'Create',
             to: '1',
             type: 'initial',
           },
-          {
+          tran3: {
             name: 'hey',
             from: ['1'],
             to: '5',
             type: 'directed',
           },
-          {
+          tran4: {
             name: 'super',
             from: ['10007'],
             to: '400',
             type: 'directed',
           },
-          {
+          tran5: {
             name: 'yey',
             from: ['5'],
             to: '10007',
             type: 'directed',
           },
-        ],
+        },
       }
     )
 
@@ -284,10 +284,10 @@ describe('workflowDiagramFilter', () => {
         },
       )
       expect(elements).toHaveLength(3)
-      expect(instance.value.transitions[2].from).toBeDefined()
-      expect(instance.value.transitions[2].from[0].id).toEqual('1')
-      expect(instance.value.transitions[2].from[0].sourceAngle).toEqual(-78.11)
-      expect(instance.value.transitions[2].from[0].targetAngle).toEqual(173.58)
+      expect(instance.value.transitions.tran3.from).toBeDefined()
+      expect(instance.value.transitions.tran3.from[0].id).toEqual('1')
+      expect(instance.value.transitions.tran3.from[0].sourceAngle).toEqual(-78.11)
+      expect(instance.value.transitions.tran3.from[0].targetAngle).toEqual(173.58)
     })
     it('should add angles to from of initial transitions with undefined id', async () => {
       const elements = [instance]
@@ -300,10 +300,10 @@ describe('workflowDiagramFilter', () => {
         },
       )
       expect(elements).toHaveLength(3)
-      expect(instance.value.transitions[1].from).toBeDefined()
-      expect(instance.value.transitions[1].from[0].id).toBeUndefined()
-      expect(instance.value.transitions[1].from[0].sourceAngle).toEqual(99.11)
-      expect(instance.value.transitions[1].from[0].targetAngle).toEqual(173.58)
+      expect(instance.value.transitions.tran2.from).toBeDefined()
+      expect(instance.value.transitions.tran2.from[0].id).toBeUndefined()
+      expect(instance.value.transitions.tran2.from[0].sourceAngle).toEqual(99.11)
+      expect(instance.value.transitions.tran2.from[0].targetAngle).toEqual(173.58)
     })
     it('from should not be undefined in global transitions', async () => {
       const elements = [instance]
@@ -316,7 +316,7 @@ describe('workflowDiagramFilter', () => {
         },
       )
       expect(elements).toHaveLength(3)
-      expect(instance.value.transitions[0].from).toBeUndefined()
+      expect(instance.value.transitions.tran1.from).toBeUndefined()
     })
     it('should add diagramGlobalLoopedTransition angles to the instance', async () => {
       const elements = [instance]

--- a/packages/jira-adapter/test/filters/workflow/workflow_diagrams.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_diagrams.test.ts
@@ -451,9 +451,9 @@ describe('workflowDiagramFilter', () => {
       expect(instance.value.statuses[0].location).toBeDefined()
       expect(instance.value.statuses[0].location.x).toEqual(-3)
       expect(instance.value.statuses[0].location.y).toEqual(6)
-      expect(instance.value.transitions[2].from[0].id).toBeDefined()
-      expect(instance.value.transitions[2].from[0].sourceAngle).toEqual(-78.11)
-      expect(instance.value.transitions[2].from[0].targetAngle).toEqual(173.58)
+      expect(instance.value.transitions.tran3.from[0].id).toBeDefined()
+      expect(instance.value.transitions.tran3.from[0].sourceAngle).toEqual(-78.11)
+      expect(instance.value.transitions.tran3.from[0].targetAngle).toEqual(173.58)
     })
 
     it('should log error when response is not valid', async () => {

--- a/packages/jira-adapter/test/filters/workflow/workflow_modification_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_modification_filter.test.ts
@@ -334,13 +334,12 @@ describe('workflowModificationFilter', () => {
     })
     it('should clean when failure in deploy of the actual instance not related to sync', async () => {
       deployWorkflowMock.mockResolvedValueOnce()
-      deployWorkflowMock.mockRejectedValueOnce({
-        response: {
-          data: {
-            errorMessages: ['Other error'],
-          },
+      deployWorkflowMock.mockRejectedValueOnce(new clientUtils.HTTPError('message', {
+        status: 400,
+        data: {
+          errorMessages: ['other error'],
         },
-      })
+      }))
       await filter.deploy([change])
       expectDeleteOfTempWorkflow(3)
       expectSchemeChangeBack(3)

--- a/packages/jira-adapter/test/filters/workflow/workflow_properties_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_properties_filter.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ElemID, getChangeData, InstanceElement, ListType, ObjectType, toChange } from '@salto-io/adapter-api'
+import { ElemID, getChangeData, InstanceElement, ListType, MapType, ObjectType, toChange } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import JiraClient from '../../../src/client/client'
 import { JIRA, WORKFLOW_TYPE_NAME } from '../../../src/constants'
@@ -33,7 +33,7 @@ describe('workflowPropertiesFilter', () => {
       elemID: new ElemID(JIRA, WORKFLOW_TYPE_NAME),
       fields: {
         statuses: { refType: new ListType(workflowStatusType) },
-        transitions: { refType: new ListType(workflowTransitionType) },
+        transitions: { refType: new MapType(workflowTransitionType) },
       },
     })
 
@@ -79,7 +79,7 @@ describe('workflowPropertiesFilter', () => {
               },
             },
           ],
-          transitions: [],
+          transitions: {},
         }
       )
       await filter.onFetch([instance])
@@ -98,7 +98,7 @@ describe('workflowPropertiesFilter', () => {
             ],
           },
         ],
-        transitions: [],
+        transitions: {},
       })
     })
 
@@ -107,38 +107,42 @@ describe('workflowPropertiesFilter', () => {
         'instance',
         workflowType,
         {
-          transitions: [
-            {
+          transitions: {
+            a: {
+              name: 'a',
               properties: {
                 a: '1',
                 b: '2',
               },
             },
-            {
+            b: {
+              name: 'b',
               properties: {
                 c: '3',
                 d: '4',
               },
             },
-          ],
+          },
         }
       )
       await filter.onFetch([instance])
       expect(instance.value).toEqual({
-        transitions: [
-          {
+        transitions: {
+          a: {
+            name: 'a',
             properties: [
               { key: 'a', value: '1' },
               { key: 'b', value: '2' },
             ],
           },
-          {
+          b: {
+            name: 'b',
             properties: [
               { key: 'c', value: '3' },
               { key: 'd', value: '4' },
             ],
           },
-        ],
+        },
       })
     })
   })
@@ -163,7 +167,7 @@ describe('workflowPropertiesFilter', () => {
               ],
             },
           ],
-          transitions: [],
+          transitions: {},
         }
       )
       const changes = [toChange({ after: instance })]
@@ -185,7 +189,7 @@ describe('workflowPropertiesFilter', () => {
             },
           },
         ],
-        transitions: [],
+        transitions: {},
       })
 
       await filter.onDeploy?.(changes)
@@ -199,20 +203,22 @@ describe('workflowPropertiesFilter', () => {
         'instance',
         workflowType,
         {
-          transitions: [
-            {
+          transitions: {
+            a: {
+              name: 'a',
               properties: [
                 { key: 'a', value: '1' },
                 { key: 'b', value: '2' },
               ],
             },
-            {
+            b: {
+              name: 'b',
               properties: [
                 { key: 'c', value: '3' },
                 { key: 'd', value: '4' },
               ],
             },
-          ],
+          },
         }
       )
       const changes = [toChange({ after: instance })]
@@ -220,20 +226,22 @@ describe('workflowPropertiesFilter', () => {
 
       const instanceAfter = getChangeData(changes[0])
       expect(instanceAfter.value).toEqual({
-        transitions: [
-          {
+        transitions: {
+          a: {
+            name: 'a',
             properties: {
               a: '1',
               b: '2',
             },
           },
-          {
+          b: {
+            name: 'b',
             properties: {
               c: '3',
               d: '4',
             },
           },
-        ],
+        },
       })
 
       await filter.onDeploy?.(changes)

--- a/packages/jira-adapter/test/filters/workflow/workflow_structure_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_structure_filter.test.ts
@@ -13,13 +13,15 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, ElemID, Field, InstanceElement, ObjectType } from '@salto-io/adapter-api'
-import { filterUtils } from '@salto-io/adapter-components'
+import { BuiltinTypes, ElemID, Field, InstanceElement, MapType, ObjectType } from '@salto-io/adapter-api'
+import { naclCase } from '@salto-io/adapter-utils'
 import JiraClient from '../../../src/client/client'
-import { JIRA, WORKFLOW_RULES_TYPE_NAME, WORKFLOW_TYPE_NAME } from '../../../src/constants'
+import { JIRA, WORKFLOW_RULES_TYPE_NAME, WORKFLOW_TRANSITION_TYPE_NAME, WORKFLOW_TYPE_NAME } from '../../../src/constants'
 import workflowFilter from '../../../src/filters/workflow/workflow_structure_filter'
-import { getFilterParams, mockClient } from '../../utils'
-import { EXPECTED_POST_FUNCTIONS, WITH_POST_FUNCTIONS, WITH_UNSUPPORTED_POST_FUNCTIONS, WITH_VALIDATORS } from './workflow_values'
+import { createEmptyType, getFilterParams, mockClient } from '../../utils'
+import { WITH_UNSUPPORTED_POST_FUNCTIONS, WITH_VALIDATORS } from './workflow_values'
+import { Transition } from '../../../src/filters/workflow/types'
+import { Filter } from '../../../src/filter'
 
 jest.mock('@salto-io/adapter-components', () => {
   const actual = jest.requireActual('@salto-io/adapter-components')
@@ -32,17 +34,33 @@ jest.mock('@salto-io/adapter-components', () => {
   }
 })
 
+const transitionKeyMap = {
+  tran1: naclCase('tran1::From: any status::Circular'),
+  tran2: naclCase('tran2::From: any status::Circular'),
+  tran3: naclCase('tran3::From: any status::Circular'),
+  tran1Initial: naclCase('tran1::From: none::Initial'),
+}
+
+const createEmptyTransition = (tranNum: string): Transition => ({
+  name: `tran${tranNum}`,
+  rules: {
+  },
+})
+
 describe('workflowStructureFilter', () => {
-  let filter: filterUtils.FilterWith<'onFetch' | 'deploy'>
+  let filter: Filter
   let workflowType: ObjectType
+  let transitionType: ObjectType
   let client: JiraClient
   beforeEach(async () => {
     workflowType = new ObjectType({
       elemID: new ElemID(JIRA, WORKFLOW_TYPE_NAME),
       fields: {
         operations: { refType: BuiltinTypes.STRING },
+        transitions: { refType: new MapType(BuiltinTypes.STRING) },
       },
     })
+    transitionType = createEmptyType(WORKFLOW_TRANSITION_TYPE_NAME)
 
     const { client: cli, paginator } = mockClient()
     client = cli
@@ -66,7 +84,7 @@ describe('workflowStructureFilter', () => {
         },
       })
       workflowType.fields.id = new Field(workflowType, 'id', workflowIdType)
-      await filter.onFetch([workflowType])
+      await filter.onFetch?.([workflowType])
       expect(workflowType.fields.id).toBeUndefined()
     })
 
@@ -77,7 +95,7 @@ describe('workflowStructureFilter', () => {
           name: { refType: BuiltinTypes.STRING },
         },
       })
-      await filter.onFetch([workflowStatusType])
+      await filter.onFetch?.([workflowStatusType])
       expect(workflowStatusType.fields.properties).toBeDefined()
     })
 
@@ -90,7 +108,7 @@ describe('workflowStructureFilter', () => {
           },
         },
       })
-      await filter.onFetch([workflowRulesType])
+      await filter.onFetch?.([workflowRulesType])
       expect(workflowRulesType.fields.conditionsTree).toBeUndefined()
       expect(workflowRulesType.fields.conditions).toBeDefined()
     })
@@ -111,7 +129,7 @@ describe('workflowStructureFilter', () => {
         },
       })
       const elements = [workflowRulesType]
-      await filter.onFetch(elements)
+      await filter.onFetch?.(elements)
       expect(elements.length).toBeGreaterThan(1)
       expect((await workflowRulesType.fields.postFunctions.getType()).elemID.getFullName()).toBe('List<jira.PostFunction>')
       expect((await workflowRulesType.fields.validators.getType()).elemID.getFullName()).toBe('List<jira.Validator>')
@@ -127,9 +145,13 @@ describe('workflowStructureFilter', () => {
         },
       })
       const elements = [workflowConditionType]
-      await filter.onFetch(elements)
+      await filter.onFetch?.(elements)
       expect(elements.length).toBeGreaterThan(1)
       expect((await workflowConditionType.fields.configuration.getType()).elemID.getFullName()).toBe('jira.ConditionConfiguration')
+    })
+    it('should convert transitions type to a map', async () => {
+      await filter.onFetch?.([transitionType, workflowType])
+      expect((await workflowType.fields.transitions.getType()).elemID.getFullName()).toBe('Map<jira.Transition>')
     })
 
     it('should split the id value to entityId and name in Workflow instances', async () => {
@@ -144,11 +166,11 @@ describe('workflowStructureFilter', () => {
           transitions: [],
         }
       )
-      await filter.onFetch([instance])
+      await filter.onFetch?.([instance])
       expect(instance.value).toEqual({
         entityId: 'id',
         name: 'name',
-        transitions: [],
+        transitions: {},
       })
     })
 
@@ -179,7 +201,7 @@ describe('workflowStructureFilter', () => {
           transitions: [],
         }
       )
-      await filter.onFetch([instance])
+      await filter.onFetch?.([instance])
       expect(instance.value.statuses).toEqual([
         {
           properties: {
@@ -202,6 +224,7 @@ describe('workflowStructureFilter', () => {
         {
           transitions: [
             {
+              name: 'tran1',
               properties: {
                 additionalProperties: {
                   'jira.issue.editable': 'true',
@@ -210,6 +233,7 @@ describe('workflowStructureFilter', () => {
               },
             },
             {
+              name: 'tran2',
               properties: {
                 additionalProperties: {
                   'jira.issue.editable': 'false',
@@ -217,24 +241,17 @@ describe('workflowStructureFilter', () => {
                 },
               },
             },
-            {},
+            { name: 'tran3' },
           ],
         }
       )
-      await filter.onFetch([instance])
-      expect(instance.value.transitions).toEqual([
-        {
-          properties: {
-            'jira.issue.editable': 'true',
-          },
-        },
-        {
-          properties: {
-            'jira.issue.editable': 'false',
-          },
-        },
-        {},
-      ])
+      await filter.onFetch?.([instance])
+      expect(instance.value.transitions[transitionKeyMap.tran1].properties).toEqual({
+        'jira.issue.editable': 'true',
+      })
+      expect(instance.value.transitions[transitionKeyMap.tran2].properties).toEqual({
+        'jira.issue.editable': 'false',
+      })
     })
 
     it('should replace conditionsTree with conditions', async () => {
@@ -244,6 +261,7 @@ describe('workflowStructureFilter', () => {
         {
           transitions: [
             {
+              name: 'tran1',
               rules: {
                 conditionsTree: { type: 'type' },
               },
@@ -251,14 +269,12 @@ describe('workflowStructureFilter', () => {
           ],
         }
       )
-      await filter.onFetch([instance])
-      expect(instance.value.transitions).toEqual([
+      await filter.onFetch?.([instance])
+      expect(instance.value.transitions[transitionKeyMap.tran1].rules).toEqual(
         {
-          rules: {
-            conditions: { type: 'type' },
-          },
-        },
-      ])
+          conditions: { type: 'type' },
+        }
+      )
     })
 
     it('should remove id if condition type is an extension', async () => {
@@ -268,6 +284,7 @@ describe('workflowStructureFilter', () => {
         {
           transitions: [
             {
+              name: 'tran1',
               rules: {
                 conditionsTree: {
                   type: 'com.innovalog.jmwe.jira-misc-workflow-extensions__LinkIssuesFunction',
@@ -286,24 +303,18 @@ describe('workflowStructureFilter', () => {
           ],
         }
       )
-      await filter.onFetch([instance])
-      expect(instance.value).toEqual({
-        transitions: [
-          {
-            rules: {
-              conditions: {
-                type: 'com.innovalog.jmwe.jira-misc-workflow-extensions__LinkIssuesFunction',
-                configuration: {
-                },
-                conditions: [{
-                  type: 'com.innovalog.jmwe.jira-misc-workflow-extensions__LinkIssuesCondition',
-                  configuration: {
-                  },
-                }],
-              },
-            },
+      await filter.onFetch?.([instance])
+      expect(instance.value.transitions[transitionKeyMap.tran1].rules).toEqual({
+        conditions: {
+          type: 'com.innovalog.jmwe.jira-misc-workflow-extensions__LinkIssuesFunction',
+          configuration: {
           },
-        ],
+          conditions: [{
+            type: 'com.innovalog.jmwe.jira-misc-workflow-extensions__LinkIssuesCondition',
+            configuration: {
+            },
+          }],
+        },
       })
     })
 
@@ -314,6 +325,7 @@ describe('workflowStructureFilter', () => {
         {
           transitions: [
             {
+              name: 'tran1',
               rules: {
                 conditionsTree: {
                   type: 'type',
@@ -335,27 +347,21 @@ describe('workflowStructureFilter', () => {
           ],
         }
       )
-      await filter.onFetch([instance])
-      expect(instance.value).toEqual({
-        transitions: [
-          {
-            rules: {
-              conditions: {
-                type: 'type',
-                configuration: {
-                  other: 'other',
-                },
-                conditions: [{
-                  type: 'com.innovalog.jmwe.jira-misc-workflow-extensions__LinkIssuesCondition',
-                  configuration: {
-                    vals: [{
-                    }],
-                  },
-                }],
-              },
-            },
+      await filter.onFetch?.([instance])
+      expect(instance.value.transitions[transitionKeyMap.tran1].rules).toEqual({
+        conditions: {
+          type: 'type',
+          configuration: {
+            other: 'other',
           },
-        ],
+          conditions: [{
+            type: 'com.innovalog.jmwe.jira-misc-workflow-extensions__LinkIssuesCondition',
+            configuration: {
+              vals: [{
+              }],
+            },
+          }],
+        },
       })
     })
 
@@ -366,6 +372,7 @@ describe('workflowStructureFilter', () => {
         {
           transitions: [
             {
+              name: 'tran1',
               rules: {
                 conditionsTree: {
                   type: 'com.innovalog.jmwe.jira-misc-workflow-extensions__LinkIssuesFunction',
@@ -375,17 +382,11 @@ describe('workflowStructureFilter', () => {
           ],
         }
       )
-      await filter.onFetch([instance])
-      expect(instance.value).toEqual({
-        transitions: [
-          {
-            rules: {
-              conditions: {
-                type: 'com.innovalog.jmwe.jira-misc-workflow-extensions__LinkIssuesFunction',
-              },
-            },
-          },
-        ],
+      await filter.onFetch?.([instance])
+      expect(instance.value.transitions[transitionKeyMap.tran1].rules).toEqual({
+        conditions: {
+          type: 'com.innovalog.jmwe.jira-misc-workflow-extensions__LinkIssuesFunction',
+        },
       })
     })
 
@@ -394,12 +395,90 @@ describe('workflowStructureFilter', () => {
         const instance = new InstanceElement(
           'instance',
           workflowType,
-          WITH_POST_FUNCTIONS
+          {
+            transitions: [
+              {
+                name: 'tran1',
+                rules: {
+                  postFunctions: [
+                    {
+                      type: 'FireIssueEventFunction',
+                      configuration: {
+                        event: {
+                          id: '1',
+                          name: 'name',
+                        },
+                      },
+                    },
+                    {
+                      type: 'FireIssueEventFunction',
+                      configuration: {
+                      },
+                    },
+                    {
+                      type: 'FireIssueEventFunction',
+                    },
+                    {
+                      type: 'SetIssueSecurityFromRoleFunction',
+                      configuration: {
+                        projectRole: {
+                          id: '1',
+                          name: 'name',
+                        },
+                      },
+                    },
+                    {
+                      type: 'SetIssueSecurityFromRoleFunction',
+                      configuration: {
+                      },
+                    },
+                    {
+                      type: 'SetIssueSecurityFromRoleFunction',
+                    },
+                  ],
+                },
+              },
+            ],
+          }
         )
-        await filter.onFetch([instance])
-        expect(instance.value.transitions).toEqual([
-          EXPECTED_POST_FUNCTIONS,
-        ])
+        await filter.onFetch?.([instance])
+        expect(instance.value.transitions[transitionKeyMap.tran1].rules).toEqual(
+          {
+            postFunctions: [
+              {
+                type: 'FireIssueEventFunction',
+                configuration: {
+                  event: {
+                    id: '1',
+                  },
+                },
+              },
+              {
+                type: 'FireIssueEventFunction',
+                configuration: {},
+              },
+              {
+                type: 'FireIssueEventFunction',
+              },
+              {
+                type: 'SetIssueSecurityFromRoleFunction',
+                configuration: {
+                  projectRole: {
+                    id: '1',
+                  },
+                },
+              },
+              {
+                type: 'SetIssueSecurityFromRoleFunction',
+                configuration: {
+                },
+              },
+              {
+                type: 'SetIssueSecurityFromRoleFunction',
+              },
+            ],
+          }
+        )
       })
 
       it('should remove id from post functions with an extension type', async () => {
@@ -409,6 +488,7 @@ describe('workflowStructureFilter', () => {
           {
             transitions: [
               {
+                name: 'tran1',
                 rules: {
                   postFunctions: [
                     {
@@ -423,18 +503,12 @@ describe('workflowStructureFilter', () => {
             ],
           }
         )
-        await filter.onFetch([instance])
-        expect(instance.value).toEqual({
-          transitions: [
+        await filter.onFetch?.([instance])
+        expect(instance.value.transitions[transitionKeyMap.tran1].rules).toEqual({
+          postFunctions: [
             {
-              rules: {
-                postFunctions: [
-                  {
-                    type: 'com.innovalog.jmwe.jira-misc-workflow-extensions__LinkIssuesFunction',
-                    configuration: {
-                    },
-                  },
-                ],
+              type: 'com.innovalog.jmwe.jira-misc-workflow-extensions__LinkIssuesFunction',
+              configuration: {
               },
             },
           ],
@@ -448,6 +522,7 @@ describe('workflowStructureFilter', () => {
           {
             transitions: [
               {
+                name: 'tran1',
                 rules: {
                   postFunctions: [
                     {
@@ -459,17 +534,11 @@ describe('workflowStructureFilter', () => {
             ],
           }
         )
-        await filter.onFetch([instance])
-        expect(instance.value).toEqual({
-          transitions: [
+        await filter.onFetch?.([instance])
+        expect(instance.value.transitions[transitionKeyMap.tran1].rules).toEqual({
+          postFunctions: [
             {
-              rules: {
-                postFunctions: [
-                  {
-                    type: 'com.innovalog.jmwe.jira-misc-workflow-extensions__LinkIssuesFunction',
-                  },
-                ],
-              },
+              type: 'com.innovalog.jmwe.jira-misc-workflow-extensions__LinkIssuesFunction',
             },
           ],
         })
@@ -481,28 +550,20 @@ describe('workflowStructureFilter', () => {
           workflowType,
           WITH_UNSUPPORTED_POST_FUNCTIONS
         )
-        await filter.onFetch([instance])
-        expect(instance.value.transitions).toEqual([
-          {
-            type: 'initial',
-            rules: {
-              postFunctions: [
-                { type: 'AssignToCurrentUserFunction' },
-                { type: 'UpdateIssueStatusFunction' },
-                {},
-              ],
-            },
-          },
-          {
-            type: 'global',
-            rules: {
-              postFunctions: [
-                { type: 'AssignToCurrentUserFunction' },
-                {},
-              ],
-            },
-          },
-        ])
+        await filter.onFetch?.([instance])
+        expect(instance.value.transitions[transitionKeyMap.tran1Initial].rules.postFunctions).toEqual(
+          [
+            { type: 'AssignToCurrentUserFunction' },
+            { type: 'UpdateIssueStatusFunction' },
+            {},
+          ],
+        )
+        expect(instance.value.transitions[transitionKeyMap.tran2].rules.postFunctions).toEqual(
+          [
+            { type: 'AssignToCurrentUserFunction' },
+            {},
+          ],
+        )
       })
     })
 
@@ -513,32 +574,26 @@ describe('workflowStructureFilter', () => {
           workflowType,
           WITH_VALIDATORS,
         )
-        await filter.onFetch([instance])
-        expect(instance.value.transitions).toEqual([
+        await filter.onFetch?.([instance])
+        expect(instance.value.transitions[transitionKeyMap.tran1].rules.validators).toEqual([
           {
-            rules: {
-              validators: [
-                {
-                  type: 'ParentStatusValidator',
-                  configuration: {
-                    parentStatuses: [{
-                      id: '1',
-                    }],
-                  },
-                },
-                {
-                  type: 'PreviousStatusValidator',
-                  configuration: {
-                    previousStatus: {
-                      id: '1',
-                    },
-                  },
-                },
-                {
-                  type: 'PreviousStatusValidator',
-                },
-              ],
+            type: 'ParentStatusValidator',
+            configuration: {
+              parentStatuses: [{
+                id: '1',
+              }],
             },
+          },
+          {
+            type: 'PreviousStatusValidator',
+            configuration: {
+              previousStatus: {
+                id: '1',
+              },
+            },
+          },
+          {
+            type: 'PreviousStatusValidator',
           },
         ])
       })
@@ -550,6 +605,7 @@ describe('workflowStructureFilter', () => {
           {
             transitions: [
               {
+                name: 'tran1',
                 rules: {
                   validators: [
                     {
@@ -564,22 +620,14 @@ describe('workflowStructureFilter', () => {
             ],
           }
         )
-        await filter.onFetch([instance])
-        expect(instance.value).toEqual({
-          transitions: [
-            {
-              rules: {
-                validators: [
-                  {
-                    type: 'com.innovalog.jmwe.jira-misc-workflow-extensions__LinkIssuesFunction',
-                    configuration: {
-                    },
-                  },
-                ],
-              },
+        await filter.onFetch?.([instance])
+        expect(instance.value.transitions[transitionKeyMap.tran1].rules.validators).toEqual([
+          {
+            type: 'com.innovalog.jmwe.jira-misc-workflow-extensions__LinkIssuesFunction',
+            configuration: {
             },
-          ],
-        })
+          },
+        ])
       })
 
       it('should rename fields to fieldIds', async () => {
@@ -589,6 +637,7 @@ describe('workflowStructureFilter', () => {
           {
             transitions: [
               {
+                name: 'tran1',
                 rules: {
                   validators: [
                     {
@@ -604,19 +653,13 @@ describe('workflowStructureFilter', () => {
             ],
           }
         )
-        await filter.onFetch([instance])
-        expect(instance.value.transitions).toEqual([
+        await filter.onFetch?.([instance])
+        expect(instance.value.transitions[transitionKeyMap.tran1].rules.validators).toEqual([
           {
-            rules: {
-              validators: [
-                {
-                  type: 'ParentStatusValidator',
-                  configuration: {
-                    fieldIds: ['1'],
-                    fieldId: '1',
-                  },
-                },
-              ],
+            type: 'ParentStatusValidator',
+            configuration: {
+              fieldIds: ['1'],
+              fieldId: '1',
             },
           },
         ])
@@ -629,6 +672,7 @@ describe('workflowStructureFilter', () => {
           {
             transitions: [
               {
+                name: 'tran1',
                 rules: {
                   validators: [
                     {
@@ -643,21 +687,177 @@ describe('workflowStructureFilter', () => {
             ],
           }
         )
-        await filter.onFetch([instance])
-        expect(instance.value.transitions).toEqual([
+        await filter.onFetch?.([instance])
+        expect(instance.value.transitions[transitionKeyMap.tran1].rules.validators).toEqual([
           {
-            rules: {
-              validators: [
-                {
-                  type: 'ParentStatusValidator',
-                  configuration: {
-                    windowsDays: 1,
-                  },
-                },
-              ],
+            type: 'ParentStatusValidator',
+            configuration: {
+              windowsDays: 1,
             },
           },
         ])
+      })
+    })
+    describe('transitions map', () => {
+      it('should convert transitions to a map', async () => {
+        const instance = new InstanceElement(
+          'instance',
+          workflowType,
+          {
+            transitions: [
+              createEmptyTransition('1'),
+              createEmptyTransition('2'),
+            ],
+          },
+        )
+        await filter.onFetch?.([instance])
+        expect(instance.value.transitions).toEqual({
+          [transitionKeyMap.tran1]: createEmptyTransition('1'),
+          [transitionKeyMap.tran2]: createEmptyTransition('2'),
+        })
+      })
+      it('should add the correct name to the transition', async () => {
+        const instance = new InstanceElement(
+          'instance',
+          workflowType,
+          {
+            transitions: [
+              createEmptyTransition('1'),
+              createEmptyTransition('2'),
+            ],
+            statuses: [
+              {
+                id: '1',
+                name: 'status1',
+              },
+              {
+                id: '2',
+                name: 'status2',
+              },
+            ],
+          },
+        )
+        instance.value.transitions[0].from = ['1']
+        instance.value.transitions[1].from = ['2']
+
+        await filter.onFetch?.([instance])
+        expect(instance.value.transitions[naclCase('tran1::From: status1::Directed')].name).toEqual('tran1')
+        expect(instance.value.transitions[naclCase('tran2::From: status2::Directed')].name).toEqual('tran2')
+      })
+      it('should add all from statuses in the correct order', async () => {
+        const instance = new InstanceElement(
+          'instance',
+          workflowType,
+          {
+            transitions: [
+              createEmptyTransition('1'),
+            ],
+            statuses: [
+              {
+                id: '1',
+                name: 'b',
+              },
+              {
+                id: '2',
+                name: 'cc',
+              },
+              {
+                id: '3',
+                name: 'aaa',
+              },
+            ],
+          },
+        )
+        instance.value.transitions[0].from = ['2', '3', '1']
+        await filter.onFetch?.([instance])
+        expect(Object.keys(instance.value.transitions)).toEqual([naclCase('tran1::From: aaa,b,cc::Directed')])
+      })
+      it('should add global transition key correctly', async () => {
+        const instance = new InstanceElement(
+          'instance',
+          workflowType,
+          {
+            transitions: [
+              createEmptyTransition('1'),
+            ],
+          }
+        )
+        instance.value.transitions[0].to = ['1']
+        await filter.onFetch?.([instance])
+        expect(Object.keys(instance.value.transitions)).toEqual([naclCase('tran1::From: any status::Global')])
+      })
+      it('should add global circular transition key correctly', async () => {
+        const instance = new InstanceElement(
+          'instance',
+          workflowType,
+          {
+            transitions: [
+              createEmptyTransition('1'),
+            ],
+          }
+        )
+        await filter.onFetch?.([instance])
+        expect(Object.keys(instance.value.transitions)).toEqual([naclCase('tran1::From: any status::Circular')])
+      })
+      it('should add initial transition key correctly', async () => {
+        const instance = new InstanceElement(
+          'instance',
+          workflowType,
+          {
+            transitions: [
+              createEmptyTransition('1'),
+            ],
+          }
+        )
+        instance.value.transitions[0].type = 'initial'
+        await filter.onFetch?.([instance])
+        expect(Object.keys(instance.value.transitions)).toEqual([naclCase('tran1::From: none::Initial')])
+      })
+      it('should add transition key differentiators correctly', async () => {
+        const instance = new InstanceElement(
+          'instance',
+          workflowType,
+          {
+            transitions: [
+              createEmptyTransition('1'),
+              createEmptyTransition('1'),
+              createEmptyTransition('2'),
+              createEmptyTransition('1'),
+            ],
+          }
+        )
+        await filter.onFetch?.([instance])
+        expect(Object.keys(instance.value.transitions)[0]).toEqual(naclCase('tran1::From: any status::Circular::1'))
+        expect(Object.keys(instance.value.transitions)[1]).toEqual(naclCase('tran1::From: any status::Circular::2'))
+        expect(Object.keys(instance.value.transitions)[3]).toEqual(naclCase('tran1::From: any status::Circular::3'))
+      })
+      it('should issue a fetch warning when same key transitions', async () => {
+        const instance = new InstanceElement(
+          'instance',
+          workflowType,
+          {
+            id: {
+              name: 'instance',
+            },
+            transitions: [
+              createEmptyTransition('1'),
+              createEmptyTransition('1'),
+              createEmptyTransition('1'),
+              createEmptyTransition('2'),
+              createEmptyTransition('3'),
+              createEmptyTransition('2'),
+            ],
+          }
+        )
+        const fetchResults = await filter.onFetch?.([instance])
+        // expect(fetchResults?.errors).toHaveLength(1)
+        expect(fetchResults).toEqual({ errors: [
+          {
+            severity: 'Warning',
+            message: `The following transitions of workflow instance have the same key: ${transitionKeyMap.tran1}, ${transitionKeyMap.tran2}.
+It is strongly recommended to rename these transitions so they are unique in Jira, then re-fetch`,
+          },
+        ] })
       })
     })
 
@@ -683,7 +883,7 @@ describe('workflowStructureFilter', () => {
           ],
         }
       )
-      await filter.onFetch([instance])
+      await filter.onFetch?.([instance])
       expect(instance.value.transitions).toEqual([
         {
           rules: {

--- a/packages/jira-adapter/test/filters/workflow/workflow_values.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_values.ts
@@ -15,93 +15,10 @@
 */
 import { INITIAL_VALIDATOR } from '../../../src/filters/workflow/workflow_deploy_filter'
 
-export const WITH_POST_FUNCTIONS = {
-  transitions: [
-    {
-      rules: {
-        postFunctions: [
-          {
-            type: 'FireIssueEventFunction',
-            configuration: {
-              event: {
-                id: '1',
-                name: 'name',
-              },
-            },
-          },
-          {
-            type: 'FireIssueEventFunction',
-            configuration: {
-            },
-          },
-          {
-            type: 'FireIssueEventFunction',
-          },
-          {
-            type: 'SetIssueSecurityFromRoleFunction',
-            configuration: {
-              projectRole: {
-                id: '1',
-                name: 'name',
-              },
-            },
-          },
-          {
-            type: 'SetIssueSecurityFromRoleFunction',
-            configuration: {
-            },
-          },
-          {
-            type: 'SetIssueSecurityFromRoleFunction',
-          },
-        ],
-      },
-    },
-  ],
-}
-
-export const EXPECTED_POST_FUNCTIONS = {
-  rules: {
-    postFunctions: [
-      {
-        type: 'FireIssueEventFunction',
-        configuration: {
-          event: {
-            id: '1',
-          },
-        },
-      },
-      {
-        type: 'FireIssueEventFunction',
-        configuration: {},
-      },
-      {
-        type: 'FireIssueEventFunction',
-      },
-
-      {
-        type: 'SetIssueSecurityFromRoleFunction',
-        configuration: {
-          projectRole: {
-            id: '1',
-          },
-        },
-      },
-      {
-        type: 'SetIssueSecurityFromRoleFunction',
-        configuration: {
-        },
-      },
-      {
-        type: 'SetIssueSecurityFromRoleFunction',
-      },
-    ],
-  },
-}
-
 export const WITH_UNSUPPORTED_POST_FUNCTIONS = {
   transitions: [
     {
+      name: 'tran1',
       type: 'initial',
       rules: {
         postFunctions: [
@@ -113,6 +30,7 @@ export const WITH_UNSUPPORTED_POST_FUNCTIONS = {
       },
     },
     {
+      name: 'tran2',
       type: 'global',
       rules: {
         postFunctions: [
@@ -129,6 +47,7 @@ export const WITH_UNSUPPORTED_POST_FUNCTIONS = {
 export const WITH_VALIDATORS = {
   transitions: [
     {
+      name: 'tran1',
       rules: {
         validators: [
           {

--- a/packages/jira-adapter/test/filters/workflow/workflow_values.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_values.ts
@@ -79,8 +79,9 @@ export const WITH_VALIDATORS = {
 
 export const WITH_PERMISSION_VALIDATORS = {
   name: 'name',
-  transitions: [
-    {
+  transitions: {
+    'tran1__From__none__Initial@fffsff': {
+      name: 'tran1',
       type: 'initial',
       rules: {
         validators: [
@@ -104,5 +105,5 @@ export const WITH_PERMISSION_VALIDATORS = {
         ],
       },
     },
-  ],
+  },
 }


### PR DESCRIPTION
_Stage 1: change the workflow transitions list to a map_

---

_Currently the tests do not pass as I did not touch the deployment_

---
_Release Notes_: 
Jira Adapter:
* Add references to workflow transitions in scriptrunner's relevant post functions

---
_User Notifications_: 
Jira Adapter:
* Workflow transitions will be kept in a map from now on. The key will be based on the name of the transition and the `from` field
