### PR TITLE
SALTO-5000 - Lower log level of duplicate file props in SF

### DIFF
--- a/packages/salesforce-adapter/src/filters/utils.ts
+++ b/packages/salesforce-adapter/src/filters/utils.ts
@@ -622,7 +622,7 @@ const removeDuplicateFileProps = (files: FileProperties[]): FileProperties[] => 
     uniques,
   } = splitDuplicates(files, fileProps => `${fileProps.namespacePrefix}__${fileProps.fullName}`)
   duplicates.forEach(props => {
-    log.warn('Found duplicate file props with the same name in response to listMetadataObjects: %o', props)
+    log.debug('Found duplicate file props with the same name in response to listMetadataObjects: %o', props)
   })
   return uniques.concat(duplicates.map(props => props[0]))
 }


### PR DESCRIPTION
Lower log level of duplicate file props in SF

---

_Additional context for reviewer_
This happens on every fetch for installed packages and is confusing readers of the log when it is a warn. Lowered to debug.

---
_Release Notes_: 
None.

---
_User Notifications_: 
None.