### PR TITLE
SALTO-4732: "Used by" profile dependencies for new objects do not include field permissions, just object permissions

### DIFF
--- a/packages/salesforce-adapter/src/additional_references.ts
+++ b/packages/salesforce-adapter/src/additional_references.ts
@@ -251,6 +251,11 @@ const createRefIfExistingOrAnyAccess = (valueBefore: Value, valueAfter: Value): 
   || valueAfter.viewAllRecords
 )
 
+const createRefIfFieldsExistingOrAnyAccess = (valueBefore: Value, valueAfter: Value): boolean => (
+  valueBefore !== undefined
+  || (_.isPlainObject(valueAfter) && Object.values(valueAfter).some(val => val !== 'NoAccess'))
+)
+
 const alwaysCreateRefs = (): boolean => true
 
 
@@ -352,6 +357,15 @@ export const getAdditionalReferences: GetAdditionalReferencesFunc = async change
     instancesIndex.byTypeAndElemId,
   )
 
+  const objectFieldRefs = await instanceRefsFromProfileOrPermissionSet(
+    profilesAndPermSetsChanges,
+    FIELD_PERMISSIONS,
+    (_object, key) => ([{ typeName: key, refName: key }]),
+    createRefIfFieldsExistingOrAnyAccess,
+    instancesIndex.byTypeAndApiName,
+    instancesIndex.byTypeAndElemId,
+  )
+
   const fieldPermissionsRefs = awu(relevantFieldChanges)
     .flatMap(async field => fieldRefsFromProfileOrPermissionSet(profilesAndPermSetsChanges, field))
 
@@ -383,6 +397,7 @@ export const getAdditionalReferences: GetAdditionalReferencesFunc = async change
     .concat(flowRefs)
     .concat(layoutRefs)
     .concat(objectRefs)
+    .concat(objectFieldRefs)
     .concat(apexPageRefs)
     .concat(recordTypeRefs)
     .toArray()

--- a/packages/salesforce-adapter/test/additional_references.test.ts
+++ b/packages/salesforce-adapter/test/additional_references.test.ts
@@ -791,6 +791,71 @@ describe('getAdditionalReferences', () => {
         { source: permissionSetInstanceAfter.elemID.createNestedID('objectPermissions', 'Account', 'allowCreate'), target: customObject.elemID.createNestedID('attr', 'someAnn') },
       ])
     })
+
+    it('should create a reference to fields', async () => {
+      customObject = createCustomObjectType('Account', {
+        fields: {
+          someField: {
+            refType: BuiltinTypes.STRING,
+            annotations: {
+              [API_NAME]: 'Account.someField',
+            },
+          },
+        },
+      })
+      const [profileInstanceBefore, permissionSetInstanceBefore] = createTestInstances({
+        fieldPermissions: {
+        },
+      })
+      const [profileInstanceAfter, permissionSetInstanceAfter] = createTestInstances({
+        fieldPermissions: {
+          Account: {
+            someField: 'Read',
+          },
+        },
+      })
+      changes = [
+        toChange({ before: profileInstanceBefore, after: profileInstanceAfter }),
+        toChange({ before: permissionSetInstanceBefore, after: permissionSetInstanceAfter }),
+        toChange({ after: customObject }),
+      ]
+      const refs = await getAdditionalReferences(changes)
+      expect(refs).toIncludeAllPartialMembers([
+        { source: permissionSetInstanceAfter.elemID.createNestedID('fieldPermissions', 'Account'), target: customObject.elemID },
+        { source: profileInstanceAfter.elemID.createNestedID('fieldPermissions', 'Account'), target: customObject.elemID },
+      ])
+    })
+
+    it('should not create a reference to fields if fields have default permissions', async () => {
+      customObject = createCustomObjectType('Account', {
+        fields: {
+          someField: {
+            refType: BuiltinTypes.STRING,
+            annotations: {
+              [API_NAME]: 'Account.someField',
+            },
+          },
+        },
+      })
+      const [profileInstanceBefore, permissionSetInstanceBefore] = createTestInstances({
+        fieldPermissions: {
+        },
+      })
+      const [profileInstanceAfter, permissionSetInstanceAfter] = createTestInstances({
+        fieldPermissions: {
+          Account: {
+            someField: 'NoAccess',
+          },
+        },
+      })
+      changes = [
+        toChange({ before: profileInstanceBefore, after: profileInstanceAfter }),
+        toChange({ before: permissionSetInstanceBefore, after: permissionSetInstanceAfter }),
+        toChange({ after: customObject }),
+      ]
+      const refs = await getAdditionalReferences(changes)
+      expect(refs).toEqual([])
+    })
   })
 
   describe('Apex pages', () => {


### PR DESCRIPTION
Added references between new objects to field permissions

---
_Release Notes_: 
_Salesforce Adapter_:
- Added references between new objects to field permissions

---
_User Notifications_: 
None