### PR TITLE
Removed backward compatibility for the old salesforce disable change …

### DIFF
--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -27,7 +27,7 @@ import {
   isAccessTokenConfig, SalesforceConfig, accessTokenCredentialsType,
   UsernamePasswordCredentials, Credentials, OauthAccessTokenCredentials, CLIENT_CONFIG,
   SalesforceClientConfig, RetryStrategyName, FETCH_CONFIG, MAX_ITEMS_IN_RETRIEVE_REQUEST,
-  ENUM_FIELD_PERMISSIONS, DEPLOY_CONFIG, ChangeValidatorConfig,
+  ENUM_FIELD_PERMISSIONS, DEPLOY_CONFIG,
 } from './types'
 import { validateFetchParameters } from './fetch_profile/fetch_profile'
 import { ConfigValidationError } from './config_validation'
@@ -130,17 +130,13 @@ SalesforceConfig => {
 
   validateEnumFieldPermissions(config?.value?.enumFieldPermissions)
 
-  // Deprecated and used for backwards compatibility (SALTO-4468)
-  type adapterConfigType = SalesforceConfig & { validators?: ChangeValidatorConfig }
-
-  const adapterConfig: { [K in keyof Required<adapterConfigType>]: adapterConfigType[K] } = {
+  const adapterConfig: { [K in keyof Required<SalesforceConfig>]: SalesforceConfig[K] } = {
     fetch: config?.value?.[FETCH_CONFIG],
     maxItemsInRetrieveRequest: config?.value?.[MAX_ITEMS_IN_RETRIEVE_REQUEST],
     enumFieldPermissions: config?.value?.[ENUM_FIELD_PERMISSIONS],
     client: config?.value?.[CLIENT_CONFIG],
     deploy: config?.value?.[DEPLOY_CONFIG],
     // Deprecated and used for backwards compatibility (SALTO-4468)
-    validators: config?.value?.validators,
   }
   Object.keys(config?.value ?? {})
     .filter(k => !Object.keys(adapterConfig).includes(k))

--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -102,14 +102,9 @@ const createSalesforceChangeValidator = ({ config, isSandbox, checkOnly, client 
     ? defaultChangeValidatorsValidateConfig
     : defaultChangeValidatorsDeployConfig
 
-  // Used for backward compatibility of the old config for disabling validators (SALTO-4468)
-  const oldValidatorsActivationConfig = (config as { validators?: Record<string, boolean> }).validators
-
-  const validatorsActivationConfig = { ...config[DEPLOY_CONFIG]?.changeValidators, ...oldValidatorsActivationConfig }
-
   const changeValidator = createChangeValidator({
     validators: _.mapValues(changeValidators, validator => validator(config, isSandbox, client)),
-    validatorsActivationConfig: { ...defaultValidatorsActivationConfig, ...validatorsActivationConfig },
+    validatorsActivationConfig: { ...defaultValidatorsActivationConfig, ...config[DEPLOY_CONFIG]?.changeValidators },
   })
 
   // Returns a change validator with elementsSource that lazily resolves types using resolveTypeShallow

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -118,8 +118,7 @@ export type ChangeValidatorName = (
   | 'dataCategoryGroup'
 )
 
-// Can stop being exported with (SALTO-4468)
-export type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
+type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
 
 type ObjectIdSettings = {
   objectsRegex: string


### PR DESCRIPTION
…validator config

_Replace me with a description of the changes in this PR_

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
