### PR TITLE
SALTO-4896: expand secondGlobalContext CV for handling invalid removals of contextFields from a project - Jira

### DIFF
--- a/packages/jira-adapter/src/change_validators/field_contexts/second_global_context.ts
+++ b/packages/jira-adapter/src/change_validators/field_contexts/second_global_context.ts
@@ -79,9 +79,8 @@ export const fieldSecondGlobalContextValidator: ChangeValidator = async (changes
       .filter(change => getChangeData(change).elemID.typeName === PROJECT_TYPE)
       .filter(isRemovalOrModificationChange)
       .forEach(async change => {
-        const promises = change.data.before.value.fieldContexts
-          .filter(isReferenceExpression)
-          .map(async (context: ReferenceExpression) => {
+        await awu(change.data.before.value.fieldContexts).filter(isReferenceExpression)
+          .forEach(async (context: ReferenceExpression) => {
             if (fieldContextToProjectChangeData.get(context.elemID.getFullName()) === undefined) {
               const fieldElemId = getParentElemID(await context.getResolvedValue(elementSource))
               fieldContextToProjectChangeData.set(
@@ -91,7 +90,6 @@ export const fieldSecondGlobalContextValidator: ChangeValidator = async (changes
             }
             fieldContextToProjectChangeData.get(context.elemID.getFullName())?.changes.push(change)
           })
-        await Promise.all(promises)
       })
     if (fieldContextToProjectChangeData.size === 0) {
       return fieldContextToProjectChangeData
@@ -119,12 +117,12 @@ export const fieldSecondGlobalContextValidator: ChangeValidator = async (changes
 
   Array.from(fieldContextToProjectChangesData)
     .filter(([fieldContextName]) => (!globalContextElemIdsSet.has(fieldContextName)))
-    .forEach(([, { changes: projectChanges, fieldElemId }]) => {
+    .forEach(([, { fieldElemId }]) => {
       const fieldFullName = fieldElemId.getFullName()
       if (fieldToImplicitGlobalContextCount[fieldFullName] === undefined) {
-        fieldToImplicitGlobalContextCount[fieldFullName] = projectChanges.length
+        fieldToImplicitGlobalContextCount[fieldFullName] = 1
       } else {
-        fieldToImplicitGlobalContextCount[fieldFullName] += projectChanges.length
+        fieldToImplicitGlobalContextCount[fieldFullName] += 1
       }
     })
 

--- a/packages/jira-adapter/src/change_validators/field_contexts/second_global_context.ts
+++ b/packages/jira-adapter/src/change_validators/field_contexts/second_global_context.ts
@@ -13,24 +13,27 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ChangeError, ChangeValidator, CORE_ANNOTATIONS, ElemID, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, isInstanceElement, isReferenceExpression, ReadOnlyElementsSource, SeverityLevel } from '@salto-io/adapter-api'
+import { ChangeError, ChangeValidator, CORE_ANNOTATIONS, ElemID, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, isInstanceElement, isModificationChange, isReferenceExpression, ModificationChange, ReadOnlyElementsSource, ReferenceExpression, SeverityLevel } from '@salto-io/adapter-api'
 import { getParent } from '@salto-io/adapter-utils'
 import { collections, values } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import { FIELD_CONTEXT_TYPE_NAME } from '../../filters/fields/constants'
+import { PROJECT_TYPE } from '../../constants'
 
 
 const { awu } = collections.asynciterable
 const log = logger(module)
 
-const createErrorMessage = (elemID: ElemID, fieldName: string): ChangeError => ({
+const createErrorMessage = (elemID: ElemID, fieldName?: string): ChangeError => ({
   elemID,
   severity: 'Error' as SeverityLevel,
   message: 'A field can only have a single global context',
-  detailedMessage: `Can't deploy this global context because the deployment will result in more than a single global context for field ${fieldName}.`,
+  detailedMessage: elemID.typeName === PROJECT_TYPE
+    ? 'Can\'t remove this context from this project as it will result in more than a single global context'
+    : `Can't deploy this global context because the deployment will result in more than a single global context for field ${fieldName}.`,
 })
 
-const getParenWithElementSource = async (instance: InstanceElement, elementSource: ReadOnlyElementsSource)
+const getParentWithElementSource = async (instance: InstanceElement, elementSource: ReadOnlyElementsSource)
 : Promise<InstanceElement> => {
   const parent = instance.annotations[CORE_ANNOTATIONS.PARENT][0]
   if (!isReferenceExpression(parent)) {
@@ -55,7 +58,7 @@ export const fieldSecondGlobalContextValidator: ChangeValidator = async (changes
       .filter(isInstanceElement)
       .filter(instance => instance.value.isGlobalContext)
       .forEach(async instance => {
-        const field = await getParenWithElementSource(instance, elementSource)
+        const field = await getParentWithElementSource(instance, elementSource)
         const fieldName = field.elemID.getFullName()
         if (fieldToGlobalContextCount[fieldName] === undefined) {
           fieldToGlobalContextCount[fieldName] = 1
@@ -70,10 +73,32 @@ export const fieldSecondGlobalContextValidator: ChangeValidator = async (changes
     .filter(instance => instance.elemID.typeName === FIELD_CONTEXT_TYPE_NAME)
     .filter(instance => instance.value.isGlobalContext)
     .toArray()
+  await fillFieldToGlobalContextCount()
+  const isInvalidProjectFieldContextsModification = async (change: ModificationChange<InstanceElement>)
+    : Promise<boolean> => {
+    const afterContexts = new Set((change.data.after.value.fieldContexts ?? [])
+      .map((context: ReferenceExpression) => context.elemID.getFullName()))
+    const removedContexts = change.data.before.value.fieldContexts
+      .filter((context: ReferenceExpression) => !afterContexts.has(context.elemID.getFullName()))
+    const removedContextsFields = await Promise.all(removedContexts.map(async (context: ReferenceExpression) => (
+      getParentWithElementSource(await context.getResolvedValue(), elementSource)
+    )))
+    // removing fieldContext from a project implicitly makes it global
+    const fieldsWithSecondGlobalContext = removedContextsFields.filter(isInstanceElement)
+      .filter((fieldInstance: InstanceElement) => fieldToGlobalContextCount[fieldInstance.elemID.getFullName()] === 1)
+    return fieldsWithSecondGlobalContext.length > 0
+  }
 
+  const invalidProjectFieldContextsModification = await awu(changes).filter(isInstanceChange)
+    .filter(isModificationChange)
+    .filter(change => change.data.after.elemID.typeName === PROJECT_TYPE)
+    .filter(isInvalidProjectFieldContextsModification)
+    .toArray()
+
+  const errorMessages = [...invalidProjectFieldContextsModification
+    .map(change => createErrorMessage(change.data.after.elemID))]
   if (globalContextList.length > 0) {
-    await fillFieldToGlobalContextCount()
-    return globalContextList
+    const secondGlobalContextErrorMessages = globalContextList
       .map(instance => ({ context: instance, field: getParent(instance) }))
       .map(contextAndField => {
         if (fieldToGlobalContextCount[contextAndField.field.elemID.getFullName()] > 1) {
@@ -85,6 +110,7 @@ export const fieldSecondGlobalContextValidator: ChangeValidator = async (changes
         return undefined
       })
       .filter(values.isDefined)
+    errorMessages.push(...secondGlobalContextErrorMessages)
   }
-  return []
+  return errorMessages
 }

--- a/packages/jira-adapter/test/change_validators/field_contexts/second_global_context.test.ts
+++ b/packages/jira-adapter/test/change_validators/field_contexts/second_global_context.test.ts
@@ -222,7 +222,7 @@ describe('Field second global contexts', () => {
           elemID: afterProjectInstance.elemID,
           severity: 'Error',
           message: 'A field can only have a single global context',
-          detailedMessage: 'Can\'t remove this context from this project as it will result in more than a single global context',
+          detailedMessage: "Can't remove the field context fieldContextInstance from this project as it will result in more than a single global context.",
         },
       ])
     })

--- a/packages/jira-adapter/test/change_validators/field_contexts/second_global_context.test.ts
+++ b/packages/jira-adapter/test/change_validators/field_contexts/second_global_context.test.ts
@@ -207,10 +207,10 @@ describe('Field second global contexts', () => {
           ],
         }
       )
-      elements = [fieldInstance, firstGlobalContextInstance, projectInstance, fieldContextInstance]
-      elementsSource = buildElementsSourceFromElements(elements)
       afterProjectInstance = projectInstance.clone()
       afterProjectInstance.value.fieldContexts = []
+      elements = [fieldInstance, firstGlobalContextInstance, afterProjectInstance, fieldContextInstance]
+      elementsSource = buildElementsSourceFromElements(elements)
       changes = [toChange({ before: projectInstance, after: afterProjectInstance })]
     })
     it('should return an error when removing field context from a project when the field has a global context', async () => {

--- a/packages/jira-adapter/test/change_validators/field_contexts/second_global_context.test.ts
+++ b/packages/jira-adapter/test/change_validators/field_contexts/second_global_context.test.ts
@@ -16,7 +16,7 @@
 import { ObjectType, ElemID, ReadOnlyElementsSource, InstanceElement, ReferenceExpression, toChange, Change, ChangeDataType, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { FIELD_CONTEXT_TYPE_NAME, FIELD_TYPE_NAME } from '../../../src/filters/fields/constants'
-import { JIRA } from '../../../src/constants'
+import { JIRA, PROJECT_TYPE } from '../../../src/constants'
 import { fieldSecondGlobalContextValidator } from '../../../src/change_validators/field_contexts/second_global_context'
 
 const mockLogError = jest.fn()
@@ -70,113 +70,168 @@ describe('Field second global contexts', () => {
       undefined,
       { _parent: [new ReferenceExpression(fieldInstance.elemID, fieldInstance)] }
     )
+  })
+  describe('field context change', () => {
+    beforeEach(() => {
+      elements = [fieldInstance, firstGlobalContextInstance]
+      elementsSource = buildElementsSourceFromElements(elements)
+      changes = elements.map(element => toChange({ after: element }))
+    })
 
-    elements = [fieldInstance, firstGlobalContextInstance]
-    elementsSource = buildElementsSourceFromElements(elements)
-    changes = elements.map(element => toChange({ after: element }))
-  })
+    it('should not return error when setting one global context to the field', async () => {
+      expect(await fieldSecondGlobalContextValidator(
+        changes,
+        elementsSource
+      )).toEqual([])
+    })
+    it('should not return changes when its not global context change', async () => {
+      const notGlobalContextInstance = new InstanceElement(
+        'notGlobal',
+        contextType,
+        undefined,
+        undefined,
+        { _parent: [new ReferenceExpression(fieldInstance.elemID, fieldInstance)] }
+      )
+      elements = [notGlobalContextInstance]
+      elementsSource = buildElementsSourceFromElements(elements)
+      changes = [toChange({ after: notGlobalContextInstance })]
+      expect(await fieldSecondGlobalContextValidator(
+        changes,
+        elementsSource
+      )).toEqual([])
+    })
+    it('should log error if elementSource is undefined', async () => {
+      expect(await fieldSecondGlobalContextValidator(
+        changes,
+      )).toEqual([])
+      expect(mockLogError).toHaveBeenCalledWith('Failed to run fieldSecondGlobalContextValidator because element source is undefined')
+    })
 
-  it('should not return error when setting one global context to the field', async () => {
-    expect(await fieldSecondGlobalContextValidator(
-      changes,
-      elementsSource
-    )).toEqual([])
+    it('should return error when setting two global contexts to a field', async () => {
+      fieldInstance.value.contexts.push(
+        new ReferenceExpression(secondGlobalContextInstance.elemID, secondGlobalContextInstance)
+      )
+      elements = [fieldInstance, firstGlobalContextInstance, secondGlobalContextInstance]
+      elementsSource = buildElementsSourceFromElements(elements)
+      changes = elements.map(element => toChange({ after: element }))
+      expect(await fieldSecondGlobalContextValidator(
+        changes,
+        elementsSource
+      )).toEqual([
+        {
+          elemID: firstGlobalContextInstance.elemID,
+          severity: 'Error',
+          message: 'A field can only have a single global context',
+          detailedMessage: 'Can\'t deploy this global context because the deployment will result in more than a single global context for field jira.Field.instance.field_name.',
+        },
+        {
+          elemID: secondGlobalContextInstance.elemID,
+          severity: 'Error',
+          message: 'A field can only have a single global context',
+          detailedMessage: 'Can\'t deploy this global context because the deployment will result in more than a single global context for field jira.Field.instance.field_name.',
+        },
+      ])
+    })
+    it('should return error when setting two global contexts to a field with alias', async () => {
+      fieldInstance.annotations[CORE_ANNOTATIONS.ALIAS] = 'beautiful name'
+      fieldInstance.value.contexts.push(
+        new ReferenceExpression(secondGlobalContextInstance.elemID, secondGlobalContextInstance)
+      )
+      elements = [fieldInstance, firstGlobalContextInstance, secondGlobalContextInstance]
+      elementsSource = buildElementsSourceFromElements(elements)
+      changes = elements.map(element => toChange({ after: element }))
+      expect(await fieldSecondGlobalContextValidator(
+        changes,
+        elementsSource
+      )).toEqual([
+        {
+          elemID: firstGlobalContextInstance.elemID,
+          severity: 'Error',
+          message: 'A field can only have a single global context',
+          detailedMessage: 'Can\'t deploy this global context because the deployment will result in more than a single global context for field beautiful name.',
+        },
+        {
+          elemID: secondGlobalContextInstance.elemID,
+          severity: 'Error',
+          message: 'A field can only have a single global context',
+          detailedMessage: 'Can\'t deploy this global context because the deployment will result in more than a single global context for field beautiful name.',
+        },
+      ])
+    })
+    it('should return error when adding two global contexts to a field without global context', async () => {
+      fieldInstance.value.contexts = []
+      elements = [firstGlobalContextInstance, secondGlobalContextInstance]
+      elementsSource = buildElementsSourceFromElements(elements)
+      changes = elements.map(element => toChange({ after: element }))
+      expect(await fieldSecondGlobalContextValidator(
+        changes,
+        elementsSource
+      )).toEqual([
+        {
+          elemID: firstGlobalContextInstance.elemID,
+          severity: 'Error',
+          message: 'A field can only have a single global context',
+          detailedMessage: 'Can\'t deploy this global context because the deployment will result in more than a single global context for field jira.Field.instance.field_name.',
+        },
+        {
+          elemID: secondGlobalContextInstance.elemID,
+          severity: 'Error',
+          message: 'A field can only have a single global context',
+          detailedMessage: 'Can\'t deploy this global context because the deployment will result in more than a single global context for field jira.Field.instance.field_name.',
+        },
+      ])
+    })
   })
-  it('should not return changes when its not global context change', async () => {
-    const notGlobalContextInstance = new InstanceElement(
-      'notGlobal',
-      contextType,
-      undefined,
-      undefined,
-      { _parent: [new ReferenceExpression(fieldInstance.elemID, fieldInstance)] }
-    )
-    elements = [notGlobalContextInstance]
-    elementsSource = buildElementsSourceFromElements(elements)
-    changes = [toChange({ after: notGlobalContextInstance })]
-    expect(await fieldSecondGlobalContextValidator(
-      changes,
-      elementsSource
-    )).toEqual([])
-  })
-  it('should log error if elementSource is undefined', async () => {
-    expect(await fieldSecondGlobalContextValidator(
-      changes,
-    )).toEqual([])
-    expect(mockLogError).toHaveBeenCalledWith('Failed to run fieldSecondGlobalContextValidator because element source is undefined')
-  })
-
-  it('should return error when setting two global contexts to a field', async () => {
-    fieldInstance.value.contexts.push(
-      new ReferenceExpression(secondGlobalContextInstance.elemID, secondGlobalContextInstance)
-    )
-    elements = [fieldInstance, firstGlobalContextInstance, secondGlobalContextInstance]
-    elementsSource = buildElementsSourceFromElements(elements)
-    changes = elements.map(element => toChange({ after: element }))
-    expect(await fieldSecondGlobalContextValidator(
-      changes,
-      elementsSource
-    )).toEqual([
-      {
-        elemID: firstGlobalContextInstance.elemID,
-        severity: 'Error',
-        message: 'A field can only have a single global context',
-        detailedMessage: 'Can\'t deploy this global context because the deployment will result in more than a single global context for field jira.Field.instance.field_name.',
-      },
-      {
-        elemID: secondGlobalContextInstance.elemID,
-        severity: 'Error',
-        message: 'A field can only have a single global context',
-        detailedMessage: 'Can\'t deploy this global context because the deployment will result in more than a single global context for field jira.Field.instance.field_name.',
-      },
-    ])
-  })
-  it('should return error when setting two global contexts to a field with alias', async () => {
-    fieldInstance.annotations[CORE_ANNOTATIONS.ALIAS] = 'beautiful name'
-    fieldInstance.value.contexts.push(
-      new ReferenceExpression(secondGlobalContextInstance.elemID, secondGlobalContextInstance)
-    )
-    elements = [fieldInstance, firstGlobalContextInstance, secondGlobalContextInstance]
-    elementsSource = buildElementsSourceFromElements(elements)
-    changes = elements.map(element => toChange({ after: element }))
-    expect(await fieldSecondGlobalContextValidator(
-      changes,
-      elementsSource
-    )).toEqual([
-      {
-        elemID: firstGlobalContextInstance.elemID,
-        severity: 'Error',
-        message: 'A field can only have a single global context',
-        detailedMessage: 'Can\'t deploy this global context because the deployment will result in more than a single global context for field beautiful name.',
-      },
-      {
-        elemID: secondGlobalContextInstance.elemID,
-        severity: 'Error',
-        message: 'A field can only have a single global context',
-        detailedMessage: 'Can\'t deploy this global context because the deployment will result in more than a single global context for field beautiful name.',
-      },
-    ])
-  })
-  it('should return error when adding two global contexts to a field without global context', async () => {
-    fieldInstance.value.contexts = []
-    elements = [firstGlobalContextInstance, secondGlobalContextInstance]
-    elementsSource = buildElementsSourceFromElements(elements)
-    changes = elements.map(element => toChange({ after: element }))
-    expect(await fieldSecondGlobalContextValidator(
-      changes,
-      elementsSource
-    )).toEqual([
-      {
-        elemID: firstGlobalContextInstance.elemID,
-        severity: 'Error',
-        message: 'A field can only have a single global context',
-        detailedMessage: 'Can\'t deploy this global context because the deployment will result in more than a single global context for field jira.Field.instance.field_name.',
-      },
-      {
-        elemID: secondGlobalContextInstance.elemID,
-        severity: 'Error',
-        message: 'A field can only have a single global context',
-        detailedMessage: 'Can\'t deploy this global context because the deployment will result in more than a single global context for field jira.Field.instance.field_name.',
-      },
-    ])
+  describe('project field contexts change', () => {
+    let projectType: ObjectType
+    let projectInstance: InstanceElement
+    let afterProjectInstance: InstanceElement
+    let fieldContextInstance: InstanceElement
+    beforeEach(() => {
+      projectType = new ObjectType({ elemID: new ElemID(JIRA, PROJECT_TYPE) })
+      fieldContextInstance = new InstanceElement(
+        'fieldContextInstance',
+        contextType,
+        {
+          isGlobalContext: false,
+        },
+        undefined,
+        { _parent: [new ReferenceExpression(fieldInstance.elemID, fieldInstance)] }
+      )
+      projectInstance = new InstanceElement(
+        'project',
+        projectType,
+        {
+          fieldContexts: [
+            new ReferenceExpression(fieldContextInstance.elemID, fieldContextInstance),
+          ],
+        }
+      )
+      elements = [fieldInstance, firstGlobalContextInstance, projectInstance, fieldContextInstance]
+      elementsSource = buildElementsSourceFromElements(elements)
+      afterProjectInstance = projectInstance.clone()
+      afterProjectInstance.value.fieldContexts = []
+      changes = [toChange({ before: projectInstance, after: afterProjectInstance })]
+    })
+    it('should return an error when removing field context from a project when the field has a global context', async () => {
+      expect(await fieldSecondGlobalContextValidator(
+        changes,
+        elementsSource
+      )).toEqual([
+        {
+          elemID: afterProjectInstance.elemID,
+          severity: 'Error',
+          message: 'A field can only have a single global context',
+          detailedMessage: 'Can\'t remove this context from this project as it will result in more than a single global context',
+        },
+      ])
+    })
+    it('should not return an error when removing field context from a project when the field does not have a global context', async () => {
+      firstGlobalContextInstance.value.isGlobalContext = false
+      expect(await fieldSecondGlobalContextValidator(
+        changes,
+        elementsSource
+      )).toEqual([])
+    })
   })
 })


### PR DESCRIPTION
_expand secondGlobalContext CV for handling invalid removals of contextFields from a project_

---

_Additional context for reviewer_
* we already have a change validator for second global context (which is forbidden in Jira)
* the scenario: when we remove a fieldContext from a project it implicitly becomes a global context, if there is another global context the service fails this change.

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
