### PR TITLE
SALTO-4901: Verify parent app supports group push

### DIFF
--- a/packages/okta-adapter/src/change_validators/app_with_group_push.ts
+++ b/packages/okta-adapter/src/change_validators/app_with_group_push.ts
@@ -26,7 +26,7 @@ const { isDefined } = values
 const GROUP_PUSH_HELP_ARTICLE = 'https://help.okta.com/oie/en-us/content/topics/users-groups-profiles/usgp-group-push-prerequisites.htm'
 
 /**
- * Verify application suppports group push feature before addition of GroupPush and GroupPushRule instances
+ * Verify application supports group push feature before addition of GroupPush and GroupPushRule instances
  */
 export const appWithGroupPushValidator: ChangeValidator = async changes => {
   const groupPushInstances = changes

--- a/packages/okta-adapter/src/change_validators/app_with_group_push.ts
+++ b/packages/okta-adapter/src/change_validators/app_with_group_push.ts
@@ -1,0 +1,58 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ChangeValidator, getChangeData, isInstanceChange, isAdditionChange } from '@salto-io/adapter-api'
+import { values } from '@salto-io/lowerdash'
+import { logger } from '@salto-io/logging'
+import { getParent } from '@salto-io/adapter-utils'
+import { GROUP_PUSH_RULE_TYPE_NAME, GROUP_PUSH_TYPE_NAME } from '../constants'
+import { isAppSupportsGroupPush } from '../filters/group_push'
+
+const log = logger(module)
+const { isDefined } = values
+
+const GROUP_PUSH_HELP_ARTICLE = 'https://help.okta.com/oie/en-us/content/topics/users-groups-profiles/usgp-group-push-prerequisites.htm'
+
+/**
+ * Verify application suppports group push feature before addition of GroupPush and GroupPushRule instances
+ */
+export const appWithGroupPushValidator: ChangeValidator = async changes => {
+  const groupPushInstances = changes
+    .filter(isInstanceChange)
+    .filter(isAdditionChange)
+    .map(getChangeData)
+    .filter(instance => [GROUP_PUSH_TYPE_NAME, GROUP_PUSH_RULE_TYPE_NAME].includes(instance.elemID.typeName))
+
+  const invalidGroupPushToApp = Object.fromEntries(
+    groupPushInstances.map(groupPush => {
+      try {
+        const parentApp = getParent(groupPush)
+        return isAppSupportsGroupPush(parentApp) ? undefined : [groupPush.elemID.getFullName(), parentApp.elemID.name]
+      } catch (err) {
+        log.error(`Could not find parent app for: ${groupPush.elemID.getFullName()}: ${err.message}`)
+        return undefined
+      }
+    }).filter(isDefined)
+  )
+
+  return groupPushInstances
+    .filter(instance => invalidGroupPushToApp[instance.elemID.getFullName()] !== undefined)
+    .map(instance => ({
+      elemID: instance.elemID,
+      severity: 'Error',
+      message: 'Group Push is not supported for application',
+      detailedMessage: `Group Push must be enabled for application ${invalidGroupPushToApp[instance.elemID.getFullName()]}, for more info see: ${GROUP_PUSH_HELP_ARTICLE}`,
+    }))
+}

--- a/packages/okta-adapter/src/change_validators/index.ts
+++ b/packages/okta-adapter/src/change_validators/index.ts
@@ -30,6 +30,7 @@ import { groupSchemaModifyBaseValidator } from './group_schema_modify_base_field
 import { enabledAuthenticatorsValidator } from './enabled_authenticators'
 import { roleAssignmentValidator } from './role_assignment'
 import { usersValidator } from './user'
