### PR TITLE
SALTO-4467: add dependency between attachment to article

### DIFF
--- a/packages/zendesk-adapter/src/dependency_changers/article_attachment_change.ts
+++ b/packages/zendesk-adapter/src/dependency_changers/article_attachment_change.ts
@@ -1,0 +1,65 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  Change, dependencyChange, DependencyChange,
+  DependencyChanger,
+  getChangeData,
+  InstanceElement, isAdditionChange,
+  isInstanceChange, isModificationChange,
+} from '@salto-io/adapter-api'
+import { collections, values as lowerDashValues } from '@salto-io/lowerdash'
+import { getParents } from '@salto-io/adapter-utils'
+import _ from 'lodash'
+import { ARTICLE_ATTACHMENT_TYPE_NAME, ARTICLE_TYPE_NAME } from '../constants'
+
+const { isDefined } = lowerDashValues
+
+const getNameFromChange = (change: { key: collections.set.SetId; change: Change<InstanceElement> }): string =>
+  getChangeData(change.change).elemID.getFullName()
+
+const getDependencies = (changes: { key: collections.set.SetId; change: Change<InstanceElement> }[])
+  : DependencyChange[] => {
+  const articleModificationChanges = changes.filter(change =>
+    (getChangeData(change.change).elemID.typeName === ARTICLE_TYPE_NAME && isModificationChange(change.change)))
+  const articleAttachmentAdditionChanges = changes.filter(change =>
+    (getChangeData(change.change).elemID.typeName === ARTICLE_ATTACHMENT_TYPE_NAME && isAdditionChange(change.change)))
+
+  const articleElemIdToChange = _.keyBy(articleModificationChanges, getNameFromChange)
+  return articleAttachmentAdditionChanges.map(change => {
+    const parent = getParents(getChangeData(change.change))[0]
+    const parentElemId = parent ? parent.elemID.getFullName() : ''
+    if (articleElemIdToChange[parentElemId] !== undefined) {
+      return dependencyChange(
+        'add',
+        change.key,
+        articleElemIdToChange[parentElemId].key,
+      )
+    }
+    return undefined
+  }).filter(isDefined)
+}
+
+
+export const articleAttachmentDependencyChanger: DependencyChanger = async changes => {
+  const potentialChanges = Array.from(changes.entries())
+    .map(([key, change]) => ({ key, change }))
+    .filter(
+      (change): change is { key: collections.set.SetId; change: Change<InstanceElement> } =>
+        isInstanceChange(change.change)
+    )
+
+  return getDependencies(potentialChanges)
+}

--- a/packages/zendesk-adapter/src/dependency_changers/article_attachment_change.ts
+++ b/packages/zendesk-adapter/src/dependency_changers/article_attachment_change.ts
@@ -20,17 +20,18 @@ import {
   InstanceElement, isAdditionChange,
   isInstanceChange, isModificationChange,
 } from '@salto-io/adapter-api'
-import { collections, values as lowerDashValues } from '@salto-io/lowerdash'
+import { values as lowerDashValues } from '@salto-io/lowerdash'
 import { getParents } from '@salto-io/adapter-utils'
+import { deployment } from '@salto-io/adapter-components'
 import _ from 'lodash'
 import { ARTICLE_ATTACHMENT_TYPE_NAME, ARTICLE_TYPE_NAME } from '../constants'
 
 const { isDefined } = lowerDashValues
 
-const getNameFromChange = (change: { key: collections.set.SetId; change: Change<InstanceElement> }): string =>
+const getNameFromChange = (change: deployment.dependency.ChangeWithKey<Change<InstanceElement>>): string =>
   getChangeData(change.change).elemID.getFullName()
 
