### PR TITLE
Add SOAP retryable error - request aborted error

### DIFF
--- a/packages/netsuite-adapter/src/client/suiteapp_client/constants.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/constants.ts
@@ -21,6 +21,7 @@ export const ECONN_ERROR = 'ECONN'
 export const UNEXPECTED_ERROR = 'UNEXPECTED_ERROR'
 export const INSUFFICIENT_PERMISSION_ERROR = 'INSUFFICIENT_PERMISSION'
 export const VALIDATION_ERROR = 'VALIDATION_ERROR'
+export const REQUEST_ABORTED_ERROR = 'REQUEST ABORTED'
 
 // SuiteApp instance fields
 export const PLATFORM_CORE_CUSTOM_FIELD = 'platformCore:customField'

--- a/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
@@ -24,7 +24,7 @@ import { collections, decorators, promises, strings } from '@salto-io/lowerdash'
 import { v4 as uuidv4 } from 'uuid'
 import { RECORD_REF } from '../../../constants'
 import { SuiteAppSoapCredentials, toUrlAccountId } from '../../credentials'
-import { CONSUMER_KEY, CONSUMER_SECRET, ECONN_ERROR, INSUFFICIENT_PERMISSION_ERROR, UNEXPECTED_ERROR, VALIDATION_ERROR } from '../constants'
+import { CONSUMER_KEY, CONSUMER_SECRET, ECONN_ERROR, INSUFFICIENT_PERMISSION_ERROR, REQUEST_ABORTED_ERROR, UNEXPECTED_ERROR, VALIDATION_ERROR } from '../constants'
 import { ReadFileError } from '../errors'
 import { CallsLimiter, ExistingFileCabinetInstanceDetails, FileCabinetInstanceDetails, FileDetails, FolderDetails, HasElemIDFunc } from '../types'
 import { CustomRecordResponse, DeployListResults, GetAllResponse, GetResult, isDeployListSuccess, isGetSuccess, isWriteResponseSuccess, RecordResponse, RecordValue, SearchErrorResponse, SearchPageResponse, SearchResponse, SoapSearchType, WriteResponse } from './types'
@@ -59,7 +59,13 @@ const SOAP_FILE_CABINET_URN = `urn:filecabinet_${NETSUITE_VERSION}.documents.web
 
 const SOAP_CUSTOM_RECORD_TYPE_NAME = 'CustomRecord'
 
-const RETRYABLE_MESSAGES = [ECONN_ERROR, UNEXPECTED_ERROR, INSUFFICIENT_PERMISSION_ERROR, VALIDATION_ERROR]
+const RETRYABLE_MESSAGES = [
+  ECONN_ERROR,
+  UNEXPECTED_ERROR,
+  INSUFFICIENT_PERMISSION_ERROR,
+  VALIDATION_ERROR,
+  REQUEST_ABORTED_ERROR,
+]
 const SOAP_RETRYABLE_MESSAGES = ['CONCURRENT']
 const SOAP_RETRYABLE_STATUS_INITIALS = ['5']
 


### PR DESCRIPTION

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Add SOAP retryable error - request aborted error

---
_User Notifications_: 
None
