### PR TITLE
SALTO-4138: Added a check for unique scriptid of custom fields in states within workflows

### DIFF
--- a/packages/netsuite-adapter/src/change_validators/unique_fields.ts
+++ b/packages/netsuite-adapter/src/change_validators/unique_fields.ts
@@ -83,9 +83,9 @@ const getNestedScriptIDField = async (
   _.values(await elementsSource.get(elemID.createNestedID(...nestPath)))
     .map(val => val[SCRIPT_ID])
 
-const getWorkflowFields = (elem: Value): string[] => {
-  const customFieldsScriptid = _.values(_.get(elem.value, WORKFLOW_CUSTOM_FIELDS_PATH)).map(val => val[SCRIPT_ID])
-  const stateFieldsScriptid = _.values(_.get(elem.value, WORKFLOW_STATES_PATH))
+const getWorkflowFields = (elem: ChangeDataType): string[] => {
+  const customFieldsScriptid = getChangeNestedScriptIDField(elem, WORKFLOW_CUSTOM_FIELDS_PATH)
+  const stateFieldsScriptid = _.values(getChangeNestedField(elem, WORKFLOW_STATES_PATH))
     .flatMap(state => _.values(_.get(state, WORKFLOW_STATES_CUSTOM_FIELDS_PATH)))
     .map(val => val[SCRIPT_ID])
   return customFieldsScriptid.concat(stateFieldsScriptid)

--- a/packages/netsuite-adapter/src/change_validators/unique_fields.ts
+++ b/packages/netsuite-adapter/src/change_validators/unique_fields.ts
@@ -86,7 +86,7 @@ const getNestedScriptIDField = async (
 const getChangeWorkflowFields = (
   change: ChangeDataType,
 ): string[] =>
-  // custom fields and states' custom fields must have different prefix: "custworkflow" and "custwfstate"
+  // custom fields and states' custom fields must have a different prefix: "custworkflow" and "custwfstate"
   [..._.values(getChangeNestedField(change, WORKFLOW_CUSTOM_FIELDS_PATH)).map(val => val[SCRIPT_ID]),
     ..._.values(getChangeNestedField(change, WORKFLOW_STATES_PATH))
       .flatMap(state => _.values(_.get(state, WORKFLOW_STATES_CUSTOM_FIELDS_PATH)))
@@ -95,7 +95,7 @@ const getChangeWorkflowFields = (
 const getSourceWorkflowFields = async (
   { elemID, elementsSource }: GetterParams
 ): Promise<string[]> =>
-  // custom fields and states' custom fields must have different prefix: "custworkflow" and "custwfstate"
+  // custom fields and states' custom fields must have a different prefix: "custworkflow" and "custwfstate"
   _.values(await elementsSource.get(elemID))
     .map(elem => ({
       customFieldsScriptid: _.values(_.get(elem, WORKFLOW_CUSTOM_FIELDS_PATH)).map(val => val[SCRIPT_ID]),

--- a/packages/netsuite-adapter/test/change_validators/unique_fields.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/unique_fields.test.ts
@@ -346,7 +346,6 @@ describe('unique fields validator', () => {
 
   describe("Workflow and states' custom field unique `scriptid` field validator", () => {
     const testElements = getWorkflowElements()
-    // const testElementsStates = getWorkflowStatesElements()
     describe('Workflow custom field with a unique scriptid', () => {
       it('Should not have a change error when adding a new Workflow without a custom field/state', async () => {
         const emptyElement = new InstanceElement('empty', new ObjectType({ elemID: new ElemID(NETSUITE, WORKFLOW) }))
@@ -529,14 +528,14 @@ describe('unique fields validator', () => {
   describe('Multiple types', () => {
     const savedSearchTestInstances = getSavedSearchElements()
     const financialLayoutTestInstances = getFinancialLayoutElements()
-    const workflowCustomFieldTestInstances = getWorkflowElements()
+    const workflowTestInstances = getWorkflowElements()
     const scriptTestInstances = getScriptElements('restlet')
     const customRecordTestObjects = getCustomRecordElements()
     const customRecordTestChanges = getCustomRecordChanges(customRecordTestObjects)
 
     const idToValSavedSearch = getIDToVal(savedSearchTestInstances, FIELD_DEFAULT_NAME)
     const idToValFinancialLayout = getIDToVal(financialLayoutTestInstances, NAME_FIELD)
-    const idToValWorkflowCustomField = getIDToVal(workflowCustomFieldTestInstances)
+    const idToValWorkflowCustomField = getIDToVal(workflowTestInstances)
     const idToValScript = getIDToVal(scriptTestInstances, 'scriptcustomfields', 'scriptcustomfield')
     const idToVal = new Map([
       ...idToValSavedSearch,
@@ -554,14 +553,14 @@ describe('unique fields validator', () => {
           toChange({ after: savedSearchTestInstances.basic }),
           toChange({ after: financialLayoutTestInstances.basic }),
           toChange({ after: customRecordTestChanges.basic }),
-          toChange({ after: workflowCustomFieldTestInstances.basic }),
+          toChange({ after: workflowTestInstances.basic }),
           toChange({ after: scriptTestInstances.basic }),
         ], undefined, buildElementsSource(
           [
             savedSearchTestInstances.diffField, savedSearchTestInstances.basic,
             financialLayoutTestInstances.diffField, financialLayoutTestInstances.basic,
             customRecordTestObjects.diffField, customRecordTestObjects.basic,
-            workflowCustomFieldTestInstances.diffField, workflowCustomFieldTestInstances.basic,
+            workflowTestInstances.diffField, workflowTestInstances.basic,
             scriptTestInstances.diffField, scriptTestInstances.basic,
           ]
         ))
@@ -573,15 +572,15 @@ describe('unique fields validator', () => {
           toChange({ before: savedSearchTestInstances.basic, after: savedSearchTestInstances.sameField }),
           toChange({ before: financialLayoutTestInstances.basic, after: financialLayoutTestInstances.sameField }),
           toChange({ before: customRecordTestChanges.basic, after: customRecordTestChanges.sameField }),
-          toChange({ before: workflowCustomFieldTestInstances.basic,
-            after: workflowCustomFieldTestInstances.sameField }),
+          toChange({ before: workflowTestInstances.basic,
+            after: workflowTestInstances.sameField }),
           toChange({ before: scriptTestInstances.basic, after: scriptTestInstances.sameField }),
         ], undefined, buildElementsSource(
           [
             savedSearchTestInstances.diffField, savedSearchTestInstances.sameField,
             financialLayoutTestInstances.diffField, financialLayoutTestInstances.sameField,
             customRecordTestObjects.diffField, customRecordTestObjects.sameField,
-            workflowCustomFieldTestInstances.diffField, workflowCustomFieldTestInstances.sameField,
+            workflowTestInstances.diffField, workflowTestInstances.sameField,
             scriptTestInstances.diffField, scriptTestInstances.sameField,
           ]
         ))
@@ -595,14 +594,14 @@ describe('unique fields validator', () => {
           toChange({ after: savedSearchTestInstances.sameField }),
           toChange({ after: financialLayoutTestInstances.sameField }),
           toChange({ after: customRecordTestChanges.sameField }),
-          toChange({ after: workflowCustomFieldTestInstances.sameField }),
+          toChange({ after: workflowTestInstances.sameField }),
           toChange({ after: scriptTestInstances.sameField }),
         ], undefined, buildElementsSource(
           [
             savedSearchTestInstances.basic, savedSearchTestInstances.sameField,
             financialLayoutTestInstances.basic, financialLayoutTestInstances.sameField,
             customRecordTestObjects.basic, customRecordTestObjects.sameField,
-            workflowCustomFieldTestInstances.basic, workflowCustomFieldTestInstances.sameField,
+            workflowTestInstances.basic, workflowTestInstances.sameField,
             scriptTestInstances.basic, scriptTestInstances.sameField,
           ]
         ))
@@ -612,7 +611,7 @@ describe('unique fields validator', () => {
           savedSearchTestInstances.sameField.elemID,
           financialLayoutTestInstances.sameField.elemID,
           customRecordTestChanges.sameField.elemID,
-          workflowCustomFieldTestInstances.sameField.elemID,
+          workflowTestInstances.sameField.elemID,
           scriptTestInstances.sameField.elemID,
         ]))
       })
@@ -622,15 +621,15 @@ describe('unique fields validator', () => {
           toChange({ before: savedSearchTestInstances.diffField, after: savedSearchTestInstances.sameField }),
           toChange({ before: financialLayoutTestInstances.diffField, after: financialLayoutTestInstances.sameField }),
           toChange({ before: customRecordTestChanges.diffField, after: customRecordTestChanges.sameField }),
-          toChange({ before: workflowCustomFieldTestInstances.diffField,
-            after: workflowCustomFieldTestInstances.sameField }),
+          toChange({ before: workflowTestInstances.diffField,
+            after: workflowTestInstances.sameField }),
           toChange({ before: scriptTestInstances.diffField, after: scriptTestInstances.sameField }),
         ], undefined, buildElementsSource(
           [
             savedSearchTestInstances.basic, savedSearchTestInstances.sameField,
             financialLayoutTestInstances.basic, financialLayoutTestInstances.sameField,
             customRecordTestObjects.basic, customRecordTestObjects.sameField,
-            workflowCustomFieldTestInstances.basic, workflowCustomFieldTestInstances.sameField,
+            workflowTestInstances.basic, workflowTestInstances.sameField,
             scriptTestInstances.basic, scriptTestInstances.sameField,
           ]
         ))
@@ -640,7 +639,7 @@ describe('unique fields validator', () => {
           savedSearchTestInstances.sameField.elemID,
           financialLayoutTestInstances.sameField.elemID,
           customRecordTestChanges.sameField.elemID,
-          workflowCustomFieldTestInstances.sameField.elemID,
+          workflowTestInstances.sameField.elemID,
           scriptTestInstances.sameField.elemID,
         ]))
       })


### PR DESCRIPTION
_Added states of workflows to the unique fields change validator_

---

_Additional context for reviewer_
_Incident: https://salto-io.atlassian.net/browse/INCIDENT-7262?focusedCommentId=95306&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-95306_


---
_Release Notes_: 
_Users will get an error when trying to deploy a workflow which contains a state with a custom field that has a non-unique scriptid_

---
_User Notifications_: 
_None_
