### PR TITLE
SALTO-5035: Deploy Assets attributes

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -149,6 +149,7 @@ import scriptRunnerListenersDeployFilter from './filters/script_runner/script_ru
 import scriptedFragmentsDeployFilter from './filters/script_runner/scripted_fragments_deploy'
 import fetchJsmTypesFilter from './filters/jsm_types_fetch_filter'
 import assetsInstancesAdditionFilter from './filters/assets/assets_instances_addition'
+import deployAttributesFilter from './filters/assets/attribute_deploy_filter'
 import deployJsmTypesFilter from './filters/jsm_types_deploy_filter'
 import jsmPathFilter from './filters/jsm_paths'
 import portalSettingsFilter from './filters/portal_settings'
@@ -337,6 +338,7 @@ export const DEFAULT_FILTERS = [
   requestTypeFilter,
   // Must run before asstesDeployFilter
   assetsInstancesAdditionFilter,
+  deployAttributesFilter,
   deployJsmTypesFilter,
   // Must be done after JsmTypesFilter
   jsmPathFilter,

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -2245,6 +2245,9 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
   AssetsObjectTypes: {
     request: {
       url: '/gateway/api/jsm/assets/workspace/{workspaceId}/v1/objectschema/{AssetsSchemaId}/objecttypes/flat',
+      queryParams: {
+        includeObjectCounts: 'true',
+      },
     },
     transformation: {
       dataField: '.',
@@ -2261,7 +2264,6 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
         { fieldName: 'created' },
         { fieldName: 'updated' },
         { fieldName: 'globalId' },
-        { fieldName: 'objectCount' },
         { fieldName: 'objectSchemaId' },
         { fieldName: 'workspaceId' },
       ],
@@ -2271,10 +2273,12 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       add: {
         url: '/gateway/api/jsm/assets/workspace/{workspaceId}/v1/objecttype/create',
         method: 'post',
+        fieldsToIgnore: ['objectCount'],
       },
       modify: {
         url: '/gateway/api/jsm/assets/workspace/{workspaceId}/v1/objecttype/{id}',
         method: 'put',
+        fieldsToIgnore: ['objectCount'],
       },
       remove: {
         url: '/gateway/api/jsm/assets/workspace/{workspaceId}/v1/objecttype/{id}',
@@ -2300,7 +2304,27 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       ],
       fieldsToOmit: [
         { fieldName: 'globalId' },
+        { fieldName: 'system' },
+        { fieldName: 'referenceObjectType' }, // API returns referenceObjectTypeId as well.
       ],
+      fieldTypeOverrides: [
+        { fieldName: 'typeValue', fieldType: 'string' },
+      ],
+    },
+    deployRequests: {
+      add: {
+        url: '/gateway/api/jsm/assets/workspace/{workspaceId}/v1/objecttypeattribute/{objectType}',
+        method: 'post',
+      },
+      modify: {
+        url: '/gateway/api/jsm/assets/workspace/{workspaceId}/v1/objecttypeattribute/{objectType}/{id}',
+        method: 'put',
+      },
+      remove: {
+        url: '/gateway/api/jsm/assets/workspace/{workspaceId}/v1//objecttypeattribute/{id}',
+        method: 'delete',
+        omitRequestBody: true,
+      },
     },
   },
 }

