### PR TITLE
SALTO-4609: Added core change validators to Salesforce Adapter.

### DIFF
--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -48,7 +48,7 @@ import dataCategoryGroupValidator from './change_validators/data_category_group'
 import SalesforceClient from './client/client'
 import { ChangeValidatorName, DEPLOY_CONFIG, SalesforceConfig } from './types'
 
-const { createChangeValidator } = deployment.changeValidators
+const { createChangeValidator, getDefaultChangeValidators } = deployment.changeValidators
 
 type ChangeValidatorCreator = (config: SalesforceConfig,
                                isSandbox: boolean,
@@ -89,6 +89,7 @@ export const changeValidators: Record<ChangeValidatorName, ChangeValidatorCreato
   unknownPicklistValues: () => unknownPicklistValues,
   installedPackages: () => installedPackages,
   dataCategoryGroup: () => dataCategoryGroupValidator,
+  ...getDefaultChangeValidators(),
 }
 
 const createSalesforceChangeValidator = ({ config, isSandbox, checkOnly, client }: {

--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -89,7 +89,7 @@ export const changeValidators: Record<ChangeValidatorName, ChangeValidatorCreato
   unknownPicklistValues: () => unknownPicklistValues,
   installedPackages: () => installedPackages,
   dataCategoryGroup: () => dataCategoryGroupValidator,
-  ...getDefaultChangeValidators(),
+  ..._.mapValues(getDefaultChangeValidators(), validator => (() => validator)),
 }
 
 const createSalesforceChangeValidator = ({ config, isSandbox, checkOnly, client }: {

--- a/packages/salesforce-adapter/test/change_validator.test.ts
+++ b/packages/salesforce-adapter/test/change_validator.test.ts
@@ -155,4 +155,7 @@ describe('createSalesforceChangeValidator', () => {
       })
     })
   })
+  it('should include the default change validators from core', () => {
+    expect(changeValidators).toContainKeys(Object.keys(deployment.changeValidators.getDefaultChangeValidators()))
+  })
 })


### PR DESCRIPTION
Added core change validators to Salesforce Adapter.

---

This caused flows where users where not blocked when the deploy scope did not contain required dependencies.

---
_Release Notes_: 
Salesforce Adapter:
- Deploys that miss required missing dependencies will be blocked.

---
_User Notifications_: 
_None_
