### PR TITLE
SALTO-4830: make getImportantValues return and array

### DIFF
--- a/packages/adapter-utils/src/important_values.ts
+++ b/packages/adapter-utils/src/important_values.ts
@@ -74,9 +74,9 @@ const extractImportantValuesFromElement = ({
   element: Element
   indexedOnly?: boolean
   highlightedOnly?: boolean
-}): Values => {
+}): Values[] => {
   if (_.isEmpty(importantValues)) {
-    return {}
+    return []
   }
   const relevantImportantValues = getRelevantImportantValues(importantValues, indexedOnly, highlightedOnly)
   const getFrom = isInstanceElement(element) ? element.value : element.annotations
@@ -109,7 +109,7 @@ export const getImportantValues = async ({
   elementSource?: ReadOnlyElementsSource
   indexedOnly?: boolean
   highlightedOnly?: boolean
-}): Promise<Values> => {
+}): Promise<Values[]> => {
   if (isObjectType(element)) {
     const importantValues = element.annotations[CORE_ANNOTATIONS.SELF_IMPORTANT_VALUES]
     return extractImportantValuesFromElement({ importantValues, element, indexedOnly, highlightedOnly })
@@ -119,5 +119,5 @@ export const getImportantValues = async ({
     const importantValues = typeObj?.annotations[CORE_ANNOTATIONS.IMPORTANT_VALUES]
     return extractImportantValuesFromElement({ importantValues, element, indexedOnly, highlightedOnly })
   }
-  return {}
+  return []
 }

--- a/packages/adapter-utils/test/important_values.test.ts
+++ b/packages/adapter-utils/test/important_values.test.ts
@@ -182,7 +182,7 @@ describe('getImportantValues', () => {
       element: inst,
       elementSource: elementSourceNoImportant,
     })
-    expect(res).toEqual({})
+    expect(res).toEqual([])
   })
   it('should return only indexed values', async () => {
     const res = await getImportantValues({


### PR DESCRIPTION
make getImportantValues return and array

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
