### PR TITLE
SALTO-1641: Removed flush from adapter config source

### DIFF
--- a/packages/workspace/src/workspace/adapters_config_source.ts
+++ b/packages/workspace/src/workspace/adapters_config_source.ts
@@ -140,8 +140,6 @@ export const buildAdaptersConfigSource = async ({
       .map(conf => ({
         id: conf.elemID, action: 'remove', data: { before: conf },
       })))
-    // If flush is not called here the removal seems to be ignored
-    await naclSource.flush()
 
     const removeUndefined = async (instance: InstanceElement): Promise<InstanceElement> =>
       transformElement({

--- a/packages/workspace/test/workspace/adapters_config.test.ts
+++ b/packages/workspace/test/workspace/adapters_config.test.ts
@@ -164,7 +164,6 @@ describe('adapters config', () => {
       })
     ))
     expect(mockNaclFilesSource.updateNaclFiles).toHaveBeenCalledWith([expect.objectContaining({ path: ['salto.config', 'adapters', 'salesforce', 'salesforce'] })])
-    expect(mockNaclFilesSource.flush).toHaveBeenCalled()
   })
 
   it('should set adapter in nacl files source with the config path', async () => {
@@ -177,7 +176,6 @@ describe('adapters config', () => {
       ['dir', 'file']
     ))
     expect(mockNaclFilesSource.updateNaclFiles).toHaveBeenCalledWith([expect.objectContaining({ path: ['salto.config', 'adapters', 'salesforce', 'dir', 'file'] })])
-    expect(mockNaclFilesSource.flush).toHaveBeenCalled()
   })
 
   it('should set adapter in nacl files source with the config path, if account name isnt same as service', async () => {
@@ -188,7 +186,6 @@ describe('adapters config', () => {
       }),
     ))
     expect(mockNaclFilesSource.updateNaclFiles).toHaveBeenCalledWith([expect.objectContaining({ path: ['salto.config', 'adapters', 'salesforce2', 'salesforce2'] })])
-    expect(mockNaclFilesSource.flush).toHaveBeenCalled()
   })
 
   it('should return errors with "config" source', async () => {
@@ -213,7 +210,6 @@ describe('adapters config', () => {
     ))
     const receivedChange = mockNaclFilesSource.updateNaclFiles.mock.calls[1][0][0]
     expect(getChangeData(receivedChange).value).toEqual({ value: { inner2: 2, inner3: [] } })
-    expect(mockNaclFilesSource.flush).toHaveBeenCalled()
   })
 
   it('getElementNaclFiles should return the configuration files', async () => {
@@ -232,7 +228,6 @@ describe('adapters config', () => {
       conf.value.overridden = 3
       await expect(configSource.setAdapter(SALESFORCE, SALESFORCE, conf)).rejects.toThrow()
       expect(mockNaclFilesSource.updateNaclFiles).not.toHaveBeenCalled()
-      expect(mockNaclFilesSource.flush).not.toHaveBeenCalled()
     })
 
     it('update a none overridden field should not throw an exception', async () => {
@@ -240,7 +235,6 @@ describe('adapters config', () => {
       conf.value.other = 3
       await configSource.setAdapter(SALESFORCE, SALESFORCE, conf)
       expect(mockNaclFilesSource.updateNaclFiles).toHaveBeenCalled()
-      expect(mockNaclFilesSource.flush).toHaveBeenCalled()
     })
 
     it('should call updateNaclFiles twice when there is no configuration', async () => {
@@ -248,7 +242,6 @@ describe('adapters config', () => {
       mockNaclFilesSource.get.mockResolvedValue(undefined)
       await configSource.setAdapter(SALESFORCE, SALESFORCE, conf)
       expect(mockNaclFilesSource.updateNaclFiles).toHaveBeenCalledTimes(2)
-      expect(mockNaclFilesSource.flush).toHaveBeenCalled()
     })
 
     it('setNaclFile should recalculate errors', async () => {


### PR DESCRIPTION
There was a bug that causes us to add a flush call when setting the adapter config. The bug was solved so we can remove it

---
_Release Notes_: 
None

---
_User Notifications_: 
None