### PR TITLE
SALTO-4808 - Convert JSON pairs of 'id' to reference expression

### DIFF
--- a/packages/zendesk-adapter/config_doc.md
+++ b/packages/zendesk-adapter/config_doc.md
@@ -79,6 +79,7 @@ zendesk {
 | includeAuditDetails                | false                             | When enabled, changed_at and changed_by information will be added to instances
 | handleIdenticalAttachmentConflicts | false                             | When enabled, one attachment will be kept from each set of identical attachments (having the same hash) associated with the same article
 | extractReferencesFromFreeText      | false                             | When enabled, convert ids in zendesk links in string values to salto references
+| convertJsonIdsToReferences         | false                             | When enabled, If a field is a json with an 'id' field, convert its value to a reference
 
 
 ## Fetch entry options

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -85,6 +85,7 @@ export type ZendeskFetchConfig = configUtils.UserFetchConfig
   guide?: Guide
   resolveOrganizationIDs?: boolean
   extractReferencesFromFreeText?: boolean
+  convertJsonIdsToReferences?: boolean
 }
 export type ZedneskDeployConfig = configUtils.UserDeployConfig & configUtils.DefaultMissingUserFallbackConfig & {
   createMissingOrganizations?: boolean
@@ -2940,6 +2941,7 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
           guide: { refType: GuideType },
           resolveOrganizationIDs: { refType: BuiltinTypes.BOOLEAN },
           extractReferencesFromFreeText: { refType: BuiltinTypes.BOOLEAN },
+          convertJsonIdsToReferences: { refType: BuiltinTypes.BOOLEAN },
         },
       ),
     },

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -2973,6 +2973,8 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
       `${FETCH_CONFIG}.includeAuditDetails`,
       `${FETCH_CONFIG}.addAlias`,
       `${FETCH_CONFIG}.handleIdenticalAttachmentConflicts`,
+      `${FETCH_CONFIG}.extractReferencesFromFreeText`,
+      `${FETCH_CONFIG}.convertJsonIdsToReferences`,
       DEPLOY_CONFIG,
     ),
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
@@ -422,9 +422,9 @@ const replaceFormulasWithTemplates = ({
           return expression
         }
 
-        const expressionWithId = expression.replace(idRegex, '')
+        const expressionWithoutId = expression.replace(idRegex, '')
         const idInstance = instance ?? createMissingInstance(ZENDESK, 'unknown', id)
-        return [expressionWithId, new ReferenceExpression(idInstance.elemID, idInstance)]
+        return [expressionWithoutId, new ReferenceExpression(idInstance.elemID, idInstance)]
       }
     )
   }

