### PR TITLE
SALTO-4138: enforce uniqueness of workflow and scripts custom fields

### DIFF
--- a/packages/netsuite-adapter/src/change_validators/unique_fields.ts
+++ b/packages/netsuite-adapter/src/change_validators/unique_fields.ts
@@ -206,11 +206,7 @@ const validateDuplication = (
   return awu(changesData)
     .map(change => ({
       elemID: change.elemID,
-      fields: Array.from(
-        new Set(
-          getters.getChangeRestrictedFields(change).filter(field => uniqueFieldToID[field] > 1)
-        )
-      ),
+      fields: _.uniq(getters.getChangeRestrictedFields(change).filter(field => uniqueFieldToID[field] > 1)),
     }))
     .filter(({ fields }) => fields.length > 0)
     .map(({ elemID, fields }): ChangeError => ({

--- a/packages/netsuite-adapter/src/change_validators/unique_fields.ts
+++ b/packages/netsuite-adapter/src/change_validators/unique_fields.ts
@@ -109,17 +109,17 @@ const customRecordGetters: RestrictedTypeGetters = {
 const workflowGetters: RestrictedTypeGetters = {
   getChangeRestrictedField: getWorkflowChangeRestrictedData,
   getSourceRestrictedFields: workflowSourceGetter,
-  getMessage: () => 'This Workflow contains a custom field with an existing ID',
-  getDetailedMessage: scriptids => `Can't deploy this Workflow as it contains custom fields with IDs that already exist in the target environment: "${scriptids.toString()}".`
-  + ' To deploy it, change their IDs to a unique one.', // need to change the message
+  getMessage: () => 'Workflow contains custom fields with non-unique IDs',
+  getDetailedMessage: scriptids => `Can't deploy this workflow as it contains custom fields with IDs that are not unique within this environment: "${scriptids.join(', ')}".`
+  + ' To deploy it, change their IDs to unique ones.',
 }
 
 const scriptGetters: RestrictedTypeGetters = {
   getChangeRestrictedField: getscriptChangeRestrictedData,
   getSourceRestrictedFields: scriptSourceGetter,
-  getMessage: () => 'This script contains a parameter with an existing ID',
-  getDetailedMessage: scriptids => `Can't deploy this script as it contains parameters ("scriptcustomfields") with IDs that already exist in the target environment: "${scriptids.toString()}".`
-  + ' To deploy it, change their IDs to a unique one.', // need to change the message
+  getMessage: () => 'Script contains parameters with non-unique IDs',
+  getDetailedMessage: scriptids => `Can't deploy this script as it contains parameters ("scriptcustomfields") with IDs that are not unique within this environment: "${scriptids.join(', ')}"`
+  + ' To deploy it, change their IDs to unique ones.',
 }
 
 const restrictedTypeGettersMap: Record<RestrictedType, RestrictedTypeGetters> = {

--- a/packages/netsuite-adapter/src/change_validators/unique_fields.ts
+++ b/packages/netsuite-adapter/src/change_validators/unique_fields.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { ElemID, getChangeData, isAdditionOrModificationChange, ChangeError,
-  ReadOnlyElementsSource, ChangeDataType, isObjectType, isInstanceElement } from '@salto-io/adapter-api'
+  ReadOnlyElementsSource, ChangeDataType, isObjectType, InstanceElement } from '@salto-io/adapter-api'
 import { values, collections, promises } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { resolvePath } from '@salto-io/adapter-utils'
@@ -67,16 +67,16 @@ const getCustomRecordRestrictedData = async ({ elemID, elementsSource }: GetterP
 }
 
 const getWorkflowChangeRestrictedData = (change: ChangeDataType): string[] =>
-  (isInstanceElement(change)
-    ? _.values(change.value.workflowcustomfields?.workflowcustomfield ?? {}).map(val => val.scriptid) : [])
+  // The change nust be an instance, we call this function only on instances of workflows we filtered from the changes
+  _.values((change as InstanceElement).value.workflowcustomfields?.workflowcustomfield ?? {}).map(val => val.scriptid)
 
 const workflowSourceGetter = async ({ elemID, elementsSource }: GetterParams): Promise<string[]> =>
   _.values((await elementsSource.get(elemID)).value.workflowcustomfields?.workflowcustomfield ?? {})
     .map(val => val.scriptid)
 
 const getscriptChangeRestrictedData = (change: ChangeDataType): string[] =>
-  (isInstanceElement(change)
-    ? _.values(change.value.scriptcustomfields?.scriptcustomfield ?? {}).map(val => val.scriptid) : [])
+  // The change nust be an instance, we call this function only on instances of scripts we filtered from the changes
+  _.values((change as InstanceElement).value.scriptcustomfields?.scriptcustomfield ?? {}).map(val => val.scriptid)
 
 const scriptSourceGetter = async ({ elemID, elementsSource }: GetterParams): Promise<string[]> =>
   _.values((await elementsSource.get(elemID)).value.scriptcustomfields?.scriptcustomfield ?? {})
@@ -209,7 +209,7 @@ const validateDuplication = (
       elemID: change.elemID,
       fields: Array.from(
         new Set(
-          getters.getChangeRestrictedField(change).filter(field => (uniqueFieldToID[field] ?? 0) > 1)
+          getters.getChangeRestrictedField(change).filter(field => (uniqueFieldToID[field]) > 1)
         )
       ),
     }))

--- a/packages/netsuite-adapter/src/change_validators/unique_fields.ts
+++ b/packages/netsuite-adapter/src/change_validators/unique_fields.ts
@@ -204,36 +204,21 @@ const validateDuplication = (
 ): Promise<Array<ChangeError>> => {
   const getters = restrictedTypeGettersMap[type]
 
-  if (type === 'workflow' || type === 'script') {
-    return awu(changesData)
-      .map(change => ({
-        elemID: change.elemID,
-        fields: Array.from(
-          new Set(
-            getters.getChangeRestrictedField(change).filter(field => (uniqueFieldToID[field] ?? 0) > 1)
-          )
-        ),
-      }))
-      .filter(({ fields }) => fields.length > 0)
-      .map(({ elemID, fields }): ChangeError => ({
-        elemID,
-        severity: 'Error',
-        message: getters.getMessage(),
-        detailedMessage: getters.getDetailedMessage(fields),
-      }))
-      .toArray()
-  }
   return awu(changesData)
     .map(change => ({
       elemID: change.elemID,
-      field: getters.getChangeRestrictedField(change),
+      fields: Array.from(
+        new Set(
+          getters.getChangeRestrictedField(change).filter(field => (uniqueFieldToID[field] ?? 0) > 1)
+        )
+      ),
     }))
-    .filter(({ field }) => (uniqueFieldToID[field[0]] ?? 0) > 1)
-    .map(({ elemID, field }): ChangeError => ({
+    .filter(({ fields }) => fields.length > 0)
+    .map(({ elemID, fields }): ChangeError => ({
       elemID,
       severity: 'Error',
       message: getters.getMessage(),
-      detailedMessage: getters.getDetailedMessage(field),
+      detailedMessage: getters.getDetailedMessage(fields),
     }))
     .toArray()
 }

--- a/packages/netsuite-adapter/test/change_validators/unique_fields.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/unique_fields.test.ts
@@ -16,7 +16,7 @@
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { ElemID, InstanceElement, ObjectType, toChange, ReadOnlyElementsSource, Field, Element, ChangeDataType } from '@salto-io/adapter-api'
 import uniqueFields from '../../src/change_validators/unique_fields'
-import { CUSTOM_RECORD_TYPE, CUSTOM_RECORD_TYPE_PREFIX, FINANCIAL_LAYOUT, METADATA_TYPE, NAME_FIELD, NETSUITE, SAVED_SEARCH } from '../../src/constants'
+import { CUSTOM_RECORD_TYPE, CUSTOM_RECORD_TYPE_PREFIX, FINANCIAL_LAYOUT, METADATA_TYPE, NAME_FIELD, NETSUITE, SAVED_SEARCH, WORKFLOW } from '../../src/constants'
 
 const DUPLICATED_FIELD = 'test uniqueness'
 const UNIQUE_FIELD = 'test uniqueness 2'
@@ -59,6 +59,24 @@ describe('unique fields validator', () => {
       [elem.elemID.createNestedID(nestedField).getFullName(),
         (elem as InstanceElement).value[nestedField]]))
 
+  const getIDToValWorkflow = (
+    testInstances: TestElements,
+    nestedField: string
+  ): Map<string, string> => new Map(Object.values(testInstances)
+    .map(elem =>
+      [elem.elemID.createNestedID(nestedField).getFullName(),
+        (elem as InstanceElement).value
+          .workflowcustomfields.workflowcustomfield.custworkflow1.scriptid]))
+
+  const getIDToValScript = (
+    testInstances: TestElements,
+    nestedField: string
+  ): Map<string, string> => new Map(Object.values(testInstances)
+    .map(elem =>
+      [elem.elemID.createNestedID(nestedField).getFullName(),
+        (elem as InstanceElement).value
+          .scriptcustomfields.scriptcustomfield.custscript1.scriptid]))
+
   const buildMockElementsSource = (
     elementSource: ReadOnlyElementsSource,
     idToVal: Map<string, string>
@@ -81,6 +99,36 @@ describe('unique fields validator', () => {
   const getFinancialLayoutElements = (): TestElements => getTestElements(FINANCIAL_LAYOUT,
     (name: string, elemID: ObjectType, uniqueField: string) =>
       new InstanceElement(name, elemID, { name: uniqueField }))
+
+  const getWorkflowElements = (): TestElements => getTestElements(WORKFLOW,
+    (name: string, elemID: ObjectType, uniqueField: string) => {
+      const custworkflow1 = {
+        scriptid: uniqueField,
+      }
+      const workflowcustomfield = { custworkflow1 }
+      const workflowCustomFields = { workflowcustomfield }
+      return new InstanceElement(name, elemID, { workflowcustomfields: workflowCustomFields })
+    })
+
+  const getScriptSuiteletElements = (): TestElements => getTestElements('suitelet',
+    (name: string, elemID: ObjectType, uniqueField: string) => {
+      const custscript1 = {
+        scriptid: uniqueField,
+      }
+      const scriptcustomfield = { custscript1 }
+      const scriptCustomFields = { scriptcustomfield }
+      return new InstanceElement(name, elemID, { scriptcustomfields: scriptCustomFields })
+    })
+
+  const getScriptRestletElements = (): TestElements => getTestElements('restlet',
+    (name: string, elemID: ObjectType, uniqueField: string) => {
+      const custscript1 = {
+        scriptid: uniqueField,
+      }
+      const scriptcustomfield = { custscript1 }
+      const scriptCustomFields = { scriptcustomfield }
+      return new InstanceElement(name, elemID, { scriptcustomfields: scriptCustomFields })
+    })
 
   const getCustomRecordElements = (): TestElements => getTestElements(CUSTOM_RECORD_TYPE_PREFIX,
     (name: string, elemID: ObjectType, uniqueField: string) =>
@@ -306,15 +354,177 @@ describe('unique fields validator', () => {
     })
   })
 
+  describe('Workflow custom field unique `scriptid` field validator', () => {
+    const testElements = getWorkflowElements()
+    const idToVal = getIDToValWorkflow(testElements, 'workflowcustomfields.workflowcustomfield.custworkflow1.scriptid')
+    const buildElementsSource = (elements: readonly Element[]): ReadOnlyElementsSource =>
+      buildMockElementsSource(buildElementsSourceFromElements(elements), idToVal)
+
+    describe('Workflow custom field with a unique scriptid', () => {
+      it('Should not have a change error when adding a new Workflow with a custom field that has unique scriptid', async () => {
+        const changeErrors = await uniqueFields(
+          [toChange({ after: testElements.basic })],
+          undefined,
+          buildElementsSource([
+            testElements.diffField,
+            testElements.basic])
+        )
+        expect(changeErrors).toHaveLength(0)
+      })
+
+      it('Should not have a change error when modifying a Workflow with uniwue custom fields', async () => {
+        const changeErrors = await uniqueFields(
+          [toChange(
+            { before: testElements.basic,
+              after: testElements.sameField }
+          )],
+          undefined,
+          buildElementsSource([
+            testElements.diffField,
+            testElements.sameField])
+        )
+        expect(changeErrors).toHaveLength(0)
+      })
+    })
+
+    describe('Workflow with a custom field that has a not-unique scriptid', () => {
+      it('Should have a change error when adding a new Workflow with a custom field that has a not-unique scriptid', async () => {
+        const changeErrors = await uniqueFields(
+          [toChange({ after: testElements.sameField })],
+          undefined,
+          buildElementsSource([
+            testElements.basic,
+            testElements.sameField])
+        )
+        expect(changeErrors).toHaveLength(1)
+        expect(changeErrors[0].severity).toEqual('Error')
+        expect(changeErrors[0].elemID).toBe(testElements.sameField.elemID)
+        expect(changeErrors[0].detailedMessage).toContain(DUPLICATED_FIELD)
+      })
+
+      it('Should have a change error when modifying a custom field scriptid to an existing one', async () => {
+        const changeErrors = await uniqueFields([
+          toChange(
+            { before: testElements.diffField,
+              after: testElements.sameField }
+          ),
+        ], undefined,
+        buildElementsSource([
+          testElements.basic,
+          testElements.sameField]))
+        expect(changeErrors).toHaveLength(1)
+        expect(changeErrors[0].severity).toEqual('Error')
+        expect(changeErrors[0].elemID).toBe(testElements.sameField.elemID)
+        expect(changeErrors[0].detailedMessage).toContain(DUPLICATED_FIELD)
+      })
+    })
+  })
+
+  describe('Script custom field unique `scriptid` field validator', () => {
+    const testElementsRestlet = getScriptRestletElements()
+    const testElementsSuitelet = getScriptSuiteletElements()
+    const idToValRestlet = getIDToValScript(testElementsRestlet, 'scriptcustomfields.scriptcustomfield.custscript1.scriptid')
+    const idToValSuitelet = getIDToValScript(testElementsSuitelet, 'scriptcustomfields.scriptcustomfield.custscript1.scriptid')
+    const idToEval = new Map([...idToValRestlet.entries(), ...idToValSuitelet.entries()])
+
+    const buildElementsSource = (elements: readonly Element[]): ReadOnlyElementsSource =>
+      buildMockElementsSource(buildElementsSourceFromElements(elements), idToEval)
+
+    describe('Script custom field with a unique scriptid', () => {
+      it('Should not have a change error when adding a new Script with a custom field that has unique scriptid', async () => {
+        const changeErrors = await uniqueFields(
+          [toChange({ after: testElementsRestlet.basic })],
+          undefined,
+          buildElementsSource([
+            testElementsRestlet.diffField,
+            testElementsRestlet.basic])
+        )
+        expect(changeErrors).toHaveLength(0)
+      })
+
+      it('Should not have a change error when modifying a Script with unique custom fields', async () => {
+        const changeErrors = await uniqueFields(
+          [toChange(
+            { before: testElementsRestlet.basic,
+              after: testElementsRestlet.sameField }
+          )],
+          undefined,
+          buildElementsSource([
+            testElementsRestlet.diffField,
+            testElementsRestlet.sameField])
+        )
+        expect(changeErrors).toHaveLength(0)
+      })
+      it('Should not have a change error when adding a new Script with a custom field that has unique scriptid with 2 different script types', async () => {
+        const changeErrors = await uniqueFields(
+          [toChange({ after: testElementsRestlet.basic })],
+          undefined,
+          buildElementsSource([
+            testElementsRestlet.diffField,
+            testElementsSuitelet.basic])
+        )
+        expect(changeErrors).toHaveLength(0)
+      })
+    })
+
+    describe('Script with a custom field that has a not-unique scriptid', () => {
+      it('Should have a change error when adding a new Script with a custom field that has a not-unique scriptid', async () => {
+        const changeErrors = await uniqueFields(
+          [toChange({ after: testElementsRestlet.sameField })],
+          undefined,
+          buildElementsSource([
+            testElementsRestlet.basic,
+            testElementsRestlet.sameField])
+        )
+        expect(changeErrors).toHaveLength(1)
+        expect(changeErrors[0].severity).toEqual('Error')
+        expect(changeErrors[0].elemID).toBe(testElementsRestlet.sameField.elemID)
+        expect(changeErrors[0].detailedMessage).toContain(DUPLICATED_FIELD)
+      })
+      it('Should have a change error when adding a new Script with a custom field that has the same scriptid as another custom field in different script type', async () => {
+        const changeErrors = await uniqueFields(
+          [toChange({ after: testElementsRestlet.sameField })],
+          undefined,
+          buildElementsSource([
+            testElementsRestlet.basic,
+            testElementsSuitelet.sameField])
+        )
+        expect(changeErrors).toHaveLength(1)
+        expect(changeErrors[0].severity).toEqual('Error')
+        expect(changeErrors[0].elemID).toBe(testElementsRestlet.sameField.elemID)
+        expect(changeErrors[0].detailedMessage).toContain(DUPLICATED_FIELD)
+      })
+      it('Should have a change error when modifying a custom field scriptid to an existing one', async () => {
+        const changeErrors = await uniqueFields([
+          toChange(
+            { before: testElementsRestlet.diffField,
+              after: testElementsRestlet.sameField }
+          ),
+        ], undefined,
+        buildElementsSource([
+          testElementsRestlet.basic,
+          testElementsRestlet.sameField]))
+        expect(changeErrors).toHaveLength(1)
+        expect(changeErrors[0].severity).toEqual('Error')
+        expect(changeErrors[0].elemID).toBe(testElementsRestlet.sameField.elemID)
+        expect(changeErrors[0].detailedMessage).toContain(DUPLICATED_FIELD)
+      })
+    })
+  })
+
   describe('Multiple types', () => {
     const savedSearchTestInstances = getSavedSearchElements()
     const financialLayoutTestInstances = getFinancialLayoutElements()
+    const workflowTestInstances = getWorkflowElements()
+    const scriptTestInstances = getScriptRestletElements()
     const customRecordTestObjects = getCustomRecordElements()
     const customRecordTestChanges = getCustomRecordChanges(customRecordTestObjects)
 
     const idToValSavedSearch = getIDToVal(savedSearchTestInstances, FIELD_DEFAULT_NAME)
     const idToValFinancialLayout = getIDToVal(financialLayoutTestInstances, NAME_FIELD)
-    const idToVal = new Map([...idToValSavedSearch, ...idToValFinancialLayout])
+    const idToValWorkflow = getIDToValWorkflow(workflowTestInstances, 'workflowcustomfields.workflowcustomfield.custworkflow1.scriptid')
+    const idToValScript = getIDToValScript(scriptTestInstances, 'scriptcustomfields.scriptcustomfield.custscript1.scriptid')
+    const idToVal = new Map([...idToValSavedSearch, ...idToValFinancialLayout, ...idToValWorkflow, ...idToValScript])
 
     const buildElementsSource = (elements: readonly Element[]): ReadOnlyElementsSource =>
       buildMockElementsSource(buildElementsSourceFromElements(elements), idToVal)
@@ -325,10 +535,16 @@ describe('unique fields validator', () => {
           toChange({ after: savedSearchTestInstances.basic }),
           toChange({ after: financialLayoutTestInstances.basic }),
           toChange({ after: customRecordTestChanges.basic }),
+          toChange({ after: workflowTestInstances.basic }),
+          toChange({ after: scriptTestInstances.basic }),
         ], undefined, buildElementsSource(
-          [savedSearchTestInstances.diffField, savedSearchTestInstances.basic,
+          [
+            savedSearchTestInstances.diffField, savedSearchTestInstances.basic,
             financialLayoutTestInstances.diffField, financialLayoutTestInstances.basic,
-            customRecordTestObjects.diffField, customRecordTestObjects.basic]
+            customRecordTestObjects.diffField, customRecordTestObjects.basic,
+            workflowTestInstances.diffField, workflowTestInstances.basic,
+            scriptTestInstances.diffField, scriptTestInstances.basic,
+          ]
         ))
         expect(changeErrors).toHaveLength(0)
       })
@@ -338,10 +554,16 @@ describe('unique fields validator', () => {
           toChange({ before: savedSearchTestInstances.basic, after: savedSearchTestInstances.sameField }),
           toChange({ before: financialLayoutTestInstances.basic, after: financialLayoutTestInstances.sameField }),
           toChange({ before: customRecordTestChanges.basic, after: customRecordTestChanges.sameField }),
+          toChange({ before: workflowTestInstances.basic, after: workflowTestInstances.sameField }),
+          toChange({ before: scriptTestInstances.basic, after: scriptTestInstances.sameField }),
         ], undefined, buildElementsSource(
-          [savedSearchTestInstances.diffField, savedSearchTestInstances.sameField,
+          [
+            savedSearchTestInstances.diffField, savedSearchTestInstances.sameField,
             financialLayoutTestInstances.diffField, financialLayoutTestInstances.sameField,
-            customRecordTestObjects.diffField, customRecordTestObjects.sameField]
+            customRecordTestObjects.diffField, customRecordTestObjects.sameField,
+            workflowTestInstances.diffField, workflowTestInstances.sameField,
+            scriptTestInstances.diffField, scriptTestInstances.sameField,
+          ]
         ))
         expect(changeErrors).toHaveLength(0)
       })
@@ -353,17 +575,25 @@ describe('unique fields validator', () => {
           toChange({ after: savedSearchTestInstances.sameField }),
           toChange({ after: financialLayoutTestInstances.sameField }),
           toChange({ after: customRecordTestChanges.sameField }),
+          toChange({ after: workflowTestInstances.sameField }),
+          toChange({ after: scriptTestInstances.sameField }),
         ], undefined, buildElementsSource(
-          [savedSearchTestInstances.basic, savedSearchTestInstances.sameField,
+          [
+            savedSearchTestInstances.basic, savedSearchTestInstances.sameField,
             financialLayoutTestInstances.basic, financialLayoutTestInstances.sameField,
-            customRecordTestObjects.basic, customRecordTestObjects.sameField]
+            customRecordTestObjects.basic, customRecordTestObjects.sameField,
+            workflowTestInstances.basic, workflowTestInstances.sameField,
+            scriptTestInstances.basic, scriptTestInstances.sameField,
+          ]
         ))
-        expect(changeErrors).toHaveLength(3)
-        expect(changeErrors.map(changeError => changeError.severity)).toEqual(['Error', 'Error', 'Error'])
+        expect(changeErrors).toHaveLength(5)
+        expect(changeErrors.map(changeError => changeError.severity)).toEqual(['Error', 'Error', 'Error', 'Error', 'Error'])
         expect(changeErrors.map(changeError => changeError.elemID)).toEqual(expect.arrayContaining([
           savedSearchTestInstances.sameField.elemID,
           financialLayoutTestInstances.sameField.elemID,
           customRecordTestChanges.sameField.elemID,
+          workflowTestInstances.sameField.elemID,
+          scriptTestInstances.sameField.elemID,
         ]))
       })
 
@@ -372,17 +602,25 @@ describe('unique fields validator', () => {
           toChange({ before: savedSearchTestInstances.diffField, after: savedSearchTestInstances.sameField }),
           toChange({ before: financialLayoutTestInstances.diffField, after: financialLayoutTestInstances.sameField }),
           toChange({ before: customRecordTestChanges.diffField, after: customRecordTestChanges.sameField }),
+          toChange({ before: workflowTestInstances.diffField, after: workflowTestInstances.sameField }),
+          toChange({ before: scriptTestInstances.diffField, after: scriptTestInstances.sameField }),
         ], undefined, buildElementsSource(
-          [savedSearchTestInstances.basic, savedSearchTestInstances.sameField,
+          [
+            savedSearchTestInstances.basic, savedSearchTestInstances.sameField,
             financialLayoutTestInstances.basic, financialLayoutTestInstances.sameField,
-            customRecordTestObjects.basic, customRecordTestObjects.sameField]
+            customRecordTestObjects.basic, customRecordTestObjects.sameField,
+            workflowTestInstances.basic, workflowTestInstances.sameField,
+            scriptTestInstances.basic, scriptTestInstances.sameField,
+          ]
         ))
-        expect(changeErrors).toHaveLength(3)
-        expect(changeErrors.map(changeError => changeError.severity)).toEqual(['Error', 'Error', 'Error'])
+        expect(changeErrors).toHaveLength(5)
+        expect(changeErrors.map(changeError => changeError.severity)).toEqual(['Error', 'Error', 'Error', 'Error', 'Error'])
         expect(changeErrors.map(changeError => changeError.elemID)).toEqual(expect.arrayContaining([
           savedSearchTestInstances.sameField.elemID,
           financialLayoutTestInstances.sameField.elemID,
           customRecordTestChanges.sameField.elemID,
+          workflowTestInstances.sameField.elemID,
+          scriptTestInstances.sameField.elemID,
         ]))
       })
     })


### PR DESCRIPTION
_Added workflows and scripts to the unique fields change validator_

---

_Additional context for reviewer_
_ticket: https://salto-io.atlassian.net/browse/SALTO-4138 first ticket about this change validator https://salto-io.atlassian.net/browse/SALTO-2915
Changed some logics in the existing code for it to match the new type of fields (inner fields)_

---
_Release Notes_: 
_In case users give the same scriptid for the custom fields, the change validator will cache this and cancel the deployment instead of getting exception_

---
_User Notifications_: 
_None_
