### PR TITLE
SALTO-4656: Add getCustomReferences adapter API

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -177,7 +177,20 @@ export type ReferenceMapping = {
   target: ElemID
 }
 
+/**
+ * @deprecated
+ */
 export type GetAdditionalReferencesFunc = (changes: Change[]) => Promise<ReferenceMapping[]>
+
+export type ReferenceType = 'strong' | 'weak'
+
+export type ReferenceInfo = {
+  source: ElemID
+  target: ElemID
+  type: ReferenceType
+}
+
+export type GetCustomReferencesFunc = (elements: Element[]) => Promise<ReferenceInfo[]>
 
 export type Adapter = {
   operations: (context: AdapterOperationsContext) => AdapterOperations
@@ -188,6 +201,7 @@ export type Adapter = {
   install?: () => Promise<AdapterInstallResult>
   loadElementsFromFolder?: (args: LoadElementsFromFolderArgs) => Promise<FetchResult>
   getAdditionalReferences?: GetAdditionalReferencesFunc
+  getCustomReferences?: GetCustomReferencesFunc
 }
 
 export const OBJECT_SERVICE_ID = 'object_service_id'

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -23,7 +23,7 @@ export { RenameElementIdError } from './src/core/rename'
 export {
   loadLocalWorkspace, initLocalWorkspace, loadLocalElementsSources,
   CACHE_DIR_NAME, STATES_DIR_NAME, locateWorkspaceRoot, createEnvironmentSource,
-  getAdapterConfigsPerAccount,
+  getAdapterConfigsPerAccount, getCustomReferences,
 } from './src/local-workspace/workspace'
 export {
   workspaceConfigSource as localWorkspaceConfigSource,

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -672,7 +672,9 @@ export const rename = async (
 export const getAdapterConfigOptionsType = (adapterName: string): ObjectType | undefined =>
   adapterCreators[adapterName].configCreator?.optionsType
 
-
+/**
+ * @deprecated
+ */
 export const getAdditionalReferences = async (
   workspace: Workspace,
   changes: Change[],

--- a/packages/core/src/local-workspace/workspace.ts
+++ b/packages/core/src/local-workspace/workspace.ts
@@ -250,10 +250,10 @@ export const getCustomReferences = async (
   accountToServiceName: Record<string, string>,
 ): Promise<ReferenceInfo[]> => {
   const accountToElements = _.groupBy(elements.filter(e => e.elemID.adapter !== GLOBAL_ADAPTER), e => e.elemID.adapter)
-  return (await Promise.all(Object.entries(accountToElements).map(([account, accountElements]) => {
+  return (await Promise.all(Object.entries(accountToElements).map(async ([account, accountElements]) => {
     const serviceName = accountToServiceName[account] ?? account
     try {
-      return adapterCreators[serviceName]?.getCustomReferences?.(accountElements) ?? []
+      return await adapterCreators[serviceName]?.getCustomReferences?.(accountElements) ?? []
     } catch (err) {
       log.error('failed to get custom references for %s: %o', account, err)
       return []

--- a/packages/core/src/local-workspace/workspace.ts
+++ b/packages/core/src/local-workspace/workspace.ts
@@ -16,7 +16,7 @@
 import _ from 'lodash'
 import path from 'path'
 import { v4 as uuidv4 } from 'uuid'
-import { DetailedChange, ObjectType } from '@salto-io/adapter-api'
+import { DetailedChange, ObjectType, ReferenceInfo, Element } from '@salto-io/adapter-api'
 import { exists, isEmptyDir, rm } from '@salto-io/file'
 import { Workspace, loadWorkspace, EnvironmentsSources, initWorkspace, nacl, remoteMap,
   configSource as cs, staticFiles, dirStore, WorkspaceComponents, errors, elementSource,
@@ -30,7 +30,7 @@ import { localState } from './state'
 import { workspaceConfigSource } from './workspace_config'
 import { buildLocalStaticFilesCache } from './static_files_cache'
 import { createRemoteMapCreator } from './remote_map'
-import { getAdaptersConfigTypesMap } from '../core/adapters'
+import { adapterCreators, getAdaptersConfigTypesMap } from '../core/adapters'
 import { buildLocalAdaptersConfigSource } from './adapters_config'
 
 const { awu } = collections.asynciterable
@@ -245,6 +245,18 @@ export const getAdapterConfigsPerAccount = async (envs: EnvConfig[]): Promise<Ob
   return Object.values(configTypesByAccount).flat()
 }
 
+export const getCustomReferences = async (
+  elements: Element[],
+  accountToServiceName: Record<string, string>,
+): Promise<ReferenceInfo[]> => {
+  const accountToElements = _.groupBy(elements.filter(e => e.elemID.adapter !== ''), e => e.elemID.adapter)
+  return (await Promise.all(Object.entries(accountToElements).map(([account, accountElements]) => {
+    const serviceName = accountToServiceName[account] ?? account
+    return adapterCreators[serviceName].getCustomReferences?.(accountElements) ?? []
+  }))).flat()
+}
+
+
 type LoadLocalWorkspaceArgs = {
   path: string
   configOverrides?: DetailedChange[]
@@ -294,8 +306,9 @@ const loadLocalWorkspaceImpl = async ({
     credentials,
     elemSources,
     remoteMapCreator,
+    getCustomReferences,
     false,
-    persistent
+    persistent,
   )
 
   return {
@@ -396,6 +409,7 @@ Promise<Workspace> => {
     adaptersConfig,
     credentials,
     elemSources,
-    remoteMapCreator
+    remoteMapCreator,
+    getCustomReferences,
   )
 }

--- a/packages/core/test/workspace/local/workspace.test.ts
+++ b/packages/core/test/workspace/local/workspace.test.ts
@@ -555,5 +555,13 @@ describe('local workspace', () => {
       const references = await getCustomReferences([instance], { test2: 'test' })
       expect(references).toEqual([])
     })
+
+    it('Should return empty array if adapter getCustomReferences throws an error', async () => {
+      adapterCreators.test = {
+        getCustomReferences: mockFunction<GetCustomReferencesFunc>().mockRejectedValue(new Error('aaa')),
+      } as unknown as Adapter
+      const references = await getCustomReferences([instance], { test2: 'test' })
+      expect(references).toEqual([])
+    })
   })
 })

--- a/packages/core/test/workspace/local/workspace.test.ts
+++ b/packages/core/test/workspace/local/workspace.test.ts
@@ -238,6 +238,8 @@ describe('local workspace', () => {
             expect.anything(),
             expect.anything(),
             expect.anything(),
+            undefined,
+            expect.anything(),
           )
         })
       })
@@ -255,6 +257,8 @@ describe('local workspace', () => {
             expect.anything(),
             expect.anything(),
             false,
+            undefined,
+            expect.anything(),
           )
         })
       })

--- a/packages/dummy-adapter/src/adapter_creator.ts
+++ b/packages/dummy-adapter/src/adapter_creator.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Adapter, ElemID, CORE_ANNOTATIONS, BuiltinTypes, ObjectType, ListType } from '@salto-io/adapter-api'
+import { Adapter, ElemID, CORE_ANNOTATIONS, BuiltinTypes, ObjectType, ListType, GetCustomReferencesFunc } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import DummyAdapter from './adapter'
 import { GeneratorParams, DUMMY_ADAPTER, defaultParams, changeErrorType } from './generator'
@@ -36,6 +36,17 @@ export const configType = new ObjectType({
   },
 })
 
+const getCustomReferences: GetCustomReferencesFunc = async elements => (
+  elements.find(e => e.elemID.getFullName() === 'dummy.Full.instance.FullInst1')
+    ? [{
+      source: ElemID.fromFullName('dummy.Full.instance.FullInst1.strField'),
+      target: ElemID.fromFullName('dummy.Full.instance.FullInst2.strField'),
+      type: 'weak',
+    }]
+    : []
+)
+
+
 export const adapter: Adapter = {
   operations: context => new DummyAdapter(context.config?.value as GeneratorParams),
   validateCredentials: async () => ({ accountId: '' }),
@@ -43,4 +54,5 @@ export const adapter: Adapter = {
     credentialsType: new ObjectType({ elemID: new ElemID(DUMMY_ADAPTER) }),
   } }),
   configType,
+  getCustomReferences,
 }

--- a/packages/lang-server/test/workspace.ts
+++ b/packages/lang-server/test/workspace.ts
@@ -266,7 +266,6 @@ Promise<Workspace> => {
     mockCredentialsSource,
     elementsSources,
     mockCreateRemoteMap,
-    async () => [],
   )
 }
 

--- a/packages/lang-server/test/workspace.ts
+++ b/packages/lang-server/test/workspace.ts
@@ -266,6 +266,7 @@ Promise<Workspace> => {
     mockCredentialsSource,
     elementsSources,
     mockCreateRemoteMap,
+    async () => [],
   )
 }
 

