### PR TITLE
SALTO-4025: log paths without path prefix instead of adding them

### DIFF
--- a/packages/netsuite-adapter/src/filters/element_references.ts
+++ b/packages/netsuite-adapter/src/filters/element_references.ts
@@ -135,9 +135,11 @@ const getServiceElemIDsFromPaths = (
 ): ElemID[] =>
   foundReferences
     .flatMap(ref => {
-      const absolutePath = pathPrefixRegex.test(ref)
-        ? resolveRelativePath(element.value[PATH], ref)
-        : FILE_CABINET_PATH_SEPARATOR.concat(ref)
+      const absolutePath = resolveRelativePath(element.value[PATH], ref)
+      // TODO: The log should be removed when SALTO-4025 is communicated.
+      if (!pathPrefixRegex.test(ref)) {
+        log.debug('Found a possible file reference without a path prefix: %s', ref)
+      }
       return [ref, absolutePath].concat(
         osPath.extname(absolutePath) === '' && osPath.extname(element.value[PATH]) !== ''
           ? [absolutePath.concat(osPath.extname(element.value[PATH]))]

--- a/packages/netsuite-adapter/src/filters/element_references.ts
+++ b/packages/netsuite-adapter/src/filters/element_references.ts
@@ -138,9 +138,13 @@ const getServiceElemIDsFromPaths = (
       const absolutePath = resolveRelativePath(element.value[PATH], ref)
       // TODO: The log should be removed when SALTO-4025 is communicated.
       if (!pathPrefixRegex.test(ref)) {
-        log.debug('Found a possible file reference without a path prefix: %s', ref)
+        const maybeServiceIdRecord = serviceIdToElemID[FILE_CABINET_PATH_SEPARATOR.concat(ref)]
+        if (_.isPlainObject(maybeServiceIdRecord)) {
+          log.debug('Found a file reference without a path prefix: %s', ref)
+        }
+        return [ref]
       }
-      return [ref, absolutePath].concat(
+      return [absolutePath].concat(
         osPath.extname(absolutePath) === '' && osPath.extname(element.value[PATH]) !== ''
           ? [absolutePath.concat(osPath.extname(element.value[PATH]))]
           : []

--- a/packages/netsuite-adapter/test/filters/element_references.test.ts
+++ b/packages/netsuite-adapter/test/filters/element_references.test.ts
@@ -538,21 +538,7 @@ describe('instance_references filter', () => {
         isPartial: false,
         config: await getDefaultAdapterConfig(),
       }).onFetch?.([fileInstance, noExtensionInstance, fileWithExtension])
-      expect(fileInstance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toHaveLength(2)
-      expect(fileInstance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toEqual(expect.arrayContaining([
-        {
-          reference: new ReferenceExpression(
-            noExtensionInstance.elemID.createNestedID(PATH)
-          ),
-          occurrences: undefined,
-        },
-        {
-          reference: new ReferenceExpression(
-            fileWithExtension.elemID.createNestedID(PATH)
-          ),
-          occurrences: undefined,
-        },
-      ]))
+      expect(fileInstance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeUndefined()
     })
 
     it('should add generated dependency from comment', async () => {


### PR DESCRIPTION
_log paths without path prefix instead of adding them until communicated_

---

_we should log the references instead of adding them until PROD-125 is communicated_

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
