### PR TITLE
SAAS-9299: NetSuite credentials not propagated as credentials issue

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -266,7 +266,11 @@ export default class NetsuiteAdapter implements AdapterOperations {
       )
       : []
 
-    const dataElementsPromise = getDataElements(this.client, fetchQuery, this.getElemIdFunc)
+    const {
+      elements: dataElements,
+      requestedTypes: requestedDataTypes,
+      largeTypesError: dataTypeError,
+    } = await getDataElements(this.client, fetchQuery, this.getElemIdFunc)
 
     const getCustomObjectsResult = this.client.getCustomObjects(
       getStandardTypesNames(),
@@ -317,11 +321,6 @@ export default class NetsuiteAdapter implements AdapterOperations {
       this.getElemIdFunc
     )
 
-    const {
-      elements: dataElements,
-      requestedTypes: requestedDataTypes,
-      largeTypesError: dataTypeError,
-    } = await dataElementsPromise
     failedTypes.excludedTypes = failedTypes.excludedTypes.concat(dataTypeError)
     const suiteAppConfigElements = this.client.isSuiteAppConfigured()
       ? toConfigElements(configRecords, fetchQuery).concat(getConfigTypes())


### PR DESCRIPTION
A similar issue to https://github.com/salto-io/salto/pull/4995 but in the NetSuite adapter.
we create multiple promises, without awaiting all of them, which causes a "crash" while all rejects, but just the first is caught. 

More info inside the attached PR.

---

_Additional context for reviewer_

---

_Release Notes_: 
None

---

User Notifications_: 


None