### PR TITLE
SALTO-3203 detect known general SDF errors

### DIFF
--- a/packages/netsuite-adapter/src/client/language_utils.ts
+++ b/packages/netsuite-adapter/src/client/language_utils.ts
@@ -34,7 +34,7 @@ type ErrorDetectors = {
   errorObjectRegex: RegExp
   manifestErrorDetailsRegex: RegExp
   configureFeatureFailRegex: RegExp
-  validationFailed: RegExp
+  otherErrorRegexes: RegExp[]
 }
 
 export const multiLanguageErrorDetectors: Record<SupportedLanguage, ErrorDetectors> = {
@@ -55,7 +55,9 @@ export const multiLanguageErrorDetectors: Record<SupportedLanguage, ErrorDetecto
     errorObjectRegex: RegExp(`^An unexpected error has occurred\\. \\((?<${OBJECT_ID}>[a-z0-9_]+)\\)`, 'gm'),
     manifestErrorDetailsRegex: RegExp(`Details: The manifest contains a dependency on (?<${OBJECT_ID}>[a-z0-9_]+(\\.[a-z0-9_]+)*)`, 'gm'),
     configureFeatureFailRegex: RegExp(`Configure feature -- (Enabling|Disabling) of the (?<${FEATURE_NAME}>\\w+)\\(.*?\\) feature has FAILED`),
-    validationFailed: RegExp('^Validation failed\\.$', 'm'),
+    otherErrorRegexes: [
+      RegExp('An error occurred during account settings validation.'),
+    ],
   },
   // NOTE: all non-english letters are replaced with a dot
   french: {
@@ -76,7 +78,9 @@ export const multiLanguageErrorDetectors: Record<SupportedLanguage, ErrorDetecto
     errorObjectRegex: RegExp(`^An unexpected error has occurred\\. \\((?<${OBJECT_ID}>[a-z0-9_]+)\\)`, 'gm'),
     manifestErrorDetailsRegex: RegExp(`D.tails: Le manifeste comporte une d.pendance sur l'objet (?<${OBJECT_ID}>[a-z0-9_]+(\\.[a-z0-9_]+)*)`, 'gm'),
     configureFeatureFailRegex: RegExp(`Configurer la fonction -- (L'activation|La d.sactivation) de la fonction (?<${FEATURE_NAME}>\\w+)\\(.*?\\) a .chou.`),
-    validationFailed: RegExp('^La validation a .chou.\\.$', 'm'),
+    otherErrorRegexes: [
+      RegExp('An error occurred during account settings validation.'),
+    ],
   },
 }
 

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -843,6 +843,7 @@ export default class SdfClient {
       missingFeatureErrorRegexes,
       deployedObjectRegex,
       errorObjectRegex,
+      otherErrorRegexes,
     } = multiLanguageErrorDetectors[sdfLanguage]
 
     const manifestErrorScriptids = getFailedObjects(messages, manifestErrorDetailsRegex)
@@ -890,7 +891,9 @@ ${this.manifestXmlContent}
 deploy.xml:
 ${this.deployXmlContent}
 `)
-    return error
+
+    const detectedErrors = messages.filter(message => otherErrorRegexes.some(regex => regex.test(message)))
+    return detectedErrors.length > 0 ? new Error(detectedErrors.join(os.EOL)) : error
   }
 
   private async runDeployCommands(

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -1698,6 +1698,54 @@ Object: customrecord_flo_customization.custrecord_flo_custz_link (customrecordcu
         } catch (e) {
           isRejected = true
           expect(e instanceof ObjectsDeployError).toBeFalsy()
+          expect(e.message).toEqual(errorMessage)
+        }
+        expect(isRejected).toBe(true)
+      })
+      it('should throw shorten error', async () => {
+        const errorMessage = `
+The deployment process has encountered an error.
+Deploying to TSTDRV2259448 - Salto Extended Dev - Administrator.
+2022-03-30 23:55:26 (PST) Installation started
+Info -- Account [(PRODUCTION) Salto Extended Dev]
+Info -- Account Customization Project [TempSdfProject-e5a4eed4-e331-490f-9cfa-69cf84bd231b]
+Info -- Framework Version [1.0]
+Validate manifest -- Success
+Validate deploy file -- Success
+Validate configuration -- Success
+Validate objects -- Success
+Validate files -- Success
+Validate folders -- Success
+Validate translation imports -- Success
+Validation of referenceability from custom objects to translations collection strings in progress. -- Success
+Validate preferences -- Success
+Validate flags -- Success
+Validate for circular dependencies -- Success
+Validate account settings -- Failed
+*** ERROR ***
+
+Validation of account settings failed.
+
+An error occurred during account settings validation.
+Details: To install this SuiteCloud project, the INVENTORYSTATUS(Inventory Status) feature must be enabled in the account.
+Details: To install this SuiteCloud project, the CHARGEBASEDBILLING(Charge-Based Billing) feature must be enabled in the account.`
+        mockExecuteAction.mockImplementation(({ commandName }) => {
+          if (commandName === COMMANDS.DEPLOY_PROJECT) {
+            throw errorMessage
+          }
+          return { isSuccess: () => true }
+        })
+        let isRejected: boolean
+        testGraph.addNodes([new GraphNode('name', testSDFNode)])
+        try {
+          await client.deploy(...DEFAULT_DEPLOY_PARAMS)
+          isRejected = false
+        } catch (e) {
+          isRejected = true
+          expect(e instanceof ObjectsDeployError).toBeFalsy()
+          expect(e.message).toEqual(`An error occurred during account settings validation.
+Details: To install this SuiteCloud project, the INVENTORYSTATUS(Inventory Status) feature must be enabled in the account.
+Details: To install this SuiteCloud project, the CHARGEBASEDBILLING(Charge-Based Billing) feature must be enabled in the account.`)
         }
         expect(isRejected).toBe(true)
       })


### PR DESCRIPTION
In order to return shorter and more relevant deploy/validation errors.

---

_Additional context for reviewer_

Also removed unused property `validationFailed`

---
_Release Notes_: 
Netsuite Adapter:
- Detect known general SDF errors

---
_User Notifications_: 
None
