### PR TITLE
SALTO-4697: Add fixElements adapter API

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -124,6 +124,11 @@ export type DeployModifiers = {
 
 export type ValidationModifiers = Pick<DeployModifiers, 'changeValidator'>
 
+export type FixElementsFunc = (elements: Element[]) => Promise<{
+  fixedElements: Element[]
+  errors: ChangeError[]
+}>
+
 export type AdapterOperations = {
   fetch: (opts: FetchOptions) => Promise<FetchResult>
   deploy: (opts: DeployOptions) => Promise<DeployResult>
@@ -131,6 +136,7 @@ export type AdapterOperations = {
   postFetch?: (opts: PostFetchOptions) => Promise<void>
   deployModifiers?: DeployModifiers
   validationModifiers?: ValidationModifiers
+  fixElements?: FixElementsFunc
 }
 
 export type AdapterOperationName = keyof AdapterOperations
@@ -192,8 +198,6 @@ export type ReferenceInfo = {
 
 export type GetCustomReferencesFunc = (elements: Element[]) => Promise<ReferenceInfo[]>
 
-export type FixElementsFunc = (elements: Element[]) => Promise<ChangeError[]>
-
 export type Adapter = {
   operations: (context: AdapterOperationsContext) => AdapterOperations
   validateCredentials: (config: Readonly<InstanceElement>) => Promise<AccountInfo>
@@ -204,7 +208,6 @@ export type Adapter = {
   loadElementsFromFolder?: (args: LoadElementsFromFolderArgs) => Promise<FetchResult>
   getAdditionalReferences?: GetAdditionalReferencesFunc
   getCustomReferences?: GetCustomReferencesFunc
-  fixElements?: FixElementsFunc
 }
 
 export const OBJECT_SERVICE_ID = 'object_service_id'

--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -192,12 +192,7 @@ export type ReferenceInfo = {
 
 export type GetCustomReferencesFunc = (elements: Element[]) => Promise<ReferenceInfo[]>
 
-export type ElementFix = Pick<ChangeError, 'message' | 'detailedMessage'> & {
-  severity: 'Info' | 'Warning'
-  fixedElement: Element
-}
-
-export type FixElementsFunc = (elements: Element[]) => Promise<ElementFix[]>
+export type FixElementsFunc = (elements: Element[]) => Promise<ChangeError[]>
 
 export type Adapter = {
   operations: (context: AdapterOperationsContext) => AdapterOperations

--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -192,6 +192,13 @@ export type ReferenceInfo = {
 
 export type GetCustomReferencesFunc = (elements: Element[]) => Promise<ReferenceInfo[]>
 
+export type ElementFix = Pick<ChangeError, 'message' | 'detailedMessage'> & {
+  severity: 'Info' | 'Warning'
+  fixedElement: Element
+}
+
+export type FixElementsFunc = (elements: Element[]) => Promise<ElementFix[]>
+
 export type Adapter = {
   operations: (context: AdapterOperationsContext) => AdapterOperations
   validateCredentials: (config: Readonly<InstanceElement>) => Promise<AccountInfo>
@@ -202,6 +209,7 @@ export type Adapter = {
   loadElementsFromFolder?: (args: LoadElementsFromFolderArgs) => Promise<FetchResult>
   getAdditionalReferences?: GetAdditionalReferencesFunc
   getCustomReferences?: GetCustomReferencesFunc
+  fixElements?: FixElementsFunc
 }
 
 export const OBJECT_SERVICE_ID = 'object_service_id'

--- a/packages/cli/src/commands/element.ts
+++ b/packages/cli/src/commands/element.ts
@@ -23,7 +23,7 @@ import { collections, promises } from '@salto-io/lowerdash'
 import { createCommandGroupDef, createWorkspaceCommand, WorkspaceCommandAction } from '../command_builder'
 import { CliOutput, CliExitCode, KeyedOption } from '../types'
 import { errorOutputLine, outputLine } from '../outputer'
-import { formatTargetEnvRequired, formatUnknownTargetEnv, formatInvalidEnvTargetCurrent, formatCloneToEnvFailed, formatInvalidFilters, formatMoveFailed, formatListFailed, emptyLine, formatListUnresolvedFound, formatListUnresolvedMissing, formatElementListUnresolvedFailed, formatChangeErrors, formatNonTopLevelFilters } from '../formatter'
+import { formatTargetEnvRequired, formatUnknownTargetEnv, formatInvalidEnvTargetCurrent, formatCloneToEnvFailed, formatInvalidFilters, formatMoveFailed, formatListFailed, emptyLine, formatListUnresolvedFound, formatListUnresolvedMissing, formatElementListUnresolvedFailed, formatChangeErrors, formatNonTopLevelSelectors } from '../formatter'
 import { isValidWorkspaceForCommand } from '../workspace/workspace'
 import Prompts from '../prompts'
 import { EnvArg, ENVIRONMENT_OPTION, validateAndSetEnv } from './common/env'
@@ -814,7 +814,7 @@ export const fixElementsAction: WorkspaceCommandAction<FixElementsArgs> = async 
     return CliExitCode.Success
   } catch (err) {
     if (err instanceof SelectorsError) {
-      errorOutputLine(formatNonTopLevelFilters(err.invalidSelectors), output)
+      errorOutputLine(formatNonTopLevelSelectors(err.invalidSelectors), output)
       return CliExitCode.UserInputError
     }
     throw err

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -700,8 +700,8 @@ export const formatInvalidFilters = (invalidFilters: string[]): string => [
   emptyLine(),
 ].join('\n')
 
-export const formatNonTopLevelFilters = (invalidFilters: string[]): string => [
-  formatSimpleError(Prompts.NON_TOP_LEVEL_FILTERS(formatWordsSeries(invalidFilters))),
+export const formatNonTopLevelSelectors = (invalidSelectors: string[]): string => [
+  formatSimpleError(Prompts.NON_TOP_LEVEL_SELECTORS(formatWordsSeries(invalidSelectors))),
   emptyLine(),
 ].join('\n')
 

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -700,6 +700,11 @@ export const formatInvalidFilters = (invalidFilters: string[]): string => [
   emptyLine(),
 ].join('\n')
 
+export const formatNonTopLevelFilters = (invalidFilters: string[]): string => [
+  formatSimpleError(Prompts.NON_TOP_LEVEL_FILTERS(formatWordsSeries(invalidFilters))),
+  emptyLine(),
+].join('\n')
+
 export const formatMissingElementSelectors = (): string => [
   formatSimpleError(Prompts.MISSING_ELEMENT_SELECTORS),
   emptyLine(),

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -221,6 +221,10 @@ ${Prompts.ACCOUNT_ADD_HELP}`
     invalidFilters: string
   ): string => `Failed to created element ID filters for: ${invalidFilters}. Invalid Regex provided.`
 
+  public static readonly NON_TOP_LEVEL_FILTERS = (
+    invalidFilters: string
+  ): string => `Expected top level selectors, received: ${invalidFilters}.`
+
   public static readonly MISSING_ELEMENT_SELECTORS = 'No element selectors specified'
 
   public static readonly DIFF_CALC_DIFF_START = (

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -221,9 +221,9 @@ ${Prompts.ACCOUNT_ADD_HELP}`
     invalidFilters: string
   ): string => `Failed to created element ID filters for: ${invalidFilters}. Invalid Regex provided.`
 
-  public static readonly NON_TOP_LEVEL_FILTERS = (
-    invalidFilters: string
-  ): string => `Expected top level selectors, received: ${invalidFilters}.`
+  public static readonly NON_TOP_LEVEL_SELECTORS = (
+    invalidSelectors: string
+  ): string => `Expected top level selectors, received: ${invalidSelectors}.`
 
   public static readonly MISSING_ELEMENT_SELECTORS = 'No element selectors specified'
 

--- a/packages/dummy-adapter/src/adapter.ts
+++ b/packages/dummy-adapter/src/adapter.ts
@@ -15,7 +15,7 @@
 */
 import {
   FetchResult, AdapterOperations, DeployResult, FetchOptions,
-  DeployOptions, DeployModifiers, getChangeData, isInstanceElement,
+  DeployOptions, DeployModifiers, getChangeData, isInstanceElement, FixElementsFunc,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { generateElements, GeneratorParams } from './generator'
@@ -62,5 +62,29 @@ export default class DummyAdapter implements AdapterOperations {
   public deployModifiers: DeployModifiers =
   {
     changeValidator: changeValidator(this.genParams),
+  }
+
+  fixElements: FixElementsFunc = async elements => {
+    const fullInst1 = elements.find(e => e.elemID.getFullName() === 'dummy.Full.instance.FullInst1')
+    if (!isInstanceElement(fullInst1)) {
+      return { fixedElements: [], errors: [] }
+    }
+
+    if (fullInst1.value.strField === undefined) {
+      return { fixedElements: [], errors: [] }
+    }
+
+    const clonedInstance = fullInst1.clone()
+    delete clonedInstance.value.strField
+
+    return {
+      fixedElements: [clonedInstance],
+      errors: [{
+        message: 'Fixed FullInst1.strField',
+        detailedMessage: 'Removed FullInst1.strField',
+        severity: 'Info',
+        elemID: fullInst1.elemID,
+      }],
+    }
   }
 }

--- a/packages/dummy-adapter/src/adapter.ts
+++ b/packages/dummy-adapter/src/adapter.ts
@@ -80,8 +80,8 @@ export default class DummyAdapter implements AdapterOperations {
     return {
       fixedElements: [clonedInstance],
       errors: [{
-        message: 'Fixed FullInst1.strField',
-        detailedMessage: 'Removed FullInst1.strField',
+        message: 'Fixed instance',
+        detailedMessage: 'Removed strField from instance',
         severity: 'Info',
         elemID: fullInst1.elemID,
       }],

--- a/packages/dummy-adapter/src/adapter_creator.ts
+++ b/packages/dummy-adapter/src/adapter_creator.ts
@@ -64,7 +64,7 @@ const fixElements: FixElementsFunc = async elements => {
     message: 'Fixed FullInst1.strField',
     detailedMessage: 'Removed FullInst1.strField',
     severity: 'Info',
-    fixedElement: fullInst1,
+    elemID: fullInst1.elemID,
   }]
 }
 

--- a/packages/dummy-adapter/src/adapter_creator.ts
+++ b/packages/dummy-adapter/src/adapter_creator.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Adapter, ElemID, CORE_ANNOTATIONS, BuiltinTypes, ObjectType, ListType, GetCustomReferencesFunc, FixElementsFunc, isInstanceElement } from '@salto-io/adapter-api'
+import { Adapter, ElemID, CORE_ANNOTATIONS, BuiltinTypes, ObjectType, ListType, GetCustomReferencesFunc } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import DummyAdapter from './adapter'
 import { GeneratorParams, DUMMY_ADAPTER, defaultParams, changeErrorType } from './generator'
@@ -48,26 +48,6 @@ const getCustomReferences: GetCustomReferencesFunc = async elements => (
     : []
 )
 
-const fixElements: FixElementsFunc = async elements => {
-  const fullInst1 = elements.find(e => e.elemID.getFullName() === 'dummy.Full.instance.FullInst1')
-  if (!isInstanceElement(fullInst1)) {
-    return []
-  }
-
-  if (fullInst1.value.strField === undefined) {
-    return []
-  }
-
-  delete fullInst1.value.strField
-
-  return [{
-    message: 'Fixed FullInst1.strField',
-    detailedMessage: 'Removed FullInst1.strField',
-    severity: 'Info',
-    elemID: fullInst1.elemID,
-  }]
-}
-
 export const adapter: Adapter = {
   operations: context => new DummyAdapter(context.config?.value as GeneratorParams),
   validateCredentials: async () => ({ accountId: '' }),
@@ -76,5 +56,4 @@ export const adapter: Adapter = {
   } }),
   configType,
   getCustomReferences,
-  fixElements,
 }

--- a/packages/dummy-adapter/src/adapter_creator.ts
+++ b/packages/dummy-adapter/src/adapter_creator.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Adapter, ElemID, CORE_ANNOTATIONS, BuiltinTypes, ObjectType, ListType, GetCustomReferencesFunc } from '@salto-io/adapter-api'
+import { Adapter, ElemID, CORE_ANNOTATIONS, BuiltinTypes, ObjectType, ListType, GetCustomReferencesFunc, FixElementsFunc, isInstanceElement } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import DummyAdapter from './adapter'
 import { GeneratorParams, DUMMY_ADAPTER, defaultParams, changeErrorType } from './generator'
@@ -48,6 +48,25 @@ const getCustomReferences: GetCustomReferencesFunc = async elements => (
     : []
 )
 
+const fixElements: FixElementsFunc = async elements => {
+  const fullInst1 = elements.find(e => e.elemID.getFullName() === 'dummy.Full.instance.FullInst1')
+  if (!isInstanceElement(fullInst1)) {
+    return []
+  }
+
+  if (fullInst1.value.strField === undefined) {
+    return []
+  }
+
+  delete fullInst1.value.strField
+
+  return [{
+    message: 'Fixed FullInst1.strField',
+    detailedMessage: 'Removed FullInst1.strField',
+    severity: 'Info',
+    fixedElement: fullInst1,
+  }]
+}
 
 export const adapter: Adapter = {
   operations: context => new DummyAdapter(context.config?.value as GeneratorParams),
@@ -57,4 +76,5 @@ export const adapter: Adapter = {
   } }),
   configType,
   getCustomReferences,
+  fixElements,
 }

--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -35,7 +35,7 @@ import * as pathIndex from './src/workspace/path_index'
 import { Author } from './src/workspace/changed_by_index'
 import { createElementSelector, ElementSelector, validateSelectorsMatches, createTopLevelSelector,
   selectElementsBySelectorsWithoutReferences, selectElementsBySelectors,
-  selectElementIdsByTraversal, createElementSelectors, ElementIDToValue } from './src/workspace/element_selector'
+  selectElementIdsByTraversal, createElementSelectors, ElementIDToValue, isTopLevelSelector } from './src/workspace/element_selector'
 import * as validator from './src/validator'
 import * as elementSource from './src/workspace/elements_source'
 import * as remoteMap from './src/workspace/remote_map'
@@ -83,6 +83,7 @@ export {
   selectElementsBySelectors,
   createElementSelectors,
   createTopLevelSelector,
+  isTopLevelSelector,
   selectElementIdsByTraversal,
   ElementIDToValue,
   RemoteElementSource,

--- a/packages/workspace/src/workspace/element_selector.ts
+++ b/packages/workspace/src/workspace/element_selector.ts
@@ -207,7 +207,7 @@ export const createElementSelectors = (selectors: string[], caseInSensitive = fa
   }
 }
 
-const isTopLevelSelector = (selector: ElementSelector): boolean =>
+export const isTopLevelSelector = (selector: ElementSelector): boolean =>
   ElemID.fromFullName(selector.origin).isTopLevel()
 
 export const createTopLevelSelector = (selector: ElementSelector): ElementSelector => {


### PR DESCRIPTION
Added fixElements adapter API

---

- Added fixElements API to adapter and core
- Added CLI command to run it
- Added fixElements function to dummy

---
_Release Notes_: 
__CLI__:
- Added `salto element fix` command

---
_User Notifications_: 
None