### PR TITLE
SALTO-2349: Fetch and deploy Forms 

### DIFF
--- a/packages/jira-adapter/e2e_test/adapter.test.ts
+++ b/packages/jira-adapter/e2e_test/adapter.test.ts
@@ -35,7 +35,7 @@ const { replaceInstanceTypeForDeploy } = elementUtils.ducktype
 
 jest.setTimeout(600 * 1000)
 
-const excludedTypes = ['Behavior', 'Behavior__config']
+const excludedTypes = ['Behavior', 'Behavior__config', 'Form']
 
 each([
   ['Cloud', false],

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -138,6 +138,7 @@ import projectRoleRemoveTeamManagedDuplicatesFilter from './filters/remove_speci
 import issueLayoutFilter from './filters/layouts/issue_layout'
 import removeSimpleFieldProjectFilter from './filters/remove_simplified_field_project'
 import changeServiceDeskIdFieldProjectFilter from './filters/change_projects_service_desk_id'
+import formsFilter from './filters/forms/forms'
 import addJsmTypesAsFieldsFilter from './filters/add_jsm_types_as_fields'
 import createReferencesIssueLayoutFilter from './filters/layouts/create_references_layouts'
 import issueTypeHierarchyFilter from './filters/issue_type_hierarchy_filter'
@@ -329,6 +330,7 @@ export const DEFAULT_FILTERS = [
   deployJsmTypesFilter,
   // Must be done after JsmTypesFilter
   jsmPathFilter,
+  formsFilter,
   // Must be last
   defaultInstancesDeployFilter,
   ...Object.values(otherCommonFilters),

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -273,6 +273,7 @@ export const DEFAULT_FILTERS = [
   referenceBySelfLinkFilter,
   // Must run after referenceBySelfLinkFilter
   removeSelfFilter,
+  formsFilter,
   fieldReferencesFilter,
   // Must run after fieldReferencesFilter
   addJsmTypesAsFieldsFilter,
@@ -330,7 +331,6 @@ export const DEFAULT_FILTERS = [
   deployJsmTypesFilter,
   // Must be done after JsmTypesFilter
   jsmPathFilter,
-  formsFilter,
   // Must be last
   defaultInstancesDeployFilter,
   ...Object.values(otherCommonFilters),

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -2135,6 +2135,12 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       ],
     },
   },
+  Form: {
+    transformation: {
+      idFields: ['name'],
+      extendsParentId: true,
+    },
+  },
 }
 
 export const JSM_DUCKTYPE_SUPPORTED_TYPES = {

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -2137,7 +2137,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
   },
 }
 
