### PR TITLE
SALTO-5017: Add E2E for requestType requestForm and issueView

### DIFF
--- a/packages/jira-adapter/e2e_test/adapter.test.ts
+++ b/packages/jira-adapter/e2e_test/adapter.test.ts
@@ -35,7 +35,7 @@ const { replaceInstanceTypeForDeploy } = elementUtils.ducktype
 
 jest.setTimeout(600 * 1000)
 
-const excludedTypes = ['Behavior', 'Behavior__config', 'Form']
+const excludedTypes = ['Behavior', 'Behavior__config']
 
 each([
   ['Cloud', false],

--- a/packages/jira-adapter/e2e_test/instances/cloud/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/index.ts
@@ -42,6 +42,7 @@ import { createPortalGroupValues } from './jsm/portal_groups'
 import { createQueueValues } from './jsm/queue'
 import { createCalendarValues } from './jsm/calendar'
 import { createSLAValues } from './jsm/SLA'
+import { createrequestTypeValues } from './jsm/request_type'
 
 export const createInstances = (
   randomString: string,
@@ -216,6 +217,14 @@ export const createInstances = (
     { [CORE_ANNOTATIONS.PARENT]: [jsmProject] }
   )
 
+  const RequestType = new InstanceElement(
+    `${randomString}_SUP`,
+    findType('RequestType', fetchedElements),
+    createrequestTypeValues(randomString, fetchedElements),
+    undefined,
+    { [CORE_ANNOTATIONS.PARENT]: [jsmProject] }
+  )
+
   return [
     [dashboard],
     [dashboardGadget1],
@@ -241,6 +250,7 @@ export const createInstances = (
     [queue],
     [calendar],
     [SLA],
+    [RequestType],
   ]
 }
 

--- a/packages/jira-adapter/e2e_test/instances/cloud/jsm/request_type.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/jsm/request_type.ts
@@ -1,0 +1,68 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { ElemID, Values, Element } from '@salto-io/adapter-api'
+import { createReference } from '../../../utils'
+import { JIRA } from '../../../../src/constants'
+
+export const createrequestTypeValues = (name: string, allElements: Element[]): Values => ({
+  name,
+  description: 'testRequestTypeDescription',
+  helpText: 'testRequestTypeHelpCenter',
+  issueTypeId: createReference(new ElemID(JIRA, 'IssueType', 'instance', 'Emailed_request@s'), allElements),
+  workflowStatuses: [
+    {
+      id: createReference(new ElemID(JIRA, 'Status', 'instance', 'to_do@s'), allElements),
+      custom: 'toDoStatusTest',
+    },
+    {
+      id: createReference(new ElemID(JIRA, 'Status', 'instance', 'done'), allElements),
+      custom: 'doneStatusTest',
+    },
+    {
+      id: createReference(new ElemID(JIRA, 'Status', 'instance', 'in_progress@s'), allElements),
+      custom: 'inProgressStatusTest',
+    },
+  ],
+  avatarId: '10527',
+  issueView: {
+    issueLayoutConfig: {
+      items: [
+        {
+          type: 'FIELD',
+          sectionType: 'PRIMARY',
+          key: createReference(new ElemID(JIRA, 'Field', 'instance', 'Assignee__user'), allElements),
+        },
+      ],
+    },
+  },
+  requestForm: {
+    issueLayoutConfig: {
+      items: [
+        {
+          type: 'FIELD',
+          sectionType: 'REQUEST',
+          key: createReference(new ElemID(JIRA, 'Field', 'instance', 'Summary__string'), allElements),
+        },
+        {
+          type: 'FIELD',
+          sectionType: 'REQUEST',
+          key: createReference(new ElemID(JIRA, 'Field', 'instance', 'Description__string'), allElements),
+        },
+      ],
+    },
+  },
+})

--- a/packages/jira-adapter/src/filters/forms/forms.ts
+++ b/packages/jira-adapter/src/filters/forms/forms.ts
@@ -72,7 +72,7 @@ const deployForms = async (
 const filter: FilterCreator = ({ config, client, getElemIdFunc }) => ({
   name: 'formsFilter',
   onFetch: async elements => {
-    if (!config.fetch.enableJSM || !config.fetch.enableJsmExperimental) {
+    if (!config.fetch.enableJSM || client.isDataCenter) {
       return
     }
     const cloudId = await getCloudId(client)

--- a/packages/jira-adapter/test/filters/forms/forms.test.ts
+++ b/packages/jira-adapter/test/filters/forms/forms.test.ts
@@ -39,7 +39,6 @@ describe('forms filter', () => {
       beforeEach(async () => {
         const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
         config.fetch.enableJSM = true
-        config.fetch.enableJsmExperimental = true
         const { client: cli, connection: conn } = mockClient(true)
         connection = conn
         client = cli
@@ -161,22 +160,12 @@ describe('forms filter', () => {
         const formInstance = instances.find(e => e.elemID.typeName === FORM_TYPE)
         expect(formInstance).toBeUndefined()
       })
-      it('should not add forms to elements when enableJsmExperimental is false', async () => {
-        const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
-        config.fetch.enableJsmExperimental = false
-        filter = formsFilter(getFilterParams({ config, client })) as typeof filter
-        await filter.onFetch(elements)
-        const instances = elements.filter(isInstanceElement)
-        const formInstance = instances.find(e => e.elemID.typeName === FORM_TYPE)
-        expect(formInstance).toBeUndefined()
-      })
     })
     describe('deploy', () => {
       let formInstance: InstanceElement
       beforeEach(async () => {
         const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
         config.fetch.enableJSM = true
-        config.fetch.enableJsmExperimental = true
         const { client: cli, connection: conn } = mockClient(true)
         connection = conn
         client = cli
@@ -344,7 +333,6 @@ describe('forms filter', () => {
       it('should not deploy if enableJSM is false or enableJsmExperimental is false', async () => {
         const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
         config.fetch.enableJSM = false
-        config.fetch.enableJsmExperimental = false
         filter = formsFilter(getFilterParams({ config, client })) as typeof filter
         const res = await filter.deploy([{ action: 'add', data: { after: formInstance } }])
         expect(res.leftoverChanges).toHaveLength(1)
@@ -388,7 +376,6 @@ describe('forms filter', () => {
       beforeEach(async () => {
         const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
         config.fetch.enableJSM = true
-        config.fetch.enableJsmExperimental = true
         const { client: cli, connection: conn } = mockClient(true)
         connection = conn
         client = cli
@@ -509,7 +496,6 @@ describe('forms filter', () => {
       beforeEach(async () => {
         const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
         config.fetch.enableJSM = true
-        config.fetch.enableJsmExperimental = true
         const { client: cli, connection: conn } = mockClient(true)
         connection = conn
         client = cli


### PR DESCRIPTION
In this PR:
1. I added E2E for requestType requestForm and issueView.
2. I removed the `enableJsmExperimantal`. 
---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
