### PR TITLE
SALTO-5070: Move Salesforce retrieve settings into the Fetch Profile

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -428,7 +428,10 @@ export default class SalesforceAdapter implements AdapterOperations {
     const metadataQuery = withChangesDetection
       ? await buildMetadataQueryForFetchWithChangesDetection({ fetchParams, elementsSource: this.elementsSource })
       : buildMetadataQuery({ fetchParams })
-    const fetchProfile = buildFetchProfile({ fetchParams, metadataQuery })
+    const fetchProfile = buildFetchProfile({ fetchParams,
+      metadataQuery,
+      typesToSkip: new Set(this.metadataTypesOfInstancesFetchedInFilters),
+      maxItemsInRetrieveRequest: this.maxItemsInRetrieveRequest })
     if (!fetchProfile.isFeatureEnabled('fetchCustomObjectUsingRetrieveApi')) {
       // We have to fetch custom objects using retrieve in order to be able to fetch the field-level permissions
       // in profiles. If custom objects are fetched via the read API, we have to fetch profiles using that API too.
@@ -631,10 +634,7 @@ export default class SalesforceAdapter implements AdapterOperations {
       retrieveMetadataInstances({
         client: this.client,
         types: metadataTypesToRetrieve,
-        metadataQuery: fetchProfile.metadataQuery,
-        maxItemsInRetrieveRequest: this.maxItemsInRetrieveRequest,
         fetchProfile,
-        typesToSkip: new Set(this.metadataTypesOfInstancesFetchedInFilters),
       }),
       readInstances(metadataTypesToRead),
     ])

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -430,7 +430,6 @@ export default class SalesforceAdapter implements AdapterOperations {
       : buildMetadataQuery({ fetchParams })
     const fetchProfile = buildFetchProfile({ fetchParams,
       metadataQuery,
-      typesToSkip: new Set(this.metadataTypesOfInstancesFetchedInFilters),
       maxItemsInRetrieveRequest: this.maxItemsInRetrieveRequest })
     if (!fetchProfile.isFeatureEnabled('fetchCustomObjectUsingRetrieveApi')) {
       // We have to fetch custom objects using retrieve in order to be able to fetch the field-level permissions
@@ -635,6 +634,7 @@ export default class SalesforceAdapter implements AdapterOperations {
         client: this.client,
         types: metadataTypesToRetrieve,
         fetchProfile,
+        typesToSkip: new Set(this.metadataTypesOfInstancesFetchedInFilters),
       }),
       readInstances(metadataTypesToRead),
     ])

