### PR TITLE
SALTO-4226 Support subdirs of Objects folder in SDF integration

### DIFF
--- a/packages/netsuite-adapter/test/client/mocks.ts
+++ b/packages/netsuite-adapter/test/client/mocks.ts
@@ -106,7 +106,7 @@ export const OBJECT_XML_WITH_HTML_CHARS = '<entitycustomfield scriptid="custenti
   + '<label>Golf &#x26; Co&#x2019;Co element&#x200B;Name</label>'
   + '</entitycustomfield>'
 
-export const readDirMockFunction = (): string[] => ['a.xml', 'b.xml', 'a.template.html']
+export const OBJECTS_DIR_FILES = ['a.xml', 'b.xml', 'a.template.html']
 
 export const readFileMockFunction = (filePath: string): string | Buffer => {
   if (filePath.includes('.template.')) {


### PR DESCRIPTION
Also supports a case where the "Objects" folder isn't exists (treated as empty folder)

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Support subdirs of Objects folder in SDF integration

---
_User Notifications_: 
None