-const JSM_DUCKTYPE_SUPPORTED_TYPES = {
+export const JSM_DUCKTYPE_SUPPORTED_TYPES = {
   RequestType: ['RequestType'],
   CustomerPermissions: ['CustomerPermissions'],
   Queue: ['Queue'],

--- a/packages/jira-adapter/src/constants.ts
+++ b/packages/jira-adapter/src/constants.ts
@@ -111,5 +111,6 @@ export const PORTAL_SETTINGS_TYPE_NAME = 'PortalSettings'
 export const SLA_TYPE_NAME = 'SLA'
 export const ISSUE_VIEW_TYPE = 'IssueView'
 export const REQUEST_FORM_TYPE = 'RequestForm'
+export const FORM_TYPE = 'Form'
 // almost constant functions
 export const fetchFailedWarnings = (name :string):string => `Salto could not access the ${name} resource. Elements from that type were not fetched. Please make sure that this type is enabled in your service, and that the supplied user credentials have sufficient permissions to access this data. You can also exclude this data from Salto's fetches by changing the environment configuration. Learn more at https://help.salto.io/en/articles/6947061-salto-could-not-access-the-resource`

--- a/packages/jira-adapter/src/filters/forms/forms.ts
+++ b/packages/jira-adapter/src/filters/forms/forms.ts
@@ -26,8 +26,8 @@ import { createFormType, isDetailedFormsResponse, isFormsResponse } from './form
 const { isDefined } = lowerDashValues
 
 /*
-This filter fetches all forms from Jira Service Management and creates an instance element for each form.
-We use filter because we need to use cloudId which is not available in the infrastructure.
+* This filter fetches all forms from Jira Service Management and creates an instance element for each form.
+* We use filter because we need to use cloudId which is not available in the infrastructure.
 */
 const filter: FilterCreator = ({ config, client, getElemIdFunc }) => ({
   name: 'formsFilter',
@@ -42,7 +42,7 @@ const filter: FilterCreator = ({ config, client, getElemIdFunc }) => ({
 
     const jsmProjects = elements
       .filter(isInstanceElement)
-      .filter(instnace => instnace.elemID.typeName === PROJECT_TYPE)
+      .filter(instance => instance.elemID.typeName === PROJECT_TYPE)
       .filter(project => project.value.projectTypeKey === SERVICE_DESK)
 
     const forms = (await Promise.all(jsmProjects
@@ -60,13 +60,7 @@ const filter: FilterCreator = ({ config, client, getElemIdFunc }) => ({
               return undefined
             }
             const name = `${project.value.name}_${formResponse.name}`
-            delete detailedRes.data?.publish
-            delete detailedRes.data.design.settings.templateFormUuid
-            detailedRes.data.design.questions = Object.values(detailedRes.data.design.questions)
-            detailedRes.data.design.sections = Object.values(detailedRes.data.design.sections)
-            detailedRes.data.design.conditions = Object.values(detailedRes.data.design.conditions)
             const formValue = detailedRes.data
-            formValue.id = formResponse.id
             const serviceIds = adapterElements.createServiceIds(formValue, 'uuid', formType.elemID)
             const instanceName = getElemIdFunc ? getElemIdFunc(JIRA, serviceIds, naclCase(name)).name
               : naclCase(name)

--- a/packages/jira-adapter/src/filters/forms/forms.ts
+++ b/packages/jira-adapter/src/filters/forms/forms.ts
@@ -115,7 +115,6 @@ const filter: FilterCreator = ({ config, client, getElemIdFunc }) => ({
               transformationConfigByType: getTransformationConfigByType(jsmDuckTypeApiDefinitions.types),
               transformationDefaultConfig: jsmDuckTypeApiDefinitions.typeDefaults.transformation,
               parent: project,
-              // what ever default name you'd like
               defaultName: name,
               getElemIdFunc,
             })

--- a/packages/jira-adapter/src/filters/forms/forms.ts
+++ b/packages/jira-adapter/src/filters/forms/forms.ts
@@ -35,8 +35,9 @@ const filter: FilterCreator = ({ config, client, getElemIdFunc }) => ({
       return
     }
     const cloudId = await getCloudId(client)
-    const { formType } = createFormType()
+    const { formType, subTypes } = createFormType()
     elements.push(formType)
+    subTypes.forEach(subType => { elements.push(subType) })
 
     const jsmProject = elements
       .filter(isInstanceElement)
@@ -54,6 +55,9 @@ const filter: FilterCreator = ({ config, client, getElemIdFunc }) => ({
             const name = `${project.value.name}_${formResponse.name}`
             delete detailedRes.data?.publish
             delete detailedRes.data.design.settings.templateFormUuid
+            detailedRes.data.design.questions = Object.values(detailedRes.data.design.questions)
+            detailedRes.data.design.sections = Object.values(detailedRes.data.design.sections)
+            detailedRes.data.design.conditions = Object.values(detailedRes.data.design.conditions)
             const formValue = detailedRes.data
             formValue.id = formResponse.id
             const serviceIds = adapterElements.createServiceIds(formValue, 'uuid', formType.elemID)

--- a/packages/jira-adapter/src/filters/forms/forms.ts
+++ b/packages/jira-adapter/src/filters/forms/forms.ts
@@ -1,0 +1,78 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
+import { values as lowerDashValues } from '@salto-io/lowerdash'
+import { elements as adapterElements } from '@salto-io/adapter-components'
+import { createSchemeGuard, naclCase, pathNaclCase } from '@salto-io/adapter-utils'
+import { FilterCreator } from '../../filter'
+import { JIRA, PROJECT_TYPE } from '../../constants'
+import { getCloudId } from '../automation/cloud_id'
+import { DETAILED_FORM_RESPONSE_SCHEME, FORMS_RESPONSE_SCHEME, createFormType, detailedFormResponse, formsResponse } from './forms_types'
+
+const { isDefined } = lowerDashValues
+
+const isFormsResponse = createSchemeGuard<formsResponse>(FORMS_RESPONSE_SCHEME)
+const isDetailedFormsResponse = createSchemeGuard<detailedFormResponse>(DETAILED_FORM_RESPONSE_SCHEME)
+
+const filter: FilterCreator = ({ config, client, getElemIdFunc }) => ({
+  name: 'formsFilter',
+  onFetch: async elements => {
+    if (!config.fetch.enableJSM) {
+      return
+    }
+    const cloudId = await getCloudId(client)
+    const { formType } = createFormType()
+    elements.push(formType)
+
+    const jsmProject = elements
+      .filter(isInstanceElement)
+      .filter(e => e.elemID.typeName === PROJECT_TYPE)
+      .filter(e => e.value.projectTypeKey === 'service_desk')
+
+    const forms = (await Promise.all(jsmProject.flatMap(async project => {
+      const url = `/gateway/api/proforma/cloudid/${cloudId}/api/1/projects/${project.value.id}/forms`
+      const res = await client.getSinglePage({ url })
+      if (isFormsResponse(res)) {
+        return Promise.all(res.data.map(async formResponse => {
+          const detailedUrl = `/gateway/api/proforma/cloudid/${cloudId}/api/2/projects/${project.value.id}/forms/${formResponse.id}`
+          const detailedRes = await client.getSinglePage({ url: detailedUrl })
+          if (isDetailedFormsResponse(detailedRes)) {
+            const name = `${project.value.name}_${formResponse.name}`
+            delete detailedRes.data?.publish
+            delete detailedRes.data.design.settings.templateFormUuid
+            const formValue = detailedRes.data
+            formValue.id = formResponse.id
+            const serviceIds = adapterElements.createServiceIds(formValue, 'uuid', formType.elemID)
+            const instanceName = getElemIdFunc ? getElemIdFunc(JIRA, serviceIds, naclCase(name)).name
+              : naclCase(name)
+            const prefixPath = project.path ?? []
+            return new InstanceElement(
+              instanceName,
+              formType,
+              formValue,
+              [...prefixPath.slice(0, -1), 'forms', pathNaclCase(instanceName)],
+            )
+          }
+          return undefined
+        }))
+      }
+      return undefined
+    }))).flat().filter(isDefined)
+    forms.forEach(form => elements.push(form))
+  },
+})
+export default filter

--- a/packages/jira-adapter/src/filters/forms/forms.ts
+++ b/packages/jira-adapter/src/filters/forms/forms.ts
@@ -14,16 +14,55 @@
 * limitations under the License.
 */
 
-import { InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, Change, InstanceElement, ReferenceExpression, getChangeData, isAdditionChange, isAdditionOrModificationChange, isInstanceChange, isInstanceElement } from '@salto-io/adapter-api'
 import { values as lowerDashValues } from '@salto-io/lowerdash'
 import { elements as adapterElements } from '@salto-io/adapter-components'
-import { naclCase, pathNaclCase } from '@salto-io/adapter-utils'
+import { getParent, naclCase, pathNaclCase } from '@salto-io/adapter-utils'
+import _ from 'lodash'
 import { FilterCreator } from '../../filter'
-import { JIRA, PROJECT_TYPE, SERVICE_DESK } from '../../constants'
+import { FORM_TYPE, JIRA, PROJECT_TYPE, SERVICE_DESK } from '../../constants'
 import { getCloudId } from '../automation/cloud_id'
-import { createFormType, isDetailedFormsResponse, isFormsResponse } from './forms_types'
+import { createFormType, isCreateFormResponse, isDetailedFormsResponse, isFormsResponse } from './forms_types'
+import { deployChanges } from '../../deployment/standard_deployment'
+import JiraClient from '../../client/client'
+import { setTypeDeploymentAnnotations, addAnnotationRecursively } from '../../utils'
 
 const { isDefined } = lowerDashValues
+
+const deployForms = async (
+  change: Change<InstanceElement>,
+  client: JiraClient,
+): Promise<void> => {
+  const form = getChangeData(change)
+  const project = getParent(form)
+  if (form.value.design?.settings?.name === undefined) {
+    return
+  }
+  const cloudId = await getCloudId(client)
+  if (isAdditionOrModificationChange(change)) {
+    if (isAdditionChange(change)) {
+      const resp = await client.post({
+        url: `/gateway/api/proforma/cloudid/${cloudId}/api/2/projects/${project.value.id}/forms`,
+        data: {
+          name: form.value.design.settings.name,
+        },
+      })
+      if (!isCreateFormResponse(resp.data)) {
+        return
+      }
+      form.value.id = resp.data.id
+      form.value.design.settings.templateId = resp.data.id
+    }
+    await client.put({
+      url: `/gateway/api/proforma/cloudid/${cloudId}/api/2/projects/${project.value.id}/forms/${form.value.id}`,
+      data: form.value,
+    })
+  } else {
+    await client.delete({
+      url: `/gateway/api/proforma/cloudid/${cloudId}/api/1/projects/${project.value.id}/forms/${form.value.id}`,
+    })
+  }
+}
 
 /*
 * This filter fetches all forms from Jira Service Management and creates an instance element for each form.
@@ -32,11 +71,15 @@ const { isDefined } = lowerDashValues
 const filter: FilterCreator = ({ config, client, getElemIdFunc }) => ({
   name: 'formsFilter',
   onFetch: async elements => {
-    if (!config.fetch.enableJSM) {
+    if (!config.fetch.enableJSM || !config.fetch.enableJsmExperimental) {
       return
     }
     const cloudId = await getCloudId(client)
     const { formType, subTypes } = createFormType()
+    setTypeDeploymentAnnotations(formType)
+    await addAnnotationRecursively(formType, CORE_ANNOTATIONS.CREATABLE)
+    await addAnnotationRecursively(formType, CORE_ANNOTATIONS.UPDATABLE)
+    await addAnnotationRecursively(formType, CORE_ANNOTATIONS.DELETABLE)
     elements.push(formType)
     subTypes.forEach(subType => { elements.push(subType) })
 
@@ -56,7 +99,7 @@ const filter: FilterCreator = ({ config, client, getElemIdFunc }) => ({
           .map(async formResponse => {
             const detailedUrl = `/gateway/api/proforma/cloudid/${cloudId}/api/2/projects/${project.value.id}/forms/${formResponse.id}`
             const detailedRes = await client.getSinglePage({ url: detailedUrl })
-            if (!isDetailedFormsResponse(detailedRes)) {
+            if (!isDetailedFormsResponse(detailedRes.data)) {
               return undefined
             }
             const name = `${project.value.name}_${formResponse.name}`
@@ -70,12 +113,35 @@ const filter: FilterCreator = ({ config, client, getElemIdFunc }) => ({
               formType,
               formValue,
               [...prefixPath.slice(0, -1), 'forms', pathNaclCase(instanceName)],
+              {
+                [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(project.elemID, project)],
+              }
             )
           }))
       })))
       .flat()
       .filter(isDefined)
     forms.forEach(form => elements.push(form))
+  },
+  deploy: async changes => {
+    if (!config.fetch.enableJSM || !config.fetch.enableJsmExperimental) {
+      return {
+        deployResult: { appliedChanges: [], errors: [] },
+        leftoverChanges: changes,
+      }
+    }
+    const [formsChanges, leftoverChanges] = _.partition(
+      changes,
+      (change): change is Change<InstanceElement> => isInstanceChange(change)
+      && getChangeData(change).elemID.typeName === FORM_TYPE
+    )
+    const deployResult = await deployChanges(formsChanges,
+      async change => deployForms(change, client))
+
+    return {
+      leftoverChanges,
+      deployResult,
+    }
   },
 })
 export default filter

--- a/packages/jira-adapter/src/filters/forms/forms_types.ts
+++ b/packages/jira-adapter/src/filters/forms/forms_types.ts
@@ -28,6 +28,9 @@ export type detailedFormResponse = {
       settings: {
         templateFormUuid?: string
       }
+      questions: {}
+      sections: {}
+      conditions: {}
     }
   }
 }
@@ -102,7 +105,26 @@ export const createFormType = (): {
       },
     },
   })
-
+  const questionType = new ObjectType({
+    elemID: new ElemID(JIRA, 'Question'),
+    fields: {
+      type: {
+        refType: BuiltinTypes.STRING,
+      },
+      label: {
+        refType: BuiltinTypes.STRING,
+      },
+      description: {
+        refType: BuiltinTypes.STRING,
+      },
+      questionKey: {
+        refType: BuiltinTypes.STRING,
+      },
+      jiraField: {
+        refType: BuiltinTypes.STRING,
+      },
+    },
+  })
   const FormDesignType = new ObjectType({
     elemID: new ElemID(JIRA, 'FormDesign'),
     fields: {
@@ -119,7 +141,7 @@ export const createFormType = (): {
         refType: BuiltinTypes.UNKNOWN,
       },
       questions: {
-        refType: BuiltinTypes.UNKNOWN,
+        refType: new ListType(questionType),
       },
     },
   })
@@ -146,6 +168,6 @@ export const createFormType = (): {
   })
   return {
     formType,
-    subTypes: [FormSubmitType, FormSettingsType, FormLayoutItemType, FormDesignType],
+    subTypes: [FormSubmitType, FormSettingsType, FormLayoutItemType, FormDesignType, questionType],
   }
 }

--- a/packages/jira-adapter/src/filters/forms/forms_types.ts
+++ b/packages/jira-adapter/src/filters/forms/forms_types.ts
@@ -20,11 +20,9 @@ import { elements as adapterElements } from '@salto-io/adapter-components'
 import { createSchemeGuard } from '@salto-io/adapter-utils'
 import { JIRA, FORM_TYPE } from '../../constants'
 
-export type DetailedFormDataResponse = {
+type DetailedFormDataResponse = {
     id: number
-    updated: string
     uuid: string
-    publish: {}
     design: {
       settings: {
         templateId: string
@@ -46,7 +44,7 @@ type FormResponse = {
   name: string
 }
 
-export type FormsResponse = {
+type FormsResponse = {
   data: FormResponse[]
 }
 
@@ -58,6 +56,7 @@ export const FORMS_RESPONSE_SCHEME = Joi.object({
 }).unknown(true).required()
 
 export const DETAILED_FORM_RESPONSE_SCHEME = Joi.object({
+  id: Joi.number().required(),
   uuid: Joi.string().required(),
   design: Joi.object({
     settings: Joi.object({
@@ -66,7 +65,7 @@ export const DETAILED_FORM_RESPONSE_SCHEME = Joi.object({
       submit: Joi.object({
         lock: Joi.boolean().required(),
         pdf: Joi.boolean().required(),
-      }).required(),
+      }).unknown(true).required(),
       templateFormUuid: Joi.string().required(),
     }).unknown(true).required(),
     questions: Joi.object().unknown(true).required(),
@@ -212,9 +211,8 @@ export const createFormType = (): {
   }
 }
 
-export const isFormsResponse = createSchemeGuard<FormsResponse>(FORMS_RESPONSE_SCHEME)
-export const isDetailedFormsResponse = createSchemeGuard<DetailedFormDataResponse>(DETAILED_FORM_RESPONSE_SCHEME)
-
+export const isFormsResponse = createSchemeGuard<FormsResponse>(FORMS_RESPONSE_SCHEME, 'bad forms response from jira server')
+export const isDetailedFormsResponse = createSchemeGuard<DetailedFormDataResponse>(DETAILED_FORM_RESPONSE_SCHEME, 'bad detailed form response from jira server')
 
 type createFormResponse = {
   id: number
@@ -224,4 +222,4 @@ const CREATE_FORM_RESPONSE_SCHEME = Joi.object({
   id: Joi.number().required(),
 }).unknown(true).required()
 
-export const isCreateFormResponse = createSchemeGuard<createFormResponse>(CREATE_FORM_RESPONSE_SCHEME)
+export const isCreateFormResponse = createSchemeGuard<createFormResponse>(CREATE_FORM_RESPONSE_SCHEME, 'bad form creation response from jira server')

--- a/packages/jira-adapter/src/filters/forms/forms_types.ts
+++ b/packages/jira-adapter/src/filters/forms/forms_types.ts
@@ -1,0 +1,151 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { ObjectType, ElemID, BuiltinTypes, CORE_ANNOTATIONS, ListType } from '@salto-io/adapter-api'
+import Joi from 'joi'
+import { elements as adapterElements } from '@salto-io/adapter-components'
+import { JIRA, FORM_TYPE } from '../../constants'
+
+export type detailedFormResponse = {
+  data: {
+    uuid?: string
+    publish?: string
+    id: number
+    design: {
+      settings: {
+        templateFormUuid?: string
+      }
+    }
+  }
+}
+
+type formResponse = {
+  id: number
+  name: string
+}
+
+export type formsResponse = {
+  data: formResponse[]
+}
+
+export const FORMS_RESPONSE_SCHEME = Joi.object({
+  data: Joi.array().items(Joi.object({
+  }).unknown(true).required()),
+}).unknown(true).required()
+
+export const DETAILED_FORM_RESPONSE_SCHEME = Joi.object({
+  data: Joi.object({
+    uuid: Joi.string().required(),
+    design: Joi.object({
+    }).unknown(true).required(),
+  }).unknown(true).required(),
+}).unknown(true).required()
+
+
+export const createFormType = (): {
+    formType: ObjectType
+    subTypes: ObjectType[]
+  } => {
+  const FormSubmitType = new ObjectType({
+    elemID: new ElemID(JIRA, 'FormSubmitettings'),
+    fields: {
+      lock: {
+        refType: BuiltinTypes.BOOLEAN,
+      },
+      pdf: {
+        refType: BuiltinTypes.BOOLEAN,
+      },
+    },
+  })
+
+  const FormSettingsType = new ObjectType({
+    elemID: new ElemID(JIRA, 'FormSettings'),
+    fields: {
+      templateId: {
+        refType: BuiltinTypes.NUMBER,
+      },
+      name: {
+        refType: BuiltinTypes.STRING,
+      },
+      submit: {
+        refType: FormSubmitType,
+      },
+      templateFormUuid: {
+        refType: BuiltinTypes.STRING,
+      },
+    },
+  })
+  const FormLayoutItemType = new ObjectType({
+    elemID: new ElemID(JIRA, 'layoutForm'),
+    fields: {
+      versoin: {
+        refType: BuiltinTypes.NUMBER,
+      },
+      type: {
+        refType: BuiltinTypes.STRING,
+      },
+      content: {
+        refType: new ListType(BuiltinTypes.UNKNOWN),
+      },
+    },
+  })
+
+  const FormDesignType = new ObjectType({
+    elemID: new ElemID(JIRA, 'FormDesign'),
+    fields: {
+      settings: {
+        refType: FormSettingsType,
+      },
+      layout: {
+        refType: new ListType(FormLayoutItemType),
+      },
+      conditions: {
+        refType: BuiltinTypes.UNKNOWN,
+      },
+      sections: {
+        refType: BuiltinTypes.UNKNOWN,
+      },
+      questions: {
+        refType: BuiltinTypes.UNKNOWN,
+      },
+    },
+  })
+
+  const formType = new ObjectType({
+    elemID: new ElemID(JIRA, FORM_TYPE),
+    fields: {
+      id: {
+        refType: BuiltinTypes.NUMBER,
+        annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
+      },
+      uuid: {
+        refType: BuiltinTypes.SERVICE_ID,
+        annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
+      },
+      updated: {
+        refType: BuiltinTypes.STRING,
+      },
+      design: {
+        refType: FormDesignType,
+      },
+    },
+    path: [JIRA, adapterElements.TYPES_PATH, FORM_TYPE],
+  })
+  return {
+    formType,
+    subTypes: [FormSubmitType, FormSettingsType, FormLayoutItemType, FormDesignType],
+  }
+}

--- a/packages/jira-adapter/src/filters/forms/forms_types.ts
+++ b/packages/jira-adapter/src/filters/forms/forms_types.ts
@@ -20,8 +20,7 @@ import { elements as adapterElements } from '@salto-io/adapter-components'
 import { createSchemeGuard } from '@salto-io/adapter-utils'
 import { JIRA, FORM_TYPE } from '../../constants'
 
-export type DetailedFormResponse = {
-  data: {
+export type DetailedFormDataResponse = {
     id: number
     updated: string
     uuid: string
@@ -40,7 +39,6 @@ export type DetailedFormResponse = {
       sections: {}
       conditions: {}
     }
-  }
 }
 
 type FormResponse = {
@@ -60,22 +58,20 @@ export const FORMS_RESPONSE_SCHEME = Joi.object({
 }).unknown(true).required()
 
 export const DETAILED_FORM_RESPONSE_SCHEME = Joi.object({
-  data: Joi.object({
-    uuid: Joi.string().required(),
-    design: Joi.object({
-      settings: Joi.object({
-        templateId: Joi.number().required(),
-        name: Joi.string().required(),
-        submit: Joi.object({
-          lock: Joi.boolean().required(),
-          pdf: Joi.boolean().required(),
-        }).required(),
-        templateFormUuid: Joi.string().required(),
-      }).unknown(true).required(),
-      questions: Joi.object().unknown(true).required(),
-      sections: Joi.object().unknown(true).required(),
-      conditions: Joi.object().unknown(true).required(),
+  uuid: Joi.string().required(),
+  design: Joi.object({
+    settings: Joi.object({
+      templateId: Joi.number().required(),
+      name: Joi.string().required(),
+      submit: Joi.object({
+        lock: Joi.boolean().required(),
+        pdf: Joi.boolean().required(),
+      }).required(),
+      templateFormUuid: Joi.string().required(),
     }).unknown(true).required(),
+    questions: Joi.object().unknown(true).required(),
+    sections: Joi.object().unknown(true).required(),
+    conditions: Joi.object().unknown(true).required(),
   }).unknown(true).required(),
 }).unknown(true).required()
 
@@ -101,7 +97,6 @@ export const createFormType = (): {
     fields: {
       templateId: {
         refType: BuiltinTypes.NUMBER,
-        annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
       },
       name: {
         refType: BuiltinTypes.STRING,
@@ -111,7 +106,6 @@ export const createFormType = (): {
       },
       templateFormUuid: {
         refType: BuiltinTypes.STRING,
-        annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
       },
     },
   })
@@ -120,7 +114,6 @@ export const createFormType = (): {
     fields: {
       localId: {
         refType: BuiltinTypes.STRING,
-        annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
       },
     },
   })
@@ -132,7 +125,6 @@ export const createFormType = (): {
       },
       localId: {
         refType: new ListType(BuiltinTypes.STRING),
-        annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
       },
       attrs: {
         refType: AttributeContentLayoutType,
@@ -221,4 +213,15 @@ export const createFormType = (): {
 }
 
 export const isFormsResponse = createSchemeGuard<FormsResponse>(FORMS_RESPONSE_SCHEME)
-export const isDetailedFormsResponse = createSchemeGuard<DetailedFormResponse>(DETAILED_FORM_RESPONSE_SCHEME)
+export const isDetailedFormsResponse = createSchemeGuard<DetailedFormDataResponse>(DETAILED_FORM_RESPONSE_SCHEME)
+
+
+type createFormResponse = {
+  id: number
+}
+
+const CREATE_FORM_RESPONSE_SCHEME = Joi.object({
+  id: Joi.number().required(),
+}).unknown(true).required()
+
+export const isCreateFormResponse = createSchemeGuard<createFormResponse>(CREATE_FORM_RESPONSE_SCHEME)

--- a/packages/jira-adapter/src/filters/forms/forms_types.ts
+++ b/packages/jira-adapter/src/filters/forms/forms_types.ts
@@ -77,7 +77,7 @@ export const createFormType = (): {
     formType: ObjectType
     subTypes: ObjectType[]
   } => {
-  const FormSubmitType = new ObjectType({
+  const formSubmitType = new ObjectType({
     elemID: new ElemID(JIRA, 'FormSubmitettings'),
     fields: {
       lock: {
@@ -89,7 +89,7 @@ export const createFormType = (): {
     },
   })
 
-  const FormSettingsType = new ObjectType({
+  const formSettingsType = new ObjectType({
     elemID: new ElemID(JIRA, 'FormSettings'),
     fields: {
       templateId: {
@@ -99,14 +99,14 @@ export const createFormType = (): {
         refType: BuiltinTypes.STRING,
       },
       submit: {
-        refType: FormSubmitType,
+        refType: formSubmitType,
       },
       templateFormUuid: {
         refType: BuiltinTypes.STRING,
       },
     },
   })
-  const AttributeContentLayoutType = new ObjectType({
+  const attributeContentLayoutType = new ObjectType({
     elemID: new ElemID(JIRA, 'AttributeContentLayoutType'),
     fields: {
       localId: {
@@ -114,7 +114,7 @@ export const createFormType = (): {
       },
     },
   })
-  const ContentLayoutType = new ObjectType({
+  const contentLayoutType = new ObjectType({
     elemID: new ElemID(JIRA, 'ContentLayout'),
     fields: {
       type: {
@@ -124,11 +124,11 @@ export const createFormType = (): {
         refType: new ListType(BuiltinTypes.STRING),
       },
       attrs: {
-        refType: AttributeContentLayoutType,
+        refType: attributeContentLayoutType,
       },
     },
   })
-  const FormLayoutItemType = new ObjectType({
+  const formLayoutItemType = new ObjectType({
     elemID: new ElemID(JIRA, 'LayoutForm'),
     fields: {
       version: {
@@ -138,11 +138,11 @@ export const createFormType = (): {
         refType: BuiltinTypes.STRING,
       },
       content: {
-        refType: new ListType(ContentLayoutType),
+        refType: new ListType(contentLayoutType),
       },
     },
   })
-  const QuestionType = new ObjectType({
+  const questionType = new ObjectType({
     elemID: new ElemID(JIRA, 'Question'),
     fields: {
       type: {
@@ -162,14 +162,14 @@ export const createFormType = (): {
       },
     },
   })
-  const FormDesignType = new ObjectType({
+  const formDesignType = new ObjectType({
     elemID: new ElemID(JIRA, 'FormDesign'),
     fields: {
       settings: {
-        refType: FormSettingsType,
+        refType: formSettingsType,
       },
       layout: {
-        refType: new ListType(FormLayoutItemType),
+        refType: new ListType(formLayoutItemType),
       },
       conditions: {
         refType: BuiltinTypes.UNKNOWN,
@@ -178,12 +178,12 @@ export const createFormType = (): {
         refType: BuiltinTypes.UNKNOWN,
       },
       questions: {
-        refType: new ListType(QuestionType),
+        refType: new ListType(questionType),
       },
     },
   })
 
-  const FormType = new ObjectType({
+  const formType = new ObjectType({
     elemID: new ElemID(JIRA, FORM_TYPE),
     fields: {
       id: {
@@ -198,14 +198,14 @@ export const createFormType = (): {
         refType: BuiltinTypes.STRING,
       },
       design: {
-        refType: FormDesignType,
+        refType: formDesignType,
       },
     },
     path: [JIRA, adapterElements.TYPES_PATH, FORM_TYPE],
   })
   return {
-    formType: FormType,
-    subTypes: [FormSubmitType, FormSettingsType, FormLayoutItemType, FormDesignType, QuestionType, ContentLayoutType],
+    formType,
+    subTypes: [formSubmitType, formSettingsType, formLayoutItemType, formDesignType, questionType, contentLayoutType],
   }
 }
 

--- a/packages/jira-adapter/src/filters/forms/forms_types.ts
+++ b/packages/jira-adapter/src/filters/forms/forms_types.ts
@@ -17,6 +17,7 @@
 import { ObjectType, ElemID, BuiltinTypes, CORE_ANNOTATIONS, ListType } from '@salto-io/adapter-api'
 import Joi from 'joi'
 import { elements as adapterElements } from '@salto-io/adapter-components'
+import { createSchemeGuard } from '@salto-io/adapter-utils'
 import { JIRA, FORM_TYPE } from '../../constants'
 
 export type detailedFormResponse = {
@@ -91,6 +92,30 @@ export const createFormType = (): {
       },
     },
   })
+  const attributeContnetLayoutType = new ObjectType({
+    elemID: new ElemID(JIRA, 'attributeContnetLayout'),
+    fields: {
+      localId: {
+        refType: BuiltinTypes.STRING,
+        annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
+      },
+    },
+  })
+  const contentLayoutType = new ObjectType({
+    elemID: new ElemID(JIRA, 'contentLayout'),
+    fields: {
+      type: {
+        refType: BuiltinTypes.STRING,
+      },
+      localId: {
+        refType: new ListType(BuiltinTypes.STRING),
+        annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
+      },
+      attrs: {
+        refType: attributeContnetLayoutType,
+      },
+    },
+  })
   const FormLayoutItemType = new ObjectType({
     elemID: new ElemID(JIRA, 'layoutForm'),
     fields: {
@@ -101,7 +126,7 @@ export const createFormType = (): {
         refType: BuiltinTypes.STRING,
       },
       content: {
-        refType: new ListType(BuiltinTypes.UNKNOWN),
+        refType: new ListType(contentLayoutType),
       },
     },
   })
@@ -168,6 +193,9 @@ export const createFormType = (): {
   })
   return {
     formType,
-    subTypes: [FormSubmitType, FormSettingsType, FormLayoutItemType, FormDesignType, questionType],
+    subTypes: [FormSubmitType, FormSettingsType, FormLayoutItemType, FormDesignType, questionType, contentLayoutType],
   }
 }
+
+export const isFormsResponse = createSchemeGuard<formsResponse>(FORMS_RESPONSE_SCHEME)
+export const isDetailedFormsResponse = createSchemeGuard<detailedFormResponse>(DETAILED_FORM_RESPONSE_SCHEME)

--- a/packages/jira-adapter/src/filters/forms/forms_types.ts
+++ b/packages/jira-adapter/src/filters/forms/forms_types.ts
@@ -21,7 +21,6 @@ import { createSchemeGuard } from '@salto-io/adapter-utils'
 import { JIRA, FORM_TYPE } from '../../constants'
 
 type DetailedFormDataResponse = {
-    id: number
     uuid: string
     design: {
       settings: {
@@ -56,7 +55,6 @@ export const FORMS_RESPONSE_SCHEME = Joi.object({
 }).unknown(true).required()
 
 export const DETAILED_FORM_RESPONSE_SCHEME = Joi.object({
-  id: Joi.number().required(),
   uuid: Joi.string().required(),
   design: Joi.object({
     settings: Joi.object({

--- a/packages/jira-adapter/src/filters/jsm_paths.ts
+++ b/packages/jira-adapter/src/filters/jsm_paths.ts
@@ -17,7 +17,7 @@
 import { isInstanceElement } from '@salto-io/adapter-api'
 import { getParent, pathNaclCase } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../filter'
-import { CALENDAR_TYPE, QUEUE_TYPE, PORTAL_GROUP_TYPE, REQUEST_TYPE_NAME, PORTAL_SETTINGS_TYPE_NAME, SLA_TYPE_NAME } from '../constants'
+import { CALENDAR_TYPE, QUEUE_TYPE, PORTAL_GROUP_TYPE, REQUEST_TYPE_NAME, PORTAL_SETTINGS_TYPE_NAME, SLA_TYPE_NAME, FORM_TYPE } from '../constants'
 
 const JSM_ELEMENT_DIRECTORY: Record<string, string> = {
   [QUEUE_TYPE]: 'queues',
@@ -26,6 +26,7 @@ const JSM_ELEMENT_DIRECTORY: Record<string, string> = {
   [PORTAL_GROUP_TYPE]: 'portalGroups',
   [PORTAL_SETTINGS_TYPE_NAME]: 'portalSettings',
   [SLA_TYPE_NAME]: 'SLAs',
+  [FORM_TYPE]: 'forms',
 }
 const filter: FilterCreator = ({ config }) => ({
   name: 'jsmPathsFilter',

--- a/packages/jira-adapter/src/filters/jsm_types_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/jsm_types_deploy_filter.ts
@@ -18,15 +18,9 @@ import _ from 'lodash'
 import { getChangeData, isInstanceChange, Change, InstanceElement } from '@salto-io/adapter-api'
 import { defaultDeployChange, deployChanges } from '../deployment/standard_deployment'
 import { FilterCreator } from '../filter'
-import { CALENDAR_TYPE, CUSTOMER_PERMISSIONS_TYPE, QUEUE_TYPE, PORTAL_GROUP_TYPE, SLA_TYPE_NAME } from '../constants'
+import { JSM_DUCKTYPE_SUPPORTED_TYPES } from '../config/api_config'
 
-const jsmSupportedTypes = [
-  CUSTOMER_PERMISSIONS_TYPE,
-  CALENDAR_TYPE,
-  QUEUE_TYPE,
-  PORTAL_GROUP_TYPE,
-  SLA_TYPE_NAME,
-]
+const SUPPORTED_TYPES = Object.keys(JSM_DUCKTYPE_SUPPORTED_TYPES)
 
 const filterCreator: FilterCreator = ({ config, client }) => ({
   name: 'jsmTypesFilter',
@@ -41,7 +35,7 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
     const [jsmTypesChanges, leftoverChanges] = _.partition(
       changes,
       change =>
-        jsmSupportedTypes.includes(getChangeData(change).elemID.typeName)
+        SUPPORTED_TYPES.includes(getChangeData(change).elemID.typeName)
         && isInstanceChange(change)
     )
 

--- a/packages/jira-adapter/src/filters/jsm_types_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/jsm_types_deploy_filter.ts
@@ -20,7 +20,7 @@ import { defaultDeployChange, deployChanges } from '../deployment/standard_deplo
 import { FilterCreator } from '../filter'
 import { JSM_DUCKTYPE_SUPPORTED_TYPES } from '../config/api_config'
 
-const SUPPORTED_TYPES = Object.keys(JSM_DUCKTYPE_SUPPORTED_TYPES)
+const SUPPORTED_TYPES = new Set(Object.keys(JSM_DUCKTYPE_SUPPORTED_TYPES))
 
 const filterCreator: FilterCreator = ({ config, client }) => ({
   name: 'jsmTypesFilter',
@@ -35,7 +35,7 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
     const [jsmTypesChanges, leftoverChanges] = _.partition(
       changes,
       change =>
-        SUPPORTED_TYPES.includes(getChangeData(change).elemID.typeName)
+        SUPPORTED_TYPES.has(getChangeData(change).elemID.typeName)
         && isInstanceChange(change)
     )
 

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -993,7 +993,7 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     src: { field: 'jiraField', parentTypes: ['Question'] },
     serializationStrategy: 'id',
     jiraMissingRefStrategy: 'typeAndValue',
-    target: { type: 'Field' },
+    target: { type: FIELD_TYPE_NAME },
   },
 ]
 

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -989,6 +989,12 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     jiraMissingRefStrategy: 'typeAndValue',
     target: { type: REQUEST_TYPE_NAME },
   },
+  {
+    src: { field: 'jiraField', parentTypes: ['Question'] },
+    serializationStrategy: 'id',
+    jiraMissingRefStrategy: 'typeAndValue',
+    target: { type: 'Field' },
+  },
 ]
 
 const lookupNameFuncs: GetLookupNameFunc[] = [

--- a/packages/jira-adapter/test/adapter.test.ts
+++ b/packages/jira-adapter/test/adapter.test.ts
@@ -15,7 +15,7 @@
 */
 import { AdapterOperations, ObjectType, ElemID, ProgressReporter, FetchResult, InstanceElement, toChange, isRemovalChange, getChangeData, BuiltinTypes, ReferenceExpression, ElemIdGetter, ServiceIds } from '@salto-io/adapter-api'
 import { deployment, elements, client as clientUtils } from '@salto-io/adapter-components'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { buildElementsSourceFromElements, safeJsonStringify } from '@salto-io/adapter-utils'
 import MockAdapter from 'axios-mock-adapter'
 import axios from 'axios'
 import { mockFunction } from '@salto-io/test-utils'
@@ -25,6 +25,7 @@ import { getDefaultConfig } from '../src/config/config'
 import { ISSUE_TYPE_NAME, JIRA, PROJECT_TYPE, SERVICE_DESK } from '../src/constants'
 import { createCredentialsInstance, createConfigInstance, mockClient, createEmptyType } from './utils'
 import { jiraJSMEntriesFunc } from '../src/jsm_utils'
+import { CLOUD_RESOURCE_FIELD } from '../src/filters/automation/cloud_id'
 
 const { getAllElements, getEntriesResponseValues } = elements.ducktype
 const { generateTypes, getAllInstances, loadSwagger } = elements.swagger
@@ -435,6 +436,14 @@ describe('adapter', () => {
         mockAxiosAdapter = new MockAdapter(axios)
         // mock as there are gets of license during fetch
         mockAxiosAdapter.onGet().reply(200, { })
+        // mock as we call getCloudId in the forms filter.
+        mockAxiosAdapter.onPost().reply(200, {
+          unparsedData: {
+            [CLOUD_RESOURCE_FIELD]: safeJsonStringify({
+              tenantId: 'cloudId',
+            }),
+          },
+        })
         result = await srAdapter.fetch({ progressReporter })
       })
       afterEach(() => {

--- a/packages/jira-adapter/test/filters/forms/forms.test.ts
+++ b/packages/jira-adapter/test/filters/forms/forms.test.ts
@@ -147,9 +147,9 @@ describe('forms filter', () => {
                 ],
               },
             ],
-            conditions: {},
-            sections: {},
-            questions: {},
+            conditions: [],
+            sections: [],
+            questions: [],
           },
         })
       })

--- a/packages/jira-adapter/test/filters/forms/forms.test.ts
+++ b/packages/jira-adapter/test/filters/forms/forms.test.ts
@@ -39,6 +39,7 @@ describe('forms filter', () => {
       beforeEach(async () => {
         const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
         config.fetch.enableJSM = true
+        config.fetch.enableJsmExperimental = true
         const { client: cli, connection: conn } = mockClient(true)
         connection = conn
         client = cli
@@ -157,6 +158,15 @@ describe('forms filter', () => {
       it('should not add forms to elements when enableJSM is false', async () => {
         const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
         config.fetch.enableJSM = false
+        filter = formsFilter(getFilterParams({ config, client })) as typeof filter
+        await filter.onFetch(elements)
+        const instances = elements.filter(isInstanceElement)
+        const formInstance = instances.find(e => e.elemID.typeName === FORM_TYPE)
+        expect(formInstance).toBeUndefined()
+      })
+      it('should not add forms to elements when enableJsmExperimental is false', async () => {
+        const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+        config.fetch.enableJsmExperimental = false
         filter = formsFilter(getFilterParams({ config, client })) as typeof filter
         await filter.onFetch(elements)
         const instances = elements.filter(isInstanceElement)

--- a/packages/jira-adapter/test/filters/forms/forms.test.ts
+++ b/packages/jira-adapter/test/filters/forms/forms.test.ts
@@ -86,6 +86,7 @@ describe('forms filter', () => {
                   lock: false,
                   pdf: false,
                 },
+                templateFormUuid: 'templateFormUuid',
               },
               layout: [
                 {
@@ -118,7 +119,6 @@ describe('forms filter', () => {
         const formInstance = instances.find(e => e.elemID.typeName === FORM_TYPE)
         expect(formInstance).toBeDefined()
         expect(formInstance?.value).toEqual({
-          id: 1,
           uuid: 'uuid',
           updated: '2023-09-28T08:20:31.552322Z',
           design: {
@@ -129,6 +129,7 @@ describe('forms filter', () => {
                 lock: false,
                 pdf: false,
               },
+              templateFormUuid: 'templateFormUuid',
             },
             layout: [
               {
@@ -147,9 +148,9 @@ describe('forms filter', () => {
                 ],
               },
             ],
-            conditions: [],
-            sections: [],
-            questions: [],
+            conditions: {},
+            sections: {},
+            questions: {},
           },
         })
       })

--- a/packages/jira-adapter/test/filters/forms/forms.test.ts
+++ b/packages/jira-adapter/test/filters/forms/forms.test.ts
@@ -1,0 +1,166 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { filterUtils, elements as adapterElements, client as clientUtils } from '@salto-io/adapter-components'
+import _ from 'lodash'
+import { InstanceElement, Element, isInstanceElement } from '@salto-io/adapter-api'
+import { MockInterface } from '@salto-io/test-utils'
+import { safeJsonStringify } from '@salto-io/adapter-utils'
+import { getDefaultConfig } from '../../../src/config/config'
+import formsFilter from '../../../src/filters/forms/forms'
+import { createEmptyType, getFilterParams, mockClient } from '../../utils'
+import { FORM_TYPE, JIRA, PROJECT_TYPE } from '../../../src/constants'
+import JiraClient from '../../../src/client/client'
+import { CLOUD_RESOURCE_FIELD } from '../../../src/filters/automation/cloud_id'
+
+
+describe('forms filter', () => {
+    type FilterType = filterUtils.FilterWith<'onFetch'>
+    let filter: FilterType
+    let connection: MockInterface<clientUtils.APIConnection>
+    let client: JiraClient
+    const projectType = createEmptyType(PROJECT_TYPE)
+    let projectInstance: InstanceElement
+    let elements: Element[]
+    describe('on fetch', () => {
+      beforeEach(async () => {
+        const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+        config.fetch.enableJSM = true
+        const { client: cli, connection: conn } = mockClient(true)
+        connection = conn
+        client = cli
+        filter = formsFilter(getFilterParams({ config, client })) as typeof filter
+        projectInstance = new InstanceElement(
+          'project1',
+          projectType,
+          {
+            id: 11111,
+            name: 'project1',
+            projectTypeKey: 'service_desk',
+            key: 'project1Key',
+          },
+          [JIRA, adapterElements.RECORDS_PATH, PROJECT_TYPE, 'project1']
+        )
+        connection.post.mockResolvedValueOnce({
+          status: 200,
+          data: {
+            unparsedData: {
+              [CLOUD_RESOURCE_FIELD]: safeJsonStringify({
+                tenantId: 'cloudId',
+              }),
+            },
+          },
+        })
+
+        connection.get.mockResolvedValueOnce({
+          status: 200,
+          data: [{
+            id: 1,
+            name: 'form1',
+          }],
+        })
+
+        connection.get.mockResolvedValueOnce({
+          status: 200,
+          data: {
+            updated: '2023-09-28T08:20:31.552322Z',
+            uuid: 'uuid',
+            design: {
+              settings: {
+                templateId: 6,
+                name: 'form6',
+                submit: {
+                  lock: false,
+                  pdf: false,
+                },
+              },
+              layout: [
+                {
+                  version: 1,
+                  type: 'doc',
+                  content: [
+                    {
+                      type: 'paragraph',
+                      content: [
+                        {
+                          type: 'text',
+                          text: 'form 6 content',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+              conditions: {},
+              sections: {},
+              questions: {},
+            },
+          },
+        })
+        elements = [projectInstance, projectType]
+      })
+      it('should add forms to elements when enableJSM is true', async () => {
+        await filter.onFetch(elements)
+        const instances = elements.filter(isInstanceElement)
+        const formInstance = instances.find(e => e.elemID.typeName === FORM_TYPE)
+        expect(formInstance).toBeDefined()
+        expect(formInstance?.value).toEqual({
+          id: 1,
+          uuid: 'uuid',
+          updated: '2023-09-28T08:20:31.552322Z',
+          design: {
+            settings: {
+              templateId: 6,
+              name: 'form6',
+              submit: {
+                lock: false,
+                pdf: false,
+              },
+            },
+            layout: [
+              {
+                version: 1,
+                type: 'doc',
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [
+                      {
+                        type: 'text',
+                        text: 'form 6 content',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            conditions: {},
+            sections: {},
+            questions: {},
+          },
+        })
+      })
+      it('should not add forms to elements when enableJSM is false', async () => {
+        const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+        config.fetch.enableJSM = false
+        filter = formsFilter(getFilterParams({ config, client })) as typeof filter
+        await filter.onFetch(elements)
+        const instances = elements.filter(isInstanceElement)
+        const formInstance = instances.find(e => e.elemID.typeName === FORM_TYPE)
+        expect(formInstance).toBeUndefined()
+      })
+    })
+})


### PR DESCRIPTION
In this PR I started to support fetch of forms. 
I also added support for deploy to check that the fetch and deploy is multienv friendly. 


---

Please Review from [initial forms fetch support](https://github.com/salto-io/salto/commit/81a7768780bb2beaea8ead9f3a99ff950c17b558) and any sub commit. 

---
_Release Notes_: 
_Jira adapter_:
Now supporting fetch  and deploy operations for Form.

---
_User Notifications_: 
_JIra Adapter_:
You can now fetch and deploy Forms in JSM.
