### PR TITLE
SALTO-5092: Fix bug in reference update for renamed instances in referencedInstanceNames filter

### DIFF
--- a/packages/adapter-components/src/filters/referenced_instance_names.ts
+++ b/packages/adapter-components/src/filters/referenced_instance_names.ts
@@ -33,7 +33,7 @@ const { awu } = collections.asynciterable
 
 const log = logger(module)
 const { isDefined } = lowerDashValues
-const { getUpdatedReference, createReferencesTransformFunc } = references
+const { createReferencesTransformFunc } = references
 
 type TransformationIdConfig = {
   idFields: string[]
@@ -206,12 +206,12 @@ const updateAllReferences = ({
   referenceIndex,
   instanceOriginalName,
   nameToInstance,
-  newElemId,
+  newInstance,
 }:{
   referenceIndex: Record<string, { path: ElemID; value: ReferenceExpression }[]>
   instanceOriginalName: string
-  nameToInstance: Record<string, Element>
-  newElemId: ElemID
+  nameToInstance: Record<string, InstanceElement>
+  newInstance: InstanceElement
 }): void => {
   const referencesToChange = referenceIndex[instanceOriginalName]
   if (referencesToChange === undefined || referencesToChange.length === 0) {
@@ -224,7 +224,11 @@ const updateAllReferences = ({
       if (!updatedReferenceMap.has(referenceValueFullName)) {
         updatedReferenceMap.set(
           referenceValueFullName,
-          getUpdatedReference(ref.value, newElemId)
+          new ReferenceExpression(
+            // reference might not be to the top level instance
+            newInstance.elemID.createNestedID(...ref.value.elemID.createTopLevelParentID().path),
+            newInstance,
+          )
         )
       }
       const updatedReference = updatedReferenceMap.get(referenceValueFullName)
@@ -371,7 +375,7 @@ export const addReferencesToInstanceNames = async (
           referenceIndex,
           instanceOriginalName: originalFullName,
           nameToInstance,
-          newElemId: newInstance.elemID,
+          newInstance,
         })
 
         if (nameToInstance[originalFullName] !== undefined) {

--- a/packages/adapter-components/test/filters/referenced_instance_name.test.ts
+++ b/packages/adapter-components/test/filters/referenced_instance_name.test.ts
@@ -157,6 +157,14 @@ describe('referenced instances', () => {
           fav_recipe: new ReferenceExpression(recipes[0].elemID, recipes[0]),
         },
       ),
+      new InstanceElement(
+        'group3',
+        groupType,
+        {
+          name: 'groupThree',
+          fav_recipe: new ReferenceExpression(recipes[1].elemID, recipes[1]),
+        },
+      ),
     ]
     const folderType = new ObjectType({
       elemID: new ElemID(ADAPTER_NAME, 'folder'),
@@ -313,6 +321,7 @@ describe('referenced instances', () => {
           'myAdapter.folder.instance.recipe123_123_ROOT__lastRecipe_456_123_ROOT__Documents',
           'myAdapter.group.instance.group1',
           'myAdapter.group.instance.group2',
+          'myAdapter.group.instance.group3',
           'myAdapter.noIdFields.instance.no_idFieldsParent',
           'myAdapter.recipe.instance.recipe123_123_ROOT',
           'myAdapter.recipe.instance.recipe123_123_ROOT__lastRecipe_456_123_ROOT',
@@ -343,7 +352,7 @@ describe('referenced instances', () => {
       const sortedResult = result
         .filter(isInstanceElement)
         .map(i => i.elemID.getFullName()).sort()
-      expect(result.length).toEqual(14)
+      expect(result.length).toEqual(15)
       expect(sortedResult)
         .toEqual(['myAdapter.book.instance.123_ROOT',
           'myAdapter.book.instance.456_123_ROOT',
@@ -351,11 +360,28 @@ describe('referenced instances', () => {
           'myAdapter.folder.instance.recipe123_123_ROOT__lastRecipe_456_123_ROOT__Documents',
           'myAdapter.group.instance.group1',
           'myAdapter.group.instance.group2',
+          'myAdapter.group.instance.group3',
           'myAdapter.noIdFields.instance.no_idFieldsWithParent',
           'myAdapter.recipe.instance.recipe123_123_ROOT',
           'myAdapter.recipe.instance.recipe123_123_ROOT__lastRecipe_456_123_ROOT',
           'myAdapter.recipe.instance.recipe456_456_123_ROOT',
         ])
+    })
+    it('should update references to the renamed instance correctly', async () => {
+      elements = generateElements()
+      const result = await addReferencesToInstanceNames(
+        elements,
+        transformationConfigByType,
+        transformationDefaultConfig
+      )
+      const updatedRecipe = result.filter(isInstanceElement).find(inst => inst.elemID.name === 'recipe456_456_123_ROOT')
+      const updatedGroup = result.filter(isInstanceElement).find(inst => inst.elemID.name === 'group3')
+      const updatedReference = updatedGroup?.value.fav_recipe
+      expect(updatedReference).toBeInstanceOf(ReferenceExpression)
+      expect((updatedReference as ReferenceExpression).elemID).toEqual(updatedRecipe?.elemID)
+      // verify reference value was updates as well
+      expect((updatedReference as ReferenceExpression).value.value.book_id.elemID)
+        .toEqual(updatedRecipe?.value.book_id.elemID)
     })
     it('should change references correctly inside template expressions', async () => {
       elements = generateElements()
@@ -380,9 +406,9 @@ describe('referenced instances', () => {
       ])
     })
     it('should not change name for duplicate elemIDs', async () => {
-      elements = generateElements().filter(e => !['status', 'email'].includes(e.elemID.typeName))
+      elements = generateElements().filter(e => !['status', 'email', 'group'].includes(e.elemID.typeName))
       const result = await addReferencesToInstanceNames(
-        elements.slice(0, 9).concat(elements.slice(12)),
+        elements,
         transformationConfigByType,
         transformationDefaultConfig
       )
@@ -415,11 +441,11 @@ describe('referenced instances', () => {
         'myAdapter.book.instance.rootBook',
         'myAdapter.book.instance.book',
         'myAdapter.recipe.instance.recipe123',
-        'myAdapter.recipe.instance.last',
         'myAdapter.recipe.instance.recipe456',
+        'myAdapter.recipe.instance.last',
       ])
       expect(Object.values(res).map(n => n.length))
-        .toEqual([4, 3, 6, 2, 1])
+        .toEqual([4, 3, 6, 2, 2])
     })
     it('should not have different results on the second fetch', async () => {
       elements = generateElements()


### PR DESCRIPTION
After instance is being renamed in `referencedInstanceNames`, we look for all its references and update them to include the new elemID. Until now we only updated the reference `elemID` and left the old res value instead of updating as well.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
