### PR TITLE
SALTO-4804 Add calculatePatchFromChanges API

### DIFF
--- a/packages/adapter-api/src/change.ts
+++ b/packages/adapter-api/src/change.ts
@@ -18,7 +18,7 @@ import {
 } from '@salto-io/dag'
 import { values as lowerDashValues } from '@salto-io/lowerdash'
 import {
-  ObjectType, InstanceElement, Field, isInstanceElement, isObjectType, isField, TypeElement,
+  ObjectType, InstanceElement, Field, isInstanceElement, isObjectType, isField, TopLevelElement,
 } from './elements'
 import { ElemID } from './element_id'
 import { Values, Value } from './values'
@@ -27,7 +27,7 @@ const { isDefined } = lowerDashValues
 
 export { ActionName }
 
-export type ChangeDataType = TypeElement | InstanceElement | Field
+export type ChangeDataType = TopLevelElement | Field
 export type AdditionChange<T> = AdditionDiff<T>
 export type ModificationChange<T> = ModificationDiff<T>
 export type RemovalChange<T> = RemovalDiff<T>

--- a/packages/adapter-api/src/elements.ts
+++ b/packages/adapter-api/src/elements.ts
@@ -148,7 +148,7 @@ export enum PrimitiveTypes {
 
 export type ContainerType = ListType | MapType
 export type TypeElement = PrimitiveType | ObjectType | ContainerType
-export type TopLevelElement = ObjectType | InstanceElement
+export type TopLevelElement = TypeElement | InstanceElement
 export type TypeMap = Record<string, TypeElement>
 type TypeOrRef<T extends TypeElement = TypeElement> = T | TypeReference
 export type TypeRefMap = Record<string, TypeOrRef>

--- a/packages/adapter-api/src/elements.ts
+++ b/packages/adapter-api/src/elements.ts
@@ -148,6 +148,7 @@ export enum PrimitiveTypes {
 
 export type ContainerType = ListType | MapType
 export type TypeElement = PrimitiveType | ObjectType | ContainerType
+export type TopLevelElement = ObjectType | InstanceElement
 export type TypeMap = Record<string, TypeElement>
 type TypeOrRef<T extends TypeElement = TypeElement> = T | TypeReference
 export type TypeRefMap = Record<string, TypeOrRef>

--- a/packages/adapter-components/src/add_alias.ts
+++ b/packages/adapter-components/src/add_alias.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { InstanceElement, CORE_ANNOTATIONS, ElemID, INSTANCE_ANNOTATIONS, isReferenceExpression, ObjectType, isInstanceElement, Value } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, ElemID, INSTANCE_ANNOTATIONS, isReferenceExpression, isInstanceElement, Value, TopLevelElement } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 
 const log = logger(module)
@@ -33,12 +33,11 @@ export type AliasData<T extends Component[] = Component[]> = {
   separator?: string
 }
 
-type SupportedElement = ObjectType | InstanceElement
 
 const isInstanceAnnotation = (field: string): boolean =>
   Object.values(INSTANCE_ANNOTATIONS).includes(field.split(ElemID.NAMESPACE_SEPARATOR)[0])
 
-const isValidAlias = (aliasParts: (string | undefined)[], element: SupportedElement): boolean =>
+const isValidAlias = (aliasParts: (string | undefined)[], element: TopLevelElement): boolean =>
   aliasParts.every((val, index) => {
     if (val === undefined) {
       log.debug(`for element ${element.elemID.getFullName()}, component number ${index} in the alias map resulted in undefined`)
@@ -47,16 +46,16 @@ const isValidAlias = (aliasParts: (string | undefined)[], element: SupportedElem
     return true
   })
 
-const getFieldValue = (element: SupportedElement, fieldName: string): Value => (
+const getFieldValue = (element: TopLevelElement, fieldName: string): Value => (
   !isInstanceElement(element) || isInstanceAnnotation(fieldName)
     ? _.get(element.annotations, fieldName)
     : _.get(element.value, fieldName)
 )
 
 const getAliasFromField = ({ element, component, elementsById }:{
-  element: SupportedElement
+  element: TopLevelElement
   component: AliasComponent
-  elementsById: Record<string, SupportedElement>
+  elementsById: Record<string, TopLevelElement>
 }): string | undefined => {
   const { fieldName, referenceFieldName } = component
 
@@ -83,8 +82,8 @@ const isConstantComponent = (
 ): component is ConstantComponent => 'constant' in component
 
 const calculateAlias = ({ element, elementsById, aliasData }: {
-  element: SupportedElement
-  elementsById: Record<string, SupportedElement>
+  element: TopLevelElement
+  elementsById: Record<string, TopLevelElement>
   aliasData: AliasData
 }): string | undefined => {
   const { aliasComponents, separator = ' ' } = aliasData
@@ -105,7 +104,7 @@ export const addAliasToElements = ({
   aliasMap,
   secondIterationGroupNames = [],
 }: {
-  elementsMap: Record<string, SupportedElement[]>
+  elementsMap: Record<string, TopLevelElement[]>
   aliasMap: Record<string, AliasData>
   secondIterationGroupNames?: string[]
 }): void => {

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -36,12 +36,15 @@ import {
   isAdditionOrModificationChange,
   ChangeError,
   AdapterOperations,
+  TopLevelElement,
+  isAdditionChange,
+  isRemovalChange,
 } from '@salto-io/adapter-api'
 import { EventEmitter } from 'pietile-eventemitter'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { promises, collections, values, objects } from '@salto-io/lowerdash'
-import { Workspace, ElementSelector, elementSource, expressions, merger, selectElementIdsByTraversal, isTopLevelSelector } from '@salto-io/workspace'
+import { Workspace, ElementSelector, elementSource, expressions, merger, selectElementIdsByTraversal, isTopLevelSelector, pathIndex as pathIndexModule } from '@salto-io/workspace'
 import { EOL } from 'os'
 import {
   buildElementsSourceFromElements,
@@ -356,6 +359,42 @@ export const fetchFromWorkspace: FetchFromWorkspaceFunc = async ({
     accountNameToConfigMessage,
     progressEmitter,
   }
+}
+
+type CalculatePatchFromChangesArgs = {
+  workspace: Workspace
+  changes: Change<TopLevelElement>[]
+  pathIndex: pathIndexModule.PathIndex
+}
+
+export const calculatePatchFromChanges = async (
+  {
+    workspace,
+    changes,
+    pathIndex,
+  }: CalculatePatchFromChangesArgs,
+): Promise<FetchChange[]> => {
+  const [additions, removalAndModifications] = _.partition(changes, isAdditionChange)
+  const [removals, modifications] = _.partition(removalAndModifications, isRemovalChange)
+  const beforeElements = [...removals, ...modifications].map(change => change.data.before)
+  const afterElements = [...additions, ...modifications].map(change => change.data.after)
+  const unmergedAfterElements = await awu(afterElements)
+    .flatMap(element => pathIndexModule.splitElementByPath(element, pathIndex))
+    .toArray()
+  const accounts = [...beforeElements, ...afterElements].map(element => element.elemID.adapter)
+  const partialFetchData = new Map(accounts.map(account => [account, { deletedElements: new Set<string>() }]))
+  removals.map(change => getChangeData(change).elemID).forEach(id => {
+    partialFetchData.get(id.adapter)?.deletedElements.add(id.getFullName())
+  })
+  const result = await calcFetchChanges(
+    unmergedAfterElements,
+    afterElements,
+    elementSource.createInMemoryElementSource(beforeElements),
+    await workspace.elements(),
+    partialFetchData,
+    new Set(accounts),
+  )
+  return result.changes
 }
 
 type CalculatePatchArgs = {

--- a/packages/netsuite-adapter/src/client/types.ts
+++ b/packages/netsuite-adapter/src/client/types.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, ChangeData, ElemID, getChangeData, InstanceElement, isInstanceChange, isObjectType, isObjectTypeChange, TopLevelElement, Values } from '@salto-io/adapter-api'
+import { Change, ChangeData, ElemID, getChangeData, InstanceElement, isInstanceChange, isObjectType, isObjectTypeChange, ObjectType, TopLevelElement, Values } from '@salto-io/adapter-api'
 import { toCustomRecordTypeInstance } from '../custom_records/custom_record_type'
 import { NetsuiteFilePathsQueryParams, NetsuiteTypesQueryParams, ObjectID } from '../query'
 
@@ -124,7 +124,7 @@ export class InvalidSuiteAppCredentialsError extends Error {
   }
 }
 
-export type DeployableChange = Change<TopLevelElement>
+export type DeployableChange = Change<ObjectType | InstanceElement>
 
 export type SDFObjectNode = {
   change: DeployableChange

--- a/packages/netsuite-adapter/src/client/types.ts
+++ b/packages/netsuite-adapter/src/client/types.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, ChangeData, ElemID, getChangeData, InstanceElement, isInstanceChange, isObjectType, isObjectTypeChange, ObjectType, Values } from '@salto-io/adapter-api'
+import { Change, ChangeData, ElemID, getChangeData, InstanceElement, isInstanceChange, isObjectType, isObjectTypeChange, TopLevelElement, Values } from '@salto-io/adapter-api'
 import { toCustomRecordTypeInstance } from '../custom_records/custom_record_type'
 import { NetsuiteFilePathsQueryParams, NetsuiteTypesQueryParams, ObjectID } from '../query'
 
@@ -87,7 +87,7 @@ export type ImportObjectsResult = {
 }
 
 export type DataElementsResult = {
-  elements: (ObjectType | InstanceElement)[]
+  elements: TopLevelElement[]
   requestedTypes: string[]
   largeTypesError: string[]
 }
@@ -124,7 +124,7 @@ export class InvalidSuiteAppCredentialsError extends Error {
   }
 }
 
-export type DeployableChange = Change<ObjectType | InstanceElement>
+export type DeployableChange = Change<TopLevelElement>
 
 export type SDFObjectNode = {
   change: DeployableChange

--- a/packages/netsuite-adapter/src/reference_dependencies.ts
+++ b/packages/netsuite-adapter/src/reference_dependencies.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import {
   isInstanceElement, isPrimitiveType, ElemID, getFieldType,
-  isReferenceExpression, Value, isServiceId, isObjectType, ChangeDataType, ObjectType, InstanceElement,
+  isReferenceExpression, Value, isServiceId, isObjectType, ChangeDataType, TopLevelElement,
 } from '@salto-io/adapter-api'
 import { transformElement, TransformFunc } from '@salto-io/adapter-utils'
 import { values as lowerDashValues, collections } from '@salto-io/lowerdash'
@@ -30,7 +30,6 @@ const { awu } = collections.asynciterable
 const { isDefined } = lowerDashValues
 const log = logger(module)
 
-type TopLevelElement = ObjectType | InstanceElement
 const isTopLevelElement = (value: unknown): value is TopLevelElement =>
   isObjectType(value) || isInstanceElement(value)
 

--- a/packages/netsuite-adapter/src/suiteapp_config_elements.ts
+++ b/packages/netsuite-adapter/src/suiteapp_config_elements.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { BuiltinTypes, ElemID, getChangeData, InstanceElement, isInstanceElement, ModificationChange, ObjectType } from '@salto-io/adapter-api'
+import { BuiltinTypes, ElemID, getChangeData, InstanceElement, isInstanceElement, ModificationChange, ObjectType, TopLevelElement } from '@salto-io/adapter-api'
 import { NETSUITE, SELECT_OPTION, SETTINGS_PATH, TYPES_PATH } from './constants'
 import { SUITEAPP_CONFIG_TYPES_TO_TYPE_NAMES, DeployResult } from './types'
 import { NetsuiteQuery } from './query'
@@ -32,9 +32,7 @@ export const getConfigTypes = (): ObjectType[] => ([new ObjectType({
 export const toConfigElements = (
   configRecords: ConfigRecord[],
   fetchQuery: NetsuiteQuery
-): (
-  ObjectType | InstanceElement
-)[] => {
+): TopLevelElement[] => {
   const elements = configRecords
     .flatMap(configRecord => {
       const typeName = SUITEAPP_CONFIG_TYPES_TO_TYPE_NAMES[configRecord.configType]

--- a/packages/netsuite-adapter/src/transformer.ts
+++ b/packages/netsuite-adapter/src/transformer.ts
@@ -19,11 +19,11 @@ import {
   OBJECT_SERVICE_ID, OBJECT_NAME, toServiceIdsString, ServiceIds,
   isInstanceElement,
   ElemIDType,
-  TypeElement,
   BuiltinTypes,
   ReadOnlyElementsSource,
   CORE_ANNOTATIONS,
   TypeReference,
+  TopLevelElement,
 } from '@salto-io/adapter-api'
 import { MapKeyFunc, mapKeysRecursive, TransformFunc, transformValues, GetLookupNameFunc, naclCase, pathNaclCase } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
@@ -201,7 +201,7 @@ export const createElements = async (
   customizationInfos: CustomizationInfo[],
   elementsSource: ReadOnlyElementsSource,
   getElemIdFunc?: ElemIdGetter,
-): Promise<Array<InstanceElement | TypeElement>> => {
+): Promise<Array<TopLevelElement>> => {
   const { standardTypes, additionalTypes, innerAdditionalTypes } = getMetadataTypes()
 
   getTopLevelStandardTypes(standardTypes).concat(Object.values(additionalTypes))


### PR DESCRIPTION
This API is similar to `calculatePatch`, except it gets a list of changes, a workspace and a path index (to split the changes into fragments) - and calculates the fetch changes of the patch, including conflicts (where the value in the workspace is different from the value in the changes' `before`).

---

_Additional context for reviewer_

---
_Release Notes_: 
Core:
- Add calculatePatchFromChanges API

---
_User Notifications_: 
None