### PR TITLE
SALTO-4402 - Salesforce: Recreate profile refs as additional refs

### DIFF
--- a/packages/salesforce-adapter/src/additional_references.ts
+++ b/packages/salesforce-adapter/src/additional_references.ts
@@ -13,15 +13,78 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { GetAdditionalReferencesFunc, getChangeData, isAdditionChange, isFieldChange, isInstanceChange, isRemovalOrModificationChange } from '@salto-io/adapter-api'
+import {
+  Element,
+  GetAdditionalReferencesFunc,
+  getChangeData,
+  InstanceElement,
+  isAdditionChange,
+  isFieldChange,
+  isInstanceChange,
+  isRemovalOrModificationChange,
+  ReferenceMapping,
+} from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { collections } from '@salto-io/lowerdash'
-import { isFieldOfCustomObject } from './transformers/transformer'
+import {
+  isCustomObject,
+  isFieldOfCustomObject,
+} from './transformers/transformer'
 import { isInstanceOfType, safeApiName } from './filters/utils'
-import { API_NAME_SEPARATOR, FIELD_PERMISSIONS, PERMISSION_SET_METADATA_TYPE, PROFILE_METADATA_TYPE } from './constants'
+import {
+  API_NAME_SEPARATOR,
+  FIELD_PERMISSIONS,
+  FLOW_METADATA_TYPE,
+  LAYOUT_TYPE_ID_METADATA_TYPE,
+  PERMISSION_SET_METADATA_TYPE,
+  PROFILE_METADATA_TYPE,
+  RECORD_TYPE_METADATA_TYPE,
+} from './constants'
 
 const { awu } = collections.asynciterable
+const { makeArray } = collections.array
 
