### PR TITLE
SALTO-4881 - Salesforce: Support more complex SOQL queries

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/unknown_users.ts
+++ b/packages/salesforce-adapter/src/change_validators/unknown_users.ts
@@ -222,7 +222,7 @@ const getSalesforceUsers = async (client: SalesforceClient, users: string[]): Pr
     return []
   }
 
-  const queries = await buildSelectQueries('User', ['Username'], users.map(userName => ({ Username: `'${userName}'` })), SALESFORCE_MAX_QUERY_LEN)
+  const queries = buildSelectQueries('User', ['Username'], users.map(userName => ({ Username: `'${userName}'` })), [], SALESFORCE_MAX_QUERY_LEN)
 
   return awu(await queryClient(client, queries)).map(sfRecord => sfRecord.Username).toArray()
 }

--- a/packages/salesforce-adapter/src/change_validators/unknown_users.ts
+++ b/packages/salesforce-adapter/src/change_validators/unknown_users.ts
@@ -222,7 +222,10 @@ const getSalesforceUsers = async (client: SalesforceClient, users: string[]): Pr
     return []
   }
 
-  const queries = buildSelectQueries('User', ['Username'], users.map(userName => ({ Username: `'${userName}'` })), [], SALESFORCE_MAX_QUERY_LEN)
+  const queries = buildSelectQueries('User',
+    ['Username'],
+    users.map(userName => [{ fieldName: 'Username', operator: 'IN', value: `'${userName}'` }]),
+    SALESFORCE_MAX_QUERY_LEN)
 
   return awu(await queryClient(client, queries)).map(sfRecord => sfRecord.Username).toArray()
 }

--- a/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
+++ b/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
@@ -168,7 +168,7 @@ const getRecordsBySaltoIds = async (
         (await awu(saltoIdFields).flatMap(getFieldNamesForQuery).toArray())
       )
   )
-  const queries = await buildSelectQueries(
+  const queries = buildSelectQueries(
     await apiName(type),
     fieldsToQuery,
     instanceIdValues,

--- a/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
+++ b/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
@@ -154,7 +154,7 @@ const getRecordsBySaltoIds = async (
     const idFieldsNameToValue = (await Promise.all(
       saltoIdFields.map(field => getFieldNamesToValues(inst, field))
     )).flat()
-    const r = Object.fromEntries(idFieldsNameToValue)
+    const r = idFieldsNameToValue.map(([fieldName, value]) => ({ fieldName, operator: 'IN' as const, value }))
     return r
   }))
 

--- a/packages/salesforce-adapter/src/filters/author_information/data_instances.ts
+++ b/packages/salesforce-adapter/src/filters/author_information/data_instances.ts
@@ -29,7 +29,7 @@ const getIDToNameMap = async (client: SalesforceClient,
     instances.flatMap(instance => [instance.value.CreatedById, instance.value.LastModifiedById])
   ))
   const queries = conditionQueries(GET_ID_AND_NAMES_OF_USERS_QUERY,
-    instancesIDs.map(id => ({ Id: `'${id}'` })))
+    instancesIDs.map(id => [{ fieldName: 'Id', operator: 'IN', value: `'${id}'` }]))
   const records = await queryClient(client, queries)
   return Object.fromEntries(records.map(record => [record.Id, record.Name]))
 }

--- a/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
@@ -58,6 +58,7 @@ import {
   isHiddenField,
   isReadOnlyField,
   isCustomObjectSync,
+  SoqlQuery,
 } from './utils'
 import { ConfigChangeSuggestion, DataManagement } from '../types'
 
@@ -102,9 +103,9 @@ const buildQueryStrings = async (
   const fieldNames = await awu(fields)
     .flatMap(getFieldNamesForQuery)
     .toArray()
-  const queryConditions: Record<string, string>[] = [
-    ...makeArray(ids).map(id => ({ Id: `'${id}'` })),
-    ...(managedBySaltoField !== undefined ? [{ [managedBySaltoField]: 'TRUE' }] : []),
+  const queryConditions: SoqlQuery[][] = [
+    ...makeArray(ids).map(id => [{ fieldName: 'Id', operator: 'IN' as const, value: `'${id}'` }]),
+    ...(managedBySaltoField !== undefined ? [[{ fieldName: managedBySaltoField, operator: '=' as const, value: 'TRUE' }]] : []),
   ]
   return buildSelectQueries(typeName, fieldNames, queryConditions)
 }

--- a/packages/salesforce-adapter/src/filters/utils.ts
+++ b/packages/salesforce-adapter/src/filters/utils.ts
@@ -420,23 +420,37 @@ export const extractFlatCustomObjectFields = async (elem: Element): Promise<Elem
     : [elem]
 )
 
