### PR TITLE
SALTO-3417 ignore scriptid permissions

### DIFF
--- a/packages/netsuite-adapter/src/change_validators/role_permission_ids.ts
+++ b/packages/netsuite-adapter/src/change_validators/role_permission_ids.ts
@@ -20,6 +20,7 @@ import { values } from '@salto-io/lowerdash'
 import { ROLE } from '../constants'
 import { NetsuiteChangeValidator } from './types'
 import { ID_TO_PERMISSION_INFO, PermissionLevel } from '../autogen/role_permissions/role_permissions'
+import { captureServiceIdInfo } from '../service_id_info'
 
 const { isDefined } = values
 const log = logger(module)
@@ -41,7 +42,7 @@ const isValidPermissions = ({ permkey, permlevel }: RolePermissionType): boolean
     ? permissionsToAdd[permkey] ?? ID_TO_PERMISSION_INFO[permkey] : undefined
   if (!isDefined(validPermissionLevels)) {
     // in case of undocumented premission we log the id and ignore
-    if (!isReferenceExpression(permkey)) {
+    if (!isReferenceExpression(permkey) && captureServiceIdInfo(permkey).length === 0) {
       log.debug(`The following permissions does not appear in the documentation: ${permkey}`)
     }
     return true


### PR DESCRIPTION
We should not log permissions that are in the pattern of `[scriptid=...]`.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
