### PR TITLE
SALTO-5074: Handle unresolved references when resolving template expressions

### DIFF
--- a/packages/zendesk-adapter/src/filters/article/article_body.ts
+++ b/packages/zendesk-adapter/src/filters/article/article_body.ts
@@ -144,10 +144,10 @@ const updateArticleTranslationBody = ({
 export const prepRef = (part: ReferenceExpression): TemplatePart => {
   // In some cases this function may run on the .before value of a Change, which may contain unresolved references.
   // .after values are always resolved because unresolved references are dropped by unresolved_references validator
-  // we should add a generic solution since we have seen this repeating
+  // we should add a generic solution since we have seen this repeating (SALTO-5074)
   // This fix is enough since the .before value is not used in the deployment process
   if (part.value instanceof UnresolvedReference) {
-    log.debug('prepRef received a part as unresolved reference, returning an empty string, instance fullName: %s ', part.elemID.getFullName())
+    log.trace('prepRef received a part as unresolved reference, returning an empty string, instance fullName: %s ', part.elemID.getFullName())
     return ''
   }
   if (part.elemID.typeName === BRAND_TYPE_NAME) {

--- a/packages/zendesk-adapter/test/filters/article/article_body.test.ts
+++ b/packages/zendesk-adapter/test/filters/article/article_body.test.ts
@@ -13,10 +13,20 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ElemID, InstanceElement, ObjectType,
-  BuiltinTypes, toChange, isInstanceElement, TemplateExpression, ReferenceExpression, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
+import {
+  ElemID,
+  InstanceElement,
+  ObjectType,
+  BuiltinTypes,
+  toChange,
+  isInstanceElement,
+  TemplateExpression,
+  ReferenceExpression,
+  CORE_ANNOTATIONS,
+  UnresolvedReference,
+} from '@salto-io/adapter-api'
 import { filterUtils, references as referencesUtils } from '@salto-io/adapter-components'
-import filterCreator from '../../../src/filters/article/article_body'
+import filterCreator, { prepRef } from '../../../src/filters/article/article_body'
 import {
   ARTICLE_ATTACHMENT_TYPE_NAME,
   ARTICLE_TYPE_NAME,
@@ -28,6 +38,7 @@ import {
 import { createFilterCreatorParams } from '../../utils'
 import { DEFAULT_CONFIG, FETCH_CONFIG } from '../../../src/config'
 import { FilterResult } from '../../../src/filter'
+
 
 const { createMissingInstance } = referencesUtils
 
@@ -344,6 +355,15 @@ describe('article body filter', () => {
       const elementsAfterOnDeploy = elementsAfterPreDeploy.map(e => e.clone())
       await filter.onDeploy(elementsAfterOnDeploy.map(e => toChange({ before: e, after: e })))
       expect(elementsAfterOnDeploy).toEqual(elementsAfterFetch)
+    })
+  })
+  describe('prepRef', () => {
+    it('should return an empty string on UnresolvedReference', () => {
+      const elemId = new ElemID(ZENDESK, 'test')
+      const unresolvedRef = new UnresolvedReference(elemId)
+      const unresolvedPrepRef = prepRef(new ReferenceExpression(elemId, unresolvedRef))
+
+      expect(unresolvedPrepRef).toEqual('')
     })
   })
 })


### PR DESCRIPTION
Handle unresolved references when resolving template expressions

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* Avoid crushing when resolving an article_body template expression with an unresolved reference
---
_User Notifications_: 
None
