### PR TITLE
SALTO-4177 Support deploy of issue layout

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -131,7 +131,7 @@ import storeUsersFilter from './filters/store_users'
 import projectCategoryFilter from './filters/project_category'
 import addAliasFilter from './filters/add_alias'
 import projectRoleRemoveTeamManagedDuplicatesFilter from './filters/remove_specific_duplicate_roles'
-// import issueLayoutFilter from './filters/issue_layout/issue_layout' // will be enabled after the deploy will merge
+import issueLayoutFilter from './filters/issue_layout/issue_layout'
 import projectFieldContextOrder from './filters/project_field_contexts_order'
 import scriptedFieldsIssueTypesFilter from './filters/script_runner/scripted_fields_issue_types'
 import scriptRunnerFilter from './filters/script_runner/script_runner_filter'
@@ -245,7 +245,7 @@ export const DEFAULT_FILTERS = [
   // Must run after referenceBySelfLinkFilter
   removeSelfFilter,
   fieldReferencesFilter,
-  // issueLayoutFilter, - will be enabled after the deploy will merge
+  issueLayoutFilter,
   // Must run after fieldReferencesFilter
   contextsProjectsFilter,
   // must run after contextsProjectsFilter

--- a/packages/jira-adapter/src/filters/issue_layout/issue_layout.ts
+++ b/packages/jira-adapter/src/filters/issue_layout/issue_layout.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { CORE_ANNOTATIONS, Element, InstanceElement, ReferenceExpression, isInstanceElement } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, Change, Element, InstanceElement, ReferenceExpression, getChangeData, isInstanceChange, isInstanceElement } from '@salto-io/adapter-api'
 import { values as lowerDashValues } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import { createSchemeGuard, isResolvedReferenceExpression, naclCase, pathNaclCase } from '@salto-io/adapter-utils'
@@ -27,9 +27,16 @@ import { ISSUE_LAYOUT_CONFIG_ITEM_SCHEME, ISSUE_LAYOUT_RESPONSE_SCHEME, IssueLay
 import { addAnnotationRecursively, setTypeDeploymentAnnotations } from '../../utils'
 import { JiraConfig } from '../../config/config'
 import { referencesRules, JiraFieldReferenceResolver, contextStrategyLookup } from '../../reference_mapping'
+import { deployChanges } from '../../deployment/standard_deployment'
 
 const { isDefined } = lowerDashValues
 const log = logger(module)
+const CAPITAL_CONTAINER_TO_LOWER_CONTAINER: Record<string, string> = {
+  PRIMARY: 'primary',
+  SECONDARY: 'secondary',
+  CONTENT: 'content',
+}
+
 type issueTypeMappingStruct = {
     issueTypeId: string
     screenSchemeId: ReferenceExpression
@@ -113,6 +120,44 @@ const getProjectToScreenMapping = async (elements: Element[]): Promise<Record<st
   return projectToScreenId
 }
 
+const deployIssueLayoutChanges = async (
+  change: Change<InstanceElement>,
+  client: JiraClient,
+): Promise<void> => {
+  const issueLayout = getChangeData(change)
+  const items = issueLayout.value.issueLayoutConfig.items.map((item: IssueLayoutConfigItem) => {
+    if (isResolvedReferenceExpression(item.key)) {
+      const key = item.key.value.value.id
+      return {
+        type: item.type,
+        sectionType: CAPITAL_CONTAINER_TO_LOWER_CONTAINER[item.sectionType],
+        key,
+        data: {
+          name: item.key.value.value.name,
+          type: item.key.value.value.type ?? key,
+        },
+      }
+    }
+    return undefined
+  }).filter(isDefined)
+
+  if (isResolvedReferenceExpression(issueLayout.value.projectId)
+  && isResolvedReferenceExpression(issueLayout.value.extraDefinerId)) {
+    const data = {
+      projectId: issueLayout.value.projectId.value.value.id,
+      extraDefinerId: issueLayout.value.extraDefinerId.value.value.id,
+      issueLayoutType: 'ISSUE_VIEW',
+      owners: [],
+      issueLayoutConfig: {
+        items,
+      },
+    }
+    const url = `/rest/internal/1.0/issueLayouts/${issueLayout.value.id}`
+    await client.put({ url, data })
+  }
+  return undefined
+}
+
 const filter: FilterCreator = ({ client, config, fetchQuery, getElemIdFunc }) => ({
   name: 'issueLayoutFilter',
   onFetch: async elements => {
@@ -168,6 +213,19 @@ const filter: FilterCreator = ({ client, config, fetchQuery, getElemIdFunc }) =>
           await addAnnotationRecursively(issueLayoutType, CORE_ANNOTATIONS.DELETABLE)
         }
       })))
