### PR TITLE
SALTO-5066 Fixed forms test to compare times in the minute level

### DIFF
--- a/packages/jira-adapter/test/filters/forms/forms.test.ts
+++ b/packages/jira-adapter/test/filters/forms/forms.test.ts
@@ -26,7 +26,6 @@ import { FORM_TYPE, JIRA, PROJECT_TYPE } from '../../../src/constants'
 import JiraClient from '../../../src/client/client'
 import { CLOUD_RESOURCE_FIELD } from '../../../src/filters/automation/cloud_id'
 
-
 describe('forms filter', () => {
     type FilterType = filterUtils.FilterWith<'onFetch' | 'deploy' | 'onDeploy' | 'preDeploy'>
     let filter: FilterType
@@ -485,7 +484,7 @@ describe('forms filter', () => {
       })
       it('should add the current updated time', async () => {
         await filter.preDeploy([{ action: 'add', data: { after: formInstance } }])
-        expect(formInstance.value.updated).toEqual(new Date().toISOString())
+        expect(formInstance.value.updated.slice(0, -8)).toEqual(new Date().toISOString().slice(0, -8))
       })
     })
     describe('onDeploy', () => {


### PR DESCRIPTION
Currently we compare the time in the ms level so the test if flaky. Change it to the minute time. 

---

_Additional context for reviewer_
None

---
_Release Notes_: 
None

---
_User Notifications_: 
None