--- a/packages/jira-adapter/src/filters/assets/attribute_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/assets/attribute_deploy_filter.ts
@@ -1,0 +1,80 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { config as configUtils } from '@salto-io/adapter-components'
+import { Change, DeployResult, InstanceElement, getChangeData, isAdditionOrModificationChange, isInstanceChange } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { defaultDeployChange, deployChanges } from '../../deployment/standard_deployment'
+import { FilterCreator } from '../../filter'
+import { ASSETS_ATTRIBUTE_TYPE } from '../../constants'
+import { getWorkspaceId } from '../../workspace_id'
+import JiraClient from '../../client/client'
+
+
+const deployAttributeChanges = async (
+  jsmApiDefinitions: configUtils.AdapterDuckTypeApiConfig,
+  changes: Change<InstanceElement>[],
+  client: JiraClient):
+  Promise<Omit<DeployResult, 'extraProperties'>> => {
+  const workspaceId = await getWorkspaceId(client)
+  const additionalUrlVars = workspaceId ? { workspaceId } : undefined
+  return deployChanges(
+    changes,
+    async change => {
+      const instance = getChangeData(change)
+      await defaultDeployChange({
+        change,
+        client,
+        apiDefinitions: jsmApiDefinitions,
+        additionalUrlVars,
+      })
+      if (isAdditionOrModificationChange(change)) {
+        const data = _.omit(instance.value, ['objectType', 'typeValue'])
+        const url = `gateway/api/jsm/assets/workspace/${workspaceId}/v1/objecttypeattribute/${instance.value.id}/configure`
+        await client.put({
+          url,
+          data,
+        })
+      }
+    }
+  )
+}
+
+const filter: FilterCreator = ({ config, client }) => ({
+  name: 'deployAttributesFilter',
+  deploy: async changes => {
+    const { jsmApiDefinitions } = config
+    if (!config.fetch.enableJSM || !config.fetch.enableJsmExperimental || jsmApiDefinitions === undefined) {
+      return {
+        deployResult: { appliedChanges: [], errors: [] },
+        leftoverChanges: changes,
+      }
+    }
+    const [attributesChanges, leftoverChanges] = _.partition(
+      changes,
+      (change): change is Change<InstanceElement> => isInstanceChange(change)
+      && getChangeData(change).elemID.typeName === ASSETS_ATTRIBUTE_TYPE
+    )
+    const deployResult = await deployAttributeChanges(jsmApiDefinitions, attributesChanges, client)
+
+    return {
+      leftoverChanges,
+      deployResult,
+    }
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/src/filters/assets/attribute_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/assets/attribute_deploy_filter.ts
@@ -16,7 +16,7 @@
 
 import { config as configUtils } from '@salto-io/adapter-components'
 import { logger } from '@salto-io/logging'
-import { Change, DeployResult, InstanceElement, SaltoElementError, SaltoError, createSaltoElementError, getChangeData, isAdditionOrModificationChange, isInstanceChange } from '@salto-io/adapter-api'
+import { Change, DeployResult, InstanceElement, createSaltoElementError, getChangeData, isAdditionOrModificationChange, isInstanceChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { defaultDeployChange, deployChanges } from '../../deployment/standard_deployment'
 import { FilterCreator } from '../../filter'

--- a/packages/jira-adapter/src/filters/change_jsm_fields.ts
+++ b/packages/jira-adapter/src/filters/change_jsm_fields.ts
@@ -29,6 +29,7 @@ const OBJECT_RESPONSE_SCHEME = Joi.object({
 
 const isObjectWithId = createSchemeGuard<ObjectWithId>(OBJECT_RESPONSE_SCHEME)
 
+/* This filter modifies JSM object fields to ensure compatibility with their deployment requirements. */
 const filter: FilterCreator = () => ({
   name: 'changeJSMElementsFieldFilter',
   onFetch: async elements => {

--- a/packages/jira-adapter/src/filters/change_jsm_fields.ts
+++ b/packages/jira-adapter/src/filters/change_jsm_fields.ts
@@ -18,7 +18,7 @@ import { isInstanceElement } from '@salto-io/adapter-api'
 import Joi from 'joi'
 import { createSchemeGuard } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../filter'
-import { ASSETS_OBJECT_TYPE, PROJECT_TYPE, SERVICE_DESK } from '../constants'
+import { ASSETS_ATTRIBUTE_TYPE, ASSETS_OBJECT_TYPE, PROJECT_TYPE, SERVICE_DESK } from '../constants'
 
 type ObjectWithId = {
   id: number
@@ -48,6 +48,18 @@ const filter: FilterCreator = () => ({
       .forEach(instance => {
         instance.value.iconId = isObjectWithId(instance.value.icon) ? instance.value.icon.id : instance.value.icon
         delete instance.value.icon
+      })
+
+    instanceElements
+      .filter(e => e.elemID.typeName === ASSETS_ATTRIBUTE_TYPE)
+      .forEach(instance => {
+        instance.value.defaultTypeId = isObjectWithId(instance.value.defaultType) ? instance.value.defaultType.id : -1
+        delete instance.value.defaultType
+        instance.value.additionalValue = isObjectWithId(instance.value.referenceType)
+          ? instance.value.referenceType.id : undefined
+        delete instance.value.referenceType
+        instance.value.typeValue = instance.value.referenceObjectTypeId
+        delete instance.value.referenceObjectTypeId
       })
   },
 })

--- a/packages/jira-adapter/src/filters/jsm_types_fetch_filter.ts
+++ b/packages/jira-adapter/src/filters/jsm_types_fetch_filter.ts
@@ -17,7 +17,7 @@
 
 import { isObjectType, CORE_ANNOTATIONS, isInstanceElement } from '@salto-io/adapter-api'
 import { FilterCreator } from '../filter'
-import { ASSESTS_SCHEMA_TYPE, ASSETS_OBJECT_TYPE, ASSETS_STATUS_TYPE, CALENDAR_TYPE, CUSTOMER_PERMISSIONS_TYPE, PORTAL_GROUP_TYPE, PORTAL_SETTINGS_TYPE_NAME, QUEUE_TYPE, REQUEST_TYPE_NAME, SLA_TYPE_NAME } from '../constants'
+import { ASSESTS_SCHEMA_TYPE, ASSETS_ATTRIBUTE_TYPE, ASSETS_OBJECT_TYPE, ASSETS_STATUS_TYPE, CALENDAR_TYPE, CUSTOMER_PERMISSIONS_TYPE, PORTAL_GROUP_TYPE, PORTAL_SETTINGS_TYPE_NAME, QUEUE_TYPE, REQUEST_TYPE_NAME, SLA_TYPE_NAME } from '../constants'
 import { setTypeDeploymentAnnotations, addAnnotationRecursively } from '../utils'
 
 
@@ -35,6 +35,7 @@ const assetsSupportedTypes = [
   ASSESTS_SCHEMA_TYPE,
   ASSETS_STATUS_TYPE,
   ASSETS_OBJECT_TYPE,
+  ASSETS_ATTRIBUTE_TYPE,
 ]
 
 const filterCreator: FilterCreator = ({ config }) => ({

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -1007,6 +1007,12 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     jiraMissingRefStrategy: 'typeAndValue',
     target: { type: ASSETS_OBJECT_TYPE },
   },
+  {
+    src: { field: 'typeValue', parentTypes: [ASSETS_ATTRIBUTE_TYPE] },
+    serializationStrategy: 'id',
+    jiraMissingRefStrategy: 'typeAndValue',
+    target: { type: ASSETS_OBJECT_TYPE },
+  },
 ]
 
 const lookupNameFuncs: GetLookupNameFunc[] = [

--- a/packages/jira-adapter/test/filters/assets/attribute_deploy_filter.test.ts
+++ b/packages/jira-adapter/test/filters/assets/attribute_deploy_filter.test.ts
@@ -1,0 +1,145 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
+import _ from 'lodash'
+import { BuiltinTypes, ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { MockInterface } from '@salto-io/test-utils'
+import { getDefaultConfig } from '../../../src/config/config'
+import deployAttributesFilter from '../../../src/filters/assets/attribute_deploy_filter'
+import { createEmptyType, getFilterParams, mockClient } from '../../utils'
+import { ASSETS_ATTRIBUTE_TYPE, ASSETS_OBJECT_TYPE, JIRA } from '../../../src/constants'
+import JiraClient from '../../../src/client/client'
+
+
+describe('deployAttributesFilter', () => {
+  type FilterType = filterUtils.FilterWith<'deploy'>
+  let filter: FilterType
+  let client: JiraClient
+  let connection: MockInterface<clientUtils.APIConnection>
+  const assetsObjectTypeInstance = new InstanceElement(
+    'assetsObjectType',
+    createEmptyType(ASSETS_OBJECT_TYPE),
+    {
+      id: '11111',
+      name: 'AssetsObjectType',
+    },
+  )
+  const attributeType = new ObjectType({
+    elemID: new ElemID(JIRA, ASSETS_ATTRIBUTE_TYPE),
+    fields: {
+      objectType: { refType: BuiltinTypes.STRING },
+    },
+  })
+  let attributesInstance: InstanceElement
+  describe('deploy', () => {
+    beforeEach(() => {
+      const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+      config.fetch.enableJSM = true
+      config.fetch.enableJsmExperimental = true
+      const { client: cli, connection: conn } = mockClient(false)
+      client = cli
+      connection = conn
+      filter = deployAttributesFilter(getFilterParams({ config, client })) as typeof filter
+      attributesInstance = new InstanceElement(
+        'attributesInstance',
+        attributeType,
+        {
+          id: '11',
+          name: 'attributesInstance',
+          objectType: new ReferenceExpression(assetsObjectTypeInstance.elemID, assetsObjectTypeInstance),
+          type: 0,
+          defaultTypeId: 0,
+          description: 'description',
+          uniqueAttribute: false,
+        },
+      )
+      connection.get.mockImplementation(async url => {
+        if (url === '/rest/servicedeskapi/assets/workspace') {
+          return {
+            status: 200,
+            data: {
+              values: [
+                {
+                  workspaceId: 'workspaceId',
+                },
+              ],
+            },
+          }
+        }
+        throw new Error('Unexpected url')
+      })
+      connection.post.mockImplementation(async url => {
+        if (url === '/gateway/api/jsm/assets/workspace/workspaceId/v1/objecttypeattribute/11111') {
+          return { status: 200, data: {} }
+        }
+        throw new Error('Unexpected url')
+      })
+      connection.put.mockResolvedValueOnce({ status: 200, data: {} })
+    })
+    it('should add attribute', async () => {
+      const changes = [toChange({ after: attributesInstance })]
+      const res = await filter.deploy(changes)
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.deployResult.appliedChanges).toHaveLength(1)
+      expect(connection.post).toHaveBeenCalledTimes(1)
+      expect(connection.put).toHaveBeenCalledTimes(1)
+    })
+    it('should modify attribute when chaning values for first api', async () => {
+      const attributesInstanceAfter = attributesInstance.clone()
+      attributesInstanceAfter.value.description = 'new description'
+      const changes = [toChange({ before: attributesInstance, after: attributesInstanceAfter })]
+      const res = await filter.deploy(changes)
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.deployResult.appliedChanges).toHaveLength(1)
+      expect(connection.post).toHaveBeenCalledTimes(0)
+      expect(connection.put).toHaveBeenCalledTimes(2)
+    })
+    it('should modify attribute when chaning values for second api', async () => {
+      const attributesInstanceAfter = attributesInstance.clone()
+      attributesInstanceAfter.value.uniqueAttribute = true
+      const changes = [toChange({ before: attributesInstance, after: attributesInstanceAfter })]
+      const res = await filter.deploy(changes)
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.deployResult.appliedChanges).toHaveLength(1)
+      expect(connection.post).toHaveBeenCalledTimes(0)
+      expect(connection.put).toHaveBeenCalledTimes(2)
+    })
+    it('should remove attribute', async () => {
+      const changes = [toChange({ before: attributesInstance })]
+      const res = await filter.deploy(changes)
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.deployResult.appliedChanges).toHaveLength(1)
+      expect(connection.post).toHaveBeenCalledTimes(0)
+      expect(connection.put).toHaveBeenCalledTimes(0)
+      expect(connection.delete).toHaveBeenCalledTimes(1)
+    })
+    it('should return error when workspaceId is not found', async () => {
+      connection.get.mockResolvedValueOnce({ status: 200, data: { values: [] } })
+      const changes = [toChange({ after: attributesInstance })]
+      const res = await filter.deploy(changes)
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toHaveLength(1)
+      expect(res.deployResult.appliedChanges).toHaveLength(0)
+      expect(connection.post).toHaveBeenCalledTimes(1)
+      expect(connection.put).toHaveBeenCalledTimes(0)
+    })
+  })
+})

--- a/packages/jira-adapter/test/filters/assets/attribute_deploy_filter.test.ts
+++ b/packages/jira-adapter/test/filters/assets/attribute_deploy_filter.test.ts
@@ -99,7 +99,7 @@ describe('deployAttributesFilter', () => {
       expect(connection.post).toHaveBeenCalledTimes(1)
       expect(connection.put).toHaveBeenCalledTimes(1)
     })
-    it('should modify attribute when chaning values for first api', async () => {
+    it('should modify attribute when changing values for first api', async () => {
       const attributesInstanceAfter = attributesInstance.clone()
       attributesInstanceAfter.value.description = 'new description'
       const changes = [toChange({ before: attributesInstance, after: attributesInstanceAfter })]
@@ -110,7 +110,7 @@ describe('deployAttributesFilter', () => {
       expect(connection.post).toHaveBeenCalledTimes(0)
       expect(connection.put).toHaveBeenCalledTimes(2)
     })
-    it('should modify attribute when chaning values for second api', async () => {
+    it('should modify attribute when changing values for second api', async () => {
       const attributesInstanceAfter = attributesInstance.clone()
       attributesInstanceAfter.value.uniqueAttribute = true
       const changes = [toChange({ before: attributesInstance, after: attributesInstanceAfter })]
@@ -131,14 +131,14 @@ describe('deployAttributesFilter', () => {
       expect(connection.put).toHaveBeenCalledTimes(0)
       expect(connection.delete).toHaveBeenCalledTimes(1)
     })
-    it('should return error when workspaceId is not found', async () => {
+    it('should return error when workspaceId is undefined', async () => {
       connection.get.mockResolvedValueOnce({ status: 200, data: { values: [] } })
       const changes = [toChange({ after: attributesInstance })]
       const res = await filter.deploy(changes)
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(1)
       expect(res.deployResult.appliedChanges).toHaveLength(0)
-      expect(connection.post).toHaveBeenCalledTimes(1)
+      expect(connection.post).toHaveBeenCalledTimes(0)
       expect(connection.put).toHaveBeenCalledTimes(0)
     })
   })

--- a/packages/jira-adapter/test/filters/change_jsm_fields.test.ts
+++ b/packages/jira-adapter/test/filters/change_jsm_fields.test.ts
@@ -16,14 +16,15 @@
 
 import { InstanceElement } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
-import { ASSETS_OBJECT_TYPE, PROJECT_TYPE, SERVICE_DESK } from '../../src/constants'
+import { ASSETS_ATTRIBUTE_TYPE, ASSETS_OBJECT_TYPE, PROJECT_TYPE, SERVICE_DESK } from '../../src/constants'
 import { createEmptyType, getFilterParams } from '../utils'
 import changeJSMElementsFieldFilter from '../../src/filters/change_jsm_fields'
 
 describe('changeJSMElementsFieldFilter', () => {
     type FilterType = filterUtils.FilterWith<'onFetch'>
     let filter: FilterType
-    let AssetsObjectTypeInstance: InstanceElement
+    let assetsObjectTypeInstance: InstanceElement
+    let assetsAttributeInstance: InstanceElement
     let elements: InstanceElement[]
     const projectInstance = new InstanceElement(
       'project1',
@@ -39,7 +40,7 @@ describe('changeJSMElementsFieldFilter', () => {
     )
 
     beforeEach(() => {
-      AssetsObjectTypeInstance = new InstanceElement(
+      assetsObjectTypeInstance = new InstanceElement(
         'assetsObjectType',
         createEmptyType(ASSETS_OBJECT_TYPE),
         {
@@ -50,7 +51,22 @@ describe('changeJSMElementsFieldFilter', () => {
           },
         },
       )
-      elements = [projectInstance, AssetsObjectTypeInstance]
+      assetsAttributeInstance = new InstanceElement(
+        'assetsAttribute',
+        createEmptyType(ASSETS_ATTRIBUTE_TYPE),
+        {
+          id: '11111',
+          name: 'AssetsAttribute',
+          defaultType: {
+            id: '1',
+          },
+          referenceType: {
+            id: '5',
+          },
+          referenceObjectTypeId: '6',
+        },
+      )
+      elements = [projectInstance, assetsObjectTypeInstance, assetsAttributeInstance]
     })
     it('should change service desk Id from object to string', async () => {
       filter = changeJSMElementsFieldFilter(getFilterParams({})) as typeof filter
@@ -65,14 +81,14 @@ describe('changeJSMElementsFieldFilter', () => {
     it('should change icon Id from object to string', async () => {
       filter = changeJSMElementsFieldFilter(getFilterParams({})) as typeof filter
       await filter.onFetch(elements)
-      expect(AssetsObjectTypeInstance.value).toEqual({
+      expect(assetsObjectTypeInstance.value).toEqual({
         id: '11111',
         name: 'AssetsObjectType',
         iconId: '12345',
       })
     })
-    it('should not change icon Id  if icon isnt an object', async () => {
-      AssetsObjectTypeInstance = new InstanceElement(
+    it('should not change icon Id if icon isnt an object', async () => {
+      assetsObjectTypeInstance = new InstanceElement(
         'assetsObjectType',
         createEmptyType(ASSETS_OBJECT_TYPE),
         {
@@ -81,13 +97,38 @@ describe('changeJSMElementsFieldFilter', () => {
           icon: '12345',
         },
       )
-      elements = [projectInstance, AssetsObjectTypeInstance]
+      elements = [projectInstance, assetsObjectTypeInstance]
       filter = changeJSMElementsFieldFilter(getFilterParams({})) as typeof filter
       await filter.onFetch(elements)
-      expect(AssetsObjectTypeInstance.value).toEqual({
+      expect(assetsObjectTypeInstance.value).toEqual({
         id: '11111',
         name: 'AssetsObjectType',
         iconId: '12345',
       })
+    })
+    it('should change defaultTypeId, additionalValue and typeValue from object to string', async () => {
+      filter = changeJSMElementsFieldFilter(getFilterParams({})) as typeof filter
+      await filter.onFetch(elements)
+      expect(assetsAttributeInstance.value).toEqual({
+        id: '11111',
+        name: 'AssetsAttribute',
+        defaultTypeId: '1',
+        additionalValue: '5',
+        typeValue: '6',
+      })
+    })
+    it('should change defualtTypeId to -1 if defualtType isnt an object', async () => {
+      assetsAttributeInstance.value.defaultType = '1'
+      elements = [projectInstance, assetsAttributeInstance]
+      filter = changeJSMElementsFieldFilter(getFilterParams({})) as typeof filter
+      await filter.onFetch(elements)
+      expect(assetsAttributeInstance.value.defaultTypeId).toEqual(-1)
+    })
+    it('should change additionalValue to undefined if referenceType isnt an object', async () => {
+      assetsAttributeInstance.value.referenceType = '1'
+      elements = [projectInstance, assetsAttributeInstance]
+      filter = changeJSMElementsFieldFilter(getFilterParams({})) as typeof filter
+      await filter.onFetch(elements)
+      expect(assetsAttributeInstance.value.additionalValue).toBeUndefined()
     })
 })


### PR DESCRIPTION
In this PR I support deployment of attributes. 

---

_Additional context for reviewer_
Still need to add 2 CV:
1. CV that checks that I don't delete default attribute.
2. CV that checks that I don't modify typeValue while it has objects. 

---
_Release Notes_: 
_Jira Adapter:_
Now supports deployment of attributes. 

---
_User Notifications_: 
None
