### PR TITLE
SALTO-3203 return more readable error messages on NS SDF deploy and reuse in SDF validation

### DIFF
--- a/packages/netsuite-adapter/src/change_validators/client_validation.ts
+++ b/packages/netsuite-adapter/src/change_validators/client_validation.ts
@@ -14,67 +14,57 @@
 * limitations under the License.
 */
 import _ from 'lodash'
+import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
-import { Change, ChangeError, changeId, getChangeData, ChangeDataType, isField, isFieldChange } from '@salto-io/adapter-api'
+import { Change, ChangeError, changeId, getChangeData, isSaltoElementError, SaltoElementError } from '@salto-io/adapter-api'
 import { AdditionalDependencies } from '../config'
 import { getGroupItemFromRegex } from '../client/utils'
 import NetsuiteClient from '../client/client'
 import { getChangeGroupIdsFunc } from '../group_changes'
-import { getDeployableChanges } from '../client/types'
-import { ManifestValidationError, ObjectsDeployError, SettingsDeployError } from '../client/errors'
-import { detectLanguage, multiLanguageErrorDetectors, OBJECT_ID } from '../client/language_utils'
-import { SCRIPT_ID } from '../constants'
-import { getElementValueOrAnnotations } from '../types'
+import { multiLanguageErrorDetectors, OBJECT_ID } from '../client/language_utils'
 import { Filter } from '../filter'
 import { cloneChange } from './utils'
 
+const log = logger(module)
 const { awu } = collections.asynciterable
 
