### PR TITLE
SALTO-4717 reduce log level to debug in some cases, relax zendesk restrictions

### DIFF
--- a/packages/adapter-components/src/elements/type_elements.ts
+++ b/packages/adapter-components/src/elements/type_elements.ts
@@ -39,11 +39,14 @@ export const hideFields = (
   const typeFields = type.fields
   fieldsToHide.forEach(({ fieldName, fieldType }) => {
     if (fieldType !== undefined
-      && fieldType !== typeFields[fieldName]?.refType?.elemID.name) {
-      const endLogString = typeFields[fieldName]?.refType !== undefined
-        ? `type is ${typeFields[fieldName].refType.elemID.name}`
-        : 'field is not defined'
-      log.warn(`Failed to hide field ${type.elemID.name}.${fieldName}- override type is ${fieldType} while ${endLogString}`)
+      && fieldType !== typeFields[fieldName]?.refType.elemID.name) {
+      if (
+        typeFields[fieldName] === undefined
+      ) {
+        log.debug(`Cannot hide field ${type.elemID.name}.${fieldName} - override type is ${fieldType} while field is not defined`)
+      } else {
+        log.warn(`Failed to hide field ${type.elemID.name}.${fieldName} - override type is ${fieldType} while type is ${typeFields[fieldName].refType.elemID.name}`)
+      }
       return
     }
     if (!Object.prototype.hasOwnProperty.call(typeFields, fieldName)) {

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -1234,7 +1234,11 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
         { fieldName: 'secret', fieldType: 'string' },
         { fieldName: 'user_id', fieldType: 'number' },
       ]),
-      fieldTypeOverrides: [{ fieldName: 'id', fieldType: 'number' }],
+      fieldTypeOverrides: [
+        { fieldName: 'id', fieldType: 'number' },
+        { fieldName: 'secret', fieldType: 'string' },
+        { fieldName: 'user_id', fieldType: 'number' },
+      ],
       serviceUrl: '/admin/apps-integrations/apis/zendesk-api/oauth_clients',
     },
     deployRequests: {

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -45,10 +45,10 @@ export const FIELDS_TO_OMIT: configUtils.FieldToOmitType[] = [
   { fieldName: 'count', fieldType: 'number' },
 ]
 export const FIELDS_TO_HIDE: configUtils.FieldToHideType[] = [
-  { fieldName: 'created_at', fieldType: 'string' },
-  { fieldName: 'updated_at', fieldType: 'string' },
-  { fieldName: 'created_by_id', fieldType: 'number' },
-  { fieldName: 'updated_by_id', fieldType: 'number' },
+  { fieldName: 'created_at' },
+  { fieldName: 'updated_at' },
+  { fieldName: 'created_by_id' },
+  { fieldName: 'updated_by_id' },
 ]
 export const PAGE_SIZE = 100
 export const DEFAULT_QUERY_PARAMS = {

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -2447,6 +2447,22 @@ describe('adapter', () => {
                   annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
                 },
                 name: { refType: BuiltinTypes.STRING },
+                created_at: {
+                  refType: BuiltinTypes.UNKNOWN,
+                  annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
+                },
+                updated_at: {
+                  refType: BuiltinTypes.UNKNOWN,
+                  annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
+                },
+                created_by_id: {
+                  refType: BuiltinTypes.UNKNOWN,
+                  annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
+                },
+                updated_by_id: {
+                  refType: BuiltinTypes.UNKNOWN,
+                  annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
+                },
               },
               // generateType function creates path
               path: [ZENDESK, elementsUtils.TYPES_PATH, 'group'],
@@ -2480,6 +2496,22 @@ describe('adapter', () => {
             fields: {
               id: {
                 refType: BuiltinTypes.SERVICE_ID_NUMBER,
+                annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
+              },
+              created_at: {
+                refType: BuiltinTypes.UNKNOWN,
+                annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
+              },
+              updated_at: {
+                refType: BuiltinTypes.UNKNOWN,
+                annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
+              },
+              created_by_id: {
+                refType: BuiltinTypes.UNKNOWN,
+                annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
+              },
+              updated_by_id: {
+                refType: BuiltinTypes.UNKNOWN,
                 annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
               },
             },


### PR DESCRIPTION
Reduce the noise in the logs - 
1. reduce level to `debug` if field is not defined
2. relax restrictions in zendesk to not expect a specific type for the default-hidden fields, since there is sometimes inconsistency between string/number that causes the field type to be unknown and we should still hide it in this case
3. assign a few more field types with `fieldTypeOverrides` since they don't always exist

---
_Release Notes_: 
None

---
_User Notifications_: 
None