### PR TITLE
Workato jira cross service split project issuetype

### DIFF
--- a/packages/workato-adapter/src/constants.ts
+++ b/packages/workato-adapter/src/constants.ts
@@ -18,12 +18,13 @@ export const WORKATO = 'workato'
 export const SALESFORCE = 'salesforce'
 export const NETSUITE = 'netsuite'
 export const ZUORA_BILLING = 'zuora_billing'
-
+export const JIRA = 'jira'
 
 export const CROSS_SERVICE_SUPPORTED_APPS = {
   [SALESFORCE]: ['salesforce', 'salesforce_secondary'],
   [NETSUITE]: ['netsuite', 'netsuite_secondary'],
   [ZUORA_BILLING]: ['zuora'],
+  [JIRA]: ['jira', 'jira_secondary'],
 }
 
 export const PROPERTY_TYPE = 'property'

--- a/packages/workato-adapter/src/filters/cross_service/jira/project_issuetypes.ts
+++ b/packages/workato-adapter/src/filters/cross_service/jira/project_issuetypes.ts
@@ -1,0 +1,82 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Element, isInstanceElement, Value } from '@salto-io/adapter-api'
+import { walkOnElement, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
+import _ from 'lodash'
+import { CROSS_SERVICE_SUPPORTED_APPS, JIRA, RECIPE_CODE_TYPE } from '../../../constants'
+import { FilterCreator } from '../../../filter'
+
+const INPUT_SEPERATOR = '--'
+
+const splitProjectAndIssueType = (
+  value: Value, argName: 'project_issuetype' | 'sample_project_issuetype', firstKey: string, secondKey: string
+): void => {
+  const objValues = isInstanceElement(value) ? value.value : value
+  if (_.isPlainObject(objValues)
+    && _.isObjectLike(objValues.input)
+    && CROSS_SERVICE_SUPPORTED_APPS[JIRA].includes(value.provider)
+    && objValues.input[argName] !== undefined
+    && objValues.input[argName].includes(INPUT_SEPERATOR)
+    && _.isObjectLike(objValues.dynamicPickListSelection)
+    && objValues.dynamicPickListSelection[argName] !== undefined) {
+    // The project key can't contain '-' sign while issueTypeName and projectName could.
+    // So we split by first '-' in input args.
+    const firstValue = objValues.input[argName].split(INPUT_SEPERATOR, 1)[0]
+    const secondValue = objValues.input[argName]
+      .substring(firstValue.length + INPUT_SEPERATOR.length)
+    objValues.input[firstKey] = firstValue
+    objValues.input[secondKey] = secondValue
+    delete objValues.input[argName]
+    delete objValues.dynamicPickListSelection[argName]
+  }
+}
+
+/**
+ * Workato recipe connected to Jira account include jira blocks from the format
+ * {
+ * ...
+ *  dynamicPickListSelection: {
+ *    project_issuetype: <project1Name> : <issueType1Name>
+ *    sample_project_issuetype: <project2Name> : <issueType2Name>
+ *  }
+ *  input: {
+ *    project_issuetype: <project1Key>--<issueType1Name>
+ *    sample_project_issuetype: <project2Key>--<issueType2Name>
+ *  }
+ * ...
+ * }
+ * To avoid duplications, we delete the dynamicPickListSelection arguments and split input
+ * args to projectKey and issueTypeName
+ */
+
+const filter: FilterCreator = () => ({
+  name: 'jiraProjectIssueTypeFilter',
+  onFetch: async (elements: Element[]) => {
+    elements
+      .filter(isInstanceElement)
+      .filter(inst => inst.elemID.typeName === RECIPE_CODE_TYPE)
+      .forEach(inst => walkOnElement({
+        element: inst,
+        func: ({ value }) => {
+          splitProjectAndIssueType(value, 'project_issuetype', 'projectKey', 'issueType')
+          splitProjectAndIssueType(value, 'sample_project_issuetype', 'sampleProjectKey', 'sampleIssueType')
+          return WALK_NEXT_STEP.RECURSE
+        },
+      }))
+  },
+})
+
+export default filter

--- a/packages/workato-adapter/test/filters/project_issuetypes.test.ts
+++ b/packages/workato-adapter/test/filters/project_issuetypes.test.ts
@@ -1,0 +1,197 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType, Element } from '@salto-io/adapter-api'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import _ from 'lodash'
+import { WORKATO } from '../../src/constants'
+import WorkatoClient from '../../src/client/client'
+import { paginate } from '../../src/client/pagination'
+import { DEFAULT_CONFIG } from '../../src/config'
+import filterCreator from '../../src/filters/cross_service/jira/project_issuetypes'
+
+describe('projectIssuetype filter', () => {
+  let client: WorkatoClient
+  let elements: Element[]
+  type FilterType = filterUtils.FilterWith<'onFetch'>
+  let filter: FilterType
+
+  beforeAll(() => {
+    client = new WorkatoClient({
+      credentials: { username: 'a', token: 'b' },
+    })
+    filter = filterCreator({
+      client,
+      paginator: clientUtils.createPaginator({
+        client,
+        paginationFuncCreator: paginate,
+      }),
+      config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
+    }) as FilterType
+  })
+
+  const generateElements = (): Element[] => {
+    const notCodeType = new ObjectType({ elemID: new ElemID(WORKATO, 'not_recipe__code') })
+    const codeType = new ObjectType({ elemID: new ElemID(WORKATO, 'recipe__code') })
+
+    const notRecipeCode = new InstanceElement('notRecipeCode', notCodeType, {
+      as: 'notRecipeCode',
+      provider: 'jira',
+      name: 'create_issue',
+      keyword: 'trigger',
+      dynamicPickListSelection: {
+        project_issuetype: 'projectName : IssueType',
+      },
+      input: {
+        project_issuetype: 'PNM : IssueType',
+      },
+    })
+    const notJiraCode = new InstanceElement('notJiraCode', codeType, {
+      as: 'notJiraCode',
+      provider: 'notJira',
+      name: 'create_issue',
+      keyword: 'trigger',
+      dynamicPickListSelection: {
+        project_issuetype: 'projectName : IssueType',
+      },
+      input: {
+        project_issuetype: 'PNM : IssueType',
+      },
+    })
+    const recipeCode = new InstanceElement('recipeCode', codeType, {
+      as: 'recipeCode',
+      provider: 'jira',
+      name: 'new_issue',
+      keyword: 'trigger',
+      input: {
+        since: '2023-01-01T00:00:00-01:00',
+      },
+      block: [
+        {
+          number: 1,
+          keyword: 'if',
+          input: {
+            type: 'compound',
+            operand: 'and',
+            conditions: [
+              {
+                operand: 'contains',
+                lhs: "#{_('data.jira.recipeCode.Key')}",
+                rhs: 'PK1',
+                uuid: 'condition-uuid',
+              },
+            ],
+          },
+          block: [
+            {
+              number: 2,
+              provider: 'jira',
+              name: 'create_issue',
+              description: '',
+              as: 'recipeCodeNested',
+              keyword: 'action',
+              dynamicPickListSelection: {
+                project_issuetype: 'project name with \' : \' sign : Issue Type Name with \' : \' sign and \'--\' sign ',
+                sample_project_issuetype: 'sampleProjectName : SampleIssueTypeName',
+                priority: 'High',
+              },
+              input: {
+                project_issuetype: 'PRN--Issue Type Name with \' : \' sign and \'--\' sign ',
+                sample_project_issuetype: 'SPN--SampleIssueTypeName',
+                summary: "#{_('data.jira.recipeCode.fields.summary')}",
+              },
+              visible_config_fields: [
+                'project_issuetype',
+                'sample_project_issuetype',
+              ],
+              uuid: 'uuid1',
+            },
+          ],
+          uuid: 'uuid2',
+        },
+        {
+          number: 3,
+          provider: 'jira',
+          name: 'update_issue',
+          as: 'recipeCode_second',
+          description: '',
+          keyword: 'action',
+          dynamicPickListSelection: {
+            project_issuetype: 'projectInSecondBlockName : IssueType',
+          },
+          input: {
+            project_issuetype: 'PISB--IssueType',
+            issuekey: 'issue key',
+            reporter_id: "#{_('data.jira.recipeCode.fields.customfield_10027')}",
+          },
+          uuid: 'uuid3',
+        },
+      ],
+    })
+
+    return [
+      codeType, notJiraCode, recipeCode, notRecipeCode,
+    ]
+  }
+
+  beforeEach(async () => {
+    elements = generateElements()
+  })
+  describe('onFetch', () => {
+    it('should keep all elements which have non-jira provider or non recipe__code type', async () => {
+      const beforeElements = _.cloneDeep(elements)
+      await filter.onFetch(elements)
+      expect(elements.filter(e => e.elemID.name !== 'recipeCode'))
+        .toEqual(beforeElements.filter(e => e.elemID.name !== 'recipeCode'))
+    })
+
+    it('should remove all \'project_issuetype\' and \'sample_project_issuetype\' from dynamicPickListSelection and split them in input', async () => {
+      const beforeRecipe = elements.find(e => e.elemID.name === 'recipeCode') as InstanceElement
+      expect(beforeRecipe.value.block[0].block[0].dynamicPickListSelection.project_issuetype).toBeDefined()
+      expect(beforeRecipe.value.block[0].block[0].dynamicPickListSelection.sample_project_issuetype).toBeDefined()
+      expect(beforeRecipe.value.block[1].dynamicPickListSelection.project_issuetype).toBeDefined()
+
+      expect(beforeRecipe.value.block[0].block[0].input.project_issuetype).toBeDefined()
+      expect(beforeRecipe.value.block[0].block[0].input.sample_project_issuetype).toBeDefined()
+      expect(beforeRecipe.value.block[1].input.project_issuetype).toBeDefined()
+
+      await filter.onFetch(elements)
+      const recipe = elements.find(e => e.elemID.name === 'recipeCode') as InstanceElement
+      expect(recipe.value.block[0].block[0].dynamicPickListSelection.project_issuetype).toBeUndefined()
+      expect(recipe.value.block[0].block[0].dynamicPickListSelection.sample_project_issuetype).toBeUndefined()
+      expect(recipe.value.block[1].dynamicPickListSelection.project_issuetype).toBeUndefined()
+
+      expect(recipe.value.block[0].block[0].input.project_issuetype).toBeUndefined()
+      expect(recipe.value.block[0].block[0].input.sample_project_issuetype).toBeUndefined()
+      expect(recipe.value.block[1].input.project_issuetype).toBeUndefined()
+
+      expect(recipe.value.block[0].block[0].input.projectKey).toBeDefined()
+      expect(recipe.value.block[0].block[0].input.projectKey).toEqual('PRN')
+      expect(recipe.value.block[0].block[0].input.issueType).toBeDefined()
+      expect(recipe.value.block[0].block[0].input.issueType).toEqual('Issue Type Name with \' : \' sign and \'--\' sign ')
+
+      expect(recipe.value.block[0].block[0].input.sampleProjectKey).toBeDefined()
+      expect(recipe.value.block[0].block[0].input.sampleProjectKey).toEqual('SPN')
+      expect(recipe.value.block[0].block[0].input.sampleIssueType).toBeDefined()
+      expect(recipe.value.block[0].block[0].input.sampleIssueType).toEqual('SampleIssueTypeName')
+
+      expect(recipe.value.block[1].input.projectKey).toBeDefined()
+      expect(recipe.value.block[1].input.projectKey).toEqual('PISB')
+      expect(recipe.value.block[1].input.issueType).toBeDefined()
+      expect(recipe.value.block[1].input.issueType).toEqual('IssueType')
+    })
+  })
+})


### PR DESCRIPTION
In this pull request, I have divided 'project_issuetype' and 'sample_project_issuetype' into two separate entities: 'project_key' and 'issuetype'.

---

This PR is based on https://github.com/salto-io/salto/pull/4600  branch  and is base branch for future SALTO-1619 https://github.com/salto-io/salto/pull/4487   PR. (we want to use Joi while validating Jira block) 

---
Release Notes:

Workato Adapter -

- change jira-connected input arguments. splitting project_issuetype and sample_project_issuetype.

---
User Notifications:

With each fetch using the Workato adapter, any Jira-Connected recipe code will now retrieve 'projectKey' and 'issueType' as separate entities rather than the combined 'project_issue_type'. This change will be reflected similarly in 'sample_project_issuetype'