### PR TITLE
SALTO-4626: do not treat CredentialError differently in validateCredentials and fetch

### DIFF
--- a/packages/adapter-api/src/error.ts
+++ b/packages/adapter-api/src/error.ts
@@ -57,6 +57,3 @@ export const createSaltoElementError = ({
 }): SaltoElementError => ({ message, severity, elemID })
 
 export class CredentialError extends Error {}
-
-export const isCredentialError = (error: unknown): error is CredentialError =>
-  error instanceof CredentialError

--- a/packages/adapter-api/test/error.test.ts
+++ b/packages/adapter-api/test/error.test.ts
@@ -17,21 +17,12 @@
 import {
   createSaltoElementError,
   createSaltoElementErrorFromError,
-  CredentialError,
-  isCredentialError, isSaltoError,
+  isSaltoError,
 } from '../src/error'
 import { ElemID } from '../src/element_id'
 import { toChange } from '../src/change'
 import { InstanceElement, ObjectType } from '../src/elements'
 
-describe('is credential error', () => {
-  it('should return false', () => {
-    expect(isCredentialError(new Error('test'))).toBeFalsy()
-  })
-  it('should return true', () => {
-    expect(isCredentialError(new CredentialError('test'))).toBeTruthy()
-  })
-})
 describe('create saltoElementError', () => {
   const elemId = new ElemID('adapter', 'test')
   it('should create correctly from error', () => {

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { AdapterOperations, BuiltinTypes, CORE_ANNOTATIONS, Element, ElemID, InstanceElement, ObjectType, PrimitiveType, PrimitiveTypes, Adapter, isObjectType, isEqualElements, isAdditionChange, ChangeDataType, AdditionChange, isInstanceElement, isModificationChange, DetailedChange, ReferenceExpression, Field, CredentialError, getChangeData, toChange, SeverityLevel, GetAdditionalReferencesFunc, Change } from '@salto-io/adapter-api'
+import { AdapterOperations, BuiltinTypes, CORE_ANNOTATIONS, Element, ElemID, InstanceElement, ObjectType, PrimitiveType, PrimitiveTypes, Adapter, isObjectType, isEqualElements, isAdditionChange, ChangeDataType, AdditionChange, isInstanceElement, isModificationChange, DetailedChange, ReferenceExpression, Field, getChangeData, toChange, SeverityLevel, GetAdditionalReferencesFunc, Change } from '@salto-io/adapter-api'
 import * as workspace from '@salto-io/workspace'
 import { collections } from '@salto-io/lowerdash'
 import { mockFunction, MockInterface } from '@salto-io/test-utils'
@@ -269,14 +269,9 @@ describe('api.ts', () => {
       beforeAll(() => {
         ws = mockWorkspace({ stateElements: [] })
       })
-      it('to return credential error', async () => {
-        mockFetchChanges.mockRejectedValueOnce(new CredentialError('test'))
-        const result = await api.fetch(ws, undefined, [mockService])
-        expect(result).toEqual(expect.objectContaining({ fetchErrors: expect.arrayContaining([{ message: 'test', severity: 'Error' }]) }))
-      })
-      it('throw unexpected error', async () => {
+      it('should throw an error upon failure', async () => {
         mockFetchChanges.mockRejectedValueOnce(new Error('test'))
-        await expect(api.fetch(ws, undefined, [mockService])).rejects.toThrow()
+        await expect(api.fetch(ws, undefined, [mockService])).rejects.toThrow(new Error('test'))
       })
     })
   })


### PR DESCRIPTION
There is an implicit assumption that whenever the adapter fails due to invalid credentials in fetch or validateCredentials flows, an CredentialError will be thrown from the adapter.
We found that there are cases that this doesn't really happen and we wouldn't like to count on it and behave differently in such cases.

---
_Release Notes_: 
Core:
SALTO-4626: identify credentials error in fetch, deploy and validateCredentials flows

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
