### PR TITLE
SALTO-4515: Projects are not added to automation names

### DIFF
--- a/packages/jira-adapter/src/filters/automation/automation_fetch.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_fetch.ts
@@ -16,7 +16,7 @@
 import { ElemIdGetter, InstanceElement, isInstanceElement, ObjectType, Values } from '@salto-io/adapter-api'
 import { createSchemeGuard, naclCase, pathNaclCase } from '@salto-io/adapter-utils'
 import { elements as elementUtils, client as clientUtils } from '@salto-io/adapter-components'
-// import { values as lowerdashValues } from '@salto-io/lowerdash'
+import { values as lowerdashValues } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import Joi from 'joi'
 import _ from 'lodash'
@@ -92,9 +92,10 @@ const createInstance = (
   const serviceIds = elementUtils.createServiceIds(values, 'id', type.elemID)
   const defaultName = naclCase([
     values.name,
-    (convertRuleScopeValueToProjects(values) ?? [])
-      .filter((project: Values) => idToProject[project.projectId]?.value.name !== undefined)
-      .map((project: Values) => `_${idToProject[project.projectId]?.value.name}`)].join(''))
+    ...(convertRuleScopeValueToProjects(values) ?? [])
+      .map((project: Values) => idToProject[project.projectId]?.value.name)
+      .filter(lowerdashValues.isDefined),
+  ].join('_'))
 
   const instanceName = getElemIdFunc && serviceIds
     ? getElemIdFunc(JIRA, serviceIds, defaultName).name

--- a/packages/jira-adapter/src/filters/automation/automation_fetch.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_fetch.ts
@@ -16,7 +16,7 @@
 import { ElemIdGetter, InstanceElement, isInstanceElement, ObjectType, Values } from '@salto-io/adapter-api'
 import { createSchemeGuard, naclCase, pathNaclCase } from '@salto-io/adapter-utils'
 import { elements as elementUtils, client as clientUtils } from '@salto-io/adapter-components'
-import { values as lowerdashValues } from '@salto-io/lowerdash'
+// import { values as lowerdashValues } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import Joi from 'joi'
 import _ from 'lodash'
@@ -26,6 +26,7 @@ import { FilterCreator } from '../../filter'
 import { createAutomationTypes } from './types'
 import { JiraConfig } from '../../config/config'
 import { getCloudId } from './cloud_id'
+import { convertRuleScopeValueToProjects } from './automation_structure'
 
 const DEFAULT_PAGE_SIZE = 1000
 
@@ -89,13 +90,11 @@ const createInstance = (
   getElemIdFunc?: ElemIdGetter,
 ): InstanceElement => {
   const serviceIds = elementUtils.createServiceIds(values, 'id', type.elemID)
-
   const defaultName = naclCase([
     values.name,
-    ...values.projects
-      .map((project: Values) => idToProject[project.projectId]?.value.name)
-      .filter(lowerdashValues.isDefined),
-  ].join('_'))
+    (convertRuleScopeValueToProjects(values) ?? [])
+      .filter((project: Values) => idToProject[project.projectId]?.value.name !== undefined)
+      .map((project: Values) => `_${idToProject[project.projectId]?.value.name}`)].join(''))
 
   const instanceName = getElemIdFunc && serviceIds
     ? getElemIdFunc(JIRA, serviceIds, defaultName).name

--- a/packages/jira-adapter/src/filters/automation/automation_structure.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_structure.ts
@@ -308,14 +308,22 @@ const getScope = (resource: string): { projectId?: string; projectTypeKey?: stri
   return undefined
 }
 
-const convertRuleScopeToProjects = (instance: InstanceElement): void => {
-  const { ruleScope } = instance.value
+export const convertRuleScopeValueToProjects = (values: Values): {
+  projectId?: string
+  projectTypeKey?: string
+}[] | undefined => {
+  const { ruleScope } = values
   if (!isRuleScope(ruleScope)) {
-    return
+    return undefined
   }
-  instance.value.projects = ruleScope.resources
+  return ruleScope.resources
     .map(getScope)
     .filter(isDefined)
+}
+
+
+const convertRuleScopeToProjects = (instance: InstanceElement): void => {
+  instance.value.projects = convertRuleScopeValueToProjects(instance.value)
 }
 
 const filter: FilterCreator = ({ client }) => {

--- a/packages/jira-adapter/test/filters/automation/automation_fetch.test.ts
+++ b/packages/jira-adapter/test/filters/automation/automation_fetch.test.ts
@@ -50,6 +50,9 @@ describe('automationFetchFilter', () => {
               projectId: '2',
             },
           ],
+          ruleScope: {
+            resources: ['ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8:project/2'],
+          },
         },
       ],
     },
@@ -131,6 +134,9 @@ describe('automationFetchFilter', () => {
             projectId: '2',
           },
         ],
+        ruleScope: {
+          resources: ['ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8:project/2'],
+        },
       })
 
       expect(connection.post).toHaveBeenCalledWith(
@@ -197,6 +203,9 @@ describe('automationFetchFilter', () => {
             projectId: '2',
           },
         ],
+        ruleScope: {
+          resources: ['ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8:project/2'],
+        },
       })
 
       expect(connection.post).not.toHaveBeenCalled()

--- a/packages/jira-adapter/test/filters/automation/automation_structure.test.ts
+++ b/packages/jira-adapter/test/filters/automation/automation_structure.test.ts
@@ -133,6 +133,9 @@ describe('automationStructureFilter', () => {
             projectTypeKey: 'key2',
           },
         ],
+        ruleScope: {
+          resources: ['ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8:project/3'],
+        },
       }
     )
 
@@ -215,9 +218,6 @@ describe('automationStructureFilter', () => {
       expect(instance.value.projects).toEqual([
         {
           projectId: '3',
-        },
-        {
-          projectTypeKey: 'key2',
         },
       ])
     })


### PR DESCRIPTION
Jira changed Their API so project names are supported through `ruleScope`. This PR supports this change.

---

None

---
_Release Notes_: 
None

---
_User Notifications_: 
None