### PR TITLE
SALTO-5045: move spamming debug log to trace

### DIFF
--- a/packages/workspace/src/workspace/state/static_files_sources/history_static_files_source.ts
+++ b/packages/workspace/src/workspace/state/static_files_sources/history_static_files_source.ts
@@ -69,10 +69,10 @@ export const buildHistoryStateStaticFilesSource = (
     },
 
     rename: async name => {
-      log.debug('rename to %s ignored in history state static files source', name)
+      log.trace('rename to %s ignored in history state static files source', name)
     },
     delete: async file => {
-      log.debug('delete %s ignored in history state static files source', file.filepath)
+      log.trace('delete %s ignored in history state static files source', file.filepath)
     },
     clear: async () => {
       log.debug('clear ignored in history state static files source')


### PR DESCRIPTION
Log lines in history static files source get written per-file and are not that interesting especially given the logs are about the code not doing anything

---

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_