### PR TITLE
SALTO-4305: Create references to custom record fields in suitescripts

### DIFF
--- a/packages/netsuite-adapter/src/elements_source_index/elements_source_index.ts
+++ b/packages/netsuite-adapter/src/elements_source_index/elements_source_index.ts
@@ -125,8 +125,8 @@ const createIndexes = async (elementsSource: ReadOnlyElementsSource, isPartial: 
   }
 
   const updateCustomRecordFieldsIndex = (customObjectType: ObjectType): void => {
-    const serviceIdRecords = extractCustomRecordFields(customObjectType)
-    _.assign(serviceIdRecordsIndex, serviceIdRecords)
+    const serviceIdRecords = _.keyBy(extractCustomRecordFields(customObjectType), 'serviceID')
+    _.assign(customRecordFieldsServiceIdRecordsIndex, serviceIdRecords)
   }
 
   const deletedElementSet = new Set(deletedElements.map(elemId => elemId.getFullName()))

--- a/packages/netsuite-adapter/src/elements_source_index/elements_source_index.ts
+++ b/packages/netsuite-adapter/src/elements_source_index/elements_source_index.ts
@@ -14,13 +14,13 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { CORE_ANNOTATIONS, InstanceElement, isInstanceElement, ReadOnlyElementsSource, ElemID, Element, isObjectType, Value } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, InstanceElement, isInstanceElement, ReadOnlyElementsSource, ElemID, Element, isObjectType, Value, ObjectType } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import { getElementValueOrAnnotations, isCustomRecordType } from '../types'
 import { ElementsSourceIndexes, LazyElementsSourceIndexes, ServiceIdRecords } from './types'
 import { getFieldInstanceTypes } from '../data_elements/custom_fields'
-import { getElementServiceIdRecords } from '../filters/element_references'
+import { extractCustomRecordFields, getElementServiceIdRecords } from '../filters/element_references'
 import { CUSTOM_LIST, CUSTOM_RECORD_TYPE, INTERNAL_ID, IS_SUB_INSTANCE } from '../constants'
 import { TYPES_TO_INTERNAL_ID } from '../data_elements/types'
 
@@ -89,6 +89,7 @@ const createIndexes = async (elementsSource: ReadOnlyElementsSource, isPartial: 
   const customFieldsIndex: Record<string, InstanceElement[]> = {}
   const elemIdToChangeByIndex: Record<string, string> = {}
   const elemIdToChangeAtIndex: Record<string, string> = {}
+  const customRecordFieldsServiceIdRecordsIndex: ServiceIdRecords = {}
 
   const updateInternalIdsIndex = async (element: Element): Promise<void> => {
     await assignToInternalIdsIndex(element, internalIdsIndex, elementsSource)
@@ -123,6 +124,11 @@ const createIndexes = async (elementsSource: ReadOnlyElementsSource, isPartial: 
     }
   }
 
+  const updateCustomRecordFieldsIndex = (customObjectType: ObjectType): void => {
+    const serviceIdRecords = extractCustomRecordFields(customObjectType)
+    _.assign(serviceIdRecordsIndex, serviceIdRecords)
+  }
+
   const deletedElementSet = new Set(deletedElements.map(elemId => elemId.getFullName()))
   const elements = await elementsSource.getAll()
   await awu(elements)
@@ -137,6 +143,8 @@ const createIndexes = async (elementsSource: ReadOnlyElementsSource, isPartial: 
         await updateInternalIdsIndex(element)
         if (isInstanceElement(element)) {
           updateCustomFieldsIndex(element)
+        } else if (isObjectType(element) && isCustomRecordType(element)) {
+          updateCustomRecordFieldsIndex(element)
         }
       }
     })
@@ -147,6 +155,7 @@ const createIndexes = async (elementsSource: ReadOnlyElementsSource, isPartial: 
     customFieldsIndex,
     elemIdToChangeByIndex,
     elemIdToChangeAtIndex,
+    customRecordFieldsServiceIdRecordsIndex,
   }
 }
 

