### PR TITLE
SALTO-4854: Fetch WorkflowStatuses

### DIFF
--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1791,6 +1791,13 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
   RequestType: {
     request: {
       url: '/rest/servicedeskapi/servicedesk/{serviceDeskId}/requesttype',
+      recurseInto: [
+        {
+          type: 'RequestType__workflowStatuses',
+          toField: 'workflowStatuses',
+          context: [{ name: 'requestTypeId', fromField: 'id' }],
+        },
+      ],
     },
     transformation: {
       idFields: ['name', 'projectKey'],
@@ -1872,6 +1879,20 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       dataField: 'calendars',
       fieldsToHide: [
         { fieldName: 'id' },
+      ],
+    },
+  },
+  RequestType__workflowStatuses: {
+    request: {
+      url: '/rest/servicedesk/1/servicedesk-data/{projectKey}/request-type/{requestTypeId}/workflow',
+    },
+    transformation: {
+      dataField: 'statuses',
+      sourceTypeName: 'RequestType__workflowStatuses__statuses',
+      fieldsToOmit: [
+        { fieldName: 'projectKey' },
+        { fieldName: 'statusNameId' },
+        { fieldName: 'original' },
       ],
     },
   },

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -965,6 +965,12 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     jiraMissingRefStrategy: 'typeAndValue',
     target: { type: PORTAL_GROUP_TYPE },
   },
+  {
+    src: { field: 'id', parentTypes: ['RequestType__workflowStatuses'] },
+    serializationStrategy: 'id',
+    jiraMissingRefStrategy: 'typeAndValue',
+    target: { type: STATUS_TYPE_NAME },
+  },
 ]
 
 const lookupNameFuncs: GetLookupNameFunc[] = [


### PR DESCRIPTION
In this PR I support fetching of workflow statuses

---

None

---
_Release Notes_: 
_Jira Adapter:_
Now supports Workflow statuses in JSM. 

---
_User Notifications_: 
_Jira Adapter:_
JSM RequestType will now have new field - workfowStatuses. 
