### PR TITLE
Fix missing feature error detector in suiteapp file cabinet fetch

### DIFF
--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_file_cabinet.ts
@@ -169,7 +169,7 @@ export const SUITEBUNDLES_DISABLED_ERROR = 'Failed to list folders. Please verif
 
 
 export const THROW_ON_MISSING_FEATURE_ERROR: Record<string, string> = {
-  'Search error occurred: Unknown identifier \'bundleable\'': SUITEBUNDLES_DISABLED_ERROR,
+  'Unknown identifier \'bundleable\'': SUITEBUNDLES_DISABLED_ERROR,
 }
 
 export type SuiteAppFileCabinetOperations = {


### PR DESCRIPTION
the beginning of the error message is different per account language, so it prevents us from detecting that error. removing the language-specific text should be safe. 

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None