### PR TITLE
SALTO-4733 treat selectors as elemIds when there are no wildcards

### DIFF
--- a/packages/workspace/src/workspace/element_selector.ts
+++ b/packages/workspace/src/workspace/element_selector.ts
@@ -99,9 +99,15 @@ function isElementContainer(value: any): value is ElementIDContainer {
   return value && value.elemID && value.elemID instanceof ElemID
 }
 
+const isWildcardSelector = (selector: string): boolean => selector.includes('*')
+
+const hasReferencedBy = (selector: ElementSelector): boolean =>
+  selector.referencedBy !== undefined
+
 export const validateSelectorsMatches = (selectors: ElementSelector[],
   matches: Record<string, boolean>): void => {
-  const invalidDeterminedMatchers = selectors.filter(selector => !selector.origin.includes('*') && !matches[selector.origin])
+  const invalidDeterminedMatchers = selectors.filter(selector =>
+    !isWildcardSelector(selector.origin) && !matches[selector.origin])
   if (invalidDeterminedMatchers.length > 0) {
     throw new Error(`The following salto ids were not found: ${invalidDeterminedMatchers.map(selector => selector.origin)}`)
   }
@@ -198,7 +204,7 @@ const isValidSelector = (selector: string): boolean => {
 export const createElementSelectors = (selectors: string[], caseInSensitive = false):
   {validSelectors: ElementSelector[]; invalidSelectors: string[]} => {
   const [validSelectors, invalidSelectors] = _.partition(selectors, isValidSelector)
-  const [wildcardSelectors, determinedSelectors] = _.partition(validSelectors, selector => selector.includes('*'))
+  const [wildcardSelectors, determinedSelectors] = _.partition(validSelectors, isWildcardSelector)
   const orderedSelectors = determinedSelectors.concat(wildcardSelectors)
   return {
     validSelectors: orderedSelectors
@@ -254,7 +260,7 @@ const isBaseIdSelector = (selector: ElementSelector): boolean =>
 const validateSelector = (
   selector: ElementSelector,
 ): void => {
-  if (selector.referencedBy !== undefined) {
+  if (hasReferencedBy(selector)) {
     if (!isBaseIdSelector(selector)) {
       throw new Error(`Unsupported selector: referencedBy is only supported for selector of base ids (types, fields or instances), received: ${selector.origin}`)
     }
@@ -276,8 +282,10 @@ export const selectElementIdsByTraversal = async ({
 }): Promise<AsyncIterable<ElemID>> =>
   (log.time(
     async () => {
-      if (selectors.length === 0) {
-        return awu([])
+      const determinedSelectors = selectors.filter(selector =>
+        !isWildcardSelector(selector.origin) && !hasReferencedBy(selector))
+      if (determinedSelectors.length === selectors.length) {
+        return awu(determinedSelectors).map(selector => ElemID.fromFullName(selector.origin))
       }
       selectors.forEach(selector => validateSelector(selector))
 
@@ -313,10 +321,10 @@ export const selectElementIdsByTraversal = async ({
         ? possibleParentIDs.filter(id => !currentIds.has(id.getFullName()))
         : possibleParentIDs
 
-      const [subSelectorsWithReferencedBy, subSelectorsWithoutReferencedBy] = _.partition(
-        subElementSelectors,
-        selector => selector.referencedBy !== undefined
-      )
+      const [
+        subSelectorsWithReferencedBy,
+        subSelectorsWithoutReferencedBy,
+      ] = _.partition(subElementSelectors, hasReferencedBy)
 
       const subElementIDs = new Set<string>()
       const selectFromSubElements: WalkOnFunc = ({ path }) => {

--- a/packages/workspace/test/element_selector.test.ts
+++ b/packages/workspace/test/element_selector.test.ts
@@ -449,7 +449,21 @@ describe('select elements recursively', () => {
     const elementIds = await testSelect(selectors, true)
     expect(elementIds).toEqual([ElemID.fromFullName('mockAdapter.test.instance.mockInstance.bool')])
   })
-  it('should not return non-existent element id', async () => {
+  it('should not return non-existent element id when some selectors have wildcard', async () => {
+    const selectors = createElementSelectors([
+      'mockAdapter.test.instance.mockInstance.thispropertydoesntexist',
+      'mockAdapter.test.field.strMap',
+      'mockAdapter.*.field.strMap',
+    ]).validSelectors
+    const elementIds = await awu(await selectElementIdsByTraversal({
+      selectors,
+      source: createInMemoryElementSource([mockInstance, mockType]),
+      referenceSourcesIndex: createMockRemoteMap<ElemID[]>(),
+      compact: false,
+    })).toArray()
+    expect(elementIds).toEqual([ElemID.fromFullName('mockAdapter.test.field.strMap')])
+  })
+  it('should return all element ids when there are no wildcards', async () => {
     const selectors = createElementSelectors([
       'mockAdapter.test.instance.mockInstance.thispropertydoesntexist',
       'mockAdapter.test.field.strMap',
@@ -460,7 +474,10 @@ describe('select elements recursively', () => {
       referenceSourcesIndex: createMockRemoteMap<ElemID[]>(),
       compact: false,
     })).toArray()
-    expect(elementIds).toEqual([ElemID.fromFullName('mockAdapter.test.field.strMap')])
+    expect(elementIds).toEqual([
+      ElemID.fromFullName('mockAdapter.test.instance.mockInstance.thispropertydoesntexist'),
+      ElemID.fromFullName('mockAdapter.test.field.strMap'),
+    ])
   })
 })
 


### PR DESCRIPTION
Return quickly in `selectElementIdsByTraversal` when all given selectors are actually elemIds - without wildcards or referencedBy.

---

_Additional context for reviewer_

---
_Release Notes_:
None

---
_User Notifications_: 
None
