### PR TITLE
SALTO-4653 - Salesforce: Add change validator on deletions of non-queryable customFields

### DIFF
--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -92,7 +92,7 @@ export const changeValidators: Record<ChangeValidatorName, ChangeValidatorCreato
   installedPackages: () => installedPackages,
   dataCategoryGroup: () => dataCategoryGroupValidator,
   standardFieldOrObjectAdditionsOrDeletions: () => standardFieldOrObjectAdditionsOrDeletions,
-  deletedNonQueryableFields,
+  deletedNonQueryableFields: () => deletedNonQueryableFields,
   ..._.mapValues(getDefaultChangeValidators(), validator => (() => validator)),
 }
 

--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -46,6 +46,7 @@ import accountSettings from './change_validators/account_settings'
 import installedPackages from './change_validators/installed_packages'
 import dataCategoryGroupValidator from './change_validators/data_category_group'
 import standardFieldOrObjectAdditionsOrDeletions from './change_validators/standard_field_or_object_additions_or_deletions'
+import deletedNonQueryableFields from './change_validators/deleted_non_queryable_fields'
 import SalesforceClient from './client/client'
 import { ChangeValidatorName, DEPLOY_CONFIG, SalesforceConfig } from './types'
 
@@ -91,6 +92,7 @@ export const changeValidators: Record<ChangeValidatorName, ChangeValidatorCreato
   installedPackages: () => installedPackages,
   dataCategoryGroup: () => dataCategoryGroupValidator,
   standardFieldOrObjectAdditionsOrDeletions: () => standardFieldOrObjectAdditionsOrDeletions,
+  deletedNonQueryableFields,
   ..._.mapValues(getDefaultChangeValidators(), validator => (() => validator)),
 }
 

--- a/packages/salesforce-adapter/src/change_validators/deleted_non_queryable_fields.ts
+++ b/packages/salesforce-adapter/src/change_validators/deleted_non_queryable_fields.ts
@@ -34,8 +34,7 @@ const { isNonEmptyArray } = types
 
 const getVisibleNonQueryableFieldsOfInstanceType = (instance: InstanceElement): string[] => (
   Object.values(instance.getTypeSync().fields)
-    .filter(field => !isQueryableField(field))
-    .filter(field => !isReadOnlyField(field) && !isHiddenField(field))
+    .filter(field => !isQueryableField(field) && !isReadOnlyField(field) && !isHiddenField(field))
     .map(field => apiNameSync(field))
     .filter(isDefined)
 )

--- a/packages/salesforce-adapter/src/change_validators/deleted_non_queryable_fields.ts
+++ b/packages/salesforce-adapter/src/change_validators/deleted_non_queryable_fields.ts
@@ -58,7 +58,7 @@ const createNonQueryableFieldsWarning = (
   {
     elemID: instance.elemID,
     severity: 'Warning',
-    message: `The type of this instance (${instance.getTypeSync()}) has inaccessible fields. Deploying the instance may be interpreted as deleting these fields.`,
+    message: `The type of this instance (${apiNameSync(instance.getTypeSync())}) has inaccessible fields. Deploying the instance may be interpreted as deleting these fields.`,
     detailedMessage: `The following fields were not readable/queryable by the user who last fetched this workspace. As a result, these fields are seen as empty, and when they are deployed their values will be erased in the target environment: ${fields.join(',')}`,
   }
 )

--- a/packages/salesforce-adapter/src/change_validators/deleted_non_queryable_fields.ts
+++ b/packages/salesforce-adapter/src/change_validators/deleted_non_queryable_fields.ts
@@ -20,29 +20,17 @@ import {
   getChangeData,
   InstanceElement,
   ChangeError,
-  Field,
-  CORE_ANNOTATIONS,
 } from '@salto-io/adapter-api'
 import { values, types } from '@salto-io/lowerdash'
-import { FIELD_ANNOTATIONS } from '../constants'
 import {
   apiNameSync,
+  isHiddenField,
+  isQueryableField,
+  isReadOnlyField,
 } from '../filters/utils'
 
 const { isDefined } = values
 const { isNonEmptyArray } = types
