### PR TITLE
SALTO-4517: Avoid running multiple resolve elements

### DIFF
--- a/packages/core/src/core/adapters/adapters.ts
+++ b/packages/core/src/core/adapters/adapters.ts
@@ -197,10 +197,8 @@ const filterElementsSource = (
 export const createResolvedTypesElementsSource = (
   elementsSource: ReadOnlyElementsSource
 ): ReadOnlyElementsSource => {
-  const resolvedTypes: Map<string, TypeElement> = new Map()
-  let typesWereResolved = false
-  const resolveTypes = async (): Promise<void> => {
-    typesWereResolved = true
+  let resolvedTypesPromise: Promise<Map<string, TypeElement>> | undefined
+  const resolveTypes = async (): Promise<Map<string, TypeElement>> => {
     const typeElements = await awu(await elementsSource.getAll()).filter(isType).toArray()
     // Resolve all the types together for better performance
     const resolved = await expressions.resolve(
@@ -210,16 +208,14 @@ export const createResolvedTypesElementsSource = (
         shouldResolveReferences: false,
       }
     )
-    resolved.filter(isType)
-      .forEach(typeElement => {
-        resolvedTypes.set(typeElement.elemID.getFullName(), typeElement)
-      })
+    return new Map(resolved.filter(isType).map(resolvedType => [resolvedType.elemID.getFullName(), resolvedType]))
   }
 
   const getResolved = async (id: ElemID): Promise<Element> => {
-    if (!typesWereResolved) {
-      await resolveTypes()
+    if (resolvedTypesPromise === undefined) {
+      resolvedTypesPromise = resolveTypes()
     }
+    const resolvedTypes = await resolvedTypesPromise
     // Container types
     const containerInfo = id.getContainerPrefixAndInnerType()
     if (containerInfo !== undefined) {


### PR DESCRIPTION
When called through concurrent code, the previous implementation of ResolvedTypesElementsSource could theoretcially try to resolve all the types multiple times.
using a promise as a lock to avoid this

---

_Additional context for reviewer_
No release notes as the issue is only theoretical AFAIK 

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_