### PR TITLE
SALTO-4295 - Zendesk Adapter - Support missing reference for dynamic_content

### DIFF
--- a/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
@@ -233,7 +233,7 @@ const formulaToTemplate = (
       const missingInstance = createMissingInstance(
         ZENDESK,
         DYNAMIC_CONTENT_ITEM_TYPE_NAME,
-        dcPlaceholder.slice(3) // slice dc. from the placeholder
+        dcPlaceholder.startsWith('dc.') ? dcPlaceholder.slice(3) : dcPlaceholder
       )
       missingInstance.value.placeholder = `{{${dcPlaceholder}}}`
       return new ReferenceExpression(missingInstance.elemID, missingInstance)

--- a/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
@@ -276,16 +276,11 @@ const replaceFormulasWithTemplates = async (
 ): Promise<void> => {
   const instancesByType = _.groupBy(instances, i => i.elemID.typeName)
 
-  // Recursively replace formulas with templates
   const formulaToTemplateValue = (value: unknown): unknown => {
     if (Array.isArray(value)) {
-      const newValues = value.map(innerValue =>
-        formulaToTemplateValue(innerValue))
-      return newValues
-    } if (_.isString(value)) {
-      return formulaToTemplate(value, instancesByType, enableMissingReferences)
+      return value.map(innerValue => formulaToTemplateValue(innerValue))
     }
-    return value
+    return _.isString(value) ? formulaToTemplate(value, instancesByType, enableMissingReferences) : value
   }
 
   try {


### PR DESCRIPTION
Support missing references for dynamic content
Also support array in array structure in 'actions' field of instances

---

trigger type action's are array inside array, and we covered only 1 nesting level with our code, so i made it recursive to cover all possible nesting levels (which is currently 2)

---
_Release Notes_: 
Zendesk adapter:
* References inside array inside array in 'actions' field of instances will be converted to reference expressions
* Dynamic content references will now be converted to reference expressions

---
_User Notifications_: 
None