### PR TITLE
SALTO-4475: Fix Okta E2E

### DIFF
--- a/packages/okta-adapter/e2e_test/mock_elements.ts
+++ b/packages/okta-adapter/e2e_test/mock_elements.ts
@@ -102,6 +102,8 @@ export const mockDefaultValues: Record<string, Values> = {
           enabled: false,
         },
       },
+      manualProvisioning: false,
+      implicitAssignment: false,
     },
   },
   [GROUP_TYPE_NAME]: {


### PR DESCRIPTION
 Fix Okta E2E

---

2 fields were added to app instances and needed to be added to apps mock as well

---
_Release Notes_: 
None

---
_User Notifications_: 
None
