### PR TITLE
SALTO-2349: Added additional request context

### DIFF
--- a/packages/adapter-components/src/elements/ducktype/transformer.ts
+++ b/packages/adapter-components/src/elements/ducktype/transformer.ts
@@ -143,7 +143,8 @@ const getEntriesForType = async (
   const requestWithDefaults = getConfigWithDefault(request, typeDefaultConfig.request ?? {})
 
   const getEntries = async (context: Values | undefined): Promise<Values[]> => {
-    const getArgs = computeGetArgs(requestWithDefaults, contextElements, context, reversedSupportedTypes)
+    const getArgs = computeGetArgs(requestWithDefaults, contextElements, _.assign({}, context, requestContext),
+      reversedSupportedTypes)
     return (await Promise.all(
       getArgs.map(async args => (
         getEntriesResponseValuesFunc
@@ -284,6 +285,7 @@ export const getTypeAndInstances = async ({
   getEntriesResponseValuesFunc,
   reversedSupportedTypes,
   customInstanceFilter,
+  requestContext,
 }: {
   adapterName: string
   typeName: string
@@ -297,6 +299,7 @@ export const getTypeAndInstances = async ({
   getEntriesResponseValuesFunc?: EntriesRequester
   reversedSupportedTypes: Record<string, string[]>
   customInstanceFilter?: (instances: InstanceElement[]) => InstanceElement[]
+  requestContext?: Record<string, unknown>
 }): Promise<Element[]> => {
   const entries = await getEntriesForType({
     adapterName,
@@ -310,6 +313,7 @@ export const getTypeAndInstances = async ({
     getElemIdFunc,
     getEntriesResponseValuesFunc,
     reversedSupportedTypes,
+    requestContext,
   })
   const { type, nestedTypes, instances } = entries
   const filteredInstances = customInstanceFilter !== undefined ? customInstanceFilter(instances) : instances
@@ -349,6 +353,7 @@ export const getAllElements = async ({
   getEntriesResponseValuesFunc,
   isErrorTurnToConfigSuggestion,
   customInstanceFilter,
+  additionalRequestContext,
 }: {
   adapterName: string
   fetchQuery: ElementQuery
@@ -363,6 +368,7 @@ export const getAllElements = async ({
   getEntriesResponseValuesFunc?: EntriesRequester
   isErrorTurnToConfigSuggestion?: (error: Error) => boolean
   customInstanceFilter?: (instances: InstanceElement[]) => InstanceElement[]
+  additionalRequestContext? : Record<string, unknown>
 }): Promise<FetchElements<Element[]>> => {
   const supportedTypesWithEndpoints = _.mapValues(
     supportedTypes,
@@ -382,6 +388,7 @@ export const getAllElements = async ({
     paginator,
     nestedFieldFinder,
     computeGetArgs,
+    requestContext: additionalRequestContext,
     typesConfig: types,
     typeDefaultConfig: typeDefaults,
     getElemIdFunc,

--- a/packages/adapter-components/src/elements/ducktype/transformer.ts
+++ b/packages/adapter-components/src/elements/ducktype/transformer.ts
@@ -285,7 +285,7 @@ export const getTypeAndInstances = async ({
   getEntriesResponseValuesFunc,
   reversedSupportedTypes,
   customInstanceFilter,
-  requestContext,
+  additionalRequestContext,
 }: {
   adapterName: string
   typeName: string
@@ -299,7 +299,7 @@ export const getTypeAndInstances = async ({
   getEntriesResponseValuesFunc?: EntriesRequester
   reversedSupportedTypes: Record<string, string[]>
   customInstanceFilter?: (instances: InstanceElement[]) => InstanceElement[]
-  requestContext?: Record<string, unknown>
+  additionalRequestContext?: Record<string, unknown>
 }): Promise<Element[]> => {
   const entries = await getEntriesForType({
     adapterName,
@@ -313,7 +313,7 @@ export const getTypeAndInstances = async ({
     getElemIdFunc,
     getEntriesResponseValuesFunc,
     reversedSupportedTypes,
-    requestContext,
+    requestContext: additionalRequestContext,
   })
   const { type, nestedTypes, instances } = entries
   const filteredInstances = customInstanceFilter !== undefined ? customInstanceFilter(instances) : instances

--- a/packages/adapter-components/test/elements/ducktype/transformer.test.ts
+++ b/packages/adapter-components/test/elements/ducktype/transformer.test.ts
@@ -37,7 +37,8 @@ import { InvalidSingletonType } from '../../../src/config/shared'
 
 describe('ducktype_transformer', () => {
   describe('getTypeAndInstances', () => {
-    let mockPaginator: Paginator
+    let mockPaginator: jest.MockedFunction<Paginator>
+
 
     beforeEach(() => {
       mockPaginator = mockFunction<Paginator>().mockImplementationOnce(async function *get() {
@@ -350,6 +351,66 @@ describe('ducktype_transformer', () => {
         },
         defaultName: 'unnamed_1_0',
       })
+    })
+
+    it('should call paginator with correct context and additional context', async () => {
+      mockPaginator = mockFunction<Paginator>().mockImplementation(async function *get(params) {
+        if (params.url === '/folders') {
+          yield [{ id: 1, name: 'folder1' }, { id: 2, name: 'folder2' }]
+        }
+        if (params.url === '/folders/1/subfolders/extra') {
+          yield [{ id: 3, name: 'subfolder1' }]
+        }
+        if (params.url === '/folders/2/subfolders/extra') {
+          yield [{ id: 4, name: 'subfolder2' }]
+        }
+      })
+      jest.spyOn(typeElements, 'generateType').mockRestore()
+      jest.spyOn(instanceElements, 'toInstance').mockRestore()
+      await getTypeAndInstances({
+        adapterName: 'something',
+        paginator: mockPaginator,
+        computeGetArgs,
+        typeName: 'folder',
+        typesConfig: {
+          folder: {
+            request: {
+              url: '/folders',
+              recurseInto: [
+                {
+                  type: 'subfolder',
+                  toField: 'subfolders',
+                  context: [{ name: 'folderId', fromField: 'id' }],
+                },
+              ],
+            },
+            transformation: {
+              standaloneFields: [{ fieldName: 'subfolders' }],
+            },
+          },
+          subfolder: {
+            request: {
+              url: '/folders/{folderId}/subfolders/{extraContext}',
+            },
+            transformation: {
+              sourceTypeName: 'folder__subfolders',
+            },
+          },
+        },
+        typeDefaultConfig: {
+          transformation: {
+            idFields: ['name'],
+            fileNameFields: ['also_name'],
+          },
+        },
+        nestedFieldFinder: returnFullEntry,
+        reversedSupportedTypes: { folders: ['folder'], subfolder: ['subfolder'] },
+        additionalRequestContext: { extraContext: 'extra' },
+      })
+      expect(mockPaginator).toHaveBeenCalledTimes(3)
+      expect(mockPaginator.mock.calls[0][0]).toEqual({ url: '/folders', queryParams: undefined, recursiveQueryParams: undefined, paginationField: undefined })
+      expect(mockPaginator.mock.calls[1][0]).toEqual({ url: '/folders/1/subfolders/extra', queryParams: undefined, recursiveQueryParams: undefined, paginationField: undefined })
+      expect(mockPaginator.mock.calls[2][0]).toEqual({ url: '/folders/2/subfolders/extra', queryParams: undefined, recursiveQueryParams: undefined, paginationField: undefined })
     })
 
     it('should fail if type is missing from config', async () => {


### PR DESCRIPTION
Following this [PR](https://github.com/salto-io/salto/pull/4857) I splited adapter components from jsm initial fetch.

---

None

---
_Release Notes_: 
None
---
_User Notifications_: 
None
