### PR TITLE
SALTO-4376: Netsuite - Update validateCredentials to return accountType and isProduction info

### DIFF
--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -490,7 +490,12 @@ export default class NetsuiteClient {
   }
 
   public async getSystemInformation(): Promise<SystemInformation | undefined> {
-    return this.suiteAppClient?.getSystemInformation()
+    try {
+      return await this.suiteAppClient?.getSystemInformation()
+    } catch (error) {
+      log.error('The following error was thrown in getSystemInformation', { error })
+      return undefined
+    }
   }
 
   public isSuiteAppConfigured(): boolean {

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
@@ -246,10 +246,10 @@ export default class SuiteAppClient {
       const results = await this.sendRestletRequest('sysInfo')
       return this.parseSystemInformation(results)
     } catch (error) {
-      log.error('error was thrown in getSystemInformation', { error })
       if (error instanceof InvalidSuiteAppCredentialsError) {
         throw error
       }
+      log.error('error was thrown in getSystemInformation', { error })
       return undefined
     }
   }

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
@@ -247,6 +247,9 @@ export default class SuiteAppClient {
       return this.parseSystemInformation(results)
     } catch (error) {
       log.error('error was thrown in getSystemInformation', { error })
+      if (error instanceof InvalidSuiteAppCredentialsError) {
+        throw error
+      }
       return undefined
     }
   }

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
@@ -406,13 +406,18 @@ export default class SuiteAppClient {
     }
   }
 
-  public static async validateCredentials(credentials: SuiteAppCredentials): Promise<void> {
+  public static async validateCredentials(credentials: SuiteAppCredentials): Promise<SystemInformation> {
     const client = new SuiteAppClient({
       credentials,
       globalLimiter: new Bottleneck(),
       instanceLimiter: () => false,
     })
-    await client.sendRestletRequest('sysInfo')
+    const sysInfo = await client.getSystemInformation()
+
+    if (sysInfo === undefined) {
+      throw new Error('Failed getting SuiteApp system information')
+    }
+    return sysInfo
   }
 
   private async safeAxiosPost(

--- a/packages/netsuite-adapter/test/client/suiteapp_client/suiteapp_client.test.ts
+++ b/packages/netsuite-adapter/test/client/suiteapp_client/suiteapp_client.test.ts
@@ -310,9 +310,13 @@ describe('SuiteAppClient', () => {
       })
 
       describe('request failure', () => {
-        it('exception thrown', async () => {
+        it('general exception thrown', async () => {
           mockAxiosAdapter.onPost().reply(() => [])
           expect(await client.getSystemInformation()).toBeUndefined()
+        })
+        test.each([401, 403])('Post request fails with error code %d - should throw InvalidSuiteAppCredentialsError', async errorCode => {
+          mockAxiosAdapter.onPost().replyOnce(errorCode)
+          await expect(client.getSystemInformation()).rejects.toThrow(InvalidSuiteAppCredentialsError)
         })
         it('invalid results', async () => {
           mockAxiosAdapter.onPost().reply(200, { status: 'success', results: {} })

--- a/packages/netsuite-adapter/test/client/suiteapp_client/suiteapp_client.test.ts
+++ b/packages/netsuite-adapter/test/client/suiteapp_client/suiteapp_client.test.ts
@@ -633,40 +633,55 @@ describe('SuiteAppClient', () => {
       )).rejects.toThrow()
     })
 
-    it('should succeed with activationKey', async () => {
-      mockAxiosAdapter.onPost().reply(200, {
-        status: 'success',
-        results: {
-          appVersion: [0, 1, 3],
-          time: 1000,
-        },
+    describe('With activationKey', () => {
+      const systemInformation = {
+        appVersion: [0, 1, 3],
+        time: 1000,
+        envType: EnvType.BETA,
+      }
+
+      beforeEach(() => {
+        mockAxiosAdapter.onPost().reply(200, {
+          status: 'success',
+          results: systemInformation,
+        })
       })
 
-      await expect(SuiteAppClient.validateCredentials(
-        {
-          accountId: 'ACCOUNT_ID',
-          suiteAppTokenId: 'tokenId',
-          suiteAppTokenSecret: 'tokenSecret',
-          suiteAppActivationKey: 'activationKey',
-        },
-      )).resolves.toBeUndefined()
+      it('should succeed and return systemInformation', async () => {
+        await expect(SuiteAppClient.validateCredentials(
+          {
+            accountId: 'ACCOUNT_ID',
+            suiteAppTokenId: 'tokenId',
+            suiteAppTokenSecret: 'tokenSecret',
+            suiteAppActivationKey: 'activationKey',
+          },
+        )).resolves.toEqual({ ...systemInformation, time: new Date(systemInformation.time) })
+      })
     })
-    it('should succeed without activationKey', async () => {
-      mockAxiosAdapter.onPost().reply(200, {
-        status: 'success',
-        results: {
-          appVersion: [0, 1, 3],
-          time: 1000,
-        },
+
+    describe('Without activationKey', () => {
+      const systemInformation = {
+        appVersion: [0, 1, 3],
+        time: 1000,
+        envType: EnvType.PRODUCTION,
+      }
+
+      beforeEach(() => {
+        mockAxiosAdapter.onPost().reply(200, {
+          status: 'success',
+          results: systemInformation,
+        })
       })
 
-      await expect(SuiteAppClient.validateCredentials(
-        {
-          accountId: 'ACCOUNT_ID',
-          suiteAppTokenId: 'tokenId',
-          suiteAppTokenSecret: 'tokenSecret',
-        },
-      )).resolves.toBeUndefined()
+      it('should succeed and return systemInformation', async () => {
+        await expect(SuiteAppClient.validateCredentials(
+          {
+            accountId: 'ACCOUNT_ID',
+            suiteAppTokenId: 'tokenId',
+            suiteAppTokenSecret: 'tokenSecret',
+          },
+        )).resolves.toEqual({ ...systemInformation, time: new Date(systemInformation.time) })
+      })
     })
   })
 


### PR DESCRIPTION
Use `systemInformation` as returned from SuiteApp in order to define the `accountType` and `isProduction` values.

---

_Additional context for reviewer_

A new SuiteApp version returns envType info - which is one of the 4 values - `production`, `sandbox`, `beta` or `internal`.
We use these values to define the account type and whether it's a production account or not.

Notice that `accountType` and `isProduction` values are optional and are not returned in cases the account does not have SuiteApp credentials.

---
_Release Notes_: 

---
_User Notifications_: 
