### PR TITLE
SALTO-4642: Display ElemId in deploy error messages

### DIFF
--- a/packages/cli/test/formatter.test.ts
+++ b/packages/cli/test/formatter.test.ts
@@ -79,25 +79,25 @@ describe('formatter', () => {
     severity: 'Info',
   }
   const workspaceDeployProblems: DeployError[] = [{
-    elemID: new ElemID('salesforce', 'TestType'),
+    elemID: new ElemID('salesforce', 'TestType1'),
     message: 'my error message 1',
     severity: 'Error',
     groupId: 'test group',
   },
   {
-    elemID: new ElemID('salesforce', 'TestType'),
+    elemID: new ElemID('salesforce', 'TestType2'),
     message: 'my error message 2',
     severity: 'Error',
     groupId: 'test group',
   },
   {
-    elemID: new ElemID('salesforce', 'TestType'),
+    elemID: new ElemID('salesforce', 'TestType3'),
     message: 'my warning message',
     severity: 'Warning',
     groupId: 'test group',
   },
   {
-    elemID: new ElemID('salesforce', 'TestType'),
+    elemID: new ElemID('salesforce', 'TestType4'),
     message: 'my info message',
     severity: 'Info',
     groupId: 'test group',
@@ -576,6 +576,12 @@ describe('formatter', () => {
       expect(formattedErrors).toContain('my error message 2')
       expect(formattedErrors).toContain('my warning message')
       expect(formattedErrors).toContain('my info message')
+    })
+    it('should contain element ID for salto element errors', () => {
+      expect(formattedErrors).toContain('salesforce.TestType1')
+      expect(formattedErrors).toContain('salesforce.TestType2')
+      expect(formattedErrors).toContain('salesforce.TestType3')
+      expect(formattedErrors).toContain('salesforce.TestType4')
     })
   })
 })


### PR DESCRIPTION
Display ElemId in deploy error messages & some readability improvements 

---

before:
<img width="1213" alt="image" src="https://github.com/salto-io/salto/assets/74004474/7b4e0f62-1b70-4d10-be42-d00c5434288d">


after:
<img width="1211" alt="image" src="https://github.com/salto-io/salto/assets/74004474/1ac1d436-7653-4d10-b7c7-10a12ff8609d">

---
_Release Notes_: 

_CLI_
- Improve readability of deploy errors in the CLI

---
_User Notifications_: 
None