### PR TITLE
Salto 1618/support cross service from workato to zendesk

### DIFF
--- a/packages/workato-adapter/src/constants.ts
+++ b/packages/workato-adapter/src/constants.ts
@@ -18,12 +18,14 @@ export const WORKATO = 'workato'
 export const SALESFORCE = 'salesforce'
 export const NETSUITE = 'netsuite'
 export const ZUORA_BILLING = 'zuora_billing'
+export const ZENDESK = 'zendesk'
 export const JIRA = 'jira'
 
 export const CROSS_SERVICE_SUPPORTED_APPS = {
   [SALESFORCE]: ['salesforce', 'salesforce_secondary'],
   [NETSUITE]: ['netsuite', 'netsuite_secondary'],
   [ZUORA_BILLING]: ['zuora'],
+  [ZENDESK]: ['zendesk', 'zendesk_secondary'],
   [JIRA]: ['jira', 'jira_secondary'],
 }
 

--- a/packages/workato-adapter/src/filters/cross_service/recipe_references.ts
+++ b/packages/workato-adapter/src/filters/cross_service/recipe_references.ts
@@ -22,7 +22,7 @@ import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import { FilterCreator } from '../../filter'
 import { FETCH_CONFIG } from '../../config'
-import { SALESFORCE, NETSUITE, ZUORA_BILLING, JIRA } from '../../constants'
+import { SALESFORCE, NETSUITE, ZUORA_BILLING, JIRA, ZENDESK } from '../../constants'
 import { addNetsuiteRecipeReferences } from './netsuite/reference_finder'
 import { addSalesforceRecipeReferences } from './salesforce/reference_finder'
 import { addZuoraRecipeReferences } from './zuora_billing/reference_finder'
@@ -31,6 +31,8 @@ import { indexNetsuiteByTypeAndScriptId } from './netsuite/element_index'
 import { indexZuoraByElemId } from './zuora_billing/element_index'
 import { indexJira } from './jira/element_index'
 import { addJiraRecipeReferences } from './jira/reference_finder'
+import { indexZendesk } from './zendesk/element_index'
+import { addZendeskRecipeReferences } from './zendesk/reference_finder'
 
 const log = logger(module)
 const { makeArray } = collections.array
@@ -135,6 +137,13 @@ const addReferencesForConnectionRecipes = async (
     const index = indexJira(serviceElements)
     await awu(relevantRecipeCodes).forEach(
       inst => addJiraRecipeReferences(inst, index, appName)
+    )
+  }
+
+  if (serviceName === ZENDESK) {
+    const index = indexZendesk(serviceElements)
+    await awu(relevantRecipeCodes).forEach(
+      inst => addZendeskRecipeReferences(inst, index, appName)
     )
   }
 }

--- a/packages/workato-adapter/src/filters/cross_service/reference_finders.ts
+++ b/packages/workato-adapter/src/filters/cross_service/reference_finders.ts
@@ -23,12 +23,13 @@ import { NetsuiteBlock } from './netsuite/recipe_block_types'
 import { ZuoraBlock } from './zuora_billing/recipe_block_types'
 import { BlockBase } from './recipe_block_types'
 import { JiraBlock } from './jira/recipe_block_types'
+import { ZendeskBlock } from './zendesk/recipe_block_types'
 
 const { isDefined } = lowerdashValues
 const { matchAll } = strings
 const log = logger(module)
 
