### PR TITLE
SALTO-5130: add CV for Board without at least one column with at least one status

### DIFF
--- a/packages/jira-adapter/src/change_validators/board_culomn_config.ts
+++ b/packages/jira-adapter/src/change_validators/board_culomn_config.ts
@@ -59,8 +59,8 @@ export const boardColumnConfigValidator: ChangeValidator = async changes => (
     .map(async instance => ({
       elemID: instance.elemID,
       severity: 'Error' as SeverityLevel,
-      message: 'Can\'t deploy board without at least one column with at least one status.',
-      detailedMessage: 'Can\'t deploy board without at least one column with at least one status.',
+      message: 'Unable to deploy Board without Columns and Statuses.',
+      detailedMessage: 'The board must have at least one column, and at least one of these columns must include a status. Please verify that these conditions are met before deploying it.',
     }))
     .toArray()
 )

--- a/packages/jira-adapter/src/change_validators/board_culomn_config.ts
+++ b/packages/jira-adapter/src/change_validators/board_culomn_config.ts
@@ -1,0 +1,67 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ChangeValidator, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, ReferenceExpression, SeverityLevel } from '@salto-io/adapter-api'
+import Joi from 'joi'
+import { createSchemeGuard } from '@salto-io/adapter-utils'
+import { collections } from '@salto-io/lowerdash'
+import _ from 'lodash'
+import { BOARD_TYPE_NAME } from '../constants'
+
+const { awu } = collections.asynciterable
+
+type BoardColumn = {
+  name: string
+  statuses?: (string | ReferenceExpression)[]
+}
+
+type BoardColumnConfig ={
+    columns: BoardColumn[]
+  }
+
+
+const COLUMN_CONFIG_SCHEME = Joi.object({
+  columns: Joi.array().items(Joi.object({
+    name: Joi.string().required(),
+    statuses: Joi.array(),
+  })).required(),
+}).required().unknown(true)
+
+const isBoardColumnConfig = createSchemeGuard<BoardColumnConfig>(COLUMN_CONFIG_SCHEME)
+
+const isInvalidColumnConfig = (boardInstance: InstanceElement): boolean => {
+  if (!isBoardColumnConfig(boardInstance.value.columnConfig)) {
+    return true
+  }
+  const { columns } = boardInstance.value.columnConfig
+  const columnsWithStatuses = columns.map(column => column.statuses)
+    .filter(statuses => !_.isEmpty(statuses))
+  return columnsWithStatuses.length === 0
+}
+export const boardColumnConfigValidator: ChangeValidator = async changes => (
+  awu(changes)
+    .filter(isInstanceChange)
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+    .filter(instance => instance.elemID.typeName === BOARD_TYPE_NAME)
+    .filter(isInvalidColumnConfig)
+    .map(async instance => ({
+      elemID: instance.elemID,
+      severity: 'Error' as SeverityLevel,
+      message: 'Can\'t deploy board without at least one column with at least one status.',
+      detailedMessage: 'Can\'t deploy board without at least one column with at least one status.',
+    }))
+    .toArray()
+)

--- a/packages/jira-adapter/src/change_validators/board_culomn_config.ts
+++ b/packages/jira-adapter/src/change_validators/board_culomn_config.ts
@@ -46,9 +46,8 @@ const isInvalidColumnConfig = (boardInstance: InstanceElement): boolean => {
     return true
   }
   const { columns } = boardInstance.value.columnConfig
