### PR TITLE
SALTO-4811: sort projects in automations elem id

### DIFF
--- a/packages/jira-adapter/src/filters/automation/automation_fetch.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_fetch.ts
@@ -94,7 +94,8 @@ const createInstance = (
     values.name,
     ...(convertRuleScopeValueToProjects(values) ?? [])
       .map((project: Values) => idToProject[project.projectId]?.value.name)
-      .filter(lowerdashValues.isDefined),
+      .filter(lowerdashValues.isDefined)
+      .sort(),
   ].join('_'))
 
   const instanceName = getElemIdFunc && serviceIds

--- a/packages/jira-adapter/test/filters/automation/automation_fetch.test.ts
+++ b/packages/jira-adapter/test/filters/automation/automation_fetch.test.ts
@@ -31,7 +31,8 @@ import { CLOUD_RESOURCE_FIELD } from '../../../src/filters/automation/cloud_id'
 describe('automationFetchFilter', () => {
   let filter: filterUtils.FilterWith<'onFetch'>
   let projectType: ObjectType
-  let projectInstance: InstanceElement
+  let project2Instance: InstanceElement
+  let project3Instance: InstanceElement
   let config: JiraConfig
   let client: JiraClient
   let connection: MockInterface<clientUtils.APIConnection>
@@ -49,9 +50,13 @@ describe('automationFetchFilter', () => {
             {
               projectId: '2',
             },
+            {
+              projectId: '3',
+            },
           ],
           ruleScope: {
-            resources: ['ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8:project/2'],
+            resources: ['ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8:project/2',
+              'ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8:project/3'],
           },
         },
       ],
@@ -78,12 +83,21 @@ describe('automationFetchFilter', () => {
       elemID: new ElemID(JIRA, PROJECT_TYPE),
     })
 
-    projectInstance = new InstanceElement(
-      'projectInstance',
+    project2Instance = new InstanceElement(
+      'project2Instance',
       projectType,
       {
         name: 'projectName',
         id: '2',
+      }
+    )
+
+    project3Instance = new InstanceElement(
+      'project2InstanceOther',
+      projectType,
+      {
+        name: 'otherName',
+        id: '3',
       }
     )
 
@@ -111,20 +125,20 @@ describe('automationFetchFilter', () => {
 
   describe('onFetch', () => {
     it('should fetch automations from the service', async () => {
-      const elements = [projectInstance]
+      const elements = [project2Instance, project3Instance]
       await filter.onFetch(elements)
 
       const automationTypes = createAutomationTypes()
       expect(elements).toHaveLength(
-        1 // original project
+        2 // original projects
         + 1 // new automation
         + 1 // automation top level type
         + automationTypes.subTypes.length
       )
 
-      const automation = elements[1]
+      const automation = elements[2]
 
-      expect(automation.elemID.getFullName()).toEqual('jira.Automation.instance.automationName_projectName')
+      expect(automation.elemID.getFullName()).toEqual('jira.Automation.instance.automationName_otherName_projectName')
 
       expect(automation.value).toEqual({
         id: '1',
@@ -133,9 +147,13 @@ describe('automationFetchFilter', () => {
           {
             projectId: '2',
           },
+          {
+            projectId: '3',
+          },
         ],
         ruleScope: {
-          resources: ['ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8:project/2'],
+          resources: ['ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8:project/2',
+            'ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8:project/3'],
         },
       })
 
@@ -180,7 +198,7 @@ describe('automationFetchFilter', () => {
         client,
       })) as filterUtils.FilterWith<'onFetch'>
 
-      const elements = [projectInstance]
+      const elements = [project2Instance]
       await filter.onFetch(elements)
 
       const automationTypes = createAutomationTypes()
@@ -202,9 +220,13 @@ describe('automationFetchFilter', () => {
           {
             projectId: '2',
           },
+          {
+            projectId: '3',
+          },
         ],
         ruleScope: {
-          resources: ['ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8:project/2'],
+          resources: ['ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8:project/2',
+            'ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8:project/3'],
         },
       })
 
@@ -217,7 +239,7 @@ describe('automationFetchFilter', () => {
 
     it('should not fetch automations if usePrivateApi is false', async () => {
       config.client.usePrivateAPI = false
-      const elements = [projectInstance]
+      const elements = [project2Instance]
       await filter.onFetch(elements)
 
 
@@ -229,7 +251,7 @@ describe('automationFetchFilter', () => {
     it('should not fetch automations if automations were excluded', async () => {
       fetchQuery.isTypeMatch.mockReturnValue(false)
       config.client.usePrivateAPI = false
-      const elements = [projectInstance]
+      const elements = [project2Instance]
       await filter.onFetch(elements)
 
 
@@ -247,7 +269,7 @@ describe('automationFetchFilter', () => {
         getElemIdFunc: () => new ElemID(JIRA, 'someName'),
       })) as filterUtils.FilterWith<'onFetch'>
 
-      const elements = [projectInstance]
+      const elements = [project2Instance]
       await filter.onFetch(elements)
 
       const automation = elements[1]
@@ -297,7 +319,7 @@ describe('automationFetchFilter', () => {
         throw new Error(`Unexpected url ${url}`)
       })
 
-      const elements = [projectInstance]
+      const elements = [project2Instance]
       await expect(filter.onFetch(elements)).rejects.toThrow()
     })
 
@@ -337,7 +359,7 @@ describe('automationFetchFilter', () => {
         throw new Error(`Unexpected url ${url}`)
       })
 
-      const elements = [projectInstance]
+      const elements = [project2Instance]
       await expect(filter.onFetch(elements)).rejects.toThrow()
     })
 
@@ -377,7 +399,7 @@ describe('automationFetchFilter', () => {
         throw new Error(`Unexpected url ${url}`)
       })
 
-      const elements = [projectInstance]
+      const elements = [project2Instance]
       await expect(filter.onFetch(elements)).rejects.toThrow()
     })
 
@@ -413,7 +435,7 @@ describe('automationFetchFilter', () => {
         throw new Error(`Unexpected url ${url}`)
       })
 
-      const elements = [projectInstance]
+      const elements = [project2Instance]
       await expect(filter.onFetch(elements)).rejects.toThrow()
     })
   })
@@ -433,7 +455,7 @@ describe('automationFetchFilter', () => {
     filter = automationFetchFilter(getFilterParams({
       client,
     })) as filterUtils.FilterWith<'onFetch'>
-    const elements = [projectInstance]
+    const elements = [project2Instance]
     expect(await filter.onFetch(elements)).toEqual({
       errors: [{
         message: 'Salto could not access the Automation resource. Elements from that type were not fetched. Please make sure that this type is enabled in your service, and that the supplied user credentials have sufficient permissions to access this data. You can also exclude this data from Salto\'s fetches by changing the environment configuration. Learn more at https://help.salto.io/en/articles/6947061-salto-could-not-access-the-resource',
@@ -457,7 +479,7 @@ describe('automationFetchFilter', () => {
     filter = automationFetchFilter(getFilterParams({
       client,
     })) as filterUtils.FilterWith<'onFetch'>
-    const elements = [projectInstance]
+    const elements = [project2Instance]
     expect(await filter.onFetch(elements)).toEqual({
       errors: [{
         message: 'Salto could not access the Automation resource. Elements from that type were not fetched. Please make sure that this type is enabled in your service, and that the supplied user credentials have sufficient permissions to access this data. You can also exclude this data from Salto\'s fetches by changing the environment configuration. Learn more at https://help.salto.io/en/articles/6947061-salto-could-not-access-the-resource',

--- a/packages/jira-adapter/test/filters/automation/automation_fetch.test.ts
+++ b/packages/jira-adapter/test/filters/automation/automation_fetch.test.ts
@@ -93,7 +93,7 @@ describe('automationFetchFilter', () => {
     )
 
     project3Instance = new InstanceElement(
-      'project2InstanceOther',
+      'project3Instance',
       projectType,
       {
         name: 'otherName',


### PR DESCRIPTION
_Sort projects in the automations elem ID_

---
_Release Notes_: 
Jira Adapter: 
* Automations with several projects will now have a consistent elemID (projects names in the ID are now sorted)

---
_User Notifications_: 
Jira Adapter: 
* For new envs the projects part of the automations elem ID will now be sorted. It can create a mismatch (add & removal instead of modification) when comparing to an older env