### PR TITLE
SALTO-4813 - Salesforce: only show relevant instances when warning about broken refs

### DIFF
--- a/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
@@ -110,6 +110,7 @@ const createWarnings = async (
     const perTargetTypeMsgs = typesOfMissingRefsTargets.join('\n')
     const perInstancesPreamble = 'and these objects are not part of your Salto configuration. \n\nHere are the records:'
     const perMissingInstanceMsgs = missingRefs
+      .filter(missingRef => missingRef.origin.type === originTypeName)
       .map(missingRef => `${getInstanceDesc(missingRef.origin.id, baseUrl)} relates to ${getInstanceDesc(missingRef.targetId, baseUrl)}`)
       .slice(0, MAX_BREAKDOWN_ELEMENTS)
       .sort() // this effectively sorts by origin instance ID


### PR DESCRIPTION
The warning message about dropped instances due to broken refs is aggregated by type - we display a separate warning for each type that contains broken refs. But when we list the actual instances that were dropped we list all of them, not just the instances of the specific type we're warning about.

---


---
_Release Notes_: 
N/A

---
_User Notifications_: 
N/A