### PR TITLE
Revert "added missing annotations to workflow (#4968)"

### DIFF
--- a/packages/jira-adapter/src/filters/workflow/conditions_types.ts
+++ b/packages/jira-adapter/src/filters/workflow/conditions_types.ts
@@ -16,12 +16,11 @@
 import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, ListType, ObjectType } from '@salto-io/adapter-api'
 import { elements } from '@salto-io/adapter-components'
 import { CONDITION_CONFIGURATION, JIRA } from '../../constants'
-import { addAnnotationRecursively } from '../../utils'
 
-export const createConditionConfigurationTypes = async (): Promise<{
+export const createConditionConfigurationTypes = (): {
   type: ObjectType
   subTypes: ObjectType[]
-}> => {
+} => {
   const conditionProjectRoleType = new ObjectType({
     elemID: new ElemID(JIRA, 'ConditionProjectRole'),
     fields: {
@@ -156,9 +155,6 @@ export const createConditionConfigurationTypes = async (): Promise<{
     },
     path: [JIRA, elements.TYPES_PATH, 'ConditionConfiguration'],
   })
-
-  await addAnnotationRecursively(conditionConfigurationType, CORE_ANNOTATIONS.CREATABLE)
-  await addAnnotationRecursively(conditionConfigurationType, CORE_ANNOTATIONS.UPDATABLE)
 
   return {
     type: conditionConfigurationType,

--- a/packages/jira-adapter/src/filters/workflow/workflow_structure_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_structure_filter.ts
@@ -195,7 +195,7 @@ const filter: FilterCreator = ({ config }) => ({
 
     const workflowRulesType = findObject(elements, WORKFLOW_RULES_TYPE_NAME)
 
-    const conditionConfigurationTypes = await createConditionConfigurationTypes()
+    const conditionConfigurationTypes = createConditionConfigurationTypes()
 
     if (workflowRulesType !== undefined) {
       workflowRulesType.fields.conditions = new Field(workflowRulesType, 'conditions', await workflowRulesType.fields.conditionsTree.getType())
@@ -212,15 +212,7 @@ const filter: FilterCreator = ({ config }) => ({
     const worfkflowConditionType = findObject(elements, 'WorkflowCondition')
 
     if (worfkflowConditionType !== undefined) {
-      worfkflowConditionType.fields.configuration = new Field(
-        worfkflowConditionType,
-        'configuration',
-        conditionConfigurationTypes.type,
-        {
-          [CORE_ANNOTATIONS.CREATABLE]: true,
-          [CORE_ANNOTATIONS.UPDATABLE]: true,
-        }
-      )
+      worfkflowConditionType.fields.configuration = new Field(worfkflowConditionType, 'configuration', conditionConfigurationTypes.type)
     }
 
     elements.push(...postFunctionTypes)

--- a/packages/jira-adapter/test/filters/workflow/workflow_structure_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_structure_filter.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, InstanceElement, MapType, ObjectType } from '@salto-io/adapter-api'
+import { BuiltinTypes, ElemID, Field, InstanceElement, MapType, ObjectType } from '@salto-io/adapter-api'
 import { naclCase } from '@salto-io/adapter-utils'
 import JiraClient from '../../../src/client/client'
 import { JIRA, WORKFLOW_RULES_TYPE_NAME, WORKFLOW_TRANSITION_TYPE_NAME, WORKFLOW_TYPE_NAME } from '../../../src/constants'
@@ -148,10 +148,6 @@ describe('workflowStructureFilter', () => {
       await filter.onFetch?.(elements)
       expect(elements.length).toBeGreaterThan(1)
       expect((await workflowConditionType.fields.configuration.getType()).elemID.getFullName()).toBe('jira.ConditionConfiguration')
-      expect(workflowConditionType.fields.configuration.annotations).toEqual({
-        [CORE_ANNOTATIONS.CREATABLE]: true,
-        [CORE_ANNOTATIONS.UPDATABLE]: true,
-      })
     })
     it('should convert transitions type to a map', async () => {
       await filter.onFetch?.([transitionType, workflowType])


### PR DESCRIPTION
This reverts commit 6725c81861e618b04f7179eb537e0f627b866bb0.

Not all cases are supported by the old workflow APIs - reverting for now until this is tested more thoroughly

---

_Additional context for reviewer_

---
_Release Notes_: 

_Jira adapter_:
* Temporarily restricting deployment of some parts of workflows that are not fully supported using the current APIs

---
_User Notifications_: 
None