-const getDependencies = (changes: { key: collections.set.SetId; change: Change<InstanceElement> }[])
+const getDependencies = (changes: deployment.dependency.ChangeWithKey<Change<InstanceElement>>[])
   : DependencyChange[] => {
   const articleModificationChanges = changes.filter(change =>
     (getChangeData(change.change).elemID.typeName === ARTICLE_TYPE_NAME && isModificationChange(change.change)))
@@ -40,7 +41,10 @@ const getDependencies = (changes: { key: collections.set.SetId; change: Change<I
   const articleElemIdToChange = _.keyBy(articleModificationChanges, getNameFromChange)
   return articleAttachmentAdditionChanges.map(change => {
     const parent = getParents(getChangeData(change.change))[0]
-    const parentElemId = parent ? parent.elemID.getFullName() : ''
+    if (parent === undefined) {
+      return undefined
+    }
+    const parentElemId = parent.elemID.getFullName()
     if (articleElemIdToChange[parentElemId] !== undefined) {
       return dependencyChange(
         'add',
@@ -52,12 +56,16 @@ const getDependencies = (changes: { key: collections.set.SetId; change: Change<I
   }).filter(isDefined)
 }
 
-
+/**
+ * This dependency changer is used to add dependency between article attachments and their parent article in the case
+ * where the article attachment changes are additions and the article changes are modifications. This is because
+ * addition of article attachments do not work without the deploy of the corresponding modified article.
+ */
 export const articleAttachmentDependencyChanger: DependencyChanger = async changes => {
   const potentialChanges = Array.from(changes.entries())
     .map(([key, change]) => ({ key, change }))
     .filter(
-      (change): change is { key: collections.set.SetId; change: Change<InstanceElement> } =>
+      (change): change is deployment.dependency.ChangeWithKey<Change<InstanceElement>> =>
         isInstanceChange(change.change)
     )
 

--- a/packages/zendesk-adapter/src/dependency_changers/index.ts
+++ b/packages/zendesk-adapter/src/dependency_changers/index.ts
@@ -19,6 +19,7 @@ import { collections } from '@salto-io/lowerdash'
 import { customFieldOptionDependencyChanger } from './custom_field_option_change'
 import { guideOrderDependencyChanger } from './guide_order_change'
 import { ticketFormDependencyChanger } from './ticket_form_change'
+import { articleAttachmentDependencyChanger } from './article_attachment_change'
 
 const { awu } = collections.asynciterable
 
@@ -27,6 +28,7 @@ const DEPENDENCY_CHANGERS: DependencyChanger[] = [
   customFieldOptionDependencyChanger,
   guideOrderDependencyChanger,
   ticketFormDependencyChanger,
+  articleAttachmentDependencyChanger,
 ]
 
 export const dependencyChanger: DependencyChanger = async (

--- a/packages/zendesk-adapter/test/dependency_changers/article_attachment_change.test.ts
+++ b/packages/zendesk-adapter/test/dependency_changers/article_attachment_change.test.ts
@@ -1,0 +1,92 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  InstanceElement,
+  toChange,
+  CORE_ANNOTATIONS,
+  ReferenceExpression, ObjectType, ElemID,
+} from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import {
+  ARTICLE_ATTACHMENT_TYPE_NAME,
+  ARTICLE_TYPE_NAME,
+  ZENDESK,
+} from '../../src/constants'
+import { articleAttachmentDependencyChanger } from '../../src/dependency_changers/article_attachment_change'
+
+describe('articleAttachmentDependencyChanger', () => {
+  const articleType = new ObjectType({ elemID: new ElemID(ZENDESK, ARTICLE_TYPE_NAME) })
+  const articleAttachmentType = new ObjectType({ elemID: new ElemID(ZENDESK, ARTICLE_ATTACHMENT_TYPE_NAME) })
+  const article = new InstanceElement(
+    'article',
+    articleType,
+    {
+      attachments: [],
+    }
+  )
+  const articleAttachment = new InstanceElement(
+    'attachment1',
+    articleAttachmentType,
+    {},
+    undefined,
+    { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(article.elemID, article)] }
+  )
+
+  article.value.attachments = [
+    new ReferenceExpression(articleAttachment.elemID, articleAttachment),
+  ]
+
+  it('should add dependency from attachment to its parent in addition of attachment', async () => {
+    const inputChanges = new Map([
+      [0, toChange({ after: articleAttachment })],
+      [1, toChange({ before: article, after: article })],
+    ])
+    const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([
+      [0, new Set()], [1, new Set()],
+    ])
+
+    const dependencyChanges = [...await articleAttachmentDependencyChanger(inputChanges, inputDeps)]
+    expect(dependencyChanges.length).toBe(1)
+    expect(dependencyChanges.every(change => change.action === 'add')).toBe(true)
+    expect(dependencyChanges[0].dependency).toMatchObject({ source: 0, target: 1 })
+  })
+  it('should not add dependency from attachment to its parent in addition of both', async () => {
+    const inputChanges = new Map([
+      [0, toChange({ after: articleAttachment })],
+      [1, toChange({ after: article })],
+    ])
+    const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([
+      [0, new Set()], [1, new Set()],
+    ])
+
+    const dependencyChanges = [...await articleAttachmentDependencyChanger(inputChanges, inputDeps)]
+    expect(dependencyChanges.length).toBe(0)
+  })
+  it('should crush and add dependency if parent is not defined for attachment', async () => {
+    const clonedAttachment = articleAttachment.clone()
+    clonedAttachment.annotations[CORE_ANNOTATIONS.PARENT] = []
+    const inputChanges = new Map([
+      [0, toChange({ after: clonedAttachment })],
+      [1, toChange({ after: article })],
+    ])
+    const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([
+      [0, new Set()], [1, new Set()],
+    ])
+
+    const dependencyChanges = [...await articleAttachmentDependencyChanger(inputChanges, inputDeps)]
+    expect(dependencyChanges.length).toBe(0)
+  })
+})


### PR DESCRIPTION
add dependency between attachment to article

---

_Additional context for reviewer_

---
_Release Notes_: 
* deploy of addition of attachments to an article with change validator errors will fail.

---
_User Notifications_: 
None
