### PR TITLE
SALTO-4798 fetch NS bin instances

### DIFF
--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -823,8 +823,9 @@ export const LARGE_TYPES_EXCLUDED_MESSAGE = 'Some types were excluded from the f
  + ' To include them, increase the types elements\' size limitations and remove their exclusion rules.'
 
 const SUPPORT_BINS_DATE = '2023-10-10'
-export const EXCLUDE_BINS_MESSAGE = `The "Bin" type instances are now supported and will be automatically fetched from ${SUPPORT_BINS_DATE}`
- + ' if removed from "fetch.exclude". In order to fetch them before that, remove "bin" from "fetch.exclude" and add it explicitly to "fetch.include".'
+export const EXCLUDE_BINS_MESSAGE = `Starting October 10th, 2023, "Bin" type instances can be fetched by Salto.
+
+To start fetching these instances in your environment, go to your environment configuration, remove "{ name = "bin" }" from the fetch.exclude.types section, then add it to the fetch.include.types section.`
 
 const createFolderExclude = (folderPaths: NetsuiteFilePathsQueryParams): string[] =>
   folderPaths.map(folder => `^${_.escapeRegExp(folder)}.*`)
@@ -1017,6 +1018,7 @@ const splitConfig = (config: NetsuiteConfig): InstanceElement[] => {
   ]
 }
 
+// TODO: remove at December '23 (SALTO-4798)
 export const shouldExcludeBins = async (
   config: NetsuiteConfig,
   elementsSource: ReadOnlyElementsSource
@@ -1039,6 +1041,7 @@ export const getConfigFromConfigChanges = (
   const didUpdateLargeFolders = updateConfigFromLargeFolders(config, failures.failedFilePaths)
   const didUpdateLargeTypes = updateConfigFromLargeTypes(config, failures)
 
+  // TODO: remove at December '23 (SALTO-4798)
   if (excludeBins) {
     config.fetch = {
       ...config.fetch,

--- a/packages/netsuite-adapter/src/constants.ts
+++ b/packages/netsuite-adapter/src/constants.ts
@@ -63,6 +63,7 @@ export const EMPLOYEE = 'employee'
 export const REPORT_DEFINITION = 'reportdefinition'
 export const FINANCIAL_LAYOUT = 'financiallayout'
 export const BUNDLE = 'bundle'
+export const BIN = 'bin'
 
 // Type Annotations
 export const SOURCE = 'source'

--- a/packages/netsuite-adapter/src/data_elements/types.ts
+++ b/packages/netsuite-adapter/src/data_elements/types.ts
@@ -48,7 +48,8 @@ type ItemType = 'assemblyItem' |
 
 type TypeWithMultiFieldsIdentifier = 'accountingPeriod' |
 'nexus' |
-'account'
+'account' |
+'bin'
 
 type TypeWithSingleFieldIdentifier = 'subsidiary' |
 'department' |
@@ -306,6 +307,7 @@ export const TYPE_TO_ID_FIELD_PATHS: Record<TypeWithMultiFieldsIdentifier, strin
   accountingPeriod: [['periodName'], ['fiscalCalendar', 'name']],
   nexus: [['country'], ['state', 'name']],
   account: [['acctName'], ['acctNumber']],
+  bin: [['location', 'name'], ['binNumber']],
 }
 
 export const isTypeWithMultiFieldsIdentifier = (type: string): type is TypeWithMultiFieldsIdentifier =>
@@ -358,6 +360,7 @@ const TYPE_WITH_MULTI_FIELDS_TO_IDENTIFIER: Record<TypeWithMultiFieldsIdentifier
   accountingPeriod: IDENTIFIER_FIELD,
   account: IDENTIFIER_FIELD,
   nexus: IDENTIFIER_FIELD,
+  bin: IDENTIFIER_FIELD,
 }
 
 const supportedTypesToIdentifier: Record<SupportedDataType, string> = {

--- a/packages/netsuite-adapter/src/filters/add_alias.ts
+++ b/packages/netsuite-adapter/src/filters/add_alias.ts
@@ -243,6 +243,7 @@ const dataInstancesAliasMap: Record<SupportedDataType, AliasDataWithMultipleComp
   accountingPeriod: periodNameAlias,
   account: accountNameAlias,
   nexus: identifierAlias,
+  bin: identifierAlias,
 }
 
 const dataTypesAliasMap: Record<SupportedDataType, ConstantAliasData> = {
@@ -284,6 +285,7 @@ const dataTypesAliasMap: Record<SupportedDataType, ConstantAliasData> = {
   accountingPeriod: toConstantAliasData('Accounting Period'),
   account: toConstantAliasData('Account'),
   nexus: toConstantAliasData('Nexus'),
+  bin: toConstantAliasData('Bin'),
 }
 
 const [itemInstances, otherDataInstances] = _.partition(Object.keys(dataInstancesAliasMap), isItemType)

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -432,6 +432,7 @@ describe('Adapter', () => {
           failedCustomRecords: expect.anything(),
         },
         config,
+        { excludeBins: false },
       )
     })
 
@@ -454,6 +455,7 @@ describe('Adapter', () => {
           failedCustomRecords: [],
         },
         config,
+        { excludeBins: false },
       )
     })
 
