### PR TITLE
SALTO-4142: Adding permissions to custom record types pre deploy

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -62,6 +62,7 @@ import additionalChanges from './filters/additional_changes'
 import addInstancesFetchTime from './filters/add_instances_fetch_time'
 import addAliasFilter from './filters/add_alias'
 import addBundleReferences from './filters/bundle_ids'
+import addPermissionsToCustomRecord from './filters/add_permissions_to_cutomRecord'
 import { Filter, LocalFilterCreator, LocalFilterCreatorDefinition, RemoteFilterCreator, RemoteFilterCreatorDefinition } from './filter'
 import { getConfigFromConfigChanges, NetsuiteConfig, DEFAULT_DEPLOY_REFERENCED_ELEMENTS, DEFAULT_WARN_STALE_DATA, DEFAULT_VALIDATE, AdditionalDependencies, DEFAULT_MAX_FILE_CABINET_SIZE_IN_GB, shouldExcludeBins } from './config'
 import { andQuery, buildNetsuiteQuery, NetsuiteQuery, NetsuiteQueryParameters, notQuery, QueryParams, convertToQueryParams, getFixedTargetFetch } from './query'
@@ -129,6 +130,7 @@ export const allFilters: (LocalFilterCreatorDefinition | RemoteFilterCreatorDefi
   // serviceUrls must run after suiteAppInternalIds and SDFInternalIds filter
   { creator: serviceUrls, addsNewInformation: true },
   { creator: addBundleReferences },
+  { creator: addPermissionsToCustomRecord },
   // omitFieldsFilter should be the last onFetch filter to run
   { creator: omitFieldsFilter },
   // additionalChanges should be the first preDeploy filter to run

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -36,7 +36,7 @@ import { isSdfCreateOrUpdateGroupId, isSdfDeleteGroupId, isSuiteAppCreateRecords
   isSuiteAppUpdateRecordsGroupId, SUITEAPP_CREATING_FILES_GROUP_ID, SUITEAPP_DELETING_FILES_GROUP_ID,
   SUITEAPP_FILE_CABINET_GROUPS, SUITEAPP_UPDATING_CONFIG_GROUP_ID, SUITEAPP_UPDATING_FILES_GROUP_ID } from '../group_changes'
 import { DeployResult, getElementValueOrAnnotations, getServiceId } from '../types'
-import { APPLICATION_ID, CONFIG_FEATURES } from '../constants'
+import { APPLICATION_ID, CONFIG_FEATURES, CUSTOM_RECORD_TYPE, ROLE } from '../constants'
 import { toConfigDeployResult, toSetConfigTypes } from '../suiteapp_config_elements'
 import { FeaturesDeployError, MissingManifestFeaturesError, getChangesElemIdsToRemove, toFeaturesDeployPartialSuccessResult } from './errors'
 import { Graph, GraphNode } from './graph_utils'
@@ -63,12 +63,22 @@ type DependencyInfo = {
   dependencyGraph: Graph<SDFObjectNode>
 }
 
+const isRoleToCustomRecordType = (
+  startNode: GraphNode<SDFObjectNode>,
+  endNode: GraphNode<SDFObjectNode>,
+): boolean =>
+  (startNode.value.customizationInfo.typeName === ROLE
+    && endNode.value.customizationInfo.typeName === CUSTOM_RECORD_TYPE)
+
 const isLegalEdge = (
   startNode: GraphNode<SDFObjectNode>,
   endNode: GraphNode<SDFObjectNode>,
 ): boolean =>
-  startNode.value.changeType === 'addition'
-  && (startNode.id !== endNode.id)
+  (startNode.id !== endNode.id)
+  && (
+    startNode.value.changeType === 'addition'
+    || isRoleToCustomRecordType(startNode, endNode)
+  )
 
 export default class NetsuiteClient {
   private sdfClient: SdfClient

--- a/packages/netsuite-adapter/src/client/deploy_xml_utils.ts
+++ b/packages/netsuite-adapter/src/client/deploy_xml_utils.ts
@@ -21,6 +21,8 @@ import { Graph } from './graph_utils'
 import { SDFObjectNode } from './types'
 import { isCustomTypeInfo } from './utils'
 import { OBJECTS_DIR, getCustomTypeInfoPath } from './sdf_parser'
+import { ROLE } from '../constants'
+
 
 const log = logger(module)
 
@@ -36,6 +38,16 @@ export const reorderDeployXml = (
   const custInfosInTopologicalOrder = dependencyGraph.getTopologicalOrder()
     .filter(node => !nodesInCycle.has(node.id))
     .map(node => node.value.customizationInfo)
+
+  custInfosInTopologicalOrder.sort((obj1, obj2) => {
+    if (obj1.typeName === ROLE && obj2.typeName !== ROLE) {
+      return -1
+    }
+    if (obj1.typeName !== ROLE && obj2.typeName === ROLE) {
+      return 1
+    }
+    return 0
+  })
 
   const customTypeInfos = custInfosInTopologicalOrder.filter(isCustomTypeInfo)
   const deployXml = xmlParser.parse(deployContent, { ignoreAttributes: false })

--- a/packages/netsuite-adapter/src/client/deploy_xml_utils.ts
+++ b/packages/netsuite-adapter/src/client/deploy_xml_utils.ts
@@ -21,7 +21,6 @@ import { Graph } from './graph_utils'
 import { SDFObjectNode } from './types'
 import { isCustomTypeInfo } from './utils'
 import { OBJECTS_DIR, getCustomTypeInfoPath } from './sdf_parser'
-import { ROLE } from '../constants'
 
 
 const log = logger(module)
@@ -38,16 +37,6 @@ export const reorderDeployXml = (
   const custInfosInTopologicalOrder = dependencyGraph.getTopologicalOrder()
     .filter(node => !nodesInCycle.has(node.id))
     .map(node => node.value.customizationInfo)
-
-  custInfosInTopologicalOrder.sort((obj1, obj2) => {
-    if (obj1.typeName === ROLE && obj2.typeName !== ROLE) {
-      return -1
-    }
-    if (obj1.typeName !== ROLE && obj2.typeName === ROLE) {
-      return 1
-    }
-    return 0
-  })
 
   const customTypeInfos = custInfosInTopologicalOrder.filter(isCustomTypeInfo)
   const deployXml = xmlParser.parse(deployContent, { ignoreAttributes: false })

--- a/packages/netsuite-adapter/src/filters/add_permissions_to_cutomRecord.ts
+++ b/packages/netsuite-adapter/src/filters/add_permissions_to_cutomRecord.ts
@@ -14,8 +14,7 @@
 * limitations under the License.
 */
 
-import { ObjectType, ReferenceExpression, getChangeData, isInstanceChange, isObjectType, isReferenceExpression } from '@salto-io/adapter-api'
-import _ from 'lodash'
+import { InstanceElement, ObjectType, ReadOnlyElementsSource, ReferenceExpression, getChangeData, isInstanceChange, isObjectType, isReferenceExpression } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { values, collections } from '@salto-io/lowerdash'
 import { LocalFilterCreator } from '../filter'
@@ -24,6 +23,80 @@ import { ROLE, SCRIPT_ID } from '../constants'
 
 const log = logger(module)
 const { awu } = collections.asynciterable
+
+const addPermissionField = (custRecordMap: Map<string, ObjectType>): void =>
+  custRecordMap.forEach(value => {
+    if (value.annotations.permissions?.permission === undefined) {
+      value.annotations.permissions = {
+        permission: {},
+      }
+    }
+  })
+
+const createRoleToPermittedroleMap = async (
+  roles: InstanceElement[],
+  elementsSource: ReadOnlyElementsSource,
+): Promise<Map<string, ReferenceExpression>> =>
+  new Map<string, ReferenceExpression>(
+    await awu(roles)
+      .map(async (role): Promise<[string, ReferenceExpression]> => {
+        const roleFullNameList = role.elemID.getFullNameParts()
+        const roleName = roleFullNameList[roleFullNameList.length - 1]
+        const permittedrole = new ReferenceExpression(role.elemID.createNestedID(SCRIPT_ID))
+        permittedrole.topLevelParent = await elementsSource.get(
+          permittedrole.elemID.createTopLevelParentID().parent
+        )
+        return [roleName, permittedrole]
+      })
+      .toArray()
+  )
+
+const addPermissionToCustomRecordTypes = (
+  val: Record<string, unknown>,
+  customRecordChangedMap: Map<string, ObjectType>,
+  roleName: string,
+  roleToPermittedroleMap: Map<string, ReferenceExpression>,
+): void => {
+  if (isReferenceExpression(val.permkey)
+      && isObjectType(val.permkey.topLevelParent)
+      && isCustomRecordType(val.permkey.topLevelParent)) {
+    const custRecord = customRecordChangedMap.get(val.permkey.topLevelParent.elemID.typeName)
+    if (custRecord !== undefined) {
+      custRecord.annotations.permissions.permission[roleName] = {
+        permittedlevel: val.permlevel,
+        permittedrole: roleToPermittedroleMap.get(roleName),
+      }
+    }
+  }
+}
+const addPermissionsToCustomRecordTypes = (
+  roles: InstanceElement[],
+  customRecordChangedMap: Map<string, ObjectType>,
+  roleToPermittedroleMap: Map<string, ReferenceExpression>,
+): void =>
+  roles.forEach(role => {
+    const permissionObject = role.value.permissions?.permission
+    const roleFullNameList = role.elemID.getFullNameParts()
+    const roleName = roleFullNameList[roleFullNameList.length - 1]
+    if (values.isPlainRecord(permissionObject)) {
+      Object.values(permissionObject)
+        .filter(values.isPlainRecord)
+        .forEach(async val => {
+          addPermissionToCustomRecordTypes(val, customRecordChangedMap, roleName, roleToPermittedroleMap)
+          // if (isReferenceExpression(val.permkey)
+          //   && isObjectType(val.permkey.topLevelParent)
+          //   && isCustomRecordType(val.permkey.topLevelParent)) {
+          //   const custRecord = customRecordChangedMap.get(val.permkey.topLevelParent.elemID.typeName)
+          //   if (custRecord !== undefined) {
+          //     custRecord.annotations.permissions.permission[roleName] = {
+          //       permittedlevel: val.permlevel,
+          //       permittedrole: roleToPermittedroleMap.get(role.elemID.getFullName()),
+          //     }
+          //   }
+          // }
+        })
+    }
+  })
 
 const filterCreator: LocalFilterCreator = ({ elementsSource }) => ({
   name: 'addPermissions',
@@ -40,60 +113,13 @@ const filterCreator: LocalFilterCreator = ({ elementsSource }) => ({
       .filter(instance => instance.elemID.typeName === ROLE)
 
     if (customRecordChangedMap.size > 0 && roleChanged.length > 0) {
-      customRecordChangedMap.forEach(value => {
-        if (value.annotations.permissions?.permission === undefined) {
-          value.annotations.permissions = {
-            permission: {},
-          }
-        }
-      })
+      addPermissionField(customRecordChangedMap)
 
-      const roleToPermittedroleMap = new Map<string, ReferenceExpression>(
-        await awu(roleChanged)
-          .map(async (role): Promise<[string, ReferenceExpression]> => {
-            const permittedrole = new ReferenceExpression(role.elemID.createNestedID(SCRIPT_ID))
-            permittedrole.topLevelParent = await elementsSource.get(
-              permittedrole.elemID.createTopLevelParentID().parent
-            )
-            return [role.elemID.getFullName(), permittedrole]
-          })
-          .toArray()
-      )
+      const roleToPermittedroleMap = await createRoleToPermittedroleMap(roleChanged, elementsSource)
 
-      roleChanged.forEach(role => {
-        const permissionObject = role.value.permissions?.permission
-        const roleFullNameList = role.elemID.getFullNameParts()
-        const roleName = roleFullNameList[roleFullNameList.length - 1]
-        const regex = /^\[scriptid=(.+)\]$/
-        if (values.isPlainRecord(permissionObject)) {
-          Object.values(permissionObject)
-            .filter(values.isPlainRecord)
-            .forEach(async val => {
-              if (isReferenceExpression(val.permkey)
-                && isObjectType(val.permkey.topLevelParent)
-                && isCustomRecordType(val.permkey.topLevelParent)) {
-                const custRecord = customRecordChangedMap.get(val.permkey.topLevelParent.elemID.typeName)
-                if (custRecord !== undefined) {
-                  custRecord.annotations.permissions.permission[roleName] = {
-                    permittedlevel: val.permlevel,
-                    permittedrole: roleToPermittedroleMap.get(role.elemID.getFullName()),
-                  }
-                }
-                log.debug('', custRecord)
-              } else if (_.isString(val.permkey) && regex.test(val.permkey)) {
-                const match = regex.exec(val.permkey)
-                const custRecord = match ? customRecordChangedMap.get(match[1]) : undefined
-                if (custRecord !== undefined) {
-                  custRecord.annotations.permissions.permission[roleName] = {
-                    permittedlevel: val.permlevel,
-                    permittedrole: roleToPermittedroleMap.get(role.elemID.getFullName()),
-                  }
-                }
-              }
-            })
-        }
-      })
+      addPermissionsToCustomRecordTypes(roleChanged, customRecordChangedMap, roleToPermittedroleMap)
     }
+    log.debug('')
   },
 })
 

--- a/packages/netsuite-adapter/src/filters/add_permissions_to_cutomRecord.ts
+++ b/packages/netsuite-adapter/src/filters/add_permissions_to_cutomRecord.ts
@@ -83,17 +83,6 @@ const addPermissionsToCustomRecordTypes = (
         .filter(values.isPlainRecord)
         .forEach(async val => {
           addPermissionToCustomRecordTypes(val, customRecordChangedMap, roleName, roleToPermittedroleMap)
-          // if (isReferenceExpression(val.permkey)
-          //   && isObjectType(val.permkey.topLevelParent)
-          //   && isCustomRecordType(val.permkey.topLevelParent)) {
-          //   const custRecord = customRecordChangedMap.get(val.permkey.topLevelParent.elemID.typeName)
-          //   if (custRecord !== undefined) {
-          //     custRecord.annotations.permissions.permission[roleName] = {
-          //       permittedlevel: val.permlevel,
-          //       permittedrole: roleToPermittedroleMap.get(role.elemID.getFullName()),
-          //     }
-          //   }
-          // }
         })
     }
   })

--- a/packages/netsuite-adapter/src/filters/add_permissions_to_cutomRecord.ts
+++ b/packages/netsuite-adapter/src/filters/add_permissions_to_cutomRecord.ts
@@ -1,0 +1,123 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { ElemID, ReferenceExpression, getChangeData, isInstanceChange, isObjectType, isReferenceExpression } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { logger } from '@salto-io/logging'
+import { values } from '@salto-io/lowerdash'
+import { LocalFilterCreator } from '../filter'
+import { isCustomRecordType } from '../types'
+import { ROLE, SCRIPT_ID } from '../constants'
+
+const log = logger(module)
+
+const filterCreator: LocalFilterCreator = () => ({
+  name: 'addPermissions',
+  preDeploy: async changes => {
+    const customRecordChangesList = changes
+      .map(getChangeData)
+      .filter(isObjectType)
+      .filter(isCustomRecordType)
+
+    const customRecordScriptIdsList = customRecordChangesList
+      .map(change => change.elemID.typeName)
+    const roleChanges = changes
+      .filter(isInstanceChange)
+      .map(getChangeData)
+      .filter(instance => instance.elemID.typeName === ROLE)
+    if (customRecordScriptIdsList.length !== 0 && !_.isEmpty(roleChanges)) {
+      customRecordChangesList
+        .forEach(custRecordType => {
+          if (_.isUndefined(custRecordType.annotations.permissions?.permission)) {
+            custRecordType.annotations.permissions = {
+              permission: {},
+            }
+          }
+        })
+      const regex = /^\[scriptid=(.+)\]$/
+      // for (const role of roleChanges) {
+      //   const permissionObject = role.value.permissions?.permission
+      //   if (_.isPlainObject(permissionObject)) {
+      //     for (const val of Object.values(permissionObject)) {
+      //       if (values.isPlainRecord(val)) {
+      //         if (isReferenceExpression(val.permkey)) {
+      //           if (isObjectType(val.permkey.topLevelParent)
+      //           && isCustomRecordType(val.permkey.topLevelParent)) {
+      //             val.permkey.topLevelParent
+      //               .annotations.permissions.permission[role.elemID.getFullNameParts()[0]] = {
+      //                 permittedlevel: val.permlevel,
+      //                 permittedrole: new ReferenceExpression(new ElemID(
+      //                   `${role.elemID.getFullName()}.${SCRIPT_ID}`
+      //                 )),
+      //               }
+      //             log.debug('')
+      //           }
+      //         } else if (_.isString(val.permkey) && regex.test(val.permkey)) {
+      //           const match = regex.exec(val.permkey)
+      //           const indexOfCustomRecord = match
+      //             ? customRecordScriptIdsList.findIndex(scriptid => scriptid === match[1]) : -1
+      //           if (indexOfCustomRecord !== -1) {
+      //             const roleFullNameList = role.elemID.getFullNameParts()
+      //             const roleName = roleFullNameList[roleFullNameList.length - 1]
+      //             customRecordChangesList[indexOfCustomRecord]
+      //               .annotations.permissions.permission[roleName] = {
+      //                 permittedlevel: val.permlevel,
+      //                 permittedrole: new ReferenceExpression(new ElemID(
+      //                   `${role.elemID.getFullName()}.${SCRIPT_ID}`
+      //                 )),
+      //               }
+      //           }
+      //         }
+      //       }
+      //     }
+      //   }
+      // }
+      roleChanges
+        .forEach(role => {
+          const permissionObject = role.value.permissions?.permission
+          Object.values(permissionObject)
+            .filter(values.isPlainRecord)
+            .forEach(async val => {
+              const roleFullNameList = role.elemID.getFullNameParts()
+              const roleName = roleFullNameList[roleFullNameList.length - 1]
+              if (isReferenceExpression(val.permkey)
+                && isObjectType(val.permkey.topLevelParent)
+                && isCustomRecordType(val.permkey.topLevelParent)) {
+                val.permkey.topLevelParent.annotations.permissions.permission[roleName] = {
+                  permittedlevel: val.permlevel,
+                  permittedrole: new ReferenceExpression(new ElemID(`${role.elemID.getFullName()}.${SCRIPT_ID}`)),
+                }
+                log.debug('')
+              } else if (_.isString(val.permkey) && regex.test(val.permkey)) {
+                const match = regex.exec(val.permkey)
+                const indexOfCustomRecord = match
+                  ? customRecordScriptIdsList.findIndex(scriptid => scriptid === match[1]) : -1
+                if (indexOfCustomRecord !== -1) {
+                  customRecordChangesList[indexOfCustomRecord]
+                    .annotations.permissions.permission[roleName] = {
+                      permittedlevel: val.permlevel,
+                      permittedrole: new ReferenceExpression(new ElemID(`${role.elemID.getFullName()}.${SCRIPT_ID}`)),
+                    }
+                }
+              }
+            })
+        })
+    }
+    log.debug('')
+  },
+})
+
+export default filterCreator

--- a/packages/netsuite-adapter/src/filters/add_permissions_to_cutomRecord.ts
+++ b/packages/netsuite-adapter/src/filters/add_permissions_to_cutomRecord.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-import { ElemID, ReferenceExpression, getChangeData, isInstanceChange, isObjectType, isReferenceExpression } from '@salto-io/adapter-api'
+import { ElemID, ObjectType, ReferenceExpression, getChangeData, isInstanceChange, isObjectType, isReferenceExpression } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import { values } from '@salto-io/lowerdash'
@@ -27,95 +27,151 @@ const log = logger(module)
 const filterCreator: LocalFilterCreator = () => ({
   name: 'addPermissions',
   preDeploy: async changes => {
-    const customRecordChangesList = changes
+    const customRecordChangedMap = new Map<string, ObjectType>(changes
       .map(getChangeData)
       .filter(isObjectType)
       .filter(isCustomRecordType)
+      .map(custRecord => [custRecord.elemID.typeName, custRecord]))
 
-    const customRecordScriptIdsList = customRecordChangesList
-      .map(change => change.elemID.typeName)
-    const roleChanges = changes
+    const roleChanged = changes
       .filter(isInstanceChange)
       .map(getChangeData)
       .filter(instance => instance.elemID.typeName === ROLE)
-    if (customRecordScriptIdsList.length !== 0 && !_.isEmpty(roleChanges)) {
-      customRecordChangesList
-        .forEach(custRecordType => {
-          if (_.isUndefined(custRecordType.annotations.permissions?.permission)) {
-            custRecordType.annotations.permissions = {
-              permission: {},
-            }
+
+    if (customRecordChangedMap.size > 0 && roleChanged.length > 0) {
+      customRecordChangedMap.forEach(value => {
+        if (value.annotations.permissions?.permission === undefined) {
+          value.annotations.permissions = {
+            permission: {},
           }
-        })
-      const regex = /^\[scriptid=(.+)\]$/
-      // for (const role of roleChanges) {
-      //   const permissionObject = role.value.permissions?.permission
-      //   if (_.isPlainObject(permissionObject)) {
-      //     for (const val of Object.values(permissionObject)) {
-      //       if (values.isPlainRecord(val)) {
-      //         if (isReferenceExpression(val.permkey)) {
-      //           if (isObjectType(val.permkey.topLevelParent)
-      //           && isCustomRecordType(val.permkey.topLevelParent)) {
-      //             val.permkey.topLevelParent
-      //               .annotations.permissions.permission[role.elemID.getFullNameParts()[0]] = {
-      //                 permittedlevel: val.permlevel,
-      //                 permittedrole: new ReferenceExpression(new ElemID(
-      //                   `${role.elemID.getFullName()}.${SCRIPT_ID}`
-      //                 )),
-      //               }
-      //             log.debug('')
-      //           }
-      //         } else if (_.isString(val.permkey) && regex.test(val.permkey)) {
-      //           const match = regex.exec(val.permkey)
-      //           const indexOfCustomRecord = match
-      //             ? customRecordScriptIdsList.findIndex(scriptid => scriptid === match[1]) : -1
-      //           if (indexOfCustomRecord !== -1) {
-      //             const roleFullNameList = role.elemID.getFullNameParts()
-      //             const roleName = roleFullNameList[roleFullNameList.length - 1]
-      //             customRecordChangesList[indexOfCustomRecord]
-      //               .annotations.permissions.permission[roleName] = {
-      //                 permittedlevel: val.permlevel,
-      //                 permittedrole: new ReferenceExpression(new ElemID(
-      //                   `${role.elemID.getFullName()}.${SCRIPT_ID}`
-      //                 )),
-      //               }
-      //           }
-      //         }
-      //       }
-      //     }
-      //   }
-      // }
-      roleChanges
-        .forEach(role => {
-          const permissionObject = role.value.permissions?.permission
+        }
+      })
+      roleChanged.forEach(role => {
+        const permissionObject = role.value.permissions?.permission
+        const roleFullNameList = role.elemID.getFullNameParts()
+        const roleName = roleFullNameList[roleFullNameList.length - 1]
+        const regex = /^\[scriptid=(.+)\]$/
+        if (values.isPlainRecord(permissionObject)) {
           Object.values(permissionObject)
             .filter(values.isPlainRecord)
             .forEach(async val => {
-              const roleFullNameList = role.elemID.getFullNameParts()
-              const roleName = roleFullNameList[roleFullNameList.length - 1]
               if (isReferenceExpression(val.permkey)
                 && isObjectType(val.permkey.topLevelParent)
                 && isCustomRecordType(val.permkey.topLevelParent)) {
-                val.permkey.topLevelParent.annotations.permissions.permission[roleName] = {
-                  permittedlevel: val.permlevel,
-                  permittedrole: new ReferenceExpression(new ElemID(`${role.elemID.getFullName()}.${SCRIPT_ID}`)),
+                const custRecord = customRecordChangedMap.get(val.permkey.topLevelParent.elemID.typeName)
+                if (custRecord !== undefined) {
+                  custRecord.annotations.permissions.permission[roleName] = {
+                    permittedlevel: val.permlevel,
+                    permittedrole: new ReferenceExpression(role.elemID.createNestedID(SCRIPT_ID)),
+                  }
                 }
-                log.debug('')
+                log.debug('', custRecord)
               } else if (_.isString(val.permkey) && regex.test(val.permkey)) {
                 const match = regex.exec(val.permkey)
-                const indexOfCustomRecord = match
-                  ? customRecordScriptIdsList.findIndex(scriptid => scriptid === match[1]) : -1
-                if (indexOfCustomRecord !== -1) {
-                  customRecordChangesList[indexOfCustomRecord]
-                    .annotations.permissions.permission[roleName] = {
-                      permittedlevel: val.permlevel,
-                      permittedrole: new ReferenceExpression(new ElemID(`${role.elemID.getFullName()}.${SCRIPT_ID}`)),
-                    }
+                const custRecord = match ? customRecordChangedMap.get(match[1]) : undefined
+                if (custRecord !== undefined) {
+                  custRecord.annotations.permissions.permission[roleName] = {
+                    permittedlevel: val.permlevel,
+                    permittedrole: new ReferenceExpression(new ElemID(`${role.elemID.getFullName()}.${SCRIPT_ID}`)),
+                  }
                 }
               }
+              log.debug('')
             })
-        })
+        }
+      })
     }
+
+
+    // const customRecordChangesList = changes
+    //   .map(getChangeData)
+    //   .filter(isObjectType)
+    //   .filter(isCustomRecordType)
+
+    // const customRecordScriptIdsList = customRecordChangesList
+    //   .map(change => change.elemID.typeName)
+    // const roleChanges = changes
+    //   .filter(isInstanceChange)
+    //   .map(getChangeData)
+    //   .filter(instance => instance.elemID.typeName === ROLE)
+    // if (customRecordScriptIdsList.length !== 0 && !_.isEmpty(roleChanges)) {
+    //   customRecordChangesList
+    //     .forEach(custRecordType => {
+    //       if (_.isUndefined(custRecordType.annotations.permissions?.permission)) {
+    //         custRecordType.annotations.permissions = {
+    //           permission: {},
+    //         }
+    //       }
+    //     })
+    //   // for (const role of roleChanges) {
+    //   //   const permissionObject = role.value.permissions?.permission
+    //   //   if (_.isPlainObject(permissionObject)) {
+    //   //     for (const val of Object.values(permissionObject)) {
+    //   //       if (values.isPlainRecord(val)) {
+    //   //         if (isReferenceExpression(val.permkey)) {
+    //   //           if (isObjectType(val.permkey.topLevelParent)
+    //   //           && isCustomRecordType(val.permkey.topLevelParent)) {
+    //   //             val.permkey.topLevelParent
+    //   //               .annotations.permissions.permission[role.elemID.getFullNameParts()[0]] = {
+    //   //                 permittedlevel: val.permlevel,
+    //   //                 permittedrole: new ReferenceExpression(new ElemID(
+    //   //                   `${role.elemID.getFullName()}.${SCRIPT_ID}`
+    //   //                 )),
+    //   //               }
+    //   //             log.debug('')
+    //   //           }
+    //   //         } else if (_.isString(val.permkey) && regex.test(val.permkey)) {
+    //   //           const match = regex.exec(val.permkey)
+    //   //           const indexOfCustomRecord = match
+    //   //             ? customRecordScriptIdsList.findIndex(scriptid => scriptid === match[1]) : -1
+    //   //           if (indexOfCustomRecord !== -1) {
+    //   //             const roleFullNameList = role.elemID.getFullNameParts()
+    //   //             const roleName = roleFullNameList[roleFullNameList.length - 1]
+    //   //             customRecordChangesList[indexOfCustomRecord]
+    //   //               .annotations.permissions.permission[roleName] = {
+    //   //                 permittedlevel: val.permlevel,
+    //   //                 permittedrole: new ReferenceExpression(new ElemID(
+    //   //                   `${role.elemID.getFullName()}.${SCRIPT_ID}`
+    //   //                 )),
+    //   //               }
+    //   //           }
+    //   //         }
+    //   //       }
+    //   //     }
+    //   //   }
+    //   // }
+    //   roleChanges
+    //     .forEach(role => {
+    //       const permissionObject = role.value.permissions?.permission
+    //       Object.values(permissionObject)
+    //         .filter(values.isPlainRecord)
+    //         .forEach(async val => {
+    //           const roleFullNameList = role.elemID.getFullNameParts()
+    //           const roleName = roleFullNameList[roleFullNameList.length - 1]
+    //           if (isReferenceExpression(val.permkey)
+    //             && isObjectType(val.permkey.topLevelParent)
+    //             && isCustomRecordType(val.permkey.topLevelParent)) {
+    //             val.permkey.topLevelParent.annotations.permissions.permission[roleName] = {
+    //               permittedlevel: val.permlevel,
+    //               permittedrole: new ReferenceExpression(new ElemID(`${role.elemID.getFullName()}.${SCRIPT_ID}`)),
+    //             }
+    //             log.debug('')
+    //           } else if (_.isString(val.permkey) && regex.test(val.permkey)) {
+    //             const match = regex.exec(val.permkey)
+    //             const indexOfCustomRecord = match
+    //               ? customRecordScriptIdsList.findIndex(scriptid => scriptid === match[1]) : -1
+    //             if (indexOfCustomRecord !== -1) {
+    //               customRecordChangesList[indexOfCustomRecord]
+    //                 .annotations.permissions.permission[roleName] = {
+    //                   permittedlevel: val.permlevel,
+    //                   permittedrole:
+    //                     new ReferenceExpression(new ElemID(`${role.elemID.getFullName()}.${SCRIPT_ID}`)),
+    //                 }
+    //             }
+    //           }
+    //         })
+    //     })
+    // }
     log.debug('')
   },
 })

--- a/packages/netsuite-adapter/src/filters/add_permissions_to_cutomRecord.ts
+++ b/packages/netsuite-adapter/src/filters/add_permissions_to_cutomRecord.ts
@@ -15,13 +15,11 @@
 */
 
 import { InstanceElement, ObjectType, ReadOnlyElementsSource, ReferenceExpression, getChangeData, isInstanceChange, isObjectType, isReferenceExpression } from '@salto-io/adapter-api'
-import { logger } from '@salto-io/logging'
 import { values, collections } from '@salto-io/lowerdash'
 import { LocalFilterCreator } from '../filter'
 import { isCustomRecordType } from '../types'
 import { ROLE, SCRIPT_ID } from '../constants'
 
-const log = logger(module)
 const { awu } = collections.asynciterable
 
 const addPermissionField = (custRecordMap: Map<string, ObjectType>): void =>
@@ -51,7 +49,7 @@ const createRoleToPermittedroleMap = async (
       .toArray()
   )
 
-const addPermissionToCustomRecordTypes = (
+const addPermission = (
   val: Record<string, unknown>,
   customRecordChangedMap: Map<string, ObjectType>,
   roleName: string,
@@ -69,6 +67,7 @@ const addPermissionToCustomRecordTypes = (
     }
   }
 }
+
 const addPermissionsToCustomRecordTypes = (
   roles: InstanceElement[],
   customRecordChangedMap: Map<string, ObjectType>,
@@ -82,7 +81,7 @@ const addPermissionsToCustomRecordTypes = (
       Object.values(permissionObject)
         .filter(values.isPlainRecord)
         .forEach(async val => {
-          addPermissionToCustomRecordTypes(val, customRecordChangedMap, roleName, roleToPermittedroleMap)
+          addPermission(val, customRecordChangedMap, roleName, roleToPermittedroleMap)
         })
     }
   })
@@ -108,7 +107,6 @@ const filterCreator: LocalFilterCreator = ({ elementsSource }) => ({
 
       addPermissionsToCustomRecordTypes(roleChanged, customRecordChangedMap, roleToPermittedroleMap)
     }
-    log.debug('')
   },
 })
 

--- a/packages/netsuite-adapter/test/client/client.test.ts
+++ b/packages/netsuite-adapter/test/client/client.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ElemID, InstanceElement, ObjectType, toChange, Change, BuiltinTypes, getChangeData } from '@salto-io/adapter-api'
+import { ElemID, InstanceElement, ObjectType, toChange, Change, BuiltinTypes, getChangeData, ReferenceExpression } from '@salto-io/adapter-api'
 import SuiteAppClient from '../../src/client/suiteapp_client/suiteapp_client'
 import SdfClient from '../../src/client/sdf_client'
 import NetsuiteClient from '../../src/client/client'
@@ -26,6 +26,7 @@ import { FeaturesDeployError, ManifestValidationError, MissingManifestFeaturesEr
 import { AdditionalDependencies } from '../../src/config'
 import { Graph, GraphNode } from '../../src/client/graph_utils'
 import { SDFObjectNode } from '../../src/client/types'
+import { roleType } from '../../src/autogen/types/standard_types/role'
 
 describe('NetsuiteClient', () => {
   describe('with SDF client', () => {
@@ -55,7 +56,69 @@ describe('NetsuiteClient', () => {
         jest.resetAllMocks()
         deployParams[0].include.features = []
       })
+      describe('Dependency graph and map', () => {
+        const type = new ObjectType({ elemID: new ElemID(NETSUITE, 'type') })
+        const instanceWithRef1 = new InstanceElement('instanceWithRef1', type, { scriptid: 'instanceWithRef1' })
+        const instanceWithRef2 = new InstanceElement('instanceWithRef2', type, { scriptid: 'instanceWithRef2', ref: new ReferenceExpression(instanceWithRef1.elemID) })
+        instanceWithRef1.value.ref = new ReferenceExpression(instanceWithRef2.elemID)
 
+        const customRecord = new ObjectType({
+          elemID: new ElemID(NETSUITE, 'customrecord_1'),
+          annotations: {
+            scriptid: 'customrecord_1',
+            [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
+            permissions: {
+              permission: {
+                ref: '[scriptid=customrole_with_ref]',
+              },
+            },
+          },
+        })
+        const roleWithRef = new InstanceElement(
+          'customrole_with_ref',
+          roleType().type,
+          {
+            scriptid: 'customrole_with_ref',
+            ref: '[scriptid=customrecord_1]',
+          },
+        )
+        it('should build a map and a graph with an edge role->customrecord when given new role and existing custom record ', async () => {
+          const mapAndGraph = await NetsuiteClient.createDependencyMapAndGraph([
+            toChange({ after: roleWithRef }),
+            toChange({ before: customRecord, after: customRecord }),
+          ])
+          const { dependencyMap, dependencyGraph } = mapAndGraph
+          expect(dependencyMap.get(roleWithRef.elemID.getFullName())?.has('customrecord_1'))
+            .toBeTruthy()
+          expect(dependencyGraph.nodes.get(roleWithRef.elemID.getFullName())?.edges.size).toEqual(1)
+          expect(dependencyGraph.nodes.get(roleWithRef.elemID.getFullName())?.edges
+            .get(customRecord.elemID.getFullName())).not.toBeUndefined()
+        })
+        it('should build a map and a graph with an edge role->customrecord when given new role and new custom record ', async () => {
+          const mapAndGraph = await NetsuiteClient.createDependencyMapAndGraph([
+            toChange({ after: roleWithRef }),
+            toChange({ after: customRecord }),
+          ])
+          const { dependencyMap, dependencyGraph } = mapAndGraph
+          expect(dependencyMap.get(roleWithRef.elemID.getFullName())?.has('customrecord_1'))
+            .toBeTruthy()
+          expect(dependencyGraph.nodes.get(roleWithRef.elemID.getFullName())?.edges.size).toEqual(1)
+          expect(dependencyGraph.nodes.get(roleWithRef.elemID.getFullName())?.edges
+            .get(customRecord.elemID.getFullName())).not.toBeUndefined()
+        })
+        it('should build a map and a graph with an edge role->customrecord when given existing role and new custom record ', async () => {
+          const mapAndGraph = await NetsuiteClient.createDependencyMapAndGraph([
+            toChange({ before: roleWithRef, after: roleWithRef }),
+            toChange({ after: customRecord }),
+          ])
+          const { dependencyMap, dependencyGraph } = mapAndGraph
+          expect(dependencyMap.get(roleWithRef.elemID.getFullName())?.has('customrecord_1'))
+            .toBeTruthy()
+          expect(dependencyGraph.nodes.get(roleWithRef.elemID.getFullName())?.edges.size).toEqual(1)
+          expect(dependencyGraph.nodes.get(roleWithRef.elemID.getFullName())?.edges
+            .get(customRecord.elemID.getFullName())).not.toBeUndefined()
+        })
+      })
       it('should try again to deploy after ObjectsDeployError', async () => {
         const type = new ObjectType({ elemID: new ElemID(NETSUITE, 'type') })
         const failedObjectsMap = new Map([['failedObject', [{ message: 'error' }]]])

--- a/packages/netsuite-adapter/test/filters/add_permissions_to_customRecord.test.ts
+++ b/packages/netsuite-adapter/test/filters/add_permissions_to_customRecord.test.ts
@@ -1,0 +1,202 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { ElemID, InstanceElement, ObjectType, ReadOnlyElementsSource, ReferenceExpression, getChangeData, isAdditionChange, toChange } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { isPlainObject } from 'lodash'
+import { roleType } from '../../src/autogen/types/standard_types/role'
+import { CUSTOM_RECORD_TYPE, METADATA_TYPE, NETSUITE, SCRIPT_ID } from '../../src/constants'
+import filterCreator from '../../src/filters/add_permissions_to_cutomRecord'
+import { LocalFilterOpts } from '../../src/filter'
+
+const log = logger(module)
+
+describe('add permissions to custom record types filter', () => {
+  let customRecord: ObjectType
+  let customRecordWithPermissionsField: ObjectType
+  let roleWithoutPermission: InstanceElement
+  let roleWithIrrelevantPermission: InstanceElement
+  let roleWithPermission: InstanceElement
+  let otherRoleWithPermission: InstanceElement
+  let elementsSource: ReadOnlyElementsSource
+  let referenceToCustomRecord: ReferenceExpression
+  let referenceToCustomRecordWithPermissions: ReferenceExpression
+  let referenceToRoleWithPermission: ReferenceExpression
+  let referenceToOtherRoleWithPermission: ReferenceExpression
+
+  beforeEach(() => {
+    customRecord = new ObjectType({
+      elemID: new ElemID(NETSUITE, 'customRecord'),
+      annotations: {
+        scriptid: 'custom_record_field',
+        [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
+      },
+    })
+    customRecordWithPermissionsField = new ObjectType({
+      elemID: new ElemID(NETSUITE, 'customRecordWithPermissions'),
+      annotations: {
+        scriptid: 'custom_record_with_permissions_field',
+        [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
+        permissions: {
+          permission: {
+          },
+        },
+      },
+    })
+    roleWithoutPermission = new InstanceElement('role_without_permission', roleType().type, {
+      scriptid: 'customrole_withoutPermission',
+    })
+    roleWithIrrelevantPermission = new InstanceElement('role_with_irrelevant_permission', roleType().type, {
+      scriptid: 'customrole_withIrrelevantPermission',
+      permissions: {
+        permission: {
+          TRAN_PAYMENTAUDIT: {
+            permkey: 'TRAN_PAYMENTAUDIT',
+            permlevel: 'EDIT',
+          },
+        },
+      },
+    })
+
+    referenceToCustomRecord = new ReferenceExpression(customRecord.elemID.createNestedID('attr', SCRIPT_ID))
+    referenceToCustomRecord.topLevelParent = customRecord
+
+    referenceToCustomRecordWithPermissions = new ReferenceExpression(customRecordWithPermissionsField.elemID.createNestedID('attr', SCRIPT_ID))
+    referenceToCustomRecordWithPermissions.topLevelParent = customRecordWithPermissionsField
+
+    roleWithPermission = new InstanceElement('role_with_permission', roleType().type, {
+      scriptid: 'customrole_withPermission',
+      permissions: {
+        permission: {
+          customRecord: {
+            permkey: referenceToCustomRecord,
+            permlevel: 'EDIT',
+          },
+        },
+      },
+    })
+    otherRoleWithPermission = new InstanceElement('other_role_with_permission', roleType().type, {
+      scriptid: 'customrole_otherWithPermission',
+      permissions: {
+        permission: {
+          customRecord: {
+            permkey: referenceToCustomRecord,
+            permlevel: 'EDIT',
+          },
+          customRecordWithPermissionsField: {
+            permkey: referenceToCustomRecordWithPermissions,
+            permlevel: 'EDIT',
+          },
+        },
+      },
+    })
+
+    referenceToRoleWithPermission = new ReferenceExpression(roleWithPermission.elemID.createNestedID(SCRIPT_ID))
+    referenceToRoleWithPermission.topLevelParent = roleWithPermission
+
+    referenceToOtherRoleWithPermission = new ReferenceExpression(
+      otherRoleWithPermission.elemID.createNestedID(SCRIPT_ID)
+    )
+    referenceToOtherRoleWithPermission.topLevelParent = otherRoleWithPermission
+
+    customRecordWithPermissionsField.annotations.permissions.permission.roleWithPermission = {
+      permittedlevel: 'EDIT',
+      permittedrole: referenceToRoleWithPermission,
+    }
+    elementsSource = buildElementsSourceFromElements([
+      customRecord,
+      customRecordWithPermissionsField,
+      roleWithoutPermission,
+      roleWithIrrelevantPermission,
+      roleWithPermission,
+      otherRoleWithPermission,
+    ])
+  })
+  it('should not add custom record to the deployment', async () => {
+    const changes = [
+      toChange({ before: roleWithoutPermission, after: roleWithPermission }),
+      toChange({ after: otherRoleWithPermission }),
+    ]
+    await filterCreator({ elementsSource } as LocalFilterOpts).preDeploy?.(changes)
+    expect(changes.length).toEqual(2)
+  })
+  it('should not add permissions to custom record if there are no roles in the deployment', async () => {
+    const changes = [
+      toChange({ after: customRecord }),
+      toChange({ after: customRecordWithPermissionsField }),
+    ]
+    await filterCreator({ elementsSource } as LocalFilterOpts).preDeploy?.(changes)
+    expect(changes.length).toEqual(2)
+    const permissionsOfChange0 = getChangeData(changes[0]).annotations.permissions?.permission
+    expect(permissionsOfChange0 === undefined
+      || (isPlainObject(permissionsOfChange0) && Object.keys(permissionsOfChange0).length === 0)).toBeTruthy()
+    const permissionsOfChange1 = getChangeData(changes[1]).annotations.permissions?.permission
+    expect(isPlainObject(permissionsOfChange1) && Object.keys(permissionsOfChange1).length === 1).toBeTruthy()
+  })
+  it('should not add permissions to custom record if there are no roles with permission related to the custom record', async () => {
+    const changes = [
+      toChange({ after: customRecordWithPermissionsField }),
+      toChange({ after: roleWithoutPermission }),
+      toChange({ after: roleWithIrrelevantPermission }),
+      toChange({ after: roleWithPermission }), // the permission in this role is for the other custom record
+    ]
+    await filterCreator({ elementsSource } as LocalFilterOpts).preDeploy?.(changes)
+    expect(changes.length).toEqual(4)
+    const permissionsOfChange0 = isAdditionChange(changes[0])
+      ? changes[0].data.after?.annotations.permissions?.permission
+      : undefined
+    expect(isPlainObject(permissionsOfChange0) && Object.keys(permissionsOfChange0).length === 1).toBeTruthy()
+  })
+  it('should add permissions to custom record if there is a role with permission related to the custom record', async () => {
+    const changes = [
+      toChange({ after: customRecord }),
+      toChange({ after: customRecordWithPermissionsField }),
+      toChange({ after: roleWithPermission }),
+      toChange({ after: otherRoleWithPermission }),
+    ]
+    await filterCreator({ elementsSource } as LocalFilterOpts).preDeploy?.(changes)
+    expect(changes.length).toEqual(4)
+
+    const permissionsOfChange0 = isAdditionChange(changes[0])
+      ? changes[0].data.after?.annotations.permissions?.permission
+      : undefined
+    expect(isPlainObject(permissionsOfChange0)).toBeTruthy()
+    expect(Object.keys(permissionsOfChange0).length).toEqual(2)
+    expect(Object.values(permissionsOfChange0)[0]).toEqual({
+      permittedlevel: 'EDIT',
+      permittedrole: referenceToRoleWithPermission,
+    })
+    expect(Object.values(permissionsOfChange0)[1]).toEqual({
+      permittedlevel: 'EDIT',
+      permittedrole: referenceToOtherRoleWithPermission,
+    })
+    const permissionsOfChange1 = isAdditionChange(changes[1])
+      ? changes[1].data.after?.annotations.permissions?.permission
+      : undefined
+    expect(isPlainObject(permissionsOfChange1)).toBeTruthy()
+    expect(Object.keys(permissionsOfChange1).length).toEqual(2)
+    expect(Object.values(permissionsOfChange1)[0]).toEqual({
+      permittedlevel: 'EDIT',
+      permittedrole: referenceToRoleWithPermission,
+    })
+    expect(Object.values(permissionsOfChange1)[1]).toEqual({
+      permittedlevel: 'EDIT',
+      permittedrole: referenceToOtherRoleWithPermission,
+    })
+  })
+  log.debug('')
+})


### PR DESCRIPTION
_Adding relevant permissions to the custom record types that are being deployed_

---

_When deploying a role and a custom record, if the role have a reference to the custom record in the permissions, the custom record type has to have a reference to the role in it's permissions (and vice versa).
In this ticket: https://salto-io.atlassian.net/browse/SALTO-3402 we decided to not fetch permissions from custom record types by default.

Ticket: https://salto-io.atlassian.net/browse/SALTO-4142_

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
