### PR TITLE
INCIDENT-9318 - Don't crash on missing brand

### DIFF
--- a/packages/zendesk-adapter/src/change_validators/guide_order/order_children_parent_validator.ts
+++ b/packages/zendesk-adapter/src/change_validators/guide_order/order_children_parent_validator.ts
@@ -66,7 +66,7 @@ const orderChildrenDifferentParent = (
       .filter(child => orderParent !== getChildParent(child)?.value.elemID.getFullName())
     return wrongParentChildren.length > 0 ? { orderInstance, wrongParentChildren } : undefined
   } catch (e) {
-    log.warn(`${orderInstance.elemID.getFullName()} does not have parent annotation`)
+    log.error(`${orderInstance.elemID.getFullName()} does not have parent annotation`)
     return undefined
   }
 }

--- a/packages/zendesk-adapter/src/change_validators/utils.ts
+++ b/packages/zendesk-adapter/src/change_validators/utils.ts
@@ -27,9 +27,9 @@ const sectionsOrderScheme = Joi.object({ [SECTIONS_FIELD]: Joi.required() }).req
 const categoriesOrderScheme = Joi.object({ [CATEGORIES_FIELD]: Joi.required() }).required().unknown(true)
 
 const fieldToSchemeGuard: Record<string, (instance: InstanceElement) => boolean> = {
-  [ARTICLES_FIELD]: createSchemeGuardForInstance<ArticlesOrderType>(articlesOrderScheme, 'Received an invalid value for order'),
-  [SECTIONS_FIELD]: createSchemeGuardForInstance<SectionsOrderType>(sectionsOrderScheme, 'Received an invalid value for order'),
-  [CATEGORIES_FIELD]: createSchemeGuardForInstance<CategoriesOrderType>(categoriesOrderScheme, 'Received an invalid value for order'),
+  [ARTICLES_FIELD]: createSchemeGuardForInstance<ArticlesOrderType>(articlesOrderScheme),
+  [SECTIONS_FIELD]: createSchemeGuardForInstance<SectionsOrderType>(sectionsOrderScheme),
+  [CATEGORIES_FIELD]: createSchemeGuardForInstance<CategoriesOrderType>(categoriesOrderScheme),
 }
 
 // Validates that the order field exists in the element's value

--- a/packages/zendesk-adapter/test/change_validators/guide_disabled.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/guide_disabled.test.ts
@@ -16,7 +16,7 @@
 
 import { ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { guideDisabledValidator } from '../../src/change_validators/guide_disabled'
+import { guideDisabledValidator } from '../../src/change_validators'
 import { ZENDESK, CATEGORY_TYPE_NAME } from '../../src/constants'
 import { DEFAULT_CONFIG, FETCH_CONFIG } from '../../src/config'
 
@@ -29,6 +29,7 @@ describe('guideDisabledValidator', () => {
     'brandWithHelpCenterFalse',
     brandType,
     {
+      name: 'brandWithHelpCenterFalse',
       has_help_center: false,
     }
   )
@@ -37,6 +38,7 @@ describe('guideDisabledValidator', () => {
     'brandWithHelpCenterTrue',
     brandType,
     {
+      name: 'brandWithHelpCenterTrue',
       has_help_center: true,
     }
   )


### PR DESCRIPTION
* Prevent crashing in case an instance's brand doesn't exists
* remove error log if guide order instance is empty

---

None

---
_Release Notes_: 
Zendesk Adapter:
* Fix crash on deployment of a guide instance without a brand

---
_User Notifications_: 
None