### PR TITLE
SALTO-4305 & SALTO-4025 add suitescript dependencies

### DIFF
--- a/packages/netsuite-adapter/src/filters/element_references.ts
+++ b/packages/netsuite-adapter/src/filters/element_references.ts
@@ -135,16 +135,10 @@ const getServiceElemIDsFromPaths = (
 ): ElemID[] =>
   foundReferences
     .flatMap(ref => {
-      const absolutePath = resolveRelativePath(element.value[PATH], ref)
-      // TODO: The log should be removed when SALTO-4025 is communicated.
-      if (!pathPrefixRegex.test(ref)) {
-        const maybeServiceIdRecord = serviceIdToElemID[FILE_CABINET_PATH_SEPARATOR.concat(ref)]
-        if (_.isPlainObject(maybeServiceIdRecord)) {
-          log.debug('Found a file reference without a path prefix: %s', ref)
-        }
-        return [ref]
-      }
-      return [absolutePath].concat(
+      const absolutePath = pathPrefixRegex.test(ref)
+        ? resolveRelativePath(element.value[PATH], ref)
+        : FILE_CABINET_PATH_SEPARATOR.concat(ref)
+      return [ref, absolutePath].concat(
         osPath.extname(absolutePath) === '' && osPath.extname(element.value[PATH]) !== ''
           ? [absolutePath.concat(osPath.extname(element.value[PATH]))]
           : []
@@ -155,10 +149,8 @@ const getServiceElemIDsFromPaths = (
       if (_.isPlainObject(serviceIdRecord)) {
         return serviceIdRecord.elemID
       }
-      // TODO: Should be removed once SALTO-4305 is communicated
       if (_.isPlainObject(customRecordFieldsToServiceIds[ref])) {
-        log.debug(`The following cutsomRecord field is refernced by its field ID: ${ref}`)
-        // return customRecordFieldsToServiceIds[ref].elemID
+        return customRecordFieldsToServiceIds[ref].elemID
       }
       return undefined
     })

--- a/packages/netsuite-adapter/test/filters/element_references.test.ts
+++ b/packages/netsuite-adapter/test/filters/element_references.test.ts
@@ -538,7 +538,21 @@ describe('instance_references filter', () => {
         isPartial: false,
         config: await getDefaultAdapterConfig(),
       }).onFetch?.([fileInstance, noExtensionInstance, fileWithExtension])
-      expect(fileInstance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeUndefined()
+      expect(fileInstance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toHaveLength(2)
+      expect(fileInstance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toEqual(expect.arrayContaining([
+        {
+          reference: new ReferenceExpression(
+            noExtensionInstance.elemID.createNestedID(PATH)
+          ),
+          occurrences: undefined,
+        },
+        {
+          reference: new ReferenceExpression(
+            fileWithExtension.elemID.createNestedID(PATH)
+          ),
+          occurrences: undefined,
+        },
+      ]))
     })
 
     it('should add generated dependency from comment', async () => {
@@ -587,7 +601,14 @@ describe('instance_references filter', () => {
         isPartial: false,
         config: await getDefaultAdapterConfig(),
       }).onFetch?.([fileInstance, customRecordType])
-      expect(fileInstance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeUndefined()
+      expect(fileInstance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toEqual([
+        {
+          reference: new ReferenceExpression(
+            customRecordType.fields.custom_field.elemID.createNestedID(SCRIPT_ID)
+          ),
+          occurrences: undefined,
+        },
+      ])
     })
 
     it('should add customrecord field as generated dependency from elementsSource in partial fetch', async () => {
@@ -613,7 +634,14 @@ describe('instance_references filter', () => {
         isPartial: true,
         config: await getDefaultAdapterConfig(),
       }).onFetch?.([fileInstance])
-      expect(fileInstance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeUndefined()
+      expect(fileInstance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toEqual([
+        {
+          reference: new ReferenceExpression(
+            customRecordField.elemID.createNestedID(SCRIPT_ID)
+          ),
+          occurrences: undefined,
+        },
+      ])
     })
   })
   describe('preDeploy', () => {


### PR DESCRIPTION
Add dependencies instead of logging them.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Create references in SuiteScripts for paths that don't start with a path prefix
- Create references in SuiteScripts to custom record fields

---
_User Notifications_: 
Netsuite Adapter:
- New references will be added to the "generated dependencies" list in SuiteScript file instances.
- 