### PR TITLE
SALTO-5025: Improve Retrieve Polling time out retry mechanism in Salesforce

### DIFF
--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -45,7 +45,7 @@ import { AccountInfo, CredentialError, Value } from '@salto-io/adapter-api'
 import {
   CUSTOM_OBJECT_ID_FIELD,
   DEFAULT_CUSTOM_OBJECTS_DEFAULT_RETRY_OPTIONS,
-  DEFAULT_MAX_CONCURRENT_API_REQUESTS,
+  DEFAULT_MAX_CONCURRENT_API_REQUESTS, POLLING_TIMEOUT_ERROR_CODE,
   SALESFORCE,
 } from '../constants'
 import { CompleteSaveResult, SalesforceRecord, SfError } from './types'
@@ -119,7 +119,6 @@ const errorMessagesToRetry = [
    * but in case there is another error that says "retry your request", probably we should retry it
    */
   'retry your request',
-  'Polling time out',
   'SERVER_UNAVAILABLE',
   'system may be currently unavailable',
   'Unexpected internal servlet state',
@@ -130,6 +129,10 @@ const errorMessagesToRetry = [
   'Internal_Error',
   'UNABLE_TO_LOCK_ROW', // we saw this in both fetch and deploy
 ]
+
+const isPollingTimeoutError = (error: unknown): error is Error => (
+  _.isError(error) && error.message.includes('Polling time out')
+)
 
 type RateLimitBucketName = keyof ClientRateLimitConfig
 
@@ -763,9 +766,25 @@ export default class SalesforceClient {
   @logDecorator()
   @requiresLogin()
   public async retrieve(retrieveRequest: RetrieveRequest): Promise<RetrieveResult> {
-    return flatValues(
-      await this.retryOnBadResponse(() => this.conn.metadata.retrieve(retrieveRequest).complete())
-    )
+    try {
+      return flatValues(
+        await this.retryOnBadResponse(() => this.conn.metadata.retrieve(retrieveRequest).complete())
+      )
+    } catch (error: unknown) {
+      if (isPollingTimeoutError(error)) {
+        log.debug('retrieve failed on Polling time out')
+        return {
+          errorStatusCode: POLLING_TIMEOUT_ERROR_CODE,
+          errorMessage: error.message,
+          fileProperties: [],
+          id: 'UNKNOWN',
+          messages: [],
+          zipFile: '',
+        }
+      }
+      log.debug('retrieve failed with unrecoverable error %o', error)
+      throw error
+    }
   }
 
   /**

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -495,6 +495,7 @@ export const SOCKET_TIMEOUT = 'ESOCKETTIMEDOUT'
 export const INVALID_GRANT = 'invalid_grant'
 export const ENOTFOUND = 'ENOTFOUND'
 export const ERROR_HTTP_502 = 'ERROR_HTTP_502'
+export const POLLING_TIMEOUT_ERROR_CODE = 'POLLING_TIMEOUT'
 
 export const ERROR_PROPERTIES = {
   MESSAGE: 'message',

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -54,7 +54,7 @@ import {
 } from './connection'
 import { FetchElements, MAX_ITEMS_IN_RETRIEVE_REQUEST } from '../src/types'
 import * as fetchModule from '../src/fetch'
-import { fetchMetadataInstances, retrieveMetadataInstances } from '../src/fetch'
+import { fetchMetadataInstances, HANDLED_RETRIEVE_ERROR_CODES, retrieveMetadataInstances } from '../src/fetch'
 import * as xmlTransformerModule from '../src/transformers/xml_transformer'
 import {
   CUSTOM_OBJECT,
@@ -1107,7 +1107,7 @@ public class MyClass${index} {
       })
     })
 
-    it('should not fail the fetch on instances too large', async () => {
+    it.each(HANDLED_RETRIEVE_ERROR_CODES)('should not fail the fetch on handled retrieve error %s', async errorStatusCode => {
       mockMetadataType(
         { xmlName: 'ApexClass', metaFile: true, suffix: 'cls', directoryName: 'classes' },
         {
@@ -1148,7 +1148,7 @@ public class LargeClass} {
 
       connection.metadata.retrieve.mockReset()
       connection.metadata.retrieve.mockReturnValue(mockRetrieveLocator({
-        errorStatusCode: constants.RETRIEVE_SIZE_LIMIT_ERROR,
+        errorStatusCode,
       }))
 
       const { elements: result, updatedConfig: config } = await adapter.fetch(mockFetchOpts)
@@ -1164,9 +1164,9 @@ public class LargeClass} {
       )
     })
 
-    it('should retry fetch with smaller batches if zip file is too large', async () => {
+    it.each(HANDLED_RETRIEVE_ERROR_CODES)('should retry fetch with smaller batches on error %s', async errorStatusCode => {
       connection.metadata.retrieve.mockReturnValueOnce(mockRetrieveLocator({
-        errorStatusCode: constants.RETRIEVE_SIZE_LIMIT_ERROR,
+        errorStatusCode,
       }))
 
       mockMetadataType(


### PR DESCRIPTION
This PR improves the retry mechanism of `Polling time out` upon retrieve of instances.

---

As more and more types have moved to retrieve, we may face issues with the times retrieve requests can take.
We see increasing amount of fetches that fail on **Polling time out** upon retrieve. I've used the retry mechanism of sending smaller chunks that was previously implemented by @yuribro for this scenario as-well.

As for the tests:
You can see what the **it.each** I've added translates to: 
![Screen Shot 2023-11-13 at 17 35 02](https://github.com/salto-io/salto/assets/92912659/05ec848f-0d30-4440-a7b6-41fc53c10046)


---
_Release Notes_: 
Salesforce Adapter:
- Improved the retry mechanism for Fetches that encounter Polling time out.

---
_User Notifications_: 
_None_
