### PR TITLE
SALTO-5086: remove old state migration code

### DIFF
--- a/packages/cli/test/commands/deploy.test.ts
+++ b/packages/cli/test/commands/deploy.test.ts
@@ -329,19 +329,11 @@ describe('deploy command', () => {
         { key: 'version', value: saltoVersion },
       ] as {key: state.StateMetadataKey; value: string}[] : []
       const saltoMetadata = new InMemoryRemoteMap<string, state.StateMetadataKey>(metaData)
-      let dateMap: remoteMap.RemoteMap<Date> | undefined
-      // This if statement is temporary for the transition to multiple services.
-      // Remove this when no longer used, SALTO-1661
-      if ('servicesUpdateDate' in data) {
-        dateMap = data.servicesUpdateDate
-      } else if ('accountsUpdateDate' in data) {
-        dateMap = data.accountsUpdateDate
-      }
       return state.buildInMemState(async () => ({
         elements: createInMemoryElementSource(),
         pathIndex: new InMemoryRemoteMap<pathIndex.Path[]>(),
         topLevelPathIndex: new InMemoryRemoteMap<pathIndex.Path[]>(),
-        accountsUpdateDate: dateMap ?? new InMemoryRemoteMap(),
+        accountsUpdateDate: data.accountsUpdateDate ?? new InMemoryRemoteMap(),
         saltoMetadata,
         staticFilesSource: mocks.mockStateStaticFilesSource(),
       }))

--- a/packages/core/src/local-workspace/state.ts
+++ b/packages/core/src/local-workspace/state.ts
@@ -160,10 +160,6 @@ export const localState = (
     await stateData.saltoMetadata.set('hash', newHash)
   }
 
-  const getRelevantStateFiles = async (): Promise<string[]> => (
-    glob(filePathGlob(currentFilePrefix))
-  )
-
   const getHashFromContent = (contents: string[]): string =>
     toMD5(safeJsonStringify(contents.map(toMD5).sort()))
 
@@ -178,7 +174,7 @@ export const localState = (
       staticFilesSource,
       persistent,
     )
-    const filePaths = await getRelevantStateFiles()
+    const filePaths = await findStateFiles(currentFilePrefix)
     const stateFilesHash = await getHash(filePaths)
     const quickAccessHash = (await quickAccessStateData.saltoMetadata.get('hash'))
       ?? toMD5(safeJsonStringify([]))

--- a/packages/core/src/local-workspace/state.ts
+++ b/packages/core/src/local-workspace/state.ts
@@ -24,7 +24,7 @@ import { parser } from 'stream-json/jsonl/Parser'
 import getStream from 'get-stream'
 import { DetailedChange, Element, ElemID } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
-import { exists, readTextFile, mkdirp, rm, rename, replaceContents, createGZipWriteStream, isOldFormatStateZipFile, readOldFormatGZipFile, createGZipReadStream } from '@salto-io/file'
+import { exists, readTextFile, mkdirp, rm, rename, replaceContents, createGZipWriteStream, createGZipReadStream } from '@salto-io/file'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { serialization, pathIndex, state, remoteMap, staticFiles } from '@salto-io/workspace'
 import { hash, collections, promises, values as lowerdashValues } from '@salto-io/lowerdash'
@@ -42,27 +42,15 @@ const glob = promisify(origGlob)
 
 const log = logger(module)
 
-export const STATE_EXTENSION = '.jsonl'
 export const ZIPPED_STATE_EXTENSION = '.jsonl.zip'
 
 export const filePathGlob = (currentFilePrefix: string): string => (
   `${currentFilePrefix}.*([!.])${ZIPPED_STATE_EXTENSION}`
 )
 
-// This function is temporary for the transition to multiple services.
-// Remove this when no longer used, SALTO-1661
-const getUpdateDate = (data: state.StateData): remoteMap.RemoteMap<Date> => {
-  if ('servicesUpdateDate' in data) {
-    return data.servicesUpdateDate
-  }
-  return data.accountsUpdateDate
-}
-
-const findStateFiles = async (currentFilePrefix: string): Promise<string[]> => {
-  const stateFiles = await glob(filePathGlob(currentFilePrefix))
-  const oldStateFiles = await glob(`${currentFilePrefix}@(${ZIPPED_STATE_EXTENSION}|${STATE_EXTENSION})`)
-  return [...stateFiles, ...oldStateFiles]
-}
+const findStateFiles = async (currentFilePrefix: string): Promise<string[]> => (
+  glob(filePathGlob(currentFilePrefix))
+)
 
 // a single entry in the path index, [elemid, filepath[] ] - based on the types defined in workspace/path_index.ts
 type PathEntry = [string, string[][]]
@@ -83,30 +71,10 @@ const parseFromPaths = async (
     versions: [],
   }
 
-  // backward-compatible function for reading the state file (changed in SALTO-3149)
-  const createBackwardCompatibleGZipReadStream = async (
-    zipFilename: string,
-  ): Promise<Readable> => {
-    if (await isOldFormatStateZipFile(zipFilename)) {
-      // old state file compressed with UTF encoding, with an incorrectly-serialized version row
-      const data = await readOldFormatGZipFile(zipFilename) ?? ''
-      // hack to fix non-jsonl format in old state file
-      // (the last line which contains the version was missing quotes, e.g. 0.1.2 instead of "0.1.2")
-      const dataWithNewlines = (EOL !== '\n'
-        ? data.replace(EOL, '\n')
-        : data)
-      const lines = dataWithNewlines.split('\n')
-      const updatedData = [...lines.slice(0, 3), `"${lines[3]}"`].join(EOL)
-
-      return Readable.from(updatedData)
-    }
-    return createGZipReadStream(zipFilename)
-  }
-
   const streams = (await Promise.all(
     paths.map(async (p: string) => (
       await exists(p)
-        ? { filePath: p, stream: await createBackwardCompatibleGZipReadStream(p) }
+        ? { filePath: p, stream: createGZipReadStream(p) }
         : undefined
     ))
   )).filter(isDefined)
@@ -152,7 +120,6 @@ export const localState = (
   let dirty = false
   let cacheDirty = false
   let contentsAndHash: ContentsAndHash | undefined
-  let pathToClean = ''
   let currentFilePrefix = filePrefix
 
   const setDirty = (): void => {
@@ -179,7 +146,7 @@ export const localState = (
         .reduce((entry1, entry2) => Object.assign(entry1, entry2), {}) as Record<string, string>,
       dateStr => new Date(dateStr)
     )
-    const stateUpdateDate = getUpdateDate(stateData)
+    const stateUpdateDate = stateData.accountsUpdateDate
     if (stateUpdateDate !== undefined) {
       await stateUpdateDate.clear()
       await stateUpdateDate.setAll(awu(
@@ -193,18 +160,9 @@ export const localState = (
     await stateData.saltoMetadata.set('hash', newHash)
   }
 
-  const getRelevantStateFiles = async (): Promise<string[]> => {
-    const currentFilePaths = await glob(filePathGlob(currentFilePrefix))
-    if (currentFilePaths.length > 0) {
-      return currentFilePaths
-    }
-    const oldStateFilePath = `${filePrefix}${ZIPPED_STATE_EXTENSION}`
-    if (await exists(oldStateFilePath)) {
-      pathToClean = oldStateFilePath
-      return [oldStateFilePath]
-    }
-    return []
-  }
+  const getRelevantStateFiles = async (): Promise<string[]> => (
+    glob(filePathGlob(currentFilePrefix))
+  )
 
   const getHashFromContent = (contents: string[]): string =>
     toMD5(safeJsonStringify(contents.map(toMD5).sort()))
@@ -324,7 +282,7 @@ export const localState = (
       setDirty()
     },
     flush: async (): Promise<void> => {
-      if (!dirty && pathToClean === '') {
+      if (!dirty) {
         if (cacheDirty) {
           await inMemState.flush()
           cacheDirty = false
@@ -332,9 +290,6 @@ export const localState = (
         return
       }
       await mkdirp(path.dirname(currentFilePrefix))
-      if (pathToClean !== '') {
-        await rm(pathToClean)
-      }
       const { contents: filePathToContent, hash: updatedHash } = await getContentAndHash()
       await awu(filePathToContent).forEach(f => replaceContents(...f))
       await inMemState.setVersion(version)

--- a/packages/file/package.json
+++ b/packages/file/package.json
@@ -31,16 +31,13 @@
   "dependencies": {
     "@salto-io/logging": "0.3.49",
     "@salto-io/lowerdash": "0.3.49",
-    "get-stream": "^6.0.1",
     "mkdirp": "^0.5.1",
-    "pako": "^1.0.11",
     "rimraf": "^3.0.0",
     "stream-chain": "^2.2.5"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/mkdirp": "^0.5.2",
-    "@types/pako": "^1.0.1",
     "@types/rimraf": "^2.0.3",
     "@types/stream-chain": "^2.0.1",
     "@typescript-eslint/eslint-plugin": "4.22.1",
@@ -53,6 +50,7 @@
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-react": "^7.14.3",
     "eslint-plugin-react-hooks": "^1.7.0",
+    "get-stream": "^6.0.1",
     "jest": "^27.4.5",
     "jest-circus": "^27.4.5",
     "jest-junit": "^12.0.0",

--- a/packages/file/src/gzip.ts
+++ b/packages/file/src/gzip.ts
@@ -14,15 +14,9 @@
 * limitations under the License.
 */
 import fs from 'fs'
-import pako from 'pako'
 import { Readable } from 'stream'
 import { createGunzip, createGzip } from 'zlib'
 import { chain } from 'stream-chain'
-import getStream from 'get-stream'
-import { logger } from '@salto-io/logging'
-import { readFile } from './file'
-
-const log = logger(module)
 
 export const createGZipReadStream = (
   zipFilename: string,
@@ -37,30 +31,3 @@ export const createGZipWriteStream = (
   contents,
   createGzip(),
 ])
-
-
-//
-// the rest of this file contains backward-compatibility with old state file -
-// should be removed once all workspaces have been upgraded (see SALTO-3149)
-//
-
-export const isOldFormatStateZipFile = async (zipFilename: string): Promise<boolean> => {
-  const prefix = await getStream.buffer(fs.createReadStream(zipFilename, {
-    start: 0,
-    end: 2,
-  }))
-  // standard gzip compression starts with \x1f\x8b , the old state file added \xc2
-  return prefix.compare(Buffer.from([0x1f, 0xc2, 0x8b])) === 0
-}
-
-export const readOldFormatGZipFile = async (
-  zipFilename: string,
-): Promise<string | undefined> => {
-  const data = await readFile(zipFilename, { encoding: 'utf8' })
-  try {
-    return pako.ungzip(data, { to: 'string' })
-  } catch (e) {
-    log.error(`Couldn't unzip file: ${zipFilename}: ${e}`)
-    return undefined
-  }
-}

--- a/packages/file/test/gzip.test.ts
+++ b/packages/file/test/gzip.test.ts
@@ -15,7 +15,6 @@
 */
 import fs from 'fs'
 import tmp from 'tmp-promise'
-import pako from 'pako'
 import { gzip as zlibGzip } from 'zlib'
 import { promisify } from 'util'
 import { Readable } from 'stream'
@@ -95,121 +94,6 @@ describe('gzip', () => {
 
       it('should throw error', async () => {
         await expectRejectWithIncorrectHeaderException(() => getStream(gzip.createGZipReadStream(dest)))
-      })
-    })
-  })
-
-  describe('isOldFormatStateZipFile', () => {
-    const source = __filename
-    let destTmp: tmp.FileResult
-    let dest: string
-
-    describe('when the file does not exist', () => {
-      it('should reject with ErrnoException', async () => {
-        await expectRejectWithErrnoException(() => gzip.isOldFormatStateZipFile('nosuchfile'))
-      })
-    })
-
-    describe('when reading a valid old-format gzip', () => {
-      const content = 'hello world'
-      beforeEach(async () => {
-        destTmp = await tmp.file()
-        dest = destTmp.path
-        // generate in the old way using pako
-        await file.writeFile(dest, pako.gzip(content, { to: 'string' }))
-      })
-
-      afterEach(async () => {
-        await destTmp.cleanup()
-      })
-
-      it('should return true', async () => {
-        expect(await file.exists(dest)).toBeTruthy()
-        expect(await gzip.isOldFormatStateZipFile(dest)).toEqual(true)
-      })
-    })
-
-    describe('when reading a valid new-format gzip', () => {
-      const content = 'hello world'
-      beforeEach(async () => {
-        destTmp = await tmp.file()
-        dest = destTmp.path
-        await file.writeFile(dest, await getStream(gzip.createGZipWriteStream(Readable.from(content))))
-      })
-
-      afterEach(async () => {
-        await destTmp.cleanup()
-      })
-
-      it('should return false', async () => {
-        expect(await file.exists(dest)).toBeTruthy()
-        expect(await gzip.isOldFormatStateZipFile(dest)).toEqual(false)
-      })
-    })
-
-    describe('when the file exists, but is not a zip file', () => {
-      beforeEach(async () => {
-        destTmp = await tmp.file()
-        dest = destTmp.path
-        await file.copyFile(source, dest)
-      })
-
-      afterEach(async () => {
-        await destTmp.cleanup()
-      })
-
-      it('should return false', async () => {
-        expect(await gzip.isOldFormatStateZipFile(dest)).toEqual(false)
-      })
-    })
-  })
-
-  describe('readOldFormatGZipFile', () => {
-    const source = __filename
-    let destTmp: tmp.FileResult
-    let dest: string
-
-    describe('when the file does not exist', () => {
-      it('should reject with ErrnoException', async () => {
-        await expectRejectWithErrnoException(() => gzip.readOldFormatGZipFile('nosuchfile'))
-      })
-    })
-
-    describe('when the zip file exists', () => {
-      const content = 'hello world'
-      beforeEach(async () => {
-        destTmp = await tmp.file()
-        dest = destTmp.path
-        // generate in the old way using pako
-        await file.writeFile(dest, pako.gzip(content, { to: 'string' }))
-      })
-
-      afterEach(async () => {
-        await destTmp.cleanup()
-      })
-
-      describe('when all is well with the file', () => {
-        it('should return its contents', async () => {
-          expect(await file.exists(dest)).toBeTruthy()
-          const r = await gzip.readOldFormatGZipFile(dest)
-          expect(content).toEqual(r)
-        })
-      })
-    })
-
-    describe('when the file exists, but is not a zip file', () => {
-      beforeEach(async () => {
-        destTmp = await tmp.file()
-        dest = destTmp.path
-        await file.copyFile(source, dest)
-      })
-
-      afterEach(async () => {
-        await destTmp.cleanup()
-      })
-
-      it('should throw error', async () => {
-        expect(await gzip.readOldFormatGZipFile(dest)).toBeUndefined()
       })
     })
   })

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -34,7 +34,6 @@
     "@salto-io/logging": "0.3.49",
     "@salto-io/lowerdash": "0.3.49",
     "async-lock": "^1.2.4",
-    "get-stream": "^6.0.1",
     "is-promise": "4.0.0",
     "lodash": "^4.17.21",
     "moo": "^0.5.1",

--- a/packages/workspace/src/workspace/state/state.ts
+++ b/packages/workspace/src/workspace/state/state.ts
@@ -29,9 +29,7 @@ export type UpdateStateElementsArgs = {
   fetchAccounts?: string[]
 }
 
-// This distinction is temporary for the transition to multiple services.
-// Remove this when no longer used, SALTO-1661
-type OldStateData = {
+export type StateData = {
   elements: RemoteElementSource
   // The date of the last fetch
   accountsUpdateDate: RemoteMap<Date>
@@ -41,28 +39,10 @@ type OldStateData = {
   topLevelPathIndex: PathIndex
 }
 
-// This distinction is temporary for the transition to multiple services.
-// Remove this when no longer used, SALTO-1661
-type NewStateData = {
-  elements: RemoteElementSource
-  // The date of the last fetch
-  servicesUpdateDate: RemoteMap<Date>
-  pathIndex: PathIndex
-  saltoMetadata: RemoteMap<string, StateMetadataKey>
-  staticFilesSource: StateStaticFilesSource
-  topLevelPathIndex: PathIndex
-}
-
-export type StateData = OldStateData | NewStateData
-
 export interface State extends ElementsSource {
   set(element: Element): Promise<void>
   remove(id: ElemID): Promise<void>
   getAccountsUpdateDates(): Promise<Record<string, Date>>
-  // getServicesUpdateDates is deprecated, kept for backwards compatibility.
-  // use getAccountsUpdateDates.
-  // Remove this when no longer used, SALTO-1661
-  getServicesUpdateDates(): Promise<Record<string, Date>>
   existingAccounts(): Promise<string[]>
   getPathIndex(): Promise<PathIndex>
   getTopLevelPathIndex(): Promise<PathIndex>

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -2007,12 +2007,17 @@ describe('workspace', () => {
   describe('getStateRecency', () => {
     let now: number
     let modificationDate: Date
+    let mockDateNow: jest.SpiedFunction<typeof Date.now>
     const durationAfterLastModificationMinutes = 7
     const durationAfterLastModificationMs = 1000 * 60 * durationAfterLastModificationMinutes
     beforeEach(async () => {
       now = Date.now()
-      jest.spyOn(Date, 'now').mockImplementation(() => now)
+      mockDateNow = jest.spyOn(Date, 'now')
+      mockDateNow.mockImplementation(() => now)
       modificationDate = new Date(now - durationAfterLastModificationMs)
+    })
+    afterEach(() => {
+      mockDateNow.mockRestore()
     })
     it('should return valid when the state is valid', async () => {
       const ws = await createWorkspace(undefined, undefined, mockWorkspaceConfigSource(
@@ -2964,10 +2969,13 @@ describe('workspace', () => {
   describe('accountConfig', () => {
     let workspace: Workspace
     let adaptersConfig: MockInterface<AdaptersConfigSource>
+    let resolveMock: jest.SpiedFunction<typeof resolve>
     const configElemId = new ElemID('dummy', 'new')
     const configObjectType = new ObjectType({ elemID: configElemId })
     const configInstanceElement = new InstanceElement('aaa', configObjectType)
-    const resolveMock = jest.spyOn(expressionsModule, 'resolve')
+    beforeAll(() => {
+      resolveMock = jest.spyOn(expressionsModule, 'resolve')
+    })
     beforeEach(async () => {
       resolveMock.mockClear()
       adaptersConfig = mockAdaptersConfigSource()


### PR DESCRIPTION
Cleaning up the code before working on new features in the area

This also contains a couple of unit test fixes in other packages


---

_Additional context for reviewer_

---
_Release Notes_: 
Core:
- Removed code that would migrate very old state files to the "new" format - this would only affect workspaces that were not used for over 10 months

---
_User Notifications_: 
_None_
