### PR TITLE
SALTO-4577: DashboardGadget references

### DIFF
--- a/packages/adapter-components/src/references/field_references.ts
+++ b/packages/adapter-components/src/references/field_references.ts
@@ -146,6 +146,7 @@ export const replaceReferenceValues = async <
             ref: new ReferenceExpression(element.elemID, elem),
             field,
             element: instance,
+            path,
           })
           : resolvePath(element, referenceId)
         // this validation is necessary to create a reference from '$Label.check' and not 'check'
@@ -314,7 +315,7 @@ export const generateLookupFunc = <
       ref, path, field, element,
     }) ?? ReferenceSerializationStrategyLookup.fullValue
     if (!isRelativeSerializer(strategy)) {
-      return strategy.serialize({ ref, field, element })
+      return strategy.serialize({ ref, field, element, path })
     }
     return cloneDeepWithoutRefs(ref.value)
   }

--- a/packages/jira-adapter/src/filters/dashboard/gadget.ts
+++ b/packages/jira-adapter/src/filters/dashboard/gadget.ts
@@ -53,7 +53,8 @@ const deployGadgetProperties = async (
   instance: InstanceElement,
   client: JiraClient
 ): Promise<void> => {
-  const dashboardId = getParents(instance)[0].value.value.id
+  // references are already resolved
+  const dashboardId = getParents(instance)[0].id
 
   await Promise.all(
     Object.entries(instance.value.properties ?? {})

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -14,19 +14,19 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import Joi from 'joi'
 import { isInstanceElement, isReferenceExpression } from '@salto-io/adapter-api'
 import { references as referenceUtils } from '@salto-io/adapter-components'
-import { GetLookupNameFunc, createSchemeGuard, resolvePath } from '@salto-io/adapter-utils'
+import { GetLookupNameFunc } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { AUTOMATION_PROJECT_TYPE, AUTOMATION_FIELD, AUTOMATION_COMPONENT_VALUE_TYPE,
   BOARD_ESTIMATION_TYPE, ISSUE_TYPE_NAME, ISSUE_TYPE_SCHEMA_NAME, AUTOMATION_STATUS,
   AUTOMATION_CONDITION, AUTOMATION_CONDITION_CRITERIA, AUTOMATION_SUBTASK,
   AUTOMATION_ROLE, AUTOMATION_GROUP, AUTOMATION_EMAIL_RECIPENT, PROJECT_TYPE,
-  SECURITY_LEVEL_TYPE, SECURITY_SCHEME_TYPE, STATUS_TYPE_NAME, WORKFLOW_TYPE_NAME, AUTOMATION_COMPARE_VALUE, AUTOMATION_TYPE, AUTOMATION_LABEL_TYPE, GROUP_TYPE_NAME, PRIORITY_SCHEME_TYPE_NAME, SCRIPT_RUNNER_TYPE, POST_FUNCTION_CONFIGURATION, RESOLUTION_TYPE_NAME, ISSUE_EVENT_TYPE_NAME, CONDITION_CONFIGURATION, PROJECT_ROLE_TYPE, VALIDATOR_CONFIGURATION, BOARD_TYPE_NAME, ISSUE_LINK_TYPE_NAME, DIRECTED_LINK_TYPE, MAIL_LIST_TYPE_NAME, FILTER_TYPE_NAME } from './constants'
+  SECURITY_LEVEL_TYPE, SECURITY_SCHEME_TYPE, STATUS_TYPE_NAME, WORKFLOW_TYPE_NAME, AUTOMATION_COMPARE_VALUE, AUTOMATION_TYPE, AUTOMATION_LABEL_TYPE, GROUP_TYPE_NAME, PRIORITY_SCHEME_TYPE_NAME, SCRIPT_RUNNER_TYPE, POST_FUNCTION_CONFIGURATION, RESOLUTION_TYPE_NAME, ISSUE_EVENT_TYPE_NAME, CONDITION_CONFIGURATION, PROJECT_ROLE_TYPE, VALIDATOR_CONFIGURATION, BOARD_TYPE_NAME, ISSUE_LINK_TYPE_NAME, DIRECTED_LINK_TYPE, MAIL_LIST_TYPE_NAME } from './constants'
 import { getFieldsLookUpName } from './filters/fields/field_type_references_filter'
 import { getRefType } from './references/workflow_properties'
 import { FIELD_TYPE_NAME } from './filters/fields/constants'
+import { gadgetValuesContextFunc, gadgetValueSerialize, gadgetDashboradValueLookup } from './references/dashboard_gadget_properties'
 
 const { awu } = collections.asynciterable
 const { neighborContextGetter, basicLookUp } = referenceUtils
@@ -68,41 +68,6 @@ export const resolutionAndPriorityToTypeName: referenceUtils.ContextValueMapperF
   return undefined
 }
 
