### PR TITLE
SALTO-3648 - Added a validator to prevent illegal changes to standard ticket fields

### DIFF
--- a/packages/zendesk-adapter/src/change_validator.ts
+++ b/packages/zendesk-adapter/src/change_validator.ts
@@ -67,6 +67,7 @@ import {
   defaultDynamicContentItemVariantValidator,
   featureActivationValidator,
   deflectionActionValidator,
+  standardFieldsValidator,
 } from './change_validators'
 import ZendeskClient from './client/client'
 import { ZedneskDeployConfig, ZendeskFetchConfig } from './config'
@@ -146,6 +147,7 @@ export default ({
     defaultDynamicContentItemVariantValidator,
     featureActivationValidator,
     deflectionActionValidator,
+    standardFieldsValidator,
     // *** Guide Order Validators ***
     childInOrderValidator,
     childrenReferencesValidator,

--- a/packages/zendesk-adapter/src/change_validators/index.ts
+++ b/packages/zendesk-adapter/src/change_validators/index.ts
@@ -65,3 +65,4 @@ export { additionOfTicketStatusForTicketFormValidator } from './ticket_status_in
 export { defaultDynamicContentItemVariantValidator } from './default_dynamic_content_item_variant'
 export { featureActivationValidator } from './feature_activation'
 export { deflectionActionValidator } from './deflection_action'
+export { standardFieldsValidator } from './standard_fields'

--- a/packages/zendesk-adapter/src/change_validators/standard_fields.ts
+++ b/packages/zendesk-adapter/src/change_validators/standard_fields.ts
@@ -1,0 +1,65 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  ChangeError,
+  ChangeValidator,
+  getChangeData,
+  isInstanceChange,
+  isModificationChange,
+} from '@salto-io/adapter-api'
+import { detailedCompare } from '@salto-io/adapter-utils'
+import _ from 'lodash'
+import { TICKET_FIELD_TYPE_NAME } from '../constants'
+
+const STANDARD_FIELDS = [
+  'tickettype',
+  'status',
+  'priority',
+  'group',
+  'description',
+  'assignee',
+  'subject',
+]
+const NON_EDITABLE_FIELDS = ['raw_title', 'type']
+
+export const standardFieldsValidator: ChangeValidator = async changes => {
+  const relevantChanges = changes
+    .filter(isInstanceChange)
+    .filter(change => getChangeData(change).elemID.typeName === TICKET_FIELD_TYPE_NAME)
+    .filter(change => STANDARD_FIELDS.includes(getChangeData(change).value.type))
+
+  const [modifications, additionsRemovals] = _.partition(
+    relevantChanges,
+    isModificationChange
+  )
+
+  const relevantModifications = modifications.filter(change => {
+    const detailedChanges = detailedCompare(change.data.before, change.data.after)
+    return detailedChanges.some(detailedChange => NON_EDITABLE_FIELDS.includes(detailedChange.id.name))
+  })
+
+  return additionsRemovals.map((change): ChangeError => ({
+    elemID: getChangeData(change).elemID,
+    severity: 'Error',
+    message: 'Cannot add or remove standard ticket fields',
+    detailedMessage: 'Standard ticket fields cannot be added or removed in Zendesk',
+  })).concat(relevantModifications.map(change => ({
+    elemID: getChangeData(change).elemID,
+    severity: 'Error',
+    message: `Cannot edit ${NON_EDITABLE_FIELDS.join(', ')} fields of standard ticket fields`,
+    detailedMessage: `Editing ${NON_EDITABLE_FIELDS.join(', ')} fields of standard ticket fields is not supported in Zendesk`,
+  })))
+}

--- a/packages/zendesk-adapter/src/change_validators/standard_fields.ts
+++ b/packages/zendesk-adapter/src/change_validators/standard_fields.ts
@@ -50,7 +50,7 @@ export const standardFieldsValidator: ChangeValidator = async changes => {
     isModificationChange
   )
 
-  const relevantModifications = modifications.filter(change => {
+  const invalidModifications = modifications.filter(change => {
     const detailedChanges = detailedCompare(change.data.before, change.data.after)
     return detailedChanges.some(detailedChange => NON_EDITABLE_FIELDS.includes(detailedChange.id.name))
   })
@@ -60,7 +60,7 @@ export const standardFieldsValidator: ChangeValidator = async changes => {
     severity: 'Error',
     message: 'Cannot add or remove standard ticket fields',
     detailedMessage: 'Standard ticket fields cannot be added or removed in Zendesk',
-  })).concat(relevantModifications.map(change => ({
+  })).concat(invalidModifications.map(change => ({
     elemID: getChangeData(change).elemID,
     severity: 'Error',
     message: `Cannot edit [${NON_EDITABLE_FIELDS.join(', ')}] fields of standard ticket fields`,

--- a/packages/zendesk-adapter/src/change_validators/standard_fields.ts
+++ b/packages/zendesk-adapter/src/change_validators/standard_fields.ts
@@ -35,6 +35,10 @@ const STANDARD_FIELDS = [
 ]
 const NON_EDITABLE_FIELDS = ['raw_title', 'type']
 
+/**
+ * Validates that standard ticket fields are not added or removed,
+ * or that their non-editable fields are not modified
+ */
 export const standardFieldsValidator: ChangeValidator = async changes => {
   const relevantChanges = changes
     .filter(isInstanceChange)

--- a/packages/zendesk-adapter/src/change_validators/standard_fields.ts
+++ b/packages/zendesk-adapter/src/change_validators/standard_fields.ts
@@ -33,7 +33,7 @@ const STANDARD_FIELDS = [
   'assignee',
   'subject',
 ]
-const NON_EDITABLE_FIELDS = ['raw_title', 'type']
+const NON_EDITABLE_FIELDS = ['type', 'raw_title']
 
 /**
  * Validates that standard ticket fields are not added or removed,
@@ -63,7 +63,7 @@ export const standardFieldsValidator: ChangeValidator = async changes => {
   })).concat(relevantModifications.map(change => ({
     elemID: getChangeData(change).elemID,
     severity: 'Error',
-    message: `Cannot edit ${NON_EDITABLE_FIELDS.join(', ')} fields of standard ticket fields`,
-    detailedMessage: `Editing ${NON_EDITABLE_FIELDS.join(', ')} fields of standard ticket fields is not supported in Zendesk`,
+    message: `Cannot edit [${NON_EDITABLE_FIELDS.join(', ')}] fields of standard ticket fields`,
+    detailedMessage: `Editing [${NON_EDITABLE_FIELDS.join(', ')}] fields of standard ticket fields is not supported in Zendesk`,
   })))
 }

--- a/packages/zendesk-adapter/test/change_validators/standard_fields.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/standard_fields.test.ts
@@ -58,8 +58,12 @@ describe('standardFieldsValidator', () => {
     const errors = await standardFieldsValidator([
       toChange({ before: standardField, after: clonedInstance }),
     ])
-    expect(errors).toHaveLength(1)
-    expect(errors[0].message).toEqual('Cannot edit raw_title, type fields of standard ticket fields')
+    expect(errors).toMatchObject([{
+      elemID: standardField.elemID,
+      severity: 'Error',
+      message: 'Cannot edit [type, raw_title] fields of standard ticket fields',
+      detailedMessage: 'Editing [type, raw_title] fields of standard ticket fields is not supported in Zendesk',
+    }])
   })
 
   it('should not return an error for addition or removal of non-standard field', async () => {

--- a/packages/zendesk-adapter/test/change_validators/standrad_fields.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/standrad_fields.test.ts
@@ -1,0 +1,81 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import { ZENDESK } from '../../src/constants'
+import { standardFieldsValidator } from '../../src/change_validators'
+
+describe('standardFieldsValidator', () => {
+  const standardField = new InstanceElement(
+    'standardField',
+    new ObjectType({ elemID: new ElemID(ZENDESK, 'ticket_field') }),
+    {
+      type: 'status',
+      raw_title: 'Status',
+    }
+  )
+
+  const nonStandardField = standardField.clone()
+  nonStandardField.value.type = 'custom'
+
+  it('should return an error for addition or removal of standard ticket field', async () => {
+    const errors = await standardFieldsValidator([
+      toChange({ after: standardField }),
+      toChange({ before: standardField }),
+    ])
+    expect(errors).toHaveLength(2)
+    expect(errors).toMatchObject([
+      {
+        elemID: standardField.elemID,
+        severity: 'Error',
+        message: 'Cannot add or remove standard ticket fields',
+        detailedMessage: 'Standard ticket fields cannot be added or removed in Zendesk',
+      },
+      {
+        elemID: standardField.elemID,
+        severity: 'Error',
+        message: 'Cannot add or remove standard ticket fields',
+        detailedMessage: 'Standard ticket fields cannot be added or removed in Zendesk',
+      },
+    ])
+  })
+
+  it('should return an error for modification of non-editable field in standard ticket field', async () => {
+    const clonedInstance = standardField.clone()
+    clonedInstance.value.raw_title = 'Updated Status'
+    const errors = await standardFieldsValidator([
+      toChange({ before: standardField, after: clonedInstance }),
+    ])
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toEqual('Cannot edit raw_title, type fields of standard ticket fields')
+  })
+
+  it('should not return an error for addition or removal of non-standard field', async () => {
+    const errors = await standardFieldsValidator([
+      toChange({ after: nonStandardField }),
+      toChange({ before: nonStandardField }),
+    ])
+    expect(errors).toHaveLength(0)
+  })
+
+  it('should not return an error for modification of an editable field in standard field', async () => {
+    const clonedInstance = standardField.clone()
+    clonedInstance.value.someEditableField = 'Updated Value'
+    const errors = await standardFieldsValidator([
+      toChange({ before: standardField, after: clonedInstance }),
+    ])
+    expect(errors).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Validates that standard ticket fields are not added or removed or that their non-editable fields are not modified

---

It seems that some fields of standard ticket fields are uneditable under some conditions
I did not get into it because i did not see a failed deployment of the other fields so it might be better to wait and handle it if it pops

---
_Release Notes_: 
None

---
_User Notifications_: 
None