### PR TITLE
SALTO-3955: Script Runner Listeners

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -135,6 +135,7 @@ import projectRoleRemoveTeamManagedDuplicatesFilter from './filters/remove_speci
 import projectFieldContextOrder from './filters/project_field_contexts_order'
 import scriptedFieldsIssueTypesFilter from './filters/script_runner/scripted_fields_issue_types'
 import scriptRunnerFilter from './filters/script_runner/script_runner_filter'
+import scriptRunnerListenersDeployFilter from './filters/script_runner/script_runner_listeners_deploy'
 import scriptRunnerInstancesDeploy from './filters/script_runner/script_runner_instances_deploy'
 import behaviorsMappingsFilter from './filters/script_runner/behaviors_mappings'
 import behaviorsFieldUuidFilter from './filters/script_runner/behaviors_field_uuid'
@@ -286,7 +287,8 @@ export const DEFAULT_FILTERS = [
   wrongUserPermissionSchemeFilter,
   deployDcIssueEventsFilter,
   addAliasFilter,
-  // Must run after scriptRunnerBatchDeploy
+  // must be done before scriptRunnerInstances
+  scriptRunnerListenersDeployFilter,
   scriptRunnerInstancesDeploy,
   // Must be last
   defaultInstancesDeployFilter,

--- a/packages/jira-adapter/src/change_validators/broken_references.ts
+++ b/packages/jira-adapter/src/change_validators/broken_references.ts
@@ -16,14 +16,11 @@
 
 import { isAdditionOrModificationChange, ChangeValidator, getChangeData, isInstanceChange, SeverityLevel, Value } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { isResolvedReferenceExpression, prettifyName } from '@salto-io/adapter-utils'
+import { prettifyName } from '@salto-io/adapter-utils'
 import { BROKEN_REFERENCE_TYPE_MAP } from '../filters/broken_reference_filter'
 
 const capitalizeFirstLetter = (input: string): string =>
   input.charAt(0).toUpperCase() + input.slice(1)
-
-export const isReferenceBroken = (reference: Value): boolean =>
-  !isResolvedReferenceExpression(reference)
 
 export const brokenReferenceValidator: ChangeValidator = async changes =>
   Object.entries(BROKEN_REFERENCE_TYPE_MAP).flatMap(([typeName, typeInfos]) =>

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1767,7 +1767,7 @@ const DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
 }
 
 export const DUCKTYPE_SUPPORTED_TYPES = {
-  // ScriptRunnerListener: ['ScriptRunnerListener'],
+  ScriptRunnerListener: ['ScriptRunnerListener'],
   // ScriptFragment: ['ScriptFragment'],
   ScheduledJob: ['ScheduledJob'],
   Behavior: ['Behavior'],

--- a/packages/jira-adapter/src/filters/broken_reference_filter.ts
+++ b/packages/jira-adapter/src/filters/broken_reference_filter.ts
@@ -17,7 +17,7 @@
 import { Change, ChangeDataType, ReferenceExpression, Value, getChangeData, isAdditionOrModificationChange, isInstanceChange, isReferenceExpression } from '@salto-io/adapter-api'
 import { isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import _ from 'lodash'
-import { AUTOMATION_TYPE, BEHAVIOR_TYPE, SCRIPTED_FIELD_TYPE } from '../constants'
+import { AUTOMATION_TYPE, BEHAVIOR_TYPE, SCRIPTED_FIELD_TYPE, SCRIPT_RUNNER_LISTENER_TYPE } from '../constants'
 import { FilterCreator } from '../filter'
 
 export type ProjectType = { projectId: ReferenceExpression }
@@ -47,6 +47,14 @@ export const BROKEN_REFERENCE_TYPE_MAP: Record<string, BrokenReferenceInfo[]> = 
     referencesTypeName: 'projects',
     singleReferenceTypeName: 'project',
     mustHaveReference: true,
+  }],
+  [SCRIPT_RUNNER_LISTENER_TYPE]: [{
+    location: 'projects',
+    filter: (project: unknown): boolean => !isResolvedReferenceExpression(project),
+    namePath: 'value.target.name',
+    referencesTypeName: 'projects',
+    singleReferenceTypeName: 'project',
+    mustHaveReference: false,
   }],
   [SCRIPTED_FIELD_TYPE]: [{
     location: 'issueTypes',

--- a/packages/jira-adapter/src/filters/script_runner/script_runner_listeners_deploy.ts
+++ b/packages/jira-adapter/src/filters/script_runner/script_runner_listeners_deploy.ts
@@ -1,0 +1,185 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Change, SaltoElementError, SeverityLevel, Value, getChangeData, isAdditionChange, isInstanceChange, isModificationChange, isRemovalChange } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import Joi from 'joi'
+import { logger } from '@salto-io/logging'
+import { createSchemeGuard, resolveChangeElement, resolveValues } from '@salto-io/adapter-utils'
+import { collections } from '@salto-io/lowerdash'
+import { FilterCreator } from '../../filter'
+import { SCRIPT_RUNNER_LISTENER_TYPE } from '../../constants'
+import { getLookUpName } from '../../reference_mapping'
+
+const { awu } = collections.asynciterable
+const log = logger(module)
+
+type ListenersResponse = {
+  values: Value[]
+}
+
+const LISTENERS_RESPONSE_SCHEME = Joi.object({
+  values: Joi.array().required(),
+}).required().unknown(true)
+
+const isListenersResponse = createSchemeGuard<ListenersResponse>(LISTENERS_RESPONSE_SCHEME, 'Received an invalid script runner listeners response')
+
+export const applyChangesToArray = async (changes: Change[], allValues: Value[], identifier: string): Promise<{
+  errors: SaltoElementError[]
+  appliedChanges: Change[]
+}> => {
+  const idToIndex = Object.fromEntries(allValues.map((value, index) => [value[identifier], index]))
+  const errors: SaltoElementError[] = []
+  const appliedChanges: Change[] = []
+
+  await awu(changes)
+    .filter(isInstanceChange)
+    .filter(isAdditionChange)
+    .forEach(async change => {
+      const resolvedChange = await resolveChangeElement(change, getLookUpName, resolveValues)
+      const instance = getChangeData(resolvedChange)
+      const index = idToIndex[instance.value[identifier]]
+      if (index !== undefined) {
+        log.error('Should never happened, newly created uuid exists in the service')
+        errors.push({
+          message: 'Failed to add instance as it already exists in the service',
+          severity: 'Error',
+          elemID: getChangeData(change).elemID,
+        })
+      } else {
+        allValues.push(instance.value)
+        appliedChanges.push(change)
+      }
+    })
+
+  await awu(changes)
+    .filter(isInstanceChange)
+    .filter(isModificationChange)
+    .forEach(async change => {
+      const resolvedChange = await resolveChangeElement(change, getLookUpName, resolveValues)
+      const instance = getChangeData(resolvedChange)
+      const index = idToIndex[instance.value[identifier]]
+      if (index !== undefined) {
+        allValues[index] = instance.value
+        appliedChanges.push(change)
+      } else {
+        errors.push({
+          severity: 'Error',
+          message: 'Failed to modify instance as it does not exist in the service',
+          elemID: instance.elemID,
+        })
+      }
+    })
+
+  await awu(changes)
+    .filter(isRemovalChange)
+    .filter(isInstanceChange)
+    .forEach(async change => {
+      const resolvedChange = await resolveChangeElement(change, getLookUpName, resolveValues)
+      const instance = getChangeData(resolvedChange)
+      // using find Index as the indices change when we remove elements
+      const index = allValues
+        .findIndex(value => value[identifier] === instance.value[identifier])
+      if (index !== -1) {
+        allValues.splice(index, 1)
+        appliedChanges.push(change)
+      } else {
+        errors.push({
+          severity: 'Error',
+          message: 'Failed to remove instance as it does not exist in the service',
+          elemID: instance.elemID,
+        })
+      }
+    })
+  return { errors, appliedChanges }
+}
+
+// This filter deploys script runner instances that are deployed in batches
+const filter: FilterCreator = ({ scriptRunnerClient, config }) => ({
+  name: 'scripRunnerBatchDeployFilter',
+  deploy: async changes => {
+    const { scriptRunnerApiDefinitions } = config
+    if (!config.fetch.enableScriptRunnerAddon || scriptRunnerApiDefinitions === undefined) {
+      return {
+        deployResult: { appliedChanges: [], errors: [] },
+        leftoverChanges: changes,
+      }
+    }
+
+    const [relevantChanges, leftoverChanges] = _.partition(
+      changes,
+      change => isInstanceChange(change)
+        && getChangeData(change).elemID.typeName === SCRIPT_RUNNER_LISTENER_TYPE
+    )
+    if (relevantChanges.length === 0) {
+      return {
+        leftoverChanges,
+        deployResult: { errors: [], appliedChanges: [] },
+      }
+    }
+    let allValues: Value[]
+    try {
+      const response = await scriptRunnerClient
+        .getSinglePage({
+          url: '/sr-dispatcher/jira/admin/token/scriptevents',
+        })
+      if (!isListenersResponse(response.data)) {
+        throw new Error('Received an invalid script runner listeners response')
+      }
+      allValues = response.data.values
+    } catch (e) {
+      return {
+        leftoverChanges,
+        deployResult: {
+          errors: relevantChanges
+            .map(getChangeData)
+            .map(instance => ({
+              severity: 'Error' as SeverityLevel,
+              message: 'Error getting other script-listeners information from the service',
+              elemID: instance.elemID,
+            })),
+          appliedChanges: [],
+        },
+      }
+    }
+    const { errors, appliedChanges } = await applyChangesToArray(relevantChanges, allValues, 'uuid')
+    try {
+      await scriptRunnerClient.put({
+        url: '/sr-dispatcher/jira/admin/token/scriptevents',
+        data: allValues,
+      })
+    } catch (e) {
+      const errorMessage = e instanceof Error ? e.message : e
+      log.error(`Failed to put script runner listeners with the error: ${errorMessage}`)
+      errors.push(...appliedChanges
+        .map(getChangeData)
+        .map(instance => ({
+          severity: 'Error' as SeverityLevel,
+          message: `${errorMessage}`,
+          elemID: instance.elemID,
+        })))
+      return {
+        deployResult: { appliedChanges: [], errors },
+        leftoverChanges,
+      }
+    }
+    return {
+      deployResult: { appliedChanges, errors },
+      leftoverChanges,
+    }
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/src/group_change.ts
+++ b/packages/jira-adapter/src/group_change.ts
@@ -16,7 +16,7 @@
 import { getChangeData, isModificationChange, isAdditionChange } from '@salto-io/adapter-api'
 import { getParent, getParents, isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { deployment } from '@salto-io/adapter-components'
-import { FIELD_CONFIGURATION_ITEM_TYPE_NAME, SECURITY_LEVEL_TYPE, WORKFLOW_TYPE_NAME } from './constants'
+import { FIELD_CONFIGURATION_ITEM_TYPE_NAME, SCRIPT_RUNNER_LISTENER_TYPE, SECURITY_LEVEL_TYPE, WORKFLOW_TYPE_NAME } from './constants'
 
 export const getWorkflowGroup: deployment.ChangeIdFunction = async change => (
   isModificationChange(change)
@@ -52,8 +52,14 @@ const getFieldConfigItemGroup: deployment.ChangeIdFunction = async change => {
   return `${parent.elemID.getFullName()} items`
 }
 
+const getScriptListenersGroup: deployment.ChangeIdFunction = async change =>
+  (getChangeData(change).elemID.typeName === SCRIPT_RUNNER_LISTENER_TYPE
+    ? 'Script Listeners'
+    : undefined)
+
 export const getChangeGroupIds = deployment.getChangeGroupIdsFunc([
   getWorkflowGroup,
   getSecurityLevelGroup,
   getFieldConfigItemGroup,
+  getScriptListenersGroup,
 ])

--- a/packages/jira-adapter/test/filters/script_runner/script_runner_filter.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/script_runner_filter.test.ts
@@ -19,7 +19,7 @@ import _ from 'lodash'
 import scriptRunnerFilter from '../../../src/filters/script_runner/script_runner_filter'
 import { createEmptyType, getFilterParams } from '../../utils'
 import { getDefaultConfig } from '../../../src/config/config'
-import { JIRA, SCRIPTED_FIELD_TYPE } from '../../../src/constants'
+import { JIRA, SCRIPTED_FIELD_TYPE, SCRIPT_FRAGMENT_TYPE, SCRIPT_RUNNER_LISTENER_TYPE } from '../../../src/constants'
 import * as users from '../../../src/users'
 
 type FilterType = filterUtils.FilterWith<'preDeploy' | 'onFetch'>
@@ -31,14 +31,33 @@ jest.mock('uuid', () => ({
 
 describe('script_runner_filter', () => {
   let filter: FilterType
-  let instance: InstanceElement
+  let auditInstance: InstanceElement
+  let listenerInstance: InstanceElement
+  let fragmentInstance: InstanceElement
+  beforeEach(() => {
+    auditInstance = new InstanceElement(
+      'instance',
+      createEmptyType(SCRIPTED_FIELD_TYPE),
+      {}
+    )
+    listenerInstance = new InstanceElement(
+      'instance',
+      createEmptyType(SCRIPT_RUNNER_LISTENER_TYPE),
+      {}
+    )
+    fragmentInstance = new InstanceElement(
+      'instance',
+      createEmptyType(SCRIPT_FRAGMENT_TYPE),
+      {}
+    )
+  })
   describe('when script runner is enabled', () => {
     beforeEach(() => {
       const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
       config.fetch.enableScriptRunnerAddon = true
       filter = scriptRunnerFilter(getFilterParams({ config })) as FilterType
       const now = 10000
-      jest.spyOn(Date, 'now').mockReturnValueOnce(now)
+      jest.spyOn(Date, 'now').mockReturnValue(now)
       jest.spyOn(users, 'getCurrentUserInfo').mockResolvedValueOnce({
         userId: 'salto',
         displayName: 'saltoName',
@@ -60,96 +79,83 @@ describe('script_runner_filter', () => {
       expect(scriptedFields.fields.notImportant.annotations[CORE_ANNOTATIONS.DELETABLE]).toEqual(true)
     })
     describe('on creation', () => {
-      it('should add audit info', async () => {
-        instance = new InstanceElement(
-          'instance',
-          createEmptyType(SCRIPTED_FIELD_TYPE),
-          {}
-        )
-        await filter.preDeploy([toChange({ after: instance })])
-        expect(instance.value.auditData).toEqual({
+      it('should add audit info to relevant types', async () => {
+        await filter.preDeploy([
+          toChange({ after: auditInstance }),
+          toChange({ after: listenerInstance }),
+          toChange({ after: fragmentInstance })])
+        expect(auditInstance.value.auditData).toEqual({
           createdByAccountId: 'salto',
-          createdTimestamp: 10,
+          createdTimestamp: '10',
         })
+        expect(listenerInstance.value.createdByAccountId).toEqual('salto')
+        expect(listenerInstance.value.createdTimestamp).toEqual('10')
+        expect(fragmentInstance.value.createdByAccountId).toBeUndefined()
+        expect(fragmentInstance.value.createdTimestamp).toBeUndefined()
       })
       it('should add uuid', async () => {
-        instance = new InstanceElement(
-          'instance',
-          createEmptyType(SCRIPTED_FIELD_TYPE),
-          {}
-        )
-        await filter.preDeploy([toChange({ after: instance })])
-        expect(instance.value.uuid).toEqual('my-uuid')
+        await filter.preDeploy([
+          toChange({ after: auditInstance }),
+          toChange({ after: listenerInstance }),
+          toChange({ after: fragmentInstance })])
+        expect(auditInstance.value.uuid).toEqual('my-uuid')
+        expect(listenerInstance.value.uuid).toEqual('my-uuid')
+        expect(fragmentInstance.value.id).toEqual('my-uuid')
       })
       it('should add audit info when not defined', async () => {
-        instance = new InstanceElement(
-          'instance',
-          createEmptyType(SCRIPTED_FIELD_TYPE),
-          {}
-        )
         jest.spyOn(users, 'getCurrentUserInfo').mockReset()
         jest.spyOn(users, 'getCurrentUserInfo').mockResolvedValueOnce(undefined)
-        await filter.preDeploy([toChange({ after: instance })])
-        expect(instance.value.auditData).toEqual({
+        await filter.preDeploy([toChange({ after: auditInstance })])
+        expect(auditInstance.value.auditData).toEqual({
           createdByAccountId: '',
-          createdTimestamp: 10,
+          createdTimestamp: '10',
         })
       })
     })
     describe('on update', () => {
-      it('should add audit info', async () => {
-        instance = new InstanceElement(
-          'instance',
-          createEmptyType(SCRIPTED_FIELD_TYPE),
-          {
-            auditData: {
-              createdByAccountId: 'not-salto',
-              createdTimestamp: 1,
-            },
-          }
-        )
-        await filter.preDeploy([toChange({ before: instance, after: instance })])
-        expect(instance.value.auditData).toEqual({
+      beforeEach(() => {
+        const auditData = {
           createdByAccountId: 'not-salto',
-          createdTimestamp: 1,
+          createdTimestamp: '1',
+        }
+        auditInstance.value.auditData = auditData
+        listenerInstance.value = auditData
+      })
+      it('should add audit info for relevant types', async () => {
+        await filter.preDeploy([
+          toChange({ before: auditInstance, after: auditInstance }),
+          toChange({ before: listenerInstance, after: listenerInstance })])
+        expect(auditInstance.value.auditData).toEqual({
+          createdByAccountId: 'not-salto',
+          createdTimestamp: '1',
           updatedByAccountId: 'salto',
-          updatedTimestamp: 10,
+          updatedTimestamp: '10',
         })
+        expect(listenerInstance.value.updatedByAccountId).toEqual('salto')
+        expect(listenerInstance.value.updatedTimestamp).toEqual('10')
       })
       it('should not change the  uuid', async () => {
-        instance = new InstanceElement(
-          'instance',
-          createEmptyType(SCRIPTED_FIELD_TYPE),
-          {
-            uuid: 'not-my-uuid',
-            auditData: {
-              createdByAccountId: 'not-salto',
-              createdTimestamp: 1,
-            },
-          }
-        )
-        await filter.preDeploy([toChange({ before: instance, after: instance })])
-        expect(instance.value.uuid).toEqual('not-my-uuid')
+        auditInstance.value.uuid = 'not-my-uuid'
+        listenerInstance.value.uuid = 'not-my-uuid'
+        fragmentInstance.value.id = 'not-my-uuid'
+
+        await filter.preDeploy([
+          toChange({ before: auditInstance, after: auditInstance }),
+          toChange({ before: listenerInstance, after: listenerInstance }),
+          toChange({ before: fragmentInstance, after: auditInstance })])
+        expect(auditInstance.value.uuid).toEqual('not-my-uuid')
+        expect(listenerInstance.value.uuid).toEqual('not-my-uuid')
+        expect(fragmentInstance.value.id).toEqual('not-my-uuid')
       })
       it('should add audit info when not defined', async () => {
-        instance = new InstanceElement(
-          'instance',
-          createEmptyType(SCRIPTED_FIELD_TYPE),
-          {
-            auditData: {
-              createdByAccountId: 'not-salto',
-              createdTimestamp: 1,
-            },
-          }
-        )
         jest.spyOn(users, 'getCurrentUserInfo').mockReset()
         jest.spyOn(users, 'getCurrentUserInfo').mockResolvedValueOnce(undefined)
-        await filter.preDeploy([toChange({ before: instance, after: instance })])
-        expect(instance.value.auditData).toEqual({
+        await filter.preDeploy([toChange({ before: auditInstance, after: auditInstance })])
+        expect(auditInstance.value.auditData).toEqual({
           createdByAccountId: 'not-salto',
-          createdTimestamp: 1,
+          createdTimestamp: '1',
           updatedByAccountId: '',
-          updatedTimestamp: 10,
+          updatedTimestamp: '10',
         })
       })
     })
@@ -171,13 +177,8 @@ describe('script_runner_filter', () => {
       expect(scriptedFields.annotations[CORE_ANNOTATIONS.CREATABLE]).toBeUndefined()
     })
     it('should not add audit info on creation', async () => {
-      instance = new InstanceElement(
-        'instance',
-        createEmptyType(SCRIPTED_FIELD_TYPE),
-        {}
-      )
-      await filter.preDeploy([toChange({ after: instance })])
-      expect(instance.value.auditData).toBeUndefined()
+      await filter.preDeploy([toChange({ after: auditInstance })])
+      expect(auditInstance.value.auditData).toBeUndefined()
     })
   })
 })

--- a/packages/jira-adapter/test/filters/script_runner/script_runner_listeners_deploy.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/script_runner_listeners_deploy.test.ts
@@ -1,0 +1,377 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { filterUtils } from '@salto-io/adapter-components'
+import { BuiltinTypes, ElemID, InstanceElement, ListType, ObjectType, ReferenceExpression, Value, toChange } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import scriptRunnerListenersDeploy from '../../../src/filters/script_runner/script_runner_listeners_deploy'
+import { createEmptyType, getFilterParams } from '../../utils'
+import { getDefaultConfig } from '../../../src/config/config'
+import { JIRA, PROJECT_TYPE, SCRIPT_RUNNER_LISTENER_TYPE } from '../../../src/constants'
+import ScriptRunnerClient from '../../../src/client/script_runner_client'
+
+
+type FilterType = filterUtils.FilterWith<'deploy'>
+describe('script_runner_listeners_deploy', () => {
+  let filter: FilterType
+  let type: ObjectType
+  let scriptInstanceAdd: InstanceElement
+  let scriptInstanceModify: InstanceElement
+  let instance3: InstanceElement
+  let project: InstanceElement
+  let mockPut: jest.Mock
+  let mockGetSinglePage: jest.Mock
+  let baseValues: Value[]
+  beforeEach(() => {
+    type = new ObjectType({
+      elemID: new ElemID(JIRA, SCRIPT_RUNNER_LISTENER_TYPE),
+      fields: {
+        uuid: { refType: BuiltinTypes.STRING },
+        name: { refType: BuiltinTypes.STRING },
+        projects: { refType: new ListType(BuiltinTypes.STRING) },
+      },
+    })
+
+    baseValues = [{
+      uuid: '1', name: 'n1',
+    }, {
+      uuid: '2', name: 'n2',
+    }, {
+      uuid: '3', name: 'n3',
+    }, {
+      uuid: '4', name: 'n4',
+    }]
+    scriptInstanceAdd = new InstanceElement(
+      'instance',
+      type,
+      {
+        uuid: '5', name: 'n5',
+      }
+    )
+    scriptInstanceModify = new InstanceElement(
+      'instance2',
+      type,
+      {
+        uuid: '2', name: 'n55',
+      }
+    )
+    instance3 = new InstanceElement(
+      'instance3',
+      createEmptyType('type'),
+    )
+    project = new InstanceElement(
+      'project',
+      createEmptyType(PROJECT_TYPE),
+      {
+        key: 'COM',
+      }
+    )
+    const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+    config.fetch.enableScriptRunnerAddon = true
+    filter = scriptRunnerListenersDeploy(getFilterParams({ config })) as FilterType
+    mockGetSinglePage = jest.fn()
+    mockPut = jest.fn()
+    ScriptRunnerClient.prototype.getSinglePage = mockGetSinglePage
+    ScriptRunnerClient.prototype.put = mockPut
+    mockGetSinglePage.mockResolvedValue({
+      status: 200,
+      data: {
+        values: _.cloneDeep(baseValues),
+      },
+    })
+    mockPut.mockResolvedValue({
+      status: 200,
+    })
+  })
+  it('should properly add a script listener', async () => {
+    const res = await filter.deploy([toChange({ after: scriptInstanceAdd })])
+    expect(res).toEqual({
+      deployResult: {
+        appliedChanges: [toChange({ after: scriptInstanceAdd })],
+        errors: [],
+      },
+      leftoverChanges: [],
+    })
+    baseValues.push({
+      uuid: '5', name: 'n5',
+    })
+    expect(mockPut).toHaveBeenCalledWith({
+      url: '/sr-dispatcher/jira/admin/token/scriptevents',
+      data: baseValues,
+    })
+  })
+  it('should properly modify a script listener', async () => {
+    const res = await filter.deploy([toChange({ before: scriptInstanceAdd, after: scriptInstanceModify })])
+    expect(res).toEqual({
+      deployResult: {
+        appliedChanges: [toChange({ before: scriptInstanceAdd, after: scriptInstanceModify })],
+        errors: [],
+      },
+      leftoverChanges: [],
+    })
+    expect(mockPut).toHaveBeenCalledWith({
+      url: '/sr-dispatcher/jira/admin/token/scriptevents',
+      data: [{
+        uuid: '1', name: 'n1',
+      }, {
+        uuid: '2', name: 'n55',
+      }, {
+        uuid: '3', name: 'n3',
+      }, {
+        uuid: '4', name: 'n4',
+      }],
+    })
+  })
+  it('should properly remove a script listener', async () => {
+    const res = await filter.deploy([toChange({ before: scriptInstanceModify })])
+    expect(res).toEqual({
+      deployResult: {
+        appliedChanges: [toChange({ before: scriptInstanceModify })],
+        errors: [],
+      },
+      leftoverChanges: [],
+    })
+    expect(mockPut).toHaveBeenCalledWith({
+      url: '/sr-dispatcher/jira/admin/token/scriptevents',
+      data: [{
+        uuid: '1', name: 'n1',
+      }, {
+        uuid: '3', name: 'n3',
+      }, {
+        uuid: '4', name: 'n4',
+      }],
+    })
+  })
+  it('should properly deploy many script listeners', async () => {
+    const scriptInstanceRemove1 = new InstanceElement(
+      'instanceR1',
+      type,
+      {
+        uuid: '1', name: 'n1',
+      }
+    )
+    const scriptInstanceRemove2 = new InstanceElement(
+      'instanceR2',
+      type,
+      {
+        uuid: '4', name: 'n4',
+      }
+    )
+    const scriptInstanceModify2 = new InstanceElement(
+      'instanceM2',
+      type,
+      {
+        uuid: '3', name: 'n33',
+      }
+    )
+    const scriptInstanceAdd2 = new InstanceElement(
+      'instanceA2',
+      type,
+      {
+        uuid: '6', name: 'n6',
+      }
+    )
+    const changes = [
+      toChange({ before: scriptInstanceRemove1 }),
+      toChange({ before: scriptInstanceRemove2 }),
+      toChange({ before: scriptInstanceRemove1, after: scriptInstanceModify }),
+      toChange({ before: scriptInstanceRemove1, after: scriptInstanceModify2 }),
+      toChange({ after: scriptInstanceAdd }),
+      toChange({ after: scriptInstanceAdd2 }),
+    ]
+    const res = await filter.deploy(changes)
+    expect(res.deployResult.appliedChanges).toEqual(expect.arrayContaining(changes))
+    expect(res.deployResult.errors).toEqual([])
+    expect(res.leftoverChanges).toEqual([])
+    expect(mockPut).toHaveBeenCalledWith({
+      url: '/sr-dispatcher/jira/admin/token/scriptevents',
+      data: [{
+        uuid: '2', name: 'n55',
+      }, {
+        uuid: '3', name: 'n33',
+      }, {
+        uuid: '5', name: 'n5',
+      }, {
+        uuid: '6', name: 'n6',
+      }],
+    })
+  })
+  it('should return empty if no relevant changes', async () => {
+    const res = await filter.deploy([
+      toChange({ after: instance3 }),
+    ])
+    expect(res.deployResult.appliedChanges).toEqual([])
+    expect(res.deployResult.errors).toEqual([])
+    expect(res.leftoverChanges).toEqual(
+      [toChange({ after: instance3 })],
+    )
+  })
+  it('should return the proper error if get fails', async () => {
+    mockGetSinglePage.mockReset()
+    mockGetSinglePage.mockResolvedValueOnce({
+      status: 200,
+      data: {},
+    })
+    const res = await filter.deploy([toChange({ after: scriptInstanceAdd })])
+    expect(res).toEqual({
+      deployResult: {
+        appliedChanges: [],
+        errors: [{
+          severity: 'Error',
+          message: 'Error getting other script-listeners information from the service',
+          elemID: scriptInstanceAdd.elemID,
+        }],
+      },
+      leftoverChanges: [],
+    })
+  })
+  it('should handle references correctly', async () => {
+    const removedInstance = new InstanceElement(
+      'instance',
+      type,
+      {
+        uuid: '1',
+        name: 'n1',
+        projects: [new ReferenceExpression(project.elemID, project)],
+      }
+    )
+    scriptInstanceAdd.value.projects = [new ReferenceExpression(project.elemID, project)]
+    scriptInstanceModify.value.projects = [new ReferenceExpression(project.elemID, project)]
+    const res = await filter.deploy([
+      toChange({ after: scriptInstanceAdd }),
+      toChange({ before: scriptInstanceAdd, after: scriptInstanceModify }),
+      toChange({ before: removedInstance })])
+    expect(res.deployResult.appliedChanges).toEqual([
+      toChange({ after: scriptInstanceAdd }),
+      toChange({ before: scriptInstanceAdd, after: scriptInstanceModify }),
+      toChange({ before: removedInstance })])
+    expect(mockPut).toHaveBeenCalledWith({
+      url: '/sr-dispatcher/jira/admin/token/scriptevents',
+      data: [{
+        uuid: '2', name: 'n55', projects: ['COM'],
+      }, {
+        uuid: '3', name: 'n3',
+      }, {
+        uuid: '4', name: 'n4',
+      }, {
+        uuid: '5', name: 'n5', projects: ['COM'],
+      }],
+    })
+  })
+  it('should return the proper error if put fails', async () => {
+    mockPut.mockReset()
+    mockPut.mockRejectedValueOnce(new Error('error'))
+    const res = await filter.deploy(
+      [toChange({ after: scriptInstanceAdd }),
+        toChange({ before: scriptInstanceAdd, after: scriptInstanceModify })]
+    )
+    expect(res).toEqual({
+      deployResult: {
+        appliedChanges: [],
+        errors: [{
+          severity: 'Error',
+          message: 'error',
+          elemID: scriptInstanceAdd.elemID,
+        }, {
+          severity: 'Error',
+          message: 'error',
+          elemID: scriptInstanceModify.elemID,
+        },
+        ],
+      },
+      leftoverChanges: [],
+    })
+  })
+  it('should return the proper error if put fails with weird error', async () => {
+    mockPut.mockReset()
+    mockPut.mockRejectedValueOnce(1)
+    const res = await filter.deploy(
+      [toChange({ after: scriptInstanceAdd }),
+        toChange({ before: scriptInstanceAdd, after: scriptInstanceModify })]
+    )
+    expect(res).toEqual({
+      deployResult: {
+        appliedChanges: [],
+        errors: [{
+          severity: 'Error',
+          message: '1',
+          elemID: scriptInstanceAdd.elemID,
+        }, {
+          severity: 'Error',
+          message: '1',
+          elemID: scriptInstanceModify.elemID,
+        },
+        ],
+      },
+      leftoverChanges: [],
+    })
+  })
+  it('should return the proper errors if there are mismatches with the service', async () => {
+    const removalInstance = new InstanceElement(
+      'instanceR1',
+      type,
+      {
+        uuid: '6', name: 'n6',
+      }
+    )
+    const removalInstance2 = new InstanceElement(
+      'instanceR2',
+      type,
+      {
+        uuid: '3', name: 'n3',
+      }
+    )
+    const res = await filter.deploy(
+      [toChange({ after: scriptInstanceModify }),
+        toChange({ before: scriptInstanceModify, after: scriptInstanceAdd }),
+        toChange({ before: removalInstance }),
+        toChange({ before: removalInstance2 })]
+    )
+    expect(res.deployResult.appliedChanges).toEqual([toChange({ before: removalInstance2 })])
+    expect(res.leftoverChanges).toEqual([])
+    expect(res.deployResult.errors[0]).toEqual({
+      severity: 'Error',
+      message: 'Failed to add instance as it already exists in the service',
+      elemID: scriptInstanceModify.elemID,
+    })
+    expect(res.deployResult.errors[1]).toEqual({
+      severity: 'Error',
+      message: 'Failed to modify instance as it does not exist in the service',
+      elemID: scriptInstanceAdd.elemID,
+    })
+    expect(res.deployResult.errors[2]).toEqual({
+      severity: 'Error',
+      message: 'Failed to remove instance as it does not exist in the service',
+      elemID: removalInstance.elemID,
+    })
+  })
+  it('should not deploy if script runner is disabled', async () => {
+    const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+    config.fetch.enableScriptRunnerAddon = false
+    filter = scriptRunnerListenersDeploy(getFilterParams({ config })) as FilterType
+    const res = await filter.deploy([
+      toChange({ after: scriptInstanceAdd }),
+      toChange({ after: scriptInstanceModify }),
+      toChange({ after: instance3 }),
+    ])
+    expect(res.deployResult.appliedChanges).toEqual([])
+    expect(res.deployResult.errors).toEqual([])
+    expect(res.leftoverChanges).toEqual(
+      [toChange({ after: scriptInstanceAdd }),
+        toChange({ after: scriptInstanceModify }),
+        toChange({ after: instance3 })],
+    )
+  })
+})


### PR DESCRIPTION
Added support for script runner listeners

---
The deployment is done for all listeners together. Implementation tries to hide it from the users
The same deployment method is required for scripted fragments, there will be some reuse and some copy-paste

---
_Release Notes_: 
Jira Adapter:
* Added support for ScriptRunner Listeners

---
_User Notifications_: 
Jira Adapter:
* Customers with ScriptRunner enabled will see new ScriptRunner Listeners NaCls
