### PR TITLE
SALTO-3961: disable behaviors until a proper fix to the 500 bug

### DIFF
--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1790,7 +1790,7 @@ export const DUCKTYPE_SUPPORTED_TYPES = {
   ScriptRunnerListener: ['ScriptRunnerListener'],
   // ScriptFragment: ['ScriptFragment'],
   ScheduledJob: ['ScheduledJob'],
-  Behavior: ['Behavior'],
+  // Behavior: ['Behavior'],
   EscalationService: ['EscalationService'],
   ScriptedField: ['ScriptedField'],
   ScriptRunnerSettings: ['ScriptRunnerSettings'],


### PR DESCRIPTION
Revert Behaviors as users without the Behaviors App get a 500 error on the behavior get call.
We revert for now and will deploy a long term solution later on 

---

None

---
_Release Notes_: 
Jira Adapter:
* Fixed a bug in ScriptRunner that failed fetches for customers without the Behaviours app
---
_User Notifications_: 
None
