### PR TITLE
SALTO-4726 Move custom object field fallback to FixElements

### DIFF
--- a/packages/zendesk-adapter/src/filters/custom_objects/custom_object_fields.ts
+++ b/packages/zendesk-adapter/src/filters/custom_objects/custom_object_fields.ts
@@ -40,7 +40,7 @@ import {
   TRIGGER_TYPE_NAME,
   ZENDESK,
 } from '../../constants'
-import { DEPLOY_CONFIG, FETCH_CONFIG } from '../../config'
+import { FETCH_CONFIG } from '../../config'
 import {
   LOOKUP_REGEX,
   RELATIONSHIP_FILTER_REGEX,
@@ -48,7 +48,7 @@ import {
   transformRelationshipFilterField,
 } from './utils'
 import { paginate } from '../../client/pagination'
-import { getIdByEmail, getUserFallbackValue, getUsers } from '../../user_utils'
+import { getIdByEmail, getUsers } from '../../user_utils'
 
 const { makeArray } = collections.array
 const { createMissingInstance } = referencesUtils
@@ -393,27 +393,6 @@ const customObjectFieldsFilter: FilterCreator = ({ config, client }) => {
           missingUserConditions.push(condition)
         }
       })
-
-      const { defaultMissingUserFallback } = config[DEPLOY_CONFIG] ?? {}
-      if (missingUserConditions.length === 0 || defaultMissingUserFallback === undefined) {
-        return
-      }
-      const userEmails = new Set(users.map(user => user.email))
-      const fallbackValue = await getUserFallbackValue(
-        defaultMissingUserFallback,
-        userEmails,
-        client
-      )
-      if (fallbackValue !== undefined && usersByEmail[fallbackValue] !== undefined) {
-        const fallbackUserId = usersByEmail[fallbackValue].id.toString()
-        userPathToOriginalValue[fallbackUserId] = fallbackValue
-        // We do not need to revert the fallback value in onDeploy because we change the value in the service
-        missingUserConditions.forEach(condition => {
-          condition.value = fallbackUserId
-        })
-      } else {
-        log.error('Error while trying to get defaultMissingUserFallback value in customObjectFieldsFilter')
-      }
     },
     onDeploy: async changes => {
       getUserConditions(changes).forEach(condition => {

--- a/packages/zendesk-adapter/test/filters/custom_objects/custom_object_fields.test.ts
+++ b/packages/zendesk-adapter/test/filters/custom_objects/custom_object_fields.test.ts
@@ -365,23 +365,6 @@ describe('customObjectFieldsFilter', () => {
       expect(trigger.value.conditions.all[1].value).toBe(USER.email)
       expect(trigger.value.conditions.any[0].value).toBe(USER.id.toString())
     })
-    it('should use fallback user if configurated', async () => {
-      const config = _.cloneDeep(DEFAULT_CONFIG)
-      config[DEPLOY_CONFIG] = { defaultMissingUserFallback: DEFAULT_USER.email }
-      const useFallbackFilter = filterCreator(createFilterCreatorParams({ config })) as FilterType
-      const trigger = createTrigger({
-        conditions: {
-          all: [{
-            field: `lookup:ticket.ticket_field_${ticketField.value.id}.custom_fields.${customObjectField.value.key}`,
-            operator: 'is',
-            value: 'non',
-            is_user_value: true,
-          }],
-        },
-      })
-      await useFallbackFilter.preDeploy([toChange({ after: trigger })])
-      expect(trigger.value.conditions.all[0].value).toBe(DEFAULT_USER.id.toString())
-    })
   })
   describe('onDeploy', () => {
     it('should revert the userIds to user names', async () => {
@@ -396,18 +379,11 @@ describe('customObjectFieldsFilter', () => {
             value: USER.email,
             is_user_value: true,
           }],
-          any: [{
-            field: `lookup:ticket.ticket_field_${ticketField.value.id}.custom_fields.${customObjectField.value.key}`,
-            operator: 'is',
-            value: 'non',
-            is_user_value: true,
-          }],
         },
       })
       await useFallbackFilter.preDeploy([toChange({ after: trigger })])
       await useFallbackFilter.onDeploy([toChange({ after: trigger })])
       expect(trigger.value.conditions.all[0].value).toBe(USER.email)
-      expect(trigger.value.conditions.any[0].value).toBe(DEFAULT_USER.email)
     })
   })
 })


### PR DESCRIPTION
Move custom object field fallback to FixElements

---

_Additional context for reviewer_

---
_Release Notes_: 
__Zendesk Adapter__
* Move the replacement of fallback user emails also for custom object fields to happen before the deploy in order to reduce incorrect user errors (partial successes).

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
