### PR TITLE
SALTO-4601: bump Xcode version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,7 @@ jobs:
 
   test_cli_mac:
     macos:
-      xcode: 13.2.1
+      xcode: 14.3.1
 
     steps:
       - set_s3_pkg_urls

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,7 @@ jobs:
 
   test_cli_mac:
     macos:
-      xcode: 14.3.1
+      xcode: 14.2.0
 
     steps:
       - set_s3_pkg_urls


### PR DESCRIPTION
Fix a version problem in circle CI

---

None

---
_Release Notes_: 
None

---
_User Notifications_: 
None