-
-const isQueryableField = (field: Field): boolean => (
-  field.annotations[FIELD_ANNOTATIONS.QUERYABLE] === true
-)
-
-const isHiddenField = (field: Field): boolean => (
-  field.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE] === true
-)
-
-const isReadOnlyField = (field: Field): boolean => (
-  !field.annotations[FIELD_ANNOTATIONS.CREATABLE] && !field.annotations[FIELD_ANNOTATIONS.UPDATEABLE]
-)
 
 const getVisibleNonQueryableFieldsOfInstanceType = (instance: InstanceElement): string[] => (
   Object.values(instance.getTypeSync().fields)

--- a/packages/salesforce-adapter/src/change_validators/deleted_non_queryable_fields.ts
+++ b/packages/salesforce-adapter/src/change_validators/deleted_non_queryable_fields.ts
@@ -68,7 +68,7 @@ const createNonQueryableFieldsWarning = (
  * will be fetched without values for said fields. If we later try to deploy these instances, these missing values are
  * interpreted as if we want to delete the values of these fields. This is probably not what the user wants.
  * */
-const changeValidator = (): ChangeValidator => async changes => (
+const changeValidator: ChangeValidator = async changes => (
   changes
     .filter(isInstanceChange)
     .filter(isModificationChange)

--- a/packages/salesforce-adapter/src/change_validators/deleted_non_queryable_fields.ts
+++ b/packages/salesforce-adapter/src/change_validators/deleted_non_queryable_fields.ts
@@ -1,0 +1,81 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  ChangeValidator,
+  isModificationChange,
+  isInstanceChange,
+  getChangeData,
+  InstanceElement,
+  ChangeError,
+  Field,
+  CORE_ANNOTATIONS,
+} from '@salto-io/adapter-api'
+import { values, types } from '@salto-io/lowerdash'
+import { FIELD_ANNOTATIONS } from '../constants'
+import {
+  apiNameSync,
+} from '../filters/utils'
+
+const { isDefined } = values
+const { isNonEmptyArray } = types
+
+const isQueryableField = (field: Field): boolean => (
+  field.annotations[FIELD_ANNOTATIONS.QUERYABLE] === true
+)
+
+const isHiddenField = (field: Field): boolean => (
+  field.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE] === true
+)
+
+const isReadOnlyField = (field: Field): boolean => (
+  !field.annotations[FIELD_ANNOTATIONS.CREATABLE] && !field.annotations[FIELD_ANNOTATIONS.UPDATEABLE]
+)
+
+const getVisibleNonQueryableFieldsOfInstanceType = (instance: InstanceElement): string[] => (
+  Object.values(instance.getTypeSync().fields)
+    .filter(field => !isQueryableField(field))
+    .filter(field => !isReadOnlyField(field) && !isHiddenField(field))
+    .map(field => apiNameSync(field))
+    .filter(isDefined)
+)
+
+const createNonQueryableFieldsWarning = (
+  { instance, fields }: { instance: InstanceElement; fields: string[] }
+): ChangeError => (
+  {
+    elemID: instance.elemID,
+    severity: 'Warning',
+    message: `The type of this instance (${instance.getTypeSync()}) has inaccessible fields. Deploying the instance may be interpreted as deleting these fields.`,
+    detailedMessage: `The following fields were not readable/queryable by the user who last fetched this workspace. As a result, these fields are seen as empty, and when they are deployed their values will be erased in the target environment: ${fields.join(',')}`,
+  }
+)
+
+/**
+ * When we fetch a type that has some fields that are not queryable by the fetching user, any instances of this type
+ * will be fetched without values for said fields. If we later try to deploy these instances, these missing values are
+ * interpreted as if we want to delete the values of these fields. This is probably not what the user wants.
+ * */
+const changeValidator = (): ChangeValidator => async changes => (
+  changes
+    .filter(isInstanceChange)
+    .filter(isModificationChange)
+    .map(getChangeData)
+    .map(instance => ({ instance, fields: getVisibleNonQueryableFieldsOfInstanceType(instance) }))
+    .filter(({ fields }) => isNonEmptyArray(fields))
+    .map(createNonQueryableFieldsWarning)
+)
+
+export default changeValidator

--- a/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
@@ -49,7 +49,12 @@ import {
   KEY_PREFIX_LENGTH,
   SALESFORCE,
 } from '../constants'
-import { isLookupField, isMasterDetailField, safeApiName } from './utils'
+import {
+  isLookupField,
+  isMasterDetailField,
+  isReadOnlyField,
+  safeApiName,
+} from './utils'
 import { DataManagement } from '../fetch_profile/data_management'
 
 const { makeArray } = collections.array
@@ -198,11 +203,6 @@ const replaceLookupsWithRefsAndCreateRefMap = async (
     instance: InstanceElement
   ): Promise<Values> => {
     const transformFunc: TransformFunc = async ({ value, field }) => {
-      const isReadOnlyField = (fieldToCheck: Field): boolean => (
-        !(fieldToCheck?.annotations?.[FIELD_ANNOTATIONS.CREATABLE] ?? true)
-        && !(fieldToCheck?.annotations?.[FIELD_ANNOTATIONS.UPDATEABLE] ?? true)
-      )
-
       if (!isReferenceField(field)) {
         return value
       }

--- a/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
@@ -44,6 +44,7 @@ import {
   buildSelectQueries,
   getFieldNamesForQuery,
   safeApiName,
+  isQueryableField,
 } from './utils'
 import { ConfigChangeSuggestion } from '../types'
 import { DataManagement } from '../fetch_profile/data_management'
@@ -81,10 +82,6 @@ const isReferenceField = (field: Field): boolean => (
 
 const getReferenceTo = (field: Field): string[] =>
   makeArray(field.annotations[FIELD_ANNOTATIONS.REFERENCE_TO]) as string[]
-
-const isQueryableField = (field: Field): boolean => (
-  field.annotations[FIELD_ANNOTATIONS.QUERYABLE] === true
-)
 
 const getQueryableFields = (object: ObjectType): Field[] => (
   Object.values(object.fields).filter(isQueryableField)

--- a/packages/salesforce-adapter/src/filters/utils.ts
+++ b/packages/salesforce-adapter/src/filters/utils.ts
@@ -49,9 +49,12 @@ import SalesforceClient from '../client/client'
 import { INSTANCE_SUFFIXES, OptionalFeatures } from '../types'
 import {
   API_NAME,
-  API_NAME_SEPARATOR, CUSTOM_FIELD,
+  API_NAME_SEPARATOR,
+  CUSTOM_FIELD,
   CUSTOM_METADATA_SUFFIX,
-  CUSTOM_OBJECT, CUSTOM_OBJECT_ID_FIELD,
+  CUSTOM_OBJECT,
+  CUSTOM_OBJECT_ID_FIELD,
+  FIELD_ANNOTATIONS,
   INSTANCE_FULL_NAME_FIELD,
   INTERNAL_ID_ANNOTATION,
   INTERNAL_ID_FIELD,
@@ -169,6 +172,18 @@ export const isMasterDetailField = (field: Field): boolean => (
 
 export const isLookupField = (field: Field): boolean => (
   field.refType.elemID.isEqual(Types.primitiveDataTypes.Lookup.elemID)
+)
+
+export const isQueryableField = (field: Field): boolean => (
+  field.annotations[FIELD_ANNOTATIONS.QUERYABLE] === true
+)
+
+export const isHiddenField = (field: Field): boolean => (
+  field.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE] === true
+)
+
+export const isReadOnlyField = (field: Field): boolean => (
+  !field.annotations[FIELD_ANNOTATIONS.CREATABLE] && !field.annotations[FIELD_ANNOTATIONS.UPDATEABLE]
 )
 
 export const getInstancesOfMetadataType = async (elements: Element[], metadataTypeName: string):

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -122,6 +122,7 @@ export type ChangeValidatorName = (
   | 'installedPackages'
   | 'dataCategoryGroup'
   | 'standardFieldOrObjectAdditionsOrDeletions'
+  | 'deletedNonQueryableFields'
 )
 
 type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
@@ -731,6 +732,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     dataCategoryGroup: { refType: BuiltinTypes.BOOLEAN },
     installedPackages: { refType: BuiltinTypes.BOOLEAN },
     standardFieldOrObjectAdditionsOrDeletions: { refType: BuiltinTypes.BOOLEAN },
+    deletedNonQueryableFields: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/salesforce-adapter/test/change_validators/deleted_non_queryable_fields.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/deleted_non_queryable_fields.test.ts
@@ -16,7 +16,6 @@
 import {
   BuiltinTypes,
   ChangeError,
-  ChangeValidator,
   CORE_ANNOTATIONS,
   getChangeData,
   InstanceElement,
@@ -30,10 +29,9 @@ import {
 } from '../utils'
 import { createInstanceElement } from '../../src/transformers/transformer'
 import { FIELD_ANNOTATIONS } from '../../src/constants'
-import deletedNonQueryableFields from '../../src/change_validators/deleted_non_queryable_fields'
+import changeValidator from '../../src/change_validators/deleted_non_queryable_fields'
 
 describe('deletedNonQueryableFields', () => {
-  let changeValidator: ChangeValidator
   let warnings: ReadonlyArray<ChangeError>
 
   const createTypeForTest = (
@@ -56,11 +54,6 @@ describe('deletedNonQueryableFields', () => {
     })
     return type
   }
-
-
-  beforeEach(() => {
-    changeValidator = deletedNonQueryableFields()
-  })
 
   describe('addition change', () => {
     describe('some fields are non-queryable', () => {

--- a/packages/salesforce-adapter/test/change_validators/deleted_non_queryable_fields.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/deleted_non_queryable_fields.test.ts
@@ -1,0 +1,141 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  BuiltinTypes,
+  ChangeError,
+  ChangeValidator,
+  CORE_ANNOTATIONS,
+  InstanceElement,
+  ModificationChange,
+  ObjectType,
+  toChange,
+} from '@salto-io/adapter-api'
+import {
+  createCustomObjectType,
+  createField,
+} from '../utils'
+import { createInstanceElement } from '../../src/transformers/transformer'
+import { FIELD_ANNOTATIONS } from '../../src/constants'
+import deletedNonQueryableFields from '../../src/change_validators/deleted_non_queryable_fields'
+
+describe('deletedNonQueryableFields', () => {
+  let changeValidator: ChangeValidator
+  let warnings: ReadonlyArray<ChangeError>
+
+  const createTypeForTest = (
+    {
+      fieldIsQueryable,
+      fieldIsReadOnly,
+      fieldIsHidden,
+    }: {
+      fieldIsQueryable: boolean
+      fieldIsReadOnly: boolean
+      fieldIsHidden: boolean
+    }
+  ): ObjectType => {
+    const type = createCustomObjectType('SomeType', {})
+    createField(type, BuiltinTypes.BOOLEAN, 'SomeField', {
+      [FIELD_ANNOTATIONS.QUERYABLE]: fieldIsQueryable,
+      [FIELD_ANNOTATIONS.CREATABLE]: !fieldIsReadOnly,
+      [FIELD_ANNOTATIONS.UPDATEABLE]: !fieldIsReadOnly,
+      [CORE_ANNOTATIONS.HIDDEN_VALUE]: fieldIsHidden,
+    })
+    return type
+  }
+
+
+  beforeEach(() => {
+    changeValidator = deletedNonQueryableFields()
+  })
+
+  describe('addition change', () => {
+    describe('some fields are non-queryable', () => {
+      beforeEach(async () => {
+        const objectType = createTypeForTest({
+          fieldIsQueryable: false,
+          fieldIsHidden: false,
+          fieldIsReadOnly: false,
+        })
+        const instance = createInstanceElement({ fullName: 'SomeInstance', SomeField: true }, objectType)
+        warnings = await changeValidator([toChange({ after: instance })])
+      })
+      it('should not warn', () => {
+        expect(warnings).toBeEmpty()
+      })
+    })
+  })
+
+  describe('modification change', () => {
+    const createInstanceChangeForType = (objectType: ObjectType): ModificationChange<InstanceElement> => {
+      const instanceBefore = createInstanceElement({ fullName: 'SomeInstance', SomeField: true }, objectType)
+      const instanceAfter = instanceBefore.clone()
+      instanceAfter.value.SomeField = false
+      return toChange({ before: instanceBefore, after: instanceAfter }) as ModificationChange<InstanceElement>
+    }
+    describe('all fields are queryable', () => {
+      beforeEach(async () => {
+        const objectType = createTypeForTest({
+          fieldIsQueryable: true,
+          fieldIsHidden: false,
+          fieldIsReadOnly: false,
+        })
+        warnings = await changeValidator([createInstanceChangeForType(objectType)])
+      })
+      it('should not warn', () => {
+        expect(warnings).toBeEmpty()
+      })
+    })
+    describe('the only non-queryable fields are hidden', () => {
+      beforeEach(async () => {
+        const typeWithQueryableFields = createTypeForTest({
+          fieldIsQueryable: false,
+          fieldIsHidden: true,
+          fieldIsReadOnly: false,
+        })
+        warnings = await changeValidator([createInstanceChangeForType(typeWithQueryableFields)])
+      })
+      it('should not warn', () => {
+        expect(warnings).toBeEmpty()
+      })
+    })
+    describe('the only non-queryable fields are read-only', () => {
+      beforeEach(async () => {
+        const typeWithQueryableFields = createTypeForTest({
+          fieldIsQueryable: false,
+          fieldIsHidden: false,
+          fieldIsReadOnly: true,
+        })
+        warnings = await changeValidator([createInstanceChangeForType(typeWithQueryableFields)])
+      })
+      it('should not warn', () => {
+        expect(warnings).toBeEmpty()
+      })
+    })
+    describe('there are non-system non-queryable fields', () => {
+      beforeEach(async () => {
+        const typeWithQueryableFields = createTypeForTest({
+          fieldIsQueryable: false,
+          fieldIsHidden: false,
+          fieldIsReadOnly: false,
+        })
+        warnings = await changeValidator([createInstanceChangeForType(typeWithQueryableFields)])
+      })
+      it('should warn', () => {
+        expect(warnings).not.toBeEmpty()
+      })
+    })
+  })
+})

--- a/packages/salesforce-adapter/test/change_validators/deleted_non_queryable_fields.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/deleted_non_queryable_fields.test.ts
@@ -18,6 +18,7 @@ import {
   ChangeError,
   ChangeValidator,
   CORE_ANNOTATIONS,
+  getChangeData,
   InstanceElement,
   ModificationChange,
   ObjectType,
@@ -125,16 +126,25 @@ describe('deletedNonQueryableFields', () => {
       })
     })
     describe('there are non-system non-queryable fields', () => {
+      let changes: ModificationChange<InstanceElement>[]
       beforeEach(async () => {
         const typeWithQueryableFields = createTypeForTest({
           fieldIsQueryable: false,
           fieldIsHidden: false,
           fieldIsReadOnly: false,
         })
-        warnings = await changeValidator([createInstanceChangeForType(typeWithQueryableFields)])
+        changes = [createInstanceChangeForType(typeWithQueryableFields)]
+        warnings = await changeValidator(changes)
       })
       it('should warn', () => {
-        expect(warnings).not.toBeEmpty()
+        expect(warnings).toEqual([
+          {
+            elemID: getChangeData(changes[0]).elemID,
+            severity: 'Warning',
+            message: expect.stringContaining('SomeType'),
+            detailedMessage: expect.stringContaining('SomeField'),
+          },
+        ])
       })
     })
   })


### PR DESCRIPTION
When we fetch a type that has some fields that are not queryable by the fetching user, any instances of this type will be fetched without values for said fields. If we later try to deploy these instances, these missing values are interpreted as if we want to delete the values of these fields. This is probably not what the user wants.

---



---
_Release Notes_: 
Salesforce: will now warn when deploying instances of types for which the fetching user did not have permission to read certain fields

---
_User Notifications_: 
N/A