### PR TITLE
SALTO-4761: open fixRetrieveFilePaths (Retrieve Workflow instances on CustomObjects)

### DIFF
--- a/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
@@ -42,7 +42,7 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   generateRefsInProfiles: false,
   skipAliases: false,
   toolingDepsOfCurrentNamespace: false,
-  fixRetrieveFilePaths: false,
+  fixRetrieveFilePaths: true,
 }
 
 export const buildFetchProfile = ({

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -745,7 +745,7 @@ describe('SalesforceAdapter fetch', () => {
           ]),
           expect.anything(),
           expect.anything(),
-          false,
+          true,
         )
       })
     })
@@ -1840,7 +1840,7 @@ public class LargeClass${index} {
           ]),
           expect.anything(),
           expect.anything(),
-          false,
+          true,
         )
       })
     })


### PR DESCRIPTION
Opened the optional feature  fixRetrieveFilePaths.

---
_Release Notes_: 
Salesforce Adapter:
- Bugfix: Retrieve Workflow instances on **Custom Objects**.

---
_User Notifications_: 
Saleforce:
- Upon your next fetch, you may encounter new sub-instances of **Workflow** on **Custom Objects**.
