### PR TITLE
SALTO-4410: Enable CV on additions/removals of Standard Fields and Objects

### DIFF
--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -44,6 +44,7 @@ import currencyIsoCodes from './change_validators/currency_iso_codes'
 import unknownPicklistValues from './change_validators/unknown_picklist_values'
 import accountSettings from './change_validators/account_settings'
 import installedPackages from './change_validators/installed_packages'
+import standardFieldOrObjectAdditionRemoval from './change_validators/standard_field_or_object_additions_or_deletions'
 import dataCategoryGroupValidator from './change_validators/data_category_group'
 import SalesforceClient from './client/client'
 import { ChangeValidatorName, DEPLOY_CONFIG, SalesforceConfig } from './types'
@@ -89,6 +90,7 @@ export const changeValidators: Record<ChangeValidatorName, ChangeValidatorCreato
   unknownPicklistValues: () => unknownPicklistValues,
   installedPackages: () => installedPackages,
   dataCategoryGroup: () => dataCategoryGroupValidator,
+  standardFieldOrObjectAdditionRemoval: () => standardFieldOrObjectAdditionRemoval,
   ..._.mapValues(getDefaultChangeValidators(), validator => (() => validator)),
 }
 

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -117,6 +117,7 @@ export type ChangeValidatorName = (
   | 'unknownPicklistValues'
   | 'installedPackages'
   | 'dataCategoryGroup'
+  | 'standardFieldOrObjectAdditionRemoval'
 )
 
 type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
@@ -671,6 +672,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     unknownPicklistValues: { refType: BuiltinTypes.BOOLEAN },
     dataCategoryGroup: { refType: BuiltinTypes.BOOLEAN },
     installedPackages: { refType: BuiltinTypes.BOOLEAN },
+    standardFieldOrObjectAdditionRemoval: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,


### PR DESCRIPTION
Enable CV on additions/removals of Standard Fields and Objects

---

_Additional context for reviewer_

This is a previously implemented CV that wasn't enabled by mistake.


---
_Release Notes_: 
Salesforce Adapter:
- Add a Change Validator that forbids Additions and Deletions of Standard Fields and Objects.

---
_User Notifications_: 
_None_