### PR TITLE
SALTO-4386: fix is free license

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -132,6 +132,7 @@ import projectCategoryFilter from './filters/project_category'
 import addAliasFilter from './filters/add_alias'
 import projectRoleRemoveTeamManagedDuplicatesFilter from './filters/remove_specific_duplicate_roles'
 import issueLayoutFilter from './filters/issue_layout/issue_layout'
+import issueTypeHierarchyFilter from './filters/issue_type_hierarchy_filter'
 import projectFieldContextOrder from './filters/project_field_contexts_order'
 import scriptedFieldsIssueTypesFilter from './filters/script_runner/scripted_fields_issue_types'
 import scriptRunnerFilter from './filters/script_runner/script_runner_filter'
@@ -240,6 +241,7 @@ export const DEFAULT_FILTERS = [
   notificationSchemeStructureFilter,
   notificationSchemeDeploymentFilter,
   issueTypeScreenSchemeFilter,
+  issueTypeHierarchyFilter,
   fieldConfigurationFilter,
   fieldConfigurationItemsFilter,
   fieldConfigurationSchemeFilter,

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -56,6 +56,7 @@ import { projectCategoryValidator } from './project_category'
 import { unresolvedFieldConfigurationItemsValidator } from './unresolved_field_configuration_items'
 import { fieldSecondGlobalContextValidator } from './field_contexts/second_global_context'
 import { customFieldsWith10KOptionValidator } from './field_contexts/custom_field_with_10K_options'
+import { issueTypeHierarchyValidator } from './issue_type_hierarchy'
 
 const {
   deployTypesNotSupportedValidator,
@@ -109,6 +110,7 @@ export default (
     projectCategory: projectCategoryValidator(client),
     unresolvedFieldConfigurationItems: unresolvedFieldConfigurationItemsValidator,
     customFieldsWith10KOptions: customFieldsWith10KOptionValidator,
+    issueTypeHierarchy: issueTypeHierarchyValidator,
   }
 
   return createChangeValidator({

--- a/packages/jira-adapter/src/change_validators/issue_type_hierarchy.ts
+++ b/packages/jira-adapter/src/change_validators/issue_type_hierarchy.ts
@@ -1,0 +1,86 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ChangeError, ChangeValidator, getChangeData, InstanceElement, isInstanceChange, SeverityLevel, Change, ModificationChange, AdditionChange, isAdditionOrModificationChange, isAdditionChange, isModificationChange } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { ISSUE_TYPE_NAME } from '../constants'
+import { isFreeLicense } from '../utils'
+
+const { awu } = collections.asynciterable
+
+const isSubTaskStoryChange = (change: Change<InstanceElement>): boolean =>
+  isModificationChange(change)
+  && change.data.before.value.hierarchyLevel + change.data.after.value.hierarchyLevel === -1
+
+
+const getIssueTypeWithHierachyChanges = (changes: ReadonlyArray<Change>): (
+    AdditionChange<InstanceElement> | ModificationChange<InstanceElement>)[] => changes.filter(isInstanceChange)
+  .filter(isAdditionOrModificationChange)
+  .filter(change => getChangeData(change).elemID.typeName === ISSUE_TYPE_NAME)
+  .filter(change =>
+    (isAdditionChange(change) && change.data.after.value.hierarchyLevel > 0)
+      || (isModificationChange(change)
+    && change.data.before.value.hierarchyLevel !== change.data.after.value.hierarchyLevel))
+
+const getIsuueTypeHierarchyErrorMessage = (instance: InstanceElement): ChangeError => ({
+  elemID: instance.elemID,
+  severity: 'Error' as SeverityLevel,
+  message: 'Cannot deploy issue type with hierarchy level greater than 0.',
+  detailedMessage: 'Issue type hierarchy level can only be -1, 0. To deploy, change the hierarchy level to one of the allowed values.',
+})
+const getIsuueTypeUnsupportedHierarchyErrorMessage = (instance: InstanceElement): ChangeError => ({
+  elemID: instance.elemID,
+  severity: 'Error' as SeverityLevel,
+  message: 'Cannot modify hierarchy level from 0 to -1 or vice versa.',
+  detailedMessage: 'Issue type hierarchy level cannot be changed from 0 to -1 or vice versa.',
+})
+
+const getIsuueTypeHierearchyWarningMessage = (instance: InstanceElement): ChangeError => ({
+  elemID: instance.elemID,
+  severity: 'Warning' as SeverityLevel,
+  message: 'Unsupported hierarchy Level',
+  detailedMessage: `${instance.value.name} hierarchy level is unsupported for deployment. You will need to change it to your desired hierarchy level through the service. Please follow the instructions to make the necessary adjustments.`,
+  deployActions: {
+    postAction: {
+      title: 'Hierarchy level change is required',
+      description: 'To change the hierarchy level to the desired hierarchy level, follow these steps:',
+      showOnFailure: false,
+      subActions: [
+        'Go to Issue type hierarchy page in your jira account.',
+        'Under "Jira Issue Types" column, Click on your desired hierarchy level.',
+        `Select ${instance.value.name} from the list of issue types.`,
+        'Click on the "Save changes" button.',
+      ],
+    },
+  },
+})
+
+export const issueTypeHierarchyValidator: ChangeValidator = async (changes, elementSource) => {
+  if (elementSource === undefined) {
+    return []
+  }
+  const relevantChanges = getIssueTypeWithHierachyChanges(changes)
+  const isLicenseFree = await isFreeLicense(elementSource)
+  return awu(relevantChanges)
+    .map(change => {
+      const instance = getChangeData(change)
+      if (isSubTaskStoryChange(change)) {
+        return getIsuueTypeUnsupportedHierarchyErrorMessage(instance)
+      }
+      return isLicenseFree === false
+        ? getIsuueTypeHierearchyWarningMessage(instance) : getIsuueTypeHierarchyErrorMessage(instance)
+    })
+    .toArray()
+}

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -225,6 +225,7 @@ export type ChangeValidatorName = (
   | 'projectCategory'
   | 'unresolvedFieldConfigurationItems'
   | 'customFieldsWith10KOptions'
+  | 'issueTypeHierarchy'
   )
 
 type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
@@ -272,6 +273,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     projectCategory: { refType: BuiltinTypes.BOOLEAN },
     unresolvedFieldConfigurationItems: { refType: BuiltinTypes.BOOLEAN },
     customFieldsWith10KOptions: { refType: BuiltinTypes.BOOLEAN },
+    issueTypeHierarchy: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/jira-adapter/src/filters/issue_type_hierarchy_filter.ts
+++ b/packages/jira-adapter/src/filters/issue_type_hierarchy_filter.ts
@@ -1,0 +1,58 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { getChangeData, isAdditionChange, isInstanceChange } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { ISSUE_TYPE_NAME } from '../constants'
+import { FilterCreator } from '../filter'
+import { isFreeLicense } from '../utils'
+
+const { awu } = collections.asynciterable
+
+const filter: FilterCreator = ({ elementsSource }) => {
+  const IssueTypeTohierarchyLevel: Record<string, number> = {}
+  return {
+    name: 'issueTypeHierarchyFilter',
+    preDeploy: async changes => {
+      const isLicenseFree = await isFreeLicense(elementsSource)
+      if (isLicenseFree) {
+        return
+      }
+
+      await awu(changes)
+        .filter(isInstanceChange)
+        .filter(isAdditionChange)
+        .map(getChangeData)
+        .filter(instance => instance.elemID.typeName === ISSUE_TYPE_NAME)
+        .filter(instance => instance.value.hierarchyLevel > 0)
+        .forEach(instance => {
+          IssueTypeTohierarchyLevel[instance.elemID.getFullName()] = instance.value.hierarchyLevel
+          instance.value.hierarchyLevel = 0
+        })
+    },
+    onDeploy: async changes => {
+      await awu(changes)
+        .filter(isInstanceChange)
+        .map(getChangeData)
+        .filter(instance => Object.keys(IssueTypeTohierarchyLevel).includes(instance.elemID.getFullName()))
+        .forEach(instance => {
+          instance.value.hierarchyLevel = IssueTypeTohierarchyLevel[instance.elemID.getFullName()]
+        })
+    },
+  }
+}
+
+export default filter

--- a/packages/jira-adapter/src/utils.ts
+++ b/packages/jira-adapter/src/utils.ts
@@ -99,8 +99,8 @@ export const isFreeLicense = async (
   const mainApplication = accountInfo.value.license.applications.find((app: Value) => app.id === 'jira-software')
 
   if (mainApplication?.plan === undefined) {
-    log.error('could not find license of jira-software, treating the account as paid one')
-    return false
+    log.warn('could not find license of jira-software, treating the account as free one')
+    return true
   }
   return mainApplication.plan === JIRA_FREE_PLAN
 }

--- a/packages/jira-adapter/src/utils.ts
+++ b/packages/jira-adapter/src/utils.ts
@@ -99,8 +99,8 @@ export const isFreeLicense = async (
   const mainApplication = accountInfo.value.license.applications.find((app: Value) => app.id === 'jira-software')
 
   if (mainApplication?.plan === undefined) {
-    log.warn('could not find license of jira-software, treating the account as free one')
-    return true
+    log.warn('could not find license of jira-software, treating the account as paid one')
+    return false
   }
   return mainApplication.plan === JIRA_FREE_PLAN
 }

--- a/packages/jira-adapter/test/change_validators/issue_type_hierarchy.test.ts
+++ b/packages/jira-adapter/test/change_validators/issue_type_hierarchy.test.ts
@@ -1,0 +1,158 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { InstanceElement, ReadOnlyElementsSource, toChange, SeverityLevel } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { ISSUE_TYPE_NAME } from '../../src/constants'
+import { createEmptyType, getAccountInfoInstance } from '../utils'
+import { issueTypeHierarchyValidator } from '../../src/change_validators/issue_type_hierarchy'
+
+describe('issue type hierarchy validator', () => {
+  const issueTypeType = createEmptyType(ISSUE_TYPE_NAME)
+  let issueTypeLevelTwo: InstanceElement
+  let issueTypeLevelZero: InstanceElement
+  let elementsSource: ReadOnlyElementsSource
+  beforeEach(() => {
+    issueTypeLevelTwo = new InstanceElement(
+      'issueTypeLevelTwo',
+      issueTypeType,
+      {
+        hierarchyLevel: 2,
+        description: 'test',
+        name: 'issueTypeLevelTwo',
+      }
+    )
+    issueTypeLevelZero = new InstanceElement(
+      'issueTypeLevelZero',
+      issueTypeType,
+      {
+        hierarchyLevel: 0,
+        description: 'test',
+        name: 'issueTypeLevelZero',
+      }
+    )
+  })
+  describe('free account', () => {
+    const accountInfoInstanceFree = getAccountInfoInstance(true)
+    beforeEach(() => {
+      elementsSource = buildElementsSourceFromElements([accountInfoInstanceFree])
+    })
+    it('should return error if it is free account and adding issue type that has hierarchy level greater than 1', async () => {
+      const changes = [toChange({ after: issueTypeLevelTwo })]
+      expect(await issueTypeHierarchyValidator(changes, elementsSource)).toEqual([
+        {
+          elemID: issueTypeLevelTwo.elemID,
+          severity: 'Error' as SeverityLevel,
+          message: 'Cannot deploy issue type with hierarchy level greater than 0.',
+          detailedMessage: 'Issue type hierarchy level can only be -1, 0. To deploy, change the hierarchy level to one of the allowed values.',
+        },
+      ])
+    })
+    it('should return error if it is free account and modifying issue type to hierarchy level greater than 1', async () => {
+      const issueTypeAfter = issueTypeLevelZero.clone()
+      issueTypeAfter.value.hierarchyLevel = 2
+      const changes = [toChange({ before: issueTypeLevelZero, after: issueTypeAfter })]
+      expect(await issueTypeHierarchyValidator(changes, elementsSource)).toEqual([
+        {
+          elemID: issueTypeAfter.elemID,
+          severity: 'Error' as SeverityLevel,
+          message: 'Cannot deploy issue type with hierarchy level greater than 0.',
+          detailedMessage: 'Issue type hierarchy level can only be -1, 0. To deploy, change the hierarchy level to one of the allowed values.',
+        },
+      ])
+    })
+    it('should not return error if it is free account and adding issue type that has hierarchy level equal to 0 or -1', async () => {
+      const changes = [toChange({ after: issueTypeLevelZero })]
+      expect(await issueTypeHierarchyValidator(changes, elementsSource)).toEqual([])
+    })
+    it('should return error message for unsupported hierarchy change from 0 to -1 or backwards', async () => {
+      const issueTypeAfter = issueTypeLevelZero.clone()
+      issueTypeAfter.value.hierarchyLevel = -1
+      const changes = [toChange({ before: issueTypeLevelZero, after: issueTypeAfter })]
+      expect(await issueTypeHierarchyValidator(changes, elementsSource)).toEqual([
+        {
+          elemID: issueTypeAfter.elemID,
+          severity: 'Error' as SeverityLevel,
+          message: 'Cannot modify hierarchy level from 0 to -1 or vice versa.',
+          detailedMessage: 'Issue type hierarchy level cannot be changed from 0 to -1 or vice versa.',
+        }])
+    })
+  })
+  describe('paid account', () => {
+    const accountInfoInstancePaid = getAccountInfoInstance(false)
+    beforeEach(() => {
+      elementsSource = buildElementsSourceFromElements([accountInfoInstancePaid])
+    })
+    it('should return warning if it is paid account and adding issue type that has hierarchy level greater than 1', async () => {
+      const changes = [toChange({ after: issueTypeLevelTwo })]
+      expect(await issueTypeHierarchyValidator(changes, elementsSource)).toEqual([
+        {
+          elemID: issueTypeLevelTwo.elemID,
+          severity: 'Warning' as SeverityLevel,
+          message: 'Unsupported hierarchy Level',
+          detailedMessage: 'issueTypeLevelTwo hierarchy level is unsupported for deployment. You will need to change it to your desired hierarchy level through the service. Please follow the instructions to make the necessary adjustments.',
+          deployActions: {
+            postAction: {
+              title: 'Hierarchy level change is required',
+              description: 'To change the hierarchy level to the desired hierarchy level, follow these steps:',
+              showOnFailure: false,
+              subActions: [
+                'Go to Issue type hierarchy page in your jira account.',
+                'Under "Jira Issue Types" column, Click on your desired hierarchy level.',
+                'Select issueTypeLevelTwo from the list of issue types.',
+                'Click on the "Save changes" button.',
+              ],
+            },
+          },
+        }])
+    })
+    it('should return warning if it is paid account and changing issue type hierarchy', async () => {
+      const issueTypeAfter = issueTypeLevelZero.clone()
+      issueTypeAfter.value.hierarchyLevel = 2
+      const changes = [toChange({ before: issueTypeLevelZero, after: issueTypeAfter })]
+      expect(await issueTypeHierarchyValidator(changes, elementsSource)).toEqual([
+        {
+          elemID: issueTypeAfter.elemID,
+          severity: 'Warning' as SeverityLevel,
+          message: 'Unsupported hierarchy Level',
+          detailedMessage: 'issueTypeLevelZero hierarchy level is unsupported for deployment. You will need to change it to your desired hierarchy level through the service. Please follow the instructions to make the necessary adjustments.',
+          deployActions: {
+            postAction: {
+              title: 'Hierarchy level change is required',
+              description: 'To change the hierarchy level to the desired hierarchy level, follow these steps:',
+              showOnFailure: false,
+              subActions: [
+                'Go to Issue type hierarchy page in your jira account.',
+                'Under "Jira Issue Types" column, Click on your desired hierarchy level.',
+                'Select issueTypeLevelZero from the list of issue types.',
+                'Click on the "Save changes" button.',
+              ],
+            },
+          },
+        }])
+    })
+    it('should not return warning if it is paid account and adding issue type that has hierarchy level equal to 0 or -1', async () => {
+      const changes = [toChange({ after: issueTypeLevelZero })]
+      expect(await issueTypeHierarchyValidator(changes, elementsSource)).toEqual([])
+    })
+    it('should not return warning if is modification change of field different from hierarchy', async () => {
+      const issueTypeAfter = issueTypeLevelTwo.clone()
+      issueTypeAfter.value.description = 'new description'
+      const changes = [toChange({ before: issueTypeLevelTwo, after: issueTypeAfter })]
+      expect(await issueTypeHierarchyValidator(changes, elementsSource)).toEqual([])
+    })
+  })
+})

--- a/packages/jira-adapter/test/filters/issue_type_hierarchy_filter.test.ts
+++ b/packages/jira-adapter/test/filters/issue_type_hierarchy_filter.test.ts
@@ -1,0 +1,90 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { ObjectType, ElemID, InstanceElement, ReadOnlyElementsSource, toChange, getChangeData } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { JIRA, ISSUE_TYPE_NAME } from '../../src/constants'
+import { getAccountInfoInstance, getFilterParams } from '../utils'
+import issueTypeHierarchyFilter from '../../src/filters/issue_type_hierarchy_filter'
+
+describe('issue Type Hierarchy Filter', () => {
+  const issueTypeType = new ObjectType({
+    elemID: new ElemID(JIRA, ISSUE_TYPE_NAME),
+  })
+  const accountInfoInstanceFree = getAccountInfoInstance(true)
+  const accountInfoInstancePaid = getAccountInfoInstance(false)
+  let issueTypeInstanceLevelTwo: InstanceElement
+  let issueTypeInstanceLevelZero: InstanceElement
+  let elementsSource: ReadOnlyElementsSource
+  type FilterType = filterUtils.FilterWith<'preDeploy' | 'onDeploy'>
+  let filter: FilterType
+
+  beforeEach(() => {
+    issueTypeInstanceLevelTwo = new InstanceElement(
+      'issueTypeInstance',
+      issueTypeType,
+      {
+        hierarchyLevel: 2,
+        description: 'test',
+      }
+    )
+    issueTypeInstanceLevelZero = new InstanceElement(
+      'issueTypeInstanceTwo',
+      issueTypeType,
+      {
+        hierarchyLevel: 0,
+        description: 'test',
+      }
+    )
+  })
+
+  describe('preDeploy', () => {
+    it('should convert hierarchy level to 0 only if it is paid account and adding issue type that has hierarchy level greater than 0', async () => {
+      elementsSource = buildElementsSourceFromElements([accountInfoInstancePaid])
+      filter = issueTypeHierarchyFilter(getFilterParams({ elementsSource })) as FilterType
+      const changes = [toChange({ after: issueTypeInstanceLevelTwo }), toChange({ after: issueTypeInstanceLevelZero })]
+      await filter.preDeploy(changes)
+      expect(getChangeData(changes[0]).value.hierarchyLevel).toEqual(0)
+      expect(getChangeData(changes[1]).value.hierarchyLevel).toEqual(0)
+    })
+    it('should not convert hierarchy level to 0 if it has hierarchy level -1', async () => {
+      elementsSource = buildElementsSourceFromElements([accountInfoInstancePaid])
+      filter = issueTypeHierarchyFilter(getFilterParams({ elementsSource })) as FilterType
+      issueTypeInstanceLevelTwo.value.hierarchyLevel = -1
+      const changes = [toChange({ after: issueTypeInstanceLevelTwo })]
+      await filter.preDeploy(changes)
+      expect(getChangeData(changes[0]).value.hierarchyLevel).toEqual(-1)
+    })
+    it('should not convert hierarchy level to 0 if it is free account', async () => {
+      elementsSource = buildElementsSourceFromElements([accountInfoInstanceFree])
+      filter = issueTypeHierarchyFilter(getFilterParams({ elementsSource })) as FilterType
+      const changes = [toChange({ after: issueTypeInstanceLevelTwo })]
+      await filter.preDeploy(changes)
+      expect(getChangeData(changes[0]).value.hierarchyLevel).toEqual(2)
+    })
+  })
+  describe('onDeploy', () => {
+    it('should restore hierarchy level to original value', async () => {
+      elementsSource = buildElementsSourceFromElements([accountInfoInstancePaid])
+      filter = issueTypeHierarchyFilter(getFilterParams({ elementsSource })) as FilterType
+      const changes = [toChange({ after: issueTypeInstanceLevelTwo })]
+      await filter.preDeploy(changes)
+      await filter.onDeploy(changes)
+      expect(getChangeData(changes[0]).value.hierarchyLevel).toEqual(2)
+    })
+  })
+})


### PR DESCRIPTION
Returned the changes of the [Hierarchy fixes](https://github.com/salto-io/salto/pull/4696) and reverted the change for `isFreeLicense`

---

Split into two: one commit for the revert of the revert, the second for the change
---
_Release Notes_: 
Jira Adapter:
* Fixed a bug that prevented deployment of permission schemes for some customers

---
_User Notifications_: 
None
