### PR TITLE
SALTO-4981: Pass resolvedTypesElementsSource only for Salesforce accounts

### DIFF
--- a/packages/core/src/core/adapters/adapters.ts
+++ b/packages/core/src/core/adapters/adapters.ts
@@ -264,7 +264,7 @@ type AdapterConfigGetter = (
   adapter: string, defaultValue?: InstanceElement
 ) => Promise<InstanceElement | undefined>
 
-const RESOLVED_TYPES_ELEMENTS_SOURCE_ACCOUNTS = [
+const RESOLVED_TYPES_ELEMENTS_SOURCE_SERVICES = [
   'salesforce',
 ]
 
@@ -288,7 +288,7 @@ export const getAdaptersCreatorConfigs = async (
         {
           credentials: credentials[account],
           config: await getConfig(account, defaultConfig),
-          elementsSource: RESOLVED_TYPES_ELEMENTS_SOURCE_ACCOUNTS.includes(account)
+          elementsSource: RESOLVED_TYPES_ELEMENTS_SOURCE_SERVICES.includes(accountToServiceName[account])
             ? createResolvedTypesElementsSource(elemIDReplacedElementsSource)
             : elemIDReplacedElementsSource,
           getElemIdFunc: elemIdGetters[account],


### PR DESCRIPTION
Passing resolvedTypesElementsSource only for Salesforce accounts from core.

---

We should open it to other adapters gradually, after they've been fully tested with the new elements source, as we saw memory issues.

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
