### PR TITLE
SALTO-4752: script runner survey

### DIFF
--- a/packages/adapter-components/src/config/index.ts
+++ b/packages/adapter-components/src/config/index.ts
@@ -15,7 +15,7 @@
 */
 export { createDucktypeAdapterApiConfigType, AdapterDuckTypeApiConfig, DuckTypeTransformationConfig, DuckTypeTransformationDefaultConfig, TypeDuckTypeConfig, TypeDuckTypeDefaultsConfig, validateApiDefinitionConfig as validateDuckTypeApiDefinitionConfig, validateFetchConfig as validateDuckTypeFetchConfig } from './ducktype'
 export { createRequestConfigs, validateRequestConfig, FetchRequestConfig, DeployRequestConfig, UrlParams, DeploymentRequestsByAction, RecurseIntoCondition, RecurseIntoConfig, isRecurseIntoConditionByField } from './request'
-export { createAdapterApiConfigType, getConfigWithDefault, AdapterApiConfig, TypeConfig, TypeDefaultsConfig, validateSupportedTypes, defaultMissingUserFallbackField, AdapterFetchError as FetchError } from './shared'
+export { createAdapterApiConfigType, getConfigWithDefault, AdapterApiConfig, TypeConfig, TypeDefaultsConfig, validateSupportedTypes, defaultMissingUserFallbackField, AdapterFetchError } from './shared'
 export { mergeWithDefaultConfig } from './merge'
 export { createTypeNameOverrideConfigType, createSwaggerAdapterApiConfigType, AdapterSwaggerApiConfig, RequestableAdapterSwaggerApiConfig, SwaggerDefinitionBaseConfig, TypeSwaggerConfig, RequestableTypeSwaggerConfig, TypeSwaggerDefaultConfig, TypeNameOverrideConfig, validateApiDefinitionConfig as validateSwaggerApiDefinitionConfig, validateFetchConfig as validateSwaggerFetchConfig } from './swagger'
 export { createTransformationConfigTypes, validateTransoformationConfig, TransformationDefaultConfig, TransformationConfig, StandaloneFieldConfigType, FieldToOmitType, FieldToHideType, getTransformationConfigByType, dereferenceFieldName, isReferencedIdField, getTypeTransformationConfig, shouldNestFiles } from './transformation'

--- a/packages/jira-adapter/src/client/script_runner_client.ts
+++ b/packages/jira-adapter/src/client/script_runner_client.ts
@@ -17,7 +17,7 @@ import { client as clientUtils, definitions } from '@salto-io/adapter-components
 import { logger } from '@salto-io/logging'
 import { handleDeploymentErrors } from '../deployment/deployment_error_handling'
 import { JIRA } from '../constants'
-import { ScriptRunnerLoginError, createScriptRunnerConnection } from './script_runner_connection'
+import { createScriptRunnerConnection } from './script_runner_connection'
 import JiraClient from './client'
 import { ScriptRunnerCredentials } from '../auth'
 