-type GadgetValue = {
-  key: string
-  value: string
-}
-
-const GADGET_VALUE_SCHEME = Joi.object({
-  key: Joi.string().allow('').required(),
-  value: Joi.string().allow('').required(),
-}).unknown(true)
-
-const isGadgetObject = createSchemeGuard<GadgetValue>(GADGET_VALUE_SCHEME, 'Invalid gadget value')
-
-const FILTER_PREFIX = 'filter-'
-const PROJECT_PREFIX = 'project-'
-
-const gadgetValuesContextFunc: referenceUtils.ContextFunc = async ({ instance, fieldPath }) => {
-  if (fieldPath === undefined) {
-    return undefined
-  }
-  const contextObject = resolvePath(instance, fieldPath.createParentID())
-  if (!isGadgetObject(contextObject)) {
-    return undefined
-  }
-  const { key, value } = contextObject
-  switch (key) {
-    case 'ystattype':
-    case 'xstattype':
-    case 'statistictype':
-    case 'statType': return FIELD_TYPE_NAME
-    case 'filterId': return FILTER_TYPE_NAME
-    case 'projectOrFilterId': return _.startsWith(value, PROJECT_PREFIX) ? PROJECT_TYPE : FILTER_TYPE_NAME
-    default: return undefined
-  }
-}
-
 export type ReferenceContextStrategyName = 'parentSelectedFieldType' | 'parentFieldType' | 'workflowStatusPropertiesContext'
 | 'parentFieldId' | 'gadgetPropertyValue'
 
@@ -121,36 +86,6 @@ const groupNameSerialize: GetLookupNameFunc = ({ ref }) =>
 
 const groupIdSerialize: GetLookupNameFunc = ({ ref }) =>
   (isInstanceElement(ref.value) ? ref.value.value.groupId : ref.value)
-
-const gadgetValueSerialize: GetLookupNameFunc = ({ ref, path, element }) => {
-  if (path === undefined) {
-    return ref.value.value.id
-  }
-  if (ref.elemID.typeName === PROJECT_TYPE) {
-    return PROJECT_PREFIX.concat(ref.value.value.id)
-  }
-  if (ref.elemID.typeName === FILTER_TYPE_NAME) {
-    const contextObject = resolvePath(element, path.createParentID())
-    // The first condition is needed for deploy, as contextObject.value is a reference expression
-    // The second condition is needed for fetch
-    return (contextObject?.key === 'projectOrFilterId' || (_.isString(contextObject?.value) && _.startsWith(contextObject?.value, FILTER_PREFIX)))
-      ? FILTER_PREFIX.concat(ref.value.value.id)
-      : ref.value.value.id
-  }
-  return ref.value.value.id
-}
-
-const gadgetDashboradValueLookup: referenceUtils.LookupFunc = val => {
-  if (_.isString(val)) {
-    if (val.startsWith(FILTER_PREFIX)) {
-      return val.slice(FILTER_PREFIX.length)
-    }
-    if (val.startsWith(PROJECT_PREFIX)) {
-      return val.slice(PROJECT_PREFIX.length)
-    }
-  }
-  return val
-}
 
 type JiraReferenceSerializationStrategyName = 'groupStrategyById' | 'groupStrategyByOriginalName' | 'groupId' | 'key' | 'dashboradGadgetsValues'
 const JiraReferenceSerializationStrategyLookup: Record<

