### PR TITLE
SALTO-4944: add workflow deletion before second attempt of workflow deployment 

### DIFF
--- a/packages/jira-adapter/src/filters/workflow/workflow_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_deploy_filter.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { AdditionChange, Change, ElemID, getChangeData, InstanceElement, isAdditionChange, isInstanceChange, isRemovalChange, RemovalChange } from '@salto-io/adapter-api'
+import { AdditionChange, Change, ElemID, getChangeData, InstanceElement, isAdditionChange, isInstanceChange, isRemovalChange, RemovalChange, toChange } from '@salto-io/adapter-api'
 import Joi from 'joi'
 import { resolveChangeElement, walkOnValue, WALK_NEXT_STEP, inspectValue, createSchemeGuard } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
@@ -273,6 +273,8 @@ const verifyAndFixTransitionReferences = async ({
     return transitions
   }
   const originalInstance = getChangeData(resolvedChange)
+  // we need to delete to previous workflow before we can deploy the new one
+  await deployWithClone(toChange({ before: originalInstance }), client, config)
   walkOnValue({ elemId: originalInstance.elemID.createNestedID('transitions'),
     value: originalInstance.value.transitions,
     func: decodeCloudFields })

--- a/packages/jira-adapter/src/filters/workflow/workflow_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_deploy_filter.ts
@@ -209,8 +209,8 @@ const deployWithClone = async (
   const deployInstance = getChangeData(resolvedChangeForDeployment)
 
   if (isAdditionChange(resolvedChange) && await doesWorkflowExist(client, deployInstance.value.name)) {
-    log.warn(`A workflow with the name "${deployInstance.value.name}" is already exist`)
-    throw new Error(`A workflow with the name "${deployInstance.value.name}" is already exist`)
+    log.warn(`A workflow with the name "${deployInstance.value.name}" already exists`)
+    throw new Error(`A workflow with the name "${deployInstance.value.name}" already exists`)
   }
 
   if (!isRemovalChange(resolvedChange)) {

--- a/packages/jira-adapter/test/filters/workflow/workflow_deploy_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_deploy_filter.test.ts
@@ -1230,7 +1230,7 @@ describe('workflowDeployFilter', () => {
       const { deployResult: { errors, appliedChanges } } = await filter.deploy([change])
 
       expect(errors).toHaveLength(1)
-      expect(errors[0].message).toBe('Error: A workflow with the name "name" is already exist')
+      expect(errors[0].message).toBe('Error: A workflow with the name "name" already exists')
       expect(appliedChanges).toHaveLength(0)
     })
 

--- a/packages/jira-adapter/test/filters/workflow/workflow_deploy_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_deploy_filter.test.ts
@@ -556,7 +556,7 @@ describe('workflowDeployFilter', () => {
         // two calls, one for transitions, one for step deployment
         expect(mockConnectionSR.get).toHaveBeenCalledTimes(2)
       })
-      it('should deploy twice if the transitionId was not expected', async () => {
+      it('should deploy three times if the transitionId was not expected', async () => {
         mockConnectionSR.get.mockResolvedValueOnce({
           status: 200,
           data: {
@@ -614,7 +614,8 @@ describe('workflowDeployFilter', () => {
           },
         })
         await filterSR.deploy([toChange({ after: instance })])
-        expect(deployChangeMock).toHaveBeenCalledTimes(2)
+        // first call with the failed prediction, second for deleting it and third for the correct one
+        expect(deployChangeMock).toHaveBeenCalledTimes(3)
         expect(deployChangeMock).toHaveBeenCalledWith({
           change: toChange({
             after: new InstanceElement(
@@ -681,6 +682,18 @@ describe('workflowDeployFilter', () => {
                 ],
               },
             ),
+          }),
+          client: clientSR,
+          endpointDetails: getDefaultConfig({ isDataCenter: false })
+            .apiDefinitions.types.Workflow.deployRequests,
+          fieldsToIgnore: expect.toBeFunction(),
+        })
+        instance.value.transitions[INITIAL_KEY].id = undefined
+        instance.value.transitions[TRANSITION_KEY_2].id = undefined
+        instance.value.operations = undefined
+        expect(deployChangeMock).toHaveBeenCalledWith({
+          change: toChange({
+            before: instance,
           }),
           client: clientSR,
           endpointDetails: getDefaultConfig({ isDataCenter: false })
@@ -752,7 +765,7 @@ describe('workflowDeployFilter', () => {
         expect(deployResult.errors[0].message).toEqual(
           'Error: Failed to deploy workflow, transition ids changed'
         )
-        expect(deployChangeMock).toHaveBeenCalledTimes(2)
+        expect(deployChangeMock).toHaveBeenCalledTimes(3)
         // two calls for transitions and two calls to check if the workflow exist
         expect(mockConnectionSR.get).toHaveBeenCalledTimes(4)
       })


### PR DESCRIPTION
_add workflow deletion before second attempt of workflow deployment_

---


---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
