### PR TITLE
SALTO-4525: add alias to dummy adapter

### DIFF
--- a/packages/dummy-adapter/src/adapter.ts
+++ b/packages/dummy-adapter/src/adapter.ts
@@ -15,25 +15,11 @@
 */
 import {
   FetchResult, AdapterOperations, DeployResult, FetchOptions,
-  DeployOptions, DeployModifiers, getChangeData, isInstanceElement, Element, isObjectType, CORE_ANNOTATIONS,
+  DeployOptions, DeployModifiers, getChangeData, isInstanceElement,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { generateElements, GeneratorParams } from './generator'
 import { changeValidator } from './change_validator'
-
-// will add alias only to instances under records and custom objects under objects
-export const addAlias = (element: Element): void => {
-  if (isInstanceElement(element) && element.path && element.path[1] === 'Records') {
-    element.annotations[CORE_ANNOTATIONS.ALIAS] = `${element.elemID.name}_alias`
-  }
-  if (isObjectType(element) && element.path && element.path[1] === 'Objects') {
-    // for when element is split to annotations and fields files
-    if (_.last(element.path)?.endsWith('Fields')) {
-      return
-    }
-    element.annotations[CORE_ANNOTATIONS.ALIAS] = `${element.elemID.name}_alias`
-  }
-}
 
 export default class DummyAdapter implements AdapterOperations {
   public constructor(private genParams: GeneratorParams) {
@@ -44,10 +30,8 @@ export default class DummyAdapter implements AdapterOperations {
    * Account credentials were given in the constructor.
    */
   public async fetch({ progressReporter }: FetchOptions): Promise<FetchResult> {
-    const elements = await generateElements(this.genParams, progressReporter)
-    elements.forEach(addAlias)
     return {
-      elements,
+      elements: await generateElements(this.genParams, progressReporter),
     }
   }
 

--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -540,6 +540,7 @@ export const generateElements = async (
         annotationRefsOrTypes,
         annotations: await generateAnnotations(annotationRefsOrTypes),
       })
+      fullObjType.annotations[CORE_ANNOTATIONS.ALIAS] = `${fullObjType.elemID.name}_alias`
       const fieldsObjType = new ObjectType({
         elemID: fullObjType.elemID,
         fields: fullObjType.fields,
@@ -570,6 +571,7 @@ export const generateElements = async (
       ),
       [DUMMY_ADAPTER, 'Records', instanceType.elemID.name, name]
     )
+    record.annotations[CORE_ANNOTATIONS.ALIAS] = `${instanceType.elemID.name}_alias`
     if (randomGen() < defaultParams.parentFreq) {
       record.annotations[CORE_ANNOTATIONS.PARENT] = new ReferenceExpression(
         chooseObjIgnoreRank().elemID

--- a/packages/dummy-adapter/test/adapter.test.ts
+++ b/packages/dummy-adapter/test/adapter.test.ts
@@ -104,21 +104,21 @@ describe('dummy adapter', () => {
     it('should add alias to instances and custom objects', async () => {
       const mockReporter = { reportProgress: jest.fn() }
       const fetchResult = await adapter.fetch({ progressReporter: mockReporter })
-      expect(fetchResult.elements.every(elem => {
+      fetchResult.elements.forEach(elem => {
         if (isInstanceElement(elem)
           && elem.elemID.typeName !== 'Profile'
           && elem.path
           && elem.path[1] === 'Records') {
-          return elem.annotations[CORE_ANNOTATIONS.ALIAS] !== undefined
-        }
-        if (isObjectType(elem)
+          expect(elem.annotations[CORE_ANNOTATIONS.ALIAS]).toBeDefined()
+        } else if (isObjectType(elem)
           && elem.path
           && elem.path[1] === 'Objects'
           && _.last(elem.path)?.endsWith('Annotations')) {
-          return elem.annotations[CORE_ANNOTATIONS.ALIAS] !== undefined
+          expect(elem.annotations[CORE_ANNOTATIONS.ALIAS]).toBeDefined()
+        } else {
+          expect(elem.annotations[CORE_ANNOTATIONS.ALIAS]).not.toBeDefined()
         }
-        return elem.annotations[CORE_ANNOTATIONS.ALIAS] === undefined
-      })).toBeTruthy()
+      })
     })
   })
 

--- a/packages/dummy-adapter/test/adapter.test.ts
+++ b/packages/dummy-adapter/test/adapter.test.ts
@@ -23,7 +23,7 @@ import {
   isObjectType, CORE_ANNOTATIONS,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import DummyAdapter, { addAlias } from '../src/adapter'
+import DummyAdapter from '../src/adapter'
 import * as generator from '../src/generator'
 import testParams from './test_params'
 import { ChangeErrorFromConfigFile, DUMMY_ADAPTER } from '../src/generator'
@@ -92,9 +92,7 @@ describe('dummy adapter', () => {
     it('should return the result of the generateElement command withuot modifications', async () => {
       const mockReporter = { reportProgress: jest.fn() }
       const fetchResult = await adapter.fetch({ progressReporter: mockReporter })
-      const elements = await generator.generateElements(testParams, mockReporter)
-      elements.forEach(addAlias)
-      expect(fetchResult).toEqual({ elements })
+      expect(fetchResult).toEqual({ elements: await generator.generateElements(testParams, mockReporter) })
     })
     it('should report fetch progress', async () => {
       await adapter.fetch({ progressReporter: progressReportMock })
@@ -108,6 +106,7 @@ describe('dummy adapter', () => {
       const fetchResult = await adapter.fetch({ progressReporter: mockReporter })
       expect(fetchResult.elements.every(elem => {
         if (isInstanceElement(elem)
+          && elem.elemID.typeName !== 'Profile'
           && elem.path
           && elem.path[1] === 'Records') {
           return elem.annotations[CORE_ANNOTATIONS.ALIAS] !== undefined


### PR DESCRIPTION
add alias to dummy adapter

---

_Additional context for reviewer_
added only for instances and custom objects

---
_Release Notes_: 
None

---
_User Notifications_: 
None
