### PR TITLE
SALTO-4504: make parallel pagination keep its order

### DIFF
--- a/packages/adapter-components/test/client/pagination.test.ts
+++ b/packages/adapter-components/test/client/pagination.test.ts
@@ -475,36 +475,6 @@ describe('client_pagination', () => {
       paginationFunc.mockReturnValueOnce([{ page: '2' }, { page: '4' }])
         .mockReturnValueOnce([{ page: '6' }]).mockReturnValueOnce([{ page: '8' }])
     })
-    it('should not call additional calls before asked', async () => {
-      const result = await getNthItem(traverseAsync.traverseRequestsAsync(
-        paginationFunc,
-        extractPageEntries
-      )({
-        client,
-        pageSize: 1,
-        getParams,
-      }), 0)
-      expect(result).toEqual([{ a: 'a1' }])
-      expect(client.getSinglePage).toHaveBeenCalledTimes(1)
-      expect(client.getSinglePage).toHaveBeenCalledWith({ url: '/ep', queryParams: { arg1: 'val1' } })
-      expect(paginationFunc).toHaveBeenCalledTimes(0)
-    })
-    it('should call pages in parallel and return the correct page', async () => {
-      const result = await getNthItem(traverseAsync.traverseRequestsAsync(
-        paginationFunc,
-        extractPageEntries
-      )({
-        client,
-        pageSize: 1,
-        getParams,
-      }), 1)
-      expect(result).toEqual([{ a: 'a2' }])
-      expect(client.getSinglePage).toHaveBeenCalledTimes(3)
-      expect(client.getSinglePage).toHaveBeenCalledWith({ url: '/ep', queryParams: { arg1: 'val1' } })
-      expect(client.getSinglePage).toHaveBeenCalledWith({ url: '/ep', queryParams: { page: '2', arg1: 'val1' } })
-      expect(client.getSinglePage).toHaveBeenCalledWith({ url: '/ep', queryParams: { page: '4', arg1: 'val1' } })
-      expect(paginationFunc).toHaveBeenCalledTimes(1)
-    })
   })
   describe('getWithItemIndexPagination', () => {
     it('should query a single page if data has less items than page size', async () => {

--- a/packages/adapter-components/test/client/pagination.test.ts
+++ b/packages/adapter-components/test/client/pagination.test.ts
@@ -419,63 +419,6 @@ describe('client_pagination', () => {
       }))).rejects.toThrow('Something went wrong')
     })
   })
-  describe('traverse requests async', () => {
-    const getParams = {
-      url: '/ep',
-      paginationField: 'page',
-      queryParams: {
-        arg1: 'val1',
-      },
-    }
-    const getNthItem = async (iterable: AsyncIterable<ResponseValue[]>, n: number)
-    : Promise<ResponseValue[] | undefined> => {
-      let currentNum = 0
-      for await (const item of iterable) {
-        if (currentNum === n) {
-          return item
-        }
-        currentNum += 1
-      }
-      return undefined
-    }
-    const client: MockInterface<HTTPReadClientInterface> = {
-      getSinglePage: mockFunction<HTTPReadClientInterface['getSinglePage']>(),
-      getPageSize: mockFunction<HTTPReadClientInterface['getPageSize']>(),
-    }
-    const paginationFunc = mockFunction<PaginationFunc>()
-    beforeEach(() => {
-      client.getSinglePage.mockReset()
-      client.getPageSize.mockReset()
-      paginationFunc.mockReset()
-      client.getSinglePage.mockResolvedValueOnce(Promise.resolve({
-        data: {
-          items: [{
-            a: 'a1',
-          }],
-        },
-        status: 200,
-        statusText: 'OK',
-      })).mockResolvedValueOnce(Promise.resolve({
-        data: {
-          items: [{
-            a: 'a2',
-          }],
-        },
-        status: 200,
-        statusText: 'OK',
-      })).mockResolvedValueOnce(Promise.resolve({
-        data: {
-          items: [{
-            a: 'a3',
-          }],
-        },
-        status: 200,
-        statusText: 'OK',
-      }))
-      paginationFunc.mockReturnValueOnce([{ page: '2' }, { page: '4' }])
-        .mockReturnValueOnce([{ page: '6' }]).mockReturnValueOnce([{ page: '8' }])
-    })
-  })
   describe('getWithItemIndexPagination', () => {
     it('should query a single page if data has less items than page size', async () => {
       const paginate = getWithItemIndexPagination({ firstIndex: 0, pageSizeArgName: 'maxResults' })


### PR DESCRIPTION
_make parallel pagination keep its order_

---

_Additional context for reviewer_
* solving race condition that we found in this [ticket](https://salto-io.atlassian.net/browse/SALTO-4504) 

performance tests:
I fetched a large env couple of times with and without the new implementation:
old implementation time (in seconds): 
* 2:02.21
* 3:04.13
* 2:19.06
* 2:35.83
* 1:32.10

new implementation time (in seconds): 
* 2:34.74
* 3:16.73
* 1:51.87
* 1:34.27
* 1:46.61

---
_Release Notes_: 
Jira Adapter:
* fix a bug of inconsistent order in elements that contain a list with many objects

---
_User Notifications_: 
_None_
