### PR TITLE
SALTO-4458 improve path index hints generation consistency

### DIFF
--- a/packages/workspace/src/workspace/path_index.ts
+++ b/packages/workspace/src/workspace/path_index.ts
@@ -43,14 +43,14 @@ export type PathIndex = RemoteMap<Path[]>
 const getValuePathHints = (fragments: Fragment<Value>[], elemID: ElemID): PathHint[] => {
   // We only have 3 cases to handle: Object type (which can be split among files)
   // or a single list/primitive value.
-  const valueTopLevelKey = [{
-    key: elemID.getFullName(),
-    value: makeArray(fragments.map(f => f.path)),
-  }]
   if (fragments.length === 0) {
     // No fragments with this ID, so no path hints needed
     return []
   }
+  const valueTopLevelKey = [{
+    key: elemID.getFullName(),
+    value: makeArray(fragments.map(f => f.path)),
+  }]
   if (fragments.length === 1) {
     return valueTopLevelKey
   }

--- a/packages/workspace/src/workspace/path_index.ts
+++ b/packages/workspace/src/workspace/path_index.ts
@@ -131,7 +131,7 @@ const getFieldsPathHints = (
 }
 
 
-const getTypePathHints = (
+const getObjectTypePathHints = (
   elementFragments: Fragment<Element>[]
 ): PathHint[] => {
   const annoTypesHints = getAnnotationTypesPathHints(elementFragments)
@@ -174,7 +174,7 @@ const getElementPathHints = (
   if (isInstanceElement(elementFragments[0].value)) {
     return getInstancePathHints(elementFragments)
   }
-  return getTypePathHints(elementFragments)
+  return getObjectTypePathHints(elementFragments)
 }
 
 export const getElementsPathHints = (unmergedElements: Element[]):

--- a/packages/workspace/src/workspace/path_index.ts
+++ b/packages/workspace/src/workspace/path_index.ts
@@ -90,17 +90,10 @@ const getAnnotationTypesPathHints = (
 
 const getAnnotationPathHints = (
   fragments: Fragment<Element>[],
-): PathHint[] => {
-  const elem = fragments[0].value
-  // I need a comment
-  if (isInstanceElement(elem)) {
-    return []
-  }
-  return getValuePathHints(
-    fragments.filter(f => !_.isEmpty(f.value.annotations)).map(f => ({ value: f.value.annotations, path: f.path })),
-    elem.elemID.createNestedID('attr'),
-  )
-}
+): PathHint[] => getValuePathHints(
+  fragments.filter(f => !_.isEmpty(f.value.annotations)).map(f => ({ value: f.value.annotations, path: f.path })),
+  fragments[0].value.elemID.createNestedID('attr'),
+)
 
 const getFieldPathHints = (
   fragments: Fragment<Field>[],
@@ -170,7 +163,6 @@ const getElementPathHints = (
       value: [elementFragments[0].path],
     }]
   }
-  // In instances the elemIds of values and attributes are not seperated
   if (isInstanceElement(elementFragments[0].value)) {
     return getInstancePathHints(elementFragments)
   }

--- a/packages/workspace/src/workspace/path_index.ts
+++ b/packages/workspace/src/workspace/path_index.ts
@@ -309,10 +309,6 @@ export const splitElementByPath = async (
   element: Element,
   index: PathIndex
 ): Promise<Element[]> => {
-  const indexEntries = await awu(index.entries()).toArray()
-  if (!indexEntries) {
-    return [element]
-  }
   const pathHints = await getFromPathIndex(element.elemID, index)
   if (pathHints.length <= 1) {
     const clonedElement = element.clone()

--- a/packages/workspace/test/workspace/path_index.test.ts
+++ b/packages/workspace/test/workspace/path_index.test.ts
@@ -546,8 +546,9 @@ describe('getElementsPathHints', () => {
     })
     const pathHints = getElementsPathHints([singlePath])
     expect(pathHints.length).toEqual(1)
-    const hintsKeys = pathHints.map(p => p.key)
-    expect(hintsKeys).toContain('salto.obj')
+    expect(pathHints).toEqual(expect.arrayContaining([
+      expect.objectContaining({ key: 'salto.obj', value: [['salto', 'obj', 'simple']] }),
+    ]))
   })
 
   it('should return one path hint for annotations and one for fields in ObjectType', async () => {
@@ -576,17 +577,12 @@ describe('getElementsPathHints', () => {
     })
     const pathHints = getElementsPathHints([singleFieldObj, singleFieldObjAnnotations])
     expect(pathHints.length).toEqual(4)
-    const hintsKeys = pathHints.map(p => p.key)
-    expect(hintsKeys).toContain('salto.obj')
-    const fieldHints = pathHints.filter(p => p.key.includes('field'))
-    expect(hintsKeys).toContain('salto.obj.field')
-    expect(fieldHints.length).toEqual(1)
-    expect(fieldHints[0].value.length).toEqual(1)
-    const annoHints = pathHints.filter(p => p.key.includes('annotation'))
-    expect(hintsKeys).toContain('salto.obj.annotation')
-    expect(annoHints.length).toEqual(1)
-    expect(annoHints[0].value.length).toEqual(1)
-    expect(hintsKeys).toContain('salto.obj.attr')
+    expect(pathHints).toEqual(expect.arrayContaining([
+      expect.objectContaining({ key: 'salto.obj', value: [['salto', 'obj', 'field'], ['salto', 'obj', 'annotations']] }),
+      expect.objectContaining({ key: 'salto.obj.attr', value: [['salto', 'obj', 'annotations']] }),
+      expect.objectContaining({ key: 'salto.obj.annotation', value: [['salto', 'obj', 'annotations']] }),
+      expect.objectContaining({ key: 'salto.obj.field', value: [['salto', 'obj', 'field']] }),
+    ]))
   })
 
   it('should return path hints for divided annotations and divided fields in ObjectType', async () => {
@@ -638,24 +634,19 @@ describe('getElementsPathHints', () => {
       objFragAnnotationsOne, objFragAnnotationsTwo, objFragStdFields, objFragCustomFields,
     ])
     expect(pathHints.length).toEqual(10)
-    const hintsKeys = pathHints.map(p => p.key)
-    expect(hintsKeys).toContain('salto.obj')
-    const fieldHints = pathHints.filter(p => p.key.includes('field'))
-    expect(fieldHints.length).toEqual(3)
-    expect(fieldHints[0].value.length).toEqual(2)
-    expect(hintsKeys).toContain('salto.obj.field')
-    expect(hintsKeys).toContain('salto.obj.field.stdField')
-    expect(hintsKeys).toContain('salto.obj.field.customField')
-    const annoHints = pathHints.filter(p => p.key.includes('annotation'))
-    expect(annoHints.length).toEqual(3)
-    expect(annoHints[0].value.length).toEqual(2)
-    expect(hintsKeys).toContain('salto.obj.annotation')
-    expect(hintsKeys).toContain('salto.obj.annotation.anno')
-    expect(hintsKeys).toContain('salto.obj.annotation.ping')
-    const attrHints = pathHints.filter(p => p.key.includes('attr'))
-    expect(attrHints.length).toEqual(3)
-    expect(attrHints[0].value.length).toEqual(2)
-    expect(hintsKeys).toContain('salto.obj.attr')
+    expect(pathHints).toEqual(expect.arrayContaining([
+      expect.objectContaining({ key: 'salto.obj.annotation', value: [['salto', 'obj', 'annotationsOne'], ['salto', 'obj', 'annotationsTwo']] }),
+      expect.objectContaining({ key: 'salto.obj.annotation.anno', value: [['salto', 'obj', 'annotationsOne']] }),
+      expect.objectContaining({ key: 'salto.obj.annotation.ping', value: [['salto', 'obj', 'annotationsTwo']] }),
+      expect.objectContaining({ key: 'salto.obj.attr', value: [['salto', 'obj', 'annotationsOne'], ['salto', 'obj', 'annotationsTwo']] }),
+      expect.objectContaining({ key: 'salto.obj.attr.anno', value: [['salto', 'obj', 'annotationsOne']] }),
+      expect.objectContaining({ key: 'salto.obj.attr.ping', value: [['salto', 'obj', 'annotationsTwo']] }),
+      expect.objectContaining({ key: 'salto.obj.field', value: [['salto', 'obj', 'standardFields'], ['salto', 'obj', 'customFields']] }),
+      expect.objectContaining({ key: 'salto.obj.field.stdField', value: [['salto', 'obj', 'standardFields']] }),
+      expect.objectContaining({ key: 'salto.obj.field.customField', value: [['salto', 'obj', 'customFields']] }),
+      expect.objectContaining({ key: 'salto.obj', value: [['salto', 'obj', 'annotationsOne'], ['salto', 'obj', 'annotationsTwo'], ['salto', 'obj', 'standardFields'], ['salto', 'obj', 'customFields']] }),
+
+    ]))
   })
 
   it('should return path hints for nested fields in ObjectType', async () => {
@@ -684,15 +675,14 @@ describe('getElementsPathHints', () => {
       path: ['salto', 'obj', 'two'],
     })
     const pathHints = getElementsPathHints([objFragFieldOne, objFragFieldTwo])
-    const hintsKeys = pathHints.map(p => p.key)
-    expect(hintsKeys).toContain('salto.obj')
-    const fieldHints = pathHints.filter(p => p.key.includes('field'))
-    expect(fieldHints.length).toEqual(4)
-    expect(fieldHints[0].value.length).toEqual(2)
-    expect(hintsKeys).toContain('salto.obj.field')
-    expect(hintsKeys).toContain('salto.obj.field.myField')
-    expect(hintsKeys).toContain('salto.obj.field.myField.test')
-    expect(hintsKeys).toContain('salto.obj.field.myField.yo')
+    expect(pathHints.length).toEqual(5)
+    expect(pathHints).toEqual(expect.arrayContaining([
+      expect.objectContaining({ key: 'salto.obj', value: [['salto', 'obj', 'one'], ['salto', 'obj', 'two']] }),
+      expect.objectContaining({ key: 'salto.obj.field', value: [['salto', 'obj', 'one'], ['salto', 'obj', 'two']] }),
+      expect.objectContaining({ key: 'salto.obj.field.myField', value: [['salto', 'obj', 'one'], ['salto', 'obj', 'two']] }),
+      expect.objectContaining({ key: 'salto.obj.field.myField.test', value: [['salto', 'obj', 'one']] }),
+      expect.objectContaining({ key: 'salto.obj.field.myField.yo', value: [['salto', 'obj', 'two']] }),
+    ]))
   })
 
   it('should return path hints for nested values in an instances', async () => {
@@ -725,12 +715,13 @@ describe('getElementsPathHints', () => {
     )
     const pathHints = getElementsPathHints([instFragOne, instFragTwo, instAnnotations])
     expect(pathHints.length).toEqual(5)
-    const hintsKeys = pathHints.map(p => p.key)
-    expect(hintsKeys).toContain('salto.obj.instance.inst')
-    expect(hintsKeys).toContain('salto.obj.instance.inst.anno')
-    expect(hintsKeys).toContain('salto.obj.instance.inst.a')
-    expect(hintsKeys).toContain('salto.obj.instance.inst.a.b')
-    expect(hintsKeys).toContain('salto.obj.instance.inst.a.c')
+    expect(pathHints).toEqual(expect.arrayContaining([
+      expect.objectContaining({ key: 'salto.obj.instance.inst', value: [['salto', 'inst', 'A', 'B'], ['salto', 'inst', 'A', 'C'], ['salto', 'inst', 'annotations']] }),
+      expect.objectContaining({ key: 'salto.obj.instance.inst.a', value: [['salto', 'inst', 'A', 'B'], ['salto', 'inst', 'A', 'C']] }),
+      expect.objectContaining({ key: 'salto.obj.instance.inst.a.b', value: [['salto', 'inst', 'A', 'B']] }),
+      expect.objectContaining({ key: 'salto.obj.instance.inst.a.c', value: [['salto', 'inst', 'A', 'C']] }),
+      expect.objectContaining({ key: 'salto.obj.instance.inst.anno', value: [['salto', 'inst', 'annotations']] }),
+    ]))
   })
 
   it('should return path hints for divided annotations in PrimitiveType', async () => {
@@ -758,16 +749,14 @@ describe('getElementsPathHints', () => {
     })
     const pathHints = getElementsPathHints([primitiveAnnotaionsA, primitiveAnnotaionsB])
     expect(pathHints.length).toEqual(7)
-    const hintsKeys = pathHints.map(p => p.key)
-    expect(hintsKeys).toContain('salto.primitive')
-    expect(hintsKeys).not.toContain('salto.primitive.field')
-    expect(hintsKeys).toContain('salto.primitive.annotation')
-    const annoHints = pathHints.filter(p => p.key.includes('annotation'))
-    expect(annoHints.length).toEqual(3)
-    expect(annoHints[0].value.length).toEqual(2)
-    expect(hintsKeys).toContain('salto.primitive.attr')
-    const attrHints = pathHints.filter(p => p.key.includes('attr'))
-    expect(attrHints.length).toEqual(3)
-    expect(attrHints[0].value.length).toEqual(2)
+    expect(pathHints).toEqual(expect.arrayContaining([
+      expect.objectContaining({ key: 'salto.primitive.annotation', value: [['salto', 'primitive', 'a'], ['salto', 'primitive', 'b']] }),
+      expect.objectContaining({ key: 'salto.primitive.annotation.a', value: [['salto', 'primitive', 'a']] }),
+      expect.objectContaining({ key: 'salto.primitive.annotation.b', value: [['salto', 'primitive', 'b']] }),
+      expect.objectContaining({ key: 'salto.primitive.attr', value: [['salto', 'primitive', 'a'], ['salto', 'primitive', 'b']] }),
+      expect.objectContaining({ key: 'salto.primitive.attr.a', value: [['salto', 'primitive', 'a']] }),
+      expect.objectContaining({ key: 'salto.primitive.attr.b', value: [['salto', 'primitive', 'b']] }),
+      expect.objectContaining({ key: 'salto.primitive', value: [['salto', 'primitive', 'a'], ['salto', 'primitive', 'b']] }),
+    ]))
   })
 })

--- a/packages/workspace/test/workspace/path_index.test.ts
+++ b/packages/workspace/test/workspace/path_index.test.ts
@@ -540,18 +540,20 @@ describe('updatePathIndex', () => {
 describe('getElementsPathHints', () => {
   const elemId = new ElemID('salto', 'obj')
   it('should return one path hint for single path ObjectType with no annotations and fields', async () => {
-    const singlePath = new ObjectType({
+    const singlePath = ['salto', 'obj', 'simple']
+    const singlePathObjectWithoutFieldAndAnnotation = new ObjectType({
       elemID: elemId,
-      path: ['salto', 'obj', 'simple'],
+      path: singlePath,
     })
-    const pathHints = getElementsPathHints([singlePath])
-    expect(pathHints.length).toEqual(1)
+    const pathHints = getElementsPathHints([singlePathObjectWithoutFieldAndAnnotation])
     expect(pathHints).toEqual(expect.arrayContaining([
-      expect.objectContaining({ key: 'salto.obj', value: [['salto', 'obj', 'simple']] }),
+      expect.objectContaining({ key: 'salto.obj', value: [singlePath] }),
     ]))
   })
 
   it('should return one path hint for annotations and one for fields in ObjectType', async () => {
+    const fieldPath = ['salto', 'obj', 'field']
+    const annotationPath = ['salto', 'obj', 'annotations']
     const singleFieldObj = new ObjectType({
       elemID: elemId,
       fields: {
@@ -562,7 +564,7 @@ describe('getElementsPathHints', () => {
           },
         },
       },
-      path: ['salto', 'obj', 'field'],
+      path: fieldPath,
     })
 
     const singleFieldObjAnnotations = new ObjectType({
@@ -573,19 +575,22 @@ describe('getElementsPathHints', () => {
       annotations: {
         anno: 'Bye',
       },
-      path: ['salto', 'obj', 'annotations'],
+      path: annotationPath,
     })
     const pathHints = getElementsPathHints([singleFieldObj, singleFieldObjAnnotations])
-    expect(pathHints.length).toEqual(4)
     expect(pathHints).toEqual(expect.arrayContaining([
-      expect.objectContaining({ key: 'salto.obj', value: [['salto', 'obj', 'field'], ['salto', 'obj', 'annotations']] }),
-      expect.objectContaining({ key: 'salto.obj.attr', value: [['salto', 'obj', 'annotations']] }),
-      expect.objectContaining({ key: 'salto.obj.annotation', value: [['salto', 'obj', 'annotations']] }),
-      expect.objectContaining({ key: 'salto.obj.field', value: [['salto', 'obj', 'field']] }),
+      expect.objectContaining({ key: 'salto.obj', value: [fieldPath, annotationPath] }),
+      expect.objectContaining({ key: 'salto.obj.attr', value: [annotationPath] }),
+      expect.objectContaining({ key: 'salto.obj.annotation', value: [annotationPath] }),
+      expect.objectContaining({ key: 'salto.obj.field', value: [fieldPath] }),
     ]))
   })
 
   it('should return path hints for divided annotations and divided fields in ObjectType', async () => {
+    const stdFieldPath = ['salto', 'obj', 'standardFields']
+    const customFieldPath = ['salto', 'obj', 'customFields']
+    const annotationOnePath = ['salto', 'obj', 'annotationsOne']
+    const annotationTwoPath = ['salto', 'obj', 'annotationsTwo']
     const objFragStdFields = new ObjectType({
       elemID: elemId,
       fields: {
@@ -596,7 +601,7 @@ describe('getElementsPathHints', () => {
           },
         },
       },
-      path: ['salto', 'obj', 'standardFields'],
+      path: stdFieldPath,
     })
     const objFragCustomFields = new ObjectType({
       elemID: elemId,
@@ -608,7 +613,7 @@ describe('getElementsPathHints', () => {
           },
         },
       },
-      path: ['salto', 'obj', 'customFields'],
+      path: customFieldPath,
     })
     const objFragAnnotationsOne = new ObjectType({
       elemID: elemId,
@@ -618,7 +623,7 @@ describe('getElementsPathHints', () => {
       annotations: {
         anno: 'Hey',
       },
-      path: ['salto', 'obj', 'annotationsOne'],
+      path: annotationOnePath,
     })
     const objFragAnnotationsTwo = new ObjectType({
       elemID: elemId,
@@ -628,28 +633,29 @@ describe('getElementsPathHints', () => {
       annotations: {
         ping: 'pong',
       },
-      path: ['salto', 'obj', 'annotationsTwo'],
+      path: annotationTwoPath,
     })
     const pathHints = getElementsPathHints([
       objFragAnnotationsOne, objFragAnnotationsTwo, objFragStdFields, objFragCustomFields,
     ])
-    expect(pathHints.length).toEqual(10)
     expect(pathHints).toEqual(expect.arrayContaining([
-      expect.objectContaining({ key: 'salto.obj.annotation', value: [['salto', 'obj', 'annotationsOne'], ['salto', 'obj', 'annotationsTwo']] }),
-      expect.objectContaining({ key: 'salto.obj.annotation.anno', value: [['salto', 'obj', 'annotationsOne']] }),
-      expect.objectContaining({ key: 'salto.obj.annotation.ping', value: [['salto', 'obj', 'annotationsTwo']] }),
-      expect.objectContaining({ key: 'salto.obj.attr', value: [['salto', 'obj', 'annotationsOne'], ['salto', 'obj', 'annotationsTwo']] }),
-      expect.objectContaining({ key: 'salto.obj.attr.anno', value: [['salto', 'obj', 'annotationsOne']] }),
-      expect.objectContaining({ key: 'salto.obj.attr.ping', value: [['salto', 'obj', 'annotationsTwo']] }),
-      expect.objectContaining({ key: 'salto.obj.field', value: [['salto', 'obj', 'standardFields'], ['salto', 'obj', 'customFields']] }),
-      expect.objectContaining({ key: 'salto.obj.field.stdField', value: [['salto', 'obj', 'standardFields']] }),
-      expect.objectContaining({ key: 'salto.obj.field.customField', value: [['salto', 'obj', 'customFields']] }),
-      expect.objectContaining({ key: 'salto.obj', value: [['salto', 'obj', 'annotationsOne'], ['salto', 'obj', 'annotationsTwo'], ['salto', 'obj', 'standardFields'], ['salto', 'obj', 'customFields']] }),
+      expect.objectContaining({ key: 'salto.obj.annotation', value: [annotationOnePath, annotationTwoPath] }),
+      expect.objectContaining({ key: 'salto.obj.annotation.anno', value: [annotationOnePath] }),
+      expect.objectContaining({ key: 'salto.obj.annotation.ping', value: [annotationTwoPath] }),
+      expect.objectContaining({ key: 'salto.obj.attr', value: [annotationOnePath, annotationTwoPath] }),
+      expect.objectContaining({ key: 'salto.obj.attr.anno', value: [annotationOnePath] }),
+      expect.objectContaining({ key: 'salto.obj.attr.ping', value: [annotationTwoPath] }),
+      expect.objectContaining({ key: 'salto.obj.field', value: [stdFieldPath, customFieldPath] }),
+      expect.objectContaining({ key: 'salto.obj.field.stdField', value: [stdFieldPath] }),
+      expect.objectContaining({ key: 'salto.obj.field.customField', value: [customFieldPath] }),
+      expect.objectContaining({ key: 'salto.obj', value: [annotationOnePath, annotationTwoPath, stdFieldPath, customFieldPath] }),
 
     ]))
   })
 
   it('should return path hints for nested fields in ObjectType', async () => {
+    const onePath = ['salto', 'obj', 'one']
+    const twoPath = ['salto', 'obj', 'two']
     const objFragFieldOne = new ObjectType({
       elemID: elemId,
       fields: {
@@ -660,7 +666,7 @@ describe('getElementsPathHints', () => {
           },
         },
       },
-      path: ['salto', 'obj', 'one'],
+      path: onePath,
     })
     const objFragFieldTwo = new ObjectType({
       elemID: elemId,
@@ -672,20 +678,22 @@ describe('getElementsPathHints', () => {
           },
         },
       },
-      path: ['salto', 'obj', 'two'],
+      path: twoPath,
     })
     const pathHints = getElementsPathHints([objFragFieldOne, objFragFieldTwo])
-    expect(pathHints.length).toEqual(5)
     expect(pathHints).toEqual(expect.arrayContaining([
-      expect.objectContaining({ key: 'salto.obj', value: [['salto', 'obj', 'one'], ['salto', 'obj', 'two']] }),
-      expect.objectContaining({ key: 'salto.obj.field', value: [['salto', 'obj', 'one'], ['salto', 'obj', 'two']] }),
-      expect.objectContaining({ key: 'salto.obj.field.myField', value: [['salto', 'obj', 'one'], ['salto', 'obj', 'two']] }),
-      expect.objectContaining({ key: 'salto.obj.field.myField.test', value: [['salto', 'obj', 'one']] }),
-      expect.objectContaining({ key: 'salto.obj.field.myField.yo', value: [['salto', 'obj', 'two']] }),
+      expect.objectContaining({ key: 'salto.obj', value: [onePath, twoPath] }),
+      expect.objectContaining({ key: 'salto.obj.field', value: [onePath, twoPath] }),
+      expect.objectContaining({ key: 'salto.obj.field.myField', value: [onePath, twoPath] }),
+      expect.objectContaining({ key: 'salto.obj.field.myField.test', value: [onePath] }),
+      expect.objectContaining({ key: 'salto.obj.field.myField.yo', value: [twoPath] }),
     ]))
   })
 
   it('should return path hints for nested values in an instances', async () => {
+    const abFilePath = ['salto', 'inst', 'A', 'B']
+    const acFilePath = ['salto', 'inst', 'A', 'C']
+    const annotationsPath = ['salto', 'inst', 'annotations']
     const instFragOne = new InstanceElement(
       'inst',
       new TypeReference(multiPathInstanceTypeID),
@@ -694,7 +702,7 @@ describe('getElementsPathHints', () => {
           b: 'd',
         },
       },
-      ['salto', 'inst', 'A', 'B']
+      abFilePath
     )
     const instFragTwo = new InstanceElement(
       'inst',
@@ -704,27 +712,28 @@ describe('getElementsPathHints', () => {
           c: 'd',
         },
       },
-      ['salto', 'inst', 'A', 'C']
+      acFilePath
     )
     const instAnnotations = new InstanceElement(
       'inst',
       new TypeReference(multiPathInstanceTypeID),
       {},
-      ['salto', 'inst', 'annotations'],
+      annotationsPath,
       { anno: 'hey' }
     )
     const pathHints = getElementsPathHints([instFragOne, instFragTwo, instAnnotations])
-    expect(pathHints.length).toEqual(5)
     expect(pathHints).toEqual(expect.arrayContaining([
-      expect.objectContaining({ key: 'salto.obj.instance.inst', value: [['salto', 'inst', 'A', 'B'], ['salto', 'inst', 'A', 'C'], ['salto', 'inst', 'annotations']] }),
-      expect.objectContaining({ key: 'salto.obj.instance.inst.a', value: [['salto', 'inst', 'A', 'B'], ['salto', 'inst', 'A', 'C']] }),
-      expect.objectContaining({ key: 'salto.obj.instance.inst.a.b', value: [['salto', 'inst', 'A', 'B']] }),
-      expect.objectContaining({ key: 'salto.obj.instance.inst.a.c', value: [['salto', 'inst', 'A', 'C']] }),
-      expect.objectContaining({ key: 'salto.obj.instance.inst.anno', value: [['salto', 'inst', 'annotations']] }),
+      expect.objectContaining({ key: 'salto.obj.instance.inst', value: [abFilePath, acFilePath, annotationsPath] }),
+      expect.objectContaining({ key: 'salto.obj.instance.inst.a', value: [abFilePath, acFilePath] }),
+      expect.objectContaining({ key: 'salto.obj.instance.inst.a.b', value: [abFilePath] }),
+      expect.objectContaining({ key: 'salto.obj.instance.inst.a.c', value: [acFilePath] }),
+      expect.objectContaining({ key: 'salto.obj.instance.inst.anno', value: [annotationsPath] }),
     ]))
   })
 
   it('should return path hints for divided annotations in PrimitiveType', async () => {
+    const aFilePath = ['salto', 'primitive', 'a']
+    const bFilePath = ['salto', 'primitive', 'b']
     const primitiveAnnotaionsA = new PrimitiveType({
       elemID: new ElemID('salto', 'primitive'),
       primitive: PrimitiveTypes.STRING,
@@ -734,7 +743,7 @@ describe('getElementsPathHints', () => {
       annotations: {
         a: 'a',
       },
-      path: ['salto', 'primitive', 'a'],
+      path: aFilePath,
     })
     const primitiveAnnotaionsB = new PrimitiveType({
       elemID: new ElemID('salto', 'primitive'),
@@ -745,18 +754,17 @@ describe('getElementsPathHints', () => {
       annotations: {
         b: 'b',
       },
-      path: ['salto', 'primitive', 'b'],
+      path: bFilePath,
     })
     const pathHints = getElementsPathHints([primitiveAnnotaionsA, primitiveAnnotaionsB])
-    expect(pathHints.length).toEqual(7)
     expect(pathHints).toEqual(expect.arrayContaining([
-      expect.objectContaining({ key: 'salto.primitive.annotation', value: [['salto', 'primitive', 'a'], ['salto', 'primitive', 'b']] }),
-      expect.objectContaining({ key: 'salto.primitive.annotation.a', value: [['salto', 'primitive', 'a']] }),
-      expect.objectContaining({ key: 'salto.primitive.annotation.b', value: [['salto', 'primitive', 'b']] }),
-      expect.objectContaining({ key: 'salto.primitive.attr', value: [['salto', 'primitive', 'a'], ['salto', 'primitive', 'b']] }),
-      expect.objectContaining({ key: 'salto.primitive.attr.a', value: [['salto', 'primitive', 'a']] }),
-      expect.objectContaining({ key: 'salto.primitive.attr.b', value: [['salto', 'primitive', 'b']] }),
-      expect.objectContaining({ key: 'salto.primitive', value: [['salto', 'primitive', 'a'], ['salto', 'primitive', 'b']] }),
+      expect.objectContaining({ key: 'salto.primitive.annotation', value: [aFilePath, bFilePath] }),
+      expect.objectContaining({ key: 'salto.primitive.annotation.a', value: [aFilePath] }),
+      expect.objectContaining({ key: 'salto.primitive.annotation.b', value: [bFilePath] }),
+      expect.objectContaining({ key: 'salto.primitive.attr', value: [aFilePath, bFilePath] }),
+      expect.objectContaining({ key: 'salto.primitive.attr.a', value: [aFilePath] }),
+      expect.objectContaining({ key: 'salto.primitive.attr.b', value: [bFilePath] }),
+      expect.objectContaining({ key: 'salto.primitive', value: [aFilePath, bFilePath] }),
     ]))
   })
 })

--- a/packages/workspace/test/workspace/path_index.test.ts
+++ b/packages/workspace/test/workspace/path_index.test.ts
@@ -422,7 +422,8 @@ describe('split element by path', () => {
     singleFieldObj, singleFieldObjAnnotations,
   ]
   const unmergedElements = [
-    ...fullObjFrags, ...singleFieldObjFrags, singlePathObj, noPathObj, multiPathInstanceA, multiPathInstanceB,
+    multiPathInstanceB, multiPathInstanceA,
+    //    ...fullObjFrags, ...singleFieldObjFrags, singlePathObj, noPathObj, multiPathInstanceA, multiPathInstanceB,
   ]
   const pi = new InMemoryRemoteMap<Path[]>()
 

--- a/packages/workspace/test/workspace/path_index.test.ts
+++ b/packages/workspace/test/workspace/path_index.test.ts
@@ -546,6 +546,8 @@ describe('getElementsPathHints', () => {
     })
     const pathHints = getElementsPathHints([singlePath])
     expect(pathHints.length).toEqual(1)
+    const hintsKeys = pathHints.map(p => p.key)
+    expect(hintsKeys).toContain('salto.obj')
   })
 
   it('should return one path hint for annotations and one for fields', async () => {
@@ -574,12 +576,17 @@ describe('getElementsPathHints', () => {
     })
     const pathHints = getElementsPathHints([singleFieldObj, singleFieldObjAnnotations])
     expect(pathHints.length).toEqual(4)
+    const hintsKeys = pathHints.map(p => p.key)
+    expect(hintsKeys).toContain('salto.obj')
     const fieldHints = pathHints.filter(p => p.key.includes('field'))
+    expect(hintsKeys).toContain('salto.obj.field')
     expect(fieldHints.length).toEqual(1)
     expect(fieldHints[0].value.length).toEqual(1)
     const annoHints = pathHints.filter(p => p.key.includes('annotation'))
+    expect(hintsKeys).toContain('salto.obj.annotation')
     expect(annoHints.length).toEqual(1)
     expect(annoHints[0].value.length).toEqual(1)
+    expect(hintsKeys).toContain('salto.obj.attr')
   })
 
   it('should return path hints for divided annotations and divided fields', async () => {
@@ -631,15 +638,24 @@ describe('getElementsPathHints', () => {
       objFragAnnotationsOne, objFragAnnotationsTwo, objFragStdFields, objFragCustomFields,
     ])
     expect(pathHints.length).toEqual(10)
+    const hintsKeys = pathHints.map(p => p.key)
+    expect(hintsKeys).toContain('salto.obj')
     const fieldHints = pathHints.filter(p => p.key.includes('field'))
     expect(fieldHints.length).toEqual(3)
     expect(fieldHints[0].value.length).toEqual(2)
+    expect(hintsKeys).toContain('salto.obj.field')
+    expect(hintsKeys).toContain('salto.obj.field.stdField')
+    expect(hintsKeys).toContain('salto.obj.field.customField')
     const annoHints = pathHints.filter(p => p.key.includes('annotation'))
     expect(annoHints.length).toEqual(3)
     expect(annoHints[0].value.length).toEqual(2)
+    expect(hintsKeys).toContain('salto.obj.annotation')
+    expect(hintsKeys).toContain('salto.obj.annotation.anno')
+    expect(hintsKeys).toContain('salto.obj.annotation.ping')
     const attrHints = pathHints.filter(p => p.key.includes('attr'))
     expect(attrHints.length).toEqual(3)
     expect(attrHints[0].value.length).toEqual(2)
+    expect(hintsKeys).toContain('salto.obj.attr')
   })
 
   it('should return path hints for nested fields', async () => {
@@ -668,13 +684,52 @@ describe('getElementsPathHints', () => {
       path: ['salto', 'obj', 'two'],
     })
     const pathHints = getElementsPathHints([objFragFieldOne, objFragFieldTwo])
+    const hintsKeys = pathHints.map(p => p.key)
+    expect(hintsKeys).toContain('salto.obj')
     const fieldHints = pathHints.filter(p => p.key.includes('field'))
     expect(fieldHints.length).toEqual(4)
     expect(fieldHints[0].value.length).toEqual(2)
+    expect(hintsKeys).toContain('salto.obj.field')
+    expect(hintsKeys).toContain('salto.obj.field.myField')
+    expect(hintsKeys).toContain('salto.obj.field.myField.test')
+    expect(hintsKeys).toContain('salto.obj.field.myField.yo')
   })
 
-  it('should return path hints for instances', async () => {
-    const pathHints = getElementsPathHints([multiPathInstanceA, multiPathInstanceB])
-    expect(pathHints.length).toEqual(4)
+  it('should return path hints for nested values in an instances', async () => {
+    const instFragOne = new InstanceElement(
+      'inst',
+      new TypeReference(multiPathInstanceTypeID),
+      {
+        a: {
+          b: 'd',
+        },
+      },
+      ['salto', 'inst', 'A', 'B']
+    )
+    const instFragTwo = new InstanceElement(
+      'inst',
+      new TypeReference(multiPathInstanceTypeID),
+      {
+        a: {
+          c: 'd',
+        },
+      },
+      ['salto', 'inst', 'A', 'C']
+    )
+    const instAnnotations = new InstanceElement(
+      'inst',
+      new TypeReference(multiPathInstanceTypeID),
+      {},
+      ['salto', 'inst', 'annotations'],
+      { anno: 'hey' }
+    )
+    const pathHints = getElementsPathHints([instFragOne, instFragTwo, instAnnotations])
+    expect(pathHints.length).toEqual(5)
+    const hintsKeys = pathHints.map(p => p.key)
+    expect(hintsKeys).toContain('salto.obj.instance.inst')
+    expect(hintsKeys).toContain('salto.obj.instance.inst.anno')
+    expect(hintsKeys).toContain('salto.obj.instance.inst.a')
+    expect(hintsKeys).toContain('salto.obj.instance.inst.a.b')
+    expect(hintsKeys).toContain('salto.obj.instance.inst.a.c')
   })
 })


### PR DESCRIPTION
SALTO-4458 improve path index hints generation consistency
we added for keys to the pathIndex such as .annotation .field and .attr elemId (e.g: salto.obj.field).
now when the field of an object are divided between two files `salto.obj.field`   will point to both of them.
And if the few annotation under the same file, we wont have a key of each annotation in the pathIndex. instead `salto.obj.annotation` will point at the relevant file.

---
_Release Notes_: 
none

---
_User Notifications_: 
none
