### PR TITLE
SALTO-4526: fix defaultFieldConfiguration validator to not fail items changes

### DIFF
--- a/packages/jira-adapter/src/change_validators/default_field_configuration.ts
+++ b/packages/jira-adapter/src/change_validators/default_field_configuration.ts
@@ -14,7 +14,6 @@
 * limitations under the License.
 */
 import { ChangeValidator, getChangeData, isInstanceChange, isModificationChange, SeverityLevel } from '@salto-io/adapter-api'
-// import { getDetailedChanges } from '@salto-io/adapter-utils'
 
 export const defaultFieldConfigurationValidator: ChangeValidator = async changes => (
   changes

--- a/packages/jira-adapter/src/change_validators/default_field_configuration.ts
+++ b/packages/jira-adapter/src/change_validators/default_field_configuration.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import { ChangeValidator, getChangeData, isInstanceChange, isModificationChange, SeverityLevel } from '@salto-io/adapter-api'
+// import { getDetailedChanges } from '@salto-io/adapter-utils'
 
 export const defaultFieldConfigurationValidator: ChangeValidator = async changes => (
   changes
@@ -21,6 +22,8 @@ export const defaultFieldConfigurationValidator: ChangeValidator = async changes
     .filter(isModificationChange)
     .filter(change => getChangeData(change).elemID.typeName === 'FieldConfiguration')
     .filter(change => getChangeData(change).value.isDefault)
+    .filter(change => !(change.data.before.value.name === change.data.after.value.name
+      && change.data.before.value.description === change.data.after.value.description))
     .map(change => ({
       elemID: getChangeData(change).elemID,
       severity: 'Error' as SeverityLevel,

--- a/packages/jira-adapter/test/change_validators/default_field_configuration.test.ts
+++ b/packages/jira-adapter/test/change_validators/default_field_configuration.test.ts
@@ -28,6 +28,14 @@ describe('defaultFieldConfigurationValidator', () => {
       type,
       {
         isDefault: true,
+        fields:
+          {
+            item:
+            {
+              isHidden: true,
+              isRequired: false,
+            },
+          },
       }
     )
   })
@@ -48,6 +56,18 @@ describe('defaultFieldConfigurationValidator', () => {
         message: 'Modifying the default field configuration is not supported',
         detailedMessage: 'Modifying the default field configuration is not supported.',
       },
+    ])
+  })
+  it('should not return an error if the change is in the default field configuration item', async () => {
+    const afterInstance = instance.clone()
+    afterInstance.value.fields.item.isRequired = true
+
+    expect(await defaultFieldConfigurationValidator([
+      toChange({
+        before: instance,
+        after: afterInstance,
+      }),
+    ])).toEqual([
     ])
   })
 


### PR DESCRIPTION
_fix defaultFieldConfiguration validator to not fail items changes_

---

_Additional context for reviewer_
* lately we inserted the `fieldConfigurationItems` into `fieldConfiguration` and we did not change the validator accordingly.  

---
_Release Notes_: 
Jira Adapter:
* fix a bug with deploying changes on the default Field Configuration Items

---
_User Notifications_: 
None