-type SupportedRecipeBlock = SalesforceBlock | NetsuiteBlock | ZuoraBlock | JiraBlock
+type SupportedRecipeBlock = SalesforceBlock | NetsuiteBlock | ZuoraBlock | JiraBlock | ZendeskBlock
 
 
 export type MappedReference = FlatDetailedDependency & {

--- a/packages/workato-adapter/src/filters/cross_service/zendesk/element_index.ts
+++ b/packages/workato-adapter/src/filters/cross_service/zendesk/element_index.ts
@@ -1,0 +1,133 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import Joi from 'joi'
+import { Element, InstanceElement, ReferenceExpression, isInstanceElement, isReferenceExpression } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { createSchemeGuard } from '@salto-io/adapter-utils'
+
+const ZENDESK_TICKET_FIELD_TYPE = 'ticket_field'
+const ZENDESK_USER_FIELD_TYPE = 'user_field'
+const ZENDESK_ORGANIZATION_FIELD_TYPE = 'organization_field'
+const ZENDESK_MACRO_TYPE = 'macro'
+const ZENDESK_GROUP_TYPE = 'group'
+const ZENDESK_BRAND_TYPE = 'brand'
+const ZENDESK_TICKET_FORM_TYPE = 'ticket_form'
+
+export type ZendeskIndex = {
+  elementsByInternalID: Record<string, Record<number, Readonly<InstanceElement>>>
+  customFieldsByKey: Record<string, Record<string, Readonly<InstanceElement>>>
+  ticketCustomOptionByFieldIdAndValue: Record<number, Record<string, Readonly<InstanceElement>>>
+  customOptionsByFieldKeyAndValue: Record<string, Record<string, Record<string, Readonly<InstanceElement>>>>
+}
+
+type fieldWithOption = InstanceElement & {
+  value: {
+    // eslint-disable-next-line camelcase
+    custom_field_options: ReferenceExpression[]
+  }
+}
+
+const FIELD_SCHEMA = Joi.object({
+  value: Joi.object({
+    // eslint-disable-next-line camelcase
+    custom_field_options: Joi.array().required(),
+  }).unknown(true).required(),
+}).unknown(true).required()
+
+const isFieldWithOptions = createSchemeGuard<fieldWithOption>(FIELD_SCHEMA)
+
+const indexElementsByInternalID = (
+  elements: InstanceElement[],
+): Record<number, Readonly<InstanceElement>> => _.keyBy(
+  elements.filter(isInstanceElement).filter(e => !Number.isNaN(Number(e.value.id))),
+  e => Number(e.value.id),
+)
+
+const isKeyStringInstance = (
+  element: Readonly<Element>
+): element is InstanceElement & { value: { key: string }} => (
+  isInstanceElement(element) && element.value.key !== undefined && _.isString(element.value.key)
+)
+
+const indexByKey = (
+  elements: ReadonlyArray<Readonly<Element>>, typeName: string
+): Record<string, Readonly<InstanceElement>> => _.keyBy(
+  elements
+    .filter(isKeyStringInstance)
+    .filter(e => e.elemID.typeName === typeName),
+  e => e.value.key,
+)
+
+const isOptionValueInstance = (
+  element: Readonly<Element>
+): element is InstanceElement & { value: { value: string }} => (
+  isInstanceElement(element) && element.value.value !== undefined && _.isString(element.value.value)
+)
+
+const indexCustomOptionByFieldAndValue = (
+  indexedFields: Record<string | number, Readonly<InstanceElement>>
+): Record<string| number, Record<string, Readonly<InstanceElement>>> => {
+  const mapFieldsToCustomOptions = (
+    field: Readonly<InstanceElement>
+  ): Record<string, Readonly<InstanceElement>> => _.keyBy(
+    isFieldWithOptions(field)
+      ? field.value.custom_field_options
+        .filter(isReferenceExpression)
+        .map(ref => ref.value)
+        .filter(isOptionValueInstance)
+      : [],
+    e => e.value.value,
+  )
+
+  return _.mapValues(
+    indexedFields,
+    mapFieldsToCustomOptions,
+  )
+}
+
+export const indexZendesk = (
+  elements: ReadonlyArray<Readonly<Element>>
+): ZendeskIndex => {
+  const instances = elements.filter(isInstanceElement)
+
+  const fieldsByKey = {
+    user: indexByKey(instances, ZENDESK_USER_FIELD_TYPE),
+    organization: indexByKey(instances, ZENDESK_ORGANIZATION_FIELD_TYPE),
+  }
+
+  // User and organization custom fields parsed as field_<value.key>
+  // whereas ticket custom field parsed as field_<ID>
+  const optionsByFieldKeyAndValue = {
+    user: indexCustomOptionByFieldAndValue(fieldsByKey.user),
+    organization: indexCustomOptionByFieldAndValue(fieldsByKey.organization),
+  }
+
+  const internalIdIndex = {
+    macros: indexElementsByInternalID(instances.filter(e => e.elemID.typeName === ZENDESK_MACRO_TYPE)),
+    groups: indexElementsByInternalID(instances.filter(e => e.elemID.typeName === ZENDESK_GROUP_TYPE)),
+    brands: indexElementsByInternalID(instances.filter(e => e.elemID.typeName === ZENDESK_BRAND_TYPE)),
+    ticketForms: indexElementsByInternalID(instances.filter(e => e.elemID.typeName === ZENDESK_TICKET_FORM_TYPE)),
+    ticketFields: indexElementsByInternalID(instances.filter(e => e.elemID.typeName === ZENDESK_TICKET_FIELD_TYPE)),
+  }
+
+  return {
+    elementsByInternalID: internalIdIndex,
+    customFieldsByKey: fieldsByKey,
+    ticketCustomOptionByFieldIdAndValue: indexCustomOptionByFieldAndValue(internalIdIndex.ticketFields),
+    customOptionsByFieldKeyAndValue: optionsByFieldKeyAndValue,
+  }
+}

--- a/packages/workato-adapter/src/filters/cross_service/zendesk/recipe_block_types.ts
+++ b/packages/workato-adapter/src/filters/cross_service/zendesk/recipe_block_types.ts
@@ -1,0 +1,38 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import Joi from 'joi'
+import { Value } from '@salto-io/adapter-api'
+import { createSchemeGuard } from '@salto-io/adapter-utils'
+import { BlockBase } from '../recipe_block_types'
+
+export type ZendeskBlock = BlockBase & {
+  as: string
+  provider: 'zendesk' | 'zendesk_secondary'
+  name: string
+  input: {
+    [key: string]: Value
+  }
+}
+
+const ZENDESK_BLOCK_SCHEMA = Joi.object({
+  keyword: Joi.string().required(),
+  as: Joi.string().required(),
+  provider: Joi.string().valid('zendesk', 'zendesk_secondary').required(),
+  name: Joi.string().required(),
+  input: Joi.object().required(),
+}).unknown(true).required()
+
+export const isZendeskBlock = createSchemeGuard<ZendeskBlock>(ZENDESK_BLOCK_SCHEMA)

--- a/packages/workato-adapter/src/filters/cross_service/zendesk/reference_finder.ts
+++ b/packages/workato-adapter/src/filters/cross_service/zendesk/reference_finder.ts
@@ -1,0 +1,236 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import {
+  InstanceElement, isInstanceElement, ReferenceExpression,
+  ElemID, Values,
+} from '@salto-io/adapter-api'
+import { DependencyDirection } from '@salto-io/adapter-utils'
+import { values as lowerdashValues } from '@salto-io/lowerdash'
+import { logger } from '@salto-io/logging'
+import { addReferencesForService, FormulaReferenceFinder, MappedReference, ReferenceFinder, getBlockDependencyDirection, createMatcher, Matcher } from '../reference_finders'
+import { ZendeskIndex } from './element_index'
+import { isZendeskBlock, ZendeskBlock } from './recipe_block_types'
+
+const log = logger(module)
+const { isDefined } = lowerdashValues
+const ID_FIELD_REGEX = /^field_(\d+)$/ // pattern: field_<number>
+const KEY_FIELD_REGEX = /^field_([^\s]+)$/ // pattern: field_<string>
+
+const BLOCK_NAMES_BY_TYPE = {
+  ticket: ['update_ticket', 'create_ticket', 'bulk_ticket_update', 'close_ticket'],
+  user: ['search_user', 'update_user', 'create_user'],
+  organization: ['update_organization'],
+  other: ['create_custom_record', 'create_relationship_record', 'bulk_upsert', 'delete_custom_record', 'get_user_by_id', 'get_orgs_by_external_ids', 'lookup_group', 'get_relationship_records', 'create_upload', 'get_custom_record', 'get_tickets_by_external_id', 'list_user_identities'],
+}
+
+type ZendeskFieldMatchGroup = { custom?: string; field: string; block: string }
+
+type CustomFieldsReferencesArgs = {
+  indexKey: Record<string | number, Readonly<InstanceElement>>
+  indexValue: Record<string | number, Record<string, Readonly<InstanceElement>>>
+  regex?: RegExp
+  fieldKeyConverter?: (match: string) => string | number
+}
+
+const isZendeskFieldMatchGroup = (val: Values): val is ZendeskFieldMatchGroup => (
+  (val.custom === undefined || _.isString(val.custom))
+  && _.isString(val.field)
+  && _.isString(val.block)
+)
+
+const createFormulaFieldMatcher = (application: string): Matcher<ZendeskFieldMatchGroup> => {
+  // example: ('data.zendesk.1234abcd.priority')
+  const ticketStandardFieldMatcher = new RegExp(`\\('data\\.${application}\\.(?<block>\\w+)\\.(?<field>\\w+)'\\)`, 'g')
+
+  // example: ('data.zendesk.1234abcd.custom_field.field_6092682303763')
+  // example: ('data.zendesk.1234abcd.organization_fields.field_age')
+  // example: ('data.zendesk.1234abcd.user_field.field_userfield1')
+  // example: ('data.zendesk.1234abcd.users.first.user_field.field_userfield1')
+  // example: ('data.zendesk.1234abcd.get_user_by_id(requester_id>id).user_field.field_userfield1')
+  // example: ('data.zendesk.1234abcd.get_organization_by_id(organization_id>id).organization_fields.field_age')
+  const customFieldMatcher = new RegExp(`\\('data\\.${application}\\.(?<block>\\w+)\\.[^\\']*?\\.(?<custom>\\w+)_fields\\.field_(?<field>\\w+)[^\\']*?'\\)`, 'g')
+
+  return createMatcher(
+    [
+      ticketStandardFieldMatcher,
+      customFieldMatcher,
+    ],
+    isZendeskFieldMatchGroup,
+  )
+}
+
+const getFieldReference = (
+  index: Record<string | number, Readonly<InstanceElement>>,
+  path: ElemID,
+  fieldName?: string | number,
+) : MappedReference | undefined => {
+  if (fieldName === undefined || !isInstanceElement(index[fieldName])) {
+    return undefined
+  }
+
+  return {
+    location: new ReferenceExpression(path),
+    // references inside formulas are always used as input
+    direction: 'input' as DependencyDirection,
+    reference: new ReferenceExpression(index[fieldName].elemID, index[fieldName]),
+  }
+}
+
+export const addZendeskRecipeReferences = async (
+  inst: InstanceElement,
+  indexedElements: ZendeskIndex,
+  appName: string,
+): Promise<void> => {
+  const references: MappedReference[] = []
+  const zendeskBlocks : string[] = []
+
+  const referenceFinder: ReferenceFinder<ZendeskBlock> = (blockValue, path) => {
+    const { input, name } = blockValue
+    zendeskBlocks.push(blockValue.as)
+
+    const direction = getBlockDependencyDirection(blockValue)
+    const inputFieldKeys = Object.keys(input)
+
+    const addPotentialIdReference = (
+      valueInst: unknown, nestedPath?: ElemID,
+    ): boolean => {
+      if (isInstanceElement(valueInst)) {
+        references.push(
+          {
+            pathToOverride: nestedPath,
+            location: new ReferenceExpression(path),
+            direction,
+            reference: new ReferenceExpression(valueInst.elemID, valueInst),
+          },
+        )
+        return true
+      }
+      return false
+    }
+
+    const addCustomFieldsReferences = (
+      { indexKey, indexValue, regex = KEY_FIELD_REGEX, fieldKeyConverter = match => match } : CustomFieldsReferencesArgs
+    ) : void => {
+      inputFieldKeys.forEach(field => {
+        const match = field.match(regex)
+        if (match === null || match.length < 2) {
+          return
+        }
+
+        const fieldKey = fieldKeyConverter(match[1])
+        if (!_.isNaN(fieldKey) && addPotentialIdReference(
+          indexKey[fieldKey]
+          // no pathToOverride because we can't override the field keys in the current format
+        )) {
+          const optionsByValue = indexValue[fieldKey]
+          if (optionsByValue !== undefined && input[field] !== undefined) {
+            addPotentialIdReference(
+              optionsByValue[input[field]],
+              path.createNestedID('input', field),
+            )
+          }
+        }
+      })
+    }
+
+    if (input.macro_ids !== undefined && input.macro_ids.id !== undefined) {
+      addPotentialIdReference(
+        indexedElements.elementsByInternalID.macros[input.macro_ids.id],
+        path.createNestedID('input', 'macro_ids', 'id')
+      )
+    }
+
+    if (input.group_id !== undefined) {
+      addPotentialIdReference(
+        indexedElements.elementsByInternalID.groups[input.group_id],
+        path.createNestedID('input', 'group_id')
+      )
+    }
+
+    if (input.brand_id !== undefined) {
+      addPotentialIdReference(
+        indexedElements.elementsByInternalID.brands[input.brand_id],
+        path.createNestedID('input', 'brand_id')
+      )
+    }
+
+    if (input.ticket_form_id !== undefined) {
+      addPotentialIdReference(
+        indexedElements.elementsByInternalID.ticketForms[input.ticket_form_id],
+        path.createNestedID('input', 'ticket_form_id')
+      )
+    }
+
+    if (BLOCK_NAMES_BY_TYPE.ticket.includes(name)) {
+      addCustomFieldsReferences({
+        indexKey: indexedElements.elementsByInternalID.ticketFields,
+        indexValue: indexedElements.ticketCustomOptionByFieldIdAndValue,
+        regex: ID_FIELD_REGEX,
+        fieldKeyConverter: match => Number(match),
+      })
+    } else if (BLOCK_NAMES_BY_TYPE.user.includes(name)) {
+      addCustomFieldsReferences({
+        indexKey: indexedElements.customFieldsByKey.user,
+        indexValue: indexedElements.customOptionsByFieldKeyAndValue.user,
+      })
+    } else if (BLOCK_NAMES_BY_TYPE.organization.includes(name)) {
+      addCustomFieldsReferences({
+        indexKey: indexedElements.customFieldsByKey.organization,
+        indexValue: indexedElements.customOptionsByFieldKeyAndValue.organization,
+      })
+    }
+
+    return references
+  }
+
+  const formulaFieldMatcher = createFormulaFieldMatcher(appName)
+
+  const formulaReferenceFinder: FormulaReferenceFinder = (value, path) => {
+    const potentialMatchGroups = formulaFieldMatcher(value)
+    return potentialMatchGroups.map(({ custom, block, field: fieldName }) => {
+      if (custom !== undefined && block !== undefined && zendeskBlocks.includes(block)) {
+        if (custom === 'custom') { // === 'ticket'. there is no ticket_fields only custom_fields
+          const fieldId = Number(fieldName)
+          if (!_.isNaN(fieldId)) {
+            return getFieldReference(indexedElements.elementsByInternalID.ticketFields, path, fieldId)
+          }
+          log.debug('Unknown custom_field Zehdesk Formula - %s. field_%s should looks like field_<ID (Number)>', value, custom)
+          return undefined
+        }
+
+        if (custom === 'user') {
+          return getFieldReference(indexedElements.customFieldsByKey.user, path, fieldName)
+        }
+
+        if (custom === 'organization') {
+          return getFieldReference(indexedElements.customFieldsByKey.organization, path, fieldName)
+        }
+        log.debug('Unknown field_%s in Zendesk Formula: %s', custom, value)
+      }
+
+      return undefined
+    }).filter(isDefined)
+  }
+
+  return addReferencesForService<ZendeskBlock>(
+    inst,
+    appName,
+    isZendeskBlock,
+    referenceFinder,
+    formulaReferenceFinder,
+  )
+}

--- a/packages/workato-adapter/test/filters/cross_service/element_index.test.ts
+++ b/packages/workato-adapter/test/filters/cross_service/element_index.test.ts
@@ -1,0 +1,458 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType, ReferenceExpression, Element, BuiltinTypes, ListType } from '@salto-io/adapter-api'
+import { ZendeskIndex, indexZendesk } from '../../../src/filters/cross_service/zendesk/element_index'
+
+const generateZendeskElements = (): Record<string, Element[]> => {
+  const ticketOptionType = new ObjectType({
+    elemID: new ElemID('zendesk', 'ticket_field__custom_field_options'),
+    fields: {
+      id: { refType: BuiltinTypes.NUMBER },
+      value: { refType: BuiltinTypes.STRING },
+    },
+  })
+
+  const ticketFieldType = new ObjectType({
+    elemID: new ElemID('zendesk', 'ticket_field'),
+    fields: {
+      id: { refType: BuiltinTypes.NUMBER },
+      type: { refType: BuiltinTypes.STRING },
+      key: { refType: BuiltinTypes.STRING },
+      raw_title: { refType: BuiltinTypes.STRING },
+      custom_field_options: { refType: new ListType(BuiltinTypes.NUMBER) },
+    },
+  })
+
+  const organizationOptionType = new ObjectType({
+    elemID: new ElemID('zendesk', 'organization_field__custom_field_options'),
+    fields: {
+      id: { refType: BuiltinTypes.NUMBER },
+      value: { refType: BuiltinTypes.STRING },
+    },
+  })
+
+  const organizationFieldType = new ObjectType({
+    elemID: new ElemID('zendesk', 'organization_field'),
+    fields: {
+      id: { refType: BuiltinTypes.NUMBER },
+      key: { refType: BuiltinTypes.STRING },
+      custom_field_options: { refType: new ListType(BuiltinTypes.NUMBER) },
+    },
+  })
+
+  const userOptionType = new ObjectType({
+    elemID: new ElemID('zendesk', 'user_field__custom_field_options'),
+    fields: {
+      id: { refType: BuiltinTypes.NUMBER },
+      value: { refType: BuiltinTypes.STRING },
+    },
+  })
+
+  const userFieldType = new ObjectType({
+    elemID: new ElemID('zendesk', 'user_field'),
+    fields: {
+      id: { refType: BuiltinTypes.NUMBER },
+      key: { refType: BuiltinTypes.STRING },
+      custom_field_options: { refType: new ListType(BuiltinTypes.NUMBER) },
+    },
+  })
+
+  const macroType = new ObjectType({
+    elemID: new ElemID('zendesk', 'macro'),
+    fields: {
+      id: { refType: BuiltinTypes.NUMBER },
+    },
+  })
+
+  const groupType = new ObjectType({
+    elemID: new ElemID('zendesk', 'group'),
+    fields: {
+      id: { refType: BuiltinTypes.NUMBER },
+    },
+  })
+
+  const brandType = new ObjectType({
+    elemID: new ElemID('zendesk', 'brand'),
+    fields: {
+      id: { refType: BuiltinTypes.NUMBER },
+    },
+  })
+
+  const ticketFormType = new ObjectType({
+    elemID: new ElemID('zendesk', 'ticket_form'),
+    fields: {
+      id: { refType: BuiltinTypes.NUMBER },
+      default: { refType: BuiltinTypes.BOOLEAN },
+      ticket_field_ids: { refType: new ListType(BuiltinTypes.NUMBER) },
+    },
+  })
+
+  const macroInst = new InstanceElement(
+    'macroInstName',
+    macroType,
+    { id: 10 }
+  )
+
+  const groupInst = new InstanceElement(
+    'groupInstName',
+    groupType,
+    { id: 11 }
+  )
+
+  const brandInst = new InstanceElement(
+    'brandInstName',
+    brandType,
+    { id: 15 }
+  )
+
+  const ticketFormInst = new InstanceElement(
+    'ticketFormInstName',
+    ticketFormType,
+    { id: 16, default: false }
+  )
+
+  const ticketFieldPriority = new InstanceElement(
+    'priority',
+    ticketFieldType,
+    {
+      id: 1,
+      type: 'priority',
+      raw_title: 'Priority',
+    }
+  )
+
+  const ticketFieldStatus = new InstanceElement(
+    'status',
+    ticketFieldType,
+    {
+      id: 2,
+      type: 'status',
+      raw_title: 'Status',
+    }
+  )
+
+  const defaultTicketFormInst = new InstanceElement(
+    'defaultTicketFormInstName',
+    ticketFormType,
+    { id: 17,
+      default: true,
+      ticket_field_ids: [
+        new ReferenceExpression(ticketFieldStatus.elemID, ticketFieldStatus),
+        new ReferenceExpression(ticketFieldPriority.elemID, ticketFieldPriority),
+      ] }
+  )
+
+  const ticketField12Option1 = new InstanceElement(
+    'ticketField12Option1Name',
+    ticketOptionType,
+    {
+      id: 121,
+      value: 'field 12 value 1',
+    }
+  )
+
+  const ticketField12Option2 = new InstanceElement(
+    'ticketField12Option2Name',
+    ticketOptionType,
+    {
+      id: 122,
+      value: 'field 12 value 2',
+    }
+  )
+
+  const ticketField12 = new InstanceElement(
+    'ticketField12Name',
+    ticketFieldType,
+    {
+      id: 12,
+      custom_field_options: [
+        new ReferenceExpression(ticketField12Option1.elemID, ticketField12Option1),
+        new ReferenceExpression(ticketField12Option2.elemID, ticketField12Option2),
+      ],
+    }
+  )
+
+  const ticketField13 = new InstanceElement(
+    'ticketField13Name',
+    ticketFieldType,
+    {
+      id: 13,
+    }
+  )
+
+  const ticketField14Option = new InstanceElement(
+    'ticketField14OptionName',
+    ticketOptionType,
+    {
+      id: 141,
+      value: 'same value name',
+    }
+  )
+
+  const ticketField14 = new InstanceElement(
+    'ticketField14Name',
+    ticketFieldType,
+    {
+      id: 14,
+      custom_field_options: [
+        new ReferenceExpression(ticketField14Option.elemID, ticketField14Option),
+      ],
+    }
+  )
+
+  const ticketFieldSame = new InstanceElement(
+    'ticketFieldSameName',
+    ticketFieldType,
+    {
+      id: 0,
+      key: 'same',
+    }
+  )
+
+  const organizationField1Option = new InstanceElement(
+    'organizationField1OptionName',
+    organizationOptionType,
+    {
+      id: 311,
+      value: 'org field 1 value 1',
+    }
+  )
+
+  const organizationField1 = new InstanceElement(
+    'organizationField1Name',
+    organizationFieldType,
+    {
+      id: 31,
+      key: 'organization_field_1',
+      custom_field_options: [
+        new ReferenceExpression(organizationField1Option.elemID, organizationField1Option),
+      ],
+    }
+  )
+
+  const organizationField2Option = new InstanceElement(
+    'organizationField2OptionName',
+    organizationOptionType,
+    {
+      id: 321,
+      value: 'same value name',
+    }
+  )
+
+  const organizationField2 = new InstanceElement(
+    'organizationField2Name',
+    organizationFieldType,
+    {
+      id: 32,
+      key: 'organization_field_2',
+      custom_field_options: [
+        new ReferenceExpression(organizationField2Option.elemID, organizationField2Option),
+      ],
+    }
+  )
+
+  const organizationField3 = new InstanceElement(
+    'organizationField3Name',
+    organizationFieldType,
+    {
+      id: 33,
+      key: 'organization_field_3',
+    }
+  )
+
+  const organizationFieldSameOption = new InstanceElement(
+    'organizationFieldSameOptionName',
+    organizationOptionType,
+    {
+      id: 341,
+      value: 'same',
+    }
+  )
+
+  const organizationFieldSame = new InstanceElement(
+    'organizationFieldSameName',
+    organizationFieldType,
+    {
+      id: 34,
+      key: 'same',
+      custom_field_options: [
+        new ReferenceExpression(organizationFieldSameOption.elemID, organizationFieldSameOption),
+      ],
+    }
+  )
+
+
+  const userField1Option = new InstanceElement(
+    'userField1OptionName',
+    userOptionType,
+    {
+      id: 411,
+      value: 'user field 1 value 1',
+    }
+  )
+
+  const userField1 = new InstanceElement(
+    'userField1Name',
+    userFieldType,
+    {
+      id: 41,
+      key: 'user_field_1',
+      custom_field_options: [
+        new ReferenceExpression(userField1Option.elemID, userField1Option),
+      ],
+    }
+  )
+
+  const userField2Option = new InstanceElement(
+    'userField2OptionName',
+    userOptionType,
+    {
+      id: 421,
+      value: 'same value name',
+    }
+  )
+
+  const userField2 = new InstanceElement(
+    'userField2Name',
+    userFieldType,
+    {
+      id: 42,
+      key: 'user_field_2',
+      custom_field_options: [
+        new ReferenceExpression(userField2Option.elemID, userField2Option),
+      ],
+    }
+  )
+
+  const userField3 = new InstanceElement(
+    'userField3Name',
+    userFieldType,
+    {
+      id: 43,
+      key: 'user_field_3',
+    }
+  )
+
+  const userFieldSameOption = new InstanceElement(
+    'userFieldSameOptionName',
+    userOptionType,
+    {
+      id: 441,
+      value: 'same',
+    }
+  )
+
+  const userFieldSame = new InstanceElement(
+    'userFieldSameName',
+    userFieldType,
+    {
+      id: 44,
+      key: 'same',
+      custom_field_options: [
+        new ReferenceExpression(userFieldSameOption.elemID, userFieldSameOption),
+      ],
+    }
+  )
+
+  return {
+    types: [ticketOptionType, ticketFieldType, organizationOptionType, organizationFieldType,
+      userOptionType, userFieldType, macroType, groupType, brandType, ticketFormType],
+    macros: [macroInst],
+    groups: [groupInst],
+    brands: [brandInst],
+    ticketForms: [ticketFormInst, defaultTicketFormInst],
+    ticketFields: [ticketFieldPriority, ticketFieldStatus, ticketField12, ticketField13, ticketField14,
+      ticketFieldSame],
+    ticketFieldOptions: [ticketField12Option1, ticketField12Option2, ticketField14Option],
+    organizationFields: [organizationField1, organizationField2, organizationField3, organizationFieldSame],
+    organizationFieldOptions: [organizationField1Option, organizationField2Option, organizationFieldSameOption],
+    userFields: [userField1, userField2, userField3, userFieldSame],
+    userFieldOptions: [userField1Option, userField2Option, userFieldSameOption],
+  }
+}
+
+
+describe('indexZendesk', () => {
+  let elements: Record<string, Element[]>
+  let indexed: ZendeskIndex
+
+  beforeEach(() => {
+    elements = generateZendeskElements()
+    indexed = indexZendesk(Object.values(elements).flat())
+  })
+
+  it('should index ticket fields by id', () => {
+    expect(indexed.elementsByInternalID.ticketFields).toBeDefined()
+    expect(indexed.elementsByInternalID.ticketFields[1]).toBe(elements.ticketFields[0])
+    expect(indexed.elementsByInternalID.ticketFields[2]).toBe(elements.ticketFields[1])
+    expect(indexed.elementsByInternalID.ticketFields[12]).toBe(elements.ticketFields[2])
+    expect(indexed.elementsByInternalID.ticketFields[13]).toBe(elements.ticketFields[3])
+    expect(indexed.elementsByInternalID.ticketFields[14]).toBe(elements.ticketFields[4])
+    expect(indexed.elementsByInternalID.ticketFields[0]).toBe(elements.ticketFields[5])
+  })
+  it('should index basic elements by id', () => {
+    expect(indexed.elementsByInternalID.macros).toBeDefined()
+    expect(indexed.elementsByInternalID.macros[10]).toBe(elements.macros[0])
+    expect(indexed.elementsByInternalID.groups).toBeDefined()
+    expect(indexed.elementsByInternalID.groups[11]).toBe(elements.groups[0])
+    expect(indexed.elementsByInternalID.brands).toBeDefined()
+    expect(indexed.elementsByInternalID.brands[15]).toBe(elements.brands[0])
+    expect(indexed.elementsByInternalID.ticketForms).toBeDefined()
+    expect(indexed.elementsByInternalID.ticketForms[16]).toBe(elements.ticketForms[0])
+    expect(indexed.elementsByInternalID.ticketForms[17]).toBe(elements.ticketForms[1])
+  })
+  it('should index custom fields by key', () => {
+    expect(indexed.customFieldsByKey.user).toBeDefined()
+    expect(indexed.customFieldsByKey.user.user_field_1).toBe(elements.userFields[0])
+    expect(indexed.customFieldsByKey.user.user_field_2).toBe(elements.userFields[1])
+    expect(indexed.customFieldsByKey.user.user_field_3).toBe(elements.userFields[2])
+    expect(indexed.customFieldsByKey.user.same).toBe(elements.userFields[3])
+
+    expect(indexed.customFieldsByKey.organization).toBeDefined()
+    expect(indexed.customFieldsByKey.organization.organization_field_1).toBe(elements.organizationFields[0])
+    expect(indexed.customFieldsByKey.organization.organization_field_2).toBe(elements.organizationFields[1])
+    expect(indexed.customFieldsByKey.organization.organization_field_3).toBe(elements.organizationFields[2])
+    expect(indexed.customFieldsByKey.organization.same).toBe(elements.organizationFields[3])
+  })
+  it('should index ticket custom options by field id and value', () => {
+    expect(indexed.ticketCustomOptionByFieldIdAndValue[12]).toBeDefined()
+    expect(indexed.ticketCustomOptionByFieldIdAndValue[12]['field 12 value 1']).toBe(elements.ticketFieldOptions[0])
+    expect(indexed.ticketCustomOptionByFieldIdAndValue[12]['field 12 value 2']).toBe(elements.ticketFieldOptions[1])
+    expect(indexed.ticketCustomOptionByFieldIdAndValue[14]).toBeDefined()
+    expect(indexed.ticketCustomOptionByFieldIdAndValue[14]['same value name']).toBe(elements.ticketFieldOptions[2])
+  })
+  it('should index custom options by field key and value', () => {
+    expect(indexed.customOptionsByFieldKeyAndValue.user).toBeDefined()
+    expect(indexed.customOptionsByFieldKeyAndValue.user.user_field_1).toBeDefined()
+    expect(indexed.customOptionsByFieldKeyAndValue.user.user_field_1['user field 1 value 1']).toBe(elements.userFieldOptions[0])
+    expect(indexed.customOptionsByFieldKeyAndValue.user.user_field_2).toBeDefined()
+    expect(indexed.customOptionsByFieldKeyAndValue.user.user_field_2['same value name']).toBe(elements.userFieldOptions[1])
+    expect(indexed.customOptionsByFieldKeyAndValue.user.user_field_3).toBeDefined()
+    expect(indexed.customOptionsByFieldKeyAndValue.user.user_field_3).toEqual({})
+    expect(indexed.customOptionsByFieldKeyAndValue.user.same).toBeDefined()
+    expect(indexed.customOptionsByFieldKeyAndValue.user.same.same).toBe(elements.userFieldOptions[2])
+
+    expect(indexed.customOptionsByFieldKeyAndValue.organization).toBeDefined()
+    expect(indexed.customOptionsByFieldKeyAndValue.organization.organization_field_1).toBeDefined()
+    expect(indexed.customOptionsByFieldKeyAndValue.organization.organization_field_1['org field 1 value 1']).toBe(elements.organizationFieldOptions[0])
+    expect(indexed.customOptionsByFieldKeyAndValue.organization.organization_field_2).toBeDefined()
+    expect(indexed.customOptionsByFieldKeyAndValue.organization.organization_field_2['same value name']).toBe(elements.organizationFieldOptions[1])
+    expect(indexed.customOptionsByFieldKeyAndValue.organization.organization_field_3).toBeDefined()
+    expect(indexed.customOptionsByFieldKeyAndValue.organization.organization_field_3).toEqual({})
+    expect(indexed.customOptionsByFieldKeyAndValue.organization.same).toBeDefined()
+    expect(indexed.customOptionsByFieldKeyAndValue.organization.same.same).toBe(elements.organizationFieldOptions[2])
+  })
+})

