### PR TITLE
SALTO-4402 - Salesforce: Recreate references from profiles' layoutAssignments' recordTypes

### DIFF
--- a/packages/salesforce-adapter/test/additional_references.test.ts
+++ b/packages/salesforce-adapter/test/additional_references.test.ts
@@ -255,10 +255,31 @@ describe('getAdditionalReferences', () => {
 
     it('should create a reference', async () => {
       const refs = await getAdditionalReferences(changes)
+      expect(refs).toHaveLength(2)
       expect(refs).toIncludeAllPartialMembers([
         { source: permissionSetInstance.elemID.createNestedID('layoutAssignments', 'Account_Account_Layout'), target: layout.elemID },
         { source: profileInstance.elemID.createNestedID('layoutAssignments', 'Account_Account_Layout'), target: layout.elemID },
       ])
+    })
+
+    describe('with recordType reference', () => {
+      let recordType: InstanceElement
+      beforeEach(() => {
+        recordType = new InstanceElement(
+          'SomeRecordType',
+          mockTypes.RecordType,
+          { [INSTANCE_FULL_NAME_FIELD]: 'SomeRecordType' },
+        )
+        profileInstance.value.layoutAssignments.Account_Account_Layout[0].recordType = 'SomeRecordType'
+        changes.push(toChange({ after: recordType }))
+      })
+
+      it('should create a recordType reference', async () => {
+        const refs = await getAdditionalReferences(changes)
+        expect(refs).toIncludeAllPartialMembers([
+          { source: profileInstance.elemID.createNestedID('layoutAssignments', 'Account_Account_Layout'), target: recordType.elemID },
+        ])
+      })
     })
   })
 


### PR DESCRIPTION
These refs require some special handling that we didn't have time to implement in the previous PR, so add them now.

---


---
_Release Notes_: 
N/A

---
_User Notifications_: 
N/A