### PR TITLE
SALTO-4727: Remove creation of the fetchProfile from the SalesforceAdapter constructor  

### DIFF
--- a/packages/cli/e2e_test/helpers/salesforce.ts
+++ b/packages/cli/e2e_test/helpers/salesforce.ts
@@ -106,7 +106,7 @@ export const addElements = async <T extends InstanceElement | ObjectType>(
   elements: T[]
 ): Promise<T[]> => {
   const adapter = new SalesforceAdapter(
-    { client, config: {}, elementsSource: buildElementsSourceFromElements([]), isFetchWithChangesDetection: false }
+    { client, config: {}, elementsSource: buildElementsSourceFromElements([]) }
   )
   const changeGroup: ChangeGroup = {
     groupID: elements[0].elemID.getFullName(),
@@ -125,7 +125,7 @@ export const removeElements = async <T extends InstanceElement | ObjectType>(
   elements: T[]
 ): Promise<void> => {
   const adapter = new SalesforceAdapter(
-    { client, config: {}, elementsSource: buildElementsSourceFromElements([]), isFetchWithChangesDetection: false }
+    { client, config: {}, elementsSource: buildElementsSourceFromElements([]) }
   )
   const changeGroup: ChangeGroup = {
     groupID: elements[0].elemID.getFullName(),

--- a/packages/salesforce-adapter/e2e_test/adapter.ts
+++ b/packages/salesforce-adapter/e2e_test/adapter.ts
@@ -43,7 +43,6 @@ const realAdapter = ({ adapterParams, credentials }: Opts, config?: SalesforceCo
     client,
     config: config ?? {},
     elementsSource: buildElementsSourceFromElements([]),
-    isFetchWithChangesDetection: false,
     ...adapterParams || { getElemIdFunc: mockGetElemIdFunc },
   })
   return { client, adapter }

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -96,7 +96,7 @@ import removeUnixTimeZeroFilter from './filters/remove_unix_time_zero'
 import organizationWideDefaults from './filters/organization_wide_sharing_defaults'
 import centralizeTrackingInfoFilter from './filters/centralize_tracking_info'
 import changedAtSingletonFilter from './filters/changed_at_singleton'
-import { FetchElements, FetchProfile, SalesforceConfig } from './types'
+import { FetchElements, FetchProfile, MetadataQuery, SalesforceConfig } from './types'
 import { getConfigFromConfigChanges } from './config_change'
 import { LocalFilterCreator, Filter, FilterResult, RemoteFilterCreator, LocalFilterCreatorDefinition, RemoteFilterCreatorDefinition } from './filter'
 import { addDefaults, isCustomObjectSync, isCustomType, listMetadataObjects } from './filters/utils'
@@ -241,8 +241,6 @@ export interface SalesforceAdapterParams {
   config: SalesforceConfig
 
   elementsSource: ReadOnlyElementsSource
-
-  isFetchWithChangesDetection: boolean
 }
 
 const METADATA_TO_RETRIEVE = [
@@ -337,10 +335,9 @@ export default class SalesforceAdapter implements AdapterOperations {
   private metadataToRetrieve: string[]
   private metadataTypesOfInstancesFetchedInFilters: string[]
   private nestedMetadataTypes: Record<string, NestedMetadataTypeInfo>
-  private createFiltersRunner: () => Promise<Required<Filter>>
+  private createFiltersRunner: (fetchProfile: FetchProfile) => Promise<Required<Filter>>
   private client: SalesforceClient
   private userConfig: SalesforceConfig
-  private fetchProfilePromise: Promise<FetchProfile>
   private elementsSource: ReadOnlyElementsSource
 
   public constructor({
@@ -393,7 +390,6 @@ export default class SalesforceAdapter implements AdapterOperations {
     systemFields = SYSTEM_FIELDS,
     unsupportedSystemFields = UNSUPPORTED_SYSTEM_FIELDS,
     config,
-    isFetchWithChangesDetection,
   }: SalesforceAdapterParams) {
     this.maxItemsInRetrieveRequest = config.maxItemsInRetrieveRequest ?? maxItemsInRetrieveRequest
     this.metadataToRetrieve = metadataToRetrieve
@@ -402,17 +398,7 @@ export default class SalesforceAdapter implements AdapterOperations {
     this.nestedMetadataTypes = nestedMetadataTypes
     this.client = client
     this.elementsSource = elementsSource
-
-    this.fetchProfilePromise = isFetchWithChangesDetection
-      ? buildFetchProfileForFetchWithChangesDetection({
-        fetchParams: config.fetch ?? {},
-        elementsSource,
-      })
-      : Promise.resolve(buildFetchProfile({
-        fetchParams: config.fetch ?? {},
-        elementsSource,
-      }))
-    this.createFiltersRunner = async () => filter.filtersRunner(
+    this.createFiltersRunner = async (fetchProfile: FetchProfile) => filter.filtersRunner(
       {
         client,
         config: {
@@ -420,7 +406,7 @@ export default class SalesforceAdapter implements AdapterOperations {
           systemFields,
           enumFieldPermissions: config.enumFieldPermissions
             ?? constants.DEFAULT_ENUM_FIELD_PERMISSIONS,
-          fetchProfile: await this.fetchProfilePromise,
+          fetchProfile,
           elementsSource,
           separateFieldToFiles: config.fetch?.metadata?.objectsToSeperateFieldsToFiles,
         },
@@ -439,7 +425,15 @@ export default class SalesforceAdapter implements AdapterOperations {
    */
   @logDuration('fetching account configuration')
   async fetch({ progressReporter, withChangesDetection = false }: FetchOptions): Promise<FetchResult> {
-    const fetchProfile = await this.fetchProfilePromise
+    const fetchProfile = withChangesDetection
+      ? await buildFetchProfileForFetchWithChangesDetection({
+        fetchParams: this.userConfig.fetch ?? {},
+        elementsSource: this.elementsSource,
+      })
+      : buildFetchProfile({
+        fetchParams: this.userConfig.fetch ?? {},
+        elementsSource: this.elementsSource,
+      })
     if (!fetchProfile.isFeatureEnabled('fetchCustomObjectUsingRetrieveApi')) {
       // We have to fetch custom objects using retrieve in order to be able to fetch the field-level permissions
       // in profiles. If custom objects are fetched via the read API, we have to fetch profiles using that API too.
@@ -456,7 +450,7 @@ export default class SalesforceAdapter implements AdapterOperations {
       ...Types.getAnnotationTypes(),
       ...Object.values(ArtificialTypes),
     ]
-    const metadataTypeInfosPromise = this.listMetadataTypes()
+    const metadataTypeInfosPromise = this.listMetadataTypes(fetchProfile.metadataQuery)
     const metadataTypesPromise = withChangesDetection
       ? getMetadataTypesFromElementsSource(this.elementsSource)
       : this.fetchMetadataTypes(
@@ -481,7 +475,7 @@ export default class SalesforceAdapter implements AdapterOperations {
     ]
     progressReporter.reportProgress({ message: 'Running filters for additional information' })
     const onFetchFilterResult = (
-      await (await this.createFiltersRunner()).onFetch(elements)
+      await (await this.createFiltersRunner(fetchProfile)).onFetch(elements)
     ) as FilterResult
     const configChangeSuggestions = [
       ...metadataInstancesConfigInstances, ...(onFetchFilterResult.configSuggestions ?? []),
@@ -502,7 +496,10 @@ export default class SalesforceAdapter implements AdapterOperations {
     { changeGroup }: DeployOptions,
     checkOnly: boolean
   ): Promise<DeployResult> {
-    const fetchProfile = await this.fetchProfilePromise
+    const fetchProfile = buildFetchProfile({
+      fetchParams: this.userConfig.fetch ?? {},
+      elementsSource: this.elementsSource,
+    })
     log.debug(`about to ${checkOnly ? 'validate' : 'deploy'} group ${changeGroup.groupID} with scope (first 100): ${safeJsonStringify(changeGroup.changes.slice(0, 100).map(getChangeData).map(e => e.elemID.getFullName()))}`)
     const isDataDeployGroup = await isCustomObjectInstanceChanges(changeGroup.changes)
     const getLookupNameFunc = isDataDeployGroup
@@ -513,7 +510,7 @@ export default class SalesforceAdapter implements AdapterOperations {
       .toArray()
 
     await awu(resolvedChanges).filter(isAdditionChange).map(getChangeData).forEach(addDefaults)
-    const filtersRunner = await this.createFiltersRunner()
+    const filtersRunner = await this.createFiltersRunner(fetchProfile)
     await filtersRunner.preDeploy(resolvedChanges)
     log.debug(`preDeploy of group ${changeGroup.groupID} finished`)
 
@@ -576,10 +573,9 @@ export default class SalesforceAdapter implements AdapterOperations {
     return this.deployOrValidate(deployOptions, true)
   }
 
-  private async listMetadataTypes(): Promise<MetadataObject[]> {
-    const fetchProfile = await this.fetchProfilePromise
+  private async listMetadataTypes(metadataQuery: MetadataQuery): Promise<MetadataObject[]> {
     return (await this.client.listMetadataTypes())
-      .filter(info => fetchProfile.metadataQuery.isTypeMatch(info.xmlName))
+      .filter(info => metadataQuery.isTypeMatch(info.xmlName))
   }
 
   @logDuration('fetching metadata types')

--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -173,10 +173,6 @@ In Addition, ${configFromFetch.message}`,
   return configFromFetch
 }
 
-type CreateSalesforceAdapterParams = {
-  isFetchWithChangesDetection?: boolean
-}
-
 export const adapter: Adapter = {
   operations: context => {
     const updatedConfig = context.config && updateDeprecatedConfiguration(context.config)
@@ -184,25 +180,19 @@ export const adapter: Adapter = {
     const credentials = credentialsFromConfig(context.credentials)
     const client = new SalesforceClient({ credentials, config: config[CLIENT_CONFIG] })
 
-    const createSalesforceAdapter = async ({
-      isFetchWithChangesDetection = false,
-    }: CreateSalesforceAdapterParams = {}
-    ): Promise<SalesforceAdapter> => {
+    const createSalesforceAdapter = (): SalesforceAdapter => {
       const { elementsSource, getElemIdFunc } = context
       return new SalesforceAdapter({
         client,
         config,
         getElemIdFunc,
         elementsSource,
-        isFetchWithChangesDetection,
       })
     }
 
     return {
       fetch: async opts => {
-        const salesforceAdapter = await createSalesforceAdapter({
-          isFetchWithChangesDetection: opts.withChangesDetection ?? false,
-        })
+        const salesforceAdapter = createSalesforceAdapter()
         const fetchResults = await salesforceAdapter.fetch(opts)
         fetchResults.updatedConfig = getConfigChange(
           fetchResults.updatedConfig,
@@ -215,11 +205,11 @@ export const adapter: Adapter = {
       },
 
       deploy: async opts => {
-        const salesforceAdapter = await createSalesforceAdapter()
+        const salesforceAdapter = createSalesforceAdapter()
         return salesforceAdapter.deploy(opts)
       },
       validate: async opts => {
-        const salesforceAdapter = await createSalesforceAdapter()
+        const salesforceAdapter = createSalesforceAdapter()
         return salesforceAdapter.validate(opts)
       },
       deployModifiers: {

--- a/packages/salesforce-adapter/test/adapter.creator.test.ts
+++ b/packages/salesforce-adapter/test/adapter.creator.test.ts
@@ -212,7 +212,6 @@ describe('SalesforceAdapter creator', () => {
         client: expect.any(Object),
         getElemIdFunc: undefined,
         elementsSource: expect.any(Object),
-        isFetchWithChangesDetection: false,
       })
     })
 
@@ -654,7 +653,6 @@ describe('SalesforceAdapter creator', () => {
         client: expect.any(Object),
         getElemIdFunc: undefined,
         elementsSource: expect.any(Object),
-        isFetchWithChangesDetection: false,
       })
     })
 

--- a/packages/salesforce-adapter/test/adapter.ts
+++ b/packages/salesforce-adapter/test/adapter.ts
@@ -37,7 +37,6 @@ const mockAdapter = ({ adapterParams }: Opts = {}): Mocks => {
     metadataTypesOfInstancesFetchedInFilters: ['Queue'],
     config: {},
     elementsSource: buildElementsSourceFromElements([]),
-    isFetchWithChangesDetection: false,
     ...adapterParams || {},
   })
   return {


### PR DESCRIPTION
Moved the creation of the fetchProfile from the SalesforceAdapter constructor  to the operations themselves.

---

This is a necessary refactor, since in https://github.com/salto-io/salto/pull/5030 the **fetchProfile** receives the promise of **relatedPropsByMetadataType** that should only start executing in fetch, and not in the creation of the adapter. (As we invoke client calls there).
We should never leave hanging promises that won't be necessarily awaited in our code.

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
