### PR TITLE
SALTO-4604: Improve remote map performance when iterating over entries

### DIFF
--- a/packages/core/src/local-workspace/remote_map/counters.ts
+++ b/packages/core/src/local-workspace/remote_map/counters.ts
@@ -61,7 +61,7 @@ const createLocationCounters = (location: string): LocationCounters => {
     ...COUNTER_TYPES.map(counterType => [counterType, createCounter()]),
     ['dump', () => {
       log.debug('Remote Map Stats for location \'%s\': %o',
-        location, Object.fromEntries(COUNTER_TYPES.map(counterType => [counterType, counters[counterType]])))
+        location, Object.fromEntries(COUNTER_TYPES.map(counterType => [counterType, counters[counterType].value()])))
     }],
   ])
   return counters


### PR DESCRIPTION
Prefer using the cache over deserializing as it tends to be faster

---

_Additional context for reviewer_

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_