### PR TITLE
SALTO-4746 fix splitElementByPath (fetch from) for fields that are not in the path index

### DIFF
--- a/packages/core/test/core/restore.test.ts
+++ b/packages/core/test/core/restore.test.ts
@@ -339,6 +339,10 @@ describe('restore', () => {
       await index.set(type.fields.field2.elemID.getFullName(), [
         ['salto', 'type', 'field2'],
       ])
+      await index.set('salto.type.field', [
+        ['salto', 'type', 'field1'],
+        ['salto', 'type', 'field2'],
+      ])
     })
     it('should create deletion and addition references', async () => {
       const changes = await createRestorePathChanges(

--- a/packages/workspace/src/workspace/path_index.ts
+++ b/packages/workspace/src/workspace/path_index.ts
@@ -255,7 +255,7 @@ export const getFromPathIndex = async (
 }
 
 export const filterByPathHint = async (index: PathIndex, hint:Path, id: ElemID): Promise<FILTER_FUNC_NEXT_STEP> => {
-  const idHints = await index.get(id.getFullName()) ?? []
+  const idHints = await getFromPathIndex(id, index)
   const isHintMatch = idHints.some(idHint => _.isEqual(idHint, hint))
   if (!isHintMatch) {
     // This case will be removed, when we fix the .annotation and .field keys in the path index

--- a/packages/workspace/test/workspace/path_index.test.ts
+++ b/packages/workspace/test/workspace/path_index.test.ts
@@ -377,6 +377,51 @@ describe('split element by path', () => {
     },
   })
 
+  const fieldWithoutPathIndexElemId = new ElemID('salto', 'obj3')
+  const fieldWithoutPathIndex = new ObjectType({
+    elemID: fieldWithoutPathIndexElemId,
+    fields: {
+      uriField: {
+        refType: createRefToElmWithValue(BuiltinTypes.STRING),
+        annotations: {
+          test: 'test',
+        },
+      },
+    },
+    path: ['salto', 'obj2', 'field', 'noPath'],
+  })
+
+  const fieldWithPathIndex = new ObjectType({
+    elemID: fieldWithoutPathIndexElemId,
+    fields: {
+      barField: {
+        refType: createRefToElmWithValue(BuiltinTypes.STRING),
+        annotations: {
+          yo: 'yo',
+        },
+      },
+    },
+    path: ['salto', 'obj2', 'field'],
+  })
+
+  const fieldWithoutPathIndexFull = new ObjectType({
+    elemID: fieldWithoutPathIndexElemId,
+    fields: {
+      barField: {
+        refType: createRefToElmWithValue(BuiltinTypes.STRING),
+        annotations: {
+          yo: 'yo',
+        },
+      },
+      uriField: {
+        refType: createRefToElmWithValue(BuiltinTypes.STRING),
+        annotations: {
+          test: 'test',
+        },
+      },
+    },
+  })
+
   const singlePathObj = new ObjectType({
     elemID: new ElemID('salto', 'singlePath'),
     fields: {
@@ -434,8 +479,13 @@ describe('split element by path', () => {
   const singleFieldObjFrags = [
     singleFieldObj, singleFieldObjAnnotations,
   ]
+  const fieldWithoutPathIndexFrags = [
+    fieldWithoutPathIndex, fieldWithoutPathIndexFull,
+  ]
+
   const unmergedElements = [
-    ...fullObjFrags, ...singleFieldObjFrags, singlePathObj, noPathObj, multiPathInstanceA, multiPathInstanceB,
+    ...fullObjFrags, ...singleFieldObjFrags,
+    singlePathObj, noPathObj, multiPathInstanceA, multiPathInstanceB, fieldWithPathIndex,
   ]
   const pi = new InMemoryRemoteMap<Path[]>()
 
@@ -453,6 +503,13 @@ describe('split element by path', () => {
   it('should split an element with one fields file', async () => {
     const splitElements = await splitElementByPath(singleFieldObjFull, pi)
     singleFieldObjFrags.forEach(
+      frag => expect(splitElements.filter(elem => elem.isEqual(frag))).toHaveLength(1)
+    )
+  })
+
+  it('should find file to a field that is not is the path index', async () => {
+    const splitElements = await splitElementByPath(fieldWithoutPathIndexFull, pi)
+    fieldWithoutPathIndexFrags.forEach(
       frag => expect(splitElements.filter(elem => elem.isEqual(frag))).toHaveLength(1)
     )
   })

--- a/packages/workspace/test/workspace/path_index.test.ts
+++ b/packages/workspace/test/workspace/path_index.test.ts
@@ -404,6 +404,17 @@ describe('split element by path', () => {
     path: ['salto', 'obj2', 'field'],
   })
 
+  const fieldWithoutPathIndexAnnotations = new ObjectType({
+    elemID: fieldWithoutPathIndexElemId,
+    annotationRefsOrTypes: {
+      anno: createRefToElmWithValue(BuiltinTypes.STRING),
+    },
+    annotations: {
+      anno: 'Bye',
+    },
+    path: ['salto', 'obj2', 'annotations'],
+  })
+
   const fieldWithoutPathIndexFull = new ObjectType({
     elemID: fieldWithoutPathIndexElemId,
     fields: {
@@ -419,6 +430,12 @@ describe('split element by path', () => {
           test: 'test',
         },
       },
+    },
+    annotationRefsOrTypes: {
+      anno: createRefToElmWithValue(BuiltinTypes.STRING),
+    },
+    annotations: {
+      anno: 'Bye',
     },
   })
 
@@ -480,12 +497,11 @@ describe('split element by path', () => {
     singleFieldObj, singleFieldObjAnnotations,
   ]
   const fieldWithoutPathIndexFrags = [
-    fieldWithoutPathIndex, fieldWithoutPathIndexFull,
+    fieldWithoutPathIndex, fieldWithPathIndex, fieldWithoutPathIndexAnnotations,
   ]
-
   const unmergedElements = [
-    ...fullObjFrags, ...singleFieldObjFrags,
-    singlePathObj, noPathObj, multiPathInstanceA, multiPathInstanceB, fieldWithPathIndex,
+    ...fullObjFrags, ...singleFieldObjFrags, singlePathObj, noPathObj, multiPathInstanceA, multiPathInstanceB,
+    fieldWithPathIndex, fieldWithoutPathIndexAnnotations,
   ]
   const pi = new InMemoryRemoteMap<Path[]>()
 


### PR DESCRIPTION
SALTO-4746 fix splitElementByPath (fetch from) for fields that are not in the path index

---

_Additional context for reviewer_

---
_Release Notes_: 
Core:
- fix issue where "fetch from" would omit fields that were not in the path index (fields that were recently deployed)

---
_User Notifications_: 
None
