### PR TITLE
SALTO-5035:  Add AssetsObjedctType attributes

### DIFF
--- a/packages/jira-adapter/e2e_test/adapter.test.ts
+++ b/packages/jira-adapter/e2e_test/adapter.test.ts
@@ -29,14 +29,14 @@ import { createInstances, createModifyInstances } from './instances'
 import { findInstance } from './utils'
 import { getLookUpName } from '../src/reference_mapping'
 import { getDefaultConfig } from '../src/config/config'
-import { ASSESTS_SCHEMA_TYPE } from '../src/constants'
+import { ASSESTS_SCHEMA_TYPE, ASSETS_ATTRIBUTE_TYPE, ASSETS_OBJECT_TYPE } from '../src/constants'
 
 const { awu } = collections.asynciterable
 const { replaceInstanceTypeForDeploy } = elementUtils.ducktype
 
 jest.setTimeout(600 * 1000)
 
-const excludedTypes = ['Behavior', 'Behavior__config', ASSESTS_SCHEMA_TYPE, 'AssetsSchemas', 'AssetsStatuses', 'AssetsStatus', 'AssetsObjectTypes', 'AssetsObjectType']
+const excludedTypes = ['Behavior', 'Behavior__config', ASSESTS_SCHEMA_TYPE, 'AssetsSchemas', 'AssetsStatuses', 'AssetsStatus', 'AssetsObjectTypes', ASSETS_OBJECT_TYPE, ASSETS_ATTRIBUTE_TYPE]
 
 each([
   ['Cloud', false],

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -159,9 +159,10 @@ import changeQueueFieldsFilter from './filters/change_queue_fields'
 import portalGroupsFilter from './filters/portal_groups'
 import assetsObjectTypePath from './filters/assets/assets_object_type_path'
 import assetsObjectTypeChangeFields from './filters/assets/assets_object_type_change_fields'
+import changeAttributesPathFilter from './filters/assets/change_attributes_path'
 import ScriptRunnerClient from './client/script_runner_client'
 import { weakReferenceHandlers } from './weak_references'
-import { jiraJSMEntriesFunc } from './jsm_utils'
+import { jiraJSMAssetsEntriesFunc, jiraJSMEntriesFunc } from './jsm_utils'
 import { getWorkspaceId } from './workspace_id'
 import { JSM_ASSETS_DUCKTYPE_SUPPORTED_TYPES } from './config/api_config'
 
@@ -341,6 +342,8 @@ export const DEFAULT_FILTERS = [
   ...Object.values(otherCommonFilters),
   // Must run after otherCommonFilters and specificly after referencedInstanceNamesFilterCreator.
   assetsObjectTypePath,
+  // Must run after assetsObjectTypePath
+  changeAttributesPathFilter,
 ]
 
 export interface JiraAdapterParams {
@@ -539,6 +542,7 @@ export default class JiraAdapter implements AdapterOperations {
       typeDefaults: jsmApiDefinitions.typeDefaults,
       additionalRequestContext: workspaceContext,
       getElemIdFunc: this.getElemIdFunc,
+      getEntriesResponseValuesFunc: jiraJSMAssetsEntriesFunc(),
     })
   }
 

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -2149,6 +2149,13 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
           toField: 'assetsObjectTypes',
           context: [{ name: 'AssetsSchemaId', fromField: 'id' }],
         },
+        {
+          type: 'AssetsObjectTypeAttribute',
+          toField: 'attributes',
+          context: [
+            { name: 'AssetsSchemaId', fromField: 'id' },
+          ],
+        },
       ],
     },
     transformation: {
@@ -2170,6 +2177,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       standaloneFields: [
         { fieldName: 'assetsStatuses' },
         { fieldName: 'assetsObjectTypes' },
+        { fieldName: 'attributes' },
       ],
       fieldTypeOverrides: [
         { fieldName: 'assetsStatuses', fieldType: 'List<AssetsStatus>' },
@@ -2218,6 +2226,26 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
         { fieldName: 'workspaceId' },
       ],
       extendsParentId: false,
+    },
+  },
+  AssetsObjectTypeAttribute: {
+    request: {
+      url: '/gateway/api/jsm/assets/workspace/{workspaceId}/v1/objectschema/{AssetsSchemaId}/attributes',
+      queryParams: {
+        extended: 'true',
+      },
+    },
+    transformation: {
+      dataField: '.',
+      idFields: ['&objectType', 'name'],
+      sourceTypeName: 'AssetsSchema__attributes',
+      fieldsToHide: [
+        { fieldName: 'id' },
+      ],
+      fieldsToOmit: [
+        { fieldName: 'workspaceId' },
+        { fieldName: 'globalId' },
+      ],
     },
   },
 }

