### PR TITLE
SALTO-4558: omit usage_7d from selected_macros in workspace

### DIFF
--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -1128,6 +1128,7 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
   workspace__selected_macros: {
     transformation: {
       fieldsToHide: [],
+      fieldsToOmit: [{ fieldName: 'usage_7d', fieldType: 'number' }],
     },
   },
   workspace__selected_macros__restriction: {


### PR DESCRIPTION
omit usage_7d from selected_macros in workspace

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* omit usage_7d from selected_macros in workspace

---
_User Notifications_: 
zendesk:
* remove field usage_7d from selected_macros in workspace
