### PR TITLE
SALTO-5030: fix template expressions in zendesk

### DIFF
--- a/packages/zendesk-adapter/src/filters/article/article_body.ts
+++ b/packages/zendesk-adapter/src/filters/article/article_body.ts
@@ -23,6 +23,7 @@ import {
 import {
   applyFunctionToChangeData,
   compactTemplate,
+  createTemplateExpression,
   extractTemplate,
   getParent,
   replaceTemplatesWithValues,
@@ -88,7 +89,7 @@ const updateArticleTranslationBody = ({
   // Find the urls that are in the body
   const processedTranslationBodyParts = originalTranslationBodyParts.map(part =>
     (isReferenceExpression(part)
-      ? new TemplateExpression({ parts: [part] })
+      ? createTemplateExpression({ parts: [part] })
       : extractTemplate(
         part,
         [URL_REGEX],
@@ -131,7 +132,7 @@ const updateArticleTranslationBody = ({
         }
       )))
 
-  const processedTranslationBody = new TemplateExpression({ parts:
+  const processedTranslationBody = createTemplateExpression({ parts:
     processedTranslationBodyParts.flatMap(part => (_.isString(part) ? [part] : part.parts)) })
   translationInstance.value.body = compactTemplate(processedTranslationBody)
   return _.isEmpty(missingBrands) ? [] : _.unionBy(missingBrands, obj => obj.brandName)

--- a/packages/zendesk-adapter/src/filters/custom_objects/utils.ts
+++ b/packages/zendesk-adapter/src/filters/custom_objects/utils.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { InstanceElement, isReferenceExpression, ReferenceExpression, TemplateExpression } from '@salto-io/adapter-api'
-import { compactTemplate, isResolvedReferenceExpression } from '@salto-io/adapter-utils'
+import { compactTemplate, createTemplateExpression, isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { references as referencesUtils } from '@salto-io/adapter-components'
 import {
   CUSTOM_OBJECT_FIELD_TYPE_NAME,
@@ -68,7 +68,7 @@ type TransformResult = {
 }
 
 const buildFieldTemplate = (ticketField: string | ReferenceExpression, option: string | ReferenceExpression)
-  : TemplateExpression => new TemplateExpression({
+  : TemplateExpression => createTemplateExpression({
   parts: [
     'lookup:ticket.ticket_field_',
     ticketField,
@@ -155,7 +155,7 @@ export const transformCustomObjectLookupField = ({
 }
 
 const buildFilterTemplate = (customObject: string | ReferenceExpression, field: string | ReferenceExpression)
-  : TemplateExpression => new TemplateExpression({
+  : TemplateExpression => createTemplateExpression({
   parts: [
     'custom_object.',
     customObject,

--- a/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
@@ -17,7 +17,13 @@ import {
   Change, Element, getChangeData, InstanceElement, isInstanceElement, isReferenceExpression, isTemplateExpression,
   ReferenceExpression, TemplateExpression, TemplatePart, UnresolvedReference, Values,
 } from '@salto-io/adapter-api'
-import { extractTemplate, TemplateContainer, replaceTemplatesWithValues, resolveTemplates } from '@salto-io/adapter-utils'
+import {
+  extractTemplate,
+  TemplateContainer,
+  replaceTemplatesWithValues,
+  resolveTemplates,
+  createTemplateExpression,
+} from '@salto-io/adapter-utils'
 import { references as referencesUtils } from '@salto-io/adapter-components'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
@@ -385,7 +391,7 @@ const replaceFormulasWithTemplates = ({
       })
       return isTemplateExpression(template) ? template.parts : template
     })
-    return new TemplateExpression({ parts: newParts })
+    return createTemplateExpression({ parts: newParts })
   }
 
   // If a string is a JSON, and it has keys of 'id' with a numeric value - try to convert it to a reference

--- a/packages/zendesk-adapter/src/filters/side_conversation.ts
+++ b/packages/zendesk-adapter/src/filters/side_conversation.ts
@@ -18,13 +18,13 @@ import {
   InstanceElement,
   isInstanceElement,
   ReferenceExpression,
-  TemplateExpression,
   Value,
 } from '@salto-io/adapter-api'
 import { references as referencesUtils } from '@salto-io/adapter-components'
 import _ from 'lodash'
 import joi from 'joi'
 import { logger } from '@salto-io/logging'
+import { createTemplateExpression } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../filter'
 import { GROUP_TYPE_NAME, ZENDESK } from '../constants'
 import { FETCH_CONFIG, ZendeskConfig } from '../config'
@@ -76,7 +76,7 @@ export const sideConversationsOnFetch = (elements: Element[], config: ZendeskCon
           const missingInstance = createMissingInstance(ZENDESK, GROUP_TYPE_NAME, groupId)
           missingInstance.value.id = groupId
           // Replace the group part with a missing reference
-          action.value[2] = new TemplateExpression({
+          action.value[2] = createTemplateExpression({
             parts: [
               prefix,
               new ReferenceExpression(missingInstance.elemID, missingInstance),
@@ -90,7 +90,7 @@ export const sideConversationsOnFetch = (elements: Element[], config: ZendeskCon
       // Type check is done in the if statement above
       const group = groupsById[groupId] as InstanceElement
       // Replace the group part with a reference expression
-      action.value[2] = new TemplateExpression({ parts: [
+      action.value[2] = createTemplateExpression({ parts: [
         prefix,
         new ReferenceExpression(group.elemID, group),
         suffix,

--- a/packages/zendesk-adapter/src/filters/side_conversation.ts
+++ b/packages/zendesk-adapter/src/filters/side_conversation.ts
@@ -81,7 +81,7 @@ export const sideConversationsOnFetch = (elements: Element[], config: ZendeskCon
               prefix,
               new ReferenceExpression(missingInstance.elemID, missingInstance),
               suffix,
-            ].filter(part => !_.isEmpty(part)),
+            ],
           })
         }
         return
@@ -94,7 +94,7 @@ export const sideConversationsOnFetch = (elements: Element[], config: ZendeskCon
         prefix,
         new ReferenceExpression(group.elemID, group),
         suffix,
-      ].filter(part => !_.isEmpty(part)) })
+      ] })
     })
   })
 }

--- a/packages/zendesk-adapter/src/filters/side_conversation.ts
+++ b/packages/zendesk-adapter/src/filters/side_conversation.ts
@@ -81,7 +81,7 @@ export const sideConversationsOnFetch = (elements: Element[], config: ZendeskCon
               prefix,
               new ReferenceExpression(missingInstance.elemID, missingInstance),
               suffix,
-            ],
+            ].filter(part => !_.isEmpty(part)),
           })
         }
         return
@@ -94,7 +94,7 @@ export const sideConversationsOnFetch = (elements: Element[], config: ZendeskCon
         prefix,
         new ReferenceExpression(group.elemID, group),
         suffix,
-      ] })
+      ].filter(part => !_.isEmpty(part)) })
     })
   })
 }

--- a/packages/zendesk-adapter/test/filters/side_conversation.test.ts
+++ b/packages/zendesk-adapter/test/filters/side_conversation.test.ts
@@ -51,8 +51,8 @@ describe('sideConversationFilter', () => {
 
     await filter.onFetch([group, trigger, macro])
 
-    expect(trigger.value.actions[0].value[2]).toEqual({ parts: ['SupportAssignable:support_assignable/group/', new ReferenceExpression(group.elemID, group), ''] })
-    expect(macro.value.actions[0].value[2]).toEqual({ parts: ['SupportAssignable:support_assignable/group/', new ReferenceExpression(group.elemID, group), ''] })
+    expect(trigger.value.actions[0].value[2]).toEqual({ parts: ['SupportAssignable:support_assignable/group/', new ReferenceExpression(group.elemID, group)] })
+    expect(macro.value.actions[0].value[2]).toEqual({ parts: ['SupportAssignable:support_assignable/group/', new ReferenceExpression(group.elemID, group)] })
   })
   it('should replace group_id with missing reference when group does not exists', async () => {
     const instanceValue = createInstanceValue([


### PR DESCRIPTION
fix side conversation group template expression

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* remove empty strings from side conversation group template expressions

---
_User Notifications_: 
None
