### PR TITLE
SALTO-3067: add change validator for translation collection NS references

### DIFF
--- a/packages/netsuite-adapter/src/change_validator.ts
+++ b/packages/netsuite-adapter/src/change_validator.ts
@@ -45,6 +45,7 @@ import netsuiteClientValidation from './change_validators/client_validation'
 import currencyUndeployableFieldsValidator from './change_validators/currency_undeployable_fields'
 import fileCabinetInternalIdsValidator from './change_validators/file_cabinet_internal_ids'
 import rolePermissionValidator from './change_validators/role_permission_ids'
+import translationCollectionValidator from './change_validators/translation_collection_references'
 import NetsuiteClient from './client/client'
 import {
   AdditionalDependencies,
@@ -83,6 +84,7 @@ const netsuiteChangeValidators: Record<NetsuiteValidatorName, NetsuiteChangeVali
   undeployableConfigFeatures: undeployableConfigFeaturesValidator,
   extraReferenceDependencies: extraReferenceDependenciesValidator,
   rolePermission: rolePermissionValidator,
+  translationCollectionReferences: translationCollectionValidator,
 }
 
 const nonSuiteAppValidators: Record<NonSuiteAppValidatorName, NetsuiteChangeValidator> = {

--- a/packages/netsuite-adapter/src/change_validators/translation_collection_references.ts
+++ b/packages/netsuite-adapter/src/change_validators/translation_collection_references.ts
@@ -25,7 +25,7 @@ const customCollectionRegex = new RegExp('\\[scriptid=custcollection.*', 'gm')
 const toChangeError = (instance: InstanceElement): ChangeError => ({
   elemID: instance.elemID,
   severity: 'Error',
-  message: 'Cannot deploy elements with translation references',
+  message: 'Cannot deploy element with invalid translation reference',
   detailedMessage: 'Cannot deploy this element because it contains a reference to a translation collection that does not exist in the project.'
    + ' To proceed with the deployment, please replace the reference with a valid string. After the deployment, you can reconnect the elements in the NS UI.',
 })

--- a/packages/netsuite-adapter/src/change_validators/translation_collection_references.ts
+++ b/packages/netsuite-adapter/src/change_validators/translation_collection_references.ts
@@ -46,7 +46,7 @@ const changeValidator: NetsuiteChangeValidator = async changes => (
             customCollectionReferences.push(
               ...captureServiceIdInfo(value)
                 .map(serviceIdInfo => serviceIdInfo.serviceId)
-                .filter(serviceId => serviceId.includes(CUSTOM_COLLECTION))
+                .filter(serviceId => serviceId.startsWith(CUSTOM_COLLECTION))
                 .map(serviceId => serviceId.split('.')[0])
             )
             return WALK_NEXT_STEP.SKIP
@@ -55,7 +55,7 @@ const changeValidator: NetsuiteChangeValidator = async changes => (
         },
       })
       return customCollectionReferences.length > 0
-        ? toChangeError(element, customCollectionReferences)
+        ? toChangeError(element, _.uniq(customCollectionReferences))
         : undefined
     })
     .filter(isDefined)

