### PR TITLE
SALTO-4613: Remove redundant log when creating gadget references in Jira

### DIFF
--- a/packages/jira-adapter/src/references/dashboard_gadget_properties.ts
+++ b/packages/jira-adapter/src/references/dashboard_gadget_properties.ts
@@ -33,7 +33,7 @@ const GADGET_VALUE_SCHEME = Joi.object({
   value: Joi.string().allow('').required(),
 }).unknown(true)
 
-const isGadgetObject = createSchemeGuard<GadgetValue>(GADGET_VALUE_SCHEME, 'Invalid gadget value')
+const isGadgetObject = createSchemeGuard<GadgetValue>(GADGET_VALUE_SCHEME)
 
 export const gadgetValuesContextFunc: referenceUtils.ContextFunc = async ({ instance, fieldPath }) => {
   if (fieldPath === undefined) {


### PR DESCRIPTION
We accidentally logged error when iterating gadget values to create references, I removed this cause it's not an error

---
_Release Notes_: 
None

---
_User Notifications_: 
None
