### PR TITLE
SALTO-4747: add handleIdenticalAttachmentConflicts flag

### DIFF
--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -79,6 +79,7 @@ export type ZendeskFetchConfig = configUtils.UserFetchConfig
   enableMissingReferences?: boolean
   includeAuditDetails?: boolean
   addAlias?: boolean
+  handleIdenticalAttachmentConflicts?: boolean
   greedyAppReferences?: boolean
   appReferenceLocators?: IdLocator[]
   guide?: Guide
@@ -2564,6 +2565,7 @@ export const DEFAULT_CONFIG: ZendeskConfig = {
     resolveOrganizationIDs: false,
     includeAuditDetails: false,
     addAlias: true,
+    handleIdenticalAttachmentConflicts: false,
   },
   [DEPLOY_CONFIG]: {
     createMissingOrganizations: false,
@@ -2781,6 +2783,7 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
           enableMissingReferences: { refType: BuiltinTypes.BOOLEAN },
           includeAuditDetails: { refType: BuiltinTypes.BOOLEAN },
           addAlias: { refType: BuiltinTypes.BOOLEAN },
+          handleIdenticalAttachmentConflicts: { refType: BuiltinTypes.BOOLEAN },
           greedyAppReferences: { refType: BuiltinTypes.BOOLEAN },
           appReferenceLocators: { refType: IdLocatorType },
           guide: { refType: GuideType },
@@ -2815,6 +2818,7 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
       `${FETCH_CONFIG}.resolveOrganizationIDs`,
       `${FETCH_CONFIG}.includeAuditDetails`,
       `${FETCH_CONFIG}.addAlias`,
+      `${FETCH_CONFIG}.handleIdenticalAttachmentConflicts`,
       DEPLOY_CONFIG,
     ),
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/zendesk-adapter/src/filters/handle_identical_attachment_conflicts.ts
+++ b/packages/zendesk-adapter/src/filters/handle_identical_attachment_conflicts.ts
@@ -1,0 +1,59 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { logger } from '@salto-io/logging'
+import _ from 'lodash'
+import { isInstanceElement, isStaticFile } from '@salto-io/adapter-api'
+import { FilterCreator } from '../filter'
+import { FETCH_CONFIG } from '../config'
+import { ARTICLE_ATTACHMENT_TYPE_NAME } from '../constants'
+
+
+const log = logger(module)
+
+const filterCreator: FilterCreator = ({ config }) => ({
+  name: 'handleIdenticalAttachmentConflictsFilter',
+  onFetch: async elements => {
+    if (config[FETCH_CONFIG].handleIdenticalAttachmentConflicts !== true) {
+      log.debug('handleIdenticalAttachmentConflicts is false not running handleIdenticalAttachmentConflictsFilter')
+      return
+    }
+    const articleAttachmentInstances = elements
+      .filter(isInstanceElement)
+      .filter(elem => elem.elemID.typeName === ARTICLE_ATTACHMENT_TYPE_NAME)
+      .filter(attachment =>
+        attachment.value.id !== undefined
+        && isStaticFile(attachment.value.content)
+        && attachment.value.content.hash !== undefined)
+    const attachmentsByElemId = _.groupBy(articleAttachmentInstances, elem => elem.elemID.getFullName())
+    const idsToRemove = new Set(Object.values(attachmentsByElemId)
+      .filter(attachments => attachments.length > 1)
+      .flatMap(attachments => {
+        const hashSet = new Set(attachments.map(attachment => attachment.value.content.hash))
+        // check if there are different files with the same name
+        if (hashSet.size !== 1) {
+          return []
+        }
+        // all files have the same hash, so we can remove the duplicates and keep only one
+        return attachments.slice(1).map(att => att.value.id)
+      }))
+    _.remove(elements, elem =>
+      isInstanceElement(elem)
+      && elem.elemID.typeName === ARTICLE_ATTACHMENT_TYPE_NAME
+      && idsToRemove.has(elem.value.id))
+  },
+})
+
+export default filterCreator

