### PR TITLE
SALTO-5058: Avoid iterating all workspace IDs multiple times when deploying guide changes

### DIFF
--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -334,7 +334,7 @@ const zendeskGuideEntriesFunc = (
   return getZendeskGuideEntriesResponseValues
 }
 
-const getBrandsFromElementsSourceNoCash = async (
+const getBrandsFromElementsSourceNoCache = async (
   elementsSource: ReadOnlyElementsSource
 ): Promise<InstanceElement[]> => (
   awu(await elementsSource.list())
@@ -698,9 +698,9 @@ export default class ZendeskAdapter implements AdapterOperations {
     return { elements, errors: fetchErrors, updatedConfig }
   }
 
-  private async getBrands(elementsSource: ReadOnlyElementsSource): Promise<InstanceElement[]> {
+  private getBrandsFromElementsSource(): Promise<InstanceElement[]> {
     if (this.brandsList === undefined) {
-      this.brandsList = getBrandsFromElementsSourceNoCash(elementsSource)
+      this.brandsList = getBrandsFromElementsSourceNoCache(this.elementsSource)
     }
     return this.brandsList
   }
@@ -709,7 +709,7 @@ export default class ZendeskAdapter implements AdapterOperations {
     if (_.isEmpty(guideResolvedChanges)) {
       return []
     }
-    const brandsList = await this.getBrands(this.elementsSource)
+    const brandsList = await this.getBrandsFromElementsSource()
     log.debug('Found %d brands to handle %d guide changes', brandsList.length, guideResolvedChanges.length)
     const resolvedBrandIdToSubdomain = Object.fromEntries(brandsList.map(
       brandInstance => [brandInstance.value.id, brandInstance.value.subdomain]

--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -334,7 +334,7 @@ const zendeskGuideEntriesFunc = (
   return getZendeskGuideEntriesResponseValues
 }
 
-const getBrandsFromElementsSource = async (
+const getBrandsFromElementsSourceNoCash = async (
   elementsSource: ReadOnlyElementsSource
 ): Promise<InstanceElement[]> => (
   awu(await elementsSource.list())
@@ -343,6 +343,21 @@ const getBrandsFromElementsSource = async (
     .filter(isInstanceElement)
     .toArray()
 )
+
+const getBrandsFromElementsSourceFunc = ():(elementsSource: ReadOnlyElementsSource) => Promise<InstanceElement[]> => {
+  let calculatedBrandsPromise: Promise<InstanceElement[]>
+
+  const getBrands = async (elementsSource: ReadOnlyElementsSource): Promise<InstanceElement[]> => {
+    if (calculatedBrandsPromise === undefined) {
+      calculatedBrandsPromise = getBrandsFromElementsSourceNoCash(elementsSource)
+    }
+    return calculatedBrandsPromise
+  }
+
+  return getBrands
+}
+
+const getBrandsFromElementsSource = getBrandsFromElementsSourceFunc()
 
 /**
  * Fetch Guide (help_center) elements for the given brands.

--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -458,6 +458,7 @@ export default class ZendeskAdapter implements AdapterOperations {
   private fixElementsFunc: FixElementsFunc
   private createClientBySubdomain: (subdomain: string, deployRateLimit?: boolean) => ZendeskClient
   private getClientBySubdomain: (subdomain: string, deployRateLimit?: boolean) => ZendeskClient
+  private getBrandsFromElementsSource: (elementsSource: ReadOnlyElementsSource) => Promise<InstanceElement[]>
   private createFiltersRunner: ({
     filterRunnerClient,
     paginator,
@@ -484,6 +485,7 @@ export default class ZendeskAdapter implements AdapterOperations {
     this.logIdsFunc = wrapper?.logIdsFunc
     this.client = client
     this.elementsSource = elementsSource
+    this.getBrandsFromElementsSource = getBrandsFromElementsSource
     this.paginator = createPaginator({
       client: this.client,
       paginationFuncCreator: paginate,
@@ -715,7 +717,7 @@ export default class ZendeskAdapter implements AdapterOperations {
     if (_.isEmpty(guideResolvedChanges)) {
       return []
     }
-    const brandsList = await getBrandsFromElementsSource(this.elementsSource)
+    const brandsList = await this.getBrandsFromElementsSource(this.elementsSource)
     log.debug('Found %d brands to handle %d guide changes', brandsList.length, guideResolvedChanges.length)
     const resolvedBrandIdToSubdomain = Object.fromEntries(brandsList.map(
       brandInstance => [brandInstance.value.id, brandInstance.value.subdomain]


### PR DESCRIPTION
Avoid iterating all workspace IDs multiple times when deploying guide changes

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
