### PR TITLE
SALTO-4500 - Salesforce: update error message when dropping data instances

### DIFF
--- a/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
@@ -93,17 +93,22 @@ const createWarnings = async (
       .uniq()
       .value()
     const numMissingInstances = _.uniqBy(missingRefsFromOriginType, missingRef => missingRef.targetId).length
-    const header = `${numMissingInstances} records of the ${originTypeName} object were not fetched, along with their child records of the ${typesOfMissingRefsTargets.join(', ')} objects.\n\nHere are the relevant records:`
+    const header = `Your Salto environment is configured to manage records of the ${originTypeName} object. ${numMissingInstances} ${originTypeName} records were not fetched because they have a lookup relationship to one of the following objects:`
+    const perTargetTypeMsgs = typesOfMissingRefsTargets.join('\n')
+    const perInstancesPreamble = 'and these objects are not part of your Salto configuration. \n\nHere are the records:'
     const perMissingInstanceMsgs = missingRefs
       .map(missingRef => `${getInstanceDesc(missingRef.origin.id, baseUrl)} relates to ${getInstanceDesc(missingRef.targetId, baseUrl)}`)
       .slice(0, MAX_BREAKDOWN_ELEMENTS)
+      .sort() // this effectively sorts by origin instance ID
 
-    const epilogue = `This is most likely because ${originTypeName} has a relationship to ${typesOfMissingRefsTargets.join(', ')}, yet ${typesOfMissingRefsTargets.join(', ')} hasn't been included in your data fetch configuration.
-
-Please follow the instructions here [new intercom article] to resolve this issue. `
-    const overflowMsg = numMissingInstances > MAX_BREAKDOWN_ELEMENTS ? ['', `... and ${numMissingInstances - MAX_BREAKDOWN_ELEMENTS} more missing Instances`] : []
+    const epilogue = 'To resolve this issue, follow the steps outlined here: https://help.salto.io/en/articles/8283155-data-records-were-not-fetched'
+    const overflowMsg = numMissingInstances > MAX_BREAKDOWN_ELEMENTS ? ['', `... and ${numMissingInstances - MAX_BREAKDOWN_ELEMENTS} more missing records`] : []
     return createWarningFromMsg([
       header,
+      '',
+      perTargetTypeMsgs,
+      '',
+      perInstancesPreamble,
       '',
       ...perMissingInstanceMsgs,
       ...overflowMsg,

--- a/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
@@ -20,7 +20,6 @@ import {
   TransformFunc,
   getAndLogCollisionWarnings,
   getInstanceDesc,
-  getInstancesDetailsMsg,
   createWarningFromMsg,
   getInstancesWithCollidingElemID,
   safeJsonStringify,
@@ -37,8 +36,8 @@ import {
   CORE_ANNOTATIONS,
 } from '@salto-io/adapter-api'
 import { FilterResult, RemoteFilterCreator } from '../filter'
-import { apiName, isInstanceOfCustomObject, isCustomObject } from '../transformers/transformer'
-import { FIELD_ANNOTATIONS, KEY_PREFIX, KEY_PREFIX_LENGTH, SALESFORCE } from '../constants'
+import { apiName, isInstanceOfCustomObject } from '../transformers/transformer'
+import { FIELD_ANNOTATIONS, SALESFORCE } from '../constants'
 import { isLookupField, isMasterDetailField, safeApiName } from './utils'
 import { DataManagement } from '../fetch_profile/data_management'
 
@@ -47,8 +46,7 @@ const { isDefined } = lowerdashValues
 const { DefaultMap } = collections.map
 const { keyByAsync } = collections.asynciterable
 const { removeAsync } = promises.array
-const { mapValuesAsync } = promises.object
-type RefOrigin = { type: string; id: string; field?: string }
+type RefOrigin = { type: string; id: string; field?: Field }
 type MissingRef = {
   origin: RefOrigin
   targetId: string
@@ -82,10 +80,42 @@ const createWarnings = async (
   instancesWithEmptyIds: InstanceElement[],
   missingRefs: MissingRef[],
   illegalRefSources: Set<string>,
-  customObjectPrefixKeyMap: Record<string, string>,
   dataManagement: DataManagement,
   baseUrl?: string,
 ): Promise<SaltoError[]> => {
+  const createOmittedInstancesWarning = async (
+    originTypeName: string,
+    missingRefsFromOriginType: MissingRef[],
+  ): Promise<SaltoError> => {
+    const typesOfMissingRefsTargets: string[] = _(missingRefsFromOriginType)
+      .map(missingRef => missingRef.origin.field?.annotations[FIELD_ANNOTATIONS.REFERENCE_TO])
+      .filter(isDefined)
+      .uniq()
+      .value()
+    const numMissingInstances = _(missingRefsFromOriginType)
+      .map(missingRef => missingRef.targetId)
+      .uniq()
+      .value().length
+    const header = `${numMissingInstances} records of the ${originTypeName} object were not fetched, along with their child records of the ${typesOfMissingRefsTargets.join(', ')} objects.\n\nHere are the relevant records:`
+    const perMissingInstanceMsgs = missingRefs
+      .map(missingRef => `${getInstanceDesc(missingRef.origin.id, baseUrl)} relates to ${getInstanceDesc(missingRef.targetId, baseUrl)}`)
+      .slice(0, MAX_BREAKDOWN_ELEMENTS)
+
+    const epilogue = `This is most likely because ${originTypeName} has a relationship to ${typesOfMissingRefsTargets.join(', ')}, yet ${typesOfMissingRefsTargets.join(', ')} hasn't been included in your data fetch configuration.
+
+Please follow the instructions here [new intercom article] to resolve this issue. `
+    const overflowMsg = numMissingInstances > MAX_BREAKDOWN_ELEMENTS ? ['', `... and ${numMissingInstances - MAX_BREAKDOWN_ELEMENTS} more missing Instances`] : []
+    return createWarningFromMsg([
+      header,
+      '',
+      ...perMissingInstanceMsgs,
+      ...overflowMsg,
+      '',
+      epilogue,
+    ].join('\n'))
+  }
+
+
   const collisionWarnings = await getAndLogCollisionWarnings({
     adapterName: SALESFORCE,
     baseUrl,
@@ -112,37 +142,19 @@ const createWarnings = async (
     })
     .toArray()
 
-  const typeToInstanceIdToMissingRefs = _.mapValues(
-    _.groupBy(
-      missingRefs,
-      missingRef => customObjectPrefixKeyMap[missingRef.targetId.substring(0, KEY_PREFIX_LENGTH)],
-    ),
-    typeMissingRefs => _.groupBy(typeMissingRefs, missingRef => missingRef.targetId)
-  )
+  // const typeToInstanceIdToMissingRefs = _.mapValues(
+  //   _.groupBy(
+  //     missingRefs,
+  //     missingRef => customObjectPrefixKeyMap[missingRef.targetId.substring(0, KEY_PREFIX_LENGTH)],
+  //   ),
+  //   typeMissingRefs => _.groupBy(typeMissingRefs, missingRef => missingRef.targetId)
+  // )
 
-  const missingRefsWarnings = Object.entries(typeToInstanceIdToMissingRefs)
-    .map(([type, instanceIdToMissingRefs]) => {
-      const numMissingInstances = Object.keys(instanceIdToMissingRefs).length
-      const header = `Identified references to ${numMissingInstances} missing instances of ${type}`
-      const perMissingInstToDisplay = Object.entries(instanceIdToMissingRefs)
-        .slice(0, MAX_BREAKDOWN_ELEMENTS)
-      const perMissingInstanceMsgs = perMissingInstToDisplay
-        .map(([instanceId, instanceMissingRefs]) => `${getInstanceDesc(instanceId, baseUrl)} referenced from -
-  ${getInstancesDetailsMsg(instanceMissingRefs.map(instanceMissingRef => instanceMissingRef.origin.id), baseUrl)}`)
-      const epilogue = `To resolve this issue please edit the salesforce.nacl file to include ${type} instances in the data management configuration and fetch again.
+  const originTypeToMissingRef = _.groupBy(missingRefs, missingRef => missingRef.origin.type)
 
-      Alternatively, you can exclude the referring types from the data management configuration in salesforce.nacl`
-      const missingInstCount = Object.keys(instanceIdToMissingRefs).length
-      const overflowMsg = missingInstCount > MAX_BREAKDOWN_ELEMENTS ? ['', `And ${missingInstCount - MAX_BREAKDOWN_ELEMENTS} more missing Instances`] : []
-      return createWarningFromMsg([
-        header,
-        '',
-        ...perMissingInstanceMsgs,
-        ...overflowMsg,
-        '',
-        epilogue,
-      ].join('\n'))
-    })
+  const missingRefsWarnings = await awu(Object.entries(originTypeToMissingRef))
+    .map(([originType, missingRefsFromType]) => createOmittedInstancesWarning(originType, missingRefsFromType))
+    .toArray()
 
   const typesOfIllegalRefSources = _.uniq([...illegalRefSources]
     .map(deserializeInternalID)
@@ -210,7 +222,7 @@ const replaceLookupsWithRefsAndCreateRefMap = async (
             origin: {
               type: await apiName(await instance.getType(), true),
               id: await apiName(instance),
-              field: field.name,
+              field,
             },
             targetId: instance.value[field.name],
           })
@@ -266,25 +278,6 @@ const getIllegalRefSources = (
   return illegalRefSources
 }
 
-const buildCustomObjectPrefixKeyMap = async (
-  elements: Element[]
-): Promise<Record<string, string>> => {
-  const customObjects = await awu(elements)
-    .filter(isCustomObject)
-    .filter(customObject => isDefined(customObject.annotations[KEY_PREFIX]))
-    .toArray()
-  const keyPrefixToCustomObject = _.keyBy(
-    customObjects,
-    customObject => customObject.annotations[KEY_PREFIX] as string,
-  )
-  return mapValuesAsync(
-    keyPrefixToCustomObject,
-    // Looking at Salesforce's keyPrefix results duplicate types with
-    // the same prefix exist but are not relevant/important to differentiate between
-    keyCustomObject => apiName(keyCustomObject),
-  )
-}
-
 const filter: RemoteFilterCreator = ({ client, config }) => ({
   name: 'customObjectInstanceReferencesFilter',
   remote: true,
@@ -332,14 +325,13 @@ const filter: RemoteFilterCreator = ({ client, config }) => ({
         && invalidInstances.has(await serializeInstanceInternalID(element as InstanceElement))),
     )
     const baseUrl = await client.getUrl()
-    const customObjectPrefixKeyMap = await buildCustomObjectPrefixKeyMap(elements)
+    // const customObjectPrefixKeyMap = await buildCustomObjectPrefixKeyMap(elements)
     return {
       errors: await createWarnings(
         instancesWithCollidingElemID,
         instancesWithEmptyId,
         missingRefs,
         illegalRefSources,
-        customObjectPrefixKeyMap,
         dataManagement,
         baseUrl?.origin,
       ),

--- a/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
@@ -92,10 +92,7 @@ const createWarnings = async (
       .filter(isDefined)
       .uniq()
       .value()
-    const numMissingInstances = _(missingRefsFromOriginType)
-      .map(missingRef => missingRef.targetId)
-      .uniq()
-      .value().length
+    const numMissingInstances = _.uniqBy(missingRefsFromOriginType, missingRef => missingRef.targetId).length
     const header = `${numMissingInstances} records of the ${originTypeName} object were not fetched, along with their child records of the ${typesOfMissingRefsTargets.join(', ')} objects.\n\nHere are the relevant records:`
     const perMissingInstanceMsgs = missingRefs
       .map(missingRef => `${getInstanceDesc(missingRef.origin.id, baseUrl)} relates to ${getInstanceDesc(missingRef.targetId, baseUrl)}`)
@@ -141,14 +138,6 @@ Please follow the instructions here [new intercom article] to resolve this issue
       )
     })
     .toArray()
-
-  // const typeToInstanceIdToMissingRefs = _.mapValues(
-  //   _.groupBy(
-  //     missingRefs,
-  //     missingRef => customObjectPrefixKeyMap[missingRef.targetId.substring(0, KEY_PREFIX_LENGTH)],
-  //   ),
-  //   typeMissingRefs => _.groupBy(typeMissingRefs, missingRef => missingRef.targetId)
-  // )
 
   const originTypeToMissingRef = _.groupBy(missingRefs, missingRef => missingRef.origin.type)
 
@@ -325,7 +314,6 @@ const filter: RemoteFilterCreator = ({ client, config }) => ({
         && invalidInstances.has(await serializeInstanceInternalID(element as InstanceElement))),
     )
     const baseUrl = await client.getUrl()
-    // const customObjectPrefixKeyMap = await buildCustomObjectPrefixKeyMap(elements)
     return {
       errors: await createWarnings(
         instancesWithCollidingElemID,


### PR DESCRIPTION
Change the format of the error message as described by our Product folks.

---

Looks like when we went from grouping by ref target to grouping by ref source the code ends up much simpler. Or maybe there's something I missed.

 - [x] Intercom article link


New message looks like this:
```
Your Salto environment is configured to manage records of the Case object. 24 Case records were not fetched because they have a lookup relationship to one of the following objects:

Account
Contact

and these objects are not part of your Salto configuration. 

Here are the records:

https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0oWIAS relates to https://salto-b7-dev-ed.my.salesforce.com/001Dn0000063rYwIAI
https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0oWIAS relates to https://salto-b7-dev-ed.my.salesforce.com/003Dn000003q0a6IAA
https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0oXIAS relates to https://salto-b7-dev-ed.my.salesforce.com/001Dn0000063rYrIAI
https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0oXIAS relates to https://salto-b7-dev-ed.my.salesforce.com/003Dn000003q0ZpIAI
https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0oYIAS relates to https://salto-b7-dev-ed.my.salesforce.com/001Dn0000063rYwIAI
https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0oYIAS relates to https://salto-b7-dev-ed.my.salesforce.com/003Dn000003q0ZwIAI
https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0oZIAS relates to https://salto-b7-dev-ed.my.salesforce.com/001Dn0000063rYxIAI
https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0oZIAS relates to https://salto-b7-dev-ed.my.salesforce.com/003Dn000003q0ZyIAI
https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0oaIAC relates to https://salto-b7-dev-ed.my.salesforce.com/001Dn0000063rYxIAI
https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0oaIAC relates to https://salto-b7-dev-ed.my.salesforce.com/003Dn000003q0ZyIAI

... and 14 more missing records

To resolve this issue, follow the steps outlined here: https://help.salto.io/en/articles/8283155-data-records-were-not-fetched
```

Original message:
```

Identified references to 9 missing instances of Account

https://salto-b7-dev-ed.my.salesforce.com/001Dn0000063rYwIAI referenced from -
  	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0oWIAS
	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0oYIAS
	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0orIAC
	* 4 more instances
https://salto-b7-dev-ed.my.salesforce.com/001Dn0000063rYrIAI referenced from -
  	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0oXIAS
	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0onIAC
	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0ooIAC
https://salto-b7-dev-ed.my.salesforce.com/001Dn0000063rYxIAI referenced from -
  	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0oZIAS
	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0oaIAC
	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0obIAC
https://salto-b7-dev-ed.my.salesforce.com/001Dn0000063rZ1IAI referenced from -
  	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0ocIAC
	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0omIAC
https://salto-b7-dev-ed.my.salesforce.com/001Dn0000063rYvIAI referenced from -
  	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0odIAC
	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0oeIAC
	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0ojIAC
	* 1 more instances
https://salto-b7-dev-ed.my.salesforce.com/001Dn0000063rYzIAI referenced from -
  	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0ofIAC
https://salto-b7-dev-ed.my.salesforce.com/001Dn0000063rZ0IAI referenced from -
  	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0ogIAC
	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0ohIAC
	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0olIAC
https://salto-b7-dev-ed.my.salesforce.com/001Dn0000063rYyIAI referenced from -
  	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0oiIAC
https://salto-b7-dev-ed.my.salesforce.com/001Dn0000063rYsIAI referenced from -
  	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0opIAC
	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0oqIAC

To resolve this issue please edit the salesforce.nacl file to include Account instances in the data management configuration and fetch again.

      Alternatively, you can exclude the referring types from the data management configuration in salesforce.nacl

Identified references to 15 missing instances of Contact

https://salto-b7-dev-ed.my.salesforce.com/003Dn000003q0a6IAA referenced from -
  	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0oWIAS
https://salto-b7-dev-ed.my.salesforce.com/003Dn000003q0ZpIAI referenced from -
  	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0oXIAS
https://salto-b7-dev-ed.my.salesforce.com/003Dn000003q0ZwIAI referenced from -
  	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0oYIAS
	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0orIAC
	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0osIAC
	* 1 more instances
https://salto-b7-dev-ed.my.salesforce.com/003Dn000003q0ZyIAI referenced from -
  	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0oZIAS
	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0oaIAC
https://salto-b7-dev-ed.my.salesforce.com/003Dn000003q0ZzIAI referenced from -
  	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0obIAC
https://salto-b7-dev-ed.my.salesforce.com/003Dn000003q0a5IAA referenced from -
  	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0ocIAC
	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0omIAC
https://salto-b7-dev-ed.my.salesforce.com/003Dn000003q0ZuIAI referenced from -
  	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0odIAC
	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0oeIAC
https://salto-b7-dev-ed.my.salesforce.com/003Dn000003q0a2IAA referenced from -
  	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0ofIAC
https://salto-b7-dev-ed.my.salesforce.com/003Dn000003q0a3IAA referenced from -
  	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0ogIAC
https://salto-b7-dev-ed.my.salesforce.com/003Dn000003q0a4IAA referenced from -
  	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0ohIAC
	* https://salto-b7-dev-ed.my.salesforce.com/500Dn000002U0olIAC

And 5 more missing Instances

To resolve this issue please edit the salesforce.nacl file to include Contact instances in the data management configuration and fetch again.

      Alternatively, you can exclude the referring types from the data management configuration in salesforce.nacl
```

---
_Release Notes_: 
N/A

---
_User Notifications_: 
N/A