### PR TITLE
SAAS-2351 add instanceUrl as accountId to validateCredentials response for SF sandbox

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -166,6 +166,7 @@ export type AccountInfo = {
   accountId: string
   accountType?: string
   isProduction?: boolean
+  extraInformation?: Record<string, string>
 }
 
 export type ConfigCreator = {

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -500,6 +500,17 @@ export const validateCredentials = async (
       `Remaining limits: ${remainingDailyRequests}, needed: ${minApiRequestsRemaining}`
     )
   }
+  if (creds.isSandbox) {
+    if (connection?.instanceUrl === undefined) {
+      throw new Error('Salesforve sandboxes must have an instance url')
+    }
+    return {
+      accountId: connection.instanceUrl,
+      accountType,
+      isProduction,
+      extraInformation: { orgId },
+    }
+  }
   return {
     accountId: orgId,
     accountType,

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -489,6 +489,8 @@ export const getConnectionDetails = async (
   }
 }
 
+const ACCOUNT_ID_VERSION = '1'
+
 export const validateCredentials = async (
   creds: Credentials, minApiRequestsRemaining = 0, connection?: Connection,
 ): Promise<AccountInfo> => {
@@ -502,13 +504,13 @@ export const validateCredentials = async (
   }
   if (creds.isSandbox) {
     if (connection?.instanceUrl === undefined) {
-      throw new Error('Salesforve sandboxes must have an instance url')
+      throw new Error('Salesforce sandboxes must have an instance url')
     }
     return {
       accountId: connection.instanceUrl,
       accountType,
       isProduction,
-      extraInformation: { orgId },
+      extraInformation: { orgId, accountIdVersion: ACCOUNT_ID_VERSION },
     }
   }
   return {

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -489,8 +489,6 @@ export const getConnectionDetails = async (
   }
 }
 
-const ACCOUNT_ID_VERSION = '1'
-
 export const validateCredentials = async (
   creds: Credentials, minApiRequestsRemaining = 0, connection?: Connection,
 ): Promise<AccountInfo> => {
@@ -510,13 +508,14 @@ export const validateCredentials = async (
       accountId: connection.instanceUrl,
       accountType,
       isProduction,
-      extraInformation: { orgId, accountIdVersion: ACCOUNT_ID_VERSION },
+      extraInformation: { orgId },
     }
   }
   return {
     accountId: orgId,
     accountType,
     isProduction,
+    extraInformation: { orgId },
   }
 }
 export default class SalesforceClient {

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -504,7 +504,7 @@ export const validateCredentials = async (
   }
   if (creds.isSandbox) {
     if (connection?.instanceUrl === undefined) {
-      throw new Error('Salesforce sandboxes must have an instance url')
+      throw new Error('Expected Salesforce organization URL to exist in the connection')
     }
     return {
       accountId: connection.instanceUrl,

--- a/packages/salesforce-adapter/test/client.test.ts
+++ b/packages/salesforce-adapter/test/client.test.ts
@@ -560,9 +560,7 @@ describe('salesforce client', () => {
           })
           it('should throw an error when there is no instanceUrl', async () => {
             const mockConnection = mockClient().connection
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            mockConnection.instanceUrl = undefined
+            _.set(mockConnection, 'instanceUrl', undefined)
             await expect(validateCredentials(sandboxCredentials, 3, mockConnection))
               .rejects.toThrow('Expected Salesforce organization URL to exist in the connection')
           })

--- a/packages/salesforce-adapter/test/client.test.ts
+++ b/packages/salesforce-adapter/test/client.test.ts
@@ -69,6 +69,12 @@ describe('salesforce client', () => {
     isSandbox: false,
     apiToken: 'myToken',
   })
+  const sandboxCredentials = new UsernamePasswordCredentials({
+    username: 'myUser',
+    password: 'myPass',
+    isSandbox: true,
+    apiToken: 'myToken',
+  })
   const { connection } = mockClient()
   const client = new SalesforceClient({
     credentials: new UsernamePasswordCredentials({
@@ -532,10 +538,11 @@ describe('salesforce client', () => {
             mockOrganizationQueryResult({ orgType: PRODUCTION_ORGANIZATION_TYPE, isSandbox: true })
           })
           it('should return isProduction false and correct accountType', async () => {
-            expect(await validateCredentials(credentials, 3, connection)).toEqual({
-              accountId: '',
+            expect(await validateCredentials(sandboxCredentials, 3, connection)).toEqual({
+              accountId: 'https://url.com/',
               isProduction: false,
               accountType: PRODUCTION_ORGANIZATION_TYPE,
+              extraInformation: { orgId: '' },
             })
           })
         })
@@ -544,10 +551,11 @@ describe('salesforce client', () => {
             mockOrganizationQueryResult({ orgType: NON_PRODUCTION_ORGANIZATION_TYPE, isSandbox: true })
           })
           it('should return isProduction false and correct accountType', async () => {
-            expect(await validateCredentials(credentials, 3, connection)).toEqual({
-              accountId: '',
+            expect(await validateCredentials(sandboxCredentials, 3, connection)).toEqual({
+              accountId: 'https://url.com/',
               isProduction: false,
               accountType: NON_PRODUCTION_ORGANIZATION_TYPE,
+              extraInformation: { orgId: '' },
             })
           })
         })

--- a/packages/salesforce-adapter/test/client.test.ts
+++ b/packages/salesforce-adapter/test/client.test.ts
@@ -558,6 +558,14 @@ describe('salesforce client', () => {
               extraInformation: { orgId: '', accountIdVersion: '1' },
             })
           })
+          it('should throw an error when there is no instanceUrl', async () => {
+            const mockConnection = mockClient().connection
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            mockConnection.instanceUrl = undefined
+            await expect(validateCredentials(sandboxCredentials, 3, mockConnection))
+              .rejects.toThrow('Expected Salesforce organization URL to exist in the connection')
+          })
         })
       })
       describe('when organization is not a sandbox', () => {

--- a/packages/salesforce-adapter/test/client.test.ts
+++ b/packages/salesforce-adapter/test/client.test.ts
@@ -542,7 +542,7 @@ describe('salesforce client', () => {
               accountId: 'https://url.com/',
               isProduction: false,
               accountType: PRODUCTION_ORGANIZATION_TYPE,
-              extraInformation: { orgId: '' },
+              extraInformation: { orgId: '', accountIdVersion: '1' },
             })
           })
         })