+const CUSTOM_APPLICATION_TYPE = 'CustomApplication'
+const APEX_CLASS_TYPE = 'ApexClass'
+const APEX_PAGE_TYPE = 'ApexPage'
+const CUSTOM_APP_SECTION = 'applicationVisibilities'
+const APEX_CLASS_SECTION = 'classAccesses'
+const FLOW_SECTION = 'flowAccesses'
+const LAYOUTS_SECTION = 'layoutAssignments'
+const OBJECT_SECTION = 'objectPermissions'
+const APEX_PAGE_SECTION = 'pageAccesses'
+const RECORD_TYPE_SECTION = 'recordTypeVisibilities'
+
+const generateRefsFromProfileOrPermissionSet = async (
+  profilesAndPermissionSets: InstanceElement[],
+  potentialTarget: Readonly<Element>,
+  profileSection: string,
+  profileSectionField?: string,
+): Promise<ReferenceMapping[]> => {
+  const apiName = await safeApiName(potentialTarget)
+  if (apiName === undefined) {
+    return []
+  }
+  return profilesAndPermissionSets
+    .filter(profileOrPermissionSet => _.get(profileOrPermissionSet.value[profileSection], apiName))
+    .flatMap(profileOrPermissionSet => {
+      const sectionEntry = _.get(profileOrPermissionSet.value[profileSection], apiName)
+      // For layoutAssignments, every entry is an array
+      const shouldAddArrayIndex = Array.isArray(sectionEntry)
+      return makeArray(sectionEntry)
+        .map((_unused, index) => {
+          const refSourceField = [
+            ...apiName.split(API_NAME_SEPARATOR),
+            ...shouldAddArrayIndex ? [`[${index}]`] : [],
+            ...makeArray(profileSectionField),
+          ]
+          return {
+            source: profileOrPermissionSet.elemID.createNestedID(profileSection, ...refSourceField),
+            target: potentialTarget.elemID,
+          }
+        })
+    })
+}
 
 export const getAdditionalReferences: GetAdditionalReferencesFunc = async changes => {
   const relevantFields = await awu(changes)
@@ -31,9 +94,19 @@ export const getAdditionalReferences: GetAdditionalReferencesFunc = async change
     .filter(isFieldOfCustomObject)
     .toArray()
 
-  if (relevantFields.length === 0) {
-    return []
-  }
+  const customObjects = changes
+    .filter(isAdditionChange)
+    .map(getChangeData)
+    .filter(isCustomObject)
+
+
+  const addedInstances = changes
+    .filter(isInstanceChange)
+    .filter(isAdditionChange)
+    .map(getChangeData)
+
+  const addedInstancesByType = await awu(addedInstances)
+    .groupBy(async instance => (await instance.getType()).elemID.typeName)
 
   const profilesAndPermissionSets = await awu(changes)
     .filter(isRemovalOrModificationChange)
@@ -42,18 +115,37 @@ export const getAdditionalReferences: GetAdditionalReferencesFunc = async change
     .filter(instance => isInstanceOfType(PROFILE_METADATA_TYPE, PERMISSION_SET_METADATA_TYPE)(instance))
     .toArray()
 
-  return awu(relevantFields)
-    .flatMap(async field => {
-      const fieldApiName = await safeApiName(field)
-      if (fieldApiName === undefined) {
-        return []
-      }
-      return profilesAndPermissionSets
-        .filter(instance => _.get(instance.value.fieldPermissions, fieldApiName) !== undefined)
-        .map(instance => ({
-          source: instance.elemID.createNestedID(FIELD_PERMISSIONS, ...fieldApiName.split(API_NAME_SEPARATOR)),
-          target: field.elemID,
-        }))
-    })
+  const fieldPermissionsRefs = awu(relevantFields)
+    .flatMap(async field => generateRefsFromProfileOrPermissionSet(profilesAndPermissionSets, field, FIELD_PERMISSIONS))
+
+  const customAppsRefs = awu(addedInstancesByType[CUSTOM_APPLICATION_TYPE] ?? [])
+    .flatMap(async customApp => generateRefsFromProfileOrPermissionSet(profilesAndPermissionSets, customApp, CUSTOM_APP_SECTION, 'application'))
+
+  const apexClassRefs = awu(addedInstancesByType[APEX_CLASS_TYPE] ?? [])
+    .flatMap(async apexClass => generateRefsFromProfileOrPermissionSet(profilesAndPermissionSets, apexClass, APEX_CLASS_SECTION, 'apexClass'))
+
+  const flowRefs = awu(addedInstancesByType[FLOW_METADATA_TYPE] ?? [])
+    .flatMap(async flow => generateRefsFromProfileOrPermissionSet(profilesAndPermissionSets, flow, FLOW_SECTION, 'flow'))
+
+  const layoutRefs = awu(addedInstancesByType[LAYOUT_TYPE_ID_METADATA_TYPE] ?? [])
+    .flatMap(async layout => generateRefsFromProfileOrPermissionSet(profilesAndPermissionSets, layout, LAYOUTS_SECTION, 'layout'))
+
+  const apexPageRefs = awu(addedInstancesByType[APEX_PAGE_TYPE] ?? [])
+    .flatMap(async apexPage => generateRefsFromProfileOrPermissionSet(profilesAndPermissionSets, apexPage, APEX_PAGE_SECTION, 'apexPage'))
+
+  const recordTypeRefs = awu(addedInstancesByType[RECORD_TYPE_METADATA_TYPE] ?? [])
+    .flatMap(async recordType => generateRefsFromProfileOrPermissionSet(profilesAndPermissionSets, recordType, RECORD_TYPE_SECTION, 'recordType'))
+
+  const objectRefs = awu(customObjects)
+    .flatMap(async object => generateRefsFromProfileOrPermissionSet(profilesAndPermissionSets, object, OBJECT_SECTION, 'object'))
+
+  return fieldPermissionsRefs
+    .concat(customAppsRefs)
+    .concat(apexClassRefs)
+    .concat(flowRefs)
+    .concat(layoutRefs)
+    .concat(objectRefs)
+    .concat(apexPageRefs)
+    .concat(recordTypeRefs)
     .toArray()
 }

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -382,8 +382,11 @@ export const INSTALLED_PACKAGE_METADATA = 'InstalledPackage'
 export const ACCOUNT_SETTINGS_METADATA_TYPE = 'AccountSettings'
 export const PERMISSION_SET_TYPE_ID_METADATA_TYPE = 'PermissionSet'
 export const DATA_CATEGORY_GROUP_METADATA_TYPE = 'DataCategoryGroup'
