### PR TITLE
SALTO-4535: Fix a bug with field contexts

### DIFF
--- a/packages/jira-adapter/src/change_validators/field_contexts/field_contexts.ts
+++ b/packages/jira-adapter/src/change_validators/field_contexts/field_contexts.ts
@@ -16,7 +16,6 @@
 import { ChangeValidator, getChangeData, InstanceElement, isInstanceElement, isReferenceExpression, ReadOnlyElementsSource, ReferenceExpression, UnresolvedReference } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
-import { isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { PROJECT_CONTEXTS_FIELD } from '../../filters/fields/contexts_projects_filter'
 import { PROJECT_TYPE } from '../../constants'
 import { FIELD_CONTEXT_TYPE_NAME } from '../../filters/fields/constants'
@@ -84,7 +83,7 @@ export const fieldContextValidator: ChangeValidator = async (changes, elementSou
     .map(project => [
       project.elemID.name,
       new Set(project.value[PROJECT_CONTEXTS_FIELD].filter((ref: ReferenceExpression) => {
-        if (!isResolvedReferenceExpression(ref)) {
+        if (!isReferenceExpression(ref)) {
           log.warn(`Found a non reference expression in project ${project.elemID.getFullName()}`)
           return false
         }


### PR DESCRIPTION
_There is currently a bug that prevents deployments of non-global contexts_

---

The previous fix for 4535 was not complete

---
_Release Notes_: 
JIra Adapter:
* Fixed a bug that prevented deployment of non-global field contexts

---
_User Notifications_: 
None