### PR TITLE
SAAS-9321: Await types promise before creating the metadataInstancesPromise

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -463,13 +463,14 @@ export default class SalesforceAdapter implements AdapterOperations {
         metadataTypeInfosPromise,
         hardCodedTypes,
       )
+    progressReporter.reportProgress({ message: 'Fetching types' })
+    const metadataTypes = await metadataTypesPromise
+
     const metadataInstancesPromise = this.fetchMetadataInstances(
       metadataTypeInfosPromise,
       metadataTypesPromise,
       fetchProfile,
     )
-    progressReporter.reportProgress({ message: 'Fetching types' })
-    const metadataTypes = await metadataTypesPromise
     progressReporter.reportProgress({ message: 'Fetching instances' })
     const {
       elements: metadataInstancesElements,


### PR DESCRIPTION
in `fetch` code inside the SF adapter, we have created 2 promises, and await only the first(metadatatypes)
In the specific use-case described in SAAS-9321, the first promise rejects(and rightfully so, due to invalid credentials)

And the whole fetch handler is returned, however, a few millis after, the second promise(as far as I believe, rejects as well)
And since it's un-handled, crashes the APP with a non zero exit code.


My Suspicion ( did not 100% prove this, as the docs say otherwise, but Im probably missing something here ? ):
In older versions of node, the following error was thrown


`(node:31727) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
`


 and It fits 100% what I'm seeing in this ticket. the APP crashes with a non-zero exit code, and I suspect it's due to this promise.

awaiting it(like done on this PR) solves the issue


I suspect my reasoning is not 100% precent(and hence why I wrote here), but I do believe my fix is a valid one in any case.

---

_Additional context for reviewer_

---

_Release Notes_: 
None

---

_User Notifications_: 
None