### PR TITLE
SALTO-5068: Salesforce FileProperties Metadata Query

### DIFF
--- a/packages/salesforce-adapter/src/fetch_profile/metadata_query.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/metadata_query.ts
@@ -16,6 +16,7 @@
 import { regex, values } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { ReadOnlyElementsSource } from '@salto-io/adapter-api'
+import { FileProperties } from '@salto-io/jsforce'
 import {
   CUSTOM_FIELD,
   CUSTOM_METADATA,
@@ -241,5 +242,27 @@ export const validateMetadataParams = (
       [...fieldPath, METADATA_SEPARATE_FIELD_LIST],
       `${METADATA_SEPARATE_FIELD_LIST} should not be larger than ${MAX_TYPES_TO_SEPARATE_TO_FILE_PER_FIELD}. current length is ${params.objectsToSeperateFieldsToFiles.length}`
     )
+  }
+}
+
+export const buildFilePropsMetadataQuery = (
+  metadataQuery: MetadataQuery
+): MetadataQuery<FileProperties> => {
+  const filePropsToMetadataInstance = ({
+    namespacePrefix,
+    type: metadataType,
+    fullName: name,
+    lastModifiedDate: changedAt,
+  }: FileProperties): MetadataInstance => ({
+    namespace: namespacePrefix === undefined || namespacePrefix === '' ? DEFAULT_NAMESPACE : namespacePrefix,
+    metadataType,
+    name,
+    changedAt,
+    isFolderType: false,
+  })
+  return {
+    ...metadataQuery,
+    isInstanceIncluded: instance => metadataQuery.isInstanceIncluded(filePropsToMetadataInstance(instance)),
+    isInstanceMatch: instance => metadataQuery.isInstanceMatch(filePropsToMetadataInstance(instance)),
   }
 }

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -862,10 +862,10 @@ export const configType = createMatchingObjectType<SalesforceConfig>({
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },
 })
-export type MetadataQuery = {
+export type MetadataQuery<T = MetadataInstance> = {
   isTypeMatch: (type: string) => boolean
-  isInstanceIncluded: (instance: MetadataInstance) => boolean
-  isInstanceMatch: (instance: MetadataInstance) => boolean
+  isInstanceIncluded: (instance: T) => boolean
+  isInstanceMatch: (instance: T) => boolean
   isTargetedFetch: () => boolean
   isFetchWithChangesDetection: () => boolean
   isPartialFetch: () => boolean


### PR DESCRIPTION
Required step for fetch with changes detection on **Profiles** and **Nested Instances**
 
---

You can already see usage of this code in this PR: https://github.com/salto-io/salto/pull/5109

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
