### PR TITLE
SALTO-4780 - Salesforce: convert profile and permission sets to custom references

### DIFF
--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -37,6 +37,7 @@ import { ConfigChange } from './config_change'
 import { configCreator } from './config_creator'
 import { loadElementsFromFolder } from './sfdx_parser/sfdx_parser'
 import { getAdditionalReferences } from './additional_references'
+import { getCustomReferences } from './custom_references'
 
 type ValidatorsActivationConfig = deployment.changeValidators.ValidatorsActivationConfig
 
@@ -248,4 +249,5 @@ export const adapter: Adapter = {
   configCreator,
   loadElementsFromFolder,
   getAdditionalReferences,
+  getCustomReferences,
 }

--- a/packages/salesforce-adapter/src/custom_references.ts
+++ b/packages/salesforce-adapter/src/custom_references.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2023 Salto Labs Ltd.
+*                      Copyright 2024 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/custom_references.ts
+++ b/packages/salesforce-adapter/src/custom_references.ts
@@ -1,0 +1,214 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { collections } from '@salto-io/lowerdash'
+import { logger } from '@salto-io/logging'
+import { Element, ElemID, GetCustomReferencesFunc, InstanceElement, ReferenceInfo, Values } from '@salto-io/adapter-api'
+import { isInstanceOfTypeSync } from './filters/utils'
+import {
+  APEX_CLASS_METADATA_TYPE, APEX_PAGE_METADATA_TYPE, API_NAME_SEPARATOR, CUSTOM_APPLICATION_METADATA_TYPE, SALESFORCE,
+  FIELD_PERMISSIONS, FLOW_METADATA_TYPE, LAYOUT_TYPE_ID_METADATA_TYPE, PROFILE_METADATA_TYPE, RECORD_TYPE_METADATA_TYPE,
+  PERMISSION_SET_METADATA_TYPE,
+} from './constants'
+import { Types } from './transformers/transformer'
+
+const { makeArray } = collections.array
+const log = logger(module)
+
+const APP_VISIBILITY_SECTION = 'applicationVisibilities'
+const APEX_CLASS_SECTION = 'classAccesses'
+const FLOW_SECTION = 'flowAccesses'
+const LAYOUTS_SECTION = 'layoutAssignments'
+const OBJECT_SECTION = 'objectPermissions'
+const APEX_PAGE_SECTION = 'pageAccesses'
+const RECORD_TYPE_SECTION = 'recordTypeVisibilities'
+
+const FIELD_NO_ACCESS = 'NoAccess'
+
+const fullNameToElemIdName = (fullName: string): string => (
+  Types.getElemId(
+    fullName.replace(API_NAME_SEPARATOR, '_'),
+    true,
+  ).name
+)
+
+type ReferenceInSection = {
+  sourceField?: string
+  target: ElemID
+}
+
+type RefTargetsGetter = (sectionEntry: Values, sectionEntryKey: string) => ReferenceInSection[]
+
+const referencesFromSection = (
+  profile: InstanceElement,
+  sectionName: string,
+  filter: (sectionEntry: Values) => boolean,
+  targetsGetter: RefTargetsGetter,
+): ReferenceInfo[] => {
+  if (!profile.value[sectionName]) {
+    return []
+  }
+  return Object.entries(profile.value[sectionName] as Values)
+    .filter(([, sectionEntry]) => filter(sectionEntry))
+    .flatMap(([sectionEntryKey, sectionEntry]): ReferenceInfo[] => {
+      const refTargets = targetsGetter(sectionEntry, sectionEntryKey)
+      return refTargets.map(({ target, sourceField }) => ({
+        source: profile.elemID.createNestedID(sectionName, sectionEntryKey, ...makeArray(sourceField)),
+        target,
+        type: 'weak',
+      }))
+    })
+}
+
+const isEnabled = (sectionEntry: Values): boolean => (
+  sectionEntry.enabled
+)
+
+const isAnyAccessEnabledForObject = (objectAccessSectionEntry: Values): boolean => (
+  objectAccessSectionEntry.allowCreate
+  || objectAccessSectionEntry.allowDelete
+  || objectAccessSectionEntry.allowEdit
+  || objectAccessSectionEntry.allowRead
+  || objectAccessSectionEntry.modifyAllRecords
+  || objectAccessSectionEntry.viewAllRecords
+)
+
+const isAnyAccessEnabledForField = (fieldPermissionsSectionEntry: Values): boolean => (
+  Object.values(fieldPermissionsSectionEntry).some(val => val !== FIELD_NO_ACCESS)
+)
+
+const referenceToInstance = (fieldName: string, targetType: string): RefTargetsGetter => (
+  sectionEntry => {
+    const elemIdName = fullNameToElemIdName(sectionEntry[fieldName])
+    return [{
+      target: Types.getElemId(targetType, false).createNestedID('instance', elemIdName),
+    }]
+  }
+)
+
+const referenceToType = (fieldName: string): RefTargetsGetter => (
+  sectionEntry => [{
+    target: Types.getElemId(sectionEntry[fieldName], true),
+  }]
+)
+
+const referencesToFields: RefTargetsGetter = (sectionEntry, sectionEntryKey) => {
+  const typeElemId = Types.getElemId(sectionEntryKey, true)
+  return Object.entries(sectionEntry)
+    .filter(([, fieldAccess]) => fieldAccess !== FIELD_NO_ACCESS)
+    .map(([fieldName]) => ({
+      target: typeElemId.createNestedID('field', fullNameToElemIdName(fieldName)),
+      sourceField: fieldName,
+    }))
+}
+
+const layoutReferences: RefTargetsGetter = sectionEntry => {
+  const layoutElemIdName = fullNameToElemIdName(sectionEntry[0].layout)
+  const layoutRef = {
+    target: new ElemID(SALESFORCE, LAYOUT_TYPE_ID_METADATA_TYPE, 'instance', layoutElemIdName),
+  }
+
+  const recordTypeRefs = sectionEntry
+    .filter((layoutAssignment: Values) => layoutAssignment.recordType !== undefined)
+    .map((layoutAssignment: Values) => ({
+      target: new ElemID(SALESFORCE, RECORD_TYPE_METADATA_TYPE, 'instance', fullNameToElemIdName(layoutAssignment.recordType)),
+    }))
+
+  return [
+    ...makeArray(layoutRef),
+    ...recordTypeRefs,
+  ]
+}
+
+const recordTypeReferences: RefTargetsGetter = sectionEntry => (
+  Object.entries(sectionEntry)
+    .filter(([, recordTypeVisibility]) => recordTypeVisibility.default || recordTypeVisibility.visible)
+    .map(([recordTypeVisibilityKey, recordTypeVisibility]) => ({
+      target: new ElemID(SALESFORCE, RECORD_TYPE_METADATA_TYPE, 'instance', fullNameToElemIdName(recordTypeVisibility.recordType)),
+      sourceField: recordTypeVisibilityKey,
+    }))
+)
+
+const referencesFromProfile = (profile: InstanceElement): ReferenceInfo[] => {
+  const appVisibilityRefs = referencesFromSection(
+    profile,
+    APP_VISIBILITY_SECTION,
+    appVisibilityEntry => appVisibilityEntry.default || appVisibilityEntry.visible,
+    referenceToInstance('application', CUSTOM_APPLICATION_METADATA_TYPE),
+  )
+  const apexClassRefs = referencesFromSection(
+    profile,
+    APEX_CLASS_SECTION,
+    isEnabled,
+    referenceToInstance('apexClass', APEX_CLASS_METADATA_TYPE),
+  )
+  const flowRefs = referencesFromSection(
+    profile,
+    FLOW_SECTION,
+    isEnabled,
+    referenceToInstance('flow', FLOW_METADATA_TYPE),
+  )
+
+  const apexPageRefs = referencesFromSection(
+    profile,
+    APEX_PAGE_SECTION,
+    isEnabled,
+    referenceToInstance('apexPage', APEX_PAGE_METADATA_TYPE),
+  )
+
+  const objectRefs = referencesFromSection(
+    profile,
+    OBJECT_SECTION,
+    isAnyAccessEnabledForObject,
+    referenceToType('object'),
+  )
+
+  const fieldPermissionsRefs = referencesFromSection(
+    profile,
+    FIELD_PERMISSIONS,
+    isAnyAccessEnabledForField,
+    referencesToFields,
+  )
+
+  const layoutAssignmentRefs = referencesFromSection(
+    profile,
+    LAYOUTS_SECTION,
+    () => true,
+    layoutReferences,
+  )
+
+  const recordTypeRefs = referencesFromSection(
+    profile,
+    RECORD_TYPE_SECTION,
+    () => true,
+    recordTypeReferences,
+  )
+
+  return appVisibilityRefs
+    .concat(apexClassRefs)
+    .concat(flowRefs)
+    .concat(apexPageRefs)
+    .concat(objectRefs)
+    .concat(fieldPermissionsRefs)
+    .concat(layoutAssignmentRefs)
+    .concat(recordTypeRefs)
+}
+
+export const getCustomReferences: GetCustomReferencesFunc = async (elements: Element[]): Promise<ReferenceInfo[]> => (
+  log.time(() => (elements
+    .filter(isInstanceOfTypeSync(PROFILE_METADATA_TYPE, PERMISSION_SET_METADATA_TYPE))
+    .flatMap(referencesFromProfile)),
+  'Generating references from profiles')
+)

