### PR TITLE
SALTO-5013 - Salesforce: Report progress during deploy

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -75,6 +75,7 @@ export type FetchOptions = {
 }
 
 export type DeployOptions = {
+  progressReporter?: ProgressReporter
   changeGroup: ChangeGroup
 }
 

--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -75,7 +75,7 @@ export type FetchOptions = {
 }
 
 export type DeployOptions = {
-  progressReporter?: ProgressReporter
+  progressReporter: ProgressReporter
   changeGroup: ChangeGroup
 }
 

--- a/packages/cli/e2e_test/helpers/salesforce.ts
+++ b/packages/cli/e2e_test/helpers/salesforce.ts
@@ -22,7 +22,9 @@ import SalesforceAdapter, {
 // eslint-disable-next-line no-restricted-imports
 import { testHelpers as salesforceTestHelpers, testTypes as salesforceTestTypes } from '@salto-io/salesforce-adapter/dist/e2e_test/jest_environment'
 import _ from 'lodash'
-import { InstanceElement, ElemID, ObjectType, ChangeGroup, getChangeData } from '@salto-io/adapter-api'
+import {
+  InstanceElement, ElemID, ObjectType, ChangeGroup, getChangeData, ProgressReporter,
+} from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 
 export const naclNameToSFName = (objName: string): string => `${objName}__c`
@@ -101,6 +103,10 @@ export const getSalesforceClient = (credentials: UsernamePasswordCredentials): S
   })
 )
 
