### PR TITLE
SALTO-4612 - Remove CPU intensive log from SF adapter

### DIFF
--- a/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
+++ b/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
@@ -66,11 +66,7 @@ type InstanceAndResult = {
 const logErroredInstances = (instancesAndResults: InstanceAndResult[]): void => (
   instancesAndResults.forEach(({ instance, result }) => {
     if (result.errors !== undefined) {
-      log.error(`Instance ${instance.elemID.getFullName()} had deploy errors - ${['', ...result.errors].join('\n\t')}
-
-and values -
-${safeJsonStringify(instance.value, undefined, 2,)}
-`)
+      log.error(`Instance ${instance.elemID.getFullName()} had deploy errors - ${['', ...result.errors].join('\n\t')}`)
     }
   })
 )

--- a/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
+++ b/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
+import { inspect } from 'util'
 import { logger } from '@salto-io/logging'
 import { collections, hash, strings, promises, values } from '@salto-io/lowerdash'
 import {
@@ -66,7 +67,11 @@ type InstanceAndResult = {
 const logErroredInstances = (instancesAndResults: InstanceAndResult[]): void => (
   instancesAndResults.forEach(({ instance, result }) => {
     if (result.errors !== undefined) {
-      log.error(`Instance ${instance.elemID.getFullName()} had deploy errors - ${['', ...result.errors].join('\n\t')}`)
+      log.error(`Instance ${instance.elemID.getFullName()} had deploy errors - ${['', ...result.errors].join('\n\t')}
+
+and values -
+${inspect(instance.value)}
+`)
     }
   })
 )


### PR DESCRIPTION
Remove CPU intensive log from SF adapter

---

_Additional context for reviewer_
This would get stuck in some cases where we needed to serialize profiles.

---
_Release Notes_: 
Resolve some rare cases where deploy would get stuck.

---
_User Notifications_: 
Resolve some rare cases where deploy would get stuck.