### PR TITLE
SALTO-1590 support exclude by criteria in netsuite

### DIFF
--- a/packages/netsuite-adapter/config_doc.md
+++ b/packages/netsuite-adapter/config_doc.md
@@ -24,7 +24,13 @@ netsuite {
         {
           name = "savedsearch"
           ids = [".*"]
-        }
+        },
+        {
+          name = ".*"
+          criteria = {
+            isinactive = true
+          }
+        },
       ]
       fileCabinet = [
         "^/Web Site Hosting Files.*",

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -62,7 +62,8 @@ import additionalChanges from './filters/additional_changes'
 import addInstancesFetchTime from './filters/add_instances_fetch_time'
 import addAliasFilter from './filters/add_alias'
 import addBundleReferences from './filters/bundle_ids'
-import excludeByCriteria from './filters/exclude_by_criteria'
+import excludeCustomRecordTypes from './filters/exclude_by_criteria/exclude_custom_record_types'
+import excludeInstances from './filters/exclude_by_criteria/exclude_instances'
 import { Filter, LocalFilterCreator, LocalFilterCreatorDefinition, RemoteFilterCreator, RemoteFilterCreatorDefinition, RemoteFilterOpts } from './filter'
 import { getConfigFromConfigChanges, NetsuiteConfig, DEFAULT_DEPLOY_REFERENCED_ELEMENTS, DEFAULT_WARN_STALE_DATA, DEFAULT_VALIDATE, AdditionalDependencies, DEFAULT_MAX_FILE_CABINET_SIZE_IN_GB, shouldExcludeBins } from './config'
 import { andQuery, buildNetsuiteQuery, NetsuiteQuery, NetsuiteQueryParameters, notQuery, QueryParams, convertToQueryParams, getFixedTargetFetch, ObjectID } from './query'
@@ -89,7 +90,9 @@ const { awu } = collections.asynciterable
 const log = logger(module)
 
 export const allFilters: (LocalFilterCreatorDefinition | RemoteFilterCreatorDefinition)[] = [
-  { creator: excludeByCriteria },
+  // excludeCustomRecordTypes should run before customRecordTypesType,
+  // because otherwise there will be broken references to excluded type.
+  { creator: excludeCustomRecordTypes },
   { creator: customRecordTypesType },
   { creator: omitSdfUntypedValues },
   { creator: dataInstancesIdentifiers },
@@ -99,6 +102,9 @@ export const allFilters: (LocalFilterCreatorDefinition | RemoteFilterCreatorDefi
   { creator: parseReportTypes },
   { creator: convertLists },
   { creator: consistentValues },
+  // excludeInstances should run after parseReportTypes & consistentValues,
+  // so users will be able to exclude elements based on parsed values.
+  { creator: excludeInstances },
   // convertListsToMaps must run after convertLists and consistentValues
   // and must run before replaceInstanceReferencesFilter
   { creator: convertListsToMaps },

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -62,6 +62,7 @@ import additionalChanges from './filters/additional_changes'
 import addInstancesFetchTime from './filters/add_instances_fetch_time'
 import addAliasFilter from './filters/add_alias'
 import addBundleReferences from './filters/bundle_ids'
+import excludeByCriteria from './filters/exclude_by_criteria'
 import { Filter, LocalFilterCreator, LocalFilterCreatorDefinition, RemoteFilterCreator, RemoteFilterCreatorDefinition, RemoteFilterOpts } from './filter'
 import { getConfigFromConfigChanges, NetsuiteConfig, DEFAULT_DEPLOY_REFERENCED_ELEMENTS, DEFAULT_WARN_STALE_DATA, DEFAULT_VALIDATE, AdditionalDependencies, DEFAULT_MAX_FILE_CABINET_SIZE_IN_GB, shouldExcludeBins } from './config'
 import { andQuery, buildNetsuiteQuery, NetsuiteQuery, NetsuiteQueryParameters, notQuery, QueryParams, convertToQueryParams, getFixedTargetFetch, ObjectID } from './query'
@@ -88,6 +89,7 @@ const { awu } = collections.asynciterable
 const log = logger(module)
 
 export const allFilters: (LocalFilterCreatorDefinition | RemoteFilterCreatorDefinition)[] = [
+  { creator: excludeByCriteria },
   { creator: customRecordTypesType },
   { creator: omitSdfUntypedValues },
   { creator: dataInstancesIdentifiers },

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -91,7 +91,7 @@ const log = logger(module)
 
 export const allFilters: (LocalFilterCreatorDefinition | RemoteFilterCreatorDefinition)[] = [
   // excludeCustomRecordTypes should run before customRecordTypesType,
-  // because otherwise there will be broken references to excluded type.
+  // because otherwise there will be broken references to excluded types.
   { creator: excludeCustomRecordTypes },
   { creator: customRecordTypesType },
   { creator: omitSdfUntypedValues },

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -706,7 +706,7 @@ export const validateFetchConfig = ({
   validatePlainObject(include, [CONFIG.fetch, FETCH_PARAMS.include])
   validateFetchParameters(include)
   if (include.types.concat(include.customRecords ?? []).filter(isCriteriaQuery).length > 0) {
-    throw new Error('criteria is only allowed in fetch.exclude')
+    throw new Error('The "criteria" configuration option is exclusively permitted within the "fetch.exclude" configuration and should not be used within the "fetch.include" configuration.')
   }
 
   validateDefined(exclude, [CONFIG.fetch, FETCH_PARAMS.exclude])

--- a/packages/netsuite-adapter/src/filters/exclude_by_criteria.ts
+++ b/packages/netsuite-adapter/src/filters/exclude_by_criteria.ts
@@ -1,0 +1,91 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { regex } from '@salto-io/lowerdash'
+import { logger } from '@salto-io/logging'
+import { ObjectType, Values, isInstanceElement, isObjectType } from '@salto-io/adapter-api'
+import { CriteriaQuery, isCriteriaQuery } from '../query'
+import { LocalFilterCreator } from '../filter'
+import { isCustomRecordType } from '../types'
+import { CUSTOM_RECORD_TYPE } from '../constants'
+
+const log = logger(module)
+
+const shouldExcludeElement = (
+  elementValues: Values,
+  criteriaQueries: CriteriaQuery[]
+): boolean => criteriaQueries.some(query =>
+  _.isEqualWith(
+    _.pick(elementValues, Object.keys(query.criteria)),
+    query.criteria,
+    (elemValue: unknown, criteriaValue: unknown) => {
+      if (_.isString(elemValue) && _.isString(criteriaValue)) {
+        return regex.isFullRegexMatch(elemValue, criteriaValue)
+      }
+      return undefined
+    }
+  ))
+
+const createCriteriaByTypeMap = (
+  types: ObjectType[],
+  criteriaQueries: CriteriaQuery[],
+): Record<string, CriteriaQuery[]> => Object.fromEntries(
+  types.map(type => type.elemID.name).map(typeName => [
+    typeName,
+    criteriaQueries.filter(query => regex.isFullRegexMatch(typeName, query.name)),
+  ] as [string, CriteriaQuery[]])
+)
+
+const filterCreator: LocalFilterCreator = ({ config }) => ({
+  name: 'excludeByCriteria',
+  onFetch: async elements => {
+    const typeCriteriaQueries = config.fetch.exclude.types.filter(isCriteriaQuery)
+    const customRecordCriteriaQueries = config.fetch.exclude.customRecords?.filter(isCriteriaQuery) ?? []
+    if (typeCriteriaQueries.length === 0 && customRecordCriteriaQueries.length === 0) {
+      return
+    }
+    const [customRecordTypes, types] = _.partition(elements.filter(isObjectType), isCustomRecordType)
+    const criteriaByType = createCriteriaByTypeMap(types, typeCriteriaQueries)
+    const criteriaByCustomRecordType = createCriteriaByTypeMap(customRecordTypes, customRecordCriteriaQueries)
+
+    const removedCustomRecordTypes = _.remove(elements, element => {
+      if (isObjectType(element) && isCustomRecordType(element)) {
+        return shouldExcludeElement(element.annotations, criteriaByType[CUSTOM_RECORD_TYPE])
+      }
+      return false
+    })
+    const removedCustomRecordTypeNames = new Set(removedCustomRecordTypes.map(type => type.elemID.name))
+    const removedInstances = _.remove(elements, element => {
+      if (isInstanceElement(element)) {
+        const type = element.elemID.typeName
+        if (removedCustomRecordTypeNames.has(type)) {
+          return true
+        }
+        const criteria = criteriaByCustomRecordType[type] ?? criteriaByType[type]
+        return shouldExcludeElement(element.value, criteria)
+      }
+      return false
+    })
+    const removedElements = removedCustomRecordTypes.concat(removedInstances)
+    log.debug(
+      'excluding %d elements by criteria: %o',
+      removedElements.length,
+      removedElements.map(elem => elem.elemID.getFullName())
+    )
+  },
+})
+
+export default filterCreator

--- a/packages/netsuite-adapter/src/filters/exclude_by_criteria/exclude_custom_record_types.ts
+++ b/packages/netsuite-adapter/src/filters/exclude_by_criteria/exclude_custom_record_types.ts
@@ -1,0 +1,51 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { regex } from '@salto-io/lowerdash'
+import { logger } from '@salto-io/logging'
+import { isInstanceElement, isObjectType } from '@salto-io/adapter-api'
+import { isCriteriaQuery } from '../../query'
+import { LocalFilterCreator } from '../../filter'
+import { isCustomRecordType } from '../../types'
+import { CUSTOM_RECORD_TYPE } from '../../constants'
+import { shouldExcludeElement } from './exclude_instances'
+
+const log = logger(module)
+
+const filterCreator: LocalFilterCreator = ({ config }) => ({
+  name: 'excludeCustomRecordTypes',
+  onFetch: async elements => {
+    const customRecordTypeCriteria = config.fetch.exclude.types.filter(isCriteriaQuery)
+      .filter(query => regex.isFullRegexMatch(CUSTOM_RECORD_TYPE, query.name))
+    if (customRecordTypeCriteria.length === 0) {
+      return
+    }
+    const removedCustomRecordTypes = _.remove(elements, element =>
+      isObjectType(element) && isCustomRecordType(element)
+      && shouldExcludeElement(element.annotations, customRecordTypeCriteria))
+    const removedCustomRecordTypeNames = new Set(removedCustomRecordTypes.map(type => type.elemID.name))
+    const removedCustomRecordInstances = _.remove(elements, element =>
+      isInstanceElement(element) && removedCustomRecordTypeNames.has(element.elemID.typeName))
+    log.debug(
+      'excluding %d custom record types and %d custom record instances by criteria: %o',
+      removedCustomRecordTypes.length,
+      removedCustomRecordInstances.length,
+      removedCustomRecordTypes.map(elem => elem.elemID.getFullName())
+    )
+  },
+})
+
+export default filterCreator

--- a/packages/netsuite-adapter/src/filters/exclude_by_criteria/exclude_instances.ts
+++ b/packages/netsuite-adapter/src/filters/exclude_by_criteria/exclude_instances.ts
@@ -34,6 +34,7 @@ export const shouldExcludeElement = (
       if (_.isString(elemValue) && _.isString(criteriaValue)) {
         return regex.isFullRegexMatch(elemValue, criteriaValue)
       }
+      // returning undefined makes lodash to handle the comparison (using isEqual)
       return undefined
     }
   ))

--- a/packages/netsuite-adapter/src/query.ts
+++ b/packages/netsuite-adapter/src/query.ts
@@ -208,27 +208,27 @@ export function validateFetchParameters(
   }
   const corruptedTypeQueries = types.filter(isInvalidTypeQuery)
   if (corruptedTypeQueries.length !== 0) {
-    throw new Error(`${ERROR_MESSAGE_PREFIX} Expected type name to be a string and not to have both ids & criteria, but found:\n${JSON.stringify(corruptedTypeQueries, null, 4)}.`)
+    throw new Error(`${ERROR_MESSAGE_PREFIX} Expected the type name to be a string without both "ids" and "criteria", but found:\n${JSON.stringify(corruptedTypeQueries, null, 4)}.`)
   }
   const corruptedTypesIds = types.filter(isInvalidIdsParam)
   if (corruptedTypesIds.length !== 0) {
-    throw new Error(`${ERROR_MESSAGE_PREFIX} Expected type ids to be an array of strings, but found:\n${JSON.stringify(corruptedTypesIds, null, 4)}}.`)
+    throw new Error(`${ERROR_MESSAGE_PREFIX} Expected type "ids" to be an array of strings, but found:\n${JSON.stringify(corruptedTypesIds, null, 4)}}.`)
   }
   const corruptedTypesCriteria = types.filter(isInvalidCriteriaParam)
   if (corruptedTypesCriteria.length !== 0) {
-    throw new Error(`${ERROR_MESSAGE_PREFIX} Expected type criteria to be a non empty object, but found:\n${JSON.stringify(corruptedTypesCriteria, null, 4)}}.`)
+    throw new Error(`${ERROR_MESSAGE_PREFIX} Expected type "criteria" to be a non-empty object, but found:\n${JSON.stringify(corruptedTypesCriteria, null, 4)}}.`)
   }
   const corruptedCustomRecords = customRecords.filter(isInvalidTypeQuery)
   if (corruptedCustomRecords.length !== 0) {
-    throw new Error(`${ERROR_MESSAGE_PREFIX} Expected custom record name to be a string and not to have both ids & criteria, but found:\n${JSON.stringify(corruptedCustomRecords, null, 4)}.`)
+    throw new Error(`${ERROR_MESSAGE_PREFIX} Expected the custom record name to be a string without both "ids" and "criteria", but found:\n${JSON.stringify(corruptedCustomRecords, null, 4)}.`)
   }
   const corruptedCustomRecordsIds = customRecords.filter(isInvalidIdsParam)
   if (corruptedCustomRecordsIds.length !== 0) {
-    throw new Error(`${ERROR_MESSAGE_PREFIX} Expected custom record ids to be an array of strings, but found:\n${JSON.stringify(corruptedCustomRecordsIds, null, 4)}}.`)
+    throw new Error(`${ERROR_MESSAGE_PREFIX} Expected custom record "ids" to be an array of strings, but found:\n${JSON.stringify(corruptedCustomRecordsIds, null, 4)}}.`)
   }
   const corruptedCustomRecordsCriteria = customRecords.filter(isInvalidCriteriaParam)
   if (corruptedCustomRecordsCriteria.length !== 0) {
-    throw new Error(`${ERROR_MESSAGE_PREFIX} Expected custom record criteria to be a non empty object, but found:\n${JSON.stringify(corruptedCustomRecordsCriteria, null, 4)}}.`)
+    throw new Error(`${ERROR_MESSAGE_PREFIX} Expected custom record "criteria" to be a non-empty object, but found:\n${JSON.stringify(corruptedCustomRecordsCriteria, null, 4)}}.`)
   }
 
   const receivedTypes = types.map(obj => obj.name)

--- a/packages/netsuite-adapter/src/query.ts
+++ b/packages/netsuite-adapter/src/query.ts
@@ -15,6 +15,7 @@
 */
 import _ from 'lodash'
 import { collections, regex, strings, types as lowerdashTypes } from '@salto-io/lowerdash'
+import { Values } from '@salto-io/adapter-api'
 import { CUSTOM_RECORD_TYPE, CUSTOM_SEGMENT } from './constants'
 import { TYPES_TO_INTERNAL_ID } from './data_elements/types'
 import { netsuiteSupportedTypes, removeCustomRecordTypePrefix } from './types'
@@ -36,10 +37,17 @@ export type NetsuiteQueryParameters = {
   customRecords?: NetsuiteTypesQueryParams
 }
 
-export type FetchTypeQueryParams = {
+export type IdsQuery = {
   name: string
   ids?: string[]
 }
+
+export type CriteriaQuery = {
+  name: string
+  criteria: Values
+}
+
+export type FetchTypeQueryParams = IdsQuery | CriteriaQuery
 
 export type QueryParams = {
   types: FetchTypeQueryParams[]
@@ -71,6 +79,15 @@ export type FetchParams = {
   addBundles?: boolean
 } & LockedElementsConfig['fetch']
 
+export const isCriteriaQuery = (
+  type: FetchTypeQueryParams
+): type is CriteriaQuery =>
+  'criteria' in type
+
+export const isIdsQuery = (
+  type: FetchTypeQueryParams
+): type is IdsQuery =>
+  !isCriteriaQuery(type)
 
 export const fullQueryParams = (): QueryParams => ({
   types: [{ name: '.*' }],
@@ -171,9 +188,17 @@ export const noSupportedTypeMatch = (name: string): boolean =>
     || checkTypeNameRegMatch({ name },
       strings.capitalizeFirstLetter(existTypeName)))
 
-export const validateFetchParameters = ({
-  types, fileCabinet, customRecords = [],
-}: Partial<Record<keyof QueryParams, unknown>>): void => {
+const isInvalidTypeQuery = (obj: Record<string, unknown>): boolean =>
+  typeof obj.name !== 'string' || (obj.ids !== undefined && obj.criteria !== undefined)
+const isInvalidIdsParam = (obj: Record<string, unknown>): boolean =>
+  obj.ids !== undefined && (!Array.isArray(obj.ids) || obj.ids.some((id: unknown) => typeof id !== 'string'))
+const isInvalidCriteriaParam = (obj: Record<string, unknown>): boolean =>
+  obj.criteria !== undefined && (!_.isPlainObject(obj.criteria) || _.isEmpty(obj.criteria))
+
+export function validateFetchParameters(
+  params: Partial<Record<keyof QueryParams, unknown>>
+): asserts params is QueryParams {
+  const { types, fileCabinet, customRecords = [] } = params
   if (!Array.isArray(types) || !Array.isArray(fileCabinet) || !Array.isArray(customRecords)) {
     const typesErr = !Array.isArray(types) ? ' "types" field is expected to be an array\n' : ''
     const fileCabinetErr = !Array.isArray(fileCabinet) ? ' "fileCabinet" field is expected to be an array\n' : ''
@@ -181,21 +206,29 @@ export const validateFetchParameters = ({
     const message = `${ERROR_MESSAGE_PREFIX}${typesErr}${fileCabinetErr}${customRecordsErr}`
     throw new Error(message)
   }
-  const corruptedTypesNames = types.filter(obj => (obj.name === undefined || typeof obj.name !== 'string'))
-  if (corruptedTypesNames.length !== 0) {
-    throw new Error(`${ERROR_MESSAGE_PREFIX} Expected type name to be a string, but found:\n${JSON.stringify(corruptedTypesNames, null, 4)}.`)
+  const corruptedTypeQueries = types.filter(isInvalidTypeQuery)
+  if (corruptedTypeQueries.length !== 0) {
+    throw new Error(`${ERROR_MESSAGE_PREFIX} Expected type name to be a string and not to have both ids & criteria, but found:\n${JSON.stringify(corruptedTypeQueries, null, 4)}.`)
   }
-  const corruptedTypesIds = types.filter(obj => (obj.ids !== undefined && (!Array.isArray(obj.ids) || obj.ids.some((id: unknown) => typeof id !== 'string'))))
+  const corruptedTypesIds = types.filter(isInvalidIdsParam)
   if (corruptedTypesIds.length !== 0) {
     throw new Error(`${ERROR_MESSAGE_PREFIX} Expected type ids to be an array of strings, but found:\n${JSON.stringify(corruptedTypesIds, null, 4)}}.`)
   }
-  const corruptedCustomRecords = customRecords.filter(obj => (obj.name === undefined || typeof obj.name !== 'string'))
-  if (corruptedCustomRecords.length !== 0) {
-    throw new Error(`${ERROR_MESSAGE_PREFIX} Expected custom record name to be a string, but found:\n${JSON.stringify(corruptedCustomRecords, null, 4)}.`)
+  const corruptedTypesCriteria = types.filter(isInvalidCriteriaParam)
+  if (corruptedTypesCriteria.length !== 0) {
+    throw new Error(`${ERROR_MESSAGE_PREFIX} Expected type criteria to be a non empty object, but found:\n${JSON.stringify(corruptedTypesCriteria, null, 4)}}.`)
   }
-  const corruptedCustomRecordsIds = customRecords.filter(obj => (obj.ids !== undefined && (!Array.isArray(obj.ids) || obj.ids.some((id: unknown) => typeof id !== 'string'))))
+  const corruptedCustomRecords = customRecords.filter(isInvalidTypeQuery)
+  if (corruptedCustomRecords.length !== 0) {
+    throw new Error(`${ERROR_MESSAGE_PREFIX} Expected custom record name to be a string and not to have both ids & criteria, but found:\n${JSON.stringify(corruptedCustomRecords, null, 4)}.`)
+  }
+  const corruptedCustomRecordsIds = customRecords.filter(isInvalidIdsParam)
   if (corruptedCustomRecordsIds.length !== 0) {
     throw new Error(`${ERROR_MESSAGE_PREFIX} Expected custom record ids to be an array of strings, but found:\n${JSON.stringify(corruptedCustomRecordsIds, null, 4)}}.`)
+  }
+  const corruptedCustomRecordsCriteria = customRecords.filter(isInvalidCriteriaParam)
+  if (corruptedCustomRecordsCriteria.length !== 0) {
+    throw new Error(`${ERROR_MESSAGE_PREFIX} Expected custom record criteria to be a non empty object, but found:\n${JSON.stringify(corruptedCustomRecordsCriteria, null, 4)}}.`)
   }
 
   const receivedTypes = types.map(obj => obj.name)
@@ -255,6 +288,7 @@ const buildTypesQuery = (types: FetchTypeQueryParams[]): TypesQuery => {
 
   const matchingTypesRegexes = (typeName: string): string[] =>
     matchingTypes(typeName)
+      .filter(isIdsQuery)
       .flatMap(type => type.ids ?? ['.*'])
 
   return {

--- a/packages/netsuite-adapter/test/config.test.ts
+++ b/packages/netsuite-adapter/test/config.test.ts
@@ -267,7 +267,7 @@ describe('config', () => {
       expect(() => netsuiteConfigFromConfig(configWithInvalidExclude)).toThrow('Failed to load Netsuite config: Received invalid adapter config input. "types" field is expected to be an array\n "fileCabinet" field is expected to be an array\n'))
 
     it('Should throw an error if include contains criteria query', () =>
-      expect(() => netsuiteConfigFromConfig(configWithIncludeCriteria)).toThrow('Failed to load Netsuite config: criteria is only allowed in fetch.exclude.'))
+      expect(() => netsuiteConfigFromConfig(configWithIncludeCriteria)).toThrow('Failed to load Netsuite config: The "criteria" configuration option is exclusively permitted within the "fetch.exclude" configuration and should not be used within the "fetch.include" configuration.'))
 
     it('Should not throw an error if exclude contains criteria query', () =>
       expect(() => netsuiteConfigFromConfig(configWithExcludeCriteria)).not.toThrow())

--- a/packages/netsuite-adapter/test/config.test.ts
+++ b/packages/netsuite-adapter/test/config.test.ts
@@ -43,6 +43,7 @@ describe('config', () => {
         types: [
           { name: 'testAll', ids: ['.*'] },
           { name: 'testExistingPartial', ids: ['scriptid1', 'scriptid2'] },
+          { name: '.*', criteria: { isinactive: true } },
         ],
         fileCabinet: ['SomeRegex'],
       },
@@ -125,6 +126,7 @@ describe('config', () => {
       types: [
         { name: 'testAll', ids: ['.*'] },
         { name: 'testExistingPartial', ids: ['scriptid1', 'scriptid2', 'scriptid3', 'scriptid4'] },
+        { name: '.*', criteria: { isinactive: true } },
         { name: 'testNew', ids: ['scriptid5', 'scriptid6'] },
         { name: 'excludedTypeTest' },
       ],
@@ -195,29 +197,59 @@ describe('config', () => {
       .toBe(formatConfigSuggestionsReasons([STOP_MANAGING_ITEMS_MSG, LARGE_FOLDERS_EXCLUDED_MESSAGE]))
   })
   describe('Fetch validation', () => {
-    const configWithoutFetch = new InstanceElement('empty', configType, {})
-    const configWithoutInclude = new InstanceElement('noInclude', configType, {
+    const defaultFetchConfig = new InstanceElement(ElemID.CONFIG_NAME, configType, {
+      fetch: fetchDefault,
+    })
+    const configWithoutFetch = new InstanceElement(ElemID.CONFIG_NAME, configType, {})
+    const configWithoutInclude = new InstanceElement(ElemID.CONFIG_NAME, configType, {
       fetch: {
         exclude: emptyQueryParams(),
       },
     })
-    const configWithInvalidInclude = new InstanceElement('invalidInclude', configType, {
+    const configWithInvalidInclude = new InstanceElement(ElemID.CONFIG_NAME, configType, {
       fetch: {
         include: {},
         exclude: emptyQueryParams(),
       },
     })
-    const configWithoutExclude = new InstanceElement('noExclude', configType, {
+    const configWithoutExclude = new InstanceElement(ElemID.CONFIG_NAME, configType, {
       fetch: {
         include: emptyQueryParams(),
       },
     })
-    const configWithInvalidExclude = new InstanceElement('invalidExclude', configType, {
+    const configWithInvalidExclude = new InstanceElement(ElemID.CONFIG_NAME, configType, {
       fetch: {
         include: emptyQueryParams(),
         exclude: {},
       },
     })
+    const configWithIncludeCriteria = new InstanceElement(ElemID.CONFIG_NAME, configType, {
+      fetch: {
+        ...fetchDefault,
+        include: {
+          ...fetchDefault.include,
+          types: [
+            ...fetchDefault.include.types,
+            { name: '.*', criteria: { isinactive: false } },
+          ],
+        },
+      },
+    })
+    const configWithExcludeCriteria = new InstanceElement(ElemID.CONFIG_NAME, configType, {
+      fetch: {
+        ...fetchDefault,
+        exclude: {
+          ...fetchDefault.exclude,
+          types: [
+            ...fetchDefault.exclude.types,
+            { name: '.*', criteria: { isinactive: false } },
+          ],
+        },
+      },
+    })
+
+    it('Should not throw on a valid fetch config', () =>
+      expect(() => netsuiteConfigFromConfig(defaultFetchConfig)).not.toThrow())
 
     it('Should throw an error if the fetch is undefined', () =>
       expect(() => netsuiteConfigFromConfig(configWithoutFetch)).toThrow('Failed to load Netsuite config: fetch should be defined'))
@@ -233,6 +265,12 @@ describe('config', () => {
 
     it('Should throw an error if the exclude is non-valid', () =>
       expect(() => netsuiteConfigFromConfig(configWithInvalidExclude)).toThrow('Failed to load Netsuite config: Received invalid adapter config input. "types" field is expected to be an array\n "fileCabinet" field is expected to be an array\n'))
+
+    it('Should throw an error if include contains criteria query', () =>
+      expect(() => netsuiteConfigFromConfig(configWithIncludeCriteria)).toThrow('Failed to load Netsuite config: criteria is only allowed in fetch.exclude.'))
+
+    it('Should not throw an error if exclude contains criteria query', () =>
+      expect(() => netsuiteConfigFromConfig(configWithExcludeCriteria)).not.toThrow())
   })
 
   describe('should have a correct default fetch config', () => {

--- a/packages/netsuite-adapter/test/filters/exclude_by_criteria.test.ts
+++ b/packages/netsuite-adapter/test/filters/exclude_by_criteria.test.ts
@@ -14,12 +14,18 @@
 * limitations under the License.
 */
 import { Element, ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { buildElementsSourceFromElements, filter } from '@salto-io/adapter-utils'
 import { createEmptyElementsSourceIndexes, getDefaultAdapterConfig } from '../utils'
 import { CUSTOM_RECORD_TYPE, METADATA_TYPE, NETSUITE, WORKFLOW } from '../../src/constants'
-import filterCreator from '../../src/filters/exclude_by_criteria'
+import excludeCustomRecordTypes from '../../src/filters/exclude_by_criteria/exclude_custom_record_types'
+import excludeInstances from '../../src/filters/exclude_by_criteria/exclude_instances'
 import { LocalFilterOpts } from '../../src/filter'
 import { customrecordtypeType } from '../../src/autogen/types/standard_types/customrecordtype'
+
+const filters = [
+  excludeCustomRecordTypes,
+  excludeInstances,
+]
 
 describe('omit fields filter', () => {
   let filterOpts: LocalFilterOpts
@@ -116,7 +122,7 @@ describe('omit fields filter', () => {
   })
   it('should quick return when there are no criteria', async () => {
     const elementsLength = elements.length
-    await filterCreator(filterOpts).onFetch?.(elements)
+    await filter.filtersRunner(filterOpts, filters).onFetch?.(elements)
     expect(elements.length).toEqual(elementsLength)
   })
   it('should exclude instance by criteria', async () => {
@@ -125,7 +131,7 @@ describe('omit fields filter', () => {
       criteria: { isinactive: true },
     })
     const elementsLength = elements.length
-    await filterCreator(filterOpts).onFetch?.(elements)
+    await filter.filtersRunner(filterOpts, filters).onFetch?.(elements)
     expect(elements.length).toEqual(elementsLength - 1)
     expect(elements.find(elem => elem.elemID.isEqual(instanceToExclude.elemID))).toBeUndefined()
   })
@@ -138,7 +144,7 @@ describe('omit fields filter', () => {
       },
     })
     const elementsLength = elements.length
-    await filterCreator(filterOpts).onFetch?.(elements)
+    await filter.filtersRunner(filterOpts, filters).onFetch?.(elements)
     expect(elements.length).toEqual(elementsLength - 1)
     expect(elements.find(elem => elem.elemID.isEqual(instanceToExclude.elemID))).toBeUndefined()
   })
@@ -148,7 +154,7 @@ describe('omit fields filter', () => {
       criteria: { isinactive: true },
     })
     const elementsLength = elements.length
-    await filterCreator(filterOpts).onFetch?.(elements)
+    await filter.filtersRunner(filterOpts, filters).onFetch?.(elements)
     expect(elements.length).toEqual(elementsLength - 2)
     expect(elements.find(elem => elem.elemID.isEqual(customRecordTypeToExclude.elemID))).toBeUndefined()
     expect(elements.find(elem => elem.elemID.isEqual(customRecordInstance.elemID))).toBeUndefined()
@@ -159,7 +165,7 @@ describe('omit fields filter', () => {
       criteria: { isinactive: true },
     }]
     const elementsLength = elements.length
-    await filterCreator(filterOpts).onFetch?.(elements)
+    await filter.filtersRunner(filterOpts, filters).onFetch?.(elements)
     expect(elements.length).toEqual(elementsLength - 1)
     expect(elements.find(elem => elem.elemID.isEqual(customRecordInstanceToExclude.elemID))).toBeUndefined()
   })

--- a/packages/netsuite-adapter/test/filters/exclude_by_criteria.test.ts
+++ b/packages/netsuite-adapter/test/filters/exclude_by_criteria.test.ts
@@ -1,0 +1,166 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Element, ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { createEmptyElementsSourceIndexes, getDefaultAdapterConfig } from '../utils'
+import { CUSTOM_RECORD_TYPE, METADATA_TYPE, NETSUITE, WORKFLOW } from '../../src/constants'
+import filterCreator from '../../src/filters/exclude_by_criteria'
+import { LocalFilterOpts } from '../../src/filter'
+import { customrecordtypeType } from '../../src/autogen/types/standard_types/customrecordtype'
+
+describe('omit fields filter', () => {
+  let filterOpts: LocalFilterOpts
+  let standardType: ObjectType
+  let otherType: ObjectType
+  let customRecordType: ObjectType
+  let customRecordTypeToExclude: ObjectType
+  let instanceToExclude: InstanceElement
+  let otherTypeInstance: InstanceElement
+  let noMatchInstance: InstanceElement
+  let customRecordInstance: InstanceElement
+  let customRecordInstanceToExclude: InstanceElement
+  let elements: Element[]
+
+  beforeEach(async () => {
+    standardType = new ObjectType({ elemID: new ElemID(NETSUITE, WORKFLOW) })
+    otherType = new ObjectType({ elemID: new ElemID(NETSUITE, 'someType') })
+    customRecordType = new ObjectType({
+      elemID: new ElemID(NETSUITE, 'custrecord1'),
+      annotations: {
+        scriptid: 'custrecord1',
+        isinactive: false,
+        [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
+      },
+    })
+    customRecordTypeToExclude = new ObjectType({
+      elemID: new ElemID(NETSUITE, 'custrecord2'),
+      annotations: {
+        scriptid: 'custrecord2',
+        isinactive: true,
+        [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
+      },
+    })
+    instanceToExclude = new InstanceElement(
+      'workflow1',
+      standardType,
+      {
+        scriptid: 'workflow1',
+        isinactive: true,
+      }
+    )
+    otherTypeInstance = new InstanceElement(
+      'someInstance',
+      otherType,
+      {
+        name: 'some instance',
+        isinactive: true,
+      }
+    )
+    noMatchInstance = new InstanceElement(
+      'workflow2',
+      standardType,
+      {
+        scriptid: 'workflow2',
+        isinactive: false,
+      }
+    )
+    customRecordInstance = new InstanceElement(
+      'val_123',
+      customRecordTypeToExclude,
+      {
+        scriptid: 'val_123',
+        isinactive: false,
+      }
+    )
+    customRecordInstanceToExclude = new InstanceElement(
+      'val_456',
+      customRecordType,
+      {
+        scriptid: 'val_456',
+        isinactive: true,
+      }
+    )
+    elements = [
+      customrecordtypeType().type,
+      standardType,
+      otherType,
+      customRecordType,
+      customRecordTypeToExclude,
+      instanceToExclude,
+      otherTypeInstance,
+      noMatchInstance,
+      customRecordInstance,
+      customRecordInstanceToExclude,
+    ]
+    filterOpts = {
+      elementsSourceIndex: {
+        getIndexes: async () => createEmptyElementsSourceIndexes(),
+      },
+      elementsSource: buildElementsSourceFromElements([]),
+      isPartial: false,
+      config: await getDefaultAdapterConfig(),
+    }
+  })
+  it('should quick return when there are no criteria', async () => {
+    const elementsLength = elements.length
+    await filterCreator(filterOpts).onFetch?.(elements)
+    expect(elements.length).toEqual(elementsLength)
+  })
+  it('should exclude instance by criteria', async () => {
+    filterOpts.config.fetch.exclude.types.push({
+      name: WORKFLOW,
+      criteria: { isinactive: true },
+    })
+    const elementsLength = elements.length
+    await filterCreator(filterOpts).onFetch?.(elements)
+    expect(elements.length).toEqual(elementsLength - 1)
+    expect(elements.find(elem => elem.elemID.isEqual(instanceToExclude.elemID))).toBeUndefined()
+  })
+  it('should exclude instance by complex criteria', async () => {
+    filterOpts.config.fetch.exclude.types.push({
+      name: '.*',
+      criteria: {
+        scriptid: 'workflow.*',
+        isinactive: true,
+      },
+    })
+    const elementsLength = elements.length
+    await filterCreator(filterOpts).onFetch?.(elements)
+    expect(elements.length).toEqual(elementsLength - 1)
+    expect(elements.find(elem => elem.elemID.isEqual(instanceToExclude.elemID))).toBeUndefined()
+  })
+  it('should exclude custom record type by criteria with its instances', async () => {
+    filterOpts.config.fetch.exclude.types.push({
+      name: CUSTOM_RECORD_TYPE,
+      criteria: { isinactive: true },
+    })
+    const elementsLength = elements.length
+    await filterCreator(filterOpts).onFetch?.(elements)
+    expect(elements.length).toEqual(elementsLength - 2)
+    expect(elements.find(elem => elem.elemID.isEqual(customRecordTypeToExclude.elemID))).toBeUndefined()
+    expect(elements.find(elem => elem.elemID.isEqual(customRecordInstance.elemID))).toBeUndefined()
+  })
+  it('should exclude custom record instance by criteria', async () => {
+    filterOpts.config.fetch.exclude.customRecords = [{
+      name: '.*',
+      criteria: { isinactive: true },
+    }]
+    const elementsLength = elements.length
+    await filterCreator(filterOpts).onFetch?.(elements)
+    expect(elements.length).toEqual(elementsLength - 1)
+    expect(elements.find(elem => elem.elemID.isEqual(customRecordInstanceToExclude.elemID))).toBeUndefined()
+  })
+})

--- a/packages/netsuite-adapter/test/query.test.ts
+++ b/packages/netsuite-adapter/test/query.test.ts
@@ -250,10 +250,12 @@ describe('NetsuiteQuery', () => {
         types: [
           { name: 'addressForm', ids: ['aaa.*', 'bbb.*'] },
           { name: 'advancedpdftemplate', ids: ['ccc.*', 'ddd.*'] },
+          { name: '.*', criteria: { isinactive: true } },
         ],
         fileCabinet: ['eee.*', 'fff.*'],
         customRecords: [
           { name: 'customrecord.*', ids: ['.*'] },
+          { name: '.*', criteria: { isInactive: true } },
         ],
       })).not.toThrow()
     })
@@ -315,7 +317,27 @@ describe('NetsuiteQuery', () => {
       }
 
       expect(error).toBeDefined()
-      expect(error?.message).toContain('Received invalid adapter config input. Expected type name to be a string, but found:')
+      expect(error?.message).toContain('Received invalid adapter config input. Expected type name to be a string and not to have both ids & criteria, but found:')
+    })
+    it('should throw an error when type has both ids & criteria', () => {
+      let error: Error | undefined
+      try {
+        validateFetchParameters({
+          types: [
+            {
+              name: 'aa',
+              ids: ['abc'],
+              criteria: { isinactive: true },
+            },
+          ],
+          fileCabinet: [],
+        })
+      } catch (e) {
+        error = e
+      }
+
+      expect(error).toBeDefined()
+      expect(error?.message).toContain('Received invalid adapter config input. Expected type name to be a string and not to have both ids & criteria, but found:')
     })
     it('should throw an error when customRecords has undefined "name"', () => {
       let error: Error | undefined
@@ -333,7 +355,25 @@ describe('NetsuiteQuery', () => {
       }
 
       expect(error).toBeDefined()
-      expect(error?.message).toContain('Received invalid adapter config input. Expected custom record name to be a string, but found:')
+      expect(error?.message).toContain('Received invalid adapter config input. Expected custom record name to be a string and not to have both ids & criteria, but found:')
+    })
+    it('should throw an error when customRecords has both ids & criteria', () => {
+      let error: Error | undefined
+      try {
+        validateFetchParameters({
+          types: [],
+          fileCabinet: [],
+          customRecords: [
+            { name: 'aa' },
+            { name: '.*', ids: ['abc'], criteria: { isinactive: true } },
+          ],
+        })
+      } catch (e) {
+        error = e
+      }
+
+      expect(error).toBeDefined()
+      expect(error?.message).toContain('Received invalid adapter config input. Expected custom record name to be a string and not to have both ids & criteria, but found:')
     })
     it('should throw an error when fileCabinet is undefined', () => {
       let error: Error | undefined
@@ -395,6 +435,33 @@ describe('NetsuiteQuery', () => {
       expect(error).toBeDefined()
       expect(error?.message).toContain('Received invalid adapter config input. Expected type ids to be an array of strings, but found:')
     })
+    it('should throw an error when types has invalid criteria field', () => {
+      let error: Error | undefined
+      try {
+        validateFetchParameters({
+          types: [
+            {
+              name: 'aaa',
+              criteria: { inactive: true },
+            },
+            {
+              name: 'aaa',
+              criteria: true,
+            },
+            {
+              name: 'aaa',
+              criteria: {},
+            },
+          ],
+          fileCabinet: [],
+        })
+      } catch (e) {
+        error = e
+      }
+
+      expect(error).toBeDefined()
+      expect(error?.message).toContain('Received invalid adapter config input. Expected type criteria to be a non empty object, but found:')
+    })
     it('should throw an error when customRecords has invalid ids field', () => {
       let error: Error | undefined
       try {
@@ -412,6 +479,24 @@ describe('NetsuiteQuery', () => {
 
       expect(error).toBeDefined()
       expect(error?.message).toContain('Received invalid adapter config input. Expected custom record ids to be an array of strings, but found:')
+    })
+    it('should throw an error when customRecords has invalid criteria field', () => {
+      let error: Error | undefined
+      try {
+        validateFetchParameters({
+          types: [],
+          fileCabinet: [],
+          customRecords: [{
+            name: 'aaa',
+            criteria: {},
+          }],
+        })
+      } catch (e) {
+        error = e
+      }
+
+      expect(error).toBeDefined()
+      expect(error?.message).toContain('Received invalid adapter config input. Expected custom record criteria to be a non empty object, but found:')
     })
     it('should throw an error with all invalid types', () => {
       let error: Error | undefined

--- a/packages/netsuite-adapter/test/query.test.ts
+++ b/packages/netsuite-adapter/test/query.test.ts
@@ -317,7 +317,7 @@ describe('NetsuiteQuery', () => {
       }
 
       expect(error).toBeDefined()
-      expect(error?.message).toContain('Received invalid adapter config input. Expected type name to be a string and not to have both ids & criteria, but found:')
+      expect(error?.message).toContain('Received invalid adapter config input. Expected the type name to be a string without both "ids" and "criteria", but found:')
     })
     it('should throw an error when type has both ids & criteria', () => {
       let error: Error | undefined
@@ -337,7 +337,7 @@ describe('NetsuiteQuery', () => {
       }
 
       expect(error).toBeDefined()
-      expect(error?.message).toContain('Received invalid adapter config input. Expected type name to be a string and not to have both ids & criteria, but found:')
+      expect(error?.message).toContain('Received invalid adapter config input. Expected the type name to be a string without both "ids" and "criteria", but found:')
     })
     it('should throw an error when customRecords has undefined "name"', () => {
       let error: Error | undefined
@@ -355,7 +355,7 @@ describe('NetsuiteQuery', () => {
       }
 
       expect(error).toBeDefined()
-      expect(error?.message).toContain('Received invalid adapter config input. Expected custom record name to be a string and not to have both ids & criteria, but found:')
+      expect(error?.message).toContain('Received invalid adapter config input. Expected the custom record name to be a string without both "ids" and "criteria", but found:')
     })
     it('should throw an error when customRecords has both ids & criteria', () => {
       let error: Error | undefined
@@ -373,7 +373,7 @@ describe('NetsuiteQuery', () => {
       }
 
       expect(error).toBeDefined()
-      expect(error?.message).toContain('Received invalid adapter config input. Expected custom record name to be a string and not to have both ids & criteria, but found:')
+      expect(error?.message).toContain('Received invalid adapter config input. Expected the custom record name to be a string without both "ids" and "criteria", but found:')
     })
     it('should throw an error when fileCabinet is undefined', () => {
       let error: Error | undefined
@@ -433,7 +433,7 @@ describe('NetsuiteQuery', () => {
       }
 
       expect(error).toBeDefined()
-      expect(error?.message).toContain('Received invalid adapter config input. Expected type ids to be an array of strings, but found:')
+      expect(error?.message).toContain('Received invalid adapter config input. Expected type "ids" to be an array of strings, but found:')
     })
     it('should throw an error when types has invalid criteria field', () => {
       let error: Error | undefined
@@ -460,7 +460,7 @@ describe('NetsuiteQuery', () => {
       }
 
       expect(error).toBeDefined()
-      expect(error?.message).toContain('Received invalid adapter config input. Expected type criteria to be a non empty object, but found:')
+      expect(error?.message).toContain('Received invalid adapter config input. Expected type "criteria" to be a non-empty object, but found:')
     })
     it('should throw an error when customRecords has invalid ids field', () => {
       let error: Error | undefined
@@ -478,7 +478,7 @@ describe('NetsuiteQuery', () => {
       }
 
       expect(error).toBeDefined()
-      expect(error?.message).toContain('Received invalid adapter config input. Expected custom record ids to be an array of strings, but found:')
+      expect(error?.message).toContain('Received invalid adapter config input. Expected custom record "ids" to be an array of strings, but found:')
     })
     it('should throw an error when customRecords has invalid criteria field', () => {
       let error: Error | undefined
@@ -496,7 +496,7 @@ describe('NetsuiteQuery', () => {
       }
 
       expect(error).toBeDefined()
-      expect(error?.message).toContain('Received invalid adapter config input. Expected custom record criteria to be a non empty object, but found:')
+      expect(error?.message).toContain('Received invalid adapter config input. Expected custom record "criteria" to be a non-empty object, but found:')
     })
     it('should throw an error with all invalid types', () => {
       let error: Error | undefined

--- a/packages/netsuite-adapter/test/utils.ts
+++ b/packages/netsuite-adapter/test/utils.ts
@@ -24,7 +24,7 @@ export const mockGetElemIdFunc = (adapterName: string, _serviceIds: ServiceIds, 
 
 export const getDefaultAdapterConfig = async (): Promise<NetsuiteConfig> => {
   const defaultConfigInstance = await createDefaultInstanceFromType(NETSUITE, configType)
-  return defaultConfigInstance.value as NetsuiteConfig
+  return defaultConfigInstance.clone().value as NetsuiteConfig
 }
 
 export const createEmptyElementsSourceIndexes = (): ElementsSourceIndexes => ({


### PR DESCRIPTION
Add the ability to exclude elements using the `criteria` config.

---

_Additional context for reviewer_

TODO:
- [x] add documentation
- [x] PM approval on error messages

---
_Release Notes_: 
Netsuite Adapter:
- Support excluding elements by criteria (e.g `isinactive = true`)

```
netsuite {
  ...
  exclude = {
    ...
    types = [
      ...
      {
         name = ".*"
         criteria = {
            isinactive = true
         }
      },
    ]
  }
}
```

---
_User Notifications_: 
None