+const nullProgressReporter: ProgressReporter = {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  reportProgress: () => {},
+}
 export const addElements = async <T extends InstanceElement | ObjectType>(
   client: SalesforceClient,
   elements: T[]
@@ -112,7 +118,7 @@ export const addElements = async <T extends InstanceElement | ObjectType>(
     groupID: elements[0].elemID.getFullName(),
     changes: elements.map(e => ({ action: 'add', data: { after: e } })),
   }
-  const deployResult = await adapter.deploy({ changeGroup })
+  const deployResult = await adapter.deploy({ changeGroup, progressReporter: nullProgressReporter })
   if (deployResult.errors.length > 0) {
     throw new Error(`Failed to remove elements with: ${deployResult.errors.join('\n')}`)
   }
@@ -131,7 +137,7 @@ export const removeElements = async <T extends InstanceElement | ObjectType>(
     groupID: elements[0].elemID.getFullName(),
     changes: elements.map(e => ({ action: 'remove', data: { before: e } })),
   }
-  const deployResult = await adapter.deploy({ changeGroup })
+  const deployResult = await adapter.deploy({ changeGroup, progressReporter: nullProgressReporter })
   if (deployResult.errors.length > 0) {
     throw new Error(`Failed to remove elements with: ${deployResult.errors.join('\n')}`)
   }

--- a/packages/dummy-adapter/test/adapter.test.ts
+++ b/packages/dummy-adapter/test/adapter.test.ts
@@ -20,7 +20,7 @@ import {
   InstanceElement,
   getChangeData,
   isInstanceElement,
-  isObjectType, CORE_ANNOTATIONS,
+  isObjectType, CORE_ANNOTATIONS, ProgressReporter,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import DummyAdapter from '../src/adapter'
@@ -42,6 +42,10 @@ const objType = new ObjectType({
 const myInst1Change = toChange({ before: new InstanceElement('myIns1', objType) })
 const myInst2Change = toChange({ before: new InstanceElement('myIns2', objType) })
 
+const nullProgressReporter: ProgressReporter = {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  reportProgress: () => {},
+}
 
 describe('dummy adapter', () => {
   const adapter = new DummyAdapter(testParams)
@@ -50,7 +54,7 @@ describe('dummy adapter', () => {
       expect(adapter.deploy).toBeDefined()
     })
     it('should do nothing', async () => {
-      expect(await adapter.deploy({ changeGroup: { changes: [], groupID: ':)' } })).toEqual({
+      expect(await adapter.deploy({ changeGroup: { changes: [], groupID: ':)' }, progressReporter: nullProgressReporter })).toEqual({
         appliedChanges: [],
         errors: [],
       })
@@ -66,7 +70,10 @@ describe('dummy adapter', () => {
         type,
         { fieldToOmit: 'val1', field2: 'val2' }
       )
-      const res = await adapter.deploy({ changeGroup: { changes: [toChange({ after: instance })], groupID: ':)' } })
+      const res = await adapter.deploy({
+        changeGroup: { changes: [toChange({ after: instance })], groupID: ':)' },
+        progressReporter: nullProgressReporter,
+      })
 
       const appliedInstance = getChangeData(res.appliedChanges[0]) as InstanceElement
 
@@ -78,7 +85,7 @@ describe('dummy adapter', () => {
       expect(adapter.validate).toBeDefined()
     })
     it('should do nothing', async () => {
-      expect(await adapter.validate({ changeGroup: { changes: [], groupID: ':)' } })).toEqual({
+      expect(await adapter.validate({ changeGroup: { changes: [], groupID: ':)' }, progressReporter: nullProgressReporter })).toEqual({
         appliedChanges: [],
         errors: [],
       })

--- a/packages/jira-adapter/e2e_test/adapter.test.ts
+++ b/packages/jira-adapter/e2e_test/adapter.test.ts
@@ -13,9 +13,11 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { DeployResult, Element, getChangeData, InstanceElement, isAdditionChange, isInstanceElement, isObjectType,
-  ModificationChange,
-  ReadOnlyElementsSource, toChange } from '@salto-io/adapter-api'
+import {
+  DeployResult, Element, getChangeData, InstanceElement, isAdditionChange, isInstanceElement, isObjectType,
+  ModificationChange, ProgressReporter,
+  ReadOnlyElementsSource, toChange,
+} from '@salto-io/adapter-api'
 import { elements as elementUtils } from '@salto-io/adapter-components'
 import { CredsLease } from '@salto-io/e2e-credentials-store'
 import { buildElementsSourceFromElements, getParents, resolveValues } from '@salto-io/adapter-utils'
@@ -38,6 +40,10 @@ jest.setTimeout(600 * 1000)
 
 const excludedTypes = ['Behavior', 'Behavior__config', ASSESTS_SCHEMA_TYPE, 'AssetsSchemas', 'AssetsStatuses', 'AssetsStatus', 'AssetsObjectTypes', ASSETS_OBJECT_TYPE, ASSETS_ATTRIBUTE_TYPE]
 
+const nullProgressReporter: ProgressReporter = {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  reportProgress: () => {},
+}
 each([
   ['Cloud', false],
   ['Data Center', true],
@@ -135,6 +141,7 @@ each([
             groupID: group[0].elemID.getFullName(),
             changes: group.map(instance => toChange({ after: instance })),
           },
+          progressReporter: nullProgressReporter,
         })
 
         res.appliedChanges.forEach(appliedChange => {
@@ -158,6 +165,7 @@ each([
             groupID: group[0].data.after.elemID.getFullName(),
             changes: group,
           },
+          progressReporter: nullProgressReporter,
         })
 
         res.appliedChanges.forEach(appliedChange => {
@@ -248,6 +256,7 @@ each([
             groupID: getChangeData(change).elemID.getFullName(),
             changes: [change],
           },
+          progressReporter: nullProgressReporter,
         })))
 
       const errors = addDeployResults.flatMap(res => res.errors)

--- a/packages/jira-adapter/test/adapter.test.ts
+++ b/packages/jira-adapter/test/adapter.test.ts
@@ -62,6 +62,11 @@ describe('adapter', () => {
   let adapter: AdapterOperations
   let getElemIdFunc: ElemIdGetter
 
+  const nullProgressReporter: ProgressReporter = {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    reportProgress: () => {},
+  }
+
   beforeEach(() => {
     const elementsSource = buildElementsSourceFromElements([])
     getElemIdFunc = (adapterName: string, _serviceIds: ServiceIds, name: string): ElemID =>
@@ -103,6 +108,7 @@ describe('adapter', () => {
             toChange({ before: new InstanceElement('inst2', fieldConfigurationIssueTypeItemType) }),
           ],
         },
+        progressReporter: nullProgressReporter,
       })
 
       expect(deployRes.appliedChanges).toEqual([
@@ -129,6 +135,7 @@ describe('adapter', () => {
             }),
           ],
         },
+        progressReporter: nullProgressReporter,
       })
 
       expect(deployChangeMock).toHaveBeenCalledWith({
@@ -154,6 +161,7 @@ describe('adapter', () => {
             toChange({ before: new InstanceElement('inst2', fieldConfigurationIssueTypeItemType) }),
           ],
         },
+        progressReporter: nullProgressReporter,
       })
       expect(deployRes.errors).toEqual([
         {
@@ -178,6 +186,7 @@ describe('adapter', () => {
             toChange({ after: instance }),
           ],
         },
+        progressReporter: nullProgressReporter,
       })
 
       expect((getChangeData(appliedChanges[0]) as InstanceElement)?.value.id).toEqual(2)
@@ -192,6 +201,7 @@ describe('adapter', () => {
             toChange({ after: instance }),
           ],
         },
+        progressReporter: nullProgressReporter,
       })
 
       expect((getChangeData(appliedChanges[0]) as InstanceElement)?.value.id).toBeUndefined()

--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -21,7 +21,7 @@ import {
   toChange, FetchResult, InstanceElement, ReferenceExpression, isReferenceExpression,
   Element, DeployResult, Values, isStaticFile, StaticFile, FetchOptions, Change,
   ChangeId, ChangeGroupId, ElemID, ChangeError, getChangeData, ObjectType, BuiltinTypes,
-  isInstanceElement, CORE_ANNOTATIONS, Field, isObjectType,
+  isInstanceElement, CORE_ANNOTATIONS, Field, isObjectType, ProgressReporter,
 } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements, findElement, naclCase } from '@salto-io/adapter-utils'
 import { MockInterface } from '@salto-io/test-utils'
@@ -58,6 +58,11 @@ const logging = (message: string): void => {
     // eslint-disable-next-line no-console
     console.log(message)
   }
+}
+
+const nullProgressReporter: ProgressReporter = {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  reportProgress: () => {},
 }
 
 describe('Netsuite adapter E2E with real account', () => {
@@ -393,6 +398,7 @@ describe('Netsuite adapter E2E with real account', () => {
         logMessage(`running deploy for group ${id} with ${group.length} changes`)
         const result = await nsAdapter.deploy({
           changeGroup: { groupID: id, changes: group },
+          progressReporter: nullProgressReporter,
         })
         updateInternalIds(result.appliedChanges)
         return result
@@ -482,7 +488,10 @@ describe('Netsuite adapter E2E with real account', () => {
       let deployResult: DeployResult
       beforeAll(async () => {
         logMessage(`running deploy for group SDF with ${changes.length} changes`)
-        deployResult = await adapter.deploy({ changeGroup: { groupID: SDF_CREATE_OR_UPDATE_GROUP_ID, changes } })
+        deployResult = await adapter.deploy({
+          changeGroup: { groupID: SDF_CREATE_OR_UPDATE_GROUP_ID, changes },
+          progressReporter: nullProgressReporter,
+        })
       })
 
       it('should deploy new records that depend on existing ones', async () => {

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -14,8 +14,11 @@
 * limitations under the License.
 */
 
-import { ElemID, InstanceElement, StaticFile, ChangeDataType, DeployResult,
-  getChangeData, FetchOptions, ObjectType, Change, isObjectType, toChange, BuiltinTypes, SaltoError, SaltoElementError } from '@salto-io/adapter-api'
+import {
+  ElemID, InstanceElement, StaticFile, ChangeDataType, DeployResult,
+  getChangeData, FetchOptions, ObjectType, Change, isObjectType, toChange, BuiltinTypes, SaltoError, SaltoElementError,
+  ProgressReporter,
+} from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { mockFunction, MockInterface } from '@salto-io/test-utils'
@@ -93,6 +96,11 @@ const secondDummyFilter: LocalFilterCreator = () => ({
   name: 'secondDummyFilter',
   onFetch: () => onFetchMock(2),
 })
+
+const nullProgressReporter: ProgressReporter = {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  reportProgress: () => {},
+}
 
 describe('Adapter', () => {
   const client = createClient()
@@ -629,6 +637,7 @@ describe('Adapter', () => {
         groupID: SDF_CREATE_OR_UPDATE_GROUP_ID,
         changes: [{ action: 'add', data: { after } }],
       },
+      progressReporter: nullProgressReporter,
     })
 
     describe('add', () => {
@@ -714,6 +723,7 @@ describe('Adapter', () => {
               folderChange,
             ],
           },
+          progressReporter: nullProgressReporter,
         })
         const folderCustInfo = await toCustomizationInfo(folderInstance)
         const fileCustInfo = await toCustomizationInfo(fileInstance)
@@ -751,6 +761,7 @@ describe('Adapter', () => {
               folderChange,
             ],
           },
+          progressReporter: nullProgressReporter,
         })
         const folderCustInfo = await toCustomizationInfo(folderInstance)
         const fileCustInfo = await toCustomizationInfo(fileInstance)
@@ -785,6 +796,7 @@ describe('Adapter', () => {
           groupID: SDF_CREATE_OR_UPDATE_GROUP_ID,
           changes: [{ action: 'modify', data: { before, after } }],
         },
+        progressReporter: nullProgressReporter,
       })
 
       it('should update custom type instance', async () => {
@@ -947,6 +959,7 @@ describe('Adapter', () => {
             groupID: SDF_CREATE_OR_UPDATE_GROUP_ID,
             changes: [{ action: 'add', data: { after: instance } }],
           },
+          progressReporter: nullProgressReporter,
         })
         testGraph.addNodes([
           new GraphNode(
@@ -1151,6 +1164,7 @@ describe('Adapter', () => {
             changes: [toChange({ after: customRecordType.fields.custom_field })],
             groupID: SDF_CREATE_OR_UPDATE_GROUP_ID,
           },
+          progressReporter: nullProgressReporter,
         })
         expect(deployRes).toEqual({
           appliedChanges: [],

--- a/packages/okta-adapter/e2e_test/adapter.test.ts
+++ b/packages/okta-adapter/e2e_test/adapter.test.ts
@@ -15,9 +15,11 @@
 */
 import _ from 'lodash'
 import { v4 as uuidv4 } from 'uuid'
-import { Change, CORE_ANNOTATIONS, DeployResult, Element, getChangeData,
+import {
+  Change, CORE_ANNOTATIONS, DeployResult, Element, getChangeData,
   InstanceElement, isAdditionChange, isAdditionOrModificationChange, isEqualValues, isInstanceChange, isInstanceElement,
-  isObjectType, ObjectType, ReferenceExpression, TemplateExpression, toChange, Values } from '@salto-io/adapter-api'
+  isObjectType, ObjectType, ProgressReporter, ReferenceExpression, TemplateExpression, toChange, Values,
+} from '@salto-io/adapter-api'
 import { applyDetailedChanges, buildElementsSourceFromElements, detailedCompare, getParents, naclCase, safeJsonStringify } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { config as configUtils, elements as elementsUtils } from '@salto-io/adapter-components'
@@ -204,6 +206,11 @@ const createInstancesForDeploy = (types: ObjectType[], testSuffix: string): Inst
     accessPolicyRule, profileEnrollment, profileEnrollmentRule, app]
 }
 
+const nullProgressReporter: ProgressReporter = {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  reportProgress: () => {},
+}
+
 const deployChanges = async (
   adapterAttr: Reals, instancesToAdd: InstanceElement[],
 ): Promise<DeployResult[]> => {
@@ -212,6 +219,7 @@ const deployChanges = async (
     .map(async instance => {
       const deployResult = await adapterAttr.adapter.deploy({
         changeGroup: { groupID: instance.elemID.getFullName(), changes: [toChange({ after: instance })] },
+        progressReporter: nullProgressReporter,
       })
       expect(deployResult.errors).toHaveLength(0)
       expect(deployResult.appliedChanges).not.toHaveLength(0)
@@ -241,10 +249,13 @@ const removeApp = async (adapterAttr: Reals, changes: Change<InstanceElement>[])
   inactiveApp.value.status = INACTIVE_STATUS
   // Application must be deactivated before removal
   const appDeactivationChange = toChange({ before: activeApp, after: inactiveApp })
-  const appDeployResult = await adapterAttr.adapter.deploy({ changeGroup: {
-    groupID: getChangeData(appDeactivationChange).elemID.getFullName(),
-    changes: [appDeactivationChange],
-  } })
+  const appDeployResult = await adapterAttr.adapter.deploy({
+    changeGroup: {
+      groupID: getChangeData(appDeactivationChange).elemID.getFullName(),
+      changes: [appDeactivationChange],
+    },
+    progressReporter: nullProgressReporter,
+  })
 
   const appRemovalChange = appDeployResult.appliedChanges
     .find(change => getChangeData(change).elemID.typeName === APPLICATION_TYPE_NAME)
@@ -256,6 +267,7 @@ const removeApp = async (adapterAttr: Reals, changes: Change<InstanceElement>[])
       groupID: getChangeData(appRemovalChange).elemID.getFullName(),
       changes: [toChange({ before: getChangeData(appRemovalChange) })],
     },
+    progressReporter: nullProgressReporter,
   })
 }
 
@@ -342,6 +354,7 @@ describe('Okta adapter E2E', () => {
             groupID: getChangeData(change).elemID.getFullName(),
             changes: [change],
           },
+          progressReporter: nullProgressReporter,
         })).toArray()
 
       const errors = deployResults.flatMap(res => res.errors)

--- a/packages/salesforce-adapter/e2e_test/adapter.test.ts
+++ b/packages/salesforce-adapter/e2e_test/adapter.test.ts
@@ -56,7 +56,7 @@ import { mockTypes, lwcJsResourceContent, lwcHtmlResourceContent, mockDefaultVal
 import {
   objectExists, getMetadata, getMetadataFromElement, createInstance, removeElementAndVerify,
   removeElementIfAlreadyExists, createElementAndVerify, createElement, removeElement,
-  removeMetadataIfAlreadyExists,
+  removeMetadataIfAlreadyExists, nullProgressReporter,
 } from './utils'
 import {
   accountApiName, CUSTOM_FIELD_NAMES, customObjectAddFieldsName,
@@ -669,6 +669,7 @@ describe('Salesforce adapter E2E with real account', () => {
           groupID: oldElement.elemID.getFullName(),
           changes,
         },
+        progressReporter: nullProgressReporter,
       })
 
       expect(modificationResult.errors).toHaveLength(0)
@@ -758,6 +759,7 @@ describe('Salesforce adapter E2E with real account', () => {
           groupID: newInstance.elemID.getFullName(),
           changes: [{ action: 'modify', data: { before: oldInstance, after: newInstance } }],
         },
+        progressReporter: nullProgressReporter,
       })
 
       // Test
@@ -918,6 +920,7 @@ describe('Salesforce adapter E2E with real account', () => {
           groupID: newElement.elemID.getFullName(),
           changes,
         },
+        progressReporter: nullProgressReporter,
       })
       expect(modificationResult.errors).toHaveLength(0)
       expect(modificationResult.appliedChanges).toEqual(changes)
@@ -993,6 +996,7 @@ describe('Salesforce adapter E2E with real account', () => {
           groupID: newElement.elemID.getFullName(),
           changes,
         },
+        progressReporter: nullProgressReporter,
       })
       expect(modificationResult.errors).toHaveLength(0)
       expect(modificationResult.appliedChanges).toEqual(changes)
@@ -1780,6 +1784,7 @@ describe('Salesforce adapter E2E with real account', () => {
                   groupID: caseObj.elemID.getFullName(),
                   changes: [{ action: 'remove', data: { before: caseObj.fields[fieldName] } }],
                 },
+                progressReporter: nullProgressReporter,
               })
               return caseAfterFieldRemoval
             }
@@ -1821,6 +1826,7 @@ describe('Salesforce adapter E2E with real account', () => {
                     data: { after: caseAfterFieldAddition.fields[rollupSummaryFieldName] },
                   }],
                 },
+                progressReporter: nullProgressReporter,
               })
               return caseAfterFieldAddition
             }
@@ -2151,6 +2157,7 @@ describe('Salesforce adapter E2E with real account', () => {
                   data: { before: customFieldsObject.fields[f], after: newCustomObject.fields[f] },
                 })),
             },
+            progressReporter: nullProgressReporter,
           })
           objectInfo = await getMetadata(client, constants.CUSTOM_OBJECT,
             customObjectWithFieldsName) as CustomObject
@@ -2359,6 +2366,7 @@ describe('Salesforce adapter E2E with real account', () => {
                 groupID: account.elemID.getFullName(),
                 changes: [{ action: 'modify', data: { before: field, after: updatedField } }],
               },
+              progressReporter: nullProgressReporter,
             })
             const fieldInfo = await getMetadata(client, constants.CUSTOM_FIELD,
               fullName) as CustomField
@@ -2446,6 +2454,7 @@ describe('Salesforce adapter E2E with real account', () => {
           groupID: oldElement.elemID.getFullName(),
           changes,
         },
+        progressReporter: nullProgressReporter,
       })
       expect(modificationResult.errors).toHaveLength(0)
       expect(modificationResult.appliedChanges).toHaveLength(1)
@@ -2576,6 +2585,7 @@ describe('Salesforce adapter E2E with real account', () => {
           groupID: oldElement.elemID.getFullName(),
           changes: [{ action: 'modify', data: { before: oldElement, after: newElement } }],
         },
+        progressReporter: nullProgressReporter,
       })
 
       const updatedElement = getChangeData(modificationResult.appliedChanges[0])
@@ -2651,6 +2661,7 @@ describe('Salesforce adapter E2E with real account', () => {
             groupID: before.elemID.getFullName(),
             changes: [{ action: 'modify', data: { before, after } }],
           },
+          progressReporter: nullProgressReporter,
         })
 
         const updatedRules = await getRulesFromClient()
@@ -2663,6 +2674,7 @@ describe('Salesforce adapter E2E with real account', () => {
             groupID: before.elemID.getFullName(),
             changes: [{ action: 'modify', data: { before: after, after: before } }],
           },
+          progressReporter: nullProgressReporter,
         })
         const rules = await getRulesFromClient()
         expect(new Set(makeArray(rules.assignmentRule)))
@@ -2695,6 +2707,7 @@ describe('Salesforce adapter E2E with real account', () => {
             groupID: before.elemID.getFullName(),
             changes: [{ action: 'modify', data: { before, after } }],
           },
+          progressReporter: nullProgressReporter,
         })
 
         const updatedRules = await getRulesFromClient()
@@ -2704,6 +2717,7 @@ describe('Salesforce adapter E2E with real account', () => {
             groupID: before.elemID.getFullName(),
             changes: [{ action: 'modify', data: { before: after, after: before } }],
           },
+          progressReporter: nullProgressReporter,
         })
       })
     })
