### PR TITLE
SALTO-4964: Fail to deploy global automation in Jira DC

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/datacenter/automation.ts
+++ b/packages/jira-adapter/e2e_test/instances/datacenter/automation.ts
@@ -93,8 +93,6 @@ export const createAutomationValues = (name: string): Values => ({
       newComponent: false,
     },
   ],
-  projects: [
-  ],
   labels: [
   ],
   tags: [

--- a/packages/jira-adapter/src/filters/automation/automation_structure.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_structure.ts
@@ -335,6 +335,12 @@ const convertRuleScopeToProjects = (instance: InstanceElement): void => {
   instance.value.projects = convertRuleScopeValueToProjects(instance.value)
 }
 
+const handleDCProjects = (instance: InstanceElement): void => {
+  if (instance.value.projects.length === 0) {
+    instance.value.projects = undefined
+  }
+}
+
 const filter: FilterCreator = ({ client }) => {
   let originalAutomationChanges: Record<string, Change<InstanceElement>>
   return {
@@ -349,7 +355,9 @@ const filter: FilterCreator = ({ client }) => {
             await instance.getType(),
             true,
           )
-          if (!client.isDataCenter) {
+          if (client.isDataCenter) {
+            handleDCProjects(instance)
+          } else {
             convertRuleScopeToProjects(instance)
           }
           await removeRedundantKeys(instance)

--- a/packages/jira-adapter/src/filters/automation/automation_structure.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_structure.ts
@@ -335,7 +335,7 @@ const convertRuleScopeToProjects = (instance: InstanceElement): void => {
   instance.value.projects = convertRuleScopeValueToProjects(instance.value)
 }
 
-const handleDCProjects = (instance: InstanceElement): void => {
+const removeProjectsForGlobalDCAutomation = (instance: InstanceElement): void => {
   if (instance.value.projects.length === 0) {
     instance.value.projects = undefined
   }
@@ -356,7 +356,7 @@ const filter: FilterCreator = ({ client }) => {
             true,
           )
           if (client.isDataCenter) {
-            handleDCProjects(instance)
+            removeProjectsForGlobalDCAutomation(instance)
           } else {
             convertRuleScopeToProjects(instance)
           }

--- a/packages/jira-adapter/test/filters/automation/automation_structure.test.ts
+++ b/packages/jira-adapter/test/filters/automation/automation_structure.test.ts
@@ -307,36 +307,48 @@ describe('automationStructureFilter', () => {
           }
         )
       })
-      it('should covert rule scope to projects', async () => {
-        await filter.onFetch([ruleScopeInstance])
-        expect(ruleScopeInstance.value.projects).toEqual([
-          {
-            projectId: '10024',
-          },
-          {
-            projectTypeKey: 'software',
-          },
-          {
-            projectId: '10034',
-          },
-          {
-            projectTypeKey: 'business',
-          },
-        ])
+      describe('when using Jira Cloud', () => {
+        it('should covert rule scope to projects', async () => {
+          await filter.onFetch([ruleScopeInstance])
+          expect(ruleScopeInstance.value.projects).toEqual([
+            {
+              projectId: '10024',
+            },
+            {
+              projectTypeKey: 'software',
+            },
+            {
+              projectId: '10034',
+            },
+            {
+              projectTypeKey: 'business',
+            },
+          ])
+        })
+        it('should covert global rule scope', async () => {
+          await filter.onFetch([globalScopeInstance])
+          expect(globalScopeInstance.value.projects).toBeUndefined()
+        })
+        it('should not covert if unknown project type', async () => {
+          ruleScopeInstance.value.ruleScope.resources[1] = 'ari:cloud:jira-none::site/128baddc-c238-4857-b249-cfc84bd10c4b'
+          await filter.onFetch([ruleScopeInstance])
+          expect(ruleScopeInstance.value.projects.length).toEqual(3)
+        })
+        it('should not covert if unknown resource', async () => {
+          ruleScopeInstance.value.ruleScope.resources = ['ari:cloud:not-a--known-pattern']
+          await filter.onFetch([ruleScopeInstance])
+          expect(ruleScopeInstance.value.projects).toEqual([])
+        })
       })
-      it('should covert global rule scope', async () => {
-        await filter.onFetch([globalScopeInstance])
-        expect(globalScopeInstance.value.projects).toBeUndefined()
-      })
-      it('should not covert if unknown project type', async () => {
-        ruleScopeInstance.value.ruleScope.resources[1] = 'ari:cloud:jira-none::site/128baddc-c238-4857-b249-cfc84bd10c4b'
-        await filter.onFetch([ruleScopeInstance])
-        expect(ruleScopeInstance.value.projects.length).toEqual(3)
-      })
-      it('should not covert if unknown resource', async () => {
-        ruleScopeInstance.value.ruleScope.resources = ['ari:cloud:not-a--known-pattern']
-        await filter.onFetch([ruleScopeInstance])
-        expect(ruleScopeInstance.value.projects).toEqual([])
+      describe('when using Jira DC', () => {
+        beforeEach(async () => {
+          filter = automationStructureFilter(getFilterParams(undefined, true)) as typeof filter
+          globalScopeInstance.value.resources = undefined
+          await filter.onFetch([globalScopeInstance])
+        })
+        it('should remove project list for global rules ', () => {
+          expect(globalScopeInstance.value.projects).toBeUndefined()
+        })
       })
     })
   })


### PR DESCRIPTION
_Fail to deploy global automation in Jira DC_

---

_Additional context for reviewer_
* it was caused by this [change](https://github.com/salto-io/salto/pull/4885) that affected only cloud users.
* I added a simple change that removes the project list when it's empty to align with the cloud behavior.

---
_Release Notes_: 
Jira Adapter: 
* fix a bug in deploying global Automation using Jira DC


---
_User Notifications_: 
_None_
