### PR TITLE
SALTO-4553 - Fix TOCTOU issue when creating workspace state

### DIFF
--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -499,11 +499,13 @@ export const loadWorkspace = async (
      * This means you can't put an `await` between the start of `buildWorkspaceState` and the following lines.
      */
     const initBuild = workspaceState === undefined
-    const stateToBuild = workspaceState !== undefined
-      ? await workspaceState
-      : await initState()
 
     const wsChanges = await workspaceChanges
+
+    const stateToBuild = (!initBuild
+      ? await workspaceState
+      : await initState()) as WorkspaceState
+
 
     const getWorkspaceChangesForEnv = (envName: string): ChangeSet<Change> | undefined => wsChanges[envName]
 
@@ -1285,7 +1287,9 @@ export const loadWorkspace = async (
       return loadWorkspace(config, adaptersConfig, credentials, envSources, remoteMapCreator)
     },
     clear: async (args: ClearFlags) => {
+      log.info('Starting workspace.clear()')
       const currentWSState = await getWorkspaceState()
+      log.info('After first getWorkspaceState()')
       if (args.cache || args.nacl || args.staticResources) {
         if (args.staticResources && !(args.state && args.cache && args.nacl)) {
           throw new Error('Cannot clear static resources without clearing the state, cache and nacls')
@@ -1303,7 +1307,9 @@ export const loadWorkspace = async (
         await promises.array.series(envs().map(e => (() => credentials.delete(e))))
       }
       workspaceState = undefined
+      log.info('Before second getWorkspaceState()')
       await getWorkspaceState()
+      log.info('After second getWorkspaceState()')
     },
     addAccount,
     addService: addAccount,

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -500,14 +500,8 @@ export const loadWorkspace = async (
      */
     const previousState = workspaceState
 
-    if (workspaceChanges === undefined && previousState !== undefined) {
-      // We assume that we only want to get the changes from naclFilesSource if the workspace is 'clean' (i.e. there's
-      // no previous state to override.
-      throw new Error('workspaceChanges can be undefined only if the workspace is clean')
-    }
-
-    const wsChanges = (previousState !== undefined)
-      ? (workspaceChanges ?? {})
+    const wsChanges = (workspaceChanges !== undefined)
+      ? workspaceChanges
       : await naclFilesSource.load({ ignoreFileChanges })
 
     const stateToBuild = (previousState !== undefined)

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -760,13 +760,17 @@ export const loadWorkspace = async (
   }
 
   const getWorkspaceState = async (): Promise<WorkspaceState> => {
+    const wsConfig = await config.getWorkspaceConfig()
     if (_.isUndefined(workspaceState)) {
-      const wsConfig = await config.getWorkspaceConfig()
       log.debug('No workspace state for %s/%s. Building new workspace state.', wsConfig.uid, wsConfig.name)
       const workspaceChanges = await naclFilesSource.load({ ignoreFileChanges })
-      workspaceState = buildWorkspaceState({
-        workspaceChanges,
-      })
+      // it's possible that during the 'await' in the line above somebody initialized the workspace state. So we check
+      // again before calling `buildWorkspaceState`
+      if (_.isUndefined(workspaceState)) {
+        workspaceState = buildWorkspaceState({
+          workspaceChanges,
+        })
+      }
     }
     return workspaceState
   }


### PR DESCRIPTION
Double-check whether workspace state exists before creating it.

---

There is a call to an async function between the time we check whether the workspace state exists and the time we initialize it if it doesn't. 
This `await` can cause Node.js to switch to another context that also called this function, which would also see that the workspace has no state and try to create it.
Best case scenario we crash because we open too many files when we parse the NaCl files in the workspace multiple times concurrently. Worst case scenario we overwrite the state with another state, which may or may not be benign but we'll never know we did it.

---
_Release Notes_: 
Improve stability when loading a workspace

---
_User Notifications_: 
N/A