### PR TITLE
SALTO-4891: Fixing issue layouts duplicates

### DIFF
--- a/packages/jira-adapter/src/filters/layouts/issue_layout.ts
+++ b/packages/jira-adapter/src/filters/layouts/issue_layout.ts
@@ -41,10 +41,10 @@ const getProjectToScreenMapping = async (elements: Element[]): Promise<Record<st
           .flatMap((struct: issueTypeMappingStruct) => struct.screenSchemeId.value) as unknown[])
           .filter(isInstanceElement)
 
-        const screens = screenSchemes
+        const screens = Array.from(new Set(screenSchemes
           .map(screenScheme => screenScheme.value.screens.default)
           .filter(isResolvedReferenceExpression)
-          .map(defualtScreen => defualtScreen.value.value.id)
+          .map(defualtScreen => defualtScreen.value.value.id)))
         return [project.value.id, screens]
       })))
   )


### PR DESCRIPTION
Fixing incident that can be viewed in [dataDog](https://app.datadoghq.com/logs?query=%40operationId%3Aeb920232-a15a-40f4-ba98-85d88f889aa6%20all%20merge%20errors%20&cols=host%2Cservice&event=AgAAAYs3J2RqNrXPkQAAAAAAAAAYAAAAAEFZczNKMjl0QUFBajFoUEdIZWZGc0FCMwAAACQAAAAAMDE4YjM3NjEtNGVlMy00MTYzLTg1NTEtODJhYjA3YTdiZTE5&index=%2A&messageDisplay=inline&refresh_mode=sliding&stream_sort=desc&viz=stream&from_ts=1697437247087&to_ts=1697437435348&live=false).

---

_Additional context for reviewer_
None

---
_Release Notes_: 
_Jira Adapter:_
Fixing bug in issue layouts that causes to duplicate elemIDs.

---
_User Notifications_: 
None
