### PR TITLE
SALTO-5024: allow idFields fro support address to be username of email

### DIFF
--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -711,7 +711,7 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
       fieldsToHide: FIELDS_TO_HIDE.concat([
         { fieldName: 'id', fieldType: 'number' },
         { fieldName: 'domain_verification_code' },
-        { fieldName: 'username' },
+        { fieldName: 'username', fieldType: 'string' },
       ]),
     },
     deployRequests: {

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -711,6 +711,7 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
       fieldsToHide: FIELDS_TO_HIDE.concat([
         { fieldName: 'id', fieldType: 'number' },
         { fieldName: 'domain_verification_code' },
+        { fieldName: 'username' },
       ]),
     },
     deployRequests: {

--- a/packages/zendesk-adapter/src/filters/support_address.ts
+++ b/packages/zendesk-adapter/src/filters/support_address.ts
@@ -99,6 +99,7 @@ const extractUsernameFromEmail = (instance: InstanceElement): void => {
   const originalEmail = instance.value.email
   if (!_.isString(originalEmail)) {
     log.error(`email of ${instance.elemID.getFullName()} is not a string`)
+    instance.value.username = 'INVALID_USERNAME'
     return
   }
   const regex = /^([^@]+)/

--- a/packages/zendesk-adapter/src/filters/support_address.ts
+++ b/packages/zendesk-adapter/src/filters/support_address.ts
@@ -33,6 +33,7 @@ import { FilterCreator } from '../filter'
 import { BRAND_TYPE_NAME, SUPPORT_ADDRESS_TYPE_NAME } from '../constants'
 
 const log = logger(module)
+export const INVALID_USERNAME = 'INVALID_USERNAME'
 
 
 const referenceEmail = ({ emailPart, brandInstances }: {
@@ -99,24 +100,23 @@ const extractUsernameFromEmail = (instance: InstanceElement): void => {
   const originalEmail = instance.value.email
   if (!_.isString(originalEmail)) {
     log.error(`email of ${instance.elemID.getFullName()} is not a string`)
-    instance.value.username = 'INVALID_USERNAME'
+    instance.value.username = INVALID_USERNAME
     return
   }
-  const regex = /^([^@]+)/
-  const match = originalEmail.match(regex)
+  const splitEmail = originalEmail.split('@')
 
-  if (Array.isArray(match) && match[1] !== undefined) {
+  if (splitEmail[0] !== undefined) {
     // eslint-disable-next-line prefer-destructuring
-    instance.value.username = match[1]
+    instance.value.username = splitEmail[0]
     return
   }
-  instance.value.username = 'INVALID_USERNAME'
+  instance.value.username = INVALID_USERNAME
 }
 
 /**
  * 1. OnFetch and in onDeploy this filter turns the email in support_address to a template expression with a reference
  * to the brand's subdomain. only for zendesk emails. In preDeploy the template expressions are turned back to string.
- * 2. OnFetch, from the email username@subdomain.zendesk.com we will extranct the username to a hidden field
+ * 2. OnFetch, from the email username@subdomain.zendesk.com we will extract the username to a hidden field
  */
 const filterCreator: FilterCreator = () => {
   const deployTemplateMapping: Record<string, TemplateExpression> = {}

--- a/packages/zendesk-adapter/test/filters/support_address.test.ts
+++ b/packages/zendesk-adapter/test/filters/support_address.test.ts
@@ -78,7 +78,7 @@ describe('support address filter', () => {
     filter = filterCreator(createFilterCreatorParams({ elementsSource })) as FilterType
   })
   describe('onFetch', () => {
-    it('should turn zendesk emails to template expression', async () => {
+    it('should turn zendesk emails to template expression and add username', async () => {
       const elements = [
         supportAddressZendesk,
         supportAddressOther,
@@ -96,8 +96,12 @@ describe('support address filter', () => {
       if (zendeskAddress === undefined || otherAddress === undefined || undefinedAddress === undefined) {
         return
       }
-      expect(zendeskAddress).toEqual(supportAddressZendeskAfterFetch)
-      expect(otherAddress).toEqual(supportAddressOther)
+      const supportAddressZendeskAfterFetchCloned = supportAddressZendeskAfterFetch.clone()
+      supportAddressZendeskAfterFetchCloned.value.username = 'support.1'
+      const supportAddressOtherCloned = supportAddressOther.clone()
+      supportAddressOtherCloned.value.username = 'support1'
+      expect(zendeskAddress).toEqual(supportAddressZendeskAfterFetchCloned)
+      expect(otherAddress).toEqual(supportAddressOtherCloned)
       expect(undefinedAddress).toEqual(supportAddressUndefined)
     })
   })


### PR DESCRIPTION
allow idFields fro support address to be username of email

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* It is possible to add the email username as idField for support_address using `&username`.
---
_User Notifications_: 
None