### PR TITLE
SALTO-4641: Fix NS crash in data_instances_attributes trying to access "attributes" on null

### DIFF
--- a/packages/netsuite-adapter/src/filters/data_instances_attributes.ts
+++ b/packages/netsuite-adapter/src/filters/data_instances_attributes.ts
@@ -35,7 +35,7 @@ const filterCreator: LocalFilterCreator = () => ({
           type: await e.getType(),
           strict: false,
           transformFunc: async ({ value }) => {
-            if (typeof value === 'object' && 'attributes' in value) {
+            if (_.isPlainObject(value) && 'attributes' in value) {
               _.assign(value, value.attributes)
               delete value.attributes
               delete value[XSI_TYPE]


### PR DESCRIPTION
_Replace me with a description of the changes in this PR_

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
SALTO-4641: Fix crash in data_instances_attributes trying to access "attributes" on null
---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
