### PR TITLE
SALTO-4356 improve splitElementByPath complexity 

### DIFF
--- a/packages/adapter-api/src/element_id.ts
+++ b/packages/adapter-api/src/element_id.ts
@@ -155,7 +155,7 @@ export class ElemID {
       // First name part is the instance name which is top level
       return this.nameParts.length - 1
     }
-    if (this.isAnnotationTypeID()) {
+    if (this.isIDNestedInType()) {
       // annotation/attr/field are already 1 level nested
       return this.nameParts.length + 1
     }

--- a/packages/adapter-api/src/element_id.ts
+++ b/packages/adapter-api/src/element_id.ts
@@ -156,7 +156,7 @@ export class ElemID {
       return this.nameParts.length - 1
     }
     if (this.isAnnotationTypeID()) {
-      // annotation is already 1 level nested
+      // annotation/attr/field are already 1 level nested
       return this.nameParts.length + 1
     }
     return this.nameParts.length

--- a/packages/adapter-api/src/element_id.ts
+++ b/packages/adapter-api/src/element_id.ts
@@ -329,4 +329,10 @@ export class ElemID {
     }
     return undefined
   }
+
+  isIDNestedInType(): boolean {
+    // These id types represent "logical groups" of IDs that count towards the nesting level
+    // e.g - adapter.type.field.bla is nested under adapter.type.field
+    return this.idType === 'annotation' || this.idType === 'attr' || this.idType === 'field'
+  }
 }

--- a/packages/adapter-api/src/element_id.ts
+++ b/packages/adapter-api/src/element_id.ts
@@ -155,8 +155,8 @@ export class ElemID {
       // First name part is the instance name which is top level
       return this.nameParts.length - 1
     }
-    if (this.isIDNestedInType()) {
-      // annotation/attr/field are already 1 level nested
+    if (this.isAnnotationTypeID()) {
+      // annotation is already 1 level nested
       return this.nameParts.length + 1
     }
     return this.nameParts.length

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -39,7 +39,7 @@ import {
   getPath,
   getSubtypes,
   formatConfigSuggestionsReasons,
-  isResolvedReferenceExpression,
+  isResolvedReferenceExpression, FILTER_FUNC_NEXT_STEP,
 } from '../src/utils'
 import { buildElementsSourceFromElements } from '../src/element_source'
 
@@ -1814,6 +1814,7 @@ describe('Test utils.ts', () => {
       },
       primitive: PrimitiveTypes.STRING,
     })
