### PR TITLE
SALTO-4761: Support fetch of Workflow on Custom Objects

### DIFF
--- a/packages/salesforce-adapter/e2e_test/adapter.test.ts
+++ b/packages/salesforce-adapter/e2e_test/adapter.test.ts
@@ -2735,6 +2735,7 @@ describe('Salesforce adapter E2E with real account', () => {
             fileProps,
             new Set((await instance.getType()).annotations.hasMetaFile ? [type] : []),
             new Set(constants.METADATA_CONTENT_FIELD in instance.value ? [type] : []),
+            false,
           )
           return awu(instances)
             .filter(async ({ file }) => file.fullName === await apiName(instance))

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -599,7 +599,7 @@ export default class SalesforceAdapter implements AdapterOperations {
         types: metadataTypesToRetrieve,
         metadataQuery: this.fetchProfile.metadataQuery,
         maxItemsInRetrieveRequest: this.maxItemsInRetrieveRequest,
-        addNamespacePrefixToFullName: this.fetchProfile.addNamespacePrefixToFullName,
+        fetchProfile: this.fetchProfile,
         typesToSkip: new Set(this.metadataTypesOfInstancesFetchedInFilters),
       }),
       readInstances(metadataTypesToRead),

--- a/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
@@ -42,6 +42,7 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   generateRefsInProfiles: false,
   skipAliases: false,
   toolingDepsOfCurrentNamespace: false,
+  fixRetrieveFilePaths: false,
 }
 
 export const buildFetchProfile = ({

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -89,6 +89,7 @@ export type OptionalFeatures = {
   fetchProfilesUsingReadApi?: boolean
   toolingDepsOfCurrentNamespace?: boolean
   useLabelAsAlias?: boolean
+  fixRetrieveFilePaths?: boolean
 }
 
 export type ChangeValidatorName = (
@@ -659,6 +660,7 @@ const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
     fetchProfilesUsingReadApi: { refType: BuiltinTypes.BOOLEAN },
     toolingDepsOfCurrentNamespace: { refType: BuiltinTypes.BOOLEAN },
     useLabelAsAlias: { refType: BuiltinTypes.BOOLEAN },
+    fixRetrieveFilePaths: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -64,6 +64,7 @@ import SalesforceClient from '../src/client/client'
 import createMockClient from './client'
 import { mockTypes } from './mock_elements'
 import { buildMetadataQuery } from '../src/fetch_profile/metadata_query'
+import { buildFetchProfile } from '../src/fetch_profile/fetch_profile'
 
 const { makeArray } = collections.array
 const { awu } = collections.asynciterable
@@ -744,6 +745,7 @@ describe('SalesforceAdapter fetch', () => {
           ]),
           expect.anything(),
           expect.anything(),
+          false,
         )
       })
     })
@@ -1758,6 +1760,7 @@ public class LargeClass${index} {
           ]),
           expect.anything(),
           expect.anything(),
+          false,
         )
       })
     })
@@ -1851,7 +1854,7 @@ describe('Fetch via retrieve API', () => {
           types: [mockTypes.ApexClass],
           maxItemsInRetrieveRequest: DEFAULT_MAX_ITEMS_IN_RETRIEVE_REQUEST,
           metadataQuery: buildMetadataQuery({}),
-          addNamespacePrefixToFullName: false,
+          fetchProfile: buildFetchProfile({ addNamespacePrefixToFullName: false }),
           typesToSkip: new Set(),
         }
       )
@@ -1882,7 +1885,7 @@ describe('Fetch via retrieve API', () => {
           types: [mockTypes.ApexClass, mockTypes.CustomObject],
           maxItemsInRetrieveRequest: chunkSize,
           metadataQuery: buildMetadataQuery({}),
-          addNamespacePrefixToFullName: false,
+          fetchProfile: buildFetchProfile({ addNamespacePrefixToFullName: false }),
           typesToSkip: new Set(),
         }
       )
@@ -1917,7 +1920,7 @@ describe('Fetch via retrieve API', () => {
           types: [mockTypes.CustomObject, mockTypes.Profile],
           maxItemsInRetrieveRequest: chunkSize,
           metadataQuery: buildMetadataQuery({}),
-          addNamespacePrefixToFullName: false,
+          fetchProfile: buildFetchProfile({ addNamespacePrefixToFullName: false }),
           typesToSkip: new Set(),
         }
       )
