### PR TITLE
SALTO-4833: Initial deploy portal group

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -104,6 +104,7 @@ import filtersFilter from './filters/filter'
 import removeEmptyValuesFilter from './filters/remove_empty_values'
 import jqlReferencesFilter from './filters/jql/jql_references'
 import userFilter from './filters/user'
+import changePortalGroupFieldsFilter from './filters/change_portal_group_fields'
 import { JIRA, PROJECT_TYPE, SERVICE_DESK } from './constants'
 import { paginate, removeScopedObjects } from './client/pagination'
 import { dependencyChanger } from './dependency_changers'
@@ -173,6 +174,7 @@ export const DEFAULT_FILTERS = [
   storeUsersFilter,
   changeServiceDeskIdFieldProjectFilter,
   changeQueueFieldsFilter,
+  changePortalGroupFieldsFilter,
   automationLabelFetchFilter,
   automationLabelDeployFilter,
   automationFetchFilter,
@@ -509,6 +511,7 @@ export default class JiraAdapter implements AdapterOperations {
       const serviceDeskProjRecord: Record<string, string> = {
         projectKey: projectInstance.value.key,
         serviceDeskId: projectInstance.value.serviceDeskId.id,
+        projectId: projectInstance.value.id,
       }
       log.debug(`Fetching elements for brand ${projectInstance.elemID.name}`)
       return getAllElements({

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -150,6 +150,7 @@ import scriptRunnerInstancesDeploy from './filters/script_runner/script_runner_i
 import behaviorsMappingsFilter from './filters/script_runner/behaviors_mappings'
 import behaviorsFieldUuidFilter from './filters/script_runner/behaviors_field_uuid'
 import changeQueueFieldsFilter from './filters/change_queue_fields'
+import portalGroupsFilter from './filters/portal_groups'
 import ScriptRunnerClient from './client/script_runner_client'
 import { weakReferenceHandlers } from './weak_references'
 import { jiraJSMEntriesFunc } from './jsm_utils'
@@ -313,6 +314,7 @@ export const DEFAULT_FILTERS = [
   scriptedFragmentsDeployFilter,
   scriptRunnerInstancesDeploy,
   queueDeleteFilter,
+  portalGroupsFilter,
   deployJsmTypesFilter,
   // Must be done after JsmTypesFilter
   jsmPathFilter,

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1808,6 +1808,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
         { fieldName: '_expands' },
         { fieldName: 'serviceDeskId' },
         { fieldName: 'portalId' },
+        { fieldName: 'groupIds' },
       ],
       fieldsToHide: [
         { fieldName: 'id' },
@@ -1884,14 +1885,17 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
   },
   PortalGroup: {
     request: {
-      url: '/rest/servicedeskapi/servicedesk/{serviceDeskId}/requesttypegroup',
+      url: '/rest/servicedesk/{serviceDeskId}/servicedesk/{projectId}/request-types?isValidOnly=true',
     },
     transformation: {
       idFields: ['name', 'projectKey'],
-      sourceTypeName: 'PortalGroup__values',
-      dataField: 'values',
+      sourceTypeName: 'PortalGroup__groups',
+      dataField: 'groups',
       fieldsToHide: [
         { fieldName: 'id' },
+      ],
+      fieldTypeOverrides: [
+        { fieldName: 'ticketTypeIds', fieldType: 'List<RequestType>' },
       ],
     },
     deployRequests: {
@@ -1904,21 +1908,19 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
         },
       },
       modify: {
-        url: '/rest/servicedesk/{serviceDeskId}/servicedesk/{projectId}/portal-groups/{portalGroupId}',
+        url: '/rest/servicedesk/{serviceDeskId}/servicedesk/{projectId}/portal-groups/{id}',
         method: 'put',
         urlParamsToFields: {
           serviceDeskId: '_parent.0.serviceDeskId',
           projectId: '_parent.0.id',
-          portalGroupId: 'id',
         },
       },
       remove: {
-        url: '/rest/servicedesk/{serviceDeskId}/servicedesk/{projectId}/portal-groups/{portalGroupId}',
+        url: '/rest/servicedesk/{serviceDeskId}/servicedesk/{projectId}/portal-groups/{id}',
         method: 'delete',
         urlParamsToFields: {
           serviceDeskId: '_parent.0.serviceDeskId',
           projectId: '_parent.0.id',
-          portalGroupId: 'id',
         },
       },
     },

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1894,6 +1894,34 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
         { fieldName: 'id' },
       ],
     },
+    deployRequests: {
+      add: {
+        url: '/rest/servicedesk/{serviceDeskId}/servicedesk/{projectId}/portal-groups',
+        method: 'post',
+        urlParamsToFields: {
+          serviceDeskId: '_parent.0.serviceDeskId',
+          projectId: '_parent.0.id',
+        },
+      },
+      modify: {
+        url: '/rest/servicedesk/{serviceDeskId}/servicedesk/{projectId}/portal-groups/{portalGroupId}',
+        method: 'put',
+        urlParamsToFields: {
+          serviceDeskId: '_parent.0.serviceDeskId',
+          projectId: '_parent.0.id',
+          portalGroupId: 'id',
+        },
+      },
+      remove: {
+        url: '/rest/servicedesk/{serviceDeskId}/servicedesk/{projectId}/portal-groups/{portalGroupId}',
+        method: 'delete',
+        urlParamsToFields: {
+          serviceDeskId: '_parent.0.serviceDeskId',
+          projectId: '_parent.0.id',
+          portalGroupId: 'id',
+        },
+      },
+    },
   },
   Calendar: {
     request: {

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1885,7 +1885,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
   },
   PortalGroup: {
     request: {
-      url: '/rest/servicedesk/{serviceDeskId}/servicedesk/{projectId}/request-types?isValidOnly=true',
+      url: '/rest/servicedesk/1/servicedesk/{projectId}/request-types?isValidOnly=true',
     },
     transformation: {
       idFields: ['name', 'projectKey'],
@@ -1900,7 +1900,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
     },
     deployRequests: {
       add: {
-        url: '/rest/servicedesk/{serviceDeskId}/servicedesk/{projectId}/portal-groups',
+        url: '/rest/servicedesk/1/servicedesk/{projectId}/portal-groups',
         method: 'post',
         urlParamsToFields: {
           serviceDeskId: '_parent.0.serviceDeskId',
@@ -1908,7 +1908,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
         },
       },
       modify: {
-        url: '/rest/servicedesk/{serviceDeskId}/servicedesk/{projectId}/portal-groups/{id}',
+        url: '/rest/servicedesk/1/servicedesk/{projectId}/portal-groups/{id}',
         method: 'put',
         urlParamsToFields: {
           serviceDeskId: '_parent.0.serviceDeskId',
@@ -1916,7 +1916,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
         },
       },
       remove: {
-        url: '/rest/servicedesk/{serviceDeskId}/servicedesk/{projectId}/portal-groups/{id}',
+        url: '/rest/servicedesk/1/servicedesk/{projectId}/portal-groups/{id}',
         method: 'delete',
         urlParamsToFields: {
           serviceDeskId: '_parent.0.serviceDeskId',

--- a/packages/jira-adapter/src/filters/change_portal_group_fields.ts
+++ b/packages/jira-adapter/src/filters/change_portal_group_fields.ts
@@ -1,0 +1,37 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { isInstanceElement } from '@salto-io/adapter-api'
+import { FilterCreator } from '../filter'
+import { PORTAL_GROUP_TYPE } from '../constants'
+
+const filter: FilterCreator = ({ config }) => ({
+  name: 'changePortalGroupFieldsFilter',
+  onFetch: async elements => {
+    if (!config.fetch.enableJSM) {
+      return
+    }
+    elements
+      .filter(element => element.elemID.typeName === PORTAL_GROUP_TYPE)
+      .filter(isInstanceElement)
+      .forEach(instance => {
+        instance.value.ticketTypeIds = instance.value.ticketTypes
+        delete instance.value.ticketTypes
+      })
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/src/filters/jsm_types_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/jsm_types_deploy_filter.ts
@@ -18,12 +18,13 @@ import _ from 'lodash'
 import { getChangeData, isInstanceChange, Change, InstanceElement } from '@salto-io/adapter-api'
 import { defaultDeployChange, deployChanges } from '../deployment/standard_deployment'
 import { FilterCreator } from '../filter'
-import { CALENDAR_TYPE, CUSTOMER_PERMISSIONS_TYPE, QUEUE_TYPE } from '../constants'
+import { CALENDAR_TYPE, CUSTOMER_PERMISSIONS_TYPE, QUEUE_TYPE, PORTAL_GROUP_TYPE } from '../constants'
 
 const jsmSupportedTypes = [
   CUSTOMER_PERMISSIONS_TYPE,
   CALENDAR_TYPE,
   QUEUE_TYPE,
+  PORTAL_GROUP_TYPE,
 ]
 
 const filterCreator: FilterCreator = ({ config, client }) => ({

--- a/packages/jira-adapter/src/filters/portal_groups.ts
+++ b/packages/jira-adapter/src/filters/portal_groups.ts
@@ -1,0 +1,51 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { getChangeData, isInstanceChange } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { FilterCreator } from '../filter'
+import { PORTAL_GROUP_TYPE } from '../constants'
+
+const { awu } = collections.asynciterable
+
+const filter: FilterCreator = ({ config }) => ({
+  name: 'portalGroupsFilter',
+  preDeploy: async changes => {
+    if (!config.fetch.enableJSM) {
+      return
+    }
+    await awu(changes)
+      .filter(isInstanceChange)
+      .filter(change => getChangeData(change).elemID.typeName === PORTAL_GROUP_TYPE)
+      .forEach(change => {
+        const instance = getChangeData(change)
+        instance.value.ticketTypeIds = []
+      })
+  },
+  onDeploy: async changes => {
+    if (!config.fetch.enableJSM) {
+      return
+    }
+    await awu(changes)
+      .filter(isInstanceChange)
+      .filter(change => getChangeData(change).elemID.typeName === PORTAL_GROUP_TYPE)
+      .forEach(change => {
+        const instance = getChangeData(change)
+        delete instance.value.ticketTypeIds
+      })
+  },
+})
+export default filter

--- a/packages/jira-adapter/src/filters/portal_groups.ts
+++ b/packages/jira-adapter/src/filters/portal_groups.ts
@@ -48,7 +48,7 @@ const filter: FilterCreator = ({ config, client }) => ({
             .filter(isResolvedReferenceExpression)
             .map((ticketType: ReferenceExpression) => ticketType.value.value.id)
           await client.post({
-            url: `/rest/servicedesk/${project.value.serviceDeskId}/servicedesk/${project.value.id}/portal-groups/request-types`,
+            url: `/rest/servicedesk/1/servicedesk/${project.value.id}/portal-groups/request-types`,
             data: {
               groups: [{
                 groupId: instance.value.id,

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -960,10 +960,10 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     target: { type: PROJECT_TYPE },
   },
   {
-    src: { field: 'groupIds', parentTypes: [REQUEST_TYPE_NAME] },
+    src: { field: 'ticketTypeIds', parentTypes: [PORTAL_GROUP_TYPE] },
     serializationStrategy: 'id',
     jiraMissingRefStrategy: 'typeAndValue',
-    target: { type: PORTAL_GROUP_TYPE },
+    target: { type: REQUEST_TYPE_NAME },
   },
   {
     src: { field: 'id', parentTypes: ['RequestType__workflowStatuses'] },

--- a/packages/jira-adapter/test/filters/change_portal_group_fields.test.ts
+++ b/packages/jira-adapter/test/filters/change_portal_group_fields.test.ts
@@ -1,0 +1,59 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { filterUtils } from '@salto-io/adapter-components'
+import _ from 'lodash'
+import { InstanceElement } from '@salto-io/adapter-api'
+import { getDefaultConfig } from '../../src/config/config'
+import changePortalGroupFieldsFilter from '../../src/filters/change_portal_group_fields'
+import { createEmptyType, getFilterParams } from '../utils'
+import { PORTAL_GROUP_TYPE } from '../../src/constants'
+
+
+describe('changePortalGroupFields filter', () => {
+    type FilterType = filterUtils.FilterWith<'onFetch'>
+    let filter: FilterType
+    let portalInstance: InstanceElement
+    describe('on Fetch', () => {
+      beforeEach(() => {
+        const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+        config.fetch.enableJSM = true
+        filter = changePortalGroupFieldsFilter(getFilterParams({ config })) as typeof filter
+        portalInstance = new InstanceElement(
+          'portalGroup1',
+          createEmptyType(PORTAL_GROUP_TYPE),
+          {
+            id: 11,
+            name: 'portalGroup1',
+            ticketTypes: [2],
+          },
+        )
+      })
+      it('should delete fields field and add columns field', async () => {
+        await filter.onFetch([portalInstance])
+        expect(portalInstance.value.ticketTypes).toBeUndefined()
+        expect(portalInstance.value.ticketTypeIds).toEqual([2])
+      })
+      it('should not delete fields field and add columns field if enableJSM is false', async () => {
+        const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+        config.fetch.enableJSM = false
+        filter = changePortalGroupFieldsFilter(getFilterParams({ config })) as typeof filter
+        await filter.onFetch([portalInstance])
+        expect(portalInstance.value.ticketTypes).toBeDefined()
+        expect(portalInstance.value.ticketTypeIds).toBeUndefined()
+      })
+    })
+})

--- a/packages/jira-adapter/test/filters/jsm_types_deploy_filter.test.ts
+++ b/packages/jira-adapter/test/filters/jsm_types_deploy_filter.test.ts
@@ -20,7 +20,7 @@ import { InstanceElement, ReferenceExpression, CORE_ANNOTATIONS } from '@salto-i
 import { getDefaultConfig } from '../../src/config/config'
 import jsmTypesFilter from '../../src/filters/jsm_types_deploy_filter'
 import { createEmptyType, getFilterParams } from '../utils'
-import { CUSTOMER_PERMISSIONS_TYPE, PROJECT_TYPE } from '../../src/constants'
+import { PORTAL_GROUP_TYPE, PROJECT_TYPE } from '../../src/constants'
 
 const mockDeployChange = jest.fn()
 jest.mock('@salto-io/adapter-components', () => {
@@ -39,8 +39,7 @@ describe('jsmTypesDeployFilter', () => {
     let filter: FilterType
     const projectType = createEmptyType(PROJECT_TYPE)
     let projectInstance: InstanceElement
-    const customerPermissionsType = createEmptyType(CUSTOMER_PERMISSIONS_TYPE)
-    let customerPermissionsInstance: InstanceElement
+    let portalGroupInstance: InstanceElement
 
     beforeEach(() => {
       const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
@@ -59,14 +58,12 @@ describe('jsmTypesDeployFilter', () => {
     describe('deploy', () => {
       beforeEach(async () => {
         jest.clearAllMocks()
-        customerPermissionsInstance = new InstanceElement(
-          'customerPermissions1',
-          customerPermissionsType,
+        portalGroupInstance = new InstanceElement(
+          'portalGroup1',
+          createEmptyType(PORTAL_GROUP_TYPE),
           {
             id: 11111,
-            manageEnabled: false,
-            autocompleteEnabled: false,
-            serviceDeskOpenAccess: true,
+            name: 'portalGroup1',
           },
           undefined,
           {
@@ -77,12 +74,12 @@ describe('jsmTypesDeployFilter', () => {
         )
       })
       it('should pass the correct params to deployChange on update', async () => {
-        const clonedCustomerPermissionsBefore = customerPermissionsInstance.clone()
-        const clonedCustomerPermissionsAfter = customerPermissionsInstance.clone()
-        clonedCustomerPermissionsAfter.value.serviceDeskOpenAccess = false
+        const clonedPortalGroupBefore = portalGroupInstance.clone()
+        const clonedPortalGroupAfter = portalGroupInstance.clone()
+        clonedPortalGroupAfter.value.serviceDeskOpenAccess = false
         mockDeployChange.mockImplementation(async () => ({}))
         const res = await filter
-          .deploy([{ action: 'modify', data: { before: clonedCustomerPermissionsBefore, after: clonedCustomerPermissionsAfter } }])
+          .deploy([{ action: 'modify', data: { before: clonedPortalGroupBefore, after: clonedPortalGroupAfter } }])
         expect(mockDeployChange).toHaveBeenCalledTimes(1)
         expect(res.leftoverChanges).toHaveLength(0)
         expect(res.deployResult.errors).toHaveLength(0)
@@ -91,27 +88,27 @@ describe('jsmTypesDeployFilter', () => {
           .toEqual([
             {
               action: 'modify',
-              data: { before: clonedCustomerPermissionsBefore, after: clonedCustomerPermissionsAfter },
+              data: { before: clonedPortalGroupBefore, after: clonedPortalGroupAfter },
             },
           ])
       })
       it('should not deploy if enableJSM is false', async () => {
         const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
         config.fetch.enableJSM = false
-        const clonedCustomerPermissionsBefore = customerPermissionsInstance.clone()
-        const clonedCustomerPermissionsAfter = customerPermissionsInstance.clone()
-        clonedCustomerPermissionsAfter.value.serviceDeskOpenAccess = false
+        const clonedPortalGroupBefore = portalGroupInstance.clone()
+        const clonedPortalGroupAfter = portalGroupInstance.clone()
+        clonedPortalGroupAfter.value.name = 'portalGroup2'
         filter = jsmTypesFilter(getFilterParams({ config })) as typeof filter
         mockDeployChange.mockImplementation(async () => ({}))
         const res = await filter
-          .deploy([{ action: 'modify', data: { before: clonedCustomerPermissionsBefore, after: clonedCustomerPermissionsAfter } }])
+          .deploy([{ action: 'modify', data: { before: clonedPortalGroupBefore, after: clonedPortalGroupAfter } }])
         expect(mockDeployChange).toHaveBeenCalledTimes(0)
         expect(res.leftoverChanges).toHaveLength(1)
         expect(res.leftoverChanges)
           .toEqual([
             {
               action: 'modify',
-              data: { before: clonedCustomerPermissionsBefore, after: clonedCustomerPermissionsAfter },
+              data: { before: clonedPortalGroupBefore, after: clonedPortalGroupAfter },
             },
           ])
         expect(res.deployResult.errors).toHaveLength(0)

--- a/packages/jira-adapter/test/filters/portal_groups.test.ts
+++ b/packages/jira-adapter/test/filters/portal_groups.test.ts
@@ -1,0 +1,121 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { filterUtils, elements as adapterElements } from '@salto-io/adapter-components'
+import _ from 'lodash'
+import { InstanceElement, ReferenceExpression, CORE_ANNOTATIONS, toChange } from '@salto-io/adapter-api'
+import { getDefaultConfig } from '../../src/config/config'
+import portalGroupsFilter from '../../src/filters/portal_groups'
+import { createEmptyType, getFilterParams, mockClient } from '../utils'
+import { JIRA, PORTAL_GROUP_TYPE, PROJECT_TYPE } from '../../src/constants'
+import JiraClient from '../../src/client/client'
+
+
+describe('queue filter', () => {
+    type FilterType = filterUtils.FilterWith<'preDeploy' | 'onDeploy'>
+    let filter: FilterType
+    let client: JiraClient
+    const projectInstance = new InstanceElement(
+      'project1',
+      createEmptyType(PROJECT_TYPE),
+      {
+        id: 11111,
+        name: 'project1',
+        projectTypeKey: 'service_desk',
+        key: 'project1Key',
+      },
+      [JIRA, adapterElements.RECORDS_PATH, PROJECT_TYPE, 'project1']
+    )
+    let portalGroupInstance: InstanceElement
+    describe('pre deploy', () => {
+      beforeEach(() => {
+        const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+        config.fetch.enableJSM = true
+        const { client: cli } = mockClient(true)
+        client = cli
+        filter = portalGroupsFilter(getFilterParams({ config, client })) as typeof filter
+        portalGroupInstance = new InstanceElement(
+          'queue1',
+          createEmptyType(PORTAL_GROUP_TYPE),
+          {
+            id: 11,
+            name: 'portalGroup1',
+          },
+          undefined,
+          {
+            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(projectInstance.elemID, projectInstance)],
+          },
+        )
+      })
+      it('should add ticketTypeIds to portalGroupInstance', async () => {
+        const changes = [toChange({ after: portalGroupInstance })]
+        await filter.preDeploy(changes)
+        expect(portalGroupInstance.value.ticketTypeIds).toEqual([])
+      })
+      it('should add ticketTypeIds to portalGroupInstance when modifying', async () => {
+        const portalGroupInstanceAfter = portalGroupInstance.clone()
+        portalGroupInstanceAfter.value.name = 'portalGroup2'
+        const changes = [toChange({ before: portalGroupInstance, after: portalGroupInstanceAfter })]
+        await filter.preDeploy(changes)
+        expect(portalGroupInstanceAfter.value.ticketTypeIds).toEqual([])
+      })
+      it('should not add ticketTypeIds to portalGroupInstance when enable JSM is false', async () => {
+        const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+        config.fetch.enableJSM = false
+        filter = portalGroupsFilter(getFilterParams({ config, client })) as typeof filter
+        const changes = [toChange({ after: portalGroupInstance })]
+        await filter.preDeploy(changes)
+        expect(portalGroupInstance.value.ticketTypeIds).toBeUndefined()
+      })
+    })
+    describe('on deploy', () => {
+      let portalGroupWithTicketTypeIds: InstanceElement
+      beforeEach(() => {
+        const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+        config.fetch.enableJSM = true
+        const { client: cli } = mockClient(true)
+        client = cli
+        filter = portalGroupsFilter(getFilterParams({ config, client })) as typeof filter
+        portalGroupInstance = new InstanceElement(
+          'queue1',
+          createEmptyType(PORTAL_GROUP_TYPE),
+          {
+            id: 11,
+            name: 'portalGroup1',
+          },
+          undefined,
+          {
+            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(projectInstance.elemID, projectInstance)],
+          },
+        )
+        portalGroupWithTicketTypeIds = portalGroupInstance.clone()
+        portalGroupWithTicketTypeIds.value.ticketTypeIds = []
+      })
+      it('should remove ticketTypeIds from portalGroupInstance', async () => {
+        const changes = [toChange({ after: portalGroupWithTicketTypeIds })]
+        await filter.onDeploy(changes)
+        expect(portalGroupInstance.value.ticketTypeIds).toBeUndefined()
+      })
+      it('should not remove ticketTypeIds from portalGroupInstance when enable JSM is false', async () => {
+        const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+        config.fetch.enableJSM = false
+        filter = portalGroupsFilter(getFilterParams({ config, client })) as typeof filter
+        const changes = [toChange({ after: portalGroupWithTicketTypeIds })]
+        await filter.onDeploy(changes)
+        expect(portalGroupWithTicketTypeIds.value.ticketTypeIds).toEqual([])
+      })
+    })
+})

--- a/packages/jira-adapter/test/filters/portal_groups.test.ts
+++ b/packages/jira-adapter/test/filters/portal_groups.test.ts
@@ -97,7 +97,7 @@ describe('queue filter', () => {
       expect(res.deployResult.appliedChanges).toHaveLength(1)
       expect(connection.post).toHaveBeenCalledTimes(1)
       expect(connection.post).toHaveBeenCalledWith(
-        '/rest/servicedesk/100/servicedesk/11111/portal-groups',
+        '/rest/servicedesk/1/servicedesk/11111/portal-groups',
         {
           id: 11,
           name: 'portalGroup1',
@@ -119,7 +119,7 @@ describe('queue filter', () => {
       expect(res.deployResult.appliedChanges).toHaveLength(1)
       expect(connection.put).toHaveBeenCalledTimes(1)
       expect(connection.put).toHaveBeenCalledWith(
-        '/rest/servicedesk/100/servicedesk/11111/portal-groups/11',
+        '/rest/servicedesk/1/servicedesk/11111/portal-groups/11',
         {
           id: 11,
           name: 'portalGroup1',
@@ -129,7 +129,7 @@ describe('queue filter', () => {
       )
       expect(connection.post).toHaveBeenCalledTimes(1)
       expect(connection.post).toHaveBeenCalledWith(
-        '/rest/servicedesk/100/servicedesk/11111/portal-groups/request-types',
+        '/rest/servicedesk/1/servicedesk/11111/portal-groups/request-types',
         {
           groups: [{
             groupId: 11,


### PR DESCRIPTION
In this PR I added:
1. Changed portal group fetch to include current request types.
2. Omited groups from request types. 
3. Support for deployment of portal group. 
4. Support for addition of id in addition change. 

---

None

---
_Release Notes_: 
_Jira Adapter:_
Now supports deployment of portal groups. 

---
_User Notifications_: 
None
