### PR TITLE
SALTO-4839 - Salesforce: support quick fetch for data instances

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -117,9 +117,9 @@ import {
   CUSTOM_OBJECT,
   FLOW_DEFINITION_METADATA_TYPE,
   FLOW_METADATA_TYPE,
+  LAST_MODIFIED_DATE,
+  OWNER_ID,
   PROFILE_METADATA_TYPE,
-  SYSTEM_FIELDS,
-  UNSUPPORTED_SYSTEM_FIELDS,
 } from './constants'
 import { buildMetadataQuery, buildMetadataQueryForFetchWithChangesDetection } from './fetch_profile/metadata_query'
 
@@ -298,6 +298,30 @@ const METADATA_TO_RETRIEVE = [
   'Workflow',
 ]
 
+// See: https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_objects_custom_object__c.htm
+export const SYSTEM_FIELDS = [
+  'ConnectionReceivedId',
+  'ConnectionSentId',
+  'CreatedById',
+  'CreatedDate',
+  'Id',
+  'IsDeleted',
+  'LastActivityDate',
+  LAST_MODIFIED_DATE,
+  'LastModifiedById',
+  'LastReferencedDate',
+  'LastViewedDate',
+  'Name',
+  'RecordTypeId',
+  'SystemModstamp',
+  OWNER_ID,
+  'SetupOwnerId',
+]
+
+export const UNSUPPORTED_SYSTEM_FIELDS = [
+  'LastReferencedDate',
+  'LastViewedDate',
+]
 
 const getMetadataTypesFromElementsSource = async (
   elementsSource: ReadOnlyElementsSource

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -136,6 +136,7 @@ export enum ANNOTATION_TYPE_NAMES {
 
 // Salesforce System Fields
 export const OWNER_ID = 'OwnerId'
+export const LAST_MODIFIED_DATE = 'LastModifiedDate'
 
 // Salto annotations
 export const API_NAME = 'apiName'

--- a/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
@@ -139,11 +139,8 @@ const getRecords = async (
 
   const queryableFields = getQueryableFields(objectType)
     .filter(field => !omittedFields.includes(apiNameSync(field) ?? ''))
-  if (_.isEmpty(queryableFields)) {
-    const queryableFieldNames = queryableFields.map(field => apiNameSync(field))
-    log.debug('Type %s had no queryable fields or they were all omitted. %o', typeName, { omittedFields, queryableFieldNames })
-    return {}
-  }
+  // queryableFields can't be empty - at least the ID fields are queryable and not omitted or we'll consider the config
+  // for the object to be invalid and won't get here.
 
   log.debug(
     'Fetching records for type %s%s%s',

--- a/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
@@ -43,7 +43,7 @@ import {
   DETECTS_PARENTS_INDICATOR,
   API_NAME_SEPARATOR,
   LAST_MODIFIED_DATE,
-  CUSTOM_OBJECT,
+  DATA_INSTANCES_CHANGED_AT_MAGIC,
 } from '../constants'
 import { FilterResult, RemoteFilterCreator } from '../filter'
 import { apiName, isCustomObject, Types, createInstanceServiceIds, isNameField } from '../transformers/transformer'
@@ -64,7 +64,6 @@ import {
   SoqlQuery,
   buildElementsSourceForFetch,
   getChangedAtSingleton,
-  getTypeInstancesChangedAt,
 } from './utils'
 import { ConfigChangeSuggestion, DataManagement } from '../types'
 
@@ -502,7 +501,7 @@ export const getCustomObjectsFetchSettings = async (
     if (changedAtSingleton === undefined) {
       return undefined
     }
-    const lastChangedAt = getTypeInstancesChangedAt(changedAtSingleton, CUSTOM_OBJECT, typeName)
+    const lastChangedAt = _.get(changedAtSingleton.value, [DATA_INSTANCES_CHANGED_AT_MAGIC, typeName])
     return _.isString(lastChangedAt) ? new Date(lastChangedAt).toISOString() : undefined
   }
   const isInvalidManagedBySaltoField = (type: ObjectType): boolean => {

--- a/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
@@ -1983,7 +1983,7 @@ describe('Custom Object Instances filter', () => {
     describe('When enabled', () => {
       beforeEach(async () => {
         const changedAtSingleton = mockInstances()[CHANGED_AT_SINGLETON]
-        _.set(changedAtSingleton.value, [DATA_INSTANCES_CHANGED_AT_MAGIC, CUSTOM_OBJECT, testTypeName], changedAtCutoff)
+        _.set(changedAtSingleton.value, [DATA_INSTANCES_CHANGED_AT_MAGIC, testTypeName], changedAtCutoff)
 
         const elementsSource = buildElementsSourceFromElements([
           changedAtSingleton,

--- a/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
@@ -1975,7 +1975,7 @@ describe('Custom Object Instances filter', () => {
       })
     })
   })
-  describe('Quickfetch', () => {
+  describe('Fetch with changes detection', () => {
     let fetchProfile: FetchProfile
     const testTypeName = 'TestType'
     const changedAtCutoff = new Date(2023, 12, 21).toISOString()
@@ -2038,7 +2038,7 @@ describe('Custom Object Instances filter', () => {
         ) as FilterType
         await filter.onFetch([createCustomObject(testTypeName)])
       })
-      it('Should query using the changed-at value', () => {
+      it('Should not query using the changed-at value', () => {
         expect(basicQueryImplementation).toHaveBeenLastCalledWith(expect.not.stringContaining(`LastModifiedDate > ${changedAtCutoff}`))
       })
     })

--- a/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
@@ -292,6 +292,10 @@ describe('Custom Object Instances filter', () => {
     })
   }
 
+  const getInstancesOfObjectType = (elementsToCheck: Element[], type: ObjectType): InstanceElement[] => (
+    elementsToCheck.filter(e => isInstanceElement(e) && e.getTypeSync().isEqual(type)) as InstanceElement[]
+  )
+
   describe('config interactions', () => {
     // ref: https://salto-io.atlassian.net/browse/SALTO-4579?focusedCommentId=97852
     const testTypeName = 'TestType'
@@ -699,38 +703,29 @@ describe('Custom Object Instances filter', () => {
         beforeEach(async () => {
           fetchResult = await filter.onFetch(elements) as FetchResult
         })
+
         it('should not fetch for non-configured objects', async () => {
-          const notConfiguredObjInstances = await awu(elements).filter(
-            async e => isInstanceElement(e) && await e.getType() === notConfiguredObj
-          ).toArray() as InstanceElement[]
+          const notConfiguredObjInstances = getInstancesOfObjectType(elements, notConfiguredObj)
           expect(notConfiguredObjInstances.length).toEqual(0)
         })
 
-        it('should fetch for regex configured objects', async () => {
-          const includedNameSpaceObjInstances = await awu(elements).filter(
-            async e => isInstanceElement(e) && await e.getType() === includedNameSpaceObj
-          ).toArray() as InstanceElement[]
+        it('should fetch for regex configured objects', () => {
+          const includedNameSpaceObjInstances = getInstancesOfObjectType(elements, includedNameSpaceObj)
           expect(includedNameSpaceObjInstances.length).toEqual(2)
         })
 
         it('should fetch for object included specifically configured', async () => {
-          const includedObjectInstances = await awu(elements).filter(
-            async e => isInstanceElement(e) && await e.getType() === includedObject
-          ).toArray() as InstanceElement[]
+          const includedObjectInstances = getInstancesOfObjectType(elements, includedObject)
           expect(includedObjectInstances.length).toEqual(2)
         })
 
         it('should not fetch for object from a configured regex whose excluded specifically', async () => {
-          const excludedObjectInstances = await awu(elements).filter(
-            async e => isInstanceElement(e) && await e.getType() === excludedObject
-          ).toArray() as InstanceElement[]
+          const excludedObjectInstances = getInstancesOfObjectType(elements, excludedObject)
           expect(excludedObjectInstances.length).toEqual(0)
         })
 
         it('should not fetch for object from a configured as excluded even if it was included by object', async () => {
-          const excludeOverrideObjectInstances = await awu(elements).filter(
-            async e => isInstanceElement(e) && await e.getType() === excludeOverrideObject
-          ).toArray() as InstanceElement[]
+          const excludeOverrideObjectInstances = getInstancesOfObjectType(elements, excludeOverrideObject)
           expect(excludeOverrideObjectInstances.length).toEqual(0)
         })
       })
@@ -830,9 +825,7 @@ describe('Custom Object Instances filter', () => {
       describe('simple object', () => {
         let instances: InstanceElement[]
         beforeEach(async () => {
-          instances = await awu(elements).filter(
-            async e => isInstanceElement(e) && await e.getType() === simpleObject
-          ).toArray() as InstanceElement[]
+          instances = getInstancesOfObjectType(elements, simpleObject)
         })
 
 
@@ -869,9 +862,7 @@ describe('Custom Object Instances filter', () => {
       describe('object with no queryable fields', () => {
         let instances: InstanceElement[]
         beforeEach(async () => {
-          instances = await awu(elements).filter(
-            async e => isInstanceElement(e) && await e.getType() === objWithNoFields
-          ).toArray() as InstanceElement[]
+          instances = getInstancesOfObjectType(elements, objWithNoFields)
         })
 
         it('should not try to query for object', () => {
@@ -886,9 +877,7 @@ describe('Custom Object Instances filter', () => {
       describe('not in namespace object', () => {
         let instances: InstanceElement[]
         beforeEach(async () => {
-          instances = await awu(elements).filter(
-            async e => isInstanceElement(e) && await e.getType() === objNotInNamespace
-          ).toArray() as InstanceElement[]
+          instances = getInstancesOfObjectType(elements, objNotInNamespace)
         })
         it('should create instances according to results', () => {
           expect(instances.length).toEqual(2)
@@ -903,9 +892,7 @@ describe('Custom Object Instances filter', () => {
       describe('object with compound Name', () => {
         let instances: InstanceElement[]
         beforeEach(async () => {
-          instances = await awu(elements).filter(
-            async e => isInstanceElement(e) && await e.getType() === objWithNameField
-          ).toArray() as InstanceElement[]
+          instances = getInstancesOfObjectType(elements, objWithNameField)
         })
 
         it('should call query with the object fields', () => {
@@ -947,9 +934,7 @@ describe('Custom Object Instances filter', () => {
       describe('object with compound Address', () => {
         let instances: InstanceElement[]
         beforeEach(async () => {
-          instances = await awu(elements).filter(
-            async e => isInstanceElement(e) && await e.getType() === objWithAddressField
-          ).toArray() as InstanceElement[]
+          instances = getInstancesOfObjectType(elements, objWithAddressField)
         })
 
         it('should call query with the object fields', () => {
@@ -1284,9 +1269,7 @@ describe('Custom Object Instances filter', () => {
     describe('grandparent object (no master)', () => {
       let instances: InstanceElement[]
       beforeEach(async () => {
-        instances = await awu(elements).filter(
-          async e => isInstanceElement(e) && await e.getType() === grandparentObject
-        ).toArray() as InstanceElement[]
+        instances = getInstancesOfObjectType(elements, grandparentObject)
       })
 
       it('should base elemID on record name only', () => {
@@ -1297,9 +1280,7 @@ describe('Custom Object Instances filter', () => {
     describe('parent object (master is grandparent)', () => {
       let instances: InstanceElement[]
       beforeEach(async () => {
-        instances = await awu(elements).filter(
-          async e => isInstanceElement(e) && await e.getType() === parentObject
-        ).toArray() as InstanceElement[]
+        instances = getInstancesOfObjectType(elements, parentObject)
       })
 
       it('should base elemID on grandparentName + parent', () => {
@@ -1312,9 +1293,7 @@ describe('Custom Object Instances filter', () => {
     describe('grandson object (master is parent who has grandparent as master)', () => {
       let instances: InstanceElement[]
       beforeEach(async () => {
-        instances = await awu(elements).filter(
-          async e => isInstanceElement(e) && await e.getType() === grandsonObject
-        ).toArray() as InstanceElement[]
+        instances = getInstancesOfObjectType(elements, grandsonObject)
       })
 
       it('should base elemID on grandparentName + parent + grandson if all exist', () => {
@@ -1328,9 +1307,7 @@ describe('Custom Object Instances filter', () => {
     describe('orphan object (master non-existance)', () => {
       let instances: InstanceElement[]
       beforeEach(async () => {
-        instances = await awu(elements).filter(
-          async e => isInstanceElement(e) && await e.getType() === orphanObject
-        ).toArray() as InstanceElement[]
+        instances = getInstancesOfObjectType(elements, orphanObject)
       })
       it('should not create instances and suggest to add to include list', () => {
         expect(instances).toHaveLength(0)
@@ -1346,9 +1323,7 @@ describe('Custom Object Instances filter', () => {
     describe('badIdFields object', () => {
       let instances: InstanceElement[]
       beforeEach(async () => {
-        instances = await awu(elements).filter(
-          async e => isInstanceElement(e) && await e.getType() === badIdFieldsObject
-        ).toArray() as InstanceElement[]
+        instances = getInstancesOfObjectType(elements, badIdFieldsObject)
       })
 
       it('should not create instances and suggest to add to include list', () => {
@@ -1365,9 +1340,7 @@ describe('Custom Object Instances filter', () => {
     describe('notQueryableIdFields object', () => {
       let instances: InstanceElement[]
       beforeEach(async () => {
-        instances = await awu(elements).filter(
-          async e => isInstanceElement(e) && await e.getType() === notQueryableIdFieldsObject
-        ).toArray() as InstanceElement[]
+        instances = getInstancesOfObjectType(elements, notQueryableIdFieldsObject)
       })
 
       it('should not create instances and suggest to add to include list', () => {
@@ -1384,9 +1357,7 @@ describe('Custom Object Instances filter', () => {
     describe('ref from object (with master that is defined as ref to and not "base" object)', () => {
       let instances: InstanceElement[]
       beforeEach(async () => {
-        instances = await awu(elements).filter(
-          async e => isInstanceElement(e) && await e.getType() === refFromObject
-        ).toArray() as InstanceElement[]
+        instances = getInstancesOfObjectType(elements, refFromObject)
       })
 
       it('should base elemID on refTo name as "parent" and refFrom as "child"', () => {
@@ -1399,9 +1370,7 @@ describe('Custom Object Instances filter', () => {
     describe('ref to object (not base object, only fetched cause of ref to it)', () => {
       let instances: InstanceElement[]
       beforeEach(async () => {
-        instances = await awu(elements).filter(
-          async e => isInstanceElement(e) && await e.getType() === refToObject
-        ).toArray() as InstanceElement[]
+        instances = getInstancesOfObjectType(elements, refToObject)
       })
 
       it('should base elemID on record name', () => {
@@ -1412,9 +1381,7 @@ describe('Custom Object Instances filter', () => {
     describe('PricebookEntry object (special case - Lookup)', () => {
       let instances: InstanceElement[]
       beforeEach(async () => {
-        instances = await awu(elements).filter(
-          async e => isInstanceElement(e) && await e.getType() === pricebookEntryObject
-        ).toArray() as InstanceElement[]
+        instances = getInstancesOfObjectType(elements, pricebookEntryObject)
       })
 
       it('should base elemID on Pricebook2Id lookup name + the entry', () => {
@@ -1427,9 +1394,7 @@ describe('Custom Object Instances filter', () => {
     describe('Product2 object - checking case of non-existing values', () => {
       let instances: InstanceElement[]
       beforeEach(async () => {
-        instances = await awu(elements).filter(
-          async e => isInstanceElement(e) && await e.getType() === productObject
-        ).toArray() as InstanceElement[]
+        instances = getInstancesOfObjectType(elements, productObject)
       })
 
       it('should base elemID on name only because value of other field is null', () => {
@@ -1448,9 +1413,7 @@ describe('Custom Object Instances filter', () => {
     describe('SBQQ__CustomAction__c object (special case - base on record values besides name)', () => {
       let instances: InstanceElement[]
       beforeEach(async () => {
-        instances = await awu(elements).filter(
-          async e => isInstanceElement(e) && await e.getType() === SBQQCustomActionObject
-        ).toArray() as InstanceElement[]
+        instances = getInstancesOfObjectType(elements, SBQQCustomActionObject)
       })
 
       it('should base elemID on Name + displayOrder + location', () => {


### PR DESCRIPTION
Use the changed-at data we aggregate into the changed-at Singleton in the SOQL query we use to fetch instances

---

**PR Chain**:
 - https://github.com/salto-io/salto/pull/5071
 - https://github.com/salto-io/salto/pull/4964
 - https://github.com/salto-io/salto/pull/4965 👈 YOU ARE HERE 👈 

---
_Release Notes_: 
Salesforce: Quickfetch is now supported for data records

---
_User Notifications_: 
N/A
