### PR TITLE
SALTO-4807 - Zendesk Adapter - catch urls with both and without initial '/'

### DIFF
--- a/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
@@ -327,7 +327,7 @@ const formulaToTemplate = ({
       if (extractReferencesFromFreeText) {
         // Check if the expression is a link to a zendesk page without a subdomain
         // href="/hc/en-us/../articles/123123
-        const isZendeskLink = new RegExp(`"/hc/\\S*${_.escapeRegExp(expression)}`).test(formula)
+        const isZendeskLink = new RegExp(`"/?hc/\\S*${_.escapeRegExp(expression)}`).test(formula)
         if (isZendeskLink) {
           return transformReferenceUrls({
             urlPart: expression,


### PR DESCRIPTION
A link can now start with a '/' and still be converted

---

None

---
_Release Notes_: 
None

---
_User Notifications_: 
None