### PR TITLE
SALTO-4794:Empty Validators

### DIFF
--- a/packages/jira-adapter/src/change_validators/workflows/empty_validator_workflow.ts
+++ b/packages/jira-adapter/src/change_validators/workflows/empty_validator_workflow.ts
@@ -22,8 +22,6 @@ export const CONFIGURATION_VALIDATOR_TYPE = new Set([
   'FieldChangedValidator',
   'FieldHasSingleValueValidator',
   'ParentStatusValidator',
-  'ProFormaFormsAttachedValidator',
-  'ProFormaFormsSubmittedValidator',
   'DateFieldValidator',
   'PermissionValidator',
   'PreviousStatusValidator',


### PR DESCRIPTION
The Empty workflow validators change validators contained some validators that should be empty

---
_Release Notes_: 
Jira Adapter:
* Fixed a bug that prevented the deployment of some workflow validators

---
_User Notifications_: 
None
