### PR TITLE
SALTO-4517: only resolve types in fetch, not in deploy

### DIFF
--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -1236,6 +1236,7 @@ export const getFetchAdapterAndServicesSetup = async (
         awu(await elementsSource.getAll()).filter(e => e.elemID.adapter === account),
         workspace.state()
       ))
+  const resolveTypes = !getCoreFlagBool(CORE_FLAGS.skipResolveTypesInElementSource)
   const adaptersCreatorConfigs = await getAdaptersCreatorConfigs(
     fetchServices,
     await workspace.accountCredentials(fetchServices),
@@ -1243,6 +1244,7 @@ export const getFetchAdapterAndServicesSetup = async (
     elementsSource,
     accountToServiceNameMap,
     elemIDGetters,
+    resolveTypes,
   )
   const currentConfigs = Object.values(adaptersCreatorConfigs)
     .map(creatorConfig => creatorConfig.config)


### PR DESCRIPTION
The original implementation was meant to only [affect fetch operations](https://salto-io.atlassian.net/browse/SALTO-4517?focusedCommentId=93101) Since it uses a cache, it must not be used in deploy where the underlying element source changes

---

_Additional context for reviewer_
We haven't seen a bug directly from the original reason why this shouldn't be used in deploy, but we did see a possibly related bug in zendesk deployments.
we should still get to the bottom of the the possibly related bug probably, but changing the implementation here because regardless of the other bug, caching elements in deploy could lead to incorrect behavior when deploying ObjectType elements

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_