### PR TITLE
SALTO-2349: Improve JSM defualt deployment

### DIFF
--- a/packages/jira-adapter/src/deployment/standard_deployment.ts
+++ b/packages/jira-adapter/src/deployment/standard_deployment.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, ChangeDataType, DeployResult, ElemID, getChangeData, InstanceElement, isAdditionChange, isEqualValues, isModificationChange, ReadOnlyElementsSource, SaltoElementError } from '@salto-io/adapter-api'
+import { AdditionChange, Change, ChangeDataType, DeployResult, ElemID, getChangeData, InstanceElement, isAdditionChange, isEqualValues, isModificationChange, ReadOnlyElementsSource, SaltoElementError } from '@salto-io/adapter-api'
 import { config, deployment, client as clientUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { invertNaclCase, resolveChangeElement, resolveValues } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
@@ -42,6 +42,37 @@ const invertKeysNames = (instance: Record<string, unknown>): void => {
     })
 }
 
+export const addIdToAdditionChange = (
+  response: deployment.ResponseResult,
+  change: AdditionChange<InstanceElement>,
+  apiDefinitions: config.AdapterApiConfig
+): void => {
+  if (!Array.isArray(response)) {
+    const serviceIdField = apiDefinitions.types[getChangeData(change).elemID.typeName]?.transformation?.serviceIdField ?? 'id'
+    if (response?.[serviceIdField] !== undefined) {
+      getChangeData(change).value[serviceIdField] = response[serviceIdField]
+    }
+  } else {
+    log.warn('Received unexpected response from deployChange: %o', response)
+  }
+}
+
+export const getResolvedChange = async ({
+  change,
+  elementsSource,
+}: {
+  change: Change<InstanceElement>
+  elementsSource?: ReadOnlyElementsSource | undefined
+}): Promise<Change<InstanceElement>> => {
+  const resolvedChange = await resolveChangeElement(change, getLookUpName, resolveValues, elementsSource)
+  invertKeysNames(getChangeData(resolvedChange).value)
+  const changeToDeploy = await elementUtils.swagger.flattenAdditionalProperties(
+    resolvedChange,
+    elementsSource,
+  )
+  return changeToDeploy
+}
+
 /**
  * Deploy change with the standard "add", "modify", "remove" endpoints
  */