@@ -515,6 +517,7 @@ describe('Adapter', () => {
           failedCustomRecords: [],
         },
         config,
+        { excludeBins: false },
       )
       expect(fetchResult.updatedConfig).toBeUndefined()
     })
@@ -537,6 +540,7 @@ describe('Adapter', () => {
           failedCustomRecords: [],
         },
         config,
+        { excludeBins: false },
       )
       expect(fetchResult.updatedConfig?.config[0].isEqual(updatedConfig)).toBe(true)
     })
@@ -562,6 +566,7 @@ describe('Adapter', () => {
           failedCustomRecords: [],
         },
         config,
+        { excludeBins: false },
       )
       expect(fetchResult.updatedConfig?.config[0].isEqual(updatedConfig)).toBe(true)
     })
@@ -586,6 +591,7 @@ describe('Adapter', () => {
           failedCustomRecords: [],
         },
         config,
+        { excludeBins: false },
       )
       expect(fetchResult.updatedConfig?.config[0].isEqual(updatedConfig)).toBe(true)
     })
@@ -1410,6 +1416,7 @@ describe('Adapter', () => {
             failedCustomRecords: ['excludedTypeCustomRecord'],
           },
           config,
+          { excludeBins: false },
         )
       })
     })

--- a/packages/netsuite-adapter/test/config.test.ts
+++ b/packages/netsuite-adapter/test/config.test.ts
@@ -67,7 +67,8 @@ describe('config', () => {
         failedTypes: { lockedError: {}, unexpectedError: {}, excludedTypes: [] },
         failedCustomRecords: [],
       },
-      currentConfigWithFetch
+      currentConfigWithFetch,
+      { excludeBins: false }
     )).toBeUndefined()
   })
 
@@ -81,7 +82,8 @@ describe('config', () => {
         failedTypes: { lockedError: lockedTypes, unexpectedError: suggestedSkipListTypes, excludedTypes: [] },
         failedCustomRecords: [],
       },
-      { fetch: fullFetchConfig() }
+      { fetch: fullFetchConfig() },
+      { excludeBins: false }
     )?.config as InstanceElement[]
     expect(configFromConfigChanges[0].isEqual(new InstanceElement(
       ElemID.CONFIG_NAME,
@@ -139,6 +141,7 @@ describe('config', () => {
         failedCustomRecords: ['excludedCustomRecord'],
       },
       currentConfigWithFetch,
+      { excludeBins: false }
     )
     expect(configChange?.config[0]
       .isEqual(new InstanceElement(
@@ -184,7 +187,8 @@ describe('config', () => {
         failedTypes: { lockedError: {}, unexpectedError: {}, excludedTypes: [] },
         failedCustomRecords: [],
       },
-      config
+      config,
+      { excludeBins: false }
     )
 
     expect(configChange?.message)


### PR DESCRIPTION
Add support in `bin` instances and exclude it by default.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Support fetching `bin` instances. To start fetching `bin` instances in your environment, go to your environment configuration, remove `{ name = "bin" }` from the `fetch.exclude.types` section, then add it to the `fetch.include.types` section.

---
_User Notifications_: 
Netsuite Adapter:
- `bin` will be added to `fetch.exclude.types` configuration.