--- a/packages/zendesk-adapter/test/filters/handle_identical_attahments_conflicts.test.ts
+++ b/packages/zendesk-adapter/test/filters/handle_identical_attahments_conflicts.test.ts
@@ -1,0 +1,104 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { filterUtils } from '@salto-io/adapter-components'
+import {
+  ElemID,
+  InstanceElement,
+  ObjectType,
+  StaticFile,
+} from '@salto-io/adapter-api'
+import filterCreator from '../../src/filters/handle_identical_attachment_conflicts'
+import { ARTICLE_ATTACHMENT_TYPE_NAME, ZENDESK } from '../../src/constants'
+import { createFilterCreatorParams } from '../utils'
+import { DEFAULT_CONFIG, FETCH_CONFIG } from '../../src/config'
+
+const attachmentType = new ObjectType({ elemID: new ElemID(ZENDESK, ARTICLE_ATTACHMENT_TYPE_NAME) })
+const createAttachment = (name: string, contentText: string, id: number): InstanceElement => new InstanceElement(
+  name,
+  attachmentType,
+  {
+    id,
+    content: new StaticFile({
+      filepath: 'test',
+      content: Buffer.from(contentText),
+    }),
+  }
+)
+
+describe('handle identical attachments conflicts filter', () => {
+  type FilterType = filterUtils.FilterWith<'onFetch'>
+  let filter: FilterType
+
+  beforeEach(async () => {
+    filter = filterCreator(createFilterCreatorParams({
+      config: {
+        ...DEFAULT_CONFIG,
+        [FETCH_CONFIG]: {
+          include: [{
+            type: '.*',
+          }],
+          exclude: [],
+          handleIdenticalAttachmentConflicts: true,
+        },
+      },
+    })) as FilterType
+  })
+
+  describe('onFetch', () => {
+    it('should do nothing if flag is false', async () => {
+      filter = filterCreator(createFilterCreatorParams({
+        config: {
+          ...DEFAULT_CONFIG,
+          [FETCH_CONFIG]: {
+            include: [{
+              type: '.*',
+            }],
+            exclude: [],
+            handleIdenticalAttachmentConflicts: false,
+          },
+        },
+      })) as FilterType
+      const attachment1 = createAttachment('att1', 'test', 1)
+      const attachment2 = createAttachment('att1', 'test', 2)
+      const elements = [attachment1, attachment2]
+      await filter.onFetch(elements)
+      expect(elements.map(elem => elem.elemID.name)).toEqual(['att1', 'att1'])
+    })
+    it('should remove duplicate attachments', async () => {
+      const attachment1 = createAttachment('att1', 'test', 1)
+      const attachment2 = createAttachment('att1', 'test', 2)
+      const attachment3 = createAttachment('att2', 'other', 3)
+      const attachment4 = createAttachment('att2', 'other', 4)
+      const elements = [attachment1, attachment2, attachment3, attachment4]
+      await filter.onFetch(elements)
+      expect(elements.map(elem => elem.elemID.name)).toEqual(['att1', 'att2'])
+    })
+    it('should do nothing if duplicates have different hash', async () => {
+      const attachment1 = createAttachment('att1', 'test', 1)
+      const attachment2 = createAttachment('att1', 'test2', 2)
+      const elements = [attachment1, attachment2]
+      await filter.onFetch(elements)
+      expect(elements.map(elem => elem.elemID.name)).toEqual(['att1', 'att1'])
+    })
+    it('should do nothing if there are no duplicates', async () => {
+      const attachment1 = createAttachment('att1', 'test', 1)
+      const attachment2 = createAttachment('att2', 'test', 2)
+      const elements = [attachment1, attachment2]
+      await filter.onFetch(elements)
+      expect(elements.map(elem => elem.elemID.name)).toEqual(['att1', 'att2'])
+    })
+  })
+})


### PR DESCRIPTION
add handleIdenticalAttachmentConflicts flag

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* add `handleIdenticalAttachmentConflicts` flag. when it is true it will look at all attachments with the same elemId and hash and will keep only one.

---
_User Notifications_: 
None