--- a/packages/jira-adapter/src/references/dashboard_gadget_properties.ts
+++ b/packages/jira-adapter/src/references/dashboard_gadget_properties.ts
@@ -1,0 +1,86 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import Joi from 'joi'
+import { references as referenceUtils } from '@salto-io/adapter-components'
+import { GetLookupNameFunc, createSchemeGuard, resolvePath } from '@salto-io/adapter-utils'
+import { FILTER_TYPE_NAME, PROJECT_TYPE } from '../constants'
+import { FIELD_TYPE_NAME } from '../filters/fields/constants'
+
+const FILTER_PREFIX = 'filter-'
+const PROJECT_PREFIX = 'project-'
+
+type GadgetValue = {
+  key: string
+  value: string
+}
+
+const GADGET_VALUE_SCHEME = Joi.object({
+  key: Joi.string().allow('').required(),
+  value: Joi.string().allow('').required(),
+}).unknown(true)
+
+const isGadgetObject = createSchemeGuard<GadgetValue>(GADGET_VALUE_SCHEME, 'Invalid gadget value')
+
+export const gadgetValuesContextFunc: referenceUtils.ContextFunc = async ({ instance, fieldPath }) => {
+  if (fieldPath === undefined) {
+    return undefined
+  }
+  const contextObject = resolvePath(instance, fieldPath.createParentID())
+  if (!isGadgetObject(contextObject)) {
+    return undefined
+  }
+  const { key, value } = contextObject
+  switch (key) {
+    case 'ystattype':
+    case 'xstattype':
+    case 'statistictype':
+    case 'statType': return FIELD_TYPE_NAME
+    case 'filterId': return FILTER_TYPE_NAME
+    case 'projectOrFilterId': return _.startsWith(value, PROJECT_PREFIX) ? PROJECT_TYPE : FILTER_TYPE_NAME
+    default: return undefined
+  }
+}
+
+export const gadgetValueSerialize: GetLookupNameFunc = ({ ref, path, element }) => {
+  if (path === undefined) {
+    return ref.value.value.id
+  }
+  if (ref.elemID.typeName === PROJECT_TYPE) {
+    return PROJECT_PREFIX.concat(ref.value.value.id)
+  }
+  if (ref.elemID.typeName === FILTER_TYPE_NAME) {
+    const contextObject = resolvePath(element, path.createParentID())
+    // The first condition is needed for deploy, as contextObject.value is a reference expression
+    // The second condition is needed for fetch
+    return (contextObject?.key === 'projectOrFilterId' || (_.isString(contextObject?.value) && _.startsWith(contextObject?.value, FILTER_PREFIX)))
+      ? FILTER_PREFIX.concat(ref.value.value.id)
+      : ref.value.value.id
+  }
+  return ref.value.value.id
+}
+
+export const gadgetDashboradValueLookup: referenceUtils.LookupFunc = val => {
+  if (_.isString(val)) {
+    if (val.startsWith(FILTER_PREFIX)) {
+      return val.slice(FILTER_PREFIX.length)
+    }
+    if (val.startsWith(PROJECT_PREFIX)) {
+      return val.slice(PROJECT_PREFIX.length)
+    }
+  }
+  return val
+}

--- a/packages/jira-adapter/test/filters/dashboard/gadget.test.ts
+++ b/packages/jira-adapter/test/filters/dashboard/gadget.test.ts
@@ -307,6 +307,8 @@ describe('gadgetFilter', () => {
         key1: 'value1',
         key2: 'value2',
       }
+      // references are resolved in pre deploy
+      instance.annotations[CORE_ANNOTATIONS.PARENT][0] = { id: '0' }
 
       change = toChange({ after: instance })
     })

