### PR TITLE
SALTO-4878: OAuth for Okta - part 1

### DIFF
--- a/packages/adapter-components/src/auth/index.ts
+++ b/packages/adapter-components/src/auth/index.ts
@@ -13,4 +13,4 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-export { oauthClientCredentialsBearerToken, OAuthClientCredentialsArgs } from './oauth'
+export { oauthClientCredentialsBearerToken, oauthAccessTokenRefresh, OAuthClientCredentialsArgs } from './oauth'

--- a/packages/adapter-components/src/auth/oauth.ts
+++ b/packages/adapter-components/src/auth/oauth.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import _ from 'lodash'
 import qs from 'qs'
 import axios, { AxiosRequestHeaders } from 'axios'
 import axiosRetry from 'axios-retry'
@@ -73,6 +74,54 @@ export const oauthClientCredentialsBearerToken = async ({
   const { token_type: tokenType, access_token: accessToken, expires_in: expiresIn } = res.data
   log.debug('received access token: type %s, expires in %s', tokenType, expiresIn)
   if (tokenType !== BEARER_TOKEN_TYPE) {
+    throw new Error(`Unsupported token type ${tokenType}`)
+  }
+  return {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  }
+}
+
+/**
+ * Refresh OAuth 2.0 accessToken using authorization code grant type.
+ */
+export const oauthAccessTokenRefresh = async ({
+  endpoint,
+  baseURL,
+  clientId,
+  clientSecret,
+  refreshToken,
+  retryOptions,
+}: {
+  endpoint: string
+  baseURL: string
+  clientId: string
+  clientSecret: string
+  refreshToken: string
+  retryOptions: RetryOptions
+}): Promise<{ headers?: AxiosRequestHeaders }> => {
+  const httpClient = axios.create({
+    baseURL,
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`, 'binary').toString('base64')}`,
+    },
+  })
+  axiosRetry(httpClient, retryOptions)
+
+  const res = await httpClient.post(
+    endpoint,
+    qs.stringify({
+      // eslint-disable-next-line camelcase
+      refresh_token: refreshToken,
+      // eslint-disable-next-line camelcase
+      grant_type: 'refresh_token',
+    }),
+  )
+  const { token_type: tokenType, access_token: accessToken, expires_in: expiresIn } = res.data
+  log.debug('refreshed access token: type %s, expires in %s', tokenType, expiresIn)
+  if (_.lowerCase(tokenType) !== BEARER_TOKEN_TYPE) {
     throw new Error(`Unsupported token type ${tokenType}`)
   }
   return {

--- a/packages/okta-adapter/src/adapter_creator.ts
+++ b/packages/okta-adapter/src/adapter_creator.ts
@@ -48,15 +48,20 @@ const {
 } = configUtils
 
 const credentialsFromConfig = (config: Readonly<InstanceElement>): Credentials => {
-  const { baseUrl, token } = config.value
+  const { baseUrl, authType } = config.value
   const hostName = new URL(baseUrl).hostname
   if (!hostName.includes(OKTA)) {
     throw new Error(`'${hostName}' is not a valid okta account url`)
   }
-  return {
-    baseUrl,
-    token,
-  }
+  return authType === 'oauth'
+    ? {
+      baseUrl,
+      accessToken: config.value.accessToken,
+      clientId: config.value.clientId,
+      clientSecret: config.value.clientSecret,
+      refreshToken: config.value.refreshToken,
+    }
+    : { baseUrl, token: config.value.token }
 }
 
 const adapterConfigFromConfig = (config: Readonly<InstanceElement> | undefined): OktaConfig => {

--- a/packages/okta-adapter/src/auth.ts
+++ b/packages/okta-adapter/src/auth.ts
@@ -24,8 +24,7 @@ export type AccessTokenCredentials = {
 
 export type OAuthAccessTokenCredentials = {
   baseUrl: string
-  accessToken: string
-  refreshToken?: string
+  refreshToken: string
   clientId: string
   clientSecret: string
 }
@@ -44,7 +43,7 @@ export const accessTokenCredentialsType = createMatchingObjectType<AccessTokenCr
   },
 })
 
-export const OAuthAccessTokenCredentialsType = createMatchingObjectType<
+export const oauthAccessTokenCredentialsType = createMatchingObjectType<
 OAuthAccessTokenCredentials
 >({
   elemID: new ElemID(constants.OKTA),
@@ -53,12 +52,9 @@ OAuthAccessTokenCredentials
       refType: BuiltinTypes.STRING,
       annotations: { _required: true },
     },
-    accessToken: {
-      refType: BuiltinTypes.STRING,
-      annotations: { _required: true },
-    },
     refreshToken: {
       refType: BuiltinTypes.STRING,
+      annotations: { _required: true },
     },
     clientId: {
       refType: BuiltinTypes.STRING,
@@ -76,4 +72,4 @@ export type Credentials = AccessTokenCredentials | OAuthAccessTokenCredentials
 export const isOAuthAccessTokenCredentials = (
   credentials: Credentials
 ): credentials is OAuthAccessTokenCredentials =>
-  'accessToken' in credentials
+  'refreshToken' in credentials

--- a/packages/okta-adapter/src/auth.ts
+++ b/packages/okta-adapter/src/auth.ts
@@ -22,6 +22,14 @@ export type AccessTokenCredentials = {
   token: string
 }
 
+export type OAuthAccessTokenCredentials = {
+  baseUrl: string
+  accessToken: string
+  refreshToken?: string
+  clientId: string
+  clientSecret: string
+}
+
 export const accessTokenCredentialsType = createMatchingObjectType<AccessTokenCredentials>({
   elemID: new ElemID(constants.OKTA),
   fields: {
@@ -36,4 +44,36 @@ export const accessTokenCredentialsType = createMatchingObjectType<AccessTokenCr
   },
 })
 
-export type Credentials = AccessTokenCredentials
+export const OAuthAccessTokenCredentialsType = createMatchingObjectType<
+OAuthAccessTokenCredentials
+>({
+  elemID: new ElemID(constants.OKTA),
+  fields: {
+    baseUrl: {
+      refType: BuiltinTypes.STRING,
+      annotations: { _required: true },
+    },
+    accessToken: {
+      refType: BuiltinTypes.STRING,
+      annotations: { _required: true },
+    },
+    refreshToken: {
+      refType: BuiltinTypes.STRING,
+    },
+    clientId: {
+      refType: BuiltinTypes.STRING,
+      annotations: { _required: true },
+    },
+    clientSecret: {
+      refType: BuiltinTypes.STRING,
+      annotations: { _required: true },
+    },
+  },
+})
+
+export type Credentials = AccessTokenCredentials | OAuthAccessTokenCredentials
+
+export const isOAuthAccessTokenCredentials = (
+  credentials: Credentials
+): credentials is OAuthAccessTokenCredentials =>
+  'accessToken' in credentials

--- a/packages/okta-adapter/src/client/connection.ts
+++ b/packages/okta-adapter/src/client/connection.ts
@@ -60,7 +60,7 @@ export const validateCredentials = async (_creds: {
   }
 }
 
-const APITokenAuthParamsFunc = (
+const apiTokenAuthParamsFunc = (
   { token }: AccessTokenCredentials
 ): clientUtils.AuthParams => ({
   headers: {
@@ -68,25 +68,19 @@ const APITokenAuthParamsFunc = (
   },
 })
 
-const OAuthAuthParamsFunc = async (
+const oauthAuthParamsFunc = async (
   creds: OAuthAccessTokenCredentials,
   retryOptions: clientUtils.RetryOptions,
 ): Promise<clientUtils.AuthParams> => {
-  const { baseUrl, clientId, clientSecret, refreshToken, accessToken } = creds
-  if (refreshToken !== undefined) {
-    return authUtils.oauthAccessTokenRefresh({
-      endpoint: '/oauth2/v1/token',
-      baseURL: baseUrl,
-      clientId,
-      clientSecret,
-      refreshToken,
-      retryOptions,
-    })
-  }
-  // if refreshToken in undefined, we might be able to use current accessToken
-  return {
-    headers: { Authorization: `Bearer ${accessToken}` },
-  }
+  const { baseUrl, clientId, clientSecret, refreshToken } = creds
+  return authUtils.oauthAccessTokenRefresh({
+    endpoint: '/oauth2/v1/token',
+    baseURL: baseUrl,
+    clientId,
+    clientSecret,
+    refreshToken,
+    retryOptions,
+  })
 }
 
 export const createConnection: clientUtils.ConnectionCreator<Credentials> = (
@@ -96,8 +90,8 @@ export const createConnection: clientUtils.ConnectionCreator<Credentials> = (
     retryOptions,
     authParamsFunc: async (creds: Credentials) => (
       isOAuthAccessTokenCredentials(creds)
-        ? OAuthAuthParamsFunc(creds, retryOptions)
-        : APITokenAuthParamsFunc(creds)
+        ? oauthAuthParamsFunc(creds, retryOptions)
+        : apiTokenAuthParamsFunc(creds)
     ),
     baseURLFunc: async ({ baseUrl }) => baseUrl,
     credValidateFunc: validateCredentials,

--- a/packages/okta-adapter/test/client/connection.test.ts
+++ b/packages/okta-adapter/test/client/connection.test.ts
@@ -15,7 +15,6 @@
 */
 import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
-import { mockFunction } from '@salto-io/test-utils'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { AccountInfo } from '@salto-io/adapter-api'
 import { createConnection, validateCredentials } from '../../src/client/connection'

--- a/packages/okta-adapter/test/client/connection.test.ts
+++ b/packages/okta-adapter/test/client/connection.test.ts
@@ -15,9 +15,23 @@
 */
 import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
+import { mockFunction } from '@salto-io/test-utils'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { AccountInfo } from '@salto-io/adapter-api'
 import { createConnection, validateCredentials } from '../../src/client/connection'
+
+const mockRefreshToken = jest.fn()
+jest.mock('@salto-io/adapter-components', () => {
+  const actual = jest.requireActual('@salto-io/adapter-components')
+  return {
+    ...actual,
+    auth: {
+      ...actual.auth,
+      oauthAccessTokenRefresh: jest.fn((...args) => mockRefreshToken(...args)),
+    },
+  }
+})
+
 
 describe('validateCredentials', () => {
   let mockAxios: MockAdapter
@@ -26,45 +40,98 @@ describe('validateCredentials', () => {
   beforeEach(async () => {
     mockAxios = new MockAdapter(axios)
     mockAxios.onGet('/api/v1/org').reply(200, { id: 'abc123', subdomain: 'my' })
-    connection = await createConnection({ retries: 1 }).login(
-      { baseUrl: 'http://my.okta.net', token: 'token' }
-    )
   })
   afterEach(() => {
     mockAxios.restore()
   })
 
-  describe('when authorized', () => {
-    let result: AccountInfo
-
+  describe('when autheticating with API token', () => {
     beforeEach(async () => {
-      result = await validateCredentials({
-        credentials: { baseUrl: 'http://my.okta.net', token: 'token' },
-        connection,
+      connection = await createConnection({ retries: 1 }).login(
+        { baseUrl: 'http://my.okta.net', token: 'token' }
+      )
+      mockRefreshToken.mockResolvedValue(
+        {
+          headers: {
+            Authorization: 'Bearer newAccessToken',
+          },
+        }
+      )
+    })
+    describe('when authorized', () => {
+      let result: AccountInfo
+
+      beforeEach(async () => {
+        result = await validateCredentials({
+          credentials: { baseUrl: 'http://my.okta.net', token: 'token' },
+          connection,
+        })
+      })
+
+      it('should get auth header', () => {
+        expect(mockAxios.history.get).toContainEqual(expect.objectContaining({
+          url: '/api/v1/org',
+          baseURL: 'http://my.okta.net',
+        }))
+        expect(mockAxios.history.get[0].headers).toEqual(expect.objectContaining({
+          Authorization: 'SSWS token',
+        }))
+      })
+
+      it('should return the org id from the response as account id', () => {
+        expect(result.accountId).toEqual('abc123')
       })
     })
 
-    it('should get auth header', () => {
-      expect(mockAxios.history.get).toContainEqual(expect.objectContaining({
-        url: '/api/v1/org',
-        baseURL: 'http://my.okta.net',
-      }))
-      expect(mockAxios.history.get[0].headers).toEqual(expect.objectContaining({
-        Authorization: 'SSWS token',
-      }))
-    })
-
-    it('should return the org id from the response as account id', () => {
-      expect(result.accountId).toEqual('abc123')
+    describe('when unauthorized', () => {
+      it('should throw Invalid Credentials Error', async () => {
+        mockAxios.onGet('/api/v1/org').reply(401)
+        await expect(
+          validateCredentials({ credentials: { baseUrl: 'http://my.okta.net', token: 'token' }, connection })
+        ).rejects.toThrow(new Error('Invalid Credentials'))
+      })
     })
   })
 
-  describe('when unauthorized', () => {
-    it('should throw Invalid Credentials Error', async () => {
-      mockAxios.onGet('/api/v1/org').reply(401)
-      await expect(
-        validateCredentials({ credentials: { baseUrl: 'http://my.okta.net', token: 'token' }, connection })
-      ).rejects.toThrow(new Error('Invalid Credentials'))
+  describe('when autheticating with oauth', () => {
+    beforeEach(async () => {
+      connection = await createConnection({ retries: 1 }).login(
+        { baseUrl: 'http://my.okta.net', accessToken: 'access_token', refreshToken: 'refresh_token', clientId: 'client', clientSecret: 'secret' }
+      )
+    })
+
+    describe('when authorized', () => {
+      let result: AccountInfo
+
+      beforeEach(async () => {
+        result = await validateCredentials({
+          credentials: { baseUrl: 'http://my.okta.net', accessToken: 'access_token', refreshToken: 'refresh_token', clientId: 'client', clientSecret: 'secret' },
+          connection,
+        })
+      })
+
+      it('should get auth header', () => {
+        expect(mockAxios.history.get).toContainEqual(expect.objectContaining({
+          url: '/api/v1/org',
+          baseURL: 'http://my.okta.net',
+        }))
+        expect(mockAxios.history.get[0].headers).toEqual(expect.objectContaining({
+          Authorization: 'Bearer newAccessToken',
+        }))
+      })
+
+      it('should return the org id from the response as account id', () => {
+        expect(result.accountId).toEqual('abc123')
+      })
+    })
+
+    describe('when unauthorized', () => {
+      it('should throw Invalid Credentials Error', async () => {
+        mockAxios.onGet('/api/v1/org').reply(401)
+        await expect(
+          validateCredentials({ credentials: { baseUrl: 'http://my.okta.net', token: 'token' }, connection })
+        ).rejects.toThrow(new Error('Invalid Credentials'))
+      })
     })
   })
 })

--- a/packages/okta-adapter/test/client/connection.test.ts
+++ b/packages/okta-adapter/test/client/connection.test.ts
@@ -95,7 +95,7 @@ describe('validateCredentials', () => {
   describe('when autheticating with oauth', () => {
     beforeEach(async () => {
       connection = await createConnection({ retries: 1 }).login(
-        { baseUrl: 'http://my.okta.net', accessToken: 'access_token', refreshToken: 'refresh_token', clientId: 'client', clientSecret: 'secret' }
+        { baseUrl: 'http://my.okta.net', refreshToken: 'refresh_token', clientId: 'client', clientSecret: 'secret' }
       )
     })
 
@@ -104,7 +104,7 @@ describe('validateCredentials', () => {
 
       beforeEach(async () => {
         result = await validateCredentials({
-          credentials: { baseUrl: 'http://my.okta.net', accessToken: 'access_token', refreshToken: 'refresh_token', clientId: 'client', clientSecret: 'secret' },
+          credentials: { baseUrl: 'http://my.okta.net', refreshToken: 'refresh_token', clientId: 'client', clientSecret: 'secret' },
           connection,
         })
       })


### PR DESCRIPTION
Change adapter code so it will be able to get `clientId`, `clientSecret`, `accessToken` and `refreshToken`, as credentials, and refresh access token a create connection with it.
This code is enough to start implementing OAUTH in saas, but we will need to make adjustment to support oauth flow for OSS.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
