### PR TITLE
SALTO-4227 Support loading files without their attributes in SDF integration

### DIFF
--- a/packages/netsuite-adapter/e2e_test/sdf_executor.ts
+++ b/packages/netsuite-adapter/e2e_test/sdf_executor.ts
@@ -17,13 +17,13 @@ import _ from 'lodash'
 import os from 'os'
 import osPath from 'path'
 import { v4 as uuidv4 } from 'uuid'
-import { rm } from '@salto-io/file'
+import { mkdirp, rm, writeFile } from '@salto-io/file'
 import Bottleneck from 'bottleneck'
 import { SdfCredentials, toCredentialsAccountId } from '../src/client/credentials'
 import SdfClient, { ALL_FEATURES, COMMANDS, safeQuoteArgument } from '../src/client/sdf_client'
 import { DEFAULT_MAX_ITEMS_IN_IMPORT_OBJECTS_REQUEST } from '../src/config'
 import { FILE_CABINET_PATH_SEPARATOR } from '../src/constants'
-import { OBJECTS_DIR } from '../src/client/sdf_parser'
+import { FILE_CABINET_DIR, OBJECTS_DIR, SRC_DIR } from '../src/client/sdf_parser'
 
 export type ProjectInfo = {
   projectPath: string
@@ -117,4 +117,17 @@ export const createSdfExecutor = (): SDFExecutor => {
       })
     },
   }
+}
+
+export const createAdditionalFiles = async (
+  projectPath: string,
+  files: Array<{ path: string[]; content: string }>
+): Promise<void> => {
+  await Promise.all(files.map(async ({ path, content }) => {
+    await mkdirp(osPath.join(projectPath, SRC_DIR, FILE_CABINET_DIR, ...path.slice(0, -1)))
+    await writeFile(
+      osPath.join(projectPath, SRC_DIR, FILE_CABINET_DIR, ...path),
+      content
+    )
+  }))
 }

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -298,6 +298,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
 
     const baseElements = await createElements(
       [...customObjects, ...fileCabinetContent],
+      this.elementsSource,
       this.getElemIdFunc,
     )
 