--- a/packages/jira-adapter/src/constants.ts
+++ b/packages/jira-adapter/src/constants.ts
@@ -114,5 +114,6 @@ export const REQUEST_FORM_TYPE = 'RequestForm'
 export const FORM_TYPE = 'Form'
 export const ASSESTS_SCHEMA_TYPE = 'AssetsSchema'
 export const ASSETS_OBJECT_TYPE = 'AssetsObjectType'
+export const ASSETS_ATTRIBUTE_TYPE = 'AssetsObjectTypeAttribute'
 // almost constant functions
 export const fetchFailedWarnings = (name :string):string => `Salto could not access the ${name} resource. Elements from that type were not fetched. Please make sure that this type is enabled in your service, and that the supplied user credentials have sufficient permissions to access this data. You can also exclude this data from Salto's fetches by changing the environment configuration. Learn more at https://help.salto.io/en/articles/6947061-salto-could-not-access-the-resource`

--- a/packages/jira-adapter/src/filters/assets/change_attributes_path.ts
+++ b/packages/jira-adapter/src/filters/assets/change_attributes_path.ts
@@ -1,0 +1,54 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { CORE_ANNOTATIONS, isInstanceElement } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { pathNaclCase } from '@salto-io/adapter-utils'
+import { FilterCreator } from '../../filter'
+import { ASSETS_ATTRIBUTE_TYPE } from '../../constants'
+
+/* This filter change the attributes path to be nested to the AssetsObjectType that created them.
+* The filter also removes the attributes from their parent asset schema.
+*/
+const filter: FilterCreator = ({ config }) => ({
+  name: 'changeAttributesPathFilter',
+  onFetch: async elements => {
+    if (!config.fetch.enableJSM || !config.fetch.enableJsmExperimental) {
+      return
+    }
+    const attributes = elements
+      .filter(isInstanceElement)
+      .filter(instance => instance.elemID.typeName === ASSETS_ATTRIBUTE_TYPE)
+    const attributesByAssetObjectTypeName = _.groupBy(attributes,
+      attribute => attribute.value.objectType.elemID.getFullName())
+
+    Object.values(attributesByAssetObjectTypeName).forEach(assetAttributes => {
+      const assetsObjectType = assetAttributes[0].value.objectType.value
+      assetAttributes.forEach(attribute => {
+        attribute.path = [...assetsObjectType.path.slice(0, -1), 'attributes', pathNaclCase(attribute.value.name)]
+        delete attribute.annotations[CORE_ANNOTATIONS.PARENT]
+      })
+    })
+
+    elements
+      .filter(isInstanceElement)
+      .filter(instance => instance.elemID.typeName === 'AssetsSchema')
+      .forEach(instance => {
+        delete instance.value.attributes
+      })
+  },
+})
+export default filter

