### PR TITLE
SALTO-1872: support analytics (NETSUITE)

### DIFF
--- a/packages/lowerdash/src/strings.ts
+++ b/packages/lowerdash/src/strings.ts
@@ -63,3 +63,5 @@ export function *matchAll(str: string, matcher: RegExp): Iterable<RegExpExecArra
     yield match
   }
 }
+
+export const isNumberStr = (str: string): boolean => !Number.isNaN(Number(str)) && str !== ''

--- a/packages/lowerdash/test/strings.test.ts
+++ b/packages/lowerdash/test/strings.test.ts
@@ -153,4 +153,19 @@ describe('strings', () => {
       expect(strings.humanFileSize(50000000000000)).toEqual('45.47 TB')
     })
   })
+
+  describe('isNumberStr', () => {
+    it('should return true on string of number', () => {
+      expect(strings.isNumberStr('500')).toBeTruthy()
+    })
+    it('should return false on a string of nan', () => {
+      expect(strings.isNumberStr('adc')).toBeFalsy()
+    })
+    it('should return true on a string of decimal number', () => {
+      expect(strings.isNumberStr('0.95')).toBeTruthy()
+    })
+    it('should return false on an empty string', () => {
+      expect(strings.isNumberStr('')).toBeFalsy()
+    })
+  })
 })

--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -48,6 +48,8 @@ import { reportdefinitionType } from '../src/type_parsers/report_definition_pars
 import { financiallayoutType } from '../src/type_parsers/financial_layout_parsing/parsed_financial_layout'
 import { SERVER_TIME_TYPE_NAME } from '../src/server_time'
 import { ProjectInfo, createAdditionalFiles, createSdfExecutor } from './sdf_executor'
+import { parsedDatasetType } from '../src/type_parsers/analytics_parsers/parsed_dataset'
+import { parsedWorkbookType } from '../src/type_parsers/analytics_parsers/parsed_workbook'
 
 const log = logger(module)
 const { awu } = collections.asynciterable
