### PR TITLE
SALTO-4565 Skip integration objects on SDF folder parsing

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -23,8 +23,8 @@ import { collections, values } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import { filter } from '@salto-io/adapter-utils'
 import { createElements } from './transformer'
-import { DeployResult, isCustomRecordType } from './types'
-import { BUNDLE, INTEGRATION } from './constants'
+import { DeployResult, TYPES_TO_SKIP, isCustomRecordType } from './types'
+import { BUNDLE } from './constants'
 import convertListsToMaps from './filters/convert_lists_to_maps'
 import replaceElementReferences from './filters/element_references'
 import parseReportTypes from './filters/parse_report_types'
@@ -186,12 +186,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
     client,
     elementsSource,
     filtersCreators = defaultFilters,
-    typesToSkip = [
-      INTEGRATION, // The imported xml has no values, especially no SCRIPT_ID, for standard
-      // integrations and contains only SCRIPT_ID attribute for custom ones.
-      // There is no value in fetching them as they contain no data and are not deployable.
-      // If we decide to fetch them we should set the SCRIPT_ID by the xml's filename upon fetch.
-    ],
+    typesToSkip = TYPES_TO_SKIP,
     filePathRegexSkipList = [],
     getElemIdFunc,
     config,

--- a/packages/netsuite-adapter/src/sdf_folder_loader.ts
+++ b/packages/netsuite-adapter/src/sdf_folder_loader.ts
@@ -20,10 +20,7 @@ import { createElementsSourceIndex } from './elements_source_index/elements_sour
 import { parseSdfProjectDir } from './client/sdf_parser'
 import { createElements } from './transformer'
 import { netsuiteConfigFromConfig } from './config'
-import { INTEGRATION } from './constants'
-
-// see comment on typesToSkip in adapter.ts
-const typesToSkip = new Set([INTEGRATION])
+import { TYPES_TO_SKIP } from './types'
 
 const localFilters = allFilters
   .filter(filter.isLocalFilterCreator)
@@ -45,7 +42,7 @@ const loadElementsFromFolder = async (
   )
   const customizationInfos = await parseSdfProjectDir(baseDir)
   const elements = await createElements(
-    customizationInfos.filter(custInfo => !typesToSkip.has(custInfo.typeName)),
+    customizationInfos.filter(custInfo => !TYPES_TO_SKIP.includes(custInfo.typeName)),
     elementsSource,
     getElemIdFunc,
   )

--- a/packages/netsuite-adapter/src/sdf_folder_loader.ts
+++ b/packages/netsuite-adapter/src/sdf_folder_loader.ts
@@ -20,6 +20,10 @@ import { createElementsSourceIndex } from './elements_source_index/elements_sour
 import { parseSdfProjectDir } from './client/sdf_parser'
 import { createElements } from './transformer'
 import { netsuiteConfigFromConfig } from './config'
+import { INTEGRATION } from './constants'
+
+// see comment on typesToSkip in adapter.ts
+const typesToSkip = new Set([INTEGRATION])
 
 const localFilters = allFilters
   .filter(filter.isLocalFilterCreator)
@@ -40,7 +44,11 @@ const loadElementsFromFolder = async (
     filters,
   )
   const customizationInfos = await parseSdfProjectDir(baseDir)
-  const elements = await createElements(customizationInfos, elementsSource, getElemIdFunc)
+  const elements = await createElements(
+    customizationInfos.filter(custInfo => !typesToSkip.has(custInfo.typeName)),
+    elementsSource,
+    getElemIdFunc,
+  )
   await filtersRunner.onFetch(elements)
 
   return { elements }

