### PR TITLE
SALTO-4714: add onDeploy filter for ticket form

### DIFF
--- a/packages/zendesk-adapter/src/filters/ticket_form.ts
+++ b/packages/zendesk-adapter/src/filters/ticket_form.ts
@@ -194,7 +194,9 @@ const filterCreator: FilterCreator = ({ config, client, elementsSource }) => ({
     }
     return { deployResult, leftoverChanges }
   },
-  // this onDeploy filter should be temporary and deleted once SALTO-4726 is implemented
+  // this onDeploy filter should be temporary and deleted once SALTO-4726 is implemented. This is because when
+  // custom_status ticket_field does not exist in the env and is referenced by a form, it is removed from the form and
+  // the deploy fails due to summarizeDeployChanges. This onDeploy filter restores ticket_field_ids to its initial state
   onDeploy: async (changes: Change<InstanceElement>[]) => {
     const ticketFormChanges = changes
       .filter(isAdditionOrModificationChange)
@@ -224,7 +226,6 @@ const filterCreator: FilterCreator = ({ config, client, elementsSource }) => ({
       .map(async id => {
         const form = await elementsSource.get(id)
         if (!isInstanceElement(form)) {
-          log.error(`could not find in the elementsSource a form with name ${id.name} `)
           return [id.getFullName(), undefined]
         }
         const ticketFieldIds = form.value.ticket_field_ids // the references are unresolved

--- a/packages/zendesk-adapter/src/filters/ticket_form.ts
+++ b/packages/zendesk-adapter/src/filters/ticket_form.ts
@@ -194,6 +194,7 @@ const filterCreator: FilterCreator = ({ config, client, elementsSource }) => ({
     }
     return { deployResult, leftoverChanges }
   },
+  // this onDeploy filter should be temporary and deleted once SALTO-4726 is implemented
   onDeploy: async (changes: Change<InstanceElement>[]) => {
     const ticketFormChanges = changes
       .filter(isAdditionOrModificationChange)

--- a/packages/zendesk-adapter/test/filters/ticket_form.test.ts
+++ b/packages/zendesk-adapter/test/filters/ticket_form.test.ts
@@ -478,7 +478,7 @@ describe('ticket form filter', () => {
       const clonedForm = formToDeploy.clone()
       await filter.onDeploy([toChange({ after: clonedForm })])
       expect(clonedForm.value.ticket_field_ids).toEqual(formToDeploy.value.ticket_field_ids)
-      expect(mockLogError).toHaveBeenCalledWith(`could not find in the elementsSource a form with name ${clonedForm.elemID.name} `)
+      expect(mockLogError).toHaveBeenCalledWith(`could not find ticketFieldIds for form ${clonedForm.elemID.name}`)
     })
     it('should do nothing if ticket_field_ids is undefined', async () => {
       const clonedElementSourceForm = elementSourceForm.clone()


### PR DESCRIPTION
add onDeploy filter for ticket form.
when there is a ticket status field in the env and it does not have an id, the onDeploy for `ticket_forms` will add the `ticket_field_ids` to the form from the `elmentSource` 

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* prevent the failure of deployment of `ticket_form` when ticket status `ticket_field` is added to the env

---
_User Notifications_: 
None