-export const getWhereConditions = (
-  conditionSets: Record<string, string>[],
-  maxLen: number
+type QueryOperator = '>' | '<'
+type ComplexQuery = [string, QueryOperator, string]
+
+const getWhereConditions = (
+  exactConditionSets: Record<string, string>[],
+  complexConditionSets: ReadonlyArray<ComplexQuery>,
+  maxLen: number,
 ): string[] => {
-  const keys = _.uniq(conditionSets.flatMap(Object.keys))
+  const keys = _.uniq(exactConditionSets.flatMap(Object.keys))
   const constConditionPartLen = (
     _.sumBy(keys, key => `${key} IN ()`.length)
     + (' AND '.length * (keys.length - 1))
   )
 
+  const complexConditionQuery = complexConditionSets
+    .map(([field, op, value]) => `${field} ${op} ${value}`)
+    .join(' AND ')
+  const complexConditionsLength = complexConditionQuery.length
+    + ((Object.keys(exactConditionSets).length > 0 && complexConditionQuery.length > 0) ? ' AND '.length : 0)
+
+  if (complexConditionsLength > maxLen) {
+    throw new Error('Complex conditions need to be included in every query, thus can`t be longer than the maximum query length')
+  }
+
   const conditionChunks = weightedChunks(
-    conditionSets,
+    exactConditionSets,
     maxLen - constConditionPartLen,
     // Note - this calculates the condition length as if all values are added to the query.
     // the actual query might end up being shorter if some of the values are not unique.
     // this can be optimized in the future if needed
-    condition => _.sumBy(Object.values(condition), val => `${val},`.length),
+    condition => _.sumBy(Object.values(condition), val => `${val},`.length) + complexConditionsLength,
   )
   const r = conditionChunks.map(conditionChunk => {
     const conditionsByKey = _.groupBy(
@@ -449,13 +463,27 @@ export const getWhereConditions = (
       ))
       .join(' AND ')
   })
-  return r
+  if (r.length === 0) {
+    return [complexConditionQuery]
+  }
+  return r.map(queryChunk => `${queryChunk}${(queryChunk.length > 0 && complexConditionSets.length > 0) ? ' AND ' : ''}${complexConditionQuery}`)
 }
 
-export const conditionQueries = (query: string, conditionSets: Record<string,
-  string>[], maxQueryLen = MAX_QUERY_LENGTH): string[] => {
+export const conditionQueries = (
+  query: string,
+  exactConditionSets: Record<string, string>[],
+  complexConditionSets: ReadonlyArray<ComplexQuery> = [],
+  maxQueryLen = MAX_QUERY_LENGTH,
+): string[] => {
+  if (exactConditionSets.length === 0 && complexConditionSets.length === 0) {
+    return [query]
+  }
   const selectWhereStr = `${query} WHERE `
-  const whereConditions = getWhereConditions(conditionSets, maxQueryLen - selectWhereStr.length)
+  const whereConditions = getWhereConditions(
+    exactConditionSets,
+    complexConditionSets,
+    maxQueryLen - selectWhereStr.length
+  )
   return whereConditions.map(whereCondition => `${selectWhereStr}${whereCondition}`)
 }
 
@@ -471,21 +499,24 @@ export const getFieldNamesForQuery = async (field: Field): Promise<string[]> => 
  *
  * @param typeName The name of the table to query from
  * @param fields The names of the fields to query
- * @param conditionSets Each entry specifies field values used to match a specific record
+ * @param exactConditionSets Each entry specifies field values used to match a specific record
+ * @param complexConditionSets Each entry specifies a field name, an operator and an operand to further limit the
+ *                             returned records.
  * @param maxQueryLen returned queries will be split such that no single query exceeds this length
  */
-export const buildSelectQueries = async (
+export const buildSelectQueries = (
   typeName: string,
   fields: string[],
-  conditionSets?: Record<string, string>[],
+  exactConditionSets: Record<string, string>[] = [],
+  complexConditionSets: ReadonlyArray<ComplexQuery> = [],
   maxQueryLen = MAX_QUERY_LENGTH,
-): Promise<string[]> => {
+): string[] => {
   const fieldsNameQuery = fields.join(',')
   const selectStr = `SELECT ${fieldsNameQuery} FROM ${typeName}`
-  if (conditionSets === undefined || conditionSets.length === 0) {
-    return [selectStr]
+  if (selectStr.length > maxQueryLen) {
+    throw new Error('Max query length is too short for the SELECT clause')
   }
-  return conditionQueries(selectStr, conditionSets, maxQueryLen)
+  return conditionQueries(selectStr, exactConditionSets, complexConditionSets, maxQueryLen)
 }
 
 export const queryClient = async (client: SalesforceClient,

--- a/packages/salesforce-adapter/src/filters/utils.ts
+++ b/packages/salesforce-adapter/src/filters/utils.ts
@@ -445,7 +445,8 @@ const getWhereConditions = (
     + ((Object.keys(exactConditionSets).length > 0 && complexConditionQuery.length > 0) ? ' AND '.length : 0)
 
   if (complexConditionsLength > maxLen) {
-    throw new Error('Complex conditions need to be included in every query, thus can`t be longer than the maximum query length')
+    log.error('Complex conditions need to be included in every query - they can`t be broken down so they can`t be longer than the maximum query length. getWhereConditions params: %o', { exactConditionSets, limitingConditionSets, maxLen })
+    throw new Error('SOQL query too long')
   }
 
   const conditionChunks = weightedChunks(


### PR DESCRIPTION
Make it possible to run range-based queries in addition to exact-match queries. If the query is too long and has to be broken into multiple queries, make sure the range-based queries are appended to every query that is created, to maintain the expected behavior.

---

**PR Chain**:
 - https://github.com/salto-io/salto/pull/4961 👈 YOU ARE HERE 👈 
 - https://github.com/salto-io/salto/pull/4964
 - https://github.com/salto-io/salto/pull/4965

---
_Release Notes_: 
N/A

---
_User Notifications_: 
N/A