### PR TITLE
SALTO-4654 - Zendesk Adapter - Add gaps to order positions

### DIFF
--- a/packages/zendesk-adapter/src/filters/guide_order/guide_order_utils.ts
+++ b/packages/zendesk-adapter/src/filters/guide_order/guide_order_utils.ts
@@ -35,6 +35,7 @@ import ZendeskClient from '../../client/client'
 import { API_DEFINITIONS_CONFIG, FilterContext } from '../../config'
 import { BRAND_TYPE_NAME, CATEGORY_ORDER_TYPE_NAME, SECTION_ORDER_TYPE_NAME, ARTICLE_ORDER_TYPE_NAME, CATEGORY_TYPE_NAME, ZENDESK, CATEGORIES_FIELD, SECTION_TYPE_NAME, SECTIONS_FIELD, ARTICLE_TYPE_NAME, ARTICLES_FIELD } from '../../constants'
 import { getZendeskError } from '../../errors'
+import { createOrderPosition } from '../reorder/creator'
 
 
 const { isDefined } = lowerDashValues
@@ -141,9 +142,10 @@ const updateElementPositions = async (
         })
       }
 
+      const position = createOrderPosition(i)
       // Send an api request to update the positions of the elements in the order list
       // There is no reason to update elements that weren't changed
-      if (resolvedChild.value.position !== i) {
+      if (resolvedChild.value.position !== position) {
         try {
           await client.put({
             url: createUrl({
@@ -151,7 +153,7 @@ const updateElementPositions = async (
               baseUrl: childUpdateApi.url,
               urlParamsToFields: childUpdateApi.urlParamsToFields,
             }),
-            data: { position: i },
+            data: { position },
           })
         } catch (err) {
           return getZendeskError(getChangeData(change).elemID, err)

--- a/packages/zendesk-adapter/src/filters/reorder/creator.ts
+++ b/packages/zendesk-adapter/src/filters/reorder/creator.ts
@@ -40,6 +40,8 @@ import ZendeskClient from '../../client/client'
 
 const { TYPES_PATH, SUBTYPES_PATH, RECORDS_PATH, SETTINGS_NESTED_PATH } = elementsUtils
 
+export const createOrderPosition = (position: number): number => (position + 1) * 100 // (SALTO-4654)
+
 export type DeployFuncType = (
   change: Change<InstanceElement>,
   client: ZendeskClient,
@@ -200,7 +202,7 @@ export const deployFuncCreator = (fieldName: string): DeployFuncType =>
         elemID: getChangeData(change).elemID,
       })
     }
-    const idsWithPositions = ids.map((id, position) => ({ id, position: position + 1 }))
+    const idsWithPositions = ids.map((id, position) => ({ id, position: createOrderPosition(position) }))
     instance.value[fieldName] = idsWithPositions
     delete instance.value.ids
     await deployChange(clonedChange, client, apiDefinitions)

--- a/packages/zendesk-adapter/src/filters/reorder/trigger.ts
+++ b/packages/zendesk-adapter/src/filters/reorder/trigger.ts
@@ -33,7 +33,7 @@ import { logger } from '@salto-io/logging'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
 import { FilterCreator } from '../../filter'
 import { deployChange } from '../../deployment'
-import { createOrderTypeName, createReorderFilterCreator, DeployFuncType } from './creator'
+import { createOrderTypeName, createOrderPosition, createReorderFilterCreator, DeployFuncType } from './creator'
 import { TRIGGER_CATEGORY_TYPE_NAME, TRIGGER_TYPE_NAME, ZENDESK } from '../../constants'
 
 const TRIGGER_ORDER_ENTRY_TYPE_NAME = 'trigger_order_entry'
@@ -74,13 +74,11 @@ const deployFunc: DeployFuncType = async (change, client, apiDefinitions) => {
   }
   const triggerCategories = order
     .map(entry => entry.category)
-    // We send position + 1, since the position in the service are starting from 1
-    .map((id, position) => ({ id, position: position + 1 }))
+    .map((id, position) => ({ id, position: createOrderPosition(position) }))
   const triggers = order
     .flatMap(entry => (entry.active ?? []).concat(entry.inactive ?? []).map((id, position) => ({
       id: id.toString(),
-      // We send position + 1, since the position in the service are starting from 1
-      position: position + 1,
+      position: createOrderPosition(position),
       category_id: entry.category,
     })))
   instance.value.action = 'patch'

--- a/packages/zendesk-adapter/test/filters/guide_orders.test.ts
+++ b/packages/zendesk-adapter/test/filters/guide_orders.test.ts
@@ -23,6 +23,7 @@ import { createFilterCreatorParams } from '../utils'
 import { createOrderType } from '../../src/filters/guide_order/guide_order_utils'
 import { DEFAULT_CONFIG, FETCH_CONFIG } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
+import { createOrderPosition } from '../../src/filters/reorder/creator'
 
 const { createUrl } = elementsUtils
 
@@ -193,7 +194,7 @@ const testDeploy = async (
       baseUrl: updateApi.url,
       urlParamsToFields: updateApi.urlParamsToFields,
     }),
-    data: { position: 0 },
+    data: { position: createOrderPosition(0) },
   })
   expect(mockPut).toHaveBeenCalledWith({
     url: createUrl({
@@ -201,7 +202,7 @@ const testDeploy = async (
       baseUrl: updateApi.url,
       urlParamsToFields: updateApi.urlParamsToFields,
     }),
-    data: { position: 1 },
+    data: { position: createOrderPosition(1) },
   })
 }
 

