### PR TITLE
SALTO-4863 create path index for element

### DIFF
--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -30,7 +30,7 @@ import {
 } from '@salto-io/adapter-api'
 import { applyInstancesDefaults, resolvePath, flattenElementStr, buildElementsSourceFromElements, safeJsonStringify, walkOnElement, WalkOnFunc, WALK_NEXT_STEP, setPath, walkOnValue } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
-import { merger, elementSource, expressions, Workspace, pathIndex, updateElementsWithAlternativeAccount, createAdapterReplacedID, remoteMap, adaptersConfigSource as acs } from '@salto-io/workspace'
+import { merger, elementSource, expressions, Workspace, pathIndex, updateElementsWithAlternativeAccount, createAdapterReplacedID, remoteMap, adaptersConfigSource as acs, createPathIndexForElement } from '@salto-io/workspace'
 import { collections, promises, types, values } from '@salto-io/lowerdash'
 import { isAutoMergeDisabled } from '../app_config'
 import { StepEvents } from './deploy'
@@ -1068,7 +1068,7 @@ export const fetchChangesFromWorkspace = async (
     (await withLimitedConcurrency(
       wu(unmergedWithoutPath).map(elem => async () =>
         pathIndex.splitElementByPath(
-          elem, await pathIndex.createPathIndexForElement(otherWorkspace, elem.elemID)
+          elem, await createPathIndexForElement(otherWorkspace, elem.elemID)
         )),
       MAX_SPLIT_CONCURRENCY
     )).flat(), 'Splitting elements by files')

--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -44,6 +44,7 @@ import { RemoteElementSource, ElementsSource } from './src/workspace/elements_so
 import { FromSource } from './src/workspace/nacl_files/multi_env/multi_env_source'
 import { State } from './src/workspace/state'
 import { PathIndex, splitElementByPath, getElementsPathHints, filterByPathHint } from './src/workspace/path_index'
