### PR TITLE
SALTO-4608: turn default alias config flag to true for all adapters

### DIFF
--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -151,6 +151,7 @@ export const PARTIAL_DEFAULT_CONFIG: Omit<JiraConfig, 'apiDefinitions'> = {
     hideTypes: true,
     enableMissingReferences: true,
     removeDuplicateProjectRoles: true,
+    addAlias: true,
 
   },
   deploy: {
@@ -347,6 +348,7 @@ export const configType = createMatchingObjectType<Partial<JiraConfig>>({
       'masking',
       'fetch.hideTypes',
       'fetch.enableMissingReferences',
+      'fetch.addAlias',
       SCRIPT_RUNNER_API_DEFINITIONS]),
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },

--- a/packages/jira-adapter/test/filters/add_alias.test.ts
+++ b/packages/jira-adapter/test/filters/add_alias.test.ts
@@ -101,6 +101,16 @@ describe('add alias filter', () => {
         undefined,
       ])
     })
+    it('should not add alias if flag is false', async () => {
+      config.fetch.addAlias = false
+      filter = filterCreator(getFilterParams({ client, config })) as FilterType
+      const dashboardGadgetInstance = new InstanceElement('instance2', dashboardGadgetType, { title: 'gadget name alias' })
+      const elements = [
+        dashboardGadgetInstance,
+      ]
+      await filter.onFetch(elements)
+      expect(dashboardGadgetInstance.annotations[CORE_ANNOTATIONS.ALIAS]).not.toBeDefined()
+    })
     it('should not crush when one of the values is undefined', async () => {
       const dashboardGadgetInstanceInvalid = new InstanceElement(
         'instance1',

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -2546,7 +2546,7 @@ export const DEFAULT_CONFIG: ZendeskConfig = {
     enableMissingReferences: true,
     resolveOrganizationIDs: false,
     includeAuditDetails: false,
-    addAlias: false,
+    addAlias: true,
   },
   [API_DEFINITIONS_CONFIG]: {
     typeDefaults: {
@@ -2756,7 +2756,7 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
         {
           enableMissingReferences: { refType: BuiltinTypes.BOOLEAN },
           includeAuditDetails: { refType: BuiltinTypes.BOOLEAN },
-          addAlias: { refType: BuiltinTypes.BOOLEAN }, // SALTO-3662 this flag should become true by default
+          addAlias: { refType: BuiltinTypes.BOOLEAN },
           greedyAppReferences: { refType: BuiltinTypes.BOOLEAN },
           appReferenceLocators: { refType: IdLocatorType },
           guide: { refType: GuideType },


### PR DESCRIPTION
turn default alias config flag to true for all adapters
PR https://github.com/salto-io/salto/pull/4611 is for netsuite
PR https://github.com/salto-io/salto/pull/4734 is for salesforce

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* annotation _alias will be added by default

jira:
* annotation _alias will be added by default

---
_User Notifications_: 
zendesk:
* annotation _alias will be added to the relevant nacls by default

jira:
* annotation _alias will be added to the relevant nacls by default
