### PR TITLE
SALTO-2349: Add enableJSM to user fetch config

### DIFF
--- a/packages/jira-adapter/src/config_creator.ts
+++ b/packages/jira-adapter/src/config_creator.ts
@@ -48,11 +48,13 @@ export const getConfig = async (
   options?: InstanceElement
 ): Promise<InstanceElement> => {
   const defaultConf = await createDefaultInstanceFromType(ElemID.CONFIG_NAME, configType)
-  if (options !== undefined && isOptionsTypeInstance(options) && options.value.enableScriptRunnerAddon) {
-    defaultConf.value.fetch.enableScriptRunnerAddon = true
-  }
-  if (options !== undefined && isOptionsTypeInstance(options) && options.value.enableJSM) {
-    defaultConf.value.fetch.enableJSM = true
+  if (options !== undefined && isOptionsTypeInstance(options)) {
+    if (options.value.enableScriptRunnerAddon) {
+      defaultConf.value.fetch.enableScriptRunnerAddon = true
+    }
+    if (options.value.enableJSM) {
+      defaultConf.value.fetch.enableJSM = true
+    }
   }
   return defaultConf
 }

--- a/packages/jira-adapter/src/config_creator.ts
+++ b/packages/jira-adapter/src/config_creator.ts
@@ -26,11 +26,13 @@ const optionsElemId = new ElemID(constants.JIRA, 'configOptionsType')
 
 type ConfigOptionsType = {
   enableScriptRunnerAddon?: boolean
+  enableJSM?: boolean
 }
 export const optionsType = createMatchingObjectType<ConfigOptionsType>({
   elemID: optionsElemId,
   fields: {
     enableScriptRunnerAddon: { refType: BuiltinTypes.BOOLEAN },
+    enableJSM: { refType: BuiltinTypes.BOOLEAN },
   },
 })
 const isOptionsTypeInstance = (instance: InstanceElement):
@@ -48,6 +50,9 @@ export const getConfig = async (
   const defaultConf = await createDefaultInstanceFromType(ElemID.CONFIG_NAME, configType)
   if (options !== undefined && isOptionsTypeInstance(options) && options.value.enableScriptRunnerAddon) {
     defaultConf.value.fetch.enableScriptRunnerAddon = true
+  }
+  if (options !== undefined && isOptionsTypeInstance(options) && options.value.enableJSM) {
+    defaultConf.value.fetch.enableJSM = true
   }
   return defaultConf
 }

--- a/packages/jira-adapter/test/config_creator.test.ts
+++ b/packages/jira-adapter/test/config_creator.test.ts
@@ -25,7 +25,10 @@ describe('config creator', () => {
     options = new InstanceElement(
       'instance',
       optionsType,
-      { enableScriptRunnerAddon: true }
+      {
+        enableScriptRunnerAddon: true,
+        enableJSM: true,
+      }
     )
   })
   it('should return config creator', async () => {
@@ -41,6 +44,7 @@ describe('config creator', () => {
   })
   it('get config should return default config when false', async () => {
     options.value.enableScriptRunnerAddon = false
+    options.value.enableJSM = false
     const config = await getConfig(options)
     expect(config).toEqual(await createDefaultInstanceFromType(ElemID.CONFIG_NAME, configType))
   })
@@ -48,7 +52,10 @@ describe('config creator', () => {
     options = new InstanceElement(
       'instance',
       createEmptyType('empty'),
-      { enableScriptRunnerAddon: true }
+      {
+        enableScriptRunnerAddon: true,
+        enableJSM: true,
+      }
     )
     const config = await getConfig(options)
     expect(config).toEqual(await createDefaultInstanceFromType(ElemID.CONFIG_NAME, configType))
@@ -56,5 +63,6 @@ describe('config creator', () => {
   it('get config should return return correctly when true', async () => {
     const config = await getConfig(options)
     expect(config.value.fetch.enableScriptRunnerAddon).toBeTrue()
+    expect(config.value.fetch.enableJSM).toBeTrue()
   })
 })

--- a/packages/jira-adapter/test/config_creator.test.ts
+++ b/packages/jira-adapter/test/config_creator.test.ts
@@ -42,7 +42,7 @@ describe('config creator', () => {
     const config = await getConfig()
     expect(config).toEqual(await createDefaultInstanceFromType(ElemID.CONFIG_NAME, configType))
   })
-  it('get config should return default config when false', async () => {
+  it('get config should return default config when all options are false', async () => {
     options.value.enableScriptRunnerAddon = false
     options.value.enableJSM = false
     const config = await getConfig(options)
@@ -60,9 +60,13 @@ describe('config creator', () => {
     const config = await getConfig(options)
     expect(config).toEqual(await createDefaultInstanceFromType(ElemID.CONFIG_NAME, configType))
   })
-  it('get config should return return correctly when true', async () => {
+  it('get config should return correctly when enableScriptRunnerAddon is true', async () => {
     const config = await getConfig(options)
     expect(config.value.fetch.enableScriptRunnerAddon).toBeTrue()
+    expect(config.value.fetch.enableJSM).toBeTrue()
+  })
+  it('get config should return correctly when enableJSM is true', async () => {
+    const config = await getConfig(options)
     expect(config.value.fetch.enableJSM).toBeTrue()
   })
 })


### PR DESCRIPTION
In this PR I added the flag enableJSM to user Fetch config. 
---

None

---
_Release Notes_: 
None

---
_User Notifications_: 
None