+export const CUSTOM_APPLICATION_METADATA_TYPE = 'CustomApplication'
+export const APEX_CLASS_METADATA_TYPE = 'ApexClass'
+export const APEX_PAGE_METADATA_TYPE = 'ApexPage'
 
-// Artifitial Types
+// Artificial Types
 export const CURRENCY_CODE_TYPE_NAME = 'CurrencyIsoCodes'
 
 // Standard Object Types

--- a/packages/salesforce-adapter/test/additional_references.test.ts
+++ b/packages/salesforce-adapter/test/additional_references.test.ts
@@ -150,8 +150,8 @@ describe('getAdditionalReferences', () => {
     it('should create a reference', async () => {
       const refs = await getAdditionalReferences(changes)
       expect(refs).toIncludeAllPartialMembers([
-        { source: permissionSetInstance.elemID.createNestedID('applicationVisibilities', 'SomeApplication', 'application'), target: customApp.elemID },
-        { source: profileInstance.elemID.createNestedID('applicationVisibilities', 'SomeApplication', 'application'), target: customApp.elemID },
+        { source: permissionSetInstance.elemID.createNestedID('applicationVisibilities', 'SomeApplication'), target: customApp.elemID },
+        { source: profileInstance.elemID.createNestedID('applicationVisibilities', 'SomeApplication'), target: customApp.elemID },
       ])
     })
   })
@@ -185,8 +185,8 @@ describe('getAdditionalReferences', () => {
     it('should create a reference', async () => {
       const refs = await getAdditionalReferences(changes)
       expect(refs).toIncludeAllPartialMembers([
-        { source: permissionSetInstance.elemID.createNestedID('classAccesses', 'SomeApexClass', 'apexClass'), target: apexClass.elemID },
-        { source: profileInstance.elemID.createNestedID('classAccesses', 'SomeApexClass', 'apexClass'), target: apexClass.elemID },
+        { source: permissionSetInstance.elemID.createNestedID('classAccesses', 'SomeApexClass'), target: apexClass.elemID },
+        { source: profileInstance.elemID.createNestedID('classAccesses', 'SomeApexClass'), target: apexClass.elemID },
       ])
     })
   })
@@ -220,8 +220,8 @@ describe('getAdditionalReferences', () => {
     it('should create a reference', async () => {
       const refs = await getAdditionalReferences(changes)
       expect(refs).toIncludeAllPartialMembers([
-        { source: permissionSetInstance.elemID.createNestedID('flowAccesses', 'SomeFlow', 'flow'), target: flow.elemID },
-        { source: profileInstance.elemID.createNestedID('flowAccesses', 'SomeFlow', 'flow'), target: flow.elemID },
+        { source: permissionSetInstance.elemID.createNestedID('flowAccesses', 'SomeFlow'), target: flow.elemID },
+        { source: profileInstance.elemID.createNestedID('flowAccesses', 'SomeFlow'), target: flow.elemID },
       ])
     })
   })
@@ -256,8 +256,8 @@ describe('getAdditionalReferences', () => {
     it('should create a reference', async () => {
       const refs = await getAdditionalReferences(changes)
       expect(refs).toIncludeAllPartialMembers([
-        { source: permissionSetInstance.elemID.createNestedID('layoutAssignments', 'Account_Account_Layout', '[0]', 'layout'), target: layout.elemID },
-        { source: profileInstance.elemID.createNestedID('layoutAssignments', 'Account_Account_Layout', '[0]', 'layout'), target: layout.elemID },
+        { source: permissionSetInstance.elemID.createNestedID('layoutAssignments', 'Account_Account_Layout'), target: layout.elemID },
+        { source: profileInstance.elemID.createNestedID('layoutAssignments', 'Account_Account_Layout'), target: layout.elemID },
       ])
     })
   })
