### PR TITLE
SALTO-4324 do not allow returning Error in DeployResult

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -54,18 +54,12 @@ type SaltoDeployErrors = {
   errors: ReadonlyArray<SaltoError | SaltoElementError>
 }
 
-type AdapterDeployErrors = {
-  errors: ReadonlyArray<SaltoError | SaltoElementError | Error>
-}
-
 type BaseDeployResult = {
   appliedChanges: ReadonlyArray<Change>
   extraProperties?: DeployExtraProperties
 }
 
-export type AdapterDeployResult = SaltoDeployErrors & BaseDeployResult
-
-export type DeployResult = AdapterDeployErrors & BaseDeployResult
+export type DeployResult = SaltoDeployErrors & BaseDeployResult
 
 export type Progress = {
   message: string

--- a/packages/adapter-utils/src/filter.ts
+++ b/packages/adapter-utils/src/filter.ts
@@ -145,7 +145,7 @@ export const filtersRunner = <
         {
           deployResult: {
             appliedChanges: [] as ReadonlyArray<Change>,
-            errors: [] as ReadonlyArray<SaltoError | SaltoElementError | Error>,
+            errors: [] as ReadonlyArray<SaltoError | SaltoElementError>,
           },
           leftoverChanges: changes,
         }

--- a/packages/core/src/core/deploy/deploy_actions.ts
+++ b/packages/core/src/core/deploy/deploy_actions.ts
@@ -18,7 +18,7 @@ import {
   AdapterOperations, getChangeData, Change,
   isAdditionOrModificationChange,
   DeployExtraProperties, DeployOptions, Group,
-  SaltoElementError, SaltoError, SeverityLevel, AdapterDeployResult, DeployResult, ChangeDataType,
+  SaltoElementError, SaltoError, SeverityLevel, DeployResult, ChangeDataType,
 } from '@salto-io/adapter-api'
 import { detailedCompare, applyDetailedChanges } from '@salto-io/adapter-utils'
 import { WalkError, NodeSkippedError } from '@salto-io/dag'
@@ -45,33 +45,15 @@ const addElemIDsToError = (
   ))
   )
 
