### PR TITLE
SALTO-4036: avoid merge errors on collision in zendesk

### DIFF
--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -87,7 +87,7 @@ import automationOrderFilter from './filters/reorder/automation'
 import triggerOrderFilter from './filters/reorder/trigger'
 import viewOrderFilter from './filters/reorder/view'
 import businessHoursScheduleFilter from './filters/business_hours_schedule'
-import collisionErrorsFilter from './filters/collision_errors'
+import omitCollisionFilter from './filters/omit_collision'
 import accountSettingsFilter from './filters/account_settings'
 import ticketFieldFilter from './filters/custom_field_options/ticket_field'
 import userFieldFilter from './filters/custom_field_options/user_field'
@@ -254,7 +254,7 @@ export const DEFAULT_FILTERS = [
   // handleIdenticalAttachmentConflicts needs to be before collisionErrorsFilter and after referencedIdFieldsFilter
   // and articleBodyFilter
   handleIdenticalAttachmentConflicts,
-  collisionErrorsFilter, // needs to be after referencedIdFieldsFilter (which is part of the common filters)
+  omitCollisionFilter, // needs to be after referencedIdFieldsFilter (which is part of the common filters)
   deployBrandedGuideTypesFilter,
   guideArrangePaths,
   hideAccountFeatures,

--- a/packages/zendesk-adapter/src/filters/omit_collision.ts
+++ b/packages/zendesk-adapter/src/filters/omit_collision.ts
@@ -41,12 +41,13 @@ const removeChildElements = (elements: Element[], collidingElements: InstanceEle
 
 
 /**
- * Adds collision warnings
+ * Adds collision warnings and remove colliding elements and their children
  */
 const filterCreator: FilterCreator = ({ config }) => ({
-  name: 'collisionErrorsFilter',
+  name: 'omitCollisionsFilter',
   onFetch: async (elements: Element[]) => {
     const collidingElements = getInstancesWithCollidingElemID(elements.filter(isInstanceElement))
+    const collidingElemIds = new Set(collidingElements.map(elem => elem.elemID.getFullName()))
     removeChildElements(elements, collidingElements)
     const collisionWarnings = await getAndLogCollisionWarnings({
       adapterName: ZENDESK,
@@ -63,6 +64,7 @@ const filterCreator: FilterCreator = ({ config }) => ({
       docsUrl: 'https://help.salto.io/en/articles/6927157-salto-id-collisions',
       addChildrenMessage: true,
     })
+    _.remove(elements, e => collidingElemIds.has(e.elemID.getFullName()))
     return { errors: collisionWarnings }
   },
 })

--- a/packages/zendesk-adapter/src/filters/omit_collision.ts
+++ b/packages/zendesk-adapter/src/filters/omit_collision.ts
@@ -54,7 +54,6 @@ const filterCreator: FilterCreator = ({ config }) => ({
       configurationName: 'service',
       instances: collidingElements,
       getTypeName: async instance => instance.elemID.typeName,
-      // TODO fix it to use apiName once we have apiName
       getInstanceName: async instance => instance.elemID.name,
       getIdFieldsByType: typeName => configUtils.getConfigWithDefault(
         config[API_DEFINITIONS_CONFIG].types[typeName]?.transformation,

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -468,8 +468,6 @@ describe('adapter', () => {
           'zendesk.ticket_field.instance.Description_description',
           'zendesk.ticket_field.instance.Group_group',
           'zendesk.ticket_field.instance.Priority_priority',
-          'zendesk.ticket_field.instance.Product_components_multiselect@su',
-          'zendesk.ticket_field.instance.Product_components_multiselect@su', // intentional dup
           'zendesk.ticket_field.instance.Status_status',
           'zendesk.ticket_field.instance.Subject_subject',
           'zendesk.ticket_field.instance.Type_tickettype',
@@ -481,10 +479,6 @@ describe('adapter', () => {
           'zendesk.ticket_field__custom_field_options.instance.Customer_Tier_multiselect_su__enterprise@uumuu',
           'zendesk.ticket_field__custom_field_options.instance.Customer_Tier_multiselect_su__free@uumuu',
           'zendesk.ticket_field__custom_field_options.instance.Customer_Tier_multiselect_su__paying@uumuu',
-          'zendesk.ticket_field__custom_field_options.instance.Product_components_multiselect_su__component_a@uumuuu',
-          'zendesk.ticket_field__custom_field_options.instance.Product_components_multiselect_su__component_a@uumuuu', // intentional dup
-          'zendesk.ticket_field__custom_field_options.instance.Product_components_multiselect_su__component_b@uumuuu',
-          'zendesk.ticket_field__custom_field_options.instance.Product_components_multiselect_su__component_b@uumuuu', // intentional dup
           'zendesk.ticket_field__custom_field_options.instance.agent_dropdown_643_for_agent_multiselect_ssssu__v1@uuuuumuu',
           'zendesk.ticket_field__custom_field_options.instance.agent_dropdown_643_for_agent_multiselect_ssssu__v2_modified@uuuuumuuu',
           'zendesk.ticket_field__system_field_options',
@@ -1010,8 +1004,6 @@ describe('adapter', () => {
           'zendesk.ticket_field.instance.Description_description',
           'zendesk.ticket_field.instance.Group_group',
           'zendesk.ticket_field.instance.Priority_priority',
-          'zendesk.ticket_field.instance.Product_components_multiselect@su',
-          'zendesk.ticket_field.instance.Product_components_multiselect@su', // intentional dup
           'zendesk.ticket_field.instance.Status_status',
           'zendesk.ticket_field.instance.Subject_subject',
           'zendesk.ticket_field.instance.Type_tickettype',
@@ -1023,10 +1015,6 @@ describe('adapter', () => {
           'zendesk.ticket_field__custom_field_options.instance.Customer_Tier_multiselect_su__enterprise@uumuu',
           'zendesk.ticket_field__custom_field_options.instance.Customer_Tier_multiselect_su__free@uumuu',
           'zendesk.ticket_field__custom_field_options.instance.Customer_Tier_multiselect_su__paying@uumuu',
-          'zendesk.ticket_field__custom_field_options.instance.Product_components_multiselect_su__component_a@uumuuu',
-          'zendesk.ticket_field__custom_field_options.instance.Product_components_multiselect_su__component_a@uumuuu', // intentional dup
-          'zendesk.ticket_field__custom_field_options.instance.Product_components_multiselect_su__component_b@uumuuu',
-          'zendesk.ticket_field__custom_field_options.instance.Product_components_multiselect_su__component_b@uumuuu', // intentional dup
           'zendesk.ticket_field__custom_field_options.instance.agent_dropdown_643_for_agent_multiselect_ssssu__v1@uuuuumuu',
           'zendesk.ticket_field__custom_field_options.instance.agent_dropdown_643_for_agent_multiselect_ssssu__v2_modified@uuuuumuuu',
           'zendesk.ticket_field__system_field_options',

--- a/packages/zendesk-adapter/test/filters/omit_collision.test.ts
+++ b/packages/zendesk-adapter/test/filters/omit_collision.test.ts
@@ -63,13 +63,11 @@ Alternatively, you can exclude obj from the service configuration in zendesk.nac
 
 Learn more at: https://help.salto.io/en/articles/6927157-salto-id-collisions`,
       })
-      expect(elements).toEqual([differentInst])
     })
     it('should return no errors if there were no collisions', async () => {
       const elements = [inst, differentInst]
       const filterResult = await filter.onFetch(elements) as FilterResult
       expect(filterResult.errors).toHaveLength(0)
-      expect(elements).toEqual([inst, differentInst])
     })
     it('should remove child element on collision', async () => {
       const elements = [inst, collidedInst, differentInst, childInst1]
@@ -82,6 +80,18 @@ Learn more at: https://help.salto.io/en/articles/6927157-salto-id-collisions`,
       const filterResult = await filter.onFetch(elements) as FilterResult
       expect(filterResult.errors).toHaveLength(0)
       expect(elements).toEqual([inst, differentInst, childInst1])
+    })
+    it('should omit colliding elements if there is a collision', async () => {
+      const elements = [inst, collidedInst, differentInst]
+      const filterResult = await filter.onFetch(elements) as FilterResult
+      expect(filterResult.errors).toHaveLength(1)
+      expect(elements).toEqual([differentInst])
+    })
+    it('should not remove elements if there were no collisions', async () => {
+      const elements = [inst, differentInst]
+      const filterResult = await filter.onFetch(elements) as FilterResult
+      expect(filterResult.errors).toHaveLength(0)
+      expect(elements).toEqual([inst, differentInst])
     })
   })
 })


### PR DESCRIPTION
avoid merge errors on collision in zendesk

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* remove merge errors on collision of elemIds

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