-type FailedChangeWithDependencies = {
-  change: Change<ChangeDataType>
-  dependencies: string[]
-}
+const toChangeErrors = (
+  errors: SaltoElementError[]
+): ChangeError[] => {
+  const missingDependenciesRegexes = Object.values(multiLanguageErrorDetectors)
+    .map(regexes => regexes.manifestErrorDetailsRegex)
+  const [missingDependenciesErrors, otherErrors] = _.partition(
+    errors,
+    error => missingDependenciesRegexes.some(regex =>
+      getGroupItemFromRegex(error.message, regex, OBJECT_ID).length > 0)
+  )
 
-const mapObjectDeployErrorToInstance = (error: Error):
-{ get: (changeData: ChangeDataType) => string | undefined } => {
-  const detectedLanguage = detectLanguage(error.message)
-  const {
-    validationFailed,
-    objectValidationErrorRegex,
-    settingsValidationErrorRegex,
-  } = multiLanguageErrorDetectors[detectedLanguage]
-  const scriptIdToErrorRecord: Record<string, string> = {}
-  const splitterRegex = validationFailed.test(error.message) ? validationFailed : settingsValidationErrorRegex
-  const errorMessageChunks = error.message.split(splitterRegex)[1]?.split('\n\n') ?? [error.message]
-  errorMessageChunks.forEach(chunk => {
-    const objectErrorScriptId = getGroupItemFromRegex(
-      chunk, objectValidationErrorRegex, OBJECT_ID
-    )
-    objectErrorScriptId.forEach(scriptId => { scriptIdToErrorRecord[scriptId] = chunk })
+  const missingDependenciesChangeErrors = Object.values(_.groupBy(
+    missingDependenciesErrors,
+    error => error.elemID.getFullName()
+  )).map(elementErrors => {
+    const missingDependencies = elementErrors
+      .flatMap(error => missingDependenciesRegexes
+        .flatMap(regex => getGroupItemFromRegex(error.message, regex, OBJECT_ID)))
+
+    return {
+      elemID: elementErrors[0].elemID,
+      severity: 'Error' as const,
+      message: 'This element depends on missing elements',
+      detailedMessage: `Cannot deploy elements because of missing dependencies: ${missingDependencies.join(', ')}.`
+        + ' The missing dependencies might be locked elements in the source environment which do not exist in the target environment.'
+        + ' Moreover, the dependencies might be part of a 3rd party bundle or SuiteApp.'
+        + ' If so, please make sure that all the bundles from the source account are installed and updated in the target account.',
+    }
   })
-  return {
-    get: changeData => scriptIdToErrorRecord[getElementValueOrAnnotations(changeData)[SCRIPT_ID]] ?? (
-      isField(changeData)
-        ? scriptIdToErrorRecord[getElementValueOrAnnotations(changeData.parent)[SCRIPT_ID]]
-        : undefined
-    ),
-  }
+
+  return otherErrors.map(error => ({
+    elemID: error.elemID,
+    severity: error.severity,
+    message: 'SDF validation error',
+    detailedMessage: error.message,
+  })).concat(missingDependenciesChangeErrors)
 }
-
-const getFailedChangesWithDependencies = (
-  groupChanges:Change<ChangeDataType>[],
-  dependencyMap: Map<string, Set<string>>,
-  error: ManifestValidationError,
-): FailedChangeWithDependencies[] => groupChanges
-  .map(change => ({
-    change,
-    dependencies: error.missingDependencyScriptIds.filter(scriptid =>
-      dependencyMap.get(getChangeData(change).elemID.getFullName())?.has(scriptid)
-      || (isFieldChange(change)
-      && dependencyMap.get(getChangeData(change).parent.elemID.getFullName())?.has(scriptid))),
-  }))
-  .filter(({ dependencies }) => dependencies.length > 0)
-
 
 export type ClientChangeValidator = (
   changes: ReadonlyArray<Change>,
@@ -118,64 +108,26 @@ const changeValidator: ClientChangeValidator = async (
         groupId,
         additionalDependencies,
       )
-      if (errors.length > 0) {
-        const topLevelChanges = getDeployableChanges(groupChanges)
-        const { dependencyMap } = await NetsuiteClient.createDependencyMapAndGraph(topLevelChanges)
-        return awu(errors).flatMap(async error => {
-          if (error instanceof ObjectsDeployError) {
-            const scriptIdToErrorMap = mapObjectDeployErrorToInstance(error)
-            return groupChanges.map(getChangeData)
-              .filter(element => scriptIdToErrorMap.get(element) !== undefined)
-              .map(element => ({
-                message: 'Netsuite\'s validation failed with an SDF Objects validation error',
-                severity: 'Error' as const,
-                elemID: element.elemID,
-                detailedMessage: `SDF Objects validation error: ${scriptIdToErrorMap.get(element) ?? ''}`,
-              }))
-          }
-          if (error instanceof SettingsDeployError) {
-            const failedChanges = groupChanges
-              .filter(change => error.failedConfigTypes.has(getChangeData(change).elemID.typeName))
-            return (failedChanges.length > 0 ? failedChanges : groupChanges)
-              .map(change => ({
-                message: 'Netsuite\'s validation failed with an SDF Settings validation error',
-                severity: 'Error' as const,
-                elemID: getChangeData(change).elemID,
-                detailedMessage: `SDF Settings validation error: ${error.message}`,
-              }))
-          }
-          if (error instanceof ManifestValidationError) {
-            const failedChangesWithDependencies = getFailedChangesWithDependencies(
-              groupChanges, dependencyMap, error
-            )
-            const lockedElemsMessage = `The missing dependencies might be locked elements in the source environment which do not exist in the target environment. Moreover, the dependencies might be part of a 3rd party bundle or SuiteApp.
-If so, please make sure that all the bundles from the source account are installed and updated in the target account.`
-            if (failedChangesWithDependencies.length === 0) {
-              return groupChanges.map(change => ({
-                message: 'Some elements in this deployment have missing dependencies',
-                severity: 'Error' as const,
-                elemID: getChangeData(change).elemID,
-                detailedMessage: `Cannot deploy elements because of missing dependencies: (${error.missingDependencyScriptIds.join(', ')}).\n${lockedElemsMessage}`,
-              }))
-            }
-            return failedChangesWithDependencies
-              .map(changeAndMissingDependencies => ({
-                message: 'This element depends on missing elements',
-                severity: 'Error' as const,
-                elemID: getChangeData(changeAndMissingDependencies.change).elemID,
-                detailedMessage: `This element depends on the following missing elements: (${changeAndMissingDependencies.dependencies.join(', ')}).\n${lockedElemsMessage}`,
-              }))
-          }
-          return groupChanges
-            .map(change => ({
-              message: `NetSuite validation error on ${groupId}`,
-              severity: 'Error' as const,
-              elemID: getChangeData(change).elemID,
-              detailedMessage: `SDF validation error for ${groupId}: ${error.message}`,
-            }))
-        })
-      }
-      return []
+      const originalChangesElemIds = new Set(groupChanges.map(change =>
+        getChangeData(change).elemID.getFullName()))
+
+      const [saltoElementErrors, saltoErrors] = _.partition(errors, isSaltoElementError)
+
+      const originalChangesErrors = saltoElementErrors.filter(error => {
+        if (!originalChangesElemIds.has(error.elemID.createBaseID().parent.getFullName())) {
+          log.warn('ignoring error on element that is not in the original changes list: %o', error)
+          return false
+        }
+        return true
+      })
+
+      const errorsOnAllChanges = saltoErrors.flatMap(error => groupChanges.map(change => ({
+        elemID: getChangeData(change).elemID,
+        message: error.message,
+        severity: error.severity,
+      })))
+
+      return toChangeErrors(originalChangesErrors.concat(errorsOnAllChanges))
     })
     .toArray()
 }

--- a/packages/netsuite-adapter/src/client/errors.ts
+++ b/packages/netsuite-adapter/src/client/errors.ts
@@ -18,6 +18,15 @@ import _ from 'lodash'
 import { Change, ElemID, getChangeData, isInstanceChange, isInstanceElement, isModificationChange } from '@salto-io/adapter-api'
 import { CONFIG_FEATURES, SCRIPT_ID } from '../constants'
 import { DeployableChange } from './types'
+import { getGroupItemFromRegex } from './utils'
+import { OBJECT_ID } from './language_utils'
+
+type Message = {
+  message: string
+  detailedMessage?: string
+}
+type MessageAndElemID = Message & { elemID: ElemID }
+type MessageAndScriptId = Message & { scriptId: string }
 
 export class FeaturesDeployError extends Error {
   ids: string[]
@@ -29,8 +38,8 @@ export class FeaturesDeployError extends Error {
 }
 
 export class ObjectsDeployError extends Error {
-  failedObjects: Set<string>
-  constructor(message: string, failedObjects: Set<string>) {
+  failedObjects: Map<string, Message[]>
+  constructor(message: string, failedObjects: Map<string, Message[]>) {
     super(message)
     this.failedObjects = failedObjects
     this.name = 'ObjectsDeployError'
@@ -38,8 +47,8 @@ export class ObjectsDeployError extends Error {
 }
 
 export class SettingsDeployError extends Error {
-  failedConfigTypes: Set<string>
-  constructor(message: string, failedConfigTypes: Set<string>) {
+  failedConfigTypes: Map<string, Message[]>
+  constructor(message: string, failedConfigTypes: Map<string, Message[]>) {
     super(message)
     this.failedConfigTypes = failedConfigTypes
     this.name = 'SettingsDeployError'
@@ -47,11 +56,11 @@ export class SettingsDeployError extends Error {
 }
 
 export class ManifestValidationError extends Error {
-  missingDependencyScriptIds: string[]
-  constructor(message: string, missingDependencyScriptIds: string[]) {
+  missingDependencies: MessageAndScriptId[]
+  constructor(message: string, missingDependencies: MessageAndScriptId[]) {
     super(message)
     this.name = 'ManifestValidationError'
-    this.missingDependencyScriptIds = missingDependencyScriptIds
+    this.missingDependencies = missingDependencies
   }
 }
 
@@ -63,6 +72,20 @@ export class MissingManifestFeaturesError extends Error {
     this.missingFeatures = missingFeatures
   }
 }
+
+export const getFailedObjects = (
+  messages: string[],
+  regex: RegExp,
+): MessageAndScriptId[] => messages
+  .flatMap(message => getGroupItemFromRegex(message, regex, OBJECT_ID)
+    .map(scriptId => ({ scriptId, message })))
+
+export const getFailedObjectsMap = (
+  messages: string[],
+  regex: RegExp,
+): Map<string, MessageAndScriptId[]> => new Map(Object.entries(
+  _.groupBy(getFailedObjects(messages, regex), obj => obj.scriptId)
+))
 
 export const toFeaturesDeployPartialSuccessResult = (
   error: FeaturesDeployError,
@@ -90,35 +113,37 @@ export const toFeaturesDeployPartialSuccessResult = (
 const getFailedManifestErrorElemIds = (
   error: ManifestValidationError,
   dependencyMap: Map<string, Set<string>>,
-): ElemID[] => Array.from(dependencyMap.keys())
-  .filter(topLevelChangedElement => error.missingDependencyScriptIds
-    .some(scriptid => dependencyMap.get(topLevelChangedElement)?.has(scriptid)))
-  .map(ElemID.fromFullName)
+): MessageAndElemID[] => Array.from(dependencyMap.keys()).flatMap(elemId => {
+  const elemID = ElemID.fromFullName(elemId)
+  const dependencies = dependencyMap.get(elemId)
+  return error.missingDependencies
+    .filter(dep => dependencies?.has(dep.scriptId))
+    .map(dep => ({ elemID, message: dep.message }))
+})
 
 const getFailedSdfDeployChangesElemIDs = (
   error: ObjectsDeployError,
   changes: DeployableChange[],
-): ElemID[] => changes
-  .map(getChangeData)
-  .filter(elem => (
-    isInstanceElement(elem) && error.failedObjects.has(elem.value[SCRIPT_ID])
-  ) || (
-    error.failedObjects.has(elem.annotations[SCRIPT_ID])
-  ))
-  .map(elem => elem.elemID)
+): MessageAndElemID[] => changes.map(getChangeData).flatMap(elem => {
+  const failedObjectErrors = isInstanceElement(elem)
+    ? error.failedObjects.get(elem.value[SCRIPT_ID])
+    : error.failedObjects.get(elem.annotations[SCRIPT_ID])
+  return failedObjectErrors?.map(({ message }) => ({ elemID: elem.elemID, message })) ?? []
+})
 
 const getFailedSettingsErrorChanges = (
   error: SettingsDeployError,
   changes: DeployableChange[],
-): ElemID[] => changes
-  .map(change => getChangeData(change).elemID)
-  .filter(changeElemId => error.failedConfigTypes.has(changeElemId.typeName))
+): MessageAndElemID[] => changes.map(getChangeData).flatMap(
+  ({ elemID }) => error.failedConfigTypes
+    .get(elemID.typeName)?.map(({ message }) => ({ elemID, message })) ?? []
+)
 
 export const getChangesElemIdsToRemove = (
   error: unknown,
   dependencyMap: Map<string, Set<string>>,
   changes: DeployableChange[]
-): ElemID[] => {
+): MessageAndElemID[] => {
   if (error instanceof ManifestValidationError) {
     return getFailedManifestErrorElemIds(error, dependencyMap)
   }

--- a/packages/netsuite-adapter/src/client/language_utils.ts
+++ b/packages/netsuite-adapter/src/client/language_utils.ts
@@ -48,7 +48,7 @@ export const multiLanguageErrorDetectors: Record<SupportedLanguage, ErrorDetecto
       RegExp(`Details: The following features must be specified in the manifest to use the .*: (?<${FEATURE_NAME}>\\w+)`, 'gm'),
     ],
     deployedObjectRegex: RegExp(`^(Create|Update) object -- (?<${OBJECT_ID}>[a-z0-9_]+)`, 'gm'),
-    errorObjectRegex: RegExp(`^An unexpected error has occurred\\. \\((?<${OBJECT_ID}>[a-z0-9_]+)\\)`, 'm'),
+    errorObjectRegex: RegExp(`^An unexpected error has occurred\\. \\((?<${OBJECT_ID}>[a-z0-9_]+)\\)`, 'gm'),
     manifestErrorDetailsRegex: RegExp(`Details: The manifest contains a dependency on (?<${OBJECT_ID}>[a-z0-9_]+(\\.[a-z0-9_]+)*)`, 'gm'),
     configureFeatureFailRegex: RegExp(`Configure feature -- (Enabling|Disabling) of the (?<${FEATURE_NAME}>\\w+)\\(.*?\\) feature has FAILED`),
     validationFailed: RegExp('^Validation failed\\.$', 'm'),
@@ -65,7 +65,7 @@ export const multiLanguageErrorDetectors: Record<SupportedLanguage, ErrorDetecto
     ],
     deployedObjectRegex: RegExp(`^(Cr.er un objet|Mettre . jour l'objet) -- (?<${OBJECT_ID}>[a-z0-9_]+)`, 'gm'),
     // TODO: find in french
-    errorObjectRegex: RegExp(`^An unexpected error has occurred\\. \\((?<${OBJECT_ID}>[a-z0-9_]+)\\)`, 'm'),
+    errorObjectRegex: RegExp(`^An unexpected error has occurred\\. \\((?<${OBJECT_ID}>[a-z0-9_]+)\\)`, 'gm'),
     manifestErrorDetailsRegex: RegExp(`D.tails: Le manifeste comporte une d.pendance sur l'objet (?<${OBJECT_ID}>[a-z0-9_]+(\\.[a-z0-9_]+)*)`, 'gm'),
     configureFeatureFailRegex: RegExp(`Configurer la fonction -- (L'activation|La d.sactivation) de la fonction (?<${FEATURE_NAME}>\\w+)\\(.*?\\) a .chou.`),
     validationFailed: RegExp('^La validation a .chou.\\.$', 'm'),

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -39,7 +39,7 @@ import {
   DEFAULT_MAX_ITEMS_IN_IMPORT_OBJECTS_REQUEST, DEFAULT_CONCURRENCY, ClientConfig, InstanceLimiterFunc,
 } from '../config'
 import { NetsuiteFetchQueries, NetsuiteQuery, NetsuiteTypesQueryParams, ObjectID } from '../query'
-import { FeaturesDeployError, ManifestValidationError, ObjectsDeployError, SettingsDeployError, MissingManifestFeaturesError } from './errors'
+import { FeaturesDeployError, ManifestValidationError, ObjectsDeployError, SettingsDeployError, MissingManifestFeaturesError, getFailedObjectsMap, getFailedObjects } from './errors'
 import { SdfCredentials } from './credentials'
 import {
   CustomizationInfo, CustomTypeInfo, FailedImport, FailedTypes, FileCustomizationInfo,
@@ -49,14 +49,14 @@ import {
 import { fileCabinetTopLevelFolders } from './constants'
 import {
   isCustomTypeInfo, isFileCustomizationInfo, isFolderCustomizationInfo, isTemplateCustomTypeInfo,
-  mergeTypeToInstances, getGroupItemFromRegex, toError,
+  mergeTypeToInstances, getGroupItemFromRegex, toError, sliceMessagesByRegex,
 } from './utils'
 import { fixManifest } from './manifest_utils'
 import { detectLanguage, FEATURE_NAME, fetchLockedObjectErrorRegex, fetchUnexpectedErrorRegex, multiLanguageErrorDetectors, OBJECT_ID } from './language_utils'
 import { Graph } from './graph_utils'
 import { FileSize, filterFilesInFolders, largeFoldersToExclude } from './file_cabinet_utils'
 import { reorderDeployXml } from './deploy_xml_utils'
-import { OBJECTS_DIR, ADDITIONAL_FILE_PATTERN, ATTRIBUTES_FILE_SUFFIX, ATTRIBUTES_FOLDER_NAME, FOLDER_ATTRIBUTES_FILE_SUFFIX, READ_CONCURRENCY, convertToXmlContent, parseFeaturesXml, parseFileCabinetDir, parseObjectsDir, convertToFeaturesXmlContent, FEATURES_XML, getCustomTypeInfoPath, getFileCabinetCustomInfoPath, getFileCabinetDirPath, getSrcDirPath, getDeployFilePath, getManifestFilePath, getFeaturesXmlPath } from './sdf_parser'
+import { OBJECTS_DIR, ADDITIONAL_FILE_PATTERN, ATTRIBUTES_FILE_SUFFIX, ATTRIBUTES_FOLDER_NAME, FOLDER_ATTRIBUTES_FILE_SUFFIX, READ_CONCURRENCY, convertToXmlContent, parseFeaturesXml, parseFileCabinetDir, parseObjectsDir, convertToFeaturesXmlContent, getCustomTypeInfoPath, getFileCabinetCustomInfoPath, getFileCabinetDirPath, getSrcDirPath, getDeployFilePath, getManifestFilePath, getFeaturesXmlPath, FEATURES_XML } from './sdf_parser'
 
 const { makeArray } = collections.array
 const { withLimitedConcurrency } = promises.array
@@ -834,8 +834,8 @@ export default class SdfClient {
       return error
     }
 
-    const errorMessage = error.message
-    const sdfLanguage = detectLanguage(errorMessage)
+    const messages = error.message.split(`${os.EOL}${os.EOL}`)
+    const sdfLanguage = detectLanguage(error.message)
     const {
       settingsValidationErrorRegex,
       manifestErrorDetailsRegex,
@@ -844,34 +844,42 @@ export default class SdfClient {
       deployedObjectRegex,
       errorObjectRegex,
     } = multiLanguageErrorDetectors[sdfLanguage]
-    const manifestErrorScriptids = getGroupItemFromRegex(errorMessage, manifestErrorDetailsRegex, OBJECT_ID)
+
+    const manifestErrorScriptids = getFailedObjects(messages, manifestErrorDetailsRegex)
     if (manifestErrorScriptids.length > 0) {
-      return new ManifestValidationError(errorMessage, manifestErrorScriptids)
+      return new ManifestValidationError(error.message, manifestErrorScriptids)
     }
+
     const missingFeatureNames = missingFeatureErrorRegex
-      .flatMap(regex => getGroupItemFromRegex(errorMessage, regex, FEATURE_NAME))
+      .flatMap(regex => getGroupItemFromRegex(error.message, regex, FEATURE_NAME))
     if (missingFeatureNames.length > 0) {
-      return new MissingManifestFeaturesError(errorMessage, _.uniq(missingFeatureNames))
+      return new MissingManifestFeaturesError(error.message, _.uniq(missingFeatureNames))
     }
-    const validationErrorObjects = getGroupItemFromRegex(
-      errorMessage, objectValidationErrorRegex, OBJECT_ID
-    )
-    if (validationErrorObjects.length > 0) {
-      return new ObjectsDeployError(errorMessage, new Set(validationErrorObjects))
+
+    const validationErrorsMap = getFailedObjectsMap(messages, objectValidationErrorRegex)
+    if (validationErrorsMap.size > 0) {
+      return new ObjectsDeployError(error.message, validationErrorsMap)
     }
-    if (settingsValidationErrorRegex.test(errorMessage) && errorMessage.includes(FEATURES_XML)) {
-      return new SettingsDeployError(errorMessage, new Set([CONFIG_FEATURES]))
+
+    const settingsErrors = sliceMessagesByRegex(messages, settingsValidationErrorRegex)
+      .filter(message => message.includes(FEATURES_XML))
+      .map(message => ({ message }))
+    if (settingsErrors.length > 0) {
+      return new SettingsDeployError(error.message, new Map([[CONFIG_FEATURES, settingsErrors]]))
     }
-    const errorObject = errorMessage.match(errorObjectRegex)?.groups?.[OBJECT_ID]
-    if (errorObject !== undefined) {
-      return new ObjectsDeployError(errorMessage, new Set([errorObject]))
+
+    const errorObjectsMap = getFailedObjectsMap(messages, errorObjectRegex)
+    if (errorObjectsMap.size > 0) {
+      return new ObjectsDeployError(error.message, errorObjectsMap)
     }
-    const allDeployedObjects = getGroupItemFromRegex(
-      errorMessage, deployedObjectRegex, OBJECT_ID
-    )
+
+    const allDeployedObjects = getGroupItemFromRegex(error.message, deployedObjectRegex, OBJECT_ID)
     if (allDeployedObjects.length > 0) {
+      const errorMessages = sliceMessagesByRegex(messages, deployedObjectRegex, false)
+      const message = errorMessages.length > 0 ? errorMessages.join(os.EOL) : error.message
       // the last object in the error message is the one that failed the deploy
-      return new ObjectsDeployError(errorMessage, new Set([allDeployedObjects.slice(-1)[0]]))
+      const errorsMap = new Map([[allDeployedObjects.slice(-1)[0], [{ message }]]])
+      return new ObjectsDeployError(error.message, errorsMap)
     }
 
     log.warn(`

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_file_cabinet.ts
@@ -42,7 +42,7 @@ import { DEFAULT_MAX_FILE_CABINET_SIZE_IN_GB } from '../../config'
 import { NetsuiteQuery } from '../../query'
 import { isFileCabinetType, isFileInstance } from '../../types'
 import { filterFilePathsInFolders, filterFolderPathsInFolders, largeFoldersToExclude } from '../file_cabinet_utils'
-import { getDeployResultFromSuiteAppResult, toError } from '../utils'
+import { getDeployResultFromSuiteAppResult, toElementError, toError } from '../utils'
 
 const log = logger(module)
 
@@ -607,7 +607,7 @@ SuiteAppFileCabinetOperations => {
     } catch (e) {
       const { message } = toError(e)
       return {
-        errors: changes.map(change => ({ elemID: getChangeData(change).elemID, message, severity: 'Error' })),
+        errors: changes.map(change => toElementError(getChangeData(change).elemID, message)),
         appliedChanges: [],
         elemIdToInternalId: {},
       }
@@ -686,11 +686,8 @@ SuiteAppFileCabinetOperations => {
 
     const dependencyErrors = [...changesToSkip].map(id => {
       const elemID = ElemID.fromFullName(id)
-      return {
-        elemID,
-        message: `Cannot deploy this ${elemID.typeName} because its parent folder deploy failed`,
-        severity: 'Error' as const,
-      }
+      const message = `Cannot deploy this ${elemID.typeName} because its parent folder deploy failed`
+      return toElementError(elemID, message)
     })
 
     return {

--- a/packages/netsuite-adapter/src/client/utils.ts
+++ b/packages/netsuite-adapter/src/client/utils.ts
@@ -65,7 +65,9 @@ export const sliceMessagesByRegex = (
   lookFromRegex: RegExp,
   includeMatchedRegex = true
 ): string[] => {
-  const matchedMessages = messages.map(message => lookFromRegex.test(message))
+  // remove the global flag of the regex
+  const fixedLookedFromRegex = RegExp(lookFromRegex, '')
+  const matchedMessages = messages.map(message => fixedLookedFromRegex.test(message))
   const lookFromIndex = includeMatchedRegex
     ? matchedMessages.indexOf(true)
     : matchedMessages.lastIndexOf(true)

--- a/packages/netsuite-adapter/src/client/utils.ts
+++ b/packages/netsuite-adapter/src/client/utils.ts
@@ -66,7 +66,7 @@ export const sliceMessagesByRegex = (
   includeMatchedRegex = true
 ): string[] => {
   // remove the global flag of the regex
-  const fixedLookedFromRegex = RegExp(lookFromRegex, '')
+  const fixedLookedFromRegex = RegExp(lookFromRegex, lookFromRegex.flags.replace('g', ''))
   const matchedMessages = messages.map(message => fixedLookedFromRegex.test(message))
   const lookFromIndex = includeMatchedRegex
     ? matchedMessages.indexOf(true)

--- a/packages/netsuite-adapter/src/client/utils.ts
+++ b/packages/netsuite-adapter/src/client/utils.ts
@@ -60,10 +60,33 @@ export const getGroupItemFromRegex = (str: string, regex: RegExp, item: string):
     .filter(isDefined)
     .map(groups => groups[item])
 
+export const sliceMessagesByRegex = (
+  messages: string[],
+  lookFromRegex: RegExp,
+  includeMatchedRegex = true
+): string[] => {
+  const matchedMessages = messages.map(message => lookFromRegex.test(message))
+  const lookFromIndex = includeMatchedRegex
+    ? matchedMessages.indexOf(true)
+    : matchedMessages.lastIndexOf(true)
+  return lookFromIndex !== -1
+    ? messages.slice(lookFromIndex + (includeMatchedRegex ? 0 : 1))
+    : []
+}
+
 export const getConfigRecordsFieldValue = (
   configRecord: ConfigRecord | undefined,
   field: string,
 ): unknown => configRecord?.data?.fields?.[field]
+
+export const toElementError = (
+  elemID: ElemID,
+  message: string
+): SaltoElementError => ({
+  elemID,
+  message,
+  severity: 'Error',
+})
 
 export const toDependencyError = (
   dependency: { elemId: ElemID; dependOn: ElemID[] }
@@ -103,7 +126,7 @@ export const getDeployResultFromSuiteAppResult = <T extends Change>(
         appliedChanges.push(change)
         elemIdToInternalId[elemID.getFullName()] = result.toString()
       } else {
-        errors.push({ elemID, message: result.message, severity: 'Error' })
+        errors.push(toElementError(elemID, result.message))
       }
     })
 

--- a/packages/netsuite-adapter/src/types.ts
+++ b/packages/netsuite-adapter/src/types.ts
@@ -140,9 +140,10 @@ export const FIELD_TYPES = [
   'customfield',
 ]
 
+type DeployError = SaltoElementError | SaltoError
 export type DeployResult = {
   appliedChanges: Change[]
-  errors: (SaltoElementError | SaltoError)[]
+  errors: DeployError[]
   sdfErrors?: Error[]
   elemIdToInternalId?: Record<string, string>
 }

--- a/packages/netsuite-adapter/src/types.ts
+++ b/packages/netsuite-adapter/src/types.ts
@@ -144,8 +144,8 @@ type DeployError = SaltoElementError | SaltoError
 export type DeployResult = {
   appliedChanges: Change[]
   errors: DeployError[]
-  sdfErrors?: Error[]
   elemIdToInternalId?: Record<string, string>
+  failedFeaturesIds?: string[]
 }
 
 export const SUITEAPP_CONFIG_RECORD_TYPES = [

--- a/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
@@ -13,13 +13,12 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, Change, ElemID, Field, getChangeData, InstanceElement, isObjectTypeChange, ObjectType, toChange } from '@salto-io/adapter-api'
+import { Change, ElemID, getChangeData, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
 import { Filter } from '../../src/filter'
 import { CUSTOM_RECORD_TYPE, METADATA_TYPE, NETSUITE, SCRIPT_ID } from '../../src/constants'
 import clientValidation from '../../src/change_validators/client_validation'
 import NetsuiteClient from '../../src/client/client'
 import { AdditionalDependencies } from '../../src/config'
-import { ManifestValidationError, ObjectsDeployError, SettingsDeployError } from '../../src/client/errors'
 import { workflowType } from '../../src/autogen/types/standard_types/workflow'
 import { fileType } from '../../src/types/file_cabinet_types'
 import { SDF_CREATE_OR_UPDATE_GROUP_ID } from '../../src/group_changes'
@@ -43,15 +42,14 @@ describe('client validation', () => {
     changes = [
       toChange({
         after: new InstanceElement(
-          'instanceName',
+          'customworkflow1',
           workflowType().type,
-          { [SCRIPT_ID]: 'object_name', manifestTest: '[scriptid=some_scriptid]' }
+          { [SCRIPT_ID]: 'customworkflow1' }
         ),
       }), toChange({
         after: new ObjectType({
           elemID: new ElemID(NETSUITE, 'customrecord1'),
           annotations: {
-            manifestTest: '[scriptid=ref_in_custom_record_type]',
             [SCRIPT_ID]: 'customrecord1',
             [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
           },
@@ -60,7 +58,7 @@ describe('client validation', () => {
     ]
   })
   it('should not have errors', async () => {
-    mockValidate.mockReturnValue([])
+    mockValidate.mockResolvedValue([])
     const changeErrors = await clientValidation(
       changes,
       client,
@@ -69,247 +67,90 @@ describe('client validation', () => {
     )
     expect(changeErrors).toHaveLength(0)
   })
-  it('should have SDF Objects Validation Error for instance', async () => {
-    const detailedMessage = `An error occurred during custom object validation. (object_name)
-Details: The object field daterange is missing.
-Details: The object field kpi must not be OPENJOBS.
-Details: The object field periodrange is missing.
-Details: The object field compareperiodrange is missing.
-Details: The object field defaultgeneraltype must not be ENTITY_ENTITY_NAME.
-Details: The object field type must not be 449.
-File: ~/Objects/object_name.xml`
-    const fullErrorMessage = `Validation failed.\n\n${detailedMessage}`
-    mockValidate.mockReturnValue([
-      new ObjectsDeployError(fullErrorMessage, new Set(['object_name'])),
-    ])
-    const changeErrors = await clientValidation(
-      changes,
-      client,
-      {} as unknown as AdditionalDependencies,
-      mockFiltersRunner,
-    )
-    expect(changeErrors).toHaveLength(1)
-    expect(changeErrors[0]).toEqual({
-      detailedMessage: `SDF Objects validation error: ${detailedMessage}`,
+  it('should return error on a specific change', async () => {
+    mockValidate.mockResolvedValue([{
       elemID: getChangeData(changes[0]).elemID,
-      message: 'Netsuite\'s validation failed with an SDF Objects validation error',
+      message: 'Some Error',
       severity: 'Error',
-    })
-  })
-  it('should have SDF Objects Validation Error for customRecordType', async () => {
-    const detailedMessage = `An error occurred during custom object validation. (customrecord1)
-Details: The object field daterange is missing.
-Details: The object field kpi must not be OPENJOBS.
-Details: The object field periodrange is missing.
-Details: The object field compareperiodrange is missing.
-Details: The object field defaultgeneraltype must not be ENTITY_ENTITY_NAME.
-Details: The object field type must not be 449.
-File: ~/Objects/customrecord1.xml`
-    const fullErrorMessage = `Validation failed.\n\n${detailedMessage}`
-    mockValidate.mockReturnValue([
-      new ObjectsDeployError(fullErrorMessage, new Set(['customrecord1'])),
-    ])
+    }])
     const changeErrors = await clientValidation(
       changes,
       client,
       {} as unknown as AdditionalDependencies,
       mockFiltersRunner,
     )
-    expect(changeErrors).toHaveLength(1)
-    expect(changeErrors[0]).toEqual({
-      detailedMessage: `SDF Objects validation error: ${detailedMessage}`,
-      elemID: getChangeData(changes[1]).elemID,
-      message: 'Netsuite\'s validation failed with an SDF Objects validation error',
-      severity: 'Error',
-    })
-  })
-  it('should have SDF account settings validation Error for customRecordType', async () => {
-    const detailedMessage = `An error occurred during custom object validation. (customrecord1)
-Details: The object field daterange is missing.
-Details: The object field kpi must not be OPENJOBS.
-Details: The object field periodrange is missing.
-Details: The object field compareperiodrange is missing.
-Details: The object field defaultgeneraltype must not be ENTITY_ENTITY_NAME.
-Details: The object field type must not be 449.
-File: ~/Objects/customrecord1.xml`
-    const fullErrorMessage = `Validation of account settings failed.\n\n${detailedMessage}`
-    mockValidate.mockReturnValue([
-      new ObjectsDeployError(fullErrorMessage, new Set(['customrecord1'])),
-    ])
-    const changeErrors = await clientValidation(
-      changes,
-      client,
-      {} as unknown as AdditionalDependencies,
-      mockFiltersRunner,
-    )
-    expect(changeErrors).toHaveLength(1)
-    expect(changeErrors[0]).toEqual({
-      detailedMessage: `SDF Objects validation error: ${detailedMessage}`,
-      elemID: getChangeData(changes[1]).elemID,
-      message: 'Netsuite\'s validation failed with an SDF Objects validation error',
-      severity: 'Error',
-    })
-  })
-  it('should have SDF Objects Validation Error for customRecordType field', async () => {
-    const detailedMessage = `An error occurred during custom object validation. (customrecord1)
-Details: The object field daterange is missing.
-Details: The object field kpi must not be OPENJOBS.
-Details: The object field periodrange is missing.
-Details: The object field compareperiodrange is missing.
-Details: The object field defaultgeneraltype must not be ENTITY_ENTITY_NAME.
-Details: The object field type must not be 449.
-File: ~/Objects/customrecord1.xml`
-    const fullErrorMessage = `Validation failed.\n\n${detailedMessage}`
-    mockValidate.mockReturnValue([
-      new ObjectsDeployError(fullErrorMessage, new Set(['customrecord1'])),
-    ])
-    const fieldChanges = changes.filter(isObjectTypeChange).map(getChangeData).map(type => toChange({
-      after: new Field(type, 'some_field', BuiltinTypes.STRING, { [SCRIPT_ID]: 'some_field' }),
-    }))
-    const changeErrors = await clientValidation(
-      fieldChanges,
-      client,
-      {} as unknown as AdditionalDependencies,
-      mockFiltersRunner,
-    )
-    expect(changeErrors).toHaveLength(1)
-    expect(changeErrors[0]).toEqual({
-      detailedMessage: `SDF Objects validation error: ${detailedMessage}`,
-      elemID: getChangeData(fieldChanges[0]).elemID,
-      message: 'Netsuite\'s validation failed with an SDF Objects validation error',
-      severity: 'Error',
-    })
-  })
-  it('should have SDF Objects Validation Error - in other language', async () => {
-    const detailedMessage = `Une erreur s'est produite lors de la validation de l'objet personnalis.. (object_name)
-Details: The object field daterange is missing.
-Details: The object field kpi must not be OPENJOBS.
-Details: The object field periodrange is missing.
-Details: The object field compareperiodrange is missing.
-Details: The object field defaultgeneraltype must not be ENTITY_ENTITY_NAME.
-Details: The object field type must not be 449.
-File: ~/Objects/object_name.xml`
-    const fullErrorMessage = `
-*** ERREUR ***
-La validation a .chou..
-
-${detailedMessage}`
-
-    mockValidate.mockReturnValue([
-      new ObjectsDeployError(fullErrorMessage, new Set(['object_name'])),
-    ])
-    const changeErrors = await clientValidation(
-      changes,
-      client,
-      {} as unknown as AdditionalDependencies,
-      mockFiltersRunner,
-    )
-    expect(changeErrors).toHaveLength(1)
-    expect(changeErrors[0]).toEqual({
-      detailedMessage: `SDF Objects validation error: ${detailedMessage}`,
+    expect(changeErrors).toEqual([{
       elemID: getChangeData(changes[0]).elemID,
-      message: 'Netsuite\'s validation failed with an SDF Objects validation error',
+      message: 'SDF validation error',
+      detailedMessage: 'Some Error',
       severity: 'Error',
-    })
+    }])
   })
-  it('should have SDF Manifest Validation Error and remove the element causing it', async () => {
-    const detailedMessage = `Validation of account settings failed.
-    
-    An error occurred during account settings validation.
-    Details: The manifest contains a dependency on some_scriptid object, but it is not in the account.`
-    mockValidate.mockReturnValue([new ManifestValidationError(detailedMessage, ['some_scriptid'])])
+  it('should return errors on all changes', async () => {
+    mockValidate.mockResolvedValue([{
+      message: 'Some Error',
+      severity: 'Error',
+    }])
     const changeErrors = await clientValidation(
       changes,
       client,
       {} as unknown as AdditionalDependencies,
       mockFiltersRunner,
     )
-    expect(changeErrors).toHaveLength(1)
-    expect(changeErrors[0]).toEqual({
-      detailedMessage: `This element depends on the following missing elements: (some_scriptid).
-The missing dependencies might be locked elements in the source environment which do not exist in the target environment. Moreover, the dependencies might be part of a 3rd party bundle or SuiteApp.
-If so, please make sure that all the bundles from the source account are installed and updated in the target account.`,
-      elemID: getChangeData(changes[0]).elemID,
-      message: 'This element depends on missing elements',
-      severity: 'Error',
-    })
-  })
-  it('should have SDF Manifest Validation Error on field', async () => {
-    mockValidate.mockReturnValue([new ManifestValidationError('', ['ref_in_custom_record_type'])])
-    const fieldChanges = changes.filter(isObjectTypeChange).flatMap(change => [
-      change,
-      toChange({
-        after: new Field(
-          getChangeData(change),
-          'some_field',
-          BuiltinTypes.STRING,
-          { [SCRIPT_ID]: 'some_field' }
-        ),
-      }),
-    ])
-    const changeErrors = await clientValidation(
-      fieldChanges,
-      client,
-      {} as unknown as AdditionalDependencies,
-      mockFiltersRunner,
-    )
-    expect(changeErrors).toHaveLength(2)
-    expect(changeErrors.map(changeErr => changeErr.elemID.getFullName())).toEqual([
-      'netsuite.customrecord1',
-      'netsuite.customrecord1.field.some_field',
-    ])
-  })
-  it('should have general Validation Error', async () => {
-    const detailedMessage = 'some error'
-    mockValidate.mockReturnValue([new Error(detailedMessage)])
-    const changeErrors = await clientValidation(
-      changes,
-      client,
-      {} as unknown as AdditionalDependencies,
-      mockFiltersRunner,
-    )
-    expect(changeErrors).toHaveLength(2)
-    expect(changeErrors[0]).toEqual({
-      detailedMessage: `SDF validation error for SDF - create or update: ${detailedMessage}`,
-      elemID: getChangeData(changes[0]).elemID,
-      message: 'NetSuite validation error on SDF - create or update',
-      severity: 'Error',
-    })
-  })
-
-  it('should have settings deploy error for a specific change', async () => {
-    const detailedMessage = 'Validation of account settings failed.'
-    mockValidate.mockReturnValue([new SettingsDeployError(`${detailedMessage}`, new Set(['workflow']))])
-    const changeErrors = await clientValidation(
-      changes,
-      client,
-      {} as unknown as AdditionalDependencies,
-      mockFiltersRunner,
-    )
-    expect(changeErrors).toHaveLength(1)
-    expect(changeErrors[0]).toEqual({
-      detailedMessage: `SDF Settings validation error: ${detailedMessage}`,
-      elemID: getChangeData(changes[0]).elemID,
-      message: 'Netsuite\'s validation failed with an SDF Settings validation error',
-      severity: 'Error',
-    })
-  })
-  it('should have settings deploy error for all changes', async () => {
-    const detailedMessage = 'Validation of account settings failed.'
-    mockValidate.mockReturnValue([new SettingsDeployError(`${detailedMessage}`, new Set(['abc']))])
-    const changeErrors = await clientValidation(
-      changes,
-      client,
-      {} as unknown as AdditionalDependencies,
-      mockFiltersRunner,
-    )
-    expect(changeErrors).toHaveLength(2)
-    expect(changeErrors).toEqual(changes.map(change => ({
-      detailedMessage: `SDF Settings validation error: ${detailedMessage}`,
+    expect(changeErrors).toHaveLength(changes.length)
+    expect(changeErrors).toEqual(expect.arrayContaining(changes.map(change => ({
       elemID: getChangeData(change).elemID,
-      message: 'Netsuite\'s validation failed with an SDF Settings validation error',
+      message: 'SDF validation error',
+      detailedMessage: 'Some Error',
       severity: 'Error',
-    })))
+    }))))
+  })
+  it('should ignore error on a specific element that is not in the changes list', async () => {
+    mockValidate.mockResolvedValue([{
+      elemID: new ElemID(NETSUITE, 'type', 'instance', 'additional'),
+      message: 'Some Error',
+      severity: 'Error',
+    }])
+    const changeErrors = await clientValidation(
+      changes,
+      client,
+      {} as unknown as AdditionalDependencies,
+      mockFiltersRunner,
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
+  it('should return missing dependencies errors', async () => {
+    mockValidate.mockResolvedValue([{
+      elemID: getChangeData(changes[0]).elemID,
+      message: 'Details: The manifest contains a dependency on customlist1',
+      severity: 'Error',
+    }, {
+      elemID: getChangeData(changes[0]).elemID,
+      message: 'Details: The manifest contains a dependency on customworkflow2.workflowstate1',
+      severity: 'Error',
+    }, {
+      elemID: getChangeData(changes[1]).elemID,
+      message: 'D.tails: Le manifeste comporte une d.pendance sur l\'objet customlist1',
+      severity: 'Error',
+    }])
+    const changeErrors = await clientValidation(
+      changes,
+      client,
+      {} as unknown as AdditionalDependencies,
+      mockFiltersRunner,
+    )
+    expect(changeErrors).toHaveLength(2)
+    expect(changeErrors).toEqual(expect.arrayContaining([{
+      elemID: getChangeData(changes[0]).elemID,
+      severity: 'Error',
+      message: 'This element depends on missing elements',
+      detailedMessage: expect.stringContaining('Cannot deploy elements because of missing dependencies: customlist1, customworkflow2.workflowstate1.'),
+    }, {
+      elemID: getChangeData(changes[1]).elemID,
+      severity: 'Error',
+      message: 'This element depends on missing elements',
+      detailedMessage: expect.stringContaining('Cannot deploy elements because of missing dependencies: customlist1.'),
+    }]))
   })
   describe('validate file cabinet instances', () => {
     let fileChange: Change<InstanceElement>

--- a/packages/netsuite-adapter/test/client/client.test.ts
+++ b/packages/netsuite-adapter/test/client/client.test.ts
@@ -78,7 +78,6 @@ describe('NetsuiteClient', () => {
             message: objectsDeployError.message,
             severity: 'Error',
           }],
-          sdfErrors: [objectsDeployError],
           appliedChanges: [successChange],
         })
         expect(mockSdfDeploy).toHaveBeenCalledTimes(2)
@@ -101,7 +100,6 @@ describe('NetsuiteClient', () => {
           async () => true,
         )).toEqual({
           errors: [{ message: objectsDeployError.message, severity: 'Error' }],
-          sdfErrors: [objectsDeployError],
           appliedChanges: [],
         })
         expect(mockSdfDeploy).toHaveBeenCalledTimes(1)
@@ -129,7 +127,6 @@ describe('NetsuiteClient', () => {
             message: settingsDeployError.message,
             severity: 'Error',
           }],
-          sdfErrors: [settingsDeployError],
           appliedChanges: [successChange],
         })
         expect(mockSdfDeploy).toHaveBeenCalledTimes(2)
@@ -149,7 +146,6 @@ describe('NetsuiteClient', () => {
           async () => true,
         )).toEqual({
           errors: [{ message: settingsDeployError.message, severity: 'Error' }],
-          sdfErrors: [settingsDeployError],
           appliedChanges: [],
         })
         expect(mockSdfDeploy).toHaveBeenCalledTimes(1)
@@ -180,7 +176,6 @@ describe('NetsuiteClient', () => {
             message: manifestValidationError.message,
             severity: 'Error',
           }],
-          sdfErrors: [manifestValidationError],
           appliedChanges: [successChange],
         })
         expect(mockSdfDeploy).toHaveBeenCalledTimes(2)
@@ -211,7 +206,6 @@ describe('NetsuiteClient', () => {
             message: manifestValidationError.message,
             severity: 'Error',
           }],
-          sdfErrors: [manifestValidationError],
           appliedChanges: [successChange],
         })
         expect(mockSdfDeploy).toHaveBeenCalledTimes(2)
@@ -238,7 +232,6 @@ describe('NetsuiteClient', () => {
           async () => true,
         )).toEqual({
           errors: [{ message: manifestValidationError.message, severity: 'Error' }],
-          sdfErrors: [manifestValidationError],
           appliedChanges: [],
         })
         expect(mockSdfDeploy).toHaveBeenCalledTimes(1)
@@ -276,7 +269,6 @@ describe('NetsuiteClient', () => {
             message: `Element cannot be deployed due to an error in its dependency: ${getChangeData(failedChange).elemID.getFullName()}`,
             severity: 'Error',
           }],
-          sdfErrors: [manifestValidationError],
           appliedChanges: [successChange],
         })
         expect(mockSdfDeploy).toHaveBeenCalledTimes(2)
@@ -311,7 +303,6 @@ describe('NetsuiteClient', () => {
             message: manifestValidationError.message,
             severity: 'Error',
           }],
-          sdfErrors: [manifestValidationError],
           appliedChanges: [successChange, failedChangeDependency],
         })
         expect(mockSdfDeploy).toHaveBeenCalledTimes(2)
@@ -415,7 +406,6 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
             { message: missingManifestFeaturesError.message, severity: 'Error' },
             { message: 'The following features are required but they are excluded: SUBSCRIPTIONBILLING.', severity: 'Error' },
           ],
-          sdfErrors: [missingManifestFeaturesError],
           appliedChanges: [],
         })
         expect(mockSdfDeploy).toHaveBeenCalledTimes(2)
@@ -479,7 +469,6 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
           async () => true,
         )).toEqual({
           errors: [{ message: missingManifestFeaturesError.message, severity: 'Error' }],
-          sdfErrors: [missingManifestFeaturesError],
           appliedChanges: [],
         })
         expect(mockSdfDeploy).toHaveBeenCalledTimes(3)
@@ -564,7 +553,6 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
             async () => true,
           )).toEqual({
             errors: [],
-            sdfErrors: [],
             appliedChanges: [change],
           })
           expect(mockSdfDeploy).toHaveBeenCalledWith(
@@ -622,7 +610,6 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
               message: objectsDeployError.message,
               severity: 'Error',
             }],
-            sdfErrors: [objectsDeployError],
             appliedChanges: [successTypeChange, successFieldChange],
           })
         })
@@ -667,8 +654,8 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
               message: featuresDeployError.message,
               severity: 'Error',
             }],
-            sdfErrors: [featuresDeployError],
             appliedChanges: [],
+            failedFeaturesIds: ['ABC'],
           })
         })
         it('should return change and error when some features deployed and some failed', async () => {
@@ -704,8 +691,8 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
               message: featuresDeployError.message,
               severity: 'Error',
             }],
-            sdfErrors: [featuresDeployError],
             appliedChanges: [change],
+            failedFeaturesIds: ['ABC'],
           })
         })
       })

--- a/packages/netsuite-adapter/test/client/client.test.ts
+++ b/packages/netsuite-adapter/test/client/client.test.ts
@@ -58,7 +58,8 @@ describe('NetsuiteClient', () => {
 
       it('should try again to deploy after ObjectsDeployError', async () => {
         const type = new ObjectType({ elemID: new ElemID(NETSUITE, 'type') })
-        const objectsDeployError = new ObjectsDeployError('error', new Set(['failedObject']))
+        const failedObjectsMap = new Map([['failedObject', [{ message: 'error' }]]])
+        const objectsDeployError = new ObjectsDeployError('error', failedObjectsMap)
         mockSdfDeploy.mockRejectedValueOnce(objectsDeployError)
         const successChange = toChange({
           after: new InstanceElement('instance', type, { scriptid: 'someObject' }),
@@ -84,7 +85,8 @@ describe('NetsuiteClient', () => {
       })
       it('should fail when failed changes couldn\'t be found in ObjectsDeployError', async () => {
         const type = new ObjectType({ elemID: new ElemID(NETSUITE, 'type') })
-        const objectsDeployError = new ObjectsDeployError('error', new Set(['unknownObject']))
+        const failedObjectsMap = new Map([['unknownObject', [{ message: 'error' }]]])
+        const objectsDeployError = new ObjectsDeployError('error', failedObjectsMap)
         mockSdfDeploy.mockRejectedValueOnce(objectsDeployError)
         const successChange = toChange({
           after: new InstanceElement('instance', type, { scriptid: 'someObject' }),
@@ -107,7 +109,8 @@ describe('NetsuiteClient', () => {
       it('should try again to deploy after SettingsDeployError', async () => {
         const type = new ObjectType({ elemID: new ElemID(NETSUITE, 'type') })
         const settingsType = new ObjectType({ elemID: new ElemID(NETSUITE, 'settingsType') })
-        const settingsDeployError = new SettingsDeployError('error', new Set(['settingsType']))
+        const failedSettingsMap = new Map([['settingsType', [{ message: 'error' }]]])
+        const settingsDeployError = new SettingsDeployError('error', failedSettingsMap)
         mockSdfDeploy.mockRejectedValueOnce(settingsDeployError)
         const successChange = toChange({
           after: new InstanceElement('instance', type, { scriptid: 'someObject' }),
@@ -133,7 +136,8 @@ describe('NetsuiteClient', () => {
       })
       it('should not try again to deploy if SettingsDeployError doesn\'t contain an actual failing change', async () => {
         const type = new ObjectType({ elemID: new ElemID(NETSUITE, 'type') })
-        const settingsDeployError = new SettingsDeployError('error', new Set(['settingsType']))
+        const failedSettingsMap = new Map([['settingsType', [{ message: 'error' }]]])
+        const settingsDeployError = new SettingsDeployError('error', failedSettingsMap)
         mockSdfDeploy.mockRejectedValue(settingsDeployError)
         const change = toChange({
           after: new InstanceElement('instance', type, { scriptid: 'someObject' }),
@@ -154,7 +158,10 @@ describe('NetsuiteClient', () => {
       it('should try to deploy again after ManifestValidationError', async () => {
         const type = new ObjectType({ elemID: new ElemID(NETSUITE, 'type') })
         const manifestErrorMessage = 'Details: The manifest contains a dependency on failed_scriptid'
-        const manifestValidationError = new ManifestValidationError(manifestErrorMessage, ['failed_scriptid'])
+        const manifestValidationError = new ManifestValidationError(
+          manifestErrorMessage,
+          [{ message: manifestErrorMessage, scriptId: 'failed_scriptid' }]
+        )
         mockSdfDeploy.mockRejectedValueOnce(manifestValidationError)
         const successChange = toChange({
           after: new InstanceElement('instance', type, { scriptid: 'someObject', ref: '[scriptid=test_scriptid]' },),
@@ -182,7 +189,10 @@ describe('NetsuiteClient', () => {
       it('should try to deploy again after ManifestValidationError from inner NS ref', async () => {
         const type = new ObjectType({ elemID: new ElemID(NETSUITE, 'type') })
         const manifestErrorMessage = 'Details: The manifest contains a dependency on customworkflow1.workflowstate17.workflowaction33'
-        const manifestValidationError = new ManifestValidationError(manifestErrorMessage, ['customworkflow1.workflowstate17.workflowaction33'])
+        const manifestValidationError = new ManifestValidationError(
+          manifestErrorMessage,
+          [{ message: manifestErrorMessage, scriptId: 'customworkflow1.workflowstate17.workflowaction33' }]
+        )
         mockSdfDeploy.mockRejectedValueOnce(manifestValidationError)
         const successChange = toChange({
           after: new InstanceElement('instance', type, { scriptid: 'someObject', ref: '[scriptid=customworkflow1]' }),
@@ -210,7 +220,10 @@ describe('NetsuiteClient', () => {
       it('should not apply any changes if failed scriptid cant be extracted from error message', async () => {
         const type = new ObjectType({ elemID: new ElemID(NETSUITE, 'type') })
         const manifestErrorMessage = 'Details: The manifest contains a dependency on some_id'
-        const manifestValidationError = new ManifestValidationError(manifestErrorMessage, ['some_id'])
+        const manifestValidationError = new ManifestValidationError(
+          manifestErrorMessage,
+          [{ message: manifestErrorMessage, scriptId: 'some_id' }]
+        )
         mockSdfDeploy.mockRejectedValueOnce(manifestValidationError)
         const successChange = toChange({
           after: new InstanceElement('instance', type, { scriptid: 'someObject', ref: '[scriptid=some_ref]' }),
@@ -234,7 +247,10 @@ describe('NetsuiteClient', () => {
       it('should try to deploy again after removing instance and its dependencies due to ManifestValidationError', async () => {
         const type = new ObjectType({ elemID: new ElemID(NETSUITE, 'type') })
         const manifestErrorMessage = 'Details: The manifest contains a dependency on failed_scriptid'
-        const manifestValidationError = new ManifestValidationError(manifestErrorMessage, ['failed_scriptid'])
+        const manifestValidationError = new ManifestValidationError(
+          manifestErrorMessage,
+          [{ message: manifestErrorMessage, scriptId: 'failed_scriptid' }]
+        )
         mockSdfDeploy.mockRejectedValueOnce(manifestValidationError)
         const successChange = toChange({
           after: new InstanceElement('instance', type, { scriptid: 'someObject', ref: '[scriptid=some_ref]' }),
@@ -269,7 +285,10 @@ describe('NetsuiteClient', () => {
       it('should try to deploy again without removing dependencies when the failed changeType is modification', async () => {
         const type = new ObjectType({ elemID: new ElemID(NETSUITE, 'type') })
         const manifestErrorMessage = 'Details: The manifest contains a dependency on failed_scriptid'
-        const manifestValidationError = new ManifestValidationError(manifestErrorMessage, ['failed_scriptid'])
+        const manifestValidationError = new ManifestValidationError(
+          manifestErrorMessage,
+          [{ message: manifestErrorMessage, scriptId: 'failed_scriptid' }]
+        )
         mockSdfDeploy.mockRejectedValueOnce(manifestValidationError)
         const successChange = toChange({
           after: new InstanceElement('instance', type, { scriptid: 'someObject', ref: '[scriptid=some_ref]' }),
@@ -576,7 +595,8 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
               [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
             },
           })
-          const objectsDeployError = new ObjectsDeployError('error', new Set(['some_object']))
+          const failedObjectsMap = new Map([['some_object', [{ message: 'error' }]]])
+          const objectsDeployError = new ObjectsDeployError('error', failedObjectsMap)
           mockSdfDeploy.mockRejectedValueOnce(objectsDeployError)
           const failedChange = toChange({
             after: new InstanceElement(

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -1476,7 +1476,15 @@ File: ~/Objects/custform_114_t1441298_782.xml
         } catch (e) {
           isRejected = true
           expect(e instanceof ObjectsDeployError).toBeTruthy()
-          expect(e instanceof ObjectsDeployError && e.failedObjects).toEqual(new Set(['custform_114_t1441298_782']))
+          expect(e instanceof ObjectsDeployError && e.failedObjects).toEqual(new Map([[
+            'custform_114_t1441298_782',
+            [{
+              message: `An error occurred during custom object validation. (custform_114_t1441298_782)
+File: ~/Objects/custform_114_t1441298_782.xml
+        `,
+              scriptId: 'custform_114_t1441298_782',
+            }],
+          ]]))
         }
         expect(isRejected).toBe(true)
       })
@@ -1513,7 +1521,15 @@ File: ~/Objects/custform_114_t1441298_782.xml
         } catch (e) {
           isRejected = true
           expect(e instanceof ObjectsDeployError).toBeTruthy()
-          expect(e instanceof ObjectsDeployError && e.failedObjects).toEqual(new Set(['custform_114_t1441298_782']))
+          expect(e instanceof ObjectsDeployError && e.failedObjects).toEqual(new Map([[
+            'custform_114_t1441298_782',
+            [{
+              message: `Une erreur s'est produite lors de la validation de l'objet personnalis.. (custform_114_t1441298_782)
+File: ~/Objects/custform_114_t1441298_782.xml
+        `,
+              scriptId: 'custform_114_t1441298_782',
+            }],
+          ]]))
         }
         expect(isRejected).toBe(true)
       })
@@ -1565,7 +1581,15 @@ File: ~/Objects/custform_15_t1049933_143.xml
         } catch (e) {
           isRejected = true
           expect(e instanceof ObjectsDeployError).toBeTruthy()
-          expect(e instanceof ObjectsDeployError && e.failedObjects).toEqual(new Set(['custform_15_t1049933_143']))
+          expect(e instanceof ObjectsDeployError && e.failedObjects).toEqual(new Map([[
+            'custform_15_t1049933_143',
+            [{
+              message: `An unexpected error has occurred. (custform_15_t1049933_143)
+File: ~/Objects/custform_15_t1049933_143.xml
+`,
+              scriptId: 'custform_15_t1049933_143',
+            }],
+          ]]))
         }
         expect(isRejected).toBe(true)
       })
@@ -1615,7 +1639,15 @@ File: ~/Objects/custform_15_t1049933_143.xml
         } catch (e) {
           isRejected = true
           expect(e instanceof ObjectsDeployError).toBeTruthy()
-          expect(e instanceof ObjectsDeployError && e.failedObjects).toEqual(new Set(['custform_15_t1049933_143']))
+          expect(e instanceof ObjectsDeployError && e.failedObjects).toEqual(new Map([[
+            'custform_15_t1049933_143',
+            [{
+              message: `An unexpected error has occurred. (custform_15_t1049933_143)
+File: ~/Objects/custform_15_t1049933_143.xml
+`,
+              scriptId: 'custform_15_t1049933_143',
+            }],
+          ]]))
         }
         expect(isRejected).toBe(true)
       })
@@ -1718,7 +1750,13 @@ Object: customrecord_flo_customization.custrecord_flo_custz_link (customrecordcu
         } catch (e) {
           isRejected = true
           expect(e instanceof ObjectsDeployError).toBeTruthy()
-          expect(e instanceof ObjectsDeployError && e.failedObjects).toEqual(new Set(['customrecord_flo_customization']))
+          expect(e instanceof ObjectsDeployError && e.failedObjects).toEqual(new Map([[
+            'customrecord_flo_customization',
+            [{ message: `An error occurred during custom object update.
+File: ~/Objects/customrecord_flo_customization.xml
+Object: customrecord_flo_customization.custrecord_flo_custz_link (customrecordcustomfield)
+` }],
+          ]]))
         }
         expect(isRejected).toBe(true)
       })
@@ -1772,7 +1810,12 @@ File: ~/AccountConfiguration/features.xml`
         } catch (e) {
           isRejected = true
           expect(e instanceof SettingsDeployError).toBeTruthy()
-          expect(e instanceof SettingsDeployError && e.failedConfigTypes).toEqual(new Set(['companyFeatures']))
+          expect(e instanceof SettingsDeployError && e.failedConfigTypes).toEqual(new Map([[
+            'companyFeatures',
+            [{ message: `An error occurred during configuration validation.
+Details: Disable the SUPPLYCHAINPREDICTEDRISKS(Supply Chain Predicted Risks) feature before disabling the SUPPLYCHAINCONTROLTOWER(Supply Chain Control Tower) feature.
+File: ~/AccountConfiguration/features.xml` }],
+          ]]))
         }
         expect(isRejected).toBe(true)
       })
@@ -2000,7 +2043,8 @@ File: ~/AccountConfiguration/features.xml`
       it('should throw ManifestValidationError', async () => {
         let errorMessage: string
         const errorReferenceName = 'some_scriptid'
-        const manifestErrorMessage = `Details: The manifest contains a dependency on ${errorReferenceName} object, but it is not in the account.`
+        const manifestErrorMessage = `An error occurred during account settings validation.
+Details: The manifest contains a dependency on ${errorReferenceName} object, but it is not in the account.`
         mockExecuteAction.mockImplementation(context => {
           if (context.commandName === COMMANDS.VALIDATE_PROJECT) {
             errorMessage = `Warning: The validation process has encountered an error.
@@ -2039,7 +2083,7 @@ Details: The manifest contains a dependency on ${errorReferenceName} object, but
         } catch (e) {
           expect(e instanceof ManifestValidationError).toBeTruthy()
           expect(e.message).toContain(manifestErrorMessage)
-          expect(e.missingDependencyScriptIds).toContain(errorReferenceName)
+          expect(e.missingDependencies).toEqual([{ scriptId: errorReferenceName, message: manifestErrorMessage }])
         }
       })
 

--- a/packages/netsuite-adapter/test/filters/config_features.test.ts
+++ b/packages/netsuite-adapter/test/filters/config_features.test.ts
@@ -15,7 +15,6 @@
 */
 import { BuiltinTypes, Change, ElemID, getChangeData, InstanceElement, isListType, ObjectType, toChange } from '@salto-io/adapter-api'
 import filterCreator from '../../src/filters/config_features'
-import { FeaturesDeployError } from '../../src/client/errors'
 import { CONFIG_FEATURES, NETSUITE } from '../../src/constants'
 import { featuresType } from '../../src/types/configuration_types'
 import { LocalFilterOpts } from '../../src/filter'
@@ -96,12 +95,12 @@ describe('config features filter', () => {
   describe('onDeploy', () => {
     it('should succeed', async () => {
       const change = getChange()
-      await filterCreator({} as LocalFilterOpts).onDeploy?.([change], { sdfErrors: [new Error('error')], appliedChanges: [], errors: [] })
+      await filterCreator({} as LocalFilterOpts).onDeploy?.([change], { appliedChanges: [], errors: [] })
       expect(getChangeData(change).value).toEqual({ ABC: true, DEF: true })
     })
     it('should restore failed to deploy features', async () => {
       const change = getChange()
-      await filterCreator({} as LocalFilterOpts).onDeploy?.([change], { sdfErrors: [new FeaturesDeployError('error', ['ABC'])], appliedChanges: [], errors: [] })
+      await filterCreator({} as LocalFilterOpts).onDeploy?.([change], { failedFeaturesIds: ['ABC'], appliedChanges: [], errors: [] })
       expect(getChangeData(change).value).toEqual({ ABC: false, DEF: true })
     })
   })


### PR DESCRIPTION

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
