### PR TITLE
SALTO-4946: Fixed jira E2E test 

### DIFF
--- a/packages/jira-adapter/e2e_test/adapter.test.ts
+++ b/packages/jira-adapter/e2e_test/adapter.test.ts
@@ -92,7 +92,8 @@ each([
   it('should fetch project with schemes', () => {
     const projectInstance = fetchedElements
       .filter(isInstanceElement)
-      .find(e => e.elemID.typeName === 'Project')
+      .filter(e => e.elemID.typeName === 'Project')
+      .filter(e => e.value.name === 'Test Project')[0]
     expect(projectInstance?.value).toContainKeys([
       'workflowScheme',
       'permissionScheme',


### PR DESCRIPTION
I added another project to jira test account of type JSM. 
Due to this addition, I needed to modify the jira E2E tests. 

---

_Additional context for reviewer_
None

---
_Release Notes_: 
None

---
_User Notifications_: 
None
