### PR TITLE
SALTO-5051: omit inactive instances by default in zendesk

### DIFF
--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -2752,6 +2752,7 @@ export const DEFAULT_CONFIG: ZendeskConfig = {
         fieldsToOmit: FIELDS_TO_OMIT,
         fieldsToHide: FIELDS_TO_HIDE,
         serviceIdField: DEFAULT_SERVICE_ID_FIELD,
+        omitInactive: true,
         // TODO: change this to true for SALTO-3593.
         nestStandaloneInstances: false,
       },

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -134,6 +134,14 @@ describe('adapter', () => {
                   brands: ['.*'],
                 },
               },
+              [API_DEFINITIONS_CONFIG]: {
+                ...DEFAULT_CONFIG[API_DEFINITIONS_CONFIG],
+                typeDefaults: {
+                  transformation: {
+                    omitInactive: false,
+                  },
+                },
+              },
             }
           ),
           elementsSource: buildElementsSourceFromElements([]),
@@ -670,6 +678,14 @@ describe('adapter', () => {
                 ],
                 guide: {
                   brands: ['.*'],
+                },
+              },
+              [API_DEFINITIONS_CONFIG]: {
+                ...DEFAULT_CONFIG[API_DEFINITIONS_CONFIG],
+                typeDefaults: {
+                  transformation: {
+                    omitInactive: false,
+                  },
                 },
               },
             }
@@ -1745,6 +1761,14 @@ describe('adapter', () => {
                   brands: ['.*'],
                 },
               },
+              [API_DEFINITIONS_CONFIG]: {
+                ...DEFAULT_CONFIG[API_DEFINITIONS_CONFIG],
+                typeDefaults: {
+                  transformation: {
+                    omitInactive: false,
+                  },
+                },
+              },
             }
           ),
           elementsSource: buildElementsSourceFromElements([]),
@@ -1788,6 +1812,14 @@ describe('adapter', () => {
                 exclude: [],
                 guide: {
                   brands: ['.*'],
+                },
+              },
+              [API_DEFINITIONS_CONFIG]: {
+                ...DEFAULT_CONFIG[API_DEFINITIONS_CONFIG],
+                typeDefaults: {
+                  transformation: {
+                    omitInactive: false,
+                  },
                 },
               },
             }
@@ -1876,6 +1908,14 @@ describe('adapter', () => {
               exclude: [],
               guide: {
                 brands: ['BestBrand'],
+              },
+            },
+            [API_DEFINITIONS_CONFIG]: {
+              ...DEFAULT_CONFIG[API_DEFINITIONS_CONFIG],
+              typeDefaults: {
+                transformation: {
+                  omitInactive: false,
+                },
               },
             },
           }

--- a/packages/zendesk-adapter/test/change_validators/trigger_category_removal.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/trigger_category_removal.test.ts
@@ -57,6 +57,7 @@ describe('triggerCategoryRemovalValidator', () => {
       { active: false, category_id: triggerCategoryRef }
     )
     apiConfig = DEFAULT_CONFIG[API_DEFINITIONS_CONFIG]
+    apiConfig.typeDefaults.transformation.omitInactive = false
   })
 
   it('should error on removal of a trigger category with active trigger', async () => {

--- a/packages/zendesk-adapter/test/inactive.test.ts
+++ b/packages/zendesk-adapter/test/inactive.test.ts
@@ -65,6 +65,11 @@ describe('omit inactive', () => {
                   omitInactive: true,
                 },
               },
+              view: {
+                transformation: {
+                  omitInactive: false,
+                },
+              },
             },
           },
         }


### PR DESCRIPTION
 omit inactive instances by default in zendesk

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk: 
* inactive instances will be omitted by default

---
_User Notifications_: 
zendesk: 
* inactive instances will be omitted by default
