### PR TITLE
SALTO-4731 - Remove content size limitation on client post requests

### DIFF
--- a/packages/adapter-components/src/client/http_connection.ts
+++ b/packages/adapter-components/src/client/http_connection.ts
@@ -184,7 +184,6 @@ export const axiosConnection = <TCredentials>({
     const httpClient = axios.create({
       baseURL: await baseURLFunc(creds),
       ...await authParamsFunc(creds),
-      maxContentLength: Infinity,
       maxBodyLength: Infinity,
     })
     axiosRetry(httpClient, retryOptions)

--- a/packages/adapter-components/src/client/http_connection.ts
+++ b/packages/adapter-components/src/client/http_connection.ts
@@ -184,6 +184,8 @@ export const axiosConnection = <TCredentials>({
     const httpClient = axios.create({
       baseURL: await baseURLFunc(creds),
       ...await authParamsFunc(creds),
+      maxContentLength: Infinity,
+      maxBodyLength: Infinity,
     })
     axiosRetry(httpClient, retryOptions)
 


### PR DESCRIPTION
default limitation is 10MB, there is no reason to limit us at the client level

---

None

---
_Release Notes_: 
* Deploying now supports objects larger than 10MB

---
_User Notifications_: 
None