@@ -2778,6 +2792,7 @@ describe('Salesforce adapter E2E with real account', () => {
               groupID: instance.elemID.getFullName(),
               changes: [{ action: 'modify', data: { before: instance, after } }],
             },
+            progressReporter: nullProgressReporter,
           })
           const instanceInfo = await findInstance(instance)
           expect(instanceInfo).toBeDefined()
@@ -2943,6 +2958,7 @@ describe('Salesforce adapter E2E with real account', () => {
               groupID: instance.elemID.getFullName(),
               changes: [{ action: 'modify', data: { before: instance, after } }],
             },
+            progressReporter: nullProgressReporter,
           })
           if (deployResult.errors.length > 0) {
             if (deployResult.errors.length === 1) throw deployResult.errors[0]
@@ -3524,6 +3540,7 @@ describe('Salesforce adapter E2E with real account', () => {
             groupID: flow.elemID.getFullName(),
             changes: [{ action: 'modify', data: { before: flow, after: newFlow } }],
           },
+          progressReporter: nullProgressReporter,
         })
         flow = getChangeData(deployResult.appliedChanges[0]) as InstanceElement
 
@@ -3713,6 +3730,7 @@ describe('Salesforce adapter E2E with real account', () => {
             groupID: layout.elemID.getFullName(),
             changes: [{ action: 'modify', data: { before: layout, after: newLayout } }],
           },
+          progressReporter: nullProgressReporter,
         })
         layout = getChangeData(deployResult.appliedChanges[0]) as InstanceElement
 
@@ -3782,6 +3800,7 @@ describe('Salesforce adapter E2E with real account', () => {
             groupID: oldElement.elemID.getFullName(),
             changes,
           },
+          progressReporter: nullProgressReporter,
         })
 
         expect(modificationResult.errors).toHaveLength(0)
@@ -3804,6 +3823,7 @@ describe('Salesforce adapter E2E with real account', () => {
             groupID: quickAction.elemID.getFullName(),
             changes,
           },
+          progressReporter: nullProgressReporter,
         })
 
         expect(additionDeploy.errors).toHaveLength(0)

--- a/packages/salesforce-adapter/e2e_test/custom_object_instances.test.ts
+++ b/packages/salesforce-adapter/e2e_test/custom_object_instances.test.ts
@@ -24,7 +24,10 @@ import SalesforceAdapter from '../index'
 import realAdapter from './adapter'
 import SalesforceClient from '../src/client/client'
 import { UsernamePasswordCredentials } from '../src/types'
-import { runFiltersOnFetch, createElement, removeElementAndVerify, createInstance, getRecordOfInstance, fetchTypes, getMetadataInstance, removeElement, removeElementIfAlreadyExists } from './utils'
+import {
+  runFiltersOnFetch, createElement, removeElementAndVerify, createInstance, getRecordOfInstance, fetchTypes,
+  getMetadataInstance, removeElement, removeElementIfAlreadyExists, nullProgressReporter,
+} from './utils'
 import { apiName, isInstanceOfCustomObject } from '../src/transformers/transformer'
 import customObjectsFromDescribeFilter from '../src/filters/custom_objects_from_soap_describe'
 import customObjectsToObjectTypeFilter from '../src/filters/custom_objects_to_object_type'
@@ -191,6 +194,7 @@ describe('custom object instances e2e', () => {
             groupID: updatedInstance.elemID.getFullName(),
             changes: [{ action: 'modify', data: { before: createdInstance, after: updatedInstance } }],
           },
+          progressReporter: nullProgressReporter,
         })
         const fields = ['IsActive', 'ProductCode', 'IsArchived']
         const result = await getRecordOfInstance(client, createdInstance, fields)

