### PR TITLE
SALTO-4280 - Zendesk Adapter - allow omitInactive in typeDefaults

### DIFF
--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -86,7 +86,8 @@ export type ZendeskFetchConfig = configUtils.UserFetchConfig
 }
 export type ZedneskDeployConfig = configUtils.UserDeployConfig & configUtils.DefaultMissingUserFallbackConfig
 export type ZendeskApiConfig = configUtils.AdapterApiConfig<
-  configUtils.DuckTypeTransformationConfig & { omitInactive?: boolean }
+  configUtils.DuckTypeTransformationConfig & { omitInactive?: boolean },
+  configUtils.TransformationDefaultConfig & { omitInactive?: boolean }
   >
 
 export type ZendeskConfig = {
@@ -2757,7 +2758,10 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
       ),
     },
     [API_DEFINITIONS_CONFIG]: {
-      refType: createDucktypeAdapterApiConfigType({ adapter: ZENDESK }),
+      refType: createDucktypeAdapterApiConfigType({
+        adapter: ZENDESK,
+        additionalTransformationFields: { omitInactive: { refType: BuiltinTypes.BOOLEAN } },
+      }),
     },
   },
   annotations: {

--- a/packages/zendesk-adapter/src/filters/omit_inactive.ts
+++ b/packages/zendesk-adapter/src/filters/omit_inactive.ts
@@ -16,6 +16,7 @@
 import _ from 'lodash'
 import { isInstanceElement, Element } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
+import { config as configUtils } from '@salto-io/adapter-components'
 import { FilterCreator } from '../filter'
 import { API_DEFINITIONS_CONFIG } from '../config'
 
@@ -36,8 +37,10 @@ const filterCreator: FilterCreator = ({ config }) => ({
     const shouldRemoveElement = (element: Element): boolean =>
       (isInstanceElement(element)
         && !CAN_NOT_OMIT_INACTIVE_TYPE_NAMES.includes(element.elemID.typeName)
-        && config[API_DEFINITIONS_CONFIG]
-          .types[element.elemID.typeName]?.transformation?.omitInactive === true
+        && configUtils.getConfigWithDefault(
+          config[API_DEFINITIONS_CONFIG].types?.[element.elemID.typeName]?.transformation,
+          config[API_DEFINITIONS_CONFIG].typeDefaults.transformation
+        ).omitInactive === true
         && (element.elemID.typeName === 'webhook'
           ? element.value.status === 'inactive'
           : element.value.active === false))

--- a/packages/zendesk-adapter/test/filters/omit_inactive.test.ts
+++ b/packages/zendesk-adapter/test/filters/omit_inactive.test.ts
@@ -22,8 +22,17 @@ import filterCreator from '../../src/filters/omit_inactive'
 import { FilterResult } from '../../src/filter'
 import { createFilterCreatorParams } from '../utils'
 
+type FilterType = filterUtils.FilterWith<'onFetch', FilterResult>
+const testMustHaveInstance = async (filter: FilterType): Promise<void> => {
+  const ticketFormObjType = new ObjectType({ elemID: new ElemID(ZENDESK, 'ticket_form') })
+  const ticketForm = new InstanceElement('inst1', ticketFormObjType, { name: 'test', active: false })
+  const elements = [ticketForm]
+  await filter.onFetch(elements)
+  expect(elements.map(elem => elem.elemID.getFullName()))
+    .toEqual([ticketForm.elemID.getFullName()])
+}
+
 describe('omit inactive', () => {
-  type FilterType = filterUtils.FilterWith<'onFetch', FilterResult>
   let filter: FilterType
   const objType1 = new ObjectType({ elemID: new ElemID(ZENDESK, 'trigger') })
   const objType2 = new ObjectType({ elemID: new ElemID(ZENDESK, 'view') })
@@ -38,99 +47,103 @@ describe('omit inactive', () => {
   const webhook2 = new InstanceElement('inst2', webhookObjType, { name: 'test', status: 'inactive' })
   const webhook3 = new InstanceElement('inst3', webhookObjType, { name: 'test' })
 
-  beforeEach(async () => {
-    jest.clearAllMocks()
-    filter = filterCreator(createFilterCreatorParams({
-      config: {
-        ...DEFAULT_CONFIG,
-        [API_DEFINITIONS_CONFIG]: {
-          ...DEFAULT_CONFIG[API_DEFINITIONS_CONFIG],
-          types: {
-            trigger: {
-              transformation: {
-                omitInactive: true,
-              },
-            },
-            macro: {
-              transformation: {
-                omitInactive: true,
-              },
-            },
-            webhook: {
-              transformation: {
-                omitInactive: true,
-              },
-            },
-            ticket_form: {
-              transformation: {
-                omitInactive: true,
+  describe('onFetch', () => {
+    describe('types config', () => {
+      beforeEach(async () => {
+        jest.clearAllMocks()
+        filter = filterCreator(createFilterCreatorParams({
+          config: {
+            ...DEFAULT_CONFIG,
+            [API_DEFINITIONS_CONFIG]: {
+              ...DEFAULT_CONFIG[API_DEFINITIONS_CONFIG],
+              types: {
+                trigger: {
+                  transformation: {
+                    omitInactive: true,
+                  },
+                },
+                macro: {
+                  transformation: {
+                    omitInactive: true,
+                  },
+                },
+                webhook: {
+                  transformation: {
+                    omitInactive: true,
+                  },
+                },
+                ticket_form: {
+                  transformation: {
+                    omitInactive: true,
+                  },
+                },
               },
             },
           },
-        },
-      },
-    })) as FilterType
-  })
-
-  describe('onFetch', () => {
-    it('should omit inactive instances if the omitInactive is true in their type config', async () => {
-      const elements = [inst1, inst2, inst3, inst4, inst5, webhook1, webhook2, webhook3]
-      await filter.onFetch(elements)
-      expect(elements.map(elem => elem.elemID.getFullName()))
-        .toEqual([
-          inst1.elemID.getFullName(),
-          inst3.elemID.getFullName(),
-          inst5.elemID.getFullName(),
-          webhook1.elemID.getFullName(),
-          webhook3.elemID.getFullName(),
-        ])
+        })) as FilterType
+      })
+      it('should omit inactive instances if the omitInactive is true in their type config', async () => {
+        const elements = [inst1, inst2, inst3, inst4, inst5, webhook1, webhook2, webhook3]
+        await filter.onFetch(elements)
+        expect(elements.map(elem => elem.elemID.getFullName()))
+          .toEqual([
+            inst1.elemID.getFullName(),
+            inst3.elemID.getFullName(),
+            inst5.elemID.getFullName(),
+            webhook1.elemID.getFullName(),
+            webhook3.elemID.getFullName(),
+          ])
+      })
+      it('should not omit instance of types that we need their inactive instances for reorder', async () => {
+        await testMustHaveInstance(filter)
+      })
+      it('should omit inactive webhooks', async () => {
+        const elements = [inst1, inst2, inst3, inst4, inst5]
+        await filter.onFetch(elements)
+        expect(elements.map(elem => elem.elemID.getFullName()))
+          .toEqual([
+            inst1.elemID.getFullName(),
+            inst3.elemID.getFullName(),
+            inst5.elemID.getFullName(),
+          ])
+      })
+      it('should not omit instance if it does not have active field', async () => {
+        const inst = new InstanceElement('inst1', objType1, { name: 'test' })
+        const elements = [inst]
+        await filter.onFetch(elements)
+        expect(elements.map(elem => elem.elemID.getFullName()))
+          .toEqual([inst.elemID.getFullName()])
+      })
+      it('should omit only the inactive instance if two instances have the same id', async () => {
+        const activeInst = new InstanceElement('inst1', objType1, { name: 'test', active: true })
+        const inactiveInst = new InstanceElement('inst1', objType1, { name: 'test', active: false })
+        const elements = [activeInst, inactiveInst]
+        await filter.onFetch(elements)
+        expect(elements.map(elem => elem.elemID.getFullName()))
+          .toEqual([activeInst.elemID.getFullName()])
+      })
     })
-    it('should omit inactive instances if omitInactive in typeDefaults is true', async () => {
-      const config = _.cloneDeep(DEFAULT_CONFIG)
-      config[API_DEFINITIONS_CONFIG].typeDefaults.transformation.omitInactive = true
-      const omitFilter = filterCreator(createFilterCreatorParams({ config })) as FilterType
-      const elements = [inst1, inst2, inst3, inst4, inst5, webhook1, webhook2, webhook3]
-      await omitFilter.onFetch(elements)
-      expect(elements.map(elem => elem.elemID.getFullName()))
-        .toEqual([
-          inst1.elemID.getFullName(),
-          inst5.elemID.getFullName(),
-          webhook1.elemID.getFullName(),
-          webhook3.elemID.getFullName(),
-        ])
-    })
-    it('should omit inactive webhooks', async () => {
-      const elements = [inst1, inst2, inst3, inst4, inst5]
-      await filter.onFetch(elements)
-      expect(elements.map(elem => elem.elemID.getFullName()))
-        .toEqual([
-          inst1.elemID.getFullName(),
-          inst3.elemID.getFullName(),
-          inst5.elemID.getFullName(),
-        ])
-    })
-    it('should not omit instance if it does not have active field', async () => {
-      const inst = new InstanceElement('inst1', objType1, { name: 'test' })
-      const elements = [inst]
-      await filter.onFetch(elements)
-      expect(elements.map(elem => elem.elemID.getFullName()))
-        .toEqual([inst.elemID.getFullName()])
-    })
-    it('should omit only the inactive instance if two instances have the same id', async () => {
-      const activeInst = new InstanceElement('inst1', objType1, { name: 'test', active: true })
-      const inactiveInst = new InstanceElement('inst1', objType1, { name: 'test', active: false })
-      const elements = [activeInst, inactiveInst]
-      await filter.onFetch(elements)
-      expect(elements.map(elem => elem.elemID.getFullName()))
-        .toEqual([activeInst.elemID.getFullName()])
-    })
-    it('should not omit instance of types that we need their inactive instances for reorder', async () => {
-      const ticketFormObjType = new ObjectType({ elemID: new ElemID(ZENDESK, 'ticket_form') })
-      const ticketForm = new InstanceElement('inst1', ticketFormObjType, { name: 'test', active: false })
-      const elements = [ticketForm]
-      await filter.onFetch(elements)
-      expect(elements.map(elem => elem.elemID.getFullName()))
-        .toEqual([ticketForm.elemID.getFullName()])
+    describe('typeDefaults config', () => {
+      beforeEach(async () => {
+        jest.clearAllMocks()
+        const config = _.cloneDeep(DEFAULT_CONFIG)
+        config[API_DEFINITIONS_CONFIG].typeDefaults.transformation.omitInactive = true
+        filter = filterCreator(createFilterCreatorParams({ config })) as FilterType
+      })
+      it('should omit inactive instances if omitInactive in typeDefaults is true', async () => {
+        const elements = [inst1, inst2, inst3, inst4, inst5, webhook1, webhook2, webhook3]
+        await filter.onFetch(elements)
+        expect(elements.map(elem => elem.elemID.getFullName()))
+          .toEqual([
+            inst1.elemID.getFullName(),
+            inst5.elemID.getFullName(),
+            webhook1.elemID.getFullName(),
+            webhook3.elemID.getFullName(),
+          ])
+      })
+      it('should not omit instance of types that we need their inactive instances for reorder', async () => {
+        await testMustHaveInstance(filter)
+      })
     })
   })
 })

--- a/packages/zendesk-adapter/test/filters/omit_inactive.test.ts
+++ b/packages/zendesk-adapter/test/filters/omit_inactive.test.ts
@@ -15,6 +15,7 @@
 */
 import { ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
+import _ from 'lodash'
 import { API_DEFINITIONS_CONFIG, DEFAULT_CONFIG } from '../../src/config'
 import { ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/omit_inactive'
@@ -72,13 +73,27 @@ describe('omit inactive', () => {
   })
 
   describe('onFetch', () => {
-    it('should omit inactive instances if the omitInactive is true', async () => {
+    it('should omit inactive instances if the omitInactive is true in their type config', async () => {
       const elements = [inst1, inst2, inst3, inst4, inst5, webhook1, webhook2, webhook3]
       await filter.onFetch(elements)
       expect(elements.map(elem => elem.elemID.getFullName()))
         .toEqual([
           inst1.elemID.getFullName(),
           inst3.elemID.getFullName(),
+          inst5.elemID.getFullName(),
+          webhook1.elemID.getFullName(),
+          webhook3.elemID.getFullName(),
+        ])
+    })
+    it('should omit inactive instances if omitInactive in typeDefaults is true', async () => {
+      const config = _.cloneDeep(DEFAULT_CONFIG)
+      config[API_DEFINITIONS_CONFIG].typeDefaults.transformation.omitInactive = true
+      const omitFilter = filterCreator(createFilterCreatorParams({ config })) as FilterType
+      const elements = [inst1, inst2, inst3, inst4, inst5, webhook1, webhook2, webhook3]
+      await omitFilter.onFetch(elements)
+      expect(elements.map(elem => elem.elemID.getFullName()))
+        .toEqual([
+          inst1.elemID.getFullName(),
           inst5.elemID.getFullName(),
           webhook1.elemID.getFullName(),
           webhook3.elemID.getFullName(),


### PR DESCRIPTION
Allow to put omitInactive in typeDefault to omit inactive instances from all types, being able to override that default in the type specific config

---

None

---
_Release Notes_: 
Zendesk Adapter:
* Added the option to default omit all inactive instances using typeDefaults config

---
_User Notifications_: 
None