### PR TITLE
SALTO-4905: fix a bug in screenTab fields with missingReference - Jira

### DIFF
--- a/packages/jira-adapter/src/filters/screen/screen.ts
+++ b/packages/jira-adapter/src/filters/screen/screen.ts
@@ -106,6 +106,7 @@ const filter: FilterCreator = ({ config, client }) => ({
       screenTabType.fields.originalFieldsIds = new Field(
         screenTabType,
         'originalFieldsIds',
+        // I used this Map because a regular List did not work with hidden_value
         new MapType(new ListType(BuiltinTypes.STRING)),
         { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true }
       )
@@ -123,6 +124,8 @@ const filter: FilterCreator = ({ config, client }) => ({
                 return {
                   ...tab,
                   fields: fieldIds,
+                  // in screen filter we may remove the beforeInstance screenTab fields,
+                  // a field might be a missing reference so we need to save its original id
                   originalFieldsIds: { ids: fieldIds },
                   position,
                 }
@@ -137,7 +140,7 @@ const filter: FilterCreator = ({ config, client }) => ({
       .filter(isInstanceChange)
       .filter(isModificationChange)
       .filter(change => getChangeData(change).elemID.typeName === SCREEN_TYPE_NAME)
-      .filter(change => !_.isEmpty(change.data.after.value.tabs))
+      .filter(change => !_.isEmpty(change.data.before.value.tabs))
       .forEach(change => {
         Object.values(change.data.before.value.tabs).forEach((tab: Value): void => {
           if (tab.originalFieldsIds.ids) {

--- a/packages/jira-adapter/src/filters/screen/screen.ts
+++ b/packages/jira-adapter/src/filters/screen/screen.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { AdditionChange, BuiltinTypes, CORE_ANNOTATIONS, Field, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, isInstanceElement, isModificationChange, ListType, MapType, ModificationChange, Values } from '@salto-io/adapter-api'
+import { AdditionChange, BuiltinTypes, Change, ChangeDataType, CORE_ANNOTATIONS, Field, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, isInstanceElement, isModificationChange, ListType, MapType, ModificationChange, Value, Values } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { collections } from '@salto-io/lowerdash'
 import { naclCase } from '@salto-io/adapter-utils'
@@ -103,6 +103,12 @@ const filter: FilterCreator = ({ config, client }) => ({
         new ListType(BuiltinTypes.STRING),
         { [CORE_ANNOTATIONS.CREATABLE]: true, [CORE_ANNOTATIONS.UPDATABLE]: true }
       )
+      screenTabType.fields.originalFieldsIds = new Field(
+        screenTabType,
+        'originalFieldsIds',
+        new MapType(new ListType(BuiltinTypes.STRING)),
+        { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true }
+      )
     }
 
     elements
@@ -112,14 +118,32 @@ const filter: FilterCreator = ({ config, client }) => ({
         element.value.tabs = element.value.tabs
           && _.keyBy(
             element.value.tabs.map(
-              (tab: Values, position: number) => ({
-                ...tab,
-                fields: tab.fields && tab.fields.map((field: Values) => field.id),
-                position,
-              })
+              (tab: Values, position: number) => {
+                const fieldIds = tab.fields && tab.fields.map((field: Values) => field.id)
+                return {
+                  ...tab,
+                  fields: fieldIds,
+                  originalFieldsIds: { ids: fieldIds },
+                  position,
+                }
+              }
             ),
             tab => naclCase(tab.name),
           )
+      })
+  },
+  preDeploy: async (changes: Change<ChangeDataType>[]) => {
+    changes
+      .filter(isInstanceChange)
+      .filter(isModificationChange)
+      .filter(change => getChangeData(change).elemID.typeName === SCREEN_TYPE_NAME)
+      .filter(change => !_.isEmpty(change.data.after.value.tabs))
+      .forEach(change => {
+        Object.values(change.data.before.value.tabs).forEach((tab: Value): void => {
+          if (tab.originalFieldsIds.ids) {
+            tab.fields = tab.originalFieldsIds.ids
+          }
+        })
       })
   },
   deploy: async changes => {


### PR DESCRIPTION
_fix a bug in screenTab fields with missingReference_

---

_Additional context for reviewer_
* currently we have a change validator that prevents missing references in the `after` instance
* if the change is a modification, the screen filter uses the `before` instance fields, so we got an error because it is a missing reference.
* I added a hidden value that stores the original fields ids and a `preDeploy` operation to the screen filter that uses the original fields ids in order to prevent this error.

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
