### PR TITLE
SALTO-4722: Allow silent DC plugin upgrades

### DIFF
--- a/packages/jira-adapter/src/filters/data_center/plugin_version.ts
+++ b/packages/jira-adapter/src/filters/data_center/plugin_version.ts
@@ -48,16 +48,6 @@ const filter: FilterCreator = ({ client }) => ({
       if (!isInfoResonse(response.data)) {
         throw new Error('Invalid pluginInfo response')
       }
-      if (semver.gt(response.data.version, PLUGIN_VERSION_NUMBER)) {
-        return {
-          errors: [
-            {
-              message: 'The Salto for Jira DC addon version number is higher than expected. You may be running an outdated Salto CLI; please update it to the latest version from https://github.com/salto-io/salto/releases',
-              severity: 'Info',
-            },
-          ],
-        }
-      }
       if (semver.lt(response.data.version, PLUGIN_VERSION_NUMBER)) {
         return {
           errors: [

--- a/packages/jira-adapter/test/filters/data_center/plugin_version.test.ts
+++ b/packages/jira-adapter/test/filters/data_center/plugin_version.test.ts
@@ -61,7 +61,7 @@ describe('plugin_version', () => {
       }],
     })
   })
-  it('should raise an info if plugin version is newer', async () => {
+  it('should not raise an error if plugin version is newer', async () => {
     const newerVersion = changeVersion(PLUGIN_VERSION_NUMBER, 1)
     mockConnection.get.mockResolvedValueOnce({
       status: 200,
@@ -70,12 +70,7 @@ describe('plugin_version', () => {
       },
     })
     const errors = await filter.onFetch([])
-    expect(errors).toEqual({
-      errors: [{
-        message: 'The Salto for Jira DC addon version number is higher than expected. You may be running an outdated Salto CLI; please update it to the latest version from https://github.com/salto-io/salto/releases',
-        severity: 'Info',
-      }],
-    })
+    expect(errors).toEqual(undefined)
   })
   it('should raise a warning if server answer is not in the correct format', async () => {
     mockConnection.get.mockResolvedValueOnce({


### PR DESCRIPTION
Do not raise fetch errors if dc plugin version is newer to allow updates

---

We need to update the supported versions of Jira DC. For that we need to issue a new plugin version.
Currently, we have a problem- we issue warnings on plugin versions which are higher or lower than expected. It means we need to issue both a new SAAS version and a plugin version at the same time, and we cannot do it.

The solution is to remove the info warning if the plugin version is higher than expected, as the warning is for CLI users and I think the amount of possible users for CLI against DC is small, and the loss is minimal.

---
_Release Notes_: 
None

---
_User Notifications_: 
None
