### PR TITLE
SALTO-4807 - fix mischange

### DIFF
--- a/packages/zendesk-adapter/src/filters/utils.ts
+++ b/packages/zendesk-adapter/src/filters/utils.ts
@@ -195,7 +195,7 @@ const createInstanceReference = ({ urlPart, brandOfInstance, instancesById, idRe
     // if could not find a valid instance, create a MissingReferences.
     if (enableMissingReferences) {
       // If we know the brand that the instance belongs to, we can create a MissingReference with the brand name
-      const missingInstanceId = brandOfInstance ? `${brandOfInstance.elemID.name}_${id}` : id
+      const missingInstanceId = brandOfInstance ? `${brandOfInstance.value.name}_${id}` : id
       const missingInstance = createMissingInstance(ZENDESK, type, missingInstanceId)
       missingInstance.value.id = id
       return [url, new ReferenceExpression(missingInstance.elemID, missingInstance)]

--- a/packages/zendesk-adapter/test/filters/utils.test.ts
+++ b/packages/zendesk-adapter/test/filters/utils.test.ts
@@ -186,7 +186,7 @@ describe('Zendesk utils', () => {
       brand = new InstanceElement(
         'brand',
         new ObjectType({ elemID: new ElemID(ZENDESK, BRAND_TYPE_NAME) }),
-        { id: 1 }
+        { id: 1, name: 'brand' }
       )
       article = new InstanceElement(
         'article',


### PR DESCRIPTION
Revert the missing instance id to the original, before SALTO-4807 change

---

None

---
_Release Notes_: 
None

---
_User Notifications_: 
None