### PR TITLE
SALTO-4757 enable auto-merge by default

### DIFF
--- a/packages/core/src/app_config.ts
+++ b/packages/core/src/app_config.ts
@@ -58,8 +58,8 @@ const telemetryDisabled = (): boolean => (
     && process.env.SALTO_TELEMETRY_DISABLE === '1') || telemetryURL() === ''
 )
 
-export const isAutoMergeEnabled = (): boolean => (
-  process.env.SALTO_FETCH_AUTO_MERGE === '1'
+export const isAutoMergeDisabled = (): boolean => (
+  process.env.SALTO_AUTO_MERGE_DISABLE === '1'
 )
 
 const DEFAULT_TELEMETRY_CONFIG: TelemetryConfig = {

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -32,7 +32,7 @@ import { applyInstancesDefaults, resolvePath, flattenElementStr, buildElementsSo
 import { logger } from '@salto-io/logging'
 import { merger, elementSource, expressions, Workspace, pathIndex, updateElementsWithAlternativeAccount, createAdapterReplacedID, remoteMap, adaptersConfigSource as acs } from '@salto-io/workspace'
 import { collections, promises, types, values } from '@salto-io/lowerdash'
-import { isAutoMergeEnabled } from '../app_config'
+import { isAutoMergeDisabled } from '../app_config'
 import { StepEvents } from './deploy'
 import { getPlan, Plan } from './plan'
 import { AdapterEvents, createAdapterProgressReporter } from './adapters/progress'
@@ -202,7 +202,7 @@ const toMergedTextChange = (change: FetchChange, after: string | StaticFile): Fe
 })
 
 const autoMergeTextChange: ChangeTransformFunction = async change => {
-  if (!isAutoMergeEnabled() || !isMergeableDiffChange(change)) {
+  if (isAutoMergeDisabled() || !isMergeableDiffChange(change)) {
     return [change]
   }
 

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -877,29 +877,7 @@ describe('fetch', () => {
         )
         describe('when auto merge is disabled', () => {
           beforeEach(async () => {
-            mockAdapters[testID.adapter].fetch.mockResolvedValueOnce(
-              Promise.resolve({ elements: [serviceInstance] })
-            )
-            const result = await fetchChanges(
-              mockAdapters,
-              createElementSource([workspaceInstance]),
-              createElementSource([stateInstance]),
-              { [testID.adapter]: 'dummy' },
-              [],
-            )
-            changes = [...result.changes]
-          })
-          it('should calculate fetch changes', () => {
-            expect(changes).toHaveLength(5)
-          })
-          it('should not merge any change', () => {
-            expect(changes.every(change => isModificationChange(change.change)
-              && _.isEqual(change.change.data.after, allValues.serviceValue))).toBeTrue()
-          })
-        })
-        describe('when auto merge is enabled', () => {
-          beforeEach(async () => {
-            process.env.SALTO_FETCH_AUTO_MERGE = '1'
+            process.env.SALTO_AUTO_MERGE_DISABLE = '1'
             mockAdapters[testID.adapter].fetch.mockResolvedValueOnce(
               Promise.resolve({ elements: [serviceInstance] })
             )
@@ -913,7 +891,29 @@ describe('fetch', () => {
             changes = [...result.changes]
           })
           afterEach(() => {
-            delete process.env.SALTO_FETCH_AUTO_MERGE
+            delete process.env.SALTO_AUTO_MERGE_DISABLE
+          })
+          it('should calculate fetch changes', () => {
+            expect(changes).toHaveLength(5)
+          })
+          it('should not merge any change', () => {
+            expect(changes.every(change => isModificationChange(change.change)
+              && _.isEqual(change.change.data.after, allValues.serviceValue))).toBeTrue()
+          })
+        })
+        describe('when auto merge is enabled', () => {
+          beforeEach(async () => {
+            mockAdapters[testID.adapter].fetch.mockResolvedValueOnce(
+              Promise.resolve({ elements: [serviceInstance] })
+            )
+            const result = await fetchChanges(
+              mockAdapters,
+              createElementSource([workspaceInstance]),
+              createElementSource([stateInstance]),
+              { [testID.adapter]: 'dummy' },
+              [],
+            )
+            changes = [...result.changes]
           })
           it('should calculate fetch changes', () => {
             expect(changes).toHaveLength(5)


### PR DESCRIPTION
Change the default behavior of auto-merge - disable only when `SALTO_AUTO_MERGE_DISABLE=1`.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