--- a/packages/salesforce-adapter/e2e_test/quick_deploy.test.ts
+++ b/packages/salesforce-adapter/e2e_test/quick_deploy.test.ts
@@ -25,6 +25,7 @@ import { SalesforceConfig, UsernamePasswordCredentials } from '../src/types'
 import { testHelpers } from './jest_environment'
 import { mockTypes } from '../test/mock_elements'
 import { createInstanceElement, MetadataInstanceElement } from '../src/transformers/transformer'
+import { nullProgressReporter } from './utils'
 
 describe('validation and quick deploy e2e', () => {
   // Set long timeout as we communicate with salesforce API
@@ -72,7 +73,10 @@ describe('validation and quick deploy e2e', () => {
       { credentials: new UsernamePasswordCredentials(credLease.value) },
       validationConfig
     )
-    const validationResult = await adapterValidation.adapter.validate({ changeGroup })
+    const validationResult = await adapterValidation.adapter.validate({
+      changeGroup,
+      progressReporter: nullProgressReporter,
+    })
     const groupResult = validationResult.extraProperties?.groups?.[0] ?? {}
     const { requestId, hash } = groupResult
     expect(requestId).toBeDefined()
@@ -98,7 +102,7 @@ describe('validation and quick deploy e2e', () => {
   })
 
   it('should perform quick deploy', async () => {
-    const deployResult = await adapter.deploy({ changeGroup })
+    const deployResult = await adapter.deploy({ changeGroup, progressReporter: nullProgressReporter })
     expect(deployResult.appliedChanges).toHaveLength(changeGroup.changes.length)
     expect(quickDeploySpy).toHaveBeenCalledOnce()
   })
@@ -113,7 +117,7 @@ describe('validation and quick deploy e2e', () => {
         groupID: 'remove test elements',
         changes: [toChange({ before: apexClassInstance }), toChange({ before: apexTestInstance })],
       }
-      await adapterDeploy.adapter.deploy({ changeGroup: removeInstances })
+      await adapterDeploy.adapter.deploy({ changeGroup: removeInstances, progressReporter: nullProgressReporter })
     } finally {
       if (credLease.return) {
         await credLease.return()

--- a/packages/salesforce-adapter/e2e_test/utils.ts
+++ b/packages/salesforce-adapter/e2e_test/utils.ts
@@ -14,7 +14,10 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { Value, ObjectType, ElemID, InstanceElement, Element, isObjectType, ChangeGroup, getChangeData, DeployResult } from '@salto-io/adapter-api'
+import {
+  Value, ObjectType, ElemID, InstanceElement, Element, isObjectType, ChangeGroup, getChangeData, DeployResult,
+  ProgressReporter,
+} from '@salto-io/adapter-api'
 import { filter, findElement } from '@salto-io/adapter-utils'
 import { collections, values } from '@salto-io/lowerdash'
 import { MetadataInfo } from '@salto-io/jsforce'
@@ -173,6 +176,11 @@ export const removeElementIfAlreadyExists = async (
   }
 }
 
+export const nullProgressReporter: ProgressReporter = {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  reportProgress: () => {},
+}
+
 export const createElement = async <T extends InstanceElement | ObjectType>(
   adapter: SalesforceAdapter, element: T, verify = true,
 ): Promise<T> => {
@@ -180,7 +188,7 @@ export const createElement = async <T extends InstanceElement | ObjectType>(
     groupID: 'add test elements',
     changes: [{ action: 'add', data: { after: element } }],
   }
-  const result = await adapter.deploy({ changeGroup })
+  const result = await adapter.deploy({ changeGroup, progressReporter: nullProgressReporter })
   if (verify && result.errors.length > 0) {
     if (result.errors.length === 1) throw result.errors[0]
     throw new Error(`Failed adding element ${element.elemID.getFullName()} with errors: ${result.errors}`)
@@ -217,7 +225,7 @@ export const removeElement = async <T extends InstanceElement | ObjectType>(
     groupID: 'remove test elements',
     changes: [{ action: 'remove', data: { before: element } }],
   }
-  const result = await adapter.deploy({ changeGroup })
+  const result = await adapter.deploy({ changeGroup, progressReporter: nullProgressReporter })
   if (verify && result.errors.length > 0) {
     if (result.errors.length === 1) throw result.errors[0]
     throw new Error(`Failed adding element ${element.elemID.getFullName()} with errors: ${result.errors}`)

--- a/packages/salesforce-adapter/e2e_test/workflow.test.ts
+++ b/packages/salesforce-adapter/e2e_test/workflow.test.ts
@@ -37,7 +37,7 @@ import SalesforceAdapter from '../src/adapter'
 import { findElements } from '../test/utils'
 import {
   getMetadataInstance, getMetadata, removeMetadataIfAlreadyExists, createAndVerify,
-  removeElementAndVerify, fetchTypes, runFiltersOnFetch,
+  removeElementAndVerify, fetchTypes, runFiltersOnFetch, nullProgressReporter,
 } from './utils'
 import { testHelpers } from './jest_environment'
 
@@ -263,6 +263,7 @@ describe('workflow filter', () => {
               groupID: newAlert.elemID.getFullName(),
               changes: [{ action: 'modify', data: { before: oldAlert, after: newAlert } }],
             },
+            progressReporter: nullProgressReporter,
           })
 
           const postUpdate = await getMetadata(client, alertType, newInstanceName)
@@ -327,6 +328,7 @@ describe('workflow filter', () => {
               groupID: newInstance.elemID.getFullName(),
               changes: [{ action: 'modify', data: { before: old, after: newInstance } }],
             },
+            progressReporter: nullProgressReporter,
           })
 
           const workflowFieldUpdateInfo = await getMetadata(client, fieldUpdateType,
@@ -382,6 +384,7 @@ describe('workflow filter', () => {
               groupID: newInstance.elemID.getFullName(),
               changes: [{ action: 'modify', data: { before: old, after: newInstance } }],
             },
+            progressReporter: nullProgressReporter,
           })
 
           const workflowTaskInfo = await getMetadata(client, taskType, newInstanceName)
@@ -473,6 +476,7 @@ describe('workflow filter', () => {
               groupID: newInstance.elemID.getFullName(),
               changes: [{ action: 'modify', data: { before: old, after: newInstance } }],
             },
+            progressReporter: nullProgressReporter,
           })
 
           const workflowRuleInfo = await getMetadata(client, rulesType, newInstanceName)

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -16,7 +16,7 @@
 import {
   TypeElement, ObjectType, InstanceElement, isAdditionChange, getChangeData, Change,
   ElemIdGetter, FetchResult, AdapterOperations, DeployResult, FetchOptions, DeployOptions,
-  ReadOnlyElementsSource, ElemID, PartialFetchData, Element,
+  ReadOnlyElementsSource, ElemID, PartialFetchData, Element, ProgressReporter,
 } from '@salto-io/adapter-api'
 import {
   filter,
@@ -530,7 +530,7 @@ export default class SalesforceAdapter implements AdapterOperations {
   }
 
   private async deployOrValidate(
-    { changeGroup }: DeployOptions,
+    { changeGroup, progressReporter }: DeployOptions,
     checkOnly: boolean
   ): Promise<DeployResult> {
     const fetchParams = this.userConfig.fetch ?? {}
@@ -564,9 +564,14 @@ export default class SalesforceAdapter implements AdapterOperations {
         fetchProfile.dataManagement,
       )
     } else {
+      const nullProgressReporter: ProgressReporter = {
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        reportProgress: () => {},
+      }
       deployResult = await deployMetadata(resolvedChanges, this.client, changeGroup.groupID,
-        this.nestedMetadataTypes, this.userConfig.client?.deploy?.deleteBeforeUpdate, checkOnly,
-          this.userConfig.client?.deploy?.quickDeployParams)
+        this.nestedMetadataTypes, progressReporter ?? nullProgressReporter,
+        this.userConfig.client?.deploy?.deleteBeforeUpdate, checkOnly,
+        this.userConfig.client?.deploy?.quickDeployParams)
     }
     log.debug(`received deployResult for group ${changeGroup.groupID}`)
     // onDeploy can change the change list in place, so we need to give it a list it can modify

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -520,6 +520,7 @@ export const validateCredentials = async (
     extraInformation: { orgId },
   }
 }
+
 export default class SalesforceClient {
   private readonly retryOptions: RequestRetryOptions
   private readonly conn: Connection

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -839,7 +839,11 @@ export default class SalesforceClient {
       }
       const pollingInterval = setInterval(progressCallbackWrapper, DEPLOY_STATUS_POLLING_INTERVAL_MS)
 
-      deployResult = await deployStatus.complete(true).finally(() => clearInterval(pollingInterval))
+      const clearPollingInterval = (result: DeployResult): DeployResult => {
+        clearInterval(pollingInterval)
+        return result
+      }
+      deployResult = await deployStatus.complete(true).then(clearPollingInterval, clearPollingInterval)
     } else {
       deployResult = await deployStatus.complete(true)
     }

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -843,6 +843,9 @@ export default class SalesforceClient {
         clearInterval(pollingInterval)
         return result
       }
+      // We can't use finally() because, despite what the type definition for jsforce says,
+      // DeployResultLocator.complete() actually returns an AsyncResultLocator<T> and not a Promise<T>.
+      // ref. https://github.com/jsforce/jsforce/blob/c04515846e91f84affa4eb87a7b2adb1f58bf04d/lib/api/metadata.js#L830
       deployResult = await deployStatus.complete(true).then(clearPollingInterval, clearPollingInterval)
     } else {
       deployResult = await deployStatus.complete(true)

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -834,8 +834,12 @@ export default class SalesforceClient {
     if (progressCallback) {
       const progressCallbackWrapper = async (): Promise<void> => {
         const partialResult = await deployStatus.check()
-        const detailedResult = await this.conn.metadata.checkDeployStatus(partialResult.id, true)
-        progressCallback(detailedResult)
+        try {
+          const detailedResult = await this.conn.metadata.checkDeployStatus(partialResult.id, true)
+          progressCallback(detailedResult)
+        } catch (e) {
+          log.warn('checkDeployStatus API call failed. Progress update will not take place. Error: %s', e.message)
+        }
       }
       const pollingInterval = setInterval(progressCallbackWrapper, DEPLOY_STATUS_POLLING_INTERVAL_MS)
 

--- a/packages/salesforce-adapter/src/client/jsforce.ts
+++ b/packages/salesforce-adapter/src/client/jsforce.ts
@@ -28,6 +28,8 @@ import { Value } from '@salto-io/adapter-api'
 export interface Metadata {
   pollInterval: number
   pollTimeout: number
+
+  checkDeployStatus(id: string, includeDetails?: boolean, callback?: Callback<DeployResult>): Promise<DeployResult>
   describe(): Promise<{ metadataObjects: MetadataObject[]; organizationNamespace: string }>
   describeValueType(type: string): Promise<DescribeValueTypeResult>
   read(type: string, fullNames: string | string[]): Promise<MetadataInfo | MetadataInfo[]>

--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -331,9 +331,9 @@ const deployProgressMessage = async (
   const url = await getDeployStatusUrl(deployResult, client)
   const testStatus = `${deployResult.numberTestsCompleted}/${deployResult.numberComponentsTotal} (${deployResult.numberTestErrors} errors)`
   const componentStatus = `${deployResult.numberComponentsDeployed}/${deployResult.numberComponentsTotal} (${deployResult.numberComponentErrors} errors)`
-  const logLine = `Tests: ${testStatus} Components: ${componentStatus} URL: ${url}`
-  log.debug(logLine)
-  return logLine
+  const progressMessage = `Tests: ${testStatus} Components: ${componentStatus} URL: ${url}`
+  log.debug(progressMessage)
+  return progressMessage
 }
 
 const quickDeployOrDeploy = async (

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -1712,6 +1712,7 @@ describe('SalesforceAdapter CRUD', () => {
       let resultProfile: DeployResult
       beforeEach(async () => {
         const steps = stepManager(['firstDeploy', 'secondDeploy'])
+        const deployId = _.uniqueId()
 
         connection.metadata.deploy
           .mockReturnValueOnce({
@@ -1719,6 +1720,15 @@ describe('SalesforceAdapter CRUD', () => {
               steps.resolveStep('firstDeploy')
               await steps.waitStep('secondDeploy')
               return mockDeployResultComplete({
+                id: deployId,
+                componentSuccess: [{ fullName: 'Test__c.Valid', componentType: 'ValidationRule' }],
+              })
+            },
+            check: async () => {
+              steps.resolveStep('firstDeploy')
+              await steps.waitStep('secondDeploy')
+              return mockDeployResultComplete({
+                id: deployId,
                 componentSuccess: [{ fullName: 'Test__c.Valid', componentType: 'ValidationRule' }],
               })
             },
@@ -1727,6 +1737,14 @@ describe('SalesforceAdapter CRUD', () => {
             complete: async () => {
               steps.resolveStep('secondDeploy')
               return mockDeployResultComplete({
+                id: deployId,
+                componentSuccess: [{ fullName: 'TestAddProfileInstance__c', componentType: 'Profile' }],
+              })
+            },
+            check: async () => {
+              steps.resolveStep('secondDeploy')
+              return mockDeployResultComplete({
+                id: deployId,
                 componentSuccess: [{ fullName: 'TestAddProfileInstance__c', componentType: 'Profile' }],
               })
             },

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -15,7 +15,11 @@
 */
 import _ from 'lodash'
 import { collections, promises } from '@salto-io/lowerdash'
-import { ObjectType, ElemID, InstanceElement, BuiltinTypes, CORE_ANNOTATIONS, createRestriction, DeployResult, getChangeData, Values, Change, toChange, ChangeGroup, isAdditionOrModificationChange, isServiceId, INSTANCE_ANNOTATIONS, ReferenceExpression, isInstanceElement, SeverityLevel, isSaltoElementError } from '@salto-io/adapter-api'
+import {
+  ObjectType, ElemID, InstanceElement, BuiltinTypes, CORE_ANNOTATIONS, createRestriction, DeployResult, getChangeData,
+  Values, Change, toChange, ChangeGroup, isAdditionOrModificationChange, isServiceId, INSTANCE_ANNOTATIONS,
+  ReferenceExpression, isInstanceElement, SeverityLevel, isSaltoElementError,
+} from '@salto-io/adapter-api'
 import { MockInterface, stepManager } from '@salto-io/test-utils'
 import { Package, DeployResultLocator, DeployResult as JSForceDeployResult } from '@salto-io/jsforce'
 import JSZip from 'jszip'
@@ -26,7 +30,7 @@ import { Types, createInstanceElement, apiName, metadataType, createMetadataObje
 import Connection from '../src/client/jsforce'
 import { CustomObject } from '../src/client/types'
 import mockAdapter from './adapter'
-import { createValueSetEntry, createCustomObjectType } from './utils'
+import { createValueSetEntry, createCustomObjectType, nullProgressReporter } from './utils'
 import { createElement, removeElement } from '../e2e_test/utils'
 import { mockTypes, mockDefaultValues } from './mock_elements'
 import { mockDeployResult, mockRunTestFailure, mockDeployResultComplete } from './connection'
@@ -197,6 +201,7 @@ describe('SalesforceAdapter CRUD', () => {
                 { action: 'add', data: { after: businessProcessInstance } },
                 { action: 'add', data: { after: workflowFieldUpdate } }],
             },
+            progressReporter: nullProgressReporter,
           })
         })
 
@@ -247,6 +252,7 @@ describe('SalesforceAdapter CRUD', () => {
               groupID: newInst.elemID.getFullName(),
               changes: [{ action: 'add', data: { after: newInst } }],
             },
+            progressReporter: nullProgressReporter,
           })
         })
 
@@ -273,6 +279,7 @@ describe('SalesforceAdapter CRUD', () => {
                   groupID: instance.elemID.getFullName(),
                   changes: [{ action: 'add', data: { after: instance } }],
                 },
+                progressReporter: nullProgressReporter,
               })
             })
             it('should return applied changes', () => {
@@ -294,6 +301,7 @@ describe('SalesforceAdapter CRUD', () => {
                   groupID: instance.elemID.getFullName(),
                   changes: [{ action: 'add', data: { after: instance } }],
                 },
+                progressReporter: nullProgressReporter,
               })
             })
             it('should return applied changes', () => {
@@ -315,6 +323,7 @@ describe('SalesforceAdapter CRUD', () => {
                 groupID: instance.elemID.getFullName(),
                 changes: [{ action: 'add', data: { after: customObjectInstance } }],
               },
+              progressReporter: nullProgressReporter,
             })
           })
           it('should return error', () => {
@@ -360,6 +369,7 @@ describe('SalesforceAdapter CRUD', () => {
                 groupID: instance.elemID.getFullName(),
                 changes: [{ action: 'add', data: { after: instance } }],
               },
+              progressReporter: nullProgressReporter,
             })
           })
           it('should not return applied changes', () => {
@@ -377,6 +387,7 @@ describe('SalesforceAdapter CRUD', () => {
                 groupID: instance.elemID.getFullName(),
                 changes: [{ action: 'add', data: { after: customObjectInstance } }],
               },
+              progressReporter: nullProgressReporter,
             })
           })
           it('should return error', () => {
@@ -414,6 +425,7 @@ describe('SalesforceAdapter CRUD', () => {
                 groupID: instance.elemID.getFullName(),
                 changes: [{ action: 'add', data: { after: instance } }],
               },
+              progressReporter: nullProgressReporter,
             })
           })
           it('should deploy', () => {
@@ -444,6 +456,7 @@ describe('SalesforceAdapter CRUD', () => {
                 groupID: instance.elemID.getFullName(),
                 changes: [{ action: 'add', data: { after: instance } }],
               },
+              progressReporter: nullProgressReporter,
             })
           })
           it('should not deploy', () => {
@@ -472,6 +485,7 @@ describe('SalesforceAdapter CRUD', () => {
                 groupID: instance.elemID.getFullName(),
                 changes: [{ action: 'add', data: { after: instance } }],
               },
+              progressReporter: nullProgressReporter,
             })
             expect(errors).toBeEmpty()
           })
