### PR TITLE
SALTO-4925: Make okta config options visible in the adapter's nacl

### DIFF
--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -1782,10 +1782,7 @@ export const configType = createMatchingObjectType<Partial<OktaConfig>>({
       PRIVATE_API_DEFINITIONS_CONFIG,
       CLIENT_CONFIG,
       `${FETCH_CONFIG}.hideTypes`,
-      `${FETCH_CONFIG}.convertUsersIds`,
       `${FETCH_CONFIG}.enableMissingReferences`,
-      `${FETCH_CONFIG}.includeGroupMemberships`,
-      `${FETCH_CONFIG}.includeProfileMappingProperties`
     ),
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },


### PR DESCRIPTION
Make okta config options visible in the adapter's nacl

---

We recently added many config options to Okta. Making those visible will make it easier to CE to follow.
Only changed config options that I believe can be useful in first fetch

The new adapter config default - 

```
okta {
  fetch = {
    include = [
      {
        type = ".*"
      },
    ]
    exclude = [
    ]
    convertUsersIds = true
    includeGroupMemberships = false
    includeProfileMappingProperties = true
  }
}
```

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
