### PR TITLE
SALTO-4744: add important values to all object types in dummy

### DIFF
--- a/packages/dummy-adapter/src/adapter_creator.ts
+++ b/packages/dummy-adapter/src/adapter_creator.ts
@@ -35,6 +35,7 @@ export const configType = new ObjectType({
     fieldsToOmitOnDeploy: { refType: new ListType(BuiltinTypes.STRING) },
     // Exclude elements from the fetch by their elemIDs
     elementsToExclude: { refType: new ListType(BuiltinTypes.STRING) },
+    importantValuesFreq: { refType: new ListType(BuiltinTypes.NUMBER) },
   },
 })
 

--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -165,7 +165,7 @@ export type GeneratorParams = {
     generateEnvName? : string
     fieldsToOmitOnDeploy?: string[]
     elementsToExclude?: string[]
-    importantValuesFreq: number
+    importantValuesFreq?: number
 }
 
 export const defaultParams: Omit<GeneratorParams, 'extraNaclPaths'> = {
@@ -394,12 +394,14 @@ export const generateElements = async (
     // the  important values should be only a small portion of the fields
     const halfLength = Math.floor((fieldNames.length / 2) + 1)
     const randomNum = randomGen()
-    const randomNumToUse = randomNum < params.importantValuesFreq ? randomNum : 0
+    const importantValuesFreq = params.importantValuesFreq ?? 1
+    const randomNumToUse = randomNum < importantValuesFreq ? randomNum : 0
     const numberOfImportantValues = Math.floor(randomNumToUse * halfLength)
     const fieldSet = new Set<string>()
+    const finalFieldNames = fieldNames.filter(name => name.startsWith('_'))
     const importantValuesDef = Array.from({ length: numberOfImportantValues }).map(() => {
-      const value = weightedRandomSelect(fieldNames)
-      if (fieldSet.has(value) || value.startsWith('_')) {
+      const value = weightedRandomSelect(finalFieldNames)
+      if (fieldSet.has(value)) {
         return undefined
       }
       fieldSet.add(value)

--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -165,6 +165,7 @@ export type GeneratorParams = {
     generateEnvName? : string
     fieldsToOmitOnDeploy?: string[]
     elementsToExclude?: string[]
+    importantValuesFreq: number
 }
 
 export const defaultParams: Omit<GeneratorParams, 'extraNaclPaths'> = {
@@ -198,6 +199,7 @@ export const defaultParams: Omit<GeneratorParams, 'extraNaclPaths'> = {
   staticFileLinesStd: 4.85,
   listLengthMean: 8.7,
   listLengthStd: 3.6,
+  importantValuesFreq: 0.75,
 }
 
 const MOCK_NACL_SUFFIX = 'nacl.mock'
@@ -391,7 +393,9 @@ export const generateElements = async (
   const generateImportantValues = (fieldNames: string[]): ImportantValues | undefined => {
     // the  important values should be only a small portion of the fields
     const halfLength = Math.floor((fieldNames.length / 2) + 1)
-    const numberOfImportantValues = Math.floor(randomGen() * halfLength)
+    const randomNum = randomGen()
+    const randomNumToUse = randomNum < params.importantValuesFreq ? randomNum : 0
+    const numberOfImportantValues = Math.floor(randomNumToUse * halfLength)
     const fieldSet = new Set<string>()
     const importantValuesDef = Array.from({ length: numberOfImportantValues }).map(() => {
       const value = weightedRandomSelect(fieldNames)

--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -750,8 +750,24 @@ export const generateElements = async (
       annotationRefsOrTypes: {
         SharedHidden: BuiltinTypes.HIDDEN_STRING,
         DiffHidden: BuiltinTypes.HIDDEN_STRING,
+        active: BuiltinTypes.BOOLEAN,
+        name: BuiltinTypes.STRING,
       },
       path: [DUMMY_ADAPTER, 'EnvStuff', 'PrimWithAnnos'],
+      annotations: {
+        [CORE_ANNOTATIONS.IMPORTANT_VALUES]: [
+          {
+            value: 'active',
+            indexed: true,
+            highlighted: true,
+          },
+          {
+            value: 'name',
+            indexed: false,
+            highlighted: false,
+          },
+        ],
+      },
     })
 
     const sharedObj = new ObjectType({
@@ -771,6 +787,8 @@ export const generateElements = async (
           annotations: {
             SharedHidden: 'HIDDEN!',
             DiffHidden: `${envID}-HIDDENNNN!!!!`,
+            active: true,
+            name: 'test',
           },
         },
       },
@@ -788,6 +806,35 @@ export const generateElements = async (
         SharedHidden: 'HIDDEN!',
         DiffHidden: `${envID}-HIDDENNNN!!!!`,
         [CORE_ANNOTATIONS.ALIAS]: 'EnvObj_alias',
+        [CORE_ANNOTATIONS.IMPORTANT_VALUES]: [
+          {
+            value: 'SharedButDiffField',
+            indexed: true,
+            highlighted: true,
+          },
+          {
+            value: 'SharedField',
+            indexed: false,
+            highlighted: false,
+          },
+          {
+            value: 'doesNotExist',
+            indexed: false,
+            highlighted: true,
+          },
+        ],
+        [CORE_ANNOTATIONS.SELF_IMPORTANT_VALUES]: [
+          {
+            value: 'SharedButDiffAnno',
+            indexed: true,
+            highlighted: false,
+          },
+          {
+            value: 'SharedAnno',
+            indexed: false,
+            highlighted: true,
+          },
+        ],
       },
       path: [DUMMY_ADAPTER, 'EnvStuff', 'EnvObj'],
     })
@@ -811,16 +858,34 @@ export const generateElements = async (
         Field: {
           refType: BuiltinTypes.STRING,
         },
+        active: {
+          refType: BuiltinTypes.BOOLEAN,
+        },
       },
       path: [DUMMY_ADAPTER, 'EnvStuff', `${envID}EnvObj`],
       annotations: {
         [CORE_ANNOTATIONS.ALIAS]: `${envID}EnvObj_alias`,
+        [CORE_ANNOTATIONS.IMPORTANT_VALUES]: [
+          {
+            value: 'Field',
+            indexed: false,
+            highlighted: true,
+          },
+          {
+            value: 'active',
+            indexed: true,
+            highlighted: false,
+          },
+        ],
       },
     })
     const envSpecificInst = new InstanceElement(
       `${envID}EnvInst`,
       envSpecificObj,
-      { Field: 'FieldValue' },
+      {
+        Field: 'FieldValue',
+        active: true,
+      },
       [DUMMY_ADAPTER, 'EnvStuff', `${envID}EnvInst`],
       {
         [CORE_ANNOTATIONS.ALIAS]: `${envID}EnvInst_alias`,

--- a/packages/dummy-adapter/test/generator.test.ts
+++ b/packages/dummy-adapter/test/generator.test.ts
@@ -13,11 +13,19 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { isObjectType, isInstanceElement, isPrimitiveType, isMapType, isListType, StaticFile } from '@salto-io/adapter-api'
+import {
+  isObjectType,
+  isInstanceElement,
+  isPrimitiveType,
+  isMapType,
+  isListType,
+  CORE_ANNOTATIONS,
+  StaticFile,
+} from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import path from 'path'
-import { generateElements } from '../src/generator'
+import { defaultParams, generateElements, GeneratorParams } from '../src/generator'
 import testParams from './test_params'
 
 const { awu } = collections.asynciterable
@@ -129,6 +137,44 @@ describe('elements generator', () => {
         const fragments = elements.filter(e => e.elemID.getFullName() === fixture.fullName)
         expect(fragments).toHaveLength(fixture.numOfFragments)
       })
+    })
+  })
+  describe('important values', () => {
+    it('should not create important values if importantValuesFreq is 0', async () => {
+      const importantValuesTestParams: GeneratorParams = {
+        ...defaultParams,
+        numOfObjs: 10,
+        numOfPrimitiveTypes: 0,
+        numOfProfiles: 0,
+        numOfRecords: 0,
+        numOfTypes: 10,
+        importantValuesFreq: 0,
+      }
+      const elements = await generateElements(importantValuesTestParams, mockProgressReporter)
+      const elementsWithImportantValues = elements
+        .filter(isObjectType)
+        .filter(obj =>
+          obj.annotations[CORE_ANNOTATIONS.IMPORTANT_VALUES] !== undefined
+          || obj.annotations[CORE_ANNOTATIONS.SELF_IMPORTANT_VALUES] !== undefined)
+      expect(_.isEmpty(elementsWithImportantValues)).toBeTruthy()
+    })
+    it('should create some important values if importantValuesFreq is 0.75', async () => {
+      const importantValuesTestParams: GeneratorParams = {
+        ...defaultParams,
+        numOfObjs: 10,
+        numOfPrimitiveTypes: 0,
+        numOfProfiles: 0,
+        numOfRecords: 0,
+        numOfTypes: 10,
+        importantValuesFreq: 0.75,
+      }
+      const elements = await generateElements(importantValuesTestParams, mockProgressReporter)
+      const elementsWithImportantValues = elements
+        .filter(isObjectType)
+        .filter(obj =>
+          obj.annotations[CORE_ANNOTATIONS.IMPORTANT_VALUES] !== undefined
+          || obj.annotations[CORE_ANNOTATIONS.SELF_IMPORTANT_VALUES] !== undefined)
+      expect(_.isEmpty(elementsWithImportantValues)).toBeFalsy()
     })
   })
   describe('env data', () => {

--- a/packages/dummy-adapter/test/generator.test.ts
+++ b/packages/dummy-adapter/test/generator.test.ts
@@ -166,7 +166,24 @@ describe('elements generator', () => {
         numOfProfiles: 0,
         numOfRecords: 0,
         numOfTypes: 10,
-        importantValuesFreq: 0.75,
+      }
+      const elements = await generateElements(importantValuesTestParams, mockProgressReporter)
+      const elementsWithImportantValues = elements
+        .filter(isObjectType)
+        .filter(obj =>
+          obj.annotations[CORE_ANNOTATIONS.IMPORTANT_VALUES] !== undefined
+          || obj.annotations[CORE_ANNOTATIONS.SELF_IMPORTANT_VALUES] !== undefined)
+      expect(_.isEmpty(elementsWithImportantValues)).toBeFalsy()
+    })
+    it('should create some important values if importantValuesFreq is undefined', async () => {
+      const importantValuesTestParams: GeneratorParams = {
+        ...defaultParams,
+        numOfObjs: 10,
+        numOfPrimitiveTypes: 0,
+        numOfProfiles: 0,
+        numOfRecords: 0,
+        numOfTypes: 10,
+        importantValuesFreq: undefined,
       }
       const elements = await generateElements(importantValuesTestParams, mockProgressReporter)
       const elementsWithImportantValues = elements


### PR DESCRIPTION
add important values to all object types in dummy

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
