### PR TITLE
SALTO-4980:  remove child elements if their parent is omitted due to id collision

### DIFF
--- a/packages/adapter-components/src/filters/index.ts
+++ b/packages/adapter-components/src/filters/index.ts
@@ -15,5 +15,5 @@
 */
 export { serviceUrlFilterCreator, addUrlToInstance } from './service_url'
 export { referencedInstanceNamesFilterCreator } from './referenced_instance_names'
-export { queryFilterCreator } from './query'
+export { queryFilterCreator, createParentChildGraph } from './query'
 export { hideTypesFilterCreator } from './hide_types'

--- a/packages/adapter-components/src/filters/query.ts
+++ b/packages/adapter-components/src/filters/query.ts
@@ -27,7 +27,7 @@ const log = logger(module)
 /*
  * Create a graph with instance ids as nodes and parent annotations+fields as edges
  */
-const createParentChildGraph = (
+export const createParentChildGraph = (
   instances: InstanceElement[],
   additionalParentFields?: Record<string, string[]>,
 ): AbstractNodeMap => {

--- a/packages/adapter-utils/src/collisions.ts
+++ b/packages/adapter-utils/src/collisions.ts
@@ -119,10 +119,10 @@ export const getAndLogCollisionWarnings = async ({
   await logInstancesWithCollidingElemID(typeToElemIDtoInstances)
   return Promise.all(Object.entries(typeToElemIDtoInstances)
     .map(async ([type, elemIDtoInstances]) => {
-      const childMessage = addChildrenMessage === true ? 'and all their child instances' : ''
+      const childMessage = addChildrenMessage === true ? 'and all their child instances ' : ''
       const numInstances = Object.values(elemIDtoInstances)
         .flat().length
-      const header = `Omitted ${numInstances} instances ${childMessage} of ${type} due to Salto ID collisions.
+      const header = `Omitted ${numInstances} instances ${childMessage}of ${type} due to Salto ID collisions.
 Current Salto ID configuration for ${type} is defined as [${getIdFieldsByType(type).join(', ')}].`
 
       const collisionsHeader = 'Breakdown per colliding Salto ID:'

--- a/packages/adapter-utils/src/collisions.ts
+++ b/packages/adapter-utils/src/collisions.ts
@@ -100,6 +100,7 @@ export const getAndLogCollisionWarnings = async ({
   maxBreakdownDetailsElements = MAX_BREAKDOWN_DETAILS_ELEMENTS,
   baseUrl,
   docsUrl,
+  addChildrenMessage,
 }: {
   instances: InstanceElement[]
   getTypeName: (instance: InstanceElement) => Promise<string>
@@ -112,14 +113,16 @@ export const getAndLogCollisionWarnings = async ({
   maxBreakdownDetailsElements?: number
   baseUrl?: string
   docsUrl?: string
+  addChildrenMessage?: boolean
 }): Promise<SaltoError[]> => {
   const typeToElemIDtoInstances = await groupInstancesByTypeAndElemID(instances, getTypeName)
   await logInstancesWithCollidingElemID(typeToElemIDtoInstances)
   return Promise.all(Object.entries(typeToElemIDtoInstances)
     .map(async ([type, elemIDtoInstances]) => {
+      const childMessage = addChildrenMessage === true ? 'and all their child instances' : ''
       const numInstances = Object.values(elemIDtoInstances)
         .flat().length
-      const header = `Omitted ${numInstances} instances of ${type} due to Salto ID collisions.
+      const header = `Omitted ${numInstances} instances ${childMessage} of ${type} due to Salto ID collisions.
 Current Salto ID configuration for ${type} is defined as [${getIdFieldsByType(type).join(', ')}].`
 
       const collisionsHeader = 'Breakdown per colliding Salto ID:'

--- a/packages/zendesk-adapter/src/filters/collision_errors.ts
+++ b/packages/zendesk-adapter/src/filters/collision_errors.ts
@@ -13,12 +13,17 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { isInstanceElement, Element } from '@salto-io/adapter-api'
-import { config as configUtils } from '@salto-io/adapter-components'
-import { getAndLogCollisionWarnings, getInstancesWithCollidingElemID } from '@salto-io/adapter-utils'
+import { isInstanceElement, Element, isReferenceExpression } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { config as configUtils, filters } from '@salto-io/adapter-components'
+import { getAndLogCollisionWarnings, getInstancesWithCollidingElemID, getParents } from '@salto-io/adapter-utils'
+import _ from 'lodash'
 import { FilterCreator } from '../filter'
 import { ZENDESK } from '../constants'
 import { API_DEFINITIONS_CONFIG } from '../config'
+
+
+const log = logger(module)
 
 
 /**
@@ -27,10 +32,36 @@ import { API_DEFINITIONS_CONFIG } from '../config'
 const filterCreator: FilterCreator = ({ config }) => ({
   name: 'collisionErrorsFilter',
   onFetch: async (elements: Element[]) => {
-    const collistionWarnings = await getAndLogCollisionWarnings({
+    const collidingElements = getInstancesWithCollidingElemID(elements.filter(isInstanceElement))
+    const collidingElementsNames = new Set(collidingElements.map(e => e.elemID.getFullName()))
+    const graph = filters.createParentChildGraph(elements.filter(isInstanceElement))
+    const additionalIDsToRemove = graph.getComponent({
+      roots: collidingElements.map(e => e.elemID.getFullName()),
+      reverse: true,
+    })
+    const dependentRemovedInstances = _.remove(
+      elements,
+      element => additionalIDsToRemove.has(element.elemID.getFullName())
+        && !collidingElementsNames.has(element.elemID.getFullName())
+    )
+    const removedChildsByParent = _.groupBy(
+      dependentRemovedInstances.filter(removedInst => {
+        if (!isReferenceExpression(getParents(removedInst)[0])) {
+          log.error(`${removedInst.elemID.getFullName()} does not have a parent`)
+          return false
+        }
+        return true
+      }),
+      removedInst => getParents(removedInst)[0].elemID.getFullName()
+    )
+    const childWarning = Object.keys(removedChildsByParent)
+      .map(parent =>
+        `removed ${removedChildsByParent[parent].map(element => element.elemID.getFullName()).join(' , ')} as its parent ${parent} was removed due to collision of elemId`)
+    log.debug(`${childWarning.join('\n')}`)
+    const collisionWarnings = await getAndLogCollisionWarnings({
       adapterName: ZENDESK,
       configurationName: 'service',
-      instances: getInstancesWithCollidingElemID(elements.filter(isInstanceElement)),
+      instances: collidingElements,
       getTypeName: async instance => instance.elemID.typeName,
       // TODO fix it to use apiName once we have apiName
       getInstanceName: async instance => instance.elemID.name,
@@ -41,7 +72,7 @@ const filterCreator: FilterCreator = ({ config }) => ({
       idFieldsName: 'idFields',
       docsUrl: 'https://help.salto.io/en/articles/6927157-salto-id-collisions',
     })
-    return { errors: collistionWarnings }
+    return { errors: collisionWarnings }
   },
 })
 

--- a/packages/zendesk-adapter/src/filters/collision_errors.ts
+++ b/packages/zendesk-adapter/src/filters/collision_errors.ts
@@ -61,6 +61,7 @@ const filterCreator: FilterCreator = ({ config }) => ({
       ).idFields,
       idFieldsName: 'idFields',
       docsUrl: 'https://help.salto.io/en/articles/6927157-salto-id-collisions',
+      addChildrenMessage: true,
     })
     return { errors: collisionWarnings }
   },

--- a/packages/zendesk-adapter/src/filters/collision_errors.ts
+++ b/packages/zendesk-adapter/src/filters/collision_errors.ts
@@ -13,10 +13,10 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { isInstanceElement, Element, isReferenceExpression } from '@salto-io/adapter-api'
+import { isInstanceElement, Element, InstanceElement } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { config as configUtils, filters } from '@salto-io/adapter-components'
-import { getAndLogCollisionWarnings, getInstancesWithCollidingElemID, getParents } from '@salto-io/adapter-utils'
+import { getAndLogCollisionWarnings, getInstancesWithCollidingElemID } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { FilterCreator } from '../filter'
 import { ZENDESK } from '../constants'
@@ -24,6 +24,20 @@ import { API_DEFINITIONS_CONFIG } from '../config'
 
 
 const log = logger(module)
+const removeChildElements = (elements: Element[], collidingElements: InstanceElement[]): void => {
+  const collidingElementsNames = new Set(collidingElements.map(e => e.elemID.getFullName()))
+  const graph = filters.createParentChildGraph(elements.filter(isInstanceElement))
+  const additionalIDsToRemove = graph.getComponent({
+    roots: collidingElements.map(e => e.elemID.getFullName()),
+    reverse: true,
+  })
+  const dependentRemovedInstances = _.remove(
+    elements,
+    element => additionalIDsToRemove.has(element.elemID.getFullName())
+      && !collidingElementsNames.has(element.elemID.getFullName())
+  )
+  log.debug(`Instances removed because their parent was removed due to elemId collision: ${dependentRemovedInstances.map(inst => inst.elemID.getFullName()).join('\n')}`)
+}
 
 
 /**
@@ -33,31 +47,7 @@ const filterCreator: FilterCreator = ({ config }) => ({
   name: 'collisionErrorsFilter',
   onFetch: async (elements: Element[]) => {
     const collidingElements = getInstancesWithCollidingElemID(elements.filter(isInstanceElement))
-    const collidingElementsNames = new Set(collidingElements.map(e => e.elemID.getFullName()))
-    const graph = filters.createParentChildGraph(elements.filter(isInstanceElement))
-    const additionalIDsToRemove = graph.getComponent({
-      roots: collidingElements.map(e => e.elemID.getFullName()),
-      reverse: true,
-    })
-    const dependentRemovedInstances = _.remove(
-      elements,
-      element => additionalIDsToRemove.has(element.elemID.getFullName())
-        && !collidingElementsNames.has(element.elemID.getFullName())
-    )
-    const removedChildsByParent = _.groupBy(
-      dependentRemovedInstances.filter(removedInst => {
-        if (!isReferenceExpression(getParents(removedInst)[0])) {
-          log.error(`${removedInst.elemID.getFullName()} does not have a parent`)
-          return false
-        }
-        return true
-      }),
-      removedInst => getParents(removedInst)[0].elemID.getFullName()
-    )
-    const childWarning = Object.keys(removedChildsByParent)
-      .map(parent =>
-        `removed ${removedChildsByParent[parent].map(element => element.elemID.getFullName()).join(' , ')} as its parent ${parent} was removed due to collision of elemId`)
-    log.debug(`${childWarning.join('\n')}`)
+    removeChildElements(elements, collidingElements)
     const collisionWarnings = await getAndLogCollisionWarnings({
       adapterName: ZENDESK,
       configurationName: 'service',

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -1812,8 +1812,8 @@ describe('adapter', () => {
           severity: 'Warning',
           message: "Salto could not access the custom_statuses resource. Elements from that type were not fetched. Please make sure that this type is enabled in your service, and that the supplied user credentials have sufficient permissions to access this data. You can also exclude this data from Salto's fetches by changing the environment configuration. Learn more at https://help.salto.io/en/articles/6947061-salto-could-not-access-the-resource",
         })
-        expect(errors?.[1].message.split('.')[0]).toEqual('Omitted 2 instances of ticket_field due to Salto ID collisions')
-        expect(errors?.[2].message.split('.')[0]).toEqual('Omitted 4 instances of ticket_field__custom_field_options due to Salto ID collisions')
+        expect(errors?.[1].message.split('.')[0]).toEqual('Omitted 2 instances and all their child instances of ticket_field due to Salto ID collisions')
+        expect(errors?.[2].message.split('.')[0]).toEqual('Omitted 4 instances and all their child instances of ticket_field__custom_field_options due to Salto ID collisions')
         const elementsNames = elements.map(e => e.elemID.getFullName())
         expect(elementsNames).not.toContain('zendesk.custom_status.instance.new___zd_status_new__@u_00123_00123vu_00125_00125')
         expect(elementsNames).not.toContain('zendesk.custom_status.instance.open___zd_status_open__@u_00123_00123vu_00125_00125')
@@ -1902,8 +1902,8 @@ describe('adapter', () => {
           severity: 'Warning',
           message: 'Could not find any brands matching the included patterns: [BestBrand]. Please update the configuration under fetch.guide.brands in the configuration file',
         })
-        expect(fetchRes.errors?.[1].message.split('.')[0]).toEqual('Omitted 2 instances of ticket_field due to Salto ID collisions')
-        expect(fetchRes.errors?.[2].message.split('.')[0]).toEqual('Omitted 4 instances of ticket_field__custom_field_options due to Salto ID collisions')
+        expect(fetchRes.errors?.[1].message.split('.')[0]).toEqual('Omitted 2 instances and all their child instances of ticket_field due to Salto ID collisions')
+        expect(fetchRes.errors?.[2].message.split('.')[0]).toEqual('Omitted 4 instances and all their child instances of ticket_field__custom_field_options due to Salto ID collisions')
         expect(fetchRes.elements.filter(isInstanceElement).find(e => e.elemID.typeName === 'article')).not.toBeDefined()
         expect(fetchRes.elements.filter(isObjectType).find(e => e.elemID.typeName === 'article')).toBeDefined()
       })

--- a/packages/zendesk-adapter/test/filters/collision_errors.test.ts
+++ b/packages/zendesk-adapter/test/filters/collision_errors.test.ts
@@ -54,7 +54,7 @@ describe('collision errors', () => {
       expect(filterResult.errors).toHaveLength(1)
       expect(filterResult.errors?.[0]).toEqual({
         severity: 'Warning',
-        message: `Omitted 2 instances of obj due to Salto ID collisions.
+        message: `Omitted 2 instances and all their child instances of obj due to Salto ID collisions.
 Current Salto ID configuration for obj is defined as [name].
 
 Breakdown per colliding Salto ID:


### PR DESCRIPTION
remove child elements if their parent is omitted due to id collision

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
- child elements will be omitted when their parent is omitted due to elemId collision

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
