### PR TITLE
SALTO-4481: omit fields in preDeploy

### DIFF
--- a/packages/netsuite-adapter/src/change_validator.ts
+++ b/packages/netsuite-adapter/src/change_validator.ts
@@ -46,6 +46,7 @@ import currencyUndeployableFieldsValidator from './change_validators/currency_un
 import fileCabinetInternalIdsValidator from './change_validators/file_cabinet_internal_ids'
 import rolePermissionValidator from './change_validators/role_permission_ids'
 import translationCollectionValidator from './change_validators/translation_collection_references'
+import omitFieldsValidator from './change_validators/omit_fields'
 import NetsuiteClient from './client/client'
 import {
   AdditionalDependencies,
@@ -85,6 +86,7 @@ const netsuiteChangeValidators: Record<NetsuiteValidatorName, NetsuiteChangeVali
   extraReferenceDependencies: extraReferenceDependenciesValidator,
   rolePermission: rolePermissionValidator,
   translationCollectionReferences: translationCollectionValidator,
+  omitFields: omitFieldsValidator,
 }
 
 const nonSuiteAppValidators: Record<NonSuiteAppValidatorName, NetsuiteChangeValidator> = {

--- a/packages/netsuite-adapter/src/change_validator.ts
+++ b/packages/netsuite-adapter/src/change_validator.ts
@@ -50,6 +50,7 @@ import omitFieldsValidator from './change_validators/omit_fields'
 import NetsuiteClient from './client/client'
 import {
   AdditionalDependencies,
+  NetsuiteConfig,
   NetsuiteValidatorName,
   NonSuiteAppValidatorName,
   OnlySuiteAppValidatorName,
@@ -148,6 +149,7 @@ const getChangeValidator: ({
   filtersRunner: (groupID: string) => Required<Filter>
   elementsSource: ReadOnlyElementsSource
   validatorsActivationConfig?: ValidatorsActivationConfig
+  userConfig?: NetsuiteConfig
   }) => ChangeValidator = (
     {
       client,
@@ -160,6 +162,7 @@ const getChangeValidator: ({
       filtersRunner,
       elementsSource,
       validatorsActivationConfig,
+      userConfig,
     }
   ) =>
     async (changes, elementSource) => {
@@ -171,7 +174,8 @@ const getChangeValidator: ({
       const validators: Record<string, ChangeValidator> = _.mapValues(
         netsuiteValidators,
         validator =>
-          (innerChanges: ReadonlyArray<Change>) => validator(innerChanges, deployReferencedElements, elementsSource)
+          (innerChanges: ReadonlyArray<Change>) =>
+            validator(innerChanges, deployReferencedElements, elementsSource, userConfig)
       )
 
       const safeDeploy = warnStaleData

--- a/packages/netsuite-adapter/src/change_validators/omit_fields.ts
+++ b/packages/netsuite-adapter/src/change_validators/omit_fields.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-import { Change, ChangeDataType, ChangeError, getChangeData, isModificationChange, Values } from '@salto-io/adapter-api'
+import { Change, ChangeDataType, ChangeError, getChangeData, isAdditionOrModificationChange, isModificationChange, Values } from '@salto-io/adapter-api'
 import { values } from '@salto-io/lowerdash'
 import { NetsuiteChangeValidator } from './types'
 import { FIELDS_TO_OMIT_PRE_DEPLOY, getFieldsToOmitByType } from '../filters/omit_fields'
@@ -40,7 +40,7 @@ const getChangeError = (
     return {
       elemID: element.elemID,
       severity: 'Error',
-      message: 'This element will be removed from deployment',
+      message: 'This element contains an undeployable change',
       detailedMessage: `This element will be removed from deployment because it only contains changes to the undeployable field '${fieldsToOmitByType[element.elemID.typeName].join(', ')}'.`,
     }
   }
@@ -58,6 +58,7 @@ const changeValidator: NetsuiteChangeValidator = async changes => {
   const fieldsToOmitByType = getFieldsToOmitByType(typeNames, FIELDS_TO_OMIT_PRE_DEPLOY)
 
   return changes
+    .filter(isAdditionOrModificationChange)
     .map(change => {
       const element = getChangeData(change)
       const { typeName } = element.elemID

--- a/packages/netsuite-adapter/src/change_validators/omit_fields.ts
+++ b/packages/netsuite-adapter/src/change_validators/omit_fields.ts
@@ -1,0 +1,73 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { Change, ChangeDataType, ChangeError, getChangeData, isModificationChange, Values } from '@salto-io/adapter-api'
+import { values } from '@salto-io/lowerdash'
+import { NetsuiteChangeValidator } from './types'
+import { FIELDS_TO_OMIT_PRE_DEPLOY, getFieldsToOmitByType } from '../filters/omit_fields'
+import { getDifferentKeys } from '../filters/data_instances_diff'
+import { getElementValueOrAnnotations } from '../types'
+
+const { isDefined } = values
+
+const getFieldsToOmit = (
+  value: Values,
+  typeName: string,
+  fieldsToOmitByType: Record<string, string[]>
+): string[] =>
+  fieldsToOmitByType[typeName]
+    .filter(fieldToOmit => fieldToOmit in value)
+
+const getChangeError = (
+  change: Change,
+  fieldsToOmitByType: Record<string, string[]>,
+  element: ChangeDataType,
+): ChangeError => {
+  if (isModificationChange(change) && getDifferentKeys(change).size === 1) {
+    return {
+      elemID: element.elemID,
+      severity: 'Error',
+      message: 'This element will be removed from deployment',
+      detailedMessage: `This element will be removed from deployment because it only contains changes to the undeployable field '${fieldsToOmitByType[element.elemID.typeName].join(', ')}'.`,
+    }
+  }
+  const wrappedFieldNames = fieldsToOmitByType[element.elemID.typeName].map(field => `'${field}'`).join(', ')
+  return {
+    elemID: element.elemID,
+    severity: 'Warning',
+    message: `This element will be deployed without the following fields: ${wrappedFieldNames}`,
+    detailedMessage: `This element will be deployed without the following fields: ${wrappedFieldNames}, as NetSuite does not support deploying them.`,
+  }
+}
+
+const changeValidator: NetsuiteChangeValidator = async changes => {
+  const typeNames = FIELDS_TO_OMIT_PRE_DEPLOY.map(fieldToOmit => fieldToOmit.type)
+  const fieldsToOmitByType = getFieldsToOmitByType(typeNames, FIELDS_TO_OMIT_PRE_DEPLOY)
+
+  return changes
+    .map(change => {
+      const element = getChangeData(change)
+      const { typeName } = element.elemID
+      if (typeName in fieldsToOmitByType
+        && getFieldsToOmit(getElementValueOrAnnotations(element), typeName, fieldsToOmitByType).length > 0) {
+        return getChangeError(change, fieldsToOmitByType, element)
+      }
+      return undefined
+    })
+    .filter(isDefined)
+}
+
+export default changeValidator

--- a/packages/netsuite-adapter/src/change_validators/types.ts
+++ b/packages/netsuite-adapter/src/change_validators/types.ts
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 import { Change, ChangeError, ReadOnlyElementsSource } from '@salto-io/adapter-api'
+import { NetsuiteConfig } from '../config'
 
 export type NetsuiteChangeValidator = (
     changes: ReadonlyArray<Change>,
     deployReferencedElements?: boolean,
     elementsSource?: ReadOnlyElementsSource,
+    config?: NetsuiteConfig
   ) => Promise<ReadonlyArray<ChangeError>>

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -612,6 +612,7 @@ const baseDeployConfigType = createMatchingObjectType<Omit<DeployParams, keyof U
     validate: { refType: BuiltinTypes.BOOLEAN },
     deployReferencedElements: { refType: BuiltinTypes.BOOLEAN },
     additionalDependencies: { refType: additionalDependenciesType },
+    fieldsToOmit: { refType: new ListType(fieldsToOmitConfig) },
   },
 })
 
@@ -702,6 +703,7 @@ export const validateDeployParams = (
     warnOnStaleWorkspaceData,
     validate,
     additionalDependencies,
+    fieldsToOmit,
   }: Record<keyof DeployParams, unknown>
 ): void => {
   if (deployReferencedElements !== undefined
@@ -719,6 +721,9 @@ export const validateDeployParams = (
   if (additionalDependencies !== undefined) {
     validatePlainObject(additionalDependencies, additionalDependenciesConfigPath)
     validateAdditionalDependencies(additionalDependencies)
+  }
+  if (fieldsToOmit !== undefined) {
+    validateFieldsToOmitConfig(fieldsToOmit)
   }
 }
 

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -82,6 +82,7 @@ export type DeployParams = UserDeployConfig & {
     include?: Partial<AdditionalSdfDeployDependencies>
     exclude?: Partial<AdditionalSdfDeployDependencies>
   }
+  fieldsToOmit?: FieldToOmitParams[]
 }
 
 export const DEPLOY_PARAMS: lowerdashTypes.TypeKeysEnum<DeployParams> = {
@@ -90,6 +91,7 @@ export const DEPLOY_PARAMS: lowerdashTypes.TypeKeysEnum<DeployParams> = {
   deployReferencedElements: 'deployReferencedElements',
   additionalDependencies: 'additionalDependencies',
   changeValidators: 'changeValidators',
+  fieldsToOmit: 'fieldsToOmit',
 }
 
 type MaxInstancesPerType = {
@@ -550,6 +552,7 @@ export type NetsuiteValidatorName = (
   | 'extraReferenceDependencies'
   | 'rolePermission'
   | 'translationCollectionReferences'
+  | 'omitFields'
 )
 
 export type NonSuiteAppValidatorName = (
@@ -595,6 +598,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     removeStandardTypes: { refType: BuiltinTypes.BOOLEAN },
     fileCabinetInternalIds: { refType: BuiltinTypes.BOOLEAN },
     translationCollectionReferences: { refType: BuiltinTypes.BOOLEAN },
+    omitFields: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/netsuite-adapter/src/filters/data_instances_diff.ts
+++ b/packages/netsuite-adapter/src/filters/data_instances_diff.ts
@@ -13,23 +13,27 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { getChangeData, InstanceElement, isEqualValues, isInstanceChange, isModificationChange, ModificationChange } from '@salto-io/adapter-api'
+import { getChangeData, InstanceElement, isEqualValues, isInstanceChange, isModificationChange, ModificationChange, Element } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
-import { isDataObjectType } from '../types'
+import { getElementValueOrAnnotations, isDataObjectType } from '../types'
 import { LocalFilterCreator } from '../filter'
 
 const { awu } = collections.asynciterable
 
 export const getDifferentKeys = (
-  change: ModificationChange<InstanceElement>
-): Set<string> => new Set(
-  Object.keys(change.data.after.value)
-    .filter(key => !isEqualValues(
-      change.data.after.value[key],
-      change.data.before.value[key]
-    ))
-)
+  change: ModificationChange<Element>
+): Set<string> => {
+  const afterValues = getElementValueOrAnnotations(change.data.after)
+  const beforeValues = getElementValueOrAnnotations(change.data.before)
+  return new Set(
+    Object.keys(afterValues)
+      .filter(key => !isEqualValues(
+        afterValues[key],
+        beforeValues[key]
+      ))
+  )
+}
 
 export const removeIdenticalValues = (change: ModificationChange<InstanceElement>): void => {
   const differentKeys = getDifferentKeys(change)

--- a/packages/netsuite-adapter/src/filters/omit_fields.ts
+++ b/packages/netsuite-adapter/src/filters/omit_fields.ts
@@ -141,7 +141,9 @@ const filterCreator: LocalFilterCreator = ({ config, elementsSource }) => ({
       return
     }
 
-    const typeNames = await awu(await elementsSource.list()).map(elemId => elemId.name).toArray()
+    const typeNames = await awu(await elementsSource.list())
+      .filter(elemId => elemId.idType === 'type')
+      .map(elemId => elemId.name).toArray()
     const fieldsToOmitByType = getFieldsToOmitByType(typeNames, fieldsToOmit)
     if (_.isEmpty(fieldsToOmitByType)) {
       return

--- a/packages/netsuite-adapter/src/filters/omit_fields.ts
+++ b/packages/netsuite-adapter/src/filters/omit_fields.ts
@@ -26,9 +26,8 @@ import { CUSTOM_FIELDS_LIST } from '../custom_records/custom_record_type'
 const { awu } = collections.asynciterable
 const { isFullRegexMatch } = regex
 
-const FIELDS_TO_OMIT_ON_FETCH: FieldToOmitParams[] = []
 const CLASS_TRANSLATION_LIST = 'classTranslationList'
-
+const FIELDS_TO_OMIT_ON_FETCH: FieldToOmitParams[] = []
 export const FIELDS_TO_OMIT_PRE_DEPLOY: FieldToOmitParams[] = [
   { type: 'inventoryItem', fields: [CURRENCY] },
   { type: 'subsidiary', fields: [CLASS_TRANSLATION_LIST] },

--- a/packages/netsuite-adapter/src/filters/omit_fields.ts
+++ b/packages/netsuite-adapter/src/filters/omit_fields.ts
@@ -14,96 +14,141 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { isInstanceElement, isObjectType, Values } from '@salto-io/adapter-api'
+import { getChangeData, isInstanceElement, isObjectType, Values, Element } from '@salto-io/adapter-api'
 import { transformElementAnnotations, TransformFunc, transformValues } from '@salto-io/adapter-utils'
 import { collections, regex } from '@salto-io/lowerdash'
 import { LocalFilterCreator } from '../filter'
 import { FieldToOmitParams } from '../query'
-import { CUSTOM_RECORD_TYPE } from '../constants'
+import { CURRENCY, CUSTOM_RECORD_TYPE } from '../constants'
 import { isCustomRecordType } from '../types'
 import { CUSTOM_FIELDS_LIST } from '../custom_records/custom_record_type'
 
 const { awu } = collections.asynciterable
 const { isFullRegexMatch } = regex
 
-const FIELDS_TO_OMIT: FieldToOmitParams[] = []
+const FIELDS_TO_OMIT_ON_FETCH: FieldToOmitParams[] = []
+const CLASS_TRANSLATION_LIST = 'classTranslationList'
 
-const filterCreator: LocalFilterCreator = ({ config }) => ({
+export const FIELDS_TO_OMIT_PRE_DEPLOY: FieldToOmitParams[] = [
+  { type: 'inventoryItem', fields: [CURRENCY] },
+  { type: 'subsidiary', fields: [CLASS_TRANSLATION_LIST] },
+  { type: 'location', fields: [CLASS_TRANSLATION_LIST] },
+  { type: 'department', fields: [CLASS_TRANSLATION_LIST] },
+  { type: 'classification', fields: [CLASS_TRANSLATION_LIST] },
+]
+
+export const getFieldsToOmitByType = (
+  typeNames: string[],
+  fieldsToOmit: FieldToOmitParams[]
+): Record<string, string[]> =>
+  Object.fromEntries(
+    typeNames.map((typeName: string): [string, string[]] => [
+      typeName,
+      fieldsToOmit
+        .filter(({ type, subtype }) => isFullRegexMatch(typeName, subtype !== undefined ? subtype : type))
+        .flatMap(params => params.fields),
+    ]).filter(([_t, fields]) => fields.length > 0)
+  )
+
+const getTypesForDeepTransformation = (typeNames: string[], fieldsToOmit: FieldToOmitParams[]): Set<string> =>
+  new Set(
+    typeNames.filter(typeName => fieldsToOmit
+      .some(({ type, subtype }) => subtype !== undefined && subtype !== type && isFullRegexMatch(typeName, type)))
+  )
+
+const omitFieldsFromElements = async (
+  elements: Element[],
+  fieldsToOmitByType: Record<string, string[]>,
+  typesForDeepTransformation: Set<string>,
+): Promise<void> => {
+  const omitValues = (value: Values, typeName: string): Values => (
+    typeName in fieldsToOmitByType
+      ? _.omitBy(value, (_val, key) => fieldsToOmitByType[typeName]
+        .some(fieldToOmit => isFullRegexMatch(key, fieldToOmit)))
+      : value
+  )
+
+  const transformFunc: TransformFunc = async ({ value, field }) => {
+    if (!_.isPlainObject(value)) {
+      return value
+    }
+    const fieldType = await field?.getType()
+    if (!isObjectType(fieldType)) {
+      return value
+    }
+    return omitValues(value, fieldType.elemID.name)
+  }
+
+  await awu(elements)
+    .filter(isInstanceElement)
+    .forEach(async instance => {
+      instance.value = omitValues(instance.value, instance.elemID.typeName)
+      if (typesForDeepTransformation.has(instance.elemID.typeName)) {
+        instance.value = await transformValues({
+          values: instance.value,
+          type: await instance.getType(),
+          transformFunc,
+          strict: false,
+        }) ?? {}
+      }
+    })
+
+  await awu(elements)
+    .filter(isObjectType)
+    .filter(isCustomRecordType)
+    .forEach(async type => {
+      type.annotations = omitValues(type.annotations, CUSTOM_RECORD_TYPE)
+      if (typesForDeepTransformation.has(CUSTOM_RECORD_TYPE)) {
+        type.annotations = await transformElementAnnotations({
+          element: type,
+          transformFunc,
+          strict: false,
+        })
+      }
+      Object.values(type.fields).forEach(field => {
+        field.annotations = omitValues(field.annotations, CUSTOM_FIELDS_LIST)
+      })
+    })
+}
+
+
+const filterCreator: LocalFilterCreator = ({ config, elementsSource }) => ({
   name: 'omitFieldsFilter',
   onFetch: async elements => {
-    const fieldsToOmit = FIELDS_TO_OMIT.concat(config.fetch?.fieldsToOmit ?? [])
+    const fieldsToOmit = FIELDS_TO_OMIT_ON_FETCH.concat(config.fetch?.fieldsToOmit ?? [])
 
     if (fieldsToOmit.length === 0) {
       return
     }
 
     const typeNames = elements.filter(isObjectType).map(elem => elem.elemID.name).concat(CUSTOM_FIELDS_LIST)
-    const fieldsToOmitByType = Object.fromEntries(
-      typeNames.map((typeName: string): [string, string[]] => [
-        typeName,
-        fieldsToOmit
-          .filter(({ type, subtype }) => isFullRegexMatch(typeName, subtype !== undefined ? subtype : type))
-          .flatMap(params => params.fields),
-      ]).filter(([_t, fields]) => fields.length > 0)
-    )
+    const fieldsToOmitByType = getFieldsToOmitByType(typeNames, fieldsToOmit)
 
     if (_.isEmpty(fieldsToOmitByType)) {
       return
     }
 
-    const typesForDeepTransformation = new Set(
-      typeNames.filter(typeName => fieldsToOmit
-        .some(({ type, subtype }) => subtype !== undefined && subtype !== type && isFullRegexMatch(typeName, type)))
-    )
+    const typesForDeepTransformation = getTypesForDeepTransformation(typeNames, fieldsToOmit)
 
-    const omitValues = (value: Values, typeName: string): Values => (
-      typeName in fieldsToOmitByType
-        ? _.omitBy(value, (_val, key) => fieldsToOmitByType[typeName]
-          .some(fieldToOmit => isFullRegexMatch(key, fieldToOmit)))
-        : value
-    )
+    await omitFieldsFromElements(elements, fieldsToOmitByType, typesForDeepTransformation)
+  },
+  preDeploy: async changes => {
+    const elements = changes.map(getChangeData)
+    const fieldsToOmit = FIELDS_TO_OMIT_PRE_DEPLOY.concat(config.deploy?.fieldsToOmit ?? [])
 
-    const transformFunc: TransformFunc = async ({ value, field }) => {
-      if (!_.isPlainObject(value)) {
-        return value
-      }
-      const fieldType = await field?.getType()
-      if (!isObjectType(fieldType)) {
-        return value
-      }
-      return omitValues(value, fieldType.elemID.name)
+    if (fieldsToOmit.length === 0) {
+      return
     }
 
-    await awu(elements)
-      .filter(isInstanceElement)
-      .forEach(async instance => {
-        instance.value = omitValues(instance.value, instance.elemID.typeName)
-        if (typesForDeepTransformation.has(instance.elemID.typeName)) {
-          instance.value = await transformValues({
-            values: instance.value,
-            type: await instance.getType(),
-            transformFunc,
-            strict: false,
-          }) ?? {}
-        }
-      })
+    const typeNames = await awu(await elementsSource.list()).map(elemId => elemId.name).toArray()
+    const fieldsToOmitByType = getFieldsToOmitByType(typeNames, fieldsToOmit)
+    if (_.isEmpty(fieldsToOmitByType)) {
+      return
+    }
 
-    await awu(elements)
-      .filter(isObjectType)
-      .filter(isCustomRecordType)
-      .forEach(async type => {
-        type.annotations = omitValues(type.annotations, CUSTOM_RECORD_TYPE)
-        if (typesForDeepTransformation.has(CUSTOM_RECORD_TYPE)) {
-          type.annotations = await transformElementAnnotations({
-            element: type,
-            transformFunc,
-            strict: false,
-          })
-        }
-        Object.values(type.fields).forEach(field => {
-          field.annotations = omitValues(field.annotations, CUSTOM_FIELDS_LIST)
-        })
-      })
+    const typesForDeepTransformation = getTypesForDeepTransformation(typeNames, fieldsToOmit)
+
+    await omitFieldsFromElements(elements, fieldsToOmitByType, typesForDeepTransformation)
   },
 })
 

--- a/packages/netsuite-adapter/test/change_validator.test.ts
+++ b/packages/netsuite-adapter/test/change_validator.test.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import { Change, ChangeError, ElemID, InstanceElement, ObjectType, ProgressReporter, toChange, getChangeData, SeverityLevel, ReadOnlyElementsSource } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { Filter } from '../src/filter'
 import { fileType } from '../src/types/file_cabinet_types'
 import getChangeValidator from '../src/change_validator'
@@ -65,7 +66,7 @@ describe('change validator', () => {
     describe('without SuiteApp', () => {
       it('should have change error when removing an instance with file cabinet type', async () => {
         const changeValidator = getChangeValidator(
-          { ...DEFAULT_OPTIONS, client, fetchByQuery }
+          { ...DEFAULT_OPTIONS, client, fetchByQuery, elementsSource: buildElementsSourceFromElements([]) }
         )
         const instance = new InstanceElement('test', file, { path: 'somePath' })
         const changeErrors = await changeValidator([toChange({ before: instance })])
@@ -75,7 +76,7 @@ describe('change validator', () => {
       })
       it('should not have change error when modifying an file cabinet instance without internal id', async () => {
         const changeValidator = getChangeValidator(
-          { ...DEFAULT_OPTIONS, client, fetchByQuery }
+          { ...DEFAULT_OPTIONS, client, fetchByQuery, elementsSource: buildElementsSourceFromElements([]) }
         )
         const instance = new InstanceElement('test', file, { path: 'somePath' })
         const changeErrors = await changeValidator([toChange({ before: instance, after: instance })])
@@ -91,6 +92,7 @@ describe('change validator', () => {
             withSuiteApp: true,
             client,
             fetchByQuery,
+            elementsSource: buildElementsSourceFromElements([]),
           }
         )
         const instance = new InstanceElement('test', file, { [INTERNAL_ID]: '1', path: 'somePath' })
@@ -104,6 +106,7 @@ describe('change validator', () => {
             withSuiteApp: true,
             client,
             fetchByQuery,
+            elementsSource: buildElementsSourceFromElements([]),
           }
         )
         const instance = new InstanceElement('test', file, { path: 'somePath' })
@@ -144,6 +147,7 @@ describe('change validator', () => {
           ...DEFAULT_OPTIONS,
           client,
           fetchByQuery,
+          elementsSource: buildElementsSourceFromElements([]),
         }
       )([change])
       expect(changeErrors).toHaveLength(0)
@@ -155,6 +159,7 @@ describe('change validator', () => {
           warnStaleData: true,
           client,
           fetchByQuery,
+          elementsSource: buildElementsSourceFromElements([]),
         }
       )([change])
       expect(changeErrors).toHaveLength(1)
@@ -168,6 +173,7 @@ describe('change validator', () => {
         {
           ...DEFAULT_OPTIONS,
           client,
+          elementsSource: buildElementsSourceFromElements([]),
         }
       )([toChange({ after: new InstanceElement('test', file, { path: 'somePath' }) })])
       expect(netsuiteClientValidationMock).not.toHaveBeenCalled()
@@ -179,6 +185,7 @@ describe('change validator', () => {
           ...DEFAULT_OPTIONS,
           client,
           validate: true,
+          elementsSource: buildElementsSourceFromElements([]),
         }
       )(changes)
       expect(netsuiteClientValidationMock).toHaveBeenCalledWith(
@@ -203,6 +210,7 @@ describe('change validator', () => {
           ...DEFAULT_OPTIONS,
           client,
           validate: true,
+          elementsSource: buildElementsSourceFromElements([]),
         }
       )([validChange, invalidChange])
       expect(netsuiteClientValidationMock).toHaveBeenCalledWith(

--- a/packages/netsuite-adapter/test/change_validators/omit_fields.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/omit_fields.test.ts
@@ -55,7 +55,7 @@ describe('omit fields change validator test', () => {
     expect(changeError[0]).toEqual({
       elemID: instance.elemID,
       severity: 'Error',
-      message: 'This element will be removed from deployment',
+      message: 'This element contains an undeployable change',
       detailedMessage: 'This element will be removed from deployment because it only contains changes to the undeployable field \'currency\'.',
     })
   })

--- a/packages/netsuite-adapter/test/change_validators/omit_fields.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/omit_fields.test.ts
@@ -103,8 +103,8 @@ describe('omit fields change validator test', () => {
     expect(changeErrors[0]).toEqual({
       elemID: instance.elemID,
       severity: 'Warning',
-      message: 'This element will be deployed without the following fields: \'currency\', \'inner2\'',
-      detailedMessage: 'This element will be deployed without the following fields: \'currency\', \'inner2\', as NetSuite does not support deploying them.',
+      message: 'This element will be deployed without the following fields: \'currency\', \'innerField.inner2\'',
+      detailedMessage: 'This element will be deployed without the following fields: \'currency\', \'innerField.inner2\', as NetSuite does not support deploying them.',
     })
   })
 

--- a/packages/netsuite-adapter/test/change_validators/omit_fields.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/omit_fields.test.ts
@@ -1,0 +1,68 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { BuiltinTypes, ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { NETSUITE } from '../../src/constants'
+import omitFieldsValidation from '../../src/change_validators/omit_fields'
+
+describe('omit fields change validator test', () => {
+  let type: ObjectType
+  let instance: InstanceElement
+  let after: InstanceElement
+  beforeEach(() => {
+    type = new ObjectType({
+      elemID: new ElemID(NETSUITE, 'inventoryItem'),
+      fields: {
+        currency: { refType: BuiltinTypes.STRING },
+        field2: { refType: BuiltinTypes.BOOLEAN },
+      },
+    })
+    instance = new InstanceElement('test', type, {
+      currency: 'Shekel',
+      field2: true,
+    })
+    after = instance.clone()
+  })
+  it('should have warning on elements that contain fields that will be omitted', async () => {
+    const changeError = await omitFieldsValidation([toChange({ after: instance })])
+    expect(changeError).toHaveLength(1)
+    expect(changeError[0]).toEqual({
+      elemID: instance.elemID,
+      severity: 'Warning',
+      message: 'This element will be deployed without the following fields: \'currency\'',
+      detailedMessage: 'This element will be deployed without the following fields: \'currency\', as NetSuite does not support deploying them.',
+    })
+  })
+
+  it('should have error when only a single field has been changed and will be ommited', async () => {
+    after.value.currency = 'Dong'
+    const changeError = await omitFieldsValidation([toChange({ before: instance, after })])
+    expect(changeError).toHaveLength(1)
+    expect(changeError[0]).toEqual({
+      elemID: instance.elemID,
+      severity: 'Error',
+      message: 'This element will be removed from deployment',
+      detailedMessage: 'This element will be removed from deployment because it only contains changes to the undeployable field \'currency\'.',
+    })
+  })
+
+  it('should not have change error if no field is about to be ommited', async () => {
+    instance.value = _.omit(instance.value, ['currency'])
+    const changeError = await omitFieldsValidation([toChange({ after: instance })])
+    expect(changeError).toHaveLength(0)
+  })
+})

--- a/packages/netsuite-adapter/test/filters/omit_fields.test.ts
+++ b/packages/netsuite-adapter/test/filters/omit_fields.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import { BuiltinTypes, ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { LazyElementsSourceIndexes } from '../../src/elements_source_index/types'
 import { getDefaultAdapterConfig } from '../utils'
@@ -28,6 +28,8 @@ describe('omit fields filter', () => {
   let innerType: ObjectType
   let instance: InstanceElement
   let defaultOpts: LocalFilterOpts
+  let customRecordObjectType: ObjectType
+  const { type: customrecordtype, innerTypes: customrecordInnerTypes } = customrecordtypeType()
   beforeEach(async () => {
     innerType = new ObjectType({ elemID: new ElemID(NETSUITE, 'innerType') })
     type = new ObjectType({
@@ -47,44 +49,7 @@ describe('omit fields filter', () => {
       isPartial: false,
       config: await getDefaultAdapterConfig(),
     }
-  })
-  it('should not omit fields by default', async () => {
-    await filterCreator(defaultOpts).onFetch?.([instance])
-    expect(instance.value).toEqual({
-      field1: true,
-      field2: { nested1: 'test', nested2: 'test2' },
-    })
-  })
-  it('should not omit when no rule matches', async () => {
-    await filterCreator({
-      ...defaultOpts,
-      config: { fetch: { fieldsToOmit: [{ type: 'notSome.*', fields: ['.*'] }] } },
-    }).onFetch?.([instance, type, innerType])
-    expect(instance.value).toEqual({
-      field1: true,
-      field2: { nested1: 'test', nested2: 'test2' },
-    })
-  })
-  it('should omit fields in top level element', async () => {
-    await filterCreator({
-      ...defaultOpts,
-      config: { fetch: { fieldsToOmit: [{ type: 'some.*', fields: ['.*2'] }] } },
-    }).onFetch?.([instance, type, innerType])
-    expect(instance.value).toEqual({ field1: true })
-  })
-  it('should omit fields in inner type', async () => {
-    await filterCreator({
-      ...defaultOpts,
-      config: { fetch: { fieldsToOmit: [{ type: 'some.*', subtype: 'inner.*', fields: ['.*2'] }] } },
-    }).onFetch?.([instance, type, innerType])
-    expect(instance.value).toEqual({
-      field1: true,
-      field2: { nested1: 'test' },
-    })
-  })
-  it('should omit fields in custom record type', async () => {
-    const { type: customrecordtype, innerTypes: customrecordInnerTypes } = customrecordtypeType()
-    const customRecordObjectType = new ObjectType({
+    customRecordObjectType = new ObjectType({
       elemID: new ElemID(NETSUITE, 'customrecord1'),
       fields: {
         custom_custfield1: {
@@ -122,34 +87,146 @@ describe('omit fields filter', () => {
         metadataType: 'customrecordtype',
       },
     })
-    await filterCreator({
-      ...defaultOpts,
-      config: {
-        fetch: {
-          fieldsToOmit: [
-            { type: 'customrecordtype', fields: ['links'] },
-            { type: 'customrecordtype', subtype: 'customrecordtype_permissions_permission', fields: ['.*level'] },
-            { type: 'customrecordcustomfield', fields: ['is.*'] },
+  })
+
+  describe('omit fields onFetch', () => {
+    it('should not omit fields by default', async () => {
+      await filterCreator(defaultOpts).onFetch?.([instance])
+      expect(instance.value).toEqual({
+        field1: true,
+        field2: { nested1: 'test', nested2: 'test2' },
+      })
+    })
+    it('should not omit when no rule matches', async () => {
+      await filterCreator({
+        ...defaultOpts,
+        config: { fetch: { fieldsToOmit: [{ type: 'notSome.*', fields: ['.*'] }] } },
+      }).onFetch?.([instance, type, innerType])
+      expect(instance.value).toEqual({
+        field1: true,
+        field2: { nested1: 'test', nested2: 'test2' },
+      })
+    })
+    it('should omit fields in top level element', async () => {
+      await filterCreator({
+        ...defaultOpts,
+        config: { fetch: { fieldsToOmit: [{ type: 'some.*', fields: ['.*2'] }] } },
+      }).onFetch?.([instance, type, innerType])
+      expect(instance.value).toEqual({ field1: true })
+    })
+    it('should omit fields in inner type', async () => {
+      await filterCreator({
+        ...defaultOpts,
+        config: { fetch: { fieldsToOmit: [{ type: 'some.*', subtype: 'inner.*', fields: ['.*2'] }] } },
+      }).onFetch?.([instance, type, innerType])
+      expect(instance.value).toEqual({
+        field1: true,
+        field2: { nested1: 'test' },
+      })
+    })
+    it('should omit fields in custom record type', async () => {
+      await filterCreator({
+        ...defaultOpts,
+        config: {
+          fetch: {
+            fieldsToOmit: [
+              { type: 'customrecordtype', fields: ['links'] },
+              { type: 'customrecordtype', subtype: 'customrecordtype_permissions_permission', fields: ['.*level'] },
+              { type: 'customrecordcustomfield', fields: ['is.*'] },
+            ],
+          },
+        },
+      }).onFetch?.([customrecordtype, customRecordObjectType, ...Object.values(customrecordInnerTypes)])
+      expect(customRecordObjectType.annotations).toEqual({
+        scriptid: 'customrecord1',
+        // used to verify that a field that match 'type' but doesn't match the 'subtype' is not omitted
+        istoplevel: true,
+        permissions: {
+          permission: [
+            {
+              permittedrole: 'ADMINISTRATOR',
+            },
           ],
         },
-      },
-    }).onFetch?.([customrecordtype, customRecordObjectType, ...Object.values(customrecordInnerTypes)])
-    expect(customRecordObjectType.annotations).toEqual({
-      scriptid: 'customrecord1',
-      // used to verify that a field that match 'type' but doesn't match the 'subtype' is not omitted
-      istoplevel: true,
-      permissions: {
-        permission: [
-          {
-            permittedrole: 'ADMINISTRATOR',
-          },
-        ],
-      },
-      metadataType: 'customrecordtype',
+        metadataType: 'customrecordtype',
+      })
+      expect(customRecordObjectType.fields.custom_custfield1.annotations).toEqual({
+        scriptid: 'custfield1',
+        label: 'Custom Field 1',
+      })
     })
-    expect(customRecordObjectType.fields.custom_custfield1.annotations).toEqual({
-      scriptid: 'custfield1',
-      label: 'Custom Field 1',
+  })
+  describe('omit fields preDeploy tests', () => {
+    it('should not omit by default', async () => {
+      await filterCreator(defaultOpts).preDeploy?.([toChange({ after: instance })])
+      expect(instance.value).toEqual({
+        field1: true,
+        field2: { nested1: 'test', nested2: 'test2' },
+      })
+    })
+
+    it('should not omit if rule doesn\'t match', async () => {
+      await filterCreator({ ...defaultOpts,
+        config: { deploy: { fieldsToOmit: [{ type: 'notSome.*', fields: ['.*'] }] } } })
+        .preDeploy?.([
+          toChange({ after: instance }),
+        ])
+      expect(instance.value).toEqual({
+        field1: true,
+        field2: { nested1: 'test', nested2: 'test2' },
+      })
+    })
+
+    it('should omit field from top level element', async () => {
+      await filterCreator({
+        ...defaultOpts,
+        elementsSource: buildElementsSourceFromElements([instance, type, innerType]),
+        config: { deploy: { fieldsToOmit: [{ type: 'some.*', fields: ['.*2'] }] } },
+      }).preDeploy?.([toChange({ after: instance })])
+      expect(instance.value).toEqual({ field1: true })
+    })
+
+    it('should omit field from inner type', async () => {
+      await filterCreator({
+        ...defaultOpts,
+        elementsSource: buildElementsSourceFromElements([instance, type, innerType]),
+        config: { deploy: { fieldsToOmit: [{ type: 'some.*', subtype: 'inner.*', fields: ['.*2'] }] } },
+      }).preDeploy?.([toChange({ after: instance })])
+      expect(instance.value).toEqual({
+        field1: true,
+        field2: { nested1: 'test' },
+      })
+    })
+
+    it('should omit fields from custom record type', async () => {
+      await filterCreator({
+        ...defaultOpts,
+        elementsSource: buildElementsSourceFromElements([
+          customrecordtype,
+          ...Object.values(customrecordInnerTypes),
+          customRecordObjectType]),
+        config: {
+          deploy: {
+            fieldsToOmit: [
+              { type: 'customrecordtype', fields: ['links'] },
+              { type: 'customrecordtype', subtype: 'customrecordtype_permissions_permission', fields: ['.*level'] },
+              { type: 'customrecordcustomfield', fields: ['is.*'] },
+            ],
+          },
+        },
+      }).preDeploy?.([toChange({ after: customRecordObjectType })])
+      expect(customRecordObjectType.annotations).toEqual({
+        scriptid: 'customrecord1',
+        istoplevel: true,
+        permissions: {
+          permission: [
+            {
+              permittedrole: 'ADMINISTRATOR',
+            },
+          ],
+        },
+        metadataType: 'customrecordtype',
+      })
     })
   })
 })


### PR DESCRIPTION
_omit_fields filter now removes fields on preDeploy according to hard coded fields and fields from config_

---

_This pr covers two tickets_:
* https://salto-io.atlassian.net/browse/SALTO-2781
* https://salto-io.atlassian.net/browse/SALTO-4481

---
_Release Notes_: 
_Netsuite Adapter_:
* 'classTranslationList' field in data elements and 'currency' field in inventory items will be omitted in preDeploy
* fieldToOmit added to config.deploy similar to the existing logic in config.fetch

---
_User Notifications_: 
_None_
