### PR TITLE
SAAS-6359: Move static files cache from core to workspace package

### DIFF
--- a/packages/core/src/local-workspace/adapters_config.ts
+++ b/packages/core/src/local-workspace/adapters_config.ts
@@ -15,14 +15,12 @@
 * limitations under the License.
 */
 import path from 'path'
-import { nacl, staticFiles, adaptersConfigSource as acs, remoteMap } from '@salto-io/workspace'
+import { nacl, staticFiles, adaptersConfigSource as acs, remoteMap, buildStaticFilesCache } from '@salto-io/workspace'
 import { DetailedChange, ObjectType } from '@salto-io/adapter-api'
 import { localDirectoryStore, createExtensionFileFilter } from './dir_store'
-import { buildLocalStaticFilesCache } from './static_files_cache'
 
 const createNaclSource = async (
   baseDir: string,
-  localStorage: string,
   remoteMapCreator: remoteMap.RemoteMapCreator,
   persistent: boolean,
 ) : Promise<nacl.NaclFilesSource> => {
@@ -40,7 +38,7 @@ const createNaclSource = async (
 
   const staticFileSource = staticFiles.buildStaticFilesSource(
     naclStaticFilesStore,
-    buildLocalStaticFilesCache(localStorage, 'config-cache', remoteMapCreator, persistent),
+    buildStaticFilesCache('config-cache', remoteMapCreator, persistent),
   )
 
   const source = await nacl.naclFilesSource(
@@ -55,13 +53,12 @@ const createNaclSource = async (
 
 export const buildLocalAdaptersConfigSource = async (
   baseDir: string,
-  localStorage: string,
   remoteMapCreator: remoteMap.RemoteMapCreator,
   persistent: boolean,
   configTypes: ObjectType[],
   configOverrides: DetailedChange[] = [],
 ): Promise<acs.AdaptersConfigSource> => acs.buildAdaptersConfigSource({
-  naclSource: await createNaclSource(baseDir, localStorage, remoteMapCreator, persistent),
+  naclSource: await createNaclSource(baseDir, remoteMapCreator, persistent),
   ignoreFileChanges: false,
   remoteMapCreator,
   persistent,

--- a/packages/core/test/workspace/local/adapters_config.test.ts
+++ b/packages/core/test/workspace/local/adapters_config.test.ts
@@ -63,7 +63,7 @@ describe('adapters local config', () => {
       isEmpty: mockFunction<remoteMap.RemoteMap<validator.ValidationError[]>['isEmpty']>(),
     }
 
-    await buildLocalAdaptersConfigSource('baseDir', 'somePath', mockFunction<remoteMap.RemoteMapCreator>().mockResolvedValue(validationErrorsMap), true, [], [])
+    await buildLocalAdaptersConfigSource('baseDir', mockFunction<remoteMap.RemoteMapCreator>().mockResolvedValue(validationErrorsMap), true, [], [])
   })
 
   describe('initialization', () => {

--- a/packages/core/test/workspace/local/workspace.test.ts
+++ b/packages/core/test/workspace/local/workspace.test.ts
@@ -56,16 +56,14 @@ jest.mock('@salto-io/file', () => ({
 }))
 jest.mock('@salto-io/workspace', () => ({
   ...jest.requireActual<{}>('@salto-io/workspace'),
+  buildStaticFilesCache: () => ({
+    rename: jest.fn(),
+    list: jest.fn().mockResolvedValue([]),
+  }),
   initWorkspace: jest.fn(),
   loadWorkspace: jest.fn(),
 }))
 jest.mock('../../../src/local-workspace/dir_store')
-jest.mock('../../../src/local-workspace/static_files_cache', () => ({
-  buildLocalStaticFilesCache: () => ({
-    rename: jest.fn(),
-    list: jest.fn().mockResolvedValue([]),
-  }),
-}))
 jest.mock('../../../src/local-workspace/remote_map', () => ({
   ...jest.requireActual<{}>('../../../src/local-workspace/remote_map'),
   createRemoteMapCreator: () => mockRemoteMapCreator,

--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -39,6 +39,7 @@ import { createElementSelector, ElementSelector, validateSelectorsMatches, creat
 import * as validator from './src/validator'
 import * as elementSource from './src/workspace/elements_source'
 import * as remoteMap from './src/workspace/remote_map'
+import { buildStaticFilesCache } from './src/workspace/static_files/static_files_cache'
 import { updateElementsWithAlternativeAccount, createAdapterReplacedID } from './src/element_adapter_rename'
 import { RemoteElementSource, ElementsSource } from './src/workspace/elements_source'
 import { FromSource } from './src/workspace/nacl_files/multi_env/multi_env_source'
@@ -103,4 +104,5 @@ export {
   createAdapterReplacedID,
   Author,
   createPathIndexForElement,
+  buildStaticFilesCache,
 }

--- a/packages/workspace/src/workspace/static_files/index.ts
+++ b/packages/workspace/src/workspace/static_files/index.ts
@@ -16,3 +16,4 @@
 export { StaticFilesCache, StaticFilesData } from './cache'
 export { buildStaticFilesSource, buildInMemStaticFilesSource, LazyStaticFile, AbsoluteStaticFile } from './source'
 export { StaticFilesSource, MissingStaticFile, AccessDeniedStaticFile, StateStaticFilesStore, StateStaticFilesSource } from './common'
+export { buildStaticFilesCache } from './static_files_cache'


### PR DESCRIPTION
First step of SAAS-6359: Move static_file_cache to `workspace` package,  remove migration code, and remove `local` prefix from it

---

_Additional context for reviewer_

---

_Release Notes_: 
None

---

_User Notifications_: 

none
