### PR TITLE
SALTO-5097: Support deploy of assets statuses

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -148,6 +148,7 @@ import scriptRunnerFilter from './filters/script_runner/script_runner_filter'
 import scriptRunnerListenersDeployFilter from './filters/script_runner/script_runner_listeners_deploy'
 import scriptedFragmentsDeployFilter from './filters/script_runner/scripted_fragments_deploy'
 import fetchJsmTypesFilter from './filters/jsm_types_fetch_filter'
+import assetsStatusAdditionFilter from './filters/assets/assets_status_addition'
 import deployJsmTypesFilter from './filters/jsm_types_deploy_filter'
 import jsmPathFilter from './filters/jsm_paths'
 import portalSettingsFilter from './filters/portal_settings'
@@ -334,6 +335,8 @@ export const DEFAULT_FILTERS = [
   queueDeleteFilter,
   portalGroupsFilter,
   requestTypeFilter,
+  // Must run before asstesDeployFilter
+  assetsStatusAdditionFilter,
   deployJsmTypesFilter,
   // Must be done after JsmTypesFilter
   jsmPathFilter,

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -2219,8 +2219,26 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       sourceTypeName: 'AssetsSchema__assetsStatuses',
       fieldsToHide: [
         { fieldName: 'id' },
+        { fieldName: 'workspaceId' },
+      ],
+      fieldsToOmit: [
         { fieldName: 'objectSchemaId' },
       ],
+    },
+    deployRequests: {
+      add: {
+        url: '/gateway/api/jsm/assets/workspace/{workspaceId}/v1/config/statustype',
+        method: 'post',
+      },
+      modify: {
+        url: '/gateway/api/jsm/assets/workspace/{workspaceId}/v1/config/statustype/{id}',
+        method: 'put',
+      },
+      remove: {
+        url: '/gateway/api/jsm/assets/workspace/{workspaceId}/v1/config/statustype/{id}',
+        method: 'delete',
+        omitRequestBody: true,
+      },
     },
   },
   AssetsObjectTypes: {
@@ -2263,9 +2281,9 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       sourceTypeName: 'AssetsSchema__attributes',
       fieldsToHide: [
         { fieldName: 'id' },
+        { fieldName: 'workspaceId' },
       ],
       fieldsToOmit: [
-        { fieldName: 'workspaceId' },
         { fieldName: 'globalId' },
       ],
     },

--- a/packages/jira-adapter/src/constants.ts
+++ b/packages/jira-adapter/src/constants.ts
@@ -113,6 +113,7 @@ export const ISSUE_VIEW_TYPE = 'IssueView'
 export const REQUEST_FORM_TYPE = 'RequestForm'
 export const FORM_TYPE = 'Form'
 export const ASSESTS_SCHEMA_TYPE = 'AssetsSchema'
+export const ASSETS_STATUS_TYPE = 'AssetsStatus'
 export const ASSETS_OBJECT_TYPE = 'AssetsObjectType'
 export const ASSETS_ATTRIBUTE_TYPE = 'AssetsObjectTypeAttribute'
 // almost constant functions

--- a/packages/jira-adapter/src/filters/assets/assets_status_addition.ts
+++ b/packages/jira-adapter/src/filters/assets/assets_status_addition.ts
@@ -1,0 +1,63 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { getChangeData, isAdditionChange, isInstanceChange } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { getParent } from '@salto-io/adapter-utils'
+import { FilterCreator } from '../../filter'
+import { ASSETS_STATUS_TYPE } from '../../constants'
+
+
+const { awu } = collections.asynciterable
+
+const filter: FilterCreator = ({ config }) => ({
+  name: 'assetsStatusAdditionFilter',
+  preDeploy: async changes => {
+    const { jsmApiDefinitions } = config
+    if (!config.fetch.enableJSM
+        || !config.fetch.enableJsmExperimental
+        || jsmApiDefinitions === undefined) {
+      return
+    }
+
+    await awu(changes)
+      .filter(isInstanceChange)
+      .filter(isAdditionChange)
+      .map(getChangeData)
+      .filter(instance => instance.elemID.typeName === ASSETS_STATUS_TYPE)
+      .forEach(instance => {
+        instance.value.objectSchemaId = getParent(instance).value.id
+      })
+  },
+  onDeploy: async changes => {
+    const { jsmApiDefinitions } = config
+    if (!config.fetch.enableJSM
+        || !config.fetch.enableJsmExperimental
+        || jsmApiDefinitions === undefined) {
+      return
+    }
+
+    await awu(changes)
+      .filter(isInstanceChange)
+      .filter(isAdditionChange)
+      .map(getChangeData)
+      .filter(instance => instance.elemID.typeName === ASSETS_STATUS_TYPE)
+      .forEach(instance => {
+        delete instance.value.objectSchemaId
+      })
+  },
+})
+export default filter

--- a/packages/jira-adapter/src/filters/jsm_types_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/jsm_types_deploy_filter.ts
@@ -19,10 +19,10 @@ import { getChangeData, isInstanceChange, Change, InstanceElement } from '@salto
 import { defaultDeployChange, deployChanges } from '../deployment/standard_deployment'
 import { FilterCreator } from '../filter'
 import { JSM_DUCKTYPE_SUPPORTED_TYPES } from '../config/api_config'
-import { ASSESTS_SCHEMA_TYPE } from '../constants'
+import { ASSESTS_SCHEMA_TYPE, ASSETS_STATUS_TYPE } from '../constants'
 import { getWorkspaceId } from '../workspace_id'
 
