### PR TITLE
SALTO-4456: Add flag to CLI restore to also restore paths

### DIFF
--- a/packages/cli/src/commands/restore.ts
+++ b/packages/cli/src/commands/restore.ts
@@ -156,7 +156,7 @@ export const action: WorkspaceCommandAction<RestoreArgs> = async ({
     detailedPlan, listPlannedChanges, accounts, mode, reorganizeDirStructure,
   } = input
   if (elementSelectors.length > 0 && reorganizeDirStructure) {
-    errorOutputLine(Prompts.RESTORE_PATHS_WITH_ELEMENT_SELECTORS, output)
+    errorOutputLine(Prompts.REORGANIZE_DIR_STRUCTURE_WITH_ELEMENT_SELECTORS, output)
     return CliExitCode.UserInputError
   }
 

--- a/packages/cli/src/commands/restore.ts
+++ b/packages/cli/src/commands/restore.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import { Workspace, nacl, createElementSelectors } from '@salto-io/workspace'
 import { EOL } from 'os'
 import { logger } from '@salto-io/logging'
-import { CommandConfig, LocalChange, restore } from '@salto-io/core'
+import { CommandConfig, LocalChange, restore, restorePaths as restorePathsCore } from '@salto-io/core'
 import { getChangeData, isRemovalChange } from '@salto-io/adapter-api'
 import { collections, promises, values } from '@salto-io/lowerdash'
 import { CliOutput, CliExitCode, CliTelemetry } from '../types'
@@ -72,6 +72,7 @@ type RestoreArgs = {
     dryRun: boolean
     detailedPlan: boolean
     listPlannedChanges: boolean
+    restorePaths?: boolean
 } & AccountsArg & EnvArg & UpdateModeArg
 
 const applyLocalChangesToWorkspace = async (
@@ -152,8 +153,13 @@ export const action: WorkspaceCommandAction<RestoreArgs> = async ({
 }): Promise<CliExitCode> => {
   const {
     elementSelectors = [], force, dryRun,
-    detailedPlan, listPlannedChanges, accounts, mode,
+    detailedPlan, listPlannedChanges, accounts, mode, restorePaths,
   } = input
+  if (elementSelectors.length > 0 && restorePaths) {
+    errorOutputLine(Prompts.RESTORE_PATHS_WITH_ELEMENT_SELECTORS, output)
+    return CliExitCode.UserInputError
+  }
+
   const { validSelectors, invalidSelectors } = createElementSelectors(elementSelectors)
   if (!_.isEmpty(invalidSelectors)) {
     errorOutputLine(formatInvalidFilters(invalidSelectors), output)
@@ -177,9 +183,16 @@ export const action: WorkspaceCommandAction<RestoreArgs> = async ({
   outputLine(EOL, output)
   outputLine(formatStepStart(Prompts.RESTORE_CALC_DIFF_START), output)
 
-  const changes = await restore(workspace, activeAccounts, validSelectors)
+  let changes: LocalChange[] | undefined
+  const getRestoreChanges = async (): Promise<LocalChange[]> => {
+    if (changes === undefined) {
+      changes = await restore(workspace, activeAccounts, validSelectors)
+    }
+    return changes
+  }
+
   if (listPlannedChanges || dryRun) {
-    await printRestorePlan(changes, detailedPlan, output)
+    await printRestorePlan(await getRestoreChanges(), detailedPlan, output)
   }
 
   outputLine(formatStepCompleted(Prompts.RESTORE_CALC_DIFF_FINISH), output)
@@ -188,7 +201,7 @@ export const action: WorkspaceCommandAction<RestoreArgs> = async ({
     return CliExitCode.Success
   }
 
-  if (_.isEmpty(changes)) {
+  if (!restorePaths && _.isEmpty(await getRestoreChanges())) {
     outputLine(EOL, output)
     outputLine(Prompts.FETCH_NO_CHANGES, output)
     return CliExitCode.Success
@@ -199,8 +212,12 @@ export const action: WorkspaceCommandAction<RestoreArgs> = async ({
     return CliExitCode.Success
   }
 
+  const changesToApply = restorePaths
+    ? await restorePathsCore(workspace, accounts)
+    : await getRestoreChanges()
+
   const updatingWsSucceeded = await applyLocalChangesToWorkspace(
-    changes,
+    changesToApply,
     workspace,
     cliTelemetry,
     config,
@@ -252,6 +269,13 @@ const restoreDef = createWorkspaceCommand({
         name: 'listPlannedChanges',
         alias: 'l',
         description: 'Print a summary of the planned changes',
+        type: 'boolean',
+      },
+      {
+        name: 'restorePaths',
+        alias: 'r',
+        description: 'Restore the elements to their original path',
+        required: false,
         type: 'boolean',
       },
       ACCOUNTS_OPTION,

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -216,7 +216,7 @@ ${Prompts.ACCOUNT_ADD_HELP}`
   public static readonly RESTORE_SUCCESS_FINISHED = 'Done! Your NaCL files are now updated with the latest changes.'
   public static readonly RESTORE_UPDATE_WORKSPACE_FAIL = 'Failed to apply changes to your NaCL files.'
   public static readonly SHOULD_EXECUTE_RESTORE = 'Do you want to restore?'
-  public static readonly RESTORE_PATHS_WITH_ELEMENT_SELECTORS = 'Restore paths flag with element selectors is not supported'
+  public static readonly REORGANIZE_DIR_STRUCTURE_WITH_ELEMENT_SELECTORS = 'Reorganize dir structure flag with element selectors is not supported'
   public static readonly INVALID_FILTERS = (
     invalidFilters: string
   ): string => `Failed to created element ID filters for: ${invalidFilters}. Invalid Regex provided.`

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -216,6 +216,7 @@ ${Prompts.ACCOUNT_ADD_HELP}`
   public static readonly RESTORE_SUCCESS_FINISHED = 'Done! Your NaCL files are now updated with the latest changes.'
   public static readonly RESTORE_UPDATE_WORKSPACE_FAIL = 'Failed to apply changes to your NaCL files.'
   public static readonly SHOULD_EXECUTE_RESTORE = 'Do you want to restore?'
+  public static readonly RESTORE_PATHS_WITH_ELEMENT_SELECTORS = 'Restore paths flag with element selectors is not supported'
   public static readonly INVALID_FILTERS = (
     invalidFilters: string
   ): string => `Failed to created element ID filters for: ${invalidFilters}. Invalid Regex provided.`

--- a/packages/cli/test/commands/restore.test.ts
+++ b/packages/cli/test/commands/restore.test.ts
@@ -593,7 +593,7 @@ describe('restore command', () => {
         workspace,
       })
 
-      expect(output.stderr.content).toContain(Prompts.RESTORE_PATHS_WITH_ELEMENT_SELECTORS)
+      expect(output.stderr.content).toContain(Prompts.REORGANIZE_DIR_STRUCTURE_WITH_ELEMENT_SELECTORS)
       expect(result).toBe(CliExitCode.UserInputError)
     })
   })

--- a/packages/cli/test/commands/restore.test.ts
+++ b/packages/cli/test/commands/restore.test.ts
@@ -49,6 +49,7 @@ describe('restore command', () => {
   let telemetry: mocks.MockTelemetry
   let output: mocks.MockCliOutput
   let mockRestore: jest.MockedFunction<typeof restore>
+  let mockRestorePaths: jest.MockedFunction<typeof restorePaths>
   let mockGetUserBooleanInput: jest.MockedFunction<typeof getUserBooleanInput>
 
   beforeEach(() => {
@@ -59,6 +60,11 @@ describe('restore command', () => {
     mockRestore = restore as typeof mockRestore
     mockRestore.mockReset()
     mockRestore.mockResolvedValue(
+      mocks.dummyChanges.map(change => ({ change, serviceChanges: [change] }))
+    )
+    mockRestorePaths = restorePaths as typeof mockRestorePaths
+    mockRestorePaths.mockReset()
+    mockRestorePaths.mockResolvedValue(
       mocks.dummyChanges.map(change => ({ change, serviceChanges: [change] }))
     )
     mockGetUserBooleanInput = getUserBooleanInput as typeof mockGetUserBooleanInput
@@ -544,7 +550,7 @@ describe('restore command', () => {
   })
 
   describe('restore paths', () => {
-    it('should not warn of added static files with content', async () => {
+    it('should call the restorePaths api', async () => {
       const workspace = mocks.mockWorkspace({})
 
       const result = await action({
@@ -556,13 +562,16 @@ describe('restore command', () => {
           listPlannedChanges: false,
           mode: 'default',
           accounts,
-          restorePaths: true,
+          reorganizeDirStructure: true,
         },
         workspace,
       })
 
       expect(restorePaths).toHaveBeenCalled()
       expect(restore).not.toHaveBeenCalled()
+
+      expect(workspace.updateNaclFiles).toHaveBeenCalledWith(mocks.dummyChanges, 'default')
+
       expect(result).toBe(CliExitCode.Success)
     })
 
@@ -579,7 +588,7 @@ describe('restore command', () => {
           listPlannedChanges: false,
           mode: 'default',
           accounts,
-          restorePaths: true,
+          reorganizeDirStructure: true,
         },
         workspace,
       })

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -525,7 +525,7 @@ export const restorePaths = async (
   workspace: Workspace,
   accounts?: string[],
 ): Promise<LocalChange[]> => (await createRestorePathChanges(
-  await workspace.elements(),
+  await awu(await (await workspace.elements()).getAll()).toArray(),
   await workspace.state().getPathIndex(),
   accounts,
 )).map(change => ({ change, serviceChanges: [change] }))

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -63,7 +63,7 @@ import {
   calcFetchChanges,
 } from './core/fetch'
 import { defaultDependencyChangers } from './core/plan/plan'
-import { createRestoreChanges } from './core/restore'
+import { createRestoreChanges, createRestorePathChanges } from './core/restore'
 import { getAdapterChangeGroupIdFunctions } from './core/adapters/custom_group_key'
 import { createDiffChanges } from './core/diff'
 import getChangeValidators from './core/plan/change_validators'
@@ -520,6 +520,15 @@ export async function restore(
   )
   return detailedChanges.map(change => ({ change, serviceChanges: [change] }))
 }
+
+export const restorePaths = async (
+  workspace: Workspace,
+  accounts?: string[],
+): Promise<LocalChange[]> => (await createRestorePathChanges(
+  await workspace.elements(),
+  await workspace.state().getPathIndex(),
+  accounts,
+)).map(change => ({ change, serviceChanges: [change] }))
 
 export function diff(
   workspace: Workspace,

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -60,6 +60,15 @@ jest.mock('../src/core/restore', () => ({
       }]
       : detailedChanges
   }),
+  createRestorePathChanges: jest.fn().mockResolvedValue([{
+    action: 'add',
+    data: { after: 'value' },
+    detailedChanges: () => [{
+      action: 'add',
+      data: { after: 'value' },
+      path: ['path'],
+    }],
+  }]),
 }))
 
 jest.mock('../src/core/diff', () => ({
@@ -719,6 +728,20 @@ describe('api.ts', () => {
       const changes = await api.restore(ws, undefined, undefined, 'changes')
       expect(changes).toHaveLength(1)
       expect(_.keys(changes[0])).toEqual(['action', 'data', 'detailedChanges'])
+    })
+  })
+
+  describe('restorePaths', () => {
+    it('should return all changes as local changes', async () => {
+      const ws = mockWorkspace({
+        elements: [],
+        name: 'restore',
+        index: [],
+        stateElements: [],
+      })
+      const changes = await api.restorePaths(ws)
+      expect(changes).toHaveLength(1)
+      expect(_.keys(changes[0])).toEqual(['change', 'serviceChanges'])
     })
   })
 

--- a/packages/core/test/core/restore.test.ts
+++ b/packages/core/test/core/restore.test.ts
@@ -13,10 +13,10 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Element, ObjectType, ElemID, BuiltinTypes, ListType, InstanceElement, DetailedChange, isAdditionChange, isRemovalChange, isModificationChange } from '@salto-io/adapter-api'
+import { Element, ObjectType, ElemID, BuiltinTypes, ListType, InstanceElement, DetailedChange, isAdditionChange, isRemovalChange, isModificationChange, getChangeData } from '@salto-io/adapter-api'
 import { merger, pathIndex, remoteMap } from '@salto-io/workspace'
 import { collections } from '@salto-io/lowerdash'
-import { createRestoreChanges } from '../../src/core/restore'
+import { createRestoreChanges, createRestorePathChanges } from '../../src/core/restore'
 import { createElementSource } from '../common/helpers'
 import { ChangeWithDetails } from '../../src/core/plan/plan_item'
 
@@ -311,6 +311,90 @@ describe('restore', () => {
         expect(changes).toHaveLength(1)
         expect(changes[0].detailedChanges()).toHaveLength(1)
       })
+    })
+  })
+
+  describe('restorePaths', () => {
+    let type: ObjectType
+
+    beforeAll(async () => {
+      type = new ObjectType({
+        elemID: new ElemID('salto', 'type'),
+        fields: {
+          field1: { refType: BuiltinTypes.STRING },
+          field2: { refType: BuiltinTypes.STRING },
+        },
+      })
+
+      index = new remoteMap.InMemoryRemoteMap<pathIndex.Path[]>()
+      await index.set(type.elemID.getFullName(), [
+        ['salto', 'type', 'field1'],
+        ['salto', 'type', 'field2'],
+      ])
+      await index.set(type.fields.field1.elemID.getFullName(), [
+        ['salto', 'type', 'field1'],
+      ])
+      await index.set(type.fields.field2.elemID.getFullName(), [
+        ['salto', 'type', 'field2'],
+      ])
+    })
+    it('should create deletion and addition references', async () => {
+      const changes = await createRestorePathChanges(
+        createElementSource([type]),
+        index,
+      )
+
+      expect(changes).toHaveLength(3)
+      const [removalChange, additionChange1, additionChange2] = changes
+
+      expect(isRemovalChange(removalChange)).toBeTruthy()
+      expect(removalChange.id).toEqual(type.elemID)
+
+      expect(isAdditionChange(additionChange1)).toBeTruthy()
+      expect(additionChange1.id).toEqual(type.elemID)
+      expect(additionChange1.path).toEqual(['salto', 'type', 'field1'])
+      expect(getChangeData(additionChange1)).toHaveProperty('fields.field1')
+      expect(getChangeData(additionChange1)).not.toHaveProperty('fields.field2')
+
+      expect(isAdditionChange(additionChange2)).toBeTruthy()
+      expect(additionChange2.id).toEqual(type.elemID)
+      expect(additionChange2.path).toEqual(['salto', 'type', 'field2'])
+      expect(getChangeData(additionChange2)).toHaveProperty('fields.field2')
+      expect(getChangeData(additionChange2)).not.toHaveProperty('fields.field1')
+    })
+
+    it('should restore only the requested accounts', async () => {
+      const type2 = new ObjectType({
+        elemID: new ElemID('salto2', 'type2'),
+      })
+
+      await index.set(type2.elemID.getFullName(), [
+        ['salto2', 'type2'],
+      ])
+
+      const changes = await createRestorePathChanges(
+        createElementSource([type, type2]),
+        index,
+        ['salto'],
+      )
+
+      expect(changes).toHaveLength(3)
+      const [removalChange, additionChange1, additionChange2] = changes
+
+      expect(isRemovalChange(removalChange)).toBeTruthy()
+      expect(removalChange.id).toEqual(type.elemID)
+
+      expect(isAdditionChange(additionChange1)).toBeTruthy()
+      expect(additionChange1.id).toEqual(type.elemID)
+      expect(additionChange1.path).toEqual(['salto', 'type', 'field1'])
+      expect(getChangeData(additionChange1)).toHaveProperty('fields.field1')
+      expect(getChangeData(additionChange1)).not.toHaveProperty('fields.field2')
+
+      expect(isAdditionChange(additionChange2)).toBeTruthy()
+      expect(additionChange2.id).toEqual(type.elemID)
+      expect(additionChange2.path).toEqual(['salto', 'type', 'field2'])
+      expect(getChangeData(additionChange2)).toHaveProperty('fields.field2')
+      expect(getChangeData(additionChange2)).not.toHaveProperty('fields.field1')
     })
   })
 })

--- a/packages/core/test/core/restore.test.ts
+++ b/packages/core/test/core/restore.test.ts
@@ -340,7 +340,7 @@ describe('restore', () => {
     })
     it('should create deletion and addition references', async () => {
       const changes = await createRestorePathChanges(
-        createElementSource([type]),
+        [type],
         index,
       )
 
@@ -373,7 +373,7 @@ describe('restore', () => {
       ])
 
       const changes = await createRestorePathChanges(
-        createElementSource([type, type2]),
+        [type, type2],
         index,
         ['salto'],
       )


### PR DESCRIPTION
Added flag to CLI restore to also restore paths

---

The way to restore paths currently is to delete and re-add all the elements in the workspace.
I added another API in core to do that.

---
_Release Notes_: 
CLI:
- Added `-r` flag to restore to also restore elements to their original paths

---
_User Notifications_: 
None