### PR TITLE
SALTO-2525: Add logs to Script Runner Authentication

### DIFF
--- a/packages/jira-adapter/src/client/script_runner_connection.ts
+++ b/packages/jira-adapter/src/client/script_runner_connection.ts
@@ -75,7 +75,7 @@ const getSrTokenFromHtml = (html: string): string => {
   // Find the meta tag with name="sr-token"
   const srTokenElement = root.querySelector('meta[name="sr-token"]')
   if (srTokenElement === null) {
-    log.error('Failed to get script runner token from scriptRunner service, could not find meta tag with name="sr-token"')
+    log.error('Failed to get script runner token from scriptRunner service, could not find meta tag with name="sr-token"', html)
     throw new ScriptRunnerLoginError('Failed to get script runner token from scriptRunner service, could not find meta tag with name="sr-token"')
   }
 
@@ -83,7 +83,7 @@ const getSrTokenFromHtml = (html: string): string => {
   const srToken = srTokenElement.getAttribute('content')
 
   if (srToken === undefined) {
-    log.error('Failed to get script runner token from scriptRunner service, could not find content attribute"')
+    log.error('Failed to get script runner token from scriptRunner service, could not find content attribute"', html)
     throw new ScriptRunnerLoginError('Failed to get script runner token from scriptRunner service, could not find content attribute')
   }
   return srToken

--- a/packages/jira-adapter/test/client/script_runner_client.test.ts
+++ b/packages/jira-adapter/test/client/script_runner_client.test.ts
@@ -94,17 +94,17 @@ describe('scriptRunnerClient', () => {
       it('should fail when not html response', async () => {
         mockAxios.onGet(SCRIPT_RUNNER_VALID_URL).replyOnce(200, 'not another html answer')
         expect(await scriptRunnerClient.getSinglePage({ url: '/myPath' })).toEqual({ status: 401, data: [] })
-        expect(logErrorSpy).toHaveBeenCalledWith('Failed to get script runner token from scriptRunner service, could not find meta tag with name="sr-token"')
+        expect(logErrorSpy).toHaveBeenCalledWith('Failed to get script runner token from scriptRunner service, could not find meta tag with name="sr-token"', 'not another html answer')
       })
       it('should fail when not SR token', async () => {
         mockAxios.onGet(SCRIPT_RUNNER_VALID_URL).replyOnce(200, NO_SR_HTML)
         expect(await scriptRunnerClient.getSinglePage({ url: '/myPath' })).toEqual({ status: 401, data: [] })
-        expect(logErrorSpy).toHaveBeenCalledWith('Failed to get script runner token from scriptRunner service, could not find meta tag with name="sr-token"')
+        expect(logErrorSpy).toHaveBeenCalledWith('Failed to get script runner token from scriptRunner service, could not find meta tag with name="sr-token"', '<!DOCTYPE html><html><head></head></html>')
       })
       it('should fail when sr element does not have context', async () => {
         mockAxios.onGet(SCRIPT_RUNNER_VALID_URL).replyOnce(200, NO_CONTENT_HTML)
         expect(await scriptRunnerClient.getSinglePage({ url: '/myPath' })).toEqual({ status: 401, data: [] })
-        expect(logErrorSpy).toHaveBeenCalledWith('Failed to get script runner token from scriptRunner service, could not find content attribute"')
+        expect(logErrorSpy).toHaveBeenCalledWith('Failed to get script runner token from scriptRunner service, could not find content attribute"', '<!DOCTYPE html><html><head><meta name="sr-token"></head></html>')
       })
       it('should call send request decorator for page', async () => {
         mockAxios.onGet(SCRIPT_RUNNER_VALID_URL).replyOnce(200, VALID_HTML)


### PR DESCRIPTION
We make in the ScriptRunner Authentication a call using axios which is not documented. It is OK as it contains sensitive information, but in case we cannot parse it correctly we need to print the content of the answer

---

None

---
_Release Notes_: 
None

---
_User Notifications_: 
None
