### PR TITLE
SALTO-4904: Added serviceUrl for JSM

### DIFF
--- a/packages/adapter-components/src/config/transformation.ts
+++ b/packages/adapter-components/src/config/transformation.ts
@@ -46,7 +46,6 @@ export type NameMappingOptions = 'lowercase' | 'uppercase'
 type serviceUrlConfig = {
   url: string
   urlParamsToFields?: UrlParams
-  deployAsField?: string
 }
 
 export type TransformationConfig = {

--- a/packages/adapter-components/src/config/transformation.ts
+++ b/packages/adapter-components/src/config/transformation.ts
@@ -18,7 +18,7 @@ import { ElemID, ObjectType, BuiltinTypes, CORE_ANNOTATIONS,
   FieldDefinition, ListType, RestrictionAnnotationType } from '@salto-io/adapter-api'
 import { types, values, collections } from '@salto-io/lowerdash'
 import { getConfigWithDefault, TypeConfig, TypeDefaultsConfig } from './shared'
-import { getConfigTypeName } from './request'
+import { UrlParams, getConfigTypeName } from './request'
 
 const { findDuplicates } = collections.array
 
@@ -33,6 +33,7 @@ type FieldToAdjustType = {
   fieldName: string
   fieldType?: string
 }
+
 export type FieldToOmitType = FieldToAdjustType
 export type FieldToHideType = FieldToAdjustType
 export type FieldTypeOverrideType = {
@@ -41,6 +42,12 @@ export type FieldTypeOverrideType = {
   restrictions?: RestrictionAnnotationType
 }
 export type NameMappingOptions = 'lowercase' | 'uppercase'
+
+type serviceUrlConfig = {
+  url: string
+  urlParamsToFields?: UrlParams
+  deployAsField?: string
+}
 
 export type TransformationConfig = {
   // explicitly set types for fields that are not generated correctly
@@ -68,7 +75,7 @@ export type TransformationConfig = {
   // The identifier field for the service
   serviceIdField?: string
   // The url of the type in the service
-  serviceUrl?: string
+  serviceUrl?: serviceUrlConfig
   // if provided, instance id and file name change, otherwise there’s no change
   nameMapping?: NameMappingOptions
   // if provided and true, types that are standalone fields will nest their instances under parent instances folders.

--- a/packages/adapter-components/src/filters/service_url.ts
+++ b/packages/adapter-components/src/filters/service_url.ts
@@ -24,7 +24,6 @@ export const addUrlToInstance = (
   instance: InstanceElement,
   baseUrl: string,
   apiDefinitions: AdapterApiConfig | AdapterDuckTypeApiConfig,
-  additionalUrlVars?: Record<string, string>,
 ): void => {
   const serviceUrl = apiDefinitions
     .types[instance.elemID.typeName]?.transformation?.serviceUrl
@@ -34,7 +33,6 @@ export const addUrlToInstance = (
   const url = createUrl({
     instance,
     baseUrl: serviceUrl.url,
-    additionalUrlVars,
     urlParamsToFields: serviceUrl.urlParamsToFields,
   })
   instance.annotations[CORE_ANNOTATIONS.SERVICE_URL] = (new URL(url, baseUrl)).href

--- a/packages/adapter-components/src/filters/service_url.ts
+++ b/packages/adapter-components/src/filters/service_url.ts
@@ -21,14 +21,14 @@ import { AdapterApiConfig } from '../config'
 
 
 export const addUrlToInstance = <TContext extends { apiDefinitions: AdapterApiConfig }>(
-  instance: InstanceElement, baseUrl: string, config: TContext
+  instance: InstanceElement, baseUrl: string, config: TContext, additionalUrlVars?: Record<string, string>
 ): void => {
   const serviceUrl = config.apiDefinitions
     .types[instance.elemID.typeName]?.transformation?.serviceUrl
   if (serviceUrl === undefined) {
     return
   }
-  const url = createUrl({ instance, baseUrl: serviceUrl })
+  const url = createUrl({ instance, baseUrl: serviceUrl, additionalUrlVars })
   instance.annotations[CORE_ANNOTATIONS.SERVICE_URL] = (new URL(url, baseUrl)).href
 }
 

--- a/packages/adapter-components/src/filters/service_url.ts
+++ b/packages/adapter-components/src/filters/service_url.ts
@@ -28,7 +28,12 @@ export const addUrlToInstance = <TContext extends { apiDefinitions: AdapterApiCo
   if (serviceUrl === undefined) {
     return
   }
-  const url = createUrl({ instance, baseUrl: serviceUrl, additionalUrlVars })
+  const url = createUrl({
+    instance,
+    baseUrl: serviceUrl.url,
+    additionalUrlVars,
+    urlParamsToFields: serviceUrl.urlParamsToFields,
+  })
   instance.annotations[CORE_ANNOTATIONS.SERVICE_URL] = (new URL(url, baseUrl)).href
 }
 

--- a/packages/adapter-components/test/filters/service_url.test.ts
+++ b/packages/adapter-components/test/filters/service_url.test.ts
@@ -34,12 +34,16 @@ describe('service url filter', () => {
       types: {
         role: {
           transformation: {
-            serviceUrl: '/roles/{id}',
+            serviceUrl: {
+              url: '/roles/{id}',
+            },
           },
         },
         brand: {
           transformation: {
-            serviceUrl: '/brands/{id}/{additionalGuideKey}',
+            serviceUrl: {
+              url: '/brands/{id}/{additionalGuideKey}',
+            },
           },
         },
       },

--- a/packages/adapter-components/test/filters/service_url.test.ts
+++ b/packages/adapter-components/test/filters/service_url.test.ts
@@ -114,7 +114,7 @@ describe('service url filter', () => {
   })
   describe('additional url vars', () => {
     it('should use additional url vars if they are provided', async () => {
-      addUrlToInstance(brandInst, baseUrl, config, { additionalGuideKey: 'guide' })
+      addUrlToInstance(brandInst, baseUrl, config.apiDefinitions)
       expect(brandInst.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://www.example.com/brands/11/guide')
     })
   })

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -82,6 +82,7 @@ import accountIdFilter from './filters/account_id/account_id_filter'
 import userFallbackFilter from './filters/account_id/user_fallback_filter'
 import userIdFilter from './filters/account_id/user_id_filter'
 import fieldStructureFilter from './filters/fields/field_structure_filter'
+import jsmServiceUrlFilter from './filters/jsm_service_url'
 import fieldDeploymentFilter from './filters/fields/field_deployment_filter'
 import contextDeploymentFilter from './filters/fields/context_deployment_filter'
 import fieldTypeReferencesFilter from './filters/fields/field_type_references_filter'
@@ -276,6 +277,7 @@ export const DEFAULT_FILTERS = [
   addJsmTypesAsFieldsFilter,
   issueLayoutFilter,
   fetchJsmTypesFilter,
+  jsmServiceUrlFilter,
   // Must run after issueLayoutFilter
   removeSimpleFieldProjectFilter,
   requestTypeLayoutsFilter,

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -272,12 +272,13 @@ export const DEFAULT_FILTERS = [
   referenceBySelfLinkFilter,
   // Must run after referenceBySelfLinkFilter
   removeSelfFilter,
+  serviceUrlFilter,
+  jsmServiceUrlFilter,
   fieldReferencesFilter,
   // Must run after fieldReferencesFilter
   addJsmTypesAsFieldsFilter,
   issueLayoutFilter,
   fetchJsmTypesFilter,
-  jsmServiceUrlFilter,
   // Must run after issueLayoutFilter
   removeSimpleFieldProjectFilter,
   requestTypeLayoutsFilter,
@@ -300,7 +301,6 @@ export const DEFAULT_FILTERS = [
   // Must run after fieldReferencesFilter
   sortListsFilter,
   serviceUrlInformationFilter,
-  serviceUrlFilter,
   filtersFilter,
   hiddenValuesInListsFilter,
   missingDescriptionsFilter,

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -273,12 +273,12 @@ export const DEFAULT_FILTERS = [
   // Must run after referenceBySelfLinkFilter
   removeSelfFilter,
   serviceUrlFilter,
-  jsmServiceUrlFilter,
   fieldReferencesFilter,
   // Must run after fieldReferencesFilter
   addJsmTypesAsFieldsFilter,
   issueLayoutFilter,
   fetchJsmTypesFilter,
+  jsmServiceUrlFilter,
   // Must run after issueLayoutFilter
   removeSimpleFieldProjectFilter,
   requestTypeLayoutsFilter,

--- a/packages/jira-adapter/src/change_validators/workflow_scheme_migration.ts
+++ b/packages/jira-adapter/src/change_validators/workflow_scheme_migration.ts
@@ -254,7 +254,8 @@ export const workflowSchemeMigrationValidator = (
     const errors = await awu(activeWorkflowsChanges).map(async change => {
       await updateSchemeId(change, client, paginator, config)
       const instance = getChangeData(change)
-      addUrlToInstance(instance, client.baseUrl, config)
+      const { apiDefinitions } = config
+      addUrlToInstance(instance, client.baseUrl, apiDefinitions)
       const changedItems = await getChangedItemsFromChange(
         change,
         workflowSchemesToProjects[getChangeData(change).elemID.getFullName()],

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1868,7 +1868,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       serviceUrl: {
         url: '/jira/servicedesk/projects/{projectKey}/settings/request-types/request-type/{id}/request-form',
         urlParamsToFields: {
-          projectKey: '_parent.0.key',
+          projectKey: '_parent.0.value.value.key',
         },
       },
     },
@@ -1919,7 +1919,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       serviceUrl: {
         url: '/jira/servicedesk/projects/{projectKey}/queues/custom/{id}',
         urlParamsToFields: {
-          projectKey: '_parent.0.key',
+          projectKey: '_parent.0.value.value.key',
         },
       },
     },
@@ -1964,7 +1964,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       serviceUrl: {
         url: '/jira/servicedesk/projects/{projectKey}/settings/portal-settings/portal-groups',
         urlParamsToFields: {
-          projectKey: '_parent.0.key',
+          projectKey: '_parent.0.value.value.key',
         },
       },
     },
@@ -2075,7 +2075,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       serviceUrl: {
         url: '/jira/servicedesk/projects/{projectKey}/settings/portal-settings',
         urlParamsToFields: {
-          projectKey: '_parent.0.key',
+          projectKey: '_parent.0.value.value.key',
         },
       },
     },
@@ -2102,6 +2102,9 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       ],
       serviceUrl: {
         url: '/jira/servicedesk/projects/{projectKey}/settings/sla/custom/{id}',
+        urlParamsToFields: {
+          projectKey: '_parent.0.value.value.key',
+        },
       },
     },
     deployRequests: {

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -2146,7 +2146,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
   },
 }
 
-const JSM_DUCKTYPE_SUPPORTED_TYPES = {
+export const JSM_DUCKTYPE_SUPPORTED_TYPES = {
   RequestType: ['RequestType'],
   CustomerPermissions: ['CustomerPermissions'],
   Queue: ['Queue'],

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1865,6 +1865,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       fieldsToHide: [
         { fieldName: 'id' },
       ],
+      serviceUrl: '/jira/servicedesk/projects/{projectKey}/settings/request-types/request-type/{id}/request-form',
     },
   },
   CustomerPermissions: {
@@ -1910,6 +1911,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       fieldTypeOverrides: [
         { fieldName: 'columns', fieldType: 'List<Field>' },
       ],
+      serviceUrl: '/jira/servicedesk/projects/{projectKey}/queues/custom/{id}',
     },
     deployRequests: {
       add: {
@@ -1949,6 +1951,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       fieldTypeOverrides: [
         { fieldName: 'ticketTypeIds', fieldType: 'List<RequestType>' },
       ],
+      serviceUrl: '/jira/servicedesk/projects/{projectKey}/settings/portal-settings/portal-groups',
     },
     deployRequests: {
       add: {
@@ -2054,6 +2057,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
         { fieldName: 'portalLogoUrl' },
         { fieldName: 'canAdministerJIRA' },
       ],
+      serviceUrl: '/jira/servicedesk/projects/{projectKey}/settings/portal-settings',
     },
   },
   PortalSettings__announcementSettings: {
@@ -2076,6 +2080,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
         { fieldName: 'id' },
         { fieldName: 'customFieldId' },
       ],
+      serviceUrl: '/jira/servicedesk/projects/{projectKey}/settings/sla/custom/{id}',
     },
     deployRequests: {
       add: {

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -61,7 +61,9 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
     transformation: {
       dataField: '.',
       isSingleton: true,
-      serviceUrl: '/secure/admin/ViewApplicationProperties.jspa',
+      serviceUrl: {
+        url: '/secure/admin/ViewApplicationProperties.jspa',
+      },
     },
   },
   Dashboards: {
@@ -149,7 +151,9 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
           fieldName: 'gadgets',
         },
       ],
-      serviceUrl: '/jira/dashboards/{id}',
+      serviceUrl: {
+        url: '/jira/dashboards/{id}',
+      },
     },
     deployRequests: {
       add: {
@@ -401,7 +405,9 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
           fieldName: 'id',
         },
       ],
-      serviceUrl: '/secure/admin/ConfigureFieldLayout!default.jspa?=&id={id}',
+      serviceUrl: {
+        url: '/secure/admin/ConfigureFieldLayout!default.jspa?=&id={id}',
+      },
     },
     deployRequests: {
       add: {
@@ -451,7 +457,9 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
           fieldName: 'id',
         },
       ],
-      serviceUrl: '/secure/admin/ConfigureFieldLayoutScheme!default.jspa?=&id={id}',
+      serviceUrl: {
+        url: '/secure/admin/ConfigureFieldLayoutScheme!default.jspa?=&id={id}',
+      },
     },
     deployRequests: {
       add: {
@@ -517,7 +525,9 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       fieldsToOmit: [
         { fieldName: 'expand' },
       ],
-      serviceUrl: '/issues/?filter={id}',
+      serviceUrl: {
+        url: '/issues/?filter={id}',
+      },
     },
     deployRequests: {
       add: {
@@ -581,7 +591,9 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       fieldsToHide: [
         { fieldName: 'id' },
       ],
-      serviceUrl: '/secure/admin/ConfigureOptionSchemes!default.jspa?fieldId=&schemeId={id}',
+      serviceUrl: {
+        url: '/secure/admin/ConfigureOptionSchemes!default.jspa?fieldId=&schemeId={id}',
+      },
     },
     deployRequests: {
       add: {
@@ -642,7 +654,9 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
           fieldName: 'id',
         },
       ],
-      serviceUrl: '/secure/admin/ConfigureIssueTypeScreenScheme.jspa?id={id}',
+      serviceUrl: {
+        url: '/secure/admin/ConfigureIssueTypeScreenScheme.jspa?id={id}',
+      },
     },
     request: {
       url: '/rest/api/3/issuetypescreenscheme',
@@ -751,7 +765,9 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
           fieldName: 'id',
         },
       ],
-      serviceUrl: '/secure/admin/EditPermissions!default.jspa?schemeId={id}',
+      serviceUrl: {
+        url: '/secure/admin/EditPermissions!default.jspa?schemeId={id}',
+      },
     },
     request: {
       url: '/rest/api/3/project/{projectId}/permissionscheme',
@@ -802,7 +818,9 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
           fieldName: 'id',
         },
       ],
-      serviceUrl: '/secure/admin/projectcategories/EditProjectCategory!default.jspa?id={id}',
+      serviceUrl: {
+        url: '/secure/admin/projectcategories/EditProjectCategory!default.jspa?id={id}',
+      },
     },
     deployRequests: {
       add: {
@@ -853,7 +871,9 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
           fieldName: 'components',
         },
       ],
-      serviceUrl: '/secure/project/EditProject!default.jspa?pid={id}',
+      serviceUrl: {
+        url: '/secure/project/EditProject!default.jspa?pid={id}',
+      },
     },
     deployRequests: {
       add: {
@@ -930,7 +950,9 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
     },
     transformation: {
       fieldsToHide: [{ fieldName: 'id' }],
-      serviceUrl: '/secure/admin/EditNotifications!default.jspa?schemeId={id}',
+      serviceUrl: {
+        url: '/secure/admin/EditNotifications!default.jspa?schemeId={id}',
+      },
     },
   },
   NotificationSchemeEvent: {
@@ -989,7 +1011,9 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
           fieldName: 'id',
         },
       ],
-      serviceUrl: '/secure/admin/EditResolution!default.jspa?id={id}',
+      serviceUrl: {
+        url: '/secure/admin/EditResolution!default.jspa?id={id}',
+      },
     },
     deployRequests: {
       add: {
@@ -1013,7 +1037,9 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
           fieldName: 'id',
         },
       ],
