### PR TITLE
SALTO-4451: Statuses pagination bug

### DIFF
--- a/packages/adapter-components/src/client/index.ts
+++ b/packages/adapter-components/src/client/index.ts
@@ -19,7 +19,7 @@ export { DEFAULT_RETRY_OPTS, RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS } from
 export { logDecorator, requiresLogin } from './decorators'
 export { AdapterHTTPClient, ClientBaseParams, ClientDataParams, ClientOpts, HTTPReadClientInterface, HTTPWriteClientInterface, HTTPError, HttpMethodToClientParams } from './http_client'
 export { axiosConnection, createClientConnection, createRetryOptions, validateCredentials, APIConnection, ConnectionCreator, Response, ResponseValue, UnauthorizedError, Connection, RetryOptions, AuthParams, AuthenticatedAPIConnection } from './http_connection'
-export { createPaginator, getWithCursorPagination, getWithItemOffsetPagination as getWithItemIndexPagination, getWithPageOffsetPagination, getWithPageOffsetAndLastPagination, traverseRequests, PathCheckerFunc, defaultPathChecker } from './pagination/pagination'
+export { createPaginator, getWithCursorPagination, getWithItemOffsetPagination as getWithItemIndexPagination, getWithPageOffsetPagination, getWithPageOffsetAndLastPagination, getWithOffsetAndLimit, traverseRequests, PathCheckerFunc, defaultPathChecker } from './pagination/pagination'
 export { ClientGetWithPaginationParams, GetAllItemsFunc, PageEntriesExtractor, PaginationFunc, PaginationFuncCreator, Paginator } from './pagination/common'
 export { getAllPagesWithOffsetAndTotal } from './pagination/pagination_async'
 export { createRateLimitersFromConfig, throttle, BottleneckBuckets } from './rate_limit'

--- a/packages/jira-adapter/src/client/pagination.ts
+++ b/packages/jira-adapter/src/client/pagination.ts
@@ -59,5 +59,8 @@ export const paginate: clientUtils.PaginationFuncCreator = args => {
       }
     )
   }
+  if (args.getParams?.url === '/rest/api/3/statuses/search') {
+    return clientUtils.getWithOffsetAndLimit()
+  }
   return clientUtils.getAllPagesWithOffsetAndTotal()
 }


### PR DESCRIPTION
_Due to an internal jira bug temporary fix to allow fetching all statuses_

---

_The pagination function and its tests were restored completely from a previous version of the file, they are not new_

---
_Release Notes_: 
Jira Adapter: Fixed a bug that prevented fetching more than 200 statuses

---
_User Notifications_: 
None
