### PR TITLE
SALTO-4402 - undo revert and disable by default

### DIFF
--- a/packages/salesforce-adapter/src/filters/field_references.ts
+++ b/packages/salesforce-adapter/src/filters/field_references.ts
@@ -159,7 +159,7 @@ const filter: LocalFilterCreator = ({ config }) => ({
   onFetch: async elements => {
     const refDef = getReferenceMappingDefs({
       enumFieldPermissions: config.enumFieldPermissions ?? false,
-      fetchProfiles: !config.fetchProfile.isFeatureEnabled('ignoreRefsInProfiles'),
+      otherProfileRefs: config.fetchProfile.isFeatureEnabled('generateRefsInProfiles'),
     })
     await addReferences(
       elements,

--- a/packages/salesforce-adapter/src/filters/field_references.ts
+++ b/packages/salesforce-adapter/src/filters/field_references.ts
@@ -20,7 +20,13 @@ import { logger } from '@salto-io/logging'
 import { collections, multiIndex } from '@salto-io/lowerdash'
 import { apiName, metadataType } from '../transformers/transformer'
 import { LocalFilterCreator } from '../filter'
-import { generateReferenceResolverFinder, ReferenceContextStrategyName, FieldReferenceDefinition, getLookUpName, fieldNameToTypeMappingDefs, defaultFieldNameToTypeMappingDefs } from '../transformers/reference_mapping'
+import {
+  generateReferenceResolverFinder,
+  ReferenceContextStrategyName,
+  FieldReferenceDefinition,
+  getLookUpName,
+  getReferenceMappingDefs,
+} from '../transformers/reference_mapping'
 import {
   WORKFLOW_ACTION_ALERT_METADATA_TYPE, WORKFLOW_FIELD_UPDATE_METADATA_TYPE,
   WORKFLOW_FLOW_ACTION_METADATA_TYPE, WORKFLOW_OUTBOUND_MESSAGE_METADATA_TYPE,
@@ -105,7 +111,7 @@ const contextStrategyLookup: Record<
 export const addReferences = async (
   elements: Element[],
   referenceElements: ReadOnlyElementsSource,
-  defs?: FieldReferenceDefinition[]
+  defs: FieldReferenceDefinition[]
 ): Promise<void> => {
   const resolverFinder = generateReferenceResolverFinder(defs)
 
@@ -151,9 +157,10 @@ export const addReferences = async (
 const filter: LocalFilterCreator = ({ config }) => ({
   name: 'fieldReferencesFilter',
   onFetch: async elements => {
-    const refDef = config.enumFieldPermissions
-      ? defaultFieldNameToTypeMappingDefs
-      : fieldNameToTypeMappingDefs
+    const refDef = getReferenceMappingDefs({
+      enumFieldPermissions: config.enumFieldPermissions ?? false,
+      fetchProfiles: !config.fetchProfile.isFeatureEnabled('ignoreRefsInProfiles'),
+    })
     await addReferences(
       elements,
       buildElementsSourceForFetch(elements, config),

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -244,7 +244,7 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     target: { type: 'ApexPage' },
   },
   {
-    src: { field: 'apexClass', parentTypes: ['FlowApexPluginCall', 'FlowVariable', 'ProfileApexClassAccess', 'TransactionSecurityPolicy'] },
+    src: { field: 'apexClass', parentTypes: ['FlowApexPluginCall', 'FlowVariable', 'TransactionSecurityPolicy'] },
     target: { type: 'ApexClass' },
   },
   {
@@ -252,28 +252,8 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     target: { type: 'Role' },
   },
   {
-    src: { field: 'application', parentTypes: ['ProfileApplicationVisibility'] },
-    target: { type: 'CustomApplication' },
-  },
-  {
     src: { field: 'permissionSets', parentTypes: ['PermissionSetGroup', 'DelegateGroup'] },
     target: { type: 'PermissionSet' },
-  },
-  {
-    src: { field: 'layout', parentTypes: ['ProfileLayoutAssignment'] },
-    target: { type: 'Layout' },
-  },
-  {
-    src: { field: 'recordType', parentTypes: ['ProfileLayoutAssignment'] },
-    target: { type: 'RecordType' },
-  },
-  {
-    src: { field: 'flow', parentTypes: ['ProfileFlowAccess'] },
-    target: { type: 'Flow' },
-  },
-  {
-    src: { field: 'recordType', parentTypes: ['ProfileRecordTypeVisibility'] },
-    target: { type: 'RecordType' },
   },
   {
     src: { field: 'tabs', parentTypes: ['CustomApplication'] },
@@ -309,7 +289,7 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     target: { type: CUSTOM_OBJECT },
   },
   {
-    src: { field: 'object', parentTypes: ['ProfileObjectPermissions', 'FlowDynamicChoiceSet', 'FlowRecordLookup', 'FlowRecordUpdate', 'FlowRecordCreate', 'FlowRecordDelete', 'FlowStart', 'PermissionSetObjectPermissions'] },
+    src: { field: 'object', parentTypes: ['FlowDynamicChoiceSet', 'FlowRecordLookup', 'FlowRecordUpdate', 'FlowRecordCreate', 'FlowRecordDelete', 'FlowStart', 'PermissionSetObjectPermissions'] },
     target: { type: CUSTOM_OBJECT },
   },
   {
@@ -675,10 +655,41 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
 ]
 
 // Optional reference that should not be used if enumFieldPermissions config is on
-const fieldPermissionEnumDisabledExtraMappingDefs: FieldReferenceDefinition[] = [
+export const fieldPermissionEnumDisabledExtraMappingDefs: FieldReferenceDefinition[] = [
   {
     src: { field: 'field', parentTypes: ['ProfileFieldLevelSecurity'] },
     target: { type: CUSTOM_FIELD },
+  },
+]
+
+export const referencesFromProfile: FieldReferenceDefinition[] = [
+  {
+    src: { field: 'object', parentTypes: ['ProfileObjectPermissions'] },
+    target: { type: CUSTOM_OBJECT },
+  },
+  {
+    src: { field: 'apexClass', parentTypes: ['ProfileApexClassAccess'] },
+    target: { type: 'ApexClass' },
+  },
+  {
+    src: { field: 'layout', parentTypes: ['ProfileLayoutAssignment'] },
+    target: { type: 'Layout' },
+  },
+  {
+    src: { field: 'recordType', parentTypes: ['ProfileLayoutAssignment'] },
+    target: { type: 'RecordType' },
+  },
+  {
+    src: { field: 'flow', parentTypes: ['ProfileFlowAccess'] },
+    target: { type: 'Flow' },
+  },
+  {
+    src: { field: 'recordType', parentTypes: ['ProfileRecordTypeVisibility'] },
+    target: { type: 'RecordType' },
+  },
+  {
+    src: { field: 'application', parentTypes: ['ProfileApplicationVisibility'] },
+    target: { type: 'CustomApplication' },
   },
 ]
 
@@ -693,10 +704,24 @@ const fieldPermissionEnumDisabledExtraMappingDefs: FieldReferenceDefinition[] = 
  * 1. An element matching the rule is found.
  * 2. Resolving the resulting reference expression back returns the original value.
  */
-export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
+const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
   ...defaultFieldNameToTypeMappingDefs,
   ...fieldPermissionEnumDisabledExtraMappingDefs,
+  ...referencesFromProfile,
 ]
+
+export const getReferenceMappingDefs = (
+  args: {enumFieldPermissions: boolean; fetchProfiles: boolean }
+): FieldReferenceDefinition[] => {
+  let refDefs = defaultFieldNameToTypeMappingDefs
+  if (args.enumFieldPermissions) {
+    refDefs = refDefs.concat(fieldPermissionEnumDisabledExtraMappingDefs)
+  }
+  if (args.fetchProfiles) {
+    refDefs = refDefs.concat(referencesFromProfile)
+  }
+  return refDefs
+}
 
 const matchName = (name: string, matcher: string | RegExp): boolean => (
   _.isString(matcher)
@@ -756,7 +781,7 @@ export type ReferenceResolverFinder = (
  * Generates a function that filters the relevant resolvers for a given field.
  */
 export const generateReferenceResolverFinder = (
-  defs = fieldNameToTypeMappingDefs
+  defs: FieldReferenceDefinition[],
 ): ReferenceResolverFinder => {
   const referenceDefinitions = defs.map(
     def => FieldReferenceResolver.create(def)
@@ -829,4 +854,4 @@ const getLookUpNameImpl = (defs = fieldNameToTypeMappingDefs): GetLookupNameFunc
 /**
  * Translate a reference expression back to its original value before deploy.
  */
-export const getLookUpName = getLookUpNameImpl()
+export const getLookUpName = getLookUpNameImpl(fieldNameToTypeMappingDefs)

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -711,13 +711,13 @@ const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
 ]
 
 export const getReferenceMappingDefs = (
-  args: {enumFieldPermissions: boolean; fetchProfiles: boolean }
+  args: {enumFieldPermissions: boolean; otherProfileRefs: boolean }
 ): FieldReferenceDefinition[] => {
   let refDefs = defaultFieldNameToTypeMappingDefs
   if (args.enumFieldPermissions) {
     refDefs = refDefs.concat(fieldPermissionEnumDisabledExtraMappingDefs)
   }
-  if (args.fetchProfiles) {
+  if (args.otherProfileRefs) {
     refDefs = refDefs.concat(referencesFromProfile)
   }
   return refDefs

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -79,6 +79,7 @@ export type OptionalFeatures = {
   skipAliases?: boolean
   formulaDeps?: boolean
   fetchCustomObjectUsingRetrieveApi?: boolean
+  ignoreRefsInProfiles?: boolean
 }
 
 export type ChangeValidatorName = (
@@ -574,6 +575,7 @@ const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
     skipAliases: { refType: BuiltinTypes.BOOLEAN },
     formulaDeps: { refType: BuiltinTypes.BOOLEAN },
     fetchCustomObjectUsingRetrieveApi: { refType: BuiltinTypes.BOOLEAN },
+    ignoreRefsInProfiles: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -79,7 +79,7 @@ export type OptionalFeatures = {
   skipAliases?: boolean
   formulaDeps?: boolean
   fetchCustomObjectUsingRetrieveApi?: boolean
-  ignoreRefsInProfiles?: boolean
+  generateRefsInProfiles?: boolean
 }
 
 export type ChangeValidatorName = (
@@ -575,7 +575,7 @@ const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
     skipAliases: { refType: BuiltinTypes.BOOLEAN },
     formulaDeps: { refType: BuiltinTypes.BOOLEAN },
     fetchCustomObjectUsingRetrieveApi: { refType: BuiltinTypes.BOOLEAN },
-    ignoreRefsInProfiles: { refType: BuiltinTypes.BOOLEAN },
+    generateRefsInProfiles: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/salesforce-adapter/test/filters/field_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/field_references.test.ts
@@ -18,7 +18,10 @@ import { ElemID, InstanceElement, ObjectType, ReferenceExpression, Element, Buil
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import filterCreator, { addReferences } from '../../src/filters/field_references'
-import { fieldNameToTypeMappingDefs } from '../../src/transformers/reference_mapping'
+import {
+  FieldReferenceDefinition,
+  getReferenceMappingDefs,
+} from '../../src/transformers/reference_mapping'
 import { OBJECTS_PATH, SALESFORCE, CUSTOM_OBJECT, METADATA_TYPE, INSTANCE_FULL_NAME_FIELD, CUSTOM_OBJECT_ID_FIELD, API_NAME, API_NAME_SEPARATOR, WORKFLOW_ACTION_REFERENCE_METADATA_TYPE, WORKFLOW_RULE_METADATA_TYPE, CPQ_QUOTE_LINE_FIELDS, CPQ_CUSTOM_SCRIPT, CPQ_CONFIGURATION_ATTRIBUTE, CPQ_DEFAULT_OBJECT_FIELD, CPQ_LOOKUP_QUERY, CPQ_TESTED_OBJECT, CPQ_DISCOUNT_SCHEDULE, CPQ_CONSTRAINT_FIELD } from '../../src/constants'
 import { metadataType, apiName, createInstanceElement } from '../../src/transformers/transformer'
 import { CUSTOM_OBJECT_TYPE_ID } from '../../src/filters/custom_objects_to_object_type'
@@ -485,7 +488,7 @@ describe('FieldReferences filter', () => {
 
     beforeAll(async () => {
       elements = generateElements()
-      const modifiedDefs = fieldNameToTypeMappingDefs.map(def => _.omit(def, 'serializationStrategy'))
+      const modifiedDefs = getReferenceMappingDefs({ enumFieldPermissions: false, fetchProfiles: false }).map(def => _.omit(def, 'serializationStrategy'))
       await addReferences(elements, buildElementsSourceFromElements(elements), modifiedDefs)
     })
     afterAll(() => {
@@ -738,6 +741,63 @@ describe('FieldReferences filter - neighbor context strategy', () => {
       expect(instanceMissingActionForType.value.actions.name).toEqual('foo')
       expect(instanceInvalidActionType.value.actions.name).toEqual('foo')
       expect(instanceFlowRecordLookup.value.filters[1].field).toEqual('unknown')
+    })
+  })
+})
+
+describe('getReferenceMappingDefs', () => {
+  let defs: FieldReferenceDefinition[]
+
+  describe('Without any optional defs', () => {
+    beforeEach(() => {
+      defs = getReferenceMappingDefs({ enumFieldPermissions: false, fetchProfiles: false })
+    })
+    it('should not have any profile-related references', () => {
+      defs
+        .flatMap(def => def.src.parentTypes)
+        .forEach(type => expect(type).not.toInclude('Profile'))
+    })
+  })
+  describe('With profile-related optional defs', () => {
+    beforeEach(() => {
+      defs = getReferenceMappingDefs({ enumFieldPermissions: false, fetchProfiles: true })
+    })
+    it('should have profile-related references, but not FLS', () => {
+      const profileRelatedDefs = defs
+        .flatMap(def => def.src.parentTypes)
+        .filter(type => type.includes('Profile'))
+      expect(profileRelatedDefs).not.toBeEmpty()
+
+      profileRelatedDefs
+        .forEach(type => expect(type).not.toInclude('ProfileFieldLevelSecurity'))
+    })
+  })
+  describe('With FLS-related optional defs', () => {
+    beforeEach(() => {
+      defs = getReferenceMappingDefs({ enumFieldPermissions: true, fetchProfiles: false })
+    })
+    it('should have only FLS-related profile references', () => {
+      const profileRelatedDefs = defs
+        .flatMap(def => def.src.parentTypes)
+        .filter(type => type.includes('Profile'))
+      expect(profileRelatedDefs).not.toBeEmpty()
+
+      profileRelatedDefs
+        .forEach(type => expect(type).toInclude('ProfileFieldLevelSecurity'))
+    })
+  })
+  describe('With all optional defs', () => {
+    beforeEach(() => {
+      defs = getReferenceMappingDefs({ enumFieldPermissions: true, fetchProfiles: true })
+    })
+    it('should have only all profile references', () => {
+      const profileRelatedDefs = defs
+        .flatMap(def => def.src.parentTypes)
+        .filter(type => type.includes('Profile'))
+      const flsRelatedDefs = profileRelatedDefs
+        .filter(type => type.includes('ProfileFieldLevelSecurity'))
+      expect(flsRelatedDefs).not.toBeEmpty()
+      expect(profileRelatedDefs.length).toBeGreaterThan(flsRelatedDefs.length)
     })
   })
 })

--- a/packages/salesforce-adapter/test/filters/field_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/field_references.test.ts
@@ -488,7 +488,7 @@ describe('FieldReferences filter', () => {
 
     beforeAll(async () => {
       elements = generateElements()
-      const modifiedDefs = getReferenceMappingDefs({ enumFieldPermissions: false, fetchProfiles: false }).map(def => _.omit(def, 'serializationStrategy'))
+      const modifiedDefs = getReferenceMappingDefs({ enumFieldPermissions: false, otherProfileRefs: false }).map(def => _.omit(def, 'serializationStrategy'))
       await addReferences(elements, buildElementsSourceFromElements(elements), modifiedDefs)
     })
     afterAll(() => {
@@ -750,7 +750,7 @@ describe('getReferenceMappingDefs', () => {
 
   describe('Without any optional defs', () => {
     beforeEach(() => {
-      defs = getReferenceMappingDefs({ enumFieldPermissions: false, fetchProfiles: false })
+      defs = getReferenceMappingDefs({ enumFieldPermissions: false, otherProfileRefs: false })
     })
     it('should not have any profile-related references', () => {
       defs
@@ -760,7 +760,7 @@ describe('getReferenceMappingDefs', () => {
   })
   describe('With profile-related optional defs', () => {
     beforeEach(() => {
-      defs = getReferenceMappingDefs({ enumFieldPermissions: false, fetchProfiles: true })
+      defs = getReferenceMappingDefs({ enumFieldPermissions: false, otherProfileRefs: true })
     })
     it('should have profile-related references, but not FLS', () => {
       const profileRelatedDefs = defs
@@ -774,7 +774,7 @@ describe('getReferenceMappingDefs', () => {
   })
   describe('With FLS-related optional defs', () => {
     beforeEach(() => {
-      defs = getReferenceMappingDefs({ enumFieldPermissions: true, fetchProfiles: false })
+      defs = getReferenceMappingDefs({ enumFieldPermissions: true, otherProfileRefs: false })
     })
     it('should have only FLS-related profile references', () => {
       const profileRelatedDefs = defs
@@ -788,7 +788,7 @@ describe('getReferenceMappingDefs', () => {
   })
   describe('With all optional defs', () => {
     beforeEach(() => {
-      defs = getReferenceMappingDefs({ enumFieldPermissions: true, fetchProfiles: true })
+      defs = getReferenceMappingDefs({ enumFieldPermissions: true, otherProfileRefs: true })
     })
     it('should have only all profile references', () => {
       const profileRelatedDefs = defs


### PR DESCRIPTION
Re-introduce the change from SALTO-4402 (https://github.com/salto-io/salto/pull/4537), but make them disabled by default.

From original PR: Fetching profiles takes a very long time. One part of that time is resolving references on the many, many fields that each profile has (basically the number of fields in a single profile = O(number of fields in all custom objects)).
So let's not resolve references in profiles by default, unless the user explicitly asks us to.

---


---
_Release Notes_: 
Salesforce: add an adapter fetch configuration that controls reference generation for profiles

---
_User Notifications_: 
N/A