@@ -73,13 +73,6 @@ export default class ScriptRunnerClient extends clientUtils.AdapterHTTPClient<
         },
       })
     } catch (e) {
-      if (e instanceof ScriptRunnerLoginError) {
-        log.error('Suppressing script runner login error %o', e)
-        return {
-          data: [],
-          status: 401,
-        }
-      }
       // The http_client code catches the original error and transforms it such that it removes
       // the parsed information (like the status code), so we have to parse the string here in order
       // to realize what type of error was thrown

--- a/packages/jira-adapter/src/client/script_runner_connection.ts
+++ b/packages/jira-adapter/src/client/script_runner_connection.ts
@@ -17,15 +17,15 @@ import Joi from 'joi'
 import axios from 'axios'
 import { createSchemeGuard } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
-import { client as clientUtils } from '@salto-io/adapter-components'
-import { parse } from 'node-html-parser'
+import { client as clientUtils, config } from '@salto-io/adapter-components'
+import { HTMLElement, parse } from 'node-html-parser'
 import JiraClient from './client'
 import { ScriptRunnerCredentials } from '../auth'
 
 const log = logger(module)
+const { AdapterFetchError } = config
 
-export class ScriptRunnerLoginError extends Error {
-}
+const SURVEY_TITLE = 'Post Install Complete'
 
 type TokenAddressResponse = {
   url: string
@@ -35,7 +35,7 @@ const TOKEN_ADDRESS_RESPONSE_SCHEME = Joi.object({
   url: Joi.string().required(),
 }).unknown(true)
 
-const isTokenAddressResponse = createSchemeGuard<TokenAddressResponse>(TOKEN_ADDRESS_RESPONSE_SCHEME, 'Failed to get script runner token from jira service')
+const isTokenAddressResponse = createSchemeGuard<TokenAddressResponse>(TOKEN_ADDRESS_RESPONSE_SCHEME, 'Failed to get scriptRunner token from jira service')
 
 type TokenResponse = {
   data: string
@@ -45,22 +45,31 @@ const TOKEN_RESPONSE_SCHEME = Joi.object({
   data: Joi.string().required(),
 }).unknown(true)
 
-const isTokenResponse = createSchemeGuard<TokenResponse>(TOKEN_RESPONSE_SCHEME, 'Failed to get script runner token from scriptRunner service')
+const isTokenResponse = createSchemeGuard<TokenResponse>(TOKEN_RESPONSE_SCHEME, 'Failed to get scriptRunner token from scriptRunner service')
+
+const isSurveyScreen = (root: HTMLElement): boolean =>
+  root.querySelector('title')?.text === SURVEY_TITLE
+
+const getSurveyUrl = (baseUrl: string): string =>
+  `${baseUrl}plugins/servlet/ac/com.onresolve.jira.groovy.groovyrunner/post-install-nav-link`
+
+const getLoginError = (): Error =>
+  new AdapterFetchError('Failed to get ScriptRunner token, the response from the jira service was not as expected. Please try again later. Our support team was notified about this, and we will investigate it as well.', 'Error')
 
 const getUrlFromService = async (jiraClient: JiraClient): Promise<string> => {
   const jiraResponse = await jiraClient.get({
     url: '/plugins/servlet/ac/com.onresolve.jira.groovy.groovyrunner/scriptrunner-home?classifier=json&s=com.onresolve.jira.groovy.groovyrunner__scriptrunner-home',
   })
   if (!isTokenAddressResponse(jiraResponse.data)) {
-    log.error('Failed to get script runner token, the response from the jira service was not as expected')
-    throw new ScriptRunnerLoginError('Failed to get script runner token, the response from the jira service was not as expected')
+    log.error('Failed to get scriptRunner token, the response from the jira service was not as expected')
+    throw getLoginError()
   }
   try {
     // eslint-disable-next-line no-new
     new URL(jiraResponse.data.url)
   } catch (e) {
-    log.error('Failed to parse script runner token, the response from the jira service was not a valid url', jiraResponse.data.url)
-    throw new ScriptRunnerLoginError('Failed to parse script runner token, the response from the jira service was not a valid url')
+    log.error('Failed to parse scriptRunner token, the response from the jira service was not a valid url', jiraResponse.data.url)
+    throw getLoginError()
   }
   return jiraResponse.data.url
 }
@@ -69,27 +78,30 @@ const getBaseUrl = async (getUrl: Promise<string>): Promise<string> =>
   new URL(await getUrl).origin
 
 
-const getSrTokenFromHtml = (html: string): string => {
+const getSrTokenFromHtml = (html: string, surveyUrl: string): string => {
   const root = parse(html)
 
   // Find the meta tag with name="sr-token"
   const srTokenElement = root.querySelector('meta[name="sr-token"]')
   if (srTokenElement === null) {
-    log.error('Failed to get script runner token from scriptRunner service, could not find meta tag with name="sr-token"', html)
-    throw new ScriptRunnerLoginError('Failed to get script runner token from scriptRunner service, could not find meta tag with name="sr-token"')
+    log.error('Failed to get scriptRunner token from scriptRunner service, could not find meta tag with name="sr-token"', html)
+
+    throw isSurveyScreen(root)
+      ? new AdapterFetchError(`Fetch failed as ScriptRunner was not fully installed in the Jira Instance. To continue, please open the ScriptRunner app at ${surveyUrl}, fill and send the survey, and try again.`, 'Error')
+      : getLoginError()
   }
 
   // Extract the content attribute value
   const srToken = srTokenElement.getAttribute('content')
 
   if (srToken === undefined) {
-    log.error('Failed to get script runner token from scriptRunner service, could not find content attribute"', html)
-    throw new ScriptRunnerLoginError('Failed to get script runner token from scriptRunner service, could not find content attribute')
+    log.error('Failed to get scriptRunner token from scriptRunner service, could not find content attribute"', html)
+    throw getLoginError()
   }
   return srToken
 }
 
-const getJwtFromService = async (getUrl: Promise<string>): Promise<string> => {
+const getJwtFromService = async (getUrl: Promise<string>, jiraUrl: string): Promise<string> => {
   const url = await getUrl
   const baseURL = await getBaseUrl(getUrl)
   const httpClient = axios.create({
@@ -98,13 +110,16 @@ const getJwtFromService = async (getUrl: Promise<string>): Promise<string> => {
   try {
     const srResponse = await httpClient.get(url.replace(baseURL, ''),)
     if (!isTokenResponse(srResponse)) {
-      log.error('Failed to get script runner token from scriptRunner service', srResponse)
-      throw new ScriptRunnerLoginError('Failed to get script runner token from scriptRunner service')
+      log.error('Failed to get scriptRunner token from scriptRunner service', srResponse)
+      throw getLoginError()
     }
-    return getSrTokenFromHtml(srResponse.data)
+    return getSrTokenFromHtml(srResponse.data, getSurveyUrl(jiraUrl))
   } catch (e) {
-    log.error('Failed to get script runner token from scriptRunner service', e)
-    throw new ScriptRunnerLoginError('Failed to get script runner token from scriptRunner service')
+    if (e instanceof AdapterFetchError) {
+      throw e
+    }
+    log.error('Failed to get scriptRunner token from scriptRunner service', e)
+    throw getLoginError()
   }
 }
 
@@ -128,7 +143,7 @@ export const createScriptRunnerConnection = (
       retryOptions,
       authParamsFunc: async _credentials => ({
         headers: {
-          Authorization: `JWT ${await getJwtFromService(getUrl())}`,
+          Authorization: `JWT ${await getJwtFromService(getUrl(), jiraClient.baseUrl)}`,
         },
       }),
       baseURLFunc: async _credentials => getBaseUrl(getUrl()),

--- a/packages/jira-adapter/test/client/script_runner_client.test.ts
+++ b/packages/jira-adapter/test/client/script_runner_client.test.ts
@@ -17,20 +17,27 @@ import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
 import { logger } from '@salto-io/logging'
 import * as clientUtils from '@salto-io/adapter-components'
+import { config } from '@salto-io/adapter-components'
 import JiraClient from '../../src/client/client'
 
 import ScriptRunnerClient from '../../src/client/script_runner_client'
+
+const { AdapterFetchError } = config
 
 const SCRIPT_RUNNER_VALID_URL = 'https://my.scriptrunner.net/myUrlPath'
 
 const VALID_HTML = '<!DOCTYPE html><html><head><meta name="sr-token" content="validSR"></head></html>'
 const NO_CONTENT_HTML = '<!DOCTYPE html><html><head><meta name="sr-token"></head></html>'
 const NO_SR_HTML = '<!DOCTYPE html><html><head></head></html>'
+const SURVEY_HTML = '<!DOCTYPE html><html><head><title>Post Install Complete</title></head></html>'
 
 const JWT_ACCESS_URL = '/plugins/servlet/ac/com.onresolve.jira.groovy.groovyrunner/scriptrunner-home?classifier=json&s=com.onresolve.jira.groovy.groovyrunner__scriptrunner-home'
 
 const logging = logger('jira-adapter/src/client/script_runner_connection')
 const logErrorSpy = jest.spyOn(logging, 'error')
+
+const getLoginError = (): Error =>
+  new AdapterFetchError('Failed to get ScriptRunner token, the response from the jira service was not as expected. Please try again later. Our support team was notified about this, and we will investigate it as well.', 'Error')
 
 describe('scriptRunnerClient', () => {
   let jiraClient: JiraClient
@@ -38,7 +45,7 @@ describe('scriptRunnerClient', () => {
   let mockAxios: MockAdapter
   beforeEach(() => {
     mockAxios = new MockAdapter(axios)
-    jiraClient = new JiraClient({ credentials: { baseUrl: 'http://myjira.net', user: 'me', token: 'tok' }, isDataCenter: false })
+    jiraClient = new JiraClient({ credentials: { baseUrl: 'http://myjira.net/', user: 'me', token: 'tok' }, isDataCenter: false })
     scriptRunnerClient = new ScriptRunnerClient(
       { credentials: {},
         jiraClient,
@@ -64,15 +71,13 @@ describe('scriptRunnerClient', () => {
       })
       it('should fail when JWT address object is not in the right format', async () => {
         mockAxios.onGet(JWT_ACCESS_URL).reply(200, { xurl: SCRIPT_RUNNER_VALID_URL })
-        const result = await scriptRunnerClient.get({ url: '/myPath' })
-        expect(result).toEqual({ status: 401, data: [] })
-        expect(logErrorSpy).toHaveBeenCalledWith('Failed to get script runner token, the response from the jira service was not as expected')
+        await expect(async () => scriptRunnerClient.get({ url: '/myPath' })).rejects.toThrow(getLoginError())
+        expect(logErrorSpy).toHaveBeenCalledWith('Failed to get scriptRunner token, the response from the jira service was not as expected')
       })
       it('should fail when JWT address object is not a valid url', async () => {
         mockAxios.onGet(JWT_ACCESS_URL).reply(200, { url: 'http' })
-        const result = await scriptRunnerClient.get({ url: '/myPath' })
-        expect(result).toEqual({ status: 401, data: [] })
-        expect(logErrorSpy).toHaveBeenCalledWith('Failed to parse script runner token, the response from the jira service was not a valid url', 'http')
+        await expect(async () => scriptRunnerClient.get({ url: '/myPath' })).rejects.toThrow(getLoginError())
+        expect(logErrorSpy).toHaveBeenCalledWith('Failed to parse scriptRunner token, the response from the jira service was not a valid url', 'http')
       })
       it('should not call the address endpoint again', async () => {
         mockAxios.onGet(JWT_ACCESS_URL).reply(200, { url: SCRIPT_RUNNER_VALID_URL })
@@ -90,27 +95,35 @@ describe('scriptRunnerClient', () => {
       })
       it('should fail when cannot access JWT address', async () => {
         mockAxios.onGet(SCRIPT_RUNNER_VALID_URL).reply(400, { response: 'asd', errorMessages: ['error message'] })
-        expect(await scriptRunnerClient.get({ url: '/myPath' })).toEqual({ status: 401, data: [] })
-        expect(logErrorSpy).toHaveBeenCalledWith('Failed to get script runner token from scriptRunner service', new Error('Request failed with status code 400'))
+        await expect(async () => scriptRunnerClient.get({ url: '/myPath' })).rejects.toThrow(getLoginError())
+        expect(logErrorSpy).toHaveBeenCalledWith('Failed to get scriptRunner token from scriptRunner service', new Error('Request failed with status code 400'))
       })
       it('should fail when sr not in correct format', async () => {
         mockAxios.onGet(SCRIPT_RUNNER_VALID_URL).replyOnce(200, { response: 'asd' })
-        expect(await scriptRunnerClient.get({ url: '/myPath' })).toEqual({ status: 401, data: [] })
+        await expect(async () => scriptRunnerClient.get({ url: '/myPath' })).rejects.toThrow(getLoginError())
       })
       it('should fail when not html response', async () => {
         mockAxios.onGet(SCRIPT_RUNNER_VALID_URL).replyOnce(200, 'not another html answer')
-        expect(await scriptRunnerClient.get({ url: '/myPath' })).toEqual({ status: 401, data: [] })
-        expect(logErrorSpy).toHaveBeenCalledWith('Failed to get script runner token from scriptRunner service, could not find meta tag with name="sr-token"', 'not another html answer')
+        await expect(async () => scriptRunnerClient.get({ url: '/myPath' })).rejects.toThrow(getLoginError())
+        expect(logErrorSpy).toHaveBeenCalledWith('Failed to get scriptRunner token from scriptRunner service, could not find meta tag with name="sr-token"', 'not another html answer')
       })
       it('should fail when not SR token', async () => {
         mockAxios.onGet(SCRIPT_RUNNER_VALID_URL).replyOnce(200, NO_SR_HTML)
-        expect(await scriptRunnerClient.get({ url: '/myPath' })).toEqual({ status: 401, data: [] })
-        expect(logErrorSpy).toHaveBeenCalledWith('Failed to get script runner token from scriptRunner service, could not find meta tag with name="sr-token"', '<!DOCTYPE html><html><head></head></html>')
+        await expect(async () => scriptRunnerClient.get({ url: '/myPath' })).rejects.toThrow(getLoginError())
+        expect(logErrorSpy).toHaveBeenCalledWith('Failed to get scriptRunner token from scriptRunner service, could not find meta tag with name="sr-token"', '<!DOCTYPE html><html><head></head></html>')
+      })
+      it('should fail with correct info when a survey screen is active', async () => {
+        mockAxios.onGet(SCRIPT_RUNNER_VALID_URL).replyOnce(200, SURVEY_HTML)
+        await expect(async () => scriptRunnerClient.get({ url: '/myPath' })).rejects.toThrow(
+          new AdapterFetchError('Fetch failed as ScriptRunner was not fully installed in the Jira Instance. To continue, please open the ScriptRunner app at '
+            + 'http://myjira.net/plugins/servlet/ac/com.onresolve.jira.groovy.groovyrunner/post-install-nav-link, fill and send the survey, and try again.', 'Error')
+        )
+        expect(logErrorSpy).toHaveBeenCalledWith('Failed to get scriptRunner token from scriptRunner service, could not find meta tag with name="sr-token"', SURVEY_HTML)
       })
       it('should fail when sr element does not have context', async () => {
         mockAxios.onGet(SCRIPT_RUNNER_VALID_URL).replyOnce(200, NO_CONTENT_HTML)
-        expect(await scriptRunnerClient.get({ url: '/myPath' })).toEqual({ status: 401, data: [] })
-        expect(logErrorSpy).toHaveBeenCalledWith('Failed to get script runner token from scriptRunner service, could not find content attribute"', '<!DOCTYPE html><html><head><meta name="sr-token"></head></html>')
+        await expect(async () => scriptRunnerClient.get({ url: '/myPath' })).rejects.toThrow(getLoginError())
+        expect(logErrorSpy).toHaveBeenCalledWith('Failed to get scriptRunner token from scriptRunner service, could not find content attribute"', '<!DOCTYPE html><html><head><meta name="sr-token"></head></html>')
       })
       it('should call send request decorator for page', async () => {
         mockAxios.onGet(SCRIPT_RUNNER_VALID_URL).replyOnce(200, VALID_HTML)
@@ -144,7 +157,7 @@ describe('scriptRunnerClient', () => {
     it('should request the correct path with auth headers', () => {
       expect(mockAxios.history.get).toHaveLength(6)
       const jiraAddress = mockAxios.history.get.find(r => r.url === JWT_ACCESS_URL)
-      expect(jiraAddress?.baseURL).toEqual('http://myjira.net')
+      expect(jiraAddress?.baseURL).toEqual('http://myjira.net/')
       expect(jiraAddress?.url).toEqual(JWT_ACCESS_URL)
       const srRequest = mockAxios.history.get.find(r => r.url === '/myUrlPath')
       expect(srRequest?.auth).toBeUndefined()


### PR DESCRIPTION
Change the login failures in ScriptRunner to cause fetch errors.
Also add a special message when the cause of failure is the survey screen
(And changed an error I made in the previous PR that exported the AdapterFetchError under the wrong name)

---

It was tested against a real-life scenario

---
_Release Notes_: 
Jira Adapter:
* In case a fetch that includes ScriptRunner fails the fetch will end with a fetch error. Also, in case the reason is the ScriptRunner's Survey, the user will be provided with the relevant instructions

---
_User Notifications_: 
None
