### PR TITLE
Revert "SALTO-4322: Data Records Circular Dependencies Workaround"

### DIFF
--- a/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
+++ b/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
@@ -24,7 +24,6 @@ import {
   SaltoElementError,
   SaltoError,
   SeverityLevel,
-  isInstanceElement,
 } from '@salto-io/adapter-api'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { BatchResultInfo } from 'jsforce-types'
@@ -320,15 +319,6 @@ const deployAddInstances = async (
   client: SalesforceClient,
   groupId: string
 ): Promise<DeployResult> => {
-  const instancesToUpdate = instances
-    .filter(instance => Object.values(instance.value).some(isInstanceElement))
-  // Replacing self-reference field values with the resolved instances that will later contain the Record Ids
-  const instanceByElemId = _.keyBy(instances, instance => instance.elemID.getFullName())
-  await awu(instances).forEach(instance => {
-    instance.value = _.mapValues(instance.value, val => (isInstanceElement(val)
-      ? instanceByElemId[val.elemID.getFullName()] ?? val
-      : val))
-  })
   const type = await instances[0].getType()
   const typeName = await apiName(type)
   const idFieldsNames = idFields.map(field => field.name)
@@ -372,7 +362,7 @@ const deployAddInstances = async (
     errorInstances: errorUpdateInstances,
   } = await retryFlow(
     updateInstances,
-    { typeName: await apiName(type), instances: existingInstances.concat(instancesToUpdate), client },
+    { typeName: await apiName(type), instances: existingInstances, client },
     client.dataRetry.maxAttempts
   )
   const allSuccessInstances = [...successInsertInstances, ...successUpdateInstances]

--- a/packages/salesforce-adapter/src/group_changes.ts
+++ b/packages/salesforce-adapter/src/group_changes.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { collections } from '@salto-io/lowerdash'
-import { Change, ChangeGroupIdFunction, getChangeData, InstanceElement, ChangeGroupId, ChangeId } from '@salto-io/adapter-api'
+import { Change, ChangeGroupIdFunction, getChangeData, InstanceElement, isAdditionChange, ChangeGroupId, ChangeId } from '@salto-io/adapter-api'
 import { apiName } from './transformers/transformer'
 import { isInstanceOfCustomObjectChange } from './custom_object_instances_deploy'
 
@@ -31,7 +31,7 @@ const instanceOfCustomObjectChangeToGroupId: ChangeIdFunction = async change => 
   groupId: `${change.action}_${await apiName(await (getChangeData(change) as InstanceElement).getType())}_instances`,
   // CustomObjects instances might have references to instances of the same type (via Lookup
   // fields), and if we deploy them together the reference gets removed.
-  disjoint: false,
+  disjoint: isAdditionChange(change),
 })
 
 // Everything that is not a custom object instance goes into the deploy api

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -844,7 +844,7 @@ const getLookUpNameImpl = (defs = fieldNameToTypeMappingDefs): GetLookupNameFunc
       }
       if (isElement(ref.value)) {
         const defaultStrategy = ReferenceSerializationStrategyLookup.absoluteApiName
-        return await defaultStrategy.serialize({ ref, element }) ?? ref.value
+        return defaultStrategy.serialize({ ref, element })
       }
     }
     return ref.value

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -946,17 +946,7 @@ const toRecord = async (
   const instanceType = await instance.getType()
   const values = {
     ...withNulls ? _.mapValues(instanceType.fields, () => null) : {},
-    ..._.mapValues(instance.value, val => {
-      // Lookups to the same types will have an Id value only after the referenced Record was deployed
-      if (isInstanceElement(val)) {
-        const referencedRecordId = val.value[CUSTOM_OBJECT_ID_FIELD]
-        if (referencedRecordId === undefined) {
-          return null
-        }
-        return referencedRecordId
-      }
-      return val
-    }),
+    ...instance.value,
   }
   const filteredRecordValues = {
     [CUSTOM_OBJECT_ID_FIELD]: instance.value[CUSTOM_OBJECT_ID_FIELD],


### PR DESCRIPTION
Reverts salto-io/salto#4491 due to possible bug.
Will run more tests and re-open the PR