+  },
+  deploy: async changes => {
+    const [issueLayoutsChanges, leftoverChanges] = _.partition(
+      changes,
+      change => isInstanceChange(change) && getChangeData(change).elemID.typeName === ISSUE_LAYOUT_TYPE
+    )
+    const deployResult = await deployChanges(issueLayoutsChanges.filter(isInstanceChange),
+      async change => deployIssueLayoutChanges(change, client))
+
+    return {
+      leftoverChanges,
+      deployResult,
+    }
   },
 })
 

--- a/packages/jira-adapter/src/filters/issue_layout/issue_layout.ts
+++ b/packages/jira-adapter/src/filters/issue_layout/issue_layout.ts
@@ -152,14 +152,15 @@ const deployIssueLayoutChanges = async (
         screenId: issueLayout.value.extraDefinerId.value.value.id,
         client })
       if (!isIssueLayoutResponse(response.data)) {
-        return undefined
+        throw Error('Failed to deploy issue layout changes due to bad response from jira service')
       }
       issueLayout.value.id = response.data.issueLayoutConfiguration.issueLayoutResult.id
     }
     const url = `/rest/internal/1.0/issueLayouts/${issueLayout.value.id}`
     await client.put({ url, data })
+    return undefined
   }
-  return undefined
+  throw Error('Failed to deploy issue layout changes due to missing references')
 }
 
 const filter: FilterCreator = ({ client, config, fetchQuery, getElemIdFunc }) => ({

--- a/packages/jira-adapter/test/filters/issue_layout/issue_layout.test.ts
+++ b/packages/jira-adapter/test/filters/issue_layout/issue_layout.test.ts
@@ -579,5 +579,41 @@ describe('issue layout filter', () => {
         undefined
       )
     })
+    it('should return error if project is not reference expression', async () => {
+      const issueLayoutInstanceWithoutProj = new InstanceElement(
+        'issueLayoutInstanceWithoutProj',
+        issueLayoutType,
+        {
+          projectId: 11111,
+          extraDefinerId: new ReferenceExpression(screenInstance.elemID, screenInstance),
+          owners: [
+            new ReferenceExpression(issueTypeInstance.elemID, issueTypeInstance),
+          ],
+          issueLayoutConfig: {
+            items: [
+              {
+                type: 'FIELD',
+                sectionType: 'PRIMARY',
+                key: new ReferenceExpression(fieldInstance1.elemID, fieldInstance1),
+              },
+              {
+                type: 'FIELD',
+                sectionType: 'SECONDARY',
+                key: new ReferenceExpression(fieldInstance2.elemID, fieldInstance2),
+              },
+            ],
+          },
+        }
+      )
+      const res = await filter.deploy([
+        { action: 'add', data: { after: issueLayoutInstanceWithoutProj } },
+      ])
+      expect(res.deployResult.errors).toHaveLength(1)
+      expect(res.deployResult.errors[0].message).toEqual(
+        `Deployment of ${issueLayoutInstanceWithoutProj.elemID.getFullName()} failed: Error: Failed to deploy issue layout changes due to missing references`
+      )
+      expect(res.deployResult.appliedChanges).toHaveLength(0)
+      expect(res.leftoverChanges).toHaveLength(0)
+    })
   })
 })