--- a/packages/netsuite-adapter/src/change_validators/translation_collection_references.ts
+++ b/packages/netsuite-adapter/src/change_validators/translation_collection_references.ts
@@ -26,8 +26,8 @@ const toChangeError = (instance: InstanceElement): ChangeError => ({
   elemID: instance.elemID,
   severity: 'Error',
   message: 'Cannot deploy elements with translation references',
-  detailedMessage: 'Cannot deploy this element since it contains a translation reference.'
-  + ' To deploy it, replace the reference with any string. After the deployment, reconnect the elements in the NS UI',
+  detailedMessage: 'Cannot deploy this element because it contains a reference to a translation collection that does not exist in the project.'
+   + ' To proceed with the deployment, please replace the reference with a valid string. After the deployment, you can reconnect the elements in the NS UI.',
 })
 
 const changeValidator: NetsuiteChangeValidator = async changes => (

--- a/packages/netsuite-adapter/src/change_validators/translation_collection_references.ts
+++ b/packages/netsuite-adapter/src/change_validators/translation_collection_references.ts
@@ -1,0 +1,54 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ChangeError, getChangeData, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
+import { walkOnElement, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
+import { values } from '@salto-io/lowerdash'
+import _ from 'lodash'
+import { NetsuiteChangeValidator } from './types'
+
+const { isDefined } = values
+const customCollectionRegex = new RegExp('\\[scriptid=custcollection.*', 'gm')
+
+const toChangeError = (instance: InstanceElement): ChangeError => ({
+  elemID: instance.elemID,
+  severity: 'Error',
+  message: 'Cannot deploy elements with translation references',
+  detailedMessage: 'Cannot deploy this element since it contains a translation reference.'
+  + ' To deploy it, replace the reference with any string. After the deployment, reconnect the elements in the NS UI',
+})
+
+const changeValidator: NetsuiteChangeValidator = async changes => (
+  changes
+    .map(getChangeData)
+    .filter(isInstanceElement)
+    .map(instance => {
+      let changeError: ChangeError | undefined
+      walkOnElement({
+        element: instance,
+        func: ({ value }) => {
+          if (_.isString(value) && customCollectionRegex.test(value)) {
+            changeError = toChangeError(instance)
+            return WALK_NEXT_STEP.EXIT
+          }
+          return WALK_NEXT_STEP.RECURSE
+        },
+      })
+      return changeError
+    })
+    .filter(isDefined)
+)
+
+export default changeValidator

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -549,6 +549,7 @@ export type NetsuiteValidatorName = (
   | 'undeployableConfigFeatures'
   | 'extraReferenceDependencies'
   | 'rolePermission'
+  | 'translationCollectionReferences'
 )
 
 export type NonSuiteAppValidatorName = (

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -562,8 +562,8 @@ export type OnlySuiteAppValidatorName = (
 )
 
 type ChangeValidatorConfig = Record<
-  NetsuiteValidatorName & NonSuiteAppValidatorName & OnlySuiteAppValidatorName,
-  boolean
+  NetsuiteValidatorName | NonSuiteAppValidatorName | OnlySuiteAppValidatorName,
+  boolean | undefined
 >
 
 const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig>({
@@ -594,6 +594,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     removeFileCabinet: { refType: BuiltinTypes.BOOLEAN },
     removeStandardTypes: { refType: BuiltinTypes.BOOLEAN },
     fileCabinetInternalIds: { refType: BuiltinTypes.BOOLEAN },
+    translationCollectionReferences: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/netsuite-adapter/test/change_validators/translation_collection_references.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/translation_collection_references.test.ts
@@ -19,16 +19,32 @@ import { addressFormType } from '../../src/autogen/types/standard_types/addressF
 
 describe('translation collection change validator', () => {
   const addressFormInstance = new InstanceElement('test', addressFormType().type, { field: '[scriptid=custcollection1]' })
+  const nestedRefInstance = new InstanceElement('test1', addressFormType().type,
+    {
+      field: '[type=custcollection, scriptid=custcollection2]',
+      field2: '[scriptid=custcollection3.inner]',
+    })
   const noReferenceInstance = new InstanceElement('test2', addressFormType().type, {})
   it('should return changeError in case there\'s a NS reference to a translation collection', async () => {
-    const changes = [{ after: addressFormInstance }, { after: noReferenceInstance }].map(toChange)
+    const changes = [
+      { after: addressFormInstance },
+      { after: noReferenceInstance },
+      { after: nestedRefInstance },
+    ].map(toChange)
     const changeErrors = await translationCollectionValidator(changes)
-    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors).toHaveLength(2)
     expect(changeErrors[0]).toEqual({
       elemID: addressFormInstance.elemID,
       severity: 'Error',
       message: 'Cannot deploy element with invalid translation reference',
-      detailedMessage: 'Cannot deploy this element because it contains a reference to the \'custcollection1\' translation collection that does not exist in the environment.'
+      detailedMessage: 'Cannot deploy this element because it contains references to the following translation collections that do not exist in your environment: \'custcollection1\'.'
+  + ' To proceed with the deployment, please replace the reference with a valid string. After the deployment, you can reconnect the elements in the NetSuite UI.',
+    })
+    expect(changeErrors[1]).toEqual({
+      elemID: nestedRefInstance.elemID,
+      severity: 'Error',
+      message: 'Cannot deploy element with invalid translation reference',
+      detailedMessage: 'Cannot deploy this element because it contains references to the following translation collections that do not exist in your environment: \'custcollection2\', \'custcollection3\'.'
   + ' To proceed with the deployment, please replace the reference with a valid string. After the deployment, you can reconnect the elements in the NetSuite UI.',
     })
   })

--- a/packages/netsuite-adapter/test/change_validators/translation_collection_references.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/translation_collection_references.test.ts
@@ -28,8 +28,8 @@ describe('translation collection change validator', () => {
       elemID: addressFormInstance.elemID,
       severity: 'Error',
       message: 'Cannot deploy elements with translation references',
-      detailedMessage: 'Cannot deploy this element since it contains a translation reference.'
-  + ' To deploy it, replace the reference with any string. After the deployment, reconnect the elements in the NS UI',
+      detailedMessage: 'Cannot deploy this element because it contains a reference to a translation collection that does not exist in the project.'
+  + ' To proceed with the deployment, please replace the reference with a valid string. After the deployment, you can reconnect the elements in the NS UI.',
     })
   })
 })

--- a/packages/netsuite-adapter/test/change_validators/translation_collection_references.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/translation_collection_references.test.ts
@@ -28,8 +28,8 @@ describe('translation collection change validator', () => {
       elemID: addressFormInstance.elemID,
       severity: 'Error',
       message: 'Cannot deploy element with invalid translation reference',
-      detailedMessage: 'Cannot deploy this element because it contains a reference to a translation collection that does not exist in the project.'
-  + ' To proceed with the deployment, please replace the reference with a valid string. After the deployment, you can reconnect the elements in the NS UI.',
+      detailedMessage: 'Cannot deploy this element because it contains a reference to the \'custcollection1\' translation collection that does not exist in the environment.'
+  + ' To proceed with the deployment, please replace the reference with a valid string. After the deployment, you can reconnect the elements in the NetSuite UI.',
     })
   })
 })

