### PR TITLE
SALTO-4633: fix removal of a field and conditions from a form at the same time

### DIFF
--- a/packages/zendesk-adapter/src/filters/ticket_form.ts
+++ b/packages/zendesk-adapter/src/filters/ticket_form.ts
@@ -137,8 +137,6 @@ const getChangeWithoutRemovedFields = (change: ModificationChange<InstanceElemen
   const afterFields = new Set(after.value.ticket_field_ids ?? [])
   const removedFields = beforeFields.filter(field => !afterFields.has(field))
   const clonedInst = after.clone()
-  // it is true because if we get to returnValidInstance function its after we got true from isInvalidTicketForm so
-  // custom_statuses is enabled
   clonedInst.value.ticket_field_ids = (clonedInst.value.ticket_field_ids ?? []).concat(removedFields)
   return clonedInst
 }

--- a/packages/zendesk-adapter/src/filters/ticket_form.ts
+++ b/packages/zendesk-adapter/src/filters/ticket_form.ts
@@ -14,9 +14,16 @@
 * limitations under the License.
 */
 import {
-  Change, DeployResult, ElemID,
+  Change,
+  DeployResult,
+  ElemID,
   getChangeData,
-  InstanceElement, isAdditionOrModificationChange, isInstanceChange, isInstanceElement, ReadOnlyElementsSource,
+  InstanceElement,
+  isAdditionOrModificationChange,
+  isInstanceChange,
+  isInstanceElement,
+  isModificationChange, ModificationChange,
+  ReadOnlyElementsSource, toChange,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
@@ -121,6 +128,21 @@ const returnValidInstance = (inst: InstanceElement): InstanceElement => {
   return clonedInst
 }
 
+// this function returns an instance that contains the removed field. This is because zendesk does not allow removing
+// field and condition at the same time
+const getChangeWithoutRemovedFields = (change: ModificationChange<InstanceElement>): InstanceElement => {
+  const { before } = change.data
+  const { after } = change.data
+  const beforeFields: number[] = before.value.ticket_field_ids ?? []
+  const afterFields = new Set(after.value.ticket_field_ids ?? [])
+  const removedFields = beforeFields.filter(field => !afterFields.has(field))
+  const clonedInst = after.clone()
+  // it is true because if we get to returnValidInstance function its after we got true from isInvalidTicketForm so
+  // custom_statuses is enabled
+  clonedInst.value.ticket_field_ids = (clonedInst.value.ticket_field_ids ?? []).concat(removedFields)
+  return clonedInst
+}
+
 /**
  * this filter deploys ticket_form changes. if the instance has both statuses and custom_statuses under
  * required_on_statuses then it removes the statuses field.
@@ -143,9 +165,18 @@ const filterCreator: FilterCreator = ({ config, client, elementsSource }) => ({
       .map(change => applyFunctionToChangeData(change, returnValidInstance))
       .toArray()
 
+    const allChanges = fixedTicketFormChanges.concat(otherTicketFormChanges)
+
     const tempDeployResult = await deployChanges(
-      [...fixedTicketFormChanges, ...otherTicketFormChanges],
+      allChanges,
       async change => {
+        if (isModificationChange(change)) {
+          const intermediateChange = toChange(
+            { before: change.data.before, after: getChangeWithoutRemovedFields(change) }
+          )
+          // first deploy is without the removed fields
+          await deployChange(intermediateChange, client, config.apiDefinitions)
+        }
         await deployChange(change, client, config.apiDefinitions)
       }
     )

--- a/packages/zendesk-adapter/test/filters/ticket_form.test.ts
+++ b/packages/zendesk-adapter/test/filters/ticket_form.test.ts
@@ -304,7 +304,7 @@ describe('ticket form filter', () => {
           ticket_forms: clonedElement,
         }))
       const res = await filter.deploy([toChange({ before: clonedElement, after: clonedElement })])
-      expect(mockDeployChange).toHaveBeenCalledTimes(2)
+      expect(mockDeployChange).toHaveBeenCalledTimes(1)
       expect(mockDeployChange).toHaveBeenCalledWith({
         change: { action: 'modify', data: { before: fixedTicketForm, after: fixedTicketForm } },
         client: expect.anything(),
@@ -351,7 +351,7 @@ describe('ticket form filter', () => {
           ticket_forms: clonedElement,
         }))
       const res = await filter.deploy([toChange({ before: clonedElement, after: clonedElement })])
-      expect(mockDeployChange).toHaveBeenCalledTimes(2)
+      expect(mockDeployChange).toHaveBeenCalledTimes(1)
       expect(mockDeployChange).toHaveBeenCalledWith({
         change: { action: 'modify', data: { before: clonedElement, after: clonedElement } },
         client: expect.anything(),

--- a/packages/zendesk-adapter/test/filters/ticket_form.test.ts
+++ b/packages/zendesk-adapter/test/filters/ticket_form.test.ts
@@ -107,6 +107,80 @@ describe('ticket form filter', () => {
     },
   )
 
+  describe('deploy of removal of field and its condition', () => {
+    beforeEach(async () => {
+      jest.clearAllMocks()
+      filter = filterCreator(createFilterCreatorParams({ elementsSource: createElementSource(true) })) as FilterType
+    })
+    it('should deploy modification change with removal of conditions and field', async () => {
+      const beforeTicketForm = new InstanceElement(
+        'test',
+        ticketFormType,
+        {
+          ticket_field_ids: [
+            1,
+            11,
+            123,
+            1234,
+          ],
+          agent_conditions: [
+            {
+              parent_field_id: 123,
+              child_fields: [
+                {
+                  id: 1234,
+                },
+              ],
+            },
+          ],
+          end_user_conditions: [
+            {
+              parent_field_id: 123,
+              child_fields: [
+                {
+                  id: 1234,
+                },
+              ],
+            },
+          ],
+        },
+      )
+      const afterTicketForm = beforeTicketForm.clone()
+      afterTicketForm.value.ticket_field_ids = [1, 11]
+      afterTicketForm.value.agent_conditions = []
+      afterTicketForm.value.end_user_conditions = []
+
+      const intermediateTicketForm = beforeTicketForm.clone()
+      intermediateTicketForm.value.ticket_field_ids = [1, 11, 123, 1234]
+      intermediateTicketForm.value.agent_conditions = []
+      intermediateTicketForm.value.end_user_conditions = []
+
+      mockDeployChange
+        .mockImplementation(async () => ({
+          ticket_forms: afterTicketForm,
+        }))
+      const res = await filter.deploy([toChange({ before: beforeTicketForm, after: afterTicketForm })])
+      expect(mockDeployChange).toHaveBeenCalledTimes(2)
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'modify', data: { before: beforeTicketForm, after: intermediateTicketForm } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        undefined,
+      })
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'modify', data: { before: beforeTicketForm, after: afterTicketForm } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        undefined,
+      })
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.deployResult.appliedChanges).toHaveLength(1)
+      expect(res.deployResult.appliedChanges)
+        .toEqual([toChange({ before: beforeTicketForm, after: afterTicketForm })])
+    })
+  })
+
   describe('deploy with custom_statuses enabled', () => {
     beforeEach(async () => {
       jest.clearAllMocks()
@@ -230,7 +304,7 @@ describe('ticket form filter', () => {
           ticket_forms: clonedElement,
         }))
       const res = await filter.deploy([toChange({ before: clonedElement, after: clonedElement })])
-      expect(mockDeployChange).toHaveBeenCalledTimes(1)
+      expect(mockDeployChange).toHaveBeenCalledTimes(2)
       expect(mockDeployChange).toHaveBeenCalledWith({
         change: { action: 'modify', data: { before: fixedTicketForm, after: fixedTicketForm } },
         client: expect.anything(),
@@ -277,7 +351,7 @@ describe('ticket form filter', () => {
           ticket_forms: clonedElement,
         }))
       const res = await filter.deploy([toChange({ before: clonedElement, after: clonedElement })])
-      expect(mockDeployChange).toHaveBeenCalledTimes(1)
+      expect(mockDeployChange).toHaveBeenCalledTimes(2)
       expect(mockDeployChange).toHaveBeenCalledWith({
         change: { action: 'modify', data: { before: clonedElement, after: clonedElement } },
         client: expect.anything(),


### PR DESCRIPTION
fix removal of a field and conditions from a form at the same time

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* Fix deployment error where removal of a field and relevant conditions from a form at the same time would return an error
---
_User Notifications_: 
None
