### PR TITLE
SALTO-4456: Fixed local dir store when a file is deleted

### DIFF
--- a/packages/core/src/local-workspace/dir_store.ts
+++ b/packages/core/src/local-workspace/dir_store.ts
@@ -141,7 +141,7 @@ const buildLocalDirectoryStore = <T extends dirStore.ContentType>(
       : (await fileUtils.stat.notFoundAsUndefined(getAbsFileName(filename)))?.mtimeMs
   }
 
-  const get = async (filename: string): Promise<dirStore.File<T> | undefined> => {
+  const get = async (filename: string, options?: dirStore.GetFileOptions): Promise<dirStore.File<T> | undefined> => {
     let relFilename: string
     try {
       relFilename = getRelativeFileName(filename)
@@ -149,7 +149,7 @@ const buildLocalDirectoryStore = <T extends dirStore.ContentType>(
       return Promise.reject(err)
     }
 
-    if (deleted.has(relFilename)) {
+    if (!options?.ignoreDeletionsCache && deleted.has(relFilename)) {
       return undefined
     }
 
@@ -266,8 +266,9 @@ const buildLocalDirectoryStore = <T extends dirStore.ContentType>(
 
     flush,
 
-    getFiles: async (filenames: string[]): Promise<(dirStore.File<T> | undefined) []> => log.time(
-      () => (withLimitedConcurrency(filenames.map(f => () => get(f)), READ_CONCURRENCY)),
+    getFiles: async (filenames: string[], options: dirStore.GetFileOptions)
+      : Promise<(dirStore.File<T> | undefined) []> => log.time(
+      () => (withLimitedConcurrency(filenames.map(f => () => get(f, options)), READ_CONCURRENCY)),
       'getFiles for %d files with read concurrency %d', filenames.length, READ_CONCURRENCY,
     ),
 

--- a/packages/core/test/workspace/local/directory_store.test.ts
+++ b/packages/core/test/workspace/local/directory_store.test.ts
@@ -278,6 +278,20 @@ describe('localDirectoryStore', () => {
     it('fails to get an absolute path', () =>
       localDirectoryStore({ baseDir: 'dir', name: '', encoding }).getFiles(['/aaaa'])
         .catch(err => expect(err.message).toEqual('Filepath not contained in dir store base dir: /aaaa')))
+
+    it('Should return deleted file when requested to ignore cache', async () => {
+      mockFileExists.mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(true)
+      mockReadFile.mockResolvedValueOnce('bla1').mockResolvedValueOnce('bla2')
+      mockStat.mockResolvedValue({ mtimeMs: 7 })
+      const dirStore = localDirectoryStore({ baseDir: '', name: '', encoding })
+      await dirStore.delete('b')
+      const files = await dirStore.getFiles(['a', 'b', 'c'], { ignoreDeletionsCache: true })
+      expect(files[0]).toBeUndefined()
+      expect(files[1]?.buffer).toEqual('bla1')
+      expect(files[2]?.buffer).toEqual('bla2')
+    })
   })
 
   describe('rm Nacl file', () => {

--- a/packages/core/test/workspace/local/directory_store.test.ts
+++ b/packages/core/test/workspace/local/directory_store.test.ts
@@ -119,6 +119,21 @@ describe('localDirectoryStore', () => {
       expect(mockReadFile).not.toHaveBeenCalled()
     })
 
+    it('does not return the file if it was deleted from the dir store', async () => {
+      const baseDir = 'exists'
+      const naclFileName = 'blabla/exist.nacl'
+      const content = 'content'
+      mockFileExists.mockResolvedValue(true)
+      mockReadFile.mockResolvedValue(content)
+      mockStat.mockResolvedValue({ mtimeMs: 7 })
+      const dirStore = localDirectoryStore({ baseDir, name: '', encoding })
+      await dirStore.delete(naclFileName)
+      const naclFile = await dirStore.get(naclFileName)
+      expect(naclFile).toBeUndefined()
+      expect(mockFileExists).not.toHaveBeenCalled()
+      expect(mockReadFile).not.toHaveBeenCalled()
+    })
+
     it('returns the file if it exist for string dir store', async () => {
       const baseDir = 'exists'
       const naclFileName = 'blabla/exist.nacl'
@@ -146,6 +161,21 @@ describe('localDirectoryStore', () => {
       expect(mockFileExists.mock.calls[0][0]).toMatch(path.join(baseDir, bufferFileName))
       expect(mockReadFile.mock.calls[0][0]).toMatch(path.join(baseDir, bufferFileName))
       expect(mockReadFile.mock.calls[0][1]).toEqual({ encoding: undefined })
+    })
+  })
+
+  describe('mtimestamp', () => {
+    it('does not return the timestamp if it the file was deleted from the dir store', async () => {
+      const baseDir = 'exists'
+      const naclFileName = 'blabla/exist.nacl'
+      mockFileExists.mockResolvedValue(true)
+      mockStat.mockResolvedValue({ mtimeMs: 7 })
+      const dirStore = localDirectoryStore({ baseDir, name: '', encoding })
+      await dirStore.delete(naclFileName)
+      const timestamp = await dirStore.mtimestamp(naclFileName)
+      expect(timestamp).toBeUndefined()
+      expect(mockFileExists).not.toHaveBeenCalled()
+      expect(mockStat).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/core/test/workspace/local/directory_store.test.ts
+++ b/packages/core/test/workspace/local/directory_store.test.ts
@@ -134,6 +134,22 @@ describe('localDirectoryStore', () => {
       expect(mockReadFile).not.toHaveBeenCalled()
     })
 
+    it('does return deleted files if was requested to ignore cache', async () => {
+      const baseDir = 'exists'
+      const naclFileName = 'blabla/exist.nacl'
+      const content = 'content'
+      mockFileExists.mockResolvedValue(true)
+      mockReadFile.mockResolvedValue(content)
+      mockStat.mockResolvedValue({ mtimeMs: 7 })
+      const dirStore = localDirectoryStore({ baseDir, name: '', encoding })
+      await dirStore.delete(naclFileName)
+      const naclFile = await dirStore.get(naclFileName, { ignoreDeletionsCache: true })
+      expect(naclFile?.buffer).toBe(content)
+      expect(mockFileExists.mock.calls[0][0]).toMatch(path.join(baseDir, naclFileName))
+      expect(mockReadFile.mock.calls[0][0]).toMatch(path.join(baseDir, naclFileName))
+      expect(mockReadFile.mock.calls[0][1]).toEqual({ encoding })
+    })
+
     it('returns the file if it exist for string dir store', async () => {
       const baseDir = 'exists'
       const naclFileName = 'blabla/exist.nacl'

--- a/packages/workspace/src/workspace/dir_store.ts
+++ b/packages/workspace/src/workspace/dir_store.ts
@@ -21,9 +21,13 @@ export type File<T extends ContentType> = {
   timestamp?: number
 }
 
+export type GetFileOptions = {
+  ignoreDeletionsCache?: boolean
+}
+
 export type DirectoryStore<T extends ContentType> = {
   list(): Promise<string[]>
-  get(filename: string): Promise<File<T> | undefined>
+  get(filename: string, options?: GetFileOptions): Promise<File<T> | undefined>
   set(file: File<T>): Promise<void>
   delete(filename: string): Promise<void>
   clear(): Promise<void>
@@ -31,7 +35,7 @@ export type DirectoryStore<T extends ContentType> = {
   renameFile(name: string, newName: string): Promise<void>
   flush(): Promise<void>
   mtimestamp(filename: string): Promise<number | undefined>
-  getFiles(filenames: string[]): Promise<(File<T> | undefined) []>
+  getFiles(filenames: string[], options?: GetFileOptions): Promise<(File<T> | undefined) []>
   getTotalSize(): Promise<number>
   clone(): DirectoryStore<T>
   isEmpty(): Promise<boolean>

--- a/packages/workspace/src/workspace/static_files/source.ts
+++ b/packages/workspace/src/workspace/static_files/source.ts
@@ -178,6 +178,8 @@ export const buildStaticFilesSource = (
           filepath,
           staticFileData.hash,
           staticFilesDirStore.getFullPath(filepath),
+          // We use ignoreDeletionsCache to make sure that if the file was requested and then the content
+          // was deleted, we will still lbe able to access the content
           async () => (await staticFilesDirStore.get(filepath, { ignoreDeletionsCache: true }))?.buffer,
           encoding,
         )

--- a/packages/workspace/src/workspace/static_files/source.ts
+++ b/packages/workspace/src/workspace/static_files/source.ts
@@ -178,7 +178,7 @@ export const buildStaticFilesSource = (
           filepath,
           staticFileData.hash,
           staticFilesDirStore.getFullPath(filepath),
-          async () => (await staticFilesDirStore.get(filepath))?.buffer,
+          async () => (await staticFilesDirStore.get(filepath, { ignoreDeletionsCache: true }))?.buffer,
           encoding,
         )
       } catch (e) {
@@ -235,14 +235,9 @@ export const buildStaticFilesSource = (
       staticFilesDirStore.clone() as DirectoryStore<Buffer>,
       staticFilesCache.clone(),
     ),
-    delete: async (staticFile: StaticFile): Promise<void> => {
-      // If the static file is lazy, and the content was not yet loaded,
-      // we need to load it before deleting the file since after we won't be able to
-      if (staticFile instanceof LazyStaticFile) {
-        await staticFile.getContent()
-      }
-      return staticFilesDirStore.delete(staticFile.filepath)
-    },
+    delete: async (staticFile: StaticFile): Promise<void> => (
+      staticFilesDirStore.delete(staticFile.filepath)
+    ),
     isPathIncluded: filePath => staticFilesSource.isPathIncluded(filePath),
   }
   return staticFilesSource

--- a/packages/workspace/src/workspace/static_files/source.ts
+++ b/packages/workspace/src/workspace/static_files/source.ts
@@ -235,9 +235,14 @@ export const buildStaticFilesSource = (
       staticFilesDirStore.clone() as DirectoryStore<Buffer>,
       staticFilesCache.clone(),
     ),
-    delete: async (staticFile: StaticFile): Promise<void> => (
-      staticFilesDirStore.delete(staticFile.filepath)
-    ),
+    delete: async (staticFile: StaticFile): Promise<void> => {
+      // If the static file is lazy, and the content was not yet loaded,
+      // we need to load it before deleting the file since after we won't be able to
+      if (staticFile instanceof LazyStaticFile) {
+        await staticFile.getContent()
+      }
+      return staticFilesDirStore.delete(staticFile.filepath)
+    },
     isPathIncluded: filePath => staticFilesSource.isPathIncluded(filePath),
   }
   return staticFilesSource

--- a/packages/workspace/test/workspace/static_files/source.test.ts
+++ b/packages/workspace/test/workspace/static_files/source.test.ts
@@ -15,7 +15,6 @@
 */
 import { StaticFile } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { mockFunction } from '@salto-io/test-utils'
 import { mockStaticFilesCache } from '../../common/static_files_cache'
 import { DirectoryStore } from '../../../src/workspace/dir_store'
 import { buildStaticFilesSource, StaticFilesCache, LazyStaticFile, buildInMemStaticFilesSource } from '../../../src/workspace/static_files'
@@ -274,22 +273,6 @@ describe('Static Files', () => {
       it('should invoke the dir store delete method with the static file file path attribute', async () => {
         await staticFilesSource.delete(exampleStaticFileWithContent)
         expect(mockDirStore.delete).toHaveBeenCalledWith(exampleStaticFileWithContent.filepath)
-      })
-
-      it('should load the file content before deleting if the static if is lazy', async () => {
-        const getContentFunc = mockFunction<() => Promise<Buffer | undefined>>()
-          .mockResolvedValue(Buffer.from('content'))
-
-        const lazyStaticFile = new LazyStaticFile(
-          'path',
-          'hash',
-          'absoluteFilePath',
-          getContentFunc,
-        )
-
-        await staticFilesSource.delete(lazyStaticFile)
-        expect(getContentFunc).toHaveBeenCalled()
-        expect(mockDirStore.delete).toHaveBeenCalledWith(lazyStaticFile.filepath)
       })
     })
     describe('load', () => {


### PR DESCRIPTION
Fixed local dir store when a file is deleted

---

The local dir store `get` and `mtimestamp` function did not check if a file is in the `deleted` list which made it returns a file that was deleted from the dirstore if a flush wasn't called in between.
This fix is necessary for the "restore elements path" flag, since we remove the files and recreate them.

Fixing the dirstore created another issue that we access the content of lazy static files for the first time after they were deleted so they can't be loaded. It happened in the router when we delete a static file from common and create it in a specific env. I change the LazyStaticFile to ignore deletions that were not flushed to solve this case

---
_Release Notes_: 
None (I am not aware of this having an effect on the user so far)

---
_User Notifications_: 
None