### PR TITLE
SALTO-4734: Exclude RoleAssignment by default

### DIFF
--- a/packages/okta-adapter/src/change_validators/group_rule_administrator.ts
+++ b/packages/okta-adapter/src/change_validators/group_rule_administrator.ts
@@ -26,6 +26,7 @@ const log = logger(module)
 
 /**
  * Verifies that the target groups for a GroupRule has no administrator roles.
+ * Notice RoleAssignment are not fetched by default.
  */
 export const groupRuleAdministratorValidator: ChangeValidator = async (changes, elementSource) => {
   if (elementSource === undefined) {
@@ -42,6 +43,9 @@ export const groupRuleAdministratorValidator: ChangeValidator = async (changes, 
   }
 
   const roleAssignments = await getInstancesFromElementSource(elementSource, [ROLE_ASSIGNMENT_TYPE_NAME])
+  if (_.isEmpty(roleAssignments)) {
+    return []
+  }
 
   const groupNamesWithRoles = new Set(roleAssignments.map(role => {
     const parent = getParents(role)?.[0]

--- a/packages/okta-adapter/src/change_validators/role_assignment.ts
+++ b/packages/okta-adapter/src/change_validators/role_assignment.ts
@@ -43,6 +43,7 @@ export const getTargetGroupsForRule = (groupRule: InstanceElement): string[] => 
 /**
  * prevents the assignment of admin roles to groups that are defined as "target groups" in other
  * group rules.
+ * Notice RoleAssignment are not fetched by default.
  */
 export const roleAssignmentValidator: ChangeValidator = async (changes, elementSource) => {
   if (elementSource === undefined) {

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -262,13 +262,6 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
   api__v1__groups: {
     request: {
       url: '/api/v1/groups',
-      recurseInto: [
-        {
-          type: 'api__v1__groups___groupId___roles@uuuuuu_00123_00125uu',
-          toField: 'roles',
-          context: [{ name: 'groupId', fromField: 'id' }],
-        },
-      ],
     },
   },
   Group: {
@@ -311,6 +304,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
       },
     },
   },
+  // group-roles are not fetched by default
   'api__v1__groups___groupId___roles@uuuuuu_00123_00125uu': {
     request: {
       url: '/api/v1/groups/{groupId}/roles',


### PR DESCRIPTION
Changed config so we won't recurse into group role for every group
It slows down fetch a lot and doesn't seem to be important 

---
_Release Notes_: 

_Okta_adapter_
- Improve fetch times
- RoleAssignment instances will be excluded by default, this can be changed by editing the adapter config file.

---
_User Notifications_: 

_Okta_adapter_
- RoleAssignment instances will be removed
