### PR TITLE
SALTO-4045: Warning about adding a file without referencing it

### DIFF
--- a/packages/netsuite-adapter/src/change_validator.ts
+++ b/packages/netsuite-adapter/src/change_validator.ts
@@ -47,6 +47,7 @@ import fileCabinetInternalIdsValidator from './change_validators/file_cabinet_in
 import rolePermissionValidator from './change_validators/role_permission_ids'
 import translationCollectionValidator from './change_validators/translation_collection_references'
 import omitFieldsValidator from './change_validators/omit_fields'
+import unreferensedFileAdditionValidator from './change_validators/unreferenced_file_addition'
 import NetsuiteClient from './client/client'
 import {
   AdditionalDependencies,
@@ -88,6 +89,7 @@ const netsuiteChangeValidators: Record<NetsuiteValidatorName, NetsuiteChangeVali
   rolePermission: rolePermissionValidator,
   translationCollectionReferences: translationCollectionValidator,
   omitFields: omitFieldsValidator,
+  unreferensedFileAddition: unreferensedFileAdditionValidator,
 }
 
 const nonSuiteAppValidators: Record<NonSuiteAppValidatorName, NetsuiteChangeValidator> = {

--- a/packages/netsuite-adapter/src/change_validator.ts
+++ b/packages/netsuite-adapter/src/change_validator.ts
@@ -47,7 +47,7 @@ import fileCabinetInternalIdsValidator from './change_validators/file_cabinet_in
 import rolePermissionValidator from './change_validators/role_permission_ids'
 import translationCollectionValidator from './change_validators/translation_collection_references'
 import omitFieldsValidator from './change_validators/omit_fields'
-import unreferensedFileAdditionValidator from './change_validators/unreferenced_file_addition'
+import unreferencedFileAdditionValidator from './change_validators/unreferenced_file_addition'
 import NetsuiteClient from './client/client'
 import {
   AdditionalDependencies,
@@ -89,7 +89,7 @@ const netsuiteChangeValidators: Record<NetsuiteValidatorName, NetsuiteChangeVali
   rolePermission: rolePermissionValidator,
   translationCollectionReferences: translationCollectionValidator,
   omitFields: omitFieldsValidator,
-  unreferensedFileAddition: unreferensedFileAdditionValidator,
+  unreferencedFileAddition: unreferencedFileAdditionValidator,
 }
 
 const nonSuiteAppValidators: Record<NonSuiteAppValidatorName, NetsuiteChangeValidator> = {

--- a/packages/netsuite-adapter/src/change_validators/unreferenced_addition.ts
+++ b/packages/netsuite-adapter/src/change_validators/unreferenced_addition.ts
@@ -1,0 +1,60 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { InstanceElement, getChangeData, isAdditionChange, isAdditionOrModificationChange, isInstanceElement, ChangeError } from '@salto-io/adapter-api'
+import { WALK_NEXT_STEP, WalkOnFunc, walkOnElement } from '@salto-io/adapter-utils'
+import { NetsuiteChangeValidator } from './types'
+
+const fileIsReferenced = (
+  changes: InstanceElement[],
+  fileChange: string
+): boolean => {
+  let answer = false
+
+  // how to do it whitout for
+  const func: WalkOnFunc = ({ value }) => {
+    if (value === fileChange) {
+      answer = true
+      return WALK_NEXT_STEP.EXIT
+    }
+    return WALK_NEXT_STEP.RECURSE
+  }
+
+  changes.forEach(element => walkOnElement({ element, func }))
+
+  return answer
+}
+const changeValidator: NetsuiteChangeValidator = async (changes, _deployReferencedElements, _elementsSource) => {
+  const instanceElementChanges = changes
+    .filter(isAdditionOrModificationChange)
+    .map(change => getChangeData(change))
+    .filter(isInstanceElement)
+  const fileAdditions = changes
+    .filter(isAdditionChange)
+    .map(getChangeData).filter(change => change.elemID.typeName === 'file')
+  const unreferencedFiles = fileAdditions
+    .filter(file => !fileIsReferenced(instanceElementChanges, file.elemID.getFullName()))
+  const res = unreferencedFiles
+    .map(({ elemID }): ChangeError => ({
+      elemID,
+      severity: 'Info',
+      message: 'This file is not referenced by any element',
+      detailedMessage: 'Usually files are referenced by an element, it is possible that you forgot to deploy the relevant element',
+    }))
+  return res
+}
+
+export default changeValidator

--- a/packages/netsuite-adapter/src/change_validators/unreferenced_file_addition.ts
+++ b/packages/netsuite-adapter/src/change_validators/unreferenced_file_addition.ts
@@ -59,7 +59,7 @@ const changeValidator: NetsuiteChangeValidator = async (changes, _deployReferenc
       elemID,
       severity: 'Warning',
       message: 'This file is not referenced by any element',
-      detailedMessage: 'Usually files are referenced by an element, it is possible that you forgot to deploy the relevant element',
+      detailedMessage: 'Files are typically referenced by an element. This deployment does not contain any element referencing this file',
     }))
   return res
 }

