### PR TITLE
SALTO-4482: Revert filterById change

### DIFF
--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -26,7 +26,7 @@ import {
   CORE_ANNOTATIONS, TypeElement, Change, isRemovalChange, isModificationChange, isListType,
   ChangeData, ListType, CoreAnnotationTypes, isMapType, MapType, isContainerType, isTypeReference,
   ReadOnlyElementsSource, ReferenceMap, TypeReference, createRefToElmWithValue, isElement,
-  compareSpecialValues, getChangeData, isTemplateExpression, PlaceholderObjectType, UnresolvedReference, FieldMap,
+  compareSpecialValues, getChangeData, isTemplateExpression, PlaceholderObjectType, UnresolvedReference,
 } from '@salto-io/adapter-api'
 import Joi from 'joi'
 import { walkOnElement, WalkOnFunc, WALK_NEXT_STEP } from './walk_element'
@@ -790,42 +790,42 @@ export const valuesDeepSome = (value: Value, predicate: (val: Value) => boolean)
   return false
 }
 
-export enum FILTER_FUNC_NEXT_STEP {
-  EXCLUDE, // Exclude this value from the element
-  INCLUDE, // include this value
-  RECURSE, // Only partial include, continue with the recursion
-}
-
 export const filterByID = async <T extends Element | Values>(
   id: ElemID, value: T,
-  filterFunc: (id: ElemID) => Promise<FILTER_FUNC_NEXT_STEP>
+  filterFunc: (id: ElemID) => Promise<boolean>
 ): Promise<T | undefined> => {
+  const filterInstanceAnnotations = async (annotations: Value): Promise<Value> => (
+    filterByID(id, annotations, filterFunc)
+  )
+
   const filterAnnotations = async (annotations: Values): Promise<Value> => (
-    filterByID(id.createNestedID('attr'), annotations, filterFunc)
+    _.pickBy(
+      await mapValuesAsync(annotations, async (anno, annoName) => (
+        filterByID(id.createNestedID('attr').createNestedID(annoName), anno, filterFunc)
+      )),
+      isDefined,
+    )
   )
 
-  const filterAnnotationType = async (annoRefTypes: ReferenceMap): Promise<ReferenceMap | undefined> => (
-    filterByID(id.createNestedID('annotation'), annoRefTypes, filterFunc)
-  )
+  const filterAnnotationType = async (annoRefTypes: ReferenceMap): Promise<ReferenceMap> =>
+    _.pickBy(
+      await mapValuesAsync(annoRefTypes, async (anno, annoName) => (
+        await filterFunc(id.createNestedID('annotation').createNestedID(annoName)) ? anno : undefined
+      )),
+      isDefined,
+    )
 
-  const filterFields = async (fields: FieldMap): Promise<FieldMap | undefined> => (
-    filterByID(id.createNestedID('field'), fields, filterFunc)
-  )
-
-  const filterResult = await filterFunc(id)
-  if (filterResult === FILTER_FUNC_NEXT_STEP.EXCLUDE) {
+  if (!(await filterFunc(id))) {
     return undefined
   }
-  if (filterResult === FILTER_FUNC_NEXT_STEP.INCLUDE) {
-    return value
-  }
-  // Only part of the value should be included, continue with the recursion
   if (isObjectType(value)) {
+    const filteredFields = await Promise.all(Object.values(value.fields)
+      .map(field => filterByID(field.elemID, field, filterFunc)))
     return new ObjectType({
       elemID: value.elemID,
       annotations: await filterAnnotations(value.annotations),
       annotationRefsOrTypes: await filterAnnotationType(value.annotationRefTypes),
-      fields: await filterFields(value.fields),
+      fields: _.keyBy(filteredFields.filter(isDefined), field => field.name),
       path: value.path,
       isSettings: value.isSettings,
     }) as Value as T
@@ -853,7 +853,7 @@ export const filterByID = async <T extends Element | Values>(
       value.refType,
       await filterByID(value.elemID, value.value, filterFunc),
       value.path,
-      await filterByID(id, value.annotations, filterFunc)
+      await filterInstanceAnnotations(value.annotations)
     ) as Value as T
   }
 

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -39,7 +39,7 @@ import {
   getPath,
   getSubtypes,
   formatConfigSuggestionsReasons,
-  isResolvedReferenceExpression, FILTER_FUNC_NEXT_STEP,
+  isResolvedReferenceExpression,
 } from '../src/utils'
 import { buildElementsSourceFromElements } from '../src/element_source'
 
@@ -1814,7 +1814,6 @@ describe('Test utils.ts', () => {
       },
       primitive: PrimitiveTypes.STRING,
     })
-
     it('should filter object type', async () => {
       const expectEqualFields = (actual: FieldMap | undefined, expected: FieldMap): void => {
         expect(actual).toBeDefined()
@@ -1827,7 +1826,7 @@ describe('Test utils.ts', () => {
       const onlyFields = await filterByID(
         objElemID,
         obj,
-        async id => (id.idType === 'type' || id.idType === 'field' ? FILTER_FUNC_NEXT_STEP.RECURSE : FILTER_FUNC_NEXT_STEP.EXCLUDE)
+        async id => id.idType === 'type' || id.idType === 'field'
       )
       expect(onlyFields).toBeDefined()
       expectEqualFields(onlyFields?.fields, obj.fields)
@@ -1836,7 +1835,7 @@ describe('Test utils.ts', () => {
       const onlyAnno = await filterByID(
         objElemID,
         obj,
-        async id => (id.idType === 'type' || id.idType === 'attr' ? FILTER_FUNC_NEXT_STEP.RECURSE : FILTER_FUNC_NEXT_STEP.EXCLUDE)
+        async id => id.idType === 'type' || id.idType === 'attr'
       )
       expect(onlyAnno).toBeDefined()
       expect(onlyAnno?.fields).toEqual({})
@@ -1846,7 +1845,7 @@ describe('Test utils.ts', () => {
       const onlyAnnoType = await filterByID(
         objElemID,
         obj,
-        async id => (id.idType === 'type' || id.idType === 'annotation' ? FILTER_FUNC_NEXT_STEP.RECURSE : FILTER_FUNC_NEXT_STEP.EXCLUDE)
+        async id => id.idType === 'type' || id.idType === 'annotation'
       )
       expect(onlyAnnoType).toBeDefined()
       expect(onlyAnnoType?.fields).toEqual({})
@@ -1856,7 +1855,7 @@ describe('Test utils.ts', () => {
       const withoutAnnoObjStr = await filterByID(
         objElemID,
         obj,
-        async id => (!id.getFullNameParts().includes('str') ? FILTER_FUNC_NEXT_STEP.RECURSE : FILTER_FUNC_NEXT_STEP.EXCLUDE)
+        async id => !id.getFullNameParts().includes('str')
       )
       expect(withoutAnnoObjStr).toBeDefined()
       expectEqualFields(withoutAnnoObjStr?.fields, obj.fields)
@@ -1868,7 +1867,7 @@ describe('Test utils.ts', () => {
       const withoutFieldAnnotations = await filterByID(
         objElemID,
         obj,
-        async id => (id.getFullName() !== 'salto.obj.field.obj.label' ? FILTER_FUNC_NEXT_STEP.RECURSE : FILTER_FUNC_NEXT_STEP.EXCLUDE)
+        async id => id.getFullName() !== 'salto.obj.field.obj.label'
       )
 
       expect(withoutFieldAnnotations).toBeDefined()
@@ -1880,8 +1879,8 @@ describe('Test utils.ts', () => {
         objElemID,
         obj,
         async id => (
-          (Number.isNaN(Number(_.last(id.getFullNameParts()))) || Number(_.last(id.getFullNameParts())) === 0
-            ? FILTER_FUNC_NEXT_STEP.RECURSE : FILTER_FUNC_NEXT_STEP.EXCLUDE)
+          Number.isNaN(Number(_.last(id.getFullNameParts())))
+          || Number(_.last(id.getFullNameParts())) === 0
         )
       )
       expect(onlyI).toBeDefined()
@@ -1895,7 +1894,7 @@ describe('Test utils.ts', () => {
       const filteredPrim = await filterByID(
         prim.elemID,
         prim,
-        async id => (!id.getFullNameParts().includes('str') ? FILTER_FUNC_NEXT_STEP.RECURSE : FILTER_FUNC_NEXT_STEP.EXCLUDE)
+        async id => !id.getFullNameParts().includes('str')
       )
       expect(filteredPrim?.annotations.obj).toEqual({ num: 17 })
       expect(filteredPrim?.annotationRefTypes).toEqual({ obj: createRefToElmWithValue(annoType) })
@@ -1905,7 +1904,7 @@ describe('Test utils.ts', () => {
       const filteredInstance = await filterByID(
         inst.elemID,
         inst,
-        async id => (!id.getFullNameParts().includes('list') ? FILTER_FUNC_NEXT_STEP.RECURSE : FILTER_FUNC_NEXT_STEP.EXCLUDE)
+        async id => !id.getFullNameParts().includes('list')
       )
       expect(filteredInstance?.value).toEqual({ obj: inst.value.obj, map: inst.value.map })
       expect(filteredInstance?.annotations).toEqual(inst.annotations)
@@ -1923,7 +1922,7 @@ describe('Test utils.ts', () => {
       const filteredInstance = await filterByID(
         instance.elemID,
         instance,
-        async () => FILTER_FUNC_NEXT_STEP.RECURSE
+        async () => true
       )
       expect(filteredInstance?.value).toEqual({ emptyList: [], emptyObj: {} })
     })
@@ -1932,7 +1931,7 @@ describe('Test utils.ts', () => {
       const filteredInstance = await filterByID(
         inst.elemID,
         inst,
-        async id => (id.idType !== 'instance' ? FILTER_FUNC_NEXT_STEP.RECURSE : FILTER_FUNC_NEXT_STEP.EXCLUDE)
+        async id => id.idType !== 'instance'
       )
       expect(filteredInstance).toBeUndefined()
     })
@@ -1941,47 +1940,34 @@ describe('Test utils.ts', () => {
       const withoutList = await filterByID(
         inst.elemID,
         inst,
-        async id => (Number.isNaN(Number(_.last(id.getFullNameParts())))
-          ? FILTER_FUNC_NEXT_STEP.RECURSE : FILTER_FUNC_NEXT_STEP.EXCLUDE)
+        async id => Number.isNaN(Number(_.last(id.getFullNameParts())))
       )
       expect(withoutList?.value).toEqual({ obj: inst.value.obj, map: inst.value.map })
 
       const withoutObj = await filterByID(
         inst.elemID,
         inst,
-        async id => (!id.getFullNameParts().includes('str') && !id.getFullNameParts().includes('num') ? FILTER_FUNC_NEXT_STEP.RECURSE : FILTER_FUNC_NEXT_STEP.EXCLUDE)
+        async id => !id.getFullNameParts().includes('str') && !id.getFullNameParts().includes('num')
       )
       expect(withoutObj?.value).toEqual({ list: inst.value.list, map: inst.value.map })
 
       const withoutMap = await filterByID(
         inst.elemID,
         inst,
-        async id => (!id.getFullNameParts().includes('Do') ? FILTER_FUNC_NEXT_STEP.RECURSE : FILTER_FUNC_NEXT_STEP.EXCLUDE),
+        async id => !id.getFullNameParts().includes('Do'),
       )
       expect(withoutMap?.value).toEqual({ obj: inst.value.obj, list: inst.value.list })
     })
-    it('should include value that filterFunc returns INCLUDE for without recursing', async () => {
-      const includedID = inst.elemID.createNestedID('obj')
-      const filterFunc = jest.fn().mockImplementation(
-        async (id: ElemID): Promise<FILTER_FUNC_NEXT_STEP> => {
-          if (id.isParentOf(includedID)) {
-            return FILTER_FUNC_NEXT_STEP.RECURSE
-          }
-          if (id.isEqual(includedID)) {
-            return FILTER_FUNC_NEXT_STEP.INCLUDE
-          }
-          return FILTER_FUNC_NEXT_STEP.EXCLUDE
-        }
+
+    it('should not call filter function with invalid attr ID', async () => {
+      const filterFunc = jest.fn().mockResolvedValue(true)
+      await filterByID(
+        obj.elemID,
+        obj,
+        filterFunc
       )
-      const filteredInstance = await filterByID(
-        inst.elemID,
-        inst,
-        filterFunc,
-      )
-      expect(filteredInstance?.value).toEqual({ obj: inst.value.obj })
-      Object.keys(inst.value.obj).forEach(key => {
-        expect(filterFunc).not.toHaveBeenCalledWith(includedID.createNestedID(key))
-      })
+
+      expect(filterFunc).not.toHaveBeenCalledWith(obj.elemID.createNestedID('attr'))
     })
   })
   describe('Flat Values', () => {

--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -43,7 +43,7 @@ import { updateElementsWithAlternativeAccount, createAdapterReplacedID } from '.
 import { RemoteElementSource, ElementsSource } from './src/workspace/elements_source'
 import { FromSource } from './src/workspace/nacl_files/multi_env/multi_env_source'
 import { State } from './src/workspace/state'
-import { PathIndex, splitElementByPath, getElementsPathHints, filterByPathHint } from './src/workspace/path_index'
+import { PathIndex, splitElementByPath, getElementsPathHints } from './src/workspace/path_index'
 
 export {
   errors,
@@ -95,7 +95,6 @@ export {
   State,
   splitElementByPath,
   PathIndex,
-  filterByPathHint,
   getElementsPathHints,
   updateElementsWithAlternativeAccount,
   createAdapterReplacedID,

--- a/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
@@ -13,33 +13,15 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import {
-  ChangeDataType,
-  DetailedChange,
-  Element,
-  ElemID,
-  getChangeData,
-  isAdditionChange,
-  isField,
-  isIndexPathPart,
-  isInstanceElement,
-  isObjectType,
-  isPrimitiveType,
-  Value,
-} from '@salto-io/adapter-api'
+import { getChangeData, ElemID, Value, DetailedChange, ChangeDataType, Element, isObjectType, isPrimitiveType, isInstanceElement, isField, isAdditionChange, isIndexPathPart } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { collections, promises, values } from '@salto-io/lowerdash'
-import {
-  applyDetailedChanges,
-  applyFunctionToChangeData,
-  detailedCompare,
-  FILTER_FUNC_NEXT_STEP,
-  filterByID,
-  resolvePath,
-} from '@salto-io/adapter-utils'
+import { promises, values, collections } from '@salto-io/lowerdash'
+import { resolvePath, filterByID, detailedCompare, applyFunctionToChangeData, applyDetailedChanges } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
-import { createAddChange, createRemoveChange, projectChange, projectElementOrValueToEnv } from './projections'
-import { DetailedAddition, wrapAdditions, wrapNestedValues } from '../addition_wrapper'
+import {
+  projectChange, projectElementOrValueToEnv, createAddChange, createRemoveChange,
+} from './projections'
+import { wrapAdditions, DetailedAddition, wrapNestedValues } from '../addition_wrapper'
 import { NaclFilesSource, RoutingMode, toPathHint } from '../nacl_files_source'
 import { mergeElements } from '../../../merger'
 
@@ -84,22 +66,16 @@ const filterByFile = async (
   valueID: ElemID,
   value: Value,
   fileElements: Element[],
-): Promise<Value> => {
-  const filterByMergeable = async (id: ElemID): Promise<FILTER_FUNC_NEXT_STEP> => {
-    const result = !_.isEmpty((fileElements).filter(
-      e => resolvePath(e, getMergeableParentID(id, fileElements).mergeableID) !== undefined
-    ))
-    if (result) {
-      return FILTER_FUNC_NEXT_STEP.RECURSE
-    }
-    return FILTER_FUNC_NEXT_STEP.EXCLUDE
-  }
-  return filterByID(
-    valueID,
-    value,
-    filterByMergeable
-  )
-}
+): Promise<Value> => filterByID(
+  valueID,
+  value,
+  async id => !_.isEmpty((fileElements).filter(
+    e => resolvePath(
+      e,
+      getMergeableParentID(id, fileElements).mergeableID
+    ) !== undefined
+  ))
+)
 
 const isEmptyAnnoAndAnnoTypes = (element: Element): boolean =>
   (_.isEmpty(element.annotations) && _.isEmpty(element.annotationRefTypes))

--- a/packages/workspace/src/workspace/path_index.ts
+++ b/packages/workspace/src/workspace/path_index.ts
@@ -14,20 +14,12 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { collections, serialize as lowerdashSerialize, values } from '@salto-io/lowerdash'
-import {
-  Element,
-  ElemID,
-  Field,
-  InstanceElement,
-  isInstanceElement,
-  isObjectType,
-  ObjectType,
-  Value,
-} from '@salto-io/adapter-api'
-import { FILTER_FUNC_NEXT_STEP, filterByID } from '@salto-io/adapter-utils'
+import { collections, values, serialize as lowerdashSerialize } from '@salto-io/lowerdash'
+import { ElemID, Element, Value, Field, isObjectType, isInstanceElement,
+  ObjectType, InstanceElement } from '@salto-io/adapter-api'
+import { filterByID } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
-import { RemoteMap, RemoteMapEntry } from './remote_map'
+import { RemoteMapEntry, RemoteMap } from './remote_map'
 
 const { awu } = collections.asynciterable
 const { getSerializedStream } = lowerdashSerialize
@@ -269,22 +261,6 @@ export const getFromPathIndex = async (
   return []
 }
 
-export const filterByPathHint = async (index: PathIndex, hint:Path, id: ElemID): Promise<FILTER_FUNC_NEXT_STEP> => {
-  const idHints = await index.get(id.getFullName()) ?? []
-  const isHintMatch = idHints.some(idHint => _.isEqual(idHint, hint))
-  if (!isHintMatch) {
-    // This case will be removed, when we fix the .annotation and .field keys in the path index
-    if (idHints.length === 0 && (id.isEqual(new ElemID(id.adapter, id.typeName, 'annotation')) || id.isEqual(new ElemID(id.adapter, id.typeName, 'field')) || id.isEqual(new ElemID(id.adapter, id.typeName, 'attr')))) {
-      return FILTER_FUNC_NEXT_STEP.RECURSE
-    }
-    return FILTER_FUNC_NEXT_STEP.EXCLUDE
-  }
-  if (idHints.length === 1) {
-    return FILTER_FUNC_NEXT_STEP.INCLUDE
-  }
-  return FILTER_FUNC_NEXT_STEP.RECURSE
-}
-
 export const splitElementByPath = async (
   element: Element,
   index: PathIndex
@@ -297,10 +273,14 @@ export const splitElementByPath = async (
     return [clonedElement]
   }
   return (await Promise.all(pathHints.map(async hint => {
+    const filterByPathHint = async (id: ElemID): Promise<boolean> => {
+      const idHints = await getFromPathIndex(id, index)
+      return idHints.some(idHint => _.isEqual(idHint, hint))
+    }
     const filteredElement = await filterByID(
       element.elemID,
       element,
-      id => filterByPathHint(index, hint, id)
+      filterByPathHint
     )
 
     if (filteredElement) {

--- a/packages/workspace/test/workspace/path_index.test.ts
+++ b/packages/workspace/test/workspace/path_index.test.ts
@@ -321,49 +321,6 @@ describe('split element by path', () => {
     },
   })
 
-  const singleFieldObjElemId = new ElemID('salto', 'obj2')
-  const singleFieldObj = new ObjectType({
-    elemID: singleFieldObjElemId,
-    fields: {
-      uriField: {
-        refType: createRefToElmWithValue(BuiltinTypes.STRING),
-        annotations: {
-          test: 'test',
-        },
-      },
-    },
-    path: ['salto', 'obj2', 'field'],
-  })
-
-  const singleFieldObjAnnotations = new ObjectType({
-    elemID: singleFieldObjElemId,
-    annotationRefsOrTypes: {
-      anno: createRefToElmWithValue(BuiltinTypes.STRING),
-    },
-    annotations: {
-      anno: 'Bye',
-    },
-    path: ['salto', 'obj2', 'annotations'],
-  })
-
-  const singleFieldObjFull = new ObjectType({
-    elemID: singleFieldObjElemId,
-    fields: {
-      uriField: {
-        refType: createRefToElmWithValue(BuiltinTypes.STRING),
-        annotations: {
-          test: 'test',
-        },
-      },
-    },
-    annotationRefsOrTypes: {
-      anno: createRefToElmWithValue(BuiltinTypes.STRING),
-    },
-    annotations: {
-      anno: 'Bye',
-    },
-  })
-
   const singlePathObj = new ObjectType({
     elemID: new ElemID('salto', 'singlePath'),
     fields: {
@@ -418,11 +375,8 @@ describe('split element by path', () => {
   const fullObjFrags = [
     objFragStdFields, objFragCustomFields, objFragAnnotations,
   ]
-  const singleFieldObjFrags = [
-    singleFieldObj, singleFieldObjAnnotations,
-  ]
   const unmergedElements = [
-    ...fullObjFrags, ...singleFieldObjFrags, singlePathObj, noPathObj, multiPathInstanceA, multiPathInstanceB,
+    ...fullObjFrags, singlePathObj, noPathObj, multiPathInstanceA, multiPathInstanceB,
   ]
   const pi = new InMemoryRemoteMap<Path[]>()
 
@@ -433,13 +387,6 @@ describe('split element by path', () => {
   it('should split an element with multiple pathes', async () => {
     const splitedElements = await splitElementByPath(objFull, pi)
     fullObjFrags.forEach(
-      frag => expect(splitedElements.filter(elem => elem.isEqual(frag))).toHaveLength(1)
-    )
-  })
-
-  it('should split an element with one fields file', async () => {
-    const splitedElements = await splitElementByPath(singleFieldObjFull, pi)
-    singleFieldObjFrags.forEach(
       frag => expect(splitedElements.filter(elem => elem.isEqual(frag))).toHaveLength(1)
     )
   })


### PR DESCRIPTION
This reverts commit a846cc7170baa8ba2033256a756870203e5b2446.

We discovered a behavior change in the function that breaks the SaaS

---
_Release Notes_: 
None

---
_User Notifications_: 
None