### PR TITLE
SALTO-4631: Extra Dependencies for current namespace only bugfix

### DIFF
--- a/packages/salesforce-adapter/src/filters/extra_dependencies.ts
+++ b/packages/salesforce-adapter/src/filters/extra_dependencies.ts
@@ -64,8 +64,8 @@ const createQueries = (
   if (!toolingDepsOfCurrentNamespace) {
     return baseQueries
   }
-  const nonNamespaceDepsQueries = baseQueries.map(query => `${query} AND MetadataComponentNamespacePrefix = '${orgNamespace}'`)
-  const namespaceDepsQueries = baseQueries.map(query => `${query} AND MetadataComponentNamespacePrefix != '${orgNamespace}'`)
+  const nonNamespaceDepsQueries = baseQueries.map(query => `${query} AND MetadataComponentNamespace = '${orgNamespace}'`)
+  const namespaceDepsQueries = baseQueries.map(query => `${query} AND MetadataComponentNamespace != '${orgNamespace}'`)
   return nonNamespaceDepsQueries.concat(namespaceDepsQueries)
 }
 

--- a/packages/salesforce-adapter/test/filters/extra_dependencies.test.ts
+++ b/packages/salesforce-adapter/test/filters/extra_dependencies.test.ts
@@ -334,7 +334,7 @@ describe('extra dependencies filter', () => {
       it('should have individual queries for types marked for individual query', () => {
         expect(mockQueryAll).toHaveBeenCalledTimes(6)
         mockQueryAll.mock.calls.forEach(([query]: [string, boolean]) => {
-          expect(query).not.toContain('MetadataComponentNamespacePrefix')
+          expect(query).not.toContain('MetadataComponentNamespace')
         })
       })
 
@@ -366,7 +366,7 @@ describe('extra dependencies filter', () => {
       it('should have individual queries for types marked for individual query', () => {
         expect(mockQueryAll).toHaveBeenCalledTimes(12)
         mockQueryAll.mock.calls.forEach(([query]: [string, boolean]) => {
-          expect(query).toContain('MetadataComponentNamespacePrefix')
+          expect(query).toContain('MetadataComponentNamespace')
         })
       })
     })


### PR DESCRIPTION
The wrong field was queried which caused the queries to fail when running with the optional feature `toolingDepsOfCurrentNamespace`

---

_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
