### PR TITLE
SALTO-4922: Mark dev accounts as non production in Okta

### DIFF
--- a/packages/okta-adapter/src/client/connection.ts
+++ b/packages/okta-adapter/src/client/connection.ts
@@ -13,7 +13,6 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import _ from 'lodash'
 import { AccountInfo } from '@salto-io/adapter-api'
 import { client as clientUtils, client } from '@salto-io/adapter-components'
 import { logger } from '@salto-io/logging'

--- a/packages/okta-adapter/test/adapter_creator.test.ts
+++ b/packages/okta-adapter/test/adapter_creator.test.ts
@@ -79,14 +79,28 @@ describe('adapter creator', () => {
       })
       it('when using a preview account', async () => {
         const { accountType, isProduction } = await adapter.validateCredentials(
-          createCredentialsInstance({ baseUrl: 'http://my-account.oktapreview.com', token: 't' })
+          createCredentialsInstance({ baseUrl: 'https://my-account.oktapreview.com', token: 't' })
         )
         expect(accountType).toEqual('Preview')
         expect(isProduction).toEqual(false)
       })
+      it('when using a preview dev account', async () => {
+        const { accountType, isProduction } = await adapter.validateCredentials(
+          createCredentialsInstance({ baseUrl: 'https://dev-123123.oktapreview.com', token: 't' })
+        )
+        expect(accountType).toEqual('Preview')
+        expect(isProduction).toEqual(false)
+      })
+      it('when using a production account', async () => {
+        const { accountType, isProduction } = await adapter.validateCredentials(
+          createCredentialsInstance({ baseUrl: 'https://dev-123123.okta.com', token: 't' })
+        )
+        expect(accountType).toEqual('Dev')
+        expect(isProduction).toEqual(false)
+      })
       it('when using production account', async () => {
         const { accountType, isProduction } = await adapter.validateCredentials(
-          createCredentialsInstance({ baseUrl: 'http://my-account.okta.net', token: 't' })
+          createCredentialsInstance({ baseUrl: 'https://my-account.okta.net', token: 't' })
         )
         expect(accountType).toEqual('Production')
         expect(isProduction).toEqual(true)


### PR DESCRIPTION
Added another account type - dev account
all preview accounts (regular and dev) will be marked as preview, dev accounts that are not preview will be marked as dev, and the others as production.

---
_Release Notes_: 
None

---
_User Notifications_: 
None
