### PR TITLE
SALTO-4818: Failed to get custom references for jira: TypeError: Cannot read properties of undefined

### DIFF
--- a/packages/jira-adapter/src/weak_references/automation_projects.ts
+++ b/packages/jira-adapter/src/weak_references/automation_projects.ts
@@ -39,7 +39,7 @@ const getProjectReferences = async (
   instance: InstanceElement,
 ): Promise<ReferenceInfo[]> => {
   const automationProjects = instance.value.projects
-  if (!isAutomationProjects(automationProjects)) {
+  if (automationProjects === undefined || !isAutomationProjects(automationProjects)) {
     return []
   }
 
@@ -72,7 +72,7 @@ const removeMissingAutomationProjects: WeakReferencesHandler['removeWeakReferenc
     .filter(instance => instance.elemID.typeName === AUTOMATION_TYPE)
     .map(async instance => {
       const automationProjects = instance.value.projects
-      if (!isAutomationProjects(automationProjects)) {
+      if (automationProjects === undefined || !isAutomationProjects(automationProjects)) {
         return undefined
       }
 

--- a/packages/jira-adapter/test/weak_references/automation_projects.test.ts
+++ b/packages/jira-adapter/test/weak_references/automation_projects.test.ts
@@ -60,6 +60,13 @@ describe('automation_projects', () => {
 
       expect(references).toEqual([])
     })
+
+    it('should do nothing if there are no projects', async () => {
+      delete instance.value.projects
+      const references = await automationProjectsHandler.findWeakReferences([instance])
+
+      expect(references).toEqual([])
+    })
   })
 
   describe('removeWeakReferences', () => {
@@ -84,6 +91,14 @@ describe('automation_projects', () => {
 
     it('should do nothing if received invalid automation', async () => {
       instance.value.projects = 'invalid'
+      const fixes = await automationProjectsHandler.removeWeakReferences({ elementsSource })([instance])
+
+      expect(fixes.errors).toEqual([])
+      expect(fixes.fixedElements).toEqual([])
+    })
+
+    it('should do nothing if there are no projects', async () => {
+      delete instance.value.projects
       const fixes = await automationProjectsHandler.removeWeakReferences({ elementsSource })([instance])
 
       expect(fixes.errors).toEqual([])


### PR DESCRIPTION
Fixed automation weak references function

---

I missed a case where the automation does not have a project field

---
_Release Notes_: 
None (no effect on the user)

---
_User Notifications_: 
None