### PR TITLE
SALTO-4747: change path for attachment static file

### DIFF
--- a/packages/zendesk-adapter/e2e_test/adapter.test.ts
+++ b/packages/zendesk-adapter/e2e_test/adapter.test.ts
@@ -738,7 +738,7 @@ describe('Zendesk adapter E2E', () => {
           file_name: fileName,
           content_type: 'image/png',
           content: new StaticFile({
-            filepath: `${ZENDESK}/${ARTICLE_ATTACHMENTS_FIELD}/${GUIDE}/brands/${HELP_CENTER_BRAND_NAME}/categories/${categoryName}/sections/${sectionName}/articles/${articleName}/article_attachment/${fileName}`,
+            filepath: `${ZENDESK}/${ARTICLE_ATTACHMENTS_FIELD}/${GUIDE}/brands/${HELP_CENTER_BRAND_NAME}/categories/${categoryName}/sections/${sectionName}/articles/${articleName}/article_attachment/${fileName}/80f6f478ed_${fileName}`,
             content: fs.readFileSync(path.resolve(`${__dirname}/../e2e_test/images/nacl.png`)),
           }),
           inline: false,
@@ -754,7 +754,7 @@ describe('Zendesk adapter E2E', () => {
           file_name: inlineFileName,
           content_type: 'image/png',
           content: new StaticFile({
-            filepath: `${ZENDESK}/${ARTICLE_ATTACHMENTS_FIELD}/${GUIDE}/brands/${HELP_CENTER_BRAND_NAME}/categories/${categoryName}/sections/${sectionName}/articles/${articleName}/article_attachment/${inlineFileName}`,
+            filepath: `${ZENDESK}/${ARTICLE_ATTACHMENTS_FIELD}/${GUIDE}/brands/${HELP_CENTER_BRAND_NAME}/categories/${categoryName}/sections/${sectionName}/articles/${articleName}/article_attachment/${inlineFileName}/80f6f478ed_${inlineFileName}`,
             content: fs.readFileSync(path.resolve(`${__dirname}/../e2e_test/images/nacl.png`)),
           }),
           inline: true,

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -1904,11 +1904,13 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
         { fieldName: 'id', fieldType: 'number' },
         { fieldName: 'content_url', fieldType: 'string' },
         { fieldName: 'size', fieldType: 'number' },
+        { fieldName: 'hash', fieldType: 'string' },
       ),
       fieldTypeOverrides: [
         { fieldName: 'id', fieldType: 'number' },
         { fieldName: 'article_attachments', fieldType: 'List<article_attachment>' },
         { fieldName: 'content', fieldType: 'string' },
+        { fieldName: 'hash', fieldType: 'string' },
       ],
       fieldsToOmit: FIELDS_TO_OMIT.concat(
         { fieldName: 'article_id', fieldType: 'number' },

--- a/packages/zendesk-adapter/src/filters/article/utils.ts
+++ b/packages/zendesk-adapter/src/filters/article/utils.ts
@@ -155,6 +155,7 @@ const getAttachmentContent = async ({
     filepath: `${ZENDESK}/${attachmentType.elemID.name}/${resourcePathName}`,
     content,
   })
+  attachment.value.hash = attachment.value.content.hash
   return undefined
 }
 

--- a/packages/zendesk-adapter/src/filters/guide_arrange_paths.ts
+++ b/packages/zendesk-adapter/src/filters/guide_arrange_paths.ts
@@ -362,7 +362,7 @@ const filterCreator: FilterCreator = () => ({
           ARTICLE_ATTACHMENTS_FIELD,
           ...path.slice(2, -1),
           normalizeFilePathPart(attachment.value.file_name.split('.')[0]), // file name
-          normalizeFilePathPart(`${staticFile.hash}_${attachment.value.file_name}`), // <hash>_file_name
+          normalizeFilePathPart(`${staticFile.hash.slice(0, 10)}_${attachment.value.file_name}`), // <hash>_file_name
         ]
         attachment.value.content = new StaticFile({
           filepath: staticFilePath.join('/'),

--- a/packages/zendesk-adapter/src/filters/guide_arrange_paths.ts
+++ b/packages/zendesk-adapter/src/filters/guide_arrange_paths.ts
@@ -361,7 +361,8 @@ const filterCreator: FilterCreator = () => ({
           ZENDESK,
           ARTICLE_ATTACHMENTS_FIELD,
           ...path.slice(2, -1),
-          normalizeFilePathPart(attachment.value.file_name),
+          normalizeFilePathPart(attachment.value.file_name.split('.')[0]), // file name
+          normalizeFilePathPart(`${staticFile.hash}_${attachment.value.file_name}`), // <hash>_file_name
         ]
         attachment.value.content = new StaticFile({
           filepath: staticFilePath.join('/'),

--- a/packages/zendesk-adapter/test/filters/guide_arrange_paths.test.ts
+++ b/packages/zendesk-adapter/test/filters/guide_arrange_paths.test.ts
@@ -529,7 +529,7 @@ describe('guide arrange paths', () => {
         'article_name',
         GUIDE_ELEMENT_DIRECTORY[ARTICLE_ATTACHMENT_TYPE_NAME],
         'attachment',
-        `${staticFile.hash}_attachment`,
+        `${staticFile.hash.slice(0, 10)}_attachment`,
       ].join('/'))
       expect(staticFile.isEqual(articleAttachmentInstance.value.content)).toBeTruthy()
     })

--- a/packages/zendesk-adapter/test/filters/guide_arrange_paths.test.ts
+++ b/packages/zendesk-adapter/test/filters/guide_arrange_paths.test.ts
@@ -529,6 +529,7 @@ describe('guide arrange paths', () => {
         'article_name',
         GUIDE_ELEMENT_DIRECTORY[ARTICLE_ATTACHMENT_TYPE_NAME],
         'attachment',
+        `${staticFile.hash}_attachment`,
       ].join('/'))
       expect(staticFile.isEqual(articleAttachmentInstance.value.content)).toBeTruthy()
     })


### PR DESCRIPTION
change path for attachment static file
add the possibility to use `&hash` in `idFields` of `article_attachment`

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* change the path of article attachment static file, the new path will end with `/article_attachment/fileName/<hash>_fileName.png` instead of `/article_attachment/fileName.png`
* add the possibility to use `&hash` in `idFields` of `article_attachment`
---
_User Notifications_: 
zendesk:
* change the path of article attachment static file, the new path will end with `/article_attachment/fileName/<hash>_fileName.png` instead of `/article_attachment/fileName.png`