@@ -869,7 +883,7 @@ describe('SalesforceAdapter CRUD', () => {
             ...deployResultParams,
             rollbackOnError: true,
           }))
-          result = await adapter.deploy({ changeGroup: deployChangeGroup })
+          result = await adapter.deploy({ changeGroup: deployChangeGroup, progressReporter: nullProgressReporter })
         })
         it('should not apply the instance change', () => {
           expect(result.appliedChanges).toHaveLength(0)
@@ -886,7 +900,7 @@ describe('SalesforceAdapter CRUD', () => {
             ...deployResultParams,
             rollbackOnError: false,
           }))
-          result = await adapter.deploy({ changeGroup: deployChangeGroup })
+          result = await adapter.deploy({ changeGroup: deployChangeGroup, progressReporter: nullProgressReporter })
         })
         it('should apply the component changes', () => {
           expect(result.appliedChanges).toHaveLength(1)
@@ -1073,6 +1087,7 @@ describe('SalesforceAdapter CRUD', () => {
               groupID: afterInstance.elemID.getFullName(),
               changes: [{ action: 'modify', data: { before: beforeInstance, after: afterInstance } }],
             },
+            progressReporter: nullProgressReporter,
           })
         })
         it('should return an InstanceElement', () => {
@@ -1115,6 +1130,7 @@ describe('SalesforceAdapter CRUD', () => {
               groupID: afterInstance.elemID.getFullName(),
               changes: [{ action: 'modify', data: { before: beforeInstance, after: afterInstance } }],
             },
+            progressReporter: nullProgressReporter,
           })
         })
         it('should produce a deploy error', () => {
@@ -1138,6 +1154,7 @@ describe('SalesforceAdapter CRUD', () => {
               groupID: afterInstance.elemID.getFullName(),
               changes: [{ action: 'modify', data: { before: beforeInstance, after: afterInstance } }],
             },
+            progressReporter: nullProgressReporter,
           })
         })
         it('should produce a deploy error', () => {
@@ -1154,6 +1171,7 @@ describe('SalesforceAdapter CRUD', () => {
               groupID: afterInstance.elemID.getFullName(),
               changes: [{ action: 'modify', data: { before: beforeInstance, after: afterInstance } }],
             },
+            progressReporter: nullProgressReporter,
           })
         })
 
