### PR TITLE
Revert "Revert "SAAS-7539 display the total number of workSpace errors

### DIFF
--- a/packages/lang-server/test/diagnostics.test.ts
+++ b/packages/lang-server/test/diagnostics.test.ts
@@ -57,12 +57,14 @@ describe('diagnostics', () => {
   })
   it('should diagnostics on errors', async () => {
     const workspace = new EditorWorkspace('bla', baseWs)
-    const diag = (await getDiagnostics(workspace))['/parse_error.nacl']
-    const validationError = diag[0]
+    const diag = await getDiagnostics(workspace)
+    const diagErrors = diag.errors['/parse_error.nacl']
+    const validationError = diagErrors[0]
+    expect(diag.totalNumberOfErrors).toBe(2)
     expect(validationError).toBeDefined()
     expect(validationError.msg).toContain('Blabla')
     expect(validationError.severity).toBe('Error')
-    const parseError = diag[1]
+    const parseError = diagErrors[1]
     expect(parseError).toBeDefined()
     expect(parseError.msg).toContain('parse')
     expect(parseError.severity).toBe('Error')
@@ -73,7 +75,7 @@ describe('diagnostics', () => {
       [{ severity: 'Error', message: 'Blabla' }, { severity: 'Warning', message: 'test' }],
     ))
     const workspace = new EditorWorkspace('bla', baseWs)
-    const diag = (await getDiagnostics(workspace))['/parse_error.nacl']
+    const diag = (await getDiagnostics(workspace)).errors['/parse_error.nacl']
     expect(diag).toHaveLength(1)
     const error = diag[0]
     expect(error.severity).toEqual('Error')
@@ -84,7 +86,7 @@ describe('diagnostics', () => {
       [{ severity: 'Warning', message: 'Blabla' }],
     ))
     const workspace = new EditorWorkspace('bla', baseWs)
-    const diag = (await getDiagnostics(workspace))['/parse_error.nacl']
+    const diag = (await getDiagnostics(workspace)).errors['/parse_error.nacl']
     expect(diag).toHaveLength(1)
     const error = diag[0]
     expect(error.severity).toEqual('Warning')

--- a/packages/vscode/e2e_test/extension.test.ts
+++ b/packages/vscode/e2e_test/extension.test.ts
@@ -69,7 +69,7 @@ describe.skip('extension e2e', () => {
   })
 
   it('should diagnostics on errors', async () => {
-    const diag = await diagnostics.getDiagnostics(workspace)
+    const diag = (await diagnostics.getDiagnostics(workspace)).errors
     const err = diag['error.nacl'][0]
     expect(err.msg).toContain(
       'Error merging @salto-io/core.complex.instance.inst1: duplicate key str'

--- a/packages/vscode/src/adapters.ts
+++ b/packages/vscode/src/adapters.ts
@@ -119,7 +119,7 @@ const toVSDiagnostic = (
 export const toVSDiagnostics = (
   workspaceBaseDir: string,
   workspaceDiag: diagnostics.WorkspaceSaltoDiagnostics
-): ReadonlyDiags => _(workspaceDiag)
+): ReadonlyDiags => _(workspaceDiag.errors)
   .mapValues(diags => diags.map(toVSDiagnostic))
   .entries()
   .map(([k, v]) => [vscode.Uri.file(toVSFileName(workspaceBaseDir, k)), v] as ReadonlyDiagsItem)


### PR DESCRIPTION
Revert "Revert "SAAS-7539 display the total number of workSpace errors

This reverts commit 357933a562fa5261823517049da83c31b202d401, that reverted aeebfa5fc6eb091057cc8eb40fd04522e61548ef.

---
_Release Notes_: 
display the total number of workSpace errors from diagnostics


---
_User Notifications_: 
None
