### PR TITLE
SALTO-4968: Cache Salesforce Client listMetadataObjects results

### DIFF
--- a/packages/salesforce-adapter/test/client.test.ts
+++ b/packages/salesforce-adapter/test/client.test.ts
@@ -56,12 +56,32 @@ const logging = logger('salesforce-adapter/src/client/client')
 
 
 describe('salesforce client', () => {
+  let client: SalesforceClient
   beforeEach(() => {
     nock.cleanAll()
     nock('https://test.salesforce.com')
       .persist()
       .post(/.*/)
       .reply(200, '<serverUrl>http://dodo22</serverUrl>/')
+    client = new SalesforceClient({
+      credentials: new UsernamePasswordCredentials({
+        username: '',
+        password: '',
+        isSandbox: true,
+      }),
+      config: {
+        retry: {
+          maxAttempts: 3, // try 3 times
+          retryDelay: 100, // wait for 100ms before trying again
+        },
+        maxConcurrentApiRequests: {
+          total: RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,
+          retrieve: 3,
+          read: RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,
+          list: 1,
+        },
+      },
+    })
   })
   const credentials = new UsernamePasswordCredentials({
     username: 'myUser',
@@ -76,25 +96,6 @@ describe('salesforce client', () => {
     apiToken: 'myToken',
   })
   const { connection } = mockClient()
-  const client = new SalesforceClient({
-    credentials: new UsernamePasswordCredentials({
-      username: '',
-      password: '',
-      isSandbox: true,
-    }),
-    config: {
-      retry: {
-        maxAttempts: 3, // try 3 times
-        retryDelay: 100, // wait for 100ms before trying again
-      },
-      maxConcurrentApiRequests: {
-        total: RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,
-        retrieve: 3,
-        read: RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,
-        list: 1,
-      },
-    },
-  })
   const headers = { 'content-type': 'application/json' }
   const workingReadReplay = {
     'a:Envelope': { 'a:Body': { a: { result: { records: [{ fullName: 'BLA' }] } } } },


### PR DESCRIPTION
This PR adds caching on the results of **listMetadataObjects**.

---

Main reason for this caching is the fact we have some MetadataTypes we list more than once, especially in **fetch with changes detection mode**. Listing types can be time consuming, depending on the amount of **Instances** per type. It's widely noticeable around **CustomFields** and **CustomObjects**.

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
