### PR TITLE
SALTO-4887: Increase page size for app-group assignments

### DIFF
--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -400,6 +400,12 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
       },
     },
   },
+  'api__v1__apps___appId___groups@uuuuuu_00123_00125uu': {
+    request: {
+      url: 'api/v1/apps/{appId}/groups',
+      queryParams: { limit: '200' },
+    },
+  },
   AppUserSchema: {
     request: {
       url: '/api/v1/meta/schemas/apps/{appId}/default',


### PR DESCRIPTION
Default page size is 20, but the maximum is 200. This should help in big environments to avoid reaching rate limits and make less requests 

---
_Release Notes_: 
None

---
_User Notifications_: 
None
