### PR TITLE
SALTO-2349: Fixing mistake in additionalRequestContext

### DIFF
--- a/packages/adapter-components/src/elements/ducktype/transformer.ts
+++ b/packages/adapter-components/src/elements/ducktype/transformer.ts
@@ -388,7 +388,7 @@ export const getAllElements = async ({
     paginator,
     nestedFieldFinder,
     computeGetArgs,
-    requestContext: additionalRequestContext,
+    additionalRequestContext,
     typesConfig: types,
     typeDefaultConfig: typeDefaults,
     getElemIdFunc,


### PR DESCRIPTION
Fixing a mistake in adapter components - should be additionalRequestContext.

---

None

---
_Release Notes_: 
None

---
_User Notifications_: 
None
