### PR TITLE
SALTO-4680 allow null custom_role_id in user schema

### DIFF
--- a/packages/zendesk-adapter/src/change_validators/users.ts
+++ b/packages/zendesk-adapter/src/change_validators/users.ts
@@ -127,7 +127,7 @@ const handleExistingUsers = ({ existingUsersPaths, customRolesById, usersByEmail
       return false
     }
     const userCustomRoleId = usersByEmail[user].custom_role_id
-    const customRole = customRolesById[userCustomRoleId]
+    const customRole = _.isNumber(userCustomRoleId) ? customRolesById[userCustomRoleId] : undefined
     // ticket_editing permission is required to be an assignee
     return customRole !== undefined && customRole.value.configuration?.ticket_editing === false
   })

--- a/packages/zendesk-adapter/src/user_utils.ts
+++ b/packages/zendesk-adapter/src/user_utils.ts
@@ -37,7 +37,7 @@ export type User = {
   email: string
   role: string
   // eslint-disable-next-line camelcase
-  custom_role_id: number
+  custom_role_id?: number | null
   locale: string
 }
 
@@ -50,7 +50,7 @@ const EXPECTED_USER_SCHEMA = Joi.object({
   name: Joi.string().required(),
   email: Joi.string().required(),
   role: Joi.string(),
-  custom_role_id: Joi.number(),
+  custom_role_id: Joi.number().allow(null),
   locale: Joi.string().required(),
 }).unknown(true)
 

--- a/packages/zendesk-adapter/test/user_utils.test.ts
+++ b/packages/zendesk-adapter/test/user_utils.test.ts
@@ -50,6 +50,8 @@ describe('userUtils', () => {
               { id: 1, email: 'a@a.com', name: 'a', locale: 'en-US' },
               { id: 2, email: 'b@b.com', name: 'b', locale: 'en-US' },
               { id: 2, email: 'c@c.com', role: 'agent', custom_role_id: '123', name: 'c', locale: 'en-US' },
+              { id: 2, email: 'd@d.com', role: 'agent', custom_role_id: null, name: 'd', locale: 'en-US' },
+              { id: 2, email: 'e@e.com', role: 'agent', custom_role_id: undefined, name: 'e', locale: 'en-US' },
             ] },
           ]
         })
@@ -60,6 +62,8 @@ describe('userUtils', () => {
           { id: 1, email: 'a@a.com', name: 'a', locale: 'en-US' },
           { id: 2, email: 'b@b.com', name: 'b', locale: 'en-US' },
           { id: 2, email: 'c@c.com', role: 'agent', custom_role_id: '123', name: 'c', locale: 'en-US' },
+          { id: 2, email: 'd@d.com', role: 'agent', name: 'd', locale: 'en-US', custom_role_id: null },
+          { id: 2, email: 'e@e.com', role: 'agent', name: 'e', locale: 'en-US', custom_role_id: undefined },
         ]
       )
     })
@@ -70,6 +74,7 @@ describe('userUtils', () => {
             { users: [
               { id: 1, email: 'a@a.com', name: 'a', locale: 'en-US' },
               { id: 2, email: 'b@b.com', name: 'b', locale: 'en-US' },
+              { id: 2, email: 'd@d.com', role: 'agent', custom_role_id: null, name: 'd', locale: 'en-US' },
             ] },
           ]
         })
@@ -78,6 +83,7 @@ describe('userUtils', () => {
         [
           { id: 1, email: 'a@a.com', name: 'a', locale: 'en-US' },
           { id: 2, email: 'b@b.com', name: 'b', locale: 'en-US' },
+          { id: 2, email: 'd@d.com', role: 'agent', custom_role_id: null, name: 'd', locale: 'en-US' },
         ]
       )
       const getUsersAfterCache = await userUtils.getUsers(mockPaginator)
@@ -85,6 +91,7 @@ describe('userUtils', () => {
         [
           { id: 1, email: 'a@a.com', name: 'a', locale: 'en-US' },
           { id: 2, email: 'b@b.com', name: 'b', locale: 'en-US' },
+          { id: 2, email: 'd@d.com', role: 'agent', custom_role_id: null, name: 'd', locale: 'en-US' },
         ]
       )
       await userUtils.getUsers(mockPaginator)


### PR DESCRIPTION
some automated users can have null custom role id. we should not assume this is failing the schema, because that has side-effects (we treat the entire user list as empty).
there are some other improvements we can make, but starting with a quick fix


---
_Release Notes_: 
_Zendesk adapter_:
* fix bug where users might get an incorrect deploy validation warning about a missing user due to an unexpected response structure

---
_User Notifications_: 
None