--- a/packages/jira-adapter/test/filters/issue_layout/issue_layout.test.ts
+++ b/packages/jira-adapter/test/filters/issue_layout/issue_layout.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { filterUtils, client as clientUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { ObjectType, ElemID, InstanceElement, BuiltinTypes, ListType, ReferenceExpression, Element, isInstanceElement, isObjectType } from '@salto-io/adapter-api'
+import { ObjectType, ElemID, InstanceElement, BuiltinTypes, ListType, ReferenceExpression, Element, isInstanceElement, isObjectType, getChangeData } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { MockInterface } from '@salto-io/test-utils'
 import { getDefaultConfig } from '../../../src/config/config'
@@ -22,6 +22,7 @@ import JiraClient from '../../../src/client/client'
 import issueLayoutFilter from '../../../src/filters/issue_layout/issue_layout'
 import { getFilterParams, mockClient } from '../../utils'
 import { ISSUE_LAYOUT_TYPE, JIRA, PROJECT_TYPE, SCREEN_SCHEME_TYPE } from '../../../src/constants'
+import { createIssueLayoutType } from '../../../src/filters/issue_layout/issue_layout_types'
 
 describe('issue layout filter', () => {
   let connection: MockInterface<clientUtils.APIConnection>
@@ -396,5 +397,163 @@ describe('issue layout filter', () => {
     const instances = elements.filter(isInstanceElement)
     const issueLayoutInstance = instances.find(e => e.elemID.typeName === ISSUE_LAYOUT_TYPE)
     expect(issueLayoutInstance?.elemID.getFullName()).toEqual('jira.IssueLayout.instance.project1_Default_Issue_Layout@uss')
+  })
+  describe('deploy', () => {
+    let issueLayoutInstance: InstanceElement
+    let afterIssueLayoutInstance: InstanceElement
+    const { issueLayoutType } = createIssueLayoutType()
+    beforeEach(() => {
+      client = mockCli.client
+      connection = mockCli.connection
+      issueLayoutInstance = new InstanceElement(
+        'issueLayout',
+        issueLayoutType,
+        {
+          id: '2',
+          projectId: new ReferenceExpression(projectInstance.elemID, projectInstance),
+          extraDefinerId: new ReferenceExpression(screenInstance.elemID, screenInstance),
+          owners: [
+            new ReferenceExpression(issueTypeInstance.elemID, issueTypeInstance),
+          ],
+          issueLayoutConfig: {
+            items: [
+              {
+                type: 'FIELD',
+                sectionType: 'PRIMARY',
+                key: new ReferenceExpression(fieldInstance1.elemID, fieldInstance1),
+              },
+              {
+                type: 'FIELD',
+                sectionType: 'SECONDARY',
+                key: new ReferenceExpression(fieldInstance2.elemID, fieldInstance2),
+              },
+            ],
+          },
+        }
+      )
+      afterIssueLayoutInstance = issueLayoutInstance.clone()
+    })
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+    it('should add issue layout to the elements', async () => {
+      const res = await filter.deploy([
+        { action: 'add', data: { after: issueLayoutInstance } },
+        { action: 'add', data: { after: projectInstance } },
+      ])
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.leftoverChanges).toHaveLength(1)
+      expect((getChangeData(res.leftoverChanges[0]) as InstanceElement).value)
+        .toEqual(projectInstance.value)
+      expect(res.deployResult.appliedChanges).toHaveLength(1)
+      expect(res.deployResult.appliedChanges[0]).toEqual(
+        { action: 'add', data: { after: issueLayoutInstance } }
+      )
+    })
+    it('should modify issue layout', async () => {
+      const fieldInstance3 = new InstanceElement(
+        'testField3',
+        fieldType,
+        {
+          id: 'testField3',
+          name: 'TestField3',
+        }
+      )
+      afterIssueLayoutInstance.value.issueLayoutConfig.items[2] = {
+        type: 'FIELD',
+        sectionType: 'PRIMARY',
+        key: new ReferenceExpression(fieldInstance3.elemID, fieldInstance3),
+      }
+      const res = await filter.deploy([
+        { action: 'modify', data: { before: issueLayoutInstance, after: afterIssueLayoutInstance } },
+      ])
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.leftoverChanges).toHaveLength(0)
+
+      expect(res.deployResult.appliedChanges).toHaveLength(1)
+      expect(res.deployResult.appliedChanges[0]).toEqual(
+        { action: 'modify', data: { before: issueLayoutInstance, after: afterIssueLayoutInstance } }
+      )
+      expect(connection.put).toHaveBeenCalledWith(
+        '/rest/internal/1.0/issueLayouts/2',
+        { extraDefinerId: 11,
+          projectId: 11111,
+          owners: [],
+          issueLayoutType: 'ISSUE_VIEW',
+          issueLayoutConfig: {
+            items: [
+              { key: 'testField1',
+                sectionType: 'primary',
+                type: 'FIELD',
+                data: {
+                  name: 'TestField1',
+                  type: 'testField1',
+                } },
+              { key: 'testField2',
+                sectionType: 'secondary',
+                type: 'FIELD',
+                data: {
+                  name: 'TestField2',
+                  type: 'testField2',
+                } },
+              { key: 'testField3',
+                sectionType: 'primary',
+                type: 'FIELD',
+                data: {
+                  name: 'TestField3',
+                  type: 'testField3',
+                } },
+            ],
+          } },
+        undefined
+      )
+    })
+    it('should not add item if its key is not a reference expression', async () => {
+      afterIssueLayoutInstance.value.issueLayoutConfig.items[2] = {
+        type: 'FIELD',
+        sectionType: 'PRIMARY',
+        key: 'testField3',
+      }
+      const res = await filter.deploy([
+        { action: 'modify', data: { before: issueLayoutInstance, after: afterIssueLayoutInstance } },
+      ])
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.deployResult.appliedChanges).toHaveLength(1)
+      expect(res.deployResult.appliedChanges[0]).toEqual(
+        { action: 'modify', data: { before: issueLayoutInstance, after: afterIssueLayoutInstance } }
+      )
+      expect(connection.put).toHaveBeenCalledWith(
+        '/rest/internal/1.0/issueLayouts/2',
+        { extraDefinerId: 11,
+          projectId: 11111,
+          owners: [],
+          issueLayoutType: 'ISSUE_VIEW',
+          issueLayoutConfig: {
+            items: [
+              { key: 'testField1',
+                sectionType: 'primary',
+                type: 'FIELD',
+                data: {
+                  name: 'TestField1',
+                  type: 'testField1',
+                } },
+              { key: 'testField2',
+                sectionType: 'secondary',
+                type: 'FIELD',
+                data: {
+                  name: 'TestField2',
+                  type: 'testField2',
+                } }],
+          } },
+        undefined
+      )
+    })
+    it('should not add item if its project is not a reference expression', async () => {
+      issueLayoutInstance.value.projectId = 6565
+      await filter.deploy([
+        { action: 'add', data: { after: issueLayoutInstance } },
+      ])
+      expect(connection.put).not.toHaveBeenCalled()
+    })
   })
 })


### PR DESCRIPTION
This PR supports issueLayout deploy via a private API and small fetch fixes. 

---
It follows this PR for fetching issueLayouts -  https://github.com/salto-io/salto/pull/4709

---
_Release Notes_: 
Now support deploy of issue Layout. 

---
_User Notifications_: 
Jira:
Upon your next fetch, you may encounter new instances of type **IssueLayout**.
