### PR TITLE
SALTO-4839 - Salesforce: Aggregate changed-at for instances

### DIFF
--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -428,7 +428,7 @@ export const KEY_PREFIX_LENGTH = 3
 
 // Magics
 export const DETECTS_PARENTS_INDICATOR = '##allMasterDetailFields##'
-export const LAST_MODIFIED_INSTANCES = '__Instances__'
+export const DATA_INSTANCES_CHANGED_AT_MAGIC = '__DataInstances__'
 
 // CPQ CustomObjects
 export const CPQ_NAMESPACE = 'SBQQ'

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -428,6 +428,7 @@ export const KEY_PREFIX_LENGTH = 3
 
 // Magics
 export const DETECTS_PARENTS_INDICATOR = '##allMasterDetailFields##'
+export const LAST_MODIFIED_INSTANCES = '__Instances__'
 
 // CPQ CustomObjects
 export const CPQ_NAMESPACE = 'SBQQ'

--- a/packages/salesforce-adapter/src/fetch_profile/metadata_query.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/metadata_query.ts
@@ -40,7 +40,7 @@ import {
   MetadataQuery,
   MetadataQueryParams,
 } from '../types'
-import { getChangedAtSingleton } from '../filters/utils'
+import { getChangedAtSingleton, getTypeChangedAt } from '../filters/utils'
 
 const { isDefined } = values
 
