### PR TITLE
INCIDENT-8074: Deleting issue types from the default issue type scheme fails

### DIFF
--- a/packages/jira-adapter/src/filters/issue_type_schemas/issue_type_scheme.ts
+++ b/packages/jira-adapter/src/filters/issue_type_schemas/issue_type_scheme.ts
@@ -40,17 +40,21 @@ const deployNewAndDeletedIssueTypeIds = async (
   )
 
   const instance = getChangeData(change)
-  if (addedIds.length > 0) {
-    if (!instance.value.isDefault) {
-      await client.put({
-        url: `/rest/api/3/issuetypescheme/${instance.value.id}/issuetype`,
-        data: {
-          issueTypeIds: Array.from(addedIds),
-        },
-      })
-    } else {
-      log.info('Skipping adding issues to default issue type scheme because they are automatically added')
+
+  if (instance.value.isDefault) {
+    if (removedIds.length > 0 || addedIds.length > 0) {
+      log.info('Skipping adding and removing issues to default issue type scheme because they are automatically synced')
     }
+    return
+  }
+
+  if (addedIds.length > 0) {
+    await client.put({
+      url: `/rest/api/3/issuetypescheme/${instance.value.id}/issuetype`,
+      data: {
+        issueTypeIds: Array.from(addedIds),
+      },
+    })
   }
 
   // We run this sequentially and not in parallel because there is a bug in Jira which lets you

--- a/packages/jira-adapter/test/filters/issue_type_schemas/issue_type_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/issue_type_schemas/issue_type_scheme.test.ts
@@ -244,6 +244,33 @@ describe('issueTypeScheme', () => {
       )
     })
 
+    it('should not call the delete issue type ids endpoint if the scheme is the default scheme', async () => {
+      const beforeInstance = new InstanceElement(
+        'instance',
+        type,
+        {
+          id: '1',
+          name: 'name1',
+          issueTypeIds: ['1', '2', '3'],
+          isDefault: true,
+        }
+      )
+
+      const afterInstance = new InstanceElement(
+        'instance',
+        type,
+        {
+          id: '1',
+          name: 'name2',
+          issueTypeIds: ['1', '2'],
+          isDefault: true,
+        }
+      )
+
+      await filter.deploy?.([toChange({ before: beforeInstance, after: afterInstance })])
+      expect(mockConnection.delete).not.toHaveBeenCalled()
+    })
+
     it('should not call the re-order endpoint of there are no changes in the ids', async () => {
       const beforeInstance = new InstanceElement(
         'instance',


### PR DESCRIPTION
Fixed deleting an issue type and removing it from the issue type scheme

---

_Additional context for reviewer_

---
_Release Notes_: 
__Jira Adapter__:
- Fixed deleting an issue type and removing it from the issue type scheme

---
_User Notifications_: 
None