### PR TITLE
SALTO-4703 - Escape multi line quotes inside multi line

### DIFF
--- a/packages/workspace/src/parser/internal/dump.ts
+++ b/packages/workspace/src/parser/internal/dump.ts
@@ -59,8 +59,10 @@ const escapeTemplateMarker = (prim: string): string => prim.replace(/\$\{/gi, '\
 // Double escaping happens when we stringify after escaping.
 const fixDoubleTemplateMarkerEscaping = (prim: string): string => prim.replace(/\\\\\$\{/g, '\\${')
 
+const escapeMultilineMarker = (prim: string): string => prim.replace(/'''/g, "\\'''")
+
 const dumpMultilineString = (prim: string): string =>
-  [MULTILINE_STRING_PREFIX, prim, MULTILINE_STRING_SUFFIX].join('')
+  [MULTILINE_STRING_PREFIX, escapeMultilineMarker(prim), MULTILINE_STRING_SUFFIX].join('')
 
 const dumpString = (prim: string, indentationLevel = 0): string => {
   const dumpedString = isMultilineString(prim)

--- a/packages/workspace/src/parser/internal/native/consumers/values.ts
+++ b/packages/workspace/src/parser/internal/native/consumers/values.ts
@@ -260,6 +260,8 @@ const consumeArrayItems = (
   return items
 }
 
+const unescapeMultilineMarker = (prim: string): string => prim.replace(/\\'''/g, "'''")
+
 const consumeMultilineString: Consumer<string | TemplateExpression> = context => {
   // Getting the position of the start marker
   const start = positionAtStart(context.lexer.next())
@@ -277,7 +279,7 @@ const consumeMultilineString: Consumer<string | TemplateExpression> = context =>
     context,
     tokens,
     true,
-    (_c, t) => unescapeTemplateMarker(t.text)
+    (_c, t) => unescapeMultilineMarker(unescapeTemplateMarker(t.text))
   )
   return {
     value,

--- a/packages/workspace/src/parser/internal/native/consumers/values.ts
+++ b/packages/workspace/src/parser/internal/native/consumers/values.ts
@@ -262,6 +262,9 @@ const consumeArrayItems = (
 
 const unescapeMultilineMarker = (prim: string): string => prim.replace(/\\'''/g, "'''")
 
+export const unescapeMultilineString = (text: string): string =>
+  unescapeMultilineMarker(unescapeTemplateMarker(text))
+
 const consumeMultilineString: Consumer<string | TemplateExpression> = context => {
   // Getting the position of the start marker
   const start = positionAtStart(context.lexer.next())
@@ -279,7 +282,7 @@ const consumeMultilineString: Consumer<string | TemplateExpression> = context =>
     context,
     tokens,
     true,
-    (_c, t) => unescapeMultilineMarker(unescapeTemplateMarker(t.text))
+    (_c, t) => unescapeMultilineString(t.text)
   )
   return {
     value,

--- a/packages/workspace/src/parser/internal/native/consumers/values.ts
+++ b/packages/workspace/src/parser/internal/native/consumers/values.ts
@@ -262,7 +262,7 @@ const consumeArrayItems = (
 
 const unescapeMultilineMarker = (prim: string): string => prim.replace(/\\'''/g, "'''")
 
-export const unescapeMultilineString = (text: string): string =>
+const unescapeMultilineString = (text: string): string =>
   unescapeMultilineMarker(unescapeTemplateMarker(text))
 
 const consumeMultilineString: Consumer<string | TemplateExpression> = context => {

--- a/packages/workspace/test/parser/dump.test.ts
+++ b/packages/workspace/test/parser/dump.test.ts
@@ -20,7 +20,6 @@ import { parse } from '../../src/parser'
 import { dumpAnnotationTypes, dumpElements, dumpSingleAnnotationType, dumpValues } from '../../src/parser/dump'
 import { Functions } from '../../src/parser/functions'
 import { registerTestFunction, TestFuncImpl } from '../utils'
-import { unescapeMultilineString } from '../../src/parser/internal/native/consumers/values'
 
 const funcName = 'ZOMG'
 let functions: Functions
@@ -422,6 +421,10 @@ describe('Salto Dump', () => {
     })
     it('should serialize booleans', async () => {
       expect(await dumpValues(false, functions)).toEqual('false\n')
+    })
+    it('should serialize multi line string and escape correctly', async () => {
+      // eslint-disable-next-line no-template-curly-in-string
+      expect(await dumpValues("a${a}a\n'''aaa", functions)).toEqual("'''\na\\${a}a\n\\'''aaa\n'''\n")
     })
     it('should dump list', async () => {
       expect(await dumpValues(

--- a/packages/workspace/test/parser/dump.test.ts
+++ b/packages/workspace/test/parser/dump.test.ts
@@ -416,8 +416,11 @@ describe('Salto Dump', () => {
     it('should serialize numbers', async () => {
       expect(await dumpValues(123, functions)).toEqual('123\n')
     })
-    it('should serialize strings', async () => {
-      expect(await dumpValues('aaa', functions)).toEqual('"aaa"\n')
+    it('should serialize strings and escape correctly', async () => {
+      expect(await dumpValues('"aaa"', functions)).toEqual('"\\"aaa\\""\n')
+    })
+    it('should serialize multi line string and escape correctly', async () => {
+      expect(await dumpValues("aaa\n'''aaa", functions)).toEqual("'''\naaa\n\\'''aaa\n'''\n")
     })
     it('should serialize booleans', async () => {
       expect(await dumpValues(false, functions)).toEqual('false\n')

--- a/packages/workspace/test/parser/dump.test.ts
+++ b/packages/workspace/test/parser/dump.test.ts
@@ -20,6 +20,7 @@ import { parse } from '../../src/parser'
 import { dumpAnnotationTypes, dumpElements, dumpSingleAnnotationType, dumpValues } from '../../src/parser/dump'
 import { Functions } from '../../src/parser/functions'
 import { registerTestFunction, TestFuncImpl } from '../utils'
+import { unescapeMultilineString } from '../../src/parser/internal/native/consumers/values'
 
 const funcName = 'ZOMG'
 let functions: Functions
@@ -420,7 +421,12 @@ describe('Salto Dump', () => {
       expect(await dumpValues('"aaa"', functions)).toEqual('"\\"aaa\\""\n')
     })
     it('should serialize multi line string and escape correctly', async () => {
-      expect(await dumpValues("aaa\n'''aaa", functions)).toEqual("'''\naaa\n\\'''aaa\n'''\n")
+      // eslint-disable-next-line no-template-curly-in-string
+      expect(await dumpValues("a${a}a\n'''aaa", functions)).toEqual("'''\na\\${a}a\n\\'''aaa\n'''\n")
+    })
+    it('should unescape multi line string correctly', async () => {
+      // eslint-disable-next-line no-template-curly-in-string
+      expect(unescapeMultilineString(await dumpValues("a${a}a\n'''aaa", functions))).toEqual("'''\na${a}a\n'''aaa\n'''\n")
     })
     it('should serialize booleans', async () => {
       expect(await dumpValues(false, functions)).toEqual('false\n')

--- a/packages/workspace/test/parser/dump.test.ts
+++ b/packages/workspace/test/parser/dump.test.ts
@@ -419,12 +419,12 @@ describe('Salto Dump', () => {
     it('should serialize strings and escape correctly', async () => {
       expect(await dumpValues('"aaa"', functions)).toEqual('"\\"aaa\\""\n')
     })
-    it('should serialize booleans', async () => {
-      expect(await dumpValues(false, functions)).toEqual('false\n')
-    })
     it('should serialize multi line string and escape correctly', async () => {
       // eslint-disable-next-line no-template-curly-in-string
       expect(await dumpValues("a${a}a\n'''aaa", functions)).toEqual("'''\na\\${a}a\n\\'''aaa\n'''\n")
+    })
+    it('should serialize booleans', async () => {
+      expect(await dumpValues(false, functions)).toEqual('false\n')
     })
     it('should dump list', async () => {
       expect(await dumpValues(

--- a/packages/workspace/test/parser/dump.test.ts
+++ b/packages/workspace/test/parser/dump.test.ts
@@ -96,7 +96,7 @@ describe('Salto Dump', () => {
       ],
     },
     // eslint-disable-next-line no-template-curly-in-string
-    multiLineString: 'This\nis\nmultilinestring\n${foo} "needs" Escaping',
+    multiLineString: "This\nis\nmultilinestring\n${foo}&\\n''' 'needs' Escaping",
     // eslint-disable-next-line no-template-curly-in-string
     stringNeedsEscaping: 'This string ${needs} escaping',
   })
@@ -222,7 +222,7 @@ describe('Salto Dump', () => {
       })
       it('has multiline string', () => {
         expect(body).toMatch(
-          /multiLineString = '''\n\s*This\s*\nis\s*\nmultilinestring\s*\n\s*\\\$\{foo\} "needs" Escaping\s*\n'''/m,
+          /multiLineString = '''\n\s*This\s*\nis\s*\nmultilinestring\s*\n\s*\\\$\{foo\}&\\n\\''' 'needs' Escaping\s*\n'''/m,
         )
       })
       it('Has escaped string', () => {
@@ -419,14 +419,6 @@ describe('Salto Dump', () => {
     })
     it('should serialize strings and escape correctly', async () => {
       expect(await dumpValues('"aaa"', functions)).toEqual('"\\"aaa\\""\n')
-    })
-    it('should serialize multi line string and escape correctly', async () => {
-      // eslint-disable-next-line no-template-curly-in-string
-      expect(await dumpValues("a${a}a\n'''aaa", functions)).toEqual("'''\na\\${a}a\n\\'''aaa\n'''\n")
-    })
-    it('should unescape multi line string correctly', async () => {
-      // eslint-disable-next-line no-template-curly-in-string
-      expect(unescapeMultilineString(await dumpValues("a${a}a\n'''aaa", functions))).toEqual("'''\na${a}a\n'''aaa\n'''\n")
     })
     it('should serialize booleans', async () => {
       expect(await dumpValues(false, functions)).toEqual('false\n')


### PR DESCRIPTION
Escape the string ''' inside multi line when dumping a nacl, and unescape it when parsing the nacl

---

None

---
_Release Notes_: 
Core:
* Fixed issue where multi line quotes inside a multi line value were not properly escaped in NaCl

---
_User Notifications_: 
_None_