--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -328,25 +328,20 @@ const getTypesWithMetaFile = async (
 type RetrieveMetadataInstancesArgs = {
   client: SalesforceClient
   types: ReadonlyArray<MetadataObjectType>
-  maxItemsInRetrieveRequest: number
-  metadataQuery: MetadataQuery
-  // Some types are retrieved via filters and should not be fetched in the normal fetch flow. However, we need these
-  // types as context for profiles - when fetching profiles using retrieve we only get information about the types that
-  // are included in the same retrieve request as the profile. Thus typesToSkip - a list of types that will be retrieved
-  // along with the profiles, but discarded.
-  typesToSkip: ReadonlySet<string>
   fetchProfile: FetchProfile
 }
 
 export const retrieveMetadataInstances = async ({
   client,
   types,
-  maxItemsInRetrieveRequest,
-  metadataQuery,
   fetchProfile,
-  typesToSkip,
 }: RetrieveMetadataInstancesArgs): Promise<FetchElements<InstanceElement[]>> => {
   const configChanges: ConfigChangeSuggestion[] = []
+  const {
+    metadataQuery,
+    typesToSkip,
+    maxItemsInRetrieveRequest,
+  } = fetchProfile
 
   const listFilesOfType = async (type: MetadataObjectType): Promise<FileProperties[]> => {
     const typeName = await apiName(type)

--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -329,17 +329,22 @@ type RetrieveMetadataInstancesArgs = {
   client: SalesforceClient
   types: ReadonlyArray<MetadataObjectType>
   fetchProfile: FetchProfile
+  // Some types are retrieved via filters and should not be fetched in the normal fetch flow. However, we need these
+  // types as context for profiles - when fetching profiles using retrieve we only get information about the types that
+  // are included in the same retrieve request as the profile. Thus typesToSkip - a list of types that will be retrieved
+  // along with the profiles, but discarded.
+  typesToSkip?: ReadonlySet<string>
 }
 
 export const retrieveMetadataInstances = async ({
   client,
   types,
   fetchProfile,
+  typesToSkip = new Set(),
 }: RetrieveMetadataInstancesArgs): Promise<FetchElements<InstanceElement[]>> => {
   const configChanges: ConfigChangeSuggestion[] = []
   const {
     metadataQuery,
-    typesToSkip,
     maxItemsInRetrieveRequest,
   } = fetchProfile
 

--- a/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
@@ -41,14 +41,12 @@ type BuildFetchProfileParams = {
   fetchParams: FetchParameters
   metadataQuery?: MetadataQuery
   maxItemsInRetrieveRequest?: number
-  typesToSkip?: ReadonlySet<string>
 }
 
 export const buildFetchProfile = ({
   fetchParams,
   metadataQuery = buildMetadataQuery({ fetchParams }),
   maxItemsInRetrieveRequest = DEFAULT_MAX_ITEMS_IN_RETRIEVE_REQUEST,
-  typesToSkip = new Set(),
 }: BuildFetchProfileParams): FetchProfile => {
   const {
     data,
@@ -71,7 +69,6 @@ export const buildFetchProfile = ({
     ),
     metadataQuery,
     maxItemsInRetrieveRequest,
-    typesToSkip,
   }
 }
 

--- a/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
@@ -18,11 +18,12 @@ import {
   FetchProfile,
   FetchParameters,
   METADATA_CONFIG,
-  OptionalFeatures, MetadataQuery,
+  OptionalFeatures,
+  MetadataQuery,
 } from '../types'
 import { buildDataManagement, validateDataManagementConfig } from './data_management'
 import { buildMetadataQuery, validateMetadataParams } from './metadata_query'
-import { DEFAULT_MAX_INSTANCES_PER_TYPE } from '../constants'
+import { DEFAULT_MAX_INSTANCES_PER_TYPE, DEFAULT_MAX_ITEMS_IN_RETRIEVE_REQUEST } from '../constants'
 
 type OptionalFeaturesDefaultValues = {
   [FeatureName in keyof OptionalFeatures]?: boolean
@@ -39,11 +40,15 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
 type BuildFetchProfileParams = {
   fetchParams: FetchParameters
   metadataQuery?: MetadataQuery
+  maxItemsInRetrieveRequest?: number
+  typesToSkip?: ReadonlySet<string>
 }
 
 export const buildFetchProfile = ({
   fetchParams,
   metadataQuery = buildMetadataQuery({ fetchParams }),
+  maxItemsInRetrieveRequest = DEFAULT_MAX_ITEMS_IN_RETRIEVE_REQUEST,
+  typesToSkip = new Set(),
 }: BuildFetchProfileParams): FetchProfile => {
   const {
     data,
@@ -65,6 +70,8 @@ export const buildFetchProfile = ({
       warningSettings?.[name] ?? true
     ),
     metadataQuery,
+    maxItemsInRetrieveRequest,
+    typesToSkip,
   }
 }
 

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -894,4 +894,10 @@ export type FetchProfile = {
   readonly preferActiveFlowVersions: boolean
   readonly addNamespacePrefixToFullName: boolean
   isWarningEnabled: (name: keyof WarningSettings) => boolean
+  maxItemsInRetrieveRequest: number
+  // Some types are retrieved via filters and should not be fetched in the normal fetch flow. However, we need these
+  // types as context for profiles - when fetching profiles using retrieve we only get information about the types that
+  // are included in the same retrieve request as the profile. Thus typesToSkip - a list of types that will be retrieved
+  // along with the profiles, but discarded.
+  typesToSkip: ReadonlySet<string>
 }

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -894,10 +894,5 @@ export type FetchProfile = {
   readonly preferActiveFlowVersions: boolean
   readonly addNamespacePrefixToFullName: boolean
   isWarningEnabled: (name: keyof WarningSettings) => boolean
-  maxItemsInRetrieveRequest: number
-  // Some types are retrieved via filters and should not be fetched in the normal fetch flow. However, we need these
-  // types as context for profiles - when fetching profiles using retrieve we only get information about the types that
-  // are included in the same retrieve request as the profile. Thus typesToSkip - a list of types that will be retrieved
-  // along with the profiles, but discarded.
-  typesToSkip: ReadonlySet<string>
+  readonly maxItemsInRetrieveRequest: number
 }

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -68,7 +68,6 @@ import { NON_TRANSIENT_SALESFORCE_ERRORS } from '../src/config_change'
 import SalesforceClient from '../src/client/client'
 import createMockClient from './client'
 import { mockInstances, mockTypes } from './mock_elements'
-import { buildMetadataQuery } from '../src/fetch_profile/metadata_query'
 import { buildFetchProfile } from '../src/fetch_profile/fetch_profile'
 
 const { makeArray } = collections.array
@@ -2000,14 +1999,9 @@ describe('Fetch via retrieve API', () => {
         {
           client,
           types: [mockTypes.ApexClass],
-          maxItemsInRetrieveRequest: DEFAULT_MAX_ITEMS_IN_RETRIEVE_REQUEST,
-          metadataQuery: buildMetadataQuery({
-            fetchParams: {},
-          }),
           fetchProfile: buildFetchProfile({
             fetchParams: { addNamespacePrefixToFullName: false },
           }),
-          typesToSkip: new Set(),
         }
       )
       ).elements
@@ -2035,14 +2029,10 @@ describe('Fetch via retrieve API', () => {
         {
           client,
           types: [mockTypes.ApexClass, mockTypes.CustomObject],
-          maxItemsInRetrieveRequest: chunkSize,
-          metadataQuery: buildMetadataQuery({
-            fetchParams: {},
-          }),
           fetchProfile: buildFetchProfile({
             fetchParams: { addNamespacePrefixToFullName: false },
+            maxItemsInRetrieveRequest: chunkSize,
           }),
-          typesToSkip: new Set(),
         }
       )
       ).elements
@@ -2074,14 +2064,10 @@ describe('Fetch via retrieve API', () => {
         {
           client,
           types: [mockTypes.CustomObject, mockTypes.Profile],
-          maxItemsInRetrieveRequest: chunkSize,
-          metadataQuery: buildMetadataQuery({
-            fetchParams: {},
-          }),
           fetchProfile: buildFetchProfile({
             fetchParams: { addNamespacePrefixToFullName: false },
+            maxItemsInRetrieveRequest: chunkSize,
           }),
-          typesToSkip: new Set(),
         }
       )
       ).elements
@@ -2121,14 +2107,10 @@ describe('Fetch via retrieve API', () => {
         {
           client,
           types: [mockTypes.CustomObject, mockTypes.Profile],
-          maxItemsInRetrieveRequest: 3,
-          metadataQuery: buildMetadataQuery({
-            fetchParams: {},
-          }),
           fetchProfile: buildFetchProfile({
             fetchParams: { addNamespacePrefixToFullName: false },
+            maxItemsInRetrieveRequest: 3,
           }),
-          typesToSkip: new Set(),
         }
       )
       ).elements


### PR DESCRIPTION
Required step for fetch with changes detection on Profiles. 

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
