### PR TITLE
Feature Request: Allow loadLocalWorkspace to load with ignoreFileChan…

### DIFF
--- a/packages/core/src/local-workspace/workspace.ts
+++ b/packages/core/src/local-workspace/workspace.ts
@@ -266,6 +266,7 @@ type LoadLocalWorkspaceArgs = {
   persistent?: boolean
   stateStaticFilesSource?: staticFiles.StateStaticFilesSource
   credentialSource?: cs.ConfigSource
+  ignoreFileChanges?: boolean
 }
 
 const loadLocalWorkspaceImpl = async ({
@@ -274,6 +275,7 @@ const loadLocalWorkspaceImpl = async ({
   persistent = true,
   credentialSource,
   stateStaticFilesSource,
+  ignoreFileChanges = false,
 }: LoadLocalWorkspaceArgs): Promise<Workspace> => {
   const baseDir = await locateWorkspaceRoot(path.resolve(lookupDir))
   if (_.isUndefined(baseDir)) {
@@ -309,7 +311,7 @@ const loadLocalWorkspaceImpl = async ({
     credentials,
     elemSources,
     remoteMapCreator,
-    false,
+    ignoreFileChanges,
     persistent,
     undefined,
     getCustomReferences,


### PR DESCRIPTION
This fix allows loadLocalWorkspace to load with ignoreFileChange = true

---

At Sweep we are using Salto as the source of truth to load fields and data from the workspace. Every delay in load is hurting our UX. After fetch we create a read replica that we trust should not have any NaCl changes. We want to save the time in checking if there's a change.  

---
_Release Notes_: 
Core:
* New optional argument to loadWorkspace with ignoreFileChange. Using this parameter can lead to unexpected behavior if there was a NaCl change in the workspace. Use this only if you're sure there was no NaCl file update in the workspace.

---
_User Notifications_: 
None