--- a/packages/zendesk-adapter/test/filters/reorder/automation.test.ts
+++ b/packages/zendesk-adapter/test/filters/reorder/automation.test.ts
@@ -21,7 +21,7 @@ import {
 import { filterUtils } from '@salto-io/adapter-components'
 import { ZENDESK } from '../../../src/constants'
 import filterCreator, { ORDER_FIELD_NAME } from '../../../src/filters/reorder/automation'
-import { createOrderTypeName } from '../../../src/filters/reorder/creator'
+import { createOrderPosition, createOrderTypeName } from '../../../src/filters/reorder/creator'
 import { createFilterCreatorParams } from '../../utils'
 
 const mockDeployChange = jest.fn()
@@ -112,9 +112,9 @@ describe('automation reorder filter', () => {
       const instanceToDeploy = after.clone()
       instanceToDeploy.value = {
         automations: [
-          { id: 22, position: 1 },
-          { id: 33, position: 2 },
-          { id: 11, position: 3 },
+          { id: 22, position: createOrderPosition(0) },
+          { id: 33, position: createOrderPosition(1) },
+          { id: 11, position: createOrderPosition(2) },
         ],
       }
       expect(mockDeployChange).toHaveBeenCalledWith({

--- a/packages/zendesk-adapter/test/filters/reorder/trigger.test.ts
+++ b/packages/zendesk-adapter/test/filters/reorder/trigger.test.ts
@@ -20,7 +20,7 @@ import {
 import { filterUtils } from '@salto-io/adapter-components'
 import { TRIGGER_CATEGORY_TYPE_NAME, TRIGGER_TYPE_NAME, ZENDESK } from '../../../src/constants'
 import filterCreator from '../../../src/filters/reorder/trigger'
-import { createOrderTypeName } from '../../../src/filters/reorder/creator'
+import { createOrderPosition, createOrderTypeName } from '../../../src/filters/reorder/creator'
 import { createFilterCreatorParams } from '../../utils'
 
 const mockDeployChange = jest.fn()
@@ -168,17 +168,17 @@ describe('trigger reorder filter', () => {
         action: 'patch',
         items: {
           trigger_categories: [
-            { id: '2', position: 1 },
-            { id: '3', position: 2 },
-            { id: '1', position: 3 },
+            { id: '2', position: createOrderPosition(0) },
+            { id: '3', position: createOrderPosition(1) },
+            { id: '1', position: createOrderPosition(2) },
           ],
           triggers: [
-            { id: '44', position: 1, category_id: '2' },
-            { id: '33', position: 2, category_id: '2' },
-            { id: '11', position: 1, category_id: '1' },
-            { id: '22', position: 2, category_id: '1' },
-            { id: '66', position: 3, category_id: '1' },
-            { id: '55', position: 4, category_id: '1' },
+            { id: '44', position: createOrderPosition(0), category_id: '2' },
+            { id: '33', position: createOrderPosition(1), category_id: '2' },
+            { id: '11', position: createOrderPosition(0), category_id: '1' },
+            { id: '22', position: createOrderPosition(1), category_id: '1' },
+            { id: '66', position: createOrderPosition(2), category_id: '1' },
+            { id: '55', position: createOrderPosition(3), category_id: '1' },
           ],
         },
       }

--- a/packages/zendesk-adapter/test/filters/reorder/view.test.ts
+++ b/packages/zendesk-adapter/test/filters/reorder/view.test.ts
@@ -21,7 +21,7 @@ import {
 import { filterUtils } from '@salto-io/adapter-components'
 import { VIEW_TYPE_NAME, ZENDESK } from '../../../src/constants'
 import filterCreator, { ORDER_FIELD_NAME } from '../../../src/filters/reorder/view'
-import { createOrderTypeName } from '../../../src/filters/reorder/creator'
+import { createOrderPosition, createOrderTypeName } from '../../../src/filters/reorder/creator'
 import { createFilterCreatorParams } from '../../utils'
 
 const mockDeployChange = jest.fn()
@@ -112,9 +112,9 @@ describe('view reorder filter', () => {
       const instanceToDeploy = after.clone()
       instanceToDeploy.value = {
         views: [
-          { id: 22, position: 1 },
-          { id: 33, position: 2 },
-          { id: 11, position: 3 },
+          { id: 22, position: createOrderPosition(0) },
+          { id: 33, position: createOrderPosition(1) },
+          { id: 11, position: createOrderPosition(2) },
         ],
       }
       expect(mockDeployChange).toHaveBeenCalledWith({


### PR DESCRIPTION
Add gaps to order positions, to start from 100 and go up by 100 (100, 200, 300)

---

Changed only the types where the position updates by element
Types that are updated as a whole (reorder API) are not changed

---
_Release Notes_: 
Zendesk Adapter:
* Added gaps to elements positions of triggers, automations and views

---
_User Notifications_: 
None