--- a/packages/netsuite-adapter/src/types.ts
+++ b/packages/netsuite-adapter/src/types.ts
@@ -21,7 +21,7 @@ import { StandardType, getStandardTypes, isStandardTypeName, getStandardTypesNam
 import { TypesMap } from './types/object_types'
 import { fileCabinetTypesNames, getFileCabinetTypes } from './types/file_cabinet_types'
 import { getConfigurationTypes } from './types/configuration_types'
-import { CONFIG_FEATURES, CUSTOM_FIELD_PREFIX, CUSTOM_RECORD_TYPE, CUSTOM_RECORD_TYPE_PREFIX, METADATA_TYPE, SOAP, INTERNAL_ID, SCRIPT_ID, PATH, CUSTOM_RECORD_TYPE_NAME_PREFIX, BUNDLE } from './constants'
+import { CONFIG_FEATURES, CUSTOM_FIELD_PREFIX, CUSTOM_RECORD_TYPE, CUSTOM_RECORD_TYPE_PREFIX, METADATA_TYPE, SOAP, INTERNAL_ID, SCRIPT_ID, PATH, CUSTOM_RECORD_TYPE_NAME_PREFIX, BUNDLE, INTEGRATION } from './constants'
 import { SUPPORTED_TYPES } from './data_elements/types'
 import { bundleType } from './types/bundle_type'
 
@@ -112,6 +112,13 @@ export const metadataTypesToList = (metadataTypes: MetadataTypes): TypeElement[]
     ...Object.values(innerAdditionalTypes),
   ]
 }
+
+export const TYPES_TO_SKIP = [
+  INTEGRATION, // The imported xml has no values, especially no SCRIPT_ID, for standard
+  // integrations and contains only SCRIPT_ID attribute for custom ones.
+  // There is no value in fetching them as they contain no data and are not deployable.
+  // If we decide to fetch them we should set the SCRIPT_ID by the xml's filename upon fetch.
+]
 
 export const SCRIPT_TYPES = [
   'bundleinstallationscript',

--- a/packages/netsuite-adapter/test/sdf_folder_loader.test.ts
+++ b/packages/netsuite-adapter/test/sdf_folder_loader.test.ts
@@ -17,7 +17,7 @@ import { ElemID, InstanceElement, StaticFile, isInstanceElement, isObjectType } 
 import { buildElementsSourceFromElements, naclCase } from '@salto-io/adapter-utils'
 import { mockFunction } from '@salto-io/test-utils'
 import { CustomTypeInfo, FileCustomizationInfo, FolderCustomizationInfo } from '../src/client/types'
-import { CONFIG_FEATURES, CUSTOM_RECORD_TYPE, ENTITY_CUSTOM_FIELD, FILE, FILE_CABINET_PATH, FOLDER, NETSUITE, PATH, RECORDS_PATH, SCRIPT_ID, SETTINGS_PATH } from '../src/constants'
+import { CONFIG_FEATURES, CUSTOM_RECORD_TYPE, ENTITY_CUSTOM_FIELD, FILE, FILE_CABINET_PATH, FOLDER, INTEGRATION, NETSUITE, PATH, RECORDS_PATH, SCRIPT_ID, SETTINGS_PATH } from '../src/constants'
 import loadElementsFromFolder from '../src/sdf_folder_loader'
 import { getMetadataTypes, isCustomRecordType, metadataTypesToList } from '../src/types'
 import { createCustomRecordTypes } from '../src/custom_records/custom_record_type'
@@ -83,12 +83,18 @@ describe('sdf folder loader', () => {
       scriptId: 'customrecord1',
     }
 
+    const integrationCustInfo = {
+      typeName: INTEGRATION,
+      values: '',
+    }
+
     parseSdfProjectDirMock.mockResolvedValue([
       folderCustomizationInfo,
       fileCustomizationInfo,
       featuresCustomTypeInfo,
       customTypeInfo,
       customRecordTypeCustInfo,
+      integrationCustInfo,
     ])
 
     const elementsSourceIndex = createEmptyElementsSourceIndexes()


### PR DESCRIPTION
Trying to parse integration objects causes an error to be thrown because integration object xmls has no values in them. We should skip them.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Skip integration objects on SDF folder parsing

---
_User Notifications_: 
None
