### PR TITLE
SAAS-7539 raise total number of ws errors that returns from getDiagnostics

### DIFF
--- a/packages/lang-server/src/diagnostics.ts
+++ b/packages/lang-server/src/diagnostics.ts
@@ -31,7 +31,7 @@ export type WorkspaceSaltoDiagnostics = {
   totalNumberOfErrors: number
 }
 
-const MAX_WORKSPACE_ERRORS = 30
+const MAX_WORKSPACE_ERRORS = 50
 
 export const getDiagnostics = async (
   workspace: EditorWorkspace,


### PR DESCRIPTION
SAAS-7539 raise total number of ws errors that returns from getDiagnostics
---

_Additional context for reviewer_

---
_Release Notes_: 
raise total number of ws errors that returns from getDiagnostics

---
_User Notifications_: 
none