### PR TITLE
SALTO-4712: Add order filter in Okta

### DIFF
--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -48,9 +48,9 @@ import schemaFieldsRemovalFilter from './filters/schema_field_removal'
 import appLogoFilter from './filters/app_logo'
 import brandThemeFilesFilter from './filters/brand_theme_files'
 import groupMembersFilter from './filters/group_members'
+import unorderedListsFilter from './filters/unordered_lists'
 import { APP_LOGO_TYPE_NAME, BRAND_LOGO_TYPE_NAME, FAV_ICON_TYPE_NAME, OKTA } from './constants'
 import { getLookUpName } from './reference_mapping'
-
 
 const { awu } = collections.asynciterable
 
@@ -80,6 +80,8 @@ export const DEFAULT_FILTERS = [
   appLogoFilter,
   brandThemeFilesFilter,
   fieldReferencesFilter,
+  // should run after fieldReferencesFilter
+  unorderedListsFilter,
   // should run before appDeploymentFilter and after userSchemaFilter
   serviceUrlFilter,
   appDeploymentFilter,

--- a/packages/okta-adapter/src/filters/unordered_lists.ts
+++ b/packages/okta-adapter/src/filters/unordered_lists.ts
@@ -1,0 +1,51 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { Element, InstanceElement, isInstanceElement, isReferenceExpression, ReferenceExpression } from '@salto-io/adapter-api'
+import { setPath, resolvePath } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+import { FilterCreator } from '../filter'
+import { GROUP_RULE_TYPE_NAME } from '../constants'
+
+const log = logger(module)
+
+const orderTargetGroupsInRule = (instance: InstanceElement): void => {
+  const idValidTargetGroups = (groups: unknown): groups is ReferenceExpression[] =>
+    _.isArray(groups) && groups.every(group => isReferenceExpression(group))
+  const targetGroupsPath = instance.elemID.createNestedID('actions', 'assignUserToGroups', 'groupIds')
+  const targetGroups = resolvePath(instance, targetGroupsPath)
+  if (!idValidTargetGroups(targetGroups)) {
+    log.warn('Invalid target groups path in GroupRule, skipped sorting list')
+    return
+  }
+  setPath(instance, targetGroupsPath, _.sortBy(targetGroups, group => group.elemID.getFullName()))
+}
+
+/**
+ * Sort lists whose order changes between fetches, to avoid unneeded noise.
+ */
+const filterCreator: FilterCreator = () => ({
+  name: 'unorderedListsFilter',
+  onFetch: async (elements: Element[]): Promise<void> => {
+    const instances = elements.filter(isInstanceElement)
+
+    instances
+      .filter(instance => instance.elemID.typeName === GROUP_RULE_TYPE_NAME)
+      .forEach(instance => orderTargetGroupsInRule(instance))
+  },
+})
+
+export default filterCreator

--- a/packages/okta-adapter/test/filters/unordered_lists.test.ts
+++ b/packages/okta-adapter/test/filters/unordered_lists.test.ts
@@ -1,0 +1,61 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { ObjectType, ElemID, InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import { GROUP_RULE_TYPE_NAME, GROUP_TYPE_NAME, OKTA } from '../../src/constants'
+import unorderedListsFilter from '../../src/filters/unordered_lists'
+import { getFilterParams } from '../utils'
+
+describe('unorderedListsFilter', () => {
+  let filter: filterUtils.FilterWith<'onFetch'>
+  const groupType = new ObjectType({ elemID: new ElemID(OKTA, GROUP_TYPE_NAME) })
+  const groupRuleType = new ObjectType({ elemID: new ElemID(OKTA, GROUP_RULE_TYPE_NAME) })
+
+  beforeEach(() => {
+    filter = unorderedListsFilter(getFilterParams()) as typeof filter
+  })
+
+  it('should order group rule target group list', async () => {
+    const groupA = new InstanceElement('A', groupType, { id: 'A1', profile: { name: 'A' } })
+    const groupB = new InstanceElement('B', groupType, { id: 'B2', profile: { name: 'B' } })
+    const groupC = new InstanceElement('C', groupType, { id: 'C3', profile: { name: 'C' } })
+    const groupRule = new InstanceElement(
+      'rulez',
+      groupRuleType,
+      {
+        name: 'rule',
+        status: 'ACTIVE',
+        conditions: {},
+        actions: {
+          assignUserToGroups: {
+            groupIds: [
+              new ReferenceExpression(groupB.elemID, groupB),
+              new ReferenceExpression(groupC.elemID, groupC),
+              new ReferenceExpression(groupA.elemID, groupA),
+            ],
+          },
+        },
+      },
+    )
+    await filter.onFetch([groupType, groupRuleType, groupA, groupB, groupC, groupRule])
+    expect(groupRule.value.actions.assignUserToGroups.groupIds).toEqual([
+      new ReferenceExpression(groupA.elemID, groupA),
+      new ReferenceExpression(groupB.elemID, groupB),
+      new ReferenceExpression(groupC.elemID, groupC),
+    ])
+  })
+})


### PR DESCRIPTION
We noticed differences in `GroupRule` target groups between envs. The order has no meaning so we should sort the list to avoid this 

---

_Additional context for reviewer_

---
_Release Notes_: 

_Okta_Adapter_:
- Fix a bug casing unwanted differences in GroupRule lists

---
_User Notifications_: 
_Okta_Adapter_:
- In GroupRule instances, target group list order might change
