### PR TITLE
SALTO-4898 - Remove fetch warning from e2e

### DIFF
--- a/packages/zendesk-adapter/e2e_test/adapter.test.ts
+++ b/packages/zendesk-adapter/e2e_test/adapter.test.ts
@@ -162,13 +162,7 @@ const cleanup = async (adapterAttr: Reals): Promise<void> => {
     progressReporter:
       { reportProgress: () => null },
   })
-  expect(fetchResult.errors).toHaveLength(1)
-  expect(fetchResult.errors).toEqual([
-    {
-      severity: 'Warning',
-      message: "Salto could not access the custom_statuses resource. Elements from that type were not fetched. Please make sure that this type is enabled in your service, and that the supplied user credentials have sufficient permissions to access this data. You can also exclude this data from Salto's fetches by changing the environment configuration. Learn more at https://help.salto.io/en/articles/6947061-salto-could-not-access-the-resource",
-    },
-  ])
+  expect(fetchResult.errors).toHaveLength(0)
   const { elements } = fetchResult
   const e2eBrandInstances = elements
     .filter(isInstanceElement)
@@ -236,13 +230,7 @@ describe('Zendesk adapter E2E', () => {
           { reportProgress: () => null },
       })
       elements = fetchResult.elements
-      expect(fetchResult.errors).toHaveLength(1)
-      expect(fetchResult.errors).toEqual([
-        {
-          severity: 'Warning',
-          message: "Salto could not access the custom_statuses resource. Elements from that type were not fetched. Please make sure that this type is enabled in your service, and that the supplied user credentials have sufficient permissions to access this data. You can also exclude this data from Salto's fetches by changing the environment configuration. Learn more at https://help.salto.io/en/articles/6947061-salto-could-not-access-the-resource",
-        },
-      ])
+      expect(fetchResult.errors).toHaveLength(0)
       adapterAttr = realAdapter(
         { credentials: credLease.value,
           elementsSource: buildElementsSourceFromElements(elements) },


### PR DESCRIPTION
Removing the warning from the e2e test

---

This comes with enabling the missing custom_statuses feature in the service

---
_Release Notes_: 
None

---
_User Notifications_: 
None