--- a/packages/jira-adapter/src/filters/assets/change_attributes_path.ts
+++ b/packages/jira-adapter/src/filters/assets/change_attributes_path.ts
@@ -18,7 +18,7 @@ import { CORE_ANNOTATIONS, isInstanceElement } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { pathNaclCase } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../../filter'
-import { ASSETS_ATTRIBUTE_TYPE } from '../../constants'
+import { ASSESTS_SCHEMA_TYPE, ASSETS_ATTRIBUTE_TYPE } from '../../constants'
 
 /* This filter change the attributes path to be nested to the AssetsObjectType that created them.
 * The filter also removes the attributes from their parent asset schema.
@@ -45,7 +45,7 @@ const filter: FilterCreator = ({ config }) => ({
 
     elements
       .filter(isInstanceElement)
-      .filter(instance => instance.elemID.typeName === 'AssetsSchema')
+      .filter(instance => instance.elemID.typeName === ASSESTS_SCHEMA_TYPE)
       .forEach(instance => {
         delete instance.value.attributes
       })

--- a/packages/jira-adapter/src/jsm_utils.ts
+++ b/packages/jira-adapter/src/jsm_utils.ts
@@ -24,6 +24,7 @@ import { createSchemeGuard } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import Joi from 'joi'
+import { ASSETS_ATTRIBUTE_TYPE } from './constants'
 
 const ATTRIBUTE_ENTRY_SCHEMA = Joi.object({
   objectType: Joi.object({
@@ -121,7 +122,7 @@ export const jiraJSMAssetsEntriesFunc = (): elementUtils.ducktype.EntriesRequest
       ) as clientUtils.ResponseValue[]
 
       responseEntries.forEach(entry => {
-        if (typeName === 'AssetsObjectTypeAttribute' && isAttributeEntry(entry)) {
+        if (typeName === ASSETS_ATTRIBUTE_TYPE && isAttributeEntry(entry)) {
           if (typeof entry.objectType !== 'string') {
             entry.objectType = entry.objectType.id
           }

--- a/packages/jira-adapter/src/jsm_utils.ts
+++ b/packages/jira-adapter/src/jsm_utils.ts
@@ -14,10 +14,6 @@
 * limitations under the License.
 */
 
-/**
- * Fetch JSM elements of service desk project.
-*/
-
 import { InstanceElement } from '@salto-io/adapter-api'
 import { config as configUtils, elements as elementUtils, client as clientUtils } from '@salto-io/adapter-components'
 import { createSchemeGuard } from '@salto-io/adapter-utils'
