### PR TITLE
SALTO-4919 Fix SDF deploy dependencies when referencing an added inner object/field

### DIFF
--- a/packages/netsuite-adapter/src/client/types.ts
+++ b/packages/netsuite-adapter/src/client/types.ts
@@ -126,16 +126,18 @@ export class InvalidSuiteAppCredentialsError extends Error {
 
 export type DeployableChange = Change<ObjectType | InstanceElement>
 
-export type SDFObjectNode = {
-  change: DeployableChange
-  serviceid: string
-  customizationInfo: CustomizationInfo
-} & ({
+export type SDFObjectChangeType = {
   changeType: 'addition'
 } | {
   changeType: 'modification'
   addedObjects: Set<string>
-})
+}
+
+export type SDFObjectNode = {
+  change: DeployableChange
+  serviceid: string
+  customizationInfo: CustomizationInfo
+} & SDFObjectChangeType
 
 export const getNodeId = (elemId: ElemID): string => elemId.getFullName()
 

--- a/packages/netsuite-adapter/src/client/types.ts
+++ b/packages/netsuite-adapter/src/client/types.ts
@@ -129,9 +129,13 @@ export type DeployableChange = Change<ObjectType | InstanceElement>
 export type SDFObjectNode = {
   change: DeployableChange
   serviceid: string
-  changeType: 'addition' | 'modification'
   customizationInfo: CustomizationInfo
-}
+} & ({
+  changeType: 'addition'
+} | {
+  changeType: 'modification'
+  addedObjects: Set<string>
+})
 
 export const getNodeId = (elemId: ElemID): string => elemId.getFullName()
 

--- a/packages/netsuite-adapter/src/client/utils.ts
+++ b/packages/netsuite-adapter/src/client/utils.ts
@@ -165,7 +165,12 @@ export const getChangeTypeAndAddedObjects = (
   }
   const beforeInnerObjects = getServiceIdsToElemIds(change.data.before)
   const afterInnerObjects = getServiceIdsToElemIds(change.data.after)
-  const addedObjects = new Set(Object.keys(afterInnerObjects)
-    .filter(objName => beforeInnerObjects[objName] === undefined))
-  return { changeType: 'modification', addedObjects }
+  const addedInnerObjects = Object.keys(afterInnerObjects)
+    .filter(objName => beforeInnerObjects[objName] === undefined)
+  log.debug(
+    'the following inner objects of %s were added: %o',
+    getChangeData(change).elemID.getFullName(),
+    addedInnerObjects
+  )
+  return { changeType: 'modification', addedObjects: new Set(addedInnerObjects) }
 }

--- a/packages/netsuite-adapter/src/client/utils.ts
+++ b/packages/netsuite-adapter/src/client/utils.ts
@@ -19,7 +19,7 @@ import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { Change, ElemID, SaltoElementError, getChangeData, isAdditionChange } from '@salto-io/adapter-api'
 import { FILE, FOLDER } from '../constants'
-import { CustomizationInfo, CustomTypeInfo, DeployableChange, FileCustomizationInfo, FolderCustomizationInfo, TemplateCustomTypeInfo } from './types'
+import { CustomizationInfo, CustomTypeInfo, DeployableChange, FileCustomizationInfo, FolderCustomizationInfo, SDFObjectChangeType, TemplateCustomTypeInfo } from './types'
 import { NetsuiteTypesQueryParams } from '../query'
 import { ConfigRecord } from './suiteapp_client/types'
 import { isFileCabinetInstance } from '../types'
