### PR TITLE
fit to workato ids model, new 2 tests

### DIFF
--- a/packages/workato-adapter/src/filters/cross_service/jira/project_issuetypes.ts
+++ b/packages/workato-adapter/src/filters/cross_service/jira/project_issuetypes.ts
@@ -27,9 +27,9 @@ const INPUT_SEPERATOR = '--'
 type JiraExportedBlock = BlockBase & {
   as: string
   provider: 'jira' | 'jira_secondary'
-  dynamicPickListSelection: {
-    project_issuetype: string
-    sample_project_issuetype?: string
+  dynamicPickListSelection?: {
+    project_issuetype: unknown
+    sample_project_issuetype?: unknown
   }
   input: {
     project_issuetype: string
@@ -46,9 +46,9 @@ const JIRA_EXPORTED_BLOCK_SCHEMA = Joi.object({
   as: Joi.string().required(),
   provider: Joi.string().valid('jira', 'jira_secondary').required(),
   dynamicPickListSelection: Joi.object({
-    project_issuetype: Joi.string().required(),
-    sample_project_issuetype: Joi.string(),
-  }).unknown(true).required(),
+    project_issuetype: Joi.any().required(),
+    sample_project_issuetype: Joi.any(),
+  }).unknown(true),
   input: Joi.object({
     project_issuetype: Joi.string().required(),
     sample_project_issuetype: Joi.string(),
@@ -63,8 +63,7 @@ const splitProjectAndIssueType = (
 ): void => {
   const projectKeyAndIssueType = value.input[argName]
   if (projectKeyAndIssueType !== undefined
-    && projectKeyAndIssueType.includes(INPUT_SEPERATOR)
-    && value.dynamicPickListSelection[argName] !== undefined) {
+    && projectKeyAndIssueType.includes(INPUT_SEPERATOR)) {
     // The project key can't contain '-' sign while issueTypeName and projectName could.
     // So we split by first '-' in input args.
     const firstValue = projectKeyAndIssueType.split(INPUT_SEPERATOR, 1)[0]
@@ -73,7 +72,10 @@ const splitProjectAndIssueType = (
     value.input[firstKey] = firstValue
     value.input[secondKey] = secondValue
     delete value.input[argName]
-    delete value.dynamicPickListSelection[argName]
+    if (value.dynamicPickListSelection !== undefined
+      && value.dynamicPickListSelection[argName] !== undefined) {
+      delete value.dynamicPickListSelection[argName]
+    }
   }
 }
 

--- a/packages/workato-adapter/test/filters/project_issuetypes.test.ts
+++ b/packages/workato-adapter/test/filters/project_issuetypes.test.ts
@@ -138,12 +138,34 @@ describe('projectIssuetype filter', () => {
           description: '',
           keyword: 'action',
           dynamicPickListSelection: {
-            project_issuetype: 'projectInSecondBlockName : IssueType',
+            project_issuetype: {
+              ids: [
+                'projectInSecondBlockName@@PISB',
+                'PISB--IssueType',
+              ],
+              titles: [
+                'projectInSecondBlockName',
+                'projectInSecondBlockName : IssueType',
+              ],
+            },
           },
           input: {
             project_issuetype: 'PISB--IssueType',
             issuekey: 'issue key',
             reporter_id: "#{_('data.jira.recipeCode.fields.customfield_10027')}",
+          },
+          uuid: 'uuid3',
+        },
+        {
+          number: 4,
+          provider: 'jira',
+          name: 'update_issue',
+          as: 'recipeCode_second',
+          description: '',
+          keyword: 'action',
+          input: {
+            project_issuetype: 'CheckWithout--DynamicPickListSelction',
+            issuekey: 'issue key',
           },
           uuid: 'uuid3',
         },
@@ -193,6 +215,10 @@ describe('projectIssuetype filter', () => {
       expect(recipeCode.value.block[1].input.projectKey).toBeUndefined()
       expect(recipeCode.value.block[1].input.issueType).toBeUndefined()
 
+      expect(recipeCode.value.block[2].input.project_issuetype).toBeDefined()
+      expect(recipeCode.value.block[2].input.projectKey).toBeUndefined()
+      expect(recipeCode.value.block[2].input.issueType).toBeUndefined()
+
       await filter.onFetch(elements)
 
       expect(recipeCode.value.block[0].block[0].input.project_issuetype).toBeUndefined()
@@ -206,6 +232,12 @@ describe('projectIssuetype filter', () => {
       expect(recipeCode.value.block[1].input.projectKey).toEqual('PISB')
       expect(recipeCode.value.block[1].input.issueType).toBeDefined()
       expect(recipeCode.value.block[1].input.issueType).toEqual('IssueType')
+
+      expect(recipeCode.value.block[2].input.project_issuetype).toBeUndefined()
+      expect(recipeCode.value.block[2].input.projectKey).toBeDefined()
+      expect(recipeCode.value.block[2].input.projectKey).toEqual('CheckWithout')
+      expect(recipeCode.value.block[2].input.issueType).toBeDefined()
+      expect(recipeCode.value.block[2].input.issueType).toEqual('DynamicPickListSelction')
     })
 
     it('should replace \'sample_project_issuetype\' to sampleProjectKey and sampleIssueType at input', async () => {


### PR DESCRIPTION
In  Workato Adapter - Jira recipe. allow split project_issuetype even if dynamicPickListSelction not contained.

---

This is fix for the PR here - https://github.com/salto-io/salto/pull/4602
needed because Workato change interface

---
_Release Notes_: 
Workato adapter
- jira-connected input arguments. now splitting project_issuetype and sample_project_issuetype even if dynamicPickLiseSelection isn't exist.
 

---
_User Notifications_: 
- From now, you will see the projectKey and IssueType instead of project_issuetype even if dynamicPickListSelction is not exist
