### PR TITLE
SALTO-5123-Fix forms elemID

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/cloud/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/index.ts
@@ -226,7 +226,7 @@ export const createInstances = (
     { [CORE_ANNOTATIONS.PARENT]: [jsmProject] }
   )
   const form = new InstanceElement(
-    `Support_${randomString}`,
+    `SUP_${randomString}`,
     findType(FORM_TYPE, fetchedElements),
     createFormValues(randomString),
     undefined,

--- a/packages/jira-adapter/src/filters/forms/forms.ts
+++ b/packages/jira-adapter/src/filters/forms/forms.ts
@@ -16,7 +16,7 @@
 
 import { CORE_ANNOTATIONS, Change, InstanceElement, ReferenceExpression, getChangeData, isAdditionChange, isAdditionOrModificationChange, isInstanceChange, isInstanceElement } from '@salto-io/adapter-api'
 import { values as lowerDashValues } from '@salto-io/lowerdash'
-import { getParent, pathNaclCase } from '@salto-io/adapter-utils'
+import { getParent, naclCase, pathNaclCase } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { FilterCreator } from '../../filter'
 import { FORM_TYPE, JSM_DUCKTYPE_API_DEFINITIONS, PROJECT_TYPE, SERVICE_DESK } from '../../constants'
@@ -100,7 +100,7 @@ const filter: FilterCreator = ({ config, client, fetchQuery }) => ({
             if (!isDetailedFormsResponse(detailedRes.data)) {
               return undefined
             }
-            const name = `${project.value.name}_${formResponse.name}`
+            const name = naclCase(`${project.value.key}_${formResponse.name}`)
             const formValue = detailedRes.data
             const parentPath = project.path ?? []
             const jsmDuckTypeApiDefinitions = config[JSM_DUCKTYPE_API_DEFINITIONS]


### PR DESCRIPTION
In this PR I fixed forms elemID and modified the e2e 
---

_Additional context for reviewer_
None

---
_Release Notes_: 
_Jira Adpater:_
Change forms elemID

---
_User Notifications_: 
_Jira Adapter:_
To change the current elemID, customers must perform a fetch --regenerate command. This will change the forms elemID, which may cause some disruptions