--- a/packages/salesforce-adapter/src/custom_references.ts
+++ b/packages/salesforce-adapter/src/custom_references.ts
@@ -18,6 +18,7 @@ import { logger } from '@salto-io/logging'
 import {
   Element, ElemID, GetCustomReferencesFunc, InstanceElement, isInstanceElement, ReferenceInfo, Values,
 } from '@salto-io/adapter-api'
+import { combineCustomReferenceGetters } from '@salto-io/adapter-components'
 import {
   APEX_CLASS_METADATA_TYPE, APEX_PAGE_METADATA_TYPE, API_NAME_SEPARATOR, CUSTOM_APPLICATION_METADATA_TYPE, SALESFORCE,
   FIELD_PERMISSIONS, FLOW_METADATA_TYPE, LAYOUT_TYPE_ID_METADATA_TYPE, PROFILE_METADATA_TYPE, RECORD_TYPE_METADATA_TYPE,
@@ -207,7 +208,7 @@ const referencesFromProfile = (profile: InstanceElement): ReferenceInfo[] => {
     .concat(recordTypeRefs)
 }
 
-export const getCustomReferences: GetCustomReferencesFunc = async (elements: Element[]): Promise<ReferenceInfo[]> => {
+const getProfilesCustomReferences = async (elements: Element[]): Promise<ReferenceInfo[]> => {
   // At this point the TypeRefs of instance elements are not resolved yet, so isInstanceOfTypeSync() won't work - we
   // have to figure out the type name the hard way.
   const profilesAndPermissionSets = elements
@@ -218,6 +219,11 @@ export const getCustomReferences: GetCustomReferencesFunc = async (elements: Ele
     `Generating references from ${profilesAndPermissionSets.length} profiles/permission sets`
   )
   log.debug('generated %d references', refs.length)
-
   return refs
 }
+
+const customReferencesHandlers: Record<string, GetCustomReferencesFunc> = {
+  profiles: getProfilesCustomReferences,
+}
+
+export const getCustomReferences: GetCustomReferencesFunc = combineCustomReferenceGetters(customReferencesHandlers)

--- a/packages/salesforce-adapter/src/custom_references.ts
+++ b/packages/salesforce-adapter/src/custom_references.ts
@@ -25,6 +25,7 @@ import {
   PERMISSION_SET_METADATA_TYPE,
 } from './constants'
 import { Types } from './transformers/transformer'
+import { CUSTOM_REFS_CONFIG, DATA_CONFIGURATION, FETCH_CONFIG } from './types'
 
 const { makeArray } = collections.array
 const log = logger(module)
@@ -226,4 +227,11 @@ const customReferencesHandlers: Record<string, GetCustomReferencesFunc> = {
   profiles: getProfilesCustomReferences,
 }
 
-export const getCustomReferences: GetCustomReferencesFunc = combineCustomReferenceGetters(customReferencesHandlers)
+const getCustomReferencesConfig = (adapterConfig: InstanceElement): Record<string, boolean> => (
+  adapterConfig.value[FETCH_CONFIG]?.[DATA_CONFIGURATION]?.[CUSTOM_REFS_CONFIG] ?? {}
+)
+
+export const getCustomReferences: GetCustomReferencesFunc = combineCustomReferenceGetters(
+  customReferencesHandlers,
+  getCustomReferencesConfig,
+)

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -41,6 +41,7 @@ export const CUSTOM_OBJECTS_DEPLOY_RETRY_OPTIONS = 'customObjectsDeployRetryOpti
 export const FETCH_CONFIG = 'fetch'
 export const DEPLOY_CONFIG = 'deploy'
 export const METADATA_CONFIG = 'metadata'
+export const CUSTOM_REFS_CONFIG = 'customReferences'
 export const METADATA_INCLUDE_LIST = 'include'
 export const METADATA_EXCLUDE_LIST = 'exclude'
 const METADATA_TYPE = 'metadataType'
@@ -160,6 +161,11 @@ export type BrokenOutgoingReferencesSettings = {
   perTargetTypeOverrides?: Record<string, OutgoingReferenceBehavior>
 }
 
+const customReferencesTypeNames = ['profiles'] as const
+type customReferencesTypes = typeof customReferencesTypeNames[number]
+
+export type CustomReferencesSettings = Partial<Record<customReferencesTypes, boolean>>
+
 const objectIdSettings = new ObjectType({
   elemID: new ElemID(constants.SALESFORCE, 'objectIdSettings'),
   fields: {
@@ -268,6 +274,11 @@ const brokenOutgoingReferencesSettingsType = new ObjectType({
   },
 })
 
+const customReferencesSettingsType = new ObjectType({
+  elemID: new ElemID(constants.SALESFORCE, 'saltoCustomReferencesSettings'),
+  fields: Object.fromEntries(customReferencesTypeNames.map(name => [name, { refType: BuiltinTypes.BOOLEAN }])),
+})
+
 const warningSettingsType = new ObjectType({
   elemID: new ElemID(constants.SALESFORCE, 'saltoWarningSettings'),
   fields: {
@@ -291,6 +302,7 @@ export type DataManagementConfig = {
   saltoManagementFieldSettings?: SaltoManagementFieldSettings
   brokenOutgoingReferencesSettings?: BrokenOutgoingReferencesSettings
   omittedFields?: string[]
+  [CUSTOM_REFS_CONFIG]?: CustomReferencesSettings
 }
 
 export type FetchParameters = {
@@ -548,6 +560,9 @@ const dataManagementType = new ObjectType({
     },
     omittedFields: {
       refType: new ListType(BuiltinTypes.STRING),
+    },
+    [CUSTOM_REFS_CONFIG]: {
+      refType: customReferencesSettingsType,
     },
   } as Record<keyof DataManagementConfig, FieldDefinition>,
   annotations: {

--- a/packages/salesforce-adapter/test/custom_references.test.ts
+++ b/packages/salesforce-adapter/test/custom_references.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2023 Salto Labs Ltd.
+*                      Copyright 2024 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/custom_references.test.ts
+++ b/packages/salesforce-adapter/test/custom_references.test.ts
@@ -38,10 +38,10 @@ describe('getCustomReferences', () => {
             },
           },
         })
-        refs = await getCustomReferences([
-          permissionSetInstance,
-          profileInstance,
-        ])
+        refs = await getCustomReferences(
+          [permissionSetInstance, profileInstance],
+          undefined,
+        )
       })
       it('should not create references', async () => {
         expect(refs).toBeEmpty()
@@ -57,10 +57,7 @@ describe('getCustomReferences', () => {
             },
           },
         })
-        refs = await getCustomReferences([
-          permissionSetInstance,
-          profileInstance,
-        ])
+        refs = await getCustomReferences([permissionSetInstance, profileInstance], undefined)
       })
       it('should create references', async () => {
         const expectedSource = ['fieldPermissions', 'Account', 'testField__c']
@@ -91,7 +88,7 @@ describe('getCustomReferences', () => {
           },
         })
 
-        refs = await getCustomReferences([profileInstance, permissionSetInstance])
+        refs = await getCustomReferences([profileInstance, permissionSetInstance], undefined)
       })
 
       it('should not create a reference', () => {
@@ -111,7 +108,7 @@ describe('getCustomReferences', () => {
           },
         })
 
-        refs = await getCustomReferences([profileInstance, permissionSetInstance])
+        refs = await getCustomReferences([profileInstance, permissionSetInstance], undefined)
       })
 
       it('should create a reference', () => {
@@ -142,7 +139,7 @@ describe('getCustomReferences', () => {
           },
         })
 
-        refs = await getCustomReferences([profileInstance, permissionSetInstance])
+        refs = await getCustomReferences([profileInstance, permissionSetInstance], undefined)
       })
 
       it('should create a reference', () => {
@@ -178,7 +175,7 @@ describe('getCustomReferences', () => {
             },
           },
         })