@@ -1196,6 +1214,7 @@ describe('SalesforceAdapter CRUD', () => {
                   data: { before: oldAssignmentRules, after: newAssignmentRules },
                 }],
               },
+              progressReporter: nullProgressReporter,
             })
           })
 
@@ -1265,6 +1284,7 @@ describe('SalesforceAdapter CRUD', () => {
                   data: { before: oldCustomLabels, after: newCustomLabels },
                 }],
               },
+              progressReporter: nullProgressReporter,
             })
           })
 
@@ -1297,6 +1317,7 @@ describe('SalesforceAdapter CRUD', () => {
               groupID: oldElement.elemID.getFullName(),
               changes: [{ action: 'modify', data: { before: oldElement, after: newElement } }],
             },
+            progressReporter: nullProgressReporter,
           })
         })
 
@@ -1371,6 +1392,7 @@ describe('SalesforceAdapter CRUD', () => {
               groupID: oldElement.elemID.getFullName(),
               changes,
             },
+            progressReporter: nullProgressReporter,
           })
         })
 
@@ -1486,6 +1508,7 @@ describe('SalesforceAdapter CRUD', () => {
               groupID: oldElement.elemID.getFullName(),
               changes,
             },
+            progressReporter: nullProgressReporter,
           })
         })
 
@@ -1594,6 +1617,7 @@ describe('SalesforceAdapter CRUD', () => {
                     after: newElement.fields.banana } },
               ],
             },
+            progressReporter: nullProgressReporter,
           })
         })
 
@@ -1637,6 +1661,7 @@ describe('SalesforceAdapter CRUD', () => {
                 { action: 'modify', data: { before, after } },
               ],
             },
+            progressReporter: nullProgressReporter,
           })
         })
         it('should fail because the type is not deployable', () => {
@@ -1694,6 +1719,7 @@ describe('SalesforceAdapter CRUD', () => {
               { action: 'remove', data: { before: before.fields.one } },
             ],
           },
+          progressReporter: nullProgressReporter,
         })
       })
 
@@ -1778,6 +1804,7 @@ describe('SalesforceAdapter CRUD', () => {
             groupID: testValidationRule.elemID.getFullName(),
             changes: [toChange({ after: testValidationRule })],
           },
+          progressReporter: nullProgressReporter,
         })
         await steps.waitStep('firstDeploy')
         const profilePromise = adapter.deploy({
@@ -1785,6 +1812,7 @@ describe('SalesforceAdapter CRUD', () => {
             groupID: testProfile.elemID.getFullName(),
             changes: [toChange({ after: testProfile })],
           },
+          progressReporter: nullProgressReporter,
         })
 
         resultValidationRule = await validationRulePromise
@@ -1815,7 +1843,7 @@ describe('SalesforceAdapter CRUD', () => {
           connection.metadata.deploy.mockReturnValue(mockDeployResult({
             componentSuccess: [{ fullName: 'MyValueSet__gvs', componentType: GLOBAL_VALUE_SET }],
           }))
-          result = await adapter.deploy({ changeGroup })
+          result = await adapter.deploy({ changeGroup, progressReporter: nullProgressReporter })
         })
         it('should apply the change', () => {
           expect(changesToFullNames(result.appliedChanges)).toEqual(
@@ -1833,7 +1861,7 @@ describe('SalesforceAdapter CRUD', () => {
             connection.metadata.deploy.mockReturnValue(mockDeployResult({
               componentSuccess: [{ fullName: 'MyValueSet', componentType: GLOBAL_VALUE_SET }],
             }))
-            result = await adapter.deploy({ changeGroup })
+            result = await adapter.deploy({ changeGroup, progressReporter: nullProgressReporter })
           })
           it('should apply the change', () => {
             expect(changesToFullNames(result.appliedChanges)).toEqual(
@@ -1846,7 +1874,7 @@ describe('SalesforceAdapter CRUD', () => {
             connection.metadata.deploy.mockReturnValue(mockDeployResult({
               componentSuccess: [{ fullName: 'MyValueSet__gvs', componentType: GLOBAL_VALUE_SET }],
             }))
-            result = await adapter.deploy({ changeGroup })
+            result = await adapter.deploy({ changeGroup, progressReporter: nullProgressReporter })
           })
           it('should apply the change', () => {
             expect(changesToFullNames(result.appliedChanges)).toEqual(

--- a/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
@@ -27,7 +27,7 @@ import SalesforceAdapter from '../src/adapter'
 import * as constants from '../src/constants'
 import Connection from '../src/client/jsforce'
 import mockAdapter from './adapter'
-import { createCustomObjectType } from './utils'
+import { createCustomObjectType, nullProgressReporter } from './utils'
 import {
   ADD_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP, CUSTOM_OBJECT_ID_FIELD,
   FIELD_ANNOTATIONS, OWNER_ID, SBAA_APPROVAL_CONDITION,
@@ -369,6 +369,7 @@ describe('Custom Object Instances CRUD', () => {
               { action: 'add', data: { after: nonExistingSettingInstance } },
             ],
           },
+          progressReporter: nullProgressReporter,
         })
       })
       it('Should query according to instance values', () => {
@@ -450,6 +451,7 @@ describe('Custom Object Instances CRUD', () => {
                   { action: 'add', data: { after: newInstanceWithRef } },
                 ],
               },
+              progressReporter: nullProgressReporter,
             })
           })
 
@@ -548,6 +550,7 @@ describe('Custom Object Instances CRUD', () => {
                     { action: 'add', data: { after: anotherNewInstance } },
                   ],
                 },
+                progressReporter: nullProgressReporter,
               })
             })
 
@@ -661,6 +664,7 @@ describe('Custom Object Instances CRUD', () => {
                     { action: 'add', data: { after: instanceWithoutRef } },
                   ],
                 },
+                progressReporter: nullProgressReporter,
               })
             })
             it('should update the partially deployed instances after inserting them', () => {
@@ -699,6 +703,7 @@ describe('Custom Object Instances CRUD', () => {
                   { action: 'add', data: { after: anotherExistingInstance } },
                 ],
               },
+              progressReporter: nullProgressReporter,
             })
           })
 