@@ -151,12 +151,7 @@ export const getDeployResultFromSuiteAppResult = <T extends Change>(
 
 export const getChangeTypeAndAddedObjects = (
   change: DeployableChange & { action: 'add' | 'modify' }
-): {
-  changeType: 'addition'
-} | {
-  changeType: 'modification'
-  addedObjects: Set<string>
-} => {
+): SDFObjectChangeType => {
   if (isAdditionChange(change)) {
     return { changeType: 'addition' }
   }

--- a/packages/netsuite-adapter/src/filters/additional_changes.ts
+++ b/packages/netsuite-adapter/src/filters/additional_changes.ts
@@ -23,9 +23,9 @@ import { isStandardInstanceOrCustomRecordType } from '../types'
 
 const getFieldParentChanges = (
   fieldChanges: (AdditionChange<Field> | ModificationChange<Field>)[],
-  allChanges: Change[]
+  sdfChanges: Change[]
 ): ModificationChange<ObjectType>[] => {
-  const elemIdSet = new Set(allChanges.map(getChangeData).map(elem => elem.elemID.getFullName()))
+  const elemIdSet = new Set(sdfChanges.map(getChangeData).map(elem => elem.elemID.getFullName()))
   const afterFieldsByParent = _.groupBy(
     fieldChanges.map(change => change.data.after),
     field => field.parent.elemID.getFullName(),
@@ -64,7 +64,7 @@ const filterCreator: LocalFilterCreator = ({ config }) => ({
       .filter(change => isStandardInstanceOrCustomRecordType(change.data.after))
 
     const [fieldChanges, typesAndInstancesChanges] = _.partition(sdfChanges, isFieldChange)
-    const fieldParentChanges = getFieldParentChanges(fieldChanges, changes)
+    const fieldParentChanges = getFieldParentChanges(fieldChanges, sdfChanges)
 
     const requiredElements = (await getReferencedElements(
       typesAndInstancesChanges.concat(fieldParentChanges).map(change => change.data.after),

--- a/packages/netsuite-adapter/src/filters/additional_changes.ts
+++ b/packages/netsuite-adapter/src/filters/additional_changes.ts
@@ -14,37 +14,66 @@
 * limitations under the License.
 */
 
-import { getChangeData, toChange, isAdditionOrModificationChange, isField } from '@salto-io/adapter-api'
+import { getChangeData, toChange, isAdditionOrModificationChange, isFieldChange, isModificationChange, ObjectType, AdditionChange, Field, ModificationChange, Change } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { getReferencedElements } from '../reference_dependencies'
 import { LocalFilterCreator } from '../filter'
 import { DEFAULT_DEPLOY_REFERENCED_ELEMENTS } from '../config'
 import { isStandardInstanceOrCustomRecordType } from '../types'
 
+const getFieldParentChanges = (
+  fieldChanges: (AdditionChange<Field> | ModificationChange<Field>)[],
+  allChanges: Change[]
+): ModificationChange<ObjectType>[] => {
+  const elemIdSet = new Set(allChanges.map(getChangeData).map(elem => elem.elemID.getFullName()))
+  const afterFieldsByParent = _.groupBy(
+    fieldChanges.map(change => change.data.after),
+    field => field.parent.elemID.getFullName(),
+  )
+  const beforeFieldsByParent = _.groupBy(
+    fieldChanges.filter(isModificationChange).map(change => change.data.before),
+    field => field.parent.elemID.getFullName(),
+  )
+  return Object.entries(afterFieldsByParent)
+    .filter(([parent]) => !elemIdSet.has(parent))
+    .map(([parent, afterFields]) => {
+      const afterParent = afterFields[0].parent
+      if (beforeFieldsByParent[parent] !== undefined) {
+        const beforeParent = beforeFieldsByParent[parent][0].parent
+        return {
+          action: 'modify',
+          data: { before: beforeParent, after: afterParent },
+        }
+      }
+      const beforeParent = afterParent.clone()
+      // all field changes of this parent are additions
+      afterFields.forEach(field => { delete beforeParent.fields[field.name] })
+      return {
+        action: 'modify',
+        data: { before: beforeParent, after: afterParent },
+      }
+    })
+}
+
 const filterCreator: LocalFilterCreator = ({ config }) => ({
   name: 'additionalChanges',
   preDeploy: async changes => {
-    const sdfChangesData = changes
+    const sdfChanges = changes
       // SDF objects deletions are handled by SOAP
       .filter(isAdditionOrModificationChange)
-      .map(getChangeData)
-      .filter(isStandardInstanceOrCustomRecordType)
+      .filter(change => isStandardInstanceOrCustomRecordType(change.data.after))
 
-    const [fields, typesAndInstances] = _.partition(sdfChangesData, isField)
-    const elemIdSet = new Set(changes.map(getChangeData).map(elem => elem.elemID.getFullName()))
-    const fieldsParents = _(fields)
-      .map(field => field.parent)
-      .filter(parent => !elemIdSet.has(parent.elemID.getFullName()))
-      .uniqBy(parent => parent.elemID.getFullName())
-      .value()
+    const [fieldChanges, typesAndInstancesChanges] = _.partition(sdfChanges, isFieldChange)
+    const fieldParentChanges = getFieldParentChanges(fieldChanges, changes)
 
     const requiredElements = (await getReferencedElements(
-      typesAndInstances.concat(fieldsParents),
+      typesAndInstancesChanges.concat(fieldParentChanges).map(change => change.data.after),
       config.deploy?.deployReferencedElements ?? config.deployReferencedElements ?? DEFAULT_DEPLOY_REFERENCED_ELEMENTS
     )).map(elem => elem.clone())
 
-    const additionalChanges = requiredElements.concat(fieldsParents)
+    const additionalChanges = requiredElements
       .map(elem => toChange({ before: elem, after: elem }))
+      .concat(fieldParentChanges)
 
     changes.push(...additionalChanges)
   },

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -802,6 +802,7 @@ describe('Adapter', () => {
             {
               serviceid: 'custentity_my_script_id',
               changeType: 'modification',
+              addedObjects: new Set(),
               customizationInfo,
               change: toChange({
                 before: instance,
@@ -832,6 +833,7 @@ describe('Adapter', () => {
             {
               serviceid: serviceId,
               changeType: 'modification',
+              addedObjects: new Set(),
               customizationInfo,
               change: toChange({ before: fileInstance, after: fileInstance }),
             },
@@ -858,6 +860,7 @@ describe('Adapter', () => {
             {
               serviceid: serviceId,
               changeType: 'modification',
+              addedObjects: new Set(),
               customizationInfo,
               change: toChange({ before: folderInstance, after: folderInstance }),
             },
@@ -891,6 +894,7 @@ describe('Adapter', () => {
             {
               serviceid: 'custentity_my_script_id',
               changeType: 'modification',
+              addedObjects: new Set(),
               customizationInfo,
               change: toChange({
                 before: instance,

--- a/packages/netsuite-adapter/test/client/client.test.ts
+++ b/packages/netsuite-adapter/test/client/client.test.ts
@@ -364,6 +364,7 @@ describe('NetsuiteClient', () => {
           after: new ObjectType({
             elemID: new ElemID(NETSUITE, 'customrecord1'),
             fields: {
+              scriptid: { refType: BuiltinTypes.SERVICE_ID },
               custom_field: {
                 refType: BuiltinTypes.STRING,
                 annotations: { scriptid: 'custfield123' },
@@ -382,6 +383,7 @@ describe('NetsuiteClient', () => {
           before: new ObjectType({
             elemID: new ElemID(NETSUITE, 'customrecord1'),
             fields: {
+              scriptid: { refType: BuiltinTypes.SERVICE_ID },
               custom_field: {
                 refType: BuiltinTypes.STRING,
                 annotations: { scriptid: 'custfield123' },


### PR DESCRIPTION
We are currently considering a referenced SDF object as a dependency only in case that the referenced object was added. We should also consider it a dependency when the reference is to an inner object/field (`customworkflow123.customstate123` / `customrecord123.custfield123`), that was added (although the whole object was modified).

In order to do that:
- in `additional_changes` filter - set the `before` of an added fields parent to be without the added fields.
- move logic of extracting inner objects from `element_references` filter to `service_id_info`.
- use the above logic to find the added objects in a modified SDF object.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Fix SDF deploy dependencies when referencing an added inner object/field

---
_User Notifications_: 
None