### PR TITLE
workato add Joi support for recipeBlockTypes (cross-service)

### DIFF
--- a/packages/workato-adapter/package.json
+++ b/packages/workato-adapter/package.json
@@ -34,7 +34,8 @@
     "@salto-io/adapter-utils": "0.3.41",
     "@salto-io/logging": "0.3.41",
     "@salto-io/lowerdash": "0.3.41",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "joi": "^17.4.0"
   },
   "devDependencies": {
     "@salto-io/test-utils": "0.3.41",

--- a/packages/workato-adapter/src/filters/cross_service/recipe_block_types.ts
+++ b/packages/workato-adapter/src/filters/cross_service/recipe_block_types.ts
@@ -14,7 +14,6 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-// eslint-disable-next-line import/no-extraneous-dependencies
 import Joi from 'joi'
 import { createSchemeGuard } from '@salto-io/adapter-utils'
 
@@ -26,7 +25,7 @@ export type RefListItem = {
 
 export type BlockBase = {
   keyword: string
-  provider: string
+  provider?: string
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/workato-adapter/src/filters/cross_service/recipe_block_types.ts
+++ b/packages/workato-adapter/src/filters/cross_service/recipe_block_types.ts
@@ -14,6 +14,10 @@
 * limitations under the License.
 */
 import _ from 'lodash'
+// eslint-disable-next-line import/no-extraneous-dependencies
+import Joi from 'joi'
+import { createSchemeGuard } from '@salto-io/adapter-utils'
+
 
 export type RefListItem = {
   label: string
@@ -22,9 +26,21 @@ export type RefListItem = {
 
 export type BlockBase = {
   keyword: string
+  provider: string
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const isListItem = (value: any): value is RefListItem => (
   _.isObjectLike(value) && _.isString(value.label) && _.isString(value.value)
 )
+
+export const createBlockChecker = <T extends BlockBase>(scheme: Joi.AnySchema, supportedApps: string[])
+  : (value: unknown, application: string) => value is T => (
+    value: unknown, application: string
+  ): value is T => {
+    const isAdapterBlock = createSchemeGuard<T>(scheme)
+
+    return isAdapterBlock(value)
+      && supportedApps.includes(application)
+      && value.provider === application
+  }

--- a/packages/workato-adapter/test/filters/recipe_block_type.test.ts
+++ b/packages/workato-adapter/test/filters/recipe_block_type.test.ts
@@ -13,11 +13,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-// eslint-disable-next-line import/no-extraneous-dependencies
 import Joi from 'joi'
 import { BlockBase, createBlockChecker } from '../../src/filters/cross_service/recipe_block_types'
 
-/* eslint-disable camelcase */
 
 describe('Recipe references filter', () => {
   type BlockType = BlockBase & {
@@ -34,7 +32,7 @@ describe('Recipe references filter', () => {
 
   describe('Cross service - recipe block type - create block checker', () => {
     beforeAll(() => {
-      const BLOCK_SCHEMA = Joi.object({
+      const blockSchema = Joi.object({
         keyword: Joi.string().required(),
         provider: Joi.string().valid('app', 'app_secondary').required(),
         stringItem: Joi.string().required(),
@@ -44,7 +42,7 @@ describe('Recipe references filter', () => {
           could: Joi.number(),
         }).unknown(true).required(),
       }).unknown(true).required()
-      blockChecker = createBlockChecker<BlockType>(BLOCK_SCHEMA, ['app', 'more_app'])
+      blockChecker = createBlockChecker<BlockType>(blockSchema, ['app', 'more_app'])
     })
     it('should accept valid block', () => {
       const block = {

--- a/packages/workato-adapter/test/filters/recipe_block_type.test.ts
+++ b/packages/workato-adapter/test/filters/recipe_block_type.test.ts
@@ -1,0 +1,92 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+// eslint-disable-next-line import/no-extraneous-dependencies
+import Joi from 'joi'
+import { BlockBase, createBlockChecker } from '../../src/filters/cross_service/recipe_block_types'
+
+/* eslint-disable camelcase */
+
+describe('Recipe references filter', () => {
+  type BlockType = BlockBase & {
+    stringItem : string
+    provider : 'app' | 'app_secondary'
+    numberItem : number
+    objectItem : {
+      must : string
+      could? : number
+    }
+  }
+
+  let blockChecker :(value: unknown, application: string) => value is BlockType
+
+  describe('Cross service - recipe block type - create block checker', () => {
+    beforeAll(() => {
+      const BLOCK_SCHEMA = Joi.object({
+        keyword: Joi.string().required(),
+        provider: Joi.string().valid('app', 'app_secondary').required(),
+        stringItem: Joi.string().required(),
+        numberItem: Joi.number().required(),
+        objectItem: Joi.object({
+          must: Joi.string().required(),
+          could: Joi.number(),
+        }).unknown(true).required(),
+      }).unknown(true).required()
+      blockChecker = createBlockChecker<BlockType>(BLOCK_SCHEMA, ['app', 'more_app'])
+    })
+    it('should accept valid block', () => {
+      const block = {
+        keyword: 'keyword',
+        provider: 'app',
+        stringItem: 'string',
+        numberItem: 4,
+        objectItem: {
+          must: 'string',
+          could: 4,
+          else: 'string',
+        },
+      }
+      expect(blockChecker(block, 'app')).toBeTruthy()
+    })
+    it('should reject block not in schema', () => {
+      const block = {
+        keyword: 'keyword',
+        provider: 'app',
+        stringItem: 5,
+        numberItem: 4,
+        objectItem: {
+          must: 'string',
+          could: 4,
+          else: 'string',
+        },
+      }
+      expect(blockChecker(block, 'app')).toBeFalsy()
+    })
+    it('should reject block of different app', () => {
+      const block = {
+        keyword: 'keyword',
+        provider: 'not_app',
+        stringItem: 'string',
+        numberItem: 4,
+        objectItem: {
+          must: 'string',
+          could: 4,
+          else: 'string',
+        },
+      }
+      expect(blockChecker(block, 'app')).toBeFalsy()
+    })
+  })
+})


### PR DESCRIPTION
In this PR, I have added createBlockChecker which create recipe block checker from Joi Schema. 
In addition, I have been added 'provider' arg for the blockBase such that createBlockChecker can depend on it.
(All CrossService Blocks contanis provider anyway)

---
This PR is base branch for future SALTO-1619 PR. (we want to use Joi while validating Jira block)

---
_Release Notes_: 
None

---
_User Notifications_: 
None