--- a/packages/netsuite-adapter/src/change_validators/unreferenced_file_addition.ts
+++ b/packages/netsuite-adapter/src/change_validators/unreferenced_file_addition.ts
@@ -58,8 +58,8 @@ const changeValidator: NetsuiteChangeValidator = async (changes, _deployReferenc
     .map(({ elemID }): ChangeError => ({
       elemID,
       severity: 'Warning',
-      message: 'This file is not referenced by any element',
-      detailedMessage: 'Files are typically referenced by an element. This deployment does not contain any element referencing this file',
+      message: 'File not referenced by any element',
+      detailedMessage: "This file isn't referenced by any other element. This may indicate that you forgot to include some element in your deployment which uses this file.",
     }))
   return res
 }

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -553,7 +553,7 @@ export type NetsuiteValidatorName = (
   | 'rolePermission'
   | 'translationCollectionReferences'
   | 'omitFields'
-  | 'unreferensedFileAddition'
+  | 'unreferencedFileAddition'
 )
 
 export type NonSuiteAppValidatorName = (
@@ -600,7 +600,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     fileCabinetInternalIds: { refType: BuiltinTypes.BOOLEAN },
     translationCollectionReferences: { refType: BuiltinTypes.BOOLEAN },
     omitFields: { refType: BuiltinTypes.BOOLEAN },
-    unreferensedFileAddition: { refType: BuiltinTypes.BOOLEAN },
+    unreferencedFileAddition: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -553,6 +553,7 @@ export type NetsuiteValidatorName = (
   | 'rolePermission'
   | 'translationCollectionReferences'
   | 'omitFields'
+  | 'unreferensedFileAddition'
 )
 
 export type NonSuiteAppValidatorName = (
@@ -599,6 +600,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     fileCabinetInternalIds: { refType: BuiltinTypes.BOOLEAN },
     translationCollectionReferences: { refType: BuiltinTypes.BOOLEAN },
     omitFields: { refType: BuiltinTypes.BOOLEAN },
+    unreferensedFileAddition: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/netsuite-adapter/test/change_validators/unreferenced_file_addition.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/unreferenced_file_addition.test.ts
@@ -32,7 +32,7 @@ describe('unreferenced file addition validator', () => {
       })
     const scriptNonReferenceElement = new InstanceElement('scriptElemWithoutReference', suitelet)
 
-    it('Should not have a change error when adding a File and a script referencing it', async () => {
+    it('Should not have a change error when adding a file and a script referencing it', async () => {
       const changeErrors = await unreferencedFileAddition([
         toChange({ after: scriptFileNacl }),
         toChange({ after: scriptReferenceElement }),
@@ -40,7 +40,7 @@ describe('unreferenced file addition validator', () => {
       expect(changeErrors).toHaveLength(0)
     })
 
-    it('Should not have a change error when adding a File and changing a script to reference it', async () => {
+    it('Should not have a change error when adding a file and changing a script to reference it', async () => {
       const changeErrors = await unreferencedFileAddition([
         toChange({ after: scriptFileNacl }),
         toChange({ before: scriptNonReferenceElement, after: scriptReferenceElement }),
@@ -55,7 +55,14 @@ describe('unreferenced file addition validator', () => {
       expect(changeErrors).toHaveLength(0)
     })
 
-    it('Should have a change error when adding a File without changing (adding or modifying) any element to reference it', async () => {
+    it('Should not have a change error when modifying a file', async () => {
+      const changeErrors = await unreferencedFileAddition([
+        toChange({ before: scriptFileNacl, after: scriptFileNacl }),
+      ])
+      expect(changeErrors).toHaveLength(0)
+    })
+
+    it('Should have a change error when adding a file without changing (adding or modifying) any element to reference it', async () => {
       const changeErrors = await unreferencedFileAddition([
         toChange({ after: scriptFileNacl }),
         toChange({ after: scriptNonReferenceElement }),
@@ -70,13 +77,13 @@ describe('unreferenced file addition validator', () => {
   describe('email template file', () => {
     const emailTemplateFileNacl = new InstanceElement('emailTemplateFileNacl', fileType())
     const emailTemplateReferenceElement = new InstanceElement('emailTemplateElemWithReference', emailTemplate,
-      { addcompanyaddress: true,
-        mediaitem: new ReferenceExpression(
-          emailTemplateFileNacl.elemID
-        ) })
+      {
+        addcompanyaddress: true,
+        mediaitem: new ReferenceExpression(emailTemplateFileNacl.elemID),
+      })
     const emailTemplateNonReferenceElement = new InstanceElement('emailTemplateElemWithoutReference', emailTemplate)
 
-    it('Should not have a change error when adding a File and a template referencing it', async () => {
+    it('Should not have a change error when adding a file and a template referencing it', async () => {
       const changeErrors = await unreferencedFileAddition([
         toChange({ after: emailTemplateFileNacl }),
         toChange({ after: emailTemplateReferenceElement }),
@@ -84,7 +91,7 @@ describe('unreferenced file addition validator', () => {
       expect(changeErrors).toHaveLength(0)
     })
 
-    it('Should not have a change error when adding a File and changing a template to reference it', async () => {
+    it('Should not have a change error when adding a file and changing a template to reference it', async () => {
       const changeErrors = await unreferencedFileAddition([
         toChange({ after: emailTemplateFileNacl }),
         toChange({ before: emailTemplateNonReferenceElement, after: emailTemplateReferenceElement }),
@@ -92,14 +99,21 @@ describe('unreferenced file addition validator', () => {
       expect(changeErrors).toHaveLength(0)
     })
 
-    it('Should not have a change error when not adding an email template', async () => {
+    it('Should not have a change error when not adding an email template file', async () => {
       const changeErrors = await unreferencedFileAddition([
         toChange({ after: emailTemplateNonReferenceElement }),
       ])
       expect(changeErrors).toHaveLength(0)
     })
 
-    it('Should have a change error when adding a File without changing (adding or modifying) any element to reference it', async () => {
+    it('Should not have a change error when modifying an email template file', async () => {
+      const changeErrors = await unreferencedFileAddition([
+        toChange({ before: emailTemplateFileNacl, after: emailTemplateFileNacl }),
+      ])
+      expect(changeErrors).toHaveLength(0)
+    })
+
+    it('Should have a change error when adding a file without changing (adding or modifying) any element to reference it', async () => {
       const changeErrors = await unreferencedFileAddition([
         toChange({ after: emailTemplateFileNacl }),
         toChange({ after: emailTemplateNonReferenceElement }),
@@ -113,20 +127,20 @@ describe('unreferenced file addition validator', () => {
   describe('both type of files', () => {
     const emailTemplateFileNacl = new InstanceElement('emailTemplateFileNacl', fileType())
     const emailTemplateReferenceElement = new InstanceElement('emailTemplateElemWithReference', emailTemplate,
-      { addcompanyaddress: true,
-        mediaitem: new ReferenceExpression(
-          emailTemplateFileNacl.elemID
-        ) })
+      {
+        addcompanyaddress: true,
+        mediaitem: new ReferenceExpression(emailTemplateFileNacl.elemID),
+      })
     const emailTemplateNonReferenceElement = new InstanceElement('emailTemplateElemWithoutReference', emailTemplate)
     const scriptFileNacl = new InstanceElement('scriptFileNacl', fileType())
     const scriptReferenceElement = new InstanceElement('scriptElemWithReference', suitelet,
-      { defaultfunction: 'svda',
-        scriptfile: new ReferenceExpression(
-          scriptFileNacl.elemID
-        ) })
+      {
+        defaultfunction: 'svda',
+        scriptfile: new ReferenceExpression(scriptFileNacl.elemID),
+      })
     const scriptNonReferenceElement = new InstanceElement('scriptElemWithoutReference', suitelet)
 
-    it('Should not have a change error when adding files and templates referencing them', async () => {
+    it('Should not have a change error when adding files and scripts/templates referencing them', async () => {
       const changeErrors = await unreferencedFileAddition([
         toChange({ after: emailTemplateFileNacl }),
         toChange({ after: emailTemplateReferenceElement }),
@@ -136,7 +150,7 @@ describe('unreferenced file addition validator', () => {
       expect(changeErrors).toHaveLength(0)
     })
 
-    it('Should not have a change error when adding a File and changing a template to reference it', async () => {
+    it('Should not have a change error when adding files and changing scripts/templates to reference them', async () => {
       const changeErrors = await unreferencedFileAddition([
         toChange({ after: emailTemplateFileNacl }),
         toChange({ before: emailTemplateNonReferenceElement, after: emailTemplateReferenceElement }),
@@ -146,7 +160,7 @@ describe('unreferenced file addition validator', () => {
       expect(changeErrors).toHaveLength(0)
     })
 
-    it('Should not have a change error when not adding an email template', async () => {
+    it('Should not have a change error when not adding an email-template/script', async () => {
       const changeErrors = await unreferencedFileAddition([
         toChange({ after: emailTemplateNonReferenceElement }),
         toChange({ after: scriptNonReferenceElement }),
@@ -154,7 +168,15 @@ describe('unreferenced file addition validator', () => {
       expect(changeErrors).toHaveLength(0)
     })
 
-    it('Should have a change error when adding a File without changing (adding or modifying) any element to reference it', async () => {
+    it('Should not have a change error when modifying an email-template/script', async () => {
+      const changeErrors = await unreferencedFileAddition([
+        toChange({ before: emailTemplateFileNacl, after: emailTemplateFileNacl }),
+        toChange({ before: scriptFileNacl, after: scriptFileNacl }),
+      ])
+      expect(changeErrors).toHaveLength(0)
+    })
+
+    it('Should have a change error when adding files without changing (adding or modifying) any element to reference them', async () => {
       const changeErrors = await unreferencedFileAddition([
         toChange({ after: emailTemplateFileNacl }),
         toChange({ after: emailTemplateNonReferenceElement }),

--- a/packages/netsuite-adapter/test/change_validators/unreferenced_file_addition.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/unreferenced_file_addition.test.ts
@@ -1,0 +1,165 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { EMAIL_TEMPLATE, FILE, NETSUITE } from '../../src/constants'
+import unreferencedFileAddition from '../../src/change_validators/unreferenced_file_addition'
+
+describe('unreferenced file addition validator', () => {
+  describe('script file', () => {
+    const scriptFileNacl = new InstanceElement('scriptFileNacl', new ObjectType({ elemID: new ElemID(NETSUITE, FILE) }))
+    const scriptReferenceElement = new InstanceElement('scriptElemWithReference', new ObjectType({ elemID: new ElemID(NETSUITE, 'suitlet') }),
+      { defaultfunction: 'svda',
+        scriptfile: new ReferenceExpression(
+          scriptFileNacl.elemID
+        ) })
+    const scriptNonReferenceElement = new InstanceElement('scriptElemWithoutReference', new ObjectType({ elemID: new ElemID(NETSUITE, 'suitlet') }))
+
+    it('Should not have a change error when adding a File and a script referencing it', async () => {
+      const changeErrors = await unreferencedFileAddition([
+        toChange({ after: scriptFileNacl }),
+        toChange({ after: scriptReferenceElement }),
+      ])
+      expect(changeErrors).toHaveLength(0)
+    })
+
+    it('Should not have a change error when adding a File and changing a script to reference it', async () => {
+      const changeErrors = await unreferencedFileAddition([
+        toChange({ after: scriptFileNacl }),
+        toChange({ before: scriptNonReferenceElement, after: scriptReferenceElement }),
+      ])
+      expect(changeErrors).toHaveLength(0)
+    })
+
+    it('Should not have a change error when not adding a File', async () => {
+      const changeErrors = await unreferencedFileAddition([
+        toChange({ after: scriptNonReferenceElement }),
+      ])
+      expect(changeErrors).toHaveLength(0)
+    })
+
+    it('Should have a change error when adding a File without changing (adding or modifying) any element to reference it', async () => {
+      const changeErrors = await unreferencedFileAddition([
+        toChange({ after: scriptFileNacl }),
+        toChange({ after: scriptNonReferenceElement }),
+      ])
+      expect(changeErrors).toHaveLength(1)
+      expect(changeErrors[0].severity).toEqual('Warning')
+      expect(changeErrors[0].elemID).toBe(scriptFileNacl.elemID)
+    })
+  })
+
+  describe('email template file', () => {
+    const emailTemplateFileNacl = new InstanceElement('emailTemplateFileNacl', new ObjectType({ elemID: new ElemID(NETSUITE, FILE) }))
+    const emailTemplateReferenceElement = new InstanceElement('emailTemplateElemWithReference', new ObjectType({ elemID: new ElemID(NETSUITE, EMAIL_TEMPLATE) }),
+      { addcompanyaddress: true,
+        mediaitem: new ReferenceExpression(
+          emailTemplateFileNacl.elemID
+        ) })
+    const emailTemplateNonReferenceElement = new InstanceElement('emailTemplateElemWithoutReference', new ObjectType({ elemID: new ElemID(NETSUITE, EMAIL_TEMPLATE) }))
+
+    it('Should not have a change error when adding a File and a template referencing it', async () => {
+      const changeErrors = await unreferencedFileAddition([
+        toChange({ after: emailTemplateFileNacl }),
+        toChange({ after: emailTemplateReferenceElement }),
+      ])
+      expect(changeErrors).toHaveLength(0)
+    })
+
+    it('Should not have a change error when adding a File and changing a template to reference it', async () => {
+      const changeErrors = await unreferencedFileAddition([
+        toChange({ after: emailTemplateFileNacl }),
+        toChange({ before: emailTemplateNonReferenceElement, after: emailTemplateReferenceElement }),
+      ])
+      expect(changeErrors).toHaveLength(0)
+    })
+
+    it('Should not have a change error when not adding an email template', async () => {
+      const changeErrors = await unreferencedFileAddition([
+        toChange({ after: emailTemplateNonReferenceElement }),
+      ])
+      expect(changeErrors).toHaveLength(0)
+    })
+
+    it('Should have a change error when adding a File without changing (adding or modifying) any element to reference it', async () => {
+      const changeErrors = await unreferencedFileAddition([
+        toChange({ after: emailTemplateFileNacl }),
+        toChange({ after: emailTemplateNonReferenceElement }),
+      ])
+      expect(changeErrors).toHaveLength(1)
+      expect(changeErrors[0].severity).toEqual('Warning')
+      expect(changeErrors[0].elemID).toBe(emailTemplateFileNacl.elemID)
+    })
+  })
+  describe('both type of files', () => {
+    const emailTemplateFileNacl = new InstanceElement('emailTemplateFileNacl', new ObjectType({ elemID: new ElemID(NETSUITE, FILE) }))
+    const emailTemplateReferenceElement = new InstanceElement('emailTemplateElemWithReference', new ObjectType({ elemID: new ElemID(NETSUITE, EMAIL_TEMPLATE) }),
+      { addcompanyaddress: true,
+        mediaitem: new ReferenceExpression(
+          emailTemplateFileNacl.elemID
+        ) })
+    const emailTemplateNonReferenceElement = new InstanceElement('emailTemplateElemWithoutReference', new ObjectType({ elemID: new ElemID(NETSUITE, EMAIL_TEMPLATE) }))
+    const scriptFileNacl = new InstanceElement('scriptFileNacl', new ObjectType({ elemID: new ElemID(NETSUITE, FILE) }))
+    const scriptReferenceElement = new InstanceElement('scriptElemWithReference', new ObjectType({ elemID: new ElemID(NETSUITE, 'suitlet') }),
+      { defaultfunction: 'svda',
+        scriptfile: new ReferenceExpression(
+          scriptFileNacl.elemID
+        ) })
+    const scriptNonReferenceElement = new InstanceElement('scriptElemWithoutReference', new ObjectType({ elemID: new ElemID(NETSUITE, 'suitlet') }))
+
+    it('Should not have a change error when adding files and templates referencing them', async () => {
+      const changeErrors = await unreferencedFileAddition([
+        toChange({ after: emailTemplateFileNacl }),
+        toChange({ after: emailTemplateReferenceElement }),
+        toChange({ after: scriptFileNacl }),
+        toChange({ after: scriptReferenceElement }),
+      ])
+      expect(changeErrors).toHaveLength(0)
+    })
+
+    it('Should not have a change error when adding a File and changing a template to reference it', async () => {
+      const changeErrors = await unreferencedFileAddition([
+        toChange({ after: emailTemplateFileNacl }),
+        toChange({ before: emailTemplateNonReferenceElement, after: emailTemplateReferenceElement }),
+        toChange({ after: scriptFileNacl }),
+        toChange({ before: scriptNonReferenceElement, after: scriptReferenceElement }),
+      ])
+      expect(changeErrors).toHaveLength(0)
+    })
+
+    it('Should not have a change error when not adding an email template', async () => {
+      const changeErrors = await unreferencedFileAddition([
+        toChange({ after: emailTemplateNonReferenceElement }),
+        toChange({ after: scriptNonReferenceElement }),
+      ])
+      expect(changeErrors).toHaveLength(0)
+    })
+
+    it('Should have a change error when adding a File without changing (adding or modifying) any element to reference it', async () => {
+      const changeErrors = await unreferencedFileAddition([
+        toChange({ after: emailTemplateFileNacl }),
+        toChange({ after: emailTemplateNonReferenceElement }),
+        toChange({ after: scriptFileNacl }),
+        toChange({ after: scriptNonReferenceElement }),
+      ])
+      expect(changeErrors).toHaveLength(2)
+      expect(changeErrors.map(changeError => changeError.severity)).toEqual(['Warning', 'Warning'])
+      expect(changeErrors.map(changeError => changeError.elemID)).toEqual(expect.arrayContaining([
+        emailTemplateFileNacl.elemID,
+        scriptFileNacl.elemID,
+      ]))
+    })
+  })
+})


### PR DESCRIPTION
_Added a change validator that checks for every file added in the deployment whether there is an element referencing it_

---

_Additional context for reviewer_
_None_

---
_Release Notes_: 
_Especially when deploying between 2 environments, users who added a file to the deployment but forgot to add the element referencing the file will get a warning.
This may cause warnings for a legitimate, although not typical, action_

---
_User Notifications_: 
_None_