-      serviceUrl: '/secure/admin/ConfigureFieldScreen.jspa?id={id}',
+      serviceUrl: {
+        url: '/secure/admin/ConfigureFieldScreen.jspa?id={id}',
+      },
     },
     deployRequests: {
       add: {
@@ -1142,7 +1168,9 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
         { fieldName: 'created' },
         { fieldName: 'updated' },
       ],
-      serviceUrl: '/secure/admin/workflows/ViewWorkflowSteps.jspa?workflowMode=live&workflowName={name}',
+      serviceUrl: {
+        url: '/secure/admin/workflows/ViewWorkflowSteps.jspa?workflowMode=live&workflowName={name}',
+      },
     },
     deployRequests: {
       add: {
@@ -1182,7 +1210,9 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
           fieldName: 'levels',
         },
       ],
-      serviceUrl: '/secure/admin/EditIssueSecurityScheme!default.jspa?=&schemeId={id}',
+      serviceUrl: {
+        url: '/secure/admin/EditIssueSecurityScheme!default.jspa?=&schemeId={id}',
+      },
     },
   },
 
@@ -1292,7 +1322,9 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
           fieldName: 'resolved',
         },
       ],
-      serviceUrl: '/secure/admin/EditStatus!default.jspa?id={id}',
+      serviceUrl: {
+        url: '/secure/admin/EditStatus!default.jspa?id={id}',
+      },
       nameMapping: 'lowercase',
     },
     deployRequests: {
@@ -1310,7 +1342,9 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
           fieldName: 'id',
         },
       ],