@@ -973,17 +975,30 @@ describe('Netsuite adapter E2E with real account', () => {
       })
 
       it('should load all elements successfully', () => {
+        const analyticsTypes = [
+          parsedDatasetType(),
+          parsedWorkbookType(),
+          savedsearchType(),
+          reportdefinitionType(),
+          financiallayoutType(),
+        ]
+        analyticsTypes
+          .forEach(({ type, innerTypes }) => {
+            _.remove(metadataTypes, e => _.isEqual(e.path, type.path))
+            metadataTypes.push(type)
+            metadataTypes.push(...Object.values(innerTypes))
+          })
+
+        const allTypes = (metadataTypes as { elemID: ElemID}[])
+          .concat(createCustomRecordTypes([], standardTypes.customrecordtype.type))
+          .concat([featuresInstance])
+          .concat(objectsToImport)
+          .concat(filesToImport)
+          .concat(existingFileCabinetInstances)
+          .concat(newFileCabinetInstancesElemIds)
+
         const expectedElements = _.uniq(
-          (metadataTypes as { elemID: ElemID }[])
-            .concat(createCustomRecordTypes([], standardTypes.customrecordtype.type))
-            .concat(Object.values(savedsearchType().innerTypes))
-            .concat(Object.values(reportdefinitionType().innerTypes))
-            .concat(Object.values(financiallayoutType().innerTypes))
-            .concat([featuresInstance])
-            .concat(objectsToImport)
-            .concat(filesToImport)
-            .concat(existingFileCabinetInstances)
-            .concat(newFileCabinetInstancesElemIds)
+          allTypes
             .map(type => type.elemID.getFullName())
         ).sort()
 

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -103,11 +103,11 @@ export const allFilters: (LocalFilterCreatorDefinition | RemoteFilterCreatorDefi
   { creator: dataInstancesDiff },
   // addParentFolder must run before replaceInstanceReferencesFilter
   { creator: addParentFolder },
-  { creator: parseReportTypes },
-  // analyticsDefinitionHandle must run before translationConverter and replaceElementReferences
-  // and after parseReportTypes
-  { creator: analyticsDefinitionHandle },
   { creator: convertLists },
+  { creator: parseReportTypes },
+  // analyticsDefinitionHandle must run after convertLists
+  // and before translationConverter and replaceElementReferences
+  { creator: analyticsDefinitionHandle },
   { creator: consistentValues },
   // excludeInstances should run after parseReportTypes, analyticsDefinitionHandle & consistentValues,
   // so users will be able to exclude elements based on parsed values.

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -44,6 +44,8 @@ import dataInstancesAttributes from './filters/data_instances_attributes'
 import dataInstancesNullFields from './filters/data_instances_null_fields'
 import dataInstancesDiff from './filters/data_instances_diff'
 import dataInstancesIdentifiers from './filters/data_instances_identifiers'
+import addReferencingWorkbooks from './filters/add_referencing_workbooks'
+import analyticsDefinitionHandle from './filters/analytics_definition_handle'
 import suiteAppInternalIds from './filters/internal_ids/suite_app_internal_ids'
 import SDFInternalIds from './filters/internal_ids/sdf_internal_ids'
 import accountSpecificValues from './filters/account_specific_values'
@@ -102,9 +104,12 @@ export const allFilters: (LocalFilterCreatorDefinition | RemoteFilterCreatorDefi
   // addParentFolder must run before replaceInstanceReferencesFilter
   { creator: addParentFolder },
   { creator: parseReportTypes },
+  // analyticsDefinitionHandle must run before translationConverter and replaceElementReferences
+  // and after parseReportTypes
+  { creator: analyticsDefinitionHandle },
   { creator: convertLists },
   { creator: consistentValues },
-  // excludeInstances should run after parseReportTypes & consistentValues,
+  // excludeInstances should run after parseReportTypes, analyticsDefinitionHandle & consistentValues,
   // so users will be able to exclude elements based on parsed values.
   { creator: excludeInstances },
   // convertListsToMaps must run after convertLists and consistentValues
@@ -142,8 +147,11 @@ export const allFilters: (LocalFilterCreatorDefinition | RemoteFilterCreatorDefi
   { creator: addBundleReferences },
   // omitFieldsFilter should be the last onFetch filter to run
   { creator: omitFieldsFilter },
-  // additionalChanges should be the first preDeploy filter to run
+  // additionalChanges should be right after addReferencingWorkbooks
+  // (adds required referenced elements to the deployent)
   { creator: additionalChanges },
+  // addReferencingWorkbooks should be the first preDeploy filter to run (adds workbooks to the deployment)
+  { creator: addReferencingWorkbooks },
 ]
 
 // By default we run all filters and provide a client

--- a/packages/netsuite-adapter/src/autogen/types/standard_types/workbook.ts
+++ b/packages/netsuite-adapter/src/autogen/types/standard_types/workbook.ts
@@ -72,7 +72,7 @@ export const workbookType = (): TypeAndInnerTypes => {
     },
     fields: {
       dependency: {
-        refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
+        refType: createRefToElmWithValue(new ListType(BuiltinTypes.STRING)),
         annotations: {
           [CORE_ANNOTATIONS.REQUIRED]: true,
         },
@@ -185,7 +185,7 @@ export const workbookType = (): TypeAndInnerTypes => {
         annotations: {
           [CORE_ANNOTATIONS.REQUIRED]: true,
         },
-      },
+      }, /* Original description:   */
       charts: {
         refType: createRefToElmWithValue(workbook_charts),
         annotations: {

--- a/packages/netsuite-adapter/src/change_validator.ts
+++ b/packages/netsuite-adapter/src/change_validator.ts
@@ -48,6 +48,8 @@ import rolePermissionValidator from './change_validators/role_permission_ids'
 import translationCollectionValidator from './change_validators/translation_collection_references'
 import omitFieldsValidator from './change_validators/omit_fields'
 import unreferencedFileAdditionValidator from './change_validators/unreferenced_file_addition'
+import unreferencedDatasetsValidator from './change_validators/check_referenced_datasets'
+import analyticsSilentFailureValidator from './change_validators/analytics_post_deploy_notification'
 import NetsuiteClient from './client/client'
 import {
   AdditionalDependencies,
@@ -90,6 +92,8 @@ const netsuiteChangeValidators: Record<NetsuiteValidatorName, NetsuiteChangeVali
   translationCollectionReferences: translationCollectionValidator,
   omitFields: omitFieldsValidator,
   unreferencedFileAddition: unreferencedFileAdditionValidator,
+  unreferencedDatasets: unreferencedDatasetsValidator,
+  analyticsSilentFailure: analyticsSilentFailureValidator,
 }
 
 const nonSuiteAppValidators: Record<NonSuiteAppValidatorName, NetsuiteChangeValidator> = {
@@ -174,9 +178,8 @@ const getChangeValidator: ({
         netsuiteValidators,
         validator =>
           (innerChanges: ReadonlyArray<Change>) =>
-            validator(innerChanges, deployReferencedElements, elementsSource, userConfig)
+            validator(innerChanges, deployReferencedElements, elementsSource, userConfig, client)
       )
-
       const safeDeploy = warnStaleData
         ? {
           safeDeploy: (innerChanges: ReadonlyArray<Change>) =>
@@ -192,7 +195,7 @@ const getChangeValidator: ({
 
       const dependedChangeErrors = await validateDependsOnInvalidElement(
         changeErrorsToElementIDs(validatorChangeErrors),
-        changes
+        changes,
       )
       const changeErrors = validatorChangeErrors.concat(dependedChangeErrors)
 

--- a/packages/netsuite-adapter/src/change_validators/analytics_post_deploy_notification.ts
+++ b/packages/netsuite-adapter/src/change_validators/analytics_post_deploy_notification.ts
@@ -1,0 +1,52 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { getChangeData, ChangeError, isInstanceChange, isAdditionOrModificationChange } from '@salto-io/adapter-api'
+import { NetsuiteChangeValidator } from './types'
+import { DATASET, WORKBOOK } from '../constants'
+
+const changeValidator: NetsuiteChangeValidator = async (
+  changes,
+  _deplyReferencedElements,
+  _elementsSource,
+  _config,
+  client,
+) =>
+  changes
+    .filter(isAdditionOrModificationChange)
+    .filter(isInstanceChange)
+    .map(getChangeData)
+    .filter(inst => inst.elemID.typeName === WORKBOOK || inst.elemID.typeName === DATASET)
+    .map(({ elemID }): ChangeError => ({
+      elemID,
+      severity: 'Info',
+      message: 'The deployment might not affect this element',
+      detailedMessage: '',
+      deployActions: {
+        postAction: {
+          title: 'Verify deployment success',
+          description: 'Verify that your selected workbooks or datasets have been successfully deployed in the NetSuite UI.',
+          showOnFailure: false,
+          subActions: [
+            client ? `Go to ${client.url}app/common/report/list.nl` : 'Within the NetSuite UI, navigate to Analytics',
+            'Verify that the changes you made in workbooks/datasets have been successfully deployed',
+          ],
+        },
+      },
+    }))
+
+
+export default changeValidator

--- a/packages/netsuite-adapter/src/change_validators/check_referenced_datasets.ts
+++ b/packages/netsuite-adapter/src/change_validators/check_referenced_datasets.ts
@@ -1,0 +1,114 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { ChangeError, InstanceElement, ReadOnlyElementsSource, ReferenceExpression, getChangeData, isAdditionOrModificationChange, isInstanceChange, isReferenceExpression } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { NetsuiteChangeValidator } from './types'
+import { DATASET, SCRIPT_ID, WORKBOOK } from '../constants'
+
+const { awu } = collections.asynciterable
+
+type UnreferencedDataset = {
+  forInfos: InstanceElement[]
+  forErrors: InstanceElement[]
+}
+
+export const getInstanceReferenceDependencies = (instance: InstanceElement): ReferenceExpression[] =>
+  collections.array.makeArray(instance.value.dependencies?.dependency)
+    .filter(dep => isReferenceExpression(dep))
+
+export const getAllWorkbooksFromElementsSource = async (
+  elementsSource: ReadOnlyElementsSource,
+): Promise<InstanceElement[]> =>
+  awu(await elementsSource.list())
+    .filter(elemID => elemID.typeName === WORKBOOK && elemID.idType === 'instance')
+    .map(async elemId => elementsSource.get(elemId))
+    .toArray()
+
+const getUnreferencedDatasetsDeploymentAndEnvironment = async (
+  changedDatasets: InstanceElement[],
+  changedWorkbooks: InstanceElement[],
+  elementsSource: ReadOnlyElementsSource,
+): Promise<UnreferencedDataset> => {
+  const unreferencedDatasetsWithinDeployment = new Map<string, InstanceElement>()
+  const unreferencedDatasetsWithinEnvironment = new Map<string, InstanceElement>(
+    changedDatasets
+      .map(dataset => [dataset.elemID.createNestedID(SCRIPT_ID).getFullName(), dataset])
+  )
+  changedWorkbooks
+    .flatMap(workbook => getInstanceReferenceDependencies(workbook))
+    .map(dep => dep.elemID.getFullName())
+    .forEach(fullName => unreferencedDatasetsWithinEnvironment.delete(fullName))
+  if (unreferencedDatasetsWithinEnvironment.size > 0) {
+    const allWorkbooks = await getAllWorkbooksFromElementsSource(elementsSource)
+    allWorkbooks
+      .flatMap(workbook => getInstanceReferenceDependencies(workbook))
+      .map(dep => dep.elemID.getFullName())
+      .forEach(fullName => {
+        const dataset = unreferencedDatasetsWithinEnvironment.get(fullName)
+        if (dataset !== undefined) {
+          unreferencedDatasetsWithinDeployment.set(fullName, dataset)
+          unreferencedDatasetsWithinEnvironment.delete(fullName)
+        }
+      })
+  }
+
+  return {
+    forInfos: [...unreferencedDatasetsWithinDeployment.values()],
+    forErrors: [...unreferencedDatasetsWithinEnvironment.values()],
+  }
+}
+
+const changeValidator: NetsuiteChangeValidator = async (changes, _deployReferencedElements, elementsSource) => {
+  const instancesFromAdditionOrModificationChanges = changes
+    .filter(isAdditionOrModificationChange)
+    .filter(isInstanceChange)
+    .map(getChangeData)
+
+  const changedDatasets = instancesFromAdditionOrModificationChanges
+    .filter(inst => inst.elemID.typeName === DATASET)
+
+  if (elementsSource === undefined || changedDatasets.length === 0) {
+    return []
+  }
+
+  const changedWorkbooks = instancesFromAdditionOrModificationChanges
+    .filter(inst => inst.elemID.typeName === WORKBOOK)
+
+  const {
+    forInfos: unreferencedInDeployment,
+    forErrors: unreferencedInEnvironment,
+  } = await getUnreferencedDatasetsDeploymentAndEnvironment(changedDatasets, changedWorkbooks, elementsSource)
+
+  const errors = unreferencedInDeployment
+    .map(({ elemID }): ChangeError => ({
+      elemID,
+      severity: 'Info',
+      message: 'To deploy this, an existing workbook will be re-deployed',
+      detailedMessage: 'A dataset must be deployed alongside a workbook which was connected to it. '
+        + 'Salto will automatically add to the SDF deployment an existing workbook (and the translation collection instances related to that workbook) which was already connected to this dataset. This should not affect the target environment.',
+    })).concat(unreferencedInEnvironment
+      .map(({ elemID }): ChangeError => ({
+        elemID,
+        severity: 'Error',
+        message: 'This dataset cannot be deployed without any connected workbooks',
+        detailedMessage: 'A dataset must be deployed alongside a workbook which was connected to it. '
+          + 'To deploy this dataset, add at least one workbook to your deployment which has this dataset connected.',
+      })))
+  return errors
+}
+
+export default changeValidator

--- a/packages/netsuite-adapter/src/change_validators/extra_reference_dependencies.ts
+++ b/packages/netsuite-adapter/src/change_validators/extra_reference_dependencies.ts
@@ -37,7 +37,8 @@ export const getReferencedElementsForReferrers = async (
   return awu(elements)
     .map(async element => {
       const referencedElements = await getReferencedElements(
-        [element], deployAllReferencedElements
+        [element],
+        deployAllReferencedElements,
       )
       const references = referencedElements
         .filter(referencedElement => !sourceElemIdSet.has(referencedElement.elemID.getFullName()))
@@ -62,7 +63,8 @@ const changeValidator: NetsuiteChangeValidator = async (changes, deployReference
     .filter(isStandardInstanceOrCustomRecordType)
 
   const refererToReferenceElements = await getReferencedElementsForReferrers(
-    sdfChangesData, deployReferencedElements
+    sdfChangesData,
+    deployReferencedElements,
   )
 
   return refererToReferenceElements.map(refererToReferenceElement => {

--- a/packages/netsuite-adapter/src/change_validators/report_types_move_environment.ts
+++ b/packages/netsuite-adapter/src/change_validators/report_types_move_environment.ts
@@ -19,7 +19,7 @@ import { getChangeData, InstanceElement,
   isInstanceChange, ChangeError, isAdditionOrModificationChange } from '@salto-io/adapter-api'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import _ from 'lodash'
-import { DATASET, FINANCIAL_LAYOUT, REPORT_DEFINITION, SAVED_SEARCH, WORKBOOK } from '../constants'
+import { FINANCIAL_LAYOUT, REPORT_DEFINITION, SAVED_SEARCH } from '../constants'
 import { parseDefinition as parseSavedSearchDefinition } from '../type_parsers/saved_search_parsing/saved_search_parser'
 import { parseDefinition as parseReportDefintionDefinition } from '../type_parsers/report_definition_parsing/report_definition_parser'
 import { parseDefinition as parseFinancialLayoutDefinition } from '../type_parsers/financial_layout_parsing/financial_layout_parser'
@@ -45,11 +45,6 @@ Record<string, (definition: string) => Promise<ReportTypes>> = {
   [REPORT_DEFINITION]: parseReportDefintionDefinition,
   [SAVED_SEARCH]: parseSavedSearchDefinition,
 }
-
-export const parsedTypeNames = Object.keys(typeNameToParser).concat([
-  DATASET,
-  WORKBOOK,
-])
 
 const typeNameToName: Record<string, string> = {
   [FINANCIAL_LAYOUT]: 'Financial Layout',

--- a/packages/netsuite-adapter/src/change_validators/report_types_move_environment.ts
+++ b/packages/netsuite-adapter/src/change_validators/report_types_move_environment.ts
@@ -19,7 +19,7 @@ import { getChangeData, InstanceElement,
   isInstanceChange, ChangeError, isAdditionOrModificationChange } from '@salto-io/adapter-api'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import _ from 'lodash'
-import { FINANCIAL_LAYOUT, REPORT_DEFINITION, SAVED_SEARCH } from '../constants'
+import { DATASET, FINANCIAL_LAYOUT, REPORT_DEFINITION, SAVED_SEARCH, WORKBOOK } from '../constants'
 import { parseDefinition as parseSavedSearchDefinition } from '../type_parsers/saved_search_parsing/saved_search_parser'
 import { parseDefinition as parseReportDefintionDefinition } from '../type_parsers/report_definition_parsing/report_definition_parser'
 import { parseDefinition as parseFinancialLayoutDefinition } from '../type_parsers/financial_layout_parsing/financial_layout_parser'
@@ -45,6 +45,11 @@ Record<string, (definition: string) => Promise<ReportTypes>> = {
   [REPORT_DEFINITION]: parseReportDefintionDefinition,
   [SAVED_SEARCH]: parseSavedSearchDefinition,
 }
+
+export const parsedTypeNames = Object.keys(typeNameToParser).concat([
+  DATASET,
+  WORKBOOK,
+])
 
 const typeNameToName: Record<string, string> = {
   [FINANCIAL_LAYOUT]: 'Financial Layout',

--- a/packages/netsuite-adapter/src/change_validators/types.ts
+++ b/packages/netsuite-adapter/src/change_validators/types.ts
@@ -15,10 +15,12 @@
 */
 import { Change, ChangeError, ReadOnlyElementsSource } from '@salto-io/adapter-api'
 import { NetsuiteConfig } from '../config/types'
+import NetsuiteClient from '../client/client'
 
 export type NetsuiteChangeValidator = (
     changes: ReadonlyArray<Change>,
     deployReferencedElements?: boolean,
     elementsSource?: ReadOnlyElementsSource,
-    config?: NetsuiteConfig
+    config?: NetsuiteConfig,
+    client?: NetsuiteClient,
   ) => Promise<ReadonlyArray<ChangeError>>

--- a/packages/netsuite-adapter/src/config/types.ts
+++ b/packages/netsuite-adapter/src/config/types.ts
@@ -220,6 +220,8 @@ export type NetsuiteValidatorName = (
   | 'translationCollectionReferences'
   | 'omitFields'
   | 'unreferencedFileAddition'
+  | 'unreferencedDatasets'
+  | 'analyticsSilentFailure'
 )
 
 export type NonSuiteAppValidatorName = (
@@ -592,6 +594,8 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     translationCollectionReferences: { refType: BuiltinTypes.BOOLEAN },
     omitFields: { refType: BuiltinTypes.BOOLEAN },
     unreferencedFileAddition: { refType: BuiltinTypes.BOOLEAN },
+    unreferencedDatasets: { refType: BuiltinTypes.BOOLEAN },
+    analyticsSilentFailure: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/netsuite-adapter/src/constants.ts
+++ b/packages/netsuite-adapter/src/constants.ts
@@ -101,6 +101,7 @@ export const IS_ATTRIBUTE = 'isAttribute'
 export const ADDITIONAL_FILE_SUFFIX = 'additionalFileSuffix'
 export const LIST_MAPPED_BY_FIELD = 'map_key_field'
 export const INDEX = 'index'
+export const REAL_VALUE_KEY = '#text'
 
 // SDF FileCabinet top level folders
 export const FILE_CABINET_PATH_SEPARATOR = '/'

--- a/packages/netsuite-adapter/src/filters/add_referencing_workbooks.ts
+++ b/packages/netsuite-adapter/src/filters/add_referencing_workbooks.ts
@@ -1,0 +1,153 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { createRefToElmWithValue, Element, getChangeData, InstanceElement, isAdditionOrModificationChange, isElement, isInstanceChange, isInstanceElement, isReferenceExpression, ReadOnlyElementsSource, toChange } from '@salto-io/adapter-api'
+import { transformElement, TransformFunc } from '@salto-io/adapter-utils'
+import { DATASET, SCRIPT_ID, TRANSLATION_COLLECTION, WORKBOOK } from '../constants'
+import { LocalFilterCreator } from '../filter'
+import { getAllWorkbooksFromElementsSource, getInstanceReferenceDependencies } from '../change_validators/check_referenced_datasets'
+import { parsedWorkbookType } from '../type_parsers/analytics_parsers/parsed_workbook'
+
+const resolveTypes = async (
+  elem: Element,
+  elementsSource: ReadOnlyElementsSource,
+): Promise<void> => {
+  if (isInstanceElement(elem)) {
+    const type = await elem.getType(elementsSource)
+    elem.refType = createRefToElmWithValue(type)
+  }
+
+  const transFunc:TransformFunc = async ({ value, field }) => {
+    if (field === undefined) {
+      return value
+    }
+    const fieldType = await field.getType(elementsSource)
+    field.refType = createRefToElmWithValue(fieldType)
+    return value
+  }
+
+  await transformElement({
+    element: elem,
+    transformFunc: transFunc,
+    strict: false,
+    elementsSource,
+  })
+}
+
+const addInnerReferencesTopLevelParent = async (
+  elem: InstanceElement,
+  elementsSource: ReadOnlyElementsSource,
+): Promise<void> => {
+  const transFunc: TransformFunc = async ({ value }) => {
+    if (isReferenceExpression(value) && value.topLevelParent === undefined) {
+      const topLevelParent = (await elementsSource.get(value.elemID.createTopLevelParentID().parent))
+      if (isElement(topLevelParent)) {
+        await resolveTypes(topLevelParent, elementsSource)
+        value.topLevelParent = topLevelParent.clone()
+      }
+      if (value.elemID.typeName === TRANSLATION_COLLECTION
+        && isInstanceElement(value.topLevelParent)
+        && isReferenceExpression(value.topLevelParent.value.name)) {
+        if (value.elemID.isEqual(value.topLevelParent.value.name.elemID)) {
+          value.topLevelParent.value.name.topLevelParent = value.topLevelParent
+        } else {
+          const refTopLevelParent = await elementsSource.get(
+            value.topLevelParent.value.name.elemID.createTopLevelParentID().parent
+          )
+          if (isElement(refTopLevelParent)) {
+            await resolveTypes(refTopLevelParent, elementsSource)
+            value.topLevelParent.value.name.topLevelParent = refTopLevelParent.clone()
+          }
+        }
+      }
+    }
+    return value
+  }
+
+  await transformElement({
+    element: elem,
+    transformFunc: transFunc,
+    strict: false,
+  })
+}
+
+const getUnreferencedDatasets = (
+  datasets: InstanceElement[],
+  workbooks: InstanceElement[],
+): Set<string> => {
+  const datasetElemIdFullNameSet = new Set<string>(
+    datasets
+      .map(dataset => dataset.elemID.createNestedID(SCRIPT_ID).getFullName())
+  )
+
+  workbooks
+    .flatMap(workbook => getInstanceReferenceDependencies(workbook))
+    .map(dep => dep.elemID.getFullName())
+    .forEach(fullName => datasetElemIdFullNameSet.delete(fullName))
+  return datasetElemIdFullNameSet
+}
+
+const getWorkbooksToPush = async (
+  datasets: InstanceElement[],
+  changedWorkbooks: InstanceElement[],
+  elementsSource: ReadOnlyElementsSource
+): Promise<InstanceElement[]> => {
+  const datasetFullNameSet = getUnreferencedDatasets(datasets, changedWorkbooks)
+
+  if (datasetFullNameSet.size === 0) {
+    return []
+  }
+
+  const allWorkbooks = await getAllWorkbooksFromElementsSource(elementsSource)
+
+  return allWorkbooks.reduce(async (acc, workbook) => {
+    if (datasetFullNameSet.size === 0) {
+      return acc
+    }
+    const dependencies = getInstanceReferenceDependencies(workbook)
+    const datasetDependencies = dependencies
+      .map(dep => dep.elemID.getFullName())
+      .filter(dep => datasetFullNameSet.has(dep))
+    if (datasetDependencies.length > 0) {
+      datasetDependencies.forEach(dep => datasetFullNameSet.delete(dep))
+      const clonedWorkbook = workbook.clone()
+      clonedWorkbook.refType = createRefToElmWithValue(parsedWorkbookType().type)
+      await addInnerReferencesTopLevelParent(clonedWorkbook, elementsSource)
+      const workbooks = await acc
+      return workbooks.concat(clonedWorkbook)
+    }
+    return acc
+  }, Promise.resolve([] as InstanceElement[]))
+}
+
+const filterCreator: LocalFilterCreator = ({ elementsSource }) => ({
+  name: 'pushReferencingWorkbooks',
+  preDeploy: async changes => {
+    const instancesFromAdditionOrModificationChanges = changes
+      .filter(isAdditionOrModificationChange)
+      .filter(isInstanceChange)
+      .map(getChangeData)
+
+    const workbooksToPush = await getWorkbooksToPush(
+      instancesFromAdditionOrModificationChanges.filter(instance => instance.elemID.typeName === DATASET),
+      instancesFromAdditionOrModificationChanges.filter(instance => instance.elemID.typeName === WORKBOOK),
+      elementsSource,
+    )
+    changes.push(...workbooksToPush.map(workbook => toChange({ before: workbook, after: workbook })))
+  },
+})
+
+export default filterCreator

--- a/packages/netsuite-adapter/src/filters/analytics_definition_handle.ts
+++ b/packages/netsuite-adapter/src/filters/analytics_definition_handle.ts
@@ -1,0 +1,361 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { BuiltinTypes, Change, createRefToElmWithValue, Element, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, isInstanceElement, isListType, isObjectType, ObjectType, Value, Values } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { TransformFuncArgs, transformValues, WALK_NEXT_STEP, WalkOnFunc, walkOnValue } from '@salto-io/adapter-utils'
+import { parse, j2xParser } from 'fast-xml-parser'
+import { decode, encode } from 'he'
+import { collections, strings } from '@salto-io/lowerdash'
+import { logger } from '@salto-io/logging'
+import { APPLICATION_ID, DATASET, REAL_VALUE_KEY, SCRIPT_ID, SOAP_SCRIPT_ID, WORKBOOK } from '../constants'
+import { LocalFilterCreator } from '../filter'
+import { ATTRIBUTE_PREFIX, CDATA_TAG_NAME } from '../client/constants'
+import { parsedWorkbookType } from '../type_parsers/analytics_parsers/parsed_workbook'
+import { parsedDatasetType } from '../type_parsers/analytics_parsers/parsed_dataset'
+import { TypeAndInnerTypes } from '../types/object_types'
+import { AnalyticOriginalFields, CHART_IDS, DATA_VIEW_IDS, DEFAULT_VALUE, DEFAULT_XML_TYPE, DEFINITION, DEPENDENCIES, DO_NOT_ADD, EmptyObject, EXPRESSION_VALUE_VALUE_REGEX, FALSE, FIELD_DEFINITION, FIELD_TYPE, fieldsToOmitFromDefinition, fieldsToOmitFromOriginal, FieldWithType, ITEM, NAME, originalFields, OriginalWorkbookArrays, PIVOT_IDS, ROOT, StringToStringRecord, TRANSLATION_SCRIPT_ID, TRUE, TValuesToIgnore, TYPE, XML_TYPE, xmlType } from '../type_parsers/analytics_parsers/analytics_constants'
+import { captureServiceIdInfo } from '../service_id_info'
+import { workbookType } from '../autogen/types/standard_types/workbook'
+import { datasetType } from '../autogen/types/standard_types/dataset'
+
+const log = logger(module)
+const { awu } = collections.asynciterable
+
+const isNotAtrophiedScriptIdField = (name: string, val: Value): boolean =>
+  (name.endsWith(SOAP_SCRIPT_ID) ? !_.isEqual(val, { [TYPE]: xmlType.null }) : true)
+
+const fetchTransformFunc = async (
+  { value, field, path }: TransformFuncArgs,
+  type: ObjectType,
+): Promise<Value> => {
+  const fieldType = path?.isTopLevel() ? type : await field?.getType()
+  if (
+    fieldType === undefined
+    && path !== undefined
+    && isNotAtrophiedScriptIdField(path.getFullName(), value)
+  ) {
+    log.debug('unexpected path in analytics type. Path: %s', path?.getFullName())
+  }
+  if (
+    fieldType?.elemID.isEqual(BuiltinTypes.UNKNOWN.elemID)
+    && !(_.isPlainObject(value) && value[TYPE] === xmlType.null)
+    && path !== undefined
+    && !EXPRESSION_VALUE_VALUE_REGEX.test(path.getFullName())
+  ) {
+    log.debug('Found a value with an unkown type. path: %s, value: %o', path?.getFullName(), value)
+  }
+  if (_.isPlainObject(value)) {
+    if (value[TYPE] === xmlType.null) {
+      return undefined
+    }
+    if (value[TYPE] === xmlType.array) {
+      return collections.array.makeArray(value[ITEM])
+    }
+    if (value[TYPE] === xmlType.boolean) {
+      return value[REAL_VALUE_KEY]
+    }
+    if (value[TYPE] === xmlType.string) {
+      return String(value[REAL_VALUE_KEY])
+    }
+    if (FIELD_DEFINITION in value) {
+      if (!isObjectType(fieldType) || !(XML_TYPE in fieldType.annotations)) {
+        log.debug('unexpected _T_ field in analytic instance. Path: %s', path?.getFullName())
+        return {
+          [FIELD_TYPE]: value[FIELD_DEFINITION],
+          ..._.omit(value, FIELD_DEFINITION),
+        }
+      }
+      return TValuesToIgnore.has(value[FIELD_DEFINITION]) ? _.omit(value, FIELD_DEFINITION) : {
+        [value[FIELD_DEFINITION]]: _.omit(value, FIELD_DEFINITION),
+      }
+    }
+    return value
+  }
+  if (fieldType?.elemID.isEqual(BuiltinTypes.STRING.elemID)) {
+    return String(value)
+  }
+  return value
+}
+
+const createAnalyticsInstance = async (
+  instance: InstanceElement,
+  analyticsType: ObjectType,
+): Promise<void> => {
+  const definitionValues = _.omit(parse(instance.value[DEFINITION], {
+    attributeNamePrefix: ATTRIBUTE_PREFIX,
+    ignoreAttributes: false,
+    tagValueProcessor: val => decode(val),
+  })[ROOT], fieldsToOmitFromDefinition)
+
+  const updatedValues = await transformValues({
+    values: definitionValues,
+    type: analyticsType,
+    transformFunc: args => fetchTransformFunc(args, analyticsType),
+    strict: false,
+    pathID: instance.elemID,
+  })
+
+  if (updatedValues !== undefined) {
+    instance.value = {
+      ..._.omit(instance.value, fieldsToOmitFromOriginal),
+      ...updatedValues,
+    }
+  }
+}
+
+const createEmptyObjectOfType = async (
+  fieldType: ObjectType,
+  key: string,
+): Promise<EmptyObject> => {
+  if (DEFAULT_VALUE in fieldType.fields[key].annotations) {
+    return fieldType.fields[key].annotations[DEFAULT_VALUE]
+  }
+  const keyType = await fieldType.fields[key].getType()
+
+  if (isListType(keyType)) {
+    return {
+      [TYPE]: xmlType.array,
+    }
+  }
+
+  return {
+    [TYPE]: xmlType.null,
+  }
+}
+
+const handleTypeField = (value: Value): FieldWithType => {
+  if (Array.isArray(value)) {
+    return {
+      [TYPE]: xmlType.array,
+      [ITEM]: value,
+    }
+  }
+  if (_.isBoolean(value)) {
+    return {
+      [TYPE]: xmlType.boolean,
+      [REAL_VALUE_KEY]: value ? TRUE : FALSE,
+    }
+  }
+  if (_.isString(value) && strings.isNumberStr(value)) {
+    return {
+      [TYPE]: xmlType.string,
+      [REAL_VALUE_KEY]: value,
+    }
+  }
+  return value
+}
+
+const handleFieldDefinition = (value: Value): Value => {
+  if (_.isPlainObject(value)) {
+    const innerKeys = Object.keys(value)
+    if (innerKeys.includes(FIELD_TYPE)) {
+      value[FIELD_DEFINITION] = value[FIELD_TYPE]
+      delete value[FIELD_TYPE]
+    } else if (innerKeys.includes(FIELD_DEFINITION) && !TValuesToIgnore.has(value[FIELD_DEFINITION])) {
+      // We assume that we have exactly 2 keys because the only option for an object
+      // to include the FIELD_DEFINITION key is if we added it in addMissingFields and we do so in 2 options:
+      // 1. The field DEFAULT_XML_TYPE exists
+      // 2. The field DEFAULT_XML_TYPE does not exist (not in the TValuesToIgnore) and there is only one other key
+      if (innerKeys.length !== 2) {
+        log.warn('The number of keys in an object with FIELD_DEFINITION is not 2')
+        return value
+      }
+      const otherKey = innerKeys.filter(innerKey => innerKey !== FIELD_DEFINITION)[0]
+      return {
+        [FIELD_DEFINITION]: value[FIELD_DEFINITION],
+        ...value[otherKey],
+      }
+    }
+  }
+  return value
+}
+
+const matchToXmlObjectForm = (instance: InstanceElement, definitionValues: Values): void => {
+  const deployWalkFunc: WalkOnFunc = ({ value }) => {
+    if (_.isPlainObject(value)) {
+      const keys = Object.keys(value)
+
+      keys.forEach(key => {
+        value[key] = handleFieldDefinition(value[key])
+      })
+
+      // to prevent endless recursion in children arrays
+      if (!(TYPE in value)) {
+        keys.forEach(key => {
+          value[key] = handleTypeField(value[key])
+        })
+      }
+    } else if (Array.isArray(value)) {
+      value.forEach((_val, index) => {
+        value[index] = handleFieldDefinition(value[index])
+        value[index] = handleTypeField(value[index])
+      })
+    }
+    return WALK_NEXT_STEP.RECURSE
+  }
+
+  walkOnValue({
+    elemId: instance.elemID,
+    value: definitionValues,
+    func: deployWalkFunc,
+  })
+}
+
+const addMissingFields = async (
+  instance: InstanceElement,
+  definitionValues: Values,
+  analyticsType: ObjectType,
+): Promise<void> => {
+  const deployTransformFunc = async (
+    { value, field, path }: TransformFuncArgs,
+  ): Promise<Value> => {
+    const fieldType = path?.isTopLevel() ? analyticsType : await field?.getType()
+    if (isObjectType(fieldType) && _.isPlainObject(value) && !(TYPE in value)) {
+      if (XML_TYPE in fieldType.annotations
+        && Object.keys(value).length === 1
+        && fieldType.annotations[DEFAULT_XML_TYPE] === undefined) {
+        const [key] = Object.keys(value)
+        value[FIELD_DEFINITION] = key
+      } else {
+        if (fieldType.annotations[DEFAULT_XML_TYPE] !== undefined) {
+          value[FIELD_DEFINITION] = fieldType.annotations[DEFAULT_XML_TYPE]
+        }
+        await awu(Object.keys(fieldType.fields))
+          .filter(key => !(key in value) && fieldType.fields[key].annotations[DO_NOT_ADD] !== true)
+          .forEach(async key => {
+            value[key] = await createEmptyObjectOfType(fieldType, key)
+          })
+      }
+    }
+    return value
+  }
+
+  await transformValues({
+    values: definitionValues,
+    type: analyticsType,
+    transformFunc: deployTransformFunc,
+    strict: false,
+    pathID: instance.elemID,
+  })
+}
+
+const createOriginalArray = (
+  arrName: string,
+  value: Values,
+): StringToStringRecord[] =>
+  collections.array.makeArray(value.Workbook?.[arrName])
+    .filter(_.isString)
+    .flatMap((val: string) => ({ [SCRIPT_ID]: val }))
+
+const createOriginalArrays = (value: Values): OriginalWorkbookArrays => ({
+  pivots: {
+    pivot: createOriginalArray(PIVOT_IDS, value),
+  },
+  charts: {
+    chart: createOriginalArray(CHART_IDS, value),
+  },
+  tables: {
+    table: createOriginalArray(DATA_VIEW_IDS, value),
+  },
+})
+
+const createDefinitionName = (instance: InstanceElement, definitionValues: Values): void => {
+  const name = instance.value[NAME]?.[REAL_VALUE_KEY]
+  const capture = _.isString(name) ? captureServiceIdInfo(name) : []
+  definitionValues[NAME] = (capture.length === 1) ? {
+    [TRANSLATION_SCRIPT_ID]: capture[0].serviceId,
+  } : instance.value[NAME]
+}
+
+const returnToOriginalShape = async (
+  instance: InstanceElement,
+): Promise<AnalyticOriginalFields> => {
+  const analyticsType = await instance.getType()
+
+  const arrays = (analyticsType.elemID.typeName === WORKBOOK) ? createOriginalArrays(instance.value) : []
+
+  const definitionValues: Values = _.omit(instance.value, Object.values(originalFields))
+
+  await addMissingFields(instance, definitionValues, analyticsType)
+
+  matchToXmlObjectForm(instance, definitionValues)
+
+  createDefinitionName(instance, definitionValues)
+
+  // eslint-disable-next-line new-cap
+  const xmlString = new j2xParser({
+    attributeNamePrefix: ATTRIBUTE_PREFIX,
+    format: true,
+    ignoreAttributes: false,
+    cdataTagName: CDATA_TAG_NAME,
+    tagValueProcessor: val => encode(val.toString()),
+  }).parse({ [ROOT]: definitionValues })
+
+  return {
+    [NAME]: instance.value[NAME],
+    [SCRIPT_ID]: instance.value[SCRIPT_ID],
+    [DEPENDENCIES]: instance.value[DEPENDENCIES],
+    [APPLICATION_ID]: instance.value[APPLICATION_ID],
+    [DEFINITION]: xmlString,
+    ...arrays,
+  }
+}
+
+const changeType = async (
+  { type: analyticType, innerTypes }: TypeAndInnerTypes,
+  elements: Element[],
+): Promise<void> => {
+  _.remove(elements, e => _.isEqual(e.path, analyticType.path))
+  elements.push(analyticType)
+  elements.push(...Object.values(innerTypes))
+
+  const analyticInstances = elements
+    .filter(isInstanceElement)
+    .filter(elem => elem.elemID.typeName === analyticType.elemID.name)
+  await awu(analyticInstances)
+    .forEach(async instance => {
+      instance.refType = createRefToElmWithValue(analyticType)
+      await createAnalyticsInstance(instance, analyticType)
+    })
+}
+
+const filterCreator: LocalFilterCreator = () => ({
+  name: 'parseAnalytics',
+  onFetch: async elements => {
+    await changeType(parsedWorkbookType(), elements)
+    await changeType(parsedDatasetType(), elements)
+  },
+
+  preDeploy: async (changes: Change[]) => {
+    const instanceElemsFromAdditionOrModification = changes
+      .filter(isAdditionOrModificationChange)
+      .filter(isInstanceChange)
+      .map(getChangeData)
+    const originalTypeMap: Record<string, ObjectType> = {
+      [DATASET]: datasetType().type,
+      [WORKBOOK]: workbookType().type,
+    }
+    await awu(instanceElemsFromAdditionOrModification)
+      .filter(instance => instance.elemID.typeName === DATASET || instance.elemID.typeName === WORKBOOK)
+      .forEach(async instance => {
+        instance.value = await returnToOriginalShape(instance)
+        instance.refType = createRefToElmWithValue(originalTypeMap[instance.elemID.typeName])
+      })
+  },
+})
+
+export default filterCreator

--- a/packages/netsuite-adapter/src/filters/convert_lists.ts
+++ b/packages/netsuite-adapter/src/filters/convert_lists.ts
@@ -22,8 +22,9 @@ import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { LocalFilterCreator } from '../filter'
 import { datasetType } from '../autogen/types/standard_types/dataset'
+import { workbookType } from '../autogen/types/standard_types/workbook'
 import { isCustomRecordType, isFileCabinetInstance } from '../types'
-import { parsedTypeNames } from '../change_validators/report_types_move_environment'
+import { typeNameToParser } from '../change_validators/report_types_move_environment'
 
 const { awu } = collections.asynciterable
 
@@ -31,6 +32,7 @@ type FieldFullNameToOrderBy = Map<string, string | undefined>
 
 const unorderedListFields: FieldFullNameToOrderBy = new Map([
   [datasetType().innerTypes.dataset_dependencies.fields.dependency.elemID.getFullName(), undefined],
+  [workbookType().innerTypes.workbook_dependencies.fields.dependency.elemID.getFullName(), undefined],
 ])
 
 const castAndOrderLists: TransformFunc = async ({ value, field }) => {
@@ -61,7 +63,7 @@ const filterCreator: LocalFilterCreator = () => ({
       .filter(isInstanceElement)
       // lists in report types instances are handled in parseReportTypes filter
       // file&folder instances have no list fields so we can skip them
-      .filter(inst => !(inst.elemID.typeName in parsedTypeNames) && !isFileCabinetInstance(inst))
+      .filter(inst => !(inst.elemID.typeName in typeNameToParser) && !isFileCabinetInstance(inst))
       .forEach(async inst => {
         inst.value = await transformValues({
           values: inst.value,

--- a/packages/netsuite-adapter/src/filters/convert_lists.ts
+++ b/packages/netsuite-adapter/src/filters/convert_lists.ts
@@ -23,7 +23,7 @@ import _ from 'lodash'
 import { LocalFilterCreator } from '../filter'
 import { datasetType } from '../autogen/types/standard_types/dataset'
 import { isCustomRecordType, isFileCabinetInstance } from '../types'
-import { typeNameToParser } from '../change_validators/report_types_move_environment'
+import { parsedTypeNames } from '../change_validators/report_types_move_environment'
 
 const { awu } = collections.asynciterable
 
@@ -61,7 +61,7 @@ const filterCreator: LocalFilterCreator = () => ({
       .filter(isInstanceElement)
       // lists in report types instances are handled in parseReportTypes filter
       // file&folder instances have no list fields so we can skip them
-      .filter(inst => !(inst.elemID.typeName in typeNameToParser) && !isFileCabinetInstance(inst))
+      .filter(inst => !(inst.elemID.typeName in parsedTypeNames) && !isFileCabinetInstance(inst))
       .forEach(async inst => {
         inst.value = await transformValues({
           values: inst.value,

--- a/packages/netsuite-adapter/src/filters/data_instances_internal_id.ts
+++ b/packages/netsuite-adapter/src/filters/data_instances_internal_id.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
-import { collections } from '@salto-io/lowerdash'
+import { collections, strings } from '@salto-io/lowerdash'
 import { CORE_ANNOTATIONS, ElemID, InstanceElement, isInstanceElement, isObjectType, ReferenceExpression, TypeElement } from '@salto-io/adapter-api'
 import { naclCase, TransformFunc, transformValues } from '@salto-io/adapter-utils'
 import { isStandardType, isDataObjectType, isFileCabinetType } from '../types'
@@ -25,11 +25,9 @@ import { LocalFilterCreator } from '../filter'
 const log = logger(module)
 const { awu } = collections.asynciterable
 
-const isNumberStr = (str: string): boolean => !Number.isNaN(Number(str))
-
 const getSubInstanceName = (path: ElemID, internalId: string): string => {
   const name = _.findLast(
-    path.getFullNameParts(), part => !isNumberStr(part) && part !== RECORD_REF
+    path.getFullNameParts(), part => !strings.isNumberStr(part) && part !== RECORD_REF
   )
   return naclCase(`${path.typeName}_${name}_${internalId}`)
 }
@@ -63,7 +61,7 @@ const filterCreator: LocalFilterCreator = () => ({
 
       const originalInternalId = value[INTERNAL_ID]
       const fieldType = await field?.getType()
-      const isInsideList = path.getFullNameParts().some(part => isNumberStr(part))
+      const isInsideList = path.getFullNameParts().some(part => strings.isNumberStr(part))
 
       if (!(isObjectType(fieldType)
         && (isInsideList

--- a/packages/netsuite-adapter/src/filters/parse_report_types.ts
+++ b/packages/netsuite-adapter/src/filters/parse_report_types.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-import { getChangeData, InstanceElement, isInstanceChange, isInstanceElement, isObjectType, ObjectType } from '@salto-io/adapter-api'
+import { getChangeData, InstanceElement, isInstanceChange, isInstanceElement, ObjectType } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { collections } from '@salto-io/lowerdash'
 import { resolvePath, setPath } from '@salto-io/adapter-utils'
@@ -83,8 +83,7 @@ const filterCreator: LocalFilterCreator = ({ elementsSource }) => ({
     }
     await awu([reportdefinitionType, savedsearchType, financiallayoutType]).forEach(async parsedType => {
       const { type, innerTypes } = parsedType()
-      _.remove(elements, e => isObjectType(e) && e.elemID.name === type.elemID.name)
-      _.remove(elements, e => isObjectType(e) && e.elemID.name.startsWith(type.elemID.name))
+      _.remove(elements, e => _.isEqual(e.path, type.path))
       const instances = _.remove(elements, e => isInstanceElement(e)
           && e.elemID.typeName === type.elemID.name)
       elements.push(type)

--- a/packages/netsuite-adapter/src/filters/translation_converter.ts
+++ b/packages/netsuite-adapter/src/filters/translation_converter.ts
@@ -20,7 +20,7 @@ import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import { LocalFilterCreator } from '../filter'
 import { ATTRIBUTE_PREFIX } from '../client/constants'
-import { CENTER_CATEGORY, CENTER_TAB, DATASET, NETSUITE, SUBTAB, TRANSLATION_COLLECTION, WORKBOOK } from '../constants'
+import { CENTER_CATEGORY, CENTER_TAB, DATASET, NETSUITE, REAL_VALUE_KEY, SUBTAB, TRANSLATION_COLLECTION, WORKBOOK } from '../constants'
 import { isCustomRecordType } from '../types'
 
 const { awu } = collections.asynciterable
@@ -36,7 +36,7 @@ const FIELDS_TO_CONVERT = [
   new ElemID(NETSUITE, CENTER_TAB, 'field', 'label'),
   new ElemID(NETSUITE, SUBTAB, 'field', 'title'),
 ]
-const REAL_VALUE_KEY = '#text'
+
 const TRANSLATE_KEY = 'translate'
 
 const getTranslateFieldName = (key: string): string => `${key}Translate`

--- a/packages/netsuite-adapter/src/reference_dependencies.ts
+++ b/packages/netsuite-adapter/src/reference_dependencies.ts
@@ -15,15 +15,12 @@
 */
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
-import {
-  isInstanceElement, isPrimitiveType, ElemID, getFieldType,
-  isReferenceExpression, Value, isServiceId, isObjectType, ChangeDataType, TopLevelElement,
-} from '@salto-io/adapter-api'
+import { isInstanceElement, isPrimitiveType, ElemID, getFieldType, isReferenceExpression, Value, isServiceId, isObjectType, ChangeDataType, TopLevelElement } from '@salto-io/adapter-api'
 import { transformElement, TransformFunc } from '@salto-io/adapter-utils'
 import { values as lowerDashValues, collections } from '@salto-io/lowerdash'
 import wu from 'wu'
 import os from 'os'
-import { CUSTOM_SEGMENT, DATASET, NETSUITE, SCRIPT_ID, TRANSLATION_COLLECTION, WORKBOOK } from './constants'
+import { CUSTOM_SEGMENT, NETSUITE, SCRIPT_ID, TRANSLATION_COLLECTION } from './constants'
 import { isCustomRecordType } from './types'
 
 const { awu } = collections.asynciterable
@@ -36,7 +33,7 @@ const isTopLevelElement = (value: unknown): value is TopLevelElement =>
 const elementFullName = (element: ChangeDataType): string => element.elemID.getFullName()
 
 export const findDependingElementsFromRefs = async (
-  element: ChangeDataType
+  element: ChangeDataType,
 ): Promise<TopLevelElement[]> => {
   const visitedIdToElement = new Map<string, TopLevelElement>()
   const isRefToServiceId = async (
@@ -80,7 +77,7 @@ export const findDependingElementsFromRefs = async (
  * Here we add automatically all of the referenced elements (recursively).
  */
 const getAllReferencedElements = async (
-  sourceElements: ReadonlyArray<ChangeDataType>
+  sourceElements: ReadonlyArray<ChangeDataType>,
 ): Promise<ReadonlyArray<TopLevelElement>> => {
   const visited = new Set<string>(sourceElements.map(elementFullName))
   const getNewReferencedElement = async (
@@ -106,7 +103,7 @@ const getAllReferencedElements = async (
  * Here we add manually all of the quirks we identified.
  */
 export const getRequiredReferencedElements = async (
-  sourceElements: ReadonlyArray<ChangeDataType>
+  sourceElements: ReadonlyArray<ChangeDataType>,
 ): Promise<ReadonlyArray<TopLevelElement>> => {
   const getReferencedElement = (
     value: Value,
@@ -134,11 +131,6 @@ export const getRequiredReferencedElements = async (
           return getReferencedElement(
             element.value.recordtype,
             elem => isObjectType(elem) && isCustomRecordType(elem)
-          )
-        case WORKBOOK:
-          return getReferencedElement(
-            element.value.dependencies?.dependency,
-            elem => isInstanceElement(elem) && elem.elemID.typeName === DATASET
           )
         default:
           return undefined
@@ -178,7 +170,7 @@ export const getRequiredReferencedElements = async (
 
 export const getReferencedElements = async (
   elements: ReadonlyArray<ChangeDataType>,
-  deployAllReferencedElements: boolean
+  deployAllReferencedElements: boolean,
 ): Promise<ReadonlyArray<TopLevelElement>> => (
   deployAllReferencedElements
     ? getAllReferencedElements(elements)

--- a/packages/netsuite-adapter/src/type_parsers/analytics_parsers/analytics_constants.ts
+++ b/packages/netsuite-adapter/src/type_parsers/analytics_parsers/analytics_constants.ts
@@ -1,0 +1,214 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { types } from '@salto-io/lowerdash'
+import { APPLICATION_ID, REAL_VALUE_KEY, SCRIPT_ID } from '../../constants'
+
+// annotations
+export const DEFAULT_VALUE = 'default_value'
+export const XML_TYPE = 'xml_type'
+export const DEFAULT_XML_TYPE = 'default_xml_type'
+export const DO_NOT_ADD = 'do_not_add'
+export const IGNORE_T_VALUE = 'ignore_t_value'
+
+// xml fields
+export const FIELD_DEFINITION = '_T_'
+export const TYPE = '@_type'
+export const FIELD_TYPE = 'fieldType'
+
+// const strings
+export const ROOT = 'root'
+export const DEFINITION = 'definition'
+export const ITEM = '_ITEM_'
+export const TRUE = 'true'
+export const FALSE = 'false'
+export const DEPENDENCIES = 'dependencies'
+export const NAME = 'name'
+export const TRANSLATION_SCRIPT_ID = 'translationScriptId'
+export const CHARTS = 'charts'
+export const PIVOTS = 'pivots'
+export const TABLES = 'tables'
+export const DATA_VIEWS = 'dataViews'
+export const CHART_IDS = 'chartIDs'
+export const PIVOT_IDS = 'pivotIDs'
+export const DATA_VIEW_IDS = 'dataViewIDs'
+export const EXPRESSION_VALUE_VALUE_REGEX = /expressions\.\d+\.value\.value$/
+
+// types
+
+type AudienceItem = unknown
+type ExpressionSubType = unknown
+type ExpressionUiData = unknown
+export type ApplicationId = unknown
+export type DefinitionId = unknown
+
+export const enum xmlType {
+  array = 'array',
+  boolean = 'boolean',
+  string = 'string',
+  null = 'null',
+}
+export type FieldWithType = {
+  [TYPE]: xmlType
+  [ITEM]?: unknown[]
+  [REAL_VALUE_KEY]?: string
+}
+export type Dependencies = {
+  dependency: string[]
+}
+
+export type Audience = {
+  AudienceItems?: AudienceItem[]
+  isPublic?: boolean
+}
+
+export type BaseRecord = {
+  id?: string
+  label?: string
+}
+
+export type TranslationType = {
+  translationScriptId?: string
+}
+
+export type Join = {
+  id?: string
+  targetRecordType?: string
+}
+
+export type JoinTrail = {
+  baseRecord?: BaseRecord
+  joins?: Join[]
+}
+
+export type FieldReference = {
+  id?: string
+  joinTrail?: JoinTrail
+  label?: string
+  uniqueId?: string
+  fieldValidityState?: string
+}
+
+export type FormulaFormula = {
+  dataType?: string
+  formulaSQL?: string
+  id?: string
+  label?: TranslationType
+  uniqueId?: string
+}
+
+export type Formula = {
+  // eslint-disable-next-line no-use-before-define
+  fields?: FieldOrFormula[]
+  formula?: FormulaFormula
+}
+
+export type FieldOrFormula = {
+  fieldReference?: FieldReference
+  dataSetFormula?: Formula
+}
+
+export type ExpressionValue = {
+  type?: string
+  value?: unknown
+}
+
+export type Expression = {
+  label?: string
+  subType?: ExpressionSubType
+  uiData?: ExpressionUiData[]
+  value?: ExpressionValue
+}
+
+export type Operator = {
+  code?: string
+}
+
+export type Meta = {
+  selectorType?: string
+  subType?: string
+}
+
+export type TargetFieldContext = {
+  name?: string
+}
+
+export type Filter = {
+  caseSensitive?: boolean
+  expressions?: Expression[]
+  field?: FieldOrFormula
+  fieldStateName?: string
+  meta?: Meta
+  operator?: Operator
+  targetFieldContext?: TargetFieldContext
+}
+
+export type Condition = {
+  operator?: Operator
+  // eslint-disable-next-line no-use-before-define
+  children?: ConditionOrFilter[]
+  targetFieldContext?: TargetFieldContext
+  meta?: Meta
+  field?: FieldOrFormula
+  fieldStateName?: string
+}
+
+export type ConditionOrFilter = {
+  condition?: Condition
+  filter?: Filter
+}
+export type workbookListsElement = {
+  [SCRIPT_ID]: string
+}
+
+export type AnalyticOriginalFields = {
+  [SCRIPT_ID]: string
+  [NAME]: string
+  [DEPENDENCIES]?: {
+    dependency?: string[]
+  }
+  [DEFINITION]?: string
+  [APPLICATION_ID]?: string
+}
+
+export type StringToStringRecord = { [SCRIPT_ID]: string }
+export type OriginalWorkbookArrays = Record<string, Record<string, StringToStringRecord[]>>
+export type EmptyObject = {
+  [TYPE]: xmlType.array | xmlType.null
+}
+
+// containers of special fields
+export const TValuesToIgnore = new Set([
+  'workbook',
+  'dataSet',
+  'formula',
+])
+export const fieldsToOmitFromDefinition = [
+  NAME,
+]
+export const fieldsToOmitFromOriginal = [
+  DEFINITION,
+  TABLES,
+  CHARTS,
+  PIVOTS,
+]
+export const originalFields: types.TypeKeysEnum<AnalyticOriginalFields> = {
+  [SCRIPT_ID]: SCRIPT_ID,
+  [NAME]: NAME,
+  [DEPENDENCIES]: DEPENDENCIES,
+  [DEFINITION]: DEFINITION,
+  [APPLICATION_ID]: APPLICATION_ID,
+}

--- a/packages/netsuite-adapter/src/type_parsers/analytics_parsers/parsed_dataset.ts
+++ b/packages/netsuite-adapter/src/type_parsers/analytics_parsers/parsed_dataset.ts
@@ -1,0 +1,415 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, ObjectType, createRestriction, ListType, createRefToElmWithValue } from '@salto-io/adapter-api'
+import { createMatchingObjectType } from '@salto-io/adapter-utils'
+import { TypeAndInnerTypes } from '../../types/object_types'
+import * as constants from '../../constants'
+import { fieldTypes } from '../../types/field_types'
+import { AnalyticOriginalFields, ApplicationId, Audience, BaseRecord, Condition, ConditionOrFilter, DEFAULT_VALUE, DEFAULT_XML_TYPE, DO_NOT_ADD, DefinitionId, Dependencies, Expression, ExpressionValue, FieldOrFormula, FieldReference, Filter, Formula, FormulaFormula, IGNORE_T_VALUE, Join, JoinTrail, Meta, Operator, TargetFieldContext, TranslationType, XML_TYPE } from './analytics_constants'
+
+type Column = {
+  alias?: string
+  columnId?: number
+  field?: FieldOrFormula
+  label?: TranslationType
+}
+
+type DatasetDefinitionType = {
+  applicationId?: ApplicationId
+  audience?: Audience
+  baseRecord?: BaseRecord
+  columns?: Column[]
+  criteria?: ConditionOrFilter
+  description?: TranslationType
+  formulas?: Formula[]
+  id?: DefinitionId
+  ownerId?: number
+  version?: string
+}
+
+export type Dataset = AnalyticOriginalFields & DatasetDefinitionType
+
+export const parsedDatasetType = (): TypeAndInnerTypes => {
+  const innerTypes: Record<string, ObjectType> = {}
+
+  const datasetAudienceElemID = new ElemID(constants.NETSUITE, 'dataset_audience')
+  const datasetAudience = createMatchingObjectType<Audience>({
+    elemID: datasetAudienceElemID,
+    annotations: {
+    },
+    fields: {
+      AudienceItems: { refType: new ListType(BuiltinTypes.UNKNOWN) },
+      isPublic: { refType: BuiltinTypes.BOOLEAN },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.DATASET],
+  })
+  innerTypes.datasetAudience = datasetAudience
+
+  const datasetDependenciesElemID = new ElemID(constants.NETSUITE, 'dataset_dependencies')
+  const datasetDependencies = createMatchingObjectType<Dependencies>({
+    elemID: datasetDependenciesElemID,
+    annotations: {
+    },
+    fields: {
+      dependency: {
+        refType: new ListType(BuiltinTypes.STRING),
+        annotations: {
+          _required: true,
+        },
+      },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.DATASET],
+  })
+  innerTypes.datasetDependencies = datasetDependencies
+
+  const datasetBaseRecordElemID = new ElemID(constants.NETSUITE, 'dataset_base_record')
+  const datasetBaseRecord = createMatchingObjectType<BaseRecord>({
+    elemID: datasetBaseRecordElemID,
+    annotations: {
+    },
+    fields: {
+      id: { refType: BuiltinTypes.STRING },
+      label: { refType: BuiltinTypes.STRING },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.DATASET],
+  })
+  innerTypes.datasetBaseRecord = datasetBaseRecord
+
+  const datasetJoinElemID = new ElemID(constants.NETSUITE, 'dataset_join')
+  const datasetJoin = createMatchingObjectType<Join>({
+    elemID: datasetJoinElemID,
+    annotations: {
+    },
+    fields: {
+      id: { refType: BuiltinTypes.STRING },
+      targetRecordType: { refType: BuiltinTypes.STRING },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.DATASET],
+  })
+  innerTypes.datasetJoin = datasetJoin
+
+  const datasetJoinTrailElemID = new ElemID(constants.NETSUITE, 'dataset_join_trail')
+  const datasetJoinTrail = createMatchingObjectType<JoinTrail>({
+    elemID: datasetJoinTrailElemID,
+    annotations: {
+    },
+    fields: {
+      baseRecord: { refType: datasetBaseRecord },
+      joins: { refType: new ListType(datasetJoin) },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.DATASET],
+  })
+  innerTypes.joinTrail = datasetJoinTrail
+
+  const datasetFieldReferenceElemID = new ElemID(constants.NETSUITE, 'dataset_field_reference')
+  const datasetFieldReference = createMatchingObjectType<FieldReference>({
+    elemID: datasetFieldReferenceElemID,
+    annotations: {
+    },
+    fields: {
+      id: { refType: BuiltinTypes.STRING },
+      joinTrail: { refType: datasetJoinTrail },
+      label: { refType: BuiltinTypes.STRING },
+      uniqueId: { refType: BuiltinTypes.STRING },
+      fieldValidityState: {
+        refType: BuiltinTypes.STRING,
+        annotations: {
+          [DO_NOT_ADD]: true,
+        },
+      },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.DATASET],
+  })
+  innerTypes.fieldReference = datasetFieldReference
+
+  const datasetTranslationElemID = new ElemID(constants.NETSUITE, 'dataset_translation')
+  const datasetTranslation = createMatchingObjectType<TranslationType>({
+    elemID: datasetTranslationElemID,
+    annotations: {
+    },
+    fields: {
+      translationScriptId: { refType: BuiltinTypes.STRING },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.DATASET],
+  })
+  innerTypes.datasetTranslation = datasetTranslation
+
+  const datasetFormulaFormulaElemID = new ElemID(constants.NETSUITE, 'dataset_formula_formula')
+  const datasetFormulaFormula = createMatchingObjectType<FormulaFormula>({
+    elemID: datasetFormulaFormulaElemID,
+    annotations: {
+      [XML_TYPE]: true,
+      [DEFAULT_XML_TYPE]: 'formula',
+      [IGNORE_T_VALUE]: true,
+    },
+    fields: {
+      dataType: { refType: BuiltinTypes.STRING },
+      formulaSQL: { refType: BuiltinTypes.STRING },
+      id: { refType: BuiltinTypes.STRING },
+      label: { refType: datasetTranslation },
+      uniqueId: { refType: BuiltinTypes.STRING },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.DATASET],
+  })
+  innerTypes.formulaFormula = datasetFormulaFormula
+
+  const datasetFormulaElemID = new ElemID(constants.NETSUITE, 'dataset_formula')
+  const datasetFormula = createMatchingObjectType<Formula>({
+    elemID: datasetFormulaElemID,
+    annotations: {
+    },
+    fields: {
+      fields: { refType: BuiltinTypes.UNKNOWN },
+      formula: { refType: datasetFormulaFormula },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.DATASET],
+  })
+  innerTypes.formula = datasetFormula
+
+  const datasetFieldOrFormulaElemID = new ElemID(constants.NETSUITE, 'dataset_field_or_formula')
+  const datasetFieldOrFormula = createMatchingObjectType<FieldOrFormula>({
+    elemID: datasetFieldOrFormulaElemID,
+    annotations: {
+      [XML_TYPE]: true,
+    },
+    fields: {
+      fieldReference: {
+        refType: datasetFieldReference,
+        annotations: {
+          [DO_NOT_ADD]: true,
+        },
+      },
+      dataSetFormula: {
+        refType: datasetFormula,
+        annotations: {
+          [DO_NOT_ADD]: true,
+        },
+      },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.DATASET],
+  })
+  innerTypes.fieldOrFormula = datasetFieldOrFormula
+
+  const datasetColumnElemID = new ElemID(constants.NETSUITE, 'dataset_column')
+  const datasetColumn = createMatchingObjectType<Column>({
+    elemID: datasetColumnElemID,
+    annotations: {
+    },
+    fields: {
+      alias: { refType: BuiltinTypes.STRING },
+      columnId: { refType: BuiltinTypes.NUMBER },
+      field: { refType: datasetFieldOrFormula },
+      label: { refType: datasetTranslation },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.DATASET],
+  })
+  innerTypes.column = datasetColumn
+
+  const expressionValueElemID = new ElemID(constants.NETSUITE, 'dataset_criteria_expression_value')
+  const expressionValue = createMatchingObjectType<ExpressionValue>({
+    elemID: expressionValueElemID,
+    annotations: {
+    },
+    fields: {
+      type: { refType: BuiltinTypes.STRING },
+      value: { refType: BuiltinTypes.UNKNOWN },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.DATASET],
+  })
+  innerTypes.expressionValue = expressionValue
+
+  const expressionElemID = new ElemID(constants.NETSUITE, 'dataset_criteria_expression')
+  const expression = createMatchingObjectType<Expression>({
+    elemID: expressionElemID,
+    annotations: {
+    },
+    fields: {
+      label: { refType: BuiltinTypes.STRING },
+      subType: { refType: BuiltinTypes.UNKNOWN },
+      uiData: { refType: new ListType(BuiltinTypes.STRING) },
+      value: { refType: expressionValue },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.DATASET],
+  })
+  innerTypes.expression = expression
+
+  const datasetMetaElemID = new ElemID(constants.NETSUITE, 'dataset_meta')
+  const datasetMeta = createMatchingObjectType<Meta>({
+    elemID: datasetMetaElemID,
+    annotations: {
+    },
+    fields: {
+      selectorType: { refType: BuiltinTypes.STRING },
+      subType: { refType: BuiltinTypes.STRING },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.DATASET],
+  })
+  innerTypes.criteriaMeta = datasetMeta
+
+  const datasetOperatorElemID = new ElemID(constants.NETSUITE, 'dataset_operator')
+  const datasetOperator = createMatchingObjectType<Operator>({
+    elemID: datasetOperatorElemID,
+    annotations: {
+    },
+    fields: {
+      code: {
+        refType: BuiltinTypes.STRING,
+        annotations: {
+          [DEFAULT_VALUE]: 'AND',
+        },
+      },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.DATASET],
+  })
+  innerTypes.operator = datasetOperator
+
+  const datasetTargetFieldContextElemID = new ElemID(constants.NETSUITE, 'dataset_criteria_target_field_context')
+  const datasetTargetFieldContext = createMatchingObjectType<TargetFieldContext>({
+    elemID: datasetTargetFieldContextElemID,
+    annotations: {
+    },
+    fields: {
+      name: {
+        refType: BuiltinTypes.STRING,
+        annotations: {
+          [DEFAULT_VALUE]: 'DEFAULT',
+        },
+      },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.DATASET],
+  })
+  innerTypes.context = datasetTargetFieldContext
+
+  const datasetFilterElemID = new ElemID(constants.NETSUITE, 'dataset_filter')
+  const datasetFilter = createMatchingObjectType<Filter>({
+    elemID: datasetFilterElemID,
+    annotations: {
+    },
+    fields: {
+      caseSensitive: { refType: BuiltinTypes.BOOLEAN },
+      expressions: { refType: new ListType(expression) },
+      operator: {
+        refType: datasetOperator,
+      },
+      targetFieldContext: { refType: datasetTargetFieldContext },
+      field: { refType: datasetFieldOrFormula },
+      fieldStateName: { refType: BuiltinTypes.STRING },
+      meta: { refType: datasetMeta },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.DATASET],
+  })
+  innerTypes.filter = datasetFilter
+
+  const datasetConditionElemID = new ElemID(constants.NETSUITE, 'dataset_condition')
+  const datasetCondition = createMatchingObjectType<Condition>({
+    elemID: datasetConditionElemID,
+    annotations: {
+    },
+    fields: {
+      children: { refType: BuiltinTypes.UNKNOWN },
+      operator: { refType: datasetOperator },
+      targetFieldContext: { refType: datasetTargetFieldContext },
+      meta: { refType: datasetMeta },
+      field: { refType: datasetFieldOrFormula },
+      fieldStateName: { refType: BuiltinTypes.STRING },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.DATASET],
+  })
+  innerTypes.condition = datasetCondition
+
+  const datasetCriteriaElemID = new ElemID(constants.NETSUITE, 'dataset_criteria')
+  const datasetCriteria = createMatchingObjectType<ConditionOrFilter>({
+    elemID: datasetCriteriaElemID,
+    annotations: {
+      [XML_TYPE]: true,
+    },
+    fields: {
+      condition: {
+        refType: datasetCondition,
+        annotations: {
+          [DO_NOT_ADD]: true,
+        },
+      },
+      filter: {
+        refType: datasetFilter,
+        annotations: {
+          [DO_NOT_ADD]: true,
+        },
+      },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.DATASET],
+  })
+  innerTypes.criteria = datasetCriteria
+
+  datasetFormula.fields.fields.refType = createRefToElmWithValue(new ListType(datasetFieldOrFormula))
+  datasetCondition.fields.children.refType = createRefToElmWithValue(new ListType(datasetCriteria))
+
+  const datasetElemID = new ElemID(constants.NETSUITE, 'dataset')
+  const dataset = createMatchingObjectType<Dataset>({
+    elemID: datasetElemID,
+    annotations: {
+      [XML_TYPE]: true,
+      [DEFAULT_XML_TYPE]: 'dataSet',
+      [IGNORE_T_VALUE]: true,
+    },
+    fields: {
+      scriptid: {
+        refType: BuiltinTypes.SERVICE_ID,
+        annotations: {
+          _required: true,
+          [constants.IS_ATTRIBUTE]: true,
+          [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ regex: '^custdataset[0-9a-z_]+' }),
+        },
+      },
+      name: {
+        refType: BuiltinTypes.STRING,
+        annotations: {
+          _required: true,
+        },
+      },
+      dependencies: {
+        refType: createRefToElmWithValue(datasetDependencies),
+        annotations: {
+          [DO_NOT_ADD]: true,
+        },
+      },
+      definition: {
+        refType: createRefToElmWithValue(fieldTypes.cdata),
+        annotations: {
+          [DO_NOT_ADD]: true,
+        },
+      },
+      applicationId: { refType: BuiltinTypes.UNKNOWN },
+      audience: { refType: datasetAudience },
+      baseRecord: { refType: datasetBaseRecord },
+      columns: { refType: new ListType(datasetColumn) },
+      criteria: { refType: datasetCriteria },
+      description: { refType: datasetTranslation },
+      formulas: { refType: new ListType(datasetFieldOrFormula) },
+      id: { refType: BuiltinTypes.UNKNOWN },
+      ownerId: { refType: BuiltinTypes.NUMBER },
+      version: { refType: BuiltinTypes.STRING },
+      application_id: {
+        refType: BuiltinTypes.STRING,
+        annotations: {
+          [DO_NOT_ADD]: true,
+        },
+      },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.DATASET],
+  })
+  return { type: dataset, innerTypes }
+}

--- a/packages/netsuite-adapter/src/type_parsers/analytics_parsers/parsed_workbook.ts
+++ b/packages/netsuite-adapter/src/type_parsers/analytics_parsers/parsed_workbook.ts
@@ -1,0 +1,881 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, ListType, ObjectType, createRefToElmWithValue, createRestriction } from '@salto-io/adapter-api'
+import { createMatchingObjectType } from '@salto-io/adapter-utils'
+import { TypeAndInnerTypes } from '../../types/object_types'
+import * as constants from '../../constants'
+import { fieldTypes } from '../../types/field_types'
+import { AnalyticOriginalFields, ApplicationId, Audience, BaseRecord, Condition, ConditionOrFilter, DEFAULT_VALUE, DEFAULT_XML_TYPE, DO_NOT_ADD, DefinitionId, Dependencies, Expression, ExpressionValue, FieldOrFormula, FieldReference, Filter, Formula, FormulaFormula, IGNORE_T_VALUE, Join, JoinTrail, Meta, Operator, TranslationType, XML_TYPE } from './analytics_constants'
+
+const sortDirectionList = ['ASCENDING', 'DESCENDING'] as const
+
+type sortDirection = typeof sortDirectionList[number]
+
+type TargetFieldContext = {
+  name?: string
+}
+
+type Sorting = {
+  caseSensitive?: boolean
+  direction?: sortDirection
+  localeId?: string
+  nullFirst?: boolean
+  order?: number
+}
+
+type ConditionalFormatFilter = {
+  expressions?: ExpressionValue
+  operator?: Operator
+}
+
+type FormatRuleFilter = {
+  conditionalFormatFilter?: ConditionalFormatFilter
+}
+
+type RgbColor = {
+  blue?: number
+  green?: number
+  red?: number
+}
+
+type Color = {
+  rgbColor?: RgbColor
+}
+
+type Icon = {
+  color?: Color
+  image?: string
+}
+
+type Style = {
+  backgroundColor?: Color
+  icon?: Icon
+}
+
+type ConditionalFormatRule = {
+  filter?: FormatRuleFilter
+  id?: string
+  style?: Style
+}
+
+type FormatRule = {
+  conditionalFormatRule?: ConditionalFormatRule
+}
+
+type CellConditionalFormat = {
+  formatRules?: FormatRule[]
+  id?: string
+}
+
+type ConditionalFormat = {
+  cellConditionalFormat?: CellConditionalFormat
+}
+
+type Column = {
+  conditionalFormat?: ConditionalFormat[]
+  criterion?: Filter
+  customLabel?: TranslationType
+  dataSetColumnId?: number
+  datasetScriptId?: string
+  fieldStateName?: string
+  sorting?: Sorting
+  targetFieldContext?: TargetFieldContext
+  width?: number
+}
+
+type VisualizationTypeBasics = {
+  applicationId?: ApplicationId
+  datasets?: string[]
+  id?: DefinitionId
+  name?: TranslationType
+  scriptId?: string
+  workbook?: string
+  version?: string
+}
+
+type ChartOrPivot = VisualizationTypeBasics & {
+  definition?: string
+  format?: string
+  datasetLink?: string
+  order?: number
+}
+
+type PivotOuter = {
+  pivot: ChartOrPivot
+}
+
+type ChartOuter = {
+  chart: ChartOrPivot
+}
+
+type DsLink = VisualizationTypeBasics & {
+  mapping?: string
+}
+
+type DsLinkOuter = {
+  dsLink: DsLink
+}
+
+type DataView = VisualizationTypeBasics & {
+  columns?: Column[]
+  order?: number
+}
+
+type DataViewOuter = {
+  dataView: DataView
+}
+
+type visualizationType = {
+  chart?: ChartOrPivot
+  dsLink?: DsLink
+  dataView?: DataView
+  pivot?: ChartOrPivot
+}
+
+type InnerWorkbook = {
+  applicationId?: ApplicationId
+  audience?: Audience
+  chartIDs?: string[]
+  dataViewIDs?: string[]
+  description?: TranslationType
+  id?: DefinitionId
+  name?: TranslationType
+  ownerId?: number
+  pivotIDs?: string[]
+  scriptId?: string
+  version?: string
+}
+
+type WorkbookDefinitionType = {
+  charts?: visualizationType[]
+  datasetLinks?: visualizationType[]
+  dataViews?: visualizationType[]
+  pivots?: visualizationType[]
+  Workbook?: InnerWorkbook
+}
+
+export type Workbook = AnalyticOriginalFields & WorkbookDefinitionType
+
+
+export const parsedWorkbookType = (): TypeAndInnerTypes => {
+  const innerTypes: Record<string, ObjectType> = {}
+
+  const workbookTargetFieldContextElemID = new ElemID(constants.NETSUITE, 'workbook_target_field_context')
+  const workbookTargetFieldContext = createMatchingObjectType<TargetFieldContext>({
+    elemID: workbookTargetFieldContextElemID,
+    annotations: {
+    },
+    fields: {
+      name: {
+        refType: BuiltinTypes.STRING,
+        annotations: {
+          [DEFAULT_VALUE]: 'DEFAULT',
+        },
+      },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookTargetFieldContext = workbookTargetFieldContext
+
+  const workbookSortingElemID = new ElemID(constants.NETSUITE, 'workbook_sorting')
+  const workbookSorting = createMatchingObjectType<Sorting>({
+    elemID: workbookSortingElemID,
+    annotations: {
+    },
+    fields: {
+      caseSensitive: { refType: BuiltinTypes.BOOLEAN },
+      direction: {
+        refType: BuiltinTypes.STRING,
+        annotations: {
+          [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values: sortDirectionList }),
+        },
+      },
+      localeId: { refType: BuiltinTypes.STRING },
+      nullFirst: { refType: BuiltinTypes.BOOLEAN },
+      order: { refType: BuiltinTypes.NUMBER },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookSorting = workbookSorting
+
+  const workbookExpressionValueElemID = new ElemID(constants.NETSUITE, 'workbook_expression_value')
+  const workbookExpressionValue = createMatchingObjectType<ExpressionValue>({
+    elemID: workbookExpressionValueElemID,
+    annotations: {
+    },
+    fields: {
+      type: { refType: BuiltinTypes.STRING },
+      value: { refType: BuiltinTypes.UNKNOWN },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookExpressionValue = workbookExpressionValue
+
+  const workbookExpressionElemID = new ElemID(constants.NETSUITE, 'workbook_expression')
+  const workbookExpression = createMatchingObjectType<Expression>({
+    elemID: workbookExpressionElemID,
+    annotations: {
+    },
+    fields: {
+      label: { refType: BuiltinTypes.STRING },
+      subType: { refType: BuiltinTypes.UNKNOWN },
+      uiData: { refType: new ListType(BuiltinTypes.STRING) },
+      value: { refType: workbookExpressionValue },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookExpression = workbookExpression
+
+  const workbookOperatorElemID = new ElemID(constants.NETSUITE, 'workbook_operator')
+  const workbookOperator = createMatchingObjectType<Operator>({
+    elemID: workbookOperatorElemID,
+    annotations: {
+    },
+    fields: {
+      code: {
+        refType: BuiltinTypes.STRING,
+        annotations: {
+          [DEFAULT_VALUE]: 'AND',
+        },
+      },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookOperator = workbookOperator
+
+  const workbookConditionalFormatFilterElemID = new ElemID(constants.NETSUITE, 'workbook_conditional_format_filter')
+  const workbookConditionalFormatFilter = createMatchingObjectType<ConditionalFormatFilter>({
+    elemID: workbookConditionalFormatFilterElemID,
+    annotations: {
+    },
+    fields: {
+      expressions: { refType: workbookExpressionValue },
+      operator: { refType: workbookOperator },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookConditionalFormatFilter = workbookConditionalFormatFilter
+
+  const workbookFormatRuleFilterElemID = new ElemID(constants.NETSUITE, 'workbook_format_rule_filter')
+  const workbookFormatRuleFilter = createMatchingObjectType<FormatRuleFilter>({
+    elemID: workbookFormatRuleFilterElemID,
+    annotations: {
+      [XML_TYPE]: true,
+    },
+    fields: {
+      conditionalFormatFilter: {
+        refType: workbookConditionalFormatFilter,
+        annotations: {
+          [DO_NOT_ADD]: true,
+        },
+      },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookFormatRuleFilter = workbookFormatRuleFilter
+
+  const workbookRgbColorElemID = new ElemID(constants.NETSUITE, 'workbook_rgb_color')
+  const workbookRgbColor = createMatchingObjectType<RgbColor>({
+    elemID: workbookRgbColorElemID,
+    annotations: {
+    },
+    fields: {
+      blue: { refType: BuiltinTypes.NUMBER },
+      green: { refType: BuiltinTypes.NUMBER },
+      red: { refType: BuiltinTypes.NUMBER },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookRgbColor = workbookRgbColor
+
+  const workbookColorElemID = new ElemID(constants.NETSUITE, 'workbook_color')
+  const workbookColor = createMatchingObjectType<Color>({
+    elemID: workbookColorElemID,
+    annotations: {
+      [XML_TYPE]: true,
+    },
+    fields: {
+      rgbColor: {
+        refType: workbookRgbColor,
+        annotations: {
+          [DO_NOT_ADD]: true,
+        },
+      },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookColor = workbookColor
+
+  const workbookIconElemID = new ElemID(constants.NETSUITE, 'workbook_icon')
+  const workbookIcon = createMatchingObjectType<Icon>({
+    elemID: workbookIconElemID,
+    annotations: {
+    },
+    fields: {
+      color: { refType: workbookColor },
+      image: { refType: BuiltinTypes.STRING },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookIcon = workbookIcon
+
+  const workbookStyleElemID = new ElemID(constants.NETSUITE, 'workbook_style')
+  const workbookStyle = createMatchingObjectType<Style>({
+    elemID: workbookStyleElemID,
+    annotations: {
+    },
+    fields: {
+      backgroundColor: { refType: workbookColor },
+      icon: { refType: workbookIcon },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookStyle = workbookStyle
+
+  const workbookConditionalFormatRuleElemID = new ElemID(constants.NETSUITE, 'workbook_conditional_format_rule')
+  const workbookConditionalFormatRule = createMatchingObjectType<ConditionalFormatRule>({
+    elemID: workbookConditionalFormatRuleElemID,
+    annotations: {
+    },
+    fields: {
+      filter: { refType: workbookFormatRuleFilter },
+      id: { refType: BuiltinTypes.STRING },
+      style: { refType: workbookStyle },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookConditionalFormatRule = workbookConditionalFormatRule
+
+  const workbookFormatRuleElemID = new ElemID(constants.NETSUITE, 'workbook_format_rule')
+  const workbookFormatRule = createMatchingObjectType<FormatRule>({
+    elemID: workbookFormatRuleElemID,
+    annotations: {
+      [XML_TYPE]: true,
+    },
+    fields: {
+      conditionalFormatRule: {
+        refType: workbookConditionalFormatRule,
+        annotations: {
+          [DO_NOT_ADD]: true,
+        },
+      },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookFormatRule = workbookFormatRule
+
+  const workbookCellConditionalFormatElemID = new ElemID(constants.NETSUITE, 'workbook_cell_conditional_format')
+  const workbookCellConditionalFormat = createMatchingObjectType<CellConditionalFormat>({
+    elemID: workbookCellConditionalFormatElemID,
+    annotations: {
+    },
+    fields: {
+      formatRules: { refType: new ListType(workbookFormatRule) },
+      id: { refType: BuiltinTypes.STRING },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookCellConditionalFormat = workbookCellConditionalFormat
+
+  const workbookConditionalFormatElemID = new ElemID(constants.NETSUITE, 'workbook_conditional_format')
+  const workbookConditionalFormat = createMatchingObjectType<ConditionalFormat>({
+    elemID: workbookConditionalFormatElemID,
+    annotations: {
+      [XML_TYPE]: true,
+    },
+    fields: {
+      cellConditionalFormat: {
+        refType: workbookCellConditionalFormat,
+        annotations: {
+          [DO_NOT_ADD]: true,
+        },
+      },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookConditionalFormat = workbookConditionalFormat
+
+  const workbookTranslationElemID = new ElemID(constants.NETSUITE, 'workbook_translation')
+  const workbookTranslation = createMatchingObjectType<TranslationType>({
+    elemID: workbookTranslationElemID,
+    annotations: {
+    },
+    fields: {
+      translationScriptId: { refType: BuiltinTypes.STRING },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookTranslation = workbookTranslation
+
+  const workbookBaseRecordElemID = new ElemID(constants.NETSUITE, 'workbook_base_record')
+  const workbookBaseRecord = createMatchingObjectType<BaseRecord>({
+    elemID: workbookBaseRecordElemID,
+    annotations: {
+    },
+    fields: {
+      id: { refType: BuiltinTypes.STRING },
+      label: { refType: BuiltinTypes.STRING },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookBaseRecord = workbookBaseRecord
+
+  const workbookJoinElemID = new ElemID(constants.NETSUITE, 'workbook_join')
+  const workbookJoin = createMatchingObjectType<Join>({
+    elemID: workbookJoinElemID,
+    annotations: {
+    },
+    fields: {
+      id: { refType: BuiltinTypes.STRING },
+      targetRecordType: { refType: BuiltinTypes.STRING },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookJoin = workbookJoin
+
+  const workbookJoinTrailElemID = new ElemID(constants.NETSUITE, 'workbook_join_trail')
+  const workbookJoinTrail = createMatchingObjectType<JoinTrail>({
+    elemID: workbookJoinTrailElemID,
+    annotations: {
+    },
+    fields: {
+      baseRecord: { refType: workbookBaseRecord },
+      joins: { refType: new ListType(workbookJoin) },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookJoinTrail = workbookJoinTrail
+
+  const workbookFieldReferenceElemID = new ElemID(constants.NETSUITE, 'workbook_field_reference')
+  const workbookFieldReference = createMatchingObjectType<FieldReference>({
+    elemID: workbookFieldReferenceElemID,
+    annotations: {
+    },
+    fields: {
+      id: { refType: BuiltinTypes.STRING },
+      joinTrail: { refType: workbookJoinTrail },
+      label: { refType: BuiltinTypes.STRING },
+      uniqueId: { refType: BuiltinTypes.STRING },
+      fieldValidityState: {
+        refType: BuiltinTypes.STRING,
+        annotations: {
+          [DO_NOT_ADD]: true,
+        },
+      },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookFieldReference = workbookFieldReference
+
+  const workbookFormulaFormulaElemID = new ElemID(constants.NETSUITE, 'workbook_formula_formula')
+  const workbookFormulaFormula = createMatchingObjectType<FormulaFormula>({
+    elemID: workbookFormulaFormulaElemID,
+    annotations: {
+      [XML_TYPE]: true,
+      [DEFAULT_XML_TYPE]: 'formula',
+      [IGNORE_T_VALUE]: true,
+    },
+    fields: {
+      dataType: { refType: BuiltinTypes.STRING },
+      formulaSQL: { refType: BuiltinTypes.STRING },
+      id: { refType: BuiltinTypes.STRING },
+      label: { refType: workbookTranslation },
+      uniqueId: { refType: BuiltinTypes.STRING },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookFormulaFormula = workbookFormulaFormula
+
+  const workbookFormulaElemID = new ElemID(constants.NETSUITE, 'workbook_formula')
+  const workbookFormula = createMatchingObjectType<Formula>({
+    elemID: workbookFormulaElemID,
+    annotations: {
+    },
+    fields: {
+      fields: { refType: BuiltinTypes.UNKNOWN },
+      formula: { refType: workbookFormulaFormula },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookFormula = workbookFormula
+
+  const workbookFieldOrFormulaElemID = new ElemID(constants.NETSUITE, 'workbook_field_or_formula')
+  const workbookFieldOrFormula = createMatchingObjectType<FieldOrFormula>({
+    elemID: workbookFieldOrFormulaElemID,
+    annotations: {
+      [XML_TYPE]: true,
+    },
+    fields: {
+      fieldReference: {
+        refType: workbookFieldReference,
+        annotations: {
+          [DO_NOT_ADD]: true,
+        },
+      },
+      dataSetFormula: {
+        refType: workbookFormula,
+        annotations: {
+          [DO_NOT_ADD]: true,
+        },
+      },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  workbookFormula.fields.fields.refType = createRefToElmWithValue(new ListType(workbookFieldOrFormula))
+  innerTypes.workbookFieldOrFormula = workbookFieldOrFormula
+
+  const workbookMetaElemID = new ElemID(constants.NETSUITE, 'workbook_meta')
+  const workbookMeta = createMatchingObjectType<Meta>({
+    elemID: workbookMetaElemID,
+    annotations: {
+    },
+    fields: {
+      selectorType: { refType: BuiltinTypes.STRING },
+      subType: { refType: BuiltinTypes.STRING },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookMeta = workbookMeta
+
+  const workbookFilterElemID = new ElemID(constants.NETSUITE, 'workbook_filter')
+  const workbookFilter = createMatchingObjectType<Filter>({
+    elemID: workbookFilterElemID,
+    annotations: {
+    },
+    fields: {
+      caseSensitive: { refType: BuiltinTypes.BOOLEAN },
+      expressions: { refType: new ListType(workbookExpression) },
+      operator: {
+        refType: workbookOperator,
+      },
+      targetFieldContext: { refType: workbookTargetFieldContext },
+      field: { refType: workbookFieldOrFormula },
+      fieldStateName: { refType: BuiltinTypes.STRING },
+      meta: { refType: workbookMeta },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookFilter = workbookFilter
+
+  const workbookConditionElemID = new ElemID(constants.NETSUITE, 'workbook_condition')
+  const workbookCondition = createMatchingObjectType<Condition>({
+    elemID: workbookConditionElemID,
+    annotations: {
+    },
+    fields: {
+      children: { refType: BuiltinTypes.UNKNOWN },
+      operator: { refType: workbookOperator },
+      targetFieldContext: { refType: workbookTargetFieldContext },
+      meta: { refType: workbookMeta },
+      field: { refType: workbookFieldOrFormula },
+      fieldStateName: { refType: BuiltinTypes.STRING },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookCondition = workbookCondition
+
+  const workbookCriterionElemID = new ElemID(constants.NETSUITE, 'workbook_criteria')
+  const workbookCriterion = createMatchingObjectType<ConditionOrFilter>({
+    elemID: workbookCriterionElemID,
+    annotations: {
+      [XML_TYPE]: true,
+    },
+    fields: {
+      condition: {
+        refType: workbookCondition,
+        annotations: {
+          [DO_NOT_ADD]: true,
+        },
+      },
+      filter: {
+        refType: workbookFilter,
+        annotations: {
+          [DO_NOT_ADD]: true,
+        },
+      },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookCriterion = workbookCriterion
+
+  workbookCondition.fields.children.refType = createRefToElmWithValue(new ListType(workbookCriterion))
+
+  const workbookColumnElemID = new ElemID(constants.NETSUITE, 'workbook_column')
+  const workbookColumn = createMatchingObjectType<Column>({
+    elemID: workbookColumnElemID,
+    annotations: {
+    },
+    fields: {
+      conditionalFormat: { refType: new ListType(workbookConditionalFormat) },
+      criterion: { refType: workbookCriterion },
+      customLabel: { refType: workbookTranslation },
+      dataSetColumnId: { refType: BuiltinTypes.NUMBER },
+      datasetScriptId: { refType: BuiltinTypes.STRING },
+      fieldStateName: { refType: BuiltinTypes.STRING },
+      sorting: { refType: workbookSorting },
+      targetFieldContext: { refType: workbookTargetFieldContext },
+      width: { refType: BuiltinTypes.NUMBER },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookColumn = workbookColumn
+
+  const workbookChartOrPivotElemID = new ElemID(constants.NETSUITE, 'workbook_chart_or_pivot')
+  const workbookChartOrPivot = createMatchingObjectType<ChartOrPivot>({
+    elemID: workbookChartOrPivotElemID,
+    annotations: {
+    },
+    fields: {
+      id: { refType: BuiltinTypes.UNKNOWN },
+      scriptId: { refType: BuiltinTypes.STRING },
+      applicationId: { refType: BuiltinTypes.UNKNOWN },
+      version: { refType: BuiltinTypes.STRING },
+      name: { refType: workbookTranslation },
+      workbook: { refType: BuiltinTypes.STRING },
+      datasets: { refType: new ListType(BuiltinTypes.STRING) },
+      format: { refType: BuiltinTypes.STRING },
+      order: { refType: BuiltinTypes.NUMBER },
+      definition: { refType: BuiltinTypes.STRING },
+      datasetLink: {
+        refType: BuiltinTypes.STRING,
+        annotations: {
+          [DO_NOT_ADD]: true,
+        },
+      },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookChartOrPivot = workbookChartOrPivot
+
+  const workbookPivotOuterElemID = new ElemID(constants.NETSUITE, 'workbook_pivot_outer')
+  const workbookPivotOuter = createMatchingObjectType<PivotOuter>({
+    elemID: workbookPivotOuterElemID,
+    annotations: {
+      [XML_TYPE]: true,
+      [DEFAULT_XML_TYPE]: 'pivot',
+    },
+    fields: {
+      pivot: {
+        refType: workbookChartOrPivot,
+        annotations: {
+          _required: true,
+        },
+      },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookPivotOuter = workbookPivotOuter
+
+  const workbookChartOuterElemID = new ElemID(constants.NETSUITE, 'workbook_chart_outer')
+  const workbookChartOuter = createMatchingObjectType<ChartOuter>({
+    elemID: workbookChartOuterElemID,
+    annotations: {
+      [XML_TYPE]: true,
+      [DEFAULT_XML_TYPE]: 'chart',
+    },
+    fields: {
+      chart: {
+        refType: workbookChartOrPivot,
+        annotations: {
+          _required: true,
+        },
+      },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookChartOuter = workbookChartOuter
+
+  const workbookDsLinkElemID = new ElemID(constants.NETSUITE, 'workbook_dsLink')
+  const workbookDsLink = createMatchingObjectType<DsLink>({
+    elemID: workbookDsLinkElemID,
+    annotations: {
+    },
+    fields: {
+      id: { refType: BuiltinTypes.UNKNOWN },
+      scriptId: { refType: BuiltinTypes.STRING },
+      applicationId: { refType: BuiltinTypes.UNKNOWN },
+      version: { refType: BuiltinTypes.STRING },
+      name: { refType: workbookTranslation },
+      workbook: { refType: BuiltinTypes.STRING },
+      datasets: { refType: new ListType(BuiltinTypes.STRING) },
+      mapping: { refType: BuiltinTypes.STRING },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookDsLink = workbookDsLink
+
+  const workbookDsLinkOuterElemID = new ElemID(constants.NETSUITE, 'workbook_dsLink_outer')
+  const workbookDsLinkOuter = createMatchingObjectType<DsLinkOuter>({
+    elemID: workbookDsLinkOuterElemID,
+    annotations: {
+      [XML_TYPE]: true,
+      [DEFAULT_XML_TYPE]: 'dsLink',
+    },
+    fields: {
+      dsLink: {
+        refType: workbookDsLink,
+        annotations: {
+          _required: true,
+        },
+      },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookDsLinkOuter = workbookDsLinkOuter
+
+  const workbookDataViewElemID = new ElemID(constants.NETSUITE, 'workbook_data_view')
+  const workbookDataView = createMatchingObjectType<DataView>({
+    elemID: workbookDataViewElemID,
+    annotations: {
+    },
+    fields: {
+      id: { refType: BuiltinTypes.UNKNOWN },
+      scriptId: { refType: BuiltinTypes.STRING },
+      applicationId: { refType: BuiltinTypes.UNKNOWN },
+      version: { refType: BuiltinTypes.STRING },
+      name: { refType: workbookTranslation },
+      workbook: { refType: BuiltinTypes.STRING },
+      datasets: { refType: new ListType(BuiltinTypes.STRING) },
+      columns: { refType: new ListType(workbookColumn) },
+      order: { refType: BuiltinTypes.NUMBER },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookDataView = workbookDataView
+
+  const workbookDataViewOuterElemID = new ElemID(constants.NETSUITE, 'workbook_data_view_outer')
+  const workbookDataViewOuter = createMatchingObjectType<DataViewOuter>({
+    elemID: workbookDataViewOuterElemID,
+    annotations: {
+      [XML_TYPE]: true,
+      [DEFAULT_XML_TYPE]: 'dataView',
+    },
+    fields: {
+      dataView: {
+        refType: workbookDataView,
+        annotations: {
+          _required: true,
+        },
+      },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookDataViewOuter = workbookDataViewOuter
+
+  const workbookAudienceElemID = new ElemID(constants.NETSUITE, 'workbook_audience')
+  const workbookAudience = createMatchingObjectType<Audience>({
+    elemID: workbookAudienceElemID,
+    annotations: {
+    },
+    fields: {
+      AudienceItems: { refType: new ListType(BuiltinTypes.UNKNOWN) },
+      isPublic: { refType: BuiltinTypes.BOOLEAN },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookAudience = workbookAudience
+
+  const workbookInnerWorkbookElemID = new ElemID(constants.NETSUITE, 'workbook_inner_workbook')
+  const workbookInnerWorkbook = createMatchingObjectType<InnerWorkbook>({
+    elemID: workbookInnerWorkbookElemID,
+    annotations: {
+      [XML_TYPE]: true,
+      [DEFAULT_XML_TYPE]: 'workbook',
+      [IGNORE_T_VALUE]: true,
+    },
+    fields: {
+      id: { refType: BuiltinTypes.UNKNOWN },
+      scriptId: { refType: BuiltinTypes.STRING },
+      applicationId: { refType: BuiltinTypes.UNKNOWN },
+      version: { refType: BuiltinTypes.STRING },
+      name: { refType: workbookTranslation },
+      audience: { refType: workbookAudience },
+      ownerId: { refType: BuiltinTypes.NUMBER },
+      description: { refType: workbookTranslation },
+      dataViewIDs: { refType: new ListType(BuiltinTypes.STRING) },
+      pivotIDs: { refType: new ListType(BuiltinTypes.STRING) },
+      chartIDs: { refType: new ListType(BuiltinTypes.STRING) },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookInnerWorkbook = workbookInnerWorkbook
+
+  const workbookDependenciesElemID = new ElemID(constants.NETSUITE, 'workbook_dependencies')
+  const workbookDependencies = createMatchingObjectType<Dependencies>({
+    elemID: workbookDependenciesElemID,
+    annotations: {
+    },
+    fields: {
+      dependency: {
+        refType: new ListType(BuiltinTypes.STRING),
+        annotations: {
+          _required: true,
+        },
+      },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  innerTypes.workbookDependencies = workbookDependencies
+
+  const workbookElemID = new ElemID(constants.NETSUITE, 'workbook')
+  const workbook = createMatchingObjectType<Workbook>({
+    elemID: workbookElemID,
+    annotations: {
+    },
+    fields: {
+      scriptid: {
+        refType: createRefToElmWithValue(BuiltinTypes.SERVICE_ID),
+        annotations: {
+          _required: true,
+          [constants.IS_ATTRIBUTE]: true,
+          [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ regex: '^custworkbook[0-9a-z_]+' }),
+        },
+      },
+      name: {
+        refType: BuiltinTypes.STRING,
+        annotations: {
+          _required: true,
+        },
+      },
+      dependencies: {
+        refType: workbookDependencies,
+        annotations: {
+          [DO_NOT_ADD]: true,
+        },
+      },
+      definition: {
+        refType: fieldTypes.cdata,
+        annotations: {
+          [DO_NOT_ADD]: true,
+        },
+      },
+      charts: { refType: new ListType(workbookChartOuter) },
+      datasetLinks: { refType: new ListType(workbookDsLinkOuter) },
+      dataViews: { refType: new ListType(workbookDataViewOuter) },
+      pivots: { refType: new ListType(workbookPivotOuter) },
+      Workbook: { refType: workbookInnerWorkbook },
+      application_id: {
+        refType: BuiltinTypes.STRING,
+        annotations: {
+          [DO_NOT_ADD]: true,
+        },
+      },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, constants.WORKBOOK],
+  })
+  return { type: workbook, innerTypes }
+}

--- a/packages/netsuite-adapter/test/change_validators/analytics_post_deploy_notification.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/analytics_post_deploy_notification.test.ts
@@ -1,0 +1,84 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { InstanceElement, toChange } from '@salto-io/adapter-api'
+import analyticsSilentFailureValidator from '../../src/change_validators/analytics_post_deploy_notification'
+import { parsedDatasetType } from '../../src/type_parsers/analytics_parsers/parsed_dataset'
+import { parsedWorkbookType } from '../../src/type_parsers/analytics_parsers/parsed_workbook'
+import { workflowType } from '../../src/autogen/types/standard_types/workflow'
+import NetsuiteClient from '../../src/client/client'
+
+describe('analytics post deploy notification', () => {
+  const firstDataset = new InstanceElement('dataset 1', parsedDatasetType().type, {
+    scriptid: 'custDataset 1',
+  })
+  const secondDataset = new InstanceElement('dataset 2', parsedDatasetType().type, {
+    scriptid: 'custDataset 2',
+  })
+  const firstWorkbook = new InstanceElement('workbook 1', parsedWorkbookType().type, {
+    scriptid: 'custWorkbook 1',
+  })
+  const secondWorkbook = new InstanceElement('workbook 2', parsedWorkbookType().type, {
+    scriptid: 'custWorkbook 2',
+  })
+  const other = new InstanceElement('other', workflowType().type, {
+    scriptid: 'workflow',
+  })
+  const client = { url: 'ns_url' } as unknown as NetsuiteClient
+  it('Should not have a post-deploy action if there is no dataset or workbook modification/addition', async () => {
+    const changeErrors = await analyticsSilentFailureValidator(
+      [
+        toChange({ before: other, after: other }),
+        toChange({ before: firstDataset }),
+        toChange({ before: firstWorkbook }),
+      ],
+      undefined,
+      undefined,
+      undefined,
+      client,
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
+
+  it('Should have a post-deploy action if there is a dataset modification/addition', async () => {
+    const changeErrors = await analyticsSilentFailureValidator(
+      [
+        toChange({ after: other }),
+        toChange({ before: other, after: other }),
+        toChange({ before: firstDataset, after: firstDataset }),
+        toChange({ after: secondDataset }),
+      ],
+      undefined,
+      undefined,
+      undefined,
+      client,
+    )
+    expect(changeErrors).toHaveLength(2)
+  })
+  it('Should have a post-deploy action if there is a workbook modification/addition', async () => {
+    const changeErrors = await analyticsSilentFailureValidator(
+      [
+        toChange({ after: other }),
+        toChange({ before: other, after: other }),
+        toChange({ before: firstWorkbook, after: firstWorkbook }),
+        toChange({ after: secondWorkbook }),
+      ],
+      undefined,
+      undefined,
+      undefined,
+    )
+    expect(changeErrors).toHaveLength(2)
+  })
+})

--- a/packages/netsuite-adapter/test/change_validators/check_referenced_datasets.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/check_referenced_datasets.test.ts
@@ -1,0 +1,100 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { InstanceElement, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import checkReferencedDatasets from '../../src/change_validators/check_referenced_datasets'
+import { parsedDatasetType } from '../../src/type_parsers/analytics_parsers/parsed_dataset'
+import { parsedWorkbookType } from '../../src/type_parsers/analytics_parsers/parsed_workbook'
+
+describe('unreferenced dataset validator', () => {
+  const { type: dataset } = parsedDatasetType()
+  const { type: workbook } = parsedWorkbookType()
+  const referencedDataset = new InstanceElement('referencedDataset', dataset, {
+    scriptid: 'referencedDatasetScriptId',
+  })
+  const unreferencedDataset = new InstanceElement('unreferencedDataset', dataset, {
+    scriptid: 'unreferencedDatasetScriptId',
+  })
+  const referencingWorkbook = new InstanceElement('referencingWorkbook', workbook, {
+    dependencies: {
+      dependency: new ReferenceExpression(referencedDataset.elemID.createNestedID('scriptid')),
+    },
+  })
+  const unreferencingWorkbook = new InstanceElement('unreferencingWorkbook', workbook, {
+    dependencies: {
+      dependency: [
+        'seggev test',
+      ],
+    },
+  })
+  const workbookWithoutDependencies = new InstanceElement('workbookWithoutDependencies', workbook)
+
+  it('Should not have a change error when changing a dataset and a workbook referencing it', async () => {
+    const changeErrors = await checkReferencedDatasets([
+      toChange({ after: referencedDataset }),
+      toChange({ after: referencingWorkbook }),
+    ],
+    undefined,
+    buildElementsSourceFromElements([
+      referencedDataset,
+      referencingWorkbook,
+    ]))
+    expect(changeErrors).toHaveLength(0)
+  })
+
+  it('Should not have a change error when not changing a dataset', async () => {
+    const changeErrors = await checkReferencedDatasets([
+      toChange({ after: unreferencingWorkbook }),
+    ],
+    undefined,
+    buildElementsSourceFromElements([
+      unreferencingWorkbook,
+    ]))
+    expect(changeErrors).toHaveLength(0)
+  })
+
+  it('Should have a change error (info type) when adding a dataset that is being referenced by a workbook in the elementsSource', async () => {
+    const changeErrors = await checkReferencedDatasets([
+      toChange({ after: referencedDataset }),
+    ],
+    undefined,
+    buildElementsSourceFromElements([
+      referencedDataset,
+      referencingWorkbook,
+    ]))
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0].severity).toEqual('Info')
+    expect(changeErrors[0].elemID).toBe(referencedDataset.elemID)
+  })
+
+  it('Should have a change error (error type) when adding a dataset that is not being referenced by any workbook in the elementsSource', async () => {
+    const changeErrors = await checkReferencedDatasets([
+      toChange({ after: unreferencedDataset }),
+      toChange({ after: unreferencingWorkbook }),
+    ],
+    undefined,
+    buildElementsSourceFromElements([
+      unreferencedDataset,
+      referencedDataset,
+      unreferencingWorkbook,
+      referencingWorkbook,
+      workbookWithoutDependencies,
+    ]))
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0].severity).toEqual('Error')
+    expect(changeErrors[0].elemID).toBe(unreferencedDataset.elemID)
+  })
+})

--- a/packages/netsuite-adapter/test/change_validators/dependencies.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/dependencies.test.ts
@@ -86,12 +86,15 @@ describe('Required Dependencies Validator', () => {
   it('should return no change errors if no other change depends on an invalid element', async () => {
     expect(await validateDependsOnInvalidElement(
       [dependsOn2Instances.elemID.getFullName(), fileInstance.elemID.getFullName()],
-      changes
+      changes,
     )).toEqual([])
   })
 
   it('should return change errors for all changes that have dependency on an invalid element that was added', async () => {
-    const changeErrors = await validateDependsOnInvalidElement([fileInstance.elemID.getFullName()], changes)
+    const changeErrors = await validateDependsOnInvalidElement(
+      [fileInstance.elemID.getFullName()],
+      changes,
+    )
     expect(changeErrors)
       .toEqual(expect.arrayContaining([
         expect.objectContaining({
@@ -102,7 +105,10 @@ describe('Required Dependencies Validator', () => {
   })
 
   it('should return change errors for all changes that have required dependency on an invalid element (either added or required references), including deep dependency', async () => {
-    const changeErrors = await validateDependsOnInvalidElement([customRecordType.elemID.getFullName()], changes)
+    const changeErrors = await validateDependsOnInvalidElement(
+      [customRecordType.elemID.getFullName()],
+      changes,
+    )
     expect(changeErrors)
       .toEqual(expect.arrayContaining([
         expect.objectContaining({

--- a/packages/netsuite-adapter/test/change_validators/extra_reference_dependencies.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/extra_reference_dependencies.test.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import { ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { customsegmentType } from '../../src/autogen/types/standard_types/customsegment'
 import extraReferenceDependenciesValidator from '../../src/change_validators/extra_reference_dependencies'
 import { CUSTOM_RECORD_TYPE, METADATA_TYPE, NETSUITE, SCRIPT_ID } from '../../src/constants'
@@ -23,6 +24,7 @@ import { entitycustomfieldType } from '../../src/autogen/types/standard_types/en
 describe('extra reference changes', () => {
   const customsegment = customsegmentType().type
   const entitycustomfield = entitycustomfieldType().type
+  const elementsSource = buildElementsSourceFromElements([])
 
   const entityFieldInstance = new InstanceElement('custentity_slt', entitycustomfield, {
     [SCRIPT_ID]: 'custentity_slt',
@@ -78,7 +80,7 @@ describe('extra reference changes', () => {
       toChange({ before: customRecordType, after: customRecordType }),
       toChange({ after: customSegmentInstance }),
       toChange({ before: entityFieldInstance, after: entityFieldInstance }),
-    ], false)
+    ], false, elementsSource)
     expect(changeErrors).toHaveLength(0)
   })
 
@@ -87,7 +89,7 @@ describe('extra reference changes', () => {
       toChange({ before: customRecordType, after: customRecordType }),
       toChange({ after: customSegmentInstance }),
       toChange({ before: entityFieldInstance, after: entityFieldInstance }),
-    ], true)
+    ], true, elementsSource)
     expect(changeErrors).toHaveLength(0)
   })
 
@@ -95,7 +97,7 @@ describe('extra reference changes', () => {
     const changeErrors = await extraReferenceDependenciesValidator([
       toChange({ after: customSegmentInstance }),
       toChange({ before: dependsOn2Instances, after: dependsOn2Instances }),
-    ], false)
+    ], false, elementsSource)
     expect(changeErrors).toHaveLength(1)
     expect(changeErrors)
       .toEqual(expect.arrayContaining([
@@ -111,7 +113,7 @@ describe('extra reference changes', () => {
     const changeErrors = await extraReferenceDependenciesValidator([
       toChange({ after: customRecordType }),
       toChange({ before: dependsOn2Instances, after: dependsOn2Instances }),
-    ], true)
+    ], true, elementsSource)
     expect(changeErrors).toHaveLength(2)
     const customSegmentInstanceElemId = customSegmentInstance.elemID.getFullName()
     const fileInstanceElemId = entityFieldInstance.elemID.getFullName()

--- a/packages/netsuite-adapter/test/change_validators/safe_deploy.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/safe_deploy.test.ts
@@ -100,7 +100,7 @@ describe('safe deploy change validator', () => {
           }))
           const changeErrors = await safeDeployValidator(
             [toChange({ before: origInstance, after: afterInstance })],
-            fetchByQuery
+            fetchByQuery,
           )
           expect(changeErrors).toHaveLength(0)
         })
@@ -118,7 +118,7 @@ describe('safe deploy change validator', () => {
           }))
           const changeErrors = await safeDeployValidator(
             [toChange({ before: origInstance, after: afterInstance })],
-            fetchByQuery
+            fetchByQuery,
           )
           expect(changeErrors).toHaveLength(1)
         })
@@ -151,7 +151,7 @@ describe('safe deploy change validator', () => {
           }))
           const changeErrors = await safeDeployValidator(
             [toChange({ before: customRecordType, after: afterCustomRecordType })],
-            fetchByQuery
+            fetchByQuery,
           )
           expect(changeErrors).toHaveLength(1)
         })
@@ -187,10 +187,13 @@ describe('safe deploy change validator', () => {
             elements: [serviceCustomRecordType.clone()],
             deletedElements: [],
           }))
-          const changeErrors = await safeDeployValidator([toChange({
-            before: customRecordType.fields.custom_field,
-            after: afterCustomRecordType.fields.custom_field,
-          })], fetchByQuery)
+          const changeErrors = await safeDeployValidator(
+            [toChange({
+              before: customRecordType.fields.custom_field,
+              after: afterCustomRecordType.fields.custom_field,
+            })],
+            fetchByQuery,
+          )
           expect(changeErrors).toHaveLength(1)
         })
       })
@@ -207,7 +210,7 @@ describe('safe deploy change validator', () => {
 
           const changeErrors = await safeDeployValidator(
             [toChange({ before: origInstance, after: afterInstance })],
-            fetchByQuery
+            fetchByQuery,
           )
           expect(changeErrors).toHaveLength(1)
         })
@@ -222,7 +225,7 @@ describe('safe deploy change validator', () => {
           }))
           const changeErrors = await safeDeployValidator(
             [toChange({ before: origInstance, after: afterInstance })],
-            fetchByQuery
+            fetchByQuery,
           )
           expect(changeErrors).toHaveLength(0)
         })
@@ -238,7 +241,7 @@ describe('safe deploy change validator', () => {
 
           const changeErrors = await safeDeployValidator(
             [toChange({ before: origInstance, after: afterInstance })],
-            fetchByQuery
+            fetchByQuery,
           )
           expect(changeErrors).toHaveLength(1)
         })
@@ -257,7 +260,7 @@ describe('safe deploy change validator', () => {
         }))
         const changeErrors = await safeDeployValidator(
           [toChange({ before: origInstance })],
-          fetchByQuery
+          fetchByQuery,
         )
         expect(changeErrors).toHaveLength(1)
       })
@@ -270,7 +273,7 @@ describe('safe deploy change validator', () => {
         }))
         const changeErrors = await safeDeployValidator(
           [toChange({ before: origInstance })],
-          fetchByQuery
+          fetchByQuery,
         )
         expect(changeErrors).toHaveLength(0)
       })
@@ -285,7 +288,7 @@ describe('safe deploy change validator', () => {
         }))
         const changeErrors = await safeDeployValidator(
           [toChange({ after: newInstance })],
-          fetchByQuery
+          fetchByQuery,
         )
         expect(changeErrors).toHaveLength(0)
       })
@@ -299,7 +302,7 @@ describe('safe deploy change validator', () => {
         }))
         const changeErrors = await safeDeployValidator(
           [toChange({ after: newInstance })],
-          fetchByQuery
+          fetchByQuery,
         )
         expect(changeErrors).toHaveLength(1)
       })
@@ -312,7 +315,7 @@ describe('safe deploy change validator', () => {
         }))
         const changeErrors = await safeDeployValidator(
           [toChange({ after: newInstance })],
-          fetchByQuery
+          fetchByQuery,
         )
         expect(changeErrors).toHaveLength(0)
       })
@@ -387,7 +390,7 @@ describe('safe deploy change validator', () => {
         }))
         const changeErrors = await safeDeployValidator(
           [toChange({ before: customRecordType, after: afterCustomRecordType })],
-          fetchByQuery
+          fetchByQuery,
         )
         expect(changeErrors).toHaveLength(1)
         expect(changeErrors[0].elemID.getFullName()).toEqual(customRecordType.elemID.getFullName())
@@ -506,7 +509,7 @@ describe('safe deploy change validator', () => {
           }))
           const changeErrors = await safeDeployValidator(
             [toChange({ before: origInstance, after: afterInstance })],
-            fetchByQuery
+            fetchByQuery,
           )
           expect(changeErrors).toHaveLength(0)
         })
@@ -524,7 +527,7 @@ describe('safe deploy change validator', () => {
           }))
           const changeErrors = await safeDeployValidator(
             [toChange({ before: origInstance, after: afterInstance })],
-            fetchByQuery
+            fetchByQuery,
           )
           expect(changeErrors).toHaveLength(1)
         })
@@ -542,7 +545,7 @@ describe('safe deploy change validator', () => {
 
           const changeErrors = await safeDeployValidator(
             [toChange({ before: origInstance, after: afterInstance })],
-            fetchByQuery
+            fetchByQuery,
           )
           expect(changeErrors).toHaveLength(1)
         })
@@ -557,7 +560,7 @@ describe('safe deploy change validator', () => {
           }))
           const changeErrors = await safeDeployValidator(
             [toChange({ before: origInstance, after: afterInstance })],
-            fetchByQuery
+            fetchByQuery,
           )
           expect(changeErrors).toHaveLength(0)
         })
@@ -573,7 +576,7 @@ describe('safe deploy change validator', () => {
 
           const changeErrors = await safeDeployValidator(
             [toChange({ before: origInstance, after: afterInstance })],
-            fetchByQuery
+            fetchByQuery,
           )
           expect(changeErrors).toHaveLength(1)
         })
@@ -592,7 +595,7 @@ describe('safe deploy change validator', () => {
         }))
         const changeErrors = await safeDeployValidator(
           [toChange({ before: origInstance })],
-          fetchByQuery
+          fetchByQuery,
         )
         expect(changeErrors).toHaveLength(1)
       })
@@ -605,7 +608,7 @@ describe('safe deploy change validator', () => {
         }))
         const changeErrors = await safeDeployValidator(
           [toChange({ before: origInstance })],
-          fetchByQuery
+          fetchByQuery,
         )
         expect(changeErrors).toHaveLength(0)
       })
@@ -620,7 +623,7 @@ describe('safe deploy change validator', () => {
         }))
         const changeErrors = await safeDeployValidator(
           [toChange({ after: newInstance })],
-          fetchByQuery
+          fetchByQuery,
         )
         expect(changeErrors).toHaveLength(0)
       })
@@ -634,7 +637,7 @@ describe('safe deploy change validator', () => {
         }))
         const changeErrors = await safeDeployValidator(
           [toChange({ after: newInstance })],
-          fetchByQuery
+          fetchByQuery,
         )
         expect(changeErrors).toHaveLength(1)
       })
@@ -647,7 +650,7 @@ describe('safe deploy change validator', () => {
         }))
         const changeErrors = await safeDeployValidator(
           [toChange({ after: newInstance })],
-          fetchByQuery
+          fetchByQuery,
         )
         expect(changeErrors).toHaveLength(0)
       })
@@ -689,7 +692,7 @@ describe('safe deploy change validator', () => {
             }))
             const changeErrors = await safeDeployValidator(
               [toChange({ before: origInstance, after: afterInstance })],
-              fetchByQuery
+              fetchByQuery,
             )
             expect(changeErrors).toHaveLength(0)
           })
@@ -707,7 +710,7 @@ describe('safe deploy change validator', () => {
             }))
             const changeErrors = await safeDeployValidator(
               [toChange({ before: origInstance, after: afterInstance })],
-              fetchByQuery
+              fetchByQuery,
             )
             expect(changeErrors).toHaveLength(1)
           })
@@ -722,7 +725,7 @@ describe('safe deploy change validator', () => {
             }))
             const changeErrors = await safeDeployValidator(
               [toChange({ before: origInstance, after: afterInstance })],
-              fetchByQuery
+              fetchByQuery,
             )
             expect(changeErrors).toHaveLength(0)
           })
@@ -738,7 +741,7 @@ describe('safe deploy change validator', () => {
 
             const changeErrors = await safeDeployValidator(
               [toChange({ before: origInstance, after: afterInstance })],
-              fetchByQuery
+              fetchByQuery,
             )
             expect(changeErrors).toHaveLength(1)
           })
@@ -757,7 +760,7 @@ describe('safe deploy change validator', () => {
           }))
           const changeErrors = await safeDeployValidator(
             [toChange({ before: origInstance })],
-            fetchByQuery
+            fetchByQuery,
           )
           expect(changeErrors).toHaveLength(1)
         })
@@ -770,7 +773,7 @@ describe('safe deploy change validator', () => {
           }))
           const changeErrors = await safeDeployValidator(
             [toChange({ before: origInstance })],
-            fetchByQuery
+            fetchByQuery,
           )
           expect(changeErrors).toHaveLength(0)
         })
@@ -785,7 +788,7 @@ describe('safe deploy change validator', () => {
           }))
           const changeErrors = await safeDeployValidator(
             [toChange({ after: newInstance })],
-            fetchByQuery
+            fetchByQuery,
           )
           expect(changeErrors).toHaveLength(0)
         })
@@ -799,7 +802,7 @@ describe('safe deploy change validator', () => {
           }))
           const changeErrors = await safeDeployValidator(
             [toChange({ after: newInstance })],
-            fetchByQuery
+            fetchByQuery,
           )
           expect(changeErrors).toHaveLength(1)
         })
@@ -812,7 +815,7 @@ describe('safe deploy change validator', () => {
           }))
           const changeErrors = await safeDeployValidator(
             [toChange({ after: newInstance })],
-            fetchByQuery
+            fetchByQuery,
           )
           expect(changeErrors).toHaveLength(0)
         })
@@ -851,7 +854,7 @@ describe('safe deploy change validator', () => {
             }))
             const changeErrors = await safeDeployValidator(
               [toChange({ before: origInstance, after: afterInstance })],
-              fetchByQuery
+              fetchByQuery,
             )
             expect(changeErrors).toHaveLength(0)
           })
@@ -869,7 +872,7 @@ describe('safe deploy change validator', () => {
             }))
             const changeErrors = await safeDeployValidator(
               [toChange({ before: origInstance, after: afterInstance })],
-              fetchByQuery
+              fetchByQuery,
             )
             expect(changeErrors).toHaveLength(1)
           })
@@ -884,7 +887,7 @@ describe('safe deploy change validator', () => {
             }))
             const changeErrors = await safeDeployValidator(
               [toChange({ before: origInstance, after: afterInstance })],
-              fetchByQuery
+              fetchByQuery,
             )
             expect(changeErrors).toHaveLength(0)
           })
@@ -900,7 +903,7 @@ describe('safe deploy change validator', () => {
 
             const changeErrors = await safeDeployValidator(
               [toChange({ before: origInstance, after: afterInstance })],
-              fetchByQuery
+              fetchByQuery,
             )
             expect(changeErrors).toHaveLength(1)
           })
@@ -919,7 +922,7 @@ describe('safe deploy change validator', () => {
           }))
           const changeErrors = await safeDeployValidator(
             [toChange({ before: origInstance })],
-            fetchByQuery
+            fetchByQuery,
           )
           expect(changeErrors).toHaveLength(1)
         })
@@ -932,7 +935,7 @@ describe('safe deploy change validator', () => {
           }))
           const changeErrors = await safeDeployValidator(
             [toChange({ before: origInstance })],
-            fetchByQuery
+            fetchByQuery,
           )
           expect(changeErrors).toHaveLength(0)
         })
@@ -947,7 +950,7 @@ describe('safe deploy change validator', () => {
           }))
           const changeErrors = await safeDeployValidator(
             [toChange({ after: newInstance })],
-            fetchByQuery
+            fetchByQuery,
           )
           expect(changeErrors).toHaveLength(0)
         })
@@ -961,7 +964,7 @@ describe('safe deploy change validator', () => {
           }))
           const changeErrors = await safeDeployValidator(
             [toChange({ after: newInstance })],
-            fetchByQuery
+            fetchByQuery,
           )
           expect(changeErrors).toHaveLength(1)
         })
@@ -974,7 +977,7 @@ describe('safe deploy change validator', () => {
           }))
           const changeErrors = await safeDeployValidator(
             [toChange({ after: newInstance })],
-            fetchByQuery
+            fetchByQuery,
           )
           expect(changeErrors).toHaveLength(0)
         })

--- a/packages/netsuite-adapter/test/filters/add_referencing_workbook.test.ts
+++ b/packages/netsuite-adapter/test/filters/add_referencing_workbook.test.ts
@@ -1,0 +1,172 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Change, ElemID, InstanceElement, ObjectType, ReferenceExpression, Value, getChangeData, isInstanceChange, isModificationChange, isReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils/src/element_source'
+import filterCreator from '../../src/filters/add_referencing_workbooks'
+import { LocalFilterOpts } from '../../src/filter'
+import { parsedDatasetType } from '../../src/type_parsers/analytics_parsers/parsed_dataset'
+import { parsedWorkbookType } from '../../src/type_parsers/analytics_parsers/parsed_workbook'
+import { translationcollectionType } from '../../src/autogen/types/standard_types/translationcollection'
+import { NETSUITE, SCRIPT_ID, WORKBOOK } from '../../src/constants'
+
+describe('add_referencing_workbooks filter', () => {
+  const checkTopLevelParent = (newChange: Change): boolean =>
+    isInstanceChange(newChange)
+    // && isListType(getChangeData(newChange).value.dependencies.dependency)
+    && getChangeData(newChange).value.dependencies.dependency.every((dependency: Value) =>
+      isReferenceExpression(dependency) && dependency.topLevelParent !== undefined)
+
+  const { type: workbook } = parsedWorkbookType()
+  const translation = new InstanceElement('translationcollection', translationcollectionType().type, {
+    scriptid: 'custcollection_seggev_translation',
+    nameValue: 'The name',
+  })
+  translation.value.name_with_toplevelParent_and_resValue = new ReferenceExpression(
+    translation.elemID.createNestedID('nameValue'),
+    translation.value.nameValue,
+    translation,
+  )
+  translation.value.name = new ReferenceExpression(
+    translation.elemID.createNestedID('nameValue'),
+  )
+  const dataset = new InstanceElement('dataset', parsedDatasetType().type, {
+    scriptid: 'datasetScriptId',
+  })
+  const refToDataset = new ReferenceExpression(dataset.elemID.createNestedID('scriptid'))
+  refToDataset.topLevelParent = dataset
+
+  const objElement = new ObjectType({
+    elemID: new ElemID(NETSUITE),
+  })
+
+  const referencingWorkbook = new InstanceElement('referencingWorkbook', workbook, {
+    [SCRIPT_ID]: 'refWorkbook',
+    dependencies: {
+      dependency: [
+        new ReferenceExpression(
+          translation.elemID.createNestedID('nameValue'),
+        ),
+        new ReferenceExpression(
+          translation.elemID,
+        ),
+        new ReferenceExpression(
+          objElement.elemID,
+        ),
+        refToDataset,
+      ],
+    },
+  })
+  const unreferencingWorkbook = new InstanceElement('unreferencingWorkbook', workbook, {
+    dependencies: {
+      dependency: [
+        'seggev test',
+      ],
+    },
+  })
+  const workbookWithoutDependencies = new InstanceElement('workbookWithoutDependencies', workbook)
+  it('should not add any workbook if there is no datasets in the deployment', async () => {
+    const changes = [
+      toChange({ after: referencingWorkbook }),
+    ]
+    const elementsSource = buildElementsSourceFromElements([
+      dataset,
+      referencingWorkbook,
+      unreferencingWorkbook,
+      workbookWithoutDependencies,
+      translation,
+    ])
+    const originalNumOfChanges = changes.length
+    await filterCreator({ elementsSource } as LocalFilterOpts).preDeploy?.(changes)
+    expect(changes.length).toEqual(originalNumOfChanges)
+  })
+  it('should not add any workbook if there is a dataset and a workbook referencing it in the deployment', async () => {
+    const changes = [
+      toChange({ after: referencingWorkbook }),
+      toChange({ after: dataset }),
+    ]
+    const elementsSource = buildElementsSourceFromElements([
+      dataset,
+      referencingWorkbook,
+      unreferencingWorkbook,
+      workbookWithoutDependencies,
+      translation,
+    ])
+    const originalNumOfChanges = changes.length
+    await filterCreator({ elementsSource } as LocalFilterOpts).preDeploy?.(changes)
+    expect(changes.length).toEqual(originalNumOfChanges)
+  })
+  it('should not add any workbook if there is a dataset and a workbook referencing it, with other workbooks, in the deployment', async () => {
+    const changes = [
+      toChange({ after: unreferencingWorkbook }),
+      toChange({ after: workbookWithoutDependencies }),
+      toChange({ after: referencingWorkbook }),
+      toChange({ after: dataset }),
+    ]
+    const elementsSource = buildElementsSourceFromElements([
+      dataset,
+      referencingWorkbook,
+      unreferencingWorkbook,
+      workbookWithoutDependencies,
+      translation,
+    ])
+    const originalNumOfChanges = changes.length
+    await filterCreator({ elementsSource } as LocalFilterOpts).preDeploy?.(changes)
+    expect(changes.length).toEqual(originalNumOfChanges)
+  })
+  it('should add a workbook if there is no workbook in the deployment', async () => {
+    const changes = [
+      toChange({ after: dataset }),
+    ]
+    const elementsSource = buildElementsSourceFromElements([
+      dataset,
+      unreferencingWorkbook,
+      workbookWithoutDependencies,
+      referencingWorkbook,
+      translation,
+      objElement,
+    ])
+    const originalNumOfChanges = changes.length
+    await filterCreator({ elementsSource } as LocalFilterOpts).preDeploy?.(changes)
+    expect(changes.length).toEqual(originalNumOfChanges + 1)
+    const addedChange = changes[originalNumOfChanges]
+    expect(isModificationChange(addedChange)).toBeTruthy()
+    expect(getChangeData(addedChange).elemID.typeName).toEqual(WORKBOOK)
+    expect(getChangeData(addedChange).value.scriptid).toEqual(referencingWorkbook.value.scriptid)
+    expect(checkTopLevelParent(addedChange)).toBeTruthy()
+  })
+  it('should add a workbook to the deployment if there is a unreferenced dataset', async () => {
+    const changes = [
+      toChange({ after: dataset }),
+      toChange({ after: unreferencingWorkbook }),
+    ]
+    const elementsSource = buildElementsSourceFromElements([
+      dataset,
+      referencingWorkbook,
+      unreferencingWorkbook,
+      workbookWithoutDependencies,
+      translation,
+      objElement,
+    ])
+    const originalNumOfChanges = changes.length
+    await filterCreator({ elementsSource } as LocalFilterOpts).preDeploy?.(changes)
+    expect(changes.length).toEqual(originalNumOfChanges + 1)
+    const addedChange = changes[originalNumOfChanges]
+    expect(isModificationChange(addedChange)).toBeTruthy()
+    expect(getChangeData(addedChange).elemID.typeName).toEqual(WORKBOOK)
+    expect(getChangeData(addedChange).value.scriptid).toEqual(referencingWorkbook.value.scriptid)
+    expect(checkTopLevelParent(addedChange)).toBeTruthy()
+  })
+})

--- a/packages/netsuite-adapter/test/filters/analytics_definition_handle.test.ts
+++ b/packages/netsuite-adapter/test/filters/analytics_definition_handle.test.ts
@@ -1,0 +1,169 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* eslint-disable camelcase */
+import { AdditionChange, ElemID, InstanceElement, ObjectType, isInstanceElement, isObjectType, toChange } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { LocalFilterOpts } from '../../src/filter'
+import { createEmptyElementsSourceIndexes, getDefaultAdapterConfig } from '../utils'
+import { parsedDatasetType } from '../../src/type_parsers/analytics_parsers/parsed_dataset'
+import filterCreator from '../../src/filters/analytics_definition_handle'
+import * as constants from '../../src/constants'
+import { basicDataset, basicDatasetDefinition, basicWorkbookDefinition, defaultValuesDatasetDefinition, emptyDataset, emptyDatasetDefinition, emptyWorkbook, emptyWorkbookDefinition, parsedBasicDataset, parsedBasicDatasetValue, parsedBasicWorkbook, parsedDatasetWithDefaultCompletion, parsedTypesWorkbook, parsedUnknownDataset, typesWorkbook, unknownDataset, workbookDependencies, unknownDefinition, parsedDatasetWithArrays, definitionWithArrays, tablesArray, pivotArray, basicWorkbook, parsedBasicWorkbookValue, parsedUnknownDatasetValueForFetch } from './analytics_tests_constants'
+import { CHARTS, PIVOTS, TABLES } from '../../src/type_parsers/analytics_parsers/analytics_constants'
+
+
+describe('analytics definition handle filter', () => {
+  let fetchOpts: LocalFilterOpts
+  const datasetPath = parsedDatasetType().type.path
+
+  beforeEach(async () => {
+    fetchOpts = {
+      elementsSourceIndex: {
+        getIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+      },
+      elementsSource: buildElementsSourceFromElements([]),
+      isPartial: false,
+      config: await getDefaultAdapterConfig(),
+    }
+  })
+
+  describe('onFetch', () => {
+    it('should remove old object type and add the new type', async () => {
+      const datasetObject = new ObjectType({
+        elemID: new ElemID('netsuite', constants.DATASET),
+        path: datasetPath,
+      })
+      const elements = [datasetObject]
+      await filterCreator(fetchOpts).onFetch?.(elements)
+      expect(elements.filter(isObjectType)
+        .filter(e => e.elemID.typeName === constants.DATASET)[0])
+        .not.toEqual(datasetObject)
+      expect(elements.filter(isObjectType)
+        .filter(e => e.elemID.typeName === constants.DATASET)[0])
+        .toEqual(parsedDatasetType().type)
+    })
+    it('Should accept unknown attributes acn create an element', async () => {
+      const elements = [unknownDataset]
+      await filterCreator(fetchOpts).onFetch?.(elements)
+      const newInstance = elements.filter(isInstanceElement)
+        .filter(e => e.elemID.typeName === constants.DATASET)[0].value
+      expect(newInstance)
+        .not.toEqual(unknownDataset)
+      expect(newInstance)
+        .toEqual(parsedUnknownDatasetValueForFetch)
+    })
+    it('should handle different primitive types of attributes in the definition field', async () => {
+      const elements = [typesWorkbook]
+      await filterCreator(fetchOpts).onFetch?.(elements)
+      const newInstance = elements.filter(isInstanceElement)
+        .filter(e => e.elemID.typeName === constants.WORKBOOK)[0].value
+      expect(newInstance)
+        .not.toEqual(typesWorkbook)
+      expect(newInstance)
+        .toEqual(parsedTypesWorkbook)
+    })
+    it('should handle basic dataset', async () => {
+      const elements = [basicDataset]
+      await filterCreator(fetchOpts).onFetch?.(elements)
+      const newInstance = elements.filter(isInstanceElement)
+        .filter(e => e.elemID.typeName === constants.DATASET)[0].value
+      expect(newInstance)
+        .not.toEqual(basicDataset)
+      expect(newInstance)
+        .toEqual(parsedBasicDatasetValue)
+    })
+    it('should handle basic workbook', async () => {
+      const elements = [basicWorkbook]
+      await filterCreator(fetchOpts).onFetch?.(elements)
+      const newInstance = elements.filter(isInstanceElement)
+        .filter(e => e.elemID.typeName === constants.WORKBOOK)[0].value
+      expect(newInstance)
+        .not.toEqual(basicWorkbook)
+      expect(newInstance)
+        .toEqual(parsedBasicWorkbookValue)
+    })
+  })
+  describe('preDeploy', () => {
+    it('should add the right fields to an empty dataset', async () => {
+      const datasetChange = toChange({ after: emptyDataset }) as AdditionChange<InstanceElement>
+      await filterCreator(fetchOpts).preDeploy?.([datasetChange])
+      expect(Object.keys(datasetChange.data.after.value)).toHaveLength(5)
+      expect(datasetChange.data.after.value.definition).toEqual(emptyDatasetDefinition)
+      expect(datasetChange.data.after.value.name).toEqual(emptyDataset.value.name)
+      expect(datasetChange.data.after.value.scriptid).toEqual(emptyDataset.value.scriptid)
+      expect(datasetChange.data.after.value.dependencies).toBeUndefined()
+    })
+    it('should add the right fields to an empty workbook', async () => {
+      const analyticChange = toChange({ after: emptyWorkbook }) as AdditionChange<InstanceElement>
+      await filterCreator(fetchOpts).preDeploy?.([analyticChange])
+      expect(Object.keys(analyticChange.data.after.value)).toHaveLength(8)
+      expect(analyticChange.data.after.value.definition).toEqual(emptyWorkbookDefinition)
+      expect(analyticChange.data.after.value.name).toEqual(emptyWorkbook.value.name)
+      expect(analyticChange.data.after.value.scriptid).toEqual(emptyWorkbook.value.scriptid)
+      expect(analyticChange.data.after.value.dependencies).toBeUndefined()
+    })
+    it('should create a deployable element from basic dataset', async () => {
+      const analyticChange = toChange({ after: parsedBasicDataset }) as AdditionChange<InstanceElement>
+      await filterCreator(fetchOpts).preDeploy?.([analyticChange])
+      expect(Object.keys(analyticChange.data.after.value)).toHaveLength(5)
+      expect(analyticChange.data.after.value.definition).toEqual(basicDatasetDefinition)
+      expect(analyticChange.data.after.value.name).toEqual(parsedBasicDataset.value.name)
+      expect(analyticChange.data.after.value.scriptid).toEqual(parsedBasicDataset.value.scriptid)
+      expect(analyticChange.data.after.value.dependencies).toBeUndefined()
+    })
+    it('should create a deployable element from basic workbook', async () => {
+      const analyticChange = toChange({ after: parsedBasicWorkbook }) as AdditionChange<InstanceElement>
+      await filterCreator(fetchOpts).preDeploy?.([analyticChange])
+      expect(Object.keys(analyticChange.data.after.value)).toHaveLength(8)
+      expect(analyticChange.data.after.value.definition).toEqual(basicWorkbookDefinition)
+      expect(analyticChange.data.after.value.name).toEqual(parsedBasicWorkbook.value.name)
+      expect(analyticChange.data.after.value.scriptid).toEqual(parsedBasicWorkbook.value.scriptid)
+      expect(analyticChange.data.after.value.dependencies).toEqual(workbookDependencies)
+      expect(analyticChange.data.after.value.tables).toEqual({ table: [{ scriptid: 'custview72_16951029801843995215' }] })
+    })
+    it('should add default values to missing fields with that annotation', async () => {
+      const analyticChange = toChange({ after: parsedDatasetWithDefaultCompletion }) as AdditionChange<InstanceElement>
+      await filterCreator(fetchOpts).preDeploy?.([analyticChange])
+      expect(Object.keys(analyticChange.data.after.value)).toHaveLength(5)
+      expect(analyticChange.data.after.value.definition).toEqual(defaultValuesDatasetDefinition)
+      expect(analyticChange.data.after.value.name).toEqual(parsedDatasetWithDefaultCompletion.value.name)
+      expect(analyticChange.data.after.value.scriptid).toEqual(parsedDatasetWithDefaultCompletion.value.scriptid)
+      expect(analyticChange.data.after.value.dependencies).toBeUndefined()
+    })
+    it('should handle unknown values in the create of the definition value', async () => {
+      const analyticChange = toChange({ after: parsedUnknownDataset }) as AdditionChange<InstanceElement>
+      await filterCreator(fetchOpts).preDeploy?.([analyticChange])
+      expect(Object.keys(analyticChange.data.after.value)).toHaveLength(5)
+      expect(analyticChange.data.after.value.definition).toEqual(unknownDefinition)
+      expect(analyticChange.data.after.value.name).toEqual(parsedUnknownDataset.value.name)
+      expect(analyticChange.data.after.value.scriptid).toEqual(parsedUnknownDataset.value.scriptid)
+      expect(analyticChange.data.after.value.dependencies).toBeUndefined()
+    })
+    it('should create arrays of pivots/tables/charts/dataLinks as the original', async () => {
+      const analyticChange = toChange({ after: parsedDatasetWithArrays }) as AdditionChange<InstanceElement>
+      await filterCreator(fetchOpts).preDeploy?.([analyticChange])
+      expect(Object.keys(analyticChange.data.after.value)).toHaveLength(8)
+      expect(analyticChange.data.after.value.definition).toEqual(definitionWithArrays)
+      expect(analyticChange.data.after.value.name).toEqual(parsedDatasetWithArrays.value.name)
+      expect(analyticChange.data.after.value.scriptid).toEqual(parsedDatasetWithArrays.value.scriptid)
+      expect(analyticChange.data.after.value.dependencies).toBeUndefined()
+      expect(analyticChange.data.after.value[TABLES]).toEqual({ table: tablesArray })
+      expect(analyticChange.data.after.value[PIVOTS]).toEqual({ pivot: pivotArray })
+      expect(analyticChange.data.after.value[CHARTS]).toEqual({ chart: [] })
+    })
+  })
+})

--- a/packages/netsuite-adapter/test/filters/analytics_tests_constants.ts
+++ b/packages/netsuite-adapter/test/filters/analytics_tests_constants.ts
@@ -1,0 +1,791 @@
+
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* eslint-disable camelcase */
+import _ from 'lodash'
+import { InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
+import { parsedDatasetType } from '../../src/type_parsers/analytics_parsers/parsed_dataset'
+import * as constants from '../../src/constants'
+import { translationcollectionType } from '../../src/autogen/types/standard_types/translationcollection'
+import { parsedWorkbookType } from '../../src/type_parsers/analytics_parsers/parsed_workbook'
+import { DATA_VIEWS, DATA_VIEW_IDS, FIELD_DEFINITION, FIELD_TYPE, PIVOTS, PIVOT_IDS } from '../../src/type_parsers/analytics_parsers/analytics_constants'
+
+const dataset = parsedDatasetType().type
+const workbook = parsedWorkbookType().type
+
+// translation collection
+
+const custcollectiontranslations_workbook_example_value = {
+  scriptid: 'custcollectiontranslations_workbook_example',
+  defaultlanguage: 'en-US',
+  strings: {
+    string: {
+      workbookname: {
+        scriptid: 'workbookname',
+        defaulttranslation: 'seggev',
+        description: 'Name in workbook',
+        index: 0,
+      },
+    },
+  },
+}
+export const custcollectiontranslations_workbook_example = new InstanceElement(
+  'custcollectiontranslations_workbook_example',
+  translationcollectionType().type,
+  custcollectiontranslations_workbook_example_value,
+  [constants.NETSUITE, constants.TRANSLATION_COLLECTION],
+)
+
+// basic definition
+const basicDatasetDefinitionOriginal = `
+<root>
+<_T_>dataSet</_T_>
+<id type="null"/>
+<scriptId type="null"/>
+<applicationId type="null"/>
+<version type="string">0.1</version>
+<name>
+  <translationScriptId>custcollectiontranslations_dataset_27_55a834ce148445fd9a604.dataset_name_1141_1</translationScriptId>
+</name>
+<audience>
+  <AudienceItems type="array"/>
+  <isPublic type="boolean">false</isPublic>
+</audience>
+<ownerId>5</ownerId>
+<description type="null"/>
+<baseRecord>
+  <id>account</id>
+  <label>Account</label>
+</baseRecord>
+<columns type="array">
+  <_ITEM_>
+    <columnId>5</columnId>
+    <label type="null"/>
+    <field>
+      <_T_>fieldReference</_T_>
+      <id>id</id>
+      <label>Internal ID</label>
+      <joinTrail>
+        <baseRecord>
+          <id>account</id>
+          <label>Account</label>
+        </baseRecord>
+        <joins type="array"/>
+      </joinTrail>
+      <uniqueId>id</uniqueId>
+    </field>
+    <alias>id</alias>
+  </_ITEM_>
+  <_ITEM_>
+    <columnId>6</columnId>
+    <label type="null"/>
+    <field>
+      <_T_>fieldReference</_T_>
+      <id>id</id>
+      <label>Internal ID</label>
+      <joinTrail>
+        <baseRecord>
+          <id>account</id>
+          <label>Account</label>
+        </baseRecord>
+        <joins type="array"/>
+      </joinTrail>
+      <uniqueId>id</uniqueId>
+    </field>
+    <alias>id</alias>
+  </_ITEM_>
+</columns>
+<criteria>
+  <_T_>condition</_T_>
+  <operator>
+    <code>AND</code>
+  </operator>
+  <children type="array"/>
+  <meta type="null"/>
+  <field type="null"/>
+  <targetFieldContext>
+    <name>DEFAULT</name>
+  </targetFieldContext>
+  <fieldStateName type="null"/>
+</criteria>
+<formulas type="array"/>
+</root>
+`
+const basicDatasetValue = {
+  name: 'seggev test basic',
+  scriptid: 'seggevTestBasic',
+  definition: basicDatasetDefinitionOriginal,
+}
+export const basicDataset = new InstanceElement(
+  'seggev basic',
+  dataset,
+  basicDatasetValue,
+  [constants.NETSUITE, constants.DATASET],
+)
+export const parsedBasicDatasetValue = {
+  scriptid: basicDatasetValue.scriptid,
+  name: basicDatasetValue.name,
+  version: '0.1',
+  audience: {
+    isPublic: false,
+  },
+  ownerId: 5,
+  baseRecord: {
+    id: 'account',
+    label: 'Account',
+  },
+  columns: [
+    {
+      columnId: 5,
+      field: {
+        fieldReference: {
+          id: 'id',
+          label: 'Internal ID',
+          joinTrail: {
+            baseRecord: {
+              id: 'account',
+              label: 'Account',
+            },
+          },
+          uniqueId: 'id',
+        },
+      },
+      alias: 'id',
+    },
+    {
+      columnId: 6,
+      field: {
+        fieldReference: {
+          id: 'id',
+          label: 'Internal ID',
+          joinTrail: {
+            baseRecord: {
+              id: 'account',
+              label: 'Account',
+            },
+          },
+          uniqueId: 'id',
+        },
+      },
+      alias: 'id',
+    },
+  ],
+  criteria: {
+    condition: {
+      operator: {
+        code: 'AND',
+      },
+      targetFieldContext: {
+        name: 'DEFAULT',
+      },
+    },
+  },
+}
+
+export const parsedBasicDataset = new InstanceElement(
+  'seggev parsed basic',
+  dataset,
+  parsedBasicDatasetValue,
+  [constants.NETSUITE, constants.DATASET],
+)
+
+// definition with unknown attribute
+const originalUnknownDefinition = `
+<root>
+<_T_>dataSet</_T_>
+<audience>
+  <_T_>audience</_T_>
+  <Stam_Field type="boolean">true</Stam_Field>
+  <isPublic type="boolean">true</isPublic>
+  <AudienceItems type="array"></AudienceItems>
+</audience>
+<strangeAttribute>
+  <_T_>type</_T_>
+  <num type="string">0.5</num>
+</strangeAttribute>
+</root>
+`
+const unknownDatasetValue = {
+  name: 'seggev test unknown',
+  scriptid: 'seggevTestUnknown',
+  definition: originalUnknownDefinition,
+}
+export const unknownDataset = new InstanceElement(
+  'seggev unknown',
+  dataset,
+  unknownDatasetValue,
+  [constants.NETSUITE, constants.DATASET],
+)
+
+export const parsedUnknownDatasetValue = {
+  name: unknownDatasetValue.name,
+  scriptid: unknownDatasetValue.scriptid,
+  audience: {
+    [FIELD_DEFINITION]: 'audience',
+    Stam_Field: true,
+    isPublic: true,
+  },
+  strangeAttribute: {
+    [FIELD_TYPE]: 'type',
+    num: '0.5',
+  },
+}
+
+export const parsedUnknownDatasetValueForFetch = {
+  name: unknownDatasetValue.name,
+  scriptid: unknownDatasetValue.scriptid,
+  audience: {
+    [FIELD_TYPE]: 'audience',
+    Stam_Field: true,
+    isPublic: true,
+  },
+  strangeAttribute: {
+    [FIELD_TYPE]: 'type',
+    num: '0.5',
+  },
+}
+
+export const parsedUnknownDataset = new InstanceElement(
+  'seggev parsed strange references dataset',
+  dataset,
+  parsedUnknownDatasetValue,
+  [constants.NETSUITE, constants.DATASET],
+)
+
+export const unknownDefinition = `<root>
+  <audience>
+    <_T_>audience</_T_>
+    <Stam_Field type="boolean">true</Stam_Field>
+    <isPublic type="boolean">true</isPublic>
+    <AudienceItems type="array"></AudienceItems>
+  </audience>
+  <strangeAttribute>
+    <num type="string">0.5</num>
+    <_T_>type</_T_>
+  </strangeAttribute>
+  <_T_>dataSet</_T_>
+  <scriptid type="null"></scriptid>
+  <name>seggev test unknown</name>
+  <applicationId type="null"></applicationId>
+  <baseRecord type="null"></baseRecord>
+  <columns type="array"></columns>
+  <criteria type="null"></criteria>
+  <description type="null"></description>
+  <formulas type="array"></formulas>
+  <id type="null"></id>
+  <ownerId type="null"></ownerId>
+  <version type="null"></version>
+</root>
+`
+
+// types check
+const typesDefinition = `
+<root>
+<A>1</A>
+<B type="string">1</B>
+<C type="array">
+  <_ITEM_>2</_ITEM_>
+</C>
+<D type="boolean">true</D>
+<E type="null"/>
+</root>
+`
+const typesValue = {
+  name: 'seggev test types',
+  scriptid: 'seggevTestTypes',
+  definition: typesDefinition,
+}
+export const typesWorkbook = new InstanceElement(
+  'seggev types',
+  workbook,
+  typesValue,
+  [constants.NETSUITE, constants.WORKBOOK],
+)
+export const parsedTypesWorkbook = {
+  name: typesValue.name,
+  scriptid: typesValue.scriptid,
+  A: 1,
+  B: '1',
+  C: [2],
+  D: true,
+}
+
+const emptyAnalyticValue = {
+  scriptid: 'seggevTestEmpty',
+}
+export const emptyDataset = new InstanceElement(
+  'seggev empty',
+  dataset,
+  emptyAnalyticValue,
+  [constants.NETSUITE, constants.DATASET],
+)
+export const emptyWorkbook = new InstanceElement(
+  'seggev empty',
+  workbook,
+  emptyAnalyticValue,
+  [constants.NETSUITE, constants.WORKBOOK],
+)
+
+export const emptyDatasetDefinition = '<root>\n  <_T_>dataSet</_T_>\n  <scriptid type="null"></scriptid>\n  <applicationId type="null"></applicationId>\n  <audience type="null"></audience>\n  <baseRecord type="null"></baseRecord>\n  <columns type="array"></columns>\n  <criteria type="null"></criteria>\n  <description type="null"></description>\n  <formulas type="array"></formulas>\n  <id type="null"></id>\n  <ownerId type="null"></ownerId>\n  <version type="null"></version>\n</root>\n'
+
+export const basicDatasetDefinition = `<root>
+  <version type="string">0.1</version>
+  <audience>
+    <isPublic type="boolean">false</isPublic>
+    <AudienceItems type="array"></AudienceItems>
+  </audience>
+  <ownerId>5</ownerId>
+  <baseRecord>
+    <id>account</id>
+    <label>Account</label>
+  </baseRecord>
+  <columns type="array">
+    <_ITEM_>
+      <columnId>5</columnId>
+      <field>
+        <_T_>fieldReference</_T_>
+        <id>id</id>
+        <label>Internal ID</label>
+        <joinTrail>
+          <baseRecord>
+            <id>account</id>
+            <label>Account</label>
+          </baseRecord>
+          <joins type="array"></joins>
+        </joinTrail>
+        <uniqueId>id</uniqueId>
+      </field>
+      <alias>id</alias>
+      <label type="null"></label>
+    </_ITEM_>
+    <_ITEM_>
+      <columnId>6</columnId>
+      <field>
+        <_T_>fieldReference</_T_>
+        <id>id</id>
+        <label>Internal ID</label>
+        <joinTrail>
+          <baseRecord>
+            <id>account</id>
+            <label>Account</label>
+          </baseRecord>
+          <joins type="array"></joins>
+        </joinTrail>
+        <uniqueId>id</uniqueId>
+      </field>
+      <alias>id</alias>
+      <label type="null"></label>
+    </_ITEM_>
+  </columns>
+  <criteria>
+    <_T_>condition</_T_>
+    <operator>
+      <code>AND</code>
+    </operator>
+    <targetFieldContext>
+      <name>DEFAULT</name>
+    </targetFieldContext>
+    <children type="array"></children>
+    <meta type="null"></meta>
+    <field type="null"></field>
+    <fieldStateName type="null"></fieldStateName>
+  </criteria>
+  <_T_>dataSet</_T_>
+  <scriptid type="null"></scriptid>
+  <name>seggev test basic</name>
+  <applicationId type="null"></applicationId>
+  <description type="null"></description>
+  <formulas type="array"></formulas>
+  <id type="null"></id>
+</root>
+`
+export const emptyWorkbookDefinition = `<root>
+  <scriptid type="null"></scriptid>
+  <charts type="array"></charts>
+  <datasetLinks type="array"></datasetLinks>
+  <dataViews type="array"></dataViews>
+  <pivots type="array"></pivots>
+  <Workbook type="null"></Workbook>
+</root>
+`
+
+const custcollectiontranslations_tableValue = {
+  scriptid: 'custcollectiontranslations_tableValue',
+  defaultlanguage: 'en-US',
+  name: 'table name',
+  strings: {
+    string: {
+      tableview_name: {
+        scriptid: 'tableview_name',
+        defaulttranslation: 'Table 1',
+        description: 'Name in tableView',
+        index: 0,
+      },
+    },
+  },
+}
+
+const custcollectiontranslations_table = new InstanceElement(
+  'custcollectiontranslations_tableValue',
+  translationcollectionType().type,
+  custcollectiontranslations_tableValue,
+  [constants.NETSUITE, constants.TRANSLATION_COLLECTION],
+)
+
+export const workbookDependencies = {
+  dependency: new ReferenceExpression(
+    custcollectiontranslations_table.elemID.createNestedID('strings', 'string', 'tableview_name', 'scriptid'),
+    _.get(custcollectiontranslations_table, ['strings', 'string', 'tableview_name', 'scriptid']),
+    custcollectiontranslations_table.clone(),
+  ),
+}
+
+export const parsedBasicWorkbookValue = {
+  scriptid: 'custworkbook_basic',
+  name: {
+    '#text': '[scriptid=name]',
+  },
+  dependencies: workbookDependencies,
+  tables: {
+    table: {
+      custview72_16951029801843995215: {
+        scriptid: 'custview72_16951029801843995215',
+        index: 0,
+      },
+    },
+  },
+  Workbook: {
+    version: '1.1.1',
+    name: {
+      translationScriptId: 'seggev basic workbook name',
+    },
+    audience: {
+      isPublic: false,
+    },
+    ownerId: 5,
+    dataViewIDs: [
+      'custview72_16951029801843995215',
+    ],
+  },
+  dataViews: [
+    {
+      dataView: {
+        id: 'string',
+        scriptId: 'custview72_16951029801843995215',
+        version: '1.2021.2',
+        name: {
+          translationScriptId: 'name_of_the_table',
+        },
+        workbook: 'custworkbook_basic',
+        datasets: [
+          'stddatasetMyTransactionsDataSet',
+        ],
+        columns: [
+          {
+            datasetScriptId: 'stddatasetMyTransactionsDataSet',
+            dataSetColumnId: 10,
+            targetFieldContext: {
+              name: 'DISPLAY',
+            },
+            fieldStateName: 'display',
+          },
+        ],
+        order: 0,
+      },
+    },
+  ],
+}
+export const parsedBasicWorkbook = new InstanceElement(
+  'seggev parsed basic workbook',
+  workbook,
+  parsedBasicWorkbookValue,
+  [constants.NETSUITE, constants.WORKBOOK],
+)
+
+export const basicWorkbookDefinition = `<root>
+  <tables>
+    <table>
+      <custview72_16951029801843995215>
+        <scriptid>custview72_16951029801843995215</scriptid>
+        <index>0</index>
+      </custview72_16951029801843995215>
+    </table>
+  </tables>
+  <Workbook>
+    <version>1.1.1</version>
+    <name>
+      <translationScriptId>seggev basic workbook name</translationScriptId>
+    </name>
+    <audience>
+      <isPublic type="boolean">false</isPublic>
+      <AudienceItems type="array"></AudienceItems>
+    </audience>
+    <ownerId>5</ownerId>
+    <dataViewIDs type="array">
+      <_ITEM_>custview72_16951029801843995215</_ITEM_>
+    </dataViewIDs>
+    <_T_>workbook</_T_>
+    <id type="null"></id>
+    <scriptId type="null"></scriptId>
+    <applicationId type="null"></applicationId>
+    <description type="null"></description>
+    <pivotIDs type="array"></pivotIDs>
+    <chartIDs type="array"></chartIDs>
+  </Workbook>
+  <dataViews type="array">
+    <_ITEM_>
+      <_T_>dataView</_T_>
+      <id>string</id>
+      <scriptId>custview72_16951029801843995215</scriptId>
+      <version>1.2021.2</version>
+      <name>
+        <translationScriptId>name_of_the_table</translationScriptId>
+      </name>
+      <workbook>custworkbook_basic</workbook>
+      <datasets type="array">
+        <_ITEM_>stddatasetMyTransactionsDataSet</_ITEM_>
+      </datasets>
+      <columns type="array">
+        <_ITEM_>
+          <datasetScriptId>stddatasetMyTransactionsDataSet</datasetScriptId>
+          <dataSetColumnId>10</dataSetColumnId>
+          <targetFieldContext>
+            <name>DISPLAY</name>
+          </targetFieldContext>
+          <fieldStateName>display</fieldStateName>
+          <conditionalFormat type="array"></conditionalFormat>
+          <criterion type="null"></criterion>
+          <customLabel type="null"></customLabel>
+          <sorting type="null"></sorting>
+          <width type="null"></width>
+        </_ITEM_>
+      </columns>
+      <order>0</order>
+      <applicationId type="null"></applicationId>
+    </_ITEM_>
+  </dataViews>
+  <scriptid type="null"></scriptid>
+  <name>
+    <translationScriptId>name</translationScriptId>
+  </name>
+  <charts type="array"></charts>
+  <datasetLinks type="array"></datasetLinks>
+  <pivots type="array"></pivots>
+</root>
+`
+const basicWorkbookValue = {
+  scriptid: 'custworkbook_basic',
+  name: {
+    '#text': '[scriptid=name]',
+  },
+  dependencies: workbookDependencies,
+  definition: basicWorkbookDefinition,
+}
+
+export const basicWorkbook = new InstanceElement(
+  'seggev basic workbook',
+  workbook,
+  basicWorkbookValue,
+  [constants.NETSUITE, constants.WORKBOOK],
+)
+const parsedDatasetWithDefaultCompletionValue = {
+  name: 'default test',
+  scriptid: 'default_test',
+  criteria: {
+    condition: {
+      operator: {
+      },
+      targetFieldContext: {
+      },
+    },
+  },
+}
+
+export const parsedDatasetWithDefaultCompletion = new InstanceElement(
+  'seggev parsed default dataset',
+  dataset,
+  parsedDatasetWithDefaultCompletionValue,
+  [constants.NETSUITE, constants.DATASET],
+)
+
+export const defaultValuesDatasetDefinition = `<root>
+  <criteria>
+    <_T_>condition</_T_>
+    <operator>
+      <code>AND</code>
+    </operator>
+    <targetFieldContext>
+      <name>DEFAULT</name>
+    </targetFieldContext>
+    <children type="array"></children>
+    <meta type="null"></meta>
+    <field type="null"></field>
+    <fieldStateName type="null"></fieldStateName>
+  </criteria>
+  <_T_>dataSet</_T_>
+  <scriptid type="null"></scriptid>
+  <name>default test</name>
+  <applicationId type="null"></applicationId>
+  <audience type="null"></audience>
+  <baseRecord type="null"></baseRecord>
+  <columns type="array"></columns>
+  <description type="null"></description>
+  <formulas type="array"></formulas>
+  <id type="null"></id>
+  <ownerId type="null"></ownerId>
+  <version type="null"></version>
+</root>
+`
+
+const parsedWorkbookWithArraysValue = {
+  name: 'arrays test',
+  scriptid: 'arrays_test',
+  [DATA_VIEWS]: [
+    {
+      dataView: {
+        scriptId: '1',
+      },
+    },
+    {
+      dataView: {
+        scriptId: 2,
+      },
+    },
+  ],
+  [PIVOTS]: {
+    pivot: {
+      scriptId: '4',
+    },
+  },
+  Workbook: {
+    [DATA_VIEW_IDS]: [
+      '1',
+      2,
+    ],
+    [PIVOT_IDS]: [
+      '3',
+    ],
+  },
+}
+export const tablesArray = [
+  { [constants.SCRIPT_ID]: '1' },
+]
+export const pivotArray = [
+  { [constants.SCRIPT_ID]: '3' },
+]
+export const parsedDatasetWithArrays = new InstanceElement(
+  'arrays test',
+  workbook,
+  parsedWorkbookWithArraysValue,
+  [constants.NETSUITE, constants.WORKBOOK],
+)
+
+export const definitionWithArrays = `<root>
+  <dataViews type="array">
+    <_ITEM_>
+      <_T_>dataView</_T_>
+      <scriptId type="string">1</scriptId>
+      <id type="null"></id>
+      <applicationId type="null"></applicationId>
+      <version type="null"></version>
+      <name type="null"></name>
+      <workbook type="null"></workbook>
+      <datasets type="array"></datasets>
+      <columns type="array"></columns>
+      <order type="null"></order>
+    </_ITEM_>
+    <_ITEM_>
+      <_T_>dataView</_T_>
+      <scriptId>2</scriptId>
+      <id type="null"></id>
+      <applicationId type="null"></applicationId>
+      <version type="null"></version>
+      <name type="null"></name>
+      <workbook type="null"></workbook>
+      <datasets type="array"></datasets>
+      <columns type="array"></columns>
+      <order type="null"></order>
+    </_ITEM_>
+  </dataViews>
+  <pivots>
+    <_T_>pivot</_T_>
+    <scriptId type="string">4</scriptId>
+    <id type="null"></id>
+    <applicationId type="null"></applicationId>
+    <version type="null"></version>
+    <name type="null"></name>
+    <workbook type="null"></workbook>
+    <datasets type="array"></datasets>
+    <format type="null"></format>
+    <order type="null"></order>
+    <definition type="null"></definition>
+  </pivots>
+  <Workbook>
+    <dataViewIDs type="array">
+      <_ITEM_ type="string">1</_ITEM_>
+      <_ITEM_>2</_ITEM_>
+    </dataViewIDs>
+    <pivotIDs type="array">
+      <_ITEM_ type="string">3</_ITEM_>
+    </pivotIDs>
+    <_T_>workbook</_T_>
+    <id type="null"></id>
+    <scriptId type="null"></scriptId>
+    <applicationId type="null"></applicationId>
+    <version type="null"></version>
+    <name type="null"></name>
+    <audience type="null"></audience>
+    <ownerId type="null"></ownerId>
+    <description type="null"></description>
+    <chartIDs type="array"></chartIDs>
+  </Workbook>
+  <scriptid type="null"></scriptid>
+  <name>arrays test</name>
+  <charts type="array"></charts>
+  <datasetLinks type="array"></datasetLinks>
+</root>
+`
+
+
+const parsedWorkbookWithStrangeNameValue = {
+  name: {
+    [constants.REAL_VALUE_KEY]: 'name',
+  },
+  scriptid: 'name_test',
+}
+
+export const parsedWorkbookWithStrangeName = new InstanceElement(
+  'name test',
+  workbook,
+  parsedWorkbookWithStrangeNameValue,
+  [constants.NETSUITE, constants.WORKBOOK],
+)
+
+export const definitionWithStrangeName = `<root>
+  <scriptid type="null"></scriptid>
+  <name>
+    <translationScriptId>netsuite.workbook_with_name_with_reference_to_not_custcollection</translationScriptId>
+  </name>
+  <dependencies type="null"></dependencies>
+  <definition type="null"></definition>
+  <charts type="array"></charts>
+  <datasetLinks type="array"></datasetLinks>
+  <dataViews type="array"></dataViews>
+  <pivots type="array"></pivots>
+  <Workbook type="null"></Workbook>
+</root>
+`

--- a/packages/netsuite-adapter/test/filters/parse_report_types.test.ts
+++ b/packages/netsuite-adapter/test/filters/parse_report_types.test.ts
@@ -93,7 +93,10 @@ describe('parse_report_types filter', () => {
   })
   describe('onFetch', () => {
     it('should removes old object type and adds new type', async () => {
-      const savedSearchObject = new ObjectType({ elemID: new ElemID('netsuite', SAVED_SEARCH) })
+      const savedSearchObject = new ObjectType({
+        elemID: new ElemID('netsuite', SAVED_SEARCH),
+        path: [NETSUITE, 'Types', SAVED_SEARCH],
+      })
       const elements = [savedSearchObject]
       await filterCreator(fetchOpts).onFetch?.(elements)
       expect(elements.filter(isObjectType)

--- a/packages/netsuite-adapter/test/reference_dependencies.test.ts
+++ b/packages/netsuite-adapter/test/reference_dependencies.test.ts
@@ -132,11 +132,6 @@ describe('reference dependencies', () => {
       expect(result).toEqual([customRecordType])
     })
 
-    it('should add DATASET dependency of WORKBOOK', async () => {
-      const result = await getReferencedElements([workbookInstance], false)
-      expect(result).toEqual([datasetInstance])
-    })
-
     it('should not add dependencies that already exist', async () => {
       const input = [customRecordType, customSegmentInstance, workbookInstance,
         datasetInstance, instance]
@@ -158,7 +153,7 @@ describe('reference dependencies', () => {
 
       const result = await getReferencedElements(
         [customRecordType, customRecordType2],
-        false
+        false,
       )
       expect(result)
         .toEqual([customSegmentInstance])

--- a/packages/netsuite-adapter/test/type_parsers/parsed_analytics_types.test.ts
+++ b/packages/netsuite-adapter/test/type_parsers/parsed_analytics_types.test.ts
@@ -1,0 +1,87 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { getSubtypes } from '@salto-io/adapter-utils'
+import { datasetType } from '../../src/autogen/types/standard_types/dataset'
+import { parsedDatasetType } from '../../src/type_parsers/analytics_parsers/parsed_dataset'
+import { parsedWorkbookType } from '../../src/type_parsers/analytics_parsers/parsed_workbook'
+
+describe('analytics parsed types tests', () => {
+  describe('parsed dataset tests', () => {
+    const { type: dataset, innerTypes } = parsedDatasetType()
+    it('should have a unique elemID for each inner type', () => {
+      const innerTypesSet = new Set<string>()
+      const multiUsedElemIds = new Set<string>()
+      Object.values(innerTypes)
+        .forEach(innerType => {
+          const fullName = innerType.elemID.getFullName()
+          if (innerTypesSet.has(fullName)) {
+            multiUsedElemIds.add(fullName)
+          } else {
+            innerTypesSet.add(fullName)
+          }
+        })
+      expect(multiUsedElemIds.size).toEqual(0)
+    })
+    it('should include All used objectTypes in the innerTypes', async () => {
+      const usedTypes = await getSubtypes([dataset])
+      const innerTypesNames = new Set<string>(Object.values(innerTypes)
+        .map(innerType => innerType.elemID.getFullName()))
+      expect(usedTypes.length).toEqual(innerTypesNames.size)
+      const typesNotFoundInInnerTypes = usedTypes
+        .filter(usedType => !innerTypesNames.has(usedType.elemID.getFullName()))
+      expect(typesNotFoundInInnerTypes.length).toEqual(0)
+    })
+    it('should include all of the fields of the original type in the new type', () => {
+      const newFields = new Set<string>(Object.keys(dataset))
+      const unusedFields = Object.keys(datasetType().type).filter(fieldName => !newFields.has(fieldName))
+      expect(unusedFields.length).toEqual(0)
+    })
+  })
+  describe('parsed workbook tests', () => {
+    const { type: workbook, innerTypes } = parsedWorkbookType()
+    it('should have a unique elemID for each inner type', () => {
+      const innerTypesSet = new Set<string>()
+      const multiUsedElemIds = new Set<string>()
+      Object.values(innerTypes)
+        .forEach(innerType => {
+          const fullName = innerType.elemID.getFullName()
+          if (innerTypesSet.has(fullName)) {
+            multiUsedElemIds.add(fullName)
+          } else {
+            innerTypesSet.add(fullName)
+          }
+        })
+      expect(multiUsedElemIds.size).toEqual(0)
+    })
+    it('should include All used objectTypes in the innerTypes', async () => {
+      const usedTypes = new Set<string>((await getSubtypes([workbook])).map(elem => elem.elemID.getFullName()))
+      const innerTypesNames = new Set<string>(Object.values(innerTypes)
+        .map(innerType => innerType.elemID.getFullName()))
+      const typesNotFoundInInnerTypes = [...usedTypes]
+        .filter(usedType => !innerTypesNames.has(usedType))
+      const typesNotFoundInUsedTypes = [...innerTypesNames]
+        .filter(innerType => !usedTypes.has(innerType))
+      expect(typesNotFoundInInnerTypes.length).toEqual(0)
+      expect(typesNotFoundInUsedTypes.length).toEqual(0)
+    })
+    it('should include all of the fields of the original type in the new type', () => {
+      const newFields = new Set<string>(Object.keys(workbook))
+      const unusedFields = Object.keys(datasetType().type).filter(fieldName => !newFields.has(fieldName))
+      expect(unusedFields.length).toEqual(0)
+    })
+  })
+})


### PR DESCRIPTION
Support analytics (workbooks and datasets).

Added new types - workbook, dataset.

Filters:
Created filter to match the objects to the new type on fetch and back to the old one before deploy.
Created filter to add workbooks that must be added to deploy the wanted datasets.

Change Validators:
created change validator to make sure the datasets have a workbook referencing them.
created a change validator to inform the user that the deployment of analytics may have a silent failure.
created a change validator to check if the workbooks are supported (any workbook that contains pivots/charts/datasetLinks is unsupported)

---

_Additional context for reviewer_
Jira ticket: https://salto-io.atlassian.net/browse/SALTO-1872

---
_Release Notes_: 
Users can fetch and deploy analytics with a few limitations:
1. Worbooks that contains pivots/charts/datasetLinks cannot be deployed
2. In some cases, deployments may fail without any warning (silent failure): SDF approves the deployment and indicates success, yet nothing actually happens. We added a warning to check the outcomes in the UI


---
_User Notifications_: 
_Users that fetched analytics before have a definition field (a long string). After that change when they fetch again, this field will disappear and they will have all the information in a convenient form._
