### PR TITLE
SALTO-4377: Return account type for Okta

### DIFF
--- a/packages/okta-adapter/src/client/connection.ts
+++ b/packages/okta-adapter/src/client/connection.ts
@@ -20,13 +20,24 @@ import { Credentials, AccessTokenCredentials } from '../auth'
 
 const log = logger(module)
 
+// We can only detect if an account is a preview account, as production accounts don't have indicators in their base URL
+// For more info see: https://developer.okta.com/docs/concepts/okta-organizations/#preview-and-production
+const isOktaPreviewAccount = (baseUrl: string): boolean => /.*\.oktapreview\..*/.test(baseUrl)
+const PRODUCTION_ACCOUNT_TYPE = 'Production'
+const PREVIEW_ACCOUNT_TYPE = 'Preview'
+
 export const validateCredentials = async (_creds: {
   credentials: Credentials
   connection: clientUtils.APIConnection
 }): Promise<AccountInfo> => {
   try {
     const response = await _creds.connection.get('/api/v1/org')
-    return { accountId: response.data.id }
+    const isPreview = isOktaPreviewAccount(_creds.credentials.baseUrl)
+    return {
+      accountId: response.data.id,
+      accountType: isPreview ? PREVIEW_ACCOUNT_TYPE : PRODUCTION_ACCOUNT_TYPE,
+      isProduction: !isPreview,
+    }
   } catch (error) {
     if (error.response?.status === 401) {
       log.error('Failed to validate credentials: %s', error)

--- a/packages/okta-adapter/test/adapter_creator.test.ts
+++ b/packages/okta-adapter/test/adapter_creator.test.ts
@@ -73,6 +73,25 @@ describe('adapter creator', () => {
         await expect(result).rejects.toThrow()
       })
     })
+    describe('identify account type', () => {
+      beforeEach(async () => {
+        mockAxiosAdapter.onGet().reply(200, { id: 'orgId', subdomain: 'my' })
+      })
+      it('when using a preview account', async () => {
+        const { accountType, isProduction } = await adapter.validateCredentials(
+          createCredentialsInstance({ baseUrl: 'http://my-account.oktapreview.com', token: 't' })
+        )
+        expect(accountType).toEqual('Preview')
+        expect(isProduction).toEqual(false)
+      })
+      it('when using production account', async () => {
+        const { accountType, isProduction } = await adapter.validateCredentials(
+          createCredentialsInstance({ baseUrl: 'http://my-account.okta.net', token: 't' })
+        )
+        expect(accountType).toEqual('Production')
+        expect(isProduction).toEqual(true)
+      })
+    })
   })
 
   describe('create adapter', () => {

--- a/packages/okta-adapter/test/client/connection.test.ts
+++ b/packages/okta-adapter/test/client/connection.test.ts
@@ -55,7 +55,7 @@ describe('validateCredentials', () => {
     })
 
     it('should return the org id from the response as account id', () => {
-      expect(result).toEqual({ accountId: 'abc123' })
+      expect(result.accountId).toEqual('abc123')
     })
   })
 


### PR DESCRIPTION
Return account type for Okta

---

identify if the account is sandbox or production based on base url

---
_Release Notes_: 
None

---
_User Notifications_: 
None
