### PR TITLE
SALTO-4581 - Salesforce: Fix validation of broken ref config

### DIFF
--- a/packages/salesforce-adapter/src/fetch_profile/data_management.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/data_management.ts
@@ -19,6 +19,7 @@ import { ConfigValidationError, validateRegularExpressions } from '../config_val
 import {
   DataManagementConfig,
   OutgoingReferenceBehavior,
+  outgoingReferenceBehaviors,
 } from '../types'
 import { DETECTS_PARENTS_INDICATOR } from '../constants'
 import { apiName } from '../transformers/transformer'
@@ -192,6 +193,15 @@ export const validateDataManagementConfig = (
     validateRegularExpressions(
       saltoAliasOverrides.map(override => override.objectsRegex),
       [...fieldPath, 'saltoAliasSettings', 'overrides'],
+    )
+  }
+  if (dataManagementConfig.brokenOutgoingReferencesSettings?.perTargetTypeOverrides !== undefined) {
+    Object.entries(dataManagementConfig.brokenOutgoingReferencesSettings.perTargetTypeOverrides).forEach(
+      ([type, outgoingRefBehavior]) => {
+        if (!outgoingReferenceBehaviors.includes(outgoingRefBehavior)) {
+          throw new ConfigValidationError([...fieldPath, 'brokenOutgoingReferencesSettings', 'perTargetTypeOverrides', type], `Per-target broken reference behavior must be one of ${outgoingReferenceBehaviors.join(',')}`)
+        }
+      }
     )
   }
 }

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -148,7 +148,7 @@ export type SaltoManagementFieldSettings = {
   defaultFieldName: string
 }
 
-const outgoingReferenceBehaviors = ['ExcludeInstance', 'BrokenReference', 'InternalId'] as const
+export const outgoingReferenceBehaviors = ['ExcludeInstance', 'BrokenReference', 'InternalId'] as const
 export type OutgoingReferenceBehavior = typeof outgoingReferenceBehaviors[number]
 
 export type BrokenOutgoingReferencesSettings = {
@@ -257,11 +257,6 @@ const brokenOutgoingReferencesSettingsType = new ObjectType({
     },
     perTargetTypeOverrides: {
       refType: new MapType(BuiltinTypes.STRING),
-      annotations: {
-        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({
-          values: outgoingReferenceBehaviors,
-        }),
-      },
     },
   },
   annotations: {


### PR DESCRIPTION
Follow-up to https://github.com/salto-io/salto/pull/4853 where we move the validation of the nested fields to a function, since using restrictions doesn't work as expected.
---


---
_Release Notes_: 
N/A

---
_User Notifications_: 
N/A