### PR TITLE
SALTO-4986: Support getting workspaceId and fetching assests schema

### DIFF
--- a/packages/jira-adapter/e2e_test/adapter.test.ts
+++ b/packages/jira-adapter/e2e_test/adapter.test.ts
@@ -35,7 +35,7 @@ const { replaceInstanceTypeForDeploy } = elementUtils.ducktype
 
 jest.setTimeout(600 * 1000)
 
-const excludedTypes = ['Behavior', 'Behavior__config']
+const excludedTypes = ['Behavior', 'Behavior__config', 'AssetsSchema']
 
 each([
   ['Cloud', false],

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -512,7 +512,8 @@ export default class JiraAdapter implements AdapterOperations {
     // jsmApiDefinitions is currently undefined for DC
     if (this.client === undefined
       || jsmApiDefinitions === undefined
-      || !this.userConfig.fetch.enableJSM) {
+      || !this.userConfig.fetch.enableJSM
+      || !this.userConfig.fetch.enableJsmExperimental) {
       return { elements: [] }
     }
 

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -160,6 +160,8 @@ import portalGroupsFilter from './filters/portal_groups'
 import ScriptRunnerClient from './client/script_runner_client'
 import { weakReferenceHandlers } from './weak_references'
 import { jiraJSMEntriesFunc } from './jsm_utils'
+import { getWorkspaceId } from './workspace_id'
+import { JSM_ASSESTS_DUCKTYPE_SUPPORTED_TYPES } from './config/api_config'
 
 const { getAllElements } = elementUtils.ducktype
 const { findDataField, computeGetArgs } = elementUtils
@@ -503,6 +505,37 @@ export default class JiraAdapter implements AdapterOperations {
     })
   }
 
+  @logDuration('generating JSM assests instances and types from service')
+  private async getJSMAssestsElements():
+  Promise<elementUtils.FetchElements<Element[]>> {
+    const { jsmApiDefinitions } = this.userConfig
+    // jsmApiDefinitions is currently undefined for DC
+    if (this.client === undefined
+      || jsmApiDefinitions === undefined
+      || !this.userConfig.fetch.enableJSM) {
+      return { elements: [] }
+    }
+
+    const workspaceId = await getWorkspaceId(this.client)
+    if (workspaceId === undefined) {
+      return { elements: [] }
+    }
+    const workspaceContext = { workspaceId }
+    return getAllElements({
+      adapterName: JIRA,
+      types: jsmApiDefinitions.types,
+      shouldAddRemainingTypes: false,
+      supportedTypes: JSM_ASSESTS_DUCKTYPE_SUPPORTED_TYPES,
+      fetchQuery: this.fetchQuery,
+      paginator: this.paginator,
+      nestedFieldFinder: findDataField,
+      computeGetArgs,
+      typeDefaults: jsmApiDefinitions.typeDefaults,
+      additionalRequestContext: workspaceContext,
+      getElemIdFunc: this.getElemIdFunc,
+    })
+  }
+
   @logDuration('generating JSM instances and types from service')
   private async getJSMElements(swaggerResponseElements: InstanceElement[]):
   Promise<elementUtils.FetchElements<Element[]>> {
@@ -513,13 +546,14 @@ export default class JiraAdapter implements AdapterOperations {
       || !this.userConfig.fetch.enableJSM) {
       return { elements: [] }
     }
+
     const serviceDeskProjects = swaggerResponseElements
       .filter(project => project.elemID.typeName === PROJECT_TYPE)
       .filter(isInstanceElement)
       .filter(project => project.value.projectTypeKey === SERVICE_DESK)
 
     const fetchResultWithDuplicateTypes = await Promise.all(serviceDeskProjects.map(async projectInstance => {
-      const serviceDeskProjRecord: Record<string, string> = {
+      const serviceDeskProjRecord: Record<string, unknown> = {
         projectKey: projectInstance.value.key,
         serviceDeskId: projectInstance.value.serviceDeskId.id,
         projectId: projectInstance.value.id,
@@ -584,17 +618,19 @@ export default class JiraAdapter implements AdapterOperations {
     ])
 
     const jsmElements = await this.getJSMElements(swaggerResponse.elements)
-
+    const jsmAssestsElements = await this.getJSMAssestsElements()
     const elements: Element[] = [
       ...Object.values(swaggerTypes),
       ...swaggerResponse.elements,
       ...scriptRunnerElements.elements,
       ...jsmElements.elements,
+      ...jsmAssestsElements.elements,
     ]
     return { elements,
       errors: (swaggerResponse.errors ?? [])
         .concat(scriptRunnerElements.errors ?? [])
-        .concat(jsmElements.errors ?? []),
+        .concat(jsmElements.errors ?? [])
+        .concat(jsmAssestsElements.errors ?? []),
       configChanges: (jsmElements.configChanges ?? []) }
   }
 

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -161,7 +161,7 @@ import ScriptRunnerClient from './client/script_runner_client'
 import { weakReferenceHandlers } from './weak_references'
 import { jiraJSMEntriesFunc } from './jsm_utils'
 import { getWorkspaceId } from './workspace_id'
-import { JSM_ASSESTS_DUCKTYPE_SUPPORTED_TYPES } from './config/api_config'
+import { JSM_ASSETS_DUCKTYPE_SUPPORTED_TYPES } from './config/api_config'
 
 const { getAllElements } = elementUtils.ducktype
 const { findDataField, computeGetArgs } = elementUtils
@@ -505,8 +505,8 @@ export default class JiraAdapter implements AdapterOperations {
     })
   }
 
-  @logDuration('generating JSM assests instances and types from service')
-  private async getJSMAssestsElements():
+  @logDuration('generating JSM assets instances and types from service')
+  private async getJSMAssetsElements():
   Promise<elementUtils.FetchElements<Element[]>> {
     const { jsmApiDefinitions } = this.userConfig
     // jsmApiDefinitions is currently undefined for DC
@@ -526,7 +526,7 @@ export default class JiraAdapter implements AdapterOperations {
       adapterName: JIRA,
       types: jsmApiDefinitions.types,
       shouldAddRemainingTypes: false,
-      supportedTypes: JSM_ASSESTS_DUCKTYPE_SUPPORTED_TYPES,
+      supportedTypes: JSM_ASSETS_DUCKTYPE_SUPPORTED_TYPES,
       fetchQuery: this.fetchQuery,
       paginator: this.paginator,
       nestedFieldFinder: findDataField,
@@ -619,19 +619,19 @@ export default class JiraAdapter implements AdapterOperations {
     ])
 
     const jsmElements = await this.getJSMElements(swaggerResponse.elements)
-    const jsmAssestsElements = await this.getJSMAssestsElements()
+    const jsmAssetsElements = await this.getJSMAssetsElements()
     const elements: Element[] = [
       ...Object.values(swaggerTypes),
       ...swaggerResponse.elements,
       ...scriptRunnerElements.elements,
       ...jsmElements.elements,
-      ...jsmAssestsElements.elements,
+      ...jsmAssetsElements.elements,
     ]
     return { elements,
       errors: (swaggerResponse.errors ?? [])
         .concat(scriptRunnerElements.errors ?? [])
         .concat(jsmElements.errors ?? [])
-        .concat(jsmAssestsElements.errors ?? []),
+        .concat(jsmAssetsElements.errors ?? []),
       configChanges: (jsmElements.configChanges ?? []) }
   }
 

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -554,7 +554,7 @@ export default class JiraAdapter implements AdapterOperations {
       .filter(project => project.value.projectTypeKey === SERVICE_DESK)
 
     const fetchResultWithDuplicateTypes = await Promise.all(serviceDeskProjects.map(async projectInstance => {
-      const serviceDeskProjRecord: Record<string, unknown> = {
+      const serviceDeskProjRecord: Record<string, string> = {
         projectKey: projectInstance.value.key,
         serviceDeskId: projectInstance.value.serviceDeskId.id,
         projectId: projectInstance.value.id,

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -2141,6 +2141,21 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       extendsParentId: true,
     },
   },
+  AssestsSchema: {
+    request: {
+      url: '/gateway/api/jsm/assets/workspace/{workspaceId}/v1/objectschema/list?maxResults=1000',
+    },
+    transformation: {
+      sourceTypeName: 'AssestsSchema__values',
+      dataField: 'values',
+      idFields: ['name'],
+      fieldsToOmit: [
+        { fieldName: 'created' },
+        { fieldName: 'updated' },
+        { fieldName: 'globalId' },
+      ],
+    },
+  },
 }
 
 export const JSM_DUCKTYPE_SUPPORTED_TYPES = {
@@ -2151,6 +2166,10 @@ export const JSM_DUCKTYPE_SUPPORTED_TYPES = {
   Calendar: ['Calendar'],
   PortalSettings: ['PortalSettings'],
   SLA: ['SLA'],
+}
+
+export const JSM_ASSESTS_DUCKTYPE_SUPPORTED_TYPES = {
+  AssestsSchema: ['AssestsSchema'],
 }
 
 export const SCRIPT_RUNNER_DUCKTYPE_SUPPORTED_TYPES = {

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -2143,7 +2143,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
   },
   AssetsSchema: {
     request: {
-      url: '/gateway/api/jsm/assets/workspace/{workspaceId}/v1/objectschema/list?maxResults=1000',
+      url: '/gateway/api/jsm/assets/workspace/{workspaceId}/v1/objectschema/list',
     },
     transformation: {
       sourceTypeName: 'AssetsSchema__values',
@@ -2153,6 +2153,10 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
         { fieldName: 'created' },
         { fieldName: 'updated' },
         { fieldName: 'globalId' },
+      ],
+      fieldsToHide: [
+        { fieldName: 'id' },
+        { fieldName: 'idAsInt' },
       ],
     },
   },

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -2141,12 +2141,12 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       extendsParentId: true,
     },
   },
-  AssestsSchema: {
+  AssetsSchema: {
     request: {
       url: '/gateway/api/jsm/assets/workspace/{workspaceId}/v1/objectschema/list?maxResults=1000',
     },
     transformation: {
-      sourceTypeName: 'AssestsSchema__values',
+      sourceTypeName: 'AssetsSchema__values',
       dataField: 'values',
       idFields: ['name'],
       fieldsToOmit: [
@@ -2168,8 +2168,8 @@ export const JSM_DUCKTYPE_SUPPORTED_TYPES = {
   SLA: ['SLA'],
 }
 
-export const JSM_ASSESTS_DUCKTYPE_SUPPORTED_TYPES = {
-  AssestsSchema: ['AssestsSchema'],
+export const JSM_ASSETS_DUCKTYPE_SUPPORTED_TYPES = {
+  AssetsSchema: ['AssetsSchema'],
 }
 
 export const SCRIPT_RUNNER_DUCKTYPE_SUPPORTED_TYPES = {

--- a/packages/jira-adapter/src/workspace_id.ts
+++ b/packages/jira-adapter/src/workspace_id.ts
@@ -1,0 +1,44 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import Joi from 'joi'
+import { createSchemeGuard } from '@salto-io/adapter-utils'
+import JiraClient from './client/client'
+
+type WorkspaceResponse = {
+    values: {
+        workspaceId: string
+    }[]
+}
+
+const WORKSPACE_RESPONSE_SCHEME = Joi.object({
+  values: Joi.array().items(Joi.object({
+    workspaceId: Joi.string().required(),
+  })).min(1).required(),
+}).unknown(true).required()
+
+const isWorkspaceResponse = createSchemeGuard<WorkspaceResponse>(WORKSPACE_RESPONSE_SCHEME, 'Received invalid workspace response')
+
+
+export const getWorkspaceId = async (client: JiraClient): Promise<string | undefined> => {
+  const response = await client.getSinglePage({
+    url: '/rest/servicedeskapi/assets/workspace',
+  })
+  if (!isWorkspaceResponse(response.data)) {
+    return undefined
+  }
+  return response.data.values[0].workspaceId
+}

--- a/packages/jira-adapter/src/workspace_id.ts
+++ b/packages/jira-adapter/src/workspace_id.ts
@@ -15,13 +15,15 @@
 */
 
 import Joi from 'joi'
+import { logger } from '@salto-io/logging'
 import { createSchemeGuard } from '@salto-io/adapter-utils'
 import JiraClient from './client/client'
 
+const log = logger(module)
 type WorkspaceResponse = {
-    values: {
-        workspaceId: string
-    }[]
+  values: {
+    workspaceId: string
+  }[]
 }
 
 const WORKSPACE_RESPONSE_SCHEME = Joi.object({
@@ -32,12 +34,12 @@ const WORKSPACE_RESPONSE_SCHEME = Joi.object({
 
 const isWorkspaceResponse = createSchemeGuard<WorkspaceResponse>(WORKSPACE_RESPONSE_SCHEME, 'Received invalid workspace response')
 
-
 export const getWorkspaceId = async (client: JiraClient): Promise<string | undefined> => {
   const response = await client.getSinglePage({
     url: '/rest/servicedeskapi/assets/workspace',
   })
   if (!isWorkspaceResponse(response.data)) {
+    log.trace('Received invalid workspace response %o', response.data)
     return undefined
   }
   return response.data.values[0].workspaceId


### PR DESCRIPTION
In this PR I support fetching assets schema using the infrastructure. 

---

_Additional context for reviewer_
In order to fetch assets schema I need to have `workspaceId`. 
Only users who purchased Assets will have workspaceId. 
 
---
_Release Notes_: 
_JIra Adapter:_
Now support fetching of assets schemas. 

---
_User Notifications_: 
_JIra Adapter:_
Now support fetching of assets schemas. 
