### PR TITLE
Salto-4756 - Zendesk Adapter - Fix ticket_form schema guard and remove error login if it doesn't pass

### DIFF
--- a/packages/zendesk-adapter/src/change_validators/custom_statuses_enabled.ts
+++ b/packages/zendesk-adapter/src/change_validators/custom_statuses_enabled.ts
@@ -136,7 +136,9 @@ const isTicketFormWithCustomStatus = (change: Change<ChangeDataType>): boolean =
     return false
   }
 
-  return hasConditionWithCustomStatuses([...data.value.agent_conditions ?? [], ...data.value.end_user_conditions ?? []])
+  return hasConditionWithCustomStatuses(
+    (data.value.agent_conditions ?? []).concat(data.value.end_user_conditions ?? [])
+  )
 }
 
 const createErrorsForTicketFormsWithCustomStatuses = (

--- a/packages/zendesk-adapter/src/change_validators/custom_statuses_enabled.ts
+++ b/packages/zendesk-adapter/src/change_validators/custom_statuses_enabled.ts
@@ -63,12 +63,10 @@ type TicketForm = InstanceElement & {
 
 const TICKET_FORM_SCHEMA = Joi.object({
   agent_conditions: Joi.array().items(CONDITION_SCHEMA),
-})
+  end_user_conditions: Joi.array().items(CONDITION_SCHEMA),
+}).unknown().or('agent_conditions', 'end_user_conditions')
 
-const isTicketForm = createSchemeGuardForInstance<TicketForm>(
-  TICKET_FORM_SCHEMA,
-  'Received an invalid value for TicketForm instance'
-)
+const isTicketFormWithConditions = createSchemeGuardForInstance<TicketForm>(TICKET_FORM_SCHEMA)
 
 /**
   * If this function fails to identify whether custom statuses are enabled
@@ -134,11 +132,11 @@ const isTicketFormWithCustomStatus = (change: Change<ChangeDataType>): boolean =
   const data = getChangeData(change)
   if (data.elemID.typeName !== TICKET_FORM_TYPE_NAME
     || !isInstanceElement(data)
-    || !isTicketForm(data)) {
+    || !isTicketFormWithConditions(data)) {
     return false
   }
 
-  return hasConditionWithCustomStatuses(data.value.agent_conditions ?? [])
+  return hasConditionWithCustomStatuses([...data.value.agent_conditions ?? [], ...data.value.end_user_conditions ?? []])
 }
 
 const createErrorsForTicketFormsWithCustomStatuses = (

--- a/packages/zendesk-adapter/src/change_validators/custom_statuses_enabled.ts
+++ b/packages/zendesk-adapter/src/change_validators/custom_statuses_enabled.ts
@@ -41,7 +41,7 @@ const CHILD_FIELD_SCHEMA = Joi.object({
     statuses: Joi.array().items(Joi.string()),
     custom_statuses: Joi.array(),
   }),
-})
+}).unknown()
 
 type Condition = {
   // eslint-disable-next-line camelcase
@@ -50,7 +50,7 @@ type Condition = {
 
 const CONDITION_SCHEMA = Joi.object({
   child_fields: Joi.array().items(CHILD_FIELD_SCHEMA).required(),
-})
+}).unknown()
 
 type TicketFormValue = {
   // eslint-disable-next-line camelcase
@@ -69,9 +69,9 @@ const TICKET_FORM_SCHEMA = Joi.object({
 const isTicketFormWithConditions = createSchemeGuardForInstance<TicketForm>(TICKET_FORM_SCHEMA)
 
 /**
-  * If this function fails to identify whether custom statuses are enabled
-* it will log an error and return true to skip the validator.
-  */
+ * If this function fails to identify whether custom statuses are enabled
+ * it will log an error and return true to skip the validator.
+ */
 const areCustomStatusesEnabled = async (
   elementSource?: ReadOnlyElementsSource
 ): Promise<boolean> => {

--- a/packages/zendesk-adapter/test/change_validators/custom_statuses_enabled.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/custom_statuses_enabled.test.ts
@@ -100,8 +100,10 @@ describe(customStatusesEnabledValidator.name, () => {
         const ticketFormInstance = new InstanceElement('test', ticketFormObjectType, {
           agent_conditions: [
             {
+              parent_field_id: '123',
               child_fields: [
                 {
+                  id: '123',
                   required_on_statuses: {
                     type: 'testType',
                     custom_statuses: ['custom status 1'],


### PR DESCRIPTION
* isTicketForm now allow unknown in order to not fail on every ticket form
* also added 'end_user_conditions' to the possible conditions
* no longer error log in case the schema doesn't pass (as it is not necessarily an error)

---

None

---
_Release Notes_: 
Zendesk Adapter:
* Fix warning on ticket_form deployments if the ticket form has custom ticket status, and the feature it not enabled

---
_User Notifications_: 
None