-      serviceUrl: '/secure/admin/EditWorkflowScheme.jspa?schemeId={id}',
+      serviceUrl: {
+        url: '/secure/admin/EditWorkflowScheme.jspa?schemeId={id}',
+      },
     },
     deployRequests: {
       add: {
@@ -1345,7 +1379,9 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
           fieldName: 'id',
         },
       ],
-      serviceUrl: '/secure/admin/EditIssueType!default.jspa?id={id}',
+      serviceUrl: {
+        url: '/secure/admin/EditIssueType!default.jspa?id={id}',
+      },
     },
     deployRequests: {
       add: {
@@ -1365,7 +1401,9 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
   AttachmentSettings: {
     transformation: {
       isSingleton: true,
-      serviceUrl: '/secure/admin/ViewAttachmentSettings.jspa',
+      serviceUrl: {
+        url: '/secure/admin/ViewAttachmentSettings.jspa',
+      },
     },
   },
 
@@ -1494,7 +1532,9 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
           fieldName: 'id',
         },
       ],
-      serviceUrl: '/secure/admin/EditLinkType!default.jspa?id={id}',
+      serviceUrl: {
+        url: '/secure/admin/EditLinkType!default.jspa?id={id}',
+      },
     },
   },
 
@@ -1505,7 +1545,9 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
           fieldName: 'id',
         },
       ],