-        refs = await getCustomReferences([profileInstance, permissionSetInstance])
+        refs = await getCustomReferences([profileInstance, permissionSetInstance], undefined)
       })
 
       it('should not create a reference', () => {
@@ -196,7 +193,7 @@ describe('getCustomReferences', () => {
             },
           },
         })
-        refs = await getCustomReferences([profileInstance, permissionSetInstance])
+        refs = await getCustomReferences([profileInstance, permissionSetInstance], undefined)
       })
 
       it('should create a reference', () => {
@@ -232,7 +229,7 @@ describe('getCustomReferences', () => {
             },
           },
         })
-        refs = await getCustomReferences([profileInstance, permissionSetInstance])
+        refs = await getCustomReferences([profileInstance, permissionSetInstance], undefined)
       })
       it('should not create a reference', () => {
         expect(refs).toBeEmpty()
@@ -248,7 +245,7 @@ describe('getCustomReferences', () => {
             },
           },
         })
-        refs = await getCustomReferences([profileInstance, permissionSetInstance])
+        refs = await getCustomReferences([profileInstance, permissionSetInstance], undefined)
       })
       it('should create a reference', () => {
         expect(refs).toEqual([
@@ -284,7 +281,7 @@ describe('getCustomReferences', () => {
             ],
           },
         })
-        refs = await getCustomReferences([profileInstance, permissionSetInstance])
+        refs = await getCustomReferences([profileInstance, permissionSetInstance], undefined)
       })
       it('should create a reference', () => {
         expect(refs).toEqual([
@@ -329,7 +326,7 @@ describe('getCustomReferences', () => {
             ],
           },
         })
-        refs = await getCustomReferences([profileInstance, permissionSetInstance])
+        refs = await getCustomReferences([profileInstance, permissionSetInstance], undefined)
       })
       it('should create a reference', () => {
         expect(refs).toEqual([
@@ -386,7 +383,7 @@ describe('getCustomReferences', () => {
           },
         })
 
-        refs = await getCustomReferences([profileInstance, permissionSetInstance])
+        refs = await getCustomReferences([profileInstance, permissionSetInstance], undefined)
       })
 
       it('should not create references', () => {
@@ -410,7 +407,7 @@ describe('getCustomReferences', () => {
           },
         })
 
-        refs = await getCustomReferences([profileInstance, permissionSetInstance])
+        refs = await getCustomReferences([profileInstance, permissionSetInstance], undefined)
       })
 
       it('should create a reference', () => {
@@ -446,7 +443,7 @@ describe('getCustomReferences', () => {
             },
           },
         })
