### PR TITLE
SALTO-4815 - Salesforce: Handle hierarchy fields as references in data records

### DIFF
--- a/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
@@ -50,16 +50,13 @@ import {
   SALESFORCE,
 } from '../constants'
 import {
-  isLookupField,
-  isMasterDetailField,
   isReadOnlyField,
-  apiNameSync,
-  isHierarchyField,
+  isReferenceField,
+  referenceFieldTargetTypes,
   safeApiName,
 } from './utils'
 import { DataManagement } from '../types'
 
-const { makeArray } = collections.array
 const { awu } = collections.asynciterable
 const { isDefined } = lowerdashValues
 const { DefaultMap } = collections.map
@@ -184,24 +181,6 @@ const createWarnings = async (
     ...missingRefsWarnings,
     ...illegalOriginsWarnings,
   ]
-}
-
-const isReferenceField = (field?: Field): field is Field => (
-  isDefined(field) && (isLookupField(field) || isMasterDetailField(field) || isHierarchyField(field))
-)
-
-const referenceFieldTargetTypes = (field: Field): string[] => {
-  if (isLookupField(field) || isMasterDetailField(field)) {
-    return makeArray(field.annotations?.[FIELD_ANNOTATIONS.REFERENCE_TO])
-  }
-  if (isHierarchyField(field)) {
-    // hierarchy fields always reference the type that contains them
-    return makeArray(apiNameSync(field.parent))
-  }
-  log.warn('Unknown reference field type %s for field %s',
-    field.refType.elemID.getFullName(),
-    field.elemID.getFullName())
-  return []
 }
 
 const replaceLookupsWithRefsAndCreateRefMap = async (

--- a/packages/salesforce-adapter/src/filters/utils.ts
+++ b/packages/salesforce-adapter/src/filters/utils.ts
@@ -197,7 +197,11 @@ export const isHiddenField = (field: Field): boolean => (
 )
 
 export const isReadOnlyField = (field: Field): boolean => (
-  !field.annotations[FIELD_ANNOTATIONS.CREATABLE] && !field.annotations[FIELD_ANNOTATIONS.UPDATEABLE]
+  field.annotations[FIELD_ANNOTATIONS.CREATABLE] === false && field.annotations[FIELD_ANNOTATIONS.UPDATEABLE] === false
+)
+
+export const isHierarchyField = (field: Field): boolean => (
+  field.refType.elemID.isEqual(Types.primitiveDataTypes.Hierarchy.elemID)
 )
 
 export const getInstancesOfMetadataType = async (elements: Element[], metadataTypeName: string):

--- a/packages/salesforce-adapter/src/filters/utils.ts
+++ b/packages/salesforce-adapter/src/filters/utils.ts
@@ -199,7 +199,7 @@ export const isHiddenField = (field: Field): boolean => (
 )
 
 export const isReadOnlyField = (field: Field): boolean => (
-  field.annotations[FIELD_ANNOTATIONS.CREATABLE] === false && field.annotations[FIELD_ANNOTATIONS.UPDATEABLE] === false
+  !field.annotations[FIELD_ANNOTATIONS.CREATABLE] && !field.annotations[FIELD_ANNOTATIONS.UPDATEABLE]
 )
 
 export const isHierarchyField = (field: Field): boolean => (

--- a/packages/salesforce-adapter/src/filters/utils.ts
+++ b/packages/salesforce-adapter/src/filters/utils.ts
@@ -47,7 +47,7 @@ import {
 } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements, createSchemeGuard, detailedCompare, getParents } from '@salto-io/adapter-utils'
 import { FileProperties } from 'jsforce-types'
-import { chunks, collections, types } from '@salto-io/lowerdash'
+import { chunks, collections, types, values } from '@salto-io/lowerdash'
 import Joi from 'joi'
 import SalesforceClient, { ErrorFilter } from '../client/client'
 import { FetchElements, INSTANCE_SUFFIXES, OptionalFeatures } from '../types'
@@ -95,6 +95,7 @@ const { toArrayAsync, awu } = collections.asynciterable
 const { splitDuplicates } = collections.array
 const { makeArray } = collections.array
 const { weightedChunks } = chunks
+const { isDefined } = values
 const log = logger(module)
 
 const METADATA_VALUES_SCHEME = Joi.object({
@@ -205,14 +206,19 @@ export const isHierarchyField = (field: Field): boolean => (
   field.refType.elemID.isEqual(Types.primitiveDataTypes.Hierarchy.elemID)
 )
 
-
 export const isReferenceField = (field?: Field): field is Field => (
   (field !== undefined) && (isLookupField(field) || isMasterDetailField(field) || isHierarchyField(field))
 )
 
 export const referenceFieldTargetTypes = (field: Field): string[] => {
   if (isLookupField(field) || isMasterDetailField(field)) {
-    return makeArray(field.annotations?.[FIELD_ANNOTATIONS.REFERENCE_TO])
+    const referredTypes = field.annotations?.[FIELD_ANNOTATIONS.REFERENCE_TO]
+    if (referredTypes === undefined) {
+      return []
+    }
+    return makeArray(referredTypes)
+      .map(ref => (_.isString(ref) ? ref : apiNameSync(ref.value)))
+      .filter(isDefined)
   }
   if (isHierarchyField(field)) {
     // hierarchy fields always reference the type that contains them
@@ -338,9 +344,9 @@ export const getNamespace = async (
     : getNamespaceFromString(elementApiName)
 }
 
-export const extractFullNamesFromValueList = (values: { [INSTANCE_FULL_NAME_FIELD]: string }[]):
+export const extractFullNamesFromValueList = (instanceValues: { [INSTANCE_FULL_NAME_FIELD]: string }[]):
   string[] =>
-  values.map(v => v[INSTANCE_FULL_NAME_FIELD])
+  instanceValues.map(v => v[INSTANCE_FULL_NAME_FIELD])
 
 
 export const buildAnnotationsObjectType = (annotationTypes: TypeMap): ObjectType => {

--- a/packages/salesforce-adapter/test/filters/custom_object_instances_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_object_instances_references.test.ts
@@ -174,6 +174,16 @@ describe('Custom Object Instances References filter', () => {
             ],
           },
         },
+        HierarchyExample: {
+          refType: Types.primitiveDataTypes.Hierarchy,
+          annotations: {
+            [CORE_ANNOTATIONS.REQUIRED]: true,
+            [LABEL]: 'hierarchy',
+            [API_NAME]: 'HierarchyExample',
+            [FIELD_ANNOTATIONS.CREATABLE]: true,
+            [FIELD_ANNOTATIONS.UPDATEABLE]: true,
+          },
+        },
         HiddenValueField: {
           refType: Types.primitiveDataTypes.MasterDetail,
           annotations: {
@@ -196,6 +206,7 @@ describe('Custom Object Instances References filter', () => {
     Id: '1234',
     LookupExample: 'refToId',
     MasterDetailExample: 'masterToId',
+    HierarchyExample: '1234', // hierarchy refs can only refer to the same type
     NonDeployableLookup: 'ToNothing',
     HiddenValueField: 'ToNothing',
     RefToUser: 'aaa',
@@ -352,6 +363,7 @@ describe('Custom Object Instances References filter', () => {
         Id: '1234',
         LookupExample: new ReferenceExpression(refToInstance.elemID),
         MasterDetailExample: new ReferenceExpression(masterToInstance.elemID),
+        HierarchyExample: new ReferenceExpression(refFromInstance.elemID),
         NonDeployableLookup: 'ToNothing',
         RefToUser: 'aaa',
         HiddenValueField: 'ToNothing',

--- a/packages/salesforce-adapter/test/filters/utils.test.ts
+++ b/packages/salesforce-adapter/test/filters/utils.test.ts
@@ -20,7 +20,9 @@ import {
   Field,
   InstanceElement, ListType,
   ObjectType,
-  ReadOnlyElementsSource, ReferenceExpression, toChange,
+  ReadOnlyElementsSource,
+  ReferenceExpression,
+  toChange,
 } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import {
@@ -41,11 +43,13 @@ import {
   getAuthorInformationFromFileProps,
   isElementWithResolvedParent,
   getElementAuthorInformation,
+  referenceFieldTargetTypes,
 } from '../../src/filters/utils'
 import {
   API_NAME,
   CUSTOM_OBJECT,
   CUSTOM_SETTINGS_TYPE,
+  FIELD_ANNOTATIONS,
   INSTANCE_FULL_NAME_FIELD,
   LABEL,
   METADATA_TYPE,
@@ -54,65 +58,137 @@ import {
 import { createInstanceElement, Types } from '../../src/transformers/transformer'
 import { CustomObject } from '../../src/client/types'
 import { createFlowChange, mockInstances, mockTypes } from '../mock_elements'
-import { createCustomObjectType } from '../utils'
+import { createCustomObjectType, createField } from '../utils'
 import { INSTANCE_SUFFIXES } from '../../src/types'
 import { mockFileProperties } from '../connection'
 
-describe('addDefaults', () => {
-  describe('when called with instance', () => {
-    let instance: InstanceElement
-    beforeEach(async () => {
-      instance = new InstanceElement('test', mockTypes.Profile)
-      await addDefaults(instance)
-    })
-    it('should add api name', () => {
-      expect(instance.value).toHaveProperty(INSTANCE_FULL_NAME_FIELD, 'test')
-    })
-  })
-  describe('when called with custom object instance', () => {
-    let instance: InstanceElement
-    beforeEach(async () => {
-      const customObj = createCustomObjectType('test', {})
-      instance = new InstanceElement('test', customObj)
-      await addDefaults(instance)
-    })
-    it('should not add api name', () => {
-      expect(instance.value).not.toHaveProperty(INSTANCE_FULL_NAME_FIELD)
-    })
-  })
-  describe('when called with field', () => {
-    let field: Field
-    beforeEach(async () => {
-      const obj = new ObjectType({
-        elemID: new ElemID(SALESFORCE, 'test'),
-        fields: {
-          a: { refType: Types.primitiveDataTypes.Text },
-        },
-        annotations: {
-          [API_NAME]: 'test',
-        },
-      })
-      field = obj.fields.a
-      await addDefaults(field)
-    })
-    it('should add api name', () => {
-      expect(field.annotations).toHaveProperty(API_NAME, 'test.a__c')
-    })
-    it('should add label', () => {
-      expect(field.annotations).toHaveProperty(LABEL, 'a')
-    })
-  })
-  describe('when called with custom object', () => {
-    describe('when object has no annotations', () => {
-      let object: ObjectType
+describe('filter utils', () => {
+  describe('addDefaults', () => {
+    describe('when called with instance', () => {
+      let instance: InstanceElement
       beforeEach(async () => {
-        object = new ObjectType({
+        instance = new InstanceElement('test', mockTypes.Profile)
+        await addDefaults(instance)
+      })
+      it('should add api name', () => {
+        expect(instance.value).toHaveProperty(INSTANCE_FULL_NAME_FIELD, 'test')
+      })
+    })
+    describe('when called with custom object instance', () => {
+      let instance: InstanceElement
+      beforeEach(async () => {
+        const customObj = createCustomObjectType('test', {})
+        instance = new InstanceElement('test', customObj)
+        await addDefaults(instance)
+      })
+      it('should not add api name', () => {
+        expect(instance.value).not.toHaveProperty(INSTANCE_FULL_NAME_FIELD)
+      })
+    })
+    describe('when called with field', () => {
+      let field: Field
+      beforeEach(async () => {
+        const obj = new ObjectType({
           elemID: new ElemID(SALESFORCE, 'test'),
           fields: {
             a: { refType: Types.primitiveDataTypes.Text },
           },
+          annotations: {
+            [API_NAME]: 'test',
+          },
         })
+        field = obj.fields.a
+        await addDefaults(field)
+      })
+      it('should add api name', () => {
+        expect(field.annotations).toHaveProperty(API_NAME, 'test.a__c')
+      })
+      it('should add label', () => {
+        expect(field.annotations).toHaveProperty(LABEL, 'a')
+      })
+    })
+    describe('when called with custom object', () => {
+      describe('when object has no annotations', () => {
+        let object: ObjectType
+        beforeEach(async () => {
+          object = new ObjectType({
+            elemID: new ElemID(SALESFORCE, 'test'),
+            fields: {
+              a: { refType: Types.primitiveDataTypes.Text },
+            },
+          })
 
+          await addDefaults(object)
+        })
+        it('should add annotation values', () => {
+          expect(object.annotations).toMatchObject({
+            [API_NAME]: 'test__c',
+            [METADATA_TYPE]: CUSTOM_OBJECT,
+            [LABEL]: 'test',
+          } as Partial<CustomObject>)
+        })
+        it('should add annotation types', () => {
+          expect(object.annotationRefTypes).toMatchObject({
+            [API_NAME]: createRefToElmWithValue(BuiltinTypes.SERVICE_ID),
+            [METADATA_TYPE]: createRefToElmWithValue(BuiltinTypes.SERVICE_ID),
+            [LABEL]: createRefToElmWithValue(BuiltinTypes.STRING),
+          })
+        })
+        it('should add defaults to fields', () => {
+          expect(object.fields.a.annotations).toMatchObject({
+            [API_NAME]: 'test__c.a__c',
+            [LABEL]: 'a',
+          })
+        })
+      })
+      describe('when object already has annotations', () => {
+        let object: ObjectType
+        beforeEach(async () => {
+          object = new ObjectType({
+            elemID: new ElemID(SALESFORCE, 'test'),
+            annotations: {
+              [LABEL]: 'myLabel',
+              nameField: { type: 'AutoNumber', label: 'Name' },
+            },
+            annotationRefsOrTypes: {
+              sharingModel: BuiltinTypes.HIDDEN_STRING,
+            },
+          })
+          await addDefaults(object)
+        })
+        it('should add missing annotations', () => {
+          expect(object.annotations).toMatchObject({
+            [API_NAME]: 'test__c',
+          } as Partial<CustomObject>)
+        })
+        it('should not override existing annotations', () => {
+          expect(object.annotations).toMatchObject({
+            [LABEL]: 'myLabel',
+            nameField: { type: 'AutoNumber', label: 'Name' },
+          } as Partial<CustomObject>)
+        })
+        it('should add missing annotation types', () => {
+          expect(object.annotationRefTypes).toMatchObject({
+            [API_NAME]: createRefToElmWithValue(BuiltinTypes.SERVICE_ID),
+            [LABEL]: createRefToElmWithValue(BuiltinTypes.STRING),
+          })
+        })
+        it('should not override existing annotation types', () => {
+          expect(object.annotationRefTypes).toMatchObject({
+            sharingModel: createRefToElmWithValue(BuiltinTypes.HIDDEN_STRING),
+          })
+        })
+      })
+    })
+    describe('when called with custom settings', () => {
+      let object: ObjectType
+      beforeEach(async () => {
+        object = new ObjectType({
+          elemID: new ElemID(SALESFORCE, 'test'),
+          annotations: {
+            [CUSTOM_SETTINGS_TYPE]: 'Hierarchical',
+          },
+        })
         await addDefaults(object)
       })
       it('should add annotation values', () => {
@@ -120,7 +196,7 @@ describe('addDefaults', () => {
           [API_NAME]: 'test__c',
           [METADATA_TYPE]: CUSTOM_OBJECT,
           [LABEL]: 'test',
-        } as Partial<CustomObject>)
+        })
       })
       it('should add annotation types', () => {
         expect(object.annotationRefTypes).toMatchObject({
@@ -129,113 +205,43 @@ describe('addDefaults', () => {
           [LABEL]: createRefToElmWithValue(BuiltinTypes.STRING),
         })
       })
-      it('should add defaults to fields', () => {
-        expect(object.fields.a.annotations).toMatchObject({
-          [API_NAME]: 'test__c.a__c',
-          [LABEL]: 'a',
-        })
+      it('should not add custom object annotations', () => {
+        expect(object.annotations).not.toHaveProperty('sharingModel')
+        expect(object.annotations).not.toHaveProperty('deploymentStatus')
       })
     })
-    describe('when object already has annotations', () => {
+    describe('when called with custom metadata type', () => {
+      const CUSTOM_METADATA_TYPE_NAME = 'TestCustomMetadataType__mdt'
+      const CUSTOM_METADATA_TYPE_LABEL = 'TestMetadataTypeLabel'
       let object: ObjectType
       beforeEach(async () => {
         object = new ObjectType({
-          elemID: new ElemID(SALESFORCE, 'test'),
+          elemID: new ElemID(SALESFORCE, CUSTOM_METADATA_TYPE_NAME),
           annotations: {
-            [LABEL]: 'myLabel',
-            nameField: { type: 'AutoNumber', label: 'Name' },
-          },
-          annotationRefsOrTypes: {
-            sharingModel: BuiltinTypes.HIDDEN_STRING,
+            [API_NAME]: CUSTOM_METADATA_TYPE_NAME,
+            [LABEL]: CUSTOM_METADATA_TYPE_LABEL,
           },
         })
         await addDefaults(object)
       })
-      it('should add missing annotations', () => {
+      it('should add annotation values', () => {
         expect(object.annotations).toMatchObject({
-          [API_NAME]: 'test__c',
-        } as Partial<CustomObject>)
+          [API_NAME]: CUSTOM_METADATA_TYPE_NAME,
+          [METADATA_TYPE]: CUSTOM_OBJECT,
+          [LABEL]: CUSTOM_METADATA_TYPE_LABEL,
+        })
       })
-      it('should not override existing annotations', () => {
-        expect(object.annotations).toMatchObject({
-          [LABEL]: 'myLabel',
-          nameField: { type: 'AutoNumber', label: 'Name' },
-        } as Partial<CustomObject>)
-      })
-      it('should add missing annotation types', () => {
+      it('should add annotation types', () => {
         expect(object.annotationRefTypes).toMatchObject({
           [API_NAME]: createRefToElmWithValue(BuiltinTypes.SERVICE_ID),
+          [METADATA_TYPE]: createRefToElmWithValue(BuiltinTypes.SERVICE_ID),
           [LABEL]: createRefToElmWithValue(BuiltinTypes.STRING),
         })
       })
-      it('should not override existing annotation types', () => {
-        expect(object.annotationRefTypes).toMatchObject({
-          sharingModel: createRefToElmWithValue(BuiltinTypes.HIDDEN_STRING),
-        })
+      it('should not add custom object annotations', () => {
+        expect(object.annotations).not.toHaveProperty('sharingModel')
+        expect(object.annotations).not.toHaveProperty('deploymentStatus')
       })
-    })
-  })
-  describe('when called with custom settings', () => {
-    let object: ObjectType
-    beforeEach(async () => {
-      object = new ObjectType({
-        elemID: new ElemID(SALESFORCE, 'test'),
-        annotations: {
-          [CUSTOM_SETTINGS_TYPE]: 'Hierarchical',
-        },
-      })
-      await addDefaults(object)
-    })
-    it('should add annotation values', () => {
-      expect(object.annotations).toMatchObject({
-        [API_NAME]: 'test__c',
-        [METADATA_TYPE]: CUSTOM_OBJECT,
-        [LABEL]: 'test',
-      })
-    })
-    it('should add annotation types', () => {
-      expect(object.annotationRefTypes).toMatchObject({
-        [API_NAME]: createRefToElmWithValue(BuiltinTypes.SERVICE_ID),
-        [METADATA_TYPE]: createRefToElmWithValue(BuiltinTypes.SERVICE_ID),
-        [LABEL]: createRefToElmWithValue(BuiltinTypes.STRING),
-      })
-    })
-    it('should not add custom object annotations', () => {
-      expect(object.annotations).not.toHaveProperty('sharingModel')
-      expect(object.annotations).not.toHaveProperty('deploymentStatus')
-    })
-  })
-  describe('when called with custom metadata type', () => {
-    const CUSTOM_METADATA_TYPE_NAME = 'TestCustomMetadataType__mdt'
-    const CUSTOM_METADATA_TYPE_LABEL = 'TestMetadataTypeLabel'
-    let object: ObjectType
-    beforeEach(async () => {
-      object = new ObjectType({
-        elemID: new ElemID(SALESFORCE, CUSTOM_METADATA_TYPE_NAME),
-        annotations: {
-          [API_NAME]: CUSTOM_METADATA_TYPE_NAME,
-          [LABEL]: CUSTOM_METADATA_TYPE_LABEL,
-        },
-      })
-      await addDefaults(object)
-    })
-    it('should add annotation values', () => {
-      expect(object.annotations).toMatchObject({
-        [API_NAME]: CUSTOM_METADATA_TYPE_NAME,
-        [METADATA_TYPE]: CUSTOM_OBJECT,
-        [LABEL]: CUSTOM_METADATA_TYPE_LABEL,
-      })
-    })
-    it('should add annotation types', () => {
-      expect(object.annotationRefTypes).toMatchObject({
-        [API_NAME]: createRefToElmWithValue(BuiltinTypes.SERVICE_ID),
-        [METADATA_TYPE]: createRefToElmWithValue(BuiltinTypes.SERVICE_ID),
-        [LABEL]: createRefToElmWithValue(BuiltinTypes.STRING),
-      })
-    })
-    it('should not add custom object annotations', () => {
-      expect(object.annotations).not.toHaveProperty('sharingModel')
-      expect(object.annotations).not.toHaveProperty('deploymentStatus')
     })
   })
   describe('isCustomMetadataRecordType', () => {
@@ -570,6 +576,67 @@ describe('addDefaults', () => {
           }, mockTypes.Workflow),
         })
         expect(workflowChange).not.toSatisfy(isDeactivatedFlowChangeOnly)
+      })
+    })
+  })
+  describe('referenceFieldTargetTypes', () => {
+    const fieldParent = createCustomObjectType('SomeCustomObject', {})
+    let field: Field
+    let referenceTargets: string[]
+
+    describe('when there is no annotation', () => {
+      beforeEach(() => {
+        field = createField(fieldParent, Types.primitiveDataTypes.Lookup, 'SomeCustomObject.SomeField')
+        referenceTargets = referenceFieldTargetTypes(field)
+      })
+      it('should return an empty array', () => {
+        expect(referenceTargets).toBeArrayOfSize(0)
+      })
+    })
+    describe('when the annotation is empty', () => {
+      beforeEach(() => {
+        field = createField(fieldParent, Types.primitiveDataTypes.MasterDetail, 'SomeCustomObject.SomeField', {
+          [FIELD_ANNOTATIONS.REFERENCE_TO]: [],
+        })
+        referenceTargets = referenceFieldTargetTypes(field)
+      })
+      it('should return an empty array', () => {
+        expect(referenceTargets).toBeArrayOfSize(0)
+      })
+    })
+    describe('when the annotation contains strings', () => {
+      beforeEach(() => {
+        field = createField(fieldParent, Types.primitiveDataTypes.Lookup, 'SomeCustomObject.SomeField', {
+          [FIELD_ANNOTATIONS.REFERENCE_TO]: ['SomeTargetType'],
+        })
+        referenceTargets = referenceFieldTargetTypes(field)
+      })
+      it('should return the referred type', () => {
+        expect(referenceTargets).toBeArrayOfSize(1)
+        expect(referenceTargets).toContainValue('SomeTargetType')
+      })
+    })
+    describe('when the annotation contains references', () => {
+      beforeEach(() => {
+        const targetType = createCustomObjectType('TargetType', {})
+        field = createField(fieldParent, Types.primitiveDataTypes.MasterDetail, 'SomeCustomObject.SomeField', {
+          [FIELD_ANNOTATIONS.REFERENCE_TO]: [new ReferenceExpression(targetType.elemID, targetType)],
+        })
+        referenceTargets = referenceFieldTargetTypes(field)
+      })
+      it('should return the referred type name', () => {
+        expect(referenceTargets).toBeArrayOfSize(1)
+        expect(referenceTargets).toContainValue('TargetType')
+      })
+    })
+    describe('when it`s a hierarchy field', () => {
+      beforeEach(() => {
+        field = createField(fieldParent, Types.primitiveDataTypes.Hierarchy, 'SomeCustomObject.SomeField')
+        referenceTargets = referenceFieldTargetTypes(field)
+      })
+      it('should return the referred type name', () => {
+        expect(referenceTargets).toBeArrayOfSize(1)
+        expect(referenceTargets).toContainValue('SomeCustomObject')
       })
     })
   })


### PR DESCRIPTION
Looks like there's another type of lookup field called `Hierarchy` that is used for self references

~**NOTE:** This PR builds on top of https://github.com/salto-io/salto/pull/4938~

---

Tests:
 - Fetched and verified Hierarchy fields show as references instead of the raw internal ID.

---
_Release Notes_: 
Salesforce: Hierarchy fields in data records are now treated as references

---
_User Notifications_: 
N/A