### PR TITLE
SALTO-4872: workflow transition changes are not deployed 

### DIFF
--- a/packages/jira-adapter/src/filters/workflow/conditions_types.ts
+++ b/packages/jira-adapter/src/filters/workflow/conditions_types.ts
@@ -16,11 +16,12 @@
 import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, ListType, ObjectType } from '@salto-io/adapter-api'
 import { elements } from '@salto-io/adapter-components'
 import { CONDITION_CONFIGURATION, JIRA } from '../../constants'
+import { addAnnotationRecursively } from '../../utils'
 
-export const createConditionConfigurationTypes = (): {
+export const createConditionConfigurationTypes = async (): Promise<{
   type: ObjectType
   subTypes: ObjectType[]
-} => {
+}> => {
   const conditionProjectRoleType = new ObjectType({
     elemID: new ElemID(JIRA, 'ConditionProjectRole'),
     fields: {
@@ -155,6 +156,9 @@ export const createConditionConfigurationTypes = (): {
     },
     path: [JIRA, elements.TYPES_PATH, 'ConditionConfiguration'],
   })
+
+  await addAnnotationRecursively(conditionConfigurationType, CORE_ANNOTATIONS.CREATABLE)
+  await addAnnotationRecursively(conditionConfigurationType, CORE_ANNOTATIONS.UPDATABLE)
 
   return {
     type: conditionConfigurationType,

--- a/packages/jira-adapter/src/filters/workflow/workflow_structure_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_structure_filter.ts
@@ -195,7 +195,7 @@ const filter: FilterCreator = ({ config }) => ({
 
     const workflowRulesType = findObject(elements, WORKFLOW_RULES_TYPE_NAME)
 
-    const conditionConfigurationTypes = createConditionConfigurationTypes()
+    const conditionConfigurationTypes = await createConditionConfigurationTypes()
 
     if (workflowRulesType !== undefined) {
       workflowRulesType.fields.conditions = new Field(workflowRulesType, 'conditions', await workflowRulesType.fields.conditionsTree.getType())
@@ -212,7 +212,15 @@ const filter: FilterCreator = ({ config }) => ({
     const worfkflowConditionType = findObject(elements, 'WorkflowCondition')
 
     if (worfkflowConditionType !== undefined) {
-      worfkflowConditionType.fields.configuration = new Field(worfkflowConditionType, 'configuration', conditionConfigurationTypes.type)
+      worfkflowConditionType.fields.configuration = new Field(
+        worfkflowConditionType,
+        'configuration',
+        conditionConfigurationTypes.type,
+        {
+          [CORE_ANNOTATIONS.CREATABLE]: true,
+          [CORE_ANNOTATIONS.UPDATABLE]: true,
+        }
+      )
     }
 
     elements.push(...postFunctionTypes)

--- a/packages/jira-adapter/test/filters/workflow/workflow_structure_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_structure_filter.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, ElemID, Field, InstanceElement, MapType, ObjectType } from '@salto-io/adapter-api'
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, InstanceElement, MapType, ObjectType } from '@salto-io/adapter-api'
 import { naclCase } from '@salto-io/adapter-utils'
 import JiraClient from '../../../src/client/client'
 import { JIRA, WORKFLOW_RULES_TYPE_NAME, WORKFLOW_TRANSITION_TYPE_NAME, WORKFLOW_TYPE_NAME } from '../../../src/constants'
@@ -148,6 +148,10 @@ describe('workflowStructureFilter', () => {
       await filter.onFetch?.(elements)
       expect(elements.length).toBeGreaterThan(1)
       expect((await workflowConditionType.fields.configuration.getType()).elemID.getFullName()).toBe('jira.ConditionConfiguration')
+      expect(workflowConditionType.fields.configuration.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
     })
     it('should convert transitions type to a map', async () => {
       await filter.onFetch?.([transitionType, workflowType])


### PR DESCRIPTION
Added missing annotation to workflow

---
_Release Notes_: 
__Jira Adapter__:
- Fixed a bug where workflow transition configuration would not be deployed

---
_User Notifications_: 
None