### PR TITLE
Revert "SAAS-2351 add instanceUrl as accountId to validateCredentials…

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -166,7 +166,6 @@ export type AccountInfo = {
   accountId: string
   accountType?: string
   isProduction?: boolean
-  extraInformation?: Record<string, string>
 }
 
 export type ConfigCreator = {

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -500,22 +500,10 @@ export const validateCredentials = async (
       `Remaining limits: ${remainingDailyRequests}, needed: ${minApiRequestsRemaining}`
     )
   }
-  if (creds.isSandbox) {
-    if (connection?.instanceUrl === undefined) {
-      throw new Error('Expected Salesforce organization URL to exist in the connection')
-    }
-    return {
-      accountId: connection.instanceUrl,
-      accountType,
-      isProduction,
-      extraInformation: { orgId },
-    }
-  }
   return {
     accountId: orgId,
     accountType,
     isProduction,
-    extraInformation: { orgId },
   }
 }
 export default class SalesforceClient {

--- a/packages/salesforce-adapter/test/client.test.ts
+++ b/packages/salesforce-adapter/test/client.test.ts
@@ -69,12 +69,6 @@ describe('salesforce client', () => {
     isSandbox: false,
     apiToken: 'myToken',
   })
-  const sandboxCredentials = new UsernamePasswordCredentials({
-    username: 'myUser',
-    password: 'myPass',
-    isSandbox: true,
-    apiToken: 'myToken',
-  })
   const { connection } = mockClient()
   const client = new SalesforceClient({
     credentials: new UsernamePasswordCredentials({
@@ -519,12 +513,7 @@ describe('salesforce client', () => {
       ).rejects.toThrow(ApiLimitsTooLowError)
     })
     it('should return empty string as accountId and no values for accountType and isProduction', async () => {
-      expect(await validateCredentials(credentials, 3, connection)).toEqual({
-        accountId: '',
-        isProduction: undefined,
-        accountType: undefined,
-        extraInformation: { orgId: '' },
-      })
+      expect(await validateCredentials(credentials, 3, connection)).toEqual({ accountId: '' })
     })
     describe('isProduction and accountType', () => {
       const PRODUCTION_ORGANIZATION_TYPE = 'Professional Edition'
@@ -543,11 +532,10 @@ describe('salesforce client', () => {
             mockOrganizationQueryResult({ orgType: PRODUCTION_ORGANIZATION_TYPE, isSandbox: true })
           })
           it('should return isProduction false and correct accountType', async () => {
-            expect(await validateCredentials(sandboxCredentials, 3, connection)).toEqual({
-              accountId: 'https://url.com/',
+            expect(await validateCredentials(credentials, 3, connection)).toEqual({
+              accountId: '',
               isProduction: false,
               accountType: PRODUCTION_ORGANIZATION_TYPE,
-              extraInformation: { orgId: '' },
             })
           })
         })
@@ -556,18 +544,11 @@ describe('salesforce client', () => {
             mockOrganizationQueryResult({ orgType: NON_PRODUCTION_ORGANIZATION_TYPE, isSandbox: true })
           })
           it('should return isProduction false and correct accountType', async () => {
-            expect(await validateCredentials(sandboxCredentials, 3, connection)).toEqual({
-              accountId: 'https://url.com/',
+            expect(await validateCredentials(credentials, 3, connection)).toEqual({
+              accountId: '',
               isProduction: false,
               accountType: NON_PRODUCTION_ORGANIZATION_TYPE,
-              extraInformation: { orgId: '' },
             })
-          })
-          it('should throw an error when there is no instanceUrl', async () => {
-            const mockConnection = mockClient().connection
-            _.set(mockConnection, 'instanceUrl', undefined)
-            await expect(validateCredentials(sandboxCredentials, 3, mockConnection))
-              .rejects.toThrow('Expected Salesforce organization URL to exist in the connection')
           })
         })
       })
@@ -581,7 +562,6 @@ describe('salesforce client', () => {
               accountId: '',
               isProduction: true,
               accountType: PRODUCTION_ORGANIZATION_TYPE,
-              extraInformation: { orgId: '' },
             })
           })
         })
@@ -594,7 +574,6 @@ describe('salesforce client', () => {
               accountId: '',
               isProduction: false,
               accountType: NON_PRODUCTION_ORGANIZATION_TYPE,
-              extraInformation: { orgId: '' },
             })
           })
         })


### PR DESCRIPTION
… response for SF sandbox (#4927)"

This reverts commit 9f3d8a55fc03e99f6dbdd4a5f7ab32e9661f4bcd.

_Replace me with a description of the changes in this PR_

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
