### PR TITLE
SALTO-4293 Update validateCredentials to identify whether the account is production or not

### DIFF
--- a/packages/jira-adapter/src/client/connection.ts
+++ b/packages/jira-adapter/src/client/connection.ts
@@ -13,10 +13,14 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import { logger } from '@salto-io/logging'
 import { AccountInfo, CredentialError } from '@salto-io/adapter-api'
 import { client as clientUtils } from '@salto-io/adapter-components'
+import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { Credentials } from '../auth'
 import { FORCE_ACCEPT_LANGUAGE_HEADERS } from './headers'
+
+const log = logger(module)
 
 type appInfo = {
   id: string
@@ -57,7 +61,8 @@ export const validateCredentials = async (
       return { accountId, isProduction: false, accountType: 'Sandbox' }
     }
     const response = await connection.get('/rest/api/3/instance/license')
-    const hasPaidApp = response.data.applications.some((app: appInfo) => app.plan === 'PAID') ?? false
+    log.info(`Jira application's info: ${safeJsonStringify(response.data.applications)}`)
+    const hasPaidApp = response.data.applications.some((app: appInfo) => app.plan === 'PAID')
     const isProduction = hasPaidApp ? undefined : false
     return { accountId, isProduction }
   }

--- a/packages/jira-adapter/src/client/connection.ts
+++ b/packages/jira-adapter/src/client/connection.ts
@@ -52,7 +52,7 @@ const isSandBox = async (connection: clientUtils.APIConnection): Promise<boolean
 const isProd = async (connection: clientUtils.APIConnection): Promise<boolean | undefined> => {
   const isSandBoxAccount = await isSandBox(connection)
   const response = await connection.get('/rest/api/3/instance/license')
-  const hasPaidApp = response.data?.applications.some((app: appInfo) => app.plan === 'PAID') ?? false
+  const hasPaidApp = response.data.applications.some((app: appInfo) => app.plan === 'PAID') ?? false
   return !isSandBoxAccount && hasPaidApp ? undefined : false
 }
 

--- a/packages/jira-adapter/src/client/connection.ts
+++ b/packages/jira-adapter/src/client/connection.ts
@@ -13,14 +13,11 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { logger } from '@salto-io/logging'
 import { AccountInfo, CredentialError } from '@salto-io/adapter-api'
 import { client as clientUtils } from '@salto-io/adapter-components'
-import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { Credentials } from '../auth'
 import { FORCE_ACCEPT_LANGUAGE_HEADERS } from './headers'
 
-const log = logger(module)
 
 type appInfo = {
   id: string
@@ -61,8 +58,8 @@ export const validateCredentials = async (
       return { accountId, isProduction: false, accountType: 'Sandbox' }
     }
     const response = await connection.get('/rest/api/3/instance/license')
-    log.info(`Jira application's info: ${safeJsonStringify(response.data.applications)}`)
-    const hasPaidApp = response.data.applications.some((app: appInfo) => app.plan === 'PAID')
+    // log.info(`Jira application's info: ${safeJsonStringify(response.data.applications)}`)
+    const hasPaidApp = response.data.applications.some((app: appInfo) => app.plan === 'PAID') ?? false
     const isProduction = hasPaidApp ? undefined : false
     return { accountId, isProduction }
   }

--- a/packages/jira-adapter/src/client/connection.ts
+++ b/packages/jira-adapter/src/client/connection.ts
@@ -13,11 +13,14 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import { logger } from '@salto-io/logging'
 import { AccountInfo, CredentialError } from '@salto-io/adapter-api'
 import { client as clientUtils } from '@salto-io/adapter-components'
+import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { Credentials } from '../auth'
 import { FORCE_ACCEPT_LANGUAGE_HEADERS } from './headers'
 
+const log = logger(module)
 
 type appInfo = {
   id: string
@@ -58,8 +61,8 @@ export const validateCredentials = async (
       return { accountId, isProduction: false, accountType: 'Sandbox' }
     }
     const response = await connection.get('/rest/api/3/instance/license')
-    // log.info(`Jira application's info: ${safeJsonStringify(response.data.applications)}`)
-    const hasPaidApp = response.data.applications.some((app: appInfo) => app.plan === 'PAID') ?? false
+    log.info(`Jira application's info: ${safeJsonStringify(response.data.applications)}`)
+    const hasPaidApp = response.data.applications.some((app: appInfo) => app.plan === 'PAID')
     const isProduction = hasPaidApp ? undefined : false
     return { accountId, isProduction }
   }

--- a/packages/jira-adapter/src/client/connection.ts
+++ b/packages/jira-adapter/src/client/connection.ts
@@ -39,12 +39,15 @@ const getBaseUrl = async (
   return response.data.baseUrl
 }
 
