### PR TITLE
SALTO-4579 - Salesforce: Fetch instances based on a configurable field

### DIFF
--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -165,13 +165,14 @@ salesforce {
 
 ### Data management configuration options
 
-| Name                                                              | Default when undefined                           | Description                                                                                               |
-|-------------------------------------------------------------------|--------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
-| includeObjects                                                    | N/A (required when dataManagement is configured) | Data records of matched object names will be fetched                                                      |
-| excludeObjects                                                    | []                                               | Data records of matched object names will not be fetched in case they are matched in includeObjects       |
-| allowReferenceTo                                                  | []                                               | Data records of matched object names will be fetched only when referenced from other fetched data records |
-| [saltoIDSettings](#salto-id-settings-configuration-options)       | N/A (required when dataManagement is configured) | Configuration for cross environments data record ids management                                           |
-| [saltoAliasSettings](#salto-alias-settings-configuration-options) | N/A                                              | Configuration for data record aliases                                                                     |
+| Name                                                              | Default when undefined                           | Description                                                                                                                                                       |
+|-------------------------------------------------------------------|--------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| includeObjects                                                    | N/A (required when dataManagement is configured) | Data records of matched object names will be fetched                                                                                                              |
+| excludeObjects                                                    | []                                               | Data records of matched object names will not be fetched in case they are matched in includeObjects                                                               |
+| allowReferenceTo                                                  | []                                               | Data records of matched object names will be fetched only when referenced from other fetched data records                                                         |
+| [saltoIDSettings](#salto-id-settings-configuration-options)       | N/A (required when dataManagement is configured) | Configuration for cross environments data record ids management                                                                                                   |
+| [saltoAliasSettings](#salto-alias-settings-configuration-options) | N/A                                              | Configuration for data record aliases                                                                                                                             |
+| saltoManagementFieldSettings                                      | {}                                               | Set the `defaultFieldName` entry to the name of a custom field. If this entry is set, Salto will not fetch records where this field exists and is equal to `false` |
 
 #### Salto ID settings configuration options
 

--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -82,6 +82,9 @@ salesforce {
         ".*SBQQ__CustomAction__c.*",
         ".*PricebookEntry.*",
       ]
+      saltoManagementFieldSettings = {
+        defaultFieldName = "ManagedBySalto__c"
+      }
       saltoIDSettings = {
         defaultIdFields = [
           "##allMasterDetailFields##",

--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -165,14 +165,14 @@ salesforce {
 
 ### Data management configuration options
 
-| Name                                                              | Default when undefined                           | Description                                                                                                                                                       |
-|-------------------------------------------------------------------|--------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| includeObjects                                                    | N/A (required when dataManagement is configured) | Data records of matched object names will be fetched                                                                                                              |
-| excludeObjects                                                    | []                                               | Data records of matched object names will not be fetched in case they are matched in includeObjects                                                               |
-| allowReferenceTo                                                  | []                                               | Data records of matched object names will be fetched only when referenced from other fetched data records                                                         |
-| [saltoIDSettings](#salto-id-settings-configuration-options)       | N/A (required when dataManagement is configured) | Configuration for cross environments data record ids management                                                                                                   |
-| [saltoAliasSettings](#salto-alias-settings-configuration-options) | N/A                                              | Configuration for data record aliases                                                                                                                             |
-| saltoManagementFieldSettings                                      | {}                                               | Set the `defaultFieldName` entry to the name of a custom field. If this entry is set, Salto will not fetch records where this field exists and is equal to `false` |
+| Name                                                                          | Default when undefined                           | Description                                                                                               |
+|-------------------------------------------------------------------------------|--------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
+| includeObjects                                                                | N/A (required when dataManagement is configured) | Data records of matched object names will be fetched                                                      |
+| excludeObjects                                                                | []                                               | Data records of matched object names will not be fetched in case they are matched in includeObjects       |
+| allowReferenceTo                                                              | []                                               | Data records of matched object names will be fetched only when referenced from other fetched data records |
+| [saltoIDSettings](#salto-id-settings-configuration-options)                   | N/A (required when dataManagement is configured) | Configuration for cross environments data record ids management                                           |
+| [saltoAliasSettings](#salto-alias-settings-configuration-options)             | N/A                                              | Configuration for data record aliases                                                                     |
+| [saltoManagementFieldSettings](#salto-management-field-configuration-options) | {}                                               | Configuration for managed-by-Salto field                                                                  |
 
 #### Salto ID settings configuration options
 
@@ -187,6 +187,12 @@ salesforce {
 |-----------------------------------------------------------|------------------------|----------------------------------------------------------|
 | defaultAliasFields                                        | N/A                    | Default fields list for defining the data record's alias |
 | [overrides](#object-alias-settings-configuration-options) | []                     | Overrides the default alias fields for specific objects  |
+
+#### Salto management field configuration options
+
+| Name             | Default when undefined | Description                                                                                        |
+|------------------|------------------------|----------------------------------------------------------------------------------------------------|
+| defaultFieldName | N/A                    | If this entry is set, Salto will not fetch records where this field exists and is equal to `false` |
 
 #### Object ID settings configuration options
 

--- a/packages/salesforce-adapter/src/fetch_profile/data_management.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/data_management.ts
@@ -78,15 +78,15 @@ export const buildDataManagement = (params: DataManagementConfig): DataManagemen
     const typeName = await apiName(objType)
     const hasManagedBySaltoField = managedBySaltoFieldName !== undefined
       && objType.fields[managedBySaltoFieldName] !== undefined
+    if (params.allowReferenceTo !== undefined
+      && hasManagedBySaltoField
+      && params.allowReferenceTo.some(re => new RegExp(`^${re}$`).test(typeName))) {
+      return true
+    }
     if (params.excludeObjects?.some(re => new RegExp(`^${re}$`).test(typeName))) {
       return false
     }
-    if (params.includeObjects.some(re => new RegExp(`^${re}$`).test(typeName))) {
-      return true
-    }
-    return params.allowReferenceTo !== undefined
-      && hasManagedBySaltoField
-      && params.allowReferenceTo.some(re => new RegExp(`^${re}$`).test(typeName))
+    return params.includeObjects !== undefined && params.includeObjects.some(re => new RegExp(`^${re}$`).test(typeName))
   }
   return {
     isObjectTypeMatch,

--- a/packages/salesforce-adapter/src/fetch_profile/data_management.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/data_management.ts
@@ -31,7 +31,7 @@ export type DataManagement = {
   getObjectIdsFields: (name: string) => string[]
   getObjectAliasFields: (name: string) => types.NonEmptyArray<string>
   showReadOnlyValues?: boolean
-  managedBySaltoField?: string
+  managedBySaltoFieldForType: (objType: ObjectType) => string | undefined
 }
 
 
@@ -91,7 +91,15 @@ export const buildDataManagement = (params: DataManagementConfig): DataManagemen
   return {
     isObjectTypeMatch,
 
-    managedBySaltoField: params.saltoManagementFieldSettings?.defaultFieldName,
+    managedBySaltoFieldForType: objType => {
+      if (params.saltoManagementFieldSettings?.defaultFieldName === undefined) {
+        return undefined
+      }
+      if (objType.fields[params.saltoManagementFieldSettings.defaultFieldName] === undefined) {
+        return undefined
+      }
+      return params.saltoManagementFieldSettings.defaultFieldName
+    },
 
     isReferenceAllowed: name => params.allowReferenceTo?.some(re => new RegExp(`^${re}$`).test(name))
       ?? false,

--- a/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
@@ -396,7 +396,7 @@ export const getAllInstances = async (
     customObjectFetchSetting,
     setting => setting.isBase
   )
-  log.debug('Base types: %o', baseTypesSettings)
+  log.debug('Base types: %o', _.keys(baseTypesSettings))
   const baseRecordByTypeAndId = await mapValuesAsync(
     baseTypesSettings,
     setting => getRecords(client, setting.objectType, undefined, setting.managedBySaltoField)
@@ -458,7 +458,7 @@ export const getCustomObjectsFetchSettings = async (
     objectType: type,
     isBase: await dataManagement.isObjectTypeMatch(type),
     ...await getIdFields(type, dataManagement),
-    managedBySaltoField: dataManagement.managedBySaltoField,
+    managedBySaltoField: dataManagement.managedBySaltoFieldForType(type),
   })
 
   return awu(types)

--- a/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
@@ -25,8 +25,14 @@ import {
 import SalesforceClient from '../client/client'
 import { SalesforceRecord } from '../client/types'
 import {
-  SALESFORCE, RECORDS_PATH, INSTALLED_PACKAGES_PATH, CUSTOM_OBJECT_ID_FIELD,
-  FIELD_ANNOTATIONS, UNLIMITED_INSTANCES_VALUE, DETECTS_PARENTS_INDICATOR,
+  SALESFORCE,
+  RECORDS_PATH,
+  INSTALLED_PACKAGES_PATH,
+  CUSTOM_OBJECT_ID_FIELD,
+  FIELD_ANNOTATIONS,
+  UNLIMITED_INSTANCES_VALUE,
+  DETECTS_PARENTS_INDICATOR,
+  API_NAME_SEPARATOR,
 } from '../constants'
 import { FilterResult, RemoteFilterCreator } from '../filter'
 import { apiName, isCustomObject, Types, createInstanceServiceIds, isNameField } from '../transformers/transformer'
@@ -524,7 +530,7 @@ const createInvalidAliasFieldFetchWarning = async (
 const createInvalidManagedBySaltoFieldFetchWarning = async (
   { objectType, invalidManagedBySaltoField }: CustomObjectFetchSetting
 ): Promise<SaltoError> => ({
-  message: `The type ${await safeApiName(objectType)} has the field ${invalidManagedBySaltoField}, which is configured as the 'managed by Salto' field, but the field is not queryable. Records of this type will not be fetched.`,
+  message: `The field ${await apiName(objectType)}${API_NAME_SEPARATOR}${invalidManagedBySaltoField} is configured as the filter field in the saltoManagementFieldSettings.defaultFieldName section of the Salto environment configuration. However, the user configured for fetch does not have read access to this field. Records of type ${await apiName(objectType)} will not be fetched.`,
   severity: 'Warning',
 })
 

--- a/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
@@ -456,14 +456,13 @@ export const getCustomObjectsFetchSettings = async (
 ): Promise<CustomObjectFetchSetting[]> => {
   const typeToFetchSettings = async (type: ObjectType): Promise<CustomObjectFetchSetting> => ({
     objectType: type,
-    isBase: await dataManagement.isObjectTypeMatch(type),
+    isBase: await dataManagement.shouldFetchObjectType(type) === 'Always',
     ...await getIdFields(type, dataManagement),
     managedBySaltoField: dataManagement.managedBySaltoFieldForType(type),
   })
 
   return awu(types)
-    .filter(async type => await dataManagement.isObjectTypeMatch(type)
-      || dataManagement.isReferenceAllowed(await apiName(type)))
+    .filter(async type => await dataManagement.shouldFetchObjectType(type) !== 'Never')
     .map(typeToFetchSettings)
     .toArray()
 }

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -142,6 +142,10 @@ export type SaltoAliasSettings = {
   overrides?: ObjectAliasSettings[]
 }
 
+export type SaltoManagementFieldSettings = {
+  defaultFieldName: string
+}
+
 const objectIdSettings = new ObjectType({
   elemID: new ElemID(constants.SALESFORCE, 'objectIdSettings'),
   fields: {
@@ -218,6 +222,18 @@ const saltoAliasSettingsType = new ObjectType({
   },
 })
 
+const saltoManagementFieldSettingsType = new ObjectType({
+  elemID: new ElemID(constants.SALESFORCE, 'saltoManagementFieldSettings'),
+  fields: {
+    defaultFieldName: {
+      refType: BuiltinTypes.STRING,
+    },
+  },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+  },
+})
+
 export type DataManagementConfig = {
   includeObjects: string[]
   excludeObjects?: string[]
@@ -226,6 +242,7 @@ export type DataManagementConfig = {
   saltoIDSettings: SaltoIDSettings
   showReadOnlyValues?: boolean
   saltoAliasSettings?: SaltoAliasSettings
+  saltoManagementFieldSettings?: SaltoManagementFieldSettings
 }
 
 export type FetchParameters = {
@@ -472,6 +489,9 @@ const dataManagementType = new ObjectType({
     },
     saltoAliasSettings: {
       refType: saltoAliasSettingsType,
+    },
+    saltoManagementFieldSettings: {
+      refType: saltoManagementFieldSettingsType,
     },
   } as Record<keyof DataManagementConfig, FieldDefinition>,
   annotations: {

--- a/packages/salesforce-adapter/test/fetch_profile/data_management.test.ts
+++ b/packages/salesforce-adapter/test/fetch_profile/data_management.test.ts
@@ -55,15 +55,15 @@ describe('buildDataManagement', () => {
       },
     })
   })
-  describe('isObjectMatch', () => {
-    it('should match on included objects', async () => {
-      expect(await dataManagement.isObjectTypeMatch(createCustomObjectType('aaa', {}))).toBeTrue()
-      expect(await dataManagement.isObjectTypeMatch(createCustomObjectType('aaaccc', {}))).toBeTrue()
+  describe('shouldFetchObjectType', () => {
+    it('should fetch included objects', async () => {
+      expect(await dataManagement.shouldFetchObjectType(createCustomObjectType('aaa', {}))).toEqual('Always')
+      expect(await dataManagement.shouldFetchObjectType(createCustomObjectType('aaaccc', {}))).toEqual('Always')
     })
-    it('should not match on objects we allow refs to if they are not managed by Salto', async () => {
-      expect(await dataManagement.isObjectTypeMatch(createCustomObjectType('ccc', {}))).toBeFalse()
+    it('should fetch objects we allow refs to if they are not managed by Salto', async () => {
+      expect(await dataManagement.shouldFetchObjectType(createCustomObjectType('ccc', {}))).toEqual('IfReferenced')
     })
-    it('should match on objects we allow refs to if they may be managed by Salto', async () => {
+    it('should fetch objects we allow refs to if they may be managed by Salto', async () => {
       const objType = createCustomObjectType('ccc', {
         fields: {
           ManagedBySalto__c: {
@@ -74,22 +74,17 @@ describe('buildDataManagement', () => {
           },
         },
       })
-      expect(await dataManagement.isObjectTypeMatch(objType)).toBeTrue()
+      expect(await dataManagement.shouldFetchObjectType(objType)).toEqual('Always')
     })
-    it('should not match on objects that are excluded', async () => {
-      expect(await dataManagement.isObjectTypeMatch(createCustomObjectType('bbb', {}))).toBeFalse()
-      expect(await dataManagement.isObjectTypeMatch(createCustomObjectType('cccbbb', {}))).toBeFalse()
+    it('should not fetch objects that are excluded', async () => {
+      expect(await dataManagement.shouldFetchObjectType(createCustomObjectType('bbb', {}))).toEqual('Never')
+      expect(await dataManagement.shouldFetchObjectType(createCustomObjectType('cccbbb', {}))).toEqual('Never')
     })
-    it('should not match on objects that are both included and excluded', async () => {
-      expect(await dataManagement.isObjectTypeMatch(createCustomObjectType('aaabbb', {}))).toBeFalse()
+    it('should not fetch objects that are both included and excluded', async () => {
+      expect(await dataManagement.shouldFetchObjectType(createCustomObjectType('aaabbb', {}))).toEqual('Never')
     })
   })
 
-  it('isReferenceAllowed should return currect results for allowed references', () => {
-    expect(dataManagement.isReferenceAllowed('aaa')).toBeFalsy()
-    expect(dataManagement.isReferenceAllowed('ccc')).toBeTruthy()
-    expect(dataManagement.isReferenceAllowed('aaabbb')).toBeFalsy()
-  })
 
   it('getObjectIdsFields should return currect results', () => {
     expect(dataManagement.getObjectIdsFields('aaa')).toEqual(['default'])


### PR DESCRIPTION
Introduce the `saltoManagementFieldSettings.defaultFieldName` config. Fetching instances would now work in the following way:

1. If the instance's type is in `allowReferenceTo` and there's a reference to the instance, fetch it
2. If the instance's type is in `allowReferenceTo` and the instance has the `saltoManagementField` and the field's value is `true`, fetch it
3. If the instance's type is in `excludeObjects`, don't fetch it
4. If the instance's type is in `includeObjects`, and the instance has the `saltoManagementField` and the field's value is `true`, fetch it.
5. If the instance's type is in `includeObjects`, and does not have the `saltoManagementField`, fetch it.
6. Otherwise, don't fetch it.

---

~Note that this PR builds on top of https://github.com/salto-io/salto/pull/4762 - the first two commits (and any changes to `custom_objects_instances_references.ts`) are from the other PR.~

~Unit tests for `custom_objects_instances` are still pending, but I figured it's worth starting the review.~

Tests I ran include:
* Fetch without the config value and with the type in `includeObjects`, verify all instances are fetched
* Fetch with the config value and a type in `includeObjects`, verify only instances of the type where the management field is `true` are fetched.
* Fetch with the config value and a type in `allowReferencesTo`, verify only instances of the type where the management field is `true` are fetched even though there are no references to them.

---
_Release Notes_: 
Salesforce: Introduced the `saltoManagementFieldSettings` data configuration section. Use the `defaultFieldName` entry in this section to set the name of the "Managed By Salto" field. If this configuration entry is set, only records where this field is set to `true` will be fetched.

---
_User Notifications_: 
N/A