@@ -768,6 +773,7 @@ describe('Custom Object Instances CRUD', () => {
                 groupID: 'add_Test_instances',
                 changes: _.times(100, createTestInstanceAddition),
               },
+              progressReporter: nullProgressReporter,
             })
           })
           it('should not not exceed max query size', () => {
@@ -815,6 +821,7 @@ describe('Custom Object Instances CRUD', () => {
                 { action: 'add', data: { after: anotherNewInstance } },
               ],
             },
+            progressReporter: nullProgressReporter,
           })
         })
         it('Should query according to instance values', () => {
@@ -902,7 +909,7 @@ describe('Custom Object Instances CRUD', () => {
       } as ChangeGroup
       describe('when loadBulk succeeds for all', () => {
         beforeEach(async () => {
-          result = await adapter.deploy({ changeGroup: modifyDeployGroup })
+          result = await adapter.deploy({ changeGroup: modifyDeployGroup, progressReporter: nullProgressReporter })
         })
 
         it('should return no errors and 2 fitting applied changes', async () => {
@@ -922,7 +929,7 @@ describe('Custom Object Instances CRUD', () => {
       describe('when loadBulk partially succeeds', () => {
         beforeEach(async () => {
           connection.bulk.load = partialBulkLoad
-          result = await adapter.deploy({ changeGroup: modifyDeployGroup })
+          result = await adapter.deploy({ changeGroup: modifyDeployGroup, progressReporter: nullProgressReporter })
         })
 
         it('should return one error and one applied change', async () => {
@@ -950,7 +957,7 @@ describe('Custom Object Instances CRUD', () => {
       describe('when loadBulk fails for all', () => {
         beforeEach(async () => {
           connection.bulk.load = getBulkLoadMock('fail')
-          result = await adapter.deploy({ changeGroup: modifyDeployGroup })
+          result = await adapter.deploy({ changeGroup: modifyDeployGroup, progressReporter: nullProgressReporter })
         })
 
         it('should return only errors', async () => {
@@ -996,7 +1003,7 @@ describe('Custom Object Instances CRUD', () => {
       } as ChangeGroup
       describe('when loadBulk succeeds for all', () => {
         beforeEach(async () => {
-          result = await adapter.deploy({ changeGroup: removeChangeGroup })
+          result = await adapter.deploy({ changeGroup: removeChangeGroup, progressReporter: nullProgressReporter })
         })
 
         it('should return no errors and 2 fitting applied changes', () => {
@@ -1017,7 +1024,7 @@ describe('Custom Object Instances CRUD', () => {
         describe('when loadBulk succeeds for all', () => {
           beforeEach(async () => {
             connection.bulk.load = partialBulkLoad
-            result = await adapter.deploy({ changeGroup: removeChangeGroup })
+            result = await adapter.deploy({ changeGroup: removeChangeGroup, progressReporter: nullProgressReporter })
           })
 
           it('should return two error', () => {
@@ -1047,7 +1054,7 @@ describe('Custom Object Instances CRUD', () => {
         describe('when loadBulk fails for all', () => {
           beforeEach(async () => {
             connection.bulk.load = getBulkLoadMock('fail')
-            result = await adapter.deploy({ changeGroup: removeChangeGroup })
+            result = await adapter.deploy({ changeGroup: removeChangeGroup, progressReporter: nullProgressReporter })
           })
 
           it('should return only errors', () => {
@@ -1099,6 +1106,7 @@ describe('Custom Object Instances CRUD', () => {
                   { action: 'add', data: { after: instanceOfAnotherType } },
                 ],
               },
+              progressReporter: nullProgressReporter,
             })
           })
         })
@@ -1112,6 +1120,7 @@ describe('Custom Object Instances CRUD', () => {
                   { action: 'modify', data: { before: instanceOfAnotherType, after: instanceOfAnotherType } },
                 ],
               },
+              progressReporter: nullProgressReporter,
             })
           })
         })
@@ -1125,6 +1134,7 @@ describe('Custom Object Instances CRUD', () => {
                   { action: 'remove', data: { before: instanceOfAnotherType } },
                 ],
               },
+              progressReporter: nullProgressReporter,
             })
           })
         })
@@ -1151,6 +1161,7 @@ describe('Custom Object Instances CRUD', () => {
                 { action: 'modify', data: { before: instanceToModify, after: anotherInstanceToModify } },
               ],
             },
+            progressReporter: nullProgressReporter,
           })
           expect(result.errors).toEqual([
             expect.objectContaining({
@@ -1172,6 +1183,7 @@ describe('Custom Object Instances CRUD', () => {
                 { action: 'remove', data: { before: newInstanceWithRef } },
               ],
             },
+            progressReporter: nullProgressReporter,
           })
           expect(result.errors).toEqual(([
             expect.objectContaining({
@@ -1206,6 +1218,7 @@ describe('Custom Object Instances CRUD', () => {
           }
           result = await adapter.deploy({
             changeGroup,
+            progressReporter: nullProgressReporter,
           })
         })
         it('should deploy successfully', () => {
@@ -1306,6 +1319,7 @@ describe('Custom Object Instances CRUD', () => {
 
           result = await adapter.deploy({
             changeGroup,
+            progressReporter: nullProgressReporter,
           })
         })
 
@@ -1345,7 +1359,7 @@ describe('Custom Object Instances CRUD', () => {
           }
         })
         it('should throw an error', async () => {
-          await expect(adapter.deploy({ changeGroup })).rejects.toThrow()
+          await expect(adapter.deploy({ changeGroup, progressReporter: nullProgressReporter })).rejects.toThrow()
         })
       })
     })
@@ -1378,6 +1392,7 @@ describe('Custom Object Instances CRUD', () => {
             { action: 'add', data: { after: existingInstance } },
           ],
         },
+        progressReporter: nullProgressReporter,
       })
       expect(result.errors).toEqual(([
         expect.objectContaining({
@@ -1407,6 +1422,7 @@ describe('Custom Object Instances CRUD', () => {
               { action: 'add', data: { after: existingInstance } },
             ],
           },
+          progressReporter: nullProgressReporter,
         })
       })
     })
@@ -1420,6 +1436,7 @@ describe('Custom Object Instances CRUD', () => {
               { action: 'modify', data: { before: existingInstance, after: existingInstance } },
             ],
           },
+          progressReporter: nullProgressReporter,
         })
       })
     })
@@ -1433,6 +1450,7 @@ describe('Custom Object Instances CRUD', () => {
               { action: 'remove', data: { before: existingInstance } },
             ],
           },
+          progressReporter: nullProgressReporter,
         })
       })
     })

--- a/packages/salesforce-adapter/test/filters/filters.test.ts
+++ b/packages/salesforce-adapter/test/filters/filters.test.ts
@@ -22,6 +22,7 @@ import { mockDeployResult, mockDeployMessage } from '../connection'
 import { apiName, createInstanceElement, metadataType } from '../../src/transformers/transformer'
 import { mockTypes } from '../mock_elements'
 import { FilterWith } from './mocks'
+import { nullProgressReporter } from '../utils'
 
 describe('SalesforceAdapter filters', () => {
   describe('when filter methods are implemented', () => {
@@ -85,6 +86,7 @@ describe('SalesforceAdapter filters', () => {
             groupID: instance.elemID.getFullName(),
             changes: inputChanges,
           },
+          progressReporter: nullProgressReporter,
         })
       })
 

--- a/packages/salesforce-adapter/test/utils.ts
+++ b/packages/salesforce-adapter/test/utils.ts
@@ -24,7 +24,7 @@ import {
   MapType,
   ObjectType,
   PrimitiveType,
-  PrimitiveTypes,
+  PrimitiveTypes, ProgressReporter,
   TypeElement,
   Values,
 } from '@salto-io/adapter-api'
@@ -375,4 +375,9 @@ export const defaultFilterContext: FilterContext = {
   fetchProfile: buildFetchProfile({ fetchParams: {} }),
   elementsSource: buildElementsSourceFromElements([]),
   enumFieldPermissions: false,
+}
+
+export const nullProgressReporter: ProgressReporter = {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  reportProgress: () => {},
 }

--- a/packages/sap-adapter/test/adapter.test.ts
+++ b/packages/sap-adapter/test/adapter.test.ts
@@ -21,7 +21,7 @@ import {
   InstanceElement,
   isInstanceElement,
   ListType,
-  ObjectType,
+  ObjectType, ProgressReporter,
 } from '@salto-io/adapter-api'
 import * as adapterComponents from '@salto-io/adapter-components'
 import { elements as elementUtils } from '@salto-io/adapter-components'
@@ -205,7 +205,14 @@ describe('adapter', () => {
             ),
             elementsSource: buildElementsSourceFromElements([]),
           })
-          await expect(operations.deploy({ changeGroup: { groupID: '', changes: [] } })).rejects.toThrow(new Error('Not implemented.'))
+          const nullProgressReporter: ProgressReporter = {
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
+            reportProgress: () => {},
+          }
+          await expect(operations.deploy({
+            changeGroup: { groupID: '', changes: [] },
+            progressReporter: nullProgressReporter,
+          })).rejects.toThrow(new Error('Not implemented.'))
         })
       })
     })

