### PR TITLE
SAAS-8197 define dependency type for errors

### DIFF
--- a/packages/adapter-api/src/error.ts
+++ b/packages/adapter-api/src/error.ts
@@ -18,12 +18,12 @@ import { ElemID } from './element_id'
 
 export type SeverityLevel = 'Error' | 'Warning' | 'Info'
 
-export type SaltoErrorSource = 'config'
+export type SaltoErrorType = 'config' | 'dependency'
 
 export type SaltoError = {
     message: string
     severity: SeverityLevel
-    source?: SaltoErrorSource
+    type?: SaltoErrorType
 }
 
 export type SaltoElementError = SaltoError & {

--- a/packages/core/src/core/deploy/deploy_actions.ts
+++ b/packages/core/src/core/deploy/deploy_actions.ts
@@ -18,7 +18,7 @@ import {
   AdapterOperations, getChangeData, Change,
   isAdditionOrModificationChange,
   DeployExtraProperties, DeployOptions, Group,
-  SaltoElementError, SaltoError, SeverityLevel, DeployResult, ChangeDataType,
+  SaltoElementError, SaltoError, SeverityLevel, DeployResult, ChangeDataType, SaltoErrorType,
 } from '@salto-io/adapter-api'
 import { detailedCompare, applyDetailedChanges } from '@salto-io/adapter-utils'
 import { WalkError, NodeSkippedError } from '@salto-io/dag'
@@ -173,6 +173,7 @@ export const deployActions = async (
               groupId: item.groupKey,
               message: `Element ${key} was not deployed, as it depends on element ${nodeError.causingNode} which failed to deploy`,
               severity: 'Error' as SeverityLevel,
+              type: 'dependency' as SaltoErrorType,
             })))
         } else if (nodeError instanceof WalkDeployError) {
           deployErrors.push(...nodeError.errors.map(deployError => ({ ...deployError, groupId: item.groupKey })))

--- a/packages/core/src/core/deploy/deploy_actions.ts
+++ b/packages/core/src/core/deploy/deploy_actions.ts
@@ -171,7 +171,7 @@ export const deployActions = async (
             ({
               elemID: getChangeData(change).elemID,
               groupId: item.groupKey,
-              message: `Element ${key} was not deployed, as it depends on element ${nodeError.causingNode} which failed to deploy`,
+              message: `Element was not deployed, as it depends on ${nodeError.causingNode} which failed to deploy`,
               severity: 'Error' as SeverityLevel,
               type: 'dependency' as SaltoErrorType,
             })))

--- a/packages/core/src/core/plan/filter.ts
+++ b/packages/core/src/core/plan/filter.ts
@@ -17,7 +17,7 @@ import wu from 'wu'
 import _ from 'lodash'
 
 import { DataNodeMap, DiffGraph, DiffNode } from '@salto-io/dag'
-import { ChangeError, ChangeValidator, getChangeData, ElemID, ObjectType, ChangeDataType, isField, isObjectType, ReadOnlyElementsSource, SeverityLevel, DependencyError, Change, isAdditionChange, isRemovalChange, toChange, isFieldChange, Field, isObjectTypeChange, cloneDeepWithoutRefs } from '@salto-io/adapter-api'
+import { ChangeError, ChangeValidator, getChangeData, ElemID, ObjectType, ChangeDataType, isField, isObjectType, ReadOnlyElementsSource, SeverityLevel, DependencyError, Change, isAdditionChange, isRemovalChange, toChange, isFieldChange, Field, isObjectTypeChange, cloneDeepWithoutRefs, SaltoErrorType } from '@salto-io/adapter-api'
 import { values, collections } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 
@@ -93,6 +93,7 @@ const createDependencyErr = (causeID: ElemID, droppedID: ElemID): DependencyErro
   message: 'Element cannot be deployed due to an error in its dependency',
   detailedMessage: `${droppedID.getFullName()} cannot be deployed due to an error in its dependency ${causeID.getFullName()}. Please resolve that error and try again.`,
   severity: 'Error' as SeverityLevel,
+  type: 'dependency' as SaltoErrorType,
 })
 
 const buildValidDiffGraph = (

--- a/packages/lang-server/src/workspace.ts
+++ b/packages/lang-server/src/workspace.ts
@@ -263,7 +263,7 @@ export class EditorWorkspace {
             // in this class to avoid recalculating the entire workspace validation errors on
             // each update. Thus, we take from workspace.errors only the config validation errors
             ...validation,
-            ...workspaceErrors.validation.filter((err: SaltoError) => err.source === 'config'),
+            ...workspaceErrors.validation.filter((err: SaltoError) => err.type === 'config'),
           ],
         }))
       }

--- a/packages/workspace/src/workspace/adapters_config_source.ts
+++ b/packages/workspace/src/workspace/adapters_config_source.ts
@@ -178,7 +178,7 @@ export const buildAdaptersConfigSource = async ({
 
   const createConfigError = <T extends SaltoError>(error: T): T => {
     const configError = _.clone(error)
-    configError.source = 'config'
+    configError.type = 'config'
     return configError
   }
 

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -892,7 +892,7 @@ export const loadWorkspace = async (
 
   const getErrorSourceRange = async <T extends SaltoElementError>(error: T):
   Promise<SourceRange[]> => (
-    error.source === 'config'
+    error.type === 'config'
       ? adaptersConfig.getSourceRanges(error.elemID)
       : (await getLoadedNaclFilesSource()).getSourceRanges(currentEnv(), error.elemID)
   )

--- a/packages/workspace/test/workspace/adapters_config.test.ts
+++ b/packages/workspace/test/workspace/adapters_config.test.ts
@@ -197,7 +197,7 @@ describe('adapters config', () => {
     validationErrorsMap.values.mockReturnValue(awu([[new validator.InvalidValueValidationError({ elemID: new ElemID('someID'), value: 'val', fieldName: 'field', expectedValue: 'expVal' })]]))
 
     const errs = await configSource.getErrors()
-    expect(wu(errs.all()).every(err => err.source === 'config')).toBeTruthy()
+    expect(wu(errs.all()).every(err => err.type === 'config')).toBeTruthy()
   })
 
   it('should remove undefined values when setting the configuration', async () => {

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -646,7 +646,7 @@ describe('workspace', () => {
       const mockAdaptersConfig = mockAdaptersConfigSource()
       const ws = await createWorkspace(undefined, undefined, undefined, mockAdaptersConfig)
       const error = new InvalidValueValidationError({ elemID: new ElemID('someID'), value: 'val', fieldName: 'field', expectedValue: 'expVal' });
-      (error as SaltoError).source = 'config'
+      (error as SaltoError).type = 'config'
       await ws.transformError(error)
       expect(mockAdaptersConfig.getSourceRanges).toHaveBeenCalled()
     })


### PR DESCRIPTION
Add 'dependency' to new `SaltoErrorType` to determine whether an error is a dependency error

---



---
_Release Notes_: _None_

---
_User Notifications_: _None_