### PR TITLE
SALTO-4513 remove redundant logs

### DIFF
--- a/packages/jira-adapter/src/change_validators/masking.ts
+++ b/packages/jira-adapter/src/change_validators/masking.ts
@@ -17,11 +17,9 @@ import { Change, ChangeError, ChangeValidator, CORE_ANNOTATIONS, getChangeData,
   InstanceElement,
   isAdditionOrModificationChange, isInstanceChange } from '@salto-io/adapter-api'
 import { walkOnElement, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
-import { logger } from '@salto-io/logging'
 import JiraClient from '../client/client'
 import { MASK_VALUE } from '../filters/masking'
 
-const log = logger(module)
 export const DETAILED_MESSAGE = 'This element will be deployed with masked values instead of the intended values. It will not operate correctly until manually fixing this after deployment. Learn more at https://help.salto.io/en/articles/6933977-masked-data-will-be-deployed-to-the-service'
 export const DOCUMENTATION_URL = 'https://help.salto.io/en/articles/6933977-masked-data-will-be-deployed-to-the-service'
 export const createChangeError = (
@@ -68,11 +66,10 @@ const doesHaveMaskedValues = (instance: InstanceElement): boolean => {
   return maskedValueFound
 }
 
-export const maskingValidator: (client: JiraClient) =>
-  ChangeValidator = client => async changes => log.time(() => (
-    changes
-      .filter(isAdditionOrModificationChange)
-      .filter(isInstanceChange)
-      .filter(change => doesHaveMaskedValues(getChangeData(change)))
-      .map(change => createChangeError(change, client))
-  ), 'masking change validator')
+export const maskingValidator: (client: JiraClient) => ChangeValidator = client => async changes => (
+  changes
+    .filter(isAdditionOrModificationChange)
+    .filter(isInstanceChange)
+    .filter(change => doesHaveMaskedValues(getChangeData(change)))
+    .map(change => createChangeError(change, client))
+)

--- a/packages/jira-adapter/src/change_validators/permission_scheme.ts
+++ b/packages/jira-adapter/src/change_validators/permission_scheme.ts
@@ -15,7 +15,6 @@
 */
 import { AdditionChange, ChangeError, ChangeValidator, ElemID, getChangeData, InstanceElement,
   isAdditionChange, isAdditionOrModificationChange, isInstanceChange, isModificationChange, ModificationChange, SeverityLevel } from '@salto-io/adapter-api'
-import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import { isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { isFreeLicense } from '../utils'
@@ -23,7 +22,6 @@ import JiraClient from '../client/client'
 import { PERMISSION_SCHEME_TYPE_NAME, PROJECT_TYPE } from '../constants'
 
 const { awu } = collections.asynciterable
-const log = logger(module)
 
 const projectError = (elemID: ElemID): ChangeError => ({
   elemID,
@@ -71,68 +69,67 @@ const isPermissionSchemeAssociationChange = (
  * In cloud free tier you cannot create a new one
  */
 export const permissionSchemeDeploymentValidator = (client: JiraClient): ChangeValidator =>
-  async (changes, elementsSource) =>
-    log.time(async () => {
-      if (client.isDataCenter || elementsSource === undefined
-        || (!await isFreeLicense(elementsSource))
-        || !changes) {
-        return []
-      }
-      const projectAndSchemeChanges = changes
-        .filter(isInstanceChange)
-        .filter(change => getChangeData(change).elemID.typeName === PERMISSION_SCHEME_TYPE_NAME
-              || getChangeData(change).elemID.typeName === PROJECT_TYPE)
-      if (projectAndSchemeChanges.length === 0) {
-        return []
-      }
+  async (changes, elementsSource) => {
+    if (client.isDataCenter || elementsSource === undefined
+      || (!await isFreeLicense(elementsSource))
+      || !changes) {
+      return []
+    }
+    const projectAndSchemeChanges = changes
+      .filter(isInstanceChange)
+      .filter(change => getChangeData(change).elemID.typeName === PERMISSION_SCHEME_TYPE_NAME
+            || getChangeData(change).elemID.typeName === PROJECT_TYPE)
+    if (projectAndSchemeChanges.length === 0) {
+      return []
+    }
 
-      const associatedSchemes = new Set(await awu(await elementsSource.list())
-        .filter(id => id.idType === 'instance' && id.typeName === PROJECT_TYPE)
-        .filter(async id => (await elementsSource.get(id)).value.permissionScheme !== undefined)
-        .map(async id => (await elementsSource.get(id)).value.permissionScheme.elemID.getFullName())
-        .toArray())
+    const associatedSchemes = new Set(await awu(await elementsSource.list())
+      .filter(id => id.idType === 'instance' && id.typeName === PROJECT_TYPE)
+      .filter(async id => (await elementsSource.get(id)).value.permissionScheme !== undefined)
+      .map(async id => (await elementsSource.get(id)).value.permissionScheme.elemID.getFullName())
+      .toArray())
 
-      const schemesThatWereAddedWithProjects = new Set(
-        projectAndSchemeChanges
-          .filter(change => getChangeData(change).elemID.typeName === PROJECT_TYPE)
-          .filter(isAdditionChange)
-          .filter(change => isResolvedReferenceExpression(getChangeData(change).value.permissionScheme))
-          .map(change => getChangeData(change).value.permissionScheme.elemID.getFullName())
-      )
-
-      const schemesThatWereAssociatedBefore = new Set(
-        projectAndSchemeChanges
-          .filter(change => getChangeData(change).elemID.typeName === PROJECT_TYPE)
-          .filter(isModificationChange)
-          .filter(change => isResolvedReferenceExpression(change.data.before.value.permissionScheme))
-          .map(change => change.data.before.value.permissionScheme.elemID.getFullName())
-      )
-
-      // removal should not cause a warning if the project is also removed
-      // addition changes should only cause a warning
-      const associatedSchemeChangeErrors = projectAndSchemeChanges
-        .filter(change => getChangeData(change).elemID.typeName === PERMISSION_SCHEME_TYPE_NAME)
-        .filter(change => associatedSchemes.has(getChangeData(change).elemID.getFullName()))
-        .map(change => (isAdditionChange(change)
-          && schemesThatWereAddedWithProjects.has(getChangeData(change).elemID.getFullName())
-          ? schemeWarning(getChangeData(change).elemID)
-          : schemeError(getChangeData(change).elemID)))
-      // unassociated schemes can be edited, issue an error only if an addition
-      // or if the association is removed in a different change
-      // (the element source reflects the state after the changes)
-      const unassociatedSchemeChangeErrors = projectAndSchemeChanges
-        .filter(change => isAdditionChange(change)
-          || schemesThatWereAssociatedBefore.has(getChangeData(change).elemID.getFullName()))
-        .map(getChangeData)
-        .filter(instance => instance.elemID.typeName === PERMISSION_SCHEME_TYPE_NAME)
-        .filter(instance => !associatedSchemes.has(instance.elemID.getFullName()))
-        .map(instance => schemeError(instance.elemID))
-      const projectChangeErrors = projectAndSchemeChanges
+    const schemesThatWereAddedWithProjects = new Set(
+      projectAndSchemeChanges
         .filter(change => getChangeData(change).elemID.typeName === PROJECT_TYPE)
-        .filter(isAdditionOrModificationChange)
-        .filter(isPermissionSchemeAssociationChange)
-        .map(change => (isAdditionChange(change)
-          ? projectWarning(getChangeData(change).elemID, change.data.after.value.permissionScheme.elemID.name)
-          : projectError(getChangeData(change).elemID)))
-      return [...associatedSchemeChangeErrors, ...unassociatedSchemeChangeErrors, ...projectChangeErrors]
-    }, 'permission scheme validator')
+        .filter(isAdditionChange)
+        .filter(change => isResolvedReferenceExpression(getChangeData(change).value.permissionScheme))
+        .map(change => getChangeData(change).value.permissionScheme.elemID.getFullName())
+    )
+
+    const schemesThatWereAssociatedBefore = new Set(
+      projectAndSchemeChanges
+        .filter(change => getChangeData(change).elemID.typeName === PROJECT_TYPE)
+        .filter(isModificationChange)
+        .filter(change => isResolvedReferenceExpression(change.data.before.value.permissionScheme))
+        .map(change => change.data.before.value.permissionScheme.elemID.getFullName())
+    )
+
+    // removal should not cause a warning if the project is also removed
+    // addition changes should only cause a warning
+    const associatedSchemeChangeErrors = projectAndSchemeChanges
+      .filter(change => getChangeData(change).elemID.typeName === PERMISSION_SCHEME_TYPE_NAME)
+      .filter(change => associatedSchemes.has(getChangeData(change).elemID.getFullName()))
+      .map(change => (isAdditionChange(change)
+        && schemesThatWereAddedWithProjects.has(getChangeData(change).elemID.getFullName())
+        ? schemeWarning(getChangeData(change).elemID)
+        : schemeError(getChangeData(change).elemID)))
+    // unassociated schemes can be edited, issue an error only if an addition
+    // or if the association is removed in a different change
+    // (the element source reflects the state after the changes)
+    const unassociatedSchemeChangeErrors = projectAndSchemeChanges
+      .filter(change => isAdditionChange(change)
+        || schemesThatWereAssociatedBefore.has(getChangeData(change).elemID.getFullName()))
+      .map(getChangeData)
+      .filter(instance => instance.elemID.typeName === PERMISSION_SCHEME_TYPE_NAME)
+      .filter(instance => !associatedSchemes.has(instance.elemID.getFullName()))
+      .map(instance => schemeError(instance.elemID))
+    const projectChangeErrors = projectAndSchemeChanges
+      .filter(change => getChangeData(change).elemID.typeName === PROJECT_TYPE)
+      .filter(isAdditionOrModificationChange)
+      .filter(isPermissionSchemeAssociationChange)
+      .map(change => (isAdditionChange(change)
+        ? projectWarning(getChangeData(change).elemID, change.data.after.value.permissionScheme.elemID.name)
+        : projectError(getChangeData(change).elemID)))
+    return [...associatedSchemeChangeErrors, ...unassociatedSchemeChangeErrors, ...projectChangeErrors]
+  }

--- a/packages/jira-adapter/src/filters/account_id/user_fallback_filter.ts
+++ b/packages/jira-adapter/src/filters/account_id/user_fallback_filter.ts
@@ -17,14 +17,11 @@
 import { ElemID, getChangeData, isAdditionOrModificationChange, isInstanceChange, isInstanceElement } from '@salto-io/adapter-api'
 import { setPath, walkOnElement } from '@salto-io/adapter-utils'
 import { config as configUtils } from '@salto-io/adapter-components'
-import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { FilterCreator } from '../../filter'
 import { walkOnUsers } from './account_id_filter'
 import { getCurrentUserInfo, getUserIdFromEmail, getUsersMap, getUsersMapByVisibleId, UserMap } from '../../users'
 import JiraClient from '../../client/client'
-
-const log = logger(module)
 
 const getFallbackUser = async (
   client: JiraClient,
@@ -84,7 +81,7 @@ const filter: FilterCreator = ({ client, config, elementsSource }) => {
             }, config),
           }))
     },
-    onDeploy: async changes => log.time(async () => {
+    onDeploy: async changes => {
       if (_.isEmpty(fallbackPathToUser)) {
         return
       }
@@ -106,7 +103,7 @@ const filter: FilterCreator = ({ client, config, elementsSource }) => {
 
           setPath(idToInstance[baseId], idPath.createNestedID('id'), userId)
         })
-    }, 'user_id_filter deploy'),
+    },
   }
 }
 

--- a/packages/jira-adapter/src/filters/account_info.ts
+++ b/packages/jira-adapter/src/filters/account_info.ts
@@ -129,7 +129,7 @@ const getAccountInfo = async (client: JiraClient, accountInfoType: ObjectType): 
 */
 const filter: FilterCreator = ({ client }) => ({
   name: 'accountInfo',
-  onFetch: async elements => log.time(async () => {
+  onFetch: async elements => {
     const { accountInfoType, licenseType, licensedApplications } = createAccountTypes()
     try {
       elements.push(licenseType, licensedApplications, accountInfoType, await getAccountInfo(client, accountInfoType))
@@ -152,6 +152,6 @@ const filter: FilterCreator = ({ client }) => ({
       .forEach(role => {
         delete role.value.userCount
       })
-  }, 'account info filter'),
+  },
 })
 export default filter


### PR DESCRIPTION
We have generic logs for filters and change validators, removing redundant ones that were added manually


---
_Release Notes_: 
None

---
_User Notifications_: 
None