### PR TITLE
SALTO-4986: Add assets statuses

### DIFF
--- a/packages/jira-adapter/e2e_test/adapter.test.ts
+++ b/packages/jira-adapter/e2e_test/adapter.test.ts
@@ -35,7 +35,7 @@ const { replaceInstanceTypeForDeploy } = elementUtils.ducktype
 
 jest.setTimeout(600 * 1000)
 
-const excludedTypes = ['Behavior', 'Behavior__config', 'AssetsSchema']
+const excludedTypes = ['Behavior', 'Behavior__config', 'AssetsSchema', 'AssetsSchemas', 'AssetsStatuses', 'AssetsStatus']
 
 each([
   ['Cloud', false],

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -2141,14 +2141,24 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       extendsParentId: true,
     },
   },
-  AssetsSchema: {
+  AssetsSchemas: {
     request: {
       url: '/gateway/api/jsm/assets/workspace/{workspaceId}/v1/objectschema/list',
+      recurseInto: [
+        {
+          type: 'AssetsStatuses',
+          toField: 'assetsStatuses',
+          context: [{ name: 'AssetsSchemaId', fromField: 'id' }],
+        },
+      ],
     },
     transformation: {
-      sourceTypeName: 'AssetsSchema__values',
       dataField: 'values',
-      idFields: ['name'],
+    },
+  },
+  AssetsSchema: {
+    transformation: {
+      sourceTypeName: 'AssetsSchemas__values',
       fieldsToOmit: [
         { fieldName: 'created' },
         { fieldName: 'updated' },
@@ -2157,6 +2167,29 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       fieldsToHide: [
         { fieldName: 'id' },
         { fieldName: 'idAsInt' },
+      ],
+      standaloneFields: [
+        { fieldName: 'assetsStatuses' },
+      ],
+      fieldTypeOverrides: [
+        { fieldName: 'assetsStatuses', fieldType: 'List<AssetsStatus>' },
+      ],
+    },
+  },
+  AssetsStatuses: {
+    request: {
+      url: '/gateway/api/jsm/assets/workspace/{workspaceId}/v1/config/statustype?objectSchemaId={AssetsSchemaId}',
+    },
+    transformation: {
+      dataField: '.',
+    },
+  },
+  AssetsStatus: {
+    transformation: {
+      sourceTypeName: 'AssetsSchema__assetsStatuses',
+      fieldsToHide: [
+        { fieldName: 'id' },
+        { fieldName: 'objectSchemaId' },
       ],
     },
   },
@@ -2173,7 +2206,7 @@ export const JSM_DUCKTYPE_SUPPORTED_TYPES = {
 }
 
 export const JSM_ASSETS_DUCKTYPE_SUPPORTED_TYPES = {
-  AssetsSchema: ['AssetsSchema'],
+  AssetsSchema: ['AssetsSchemas'],
 }
 
 export const SCRIPT_RUNNER_DUCKTYPE_SUPPORTED_TYPES = {


### PR DESCRIPTION
In this PR I added support for fetching assets statuses. 

---
Please review only the last commit "assets statuses". Only added a type in api_config.ts

---
_Release Notes_: 
_Jira Adapter:_
Now supporting fetch of assets statuses. 

---
_User Notifications_: 
_Jira Adapter:_
Now supporting fetch of assets statuses. 
