### PR TITLE
SALTO-4482: Fixed additional_references on modifications in profiles

### DIFF
--- a/packages/adapter-utils/src/compare.ts
+++ b/packages/adapter-utils/src/compare.ts
@@ -107,7 +107,7 @@ const compareListWithOrderMatching = ({
 /**
  * Create detailed changes from change data (before and after values)
  */
-const getValuesChanges = ({
+export const getValuesChanges = ({
   id, before, after, options, beforeId, afterId,
 }: {
   id: ElemID


### PR DESCRIPTION
Fixed additional_references to work for modifications changes in profiles

---

The fix is to instead of making the relevant section in the profile the source of the reference, I create a reference for each detailed change in the relevant section in the profile, so the source and target of the references match a detailed changes in the comparison

---
_Release Notes_: 
None

---
_User Notifications_: 
None