### PR TITLE
SALTO-4769: Add properties & push status to ProfileMapping instances (Okta)

### DIFF
--- a/packages/okta-adapter/config_doc.md
+++ b/packages/okta-adapter/config_doc.md
@@ -68,6 +68,7 @@ okta {
 | [exclude](#fetch-entry-options)             | []                                | List of entries to determine what instances to exclude in the fetch
 | convertUsersIds                             | true                              | When enabled, user IDs will be replaced with user login names
 | includeGroupMemberships                     | false                             | Include group assignments
+| includeProfileMappingProperties             | true                              | Include profile mapping properties for profile mapping instances
 
 ## Fetch entry options
 

--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -51,6 +51,7 @@ import groupMembersFilter from './filters/group_members'
 import unorderedListsFilter from './filters/unordered_lists'
 import addAliasFilter from './filters/add_alias'
 import profileMappingPropertiesFilter from './filters/profile_mapping_properties'
+import profileMappingAdditionFilter from './filters/profile_mapping_addition'
 import { APP_LOGO_TYPE_NAME, BRAND_LOGO_TYPE_NAME, FAV_ICON_TYPE_NAME, OKTA } from './constants'
 import { getLookUpName } from './reference_mapping'
 
@@ -90,6 +91,7 @@ export const DEFAULT_FILTERS = [
   // should run before appDeploymentFilter and after userSchemaFilter
   serviceUrlFilter,
   appDeploymentFilter,
+  profileMappingAdditionFilter,
   // should run after fieldReferences
   ...Object.values(commonFilters),
   // should run last

--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -50,6 +50,7 @@ import brandThemeFilesFilter from './filters/brand_theme_files'
 import groupMembersFilter from './filters/group_members'
 import unorderedListsFilter from './filters/unordered_lists'
 import addAliasFilter from './filters/add_alias'
+import profileMappingPropertiesFilter from './filters/profile_mapping_properties'
 import { APP_LOGO_TYPE_NAME, BRAND_LOGO_TYPE_NAME, FAV_ICON_TYPE_NAME, OKTA } from './constants'
 import { getLookUpName } from './reference_mapping'
 
@@ -66,6 +67,7 @@ export const DEFAULT_FILTERS = [
   deleteFieldsFilter,
   userTypeFilter,
   userSchemaFilter,
+  profileMappingPropertiesFilter,
   authorizationRuleFilter,
   // should run before fieldReferencesFilter
   urlReferencesFilter,

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -44,6 +44,7 @@ export type OktaFetchConfig = configUtils.UserFetchConfig & {
   convertUsersIds?: boolean
   enableMissingReferences?: boolean
   includeGroupMemberships?: boolean
+  includeProfileMappingProperties?: boolean
 }
 
 export type OktaSwaggerApiConfig = configUtils.AdapterSwaggerApiConfig<OktaActionName>
@@ -1224,6 +1225,16 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
       fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),
       fieldsToHide: [{ fieldName: 'id' }],
     },
+    deployRequests: {
+      // only modificaiton is supported
+      modify: {
+        url: '/api/v1/mappings/{mappingId}',
+        method: 'post',
+        urlParamsToFields: {
+          mappingId: 'id',
+        },
+      },
+    },
   },
   ProfileMappingSource: {
     transformation: {
@@ -1465,7 +1476,6 @@ export const SUPPORTED_TYPES = {
     'api__v1__idps',
   ],
   InlineHook: ['api__v1__inlineHooks'],
-  // TODO SALTO-2734 returns 401
   ProfileMapping: ['api__v1__mappings'],
   LinkedObjectDefinitions: ['api__v1__meta__schemas__user__linkedObjects'],
   GroupSchema: ['GroupSchema'],
@@ -1649,6 +1659,7 @@ export const DEFAULT_CONFIG: OktaConfig = {
     convertUsersIds: true,
     enableMissingReferences: true,
     includeGroupMemberships: false,
+    includeProfileMappingProperties: true,
   },
   [API_DEFINITIONS_CONFIG]: DEFAULT_API_DEFINITIONS,
   [PRIVATE_API_DEFINITIONS_CONFIG]: DUCKTYPE_API_DEFINITIONS,
@@ -1724,6 +1735,7 @@ export const configType = createMatchingObjectType<Partial<OktaConfig>>({
           convertUsersIds: { refType: BuiltinTypes.BOOLEAN },
           enableMissingReferences: { refType: BuiltinTypes.BOOLEAN },
           includeGroupMemberships: { refType: BuiltinTypes.BOOLEAN },
+          includeProfileMappingProperties: { refType: BuiltinTypes.BOOLEAN },
         }
       ),
     },
@@ -1753,6 +1765,7 @@ export const configType = createMatchingObjectType<Partial<OktaConfig>>({
       `${FETCH_CONFIG}.convertUsersIds`,
       `${FETCH_CONFIG}.enableMissingReferences`,
       `${FETCH_CONFIG}.includeGroupMemberships`,
+      `${FETCH_CONFIG}.includeProfileMappingProperties`
     ),
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -1220,7 +1220,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
   },
   ProfileMapping: {
     transformation: {
-      idFields: ['&source.id', '&target.id'],
+      idFields: ['source.name', 'target.name'],
       serviceIdField: 'id',
       fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),
       fieldsToHide: [{ fieldName: 'id' }],
@@ -1240,6 +1240,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
           mappingId: 'id',
         },
       },
+      // TODO SALTO-4769 add support in remove
     },
   },
   ProfileMappingSource: {

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -1220,13 +1220,19 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
   },
   ProfileMapping: {
     transformation: {
-      idFields: ['source.name', 'target.name'],
+      idFields: ['&source.id', '&target.id'],
       serviceIdField: 'id',
       fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),
       fieldsToHide: [{ fieldName: 'id' }],
     },
     deployRequests: {
-      // only modificaiton is supported
+      add: {
+        url: '/api/v1/mappings/{mappingId}',
+        method: 'post',
+        urlParamsToFields: {
+          mappingId: 'id',
+        },
+      },
       modify: {
         url: '/api/v1/mappings/{mappingId}',
         method: 'post',

--- a/packages/okta-adapter/src/filters/profile_mapping_addition.ts
+++ b/packages/okta-adapter/src/filters/profile_mapping_addition.ts
@@ -1,0 +1,88 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { Change, InstanceElement, isInstanceChange, getChangeData, isAdditionChange } from '@salto-io/adapter-api'
+import { inspectValue } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+import { PROFILE_MAPPING_TYPE_NAME } from '../constants'
+import OktaClient from '../client/client'
+import { API_DEFINITIONS_CONFIG, OktaSwaggerApiConfig } from '../config'
+import { FilterCreator } from '../filter'
+import { deployChanges, defaultDeployChange } from '../deployment'
+
+const log = logger(module)
+
+const getMappingIdBySourceAndTarget = async (
+  sourceId: string,
+  targetId: string,
+  client: OktaClient,
+): Promise<string> => {
+  const mappingEntries = (await client.getSinglePage({
+    url: '/api/v1/mappings',
+    queryParams: { sourceId, targetId },
+  })).data
+  if (_.isArray(mappingEntries) && mappingEntries.length === 1 && _.isString(mappingEntries[0].id)) {
+    return mappingEntries[0].id
+  }
+  log.error(`Recieved unexpected result for profile mapping: ${inspectValue(mappingEntries)}`)
+  throw new Error('Could not find ProfileMapping with the provided sourceId and targetId')
+}
+
+const deployProfileMappingAddition = async (
+  change: Change<InstanceElement>,
+  client: OktaClient,
+  apiDefinitions: OktaSwaggerApiConfig,
+): Promise<void> => {
+  const instance = getChangeData(change)
+  const sourceId = instance.value.source?.id
+  const targetId = instance.value.target?.id
+  if (!_.isString(sourceId) || !_.isString(targetId)) { // references are already resolved
+    log.error(`Failed to deploy ProfileMapping with sourceId: ${sourceId}, targetId: ${targetId}`)
+    throw new Error('ProfileMapping must have valid sourceId and targetId')
+  }
+  const mappingId = await getMappingIdBySourceAndTarget(sourceId, targetId, client)
+  // Assign the existing id to the added profile mapping
+  instance.value.id = mappingId
+  await defaultDeployChange(change, client, apiDefinitions)
+}
+
+/**
+ * Deploy addition changes of ProfileMapping instances,
+ * by finding the id of the existing ProfileMapping and update it
+ */
+const filterCreator: FilterCreator = ({ client, config }) => ({
+  name: 'profileMappingAdditionFilter',
+  deploy: async changes => {
+    const [relevantChanges, leftoverChanges] = _.partition(
+      changes,
+      change => isInstanceChange(change)
+        && isAdditionChange(change)
+        && getChangeData(change).elemID.typeName === PROFILE_MAPPING_TYPE_NAME
+    )
+
+    const deployResult = await deployChanges(
+      relevantChanges.filter(isInstanceChange),
+      async change => deployProfileMappingAddition(change, client, config[API_DEFINITIONS_CONFIG])
+    )
+
+    return {
+      leftoverChanges,
+      deployResult,
+    }
+  },
+})
+
+export default filterCreator

--- a/packages/okta-adapter/src/filters/profile_mapping_properties.ts
+++ b/packages/okta-adapter/src/filters/profile_mapping_properties.ts
@@ -15,11 +15,13 @@
 */
 import { Element, Values, isInstanceElement } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
+import { collections } from '@salto-io/lowerdash'
 import { FilterCreator } from '../filter'
 import { PROFILE_MAPPING_TYPE_NAME } from '../constants'
 import OktaClient from '../client/client'
 import { FETCH_CONFIG } from '../config'
 
+const { awu } = collections.asynciterable
 const log = logger(module)
 
 const getProfileMapping = async (
@@ -27,7 +29,7 @@ const getProfileMapping = async (
   client: OktaClient
 ): Promise<Values> => (await client.getSinglePage({
   url: `/api/v1/mappings/${mappingId}`,
-})).data as Values[]
+})).data as Values
 
 /**
 * Add profile mapping properties for ProfileMapping instances
@@ -43,7 +45,7 @@ const filterCreator: FilterCreator = ({ client, config }) => ({
       .filter(isInstanceElement)
       .filter(instance => instance.elemID.typeName === PROFILE_MAPPING_TYPE_NAME)
 
-    instances.forEach(async instance => {
+    await awu(instances).forEach(async instance => {
       const mappingId = instance.value.id
       const mappingProperties = (await getProfileMapping(mappingId, client))?.properties
       // not all mappings have properties

--- a/packages/okta-adapter/src/filters/profile_mapping_properties.ts
+++ b/packages/okta-adapter/src/filters/profile_mapping_properties.ts
@@ -1,0 +1,58 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Element, Values, isInstanceElement } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { FilterCreator } from '../filter'
+import { PROFILE_MAPPING_TYPE_NAME } from '../constants'
+import OktaClient from '../client/client'
+import { FETCH_CONFIG } from '../config'
+
+const log = logger(module)
+
+const getProfileMapping = async (
+  mappingId: string,
+  client: OktaClient
+): Promise<Values> => (await client.getSinglePage({
+  url: `/api/v1/mappings/${mappingId}`,
+})).data as Values[]
+
+/**
+* Add profile mapping properties for ProfileMapping instances
+*/
+const filterCreator: FilterCreator = ({ client, config }) => ({
+  name: 'profileMappingPropertiesFilter',
+  onFetch: async (elements: Element[]) => {
+    if (config[FETCH_CONFIG].includeProfileMappingProperties === false) {
+      log.debug('Fetch of profile mapping properties is disabled')
+      return
+    }
+    const instances = elements
+      .filter(isInstanceElement)
+      .filter(instance => instance.elemID.typeName === PROFILE_MAPPING_TYPE_NAME)
+
+    instances.forEach(async instance => {
+      const mappingId = instance.value.id
+      const mappingProperties = (await getProfileMapping(mappingId, client))?.properties
+      // not all mappings have properties
+      if (mappingProperties === undefined) {
+        return
+      }
+      instance.value.properties = mappingProperties
+    })
+  },
+})
+
+export default filterCreator

