### PR TITLE
SALTO-4759 Add validation of dynamic content without default

### DIFF
--- a/packages/zendesk-adapter/test/change_validators/default_dynamic_content_item_variant.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/default_dynamic_content_item_variant.test.ts
@@ -102,4 +102,20 @@ describe('defaultDynamicContentItemVariantValidator', () => {
     const errors = await defaultDynamicContentItemVariantValidator(changes)
     expect(errors.length).toBe(0)
   })
+  it('should return an error on an addition of dynamic content item without a default variant', async () => {
+    const changes = [
+      toChange({ after: dynamicContentItem }),
+    ]
+    // notDefaultVariant to make sure it doesn't reach the error case
+    setDynamicContentItemVariants([notDefaultVariant])
+    const errors = await defaultDynamicContentItemVariantValidator(changes)
+    expect(errors).toMatchObject([
+      {
+        elemID: dynamicContentItem.elemID,
+        severity: 'Error',
+        message: 'Dynamic content item must have a default variant',
+        detailedMessage: `The dynamic content item '${dynamicContentItem.elemID.name}' must have a default variant. Please ensure that you select a variant of this dynamic content item as the default`,
+      },
+    ])
+  })
 })


### PR DESCRIPTION
Add validation of dynamic content without default

---

_Additional context for reviewer_

---
_Release Notes_: 
__Zendesk__
* Add validation to prevent addition of a dynamic content with no default variant.

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
