### PR TITLE
SALTO-4897: add initialization to article attachment hash

### DIFF
--- a/packages/adapter-components/src/filters/referenced_instance_names.ts
+++ b/packages/adapter-components/src/filters/referenced_instance_names.ts
@@ -69,6 +69,10 @@ const createInstanceReferencedNameParts = (
     if (isTemplateExpression(fieldValue)) {
       return fieldValue.parts.map(part => (isReferenceExpression(part) ? dereferenceFieldValue(part) : _.toString(part))).join('')
     }
+    if (fieldValue === undefined) {
+      log.warn(`In instance: ${instance.elemID.getFullName()}, could not find idField: ${fieldName}, returning ''`)
+      return _.toString(fieldValue)
+    }
     log.warn(`In instance: ${instance.elemID.getFullName()}, could not find reference for referenced idField: ${fieldName}, falling back to original value`)
     return _.toString(fieldValue)
   }

--- a/packages/zendesk-adapter/src/filters/article/utils.ts
+++ b/packages/zendesk-adapter/src/filters/article/utils.ts
@@ -124,7 +124,8 @@ const getAttachmentContent = async ({
     severity: 'Warning',
     elemID: attachment.elemID,
   })
-
+  // need to initialize hash for the case where there is no content
+  attachment.value.hash = 'INVALID_HASH'
   if (article === undefined) {
     const error = `could not add attachment ${attachment.elemID.getFullName()}, as could not find article for article_id ${attachment.value.article_id}`
     log.error(error)


### PR DESCRIPTION
add initialization to article attachment hash

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* when using `&hash` in the `article_attachment` idFields, if the hash field does not exist it will add to the `elemId` the string `INVALID_HASH`

---
_User Notifications_: 
None
