### PR TITLE
SALTO-4923: Added flag for enableJsmExperimental

### DIFF
--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -67,6 +67,7 @@ type JiraFetchConfig = configUtils.UserFetchConfig<JiraFetchFilters> & {
   parseTemplateExpressions?: boolean
   enableScriptRunnerAddon?: boolean
   enableJSM?: boolean
+  enableJsmExperimental?: boolean
   removeDuplicateProjectRoles?: boolean
   addAlias?: boolean
   splitFieldConfiguration?: boolean
@@ -318,6 +319,7 @@ const fetchConfigType = createUserFetchConfigType(
     showUserDisplayNames: { refType: BuiltinTypes.BOOLEAN },
     enableScriptRunnerAddon: { refType: BuiltinTypes.BOOLEAN },
     enableJSM: { refType: BuiltinTypes.BOOLEAN },
+    enableJsmExperimental: { refType: BuiltinTypes.BOOLEAN },
     removeDuplicateProjectRoles: { refType: BuiltinTypes.BOOLEAN },
     // Default is true
     parseTemplateExpressions: { refType: BuiltinTypes.BOOLEAN },


### PR DESCRIPTION
Added enableJsmExperimental flag

---

_Additional context for reviewer_
We are planning to release JSM to customers. 
For not expose them to JSM elements that are being developed, I added another flag called `enableJsmExperimental`.
The customers will be able to use jsm when `enableJSM = true`. And after each type will be approve it will change from `enableJsmExperimental=true` to `enableJSM=true`

---
_Release Notes_: 
None

---
_User Notifications_: 
None
