### PR TITLE
Saved searches author information query is skipped in full fetch

### DIFF
--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -1451,7 +1451,7 @@ describe('Adapter', () => {
         const { partialFetchData } = await adapter.fetch({ ...mockFetchOpts })
         expect(getDeletedElementsMock).not.toHaveBeenCalled()
         expect(partialFetchData?.deletedElements).toEqual(undefined)
-        expect(spy).toHaveBeenCalledWith(expect.anything(), false, undefined)
+        expect(spy).toHaveBeenCalledWith(expect.anything(), false, [])
       })
     })
   })


### PR DESCRIPTION
We were passing the timeZone&format to filtersRunner only in case of `useChangesDetection=true`, but we should always pass it. It caused the author_information/saved_searches filter to skip the query.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Fix bug - saved searches author information query is skipped in full fetch

---
_User Notifications_: 
None
