### PR TITLE
SALTO-4597 add log to determine which instances are causing convertMa…

### DIFF
--- a/packages/salesforce-adapter/src/filters/convert_maps.ts
+++ b/packages/salesforce-adapter/src/filters/convert_maps.ts
@@ -244,13 +244,15 @@ const convertInstanceFieldsToMaps = async (
   instanceMapFieldDef: Record<string, MapDef>,
 ): Promise<string[]> => {
   const nonUniqueMapFields = _.uniq(instancesToConvert.flatMap(
-    instance => convertArraysToMaps(instance, instanceMapFieldDef)
+    instance => {
+      const nonUniqueFields = convertArraysToMaps(instance, instanceMapFieldDef)
+      if (nonUniqueFields.length > 0) {
+        log.info(`Instance ${instance.elemID.getFullName()} has non-unique map fields: ${nonUniqueFields}`)
+      }
+      return nonUniqueFields
+    }
   ))
   if (nonUniqueMapFields.length > 0) {
-    log.info(`Converting the following fields to non-unique maps: ${nonUniqueMapFields},
-     instances types are: ${
-  await awu(instancesToConvert).map(inst => metadataType(inst)).toArray()
-}`)
     instancesToConvert.forEach(instance => {
       convertValuesToMapArrays(instance, nonUniqueMapFields, instanceMapFieldDef)
     })


### PR DESCRIPTION
…ps to decide to convert inner value to list

---

In LwcResources.LwcResource, there are times where we determine the type as `Map<salesforce.LwcResource>` and others where we determine the type as `Map<List<salesforce.LwcResource>>`. This can cause issues when cloning elements from one environment to another since we don't copy the type. Since the root cause is unknown, updating the log that might allow us to determine what is going on.

---
_Release Notes_:  _None_
---
_User Notifications_: _None_