### PR TITLE
SALTO-4825:  Filter out settings types when getting MetadataTypes from elementsSource in Quick Fetch

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -323,9 +323,12 @@ const getMetadataTypesFromElementsSource = async (
 ): Promise<MetadataObjectType[]> => (
   awu(await elementsSource.getAll())
     .filter(isMetadataObjectType)
+    // standard and custom objects
     .filter(metadataType => !isCustomObjectSync(metadataType))
-    // Custom types shouldn't be caught here (CustomMetadata / CustomObject / CustomSettings)
+    // custom types (CustomMetadata / CustomObject (non standard) / CustomSettings)
     .filter(metadataType => !isCustomType(metadataType))
+    // settings types
+    .filter(metadataType => !metadataType.isSettings)
     .toArray()
 )
 


### PR DESCRIPTION
When getting existing metadata types from the **ElementsSource** in quick fetch, filtering out Settings types. 

---

Added missing UT and improved the documentation of the method.

---

_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