@@ -293,8 +293,8 @@ describe('getAdditionalReferences', () => {
     it('should create a reference', async () => {
       const refs = await getAdditionalReferences(changes)
       expect(refs).toIncludeAllPartialMembers([
-        { source: permissionSetInstance.elemID.createNestedID('objectPermissions', 'Account', 'object'), target: customObject.elemID },
-        { source: profileInstance.elemID.createNestedID('objectPermissions', 'Account', 'object'), target: customObject.elemID },
+        { source: permissionSetInstance.elemID.createNestedID('objectPermissions', 'Account'), target: customObject.elemID },
+        { source: profileInstance.elemID.createNestedID('objectPermissions', 'Account'), target: customObject.elemID },
       ])
     })
   })
@@ -329,8 +329,8 @@ describe('getAdditionalReferences', () => {
     it('should create a reference', async () => {
       const refs = await getAdditionalReferences(changes)
       expect(refs).toIncludeAllPartialMembers([
-        { source: permissionSetInstance.elemID.createNestedID('pageAccesses', 'SomeApexPage', 'apexPage'), target: apexPage.elemID },
-        { source: profileInstance.elemID.createNestedID('pageAccesses', 'SomeApexPage', 'apexPage'), target: apexPage.elemID },
+        { source: permissionSetInstance.elemID.createNestedID('pageAccesses', 'SomeApexPage'), target: apexPage.elemID },
+        { source: profileInstance.elemID.createNestedID('pageAccesses', 'SomeApexPage'), target: apexPage.elemID },
       ])
     })
   })
@@ -368,8 +368,8 @@ describe('getAdditionalReferences', () => {
     it('should create a reference', async () => {
       const refs = await getAdditionalReferences(changes)
       expect(refs).toIncludeAllPartialMembers([
-        { source: permissionSetInstance.elemID.createNestedID('recordTypeVisibilities', 'Case', 'SomeCaseRecordType', 'recordType'), target: recordType.elemID },
-        { source: profileInstance.elemID.createNestedID('recordTypeVisibilities', 'Case', 'SomeCaseRecordType', 'recordType'), target: recordType.elemID },
+        { source: permissionSetInstance.elemID.createNestedID('recordTypeVisibilities', 'Case', 'SomeCaseRecordType'), target: recordType.elemID },
+        { source: profileInstance.elemID.createNestedID('recordTypeVisibilities', 'Case', 'SomeCaseRecordType'), target: recordType.elemID },
       ])
     })
   })

--- a/packages/salesforce-adapter/test/additional_references.test.ts
+++ b/packages/salesforce-adapter/test/additional_references.test.ts
@@ -13,112 +13,364 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, ElemID, Field, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
-import { API_NAME, CUSTOM_OBJECT, METADATA_TYPE, SALESFORCE } from '../src/constants'
+import {
+  BuiltinTypes,
+  Change,
+  Field,
+  InstanceElement,
+  ObjectType,
+  toChange,
+  Values,
+} from '@salto-io/adapter-api'
+import {
+  API_NAME,
+  INSTANCE_FULL_NAME_FIELD,
+} from '../src/constants'
 import { getAdditionalReferences } from '../src/additional_references'
