### PR TITLE
SALTO-4887: Increase page size for group rules and apps in Okta

### DIFF
--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -981,6 +981,12 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
       serviceUrl: '/admin/workflow/eventhooks',
     },
   },
+  api__v1__groups__rules: {
+    request: {
+      url: '/api/v1/groups/rules',
+      queryParams: { limit: '200' },
+    },
+  },
   GroupRule: {
     transformation: {
       fieldTypeOverrides: [{ fieldName: 'allGroupsValid', fieldType: 'boolean' }],
@@ -991,7 +997,6 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
     deployRequests: {
       add: {
         url: '/api/v1/groups/rules',
-        queryParams: { limit: '200' },
         method: 'post',
         // status update deployed through different endpoint
         fieldsToIgnore: ['status', 'allGroupsValid'],

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -327,6 +327,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
   api__v1__apps: {
     request: {
       url: '/api/v1/apps',
+      queryParams: { limit: '200' },
       recurseInto: [
         {
           type: 'api__v1__apps___appId___groups@uuuuuu_00123_00125uu',
@@ -990,6 +991,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
     deployRequests: {
       add: {
         url: '/api/v1/groups/rules',
+        queryParams: { limit: '200' },
         method: 'post',
         // status update deployed through different endpoint
         fieldsToIgnore: ['status', 'allGroupsValid'],


### PR DESCRIPTION
Default page size was 20 for apps and 50 for rules, changed both to 200 (which is the maximum value supported)

---
_Release Notes_: 
None

---
_User Notifications_: 
None