--- a/packages/netsuite-adapter/test/change_validators/translation_collection_references.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/translation_collection_references.test.ts
@@ -20,14 +20,14 @@ import { addressFormType } from '../../src/autogen/types/standard_types/addressF
 describe('translation collection change validator', () => {
   const addressFormInstance = new InstanceElement('test', addressFormType().type, { field: '[scriptid=custcollection1]' })
   const noReferenceInstance = new InstanceElement('test2', addressFormType().type, {})
-  it('should return changeError in case translation collection is referenced', async () => {
+  it('should return changeError in case there\'s a NS reference to a translation collection', async () => {
     const changes = [{ after: addressFormInstance }, { after: noReferenceInstance }].map(toChange)
     const changeErrors = await translationCollectionValidator(changes)
     expect(changeErrors).toHaveLength(1)
     expect(changeErrors[0]).toEqual({
       elemID: addressFormInstance.elemID,
       severity: 'Error',
-      message: 'Cannot deploy elements with translation references',
+      message: 'Cannot deploy element with invalid translation reference',
       detailedMessage: 'Cannot deploy this element because it contains a reference to a translation collection that does not exist in the project.'
   + ' To proceed with the deployment, please replace the reference with a valid string. After the deployment, you can reconnect the elements in the NS UI.',
     })

--- a/packages/netsuite-adapter/test/change_validators/translation_collection_references.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/translation_collection_references.test.ts
@@ -1,0 +1,35 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { InstanceElement, toChange } from '@salto-io/adapter-api'
+import translationCollectionValidator from '../../src/change_validators/translation_collection_references'
+import { addressFormType } from '../../src/autogen/types/standard_types/addressForm'
+
+describe('translation collection change validator', () => {
+  const addressFormInstance = new InstanceElement('test', addressFormType().type, { field: '[scriptid=custcollection1]' })
+  const noReferenceInstance = new InstanceElement('test2', addressFormType().type, {})
+  it('should return changeError in case translation collection is referenced', async () => {
+    const changes = [{ after: addressFormInstance }, { after: noReferenceInstance }].map(toChange)
+    const changeErrors = await translationCollectionValidator(changes)
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0]).toEqual({
+      elemID: addressFormInstance.elemID,
+      severity: 'Error',
+      message: 'Cannot deploy elements with translation references',
+      detailedMessage: 'Cannot deploy this element since it contains a translation reference.'
+  + ' To deploy it, replace the reference with any string. After the deployment, reconnect the elements in the NS UI',
+    })
+  })
+})


### PR DESCRIPTION
_Add change validator for translation collection NS references_

---

_The ticket: https://salto-io.atlassian.net/browse/SALTO-3067_

---
_Release Notes_: 
_Netsuite Adapter_:
* NetSuite references to translation collections not in the project will raise a change error
---
_User Notifications_: 
_None_
