### PR TITLE
SALTO-5099: Add cli command to set state content provider

### DIFF
--- a/packages/aws-utils/jest.config.js
+++ b/packages/aws-utils/jest.config.js
@@ -23,10 +23,11 @@ module.exports = deepMerge(
     rootDir: `${__dirname}`,
     collectCoverageFrom: [
       '!<rootDir>/index.ts',
+      '!<rootDir>/src/index.ts',
     ],
     coverageThreshold: {
       global: {
-        branches: 85,
+        branches: 90,
         functions: 65,
         lines: 90,
         statements: 90,

--- a/packages/aws-utils/package.json
+++ b/packages/aws-utils/package.json
@@ -34,6 +34,7 @@
     "@salto-io/logging": "0.3.50"
   },
   "devDependencies": {
+    "@salto-io/test-utils": "0.3.50",
     "@types/jest": "^27.4.0",
     "@types/lodash": "^4.14.168",
     "@types/node": "^12.7.1",

--- a/packages/aws-utils/src/utils.ts
+++ b/packages/aws-utils/src/utils.ts
@@ -32,6 +32,7 @@ export const retryDecider: RetryDecider = error => {
 export const createS3Client = (
   numberOfRetries = NUMBER_OF_RETRIES
 ): AWS.S3 => new AWS.S3({
+  ...process.env.AWS_ENDPOINT_URL === undefined ? {} : { endpoint: process.env.AWS_ENDPOINT_URL, forcePathStyle: true },
   retryStrategy: new StandardRetryStrategy(
     () => Promise.resolve(numberOfRetries),
     { retryDecider }

--- a/packages/aws-utils/test/utils.test.ts
+++ b/packages/aws-utils/test/utils.test.ts
@@ -14,12 +14,28 @@
 * limitations under the License.
 */
 import * as AWS from '@aws-sdk/client-s3'
+import { setupEnvVar } from '@salto-io/test-utils'
 import { createS3Client, retryDecider } from '../src/utils'
 
 describe('utils', () => {
   describe('createS3Client', () => {
     it('should create s3 client', () => {
       expect(createS3Client()).toBeInstanceOf(AWS.S3)
+    })
+    describe('when AWS_ENDPOINT_URL is configured', () => {
+      setupEnvVar('AWS_ENDPOINT_URL', 'http://localhost:4566')
+      it('should configure the endpoint and set forcePathStyle', async () => {
+        const client = createS3Client()
+        expect(client.config.forcePathStyle).toBeTruthy()
+        await expect(client.config.endpoint()).resolves.toMatchObject({ hostname: 'localhost', port: 4566 })
+      })
+    })
+    describe('when AWS_ENDPOINT_URL is not configured', () => {
+      setupEnvVar('AWS_ENDPOINT_URL', undefined)
+      it('should not set forcePathStyle', () => {
+        const client = createS3Client()
+        expect(client.config.forcePathStyle).toBeFalsy()
+      })
     })
   })
   describe('retryDecider', () => {

--- a/packages/aws-utils/tsconfig.json
+++ b/packages/aws-utils/tsconfig.json
@@ -12,5 +12,6 @@
     ],
     "references": [
         { "path": "../logging" },
+        { "path": "../test-utils" },
     ],
 }

--- a/packages/cli/test/commands/workspace.test.ts
+++ b/packages/cli/test/commands/workspace.test.ts
@@ -16,7 +16,7 @@
 import * as core from '@salto-io/core'
 import * as callbacks from '../../src/callbacks'
 import * as mocks from '../mocks'
-import { cleanAction, cacheUpdateAction } from '../../src/commands/workspace'
+import { cleanAction, cacheUpdateAction, setStateProviderAction } from '../../src/commands/workspace'
 import { CliExitCode } from '../../src/types'
 
 
@@ -235,6 +235,74 @@ describe('workspace command group', () => {
       })
       it('should return success', () => {
         expect(result).toEqual(CliExitCode.Success)
+      })
+    })
+  })
+
+  describe('set state provider', () => {
+    const commandName = 'set-state-provider'
+    let cliCommandArgs: mocks.MockCommandArgs
+    let workspace: mocks.MockWorkspace
+    beforeEach(async () => {
+      cliCommandArgs = mocks.mockCliCommandArgs(commandName, cliArgs)
+      workspace = mocks.mockWorkspace({})
+    })
+
+    describe('when provider is undefined', () => {
+      let result: CliExitCode
+      beforeEach(async () => {
+        result = await setStateProviderAction({
+          ...cliCommandArgs,
+          input: {},
+          workspace,
+        })
+      })
+      it('should return success', () => {
+        expect(result).toEqual(CliExitCode.Success)
+      })
+      it('should set the state config to be undefined', () => {
+        expect(workspace.updateStateProvider).toHaveBeenCalledWith(undefined)
+      })
+    })
+
+    describe('when provider is file', () => {
+      it('should set the state config to have a file provider', async () => {
+        const result = await setStateProviderAction({
+          ...cliCommandArgs,
+          input: { provider: 'file' },
+          workspace,
+        })
+        expect(result).toEqual(CliExitCode.Success)
+        expect(workspace.updateStateProvider).toHaveBeenCalledWith({ provider: 'file' })
+      })
+      it('should fail if it gets an unexpected parameter', async () => {
+        const result = await setStateProviderAction({
+          ...cliCommandArgs,
+          input: { provider: 'file', bucket: 'my-bucket' },
+          workspace,
+        })
+        expect(result).toEqual(CliExitCode.UserInputError)
+        expect(workspace.updateStateProvider).not.toHaveBeenCalled()
+      })
+    })
+    describe('when provider is s3', () => {
+      it('should set the state config to have a s3 provider', async () => {
+        const result = await setStateProviderAction({
+          ...cliCommandArgs,
+          input: { provider: 's3', bucket: 'my-bucket' },
+          workspace,
+        })
+        expect(result).toEqual(CliExitCode.Success)
+        expect(workspace.updateStateProvider).toHaveBeenCalledWith({ provider: 's3', options: { s3: { bucket: 'my-bucket' } } })
+      })
+      it('should fail if the bucket argument is missing', async () => {
+        const result = await setStateProviderAction({
+          ...cliCommandArgs,
+          input: { provider: 's3' },
+          workspace,
+        })
+        expect(result).toEqual(CliExitCode.UserInputError)
+        expect(workspace.updateStateProvider).not.toHaveBeenCalled()
       })
     })
   })

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -385,6 +385,7 @@ export const mockWorkspace = ({
     demoteAll: mockFunction<Workspace['demoteAll']>(),
     copyTo: mockFunction<Workspace['copyTo']>(),
     sync: mockFunction<Workspace['sync']>(),
+    updateStateProvider: mockFunction<Workspace['updateStateProvider']>(),
     getValue: mockFunction<Workspace['getValue']>(),
     getSearchableNames: mockFunction<Workspace['getSearchableNames']>(),
     getSearchableNamesOfEnv: mockFunction<Workspace['getSearchableNamesOfEnv']>(),

--- a/packages/core/src/local-workspace/state/state.ts
+++ b/packages/core/src/local-workspace/state/state.ts
@@ -92,6 +92,27 @@ const parseStateContent = async (
   return res
 }
 
+
+export const getStateContentProvider = (
+  workspaceId: string,
+  stateConfig: StateConfig = { provider: 'file' },
+): StateContentProvider => {
+  switch (stateConfig.provider) {
+    case 'file': {
+      return createFileStateContentProvider()
+    }
+    case 's3': {
+      const bucketName = stateConfig.options?.s3?.bucket
+      if (bucketName === undefined) {
+        throw new Error('Missing key "options.s3.bucket" in workspace state configuration')
+      }
+      return createS3StateContentProvider({ workspaceId, bucketName })
+    }
+    default:
+      throw new Error(`Unsupported state provider ${stateConfig.provider}`)
+  }
+}
+
 export const localState = (
   filePrefix: string,
   envName: string,
@@ -104,6 +125,7 @@ export const localState = (
   let cacheDirty = false
   let contentsAndHash: Promise<ContentAndHash[]> | undefined
   let currentFilePrefix = filePrefix
+  let currentContentProvider = contentProvider
 
   const setDirty = (): void => {
     dirty = true
@@ -117,7 +139,7 @@ export const localState = (
     filePaths: string[]
     newHash: string
   }): Promise<void> => {
-    const res = await parseStateContent(contentProvider.readContents(filePaths))
+    const res = await parseStateContent(currentContentProvider.readContents(filePaths))
     await stateData.elements.clear()
     await stateData.elements.setAll(res.elements)
     await stateData.pathIndex.clear()
@@ -150,8 +172,8 @@ export const localState = (
       staticFilesSource,
       persistent,
     )
-    const filePaths = await contentProvider.findStateFiles(currentFilePrefix)
-    const stateFilesHash = await contentProvider.getHash(filePaths)
+    const filePaths = await currentContentProvider.findStateFiles(currentFilePrefix)
+    const stateFilesHash = await currentContentProvider.getHash(filePaths)
     const quickAccessHash = (await quickAccessStateData.saltoMetadata.get('hash')) ?? toMD5(safeJsonStringify([]))
     if (quickAccessHash !== stateFilesHash) {
       log.debug('found different hash - loading state data (quickAccessHash=%s stateFilesHash=%s)', quickAccessHash, stateFilesHash)
@@ -254,7 +276,7 @@ export const localState = (
     rename: async (newPrefix: string): Promise<void> => {
       await Promise.all([
         staticFilesSource.rename(newPrefix),
-        contentProvider.rename(currentFilePrefix, newPrefix),
+        currentContentProvider.rename(currentFilePrefix, newPrefix),
       ])
       currentFilePrefix = newPrefix
       setDirty()
@@ -275,7 +297,7 @@ export const localState = (
         updatedHash,
         Object.fromEntries(contents.map(({ account, contentHash }) => [account, contentHash])),
       )
-      await contentProvider.writeContents(currentFilePrefix, contents)
+      await currentContentProvider.writeContents(currentFilePrefix, contents)
       await inMemState.setVersion(version)
       await inMemState.setHash(updatedHash)
       await inMemState.flush()
@@ -286,7 +308,7 @@ export const localState = (
     calculateHash: calculateHashImpl,
     clear: async (): Promise<void> => {
       await Promise.all([
-        contentProvider.clear(currentFilePrefix),
+        currentContentProvider.clear(currentFilePrefix),
         inMemState.clear(),
       ])
       setDirty()
@@ -299,26 +321,22 @@ export const localState = (
       await inMemState.updateStateFromChanges({ changes, unmergedElements, fetchAccounts })
       setDirty()
     },
-  }
-}
+    updateConfig: async args => {
+      const newProvider = getStateContentProvider(args.workspaceId, args.stateConfig)
+      const contents = await getContentAndHash()
 
-export const getStateContentProvider = (
-  workspaceId: string,
-  stateConfig: StateConfig = { provider: 'file' },
-): StateContentProvider => {
-  switch (stateConfig.provider) {
-    case 'file': {
-      return createFileStateContentProvider()
-    }
-    case 's3': {
-      const bucketName = stateConfig.options?.s3?.bucket
-      if (bucketName === undefined) {
-        throw new Error('Missing key "options.s3.bucket" in workspace state configuration')
-      }
-      return createS3StateContentProvider({ workspaceId, bucketName })
-    }
-    default:
-      throw new Error(`Unsupported state provider ${stateConfig.provider}`)
+      const tempPrefix = path.join(path.dirname(currentFilePrefix), `.tmp_${path.basename(currentFilePrefix)}`)
+      await newProvider.writeContents(tempPrefix, contents)
+
+      // swap the contents from the old provider to the new one
+      // note - we have to clear before we rename in case the providers use the same file names
+      await currentContentProvider.clear(currentFilePrefix)
+      await newProvider.rename(tempPrefix, path.basename(currentFilePrefix))
+
+      currentContentProvider = newProvider
+
+      await inMemState.updateConfig(args)
+    },
   }
 }
 

--- a/packages/core/test/workspace/local/state/content_providers/file_content_provider.test.ts
+++ b/packages/core/test/workspace/local/state/content_providers/file_content_provider.test.ts
@@ -16,7 +16,7 @@
 import path from 'path'
 import getStream from 'get-stream'
 import { collections } from '@salto-io/lowerdash'
-import { setupTestDir } from '@salto-io/test-utils'
+import { setupTmpDir } from '@salto-io/test-utils'
 import { writeFile, readDir } from '@salto-io/file'
 import { createFileStateContentProvider, StateContentProvider } from '../../../../../src/local-workspace/state/content_providers'
 
@@ -27,7 +27,7 @@ describe('createFileStateContentProvider', () => {
   beforeEach(() => {
     provider = createFileStateContentProvider()
   })
-  const testDir = setupTestDir()
+  const testDir = setupTmpDir()
   const accountNames = ['salesforce', 'netsuite', 'dummy']
   const nonStateFiles = ['env.jsonl.zip', 'env.bar.jsonl.zip.not', 'env.json', 'not_env.dummy.jsonl.zip']
   const envPrefix = (): string => path.join(testDir.name(), 'env')

--- a/packages/core/test/workspace/local/state/content_providers/s3_content_provider.test.ts
+++ b/packages/core/test/workspace/local/state/content_providers/s3_content_provider.test.ts
@@ -18,7 +18,7 @@ import path from 'path'
 import { Readable } from 'stream'
 import getStream from 'get-stream'
 import { collections } from '@salto-io/lowerdash'
-import { setupTestDir } from '@salto-io/test-utils'
+import { setupTmpDir } from '@salto-io/test-utils'
 import { writeFile, readDir } from '@salto-io/file'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { GetObjectCommand, NoSuchKey, PutObjectCommandInput, S3Client, ServiceInputTypes, ServiceOutputTypes } from '@aws-sdk/client-s3'
@@ -30,7 +30,7 @@ import { LocalStateFileContent } from '../../../../../src/local-workspace/state/
 const { awu } = collections.asynciterable
 
 describe('createS3StateContentProvider', () => {
-  const testDir = setupTestDir()
+  const testDir = setupTmpDir()
   const accountNames = ['jira', 'dummy']
   const nonStateFiles = ['env.dummy.jsonl.zip', 'nonEnv.dummy.json', 'env.dummy.json.bla']
   const workspaceId = 'ws'

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -16,4 +16,4 @@
 export * from './mock'
 export * from './promise'
 export * from './setup_envvar'
-export * from './setup_testdir'
+export * from './setup_tmpdir'

--- a/packages/test-utils/src/setup_tmpdir.ts
+++ b/packages/test-utils/src/setup_tmpdir.ts
@@ -25,7 +25,7 @@ type TempDir = {
   name: () => string
 }
 
-export const setupTestDir = (
+export const setupTmpDir = (
   setupType: 'each' | 'all' = 'each',
 ): TempDir => {
   const [setupFunc, teardownFunc] = setupType === 'all' ? [beforeAll, afterAll] : [beforeEach, afterEach]

--- a/packages/test-utils/test/setup_tmpdir.test.ts
+++ b/packages/test-utils/test/setup_tmpdir.test.ts
@@ -15,11 +15,11 @@
 */
 import fs from 'fs'
 import path from 'path'
-import { setupTestDir } from '../src/setup_testdir'
+import { setupTmpDir } from '../src/setup_tmpdir'
 
-describe('setupTestDir', () => {
+describe('setupTmpDir', () => {
   describe('when set before all', () => {
-    const testDir = setupTestDir('all')
+    const testDir = setupTmpDir('all')
     let testFileName: string
     it('should create a test dir', async () => {
       expect(testDir.name()).toBeDefined()
@@ -35,7 +35,7 @@ describe('setupTestDir', () => {
     })
   })
   describe('when set to before each', () => {
-    const testDir = setupTestDir()
+    const testDir = setupTmpDir()
     let testFileName: string
     it('should create a test dir', async () => {
       expect(testDir.name()).toBeDefined()

--- a/packages/workspace/src/workspace/state/in_mem.ts
+++ b/packages/workspace/src/workspace/state/in_mem.ts
@@ -202,5 +202,8 @@ export const buildInMemState = (
         await updateStatePathIndex(unmergedElements, removedElementsFullNames)
       }
     },
+    updateConfig: async () => {
+      // Currently there is no configuration that affects this implementation
+    },
   }
 }

--- a/packages/workspace/src/workspace/state/state.ts
+++ b/packages/workspace/src/workspace/state/state.ts
@@ -20,6 +20,7 @@ import { PathIndex, Path } from '../path_index'
 import { RemoteMap, RemoteMapCreator } from '../remote_map'
 import { serialize, deserializeSingleElement } from '../../serializer/elements'
 import { StateStaticFilesSource } from '../static_files/common'
+import { StateConfig } from '../config/workspace_config_types'
 
 export type StateMetadataKey = 'version' | 'hash'
 
@@ -39,6 +40,10 @@ export type StateData = {
   topLevelPathIndex: PathIndex
 }
 
+type UpdateConfigArgs = {
+  workspaceId: string
+  stateConfig: StateConfig | undefined
+}
 export interface State extends ElementsSource {
   set(element: Element): Promise<void>
   remove(id: ElemID): Promise<void>
@@ -51,6 +56,7 @@ export interface State extends ElementsSource {
   calculateHash(): Promise<void>
   getStateSaltoVersion(): Promise<string | undefined>
   updateStateFromChanges(args: UpdateStateElementsArgs): Promise<void>
+  updateConfig(args: UpdateConfigArgs): Promise<void>
 }
 
 

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -21,6 +21,7 @@ import { Element, SaltoError, SaltoElementError, ElemID, InstanceElement, Detail
 import { logger } from '@salto-io/logging'
 import {
   applyDetailedChanges,
+  inspectValue,
   naclCase,
   resolvePath,
   safeJsonStringify,
@@ -37,7 +38,7 @@ import { ElementSelector } from './element_selector'
 import { Errors, AccountDuplicationError, EnvDuplicationError, UnknownEnvError,
   DeleteCurrentEnvError, InvalidEnvNameError, MAX_ENV_NAME_LEN, UnknownAccountError,
   InvalidAccountNameError } from './errors'
-import { EnvConfig } from './config/workspace_config_types'
+import { EnvConfig, StateConfig } from './config/workspace_config_types'
 import { handleHiddenChanges, getElementHiddenParts, isHidden } from './hidden_values'
 import { WorkspaceConfigSource } from './workspace_config_source'
 import { MergeError, mergeElements } from '../merger'
@@ -216,6 +217,7 @@ export type Workspace = {
   deleteEnvironment: (env: string, keepNacls?: boolean) => Promise<void>
   renameEnvironment: (envName: string, newEnvName: string, newSourceName? : string) => Promise<void>
   setCurrentEnv: (env: string, persist?: boolean) => Promise<void>
+  updateStateProvider: (stateConfig: StateConfig | undefined) => Promise<void>
   updateAccountCredentials: (account: string, creds: Readonly<InstanceElement>) => Promise<void>
   // updateServiceCredentials is deprecated, kept for backwards compatibility.
   // use updateAccountCredentials.
@@ -1463,6 +1465,22 @@ export const loadWorkspace = async (
         return 'Valid'
       })()
       return { serviceName: accountName, accountName, status, date }
+    },
+
+    updateStateProvider: async stateConfig => {
+      if (_.isEqual(workspaceConfig.state, stateConfig)) {
+        // The config did not change, nothing to do
+        return
+      }
+      log.debug('Changing state config from %s to %s', inspectValue(workspaceConfig.state), inspectValue(stateConfig))
+      await Promise.all(
+        Object.values(environmentsSources.sources)
+          .map(source => source.state)
+          .filter(values.isDefined)
+          .map(sourceState => sourceState.updateConfig({ workspaceId: workspaceConfig.uid, stateConfig }))
+      )
+      workspaceConfig.state = stateConfig
+      await config.setWorkspaceConfig(workspaceConfig)
     },
     getValue: async (id: ElemID, env?: string): Promise<Value | undefined> => (
       (await elements(env)).get(id)

--- a/packages/workspace/test/common/workspace.ts
+++ b/packages/workspace/test/common/workspace.ts
@@ -14,8 +14,9 @@
 * limitations under the License.
 */
 
-import { Element, Values } from '@salto-io/adapter-api'
+import { Element } from '@salto-io/adapter-api'
 import { MockInterface, mockFunction } from '@salto-io/test-utils'
+import { WorkspaceConfig } from '../../src/workspace/config/workspace_config_types'
 import { Errors } from '../../src/errors'
 import { AdaptersConfigSource } from '../../src/workspace/adapters_config_source'
 import { ConfigSource } from '../../src/workspace/config_source'
@@ -33,8 +34,8 @@ import { createMockNaclFileSource } from './nacl_file_source'
 import { mockDirStore } from './nacl_file_store'
 
 const services = ['salesforce']
-export const mockWorkspaceConfigSource = (conf?: Values,
-  secondaryEnv?: boolean): WorkspaceConfigSource => ({
+export const mockWorkspaceConfigSource = (conf?: Partial<WorkspaceConfig>,
+  secondaryEnv?: boolean): jest.Mocked<WorkspaceConfigSource> => ({
   getWorkspaceConfig: jest.fn().mockImplementation(() => ({
     envs: [
       { name: 'default',

--- a/packages/workspace/test/workspace/state.test.ts
+++ b/packages/workspace/test/workspace/state.test.ts
@@ -332,6 +332,12 @@ describe('state', () => {
         expect(stateStaticFilesSource.delete).toHaveBeenCalledWith(staticFile)
       })
     })
+
+    describe('updateConfig', () => {
+      it('should do nothing', async () => {
+        await expect(state.updateConfig({ workspaceId: '', stateConfig: undefined })).resolves.not.toThrow()
+      })
+    })
   })
 
   describe('non persistent state', () => {

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -25,7 +25,7 @@ import {
   isStaticFile, TemplateExpression,
 } from '@salto-io/adapter-api'
 import { findElement, applyDetailedChanges } from '@salto-io/adapter-utils'
-import { collections } from '@salto-io/lowerdash'
+import { collections, values } from '@salto-io/lowerdash'
 import { MockInterface } from '@salto-io/test-utils'
 import { InvalidValueValidationError, ValidationError } from '../../src/validator'
 import { WorkspaceConfigSource } from '../../src/workspace/workspace_config_source'
@@ -50,7 +50,7 @@ import { DeleteCurrentEnvError, UnknownEnvError, EnvDuplicationError,
 import { MissingStaticFile } from '../../src/workspace/static_files'
 import * as dump from '../../src/parser/dump'
 import { mockDirStore } from '../common/nacl_file_store'
-import { EnvConfig } from '../../src/workspace/config/workspace_config_types'
+import { EnvConfig, StateConfig } from '../../src/workspace/config/workspace_config_types'
 import { resolve } from '../../src/expressions'
 import { createInMemoryElementSource, ElementsSource } from '../../src/workspace/elements_source'
 import { InMemoryRemoteMap, RemoteMapCreator, RemoteMap, CreateRemoteMapParams } from '../../src/workspace/remote_map'
@@ -2047,6 +2047,58 @@ describe('workspace', () => {
       const recency = await ws.getStateRecency('salesforce')
       expect(recency.status).toBe('Nonexistent')
       expect(recency.date).toBe(undefined)
+    })
+  })
+
+  describe('updateStateProvider', () => {
+    let ws: Workspace
+    let stateUpdateConfigFuncs: jest.SpiedFunction<State['updateConfig']>[]
+    let workspaceConfigSrc: jest.Mocked<WorkspaceConfigSource>
+    beforeEach(async () => {
+      const elemSources: Record<string, EnvironmentSource> = {
+        '': { naclFiles: createMockNaclFileSource([]) },
+        default: { naclFiles: createMockNaclFileSource([]), state: createState([]) },
+        inactive: { naclFiles: createMockNaclFileSource([]), state: createState([]) },
+      }
+      stateUpdateConfigFuncs = Object.values(elemSources)
+        .map(({ state }) => state)
+        .filter(values.isDefined)
+        .map(state => jest.spyOn(state, 'updateConfig'))
+      workspaceConfigSrc = mockWorkspaceConfigSource({ uid: 'wsId' }, true)
+      ws = await createWorkspace(
+        undefined,
+        undefined,
+        workspaceConfigSrc,
+        undefined,
+        undefined,
+        undefined,
+        elemSources
+      )
+    })
+
+    describe('when configuration changed', () => {
+      const newStateConfig: StateConfig = {
+        provider: 's3',
+        options: { s3: { bucket: 'my-bucket' } },
+      }
+      beforeEach(async () => {
+        await ws.updateStateProvider(newStateConfig)
+      })
+      it('should set the new configuration in the workspace config', () => {
+        expect(workspaceConfigSrc.setWorkspaceConfig).toHaveBeenCalledWith(
+          expect.objectContaining({ state: newStateConfig })
+        )
+      })
+      it('should update the state config in all env sources', () => {
+        stateUpdateConfigFuncs.forEach(updateFunc => expect(updateFunc).toHaveBeenCalledWith({ workspaceId: 'wsId', stateConfig: newStateConfig }))
+      })
+    })
+    describe('when configuration is the same', () => {
+      it('should not do anything', async () => {
+        await ws.updateStateProvider(undefined)
+        expect(workspaceConfigSrc.setWorkspaceConfig).not.toHaveBeenCalled()
+        stateUpdateConfigFuncs.forEach(updateFunc => expect(updateFunc).not.toHaveBeenCalled())
+      })
     })
   })
 


### PR DESCRIPTION
Added `salto workspace set-state-provider` command
The new command allows configuring the state content provider
It also migrates the current state data from the current provider to the new one

---

_Additional context for reviewer_
Based on #5160 
Ignore the first commit here (review it in the other PR)

---
_Release Notes_: 
CLI:
- Added the option to store state file content in S3 instead of storing it locally, see command `salto workspace set-state-provider`

---
_User Notifications_: 
_None_