### PR TITLE
SALTO-4533: State static files are flushed twice for each workspace flush

### DIFF
--- a/packages/core/src/local-workspace/s3_dir_store.ts
+++ b/packages/core/src/local-workspace/s3_dir_store.ts
@@ -41,7 +41,7 @@ export const buildS3DirectoryStore = (
     concurrencyLimit?: number
   }
 ): staticFiles.StateStaticFilesStore => {
-  const updated: Record<string, dirStore.File<Buffer>> = {}
+  let updated: Record<string, dirStore.File<Buffer>> = {}
   const s3 = S3Client ?? createS3Client()
   const bottleneck = new Bottleneck({ maxConcurrent: concurrencyLimit })
 
@@ -134,6 +134,7 @@ export const buildS3DirectoryStore = (
 
   const flush = async (): Promise<void> => {
     await Promise.all(Object.values(updated).map(f => writeFile(f)))
+    updated = {}
   }
 
   return {

--- a/packages/core/src/local-workspace/s3_dir_store.ts
+++ b/packages/core/src/local-workspace/s3_dir_store.ts
@@ -133,8 +133,11 @@ export const buildS3DirectoryStore = (
   )
 
   const flush = async (): Promise<void> => {
-    await Promise.all(Object.values(updated).map(f => writeFile(f)))
-    updated = {}
+    const entries = Object.entries(updated)
+    await Promise.all(entries.map(async ([key, file]) => {
+      await writeFile(file)
+      delete updated[key]
+    }))
   }
 
   return {

--- a/packages/core/src/local-workspace/s3_dir_store.ts
+++ b/packages/core/src/local-workspace/s3_dir_store.ts
@@ -133,11 +133,9 @@ export const buildS3DirectoryStore = (
   )
 
   const flush = async (): Promise<void> => {
-    const entries = Object.entries(updated)
-    await Promise.all(entries.map(async ([key, file]) => {
-      await writeFile(file)
-      delete updated[key]
-    }))
+    const files = Object.values(updated)
+    updated = {}
+    await Promise.all(files.map(f => writeFile(f)))
   }
 
   return {

--- a/packages/core/test/workspace/local/s3_dir_store.test.ts
+++ b/packages/core/test/workspace/local/s3_dir_store.test.ts
@@ -189,6 +189,24 @@ describe('buildS3DirectoryStore', () => {
         Body: Buffer.from('aaa'),
       })
     })
+
+    it('should write the file only once', async () => {
+      await directoryStore.set({ filename: 'a/b', buffer: Buffer.from('aaa') })
+
+      expect(putObjectMock).not.toHaveBeenCalled()
+
+      await directoryStore.flush()
+
+      expect(putObjectMock).toHaveBeenCalledWith({
+        Bucket: bucketName,
+        Key: 'baseDir/a/b',
+        Body: Buffer.from('aaa'),
+      })
+
+      await directoryStore.flush()
+
+      expect(putObjectMock).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('getFullPath', () => {


### PR DESCRIPTION
Fixed files in s3_dir_store being flushed twice on each flush of the workspace

---
_Release Notes_: 
- Fixed files in s3_dir_store being flushed twice on each flush of the workspace

---
_User Notifications_: 
None