### PR TITLE
SALTO-4814 - Salesforce: Consider metadata instances as potential lookup targets

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -101,7 +101,7 @@ import { LocalFilterCreator, Filter, FilterResult, RemoteFilterCreator, LocalFil
 import { addDefaults, isCustomObjectSync, isCustomType, listMetadataObjects } from './filters/utils'
 import { retrieveMetadataInstances, fetchMetadataType, fetchMetadataInstances } from './fetch'
 import { isCustomObjectInstanceChanges, deployCustomObjectInstancesGroup } from './custom_object_instances_deploy'
-import { getLookUpName, getLookupNameWithFallbackToElement } from './transformers/reference_mapping'
+import { getLookUpName, getLookupNameForDataInstances } from './transformers/reference_mapping'
 import { deployMetadata, NestedMetadataTypeInfo } from './metadata_deploy'
 import nestedInstancesAuthorInformation from './filters/author_information/nested_instances'
 import { buildFetchProfile } from './fetch_profile/fetch_profile'
@@ -496,7 +496,7 @@ export default class SalesforceAdapter implements AdapterOperations {
     log.debug(`about to ${checkOnly ? 'validate' : 'deploy'} group ${changeGroup.groupID} with scope (first 100): ${safeJsonStringify(changeGroup.changes.slice(0, 100).map(getChangeData).map(e => e.elemID.getFullName()))}`)
     const isDataDeployGroup = await isCustomObjectInstanceChanges(changeGroup.changes)
     const getLookupNameFunc = isDataDeployGroup
-      ? getLookupNameWithFallbackToElement
+      ? getLookupNameForDataInstances
       : getLookUpName
     const resolvedChanges = await awu(changeGroup.changes)
       .map(change => resolveChangeElement(change, getLookupNameFunc))

--- a/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
@@ -37,6 +37,7 @@ import {
   CORE_ANNOTATIONS,
   isObjectType,
   ObjectType,
+  isInstanceElement,
 } from '@salto-io/adapter-api'
 import { FilterResult, RemoteFilterCreator } from '../filter'
 import {
@@ -329,9 +330,9 @@ const filter: RemoteFilterCreator = ({ client, config }) => ({
     if (dataManagement === undefined) {
       return {}
     }
-    const customObjectInstances = await awu(elements).filter(isInstanceOfCustomObject)
-      .toArray() as InstanceElement[]
-    const internalToInstance = await keyByAsync(customObjectInstances, serializeInstanceInternalID)
+    const allInstances = elements.filter(isInstanceElement)
+    const customObjectInstances = await awu(allInstances).filter(isInstanceOfCustomObject).toArray()
+    const internalToInstance = await keyByAsync(allInstances, serializeInstanceInternalID)
     const internalIdPrefixToType = await buildCustomObjectPrefixKeyMap(elements)
     const { reverseReferencesMap, missingRefs } = await replaceLookupsWithRefsAndCreateRefMap(
       customObjectInstances,

--- a/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
@@ -45,12 +45,15 @@ import {
   isInstanceOfCustomObject,
 } from '../transformers/transformer'
 import {
+  CUSTOM_OBJECT_ID_FIELD,
   FIELD_ANNOTATIONS,
   KEY_PREFIX,
   KEY_PREFIX_LENGTH,
   SALESFORCE,
 } from '../constants'
 import {
+  getInternalId,
+  isCustomObjectSync,
   isReadOnlyField,
   isReferenceField,
   referenceFieldTargetTypes,
@@ -79,8 +82,12 @@ const MAX_BREAKDOWN_ELEMENTS = 10
 const serializeInternalID = (typeName: string, id: string): string =>
   (`${typeName}${INTERNAL_ID_SEPARATOR}${id}`)
 
+const instanceInternalId = (instance: InstanceElement): string => (
+  isCustomObjectSync(instance.getTypeSync()) ? instance.value[CUSTOM_OBJECT_ID_FIELD] : getInternalId(instance)
+)
+
 const serializeInstanceInternalID = async (instance: InstanceElement): Promise<string> => (
-  serializeInternalID(await apiName(await instance.getType(), true), await apiName(instance))
+  serializeInternalID(await apiName(await instance.getType(), true), instanceInternalId(instance))
 )
 
 const deserializeInternalID = (internalID: string): RefOrigin => {

--- a/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
@@ -45,15 +45,13 @@ import {
   isInstanceOfCustomObject,
 } from '../transformers/transformer'
 import {
-  CUSTOM_OBJECT_ID_FIELD,
   FIELD_ANNOTATIONS,
   KEY_PREFIX,
   KEY_PREFIX_LENGTH,
   SALESFORCE,
 } from '../constants'
 import {
-  getInternalId,
-  isCustomObjectSync,
+  instanceInternalId,
   isReadOnlyField,
   isReferenceField,
   referenceFieldTargetTypes,
@@ -81,10 +79,6 @@ const MAX_BREAKDOWN_ELEMENTS = 10
 
 const serializeInternalID = (typeName: string, id: string): string =>
   (`${typeName}${INTERNAL_ID_SEPARATOR}${id}`)
-
-const instanceInternalId = (instance: InstanceElement): string => (
-  isCustomObjectSync(instance.getTypeSync()) ? instance.value[CUSTOM_OBJECT_ID_FIELD] : getInternalId(instance)
-)
 
 const serializeInstanceInternalID = async (instance: InstanceElement): Promise<string> => (
   serializeInternalID(await apiName(await instance.getType(), true), instanceInternalId(instance))

--- a/packages/salesforce-adapter/src/filters/utils.ts
+++ b/packages/salesforce-adapter/src/filters/utils.ts
@@ -412,6 +412,10 @@ export const hasInternalId = (elem: Element): boolean => (
   getInternalId(elem) !== undefined && getInternalId(elem) !== ''
 )
 
+export const instanceInternalId = (instance: InstanceElement): string => (
+  isCustomObjectSync(instance.getTypeSync()) ? instance.value[CUSTOM_OBJECT_ID_FIELD] : getInternalId(instance)
+)
+
 export const hasApiName = (elem: Element): boolean => (
   apiName(elem) !== undefined
 )

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -98,7 +98,7 @@ const safeApiName = ({ ref, path, relative }: {
 }
 
 type ReferenceSerializationStrategyName = 'absoluteApiName' | 'relativeApiName' | 'configurationAttributeMapping' | 'lookupQueryMapping' | 'scheduleConstraintFieldMapping'
- | 'mapKey' | 'customLabel' | 'referenceToInstance'
+ | 'mapKey' | 'customLabel' | 'fromDataInstance'
 const ReferenceSerializationStrategyLookup: Record<
   ReferenceSerializationStrategyName, ReferenceSerializationStrategy
 > = {
@@ -156,7 +156,7 @@ const ReferenceSerializationStrategyLookup: Record<
       return val
     },
   },
-  referenceToInstance: {
+  fromDataInstance: {
     serialize: async args => (
       await isMetadataInstanceElement(args.ref.value)
         ? instanceInternalId(args.ref.value)
@@ -931,5 +931,5 @@ export const getLookUpName = getLookUpNameImpl({
 export const getLookupNameForDataInstances = getLookUpNameImpl({
   defs: fieldNameToTypeMappingDefs,
   resolveToElementFallback: true,
-  defaultStrategyName: 'referenceToInstance',
+  defaultStrategyName: 'fromDataInstance',
 })

--- a/packages/salesforce-adapter/test/filters/custom_object_instances_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_object_instances_references.test.ts
@@ -28,9 +28,14 @@ import {
   LABEL,
   FIELD_ANNOTATIONS,
   CUSTOM_OBJECT_ID_FIELD,
+  INTERNAL_ID_FIELD,
 } from '../../src/constants'
 import { Types } from '../../src/transformers/transformer'
-import { defaultFilterContext } from '../utils'
+import {
+  createCustomObjectType,
+  createMetadataTypeElement,
+  defaultFilterContext,
+} from '../utils'
 import { mockTypes } from '../mock_elements'
 import { FilterWith } from './mocks'
 import { FetchProfile, OutgoingReferenceBehavior } from '../../src/types'
@@ -85,122 +90,117 @@ describe('Custom Object Instances References filter', () => {
     },
   })
   const refToName = 'refToName'
-  const refToElemID = new ElemID(SALESFORCE, refToName)
-  const refToObj = new ObjectType({
-    elemID: refToElemID,
-    annotations: {
-      [API_NAME]: refToName,
-      [METADATA_TYPE]: CUSTOM_OBJECT,
-    },
+  const refToObj = createCustomObjectType(refToName, {})
+  const refToElemID = refToObj.elemID
+
+  const refToMetadataName = 'refToMetadataName'
+  const refToMetadataObj = createMetadataTypeElement(refToMetadataName, {})
+
+  const refFromName = 'refFrom'
+  const refFromObj = createCustomObjectType(refFromName, {
     fields: {
-      Id: {
-        refType: stringType,
+      LookupExample: {
+        refType: Types.primitiveDataTypes.Lookup,
         annotations: {
-          [CORE_ANNOTATIONS.REQUIRED]: false,
-          [LABEL]: 'Id',
-          [API_NAME]: 'Id',
+          [CORE_ANNOTATIONS.REQUIRED]: true,
+          [LABEL]: 'lookup',
+          [API_NAME]: 'LookupExample',
+          [FIELD_ANNOTATIONS.CREATABLE]: true,
+          [FIELD_ANNOTATIONS.UPDATEABLE]: true,
+          referenceTo: [
+            refToName,
+          ],
+        },
+      },
+      NonDeployableLookup: {
+        refType: Types.primitiveDataTypes.Lookup,
+        annotations: {
+          [CORE_ANNOTATIONS.REQUIRED]: true,
+          [LABEL]: 'lookup',
+          [API_NAME]: 'LookupExample',
+          [FIELD_ANNOTATIONS.CREATABLE]: false,
+          [FIELD_ANNOTATIONS.UPDATEABLE]: false,
+          referenceTo: [
+            refToName,
+          ],
+        },
+      },
+      RefToUser: {
+        refType: Types.primitiveDataTypes.Lookup,
+        annotations: {
+          [CORE_ANNOTATIONS.REQUIRED]: true,
+          [LABEL]: 'ref to user',
+          [API_NAME]: 'RefToUser',
+          [FIELD_ANNOTATIONS.CREATABLE]: true,
+          [FIELD_ANNOTATIONS.UPDATEABLE]: true,
+          referenceTo: [
+            userObjName,
+          ],
+        },
+      },
+      MasterDetailExample: {
+        refType: Types.primitiveDataTypes.MasterDetail,
+        annotations: {
+          [CORE_ANNOTATIONS.REQUIRED]: true,
+          [LABEL]: 'detailfOfMaster',
+          [API_NAME]: 'MasterDetailExample',
+          [FIELD_ANNOTATIONS.CREATABLE]: true,
+          [FIELD_ANNOTATIONS.UPDATEABLE]: true,
+          referenceTo: [
+            masterName,
+          ],
+        },
+      },
+      HierarchyExample: {
+        refType: Types.primitiveDataTypes.Hierarchy,
+        annotations: {
+          [CORE_ANNOTATIONS.REQUIRED]: true,
+          [LABEL]: 'hierarchy',
+          [API_NAME]: 'HierarchyExample',
+          [FIELD_ANNOTATIONS.CREATABLE]: true,
+          [FIELD_ANNOTATIONS.UPDATEABLE]: true,
+        },
+      },
+      HiddenValueField: {
+        refType: Types.primitiveDataTypes.MasterDetail,
+        annotations: {
+          [CORE_ANNOTATIONS.REQUIRED]: true,
+          [LABEL]: 'hiddenValueField',
+          [API_NAME]: 'HiddenValueField',
+          [FIELD_ANNOTATIONS.CREATABLE]: true,
+          [FIELD_ANNOTATIONS.UPDATEABLE]: true,
+          [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,
+          referenceTo: [
+            masterName,
+          ],
+        },
+      },
+      RefToMetadataField: {
+        refType: Types.primitiveDataTypes.Lookup,
+        annotations: {
+          [CORE_ANNOTATIONS.REQUIRED]: true,
+          [LABEL]: 'lookupMetadataField',
+          [API_NAME]: 'LookupMetadataField',
+          [FIELD_ANNOTATIONS.CREATABLE]: true,
+          [FIELD_ANNOTATIONS.UPDATEABLE]: true,
+          referenceTo: [
+            refToMetadataName,
+          ],
         },
       },
     },
   })
-  const refFromName = 'refFrom'
-  const refFromElemID = new ElemID(SALESFORCE, refFromName)
-  const refFromObj = new ObjectType(
-    {
-      elemID: refFromElemID,
-      annotations: {
-        [API_NAME]: refFromName,
-        [METADATA_TYPE]: CUSTOM_OBJECT,
-      },
-      fields: {
-        Id: {
-          refType: stringType,
-          annotations: {
-            [CORE_ANNOTATIONS.REQUIRED]: false,
-            [LABEL]: 'Id',
-            [API_NAME]: 'Id',
-          },
-        },
-        LookupExample: {
-          refType: Types.primitiveDataTypes.Lookup,
-          annotations: {
-            [CORE_ANNOTATIONS.REQUIRED]: true,
-            [LABEL]: 'lookup',
-            [API_NAME]: 'LookupExample',
-            [FIELD_ANNOTATIONS.CREATABLE]: true,
-            [FIELD_ANNOTATIONS.UPDATEABLE]: true,
-            referenceTo: [
-              refToName,
-            ],
-          },
-        },
-        NonDeployableLookup: {
-          refType: Types.primitiveDataTypes.Lookup,
-          annotations: {
-            [CORE_ANNOTATIONS.REQUIRED]: true,
-            [LABEL]: 'lookup',
-            [API_NAME]: 'LookupExample',
-            [FIELD_ANNOTATIONS.CREATABLE]: false,
-            [FIELD_ANNOTATIONS.UPDATEABLE]: false,
-            referenceTo: [
-              refToName,
-            ],
-          },
-        },
-        RefToUser: {
-          refType: Types.primitiveDataTypes.Lookup,
-          annotations: {
-            [CORE_ANNOTATIONS.REQUIRED]: true,
-            [LABEL]: 'ref to user',
-            [API_NAME]: 'RefToUser',
-            [FIELD_ANNOTATIONS.CREATABLE]: true,
-            [FIELD_ANNOTATIONS.UPDATEABLE]: true,
-            referenceTo: [
-              userObjName,
-            ],
-          },
-        },
-        MasterDetailExample: {
-          refType: Types.primitiveDataTypes.MasterDetail,
-          annotations: {
-            [CORE_ANNOTATIONS.REQUIRED]: true,
-            [LABEL]: 'detailfOfMaster',
-            [API_NAME]: 'MasterDetailExample',
-            [FIELD_ANNOTATIONS.CREATABLE]: true,
-            [FIELD_ANNOTATIONS.UPDATEABLE]: true,
-            referenceTo: [
-              masterName,
-            ],
-          },
-        },
-        HierarchyExample: {
-          refType: Types.primitiveDataTypes.Hierarchy,
-          annotations: {
-            [CORE_ANNOTATIONS.REQUIRED]: true,
-            [LABEL]: 'hierarchy',
-            [API_NAME]: 'HierarchyExample',
-            [FIELD_ANNOTATIONS.CREATABLE]: true,
-            [FIELD_ANNOTATIONS.UPDATEABLE]: true,
-          },
-        },
-        HiddenValueField: {
-          refType: Types.primitiveDataTypes.MasterDetail,
-          annotations: {
-            [CORE_ANNOTATIONS.REQUIRED]: true,
-            [LABEL]: 'hiddenValueField',
-            [API_NAME]: 'HiddenValueField',
-            [FIELD_ANNOTATIONS.CREATABLE]: true,
-            [FIELD_ANNOTATIONS.UPDATEABLE]: true,
-            [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,
-            referenceTo: [
-              masterName,
-            ],
-          },
-        },
-      },
-    }
-  )
+  const refFromElemID = refFromObj.elemID
   let elements: Element[]
+  const refToMetadataInstanceName = 'refToMetadataInstance'
+  const refToMetadataInstanceId = 'refToMetadataId'
+  const refToMetadataInstance = new InstanceElement(
+    refToMetadataInstanceName,
+    refToMetadataObj,
+    {
+      [INTERNAL_ID_FIELD]: refToMetadataInstanceId,
+    },
+  )
   const refFromValues = {
     Id: '1234',
     LookupExample: 'refToId',
@@ -209,6 +209,7 @@ describe('Custom Object Instances References filter', () => {
     NonDeployableLookup: 'ToNothing',
     HiddenValueField: 'ToNothing',
     RefToUser: 'aaa',
+    RefToMetadataField: refToMetadataInstanceId,
   }
   const refToInstanceName = 'refToInstance'
   const refToInstance = new InstanceElement(
@@ -286,6 +287,7 @@ describe('Custom Object Instances References filter', () => {
   ]
   const legalInstances = [
     refToInstance,
+    refToMetadataInstance,
     refFromInstance,
     masterToInstance,
   ]
@@ -365,6 +367,7 @@ describe('Custom Object Instances References filter', () => {
         NonDeployableLookup: 'ToNothing',
         RefToUser: 'aaa',
         HiddenValueField: 'ToNothing',
+        RefToMetadataField: new ReferenceExpression(refToMetadataInstance.elemID),
       })
     })
 

--- a/packages/salesforce-adapter/test/transformers/reference_mapping.test.ts
+++ b/packages/salesforce-adapter/test/transformers/reference_mapping.test.ts
@@ -16,7 +16,7 @@
 import { InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
 import { GetLookupNameFunc, resolveValues } from '@salto-io/adapter-utils'
 import { mockTypes } from '../mock_elements'
-import { getLookUpName, getLookupNameWithFallbackToElement } from '../../src/transformers/reference_mapping'
+import { getLookUpName, getLookupNameForDataInstances } from '../../src/transformers/reference_mapping'
 import { CUSTOM_OBJECT_ID_FIELD } from '../../src/constants'
 
 describe('referenceMapping tests', () => {
@@ -49,7 +49,7 @@ describe('referenceMapping tests', () => {
 
   describe('getLookupNameWithFallbackToElement', () => {
     beforeEach(() => {
-      getLookupNameFunc = getLookupNameWithFallbackToElement
+      getLookupNameFunc = getLookupNameForDataInstances
     })
     describe('when the default strategy resolves to undefined', () => {
       it('should resolve to the referenced instance', async () => {


### PR DESCRIPTION
In the package `Field Service Lightning` we have custom objects instances that reference instances of metadata types. Our current code complains of invalid references, because we only look up reference targets among instances of custom objects.
So let's make a distinction between potential reference sources (only custom object instances) and potential reference targets (all instances).

---

~This relies on instances of metadata types having an `Id` field. I haven't tested this yet.~
Please note the code that gets the internal ID for both custom objects and metadata instances.

Tests:
 - Fetch and observe a reference created in the `SkillId` field of an instance of `ServiceResourceSkill`
 - Deploy an instance that contains a reference to a metadata instance

---
_Release Notes_: 
Salesforce: Lookup fields in records of custom objects that reference instances of metadata types are now handled correctly.

---
_User Notifications_: 
N/A