### PR TITLE
SALTO-4753 - Change handling of changing the default ticket form

### DIFF
--- a/packages/zendesk-adapter/test/change_validators/ticket_form_default.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/ticket_form_default.test.ts
@@ -16,75 +16,67 @@
 import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { ZENDESK, TICKET_FORM_TYPE_NAME } from '../../src/constants'
-import { onlyOneTicketFormDefaultValidator } from '../../src/change_validators/ticket_form_default'
+import { onlyOneTicketFormDefaultValidator } from '../../src/change_validators'
+
+const createTicketForm = (name: string, isDefault: boolean): InstanceElement => new InstanceElement(
+  name,
+  new ObjectType({ elemID: new ElemID(ZENDESK, TICKET_FORM_TYPE_NAME) }),
+  { default: isDefault },
+)
+
 
 describe('onlyOneTicketFormDefaultValidator', () => {
-  const ticketFormType = new ObjectType({
-    elemID: new ElemID(ZENDESK, TICKET_FORM_TYPE_NAME),
+  let defaultTicketForm1: InstanceElement
+  let defaultTicketForm2: InstanceElement
+  let notDefaultTicketForm: InstanceElement
+  beforeEach(() => {
+    defaultTicketForm1 = createTicketForm('defaultTicketForm1', true)
+    defaultTicketForm2 = createTicketForm('defaultTicketForm2', true)
+    notDefaultTicketForm = createTicketForm('notDefaultTicketForm', false)
   })
-  const defaultTicketForm = new InstanceElement(
-    'ticketForm1',
-    ticketFormType,
-    { name: 'test1', default: true },
-  )
-  const anotherDefaultTicketForm = new InstanceElement(
-    'ticketForm2',
-    ticketFormType,
-    { name: 'test2', default: true },
-  )
-  const nonDefaultTicketForm = new InstanceElement(
-    'ticketForm3',
-    ticketFormType,
-    { name: 'test3', default: false },
-  )
-  it('should return an error when we add another default ticket form', async () => {
-    const errors = await onlyOneTicketFormDefaultValidator(
-      [toChange({ after: anotherDefaultTicketForm })],
-      buildElementsSourceFromElements([ticketFormType, defaultTicketForm, anotherDefaultTicketForm])
-    )
-    expect(errors).toEqual([{
-      elemID: anotherDefaultTicketForm.elemID,
+  it('should return an error when more than one ticket form is set as default', async () => {
+    const elementsSource = buildElementsSourceFromElements([defaultTicketForm1, defaultTicketForm2])
+    const changes = [
+      toChange({ after: defaultTicketForm1 }),
+      toChange({ after: defaultTicketForm2 }),
+    ]
+    const errors = await onlyOneTicketFormDefaultValidator(changes, elementsSource)
+
+    expect(errors).toHaveLength(2)
+    expect(errors[0]).toEqual({
+      elemID: defaultTicketForm1.elemID,
       severity: 'Error',
-      message: 'Cannot set this as the default ticket form since another one is already defined as the default',
-      detailedMessage: `The following ticket forms are also marked as default: ${defaultTicketForm.elemID.getFullName()}`,
+      message: 'More than one ticket form is set as default',
+      detailedMessage: `Only one ticket form can be set as default, default ticket forms: ${[defaultTicketForm1, defaultTicketForm2].map(e => e.elemID.name).join(', ')}`,
+    })
+    expect(errors[1]).toEqual({
+      elemID: defaultTicketForm2.elemID,
+      severity: 'Error',
+      message: 'More than one ticket form is set as default',
+      detailedMessage: `Only one ticket form can be set as default, default ticket forms: ${[defaultTicketForm1, defaultTicketForm2].map(e => e.elemID.name).join(', ')}`,
+    })
+  })
+  it('should return a warning when a new default ticket form is set and there is already a default ticket form in the elementsSource', async () => {
+    const elementsSource = buildElementsSourceFromElements([defaultTicketForm2])
+    const changes = [toChange({ after: defaultTicketForm1 })]
+    const warning = await onlyOneTicketFormDefaultValidator(changes, elementsSource)
+
+    expect(warning).toHaveLength(1)
+    expect(warning).toEqual([{
+      elemID: defaultTicketForm1.elemID,
+      severity: 'Warning',
+      message: 'Setting a new default ticket form will unset the previous default ticket form',
+      detailedMessage: `Setting this ticket form as default will unset the other default ticket forms: ${defaultTicketForm2.elemID.name}`,
     }])
   })
-  it('should not return an error when we remove an item', async () => {
-    const errors = await onlyOneTicketFormDefaultValidator(
-      [toChange({ before: anotherDefaultTicketForm })],
-      buildElementsSourceFromElements([ticketFormType, defaultTicketForm])
-    )
+  it('should return nothing if there is only one default ticket form in both changes and elementsSource', async () => {
+    const elementsSource = buildElementsSourceFromElements([defaultTicketForm1, notDefaultTicketForm])
+    const changes = [
+      toChange({ after: defaultTicketForm1 }),
+      toChange({ after: notDefaultTicketForm }),
+    ]
+    const errors = await onlyOneTicketFormDefaultValidator(changes, elementsSource)
+
     expect(errors).toHaveLength(0)
-  })
-  it('should not return an error if the default value was not changed', async () => {
-    const afterAnotherDefaultTicketForm = anotherDefaultTicketForm.clone()
-    afterAnotherDefaultTicketForm.value.name = 'test3'
-    const errors = await onlyOneTicketFormDefaultValidator(
-      [toChange({ before: anotherDefaultTicketForm, after: afterAnotherDefaultTicketForm })],
-      buildElementsSourceFromElements([
-        ticketFormType, defaultTicketForm, afterAnotherDefaultTicketForm,
-      ])
-    )
-    expect(errors).toHaveLength(0)
-  })
-  it('should not return an error when we add a non default variant', async () => {
-    const errors = await onlyOneTicketFormDefaultValidator(
-      [toChange({ after: nonDefaultTicketForm })],
-      buildElementsSourceFromElements([ticketFormType, defaultTicketForm, nonDefaultTicketForm])
-    )
-    expect(errors).toEqual([])
-  })
-  it('should not return an error when there is no element source', async () => {
-    const errors = await onlyOneTicketFormDefaultValidator(
-      [toChange({ after: anotherDefaultTicketForm })],
-    )
-    expect(errors).toEqual([])
-  })
-  it('should not return an error when we add the first default', async () => {
-    const errors = await onlyOneTicketFormDefaultValidator(
-      [toChange({ after: defaultTicketForm })],
-      buildElementsSourceFromElements([ticketFormType, nonDefaultTicketForm])
-    )
-    expect(errors).toEqual([])
   })
 })


### PR DESCRIPTION
Change the handling of changing the default ticket form
* Prevent changing two ticket forms to be the default
* Warn that the current default will be set as not default

---

None

---
_Release Notes_: 
* No longer prevents deployment of a a new default ticket form if the current default is not changing

---
_User Notifications_: 
None
