### PR TITLE
SALTO-4627: Improved Metadata aliases

### DIFF
--- a/packages/salesforce-adapter/src/filters/custom_metadata_to_object_type.ts
+++ b/packages/salesforce-adapter/src/filters/custom_metadata_to_object_type.ts
@@ -24,7 +24,7 @@ import {
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
-import { LocalFilterCreator } from '../filter'
+import { FilterContext, LocalFilterCreator } from '../filter'
 import {
   CUSTOM_METADATA,
   CUSTOM_METADATA_SUFFIX,
@@ -41,13 +41,13 @@ const { awu, groupByAsync } = collections.asynciterable
 const createCustomMetadataRecordType = async (
   instance: InstanceElement,
   customMetadataType: ObjectType,
-  skipAliases: boolean
+  config: FilterContext
 )
   : Promise<ObjectType> => {
   const objectType = await createCustomTypeFromCustomObjectInstance({
     instance,
     metadataType: CUSTOM_METADATA,
-    skipAliases,
+    config,
   })
   objectType.fields = {
     ...objectType.fields,
@@ -89,7 +89,7 @@ const filterCreator: LocalFilterCreator = ({ config }) => {
         .filter(e => e.elemID.name.endsWith(CUSTOM_METADATA_SUFFIX))
 
       const customMetadataRecordTypes = await awu(customMetadataInstances)
-        .map(instance => createCustomMetadataRecordType(instance, customMetadataType, config.fetchProfile.isFeatureEnabled('skipAliases')))
+        .map(instance => createCustomMetadataRecordType(instance, customMetadataType, config))
         .toArray()
       _.pullAll(elements, customMetadataInstances)
       customMetadataRecordTypes.forEach(e => elements.push(e))

--- a/packages/salesforce-adapter/src/filters/utils.ts
+++ b/packages/salesforce-adapter/src/filters/utils.ts
@@ -69,7 +69,7 @@ import {
   apiName,
   defaultApiName,
   isCustomObject,
-  isNameField,
+  isNameField, MetadataInstanceElement,
   metadataType,
   MetadataValues,
   Types,
@@ -442,3 +442,17 @@ export const isStandardObject = async (objectType: ObjectType): Promise<boolean>
   await isCustomObject(objectType)
   && !ENDS_WITH_CUSTOM_SUFFIX_REGEX.test(await safeApiName(objectType) ?? '')
 )
+
+export const getInstanceAlias = async (
+  instance: MetadataInstanceElement,
+  useLabelAsAlias: boolean
+): Promise<string> => {
+  const label = instance.value[LABEL]
+  if (!useLabelAsAlias || label === undefined) {
+    return instance.value[INSTANCE_FULL_NAME_FIELD]
+  }
+  const namespace = await getNamespace(instance)
+  return namespace === undefined
+    ? label
+    : `${label} (${namespace})`
+}

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -87,6 +87,7 @@ export type OptionalFeatures = {
   fetchCustomObjectUsingRetrieveApi?: boolean
   generateRefsInProfiles?: boolean
   fetchProfilesUsingReadApi?: boolean
+  useLabelAsAlias?: boolean
 }
 
 export type ChangeValidatorName = (
@@ -634,6 +635,7 @@ const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
     fetchCustomObjectUsingRetrieveApi: { refType: BuiltinTypes.BOOLEAN },
     generateRefsInProfiles: { refType: BuiltinTypes.BOOLEAN },
     fetchProfilesUsingReadApi: { refType: BuiltinTypes.BOOLEAN },
+    useLabelAsAlias: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,


### PR DESCRIPTION
Changed the aliases as for the plan described on the ticket.

---

Here are examples per different use-cases:
1. Instance with label: https://github.com/salto-io/tamir-sf/blob/alias/envs/env1/salesforce/Records/CMT2__mdt/CMT2_Record1.nacl
2. Instance with label from a namespace: https://github.com/salto-io/tamir-sf/blob/alias/envs/env1/salesforce/InstalledPackages/sbaa/Records/PermissionSet/sbaa__AdvancedApprovalsUser.nacl 
3. Custom Settings: https://github.com/salto-io/tamir-sf/blob/alias/envs/env1/salesforce/Objects/MyCustomSettings__c/MyCustomSettings__cAnnotations.nacl 
4. Custom Object from a namespace: https://github.com/salto-io/tamir-sf/blob/alias/envs/env1/salesforce/InstalledPackages/SBQQ/Objects/SBQQ__AttributeSet__c/SBQQ__AttributeSet__cAnnotations.nacl
5. Layout from a Namespace: https://github.com/salto-io/tamir-sf/blob/18d592e69d6f769de6d6711079dc9014a9e41039/envs/env1/salesforce/InstalledPackages/SBQQ/Objects/SBQQ__AttributeSet__c/Layout/SBQQ__Attribute_Set_Layout.nacl#L80C13-L80C34

- Added the option to use **fullName** instead of label (By providing **useLabelAsAlias = false** in the config)

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
