### PR TITLE
SAAS-4710 Remove duplicate path from getFromPathIndex response

### DIFF
--- a/packages/workspace/src/workspace/path_index.ts
+++ b/packages/workspace/src/workspace/path_index.ts
@@ -246,7 +246,8 @@ export const getFromPathIndex = async (
       // If this is not an exact match we want to return a single hint
       // because otherwise, splitElementByPath will make it appear in multiple fragments
       // and cause merge errors.
-      return isExactMatch ? pathHints : [pathHints[0]]
+      const uniquePathHints = _.uniqWith(pathHints, _.isEqual)
+      return isExactMatch ? uniquePathHints : [uniquePathHints[0]]
     }
     idParts.pop()
     isExactMatch = false

--- a/packages/workspace/src/workspace/path_index.ts
+++ b/packages/workspace/src/workspace/path_index.ts
@@ -172,8 +172,8 @@ export const getTopLevelPathHints = (unmergedElements: Element[]): PathHint[] =>
   return Object.entries(elementsByID)
     .map(([key, value]) => ({
       key,
-      value: value.map(e => e.path as Path),
-    })).map(entry => ({ key: entry.key, value: _.uniqWith(entry.value, _.isEqual) }))
+      value: _.uniqWith(value.map(e => e.path as Path), _.isEqual),
+    }))
 }
 
 export type PathIndexArgs = {

--- a/packages/workspace/src/workspace/path_index.ts
+++ b/packages/workspace/src/workspace/path_index.ts
@@ -192,6 +192,13 @@ const updateIndex = async (
     { getHintsFunction: (unmergedElements: Element[]) => RemoteMapEntry<Path[]>[] }
 ): Promise<void> => {
   const entriesToSet = getHintsFunction(unmergedElements)
+  const uniqueEntriesToSet = entriesToSet.map(entry => {
+    const uniquePaths = _.uniqWith(entry.value, _.isEqual)
+    return {
+      key: entry.key,
+      value: uniquePaths,
+    }
+  })
 
   // Entries that are related to an element that was removed should be deleted
   const entriesToDelete = await awu(pathIndex.keys()).filter(key => {
@@ -206,7 +213,7 @@ const updateIndex = async (
   }).toArray()
 
   await pathIndex.deleteAll(entriesToDelete)
-  await pathIndex.setAll(entriesToSet)
+  await pathIndex.setAll(uniqueEntriesToSet)
 }
 
 export const updatePathIndex = async (args: PathIndexArgs): Promise<void> => log.time(async () => {

--- a/packages/workspace/test/workspace/path_index.test.ts
+++ b/packages/workspace/test/workspace/path_index.test.ts
@@ -236,7 +236,7 @@ describe('getFromPathIndex', () => {
   beforeAll(async () => {
     await index.setAll([
       { key: parentID.getFullName(), value: [nestedPath, parentPath] },
-      { key: nestedID.getFullName(), value: [nestedPath, nestedPath] },
+      { key: nestedID.getFullName(), value: [nestedPath] },
     ])
   })
 
@@ -257,6 +257,13 @@ describe('getFromPathIndex', () => {
 
   it('should return an empty array if no parent matches are found', async () => {
     expect(await getFromPathIndex(new ElemID('salto', 'nothing'), index)).toEqual([])
+  })
+
+  it('should remove duplicate keys from the path index', async () => {
+    await index.setAll([
+      { key: nestedID.getFullName(), value: [nestedPath, nestedPath] },
+    ])
+    expect(await getFromPathIndex(nestedID, index)).toEqual([nestedPath])
   })
 })
 

--- a/packages/workspace/test/workspace/path_index.test.ts
+++ b/packages/workspace/test/workspace/path_index.test.ts
@@ -223,6 +223,43 @@ describe('topLevelPathIndex', () => {
       ]
     )
   })
+
+  it('should remove duplicate paths from the path index', () => {
+    const onePath = ['salto', 'obj', 'one']
+    const elemId = new ElemID('salto', 'obj')
+    const objFragFieldOne = new ObjectType({
+      elemID: elemId,
+      fields: {
+        myField: {
+          refType: createRefToElmWithValue(BuiltinTypes.STRING),
+          annotations: {
+            test: 'test',
+          },
+        },
+      },
+      path: onePath,
+    })
+    const objFragFieldTwo = new ObjectType({
+      elemID: elemId,
+      fields: {
+        myField: {
+          refType: createRefToElmWithValue(BuiltinTypes.NUMBER),
+          annotations: {
+            yo: 'yo',
+          },
+        },
+      },
+      path: onePath,
+    })
+    const pathHints = getElementsPathHints([objFragFieldOne, objFragFieldTwo])
+    expect(pathHints).toEqual(expect.arrayContaining([
+      expect.objectContaining({ key: 'salto.obj', value: [onePath] }),
+      expect.objectContaining({ key: 'salto.obj.field', value: [onePath] }),
+      expect.objectContaining({ key: 'salto.obj.field.myField', value: [onePath] }),
+      expect.objectContaining({ key: 'salto.obj.field.myField.test', value: [onePath] }),
+      expect.objectContaining({ key: 'salto.obj.field.myField.yo', value: [onePath] }),
+    ]))
+  })
 })
 
 describe('getFromPathIndex', () => {
@@ -800,6 +837,42 @@ describe('getElementsPathHints', () => {
       expect.objectContaining({ key: 'salto.primitive.attr.a', value: [aFilePath] }),
       expect.objectContaining({ key: 'salto.primitive.attr.b', value: [bFilePath] }),
       expect.objectContaining({ key: 'salto.primitive', value: [aFilePath, bFilePath] }),
+    ]))
+  })
+
+  it('should remove duplicate paths from the path index', () => {
+    const onePath = ['salto', 'obj', 'one']
+    const objFragFieldOne = new ObjectType({
+      elemID: elemId,
+      fields: {
+        myField: {
+          refType: createRefToElmWithValue(BuiltinTypes.STRING),
+          annotations: {
+            test: 'test',
+          },
+        },
+      },
+      path: onePath,
+    })
+    const objFragFieldTwo = new ObjectType({
+      elemID: elemId,
+      fields: {
+        myField: {
+          refType: createRefToElmWithValue(BuiltinTypes.NUMBER),
+          annotations: {
+            yo: 'yo',
+          },
+        },
+      },
+      path: onePath,
+    })
+    const pathHints = getElementsPathHints([objFragFieldOne, objFragFieldTwo])
+    expect(pathHints).toEqual(expect.arrayContaining([
+      expect.objectContaining({ key: 'salto.obj', value: [onePath] }),
+      expect.objectContaining({ key: 'salto.obj.field', value: [onePath] }),
+      expect.objectContaining({ key: 'salto.obj.field.myField', value: [onePath] }),
+      expect.objectContaining({ key: 'salto.obj.field.myField.test', value: [onePath] }),
+      expect.objectContaining({ key: 'salto.obj.field.myField.yo', value: [onePath] }),
     ]))
   })
 })

--- a/packages/workspace/test/workspace/path_index.test.ts
+++ b/packages/workspace/test/workspace/path_index.test.ts
@@ -236,7 +236,7 @@ describe('getFromPathIndex', () => {
   beforeAll(async () => {
     await index.setAll([
       { key: parentID.getFullName(), value: [nestedPath, parentPath] },
-      { key: nestedID.getFullName(), value: [nestedPath] },
+      { key: nestedID.getFullName(), value: [nestedPath, nestedPath] },
     ])
   })
 


### PR DESCRIPTION
SAAS-4710 Remove duplicate path from getFromPathIndex response

---
_Release Notes_: 
Core:
- fixed bug where restore/fetchFrom on element that has multiple fragments in the same file would create merge errors in nacl

---
_User Notifications_: 
None
