### PR TITLE
SALTO-4306 make convertTypes filter synchronous

### DIFF
--- a/packages/adapter-api/src/elements.ts
+++ b/packages/adapter-api/src/elements.ts
@@ -193,6 +193,14 @@ export class ListType<T extends TypeElement = TypeElement> extends Element {
     return refInnerTypeVal
   }
 
+  getInnerTypeSync(): TypeElement {
+    const refInnerTypeVal = this.refInnerType.getResolvedValueSync()
+    if (!isType(refInnerTypeVal)) {
+      throw new Error(`Cannot resolve ${this.elemID.getFullName()}'s innerType synchronously`)
+    }
+    return refInnerTypeVal
+  }
+
   setRefInnerType(innerTypeOrRefInnerType: TypeOrRef): void {
     if (innerTypeOrRefInnerType.elemID.isEqual(this.refInnerType.elemID)) {
       this.refInnerType = getRefType(innerTypeOrRefInnerType)
@@ -252,6 +260,15 @@ export class MapType<T extends TypeElement = TypeElement> extends Element {
     }
     return refInnerTypeVal
   }
+
+  getInnerTypeSync(): TypeElement {
+    const refInnerTypeVal = this.refInnerType.getResolvedValueSync()
+    if (!isType(refInnerTypeVal)) {
+      throw new Error(`Cannot resolve ${this.elemID.getFullName()}'s innerType synchronously`)
+    }
+    return refInnerTypeVal
+  }
+
 
   setRefInnerType(innerTypeOrRefInnerType: TypeOrRef): void {
     if (innerTypeOrRefInnerType.elemID.isEqual(this.refInnerType.elemID)) {

--- a/packages/adapter-api/src/elements.ts
+++ b/packages/adapter-api/src/elements.ts
@@ -302,6 +302,14 @@ export class Field extends Element {
     return type
   }
 
+  getTypeSync(): TypeElement {
+    const type = this.refType.getResolvedValueSync()
+    if (!isType(type)) {
+      throw new Error(`Element with ElemID ${this.elemID.getFullName()}'s type is resolved non-TypeElement`)
+    }
+    return type
+  }
+
   /**
    * Clones a field
    * Note that the cloned field still has the same element ID so it cannot be used in a different
@@ -476,6 +484,21 @@ export class InstanceElement extends Element {
     }
     return type
   }
+
+  getTypeSync(): ObjectType {
+    const type = this.refType.getResolvedValueSync()
+    if (!isObjectType(type)) {
+      log.warn(`Element with ElemID ${this.elemID.getFullName()}'s type is resolved non-ObjectType`)
+      if (type === undefined) {
+        throw new Error(`Element with ElemID ${this.elemID.getFullName()}'s type is undefined`)
+      }
+      return new PlaceholderObjectType({
+        elemID: this.elemID,
+      })
+    }
+    return type
+  }
+
 
   isEqual(
     other: InstanceElement,

--- a/packages/adapter-api/src/elements.ts
+++ b/packages/adapter-api/src/elements.ts
@@ -196,7 +196,7 @@ export class ListType<T extends TypeElement = TypeElement> extends Element {
   getInnerTypeSync(): TypeElement {
     const refInnerTypeVal = this.refInnerType.getResolvedValueSync()
     if (!isType(refInnerTypeVal)) {
-      throw new Error(`Cannot resolve ${this.elemID.getFullName()}'s innerType synchronously`)
+      throw new Error(`Element with ElemID ${this.elemID.getFullName()}'s innerType is resolved non-TypeElement`)
     }
     return refInnerTypeVal
   }
@@ -264,7 +264,7 @@ export class MapType<T extends TypeElement = TypeElement> extends Element {
   getInnerTypeSync(): TypeElement {
     const refInnerTypeVal = this.refInnerType.getResolvedValueSync()
     if (!isType(refInnerTypeVal)) {
-      throw new Error(`Cannot resolve ${this.elemID.getFullName()}'s innerType synchronously`)
+      throw new Error(`Cannot resolve ${this.elemID.getFullName()}'s innerType synchronously as non-TypeElement`)
     }
     return refInnerTypeVal
   }
@@ -320,7 +320,11 @@ export class Field extends Element {
   }
 
   getTypeSync(): TypeElement {
-    return this.refType.getResolvedValueSync()
+    const type = this.refType.getResolvedValueSync()
+    if (!isType(type)) {
+      throw new Error(`Element with ElemID ${this.elemID.getFullName()}'s type is resolved non-TypeElement`)
+    }
+    return type
   }
 
   /**

--- a/packages/adapter-api/src/elements.ts
+++ b/packages/adapter-api/src/elements.ts
@@ -303,11 +303,7 @@ export class Field extends Element {
   }
 
   getTypeSync(): TypeElement {
-    const type = this.refType.getResolvedValueSync()
-    if (!isType(type)) {
-      throw new Error(`Element with ElemID ${this.elemID.getFullName()}'s type is resolved non-TypeElement`)
-    }
-    return type
+    return this.refType.getResolvedValueSync()
   }
 
   /**

--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -84,11 +84,6 @@ type StaticFileMetadata = Pick<StaticFile, 'filepath' | 'hash'>
 export const getStaticFileUniqueName = ({ filepath, hash }: StaticFileMetadata): string =>
   `${filepath}-${hash}`
 
-const getResolvedValueSync = (
-  elemID: ElemID,
-  resolvedValue?: Value
-): Value => (resolvedValue ?? new PlaceholderObjectType({ elemID }))
-
 const getResolvedValue = async (
   elemID: ElemID,
   elementsSource?: ReadOnlyElementsSource,
@@ -153,10 +148,6 @@ export class ReferenceExpression {
 
   async getResolvedValue(elementsSource?: ReadOnlyElementsSource): Promise<Value> {
     return getResolvedValue(this.elemID, elementsSource, this.value)
-  }
-
-  getResolvedValueSync(): Value {
-    return getResolvedValueSync(this.elemID, this.value)
   }
 
   [inspect.custom](): string {

--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -87,12 +87,7 @@ export const getStaticFileUniqueName = ({ filepath, hash }: StaticFileMetadata):
 const getResolvedValueSync = (
   elemID: ElemID,
   resolvedValue?: Value
-): Value => {
-  if (resolvedValue === undefined) {
-    return new PlaceholderObjectType({ elemID })
-  }
-  return resolvedValue
-}
+): Value => (resolvedValue ?? new PlaceholderObjectType({ elemID }))
 
 const getResolvedValue = async (
   elemID: ElemID,
@@ -212,7 +207,7 @@ export class TypeReference {
 
   getResolvedValueSync(): TypeElement {
     if (this.type === undefined) {
-      throw new Error(`Cannot resolve type reference ${this.elemID.getFullName()} without type`)
+      throw new Error(`Type ${this.elemID.getFullName()} cannot be resolved synchronously`)
     }
     return this.type
   }

--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -84,6 +84,16 @@ type StaticFileMetadata = Pick<StaticFile, 'filepath' | 'hash'>
 export const getStaticFileUniqueName = ({ filepath, hash }: StaticFileMetadata): string =>
   `${filepath}-${hash}`
 
+const getResolvedValueSync = (
+  elemID: ElemID,
+  resolvedValue?: Value
+): Value => {
+  if (resolvedValue === undefined) {
+    return new PlaceholderObjectType({ elemID })
+  }
+  return resolvedValue
+}
+
 const getResolvedValue = async (
   elemID: ElemID,
   elementsSource?: ReadOnlyElementsSource,
@@ -150,6 +160,10 @@ export class ReferenceExpression {
     return getResolvedValue(this.elemID, elementsSource, this.value)
   }
 
+  getResolvedValueSync(): Value {
+    return getResolvedValueSync(this.elemID, this.value)
+  }
+
   [inspect.custom](): string {
     return `ReferenceExpression(${this.elemID.getFullName()}, ${this.value ? '<omitted>' : '<no value>'})`
   }
@@ -194,6 +208,13 @@ export class TypeReference {
 
   async getResolvedValue(elementsSource?: ReadOnlyElementsSource): Promise<TypeElement> {
     return getResolvedValue(this.elemID, elementsSource, this.type)
+  }
+
+  getResolvedValueSync(): TypeElement {
+    if (this.type === undefined) {
+      throw new Error(`Cannot resolve type reference ${this.elemID.getFullName()} without type`)
+    }
+    return this.type
   }
 
   [inspect.custom](): string {

--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -196,10 +196,8 @@ export class TypeReference {
     return getResolvedValue(this.elemID, elementsSource, this.type)
   }
 
-  getResolvedValueSync(): TypeElement {
-    if (this.type === undefined) {
-      throw new Error(`Type ${this.elemID.getFullName()} cannot be resolved synchronously`)
-    }
+
+  getResolvedValueSync(): TypeElement | undefined {
     return this.type
   }
 

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -109,6 +109,17 @@ export type TransformFunc = (args: TransformFuncArgs) => Promise<Value> | Value 
 
 export type TransformFuncSync = (args: TransformFuncArgs) => lowerDashTypes.NonPromise<Value> | undefined
 
+export type TransformValuesArgs = {
+  values: Value
+  type: ObjectType | TypeMap | MapType | ListType
+  transformFunc: TransformFunc
+  strict?: boolean
+  pathID?: ElemID
+  elementsSource?: ReadOnlyElementsSource
+  isTopLevel?: boolean
+  allowEmpty?: boolean
+}
+
 // NOTE: Any changes that are made to this function need to take into account whether
 //  they're also needed over at transformValuesSync. The two functions are separated
 //  only because of the way async is intertwined with the logic.
@@ -122,16 +133,7 @@ export const transformValues = async (
     elementsSource,
     isTopLevel = true,
     allowEmpty = false,
-  }: {
-    values: Value
-    type: ObjectType | TypeMap | MapType | ListType
-    transformFunc: TransformFunc
-    strict?: boolean
-    pathID?: ElemID
-    elementsSource?: ReadOnlyElementsSource
-    isTopLevel?: boolean
-    allowEmpty?: boolean
-  }
+  }: TransformValuesArgs
 ): Promise<Values | undefined> => {
   const transformValue = async (
     value: Value,
@@ -271,19 +273,9 @@ export const transformValuesSync = (
     transformFunc,
     strict = true,
     pathID = undefined,
-    elementsSource,
     isTopLevel = true,
     allowEmpty = false,
-  }: {
-    values: Value
-    type: ObjectType | TypeMap | MapType | ListType
-    transformFunc: TransformFuncSync
-    strict?: boolean
-    pathID?: ElemID
-    elementsSource?: ReadOnlyElementsSource
-    isTopLevel?: boolean
-    allowEmpty?: boolean
-  }
+  }: Omit<TransformValuesArgs, 'elementsSource'>,
 ): Values | undefined => {
   const transformValueSync = (
     value: Value,
@@ -366,7 +358,6 @@ export const transformValuesSync = (
           transformFunc,
           strict,
           pathID: keyPathID,
-          elementsSource,
           isTopLevel: false,
           allowEmpty,
         }),

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -109,6 +109,9 @@ export type TransformFunc = (args: TransformFuncArgs) => Promise<Value> | Value 
 
 export type TransformFuncSync = (args: TransformFuncArgs) => lowerDashTypes.NonPromise<Value> | undefined
 
+// NOTE: Any changes that are made to this function need to take into account whether
+//  they're also needed over at transformValuesSync. The two functions are separated
+//  only because of the way async is intertwined with the logic.
 export const transformValues = async (
   {
     values,
@@ -256,7 +259,11 @@ export const transformValues = async (
   return newVal
 }
 
-// TODOADI call this function only from transformValues if elementSource doesn't exist
+// IMPORTANT: this function will only work if transformFunc is synchronous.
+//  It is up to the caller to ensure that this is the case.
+// NOTE: Any changes that are made to this function need to take into account whether
+//  they're also needed over at transformValues. The two functions are separated
+//  only because of the way async is intertwined with the logic.
 export const transformValuesSync = (
   {
     values,

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -18,7 +18,7 @@ import wu from 'wu'
 import _ from 'lodash'
 import safeStringify from 'fast-safe-stringify'
 import { logger } from '@salto-io/logging'
-import { collections, values as lowerDashValues, promises } from '@salto-io/lowerdash'
+import { types as lowerDashTypes, collections, values as lowerDashValues, promises } from '@salto-io/lowerdash'
 import {
   ObjectType, isStaticFile, StaticFile, ElemID, PrimitiveType, Values, Value, isReferenceExpression,
   Element, isInstanceElement, InstanceElement, isPrimitiveType, TypeMap, isField, ChangeDataType,
@@ -29,7 +29,6 @@ import {
   compareSpecialValues, getChangeData, isTemplateExpression, PlaceholderObjectType, UnresolvedReference, FieldMap,
 } from '@salto-io/adapter-api'
 import Joi from 'joi'
-import { types } from '@salto-io/lowerdash'
 import { walkOnElement, WalkOnFunc, WALK_NEXT_STEP } from './walk_element'
 
 const { mapValuesAsync } = promises.object
@@ -108,7 +107,7 @@ export type TransformFuncArgs = {
 }
 export type TransformFunc = (args: TransformFuncArgs) => Promise<Value> | Value | undefined
 
-export type TransformFuncSync = (args: TransformFuncArgs) => types.NonPromise<Value> | undefined
+export type TransformFuncSync = (args: TransformFuncArgs) => lowerDashTypes.NonPromise<Value> | undefined
 
 export const transformValues = async (
   {

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -109,15 +109,19 @@ export type TransformFunc = (args: TransformFuncArgs) => Promise<Value> | Value 
 
 export type TransformFuncSync = (args: TransformFuncArgs) => lowerDashTypes.NonPromise<Value> | undefined
 
-export type TransformValuesArgs = {
+type TransformValuesBaseArgs = {
   values: Value
   type: ObjectType | TypeMap | MapType | ListType
-  transformFunc: TransformFunc
   strict?: boolean
   pathID?: ElemID
-  elementsSource?: ReadOnlyElementsSource
   isTopLevel?: boolean
   allowEmpty?: boolean
+}
+
+type TransformValuesSyncArgs = TransformValuesBaseArgs & {transformFunc: TransformFuncSync}
+type TransformValuesArgs = TransformValuesBaseArgs & {
+  transformFunc: TransformFunc
+  elementsSource?: ReadOnlyElementsSource
 }
 
 // NOTE: Any changes that are made to this function need to take into account whether
@@ -261,8 +265,6 @@ export const transformValues = async (
   return newVal
 }
 
-// IMPORTANT: this function will only work if transformFunc is synchronous.
-//  It is up to the caller to ensure that this is the case.
 // NOTE: Any changes that are made to this function need to take into account whether
 //  they're also needed over at transformValues. The two functions are separated
 //  only because of the way async is intertwined with the logic.
@@ -275,7 +277,7 @@ export const transformValuesSync = (
     pathID = undefined,
     isTopLevel = true,
     allowEmpty = false,
-  }: Omit<TransformValuesArgs, 'elementsSource'>,
+  }: TransformValuesSyncArgs,
 ): Values | undefined => {
   const transformValueSync = (
     value: Value,

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -118,7 +118,7 @@ type TransformValuesBaseArgs = {
   allowEmpty?: boolean
 }
 
-type TransformValuesSyncArgs = TransformValuesBaseArgs & {transformFunc: TransformFuncSync}
+type TransformValuesSyncArgs = TransformValuesBaseArgs & { transformFunc: TransformFuncSync }
 type TransformValuesArgs = TransformValuesBaseArgs & {
   transformFunc: TransformFunc
   elementsSource?: ReadOnlyElementsSource

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -15,7 +15,7 @@
 */
 import os from 'os'
 import wu from 'wu'
-import _ from 'lodash'
+import _, { mapValues } from 'lodash'
 import safeStringify from 'fast-safe-stringify'
 import { logger } from '@salto-io/logging'
 import { collections, values as lowerDashValues, promises } from '@salto-io/lowerdash'
@@ -106,6 +106,8 @@ export type TransformFuncArgs = {
   field?: Field
 }
 export type TransformFunc = (args: TransformFuncArgs) => Promise<Value> | Value | undefined
+
+export type TransformFuncSync = (args: TransformFuncArgs) => Value | undefined
 
 export const transformValues = async (
   {
@@ -249,6 +251,156 @@ export const transformValues = async (
       ))
       .filter(value => !_.isUndefined(value))
       .toArray()
+    return result.length === 0 && !allowEmpty ? undefined : result
+  }
+  return newVal
+}
+
+
+export const transformValuesSync = (
+  {
+    values,
+    type,
+    transformFunc,
+    strict = true,
+    pathID = undefined,
+    elementsSource,
+    isTopLevel = true,
+    allowEmpty = false,
+  }: {
+    values: Value
+    type: ObjectType | TypeMap | MapType | ListType
+    transformFunc: TransformFuncSync
+    strict?: boolean
+    pathID?: ElemID
+    elementsSource?: ReadOnlyElementsSource
+    isTopLevel?: boolean
+    allowEmpty?: boolean
+  }
+): Values | undefined => {
+  const transformValueSync = (
+    value: Value,
+    keyPathID?: ElemID, field?: Field
+  ): Value => {
+    if (field === undefined && strict) {
+      return undefined
+    }
+
+    if (isReferenceExpression(value)) {
+      return transformFunc({ value, path: keyPathID, field })
+    }
+
+    const newVal = transformFunc({ value, path: keyPathID, field })
+    if (newVal === undefined) {
+      return undefined
+    }
+
+    if (isReferenceExpression(newVal)) {
+      return newVal
+    }
+
+    const fieldType = field?.getTypeSync()
+
+    if (field && isListType(fieldType)) {
+      const transformListInnerValue = (item: Value, index?: number): Value =>
+        (transformValueSync(
+          item,
+          !_.isUndefined(index) ? keyPathID?.createNestedID(String(index)) : keyPathID,
+          new Field(
+            field.parent,
+            field.name,
+            fieldType.refInnerType,
+            field.annotations
+          ),
+        ))
+      if (!_.isArray(newVal)) {
+        if (strict) {
+          log.debug(`Array value and isListType mis-match for field - ${field.name}. Got non-array for ListType.`)
+        }
+        return transformListInnerValue(newVal)
+      }
+      const transformed = wu(newVal)
+        .enumerate()
+        .map(([item, index]) => transformListInnerValue(item, index))
+        .filter((val: Value) => !_.isUndefined(val))
+        .toArray()
+      return transformed.length === 0 && (newVal.length > 0 || !allowEmpty)
+        ? undefined
+        : transformed
+    }
+    if (_.isArray(newVal)) {
+      // Even fields that are not defined as ListType can have array values
+      const transformed = wu(newVal)
+        .enumerate()
+        .map(([item, index]) => transformValueSync(item, keyPathID?.createNestedID(String(index)), field))
+        .filter(val => !_.isUndefined(val))
+        .toArray()
+      return transformed.length === 0 && (newVal.length > 0 || !allowEmpty)
+        ? undefined
+        : transformed
+    }
+
+    if (isObjectType(fieldType) || isMapType(fieldType)) {
+      if (!_.isPlainObject(newVal)) {
+        if (strict) {
+          log.debug(`Value mis-match for field ${field?.name} - value is not an object`)
+        }
+        // _.isEmpty returns true for primitive values (boolean, number)
+        // but we do not want to omit those, we only want to omit empty
+        // objects, arrays and strings. we don't need to check for objects here
+        // because we cannot get here with an object
+        const valueIsEmpty = (Array.isArray(newVal) || _.isString(newVal)) && _.isEmpty(newVal)
+        return (valueIsEmpty && !allowEmpty) ? undefined : newVal
+      }
+      const transformed = _.omitBy(
+        transformValuesSync({
+          values: newVal,
+          type: fieldType,
+          transformFunc,
+          strict,
+          pathID: keyPathID,
+          elementsSource,
+          isTopLevel: false,
+          allowEmpty,
+        }),
+        _.isUndefined
+      )
+      return _.isEmpty(transformed) && (!_.isEmpty(newVal) || !allowEmpty) ? undefined : transformed
+    }
+    if (_.isPlainObject(newVal) && !strict) {
+      const transformed = _.omitBy(
+        mapValues(
+          newVal ?? {},
+          (val, key) => transformValueSync(val, keyPathID?.createNestedID(key)),
+        ),
+        _.isUndefined,
+      )
+      return _.isEmpty(transformed) && (!allowEmpty || !_.isEmpty(newVal)) ? undefined : transformed
+    }
+    return newVal
+  }
+
+  const fieldMapper = fieldMapperGenerator(type, values)
+
+  const newVal = isTopLevel ? transformFunc({ value: values, path: pathID }) : values
+  if (_.isPlainObject(newVal)) {
+    const result = _.omitBy(
+      mapValues(
+        newVal ?? {},
+        (value, key) => transformValueSync(value, pathID?.createNestedID(key), fieldMapper(key))
+      ),
+      _.isUndefined
+    )
+    return _.isEmpty(result) && !allowEmpty ? undefined : result
+  }
+  if (_.isArray(newVal)) {
+    const result = newVal
+      .map((value, index) => transformValueSync(
+        value,
+        pathID?.createNestedID(String(index)),
+        fieldMapper(String(index))
+      ))
+      .filter(value => !_.isUndefined(value))
     return result.length === 0 && !allowEmpty ? undefined : result
   }
   return newVal

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -15,7 +15,7 @@
 */
 import os from 'os'
 import wu from 'wu'
-import _, { mapValues } from 'lodash'
+import _ from 'lodash'
 import safeStringify from 'fast-safe-stringify'
 import { logger } from '@salto-io/logging'
 import { collections, values as lowerDashValues, promises } from '@salto-io/lowerdash'
@@ -29,6 +29,7 @@ import {
   compareSpecialValues, getChangeData, isTemplateExpression, PlaceholderObjectType, UnresolvedReference, FieldMap,
 } from '@salto-io/adapter-api'
 import Joi from 'joi'
+import { types } from '@salto-io/lowerdash'
 import { walkOnElement, WalkOnFunc, WALK_NEXT_STEP } from './walk_element'
 
 const { mapValuesAsync } = promises.object
@@ -107,7 +108,7 @@ export type TransformFuncArgs = {
 }
 export type TransformFunc = (args: TransformFuncArgs) => Promise<Value> | Value | undefined
 
-export type TransformFuncSync = (args: TransformFuncArgs) => Value | undefined
+export type TransformFuncSync = (args: TransformFuncArgs) => types.NonPromise<Value> | undefined
 
 export const transformValues = async (
   {
@@ -256,7 +257,7 @@ export const transformValues = async (
   return newVal
 }
 
-
+// TODOADI call this function only from transformValues if elementSource doesn't exist
 export const transformValuesSync = (
   {
     values,
@@ -369,7 +370,7 @@ export const transformValuesSync = (
     }
     if (_.isPlainObject(newVal) && !strict) {
       const transformed = _.omitBy(
-        mapValues(
+        _.mapValues(
           newVal ?? {},
           (val, key) => transformValueSync(val, keyPathID?.createNestedID(key)),
         ),
@@ -385,7 +386,7 @@ export const transformValuesSync = (
   const newVal = isTopLevel ? transformFunc({ value: values, path: pathID }) : values
   if (_.isPlainObject(newVal)) {
     const result = _.omitBy(
-      mapValues(
+      _.mapValues(
         newVal ?? {},
         (value, key) => transformValueSync(value, pathID?.createNestedID(key), fieldMapper(key))
       ),

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -836,6 +836,21 @@ describe('Test utils.ts', () => {
           })
         })
 
+        it('should call transform on non-list types even for list types', () => {
+          expect(isListType(mockType.fields.strArray.getTypeSync())).toBeTruthy()
+          expect(transformFunc).toHaveBeenCalledWith({
+            value: mockInstance.value.strArray,
+            path: undefined,
+            field: new Field(
+              mockType.fields.strArray.parent,
+              mockType.fields.strArray.name,
+              (mockType.fields.strArray.getTypeSync() as ListType).getInnerTypeSync(),
+              mockType.fields.strArray.annotations,
+            ),
+          })
+        })
+
+
         it('should call transform on map types', () => {
           expect(isMapType(mockType.fields.strMap.getTypeSync())).toBeTruthy()
           expect(transformFunc).toHaveBeenCalledWith({

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -26,6 +26,7 @@ import {
 import { collections } from '@salto-io/lowerdash'
 import { mockFunction } from '@salto-io/test-utils'
 import Joi from 'joi'
+import wu from 'wu'
 import {
   transformValues, resolvePath, TransformFunc, restoreValues, resolveValues, resolveChangeElement,
   findElement, findElements, findObjectType, GetLookupNameFunc, safeJsonStringify,
@@ -39,7 +40,10 @@ import {
   getPath,
   getSubtypes,
   formatConfigSuggestionsReasons,
-  isResolvedReferenceExpression, FILTER_FUNC_NEXT_STEP,
+  isResolvedReferenceExpression,
+  FILTER_FUNC_NEXT_STEP,
+  transformValuesSync,
+  TransformFuncSync,
 } from '../src/utils'
 import { buildElementsSourceFromElements } from '../src/element_source'
 
@@ -772,6 +776,502 @@ describe('Test utils.ts', () => {
     })
   })
 
+  describe('transformValuesSync func', () => {
+    let resp: Values
+
+    const defaultFieldParent = new ObjectType({ elemID: new ElemID('') })
+
+    describe('with empty values', () => {
+      it('should return undefined', async () => {
+        expect(transformValuesSync({
+          values: {},
+          transformFunc: () => undefined,
+          type: mockType,
+        })).toBeUndefined()
+      })
+    })
+
+    describe('with empty transform func', () => {
+      let transformFunc: jest.MockedFunction<TransformFuncSync>
+
+      beforeEach(() => {
+        transformFunc = mockFunction<TransformFuncSync>().mockImplementation(({ value }) => value)
+      })
+
+      describe('when called with objectType as type parameter', () => {
+        beforeEach(async () => {
+          const result = transformValuesSync({
+            values: mockInstance.value,
+            type: mockType,
+            transformFunc,
+          })
+
+          expect(result).toBeDefined()
+          resp = result as Values
+        })
+
+        it('should preserve static files', () => {
+          expect(resp.file).toBeInstanceOf(StaticFile)
+        })
+
+        it('should call transform on top level primitive values', () => {
+          const primitiveFieldNames = ['str', 'bool', 'num']
+          primitiveFieldNames.forEach(field => {
+            expect(transformFunc).toHaveBeenCalledWith({
+              value: mockInstance.value[field],
+              path: undefined,
+              field: mockType.fields[field],
+            })
+          })
+        })
+
+        it('should call transform on top level references values', () => {
+          const referenceFieldNames = ['ref']
+          referenceFieldNames.forEach(field => {
+            expect(transformFunc).toHaveBeenCalledWith({
+              value: mockInstance.value[field],
+              path: undefined,
+              field: mockType.fields[field],
+            })
+          })
+        })
+
+        it('should call transform on map types', () => {
+          expect(isMapType(mockType.fields.strMap.getTypeSync())).toBeTruthy()
+          expect(transformFunc).toHaveBeenCalledWith({
+            value: mockInstance.value.strMap,
+            path: undefined,
+            field: new Field(
+              mockType.fields.strMap.parent,
+              mockType.fields.strMap.name,
+              mockType.fields.strMap.getTypeSync(),
+              mockType.fields.strMap.annotations,
+            ),
+          })
+        })
+
+        it('should call transform on array elements', () => {
+          const numArrayFieldType = mockType.fields.numArray.getTypeSync()
+          expect(isListType(numArrayFieldType)).toBeTruthy()
+          const numArrayValues = (mockInstance.value.numArray as string[])
+          wu(numArrayValues).forEach(
+            async value => expect(transformFunc).toHaveBeenCalledWith({
+              value,
+              path: undefined,
+              field: new Field(
+                mockType.fields.numArray.parent,
+                mockType.fields.numArray.name,
+                await (numArrayFieldType as ListType).getInnerType(),
+                mockType.fields.numArray.annotations,
+              ),
+            })
+          )
+        })
+
+        it('should call transform on map value elements', () => {
+          const numMapFieldType = mockType.fields.numMap.getTypeSync()
+          expect(isMapType(numMapFieldType)).toBeTruthy()
+          const numMapValues = (mockInstance.value.numMap as Map<string, number>)
+          wu(Object.entries(numMapValues)).forEach(
+            async ([key, value]) => {
+              const calls = transformFunc.mock.calls.map(c => c[0]).filter(
+                c => c.field && c.field.name === key
+              )
+              expect(calls).toHaveLength(1)
+              expect(calls[0].value).toEqual(value)
+              expect(calls[0].path).toBeUndefined()
+              expect(await calls[0].field?.getType()).toEqual(BuiltinTypes.NUMBER)
+              expect(calls[0].field?.parent.elemID).toEqual(mockType.fields.numMap.refType.elemID)
+            }
+          )
+        })
+
+        it('should call transform on primitive types in nested objects', () => {
+          const getField = async (
+            type: ObjectType | ContainerType,
+            path: (string | number)[],
+            value: Values,
+          ): Promise<Field> => {
+            if (isListType(type)) {
+              if (typeof path[0] !== 'number') {
+                throw new Error(`type ${type.elemID.getFullName()} is a list type but path part ${path[0]} is not a number`)
+              }
+              return getField(
+                (await type.getInnerType() as ObjectType | ContainerType),
+                path.slice(1),
+                value[path[0]],
+              )
+            }
+            const field = isMapType(type)
+              ? new Field(toObjectType(type, value), String(path[0]), await type.getInnerType())
+              : type.fields[path[0]]
+            return path.length === 1 ? field
+              : getField(
+                await field.getType() as ObjectType | ContainerType, path.slice(1), value[path[0]]
+              )
+          }
+          const nestedPrimitivePaths = [
+            ['obj', 0, 'field'],
+            ['obj', 1, 'field'],
+            ['obj', 2, 'field'],
+            ['obj', 0, 'innerObj', 'name'],
+            ['obj', 0, 'innerObj', 'magical', 'deepName'],
+            ['obj', 0, 'mapOfStringList'],
+            ['obj', 0, 'mapOfStringList', 'l1'],
+            ['obj', 1, 'mapOfStringList', 'something'],
+          ]
+          wu(nestedPrimitivePaths).forEach(
+            async path => {
+              const field = await getField(mockType, path, mockInstance.value)
+              const calls = transformFunc.mock.calls.map(c => c[0]).filter(
+                c => c.field && c.field.name === field.name
+                  && c.value === _.get(mockInstance.value, path)
+              )
+              expect(calls).toHaveLength(1)
+              expect(calls[0].path).toBeUndefined()
+              expect(calls[0].field?.getTypeSync()).toEqual(field.getTypeSync())
+              expect(calls[0].field?.parent.elemID).toEqual(field.parent.elemID)
+            }
+          )
+        })
+
+        it('should omit undefined fields in object', () => {
+          expect(resp).not.toHaveProperty('notExist')
+          expect(resp).not.toHaveProperty('notExistArray')
+        })
+
+        it('should omit undefined fields in nested objects', () => {
+          const { magical } = resp?.obj[1]?.innerObj
+          expect(magical).toBeDefined()
+          expect(magical).not.toHaveProperty('notExist2')
+        })
+
+        it('should keep all defined field values', () => {
+          Object.keys(mockType.fields)
+            .filter(key => !['obj', 'emptyStr', 'emptyArray'].includes(key))
+            .forEach(key => {
+              expect(resp[key]).toEqual(mockInstance.value[key])
+            })
+        })
+
+        it('should keep all nested defined fields values', () => {
+          expect(resp.obj[0]).toEqual(mockInstance.value.obj[0])
+        })
+      })
+
+      describe('when called with instance annotations', () => {
+        beforeEach(async () => {
+          const result = transformValuesSync({
+            values: mockInstance.annotations,
+            type: InstanceAnnotationTypes,
+            transformFunc,
+          })
+          expect(result).toEqual(mockInstance.annotations)
+        })
+
+
+        it('should call transform on instance annotation references values', () => {
+          const referenceAnnotationNames = [CORE_ANNOTATIONS.DEPENDS_ON]
+          referenceAnnotationNames.forEach(annotation => {
+            expect(transformFunc).toHaveBeenCalledWith({
+              value: mockInstance.annotations[annotation],
+              path: undefined,
+              field: new Field(defaultFieldParent, annotation, InstanceAnnotationTypes[annotation]),
+            })
+          })
+        })
+      })
+
+      describe('when called with type map', () => {
+        let origValue: Values
+        let typeMap: TypeMap
+        beforeEach(async () => {
+          origValue = {
+            str: 'asd',
+            num: '10',
+            bool: 'true',
+            nums: ['1', '2'],
+            numMap: { one: 1, two: 2 },
+            notExist: 'a',
+          }
+          typeMap = {
+            str: BuiltinTypes.STRING,
+            num: BuiltinTypes.NUMBER,
+            bool: BuiltinTypes.BOOLEAN,
+            nums: new ListType(BuiltinTypes.NUMBER),
+            numMap: new MapType(BuiltinTypes.NUMBER),
+          }
+          const result = transformValuesSync({
+            values: origValue,
+            type: typeMap,
+            transformFunc,
+          })
+
+          expect(result).toBeDefined()
+          resp = result as Values
+        })
+        it('should call transform func on all defined types', () => {
+          const primitiveTypes = ['str', 'num', 'bool']
+          primitiveTypes.forEach(
+            name => expect(transformFunc).toHaveBeenCalledWith({
+              value: origValue[name],
+              path: undefined,
+              field: new Field(defaultFieldParent, name, typeMap[name]),
+            })
+          )
+          origValue.nums.forEach(
+            (value: string) => expect(transformFunc).toHaveBeenCalledWith({
+              value,
+              path: undefined,
+              field: new Field(defaultFieldParent, 'nums', BuiltinTypes.NUMBER),
+            })
+          )
+          wu(Object.entries(origValue.numMap)).forEach(
+            async ([key, value]) => {
+              const field = new Field(
+                toObjectType(new MapType(BuiltinTypes.NUMBER), origValue.numMap),
+                key,
+                BuiltinTypes.NUMBER,
+              )
+              const calls = transformFunc.mock.calls.map(c => c[0]).filter(
+                c => c.field && c.field.name === field.name
+                  && c.value === value
+              )
+              expect(calls).toHaveLength(1)
+              expect(calls[0].path).toBeUndefined()
+              expect(await calls[0].field?.getType()).toEqual(await field.getType())
+              expect(calls[0].field?.parent.elemID).toEqual(field.parent.elemID)
+            }
+          )
+        })
+        it('should omit undefined fields values', () => {
+          expect(resp).not.toHaveProperty('notExist')
+        })
+        it('should keep all defined fields values', () => {
+          expect(origValue).toMatchObject(resp)
+        })
+      })
+
+      describe('when called with value as top level', () => {
+        let refResult: Values | undefined
+        let staticFileResult: Values | undefined
+        let varResult: Values | undefined
+        beforeEach(async () => {
+          refResult = transformValuesSync({
+            values: new ReferenceExpression(mockInstance.elemID),
+            type: mockType,
+            transformFunc,
+          })
+          staticFileResult = transformValuesSync({
+            values: new StaticFile({ content: Buffer.from('asd'), filepath: 'a' }),
+            type: mockType,
+            transformFunc,
+          })
+          varResult = transformValuesSync({
+            values: new VariableExpression(
+              new ElemID(ElemID.VARIABLES_NAMESPACE, 'myVar', 'var')
+            ),
+            type: mockType,
+            transformFunc,
+          })
+        })
+        it('should keep the value type', () => {
+          expect(refResult).toBeInstanceOf(ReferenceExpression)
+          expect(staticFileResult).toBeInstanceOf(StaticFile)
+          expect(varResult).toBeInstanceOf(VariableExpression)
+        })
+      })
+    })
+    const MAGIC_VAL = 'magix'
+    const MOD_MAGIC_VAL = 'BIRD'
+    const transformTest: TransformFuncSync = ({ value, field }) => {
+      if (value === MAGIC_VAL) {
+        return MOD_MAGIC_VAL
+      }
+      if (isReferenceExpression(value)) {
+        return value.value
+      }
+      const fieldType = field?.getTypeSync()
+      if (!isPrimitiveType(fieldType) || !isPrimitiveValue(value)) {
+        return value
+      }
+      switch (fieldType.primitive) {
+        case PrimitiveTypes.NUMBER:
+          return Number(value)
+        case PrimitiveTypes.BOOLEAN:
+          return value.toString().toLowerCase() === 'true'
+        case PrimitiveTypes.STRING:
+          return value.toString().length === 0 ? undefined : value.toString()
+        default:
+          return value
+      }
+    }
+
+    describe('when transformPrimitives and transformReference was received', () => {
+      describe('when called with instance values', () => {
+        beforeEach(() => {
+          const result = transformValuesSync({
+            values: mockInstance.value,
+            type: mockType,
+            transformFunc: transformTest,
+          })
+          expect(result).toBeDefined()
+          resp = result as Values
+        })
+
+        it('should transform primitive types', () => {
+          expect(resp.str).toEqual('val')
+          expect(resp.bool).toEqual(true)
+          expect(resp.num).toEqual(99)
+        })
+
+        it('should transform reference types', () => {
+          expect(resp.ref).toEqual('regValue')
+        })
+
+        it('should transform inner object', () => {
+          expect(resp.obj[0].innerObj.magical.deepNumber).toEqual(888)
+        })
+      })
+    })
+
+    describe('when strict is false', () => {
+      const unTypedValues = {
+        unTypedArr: [MAGIC_VAL],
+        unTypedObj: {
+          key: MAGIC_VAL,
+        },
+      }
+      beforeEach(() => {
+        const result = transformValuesSync(
+          {
+            values: {
+              ...mockInstance.value,
+              ...unTypedValues,
+            },
+            type: mockType,
+            transformFunc: transformTest,
+            strict: false,
+          }
+        )
+        expect(result).toBeDefined()
+        resp = result as Values
+      })
+
+      it('should transform primitive types', () => {
+        expect(resp.emptyStr).toBeUndefined()
+        expect(resp.bool).toEqual(true)
+        expect(resp.num).toEqual(99)
+        expect(resp.notExist).toEqual('notExist')
+      })
+
+      it('should transform inner object', () => {
+        expect(resp.obj[0]).not.toEqual(mockInstance.value.obj[0])
+        expect(resp.obj[1].innerObj.magical.deepNumber).toBeUndefined()
+        expect(resp.obj[1].innerObj.magical.notExist2).toEqual('false')
+        expect(resp.obj[2]).not.toEqual(mockInstance.value.obj[2])
+      })
+
+      it('should not change non primitive values in primitive fields', () => {
+        expect(resp.obj[0].value).toEqual(mockInstance.value.obj[0].value)
+      })
+
+      it('should tranfsorm nested arrays which do not have a field', () => {
+        expect(resp.unTypedArr[0]).toEqual(MOD_MAGIC_VAL)
+      })
+
+      it('should tranfsorm nested objects which do not have a field', () => {
+        expect(resp.unTypedObj.key).toEqual(MOD_MAGIC_VAL)
+      })
+    })
+
+    describe('when called with pathID', () => {
+      const paths = new Set<string>()
+      const createPathsSet: TransformFuncSync = ({ value, field, path }) => {
+        if (value && field && path) {
+          paths.add(path.getFullName())
+        }
+        return value
+      }
+
+      beforeAll(() => {
+        transformValuesSync(
+          {
+            values: mockInstance.value,
+            type: mockType,
+            transformFunc: createPathsSet,
+            pathID: mockInstance.elemID,
+          }
+        )
+      })
+
+      it('should traverse list items with correct path ID', () => {
+        expect(paths)
+          .toContain(mockInstance.elemID.createNestedID('obj', '0', 'field').getFullName())
+      })
+
+      it('should traverse map items with correct path ID', () => {
+        expect(paths)
+          .toContain(mockInstance.elemID.createNestedID('obj', '0', 'mapOfStringList').getFullName())
+        expect(paths)
+          .toContain(mockInstance.elemID.createNestedID('obj', '0', 'mapOfStringList', 'l1').getFullName())
+        expect(paths)
+          .toContain(mockInstance.elemID.createNestedID('obj', '0', 'mapOfStringList', 'l1', '0').getFullName())
+      })
+    })
+
+    describe('when called with array', () => {
+      beforeEach(async () => {
+        const result = transformValuesSync({
+          values: [{ key: 1 }, { key: 2 }, { key: 3 }],
+          type: new ListType(
+            new ObjectType({
+              elemID: mockElem,
+              fields: { key: { refType: BuiltinTypes.NUMBER } },
+            })
+          ),
+          transformFunc: ({ value, path }) => (
+            _.isPlainObject(value) || _.isArray(value) ? value : `${path?.getFullName()}:${value}`
+          ),
+          pathID: mockElem.createNestedID('instance', 'list'),
+          strict: true,
+        })
+        expect(result).toBeDefined()
+        resp = result as Values
+      })
+      it('should return array with transformed values', () => {
+        expect(resp).toEqual([
+          { key: 'mockAdapter.test.instance.list.0.key:1' },
+          { key: 'mockAdapter.test.instance.list.1.key:2' },
+          { key: 'mockAdapter.test.instance.list.2.key:3' },
+        ])
+      })
+    })
+
+    describe('with allowEmpty', () => {
+      it('should not remove empty list', async () => {
+        const result = transformValuesSync({
+          values: [],
+          type: new ListType(BuiltinTypes.NUMBER),
+          transformFunc: ({ value }) => value,
+          allowEmpty: true,
+        })
+
+        expect(result).toEqual([])
+      })
+
+      it('should not remove empty object', async () => {
+        const result = transformValuesSync({
+          values: {},
+          type: new ObjectType({ elemID: new ElemID('adapter', 'type') }),
+          transformFunc: ({ value }) => value,
+          allowEmpty: true,
+        })
+
+        expect(result).toEqual({})
+      })
+    })
+  })
   describe('transformElement', () => {
     let primType: PrimitiveType
     let listType: ListType

--- a/packages/lowerdash/src/types.ts
+++ b/packages/lowerdash/src/types.ts
@@ -100,3 +100,4 @@ export const isNonEmptyArray = <T> (array: T[]): array is NonEmptyArray<T> => (
 export type AllowOnly<T, K extends keyof T> = Pick<T, K> & { [P in keyof Omit<T, K>]?: never };
 export type OneOf<T, K = keyof T> = K extends keyof T ? AllowOnly<T, K> : never
 export type XOR<A, B> = AllowOnly<A & B, keyof A> | AllowOnly<A & B, keyof B>
+export type NonPromise<T> = T extends Promise<unknown> ? never : T

--- a/packages/lowerdash/test/types.test.ts
+++ b/packages/lowerdash/test/types.test.ts
@@ -24,7 +24,6 @@ import {
   isArrayOfType,
   TypeGuard,
   isNonEmptyArray,
-  NonPromise,
 } from '../src/types'
 
 // Note: some of the tests here are compile-time, so the actual assertions may look weird.
@@ -143,22 +142,5 @@ describe('types', () => {
     it('should return false for empty array', () => {
       expect(isNonEmptyArray([])).toEqual(false)
     })
-  })
-  describe('NonPromise', () => {
-    it('should run the function if is not a promise', () => {
-      const myFunc = <T>(arg: () => NonPromise<T>): T => arg()
-
-      const syncFunc = (): number => 1
-
-      expect(myFunc(syncFunc)).toEqual(1)
-    })
-
-    // TODOADI check how to compile code inside test
-    // it('Should fail to compile code with an async function', () => {
-    //   const code = `
-    //     const asyncFunc = async (): Promise<number> => 1
-    //     myFunc(asyncFunc)
-    //   `
-    //   expect(() => compile(code)).toThrow();
   })
 })

--- a/packages/lowerdash/test/types.test.ts
+++ b/packages/lowerdash/test/types.test.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import {
-  AtLeastOne, RequiredMember, hasMember, filterHasMember, ValueOf, Bean, isArrayOfType, TypeGuard, isNonEmptyArray,
+  AtLeastOne, RequiredMember, hasMember, filterHasMember, ValueOf, Bean, isArrayOfType, TypeGuard, isNonEmptyArray, NonPromise,
 } from '../src/types'
 
 // Note: some of the tests here are compile-time, so the actual assertions may look weird.
@@ -134,5 +134,24 @@ describe('types', () => {
     it('should return false for empty array', () => {
       expect(isNonEmptyArray([])).toEqual(false)
     })
+  })
+  describe('NonPromise', () => {
+    it('should run the function if is not a promise', () => {
+      const myFunc = <T>(arg: () => NonPromise<T>): T => {
+        return arg()
+      }
+
+      const syncFunc = (): number => 1
+
+      expect(myFunc(syncFunc)).toEqual(1)
+    })
+
+    // TODOADI check how to compile code inside test
+    // it('Should fail to compile code with an async function', () => {
+    //   const code = `
+    //     const asyncFunc = async (): Promise<number> => 1
+    //     myFunc(asyncFunc)
+    //   `
+    //   expect(() => compile(code)).toThrow();
   })
 })

--- a/packages/lowerdash/test/types.test.ts
+++ b/packages/lowerdash/test/types.test.ts
@@ -15,7 +15,16 @@
 */
 import _ from 'lodash'
 import {
-  AtLeastOne, RequiredMember, hasMember, filterHasMember, ValueOf, Bean, isArrayOfType, TypeGuard, isNonEmptyArray, NonPromise,
+  AtLeastOne,
+  RequiredMember,
+  hasMember,
+  filterHasMember,
+  ValueOf,
+  Bean,
+  isArrayOfType,
+  TypeGuard,
+  isNonEmptyArray,
+  NonPromise,
 } from '../src/types'
 
 // Note: some of the tests here are compile-time, so the actual assertions may look weird.
@@ -137,9 +146,7 @@ describe('types', () => {
   })
   describe('NonPromise', () => {
     it('should run the function if is not a promise', () => {
-      const myFunc = <T>(arg: () => NonPromise<T>): T => {
-        return arg()
-      }
+      const myFunc = <T>(arg: () => NonPromise<T>): T => arg()
 
       const syncFunc = (): number => 1
 

--- a/packages/lowerdash/test/types.test.ts
+++ b/packages/lowerdash/test/types.test.ts
@@ -15,15 +15,7 @@
 */
 import _ from 'lodash'
 import {
-  AtLeastOne,
-  RequiredMember,
-  hasMember,
-  filterHasMember,
-  ValueOf,
-  Bean,
-  isArrayOfType,
-  TypeGuard,
-  isNonEmptyArray,
+  AtLeastOne, RequiredMember, hasMember, filterHasMember, ValueOf, Bean, isArrayOfType, TypeGuard, isNonEmptyArray,
 } from '../src/types'
 
 // Note: some of the tests here are compile-time, so the actual assertions may look weird.

--- a/packages/salesforce-adapter/src/filters/convert_types.ts
+++ b/packages/salesforce-adapter/src/filters/convert_types.ts
@@ -17,11 +17,11 @@ import {
   Element, isObjectType, isInstanceElement,
 } from '@salto-io/adapter-api'
 import {
-  transformValues,
+  transformValuesSync,
 } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { LocalFilterCreator } from '../filter'
-import { transformPrimitive } from '../transformers/transformer'
+import { transformPrimitiveSync } from '../transformers/transformer'
 
 const { awu } = collections.asynciterable
 
@@ -43,11 +43,11 @@ const filterCreator: LocalFilterCreator = () => ({
       .filter(isInstanceElement)
       .filter(async instance => isObjectType(await instance.getType()))
       .forEach(async instance => {
-        instance.value = await transformValues(
+        instance.value = transformValuesSync(
           {
             values: instance.value,
-            type: await instance.getType(),
-            transformFunc: transformPrimitive,
+            type: instance.getTypeSync(),
+            transformFunc: transformPrimitiveSync,
             strict: false,
             allowEmpty: true,
           }

--- a/packages/salesforce-adapter/src/filters/convert_types.ts
+++ b/packages/salesforce-adapter/src/filters/convert_types.ts
@@ -21,7 +21,7 @@ import {
 } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { LocalFilterCreator } from '../filter'
-import { transformPrimitiveSync } from '../transformers/transformer'
+import { transformPrimitive } from '../transformers/transformer'
 
 const { awu } = collections.asynciterable
 
@@ -47,7 +47,7 @@ const filterCreator: LocalFilterCreator = () => ({
           {
             values: instance.value,
             type: instance.getTypeSync(),
-            transformFunc: transformPrimitiveSync,
+            transformFunc: transformPrimitive,
             strict: false,
             allowEmpty: true,
           }

--- a/packages/salesforce-adapter/src/filters/convert_types.ts
+++ b/packages/salesforce-adapter/src/filters/convert_types.ts
@@ -19,12 +19,9 @@ import {
 import {
   transformValuesSync,
 } from '@salto-io/adapter-utils'
-import { collections } from '@salto-io/lowerdash'
+import wu from 'wu'
 import { LocalFilterCreator } from '../filter'
 import { transformPrimitive } from '../transformers/transformer'
-
-const { awu } = collections.asynciterable
-
 
 /**
  * Convert types of values in instance elements to match the expected types according to the
@@ -39,10 +36,10 @@ const filterCreator: LocalFilterCreator = () => ({
    * @param elements the already fetched elements
    */
   onFetch: async (elements: Element[]) => {
-    await awu(elements)
+    wu(elements)
       .filter(isInstanceElement)
-      .filter(async instance => isObjectType(await instance.getType()))
-      .forEach(async instance => {
+      .filter(instance => isObjectType(instance.getTypeSync()))
+      .forEach(instance => {
         instance.value = transformValuesSync(
           {
             values: instance.value,

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -1195,6 +1195,45 @@ export const transformPrimitive: TransformFunc = async ({ value, path, field }) 
   }
 }
 
+export const transformPrimitiveSync: TransformFunc = ({ value, path, field }) => {
+  if (isNull(value)) {
+    // We transform null to undefined as currently we don't support null in Salto language
+    // and the undefined values are omitted later in the code
+    return undefined
+  }
+
+  // (Salto-394) Salesforce returns objects like:
+  // { "_": "fieldValue", "$": { "xsi:type": "xsd:string" } }
+  if (_.isObject(value) && Object.keys(value).includes('_')) {
+    const convertFunc = getXsdConvertFunc(_.get(value, ['$', 'xsi:type']))
+    return transformPrimitiveSync({ value: convertFunc(_.get(value, '_')), path, field })
+  }
+  const fieldType = field?.getTypeSync()
+
+  if (isContainerType(fieldType) && _.isEmpty(value)) {
+    return undefined
+  }
+  if (isObjectType(fieldType) && value === '') {
+    // Salesforce returns empty objects in XML as <quickAction></quickAction> for example
+    // We treat them as "" (empty string), and we don't want to delete them
+    // We should replace them with {} (empty object)
+    return {}
+  }
+  if (!isPrimitiveType(fieldType) || !isPrimitiveValue(value)) {
+    return value
+  }
+  switch (fieldType.primitive) {
+    case PrimitiveTypes.NUMBER:
+      return Number(value)
+    case PrimitiveTypes.BOOLEAN:
+      return value.toString().toLowerCase() === 'true'
+    case PrimitiveTypes.STRING:
+      return value.toString()
+    default:
+      return value
+  }
+}
+
 const isDefaultWithType = (val: PrimitiveValue | DefaultValueWithType):
   val is DefaultValueWithType => new Set(_.keys(val)).has('_')
 

--- a/packages/salesforce-adapter/test/transformers/transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/transformer.test.ts
@@ -2260,69 +2260,69 @@ describe('transformer', () => {
       })
     })
     describe('with primitive field', () => {
-      it('should convert number type', async () => {
+      it('should convert number type', () => {
         expect(
-          await transformPrimitive({ value: '1', field: mockObjType.fields.num })
+          transformPrimitive({ value: '1', field: mockObjType.fields.num })
         ).toEqual(1)
       })
-      it('should convert string type', async () => {
+      it('should convert string type', () => {
         expect(
-          await transformPrimitive({ value: '1', field: mockObjType.fields.str })
+          transformPrimitive({ value: '1', field: mockObjType.fields.str })
         ).toEqual('1')
       })
-      it('should convert boolean type', async () => {
+      it('should convert boolean type', () => {
         expect(
-          await transformPrimitive({ value: 'true', field: mockObjType.fields.bool })
+          transformPrimitive({ value: 'true', field: mockObjType.fields.bool })
         ).toEqual(true)
       })
-      it('should leave unknown type as-is', async () => {
+      it('should leave unknown type as-is', () => {
         expect(
-          await transformPrimitive({ value: '1', field: mockObjType.fields.unknown })
+          transformPrimitive({ value: '1', field: mockObjType.fields.unknown })
         ).toEqual('1')
         expect(
-          await transformPrimitive({ value: 1, field: mockObjType.fields.unknown })
+          transformPrimitive({ value: 1, field: mockObjType.fields.unknown })
         ).toEqual(1)
       })
-      it('should convert values with xsi:type attribute', async () => {
+      it('should convert values with xsi:type attribute', () => {
         expect(
-          await transformPrimitive({
+          transformPrimitive({
             value: { _: 'true', $: { 'xsi:type': 'xsd:boolean' } },
             field: mockObjType.fields.bool,
           })
         ).toEqual(true)
         expect(
-          await transformPrimitive({
+          transformPrimitive({
             value: { _: '12.3', $: { 'xsi:type': 'xsd:double' } },
             field: mockObjType.fields.num,
           })
         ).toEqual(12.3)
       })
-      it('should convert value by field type if xsi:type is unrecognized', async () => {
+      it('should convert value by field type if xsi:type is unrecognized', () => {
         expect(
-          await transformPrimitive({
+          transformPrimitive({
             value: { _: 'true', $: { 'xsi:type': 'xsd:unknown' } },
             field: mockObjType.fields.bool,
           })
         ).toEqual(true)
         expect(
-          await transformPrimitive({
+          transformPrimitive({
             value: { _: 'true', $: { 'xsi:type': 'xsd:unknown' } },
             field: mockObjType.fields.str,
           })
         ).toEqual('true')
       })
-      it('should omit null values', async () => {
-        expect(await transformPrimitive({
+      it('should omit null values', () => {
+        expect(transformPrimitive({
           value: { $: { 'xsi:nil': 'true' } }, field: mockObjType.fields.bool,
         })).toBeUndefined()
       })
-      it('should not transform object types', async () => {
-        expect(await transformPrimitive({
+      it('should not transform object types', () => {
+        expect(transformPrimitive({
           value: { bla: 'foo' }, field: mockObjType.fields.obj,
         })).toEqual({ bla: 'foo' })
       })
-      it('should not transform object values', async () => {
-        expect(await transformPrimitive({
+      it('should not transform object values', () => {
+        expect(transformPrimitive({
           value: { bla: 'foo' }, field: mockObjType.fields.string,
         })).toEqual({ bla: 'foo' })
       })


### PR DESCRIPTION
Shorten runtime of covertTypes filter by making it run synchronously

---

Made covertTypes filter synchronous by creating sync versions of `transformValues` and `transformPrimitive`

---

_Release Notes_:  _None_

---

_User Notifications_: _None_