### PR TITLE
SALTO-4968: Cached listMetadataObjects results in Salesforce Client

### DIFF
--- a/packages/salesforce-adapter/test/client.test.ts
+++ b/packages/salesforce-adapter/test/client.test.ts
@@ -1152,4 +1152,24 @@ describe('salesforce client', () => {
       expect(nonSandBoxClient.isSandbox()).toBeFalsy()
     })
   })
+
+  describe('filePropertiesByType', () => {
+    let expectedProperties: FileProperties
+    let testClient: SalesforceClient
+    let testConnection: MockInterface<Connection>
+    beforeEach(() => {
+      const mockClientAndConnection = mockClient()
+      testClient = mockClientAndConnection.client
+      testConnection = mockClientAndConnection.connection
+      expectedProperties = mockFileProperties({ type: 'CustomObject', fullName: 'A__c' })
+      testConnection.metadata.list.mockResolvedValue([expectedProperties])
+    })
+    it('should have correct value and not invoke listMetadataObjects twice on the same type', async () => {
+      expect(await testClient.listMetadataObjects({ type: 'CustomObject' }))
+        .toMatchObject({ result: [expectedProperties] })
+      expect(testClient.filePropsByType).toEqual({ CustomObject: [expectedProperties] })
+      await testClient.listMetadataObjects({ type: 'CustomObject' })
+      expect(testConnection.metadata.list).toHaveBeenCalledOnce()
+    })
+  })
 })


### PR DESCRIPTION
Added caching mechanism on **listMetadataObjects** of the Salesforce client
---

Motives for this PR:
- We have some flows where we list the same MetadataTypes twice. This will make the fetch faster.
- A necessary step for quick fetch on Profile Instances.

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