-      serviceUrl: '/secure/project/EditProjectRole!default.jspa?id={id}',
+      serviceUrl: {
+        url: '/secure/project/EditProjectRole!default.jspa?id={id}',
+      },
     },
     deployRequests: {
       add: {
@@ -1525,13 +1567,17 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
 
   TimeTrackingProvider: {
     transformation: {
-      serviceUrl: '/secure/admin/TimeTrackingAdmin.jspa',
+      serviceUrl: {
+        url: '/secure/admin/TimeTrackingAdmin.jspa',
+      },
     },
   },
 
   Automation: {
     transformation: {
-      serviceUrl: '/jira/settings/automation#/rule/{id}',
+      serviceUrl: {
+        url: '/jira/settings/automation#/rule/{id}',
+      },
     },
   },
 
@@ -1546,7 +1592,9 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
           fieldName: 'id',
         },
       ],
-      serviceUrl: '/secure/admin/ListEventTypes.jspa',
+      serviceUrl: {
+        url: '/secure/admin/ListEventTypes.jspa',
+      },
     },
   },
   Priority: {
@@ -1556,7 +1604,9 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
           fieldName: 'id',
         },
       ],
-      serviceUrl: '/secure/admin/EditPriority!default.jspa?id={id}',
+      serviceUrl: {
+        url: '/secure/admin/EditPriority!default.jspa?id={id}',
+      },
     },
     deployRequests: {
       add: {
@@ -1605,7 +1655,9 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
           fieldName: 'id',
         },
       ],
