### PR TITLE
SALTO-4424: Add timeout for soap client

### DIFF
--- a/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
@@ -20,7 +20,7 @@ import path from 'path'
 import { elements as elementUtils } from '@salto-io/adapter-components'
 import _ from 'lodash'
 import { InstanceElement, isListType, isObjectType, ObjectType, Value, Values } from '@salto-io/adapter-api'
-import { collections, decorators, strings } from '@salto-io/lowerdash'
+import { collections, decorators, promises, strings } from '@salto-io/lowerdash'
 import { v4 as uuidv4 } from 'uuid'
 import { RECORD_REF } from '../../../constants'
 import { SuiteAppSoapCredentials, toUrlAccountId } from '../../credentials'
@@ -125,15 +125,18 @@ export default class SoapClient {
   private ajv: Ajv
   private client: elementUtils.soap.Client | undefined
   private instanceLimiter: InstanceLimiterFunc
+  private timeout: number
 
   constructor(
     credentials: SuiteAppSoapCredentials,
     callsLimiter: CallsLimiter,
-    instanceLimiter: InstanceLimiterFunc
+    instanceLimiter: InstanceLimiterFunc,
+    timeout: number
   ) {
     this.credentials = credentials
     this.callsLimiter = callsLimiter
     this.instanceLimiter = instanceLimiter
+    this.timeout = timeout
     this.ajv = new Ajv({ allErrors: true, strict: false })
   }
 
@@ -374,9 +377,12 @@ export default class SoapClient {
     REQUEST_RETRY_DELAY
   )
   private static async soapRequestWithRetries(
-    client: elementUtils.soap.Client, operation: string, body: object
+    client: elementUtils.soap.Client, operation: string, body: object, timeout: number
   ): Promise<unknown> {
-    return (await client[`${operation}Async`](body))[0]
+    const result = await promises.timeout.withTimeout<unknown[]>(
+      client[`${operation}Async`](body), timeout
+    )
+    return result[0]
   }
 
   private async sendSoapRequest(operation: string, body: object): Promise<unknown> {
@@ -384,7 +390,7 @@ export default class SoapClient {
     try {
       return await this.callsLimiter(
         async () => log.time(
-          () => SoapClient.soapRequestWithRetries(client, operation, body),
+          () => SoapClient.soapRequestWithRetries(client, operation, body, this.timeout),
           `${operation}-soap-request`
         )
       )

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
@@ -142,10 +142,10 @@ export default class SuiteAppClient {
     this.restletUrl = new URL(`https://${accountIdUrl}.restlets.api.netsuite.com/app/site/hosting/restlet.nl?script=customscript_salto_restlet&deploy=customdeploy_salto_restlet`)
 
     this.ajv = new Ajv({ allErrors: true, strict: false })
-    this.soapClient = new SoapClient(this.credentials, this.callsLimiter, params.instanceLimiter)
+    const timeout = (params.config?.httpTimeoutLimitInMinutes ?? DEFAULT_AXIOS_TIMEOUT_IN_MINUTES) * 60 * 1000
+    this.soapClient = new SoapClient(this.credentials, this.callsLimiter, params.instanceLimiter, timeout)
 
-    this.axiosClient = axios.create({ timeout:
-      (params.config?.httpTimeoutLimitInMinutes ?? DEFAULT_AXIOS_TIMEOUT_IN_MINUTES) * 60 * 1000 })
+    this.axiosClient = axios.create({ timeout })
     const retryOptions = createRetryOptions(DEFAULT_RETRY_OPTS)
     axiosRetry(
       this.axiosClient,

--- a/packages/netsuite-adapter/test/client/suiteapp_client/soap_client/soap_client.test.ts
+++ b/packages/netsuite-adapter/test/client/suiteapp_client/soap_client/soap_client.test.ts
@@ -17,6 +17,8 @@ import _ from 'lodash'
 import { ElemID, InstanceElement, ListType, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
 import { elements as elementUtils } from '@salto-io/adapter-components'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { promises } from '@salto-io/lowerdash'
+import { DEFAULT_AXIOS_TIMEOUT_IN_MINUTES } from '../../../../src/config'
 import { ExistingFileCabinetInstanceDetails } from '../../../../src/client/suiteapp_client/types'
 import { ReadFileError } from '../../../../src/client/suiteapp_client/errors'
 import SoapClient, * as soapClientUtils from '../../../../src/client/suiteapp_client/soap_client/soap_client'
@@ -30,6 +32,8 @@ jest.mock('uuid', () => ({
   v4: jest.fn().mockReturnValue(''),
 }))
 
+jest.spyOn(promises.timeout, 'withTimeout').mockImplementation(promise => promise)
+
 describe('soap_client', () => {
   const addListAsyncMock = jest.fn()
   const updateListAsyncMock = jest.fn()
@@ -40,6 +44,7 @@ describe('soap_client', () => {
   const getAsyncMock = jest.fn()
   let wsdl: Record<string, unknown>
   const createClientAsyncMock = jest.spyOn(soapClientUtils, 'createClientAsync')
+  const defaultSoapTimeOut = DEFAULT_AXIOS_TIMEOUT_IN_MINUTES * 60 * 1000
   let client: SoapClient
 
   beforeEach(() => {
@@ -77,9 +82,9 @@ describe('soap_client', () => {
       },
       fn => fn(),
       (_t: string, _c: number) => false,
+      defaultSoapTimeOut
     )
   })
-
 
   describe('retries', () => {
     it('when succeeds within the permitted retries should return the results', async () => {
@@ -628,6 +633,7 @@ describe('soap_client', () => {
         },
         fn => fn(),
         (_type: string, count: number) => count > 1,
+        defaultSoapTimeOut
       )
       await expect(client.getAllRecords(['subsidiary'])).resolves.toMatchObject({
         records: [],
@@ -953,6 +959,7 @@ describe('soap_client', () => {
         },
         fn => fn(),
         (_type: string, count: number) => count > 1,
+        defaultSoapTimeOut
       )
       await expect(client.getCustomRecords(['custrecord'])).resolves.toMatchObject({
         largeTypesError: ['custrecord'], customRecords: [],
@@ -1495,6 +1502,28 @@ describe('soap_client', () => {
         .toEqual([new Error(`SOAP api call updateList for instance ${instance.elemID.getFullName()} failed.`
         + ` error code: ${INSUFFICIENT_PERMISSION_ERROR}, error message: ${errorMessage1}`)])
       expect(updateListAsyncMock).toHaveBeenCalledTimes(6)
+    })
+  })
+
+  describe('soap timeout', () => {
+    it('should throw PromiseTimedOutError when the operation exceeds the timeout', async () => {
+      (promises.timeout.withTimeout as jest.Mock).mockRestore()
+      updateListAsyncMock.mockImplementation(async () => {
+        await promises.timeout.sleep(30)
+        return []
+      })
+      const timeout = 20
+      client = new SoapClient(
+        {
+          accountId: 'ACCOUNT_ID',
+          suiteAppTokenId: 'tokenId',
+          suiteAppTokenSecret: 'tokenSecret',
+        },
+        fn => fn(),
+        (_type: string, count: number) => count > 1,
+        timeout
+      )
+      await expect(client.updateFileCabinetInstances([])).rejects.toThrow(`Promise timed out after ${timeout} ms`)
     })
   })
 })


### PR DESCRIPTION
_Timeout added for soap client_

---

_The ticket - https://salto-io.atlassian.net/browse/SALTO-4424_

---
_Release Notes_: 
_NetSuite Adapter_:
* Timeout added to soap requests

---
_User Notifications_: 
_None_
