### PR TITLE
SALTO-4767: add highlighted in annotation of important values

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -443,6 +443,7 @@ This annotation is used to define what are these element's most important values
 Type: `Array` of objects of type
 - value: `string` - The name of the important value.
 - indexed: `boolean` - Specifies if the value is index for easy searchability.
+- highlighted: `boolean` - Specifies if the value is highlighted in the display.
 
 Default: `undefined` Applicable to: Types
 Example:
@@ -452,12 +453,14 @@ type salto.example {
     {
       value = "active"
       indexed = true
+      highlighted = true
     },
   ]
   _self_important_values = [
     {
       value = "name"
       indexed = false
+      highlighted = true
     },
   ]
 }

--- a/packages/adapter-api/src/builtins.ts
+++ b/packages/adapter-api/src/builtins.ts
@@ -118,6 +118,12 @@ const importantValueType = new ObjectType({
         StandardBuiltinTypes.BOOLEAN,
       ),
     },
+    highlighted: {
+      refType: new TypeReference(
+        StandardBuiltinTypes.BOOLEAN.elemID,
+        StandardBuiltinTypes.BOOLEAN,
+      ),
+    },
   },
 })
 

--- a/packages/adapter-api/src/builtins.ts
+++ b/packages/adapter-api/src/builtins.ts
@@ -111,18 +111,21 @@ const importantValueType = new ObjectType({
         StandardBuiltinTypes.STRING.elemID,
         StandardBuiltinTypes.STRING,
       ),
+      annotations: { [CORE_ANNOTATIONS.REQUIRED]: true },
     },
     indexed: {
       refType: new TypeReference(
         StandardBuiltinTypes.BOOLEAN.elemID,
         StandardBuiltinTypes.BOOLEAN,
       ),
+      annotations: { [CORE_ANNOTATIONS.REQUIRED]: true },
     },
     highlighted: {
       refType: new TypeReference(
         StandardBuiltinTypes.BOOLEAN.elemID,
         StandardBuiltinTypes.BOOLEAN,
       ),
+      annotations: { [CORE_ANNOTATIONS.REQUIRED]: true },
     },
   },
 })

--- a/packages/adapter-api/src/constants.ts
+++ b/packages/adapter-api/src/constants.ts
@@ -50,5 +50,5 @@ export const BUILTIN_TYPE_NAMES = {
   DEPENDENCY: 'dependency',
   HIDDEN_STRING: 'hidden_string',
   HIDDEN_BOOLEAN: 'hidden_boolean',
-  IMPORTANT_VALUE: 'importantValue',
+  IMPORTANT_VALUE: 'important_value',
 }

--- a/packages/adapter-utils/src/important_values.ts
+++ b/packages/adapter-utils/src/important_values.ts
@@ -19,7 +19,7 @@ import {
   Element,
   isField,
   isInstanceElement,
-  isObjectType,
+  isObjectType, isReferenceExpression,
   ReadOnlyElementsSource, Values,
 } from '@salto-io/adapter-api'
 import { values } from '@salto-io/lowerdash'
@@ -39,7 +39,11 @@ const isValidIndexedValueData = (ImportantValue: ImportantValue, valueData: unkn
     return valueData.every(part => _.isString(part) || _.isNumber(part))
   }
 
-  return _.isString(valueData) || _.isNumber(valueData) || _.isBoolean(valueData) || valueData === undefined
+  return _.isString(valueData)
+    || _.isNumber(valueData)
+    || _.isBoolean(valueData)
+    || valueData === undefined
+    || isReferenceExpression(valueData)
 }
 
 