+import { createPathIndexForElement } from './src/path_index_fallbacks'
 
 export {
   errors,
@@ -101,4 +102,5 @@ export {
   updateElementsWithAlternativeAccount,
   createAdapterReplacedID,
   Author,
+  createPathIndexForElement,
 }

--- a/packages/workspace/src/path_index_fallbacks.ts
+++ b/packages/workspace/src/path_index_fallbacks.ts
@@ -21,6 +21,7 @@ import { PathIndex, Path, updatePathIndex } from './workspace/path_index'
 
 const { awu } = collections.asynciterable
 
+// this function can be removed when we do the fragment refactor (SALTO-2217)
 export const createPathIndexForElement = async (
   workspace: Workspace,
   id: ElemID

--- a/packages/workspace/src/path_index_fallbacks.ts
+++ b/packages/workspace/src/path_index_fallbacks.ts
@@ -1,0 +1,41 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { InMemoryRemoteMap } from './workspace/remote_map'
+import { Workspace } from './workspace/workspace'
+import { PathIndex, Path, updatePathIndex } from './workspace/path_index'
+
+const { awu } = collections.asynciterable
+
+export const createPathIndexForElement = async (
+  workspace: Workspace,
+  id: ElemID
+): Promise<PathIndex> => {
+  const { parent } = id.createTopLevelParentID()
+  const elementNaclFiles = await workspace.getElementNaclFiles(parent)
+  const naclFragments = await awu(elementNaclFiles)
+    .map(workspace.getParsedNaclFile)
+    .flatMap(async parsedFile => await parsedFile?.elements() ?? [])
+    .filter(elem => elem.elemID.isEqual(parent))
+    .toArray()
+  const naclPathIndex = new InMemoryRemoteMap<Path[]>()
+  await updatePathIndex({
+    pathIndex: naclPathIndex,
+    unmergedElements: naclFragments,
+  })
+  return naclPathIndex
+}

--- a/packages/workspace/test/common/workspace.ts
+++ b/packages/workspace/test/common/workspace.ts
@@ -1,0 +1,135 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { Element, Values } from '@salto-io/adapter-api'
+import { MockInterface, mockFunction } from '@salto-io/test-utils'
+import { Errors } from '../../src/errors'
+import { AdaptersConfigSource } from '../../src/workspace/adapters_config_source'
+import { ConfigSource } from '../../src/workspace/config_source'
+import { DirectoryStore } from '../../src/workspace/dir_store'
+import { createInMemoryElementSource } from '../../src/workspace/elements_source'
+import { naclFilesSource } from '../../src/workspace/nacl_files'
+import { Path } from '../../src/workspace/path_index'
+import { InMemoryRemoteMap, RemoteMapCreator } from '../../src/workspace/remote_map'
+import { State, buildInMemState } from '../../src/workspace/state'
+import { StaticFilesSource } from '../../src/workspace/static_files'
+import { EnvironmentSource, Workspace, loadWorkspace } from '../../src/workspace/workspace'
+import { WorkspaceConfigSource } from '../../src/workspace/workspace_config_source'
+import { mockStaticFilesSource, persistentMockCreateRemoteMap } from '../utils'
+import { createMockNaclFileSource } from './nacl_file_source'
+import { mockDirStore } from './nacl_file_store'
+
+const services = ['salesforce']
+export const mockWorkspaceConfigSource = (conf?: Values,
+  secondaryEnv?: boolean): WorkspaceConfigSource => ({
+  getWorkspaceConfig: jest.fn().mockImplementation(() => ({
+    envs: [
+      { name: 'default',
+        accounts: services,
+        accountToServiceName: Object.fromEntries(services.map(service => [service, service])) },
+      ...(secondaryEnv ? [{ name: 'inactive',
+        accounts: [...services, 'netsuite'],
+        accountToServiceName: { netsuite: 'netsuite',
+          ...Object.fromEntries(services.map(service => [service, service])) } }] : []),
+    ],
+    uid: '',
+    name: 'test',
+    currentEnv: 'default',
+    ...conf,
+  })),
+  setWorkspaceConfig: jest.fn(),
+})
+
+export const mockAdaptersConfigSource = (): MockInterface<AdaptersConfigSource> => ({
+  getAdapter: mockFunction<AdaptersConfigSource['getAdapter']>(),
+  setAdapter: mockFunction<AdaptersConfigSource['setAdapter']>(),
+  getElementNaclFiles: mockFunction<AdaptersConfigSource['getElementNaclFiles']>(),
+  getErrors: mockFunction<AdaptersConfigSource['getErrors']>().mockResolvedValue(new Errors({
+    parse: [],
+    validation: [],
+    merge: [],
+  })),
+  getSourceRanges: mockFunction<AdaptersConfigSource['getSourceRanges']>().mockResolvedValue([]),
+  getNaclFile: mockFunction<AdaptersConfigSource['getNaclFile']>(),
+  setNaclFiles: mockFunction<AdaptersConfigSource['setNaclFiles']>(),
+  flush: mockFunction<AdaptersConfigSource['flush']>(),
+  getElements: mockFunction<AdaptersConfigSource['getElements']>(),
+  getParsedNaclFile: mockFunction<AdaptersConfigSource['getParsedNaclFile']>(),
+  getSourceMap: mockFunction<AdaptersConfigSource['getSourceMap']>(),
+  listNaclFiles: mockFunction<AdaptersConfigSource['listNaclFiles']>(),
+  isConfigFile: mockFunction<AdaptersConfigSource['isConfigFile']>(),
+})
+
+export const mockCredentialsSource = (): ConfigSource => ({
+  get: jest.fn(),
+  set: jest.fn(),
+  delete: jest.fn(),
+  rename: jest.fn(),
+})
+
+
+export const createState = (
+  elements: Element[],
+  persistent = true
+): State => buildInMemState(async () => ({
+  elements: createInMemoryElementSource(elements),
+  pathIndex: new InMemoryRemoteMap<Path[]>(),
+  topLevelPathIndex: new InMemoryRemoteMap<Path[]>(),
+  referenceSources: new InMemoryRemoteMap(),
+  accountsUpdateDate: new InMemoryRemoteMap(),
+  changedBy: new InMemoryRemoteMap([{ key: 'name@@account', value: ['elemId'] }]),
+  saltoMetadata: new InMemoryRemoteMap([{ key: 'version', value: '0.0.1' }]),
+  staticFilesSource: mockStaticFilesSource(),
+}), persistent)
+
+export const createWorkspace = async (
+  dirStore?: DirectoryStore<string>,
+  state?: State,
+  configSource?: WorkspaceConfigSource,
+  adaptersConfigSource?: AdaptersConfigSource,
+  credentials?: ConfigSource,
+  staticFilesSource?: StaticFilesSource,
+  elementSources?: Record<string, EnvironmentSource>,
+  remoteMapCreator?: RemoteMapCreator,
+  persistent = true
+): Promise<Workspace> => {
+  const mapCreator = remoteMapCreator ?? persistentMockCreateRemoteMap()
+  const actualStaticFilesSource = staticFilesSource || mockStaticFilesSource()
+  return loadWorkspace(
+    configSource || mockWorkspaceConfigSource(),
+    adaptersConfigSource || mockAdaptersConfigSource(),
+    credentials || mockCredentialsSource(),
+    {
+      commonSourceName: '',
+      sources: elementSources || {
+        '': {
+          naclFiles: await naclFilesSource(
+            '',
+            dirStore || mockDirStore(),
+            actualStaticFilesSource,
+            mapCreator,
+            persistent
+          ),
+        },
+        default: {
+          naclFiles: createMockNaclFileSource([]),
+          state: state ?? createState([], persistent),
+        },
+      },
+    },
+    mapCreator,
+  )
+}

--- a/packages/workspace/test/path_index_fallbacks.test.ts
+++ b/packages/workspace/test/path_index_fallbacks.test.ts
@@ -1,0 +1,83 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  ElemID,
+} from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { Workspace } from '../src/workspace/workspace'
+import { mockDirStore } from './common/nacl_file_store'
+import { createWorkspace } from './common/workspace'
+import { createPathIndexForElement } from '../src/path_index_fallbacks'
+
+const { awu } = collections.asynciterable
+
+describe('createPathIndexForElement', () => {
+  let workspace: Workspace
+  const firstFile = `
+    type salesforce.text is string {}
+    type salesforce.lead {
+      salesforce.text singleDef {
+
+      }
+      salesforce.text multiDef {
+
+      }
+    }
+  `
+  const secondFile = `
+    type salesforce.lead {
+      salesforce.text multiDef {
+
+      }
+    }
+  `
+
+  const redHeringFile = `
+    type salesforce.hearing {
+      salesforce.text multiDef {
+
+      }
+    }
+  `
+  const naclFileStore = mockDirStore(undefined, undefined, {
+    'firstFile.nacl': firstFile,
+    'secondFile.nacl': secondFile,
+    'redHeringFile.nacl': redHeringFile,
+  })
+
+  const expected = [
+    { key: 'salesforce.lead', value: [['firstFile'], ['secondFile']] },
+    { key: 'salesforce.lead.field', value: [['firstFile'], ['secondFile']] },
+    { key: 'salesforce.lead.field.multiDef', value: [['firstFile'], ['secondFile']] },
+    { key: 'salesforce.lead.field.singleDef', value: [['firstFile']] },
+  ]
+
+  beforeAll(async () => {
+    workspace = await createWorkspace(naclFileStore)
+  })
+  it('should create path index for a top level id', async () => {
+    const id = ElemID.fromFullName('salesforce.lead')
+    const res = await awu((await createPathIndexForElement(workspace, id)).entries()).toArray()
+    expect(res).toHaveLength(expected.length)
+    expect(res).toEqual(expect.arrayContaining(expected))
+  })
+  it('should create the same path index for a nested id', async () => {
+    const id = ElemID.fromFullName('salesforce.lead.field.singleDef')
+    const res = await awu((await createPathIndexForElement(workspace, id)).entries()).toArray()
+    expect(res).toHaveLength(expected.length)
+    expect(res).toEqual(expect.arrayContaining(expected))
+  })
+})


### PR DESCRIPTION
extract into a workspace API the code that we use in fetch-from-workspace for creating a path index for elements that aren’t in the state.

NOTE: this API can be removed when we do the fragment refactor.

---

_Additional context for reviewer_

---
_Release Notes_: 
Workspace:
- create path index for element API

---
_User Notifications_: 
None