### PR TITLE
SALTO-4846 - Salesforce: make all references in REFERENCE_TO resolved

### DIFF
--- a/packages/salesforce-adapter/test/filters/reference_annotations.test.ts
+++ b/packages/salesforce-adapter/test/filters/reference_annotations.test.ts
@@ -68,6 +68,10 @@ describe('reference_annotations filter', () => {
       expect(
         nestedType.fields[parentObjFieldName].annotations[FIELD_ANNOTATIONS.REFERENCE_TO][0].elemID
       ).toEqual(new ElemID(SALESFORCE, objTypeName))
+      expect(
+        nestedType.fields[parentObjFieldName].annotations[FIELD_ANNOTATIONS.REFERENCE_TO][0].value
+      ).toEqual(objType)
+
       expect(nestedType.fields[parentObjFieldName].annotations[FIELD_ANNOTATIONS.REFERENCE_TO][1]).toEqual('unknown')
     })
     it('should convert FOREIGN_KEY_DOMAIN to reference when found', () => {
@@ -80,6 +84,9 @@ describe('reference_annotations filter', () => {
       expect(
         nestedType.fields[parentObjFieldName].annotations[FOREIGN_KEY_DOMAIN][0].elemID
       ).toEqual(new ElemID(SALESFORCE, objTypeName))
+      expect(
+        nestedType.fields[parentObjFieldName].annotations[FOREIGN_KEY_DOMAIN][0].value
+      ).toEqual(objType)
       expect(nestedType.fields[parentObjFieldName].annotations[FOREIGN_KEY_DOMAIN][1]).toEqual('something')
     })
   })


### PR DESCRIPTION
There does not seem to be a reason to use unresolved references, and it will help us avoid making the utility in https://github.com/salto-io/salto/pull/4914 async

---

This was not an issue until now because the `reference_annotation` filter runs very late and so we never tried to access the references it creates. But if we want to create generic utilities to access the contents of the REFERENCE_TO annotation, we need them to be resolved.

---
_Release Notes_: 
N/A

---
_User Notifications_: 
N/A