### PR TITLE
SALTO-4282 add SF change validators documentation

### DIFF
--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -268,17 +268,29 @@ For more details see the DeployOptions section in the [salesforce documentation 
 | overrides | Profile and PermissionSet are set to 1 | Chunk size for specific metadata types       |
 
 ## Validator Configuration Options
-| Name                  | Default when undefined | Description                                                                                       |
-|-----------------------|------------------------|---------------------------------------------------------------------------------------------------|
-| managedPackage        | true                   | Disallow changes to objects and fields that are part of a managed package                         |
-| picklistStandardField | true                   | It is forbidden to modify a picklist on a standard field. Only StandardValueSet is allowed        |
-| customObjectInstances | true                   | Validate permissions of creating / update data records                                            |
-| unknownField          | true                   | Disallow deploying an unknown field type                                                          |
-| customFieldType       | true                   | Ensure the type given to a custom field is a valid type for custom fields                         |
-| standardFieldLabel    | true                   | Disallow changing a label of a standard field                                                     |
-| profileMapKeys        | true                   | Ensure proper structure of profiles before deploying                                              |
-| multipleDefaults      | true                   | Check for multiple default values in picklists and other places where only one default is allowed |
-| picklistPromote       | true                   | Disallow promoting picklist value-set to global since it cannot be done with the API              |
-| validateOnlyFlag      | true                   | Disallow deploying data records in a validation only deploy                                       |
-| dataCategoryGroup     | true                   | Warn when deploying additions or changes to DataCategoryGroup elements                            |
-| installedPackages     | true                   | Disallow any changes on metadata instances of type InstalledPackage.                              |
+| Name                         | Default when undefined | Description                                                                                       |
+|------------------------------|------------------------|---------------------------------------------------------------------------------------------------|
+| managedPackage               | true                   | Disallow changes to objects and fields that are part of a managed package                         |
+| picklistStandardField        | true                   | It is forbidden to modify a picklist on a standard field. Only StandardValueSet is allowed        |
+| customObjectInstances        | true                   | Validate permissions of creating / update data records                                            |
+| unknownField                 | true                   | Disallow deploying an unknown field type                                                          |
+| customFieldType              | true                   | Ensure the type given to a custom field is a valid type for custom fields                         |
+| standardFieldLabel           | true                   | Disallow changing a label of a standard field                                                     |
+| mapKeys                      | true                   | Ensure proper structure of profiles before deploying                                              |
+| multipleDefaults             | true                   | Check for multiple default values in picklists and other places where only one default is allowed |
+| picklistPromote              | true                   | Disallow promoting picklist value-set to global since it cannot be done with the API              |
+| dataCategoryGroup            | true                   | Warn when deploying additions or changes to DataCategoryGroup elements                            |
+| installedPackages            | true                   | Disallow any changes on metadata instances of type InstalledPackage.                              |
+| recordTypeDeletion           | true                   | Disallow deletion of recordType.                                                                  |
+| flowsValidator               | true                   | Better flows versions management, mostly regarding the work with active flows.                    |
+| cpqValidator                 | true                   | Disallow any CPQ changes before disabling CPQ trigger on SF org.                                  |
+| fullNameChangedValidator     | true                   | Disallow any fullName property changes.                                                           |
+| invalidListViewFilterScope   | true                   | Disallow usage of some scopes as the 'filterScope' property of a ListView element.                |
+| caseAssignmentRulesValidator | true                   | Disallow deployment of case assignment rules with case teams.                                     |
+| unknownUser                  | true                   | Disallow any changes with reference to non existing users in the target org.                      |
+| animationRuleRecordType      | true                   | Disallow deployment of AnimationRule with invalid RecordType.                                     |
+| currencyIsoCodes             | true                   | Disallow any changes that includes unsupported org currency.                                      |
+| duplicateRulesSortOrder      | true                   | Disallow deployment of duplicate rule instances that are not in sequential order.                 |
+| lastLayoutRemoval            | true                   | Disallow deletion of the last layout for custom objects.                                          |
+| accountSettings              | true                   | Cannot set a value for enableAccountOwnerReport without proper org setting.                       |
+| unknownPicklistValues        | true                   | Disallow any usage of unknown pickList values.                                                    |


### PR DESCRIPTION
SALTO-4282 add SF change validators documentation
---

_Additional context for reviewer_
1. I deleted one table entry that did not showed up inhttps://github.com/salto-io/salto/blob/main/packages/salesforce-adapter/config_doc.md
2. one rename based on the same file.
3. I did not include omitData and dataChange CVs as they are used internally. 

---
_Release Notes_: 
none

---
_User Notifications_: 
none
