### PR TITLE
SALTO-4534 - Zendesk Adapter - Detect duplicate ids from removal changes

### DIFF
--- a/packages/zendesk-adapter/src/change_validators/duplicate_id_field_values.ts
+++ b/packages/zendesk-adapter/src/change_validators/duplicate_id_field_values.ts
@@ -87,7 +87,6 @@ export const duplicateIdFieldValuesValidator = (
         ? []
         : instancesByIdFields[instanceElemName].filter(i => i.elemID.getFullName() !== instance.elemID.getFullName())
 
-
       if (instancesWithSameZendeskId.length === 0) {
         return undefined
       }

--- a/packages/zendesk-adapter/src/change_validators/duplicate_id_field_values.ts
+++ b/packages/zendesk-adapter/src/change_validators/duplicate_id_field_values.ts
@@ -17,7 +17,7 @@ import {
   ChangeError,
   ChangeValidator,
   getChangeData, InstanceElement,
-  isAdditionChange, isInstanceChange,
+  isAdditionOrRemovalChange, isInstanceChange, isRemovalChange,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { elements as elementUtils } from '@salto-io/adapter-components'
@@ -53,7 +53,7 @@ export const duplicateIdFieldValuesValidator = (
 
   const changedInstancesByType = _.groupBy(
     changes
-      .filter(isAdditionChange)
+      .filter(isAdditionOrRemovalChange)
       .filter(isInstanceChange)
       .map(getChangeData)
       .filter(instance => Object.keys(ZENDESK_ID_FIELDS).includes(instance.elemID.typeName)),
@@ -61,7 +61,13 @@ export const duplicateIdFieldValuesValidator = (
   )
 
   const errors = await Promise.all(Object.entries(changedInstancesByType).map(async ([typeName, instances]) => {
-    const typeInstances = await getInstancesFromElementSource(elementSource, [typeName])
+    // Removals are not in the elementSource
+    const typeRemovals = changes
+      .filter(isRemovalChange)
+      .filter(isInstanceChange)
+      .map(getChangeData)
+      .filter(instance => instance.elemID.typeName === typeName)
+    const typeInstances = typeRemovals.concat(await getInstancesFromElementSource(elementSource, [typeName]))
     const instancesByZendeskId = _.groupBy(
       typeInstances,
       instance => toZendeskId(typeName, instance)
@@ -75,11 +81,13 @@ export const duplicateIdFieldValuesValidator = (
       const instanceZendeskId = toZendeskId(typeName, instance)
       const instanceElemName = generateInstanceNameFromConfig(instance.value, typeName, apiConfig)
 
-      const instancesWithSameZendeskId = instancesByZendeskId[instanceZendeskId]
-        .filter(i => i.elemID.getFullName() !== instance.elemID.getFullName())
+      const instancesWithSameZendeskId = _.uniq(instancesByZendeskId[instanceZendeskId]
+        .filter(i => i.elemID.getFullName() !== instance.elemID.getFullName()))
       const instancesWithSameName = instanceElemName === undefined
         ? []
-        : instancesByIdFields[instanceElemName].filter(i => i.elemID.getFullName() !== instance.elemID.getFullName())
+        : _.uniq(
+          instancesByIdFields[instanceElemName].filter(i => i.elemID.getFullName() !== instance.elemID.getFullName())
+        )
 
       if (instancesWithSameZendeskId.length === 0) {
         return undefined

--- a/packages/zendesk-adapter/src/change_validators/duplicate_id_field_values.ts
+++ b/packages/zendesk-adapter/src/change_validators/duplicate_id_field_values.ts
@@ -81,13 +81,12 @@ export const duplicateIdFieldValuesValidator = (
       const instanceZendeskId = toZendeskId(typeName, instance)
       const instanceElemName = generateInstanceNameFromConfig(instance.value, typeName, apiConfig)
 
-      const instancesWithSameZendeskId = _.uniq(instancesByZendeskId[instanceZendeskId]
-        .filter(i => i.elemID.getFullName() !== instance.elemID.getFullName()))
+      const instancesWithSameZendeskId = instancesByZendeskId[instanceZendeskId]
+        .filter(i => i.elemID.getFullName() !== instance.elemID.getFullName())
       const instancesWithSameName = instanceElemName === undefined
         ? []
-        : _.uniq(
-          instancesByIdFields[instanceElemName].filter(i => i.elemID.getFullName() !== instance.elemID.getFullName())
-        )
+        : instancesByIdFields[instanceElemName].filter(i => i.elemID.getFullName() !== instance.elemID.getFullName())
+
 
       if (instancesWithSameZendeskId.length === 0) {
         return undefined

--- a/packages/zendesk-adapter/test/change_validators/duplicate_id_field_values.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/duplicate_id_field_values.test.ts
@@ -71,14 +71,13 @@ describe('duplicateIdFieldValuesValidator', () => {
 
     const changes = [
       toChange({ after: duplicateGroup1 }),
-      toChange({ after: duplicateGroup3 }),
+      toChange({ before: duplicateGroup3 }),
       toChange({ after: duplicateGroup4 }),
       toChange({ after: uniqueGroup }),
     ]
     const elementSource = createInMemoryElementSource([
       duplicateGroup1,
       duplicateGroup2,
-      duplicateGroup3,
       duplicateGroup4,
       duplicateGroup5,
       uniqueGroup,


### PR DESCRIPTION
Also check for duplications with removals, because a change in the elemId can be translated into an addition and a removal change

---

None

---
_Release Notes_: 
Zendesk Adapter
* mismatches between environments of the elemIds of groups will be prevented

---
_User Notifications_: 
None