### PR TITLE
SALTO-4588 fix SF errors not always saving element IDs

### DIFF
--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -177,7 +177,7 @@ type MetadataId = {
   fullName: string
 }
 
-type FailureMetadata = MetadataId & { problem: DeployMessage }
+type FailureMetadata = MetadataId & { deployMessage: DeployMessage }
 
 const getUnFoundDeleteName = (
   message: DeployMessage,
@@ -209,7 +209,7 @@ const processDeployResponse = (
     .map(failure => (
       { type: failure.componentType,
         fullName: failure.fullName,
-        problem: getUserFriendlyDeployMessage(failure) }))
+        deployMessage: getUserFriendlyDeployMessage(failure) }))
 
   const testFailures = makeArray(result.details)
     .flatMap(detail => makeArray((detail.runTestResult as RunTestsResult)?.failures))
@@ -409,12 +409,12 @@ export const deployMetadata = async (
     .flatMap(change => {
       const changeElem = getChangeData(change)
       return componentErrorsFullNames.filter(error =>
-        !isUnFoundDelete(error.problem, pkg.getDeletionsPackageName())
+        !isUnFoundDelete(error.deployMessage, pkg.getDeletionsPackageName())
         && error.type === changeElem.elemID.typeName
         && error.fullName === changeElem.elemID.name)
         .map(error => (
           { elemID: changeElem.elemID,
-            message: `Failed to ${checkOnly ? 'validate' : 'deploy'} ${error.fullName} with error: ${error.problem} (${error.problem.problemType})`,
+            message: error.deployMessage.problem,
             severity: 'Error' as SeverityLevel }
         ))
     })

--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -356,7 +356,7 @@ export const deployMetadata = async (
     return { appliedChanges: [], errors: validationErrors }
   }
   const changeToDeployedIds: Record<string, MetadataIdsMap> = {}
-  const typeAndNameToElemId: Record<string, NameToElemIDMap> = {}
+  const deployedComponentsElemIdsByType: Record<string, NameToElemIDMap> = {}
 
   await awu(validChanges).forEach(async change => {
     const deployedIds = await addChangeToPackage(pkg, change, nestedMetadataTypes)
@@ -368,7 +368,7 @@ export const deployMetadata = async (
       names.forEach(name => {
         nameToElemId[name] = elemID
       })
-      typeAndNameToElemId[type] = nameToElemId
+      deployedComponentsElemIdsByType[type] = nameToElemId
     })
   })
 
@@ -397,7 +397,7 @@ export const deployMetadata = async (
   }, undefined, 2))
 
   const { errors, successfulFullNames } = processDeployResponse(
-    sfDeployRes, pkg.getDeletionsPackageName(), typeAndNameToElemId
+    sfDeployRes, pkg.getDeletionsPackageName(), deployedComponentsElemIdsByType
   )
   const isSuccessfulChange = (change: Change<MetadataInstanceElement>): boolean => {
     const changeElem = getChangeData(change)

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -177,6 +177,14 @@ export const mockTypes = {
       suffix: 'workflow',
     },
   }),
+  WorkflowFieldUpdate: createMetadataObjectType({
+    annotations: {
+      metadataType: WORKFLOW_TASK_METADATA_TYPE,
+      dirName: 'workflows',
+      suffix: 'workflow',
+    },
+  }),
+
   TestSettings: createMetadataObjectType({
     annotations: {
       metadataType: 'TestSettings',
@@ -535,6 +543,11 @@ export const mockTypes = {
     },
   }),
   TestCustomObject__c: createCustomObjectType('TestCustomObject__c', {}),
+  BusinessProcess: createMetadataObjectType({
+    annotations: {
+      metadataType: 'BusinessProcess',
+    },
+  }),
 }
 
 export const lwcJsResourceContent = "import { LightningElement } from 'lwc';\nexport default class BikeCard extends LightningElement {\n   name = 'Electra X4';\n   description = 'A sweet bike built for comfort.';\n   category = 'Mountain';\n   material = 'Steel';\n   price = '$2,700';\n   pictureUrl = 'https://s3-us-west-1.amazonaws.com/sfdc-demo/ebikes/electrax4.jpg';\n }"
@@ -691,6 +704,18 @@ export const mockDefaultValues = {
   },
   DataCategoryGroup: {
     [INSTANCE_FULL_NAME_FIELD]: 'TestDataCategoryGroup',
+  },
+  BusinessProcess: {
+    [INSTANCE_FULL_NAME_FIELD]: 'Opportunity.TestBusinessProposal',
+    active: true,
+    description: 'Test Business Proposal Description',
+  },
+  WorkflowFieldUpdate: {
+    [INSTANCE_FULL_NAME_FIELD]: 'TestWorkflowFieldUpdate',
+    actionName: 'TestWorkflowFieldUpdate',
+    description: 'Test Workflow Field Update Description',
+    assignedTo: 'TestUser',
+    status: 'Completed',
   },
 }
 


### PR DESCRIPTION
Fix issue where element IDs were not saved on failed deployments
Also, make deploy message more concise, since all the information is now saved elsewhere

---

---
_Release Notes_: _None_

---
_User Notifications_: _None_