### PR TITLE
SALTO-4991: Avoid infinite loop in resolve elem source has a bug

### DIFF
--- a/packages/workspace/src/expressions.ts
+++ b/packages/workspace/src/expressions.ts
@@ -101,6 +101,15 @@ const getElementCloneFromSource = async (
     }
     return undefined
   }
+  if (!elem.elemID.isEqual(id)) {
+    // This should really never happen, but if it does, we might find ourselves in an infinite loop
+    // so we try to protect against this case anyway
+    log.warn(
+      'resolve expected element with ID %s but found element with ID %s, returning undefine to avoid loop',
+      elem.elemID.getFullName(), id.getFullName(),
+    )
+    return undefined
+  }
   // We create a clone because we must not modify the element from the read only source
   const elemToResolve = elem.clone()
   return elemToResolve


### PR DESCRIPTION
In the previous fix of this issue we hopefully took care of the bug in the element source. But even so, and just in case there is another such issue somewhere else or in the future adding another layer of protection against cases that should never happen

---

_Additional context for reviewer_
no release notes here since this should not solve any issue, the issue was supposed to be fixed by the previous commit

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_