--- a/packages/netsuite-adapter/src/client/sdf_parser.ts
+++ b/packages/netsuite-adapter/src/client/sdf_parser.ts
@@ -278,7 +278,7 @@ const transformFoldersWithoutAttributes = (
     .map(path => path.split(FILE_CABINET_PATH_SEPARATOR))
     .map(path => path.slice(1, -1))
     // adding all parent folders
-    .flatMap(path => path.map((p, i) => [...path.slice(0, i), p]))
+    .flatMap(path => path.map((_p, i) => path.slice(0, i + 1)))
     .map(path => path.join(FILE_CABINET_PATH_SEPARATOR))
     .uniq()
     .filter(path => !foldersFromAttributesPaths.has(path))

--- a/packages/netsuite-adapter/src/client/sdf_parser.ts
+++ b/packages/netsuite-adapter/src/client/sdf_parser.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
+import os from 'os'
 import osPath from 'path'
 import he from 'he'
 import xmlParser from 'fast-xml-parser'
@@ -48,6 +49,22 @@ export const ATTRIBUTES_FOLDER_NAME = '.attributes'
 export const FOLDER_ATTRIBUTES_FILE_SUFFIX = `.folder.attr${XML_FILE_SUFFIX}`
 export const ATTRIBUTES_FILE_SUFFIX = `.attr${XML_FILE_SUFFIX}`
 const FILE_SEPARATOR = '.'
+
+const DEFAULT_FILE_ATTRIBUTES = `<file>${os.EOL}`
++ `  <availablewithoutlogin>F</availablewithoutlogin>${os.EOL}`
++ `  <bundleable>F</bundleable>${os.EOL}`
++ `  <description></description>${os.EOL}`
++ `  <generateurltimestamp>F</generateurltimestamp>${os.EOL}`
++ `  <hideinbundle>F</hideinbundle>${os.EOL}`
++ `  <isinactive>F</isinactive>${os.EOL}`
++ `</file>${os.EOL}`
+
+const DEFAULT_FOLDER_ATTRIBUTES = `<folder>${os.EOL}`
++ `  <bundleable>F</bundleable>${os.EOL}`
++ `  <description></description>${os.EOL}`
++ `  <isinactive>F</isinactive>${os.EOL}`
++ `  <isprivate>F</isprivate>${os.EOL}`
++ `</folder>${os.EOL}`
 
 const XML_PARSE_OPTIONS: xmlParser.J2xOptionsOptional = {
   attributeNamePrefix: ATTRIBUTE_PREFIX,
@@ -84,41 +101,48 @@ const convertToCustomizationInfo = (
 const convertToCustomTypeInfo = (
   xmlContent: string,
   scriptId: string
-): CustomTypeInfo =>
-  Object.assign(
-    convertToCustomizationInfo(xmlContent),
-    { scriptId }
-  )
+): CustomTypeInfo => ({
+  ...convertToCustomizationInfo(xmlContent),
+  scriptId,
+})
 
 const convertToTemplateCustomTypeInfo = (
   xmlContent: string,
   scriptId: string,
   fileExtension: string,
   fileContent: Buffer
-): TemplateCustomTypeInfo =>
-  Object.assign(
-    convertToCustomizationInfo(xmlContent),
-    { fileExtension, fileContent, scriptId }
-  )
+): TemplateCustomTypeInfo => ({
+  ...convertToCustomizationInfo(xmlContent),
+  scriptId,
+  fileContent,
+  fileExtension,
+})
 
-const convertToFileCustomizationInfo = (
-  xmlContent: string,
-  path: string[],
-  fileContent: Buffer
-): FileCustomizationInfo =>
-  Object.assign(
-    convertToCustomizationInfo(xmlContent),
-    { path, fileContent }
-  )
-
-const convertToFolderCustomizationInfo = (
-  xmlContent: string,
+const convertToFileCustomizationInfo = ({
+  xmlContent, path, fileContent, hadMissingAttributes,
+}: {
+  xmlContent: string
   path: string[]
-): FolderCustomizationInfo =>
-  Object.assign(
-    convertToCustomizationInfo(xmlContent),
-    { path }
-  )
+  fileContent: Buffer
+  hadMissingAttributes: boolean
+}): FileCustomizationInfo => ({
+  ...convertToCustomizationInfo(xmlContent),
+  path,
+  fileContent,
+  hadMissingAttributes,
+})
+
+const convertToFolderCustomizationInfo = ({
+  xmlContent, path, hadMissingAttributes,
+}: {
+  xmlContent: string
+  path: string[]
+  hadMissingAttributes: boolean
+}): FolderCustomizationInfo => ({
+  ...convertToCustomizationInfo(xmlContent),
+  path,
+  hadMissingAttributes,
+})
 
 export const convertToXmlContent = (
   customizationInfo: CustomizationInfo
@@ -193,17 +217,27 @@ const transformFiles = (
   )
 
   const transformFile = async (filePath: string): Promise<FileCustomizationInfo> => {
-    const attrsPathParts = filePathToAttrsPath[filePath].split(FILE_CABINET_PATH_SEPARATOR)
+    const attrsPathParts = filePathToAttrsPath[filePath]
+    const fileAttributesContextPromise = attrsPathParts !== undefined
+      ? readFile(osPath.resolve(
+        fileCabinetDirPath,
+        ...attrsPathParts.split(FILE_CABINET_PATH_SEPARATOR)
+      ))
+      : undefined
+
     const filePathParts = filePath.split(FILE_CABINET_PATH_SEPARATOR)
+    const fileContentPromise = readFile(osPath.resolve(fileCabinetDirPath, ...filePathParts))
+
     const [xmlContent, fileContent] = await Promise.all([
-      readFile(osPath.resolve(fileCabinetDirPath, ...attrsPathParts)),
-      readFile(osPath.resolve(fileCabinetDirPath, ...filePathParts)),
+      fileAttributesContextPromise,
+      fileContentPromise,
     ])
-    return convertToFileCustomizationInfo(
-      xmlContent.toString(),
-      filePathParts.slice(1),
-      fileContent
-    )
+    return convertToFileCustomizationInfo({
+      xmlContent: xmlContent?.toString() ?? DEFAULT_FILE_ATTRIBUTES,
+      path: filePathParts.slice(1),
+      fileContent,
+      hadMissingAttributes: xmlContent === undefined,
+    })
   }
 
   return withLimitedConcurrency(
@@ -219,16 +253,42 @@ const transformFolders = (
   const transformFolder = async (folderAttrsPath: string): Promise<FolderCustomizationInfo> => {
     const folderPathParts = folderAttrsPath.split(FILE_CABINET_PATH_SEPARATOR)
     const xmlContent = await readFile(osPath.resolve(fileCabinetDirPath, ...folderPathParts))
-    return convertToFolderCustomizationInfo(
-      xmlContent.toString(),
-      folderPathParts.slice(1, -2)
-    )
+    return convertToFolderCustomizationInfo({
+      xmlContent: xmlContent.toString(),
+      path: folderPathParts.slice(1, -2),
+      hadMissingAttributes: false,
+    })
   }
 
   return withLimitedConcurrency(
     folderAttrsPaths.map(folderAttrsPath => () => transformFolder(folderAttrsPath)),
     READ_CONCURRENCY
   )
+}
+
+const transformFoldersWithoutAttributes = (
+  foldersFromAttributes: FolderCustomizationInfo[],
+  filePaths: string[],
+): FolderCustomizationInfo[] => {
+  const foldersFromAttributesPaths = new Set(
+    foldersFromAttributes
+      .map(folder => folder.path.join(FILE_CABINET_PATH_SEPARATOR))
+  )
+  return _(filePaths)
+    .map(path => path.split(FILE_CABINET_PATH_SEPARATOR))
+    .map(path => path.slice(1, -1))
+    // adding all parent folders
+    .flatMap(path => path.map((p, i) => [...path.slice(0, i), p]))
+    .map(path => path.join(FILE_CABINET_PATH_SEPARATOR))
+    .uniq()
+    .filter(path => !foldersFromAttributesPaths.has(path))
+    .map(path => path.split(FILE_CABINET_PATH_SEPARATOR))
+    .map(path => convertToFolderCustomizationInfo({
+      xmlContent: DEFAULT_FOLDER_ATTRIBUTES,
+      path,
+      hadMissingAttributes: true,
+    }))
+    .value()
 }
 
 const listFilesRecursive = async (dirPath: string): Promise<string[]> =>
@@ -254,7 +314,11 @@ export const parseFileCabinetDir = async (
     transformFiles(filePaths, fileAttrsPaths, fileCabinetDirPath),
     transformFolders(folderAttrsPaths, fileCabinetDirPath),
   ])
-  return [...filesRes, ...foldersRes]
+  return [
+    ...filesRes,
+    ...foldersRes,
+    ...transformFoldersWithoutAttributes(foldersRes, filePaths),
+  ]
 }
 
 export const parseFeaturesXml = async (

--- a/packages/netsuite-adapter/src/client/types.ts
+++ b/packages/netsuite-adapter/src/client/types.ts
@@ -34,10 +34,12 @@ export interface TemplateCustomTypeInfo extends CustomTypeInfo {
 export interface FileCustomizationInfo extends CustomizationInfo {
   path: string[]
   fileContent: Buffer
+  hadMissingAttributes?: boolean
 }
 
 export interface FolderCustomizationInfo extends CustomizationInfo {
   path: string[]
+  hadMissingAttributes?: boolean
 }
 
 export type FileCabinetCustomizationInfo = FileCustomizationInfo | FolderCustomizationInfo

--- a/packages/netsuite-adapter/src/constants.ts
+++ b/packages/netsuite-adapter/src/constants.ts
@@ -84,6 +84,7 @@ export const EXCHANGE_RATE = 'exchangeRate'
 export const PERMISSIONS = 'permissions'
 export const CUSTOM_FIELD = 'customField'
 export const CUSTOM_FIELD_LIST = 'customFieldList'
+export const CONTENT = 'content'
 
 // Field Annotations
 export const SOAP = 'soap'

--- a/packages/netsuite-adapter/src/sdf_folder_loader.ts
+++ b/packages/netsuite-adapter/src/sdf_folder_loader.ts
@@ -40,7 +40,7 @@ const loadElementsFromFolder = async (
     filters,
   )
   const customizationInfos = await parseSdfProjectDir(baseDir)
-  const elements = await createElements(customizationInfos, getElemIdFunc)
+  const elements = await createElements(customizationInfos, elementsSource, getElemIdFunc)
   await filtersRunner.onFetch(elements)
 
   return { elements }

--- a/packages/netsuite-adapter/src/types/file_cabinet_types.ts
+++ b/packages/netsuite-adapter/src/types/file_cabinet_types.ts
@@ -26,7 +26,7 @@ export const fileType = (): ObjectType => new ObjectType({
   annotations: {
   },
   fields: {
-    path: {
+    [constants.PATH]: {
       refType: BuiltinTypes.SERVICE_ID,
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
@@ -35,7 +35,7 @@ export const fileType = (): ObjectType => new ObjectType({
         }),
       },
     },
-    content: {
+    [constants.CONTENT]: {
       refType: fieldTypes.fileContent,
       annotations: {
       },
@@ -92,7 +92,7 @@ export const folderType = (): ObjectType => new ObjectType({
   annotations: {
   },
   fields: {
-    path: {
+    [constants.PATH]: {
       refType: BuiltinTypes.SERVICE_ID,
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -159,6 +159,7 @@ describe('Adapter', () => {
 
   describe('fetch', () => {
     it('should fetch all types and instances that are not in fetch.exclude', async () => {
+      const mockElementsSource = buildElementsSourceFromElements([])
       const folderCustomizationInfo: FolderCustomizationInfo = {
         typeName: FOLDER,
         values: {
@@ -229,6 +230,7 @@ describe('Adapter', () => {
         await createInstanceElement(
           customTypeInfo,
           customFieldType as ObjectType,
+          mockElementsSource,
           mockGetElemIdFunc
         )
       )
@@ -240,6 +242,7 @@ describe('Adapter', () => {
         await createInstanceElement(
           fileCustomizationInfo,
           file as ObjectType,
+          mockElementsSource,
           mockGetElemIdFunc
         )
       )
@@ -251,6 +254,7 @@ describe('Adapter', () => {
         await createInstanceElement(
           folderCustomizationInfo,
           folder as ObjectType,
+          mockElementsSource,
           mockGetElemIdFunc
         )
       )
@@ -262,6 +266,7 @@ describe('Adapter', () => {
         await createInstanceElement(
           featuresCustomTypeInfo,
           featuresType as ObjectType,
+          mockElementsSource,
           mockGetElemIdFunc
         )
       )

--- a/packages/netsuite-adapter/test/client/mocks.ts
+++ b/packages/netsuite-adapter/test/client/mocks.ts
@@ -20,6 +20,7 @@ export const MOCK_TEMPLATE_CONTENT = Buffer.from('Template Inner Content')
 export const MOCK_FOLDER_PATH = `${osPath.sep}Templates${osPath.sep}E-mail Templates${osPath.sep}InnerFolder`
 export const MOCK_FILE_PATH = `${MOCK_FOLDER_PATH}${osPath.sep}content.html`
 export const MOCK_FILE_ATTRS_PATH = `${osPath.sep}Templates${osPath.sep}E-mail Templates${osPath.sep}InnerFolder${osPath.sep}${ATTRIBUTES_FOLDER_NAME}${osPath.sep}content.html${ATTRIBUTES_FILE_SUFFIX}`
+export const MOCK_FILE_WITHOUT_ATTRIBUTES_PATH = `${MOCK_FOLDER_PATH}${osPath.sep}test.js`
 export const MOCK_FOLDER_ATTRS_PATH = `${osPath.sep}Templates${osPath.sep}E-mail Templates${osPath.sep}InnerFolder${osPath.sep}${ATTRIBUTES_FOLDER_NAME}${osPath.sep}${FOLDER_ATTRIBUTES_FILE_SUFFIX}`
 export const TIME_DATE_FORMAT = 'YYYY-MM-DD h:mm a'
 
@@ -119,6 +120,9 @@ export const readFileMockFunction = (filePath: string): string | Buffer => {
   }
   if (filePath.endsWith(MOCK_FOLDER_ATTRS_PATH)) {
     return '<folder><description>folder description</description></folder>'
+  }
+  if (filePath.endsWith(MOCK_FILE_WITHOUT_ATTRIBUTES_PATH)) {
+    return 'console.log("Hello World!")'
   }
 
   if (filePath.endsWith('manifest.xml')) {

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -1108,7 +1108,7 @@ describe('sdf client', () => {
       })
       const { elements, failedPaths } = await client.importFileCabinetContent(allFilesQuery, maxFileCabinetSizeInGB)
       expect(readFileMock).toHaveBeenCalledTimes(3)
-      expect(elements).toHaveLength(2)
+      expect(elements).toHaveLength(4)
       expect(elements).toEqual([{
         typeName: 'file',
         values: {
@@ -1116,6 +1116,7 @@ describe('sdf client', () => {
         },
         path: ['Templates', 'E-mail Templates', 'InnerFolder', 'content.html'],
         fileContent: 'dummy file content',
+        hadMissingAttributes: false,
       },
       {
         typeName: 'folder',
@@ -1123,6 +1124,29 @@ describe('sdf client', () => {
           description: 'folder description',
         },
         path: ['Templates', 'E-mail Templates', 'InnerFolder'],
+        hadMissingAttributes: false,
+      },
+      {
+        typeName: 'folder',
+        values: {
+          bundleable: 'F',
+          description: '',
+          isinactive: 'F',
+          isprivate: 'F',
+        },
+        path: ['Templates'],
+        hadMissingAttributes: true,
+      },
+      {
+        typeName: 'folder',
+        values: {
+          bundleable: 'F',
+          description: '',
+          isinactive: 'F',
+          isprivate: 'F',
+        },
+        path: ['Templates', 'E-mail Templates'],
+        hadMissingAttributes: true,
       }])
       expect(failedPaths).toEqual({ lockedError: [], largeFolderError: [], otherError: [] })
       expect(mockExecuteAction).toHaveBeenNthCalledWith(1, createProjectCommandMatcher)
@@ -1219,6 +1243,7 @@ describe('sdf client', () => {
           description: 'folder description',
         },
         path: ['Templates', 'E-mail Templates', 'InnerFolder'],
+        hadMissingAttributes: false,
       }])
       expect(failedPaths).toEqual({ lockedError: [], largeFolderError: [], otherError: [] })
       expect(rmMock).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
Today we need all files&folders in the SDF Project’s “FileCabinet” directory to have their metadata xmls in the .attributes folder. For SDF, it is supported to deploy a file without it’s metadata xml - if the file already exists in the account only its content is updated, and if it is a new file then it gets the default metadata (non checkbox is marked, no description, etc).

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Support loading files without their attributes in SDF integration

---
_User Notifications_: 
None
