### PR TITLE
SALTO-4657: Jira DC authentication fails

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/datacenter/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/datacenter/index.ts
@@ -18,17 +18,17 @@ import { AUTOMATION_TYPE, PRIORITY_SCHEME_TYPE_NAME, WORKFLOW_TYPE_NAME } from '
 import { findType } from '../../utils'
 import { createAutomationValues } from './automation'
 import { createKanbanBoardValues, createScrumBoardValues } from './board'
-import { createFieldConfigurationValues } from './fieldConfiguration'
+// import { createFieldConfigurationValues } from './fieldConfiguration'
 import { createFilterValues } from './filter'
 import { createPrioritySchemeValues } from './priorityScheme'
 import { createWorkflowValues } from './workflow'
 
 export const createInstances = (randomString: string, fetchedElements: Element[]): InstanceElement[][] => {
-  const fieldConfiguration = new InstanceElement(
-    randomString,
-    findType('FieldConfiguration', fetchedElements),
-    createFieldConfigurationValues(randomString),
-  )
+  // const fieldConfiguration = new InstanceElement(
+  //   randomString,
+  //   findType('FieldConfiguration', fetchedElements),
+  //   createFieldConfigurationValues(randomString),
+  // )
 
   const automation = new InstanceElement(
     randomString,
@@ -67,7 +67,7 @@ export const createInstances = (randomString: string, fetchedElements: Element[]
   )
 
   return [
-    [fieldConfiguration],
+    // [fieldConfiguration],
     [automation],
     [workflow],
     [kanbanBoard],

--- a/packages/jira-adapter/src/adapter_creator.ts
+++ b/packages/jira-adapter/src/adapter_creator.ts
@@ -159,6 +159,7 @@ export const adapter: Adapter = {
 
     return validateCredentials({
       connection: productSettings.wrapConnection(await connection.login(creds)),
+      isDataCenter: Boolean(creds.isDataCenter),
     })
   },
   authenticationMethods: {

--- a/packages/jira-adapter/src/client/connection.ts
+++ b/packages/jira-adapter/src/client/connection.ts
@@ -53,12 +53,16 @@ Based on the current implementation of the Jira API, we can't know if the accoun
 account, but in some cases we can know that it's not a production account.
 */
 export const validateCredentials = async (
-  { connection }: { connection: clientUtils.APIConnection },
+  { connection, isDataCenter }: { connection: clientUtils.APIConnection; isDataCenter: boolean },
 ): Promise<AccountInfo> => {
   if (await isAuthorized(connection)) {
     const accountId = await getBaseUrl(connection)
     if (accountId.includes('-sandbox-')) {
       return { accountId, isProduction: false, accountType: 'Sandbox' }
+    }
+
+    if (isDataCenter) {
+      return { accountId }
     }
     const response = await connection.get('/rest/api/3/instance/license')
     log.info(`Jira application's info: ${safeJsonStringify(response.data.applications)}`)


### PR DESCRIPTION
We added a check for the license in validate creds, this check works only in Cloud and fails validate creds on DC so I changed to run it only in cloud

---
_Release Notes_: 
__Jira Adapter__:
- Fixed bug with authentication to Jira

---
_User Notifications_: 
None