--- a/packages/stripe-adapter/test/adapter.test.ts
+++ b/packages/stripe-adapter/test/adapter.test.ts
@@ -23,7 +23,7 @@ import {
   InstanceElement,
   isInstanceElement,
   ListType,
-  ObjectType,
+  ObjectType, ProgressReporter,
   Values,
 } from '@salto-io/adapter-api'
 import * as adapterComponents from '@salto-io/adapter-components'
@@ -351,7 +351,14 @@ describe('stripe swagger adapter', () => {
         config: DEFAULT_CONFIG_INSTANCE,
         elementsSource: buildElementsSourceFromElements([]),
       })
-      const deployOptions = { changeGroup: { groupID: '', changes: [] } }
+      const nullProgressReporter: ProgressReporter = {
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        reportProgress: () => {},
+      }
+      const deployOptions = {
+        changeGroup: { groupID: '', changes: [] },
+        progressReporter: nullProgressReporter,
+      }
       await expect(adapterOperations.deploy(deployOptions)).rejects.toThrow(new Error('Not implemented.'))
     })
   })

--- a/packages/workato-adapter/test/adapter.test.ts
+++ b/packages/workato-adapter/test/adapter.test.ts
@@ -16,7 +16,10 @@
 import _ from 'lodash'
 import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
-import { InstanceElement, isInstanceElement, ReferenceExpression, ObjectType, ElemID, CORE_ANNOTATIONS, AdapterOperations } from '@salto-io/adapter-api'
+import {
+  InstanceElement, isInstanceElement, ReferenceExpression, ObjectType, ElemID, CORE_ANNOTATIONS, AdapterOperations,
+  ProgressReporter,
+} from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { types } from '@salto-io/lowerdash'
 import mockReplies from './mock_replies.json'
@@ -487,7 +490,14 @@ describe('adapter', () => {
         ),
         elementsSource: buildElementsSourceFromElements([]),
       })
-      await expect(operations.deploy({ changeGroup: { groupID: '', changes: [] } })).rejects.toThrow(new Error('Not implemented.'))
+      const nullProgressReporter: ProgressReporter = {
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        reportProgress: () => {},
+      }
+      await expect(operations.deploy({
+        changeGroup: { groupID: '', changes: [] },
+        progressReporter: nullProgressReporter,
+      })).rejects.toThrow(new Error('Not implemented.'))
     })
   })
 })

--- a/packages/zendesk-adapter/e2e_test/adapter.test.ts
+++ b/packages/zendesk-adapter/e2e_test/adapter.test.ts
@@ -30,7 +30,7 @@ import {
   isInstanceElement,
   isObjectType, isReferenceExpression, isTemplateExpression,
   ListType,
-  ObjectType,
+  ObjectType, ProgressReporter,
   ReferenceExpression,
   StaticFile,
   TemplateExpression,
@@ -140,8 +140,13 @@ const deployChanges = async (
   const deployResults = await awu(Object.entries(changes))
     .map(async ([id, group]) => {
       planElementById = _.keyBy(group.map(getChangeData), data => data.elemID.getFullName())
+      const nullProgressReporter: ProgressReporter = {
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        reportProgress: () => {},
+      }
       const deployResult = await adapterAttr.adapter.deploy({
         changeGroup: { groupID: id, changes: group },
+        progressReporter: nullProgressReporter,
       })
       expect(deployResult.errors).toHaveLength(0)
       expect(deployResult.appliedChanges).not.toHaveLength(0)

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -27,7 +27,7 @@ import {
   BuiltinTypes,
   CORE_ANNOTATIONS,
   isRemovalChange,
-  getChangeData, TemplateExpression, isObjectType,
+  getChangeData, TemplateExpression, isObjectType, ProgressReporter,
 } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
@@ -94,6 +94,10 @@ const callbackResponseFuncWith403 = (config: AxiosRequestConfig): any => {
   return callbackResponseFunc(config)
 }
 
+const nullProgressReporter: ProgressReporter = {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  reportProgress: () => {},
+}
 
 describe('adapter', () => {
   let mockAxiosAdapter: MockAdapter
@@ -2301,6 +2305,7 @@ describe('adapter', () => {
             modificationChange,
           ],
         },
+        progressReporter: nullProgressReporter,
       })
 
       // Mind that brands have filter that deploys them before the default instances
@@ -2333,6 +2338,7 @@ describe('adapter', () => {
             toChange({ before: new InstanceElement('inst2', groupType) }),
           ],
         },
+        progressReporter: nullProgressReporter,
       })
 
       expect(deployRes.errors).toEqual([
@@ -2355,6 +2361,7 @@ describe('adapter', () => {
             toChange({ after: new InstanceElement('inst', groupType) }),
           ],
         },
+        progressReporter: nullProgressReporter,
       })
       expect(deployRes.appliedChanges).toEqual([
         toChange({ after: new InstanceElement(
@@ -2405,6 +2412,7 @@ describe('adapter', () => {
             additionChange,
           ],
         },
+        progressReporter: nullProgressReporter,
       })
       expect(deployRes.appliedChanges).toEqual([
         appliedChanges,
@@ -2419,6 +2427,7 @@ describe('adapter', () => {
             toChange({ after: new InstanceElement('inst', groupType) }),
           ],
         },
+        progressReporter: nullProgressReporter,
       })
       expect(deployRes.appliedChanges).toEqual([
         toChange({ after: new InstanceElement(
@@ -2439,6 +2448,7 @@ describe('adapter', () => {
             toChange({ after: new InstanceElement('inst', groupType) }),
           ],
         },
+        progressReporter: nullProgressReporter,
       })
       expect(deployRes.appliedChanges).toEqual([
         toChange({ after: new InstanceElement(
@@ -2459,6 +2469,7 @@ describe('adapter', () => {
             toChange({ after: instance }),
           ],
         },
+        progressReporter: nullProgressReporter,
       })
       expect(mockDeployChange).toHaveBeenCalledWith({
         change: toChange({
@@ -2511,6 +2522,7 @@ describe('adapter', () => {
             toChange({ after: new ObjectType({ elemID: new ElemID(ZENDESK, 'test') }) }),
           ],
         },
+        progressReporter: nullProgressReporter,
       })
       expect(mockDeployChange).toHaveBeenCalledTimes(1)
       expect(mockDeployChange).toHaveBeenCalledWith({
@@ -2581,6 +2593,7 @@ describe('adapter', () => {
             groupID: '1',
             changes: [toChange({ after: settings1 }), toChange({ after: settings2 })],
           },
+          progressReporter: nullProgressReporter,
         })
         const guideFilterRunnerCall = expect.objectContaining({
           filterRunnerClient: expect.objectContaining({
@@ -2616,12 +2629,14 @@ describe('adapter', () => {
             groupID: '1',
             changes: [toChange({ after: settings1 })],
           },
+          progressReporter: nullProgressReporter,
         })
         await zendeskAdapter.deploy({
           changeGroup: {
             groupID: '2',
             changes: [toChange({ before: settings1 })],
           },
+          progressReporter: nullProgressReporter,
         })
         expect(getClientSpy).toHaveBeenCalledTimes(2)
         expect(createClientSpy).toHaveBeenCalledTimes(1)

--- a/packages/zuora-billing-adapter/test/adapter.test.ts
+++ b/packages/zuora-billing-adapter/test/adapter.test.ts
@@ -25,7 +25,7 @@ import {
   MapType,
   ObjectType,
   isObjectType,
-  CORE_ANNOTATIONS,
+  CORE_ANNOTATIONS, ProgressReporter,
 } from '@salto-io/adapter-api'
 import * as adapterComponents from '@salto-io/adapter-components'
 import { elements as elementUtils } from '@salto-io/adapter-components'
@@ -469,7 +469,14 @@ describe('adapter', () => {
         ),
         elementsSource: buildElementsSourceFromElements([]),
       })
-      await expect(operations.deploy({ changeGroup: { groupID: '', changes: [] } })).rejects.toThrow(new Error('Not implemented.'))
+      const nullProgressReporter: ProgressReporter = {
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        reportProgress: () => {},
+      }
+      await expect(operations.deploy({
+        changeGroup: { groupID: '', changes: [] },
+        progressReporter: nullProgressReporter,
+      })).rejects.toThrow(new Error('Not implemented.'))
     })
   })
 })


### PR DESCRIPTION
Allow adapters to report progress during deploy

- [ ] ~Review of the progress message from @tomermevorach and @pgonzaleznetwork~

---

1. Allow adapters to accept a `ProgressReporter` during deploy
2. In the Salesforce adapter, Instead of waiting for the deploy to complete, check its status once in a while and report the progress

Tests:
 - Deploy and check the logs to see the expected data is printed out
 - Change the `client.polling.interval` and `client.polling.deployTimeout` configs to 1 second and confirm the deploy times out with the correct error message.

---
_Release Notes_: 
N/A

---
_User Notifications_: 
N/A