--- a/packages/netsuite-adapter/src/elements_source_index/types.ts
+++ b/packages/netsuite-adapter/src/elements_source_index/types.ts
@@ -28,6 +28,7 @@ export type ElementsSourceIndexes = {
   customFieldsIndex: Record<string, InstanceElement[]>
   elemIdToChangeByIndex: Record<string, string>
   elemIdToChangeAtIndex: Record<string, string>
+  customRecordFieldsServiceIdRecordsIndex: ServiceIdRecords
 }
 
 export type LazyElementsSourceIndexes = {

--- a/packages/netsuite-adapter/src/filters/element_references.ts
+++ b/packages/netsuite-adapter/src/filters/element_references.ts
@@ -21,7 +21,7 @@ import osPath from 'path'
 import { logger } from '@salto-io/logging'
 import { SCRIPT_ID, PATH, FILE_CABINET_PATH_SEPARATOR } from '../constants'
 import { LocalFilterCreator } from '../filter'
-import { isCustomRecordType, isStandardType, isFileCabinetType, isFileInstance, isFileCabinetInstance } from '../types'
+import { isCustomRecordType, isStandardType, isFileCabinetType, isFileInstance, isFileCabinetInstance, isCustomFieldName } from '../types'
 import { ElemServiceID, LazyElementsSourceIndexes, ServiceIdRecords } from '../elements_source_index/types'
 import { captureServiceIdInfo, ServiceIdInfo } from '../service_id_info'
 import { isSdfCreateOrUpdateGroupId } from '../group_changes'
@@ -268,6 +268,14 @@ const applyValuesAndAnnotationsToElement = (element: Element, newElement: Elemen
 
 export const extractCustomRecordFields = (customRecordType: ObjectType): ElemServiceID[] =>
   Object.values(customRecordType.fields)
+    .filter(field => isCustomFieldName(field.name))
+    .filter(field => {
+      if (field.annotations[SCRIPT_ID] === undefined) {
+        log.warn('custom field %s is missing a scriptid annotation', field.elemID.getFullName())
+        return false
+      }
+      return true
+    })
     .map(field => ({ serviceID: field.annotations[SCRIPT_ID], elemID: field.elemID.createNestedID(SCRIPT_ID) }))
 
 const createCustomRecordFieldsToElemID = (

--- a/packages/netsuite-adapter/src/filters/element_references.ts
+++ b/packages/netsuite-adapter/src/filters/element_references.ts
@@ -21,7 +21,7 @@ import osPath from 'path'
 import { logger } from '@salto-io/logging'
 import { SCRIPT_ID, PATH, FILE_CABINET_PATH_SEPARATOR } from '../constants'
 import { LocalFilterCreator } from '../filter'
-import { isCustomRecordType, isStandardType, isFileCabinetType, isFileInstance, isFileCabinetInstance, getServiceId } from '../types'
+import { isCustomRecordType, isStandardType, isFileCabinetType, isFileInstance, isFileCabinetInstance } from '../types'
 import { ElemServiceID, LazyElementsSourceIndexes, ServiceIdRecords } from '../elements_source_index/types'
 import { captureServiceIdInfo, ServiceIdInfo } from '../service_id_info'
 import { isSdfCreateOrUpdateGroupId } from '../group_changes'
@@ -268,7 +268,7 @@ const applyValuesAndAnnotationsToElement = (element: Element, newElement: Elemen
 
 export const extractCustomRecordFields = (customRecordType: ObjectType): ElemServiceID[] =>
   Object.values(customRecordType.fields)
-    .map(field => ({ serviceID: getServiceId(field), elemID: field.elemID }))
+    .map(field => ({ serviceID: field.annotations[SCRIPT_ID], elemID: field.elemID.createNestedID(SCRIPT_ID) }))
 
 const createCustomRecordFieldsToElemID = (
   elements: Element[],

--- a/packages/netsuite-adapter/src/filters/element_references.ts
+++ b/packages/netsuite-adapter/src/filters/element_references.ts
@@ -21,7 +21,7 @@ import osPath from 'path'
 import { logger } from '@salto-io/logging'
 import { SCRIPT_ID, PATH, FILE_CABINET_PATH_SEPARATOR } from '../constants'
 import { LocalFilterCreator } from '../filter'
-import { isCustomRecordType, isStandardType, isFileCabinetType, isFileInstance, isFileCabinetInstance } from '../types'
+import { isCustomRecordType, isStandardType, isFileCabinetType, isFileInstance, isFileCabinetInstance, getServiceId } from '../types'
 import { ElemServiceID, LazyElementsSourceIndexes, ServiceIdRecords } from '../elements_source_index/types'
 import { captureServiceIdInfo, ServiceIdInfo } from '../service_id_info'
 import { isSdfCreateOrUpdateGroupId } from '../group_changes'
@@ -271,7 +271,7 @@ const createCustomRecordFieldsToElemID = (
 ): ServiceIdRecords => {
   const extractCustomRecordFields = (customRecordType: ObjectType): ElemServiceID[] =>
     Object.values(customRecordType.fields)
-      .map(field => ({ serviceID: field.name, elemID: field.elemID }))
+      .map(field => ({ serviceID: getServiceId(field), elemID: field.elemID }))
 
   return _.keyBy(
     elements

--- a/packages/netsuite-adapter/test/elements_source_index.test.ts
+++ b/packages/netsuite-adapter/test/elements_source_index.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, InstanceElement, ObjectType, ReadOnlyElementsSource } from '@salto-io/adapter-api'
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, ReadOnlyElementsSource } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { entitycustomfieldType } from '../src/autogen/types/standard_types/entitycustomfield'
 import { CUSTOM_RECORD_TYPE, INTERNAL_ID, METADATA_TYPE, NETSUITE, SCRIPT_ID } from '../src/constants'
@@ -246,7 +246,7 @@ describe('createElementsSourceIndex', () => {
         [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
       },
     })
-    const custRecordField = new Field(custRecordType, 'custom_field', BuiltinTypes.STRING, { scriptid: 'custom_field' })
+    const custRecordField = custRecordType.fields.custom_field
     getAllMock.mockImplementation(buildElementsSourceFromElements([custRecordType]).getAll)
     expect((await createElementsSourceIndex(elementsSource, true).getIndexes()).customRecordFieldsServiceIdRecordsIndex)
       .toEqual({

--- a/packages/netsuite-adapter/test/elements_source_index.test.ts
+++ b/packages/netsuite-adapter/test/elements_source_index.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, ReadOnlyElementsSource } from '@salto-io/adapter-api'
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, InstanceElement, ObjectType, ReadOnlyElementsSource } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { entitycustomfieldType } from '../src/autogen/types/standard_types/entitycustomfield'
 import { CUSTOM_RECORD_TYPE, INTERNAL_ID, METADATA_TYPE, NETSUITE, SCRIPT_ID } from '../src/constants'
@@ -229,6 +229,28 @@ describe('createElementsSourceIndex', () => {
       .toEqual({
         'netsuite.someType.instance.inst': '03/23/2022',
         'netsuite.customrecord1': '05/26/2022',
+      })
+  })
+  it('should create the correct customRecordField index', async () => {
+    const custRecordType = new ObjectType({
+      elemID: new ElemID(NETSUITE, 'customrecord1'),
+      fields: {
+        custom_field: {
+          refType: BuiltinTypes.STRING,
+          annotations: {
+            [SCRIPT_ID]: 'custom_field',
+          },
+        },
+      },
+      annotations: {
+        [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
+      },
+    })
+    const custRecordField = new Field(custRecordType, 'custom_field', BuiltinTypes.STRING, { scriptid: 'custom_field' })
+    getAllMock.mockImplementation(buildElementsSourceFromElements([custRecordType]).getAll)
+    expect((await createElementsSourceIndex(elementsSource, true).getIndexes()).customRecordFieldsServiceIdRecordsIndex)
+      .toEqual({
+        custom_field: { elemID: custRecordField.elemID.createNestedID(SCRIPT_ID), serviceID: 'custom_field' },
       })
   })
 })

--- a/packages/netsuite-adapter/test/filters/element_references.test.ts
+++ b/packages/netsuite-adapter/test/filters/element_references.test.ts
@@ -16,7 +16,7 @@
 import {
   BuiltinTypes,
   CORE_ANNOTATIONS,
-  ElemID, InstanceElement, isReferenceExpression, ObjectType, ReferenceExpression, StaticFile, toChange,
+  ElemID, Field, InstanceElement, isReferenceExpression, ObjectType, ReferenceExpression, StaticFile, toChange,
 } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import filterCreator from '../../src/filters/element_references'
@@ -540,35 +540,52 @@ describe('instance_references filter', () => {
         }
       )
     })
-    // TODO: should be uncommented when SALTO-4305 is communicated and opened to all
-    // it('should add generated dependency for custom record fields referenced by field ID', async () => {
-    //   const fileContent = `
-    //   define(['N/record', function(record) {
-    //     return{
-    //       post: function(requestBody){
-    //       var semanticRef = 'custom_field'
-    //       log.debug('salesRep', requestBody.salesRep);
-    //       // Load employee record
-    //     }
-    //   });`
-    //   fileInstance.value.content = new StaticFile({ filepath: 'somePath', content: Buffer.from(fileContent) })
-    //   const customRecordField = new Field(customRecordType, 'custom_field', BuiltinTypes.STRING)
-    //   await filterCreator({
-    //     elementsSourceIndex,
-    //     elementsSource: buildElementsSourceFromElements([]),
-    //     isPartial: false,
-    //     config: await getDefaultAdapterConfig(),
-    //   }).onFetch?.([fileInstance, customRecordType])
-    //   expect(fileInstance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toHaveLength(1)
-    //   expect(fileInstance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toContainEqual(
-    //     {
-    //       reference: new ReferenceExpression(
-    //         customRecordField.elemID
-    //       ),
-    //       occurrences: undefined,
-    //     }
-    //   )
-    // })
+    // TODO: should be updated when SALTO-4305 is communicated and opened to all
+    it('should add generated dependency for custom record fields referenced by field ID', async () => {
+      const fileContent = `
+      define(['N/record', function(record) {
+        return{
+          post: function(requestBody){
+          var semanticRef = 'custom_field'
+          log.debug('salesRep', requestBody.salesRep);
+          // Load employee record
+        }
+      });`
+      fileInstance.value.content = new StaticFile({ filepath: 'somePath', content: Buffer.from(fileContent) })
+      await filterCreator({
+        elementsSourceIndex,
+        elementsSource: buildElementsSourceFromElements([]),
+        isPartial: false,
+        config: await getDefaultAdapterConfig(),
+      }).onFetch?.([fileInstance, customRecordType])
+      expect(fileInstance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeUndefined()
+    })
+
+    it('should add customrecord field as generated dependency from elementsSource in partial fetch', async () => {
+      const customRecordField = new Field(customRecordType, 'custom_field', BuiltinTypes.STRING)
+      getIndexesMock.mockResolvedValue({
+        customRecordTypeFieldsIndex: {
+          custom_field: { elemID: customRecordField.elemID },
+        },
+      })
+      const fileContent = `
+      define(['N/record', function(record) {
+        return{
+          post: function(requestBody){
+          var semanticRef = 'custom_field'
+          log.debug('salesRep', requestBody.salesRep);
+          // Load employee record
+        }
+      });`
+      fileInstance.value.content = new StaticFile({ filepath: 'somePath', content: Buffer.from(fileContent) })
+      await filterCreator({
+        elementsSourceIndex,
+        elementsSource: buildElementsSourceFromElements([]),
+        isPartial: true,
+        config: await getDefaultAdapterConfig(),
+      }).onFetch?.([fileInstance])
+      expect(fileInstance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeUndefined()
+    })
   })
   describe('preDeploy', () => {
     let instanceWithReferences: InstanceElement

--- a/packages/netsuite-adapter/test/filters/element_references.test.ts
+++ b/packages/netsuite-adapter/test/filters/element_references.test.ts
@@ -565,7 +565,7 @@ describe('instance_references filter', () => {
       const customRecordField = new Field(customRecordType, 'custom_field', BuiltinTypes.STRING)
       getIndexesMock.mockResolvedValue({
         customRecordFieldsServiceIdRecordsIndex: {
-          custom_field: { elemID: customRecordField.elemID },
+          custom_field: { elemID: customRecordField.elemID.createNestedID(SCRIPT_ID) },
         },
       })
       const fileContent = `

--- a/packages/netsuite-adapter/test/filters/element_references.test.ts
+++ b/packages/netsuite-adapter/test/filters/element_references.test.ts
@@ -564,7 +564,7 @@ describe('instance_references filter', () => {
     it('should add customrecord field as generated dependency from elementsSource in partial fetch', async () => {
       const customRecordField = new Field(customRecordType, 'custom_field', BuiltinTypes.STRING)
       getIndexesMock.mockResolvedValue({
-        customRecordTypeFieldsIndex: {
+        customRecordFieldsServiceIdRecordsIndex: {
           custom_field: { elemID: customRecordField.elemID },
         },
       })

--- a/packages/netsuite-adapter/test/filters/element_references.test.ts
+++ b/packages/netsuite-adapter/test/filters/element_references.test.ts
@@ -539,6 +539,35 @@ describe('instance_references filter', () => {
         }
       )
     })
+    // TODO: should be uncommented when SALTO-4305 is communicated and opened to all
+    // it('should add generated dependency for custom record fields referenced by field ID', async () => {
+    //   const fileContent = `
+    //   define(['N/record', function(record) {
+    //     return{
+    //       post: function(requestBody){
+    //       var semanticRef = 'custom_field'
+    //       log.debug('salesRep', requestBody.salesRep);
+    //       // Load employee record
+    //     }
+    //   });`
+    //   fileInstance.value.content = new StaticFile({ filepath: 'somePath', content: Buffer.from(fileContent) })
+    //   const customRecordField = new Field(customRecordType, 'custom_field', BuiltinTypes.STRING)
+    //   await filterCreator({
+    //     elementsSourceIndex,
+    //     elementsSource: buildElementsSourceFromElements([]),
+    //     isPartial: false,
+    //     config: await getDefaultAdapterConfig(),
+    //   }).onFetch?.([fileInstance, customRecordType])
+    //   expect(fileInstance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toHaveLength(1)
+    //   expect(fileInstance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toContainEqual(
+    //     {
+    //       reference: new ReferenceExpression(
+    //         customRecordField.elemID
+    //       ),
+    //       occurrences: undefined,
+    //     }
+    //   )
+    // })
   })
   describe('preDeploy', () => {
     let instanceWithReferences: InstanceElement

--- a/packages/netsuite-adapter/test/filters/element_references.test.ts
+++ b/packages/netsuite-adapter/test/filters/element_references.test.ts
@@ -123,6 +123,7 @@ describe('instance_references filter', () => {
             refType: BuiltinTypes.STRING,
             annotations: {
               parent: '[scriptid=customrecord1]',
+              scriptid: 'custom_field',
             },
           },
         },

--- a/packages/netsuite-adapter/test/utils.ts
+++ b/packages/netsuite-adapter/test/utils.ts
@@ -33,4 +33,5 @@ export const createEmptyElementsSourceIndexes = (): ElementsSourceIndexes => ({
   customFieldsIndex: {},
   elemIdToChangeByIndex: {},
   elemIdToChangeAtIndex: {},
+  customRecordFieldsServiceIdRecordsIndex: {},
 })


### PR DESCRIPTION
_Create references to custom record fields in suitescripts_

---

_The ticket: https://salto-io.atlassian.net/browse/SALTO-4305_
_Currentrly this pr contains a "softer" version which only logs the new found references and doesn't add them_

---
_Release Notes_: 
_Netsuite Adapter_:
* custom record field references in suitescripts will be logged.

---
_User Notifications_: 
_None_