-  const columnsWithStatuses = columns.map(column => column.statuses)
-    .filter(statuses => !_.isEmpty(statuses))
-  return columnsWithStatuses.length === 0
+  const hasNonEmptyStatuses = columns.some(column => !_.isEmpty(column.statuses))
+  return !hasNonEmptyStatuses
 }
 export const boardColumnConfigValidator: ChangeValidator = async changes => (
   awu(changes)

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -28,6 +28,7 @@ import { readOnlyWorkflowValidator } from './workflows/read_only_workflow'
 import { dashboardGadgetsValidator } from './dashboard_gadgets'
 import { dashboardLayoutValidator } from './dashboard_layout'
 import { permissionTypeValidator } from './permission_type'
+import { boardColumnConfigValidator } from './board_culomn_config'
 import { maskingValidator } from './masking'
 import { automationsValidator } from './automation/automations'
 import { lockedFieldsValidator } from './locked_fields'
@@ -115,6 +116,7 @@ export default (
     customFieldsWith10KOptions: customFieldsWith10KOptionValidator,
     issueTypeHierarchy: issueTypeHierarchyValidator,
     automationProjects: automationProjectsValidator,
+    boardColumnConfig: boardColumnConfigValidator,
     deleteLastQueueValidator: deleteLastQueueValidator(config),
     automationToAssets: automationToAssetsValidator(config),
   }

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -238,6 +238,7 @@ export type ChangeValidatorName = (
   | 'issueTypeHierarchy'
   | 'automationProjects'
   | 'deleteLastQueueValidator'
+  | 'boardColumnConfig'
   | 'automationToAssets'
   )
 
@@ -247,6 +248,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
   elemID: new ElemID(JIRA, 'changeValidatorConfig'),
   fields: {
     unresolvedReference: { refType: BuiltinTypes.BOOLEAN },
+    boardColumnConfig: { refType: BuiltinTypes.BOOLEAN },
     brokenReferences: { refType: BuiltinTypes.BOOLEAN },
     deployTypesNotSupported: { refType: BuiltinTypes.BOOLEAN },
     readOnlyProjectRoleChange: { refType: BuiltinTypes.BOOLEAN },

--- a/packages/jira-adapter/src/filters/board/board_columns.ts
+++ b/packages/jira-adapter/src/filters/board/board_columns.ts
@@ -192,6 +192,7 @@ const filter: FilterCreator = ({ config, client }) => ({
     }
 
     setFieldDeploymentAnnotations(boardType, COLUMNS_CONFIG_FIELD)
+    boardType.fields.columnConfig.annotations[CORE_ANNOTATIONS.REQUIRED] = true
     await addAnnotationRecursively(columnConfigType, CORE_ANNOTATIONS.CREATABLE)
     await addAnnotationRecursively(columnConfigType, CORE_ANNOTATIONS.UPDATABLE)
   },

--- a/packages/jira-adapter/test/change_validators/board_column_config.test.ts
+++ b/packages/jira-adapter/test/change_validators/board_column_config.test.ts
@@ -46,8 +46,8 @@ describe('boardColumnConfigValidator', () => {
       {
         elemID: instance.elemID,
         severity: 'Error',
-        message: "Can't deploy board without at least one column with at least one status.",
-        detailedMessage: "Can't deploy board without at least one column with at least one status.",
+        message: 'Unable to deploy Board without Columns and Statuses.',
+        detailedMessage: 'The board must have at least one column, and at least one of these columns must include a status. Please verify that these conditions are met before deploying it.',
       },
     ])
   })
@@ -62,8 +62,8 @@ describe('boardColumnConfigValidator', () => {
       {
         elemID: instance.elemID,
         severity: 'Error',
-        message: "Can't deploy board without at least one column with at least one status.",
-        detailedMessage: "Can't deploy board without at least one column with at least one status.",
+        message: 'Unable to deploy Board without Columns and Statuses.',
+        detailedMessage: 'The board must have at least one column, and at least one of these columns must include a status. Please verify that these conditions are met before deploying it.',
       },
     ])
   })
@@ -78,8 +78,8 @@ describe('boardColumnConfigValidator', () => {
       {
         elemID: instance.elemID,
         severity: 'Error',
-        message: "Can't deploy board without at least one column with at least one status.",
-        detailedMessage: "Can't deploy board without at least one column with at least one status.",
+        message: 'Unable to deploy Board without Columns and Statuses.',
+        detailedMessage: 'The board must have at least one column, and at least one of these columns must include a status. Please verify that these conditions are met before deploying it.',
       },
     ])
   })

--- a/packages/jira-adapter/test/change_validators/board_column_config.test.ts
+++ b/packages/jira-adapter/test/change_validators/board_column_config.test.ts
@@ -13,17 +13,16 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { toChange, ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { toChange, InstanceElement } from '@salto-io/adapter-api'
 import { boardColumnConfigValidator } from '../../src/change_validators/board_culomn_config'
-import { BOARD_TYPE_NAME, JIRA } from '../../src/constants'
+import { BOARD_TYPE_NAME } from '../../src/constants'
+import { createEmptyType } from '../utils'
 
 describe('boardColumnConfigValidator', () => {
-  let type: ObjectType
   let instance: InstanceElement
 
   beforeEach(() => {
-    type = new ObjectType({ elemID: new ElemID(JIRA, BOARD_TYPE_NAME) })
-    instance = new InstanceElement('instance', type, {
+    instance = new InstanceElement('instance', createEmptyType(BOARD_TYPE_NAME), {
       columnConfig: {
         columns: [
           {

--- a/packages/jira-adapter/test/filters/board/board_columns.test.ts
+++ b/packages/jira-adapter/test/filters/board/board_columns.test.ts
@@ -198,6 +198,7 @@ describe('boardColumnsFilter', () => {
     it('should add deployment annotations', async () => {
       await filter.onFetch([type, columnConfigType])
       expect(type.fields[COLUMNS_CONFIG_FIELD].annotations).toEqual({
+        [CORE_ANNOTATIONS.REQUIRED]: true,
         [CORE_ANNOTATIONS.CREATABLE]: true,
         [CORE_ANNOTATIONS.UPDATABLE]: true,
       })


### PR DESCRIPTION
_add CV for Board without at least one column with at least one status_

---

_Additional context for reviewer_
Board column config has some restrictions: 
* A board must have columnConfig with at least one column
* at least one column must have statuses inside it

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