-const extractErrors = (
-  result: DeployResult,
-  changes: readonly Change<ChangeDataType>[]
-): ReadonlyArray<SaltoElementError | SaltoError> =>
-  result.errors.flatMap(error =>
-    (error instanceof Error
-      ? addElemIDsToError(changes, error)
-      : error))
-
-
 const deployOrValidate = async (
   { adapter, adapterName, opts, checkOnly }: DeployOrValidateParams
-): Promise<AdapterDeployResult> => {
+): Promise<DeployResult> => {
   const deployOrValidateFn = checkOnly ? adapter.validate?.bind(adapter) : adapter.deploy.bind(adapter)
   if (deployOrValidateFn === undefined) {
     throw new Error(`${checkOnly ? 'Check-Only deployment' : 'Deployment'} is not supported in adapter ${adapterName}`)
   }
   try {
-    const result = await deployOrValidateFn(opts)
-    const failedChanges = opts.changeGroup.changes.filter(
-      change => !result.appliedChanges.some(c => getChangeData(c) === getChangeData(change))
-    )
-    return {
-      appliedChanges: result.appliedChanges,
-      extraProperties: result.extraProperties,
-      errors: extractErrors(result, failedChanges),
-    }
+    return await deployOrValidateFn(opts)
   } catch (error) {
     log.warn('adapter threw exception during deploy or validate, attaching to all elements in group: %o', error)
     return {
@@ -85,7 +67,7 @@ const deployAction = async (
   planItem: PlanItem,
   adapters: Record<string, AdapterOperations>,
   checkOnly: boolean
-): Promise<AdapterDeployResult> => {
+): Promise<DeployResult> => {
   const changes = [...planItem.changes()]
   const adapterName = getChangeData(changes[0]).elemID.adapter
   const adapter = adapters[adapterName]

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -426,7 +426,7 @@ describe('api.ts', () => {
         mockAdapterOps.deploy.mockImplementationOnce(async ({ changeGroup }) => ({
           appliedChanges: changeGroup.changes.filter(isModificationChange),
           errors: [
-            new Error('cannot add new employee'),
+            { message: 'cannot add new employee', severity: 'Error' as SeverityLevel, elemID: newEmployee.elemID },
             { message: 'cannot add new employee', severity: 'Error' as SeverityLevel },
           ],
         }))

--- a/packages/jira-adapter/src/deployment/jsp_deployment.ts
+++ b/packages/jira-adapter/src/deployment/jsp_deployment.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { AdditionChange, Change, DeployResult, getChangeData, InstanceElement, isAdditionChange, isInstanceChange, isModificationChange, isRemovalChange, Values } from '@salto-io/adapter-api'
+import { AdditionChange, Change, DeployResult, getChangeData, InstanceElement, isAdditionChange, isInstanceChange, isModificationChange, isRemovalChange, SeverityLevel, Values } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { resolveValues, safeJsonStringify } from '@salto-io/adapter-utils'
@@ -205,7 +205,7 @@ const verifyDeployment = async (
 
   deployResult.errors = [
     ...deployResult.errors,
-    ...invalidChanges.map(change => new Error(`Failed to deploy ${getChangeData(change).elemID.getFullName()}`)),
+    ...invalidChanges.map(change => ({ message: `Failed to deploy ${getChangeData(change).elemID.getFullName()}`, severity: 'Error' as SeverityLevel, elemID: getChangeData(change).elemID })),
   ]
 }
 
@@ -256,7 +256,7 @@ export const deployWithJspEndpoints = async ({
       log.error(`Failed to query service values: ${err}`)
       deployResult.errors = [
         ...deployResult.errors,
-        ...deployResult.appliedChanges.map(change => new Error(`Failed to deploy ${getChangeData(change).elemID.getFullName()}`)),
+        ...deployResult.appliedChanges.map(change => ({ message: `Failed to deploy ${getChangeData(change).elemID.getFullName()}`, severity: 'Error' as SeverityLevel, elemID: getChangeData(change).elemID })),
       ]
       deployResult.appliedChanges = []
     }

--- a/packages/jira-adapter/test/filters/notification_scheme/notification_scheme_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/notification_scheme/notification_scheme_deployment.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, InstanceElement, ListType, ObjectType, toChange, Values } from '@salto-io/adapter-api'
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, InstanceElement, ListType, ObjectType, SeverityLevel, toChange, Values } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
 import { MockInterface } from '@salto-io/test-utils'
@@ -422,7 +422,7 @@ describe('notificationSchemeDeploymentFilter', () => {
 
       deployWithJspEndpointsMock.mockImplementationOnce(async () => ({
         appliedChanges: [],
-        errors: [new Error('someError')],
+        errors: [{ message: 'someError', severity: 'Error' as SeverityLevel }],
       }))
 
       const { deployResult } = await filter.deploy([

--- a/packages/jira-adapter/test/filters/security_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/security_scheme.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, getChangeData, InstanceElement, isReferenceExpression, ListType, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, getChangeData, InstanceElement, isReferenceExpression, ListType, ObjectType, ReferenceExpression, SeverityLevel, toChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
 import { MockInterface } from '@salto-io/test-utils'
@@ -368,7 +368,7 @@ describe('securitySchemeFilter', () => {
       it('should return the error from deployWithJspEndpoints when deploying the schemes', async () => {
         deployWithJspEndpointsMock.mockResolvedValue({
           appliedChanges: [],
-          errors: [new Error('error')],
+          errors: [{ message: 'error', severity: 'Error' as SeverityLevel }],
         })
 
         const { deployResult } = await filter.deploy([
@@ -389,7 +389,7 @@ describe('securitySchemeFilter', () => {
         }))
         deployWithJspEndpointsMock.mockResolvedValueOnce({
           appliedChanges: [],
-          errors: [new Error('error')],
+          errors: [{ message: 'error', severity: 'Error' as SeverityLevel }],
         })
 
         const { deployResult } = await filter.deploy([

--- a/packages/zendesk-adapter/src/filters/guide_order/guide_order_utils.ts
+++ b/packages/zendesk-adapter/src/filters/guide_order/guide_order_utils.ts
@@ -172,7 +172,7 @@ export const deployOrderChanges = async ({ changes, client, config, orderField }
   config: FilterContext
   orderField: string
 }) : Promise<DeployResult> => {
-  const orderChangeErrors: (Error | SaltoElementError)[] = []
+  const orderChangeErrors: (SaltoElementError)[] = []
   const appliedChanges: Change[] = []
 
   await awu(changes).forEach(async change => {


### PR DESCRIPTION
From this point on, only SaltoError or SaltoElementError can be returned as errors from adapters. Errors can and should be thrown for exceptions and unexpected scenarios.

---

Also touched specific adapters that did not conform 100%

---

_Release Notes_: _None_

---

_User Notifications_: _None_