### PR TITLE
SALTO-3740 Add alias annotation to netsuite elements

### DIFF
--- a/packages/adapter-components/src/add_alias.ts
+++ b/packages/adapter-components/src/add_alias.ts
@@ -18,17 +18,18 @@ import { InstanceElement, CORE_ANNOTATIONS, ElemID, INSTANCE_ANNOTATIONS, isRefe
 import { logger } from '@salto-io/logging'
 
 const log = logger(module)
-type AliasComponent = {
+export type AliasComponent = {
   fieldName: string
   referenceFieldName?: string
 }
 
-type ConstantComponent = {
+export type ConstantComponent = {
   constant: string
 }
 
-export type AliasData = {
-  aliasComponents: (AliasComponent | ConstantComponent)[]
+type Component = AliasComponent | ConstantComponent
+export type AliasData<T extends Component[] = Component[]> = {
+  aliasComponents: T
   separator?: string
 }
 
@@ -67,9 +68,10 @@ const getAliasFromField = ({ element, component, elementsById }:{
     log.error(`${fieldName} is treated as a reference expression but it is not`)
     return undefined
   }
-  const referencedElement = elementsById[fieldValue.elemID.getFullName()]
+  const topLevelReferenceFullName = fieldValue.elemID.createTopLevelParentID().parent.getFullName()
+  const referencedElement = elementsById[topLevelReferenceFullName]
   if (referencedElement === undefined) {
-    log.error(`could not find ${fieldValue.elemID.getFullName()} in elementById`)
+    log.error(`could not find ${topLevelReferenceFullName} in elementById`)
     return undefined
   }
   const referencedFieldValue = getFieldValue(referencedElement, referenceFieldName)

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -60,6 +60,7 @@ import customRecordsFilter from './filters/custom_records'
 import currencyUndeployableFieldsFilter from './filters/currency_omit_fields'
 import additionalChanges from './filters/additional_changes'
 import addInstancesFetchTime from './filters/add_instances_fetch_time'
+import addAliasFilter from './filters/add_alias'
 import { Filter, LocalFilterCreator, LocalFilterCreatorDefinition, RemoteFilterCreator, RemoteFilterCreatorDefinition } from './filter'
 import { getConfigFromConfigChanges, NetsuiteConfig, DEFAULT_DEPLOY_REFERENCED_ELEMENTS, DEFAULT_WARN_STALE_DATA, DEFAULT_VALIDATE, AdditionalDependencies, DEFAULT_MAX_FILE_CABINET_SIZE_IN_GB } from './config'
 import { andQuery, buildNetsuiteQuery, NetsuiteQuery, NetsuiteQueryParameters, notQuery, QueryParams, convertToQueryParams, getFixedTargetFetch } from './query'
@@ -124,6 +125,7 @@ export const allFilters: (LocalFilterCreatorDefinition | RemoteFilterCreatorDefi
   { creator: configFeaturesFilter },
   { creator: customRecordsFilter },
   { creator: addInstancesFetchTime },
+  { creator: addAliasFilter },
   // serviceUrls must run after suiteAppInternalIds and SDFInternalIds filter
   { creator: serviceUrls, addsNewInformation: true },
   // omitFieldsFilter should be the last onFetch filter to run

--- a/packages/netsuite-adapter/src/change_validators/immutable_changes.ts
+++ b/packages/netsuite-adapter/src/change_validators/immutable_changes.ts
@@ -18,7 +18,7 @@ import { getParents } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { APPLICATION_ID, SCRIPT_ID } from '../constants'
-import { TYPE_TO_ID_FIELD_PATHS } from '../data_elements/types'
+import { isTypeWithMultiFieldsIdentifier, TYPE_TO_ID_FIELD_PATHS } from '../data_elements/types'
 import { getElementValueOrAnnotations, isCustomFieldName, isCustomRecordType, isDataObjectType, isFileCabinetType } from '../types'
 import { NetsuiteChangeValidator } from './types'
 
@@ -111,8 +111,7 @@ const toModificationInstanceErrors = async (
   const { before, after } = change.data
   const modifiedImmutableFields = await instanceServiceIdConditions(change, modificationServiceIdCondition)
 
-  if (isDataObjectType(await after.getType())
-    && after.elemID.typeName in TYPE_TO_ID_FIELD_PATHS) {
+  if (isDataObjectType(await after.getType()) && isTypeWithMultiFieldsIdentifier(after.elemID.typeName)) {
     modifiedImmutableFields.push(
       ...TYPE_TO_ID_FIELD_PATHS[after.elemID.typeName]
         .filter(path => _.get(before.value, path) !== _.get(after.value, path))

--- a/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
@@ -31,7 +31,7 @@ import { CustomRecordResponse, DeployListResults, GetAllResponse, GetResult, isD
 import { DEPLOY_LIST_SCHEMA, GET_ALL_RESPONSE_SCHEMA, GET_RESULTS_SCHEMA, SEARCH_RESPONSE_SCHEMA, SEARCH_SUCCESS_SCHEMA } from './schemas'
 import { InvalidSuiteAppCredentialsError } from '../../types'
 import { isCustomRecordType } from '../../../types'
-import { INTERNAL_ID_TO_TYPES, ITEM_TYPE_ID, ITEM_TYPE_TO_SEARCH_STRING, TYPES_TO_INTERNAL_ID } from '../../../data_elements/types'
+import { INTERNAL_ID_TO_TYPES, isItemType, ITEM_TYPE_ID, ITEM_TYPE_TO_SEARCH_STRING, TYPES_TO_INTERNAL_ID } from '../../../data_elements/types'
 import { XSI_TYPE } from '../../constants'
 import { InstanceLimiterFunc } from '../../../config'
 import { toError } from '../../utils'
@@ -404,7 +404,7 @@ export default class SoapClient {
   public async getAllRecords(types: string[]): Promise<RecordResponse> {
     log.debug(`Getting all records of ${types.join(', ')}`)
 
-    const [itemTypes, otherTypes] = _.partition(types, type => type in ITEM_TYPE_TO_SEARCH_STRING)
+    const [itemTypes, otherTypes] = _.partition(types, isItemType)
 
     const typesToSearch: SoapSearchType[] = otherTypes
       .map(type => ({ type }))

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -487,6 +487,7 @@ const fetchConfigType = createMatchingObjectType<FetchParams>({
     authorInformation: { refType: authorInfoConfig },
     strictInstanceStructure: { refType: BuiltinTypes.BOOLEAN },
     fieldsToOmit: { refType: new ListType(fieldsToOmitConfig) },
+    addAlias: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/netsuite-adapter/src/data_elements/multi_fields_identifiers.ts
+++ b/packages/netsuite-adapter/src/data_elements/multi_fields_identifiers.ts
@@ -17,7 +17,7 @@ import { BuiltinTypes, Field, ObjectType, Values } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { getDataInstanceId } from '../elements_source_index/elements_source_index'
-import { IDENTIFIER_FIELD, TYPE_TO_IDENTIFIER, TYPE_TO_ID_FIELD_PATHS } from './types'
+import { IDENTIFIER_FIELD, TYPE_TO_IDENTIFIER, TYPE_TO_ID_FIELD_PATHS, isTypeWithMultiFieldsIdentifier } from './types'
 
 const log = logger(module)
 
@@ -34,7 +34,7 @@ const getIdentifierWithoutParent = (
   values: Values,
   type: ObjectType
 ): string => {
-  if (!(type.elemID.name in TYPE_TO_ID_FIELD_PATHS)) {
+  if (!isTypeWithMultiFieldsIdentifier(type.elemID.name)) {
     return values[TYPE_TO_IDENTIFIER[type.elemID.name]]
   }
 

--- a/packages/netsuite-adapter/src/data_elements/types.ts
+++ b/packages/netsuite-adapter/src/data_elements/types.ts
@@ -21,6 +21,49 @@ export const TRANSACTION_TYPE_ID = '-30'
 const FIELD_TYPE = '-124'
 const SCRIPT_TYPE = '-417'
 
+type ItemType = 'assemblyItem' |
+'lotNumberedAssemblyItem' |
+'serializedAssemblyItem' |
+'descriptionItem' |
+'discountItem' |
+'kitItem' |
+'markupItem' |
+'nonInventoryPurchaseItem' |
+'nonInventorySaleItem' |
+'nonInventoryResaleItem' |
+'otherChargeSaleItem' |
+'otherChargeResaleItem' |
+'otherChargePurchaseItem' |
+'paymentItem' |
+'serviceResaleItem' |
+'servicePurchaseItem' |
+'serviceSaleItem' |
+'subtotalItem' |
+'inventoryItem' |
+'lotNumberedInventoryItem' |
+'serializedInventoryItem' |
+'itemGroup' |
+'giftCertificateItem' |
+'downloadItem'
+
+type TypeWithMultiFieldsIdentifier = 'accountingPeriod' |
+'nexus' |
+'account'
+
+type TypeWithSingleFieldIdentifier = 'subsidiary' |
+'department' |
+'classification' |
+'location' |
+'currency' |
+'customer' |
+'employee' |
+'job' |
+'manufacturingCostTemplate' |
+'partner' |
+'solution'
+
+export type SupportedDataType = ItemType | TypeWithMultiFieldsIdentifier | TypeWithSingleFieldIdentifier
+
 // Was taken from https://<account_id>.app.netsuite.com/app/help/helpcenter.nl?fid=section_n3432681.html&whence=
 const ORIGINAL_TYPES_TO_INTERNAL_ID: Record<string, string> = {
   account: '-112',
@@ -227,7 +270,7 @@ export const INTERNAL_ID_TO_TYPES: Record<string, string[]> = _(TYPES_TO_INTERNA
   .mapValues(values => values.map(([type]) => type))
   .value()
 
-export const ITEM_TYPE_TO_SEARCH_STRING: Record<string, string> = {
+export const ITEM_TYPE_TO_SEARCH_STRING: Record<ItemType, string> = {
   assemblyItem: '_assembly',
   lotNumberedAssemblyItem: '_assembly',
   serializedAssemblyItem: '_assembly',
@@ -254,17 +297,23 @@ export const ITEM_TYPE_TO_SEARCH_STRING: Record<string, string> = {
   downloadItem: '_downloadItem',
 }
 
+export const isItemType = (type: string): type is ItemType =>
+  type in ITEM_TYPE_TO_SEARCH_STRING
+
 // This is used for constructing a unique identifier for data types
 // field using multiple other fields
-export const TYPE_TO_ID_FIELD_PATHS: Record<string, string[][]> = {
+export const TYPE_TO_ID_FIELD_PATHS: Record<TypeWithMultiFieldsIdentifier, string[][]> = {
   accountingPeriod: [['periodName'], ['fiscalCalendar', 'name']],
   nexus: [['country'], ['state', 'name']],
   account: [['acctName'], ['acctNumber']],
 }
 
+export const isTypeWithMultiFieldsIdentifier = (type: string): type is TypeWithMultiFieldsIdentifier =>
+  type in TYPE_TO_ID_FIELD_PATHS
+
 export const IDENTIFIER_FIELD = 'identifier'
 
-export const TYPE_TO_IDENTIFIER: Record<string, string> = {
+const TYPE_TO_SINGLE_FIELD_IDENTIFIER: Record<TypeWithSingleFieldIdentifier, string> = {
   subsidiary: 'name',
   department: 'name',
   classification: 'name',
@@ -276,9 +325,48 @@ export const TYPE_TO_IDENTIFIER: Record<string, string> = {
   manufacturingCostTemplate: 'name',
   partner: 'partnerCode',
   solution: 'solutionCode',
-  ...Object.fromEntries(Object.keys(ITEM_TYPE_TO_SEARCH_STRING).map(type => [type, 'itemId'])),
-  ...Object.fromEntries(Object.keys(TYPE_TO_ID_FIELD_PATHS).map(type => [type, IDENTIFIER_FIELD])),
 }
+
+const ITEM_TYPE_TO_IDENTIFIER: Record<ItemType, 'itemId'> = {
+  assemblyItem: 'itemId',
+  lotNumberedAssemblyItem: 'itemId',
+  serializedAssemblyItem: 'itemId',
+  descriptionItem: 'itemId',
+  discountItem: 'itemId',
+  kitItem: 'itemId',
+  markupItem: 'itemId',
+  nonInventoryPurchaseItem: 'itemId',
+  nonInventorySaleItem: 'itemId',
+  nonInventoryResaleItem: 'itemId',
+  otherChargeSaleItem: 'itemId',
+  otherChargeResaleItem: 'itemId',
+  otherChargePurchaseItem: 'itemId',
+  paymentItem: 'itemId',
+  serviceResaleItem: 'itemId',
+  servicePurchaseItem: 'itemId',
+  serviceSaleItem: 'itemId',
+  subtotalItem: 'itemId',
+  inventoryItem: 'itemId',
+  lotNumberedInventoryItem: 'itemId',
+  serializedInventoryItem: 'itemId',
+  itemGroup: 'itemId',
+  giftCertificateItem: 'itemId',
+  downloadItem: 'itemId',
+}
+
+const TYPE_WITH_MULTI_FIELDS_TO_IDENTIFIER: Record<TypeWithMultiFieldsIdentifier, typeof IDENTIFIER_FIELD> = {
+  accountingPeriod: IDENTIFIER_FIELD,
+  account: IDENTIFIER_FIELD,
+  nexus: IDENTIFIER_FIELD,
+}
+
+const supportedTypesToIdentifier: Record<SupportedDataType, string> = {
+  ...TYPE_TO_SINGLE_FIELD_IDENTIFIER,
+  ...ITEM_TYPE_TO_IDENTIFIER,
+  ...TYPE_WITH_MULTI_FIELDS_TO_IDENTIFIER,
+}
+
+export const TYPE_TO_IDENTIFIER: Record<string, string> = supportedTypesToIdentifier
 
 export const getTypeIdentifier = (type: ObjectType): string => (
   type.fields[IDENTIFIER_FIELD] !== undefined

--- a/packages/netsuite-adapter/src/filters/add_alias.ts
+++ b/packages/netsuite-adapter/src/filters/add_alias.ts
@@ -1,0 +1,347 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { collections } from '@salto-io/lowerdash'
+import { CORE_ANNOTATIONS, Element, InstanceElement, ReadOnlyElementsSource, isInstanceElement, isObjectType, isReferenceExpression } from '@salto-io/adapter-api'
+import { addAliasToElements, AliasData as GenericAliasData, AliasComponent } from '@salto-io/adapter-components'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+import { LocalFilterCreator } from '../filter'
+import { APPLICATION_ID, CUSTOM_RECORD_TYPE, FILE_CABINET_PATH_SEPARATOR, IS_SUB_INSTANCE, PATH, TRANSLATION_COLLECTION } from '../constants'
+import { getElementValueOrAnnotations, isCustomRecordType, isFileCabinetType } from '../types'
+import { StandardType } from '../autogen/types'
+import { SupportedDataType, isItemType } from '../data_elements/types'
+
+const log = logger(module)
+const { awu } = collections.asynciterable
+
+const CUSTOM_RECORD_TYPES_WITH_SEGMENT = 'customrecordtypeswithsegment'
+const CUSTOM_RECORD_INSTANCES = 'customrecordinstances'
+
+const DEFAULT_TRANSLATION = 'defaulttranslation'
+
+type ElementsMap = Parameters<typeof addAliasToElements>['0']['elementsMap']
+type AliasDataWithSingleComponent = GenericAliasData<[AliasComponent]>
+type AliasDataWithMultipleComponents = GenericAliasData<AliasComponent[]>
+
+const toAliasDataWithMultipleComponents = (...parts: string[]): AliasDataWithMultipleComponents => ({
+  aliasComponents: parts.map(name => ({
+    fieldName: name,
+  })),
+})
+
+const toAliasDataWithSingleComponent = (fieldName: string): AliasDataWithSingleComponent => ({
+  aliasComponents: [{ fieldName }],
+})
+
+const labelAlias = toAliasDataWithSingleComponent('label')
+const titleAlias = toAliasDataWithSingleComponent('title')
+const nameAlias = toAliasDataWithSingleComponent('name')
+const recordNameAlias = toAliasDataWithSingleComponent('recordname')
+const identifierAlias = toAliasDataWithSingleComponent('identifier')
+const importNameAlias = toAliasDataWithSingleComponent('importname')
+const fieldDefaultNameAlias = toAliasDataWithSingleComponent('FIELD_DEFAULT_NAME')
+const fullNameAlias = toAliasDataWithMultipleComponents('firstName', 'lastName')
+const accountNumberAlias = toAliasDataWithSingleComponent('accountNumber')
+const fullNameAndAccountAlias = toAliasDataWithMultipleComponents('firstName', 'lastName', 'accountNumber')
+const displayNameAlias = toAliasDataWithSingleComponent('displayName')
+const itemIdAlias = toAliasDataWithSingleComponent('itemId')
+const entityIdAlias = toAliasDataWithSingleComponent('entityId')
+const periodNameAlias = toAliasDataWithSingleComponent('periodName')
+const accountNameAlias = toAliasDataWithSingleComponent('acctName')
+const applicationIdAlias = toAliasDataWithSingleComponent(APPLICATION_ID)
+
+const CUSTOM_SEGMENT_FIELD = 'customsegment'
+const customRecordTypesWithSegmentAlias: AliasDataWithSingleComponent = {
+  aliasComponents: [{
+    fieldName: CUSTOM_SEGMENT_FIELD,
+    referenceFieldName: CORE_ANNOTATIONS.ALIAS,
+  }],
+}
+
+const standardTypesAliasMap: Record<StandardType, AliasDataWithSingleComponent> = {
+  addressForm: nameAlias,
+  advancedpdftemplate: titleAlias,
+  bankstatementparserplugin: nameAlias,
+  bundleinstallationscript: nameAlias,
+  center: labelAlias,
+  centercategory: labelAlias,
+  centerlink: labelAlias,
+  centertab: labelAlias,
+  clientscript: nameAlias,
+  cmscontenttype: labelAlias,
+  crmcustomfield: labelAlias,
+  customglplugin: nameAlias,
+  customlist: nameAlias,
+  customrecordactionscript: nameAlias,
+  customrecordtype: recordNameAlias,
+  customsegment: labelAlias,
+  customtransactiontype: nameAlias,
+  dataset: nameAlias,
+  datasetbuilderplugin: nameAlias,
+  emailcaptureplugin: nameAlias,
+  emailtemplate: nameAlias,
+  entitycustomfield: labelAlias,
+  entryForm: nameAlias,
+  ficonnectivityplugin: nameAlias,
+  financiallayout: nameAlias,
+  fiparserplugin: nameAlias,
+  integration: applicationIdAlias,
+  itemcustomfield: labelAlias,
+  itemnumbercustomfield: labelAlias,
+  itemoptioncustomfield: labelAlias,
+  kpiscorecard: nameAlias,
+  mapreducescript: nameAlias,
+  massupdatescript: nameAlias,
+  othercustomfield: labelAlias,
+  pluginimplementation: nameAlias,
+  plugintype: nameAlias,
+  portlet: nameAlias,
+  promotionsplugin: nameAlias,
+  publisheddashboard: nameAlias,
+  reportdefinition: nameAlias,
+  restlet: nameAlias,
+  role: nameAlias,
+  savedcsvimport: importNameAlias,
+  savedsearch: fieldDefaultNameAlias,
+  scheduledscript: nameAlias,
+  sdfinstallationscript: nameAlias,
+  secret: applicationIdAlias,
+  sspapplication: nameAlias,
+  sublist: labelAlias,
+  subtab: titleAlias,
+  suitelet: nameAlias,
+  transactionForm: nameAlias,
+  transactionbodycustomfield: labelAlias,
+  transactioncolumncustomfield: labelAlias,
+  translationcollection: nameAlias,
+  usereventscript: nameAlias,
+  workbook: nameAlias,
+  workbookbuilderplugin: nameAlias,
+  workflow: nameAlias,
+  workflowactionscript: nameAlias,
+}
+
+const dataTypesAliasMap: Record<SupportedDataType, AliasDataWithMultipleComponents> = {
+  subsidiary: nameAlias,
+  department: nameAlias,
+  classification: nameAlias,
+  location: nameAlias,
+  currency: nameAlias,
+  customer: fullNameAndAccountAlias,
+  employee: fullNameAndAccountAlias,
+  job: accountNumberAlias,
+  manufacturingCostTemplate: nameAlias,
+  partner: fullNameAlias,
+  solution: titleAlias,
+  assemblyItem: displayNameAlias,
+  lotNumberedAssemblyItem: displayNameAlias,
+  serializedAssemblyItem: displayNameAlias,
+  descriptionItem: itemIdAlias,
+  discountItem: displayNameAlias,
+  kitItem: displayNameAlias,
+  markupItem: displayNameAlias,
+  nonInventoryPurchaseItem: displayNameAlias,
+  nonInventorySaleItem: displayNameAlias,
+  nonInventoryResaleItem: displayNameAlias,
+  otherChargeSaleItem: displayNameAlias,
+  otherChargeResaleItem: displayNameAlias,
+  otherChargePurchaseItem: displayNameAlias,
+  paymentItem: displayNameAlias,
+  serviceResaleItem: displayNameAlias,
+  servicePurchaseItem: displayNameAlias,
+  serviceSaleItem: displayNameAlias,
+  subtotalItem: displayNameAlias,
+  inventoryItem: displayNameAlias,
+  lotNumberedInventoryItem: displayNameAlias,
+  serializedInventoryItem: displayNameAlias,
+  itemGroup: displayNameAlias,
+  giftCertificateItem: displayNameAlias,
+  downloadItem: displayNameAlias,
+  accountingPeriod: periodNameAlias,
+  account: accountNameAlias,
+  nexus: identifierAlias,
+}
+
+const [itemTypes, otherDataTypes] = _.partition(Object.keys(dataTypesAliasMap), isItemType)
+const entityIdFallbackAliasMap = Object.fromEntries(otherDataTypes.map(type => [type, entityIdAlias]))
+const itemTypesFallbackAliasMap = Object.fromEntries(itemTypes.map(type => [type, itemIdAlias]))
+
+const splitInstancesToGroups = async (instances: InstanceElement[]): Promise<{
+  fileCabinetInstances: InstanceElement[]
+  customRecordInstances: InstanceElement[]
+  subInstances: InstanceElement[]
+  otherInstances: InstanceElement[]
+}> => {
+  const fileCabinetInstances: InstanceElement[] = []
+  const customRecordInstances: InstanceElement[] = []
+  const subInstances: InstanceElement[] = []
+  const otherInstances: InstanceElement[] = []
+  await awu(instances).forEach(async instance => {
+    if (isFileCabinetType(instance.refType)) {
+      fileCabinetInstances.push(instance)
+    } else if (isCustomRecordType(await instance.getType())) {
+      customRecordInstances.push(instance)
+    } else if (instance.value[IS_SUB_INSTANCE]) {
+      subInstances.push(instance)
+    } else {
+      otherInstances.push(instance)
+    }
+  })
+  return {
+    fileCabinetInstances,
+    customRecordInstances,
+    subInstances,
+    otherInstances,
+  }
+}
+
+const addAliasToFileCabinetInstance = (instance: InstanceElement): void => {
+  const path = instance.value[PATH]
+  if (typeof path !== 'string') {
+    log.warn('file cabinet instance %s has no string path field: %o', instance.elemID.getFullName(), path)
+  } else {
+    const basename = path.split(FILE_CABINET_PATH_SEPARATOR).slice(-1)[0]
+    instance.annotations[CORE_ANNOTATIONS.ALIAS] = basename
+  }
+}
+
+const addAliasFromTranslatedFields = async ({
+  elementsSource, elementsMap, aliasMap,
+}: {
+  elementsSource: ReadOnlyElementsSource
+  elementsMap: ElementsMap
+  aliasMap: Record<string, AliasDataWithSingleComponent>
+}): Promise<void> => {
+  const relevantElementsMap = _.pick(elementsMap, Object.keys(aliasMap))
+  await awu(Object.keys(relevantElementsMap)).forEach(async group => {
+    const { aliasComponents: [{ fieldName }] } = aliasMap[group]
+
+    await awu(relevantElementsMap[group]).forEach(async element => {
+      const fieldValue = getElementValueOrAnnotations(element)[fieldName]
+      if (!isReferenceExpression(fieldValue) || fieldValue.elemID.typeName !== TRANSLATION_COLLECTION) {
+        log.warn(
+          'cannot extract translated alias for element %s from field %s -'
+          + ' field value is not a translation collection reference: %o',
+          element.elemID.getFullName(),
+          fieldName,
+          fieldValue
+        )
+        return
+      }
+      const defaultTranslationElemId = fieldValue.elemID.createParentID().createNestedID(DEFAULT_TRANSLATION)
+      const { parent, path } = defaultTranslationElemId.createTopLevelParentID()
+      const translationCollectionInstance = await elementsSource.get(parent)
+      const alias = isInstanceElement(translationCollectionInstance)
+        ? _.get(translationCollectionInstance.value, path)
+        : undefined
+
+      if (typeof alias !== 'string') {
+        log.warn(
+          'cannot extract translated alias for element %s from reference %s -'
+          + ' reference value is not a string: %o',
+          element.elemID.getFullName(),
+          defaultTranslationElemId,
+          alias
+        )
+        return
+      }
+
+      element.annotations[CORE_ANNOTATIONS.ALIAS] = alias
+    })
+  })
+}
+
+const getElementsWithoutAlias = (elementsMap: ElementsMap): ElementsMap =>
+  Object.fromEntries(
+    Object.entries(elementsMap)
+      .map(([group, elems]) => [
+        group,
+        elems.filter(element => element.annotations[CORE_ANNOTATIONS.ALIAS] === undefined),
+      ] as const)
+      .filter(([_group, elems]) => elems.length > 0)
+  )
+
+const filterCreator: LocalFilterCreator = ({ config, elementsSource, isPartial }) => ({
+  name: 'addAlias',
+  onFetch: async (elements: Element[]): Promise<void> => {
+    if (config.fetch?.addAlias !== true) {
+      log.info('not running addAlias filter as addAlias in the config is false')
+      return
+    }
+
+    const instances = elements.filter(isInstanceElement)
+    const {
+      fileCabinetInstances,
+      customRecordInstances,
+      subInstances,
+      otherInstances,
+    } = await splitInstancesToGroups(instances)
+
+    const [customRecordTypesWithSegment, customRecordTypes] = _.partition(
+      elements.filter(isObjectType).filter(isCustomRecordType),
+      type => type.annotations[CUSTOM_SEGMENT_FIELD] !== undefined
+    )
+
+    const instancesMap = _.groupBy(otherInstances, instance => instance.elemID.typeName)
+    const elementsMap: ElementsMap = {
+      ...instancesMap,
+      [IS_SUB_INSTANCE]: subInstances,
+      [CUSTOM_RECORD_TYPE]: customRecordTypes,
+      [CUSTOM_RECORD_INSTANCES]: customRecordInstances,
+    }
+
+    addAliasToElements({
+      elementsMap,
+      aliasMap: {
+        ...standardTypesAliasMap,
+        ...dataTypesAliasMap,
+        [IS_SUB_INSTANCE]: nameAlias,
+        [CUSTOM_RECORD_INSTANCES]: nameAlias,
+      },
+    })
+
+    await addAliasFromTranslatedFields({
+      elementsSource: buildElementsSourceFromElements(instances, isPartial ? [elementsSource] : []),
+      elementsMap: getElementsWithoutAlias(elementsMap),
+      aliasMap: standardTypesAliasMap,
+    })
+
+    // some data type instances have a fallback
+    addAliasToElements({
+      elementsMap: getElementsWithoutAlias(elementsMap),
+      aliasMap: {
+        ...entityIdFallbackAliasMap,
+        ...itemTypesFallbackAliasMap,
+        [IS_SUB_INSTANCE]: labelAlias,
+      },
+    })
+
+    addAliasToElements({
+      elementsMap: {
+        ...elementsMap,
+        [CUSTOM_RECORD_TYPES_WITH_SEGMENT]: customRecordTypesWithSegment,
+      },
+      aliasMap: {
+        [CUSTOM_RECORD_TYPES_WITH_SEGMENT]: customRecordTypesWithSegmentAlias,
+      },
+    })
+
+    fileCabinetInstances.forEach(addAliasToFileCabinetInstance)
+  },
+})
+
+export default filterCreator

--- a/packages/netsuite-adapter/src/query.ts
+++ b/packages/netsuite-adapter/src/query.ts
@@ -62,6 +62,7 @@ export type FetchParams = {
   }
   strictInstanceStructure?: boolean
   fieldsToOmit?: FieldToOmitParams[]
+  addAlias?: boolean
 }
 
 export const FETCH_PARAMS: lowerdashTypes.TypeKeysEnum<FetchParams> = {
@@ -71,6 +72,7 @@ export const FETCH_PARAMS: lowerdashTypes.TypeKeysEnum<FetchParams> = {
   authorInformation: 'authorInformation',
   strictInstanceStructure: 'strictInstanceStructure',
   fieldsToOmit: 'fieldsToOmit',
+  addAlias: 'addAlias',
 }
 
 export const convertToQueryParams = ({

--- a/packages/netsuite-adapter/src/types.ts
+++ b/packages/netsuite-adapter/src/types.ts
@@ -152,7 +152,9 @@ export const SUITEAPP_CONFIG_RECORD_TYPES = [
 
 export type SuiteAppConfigRecordType = typeof SUITEAPP_CONFIG_RECORD_TYPES[number]
 
-export const SUITEAPP_CONFIG_TYPES_TO_TYPE_NAMES: Record<SuiteAppConfigRecordType, string> = {
+export type SuiteAppConfigTypeName = 'userPreferences' | 'companyInformation' | 'companyPreferences' | 'accountingPreferences'
+
+export const SUITEAPP_CONFIG_TYPES_TO_TYPE_NAMES: Record<SuiteAppConfigRecordType, SuiteAppConfigTypeName> = {
   USER_PREFERENCES: 'userPreferences',
   COMPANY_INFORMATION: 'companyInformation',
   COMPANY_PREFERENCES: 'companyPreferences',
@@ -162,10 +164,10 @@ export const SUITEAPP_CONFIG_TYPES_TO_TYPE_NAMES: Record<SuiteAppConfigRecordTyp
 export const SUITEAPP_CONFIG_TYPE_NAMES = Object.values(SUITEAPP_CONFIG_TYPES_TO_TYPE_NAMES)
 
 export const isSuiteAppConfigType = (type: ObjectType): boolean =>
-  SUITEAPP_CONFIG_TYPE_NAMES.includes(type.elemID.name)
+  SUITEAPP_CONFIG_TYPE_NAMES.includes(type.elemID.name as SuiteAppConfigTypeName)
 
 export const isSuiteAppConfigInstance = (instance: InstanceElement): boolean =>
-  SUITEAPP_CONFIG_TYPE_NAMES.includes(instance.elemID.typeName)
+  SUITEAPP_CONFIG_TYPE_NAMES.includes(instance.elemID.typeName as SuiteAppConfigTypeName)
 
 export const isSDFConfigTypeName = (typeName: string): boolean =>
   typeName === CONFIG_FEATURES

--- a/packages/netsuite-adapter/src/types/configuration_types.ts
+++ b/packages/netsuite-adapter/src/types/configuration_types.ts
@@ -17,7 +17,7 @@
 import { BuiltinTypes, ElemID, ObjectType, ListType } from '@salto-io/adapter-api'
 import * as constants from '../constants'
 
-type ConfigurationTypeName = typeof constants.CONFIG_FEATURES
+export type ConfigurationTypeName = typeof constants.CONFIG_FEATURES
 
 export const featuresType = (): ObjectType => new ObjectType({
   elemID: new ElemID(constants.NETSUITE, constants.CONFIG_FEATURES),

--- a/packages/netsuite-adapter/test/filters/add_alias.test.ts
+++ b/packages/netsuite-adapter/test/filters/add_alias.test.ts
@@ -1,0 +1,238 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, ReferenceExpression, Element } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { LazyElementsSourceIndexes } from '../../src/elements_source_index/types'
+import { getDefaultAdapterConfig } from '../utils'
+import { CUSTOM_RECORD_TYPE, IS_SUB_INSTANCE, METADATA_TYPE, NETSUITE, SCRIPT_ID } from '../../src/constants'
+import filterCreator from '../../src/filters/add_alias'
+import { LocalFilterOpts } from '../../src/filter'
+import { customsegmentType } from '../../src/autogen/types/standard_types/customsegment'
+import { workflowType } from '../../src/autogen/types/standard_types/workflow'
+import { translationcollectionType } from '../../src/autogen/types/standard_types/translationcollection'
+import { fileType } from '../../src/types/file_cabinet_types'
+
+describe('add alias filter', () => {
+  const { type: workflow } = workflowType()
+  const { type: customsegment } = customsegmentType()
+  const { type: translationcollection } = translationcollectionType()
+  const file = fileType()
+  const customer = new ObjectType({ elemID: new ElemID(NETSUITE, 'customer') })
+  const assemblyItem = new ObjectType({ elemID: new ElemID(NETSUITE, 'assemblyItem') })
+
+  let standardInstance: InstanceElement
+  let fileCabinetInstance: InstanceElement
+  let dataInstance: InstanceElement
+  let itemInstance: InstanceElement
+
+  let customRecordType: ObjectType
+  let segmentInstance: InstanceElement
+  let customRecordTypeWithSegment: ObjectType
+
+  let customRecordInstance: InstanceElement
+  let subInstance: InstanceElement
+
+  let dataInstanceWithFallback: InstanceElement
+  let itemInstanceWithFallback: InstanceElement
+  let subInstanceWithFallback: InstanceElement
+
+  let translationCollectionInstance: InstanceElement
+  let standardInstanceWithTranslation: InstanceElement
+  let customRecordTypeWithTranslation: ObjectType
+  let segmentInstanceWithTranslation: InstanceElement
+  let customRecordTypeWithSegmentWithTranslation: ObjectType
+
+  let elements: Element[]
+
+  let defaultOpts: LocalFilterOpts
+  let optsWithAlias: LocalFilterOpts
+  let optsWithAliasAndIsPartial: LocalFilterOpts
+  beforeEach(async () => {
+    standardInstance = new InstanceElement('customworkflow1', workflow, {
+      name: 'Custom Workflow 1',
+    })
+    fileCabinetInstance = new InstanceElement('someFile', file, {
+      path: '/SuiteScript/someFile.txt',
+    })
+    dataInstance = new InstanceElement('customer1', customer, {
+      firstName: 'Salto',
+      lastName: 'User',
+      accountNumber: 'A01',
+      entityId: 'entity id',
+    })
+    itemInstance = new InstanceElement('assemblyItem1', assemblyItem, {
+      displayName: 'Assembly Item 1',
+      itemId: 'item id',
+    })
+    customRecordType = new ObjectType({
+      elemID: new ElemID(NETSUITE, 'customrecord1'),
+      annotations: {
+        recordname: 'Custom Record 1',
+        [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
+      },
+    })
+    segmentInstance = new InstanceElement('cseg1', customsegment, {
+      label: 'Custom Segment 1',
+    })
+    customRecordTypeWithSegment = new ObjectType({
+      elemID: new ElemID(NETSUITE, 'customrecord_cseg1'),
+      annotations: {
+        customsegment: new ReferenceExpression(segmentInstance.elemID.createNestedID(SCRIPT_ID)),
+        [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
+      },
+    })
+    customRecordInstance = new InstanceElement('val_123', customRecordType, {
+      name: 'Custom Record Instance',
+    })
+    subInstance = new InstanceElement('subInstance1', customer, {
+      name: 'Sub Instance 1',
+      label: 'some label',
+      [IS_SUB_INSTANCE]: true,
+    })
+    dataInstanceWithFallback = new InstanceElement('customer2', customer, {
+      entityId: 'Customer 2',
+    })
+    itemInstanceWithFallback = new InstanceElement('assemblyItem2', assemblyItem, {
+      itemId: 'Assembly Item 2',
+    })
+    subInstanceWithFallback = new InstanceElement('subInstance2', customer, {
+      label: 'Sub Instance 2',
+      [IS_SUB_INSTANCE]: true,
+    })
+
+
+    translationCollectionInstance = new InstanceElement('custtranslation1', translationcollection, {
+      name: new ReferenceExpression(translationcollection.elemID.createNestedID('instance', 'custtranslation1', 'strings', 'string', 'self', SCRIPT_ID)),
+      strings: {
+        string: {
+          self: {
+            scriptid: 'translated_custtranslation',
+            defaulttranslation: 'Translated Custom Translation',
+          },
+          customworkflow: {
+            scriptid: 'translated_customworkflow',
+            defaulttranslation: 'Translated Custom Workflow',
+          },
+          customrecord: {
+            scriptid: 'translated_customrecord',
+            defaulttranslation: 'Translated Custom Record Type',
+          },
+          customsegment: {
+            scriptid: 'translated_customsegment',
+            defaulttranslation: 'Translated Custom Segment',
+          },
+        },
+      },
+    })
+    standardInstanceWithTranslation = new InstanceElement('customworkflow2', workflow, {
+      name: new ReferenceExpression(translationCollectionInstance.elemID.createNestedID('strings', 'string', 'customworkflow', SCRIPT_ID)),
+    })
+    customRecordTypeWithTranslation = new ObjectType({
+      elemID: new ElemID(NETSUITE, 'customrecord2'),
+      annotations: {
+        recordname: new ReferenceExpression(translationCollectionInstance.elemID.createNestedID('strings', 'string', 'customrecord', SCRIPT_ID)),
+        [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
+      },
+    })
+    segmentInstanceWithTranslation = new InstanceElement('cseg2', customsegment, {
+      label: new ReferenceExpression(translationCollectionInstance.elemID.createNestedID('strings', 'string', 'customsegment', SCRIPT_ID)),
+    })
+    customRecordTypeWithSegmentWithTranslation = new ObjectType({
+      elemID: new ElemID(NETSUITE, 'customrecord_cseg2'),
+      annotations: {
+        customsegment: new ReferenceExpression(segmentInstanceWithTranslation.elemID.createNestedID(SCRIPT_ID)),
+        [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
+      },
+    })
+
+    elements = [
+      standardInstance,
+      fileCabinetInstance,
+      dataInstance,
+      itemInstance,
+      customRecordType,
+      segmentInstance,
+      customRecordTypeWithSegment,
+      customRecordInstance,
+      subInstance,
+      dataInstanceWithFallback,
+      itemInstanceWithFallback,
+      subInstanceWithFallback,
+      translationCollectionInstance,
+      standardInstanceWithTranslation,
+      customRecordTypeWithTranslation,
+      segmentInstanceWithTranslation,
+      customRecordTypeWithSegmentWithTranslation,
+    ]
+
+    defaultOpts = {
+      elementsSourceIndex: {} as LazyElementsSourceIndexes,
+      elementsSource: buildElementsSourceFromElements([]),
+      isPartial: false,
+      config: await getDefaultAdapterConfig(),
+    }
+    optsWithAlias = {
+      ...defaultOpts,
+      config: {
+        fetch: {
+          addAlias: true,
+        },
+      },
+    }
+    optsWithAliasAndIsPartial = {
+      ...optsWithAlias,
+      isPartial: true,
+      elementsSource: buildElementsSourceFromElements([translationCollectionInstance]),
+    }
+  })
+  it('should not add aliases when addAlias=false', async () => {
+    await filterCreator(defaultOpts).onFetch?.(elements)
+    expect(elements.some(elem => elem.annotations[CORE_ANNOTATIONS.ALIAS] !== undefined)).toBeFalsy()
+  })
+  it('should add aliases', async () => {
+    await filterCreator(optsWithAlias).onFetch?.(elements)
+
+    expect(standardInstance.annotations[CORE_ANNOTATIONS.ALIAS]).toEqual('Custom Workflow 1')
+    expect(fileCabinetInstance.annotations[CORE_ANNOTATIONS.ALIAS]).toEqual('someFile.txt')
+    expect(dataInstance.annotations[CORE_ANNOTATIONS.ALIAS]).toEqual('Salto User A01')
+    expect(itemInstance.annotations[CORE_ANNOTATIONS.ALIAS]).toEqual('Assembly Item 1')
+    expect(customRecordType.annotations[CORE_ANNOTATIONS.ALIAS]).toEqual('Custom Record 1')
+    expect(segmentInstance.annotations[CORE_ANNOTATIONS.ALIAS]).toEqual('Custom Segment 1')
+    expect(customRecordTypeWithSegment.annotations[CORE_ANNOTATIONS.ALIAS]).toEqual('Custom Segment 1')
+    expect(customRecordInstance.annotations[CORE_ANNOTATIONS.ALIAS]).toEqual('Custom Record Instance')
+    expect(subInstance.annotations[CORE_ANNOTATIONS.ALIAS]).toEqual('Sub Instance 1')
+    expect(dataInstanceWithFallback.annotations[CORE_ANNOTATIONS.ALIAS]).toEqual('Customer 2')
+    expect(itemInstanceWithFallback.annotations[CORE_ANNOTATIONS.ALIAS]).toEqual('Assembly Item 2')
+    expect(subInstanceWithFallback.annotations[CORE_ANNOTATIONS.ALIAS]).toEqual('Sub Instance 2')
+    expect(translationCollectionInstance.annotations[CORE_ANNOTATIONS.ALIAS]).toEqual('Translated Custom Translation')
+    expect(standardInstanceWithTranslation.annotations[CORE_ANNOTATIONS.ALIAS]).toEqual('Translated Custom Workflow')
+    expect(customRecordTypeWithTranslation.annotations[CORE_ANNOTATIONS.ALIAS]).toEqual('Translated Custom Record Type')
+    expect(segmentInstanceWithTranslation.annotations[CORE_ANNOTATIONS.ALIAS]).toEqual('Translated Custom Segment')
+    expect(customRecordTypeWithSegmentWithTranslation.annotations[CORE_ANNOTATIONS.ALIAS]).toEqual('Translated Custom Segment')
+  })
+  it('should take translated names from element source on partial fetch', async () => {
+    await filterCreator(optsWithAliasAndIsPartial).onFetch?.([
+      standardInstanceWithTranslation,
+      customRecordTypeWithTranslation,
+      segmentInstanceWithTranslation,
+      customRecordTypeWithSegmentWithTranslation,
+    ])
+    expect(standardInstanceWithTranslation.annotations[CORE_ANNOTATIONS.ALIAS]).toEqual('Translated Custom Workflow')
+    expect(customRecordTypeWithTranslation.annotations[CORE_ANNOTATIONS.ALIAS]).toEqual('Translated Custom Record Type')
+    expect(segmentInstanceWithTranslation.annotations[CORE_ANNOTATIONS.ALIAS]).toEqual('Translated Custom Segment')
+    expect(customRecordTypeWithSegmentWithTranslation.annotations[CORE_ANNOTATIONS.ALIAS]).toEqual('Translated Custom Segment')
+  })
+})


### PR DESCRIPTION
Can be enabled with `netsuite { fetch = { addAlias = true } }` 

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Add alias annotation to all elements.

---
_User Notifications_: 
None
