### PR TITLE
SALTO-4652 - Salesforce: add a fetch warning for custom fields that are not queryable

### DIFF
--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -135,16 +135,17 @@ salesforce {
 
 ## Fetch configuration options
 
-| Name                                           | Default when undefined  | Description                                                                                                                                                                                                           |
-|------------------------------------------------|-------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [metadata](#metadata-configuration-options)    | Fetch all metdata       | Specified the metadata fetch                                                                                                                                                                                          |
+| Name                                      | Default when undefined  | Description                                                                                                                                                                                                           |
+|-------------------------------------------|-------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [metadata](#metadata-configuration-options) | Fetch all metdata       | Specified the metadata fetch                                                                                                                                                                                          |
 | [data](#data-management-configuration-options) | {} (do not manage data) | Data management configuration object names will not be fetched in case they are matched in includeObjects                                                                                                             |
-| fetchAllCustomSettings                         | true                    | Whether to fetch all the custom settings instances. When false, it is still possible to choose specific custom settings instances via the `data` option                                                               |
-| [optionalFeatures](#optional-features)         | {} (all enabled)        | Granular control over which features are enabled in the adapter, by default all features are enabled in order to get the most information. can be used to turn off features that cause problems until they are solved |
-| maxInstancesPerType                            | 5000                    | Do not fetch metadataTypes and CustomObjects with more instances than this number, and add those to the exclude lists                                                                                                 |
-| preferActiveFlowVersions                       | false                   | When set to false, flows' latest version will be fetched. Otherwise, flows' active version will be fetched if exists                                                                                                  |
-| addNamespacePrefixToFullName                   | true                   | When set to true, namespace prefix will be added to instances in a namespace whose fullName does not begin with the namespace. Otherwise, there will be no change to fullName                                               |
-## Metadata configuration options
+| fetchAllCustomSettings                    | true                    | Whether to fetch all the custom settings instances. When false, it is still possible to choose specific custom settings instances via the `data` option                                                               |
+| [optionalFeatures](#optional-features)    | {} (all enabled)        | Granular control over which features are enabled in the adapter, by default all features are enabled in order to get the most information. can be used to turn off features that cause problems until they are solved |
+| maxInstancesPerType                       | 5000                    | Do not fetch metadataTypes and CustomObjects with more instances than this number, and add those to the exclude lists                                                                                                 |
+| preferActiveFlowVersions                  | false                   | When set to false, flows' latest version will be fetched. Otherwise, flows' active version will be fetched if exists                                                                                                  |
+| addNamespacePrefixToFullName              | true                    | When set to true, namespace prefix will be added to instances in a namespace whose fullName does not begin with the namespace. Otherwise, there will be no change to fullName                                         |
+| [warningSettings](#warning-settings)      | {}                      | Enable/disable specific warnings                                                                                                                                                                                      |
+### Metadata configuration options
 
 | Name                           | Default when undefined       | Description                                                                                                                                                     |
 |--------------------------------|------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -152,14 +153,14 @@ salesforce {
 | [exclude](#metadata-query)     | [] (Exclude nothing)         | Specified the metadata to not fetch. Metadata that matches any of the exclude criteria will not be fetched even if it also matches some of the include criteria |
 | objectsToSeperateFieldsToFiles | [] (Don't split any objects) | Specified a list of objects which will be stored as one field per nacl file                                                                                     |
 
-## Metadata Query
+#### Metadata Query
 | Name         | Default when undefined | Description                                                    |
 |--------------|------------------------|----------------------------------------------------------------|
 | namespace    | ".*" (All namespaces)  | A regular expression of a namespace to query with              |
 | metadataType | ".*" (All types)       | A regular expression of a metadata type to query with          |
 | name         | ".*" (All names)       | A regular expression of a metadata instance name to query with |
 
-## Optional Features
+### Optional Features
 
 | Name                              | Default when undefined | Description                                                                                                                                                           |
 |-----------------------------------|------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -175,6 +176,14 @@ salesforce {
 | generateRefsInProfiles            | false                  | Generate references from profiles. This will have a significant performance impact, but will provide references from profiles to fields and elements.                 |
 | skipAliases                       | false                  | Do not create aliases for Metadata Elements                                                                                                                           |
 
+
+### Warning settings
+
+| Name                | Default when undefined | Description                                                       |
+|---------------------|------------------------|-------------------------------------------------------------------|
+| nonQueryableFields  | true                   | Warn when fetching records of an object with non-queryable fields |
+
+
 ### Data management configuration options
 
 | Name                                                                          | Default when undefined                           | Description                                                                                               |
@@ -185,9 +194,13 @@ salesforce {
 | [saltoIDSettings](#salto-id-settings-configuration-options)                   | N/A (required when dataManagement is configured) | Configuration for cross environments data record ids management                                           |
 | [saltoAliasSettings](#salto-alias-settings-configuration-options)             | N/A                                              | Configuration for data record aliases                                                                     |
 | [saltoManagementFieldSettings](#salto-management-field-configuration-options) | {}                                               | Configuration for managed-by-Salto field                                                                  |
+<<<<<<< HEAD
 | [brokenOutgoingReferencesSettings](#broken-outgoing-references-settings)      | {}                                               | Configuration for handling broken references                                                              |
 | omittedFields                                                                 | []                                               | List of API names of fields to discard when fetching data records.                                        |
 | [warningSettings](#data-warning-settings)                                     | {}                                               | Enabling/disabling specific warnings                                                                      | 
+=======
+| [brokenOutgoingReferencesSettings](#broken-outgoing-references-settings)      | {}                                               | Configuration for handling broken references                                                              | 
+>>>>>>> 3efcfb758 (Move config to fetchProfile)
 
 #### Salto ID settings configuration options
 
@@ -223,14 +236,6 @@ salesforce {
 | "ExcludeInstance" | Do not fetch instances that contain a reference whose target was not fetched                      |
 | "BrokenReference" | Fetch the instance and create Salto references to non-existant targets.                           |
 | "InternalId"      | Fetch the instance and keep the existing field value (the internal ID of the referenced instance) |
-
-
-#### Data warning settings
-
-| Name                | Default when undefined | Description                                                       |
-|---------------------|------------------------|-------------------------------------------------------------------|
-| nonQueryableFields  | true                   | Warn when fetching records of an object with non-queryable fields |
-
 
 #### Object ID settings configuration options
 

--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -187,7 +187,7 @@ salesforce {
 | [saltoManagementFieldSettings](#salto-management-field-configuration-options) | {}                                               | Configuration for managed-by-Salto field                                                                  |
 | [brokenOutgoingReferencesSettings](#broken-outgoing-references-settings)      | {}                                               | Configuration for handling broken references                                                              |
 | omittedFields                                                                 | []                                               | List of API names of fields to discard when fetching data records.                                        |
-
+| [warningSettings](#data-warning-settings)                                     | {}                                               | Enabling/disabling specific warnings                                                                      | 
 
 #### Salto ID settings configuration options
 
@@ -223,6 +223,13 @@ salesforce {
 | "ExcludeInstance" | Do not fetch instances that contain a reference whose target was not fetched                      |
 | "BrokenReference" | Fetch the instance and create Salto references to non-existant targets.                           |
 | "InternalId"      | Fetch the instance and keep the existing field value (the internal ID of the referenced instance) |
+
+
+#### Data warning settings
+
+| Name                | Default when undefined | Description                                                       |
+|---------------------|------------------------|-------------------------------------------------------------------|
+| nonQueryableFields  | true                   | Warn when fetching records of an object with non-queryable fields |
 
 
 #### Object ID settings configuration options

--- a/packages/salesforce-adapter/src/fetch_profile/data_management.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/data_management.ts
@@ -151,6 +151,9 @@ export const buildDataManagement = (params: DataManagementConfig): DataManagemen
     omittedFieldsForType: name => (
       name === undefined ? [] : makeArray(omittedFieldsByType[name])
     ),
+    isWarningEnabled: name => (
+      params.warningSettings?.[name] ?? true
+    ),
   }
 }
 

--- a/packages/salesforce-adapter/src/fetch_profile/data_management.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/data_management.ts
@@ -151,9 +151,6 @@ export const buildDataManagement = (params: DataManagementConfig): DataManagemen
     omittedFieldsForType: name => (
       name === undefined ? [] : makeArray(omittedFieldsByType[name])
     ),
-    isWarningEnabled: name => (
-      params.warningSettings?.[name] ?? true
-    ),
   }
 }
 

--- a/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
@@ -16,7 +16,13 @@
 
 import { values } from '@salto-io/lowerdash'
 import { ReadOnlyElementsSource } from '@salto-io/adapter-api'
-import { DATA_CONFIGURATION, FetchParameters, FetchProfile, METADATA_CONFIG, OptionalFeatures } from '../types'
+import {
+  DATA_CONFIGURATION,
+  FetchProfile,
+  FetchParameters,
+  METADATA_CONFIG,
+  OptionalFeatures,
+} from '../types'
 import { buildDataManagement, validateDataManagementConfig } from './data_management'
 import { buildMetadataQuery, validateMetadataParams } from './metadata_query'
 import { DEFAULT_MAX_INSTANCES_PER_TYPE } from '../constants'
@@ -54,6 +60,7 @@ const buildBaseFetchProfile = ({
     maxInstancesPerType,
     preferActiveFlowVersions,
     addNamespacePrefixToFullName,
+    warningSettings,
   } = fetchParams
   return {
     dataManagement: data && buildDataManagement(data),
@@ -62,6 +69,9 @@ const buildBaseFetchProfile = ({
     maxInstancesPerType: maxInstancesPerType ?? DEFAULT_MAX_INSTANCES_PER_TYPE,
     preferActiveFlowVersions: preferActiveFlowVersions ?? false,
     addNamespacePrefixToFullName: addNamespacePrefixToFullName ?? true,
+    isWarningEnabled: name => (
+      warningSettings?.[name] ?? true
+    ),
   }
 }
 

--- a/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
@@ -57,6 +57,7 @@ import {
   isQueryableField,
   isHiddenField,
   isReadOnlyField,
+  isCustomObjectSync,
 } from './utils'
 import { ConfigChangeSuggestion, DataManagement } from '../types'
 
@@ -630,6 +631,7 @@ const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
       elements
         .filter(isInstanceElement)
         .map(instance => instance.getTypeSync())
+        .filter(isCustomObjectSync) // we don't deploy metadata objects, so no reason to warn about them.
     )
 
     let invalidPermissionsWarnings: SaltoError[] = []

--- a/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
@@ -570,7 +570,7 @@ const createInaccessibleFieldsFetchWarning = (
   objectType: ObjectType,
   inaccessibleFields: string[],
 ): SaltoError => ({
-  message: `The following fields are not accessible and will not be fetched for records of type ${apiNameSync(objectType)}: ${inaccessibleFields.join(',')}. Values of these fields will appear as 'deleted' if these data records are ever deployed`,
+  message: `There are ${inaccessibleFields.length} fields in the ${apiNameSync(objectType)} object that the fetch user does not have access to. These are the fields: ${inaccessibleFields.join(',')} If ${apiNameSync(objectType)} records are deployed from this environment, values of these fields will appear as deletions.`,
   severity: 'Info',
 })
 

--- a/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
@@ -634,7 +634,7 @@ const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
 
     let invalidPermissionsWarnings: SaltoError[] = []
 
-    if (config.fetchProfile.dataManagement?.isWarningEnabled('nonQueryableFields') ?? false) {
+    if (config.fetchProfile.isWarningEnabled('nonQueryableFields') ?? false) {
       invalidPermissionsWarnings = customObjectFetchSetting
         .map(fetchSettings => fetchSettings.objectType)
         .filter(isCustomObject)

--- a/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
@@ -570,7 +570,7 @@ const createInaccessibleFieldsFetchWarning = (
   objectType: ObjectType,
   inaccessibleFields: string[],
 ): SaltoError => ({
-  message: `There are ${inaccessibleFields.length} fields in the ${apiNameSync(objectType)} object that the fetch user does not have access to. These are the fields: ${inaccessibleFields.join(',')} If ${apiNameSync(objectType)} records are deployed from this environment, values of these fields will appear as deletions.`,
+  message: `There are ${inaccessibleFields.length} fields in the ${apiNameSync(objectType)} object that the fetch user does not have access to. These are the fields: ${inaccessibleFields.join(',')}. If ${apiNameSync(objectType)} records are deployed from this environment, values of these fields will appear as deletions.`,
   severity: 'Info',
 })
 
@@ -639,7 +639,7 @@ const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
     if (config.fetchProfile.isWarningEnabled('nonQueryableFields') ?? false) {
       invalidPermissionsWarnings = customObjectFetchSetting
         .map(fetchSettings => fetchSettings.objectType)
-        .filter(isCustomObject)
+        .filter(isCustomObjectSync)
         .map(objectType => ({ type: objectType, fields: getInaccessibleCustomFields(objectType) }))
         .filter(({ fields }) => fields.length > 0)
         .filter(({ type }) => typesOfFetchedInstances.has(type))

--- a/packages/salesforce-adapter/src/filters/utils.ts
+++ b/packages/salesforce-adapter/src/filters/utils.ts
@@ -199,7 +199,7 @@ export const isHiddenField = (field: Field): boolean => (
 )
 
 export const isReadOnlyField = (field: Field): boolean => (
-  !field.annotations[FIELD_ANNOTATIONS.CREATABLE] && !field.annotations[FIELD_ANNOTATIONS.UPDATEABLE]
+  field.annotations[FIELD_ANNOTATIONS.CREATABLE] === false && field.annotations[FIELD_ANNOTATIONS.UPDATEABLE] === false
 )
 
 export const isHierarchyField = (field: Field): boolean => (

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -267,6 +267,19 @@ const brokenOutgoingReferencesSettingsType = new ObjectType({
   },
 })
 
+const warningSettingsType = new ObjectType({
+  elemID: new ElemID(constants.SALESFORCE, 'saltoWarningSettings'),
+  fields: {
+    nonQueryableFields: {
+      refType: BuiltinTypes.BOOLEAN,
+    },
+  },
+})
+
+export type WarningSettings = {
+  nonQueryableFields: boolean
+}
+
 export type DataManagementConfig = {
   includeObjects: string[]
   excludeObjects?: string[]
@@ -277,6 +290,7 @@ export type DataManagementConfig = {
   saltoManagementFieldSettings?: SaltoManagementFieldSettings
   brokenOutgoingReferencesSettings?: BrokenOutgoingReferencesSettings
   omittedFields?: string[]
+  warningSettings?: WarningSettings
 }
 
 export type FetchParameters = {
@@ -532,6 +546,9 @@ const dataManagementType = new ObjectType({
     },
     omittedFields: {
       refType: new ListType(BuiltinTypes.STRING),
+    },
+    warningSettings: {
+      refType: warningSettingsType,
     },
   } as Record<keyof DataManagementConfig, FieldDefinition>,
   annotations: {
@@ -867,6 +884,7 @@ export type DataManagement = {
   showReadOnlyValues?: boolean
   managedBySaltoFieldForType: (objType: ObjectType) => string | undefined
   omittedFieldsForType: (name: string) => string[]
+  isWarningEnabled: (name: keyof WarningSettings) => boolean
 }
 
 export type FetchProfile = {

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -290,7 +290,6 @@ export type DataManagementConfig = {
   saltoManagementFieldSettings?: SaltoManagementFieldSettings
   brokenOutgoingReferencesSettings?: BrokenOutgoingReferencesSettings
   omittedFields?: string[]
-  warningSettings?: WarningSettings
 }
 
 export type FetchParameters = {
@@ -302,6 +301,7 @@ export type FetchParameters = {
   maxInstancesPerType?: number
   preferActiveFlowVersions?: boolean
   addNamespacePrefixToFullName?: boolean
+  warningSettings?: WarningSettings
 }
 
 export type DeprecatedMetadataParams = {
@@ -547,9 +547,6 @@ const dataManagementType = new ObjectType({
     omittedFields: {
       refType: new ListType(BuiltinTypes.STRING),
     },
-    warningSettings: {
-      refType: warningSettingsType,
-    },
   } as Record<keyof DataManagementConfig, FieldDefinition>,
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
@@ -779,6 +776,7 @@ const fetchConfigType = createMatchingObjectType<FetchParameters>({
     maxInstancesPerType: { refType: BuiltinTypes.NUMBER },
     preferActiveFlowVersions: { refType: BuiltinTypes.BOOLEAN },
     addNamespacePrefixToFullName: { refType: BuiltinTypes.BOOLEAN },
+    warningSettings: { refType: warningSettingsType },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
@@ -884,7 +882,6 @@ export type DataManagement = {
   showReadOnlyValues?: boolean
   managedBySaltoFieldForType: (objType: ObjectType) => string | undefined
   omittedFieldsForType: (name: string) => string[]
-  isWarningEnabled: (name: keyof WarningSettings) => boolean
 }
 
 export type FetchProfile = {
@@ -895,4 +892,5 @@ export type FetchProfile = {
   readonly maxInstancesPerType: number
   readonly preferActiveFlowVersions: boolean
   readonly addNamespacePrefixToFullName: boolean
+  isWarningEnabled: (name: keyof WarningSettings) => boolean
 }

--- a/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
@@ -617,24 +617,40 @@ describe('Custom Object Instances filter', () => {
           },
         },
       })
+
+      const refToObject = createCustomObject(refToObjectName, {
+        NonQueryable: {
+          refType: stringType,
+          annotations: {
+            [FIELD_ANNOTATIONS.QUERYABLE]: false,
+            [LABEL]: 'Non-queryable field',
+            [API_NAME]: 'NonQueryableField',
+          },
+        },
+      })
       const excludedObject = createCustomObject(excludeObjectName)
       const excludeOverrideObject = createCustomObject(excludeOverrideObjectName)
       let fetchResult: FetchResult
       beforeEach(async () => {
         elements = [
           notConfiguredObj, includedNameSpaceObj,
-          includedObject, excludedObject, excludeOverrideObject,
+          includedObject, excludedObject, excludeOverrideObject, refToObject,
         ]
         fetchResult = await filter.onFetch(elements) as FetchResult
       })
 
       describe('when an object has non-queryable fields', () => {
-        it('should issue a warning', () => {
+        it('should issue a warning if there are instances of the object', () => {
           expect(fetchResult.errors).toEqual([{
             message: expect.stringContaining(includeObjectName) && expect.stringContaining('NonQueryable'),
-            severity: 'Warning',
+            severity: 'Info',
           }])
           expect(fetchResult.errors?.[0].message).not.toInclude('HiddenNonQueryable')
+        })
+        it('should not issue a warning if there are no instances of the object', () => {
+          expect(fetchResult.errors).not.toIncludeAllPartialMembers([{
+            message: expect.stringContaining(refToObjectName),
+          }])
         })
       })
 

--- a/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
@@ -645,14 +645,14 @@ describe('Custom Object Instances filter', () => {
 
       describe('when an object has non-queryable fields', () => {
         describe('when warnings are enabled', () => {
-          it('should issue a warning if there are instances of the object', () => {
+          it('should issue a message if there are instances of the object', () => {
             expect(fetchResult.errors).toEqual([{
               message: expect.stringContaining(includeObjectName) && expect.stringContaining('NonQueryable'),
               severity: 'Info',
             }])
             expect(fetchResult.errors?.[0].message).not.toInclude('HiddenNonQueryable')
           })
-          it('should not issue a warning if there are no instances of the object', () => {
+          it('should not issue a message if there are no instances of the object', () => {
             expect(fetchResult.errors).not.toIncludeAllPartialMembers([{
               message: expect.stringContaining(refToObjectName),
             }])

--- a/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
@@ -246,8 +246,12 @@ describe('Custom Object Instances filter', () => {
   const buildTestFetchProfile = (
     types: TestFetchProfileParams[],
     omittedFields: string[] = [],
+    warnOnNonQueryableInstances = false,
   ): FetchProfile => {
     const fetchProfileParams: FetchParameters = {
+      warningSettings: {
+        nonQueryableFields: warnOnNonQueryableInstances,
+      },
       data: {
         includeObjects: types
           .filter(typeParams => typeParams.included)
@@ -1671,7 +1675,7 @@ describe('Custom Object Instances filter', () => {
 
     it('Should warn if the field is not queryable', () => {
       expect(filterResult.errors ?? []).not.toBeEmpty()
-      expect(filterResult.errors).toIncludeAllPartialMembers([{
+      expect(filterResult.errors).toEqual([{
         message: expect.stringContaining('TestType') && expect.stringContaining(MANAGED_BY_SALTO_FIELD_NAME),
         severity: 'Warning',
       }])

--- a/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
@@ -640,17 +640,19 @@ describe('Custom Object Instances filter', () => {
       })
 
       describe('when an object has non-queryable fields', () => {
-        it('should issue a warning if there are instances of the object', () => {
-          expect(fetchResult.errors).toEqual([{
-            message: expect.stringContaining(includeObjectName) && expect.stringContaining('NonQueryable'),
-            severity: 'Info',
-          }])
-          expect(fetchResult.errors?.[0].message).not.toInclude('HiddenNonQueryable')
-        })
-        it('should not issue a warning if there are no instances of the object', () => {
-          expect(fetchResult.errors).not.toIncludeAllPartialMembers([{
-            message: expect.stringContaining(refToObjectName),
-          }])
+        describe('when warnings are enabled', () => {
+          it('should issue a warning if there are instances of the object', () => {
+            expect(fetchResult.errors).toEqual([{
+              message: expect.stringContaining(includeObjectName) && expect.stringContaining('NonQueryable'),
+              severity: 'Info',
+            }])
+            expect(fetchResult.errors?.[0].message).not.toInclude('HiddenNonQueryable')
+          })
+          it('should not issue a warning if there are no instances of the object', () => {
+            expect(fetchResult.errors).not.toIncludeAllPartialMembers([{
+              message: expect.stringContaining(refToObjectName),
+            }])
+          })
         })
       })
 


### PR DESCRIPTION
When the user fetches data records that have some non-queryable fields, the result may be fear, uncertainty and confusion during deploy - the fields will be deployed as deleted.
Let's warn the user about fetching data records with inaccessible fields. But not if they're hidden, since the user can't see them anyway.

---



---
_Release Notes_: 
Salesforce: Warn when fetching data records with non-queryable fields.

---
_User Notifications_: 
N/A
