### PR TITLE
SALTO-4350 - Added buffer and an rate limited endpoint

### DIFF
--- a/packages/okta-adapter/src/client/client.ts
+++ b/packages/okta-adapter/src/client/client.ts
@@ -89,7 +89,7 @@ const RATE_LIMIT_BUCKETS = [
   new RegExp('^/api/v1/iam.*'),
   new RegExp('^/api/v1/domains'),
   new RegExp('^/api/v1/device-assurances'),
-  new RegExp('^/api/internal/orgSettings/thirdPartyAdminSettin'),
+  new RegExp('^/api/internal/orgSettings/thirdPartyAdminSetting'),
   /**/
   new RegExp('^/api/v1.*'), // Has to be last
 ]

--- a/packages/okta-adapter/src/client/client.ts
+++ b/packages/okta-adapter/src/client/client.ts
@@ -89,6 +89,7 @@ const RATE_LIMIT_BUCKETS = [
   new RegExp('^/api/v1/iam.*'),
   new RegExp('^/api/v1/domains'),
   new RegExp('^/api/v1/device-assurances'),
+  new RegExp('^/api/internal/orgSettings/thirdPartyAdminSettin'),
   /**/
   new RegExp('^/api/v1.*'), // Has to be last
 ]
@@ -105,7 +106,7 @@ const shouldRunRequest = (rateLimits: OktaRateLimits, rateLimitBuffer: number): 
   const isRateLimitDisabled = rateLimitBuffer === UNLIMITED_MAX_REQUESTS_PER_MINUTE
   const isInitialRequest = _.isEqual(rateLimits, INIT_RATE_LIMITS)
   const isWithinRateLimitBuffer = rateLimits.rateLimitRemaining - rateLimits.currentlyRunning > rateLimitBuffer
-  const didRateLimitReset = rateLimits.rateLimitReset < Date.now()
+  const didRateLimitReset = rateLimits.rateLimitReset + 1000 < Date.now() // buffer in case the limit is round down
   const isRateLimitResetSet = rateLimits.rateLimitReset !== INIT_RATE_LIMITS.rateLimitReset
   const isMaxPerMinuteReached = rateLimits.currentlyRunning >= rateLimits.maxPerMinute - rateLimitBuffer
 


### PR DESCRIPTION
Added a buffer for the rate limit reset, in case okta rounds down the reset time in the headers
also added an endpoint that is rate limited but not documented

---

None

---
_Release Notes_: 
None

---
_User Notifications_: 
None