### PR TITLE
SALTO-5081 Added more fields in requestForm, issueView and issueLayout

### DIFF
--- a/packages/jira-adapter/src/filters/layouts/layout_queries.ts
+++ b/packages/jira-adapter/src/filters/layouts/layout_queries.ts
@@ -14,52 +14,20 @@
 * limitations under the License.
 */
 export const QUERY = `query SwiftJswCmpInitial($projectId: Long!, $extraDefinerId: Long!) {
-    ...CMPJSWLayoutConfigurationFragment
-  }
-    
-    fragment JiraIssueLayoutActivePanelItemFragment on JiraIssueItemPanelItem {
-      panelItemId
-    }
-  
-    fragment JiraIssueLayoutActiveFieldItemFragment on JiraIssueItemFieldItem {
-      fieldItemId
-      containerPosition
-    }
-  
-  fragment JiraIssueLayoutItemContainerFragment on JiraIssueItemContainer {
-    containerType
-    items {
-      nodes {
-        ...JiraIssueLayoutActiveFieldItemFragment,
-        ...JiraIssueLayoutActivePanelItemFragment,
-      }
-    }
-  }
-  
-  fragment CMPJSWLayoutConfigurationFragment on Query {
-    issueLayoutConfiguration(issueLayoutKey: {projectId: $projectId, extraDefinerId: $extraDefinerId}, type: ISSUE_VIEW) {
-      ... on JiraIssueLayoutConfigurationResult {
-        issueLayoutResult {
-          id
-          name
-          containers {
-              ...JiraIssueLayoutItemContainerFragment
-          }
-        }
-      }
-    }
-  }`
-
-export const QUERY_JSM = `query SwiftJsmCmpCustomerViewInitial($projectId: Long!, $extraDefinerId: Long!, $layoutType: IssueLayoutType!) {
-    ...CMPJSMLayoutConfigurationFragment
+  ...CMPJSWLayoutConfigurationFragment
 }
+
   fragment JiraIssueLayoutActivePanelItemFragment on JiraIssueItemPanelItem {
     panelItemId
   }
+
+
+
   fragment JiraIssueLayoutActiveFieldItemFragment on JiraIssueItemFieldItem {
     fieldItemId
     containerPosition
   }
+
   fragment JiraIssueLayoutTabContainerFragment on JiraIssueItemTabContainer {
       tabContainerId
       name
@@ -69,18 +37,55 @@ export const QUERY_JSM = `query SwiftJsmCmpCustomerViewInitial($projectId: Long!
         }
       }
   }
+
 fragment JiraIssueLayoutItemContainerFragment on JiraIssueItemContainer {
   containerType
   items {
     nodes {
-      ...JiraIssueLayoutActiveFieldItemFragment,
-      ...JiraIssueLayoutActivePanelItemFragment,
-      ...JiraIssueLayoutTabContainerFragment,
+      __typename
+      ... JiraIssueLayoutActiveFieldItemFragment,
+      ... JiraIssueLayoutActivePanelItemFragment,
+      ... JiraIssueLayoutTabContainerFragment,
     }
   }
 }
