### PR TITLE
SALTO-3959: Scripted-Fragments

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -137,6 +137,7 @@ import projectFieldContextOrder from './filters/project_field_contexts_order'
 import scriptedFieldsIssueTypesFilter from './filters/script_runner/scripted_fields_issue_types'
 import scriptRunnerFilter from './filters/script_runner/script_runner_filter'
 import scriptRunnerListenersDeployFilter from './filters/script_runner/script_runner_listeners_deploy'
+import scriptedFragmentsDeployFilter from './filters/script_runner/scripted_fragments_deploy'
 import scriptRunnerInstancesDeploy from './filters/script_runner/script_runner_instances_deploy'
 import behaviorsMappingsFilter from './filters/script_runner/behaviors_mappings'
 import behaviorsFieldUuidFilter from './filters/script_runner/behaviors_field_uuid'
@@ -291,6 +292,8 @@ export const DEFAULT_FILTERS = [
   addAliasFilter,
   // must be done before scriptRunnerInstances
   scriptRunnerListenersDeployFilter,
+  // must be done before scriptRunnerInstances
+  scriptedFragmentsDeployFilter,
   scriptRunnerInstancesDeploy,
   // Must be last
   defaultInstancesDeployFilter,

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1668,6 +1668,9 @@ const DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
     request: {
       url: '/sr-dispatcher/jira/token/script-fragments',
     },
+    transformation: {
+      idFields: ['id'],
+    },
   },
   ScheduledJob: {
     request: {
@@ -1788,7 +1791,7 @@ const DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
 
 export const DUCKTYPE_SUPPORTED_TYPES = {
   ScriptRunnerListener: ['ScriptRunnerListener'],
-  // ScriptFragment: ['ScriptFragment'],
+  ScriptFragment: ['ScriptFragment'],
   ScheduledJob: ['ScheduledJob'],
   Behavior: ['Behavior'],
   EscalationService: ['EscalationService'],

--- a/packages/jira-adapter/src/filters/broken_reference_filter.ts
+++ b/packages/jira-adapter/src/filters/broken_reference_filter.ts
@@ -17,7 +17,7 @@
 import { Change, ChangeDataType, ReferenceExpression, Value, getChangeData, isAdditionOrModificationChange, isInstanceChange, isReferenceExpression } from '@salto-io/adapter-api'
 import { isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import _ from 'lodash'
-import { AUTOMATION_TYPE, BEHAVIOR_TYPE, SCRIPTED_FIELD_TYPE, SCRIPT_RUNNER_LISTENER_TYPE } from '../constants'
+import { AUTOMATION_TYPE, BEHAVIOR_TYPE, SCRIPTED_FIELD_TYPE, SCRIPT_FRAGMENT_TYPE, SCRIPT_RUNNER_LISTENER_TYPE } from '../constants'
 import { FilterCreator } from '../filter'
 
 export type ProjectType = { projectId: ReferenceExpression }
@@ -82,6 +82,14 @@ export const BROKEN_REFERENCE_TYPE_MAP: Record<string, BrokenReferenceInfo[]> = 
   },
   {
     location: 'projects',
+    filter: (project: unknown): boolean => !isResolvedReferenceExpression(project),
+    namePath: 'value.target.name',
+    referencesTypeName: 'projects',
+    singleReferenceTypeName: 'project',
+    mustHaveReference: true,
+  }],
+  [SCRIPT_FRAGMENT_TYPE]: [{
+    location: 'entities',
     filter: (project: unknown): boolean => !isResolvedReferenceExpression(project),
     namePath: 'value.target.name',
     referencesTypeName: 'projects',

--- a/packages/jira-adapter/src/filters/script_runner/script_runner_filter.ts
+++ b/packages/jira-adapter/src/filters/script_runner/script_runner_filter.ts
@@ -97,12 +97,6 @@ const filter: FilterCreator = ({ client, config }) => ({
         instance.value.uuid = uuidv4()
       })
 
-    additionInstances
-      .filter(instance => instance.elemID.typeName === SCRIPT_FRAGMENT_TYPE)
-      .forEach(instance => {
-        instance.value.id = uuidv4()
-      })
-
     // Modification
     const modificationInstances = changes
       .filter(isModificationChange)

--- a/packages/jira-adapter/src/filters/script_runner/scripted_fragments_deploy.ts
+++ b/packages/jira-adapter/src/filters/script_runner/scripted_fragments_deploy.ts
@@ -1,0 +1,157 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { SeverityLevel, Value, getChangeData, isInstanceChange } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import Joi from 'joi'
+import { collections } from '@salto-io/lowerdash'
+import { logger } from '@salto-io/logging'
+import { createSchemeGuard } from '@salto-io/adapter-utils'
+import { FilterCreator } from '../../filter'
+import { PROJECT_TYPE, SCRIPT_FRAGMENT_TYPE } from '../../constants'
+import { getValuesToDeploy } from './script_runner_listeners_deploy'
+
+const { awu } = collections.asynciterable
+
+const log = logger(module)
+
+type FragmentsResponse = Value[]
+
+const FRAGMENTS_RESPONSE_SCHEME = Joi.array().required()
+
+const isFragmentsResponse = createSchemeGuard<FragmentsResponse>(FRAGMENTS_RESPONSE_SCHEME, 'Received an invalid scripted fragments response')
+
+type FragmentsProjectsProperties = {
+  fragments: string[]
+  panelLocations: string[]
+}
+
+const getProjectToPropertiesMap = (valuesToDeploy: Value[]): Record<string, FragmentsProjectsProperties> => {
+  const projectToPropertiesMap: Record<string, FragmentsProjectsProperties> = {}
+  valuesToDeploy.forEach(value => {
+    value.entities.forEach((projectKey: string) => {
+      if (projectToPropertiesMap[projectKey] === undefined) {
+        projectToPropertiesMap[projectKey] = {
+          fragments: [],
+          panelLocations: [],
+        }
+      }
+      const properties = projectToPropertiesMap[projectKey]
+      properties.fragments.push(value.id)
+      properties.panelLocations.push(`${value.panelLocation}0`)
+    })
+  })
+  return projectToPropertiesMap
+}
+
+// This filter deploys scripted fragments as a batch
+const filter: FilterCreator = ({ client, scriptRunnerClient, config, elementsSource }) => ({
+  name: 'scriptedFragmentsBatchDeployFilter',
+  deploy: async changes => {
+    const { scriptRunnerApiDefinitions } = config
+    if (!config.fetch.enableScriptRunnerAddon || scriptRunnerApiDefinitions === undefined) {
+      return {
+        deployResult: { appliedChanges: [], errors: [] },
+        leftoverChanges: changes,
+      }
+    }
+
+    const [relevantChanges, leftoverChanges] = _.partition(
+      changes,
+      change => isInstanceChange(change)
+        && getChangeData(change).elemID.typeName === SCRIPT_FRAGMENT_TYPE,
+    )
+    if (relevantChanges.length === 0) {
+      return {
+        leftoverChanges,
+        deployResult: { errors: [], appliedChanges: [] },
+      }
+    }
+    let valuesFromService: Value[]
+    try {
+      const response = await scriptRunnerClient
+        .getSinglePage({
+          url: '/sr-dispatcher/jira/token/script-fragments',
+        })
+      if (!isFragmentsResponse(response.data)) {
+        throw new Error('Received an invalid scripted fragments response')
+      }
+      valuesFromService = response.data
+    } catch (e) {
+      return {
+        leftoverChanges,
+        deployResult: {
+          errors: relevantChanges
+            .map(getChangeData)
+            .map(instance => ({
+              severity: 'Error' as SeverityLevel,
+              message: 'Error getting other scripted fragments information from the service',
+              elemID: instance.elemID,
+            })),
+          appliedChanges: [],
+        },
+      }
+    }
+    const { errors, appliedChanges, valuesToDeploy } = await getValuesToDeploy(relevantChanges, valuesFromService, 'id')
+    try {
+      await scriptRunnerClient.put({
+        url: '/sr-dispatcher/jira/admin/token/script-fragments',
+        data: valuesToDeploy,
+      })
+      const projects = await awu(await elementsSource.list())
+        .filter(id => id.idType === 'instance' && id.typeName === PROJECT_TYPE)
+        .map(id => elementsSource.get(id))
+        .toArray()
+
+      const projectToPropertiesMap = getProjectToPropertiesMap(valuesToDeploy)
+
+      await awu(projects)
+        .forEach(async project => {
+          const projectKey = project.value.key
+          const { fragments, panelLocations } = projectToPropertiesMap[projectKey]
+            ?? { fragments: [], panelLocations: [] }
+          const currentEpoch = Date.now()
+          await client.put({
+            url: `/rest/api/2/project/${projectKey}/properties/enabled-script-fragments?_r=${currentEpoch}`,
+            data: {
+              fragments,
+              itemLocations: [],
+              panelLocations,
+            },
+          })
+        })
+    } catch (e) {
+      const errorMessage = e instanceof Error ? e.message : e
+      log.error(`Failed to put scripted fragments with the error: ${errorMessage}`)
+      errors.push(...appliedChanges
+        .map(getChangeData)
+        .map(instance => ({
+          severity: 'Error' as SeverityLevel,
+          message: `${errorMessage}`,
+          elemID: instance.elemID,
+        })))
+      return {
+        deployResult: { appliedChanges: [], errors },
+        leftoverChanges,
+      }
+    }
+    return {
+      deployResult: { appliedChanges, errors },
+      leftoverChanges,
+    }
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/src/group_change.ts
+++ b/packages/jira-adapter/src/group_change.ts
@@ -16,7 +16,7 @@
 import { getChangeData, isModificationChange, isAdditionChange } from '@salto-io/adapter-api'
 import { getParent, getParents, isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { deployment } from '@salto-io/adapter-components'
-import { FIELD_CONFIGURATION_ITEM_TYPE_NAME, SCRIPT_RUNNER_LISTENER_TYPE, SECURITY_LEVEL_TYPE, WORKFLOW_TYPE_NAME } from './constants'
+import { FIELD_CONFIGURATION_ITEM_TYPE_NAME, SCRIPT_FRAGMENT_TYPE, SCRIPT_RUNNER_LISTENER_TYPE, SECURITY_LEVEL_TYPE, WORKFLOW_TYPE_NAME } from './constants'
 
 export const getWorkflowGroup: deployment.ChangeIdFunction = async change => (
   isModificationChange(change)
@@ -57,9 +57,15 @@ const getScriptListenersGroup: deployment.ChangeIdFunction = async change =>
     ? 'Script Listeners'
     : undefined)
 
+const getScriptedFragmentsGroup: deployment.ChangeIdFunction = async change =>
+  (getChangeData(change).elemID.typeName === SCRIPT_FRAGMENT_TYPE
+    ? 'Scripted Fragments'
+    : undefined)
+
 export const getChangeGroupIds = deployment.getChangeGroupIdsFunc([
   getWorkflowGroup,
   getSecurityLevelGroup,
   getFieldConfigItemGroup,
   getScriptListenersGroup,
+  getScriptedFragmentsGroup,
 ])

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -27,7 +27,7 @@ import { AUTOMATION_PROJECT_TYPE, AUTOMATION_FIELD, AUTOMATION_COMPONENT_VALUE_T
   PRIORITY_SCHEME_TYPE_NAME, SCRIPT_RUNNER_TYPE, POST_FUNCTION_CONFIGURATION, RESOLUTION_TYPE_NAME,
   ISSUE_EVENT_TYPE_NAME, CONDITION_CONFIGURATION, PROJECT_ROLE_TYPE, VALIDATOR_CONFIGURATION,
   BOARD_TYPE_NAME, ISSUE_LINK_TYPE_NAME, DIRECTED_LINK_TYPE, MAIL_LIST_TYPE_NAME,
-  SCRIPT_RUNNER_LISTENER_TYPE, SCRIPTED_FIELD_TYPE, BEHAVIOR_TYPE, ISSUE_LAYOUT_TYPE, SCRIPT_RUNNER_SETTINGS_TYPE } from './constants'
+  SCRIPT_RUNNER_LISTENER_TYPE, SCRIPTED_FIELD_TYPE, BEHAVIOR_TYPE, ISSUE_LAYOUT_TYPE, SCRIPT_RUNNER_SETTINGS_TYPE, SCRIPT_FRAGMENT_TYPE } from './constants'
 import { getFieldsLookUpName } from './filters/fields/field_type_references_filter'
 import { getRefType } from './references/workflow_properties'
 import { FIELD_TYPE_NAME } from './filters/fields/constants'
@@ -952,6 +952,12 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     jiraSerializationStrategy: 'groupStrategyByOriginalName',
     jiraMissingRefStrategy: 'typeAndValue',
     target: { type: GROUP_TYPE_NAME },
+  },
+  {
+    src: { field: 'entities', parentTypes: [SCRIPT_FRAGMENT_TYPE] },
+    jiraSerializationStrategy: 'key',
+    jiraMissingRefStrategy: 'typeAndValue',
+    target: { type: PROJECT_TYPE },
   },
 ]
 

--- a/packages/jira-adapter/test/filters/script_runner/script_runner_filter.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/script_runner_filter.test.ts
@@ -97,10 +97,9 @@ describe('script_runner_filter', () => {
         await filter.preDeploy([
           toChange({ after: auditInstance }),
           toChange({ after: listenerInstance }),
-          toChange({ after: fragmentInstance })])
+        ])
         expect(auditInstance.value.uuid).toEqual('my-uuid')
         expect(listenerInstance.value.uuid).toEqual('my-uuid')
-        expect(fragmentInstance.value.id).toEqual('my-uuid')
       })
       it('should add audit info when not defined', async () => {
         jest.spyOn(users, 'getCurrentUserInfo').mockReset()

--- a/packages/jira-adapter/test/filters/script_runner/scripted_fragments_deploy.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/scripted_fragments_deploy.test.ts
@@ -1,0 +1,474 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
+import { BuiltinTypes, ElemID, InstanceElement, ListType, ObjectType, ReferenceExpression, Value, toChange } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { MockInterface } from '@salto-io/test-utils'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import scriptedFragmentsDeploy from '../../../src/filters/script_runner/scripted_fragments_deploy'
+import { createEmptyType, getFilterParams, mockClient } from '../../utils'
+import { getDefaultConfig } from '../../../src/config/config'
+import { JIRA, PROJECT_TYPE, SCRIPT_FRAGMENT_TYPE } from '../../../src/constants'
+import ScriptRunnerClient from '../../../src/client/script_runner_client'
+
+
+type FilterType = filterUtils.FilterWith<'deploy'>
+describe('scripted_fragments_deploy', () => {
+  let filter: FilterType
+  let type: ObjectType
+  let scriptInstanceAdd: InstanceElement
+  let scriptInstanceModify: InstanceElement
+  let instance3: InstanceElement
+  let project: InstanceElement
+  let mockPut: jest.Mock
+  let mockGetSinglePage: jest.Mock
+  let baseValues: Value[]
+  let clientConnection: MockInterface<clientUtils.APIConnection>
+  beforeEach(() => {
+    type = new ObjectType({
+      elemID: new ElemID(JIRA, SCRIPT_FRAGMENT_TYPE),
+      fields: {
+        id: { refType: BuiltinTypes.STRING },
+        name: { refType: BuiltinTypes.STRING },
+        entities: { refType: new ListType(BuiltinTypes.STRING) },
+      },
+    })
+
+    baseValues = [{
+      id: '1', name: 'n1', entities: ['COM'], panelLocation: 'panelLocation1',
+    }, {
+      id: '2', name: 'n2', entities: ['COM'], panelLocation: 'panelLocation2',
+    }, {
+      id: '3', name: 'n3', entities: ['COM'], panelLocation: 'panelLocation3',
+    }, {
+      id: '4', name: 'n4', entities: ['COM'], panelLocation: 'panelLocation4',
+    }]
+    scriptInstanceAdd = new InstanceElement(
+      'instance',
+      type,
+      {
+        id: '5', name: 'n5', entities: ['COM'], panelLocation: 'panelLocation5',
+      }
+    )
+    scriptInstanceModify = new InstanceElement(
+      'instance2',
+      type,
+      {
+        id: '2', name: 'n55', entities: ['COM'], panelLocation: 'panelLocation2',
+      }
+    )
+    instance3 = new InstanceElement(
+      'instance3',
+      createEmptyType('type'),
+    )
+    project = new InstanceElement(
+      'project',
+      createEmptyType(PROJECT_TYPE),
+      {
+        key: 'COM',
+      }
+    )
+    const project2 = new InstanceElement(
+      'project2',
+      createEmptyType(PROJECT_TYPE),
+      {
+        key: 'COM2',
+      }
+    )
+    const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+    const { connection, client } = mockClient()
+    const elementsSource = buildElementsSourceFromElements([project, project2])
+    clientConnection = connection
+    config.fetch.enableScriptRunnerAddon = true
+    filter = scriptedFragmentsDeploy(getFilterParams({ config, client, elementsSource })) as FilterType
+    mockGetSinglePage = jest.fn()
+    mockPut = jest.fn()
+    ScriptRunnerClient.prototype.getSinglePage = mockGetSinglePage
+    ScriptRunnerClient.prototype.put = mockPut
+    mockGetSinglePage.mockResolvedValue({
+      status: 200,
+      data: _.cloneDeep(baseValues),
+    })
+    mockPut.mockResolvedValue({
+      status: 200,
+    })
+    clientConnection.put.mockResolvedValue({
+      status: 200,
+      data: {},
+    })
+    const now = 10000
+    jest.spyOn(Date, 'now').mockReturnValue(now)
+  })
+  it('should properly add a scripted fragment', async () => {
+    const res = await filter.deploy([toChange({ after: scriptInstanceAdd })])
+    expect(res).toEqual({
+      deployResult: {
+        appliedChanges: [toChange({ after: scriptInstanceAdd })],
+        errors: [],
+      },
+      leftoverChanges: [],
+    })
+    baseValues.push({
+      id: '5', name: 'n5', entities: ['COM'], panelLocation: 'panelLocation5',
+    })
+    expect(mockPut).toHaveBeenCalledWith({
+      url: '/sr-dispatcher/jira/admin/token/script-fragments',
+      data: baseValues,
+    })
+    expect(clientConnection.put).toHaveBeenCalledTimes(2)
+    expect(clientConnection.put).toHaveBeenCalledWith(
+      '/rest/api/2/project/COM/properties/enabled-script-fragments?_r=10000',
+      {
+        fragments: ['1', '2', '3', '4', '5'],
+        itemLocations: [],
+        panelLocations: [
+          'panelLocation10',
+          'panelLocation20',
+          'panelLocation30',
+          'panelLocation40',
+          'panelLocation50',
+        ],
+      },
+      undefined,
+    )
+    expect(clientConnection.put).toHaveBeenCalledWith(
+      '/rest/api/2/project/COM2/properties/enabled-script-fragments?_r=10000',
+      {
+        fragments: [],
+        itemLocations: [],
+        panelLocations: [],
+      },
+      undefined,
+    )
+  })
+  it('should properly modify a script listener', async () => {
+    const res = await filter.deploy([toChange({ before: scriptInstanceAdd, after: scriptInstanceModify })])
+    expect(res).toEqual({
+      deployResult: {
+        appliedChanges: [toChange({ before: scriptInstanceAdd, after: scriptInstanceModify })],
+        errors: [],
+      },
+      leftoverChanges: [],
+    })
+    expect(mockPut).toHaveBeenCalledWith({
+      url: '/sr-dispatcher/jira/admin/token/script-fragments',
+      data: [{
+        id: '1', name: 'n1', entities: ['COM'], panelLocation: 'panelLocation1',
+      }, {
+        id: '2', name: 'n55', entities: ['COM'], panelLocation: 'panelLocation2',
+      }, {
+        id: '3', name: 'n3', entities: ['COM'], panelLocation: 'panelLocation3',
+      }, {
+        id: '4', name: 'n4', entities: ['COM'], panelLocation: 'panelLocation4',
+      }],
+    })
+    expect(clientConnection.put).toHaveBeenCalledTimes(2)
+    expect(clientConnection.put).toHaveBeenCalledWith(
+      '/rest/api/2/project/COM/properties/enabled-script-fragments?_r=10000',
+      {
+        fragments: ['1', '2', '3', '4'],
+        itemLocations: [],
+        panelLocations: [
+          'panelLocation10',
+          'panelLocation20',
+          'panelLocation30',
+          'panelLocation40',
+        ],
+      },
+      undefined,
+    )
+  })
+  it('should properly remove a script listener', async () => {
+    const res = await filter.deploy([toChange({ before: scriptInstanceModify })])
+    expect(res).toEqual({
+      deployResult: {
+        appliedChanges: [toChange({ before: scriptInstanceModify })],
+        errors: [],
+      },
+      leftoverChanges: [],
+    })
+    expect(mockPut).toHaveBeenCalledWith({
+      url: '/sr-dispatcher/jira/admin/token/script-fragments',
+      data: [{
+        id: '1', name: 'n1', entities: ['COM'], panelLocation: 'panelLocation1',
+      }, {
+        id: '3', name: 'n3', entities: ['COM'], panelLocation: 'panelLocation3',
+      }, {
+        id: '4', name: 'n4', entities: ['COM'], panelLocation: 'panelLocation4',
+      }],
+    })
+    expect(clientConnection.put).toHaveBeenCalledTimes(2)
+    expect(clientConnection.put).toHaveBeenCalledWith(
+      '/rest/api/2/project/COM/properties/enabled-script-fragments?_r=10000',
+      {
+        fragments: ['1', '3', '4'],
+        itemLocations: [],
+        panelLocations: [
+          'panelLocation10',
+          'panelLocation30',
+          'panelLocation40',
+        ],
+      },
+      undefined,
+    )
+  })
+  it('should properly deploy many script listeners', async () => {
+    const scriptInstanceRemove1 = new InstanceElement(
+      'instanceR1',
+      type,
+      {
+        id: '1', name: 'n1', entities: ['COM'], panelLocation: 'panelLocation1',
+      }
+    )
+    const scriptInstanceRemove2 = new InstanceElement(
+      'instanceR2',
+      type,
+      {
+        id: '4', name: 'n4', entities: ['COM'], panelLocation: 'panelLocation4',
+      }
+    )
+    const scriptInstanceModify2 = new InstanceElement(
+      'instanceM2',
+      type,
+      {
+        id: '3', name: 'n33', entities: ['COM', 'COM2'], panelLocation: 'panelLocation3',
+      }
+    )
+    const scriptInstanceAdd2 = new InstanceElement(
+      'instanceA2',
+      type,
+      {
+        id: '6', name: 'n6', entities: ['COM2'], panelLocation: 'panelLocation6',
+      }
+    )
+    const changes = [
+      toChange({ before: scriptInstanceRemove1 }),
+      toChange({ before: scriptInstanceRemove2 }),
+      toChange({ before: scriptInstanceRemove1, after: scriptInstanceModify }),
+      toChange({ before: scriptInstanceRemove1, after: scriptInstanceModify2 }),
+      toChange({ after: scriptInstanceAdd }),
+      toChange({ after: scriptInstanceAdd2 }),
+    ]
+    const res = await filter.deploy(changes)
+    expect(res.deployResult.appliedChanges).toEqual(expect.arrayContaining(changes))
+    expect(res.deployResult.errors).toEqual([])
+    expect(res.leftoverChanges).toEqual([])
+    expect(mockPut).toHaveBeenCalledWith({
+      url: '/sr-dispatcher/jira/admin/token/script-fragments',
+      data: [{
+        id: '2', name: 'n55', entities: ['COM'], panelLocation: 'panelLocation2',
+      }, {
+        id: '3', name: 'n33', entities: ['COM', 'COM2'], panelLocation: 'panelLocation3',
+      }, {
+        id: '5', name: 'n5', entities: ['COM'], panelLocation: 'panelLocation5',
+      }, {
+        id: '6', name: 'n6', entities: ['COM2'], panelLocation: 'panelLocation6',
+      }],
+    })
+    expect(clientConnection.put).toHaveBeenCalledTimes(2)
+    expect(clientConnection.put).toHaveBeenCalledWith(
+      '/rest/api/2/project/COM/properties/enabled-script-fragments?_r=10000',
+      {
+        fragments: ['2', '3', '5'],
+        itemLocations: [],
+        panelLocations: [
+          'panelLocation20',
+          'panelLocation30',
+          'panelLocation50',
+        ],
+      },
+      undefined,
+    )
+    expect(clientConnection.put).toHaveBeenCalledWith(
+      '/rest/api/2/project/COM2/properties/enabled-script-fragments?_r=10000',
+      {
+        fragments: ['3', '6'],
+        itemLocations: [],
+        panelLocations: [
+          'panelLocation30',
+          'panelLocation60',
+        ],
+      },
+      undefined,
+    )
+  })
+  it('should return empty if no relevant changes', async () => {
+    const res = await filter.deploy([
+      toChange({ after: instance3 }),
+    ])
+    expect(res.deployResult.appliedChanges).toEqual([])
+    expect(res.deployResult.errors).toEqual([])
+    expect(res.leftoverChanges).toEqual(
+      [toChange({ after: instance3 })],
+    )
+  })
+  it('should return the proper error if get fails', async () => {
+    mockGetSinglePage.mockReset()
+    mockGetSinglePage.mockResolvedValueOnce({
+      status: 200,
+      data: {},
+    })
+    const res = await filter.deploy([toChange({ after: scriptInstanceAdd })])
+    expect(res).toEqual({
+      deployResult: {
+        appliedChanges: [],
+        errors: [{
+          severity: 'Error',
+          message: 'Error getting other scripted fragments information from the service',
+          elemID: scriptInstanceAdd.elemID,
+        }],
+      },
+      leftoverChanges: [],
+    })
+  })
+  it('should handle references correctly', async () => {
+    const removedInstance = new InstanceElement(
+      'instance',
+      type,
+      {
+        id: '1',
+        name: 'n1',
+        entities: [new ReferenceExpression(project.elemID, project)],
+      }
+    )
+    scriptInstanceAdd.value.entities = [new ReferenceExpression(project.elemID, project)]
+    scriptInstanceModify.value.entities = [new ReferenceExpression(project.elemID, project)]
+    const res = await filter.deploy([
+      toChange({ after: scriptInstanceAdd }),
+      toChange({ before: scriptInstanceAdd, after: scriptInstanceModify }),
+      toChange({ before: removedInstance })])
+    expect(res.deployResult.appliedChanges).toEqual([
+      toChange({ after: scriptInstanceAdd }),
+      toChange({ before: scriptInstanceAdd, after: scriptInstanceModify }),
+      toChange({ before: removedInstance })])
+    expect(mockPut).toHaveBeenCalledWith({
+      url: '/sr-dispatcher/jira/admin/token/script-fragments',
+      data: [{
+        id: '2', name: 'n55', entities: ['COM'], panelLocation: 'panelLocation2',
+      }, {
+        id: '3', name: 'n3', entities: ['COM'], panelLocation: 'panelLocation3',
+      }, {
+        id: '4', name: 'n4', entities: ['COM'], panelLocation: 'panelLocation4',
+      }, {
+        id: '5', name: 'n5', entities: ['COM'], panelLocation: 'panelLocation5',
+      }],
+    })
+  })
+  it('should return the proper error if put fails', async () => {
+    mockPut.mockReset()
+    mockPut.mockRejectedValueOnce(new Error('error'))
+    const res = await filter.deploy(
+      [toChange({ after: scriptInstanceAdd }),
+        toChange({ before: scriptInstanceAdd, after: scriptInstanceModify })]
+    )
+    expect(res).toEqual({
+      deployResult: {
+        appliedChanges: [],
+        errors: [{
+          severity: 'Error',
+          message: 'error',
+          elemID: scriptInstanceAdd.elemID,
+        }, {
+          severity: 'Error',
+          message: 'error',
+          elemID: scriptInstanceModify.elemID,
+        },
+        ],
+      },
+      leftoverChanges: [],
+    })
+  })
+  it('should return the proper error if put fails with weird error', async () => {
+    mockPut.mockReset()
+    mockPut.mockRejectedValueOnce(1)
+    const res = await filter.deploy(
+      [toChange({ after: scriptInstanceAdd }),
+        toChange({ before: scriptInstanceAdd, after: scriptInstanceModify })]
+    )
+    expect(res).toEqual({
+      deployResult: {
+        appliedChanges: [],
+        errors: [{
+          severity: 'Error',
+          message: '1',
+          elemID: scriptInstanceAdd.elemID,
+        }, {
+          severity: 'Error',
+          message: '1',
+          elemID: scriptInstanceModify.elemID,
+        },
+        ],
+      },
+      leftoverChanges: [],
+    })
+  })
+  it('should return the proper errors if there are mismatches with the service', async () => {
+    const removalInstance = new InstanceElement(
+      'instanceR1',
+      type,
+      {
+        id: '6', name: 'n6',
+      }
+    )
+    const removalInstance2 = new InstanceElement(
+      'instanceR2',
+      type,
+      {
+        id: '3', name: 'n3',
+      }
+    )
+    const res = await filter.deploy(
+      [toChange({ after: scriptInstanceModify }),
+        toChange({ before: scriptInstanceModify, after: scriptInstanceAdd }),
+        toChange({ before: removalInstance }),
+        toChange({ before: removalInstance2 })]
+    )
+    expect(res.deployResult.appliedChanges).toEqual([toChange({ before: removalInstance2 })])
+    expect(res.leftoverChanges).toEqual([])
+    expect(res.deployResult.errors[0]).toEqual({
+      severity: 'Error',
+      message: 'Failed to add instance as it already exists in the service',
+      elemID: scriptInstanceModify.elemID,
+    })
+    expect(res.deployResult.errors[1]).toEqual({
+      severity: 'Error',
+      message: 'Failed to modify instance as it does not exist in the service',
+      elemID: scriptInstanceAdd.elemID,
+    })
+    expect(res.deployResult.errors[2]).toEqual({
+      severity: 'Error',
+      message: 'Failed to remove instance as it does not exist in the service',
+      elemID: removalInstance.elemID,
+    })
+  })
+  it('should not deploy if script runner is disabled', async () => {
+    const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+    config.fetch.enableScriptRunnerAddon = false
+    filter = scriptedFragmentsDeploy(getFilterParams({ config })) as FilterType
+    const res = await filter.deploy([
+      toChange({ after: scriptInstanceAdd }),
+      toChange({ after: scriptInstanceModify }),
+      toChange({ after: instance3 }),
+    ])
+    expect(res.deployResult.appliedChanges).toEqual([])
+    expect(res.deployResult.errors).toEqual([])
+    expect(res.leftoverChanges).toEqual(
+      [toChange({ after: scriptInstanceAdd }),
+        toChange({ after: scriptInstanceModify }),
+        toChange({ after: instance3 })],
+    )
+  })
+})


### PR DESCRIPTION
Support scripted fragments in script runner
---

To use you can enter one of the following in the single URL
https://status.circleci.com
https://status.atlassian.com
To view it press the script fragment button in the right panel (if you choose issue sidebar) or the script fragment button in the upper panel (below the name of the issue, near link issue) if you choose issue header

After putting the fragments in the adaptavist server we need to also activate them, that is the reason for the project/properties calls.

This feature is really buggy, you get wrong warnings for certain cases (more than 2 fragments), and if you add more than 1 in the same project and location you will only see the first

---
_Release Notes_: 
Jira Adapter:
* Added support for ScriptRunner's scripted fragments

---
_User Notifications_: 
Jira Adapter:
* Customers with ScriptRunner support will see new scripted fragments NaCls