### PR TITLE
SALTO-5102: Add CV to automation with assets

### DIFF
--- a/packages/jira-adapter/src/change_validators/automation/automation_projects.ts
+++ b/packages/jira-adapter/src/change_validators/automation/automation_projects.ts
@@ -15,7 +15,7 @@
 */
 import { ChangeValidator, getChangeData, isAdditionOrModificationChange, isInstanceChange, SeverityLevel } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { AUTOMATION_TYPE } from '../constants'
+import { AUTOMATION_TYPE } from '../../constants'
 
 export const automationProjectsValidator: ChangeValidator = async changes =>
   changes

--- a/packages/jira-adapter/src/change_validators/automation/automation_to_assets.ts
+++ b/packages/jira-adapter/src/change_validators/automation/automation_to_assets.ts
@@ -65,7 +65,7 @@ export const automationToAssetsValidator: (config: JiraConfig) => ChangeValidato
     .map(instance => ({
       elemID: instance.elemID,
       severity: 'Warning' as SeverityLevel,
-      message: 'JSM Add-On Missing for Automation with Assets elements.',
-      detailedMessage: `The automation ${instance.annotations[CORE_ANNOTATIONS.ALIAS]} linked to the Assets object requires the JSM Add-On in Salto. Currently, this automation is referencing internal IDs without JSM enablement. If you've modified internal Ids, please ensure they are correctly set for the new environment. Without the JSM Add-On, these Ids can potentially lead to deployment issues.`,
+      message: 'Missing JSM Add-On for Automation Linked to Assets Elements.',
+      detailedMessage: `The automation '${instance.annotations[CORE_ANNOTATIONS.ALIAS]}', linked to the Assets object, requires the JSM Add-On in Salto. This automation currently uses internal IDs but does not have the JSM Add-On. If you have modified internal IDs, ensure they are accurate in the target environment. Incorrect IDs, without the JSM Add-On, could lead to deployment issues.`,
     }))
 }

--- a/packages/jira-adapter/src/change_validators/automation/automation_to_assets.ts
+++ b/packages/jira-adapter/src/change_validators/automation/automation_to_assets.ts
@@ -1,0 +1,71 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ChangeValidator, CORE_ANNOTATIONS, getChangeData, isAdditionChange, isAdditionOrModificationChange, isInstanceChange, SeverityLevel } from '@salto-io/adapter-api'
+import { values } from '@salto-io/lowerdash'
+import _ from 'lodash'
+import { AUTOMATION_TYPE } from '../../constants'
+import { JiraConfig } from '../../config/config'
+
+const { isDefined } = values
+type Component = {
+    component: string
+    schemaVersion: number
+    type: string
+    value: {
+        workspaceId?: string
+        schemaId?: string
+        objectTypeId?: string
+    }
+}
+
+const hasRelevantComponent = (components: Component[]): boolean =>
+  components.some(({ value }) =>
+    value.workspaceId !== undefined
+    || value.schemaId !== undefined
+    || value.objectTypeId !== undefined)
+
+const getComponentIds = (components: Component[], key: 'workspaceId' | 'schemaId' | 'objectTypeId'): string[] =>
+  components.map(component => component.value[key]).filter(isDefined)
+
+const isComponentChanged = (beforeComponents: Component[], afterComponents: Component[]): boolean => {
+  const keys: Array<'workspaceId' | 'schemaId' | 'objectTypeId'> = ['workspaceId', 'schemaId', 'objectTypeId']
+  return keys.some(key =>
+    !_.isEqual(getComponentIds(beforeComponents, key), getComponentIds(afterComponents, key)))
+}
+
+export const automationToAssetsValidator: (config: JiraConfig) => ChangeValidator = config => async changes => {
+  if (config.fetch.enableJSM) {
+    return []
+  }
+  return changes
+    .filter(isInstanceChange)
+    .filter(isAdditionOrModificationChange)
+    .filter(change => getChangeData(change).elemID.typeName === AUTOMATION_TYPE)
+    .filter(change => {
+      const instance = getChangeData(change)
+      if (isAdditionChange(change)) {
+        return hasRelevantComponent(instance.value.components)
+      }
+      return isComponentChanged(change.data.before.value.components, change.data.after.value.components)
+    })
+    .map(getChangeData)
+    .map(instance => ({
+      elemID: instance.elemID,
+      severity: 'Warning' as SeverityLevel,
+      message: 'JSM Add-On Missing for Automation with Assets elements.',
+      detailedMessage: `The automation ${instance.annotations[CORE_ANNOTATIONS.ALIAS]} linked to the Assets object requires the JSM Add-On in Salto. Currently, this automation is referencing internal IDs without JSM enablement. If you've modified internal Ids, please ensure they are correctly set for the new environment. Without the JSM Add-On, these Ids can potentially lead to deployment issues.`,
+    }))
+}

