### PR TITLE
SALTO-4784: handle undefined apiNames in transformer.isCustom in SF

### DIFF
--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -124,8 +124,8 @@ export const isFieldOfCustomObject = async (field: Field): Promise<boolean> =>
 export const isInstanceOfCustomObject = async (element: Readonly<Element>): Promise<boolean> =>
   isInstanceElement(element) && isCustomObject(await element.getType())
 
-export const isCustom = (fullName: string): boolean =>
-  fullName.endsWith(SALESFORCE_CUSTOM_SUFFIX)
+export const isCustom = (fullName: string | undefined): boolean =>
+  fullName?.endsWith(SALESFORCE_CUSTOM_SUFFIX) ?? false
 
 export const isCustomSettings = (instance: Readonly<InstanceElement>): boolean =>
   instance.value[CUSTOM_SETTINGS_TYPE]

--- a/packages/salesforce-adapter/test/transformers/transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/transformer.test.ts
@@ -25,7 +25,7 @@ import {
   getValueTypeFieldElement, createMetadataTypeElements, MetadataObjectType,
   METADATA_TYPES_TO_RENAME, instancesToDeleteRecords, instancesToCreateRecords,
   isMetadataObjectType, isMetadataInstanceElement, toDeployableInstance, transformPrimitive,
-  getAuthorAnnotations,
+  getAuthorAnnotations, isCustom,
 } from '../../src/transformers/transformer'
 import { getLookUpName } from '../../src/transformers/reference_mapping'
 import {
@@ -2337,6 +2337,17 @@ describe('transformer', () => {
           value: { bla: 'foo' }, field: mockObjType.fields.string,
         })).toEqual({ bla: 'foo' })
       })
+    })
+  })
+  describe('isCustom', () => {
+    it('should return true for custom apiNames', () => {
+      expect(isCustom('Custom__c')).toBeTrue()
+    })
+    it('should return false for undefined', () => {
+      expect(isCustom(undefined)).toBeFalse()
+    })
+    it('should return false for standard apiNames', () => {
+      expect(isCustom('Name')).toBeFalse()
     })
   })
 })


### PR DESCRIPTION
handle undefined apiNames in transformer.isCustom in Salesforce Adapter.

---

Upon modification of picklist standard fields, when the **apiName** is undefined the preview flow yielded runtime error.
See the Jira ticket for more context.

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