@@ -55,12 +86,7 @@ export const defaultDeployChange = async ({
 }: DeployChangeParam): Promise<
   clientUtils.ResponseValue | clientUtils.ResponseValue[] | undefined
 > => {
-  const resolvedChange = await resolveChangeElement(change, getLookUpName, resolveValues, elementsSource)
-  invertKeysNames(getChangeData(resolvedChange).value)
-  const changeToDeploy = await elementUtils.swagger.flattenAdditionalProperties(
-    resolvedChange,
-    elementsSource,
-  )
+  const changeToDeploy = await getResolvedChange({ change, elementsSource })
 
   if (isModificationChange(changeToDeploy)) {
     const valuesBefore = (await deployment.filterIgnoredValues(
@@ -91,14 +117,7 @@ export const defaultDeployChange = async ({
   })
 
   if (isAdditionChange(change)) {
-    if (!Array.isArray(response)) {
-      const serviceIdField = apiDefinitions.types[getChangeData(change).elemID.typeName]?.transformation?.serviceIdField ?? 'id'
-      if (response?.[serviceIdField] !== undefined) {
-        getChangeData(change).value[serviceIdField] = response[serviceIdField]
-      }
-    } else {
-      log.warn('Received unexpected response from deployChange: %o', response)
-    }
+    addIdToAdditionChange(response, change, apiDefinitions)
   }
   return response
 }

--- a/packages/jira-adapter/src/filters/jsm_types_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/jsm_types_deploy_filter.ts
@@ -15,17 +15,17 @@
 */
 
 import _ from 'lodash'
-import { getChangeData, isInstanceChange, Change, InstanceElement } from '@salto-io/adapter-api'
+import { getChangeData, isInstanceChange, Change, InstanceElement, isAdditionChange } from '@salto-io/adapter-api'
 import { deployment } from '@salto-io/adapter-components'
-import { resolveChangeElement } from '@salto-io/adapter-utils'
-import { deployChanges } from '../deployment/standard_deployment'
+import { addIdToAdditionChange, deployChanges, getResolvedChange } from '../deployment/standard_deployment'
 import { FilterCreator } from '../filter'
 import { CUSTOMER_PERMISSIONS_TYPE } from '../constants'
-import { getLookUpName } from '../reference_mapping'
 
-const jsmSupportedTypes = [CUSTOMER_PERMISSIONS_TYPE]
+const jsmSupportedTypes = [
+  CUSTOMER_PERMISSIONS_TYPE,
+]
 
-const filterCreator: FilterCreator = ({ config, client }) => ({
+const filterCreator: FilterCreator = ({ config, client, elementsSource }) => ({
   name: 'jsmTypesFilter',
   deploy: async (changes: Change<InstanceElement>[]) => {
     const { jsmApiDefinitions } = config
@@ -45,10 +45,16 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
     const deployResult = await deployChanges(
       jsmTypesChanges,
       async change => {
-        const resolvedChange = await resolveChangeElement(change, getLookUpName)
-        await deployment.deployChange({ change: resolvedChange,
+        const resolvedChange = await getResolvedChange({
+          change,
+          elementsSource,
+        })
+        const response = await deployment.deployChange({ change: resolvedChange,
           client,
           endpointDetails: jsmApiDefinitions.types[getChangeData(change).elemID.typeName].deployRequests })
+        if (isAdditionChange(change)) {
+          addIdToAdditionChange(response, change, jsmApiDefinitions)
+        }
       }
     )
     return { deployResult, leftoverChanges }

--- a/packages/jira-adapter/src/filters/jsm_types_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/jsm_types_deploy_filter.ts
@@ -15,9 +15,8 @@
 */
 
 import _ from 'lodash'
-import { getChangeData, isInstanceChange, Change, InstanceElement, isAdditionChange } from '@salto-io/adapter-api'
-import { deployment } from '@salto-io/adapter-components'
-import { addIdToAdditionChange, deployChanges, getResolvedChange } from '../deployment/standard_deployment'
+import { getChangeData, isInstanceChange, Change, InstanceElement } from '@salto-io/adapter-api'
+import { defaultDeployChange, deployChanges } from '../deployment/standard_deployment'
 import { FilterCreator } from '../filter'
 import { CUSTOMER_PERMISSIONS_TYPE } from '../constants'
 
@@ -25,7 +24,7 @@ const jsmSupportedTypes = [
   CUSTOMER_PERMISSIONS_TYPE,
 ]
 
-const filterCreator: FilterCreator = ({ config, client, elementsSource }) => ({
+const filterCreator: FilterCreator = ({ config, client }) => ({
   name: 'jsmTypesFilter',
   deploy: async (changes: Change<InstanceElement>[]) => {
     const { jsmApiDefinitions } = config
@@ -45,16 +44,7 @@ const filterCreator: FilterCreator = ({ config, client, elementsSource }) => ({
     const deployResult = await deployChanges(
       jsmTypesChanges,
       async change => {
-        const resolvedChange = await getResolvedChange({
-          change,
-          elementsSource,
-        })
-        const response = await deployment.deployChange({ change: resolvedChange,
-          client,
-          endpointDetails: jsmApiDefinitions.types[getChangeData(change).elemID.typeName].deployRequests })
-        if (isAdditionChange(change)) {
-          addIdToAdditionChange(response, change, jsmApiDefinitions)
-        }
+        await defaultDeployChange({ change, client, apiDefinitions: jsmApiDefinitions })
       }
     )
     return { deployResult, leftoverChanges }


### PR DESCRIPTION
This PR is the infrastructure for all other PRs. 
The following PRs [deploy portal group](https://github.com/salto-io/salto/pull/4932) and [deploy queue](https://github.com/salto-io/salto/pull/4902) are rebase on it. 

---

_Additional context for reviewer_
The Type CUSTOMER_PERMISSION will change in the next PR. 

---

_Release Notes_: 
None

---
_User Notifications_: 
None
