### PR TITLE
SALTO-3958: scripted fields

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -132,6 +132,9 @@ import projectCategoryFilter from './filters/project_category'
 import addAliasFilter from './filters/add_alias'
 import projectRoleRemoveTeamManagedDuplicatesFilter from './filters/remove_specific_duplicate_roles'
 import projectFieldContextOrder from './filters/project_field_contexts_order'
+import scriptedFieldsIssueTypesFilter from './filters/script_runner/scripted_fields_issue_types'
+import scriptRunnerFilter from './filters/script_runner/script_runner_filter'
+import scriptRunnerInstancesDeploy from './filters/script_runner/script_runner_instances_deploy'
 import ScriptRunnerClient from './client/script_runner_client'
 
 const { getAllElements } = elementUtils.ducktype
@@ -182,6 +185,9 @@ export const DEFAULT_FILTERS = [
   iconUrlFilter,
   triggersFilter,
   resolutionPropertyFilter,
+  scriptRunnerFilter,
+  // must run before references are transformed
+  scriptedFieldsIssueTypesFilter,
   scriptRunnerWorkflowFilter,
   // must run after scriptRunnerWorkflowFilter
   scriptRunnerWorkflowListsFilter,
@@ -272,6 +278,7 @@ export const DEFAULT_FILTERS = [
   wrongUserPermissionSchemeFilter,
   deployDcIssueEventsFilter,
   addAliasFilter,
+  scriptRunnerInstancesDeploy,
   // Must be last
   defaultInstancesDeployFilter,
   ...Object.values(otherCommonFilters),
@@ -343,6 +350,7 @@ export default class JiraAdapter implements AdapterOperations {
           fetchQuery: this.fetchQuery,
           adapterContext: filterContext,
           getUserMapFunc: this.getUserMapFunc,
+          scriptRunnerClient,
         },
         filterCreators,
         objects.concatObjects

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1648,15 +1648,87 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
 }
 
 const DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
-  ScripRunnerListeners: {
+  ScriptRunnerListener: {
     request: {
       url: '/sr-dispatcher/jira/admin/token/scriptevents',
+    },
+    transformation: {
+      serviceIdField: 'uuid',
+      sourceTypeName: 'ScriptRunnerListener__values',
+      idFields: ['description'],
+      fieldsToHide: [
+        { fieldName: 'createdByAccountId' },
+        { fieldName: 'createdTimestamp' },
+        { fieldName: 'updatedByAccountId' },
+        { fieldName: 'updatedTimestamp' },
+      ],
+    },
+  },
+  ScriptFragment: {
+    request: {
+      url: '/sr-dispatcher/jira/token/script-fragments',
+    },
+  },
+  ScheduledJob: {
+    request: {
+      url: '/sr-dispatcher/jira/rest/api/1/scheduled-scripts',
+    },
+  },
+  Behavior: {
+    request: {
+      url: '/sr-dispatcher/jira/rest/api/1/behaviours',
+    },
+  },
+  EscalationService: {
+    request: {
+      url: '/sr-dispatcher/jira/rest/api/1/escalation-scripts',
+    },
+  },
+  ScriptedField: {
+    request: {
+      url: '/sr-dispatcher/jira/rest/api/1/scripted-fields',
+    },
+    transformation: {
+      serviceIdField: 'uuid',
+      dataField: '.',
+      fieldsToHide: [
+        {
+          fieldName: 'uuid',
+        },
+        {
+          fieldName: 'auditData',
+        },
+      ],
+      fieldsToOmit: [
+        {
+          fieldName: 'issueTypes',
+        },
+      ],
+    },
+    deployRequests: {
+      add: {
+        url: '/sr-dispatcher/jira/rest/api/1/scripted-fields',
+        method: 'post',
+      },
+      modify: {
+        url: '/sr-dispatcher/jira/rest/api/1/scripted-fields/{uuid}',
+        method: 'put',
+      },
+      remove: {
+        url: '/sr-dispatcher/jira/rest/api/1/scripted-fields/{uuid}',
+        method: 'delete',
+      },
     },
   },
 }
 
 export const DUCKTYPE_SUPPORTED_TYPES = {
-  // ScripRunnerListeners: ['ScripRunnerListeners'],
+  // ScriptRunnerListener: ['ScriptRunnerListener'],
+  // ScriptFragment: ['ScriptFragment'],
+  // ScheduledJob: ['ScheduledJob'],
+  // Behavior: ['Behavior'],
+  // EscalationService: ['EscalationService'],
+  ScriptedField: ['ScriptedField'],
 }
 
 const TRANSFORMATION_DEFAULTS: configUtils.TransformationDefaultConfig = {

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1701,7 +1701,7 @@ const DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       ],
       fieldsToOmit: [
         {
-          fieldName: 'issueTypes',
+          fieldName: 'issueTypeIds',
         },
       ],
     },

--- a/packages/jira-adapter/src/constants.ts
+++ b/packages/jira-adapter/src/constants.ts
@@ -89,5 +89,13 @@ export const USERS_INSTANCE_NAME = 'users'
 export const MAIL_LIST_TYPE_NAME = 'MailList'
 export const FILTER_TYPE_NAME = 'Filter'
 export const SCRIPT_RUNNER_API_DEFINITIONS = 'scriptRunnerApiDefinitions'
+export const SCRIPT_RUNNER_LISTENER_TYPE = 'ScriptRunnerListener'
+export const SCRIPT_FRAGMENT_TYPE = 'ScriptFragment'
+export const SCHEDULED_JOB_TYPE = 'ScheduledJob'
+export const BEHAVIOR_TYPE = 'Behavior'
+export const ESCALATION_SERVICE_TYPE = 'EscalationService'
+export const SCRIPTED_FIELD_TYPE = 'ScriptedField'
+export const SCRIPT_RUNNER_TYPES = [SCRIPT_RUNNER_LISTENER_TYPE, SCRIPT_FRAGMENT_TYPE, SCHEDULED_JOB_TYPE,
+  BEHAVIOR_TYPE, ESCALATION_SERVICE_TYPE, SCRIPTED_FIELD_TYPE]
 // almost constant functions
 export const fetchFailedWarnings = (name :string):string => `Salto could not access the ${name} resource. Elements from that type were not fetched. Please make sure that this type is enabled in your service, and that the supplied user credentials have sufficient permissions to access this data. You can also exclude this data from Salto's fetches by changing the environment configuration. Learn more at https://help.salto.io/en/articles/6947061-salto-could-not-access-the-resource`

--- a/packages/jira-adapter/src/deployment/standard_deployment.ts
+++ b/packages/jira-adapter/src/deployment/standard_deployment.ts
@@ -18,7 +18,6 @@ import { config, deployment, client as clientUtils, elements as elementUtils } f
 import { resolveChangeElement, resolveValues } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections, values } from '@salto-io/lowerdash'
-import JiraClient from '../client/client'
 import { getLookUpName } from '../reference_mapping'
 
 const { awu } = collections.asynciterable
