### PR TITLE
SALTO-4718 - Zendesk Adapter - 'field' ticket fields missing reference

### DIFF
--- a/packages/zendesk-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-adapter/src/filters/field_references.ts
@@ -529,6 +529,7 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
       ],
     },
     zendeskSerializationStrategy: 'ticketField',
+    zendeskMissingRefStrategy: 'startsWith',
     target: { type: TICKET_FIELD_TYPE_NAME },
   },
   {


### PR DESCRIPTION
Add missing references for 'field' fields that supposed to have ticket_field inside of them

---

Has noise reduction

---
_Release Notes_: 
Zendesk Adapter:
* 'field' fields that are supposed to have ticket_field can now have missing references

---
_User Notifications_: 
None
