### PR TITLE
SALTO-4554: exclude built-in names from automations' account id filter

### DIFF
--- a/packages/jira-adapter/src/filters/account_id/account_id_filter.ts
+++ b/packages/jira-adapter/src/filters/account_id/account_id_filter.ts
@@ -84,9 +84,14 @@ const callbackValueOrValues = (
   }
 }
 
-const walkOnAutomationValue = (regexPath: string, callback: WalkOnUsersCallback)
-: WalkOnFunc => ({ value, path }): WALK_NEXT_STEP => {
-  if (new RegExp(regexPath).test(path.getFullName()) && value.type === 'ID') {
+const walkOnAutomationValue = (
+  regexPath: string,
+  callback: WalkOnUsersCallback,
+  excludeValues?: string[]
+): WalkOnFunc => ({ value, path }): WALK_NEXT_STEP => {
+  if (new RegExp(regexPath).test(path.getFullName())
+    && value.type === 'ID'
+    && !excludeValues?.includes(value.value)) {
     callbackValueOrValues({ value, path, callback })
     return WALK_NEXT_STEP.SKIP
   }
@@ -173,7 +178,8 @@ const accountIdsScenarios = (
         // the second is 'value.operations.0.value' (numbers can differ)
         func: walkOnAutomationValue('value\\.operations\\.\\d+.value\\.\\d+'
           + '|value\\.operations\\.\\d+\\.value',
-        callback) })
+        callback,
+        ['assignee', 'reporter']) })
       return WALK_NEXT_STEP.SKIP
     }
     // user condition

--- a/packages/jira-adapter/test/filters/account_id/account_id_common.ts
+++ b/packages/jira-adapter/test/filters/account_id/account_id_common.ts
@@ -258,6 +258,40 @@ export const createInstance = (
         },
       },
     },
+    automation61: {
+      fieldType: 'com.atlassian.jira.plugin.system.customfieldtypes:userpicker',
+      compareFieldValue: {
+        value: {
+          operations: [
+            {
+              value: [
+                {
+                  type: 'ID',
+                  value: 'assignee',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    },
+    automation62: {
+      fieldType: 'com.atlassian.jira.plugin.system.customfieldtypes:userpicker',
+      compareFieldValue: {
+        value: {
+          operations: [
+            {
+              value: [
+                {
+                  type: 'ID',
+                  value: 'reporter',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    },
     automation7: {
       type: 'jira.user.condition',
       value: {
@@ -466,6 +500,40 @@ export const createObjectedInstance = (id: string, objectType: ObjectType): Inst
         },
       },
     },
+    automation61: {
+      fieldType: 'com.atlassian.jira.plugin.system.customfieldtypes:userpicker',
+      compareFieldValue: {
+        value: {
+          operations: [
+            {
+              value: [
+                {
+                  type: 'ID',
+                  value: 'assignee',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    },
+    automation62: {
+      fieldType: 'com.atlassian.jira.plugin.system.customfieldtypes:userpicker',
+      compareFieldValue: {
+        value: {
+          operations: [
+            {
+              value: [
+                {
+                  type: 'ID',
+                  value: 'reporter',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    },
     automation7: {
       type: 'jira.user.condition',
       value: {
@@ -552,6 +620,8 @@ export const checkObjectedInstanceIds = (
     expect(objInstance.value.automation5.compareFieldValue.value.id).toEqual(`${id}automation5`)
     expect(objInstance.value.automation9.compareFieldValue.value.id).toEqual(`${id}automation9`)
     expect(objInstance.value.automation6.compareFieldValue.value.operations[0].value[0].value.id).toEqual(`${id}automation6`)
+    expect(objInstance.value.automation61.compareFieldValue.value.operations[0].value[0].value).toEqual('assignee')
+    expect(objInstance.value.automation62.compareFieldValue.value.operations[0].value[0].value).toEqual('reporter')
     expect(objInstance.value.automation7.value.conditions[1].criteria[0].value.id).toEqual(`${id}automation7`)
     expect(objInstance.value.automation7.value.conditions[2].criteria[0].value).toEqual(`${id}automation7X`)
     expect(objInstance.value.automation8.compareFieldValue[0].value.assignee.values[0].id).toEqual(`${id}automation8a`)
@@ -584,6 +654,8 @@ export const checkSimpleInstanceIds = (
     expect(objInstance.value.automation5.compareFieldValue.value).toEqual(`${id}automation5`)
     expect(objInstance.value.automation9.compareFieldValue.value).toEqual(`${id}automation9`)
     expect(objInstance.value.automation6.compareFieldValue.value.operations[0].value[0].value).toEqual(`${id}automation6`)
+    expect(objInstance.value.automation61.compareFieldValue.value.operations[0].value[0].value).toEqual('assignee')
+    expect(objInstance.value.automation62.compareFieldValue.value.operations[0].value[0].value).toEqual('reporter')
     expect(objInstance.value.automation7.value.conditions[1].criteria[0].value).toEqual(`${id}automation7`)
     expect(objInstance.value.automation8.compareFieldValue[0].value.assignee.values[0]).toEqual(`${id}automation8a`)
     expect(objInstance.value.automation8.compareFieldValue[0].value.assignee.values[1]).toEqual(`${id}automation8b`)


### PR DESCRIPTION
_Fixed a bug where automations could not be deployed due to a certain usage of a built-in user type_
[Noise reduction](https://github.com/salto-io/salto_private/pull/6332)

---

To recreate add a create issue action for an automation. 
In 'Choose fields to set' select assignee or reporter.
At the bottom of the page find the field, on the right side press the ... and change to `copy` 
Fetch, make a copy and try to deploy.
Note- the custom fields with users does not use the 'ID' type, they use 'name' so they are no a concern here

---
_Release Notes_: 
Jira Adapter: 
* Fixed a bug that prevented the deployment of automations in specific conditions

---
_User Notifications_: 
Jira Adapter:
* On very specific cases there will be a change in autmations of the structure of assignee or reporter fields
