### PR TITLE
SALTO-4705 fix static files deserialization

### DIFF
--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -530,7 +530,7 @@ const generalDeserializeParsed = async <T>(
   if (!Array.isArray(parsed)) {
     throw new Error('got non-array JSON data')
   }
-  const elements = parsed.map(restoreClasses)
+  const elements = restoreClasses(parsed)
   if (staticFiles.length > 0) {
     await Promise.all(staticFiles.map(
       async ({ obj, key }) => {

--- a/packages/workspace/test/serializer/serializer.test.ts
+++ b/packages/workspace/test/serializer/serializer.test.ts
@@ -341,6 +341,15 @@ describe('State/cache serialization', () => {
       ])
       expect(mockStoreStaticFile).toHaveBeenCalledWith(staticFile)
     })
+    it('should deserialize static files - with a reviver', async () => {
+      const staticFile = new StaticFile({ filepath: 'abc', content: Buffer.from('hello world!') })
+      const mockStaticFileReviver = jest.fn().mockResolvedValue(staticFile)
+      const deserialized = await deserializeValues(await serialize([staticFile]), mockStaticFileReviver)
+      expect(deserialized[0]).toBe(staticFile)
+      expect(mockStaticFileReviver).toHaveBeenCalledWith(
+        new StaticFile({ filepath: staticFile.filepath, hash: staticFile.hash }),
+      )
+    })
   })
 
   describe('validate deserialization', () => {


### PR DESCRIPTION
Use the static-files-reviver when deserializing a single static file value (not in an element).

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None