### PR TITLE
SALTO-4656: Support new reference index structure in deserialize

### DIFF
--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -2713,6 +2713,12 @@ describe('workspace', () => {
       const reSerializedTree = await serializeReferenceTree(deserializedTree)
       expect(reSerializedTree).toEqual(serializedTree)
     })
+
+    it('should deserialize references with types', async () => {
+      const serializedTree = '[["someAnnotation",[{"id":"test.target2.field.someField.value","type":"strong"}]]]'
+      const deserializedTree = await deserializeReferenceTree(serializedTree)
+      expect(deserializedTree.get('someAnnotation')).toEqual([ElemID.fromFullName('test.target2.field.someField.value')])
+    })
   })
   describe('deleteEnvironment', () => {
     describe('should delete environment', () => {


### PR DESCRIPTION
Add support new reference index structure in deserialize

---

This is done to have backward compatibility for the changes in https://github.com/salto-io/salto/pull/4790

---
_Release Notes_: 
None

---
_User Notifications_: 
None