### PR TITLE
SALTO-4283: update fetch warning about unknown author id

### DIFF
--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -1884,7 +1884,7 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
       ),
       fieldTypeOverrides: [
         { fieldName: 'id', fieldType: 'number' },
-        { fieldName: 'author_id', fieldType: 'string' },
+        { fieldName: 'author_id', fieldType: 'unknown' },
         { fieldName: 'translations', fieldType: 'list<article_translation>' },
         { fieldName: 'attachments', fieldType: 'list<article_attachment>' },
       ],


### PR DESCRIPTION
update fetch warning about unknown author id

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* When the 'author_id' in articles is a numerical value, we will no longer generate a fetch warning.

---
_User Notifications_: 
None