--- a/packages/workato-adapter/test/filters/recipe_references.test.ts
+++ b/packages/workato-adapter/test/filters/recipe_references.test.ts
@@ -130,6 +130,16 @@ describe('Recipe references filter', () => {
       }
     )
 
+    const zendeskSandbox = new InstanceElement(
+      'zendesk_sbx_123',
+      connectionType,
+      {
+        id: 1237,
+        application: 'zendesk',
+        name: 'zendesk sbx 123',
+      }
+    )
+
     const secondarySalesforce = new InstanceElement(
       'secondary_sf',
       connectionType,
@@ -822,6 +832,162 @@ describe('Recipe references filter', () => {
       code: new ReferenceExpression(recipe8JiraCode.elemID),
     })
 
+    const recipe9ZendeskCode = new InstanceElement('recipe9_code', codeType, {
+      as: 'zendesk9id',
+      provider: 'zendesk',
+      name: 'new_ticket_polling',
+      keyword: 'trigger',
+      dynamicPickListSelection: {
+      },
+      input: {
+        since: '2000-00-00T00:00:00-00:00',
+      },
+      block: [
+        {
+          number: 1,
+          keyword: 'if',
+          input: {
+            type: 'compound',
+            operand: 'and',
+            conditions: [
+              {
+                operand: 'greater_than',
+                lhs: "#{_('data.zendesk.zendesk9id.priority')}",
+                rhs: '111111111',
+                uuid: 'condition-uuid',
+              },
+            ],
+          },
+          block: [
+            {
+              number: 2,
+              provider: 'zendesk',
+              name: 'update_ticket',
+              as: 'recipe9id_nested',
+              description: 'Update <span class="provider">accounting code</span> in <span class="provider">Zendesk</span>',
+              keyword: 'action',
+              dynamicPickListSelection: {
+                ticket_form_id: 'Premier Priority Ticket',
+              },
+              input: {
+                macro_ids: {
+                  more: 'string',
+                  id: 10,
+                },
+                group_id: 11,
+                brand_id: 'not a number', // check ID is number
+                ticket_form_id: 1000, // check non exist ID
+                status: 'my status',
+                priority: 'very high',
+                not_in_standard_fields: 'without reference', // check non exist standard field
+                field_12: 'field 12 value 1',
+                field_13: 4, // exist field with non exist value
+                field_1001: 3, // non exist field with non exist value
+                field_14: 'same value name', // exist field_ID with exist value same as user and organziation
+                field_same: 'same', // exist field_key in organization and user. shouldnt referenced
+              },
+              visible_config_fields: [
+                'object',
+                'Fax',
+              ],
+              uuid: 'uuid1',
+            },
+          ],
+          uuid: 'uuid2',
+        },
+        {
+          number: 3,
+          provider: 'zendesk',
+          name: 'create_ticket',
+          as: 'recipe9id_3',
+          description: 'Search <span class="provider">products</span> in <span class="provider">Zendesk</span>',
+          keyword: 'action',
+          dynamicPickListSelection: {
+          },
+          input: {
+            macro_ids: {
+              more: 'string',
+              id: 'not a number', // check ID is number
+            },
+            // check group_id undefined
+            brand_id: 15,
+            ticket_form_id: 16,
+            field_12: 'field 12 value 2',
+          },
+          visible_config_fields: [
+          ],
+          uuid: 'uuid3',
+        },
+        {
+          number: 4,
+          provider: 'zendesk',
+          name: 'update_organization',
+          as: 'recipe9id_4',
+          description: 'Search <span class="provider">products</span> in <span class="provider">Zendesk</span>',
+          keyword: 'action',
+          dynamicPickListSelection: {
+          },
+          input: {
+            field_organization_field_1: 'org field 1 value 1',
+            field_organization_field_2: 'same value name', // exist field_key with exist value same as ticket and organziation
+            field_organization_field_3: 4, // exist field_key with non exist value
+            field_organization_field_1002: 4, // non exist field_key
+            field_same: 'same', // exist field_key in ticket and user. should reference the organization field
+          },
+          visible_config_fields: [
+          ],
+          uuid: 'uuid4',
+        },
+        {
+          number: 5,
+          provider: 'zendesk',
+          name: 'update_user',
+          as: 'recipe9id_5',
+          description: 'Search <span class="provider">products</span> in <span class="provider">Zendesk</span>',
+          keyword: 'action',
+          dynamicPickListSelection: {
+          },
+          input: {
+            field_user_field_1: 'user field 1 value 1',
+            field_user_field_2: 'same value name', // exist field_key with exist value same as ticket and organziation
+            field_user_field_3: 4, // exist field_key with non exist value
+            field_user_field_1002: 4, // non exist field_key
+            field_same: 'same', // exist field_key in ticket and organization. should reference the user field
+
+            comment: `should referenced #{_('data.zendesk.recipe9id_nested.priority')}
+                      should referenced #{_('data.zendesk.recipe9id_nested.status')}
+                      should referenced #{_('data.zendesk.recipe9id_nested.custom_fields.field_100')}
+                      should referenced #{_('data.zendesk.recipe9id_3.custom_fields.field_101')}
+                      should referenced #{_('data.zendesk.recipe9id_4.organization_fields.field_org1')}
+                      should referenced #{_('data.zendesk.recipe9id_4.organization_fields.field_field')}
+                      should referenced #{_('data.zendesk.recipe9id_5.user_fields.field_user1')}
+                      should referenced #{_('data.zendesk.recipe9id_5.user_fields.field_field')}
+                      should referenced #{_('data.zendesk.recipe9id_3.users.first.user_fields.field_user1')} - user block with user field
+                      `,
+            comment2: `should not referenced #{_('data.zendesk.non_exist_block.priority')} - non-exist block
+                       should not referenced #{_('data.zendesk.non_exist_block.organization_fields.field_field')} - non-exist block
+                       should not referenced #{_('data.zendesk.recipe9id_4.status')} - not ticket block
+                      `,
+          },
+          visible_config_fields: [
+          ],
+          uuid: 'uuid5',
+        },
+      ],
+    })
+
+    const recipe9Zendesk = new InstanceElement('recipe9', recipeType, {
+      config: [
+        {
+          keyword: 'application',
+          name: 'zendesk',
+          provider: 'zendesk',
+          account_id: new ReferenceExpression(zendeskSandbox.elemID),
+        },
+      ],
+      code: new ReferenceExpression(recipe9ZendeskCode.elemID),
+    })
+
     return [
       connectionType,
       sfSandbox1,
@@ -829,6 +995,7 @@ describe('Recipe references filter', () => {
       netsuiteSandbox123,
       zuoraSandbox,
       jiraSandbox,
+      zendeskSandbox,
       secondarySalesforce,
       secondaryNetsuite,
       labelValueType,
@@ -856,6 +1023,8 @@ describe('Recipe references filter', () => {
       recipe7ZuoraCode,
       recipe8Jira,
       recipe8JiraCode,
+      recipe9Zendesk,
+      recipe9ZendeskCode,
     ]
   }
 
@@ -1181,12 +1350,377 @@ describe('Recipe references filter', () => {
       fieldType, regularField, customField, inIssueField, withSpacesField, arrayField,
     ]
   }
+
+  const generateZendeskElements = (): Element[] => {
+    const ticketOptionType = new ObjectType({
+      elemID: new ElemID('zendesk', 'ticket_field__custom_field_options'),
+      fields: {
+        id: { refType: BuiltinTypes.NUMBER },
+        value: { refType: BuiltinTypes.STRING },
+      },
+    })
+
+    const ticketFieldType = new ObjectType({
+      elemID: new ElemID('zendesk', 'ticket_field'),
+      fields: {
+        id: { refType: BuiltinTypes.NUMBER },
+        type: { refType: BuiltinTypes.STRING },
+        key: { refType: BuiltinTypes.STRING },
+        raw_title: { refType: BuiltinTypes.STRING },
+        custom_field_options: { refType: new ListType(BuiltinTypes.NUMBER) },
+      },
+    })
+
+    const organizationOptionType = new ObjectType({
+      elemID: new ElemID('zendesk', 'organization_field__custom_field_options'),
+      fields: {
+        id: { refType: BuiltinTypes.NUMBER },
+        value: { refType: BuiltinTypes.STRING },
+      },
+    })
+
+    const organizationFieldType = new ObjectType({
+      elemID: new ElemID('zendesk', 'organization_field'),
+      fields: {
+        id: { refType: BuiltinTypes.NUMBER },
+        key: { refType: BuiltinTypes.STRING },
+        custom_field_options: { refType: new ListType(BuiltinTypes.NUMBER) },
+      },
+    })
+
+    const userOptionType = new ObjectType({
+      elemID: new ElemID('zendesk', 'user_field__custom_field_options'),
+      fields: {
+        id: { refType: BuiltinTypes.NUMBER },
+        value: { refType: BuiltinTypes.STRING },
+      },
+    })
+
+    const userFieldType = new ObjectType({
+      elemID: new ElemID('zendesk', 'user_field'),
+      fields: {
+        id: { refType: BuiltinTypes.NUMBER },
+        key: { refType: BuiltinTypes.STRING },
+        custom_field_options: { refType: new ListType(BuiltinTypes.NUMBER) },
+      },
+    })
+
+    const macroType = new ObjectType({
+      elemID: new ElemID('zendesk', 'macro'),
+      fields: {
+        id: { refType: BuiltinTypes.NUMBER },
+      },
+    })
+
+    const groupType = new ObjectType({
+      elemID: new ElemID('zendesk', 'group'),
+      fields: {
+        id: { refType: BuiltinTypes.NUMBER },
+      },
+    })
+
+    const brandType = new ObjectType({
+      elemID: new ElemID('zendesk', 'brand'),
+      fields: {
+        id: { refType: BuiltinTypes.NUMBER },
+      },
+    })
+
+    const ticketFormType = new ObjectType({
+      elemID: new ElemID('zendesk', 'ticket_form'),
+      fields: {
+        id: { refType: BuiltinTypes.NUMBER },
+        default: { refType: BuiltinTypes.BOOLEAN },
+        ticket_field_ids: { refType: new ListType(BuiltinTypes.NUMBER) },
+      },
+    })
+
+    const macroInst = new InstanceElement(
+      'macroInstName',
+      macroType,
+      { id: 10 }
+    )
+
+    const groupInst = new InstanceElement(
+      'groupInstName',
+      groupType,
+      { id: 11 }
+    )
+
+    const brandInst = new InstanceElement(
+      'brandInstName',
+      brandType,
+      { id: 15 }
+    )
+
+    const ticketFormInst = new InstanceElement(
+      'ticketFormInstName',
+      ticketFormType,
+      { id: 16, default: false }
+    )
+
+    const ticketFieldPriority = new InstanceElement(
+      'priority',
+      ticketFieldType,
+      {
+        id: 1,
+        type: 'priority',
+        raw_title: 'Priority',
+      }
+    )
+
+    const ticketFieldStatus = new InstanceElement(
+      'status',
+      ticketFieldType,
+      {
+        id: 2,
+        type: 'status',
+        raw_title: 'Status',
+      }
+    )
+
+    const defaultTicketFormInst = new InstanceElement(
+      'defaultTicketFormInstName',
+      ticketFormType,
+      { id: 17,
+        default: true,
+        ticket_field_ids: [
+          new ReferenceExpression(ticketFieldStatus.elemID, ticketFieldStatus),
+          new ReferenceExpression(ticketFieldPriority.elemID, ticketFieldPriority),
+        ] }
+    )
+
+    const ticketField12Option1 = new InstanceElement(
+      'ticketField12Option1Name',
+      ticketOptionType,
+      {
+        id: 121,
+        value: 'field 12 value 1',
+      }
+    )
+
+    const ticketField12Option2 = new InstanceElement(
+      'ticketField12Option2Name',
+      ticketOptionType,
+      {
+        id: 122,
+        value: 'field 12 value 2',
+      }
+    )
+
+    const ticketField12 = new InstanceElement(
+      'ticketField12Name',
+      ticketFieldType,
+      {
+        id: 12,
+        custom_field_options: [
+          new ReferenceExpression(ticketField12Option1.elemID, ticketField12Option1),
+          new ReferenceExpression(ticketField12Option2.elemID, ticketField12Option2),
+        ],
+      }
+    )
+
+    const ticketField13 = new InstanceElement(
+      'ticketField13Name',
+      ticketFieldType,
+      {
+        id: 13,
+      }
+    )
+
+    const ticketField14Option = new InstanceElement(
+      'ticketField14OptionName',
+      ticketOptionType,
+      {
+        id: 141,
+        value: 'same value name',
+      }
+    )
+
+    const ticketField14 = new InstanceElement(
+      'ticketField14Name',
+      ticketFieldType,
+      {
+        id: 14,
+        custom_field_options: [
+          new ReferenceExpression(ticketField14Option.elemID, ticketField14Option),
+        ],
+      }
+    )
+
+    const ticketFieldSame = new InstanceElement(
+      'ticketFieldSameName',
+      ticketFieldType,
+      {
+        id: 0,
+        key: 'same',
+      }
+    )
+
+    const organizationField1Option = new InstanceElement(
+      'organizationField1OptionName',
+      organizationOptionType,
+      {
+        id: 311,
+        value: 'org field 1 value 1',
+      }
+    )
+
+    const organizationField1 = new InstanceElement(
+      'organizationField1Name',
+      organizationFieldType,
+      {
+        id: 31,
+        key: 'organization_field_1',
+        custom_field_options: [
+          new ReferenceExpression(organizationField1Option.elemID, organizationField1Option),
+        ],
+      }
+    )
+
+    const organizationField2Option = new InstanceElement(
+      'organizationField2OptionName',
+      organizationOptionType,
+      {
+        id: 321,
+        value: 'same value name',
+      }
+    )
+
+    const organizationField2 = new InstanceElement(
+      'organizationField2Name',
+      organizationFieldType,
+      {
+        id: 32,
+        key: 'organization_field_2',
+        custom_field_options: [
+          new ReferenceExpression(organizationField2Option.elemID, organizationField2Option),
+        ],
+      }
+    )
+
+    const organizationField3 = new InstanceElement(
+      'organizationField3Name',
+      organizationFieldType,
+      {
+        id: 33,
+        key: 'organization_field_3',
+      }
+    )
+
+    const organizationFieldSameOption = new InstanceElement(
+      'organizationFieldSameOptionName',
+      organizationOptionType,
+      {
+        id: 341,
+        value: 'same',
+      }
+    )
+
+    const organizationFieldSame = new InstanceElement(
+      'organizationFieldSameName',
+      organizationFieldType,
+      {
+        id: 34,
+        key: 'same',
+        custom_field_options: [
+          new ReferenceExpression(organizationFieldSameOption.elemID, organizationFieldSameOption),
+        ],
+      }
+    )
+
+
+    const userField1Option = new InstanceElement(
+      'userField1OptionName',
+      userOptionType,
+      {
+        id: 411,
+        value: 'user field 1 value 1',
+      }
+    )
+
+    const userField1 = new InstanceElement(
+      'userField1Name',
+      userFieldType,
+      {
+        id: 41,
+        key: 'user_field_1',
+        custom_field_options: [
+          new ReferenceExpression(userField1Option.elemID, userField1Option),
+        ],
+      }
+    )
+
+    const userField2Option = new InstanceElement(
+      'userField2OptionName',
+      userOptionType,
+      {
+        id: 421,
+        value: 'same value name',
+      }
+    )
+
+    const userField2 = new InstanceElement(
+      'userField2Name',
+      userFieldType,
+      {
+        id: 42,
+        key: 'user_field_2',
+        custom_field_options: [
+          new ReferenceExpression(userField2Option.elemID, userField2Option),
+        ],
+      }
+    )
+
+    const userField3 = new InstanceElement(
+      'userField3Name',
+      userFieldType,
+      {
+        id: 43,
+        key: 'user_field_3',
+      }
+    )
+
+    const userFieldSameOption = new InstanceElement(
+      'userFieldSameOptionName',
+      userOptionType,
+      {
+        id: 441,
+        value: 'same',
+      }
+    )
+
+    const userFieldSame = new InstanceElement(
+      'userFieldSameName',
+      userFieldType,
+      {
+        id: 44,
+        key: 'same',
+        custom_field_options: [
+          new ReferenceExpression(userFieldSameOption.elemID, userFieldSameOption),
+        ],
+      }
+    )
+
+    return [
+      ticketOptionType, ticketFieldType, organizationOptionType, organizationFieldType,
+      userOptionType, userFieldType, macroType, groupType, brandType, ticketFormType,
+      macroInst, groupInst, brandInst, ticketFormInst, ticketFieldPriority, ticketFieldStatus,
+      defaultTicketFormInst, ticketField12Option1, ticketField12Option2, ticketField12,
+      ticketField13, ticketField14Option, ticketField14, ticketFieldSame, organizationField1Option,
+      organizationField1, organizationField2Option, organizationField2, organizationField3,
+      organizationFieldSameOption, organizationFieldSame, userField1Option, userField1,
+      userField2Option, userField2, userField3, userFieldSameOption, userFieldSame,
+    ]
+  }
+
   describe('on post-fetch primary', () => {
     let currentAdapterElements: Element[]
     let salesforceElements: Element[]
     let netsuiteElements: Element[]
     let zuoraElements: Element[]
     let jiraElements: Element[]
+    let zendeskElements: Element[]
 
     beforeAll(async () => {
       filter = filterCreator({
@@ -1203,6 +1737,7 @@ describe('Recipe references filter', () => {
               netsuite: ['netsuite sbx 123'],
               zuora_billing: ['zuora sbx 123'],
               jira: ['jira sbx 123'],
+              zendesk: ['zendesk sbx 123'],
             },
           },
           apiDefinitions: {
@@ -1223,6 +1758,7 @@ describe('Recipe references filter', () => {
       netsuiteElements = generateNetsuiteElements()
       zuoraElements = generateZuoraElements()
       jiraElements = generateJiraElements()
+      zendeskElements = generateZendeskElements()
       await filter.onPostFetch({
         currentAdapterElements,
         elementsByAccount: {
@@ -1230,12 +1766,14 @@ describe('Recipe references filter', () => {
           netsuite: netsuiteElements,
           zuora_billing: zuoraElements,
           jira: jiraElements,
+          zendesk: zendeskElements,
         },
         accountToServiceNameMap: {
           zuora_billing: 'zuora_billing',
           salesforce: 'salesforce',
           netsuite: 'netsuite',
           jira: 'jira',
+          zendesk: 'zendesk',
         },
         progressReporter: { reportProgress: () => null },
       })
@@ -1546,6 +2084,89 @@ describe('Recipe references filter', () => {
         expect(secondBlock.input.issueType.elemID.getFullName()).toEqual('jira.IssueType.instance.ThirdType')
       })
     })
+
+    describe('recipe9Zendesk', () => {
+      it('should show all resolved references in the _generated_dependencies annotation, in alphabetical order', () => {
+        const recipeCode = currentAdapterElements.find(e => e.elemID.getFullName() === 'workato.recipe__code.instance.recipe9_code')
+        expect(recipeCode).toBeDefined()
+        expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeDefined()
+        expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toHaveLength(24)
+        expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES].map(
+          dereferenceDep
+        )).toEqual([
+          { reference: 'zendesk.brand.instance.brandInstName', occurrences: [{ location: 'workato.recipe__code.instance.recipe9_code.block.1', direction: 'output' }] },
+          { reference: 'zendesk.group.instance.groupInstName', occurrences: [{ location: 'workato.recipe__code.instance.recipe9_code.block.0.block.0', direction: 'output' }] },
+          { reference: 'zendesk.macro.instance.macroInstName', occurrences: [{ location: 'workato.recipe__code.instance.recipe9_code.block.0.block.0', direction: 'output' }] },
+          { reference: 'zendesk.organization_field.instance.organizationField1Name', occurrences: [{ location: 'workato.recipe__code.instance.recipe9_code.block.2', direction: 'output' }] },
+          { reference: 'zendesk.organization_field.instance.organizationField2Name', occurrences: [{ location: 'workato.recipe__code.instance.recipe9_code.block.2', direction: 'output' }] },
+          { reference: 'zendesk.organization_field.instance.organizationField3Name', occurrences: [{ location: 'workato.recipe__code.instance.recipe9_code.block.2', direction: 'output' }] },
+          { reference: 'zendesk.organization_field.instance.organizationFieldSameName', occurrences: [{ location: 'workato.recipe__code.instance.recipe9_code.block.2', direction: 'output' }] },
+          { reference: 'zendesk.organization_field__custom_field_options.instance.organizationField1OptionName', occurrences: [{ location: 'workato.recipe__code.instance.recipe9_code.block.2', direction: 'output' }] },
+          { reference: 'zendesk.organization_field__custom_field_options.instance.organizationField2OptionName', occurrences: [{ location: 'workato.recipe__code.instance.recipe9_code.block.2', direction: 'output' }] },
+          { reference: 'zendesk.organization_field__custom_field_options.instance.organizationFieldSameOptionName', occurrences: [{ location: 'workato.recipe__code.instance.recipe9_code.block.2', direction: 'output' }] },
+          { reference: 'zendesk.ticket_field.instance.ticketField12Name', occurrences: [{ location: 'workato.recipe__code.instance.recipe9_code.block.0.block.0', direction: 'output' }, { location: 'workato.recipe__code.instance.recipe9_code.block.1', direction: 'output' }] },
+          { reference: 'zendesk.ticket_field.instance.ticketField13Name', occurrences: [{ location: 'workato.recipe__code.instance.recipe9_code.block.0.block.0', direction: 'output' }] },
+          { reference: 'zendesk.ticket_field.instance.ticketField14Name', occurrences: [{ location: 'workato.recipe__code.instance.recipe9_code.block.0.block.0', direction: 'output' }] },
+          { reference: 'zendesk.ticket_field__custom_field_options.instance.ticketField12Option1Name', occurrences: [{ location: 'workato.recipe__code.instance.recipe9_code.block.0.block.0', direction: 'output' }] },
+          { reference: 'zendesk.ticket_field__custom_field_options.instance.ticketField12Option2Name', occurrences: [{ location: 'workato.recipe__code.instance.recipe9_code.block.1', direction: 'output' }] },
+          { reference: 'zendesk.ticket_field__custom_field_options.instance.ticketField14OptionName', occurrences: [{ location: 'workato.recipe__code.instance.recipe9_code.block.0.block.0', direction: 'output' }] },
+          { reference: 'zendesk.ticket_form.instance.ticketFormInstName', occurrences: [{ location: 'workato.recipe__code.instance.recipe9_code.block.1', direction: 'output' }] },
+          { reference: 'zendesk.user_field.instance.userField1Name', occurrences: [{ location: 'workato.recipe__code.instance.recipe9_code.block.3', direction: 'output' }] },
+          { reference: 'zendesk.user_field.instance.userField2Name', occurrences: [{ location: 'workato.recipe__code.instance.recipe9_code.block.3', direction: 'output' }] },
+          { reference: 'zendesk.user_field.instance.userField3Name', occurrences: [{ location: 'workato.recipe__code.instance.recipe9_code.block.3', direction: 'output' }] },
+          { reference: 'zendesk.user_field.instance.userFieldSameName', occurrences: [{ location: 'workato.recipe__code.instance.recipe9_code.block.3', direction: 'output' }] },
+          { reference: 'zendesk.user_field__custom_field_options.instance.userField1OptionName', occurrences: [{ location: 'workato.recipe__code.instance.recipe9_code.block.3', direction: 'output' }] },
+          { reference: 'zendesk.user_field__custom_field_options.instance.userField2OptionName', occurrences: [{ location: 'workato.recipe__code.instance.recipe9_code.block.3', direction: 'output' }] },
+          { reference: 'zendesk.user_field__custom_field_options.instance.userFieldSameOptionName', occurrences: [{ location: 'workato.recipe__code.instance.recipe9_code.block.3', direction: 'output' }] },
+        ])
+      })
+
+      it('should resolve references in-place where possible', () => {
+        const recipeCode = currentAdapterElements.find(
+          e => e.elemID.getFullName() === 'workato.recipe__code.instance.recipe9_code'
+        ) as InstanceElement
+        expect(recipeCode).toBeInstanceOf(InstanceElement)
+        expect(recipeCode.value.block[0].block[0].input.macro_ids.id).toBeInstanceOf(ReferenceExpression)
+        expect(recipeCode.value.block[0].block[0].input.macro_ids.id.elemID.getFullName()).toEqual('zendesk.macro.instance.macroInstName')
+
+        expect(recipeCode.value.block[0].block[0].input.group_id).toBeInstanceOf(ReferenceExpression)
+        expect(recipeCode.value.block[0].block[0].input.group_id.elemID.getFullName()).toEqual('zendesk.group.instance.groupInstName')
+
+        expect(recipeCode.value.block[0].block[0].input.field_12).toBeInstanceOf(ReferenceExpression)
+        expect(recipeCode.value.block[0].block[0].input.field_12.elemID.getFullName()).toEqual('zendesk.ticket_field__custom_field_options.instance.ticketField12Option1Name')
+
+        expect(recipeCode.value.block[0].block[0].input.field_14).toBeInstanceOf(ReferenceExpression)
+        expect(recipeCode.value.block[0].block[0].input.field_14.elemID.getFullName()).toEqual('zendesk.ticket_field__custom_field_options.instance.ticketField14OptionName')
+
+        expect(recipeCode.value.block[1].input.brand_id).toBeInstanceOf(ReferenceExpression)
+        expect(recipeCode.value.block[1].input.brand_id.elemID.getFullName()).toEqual('zendesk.brand.instance.brandInstName')
+
+        expect(recipeCode.value.block[1].input.ticket_form_id).toBeInstanceOf(ReferenceExpression)
+        expect(recipeCode.value.block[1].input.ticket_form_id.elemID.getFullName()).toEqual('zendesk.ticket_form.instance.ticketFormInstName')
+
+        expect(recipeCode.value.block[1].input.field_12).toBeInstanceOf(ReferenceExpression)
+        expect(recipeCode.value.block[1].input.field_12.elemID.getFullName()).toEqual('zendesk.ticket_field__custom_field_options.instance.ticketField12Option2Name')
+
+        expect(recipeCode.value.block[2].input.field_organization_field_1).toBeInstanceOf(ReferenceExpression)
+        expect(recipeCode.value.block[2].input.field_organization_field_1.elemID.getFullName()).toEqual('zendesk.organization_field__custom_field_options.instance.organizationField1OptionName')
+
+        expect(recipeCode.value.block[2].input.field_organization_field_2).toBeInstanceOf(ReferenceExpression)
+        expect(recipeCode.value.block[2].input.field_organization_field_2.elemID.getFullName()).toEqual('zendesk.organization_field__custom_field_options.instance.organizationField2OptionName')
+
+        expect(recipeCode.value.block[2].input.field_same).toBeInstanceOf(ReferenceExpression)
+        expect(recipeCode.value.block[2].input.field_same.elemID.getFullName()).toEqual('zendesk.organization_field__custom_field_options.instance.organizationFieldSameOptionName')
+
+        expect(recipeCode.value.block[3].input.field_user_field_1).toBeInstanceOf(ReferenceExpression)
+        expect(recipeCode.value.block[3].input.field_user_field_1.elemID.getFullName()).toEqual('zendesk.user_field__custom_field_options.instance.userField1OptionName')
+
+        expect(recipeCode.value.block[3].input.field_user_field_2).toBeInstanceOf(ReferenceExpression)
+        expect(recipeCode.value.block[3].input.field_user_field_2.elemID.getFullName()).toEqual('zendesk.user_field__custom_field_options.instance.userField2OptionName')
+
+        expect(recipeCode.value.block[3].input.field_same).toBeInstanceOf(ReferenceExpression)
+        expect(recipeCode.value.block[3].input.field_same.elemID.getFullName()).toEqual('zendesk.user_field__custom_field_options.instance.userFieldSameOptionName')
+      })
+    })
+
 
     it('should return false if no elements were modified', async () => {
       const elements = generateCurrentAdapterElements()


### PR DESCRIPTION
In this PR I have added support for cross service references from Zendesk when fetching Workato account.

---

 None

---
_Release Notes_: 
Workato adapter
- The users will be able to add Zendesk connection to serviceConnectionNames (in workato.nacl) and get all Zendesk references in workaot recipes 

---
_User Notifications_: 
When using Workato. Zendesk connected recipe will include references to zendesk