+
     it('should filter object type', async () => {
       const expectEqualFields = (actual: FieldMap | undefined, expected: FieldMap): void => {
         expect(actual).toBeDefined()
@@ -1826,7 +1827,7 @@ describe('Test utils.ts', () => {
       const onlyFields = await filterByID(
         objElemID,
         obj,
-        async id => id.idType === 'type' || id.idType === 'field'
+        async id => (id.idType === 'type' || id.idType === 'field' ? FILTER_FUNC_NEXT_STEP.RECURSE : FILTER_FUNC_NEXT_STEP.EXCLUDE)
       )
       expect(onlyFields).toBeDefined()
       expectEqualFields(onlyFields?.fields, obj.fields)
@@ -1835,7 +1836,7 @@ describe('Test utils.ts', () => {
       const onlyAnno = await filterByID(
         objElemID,
         obj,
-        async id => id.idType === 'type' || id.idType === 'attr'
+        async id => (id.idType === 'type' || id.idType === 'attr' ? FILTER_FUNC_NEXT_STEP.RECURSE : FILTER_FUNC_NEXT_STEP.EXCLUDE)
       )
       expect(onlyAnno).toBeDefined()
       expect(onlyAnno?.fields).toEqual({})
@@ -1845,7 +1846,7 @@ describe('Test utils.ts', () => {
       const onlyAnnoType = await filterByID(
         objElemID,
         obj,
-        async id => id.idType === 'type' || id.idType === 'annotation'
+        async id => (id.idType === 'type' || id.idType === 'annotation' ? FILTER_FUNC_NEXT_STEP.RECURSE : FILTER_FUNC_NEXT_STEP.EXCLUDE)
       )
       expect(onlyAnnoType).toBeDefined()
       expect(onlyAnnoType?.fields).toEqual({})
@@ -1855,7 +1856,7 @@ describe('Test utils.ts', () => {
       const withoutAnnoObjStr = await filterByID(
         objElemID,
         obj,
-        async id => !id.getFullNameParts().includes('str')
+        async id => (!id.getFullNameParts().includes('str') ? FILTER_FUNC_NEXT_STEP.RECURSE : FILTER_FUNC_NEXT_STEP.EXCLUDE)
       )
       expect(withoutAnnoObjStr).toBeDefined()
       expectEqualFields(withoutAnnoObjStr?.fields, obj.fields)
@@ -1867,7 +1868,7 @@ describe('Test utils.ts', () => {
       const withoutFieldAnnotations = await filterByID(
         objElemID,
         obj,
-        async id => id.getFullName() !== 'salto.obj.field.obj.label'
+        async id => (id.getFullName() !== 'salto.obj.field.obj.label' ? FILTER_FUNC_NEXT_STEP.RECURSE : FILTER_FUNC_NEXT_STEP.EXCLUDE)
       )
 
       expect(withoutFieldAnnotations).toBeDefined()
@@ -1879,8 +1880,8 @@ describe('Test utils.ts', () => {
         objElemID,
         obj,
         async id => (
-          Number.isNaN(Number(_.last(id.getFullNameParts())))
-          || Number(_.last(id.getFullNameParts())) === 0
+          (Number.isNaN(Number(_.last(id.getFullNameParts()))) || Number(_.last(id.getFullNameParts())) === 0
+            ? FILTER_FUNC_NEXT_STEP.RECURSE : FILTER_FUNC_NEXT_STEP.EXCLUDE)
         )
       )
       expect(onlyI).toBeDefined()
@@ -1894,7 +1895,7 @@ describe('Test utils.ts', () => {
       const filteredPrim = await filterByID(
         prim.elemID,
         prim,
-        async id => !id.getFullNameParts().includes('str')
+        async id => (!id.getFullNameParts().includes('str') ? FILTER_FUNC_NEXT_STEP.RECURSE : FILTER_FUNC_NEXT_STEP.EXCLUDE)
       )
       expect(filteredPrim?.annotations.obj).toEqual({ num: 17 })
       expect(filteredPrim?.annotationRefTypes).toEqual({ obj: createRefToElmWithValue(annoType) })
@@ -1904,7 +1905,7 @@ describe('Test utils.ts', () => {
       const filteredInstance = await filterByID(
         inst.elemID,
         inst,
-        async id => !id.getFullNameParts().includes('list')
+        async id => (!id.getFullNameParts().includes('list') ? FILTER_FUNC_NEXT_STEP.RECURSE : FILTER_FUNC_NEXT_STEP.EXCLUDE)
       )
       expect(filteredInstance?.value).toEqual({ obj: inst.value.obj, map: inst.value.map })
       expect(filteredInstance?.annotations).toEqual(inst.annotations)
@@ -1922,7 +1923,7 @@ describe('Test utils.ts', () => {
       const filteredInstance = await filterByID(
         instance.elemID,
         instance,
-        async () => true
+        async () => FILTER_FUNC_NEXT_STEP.RECURSE
       )
       expect(filteredInstance?.value).toEqual({ emptyList: [], emptyObj: {} })
     })
@@ -1931,7 +1932,7 @@ describe('Test utils.ts', () => {
       const filteredInstance = await filterByID(
         inst.elemID,
         inst,
-        async id => id.idType !== 'instance'
+        async id => (id.idType !== 'instance' ? FILTER_FUNC_NEXT_STEP.RECURSE : FILTER_FUNC_NEXT_STEP.EXCLUDE)
       )
       expect(filteredInstance).toBeUndefined()
     })
@@ -1940,34 +1941,47 @@ describe('Test utils.ts', () => {
       const withoutList = await filterByID(
         inst.elemID,
         inst,
-        async id => Number.isNaN(Number(_.last(id.getFullNameParts())))
+        async id => (Number.isNaN(Number(_.last(id.getFullNameParts())))
+          ? FILTER_FUNC_NEXT_STEP.RECURSE : FILTER_FUNC_NEXT_STEP.EXCLUDE)
       )
       expect(withoutList?.value).toEqual({ obj: inst.value.obj, map: inst.value.map })
 
       const withoutObj = await filterByID(
         inst.elemID,
         inst,
-        async id => !id.getFullNameParts().includes('str') && !id.getFullNameParts().includes('num')
+        async id => (!id.getFullNameParts().includes('str') && !id.getFullNameParts().includes('num') ? FILTER_FUNC_NEXT_STEP.RECURSE : FILTER_FUNC_NEXT_STEP.EXCLUDE)
       )
       expect(withoutObj?.value).toEqual({ list: inst.value.list, map: inst.value.map })
 
       const withoutMap = await filterByID(
         inst.elemID,
         inst,
-        async id => !id.getFullNameParts().includes('Do'),
+        async id => (!id.getFullNameParts().includes('Do') ? FILTER_FUNC_NEXT_STEP.RECURSE : FILTER_FUNC_NEXT_STEP.EXCLUDE),
       )
       expect(withoutMap?.value).toEqual({ obj: inst.value.obj, list: inst.value.list })
     })
-
-    it('should not call filter function with invalid attr ID', async () => {
-      const filterFunc = jest.fn().mockResolvedValue(true)
-      await filterByID(
-        obj.elemID,
-        obj,
-        filterFunc
+    it('should include value that filterFunc returns INCLUDE for without recursing', async () => {
+      const includedID = inst.elemID.createNestedID('obj')
+      const filterFunc = jest.fn().mockImplementation(
+        async (id: ElemID): Promise<FILTER_FUNC_NEXT_STEP> => {
+          if (id.isParentOf(includedID)) {
+            return FILTER_FUNC_NEXT_STEP.RECURSE
+          }
+          if (id.isEqual(includedID)) {
+            return FILTER_FUNC_NEXT_STEP.INCLUDE
+          }
+          return FILTER_FUNC_NEXT_STEP.EXCLUDE
+        }
       )
-
-      expect(filterFunc).not.toHaveBeenCalledWith(obj.elemID.createNestedID('attr'))
+      const filteredInstance = await filterByID(
+        inst.elemID,
+        inst,
+        filterFunc,
+      )
+      expect(filteredInstance?.value).toEqual({ obj: inst.value.obj })
+      Object.keys(inst.value.obj).forEach(key => {
+        expect(filterFunc).not.toHaveBeenCalledWith(includedID.createNestedID(key))
+      })
     })
   })
   describe('Flat Values', () => {

--- a/packages/core/src/core/restore.ts
+++ b/packages/core/src/core/restore.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import { ElemID, DetailedChange, isRemovalChange } from '@salto-io/adapter-api'
 import { filterByID, applyFunctionToChangeData } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
-import { pathIndex, ElementSelector, elementSource, remoteMap } from '@salto-io/workspace'
+import { pathIndex, filterByPathHint, ElementSelector, elementSource, remoteMap } from '@salto-io/workspace'
 import { createDiffChanges } from './diff'
 import { ChangeWithDetails } from './plan/plan_item'
 
@@ -32,13 +32,9 @@ const splitDetailedChangeByPath = async (
     return [change]
   }
   return Promise.all(changeHints.map(async hint => {
-    const filterByPathHint = async (id: ElemID): Promise<boolean> => {
-      const idHints = await pathIndex.getFromPathIndex(id, index)
-      return idHints.some(idHint => _.isEqual(idHint, hint))
-    }
     const filteredChange = await applyFunctionToChangeData(
       change,
-      async changeData => filterByID(change.id, changeData, filterByPathHint),
+      async changeData => filterByID(change.id, changeData, id => filterByPathHint(index, hint, id)),
     )
     return {
       ...filteredChange,

--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -43,7 +43,7 @@ import { updateElementsWithAlternativeAccount, createAdapterReplacedID } from '.
 import { RemoteElementSource, ElementsSource } from './src/workspace/elements_source'
 import { FromSource } from './src/workspace/nacl_files/multi_env/multi_env_source'
 import { State } from './src/workspace/state'
-import { PathIndex, splitElementByPath, getElementsPathHints } from './src/workspace/path_index'
+import { PathIndex, splitElementByPath, getElementsPathHints, filterByPathHint } from './src/workspace/path_index'
 
 export {
   errors,
@@ -95,6 +95,7 @@ export {
   State,
   splitElementByPath,
   PathIndex,
+  filterByPathHint,
   getElementsPathHints,
   updateElementsWithAlternativeAccount,
   createAdapterReplacedID,

--- a/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
@@ -13,15 +13,33 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { getChangeData, ElemID, Value, DetailedChange, ChangeDataType, Element, isObjectType, isPrimitiveType, isInstanceElement, isField, isAdditionChange, isIndexPathPart } from '@salto-io/adapter-api'
-import _ from 'lodash'
-import { promises, values, collections } from '@salto-io/lowerdash'
-import { resolvePath, filterByID, detailedCompare, applyFunctionToChangeData, applyDetailedChanges } from '@salto-io/adapter-utils'
-import { logger } from '@salto-io/logging'
 import {
-  projectChange, projectElementOrValueToEnv, createAddChange, createRemoveChange,
-} from './projections'
-import { wrapAdditions, DetailedAddition, wrapNestedValues } from '../addition_wrapper'
+  ChangeDataType,
+  DetailedChange,
+  Element,
+  ElemID,
+  getChangeData,
+  isAdditionChange,
+  isField,
+  isIndexPathPart,
+  isInstanceElement,
+  isObjectType,
+  isPrimitiveType,
+  Value,
+} from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { collections, promises, values } from '@salto-io/lowerdash'
+import {
+  applyDetailedChanges,
+  applyFunctionToChangeData,
+  detailedCompare,
+  FILTER_FUNC_NEXT_STEP,
+  filterByID,
+  resolvePath,
+} from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+import { createAddChange, createRemoveChange, projectChange, projectElementOrValueToEnv } from './projections'
+import { DetailedAddition, wrapAdditions, wrapNestedValues } from '../addition_wrapper'
 import { NaclFilesSource, RoutingMode, toPathHint } from '../nacl_files_source'
 import { mergeElements } from '../../../merger'
 
@@ -66,16 +84,22 @@ const filterByFile = async (
   valueID: ElemID,
   value: Value,
   fileElements: Element[],
-): Promise<Value> => filterByID(
-  valueID,
-  value,
-  async id => !_.isEmpty((fileElements).filter(
-    e => resolvePath(
-      e,
-      getMergeableParentID(id, fileElements).mergeableID
-    ) !== undefined
-  ))
-)
+): Promise<Value> => {
+  const filterByMergeable = async (id: ElemID): Promise<FILTER_FUNC_NEXT_STEP> => {
+    const result = !_.isEmpty((fileElements).filter(
+      e => resolvePath(e, getMergeableParentID(id, fileElements).mergeableID) !== undefined
+    ))
+    if (result) {
+      return FILTER_FUNC_NEXT_STEP.RECURSE
+    }
+    return FILTER_FUNC_NEXT_STEP.EXCLUDE
+  }
+  return filterByID(
+    valueID,
+    value,
+    filterByMergeable
+  )
+}
 
 const isEmptyAnnoAndAnnoTypes = (element: Element): boolean =>
   (_.isEmpty(element.annotations) && _.isEmpty(element.annotationRefTypes))

--- a/packages/workspace/src/workspace/path_index.ts
+++ b/packages/workspace/src/workspace/path_index.ts
@@ -274,7 +274,8 @@ export const filterByPathHint = async (index: PathIndex, hint:Path, id: ElemID):
   const isHintMatch = idHints.some(idHint => _.isEqual(idHint, hint))
   if (!isHintMatch) {
     // This case will be removed, when we fix the .annotation and .field keys in the path index
-    if (idHints.length === 0 && id.isIDNestedInType() && id.nestingLevel === 1) {
+    if (idHints.length === 0
+        && ((id.isIDNestedInType() && id.nestingLevel === 0) || (id.isAnnotationTypeID() && id.nestingLevel === 1))) {
       return FILTER_FUNC_NEXT_STEP.RECURSE
     }
     return FILTER_FUNC_NEXT_STEP.EXCLUDE

--- a/packages/workspace/src/workspace/path_index.ts
+++ b/packages/workspace/src/workspace/path_index.ts
@@ -274,7 +274,7 @@ export const filterByPathHint = async (index: PathIndex, hint:Path, id: ElemID):
   const isHintMatch = idHints.some(idHint => _.isEqual(idHint, hint))
   if (!isHintMatch) {
     // This case will be removed, when we fix the .annotation and .field keys in the path index
-    if (idHints.length === 0 && id.isIDNestedInType() && id.nestingLevel === 0) {
+    if (idHints.length === 0 && id.isIDNestedInType() && id.nestingLevel === 1) {
       return FILTER_FUNC_NEXT_STEP.RECURSE
     }
     return FILTER_FUNC_NEXT_STEP.EXCLUDE

--- a/packages/workspace/src/workspace/path_index.ts
+++ b/packages/workspace/src/workspace/path_index.ts
@@ -14,12 +14,20 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { collections, values, serialize as lowerdashSerialize } from '@salto-io/lowerdash'
-import { ElemID, Element, Value, Field, isObjectType, isInstanceElement,
-  ObjectType, InstanceElement } from '@salto-io/adapter-api'
-import { filterByID } from '@salto-io/adapter-utils'
+import { collections, serialize as lowerdashSerialize, values } from '@salto-io/lowerdash'
+import {
+  Element,
+  ElemID,
+  Field,
+  InstanceElement,
+  isInstanceElement,
+  isObjectType,
+  ObjectType,
+  Value,
+} from '@salto-io/adapter-api'
+import { FILTER_FUNC_NEXT_STEP, filterByID } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
-import { RemoteMapEntry, RemoteMap } from './remote_map'
+import { RemoteMap, RemoteMapEntry } from './remote_map'
 
 const { awu } = collections.asynciterable
 const { getSerializedStream } = lowerdashSerialize
@@ -261,6 +269,22 @@ export const getFromPathIndex = async (
   return []
 }
 
+export const filterByPathHint = async (index: PathIndex, hint:Path, id: ElemID): Promise<FILTER_FUNC_NEXT_STEP> => {
+  const idHints = await index.get(id.getFullName()) ?? []
+  const isHintMatch = idHints.some(idHint => _.isEqual(idHint, hint))
+  if (!isHintMatch) {
+    // This case will be removed, when we fix the .annotation and .field keys in the path index
+    if (idHints.length === 0 && id.isIDNestedInType() && id.nestingLevel === 0) {
+      return FILTER_FUNC_NEXT_STEP.RECURSE
+    }
+    return FILTER_FUNC_NEXT_STEP.EXCLUDE
+  }
+  if (idHints.length === 1) {
+    return FILTER_FUNC_NEXT_STEP.INCLUDE
+  }
+  return FILTER_FUNC_NEXT_STEP.RECURSE
+}
+
 export const splitElementByPath = async (
   element: Element,
   index: PathIndex
@@ -273,14 +297,10 @@ export const splitElementByPath = async (
     return [clonedElement]
   }
   return (await Promise.all(pathHints.map(async hint => {
-    const filterByPathHint = async (id: ElemID): Promise<boolean> => {
-      const idHints = await getFromPathIndex(id, index)
-      return idHints.some(idHint => _.isEqual(idHint, hint))
-    }
     const filteredElement = await filterByID(
       element.elemID,
       element,
-      filterByPathHint
+      id => filterByPathHint(index, hint, id)
     )
 
     if (filteredElement) {

--- a/packages/workspace/test/workspace/path_index.test.ts
+++ b/packages/workspace/test/workspace/path_index.test.ts
@@ -321,6 +321,49 @@ describe('split element by path', () => {
     },
   })
 
+  const singleFieldObjElemId = new ElemID('salto', 'obj2')
+  const singleFieldObj = new ObjectType({
+    elemID: singleFieldObjElemId,
+    fields: {
+      uriField: {
+        refType: createRefToElmWithValue(BuiltinTypes.STRING),
+        annotations: {
+          test: 'test',
+        },
+      },
+    },
+    path: ['salto', 'obj2', 'field'],
+  })
+
+  const singleFieldObjAnnotations = new ObjectType({
+    elemID: singleFieldObjElemId,
+    annotationRefsOrTypes: {
+      anno: createRefToElmWithValue(BuiltinTypes.STRING),
+    },
+    annotations: {
+      anno: 'Bye',
+    },
+    path: ['salto', 'obj2', 'annotations'],
+  })
+
+  const singleFieldObjFull = new ObjectType({
+    elemID: singleFieldObjElemId,
+    fields: {
+      uriField: {
+        refType: createRefToElmWithValue(BuiltinTypes.STRING),
+        annotations: {
+          test: 'test',
+        },
+      },
+    },
+    annotationRefsOrTypes: {
+      anno: createRefToElmWithValue(BuiltinTypes.STRING),
+    },
+    annotations: {
+      anno: 'Bye',
+    },
+  })
+
   const singlePathObj = new ObjectType({
     elemID: new ElemID('salto', 'singlePath'),
     fields: {
@@ -375,8 +418,11 @@ describe('split element by path', () => {
   const fullObjFrags = [
     objFragStdFields, objFragCustomFields, objFragAnnotations,
   ]
+  const singleFieldObjFrags = [
+    singleFieldObj, singleFieldObjAnnotations,
+  ]
   const unmergedElements = [
-    ...fullObjFrags, singlePathObj, noPathObj, multiPathInstanceA, multiPathInstanceB,
+    ...fullObjFrags, ...singleFieldObjFrags, singlePathObj, noPathObj, multiPathInstanceA, multiPathInstanceB,
   ]
   const pi = new InMemoryRemoteMap<Path[]>()
 
@@ -387,6 +433,13 @@ describe('split element by path', () => {
   it('should split an element with multiple pathes', async () => {
     const splitedElements = await splitElementByPath(objFull, pi)
     fullObjFrags.forEach(
+      frag => expect(splitedElements.filter(elem => elem.isEqual(frag))).toHaveLength(1)
+    )
+  })
+
+  it('should split an element with one fields file', async () => {
+    const splitedElements = await splitElementByPath(singleFieldObjFull, pi)
+    singleFieldObjFrags.forEach(
       frag => expect(splitedElements.filter(elem => elem.isEqual(frag))).toHaveLength(1)
     )
   })

--- a/packages/workspace/test/workspace/path_index.test.ts
+++ b/packages/workspace/test/workspace/path_index.test.ts
@@ -443,17 +443,17 @@ describe('split element by path', () => {
     await updatePathIndex({ pathIndex: pi, unmergedElements })
   })
 
-  it('should split an element with multiple pathes', async () => {
-    const splitedElements = await splitElementByPath(objFull, pi)
+  it('should split an element with multiple paths', async () => {
+    const splitElements = await splitElementByPath(objFull, pi)
     fullObjFrags.forEach(
-      frag => expect(splitedElements.filter(elem => elem.isEqual(frag))).toHaveLength(1)
+      frag => expect(splitElements.filter(elem => elem.isEqual(frag))).toHaveLength(1)
     )
   })
 
   it('should split an element with one fields file', async () => {
-    const splitedElements = await splitElementByPath(singleFieldObjFull, pi)
+    const splitElements = await splitElementByPath(singleFieldObjFull, pi)
     singleFieldObjFrags.forEach(
-      frag => expect(splitedElements.filter(elem => elem.isEqual(frag))).toHaveLength(1)
+      frag => expect(splitElements.filter(elem => elem.isEqual(frag))).toHaveLength(1)
     )
   })
 
@@ -466,15 +466,15 @@ describe('split element by path', () => {
   })
 
   it('should return a single object for an element with one path', async () => {
-    const splitedElements = await splitElementByPath(singlePathObj, pi)
-    expect(splitedElements).toHaveLength(1)
-    expect(splitedElements[0]).toEqual(singlePathObj)
+    const splitElements = await splitElementByPath(singlePathObj, pi)
+    expect(splitElements).toHaveLength(1)
+    expect(splitElements[0]).toEqual(singlePathObj)
   })
 
   it('should return the element for an element with no pathes', async () => {
-    const splitedElements = await splitElementByPath(noPathObj, pi)
-    expect(splitedElements).toHaveLength(1)
-    expect(splitedElements[0]).toEqual(noPathObj)
+    const splitElements = await splitElementByPath(noPathObj, pi)
+    expect(splitElements).toHaveLength(1)
+    expect(splitElements[0]).toEqual(noPathObj)
   })
 })
 

--- a/packages/workspace/test/workspace/path_index.test.ts
+++ b/packages/workspace/test/workspace/path_index.test.ts
@@ -286,7 +286,7 @@ describe('split element by path', () => {
     },
     path: ['salto', 'obj', 'customFields'],
   })
-  const objFragAnnotations = new ObjectType({
+  const objFragAnnotationsOne = new ObjectType({
     elemID: objElemId,
     annotationRefsOrTypes: {
       anno: createRefToElmWithValue(BuiltinTypes.STRING),
@@ -294,7 +294,18 @@ describe('split element by path', () => {
     annotations: {
       anno: 'Hey',
     },
-    path: ['salto', 'obj', 'annotations'],
+    path: ['salto', 'obj', 'annotationsOne'],
+  })
+
+  const objFragAnnotationsTwo = new ObjectType({
+    elemID: objElemId,
+    annotationRefsOrTypes: {
+      num: BuiltinTypes.NUMBER,
+    },
+    annotations: {
+      num: 22,
+    },
+    path: ['salto', 'obj', 'annotationsTwo'],
   })
 
   const objFull = new ObjectType({
@@ -315,9 +326,11 @@ describe('split element by path', () => {
     },
     annotationRefsOrTypes: {
       anno: createRefToElmWithValue(BuiltinTypes.STRING),
+      num: BuiltinTypes.NUMBER,
     },
     annotations: {
       anno: 'Hey',
+      num: 22,
     },
   })
 
@@ -416,7 +429,7 @@ describe('split element by path', () => {
   })
 
   const fullObjFrags = [
-    objFragStdFields, objFragCustomFields, objFragAnnotations,
+    objFragStdFields, objFragCustomFields, objFragAnnotationsOne, objFragAnnotationsTwo,
   ]
   const singleFieldObjFrags = [
     singleFieldObj, singleFieldObjAnnotations,


### PR DESCRIPTION
SALTO-4356 improve splitElementByPath complexity 

---
_Release Notes_: 
Improve splitElementByPath and filterByID complexity 

---
_User Notifications_: 
Reduced operation time of Fetch (from workspace) and Restore 
