### PR TITLE
INCIDENT-7359: change FIELD_PARENT_GROUP type to unknown

### DIFF
--- a/packages/netsuite-adapter/src/type_parsers/report_definition_parsing/parsed_report_definition.ts
+++ b/packages/netsuite-adapter/src/type_parsers/report_definition_parsing/parsed_report_definition.ts
@@ -97,7 +97,7 @@ type ReportFieldsType = {
   FLAG_NEG_IN_RED?: boolean
   FIELD_NEG_VAL_FORMAT?: string
   FIELD_GROUP?: string
-  FIELD_PARENT_GROUP?: string
+  FIELD_PARENT_GROUP?: unknown
   FIELD_COLUMN_FILTER_GROUP?: string
   FIELD_FORMAT?: string
   FIELD_FORMULA?: string
@@ -375,7 +375,7 @@ export const reportdefinitionType = (): TypeAndInnerTypes => {
       FLAG_NEG_IN_RED: { refType: BuiltinTypes.BOOLEAN },
       FIELD_NEG_VAL_FORMAT: { refType: BuiltinTypes.STRING },
       FIELD_GROUP: { refType: BuiltinTypes.STRING },
-      FIELD_PARENT_GROUP: { refType: BuiltinTypes.STRING },
+      FIELD_PARENT_GROUP: { refType: BuiltinTypes.UNKNOWN },
       FIELD_COLUMN_FILTER_GROUP: { refType: BuiltinTypes.STRING },
       FIELD_FORMAT: { refType: BuiltinTypes.STRING },
       FIELD_FORMULA: { refType: BuiltinTypes.STRING },

--- a/packages/netsuite-adapter/src/type_parsers/report_definition_parsing/parsed_report_definition.ts
+++ b/packages/netsuite-adapter/src/type_parsers/report_definition_parsing/parsed_report_definition.ts
@@ -96,7 +96,7 @@ type ReportFieldsType = {
   FLAG_DIV_BY_THOUSAND?: boolean
   FLAG_NEG_IN_RED?: boolean
   FIELD_NEG_VAL_FORMAT?: string
-  FIELD_GROUP?: string
+  FIELD_GROUP?: unknown
   FIELD_PARENT_GROUP?: unknown
   FIELD_COLUMN_FILTER_GROUP?: string
   FIELD_FORMAT?: string
@@ -374,7 +374,7 @@ export const reportdefinitionType = (): TypeAndInnerTypes => {
       FLAG_DIV_BY_THOUSAND: { refType: BuiltinTypes.BOOLEAN },
       FLAG_NEG_IN_RED: { refType: BuiltinTypes.BOOLEAN },
       FIELD_NEG_VAL_FORMAT: { refType: BuiltinTypes.STRING },
-      FIELD_GROUP: { refType: BuiltinTypes.STRING },
+      FIELD_GROUP: { refType: BuiltinTypes.UNKNOWN },
       FIELD_PARENT_GROUP: { refType: BuiltinTypes.UNKNOWN },
       FIELD_COLUMN_FILTER_GROUP: { refType: BuiltinTypes.STRING },
       FIELD_FORMAT: { refType: BuiltinTypes.STRING },


### PR DESCRIPTION
_change FIELD_PARENT_GROUP, FIELD_GROUP type to unknown_

---

_The [incident](https://salto-io.atlassian.net/jira/software/c/projects/SALTO/issues/INCIDENT-7359?filter=myopenissues&jql=project%20in%20%28Salto%2C%20%22Salto%20SaaS%22%2C%20Incidents%29%0Aand%20assignee%20IN%20%28currentUser%28%29%29%0Aand%20statusCategory%20in%20%28%22To%20Do%22%2C%20%22In%20Progress%22%29%0AORDER%20BY%20created%20DESC)_

---
_Release Notes_: 
_Netsuite Adapter_:
* reportdefinitions FIELD_PARENT_GROUP and FIELD_GROUP type changed to unkown

---
_User Notifications_: 
_None_
