### PR TITLE
SALTO-4386 Changed isFreeLicense in Jira

### DIFF
--- a/packages/jira-adapter/src/change_validators/issue_type_hierarchy.ts
+++ b/packages/jira-adapter/src/change_validators/issue_type_hierarchy.ts
@@ -16,7 +16,7 @@
 import { ChangeError, ChangeValidator, getChangeData, InstanceElement, isInstanceChange, SeverityLevel, Change, ModificationChange, AdditionChange, isAdditionOrModificationChange, isAdditionChange, isModificationChange } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { ISSUE_TYPE_NAME } from '../constants'
-import { isFreeLicense } from '../utils'
+import { isJiraSoftwareFreeLicense } from '../utils'
 
 const { awu } = collections.asynciterable
 
@@ -72,7 +72,7 @@ export const issueTypeHierarchyValidator: ChangeValidator = async (changes, elem
     return []
   }
   const relevantChanges = getIssueTypeWithHierachyChanges(changes)
-  const isLicenseFree = await isFreeLicense(elementSource)
+  const isLicenseFree = await isJiraSoftwareFreeLicense(elementSource)
   return awu(relevantChanges)
     .map(change => {
       const instance = getChangeData(change)

--- a/packages/jira-adapter/src/change_validators/permission_scheme.ts
+++ b/packages/jira-adapter/src/change_validators/permission_scheme.ts
@@ -17,7 +17,7 @@ import { AdditionChange, ChangeError, ChangeValidator, ElemID, getChangeData, In
   isAdditionChange, isAdditionOrModificationChange, isInstanceChange, isModificationChange, ModificationChange, SeverityLevel } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { isResolvedReferenceExpression } from '@salto-io/adapter-utils'
-import { isFreeLicense } from '../utils'
+import { isAllFreeLicense } from '../utils'
 import JiraClient from '../client/client'
 import { PERMISSION_SCHEME_TYPE_NAME, PROJECT_TYPE } from '../constants'
 
@@ -71,7 +71,7 @@ const isPermissionSchemeAssociationChange = (
 export const permissionSchemeDeploymentValidator = (client: JiraClient): ChangeValidator =>
   async (changes, elementsSource) => {
     if (client.isDataCenter || elementsSource === undefined
-      || (!await isFreeLicense(elementsSource))
+      || (!await isAllFreeLicense(elementsSource))
       || !changes) {
       return []
     }

--- a/packages/jira-adapter/src/filters/issue_type_hierarchy_filter.ts
+++ b/packages/jira-adapter/src/filters/issue_type_hierarchy_filter.ts
@@ -18,7 +18,7 @@ import { getChangeData, isAdditionChange, isInstanceChange } from '@salto-io/ada
 import { collections } from '@salto-io/lowerdash'
 import { ISSUE_TYPE_NAME } from '../constants'
 import { FilterCreator } from '../filter'
-import { isFreeLicense } from '../utils'
+import { isJiraSoftwareFreeLicense } from '../utils'
 
 const { awu } = collections.asynciterable
 
@@ -27,7 +27,7 @@ const filter: FilterCreator = ({ elementsSource }) => {
   return {
     name: 'issueTypeHierarchyFilter',
     preDeploy: async changes => {
-      const isLicenseFree = await isFreeLicense(elementsSource)
+      const isLicenseFree = await isJiraSoftwareFreeLicense(elementsSource)
       if (isLicenseFree) {
         return
       }

--- a/packages/jira-adapter/src/filters/permission_scheme/deploy_permission_scheme_filter.ts
+++ b/packages/jira-adapter/src/filters/permission_scheme/deploy_permission_scheme_filter.ts
@@ -15,7 +15,7 @@
 */
 import { isInstanceChange, getChangeData, isAdditionChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { isFreeLicense } from '../../utils'
+import { isAllFreeLicense } from '../../utils'
 import { PERMISSION_SCHEME_TYPE_NAME } from '../../constants'
 import { FilterCreator } from '../../filter'
 
@@ -29,7 +29,7 @@ const filter: FilterCreator = ({ client, elementsSource }) => ({
   name: 'deployPermissionSchemeFilter',
   deploy: async changes => {
     if (client.isDataCenter
-      || !await isFreeLicense(elementsSource)) {
+      || !await isAllFreeLicense(elementsSource)) {
       return {
         leftoverChanges: changes,
         deployResult: {

--- a/packages/jira-adapter/src/filters/project.ts
+++ b/packages/jira-adapter/src/filters/project.ts
@@ -22,7 +22,7 @@ import JiraClient from '../client/client'
 import { defaultDeployChange, deployChanges } from '../deployment/standard_deployment'
 import { getLookUpName } from '../reference_mapping'
 import { FilterCreator } from '../filter'
-import { findObject, isFreeLicense, setFieldDeploymentAnnotations } from '../utils'
+import { findObject, isAllFreeLicense, setFieldDeploymentAnnotations } from '../utils'
 import { PROJECT_CONTEXTS_FIELD } from './fields/contexts_projects_filter'
 
 const PROJECT_TYPE_NAME = 'Project'
@@ -255,7 +255,7 @@ const filter: FilterCreator = ({ config, client, elementsSource }) => ({
       if (shouldSeparateSchemeDeployment(change, client.isDataCenter)) {
         fieldsToIgnore.push(WORKFLOW_SCHEME_FIELD, ISSUE_TYPE_SCREEN_SCHEME_FIELD, ISSUE_TYPE_SCHEME)
       }
-      if (await isFreeLicense(elementsSource)) {
+      if (await isAllFreeLicense(elementsSource)) {
         fieldsToIgnore.push(PERMISSION_SCHEME_FIELD)
       }
       return fieldsToIgnore

--- a/packages/jira-adapter/src/utils.ts
+++ b/packages/jira-adapter/src/utils.ts
@@ -114,7 +114,7 @@ export const isJiraSoftwareFreeLicense = async (
   const accountInfo = await elementsSource.get(ACCOUNT_INFO_ELEM_ID)
   if (!isInstanceElement(accountInfo)
   || accountInfo.value.license?.applications === undefined) {
-    log.error('account info instance or its license not found in elements source, treating the account as paid one')
+    log.error('account info instance or its license not found in elements source, treating the account as free one')
     return true
   }
   const mainApplication = accountInfo.value.license.applications.find((app: Value) => app.id === 'jira-software')

--- a/packages/jira-adapter/src/utils.ts
+++ b/packages/jira-adapter/src/utils.ts
@@ -92,6 +92,7 @@ export const isAllFreeLicense = async (
   elementsSource: ReadOnlyElementsSource
 ): Promise<boolean> => {
   if (!await elementsSource.has(ACCOUNT_INFO_ELEM_ID)) {
+    log.error('account info instance not found in elements source, treating the account as paid one')
     return false
   }
   const accountInfo = await elementsSource.get(ACCOUNT_INFO_ELEM_ID)
@@ -108,13 +109,13 @@ export const isJiraSoftwareFreeLicense = async (
   elementsSource: ReadOnlyElementsSource
 ): Promise<boolean> => {
   if (!await elementsSource.has(ACCOUNT_INFO_ELEM_ID)) {
-    return false
+    return true
   }
   const accountInfo = await elementsSource.get(ACCOUNT_INFO_ELEM_ID)
   if (!isInstanceElement(accountInfo)
   || accountInfo.value.license?.applications === undefined) {
     log.error('account info instance or its license not found in elements source, treating the account as paid one')
-    return false
+    return true
   }
   const mainApplication = accountInfo.value.license.applications.find((app: Value) => app.id === 'jira-software')
   if (mainApplication?.plan === undefined) {

--- a/packages/jira-adapter/test/change_validators/issue_type_hierarchy.test.ts
+++ b/packages/jira-adapter/test/change_validators/issue_type_hierarchy.test.ts
@@ -14,9 +14,9 @@
 * limitations under the License.
 */
 
-import { InstanceElement, ReadOnlyElementsSource, toChange, SeverityLevel, ElemID, ObjectType } from '@salto-io/adapter-api'
+import { InstanceElement, ReadOnlyElementsSource, toChange, SeverityLevel } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { ISSUE_TYPE_NAME, JIRA } from '../../src/constants'
+import { ISSUE_TYPE_NAME } from '../../src/constants'
 import { createEmptyType, getAccountInfoInstance } from '../utils'
 import { issueTypeHierarchyValidator } from '../../src/change_validators/issue_type_hierarchy'
 
@@ -93,9 +93,7 @@ describe('issue type hierarchy validator', () => {
     it('should return error if there is no jira-software in the account info instance because it considered free acount', async () => {
       const accountInfoWithNoJiraSoftware = new InstanceElement(
         '_config',
-        new ObjectType({
-          elemID: new ElemID(JIRA, 'AccountInfo'),
-        }),
+        createEmptyType('AccountInfo'),
         {
           license: {
             applications: [

--- a/packages/jira-adapter/test/filters/issue_type_hierarchy_filter.test.ts
+++ b/packages/jira-adapter/test/filters/issue_type_hierarchy_filter.test.ts
@@ -76,6 +76,13 @@ describe('issue Type Hierarchy Filter', () => {
       await filter.preDeploy(changes)
       expect(getChangeData(changes[0]).value.hierarchyLevel).toEqual(2)
     })
+    it('should not convert hierarchy level to 0 if it is free account without account info', async () => {
+      elementsSource = buildElementsSourceFromElements([])
+      filter = issueTypeHierarchyFilter(getFilterParams({ elementsSource })) as FilterType
+      const changes = [toChange({ after: issueTypeInstanceLevelTwo })]
+      await filter.preDeploy(changes)
+      expect(getChangeData(changes[0]).value.hierarchyLevel).toEqual(2)
+    })
   })
   describe('onDeploy', () => {
     it('should restore hierarchy level to original value', async () => {

--- a/packages/jira-adapter/test/filters/permission_scheme/deploy_permission_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/permission_scheme/deploy_permission_scheme.test.ts
@@ -52,7 +52,7 @@ describe('deploy permission scheme', () => {
     const elementsSource = getLicenseElementSource(true)
     filter = deployPermissionScheme(getFilterParams({ elementsSource })) as typeof filter
   })
-  it('should mock deploy of addition schemes on free license', async () => {
+  it('should deploy of addition schemes on free license', async () => {
     const { deployResult, leftoverChanges } = await filter.deploy(changes)
     expect(deployResult).toEqual({
       appliedChanges: [changes[0], changes[2]],
@@ -60,7 +60,7 @@ describe('deploy permission scheme', () => {
     })
     expect(leftoverChanges).toEqual([changes[1]])
   })
-  it('should not mock deploy removal and modification schemes on free license', async () => {
+  it('should not deploy removal and modification schemes on free license', async () => {
     const { deployResult, leftoverChanges } = await filter.deploy(otherChanges)
     expect(deployResult).toEqual({
       appliedChanges: [],
@@ -68,7 +68,7 @@ describe('deploy permission scheme', () => {
     })
     expect(leftoverChanges).toEqual(otherChanges)
   })
-  it('should not mock deploy on paid license', async () => {
+  it('should not deploy on paid license', async () => {
     const elementsSource = getLicenseElementSource(false)
     filter = deployPermissionScheme(getFilterParams({ elementsSource })) as typeof filter
     const { deployResult, leftoverChanges } = await filter.deploy(changes)
@@ -78,7 +78,7 @@ describe('deploy permission scheme', () => {
     })
     expect(leftoverChanges).toEqual(changes)
   })
-  it('should not mock deploy on paid license due to account info with some paid app', async () => {
+  it('should not deploy on paid license due to account info with some paid app', async () => {
     const accountInfoWithSomePaidApp = new InstanceElement(
       '_config',
       createEmptyType('AccountInfo'),
@@ -106,7 +106,7 @@ describe('deploy permission scheme', () => {
     })
     expect(leftoverChanges).toEqual(changes)
   })
-  it('should not mock deploy on paid license due to missing account info', async () => {
+  it('should not deploy on paid license due to missing account info', async () => {
     const elementsSource = buildElementsSourceFromElements([])
     filter = deployPermissionScheme(getFilterParams({ elementsSource })) as typeof filter
     const { deployResult, leftoverChanges } = await filter.deploy(changes)
@@ -116,7 +116,7 @@ describe('deploy permission scheme', () => {
     })
     expect(leftoverChanges).toEqual(changes)
   })
-  it('should not mock deploy on dc', async () => {
+  it('should not deploy on dc', async () => {
     filter = deployPermissionScheme(getFilterParams(undefined, true)) as typeof filter
     const { deployResult, leftoverChanges } = await filter.deploy(changes)
     expect(deployResult).toEqual({

--- a/packages/jira-adapter/test/utils.test.ts
+++ b/packages/jira-adapter/test/utils.test.ts
@@ -15,7 +15,7 @@
 */
 
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { ElemID, InstanceElement, ObjectType, ReadOnlyElementsSource, ReferenceExpression } from '@salto-io/adapter-api'
+import { ElemID, InstanceElement, ObjectType, ReadOnlyElementsSource } from '@salto-io/adapter-api'
 import { isAllFreeLicense, isJiraSoftwareFreeLicense } from '../src/utils'
 import { createEmptyType, getAccountInfoInstance } from './utils'
 import { JIRA } from '../src/constants'

--- a/packages/jira-adapter/test/utils.test.ts
+++ b/packages/jira-adapter/test/utils.test.ts
@@ -1,0 +1,119 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { ElemID, InstanceElement, ObjectType, ReadOnlyElementsSource } from '@salto-io/adapter-api'
+import { isJiraSoftwareFreeLicense } from '../src/utils'
+import { getAccountInfoInstance } from './utils'
+import { JIRA } from '../src/constants'
+
+describe('utils', () => {
+  let accountInfo: InstanceElement
+  let elementsSource: ReadOnlyElementsSource
+  let isFree: boolean
+  describe('isJiraSoftwareFreeLicense', () => {
+    it('should return true if license is free', async () => {
+      const accountInfoInstanceFree = getAccountInfoInstance(true)
+      elementsSource = buildElementsSourceFromElements([accountInfoInstanceFree])
+      isFree = await isJiraSoftwareFreeLicense(elementsSource)
+      expect(isFree).toBeTruthy()
+    })
+    it('should return false if license is not free', async () => {
+      const accountInfoInstanceFree = getAccountInfoInstance(false)
+      elementsSource = buildElementsSourceFromElements([accountInfoInstanceFree])
+      isFree = await isJiraSoftwareFreeLicense(elementsSource)
+      expect(isFree).toBeFalsy()
+    })
+    it('should return true if there is no account info instance', async () => {
+      elementsSource = buildElementsSourceFromElements([])
+      isFree = await isJiraSoftwareFreeLicense(elementsSource)
+      expect(isFree).toBeTruthy()
+    })
+    it('should return true if there is no jira software license', async () => {
+      accountInfo = new InstanceElement(
+        '_config',
+        new ObjectType({
+          elemID: new ElemID(JIRA, 'AccountInfo'),
+        }),
+        {
+          license: {
+            applications: [
+              {
+                id: 'jira-serviceDesk',
+                plan: 'PAID',
+              },
+            ],
+          },
+        }
+      )
+      elementsSource = buildElementsSourceFromElements([accountInfo])
+      isFree = await isJiraSoftwareFreeLicense(elementsSource)
+      expect(isFree).toBeTruthy()
+    })
+  })
+  describe('isAllFreeLicense', () => {
+    it('should return true if all licenses are free', async () => {
+      accountInfo = new InstanceElement(
+        '_config',
+        new ObjectType({
+          elemID: new ElemID(JIRA, 'AccountInfo'),
+        }),
+        {
+          license: {
+            applications: [
+              {
+                id: 'jira-serviceDesk',
+                plan: 'FREE',
+              },
+              {
+                id: 'jira-software',
+                plan: 'FREE',
+              },
+            ],
+          },
+        }
+      )
+      elementsSource = buildElementsSourceFromElements([accountInfo])
+      isFree = await isJiraSoftwareFreeLicense(elementsSource)
+      expect(isFree).toBeTruthy()
+    })
+    it('should return false if one license is not free', async () => {
+      accountInfo = new InstanceElement(
+        '_config',
+        new ObjectType({
+          elemID: new ElemID(JIRA, 'AccountInfo'),
+        }),
+        {
+          license: {
+            applications: [
+              {
+                id: 'jira-serviceDesk',
+                plan: 'FREE',
+              },
+              {
+                id: 'jira-software',
+                plan: 'BUSINESS',
+              },
+            ],
+          },
+        }
+      )
+      elementsSource = buildElementsSourceFromElements([accountInfo])
+      isFree = await isJiraSoftwareFreeLicense(elementsSource)
+      expect(isFree).toBeFalsy()
+    })
+  })
+})


### PR DESCRIPTION
In this PR, I've split isFreeLicense into two functions:
1. `isAllFreeLicense`, which checks if there are any non-free apps for the account.
2. `isJiraSoftwareFreeLicense`, which checks if the account has a non-free Jira Software app.

---

None

---
_Release Notes_: 
None

---
_User Notifications_: 
None
