### PR TITLE
SALTO-4869 ignore hidden values on calculatePatch

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -390,7 +390,7 @@ export const calculatePatchFromChanges = async (
     unmergedAfterElements,
     afterElements,
     elementSource.createInMemoryElementSource(beforeElements),
-    await workspace.elements(),
+    await workspace.elements(false),
     partialFetchData,
     new Set(accounts),
   )
@@ -487,7 +487,7 @@ export const calculatePatch = async (
     afterElements,
     mergedAfterElements,
     elementSource.createInMemoryElementSource(mergedBeforeElements),
-    adapterContext.elementsSource,
+    await workspace.elements(false),
     new Map([[accountName, {}]]),
     new Set([accountName]),
   )

--- a/packages/core/test/common/workspace.ts
+++ b/packages/core/test/common/workspace.ts
@@ -68,6 +68,7 @@ export const mockErrors = (errors: SaltoError[]): wsErrors.Errors => new wsError
 
 export const mockWorkspace = ({
   elements = [],
+  elementsWithoutHidden = [],
   name = undefined,
   index = [],
   stateElements = undefined,
@@ -79,6 +80,7 @@ export const mockWorkspace = ({
   staticFilesSource = undefined,
 }: {
   elements?: Element[]
+  elementsWithoutHidden?: Element[]
   name?: string
   index?: workspace.remoteMap.RemoteMapEntry<workspace.pathIndex.Path[]>[]
   stateElements?: Element[]
@@ -105,7 +107,9 @@ export const mockWorkspace = ({
   const state = mockState(ACCOUNTS, stateElements || elements, index)
   return {
     elements: jest.fn().mockImplementation(
-      async () => elementSource.createInMemoryElementSource(elements)
+      async (includeHidden = true) => elementSource.createInMemoryElementSource(
+        includeHidden ? elements : elementsWithoutHidden,
+      )
     ),
     name,
     envs: () => ['default'],


### PR DESCRIPTION
In the `calculatePatch` & `calculatePatchFromChanges` APIs we currently return removal changes on hidden values-

If the patch includes an addition of an element (without hidden values in it, since it’s coming from PR/SAAS change) and it is already exists in the workspace, we’ll have removal changes on the hidden fields/annotations of the element- like `internalId`, `_service_url` etc.

The reason is that we’re calling `calcFetchChanges` with `workspace.elements()` for the `workspaceElements` param- which includes the hidden values from the state in it. The problem is that for `stateElements`&`accountElements` we’re passing the PR’s elements, that doesn’t have hidden values in them- and the result is having removal changes on the hidden values.

IMO we should call `calcFetchChanges` with `workspace.elements({ includeHidden: false })` for the `workspaceElements`, as we’re actually interested in calculating the changes between the source PR and the visible elements in the workspace.

---

_Additional context for reviewer_

---
_Release Notes_: 
Core:
- Ignore hidden values on calculatePatch

---
_User Notifications_: 
None