--- a/packages/jira-adapter/test/filters/dashboard/gadget_properties.test.ts
+++ b/packages/jira-adapter/test/filters/dashboard/gadget_properties.test.ts
@@ -13,17 +13,53 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, Values, toChange } from '@salto-io/adapter-api'
+import { AdditionChange, BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, InstanceElement, ListType, ObjectType, ReferenceExpression, Values, getChangeData, toChange } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import { getFilterParams } from '../../utils'
 import gadgetPropertiesFilter from '../../../src/filters/dashboard/gadget_properties'
-import { DASHBOARD_GADGET_TYPE, JIRA } from '../../../src/constants'
+import { DASHBOARD_GADGET_TYPE, DASHBOARD_TYPE, FILTER_TYPE_NAME, JIRA } from '../../../src/constants'
 
+const getConvertedGadgetType = ():ObjectType => {
+  const gadgetType = new ObjectType({
+    elemID: new ElemID(JIRA, DASHBOARD_GADGET_TYPE),
+  })
+  const gadgetPropertyType = new ObjectType({
+    elemID: new ElemID(JIRA, 'DashboardGadgetProperty'),
+    fields: {
+      key: {
+        refType: BuiltinTypes.STRING,
+        annotations: { [CORE_ANNOTATIONS.CREATABLE]: true, [CORE_ANNOTATIONS.UPDATABLE]: true },
+      },
+      value: {
+        refType: BuiltinTypes.UNKNOWN,
+        annotations: { [CORE_ANNOTATIONS.CREATABLE]: true, [CORE_ANNOTATIONS.UPDATABLE]: true },
+      },
+    },
+  })
+  gadgetPropertyType.fields.values = new Field(
+    gadgetPropertyType,
+    'values',
+    new ListType(gadgetPropertyType),
+    { [CORE_ANNOTATIONS.CREATABLE]: true, [CORE_ANNOTATIONS.UPDATABLE]: true },
+  )
+
+  gadgetType.fields.properties = new Field(
+    gadgetType,
+    'properties',
+    new ListType(gadgetPropertyType),
+    { [CORE_ANNOTATIONS.CREATABLE]: true, [CORE_ANNOTATIONS.UPDATABLE]: true },
+  )
+  return gadgetType
+}
 
 describe('gadgetPropertiesFilter', () => {
   let filter: filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
   let dashboardGadgetType: ObjectType
+  let dashboardType: ObjectType
+  let filterType: ObjectType
   let instance: InstanceElement
+  let dashboard: InstanceElement
+  let filterInst: InstanceElement
 
   let originalProperties: Values
   let convertedProperties: Values
@@ -37,6 +73,20 @@ describe('gadgetPropertiesFilter', () => {
         properties: {
           refType: BuiltinTypes.STRING,
         },
+      },
+    })
+
+    dashboardType = new ObjectType({
+      elemID: new ElemID(JIRA, DASHBOARD_TYPE),
+      fields: {
+        id: { refType: BuiltinTypes.STRING },
+      },
+    })
+
+    filterType = new ObjectType({
+      elemID: new ElemID(JIRA, FILTER_TYPE_NAME),
+      fields: {
+        id: { refType: BuiltinTypes.STRING },
       },
     })
 
@@ -58,6 +108,12 @@ describe('gadgetPropertiesFilter', () => {
       { key: 'key3', values: [{ key: 'innerKey', values: [{ key: 'inner2', value: 'value3' }] }] },
     ]
 
+    dashboard = new InstanceElement(
+      'dashboard',
+      dashboardType,
+      { id: '0' }
+    )
+
     instance = new InstanceElement(
       'instance',
       dashboardGadgetType,
@@ -65,6 +121,7 @@ describe('gadgetPropertiesFilter', () => {
         properties: originalProperties,
       },
     )
+    filterInst = new InstanceElement('filter', filterType, { id: '1' })
   })
 
   describe('onFetch', () => {
@@ -127,15 +184,69 @@ describe('gadgetPropertiesFilter', () => {
   describe('preDeploy', () => {
     it('should convert properties from list to map', async () => {
       instance.value.properties = convertedProperties
-      await filter.preDeploy([toChange({ after: instance })])
-      expect(instance.value.properties).toEqual(originalProperties)
+      const changes = [toChange({ after: instance })]
+      await filter.preDeploy(changes)
+      const relevantChange = changes.find(
+        change => getChangeData(change).elemID.getFullName() === instance.elemID.getFullName()
+      ) as AdditionChange<InstanceElement>
+      expect(relevantChange.data.after.value.properties).toEqual(originalProperties)
+    })
+    it('should resolve any existing references', async () => {
+      const convertedPropertiesWithRefs = [
+        { key: 'key2', values: [{ key: 'filterId', value: new ReferenceExpression(filterInst.elemID, filterInst) }] },
+      ]
+      const inst = new InstanceElement(
+        'test',
+        getConvertedGadgetType(),
+        { properties: convertedPropertiesWithRefs },
+        undefined,
+        { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(dashboard.elemID, dashboard)] },
+      )
+      const changes = [toChange({ after: inst })]
+      await filter.preDeploy(changes)
+      const relevantChange = changes.find(
+        change => getChangeData(change).elemID.getFullName() === inst.elemID.getFullName()
+      ) as AdditionChange<InstanceElement>
+      expect(relevantChange?.data?.after.value.properties.key2.filterId).toEqual('1')
+      expect(relevantChange?.data?.after.annotations[CORE_ANNOTATIONS.PARENT][0]).toEqual({ id: '0' })
     })
   })
 
   describe('onDeploy', () => {
     it('should convert properties from map to list', async () => {
-      await filter.onDeploy([toChange({ after: instance })])
-      expect(instance.value.properties).toEqual(convertedProperties)
+      instance.value.properties = convertedProperties
+      const changes = [toChange({ after: instance })]
+      // We call preDeploy as it sets the mappings
+      await filter.preDeploy(changes)
+      await filter.onDeploy(changes)
+      const relevantChange = changes.find(
+        change => getChangeData(change).elemID.getFullName() === instance.elemID.getFullName()
+      ) as AdditionChange<InstanceElement>
+      expect(relevantChange?.data?.after.value.properties).toEqual(convertedProperties)
+    })
+    it('should restore references', async () => {
+      const convertedPropertiesWithRefs = [
+        { key: 'key2', values: [{ key: 'filterId', value: new ReferenceExpression(filterInst.elemID, filterInst) }] },
+      ]
+      const inst = new InstanceElement(
+        'test',
+        getConvertedGadgetType(),
+        { properties: convertedPropertiesWithRefs },
+        undefined,
+        { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(dashboard.elemID, dashboard)] },
+      )
+      const changes = [toChange({ after: inst })]
+      // We call preDeploy as it sets the mappings
+      await filter.preDeploy(changes)
+      await filter.onDeploy(changes)
+      const relevantChange = changes.find(
+        change => getChangeData(change).elemID.getFullName() === instance.elemID.getFullName()
+      ) as AdditionChange<InstanceElement>
+      // TODO complete
+      // expect((relevantChange?.data?.after.value.properties[0].values.value[0] as ReferenceExpression)
+      //   .elemID.getFullName()).toEqual(filterInst.elemID.getFullName())
+      // expect((relevantChange.data.after.annotations[CORE_ANNOTATIONS.PARENT][0] as ReferenceExpression)
+      //   .elemID.getFullName()).toEqual(dashboard.elemID.getFullName())
     })
   })
 })

--- a/packages/jira-adapter/test/filters/dashboard/gadget_properties.test.ts
+++ b/packages/jira-adapter/test/filters/dashboard/gadget_properties.test.ts
@@ -240,13 +240,14 @@ describe('gadgetPropertiesFilter', () => {
       await filter.preDeploy(changes)
       await filter.onDeploy(changes)
       const relevantChange = changes.find(
-        change => getChangeData(change).elemID.getFullName() === instance.elemID.getFullName()
+        change => getChangeData(change).elemID.getFullName() === inst.elemID.getFullName()
       ) as AdditionChange<InstanceElement>
-      // TODO complete
-      // expect((relevantChange?.data?.after.value.properties[0].values.value[0] as ReferenceExpression)
-      //   .elemID.getFullName()).toEqual(filterInst.elemID.getFullName())
-      // expect((relevantChange.data.after.annotations[CORE_ANNOTATIONS.PARENT][0] as ReferenceExpression)
-      //   .elemID.getFullName()).toEqual(dashboard.elemID.getFullName())
+      expect(getChangeData(relevantChange).annotations[CORE_ANNOTATIONS.PARENT]).toEqual(
+        [new ReferenceExpression(dashboard.elemID, dashboard)]
+      )
+      expect(getChangeData(relevantChange).value.properties[0].values[0].value).toEqual(
+        new ReferenceExpression(filterInst.elemID, filterInst)
+      )
     })
   })
 })

