### PR TITLE
SALTO-5095: Fix forms.test.ts

### DIFF
--- a/packages/jira-adapter/test/filters/forms/forms.test.ts
+++ b/packages/jira-adapter/test/filters/forms/forms.test.ts
@@ -19,7 +19,6 @@ import _ from 'lodash'
 import { InstanceElement, Element, isInstanceElement, CORE_ANNOTATIONS, ReferenceExpression } from '@salto-io/adapter-api'
 import { MockInterface } from '@salto-io/test-utils'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
-import moment from 'moment'
 import { getDefaultConfig } from '../../../src/config/config'
 import formsFilter from '../../../src/filters/forms/forms'
 import { createEmptyType, getFilterParams, mockClient } from '../../utils'
@@ -484,8 +483,12 @@ describe('forms filter', () => {
         elements = [projectInstance, projectType]
       })
       it('should add the current updated time', async () => {
+        const timeBeforeFilter = new Date()
         await filter.preDeploy([{ action: 'add', data: { after: formInstance } }])
-        expect(moment(formInstance.value.updated).format('YYYY-MM-DDTHH:mm')).toEqual(moment(new Date().toISOString()).format('YYYY-MM-DDTHH:mm'))
+        const timeAfterFilter = new Date()
+        const updatedTime = new Date(formInstance.value.updated)
+        const isBetween = updatedTime >= timeBeforeFilter && updatedTime <= timeAfterFilter
+        expect(isBetween).toBeTruthy()
       })
     })
     describe('onDeploy', () => {


### PR DESCRIPTION
In this  PR I fixed the forms.test.ts since it was flaky. 

---

_Additional context for reviewer_
None

---
_Release Notes_: 
None

---
_User Notifications_: 
None
