### PR TITLE
SALTO-5019: Support nestedPath in ducktypes

### DIFF
--- a/packages/adapter-components/src/elements/ducktype/standalone_field_extractor.ts
+++ b/packages/adapter-components/src/elements/ducktype/standalone_field_extractor.ts
@@ -68,7 +68,6 @@ const addFieldTypeAndInstances = async ({
   transformationConfigByType,
   transformationDefaultConfig,
   getElemIdFunc,
-  nestedPath,
 }: {
   adapterName: string
   typeName: string
@@ -78,7 +77,6 @@ const addFieldTypeAndInstances = async ({
   transformationConfigByType: Record<string, TransformationConfig>
   transformationDefaultConfig: TransformationDefaultConfig
   getElemIdFunc?: ElemIdGetter
-  nestedPath?: string[]
 }): Promise<Element[]> => {
   if (type.fields[fieldName] === undefined) {
     log.info('type %s field %s does not exist (maybe it is not populated by any of the instances), not extracting field', type.elemID.name, fieldName)
@@ -133,7 +131,7 @@ const addFieldTypeAndInstances = async ({
         transformationConfigByType,
         transformationDefaultConfig,
         getElemIdFunc,
-        nestedPath: [...(nestedPath ?? [type.elemID.name]), inst.elemID.name, fieldName],
+        nestedPath: [type.elemID.name, inst.elemID.name, fieldName],
       })
       if (fieldInstance === undefined) {
         // cannot happen
@@ -166,14 +164,12 @@ export const extractStandaloneFields = async ({
   transformationDefaultConfig,
   adapterName,
   getElemIdFunc,
-  nestedPath,
 }: {
   elements: Element[]
   transformationConfigByType: Record<string, TransformationConfig>
   transformationDefaultConfig: TransformationDefaultConfig
   adapterName: string
   getElemIdFunc?: ElemIdGetter
-  nestedPath?: string[]
 }): Promise<void> => {
   const allTypes = _.keyBy(elements.filter(isObjectType), e => e.elemID.name)
   const allInstancesbyType = _.groupBy(
@@ -212,7 +208,6 @@ export const extractStandaloneFields = async ({
           transformationConfigByType,
           transformationDefaultConfig,
           getElemIdFunc,
-          nestedPath,
         }))
       })
     })

--- a/packages/adapter-components/src/elements/ducktype/standalone_field_extractor.ts
+++ b/packages/adapter-components/src/elements/ducktype/standalone_field_extractor.ts
@@ -131,7 +131,10 @@ const addFieldTypeAndInstances = async ({
         transformationConfigByType,
         transformationDefaultConfig,
         getElemIdFunc,
-        nestedPath: [type.elemID.name, inst.elemID.name, fieldName],
+        nestedPath: [
+          ...inst.path?.slice(2, inst.path?.length - 1) ?? [],
+          fieldName,
+        ],
       })
       if (fieldInstance === undefined) {
         // cannot happen

--- a/packages/adapter-components/src/elements/ducktype/standalone_field_extractor.ts
+++ b/packages/adapter-components/src/elements/ducktype/standalone_field_extractor.ts
@@ -68,6 +68,7 @@ const addFieldTypeAndInstances = async ({
   transformationConfigByType,
   transformationDefaultConfig,
   getElemIdFunc,
+  nestedPath,
 }: {
   adapterName: string
   typeName: string
@@ -77,6 +78,7 @@ const addFieldTypeAndInstances = async ({
   transformationConfigByType: Record<string, TransformationConfig>
   transformationDefaultConfig: TransformationDefaultConfig
   getElemIdFunc?: ElemIdGetter
+  nestedPath?: string[]
 }): Promise<Element[]> => {
   if (type.fields[fieldName] === undefined) {
     log.info('type %s field %s does not exist (maybe it is not populated by any of the instances), not extracting field', type.elemID.name, fieldName)
@@ -131,6 +133,7 @@ const addFieldTypeAndInstances = async ({
         transformationConfigByType,
         transformationDefaultConfig,
         getElemIdFunc,
+        nestedPath: [...(nestedPath ?? [type.elemID.name]), inst.elemID.name, fieldName],
       })
       if (fieldInstance === undefined) {
         // cannot happen
@@ -163,12 +166,14 @@ export const extractStandaloneFields = async ({
   transformationDefaultConfig,
   adapterName,
   getElemIdFunc,
+  nestedPath,
 }: {
   elements: Element[]
   transformationConfigByType: Record<string, TransformationConfig>
   transformationDefaultConfig: TransformationDefaultConfig
   adapterName: string
   getElemIdFunc?: ElemIdGetter
+  nestedPath?: string[]
 }): Promise<void> => {
   const allTypes = _.keyBy(elements.filter(isObjectType), e => e.elemID.name)
   const allInstancesbyType = _.groupBy(
@@ -207,6 +212,7 @@ export const extractStandaloneFields = async ({
           transformationConfigByType,
           transformationDefaultConfig,
           getElemIdFunc,
+          nestedPath,
         }))
       })
     })

--- a/packages/adapter-components/src/elements/ducktype/transformer.ts
+++ b/packages/adapter-components/src/elements/ducktype/transformer.ts
@@ -287,6 +287,7 @@ export const getTypeAndInstances = async ({
   reversedSupportedTypes,
   customInstanceFilter,
   additionalRequestContext,
+  nestedPath,
 }: {
   adapterName: string
   typeName: string
@@ -301,6 +302,7 @@ export const getTypeAndInstances = async ({
   reversedSupportedTypes: Record<string, string[]>
   customInstanceFilter?: (instances: InstanceElement[]) => InstanceElement[]
   additionalRequestContext?: Record<string, unknown>
+  nestedPath?: string[]
 }): Promise<Element[]> => {
   const entries = await getEntriesForType({
     adapterName,
@@ -328,6 +330,7 @@ export const getTypeAndInstances = async ({
     transformationConfigByType,
     transformationDefaultConfig: typeDefaultConfig.transformation,
     getElemIdFunc,
+    nestedPath,
   })
   return elements
 }

--- a/packages/adapter-components/src/elements/ducktype/transformer.ts
+++ b/packages/adapter-components/src/elements/ducktype/transformer.ts
@@ -287,7 +287,6 @@ export const getTypeAndInstances = async ({
   reversedSupportedTypes,
   customInstanceFilter,
   additionalRequestContext,
-  nestedPath,
 }: {
   adapterName: string
   typeName: string
@@ -302,7 +301,6 @@ export const getTypeAndInstances = async ({
   reversedSupportedTypes: Record<string, string[]>
   customInstanceFilter?: (instances: InstanceElement[]) => InstanceElement[]
   additionalRequestContext?: Record<string, unknown>
-  nestedPath?: string[]
 }): Promise<Element[]> => {
   const entries = await getEntriesForType({
     adapterName,
@@ -330,7 +328,6 @@ export const getTypeAndInstances = async ({
     transformationConfigByType,
     transformationDefaultConfig: typeDefaultConfig.transformation,
     getElemIdFunc,
-    nestedPath,
   })
   return elements
 }

--- a/packages/adapter-components/test/elements/ducktype/standalone_field_extractor.test.ts
+++ b/packages/adapter-components/test/elements/ducktype/standalone_field_extractor.test.ts
@@ -55,6 +55,7 @@ describe('Extract standalone fields', () => {
           name: 'recipe123',
           code: jsonCode ? '{"flat":"a","nested":{"inner":"abc"}}' : { flat: 'a', nested: { inner: 'abc' } },
         },
+        [ADAPTER_NAME, 'Records', 'recipe', 'recipe123', 'recipe123']
       ),
       new InstanceElement(
         'recipe456',
@@ -63,6 +64,7 @@ describe('Extract standalone fields', () => {
           name: 'recipe456',
           code: jsonCode ? '{"nested":{"inner":"def","other":"ghi"}}' : { nested: { inner: 'def', other: 'ghi' } },
         },
+        [ADAPTER_NAME, 'Records', 'recipe', 'recipe456', 'recipe456']
       ),
       new InstanceElement(
         'book1',
@@ -188,9 +190,9 @@ describe('Extract standalone fields', () => {
       expect(Object.keys(recipeCode.fields)).toEqual(['flat', 'nested'])
       expect(Object.keys(recipeCodeNested.fields)).toEqual(['inner', 'other'])
       expect(recipe123Code.refType.elemID.isEqual(recipeCode.elemID)).toBeTruthy()
-      expect(recipe123Code.path).toEqual(['myAdapter', 'Records', 'recipe', 'recipe123', 'code', 'recipe123__unnamed_0'])
+      expect(recipe123Code.path).toEqual([ADAPTER_NAME, 'Records', 'recipe', 'recipe123', 'code', 'recipe123__unnamed_0'])
       expect(recipe456Code.refType.elemID.isEqual(recipeCode.elemID)).toBeTruthy()
-      expect(recipe456Code.path).toEqual(['myAdapter', 'Records', 'recipe', 'recipe456', 'code', 'recipe456__unnamed_0'])
+      expect(recipe456Code.path).toEqual([ADAPTER_NAME, 'Records', 'recipe', 'recipe456', 'code', 'recipe456__unnamed_0'])
 
       const origRecipe123 = origInstances[0]
       const origRecipe456 = origInstances[1]
@@ -271,6 +273,7 @@ describe('Extract standalone fields', () => {
           name: 'recipe123',
           code: [{ flat: 'a', nested: { inner: 'abc' } }, { flat: 'b', nested: { inner: 'abc' } }],
         },
+        [ADAPTER_NAME, 'Records', 'recipe', 'recipe123', 'recipe123']
       )
 
       return [recipeType, connectionType, instance]
@@ -306,8 +309,8 @@ describe('Extract standalone fields', () => {
       expect(recipe123Code1.refType.elemID.isEqual(recipeCode.elemID)).toBeTruthy()
       expect(recipe123Code2.refType.elemID.isEqual(recipeCode.elemID)).toBeTruthy()
 
-      expect(recipe123Code1.path).toEqual(['myAdapter', 'Records', 'recipe', 'recipe123', 'code', 'recipe123__unnamed_0'])
-      expect(recipe123Code2.path).toEqual(['myAdapter', 'Records', 'recipe', 'recipe123', 'code', 'recipe123__unnamed_1'])
+      expect(recipe123Code1.path).toEqual([ADAPTER_NAME, 'Records', 'recipe', 'recipe123', 'code', 'recipe123__unnamed_0'])
+      expect(recipe123Code2.path).toEqual([ADAPTER_NAME, 'Records', 'recipe', 'recipe123', 'code', 'recipe123__unnamed_1'])
 
       const origRecipe123 = origInstances[0]
 

--- a/packages/adapter-components/test/elements/ducktype/standalone_field_extractor.test.ts
+++ b/packages/adapter-components/test/elements/ducktype/standalone_field_extractor.test.ts
@@ -188,7 +188,9 @@ describe('Extract standalone fields', () => {
       expect(Object.keys(recipeCode.fields)).toEqual(['flat', 'nested'])
       expect(Object.keys(recipeCodeNested.fields)).toEqual(['inner', 'other'])
       expect(recipe123Code.refType.elemID.isEqual(recipeCode.elemID)).toBeTruthy()
+      expect(recipe123Code.path).toEqual(['myAdapter', 'Records', 'recipe', 'recipe123', 'code', 'recipe123__unnamed_0'])
       expect(recipe456Code.refType.elemID.isEqual(recipeCode.elemID)).toBeTruthy()
+      expect(recipe456Code.path).toEqual(['myAdapter', 'Records', 'recipe', 'recipe456', 'code', 'recipe456__unnamed_0'])
 
       const origRecipe123 = origInstances[0]
       const origRecipe456 = origInstances[1]
@@ -303,6 +305,9 @@ describe('Extract standalone fields', () => {
 
       expect(recipe123Code1.refType.elemID.isEqual(recipeCode.elemID)).toBeTruthy()
       expect(recipe123Code2.refType.elemID.isEqual(recipeCode.elemID)).toBeTruthy()
+
+      expect(recipe123Code1.path).toEqual(['myAdapter', 'Records', 'recipe', 'recipe123', 'code', 'recipe123__unnamed_0'])
+      expect(recipe123Code2.path).toEqual(['myAdapter', 'Records', 'recipe', 'recipe123', 'code', 'recipe123__unnamed_1'])
 
       const origRecipe123 = origInstances[0]
 


### PR DESCRIPTION
Added support for nestedPath in duckType when we recurse tInto.

---

None

---
_Release Notes_: 
None

---
_User Notifications_: 
None
