### PR TITLE
SALTO-4643: Deploying notification scheme fails in E2E

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/cloud/notificationScheme.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/notificationScheme.ts
@@ -34,10 +34,6 @@ export const createNotificationSchemeValues = (name: string): Values => ({
           type: 'CurrentUser',
         },
         {
-          parameter: 'email@gmail.com',
-          type: 'EmailAddress',
-        },
-        {
           type: 'ProjectLead',
         },
         {


### PR DESCRIPTION
It looks like Jira removed the EmailAddress notification scheme so I removed it from the e2e

---
_Release Notes_: 
None

---
_User Notifications_: 
None