@@ -52,12 +48,12 @@ const processEntries = async ({
   typesConfig,
   additionalProcessing,
 } : {
-    paginator: clientUtils.Paginator
-    args: clientUtils.ClientGetWithPaginationParams
-    typeName: string
-    typesConfig: Record<string, configUtils.TypeDuckTypeConfig>
-    additionalProcessing: (entry: clientUtils.ResponseValue) => void
-  }): Promise<clientUtils.ResponseValue[]> => {
+  paginator: clientUtils.Paginator
+  args: clientUtils.ClientGetWithPaginationParams
+  typeName: string
+  typesConfig: Record<string, configUtils.TypeDuckTypeConfig>
+  additionalProcessing: (entry: clientUtils.ResponseValue) => void
+}): Promise<clientUtils.ResponseValue[]> => {
   const jsmResponseValues = (await getEntriesResponseValues({
     paginator,
     args,

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -27,7 +27,7 @@ import { AUTOMATION_PROJECT_TYPE, AUTOMATION_FIELD, AUTOMATION_COMPONENT_VALUE_T
   PRIORITY_SCHEME_TYPE_NAME, SCRIPT_RUNNER_TYPE, POST_FUNCTION_CONFIGURATION, RESOLUTION_TYPE_NAME,
   ISSUE_EVENT_TYPE_NAME, CONDITION_CONFIGURATION, PROJECT_ROLE_TYPE, VALIDATOR_CONFIGURATION,
   BOARD_TYPE_NAME, ISSUE_LINK_TYPE_NAME, DIRECTED_LINK_TYPE, MAIL_LIST_TYPE_NAME,
-  SCRIPT_RUNNER_LISTENER_TYPE, SCRIPTED_FIELD_TYPE, BEHAVIOR_TYPE, ISSUE_LAYOUT_TYPE, SCRIPT_RUNNER_SETTINGS_TYPE, SCRIPT_FRAGMENT_TYPE, CUSTOMER_PERMISSIONS_TYPE, QUEUE_TYPE, REQUEST_TYPE_NAME, CALENDAR_TYPE, PORTAL_GROUP_TYPE, PORTAL_SETTINGS_TYPE_NAME, SLA_TYPE_NAME, ISSUE_VIEW_TYPE, REQUEST_FORM_TYPE } from './constants'
+  SCRIPT_RUNNER_LISTENER_TYPE, SCRIPTED_FIELD_TYPE, BEHAVIOR_TYPE, ISSUE_LAYOUT_TYPE, SCRIPT_RUNNER_SETTINGS_TYPE, SCRIPT_FRAGMENT_TYPE, CUSTOMER_PERMISSIONS_TYPE, QUEUE_TYPE, REQUEST_TYPE_NAME, CALENDAR_TYPE, PORTAL_GROUP_TYPE, PORTAL_SETTINGS_TYPE_NAME, SLA_TYPE_NAME, ISSUE_VIEW_TYPE, REQUEST_FORM_TYPE, ASSETS_ATTRIBUTE_TYPE, ASSETS_OBJECT_TYPE } from './constants'
 import { getFieldsLookUpName } from './filters/fields/field_type_references_filter'
 import { getRefType } from './references/workflow_properties'
 import { FIELD_TYPE_NAME } from './filters/fields/constants'
@@ -996,10 +996,16 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     target: { type: FIELD_TYPE_NAME },
   },
   {
-    src: { field: 'parentObjectTypeId', parentTypes: ['AssetsObjectType'] },
+    src: { field: 'parentObjectTypeId', parentTypes: [ASSETS_OBJECT_TYPE] },
     serializationStrategy: 'id',
     jiraMissingRefStrategy: 'typeAndValue',
-    target: { type: 'AssetsObjectType' },
+    target: { type: ASSETS_OBJECT_TYPE },
+  },
+  {
+    src: { field: 'objectType', parentTypes: [ASSETS_ATTRIBUTE_TYPE] },
+    serializationStrategy: 'id',
+    jiraMissingRefStrategy: 'typeAndValue',
+    target: { type: ASSETS_OBJECT_TYPE },
   },
 ]
 

--- a/packages/jira-adapter/test/adapter.test.ts
+++ b/packages/jira-adapter/test/adapter.test.ts
@@ -22,9 +22,9 @@ import { mockFunction } from '@salto-io/test-utils'
 import JiraClient from '../src/client/client'
 import { adapter as adapterCreator } from '../src/adapter_creator'
 import { getDefaultConfig } from '../src/config/config'
-import { ISSUE_TYPE_NAME, JIRA, PROJECT_TYPE, SERVICE_DESK } from '../src/constants'
+import { ASSETS_ATTRIBUTE_TYPE, ISSUE_TYPE_NAME, JIRA, PROJECT_TYPE, SERVICE_DESK } from '../src/constants'
 import { createCredentialsInstance, createConfigInstance, mockClient, createEmptyType } from './utils'
-import { jiraJSMEntriesFunc } from '../src/jsm_utils'
+import { jiraJSMAssetsEntriesFunc, jiraJSMEntriesFunc } from '../src/jsm_utils'
 import { CLOUD_RESOURCE_FIELD } from '../src/filters/automation/cloud_id'
 
 const { getAllElements, getEntriesResponseValues } = elements.ducktype
@@ -531,6 +531,34 @@ describe('adapter', () => {
         })
         expect(result[0]).toEqual({
           id: '1',
+        })
+      })
+    })
+    describe('jiraJSMAssetsEntriesFunc', () => {
+      let paginator: clientUtils.Paginator
+      let responseValue: clientUtils.ResponseValue[]
+      let EntriesRequesterFunc: elements.ducktype.EntriesRequester
+      beforeEach(() => {
+        const { paginator: cliPaginator } = mockClient()
+        paginator = cliPaginator
+        responseValue = [{
+          objectType: {
+            id: '1',
+          },
+        }];
+        (getEntriesResponseValues as jest.MockedFunction<typeof getEntriesResponseValues>)
+          .mockResolvedValue(responseValue)
+        EntriesRequesterFunc = jiraJSMAssetsEntriesFunc()
+      })
+      it('should change the objectType object struct to id', async () => {
+        const result = await EntriesRequesterFunc({
+          paginator,
+          args: { url: '/gateway/api/jsm/assets/workspace/defualtWorkSpaceId/v1/objectschema/2/attributes' },
+          typeName: ASSETS_ATTRIBUTE_TYPE,
+          typesConfig: { AssetsObjectTypeAttribute: { transformation: { dataField: '.' } } },
+        })
+        expect(result[0]).toEqual({
+          objectType: '1',
         })
       })
     })

--- a/packages/jira-adapter/test/filters/assets/change_attributes_path.test.ts
+++ b/packages/jira-adapter/test/filters/assets/change_attributes_path.test.ts
@@ -22,7 +22,7 @@ import addAttributesAsFieldsFilter from '../../../src/filters/assets/change_attr
 import { createEmptyType, getFilterParams } from '../../utils'
 import { ASSESTS_SCHEMA_TYPE, ASSETS_ATTRIBUTE_TYPE, ASSETS_OBJECT_TYPE, JIRA } from '../../../src/constants'
 
