### PR TITLE
SALTO-4816 fix wrong elemId in unresolved reference error in template expressions

### DIFF
--- a/packages/workspace/src/validator.ts
+++ b/packages/workspace/src/validator.ts
@@ -508,7 +508,7 @@ const validateValue = (
 
   if (isTemplateExpression(value)) {
     const templatedReferenceValidationErrors = value.parts.map(part => (
-      isReferenceExpression(part) ? createReferenceValidationErrors(part.elemID, part.value) : []
+      isReferenceExpression(part) ? createReferenceValidationErrors(elemID, part.value) : []
     )).flat()
     return [
       ...templatedReferenceValidationErrors,

--- a/packages/workspace/test/validator.test.ts
+++ b/packages/workspace/test/validator.test.ts
@@ -327,6 +327,21 @@ describe('Elements validation', () => {
       expect(errors).toHaveLength(0)
     })
 
+    it('should return an error on template expression with unresolved reference', async () => {
+      clonedType.fields.nested.annotations.annostr = new TemplateExpression({
+        parts: ['1', new ReferenceExpression(new ElemID('a', 'b'), 'hello world')],
+      })
+      const errors = await validateElements(
+        [clonedType],
+        createInMemoryElementSource([
+          clonedType,
+          ...await getFieldsAndAnnoTypes(clonedType),
+        ])
+      )
+      expect(errors).toHaveLength(1)
+      expect(errors[0].elemID).toEqual(clonedType.fields.nested.elemID.createNestedID('annostr'))
+    })
+
     it('should return error on bad num primitive type', async () => {
       clonedType.fields.nested.annotations.annonum = 'str'
       const errors = await validateElements(


### PR DESCRIPTION
SALTO-4816 fix wrong elemId in unresolved reference error in tamplate expressions

---

_Additional context for reviewer_

---
_Release Notes_: 
language server:
- fix issue where unresolved references inside template expressions did not show as workspace warnings

---
_User Notifications_: 
None
