### PR TITLE
SALTO-2781: Add filter and CV for classTranslationList changes on data elements

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -62,6 +62,7 @@ import additionalChanges from './filters/additional_changes'
 import addInstancesFetchTime from './filters/add_instances_fetch_time'
 import addAliasFilter from './filters/add_alias'
 import addBundleReferences from './filters/bundle_ids'
+import dataElementsOmitFields from './filters/data_elements_omit_fields'
 import { Filter, LocalFilterCreator, LocalFilterCreatorDefinition, RemoteFilterCreator, RemoteFilterCreatorDefinition } from './filter'
 import { getConfigFromConfigChanges, NetsuiteConfig, DEFAULT_DEPLOY_REFERENCED_ELEMENTS, DEFAULT_WARN_STALE_DATA, DEFAULT_VALIDATE, AdditionalDependencies, DEFAULT_MAX_FILE_CABINET_SIZE_IN_GB } from './config'
 import { andQuery, buildNetsuiteQuery, NetsuiteQuery, NetsuiteQueryParameters, notQuery, QueryParams, convertToQueryParams, getFixedTargetFetch } from './query'
@@ -134,6 +135,7 @@ export const allFilters: (LocalFilterCreatorDefinition | RemoteFilterCreatorDefi
   { creator: omitFieldsFilter },
   // additionalChanges should be the first preDeploy filter to run
   { creator: additionalChanges },
+  { creator: dataElementsOmitFields },
 ]
 
 // By default we run all filters and provide a client

--- a/packages/netsuite-adapter/src/change_validator.ts
+++ b/packages/netsuite-adapter/src/change_validator.ts
@@ -45,6 +45,7 @@ import netsuiteClientValidation from './change_validators/client_validation'
 import currencyUndeployableFieldsValidator from './change_validators/currency_undeployable_fields'
 import fileCabinetInternalIdsValidator from './change_validators/file_cabinet_internal_ids'
 import rolePermissionValidator from './change_validators/role_permission_ids'
