### PR TITLE
SALTO-4486 deal with case where internal ID is an empty string, and d…

### DIFF
--- a/packages/salesforce-adapter/src/transformers/xml_transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/xml_transformer.ts
@@ -305,7 +305,7 @@ export const fromRetrieveResult = async (
           contentFileName, file.type, file.namespacePrefix)
       }
     }
-    if (file.id !== undefined) {
+    if (file.id !== undefined && file.id !== '') {
       metadataValues[INTERNAL_ID_FIELD] = file.id
     }
     return metadataValues

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -1076,6 +1076,25 @@ public class MyClass${index} {
       })
     })
 
+    describe('when there is an empty id in retrieve response', () => {
+      it('should not have an id field after retrieve', async () => {
+        mockMetadataType(
+          { xmlName: 'Account' },
+          { valueTypeFields: [] },
+          [
+            {
+              props: { fullName: 'Account', id: '' },
+              values: { fullName: 'Account' },
+            },
+          ]
+        )
+        const { elements: result } = await adapter.fetch(mockFetchOpts)
+        const [testObject] = findElements(result, 'Account', 'Account') as [InstanceElement]
+        expect(testObject).toBeDefined()
+        expect(testObject.value.internalId).toBeUndefined()
+      })
+    })
+
     it('should not fail the fetch on instances too large', async () => {
       mockMetadataType(
         { xmlName: 'ApexClass', metaFile: true, suffix: 'cls', directoryName: 'classes' },

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -1077,7 +1077,7 @@ public class MyClass${index} {
     })
 
     describe('when there is an empty id in retrieve response', () => {
-      it('should not have an id field after retrieve', async () => {
+      it('should not create instance with internalId', async () => {
         mockMetadataType(
           { xmlName: 'Account' },
           { valueTypeFields: [] },


### PR DESCRIPTION
…on't add it to nacl

---

This change is in retrieve API

---
_Release Notes_: 
Salesforce:
- Fixed some invalid go-to-service URLs that were caused by API regression

---
_User Notifications_: _None_