### PR TITLE
SALTO-4025: match files referenced in suiteScripts that don't start with path prefix

### DIFF
--- a/packages/netsuite-adapter/src/filters/element_references.ts
+++ b/packages/netsuite-adapter/src/filters/element_references.ts
@@ -132,7 +132,6 @@ const getServiceElemIDsFromPaths = (
   serviceIdToElemID: ServiceIdRecords,
   customRecordFieldsToServiceIds: ServiceIdRecords,
   element: InstanceElement,
-  // fileNames: Set<string>,
 ): ElemID[] =>
   foundReferences
     .flatMap(ref => {


### PR DESCRIPTION
_match files referenced in suiteScripts that don't start with path prefix_

---

_The ticket - https://salto-io.atlassian.net/browse/SALTO-4025
This PR might cause audit noise, need communication before a noisy deployment._

---
_Release Notes_: 
_Netsuite Adapter_:
* file references in suiteScripts that dont start with a path prefix will be added to generated dependencies

---
_User Notifications_: 
*_file references in suiteScripts that dont start with a path prefix will be added to generated dependencies_
