### PR TITLE
SALTO-4535: bug with non global context change validator

### DIFF
--- a/packages/jira-adapter/src/change_validators/field_contexts/field_contexts.ts
+++ b/packages/jira-adapter/src/change_validators/field_contexts/field_contexts.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ChangeValidator, getChangeData, InstanceElement, isInstanceElement, ReadOnlyElementsSource, ReferenceExpression } from '@salto-io/adapter-api'
+import { ChangeValidator, getChangeData, InstanceElement, isInstanceElement, isReferenceExpression, ReadOnlyElementsSource, ReferenceExpression, UnresolvedReference } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import { isResolvedReferenceExpression } from '@salto-io/adapter-utils'
@@ -32,7 +32,7 @@ const getFieldContexts = async (
 ): Promise<InstanceElement[]> =>
   awu(field.value.contexts)
     .filter((ref): ref is ReferenceExpression => {
-      if (!isResolvedReferenceExpression(ref)) {
+      if (!isReferenceExpression(ref) || ref.value instanceof UnresolvedReference) {
         log.warn(`Found a non reference expression in field ${field.elemID.getFullName()}`)
         return false
       }

--- a/packages/jira-adapter/test/change_validators/field_contexts/field_contexts.test.ts
+++ b/packages/jira-adapter/test/change_validators/field_contexts/field_contexts.test.ts
@@ -113,7 +113,7 @@ describe('Field contexts', () => {
     elementsSource = buildElementsSourceFromElements(elements)
     projectInstance.value[PROJECT_CONTEXTS_FIELD] = []
     fieldInstance.value.contexts = [
-      new ReferenceExpression(contextInstance.elemID, contextInstance),
+      new ReferenceExpression(contextInstance.elemID),
     ]
     expect(await fieldContextValidator(
       changes,


### PR DESCRIPTION
_Fixed a bug in the change validator that should prevent deployment of non-global context that no project references_

---

_Additional context for reviewer_

---
_Release Notes_: 
Jira Adapter:
* Fixed a bug in change validator for non-global contexts

---
_User Notifications_: 
None