+import { mockTypes } from './mock_elements'
+import {
+  createCustomObjectType,
+  createMetadataTypeElement,
+} from './utils'
 
 describe('getAdditionalReferences', () => {
-  let permissionSetInstance: InstanceElement
-  let profileInstance: InstanceElement
-  let field: Field
+  const createTestInstances = (fields: Values): [InstanceElement, InstanceElement] => [
+    new InstanceElement('test', mockTypes.Profile, fields),
+    new InstanceElement('test', mockTypes.PermissionSet, fields),
+  ]
 
-  beforeEach(() => {
-    permissionSetInstance = new InstanceElement(
-      'test',
-      new ObjectType({
-        elemID: new ElemID(SALESFORCE, 'PermissionSet'),
-        annotations: { [METADATA_TYPE]: 'PermissionSet' },
-      }),
-      {
+  describe('fields', () => {
+    let permissionSetInstance: InstanceElement
+    let profileInstance: InstanceElement
+    let field: Field
+
+    beforeEach(() => {
+      [permissionSetInstance, profileInstance] = createTestInstances({
         fieldPermissions: {
           Account: {
             testField__c: 'ReadWrite',
           },
         },
-      }
-    )
+      })
 
-    profileInstance = new InstanceElement(
-      'test',
-      new ObjectType({
-        elemID: new ElemID(SALESFORCE, 'Profile'),
-        annotations: { [METADATA_TYPE]: 'Profile' },
-      }),
-      {
-        fieldPermissions: {
-          Account: {
-            testField__c: 'ReadWrite',
+      field = new Field(
+        mockTypes.Account,
+        'testField__c',
+        BuiltinTypes.STRING,
+        {
+          [API_NAME]: 'Account.testField__c',
+        }
+      )
+    })
+
+    it('should create references from field to profile and permission sets', async () => {
+      const refs = await getAdditionalReferences([
+        toChange({ before: permissionSetInstance, after: permissionSetInstance }),
+        toChange({ before: profileInstance, after: profileInstance }),
+        toChange({ after: field }),
+      ])
+
+      expect(refs).toEqual([
+        { source: permissionSetInstance.elemID.createNestedID('fieldPermissions', 'Account', 'testField__c'), target: field.elemID },
+        { source: profileInstance.elemID.createNestedID('fieldPermissions', 'Account', 'testField__c'), target: field.elemID },
+      ])
+    })
+
+    it('should add references only for addition fields', async () => {
+      const refs = await getAdditionalReferences([
+        toChange({ before: permissionSetInstance, after: permissionSetInstance }),
+        toChange({ before: profileInstance, after: profileInstance }),
+        toChange({ before: field, after: field }),
+      ])
+
+      expect(refs).toEqual([])
+    })
+
+    it('should not add references for addition profiles and permission sets', async () => {
+      const refs = await getAdditionalReferences([
+        toChange({ after: permissionSetInstance }),
+        toChange({ after: profileInstance }),
+        toChange({ after: field }),
+      ])
+
+      expect(refs).toEqual([])
+    })
+
+    it('should not add references if not contained the field section', async () => {
+      delete permissionSetInstance.value.fieldPermissions.Account.testField__c
+      delete profileInstance.value.fieldPermissions.Account.testField__c
+      const refs = await getAdditionalReferences([
+        toChange({ before: permissionSetInstance, after: permissionSetInstance }),
+        toChange({ before: profileInstance, after: profileInstance }),
+        toChange({ after: field }),
+      ])
+
+      expect(refs).toEqual([])
+    })
+
+    it('should not add references if field does not have an api name', async () => {
+      delete field.annotations[API_NAME]
+      const refs = await getAdditionalReferences([
+        toChange({ before: permissionSetInstance, after: permissionSetInstance }),
+        toChange({ before: profileInstance, after: profileInstance }),
+        toChange({ after: field }),
+      ])
+
+      expect(refs).toEqual([])
+    })
+  })
+  describe('custom apps', () => {
+    let permissionSetInstance: InstanceElement
+    let profileInstance: InstanceElement
+    let customApp: InstanceElement
+    let changes: Change[]
+
+    beforeEach(() => {
+      [profileInstance, permissionSetInstance] = createTestInstances({
+        applicationVisibilities: {
+          SomeApplication: {
+            application: 'SomeApplication',
+            default: false,
+            visible: false,
           },
         },
-      }
-    )
+      })
+      customApp = new InstanceElement(
+        'SomeApplication',
+        createMetadataTypeElement('CustomApplication', {}),
+        { [INSTANCE_FULL_NAME_FIELD]: 'SomeApplication' },
+      )
+      changes = [
+        toChange({ before: profileInstance, after: profileInstance }),
+        toChange({ before: permissionSetInstance, after: permissionSetInstance }),
+        toChange({ after: customApp }),
+      ]
+    })
 
-    field = new Field(
-      new ObjectType({
-        elemID: new ElemID(SALESFORCE, 'Account'),
-        annotations: { [METADATA_TYPE]: CUSTOM_OBJECT, [API_NAME]: 'Account' },
-      }),
-      'testField__c',
-      BuiltinTypes.STRING,
-      {
-        [API_NAME]: 'Account.testField__c',
-      }
-    )
+    it('should create a reference', async () => {
+      const refs = await getAdditionalReferences(changes)
+      expect(refs).toIncludeAllPartialMembers([
+        { source: permissionSetInstance.elemID.createNestedID('applicationVisibilities', 'SomeApplication', 'application'), target: customApp.elemID },
+        { source: profileInstance.elemID.createNestedID('applicationVisibilities', 'SomeApplication', 'application'), target: customApp.elemID },
+      ])
+    })
+  })
+  describe('apex classes', () => {
+    let permissionSetInstance: InstanceElement
+    let profileInstance: InstanceElement
+    let apexClass: InstanceElement
+    let changes: Change[]
+
+    beforeEach(() => {
+      [profileInstance, permissionSetInstance] = createTestInstances({
+        classAccesses: {
+          SomeApexClass: {
+            apexClass: 'SomeApexClass',
+            enabled: false,
+          },
+        },
+      })
+      apexClass = new InstanceElement(
+        'SomeApexClass',
+        mockTypes.ApexClass,
+        { [INSTANCE_FULL_NAME_FIELD]: 'SomeApexClass' },
+      )
+      changes = [
+        toChange({ before: profileInstance, after: profileInstance }),
+        toChange({ before: permissionSetInstance, after: permissionSetInstance }),
+        toChange({ after: apexClass }),
+      ]
+    })
+
+    it('should create a reference', async () => {
+      const refs = await getAdditionalReferences(changes)
+      expect(refs).toIncludeAllPartialMembers([
+        { source: permissionSetInstance.elemID.createNestedID('classAccesses', 'SomeApexClass', 'apexClass'), target: apexClass.elemID },
+        { source: profileInstance.elemID.createNestedID('classAccesses', 'SomeApexClass', 'apexClass'), target: apexClass.elemID },
+      ])
+    })
+  })
+  describe('flows', () => {
+    let permissionSetInstance: InstanceElement
+    let profileInstance: InstanceElement
+    let flow: InstanceElement
+    let changes: Change[]
+
+    beforeEach(() => {
+      [profileInstance, permissionSetInstance] = createTestInstances({
+        flowAccesses: {
+          SomeFlow: {
+            enabled: false,
+            flow: 'SomeFlow',
+          },
+        },
+      })
+      flow = new InstanceElement(
+        'SomeFlow',
+        mockTypes.Flow,
+        { [INSTANCE_FULL_NAME_FIELD]: 'SomeFlow' },
+      )
+      changes = [
+        toChange({ before: profileInstance, after: profileInstance }),
+        toChange({ before: permissionSetInstance, after: permissionSetInstance }),
+        toChange({ after: flow }),
+      ]
+    })
+
+    it('should create a reference', async () => {
+      const refs = await getAdditionalReferences(changes)
+      expect(refs).toIncludeAllPartialMembers([
+        { source: permissionSetInstance.elemID.createNestedID('flowAccesses', 'SomeFlow', 'flow'), target: flow.elemID },
+        { source: profileInstance.elemID.createNestedID('flowAccesses', 'SomeFlow', 'flow'), target: flow.elemID },
+      ])
+    })
+  })
+  describe('layouts', () => {
+    let permissionSetInstance: InstanceElement
+    let profileInstance: InstanceElement
+    let layout: InstanceElement
+    let changes: Change[]
+
+    beforeEach(() => {
+      [profileInstance, permissionSetInstance] = createTestInstances({
+        layoutAssignments: {
+          Account_Account_Layout: [
+            {
+              layout: 'Account_Account_Layout',
+            },
+          ],
+        },
+      })
+      layout = new InstanceElement(
+        'Account_Account_Layout',
+        mockTypes.Layout,
+        { [INSTANCE_FULL_NAME_FIELD]: 'Account_Account_Layout' },
+      )
+      changes = [
+        toChange({ before: profileInstance, after: profileInstance }),
+        toChange({ before: permissionSetInstance, after: permissionSetInstance }),
+        toChange({ after: layout }),
+      ]
+    })
+
+    it('should create a reference', async () => {
+      const refs = await getAdditionalReferences(changes)
+      expect(refs).toIncludeAllPartialMembers([
+        { source: permissionSetInstance.elemID.createNestedID('layoutAssignments', 'Account_Account_Layout', '[0]', 'layout'), target: layout.elemID },
+        { source: profileInstance.elemID.createNestedID('layoutAssignments', 'Account_Account_Layout', '[0]', 'layout'), target: layout.elemID },
+      ])
+    })
   })
 
-  it('should create references from field to profile and permission sets', async () => {
-    const refs = await getAdditionalReferences([
-      toChange({ before: permissionSetInstance, after: permissionSetInstance }),
-      toChange({ before: profileInstance, after: profileInstance }),
-      toChange({ after: field }),
-    ])
+  describe('objects', () => {
+    let permissionSetInstance: InstanceElement
+    let profileInstance: InstanceElement
+    let customObject: ObjectType
+    let changes: Change[]
 
-    expect(refs).toEqual([
-      { source: permissionSetInstance.elemID.createNestedID('fieldPermissions', 'Account', 'testField__c'), target: field.elemID },
-      { source: profileInstance.elemID.createNestedID('fieldPermissions', 'Account', 'testField__c'), target: field.elemID },
-    ])
+    beforeEach(() => {
+      [profileInstance, permissionSetInstance] = createTestInstances({
+        objectPermissions: {
+          Account: {
+            allowCreate: true,
+            allowDelete: true,
+            allowEdit: true,
+            allowRead: true,
+            modifyAllRecords: false,
+            object: 'Account',
+            viewAllRecords: false,
+          },
+        },
+      })
+      customObject = createCustomObjectType('Account', {})
+      changes = [
+        toChange({ before: profileInstance, after: profileInstance }),
+        toChange({ before: permissionSetInstance, after: permissionSetInstance }),
+        toChange({ after: customObject }),
+      ]
+    })
+
+    it('should create a reference', async () => {
+      const refs = await getAdditionalReferences(changes)
+      expect(refs).toIncludeAllPartialMembers([
+        { source: permissionSetInstance.elemID.createNestedID('objectPermissions', 'Account', 'object'), target: customObject.elemID },
+        { source: profileInstance.elemID.createNestedID('objectPermissions', 'Account', 'object'), target: customObject.elemID },
+      ])
+    })
   })
 
-  it('should add references only for addition fields', async () => {
-    const refs = await getAdditionalReferences([
-      toChange({ before: permissionSetInstance, after: permissionSetInstance }),
-      toChange({ before: profileInstance, after: profileInstance }),
-      toChange({ before: field, after: field }),
-    ])
+  describe('Apex pages', () => {
+    let permissionSetInstance: InstanceElement
+    let profileInstance: InstanceElement
+    let apexPage: InstanceElement
+    let changes: Change[]
 
-    expect(refs).toEqual([])
+    beforeEach(() => {
+      [profileInstance, permissionSetInstance] = createTestInstances({
+        pageAccesses: {
+          SomeApexPage: {
+            apexPage: 'SomeApexPage',
+            enabled: false,
+          },
+        },
+      })
+      apexPage = new InstanceElement(
+        'SomeApexPage',
+        mockTypes.ApexPage,
+        { [INSTANCE_FULL_NAME_FIELD]: 'SomeApexPage' },
+      )
+      changes = [
+        toChange({ before: profileInstance, after: profileInstance }),
+        toChange({ before: permissionSetInstance, after: permissionSetInstance }),
+        toChange({ after: apexPage }),
+      ]
+    })
+
+    it('should create a reference', async () => {
+      const refs = await getAdditionalReferences(changes)
+      expect(refs).toIncludeAllPartialMembers([
+        { source: permissionSetInstance.elemID.createNestedID('pageAccesses', 'SomeApexPage', 'apexPage'), target: apexPage.elemID },
+        { source: profileInstance.elemID.createNestedID('pageAccesses', 'SomeApexPage', 'apexPage'), target: apexPage.elemID },
+      ])
+    })
   })
 
-  it('should not add references for addition profiles and permission sets', async () => {
-    const refs = await getAdditionalReferences([
-      toChange({ after: permissionSetInstance }),
-      toChange({ after: profileInstance }),
-      toChange({ after: field }),
-    ])
+  describe('record types', () => {
+    let permissionSetInstance: InstanceElement
+    let profileInstance: InstanceElement
+    let recordType: InstanceElement
+    let changes: Change[]
 
-    expect(refs).toEqual([])
-  })
+    beforeEach(() => {
+      [profileInstance, permissionSetInstance] = createTestInstances({
+        recordTypeVisibilities: {
+          Case: {
+            SomeCaseRecordType: {
+              default: true,
+              recordType: 'Case.SomeCaseRecordType',
+              visible: true,
+            },
+          },
+        },
+      })
+      recordType = new InstanceElement(
+        'Case_SomeCaseRecordType',
+        mockTypes.RecordType,
+        { [INSTANCE_FULL_NAME_FIELD]: 'Case.SomeCaseRecordType' },
+      )
+      changes = [
+        toChange({ before: profileInstance, after: profileInstance }),
+        toChange({ before: permissionSetInstance, after: permissionSetInstance }),
+        toChange({ after: recordType }),
+      ]
+    })
 
-  it('should not add references if not contained the field section', async () => {
-    delete permissionSetInstance.value.fieldPermissions.Account.testField__c
-    delete profileInstance.value.fieldPermissions.Account.testField__c
-    const refs = await getAdditionalReferences([
-      toChange({ before: permissionSetInstance, after: permissionSetInstance }),
-      toChange({ before: profileInstance, after: profileInstance }),
-      toChange({ after: field }),
-    ])
-
-    expect(refs).toEqual([])
-  })
-
-  it('should not add references if field does not have an api name', async () => {
-    delete field.annotations[API_NAME]
-    const refs = await getAdditionalReferences([
-      toChange({ before: permissionSetInstance, after: permissionSetInstance }),
-      toChange({ before: profileInstance, after: profileInstance }),
-      toChange({ after: field }),
-    ])
-
-    expect(refs).toEqual([])
+    it('should create a reference', async () => {
+      const refs = await getAdditionalReferences(changes)
+      expect(refs).toIncludeAllPartialMembers([
+        { source: permissionSetInstance.elemID.createNestedID('recordTypeVisibilities', 'Case', 'SomeCaseRecordType', 'recordType'), target: recordType.elemID },
+        { source: profileInstance.elemID.createNestedID('recordTypeVisibilities', 'Case', 'SomeCaseRecordType', 'recordType'), target: recordType.elemID },
+      ])
+    })
   })
 })


### PR DESCRIPTION
Building on top of https://github.com/salto-io/salto/pull/4573, re-add the removed profile references in the adapter's `getAdditionalReferences`. 
`getAdditionalReferences` already dealt with field-level permissions, so we add all the other profile sections.

Note: This PR is missing the references from `layoutAssignments`...`recordType`. due to the urgency of this PR, I will add them in a follow-up PR.
---

I basically factored out the implementation for fieldPermissions ~and added support for a couple of edge cases (e.g. in layoutAssignments every entry is an array with a single element for some reason)~

---
_Release Notes_: 
N/A

---
_User Notifications_: 
N/A
