### PR TITLE
Keep bundle inner-types relations

### DIFF
--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -62,8 +62,8 @@ const logging = (message: string): void => {
 describe('Netsuite adapter E2E with real account', () => {
   let adapter: NetsuiteAdapter
   let credentialsLease: CredsLease<Required<Credentials>>
-  const { standardTypes, additionalTypes } = getMetadataTypes()
-  const metadataTypes = metadataTypesToList({ standardTypes, additionalTypes })
+  const { standardTypes, additionalTypes, innerAdditionalTypes } = getMetadataTypes()
+  const metadataTypes = metadataTypesToList({ standardTypes, additionalTypes, innerAdditionalTypes })
 
   const createInstanceElement = (typeName: string, valuesOverride: Values, annotations?: Values): InstanceElement => {
     const instValues = {

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -24,7 +24,7 @@ import { logger } from '@salto-io/logging'
 import { filter } from '@salto-io/adapter-utils'
 import { createElements } from './transformer'
 import { DeployResult, isCustomRecordType } from './types'
-import { INTEGRATION } from './constants'
+import { BUNDLE, INTEGRATION } from './constants'
 import convertListsToMaps from './filters/convert_lists_to_maps'
 import replaceElementReferences from './filters/element_references'
 import parseReportTypes from './filters/parse_report_types'
@@ -81,7 +81,6 @@ import { getDataElements } from './data_elements/data_elements'
 import { getStandardTypesNames } from './autogen/types'
 import { getConfigTypes, toConfigElements } from './suiteapp_config_elements'
 import { ConfigRecord } from './client/suiteapp_client/types'
-import { bundleType } from './types/bundle_type'
 
 const { makeArray } = collections.array
 const { awu } = collections.asynciterable
@@ -284,9 +283,8 @@ export default class NetsuiteAdapter implements AdapterOperations {
     )
     progressReporter.reportProgress({ message: 'Fetching file cabinet items' })
 
-    const bundleTypeName = bundleType().type.elemID.typeName
     const bundlesCustomInfo = (await this.client.getInstalledBundles())
-      .map(bundle => ({ typeName: bundleTypeName, values: { ...bundle, id: bundle.id.toString() } }))
+      .map(bundle => ({ typeName: BUNDLE, values: { ...bundle, id: bundle.id.toString() } }))
     // TODO: remove this log when SALTO-2602 is open for all customers
     log.debug('The following bundle ids are missing in the bundle record: %o', bundlesCustomInfo.map(bundle => bundle.values.id))
     const {

--- a/packages/netsuite-adapter/src/transformer.ts
+++ b/packages/netsuite-adapter/src/transformer.ts
@@ -202,7 +202,7 @@ export const createElements = async (
   elementsSource: ReadOnlyElementsSource,
   getElemIdFunc?: ElemIdGetter,
 ): Promise<Array<InstanceElement | TypeElement>> => {
-  const { standardTypes, additionalTypes } = getMetadataTypes()
+  const { standardTypes, additionalTypes, innerAdditionalTypes } = getMetadataTypes()
 
   getTopLevelStandardTypes(standardTypes).concat(Object.values(additionalTypes))
     .forEach(addApplicationIdToType)
@@ -236,7 +236,7 @@ export const createElements = async (
   )
 
   return [
-    ...metadataTypesToList({ standardTypes, additionalTypes }),
+    ...metadataTypesToList({ standardTypes, additionalTypes, innerAdditionalTypes }),
     ...instances,
     ...customRecordTypes,
   ]

--- a/packages/netsuite-adapter/src/types.ts
+++ b/packages/netsuite-adapter/src/types.ts
@@ -77,12 +77,23 @@ export const removeCustomRecordTypePrefix = (name: string): string =>
 type MetadataTypes = {
   standardTypes: TypesMap<StandardType>
   additionalTypes: Readonly<Record<string, ObjectType>>
+  innerAdditionalTypes: Readonly<Record<string, ObjectType>>
 }
 
-export const getMetadataTypes = (): MetadataTypes => ({
-  standardTypes: getStandardTypes(),
-  additionalTypes: { ...getFileCabinetTypes(), ...getConfigurationTypes(), bundle: bundleType().type },
-})
+export const getMetadataTypes = (): MetadataTypes => {
+  const bundle = bundleType()
+  return {
+    standardTypes: getStandardTypes(),
+    additionalTypes: {
+      ...getFileCabinetTypes(),
+      ...getConfigurationTypes(),
+      [BUNDLE]: bundle.type,
+    },
+    innerAdditionalTypes: {
+      ...bundle.innerTypes,
+    },
+  }
+}
 
 export const getTopLevelStandardTypes = (standardTypes: TypesMap<StandardType>): ObjectType[] =>
   Object.values(standardTypes).map(standardType => standardType.type)
@@ -91,14 +102,14 @@ export const getInnerStandardTypes = (standardTypes: TypesMap<StandardType>): Ob
   Object.values(standardTypes).flatMap(standardType => Object.values(standardType.innerTypes))
 
 export const metadataTypesToList = (metadataTypes: MetadataTypes): TypeElement[] => {
-  const { standardTypes, additionalTypes } = metadataTypes
+  const { standardTypes, additionalTypes, innerAdditionalTypes } = metadataTypes
   return [
     ...getTopLevelStandardTypes(standardTypes),
     ...getInnerStandardTypes(standardTypes),
     ...Object.values(enums),
     ...Object.values(additionalTypes),
     ...Object.values(fieldTypes),
-    ...Object.values(bundleType().innerTypes),
+    ...Object.values(innerAdditionalTypes),
   ]
 }
 

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -133,8 +133,8 @@ describe('Adapter', () => {
     progressReporter: { reportProgress: jest.fn() },
   }
 
-  const { standardTypes, additionalTypes } = getMetadataTypes()
-  const metadataTypes = metadataTypesToList({ standardTypes, additionalTypes })
+  const { standardTypes, additionalTypes, innerAdditionalTypes } = getMetadataTypes()
+  const metadataTypes = metadataTypesToList({ standardTypes, additionalTypes, innerAdditionalTypes })
     .concat(createCustomRecordTypes([], standardTypes.customrecordtype.type))
 
   beforeEach(() => {

--- a/packages/netsuite-adapter/test/sdf_folder_loader.test.ts
+++ b/packages/netsuite-adapter/test/sdf_folder_loader.test.ts
@@ -116,8 +116,8 @@ describe('sdf folder loader', () => {
     })
     expect(parseSdfProjectDirMock).toHaveBeenCalledWith('projectDir')
 
-    const { standardTypes, additionalTypes } = getMetadataTypes()
-    const metadataTypes = metadataTypesToList({ standardTypes, additionalTypes })
+    const { standardTypes, additionalTypes, innerAdditionalTypes } = getMetadataTypes()
+    const metadataTypes = metadataTypesToList({ standardTypes, additionalTypes, innerAdditionalTypes })
       .concat(createCustomRecordTypes([], standardTypes.customrecordtype.type))
 
     // metadataTypes + folderInstance + fileInstance + featuresInstance + customTypeInstance + customRecordType


### PR DESCRIPTION
We should create the bundle type and its inner types once, so the field types of the bundle type will point to the same inner type objects that we return.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