--- a/packages/jira-adapter/src/change_validators/automation/automation_to_assets.ts
+++ b/packages/jira-adapter/src/change_validators/automation/automation_to_assets.ts
@@ -37,13 +37,13 @@ const hasRelevantComponent = (components: Component[]): boolean =>
     || value.schemaId !== undefined
     || value.objectTypeId !== undefined)
 
-const getComponentIds = (components: Component[], key: 'workspaceId' | 'schemaId' | 'objectTypeId'): string[] =>
-  components.map(component => component.value[key]).filter(isDefined)
+const getUniqueValues = (components: Component[], key: keyof Component['value']): string[] =>
+  [...new Set(components.map(component => component.value[key]).filter(isDefined))].sort()
 
 const isComponentChanged = (beforeComponents: Component[], afterComponents: Component[]): boolean => {
   const keys: Array<'workspaceId' | 'schemaId' | 'objectTypeId'> = ['workspaceId', 'schemaId', 'objectTypeId']
   return keys.some(key =>
-    !_.isEqual(getComponentIds(beforeComponents, key), getComponentIds(afterComponents, key)))
+    !_.isEqual(getUniqueValues(beforeComponents, key), getUniqueValues(afterComponents, key)))
 }
 
 export const automationToAssetsValidator: (config: JiraConfig) => ChangeValidator = config => async changes => {

--- a/packages/jira-adapter/src/change_validators/automation/automations.ts
+++ b/packages/jira-adapter/src/change_validators/automation/automations.ts
@@ -16,7 +16,7 @@
 import { ChangeValidator, getChangeData, isAdditionChange, isInstanceChange, SeverityLevel } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
-import { AUTOMATION_TYPE } from '../constants'
+import { AUTOMATION_TYPE } from '../../constants'
 
 const { awu } = collections.asynciterable
 

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -29,7 +29,7 @@ import { dashboardGadgetsValidator } from './dashboard_gadgets'
 import { dashboardLayoutValidator } from './dashboard_layout'
 import { permissionTypeValidator } from './permission_type'
 import { maskingValidator } from './masking'
-import { automationsValidator } from './automations'
+import { automationsValidator } from './automation/automations'
 import { lockedFieldsValidator } from './locked_fields'
 import { systemFieldsValidator } from './system_fields'
 import { workflowPropertiesValidator } from './workflows/workflow_properties'
@@ -57,8 +57,9 @@ import { unresolvedFieldConfigurationItemsValidator } from './unresolved_field_c
 import { fieldSecondGlobalContextValidator } from './field_contexts/second_global_context'
 import { customFieldsWith10KOptionValidator } from './field_contexts/custom_field_with_10K_options'
 import { issueTypeHierarchyValidator } from './issue_type_hierarchy'
-import { automationProjectsValidator } from './automation_projects'
+import { automationProjectsValidator } from './automation/automation_projects'
 import { deleteLastQueueValidator } from './last_queue'
+import { automationToAssetsValidator } from './automation/automation_to_assets'
 
 const {
   deployTypesNotSupportedValidator,
@@ -115,6 +116,7 @@ export default (
     issueTypeHierarchy: issueTypeHierarchyValidator,
     automationProjects: automationProjectsValidator,
     deleteLastQueueValidator: deleteLastQueueValidator(config),
+    automationToAssets: automationToAssetsValidator(config),
   }
 
   return createChangeValidator({

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -238,6 +238,7 @@ export type ChangeValidatorName = (
   | 'issueTypeHierarchy'
   | 'automationProjects'
   | 'deleteLastQueueValidator'
+  | 'automationToAssets'
   )
 
 type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
@@ -288,6 +289,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     issueTypeHierarchy: { refType: BuiltinTypes.BOOLEAN },
     automationProjects: { refType: BuiltinTypes.BOOLEAN },
     deleteLastQueueValidator: { refType: BuiltinTypes.BOOLEAN },
+    automationToAssets: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/jira-adapter/test/change_validators/automations/automation_projects.test.ts
+++ b/packages/jira-adapter/test/change_validators/automations/automation_projects.test.ts
@@ -15,8 +15,8 @@
 */
 import { ObjectType, ElemID, ReadOnlyElementsSource, InstanceElement, toChange } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { automationProjectsValidator } from '../../src/change_validators/automation_projects'
-import { AUTOMATION_TYPE, JIRA } from '../../src/constants'
+import { automationProjectsValidator } from '../../../src/change_validators/automation/automation_projects'
+import { AUTOMATION_TYPE, JIRA } from '../../../src/constants'
 
 describe('automationProjectsValidator', () => {
   let automationType: ObjectType

--- a/packages/jira-adapter/test/change_validators/automations/automation_to_assets.test.ts
+++ b/packages/jira-adapter/test/change_validators/automations/automation_to_assets.test.ts
@@ -96,4 +96,19 @@ describe('automationsToAssetsValidator', () => {
     expect(await validator([toChange({ before: automationInstance, after: automationInstnaceAfter })]))
       .toEqual([])
   })
+  it('should not return a warning when adding another component with the same workspaceId and enableJSM is false', async () => {
+    const automationInstnaceAfter = automationInstance.clone()
+    automationInstnaceAfter.value.components.push({
+      component: 'BRANCH',
+      schemaVersion: 2,
+      type: 'cmdb.object.related',
+      value: {
+        workspaceId: 'workspaceId',
+        schemaId: 'schemaId',
+      },
+    })
+    const validator = automationToAssetsValidator(config)
+    expect(await validator([toChange({ before: automationInstance, after: automationInstnaceAfter })]))
+      .toEqual([])
+  })
 })

--- a/packages/jira-adapter/test/change_validators/automations/automation_to_assets.test.ts
+++ b/packages/jira-adapter/test/change_validators/automations/automation_to_assets.test.ts
@@ -1,0 +1,99 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { InstanceElement, toChange, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { automationToAssetsValidator } from '../../../src/change_validators/automation/automation_to_assets'
+import { AUTOMATION_TYPE } from '../../../src/constants'
+import { JiraConfig, getDefaultConfig } from '../../../src/config/config'
+import { createEmptyType } from '../../utils'
+
+describe('automationsToAssetsValidator', () => {
+  let automationInstance: InstanceElement
+  let config: JiraConfig
+
+  beforeEach(() => {
+    config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+    config.fetch.enableJSM = false
+    automationInstance = new InstanceElement(
+      'automationInstance1',
+      createEmptyType(AUTOMATION_TYPE),
+      {
+        name: 'automationInstance',
+        components: [
+          {
+            component: 'ACTION',
+            schemaVersion: 1,
+            type: 'cmdb.lookup.objects',
+            value: {
+              workspaceId: 'workspaceId',
+              schemaId: 'schemaId',
+            },
+          }],
+      },
+      undefined,
+      {
+        [CORE_ANNOTATIONS.ALIAS]: ['automation alias'],
+      }
+    )
+  })
+
+  it('should return a warning when its addition change and automation has workspaceId and enableJSM is false', async () => {
+    const validator = automationToAssetsValidator(config)
+    expect(await validator([toChange({ after: automationInstance })]))
+      .toEqual([
+        {
+          elemID: automationInstance.elemID,
+          severity: 'Warning',
+          message: 'JSM Add-On Missing for Automation with Assets elements.',
+          detailedMessage: "The automation automation alias linked to the Assets object requires the JSM Add-On in Salto. Currently, this automation is referencing internal IDs without JSM enablement. If you've modified internal Ids, please ensure they are correctly set for the new environment. Without the JSM Add-On, these Ids can potentially lead to deployment issues.",
+        },
+      ])
+  })
+  it('should not return a warning when its addition change and automation has workspaceId and enableJSM is true', async () => {
+    config.fetch.enableJSM = true
+    const validator = automationToAssetsValidator(config)
+    expect(await validator([toChange({ after: automationInstance })]))
+      .toEqual([])
+  })
+  it('should not return a warning when automation does not have workspaceId or schemaId and enableJSM is false', async () => {
+    automationInstance.value.components[0].value.workspaceId = undefined
+    automationInstance.value.components[0].value.schemaId = undefined
+    const validator = automationToAssetsValidator(config)
+    expect(await validator([toChange({ after: automationInstance })]))
+      .toEqual([])
+  })
+  it('should return a warning when its modification change and schemaId has changed and enableJSM is false', async () => {
+    const automationInstnaceAfter = automationInstance.clone()
+    automationInstnaceAfter.value.components[0].value.schemaId = 'newSchemaId'
+    const validator = automationToAssetsValidator(config)
+    expect(await validator([toChange({ before: automationInstance, after: automationInstnaceAfter })]))
+      .toEqual([
+        {
+          elemID: automationInstance.elemID,
+          severity: 'Warning',
+          message: 'JSM Add-On Missing for Automation with Assets elements.',
+          detailedMessage: "The automation automation alias linked to the Assets object requires the JSM Add-On in Salto. Currently, this automation is referencing internal IDs without JSM enablement. If you've modified internal Ids, please ensure they are correctly set for the new environment. Without the JSM Add-On, these Ids can potentially lead to deployment issues.",
+        },
+      ])
+  })
+  it('should not return a warning when its modification change and no internalId has changed and enableJSM is false', async () => {
+    const automationInstnaceAfter = automationInstance.clone()
+    automationInstnaceAfter.value.name = 'newNameId'
+    const validator = automationToAssetsValidator(config)
+    expect(await validator([toChange({ before: automationInstance, after: automationInstnaceAfter })]))
+      .toEqual([])
+  })
+})

--- a/packages/jira-adapter/test/change_validators/automations/automation_to_assets.test.ts
+++ b/packages/jira-adapter/test/change_validators/automations/automation_to_assets.test.ts
@@ -57,8 +57,8 @@ describe('automationsToAssetsValidator', () => {
         {
           elemID: automationInstance.elemID,
           severity: 'Warning',
-          message: 'JSM Add-On Missing for Automation with Assets elements.',
-          detailedMessage: "The automation automation alias linked to the Assets object requires the JSM Add-On in Salto. Currently, this automation is referencing internal IDs without JSM enablement. If you've modified internal Ids, please ensure they are correctly set for the new environment. Without the JSM Add-On, these Ids can potentially lead to deployment issues.",
+          message: 'Missing JSM Add-On for Automation Linked to Assets Elements.',
+          detailedMessage: 'The automation \'automation alias\', linked to the Assets object, requires the JSM Add-On in Salto. This automation currently uses internal IDs but does not have the JSM Add-On. If you have modified internal IDs, ensure they are accurate in the target environment. Incorrect IDs, without the JSM Add-On, could lead to deployment issues.',
         },
       ])
   })
@@ -84,8 +84,8 @@ describe('automationsToAssetsValidator', () => {
         {
           elemID: automationInstance.elemID,
           severity: 'Warning',
-          message: 'JSM Add-On Missing for Automation with Assets elements.',
-          detailedMessage: "The automation automation alias linked to the Assets object requires the JSM Add-On in Salto. Currently, this automation is referencing internal IDs without JSM enablement. If you've modified internal Ids, please ensure they are correctly set for the new environment. Without the JSM Add-On, these Ids can potentially lead to deployment issues.",
+          message: 'Missing JSM Add-On for Automation Linked to Assets Elements.',
+          detailedMessage: 'The automation \'automation alias\', linked to the Assets object, requires the JSM Add-On in Salto. This automation currently uses internal IDs but does not have the JSM Add-On. If you have modified internal IDs, ensure they are accurate in the target environment. Incorrect IDs, without the JSM Add-On, could lead to deployment issues.',
         },
       ])
   })

--- a/packages/jira-adapter/test/change_validators/automations/automations.test.ts
+++ b/packages/jira-adapter/test/change_validators/automations/automations.test.ts
@@ -15,8 +15,8 @@
 */
 import { ObjectType, ElemID, ReadOnlyElementsSource, InstanceElement, toChange } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { automationsValidator } from '../../src/change_validators/automations'
-import { AUTOMATION_TYPE, JIRA } from '../../src/constants'
+import { automationsValidator } from '../../../src/change_validators/automation/automations'
+import { AUTOMATION_TYPE, JIRA } from '../../../src/constants'
 
 describe('automationsValidator', () => {
   let automationType: ObjectType


### PR DESCRIPTION
In this PR, I have included a CV that verifies whether an automation contains components with assets when the user does not have JSM support.

---

_Additional context for reviewer_
None

---
_Release Notes_: 
None

---
_User Notifications_: 
None