-      serviceUrl: '/secure/admin/ConfigureFieldScreenScheme.jspa?id={id}',
+      serviceUrl: {
+        url: '/secure/admin/ConfigureFieldScreenScheme.jspa?id={id}',
+      },
     },
 
     deployRequests: {

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1865,7 +1865,12 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       fieldsToHide: [
         { fieldName: 'id' },
       ],
-      serviceUrl: '/jira/servicedesk/projects/{projectKey}/settings/request-types/request-type/{id}/request-form',
+      serviceUrl: {
+        url: '/jira/servicedesk/projects/{projectKey}/settings/request-types/request-type/{id}/request-form',
+        urlParamsToFields: {
+          projectKey: '_parent.0.key',
+        },
+      },
     },
   },
   CustomerPermissions: {
@@ -1911,7 +1916,12 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       fieldTypeOverrides: [
         { fieldName: 'columns', fieldType: 'List<Field>' },
       ],
-      serviceUrl: '/jira/servicedesk/projects/{projectKey}/queues/custom/{id}',
+      serviceUrl: {
+        url: '/jira/servicedesk/projects/{projectKey}/queues/custom/{id}',
+        urlParamsToFields: {
+          projectKey: '_parent.0.key',
+        },
+      },
     },
     deployRequests: {
       add: {
@@ -1951,7 +1961,12 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       fieldTypeOverrides: [
         { fieldName: 'ticketTypeIds', fieldType: 'List<RequestType>' },
       ],
-      serviceUrl: '/jira/servicedesk/projects/{projectKey}/settings/portal-settings/portal-groups',
+      serviceUrl: {
+        url: '/jira/servicedesk/projects/{projectKey}/settings/portal-settings/portal-groups',
+        urlParamsToFields: {
+          projectKey: '_parent.0.key',
+        },
+      },
     },
     deployRequests: {
       add: {
@@ -2057,7 +2072,12 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
         { fieldName: 'portalLogoUrl' },
         { fieldName: 'canAdministerJIRA' },
       ],
-      serviceUrl: '/jira/servicedesk/projects/{projectKey}/settings/portal-settings',
+      serviceUrl: {
+        url: '/jira/servicedesk/projects/{projectKey}/settings/portal-settings',
+        urlParamsToFields: {
+          projectKey: '_parent.0.key',
+        },
+      },
     },
   },
   PortalSettings__announcementSettings: {
@@ -2080,7 +2100,9 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
         { fieldName: 'id' },
         { fieldName: 'customFieldId' },
       ],