-const ASSETS_SUPPORTED_TYPES = [ASSESTS_SCHEMA_TYPE]
+const ASSETS_SUPPORTED_TYPES = [ASSESTS_SCHEMA_TYPE, ASSETS_STATUS_TYPE]
 const SUPPORTED_TYPES = new Set(Object.keys(JSM_DUCKTYPE_SUPPORTED_TYPES).concat(ASSETS_SUPPORTED_TYPES))
 
 const filterCreator: FilterCreator = ({ config, client }) => ({

--- a/packages/jira-adapter/src/filters/jsm_types_fetch_filter.ts
+++ b/packages/jira-adapter/src/filters/jsm_types_fetch_filter.ts
@@ -17,7 +17,7 @@
 
 import { isObjectType, CORE_ANNOTATIONS, isInstanceElement } from '@salto-io/adapter-api'
 import { FilterCreator } from '../filter'
-import { ASSESTS_SCHEMA_TYPE, CALENDAR_TYPE, CUSTOMER_PERMISSIONS_TYPE, PORTAL_GROUP_TYPE, PORTAL_SETTINGS_TYPE_NAME, QUEUE_TYPE, REQUEST_TYPE_NAME, SLA_TYPE_NAME } from '../constants'
+import { ASSESTS_SCHEMA_TYPE, ASSETS_STATUS_TYPE, CALENDAR_TYPE, CUSTOMER_PERMISSIONS_TYPE, PORTAL_GROUP_TYPE, PORTAL_SETTINGS_TYPE_NAME, QUEUE_TYPE, REQUEST_TYPE_NAME, SLA_TYPE_NAME } from '../constants'
 import { setTypeDeploymentAnnotations, addAnnotationRecursively } from '../utils'
 
 
@@ -33,6 +33,7 @@ const jsmSupportedTypes = [
 
 const assetsSupportedTypes = [
   ASSESTS_SCHEMA_TYPE,
+  ASSETS_STATUS_TYPE,
 ]
 
 const filterCreator: FilterCreator = ({ config }) => ({

--- a/packages/jira-adapter/test/filters/assets/assets_status_addition.test.ts
+++ b/packages/jira-adapter/test/filters/assets/assets_status_addition.test.ts
@@ -1,0 +1,87 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { filterUtils } from '@salto-io/adapter-components'
+import _ from 'lodash'
+import { InstanceElement, ReferenceExpression, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
+import { getDefaultConfig } from '../../../src/config/config'
+import assetsStatusAdditionFilter from '../../../src/filters/assets/assets_status_addition'
+import { createEmptyType, getFilterParams } from '../../utils'
+import { ASSESTS_SCHEMA_TYPE, ASSETS_STATUS_TYPE } from '../../../src/constants'
+
+describe('assetsStatusAddition', () => {
+    type FilterType = filterUtils.FilterWith<'preDeploy' | 'onDeploy'>
+    let filter: FilterType
+    let assetsStatusInstance: InstanceElement
+    const assetSchemaInstance = new InstanceElement(
+      'assetsSchema1',
+      createEmptyType(ASSESTS_SCHEMA_TYPE),
+      {
+        id: 5,
+        name: 'assetsSchema',
+      },
+    )
+    describe('preDeploy', () => {
+      beforeEach(async () => {
+        const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+        config.fetch.enableJSM = true
+        config.fetch.enableJsmExperimental = true
+        filter = assetsStatusAdditionFilter(getFilterParams({ config })) as typeof filter
+        assetsStatusInstance = new InstanceElement(
+          'assetsStatusInstance',
+          createEmptyType(ASSETS_STATUS_TYPE),
+          {
+            name: 'assetsStatusInstance',
+            description: 'test Description',
+            category: 2,
+          },
+          undefined,
+          {
+            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(assetSchemaInstance.elemID, assetSchemaInstance)],
+          }
+        )
+      })
+      it('should add objectSchemaId on addition', async () => {
+        await filter.preDeploy([{ action: 'add', data: { after: assetsStatusInstance } }])
+        expect(assetsStatusInstance.value.objectSchemaId).toEqual(5)
+      })
+    })
+    describe('onDeploy', () => {
+      beforeEach(async () => {
+        const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+        config.fetch.enableJSM = true
+        config.fetch.enableJsmExperimental = true
+        filter = assetsStatusAdditionFilter(getFilterParams({ config })) as typeof filter
+        assetsStatusInstance = new InstanceElement(
+          'assetsStatusInstance',
+          createEmptyType(ASSETS_STATUS_TYPE),
+          {
+            name: 'assetsStatusInstance',
+            description: 'test Description',
+            category: 2,
+            objectSchemaId: 5,
+          },
+          undefined,
+          {
+            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(assetSchemaInstance.elemID, assetSchemaInstance)],
+          }
+        )
+      })
+      it('should delete objectSchemaId', async () => {
+        await filter.onDeploy([{ action: 'add', data: { after: assetsStatusInstance } }])
+        expect(assetsStatusInstance.value.objectSchemaId).toBeUndefined()
+      })
+    })
+})


### PR DESCRIPTION
In this PR I support deploy of assets schema statuses. 

---

_Additional context for reviewer_
Please review only from [Support deploy of assetsStatuses](https://github.com/salto-io/salto/pull/5138/commits/59d3b65153d95b3a17819f88449790bc348eb619) commit and any sub commit. 

---
_Release Notes_: 
_Jira Adapter:_
Now support deploy of assets schema statuses.

---
_User Notifications_: 
None