@@ -198,7 +198,7 @@ export const buildMetadataQueryForFetchWithChangesDetection = async (
     if (instance.changedAt === undefined) {
       return true
     }
-    const lastChangedAt = _.get(changedAtSingleton.value, [instance.metadataType, instance.name])
+    const lastChangedAt = getTypeChangedAt(changedAtSingleton, instance.metadataType, instance.name)
     return _.isString(lastChangedAt)
       ? new Date(lastChangedAt).getTime() < new Date(instance.changedAt).getTime()
       : true

--- a/packages/salesforce-adapter/src/fetch_profile/metadata_query.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/metadata_query.ts
@@ -40,7 +40,7 @@ import {
   MetadataQuery,
   MetadataQueryParams,
 } from '../types'
-import { getChangedAtSingleton, getTypeChangedAt } from '../filters/utils'
+import { getChangedAtSingleton } from '../filters/utils'
 
 const { isDefined } = values
 
@@ -198,7 +198,7 @@ export const buildMetadataQueryForFetchWithChangesDetection = async (
     if (instance.changedAt === undefined) {
       return true
     }
-    const lastChangedAt = getTypeChangedAt(changedAtSingleton, instance.metadataType, instance.name)
+    const lastChangedAt = _.get(changedAtSingleton.value, [instance.metadataType, instance.name])
     return _.isString(lastChangedAt)
       ? new Date(lastChangedAt).getTime() < new Date(instance.changedAt).getTime()
       : true

--- a/packages/salesforce-adapter/src/filters/changed_at_singleton.ts
+++ b/packages/salesforce-adapter/src/filters/changed_at_singleton.ts
@@ -25,7 +25,6 @@ import _ from 'lodash'
 import { LocalFilterCreator } from '../filter'
 import {
   ArtificialTypes,
-  CUSTOM_OBJECT,
   DATA_INSTANCES_CHANGED_AT_MAGIC,
 } from '../constants'
 import {
@@ -99,7 +98,7 @@ const filterCreator: LocalFilterCreator = ({ config }) => ({
     instanceLastChangedByCustomObjectType
       .entries()
       .forEach(([typeName, dateString]) => {
-        _.set(changedAtInstance.value, [DATA_INSTANCES_CHANGED_AT_MAGIC, CUSTOM_OBJECT, typeName], dateString)
+        _.set(changedAtInstance.value, [DATA_INSTANCES_CHANGED_AT_MAGIC, typeName], dateString)
       })
   },
 })

--- a/packages/salesforce-adapter/src/filters/changed_at_singleton.ts
+++ b/packages/salesforce-adapter/src/filters/changed_at_singleton.ts
@@ -63,11 +63,11 @@ const getChangedAtSingletonInstance = async (
   return changedAtSingleton ?? createEmptyChangedAtSingletonInstance()
 }
 
-const dateStringOfMostRecentlyChangedInstance = (instances: InstanceElement[]): string => (
+const dateStringOfMostRecentlyChangedInstance = (instances: InstanceElement[]): string | undefined => (
   _(instances)
     .map(instance => instance.annotations[CORE_ANNOTATIONS.CHANGED_AT])
-    .filter(changedAt => changedAt !== undefined)
-    .maxBy((changedAt: string) => new Date(changedAt).getTime())
+    .filter(_.isString)
+    .maxBy(changedAt => new Date(changedAt).getTime())
 )
 
 const filterCreator: LocalFilterCreator = ({ config }) => ({
@@ -97,8 +97,9 @@ const filterCreator: LocalFilterCreator = ({ config }) => ({
 
     instanceLastChangedByCustomObjectType
       .entries()
-      .forEach(([typeName, dateString]) => {
-        _.set(changedAtInstance.value, [DATA_INSTANCES_CHANGED_AT_MAGIC, typeName], dateString)
+      .filter(([, mostRecentChangedAt]) => mostRecentChangedAt !== undefined)
+      .forEach(([typeName, mostRecentChangedAt]) => {
+        _.set(changedAtInstance.value, [DATA_INSTANCES_CHANGED_AT_MAGIC, typeName], mostRecentChangedAt)
       })
   },
 })

--- a/packages/salesforce-adapter/src/filters/changed_at_singleton.ts
+++ b/packages/salesforce-adapter/src/filters/changed_at_singleton.ts
@@ -26,7 +26,7 @@ import { LocalFilterCreator } from '../filter'
 import {
   ArtificialTypes,
   CUSTOM_OBJECT,
-  LAST_MODIFIED_INSTANCES,
+  DATA_INSTANCES_CHANGED_AT_MAGIC,
 } from '../constants'
 import {
   apiNameSync,
@@ -67,6 +67,7 @@ const getChangedAtSingletonInstance = async (
 const dateStringOfMostRecentlyChangedInstance = (instances: InstanceElement[]): string => (
   _(instances)
     .map(instance => instance.annotations[CORE_ANNOTATIONS.CHANGED_AT])
+    .filter(changedAt => changedAt !== undefined)
     .maxBy((changedAt: string) => new Date(changedAt).getTime())
 )
 
@@ -90,15 +91,15 @@ const filterCreator: LocalFilterCreator = ({ config }) => ({
       changedAtInstance.value,
     )
 
-    const instanceLastUpdateByType = _(elements)
+    const instanceLastChangedByCustomObjectType = _(elements)
       .filter(isInstanceOfCustomObjectSync)
       .groupBy(instance => apiNameSync(instance.getTypeSync()))
       .mapValues(dateStringOfMostRecentlyChangedInstance)
 
-    instanceLastUpdateByType
+    instanceLastChangedByCustomObjectType
       .entries()
       .forEach(([typeName, dateString]) => {
-        _.set(changedAtInstance.value, [LAST_MODIFIED_INSTANCES, CUSTOM_OBJECT, typeName], dateString)
+        _.set(changedAtInstance.value, [DATA_INSTANCES_CHANGED_AT_MAGIC, CUSTOM_OBJECT, typeName], dateString)
       })
   },
 })

--- a/packages/salesforce-adapter/src/filters/utils.ts
+++ b/packages/salesforce-adapter/src/filters/utils.ts
@@ -68,7 +68,7 @@ import {
   INTERNAL_ID_FIELD,
   KEY_PREFIX,
   LABEL,
-  LAST_MODIFIED_INSTANCES,
+  DATA_INSTANCES_CHANGED_AT_MAGIC,
   LAYOUT_TYPE_ID_METADATA_TYPE,
   METADATA_TYPE,
   NAMESPACE_SEPARATOR,
@@ -692,7 +692,7 @@ export const getTypeInstancesChangedAt = (
   metadataTypeName: string,
   typeName: string,
 ): string | undefined => (
-  _.get(changedAtSingleton.value, [LAST_MODIFIED_INSTANCES, metadataTypeName, typeName])
+  _.get(changedAtSingleton.value, [DATA_INSTANCES_CHANGED_AT_MAGIC, metadataTypeName, typeName])
 )
 
 

--- a/packages/salesforce-adapter/src/filters/utils.ts
+++ b/packages/salesforce-adapter/src/filters/utils.ts
@@ -68,7 +68,6 @@ import {
   INTERNAL_ID_FIELD,
   KEY_PREFIX,
   LABEL,
-  DATA_INSTANCES_CHANGED_AT_MAGIC,
   LAYOUT_TYPE_ID_METADATA_TYPE,
   METADATA_TYPE,
   NAMESPACE_SEPARATOR,
@@ -147,10 +146,6 @@ export const isCustomObjectSync = (element: Readonly<Element>): element is Objec
     && element.annotations[API_NAME] !== undefined
   return res
 }
-
-export const isInstanceOfCustomObjectSync = (element: Readonly<Element>): element is InstanceElement => (
-  isInstanceElement(element) && isCustomObjectSync(element.getTypeSync())
-)
 
 const fullApiNameSync = (elem: Readonly<Element>): string | undefined => {
   if (isInstanceElement(elem)) {
@@ -678,22 +673,6 @@ export const getChangedAtSingleton = async (
   const element = await elementsSource.get(new ElemID(SALESFORCE, CHANGED_AT_SINGLETON, 'instance', ElemID.CONFIG_NAME))
   return isInstanceElement(element) ? element : undefined
 }
-
-export const getTypeChangedAt = (
-  changedAtSingleton: InstanceElement,
-  metadataTypeName: string,
-  typeName: string,
-): string | undefined => (
-  _.get(changedAtSingleton.value, [metadataTypeName, typeName])
-)
-
-export const getTypeInstancesChangedAt = (
-  changedAtSingleton: InstanceElement,
-  metadataTypeName: string,
-  typeName: string,
-): string | undefined => (
-  _.get(changedAtSingleton.value, [DATA_INSTANCES_CHANGED_AT_MAGIC, metadataTypeName, typeName])
-)
 
 
 export const isCustomType = (element: Element): element is ObjectType => (

--- a/packages/salesforce-adapter/src/filters/utils.ts
+++ b/packages/salesforce-adapter/src/filters/utils.ts
@@ -68,6 +68,7 @@ import {
   INTERNAL_ID_FIELD,
   KEY_PREFIX,
   LABEL,
+  LAST_MODIFIED_INSTANCES,
   LAYOUT_TYPE_ID_METADATA_TYPE,
   METADATA_TYPE,
   NAMESPACE_SEPARATOR,
@@ -147,6 +148,9 @@ export const isCustomObjectSync = (element: Readonly<Element>): element is Objec
   return res
 }
 
+export const isInstanceOfCustomObjectSync = (element: Readonly<Element>): element is InstanceElement => (
+  isInstanceElement(element) && isCustomObjectSync(element.getTypeSync())
+)
 
 const fullApiNameSync = (elem: Readonly<Element>): string | undefined => {
   if (isInstanceElement(elem)) {
@@ -674,6 +678,23 @@ export const getChangedAtSingleton = async (
   const element = await elementsSource.get(new ElemID(SALESFORCE, CHANGED_AT_SINGLETON, 'instance', ElemID.CONFIG_NAME))
   return isInstanceElement(element) ? element : undefined
 }
+
+export const getTypeChangedAt = (
+  changedAtSingleton: InstanceElement,
+  metadataTypeName: string,
+  typeName: string,
+): string | undefined => (
+  _.get(changedAtSingleton.value, [metadataTypeName, typeName])
+)
+
+export const getTypeInstancesChangedAt = (
+  changedAtSingleton: InstanceElement,
+  metadataTypeName: string,
+  typeName: string,
+): string | undefined => (
+  _.get(changedAtSingleton.value, [LAST_MODIFIED_INSTANCES, metadataTypeName, typeName])
+)
+
 
 export const isCustomType = (element: Element): element is ObjectType => (
   isObjectType(element) && ENDS_WITH_CUSTOM_SUFFIX_REGEX.test(apiNameSync(element) ?? '')

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -123,8 +123,8 @@ export const isFieldOfCustomObject = async (field: Field): Promise<boolean> =>
 // (before the custom objects filter turns it into a type).
 // To filter for instances like the Lead definition, use isInstanceOfType(CUSTOM_OBJECT) instead
 /**
- * @deprecated use {@link isInstanceOfCustomObjectSync} instead.
- */
+ * @deprecated use {@link isInstanceOfCustomObjectSync} in fetch flows.
+*/
 export const isInstanceOfCustomObject = async (element: Readonly<Element>): Promise<boolean> =>
   isInstanceElement(element) && isCustomObject(await element.getType())
 

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -123,7 +123,7 @@ export const isFieldOfCustomObject = async (field: Field): Promise<boolean> =>
 // (before the custom objects filter turns it into a type).
 // To filter for instances like the Lead definition, use isInstanceOfType(CUSTOM_OBJECT) instead
 /**
- * @deprecated use {@link isInstanceOfCustomObjectSync} in fetch flows.
+ * @deprecated use {@link isInstanceOfCustomObjectSync}
 */
 export const isInstanceOfCustomObject = async (element: Readonly<Element>): Promise<boolean> =>
   isInstanceElement(element) && isCustomObject(await element.getType())

--- a/packages/salesforce-adapter/test/filters/changed_at_singleton.test.ts
+++ b/packages/salesforce-adapter/test/filters/changed_at_singleton.test.ts
@@ -27,7 +27,7 @@ import {
   CHANGED_AT_SINGLETON,
   CUSTOM_OBJECT,
   FLOW_METADATA_TYPE,
-  LAST_MODIFIED_INSTANCES,
+  DATA_INSTANCES_CHANGED_AT_MAGIC,
 } from '../../src/constants'
 import { apiName } from '../../src/transformers/transformer'
 import { defaultFilterContext } from '../utils'
@@ -124,7 +124,7 @@ describe('createChangedAtSingletonInstanceFilter', () => {
           [CUSTOM_OBJECT]: {
             SBQQ__Template__c: CHANGED_AT,
           },
-          [LAST_MODIFIED_INSTANCES]: {
+          [DATA_INSTANCES_CHANGED_AT_MAGIC]: {
             [CUSTOM_OBJECT]: {
               SBQQ__Template__c: CHANGED_AT,
             },

--- a/packages/salesforce-adapter/test/filters/changed_at_singleton.test.ts
+++ b/packages/salesforce-adapter/test/filters/changed_at_singleton.test.ts
@@ -125,9 +125,7 @@ describe('createChangedAtSingletonInstanceFilter', () => {
             SBQQ__Template__c: CHANGED_AT,
           },
           [DATA_INSTANCES_CHANGED_AT_MAGIC]: {
-            [CUSTOM_OBJECT]: {
-              SBQQ__Template__c: CHANGED_AT,
-            },
+            SBQQ__Template__c: CHANGED_AT,
           },
         })
       })

--- a/packages/salesforce-adapter/test/filters/changed_at_singleton.test.ts
+++ b/packages/salesforce-adapter/test/filters/changed_at_singleton.test.ts
@@ -23,7 +23,12 @@ import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { mockInstances, mockTypes } from '../mock_elements'
 import filterCreator from '../../src/filters/changed_at_singleton'
-import { CHANGED_AT_SINGLETON, CUSTOM_OBJECT, FLOW_METADATA_TYPE } from '../../src/constants'
+import {
+  CHANGED_AT_SINGLETON,
+  CUSTOM_OBJECT,
+  FLOW_METADATA_TYPE,
+  LAST_MODIFIED_INSTANCES,
+} from '../../src/constants'
 import { apiName } from '../../src/transformers/transformer'
 import { defaultFilterContext } from '../utils'
 import { FilterWith } from './mocks'
@@ -96,7 +101,6 @@ describe('createChangedAtSingletonInstanceFilter', () => {
         const customObject = mockTypes.SBQQ__Template__c
         customObject.annotations[CORE_ANNOTATIONS.CHANGED_AT] = CHANGED_AT
 
-        // Should not exist in the singleton
         const dataInstance = new InstanceElement('dataInstance', customObject, {
           Name: 'TestDataInstance',
           Id: '13560',
@@ -119,6 +123,11 @@ describe('createChangedAtSingletonInstanceFilter', () => {
           },
           [CUSTOM_OBJECT]: {
             SBQQ__Template__c: CHANGED_AT,
+          },
+          [LAST_MODIFIED_INSTANCES]: {
+            [CUSTOM_OBJECT]: {
+              SBQQ__Template__c: CHANGED_AT,
+            },
           },
         })
       })


### PR DESCRIPTION
Add a new "section" to the changed-at Singleton where we store the most recent "changed-at" among all instances of a given type

---

 - I chose to create a new "section" as the least-disruptive way of storing the data. Feedback welcome!
 - I added the `isInstanceOfCustomObjectSync` utility. Let me know if it's better added in a separate PR.
 - I added a couple of utility functions for use with the changed-at Singleton: `getTypeChangedAt` and `getTypeInstancesChangedAt`.

**PR Chain**:
 - https://github.com/salto-io/salto/pull/5071
 - https://github.com/salto-io/salto/pull/4964 👈 YOU ARE HERE 👈 
 - https://github.com/salto-io/salto/pull/4965

---
_Release Notes_: 
N/A

---
_User Notifications_: 
N/A