### PR TITLE
SALTO-4594 fix the restore flow for modify instance change

### DIFF
--- a/packages/core/src/core/restore.ts
+++ b/packages/core/src/core/restore.ts
@@ -31,6 +31,12 @@ const splitDetailedChangeByPath = async (
   if (_.isEmpty(changeHints) || isRemovalChange(change)) {
     return [change]
   }
+  if (changeHints.length === 1) {
+    return [{
+      ...change,
+      path: changeHints[0],
+    }]
+  }
   return Promise.all(changeHints.map(async hint => {
     const filteredChange = await applyFunctionToChangeData(
       change,

--- a/packages/core/test/core/restore.test.ts
+++ b/packages/core/test/core/restore.test.ts
@@ -223,6 +223,8 @@ describe('restore', () => {
           expect(modifyChange?.id).toEqual(singlePathInstMergedAfter.elemID
             .createNestedID('nested').createNestedID('str'))
           expect(modifyChange?.path).toEqual(['salto', 'inst', 'simple'])
+          expect(modifyChange?.data.before).toEqual('Str')
+          expect(modifyChange?.data.after).toEqual('modified')
         })
       })
     })


### PR DESCRIPTION
SALTO-4594 fix the restore flow for modify instance change


before this fix modify changes in instances return without data as it was excluded in the new `filterByPathHint` func.
the tests did not caught this bug as it did not checked the data of the changes.

---

_Release Notes_: 
None

---
_User Notifications_: 
None

---