--- a/packages/workspace/test/workspace/reference_indexes.test.ts
+++ b/packages/workspace/test/workspace/reference_indexes.test.ts
@@ -532,7 +532,7 @@ describe('updateReferenceIndexes', () => {
         mapVersions,
         elementsSource,
         true,
-        async () => [
+        async elements => (elements.length !== 0 ? [
           {
             source: inst.elemID.createNestedID('val2'),
             target: new ElemID('test', 'type', 'instance', 'someInstance2'),
@@ -543,7 +543,7 @@ describe('updateReferenceIndexes', () => {
             target: new ElemID('test', 'type', 'instance', 'someInstance3'),
             type: 'weak',
           },
-        ],
+        ] : []),
       )
     })
     it('should override the default references with the custom references', () => {
@@ -587,6 +587,45 @@ describe('updateReferenceIndexes', () => {
       )
     })
     it('should override the default references with the custom references', () => {
+      expect(referenceTargetsIndex.deleteAll).toHaveBeenCalledWith([
+        'test.object.instance.instance',
+      ])
+    })
+  })
+
+  describe('getCustomReferences modifications', () => {
+    beforeEach(async () => {
+      const instBefore = new InstanceElement(
+        'instance',
+        object,
+        {
+          val1: 'string',
+        }
+      )
+
+      const instAfter = new InstanceElement(
+        'instance',
+        object,
+      )
+      const changes = [toChange({ before: instBefore, after: instAfter })]
+
+      await updateReferenceIndexes(
+        changes,
+        referenceTargetsIndex,
+        referenceSourcesIndex,
+        mapVersions,
+        elementsSource,
+        true,
+        async elements => ((elements[0] as InstanceElement).value.val1 !== undefined ? [
+          {
+            source: instBefore.elemID.createNestedID('val1'),
+            target: new ElemID('test', 'type', 'instance', 'someInstance1'),
+            type: 'weak',
+          },
+        ] : []),
+      )
+    })
+    it('should remove the removed custom references', () => {
       expect(referenceTargetsIndex.deleteAll).toHaveBeenCalledWith([
         'test.object.instance.instance',
       ])

--- a/packages/workspace/test/workspace/reference_indexes.test.ts
+++ b/packages/workspace/test/workspace/reference_indexes.test.ts
@@ -16,13 +16,13 @@
 import { BuiltinTypes, ElemID, InstanceElement, ObjectType, ReferenceExpression, TemplateExpression, toChange } from '@salto-io/adapter-api'
 import { MockInterface } from '@salto-io/test-utils'
 import { collections } from '@salto-io/lowerdash'
-import { REFERENCE_INDEXES_VERSION, updateReferenceIndexes } from '../../src/workspace/reference_indexes'
+import { REFERENCE_INDEXES_VERSION, ReferenceTargetIndexValue, updateReferenceIndexes } from '../../src/workspace/reference_indexes'
 import { createInMemoryElementSource, ElementsSource } from '../../src/workspace/elements_source'
 import { RemoteMap } from '../../src/workspace/remote_map'
 import { createMockRemoteMap } from '../utils'
 
 describe('updateReferenceIndexes', () => {
-  let referenceTargetsIndex: MockInterface<RemoteMap<collections.treeMap.TreeMap<ElemID>>>
+  let referenceTargetsIndex: MockInterface<RemoteMap<ReferenceTargetIndexValue>>
   let referenceSourcesIndex: MockInterface<RemoteMap<ElemID[]>>
   let mapVersions: MockInterface<RemoteMap<number>>
   let elementsSource: ElementsSource
@@ -30,7 +30,7 @@ describe('updateReferenceIndexes', () => {
   let instance: InstanceElement
 
   beforeEach(() => {
-    referenceTargetsIndex = createMockRemoteMap<collections.treeMap.TreeMap<ElemID>>()
+    referenceTargetsIndex = createMockRemoteMap<ReferenceTargetIndexValue>()
 
     referenceSourcesIndex = createMockRemoteMap<ElemID[]>()
     referenceSourcesIndex.getMany.mockResolvedValue([])
@@ -91,19 +91,20 @@ describe('updateReferenceIndexes', () => {
         referenceSourcesIndex,
         mapVersions,
         elementsSource,
-        true
+        true,
+        async () => [],
       )
     })
     it('should add the new references to the referenceTargets index', () => {
       expect(referenceTargetsIndex.setAll).toHaveBeenCalledWith([
         {
           key: 'test.object.instance.instance',
-          value: new collections.treeMap.TreeMap<ElemID>([
-            ['someAnnotation', [new ElemID('test', 'target2', 'field', 'someField', 'value')]],
-            ['someValue', [new ElemID('test', 'target2', 'instance', 'someInstance')]],
+          value: new collections.treeMap.TreeMap([
+            ['someAnnotation', [{ id: new ElemID('test', 'target2', 'field', 'someField', 'value'), type: 'strong' }]],
+            ['someValue', [{ id: new ElemID('test', 'target2', 'instance', 'someInstance'), type: 'strong' }]],
             ['templateValue', [
-              new ElemID('test', 'target2', 'field', 'someTemplateField', 'value'),
-              new ElemID('test', 'target2', 'field', 'anotherTemplateField', 'value'),
+              { id: new ElemID('test', 'target2', 'field', 'someTemplateField', 'value'), type: 'strong' },
+              { id: new ElemID('test', 'target2', 'field', 'anotherTemplateField', 'value'), type: 'strong' },
             ],
             ],
           ]),
@@ -111,36 +112,36 @@ describe('updateReferenceIndexes', () => {
         {
           key: 'test.object.field.someField',
           value: new collections.treeMap.TreeMap([
-            ['fieldRef', [new ElemID('test', 'target2')]],
+            ['fieldRef', [{ id: new ElemID('test', 'target2'), type: 'strong' }]],
           ]),
         },
         {
           key: 'test.object.field.someTemplateField',
           value: new collections.treeMap.TreeMap([
-            ['fieldRef', [new ElemID('test', 'target2')]],
+            ['fieldRef', [{ id: new ElemID('test', 'target2'), type: 'strong' }]],
           ]),
         },
         {
           key: 'test.object.field.anotherTemplateField',
           value: new collections.treeMap.TreeMap([
-            ['fieldRef', [new ElemID('test', 'target2')]],
+            ['fieldRef', [{ id: new ElemID('test', 'target2'), type: 'strong' }]],
           ]),
         },
         {
           key: 'test.object.field.fieldWithRefToType',
           value: new collections.treeMap.TreeMap([
-            ['fieldRef', [new ElemID('test', 'object')]],
+            ['fieldRef', [{ id: new ElemID('test', 'object'), type: 'strong' }]],
           ]),
         },
         {
           key: 'test.object',
           value: new collections.treeMap.TreeMap([
-            ['typeRef', [new ElemID('test', 'target1')]],
-            ['inner.innerTypeRef', [new ElemID('test', 'target1', 'attr', 'someAttr')]],
-            ['', [new ElemID('test', 'target2')]],
-            ['', [new ElemID('test', 'target2')]],
-            ['', [new ElemID('test', 'target2')]],
-            ['', [new ElemID('test', 'object')]],
+            ['typeRef', [{ id: new ElemID('test', 'target1'), type: 'strong' }]],
+            ['inner.innerTypeRef', [{ id: new ElemID('test', 'target1', 'attr', 'someAttr'), type: 'strong' }]],
+            ['', [{ id: new ElemID('test', 'target2'), type: 'strong' }]],
+            ['', [{ id: new ElemID('test', 'target2'), type: 'strong' }]],
+            ['', [{ id: new ElemID('test', 'target2'), type: 'strong' }]],
+            ['', [{ id: new ElemID('test', 'object'), type: 'strong' }]],
           ]),
         },
       ])
@@ -239,15 +240,16 @@ describe('updateReferenceIndexes', () => {
         referenceSourcesIndex,
         mapVersions,
         elementsSource,
-        true
+        true,
+        async () => [],
       )
     })
     it('old values should be removed and new values should be added from referenceTargets index', () => {
       expect(referenceTargetsIndex.setAll).toHaveBeenCalledWith([{
         key: 'test.object.instance.instance',
         value: new collections.treeMap.TreeMap([
-          ['someAnnotation2', [new ElemID('test', 'target2', 'instance', 'someInstance', 'value')]],
-          ['someValue', [new ElemID('test', 'target2', 'instance', 'someInstance')]],
+          ['someAnnotation2', [{ id: new ElemID('test', 'target2', 'instance', 'someInstance', 'value'), type: 'strong' }]],
+          ['someValue', [{ id: new ElemID('test', 'target2', 'instance', 'someInstance'), type: 'strong' }]],
         ]),
       }])
     })
@@ -298,7 +300,8 @@ describe('updateReferenceIndexes', () => {
         referenceSourcesIndex,
         mapVersions,
         elementsSource,
-        true
+        true,
+        async () => [],
       )
     })
     it('should set the new tree in the referenceTargets index', () => {
@@ -306,15 +309,15 @@ describe('updateReferenceIndexes', () => {
         {
           key: 'test.object.field.fieldWithRefToType',
           value: new collections.treeMap.TreeMap([
-            ['fieldRef', [new ElemID('test', 'object')]],
+            ['fieldRef', [{ id: new ElemID('test', 'object'), type: 'strong' }]],
           ]),
         },
         {
           key: 'test.object',
           value: new collections.treeMap.TreeMap([
-            ['typeRef', [new ElemID('test', 'target1')]],
-            ['inner.innerTypeRef', [new ElemID('test', 'target1', 'attr', 'someAttr')]],
-            ['', [new ElemID('test', 'object')]],
+            ['typeRef', [{ id: new ElemID('test', 'target1'), type: 'strong' }]],
+            ['inner.innerTypeRef', [{ id: new ElemID('test', 'target1', 'attr', 'someAttr'), type: 'strong' }]],
+            ['', [{ id: new ElemID('test', 'object'), type: 'strong' }]],
           ]),
         }])
       expect(referenceTargetsIndex.deleteAll).toHaveBeenCalledWith([
@@ -356,7 +359,8 @@ describe('updateReferenceIndexes', () => {
         referenceSourcesIndex,
         mapVersions,
         elementsSource,
-        true
+        true,
+        async () => [],
       )
     })
 
@@ -393,19 +397,20 @@ describe('updateReferenceIndexes', () => {
           referenceSourcesIndex,
           mapVersions,
           elementsSource,
-          false
+          false,
+          async () => [],
         )
       })
       it('should update referenceTargets index using the element source', () => {
         expect(referenceTargetsIndex.clear).toHaveBeenCalled()
         expect(referenceTargetsIndex.setAll).toHaveBeenCalledWith([{
           key: 'test.object.instance.instance',
-          value: new collections.treeMap.TreeMap<ElemID>([
-            ['someAnnotation', [new ElemID('test', 'target2', 'field', 'someField', 'value')]],
-            ['someValue', [new ElemID('test', 'target2', 'instance', 'someInstance')]],
+          value: new collections.treeMap.TreeMap([
+            ['someAnnotation', [{ id: new ElemID('test', 'target2', 'field', 'someField', 'value'), type: 'strong' }]],
+            ['someValue', [{ id: new ElemID('test', 'target2', 'instance', 'someInstance'), type: 'strong' }]],
             ['templateValue', [
-              new ElemID('test', 'target2', 'field', 'someTemplateField', 'value'),
-              new ElemID('test', 'target2', 'field', 'anotherTemplateField', 'value'),
+              { id: new ElemID('test', 'target2', 'field', 'someTemplateField', 'value'), type: 'strong' },
+              { id: new ElemID('test', 'target2', 'field', 'anotherTemplateField', 'value'), type: 'strong' },
             ],
             ],
           ]),
@@ -455,19 +460,20 @@ describe('updateReferenceIndexes', () => {
           referenceSourcesIndex,
           mapVersions,
           elementsSource,
-          true
+          true,
+          async () => [],
         )
       })
       it('should update referenceTargets index using the element source', () => {
         expect(referenceTargetsIndex.clear).toHaveBeenCalled()
         expect(referenceTargetsIndex.setAll).toHaveBeenCalledWith([{
           key: 'test.object.instance.instance',
-          value: new collections.treeMap.TreeMap<ElemID>([
-            ['someAnnotation', [new ElemID('test', 'target2', 'field', 'someField', 'value')]],
-            ['someValue', [new ElemID('test', 'target2', 'instance', 'someInstance')]],
+          value: new collections.treeMap.TreeMap([
+            ['someAnnotation', [{ id: new ElemID('test', 'target2', 'field', 'someField', 'value'), type: 'strong' }]],
+            ['someValue', [{ id: new ElemID('test', 'target2', 'instance', 'someInstance'), type: 'strong' }]],
             ['templateValue', [
-              new ElemID('test', 'target2', 'field', 'someTemplateField', 'value'),
-              new ElemID('test', 'target2', 'field', 'anotherTemplateField', 'value'),
+              { id: new ElemID('test', 'target2', 'field', 'someTemplateField', 'value'), type: 'strong' },
+              { id: new ElemID('test', 'target2', 'field', 'anotherTemplateField', 'value'), type: 'strong' },
             ],
             ],
           ]),
@@ -504,6 +510,86 @@ describe('updateReferenceIndexes', () => {
           ],
         }])
       })
+    })
+  })
+
+  describe('getCustomReferences additions', () => {
+    beforeEach(async () => {
+      const inst = new InstanceElement(
+        'instance',
+        object,
+        {
+          val1: new ReferenceExpression(new ElemID('test', 'type', 'instance', 'someInstance1')),
+          val2: new ReferenceExpression(new ElemID('test', 'type', 'instance', 'someInstance2')),
+          val3: 'string',
+        }
+      )
+      const changes = [toChange({ after: inst })]
+      await updateReferenceIndexes(
+        changes,
+        referenceTargetsIndex,
+        referenceSourcesIndex,
+        mapVersions,
+        elementsSource,
+        true,
+        async () => [
+          {
+            source: inst.elemID.createNestedID('val2'),
+            target: new ElemID('test', 'type', 'instance', 'someInstance2'),
+            type: 'weak',
+          },
+          {
+            source: inst.elemID.createNestedID('val3'),
+            target: new ElemID('test', 'type', 'instance', 'someInstance3'),
+            type: 'weak',
+          },
+        ],
+      )
+    })
+    it('should override the default references with the custom references', () => {
+      expect(referenceTargetsIndex.setAll).toHaveBeenCalledWith([
+        {
+          key: 'test.object.instance.instance',
+          value: new collections.treeMap.TreeMap([
+            ['val1', [{ id: new ElemID('test', 'type', 'instance', 'someInstance1'), type: 'strong' }]],
+            ['val2', [{ id: new ElemID('test', 'type', 'instance', 'someInstance2'), type: 'weak' }]],
+            ['val3', [{ id: new ElemID('test', 'type', 'instance', 'someInstance3'), type: 'weak' }]],
+          ]),
+        },
+      ])
+    })
+  })
+
+  describe('getCustomReferences removals', () => {
+    beforeEach(async () => {
+      const inst = new InstanceElement(
+        'instance',
+        object,
+        {
+          val1: 'string',
+        }
+      )
+      const changes = [toChange({ before: inst })]
+      await updateReferenceIndexes(
+        changes,
+        referenceTargetsIndex,
+        referenceSourcesIndex,
+        mapVersions,
+        elementsSource,
+        true,
+        async () => [
+          {
+            source: inst.elemID.createNestedID('val1'),
+            target: new ElemID('test', 'type', 'instance', 'someInstance1'),
+            type: 'weak',
+          },
+        ],
+      )
+    })
+    it('should override the default references with the custom references', () => {
+      expect(referenceTargetsIndex.deleteAll).toHaveBeenCalledWith([
+        'test.object.instance.instance',
+      ])
     })
   })
 })

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -186,6 +186,7 @@ const createWorkspace = async (
       },
     },
     mapCreator,
+    async () => [],
   )
 }
 
@@ -2094,6 +2095,7 @@ describe('workspace', () => {
           },
         },
         () => Promise.resolve(new InMemoryRemoteMap()),
+        async () => [],
       )
       expect((workspaceConf.setWorkspaceConfig as jest.Mock).mock.calls[0][0]).toEqual(
         { name: 'ws-name', uid: 'uid', envs: [{ name: 'default', accountToServiceName: {} }], currentEnv: 'default' }
@@ -2692,15 +2694,15 @@ describe('workspace', () => {
   })
   describe('referenceTargetsTree index', () => {
     it('should return same result after serialize and deserialize', async () => {
-      const referenceTargetsTree = new collections.treeMap.TreeMap<ElemID>([
-        ['someAnnotation', [ElemID.fromFullName('test.target2.field.someField.value')]],
-        ['someValue', [ElemID.fromFullName('test.target2.instance.someInstance')]],
+      const referenceTargetsTree = new collections.treeMap.TreeMap([
+        ['someAnnotation', [{ id: ElemID.fromFullName('test.target2.field.someField.value'), type: 'strong' as const }]],
+        ['someValue', [{ id: ElemID.fromFullName('test.target2.instance.someInstance'), type: 'strong' as const }]],
         ['inner.templateValue', [
-          ElemID.fromFullName('test.target2.field.someTemplateField.value'),
-          ElemID.fromFullName('test.target2.field.anotherTemplateField.value'),
+          { id: ElemID.fromFullName('test.target2.field.someTemplateField.value'), type: 'strong' as const },
+          { id: ElemID.fromFullName('test.target2.field.anotherTemplateField.value'), type: 'strong' as const },
         ],
         ],
-        ['', [ElemID.fromFullName('test.target2.instance.someInstance2')]],
+        ['', [{ id: ElemID.fromFullName('test.target2.instance.someInstance2'), type: 'strong' as const }]],
 
       ])
       const serializedTree = await serializeReferenceTree(referenceTargetsTree)
@@ -2708,7 +2710,7 @@ describe('workspace', () => {
       expect(deserializedTree).toEqual(referenceTargetsTree)
     })
     it('should return same result after deserialize and serialize', async () => {
-      const serializedTree = '[["someAnnotation",["test.target2.field.someField.value"]],["someValue",["test.target2.instance.someInstance"]],["inner.templateValue",["test.target2.field.someTemplateField.value","test.target2.field.anotherTemplateField.value"]],["",["test.target2.instance.someInstance2"]]]'
+      const serializedTree = '[["someAnnotation",[{"id":"test.target2.field.someField.value","type":"strong"}]],["someValue",[{"id":"test.target2.instance.someInstance","type":"strong"}]],["inner.templateValue",[{"id":"test.target2.field.someTemplateField.value","type":"strong"},{"id":"test.target2.field.anotherTemplateField.value","type":"strong"}]],["",[{"id":"test.target2.instance.someInstance2","type":"strong"}]]]'
       const deserializedTree = await deserializeReferenceTree(serializedTree)
       const reSerializedTree = await serializeReferenceTree(deserializedTree)
       expect(reSerializedTree).toEqual(serializedTree)
@@ -2717,7 +2719,7 @@ describe('workspace', () => {
     it('should deserialize references with types', async () => {
       const serializedTree = '[["someAnnotation",[{"id":"test.target2.field.someField.value","type":"strong"}]]]'
       const deserializedTree = await deserializeReferenceTree(serializedTree)
-      expect(deserializedTree.get('someAnnotation')).toEqual([ElemID.fromFullName('test.target2.field.someField.value')])
+      expect(deserializedTree.get('someAnnotation')).toEqual([{ id: ElemID.fromFullName('test.target2.field.someField.value'), type: 'strong' }])
     })
   })
   describe('deleteEnvironment', () => {
@@ -3351,17 +3353,17 @@ describe('workspace', () => {
 
     it('top level instance should return all references under it without duplicates', async () => {
       const instanceRefs = await workspace.getElementOutgoingReferences(new ElemID('adapter', 'test', 'instance', 'test'))
-      expect(instanceRefs).toMatchObject([ref1.elemID, ref2.elemID, templateRef1.elemID, templateRef2.elemID])
+      expect(instanceRefs).toMatchObject([ref1.elemID, ref2.elemID, templateRef1.elemID, templateRef2.elemID].map(id => ({ id, type: 'strong' })))
     })
 
     it('instance field should return all references nested under it', async () => {
       const instanceRefs = await workspace.getElementOutgoingReferences(new ElemID('adapter', 'test', 'instance', 'test', 'inner'))
-      expect(instanceRefs).toMatchObject([ref2.elemID, templateRef1.elemID, templateRef2.elemID])
+      expect(instanceRefs).toMatchObject([ref2.elemID, templateRef1.elemID, templateRef2.elemID].map(id => ({ id, type: 'strong' })))
     })
 
     it('specific nested instance field path should return references under it', async () => {
       const instanceRefs = await workspace.getElementOutgoingReferences(new ElemID('adapter', 'test', 'instance', 'test', 'inner', 'inner2', 'refs'))
-      expect(instanceRefs).toMatchObject([templateRef1.elemID, templateRef2.elemID])
+      expect(instanceRefs).toMatchObject([templateRef1.elemID, templateRef2.elemID].map(id => ({ id, type: 'strong' })))
     })
 
     it('nested instance field without references should return an empty array', async () => {
@@ -3380,7 +3382,7 @@ describe('workspace', () => {
 
     it('object type should also include the references of its fields', async () => {
       const instanceRefs = await workspace.getElementOutgoingReferences(new ElemID('adapter', 'object'))
-      expect(instanceRefs).toMatchObject([ref1.elemID, ref2.elemID])
+      expect(instanceRefs).toMatchObject([ref1.elemID, ref2.elemID].map(id => ({ id, type: 'strong' })))
     })
   })
 

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -186,7 +186,6 @@ const createWorkspace = async (
       },
     },
     mapCreator,
-    async () => [],
   )
 }
 


### PR DESCRIPTION
Add getCustomReferences function to the adapter interface to allow him return references that are not in the NaCl and mark references as weak.

Changed the refernceTargetIndex structure to have a reference type for each reference

---
_Release Notes_: 
None

---
_User Notifications_: 
None