### PR TITLE
SALTO-4770: make guideTranslationFilter deploy run only when necessary

### DIFF
--- a/packages/zendesk-adapter/src/filters/guide_translation.ts
+++ b/packages/zendesk-adapter/src/filters/guide_translation.ts
@@ -84,6 +84,17 @@ const needToOmit = (change: Change<InstanceElement>, languageSettingsByIds: Reco
 const filterCreator: FilterCreator = ({ config, client, elementsSource }) => ({
   name: 'guideTranslationFilter',
   deploy: async (changes: Change<InstanceElement>[]) => {
+    const translationInstances = changes
+      .filter(change => TRANSLATION_TYPE_NAMES.includes(getChangeData(change).elemID.typeName))
+    if (_.isEmpty(translationInstances)) {
+      return {
+        deployResult: {
+          appliedChanges: [],
+          errors: [],
+        },
+        leftoverChanges: changes,
+      }
+    }
     const guideLanguageSettingsInstances = await (awu(await elementsSource.list())
       .filter(id => id.typeName === GUIDE_LANGUAGE_SETTINGS_TYPE_NAME)
       .map(async id => elementsSource.get(id))

--- a/packages/zendesk-adapter/src/filters/guide_translation.ts
+++ b/packages/zendesk-adapter/src/filters/guide_translation.ts
@@ -87,6 +87,7 @@ const filterCreator: FilterCreator = ({ config, client, elementsSource }) => ({
     const translationInstances = changes
       .filter(change => TRANSLATION_TYPE_NAMES.includes(getChangeData(change).elemID.typeName))
     if (_.isEmpty(translationInstances)) {
+      log.debug('there are no translation instances, not running guideTranslationFilter')
       return {
         deployResult: {
           appliedChanges: [],
@@ -99,6 +100,7 @@ const filterCreator: FilterCreator = ({ config, client, elementsSource }) => ({
       .filter(id => id.typeName === GUIDE_LANGUAGE_SETTINGS_TYPE_NAME)
       .map(async id => elementsSource.get(id))
       .toArray())
+    log.debug(`there are ${guideLanguageSettingsInstances.length} guide language setting instances`)
     const languageSettingsByIds = _.keyBy(guideLanguageSettingsInstances, instance => instance.elemID.name)
     const [translationChangesToIgnore, leftoverChanges] = _.partition(
       changes,


### PR DESCRIPTION
make guideTranslationFilter deploy run only when necessary

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
