### PR TITLE
SALTO-4694: summarizeDeployChanges runs on modified requested changes

### DIFF
--- a/packages/cli/test/commands/deploy.test.ts
+++ b/packages/cli/test/commands/deploy.test.ts
@@ -257,7 +257,7 @@ describe('deploy command', () => {
     })
   })
   describe('when there are deploy actions', () => {
-    const testDeployActionsVisability = async (userBooleanInput: boolean): Promise<void> => {
+    const testDeployActionsVisibility = async (userBooleanInput: boolean): Promise<void> => {
       mockGetUserBooleanInput.mockResolvedValueOnce(userBooleanInput)
       await action({
         ...cliCommandArgs,
@@ -296,10 +296,10 @@ describe('deploy command', () => {
       expect(output.stdout.content).toMatch(/fourth subtext2/s)
     }
     it('should print deploy actions when deploy is done', async () => {
-      await testDeployActionsVisability(true)
+      await testDeployActionsVisibility(true)
     })
     it('should print deploy actions when deploy is canceled', async () => {
-      await testDeployActionsVisability(false)
+      await testDeployActionsVisibility(false)
     })
   })
   describe('Using environment variable', () => {


### PR DESCRIPTION
---

_Additional context for reviewer_

`deploy` method, changes the `actionPlan` is receives, and thus, hurts the `summarizeDeployChanges` which needs the original and un-modified "requestedChanges".

This PR "saves" them by copying them before the plan, and reusing them afterwards.

---

_Release Notes_: 
Bug fix: Post-deploy actions of failed changes was not shown in salesforce CPQ use-case.


---

_User Notifications_: 
None