--- a/packages/adapter-utils/src/important_values.ts
+++ b/packages/adapter-utils/src/important_values.ts
@@ -23,7 +23,7 @@ import {
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 
-type ImportantValue = { value: string; indexed: boolean }
+type ImportantValue = { value: string; indexed: boolean; highlighted: boolean }
 type ImportantValues = ImportantValue[]
 
 const getRelevantImportantValues = (importantValues: ImportantValues, indexedOnly?: boolean): ImportantValues => (

--- a/packages/adapter-utils/src/important_values.ts
+++ b/packages/adapter-utils/src/important_values.ts
@@ -92,7 +92,9 @@ const extractImportantValuesFromElement = ({
       we do not support non primitive values as indexed important values`)
       return undefined
     }
-    return { [value]: valueData }
+    const valueSplit = value.split('.')
+    const finalValue = indexedOnly === true ? valueSplit[valueSplit.length - 1] : value
+    return { [finalValue]: valueData }
   }).filter(isDefined)
 
   return finalImportantValues

--- a/packages/adapter-utils/test/important_values.test.ts
+++ b/packages/adapter-utils/test/important_values.test.ts
@@ -30,6 +30,7 @@ const userType = new ObjectType({
       {
         value: 'label',
         indexed: true,
+        highlighted: true,
       },
     ],
   },
@@ -59,28 +60,34 @@ const obj = new ObjectType({
       {
         value: 'name',
         indexed: false,
+        highlighted: true,
       },
       {
         value: 'active',
         indexed: true,
+        highlighted: false,
       },
       {
         value: 'doesNotExist',
         indexed: true,
+        highlighted: true,
       },
     ],
     [CORE_ANNOTATIONS.SELF_IMPORTANT_VALUES]: [
       {
         value: 'name',
         indexed: false,
+        highlighted: true,
       },
       {
         value: 'apiName',
         indexed: true,
+        highlighted: false,
       },
       {
         value: 'doesNotExist',
         indexed: true,
+        highlighted: true,
       },
     ],
   },
@@ -105,22 +112,22 @@ describe('getImportantValues', () => {
       element: obj,
       elementSource,
     })
-    expect(res).toEqual({
-      name: 'test',
-      apiName: 123,
-      doesNotExist: undefined,
-    })
+    expect(res).toEqual([
+      { name: 'test' },
+      { apiName: 123 },
+      { doesNotExist: undefined },
+    ])
   })
   it('should get the right important values for an instance', async () => {
     const res = await getImportantValues({
       element: inst,
       elementSource,
     })
-    expect(res).toEqual({
-      active: true,
-      name: 'test inst',
-      doesNotExist: undefined,
-    })
+    expect(res).toEqual([
+      { name: 'test inst' },
+      { active: true },
+      { doesNotExist: undefined },
+    ])
   })
   it('should get the right important values for a field', async () => {
     const field = new Field(
@@ -136,9 +143,7 @@ describe('getImportantValues', () => {
       elementSource,
       indexedOnly: false,
     })
-    expect(res).toEqual({
-      label: 'Active',
-    })
+    expect(res).toEqual([{ label: 'Active' }])
   })
   it('should return an empty object if no important values are defined', async () => {
     const objNoImportant = new ObjectType({
@@ -176,8 +181,14 @@ describe('getImportantValues', () => {
       elementSource,
       indexedOnly: true,
     })
-    expect(res).toEqual({
-      active: true,
+    expect(res).toEqual([{ active: true }, { doesNotExist: undefined }])
+  })
+  it('should return only highlighted values', async () => {
+    const res = await getImportantValues({
+      element: inst,
+      elementSource,
+      highlightedOnly: true,
     })
+    expect(res).toEqual([{ name: 'test inst' }, { doesNotExist: undefined }])
   })
 })

--- a/packages/adapter-utils/test/important_values.test.ts
+++ b/packages/adapter-utils/test/important_values.test.ts
@@ -343,6 +343,7 @@ describe('getImportantValues', () => {
       { boolean: true },
       { stringArray: ['1', '2'] },
       { undefinedVal: undefined },
+      { reference: new ReferenceExpression(inst.elemID) },
       { 'obj.id': 12345 },
     ])
   })

--- a/packages/adapter-utils/test/important_values.test.ts
+++ b/packages/adapter-utils/test/important_values.test.ts
@@ -344,7 +344,7 @@ describe('getImportantValues', () => {
       { stringArray: ['1', '2'] },
       { undefinedVal: undefined },
       { reference: new ReferenceExpression(inst.elemID) },
-      { 'obj.id': 12345 },
+      { id: 12345 },
     ])
   })
 })


### PR DESCRIPTION
add highlighted in annotation of important values
fix `getImportantValues` to return an array and to test values that are returned
add only last value of path when indexed

---

_Additional context for reviewer_

---
_Release Notes_: 
core:
* add highlighted field in annotation of important values

---
_User Notifications_: 
None
