### PR TITLE
limit suiteapp readFiles to 10K files per request

### DIFF
--- a/packages/lowerdash/src/chunks.ts
+++ b/packages/lowerdash/src/chunks.ts
@@ -16,14 +16,19 @@
 export const weightedChunks = <T>(
   values: T[],
   size: number,
-  weightFunc: (val: T) => number
+  weightFunc: (val: T) => number,
+  maxItemsPerChunk = Infinity
 ): T[][] => {
   const chunks: T[][] = []
 
   values.reduce((chunkWeight, val) => {
     const valWeight = weightFunc(val)
 
-    if (valWeight + chunkWeight > size || chunks.length === 0) {
+    if (
+      valWeight + chunkWeight > size
+      || chunks.length === 0
+      || chunks[chunks.length - 1].length >= maxItemsPerChunk
+    ) {
       chunks.push([val])
       return valWeight
     }

--- a/packages/lowerdash/test/chunks.test.ts
+++ b/packages/lowerdash/test/chunks.test.ts
@@ -24,6 +24,10 @@ describe('weightedChunks', () => {
     const chunks = weightedChunks(['eeeeeeeeee', 'dddddd', 'cccc', 'bb', 'a'], 7, val => val.length)
     expect(chunks).toEqual([['eeeeeeeeee'], ['dddddd'], ['cccc', 'bb', 'a']])
   })
+  it('should split chunks correctly with max items per chunk limitation', () => {
+    const chunks = weightedChunks(['eeeeeeeeee', 'dddddd', 'cccc', 'bb', 'a'], 7, val => val.length, 2)
+    expect(chunks).toEqual([['eeeeeeeeee'], ['dddddd'], ['cccc', 'bb'], ['a']])
+  })
 })
 
 describe('chunkByEvenly', () => {

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_file_cabinet.ts
@@ -160,6 +160,7 @@ type FileCabinetResults = {
 }
 
 const FILES_CHUNK_SIZE = 5 * 1024 * 1024
+const MAX_FILES_IN_READ_REQUEST = 10000
 const MAX_DEPLOYABLE_FILE_SIZE = 10 * 1024 * 1024
 const DEPLOY_CHUNK_SIZE = 50
 const MAX_ITEMS_IN_WHERE_QUERY = 200
@@ -467,7 +468,8 @@ SuiteAppFileCabinetOperations => {
     const fileChunks = chunks.weightedChunks(
       filesCustomizationWithoutContent,
       FILES_CHUNK_SIZE,
-      file => file.size
+      file => file.size,
+      MAX_FILES_IN_READ_REQUEST
     )
 
     const filesContent = (await Promise.all(


### PR DESCRIPTION
`readFiles` request with a large amount of files (very small files) might be the reason for the `Script Execution Time Exceeded` error from NS restlet API. Limiting the maximum amount of files per request may be useful here.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