@@ -1960,7 +1963,7 @@ describe('Fetch via retrieve API', () => {
           types: [mockTypes.CustomObject, mockTypes.Profile],
           maxItemsInRetrieveRequest: 3,
           metadataQuery: buildMetadataQuery({}),
-          addNamespacePrefixToFullName: false,
+          fetchProfile: buildFetchProfile({ addNamespacePrefixToFullName: false }),
           typesToSkip: new Set(),
         }
       )

--- a/packages/salesforce-adapter/test/transformers/xml_transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/xml_transformer.test.ts
@@ -360,7 +360,7 @@ describe('XML Transformer', () => {
 
       it('should transform zip to MetadataInfo', async () => {
         const values = await fromRetrieveResult(
-          retrieveResult, fileProperties, new Set(['ApexClass']), new Set(['ApexClass']),
+          retrieveResult, fileProperties, new Set(['ApexClass']), new Set(['ApexClass']), false
         )
         expect(values).toHaveLength(1)
         const [apex] = values
@@ -405,7 +405,7 @@ describe('XML Transformer', () => {
 
       it('should transform zip to MetadataInfo', async () => {
         const values = await fromRetrieveResult(
-          retrieveResult, fileProperties, new Set(['ApexClass']), new Set(['ApexClass']),
+          retrieveResult, fileProperties, new Set(['ApexClass']), new Set(['ApexClass']), false
         )
         expect(values).toHaveLength(1)
         const [apex] = values
@@ -466,6 +466,7 @@ describe('XML Transformer', () => {
           fileProperties,
           new Set(['EmailTemplate', 'EmailFolder']),
           new Set(['EmailTemplate']),
+          false,
         )
         emailFolder = values.find(value => value.file.type === 'EmailFolder')?.values
         emailTemplate = values.find(value => value.file.type === 'EmailTemplate')?.values
@@ -557,7 +558,7 @@ describe('XML Transformer', () => {
         it('should transform zip to MetadataInfo', async () => {
           const fileProperties = createFileProperties()
           const values = await fromRetrieveResult(
-            await createRetrieveResult([fileProperties]), [fileProperties], new Set(), new Set(),
+            await createRetrieveResult([fileProperties]), [fileProperties], new Set(), new Set(), false,
           )
           await verifyMetadataValues(
             values,
@@ -569,7 +570,7 @@ describe('XML Transformer', () => {
         it('should transform zip to MetadataInfo for instance with namespace', async () => {
           const fileProperties = createFileProperties('myNamespace')
           const values = await fromRetrieveResult(
-            await createRetrieveResult([fileProperties]), [fileProperties], new Set(), new Set(),
+            await createRetrieveResult([fileProperties]), [fileProperties], new Set(), new Set(), false,
           )
           await verifyMetadataValues(
             values,
@@ -694,7 +695,7 @@ describe('XML Transformer', () => {
         it('should transform zip to MetadataInfo', async () => {
           const fileProperties = createFileProperties()
           const values = await fromRetrieveResult(
-            await createRetrieveResult([fileProperties]), [fileProperties], new Set(), new Set(),
+            await createRetrieveResult([fileProperties]), [fileProperties], new Set(), new Set(), false,
           )
           await verifyMetadataValues(
             values,
@@ -706,7 +707,7 @@ describe('XML Transformer', () => {
         it('should transform zip to MetadataInfo for instance with namespace', async () => {
           const fileProperties = createFileProperties('myNamespace')
           const values = await fromRetrieveResult(
-            await createRetrieveResult([fileProperties]), [fileProperties], new Set(), new Set(),
+            await createRetrieveResult([fileProperties]), [fileProperties], new Set(), new Set(), false,
           )
           await verifyMetadataValues(
             values,
@@ -744,6 +745,7 @@ describe('XML Transformer', () => {
           fileProperties,
           new Set(),
           new Set(),
+          false,
         )
         expect(values).toContainEqual(
           expect.objectContaining({ values: expect.objectContaining({ fullName: 'MyReportType' }) })


### PR DESCRIPTION
Support fetch of Workflow (it's sub-instances) on Custom Objects

---

Workspace diff with the optional feature enabled: https://github.com/salto-io/tamir-sf/commit/9a8d247550eef24f62a1be9f762247438e2b8ad1

The fileName that returned for a Workflow on a Custom Object are incorrect. See this as an example:
<img width="558" alt="Screen Shot 2023-09-14 at 11 04 56" src="https://github.com/salto-io/salto/assets/92912659/f3621905-fdb3-418a-bfae-85bdd609df43">

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
