### PR TITLE
SALTO-4476 extract string from FieldDef for detailedMessage

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/multiple_defaults.ts
+++ b/packages/salesforce-adapter/src/change_validators/multiple_defaults.ts
@@ -71,7 +71,7 @@ const createInstanceChangeError = (field: Field, contexts: string[], instance: I
     elemID: instance.elemID,
     severity: 'Warning',
     message: 'Instances cannot have more than one default',
-    detailedMessage: `There cannot be more than one 'default' ${field.name} in instance: ${instanceName} type ${field.parent.elemID.name}.\nThe following ${FIELD_NAME_TO_INNER_CONTEXT_FIELD[field.name] ?? LABEL}s are set to default: ${contexts}`,
+    detailedMessage: `There cannot be more than one 'default' ${field.name} in instance: ${instanceName} type ${field.parent.elemID.name}.\nThe following ${FIELD_NAME_TO_INNER_CONTEXT_FIELD[field.name]?.name ?? LABEL}s are set to default: ${contexts}`,
   }
 }
 
@@ -80,7 +80,7 @@ const createFieldChangeError = (field: Field, contexts: string[]):
   elemID: field.elemID,
   severity: 'Warning',
   message: 'Types cannot have more than one default',
-  detailedMessage: `There cannot be more than one 'default' ${field.name} in type ${field.parent.elemID.name}.\nThe following ${FIELD_NAME_TO_INNER_CONTEXT_FIELD[field.name] ?? LABEL}s are set to default: ${contexts}`,
+  detailedMessage: `There cannot be more than one 'default' ${field.name} in type ${field.parent.elemID.name}.\nThe following ${FIELD_NAME_TO_INNER_CONTEXT_FIELD[field.name]?.name ?? LABEL}s are set to default: ${contexts}`,
 })
 
 const getPicklistMultipleDefaultsErrors = (field: FieldWithValueSet): ChangeError[] => {


### PR DESCRIPTION
Extract string so that error message does not show `[Object object]` anymore

---

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_