### PR TITLE
SALTO-4311 - Zendesk Adapter - Fix type of missing instances in article body

### DIFF
--- a/packages/zendesk-adapter/src/filters/article/article_body.ts
+++ b/packages/zendesk-adapter/src/filters/article/article_body.ts
@@ -48,14 +48,12 @@ const ELEMENTS_REGEXES = [
   [SECTIONS_FIELD, SECTION_TYPE_NAME],
   [ARTICLES_FIELD, ARTICLE_TYPE_NAME],
   [ARTICLE_ATTACHMENTS_FIELD, ARTICLE_ATTACHMENT_TYPE_NAME],
-].map(
-  ([field, type]) => ({
-    field,
-    type,
-    urlRegex: new RegExp(`(\\/${field}\\/\\d+)`),
-    idRegex: new RegExp(`(?<url>/${field}/)(?<id>\\d+)`),
-  })
-)
+].map(([field, type]) => ({
+  field,
+  type,
+  urlRegex: new RegExp(`(\\/${field}\\/\\d+)`),
+  idRegex: new RegExp(`(?<url>/${field}/)(?<id>\\d+)`),
+}))
 
 const URL_REGEX = /(https?:[0-9a-zA-Z;,/?:@&=+$-_.!~*'()#]+)/
 const DOMAIN_REGEX = /(https:\/\/[^/]+)/

--- a/packages/zendesk-adapter/src/filters/article/article_body.ts
+++ b/packages/zendesk-adapter/src/filters/article/article_body.ts
@@ -43,9 +43,15 @@ const { createMissingInstance } = referencesUtils
 
 const BODY_FIELD = 'body'
 
-const ELEMENTS_REGEXES = [CATEGORIES_FIELD, SECTIONS_FIELD, ARTICLES_FIELD, ARTICLE_ATTACHMENTS_FIELD].map(
-  field => ({
+const ELEMENTS_REGEXES = [
+  [CATEGORIES_FIELD, CATEGORY_TYPE_NAME],
+  [SECTIONS_FIELD, SECTION_TYPE_NAME],
+  [ARTICLES_FIELD, ARTICLE_TYPE_NAME],
+  [ARTICLE_ATTACHMENTS_FIELD, ARTICLE_ATTACHMENT_TYPE_NAME],
+].map(
+  ([field, type]) => ({
     field,
+    type,
     urlRegex: new RegExp(`(\\/${field}\\/\\d+)`),
     idRegex: new RegExp(`(?<url>/${field}/)(?<id>\\d+)`),
   })
@@ -61,12 +67,12 @@ type missingBrandInfo = {
 }
 
 // Attempt to match the regex to an element and create a reference to that element
-const createInstanceReference = ({ urlPart, urlBrandInstance, idToInstance, idRegex, field, enableMissingReferences }: {
+const createInstanceReference = ({ urlPart, urlBrandInstance, idToInstance, idRegex, type, enableMissingReferences }: {
   urlPart: string
   urlBrandInstance: InstanceElement
   idToInstance: Record<string, InstanceElement>
   idRegex: RegExp
-  field: string
+  type: string
   enableMissingReferences?: boolean
 }): TemplatePart[] | undefined => {
   const { url, id } = urlPart.match(idRegex)?.groups ?? {}
@@ -82,7 +88,7 @@ const createInstanceReference = ({ urlPart, urlBrandInstance, idToInstance, idRe
     }
     // if could not find a valid instance, create a MissingReferences.
     if (enableMissingReferences) {
-      const missingInstance = createMissingInstance(ZENDESK, field, `${urlBrandInstance.value.name}_${id}`)
+      const missingInstance = createMissingInstance(ZENDESK, type, `${urlBrandInstance.value.name}_${id}`)
       missingInstance.value.id = id
       return [url, new ReferenceExpression(missingInstance.elemID, missingInstance)]
     }
@@ -103,13 +109,13 @@ const referenceUrls = ({ urlPart, urlBrandInstance, additionalInstances, enableM
   }
 
   // Attempt to match other instances, stop on the first result
-  const result = wu(ELEMENTS_REGEXES).map(({ idRegex, field }) =>
+  const result = wu(ELEMENTS_REGEXES).map(({ idRegex, field, type }) =>
     createInstanceReference({
       urlPart,
       urlBrandInstance,
       idToInstance: additionalInstances[field],
       idRegex,
-      field,
+      type,
       enableMissingReferences,
     })).find(isDefined)
 

--- a/packages/zendesk-adapter/test/filters/article/article_body.test.ts
+++ b/packages/zendesk-adapter/test/filters/article/article_body.test.ts
@@ -18,12 +18,11 @@ import { ElemID, InstanceElement, ObjectType,
 import { filterUtils, references as referencesUtils } from '@salto-io/adapter-components'
 import filterCreator from '../../../src/filters/article/article_body'
 import {
-  ARTICLE_ATTACHMENT_TYPE_NAME, ARTICLE_ATTACHMENTS_FIELD,
+  ARTICLE_ATTACHMENT_TYPE_NAME,
   ARTICLE_TYPE_NAME,
-  ARTICLES_FIELD,
-  BRAND_TYPE_NAME, CATEGORIES_FIELD,
+  BRAND_TYPE_NAME,
   CATEGORY_TYPE_NAME,
-  SECTION_TYPE_NAME, SECTIONS_FIELD,
+  SECTION_TYPE_NAME,
   ZENDESK,
 } from '../../../src/constants'
 import { createFilterCreatorParams } from '../../utils'
@@ -204,10 +203,10 @@ describe('article body filter', () => {
       it('should only match elements that exists in the matched brand', async () => {
         const filterResult = await filter.onFetch(elements) as FilterResult
         const brandName = emptyBrandInstance.value.name
-        const missingArticleInstance = createMissingInstance(ZENDESK, ARTICLES_FIELD, `${brandName}_124`)
-        const missingSectionInstance = createMissingInstance(ZENDESK, SECTIONS_FIELD, `${brandName}_123`)
-        const missingCategoryInstance = createMissingInstance(ZENDESK, CATEGORIES_FIELD, `${brandName}_123`)
-        const missingArticleAttachmentInstance = createMissingInstance(ZENDESK, ARTICLE_ATTACHMENTS_FIELD, `${brandName}_123`)
+        const missingArticleInstance = createMissingInstance(ZENDESK, ARTICLE_TYPE_NAME, `${brandName}_124`)
+        const missingSectionInstance = createMissingInstance(ZENDESK, SECTION_TYPE_NAME, `${brandName}_123`)
+        const missingCategoryInstance = createMissingInstance(ZENDESK, CATEGORY_TYPE_NAME, `${brandName}_123`)
+        const missingArticleAttachmentInstance = createMissingInstance(ZENDESK, ARTICLE_ATTACHMENT_TYPE_NAME, `${brandName}_123`)
         missingArticleInstance.value.id = '124'
         missingSectionInstance.value.id = '123'
         missingCategoryInstance.value.id = '123'


### PR DESCRIPTION
Use the type name instead of the type field

---

None

---
_Release Notes_: 
Zendesk Adapter:
* Missing instances in article body will have the correct type

---
_User Notifications_: 
Zendesk Adapters:
* article_translations with reference expressions in their body will change, the typename will change from plural to singular (eg articles -> article)