--- a/packages/okta-adapter/test/filters/add_alias.test.ts
+++ b/packages/okta-adapter/test/filters/add_alias.test.ts
@@ -15,7 +15,6 @@
 */
 import { ObjectType, ElemID, InstanceElement, isInstanceElement, CORE_ANNOTATIONS, ReferenceExpression } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG, FETCH_CONFIG } from '../../src/config'
 import { APPLICATION_TYPE_NAME, GROUP_TYPE_NAME, OKTA, PROFILE_MAPPING_TYPE_NAME } from '../../src/constants'
 import addAliasFilter from '../../src/filters/add_alias'
 import { getFilterParams } from '../utils'
@@ -25,8 +24,6 @@ describe('addAliasFilter', () => {
   const groupType = new ObjectType({ elemID: new ElemID(OKTA, GROUP_TYPE_NAME) })
   const appType = new ObjectType({ elemID: new ElemID(OKTA, APPLICATION_TYPE_NAME) })
   const profileMappingType = new ObjectType({ elemID: new ElemID(OKTA, PROFILE_MAPPING_TYPE_NAME) })
-  const config = { ...DEFAULT_CONFIG }
-  config[FETCH_CONFIG].includeGroupMemberships = true
   const groupInstance = new InstanceElement(
     'groupTest',
     groupType,

--- a/packages/okta-adapter/test/filters/profile_mapping_addition.test.ts
+++ b/packages/okta-adapter/test/filters/profile_mapping_addition.test.ts
@@ -1,0 +1,145 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { MockInterface } from '@salto-io/test-utils'
+import { ElemID, InstanceElement, ObjectType, toChange, getChangeData } from '@salto-io/adapter-api'
+import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
+import { getFilterParams, mockClient } from '../utils'
+import OktaClient from '../../src/client/client'
+import profileMappingAdditionFilter from '../../src/filters/profile_mapping_addition'
+import { OKTA, PROFILE_MAPPING_TYPE_NAME } from '../../src/constants'
+
+describe('profileMappingAdditionFilter', () => {
+  let mockConnection: MockInterface<clientUtils.APIConnection>
+  let client: OktaClient
+  type FilterType = filterUtils.FilterWith<'deploy'>
+  let filter: FilterType
+  const mappingType = new ObjectType({ elemID: new ElemID(OKTA, PROFILE_MAPPING_TYPE_NAME) })
+  const mappingInstance = new InstanceElement(
+    'mapping',
+    mappingType,
+    {
+      source: {
+        id: '111',
+        name: 'salesforce',
+        type: 'appuser',
+      },
+      target: {
+        id: '222',
+        name: 'user',
+        type: 'user',
+      },
+      properties: {
+        firstName: {
+          expression: 'appuser.name',
+          pushStatus: 'DONT_PUSH',
+        },
+      },
+    },
+  )
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    const { client: cli, connection } = mockClient()
+    mockConnection = connection
+    client = cli
+    filter = profileMappingAdditionFilter(getFilterParams({ client })) as typeof filter
+  })
+
+  describe('deploy', () => {
+    it('should successfully deploy addition changes of profile mapping', async () => {
+      mockConnection.get
+        .mockResolvedValue({
+          status: 200,
+          data: [{
+            id: 'mappingId123',
+            source: {
+              id: '111',
+              name: 'salesforce',
+              type: 'appuser',
+            },
+            target: {
+              id: '222',
+              name: 'user',
+              type: 'user',
+            },
+          }],
+        })
+      mockConnection.post.mockResolvedValue({ status: 200, data: {} })
+      const changes = [toChange({ after: mappingInstance })]
+      const result = await filter.deploy(changes)
+      expect(mockConnection.get).toHaveBeenCalledTimes(1)
+      expect(mockConnection.get).toHaveBeenCalledWith(
+        '/api/v1/mappings',
+        { headers: undefined, params: { sourceId: '111', targetId: '222' }, responseType: undefined }
+      )
+      expect(mockConnection.post).toHaveBeenCalledTimes(1)
+      const { appliedChanges } = result.deployResult
+      expect(appliedChanges).toHaveLength(1)
+      const instances = appliedChanges.map(change => getChangeData(change)) as InstanceElement[]
+      expect(instances[0].value).toEqual({
+        // validate id assigned to value
+        id: 'mappingId123',
+        source: {
+          id: '111',
+          name: 'salesforce',
+          type: 'appuser',
+        },
+        target: {
+          id: '222',
+          name: 'user',
+          type: 'user',
+        },
+        properties: {
+          firstName: {
+            expression: 'appuser.name',
+            pushStatus: 'DONT_PUSH',
+          },
+        },
+      })
+    })
+
+    it('should return error if sourceId or targetId is missing', async () => {
+      const noTarget = new InstanceElement(
+        'noTarget',
+        mappingType,
+        {
+          source: {
+            id: '111',
+            name: 'salesforce',
+            type: 'appuser',
+          },
+        },
+      )
+      const result = await filter.deploy([toChange({ after: noTarget })])
+      expect(result.deployResult.appliedChanges).toHaveLength(0)
+      expect(result.deployResult.errors).toHaveLength(1)
+      expect(result.deployResult.errors[0].message).toContain('ProfileMapping must have valid sourceId and targetId')
+    })
+
+    it('should return error if the required mapping cannot be find in the service', async () => {
+      mockConnection.get.mockResolvedValue({ status: 200, data: [] })
+      const result = await filter.deploy([toChange({ after: mappingInstance })])
+      expect(mockConnection.get).toHaveBeenCalledWith(
+        '/api/v1/mappings',
+        { headers: undefined, params: { sourceId: '111', targetId: '222' }, responseType: undefined }
+      )
+      expect(result.deployResult.appliedChanges).toHaveLength(0)
+      expect(result.deployResult.errors).toHaveLength(1)
+      expect(result.deployResult.errors[0].message).toContain('Could not find ProfileMapping with the provided sourceId and targetId')
+    })
+  })
+})

--- a/packages/okta-adapter/test/filters/profile_mapping_properties.test.ts
+++ b/packages/okta-adapter/test/filters/profile_mapping_properties.test.ts
@@ -1,0 +1,104 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { ObjectType, ElemID, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import { DEFAULT_CONFIG, FETCH_CONFIG } from '../../src/config'
+import { OKTA, PROFILE_MAPPING_TYPE_NAME } from '../../src/constants'
+import profileMappingPropertiesFilter from '../../src/filters/profile_mapping_properties'
+import { getFilterParams } from '../utils'
+import OktaClient from '../../src/client/client'
+
+describe('profileMappingPropertiesFilter', () => {
+  type FilterType = filterUtils.FilterWith<'onFetch'>
+  let filter: FilterType
+  let client: OktaClient
+  let mockGet: jest.SpyInstance
+  const mappingType = new ObjectType({ elemID: new ElemID(OKTA, PROFILE_MAPPING_TYPE_NAME) })
+  const mappingInstanceA = new InstanceElement('mapp A', mappingType, { id: 'abc123' })
+  const mappingInstanceB = new InstanceElement('mapp B', mappingType, { id: 'bcd234' })
+
+  const mappingResponse = {
+    status: 200,
+    data: {
+      id: 'abc123',
+      properties: {
+        firstName: {
+          expression: 'appuser.name',
+          pushStatus: 'DONT_PUSH',
+        },
+      },
+    },
+  }
+  const mappingResponse2 = {
+    status: 200,
+    data: {
+      id: 'bcd234',
+      properties: {
+        firstName: {
+          expression: 'appuser.lastName',
+          pushStatus: 'PUSH',
+        },
+      },
+    },
+  }
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    client = new OktaClient({
+      credentials: { baseUrl: 'a.okta.com', token: 'b' },
+    })
+    mockGet = jest.spyOn(client, 'getSinglePage')
+  })
+
+  it('should do nothing when includeProfileMappingProperties config flag is disabled', async () => {
+    const config = _.cloneDeep(DEFAULT_CONFIG)
+    config[FETCH_CONFIG].includeProfileMappingProperties = false
+    const elements = [mappingType, mappingInstanceA, mappingInstanceB]
+    filter = profileMappingPropertiesFilter(getFilterParams({ client, config })) as typeof filter
+    await filter.onFetch(elements)
+    expect(elements.filter(isInstanceElement).every(instance => !instance.value.properties)).toEqual(true)
+    expect(mockGet).toHaveBeenCalledTimes(0)
+  })
+  it('should add profile mapping properties for ProfileMapping instances when flag is enabled', async () => {
+    const elements = [mappingType, mappingInstanceA, mappingInstanceB]
+    mockGet.mockImplementation(params => {
+      if (params.url === '/api/v1/mappings/abc123') {
+        return mappingResponse
+      }
+      if (params.url === '/api/v1/mappings/bcd234') {
+        return mappingResponse2
+      }
+      throw new Error('Err')
+    })
+    filter = profileMappingPropertiesFilter(getFilterParams({ client, config: DEFAULT_CONFIG })) as typeof filter
+    await filter.onFetch(elements)
+    expect(mockGet).toHaveBeenCalledTimes(2)
+    const mappingInstances = elements.filter(isInstanceElement)
+    expect(mappingInstances[0].value.properties).toEqual({
+      firstName: {
+        expression: 'appuser.name',
+        pushStatus: 'DONT_PUSH',
+      },
+    })
+    expect(mappingInstances[1].value.properties).toEqual({
+      firstName: {
+        expression: 'appuser.lastName',
+        pushStatus: 'PUSH',
+      },
+    })
+  })
+})


### PR DESCRIPTION
Add push status info for ProfileMapping instances

---

changes:
1. Add deployment for ProfileMapping instances (only modifications)
2. Fetch properties for profile mapping which also contains info re push status of each property

---

_Release Notes_: 

_Okta_adapter_:
- Fetch properties push status in ProfileMapping instances
- Support deployments of ProfileMapping

---

_User Notifications_: 

_Okta_adapter_:
- properties push status will be added to ProfileMapping instances
