### PR TITLE
SALTO 2602: update bundle generation script and type

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -281,7 +281,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
     const bundlesCustomInfo = (await this.client.getInstalledBundles())
       .map(bundle => ({ typeName: BUNDLE, values: { ...bundle, id: bundle.id.toString() } }))
     // TODO: remove this log when SALTO-2602 is open for all customers
-    log.debug('The following bundle ids are missing in the bundle record: %o', bundlesCustomInfo.map(bundle => bundle.values.id))
+    log.debug('The following bundle ids are missing in the bundle record: %o', bundlesCustomInfo.map(bundle => [bundle.values.id, bundle.values.installedFrom?.toUpperCase(), bundle.values.publisher]))
     const {
       elements: fileCabinetContent,
       failedPaths: failedFilePaths,

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -41,7 +41,7 @@ import { toConfigDeployResult, toSetConfigTypes } from '../suiteapp_config_eleme
 import { FeaturesDeployError, MissingManifestFeaturesError, getChangesElemIdsToRemove, toFeaturesDeployPartialSuccessResult } from './errors'
 import { Graph, GraphNode } from './graph_utils'
 import { AdditionalDependencies, isRequiredFeature, removeRequiredFeatureSuffix } from '../config'
-import { BundleType } from '../types/bundle_type'
+import { SuiteAppBundleType } from '../types/bundle_type'
 import { getDeployResultFromSuiteAppResult, toDependencyError, toElementError, toError } from './utils'
 
 const { awu } = collections.asynciterable
@@ -134,7 +134,7 @@ export default class NetsuiteClient {
   }
 
   @NetsuiteClient.logDecorator
-  async getInstalledBundles(): Promise<BundleType[]> {
+  async getInstalledBundles(): Promise<SuiteAppBundleType[]> {
     return this.suiteAppClient?.getInstalledBundles() ?? []
   }
 

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
@@ -42,7 +42,7 @@ import SoapClient from './soap_client/soap_client'
 import { CustomRecordResponse, RecordResponse } from './soap_client/types'
 import { ReadFileEncodingError, ReadFileError, ReadFileInsufficientPermissionError, RetryableError, retryOnRetryableError } from './errors'
 import { InvalidSuiteAppCredentialsError } from '../types'
-import { BundleType } from '../../types/bundle_type'
+import { SuiteAppBundleType } from '../../types/bundle_type'
 
 const { isDefined } = values
 const { DEFAULT_RETRY_OPTS, createRetryOptions } = clientUtils
@@ -375,8 +375,8 @@ export default class SuiteAppClient {
     }
   }
 
-  public async getInstalledBundles(): Promise<BundleType[]> {
-    return this.getInstalledBundlesOrSuiteApps<BundleType>('listBundles', GET_BUNDLES_RESULT_SCHEMA)
+  public async getInstalledBundles(): Promise<SuiteAppBundleType[]> {
+    return this.getInstalledBundlesOrSuiteApps<SuiteAppBundleType>('listBundles', GET_BUNDLES_RESULT_SCHEMA)
   }
 
   public async getInstalledSuiteApps(): Promise<SuiteAppType[]> {

--- a/packages/netsuite-adapter/src/client/suiteapp_client/types.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/types.ts
@@ -407,7 +407,7 @@ export const GET_BUNDLES_RESULT_SCHEMA = {
         required: ['id', 'name'],
       },
     },
-    required: ['id', 'name', 'version', 'isManaged', 'description', 'dateInstalled', 'dateLastUpdated', 'installedFrom', 'publisher', 'installedBy'],
+    required: ['id', 'name', 'installedFrom', 'publisher'],
   },
 }
 

--- a/packages/netsuite-adapter/src/client/suiteapp_client/types.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/types.ts
@@ -385,8 +385,29 @@ export const GET_BUNDLES_RESULT_SCHEMA = {
       id: { type: 'number' },
       name: { type: 'string' },
       version: { type: ['string', 'null'] },
+      isManaged: { type: ['boolean', 'null'] },
+      description: { type: ['string', 'null'] },
+      dateInstalled: { type: ['string', 'null'] },
+      dateLastUpdated: { type: ['string', 'null'] },
+      installedFrom: { type: ['string', 'null'] },
+      publisher: {
+        type: ['object', 'null'],
+        properties: {
+          id: { type: 'string' },
+          name: { type: 'string' },
+        },
+        required: ['id', 'name'],
+      },
+      installedBy: {
+        type: ['object', 'null'],
+        properties: {
+          id: { type: 'number' },
+          name: { type: 'string' },
+        },
+        required: ['id', 'name'],
+      },
     },
-    required: ['id', 'name', 'version'],
+    required: ['id', 'name', 'version', 'isManaged', 'description', 'dateInstalled', 'dateLastUpdated', 'installedFrom', 'publisher', 'installedBy'],
   },
 }
 

--- a/packages/netsuite-adapter/src/types/bundle_type.ts
+++ b/packages/netsuite-adapter/src/types/bundle_type.ts
@@ -29,9 +29,8 @@ type BundlePublisher = {
   name?: string
 }
 
-export type BundleType = {
+export type SuiteAppBundleType = {
   id: string
-  isPrivate?: boolean
   name?: string
   version?: string
   description?: string
@@ -42,6 +41,8 @@ export type BundleType = {
   publisher?: BundlePublisher
   installedBy?: BundleInstalledBy
 }
+
+type BundleType = SuiteAppBundleType & { isPrivate?: boolean }
 
 export const bundleType = (): TypeAndInnerTypes => {
   const innerTypes: Record<string, ObjectType> = {}

--- a/packages/netsuite-adapter/test/client/suiteapp_client/suiteapp_client.test.ts
+++ b/packages/netsuite-adapter/test/client/suiteapp_client/suiteapp_client.test.ts
@@ -601,8 +601,8 @@ describe('SuiteAppClient', () => {
       })
       it('should return an array of bundles', async () => {
         const results = [
-          { id: 47492, name: 'Tax Audit Files', version: '1.86.2', isManaged: true, description: 'Description', publisher: { id: '3838953', name: 'NetSuite Platform Solutions Group - Tax Audit Files' } },
-          { id: 53195, name: 'Last SalesActivity', version: '1.11.2', isManaged: false, description: 'Description', publisher: { id: '3912261', name: 'NetSuite Platform Solutions Group - Tax Audit Files' } },
+          { id: 47492, name: 'Tax Audit Files', version: '1.86.2', isManaged: true, description: 'Description', publisher: { id: '3838953', name: 'NetSuite Platform Solutions Group - Tax Audit Files' }, installedFrom: 'Production' },
+          { id: 53195, name: 'Last SalesActivity', version: '1.11.2', isManaged: false, description: 'Description', publisher: { id: '3912261', name: 'NetSuite Platform Solutions Group - Tax Audit Files' }, installedFrom: 'Sandbox' },
         ]
         mockAxiosAdapter.onPost().replyOnce(200, {
           status: 'success',


### PR DESCRIPTION
_Bundle generation script updated, bundleType changed_

---

_The ticket - https://salto-io.atlassian.net/browse/SALTO-2602
**background** - Because relying on the NetSuite bundle search doesn't necessarily give the correct result, The script is changed to directly access bundles using its url. The log for installed bundles is updated to return the bundle_id, fetched_from and publisher_id which are required to access bundle's url directly. Also, this saves us some overhead when running the script.
The bundle type and schema are updated for better cover and now differentiate between the type returned from our suiteapp and the full type we late create._

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