+import { appWithGroupPushValidator } from './app_with_group_push'
 import OktaClient from '../client/client'
 import {
   API_DEFINITIONS_CONFIG,
@@ -73,6 +74,7 @@ export default ({
     roleAssignment: roleAssignmentValidator,
     users: usersValidator(client, config),
     appUserSchemaWithInactiveApp: appUserSchemaWithInactiveAppValidator,
+    appWithGroupPush: appWithGroupPushValidator,
   }
 
   return createChangeValidator({

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -1779,6 +1779,7 @@ export type ChangeValidatorName = (
   | 'roleAssignment'
   | 'users'
   | 'appUserSchemaWithInactiveApp'
+  | 'appWithGroupPush'
   )
 
 type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
@@ -1802,6 +1803,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     roleAssignment: { refType: BuiltinTypes.BOOLEAN },
     users: { refType: BuiltinTypes.BOOLEAN },
     appUserSchemaWithInactiveApp: { refType: BuiltinTypes.BOOLEAN },
+    appWithGroupPush: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/okta-adapter/src/filters/group_push.ts
+++ b/packages/okta-adapter/src/filters/group_push.ts
@@ -75,6 +75,9 @@ const isPushRulesResponse = createSchemeGuard<PushRuleEntry[]>(
   PUSH_RULE_RESPONSE_SCHEMA, 'Received an invalid response for push rules'
 )
 
+export const isAppSupportsGroupPush = (instance: InstanceElement): boolean =>
+  Array.isArray(instance.value.features) && instance.value.features.includes('GROUP_PUSH')
+
 const createGroupPushTypes = (): ObjectType[] => (
   [new ObjectType({
     elemID: new ElemID(OKTA, GROUP_PUSH_TYPE_NAME),
@@ -237,7 +240,7 @@ const groupPushFilter: FilterCreator = ({ config, adminClient, getElemIdFunc }) 
     const appsWithGroupPush = elements
       .filter(isInstanceElement)
       .filter(instance => instance.elemID.typeName === APPLICATION_TYPE_NAME)
-      .filter(instance => Array.isArray(instance.value.features) && instance.value.features.includes('GROUP_PUSH'))
+      .filter(isAppSupportsGroupPush)
 
     const [groupPushType, pushRuleType] = createGroupPushTypes()
     elements.push(groupPushType)

--- a/packages/okta-adapter/test/change_validators/app_with_group_push.test.ts
+++ b/packages/okta-adapter/test/change_validators/app_with_group_push.test.ts
@@ -1,0 +1,108 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { toChange, ObjectType, ElemID, InstanceElement, ReferenceExpression, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
+import { appWithGroupPushValidator } from '../../src/change_validators/app_with_group_push'
+import { OKTA, APPLICATION_TYPE_NAME, GROUP_PUSH_TYPE_NAME, GROUP_PUSH_RULE_TYPE_NAME } from '../../src/constants'
+
+describe('appWithGroupPushValidator', () => {
+  const appType = new ObjectType({ elemID: new ElemID(OKTA, APPLICATION_TYPE_NAME) })
+  const appWithGroupPushA = new InstanceElement(
+    'appA',
+    appType,
+    { id: 'abc', name: 'salesforce', signOnMode: 'SAML_2_0', features: ['IMPORT_USER_SCHEMA', 'GROUP_PUSH'] },
+  )
+  const appWithNoGroupPushA = new InstanceElement(
+    'appB',
+    appType,
+    { id: 'abc', name: 'jira', signOnMode: 'SAML_2_0', features: ['IMPORT_USER_SCHEMA'] },
+  )
+  const appWithNoGroupPushB = new InstanceElement(
+    'appC',
+    appType,
+    { id: 'bcd', name: 'zendesk', signOnMode: 'SAML_2_0' },
+  )
+  const groupPushType = new ObjectType({ elemID: new ElemID(OKTA, GROUP_PUSH_TYPE_NAME) })
+  const pushRuleType = new ObjectType({ elemID: new ElemID(OKTA, GROUP_PUSH_RULE_TYPE_NAME) })
+  const validGroupPush = new InstanceElement(
+    'g1',
+    groupPushType,
+    { mappingId: 'm1', status: 'ACTIVE', newAppGroupName: 'A1' },
+    undefined,
+    { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(appWithGroupPushA.elemID, appWithGroupPushA)] }
+  )
+  const invalidGroupPushA = new InstanceElement(
+    'g2',
+    groupPushType,
+    { mappingId: 'm2', status: 'INACTIVE', newAppGroupName: 'B1' },
+    undefined,
+    { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(appWithNoGroupPushA.elemID, appWithNoGroupPushA)] },
+  )
+  const invalidGroupPushB = new InstanceElement(
+    'g3',
+    groupPushType,
+    { mappingId: 'm3', status: 'ACTIVE', newAppGroupName: 'C1' },
+    undefined,
+    { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(appWithNoGroupPushB.elemID, appWithNoGroupPushB)] },
+  )
+  const validPushRule = new InstanceElement(
+    'test rule',
+    pushRuleType,
+    { mappingRuleId: 'mr1', name: 'test rule', status: 'ACTIVE', searchExpression: 'sales', searchExpressionType: 'ENDS_WITH' },
+    undefined,
+    { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(appWithGroupPushA.elemID, appWithGroupPushA)] },
+  )
+  const invalidPushRule = new InstanceElement(
+    'test rule',
+    pushRuleType,
+    { mappingRuleId: 'mr1', name: 'test rule', status: 'ACTIVE', searchExpression: 'sales', searchExpressionType: 'STARTS_WITH' },
+    undefined,
+    { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(appWithNoGroupPushA.elemID, appWithNoGroupPushA)] },
+  )
+  it('should return an error when group push is disabled for parent app', async () => {
+    const changeErrors = await appWithGroupPushValidator([
+      toChange({ after: invalidGroupPushA }),
+      toChange({ after: invalidGroupPushB }),
+      toChange({ after: invalidPushRule }),
+    ])
+    expect(changeErrors).toHaveLength(3)
+    expect(changeErrors).toEqual([
+      {
+        elemID: invalidGroupPushA.elemID,
+        severity: 'Error',
+        message: 'Group Push is not supported for application',
+        detailedMessage: 'Group Push must be enabled for application appB, for more info see: https://help.okta.com/oie/en-us/content/topics/users-groups-profiles/usgp-group-push-prerequisites.htm',
+      },
+      {
+        elemID: invalidGroupPushB.elemID,
+        severity: 'Error',
+        message: 'Group Push is not supported for application',
+        detailedMessage: 'Group Push must be enabled for application appC, for more info see: https://help.okta.com/oie/en-us/content/topics/users-groups-profiles/usgp-group-push-prerequisites.htm',
+      },
+      {
+        elemID: invalidPushRule.elemID,
+        severity: 'Error',
+        message: 'Group Push is not supported for application',
+        detailedMessage: 'Group Push must be enabled for application appB, for more info see: https://help.okta.com/oie/en-us/content/topics/users-groups-profiles/usgp-group-push-prerequisites.htm',
+      },
+    ])
+  })
+  it('should not return error if parent app enabled group push', async () => {
+    const changeErrors = await appWithGroupPushValidator([
+      toChange({ after: validGroupPush }), toChange({ after: validPushRule }),
+    ])
+    expect(changeErrors).toEqual([])
+  })
+})


### PR DESCRIPTION
Before addition of `GroupPush` or `GroupPushRule`, we should verify the associated app enabled Group Push feature

---
_Release Notes_: 
None

---
_User Notifications_: 
None