### PR TITLE
SALTO-4961 Zendesk - return early in irrelevant filters, avoid too many concurrent calls to element source

### DIFF
--- a/packages/zendesk-adapter/src/filters/article/article.ts
+++ b/packages/zendesk-adapter/src/filters/article/article.ts
@@ -482,7 +482,7 @@ const filterCreator: FilterCreator = ({ config, client, elementsSource, brandIdT
       }
 
       const everyoneUserSegmentElemID = new ElemID(ZENDESK, USER_SEGMENT_TYPE_NAME, 'instance', EVERYONE_USER_TYPE)
-      const everyoneUserSegmentInstance = await elementsSource.get(everyoneUserSegmentElemID) // ?
+      const everyoneUserSegmentInstance = await elementsSource.get(everyoneUserSegmentElemID)
       relevantChanges
         .map(getChangeData)
         .forEach(articleInstance => {

--- a/packages/zendesk-adapter/src/filters/article/article_body.ts
+++ b/packages/zendesk-adapter/src/filters/article/article_body.ts
@@ -35,7 +35,7 @@ import {
   ARTICLE_TRANSLATION_TYPE_NAME,
   BRAND_TYPE_NAME,
 } from '../../constants'
-import { FETCH_CONFIG, ZendeskConfig } from '../../config'
+import { FETCH_CONFIG, isGuideEnabled, ZendeskConfig } from '../../config'
 import { ELEMENTS_REGEXES, getBrandsForGuide, transformReferenceUrls } from '../utils'
 
 const log = logger(module)
@@ -213,7 +213,12 @@ const filterCreator: FilterCreator = ({ config }) => {
   const deployTemplateMapping: Record<string, TemplateExpression> = {}
   return {
     name: 'articleBodyFilter',
-    onFetch: async (elements: Element[]) => articleBodyOnFetch(elements, config),
+    onFetch: async (elements: Element[]) => {
+      if (!isGuideEnabled(config[FETCH_CONFIG])) {
+        return undefined
+      }
+      return articleBodyOnFetch(elements, config)
+    },
     preDeploy: async (changes: Change<InstanceElement>[]) => {
       await awu(changes)
         .filter(isAdditionOrModificationChange)

--- a/packages/zendesk-adapter/src/filters/custom_field_options/creator.ts
+++ b/packages/zendesk-adapter/src/filters/custom_field_options/creator.ts
@@ -140,6 +140,15 @@ export const createCustomFieldOptionsFilterCreator = (
       change => [parentTypeName, childTypeName]
         .includes(getChangeData(change).elemID.typeName),
     )
+    if (relevantChanges.length === 0) {
+      return {
+        leftoverChanges: changes,
+        deployResult: {
+          errors: [],
+          appliedChanges: [],
+        },
+      }
+    }
     const [parentChanges, childrenChanges] = _.partition(
       relevantChanges,
       change => getChangeData(change).elemID.typeName === parentTypeName,

--- a/packages/zendesk-adapter/src/filters/custom_statuses.ts
+++ b/packages/zendesk-adapter/src/filters/custom_statuses.ts
@@ -106,7 +106,7 @@ const filterCreator: FilterCreator = ({ client, config }) => ({
       changes,
       change => CUSTOM_STATUS_TYPE_NAME === getChangeData(change).elemID.typeName,
     )
-    const CustomStatusesDeployResult = await deployChanges(
+    const customStatusesDeployResult = await deployChanges(
       customStatusChanges,
       async change => {
         await deployChange(change, client, config.apiDefinitions)
@@ -118,7 +118,7 @@ const filterCreator: FilterCreator = ({ client, config }) => ({
     )
     if (_.isEmpty(defaultCustomStatusChanges)) {
       // since the custom statuses and the default are in different change groups
-      return { deployResult: CustomStatusesDeployResult, leftoverChanges: firstLeftoverChanges }
+      return { deployResult: customStatusesDeployResult, leftoverChanges: firstLeftoverChanges }
     }
     const defaultCustomStatusChange = defaultCustomStatusChanges
       .map(getChangeData)
@@ -141,8 +141,8 @@ const filterCreator: FilterCreator = ({ client, config }) => ({
     }
     const appliedChanges = _.isEmpty(error) ? defaultCustomStatusChanges : []
     const deployResult: DeployResult = {
-      appliedChanges: CustomStatusesDeployResult.appliedChanges.concat(appliedChanges),
-      errors: CustomStatusesDeployResult.errors.concat(error),
+      appliedChanges: customStatusesDeployResult.appliedChanges.concat(appliedChanges),
+      errors: customStatusesDeployResult.errors.concat(error),
     }
     return { deployResult, leftoverChanges }
   },

--- a/packages/zendesk-adapter/src/filters/macro_attachments.ts
+++ b/packages/zendesk-adapter/src/filters/macro_attachments.ts
@@ -263,6 +263,15 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
       change => [MACRO_ATTACHMENT_TYPE_NAME, MACRO_TYPE_NAME]
         .includes(getChangeData(change).elemID.typeName),
     )
+    if (relevantChanges.length === 0) {
+      return {
+        leftoverChanges: changes,
+        deployResult: {
+          errors: [],
+          appliedChanges: [],
+        },
+      }
+    }
     const [childrenChanges, parentChanges] = _.partition(
       relevantChanges,
       change => getChangeData(change).elemID.typeName === MACRO_ATTACHMENT_TYPE_NAME

--- a/packages/zendesk-adapter/src/filters/ticket_form.ts
+++ b/packages/zendesk-adapter/src/filters/ticket_form.ts
@@ -151,14 +151,23 @@ const getChangeWithoutRemovedFields = (change: ModificationChange<InstanceElemen
 const filterCreator: FilterCreator = ({ config, client, elementsSource }) => ({
   name: 'ticketFormDeploy',
   deploy: async (changes: Change<InstanceElement>[]) => {
-    const [TicketFormChanges, leftoverChanges] = _.partition(
+    const [ticketFormChanges, leftoverChanges] = _.partition(
       changes,
       change => TICKET_FORM_TYPE_NAME === getChangeData(change).elemID.typeName,
     )
+    if (ticketFormChanges.length === 0) {
+      return {
+        leftoverChanges: changes,
+        deployResult: {
+          errors: [],
+          appliedChanges: [],
+        },
+      }
+    }
     const hasCustomStatusesEnabled = await isCustomStatusesEnabled(elementsSource)
 
     const [invalidModificationAndAdditionChanges, otherTicketFormChanges] = _.partition(
-      TicketFormChanges,
+      ticketFormChanges,
       change => invalidTicketFormChange(change, hasCustomStatusesEnabled),
     )
 
@@ -188,7 +197,7 @@ const filterCreator: FilterCreator = ({ config, client, elementsSource }) => ({
       .map(change => getChangeData(change).elemID.getFullName()))
 
     const deployResult: DeployResult = {
-      appliedChanges: TicketFormChanges
+      appliedChanges: ticketFormChanges
         .filter(change => deployedChangesElemId.has(getChangeData(change).elemID.getFullName())),
       errors: tempDeployResult.errors,
     }


### PR DESCRIPTION
Adding early returns in a few filters to avoid doing unneeded work.

The motivation for this was an OOM we saw for macro deployments, that seems to at least be partially caused by attempting to initialize the element source many times in parallel, likely for the `ticketFormDeploy`'s `isCustomStatusesEnabled` call - but using this to remove some other cases as well (focusing for now on the ones that do not require a bigger refactor).

(besides this, we should also investigate the issue directly in the element source, but starting with a mitigation)

---
_Release Notes_: 
_Zendesk adapter_:
* Fix potential crash on large deployments due to memory consumption

---
_User Notifications_: 
None