### PR TITLE
SALTO-5012: Okta e2e fails due to structure change in Application values

### DIFF
--- a/packages/okta-adapter/e2e_test/mock_elements.ts
+++ b/packages/okta-adapter/e2e_test/mock_elements.ts
@@ -101,6 +101,7 @@ export const mockDefaultValues: Record<string, Values> = {
         slo: {
           enabled: false,
         },
+        signOnMode: 'SAML_2_0',
       },
       manualProvisioning: false,
       implicitAssignment: false,


### PR DESCRIPTION
Okta now returns `signOnMode` field 2 places

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
