### PR TITLE
SALTO-4499 - Handle errors on article attachment content requests

### DIFF
--- a/packages/zendesk-adapter/src/change_validators/attachment_without_content.ts
+++ b/packages/zendesk-adapter/src/change_validators/attachment_without_content.ts
@@ -18,8 +18,9 @@ import {
   isInstanceElement,
 } from '@salto-io/adapter-api'
 import { MACRO_ATTACHMENT_TYPE_NAME } from '../filters/macro_attachments'
+import { ARTICLE_ATTACHMENT_TYPE_NAME } from '../constants'
 
-const attachmentTypes = [MACRO_ATTACHMENT_TYPE_NAME]
+const attachmentTypes = [MACRO_ATTACHMENT_TYPE_NAME, ARTICLE_ATTACHMENT_TYPE_NAME]
 
 /**
  * prevent deployment of attachment without content. The attachment can be without content if the get content api call

--- a/packages/zendesk-adapter/src/filters/article/article.ts
+++ b/packages/zendesk-adapter/src/filters/article/article.ts
@@ -348,7 +348,7 @@ const filterCreator: FilterCreator = ({ config, client, elementsSource, brandIdT
       const attachmentType = attachments.find(isObjectType)
       if (attachmentType === undefined) {
         log.error('could not find article_attachment object type')
-        return
+        return { errors: [] }
       }
       const articleById: Record<number, InstanceElement> = _.keyBy(articleInstances, getId)
       _.remove(attachments, isObjectType)
@@ -381,7 +381,7 @@ const filterCreator: FilterCreator = ({ config, client, elementsSource, brandIdT
           && isInstanceElement(element)
           && allRemovedAttachmentsIds.has(element.elemID.name))
       )
-      await getArticleAttachments({
+      const attachmentErrors = await getArticleAttachments({
         brandIdToClient,
         attachmentType,
         articleById,
@@ -397,6 +397,7 @@ const filterCreator: FilterCreator = ({ config, client, elementsSource, brandIdT
         ])
         article.value.attachments = sortedAttachments
       })
+      return { errors: attachmentErrors }
     },
     preDeploy: async (changes: Change<InstanceElement>[]): Promise<void> => {
       await handleArticleAttachmentsPreDeploy(


### PR DESCRIPTION
When failing to get content of attachment, don't fail the fetch, don't put any content and alert the user about the failure

---

None

---
_Release Notes_: 
Zendesk Adapter:
* Failure of requesting article attachment content will no longer fail the fetch

---
_User Notifications_: 
None