### PR TITLE
SAAS-7539 fix total number of ws errors sent from getDiagnostics 

### DIFF
--- a/packages/lang-server/src/diagnostics.ts
+++ b/packages/lang-server/src/diagnostics.ts
@@ -44,6 +44,7 @@ export const getDiagnostics = async (
   const errors = errorsAndWarnings
     .filter(e => e.severity === 'Error')
   const errorsToDisplay = _.isEmpty(errors) ? errorsAndWarnings : errors
+  const totalNumberOfErrors = _.isEmpty(errors) ? errorsAndWarnings.length : errors.length
   const workspaceErrors = await Promise.all(
     wu(errorsToDisplay)
       .slice(0, MAX_WORKSPACE_ERRORS)
@@ -69,5 +70,5 @@ export const getDiagnostics = async (
     .flatten()
     .groupBy('filename')
     .value()
-  return { errors: { ...emptyDiagFiles, ...diag }, totalNumberOfErrors: errorsAndWarnings.length }
+  return { errors: { ...emptyDiagFiles, ...diag }, totalNumberOfErrors }
 }

--- a/packages/lang-server/test/diagnostics.test.ts
+++ b/packages/lang-server/test/diagnostics.test.ts
@@ -75,9 +75,11 @@ describe('diagnostics', () => {
       [{ severity: 'Error', message: 'Blabla' }, { severity: 'Warning', message: 'test' }],
     ))
     const workspace = new EditorWorkspace('bla', baseWs)
-    const diag = (await getDiagnostics(workspace)).errors['/parse_error.nacl']
-    expect(diag).toHaveLength(1)
-    const error = diag[0]
+    const diag = await getDiagnostics(workspace)
+    const diagErrors = diag.errors['/parse_error.nacl']
+    expect(diag.totalNumberOfErrors).toBe(1)
+    expect(diagErrors).toHaveLength(1)
+    const error = diagErrors[0]
     expect(error.severity).toEqual('Error')
     expect(error.msg).toEqual('Blabla')
   })


### PR DESCRIPTION
SAAS-7539 fix total number of ws errors sent from getDiagnostics 
---

_Additional context for reviewer_

---
_Release Notes_: 
none

---
_User Notifications_: 
none