+const isProd = (accountId: string): boolean => !accountId.includes('-sandbox-')
+
 export const validateCredentials = async (
   { connection }: { connection: clientUtils.APIConnection },
 ): Promise<AccountInfo> => {
   if (await isAuthorized(connection)) {
     const accountId = await getBaseUrl(connection)
-    return { accountId }
+    const isProduction = isProd(accountId)
+    return { accountId, isProduction }
   }
   throw new CredentialError('Invalid Credentials')
 }

--- a/packages/jira-adapter/test/adapter_creator.test.ts
+++ b/packages/jira-adapter/test/adapter_creator.test.ts
@@ -43,6 +43,7 @@ describe('adapter creator', () => {
     describe('with valid credentials', () => {
       let accountId: string
       beforeEach(async () => {
+        mockAxiosAdapter.onGet('/rest/api/3/instance/license').reply(200, { applications: [{ plan: 'FREE' }] })
         mockAxiosAdapter.onGet().reply(200, { baseUrl: 'http://my_account.net' });
         ({ accountId } = await adapter.validateCredentials(
           createCredentialsInstance({ baseUrl: 'http://my.net', user: 'u', token: 't' })

--- a/packages/jira-adapter/test/client/connection.test.ts
+++ b/packages/jira-adapter/test/client/connection.test.ts
@@ -170,5 +170,17 @@ describe('connection', () => {
       expect(accountType).toEqual(undefined)
       expect(isProduction).toEqual(false)
     })
+    it('should return isProduction false and accountType = undefined when account id does not include -sandbox- but has no paid app and isDataCenter is false', async () => {
+      connection = await createConnection({ retries: 1 }).login(
+        { baseUrl: 'https://test-sandbox-999.atlassian.net', user: 'me', token: 'tok', isDataCenter: false }
+      )
+      mockAxios.onGet('/rest/api/3/serverInfo').reply(200, { baseUrl: 'https://test.atlassian.net' })
+      mockAxios.onGet('/rest/api/3/instance/license').reply(200, { applications: [{ plan: 'FREE' }] })
+      const { isProduction, accountType } = await validateCredentials({
+        connection,
+      })
+      expect(accountType).toEqual(undefined)
+      expect(isProduction).toEqual(false)
+    })
   })
 })

--- a/packages/jira-adapter/test/client/connection.test.ts
+++ b/packages/jira-adapter/test/client/connection.test.ts
@@ -134,7 +134,7 @@ describe('connection', () => {
     afterEach(() => {
       mockAxios.restore()
     })
-    it('should return isProduction true when account id does not include -sandbox- and has paid app', async () => {
+    it('should return isProduction undefined when account id does not include -sandbox- and has paid app', async () => {
       connection = await createConnection({ retries: 1 }).login(
         { baseUrl: 'http://myJira.net', user: 'me', token: 'tok', isDataCenter: true }
       )
@@ -143,28 +143,30 @@ describe('connection', () => {
       const { isProduction } = await validateCredentials({
         connection,
       })
-      expect(isProduction).toEqual(true)
+      expect(isProduction).toEqual(undefined)
     })
-    it('should return isProduction false when account id includes -sandbox-', async () => {
+    it('should return isProduction false and accountType = "Sandbox" when account id includes -sandbox-', async () => {
       connection = await createConnection({ retries: 1 }).login(
         { baseUrl: 'https://test-sandbox-999.atlassian.net', user: 'me', token: 'tok', isDataCenter: true }
       )
       mockAxios.onGet('/rest/api/3/serverInfo').reply(200, { baseUrl: 'https://test-sandbox-999.atlassian.net' })
       mockAxios.onGet('/rest/api/3/instance/license').reply(200, { applications: [{ plan: 'PAID' }] })
-      const { isProduction } = await validateCredentials({
+      const { isProduction, accountType } = await validateCredentials({
         connection,
       })
       expect(isProduction).toEqual(false)
+      expect(accountType).toEqual('Sandbox')
     })
-    it('should return isProduction false when account id does not include -sandbox- but has no paid app', async () => {
+    it('should return isProduction false and accountType = undefined when account id does not include -sandbox- but has no paid app', async () => {
       connection = await createConnection({ retries: 1 }).login(
         { baseUrl: 'https://test-sandbox-999.atlassian.net', user: 'me', token: 'tok', isDataCenter: true }
       )
       mockAxios.onGet('/rest/api/3/serverInfo').reply(200, { baseUrl: 'https://test.atlassian.net' })
       mockAxios.onGet('/rest/api/3/instance/license').reply(200, { applications: [{ plan: 'FREE' }] })
-      const { isProduction } = await validateCredentials({
+      const { isProduction, accountType } = await validateCredentials({
         connection,
       })
+      expect(accountType).toEqual(undefined)
       expect(isProduction).toEqual(false)
     })
   })

--- a/packages/jira-adapter/test/client/connection.test.ts
+++ b/packages/jira-adapter/test/client/connection.test.ts
@@ -134,16 +134,17 @@ describe('connection', () => {
     afterEach(() => {
       mockAxios.restore()
     })
-    it('should return isProduction undefined when account id does not include -sandbox- and has paid app', async () => {
+    it('should return isProduction undefined and accountType = undefined when account id does not include -sandbox- and has paid app', async () => {
       connection = await createConnection({ retries: 1 }).login(
         { baseUrl: 'http://myJira.net', user: 'me', token: 'tok', isDataCenter: true }
       )
       mockAxios.onGet('/rest/api/3/serverInfo').reply(200, { baseUrl: 'http://my.jira.net' })
       mockAxios.onGet('/rest/api/3/instance/license').reply(200, { applications: [{ id: 'software', plan: 'PAID' }, { id: 'serviceDesk', plan: 'FREE' }] })
-      const { isProduction } = await validateCredentials({
+      const { isProduction, accountType } = await validateCredentials({
         connection,
       })
       expect(isProduction).toEqual(undefined)
+      expect(accountType).toEqual(undefined)
     })
     it('should return isProduction false and accountType = "Sandbox" when account id includes -sandbox-', async () => {
       connection = await createConnection({ retries: 1 }).login(

--- a/packages/jira-adapter/test/client/connection.test.ts
+++ b/packages/jira-adapter/test/client/connection.test.ts
@@ -170,17 +170,5 @@ describe('connection', () => {
       expect(accountType).toEqual(undefined)
       expect(isProduction).toEqual(false)
     })
-    it('should return isProduction false and accountType = undefined when account id does not include -sandbox- but has no paid app and isDataCenter is false', async () => {
-      connection = await createConnection({ retries: 1 }).login(
-        { baseUrl: 'https://test-sandbox-999.atlassian.net', user: 'me', token: 'tok', isDataCenter: false }
-      )
-      mockAxios.onGet('/rest/api/3/serverInfo').reply(200, { baseUrl: 'https://test.atlassian.net' })
-      mockAxios.onGet('/rest/api/3/instance/license').reply(200, { applications: [{ plan: 'FREE' }] })
-      const { isProduction, accountType } = await validateCredentials({
-        connection,
-      })
-      expect(accountType).toEqual(undefined)
-      expect(isProduction).toEqual(false)
-    })
   })
 })

--- a/packages/jira-adapter/test/client/connection.test.ts
+++ b/packages/jira-adapter/test/client/connection.test.ts
@@ -27,6 +27,7 @@ describe('connection', () => {
       mockAxios = new MockAdapter(axios)
       mockAxios.onGet('/rest/api/3/configuration').reply(200)
       mockAxios.onGet('/rest/api/3/serverInfo').reply(200, { baseUrl: 'http://my.jira.net' })
+      mockAxios.onGet('/rest/api/3/instance/license').reply(200, { applications: [{ plan: 'FREE' }] })
       connection = await createConnection({ retries: 1 }).login(
         { baseUrl: 'http://myJira.net', user: 'me', token: 'tok', isDataCenter: false }
       )
@@ -78,6 +79,7 @@ describe('connection', () => {
       mockAxios = new MockAdapter(axios)
       mockAxios.onGet('/rest/api/3/configuration').reply(200)
       mockAxios.onGet('/rest/api/3/serverInfo').reply(200, { baseUrl: 'http://my.jira.net' })
+      mockAxios.onGet('/rest/api/3/instance/license').reply(200, { applications: [{ plan: 'FREE' }] })
       connection = await createConnection({ retries: 1 }).login(
         { baseUrl: 'http://myJira.net', user: 'me', token: 'tok', isDataCenter: false }
       )
@@ -102,6 +104,7 @@ describe('connection', () => {
       mockAxios = new MockAdapter(axios)
       mockAxios.onGet('/rest/api/3/configuration').reply(200)
       mockAxios.onGet('/rest/api/3/serverInfo').reply(200, { baseUrl: 'http://my.jira.net' })
+      mockAxios.onGet('/rest/api/3/instance/license').reply(200, { applications: [{ plan: 'FREE' }] })
       connection = await createConnection({ retries: 1 }).login(
         { baseUrl: 'http://myJira.net', user: 'me', token: 'tok', isDataCenter: true }
       )
@@ -115,6 +118,7 @@ describe('connection', () => {
 
     it('should not have force accept language headers when calling Jira DC', async () => {
       mockAxios.onGet('/rest/api/3/serverInfo').reply(200, { baseUrl: 'http://my.jira.net' })
+      mockAxios.onGet('/rest/api/3/instance/license').reply(200, { applications: [{ plan: 'FREE' }] })
       expect(mockAxios.history.get).toContainEqual(expect.objectContaining({
         headers: expect.not.objectContaining(FORCE_ACCEPT_LANGUAGE_HEADERS),
       }))
@@ -130,11 +134,12 @@ describe('connection', () => {
     afterEach(() => {
       mockAxios.restore()
     })
-    it('should return isProduction true when account id does not include -sandbox-', async () => {
+    it('should return isProduction true when account id does not include -sandbox- and has paid app', async () => {
       connection = await createConnection({ retries: 1 }).login(
         { baseUrl: 'http://myJira.net', user: 'me', token: 'tok', isDataCenter: true }
       )
       mockAxios.onGet('/rest/api/3/serverInfo').reply(200, { baseUrl: 'http://my.jira.net' })
+      mockAxios.onGet('/rest/api/3/instance/license').reply(200, { applications: [{ id: 'software', plan: 'PAID' }, { id: 'serviceDesk', plan: 'FREE' }] })
       const { isProduction } = await validateCredentials({
         connection,
       })
@@ -145,6 +150,18 @@ describe('connection', () => {
         { baseUrl: 'https://test-sandbox-999.atlassian.net', user: 'me', token: 'tok', isDataCenter: true }
       )
       mockAxios.onGet('/rest/api/3/serverInfo').reply(200, { baseUrl: 'https://test-sandbox-999.atlassian.net' })
+      mockAxios.onGet('/rest/api/3/instance/license').reply(200, { applications: [{ plan: 'PAID' }] })
+      const { isProduction } = await validateCredentials({
+        connection,
+      })
+      expect(isProduction).toEqual(false)
+    })
+    it('should return isProduction false when account id does not include -sandbox- but has no paid app', async () => {
+      connection = await createConnection({ retries: 1 }).login(
+        { baseUrl: 'https://test-sandbox-999.atlassian.net', user: 'me', token: 'tok', isDataCenter: true }
+      )
+      mockAxios.onGet('/rest/api/3/serverInfo').reply(200, { baseUrl: 'https://test.atlassian.net' })
+      mockAxios.onGet('/rest/api/3/instance/license').reply(200, { applications: [{ plan: 'FREE' }] })
       const { isProduction } = await validateCredentials({
         connection,
       })

--- a/packages/jira-adapter/test/client/connection.test.ts
+++ b/packages/jira-adapter/test/client/connection.test.ts
@@ -120,4 +120,35 @@ describe('connection', () => {
       }))
     })
   })
+  describe('validate isProduction', () => {
+    let mockAxios: MockAdapter
+    let connection: clientUtils.APIConnection
+    beforeEach(async () => {
+      mockAxios = new MockAdapter(axios)
+      mockAxios.onGet('/rest/api/3/configuration').reply(200)
+    })
+    afterEach(() => {
+      mockAxios.restore()
+    })
+    it('should return isProduction true when account id does not include -sandbox-', async () => {
+      connection = await createConnection({ retries: 1 }).login(
+        { baseUrl: 'http://myJira.net', user: 'me', token: 'tok', isDataCenter: true }
+      )
+      mockAxios.onGet('/rest/api/3/serverInfo').reply(200, { baseUrl: 'http://my.jira.net' })
+      const { isProduction } = await validateCredentials({
+        connection,
+      })
+      expect(isProduction).toEqual(true)
+    })
+    it('should return isProduction false when account id includes -sandbox-', async () => {
+      connection = await createConnection({ retries: 1 }).login(
+        { baseUrl: 'https://test-sandbox-999.atlassian.net', user: 'me', token: 'tok', isDataCenter: true }
+      )
+      mockAxios.onGet('/rest/api/3/serverInfo').reply(200, { baseUrl: 'https://test-sandbox-999.atlassian.net' })
+      const { isProduction } = await validateCredentials({
+        connection,
+      })
+      expect(isProduction).toEqual(false)
+    })
+  })
 })


### PR DESCRIPTION
As of today, Jira does not have an API that checks if an account is production or sandbox.
After consultations with @omrilit  and @liorn, the solution implemented is:
1. Check if the URL contains `-sandbox-`.
2. Check if the account has paid apps.
If the URL contains the word sandbox or all the apps in the account are in a free plan, then the account will not be defined as Production.
---
None

---
_Release Notes_: 
None

---
_User Notifications_: 
None
