### PR TITLE
SALTO-6125: exclude ServerInformation in Jira

### DIFF
--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -2368,7 +2368,6 @@ const SUPPORTED_TYPES = {
   StatusCategory: ['StatusCategories'],
   Workflow: ['Workflows'],
   WorkflowScheme: ['WorkflowSchemes'],
-  ServerInformation: ['ServerInformation'],
   Board: ['Boards'],
   Group: ['Groups'],
   Automation: [],

--- a/packages/jira-adapter/system_config_doc.md
+++ b/packages/jira-adapter/system_config_doc.md
@@ -2265,9 +2265,6 @@ jira {
       WorkflowScheme = [
         "WorkflowSchemes",
       ]
-      ServerInformation = [
-        "ServerInformation",
-      ]
       Board = [
         "Boards",
       ]


### PR DESCRIPTION
exclude ServerInformation in Jira

---

When switching to the updated adapter swaggers, this type is suddenly added because it's in Jira's supported type list, but it was not fetched before for some reason. We should exclude it to avoid noise when switching to the updated swaggers

---
_Release Notes_: 
None

---
_User Notifications_: 
None
