### PR TITLE
SAAS-9617: Make referenceSourcesIndex optional

### DIFF
--- a/packages/core/src/core/diff.ts
+++ b/packages/core/src/core/diff.ts
@@ -136,12 +136,12 @@ export function createDiffChanges(
 export async function createDiffChanges(
   toElementsSrc: elementSource.ElementsSource,
   fromElementsSrc: elementSource.ElementsSource,
-  referenceSourcesIndex: remoteMap.ReadOnlyRemoteMap<ElemID[]> | undefined,
+  referenceSourcesIndex: remoteMap.ReadOnlyRemoteMap<ElemID[]> = new remoteMap.InMemoryRemoteMap<ElemID[]>(),
   elementSelectors: ElementSelector[] = [],
   topLevelFilters: IDFilter[] = [],
   resultType: 'changes' | 'detailedChanges' = 'detailedChanges'
 ): Promise<DetailedChange[] | ChangeWithDetails[]> {
-  if (elementSelectors.length > 0 && referenceSourcesIndex !== undefined) {
+  if (elementSelectors.length > 0) {
     const matchers = await createMatchers(
       toElementsSrc,
       fromElementsSrc,

--- a/packages/core/src/core/diff.ts
+++ b/packages/core/src/core/diff.ts
@@ -120,7 +120,7 @@ const createMatchers = async (
 export function createDiffChanges(
   toElementsSrc: elementSource.ElementsSource,
   fromElementsSrc: elementSource.ElementsSource,
-  referenceSourcesIndex: remoteMap.ReadOnlyRemoteMap<ElemID[]>,
+  referenceSourcesIndex: remoteMap.ReadOnlyRemoteMap<ElemID[]> | undefined,
   elementSelectors: ElementSelector[] | undefined,
   topLevelFilters: IDFilter[] | undefined,
   resultType: 'changes'
@@ -128,7 +128,7 @@ export function createDiffChanges(
 export function createDiffChanges(
   toElementsSrc: elementSource.ElementsSource,
   fromElementsSrc: elementSource.ElementsSource,
-  referenceSourcesIndex: remoteMap.ReadOnlyRemoteMap<ElemID[]>,
+  referenceSourcesIndex?: remoteMap.ReadOnlyRemoteMap<ElemID[]>,
   elementSelectors?: ElementSelector[],
   topLevelFilters?: IDFilter[],
   resultType?: 'detailedChanges'
@@ -136,12 +136,12 @@ export function createDiffChanges(
 export async function createDiffChanges(
   toElementsSrc: elementSource.ElementsSource,
   fromElementsSrc: elementSource.ElementsSource,
-  referenceSourcesIndex: remoteMap.ReadOnlyRemoteMap<ElemID[]>,
+  referenceSourcesIndex: remoteMap.ReadOnlyRemoteMap<ElemID[]> | undefined,
   elementSelectors: ElementSelector[] = [],
   topLevelFilters: IDFilter[] = [],
   resultType: 'changes' | 'detailedChanges' = 'detailedChanges'
 ): Promise<DetailedChange[] | ChangeWithDetails[]> {
-  if (elementSelectors.length > 0) {
+  if (elementSelectors.length > 0 && referenceSourcesIndex !== undefined) {
     const matchers = await createMatchers(
       toElementsSrc,
       fromElementsSrc,


### PR DESCRIPTION
It can only be used when elementSelectors are provided, and since elementSelectors is optional, this should be as well.

---

_Additional context for reviewer_

---

_Release Notes_: 
None

---

_User Notifications_: 
None