--- a/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
@@ -449,6 +449,7 @@ const replaceFormulasWithTemplates = ({
     getContainers(instances).forEach(container => {
       const { fieldName } = container
       container.values.forEach(value => {
+        // Has to be first because it needs to receive the whole string, not a template expression
         if (convertJsonIdsToReferences) {
           value[fieldName] = convertIdsInJson(value[fieldName])
         }

--- a/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
@@ -47,6 +47,7 @@ const TICKET_FIELD_SPLIT = '(?:(ticket.ticket_field|ticket.ticket_field_option_t
 const KEY_SPLIT = '(?:([^ ]+\\.custom_fields)\\.)'
 const TITLE_SPLIT = '(?:([^ ]+)\\.(title))'
 const SPLIT_REGEX = `${TICKET_FIELD_SPLIT}|${KEY_SPLIT}|${TITLE_SPLIT}`
+const ID_KEY_IN_JSON_REGEX = /("id"\s*:\s*\d+)/
 export const TICKET_TICKET_FIELD = 'ticket.ticket_field'
 export const TICKET_TICKET_FIELD_OPTION_TITLE = 'ticket.ticket_field_option_title'
 export const TICKET_ORGANIZATION_FIELD = 'ticket.organization.custom_fields'
@@ -231,10 +232,10 @@ const formulaToTemplate = ({
   extractReferencesFromFreeText,
 }: {
   formula: string
-    instancesByType: Record<string, InstanceElement[]>
-    instancesById: Record<string, InstanceElement>
-    enableMissingReferences?: boolean
-    extractReferencesFromFreeText?: boolean
+  instancesByType: Record<string, InstanceElement[]>
+  instancesById: Record<string, InstanceElement>
+  enableMissingReferences?: boolean
+  extractReferencesFromFreeText?: boolean
 }): TemplateExpression | string => {
   const handleZendeskReference = (expression: string, ref: RegExpMatchArray): TemplatePart[] => {
     const reference = ref.pop() ?? ''
@@ -326,7 +327,7 @@ const formulaToTemplate = ({
       if (extractReferencesFromFreeText) {
         // Check if the expression is a link to a zendesk page without a subdomain
         // href="/hc/en-us/../articles/123123
-        const isZendeskLink = new RegExp(`"/hc/\\S*${expression}`).test(formula)
+        const isZendeskLink = new RegExp(`"/hc/\\S*${_.escapeRegExp(expression)}`).test(formula)
         if (isZendeskLink) {
           return transformReferenceUrls({
             urlPart: expression,
@@ -352,11 +353,17 @@ const getContainers = (instances: InstanceElement[]): TemplateContainer[] =>
       ].flat().filter(template.containerValidator).filter(v => !_.isEmpty(v)),
     }))).flat()
 
-const replaceFormulasWithTemplates = (
-  instances: InstanceElement[],
-  enableMissingReferences?: boolean,
+const replaceFormulasWithTemplates = ({
+  instances,
+  enableMissingReferences,
+  extractReferencesFromFreeText,
+  convertJsonIdsToReferences,
+} :{
+  instances: InstanceElement[]
+  enableMissingReferences?: boolean
   extractReferencesFromFreeText?: boolean
-): void => {
+  convertJsonIdsToReferences?: boolean
+}): void => {
   const instancesByType = _.groupBy(instances, i => i.elemID.typeName)
   const instancesById = _.keyBy(
     instances.filter(i => _.isNumber(i.value.id)),
@@ -382,6 +389,46 @@ const replaceFormulasWithTemplates = (
     return new TemplateExpression({ parts: newParts })
   }
 
+  // If a string is a JSON, and it has keys of 'id' with a numeric value - try to convert it to a reference
+  const convertIdsInJson = (value: unknown): unknown => {
+    if (Array.isArray(value)) {
+      return value.map(innerValue => convertIdsInJson(innerValue))
+    }
+    if (!_.isString(value)) {
+      return value
+    }
+    try {
+      // Checks if this is a JSON string
+      JSON.parse(value)
+    } catch {
+      return value
+    }
+    return extractTemplate(
+      value,
+      [ID_KEY_IN_JSON_REGEX],
+      expression => {
+        if (!ID_KEY_IN_JSON_REGEX.test(expression)) {
+          return expression
+        }
+        const idRegex = /\d+/
+        const id = expression.match(idRegex)?.[0]
+        // should always be false, used for type check
+        if (id === undefined) {
+          log.error(`Error parsing id in expression: ${expression}`)
+          return expression
+        }
+        const instance = instancesById[id]
+        if (instance === undefined && !enableMissingReferences) {
+          return expression
+        }
+
+        const expressionWithId = expression.replace(idRegex, '')
+        const idInstance = instance ?? createMissingInstance(ZENDESK, 'unknown', id)
+        return [expressionWithId, new ReferenceExpression(idInstance.elemID, idInstance)]
+      }
+    )
+  }
+
   const formulaToTemplateValue = (value: unknown): unknown => {
     if (Array.isArray(value)) {
       return value.map(innerValue => formulaToTemplateValue(innerValue))
@@ -402,6 +449,9 @@ const replaceFormulasWithTemplates = (
     getContainers(instances).forEach(container => {
       const { fieldName } = container
       container.values.forEach(value => {
+        if (convertJsonIdsToReferences) {
+          value[fieldName] = convertIdsInJson(value[fieldName])
+        }
         value[fieldName] = formulaToTemplateValue(value[fieldName])
       })
     })
@@ -443,11 +493,10 @@ export const prepRef = (part: ReferenceExpression, extractReferencesFromFreeText
 }
 
 export const handleTemplateExpressionsOnFetch = (elements: Element[], config: ZendeskConfig): void => {
-  replaceFormulasWithTemplates(
-    elements.filter(isInstanceElement),
-    config[FETCH_CONFIG].enableMissingReferences,
-    config[FETCH_CONFIG].extractReferencesFromFreeText
-  )
+  replaceFormulasWithTemplates({
+    instances: elements.filter(isInstanceElement),
+    ...config[FETCH_CONFIG],
+  })
 }
 
 /**

--- a/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
+++ b/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
@@ -38,6 +38,12 @@ import { DEFAULT_CONFIG, FETCH_CONFIG } from '../../src/config'
 
 const { createMissingInstance } = referencesUtils
 
+let id = 0
+const newId = (): number => {
+  id += 1
+  return id
+}
+
 describe('handle templates filter', () => {
   type FilterType = filterUtils.FilterWith<'onFetch' | 'onDeploy' | 'preDeploy'>
   let filter: FilterType
@@ -154,34 +160,34 @@ describe('handle templates filter', () => {
     elemID: new ElemID(ZENDESK, USER_FIELD_TYPE_NAME),
   })
 
-  const placeholder1 = new InstanceElement('placeholder1', placeholder1Type, { id: 1452 })
-  const placeholder2 = new InstanceElement('placeholder2', placeholder1Type, { id: 1453 })
-  const placeholder3 = new InstanceElement('placeholder3', placeholder1Type, { id: 1454 })
+  const placeholder1 = new InstanceElement('placeholder1', placeholder1Type, { id: newId() })
+  const placeholder2 = new InstanceElement('placeholder2', placeholder1Type, { id: newId() })
+  const placeholder3 = new InstanceElement('placeholder3', placeholder1Type, { id: newId() })
   const placeholderOrganization1 = new InstanceElement('placeholder-org1', placeholder3Type, { key: 'org' })
   const placeholderOrganization2 = new InstanceElement('placeholder-org2', placeholder3Type, { key: 'org_123' })
   const placeholderUser1 = new InstanceElement('placeholder-user1', placeholder4Type, { key: 'user' })
   const placeholderUser2 = new InstanceElement('placeholder-user2', placeholder4Type, { key: 'user_123' })
 
-  const macro1 = new InstanceElement('macro1', testType, { id: 1001, actions: [{ value: 'non template', field: 'comment_value_html' }] })
-  const macro2 = new InstanceElement('macro2', testType, { id: 1002, actions: [{ value: '{{ticket.ticket_field_1452}}', field: 'comment_value' }] })
-  const macro3 = new InstanceElement('macro3', testType, { id: 1003, actions: [{ value: 'multiple refs {{ticket.ticket_field_1452}} and {{ticket.ticket_field_option_title_1453}}', field: 'comment_value_html' }] })
-  const macroOrganization = new InstanceElement('macroOrg', testType, { id: 1004, actions: [{ value: 'multiple refs {{ticket.organization.custom_fields.org_123}} and {{ticket.organization.custom_fields.org}} and {{ticket.organization.custom_fields.org_123.title}}', field: 'comment_value_html' }] })
-  const macroUser = new InstanceElement('macroUser', testType, { id: 1005, actions: [{ value: 'multiple refs {{ticket.requester.custom_fields.user_123}} and {{ticket.requester.custom_fields.user}} and {{ticket.requester.custom_fields.user_123.title}}', field: 'comment_value_html' }] })
-  const macroMissingUserAndOrganization = new InstanceElement('macroMissingOrgAndUser', testType, { id: 1005, actions: [{ value: 'multiple refs {{ticket.requester.custom_fields.user1}} and {{ticket.requester.custom_fields.user1.title}} and {{ticket.organization.custom_fields.org1}} and {{ticket.organization.custom_fields.org1.title}}', field: 'comment_value_html' }] })
+  const macro1 = new InstanceElement('macro1', testType, { id: newId(), actions: [{ value: 'non template', field: 'comment_value_html' }] })
+  const macro2 = new InstanceElement('macro2', testType, { id: newId(), actions: [{ value: `{{ticket.ticket_field_${placeholder1.value.id}}}`, field: 'comment_value' }] })
+  const macro3 = new InstanceElement('macro3', testType, { id: newId(), actions: [{ value: `multiple refs {{ticket.ticket_field_${placeholder1.value.id}}} and {{ticket.ticket_field_option_title_${placeholder2.value.id}}}`, field: 'comment_value_html' }] })
+  const macroOrganization = new InstanceElement('macroOrg', testType, { id: newId(), actions: [{ value: 'multiple refs {{ticket.organization.custom_fields.org_123}} and {{ticket.organization.custom_fields.org}} and {{ticket.organization.custom_fields.org_123.title}}', field: 'comment_value_html' }] })
+  const macroUser = new InstanceElement('macroUser', testType, { id: newId(), actions: [{ value: 'multiple refs {{ticket.requester.custom_fields.user_123}} and {{ticket.requester.custom_fields.user}} and {{ticket.requester.custom_fields.user_123.title}}', field: 'comment_value_html' }] })
+  const macroMissingUserAndOrganization = new InstanceElement('macroMissingOrgAndUser', testType, { id: newId(), actions: [{ value: 'multiple refs {{ticket.requester.custom_fields.user1}} and {{ticket.requester.custom_fields.user1.title}} and {{ticket.organization.custom_fields.org1}} and {{ticket.organization.custom_fields.org1.title}}', field: 'comment_value_html' }] })
 
-  const macroComplicated = new InstanceElement('macroComplicated', testType, { id: 1003, actions: [{ value: '{{some other irrelevancies-ticket.ticket_field_1452 | something irrelevant | dynamic content now: dc.dynamic_content_test | and done}}', field: 'comment_value_html' }] })
-  const macroDifferentBracket = new InstanceElement('macroDifferentBracket', testType, { id: 1010, actions: [{ value: '{%some other irrelevancies-ticket.ticket_field_1452 | something irrelevant | dynamic content now: dc.dynamic_content_test | and done%}', field: 'comment_value_html' }] })
+  const macroComplicated = new InstanceElement('macroComplicated', testType, { id: newId(), actions: [{ value: `{{some other irrelevancies-ticket.ticket_field_${placeholder1.value.id} | something irrelevant | dynamic content now: dc.dynamic_content_test | and done}}`, field: 'comment_value_html' }] })
+  const macroDifferentBracket = new InstanceElement('macroDifferentBracket', testType, { id: newId(), actions: [{ value: `{%some other irrelevancies-ticket.ticket_field_${placeholder1.value.id} | something irrelevant | dynamic content now: dc.dynamic_content_test | and done%}`, field: 'comment_value_html' }] })
   const macroWithSideConversationTicketTemplate = new InstanceElement(
     'macroSideConvTicket',
     testType,
     {
-      id: 1020,
+      id: newId(),
       actions: [
         {
           value:
             [
-              'Improved needs for {{ticket.ticket_field_option_title_1454}}',
-              '<p>Improved needs for {{ticket.ticket_field_option_title_1454}} due to something</p>',
+              `Improved needs for {{ticket.ticket_field_option_title_${placeholder3.value.id}}}`,
+              `<p>Improved needs for {{ticket.ticket_field_option_title_${placeholder3.value.id}}} due to something</p>`,
               'hello',
               'text/html',
             ],
@@ -190,8 +196,8 @@ describe('handle templates filter', () => {
         {
           value:
             [
-              'Improved needs for {{ticket.ticket_field_option_title_1454}}',
-              '<p>Improved needs for {{ticket.ticket_field_option_title_1454}} due to something</p>',
+              `Improved needs for {{ticket.ticket_field_option_title_${placeholder3.value.id}}}`,
+              `<p>Improved needs for {{ticket.ticket_field_option_title_${placeholder3.value.id}}} due to something</p>`,
               'hello',
               'text/html',
             ],
@@ -200,49 +206,50 @@ describe('handle templates filter', () => {
         {
           value:
             [
-              'Improved needs for {{ticket.ticket_field_1452}}',
-              '<p>Improved needs for {{ticket.ticket_field_1452}} due to something</p>',
+              `Improved needs for {{ticket.ticket_field_${placeholder1.value.id}}}`,
+              `<p>Improved needs for {{ticket.ticket_field_${placeholder1.value.id}}} due to something</p>`,
               'hello',
               'text/html',
             ],
           field: 'side_conversation',
         },
         {
-          value: 'Improved needs for {{ticket.ticket_field_1452}} - {{ticket.ticket_field_1452}}',
+          value: `Improved needs for {{ticket.ticket_field_${placeholder1.value.id}}} - {{ticket.ticket_field_${placeholder1.value.id}}}`,
           field: 'subject',
         },
       ],
     },
   )
 
-  const macroWithDC = new InstanceElement('macroDynamicContent', testType, { id: 1033, actions: [{ value: 'dynamic content ref {{dc.dynamic_content_test}} and {{ticket.ticket_field_option_title_1453}}', field: 'comment_value_html' }] })
-  const macroWithHyphenDC = new InstanceElement('macroHyphenDynamicContent', testType, { id: 1034, actions: [{ value: 'dynamic content ref {{dc.dynamic-content-test}} and {{ticket.ticket_field_option_title_1453}}', field: 'comment_value_html' }] })
+  const macroWithDC = new InstanceElement('macroDynamicContent', testType, { id: newId(), actions: [{ value: `dynamic content ref {{dc.dynamic_content_test}} and {{ticket.ticket_field_option_title_${placeholder2.value.id}}}`, field: 'comment_value_html' }] })
+  const macroWithHyphenDC = new InstanceElement('macroHyphenDynamicContent', testType, { id: newId(), actions: [{ value: `dynamic content ref {{dc.dynamic-content-test}} and {{ticket.ticket_field_option_title_${placeholder2.value.id}}}`, field: 'comment_value_html' }] })
 
-  const macroAlmostTemplate = new InstanceElement('macroAlmost', testType, { id: 1001, actions: [{ value: 'almost template {{ticket.not_an_actual_field_1452}} and {{ticket.ticket_field_1455}}', field: 'comment_value_html' }] })
-  const macroAlmostTemplate2 = new InstanceElement('macroAlmost2', testType, { id: 1001, actions: [{ value: '{{ticket.ticket_field_1452}}', field: 'not_template_field' }] })
-  const target = new InstanceElement('target', targetType, { id: 1004, target_url: 'url: {{ticket.ticket_field_1452}}' })
-  const trigger = new InstanceElement('trigger', triggerType, { id: 1005,
+  const macroAlmostTemplate = new InstanceElement('macroAlmost', testType, { id: newId(), actions: [{ value: `almost template {{ticket.not_an_actual_field_${placeholder1.value.id}}} and {{ticket.ticket_field_0}}`, field: 'comment_value_html' }] })
+  const macroAlmostTemplate2 = new InstanceElement('macroAlmost2', testType, { id: newId(), actions: [{ value: `{{ticket.ticket_field_${placeholder1.value.id}}}`, field: 'not_template_field' }] })
+  const target = new InstanceElement('target', targetType, { id: newId(), target_url: `url: {{ticket.ticket_field_${placeholder1.value.id}}}` })
+  const trigger = new InstanceElement('trigger', triggerType, { id: newId(),
     actions: [{
       field: 'notification_webhook',
       value: [
         ['my test', '{{dc.dynamic_content_test}}'],
         ['dcno', '{{dc.not_exists}}'],
+        ['testJson', `{\n\t"ticket": {\n\t\t"custom_fields": [\n\t\t\t{\n\t\t\t\t"id": ${placeholder1.value.id},\n\t\t\t\t"testdc": "${dynamicContentRecord.value.placeholder}"\n\t\t\t}\n\t\t],\n\t\t"id": ${placeholder2.value.id}\n\t},\n\t"id": ${placeholder3.value.id}\n}\n`],
       ],
     }] })
-  const webhook = new InstanceElement('webhook', webhookType, { id: 1006, endpoint: 'endpoint: {{ticket.ticket_field_1452}}' })
-  const automation = new InstanceElement('automation', automationType, { id: 1007, actions: [{ value: 'ticket: {{ticket.ticket_field_1452}}', field: 'notification_webhook' }] })
-  const dynamicContent = new InstanceElement('dc', dynamicContentItemType, { id: 1008, content: 'content: {{ticket.ticket_field_1452}}' })
+  const webhook = new InstanceElement('webhook', webhookType, { id: newId(), endpoint: `endpoint: {{ticket.ticket_field_${placeholder1.value.id}}}` })
+  const automation = new InstanceElement('automation', automationType, { id: newId(), actions: [{ value: `ticket: {{ticket.ticket_field_${placeholder1.value.id}}}`, field: 'notification_webhook' }] })
+  const dynamicContent = new InstanceElement('dc', dynamicContentItemType, { id: newId(), content: `content: {{ticket.ticket_field_${placeholder1.value.id}}}` })
   const appInstallation = new InstanceElement('appInstallation', appInstallationType, {
-    id: 1009,
-    settings: { uri_templates: 'template: {{ticket.ticket_field_1452}}' },
-    settings_objects: [{ name: 'uri_templates', value: 'object template: {{ticket.ticket_field_1452}}' }],
+    id: newId(),
+    settings: { uri_templates: `template: {{ticket.ticket_field_${placeholder1.value.id}}}` },
+    settings_objects: [{ name: 'uri_templates', value: `object template: {{ticket.ticket_field_${placeholder1.value.id}}}` }],
   })
 
   const article = new InstanceElement(
     'article',
     new ObjectType({ elemID: new ElemID(ZENDESK, ARTICLE_TYPE_NAME) }),
     {
-      id: 12341234,
+      id: newId(),
     }
   )
 
@@ -280,17 +287,17 @@ describe('handle templates filter', () => {
 
     it('should resolve almost-template normally', () => {
       const fetchedMacroAlmostTemplate = elements.filter(isInstanceElement).find(i => i.elemID.name === 'macroAlmost')
-      const missingInstance = createMissingInstance(ZENDESK, 'ticket_field', '1455')
-      missingInstance.value.id = '1455'
+      const missingInstance = createMissingInstance(ZENDESK, 'ticket_field', '0')
+      missingInstance.value.id = '0'
       expect(fetchedMacroAlmostTemplate?.value.actions[0].value).toEqual(new TemplateExpression({
         parts: [
-          `almost template {{ticket.not_an_actual_field_1452}} and {{${TICKET_TICKET_FIELD}_`,
+          `almost template {{ticket.not_an_actual_field_${placeholder1.value.id}}} and {{${TICKET_TICKET_FIELD}_`,
           new ReferenceExpression(missingInstance.elemID, missingInstance),
           '}}',
         ],
       }))
       const fetchedMacroAlmostTemplate2 = elements.filter(isInstanceElement).find(i => i.elemID.name === 'macroAlmost2')
-      expect(fetchedMacroAlmostTemplate2?.value.actions[0].value).toEqual('{{ticket.ticket_field_1452}}')
+      expect(fetchedMacroAlmostTemplate2?.value.actions[0].value).toEqual(`{{ticket.ticket_field_${placeholder1.value.id}}}`)
     })
 
     it('should resolve one template correctly, in any type', () => {
@@ -308,14 +315,13 @@ describe('handle templates filter', () => {
         new ReferenceExpression(placeholder1.elemID, placeholder1), '}}'] }))
       const fetchedTrigger = elements.filter(isInstanceElement).find(i => i.elemID.name === 'trigger')
       expect(fetchedTrigger?.value.actions[0].value).toEqual([
-        [
-          'my test',
-          new TemplateExpression({ parts: ['{{', new ReferenceExpression(dynamicContentRecord.elemID, dynamicContentRecord), '}}'] }),
-        ],
-        [
-          'dcno',
-          new TemplateExpression({ parts: ['{{', new ReferenceExpression(missingDynamicContentRecord.elemID, missingDynamicContentRecord), '}}'] }),
-        ],
+        ['my test', new TemplateExpression({ parts: ['{{', new ReferenceExpression(dynamicContentRecord.elemID, dynamicContentRecord), '}}'] })],
+        ['dcno', new TemplateExpression({ parts: ['{{', new ReferenceExpression(missingDynamicContentRecord.elemID, missingDynamicContentRecord), '}}'] })],
+        ['testJson', new TemplateExpression({ parts: [
+          `{\n\t"ticket": {\n\t\t"custom_fields": [\n\t\t\t{\n\t\t\t\t"id": ${placeholder1.value.id},\n\t\t\t\t"testdc": "{{`,
+          new ReferenceExpression(dynamicContentRecord.elemID, dynamicContentRecord),
+          `}}"\n\t\t\t}\n\t\t],\n\t\t"id": ${placeholder2.value.id}\n\t},\n\t"id": ${placeholder3.value.id}\n}\n`,
+        ] })],
       ])
       const fetchedAutomation = elements.filter(isInstanceElement).find(i => i.elemID.name === 'automation')
       expect(fetchedAutomation?.value.actions[0].value).toEqual(new TemplateExpression({ parts: [
@@ -474,10 +480,11 @@ describe('handle templates filter', () => {
       const fetchedArticleTranslation = elements.filter(isInstanceElement).find(i => i.elemID.name === 'articleTranslation')
       expect(fetchedArticleTranslation?.value.body).toEqual(`"/hc/test/test/articles/${article.value.id}/test`)
     })
-    it('should resolve urls correctly when the config flag is on', async () => {
+    it('should resolve urls correctly when config flags are on', async () => {
       elements = generateElements()
       const config = _.cloneDeep(DEFAULT_CONFIG)
       config[FETCH_CONFIG].extractReferencesFromFreeText = true
+      config[FETCH_CONFIG].convertJsonIdsToReferences = true
       const resolveLinksFilter = filterCreator(createFilterCreatorParams({ config })) as FilterType
       await resolveLinksFilter.onFetch(elements)
 
@@ -486,6 +493,19 @@ describe('handle templates filter', () => {
         '"/hc/test/test/articles/',
         new ReferenceExpression(article.elemID, article),
         '/test',
+      ] }))
+
+      const fetchedTrigger = elements.filter(isInstanceElement).find(i => i.elemID.name === 'trigger')
+      expect(fetchedTrigger?.value.actions[0].value[2][1]).toEqual(new TemplateExpression({ parts: [
+        '{\n\t"ticket": {\n\t\t"custom_fields": [\n\t\t\t{\n\t\t\t\t"id": ',
+        new ReferenceExpression(placeholder1.elemID, placeholder1),
+        ',\n\t\t\t\t"testdc": "{{',
+        new ReferenceExpression(dynamicContentRecord.elemID, dynamicContentRecord),
+        '}}"\n\t\t\t}\n\t\t],\n\t\t"id": ',
+        new ReferenceExpression(placeholder2.elemID, placeholder2),
+        '\n\t},\n\t"id": ',
+        new ReferenceExpression(placeholder3.elemID, placeholder3),
+        '\n}\n',
       ] }))
     })
   })


### PR DESCRIPTION
In free text fields, if the value is a JSON, and there is a key named 'id' with a number value - attempt to convert it to reference expression

---

No noise reduction needed because this is behind a config

---
_Release Notes_: 
Zendesk Adapter:
* Added `convertJsonIdsToReferences` config, that allows convert of JSON pairs of 'id' to reference expression

---
_User Notifications_: 
None