### PR TITLE
SALTO-4638 Allow filtering in zendesk by title, raw title, type, key

### DIFF
--- a/packages/adapter-components/src/elements/query/fetch_criteria.ts
+++ b/packages/adapter-components/src/elements/query/fetch_criteria.ts
@@ -13,9 +13,13 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import _ from 'lodash'
 import { regex } from '@salto-io/lowerdash'
 import { QueryCriterion } from './query'
 
-export const nameCriterion: QueryCriterion = ({ instance, value }): boolean => (
-  regex.isFullRegexMatch(instance.value.name, value)
+
+export const fieldCriterionCreator = (fieldName: string): QueryCriterion => ((
+  ({ instance, value }): boolean => regex.isFullRegexMatch(_.get(instance.value, fieldName), value))
 )
+
+export const nameCriterion = fieldCriterionCreator('name')

--- a/packages/adapter-components/src/elements/query/index.ts
+++ b/packages/adapter-components/src/elements/query/index.ts
@@ -14,4 +14,4 @@
 * limitations under the License.
 */
 export { ALL_TYPES, INCLUDE_ALL_CONFIG, ElementQuery, QueryCriterion, createElementQuery, createMockQuery } from './query'
-export { nameCriterion } from './fetch_criteria'
+export { nameCriterion, fieldCriterionCreator } from './fetch_criteria'

--- a/packages/adapter-components/test/elements/query/fetch_criteria.test.ts
+++ b/packages/adapter-components/test/elements/query/fetch_criteria.test.ts
@@ -14,9 +14,92 @@
 * limitations under the License.
 */
 import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
-import { nameCriterion } from '../../../src/elements/query'
+import { fieldCriterionCreator, nameCriterion } from '../../../src/elements/query'
 
 describe('fetch_criteria', () => {
+  describe('fieldCriterionCreator', () => {
+    it('should match element field value when equal', () => {
+      const instance = new InstanceElement(
+        'instance',
+        new ObjectType({ elemID: new ElemID('adapter', 'type') }),
+        {
+          name: 'name',
+          nested: {
+            value: 'xyz',
+          },
+        },
+      )
+
+      expect(fieldCriterionCreator('name')({ instance, value: '.ame' })).toBeTruthy()
+      expect(fieldCriterionCreator('name')({ instance, value: 'ame' })).toBeFalsy()
+    })
+    it('should match element nested field value when equal', () => {
+      const instance = new InstanceElement(
+        'instance',
+        new ObjectType({ elemID: new ElemID('adapter', 'type') }),
+        {
+          name: 'name',
+          nested: {
+            value: 'xyz',
+          },
+        },
+      )
+
+      expect(fieldCriterionCreator('nested.value')({ instance, value: '.y.' })).toBeTruthy()
+      expect(fieldCriterionCreator('nested.value')({ instance, value: '.z' })).toBeFalsy()
+    })
+
+    it('should not match element when field value does not exist', () => {
+      const instance = new InstanceElement(
+        'instance',
+        new ObjectType({ elemID: new ElemID('adapter', 'type') }),
+        {
+          name: 'name',
+          nested: {
+            value: 'xyz',
+          },
+        },
+      )
+
+      expect(fieldCriterionCreator('val')({ instance, value: '.ame' })).toBeFalsy()
+      expect(fieldCriterionCreator('nested.and.missing')({ instance, value: '.ame' })).toBeFalsy()
+    })
+
+    it('should not match element when field value is not a string', () => {
+      expect(fieldCriterionCreator('val')({
+        instance: new InstanceElement(
+          'instance',
+          new ObjectType({ elemID: new ElemID('adapter', 'type') }),
+          {
+            val: ['bla'],
+          },
+        ),
+        value: '.ame',
+      })).toBeFalsy()
+      expect(fieldCriterionCreator('key')({
+        instance: new InstanceElement(
+          'instance',
+          new ObjectType({ elemID: new ElemID('adapter', 'type') }),
+          {
+            key: 123,
+          },
+        ),
+        value: '.ame',
+      })).toBeFalsy()
+      expect(fieldCriterionCreator('name')({
+        instance: new InstanceElement(
+          'instance',
+          new ObjectType({ elemID: new ElemID('adapter', 'type') }),
+          {
+            name: {
+              value: 'name',
+            },
+          },
+        ),
+        value: '.ame',
+      })).toBeFalsy()
+    })
+  })
   describe('name', () => {
     it('should match element name when equal', () => {
       const instance = new InstanceElement(

--- a/packages/zendesk-adapter/config_doc.md
+++ b/packages/zendesk-adapter/config_doc.md
@@ -98,3 +98,7 @@ zendesk {
 | Name                                        | Default when undefined            | Description
 |---------------------------------------------|-----------------------------------|------------
 | name                                        | .*                                | A regex used to filter instances by matching the regex to their name value
+| key                                         | .*                                | A regex used to filter instances by matching the regex to the value of their key field
+| raw_title                                   | .*                                | A regex used to filter instances by matching the regex to their raw_title value
+| title                                       | .*                                | A regex used to filter instances by matching the regex to their title value
+| type                                        | .*                                | A regex used to filter instances by matching the regex to the value of their type field

--- a/packages/zendesk-adapter/src/fetch_criteria.ts
+++ b/packages/zendesk-adapter/src/fetch_criteria.ts
@@ -17,4 +17,8 @@ import { elements as elementUtils } from '@salto-io/adapter-components'
 
 export default {
   name: elementUtils.query.nameCriterion,
+  key: elementUtils.query.fieldCriterionCreator('key'),
+  raw_title: elementUtils.query.fieldCriterionCreator('raw_title'),
+  title: elementUtils.query.fieldCriterionCreator('title'),
+  type: elementUtils.query.fieldCriterionCreator('type'),
 }

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -1195,8 +1195,12 @@ describe('adapter', () => {
                 include: [
                   { type: 'automation' },
                   { type: 'custom_role', criteria: { name: 'A.*' } },
+                  { type: 'organization_field', criteria: { key: '.*_.*', type: 'dropdown' } },
+                  { type: 'ticket_field', criteria: { raw_title: 'A.*|agent.*' } },
                 ],
-                exclude: [],
+                exclude: [
+                  { type: 'ticket_field', criteria: { type: 'assignee' } },
+                ],
                 guide: {
                   brands: ['.*'],
                 },
@@ -1213,8 +1217,11 @@ describe('adapter', () => {
           'zendesk.automation.instance.Tag_tickets_from_Social@s',
           'zendesk.automation_order.instance', // we do not filter out order instances
           'zendesk.custom_role.instance.Advisor',
+          'zendesk.organization_field.instance.dropdown_26',
           'zendesk.organization_field_order.instance',
           'zendesk.sla_policy_order.instance',
+          'zendesk.ticket_field.instance.agent_dropdown_643_for_agent_multiselect@ssssu',
+          'zendesk.ticket_field.instance.agent_field_431_text@ssu',
           'zendesk.ticket_form_order.instance',
           'zendesk.trigger_order.instance',
           'zendesk.user_field_order.instance',


### PR DESCRIPTION
Note: also contains the changes from https://github.com/salto-io/salto/pull/4141, please only review the last commit here.

Allow filtering by additional field values in zendesk - only a hard-coded list for now.

---
_Release Notes_: 
_Zendesk adapter_:
* Allow including/excluding items by additional properties besides name, including title, raw title, key, and type.

---
_User Notifications_: 
None