### PR TITLE
SALTO-4669 SALTO-4523 add metadata types to default exclude list

### DIFF
--- a/packages/salesforce-adapter/src/config_creator.ts
+++ b/packages/salesforce-adapter/src/config_creator.ts
@@ -109,6 +109,12 @@ export const configWithCPQ = new InstanceElement(
             metadataType: 'Layout',
             name: 'CaseInteraction-Case Feed Layout',
           },
+          {
+            metadataType: 'EclairGeoData',
+          },
+          {
+            metadataType: 'OmniUiCard|OmniDataTransform|OmniIntegrationProcedure|OmniInteractionAccessConfig|OmniInteractionConfig|OmniScript',
+          },
         ],
       },
       data: {


### PR DESCRIPTION
Add problematic metadata types to default exclude list

---

---
_Release Notes_: 
Salesforce Adapter:
- Add EclairGeoData, OmniUiCard, OmniDataTransform, OmniIntegrationProcedure, OmniInteractionAccessConfig, OmniInteractionConfig, and OmniScript to default exclude list
---
_User Notifications_:  _None_