### PR TITLE
SALTO-5127: Avoid invalidating cache when static file content is unchanged

### DIFF
--- a/packages/workspace/src/workspace/static_files/source.ts
+++ b/packages/workspace/src/workspace/static_files/source.ts
@@ -80,7 +80,7 @@ export const buildStaticFilesSource = (
   staticFilesCache: StaticFilesCache,
 ): Required<StaticFilesSource> => {
   const getStaticFileData = async (filepath: string): Promise<
-    ({ hasChanged: false } | { hasChanged: true; buffer: Buffer}) & StaticFilesData
+    ({ hasChanged: boolean; buffer?: Buffer }) & StaticFilesData
   > => {
     const cachedResult = await staticFilesCache.get(filepath)
     let modified: number | undefined
@@ -114,7 +114,7 @@ export const buildStaticFilesSource = (
         hash,
         modified,
         buffer: staticFileBuffer,
-        hasChanged: true,
+        hasChanged: hash !== cachedResult?.hash,
       }
     }
     return {
@@ -163,7 +163,7 @@ export const buildStaticFilesSource = (
           return new StaticFile({ filepath, encoding, hash })
         }
 
-        if (staticFileData.hasChanged) {
+        if (staticFileData.buffer !== undefined) {
           const staticFileWithHashAndContent = new AbsoluteStaticFile(
             {
               filepath,


### PR DESCRIPTION
This fixes an issue where we would not take the content hash into account when loading static files this caused a case where if the modification time of the static file changed we would invalidate the cache even if the file content did not change

---

_Additional context for reviewer_

---
_Release Notes_: 
Core:
- Fixed issue where loadWorkspace would have degraded performance when static file modification times changed

---
_User Notifications_: 
_None_