-describe('ChaneAttributesPath', () => {
+describe('ChangeAttributesPath', () => {
     type FilterType = filterUtils.FilterWith<'onFetch'>
     let filter: FilterType
     let elements: Element[]

--- a/packages/jira-adapter/test/filters/assets/change_attributes_path.test.ts
+++ b/packages/jira-adapter/test/filters/assets/change_attributes_path.test.ts
@@ -1,0 +1,112 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { filterUtils } from '@salto-io/adapter-components'
+import _ from 'lodash'
+import { InstanceElement, ReferenceExpression, Element, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
+import { RECORDS_PATH } from '@salto-io/adapter-components/src/elements'
+import { pathNaclCase } from '@salto-io/adapter-utils'
+import { getDefaultConfig } from '../../../src/config/config'
+import addAttributesAsFieldsFilter from '../../../src/filters/assets/change_attributes_path'
+import { createEmptyType, getFilterParams } from '../../utils'
+import { ASSESTS_SCHEMA_TYPE, ASSETS_ATTRIBUTE_TYPE, ASSETS_OBJECT_TYPE, JIRA } from '../../../src/constants'
+
+describe('AddAttributesAsFields', () => {
+    type FilterType = filterUtils.FilterWith<'onFetch'>
+    let filter: FilterType
+    let elements: Element[]
+    let parentInstance: InstanceElement
+    let sonOneInstance: InstanceElement
+    let attributeInstance: InstanceElement
+    let attributeInstance2: InstanceElement
+    const assetSchemaInstance = new InstanceElement(
+      'assetsSchema1',
+      createEmptyType(ASSESTS_SCHEMA_TYPE),
+      {
+        idAsInt: 5,
+        name: 'assetsSchema',
+      },
+    )
+    describe('on fetch', () => {
+      beforeEach(async () => {
+        const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+        config.fetch.enableJSM = true
+        config.fetch.enableJsmExperimental = true
+        filter = addAttributesAsFieldsFilter(getFilterParams({ config })) as typeof filter
+        parentInstance = new InstanceElement(
+          'parentInstance',
+          createEmptyType(ASSETS_OBJECT_TYPE),
+          {
+            name: 'parentInstance',
+          },
+          [JIRA, RECORDS_PATH, ASSESTS_SCHEMA_TYPE, assetSchemaInstance.elemID.name, 'assetsObjectTypes', 'parentInstance', 'parentInstance'],
+          {
+            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(assetSchemaInstance.elemID, assetSchemaInstance)],
+          }
+        )
+        sonOneInstance = new InstanceElement(
+          'sonOneInstance',
+          createEmptyType(ASSETS_OBJECT_TYPE),
+          {
+            name: 'sonOneInstance',
+            parentObjectTypeId: new ReferenceExpression(parentInstance.elemID, parentInstance),
+          },
+          [JIRA, RECORDS_PATH, ASSESTS_SCHEMA_TYPE, assetSchemaInstance.elemID.name, 'assetsObjectTypes', 'parentInstance', 'sonOneInstance', 'sonOneInstance'],
+          {
+            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(assetSchemaInstance.elemID, assetSchemaInstance)],
+          },
+        )
+        attributeInstance = new InstanceElement(
+          'attributeInstance',
+          createEmptyType(ASSETS_ATTRIBUTE_TYPE),
+          {
+            name: 'attributeInstance',
+            objectType: new ReferenceExpression(parentInstance.elemID, parentInstance),
+          },
+          undefined,
+          {
+            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(assetSchemaInstance.elemID, assetSchemaInstance)],
+          },
+        )
+        attributeInstance2 = new InstanceElement(
+          'attributeInstance2',
+          createEmptyType(ASSETS_ATTRIBUTE_TYPE),
+          {
+            name: 'attributeInstance2',
+            objectType: new ReferenceExpression(sonOneInstance.elemID, sonOneInstance),
+          },
+          undefined,
+          {
+            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(assetSchemaInstance.elemID, assetSchemaInstance)],
+          },
+        )
+        elements = [
+          parentInstance,
+          sonOneInstance,
+          assetSchemaInstance,
+          attributeInstance,
+          attributeInstance2,
+        ]
+      })
+      it('should change each attribute path to the objectType that created it', async () => {
+        await filter.onFetch(elements)
+        expect(attributeInstance.path).toEqual([
+          ...(parentInstance.path ?? []).slice(0, -1),
+          'attributes',
+          pathNaclCase(attributeInstance.value.name),
+        ])
+      })
+    })
+})

--- a/packages/jira-adapter/test/filters/assets/change_attributes_path.test.ts
+++ b/packages/jira-adapter/test/filters/assets/change_attributes_path.test.ts
@@ -17,18 +17,17 @@ import { filterUtils } from '@salto-io/adapter-components'
 import _ from 'lodash'
 import { InstanceElement, ReferenceExpression, Element, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
 import { RECORDS_PATH } from '@salto-io/adapter-components/src/elements'
-import { pathNaclCase } from '@salto-io/adapter-utils'
 import { getDefaultConfig } from '../../../src/config/config'
 import addAttributesAsFieldsFilter from '../../../src/filters/assets/change_attributes_path'
 import { createEmptyType, getFilterParams } from '../../utils'
 import { ASSESTS_SCHEMA_TYPE, ASSETS_ATTRIBUTE_TYPE, ASSETS_OBJECT_TYPE, JIRA } from '../../../src/constants'
 
-describe('AddAttributesAsFields', () => {
+describe('ChaneAttributesPath', () => {
     type FilterType = filterUtils.FilterWith<'onFetch'>
     let filter: FilterType
     let elements: Element[]
     let parentInstance: InstanceElement
-    let sonOneInstance: InstanceElement
+    let sonInstance: InstanceElement
     let attributeInstance: InstanceElement
     let attributeInstance2: InstanceElement
     const assetSchemaInstance = new InstanceElement(
@@ -56,7 +55,7 @@ describe('AddAttributesAsFields', () => {
             [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(assetSchemaInstance.elemID, assetSchemaInstance)],
           }
         )
-        sonOneInstance = new InstanceElement(
+        sonInstance = new InstanceElement(
           'sonOneInstance',
           createEmptyType(ASSETS_OBJECT_TYPE),
           {
@@ -85,7 +84,7 @@ describe('AddAttributesAsFields', () => {
           createEmptyType(ASSETS_ATTRIBUTE_TYPE),
           {
             name: 'attributeInstance2',
-            objectType: new ReferenceExpression(sonOneInstance.elemID, sonOneInstance),
+            objectType: new ReferenceExpression(sonInstance.elemID, sonInstance),
           },
           undefined,
           {
@@ -94,7 +93,7 @@ describe('AddAttributesAsFields', () => {
         )
         elements = [
           parentInstance,
-          sonOneInstance,
+          sonInstance,
           assetSchemaInstance,
           attributeInstance,
           attributeInstance2,
@@ -103,9 +102,25 @@ describe('AddAttributesAsFields', () => {
       it('should change each attribute path to the objectType that created it', async () => {
         await filter.onFetch(elements)
         expect(attributeInstance.path).toEqual([
-          ...(parentInstance.path ?? []).slice(0, -1),
+          JIRA,
+          RECORDS_PATH,
+          ASSESTS_SCHEMA_TYPE,
+          assetSchemaInstance.elemID.name,
+          'assetsObjectTypes',
+          'parentInstance',
           'attributes',
-          pathNaclCase(attributeInstance.value.name),
+          'attributeInstance',
+        ])
+        expect(attributeInstance2.path).toEqual([
+          JIRA,
+          RECORDS_PATH,
+          ASSESTS_SCHEMA_TYPE,
+          assetSchemaInstance.elemID.name,
+          'assetsObjectTypes',
+          'parentInstance',
+          'sonOneInstance',
+          'attributes',
+          'attributeInstance2',
         ])
       })
     })


### PR DESCRIPTION
In this PR I added support for AssetsObjedctType attributes.

---

_Additional context for reviewer_
please review only from commit 3 [support assets attributes](https://github.com/salto-io/salto/pull/5113/commits/12260d0a3a87781f5464d7ad556dd828f5e2bab9) and any sub commit

---
_Release Notes_: 
_Jira Adapter:_
Now supporting fetch of assets attributes.

---
_User Notifications_: 
_JIra Adapter:_
Now supporting fetch of assets attributes.