### PR TITLE
SALTO-4915: Remove scriptedFields type from Jira E2E

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/cloud/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/index.ts
@@ -16,7 +16,7 @@
 import { InstanceElement, Element, CORE_ANNOTATIONS, ReferenceExpression, ModificationChange } from '@salto-io/adapter-api'
 import { naclCase } from '@salto-io/adapter-utils'
 import { AUTOMATION_TYPE, ESCALATION_SERVICE_TYPE, ISSUE_TYPE_SCHEMA_NAME, NOTIFICATION_SCHEME_TYPE_NAME,
-  SCHEDULED_JOB_TYPE, SCRIPTED_FIELD_TYPE, SCRIPT_FRAGMENT_TYPE, SCRIPT_RUNNER_LISTENER_TYPE,
+  SCHEDULED_JOB_TYPE, SCRIPT_FRAGMENT_TYPE, SCRIPT_RUNNER_LISTENER_TYPE,
   SECURITY_LEVEL_TYPE, SECURITY_SCHEME_TYPE, WORKFLOW_TYPE_NAME } from '../../../src/constants'
 import { createSecurityLevelValues, createSecuritySchemeValues } from './securityScheme'
 import { createIssueTypeSchemeValues } from './issueTypeScheme'

--- a/packages/jira-adapter/e2e_test/instances/cloud/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/index.ts
@@ -30,7 +30,7 @@ import { createKanbanBoardValues, createScrumBoardValues } from './board'
 import { createFilterValues } from './filter'
 import { createIssueLayoutValues } from './issueLayout'
 // import { createBehaviorValues } from './scriptrunner/beahvior'
-import { createScriptedFieldValues } from './scriptrunner/scripted_fields'
+// import { createScriptedFieldValues } from './scriptrunner/scripted_fields'
 import { createScriptRunnerListenerValues } from './scriptrunner/listener'
 import { createScheduledJobsValues } from './scriptrunner/scheduled_jobs'
 import { createEscalationServiceValues } from './scriptrunner/escalation_service'
@@ -140,11 +140,13 @@ export const createInstances = (
   //   findType('Behavior', fetchedElements),
   //   createBehaviorValues(randomString, fetchedElements),
   // )
-  const scriptedField = new InstanceElement(
-    randomString,
-    findType(SCRIPTED_FIELD_TYPE, fetchedElements),
-    createScriptedFieldValues(randomString, fetchedElements),
-  )
+
+  // TODO SALTO-4915 Should uncomment once flakiness is fixes
+  // const scriptedField = new InstanceElement(
+  //   randomString,
+  //   findType(SCRIPTED_FIELD_TYPE, fetchedElements),
+  //   createScriptedFieldValues(randomString, fetchedElements),
+  // )
   const scriptRunnerListeners = new InstanceElement(
     randomString,
     findType(SCRIPT_RUNNER_LISTENER_TYPE, fetchedElements),
@@ -184,7 +186,7 @@ export const createInstances = (
     [filter],
     [issueLayout],
     // [behavior],
-    [scriptedField],
+    // [scriptedField],
     [scriptRunnerListeners],
     [scheduledJobs],
     [escalationService],


### PR DESCRIPTION
Deployment of instances from this type is causing flakiness
removing for now until we figure out why it's happening

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