-      serviceUrl: '/jira/servicedesk/projects/{projectKey}/settings/sla/custom/{id}',
+      serviceUrl: {
+        url: '/jira/servicedesk/projects/{projectKey}/settings/sla/custom/{id}',
+      },
     },
     deployRequests: {
       add: {

--- a/packages/jira-adapter/src/filters/jsm_service_url.ts
+++ b/packages/jira-adapter/src/filters/jsm_service_url.ts
@@ -14,7 +14,6 @@
 * limitations under the License.
 */
 import { Change, getChangeData, InstanceElement, isAdditionChange, isInstanceChange, isInstanceElement } from '@salto-io/adapter-api'
-import { getParent } from '@salto-io/adapter-utils'
 import { filters } from '@salto-io/adapter-components'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
@@ -38,11 +37,7 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
       .filter(e => Object.keys(JSM_DUCKTYPE_SUPPORTED_TYPES).includes(e.elemID.typeName))
       .forEach(instance => {
         try {
-          const projectKey = getParent(instance).value.key
-          const additionalUrlVars: Record<string, string> = {
-            projectKey,
-          }
-          addUrlToInstance(instance, client.baseUrl, jsmApiDefinitions, additionalUrlVars)
+          addUrlToInstance(instance, client.baseUrl, jsmApiDefinitions)
         } catch (e) {
           log.warn(`Failed to add service url to ${instance.elemID.getFullName()}: ${e}`)
         }
@@ -64,11 +59,7 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
       .map(getChangeData)
       .forEach(instance => {
         try {
-          const projectKey = getParent(instance).value.key
-          const additionalUrlVars: Record<string, string> = {
-            projectKey,
-          }
-          addUrlToInstance(instance, client.baseUrl, jsmApiDefinitions, additionalUrlVars)
+          addUrlToInstance(instance, client.baseUrl, jsmApiDefinitions)
         } catch (e) {
           log.warn(`Failed to add service url to ${instance.elemID.getFullName()}: ${e}`)
         }

--- a/packages/jira-adapter/src/filters/jsm_service_url.ts
+++ b/packages/jira-adapter/src/filters/jsm_service_url.ts
@@ -1,0 +1,58 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Change, CORE_ANNOTATIONS, getChangeData, InstanceElement, isAdditionChange, isInstanceChange, isInstanceElement } from '@salto-io/adapter-api'
+import { elements as elementUtils } from '@salto-io/adapter-components'
+import { getParent } from '@salto-io/adapter-utils'
+import { FilterCreator } from '../filter'
+import { JiraConfig } from '../config/config'
+import JiraClient from '../client/client'
+import { JSM_SUPPORTED_TYPES } from './jsm_types_fetch_filter'
+
+const addUrlToInstance = (instance: InstanceElement, clinet: JiraClient, config: JiraConfig): void => {
+  const serviceUrl = config.jsmApiDefinitions?.types[instance.elemID.typeName]?.transformation?.serviceUrl
+  if (serviceUrl === undefined) {
+    return
+  }
+  const additionalUrlVars: Record<string, string> = {
+    projectKey: getParent(instance).value.key,
+  }
+  const url = elementUtils.createUrl({ instance, baseUrl: serviceUrl, additionalUrlVars })
+  instance.annotations[CORE_ANNOTATIONS.SERVICE_URL] = (new URL(url, clinet.baseUrl)).href
+}
+
+const filterCreator: FilterCreator = ({ config, client }) => ({
+  name: 'jsmServiceUrlFilter',
+  onFetch: async elements => {
+    if (!config.fetch.enableJSM) {
+      return
+    }
+    elements
+      .filter(isInstanceElement)
+      .filter(e => JSM_SUPPORTED_TYPES.includes(e.elemID.typeName))
+      .forEach(instance => addUrlToInstance(instance, client, config))
+  },
+  onDeploy: async (changes: Change<InstanceElement>[]) => {
+    const relevantChanges = changes
+      .filter(change => JSM_SUPPORTED_TYPES.includes(getChangeData(change).elemID.typeName))
+      .filter(isInstanceChange)
+      .filter(isAdditionChange)
+    relevantChanges
+      .map(getChangeData)
+      .forEach(instance => addUrlToInstance(instance, client, config))
+  },
+})
+
+export default filterCreator

--- a/packages/jira-adapter/src/filters/jsm_types_fetch_filter.ts
+++ b/packages/jira-adapter/src/filters/jsm_types_fetch_filter.ts
@@ -21,7 +21,7 @@ import { CALENDAR_TYPE, CUSTOMER_PERMISSIONS_TYPE, PORTAL_GROUP_TYPE, PORTAL_SET
 import { setTypeDeploymentAnnotations, addAnnotationRecursively } from '../utils'
 
 
-const jsmSupportedTypes = [
+export const JSM_SUPPORTED_TYPES = [
   CUSTOMER_PERMISSIONS_TYPE,
   QUEUE_TYPE,
   CALENDAR_TYPE,
@@ -38,7 +38,7 @@ const filterCreator: FilterCreator = ({ config }) => ({
       return
     }
     elements
-      .filter(e => jsmSupportedTypes.includes(e.elemID.typeName))
+      .filter(e => JSM_SUPPORTED_TYPES.includes(e.elemID.typeName))
       .filter(isObjectType)
       .map(async obj => {
         setTypeDeploymentAnnotations(obj)
@@ -47,7 +47,7 @@ const filterCreator: FilterCreator = ({ config }) => ({
         await addAnnotationRecursively(obj, CORE_ANNOTATIONS.DELETABLE)
       })
     elements
-      .filter(e => jsmSupportedTypes.includes(e.elemID.typeName))
+      .filter(e => JSM_SUPPORTED_TYPES.includes(e.elemID.typeName))
       .filter(isInstanceElement)
       .forEach(inst => {
         inst.annotations[CORE_ANNOTATIONS.PARENT] = [inst.value.projectKey]

--- a/packages/jira-adapter/src/filters/jsm_types_fetch_filter.ts
+++ b/packages/jira-adapter/src/filters/jsm_types_fetch_filter.ts
@@ -17,19 +17,8 @@
 
 import { isObjectType, CORE_ANNOTATIONS, isInstanceElement } from '@salto-io/adapter-api'
 import { FilterCreator } from '../filter'
-import { CALENDAR_TYPE, CUSTOMER_PERMISSIONS_TYPE, PORTAL_GROUP_TYPE, PORTAL_SETTINGS_TYPE_NAME, QUEUE_TYPE, REQUEST_TYPE_NAME, SLA_TYPE_NAME } from '../constants'
 import { setTypeDeploymentAnnotations, addAnnotationRecursively } from '../utils'
-
-
-export const JSM_SUPPORTED_TYPES = [
-  CUSTOMER_PERMISSIONS_TYPE,
-  QUEUE_TYPE,
-  CALENDAR_TYPE,
-  REQUEST_TYPE_NAME,
-  PORTAL_GROUP_TYPE,
-  PORTAL_SETTINGS_TYPE_NAME,
-  SLA_TYPE_NAME,
-]
+import { JSM_DUCKTYPE_SUPPORTED_TYPES } from '../config/api_config'
 
 const filterCreator: FilterCreator = ({ config }) => ({
   name: 'jsmTypesFetchFilter',
@@ -38,7 +27,7 @@ const filterCreator: FilterCreator = ({ config }) => ({
       return
     }
     elements
-      .filter(e => JSM_SUPPORTED_TYPES.includes(e.elemID.typeName))
+      .filter(e => Object.keys(JSM_DUCKTYPE_SUPPORTED_TYPES).includes(e.elemID.typeName))
       .filter(isObjectType)
       .map(async obj => {
         setTypeDeploymentAnnotations(obj)
@@ -47,7 +36,7 @@ const filterCreator: FilterCreator = ({ config }) => ({
         await addAnnotationRecursively(obj, CORE_ANNOTATIONS.DELETABLE)
       })
     elements
-      .filter(e => JSM_SUPPORTED_TYPES.includes(e.elemID.typeName))
+      .filter(e => Object.keys(JSM_DUCKTYPE_SUPPORTED_TYPES).includes(e.elemID.typeName))
       .filter(isInstanceElement)
       .forEach(inst => {
         inst.annotations[CORE_ANNOTATIONS.PARENT] = [inst.value.projectKey]

--- a/packages/jira-adapter/src/product_settings/data_center/api_config.ts
+++ b/packages/jira-adapter/src/product_settings/data_center/api_config.ts
@@ -51,7 +51,9 @@ export const DC_DEFAULT_API_DEFINITIONS: Partial<JiraApiConfig> = {
     },
     Dashboard: {
       transformation: {
-        serviceUrl: '/secure/Dashboard.jspa?selectPageId={id}',
+        serviceUrl: {
+          url: '/secure/Dashboard.jspa?selectPageId={id}',
+        },
       },
     },
     DashboardGadget: {
@@ -61,7 +63,9 @@ export const DC_DEFAULT_API_DEFINITIONS: Partial<JiraApiConfig> = {
     },
     Automation: {
       transformation: {
-        serviceUrl: '/secure/AutomationGlobalAdminAction!default.jspa#/rule/{id}',
+        serviceUrl: {
+          url: '/secure/AutomationGlobalAdminAction!default.jspa#/rule/{id}',
+        },
       },
     },
     Priorities: {

--- a/packages/jira-adapter/test/filters/jsm_service_url.test.ts
+++ b/packages/jira-adapter/test/filters/jsm_service_url.test.ts
@@ -1,0 +1,85 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { filterUtils } from '@salto-io/adapter-components'
+import _ from 'lodash'
+import { CORE_ANNOTATIONS, InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
+import { getDefaultConfig } from '../../src/config/config'
+import jsmServiceUrlFilter from '../../src/filters/jsm_service_url'
+import { createEmptyType, getFilterParams, mockClient } from '../utils'
+import { CALENDAR_TYPE, PROJECT_TYPE, QUEUE_TYPE } from '../../src/constants'
+import JiraClient from '../../src/client/client'
+
+describe('addJsmTypesAsFieldsFilter', () => {
+    type FilterType = filterUtils.FilterWith<'onFetch'>
+    let filter: FilterType
+    let projectInstance: InstanceElement
+    let queueInstance: InstanceElement
+    let client: JiraClient
+
+    beforeEach(() => {
+      const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+      config.fetch.enableJSM = true
+      const { client: cli } = mockClient(false)
+      client = cli
+      filter = jsmServiceUrlFilter(getFilterParams({ config, client })) as typeof filter
+      projectInstance = new InstanceElement(
+        'project1',
+        createEmptyType(PROJECT_TYPE),
+        {
+          id: 11111,
+          name: 'project1',
+          projectTypeKey: 'service_desk',
+          key: 'project1Key',
+        },
+      )
+    })
+    describe('on fetch', () => {
+      beforeEach(async () => {
+        queueInstance = new InstanceElement(
+          'queue1',
+          createEmptyType(QUEUE_TYPE),
+          {
+            id: 11,
+            name: 'queue1',
+          },
+          undefined,
+          {
+            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(projectInstance.elemID, projectInstance)],
+          },
+        )
+      })
+      it('should add serviceUrl to queue instance', async () => {
+        await filter.onFetch([projectInstance, queueInstance])
+        expect(queueInstance.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://ori-salto-test.atlassian.net/jira/servicedesk/projects/project1Key/queues/custom/11')
+      })
+      it('should not add serviceUrl to Calendar instance becuase it doesnt have serviceUrl', async () => {
+        const calendarInstance = new InstanceElement(
+          'SLA1',
+          createEmptyType(CALENDAR_TYPE),
+          {
+            id: 11,
+            name: 'SLA1',
+          },
+          undefined,
+          {
+            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(projectInstance.elemID, projectInstance)],
+          },
+        )
+        await filter.onFetch([projectInstance, calendarInstance])
+        expect(calendarInstance.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
+      })
+    })
+})

--- a/packages/jira-adapter/test/filters/jsm_service_url.test.ts
+++ b/packages/jira-adapter/test/filters/jsm_service_url.test.ts
@@ -15,19 +15,20 @@
 */
 import { filterUtils } from '@salto-io/adapter-components'
 import _ from 'lodash'
-import { CORE_ANNOTATIONS, InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, InstanceElement, ReferenceExpression, getChangeData, toChange } from '@salto-io/adapter-api'
 import { getDefaultConfig } from '../../src/config/config'
 import jsmServiceUrlFilter from '../../src/filters/jsm_service_url'
 import { createEmptyType, getFilterParams, mockClient } from '../utils'
 import { CALENDAR_TYPE, PROJECT_TYPE, QUEUE_TYPE } from '../../src/constants'
 import JiraClient from '../../src/client/client'
 
-describe('addJsmTypesAsFieldsFilter', () => {
-    type FilterType = filterUtils.FilterWith<'onFetch'>
+describe('jsmServiceUrlFilter', () => {
+    type FilterType = filterUtils.FilterWith<'onFetch' | 'onDeploy'>
     let filter: FilterType
     let projectInstance: InstanceElement
     let queueInstance: InstanceElement
     let client: JiraClient
+    let calendarInstance: InstanceElement
 
     beforeEach(() => {
       const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
@@ -45,41 +46,53 @@ describe('addJsmTypesAsFieldsFilter', () => {
           key: 'project1Key',
         },
       )
+      queueInstance = new InstanceElement(
+        'queue1',
+        createEmptyType(QUEUE_TYPE),
+        {
+          id: 11,
+          name: 'queue1',
+        },
+        undefined,
+        {
+          [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(projectInstance.elemID, projectInstance)],
+        },
+      )
+      calendarInstance = new InstanceElement(
+        'SLA1',
+        createEmptyType(CALENDAR_TYPE),
+        {
+          id: 11,
+          name: 'SLA1',
+        },
+        undefined,
+        {
+          [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(projectInstance.elemID, projectInstance)],
+        },
+      )
     })
     describe('on fetch', () => {
-      beforeEach(async () => {
-        queueInstance = new InstanceElement(
-          'queue1',
-          createEmptyType(QUEUE_TYPE),
-          {
-            id: 11,
-            name: 'queue1',
-          },
-          undefined,
-          {
-            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(projectInstance.elemID, projectInstance)],
-          },
-        )
-      })
       it('should add serviceUrl to queue instance', async () => {
         await filter.onFetch([projectInstance, queueInstance])
         expect(queueInstance.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://ori-salto-test.atlassian.net/jira/servicedesk/projects/project1Key/queues/custom/11')
       })
-      it('should not add serviceUrl to Calendar instance becuase it doesnt have serviceUrl', async () => {
-        const calendarInstance = new InstanceElement(
-          'SLA1',
-          createEmptyType(CALENDAR_TYPE),
-          {
-            id: 11,
-            name: 'SLA1',
-          },
-          undefined,
-          {
-            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(projectInstance.elemID, projectInstance)],
-          },
-        )
+      it('should not add serviceUrl to Calendar instance because it doesn`t have serviceUrl', async () => {
         await filter.onFetch([projectInstance, calendarInstance])
         expect(calendarInstance.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
+      })
+    })
+    describe('on deploy', () => {
+      it('should add service url annotation if it is exist in the config', async () => {
+        const changes = [toChange({ after: queueInstance })]
+        await filter.onDeploy(changes)
+        const instance = getChangeData(changes[0])
+        expect(instance.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://ori-salto-test.atlassian.net/jira/servicedesk/projects/project1Key/queues/custom/11')
+      })
+      it('should not add service url annotation if it is not exist in the config', async () => {
+        const changes = [toChange({ after: calendarInstance })]
+        await filter.onDeploy(changes)
+        const instance = getChangeData(changes[0])
+        expect(instance.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
       })
     })
 })

--- a/packages/okta-adapter/src/filters/service_url.ts
+++ b/packages/okta-adapter/src/filters/service_url.ts
@@ -69,7 +69,8 @@ const serviceUrlFilter: FilterCreator = ({ client, config }) => ({
           createServiceUrl(instance, baseUrl)
           return
         }
-        addUrlToInstance(instance, baseUrl, config)
+        const { apiDefinitions } = config
+        addUrlToInstance(instance, baseUrl, apiDefinitions)
       })
   },
   onDeploy: async (changes: Change<InstanceElement>[]) => {
@@ -86,7 +87,8 @@ const serviceUrlFilter: FilterCreator = ({ client, config }) => ({
           createServiceUrl(instance, baseUrl)
           return
         }
-        addUrlToInstance(instance, baseUrl, config)
+        const { apiDefinitions } = config
+        addUrlToInstance(instance, baseUrl, apiDefinitions)
       })
   },
 })


### PR DESCRIPTION
I added serviceUrl support for types in JSM. 

---
None

---
_Release Notes_: 
_Jira Adapter:_
Now supporting service Url for JSM types. 

---
_User Notifications_: 
None
