### PR TITLE
Upgrade SDF to rely on a new JAR download URL based on 2023.1.0

### DIFF
--- a/packages/netsuite-adapter/package.json
+++ b/packages/netsuite-adapter/package.json
@@ -36,7 +36,7 @@
     "@salto-io/file": "0.3.45",
     "@salto-io/logging": "0.3.45",
     "@salto-io/lowerdash": "0.3.45",
-    "@salto-io/suitecloud-cli": "1.6.2-salto-3",
+    "@salto-io/suitecloud-cli": "1.6.2-salto-4",
     "ajv": "^7.1.1",
     "async-lock": "^1.2.4",
     "axios": "^0.26.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3015,10 +3015,10 @@
     lodash "^4.17.21"
     moo "^0.5.2"
 
-"@salto-io/suitecloud-cli@1.6.2-salto-3":
-  version "1.6.2-salto-3"
-  resolved "https://registry.yarnpkg.com/@salto-io/suitecloud-cli/-/suitecloud-cli-1.6.2-salto-3.tgz#2194378de9a6045de8110b18131e2a9ace4622f5"
-  integrity sha512-QCZgpArknCoUTjbKNKdzo7YsT9NRxTH6cI8i+eU05MXCpPDykTFKD7N+NJHRuMtPHZE2SdXu1uy74ZcKcJyRkA==
+"@salto-io/suitecloud-cli@1.6.2-salto-4":
+  version "1.6.2-salto-4"
+  resolved "https://registry.yarnpkg.com/@salto-io/suitecloud-cli/-/suitecloud-cli-1.6.2-salto-4.tgz#5ed19d8e408bb9c15dcd1b5364b426b2a9bf3a35"
+  integrity sha512-DOzvW5pplIdYpSdt2jYZPkk24pShYi3h5IS1uY/z1bYfzh4hZEryUhggRWeJOBRisKZiJ78SZhDC8mGoVTZfkQ==
   dependencies:
     "@salto-io/logging" "<0.4.0"
     chalk "4.1.2"


### PR DESCRIPTION
_Replace me with a description of the changes in this PR_

---

_Additional context for reviewer_

---
_Release Notes_: 
Upgrade SDF to rely on a new JAR download URL based on 2023.1.0

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
