### PR TITLE
SALTO-4963: Custom Approval Rule And Conditions using Salto ID Setting bugfix

### DIFF
--- a/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
+++ b/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
@@ -374,6 +374,7 @@ const deployAddInstances = async (
     // Building the object this way because order of keys is important
     const idFieldsValues = Object.fromEntries(
       idFieldsNames.map(fieldName => [fieldName, vals[fieldName]])
+        // Relevant for advanced deploy groups e.g. ADD_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP
         .map(([fieldName, value]) => [fieldName, isInstanceElement(value) ? apiNameSync(value) : value])
     )
     return toMD5(safeJsonStringify(idFieldsValues))

--- a/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
+++ b/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
@@ -374,6 +374,7 @@ const deployAddInstances = async (
     // Building the object this way because order of keys is important
     const idFieldsValues = Object.fromEntries(
       idFieldsNames.map(fieldName => [fieldName, vals[fieldName]])
+        .map(([fieldName, value]) => [fieldName, isInstanceElement(value) ? apiNameSync(value) : value])
     )
     return toMD5(safeJsonStringify(idFieldsValues))
   }

--- a/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
+++ b/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
@@ -24,7 +24,7 @@ import {
   SaltoElementError,
   SaltoError,
   SeverityLevel,
-  isInstanceElement, isInstanceChange, toChange,
+  isInstanceElement, isInstanceChange, toChange, isElement,
 } from '@salto-io/adapter-api'
 import { inspectValue, safeJsonStringify } from '@salto-io/adapter-utils'
 import { BatchResultInfo } from '@salto-io/jsforce-types'
@@ -41,7 +41,7 @@ import {
   SBAA_CONDITIONS_MET,
 } from './constants'
 import { getIdFields, transformRecordToValues } from './filters/custom_objects_instances'
-import { buildSelectQueries, getFieldNamesForQuery, isInstanceOfTypeChange } from './filters/utils'
+import { apiNameSync, buildSelectQueries, getFieldNamesForQuery, isInstanceOfTypeChange } from './filters/utils'
 import { isListCustomSettingsObject } from './filters/custom_settings_filter'
 import { SalesforceRecord } from './client/types'
 import { buildDataManagement } from './fetch_profile/data_management'
@@ -104,6 +104,22 @@ const groupInstancesAndResultsByIndex = (
 const escapeWhereStr = (str: string): string =>
   str.replace(/(\\)|(')/g, escaped => `\\${escaped}`)
 
+
+const getStringValueToEscape = (field: Field, value: Value): string => {
+  if (_.isString(value)) {
+    return value
+  }
+  // Relevant for advanced deploy groups e.g. ADD_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP
+  if (isElement(value)) {
+    const referencedElementApiName = apiNameSync(value)
+    if (!_.isString(referencedElementApiName)) {
+      throw new Error(`Expected referenced element to have apiName in field ${field.elemID.getFullName()}`)
+    }
+    return referencedElementApiName
+  }
+  throw new Error(`Expected value of field ${field.elemID.getFullName()} to be string. received ${safeJsonStringify(value)}`)
+}
+
 const formatValueForWhere = async (field: Field, value: Value): Promise<string> => {
   if (value === undefined) {
     return 'null'
@@ -111,7 +127,7 @@ const formatValueForWhere = async (field: Field, value: Value): Promise<string> 
   const fieldType = await field.getType()
   if (isPrimitiveType(fieldType)) {
     if (fieldType.primitive === PrimitiveTypes.STRING) {
-      return `'${escapeWhereStr(value)}'`
+      return `'${escapeWhereStr(getStringValueToEscape(field, value))}'`
     }
     return value.toString()
   }

--- a/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
@@ -15,24 +15,43 @@
 */
 import _ from 'lodash'
 import {
-  ElemID, InstanceElement, ObjectType, BuiltinTypes, DeployResult, ReferenceExpression,
-  isRemovalChange, getChangeData, isInstanceElement, ChangeGroup, isModificationChange,
-  isAdditionChange, CORE_ANNOTATIONS, PrimitiveType, PrimitiveTypes, Change, toChange,
+  BuiltinTypes,
+  Change,
+  ChangeGroup,
+  CORE_ANNOTATIONS,
+  DeployResult,
+  ElemID,
+  getChangeData,
+  InstanceElement,
+  isAdditionChange,
+  isInstanceElement,
+  isModificationChange,
+  isRemovalChange,
+  ObjectType,
+  PrimitiveType,
+  PrimitiveTypes,
+  ReferenceExpression,
+  toChange,
 } from '@salto-io/adapter-api'
 import { MockInterface } from '@salto-io/test-utils'
-import { BulkLoadOperation, BulkOptions, Record as SfRecord, Batch } from '@salto-io/jsforce'
+import { Batch, BulkLoadOperation, BulkOptions, Record as SfRecord } from '@salto-io/jsforce'
 import { EventEmitter } from 'events'
 import { Types } from '../src/transformers/transformer'
 import SalesforceAdapter from '../src/adapter'
 import * as constants from '../src/constants'
+import {
+  ADD_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP,
+  CUSTOM_OBJECT_ID_FIELD,
+  DefaultSoqlQueryLimits,
+  FIELD_ANNOTATIONS,
+  OWNER_ID,
+  SBAA_APPROVAL_CONDITION,
+  SBAA_APPROVAL_RULE,
+  SBAA_CONDITIONS_MET,
+} from '../src/constants'
 import Connection from '../src/client/jsforce'
 import mockAdapter from './adapter'
 import { createCustomObjectType } from './utils'
-import {
-  ADD_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP, CUSTOM_OBJECT_ID_FIELD,
-  FIELD_ANNOTATIONS, OWNER_ID, SBAA_APPROVAL_CONDITION,
-  SBAA_APPROVAL_RULE, SBAA_CONDITIONS_MET, DefaultSoqlQueryLimits,
-} from '../src/constants'
 import { mockTypes } from './mock_elements'
 
 describe('Custom Object Instances CRUD', () => {
@@ -42,6 +61,8 @@ describe('Custom Object Instances CRUD', () => {
   const mockElemID = new ElemID(constants.SALESFORCE, 'Test')
   const instanceName = 'Instance'
   const anotherInstanceName = 'AnotherInstance'
+  const accountLookupField = 'AccountLookup__c'
+  const accountLookupRecordId = 'accountLookupId'
 
   const customObject = new ObjectType({
     elemID: mockElemID,
@@ -127,6 +148,15 @@ describe('Custom Object Instances CRUD', () => {
           [constants.API_NAME]: 'Name',
         },
       },
+      [accountLookupField]: {
+        refType: Types.primitiveDataTypes.Lookup,
+        annotations: {
+          [constants.FIELD_ANNOTATIONS.CREATABLE]: true,
+          [constants.FIELD_ANNOTATIONS.UPDATEABLE]: true,
+          [constants.FIELD_ANNOTATIONS.QUERYABLE]: true,
+          [constants.API_NAME]: accountLookupField,
+        },
+      },
     },
     annotationRefsOrTypes: {},
     annotations: {
@@ -134,6 +164,14 @@ describe('Custom Object Instances CRUD', () => {
       [constants.API_NAME]: 'Type',
     },
   })
+  const accountLookupInstance = new InstanceElement(
+    'accountLookupInstance',
+    mockTypes.Account,
+    {
+      Name: 'Test Account',
+      [CUSTOM_OBJECT_ID_FIELD]: accountLookupRecordId,
+    }
+  )
   const existingInstance = new InstanceElement(
     instanceName,
     customObject,
@@ -150,6 +188,7 @@ describe('Custom Object Instances CRUD', () => {
         LastName: 'last',
         Salutation: 'mrs.',
       },
+      [accountLookupField]: new ReferenceExpression(accountLookupInstance.elemID, accountLookupInstance),
     }
   )
   const existingInstanceRecordValues = {
@@ -165,6 +204,7 @@ describe('Custom Object Instances CRUD', () => {
       country: 'Israel',
       postalCode: null,
     },
+    [accountLookupField]: accountLookupRecordId,
     FirstName: 'first',
     LastName: 'last',
     Salutation: 'mrs.',
@@ -253,7 +293,7 @@ describe('Custom Object Instances CRUD', () => {
               data: {
                 includeObjects: ['Test'],
                 saltoIDSettings: {
-                  defaultIdFields: ['SaltoName', 'NumField', 'Address', 'Name'],
+                  defaultIdFields: ['SaltoName', 'NumField', 'Address', 'Name', accountLookupField],
                   overrides: [
                     { objectsRegex: 'TestType__c', idFields: ['Name'] },
                     { objectsRegex: 'sbaa__ApprovalRule__c|sbaa__ApprovalCondition__c', idFields: ['Id'] },
@@ -454,7 +494,7 @@ describe('Custom Object Instances CRUD', () => {
 
           it('Should query according to instance values', () => {
             expect(mockQuery.mock.calls).toHaveLength(1)
-            expect(mockQuery.mock.calls[0][0]).toEqual('SELECT Id,OwnerId,SaltoName,NumField,Address,FirstName,LastName,Salutation,MiddleName,Suffix FROM Type WHERE SaltoName IN (\'existingInstance\',\'newInstanceWithRef\') AND NumField IN (1,2) AND City IN (\'Tel-Aviv\',null) AND Country IN (\'Israel\',null) AND GeocodeAccuracy IN (null) AND Latitude IN (null) AND Longitude IN (null) AND PostalCode IN (null) AND State IN (null) AND Street IN (null) AND FirstName IN (\'first\',null) AND LastName IN (\'last\',null) AND Salutation IN (\'mrs.\',null) AND MiddleName IN (null) AND Suffix IN (null)')
+            expect(mockQuery.mock.calls[0][0]).toEqual('SELECT Id,OwnerId,SaltoName,NumField,Address,FirstName,LastName,Salutation,MiddleName,Suffix,AccountLookup__c FROM Type WHERE SaltoName IN (\'existingInstance\',\'newInstanceWithRef\') AND NumField IN (1,2) AND City IN (\'Tel-Aviv\',null) AND Country IN (\'Israel\',null) AND GeocodeAccuracy IN (null) AND Latitude IN (null) AND Longitude IN (null) AND PostalCode IN (null) AND State IN (null) AND Street IN (null) AND FirstName IN (\'first\',null) AND LastName IN (\'last\',null) AND Salutation IN (\'mrs.\',null) AND MiddleName IN (null) AND Suffix IN (null) AND AccountLookup__c IN (\'accountLookupId\',null)')
           })
 
           it('Should call load operation twice - once with insert once with update', () => {
@@ -552,7 +592,7 @@ describe('Custom Object Instances CRUD', () => {
 
             it('Should query according to instance values', () => {
               expect(mockQuery.mock.calls).toHaveLength(1)
-              expect(mockQuery.mock.calls[0][0]).toEqual('SELECT Id,OwnerId,SaltoName,NumField,Address,FirstName,LastName,Salutation,MiddleName,Suffix FROM Type WHERE SaltoName IN (\'newInstanceWithRef\',\'anotherNewInstance\') AND NumField IN (2,3) AND City IN (null,\'Ashkelon\') AND Country IN (null,\'Israel\') AND GeocodeAccuracy IN (null) AND Latitude IN (null) AND Longitude IN (null) AND PostalCode IN (null) AND State IN (null) AND Street IN (null) AND FirstName IN (null) AND LastName IN (null) AND Salutation IN (null) AND MiddleName IN (null) AND Suffix IN (null)')
+              expect(mockQuery.mock.calls[0][0]).toEqual('SELECT Id,OwnerId,SaltoName,NumField,Address,FirstName,LastName,Salutation,MiddleName,Suffix,AccountLookup__c FROM Type WHERE SaltoName IN (\'newInstanceWithRef\',\'anotherNewInstance\') AND NumField IN (2,3) AND City IN (null,\'Ashkelon\') AND Country IN (null,\'Israel\') AND GeocodeAccuracy IN (null) AND Latitude IN (null) AND Longitude IN (null) AND PostalCode IN (null) AND State IN (null) AND Street IN (null) AND FirstName IN (null) AND LastName IN (null) AND Salutation IN (null) AND MiddleName IN (null) AND Suffix IN (null) AND AccountLookup__c IN (null)')
             })
 
             it('Should call load operation once with insert', () => {
@@ -703,7 +743,7 @@ describe('Custom Object Instances CRUD', () => {
 
           it('Should query according to instance values', () => {
             expect(mockQuery.mock.calls).toHaveLength(1)
-            expect(mockQuery.mock.calls[0][0]).toEqual('SELECT Id,OwnerId,SaltoName,NumField,Address,FirstName,LastName,Salutation,MiddleName,Suffix FROM Type WHERE SaltoName IN (\'existingInstance\',\'anotherExistingInstanceWithThing\\\'\') AND NumField IN (1,null) AND City IN (\'Tel-Aviv\',null) AND Country IN (\'Israel\',null) AND GeocodeAccuracy IN (null) AND Latitude IN (null) AND Longitude IN (null) AND PostalCode IN (null) AND State IN (null) AND Street IN (null) AND FirstName IN (\'first\',null) AND LastName IN (\'last\',null) AND Salutation IN (\'mrs.\',null) AND MiddleName IN (null) AND Suffix IN (null)')
+            expect(mockQuery.mock.calls[0][0]).toEqual('SELECT Id,OwnerId,SaltoName,NumField,Address,FirstName,LastName,Salutation,MiddleName,Suffix,AccountLookup__c FROM Type WHERE SaltoName IN (\'existingInstance\',\'anotherExistingInstanceWithThing\\\'\') AND NumField IN (1,null) AND City IN (\'Tel-Aviv\',null) AND Country IN (\'Israel\',null) AND GeocodeAccuracy IN (null) AND Latitude IN (null) AND Longitude IN (null) AND PostalCode IN (null) AND State IN (null) AND Street IN (null) AND FirstName IN (\'first\',null) AND LastName IN (\'last\',null) AND Salutation IN (\'mrs.\',null) AND MiddleName IN (null) AND Suffix IN (null) AND AccountLookup__c IN (\'accountLookupId\',null)')
           })
 
           it('Should call load operation once with update', () => {
@@ -818,7 +858,7 @@ describe('Custom Object Instances CRUD', () => {
         })
         it('Should query according to instance values', () => {
           expect(mockQuery.mock.calls).toHaveLength(1)
-          expect(mockQuery.mock.calls[0][0]).toEqual('SELECT Id,OwnerId,SaltoName,NumField,Address,FirstName,LastName,Salutation,MiddleName,Suffix FROM Type WHERE SaltoName IN (\'existingInstance\',\'newInstanceWithRef\',\'anotherExistingInstanceWithThing\\\'\',\'anotherNewInstance\') AND NumField IN (1,2,null,3) AND City IN (\'Tel-Aviv\',null,\'Ashkelon\') AND Country IN (\'Israel\',null) AND GeocodeAccuracy IN (null) AND Latitude IN (null) AND Longitude IN (null) AND PostalCode IN (null) AND State IN (null) AND Street IN (null) AND FirstName IN (\'first\',null) AND LastName IN (\'last\',null) AND Salutation IN (\'mrs.\',null) AND MiddleName IN (null) AND Suffix IN (null)')
+          expect(mockQuery.mock.calls[0][0]).toEqual('SELECT Id,OwnerId,SaltoName,NumField,Address,FirstName,LastName,Salutation,MiddleName,Suffix,AccountLookup__c FROM Type WHERE SaltoName IN (\'existingInstance\',\'newInstanceWithRef\',\'anotherExistingInstanceWithThing\\\'\',\'anotherNewInstance\') AND NumField IN (1,2,null,3) AND City IN (\'Tel-Aviv\',null,\'Ashkelon\') AND Country IN (\'Israel\',null) AND GeocodeAccuracy IN (null) AND Latitude IN (null) AND Longitude IN (null) AND PostalCode IN (null) AND State IN (null) AND Street IN (null) AND FirstName IN (\'first\',null) AND LastName IN (\'last\',null) AND Salutation IN (\'mrs.\',null) AND MiddleName IN (null) AND Suffix IN (null) AND AccountLookup__c IN (\'accountLookupId\',null)')
         })
 
         it('Should call load operation both with update and with insert', () => {

--- a/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
@@ -256,7 +256,8 @@ describe('Custom Object Instances CRUD', () => {
                   defaultIdFields: ['SaltoName', 'NumField', 'Address', 'Name'],
                   overrides: [
                     { objectsRegex: 'TestType__c', idFields: ['Name'] },
-                    { objectsRegex: 'sbaa__ApprovalRule__c|sbaa__ApprovalCondition__c', idFields: ['Id'] },
+                    { objectsRegex: 'sbaa__ApprovalRule__c', idFields: ['Id'] },
+                    { objectsRegex: 'sbaa__ApprovalCondition__c', idFields: ['sbaa__ApprovalRule__c'] },
                   ],
                 },
               },

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -344,7 +344,7 @@ export const mockTypes = {
   ApprovalCondition: createCustomObjectType(SBAA_APPROVAL_CONDITION, {
     fields: {
       [SBAA_APPROVAL_RULE]: {
-        refType: SBAA_APPROVAL_RULE_TYPE,
+        refType: Types.primitiveDataTypes.Lookup,
         annotations: {
           [FIELD_ANNOTATIONS.QUERYABLE]: true,
           [FIELD_ANNOTATIONS.CREATABLE]: true,


### PR DESCRIPTION
Fixed an edge-case where the deploy of group `add_Custom_ApprovalRule_and_ApprovalCondition_instances` fails when the **salto Id fields** of **Approval Conditions** contain **Approval Rule**

---
_Release Notes_: 
Salesforce Adapter:
- Add deploy support in **CPQ Custom Approval Rule and Conditions** for accounts that use the old **Salto ID Settings** (non Id based).


---

_User Notifications_: 
_None_