-fragment CMPJSMLayoutConfigurationFragment on Query {
-  issueLayoutConfiguration(issueLayoutKey: {projectId: $projectId, extraDefinerId: $extraDefinerId}, type: $layoutType) {
+
+
+
+fragment PanelItemFragment on JiraIssueLayoutPanelItemConfiguration {
+  panelItemId
+  name
+}
+
+
+fragment FieldItemBaseFragment on JiraIssueLayoutFieldItemConfiguration {
+  fieldItemId
+  custom
+  global
+  description
+  configuration
+  required
+  externalUuid
+  defaultValue
+}
+
+  fragment FieldItemFragment on JiraIssueLayoutFieldItemConfiguration {
+    ...FieldItemBaseFragment
+    properties(keys: [])
+  }
+
+
+fragment JiraIssueLayoutItemConfigurationFragment on JiraIssueLayoutItemConfigurationResult {
+  items {
+    nodes {
+      ...FieldItemFragment
+      ...PanelItemFragment
+    }
+  }
+}
+
+fragment CMPJSWLayoutConfigurationFragment on Query {
+  issueLayoutConfiguration(issueLayoutKey: {projectId: $projectId, extraDefinerId: $extraDefinerId}, type: ISSUE_VIEW) {
     ... on JiraIssueLayoutConfigurationResult {
       issueLayoutResult {
         id
@@ -89,6 +94,98 @@ fragment CMPJSMLayoutConfigurationFragment on Query {
             ...JiraIssueLayoutItemContainerFragment
         }
       }
+      metadata {
+        configuration {
+            ...JiraIssueLayoutItemConfigurationFragment
+        }
+      }
     }
   }
+}`
+
+export const QUERY_JSM = `query SwiftJsmCmpCustomerViewInitial($projectId: Long!, $extraDefinerId: Long!, $layoutType: IssueLayoutType!) {
+  ...CMPJSMLayoutConfigurationFragment
+}
+
+fragment JiraIssueLayoutActivePanelItemFragment on JiraIssueItemPanelItem {
+  panelItemId
+}
+
+
+
+fragment JiraIssueLayoutActiveFieldItemFragment on JiraIssueItemFieldItem {
+  fieldItemId
+  containerPosition
+}
+
+fragment JiraIssueLayoutTabContainerFragment on JiraIssueItemTabContainer {
+    tabContainerId
+    name
+    items {
+      nodes {
+        ...JiraIssueLayoutActiveFieldItemFragment
+      }
+    }
+}
+
+fragment JiraIssueLayoutItemContainerFragment on JiraIssueItemContainer {
+containerType
+items {
+  nodes {
+    ... JiraIssueLayoutActiveFieldItemFragment,
+    ... JiraIssueLayoutActivePanelItemFragment,
+    ... JiraIssueLayoutTabContainerFragment,
+  }
+}
+}
+
+
+
+fragment PanelItemFragment on JiraIssueLayoutPanelItemConfiguration {
+panelItemId
+name
+}
+
+
+fragment FieldItemBaseFragment on JiraIssueLayoutFieldItemConfiguration {
+fieldItemId
+custom
+global
+description
+configuration
+required
+defaultValue
+}
+
+fragment FieldItemFragment on JiraIssueLayoutFieldItemConfiguration {
+  ...FieldItemBaseFragment
+  properties(keys: [])
+}
+
+fragment JiraIssueLayoutItemConfigurationFragment on JiraIssueLayoutItemConfigurationResult {
+items {
+  nodes {
+    ...FieldItemFragment
+    ...PanelItemFragment
+  }
+}
+}
+
+fragment CMPJSMLayoutConfigurationFragment on Query {
+issueLayoutConfiguration(issueLayoutKey: {projectId: $projectId, extraDefinerId: $extraDefinerId}, type: $layoutType) {
+  ... on JiraIssueLayoutConfigurationResult {
+    issueLayoutResult {
+      id
+      name
+      containers {
+          ...JiraIssueLayoutItemContainerFragment
+      }
+    }
+    metadata {
+      configuration {
+          ...JiraIssueLayoutItemConfigurationFragment
+      }
+    }
+  }
+}
 }`

--- a/packages/jira-adapter/src/filters/layouts/layout_queries.ts
+++ b/packages/jira-adapter/src/filters/layouts/layout_queries.ts
@@ -17,26 +17,24 @@ export const QUERY = `query SwiftJswCmpInitial($projectId: Long!, $extraDefinerI
   ...CMPJSWLayoutConfigurationFragment
 }
 
-  fragment JiraIssueLayoutActivePanelItemFragment on JiraIssueItemPanelItem {
-    panelItemId
+fragment JiraIssueLayoutActivePanelItemFragment on JiraIssueItemPanelItem {
+  panelItemId
+}
+
+fragment JiraIssueLayoutActiveFieldItemFragment on JiraIssueItemFieldItem {
+  fieldItemId
+  containerPosition
+}
+
+fragment JiraIssueLayoutTabContainerFragment on JiraIssueItemTabContainer {
+  tabContainerId
+  name
+  items {
+    nodes {
+      ...JiraIssueLayoutActiveFieldItemFragment
+    }
   }
-
-
-
-  fragment JiraIssueLayoutActiveFieldItemFragment on JiraIssueItemFieldItem {
-    fieldItemId
-    containerPosition
-  }
-
-  fragment JiraIssueLayoutTabContainerFragment on JiraIssueItemTabContainer {
-      tabContainerId
-      name
-      items {
-        nodes {
-          ...JiraIssueLayoutActiveFieldItemFragment
-        }
-      }
-  }
+}
 
 fragment JiraIssueLayoutItemContainerFragment on JiraIssueItemContainer {
   containerType
@@ -50,13 +48,10 @@ fragment JiraIssueLayoutItemContainerFragment on JiraIssueItemContainer {
   }
 }
 
-
-
 fragment PanelItemFragment on JiraIssueLayoutPanelItemConfiguration {
   panelItemId
   name
 }
-
 
 fragment FieldItemBaseFragment on JiraIssueLayoutFieldItemConfiguration {
   fieldItemId
@@ -69,11 +64,10 @@ fragment FieldItemBaseFragment on JiraIssueLayoutFieldItemConfiguration {
   defaultValue
 }
 
-  fragment FieldItemFragment on JiraIssueLayoutFieldItemConfiguration {
-    ...FieldItemBaseFragment
-    properties(keys: [])
-  }
-
+fragment FieldItemFragment on JiraIssueLayoutFieldItemConfiguration {
+  ...FieldItemBaseFragment
+  properties(keys: [])
+}
 
 fragment JiraIssueLayoutItemConfigurationFragment on JiraIssueLayoutItemConfigurationResult {
   items {
@@ -111,50 +105,48 @@ fragment JiraIssueLayoutActivePanelItemFragment on JiraIssueItemPanelItem {
   panelItemId
 }
 
-
-
 fragment JiraIssueLayoutActiveFieldItemFragment on JiraIssueItemFieldItem {
   fieldItemId
   containerPosition
 }
 
 fragment JiraIssueLayoutTabContainerFragment on JiraIssueItemTabContainer {
-    tabContainerId
-    name
-    items {
-      nodes {
-        ...JiraIssueLayoutActiveFieldItemFragment
-      }
+  tabContainerId
+  name
+  items {
+    nodes {
+      ...JiraIssueLayoutActiveFieldItemFragment
     }
+  }
 }
 
 fragment JiraIssueLayoutItemContainerFragment on JiraIssueItemContainer {
-containerType
-items {
-  nodes {
-    ... JiraIssueLayoutActiveFieldItemFragment,
-    ... JiraIssueLayoutActivePanelItemFragment,
-    ... JiraIssueLayoutTabContainerFragment,
+  containerType
+  items {
+    nodes {
+      ... JiraIssueLayoutActiveFieldItemFragment,
+      ... JiraIssueLayoutActivePanelItemFragment,
+      ... JiraIssueLayoutTabContainerFragment,
+    }
   }
-}
 }
 
 
 
 fragment PanelItemFragment on JiraIssueLayoutPanelItemConfiguration {
-panelItemId
-name
+  panelItemId
+  name
 }
 
 
 fragment FieldItemBaseFragment on JiraIssueLayoutFieldItemConfiguration {
-fieldItemId
-custom
-global
-description
-configuration
-required
-defaultValue
+  fieldItemId
+  custom
+  global
+  description
+  configuration
+  required
+  defaultValue
 }
 
 fragment FieldItemFragment on JiraIssueLayoutFieldItemConfiguration {
@@ -163,29 +155,29 @@ fragment FieldItemFragment on JiraIssueLayoutFieldItemConfiguration {
 }
 
 fragment JiraIssueLayoutItemConfigurationFragment on JiraIssueLayoutItemConfigurationResult {
-items {
-  nodes {
-    ...FieldItemFragment
-    ...PanelItemFragment
+  items {
+    nodes {
+      ...FieldItemFragment
+      ...PanelItemFragment
+    }
   }
-}
 }
 
 fragment CMPJSMLayoutConfigurationFragment on Query {
-issueLayoutConfiguration(issueLayoutKey: {projectId: $projectId, extraDefinerId: $extraDefinerId}, type: $layoutType) {
-  ... on JiraIssueLayoutConfigurationResult {
-    issueLayoutResult {
-      id
-      name
-      containers {
-          ...JiraIssueLayoutItemContainerFragment
+  issueLayoutConfiguration(issueLayoutKey: {projectId: $projectId, extraDefinerId: $extraDefinerId}, type: $layoutType) {
+    ... on JiraIssueLayoutConfigurationResult {
+      issueLayoutResult {
+        id
+        name
+        containers {
+            ...JiraIssueLayoutItemContainerFragment
+        }
       }
-    }
-    metadata {
-      configuration {
-          ...JiraIssueLayoutItemConfigurationFragment
+      metadata {
+        configuration {
+            ...JiraIssueLayoutItemConfigurationFragment
+        }
       }
     }
   }
-}
 }`

--- a/packages/jira-adapter/src/filters/layouts/layout_service_operations.ts
+++ b/packages/jira-adapter/src/filters/layouts/layout_service_operations.ts
@@ -103,17 +103,13 @@ export const getLayoutResponse = async ({
   return { data: undefined }
 }
 
-const fromlayoutConfigRespTolayoutConfig = (
+const fromLayoutConfigRespToLayoutConfig = (
   layoutConfig: IssueLayoutConfiguration
 ): issueLayoutConfig => {
   const { containers } = layoutConfig.issueLayoutResult
   const fieldItemIdToMetaData = Object.fromEntries(layoutConfig.metadata.configuration.items.nodes
     .filter(node => !_.isEmpty(node))
-    .map(node => {
-      const { fieldItemId } = node
-      delete node.fieldItemId
-      return [fieldItemId, node]
-    }))
+    .map(node => [node.fieldItemId, _.omit(node, 'fieldItemId')]))
 
   const items = containers
     .flatMap(container => container.items.nodes
@@ -149,7 +145,7 @@ export const getLayout = async ({
       id: issueLayoutResult.id,
       projectId: variables.projectId,
       extraDefinerId: variables.extraDefinerId,
-      issueLayoutConfig: fromlayoutConfigRespTolayoutConfig(response.data.issueLayoutConfiguration),
+      issueLayoutConfig: fromLayoutConfigRespToLayoutConfig(response.data.issueLayoutConfiguration),
     }
     const name = `${instance.value.name}_${issueLayoutResult.name}`
     const serviceIds = adapterElements.createServiceIds(value, 'id', layoutType.elemID)

--- a/packages/jira-adapter/src/filters/layouts/layout_service_operations.ts
+++ b/packages/jira-adapter/src/filters/layouts/layout_service_operations.ts
@@ -18,7 +18,7 @@ import { logger } from '@salto-io/logging'
 import { ElemIdGetter, InstanceElement, ObjectType, Element, isInstanceElement, CORE_ANNOTATIONS, Change, DeployResult, getChangeData, isInstanceChange, isAdditionChange } from '@salto-io/adapter-api'
 import { values as lowerDashValues } from '@salto-io/lowerdash'
 import { createSchemeGuard, getParent, isResolvedReferenceExpression, naclCase, pathNaclCase } from '@salto-io/adapter-utils'
-import { elements as adapterElements } from '@salto-io/adapter-components'
+import { elements as adapterElements, config as configUtils } from '@salto-io/adapter-components'
 import { FilterResult } from '@salto-io/adapter-utils/src/filter'
 import _ from 'lodash'
 import { deployChanges } from '../../deployment/standard_deployment'
@@ -26,11 +26,14 @@ import { setTypeDeploymentAnnotations, addAnnotationRecursively } from '../../ut
 import { JiraConfig } from '../../config/config'
 import JiraClient, { graphQLResponseType } from '../../client/client'
 import { QUERY, QUERY_JSM } from './layout_queries'
-import { ISSUE_LAYOUT_CONFIG_ITEM_SCHEME, ISSUE_LAYOUT_RESPONSE_SCHEME, issueLayoutConfig, layoutConfigItem, IssueLayoutResponse, containerIssueLayoutResponse, createLayoutType } from './layout_types'
+import { ISSUE_LAYOUT_CONFIG_ITEM_SCHEME, ISSUE_LAYOUT_RESPONSE_SCHEME, issueLayoutConfig, layoutConfigItem, IssueLayoutResponse, createLayoutType, IssueLayoutConfiguration } from './layout_types'
 import { ISSUE_LAYOUT_TYPE, ISSUE_VIEW_TYPE, JIRA, REQUEST_FORM_TYPE, REQUEST_TYPE_NAME } from '../../constants'
+import { DEFAULT_API_DEFINITIONS } from '../../config/api_config'
 
 const log = logger(module)
 const { isDefined } = lowerDashValues
+const { toBasicInstance } = adapterElements
+const { getTransformationConfigByType } = configUtils
 
 type LayoutTypeDetails = {
     pathParam: string
@@ -101,14 +104,25 @@ export const getLayoutResponse = async ({
 }
 
 const fromlayoutConfigRespTolayoutConfig = (
-  containers: containerIssueLayoutResponse[]
+  layoutConfig: IssueLayoutConfiguration
 ): issueLayoutConfig => {
+  const { containers } = layoutConfig.issueLayoutResult
+  const fieldItemIdToMetaData = Object.fromEntries(layoutConfig.metadata.configuration.items.nodes
+    .filter(node => !_.isEmpty(node))
+    .map(node => {
+      const { fieldItemId } = node
+      delete node.fieldItemId
+      return [fieldItemId, node]
+    }))
+
   const items = containers
-    .flatMap(container => container.items.nodes.map(node => ({
-      type: 'FIELD',
-      sectionType: container.containerType,
-      key: node.fieldItemId,
-    })))
+    .flatMap(container => container.items.nodes
+      .map(node => ({
+        type: 'FIELD',
+        sectionType: container.containerType,
+        key: node.fieldItemId,
+        data: fieldItemIdToMetaData[node.fieldItemId],
+      })))
     .filter(isLayoutConfigItem)
 
   return { items }
@@ -131,23 +145,29 @@ export const getLayout = async ({
     }): Promise<InstanceElement | undefined> => {
   if (!Array.isArray(response.data) && isIssueLayoutResponse(response.data) && instance.path !== undefined) {
     const { issueLayoutResult } = response.data.issueLayoutConfiguration
-    const { containers } = issueLayoutResult
     const value = {
       id: issueLayoutResult.id,
       projectId: variables.projectId,
       extraDefinerId: variables.extraDefinerId,
-      issueLayoutConfig: fromlayoutConfigRespTolayoutConfig(containers),
+      issueLayoutConfig: fromlayoutConfigRespTolayoutConfig(response.data.issueLayoutConfiguration),
     }
     const name = `${instance.value.name}_${issueLayoutResult.name}`
     const serviceIds = adapterElements.createServiceIds(value, 'id', layoutType.elemID)
     const instanceName = getElemIdFunc ? getElemIdFunc(JIRA, serviceIds, naclCase(name)).name
       : naclCase(name)
-    return new InstanceElement(
-      instanceName,
-      layoutType,
-      value,
-      [...instance.path.slice(0, -1), LAYOUT_TYPE_NAME_TO_DETAILS[typeName].pathParam, pathNaclCase(instanceName)],
-    )
+    return toBasicInstance({
+      entry: value,
+      type: layoutType,
+      transformationConfigByType: getTransformationConfigByType(DEFAULT_API_DEFINITIONS.types),
+      transformationDefaultConfig: DEFAULT_API_DEFINITIONS.typeDefaults.transformation,
+      parent: instance,
+      defaultName: name,
+      getElemIdFunc,
+      nestedPath:
+      [...instance.path?.slice(2, instance.path?.length - 1),
+        LAYOUT_TYPE_NAME_TO_DETAILS[typeName].pathParam,
+        pathNaclCase(instanceName)],
+    })
   }
   return undefined
 }
@@ -171,6 +191,7 @@ const deployLayoutChange = async (
         data: {
           name: item.key.value.value.name,
           type: item.key.value.value.type ?? item.key.value.value.schema.system,
+          ...item.data,
         },
       }
     }

--- a/packages/jira-adapter/src/filters/layouts/layout_types.ts
+++ b/packages/jira-adapter/src/filters/layouts/layout_types.ts
@@ -80,7 +80,7 @@ export type containerIssueLayoutResponse = {
   containerType: string
   items: {
     nodes: {
-      fieldItemId?: string
+      fieldItemId: string
       panelItemId?: string
     }[]
   }
@@ -96,20 +96,32 @@ const CONTAINER_ISSUE_LAYOUT_RESPONSE_SCHEME = Joi.object({
   }).required(),
 }).unknown(true).required()
 
-export type IssueLayoutResponse = {
-  issueLayoutConfiguration: {
-      issueLayoutResult: {
-          id: string
-          name: string
-          containers: containerIssueLayoutResponse[]
+export type IssueLayoutConfiguration = {
+  issueLayoutResult: {
+    id: string
+    name: string
+    containers: containerIssueLayoutResponse[]
+  }
+  metadata: {
+    configuration: {
+      items: {
+        nodes: {
+          fieldItemId?: string
+        }[]
       }
     }
+  }
+}
+
+export type IssueLayoutResponse = {
+  issueLayoutConfiguration: IssueLayoutConfiguration
   }
 
 export type layoutConfigItem = {
   type: string
   sectionType: 'PRIMARY' | 'SECONDARY' | 'CONTENT' | 'REQUEST'
   key: string
+  data: {}
 }
 
 export const ISSUE_LAYOUT_CONFIG_ITEM_SCHEME = Joi.object({
@@ -126,6 +138,13 @@ export const ISSUE_LAYOUT_RESPONSE_SCHEME = Joi.object({
   issueLayoutConfiguration: Joi.object({
     issueLayoutResult: Joi.object({
       containers: Joi.array().items(CONTAINER_ISSUE_LAYOUT_RESPONSE_SCHEME).required(),
+    }).unknown(true).required(),
+    metadata: Joi.object({
+      configuration: Joi.object({
+        items: Joi.object({
+          nodes: Joi.array().items(Joi.object({}).unknown(true).required()).required(),
+        }).required(),
+      }).unknown(true).required(),
     }).unknown(true).required(),
   }).unknown(true).required(),
 }).unknown(true).required()

--- a/packages/jira-adapter/src/filters/layouts/layout_types.ts
+++ b/packages/jira-adapter/src/filters/layouts/layout_types.ts
@@ -106,7 +106,7 @@ export type IssueLayoutConfiguration = {
     configuration: {
       items: {
         nodes: {
-          fieldItemId?: string
+          fieldItemId: string
         }[]
       }
     }

--- a/packages/jira-adapter/src/filters/request_type.ts
+++ b/packages/jira-adapter/src/filters/request_type.ts
@@ -113,6 +113,7 @@ const deployRequestTypeLayout = async (
       data: {
         name: item.key.value.value.name,
         type: item.key.value.value.type ?? item.key.value.value.schema.system,
+        ...item.data,
       },
     }
   }).filter(isDefined)

--- a/packages/jira-adapter/test/filters/layouts/issue_layout.test.ts
+++ b/packages/jira-adapter/test/filters/layouts/issue_layout.test.ts
@@ -199,6 +199,20 @@ describe('issue layout filter', () => {
                     },
                   ],
                 },
+                metadata: {
+                  configuration: {
+                    items: {
+                      nodes: [
+                        {
+                          fieldItemId: 'testField1',
+                        },
+                        {
+                          fieldItemId: 'testField2',
+                        },
+                      ],
+                    },
+                  },
+                },
               },
             },
           }
@@ -309,6 +323,20 @@ describe('issue layout filter', () => {
                       },
                     },
                   ],
+                },
+                metadata: {
+                  configuration: {
+                    items: {
+                      nodes: [
+                        {
+                          fieldItemId: 'testField1',
+                        },
+                        {
+                          fieldItemId: 'testField2',
+                        },
+                      ],
+                    },
+                  },
                 },
               },
             },

--- a/packages/jira-adapter/test/filters/layouts/request_type_request_form.test.ts
+++ b/packages/jira-adapter/test/filters/layouts/request_type_request_form.test.ts
@@ -137,6 +137,22 @@ describe('requestTypeLayoutsFilter', () => {
                     },
                   ],
                 },
+                metadata: {
+                  configuration: {
+                    items: {
+                      nodes: [
+                        {
+                          fieldItemId: 'testField1',
+                          required: true,
+                        },
+                        {
+                          fieldItemId: 'testField2',
+                          required: false,
+                        },
+                      ],
+                    },
+                  },
+                },
               },
             },
           }
@@ -210,6 +226,22 @@ describe('requestTypeLayoutsFilter', () => {
                       },
                     },
                   ],
+                },
+                metadata: {
+                  configuration: {
+                    items: {
+                      nodes: [
+                        {
+                          fieldItemId: 'testField1',
+                          required: true,
+                        },
+                        {
+                          fieldItemId: 'testField2',
+                          required: false,
+                        },
+                      ],
+                    },
+                  },
                 },
               },
             },

--- a/packages/jira-adapter/test/filters/request_type.test.ts
+++ b/packages/jira-adapter/test/filters/request_type.test.ts
@@ -158,6 +158,20 @@ describe('requestType filter', () => {
                       },
                     ],
                   },
+                  metadata: {
+                    configuration: {
+                      items: {
+                        nodes: [
+                          {
+                            fieldItemId: 'testField1',
+                          },
+                          {
+                            fieldItemId: 'testField2',
+                          },
+                        ],
+                      },
+                    },
+                  },
                 },
               },
             }


### PR DESCRIPTION
In this PR I added the filter that retrieves the issueLayout, issueView and requestForm. 

---

_Additional context for reviewer_
1. Convex feedback told me that they need the metadata of each field. 
2. I added the metadata request part to the graphQL body. 
3. Most of the changes are in the query and in the tests and only little bit of change are core code changes. 

---
_Release Notes_: 
_JIra adapter:_
Now supporting metadata of fields in  issueLayout, issueView and requestForm. 

---
_User Notifications_: 
_Jira adapter:_
Under  issueLayout, issueView and requestForm, there will be more fields upon your next fetch. 
