### PR TITLE
SALTO-4486 deal with case where internal ID is an empty string, and don't return it in getTypeIdenitifier

### DIFF
--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -236,7 +236,7 @@ const getPropsWithFullName = (
 
 const getInstanceFromMetadataInformation = (metadata: MetadataInfo,
   filePropertiesMap: Record<string, FileProperties>, metadataType: ObjectType): InstanceElement => {
-  const newMetadata = filePropertiesMap[metadata.fullName]?.id
+  const newMetadata = filePropertiesMap[metadata.fullName]?.id !== undefined && filePropertiesMap[metadata.fullName]?.id !== ''
     ? { ...metadata, [INTERNAL_ID_FIELD]: filePropertiesMap[metadata.fullName]?.id } : metadata
   return createInstanceElement(newMetadata, metadataType,
     filePropertiesMap[newMetadata.fullName]?.namespacePrefix,

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -404,6 +404,17 @@ describe('SalesforceAdapter fetch', () => {
                 bla: { bla: '55', bla2: 'false', bla3: 'true' },
               },
             },
+            {
+              props: {
+                fullName: 'FlowInstanceNoId',
+                fileName: 'flows/FlowInstanceNoId.flow',
+                id: '',
+              },
+              values: {
+                fullName: 'FlowInstanceNoId',
+                bla: { bla: '55', bla2: 'false', bla3: 'true' },
+              },
+            },
           ]
         )
       }
@@ -427,6 +438,14 @@ describe('SalesforceAdapter fetch', () => {
         expect(flow.annotations[CORE_ANNOTATIONS.CREATED_AT]).toEqual('2020-05-01T14:31:36.000Z')
         expect(flow.annotations[CORE_ANNOTATIONS.CHANGED_BY]).toEqual('test')
         expect(flow.annotations[CORE_ANNOTATIONS.CHANGED_AT]).toEqual('2020-05-01T14:41:36.000Z')
+      })
+
+      it('should not have id field if id is empty string in fileProps', async () => {
+        mockFlowType()
+        const { elements: result } = await adapter.fetch(mockFetchOpts)
+        const flow = findElements(result, 'Flow', 'FlowInstanceNoId').pop() as InstanceElement
+        expect((await flow.getType()).elemID).toEqual(new ElemID(constants.SALESFORCE, 'Flow'))
+        expect(flow.value.id).toBeUndefined()
       })
 
       it('should not fetch excluded namespaces', async () => {


### PR DESCRIPTION
Changes to retrieve API caused internal ID to have empty string. 

---

_Additional context for reviewer_

---
_Release Notes_: 
Salesforce:
- Fix broken go-to-service URLs

---
_User Notifications_: _None_