@@ -27,7 +26,7 @@ const log = logger(module)
 
 type DeployChangeParam = {
   change: Change<InstanceElement>
-  client: JiraClient
+  client: clientUtils.HTTPWriteClientInterface
   apiDefinitions: config.AdapterApiConfig
   fieldsToIgnore?: string[] | ((path: ElemID) => boolean)
   additionalUrlVars?: Record<string, string>

--- a/packages/jira-adapter/src/filter.ts
+++ b/packages/jira-adapter/src/filter.ts
@@ -18,6 +18,7 @@ import { filterUtils, elements as elementUtils } from '@salto-io/adapter-compone
 import JiraClient from './client/client'
 import { JiraConfig } from './config/config'
 import { GetUserMapFunc } from './users'
+import ScriptRunnerClient from './client/script_runner_client'
 
 export const { filtersRunner } = filterUtils
 
@@ -35,6 +36,7 @@ export type FilterAdditionalParams = {
   // and only when needed.
   adapterContext: Values
   getUserMapFunc: GetUserMapFunc
+  scriptRunnerClient: ScriptRunnerClient
 }
 
 export type FilterCreator = filterUtils.FilterCreator<

--- a/packages/jira-adapter/src/filters/script_runner/script_runner_filter.ts
+++ b/packages/jira-adapter/src/filters/script_runner/script_runner_filter.ts
@@ -1,0 +1,79 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { getChangeData, isInstanceChange, isObjectType, isAdditionChange,
+  isModificationChange, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { v4 as uuidv4 } from 'uuid'
+import { FilterCreator } from '../../filter'
+import { SCRIPT_RUNNER_TYPES } from '../../constants'
+import { addAnnotationRecursively, setTypeDeploymentAnnotations } from '../../utils'
+import { getCurrentUserInfo } from '../../users'
+
+const { awu } = collections.asynciterable
+
+const getTimeNowAsSeconds = (): number => Math.floor(Date.now() / 1000)
+
+// This filter is used to make script runner types deployable, and to manage the audit items
+const filter: FilterCreator = ({ client, config }) => ({
+  name: 'scriptRunnerFilter',
+  onFetch: async elements => {
+    if (!config.fetch.enableScriptRunnerAddon) {
+      return
+    }
+    await awu(elements)
+      .filter(isObjectType)
+      .filter(type => SCRIPT_RUNNER_TYPES.includes(type.elemID.typeName))
+      .forEach(async type => {
+        setTypeDeploymentAnnotations(type)
+        await addAnnotationRecursively(type, CORE_ANNOTATIONS.CREATABLE)
+        await addAnnotationRecursively(type, CORE_ANNOTATIONS.UPDATABLE)
+        await addAnnotationRecursively(type, CORE_ANNOTATIONS.DELETABLE)
+      })
+  },
+  preDeploy: async changes => {
+    if (!config.fetch.enableScriptRunnerAddon || client.isDataCenter) {
+      return
+    }
+
+    // update audit info
+    const currentUserInfo = await getCurrentUserInfo(client)
+
+    changes
+      .filter(isAdditionChange)
+      .filter(isInstanceChange)
+      .map(getChangeData)
+      .filter(instance => SCRIPT_RUNNER_TYPES.includes(instance.elemID.typeName))
+      .forEach(instance => {
+        instance.value.auditData = {
+          createdByAccountId: currentUserInfo?.userId ?? '',
+          createdTimestamp: getTimeNowAsSeconds(),
+        }
+        // generate uuid for new instances
+        instance.value.uuid = uuidv4()
+      })
+
+    changes
+      .filter(isModificationChange)
+      .filter(isInstanceChange)
+      .map(getChangeData)
+      .filter(instance => SCRIPT_RUNNER_TYPES.includes(instance.elemID.typeName))
+      .forEach(instance => {
+        instance.value.auditData.updatedByAccountId = currentUserInfo?.userId ?? ''
+        instance.value.auditData.updatedTimestamp = getTimeNowAsSeconds()
+      })
+  },
+})
+export default filter

--- a/packages/jira-adapter/src/filters/script_runner/script_runner_instances_deploy.ts
+++ b/packages/jira-adapter/src/filters/script_runner/script_runner_instances_deploy.ts
@@ -1,0 +1,58 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { getChangeData, isInstanceChange } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { defaultDeployChange, deployChanges } from '../../deployment/standard_deployment'
+import { FilterCreator } from '../../filter'
+
+// This filter deploys script runner instances
+const filter: FilterCreator = ({ scriptRunnerClient, config }) => ({
+  name: 'scripRunnerInstancesDeployFilter',
+  deploy: async changes => {
+    const { scriptRunnerApiDefinitions } = config
+    if (!config.fetch.enableScriptRunnerAddon || scriptRunnerApiDefinitions === undefined) {
+      return {
+        deployResult: { appliedChanges: [], errors: [] },
+        leftoverChanges: changes,
+      }
+    }
+
+    const [relevantChanges, leftoverChanges] = _.partition(
+      changes,
+      change => isInstanceChange(change)
+        && scriptRunnerApiDefinitions.types[getChangeData(change).elemID.typeName] !== undefined
+    )
+    if (relevantChanges.length === 0) {
+      return {
+        leftoverChanges,
+        deployResult: { errors: [], appliedChanges: [] },
+      }
+    }
+    const deployResult = await deployChanges(
+      changes.filter(isInstanceChange),
+      async change => {
+        await defaultDeployChange({
+          change,
+          client: scriptRunnerClient,
+          apiDefinitions: scriptRunnerApiDefinitions,
+        })
+      },
+    )
+    return { deployResult, leftoverChanges }
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/src/filters/script_runner/script_template_expressions.ts
+++ b/packages/jira-adapter/src/filters/script_runner/script_template_expressions.ts
@@ -18,7 +18,7 @@ import { extractTemplate, replaceTemplatesWithValues, resolveTemplates } from '@
 import { InstanceElement, isInstanceElement, TemplateExpression, ReferenceExpression, Element, Value, isAdditionOrModificationChange, getChangeData, isInstanceChange, TemplatePart } from '@salto-io/adapter-api'
 import { FilterCreator } from '../../filter'
 import { FIELD_TYPE_NAME } from '../fields/constants'
-import { referenceFunc, walkOnScripts } from './workflow/walk_on_scripts'
+import { referenceFunc, walkOnScripts } from './walk_on_scripts'
 
 const CUSTOM_FIELD_PATTERN = /(customfield_\d+)/
 

--- a/packages/jira-adapter/src/filters/script_runner/scripted_fields_issue_types.ts
+++ b/packages/jira-adapter/src/filters/script_runner/scripted_fields_issue_types.ts
@@ -30,11 +30,11 @@ const filter: FilterCreator = ({ config }) => ({
       .filter(isInstanceChange)
       .map(getChangeData)
       .filter(instance => instance.elemID.typeName === SCRIPTED_FIELD_TYPE)
-      .filter(instance => instance.value.issueTypeIds !== undefined)
+      .filter(instance => instance.value.issueTypes !== undefined)
       .forEach(instance => {
-        instance.value.issueTypes = instance.value.issueTypeIds
+        instance.value.issueTypeIds = instance.value.issueTypes
           .filter(isResolvedReferenceExpression)
-          .map((issueTypeId: ReferenceExpression) => issueTypeId.value.value.name)
+          .map((issueTypeId: ReferenceExpression) => issueTypeId.value.value.id)
       })
   },
   onDeploy: async changes => {
@@ -48,7 +48,7 @@ const filter: FilterCreator = ({ config }) => ({
       .map(getChangeData)
       .filter(instance => instance.elemID.typeName === SCRIPTED_FIELD_TYPE)
       .forEach(instance => {
-        delete instance.value.issueTypes
+        delete instance.value.issueTypeIds
       })
   },
 })

--- a/packages/jira-adapter/src/filters/script_runner/scripted_fields_issue_types.ts
+++ b/packages/jira-adapter/src/filters/script_runner/scripted_fields_issue_types.ts
@@ -1,0 +1,55 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { isResolvedReferenceExpression } from '@salto-io/adapter-utils'
+import { ReferenceExpression, isAdditionOrModificationChange, getChangeData, isInstanceChange } from '@salto-io/adapter-api'
+import { FilterCreator } from '../../filter'
+import { SCRIPTED_FIELD_TYPE } from '../../constants'
+
+// This filter is used to add the issue type names to the scripted fields
+const filter: FilterCreator = ({ config }) => ({
+  name: 'scriptedFieldsIssueTypesFilter',
+  preDeploy: async changes => {
+    if (!config.fetch.enableScriptRunnerAddon) {
+      return
+    }
+    changes
+      .filter(isAdditionOrModificationChange)
+      .filter(isInstanceChange)
+      .map(getChangeData)
+      .filter(instance => instance.elemID.typeName === SCRIPTED_FIELD_TYPE)
+      .filter(instance => instance.value.issueTypeIds !== undefined)
+      .forEach(instance => {
+        instance.value.issueTypes = instance.value.issueTypeIds
+          .filter(isResolvedReferenceExpression)
+          .map((issueTypeId: ReferenceExpression) => issueTypeId.value.value.name)
+      })
+  },
+  onDeploy: async changes => {
+    if (!config.fetch.enableScriptRunnerAddon) {
+      return
+    }
+
+    changes
+      .filter(isAdditionOrModificationChange)
+      .filter(isInstanceChange)
+      .map(getChangeData)
+      .filter(instance => instance.elemID.typeName === SCRIPTED_FIELD_TYPE)
+      .forEach(instance => {
+        delete instance.value.issueTypes
+      })
+  },
+})
+export default filter

--- a/packages/jira-adapter/src/filters/script_runner/walk_on_scripts.ts
+++ b/packages/jira-adapter/src/filters/script_runner/walk_on_scripts.ts
@@ -16,10 +16,10 @@
 
 import { walkOnValue, WalkOnFunc, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
 import { InstanceElement, Value } from '@salto-io/adapter-api'
-import { SCRIPT_RUNNER_DC_TYPES } from './workflow_dc'
-import { SCRIPT_RUNNER_CLOUD_TYPES } from './workflow_cloud'
-import { isWorkflowInstance } from '../../workflow/types'
-import { SCRIPT_RUNNER_TYPES } from '../../../constants'
+import { SCRIPT_RUNNER_DC_TYPES } from './workflow/workflow_dc'
+import { SCRIPT_RUNNER_CLOUD_TYPES } from './workflow/workflow_cloud'
+import { isWorkflowInstance } from '../workflow/types'
+import { SCRIPT_RUNNER_TYPES } from '../../constants'
 
 
 const WORKFLOW_SCRIPT_DC_FIELDS = ['FIELD_CONDITION', 'FIELD_ADDITIONAL_SCRIPT', 'FIELD_SCRIPT_FILE_OR_SCRIPT']

--- a/packages/jira-adapter/src/filters/script_runner/workflow/walk_on_scripts.ts
+++ b/packages/jira-adapter/src/filters/script_runner/workflow/walk_on_scripts.ts
@@ -19,10 +19,12 @@ import { InstanceElement, Value } from '@salto-io/adapter-api'
 import { SCRIPT_RUNNER_DC_TYPES } from './workflow_dc'
 import { SCRIPT_RUNNER_CLOUD_TYPES } from './workflow_cloud'
 import { isWorkflowInstance } from '../../workflow/types'
+import { SCRIPT_RUNNER_TYPES } from '../../../constants'
 
 
-const SCRIPT_DC_FIELDS = ['FIELD_CONDITION', 'FIELD_ADDITIONAL_SCRIPT', 'FIELD_SCRIPT_FILE_OR_SCRIPT']
-const SCRIPT_CLOUD_FIELDS = ['expression', 'additionalCode', 'emailCode', 'condition']
+const WORKFLOW_SCRIPT_DC_FIELDS = ['FIELD_CONDITION', 'FIELD_ADDITIONAL_SCRIPT', 'FIELD_SCRIPT_FILE_OR_SCRIPT']
+const WORKFLOW_SCRIPT_CLOUD_FIELDS = ['expression', 'additionalCode', 'emailCode', 'condition']
+const SCRIPT_CLOUD_FIELDS = ['script', 'executionCondition', 'codeToRun']
 
 export type referenceFunc = (value: Value, fieldName: string) => void
 
@@ -35,7 +37,7 @@ const walkOnCloudScripts = (func: (value: string, fieldName: string) => void)
     return WALK_NEXT_STEP.SKIP
   }
   if (isCloudScriptRunnerItem(value)) {
-    SCRIPT_CLOUD_FIELDS.forEach(fieldName => {
+    WORKFLOW_SCRIPT_CLOUD_FIELDS.forEach(fieldName => {
       if (value.configuration.scriptRunner[fieldName] != null) {
         func(value.configuration.scriptRunner, fieldName)
       }
@@ -54,7 +56,7 @@ const walkOnDcScripts = (func: referenceFunc)
     return WALK_NEXT_STEP.SKIP
   }
   if (isDCScriptRunnerItem(value)) {
-    SCRIPT_DC_FIELDS.forEach(fieldName => {
+    WORKFLOW_SCRIPT_DC_FIELDS.forEach(fieldName => {
       if (value.configuration[fieldName]?.script != null) {
         func(value.configuration[fieldName], 'script')
       }
@@ -80,5 +82,12 @@ export const walkOnScripts = (
               : walkOnCloudScripts(func) })
         }
       })
+    })
+  instances
+    .filter(instance => SCRIPT_RUNNER_TYPES.includes(instance.elemID.typeName))
+    .forEach(instance => {
+      Object.keys(instance.value)
+        .filter(key => SCRIPT_CLOUD_FIELDS.includes(key))
+        .forEach(key => func(instance.value, key))
     })
 }

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -22,7 +22,12 @@ import { AUTOMATION_PROJECT_TYPE, AUTOMATION_FIELD, AUTOMATION_COMPONENT_VALUE_T
   BOARD_ESTIMATION_TYPE, ISSUE_TYPE_NAME, ISSUE_TYPE_SCHEMA_NAME, AUTOMATION_STATUS,
   AUTOMATION_CONDITION, AUTOMATION_CONDITION_CRITERIA, AUTOMATION_SUBTASK,
   AUTOMATION_ROLE, AUTOMATION_GROUP, AUTOMATION_EMAIL_RECIPENT, PROJECT_TYPE,
-  SECURITY_LEVEL_TYPE, SECURITY_SCHEME_TYPE, STATUS_TYPE_NAME, WORKFLOW_TYPE_NAME, AUTOMATION_COMPARE_VALUE, AUTOMATION_TYPE, AUTOMATION_LABEL_TYPE, GROUP_TYPE_NAME, PRIORITY_SCHEME_TYPE_NAME, SCRIPT_RUNNER_TYPE, POST_FUNCTION_CONFIGURATION, RESOLUTION_TYPE_NAME, ISSUE_EVENT_TYPE_NAME, CONDITION_CONFIGURATION, PROJECT_ROLE_TYPE, VALIDATOR_CONFIGURATION, BOARD_TYPE_NAME, ISSUE_LINK_TYPE_NAME, DIRECTED_LINK_TYPE, MAIL_LIST_TYPE_NAME } from './constants'
+  SECURITY_LEVEL_TYPE, SECURITY_SCHEME_TYPE, STATUS_TYPE_NAME, WORKFLOW_TYPE_NAME,
+  AUTOMATION_COMPARE_VALUE, AUTOMATION_TYPE, AUTOMATION_LABEL_TYPE, GROUP_TYPE_NAME,
+  PRIORITY_SCHEME_TYPE_NAME, SCRIPT_RUNNER_TYPE, POST_FUNCTION_CONFIGURATION, RESOLUTION_TYPE_NAME,
+  ISSUE_EVENT_TYPE_NAME, CONDITION_CONFIGURATION, PROJECT_ROLE_TYPE, VALIDATOR_CONFIGURATION,
+  BOARD_TYPE_NAME, ISSUE_LINK_TYPE_NAME, DIRECTED_LINK_TYPE, MAIL_LIST_TYPE_NAME,
+  SCRIPT_RUNNER_LISTENER_TYPE, SCRIPTED_FIELD_TYPE } from './constants'
 import { getFieldsLookUpName } from './filters/fields/field_type_references_filter'
 import { getRefType } from './references/workflow_properties'
 import { FIELD_TYPE_NAME } from './filters/fields/constants'
@@ -874,6 +879,25 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     serializationStrategy: 'name',
     jiraMissingRefStrategy: 'typeAndValue',
     target: { type: PROJECT_ROLE_TYPE },
+  },
+  // ScriptRunner
+  {
+    src: { field: 'projects', parentTypes: [SCRIPT_RUNNER_LISTENER_TYPE] },
+    jiraSerializationStrategy: 'key',
+    jiraMissingRefStrategy: 'typeAndValue',
+    target: { type: PROJECT_TYPE },
+  },
+  {
+    src: { field: 'projectKeys', parentTypes: [SCRIPTED_FIELD_TYPE] },
+    jiraSerializationStrategy: 'key',
+    jiraMissingRefStrategy: 'typeAndValue',
+    target: { type: PROJECT_TYPE },
+  },
+  {
+    src: { field: 'issueTypeIds', parentTypes: [SCRIPTED_FIELD_TYPE] },
+    serializationStrategy: 'id',
+    jiraMissingRefStrategy: 'typeAndValue',
+    target: { type: ISSUE_TYPE_NAME },
   },
 ]
 

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -894,8 +894,8 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     target: { type: PROJECT_TYPE },
   },
   {
-    src: { field: 'issueTypeIds', parentTypes: [SCRIPTED_FIELD_TYPE] },
-    serializationStrategy: 'id',
+    src: { field: 'issueTypes', parentTypes: [SCRIPTED_FIELD_TYPE] },
+    serializationStrategy: 'name',
     jiraMissingRefStrategy: 'typeAndValue',
     target: { type: ISSUE_TYPE_NAME },
   },

--- a/packages/jira-adapter/test/adapter.test.ts
+++ b/packages/jira-adapter/test/adapter.test.ts
@@ -67,7 +67,6 @@ describe('adapter', () => {
     const config = createConfigInstance(getDefaultConfig({ isDataCenter: false }))
     config.value.client.usePrivateAPI = false
     config.value.fetch.convertUsersIds = false
-    config.value.fetch.enableScriptRunnerAddon = true
 
     adapter = adapterCreator.operations({
       elementsSource,
@@ -280,25 +279,21 @@ describe('adapter', () => {
         })
       )
     })
-    it('should call getAllElements', () => {
-      expect(getAllElements).toHaveBeenCalledTimes(1)
-    })
-
     it('should return all types and instances returned from the infrastructure', () => {
       expect(result.elements).toContain(platformTestType)
       expect(result.elements).toContain(jiraTestType)
       expect(result.elements).toContain(testInstance)
-      expect(result.elements).toContain(testInstance2)
+      expect(result.elements).not.toContain(testInstance2)
     })
   })
-  describe('no scriptRunner', () => {
+  describe('scriptRunner', () => {
     let srAdapter: AdapterOperations
     beforeEach(() => {
       const elementsSource = buildElementsSourceFromElements([])
       const config = createConfigInstance(getDefaultConfig({ isDataCenter: false }))
       config.value.client.usePrivateAPI = false
       config.value.fetch.convertUsersIds = false
-      config.value.fetch.enableScriptRunnerAddon = false
+      config.value.fetch.enableScriptRunnerAddon = true
 
       srAdapter = adapterCreator.operations({
         elementsSource,
@@ -358,7 +353,10 @@ describe('adapter', () => {
         expect(result.elements).toContain(platformTestType)
         expect(result.elements).toContain(jiraTestType)
         expect(result.elements).toContain(testInstance)
-        expect(result.elements).not.toContain(testInstance2)
+        expect(result.elements).toContain(testInstance2)
+      })
+      it('should call getAllElements', () => {
+        expect(getAllElements).toHaveBeenCalledTimes(1)
       })
     })
   })

--- a/packages/jira-adapter/test/change_validators/script_runner_unresolved_reference.test.ts
+++ b/packages/jira-adapter/test/change_validators/script_runner_unresolved_reference.test.ts
@@ -1,0 +1,116 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, ElemID, InstanceElement, toChange, UnresolvedReference, ReferenceExpression } from '@salto-io/adapter-api'
+import { brokenReferenceValidator } from '../../src/change_validators/broken_references'
+import { ISSUE_TYPE_NAME, JIRA, PROJECT_TYPE, SCRIPTED_FIELD_TYPE } from '../../src/constants'
+
+describe('automationProjectUnresolvedReferenceValidator', () => {
+  let scriptedFieldType: ObjectType
+  let projectType: ObjectType
+  let issueTypeType: ObjectType
+  let scriptedFieldInstance: InstanceElement
+  let projectInstance: InstanceElement
+  let issueTypeInstance: InstanceElement
+  let unresolvedProjectElemId: ElemID
+  let unresolvedIssueTypeElemId: ElemID
+
+  beforeEach(() => {
+    scriptedFieldType = new ObjectType({ elemID: new ElemID(JIRA, SCRIPTED_FIELD_TYPE) })
+    projectType = new ObjectType({ elemID: new ElemID(JIRA, PROJECT_TYPE) })
+    issueTypeType = new ObjectType({ elemID: new ElemID(JIRA, ISSUE_TYPE_NAME) })
+    projectInstance = new InstanceElement(
+      'ProjectInstance',
+      projectType,
+    )
+    issueTypeInstance = new InstanceElement(
+      'IssueTypeInstance',
+      issueTypeType,
+    )
+    unresolvedProjectElemId = new ElemID(JIRA, 'unresolvedProject')
+    unresolvedIssueTypeElemId = new ElemID(JIRA, 'unresolvedIssueType')
+    scriptedFieldInstance = new InstanceElement(
+      'scriptedFieldInstance',
+      scriptedFieldType,
+      {
+        projectKeys: [
+          new ReferenceExpression(projectInstance.elemID, projectInstance),
+          new ReferenceExpression(unresolvedProjectElemId, new UnresolvedReference(unresolvedProjectElemId)),
+
+        ],
+        issueTypes: [
+          new ReferenceExpression(issueTypeInstance.elemID, issueTypeInstance),
+          new ReferenceExpression(unresolvedIssueTypeElemId, new UnresolvedReference(unresolvedIssueTypeElemId)),
+        ],
+      },
+    )
+  })
+
+  it('should return a warning when project reference is unresolved', async () => {
+    expect(await brokenReferenceValidator(
+      [toChange({ after: scriptedFieldInstance })]
+    )).toEqual([
+      {
+        elemID: scriptedFieldInstance.elemID,
+        severity: 'Warning',
+        message: 'Scripted field won’t be attached to some issue types',
+        detailedMessage: 'The scripted field is attached to some issue types which do not exist in the target environment: unresolvedIssueType. If you continue, the scripted field will be deployed without them. Alternatively, you can go back and include these issue types in your deployment.',
+      },
+      {
+        elemID: scriptedFieldInstance.elemID,
+        severity: 'Warning',
+        message: 'Scripted field won’t be attached to some projects',
+        detailedMessage: 'The scripted field is attached to some projects which do not exist in the target environment: unresolvedProject. If you continue, the scripted field will be deployed without them. Alternatively, you can go back and include these projects in your deployment.',
+      },
+    ])
+  })
+  it('should not return a warning when there is not a project reference that is unresolved', async () => {
+    scriptedFieldInstance.value.projectKeys = [
+      new ReferenceExpression(projectType.elemID, projectInstance),
+    ]
+    scriptedFieldInstance.value.issueTypes = [
+      new ReferenceExpression(issueTypeInstance.elemID, issueTypeInstance),
+    ]
+
+    expect(await brokenReferenceValidator(
+      [toChange({ after: scriptedFieldInstance })]
+    )).toEqual([])
+  })
+  it('should return an error when all the projects references are unresolved', async () => {
+    scriptedFieldInstance.value.projectKeys = [
+      new ReferenceExpression(unresolvedProjectElemId, new UnresolvedReference(unresolvedProjectElemId)),
+    ]
+    scriptedFieldInstance.value.issueTypes = [
+      new ReferenceExpression(unresolvedIssueTypeElemId, new UnresolvedReference(unresolvedIssueTypeElemId)),
+    ]
+
+    expect(await brokenReferenceValidator(
+      [toChange({ after: scriptedFieldInstance })]
+    )).toEqual([
+      {
+        elemID: scriptedFieldInstance.elemID,
+        severity: 'Error',
+        message: 'Scripted field isn’t attached to any existing issue type',
+        detailedMessage: 'All issue types attached to this scripted field do not exist in the target environment: unresolvedIssueType. The scripted field can’t be deployed. To solve this, go back and include at least one attached issue type in your deployment.',
+      },
+      {
+        elemID: scriptedFieldInstance.elemID,
+        severity: 'Error',
+        message: 'Scripted field isn’t attached to any existing project',
+        detailedMessage: 'All projects attached to this scripted field do not exist in the target environment: unresolvedProject. The scripted field can’t be deployed. To solve this, go back and include at least one attached project in your deployment.',
+      },
+    ])
+  })
+})

--- a/packages/jira-adapter/test/filters/script_runner/script_runner_broken_reference.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/script_runner_broken_reference.test.ts
@@ -1,0 +1,150 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { ElemID, InstanceElement, ObjectType, toChange, ReferenceExpression } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import { createEmptyType, getFilterParams } from '../../utils'
+import scriptRunnerBrokenReferenceFilter from '../../../src/filters/broken_reference_filter'
+import { ISSUE_TYPE_NAME, JIRA, PROJECT_TYPE, SCRIPTED_FIELD_TYPE } from '../../../src/constants'
+
+describe('scriptRunnerBrokenReferenceFilter', () => {
+  let filter: filterUtils.FilterWith<'preDeploy' | 'onDeploy'>
+  let scriptedFieldsType: ObjectType
+  let projectType: ObjectType
+  let IssueTypeType: ObjectType
+  let scriptedFieldInstance: InstanceElement
+  let projectInstance: InstanceElement
+  let unresolvedProject: ReferenceExpression
+  let resolvedProject: ReferenceExpression
+  let unresolvedIssueType: ReferenceExpression
+  let resolvedIssueType: ReferenceExpression
+  let issueTypeInstance: InstanceElement
+
+
+  beforeEach(async () => {
+    filter = scriptRunnerBrokenReferenceFilter(getFilterParams()) as filterUtils.FilterWith<'preDeploy' | 'onDeploy'>
+    scriptedFieldsType = createEmptyType(SCRIPTED_FIELD_TYPE)
+    projectType = createEmptyType(PROJECT_TYPE)
+    IssueTypeType = createEmptyType(ISSUE_TYPE_NAME)
+    projectInstance = new InstanceElement(
+      'ProjectInstance',
+      projectType,
+    )
+    issueTypeInstance = new InstanceElement(
+      'IssueTypeInstance',
+      IssueTypeType,
+      { id: 'issueType1',
+        name: 'IssueTypeName1' }
+    )
+    resolvedProject = new ReferenceExpression(projectInstance.elemID, projectInstance)
+    unresolvedProject = new ReferenceExpression(new ElemID(JIRA, PROJECT_TYPE, 'instance', 'missing_1'), undefined)
+    resolvedIssueType = new ReferenceExpression(issueTypeInstance.elemID, issueTypeInstance)
+    unresolvedIssueType = new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'missing_2'), undefined)
+    scriptedFieldInstance = new InstanceElement(
+      'ScriptedFieldInstance',
+      scriptedFieldsType,
+      {
+        projectKeys: [
+          resolvedProject,
+          unresolvedProject,
+        ],
+        issueTypes: [
+          resolvedIssueType,
+          unresolvedIssueType,
+        ],
+      },
+    )
+  })
+
+  describe('preDeploy', () => {
+    it('should remove unresolved project from the instance for adding and modification', async () => {
+      const modificationInstance = scriptedFieldInstance.clone()
+      const deletedInstance = scriptedFieldInstance.clone()
+      await filter.preDeploy([
+        toChange({ after: scriptedFieldInstance }),
+        toChange({ before: scriptedFieldInstance, after: modificationInstance }),
+        toChange({ before: deletedInstance })])
+
+      expect(scriptedFieldInstance.value.projectKeys).toHaveLength(1)
+      expect(scriptedFieldInstance.value.issueTypes).toHaveLength(1)
+      expect(modificationInstance.value.projectKeys).toHaveLength(1)
+      expect(modificationInstance.value.issueTypes).toHaveLength(1)
+      expect(deletedInstance.value.projectKeys).toHaveLength(2)
+      expect(deletedInstance.value.issueTypes).toHaveLength(2)
+
+      expect(scriptedFieldInstance.value.projectKeys[0])
+        .toEqual(resolvedProject)
+      expect(scriptedFieldInstance.value.issueTypes[0])
+        .toEqual(resolvedIssueType)
+      expect(modificationInstance.value.projectKeys[0])
+        .toEqual(resolvedProject)
+      expect(modificationInstance.value.issueTypes[0])
+        .toEqual(resolvedIssueType)
+      expect(deletedInstance.value.projectKeys)
+        .toEqual([resolvedProject, unresolvedProject])
+      expect(deletedInstance.value.issueTypes)
+        .toEqual([resolvedIssueType, unresolvedIssueType])
+    })
+  })
+
+  describe('onDeploy', () => {
+    it('should add back unresolved project references to the instance when adding or modifying', async () => {
+      const modificationInstance = scriptedFieldInstance.clone()
+      const deletedInstance = scriptedFieldInstance.clone()
+
+      await filter.preDeploy([
+        toChange({ after: scriptedFieldInstance }),
+        toChange({ before: scriptedFieldInstance, after: modificationInstance }),
+        toChange({ before: deletedInstance })])
+
+      expect(scriptedFieldInstance.value.projectKeys).toHaveLength(1)
+      expect(modificationInstance.value.projectKeys).toHaveLength(1)
+      expect(deletedInstance.value.projectKeys).toHaveLength(2)
+      await filter.onDeploy([
+        toChange({ after: scriptedFieldInstance }),
+        toChange({ before: scriptedFieldInstance, after: modificationInstance }),
+        toChange({ before: deletedInstance })])
+
+      expect(scriptedFieldInstance.value.projectKeys).toHaveLength(2)
+      expect(scriptedFieldInstance.value.issueTypes).toHaveLength(2)
+      expect(modificationInstance.value.projectKeys).toHaveLength(2)
+      expect(modificationInstance.value.issueTypes).toHaveLength(2)
+      expect(deletedInstance.value.projectKeys).toHaveLength(2)
+      expect(deletedInstance.value.issueTypes).toHaveLength(2)
+
+
+      expect(scriptedFieldInstance.value.projectKeys)
+        .toEqual([resolvedProject, unresolvedProject])
+      expect(scriptedFieldInstance.value.issueTypes)
+        .toEqual([resolvedIssueType, unresolvedIssueType])
+      expect(modificationInstance.value.projectKeys)
+        .toEqual([resolvedProject, unresolvedProject])
+      expect(modificationInstance.value.issueTypes)
+        .toEqual([resolvedIssueType, unresolvedIssueType])
+      expect(deletedInstance.value.projectKeys)
+        .toEqual([resolvedProject, unresolvedProject])
+      expect(deletedInstance.value.issueTypes)
+        .toEqual([resolvedIssueType, unresolvedIssueType])
+    })
+    it('should not crash if onDeployCalled without predeploy', async () => {
+      await filter.onDeploy([
+        toChange({ after: scriptedFieldInstance }),
+      ])
+      expect(scriptedFieldInstance.value.projectKeys).toHaveLength(2)
+      expect(scriptedFieldInstance.value.issueTypes).toHaveLength(2)
+    })
+  })
+})

--- a/packages/jira-adapter/test/filters/script_runner/script_runner_filter.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/script_runner_filter.test.ts
@@ -1,0 +1,183 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { filterUtils } from '@salto-io/adapter-components'
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import scriptRunnerFilter from '../../../src/filters/script_runner/script_runner_filter'
+import { createEmptyType, getFilterParams } from '../../utils'
+import { getDefaultConfig } from '../../../src/config/config'
+import { JIRA, SCRIPTED_FIELD_TYPE } from '../../../src/constants'
+import * as users from '../../../src/users'
+
+type FilterType = filterUtils.FilterWith<'preDeploy' | 'onFetch'>
+
+jest.mock('uuid', () => ({
+  v4: jest.fn().mockReturnValue('my-uuid'),
+}))
+
+
+describe('script_runner_filter', () => {
+  let filter: FilterType
+  let instance: InstanceElement
+  describe('when script runner is enabled', () => {
+    beforeEach(() => {
+      const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+      config.fetch.enableScriptRunnerAddon = true
+      filter = scriptRunnerFilter(getFilterParams({ config })) as FilterType
+      const now = 10000
+      jest.spyOn(Date, 'now').mockReturnValueOnce(now)
+      jest.spyOn(users, 'getCurrentUserInfo').mockResolvedValueOnce({
+        userId: 'salto',
+        displayName: 'saltoName',
+      })
+    })
+    it('should add annotations to script runner types', async () => {
+      const scriptedFields = new ObjectType({
+        elemID: new ElemID(JIRA, SCRIPTED_FIELD_TYPE),
+        fields: {
+          notImportant: { refType: BuiltinTypes.STRING },
+        },
+      })
+      await filter.onFetch([scriptedFields])
+      expect(scriptedFields.annotations[CORE_ANNOTATIONS.CREATABLE]).toEqual(true)
+      expect(scriptedFields.annotations[CORE_ANNOTATIONS.UPDATABLE]).toEqual(true)
+      expect(scriptedFields.annotations[CORE_ANNOTATIONS.DELETABLE]).toEqual(true)
+      expect(scriptedFields.fields.notImportant.annotations[CORE_ANNOTATIONS.CREATABLE]).toEqual(true)
+      expect(scriptedFields.fields.notImportant.annotations[CORE_ANNOTATIONS.UPDATABLE]).toEqual(true)
+      expect(scriptedFields.fields.notImportant.annotations[CORE_ANNOTATIONS.DELETABLE]).toEqual(true)
+    })
+    describe('on creation', () => {
+      it('should add audit info', async () => {
+        instance = new InstanceElement(
+          'instance',
+          createEmptyType(SCRIPTED_FIELD_TYPE),
+          {}
+        )
+        await filter.preDeploy([toChange({ after: instance })])
+        expect(instance.value.auditData).toEqual({
+          createdByAccountId: 'salto',
+          createdTimestamp: 10,
+        })
+      })
+      it('should add uuid', async () => {
+        instance = new InstanceElement(
+          'instance',
+          createEmptyType(SCRIPTED_FIELD_TYPE),
+          {}
+        )
+        await filter.preDeploy([toChange({ after: instance })])
+        expect(instance.value.uuid).toEqual('my-uuid')
+      })
+      it('should add audit info when not defined', async () => {
+        instance = new InstanceElement(
+          'instance',
+          createEmptyType(SCRIPTED_FIELD_TYPE),
+          {}
+        )
+        jest.spyOn(users, 'getCurrentUserInfo').mockReset()
+        jest.spyOn(users, 'getCurrentUserInfo').mockResolvedValueOnce(undefined)
+        await filter.preDeploy([toChange({ after: instance })])
+        expect(instance.value.auditData).toEqual({
+          createdByAccountId: '',
+          createdTimestamp: 10,
+        })
+      })
+    })
+    describe('on update', () => {
+      it('should add audit info', async () => {
+        instance = new InstanceElement(
+          'instance',
+          createEmptyType(SCRIPTED_FIELD_TYPE),
+          {
+            auditData: {
+              createdByAccountId: 'not-salto',
+              createdTimestamp: 1,
+            },
+          }
+        )
+        await filter.preDeploy([toChange({ before: instance, after: instance })])
+        expect(instance.value.auditData).toEqual({
+          createdByAccountId: 'not-salto',
+          createdTimestamp: 1,
+          updatedByAccountId: 'salto',
+          updatedTimestamp: 10,
+        })
+      })
+      it('should not change the  uuid', async () => {
+        instance = new InstanceElement(
+          'instance',
+          createEmptyType(SCRIPTED_FIELD_TYPE),
+          {
+            uuid: 'not-my-uuid',
+            auditData: {
+              createdByAccountId: 'not-salto',
+              createdTimestamp: 1,
+            },
+          }
+        )
+        await filter.preDeploy([toChange({ before: instance, after: instance })])
+        expect(instance.value.uuid).toEqual('not-my-uuid')
+      })
+      it('should add audit info when not defined', async () => {
+        instance = new InstanceElement(
+          'instance',
+          createEmptyType(SCRIPTED_FIELD_TYPE),
+          {
+            auditData: {
+              createdByAccountId: 'not-salto',
+              createdTimestamp: 1,
+            },
+          }
+        )
+        jest.spyOn(users, 'getCurrentUserInfo').mockReset()
+        jest.spyOn(users, 'getCurrentUserInfo').mockResolvedValueOnce(undefined)
+        await filter.preDeploy([toChange({ before: instance, after: instance })])
+        expect(instance.value.auditData).toEqual({
+          createdByAccountId: 'not-salto',
+          createdTimestamp: 1,
+          updatedByAccountId: '',
+          updatedTimestamp: 10,
+        })
+      })
+    })
+  })
+  describe('when script runner is disabled', () => {
+    beforeEach(() => {
+      const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+      config.fetch.enableScriptRunnerAddon = false
+      filter = scriptRunnerFilter(getFilterParams({ config })) as FilterType
+    })
+    it('should not add annotations on fetch', async () => {
+      const scriptedFields = new ObjectType({
+        elemID: new ElemID(JIRA, SCRIPTED_FIELD_TYPE),
+        fields: {
+          notImportant: { refType: BuiltinTypes.STRING },
+        },
+      })
+      await filter.onFetch([scriptedFields])
+      expect(scriptedFields.annotations[CORE_ANNOTATIONS.CREATABLE]).toBeUndefined()
+    })
+    it('should not add audit info on creation', async () => {
+      instance = new InstanceElement(
+        'instance',
+        createEmptyType(SCRIPTED_FIELD_TYPE),
+        {}
+      )
+      await filter.preDeploy([toChange({ after: instance })])
+      expect(instance.value.auditData).toBeUndefined()
+    })
+  })
+})

--- a/packages/jira-adapter/test/filters/script_runner/script_runner_instance_deploy.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/script_runner_instance_deploy.test.ts
@@ -1,0 +1,98 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { filterUtils } from '@salto-io/adapter-components'
+import { InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import scriptRunnerInstanceDeploy from '../../../src/filters/script_runner/script_runner_instances_deploy'
+import { createEmptyType, getFilterParams } from '../../utils'
+import { getDefaultConfig } from '../../../src/config/config'
+import { SCRIPTED_FIELD_TYPE } from '../../../src/constants'
+import * as deployment from '../../../src/deployment/standard_deployment'
+
+
+type FilterType = filterUtils.FilterWith<'deploy'>
+
+describe('script_runner_instance_deploy', () => {
+  let filter: FilterType
+  let type: ObjectType
+  let scriptInstance1: InstanceElement
+  let scriptInstance2: InstanceElement
+  let instance3: InstanceElement
+
+  beforeEach(() => {
+    type = createEmptyType(SCRIPTED_FIELD_TYPE)
+    scriptInstance1 = new InstanceElement(
+      'instance',
+      type,
+    )
+    scriptInstance2 = new InstanceElement(
+      'instance2',
+      type,
+    )
+    instance3 = new InstanceElement(
+      'instance3',
+      createEmptyType('type'),
+    )
+    const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+    config.fetch.enableScriptRunnerAddon = true
+    filter = scriptRunnerInstanceDeploy(getFilterParams({ config })) as FilterType
+    jest.spyOn(deployment, 'deployChanges').mockResolvedValueOnce({
+      appliedChanges: [toChange({ after: scriptInstance1 })],
+      errors: [{ message: '123', severity: 'Warning' }],
+    })
+  })
+  it('should return correct applied changes and leftovers', async () => {
+    const res = await filter.deploy([
+      toChange({ after: scriptInstance1 }),
+      toChange({ after: scriptInstance2 }),
+      toChange({ after: instance3 }),
+    ])
+    expect(res.deployResult.appliedChanges).toEqual(
+      [toChange({ after: scriptInstance1 })],
+    )
+    expect(res.deployResult.errors).toEqual(
+      [{ message: '123', severity: 'Warning' }],
+    )
+    expect(res.leftoverChanges).toEqual(
+      [toChange({ after: instance3 })],
+    )
+  })
+  it('should return empty if no relevant changes', async () => {
+    const res = await filter.deploy([
+      toChange({ after: instance3 }),
+    ])
+    expect(res.deployResult.appliedChanges).toEqual([])
+    expect(res.deployResult.errors).toEqual([])
+    expect(res.leftoverChanges).toEqual(
+      [toChange({ after: instance3 })],
+    )
+  })
+  it('should not deploy if script runner is disabled', async () => {
+    const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+    config.fetch.enableScriptRunnerAddon = false
+    filter = scriptRunnerInstanceDeploy(getFilterParams({ config })) as FilterType
+    const res = await filter.deploy([
+      toChange({ after: scriptInstance1 }),
+      toChange({ after: scriptInstance2 }),
+      toChange({ after: instance3 }),
+    ])
+    expect(res.deployResult.appliedChanges).toEqual([])
+    expect(res.deployResult.errors).toEqual([])
+    expect(res.leftoverChanges).toEqual(
+      [toChange({ after: scriptInstance1 }), toChange({ after: scriptInstance2 }), toChange({ after: instance3 })],
+    )
+  })
+})

--- a/packages/jira-adapter/test/filters/script_runner/scripted_fields_issue_types.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/scripted_fields_issue_types.test.ts
@@ -1,0 +1,89 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { filterUtils } from '@salto-io/adapter-components'
+import { InstanceElement, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import scriptedFieldsIssueTypeFilter from '../../../src/filters/script_runner/scripted_fields_issue_types'
+import { createEmptyType, getFilterParams } from '../../utils'
+import { getDefaultConfig } from '../../../src/config/config'
+import { SCRIPTED_FIELD_TYPE } from '../../../src/constants'
+
+type FilterType = filterUtils.FilterWith<'onDeploy' | 'preDeploy'>
+
+describe('scripted_fields_issue_types', () => {
+  let filter: FilterType
+  let instance: InstanceElement
+  beforeEach(() => {
+    const scriptedFields = createEmptyType(SCRIPTED_FIELD_TYPE)
+    const issueTypes = createEmptyType('issueType')
+    const issueType1 = new InstanceElement(
+      'issueType1',
+      issueTypes,
+      {
+        name: 'issueType1',
+      }
+    )
+    const issueType2 = new InstanceElement(
+      'issueType2',
+      issueTypes,
+      {
+        name: 'issueType2',
+      }
+    )
+    instance = new InstanceElement(
+      'instance',
+      scriptedFields,
+      {
+        issueTypeIds: [
+          new ReferenceExpression(issueType1.elemID, issueType1),
+          new ReferenceExpression(issueType2.elemID, issueType2),
+        ],
+      }
+    )
+  })
+  describe('when script runner is enabled', () => {
+    beforeEach(() => {
+      const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+      config.fetch.enableScriptRunnerAddon = true
+      filter = scriptedFieldsIssueTypeFilter(getFilterParams({ config })) as FilterType
+    })
+    it('should add issueTypeNames on preDeploy', async () => {
+      await filter.preDeploy([toChange({ after: instance })])
+      expect(instance.value.issueTypes).toEqual(['issueType1', 'issueType2'])
+    })
+    it('should remove issueTypeNames on onDeploy', async () => {
+      instance.value.issueTypes = ['issueType1', 'issueType2']
+      await filter.onDeploy([toChange({ after: instance })])
+      expect(instance.value.issueTypes).toBeUndefined()
+    })
+  })
+  describe('when script runner is disabled', () => {
+    beforeEach(() => {
+      const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+      config.fetch.enableScriptRunnerAddon = false
+      filter = scriptedFieldsIssueTypeFilter(getFilterParams({ config })) as FilterType
+    })
+    it('should not add issueTypeNames on preDeploy when disabled', async () => {
+      await filter.preDeploy([toChange({ after: instance })])
+      expect(instance.value.issueTypes).toBeUndefined()
+    })
+    it('should not remove issueTypeNames on onDeploy when disabled', async () => {
+      instance.value.issueTypes = ['issueType1', 'issueType2']
+      await filter.onDeploy([toChange({ after: instance })])
+      expect(instance.value.issueTypes).toEqual(['issueType1', 'issueType2'])
+    })
+  })
+})

--- a/packages/jira-adapter/test/filters/script_runner/scripted_fields_issue_types.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/scripted_fields_issue_types.test.ts
@@ -33,6 +33,7 @@ describe('scripted_fields_issue_types', () => {
       'issueType1',
       issueTypes,
       {
+        id: '1',
         name: 'issueType1',
       }
     )
@@ -40,6 +41,7 @@ describe('scripted_fields_issue_types', () => {
       'issueType2',
       issueTypes,
       {
+        id: '2',
         name: 'issueType2',
       }
     )
@@ -47,7 +49,7 @@ describe('scripted_fields_issue_types', () => {
       'instance',
       scriptedFields,
       {
-        issueTypeIds: [
+        issueTypes: [
           new ReferenceExpression(issueType1.elemID, issueType1),
           new ReferenceExpression(issueType2.elemID, issueType2),
         ],
@@ -60,14 +62,14 @@ describe('scripted_fields_issue_types', () => {
       config.fetch.enableScriptRunnerAddon = true
       filter = scriptedFieldsIssueTypeFilter(getFilterParams({ config })) as FilterType
     })
-    it('should add issueTypeNames on preDeploy', async () => {
+    it('should add issueTypeIds on preDeploy', async () => {
       await filter.preDeploy([toChange({ after: instance })])
-      expect(instance.value.issueTypes).toEqual(['issueType1', 'issueType2'])
+      expect(instance.value.issueTypeIds).toEqual(['1', '2'])
     })
-    it('should remove issueTypeNames on onDeploy', async () => {
+    it('should remove issueTypeIdson onDeploy', async () => {
       instance.value.issueTypes = ['issueType1', 'issueType2']
       await filter.onDeploy([toChange({ after: instance })])
-      expect(instance.value.issueTypes).toBeUndefined()
+      expect(instance.value.issueTypeIds).toBeUndefined()
     })
   })
   describe('when script runner is disabled', () => {
@@ -76,14 +78,14 @@ describe('scripted_fields_issue_types', () => {
       config.fetch.enableScriptRunnerAddon = false
       filter = scriptedFieldsIssueTypeFilter(getFilterParams({ config })) as FilterType
     })
-    it('should not add issueTypeNames on preDeploy when disabled', async () => {
+    it('should not add issueTypeIds on preDeploy when disabled', async () => {
       await filter.preDeploy([toChange({ after: instance })])
-      expect(instance.value.issueTypes).toBeUndefined()
+      expect(instance.value.issueTypeIds).toBeUndefined()
     })
     it('should not remove issueTypeNames on onDeploy when disabled', async () => {
-      instance.value.issueTypes = ['issueType1', 'issueType2']
+      instance.value.issueTypeIds = ['1', '2']
       await filter.onDeploy([toChange({ after: instance })])
-      expect(instance.value.issueTypes).toEqual(['issueType1', 'issueType2'])
+      expect(instance.value.issueTypeIds).toEqual(['1', '2'])
     })
   })
 })

--- a/packages/jira-adapter/test/filters/script_runner/workflow/empty_account_ids.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/workflow/empty_account_ids.test.ts
@@ -16,11 +16,11 @@
 import { filterUtils } from '@salto-io/adapter-components'
 import { InstanceElement, toChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { createEmptyType, getFilterParams, mockClient } from '../../utils'
-import { SCRIPT_RUNNER_POST_FUNCTION_TYPE, SCRIPT_RUNNER_SEND_NOTIFICATIONS } from '../../../src/filters/script_runner/workflow/workflow_cloud'
-import emptyAccountIds from '../../../src/filters/script_runner/workflow/empty_account_ids'
-import { WORKFLOW_TYPE_NAME } from '../../../src/constants'
-import { getDefaultConfig } from '../../../src/config/config'
+import { createEmptyType, getFilterParams, mockClient } from '../../../utils'
+import { SCRIPT_RUNNER_POST_FUNCTION_TYPE, SCRIPT_RUNNER_SEND_NOTIFICATIONS } from '../../../../src/filters/script_runner/workflow/workflow_cloud'
+import emptyAccountIds from '../../../../src/filters/script_runner/workflow/empty_account_ids'
+import { WORKFLOW_TYPE_NAME } from '../../../../src/constants'
+import { getDefaultConfig } from '../../../../src/config/config'
 
 describe('ScriptRunner cloud empty account id', () => {
   let filter: filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>

--- a/packages/jira-adapter/test/filters/script_runner/workflow/workflow_cloud.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/workflow/workflow_cloud.test.ts
@@ -18,12 +18,12 @@ import { ElemID, InstanceElement, ObjectType, toChange, Value } from '@salto-io/
 import _ from 'lodash'
 import { gzip } from 'pako'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
-import { getFilterParams } from '../../utils'
-import { isCompressedObject } from '../../../src/filters/script_runner/workflow/workflow_cloud'
-import workflowFilter from '../../../src/filters/script_runner/workflow/workflow_filter'
-import { WORKFLOW_TYPE_NAME } from '../../../src/constants'
-import { getDefaultConfig } from '../../../src/config/config'
-import { renameKey } from '../../../src/utils'
+import { getFilterParams } from '../../../utils'
+import { isCompressedObject } from '../../../../src/filters/script_runner/workflow/workflow_cloud'
+import workflowFilter from '../../../../src/filters/script_runner/workflow/workflow_filter'
+import { WORKFLOW_TYPE_NAME } from '../../../../src/constants'
+import { getDefaultConfig } from '../../../../src/config/config'
+import { renameKey } from '../../../../src/utils'
 
 const SCRIPT_RUNNER_SEND_NOTIFICATIONS = 'com.adaptavist.sr.cloud.workflow.SendNotification'
 

--- a/packages/jira-adapter/test/filters/script_runner/workflow/workflow_dc.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/workflow/workflow_dc.test.ts
@@ -17,10 +17,10 @@ import { filterUtils } from '@salto-io/adapter-components'
 import { ElemID, InstanceElement, ObjectType, toChange, Value } from '@salto-io/adapter-api'
 import _ from 'lodash'
 
-import { getFilterParams, mockClient } from '../../utils'
-import workflowFilter from '../../../src/filters/script_runner/workflow/workflow_filter'
-import { CONDITION_CONFIGURATION, JIRA, POST_FUNCTION_CONFIGURATION, WORKFLOW_TYPE_NAME } from '../../../src/constants'
-import { getDefaultConfig } from '../../../src/config/config'
+import { getFilterParams, mockClient } from '../../../utils'
+import workflowFilter from '../../../../src/filters/script_runner/workflow/workflow_filter'
+import { CONDITION_CONFIGURATION, JIRA, POST_FUNCTION_CONFIGURATION, WORKFLOW_TYPE_NAME } from '../../../../src/constants'
+import { getDefaultConfig } from '../../../../src/config/config'
 
 
 const compareScriptObjectsBase64 = (obj1: string, obj2: string): void => {

--- a/packages/jira-adapter/test/filters/script_runner/workflow/workflow_link_type.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/workflow/workflow_link_type.test.ts
@@ -16,10 +16,10 @@
 import { filterUtils } from '@salto-io/adapter-components'
 import { InstanceElement, toChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { createEmptyType, getFilterParams, mockClient } from '../../utils'
-import orFilter from '../../../src/filters/script_runner/workflow/workflow_lists_parsing'
-import { WORKFLOW_TYPE_NAME } from '../../../src/constants'
-import { getDefaultConfig } from '../../../src/config/config'
+import { createEmptyType, getFilterParams, mockClient } from '../../../utils'
+import orFilter from '../../../../src/filters/script_runner/workflow/workflow_lists_parsing'
+import { WORKFLOW_TYPE_NAME } from '../../../../src/constants'
+import { getDefaultConfig } from '../../../../src/config/config'
 
 describe('ScriptRunner linkTypes in DC', () => {
   let filter: filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>

--- a/packages/jira-adapter/test/filters/script_runner/workflow/workflow_mail_lists.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/workflow/workflow_mail_lists.test.ts
@@ -17,10 +17,10 @@ import { filterUtils } from '@salto-io/adapter-components'
 import { InstanceElement, toChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
-import { createEmptyType, getFilterParams, mockClient } from '../../utils'
-import orFilter, { MAIL_LISTS_FIELDS } from '../../../src/filters/script_runner/workflow/workflow_lists_parsing'
-import { WORKFLOW_TYPE_NAME } from '../../../src/constants'
-import { getDefaultConfig } from '../../../src/config/config'
+import { createEmptyType, getFilterParams, mockClient } from '../../../utils'
+import orFilter, { MAIL_LISTS_FIELDS } from '../../../../src/filters/script_runner/workflow/workflow_lists_parsing'
+import { WORKFLOW_TYPE_NAME } from '../../../../src/constants'
+import { getDefaultConfig } from '../../../../src/config/config'
 
 
 describe('ScriptRunner mail lists in DC', () => {

--- a/packages/jira-adapter/test/filters/script_runner/workflow/workflow_ors.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/workflow/workflow_ors.test.ts
@@ -16,10 +16,10 @@
 import { filterUtils } from '@salto-io/adapter-components'
 import { InstanceElement, toChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { createEmptyType, getFilterParams, mockClient } from '../../utils'
-import orFilter, { OR_FIELDS } from '../../../src/filters/script_runner/workflow/workflow_lists_parsing'
-import { WORKFLOW_TYPE_NAME } from '../../../src/constants'
-import { getDefaultConfig } from '../../../src/config/config'
+import { createEmptyType, getFilterParams, mockClient } from '../../../utils'
+import orFilter, { OR_FIELDS } from '../../../../src/filters/script_runner/workflow/workflow_lists_parsing'
+import { WORKFLOW_TYPE_NAME } from '../../../../src/constants'
+import { getDefaultConfig } from '../../../../src/config/config'
 
 const REDUCED_OR_FIELDS = OR_FIELDS.filter(field => field !== 'FIELD_LINK_DIRECTION')
 describe('ScriptRunner ors in DC', () => {

--- a/packages/jira-adapter/test/filters/script_runner/workflow/workflow_references.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/workflow/workflow_references.test.ts
@@ -16,10 +16,10 @@
 import { filterUtils } from '@salto-io/adapter-components'
 import { ElemID, InstanceElement, ReferenceExpression, toChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { createEmptyType, getFilterParams, mockClient } from '../../utils'
-import referencesFilter from '../../../src/filters/script_runner/workflow/workflow_references'
-import { WORKFLOW_TYPE_NAME } from '../../../src/constants'
-import { getDefaultConfig } from '../../../src/config/config'
+import { createEmptyType, getFilterParams, mockClient } from '../../../utils'
+import referencesFilter from '../../../../src/filters/script_runner/workflow/workflow_references'
+import { WORKFLOW_TYPE_NAME } from '../../../../src/constants'
+import { getDefaultConfig } from '../../../../src/config/config'
 
 
 const resolvedInstance = new InstanceElement(

--- a/packages/jira-adapter/test/utils.ts
+++ b/packages/jira-adapter/test/utils.ts
@@ -25,6 +25,7 @@ import { FilterCreator } from '../src/filter'
 import { paginate } from '../src/client/pagination'
 import { GetUserMapFunc, getUserMapFuncCreator } from '../src/users'
 import { JIRA } from '../src/constants'
+import ScriptRunnerClient from '../src/client/script_runner_client'
 
 
 export const createCredentialsInstance = (credentials: Credentials): InstanceElement => (
@@ -56,6 +57,7 @@ type ClientWithMockConnection = {
   paginator: clientUtils.Paginator
   connection: MockInterface<clientUtils.APIConnection>
   getUserMapFunc: GetUserMapFunc
+  scriptRunnerClient: ScriptRunnerClient
 }
 export const mockClient = (isDataCenter = false): ClientWithMockConnection => {
   const connection = mockConnection()
@@ -79,7 +81,13 @@ export const mockClient = (isDataCenter = false): ClientWithMockConnection => {
     { paginationFuncCreator: paginate, client }
   )
   const getUserMapFunc = getUserMapFuncCreator(paginator, client.isDataCenter)
-  return { client, paginator, connection, getUserMapFunc }
+  const scriptRunnerClient = new ScriptRunnerClient({
+    credentials: {},
+    isDataCenter,
+    jiraClient: client,
+  })
+
+  return { client, paginator, connection, getUserMapFunc, scriptRunnerClient }
 }
 
 export const getDefaultAdapterConfig = async (): Promise<JiraConfig> => {


### PR DESCRIPTION
Added support for fetch and deployment for scripted fields

---

Added some filters and repaired deployment for all script runner items.
Also Added initial fetch for api_config, commented out.
I have split  the PR to two commits, as one was a folder restructure

---
_Release Notes_: 
Jira Adapter:
* Added support for scripted fields in ScriptRunner

---
_User Notifications_: 
Jira Adapter:
* Added support for scripted fields in ScriptRunner

