### PR TITLE
SALTO-2957 move getComponent to AbstractNodeMap

### DIFF
--- a/packages/dag/src/nodemap.ts
+++ b/packages/dag/src/nodemap.ts
@@ -255,34 +255,6 @@ export class AbstractNodeMap extends collections.map.DefaultMap<NodeId, Set<Node
       .find(values.isDefined)
   }
 
-  clear(): void {
-    super.clear()
-    this.reverseNeighbors.clear()
-  }
-}
-
-// This class adds storage of node data to NodeMap
-export class DataNodeMap<T> extends AbstractNodeMap {
-  readonly nodeData: Map<NodeId, T>
-
-  constructor(
-    entries?: Iterable<[NodeId, Set<NodeId>]>,
-    nodeData?: Map<NodeId, T>,
-  ) {
-    super(entries)
-    this.nodeData = nodeData || new Map<NodeId, T>()
-  }
-
-  addNode(id: NodeId, dependsOn: Iterable<NodeId>, data: T): void {
-    super.addNodeBase(id, dependsOn)
-    this.nodeData.set(id, data)
-  }
-
-  deleteNode(id: NodeId): Set<NodeId> {
-    this.nodeData.delete(id)
-    return super.deleteNode(id)
-  }
-
   getComponent({ roots, filterFunc, reverse }:{
     roots: NodeId[]
     filterFunc?: (id: NodeId) => boolean
@@ -309,6 +281,35 @@ export class DataNodeMap<T> extends AbstractNodeMap {
     const visited = new Set<NodeId>()
 
     return new Set(roots.flatMap(root => [...getComponentImpl(root, visited, filterFunc).values()]))
+  }
+
+
+  clear(): void {
+    super.clear()
+    this.reverseNeighbors.clear()
+  }
+}
+
+// This class adds storage of node data to NodeMap
+export class DataNodeMap<T> extends AbstractNodeMap {
+  readonly nodeData: Map<NodeId, T>
+
+  constructor(
+    entries?: Iterable<[NodeId, Set<NodeId>]>,
+    nodeData?: Map<NodeId, T>,
+  ) {
+    super(entries)
+    this.nodeData = nodeData || new Map<NodeId, T>()
+  }
+
+  addNode(id: NodeId, dependsOn: Iterable<NodeId>, data: T): void {
+    super.addNodeBase(id, dependsOn)
+    this.nodeData.set(id, data)
+  }
+
+  deleteNode(id: NodeId): Set<NodeId> {
+    this.nodeData.delete(id)
+    return super.deleteNode(id)
   }
 
   cloneWithout(ids: Set<NodeId>): this {

--- a/packages/dag/test/nodemap.test.ts
+++ b/packages/dag/test/nodemap.test.ts
@@ -16,7 +16,7 @@
 import wu from 'wu'
 import _ from 'lodash'
 import {
-  NodeId, CircularDependencyError, WalkError, NodeSkippedError, DataNodeMap, DAG,
+  NodeId, CircularDependencyError, WalkError, NodeSkippedError, DataNodeMap, DAG, AbstractNodeMap,
 } from '../src/nodemap'
 
 class MaxCounter {
@@ -1071,6 +1071,48 @@ describe('NodeMap', () => {
       it('should not modify the graph', () => {
         expect(subject).toEqual(origGraph)
       })
+    })
+  })
+})
+
+describe('AbstractNodeMap', () => {
+  let subject: AbstractNodeMap
+
+  beforeEach(() => {
+    subject = new AbstractNodeMap()
+  })
+
+  describe('get component', () => {
+    beforeEach(() => {
+      subject = new AbstractNodeMap()
+      subject.addEdge(1, 2)
+      subject.addEdge(1, 3)
+      subject.addEdge(2, 2)
+      subject.addEdge(2, 3)
+      subject.addEdge(2, 4)
+      subject.addEdge(3, 1)
+      subject.addEdge(4, 5)
+      subject.addEdge(4, 2)
+      subject.addEdge(6, 7)
+      subject.addEdge(6, 4)
+    })
+    it('should return the connected components of a node', () => {
+      expect([...subject.getComponent({ roots: [3] }).keys()].sort()).toEqual([1, 2, 3, 4, 5])
+    })
+
+    it('should return the connected components of a node in reverse order', () => {
+      expect([...subject.getComponent({ roots: [3], reverse: true }).keys()].sort())
+        .toEqual([1, 2, 3, 4, 6])
+    })
+
+    it('should filter out nodes that are filtered by the filter func', () => {
+      expect([...subject.getComponent({ roots: [3], filterFunc: id => id !== 4 }).keys()].sort())
+        .toEqual([1, 2, 3])
+    })
+
+    it('should return the connected components of multiple roots', () => {
+      expect([...subject.getComponent({ roots: [3, 6], filterFunc: id => id !== 4 }).keys()].sort())
+        .toEqual([1, 2, 3, 6, 7])
     })
   })
 })


### PR DESCRIPTION
move `getComponent` so it can be used for graph traversal that doesn't require node values, e.g. https://github.com/salto-io/salto/pull/4141

---
_Release Notes_: 
None

---
_User Notifications_: 
None