### PR TITLE
SALTO-4882 - Salesforce: multiple_defaults CV crashes if instance has a field that's missing from its type

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/multiple_defaults.ts
+++ b/packages/salesforce-adapter/src/change_validators/multiple_defaults.ts
@@ -131,10 +131,12 @@ const getInstancesMultipleDefaultsErrors = async (
 
   const errors: ChangeError[] = await awu(Object.entries(after.value))
     .filter(([fieldName]) => Object.keys(FIELD_NAME_TO_INNER_CONTEXT_FIELD).includes(fieldName))
-    // See SALTO-4882
-    .filter(async ([fieldName]) => (await after.getType()).fields[fieldName] !== undefined)
     .flatMap(async ([fieldName, value]) => {
       const field = (await after.getType()).fields[fieldName]
+      if (field === undefined) {
+        // Can happen if the field exists in the instance but not in the type.
+        return []
+      }
       const fieldType = await field.getType()
       const valueName = FIELD_NAME_TO_INNER_CONTEXT_FIELD[fieldName].name
       if (_.isPlainObject(value) && FIELD_NAME_TO_INNER_CONTEXT_FIELD[fieldName].nested) {

--- a/packages/salesforce-adapter/src/change_validators/multiple_defaults.ts
+++ b/packages/salesforce-adapter/src/change_validators/multiple_defaults.ts
@@ -131,6 +131,8 @@ const getInstancesMultipleDefaultsErrors = async (
 
   const errors: ChangeError[] = await awu(Object.entries(after.value))
     .filter(([fieldName]) => Object.keys(FIELD_NAME_TO_INNER_CONTEXT_FIELD).includes(fieldName))
+    // See SALTO-4882
+    .filter(async ([fieldName]) => (await after.getType()).fields[fieldName] !== undefined)
     .flatMap(async ([fieldName, value]) => {
       const field = (await after.getType()).fields[fieldName]
       const fieldType = await field.getType()
@@ -146,7 +148,8 @@ const getInstancesMultipleDefaultsErrors = async (
       }
       const defaultsContexts = await findMultipleDefaults(value, fieldType, valueName)
       return createChangeErrorFromContext(field, defaultsContexts, after)
-    }).toArray()
+    })
+    .toArray()
 
   return errors
 }

--- a/packages/salesforce-adapter/test/change_validators/multiple_defaults.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/multiple_defaults.test.ts
@@ -156,19 +156,24 @@ describe('multiple defaults change validator', () => {
       }
 
       it('should have warning for a GlobalValueSet instance', async () => {
-        const beforeInstance = createInstanceElement({ fullName: 'globalValueSetIntance',
-          customValue: [
-            {
-              fullName: 'lolo',
-              default: true,
-              label: 'lolo',
-            },
-            {
-              fullName: 'lala',
-              default: false,
-              label: 'lala',
-            },
-          ] }, type)
+        const beforeInstance = createInstanceElement(
+          {
+            fullName: 'globalValueSetInstance',
+            customValue: [
+              {
+                fullName: 'lolo',
+                default: true,
+                label: 'lolo',
+              },
+              {
+                fullName: 'lala',
+                default: false,
+                label: 'lala',
+              },
+            ],
+          },
+          type,
+        )
         const afterInstance = createAfterInstance(beforeInstance)
         const changeErrors = await runChangeValidatorOnUpdate(beforeInstance, afterInstance)
         expect(changeErrors).toHaveLength(1)
@@ -177,7 +182,7 @@ describe('multiple defaults change validator', () => {
         expect(changeError.severity).toEqual('Warning')
       })
       it('should not have error for <= 1 default values GlobalValueSet', async () => {
-        const beforeInstance = createInstanceElement({ fullName: 'globalValueSetIntance',
+        const beforeInstance = createInstanceElement({ fullName: 'globalValueSetInstance',
           customValue: [
             {
               fullName: 'lolo',
@@ -193,6 +198,44 @@ describe('multiple defaults change validator', () => {
         const afterInstance = createAfterInstance(beforeInstance)
         const changeErrors = await runChangeValidatorOnUpdate(beforeInstance, afterInstance)
         expect(changeErrors).toHaveLength(0)
+      })
+      it('should handle fields that don`t appear in the type (SALTO-4882)', async () => {
+        const beforeInstance = createInstanceElement(
+          {
+            fullName: 'globalValueSetInstance',
+            customValue: [
+              {
+                fullName: 'lolo',
+                default: true,
+                label: 'lolo',
+              },
+              {
+                fullName: 'lala',
+                default: false,
+                label: 'lala',
+              },
+            ],
+            standardValue: [
+              {
+                fullName: 'lolo',
+                default: true,
+                label: 'lolo',
+              },
+              {
+                fullName: 'lala',
+                default: false,
+                label: 'lala',
+              },
+            ],
+          },
+          type,
+        )
+        const afterInstance = createAfterInstance(beforeInstance)
+        const changeErrors = await runChangeValidatorOnUpdate(beforeInstance, afterInstance)
+        expect(changeErrors).toHaveLength(1)
+        const [changeError] = changeErrors
+        expect(changeError.elemID).toEqual(afterInstance.elemID)
+        expect(changeError.severity).toEqual('Warning')
       })
     })
 


### PR DESCRIPTION
The CV code assumes that if a field exists in an instance it also exists in the type of the instance. This is not necessarily the case.

---

I chose to just not run the validator on fields that do not exist in the type, under the assumption that the deploy will fail anyway.

---
_Release Notes_: 
Salesforce: fixed a crash if fields with certain names were created in instances whose types did not include said fields.

---
_User Notifications_: 
N/A
