### PR TITLE
SALTO-4214: change zendesk errors to return saltoErrors instead of throwing them

### DIFF
--- a/packages/adapter-api/src/error.ts
+++ b/packages/adapter-api/src/error.ts
@@ -33,8 +33,8 @@ export type SaltoElementError = SaltoError & {
 export const isSaltoElementError = (error: SaltoError | SaltoElementError):
     error is SaltoElementError => 'elemID' in error
 
-export const isError = (error: unknown): error is SaltoError | Error =>
-  (_.isObject(error) && ('message' in error) && ('severity' in error)) || _.isError(error)
+export const isSaltoError = (error: unknown): error is SaltoError =>
+  (_.isObject(error) && ('message' in error) && ('severity' in error))
 
 export const createSaltoElementErrorFromError = ({
   error,

--- a/packages/adapter-api/src/error.ts
+++ b/packages/adapter-api/src/error.ts
@@ -32,6 +32,26 @@ export type SaltoElementError = SaltoError & {
 export const isSaltoElementError = (error: SaltoError | SaltoElementError):
     error is SaltoElementError => 'elemID' in error
 
+export const createSaltoElementErrorFromError = ({
+  error,
+  severity,
+  elemID,
+}: {
+    error: Error
+    severity: SeverityLevel
+    elemID: ElemID
+}): SaltoElementError => ({ message: error.message, severity, elemID })
+
+export const createSaltoElementError = ({
+  message,
+  severity,
+  elemID,
+}: {
+    message: string
+    severity: SeverityLevel
+    elemID: ElemID
+}): SaltoElementError => ({ message, severity, elemID })
+
 export class CredentialError extends Error {}
 
 export const isCredentialError = (error: unknown): error is CredentialError =>

--- a/packages/adapter-api/src/error.ts
+++ b/packages/adapter-api/src/error.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import _ from 'lodash'
 import { ElemID } from './element_id'
 
 export type SeverityLevel = 'Error' | 'Warning' | 'Info'
@@ -31,6 +32,9 @@ export type SaltoElementError = SaltoError & {
 
 export const isSaltoElementError = (error: SaltoError | SaltoElementError):
     error is SaltoElementError => 'elemID' in error
+
+export const isError = (error: unknown): error is SaltoError | Error =>
+  (_.isObject(error) && ('message' in error) && ('severity' in error)) || _.isError(error)
 
 export const createSaltoElementErrorFromError = ({
   error,

--- a/packages/adapter-api/test/error.test.ts
+++ b/packages/adapter-api/test/error.test.ts
@@ -18,9 +18,11 @@ import {
   createSaltoElementError,
   createSaltoElementErrorFromError,
   CredentialError,
-  isCredentialError,
+  isCredentialError, isError,
 } from '../src/error'
 import { ElemID } from '../src/element_id'
+import { toChange } from '../src/change'
+import { InstanceElement, ObjectType } from '../src/elements'
 
 describe('is credential error', () => {
   it('should return false', () => {
@@ -53,5 +55,22 @@ describe('create saltoElementError', () => {
       severity: 'Error',
       elemID: elemId,
     })
+  })
+})
+
+describe('isError', () => {
+  const elemID = new ElemID('adapter', 'test')
+  const instance = new InstanceElement('inst', new ObjectType({ elemID }), {})
+  const change = toChange({ after: instance })
+  it('should return false for non saltoErrors', () => {
+    expect(isError(elemID)).toBeFalsy()
+    expect(isError(instance)).toBeFalsy()
+    expect(isError(change)).toBeFalsy()
+  })
+  it('should return true for saltoErrors', () => {
+    expect(isError(createSaltoElementError({ message: 'test', severity: 'Error', elemID }))).toBeTruthy()
+  })
+  it('should return true for Errors', () => {
+    expect(isError(new Error('test'))).toBeTruthy()
   })
 })

--- a/packages/adapter-api/test/error.test.ts
+++ b/packages/adapter-api/test/error.test.ts
@@ -18,7 +18,7 @@ import {
   createSaltoElementError,
   createSaltoElementErrorFromError,
   CredentialError,
-  isCredentialError, isError,
+  isCredentialError, isSaltoError,
 } from '../src/error'
 import { ElemID } from '../src/element_id'
 import { toChange } from '../src/change'
@@ -58,19 +58,19 @@ describe('create saltoElementError', () => {
   })
 })
 
-describe('isError', () => {
+describe('isSaltoError', () => {
   const elemID = new ElemID('adapter', 'test')
   const instance = new InstanceElement('inst', new ObjectType({ elemID }), {})
   const change = toChange({ after: instance })
   it('should return false for non saltoErrors', () => {
-    expect(isError(elemID)).toBeFalsy()
-    expect(isError(instance)).toBeFalsy()
-    expect(isError(change)).toBeFalsy()
+    expect(isSaltoError(elemID)).toBeFalsy()
+    expect(isSaltoError(instance)).toBeFalsy()
+    expect(isSaltoError(change)).toBeFalsy()
   })
   it('should return true for saltoErrors', () => {
-    expect(isError(createSaltoElementError({ message: 'test', severity: 'Error', elemID }))).toBeTruthy()
+    expect(isSaltoError(createSaltoElementError({ message: 'test', severity: 'Error', elemID }))).toBeTruthy()
   })
-  it('should return true for Errors', () => {
-    expect(isError(new Error('test'))).toBeTruthy()
+  it('should return false for Errors', () => {
+    expect(isSaltoError(new Error('test'))).toBeFalsy()
   })
 })

--- a/packages/adapter-api/test/error.test.ts
+++ b/packages/adapter-api/test/error.test.ts
@@ -14,7 +14,13 @@
 * limitations under the License.
 */
 
-import { CredentialError, isCredentialError } from '../src/error'
+import {
+  createSaltoElementError,
+  createSaltoElementErrorFromError,
+  CredentialError,
+  isCredentialError,
+} from '../src/error'
+import { ElemID } from '../src/element_id'
 
 describe('is credential error', () => {
   it('should return false', () => {
@@ -22,5 +28,30 @@ describe('is credential error', () => {
   })
   it('should return true', () => {
     expect(isCredentialError(new CredentialError('test'))).toBeTruthy()
+  })
+})
+describe('create saltoElementError', () => {
+  const elemId = new ElemID('adapter', 'test')
+  it('should create correctly from error', () => {
+    expect(createSaltoElementErrorFromError({
+      error: new Error('test'),
+      severity: 'Error',
+      elemID: elemId,
+    })).toEqual({
+      message: 'test',
+      severity: 'Error',
+      elemID: elemId,
+    })
+  })
+  it('should create correctly from message', () => {
+    expect(createSaltoElementError({
+      message: 'test',
+      severity: 'Error',
+      elemID: elemId,
+    })).toEqual({
+      message: 'test',
+      severity: 'Error',
+      elemID: elemId,
+    })
   })
 })

--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -639,7 +639,6 @@ export default class ZendeskAdapter implements AdapterOperations {
   private async getGuideDeployResults(
     subdomainToClient: Record<string, ZendeskClient>,
     subdomainToGuideChanges: Record<string, Change<InstanceElement>[]>,
-    saltoErrors: SaltoError[]
   ): Promise<DeployResult[]> {
     try {
       return await awu(Object.entries(subdomainToClient))
@@ -662,7 +661,7 @@ export default class ZendeskAdapter implements AdapterOperations {
             if (!isSaltoError(e)) {
               throw e
             }
-            saltoErrors.push(e)
+            brandDeployResults.errors = brandDeployResults.errors.concat([e])
           }
           return {
             appliedChanges: guideChangesBeforeRestore,
@@ -762,7 +761,7 @@ export default class ZendeskAdapter implements AdapterOperations {
     const subdomainToClient = Object.fromEntries(subdomainsList
       .filter(subdomain => subdomainToGuideChanges[subdomain] !== undefined)
       .map(subdomain => ([subdomain, this.getClientBySubdomain(subdomain, true)])))
-    const guideDeployResults = await this.getGuideDeployResults(subdomainToClient, subdomainToGuideChanges, saltoErrors)
+    const guideDeployResults = await this.getGuideDeployResults(subdomainToClient, subdomainToGuideChanges)
     const allChangesBeforeRestore = appliedChangesBeforeRestore.concat(
       guideDeployResults.flatMap(result => result.appliedChanges)
     )

--- a/packages/zendesk-adapter/src/deployment.ts
+++ b/packages/zendesk-adapter/src/deployment.ts
@@ -20,7 +20,7 @@ import {
   DeployResult,
   getChangeData,
   InstanceElement,
-  isAdditionChange, isError,
+  isAdditionChange, isSaltoError,
   SaltoError,
   Values,
 } from '@salto-io/adapter-api'
@@ -155,12 +155,12 @@ export const deployChange = async (
 const deployChangesHelper = async <T extends Change<ChangeDataType>>(
   change: T,
   deployChangeFunc: (change: T) => Promise<void | T[]>
-): Promise<T[] | T | Error | SaltoError> => {
+): Promise<T[] | T | SaltoError> => {
   try {
     const res = await deployChangeFunc(change)
     return res !== undefined ? res : change
   } catch (err) {
-    if (!isError(err)) {
+    if (!isSaltoError(err)) {
       throw err
     }
     return err
@@ -174,7 +174,7 @@ export const deployChanges = async <T extends Change<ChangeDataType>>(
   const result = await Promise.all(
     changes.map(async change => deployChangesHelper(change, deployChangeFunc))
   )
-  const [errors, appliedChanges] = _.partition(result.flat(), isError)
+  const [errors, appliedChanges] = _.partition(result.flat(), isSaltoError)
   return { errors, appliedChanges }
 }
 
@@ -183,7 +183,7 @@ export const deployChangesSequentially = async <T extends Change<ChangeDataType>
   deployChangeFunc: (change: T) => Promise<void | T[]>
 ): Promise<DeployResult> => {
   const result = await awu(changes).map(async change => deployChangesHelper(change, deployChangeFunc)).toArray()
-  const [errors, appliedChanges] = _.partition(result.flat(), isError)
+  const [errors, appliedChanges] = _.partition(result.flat(), isSaltoError)
   return { errors, appliedChanges }
 }
 

--- a/packages/zendesk-adapter/src/filters/account_settings.ts
+++ b/packages/zendesk-adapter/src/filters/account_settings.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import {
-  Change, getChangeData, InstanceElement,
+  Change, getChangeData, InstanceElement, SaltoError,
 } from '@salto-io/adapter-api'
 import { FilterCreator } from '../filter'
 import { deployChange, deployChanges } from '../deployment'
@@ -37,7 +37,10 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
         deployResult: {
           appliedChanges: [],
           errors: [
-            new Error(`${ACCOUNT_SETTING_TYPE_NAME} element is a singleton and should have only on instance. Found multiple: ${accountSettingChanges.length}`),
+            {
+              message: `${ACCOUNT_SETTING_TYPE_NAME} element is a singleton and should have only on instance. Found multiple: ${accountSettingChanges.length}`,
+              severity: 'Error',
+            } as SaltoError,
           ],
         },
         leftoverChanges,

--- a/packages/zendesk-adapter/src/filters/article/article_body.ts
+++ b/packages/zendesk-adapter/src/filters/article/article_body.ts
@@ -191,6 +191,7 @@ export const prepRef = (part: ReferenceExpression): TemplatePart => {
     return part.value.value.id.toString()
   }
   if (!_.isString(part.value)) {
+    // caught in try catch block
     throw new Error(`Received an invalid value inside a template expression ${part.elemID.getFullName()}: ${safeJsonStringify(part.value)}`)
   }
   return part.value

--- a/packages/zendesk-adapter/src/filters/article/utils.ts
+++ b/packages/zendesk-adapter/src/filters/article/utils.ts
@@ -26,6 +26,7 @@ import {
 } from '@salto-io/adapter-utils'
 import { collections, promises } from '@salto-io/lowerdash'
 import {
+  createSaltoElementError,
   InstanceElement,
   isReferenceExpression,
   isStaticFile,
@@ -240,6 +241,11 @@ export const updateArticleTranslationBody = async ({
         )
       } catch (e) {
         log.error(`Error serializing article translation body in Deployment for ${translationInstance.elemID.getFullName()}: ${e}, stack: ${e.stack}`)
+        throw createSaltoElementError({
+          message: `Error serializing article translation body in Deployment for ${translationInstance.elemID.getFullName()}: ${e}, stack: ${e.stack}`,
+          severity: 'Error',
+          elemID: translationInstance.elemID,
+        })
       }
       await client.put({
         url: `/api/v2/help_center/articles/${articleValues?.id}/translations/${translationInstance.value.value.locale.value.value.locale}`,

--- a/packages/zendesk-adapter/src/filters/article/utils.ts
+++ b/packages/zendesk-adapter/src/filters/article/utils.ts
@@ -192,7 +192,7 @@ export const createUnassociatedAttachment = async (
     }
     attachmentInstance.value.id = createdAttachment[0].id
   } catch (err) {
-    throw getZendeskError(attachmentInstance.elemID, err)
+    throw getZendeskError(attachmentInstance.elemID, err) // caught in adapter.ts
   }
 }
 
@@ -241,7 +241,7 @@ export const updateArticleTranslationBody = async ({
         )
       } catch (e) {
         log.error(`Error serializing article translation body in Deployment for ${translationInstance.elemID.getFullName()}: ${e}, stack: ${e.stack}`)
-        throw createSaltoElementError({
+        throw createSaltoElementError({ // caught in adapter.ts
           message: `Error serializing article translation body in Deployment for ${translationInstance.elemID.getFullName()}: ${e}, stack: ${e.stack}`,
           severity: 'Error',
           elemID: translationInstance.elemID,

--- a/packages/zendesk-adapter/src/filters/brand_logo.ts
+++ b/packages/zendesk-adapter/src/filters/brand_logo.ts
@@ -24,8 +24,7 @@ import { elements as elementsUtils } from '@salto-io/adapter-components'
 import { naclCase, safeJsonStringify, getParent, normalizeFilePathPart, pathNaclCase, elementExpressionStringifyReplacer } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import FormData from 'form-data'
-import { collections } from '@salto-io/lowerdash'
-import { isDefined } from '@salto-io/lowerdash/dist/src/values'
+import { collections, values } from '@salto-io/lowerdash'
 import ZendeskClient from '../client/client'
 import { BRAND_LOGO_TYPE_NAME, BRAND_TYPE_NAME, ZENDESK } from '../constants'
 import { getZendeskError } from '../errors'
@@ -239,7 +238,7 @@ const filterCreator: FilterCreator = ({ client }) => ({
         }
         return change
       })
-      .filter(isDefined)
+      .filter(values.isDefined)
       .toArray()
 
     return {

--- a/packages/zendesk-adapter/src/filters/brand_logo.ts
+++ b/packages/zendesk-adapter/src/filters/brand_logo.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import Joi from 'joi'
 import {
   BuiltinTypes, Change, CORE_ANNOTATIONS, ElemID, getChangeData, InstanceElement,
-  isAdditionOrModificationChange, isError, isInstanceElement, isStaticFile, ObjectType,
+  isAdditionOrModificationChange, isSaltoError, isInstanceElement, isStaticFile, ObjectType,
   ReferenceExpression, SaltoElementError, SaltoError, StaticFile,
 } from '@salto-io/adapter-api'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
@@ -237,8 +237,8 @@ const filterCreator: FilterCreator = ({ client }) => ({
 
     const [deployLogoErrors, successfulChanges] = _.partition(
       deployLogoResults,
-      isError,
-    ) as [(SaltoError | Error)[], Change[]]
+      isSaltoError,
+    ) as [SaltoError[], Change[]]
 
     return {
       deployResult: {

--- a/packages/zendesk-adapter/src/filters/business_hours_schedule.ts
+++ b/packages/zendesk-adapter/src/filters/business_hours_schedule.ts
@@ -65,7 +65,7 @@ Promise<void> => {
           data: { workweek: { intervals } },
         })
       } catch (e) {
-        throw getZendeskError(changedElement.elemID.createNestedID('intervals'), e)
+        throw getZendeskError(changedElement.elemID.createNestedID('intervals'), e) // caught in deployChanges
       }
     } else {
       log.error(`Failed to deploy intervals on ${changedElement.elemID.getFullName()} since the intervals were in invalid format`)

--- a/packages/zendesk-adapter/src/filters/custom_statuses.ts
+++ b/packages/zendesk-adapter/src/filters/custom_statuses.ts
@@ -20,7 +20,7 @@ import {
   getChangeData,
   InstanceElement,
   isInstanceChange,
-  isInstanceElement, ObjectType,
+  isInstanceElement, ObjectType, SaltoElementError,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
@@ -132,7 +132,12 @@ const filterCreator: FilterCreator = ({ client, config }) => ({
           data: { ids: defaults },
         })
       } catch (e) {
-        error.push(new Error(e))
+        const saltoError: SaltoElementError = {
+          ...e,
+          severity: 'Error',
+          elemID: defaultCustomStatusChange.elemID,
+        }
+        error.push(saltoError)
       }
     }
     const appliedChanges = _.isEmpty(error) ? defaultCustomStatusChanges : []

--- a/packages/zendesk-adapter/src/filters/custom_statuses.ts
+++ b/packages/zendesk-adapter/src/filters/custom_statuses.ts
@@ -15,12 +15,12 @@
 */
 import {
   BuiltinTypes,
-  Change, DeployResult,
+  Change, createSaltoElementErrorFromError, DeployResult,
   Element, ElemID,
   getChangeData,
   InstanceElement,
   isInstanceChange,
-  isInstanceElement, ObjectType, SaltoElementError,
+  isInstanceElement, ObjectType,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
@@ -132,12 +132,11 @@ const filterCreator: FilterCreator = ({ client, config }) => ({
           data: { ids: defaults },
         })
       } catch (e) {
-        const saltoError: SaltoElementError = {
-          ...e,
+        error.push(createSaltoElementErrorFromError({
+          error: e,
           severity: 'Error',
           elemID: defaultCustomStatusChange.elemID,
-        }
-        error.push(saltoError)
+        }))
       }
     }
     const appliedChanges = _.isEmpty(error) ? defaultCustomStatusChanges : []

--- a/packages/zendesk-adapter/src/filters/guide_order/guide_order_utils.ts
+++ b/packages/zendesk-adapter/src/filters/guide_order/guide_order_utils.ts
@@ -26,7 +26,7 @@ import {
   ElemID,
   ListType,
   BuiltinTypes,
-  SaltoElementError,
+  SaltoElementError, createSaltoElementError,
 } from '@salto-io/adapter-api'
 import { collections, values as lowerDashValues } from '@salto-io/lowerdash'
 import _ from 'lodash'
@@ -134,12 +134,11 @@ const updateElementPositions = async (
       const childUpdateApi = config[API_DEFINITIONS_CONFIG].types[childType].deployRequests?.modify
 
       if (childUpdateApi === undefined) {
-        const saltoError: SaltoElementError = {
+        return createSaltoElementError({
           message: `No endpoint of type modify for ${child.elemID.typeName}`,
           severity: 'Error',
           elemID: getChangeData(change).elemID,
-        }
-        return saltoError
+        })
       }
 
       // Send an api request to update the positions of the elements in the order list

--- a/packages/zendesk-adapter/src/filters/macro_attachments.ts
+++ b/packages/zendesk-adapter/src/filters/macro_attachments.ts
@@ -18,7 +18,7 @@ import Joi from 'joi'
 import FormData from 'form-data'
 import {
   BuiltinTypes, Change, CORE_ANNOTATIONS, ElemID, getChangeData, InstanceElement,
-  isInstanceElement, isRemovalChange, isStaticFile, ObjectType, ReferenceExpression, StaticFile,
+  isInstanceElement, isRemovalChange, isStaticFile, ObjectType, ReferenceExpression, SaltoElementError, StaticFile,
 } from '@salto-io/adapter-api'
 import { normalizeFilePathPart, naclCase, elementExpressionStringifyReplacer,
   resolveChangeElement, safeJsonStringify, pathNaclCase, references } from '@salto-io/adapter-utils'
@@ -79,7 +79,12 @@ const replaceAttachmentId = (
   if (!isArrayOfRefExprToInstances(attachments)) {
     log.error(`Failed to deploy macro because its attachment field has an invalid format: ${
       safeJsonStringify(attachments, elementExpressionStringifyReplacer)}`)
-    throw new Error('Failed to deploy macro because its attachment field has an invalid format')
+    const saltoError: SaltoElementError = {
+      message: 'Failed to deploy macro because its attachment field has an invalid format',
+      severity: 'Error',
+      elemID: parentInstance.elemID,
+    }
+    throw saltoError
   }
   parentInstance.value[ATTACHMENTS_FIELD_NAME] = attachments
     .map(ref => {
@@ -235,9 +240,14 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
           appliedChanges: [],
           errors: childrenChanges
             .map(getChangeData)
-            .map(e => new Error(
-              `Failed to update ${e.elemID.getFullName()} since it has no valid parent`
-            )),
+            .map(e => {
+              const saltoError: SaltoElementError = {
+                message: `Failed to update ${e.elemID.getFullName()} since it has no valid parent`,
+                severity: 'Error',
+                elemID: e.elemID,
+              }
+              return saltoError
+            }),
         },
         leftoverChanges,
       }
@@ -271,9 +281,14 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
           appliedChanges: [],
           errors: [...parentChanges
             .map(getChangeData)
-            .map(e => new Error(
-              `Failed to update ${e.elemID.getFullName()} since the deployment of its attachments failed`
-            )),
+            .map(e => {
+              const saltoError: SaltoElementError = {
+                message: `Failed to update ${e.elemID.getFullName()} since the deployment of its attachments failed`,
+                severity: 'Error',
+                elemID: e.elemID,
+              }
+              return saltoError
+            }),
           ...attachmentDeployResult.errors],
         },
         leftoverChanges,

--- a/packages/zendesk-adapter/src/filters/organization_field.ts
+++ b/packages/zendesk-adapter/src/filters/organization_field.ts
@@ -45,9 +45,11 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
           appliedChanges: [],
           errors: childrenChanges
             .map(getChangeData)
-            .map(e => new Error(
-              `Failed to update ${e.elemID.getFullName()} since it has no valid parent`
-            )),
+            .map(e => ({
+              message: `Failed to update ${e.elemID.getFullName()} since it has no valid parent`,
+              severity: 'Error',
+              elemID: e.elemID,
+            })),
         },
         leftoverChanges,
       }

--- a/packages/zendesk-adapter/src/filters/organizations.ts
+++ b/packages/zendesk-adapter/src/filters/organizations.ts
@@ -105,12 +105,17 @@ export const getOrganizationsByIds = async (
     _.chunk(organizationIds, 100) // The api limits to 100 ids in each request
       .map(async organizationChunk => {
         const url = `/api/v2/organizations/show_many?ids=${organizationChunk.join(',')}`
-        const result = await client.getSinglePage({ url })
-        if (!isOrganizationsResponse(result.data)) {
-          log.error('Invalid organizations response')
+        try {
+          const result = await client.getSinglePage({ url })
+          if (!isOrganizationsResponse(result.data)) {
+            log.error('Invalid organizations response')
+            return undefined
+          }
+          return result.data
+        } catch (e) {
+          log.error(`Invalid organizations response, with error: ${e}`)
           return undefined
         }
-        return result.data
       })
   )).filter(isDefined)
 

--- a/packages/zendesk-adapter/src/filters/organizations.ts
+++ b/packages/zendesk-adapter/src/filters/organizations.ts
@@ -105,17 +105,12 @@ export const getOrganizationsByIds = async (
     _.chunk(organizationIds, 100) // The api limits to 100 ids in each request
       .map(async organizationChunk => {
         const url = `/api/v2/organizations/show_many?ids=${organizationChunk.join(',')}`
-        try {
-          const result = await client.getSinglePage({ url })
-          if (!isOrganizationsResponse(result.data)) {
-            log.error('Invalid organizations response')
-            return undefined
-          }
-          return result.data
-        } catch (e) {
-          log.error(`Invalid organizations response, with error: ${e}`)
+        const result = await client.getSinglePage({ url })
+        if (!isOrganizationsResponse(result.data)) {
+          log.error('Invalid organizations response')
           return undefined
         }
+        return result.data
       })
   )).filter(isDefined)
 

--- a/packages/zendesk-adapter/src/filters/reorder/creator.ts
+++ b/packages/zendesk-adapter/src/filters/reorder/creator.ts
@@ -15,8 +15,21 @@
 */
 import _ from 'lodash'
 import {
-  Element, isInstanceElement, InstanceElement, ObjectType, ElemID, ListType, isObjectType,
-  BuiltinTypes, ReferenceExpression, Change, getChangeData, isModificationChange, isInstanceChange,
+  Element,
+  isInstanceElement,
+  InstanceElement,
+  ObjectType,
+  ElemID,
+  ListType,
+  isObjectType,
+  BuiltinTypes,
+  ReferenceExpression,
+  Change,
+  getChangeData,
+  isModificationChange,
+  isInstanceChange,
+  SaltoElementError,
+  SaltoError, isSaltoElementError,
 } from '@salto-io/adapter-api'
 import { elements as elementsUtils, config as configUtils } from '@salto-io/adapter-components'
 import { applyFunctionToChangeData, pathNaclCase, safeJsonStringify, elementExpressionStringifyReplacer } from '@salto-io/adapter-utils'
@@ -147,17 +160,24 @@ export const createReorderFilterCreator = (
       }
       const [change] = relevantChanges
       if (!isModificationChange(change)) {
-        throw new Error(
-          `only modify change is allowed on ${orderTypeName}. Found ${change.action} action`,
-        )
+        const saltoError: SaltoElementError = {
+          message: `only modify change is allowed on ${orderTypeName}. Found ${change.action} action`,
+          severity: 'Error',
+          elemID: getChangeData(change).elemID,
+        }
+        throw saltoError
       }
       await deployFunc(change, client, config[API_DEFINITIONS_CONFIG])
     } catch (err) {
-      if (!_.isError(err)) {
+      if (!(_.isError(err) || isSaltoElementError(err))) {
         throw err
       }
+      const saltoError: SaltoElementError | SaltoError = {
+        ...err,
+        severity: 'Error',
+      }
       return {
-        deployResult: { appliedChanges: [], errors: [err] },
+        deployResult: { appliedChanges: [], errors: [saltoError] },
         leftoverChanges,
       }
     }
@@ -178,7 +198,12 @@ export const deployFuncCreator = (fieldName: string): DeployFuncType =>
     const instance = getChangeData(clonedChange)
     const { ids } = instance.value
     if (!idsAreNumbers(ids)) {
-      throw new Error(`Not all the ids of ${instance.elemID.getFullName()} are numbers: ${safeJsonStringify(ids, elementExpressionStringifyReplacer)}`)
+      const saltoError: SaltoElementError = {
+        message: `Not all the ids of ${instance.elemID.getFullName()} are numbers: ${safeJsonStringify(ids, elementExpressionStringifyReplacer)}`,
+        severity: 'Error',
+        elemID: getChangeData(change).elemID,
+      }
+      throw saltoError
     }
     const idsWithPositions = ids.map((id, position) => ({ id, position: position + 1 }))
     instance.value[fieldName] = idsWithPositions

--- a/packages/zendesk-adapter/src/filters/reorder/creator.ts
+++ b/packages/zendesk-adapter/src/filters/reorder/creator.ts
@@ -29,7 +29,7 @@ import {
   isModificationChange,
   isInstanceChange,
   SaltoElementError,
-  SaltoError, isSaltoElementError, createSaltoElementError,
+  SaltoError, createSaltoElementError, isError,
 } from '@salto-io/adapter-api'
 import { elements as elementsUtils, config as configUtils } from '@salto-io/adapter-components'
 import { applyFunctionToChangeData, pathNaclCase, safeJsonStringify, elementExpressionStringifyReplacer } from '@salto-io/adapter-utils'
@@ -168,7 +168,7 @@ export const createReorderFilterCreator = (
       }
       await deployFunc(change, client, config[API_DEFINITIONS_CONFIG])
     } catch (err) {
-      if (!(_.isError(err) || isSaltoElementError(err))) {
+      if (!isError(err)) {
         throw err
       }
       const saltoError: SaltoElementError | SaltoError = {

--- a/packages/zendesk-adapter/src/filters/reorder/creator.ts
+++ b/packages/zendesk-adapter/src/filters/reorder/creator.ts
@@ -29,7 +29,7 @@ import {
   isModificationChange,
   isInstanceChange,
   SaltoElementError,
-  SaltoError, isSaltoElementError,
+  SaltoError, isSaltoElementError, createSaltoElementError,
 } from '@salto-io/adapter-api'
 import { elements as elementsUtils, config as configUtils } from '@salto-io/adapter-components'
 import { applyFunctionToChangeData, pathNaclCase, safeJsonStringify, elementExpressionStringifyReplacer } from '@salto-io/adapter-utils'
@@ -160,12 +160,11 @@ export const createReorderFilterCreator = (
       }
       const [change] = relevantChanges
       if (!isModificationChange(change)) {
-        const saltoError: SaltoElementError = {
+        throw createSaltoElementError({
           message: `only modify change is allowed on ${orderTypeName}. Found ${change.action} action`,
           severity: 'Error',
           elemID: getChangeData(change).elemID,
-        }
-        throw saltoError
+        })
       }
       await deployFunc(change, client, config[API_DEFINITIONS_CONFIG])
     } catch (err) {
@@ -198,12 +197,11 @@ export const deployFuncCreator = (fieldName: string): DeployFuncType =>
     const instance = getChangeData(clonedChange)
     const { ids } = instance.value
     if (!idsAreNumbers(ids)) {
-      const saltoError: SaltoElementError = {
+      throw createSaltoElementError({
         message: `Not all the ids of ${instance.elemID.getFullName()} are numbers: ${safeJsonStringify(ids, elementExpressionStringifyReplacer)}`,
         severity: 'Error',
         elemID: getChangeData(change).elemID,
-      }
-      throw saltoError
+      })
     }
     const idsWithPositions = ids.map((id, position) => ({ id, position: position + 1 }))
     instance.value[fieldName] = idsWithPositions

--- a/packages/zendesk-adapter/src/filters/reorder/trigger.ts
+++ b/packages/zendesk-adapter/src/filters/reorder/trigger.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import Joi from 'joi'
 import {
   getChangeData, InstanceElement, isInstanceElement, isObjectType, Element, ReferenceExpression,
-  ObjectType, ElemID, ListType, BuiltinTypes, SaltoElementError,
+  ObjectType, ElemID, ListType, BuiltinTypes, createSaltoElementError,
 } from '@salto-io/adapter-api'
 import { applyFunctionToChangeData, pathNaclCase } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
@@ -59,12 +59,11 @@ const deployFunc: DeployFuncType = async (change, client, apiDefinitions) => {
   const instance = getChangeData(clonedChange)
   const { order } = instance.value
   if (!areTriggerOrderEntries(order)) {
-    const saltoError: SaltoElementError = {
+    throw createSaltoElementError({
       message: 'trigger_order\' order field has an invalid format',
       severity: 'Error',
       elemID: getChangeData(change).elemID,
-    }
-    throw saltoError
+    })
   }
   const triggerCategories = order
     .map(entry => entry.category)

--- a/packages/zendesk-adapter/src/filters/reorder/trigger.ts
+++ b/packages/zendesk-adapter/src/filters/reorder/trigger.ts
@@ -59,7 +59,7 @@ const deployFunc: DeployFuncType = async (change, client, apiDefinitions) => {
   const instance = getChangeData(clonedChange)
   const { order } = instance.value
   if (!areTriggerOrderEntries(order)) {
-    throw createSaltoElementError({
+    throw createSaltoElementError({ // caught by try block in creator.ts
       message: 'trigger_order\' order field has an invalid format',
       severity: 'Error',
       elemID: getChangeData(change).elemID,

--- a/packages/zendesk-adapter/src/filters/reorder/trigger.ts
+++ b/packages/zendesk-adapter/src/filters/reorder/trigger.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import Joi from 'joi'
 import {
   getChangeData, InstanceElement, isInstanceElement, isObjectType, Element, ReferenceExpression,
-  ObjectType, ElemID, ListType, BuiltinTypes,
+  ObjectType, ElemID, ListType, BuiltinTypes, SaltoElementError,
 } from '@salto-io/adapter-api'
 import { applyFunctionToChangeData, pathNaclCase } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
@@ -59,7 +59,12 @@ const deployFunc: DeployFuncType = async (change, client, apiDefinitions) => {
   const instance = getChangeData(clonedChange)
   const { order } = instance.value
   if (!areTriggerOrderEntries(order)) {
-    throw new Error('trigger_order\' order field has an invalid format')
+    const saltoError: SaltoElementError = {
+      message: 'trigger_order\' order field has an invalid format',
+      severity: 'Error',
+      elemID: getChangeData(change).elemID,
+    }
+    throw saltoError
   }
   const triggerCategories = order
     .map(entry => entry.category)

--- a/packages/zendesk-adapter/src/filters/webhook.ts
+++ b/packages/zendesk-adapter/src/filters/webhook.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import {
-  Change,
+  Change, createSaltoElementError,
   getChangeData,
   InstanceElement,
   isAdditionOrModificationChange,
@@ -67,10 +67,12 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
             instance.value.authentication.type
           ]
           if (placeholder === undefined) {
-            throw new Error(
-              `Unknown auth type was found for webhook ${instance.elemID.getFullName()}: ${
+            throw createSaltoElementError({ // caught by deployChanges
+              message: `Unknown auth type was found for webhook ${instance.elemID.getFullName()}: ${
                 instance.value.authentication.type}`,
-            )
+              severity: 'Error',
+              elemID: getChangeData(change).elemID,
+            })
           }
           instance.value.authentication.data = placeholder
         }

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -1214,7 +1214,11 @@ describe('adapter', () => {
       })
 
       expect(deployRes.errors).toEqual([
-        new Error('some error'),
+        {
+          message: 'some error',
+          severity: 'Error',
+          elemID: new InstanceElement('inst2', groupType).elemID,
+        },
       ])
     })
     it('should have change validator', () => {

--- a/packages/zendesk-adapter/test/errors.test.ts
+++ b/packages/zendesk-adapter/test/errors.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { EOL } from 'os'
-import { ElemID } from '@salto-io/adapter-api'
+import { createSaltoElementError, ElemID } from '@salto-io/adapter-api'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { ZENDESK } from '../src/constants'
 import { getZendeskError } from '../src/errors'
@@ -29,21 +29,33 @@ describe('errors', () => {
           'err',
           { data: 'err' as unknown as clientUtils.ResponseValue, status: 400 }
         )
-      )).toEqual(new Error(`Deployment of ${elemId.typeName} instance ${elemId.name} failed: Error: err`))
+      )).toEqual(createSaltoElementError({
+        message: `Deployment of ${elemId.typeName} instance ${elemId.name} failed: Error: err`,
+        severity: 'Error',
+        elemID: elemId,
+      }))
     })
     it('should return the correct error message', async () => {
       const data = { error: 'err' }
       expect(getZendeskError(
         elemId,
         new clientUtils.HTTPError('err', { data, status: 400 })
-      )).toEqual(new Error(`Deployment of ${elemId.typeName} instance ${elemId.name} failed:${EOL}Error: err${EOL}{${EOL}  "error": "err"${EOL}}`))
+      )).toEqual(createSaltoElementError({
+        message: `Deployment of ${elemId.typeName} instance ${elemId.name} failed:${EOL}Error: err${EOL}{${EOL}  "error": "err"${EOL}}`,
+        severity: 'Error',
+        elemID: elemId,
+      }))
     })
     it('should return the correct error message for 403 error', async () => {
       const data = { errors: [{ title: 'one', detail: 'one detail' }, { title: 'two', detail: 'two detail' }] }
       expect(getZendeskError(
         elemId,
         new clientUtils.HTTPError('err', { data, status: 403 })
-      )).toEqual(new Error(`Deployment of ${elemId.typeName} instance ${elemId.name} failed:${EOL}${EOL}Error details:${EOL}* Title: one${EOL}  Detail: one detail${EOL}${EOL}* Title: two${EOL}  Detail: two detail${EOL}`))
+      )).toEqual(createSaltoElementError({
+        message: `Deployment of ${elemId.typeName} instance ${elemId.name} failed:${EOL}${EOL}Error details:${EOL}* Title: one${EOL}  Detail: one detail${EOL}${EOL}* Title: two${EOL}  Detail: two detail${EOL}`,
+        severity: 'Error',
+        elemID: elemId,
+      }))
     })
     it('should return the correct error message for 422 error', async () => {
       const data = {
@@ -56,14 +68,22 @@ describe('errors', () => {
       expect(getZendeskError(
         elemId,
         new clientUtils.HTTPError('err', { data, status: 422 })
-      )).toEqual(new Error(`Deployment of ${elemId.typeName} instance ${elemId.name} failed:${EOL}${EOL}${data.description}${EOL}${EOL}Error details:${EOL}* a-one des${EOL}* a-two des${EOL}* b-one des${EOL}* b-two des`))
+      )).toEqual(createSaltoElementError({
+        message: `Deployment of ${elemId.typeName} instance ${elemId.name} failed:${EOL}${EOL}${data.description}${EOL}${EOL}Error details:${EOL}* a-one des${EOL}* a-two des${EOL}* b-one des${EOL}* b-two des`,
+        severity: 'Error',
+        elemID: elemId,
+      }))
     })
     it('should return the correct error message for 400 error', async () => {
       const data = { error: { title: 'a', message: 'b' } }
       expect(getZendeskError(
         elemId,
         new clientUtils.HTTPError('err', { data, status: 400 })
-      )).toEqual(new Error(`Deployment of ${elemId.typeName} instance ${elemId.name} failed:${EOL}${EOL}Error details:${EOL}* Title: a${EOL}  Detail: b${EOL}`))
+      )).toEqual(createSaltoElementError({
+        message: `Deployment of ${elemId.typeName} instance ${elemId.name} failed:${EOL}${EOL}Error details:${EOL}* Title: a${EOL}  Detail: b${EOL}`,
+        severity: 'Error',
+        elemID: elemId,
+      }))
     })
   })
 })

--- a/packages/zendesk-adapter/test/filters/app.test.ts
+++ b/packages/zendesk-adapter/test/filters/app.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import {
-  ObjectType, ElemID, InstanceElement,
+  ObjectType, ElemID, InstanceElement, createSaltoElementError,
 } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import ZendeskClient from '../../src/client/client'
@@ -137,7 +137,13 @@ describe('app installation filter', () => {
     const clonedApp = app.clone()
     mockDeployChange.mockImplementation(async () => ({ id, pending_job_id: '123' }))
     mockGet = jest.spyOn(client, 'getSinglePage')
-    mockGet.mockImplementation(async () => { throw new Error('err') })
+    mockGet.mockImplementation(async () => {
+      throw createSaltoElementError({
+        message: 'err',
+        severity: 'Error',
+        elemID: clonedApp.elemID,
+      })
+    })
     const res = await filter.deploy([{ action: 'add', data: { after: clonedApp } }])
     expect(mockDeployChange).toHaveBeenCalledTimes(1)
     expect(mockDeployChange).toHaveBeenCalledWith({

--- a/packages/zendesk-adapter/test/filters/brand_logo.test.ts
+++ b/packages/zendesk-adapter/test/filters/brand_logo.test.ts
@@ -16,7 +16,7 @@
 import FormData from 'form-data'
 import {
   ObjectType, ElemID, InstanceElement, isInstanceElement, StaticFile, ReferenceExpression,
-  CORE_ANNOTATIONS, getChangeData,
+  CORE_ANNOTATIONS, getChangeData, createSaltoElementError,
 } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import filterCreator, { BRAND_LOGO_TYPE, LOGO_FIELD } from '../../src/filters/brand_logo'
@@ -289,7 +289,14 @@ describe('brand logo filter', () => {
       expect(mockBrandGet).toHaveBeenCalledTimes(5)
 
       expect(res.deployResult.errors).toHaveLength(1)
-      expect(res.deployResult.errors[0]).toEqual(Error(`Can't deploy ${logoInstance.elemID.name} of the type brand_logo, due to Zendesk's API limitations. Please upload it manually in Zendesk Admin Center`))
+      expect(res.deployResult.errors[0]).toEqual(
+        createSaltoElementError({
+          message: `Can't deploy ${logoInstance.elemID.name} of the type brand_logo, due to Zendesk's API limitations. Please upload it manually in Zendesk Admin Center`,
+          severity: 'Error',
+          elemID: clonedLogo.elemID,
+        })
+      )
+
       expect(res.deployResult.appliedChanges).toHaveLength(0)
       expect(res.leftoverChanges).toHaveLength(1)
       expect((getChangeData(res.leftoverChanges[0]) as InstanceElement).value)
@@ -319,7 +326,13 @@ describe('brand logo filter', () => {
       expect(mockBrandGet).toHaveBeenCalledTimes(5)
 
       expect(res.deployResult.errors).toHaveLength(1)
-      expect(res.deployResult.errors[0]).toEqual(Error(`Can't deploy ${logoInstance.elemID.name} of the type brand_logo, due to Zendesk's API limitations. Please upload it manually in Zendesk Admin Center`))
+      expect(res.deployResult.errors[0]).toEqual(
+        createSaltoElementError({
+          message: `Can't deploy ${logoInstance.elemID.name} of the type brand_logo, due to Zendesk's API limitations. Please upload it manually in Zendesk Admin Center`,
+          severity: 'Error',
+          elemID: clonedLogo.elemID,
+        })
+      )
       expect(res.deployResult.appliedChanges).toHaveLength(0)
       expect(res.leftoverChanges).toHaveLength(1)
       expect((getChangeData(res.leftoverChanges[0]) as InstanceElement).value)
@@ -335,7 +348,13 @@ describe('brand logo filter', () => {
       ])
 
       expect(res.deployResult.errors).toHaveLength(1)
-      expect(res.deployResult.errors[0]).toEqual(Error(`Expected ${clonedLogo.elemID.getFullName()} to have exactly one parent, found 0`))
+      expect(res.deployResult.errors[0]).toEqual(
+        createSaltoElementError({
+          message: `Expected ${clonedLogo.elemID.getFullName()} to have exactly one parent, found 0`,
+          severity: 'Error',
+          elemID: clonedLogo.elemID,
+        })
+      )
       expect(res.deployResult.appliedChanges).toHaveLength(0)
       expect(res.leftoverChanges).toHaveLength(1)
       expect((getChangeData(res.leftoverChanges[0]) as InstanceElement).value)


### PR DESCRIPTION
change zendesk errors to return saltoErrors instead of throwing them

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None