@@ -555,7 +555,7 @@ describe('salesforce client', () => {
               accountId: 'https://url.com/',
               isProduction: false,
               accountType: NON_PRODUCTION_ORGANIZATION_TYPE,
-              extraInformation: { orgId: '' },
+              extraInformation: { orgId: '', accountIdVersion: '1' },
             })
           })
         })

--- a/packages/salesforce-adapter/test/client.test.ts
+++ b/packages/salesforce-adapter/test/client.test.ts
@@ -519,7 +519,12 @@ describe('salesforce client', () => {
       ).rejects.toThrow(ApiLimitsTooLowError)
     })
     it('should return empty string as accountId and no values for accountType and isProduction', async () => {
-      expect(await validateCredentials(credentials, 3, connection)).toEqual({ accountId: '' })
+      expect(await validateCredentials(credentials, 3, connection)).toEqual({
+        accountId: '',
+        isProduction: undefined,
+        accountType: undefined,
+        extraInformation: { orgId: '' },
+      })
     })
     describe('isProduction and accountType', () => {
       const PRODUCTION_ORGANIZATION_TYPE = 'Professional Edition'
@@ -542,7 +547,7 @@ describe('salesforce client', () => {
               accountId: 'https://url.com/',
               isProduction: false,
               accountType: PRODUCTION_ORGANIZATION_TYPE,
-              extraInformation: { orgId: '', accountIdVersion: '1' },
+              extraInformation: { orgId: '' },
             })
           })
         })
@@ -555,7 +560,7 @@ describe('salesforce client', () => {
               accountId: 'https://url.com/',
               isProduction: false,
               accountType: NON_PRODUCTION_ORGANIZATION_TYPE,
-              extraInformation: { orgId: '', accountIdVersion: '1' },
+              extraInformation: { orgId: '' },
             })
           })
           it('should throw an error when there is no instanceUrl', async () => {
@@ -576,6 +581,7 @@ describe('salesforce client', () => {
               accountId: '',
               isProduction: true,
               accountType: PRODUCTION_ORGANIZATION_TYPE,
+              extraInformation: { orgId: '' },
             })
           })
         })
@@ -588,6 +594,7 @@ describe('salesforce client', () => {
               accountId: '',
               isProduction: false,
               accountType: NON_PRODUCTION_ORGANIZATION_TYPE,
+              extraInformation: { orgId: '' },
             })
           })
         })


### PR DESCRIPTION
SAAS-2351 add instanceUrl as accountId to validateCredentials response for SF sandbox

---
_Release Notes_: 
Salesforce:
validateCredentials on Sandboxes will now return the organization url as a stable accountId and will include extraProperties with the Organization Id

---
_User Notifications_: 
None
