### PR TITLE
SALTO-4544 add internal ID to custom fields

### DIFF
--- a/packages/salesforce-adapter/src/filters/author_information/custom_objects.ts
+++ b/packages/salesforce-adapter/src/filters/author_information/custom_objects.ts
@@ -18,7 +18,7 @@ import { FileProperties } from 'jsforce-types'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { collections } from '@salto-io/lowerdash'
-import { CUSTOM_FIELD, CUSTOM_OBJECT } from '../../constants'
+import { CUSTOM_FIELD, CUSTOM_OBJECT, INTERNAL_ID_ANNOTATION } from '../../constants'
 import { apiName, getAuthorAnnotations, isCustomObject } from '../../transformers/transformer'
 import { RemoteFilterCreator } from '../../filter'
 import SalesforceClient from '../../client/client'
@@ -51,17 +51,6 @@ const addAuthorAnnotationsToField = (
   Object.assign(field.annotations, getAuthorAnnotations(fileProperties))
 }
 
-const addAuthorAnnotationsToFields = (
-  fileProperties: FilePropertiesMap,
-  object: ObjectType
-): void => {
-  Object.values(fileProperties)
-    .forEach(fileProp => addAuthorAnnotationsToField(
-      fileProp,
-      getObjectFieldByFileProperties(fileProp, object)
-    ))
-}
-
 const getCustomObjectFileProperties = async (client: SalesforceClient):
   Promise<FilePropertiesMap> => {
   const { result, errors } = await client.listMetadataObjects({ type: CUSTOM_OBJECT })
@@ -82,7 +71,7 @@ const getCustomFieldFileProperties = async (client: SalesforceClient):
       (fileProps:FileProperties) => getFieldNameParts(fileProps).fieldName)).value()
 }
 
-const objectAuthorInformationSupplier = async (
+const objectAnnotationSupplier = async (
   customTypeFilePropertiesMap: FilePropertiesMap,
   customFieldsFilePropertiesMap: Record<string, FilePropertiesMap>,
   object: ObjectType
@@ -92,9 +81,20 @@ const objectAuthorInformationSupplier = async (
     Object.assign(object.annotations,
       getAuthorAnnotations(customTypeFilePropertiesMap[objectApiName]))
   }
-  if (objectApiName in customFieldsFilePropertiesMap) {
-    addAuthorAnnotationsToFields(customFieldsFilePropertiesMap[objectApiName], object)
-  }
+  Object.values(customFieldsFilePropertiesMap[objectApiName])
+    .forEach(fileProp => {
+      const field = getObjectFieldByFileProperties(fileProp, object)
+      if (field === undefined) {
+        return
+      }
+      addAuthorAnnotationsToField(
+        fileProp,
+        field
+      )
+      if (fileProp.id !== undefined && fileProp.id !== '') {
+        field.annotations[INTERNAL_ID_ANNOTATION] = fileProp.id
+      }
+    })
 }
 
 export const WARNING_MESSAGE = 'Encountered an error while trying to populate author information in some of the Salesforce configuration elements.'
@@ -115,7 +115,7 @@ const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
       await (awu(elements)
         .filter(isCustomObject) as AwuIterable<ObjectType>)
         .forEach(async object => {
-          await objectAuthorInformationSupplier(customTypeFilePropertiesMap,
+          await objectAnnotationSupplier(customTypeFilePropertiesMap,
             customFieldsFilePropertiesMap,
             object)
         })

--- a/packages/salesforce-adapter/test/filters/author_information/custom_objects.test.ts
+++ b/packages/salesforce-adapter/test/filters/author_information/custom_objects.test.ts
@@ -25,7 +25,7 @@ import { Filter, FilterResult } from '../../../src/filter'
 import customObjects, { WARNING_MESSAGE } from '../../../src/filters/author_information/custom_objects'
 import { defaultFilterContext } from '../../utils'
 import { buildFetchProfile } from '../../../src/fetch_profile/fetch_profile'
-import { API_NAME, CUSTOM_OBJECT } from '../../../src/constants'
+import { API_NAME, CUSTOM_OBJECT, INTERNAL_ID_ANNOTATION } from '../../../src/constants'
 
 describe('custom objects author information test', () => {
   let filter: Filter
@@ -37,19 +37,22 @@ describe('custom objects author information test', () => {
     createdByName: 'created_name',
     createdDate: 'created_date',
     lastModifiedByName: 'changed_name',
-    lastModifiedDate: 'changed_date' })
+    lastModifiedDate: 'changed_date',
+    id: 'id' })
   const fieldProperties = mockFileProperties({ fullName: 'Custom__c.StringField__c',
     type: 'test',
     createdByName: 'created_name_field',
     createdDate: 'created_date_field',
     lastModifiedByName: 'changed_name_field',
-    lastModifiedDate: 'changed_date_field' })
+    lastModifiedDate: 'changed_date_field',
+    id: 'id_field' })
   const nonExistentFieldProperties = mockFileProperties({ fullName: 'Custom__c.noSuchField',
     type: 'test',
     createdByName: 'test',
     createdDate: 'test',
     lastModifiedByName: 'test',
-    lastModifiedDate: 'test' })
+    lastModifiedDate: 'test',
+    id: 'test' })
   // In order to test a field that was described in the server and not found in our elements.
   const primID = new ElemID('test', 'prim')
   const primNum = new PrimitiveType({
@@ -63,6 +66,7 @@ describe('custom objects author information test', () => {
     expect(object.annotations[CORE_ANNOTATIONS.CREATED_AT]).toEqual(properties.createdDate)
     expect(object.annotations[CORE_ANNOTATIONS.CHANGED_BY]).toEqual(properties.lastModifiedByName)
     expect(object.annotations[CORE_ANNOTATIONS.CHANGED_AT]).toEqual(properties.lastModifiedDate)
+    expect(object.annotations[INTERNAL_ID_ANNOTATION]).toEqual(properties.id)
   }
   const objectWithoutInformation = new ObjectType({
     elemID: new ElemID('salesforce', 'otherName'),
@@ -76,9 +80,12 @@ describe('custom objects author information test', () => {
     filter = customObjects({ client, config: defaultFilterContext })
     customObject = new ObjectType({
       elemID: new ElemID('salesforce', 'Custom__c'),
-      annotations: { metadataType: CUSTOM_OBJECT, [API_NAME]: 'Custom__c' },
+      annotations: { metadataType: CUSTOM_OBJECT, [API_NAME]: 'Custom__c', [INTERNAL_ID_ANNOTATION]: 'id' },
       fields: {
-        StringField__c: { refType: primNum },
+        StringField__c: {
+          refType: primNum,
+          annotations: { [INTERNAL_ID_ANNOTATION]: 'id_field' },
+        },
       },
     })
   })


### PR DESCRIPTION
Custom fields of instances coming from managed installed packages did not save internal IDs. This fix should solve this issue.

---

---

_Release Notes_: 
Salesforce Adapter:
- Add internal ID to custom fields inside managed package if exists

---

_User Notifications_: 
Salesforce Adapter:
- Internal ID might be added to some custom fields