### PR TITLE
SALTO-4870 always default domain to zendesk.com

### DIFF
--- a/packages/zendesk-adapter/src/client/connection.ts
+++ b/packages/zendesk-adapter/src/client/connection.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import _ from 'lodash'
 import axios from 'axios'
 import axiosRetry from 'axios-retry'
 import { AccountInfo } from '@salto-io/adapter-api'
@@ -40,7 +41,7 @@ const EXPECTED_VALID_ACCOUNT_RES = Joi.object({
 }).unknown(true).required()
 
 export const instanceUrl = (subdomain: string, domain?: string): string => (
-  domain === undefined ? `https://${subdomain}.zendesk.com` : `https://${subdomain}.${domain}`
+  _.isEmpty(domain) ? `https://${subdomain}.zendesk.com` : `https://${subdomain}.${domain}`
 )
 const baseUrl = instanceUrl
 // A URL for resource files

--- a/packages/zendesk-adapter/test/adapter_creator.test.ts
+++ b/packages/zendesk-adapter/test/adapter_creator.test.ts
@@ -230,6 +230,18 @@ describe('adapter creator', () => {
       port: 8080,
       clientId: 'client',
     })).toEqual('https://abc.zendesk1.org/oauth/authorizations/new?response_type=token&redirect_uri=http://localhost:8080&client_id=client&scope=read%20write')
+    expect(createUrlFromUserInput({
+      subdomain: 'abc',
+      domain: '',
+      port: 8080,
+      clientId: 'client',
+    })).toEqual('https://abc.zendesk.com/oauth/authorizations/new?response_type=token&redirect_uri=http://localhost:8080&client_id=client&scope=read%20write')
+    expect(createUrlFromUserInput({
+      subdomain: 'abc',
+      domain: undefined,
+      port: 8080,
+      clientId: 'client',
+    })).toEqual('https://abc.zendesk.com/oauth/authorizations/new?response_type=token&redirect_uri=http://localhost:8080&client_id=client&scope=read%20write')
   })
 
   it('should validate credentials using createConnection', async () => {


### PR DESCRIPTION
always default the subdomain to zendesk.com when not provided


---
_Release Notes_: 
_Zendesk adapter_:
* Fix bug when using the OAuth credentials flow that required providing a domain argument

---
_User Notifications_: 
None