### PR TITLE
SALTO-4850: Support deploy of request Type 

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -123,6 +123,7 @@ import prioritySchemeProjectAssociationFilter from './filters/data_center/priori
 import { GetUserMapFunc, getUserMapFuncCreator } from './users'
 import commonFilters from './filters/common'
 import accountInfoFilter from './filters/account_info'
+import requestTypeFilter from './filters/request_type'
 import deployPermissionSchemeFilter from './filters/permission_scheme/deploy_permission_scheme_filter'
 import scriptRunnerWorkflowFilter from './filters/script_runner/workflow/workflow_filter'
 import pluginVersionFliter from './filters/data_center/plugin_version'
@@ -324,6 +325,7 @@ export const DEFAULT_FILTERS = [
   portalSettingsFilter,
   queueDeleteFilter,
   portalGroupsFilter,
+  requestTypeFilter,
   deployJsmTypesFilter,
   // Must be done after JsmTypesFilter
   jsmPathFilter,

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1832,7 +1832,6 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       sourceTypeName: 'RequestType__values',
       dataField: 'values',
       fieldsToOmit: [
-        { fieldName: 'icon' },
         { fieldName: '_expands' },
         { fieldName: 'serviceDeskId' },
         { fieldName: 'portalId' },
@@ -1840,7 +1839,24 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       ],
       fieldsToHide: [
         { fieldName: 'id' },
+        { fieldName: 'icon' },
       ],
+    },
+    deployRequests: {
+      add: {
+        url: '/rest/servicedeskapi/servicedesk/{serviceDeskId}/requesttype',
+        method: 'post',
+        urlParamsToFields: {
+          serviceDeskId: '_parent.0.serviceDeskId',
+        },
+      },
+      remove: {
+        url: '/rest/servicedeskapi/servicedesk/{serviceDeskId}/requesttype/{id}',
+        method: 'delete',
+        urlParamsToFields: {
+          serviceDeskId: '_parent.0.serviceDeskId',
+        },
+      },
     },
   },
   CustomerPermissions: {

--- a/packages/jira-adapter/src/filters/layouts/layout_service_operations.ts
+++ b/packages/jira-adapter/src/filters/layouts/layout_service_operations.ts
@@ -36,6 +36,7 @@ type layoutTypeDetails = {
     pathParam: string
     query: string
     layoutType?: string
+    fieldName?: string
 }
 
 type QueryVariables = {
@@ -44,12 +45,13 @@ type QueryVariables = {
     layoutType?: string
   }
 
-type LayoutTypeName = 'RequestForm' | 'IssueView' | 'IssueLayout'
-const layoutTypeNameToDetails: Record<LayoutTypeName, layoutTypeDetails> = {
+export type LayoutTypeName = 'RequestForm' | 'IssueView' | 'IssueLayout'
+export const layoutTypeNameToDetails: Record<LayoutTypeName, layoutTypeDetails> = {
   [REQUEST_FORM_TYPE]: {
     layoutType: 'REQUEST_FORM',
     pathParam: 'RequestForm',
     query: QUERY_JSM,
+    fieldName: 'requestForm',
   },
   [ISSUE_LAYOUT_TYPE]: {
     pathParam: 'layouts',
@@ -59,10 +61,11 @@ const layoutTypeNameToDetails: Record<LayoutTypeName, layoutTypeDetails> = {
     layoutType: 'ISSUE_VIEW',
     pathParam: 'IssueView',
     query: QUERY_JSM,
+    fieldName: 'issueView',
   },
 }
 
-const isIssueLayoutResponse = createSchemeGuard<IssueLayoutResponse>(ISSUE_LAYOUT_RESPONSE_SCHEME)
+export const isIssueLayoutResponse = createSchemeGuard<IssueLayoutResponse>(ISSUE_LAYOUT_RESPONSE_SCHEME)
 const isLayoutConfigItem = createSchemeGuard<layoutConfigItem>(ISSUE_LAYOUT_CONFIG_ITEM_SCHEME)
 
 function isLayoutTypeName(typeName: string): typeName is LayoutTypeName {

--- a/packages/jira-adapter/src/filters/layouts/layout_service_operations.ts
+++ b/packages/jira-adapter/src/filters/layouts/layout_service_operations.ts
@@ -32,11 +32,11 @@ import { ISSUE_LAYOUT_TYPE, ISSUE_VIEW_TYPE, JIRA, REQUEST_FORM_TYPE, REQUEST_TY
 const log = logger(module)
 const { isDefined } = lowerDashValues
 
-type layoutTypeDetails = {
+type LayoutTypeDetails = {
     pathParam: string
     query: string
     layoutType?: string
-    fieldName?: string
+    fieldName: string
 }
 
 type QueryVariables = {
@@ -46,7 +46,7 @@ type QueryVariables = {
   }
 
 export type LayoutTypeName = 'RequestForm' | 'IssueView' | 'IssueLayout'
-export const layoutTypeNameToDetails: Record<LayoutTypeName, layoutTypeDetails> = {
+export const LAYOUT_TYPE_NAME_TO_DETAILS: Record<LayoutTypeName, LayoutTypeDetails> = {
   [REQUEST_FORM_TYPE]: {
     layoutType: 'REQUEST_FORM',
     pathParam: 'RequestForm',
@@ -56,6 +56,7 @@ export const layoutTypeNameToDetails: Record<LayoutTypeName, layoutTypeDetails> 
   [ISSUE_LAYOUT_TYPE]: {
     pathParam: 'layouts',
     query: QUERY,
+    fieldName: 'issueLayout',
   },
   [ISSUE_VIEW_TYPE]: {
     layoutType: 'ISSUE_VIEW',
@@ -69,7 +70,7 @@ export const isIssueLayoutResponse = createSchemeGuard<IssueLayoutResponse>(ISSU
 const isLayoutConfigItem = createSchemeGuard<layoutConfigItem>(ISSUE_LAYOUT_CONFIG_ITEM_SCHEME)
 
 function isLayoutTypeName(typeName: string): typeName is LayoutTypeName {
-  return Object.keys(layoutTypeNameToDetails).includes(typeName)
+  return Object.keys(LAYOUT_TYPE_NAME_TO_DETAILS).includes(typeName)
 }
 
 export const getLayoutResponse = async ({
@@ -83,7 +84,7 @@ export const getLayoutResponse = async ({
     }): Promise<graphQLResponseType> => {
   const baseUrl = '/rest/gira/1'
   try {
-    const query = layoutTypeNameToDetails[typeName]?.query
+    const query = LAYOUT_TYPE_NAME_TO_DETAILS[typeName]?.query
     if (query === undefined) {
       log.error(`Failed to get issue layout for project ${variables.projectId} and screen ${variables.extraDefinerId}: query is undefined`)
     }
@@ -145,7 +146,7 @@ export const getLayout = async ({
       instanceName,
       layoutType,
       value,
-      [...instance.path.slice(0, -1), layoutTypeNameToDetails[typeName].pathParam, pathNaclCase(instanceName)],
+      [...instance.path.slice(0, -1), LAYOUT_TYPE_NAME_TO_DETAILS[typeName].pathParam, pathNaclCase(instanceName)],
     )
   }
   return undefined
@@ -271,7 +272,7 @@ export const fetchRequestTypeDetails = async ({
       const variables = {
         projectId: projectInstance.value.id,
         extraDefinerId: requestTypeId,
-        layoutType: layoutTypeNameToDetails[typeName].layoutType,
+        layoutType: LAYOUT_TYPE_NAME_TO_DETAILS[typeName].layoutType,
       }
       const response = await getLayoutResponse({
         variables,

--- a/packages/jira-adapter/src/filters/layouts/layout_types.ts
+++ b/packages/jira-adapter/src/filters/layouts/layout_types.ts
@@ -114,7 +114,7 @@ export type layoutConfigItem = {
 
 export const ISSUE_LAYOUT_CONFIG_ITEM_SCHEME = Joi.object({
   type: Joi.string().required(),
-  sectionType: Joi.string().invalid('HIDDEN_ITEMS', 'REQUEST_PORTAL').required(),
+  sectionType: Joi.string().valid('PRIMARY', 'SECONDARY', 'CONTENT', 'REQUEST').required(),
   key: Joi.string().required(),
 }).unknown(true).required()
 

--- a/packages/jira-adapter/src/filters/layouts/layout_types.ts
+++ b/packages/jira-adapter/src/filters/layouts/layout_types.ts
@@ -108,13 +108,13 @@ export type IssueLayoutResponse = {
 
 export type layoutConfigItem = {
   type: string
-  sectionType: 'PRIMARY' | 'SECONDARY' | 'CONTENT' | 'REQUEST' | 'REQUEST_PORTAL'
+  sectionType: 'PRIMARY' | 'SECONDARY' | 'CONTENT' | 'REQUEST'
   key: string
 }
 
 export const ISSUE_LAYOUT_CONFIG_ITEM_SCHEME = Joi.object({
   type: Joi.string().required(),
-  sectionType: Joi.string().invalid('HIDDEN_ITEMS').required(),
+  sectionType: Joi.string().invalid('HIDDEN_ITEMS', 'REQUEST_PORTAL').required(),
   key: Joi.string().required(),
 }).unknown(true).required()
 

--- a/packages/jira-adapter/src/filters/layouts/request_types_layouts_to_values.ts
+++ b/packages/jira-adapter/src/filters/layouts/request_types_layouts_to_values.ts
@@ -58,6 +58,7 @@ const filter: FilterCreator = ({ config }) => ({
       } else {
         requestType.value.issueView = layout.value
       }
+      requestType.value.avatarId = requestType.value.icon.id
     })
   },
 })

--- a/packages/jira-adapter/src/filters/request_type.ts
+++ b/packages/jira-adapter/src/filters/request_type.ts
@@ -1,0 +1,180 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { AdditionChange, Change, InstanceElement, ModificationChange, ReferenceExpression, getChangeData, isAdditionChange, isAdditionOrModificationChange, isEqualValues, isInstanceChange, isModificationChange } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { values as lowerDashValues } from '@salto-io/lowerdash'
+import { getParent, isResolvedReferenceExpression } from '@salto-io/adapter-utils'
+import { FilterCreator } from '../filter'
+import { ISSUE_VIEW_TYPE, REQUEST_FORM_TYPE, REQUEST_TYPE_NAME } from '../constants'
+import { deployChanges, defaultDeployChange } from '../deployment/standard_deployment'
+import JiraClient from '../client/client'
+import { layoutConfigItem } from './layouts/layout_types'
+import { LayoutTypeName, getLayoutResponse, isIssueLayoutResponse, layoutTypeNameToDetails } from './layouts/layout_service_operations'
+
+const { isDefined } = lowerDashValues
+
+type statusType = {
+  id: ReferenceExpression
+  original: string
+  custom: boolean
+}
+
+const fieldsToIgnore = [
+  'issueView',
+  'requestForm',
+  'workflowStatuses',
+  'avatarId',
+  'groupIds',
+]
+
+
+const deployWorkflowStatuses = async (
+  change: ModificationChange<InstanceElement> | AdditionChange<InstanceElement>,
+  client: JiraClient): Promise<void> => {
+  if ((isAdditionChange(change))
+    || (isModificationChange(change)
+    && !isEqualValues(change.data.before.value.workflowStatuses, change.data.after.value.workflowStatuses))) {
+    const instance = getChangeData(change)
+    const parent = getParent(instance)
+    const workflowStatuses = instance.value.workflowStatuses.map((status: statusType) => ({
+      id: status.id?.value.value.id,
+      original: status.id?.value.value.name,
+      custom: status.custom,
+    }))
+    await client.post({
+      url: `/rest/servicedesk/1/servicedesk-data/${parent.value.key}/request-type/${instance.value.id}/workflow`,
+      data: workflowStatuses,
+    })
+  }
+}
+
+const isRequesTypeDetailsChange = (
+  change: ModificationChange<InstanceElement>,
+  fieldName: string,
+): boolean => fieldName === 'requestForm'
+  && (change.data.before.value.name !== change.data.after.value.name
+    || change.data.before.value.description !== change.data.after.value.description
+    || change.data.before.value.helpText !== change.data.after.value.helpText)
+
+
+const deployRequestTypeLayout = async (
+  change: Change<InstanceElement>,
+  client: JiraClient,
+  typeName: LayoutTypeName,
+): Promise<void> => {
+  const requestType = getChangeData(change)
+  const { fieldName } = layoutTypeNameToDetails[typeName]
+  if (fieldName === undefined) {
+    return undefined
+  }
+  if ((isAdditionChange(change))
+  || (isModificationChange(change)
+  && (!isEqualValues(change.data.before.value[fieldName], change.data.after.value[fieldName])
+  || isRequesTypeDetailsChange(change, fieldName)))) {
+    const layout = requestType.value[fieldName]
+    const items = layout.issueLayoutConfig.items.map((item: layoutConfigItem) => {
+      if (isResolvedReferenceExpression(item.key)) {
+        const key = item.key.value.value.id
+        return {
+          type: item.type,
+          sectionType: item.sectionType.toLocaleLowerCase(),
+          key,
+          data: {
+            name: item.key.value.value.name,
+            type: item.key.value.value.type ?? item.key.value.value.schema.system,
+          },
+        }
+      }
+      return undefined
+    }).filter(isDefined)
+
+    const data = {
+      projectId: getParent(requestType).value.id,
+      extraDefinerId: requestType.value.id,
+      issueLayoutType: layoutTypeNameToDetails[typeName].layoutType,
+      owners: [
+        {
+          type: 'REQUEST_TYPE',
+          data: {
+            id: requestType.value.id,
+            name: requestType.value.name,
+            description: requestType.value.description,
+            avatarId: requestType.value.avatarId,
+            instructions: requestType.value.helpText,
+          },
+        },
+      ],
+      issueLayoutConfig: {
+        items,
+      },
+    }
+    if (isAdditionChange(change)) {
+      const variables = {
+        projectId: getParent(requestType).value.id,
+        extraDefinerId: requestType.value.id,
+        layoutType: layoutTypeNameToDetails[typeName].layoutType,
+      }
+      const response = await getLayoutResponse({ variables, client, typeName })
+      if (!isIssueLayoutResponse(response.data)) {
+        throw Error('Failed to deploy issue layout changes due to bad response from jira service')
+      }
+      layout.id = response.data.issueLayoutConfiguration.issueLayoutResult.id
+    }
+    const url = `/rest/internal/1.0/issueLayouts/${layout.id}`
+    await client.put({ url, data })
+  }
+
+  return undefined
+}
+
+
+const filter: FilterCreator = ({ config, client }) => ({
+  name: 'requestTypeFilter',
+  deploy: async (changes: Change<InstanceElement>[]) => {
+    const { jsmApiDefinitions } = config
+    if (!config.fetch.enableJSM || jsmApiDefinitions === undefined) {
+      return {
+        deployResult: { appliedChanges: [], errors: [] },
+        leftoverChanges: changes,
+      }
+    }
+    const [relevantChanges, leftoverChanges] = _.partition(
+      changes,
+      change =>
+        getChangeData(change).elemID.typeName === REQUEST_TYPE_NAME
+        && isInstanceChange(change)
+    )
+
+    const deployResult = await deployChanges(
+      relevantChanges,
+      async change => {
+        if (isAdditionOrModificationChange(change)) {
+          if (isAdditionChange(change)) {
+            await defaultDeployChange({ change, client, apiDefinitions: jsmApiDefinitions, fieldsToIgnore })
+          }
+          await deployRequestTypeLayout(change, client, REQUEST_FORM_TYPE)
+          await deployRequestTypeLayout(change, client, ISSUE_VIEW_TYPE)
+          await deployWorkflowStatuses(change, client)
+        } else {
+          await defaultDeployChange({ change, client, apiDefinitions: jsmApiDefinitions, fieldsToIgnore })
+        }
+      }
+    )
+    return { deployResult, leftoverChanges }
+  },
+})
+export default filter

--- a/packages/jira-adapter/test/filters/request_type.test.ts
+++ b/packages/jira-adapter/test/filters/request_type.test.ts
@@ -1,0 +1,377 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
+import _ from 'lodash'
+import { InstanceElement, ReferenceExpression, CORE_ANNOTATIONS, Value } from '@salto-io/adapter-api'
+import { MockInterface } from '@salto-io/test-utils'
+import { getDefaultConfig } from '../../src/config/config'
+import requestTypeFilter from '../../src/filters/request_type'
+import { createEmptyType, getFilterParams, mockClient } from '../utils'
+import { PROJECT_TYPE, REQUEST_TYPE_NAME } from '../../src/constants'
+import JiraClient from '../../src/client/client'
+
+describe('requestType filter', () => {
+    type FilterType = filterUtils.FilterWith<'deploy'>
+    let filter: FilterType
+    let connection: MockInterface<clientUtils.APIConnection>
+    let client: JiraClient
+    let mockGet: jest.SpyInstance
+    let projectInstance: InstanceElement
+    let requestTypeInstance: InstanceElement
+    let workFlowStatusOne: Value
+    let requestFormValue: Value
+    let issueViewValue: Value
+    const fieldInstanceOne = new InstanceElement(
+      'field1',
+      createEmptyType('Field'),
+      {
+        id: 'testField1Id',
+        name: 'field1',
+        type: 'testField1Type',
+      },
+    )
+    const fieldInstanceTwo = new InstanceElement(
+      'field2',
+      createEmptyType('Field'),
+      {
+        id: 'testField2Id',
+        name: 'field2',
+        type: 'testField2Type',
+      },
+    )
+    const statusInstanceOne = new InstanceElement(
+      'status1',
+      createEmptyType('Status'),
+      {
+        id: '1000',
+        name: 'status1',
+      },
+    )
+    describe('deploy', () => {
+      beforeEach(() => {
+        const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+        config.fetch.enableJSM = true
+        const { client: cli, connection: conn } = mockClient(false)
+        connection = conn
+        client = cli
+        filter = requestTypeFilter(getFilterParams({ config, client })) as typeof filter
+        projectInstance = new InstanceElement(
+          'project1',
+          createEmptyType(PROJECT_TYPE),
+          {
+            id: 1,
+            name: 'project1',
+            projectTypeKey: 'service_desk',
+            key: 'project1Key',
+            serviceDeskId: 'serviceDeskId',
+          },
+        )
+        workFlowStatusOne = {
+          id: new ReferenceExpression(statusInstanceOne.elemID, statusInstanceOne),
+          custom: 'My custom status',
+        }
+
+        requestFormValue = {
+          id: 4,
+          issueLayoutConfig: {
+            items: [{
+              type: 'FIELD',
+              sectionType: 'REQUEST',
+              key: new ReferenceExpression(fieldInstanceOne.elemID, fieldInstanceOne),
+            }],
+          },
+        }
+
+        issueViewValue = {
+          if: 5,
+          issueLayoutConfig: {
+            items: [{
+              type: 'FIELD',
+              sectionType: 'REQUEST',
+              key: new ReferenceExpression(fieldInstanceTwo.elemID, fieldInstanceTwo),
+            }],
+          },
+        }
+        requestTypeInstance = new InstanceElement(
+          'requestType1',
+          createEmptyType(REQUEST_TYPE_NAME),
+          {
+            id: 10,
+            name: 'requestType1',
+            description: 'requestType1 description',
+            workflowStatuses: [
+              workFlowStatusOne,
+            ],
+            requestForm: requestFormValue,
+            issueView: issueViewValue,
+            avatarId: 'avatarId1',
+            helpText: 'helpText1',
+          },
+          undefined,
+          {
+            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(projectInstance.elemID, projectInstance)],
+          },
+        )
+        mockGet = jest.spyOn(client, 'gqlPost')
+        mockGet.mockImplementation(params => {
+          if (params.url === '/rest/gira/1') {
+            return {
+              data: {
+                issueLayoutConfiguration: {
+                  issueLayoutResult: {
+                    id: '2',
+                    name: 'Default Issue Layout',
+                    containers: [
+                      {
+                        containerType: 'PRIMARY',
+                        items: {
+                          nodes: [
+                            {
+                              fieldItemId: 'testField1',
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        containerType: 'SECONDARY',
+                        items: {
+                          nodes: [
+                            {
+                              fieldItemId: 'testField2',
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            }
+          }
+          throw new Error('Err')
+        })
+      })
+      it('should deploy addition of a request type', async () => {
+        const res = await filter.deploy([{ action: 'add', data: { after: requestTypeInstance } }])
+        expect(res.leftoverChanges).toHaveLength(0)
+        expect(res.deployResult.errors).toHaveLength(0)
+        expect(res.deployResult.appliedChanges).toHaveLength(1)
+        // One call to deploy requestType and one to deployy workflow statuses.
+        expect(connection.post).toHaveBeenCalledTimes(2)
+        expect(connection.post).toHaveBeenCalledWith(
+          '/rest/servicedeskapi/servicedesk/serviceDeskId/requesttype',
+          {
+            id: 10,
+            name: 'requestType1',
+            description: 'requestType1 description',
+            helpText: 'helpText1',
+          },
+          undefined,
+        )
+        expect(connection.post).toHaveBeenCalledWith(
+          '/rest/servicedesk/1/servicedesk-data/project1Key/request-type/10/workflow',
+          [
+            {
+              custom: 'My custom status',
+              id: '1000',
+              original: 'status1',
+            },
+          ],
+          undefined,
+        )
+        // one for requestForm and one for issueView
+        expect(connection.put).toHaveBeenCalledTimes(2)
+        expect(connection.put).toHaveBeenCalledWith(
+          '/rest/internal/1.0/issueLayouts/2',
+          { extraDefinerId: 10,
+            projectId: 1,
+            owners: [{
+              type: 'REQUEST_TYPE',
+              data: {
+                id: 10,
+                name: 'requestType1',
+                description: 'requestType1 description',
+                avatarId: 'avatarId1',
+                instructions: 'helpText1',
+              },
+            }],
+            issueLayoutType: 'REQUEST_FORM',
+            issueLayoutConfig: {
+              items: [
+                { key: 'testField1Id',
+                  sectionType: 'request',
+                  type: 'FIELD',
+                  data: {
+                    name: 'field1',
+                    type: 'testField1Type',
+                  } },
+              ],
+            } },
+          undefined
+        )
+        expect(connection.put).toHaveBeenCalledWith(
+          '/rest/internal/1.0/issueLayouts/2',
+          { extraDefinerId: 10,
+            projectId: 1,
+            owners: [{
+              type: 'REQUEST_TYPE',
+              data: {
+                id: 10,
+                name: 'requestType1',
+                description: 'requestType1 description',
+                avatarId: 'avatarId1',
+                instructions: 'helpText1',
+              },
+            }],
+            issueLayoutType: 'ISSUE_VIEW',
+            issueLayoutConfig: {
+              items: [
+                { key: 'testField2Id',
+                  sectionType: 'request',
+                  type: 'FIELD',
+                  data: {
+                    name: 'field2',
+                    type: 'testField2Type',
+                  } },
+              ],
+            } },
+          undefined
+        )
+      })
+      it('should deploy modification of a request type name', async () => {
+        const requestTypeAfter = requestTypeInstance.clone()
+        requestTypeAfter.value.name = 'requestType1Modified'
+        const res = await filter.deploy([{ action: 'modify', data: { before: requestTypeInstance, after: requestTypeAfter } }])
+        expect(res.leftoverChanges).toHaveLength(0)
+        expect(res.deployResult.errors).toHaveLength(0)
+        expect(res.deployResult.appliedChanges).toHaveLength(1)
+        expect(connection.post).toHaveBeenCalledTimes(0)
+        // one call to deploy requestForm
+        expect(connection.put).toHaveBeenCalledTimes(1)
+        expect(connection.put).toHaveBeenCalledWith(
+          '/rest/internal/1.0/issueLayouts/4',
+          { extraDefinerId: 10,
+            projectId: 1,
+            owners: [{
+              type: 'REQUEST_TYPE',
+              data: {
+                id: 10,
+                name: 'requestType1Modified',
+                description: 'requestType1 description',
+                avatarId: 'avatarId1',
+                instructions: 'helpText1',
+              },
+            }],
+            issueLayoutType: 'REQUEST_FORM',
+            issueLayoutConfig: {
+              items: [
+                { key: 'testField1Id',
+                  sectionType: 'request',
+                  type: 'FIELD',
+                  data: {
+                    name: 'field1',
+                    type: 'testField1Type',
+                  } },
+              ],
+            } },
+          undefined
+        )
+      })
+      it('should deploy modification of workflow statuses', async () => {
+        const requestTypeAfter = requestTypeInstance.clone()
+        requestTypeAfter.value.workflowStatuses = [{
+          id: new ReferenceExpression(statusInstanceOne.elemID, statusInstanceOne),
+          custom: 'My custom status modified',
+        }]
+        const res = await filter.deploy([{ action: 'modify', data: { before: requestTypeInstance, after: requestTypeAfter } }])
+        expect(res.leftoverChanges).toHaveLength(0)
+        expect(res.deployResult.errors).toHaveLength(0)
+        expect(res.deployResult.appliedChanges).toHaveLength(1)
+        expect(connection.put).toHaveBeenCalledTimes(0)
+        // one call to deploy workflow statuses
+        expect(connection.post).toHaveBeenCalledTimes(1)
+        expect(connection.post).toHaveBeenCalledWith(
+          '/rest/servicedesk/1/servicedesk-data/project1Key/request-type/10/workflow',
+          [
+            {
+              custom: 'My custom status modified',
+              id: '1000',
+              original: 'status1',
+            },
+          ],
+          undefined,
+        )
+      })
+      it('should deploy modification of request form', async () => {
+        const requestTypeAfter = requestTypeInstance.clone()
+        requestTypeAfter.value.requestForm = {
+          id: 4,
+          issueLayoutConfig: {
+            items: [{
+              type: 'FIELD',
+              sectionType: 'REQUEST',
+              key: new ReferenceExpression(fieldInstanceTwo.elemID, fieldInstanceTwo),
+            }],
+          },
+        }
+        const res = await filter.deploy([{ action: 'modify', data: { before: requestTypeInstance, after: requestTypeAfter } }])
+        expect(res.leftoverChanges).toHaveLength(0)
+        expect(res.deployResult.errors).toHaveLength(0)
+        expect(res.deployResult.appliedChanges).toHaveLength(1)
+        expect(connection.post).toHaveBeenCalledTimes(0)
+        // one call to deploy requestForm
+        expect(connection.put).toHaveBeenCalledTimes(1)
+        expect(connection.put).toHaveBeenCalledWith(
+          '/rest/internal/1.0/issueLayouts/4',
+          { extraDefinerId: 10,
+            projectId: 1,
+            owners: [{
+              type: 'REQUEST_TYPE',
+              data: {
+                id: 10,
+                name: 'requestType1',
+                description: 'requestType1 description',
+                avatarId: 'avatarId1',
+                instructions: 'helpText1',
+              },
+            }],
+            issueLayoutType: 'REQUEST_FORM',
+            issueLayoutConfig: {
+              items: [
+                { key: 'testField2Id',
+                  sectionType: 'request',
+                  type: 'FIELD',
+                  data: {
+                    name: 'field2',
+                    type: 'testField2Type',
+                  } },
+              ],
+            } },
+          undefined
+        )
+      })
+      it('should deploy removal of a request type', async () => {
+        const res = await filter.deploy([{ action: 'remove', data: { before: requestTypeInstance } }])
+        expect(res.leftoverChanges).toHaveLength(0)
+        expect(res.deployResult.errors).toHaveLength(0)
+        expect(res.deployResult.appliedChanges).toHaveLength(1)
+        expect(connection.post).toHaveBeenCalledTimes(0)
+        expect(connection.put).toHaveBeenCalledTimes(0)
+        expect(connection.delete).toHaveBeenCalledTimes(1)
+      })
+    })
+})


### PR DESCRIPTION
In this PR I support deploy of request type. 

---

_Additional context for reviewer_
Request types have several endpoints:

1. For request forms, which also include request type name, description, and help text.
2. For the issue view.
3. For workflow statuses.
4. For groups.

Please review only from commit number 3 - 28b73c4efd87e8cbfe0d2371dc0df208a9c37892. 

---
_Release Notes_: 
_Jira Adapter:_
We are now providing support for the deployment of request types.

---
_User Notifications_: 
None
