### PR TITLE
SALTO-4617 - Salesforce: keep empty profile sections in minify_deployment

### DIFF
--- a/packages/salesforce-adapter/src/filters/minify_deploy.ts
+++ b/packages/salesforce-adapter/src/filters/minify_deploy.ts
@@ -92,6 +92,18 @@ const toMinifiedChange = async (
       newLayoutAssignmentNames,
     )
   }
+
+  /**
+   * Other filters downstream may rely on the presence of specific sections, so let's make sure we don't completely
+   * remove them even if we don't deploy any of their contents.
+   */
+  const profileSections = _(after.value)
+    .pickBy(_.isPlainObject)
+    .mapValues(() => ({}))
+    .value()
+
+  minifiedAfter.value = _.assign(profileSections, minifiedAfter.value)
+
   return toChange({
     before,
     after: minifiedAfter,

--- a/packages/salesforce-adapter/src/filters/profile_permissions.ts
+++ b/packages/salesforce-adapter/src/filters/profile_permissions.ts
@@ -115,7 +115,11 @@ const isAdminProfileChange = async (change: Change): Promise<boolean> => {
 
 /**
  * Profile permissions filter.
- * creates default Admin Profile.fieldsPermissions and Profile.objectsPermissions.
+ * If any object types were added, add them to the Admin profile's objectPermissions section. Do the same with added
+ * fields and fieldPermissions. This ensures that at least one user will have permissions to view/edit the newly created
+ * objects/fields.
+ * Typically, this also ensures that the next fetch will contain the new objects/fields, because the fetching user is
+ * usually an Admin.
  */
 const filterCreator: LocalFilterCreator = () => {
   let isPartialAdminProfile = false


### PR DESCRIPTION
Keep all the sections of profiles, even if `minify_deployment` determines there's nothing interesting to deploy in them.

---

The `profile_permissions` filter assumes the `fieldPermissions` and `objectPermissions` sections exist. If a new object is added, it will try to add permissions for it to the Admin profile's `objectPermissions` section. But because that section was removed by `minify_deployment` (since it contained no changes), `profile_permissions` crashes.

---
_Release Notes_: 
Salesforce: Fix crash when deploying profiles along with new custom object types.

---
_User Notifications_: 
N/A
