### PR TITLE
SALTO-4520 - Salesforce: Allow different default values for adapter configs

### DIFF
--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -160,6 +160,7 @@ salesforce {
 | formulaDeps                       | true                   | Parse formula fields in custom objects for additional dependencies beyond those provided by the tooling API                                                           |
 | fetchCustomObjectUsingRetrieveApi | true                   | Use the Salesforce Metadata Retrieve API to fetch CustomObjects. This should improve reliability and data accuracy, but may have a small performance impact           |
 | fetchProfilesUsingReadApi         | false                  | Use the Salesforce Metadata Read API to fetch Profile instances. This will reduce the accuracy of the data and may result in crashes, but may be needed for debugging |
+| generateRefsInProfiles            | false                  | Generate references from profiles. This will have a significant performance impact, but will provide references from profiles to fields and elements.                 |
 
 ### Data management configuration options
 

--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -149,16 +149,17 @@ salesforce {
 
 ## Optional Features
 
-| Name                              | Default when undefined | Description                                                                                                                                                 |
-|-----------------------------------|------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| extraDependencies                 | true                   | Find additional dependencies between configuration elements by using the salesforce tooling API                                                             |
-| elementsUrls                      | true                   | Populate URLs for your salesforce configuration elements and enable quick navigation from Salto to the corresponding salesforce screen                      |
-| addMissingIds                     | true                   | Populate Salesforce internal ids for a few types that require special handling                                                                              |
-| profilePaths                      | true                   | Update file names for profiles whose API name is different from their display name                                                                          |
-| authorInformation                 | true                   | Populate Salesforce author information about who and when last changed Salesforce configuration elements.                                                   |
-| describeSObjects                  | true                   | Fetch additional information about CustomObjects from the soap API                                                                                          |
-| formulaDeps                       | true                   | Parse formula fields in custom objects for additional dependencies beyond those provided by the tooling API                                                 |
-| fetchCustomObjectUsingRetrieveApi | true                   | Use the Salesforce Metadata Retrieve API to fetch CustomObjects. This should improve reliability and data accuracy, but may have a small performance impact | 
+| Name                              | Default when undefined | Description                                                                                                                                                           |
+|-----------------------------------|------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| extraDependencies                 | true                   | Find additional dependencies between configuration elements by using the salesforce tooling API                                                                       |
+| elementsUrls                      | true                   | Populate URLs for your salesforce configuration elements and enable quick navigation from Salto to the corresponding salesforce screen                                |
+| addMissingIds                     | true                   | Populate Salesforce internal ids for a few types that require special handling                                                                                        |
+| profilePaths                      | true                   | Update file names for profiles whose API name is different from their display name                                                                                    |
+| authorInformation                 | true                   | Populate Salesforce author information about who and when last changed Salesforce configuration elements.                                                             |
+| describeSObjects                  | true                   | Fetch additional information about CustomObjects from the soap API                                                                                                    |
+| formulaDeps                       | true                   | Parse formula fields in custom objects for additional dependencies beyond those provided by the tooling API                                                           |
+| fetchCustomObjectUsingRetrieveApi | true                   | Use the Salesforce Metadata Retrieve API to fetch CustomObjects. This should improve reliability and data accuracy, but may have a small performance impact           |
+| fetchProfilesUsingReadApi         | false                  | Use the Salesforce Metadata Read API to fetch Profile instances. This will reduce the accuracy of the data and may result in crashes, but may be needed for debugging |
 
 ### Data management configuration options
 

--- a/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
@@ -33,6 +33,14 @@ export type FetchProfile = {
   readonly addNamespacePrefixToFullName: boolean
 }
 
+type OptionalFeaturesDefaultValues = {
+  [FeatureName in keyof OptionalFeatures]?: boolean
+}
+
+const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
+  fetchProfilesUsingReadApi: false,
+}
+
 export const buildFetchProfile = ({
   metadata = {},
   data,
@@ -47,7 +55,7 @@ export const buildFetchProfile = ({
     ? getFetchTargets(target as SupportedMetadataType[])
     : undefined),
   dataManagement: data && buildDataManagement(data),
-  isFeatureEnabled: name => optionalFeatures?.[name] ?? true,
+  isFeatureEnabled: name => optionalFeatures?.[name] ?? optionalFeaturesDefaultValues[name] ?? true,
   shouldFetchAllCustomSettings: () => fetchAllCustomSettings ?? true,
   maxInstancesPerType: maxInstancesPerType ?? DEFAULT_MAX_INSTANCES_PER_TYPE,
   preferActiveFlowVersions: preferActiveFlowVersions ?? false,

--- a/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
@@ -39,6 +39,7 @@ type OptionalFeaturesDefaultValues = {
 
 const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   fetchProfilesUsingReadApi: false,
+  generateRefsInProfiles: false,
 }
 
 export const buildFetchProfile = ({


### PR DESCRIPTION
Allow a custom default value for adapter configs. This PR also changes the default value of `fetchProfilesUsingReadApi` - both to show how it's done and because we've been wanting to do it anyway.

---

If we want to use adapter configs as feature flags we need to be able to change their default values without renaming them. This means the "default is always true" logic no longer holds. So let's change it slightly to "default is true, unless explicitly overridden".

- [x] PROD-156

---
_Release Notes_: 
N/A

---
_User Notifications_: 
N/A