+import dataElementsOmitFieldsValidator from './change_validators/data_elements_omit_fields'
 import NetsuiteClient from './client/client'
 import {
   AdditionalDependencies,
@@ -83,6 +84,7 @@ const netsuiteChangeValidators: Record<NetsuiteValidatorName, NetsuiteChangeVali
   undeployableConfigFeatures: undeployableConfigFeaturesValidator,
   extraReferenceDependencies: extraReferenceDependenciesValidator,
   rolePermission: rolePermissionValidator,
+  dataElementsOmitFields: dataElementsOmitFieldsValidator,
 }
 
 const nonSuiteAppValidators: Record<NonSuiteAppValidatorName, NetsuiteChangeValidator> = {

--- a/packages/netsuite-adapter/src/change_validators/data_elements_omit_fields.ts
+++ b/packages/netsuite-adapter/src/change_validators/data_elements_omit_fields.ts
@@ -1,0 +1,36 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { isAdditionOrModificationChange, isInstanceChange, getChangeData } from '@salto-io/adapter-api'
+import { isDataElementChange } from './inactive_parent'
+import { NetsuiteChangeValidator } from './types'
+import { shouldOmitField, CLASS_TRANSLATION_LIST } from '../filters/data_elements_omit_fields'
+
+const changeValidator: NetsuiteChangeValidator = async changes =>
+  changes
+    .filter(isAdditionOrModificationChange)
+    .filter(isInstanceChange)
+    .filter(isDataElementChange)
+    .filter(change => shouldOmitField(change, CLASS_TRANSLATION_LIST))
+    .map(getChangeData)
+    .map(instance => ({
+      elemID: instance.elemID,
+      severity: 'Warning',
+      message: `Changes to the ${CLASS_TRANSLATION_LIST} are not deployable`,
+      detailedMessage: `Changes to the ${CLASS_TRANSLATION_LIST} are not deployable and will be removed from the deployment.`,
+    }))
+
+
+export default changeValidator

--- a/packages/netsuite-adapter/src/change_validators/inactive_parent.ts
+++ b/packages/netsuite-adapter/src/change_validators/inactive_parent.ts
@@ -25,7 +25,7 @@ const { awu } = collections.asynciterable
 
 const IS_INACTIVE_FIELD = 'isInactive'
 
-const isDataElementChange = async (change: Change<InstanceElement>): Promise<boolean> => {
+export const isDataElementChange = async (change: Change<InstanceElement>): Promise<boolean> => {
   const changeType = await getChangeData(change).getType()
   return isDataObjectType(changeType)
     && !isCustomRecordType(changeType) // custom record types don't have inactive parent limitation on NetSuite

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -549,6 +549,7 @@ export type NetsuiteValidatorName = (
   | 'undeployableConfigFeatures'
   | 'extraReferenceDependencies'
   | 'rolePermission'
+  | 'dataElementsOmitFields'
 )
 
 export type NonSuiteAppValidatorName = (

--- a/packages/netsuite-adapter/src/filters/data_elements_omit_fields.ts
+++ b/packages/netsuite-adapter/src/filters/data_elements_omit_fields.ts
@@ -1,0 +1,58 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { isAdditionOrModificationChange, isInstanceChange, isModificationChange, isAdditionChange, Change, ModificationChange, getChangeData, ChangeDataType } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { LocalFilterCreator } from '../filter'
+import { isDataElementChange } from '../change_validators/inactive_parent'
+import { getElementValueOrAnnotations } from '../types'
+
+export const CLASS_TRANSLATION_LIST = 'classTranslationList'
+const FIELDS_TO_OMIT = [CLASS_TRANSLATION_LIST]
+
+const fieldIsModified = (
+  change: ModificationChange<ChangeDataType>,
+  fieldToOmit: string,
+): boolean => {
+  const { before, after } = change.data
+  return !_.isEqual(
+    getElementValueOrAnnotations(before)[fieldToOmit],
+    getElementValueOrAnnotations(after)[fieldToOmit]
+  )
+}
+
+export const shouldOmitField = (
+  change: Change,
+  fieldToOmit: string
+): boolean => (isAdditionChange(change) || (isModificationChange(change) && fieldIsModified(change, fieldToOmit)))
+
+
+const filterCreator: LocalFilterCreator = () => ({
+  name: 'dataElementsOmitFields',
+  preDeploy: async changes => {
+    changes
+      .filter(isAdditionOrModificationChange)
+      .filter(isInstanceChange)
+      .filter(isDataElementChange)
+      .filter(change => shouldOmitField(change, CLASS_TRANSLATION_LIST))
+      .map(getChangeData)
+      .forEach(instanceElement => {
+        instanceElement.value = _.omit(instanceElement.value, FIELDS_TO_OMIT)
+      })
+  },
+})
+
+export default filterCreator

--- a/packages/netsuite-adapter/src/filters/data_elements_omit_fields.ts
+++ b/packages/netsuite-adapter/src/filters/data_elements_omit_fields.ts
@@ -16,9 +16,12 @@
 
 import { isAdditionOrModificationChange, isInstanceChange, isModificationChange, isAdditionChange, Change, ModificationChange, getChangeData, ChangeDataType } from '@salto-io/adapter-api'
 import _ from 'lodash'
+import { collections } from '@salto-io/lowerdash'
 import { LocalFilterCreator } from '../filter'
 import { isDataElementChange } from '../change_validators/inactive_parent'
 import { getElementValueOrAnnotations } from '../types'
+
+const { awu } = collections.asynciterable
 
 export const CLASS_TRANSLATION_LIST = 'classTranslationList'
 const FIELDS_TO_OMIT = [CLASS_TRANSLATION_LIST]
@@ -43,7 +46,7 @@ export const shouldOmitField = (
 const filterCreator: LocalFilterCreator = () => ({
   name: 'dataElementsOmitFields',
   preDeploy: async changes => {
-    changes
+    await awu(changes)
       .filter(isAdditionOrModificationChange)
       .filter(isInstanceChange)
       .filter(isDataElementChange)

--- a/packages/netsuite-adapter/test/change_validators/data_elements_omit_fields.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/data_elements_omit_fields.test.ts
@@ -1,0 +1,93 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { ObjectType, ElemID, BuiltinTypes, InstanceElement, toChange } from '@salto-io/adapter-api'
+import { NETSUITE } from '../../src/constants'
+import validateFieldsToOmit from '../../src/change_validators/data_elements_omit_fields'
+
+describe('data elements omit fields change validator tests', () => {
+  const subsidiaryType = new ObjectType({
+    elemID: new ElemID(NETSUITE, 'subsidiary'),
+    fields: {
+      internalId: {
+        refType: BuiltinTypes.STRING,
+        annotations: {
+          isAttribute: true,
+        },
+      },
+      name: { refType: BuiltinTypes.SERVICE_ID },
+      state: { refType: BuiltinTypes.STRING },
+    },
+    annotations: { source: 'soap' },
+  })
+  const classTranslationList = {
+    classTranslation: {
+      Danish: {
+        language: 'Danish',
+        name: 'Konsolideret moderselskab',
+      },
+    },
+  }
+  let subsidiaryInstance: InstanceElement
+  let after: InstanceElement
+  beforeEach(() => {
+    subsidiaryInstance = new InstanceElement(
+      'Parent_Company',
+      subsidiaryType,
+      {
+        name: 'subsidiary_name',
+        state: 'AZ',
+        classTranslationList,
+      }
+    )
+    after = subsidiaryInstance.clone()
+  })
+  it('should have a warning on addition change', async () => {
+    const changeErrors = await validateFieldsToOmit([toChange({ after: subsidiaryInstance })])
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0]).toEqual(
+      {
+        elemID: subsidiaryInstance.elemID,
+        severity: 'Warning',
+        message: 'Changes to the classTranslationList are not deployable',
+        detailedMessage: 'Changes to the classTranslationList are not deployable and will be removed from the deployment.',
+      }
+    )
+  })
+
+  it('should have warning on modification changes with changes to the field', async () => {
+    after.value.classTranslationList.classTranslation.Russian = {
+      language: 'Russian',
+      name: 'Сводная материнская компания',
+    }
+    const changeErrors = await validateFieldsToOmit([toChange({ before: subsidiaryInstance, after })])
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0]).toEqual(
+      {
+        elemID: subsidiaryInstance.elemID,
+        severity: 'Warning',
+        message: 'Changes to the classTranslationList are not deployable',
+        detailedMessage: 'Changes to the classTranslationList are not deployable and will be removed from the deployment.',
+      }
+    )
+  })
+
+  it('shouldn\'t have warning on modifications where the field hasn\'t changed', async () => {
+    after.value.state = 'FLA'
+    const changeErrors = await validateFieldsToOmit([toChange({ before: subsidiaryInstance, after })])
+    expect(changeErrors).toHaveLength(0)
+  })
+})

--- a/packages/netsuite-adapter/test/filters/data_elements_omit_fields.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_elements_omit_fields.test.ts
@@ -1,0 +1,100 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { BuiltinTypes, ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import { NETSUITE } from '../../src/constants'
+import filterCreator from '../../src/filters/data_elements_omit_fields'
+import { LocalFilterOpts } from '../../src/filter'
+
+describe('data elements omit fields filter tests', () => {
+  const filterOpts = {
+    config: {},
+    isPartial: false,
+    elementsSourceIndex: {
+      getIndexes: () => {
+        throw new Error('should not call getIndexes')
+      },
+    },
+  } as unknown as LocalFilterOpts
+  const subsidiaryType = new ObjectType({
+    elemID: new ElemID(NETSUITE, 'subsidiary'),
+    fields: {
+      internalId: {
+        refType: BuiltinTypes.STRING,
+        annotations: {
+          isAttribute: true,
+        },
+      },
+      name: { refType: BuiltinTypes.SERVICE_ID },
+      state: { refType: BuiltinTypes.STRING },
+    },
+    annotations: { source: 'soap' },
+  })
+  const classTranslationList = {
+    classTranslation: {
+      Danish: {
+        language: 'Danish',
+        name: 'Konsolideret moderselskab',
+      },
+    },
+  }
+  let subsidiaryInstance: InstanceElement
+  beforeEach(() => {
+    subsidiaryInstance = new InstanceElement(
+      'Parent_Company',
+      subsidiaryType,
+      {
+        name: 'subsidiary_name',
+        state: 'AZ',
+        classTranslationList,
+      }
+    )
+  })
+  it('should remove field from addition change on preDeploy', async () => {
+    expect(subsidiaryInstance.value.classTranslationList).toEqual(classTranslationList)
+    await filterCreator(filterOpts).preDeploy?.(
+      [
+        toChange({ after: subsidiaryInstance }),
+      ]
+    )
+    expect(subsidiaryInstance.value.classTranslationList).toBeUndefined()
+  })
+
+  it('should remove field from modification change if the field was modified', async () => {
+    const after = subsidiaryInstance.clone()
+    after.value.classTranslationList.classTranslation.Russian = {
+      language: 'Russian',
+      name: 'Сводная материнская компания',
+    }
+    await filterCreator(filterOpts).preDeploy?.(
+      [
+        toChange({ before: subsidiaryInstance, after }),
+      ]
+    )
+    expect(after.value.classTranslationList).toBeUndefined()
+  })
+
+  it('should not remove field if it wasn\'t modified', async () => {
+    const after = subsidiaryInstance.clone()
+    after.value.state = 'FLA'
+    await filterCreator(filterOpts).preDeploy?.(
+      [
+        toChange({ before: subsidiaryInstance, after }),
+      ]
+    )
+    expect(after.value.classTranslationList).toEqual(classTranslationList)
+  })
+})

--- a/packages/netsuite-adapter/test/filters/data_elements_omit_fields.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_elements_omit_fields.test.ts
@@ -52,6 +52,7 @@ describe('data elements omit fields filter tests', () => {
     },
   }
   let subsidiaryInstance: InstanceElement
+  let after: InstanceElement
   beforeEach(() => {
     subsidiaryInstance = new InstanceElement(
       'Parent_Company',
@@ -62,6 +63,7 @@ describe('data elements omit fields filter tests', () => {
         classTranslationList,
       }
     )
+    after = subsidiaryInstance.clone()
   })
   it('should remove field from addition change on preDeploy', async () => {
     expect(subsidiaryInstance.value.classTranslationList).toEqual(classTranslationList)
@@ -74,7 +76,6 @@ describe('data elements omit fields filter tests', () => {
   })
 
   it('should remove field from modification change if the field was modified', async () => {
-    const after = subsidiaryInstance.clone()
     after.value.classTranslationList.classTranslation.Russian = {
       language: 'Russian',
       name: 'Сводная материнская компания',
@@ -88,7 +89,6 @@ describe('data elements omit fields filter tests', () => {
   })
 
   it('should not remove field if it wasn\'t modified', async () => {
-    const after = subsidiaryInstance.clone()
     after.value.state = 'FLA'
     await filterCreator(filterOpts).preDeploy?.(
       [


### PR DESCRIPTION
_Deploying data elements with changes to classTranslationList field fails, Added filter to remove it in pre-deploy and CV to let the user know_

---

_The ticket - https://salto-io.atlassian.net/browse/SALTO-2781_

---
_Release Notes_: 
_Netsuite Adapter_:
* changes to the classTranslationList field in data elements are not deployable.

---
_User Notifications_: 
_None_
