### PR TITLE
SAAS-9634 conflicted elements in dummy adapter to conflict on object fields

### DIFF
--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -797,11 +797,6 @@ export const generateElements = async (
     if (!version) {
       return []
     }
-    const versionToPrimitiveType: Record<ConflictedElementsVersion, PrimitiveType> = {
-      a: BuiltinTypes.BOOLEAN,
-      b: BuiltinTypes.STRING,
-      c: BuiltinTypes.NUMBER,
-    }
     const changedObject = new ObjectType({
       elemID: new ElemID(DUMMY_ADAPTER, 'ChangedObject'),
       fields: {
@@ -809,13 +804,22 @@ export const generateElements = async (
           refType: BuiltinTypes.STRING,
         },
         ...(version !== 'a' ? { notInA: {
-          refType: versionToPrimitiveType[version],
+          refType: BuiltinTypes.STRING,
+          annotations: {
+            version,
+          },
         } } : {}),
         ...(version !== 'b' ? { notInB: {
-          refType: versionToPrimitiveType[version],
+          refType: BuiltinTypes.STRING,
+          annotations: {
+            version,
+          },
         } } : {}),
         ...(version !== 'c' ? { notInC: {
-          refType: versionToPrimitiveType[version],
+          refType: BuiltinTypes.STRING,
+          annotations: {
+            version,
+          },
         } } : {}),
       },
       path: [DUMMY_ADAPTER, 'ConflictedStuff', 'ChangedObject'],
@@ -916,7 +920,8 @@ Fifth line is the same`),
         }),
         autoMergedStaticFileInst: new StaticFile({
           content: Buffer.from(`First line changed in version a
-Second line not changed`),
+Second line not changed
+Third line not changed`),
           filepath: 'autoMergedStaticFileInst.txt',
         }),
         mapField: {
@@ -946,7 +951,8 @@ Fifth line is the same`),
         }),
         autoMergedStaticFileInst: new StaticFile({
           content: Buffer.from(`First line not change
-Second line not changed`),
+Second line not changed
+Third line not changed`),
           filepath: 'autoMergedStaticFileInst.txt',
         }),
         mapField: {
@@ -976,7 +982,8 @@ Fifth line is the same`),
         }),
         autoMergedStaticFileInst: new StaticFile({
           content: Buffer.from(`First line not change
-Second line changed in version c`),
+Second line not changed
+Third line changed in version c`),
           filepath: 'autoMergedStaticFileInst.txt',
         }),
         mapField: {

--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -797,21 +797,20 @@ export const generateElements = async (
     if (!version) {
       return []
     }
+    const versionToBuiltinType: Record<ConflictedElementsVersion, PrimitiveType> = {
+      a: BuiltinTypes.BOOLEAN,
+      b: BuiltinTypes.STRING,
+      c: BuiltinTypes.NUMBER,
+    }
     const changedObject = new ObjectType({
       elemID: new ElemID(DUMMY_ADAPTER, 'ChangedObject'),
       fields: {
-        alwaysHereField: {
+        alwaysTheSae: {
           refType: BuiltinTypes.STRING,
         },
-        ...(version !== 'a' ? { notInA: {
-          refType: BuiltinTypes.STRING,
-        } } : {}),
-        ...(version !== 'b' ? { notInB: {
-          refType: BuiltinTypes.STRING,
-        } } : {}),
-        ...(version !== 'c' ? { notInC: {
-          refType: BuiltinTypes.STRING,
-        } } : {}),
+        changedByVersion: {
+          refType: versionToBuiltinType[version],
+        },
       },
       path: [DUMMY_ADAPTER, 'ConflictedStuff', 'ChangedObject'],
       annotations: {

--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -805,7 +805,7 @@ export const generateElements = async (
     const changedObject = new ObjectType({
       elemID: new ElemID(DUMMY_ADAPTER, 'ChangedObject'),
       fields: {
-        alwaysTheSae: {
+        alwaysTheSame: {
           refType: BuiltinTypes.STRING,
         },
         changedByVersion: {

--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -797,7 +797,7 @@ export const generateElements = async (
     if (!version) {
       return []
     }
-    const versionToBuiltinType: Record<ConflictedElementsVersion, PrimitiveType> = {
+    const versionToPrimitiveType: Record<ConflictedElementsVersion, PrimitiveType> = {
       a: BuiltinTypes.BOOLEAN,
       b: BuiltinTypes.STRING,
       c: BuiltinTypes.NUMBER,
@@ -809,13 +809,13 @@ export const generateElements = async (
           refType: BuiltinTypes.STRING,
         },
         ...(version !== 'a' ? { notInA: {
-          refType: versionToBuiltinType[version],
+          refType: versionToPrimitiveType[version],
         } } : {}),
         ...(version !== 'b' ? { notInB: {
-          refType: versionToBuiltinType[version],
+          refType: versionToPrimitiveType[version],
         } } : {}),
         ...(version !== 'c' ? { notInC: {
-          refType: versionToBuiltinType[version],
+          refType: versionToPrimitiveType[version],
         } } : {}),
       },
       path: [DUMMY_ADAPTER, 'ConflictedStuff', 'ChangedObject'],

--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -808,9 +808,15 @@ export const generateElements = async (
         alwaysTheSame: {
           refType: BuiltinTypes.STRING,
         },
-        changedByVersion: {
+        ...(version !== 'a' ? { notInA: {
           refType: versionToBuiltinType[version],
-        },
+        } } : {}),
+        ...(version !== 'b' ? { notInB: {
+          refType: versionToBuiltinType[version],
+        } } : {}),
+        ...(version !== 'c' ? { notInC: {
+          refType: versionToBuiltinType[version],
+        } } : {}),
       },
       path: [DUMMY_ADAPTER, 'ConflictedStuff', 'ChangedObject'],
       annotations: {

--- a/packages/dummy-adapter/test/generator.test.ts
+++ b/packages/dummy-adapter/test/generator.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { isObjectType, isInstanceElement, isPrimitiveType, isMapType, isListType, BuiltinTypes } from '@salto-io/adapter-api'
+import { isObjectType, isInstanceElement, isPrimitiveType, isMapType, isListType } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import path from 'path'

--- a/packages/dummy-adapter/test/generator.test.ts
+++ b/packages/dummy-adapter/test/generator.test.ts
@@ -147,13 +147,8 @@ describe('elements generator', () => {
         }
         expect(elements.find(e => e.elemID.getFullName() === 'dummy.SimpleObject'))
           .toBeDefined()
-        const changedObject = elements.find(e => e.elemID.getFullName() === 'dummy.ChangedObject')
-        expect(isObjectType(changedObject)).toBeTruthy()
-        if (isObjectType(changedObject)) {
-          expect(changedObject.fields?.notInA).toBeUndefined()
-          expect(changedObject.fields.notInB.refType.elemID).toEqual(BuiltinTypes.BOOLEAN.elemID)
-          expect(changedObject.fields.notInC.refType.elemID).toEqual(BuiltinTypes.BOOLEAN.elemID)
-        }
+        expect(elements.find(e => e.elemID.getFullName() === 'dummy.ChangedObject'))
+          .toBeDefined()
         expect(elements.find(e => e.elemID.getFullName() === 'dummy.SimpleObject.instance.simpleInstDeletedInA'))
           .toBeUndefined()
         expect(elements.find(e => e.elemID.getFullName() === 'dummy.SimpleObject.instance.simpleInstDeletedInB'))
@@ -176,13 +171,8 @@ describe('elements generator', () => {
         }
         expect(elements.find(e => e.elemID.getFullName() === 'dummy.SimpleObject'))
           .toBeDefined()
-        const changedObject = elements.find(e => e.elemID.getFullName() === 'dummy.ChangedObject')
-        expect(isObjectType(changedObject)).toBeTruthy()
-        if (isObjectType(changedObject)) {
-          expect(changedObject.fields.notInA.refType.elemID).toEqual(BuiltinTypes.STRING.elemID)
-          expect(changedObject.fields?.notInB).toBeUndefined()
-          expect(changedObject.fields.notInC.refType.elemID).toEqual(BuiltinTypes.STRING.elemID)
-        }
+        expect(elements.find(e => e.elemID.getFullName() === 'dummy.ChangedObject'))
+          .toBeDefined()
         expect(elements.find(e => e.elemID.getFullName() === 'dummy.SimpleObject.instance.simpleInstDeletedInA'))
           .toBeDefined()
         expect(elements.find(e => e.elemID.getFullName() === 'dummy.SimpleObject.instance.simpleInstDeletedInB'))
@@ -205,13 +195,8 @@ describe('elements generator', () => {
         }
         expect(elements.find(e => e.elemID.getFullName() === 'dummy.SimpleObject'))
           .toBeDefined()
-        const changedObject = elements.find(e => e.elemID.getFullName() === 'dummy.ChangedObject')
-        expect(isObjectType(changedObject)).toBeTruthy()
-        if (isObjectType(changedObject)) {
-          expect(changedObject.fields.notInA.refType.elemID).toEqual(BuiltinTypes.NUMBER.elemID)
-          expect(changedObject.fields.notInB.refType.elemID).toEqual(BuiltinTypes.NUMBER.elemID)
-          expect(changedObject.fields?.notInC).toBeUndefined()
-        }
+        expect(elements.find(e => e.elemID.getFullName() === 'dummy.ChangedObject'))
+          .toBeDefined()
         expect(elements.find(e => e.elemID.getFullName() === 'dummy.ChangedObject'))
           .toBeDefined()
         expect(elements.find(e => e.elemID.getFullName() === 'dummy.SimpleObject.instance.simpleInstDeletedInA'))

--- a/packages/dummy-adapter/test/generator.test.ts
+++ b/packages/dummy-adapter/test/generator.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { isObjectType, isInstanceElement, isPrimitiveType, isMapType, isListType } from '@salto-io/adapter-api'
+import { isObjectType, isInstanceElement, isPrimitiveType, isMapType, isListType, BuiltinTypes } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import path from 'path'
@@ -147,8 +147,13 @@ describe('elements generator', () => {
         }
         expect(elements.find(e => e.elemID.getFullName() === 'dummy.SimpleObject'))
           .toBeDefined()
-        expect(elements.find(e => e.elemID.getFullName() === 'dummy.ChangedObject'))
-          .toBeDefined()
+        const changedObject = elements.find(e => e.elemID.getFullName() === 'dummy.ChangedObject')
+        expect(isObjectType(changedObject)).toBeTruthy()
+        if (isObjectType(changedObject)) {
+          expect(changedObject.fields?.notInA).toBeUndefined()
+          expect(changedObject.fields.notInB.refType.elemID).toEqual(BuiltinTypes.BOOLEAN.elemID)
+          expect(changedObject.fields.notInC.refType.elemID).toEqual(BuiltinTypes.BOOLEAN.elemID)
+        }
         expect(elements.find(e => e.elemID.getFullName() === 'dummy.SimpleObject.instance.simpleInstDeletedInA'))
           .toBeUndefined()
         expect(elements.find(e => e.elemID.getFullName() === 'dummy.SimpleObject.instance.simpleInstDeletedInB'))
@@ -171,8 +176,13 @@ describe('elements generator', () => {
         }
         expect(elements.find(e => e.elemID.getFullName() === 'dummy.SimpleObject'))
           .toBeDefined()
-        expect(elements.find(e => e.elemID.getFullName() === 'dummy.ChangedObject'))
-          .toBeDefined()
+        const changedObject = elements.find(e => e.elemID.getFullName() === 'dummy.ChangedObject')
+        expect(isObjectType(changedObject)).toBeTruthy()
+        if (isObjectType(changedObject)) {
+          expect(changedObject.fields.notInA.refType.elemID).toEqual(BuiltinTypes.STRING.elemID)
+          expect(changedObject.fields?.notInB).toBeUndefined()
+          expect(changedObject.fields.notInC.refType.elemID).toEqual(BuiltinTypes.STRING.elemID)
+        }
         expect(elements.find(e => e.elemID.getFullName() === 'dummy.SimpleObject.instance.simpleInstDeletedInA'))
           .toBeDefined()
         expect(elements.find(e => e.elemID.getFullName() === 'dummy.SimpleObject.instance.simpleInstDeletedInB'))
@@ -195,6 +205,13 @@ describe('elements generator', () => {
         }
         expect(elements.find(e => e.elemID.getFullName() === 'dummy.SimpleObject'))
           .toBeDefined()
+        const changedObject = elements.find(e => e.elemID.getFullName() === 'dummy.ChangedObject')
+        expect(isObjectType(changedObject)).toBeTruthy()
+        if (isObjectType(changedObject)) {
+          expect(changedObject.fields.notInA.refType.elemID).toEqual(BuiltinTypes.NUMBER.elemID)
+          expect(changedObject.fields.notInB.refType.elemID).toEqual(BuiltinTypes.NUMBER.elemID)
+          expect(changedObject.fields?.notInC).toBeUndefined()
+        }
         expect(elements.find(e => e.elemID.getFullName() === 'dummy.ChangedObject'))
           .toBeDefined()
         expect(elements.find(e => e.elemID.getFullName() === 'dummy.SimpleObject.instance.simpleInstDeletedInA'))


### PR DESCRIPTION
Improve the conflict generator on dummy to create conflict on objectType fields defenition

---

The previous version did not create any conflicts. we should check the definition of each field to create a conflict and not just its existence 

B -> A (autoMergedStaticFile):
<img width="1364" alt="image" src="https://github.com/salto-io/salto/assets/63018798/97dac4eb-0143-48ef-8071-1c483fff21ef">

B -> C (autoMergedStaticFile):
<img width="1495" alt="image" src="https://github.com/salto-io/salto/assets/63018798/2fa004e4-b1ea-434f-ac8d-a96bd2784ede">



---

_Release Notes_: 
None

---

_User Notifications_: 
None