### PR TITLE
SALTO-4482: added additional_references also for modifications

### DIFF
--- a/packages/salesforce-adapter/src/additional_references.ts
+++ b/packages/salesforce-adapter/src/additional_references.ts
@@ -14,20 +14,24 @@
 * limitations under the License.
 */
 import {
+  AdditionChange,
   Element,
   GetAdditionalReferencesFunc,
   getChangeData,
   InstanceElement,
   isAdditionChange,
+  isAdditionOrModificationChange,
   isFieldChange,
   isInstanceChange,
   isRemovalOrModificationChange,
+  ModificationChange,
   ReferenceMapping,
   Value,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { collections } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
+import { detailedCompare } from '@salto-io/adapter-utils'
 import {
   isCustomObject,
   isFieldOfCustomObject,
@@ -58,9 +62,29 @@ const OBJECT_SECTION = 'objectPermissions'
 const APEX_PAGE_SECTION = 'pageAccesses'
 const RECORD_TYPE_SECTION = 'recordTypeVisibilities'
 
+const createReferenceMapping = (
+  source: InstanceElement,
+  target: ModificationChange<Element> | AdditionChange<Element>,
+  targetApiName: string,
+  profileSection: string,
+): ReferenceMapping[] => {
+  if (isAdditionChange(target)) {
+    return [{
+      source: source.elemID.createNestedID(profileSection, ...targetApiName.split(API_NAME_SEPARATOR)),
+      target: getChangeData(target).elemID,
+    }]
+  }
+
+  const detailedChanges = detailedCompare(target.data.before, target.data.after)
+  return detailedChanges.map(change => ({
+    source: source.elemID.createNestedID(profileSection, ...targetApiName.split(API_NAME_SEPARATOR)),
+    target: change.id,
+  }))
+}
+
 const refsFromProfileOrPermissionSet = async (
   profilesAndPermissionSets: InstanceElement[],
-  potentialTarget: Readonly<Element>,
+  potentialTarget: ModificationChange<Element> | AdditionChange<Element>,
   profileSection: string,
 ): Promise<ReferenceMapping[]> => {
   /**
@@ -68,25 +92,25 @@ const refsFromProfileOrPermissionSet = async (
    * references, in which case we will create duplicate references and drop them. We won't crash because we don't
    * actually look at the content of any field/annotation, only on the keys in the provided profile section.
    */
-  const apiName = await safeApiName(potentialTarget)
+  const apiName = await safeApiName(getChangeData(potentialTarget))
   if (apiName === undefined) {
     return []
   }
   return profilesAndPermissionSets
     .filter(profileOrPermissionSet => _.get(profileOrPermissionSet.value[profileSection], apiName))
-    .flatMap(profileOrPermissionSet => (
-      {
-        source: profileOrPermissionSet.elemID.createNestedID(profileSection, ...apiName.split(API_NAME_SEPARATOR)),
-        target: potentialTarget.elemID,
-      }
+    .flatMap(profileOrPermissionSet => createReferenceMapping(
+      profileOrPermissionSet,
+      potentialTarget,
+      apiName,
+      profileSection,
     ))
 }
 
 const recordTypeRefsFromLayoutAssignments = (
   layoutAssignments: Value,
-  recordTypesByApiName: Record<string, InstanceElement>,
+  recordTypesByApiName: Record<string, AdditionChange<InstanceElement> | ModificationChange<InstanceElement>>,
   profileOrPermissionSet: InstanceElement,
-  LayoutApiName: string
+  layoutApiName: string
 ): ReferenceMapping[] => {
   /*
   * Every key in the layoutAssignments section contains an array. Each element in the array contains (among other
@@ -99,39 +123,34 @@ const recordTypeRefsFromLayoutAssignments = (
     log.warn('Profile layoutAssignment not an array: %o', layoutAssignments)
     return []
   }
-  const layoutApiNameParts = LayoutApiName.split(API_NAME_SEPARATOR)
   return layoutAssignments
     .filter(layoutAssignment => _.isString(layoutAssignment.recordType))
     .filter(layoutAssignment => layoutAssignment.recordType in recordTypesByApiName)
-    .map(layoutAssignment => (
-      {
-        source: profileOrPermissionSet.elemID.createNestedID(LAYOUTS_SECTION, ...layoutApiNameParts),
-        target: recordTypesByApiName[layoutAssignment.recordType].elemID,
-      }
+    .flatMap(layoutAssignment => createReferenceMapping(
+      profileOrPermissionSet,
+      recordTypesByApiName[layoutAssignment.recordType],
+      layoutApiName,
+      LAYOUTS_SECTION
     ))
 }
 
 export const getAdditionalReferences: GetAdditionalReferencesFunc = async changes => {
   const relevantFields = await awu(changes)
     .filter(isFieldChange)
-    .filter(isAdditionChange)
-    .map(getChangeData)
-    .filter(isFieldOfCustomObject)
+    .filter(isAdditionOrModificationChange)
+    .filter(change => isFieldOfCustomObject(getChangeData(change)))
     .toArray()
 
   const customObjects = changes
-    .filter(isAdditionChange)
-    .map(getChangeData)
-    .filter(isCustomObject)
+    .filter(isAdditionOrModificationChange)
+    .filter(change => isCustomObject(getChangeData(change)))
 
-
-  const addedInstances = changes
+  const addedInstancesChanges = changes
     .filter(isInstanceChange)
-    .filter(isAdditionChange)
-    .map(getChangeData)
+    .filter(isAdditionOrModificationChange)
 
-  const addedInstancesByType = await awu(addedInstances)
-    .groupBy(async instance => (await instance.getType()).elemID.typeName)
+  const addedInstancesChangesByType = await awu(addedInstancesChanges)
+    .groupBy(async change => (await getChangeData(change).getType()).elemID.typeName)
 
   const profilesAndPermSets = await awu(changes)
     .filter(isRemovalOrModificationChange)
@@ -141,35 +160,36 @@ export const getAdditionalReferences: GetAdditionalReferencesFunc = async change
     .toArray()
 
   const fieldPermissionsRefs = awu(relevantFields)
-    .flatMap(async field => refsFromProfileOrPermissionSet(profilesAndPermSets, field, FIELD_PERMISSIONS))
+    .flatMap(async fieldChange => refsFromProfileOrPermissionSet(profilesAndPermSets, fieldChange, FIELD_PERMISSIONS))
 
-  const customAppsRefs = awu(addedInstancesByType[CUSTOM_APPLICATION_METADATA_TYPE] ?? [])
+  const customAppsRefs = awu(addedInstancesChangesByType[CUSTOM_APPLICATION_METADATA_TYPE] ?? [])
     .flatMap(async customApp => refsFromProfileOrPermissionSet(profilesAndPermSets, customApp, CUSTOM_APP_SECTION))
 
-  const apexClassRefs = awu(addedInstancesByType[APEX_CLASS_METADATA_TYPE] ?? [])
+  const apexClassRefs = awu(addedInstancesChangesByType[APEX_CLASS_METADATA_TYPE] ?? [])
     .flatMap(async apexClass => refsFromProfileOrPermissionSet(profilesAndPermSets, apexClass, APEX_CLASS_SECTION))
 
-  const flowRefs = awu(addedInstancesByType[FLOW_METADATA_TYPE] ?? [])
+  const flowRefs = awu(addedInstancesChangesByType[FLOW_METADATA_TYPE] ?? [])
     .flatMap(async flow => refsFromProfileOrPermissionSet(profilesAndPermSets, flow, FLOW_SECTION))
 
   // note that permission sets don't contain layout assignments, but it simplifies our code to pretend like they might
   // ref: https://ideas.salesforce.com/s/idea/a0B8W00000GdlSPUAZ/permission-sets-with-page-layout-assignment
-  const layoutRefs = awu(addedInstancesByType[LAYOUT_TYPE_ID_METADATA_TYPE] ?? [])
+  const layoutRefs = awu(addedInstancesChangesByType[LAYOUT_TYPE_ID_METADATA_TYPE] ?? [])
     .flatMap(async layout => refsFromProfileOrPermissionSet(profilesAndPermSets, layout, LAYOUTS_SECTION))
 
-  const apexPageRefs = awu(addedInstancesByType[APEX_PAGE_METADATA_TYPE] ?? [])
+  const apexPageRefs = awu(addedInstancesChangesByType[APEX_PAGE_METADATA_TYPE] ?? [])
     .flatMap(async apexPage => refsFromProfileOrPermissionSet(profilesAndPermSets, apexPage, APEX_PAGE_SECTION))
 
-  const recordTypeRefs = awu(addedInstancesByType[RECORD_TYPE_METADATA_TYPE] ?? [])
+  const recordTypeRefs = awu(addedInstancesChangesByType[RECORD_TYPE_METADATA_TYPE] ?? [])
     .flatMap(async recordType => refsFromProfileOrPermissionSet(profilesAndPermSets, recordType, RECORD_TYPE_SECTION))
 
   const objectRefs = awu(customObjects)
     .flatMap(async object => refsFromProfileOrPermissionSet(profilesAndPermSets, object, OBJECT_SECTION))
 
-  const recordTypesByApiName = await awu(addedInstancesByType[RECORD_TYPE_METADATA_TYPE] ?? [])
-    .keyBy(async recordType => (await safeApiName(recordType)) ?? '')
+  const recordTypesByApiName = await awu(addedInstancesChangesByType[RECORD_TYPE_METADATA_TYPE] ?? [])
+    .keyBy(async recordType => (await safeApiName(getChangeData(recordType))) ?? '')
 
-  const recordTypeRefsFromLayouts = awu(addedInstancesByType[LAYOUT_TYPE_ID_METADATA_TYPE] ?? [])
+  const recordTypeRefsFromLayouts = awu(addedInstancesChangesByType[LAYOUT_TYPE_ID_METADATA_TYPE] ?? [])
+    .map(getChangeData)
     .flatMap(async layout => {
       const apiName = await safeApiName(layout)
       if (apiName === undefined) {

--- a/packages/salesforce-adapter/test/additional_references.test.ts
+++ b/packages/salesforce-adapter/test/additional_references.test.ts
@@ -76,14 +76,19 @@ describe('getAdditionalReferences', () => {
       ])
     })
 
-    it('should add references only for addition fields', async () => {
+    it('should add references only for each detailed change in a modification', async () => {
+      const fieldAfter = field.clone()
+      fieldAfter.annotations.someAnn = 'val'
       const refs = await getAdditionalReferences([
         toChange({ before: permissionSetInstance, after: permissionSetInstance }),
         toChange({ before: profileInstance, after: profileInstance }),
-        toChange({ before: field, after: field }),
+        toChange({ before: field, after: fieldAfter }),
       ])
 
-      expect(refs).toEqual([])
+      expect(refs).toEqual([
+        { source: permissionSetInstance.elemID.createNestedID('fieldPermissions', 'Account', 'testField__c'), target: field.elemID.createNestedID('someAnn') },
+        { source: profileInstance.elemID.createNestedID('fieldPermissions', 'Account', 'testField__c'), target: field.elemID.createNestedID('someAnn') },
+      ])
     })
 
     it('should not add references for addition profiles and permission sets', async () => {
@@ -140,18 +145,34 @@ describe('getAdditionalReferences', () => {
         createMetadataTypeElement('CustomApplication', {}),
         { [INSTANCE_FULL_NAME_FIELD]: 'SomeApplication' },
       )
+    })
+
+    it('should create a reference to addition', async () => {
       changes = [
         toChange({ before: profileInstance, after: profileInstance }),
         toChange({ before: permissionSetInstance, after: permissionSetInstance }),
         toChange({ after: customApp }),
       ]
-    })
-
-    it('should create a reference', async () => {
       const refs = await getAdditionalReferences(changes)
       expect(refs).toIncludeAllPartialMembers([
         { source: permissionSetInstance.elemID.createNestedID('applicationVisibilities', 'SomeApplication'), target: customApp.elemID },
         { source: profileInstance.elemID.createNestedID('applicationVisibilities', 'SomeApplication'), target: customApp.elemID },
+      ])
+    })
+
+    it('should create a reference to modification', async () => {
+      const customAppAfter = customApp.clone()
+      customApp.annotations.someAnn = 'val'
+      changes = [
+        toChange({ before: profileInstance, after: profileInstance }),
+        toChange({ before: permissionSetInstance, after: permissionSetInstance }),
+        toChange({ before: customApp, after: customAppAfter }),
+      ]
+      const refs = await getAdditionalReferences(changes)
+
+      expect(refs).toEqual([
+        { source: profileInstance.elemID.createNestedID('applicationVisibilities', 'SomeApplication'), target: customApp.elemID.createNestedID('someAnn') },
+        { source: permissionSetInstance.elemID.createNestedID('applicationVisibilities', 'SomeApplication'), target: customApp.elemID.createNestedID('someAnn') },
       ])
     })
   })
@@ -175,18 +196,34 @@ describe('getAdditionalReferences', () => {
         mockTypes.ApexClass,
         { [INSTANCE_FULL_NAME_FIELD]: 'SomeApexClass' },
       )
+    })
+
+    it('should create a reference to addition', async () => {
       changes = [
         toChange({ before: profileInstance, after: profileInstance }),
         toChange({ before: permissionSetInstance, after: permissionSetInstance }),
         toChange({ after: apexClass }),
       ]
-    })
-
-    it('should create a reference', async () => {
       const refs = await getAdditionalReferences(changes)
       expect(refs).toIncludeAllPartialMembers([
         { source: permissionSetInstance.elemID.createNestedID('classAccesses', 'SomeApexClass'), target: apexClass.elemID },
         { source: profileInstance.elemID.createNestedID('classAccesses', 'SomeApexClass'), target: apexClass.elemID },
+      ])
+    })
+
+    it('should create a reference to modification', async () => {
+      const apexClassAfter = apexClass.clone()
+      apexClass.annotations.someAnn = 'val'
+      changes = [
+        toChange({ before: profileInstance, after: profileInstance }),
+        toChange({ before: permissionSetInstance, after: permissionSetInstance }),
+        toChange({ before: apexClass, after: apexClassAfter }),
+      ]
+      const refs = await getAdditionalReferences(changes)
+
+      expect(refs).toEqual([
+        { source: profileInstance.elemID.createNestedID('classAccesses', 'SomeApexClass'), target: apexClass.elemID.createNestedID('someAnn') },
+        { source: permissionSetInstance.elemID.createNestedID('classAccesses', 'SomeApexClass'), target: apexClass.elemID.createNestedID('someAnn') },
       ])
     })
   })
@@ -210,18 +247,34 @@ describe('getAdditionalReferences', () => {
         mockTypes.Flow,
         { [INSTANCE_FULL_NAME_FIELD]: 'SomeFlow' },
       )
+    })
+
+    it('should create a reference to addition', async () => {
       changes = [
         toChange({ before: profileInstance, after: profileInstance }),
         toChange({ before: permissionSetInstance, after: permissionSetInstance }),
         toChange({ after: flow }),
       ]
-    })
-
-    it('should create a reference', async () => {
       const refs = await getAdditionalReferences(changes)
       expect(refs).toIncludeAllPartialMembers([
         { source: permissionSetInstance.elemID.createNestedID('flowAccesses', 'SomeFlow'), target: flow.elemID },
         { source: profileInstance.elemID.createNestedID('flowAccesses', 'SomeFlow'), target: flow.elemID },
+      ])
+    })
+
+    it('should create a reference to modification', async () => {
+      const flowAfter = flow.clone()
+      flow.annotations.someAnn = 'val'
+      changes = [
+        toChange({ before: profileInstance, after: profileInstance }),
+        toChange({ before: permissionSetInstance, after: permissionSetInstance }),
+        toChange({ before: flow, after: flowAfter }),
+      ]
+      const refs = await getAdditionalReferences(changes)
+
+      expect(refs).toEqual([
+        { source: profileInstance.elemID.createNestedID('flowAccesses', 'SomeFlow'), target: flow.elemID.createNestedID('someAnn') },
+        { source: permissionSetInstance.elemID.createNestedID('flowAccesses', 'SomeFlow'), target: flow.elemID.createNestedID('someAnn') },
       ])
     })
   })
@@ -246,19 +299,35 @@ describe('getAdditionalReferences', () => {
         mockTypes.Layout,
         { [INSTANCE_FULL_NAME_FIELD]: 'Account_Account_Layout' },
       )
+    })
+
+    it('should create a reference to addition', async () => {
       changes = [
         toChange({ before: profileInstance, after: profileInstance }),
         toChange({ before: permissionSetInstance, after: permissionSetInstance }),
         toChange({ after: layout }),
       ]
-    })
-
-    it('should create a reference', async () => {
       const refs = await getAdditionalReferences(changes)
       expect(refs).toHaveLength(2)
       expect(refs).toIncludeAllPartialMembers([
         { source: permissionSetInstance.elemID.createNestedID('layoutAssignments', 'Account_Account_Layout'), target: layout.elemID },
         { source: profileInstance.elemID.createNestedID('layoutAssignments', 'Account_Account_Layout'), target: layout.elemID },
+      ])
+    })
+
+    it('should create a reference to modification', async () => {
+      const layoutAfter = layout.clone()
+      layout.annotations.someAnn = 'val'
+      changes = [
+        toChange({ before: profileInstance, after: profileInstance }),
+        toChange({ before: permissionSetInstance, after: permissionSetInstance }),
+        toChange({ before: layout, after: layoutAfter }),
+      ]
+      const refs = await getAdditionalReferences(changes)
+
+      expect(refs).toEqual([
+        { source: profileInstance.elemID.createNestedID('layoutAssignments', 'Account_Account_Layout'), target: layout.elemID.createNestedID('someAnn') },
+        { source: permissionSetInstance.elemID.createNestedID('layoutAssignments', 'Account_Account_Layout'), target: layout.elemID.createNestedID('someAnn') },
       ])
     })
 
@@ -271,13 +340,37 @@ describe('getAdditionalReferences', () => {
           { [INSTANCE_FULL_NAME_FIELD]: 'SomeRecordType' },
         )
         profileInstance.value.layoutAssignments.Account_Account_Layout[0].recordType = 'SomeRecordType'
-        changes.push(toChange({ after: recordType }))
       })
 
-      it('should create a recordType reference', async () => {
+      it('should create a recordType reference on addition', async () => {
+        changes = [
+          toChange({ before: profileInstance, after: profileInstance }),
+          toChange({ before: permissionSetInstance, after: permissionSetInstance }),
+          toChange({ after: layout }),
+          toChange({ after: recordType }),
+        ]
+
         const refs = await getAdditionalReferences(changes)
         expect(refs).toIncludeAllPartialMembers([
           { source: profileInstance.elemID.createNestedID('layoutAssignments', 'Account_Account_Layout'), target: recordType.elemID },
+        ])
+      })
+
+      it('should create a recordType reference on modification', async () => {
+        const recordTypeAfter = recordType.clone()
+        recordTypeAfter.annotations.someAnn = 'val'
+        const layoutAfter = layout.clone()
+        layout.annotations.someAnn = 'val'
+        changes = [
+          toChange({ before: profileInstance, after: profileInstance }),
+          toChange({ before: permissionSetInstance, after: permissionSetInstance }),
+          toChange({ before: layout, after: layoutAfter }),
+          toChange({ before: recordType, after: recordTypeAfter }),
+        ]
+        const refs = await getAdditionalReferences(changes)
+
+        expect(refs).toIncludeAllPartialMembers([
+          { source: profileInstance.elemID.createNestedID('layoutAssignments', 'Account_Account_Layout'), target: recordType.elemID.createNestedID('someAnn') },
         ])
       })
     })
@@ -304,18 +397,33 @@ describe('getAdditionalReferences', () => {
         },
       })
       customObject = createCustomObjectType('Account', {})
+    })
+
+    it('should create a reference to addition', async () => {
       changes = [
         toChange({ before: profileInstance, after: profileInstance }),
         toChange({ before: permissionSetInstance, after: permissionSetInstance }),
         toChange({ after: customObject }),
       ]
-    })
-
-    it('should create a reference', async () => {
       const refs = await getAdditionalReferences(changes)
       expect(refs).toIncludeAllPartialMembers([
         { source: permissionSetInstance.elemID.createNestedID('objectPermissions', 'Account'), target: customObject.elemID },
         { source: profileInstance.elemID.createNestedID('objectPermissions', 'Account'), target: customObject.elemID },
+      ])
+    })
+
+    it('should create a reference to modification', async () => {
+      const customObjectAfter = customObject.clone()
+      customObjectAfter.annotations.someAnn = 'val'
+      changes = [
+        toChange({ before: profileInstance, after: profileInstance }),
+        toChange({ before: permissionSetInstance, after: permissionSetInstance }),
+        toChange({ before: customObject, after: customObjectAfter }),
+      ]
+      const refs = await getAdditionalReferences(changes)
+      expect(refs).toEqual([
+        { source: profileInstance.elemID.createNestedID('objectPermissions', 'Account'), target: customObject.elemID.createNestedID('attr', 'someAnn') },
+        { source: permissionSetInstance.elemID.createNestedID('objectPermissions', 'Account'), target: customObject.elemID.createNestedID('attr', 'someAnn') },
       ])
     })
   })
@@ -340,18 +448,33 @@ describe('getAdditionalReferences', () => {
         mockTypes.ApexPage,
         { [INSTANCE_FULL_NAME_FIELD]: 'SomeApexPage' },
       )
+    })
+
+    it('should create a reference to addition', async () => {
       changes = [
         toChange({ before: profileInstance, after: profileInstance }),
         toChange({ before: permissionSetInstance, after: permissionSetInstance }),
         toChange({ after: apexPage }),
       ]
-    })
-
-    it('should create a reference', async () => {
       const refs = await getAdditionalReferences(changes)
       expect(refs).toIncludeAllPartialMembers([
         { source: permissionSetInstance.elemID.createNestedID('pageAccesses', 'SomeApexPage'), target: apexPage.elemID },
         { source: profileInstance.elemID.createNestedID('pageAccesses', 'SomeApexPage'), target: apexPage.elemID },
+      ])
+    })
+
+    it('should create a reference to modification', async () => {
+      const apexPageAfter = apexPage.clone()
+      apexPageAfter.annotations.someAnn = 'val'
+      changes = [
+        toChange({ before: profileInstance, after: profileInstance }),
+        toChange({ before: permissionSetInstance, after: permissionSetInstance }),
+        toChange({ before: apexPage, after: apexPageAfter }),
+      ]
+      const refs = await getAdditionalReferences(changes)
+      expect(refs).toIncludeAllPartialMembers([
+        { source: permissionSetInstance.elemID.createNestedID('pageAccesses', 'SomeApexPage'), target: apexPage.elemID.createNestedID('someAnn') },
+        { source: profileInstance.elemID.createNestedID('pageAccesses', 'SomeApexPage'), target: apexPage.elemID.createNestedID('someAnn') },
       ])
     })
   })
@@ -379,18 +502,33 @@ describe('getAdditionalReferences', () => {
         mockTypes.RecordType,
         { [INSTANCE_FULL_NAME_FIELD]: 'Case.SomeCaseRecordType' },
       )
+    })
+
+    it('should create a reference to addition', async () => {
       changes = [
         toChange({ before: profileInstance, after: profileInstance }),
         toChange({ before: permissionSetInstance, after: permissionSetInstance }),
         toChange({ after: recordType }),
       ]
-    })
-
-    it('should create a reference', async () => {
       const refs = await getAdditionalReferences(changes)
       expect(refs).toIncludeAllPartialMembers([
         { source: permissionSetInstance.elemID.createNestedID('recordTypeVisibilities', 'Case', 'SomeCaseRecordType'), target: recordType.elemID },
         { source: profileInstance.elemID.createNestedID('recordTypeVisibilities', 'Case', 'SomeCaseRecordType'), target: recordType.elemID },
+      ])
+    })
+
+    it('should create a reference to modification', async () => {
+      const recordTypeAfter = recordType.clone()
+      recordTypeAfter.annotations.someAnn = 'val'
+      changes = [
+        toChange({ before: profileInstance, after: profileInstance }),
+        toChange({ before: permissionSetInstance, after: permissionSetInstance }),
+        toChange({ before: recordType, after: recordTypeAfter }),
+      ]
+      const refs = await getAdditionalReferences(changes)
+      expect(refs).toIncludeAllPartialMembers([
+        { source: permissionSetInstance.elemID.createNestedID('recordTypeVisibilities', 'Case', 'SomeCaseRecordType'), target: recordType.elemID.createNestedID('someAnn') },
+        { source: profileInstance.elemID.createNestedID('recordTypeVisibilities', 'Case', 'SomeCaseRecordType'), target: recordType.elemID.createNestedID('someAnn') },
       ])
     })
   })


### PR DESCRIPTION
Added additional references for modification changes.

---

When there is a modification change, we will create a reference between the profile to each one of the detailed changes of the modified change

---
_Release Notes_: 
Salesforce Adapter:
- Added additional references for modification changes

---
_User Notifications_: 
None