### PR TITLE
SALTO-4981: add env var that controls if we resolve types

### DIFF
--- a/packages/core/src/app_config.ts
+++ b/packages/core/src/app_config.ts
@@ -58,10 +58,6 @@ const telemetryDisabled = (): boolean => (
     && process.env.SALTO_TELEMETRY_DISABLE === '1') || telemetryURL() === ''
 )
 
-export const isAutoMergeDisabled = (): boolean => (
-  process.env.SALTO_AUTO_MERGE_DISABLE === '1'
-)
-
 const DEFAULT_TELEMETRY_CONFIG: TelemetryConfig = {
   url: telemetryURL(),
   token: telemetryToken(),

--- a/packages/core/src/core/adapters/adapters.ts
+++ b/packages/core/src/core/adapters/adapters.ts
@@ -35,6 +35,7 @@ import { logger } from '@salto-io/logging'
 import { createAdapterReplacedID, expressions, merger, updateElementsWithAlternativeAccount, elementSource as workspaceElementSource } from '@salto-io/workspace'
 import { collections, promises } from '@salto-io/lowerdash'
 import adapterCreators from './creators'
+import { CORE_FLAGS, getCoreFlagBool } from '../flags'
 
 const { awu } = collections.asynciterable
 const { mapValuesAsync } = promises.object
@@ -197,6 +198,10 @@ const filterElementsSource = (
 export const createResolvedTypesElementsSource = (
   elementsSource: ReadOnlyElementsSource
 ): ReadOnlyElementsSource => {
+  if (getCoreFlagBool(CORE_FLAGS.skipResolveTypesInElementSource)) {
+    return elementsSource
+  }
+
   let resolvedTypesPromise: Promise<Map<string, TypeElement>> | undefined
   const resolveTypes = async (): Promise<Map<string, TypeElement>> => {
     const typeElements = await awu(await elementsSource.list())

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -29,7 +29,7 @@ import { applyInstancesDefaults, resolvePath, flattenElementStr, buildElementsSo
 import { logger } from '@salto-io/logging'
 import { merger, elementSource, expressions, Workspace, pathIndex, updateElementsWithAlternativeAccount, createAdapterReplacedID, remoteMap, adaptersConfigSource as acs, createPathIndexForElement } from '@salto-io/workspace'
 import { collections, promises, types, values } from '@salto-io/lowerdash'
-import { isAutoMergeDisabled } from '../app_config'
+import { CORE_FLAGS, getCoreFlagBool } from './flags'
 import { StepEvents } from './deploy'
 import { getPlan, Plan } from './plan'
 import { AdapterEvents, createAdapterProgressReporter } from './adapters/progress'
@@ -207,7 +207,7 @@ const toMergedTextChange = (change: FetchChange, after: string | StaticFile): Fe
 })
 
 const autoMergeTextChange: ChangeTransformFunction = async change => {
-  if (isAutoMergeDisabled() || !isMergeableDiffChange(change)) {
+  if (getCoreFlagBool(CORE_FLAGS.autoMergeDisabled) || !isMergeableDiffChange(change)) {
     return [change]
   }
 

--- a/packages/core/src/core/flags.ts
+++ b/packages/core/src/core/flags.ts
@@ -1,0 +1,39 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { types } from '@salto-io/lowerdash'
+
+export const CORE_FLAG_PREFIX = 'SALTO_CORE_'
+
+export const CORE_FLAGS = {
+  skipResolveTypesInElementSource: 'SKIP_RESOLVE_TYPES_IN_ELEMENT_SOURCE',
+} as const
+
+type CoreFlagName = types.ValueOf<typeof CORE_FLAGS>
+
+export const getCoreFlag = (flagName: CoreFlagName): string | undefined => (
+  process.env[CORE_FLAG_PREFIX + flagName]
+)
+
+export const getCoreFlagBool = (flagName: CoreFlagName): boolean => {
+  const flagValue = getCoreFlag(flagName)
+  let parsedFlagValue: unknown
+  try {
+    parsedFlagValue = flagValue === undefined ? undefined : JSON.parse(flagValue)
+  } catch (e) {
+    parsedFlagValue = flagValue
+  }
+  return Boolean(parsedFlagValue)
+}

--- a/packages/core/src/core/flags.ts
+++ b/packages/core/src/core/flags.ts
@@ -15,10 +15,11 @@
 */
 import { types } from '@salto-io/lowerdash'
 
-export const CORE_FLAG_PREFIX = 'SALTO_CORE_'
+export const CORE_FLAG_PREFIX = 'SALTO_'
 
 export const CORE_FLAGS = {
   skipResolveTypesInElementSource: 'SKIP_RESOLVE_TYPES_IN_ELEMENT_SOURCE',
+  autoMergeDisabled: 'AUTO_MERGE_DISABLE',
 } as const
 
 type CoreFlagName = types.ValueOf<typeof CORE_FLAGS>

--- a/packages/core/test/core/flags.test.ts
+++ b/packages/core/test/core/flags.test.ts
@@ -1,0 +1,57 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { setupEnvVar } from '@salto-io/test-utils'
+import { getCoreFlag, getCoreFlagBool, CORE_FLAGS, CORE_FLAG_PREFIX } from '../../src/core/flags'
+
+describe('getCoreFlag', () => {
+  const flagName = CORE_FLAG_PREFIX + CORE_FLAGS.skipResolveTypesInElementSource
+
+  describe('when flag is not set', () => {
+    setupEnvVar(flagName, undefined)
+    it('should return undefined', () => {
+      expect(getCoreFlag(CORE_FLAGS.skipResolveTypesInElementSource)).toBeUndefined()
+    })
+  })
+  describe('when flag is set', () => {
+    setupEnvVar(flagName, 'true')
+    it('should return the flag value as a string', () => {
+      expect(getCoreFlag(CORE_FLAGS.skipResolveTypesInElementSource)).toEqual('true')
+    })
+  })
+})
+
+describe('getCoreFlagBool', () => {
+  const flagName = CORE_FLAG_PREFIX + CORE_FLAGS.skipResolveTypesInElementSource
+
+  describe('when flag is not set', () => {
+    setupEnvVar(flagName, undefined)
+    it('should return false', () => {
+      expect(getCoreFlagBool(CORE_FLAGS.skipResolveTypesInElementSource)).toBeFalse()
+    })
+  })
+  describe.each(['true', '1'])('when flag is set to truthy value %s', value => {
+    setupEnvVar(flagName, value)
+    it('should return true', () => {
+      expect(getCoreFlagBool(CORE_FLAGS.skipResolveTypesInElementSource)).toBeTrue()
+    })
+  })
+  describe.each(['false', '0'])('when flag is set to falsy value %s', value => {
+    setupEnvVar(flagName, value)
+    it('should return false', () => {
+      expect(getCoreFlagBool(CORE_FLAGS.skipResolveTypesInElementSource)).toBeFalse()
+    })
+  })
+})

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -15,3 +15,4 @@
 */
 export * from './mock'
 export * from './promise'
+export * from './setup_envvar'

--- a/packages/test-utils/src/setup_envvar.ts
+++ b/packages/test-utils/src/setup_envvar.ts
@@ -1,0 +1,46 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+export const setupEnvVar = (
+  name: string,
+  valueOrFactory: (
+    string | number | undefined | (() => string | number | undefined | Promise<string | number | undefined>)
+  ) = undefined,
+  setupType: 'each' | 'all' = 'each',
+): void => {
+  const [setupFunc, teardownFunc] = setupType === 'all' ? [beforeAll, afterAll] : [beforeEach, afterEach]
+
+  let savedValue: string | undefined
+  setupFunc(async () => {
+    const value = typeof valueOrFactory === 'function'
+      ? await valueOrFactory()
+      : valueOrFactory
+
+    savedValue = process.env[name]
+    if (value === undefined) {
+      delete process.env[name]
+    } else {
+      process.env[name] = String(value)
+    }
+  })
+
+  teardownFunc(() => {
+    if (savedValue === undefined) {
+      delete process.env[name]
+    } else {
+      process.env[name] = savedValue
+    }
+  })
+}

--- a/packages/test-utils/test/setup_envvar.test.ts
+++ b/packages/test-utils/test/setup_envvar.test.ts
@@ -1,0 +1,61 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { setupEnvVar } from '../src/setup_envvar'
+
+describe('setupEnvVar', () => {
+  const testEnvVarName = 'random_env_var_name_that_is_unlikely_to_exist'
+  describe('when value is defined before the setup', () => {
+    beforeAll(() => {
+      process.env[testEnvVarName] = 'value'
+    })
+    afterAll(() => {
+      expect(process.env[testEnvVarName]).toEqual('value')
+      delete process.env[testEnvVarName]
+    })
+    describe('when set as before each', () => {
+      describe('when set with undefined', () => {
+        setupEnvVar(testEnvVarName, undefined)
+        it('should unset an existing env var', () => {
+          expect(process.env[testEnvVarName]).toBeUndefined()
+          process.env[testEnvVarName] = 'mid'
+        })
+        it('should should unset between tests as well', () => {
+          expect(process.env[testEnvVarName]).toBeUndefined()
+        })
+      })
+      describe('when set with a value', () => {
+        setupEnvVar(testEnvVarName, () => 'test', 'each')
+        it('should set the value', () => {
+          expect(process.env[testEnvVarName]).toEqual('test')
+          process.env[testEnvVarName] = 'not test'
+        })
+        it('should re-set between tests', () => {
+          expect(process.env[testEnvVarName]).toEqual('test')
+        })
+      })
+    })
+  })
+  describe('when set as before all', () => {
+    setupEnvVar(testEnvVarName, 'all_val', 'all')
+    it('should set before the first test', () => {
+      expect(process.env[testEnvVarName]).toEqual('all_val')
+      process.env[testEnvVarName] = 'between_tests'
+    })
+    it('should not re-set between tests', () => {
+      expect(process.env[testEnvVarName]).toEqual('between_tests')
+    })
+  })
+})


### PR DESCRIPTION
added env var `SALTO_DISABLE_RESOLVE_TYPES_IN_ELEMENT_SOURCE` that allows skipping resolving types to be used in case of an emergency if we find this resolve is a problem

---

_Additional context for reviewer_

---
_Release Notes_: 
- Added environment flag `SALTO_DISABLE_RESOLVE_TYPES_IN_ELEMENT_SOURCE` that allows turning off type resolving in fetch / deploy

---
_User Notifications_: 
_None_