### PR TITLE
Revert "SAAS-7539 display the total number of workSpace errors from diagnostics (#4796)"

### DIFF
--- a/packages/lang-server/test/diagnostics.test.ts
+++ b/packages/lang-server/test/diagnostics.test.ts
@@ -57,14 +57,12 @@ describe('diagnostics', () => {
   })
   it('should diagnostics on errors', async () => {
     const workspace = new EditorWorkspace('bla', baseWs)
-    const diag = await getDiagnostics(workspace)
-    const diagErrors = diag.errors['/parse_error.nacl']
-    const validationError = diagErrors[0]
-    expect(diag.totalNumberOfErrors).toBe(2)
+    const diag = (await getDiagnostics(workspace))['/parse_error.nacl']
+    const validationError = diag[0]
     expect(validationError).toBeDefined()
     expect(validationError.msg).toContain('Blabla')
     expect(validationError.severity).toBe('Error')
-    const parseError = diagErrors[1]
+    const parseError = diag[1]
     expect(parseError).toBeDefined()
     expect(parseError.msg).toContain('parse')
     expect(parseError.severity).toBe('Error')
@@ -75,7 +73,7 @@ describe('diagnostics', () => {
       [{ severity: 'Error', message: 'Blabla' }, { severity: 'Warning', message: 'test' }],
     ))
     const workspace = new EditorWorkspace('bla', baseWs)
-    const diag = (await getDiagnostics(workspace)).errors['/parse_error.nacl']
+    const diag = (await getDiagnostics(workspace))['/parse_error.nacl']
     expect(diag).toHaveLength(1)
     const error = diag[0]
     expect(error.severity).toEqual('Error')
@@ -86,7 +84,7 @@ describe('diagnostics', () => {
       [{ severity: 'Warning', message: 'Blabla' }],
     ))
     const workspace = new EditorWorkspace('bla', baseWs)
-    const diag = (await getDiagnostics(workspace)).errors['/parse_error.nacl']
+    const diag = (await getDiagnostics(workspace))['/parse_error.nacl']
     expect(diag).toHaveLength(1)
     const error = diag[0]
     expect(error.severity).toEqual('Warning')

--- a/packages/vscode/e2e_test/extension.test.ts
+++ b/packages/vscode/e2e_test/extension.test.ts
@@ -69,7 +69,7 @@ describe.skip('extension e2e', () => {
   })
 
   it('should diagnostics on errors', async () => {
-    const diag = (await diagnostics.getDiagnostics(workspace)).errors
+    const diag = await diagnostics.getDiagnostics(workspace)
     const err = diag['error.nacl'][0]
     expect(err.msg).toContain(
       'Error merging @salto-io/core.complex.instance.inst1: duplicate key str'

--- a/packages/vscode/src/adapters.ts
+++ b/packages/vscode/src/adapters.ts
@@ -119,7 +119,7 @@ const toVSDiagnostic = (
 export const toVSDiagnostics = (
   workspaceBaseDir: string,
   workspaceDiag: diagnostics.WorkspaceSaltoDiagnostics
-): ReadonlyDiags => _(workspaceDiag.errors)
+): ReadonlyDiags => _(workspaceDiag)
   .mapValues(diags => diags.map(toVSDiagnostic))
   .entries()
   .map(([k, v]) => [vscode.Uri.file(toVSFileName(workspaceBaseDir, k)), v] as ReadonlyDiagsItem)


### PR DESCRIPTION
This reverts commit aeebfa5fc6eb091057cc8eb40fd04522e61548ef.

_Replace me with a description of the changes in this PR_

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
