### PR TITLE
SALTO-4637: add ability to create missing orgs in deployment

### DIFF
--- a/packages/zendesk-adapter/config_doc.md
+++ b/packages/zendesk-adapter/config_doc.md
@@ -88,9 +88,9 @@ zendesk {
 ### Deploy configuration options
 
 | Name                         | Default when undefined | Description
-|------------------------------|-----------------------|------------
-| [defaultMissingUserFallback] | ""                    | Configure replacement for missing users during deploy, can be user email or ##DEPLOYER## to fallback to deployer's user 
-| [defaultMissingOrgFallback]  | undefined             | When enabled, missing organizations will be created during deploy, 
+|------------------------------|------------------------|------------
+| [defaultMissingUserFallback] | ""                     | Configure replacement for missing users during deploy, can be user email or ##DEPLOYER## to fallback to deployer's user 
+| [createMissingOrganizations] | false                  | When enabled with resolveOrganizationIDs flag , missing organizations will be created during deploy.
 
 
 ## Fetch entry criteria

--- a/packages/zendesk-adapter/config_doc.md
+++ b/packages/zendesk-adapter/config_doc.md
@@ -87,9 +87,11 @@ zendesk {
 
 ### Deploy configuration options
 
-| Name                                                          | Default when undefined   | Description
-|---------------------------------------------------------------|--------------------------|------------
-| [defaultMissingUserFallback]                                  | ""                       | Configure replacement for missing users during deploy, can be user email or ##DEPLOYER## to fallback to deployer's user 
+| Name                         | Default when undefined | Description
+|------------------------------|-----------------------|------------
+| [defaultMissingUserFallback] | ""                    | Configure replacement for missing users during deploy, can be user email or ##DEPLOYER## to fallback to deployer's user 
+| [defaultMissingOrgFallback]  | undefined             | When enabled, missing organizations will be created during deploy, 
+
 
 ## Fetch entry criteria
 

--- a/packages/zendesk-adapter/src/change_validator.ts
+++ b/packages/zendesk-adapter/src/change_validator.ts
@@ -147,7 +147,7 @@ export default ({
     helpCenterCreationOrRemoval: helpCenterCreationOrRemovalValidator(client, apiConfig),
     externalSourceWebhook: externalSourceWebhookValidator,
     defaultGroupChange: defaultGroupChangeValidator,
-    organizationExistence: organizationExistenceValidator(client, fetchConfig),
+    organizationExistence: organizationExistenceValidator(client, fetchConfig, deployConfig),
     badFormatWebhookAction: badFormatWebhookActionValidator,
     guideDisabled: guideDisabledValidator(fetchConfig),
     additionOfTicketStatusForTicketForm: additionOfTicketStatusForTicketFormValidator,

--- a/packages/zendesk-adapter/src/change_validators/organization_existence.ts
+++ b/packages/zendesk-adapter/src/change_validators/organization_existence.ts
@@ -33,73 +33,89 @@ import {
 } from '../filters/organizations'
 import ZendeskClient from '../client/client'
 import { paginate } from '../client/pagination'
-import { ZendeskFetchConfig } from '../config'
+import { ZedneskDeployConfig, ZendeskFetchConfig } from '../config'
 
 const { awu } = collections.asynciterable
 const { isDefined } = lowerDashValues
 const log = logger(module)
 
 /**
- * Validates the existence of organizations that are referenced in added or modified elements
+ * Validates the existence of organizations that are referenced in added or modified elements, if resolveOrganizationIDs
+ * is true and defaultMissingOrgFallback than we will warn the user instead of error
  */
-export const organizationExistenceValidator: (client: ZendeskClient, fetchConfig: ZendeskFetchConfig) =>
-    ChangeValidator = (client, fetchConfig) => async changes => {
-      // If the organizations were resolved, they are stored as names instead of ids
-      // If the user change this config between a fetch and a deploy, this validator will fail
-      // This is a known issue and is ok because handling it is not trivial and the use case shouldn't be common
-      const orgIdsResolved = fetchConfig.resolveOrganizationIDs === true
+export const organizationExistenceValidator: (
+  client: ZendeskClient,
+  fetchConfig: ZendeskFetchConfig,
+  deployConfig?: ZedneskDeployConfig,
+) => ChangeValidator = (client, fetchConfig, deployConfig) => async changes => {
+  // If the organizations were resolved, they are stored as names instead of ids
+  // If the user change this config between a fetch and a deploy, this validator will fail
+  // This is a known issue and is ok because handling it is not trivial and the use case shouldn't be common
+  const orgIdsResolved = fetchConfig.resolveOrganizationIDs === true
+  const defaultMissingOrgFallback = deployConfig?.defaultMissingOrgFallback === true
 
-      const relevantChanges = changes.filter(isAdditionOrModificationChange).filter(isInstanceChange).map(getChangeData)
-        .filter(instance => Object.keys(TYPE_NAME_TO_REPLACER).includes(instance.elemID.typeName))
+  const relevantChanges = changes.filter(isAdditionOrModificationChange).filter(isInstanceChange).map(getChangeData)
+    .filter(instance => Object.keys(TYPE_NAME_TO_REPLACER).includes(instance.elemID.typeName))
 
-      const organizationPathEntries = createOrganizationPathEntries(relevantChanges)
-      const entriesByInstance = _.groupBy(organizationPathEntries, entry => entry.instance.elemID.getFullName())
+  const organizationPathEntries = createOrganizationPathEntries(relevantChanges)
+  const entriesByInstance = _.groupBy(organizationPathEntries, entry => entry.instance.elemID.getFullName())
 
-      const paginator = clientUtils.createPaginator({ client, paginationFuncCreator: paginate })
+  const paginator = clientUtils.createPaginator({ client, paginationFuncCreator: paginate })
 
-      // Will be either a list of ids or a list of names, depends on the resolveOrganizationIDs config
-      const orgIdentifiers = Array.from(new Set<string>(
-        Object.values(entriesByInstance).flatMap(entries => entries.map(entry => entry.identifier))
-      ))
+  // Will be either a list of ids or a list of names, depends on the resolveOrganizationIDs config
+  const orgIdentifiers = Array.from(new Set<string>(
+    Object.values(entriesByInstance).flatMap(entries => entries.map(entry => entry.identifier))
+  ))
 
-      let existingOrgs: Organization[]
-      try {
-        existingOrgs = orgIdsResolved
-          ? await getOrganizationsByNames(orgIdentifiers, paginator)
-          : await getOrganizationsByIds(orgIdentifiers, client)
-      } catch (e) {
-        // If we fail for any reason, we don't want to block the user from deploying
-        log.warn(`organizationExistenceValidator - Failed to get organizations from Zendesk: ${e.message}`)
-        return []
-      }
+  let existingOrgs: Organization[]
+  try {
+    existingOrgs = orgIdsResolved
+      ? await getOrganizationsByNames({
+        organizationNames: orgIdentifiers,
+        paginator,
+      })
+      : await getOrganizationsByIds(orgIdentifiers, client)
+  } catch (e) {
+    // If we fail for any reason, we don't want to block the user from deploying
+    log.warn(`organizationExistenceValidator - Failed to get organizations from Zendesk: ${e.message}`)
+    return []
+  }
 
-      const existingOrgsSet = new Set(
-        existingOrgs.map(org => (orgIdsResolved ? org.name : org.id.toString())).filter(org => !_.isEmpty(org))
+  const existingOrgsSet = new Set(
+    existingOrgs.map(org => (orgIdsResolved ? org.name : org.id.toString())).filter(org => !_.isEmpty(org))
+  )
+
+  // Because 'entriesByInstance' is already grouped by instance, we can run over it instead of over the changes
+  const errors = await awu(Object.values(entriesByInstance)).map(
+    async (entries): Promise<ChangeError | undefined> => {
+      const nonExistingOrgs = new Set<string>(
+        entries.filter(({ identifier }) => !existingOrgsSet.has(identifier)).map(org => org.identifier)
       )
 
-      // Because 'entriesByInstance' is already grouped by instance, we can run over it instead of over the changes
-      const errors = await awu(Object.values(entriesByInstance)).map(
-        async (entries): Promise<ChangeError | undefined> => {
-          const nonExistingOrgs = new Set<string>(
-            entries.filter(({ identifier }) => !existingOrgsSet.has(identifier)).map(org => org.identifier)
-          )
-
-          // If the instance includes an organization that does not exist, we won't allow a change to that instance
-          if (nonExistingOrgs.size > 0) {
-            // Check if any of the non-existing orgs are numbers, if so, we should recommend the user to resolve them
-            const nonExistingOrgsAreIds = !orgIdsResolved || wu(nonExistingOrgs.values()).some(org => _.isNumber(org))
-            const resolveOrgsRecommendation = nonExistingOrgsAreIds ? '. Salto can identify organizations by their names. This requires setting the \'resolveOrganizationIDs\' to true in the zendesk configuration file of both source and target envs and fetch.\n'
+      // If the instance includes an organization that does not exist, we won't allow a change to that instance
+      if (nonExistingOrgs.size > 0) {
+        // Check if any of the non-existing orgs are numbers, if so, we should recommend the user to resolve them
+        const nonExistingOrgsAreIds = !orgIdsResolved || wu(nonExistingOrgs.values()).some(org => _.isNumber(org))
+        const resolveOrgsRecommendation = nonExistingOrgsAreIds ? '. Salto can identify organizations by their names. This requires setting the \'resolveOrganizationIDs\' to true in the zendesk configuration file of both source and target envs and fetch.\n'
                 + 'More information about Salto\'s config files can be found here: \'https://help.salto.io/en/articles/7439324-salto-configuration-file\'' : ''
-            return {
-              elemID: entries[0].instance.elemID,
-              severity: 'Error',
-              message: 'Referenced organizations do not exist',
-              detailedMessage: `The following referenced organizations do not exist in the target environment: ${Array.from(nonExistingOrgs).join(', ')}${resolveOrgsRecommendation}`,
-            }
+        if (orgIdsResolved && defaultMissingOrgFallback) {
+          return {
+            elemID: entries[0].instance.elemID,
+            severity: 'Warning',
+            message: 'Referenced organizations do not exist',
+            detailedMessage: `The following referenced organizations do not exist in the target environment: ${Array.from(nonExistingOrgs).join(', ')}\nIf you continue, they will be created.`,
           }
-          return undefined
         }
-      ).filter(isDefined).toArray()
-
-      return errors
+        return {
+          elemID: entries[0].instance.elemID,
+          severity: 'Error',
+          message: 'Referenced organizations do not exist',
+          detailedMessage: `The following referenced organizations do not exist in the target environment: ${Array.from(nonExistingOrgs).join(', ')}${resolveOrgsRecommendation}`,
+        }
+      }
+      return undefined
     }
+  ).filter(isDefined).toArray()
+
+  return errors
+}

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -85,7 +85,7 @@ export type ZendeskFetchConfig = configUtils.UserFetchConfig
   resolveOrganizationIDs?: boolean
 }
 export type ZedneskDeployConfig = configUtils.UserDeployConfig & configUtils.DefaultMissingUserFallbackConfig & {
-defaultMissingOrgFallback?: boolean
+  createMissingOrganizations?: boolean
 }
 export type ZendeskApiConfig = configUtils.AdapterApiConfig<
   configUtils.DuckTypeTransformationConfig & { omitInactive?: boolean },
@@ -2550,6 +2550,9 @@ export const DEFAULT_CONFIG: ZendeskConfig = {
     includeAuditDetails: false,
     addAlias: false,
   },
+  [DEPLOY_CONFIG]: {
+    createMissingOrganizations: false,
+  },
   [API_DEFINITIONS_CONFIG]: {
     typeDefaults: {
       request: {
@@ -2774,7 +2777,7 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
         changeValidatorConfigType,
         {
           ...defaultMissingUserFallbackField,
-          defaultMissingOrgFallback: { refType: BuiltinTypes.BOOLEAN },
+          createMissingOrganizations: { refType: BuiltinTypes.BOOLEAN },
         },
       ),
     },

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -84,7 +84,9 @@ export type ZendeskFetchConfig = configUtils.UserFetchConfig
   guide?: Guide
   resolveOrganizationIDs?: boolean
 }
-export type ZedneskDeployConfig = configUtils.UserDeployConfig & configUtils.DefaultMissingUserFallbackConfig
+export type ZedneskDeployConfig = configUtils.UserDeployConfig & configUtils.DefaultMissingUserFallbackConfig & {
+defaultMissingOrgFallback?: boolean
+}
 export type ZendeskApiConfig = configUtils.AdapterApiConfig<
   configUtils.DuckTypeTransformationConfig & { omitInactive?: boolean },
   configUtils.TransformationDefaultConfig & { omitInactive?: boolean }
@@ -2770,7 +2772,10 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
       refType: createUserDeployConfigType(
         ZENDESK,
         changeValidatorConfigType,
-        defaultMissingUserFallbackField
+        {
+          ...defaultMissingUserFallbackField,
+          defaultMissingOrgFallback: { refType: BuiltinTypes.BOOLEAN },
+        },
       ),
     },
     [API_DEFINITIONS_CONFIG]: {

--- a/packages/zendesk-adapter/src/filters/organizations.ts
+++ b/packages/zendesk-adapter/src/filters/organizations.ts
@@ -24,7 +24,7 @@ import { FilterCreator } from '../filter'
 import { ValueReplacer, deployModificationFunc, replaceConditionsAndActionsCreator, fieldReplacer } from '../replacers_utils'
 import ZendeskClient from '../client/client'
 import { paginate } from '../client/pagination'
-import { FETCH_CONFIG } from '../config'
+import { DEPLOY_CONFIG, FETCH_CONFIG } from '../config'
 
 const log = logger(module)
 const { isDefined } = lowerDashValues
@@ -42,22 +42,33 @@ type OrganizationResponse = {
   organizations: Organization[]
 }
 
+type SingleOrganizationResponse = {
+  organization: Organization
+}
+
 type organizationIdInstanceAndPath = {
     instance: InstanceElement
     path: ElemID
     identifier: string
 }
 
-const ORGANIZATIONS_SCHEMA = Joi.array().items(Joi.object({
+const SINGLE_ORGANIZATION_SCHEMA = Joi.object({
   id: Joi.number().required(),
   name: Joi.string().required(),
-}).unknown(true)).required()
+}).unknown(true)
+
+const ORGANIZATIONS_SCHEMA = Joi.array().items(SINGLE_ORGANIZATION_SCHEMA).required()
 
 const EXPECTED_ORGANIZATION_RESPONSE_SCHEMA = Joi.object({
   organizations: ORGANIZATIONS_SCHEMA,
 }).unknown(true)
 
+const EXPECTED_SINGLE_ORGANIZATION_RESPONSE_SCHEMA = Joi.object({
+  organization: SINGLE_ORGANIZATION_SCHEMA,
+}).unknown(true)
+
 const isOrganizationsResponse = createSchemeGuard<OrganizationResponse>(EXPECTED_ORGANIZATION_RESPONSE_SCHEMA, 'Received an invalid response from organization request')
+const isSingleOrganizationResponse = createSchemeGuard<SingleOrganizationResponse>(EXPECTED_SINGLE_ORGANIZATION_RESPONSE_SCHEMA, 'Received an invalid response from single organization request')
 
 const areOrganizations = createSchemeGuard<Organization[]>(ORGANIZATIONS_SCHEMA, 'Received invalid organizations')
 
@@ -117,9 +128,17 @@ export const getOrganizationsByIds = async (
   return results.flatMap(orgResponse => orgResponse.organizations)
 }
 
-export const getOrganizationsByNames = async (
-  organizationNames: string[],
-  paginator: clientUtils.Paginator,
+export const getOrganizationsByNames = async ({
+  organizationNames,
+  paginator,
+  defaultMissingOrgFallback,
+  client,
+}: {
+ organizationNames: string[]
+ paginator: clientUtils.Paginator
+ defaultMissingOrgFallback?: boolean
+ client?: ZendeskClient
+                                                }
 ): Promise<Organization[]> => {
   const paginationArgs = {
     url: '/api/v2/organizations/autocomplete',
@@ -142,6 +161,20 @@ export const getOrganizationsByNames = async (
         const organization = res.find(org => org.name === organizationName)
         if (organization === undefined) {
           log.error(`could not find any organization with name ${organizationName}`)
+          if (defaultMissingOrgFallback === true && client !== undefined) {
+            try {
+              const postRes = (await client.post({
+                url: '/api/v2/organizations',
+                data: { organization: { name: organizationName } },
+              })).data
+              if (isSingleOrganizationResponse(postRes)) {
+                return postRes.organization
+              }
+              log.error('invalid organization creation response')
+            } catch (err) {
+              log.error(`could not create organization with name ${organizationName}, error is ${err}`)
+            }
+          }
         }
         return organization
       })
@@ -218,7 +251,10 @@ const filterCreator: FilterCreator = ({ client, config }) => {
         client,
         paginationFuncCreator: paginate,
       })
-      const organizations = await getOrganizationsByNames(organizationNames, paginator)
+      const defaultMissingOrgFallback = config[DEPLOY_CONFIG]?.defaultMissingOrgFallback ?? false
+      const organizations = await getOrganizationsByNames({
+        organizationNames, paginator, defaultMissingOrgFallback, client,
+      })
       if (_.isEmpty(organizations)) {
         return
       }

--- a/packages/zendesk-adapter/src/filters/organizations.ts
+++ b/packages/zendesk-adapter/src/filters/organizations.ts
@@ -161,19 +161,23 @@ export const getOrCreateOrganizationsByNames = async ({
         const organization = res.find(org => org.name === organizationName)
         if (organization === undefined) {
           log.debug(`could not find any organization with name ${organizationName}, if createMissingOrganizations it will be created`)
-          if (createMissingOrganizations === true && client !== undefined) {
-            try {
-              const postRes = (await client.post({
+          if (createMissingOrganizations === true) {
+            if (client === undefined) {
+              log.debug(`client is undefined, can not create org ${organizationName}`)
+            } else {
+              try {
+                const postRes = (await client.post({
                 // in case of issues we can also try to use the bulk-create alternative `organizations/create_many`
-                url: '/api/v2/organizations',
-                data: { organization: { name: organizationName } },
-              })).data
-              if (isSingleOrganizationResponse(postRes)) {
-                return postRes.organization
+                  url: '/api/v2/organizations',
+                  data: { organization: { name: organizationName } },
+                })).data
+                if (isSingleOrganizationResponse(postRes)) {
+                  return postRes.organization
+                }
+                log.error(`invalid organization creation response for org name ${organizationName}`)
+              } catch (err) {
+                log.error(`could not create organization with name ${organizationName}, error is ${err}`)
               }
-              log.error(`invalid organization creation response for org name ${organizationName}`)
-            } catch (err) {
-              log.error(`could not create organization with name ${organizationName}, error is ${err}`)
             }
           }
         }

--- a/packages/zendesk-adapter/test/change_validators/organization_existence.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/organization_existence.test.ts
@@ -149,14 +149,14 @@ describe('OrganizationExistence', () => {
       {
         elemID: slaInstance.elemID,
         severity: 'Warning',
-        message: 'Referenced organizations do not exist',
-        detailedMessage: 'The following referenced organizations do not exist in the target environment: three, four\nIf you continue, they will be created.',
+        message: 'Referenced organizations do not exist and will be created',
+        detailedMessage: 'The following organizations are referenced but do not exist in the target environment: three, four\nIf you continue, they will be created.',
       },
       {
         elemID: triggerInstance.elemID,
         severity: 'Warning',
-        message: 'Referenced organizations do not exist',
-        detailedMessage: 'The following referenced organizations do not exist in the target environment: three, four\nIf you continue, they will be created.',
+        message: 'Referenced organizations do not exist and will be created',
+        detailedMessage: 'The following organizations are referenced but do not exist in the target environment: three, four\nIf you continue, they will be created.',
       },
     ])
   })

--- a/packages/zendesk-adapter/test/change_validators/organization_existence.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/organization_existence.test.ts
@@ -125,9 +125,9 @@ describe('OrganizationExistence', () => {
       },
     ])
   })
-  it('should return a warning if the organization does not exist, with resolved Ids and defaultMissingOrgFallback is on', async () => {
+  it('should return a warning if the organization does not exist, with resolved Ids and createMissingOrganizations is on', async () => {
     const fetchConfig = { ...DEFAULT_CONFIG[FETCH_CONFIG], resolveOrganizationIDs: true }
-    const deployConfig = { defaultMissingOrgFallback: true }
+    const deployConfig = { createMissingOrganizations: true }
     const resolvedIdsClient = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
       allowOrganizationNames: true,
@@ -162,7 +162,7 @@ describe('OrganizationExistence', () => {
   })
 
   it('should return an error if the organization does not exist, and request all orgs in one request, with unresolved Ids', async () => {
-    const deployConfig = { defaultMissingOrgFallback: true }
+    const deployConfig = { createMissingOrganizations: true }
     const validator = organizationExistenceValidator(client, DEFAULT_CONFIG[FETCH_CONFIG], deployConfig)
     mockAxios.onGet().replyOnce(200).onGet()
       .replyOnce(200, { organizations: [{ id: 1, name: 'one' }, { id: 2, name: 'two' }] })

--- a/packages/zendesk-adapter/test/change_validators/organization_existence.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/organization_existence.test.ts
@@ -125,9 +125,45 @@ describe('OrganizationExistence', () => {
       },
     ])
   })
+  it('should return a warning if the organization does not exist, with resolved Ids and defaultMissingOrgFallback is on', async () => {
+    const fetchConfig = { ...DEFAULT_CONFIG[FETCH_CONFIG], resolveOrganizationIDs: true }
+    const deployConfig = { defaultMissingOrgFallback: true }
+    const resolvedIdsClient = new ZendeskClient({
+      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
+      allowOrganizationNames: true,
+    })
+    const validator = organizationExistenceValidator(resolvedIdsClient, fetchConfig, deployConfig)
+    mockAxios.onGet().reply(() => [200, { organizations: [{ id: 1, name: 'one' }, { id: 2, name: 'two' }] }])
+
+    const slaInstance = createSlaInstance(false)
+    const triggerInstance = createTriggerInstance(false)
+
+    const changes = [
+      toChange({ after: slaInstance }),
+      toChange({ before: triggerInstance, after: triggerInstance }),
+      toChange({ before: slaInstance }), // Should do nothing because we don't care about removals
+    ]
+
+    const errors = await validator(changes)
+    expect(errors).toMatchObject([
+      {
+        elemID: slaInstance.elemID,
+        severity: 'Warning',
+        message: 'Referenced organizations do not exist',
+        detailedMessage: 'The following referenced organizations do not exist in the target environment: three, four\nIf you continue, they will be created.',
+      },
+      {
+        elemID: triggerInstance.elemID,
+        severity: 'Warning',
+        message: 'Referenced organizations do not exist',
+        detailedMessage: 'The following referenced organizations do not exist in the target environment: three, four\nIf you continue, they will be created.',
+      },
+    ])
+  })
 
   it('should return an error if the organization does not exist, and request all orgs in one request, with unresolved Ids', async () => {
-    const validator = organizationExistenceValidator(client, DEFAULT_CONFIG[FETCH_CONFIG])
+    const deployConfig = { defaultMissingOrgFallback: true }
+    const validator = organizationExistenceValidator(client, DEFAULT_CONFIG[FETCH_CONFIG], deployConfig)
     mockAxios.onGet().replyOnce(200).onGet()
       .replyOnce(200, { organizations: [{ id: 1, name: 'one' }, { id: 2, name: 'two' }] })
       .onGet()

--- a/packages/zendesk-adapter/test/filters/organizations.test.ts
+++ b/packages/zendesk-adapter/test/filters/organizations.test.ts
@@ -28,6 +28,7 @@ describe('organizations filter', () => {
     credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
   })
   let mockGet: jest.SpyInstance
+  let mockPost: jest.SpyInstance
   type FilterType = filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
   const triggerType = new ObjectType({ elemID: new ElemID(ZENDESK, 'trigger') })
   const userSegmentType = new ObjectType({ elemID: new ElemID(ZENDESK, 'user_segment') })
@@ -283,53 +284,160 @@ describe('organizations filter', () => {
     beforeEach(() => {
       jest.clearAllMocks()
       mockGet = jest.spyOn(client, 'getSinglePage')
+      mockPost = jest.spyOn(client, 'post')
+    })
+    describe('getOrganizationsByNames', () => {
+      it('should return correct result on valid response', async () => {
+        mockGet.mockResolvedValueOnce({
+          status: 200,
+          data: {
+            organizations: [
+              { id: 1, name: 'org1' },
+              { id: 2, name: 'org11' },
+              { id: 3, name: 'org1111' },
+            ],
+          },
+        }).mockResolvedValueOnce({
+          status: 200,
+          data: {
+            organizations: [
+              { id: 2, name: 'org11' },
+              { id: 3, name: 'org1111' },
+            ],
+          },
+        })
+
+        const goodResult = await getOrganizationsByNames({
+          organizationNames: ['org1', 'org11'],
+          paginator,
+          defaultMissingOrgFallback: undefined,
+          client,
+        })
+        expect(goodResult).toEqual([
+          { id: 1, name: 'org1' },
+          { id: 2, name: 'org11' },
+        ])
+      })
+      it('should create org if return empty array on invalid response', async () => {
+        mockGet.mockResolvedValueOnce({
+          status: 200,
+          data: {
+            organizations: [
+              { id: 2, name: 'org11' },
+            ],
+          },
+        }).mockResolvedValueOnce({
+          status: 200,
+          data: {
+            organizations: [
+              { id: 2, name: 'org11' },
+              { id: 3 }, // Bad structure
+            ],
+          },
+        })
+        const badResult = await getOrganizationsByNames({
+          organizationNames: ['org1', 'org11'],
+          paginator,
+          defaultMissingOrgFallback: false,
+          client,
+        })
+        expect(badResult).toEqual([])
+      })
+      it('should create org if defaultMissingOrgFallback is true', async () => {
+        mockGet.mockResolvedValueOnce({
+          status: 200,
+          data: {
+            organizations: [
+              { id: 1, name: 'org1' },
+            ],
+          },
+        }).mockResolvedValueOnce({
+          status: 200,
+          data: {
+            organizations: [],
+          },
+        })
+        mockPost.mockResolvedValue({
+          status: 200,
+          data: {
+            organization:
+              { id: 2, name: 'org11' },
+          },
+        })
+
+        const goodResult = await getOrganizationsByNames({
+          organizationNames: ['org1', 'org11'],
+          paginator,
+          defaultMissingOrgFallback: true,
+          client,
+        })
+        expect(goodResult).toEqual([
+          { id: 1, name: 'org1' },
+          { id: 2, name: 'org11' },
+        ])
+      })
+      it('should not create org if defaultMissingOrgFallback is true and res is invalid', async () => {
+        mockGet.mockResolvedValueOnce({
+          status: 200,
+          data: {
+            organizations: [
+              { id: 1, name: 'org1' },
+            ],
+          },
+        }).mockResolvedValueOnce({
+          status: 200,
+          data: {
+            organizations: [],
+          },
+        })
+        mockPost.mockResolvedValue({
+          status: 200,
+          data: {
+            organization: {},
+          },
+        })
+
+        const goodResult = await getOrganizationsByNames({
+          organizationNames: ['org1', 'org11'],
+          paginator,
+          defaultMissingOrgFallback: true,
+          client,
+        })
+        expect(goodResult).toEqual([
+          { id: 1, name: 'org1' },
+        ])
+      })
+      it('should not create org if defaultMissingOrgFallback is true post fails', async () => {
+        mockGet.mockResolvedValueOnce({
+          status: 200,
+          data: {
+            organizations: [
+              { id: 1, name: 'org1' },
+            ],
+          },
+        }).mockResolvedValueOnce({
+          status: 200,
+          data: {
+            organizations: [],
+          },
+        })
+        mockPost.mockResolvedValue(
+          () => { throw Error('err') }
+        )
+
+        const goodResult = await getOrganizationsByNames({
+          organizationNames: ['org1', 'org11'],
+          paginator,
+          defaultMissingOrgFallback: true,
+          client,
+        })
+        expect(goodResult).toEqual([
+          { id: 1, name: 'org1' },
+        ])
+      })
     })
 
-    it('getOrganizationsByNames', async () => {
-      mockGet.mockResolvedValueOnce({
-        status: 200,
-        data: {
-          organizations: [
-            { id: 1, name: 'org1' },
-            { id: 2, name: 'org11' },
-            { id: 3, name: 'org1111' },
-          ],
-        },
-      }).mockResolvedValueOnce({
-        status: 200,
-        data: {
-          organizations: [
-            { id: 2, name: 'org11' },
-            { id: 3, name: 'org1111' },
-          ],
-        },
-      })
 
-      const goodResult = await getOrganizationsByNames(['org1', 'org11'], paginator)
-      expect(goodResult).toEqual([
-        { id: 1, name: 'org1' },
-        { id: 2, name: 'org11' },
-      ])
-
-      mockGet.mockResolvedValueOnce({
-        status: 200,
-        data: {
-          organizations: [
-            { id: 2, name: 'org11' },
-          ],
-        },
-      }).mockResolvedValueOnce({
-        status: 200,
-        data: {
-          organizations: [
-            { id: 2, name: 'org11' },
-            { id: 3 }, // Bad structure
-          ],
-        },
-      })
-      const badResult = await getOrganizationsByNames(['org1', 'org11'], paginator)
-      expect(badResult).toEqual([])
-    })
     it('getOrganizationsByIds', async () => {
       mockGet.mockResolvedValueOnce({
         status: 200,

--- a/packages/zendesk-adapter/test/filters/organizations.test.ts
+++ b/packages/zendesk-adapter/test/filters/organizations.test.ts
@@ -16,7 +16,7 @@
 import { ObjectType, ElemID, InstanceElement, isInstanceElement, toChange } from '@salto-io/adapter-api'
 import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
 import { ZENDESK } from '../../src/constants'
-import filterCreator, { getOrganizationsByIds, getOrganizationsByNames } from '../../src/filters/organizations'
+import filterCreator, { getOrganizationsByIds, getOrCreateOrganizationsByNames } from '../../src/filters/organizations'
 import { createFilterCreatorParams } from '../utils'
 import ZendeskClient from '../../src/client/client'
 import { FETCH_CONFIG, DEFAULT_CONFIG } from '../../src/config'
@@ -286,7 +286,7 @@ describe('organizations filter', () => {
       mockGet = jest.spyOn(client, 'getSinglePage')
       mockPost = jest.spyOn(client, 'post')
     })
-    describe('getOrganizationsByNames', () => {
+    describe('getOrCreateOrganizationsByNames', () => {
       it('should return correct result on valid response', async () => {
         mockGet.mockResolvedValueOnce({
           status: 200,
@@ -307,10 +307,10 @@ describe('organizations filter', () => {
           },
         })
 
-        const goodResult = await getOrganizationsByNames({
+        const goodResult = await getOrCreateOrganizationsByNames({
           organizationNames: ['org1', 'org11'],
           paginator,
-          defaultMissingOrgFallback: undefined,
+          createMissingOrganizations: undefined,
           client,
         })
         expect(goodResult).toEqual([
@@ -335,15 +335,15 @@ describe('organizations filter', () => {
             ],
           },
         })
-        const badResult = await getOrganizationsByNames({
+        const badResult = await getOrCreateOrganizationsByNames({
           organizationNames: ['org1', 'org11'],
           paginator,
-          defaultMissingOrgFallback: false,
+          createMissingOrganizations: false,
           client,
         })
         expect(badResult).toEqual([])
       })
-      it('should create org if defaultMissingOrgFallback is true', async () => {
+      it('should create org if createMissingOrganizations is true', async () => {
         mockGet.mockResolvedValueOnce({
           status: 200,
           data: {
@@ -365,10 +365,10 @@ describe('organizations filter', () => {
           },
         })
 
-        const goodResult = await getOrganizationsByNames({
+        const goodResult = await getOrCreateOrganizationsByNames({
           organizationNames: ['org1', 'org11'],
           paginator,
-          defaultMissingOrgFallback: true,
+          createMissingOrganizations: true,
           client,
         })
         expect(goodResult).toEqual([
@@ -376,7 +376,7 @@ describe('organizations filter', () => {
           { id: 2, name: 'org11' },
         ])
       })
-      it('should not create org if defaultMissingOrgFallback is true and res is invalid', async () => {
+      it('should not create org if createMissingOrganizations is true and res is invalid', async () => {
         mockGet.mockResolvedValueOnce({
           status: 200,
           data: {
@@ -397,17 +397,17 @@ describe('organizations filter', () => {
           },
         })
 
-        const goodResult = await getOrganizationsByNames({
+        const goodResult = await getOrCreateOrganizationsByNames({
           organizationNames: ['org1', 'org11'],
           paginator,
-          defaultMissingOrgFallback: true,
+          createMissingOrganizations: true,
           client,
         })
         expect(goodResult).toEqual([
           { id: 1, name: 'org1' },
         ])
       })
-      it('should not create org if defaultMissingOrgFallback is true post fails', async () => {
+      it('should not create org if createMissingOrganizations is true post fails', async () => {
         mockGet.mockResolvedValueOnce({
           status: 200,
           data: {
@@ -425,10 +425,10 @@ describe('organizations filter', () => {
           () => { throw Error('err') }
         )
 
-        const goodResult = await getOrganizationsByNames({
+        const goodResult = await getOrCreateOrganizationsByNames({
           organizationNames: ['org1', 'org11'],
           paginator,
-          defaultMissingOrgFallback: true,
+          createMissingOrganizations: true,
           client,
         })
         expect(goodResult).toEqual([


### PR DESCRIPTION
add ability to create missing orgs in deployment

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* when the deploy flag `defaultMissingOrgFallback` is true, missing referenced organizations will be created on deploy

---
_User Notifications_: 
None