-        refs = await getCustomReferences([profileInstance, permissionSetInstance])
+        refs = await getCustomReferences([profileInstance, permissionSetInstance], undefined)
       })
 
       it('should not create a reference', () => {
@@ -464,7 +461,7 @@ describe('getCustomReferences', () => {
             },
           },
         })
-        refs = await getCustomReferences([profileInstance, permissionSetInstance])
+        refs = await getCustomReferences([profileInstance, permissionSetInstance], undefined)
       })
 
       it('should create a reference', () => {
@@ -502,7 +499,7 @@ describe('getCustomReferences', () => {
             },
           },
         })
-        refs = await getCustomReferences([profileInstance, permissionSetInstance])
+        refs = await getCustomReferences([profileInstance, permissionSetInstance], undefined)
       })
       it('should not create a reference', () => {
         expect(refs).toBeEmpty()
@@ -521,7 +518,7 @@ describe('getCustomReferences', () => {
             },
           },
         })
-        refs = await getCustomReferences([profileInstance, permissionSetInstance])
+        refs = await getCustomReferences([profileInstance, permissionSetInstance], undefined)
       })
       it('should create a reference', () => {
         expect(refs).toEqual([
@@ -551,7 +548,7 @@ describe('getCustomReferences', () => {
             },
           },
         })
-        refs = await getCustomReferences([profileInstance, permissionSetInstance])
+        refs = await getCustomReferences([profileInstance, permissionSetInstance], undefined)
       })
       it('should create a reference', () => {
         expect(refs).toEqual([

--- a/packages/salesforce-adapter/test/custom_references.test.ts
+++ b/packages/salesforce-adapter/test/custom_references.test.ts
@@ -61,7 +61,30 @@ describe('getCustomReferences', () => {
       expect(refs).toBeEmpty()
     })
   })
+  describe('when profile custom refs config is not set', () => {
+    beforeEach(async () => {
+      [permissionSetInstance, profileInstance] = createTestInstances({
+        fieldPermissions: {
+          Account: {
+            testField__c: 'ReadWrite',
+          },
+        },
+      })
 
+      const AdapterConfigType = new ObjectType({
+        elemID: new ElemID('adapter'),
+        isSettings: true,
+      })
+      const adapterConfig = new InstanceElement(ElemID.CONFIG_NAME, AdapterConfigType)
+      refs = await getCustomReferences(
+        [permissionSetInstance, profileInstance],
+        adapterConfig,
+      )
+    })
+    it('should not generate references', () => {
+      expect(refs).toBeEmpty()
+    })
+  })
   describe('fields', () => {
     describe('when the fields are inaccessible', () => {
       beforeEach(async () => {

--- a/packages/salesforce-adapter/test/custom_references.test.ts
+++ b/packages/salesforce-adapter/test/custom_references.test.ts
@@ -1,0 +1,572 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { InstanceElement, ReferenceInfo, Values } from '@salto-io/adapter-api'
+import { INSTANCE_FULL_NAME_FIELD } from '../src/constants'
+import { mockTypes } from './mock_elements'
+import { createCustomObjectType, createMetadataTypeElement } from './utils'
+import { getCustomReferences } from '../src/custom_references'
+
+describe('getCustomReferences', () => {
+  let refs: ReferenceInfo[]
+  let permissionSetInstance: InstanceElement
+  let profileInstance: InstanceElement
+  const createTestInstances = (fields: Values): [InstanceElement, InstanceElement] => [
+    new InstanceElement('test', mockTypes.Profile, fields),
+    new InstanceElement('test', mockTypes.PermissionSet, fields),
+  ]
+
+  describe('fields', () => {
+    describe('when the fields are inaccessible', () => {
+      beforeEach(async () => {
+        [permissionSetInstance, profileInstance] = createTestInstances({
+          fieldPermissions: {
+            Account: {
+              testField__c: 'NoAccess',
+            },
+          },
+        })
+        refs = await getCustomReferences([
+          permissionSetInstance,
+          profileInstance,
+        ])
+      })
+      it('should not create references', async () => {
+        expect(refs).toBeEmpty()
+      })
+    })
+
+    describe('when the fields are accessible', () => {
+      beforeEach(async () => {
+        [permissionSetInstance, profileInstance] = createTestInstances({
+          fieldPermissions: {
+            Account: {
+              testField__c: 'ReadWrite',
+            },
+          },
+        })
+        refs = await getCustomReferences([
+          permissionSetInstance,
+          profileInstance,
+        ])
+      })
+      it('should create references', async () => {
+        const expectedSource = ['fieldPermissions', 'Account', 'testField__c']
+        const expectedTarget = mockTypes.Account.elemID.createNestedID('field', 'testField__c')
+        expect(refs).toEqual([
+          { source: permissionSetInstance.elemID.createNestedID(...expectedSource), target: expectedTarget, type: 'weak' },
+          { source: profileInstance.elemID.createNestedID(...expectedSource), target: expectedTarget, type: 'weak' },
+        ])
+      })
+    })
+  })
+  describe('custom apps', () => {
+    const customApp = new InstanceElement(
+      'SomeApplication',
+      createMetadataTypeElement('CustomApplication', {}),
+      { [INSTANCE_FULL_NAME_FIELD]: 'SomeApplication' },
+    )
+
+    describe('if neither default or visible', () => {
+      beforeEach(async () => {
+        [profileInstance, permissionSetInstance] = createTestInstances({
+          applicationVisibilities: {
+            SomeApplication: {
+              application: 'SomeApplication',
+              default: false,
+              visible: false,
+            },
+          },
+        })
+
+        refs = await getCustomReferences([profileInstance, permissionSetInstance])
+      })
+
+      it('should not create a reference', () => {
+        expect(refs).toBeEmpty()
+      })
+    })
+
+    describe('if default', () => {
+      beforeEach(async () => {
+        [profileInstance, permissionSetInstance] = createTestInstances({
+          applicationVisibilities: {
+            SomeApplication: {
+              application: 'SomeApplication',
+              default: true,
+              visible: false,
+            },
+          },
+        })
+
+        refs = await getCustomReferences([profileInstance, permissionSetInstance])
+      })
+
+      it('should create a reference', () => {
+        expect(refs).toEqual([
+          {
+            source: profileInstance.elemID.createNestedID('applicationVisibilities', 'SomeApplication'),
+            target: customApp.elemID,
+            type: 'weak',
+          },
+          {
+            source: permissionSetInstance.elemID.createNestedID('applicationVisibilities', 'SomeApplication'),
+            target: customApp.elemID,
+            type: 'weak',
+          },
+        ])
+      })
+    })
+
+    describe('if visible', () => {
+      beforeEach(async () => {
+        [profileInstance, permissionSetInstance] = createTestInstances({
+          applicationVisibilities: {
+            SomeApplication: {
+              application: 'SomeApplication',
+              default: false,
+              visible: true,
+            },
+          },
+        })
+
+        refs = await getCustomReferences([profileInstance, permissionSetInstance])
+      })
+
+      it('should create a reference', () => {
+        expect(refs).toIncludeAllPartialMembers([
+          {
+            source: permissionSetInstance.elemID.createNestedID('applicationVisibilities', 'SomeApplication'),
+            target: customApp.elemID,
+            type: 'weak',
+          },
+          {
+            source: profileInstance.elemID.createNestedID('applicationVisibilities', 'SomeApplication'),
+            target: customApp.elemID,
+            type: 'weak',
+          },
+        ])
+      })
+    })
+  })
+  describe('apex classes', () => {
+    const apexClass = new InstanceElement(
+      'SomeApexClass',
+      mockTypes.ApexClass,
+      { [INSTANCE_FULL_NAME_FIELD]: 'SomeApexClass' },
+    )
+
+    describe('when disabled', () => {
+      beforeEach(async () => {
+        [profileInstance, permissionSetInstance] = createTestInstances({
+          classAccesses: {
+            SomeApexClass: {
+              apexClass: 'SomeApexClass',
+              enabled: false,
+            },
+          },
+        })
+        refs = await getCustomReferences([profileInstance, permissionSetInstance])
+      })
+
+      it('should not create a reference', () => {
+        expect(refs).toBeEmpty()
+      })
+    })
+
+    describe('when enabled', () => {
+      beforeEach(async () => {
+        [profileInstance, permissionSetInstance] = createTestInstances({
+          classAccesses: {
+            SomeApexClass: {
+              apexClass: 'SomeApexClass',
+              enabled: true,
+            },
+          },
+        })
+        refs = await getCustomReferences([profileInstance, permissionSetInstance])
+      })
+
+      it('should create a reference', () => {
+        expect(refs).toEqual([
+          {
+            source: profileInstance.elemID.createNestedID('classAccesses', 'SomeApexClass'),
+            target: apexClass.elemID,
+            type: 'weak',
+          },
+          {
+            source: permissionSetInstance.elemID.createNestedID('classAccesses', 'SomeApexClass'),
+            target: apexClass.elemID,
+            type: 'weak',
+          },
+        ])
+      })
+    })
+  })
+  describe('flows', () => {
+    const flow = new InstanceElement(
+      'SomeFlow',
+      mockTypes.Flow,
+      { [INSTANCE_FULL_NAME_FIELD]: 'SomeFlow' },
+    )
+
+    describe('when disabled', () => {
+      beforeEach(async () => {
+        [profileInstance, permissionSetInstance] = createTestInstances({
+          flowAccesses: {
+            SomeFlow: {
+              enabled: false,
+              flow: 'SomeFlow',
+            },
+          },
+        })
+        refs = await getCustomReferences([profileInstance, permissionSetInstance])
+      })
+      it('should not create a reference', () => {
+        expect(refs).toBeEmpty()
+      })
+    })
+    describe('when enabled', () => {
+      beforeEach(async () => {
+        [profileInstance, permissionSetInstance] = createTestInstances({
+          flowAccesses: {
+            SomeFlow: {
+              enabled: true,
+              flow: 'SomeFlow',
+            },
+          },
+        })
+        refs = await getCustomReferences([profileInstance, permissionSetInstance])
+      })
+      it('should create a reference', () => {
+        expect(refs).toEqual([
+          {
+            source: profileInstance.elemID.createNestedID('flowAccesses', 'SomeFlow'),
+            target: flow.elemID,
+            type: 'weak',
+          },
+          {
+            source: permissionSetInstance.elemID.createNestedID('flowAccesses', 'SomeFlow'),
+            target: flow.elemID,
+            type: 'weak',
+          },
+        ])
+      })
+    })
+  })
+  describe('layouts', () => {
+    const layout = new InstanceElement(
+      'Account_Account_Layout@bs',
+      mockTypes.Layout,
+      { [INSTANCE_FULL_NAME_FIELD]: 'Account-Account Layout' },
+    )
+
+    describe('when there is a reference to a layout', () => {
+      beforeEach(async () => {
+        [profileInstance, permissionSetInstance] = createTestInstances({
+          layoutAssignments: {
+            'Account_Account_Layout@bs': [
+              {
+                layout: 'Account-Account Layout',
+              },
+            ],
+          },
+        })
+        refs = await getCustomReferences([profileInstance, permissionSetInstance])
+      })
+      it('should create a reference', () => {
+        expect(refs).toEqual([
+          {
+            source: profileInstance.elemID.createNestedID('layoutAssignments', 'Account_Account_Layout@bs'),
+            target: layout.elemID,
+            type: 'weak',
+          },
+          {
+            source: permissionSetInstance.elemID.createNestedID('layoutAssignments', 'Account_Account_Layout@bs'),
+            target: layout.elemID,
+            type: 'weak',
+          },
+        ])
+      })
+    })
+    describe('when there is a reference to a recordType', () => {
+      const recordTypes = [
+        new InstanceElement(
+          'SomeRecordType',
+          mockTypes.RecordType,
+          { [INSTANCE_FULL_NAME_FIELD]: 'SomeRecordType' },
+        ),
+        new InstanceElement(
+          'SomeOtherRecordType',
+          mockTypes.RecordType,
+          { [INSTANCE_FULL_NAME_FIELD]: 'SomeOtherRecordType' },
+        ),
+      ]
+      beforeEach(async () => {
+        [profileInstance, permissionSetInstance] = createTestInstances({
+          layoutAssignments: {
+            'Account_Account_Layout@bs': [
+              {
+                layout: 'Account-Account Layout',
+                recordType: 'SomeRecordType',
+              },
+              {
+                layout: 'Account-Account Layout',
+                recordType: 'SomeOtherRecordType',
+              },
+            ],
+          },
+        })
+        refs = await getCustomReferences([profileInstance, permissionSetInstance])
+      })
+      it('should create a reference', () => {
+        expect(refs).toEqual([
+          {
+            source: profileInstance.elemID.createNestedID('layoutAssignments', 'Account_Account_Layout@bs'),
+            target: layout.elemID,
+            type: 'weak',
+          },
+          {
+            source: profileInstance.elemID.createNestedID('layoutAssignments', 'Account_Account_Layout@bs'),
+            target: recordTypes[0].elemID,
+            type: 'weak',
+          },
+          {
+            source: profileInstance.elemID.createNestedID('layoutAssignments', 'Account_Account_Layout@bs'),
+            target: recordTypes[1].elemID,
+            type: 'weak',
+          },
+          {
+            source: permissionSetInstance.elemID.createNestedID('layoutAssignments', 'Account_Account_Layout@bs'),
+            target: layout.elemID,
+            type: 'weak',
+          },
+          {
+            source: permissionSetInstance.elemID.createNestedID('layoutAssignments', 'Account_Account_Layout@bs'),
+            target: recordTypes[0].elemID,
+            type: 'weak',
+          },
+          {
+            source: permissionSetInstance.elemID.createNestedID('layoutAssignments', 'Account_Account_Layout@bs'),
+            target: recordTypes[1].elemID,
+            type: 'weak',
+          },
+        ])
+      })
+    })
+  })
+  describe('objects', () => {
+    const customObject = createCustomObjectType('Account', {})
+
+    describe('when all permissions are disabled', () => {
+      beforeEach(async () => {
+        [profileInstance, permissionSetInstance] = createTestInstances({
+          objectPermissions: {
+            Account: {
+              allowCreate: false,
+              allowDelete: false,
+              allowEdit: false,
+              allowRead: false,
+              modifyAllRecords: false,
+              object: 'Account',
+              viewAllRecords: false,
+            },
+          },
+        })
+
+        refs = await getCustomReferences([profileInstance, permissionSetInstance])
+      })
+
+      it('should not create references', () => {
+        expect(refs).toBeEmpty()
+      })
+    })
+
+    describe('when some permissions are enabled', () => {
+      beforeEach(async () => {
+        [profileInstance, permissionSetInstance] = createTestInstances({
+          objectPermissions: {
+            Account: {
+              allowCreate: true,
+              allowDelete: true,
+              allowEdit: true,
+              allowRead: true,
+              modifyAllRecords: false,
+              object: 'Account',
+              viewAllRecords: false,
+            },
+          },
+        })
+
+        refs = await getCustomReferences([profileInstance, permissionSetInstance])
+      })
+
+      it('should create a reference', () => {
+        expect(refs).toEqual([
+          {
+            source: profileInstance.elemID.createNestedID('objectPermissions', 'Account'),
+            target: customObject.elemID,
+            type: 'weak',
+          },
+          {
+            source: permissionSetInstance.elemID.createNestedID('objectPermissions', 'Account'),
+            target: customObject.elemID,
+            type: 'weak',
+          },
+        ])
+      })
+    })
+  })
+  describe('Apex pages', () => {
+    const apexPage = new InstanceElement(
+      'SomeApexPage',
+      mockTypes.ApexPage,
+      { [INSTANCE_FULL_NAME_FIELD]: 'SomeApexPage' },
+    )
+
+    describe('when disabled', () => {
+      beforeEach(async () => {
+        [profileInstance, permissionSetInstance] = createTestInstances({
+          pageAccesses: {
+            SomeApexPage: {
+              apexPage: 'SomeApexPage',
+              enabled: false,
+            },
+          },
+        })
+        refs = await getCustomReferences([profileInstance, permissionSetInstance])
+      })
+
+      it('should not create a reference', () => {
+        expect(refs).toBeEmpty()
+      })
+    })
+
+    describe('when enabled', () => {
+      beforeEach(async () => {
+        [profileInstance, permissionSetInstance] = createTestInstances({
+          pageAccesses: {
+            SomeApexPage: {
+              apexPage: 'SomeApexPage',
+              enabled: true,
+            },
+          },
+        })
+        refs = await getCustomReferences([profileInstance, permissionSetInstance])
+      })
+
+      it('should create a reference', () => {
+        expect(refs).toEqual([
+          {
+            source: profileInstance.elemID.createNestedID('pageAccesses', 'SomeApexPage'),
+            target: apexPage.elemID,
+            type: 'weak',
+          },
+          {
+            source: permissionSetInstance.elemID.createNestedID('pageAccesses', 'SomeApexPage'),
+            target: apexPage.elemID,
+            type: 'weak',
+          },
+        ])
+      })
+    })
+  })
+  describe('record types', () => {
+    const recordType = new InstanceElement(
+      'Case_SomeCaseRecordType',
+      mockTypes.RecordType,
+      { [INSTANCE_FULL_NAME_FIELD]: 'Case.SomeCaseRecordType' },
+    )
+    describe('when neither default nor visible', () => {
+      beforeEach(async () => {
+        [profileInstance, permissionSetInstance] = createTestInstances({
+          recordTypeVisibilities: {
+            Case: {
+              SomeCaseRecordType: {
+                default: false,
+                recordType: 'Case.SomeCaseRecordType',
+                visible: false,
+              },
+            },
+          },
+        })
+        refs = await getCustomReferences([profileInstance, permissionSetInstance])
+      })
+      it('should not create a reference', () => {
+        expect(refs).toBeEmpty()
+      })
+    })
+    describe('when default', () => {
+      beforeEach(async () => {
+        [profileInstance, permissionSetInstance] = createTestInstances({
+          recordTypeVisibilities: {
+            Case: {
+              SomeCaseRecordType: {
+                default: true,
+                recordType: 'Case.SomeCaseRecordType',
+                visible: false,
+              },
+            },
+          },
+        })
+        refs = await getCustomReferences([profileInstance, permissionSetInstance])
+      })
+      it('should create a reference', () => {
+        expect(refs).toEqual([
+          {
+            source: profileInstance.elemID.createNestedID('recordTypeVisibilities', 'Case', 'SomeCaseRecordType'),
+            target: recordType.elemID,
+            type: 'weak',
+          },
+          {
+            source: permissionSetInstance.elemID.createNestedID('recordTypeVisibilities', 'Case', 'SomeCaseRecordType'),
+            target: recordType.elemID,
+            type: 'weak',
+          },
+        ])
+      })
+    })
+    describe('when visible', () => {
+      beforeEach(async () => {
+        [profileInstance, permissionSetInstance] = createTestInstances({
+          recordTypeVisibilities: {
+            Case: {
+              SomeCaseRecordType: {
+                default: false,
+                recordType: 'Case.SomeCaseRecordType',
+                visible: true,
+              },
+            },
+          },
+        })
+        refs = await getCustomReferences([profileInstance, permissionSetInstance])
+      })
+      it('should create a reference', () => {
+        expect(refs).toEqual([
+          {
+            source: profileInstance.elemID.createNestedID('recordTypeVisibilities', 'Case', 'SomeCaseRecordType'),
+            target: recordType.elemID,
+            type: 'weak',
+          },
+          {
+            source: permissionSetInstance.elemID.createNestedID('recordTypeVisibilities', 'Case', 'SomeCaseRecordType'),
+            target: recordType.elemID,
+            type: 'weak',
+          },
+        ])
+      })
+    })
+  })
+})


### PR DESCRIPTION
Create references from profiles and permission sets in `getCustomReferences`

---

1. Note how I create the ElemID name for the references. Given the fullName, the correct thing to do would be to look up the element with this full name and use its ElemID. However, in `getCustomReferences` we are supposed to deal with elements one at a time with no context, so that's not an option. I basically replicated how we create ElemID from fullName where we create instances.
2. ~Ideally, this would be an optional feature, but I'm not sure how to get access to the fetch profile from this callback~


** PR Chain **
 - https://github.com/salto-io/salto/pull/5150 
 - https://github.com/salto-io/salto/pull/5045 👈 YOU ARE HERE 👈
---
_Release Notes_: 
N/A

---
_User Notifications_: 
N/A