### PR TITLE
SALTO-4915 fix jira scriptedFields e2e flakiness

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/cloud/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/index.ts
@@ -16,7 +16,7 @@
 import { InstanceElement, Element, CORE_ANNOTATIONS, ReferenceExpression, ModificationChange } from '@salto-io/adapter-api'
 import { naclCase } from '@salto-io/adapter-utils'
 import { AUTOMATION_TYPE, ESCALATION_SERVICE_TYPE, ISSUE_TYPE_SCHEMA_NAME, NOTIFICATION_SCHEME_TYPE_NAME,
-  SCHEDULED_JOB_TYPE, SCRIPT_FRAGMENT_TYPE, SCRIPT_RUNNER_LISTENER_TYPE,
+  SCHEDULED_JOB_TYPE, SCRIPTED_FIELD_TYPE, SCRIPT_FRAGMENT_TYPE, SCRIPT_RUNNER_LISTENER_TYPE,
   SECURITY_LEVEL_TYPE, SECURITY_SCHEME_TYPE, WORKFLOW_TYPE_NAME } from '../../../src/constants'
 import { createSecurityLevelValues, createSecuritySchemeValues } from './securityScheme'
 import { createIssueTypeSchemeValues } from './issueTypeScheme'
@@ -30,7 +30,7 @@ import { createKanbanBoardValues, createScrumBoardValues } from './board'
 import { createFilterValues } from './filter'
 import { createIssueLayoutValues } from './issueLayout'
 // import { createBehaviorValues } from './scriptrunner/beahvior'
-// import { createScriptedFieldValues } from './scriptrunner/scripted_fields'
+import { createScriptedFieldValues } from './scriptrunner/scripted_fields'
 import { createScriptRunnerListenerValues } from './scriptrunner/listener'
 import { createScheduledJobsValues } from './scriptrunner/scheduled_jobs'
 import { createEscalationServiceValues } from './scriptrunner/escalation_service'
@@ -140,13 +140,11 @@ export const createInstances = (
   //   findType('Behavior', fetchedElements),
   //   createBehaviorValues(randomString, fetchedElements),
   // )
-
-  // TODO SALTO-4915 Should uncomment once flakiness is fixes
-  // const scriptedField = new InstanceElement(
-  //   randomString,
-  //   findType(SCRIPTED_FIELD_TYPE, fetchedElements),
-  //   createScriptedFieldValues(randomString, fetchedElements),
-  // )
+  const scriptedField = new InstanceElement(
+    randomString,
+    findType(SCRIPTED_FIELD_TYPE, fetchedElements),
+    createScriptedFieldValues(randomString, fetchedElements),
+  )
   const scriptRunnerListeners = new InstanceElement(
     randomString,
     findType(SCRIPT_RUNNER_LISTENER_TYPE, fetchedElements),
@@ -186,7 +184,7 @@ export const createInstances = (
     [filter],
     [issueLayout],
     // [behavior],
-    // [scriptedField],
+    [scriptedField],
     [scriptRunnerListeners],
     [scheduledJobs],
     [escalationService],

--- a/packages/jira-adapter/e2e_test/instances/cloud/scriptrunner/scripted_fields.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/scriptrunner/scripted_fields.ts
@@ -29,7 +29,7 @@ export const createScriptedFieldValues = (name: string, allElements: Element[]):
   ],
   scriptedFieldType: 'DATE_FIELD',
   codeToRun: 'issue.projectObject.key == XYZ17',
-  searchTerm: 'ComplexName',
+  searchTerm: `ComplexName${name}`,
   enabled: true,
   itemLocation: 'atl.jira.view.issue.right.context',
 })


### PR DESCRIPTION
fix `Full error from the logs: Search term is already being used by another scripted field` by randomizing the search term as well

---
_Release Notes_: 
None

---
_User Notifications_: 
None