--- a/packages/jira-adapter/test/references/dashboard_gadget_properties.test.ts
+++ b/packages/jira-adapter/test/references/dashboard_gadget_properties.test.ts
@@ -1,0 +1,147 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, ElemID, InstanceElement, ObjectType, ReferenceExpression, Element, Field } from '@salto-io/adapter-api'
+import { multiIndex, collections } from '@salto-io/lowerdash'
+import { DASHBOARD_GADGET_TYPE, FILTER_TYPE_NAME, JIRA } from '../../src/constants'
+import { gadgetValuesContextFunc, gadgetValueSerialize, gadgetDashboradValueLookup } from '../../src/references/dashboard_gadget_properties'
+
+const { awu } = collections.asynciterable
+
+describe('DashboardGadgetReferences', () => {
+  let dashboardGadgetType: ObjectType
+  let filterType: ObjectType
+  let instance: InstanceElement
+  let filterInst: InstanceElement
+  let filterRef: ReferenceExpression
+  let instanceWithRefs: InstanceElement
+
+  beforeEach(() => {
+    dashboardGadgetType = new ObjectType({
+      elemID: new ElemID(JIRA, DASHBOARD_GADGET_TYPE),
+      fields: {},
+    })
+
+    filterType = new ObjectType({
+      elemID: new ElemID(JIRA, FILTER_TYPE_NAME),
+      fields: {
+        id: { refType: BuiltinTypes.STRING },
+      },
+    })
+
+    filterInst = new InstanceElement(
+      'filter', filterType, { id: '123' },
+    )
+    filterRef = new ReferenceExpression(filterInst.elemID, filterInst)
+
+    instance = new InstanceElement(
+      'instance',
+      dashboardGadgetType,
+      {
+        properties: {
+          key: 'config',
+          values: [
+            { key: 'filterId', value: 'filter-123' },
+            { key: 'filterId', value: '123' },
+            { key: 'projectOrFilterId', value: 'project-123' },
+            { key: 'projectOrFilterId', value: 'filter-123' },
+            { key: 'statType', value: 'customfield_123' }
+          ],
+        },
+      },
+    )
+
+    instanceWithRefs = new InstanceElement(
+      'instance',
+      dashboardGadgetType,
+      {
+        properties: {
+          key: 'config',
+          values: [
+            { key: 'filterId', value: filterRef },
+            { key: 'filterId', value: filterRef },
+            { key: 'projectOrFilterId', value: 'project-123' },
+            { key: 'projectOrFilterId', value: filterRef },
+          ],
+        },
+      },
+    )
+  })
+
+  describe('gadgetValuesCont{extFunc', () => {
+    let field: Field
+    let elemByElemID: multiIndex.Index<[string], Element>
+
+    beforeEach(async () => {
+      // field are elemByElemID are only needed because it is mandatory in ContextFunc, but are not going to be used
+      field = new Field(filterType, 'mock', filterType)
+      const indexer = multiIndex.buildMultiIndex<Element>().addIndex({
+        name: 'elemByElemID',
+        key: elem => [elem.elemID.getFullName()],
+      })
+      elemByElemID = (await indexer.process(awu([]))).elemByElemID
+    })
+
+    it('should return undefined if fieldPath is undefined', async () => {
+      const result = await gadgetValuesContextFunc({ instance, elemByElemID, field })
+      expect(result).toBeUndefined()
+    })
+
+    it('should return FIELD_TYPE_NAME for valid keys: ystattype, xstattype, statistictype, statType', async () => {
+      const fieldPath = instance.elemID.createNestedID('properties', 'values', '4', 'value')
+      const result1 = await gadgetValuesContextFunc({ instance, elemByElemID, field, fieldPath })
+      expect(result1).toEqual('Field')
+    })
+    it('should determine type based on value prefix for the key: projectOrFilterId', async () => {
+      const projectPath = instance.elemID.createNestedID('properties', 'values', '2', 'value')
+      const filterPath = instance.elemID.createNestedID('properties', 'values', '3', 'value')
+      const result1 = await gadgetValuesContextFunc({ instance, elemByElemID, field, fieldPath: projectPath })
+      expect(result1).toEqual('Project')
+      const result2 = await gadgetValuesContextFunc({ instance, elemByElemID, field, fieldPath: filterPath })
+      expect(result2).toEqual('Filter')
+    })
+  })
+
+  describe('gadgetValueSerialize', () => {
+    it('should resolve filter references correctly', async () => {
+      const elemId1 = instanceWithRefs.elemID.createNestedID('properties', 'values', '1', 'value')
+      const elemId3 = instanceWithRefs.elemID.createNestedID('properties', 'values', '3', 'value')
+      const result1 = await gadgetValueSerialize({ ref: filterRef, path: elemId1, element: instanceWithRefs })
+      expect(result1).toEqual('123')
+      const result3 = await gadgetValueSerialize({ ref: filterRef, path: elemId3, element: instanceWithRefs })
+      expect(result3).toEqual('filter-123')
+    })
+    it('should return id if path is undefined', () => {
+      const result = gadgetValueSerialize({ ref: filterRef, path: undefined, element: instanceWithRefs })
+      expect(result).toEqual('123')
+    })
+  })
+
+  describe('gadgetDashboradValueLookup', () => {
+    it('should return the correct values', () => {
+      const test1 = 'filter-123'
+      const result1 = gadgetDashboradValueLookup(test1)
+      expect(result1).toEqual('123')
+
+      const test2 = 'project-234'
+      const result2 = gadgetDashboradValueLookup(test2)
+      expect(result2).toEqual('234')
+
+      const test3 = 15
+      const result3 = gadgetDashboradValueLookup(test3)
+      expect(result3).toEqual(15)
+    })
+  })
+})

--- a/packages/jira-adapter/test/references/dashboard_gadget_properties.test.ts
+++ b/packages/jira-adapter/test/references/dashboard_gadget_properties.test.ts
@@ -57,7 +57,7 @@ describe('DashboardGadgetReferences', () => {
             { key: 'filterId', value: '123' },
             { key: 'projectOrFilterId', value: 'project-123' },
             { key: 'projectOrFilterId', value: 'filter-123' },
-            { key: 'statType', value: 'customfield_123' }
+            { key: 'statType', value: 'customfield_123' },
           ],
         },
       },


### PR DESCRIPTION
Add references to `Filter`, `Project` and extend `Field` references to support custom fields as well

---

_Additional context for reviewer_
This PR also fixes a bug in resolving of `Field` references in `DashboardGadget` causing deployment of changes with those references to fail

Will add noise reduction

---
_Release Notes_: 

_Jira_adapter_:
- Fix bug in deployment of DashboradGadget
- Add references to Filter, Project, and Field from DashboardGadget

---
_User Notifications_: 

_Jira_adapter_:
- References to Filter, Project, and Field will be added in DashboardGadget elements
