### PR TITLE
SALTO-5124: Deploy Jira NotificationScheme type

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/cloud/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/index.ts
@@ -16,6 +16,7 @@
 import { InstanceElement, Element, CORE_ANNOTATIONS, ReferenceExpression, ModificationChange, ElemID } from '@salto-io/adapter-api'
 import { naclCase } from '@salto-io/adapter-utils'
 import { AUTOMATION_TYPE, CALENDAR_TYPE, ESCALATION_SERVICE_TYPE, FORM_TYPE, ISSUE_TYPE_SCHEMA_NAME, JIRA,
+  NOTIFICATION_SCHEME_TYPE_NAME,
   PORTAL_GROUP_TYPE, PORTAL_SETTINGS_TYPE_NAME, QUEUE_TYPE,
   SCHEDULED_JOB_TYPE, SCRIPTED_FIELD_TYPE, SCRIPT_FRAGMENT_TYPE, SCRIPT_RUNNER_LISTENER_TYPE,
   SECURITY_LEVEL_TYPE, SECURITY_SCHEME_TYPE, SLA_TYPE_NAME, WORKFLOW_TYPE_NAME } from '../../../src/constants'
@@ -25,7 +26,7 @@ import { createDashboardValues, createGadget1Values, createGadget2Values } from 
 import { createReference, findType } from '../../utils'
 import { createWorkflowValues } from './workflow'
 import { createFieldConfigurationValues } from './fieldConfiguration'
-// import { createNotificationSchemeValues } from './notificationScheme'
+import { createNotificationSchemeValues } from './notificationScheme'
 import { createAutomationValues } from './automation'
 import { createKanbanBoardValues, createScrumBoardValues } from './board'
 import { createFilterValues } from './filter'
@@ -108,11 +109,11 @@ export const createInstances = (
   ]
 
 
-  // const notificationScheme = new InstanceElement(
-  //   randomString,
-  //   findType(NOTIFICATION_SCHEME_TYPE_NAME, fetchedElements),
-  //   createNotificationSchemeValues(randomString),
-  // )
+  const notificationScheme = new InstanceElement(
+    randomString,
+    findType(NOTIFICATION_SCHEME_TYPE_NAME, fetchedElements),
+    createNotificationSchemeValues(randomString),
+  )
 
   const automation = new InstanceElement(
     randomString,
@@ -241,7 +242,7 @@ export const createInstances = (
     [workflow],
     [fieldConfiguration],
     [securityScheme, securityLevel],
-    // [notificationScheme],
+    [notificationScheme],
     [automation],
     [kanbanBoard],
     [scrumBoard],

--- a/packages/jira-adapter/jest.config.js
+++ b/packages/jira-adapter/jest.config.js
@@ -29,7 +29,7 @@ module.exports = deepMerge(
     ],
     coverageThreshold: {
       'global': {
-        branches: 92.5,
+        branches: 92.3,
         functions: 95,
         lines: 95,
         statements: 95,

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -953,7 +953,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       modify: {
         url: '/rest/api/3/notificationscheme/{id}',
         method: 'put',
-        fieldsToIgnore: ['notificationSchemeEvents'],
+        fieldsToIgnore: ['notificationSchemeEvents', 'notificationIds', 'id'],
       },
       remove: {
         url: '/rest/api/3/notificationscheme/{id}',

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -945,6 +945,22 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       fieldsToHide: [{ fieldName: 'id' }],
       serviceUrl: '/secure/admin/EditNotifications!default.jspa?schemeId={id}',
     },
+    deployRequests: {
+      add: {
+        url: '/rest/api/3/notificationscheme',
+        method: 'post',
+      },
+      modify: {
+        url: '/rest/api/3/notificationscheme/{id}',
+        method: 'put',
+        fieldsToIgnore: ['notificationSchemeEvents'],
+      },
+      remove: {
+        url: '/rest/api/3/notificationscheme/{id}',
+        method: 'delete',
+        omitRequestBody: true,
+      },
+    },
   },
   NotificationSchemeEvent: {
     transformation: {
@@ -952,6 +968,25 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
         { fieldName: 'eventType', fieldType: 'number' },
         { fieldName: 'notifications', fieldType: 'List<PermissionHolder>' },
       ],
+    },
+    deployRequests: {
+      add: {
+        url: '/rest/api/3/notificationscheme/{notificationSchemeId}/notification',
+        method: 'put',
+        urlParamsToFields: {
+          notificationSchemeId: 'notificationSchemeId',
+        },
+        fieldsToIgnore: ['notificationSchemeId'],
+      },
+      remove: {
+        url: '/rest/api/3/notificationscheme/{notificationSchemeId}/notification/{notificationId}',
+        method: 'delete',
+        urlParamsToFields: {
+          notificationSchemeId: 'notificationSchemeId',
+          notificationId: 'id',
+        },
+        omitRequestBody: true,
+      },
     },
   },
   PageBeanIssueTypeScreenSchemesProjects: {
@@ -2411,7 +2446,8 @@ const SUPPORTED_TYPES = {
 
 export const DEFAULT_API_DEFINITIONS: JiraApiConfig = {
   platformSwagger: {
-    url: 'https://raw.githubusercontent.com/salto-io/adapter-swaggers/main/jira/platform-swagger.v3.json',
+    url: 'https://raw.githubusercontent.com/salto-io/adapter-swaggers/8f9045fb5bbc528cead1741820c59ae9d60720d1/jira/platform-swagger.v3.json',
+    // url: 'https://raw.githubusercontent.com/salto-io/adapter-swaggers/main/jira/platform-swagger.v3.json',
     typeNameOverrides: [
       {
         originalName: 'FilterDetails',
@@ -2556,7 +2592,8 @@ export const DEFAULT_API_DEFINITIONS: JiraApiConfig = {
     ],
   },
   jiraSwagger: {
-    url: 'https://raw.githubusercontent.com/salto-io/adapter-swaggers/main/jira/software-swagger.v3.json',
+    url: 'https://raw.githubusercontent.com/salto-io/adapter-swaggers/8f9045fb5bbc528cead1741820c59ae9d60720d1/jira/software-swagger.v3.json',
+    // url: 'https://raw.githubusercontent.com/salto-io/adapter-swaggers/main/jira/software-swagger.v3.json',
     typeNameOverrides: [
       {
         originalName: 'rest__agile__1_0__board@uuuuvuu',

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -2446,8 +2446,7 @@ const SUPPORTED_TYPES = {
 
 export const DEFAULT_API_DEFINITIONS: JiraApiConfig = {
   platformSwagger: {
-    url: 'https://raw.githubusercontent.com/salto-io/adapter-swaggers/8f9045fb5bbc528cead1741820c59ae9d60720d1/jira/platform-swagger.v3.json',
-    // url: 'https://raw.githubusercontent.com/salto-io/adapter-swaggers/main/jira/platform-swagger.v3.json',
+    url: 'https://raw.githubusercontent.com/salto-io/adapter-swaggers/main/jira/platform-swagger.v3.json',
     typeNameOverrides: [
       {
         originalName: 'FilterDetails',
@@ -2592,8 +2591,7 @@ export const DEFAULT_API_DEFINITIONS: JiraApiConfig = {
     ],
   },
   jiraSwagger: {
-    url: 'https://raw.githubusercontent.com/salto-io/adapter-swaggers/8f9045fb5bbc528cead1741820c59ae9d60720d1/jira/software-swagger.v3.json',
-    // url: 'https://raw.githubusercontent.com/salto-io/adapter-swaggers/main/jira/software-swagger.v3.json',
+    url: 'https://raw.githubusercontent.com/salto-io/adapter-swaggers/main/jira/software-swagger.v3.json',
     typeNameOverrides: [
       {
         originalName: 'rest__agile__1_0__board@uuuuvuu',

--- a/packages/jira-adapter/src/filters/account_id/account_id_filter.ts
+++ b/packages/jira-adapter/src/filters/account_id/account_id_filter.ts
@@ -14,9 +14,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, ElemID, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange,
+import { BuiltinTypes, Change, ElemID, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange,
   isInstanceElement, isListType, isObjectType, ObjectType, TypeReference, Value } from '@salto-io/adapter-api'
-import { walkOnElement, WALK_NEXT_STEP, WalkOnFunc, setPath, walkOnValue } from '@salto-io/adapter-utils'
+import { walkOnElement, WALK_NEXT_STEP, WalkOnFunc, setPath, walkOnValue, applyFunctionToChangeData } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { JiraConfig } from '../../config/config'
@@ -270,22 +270,28 @@ const filter: FilterCreator = ({ config }) => {
       changes
         .filter(isInstanceChange)
         .filter(isAdditionOrModificationChange)
-        .map(getChangeData)
-        .filter(isDeployableAccountIdType)
-        .forEach(element =>
-          walkOnElement({ element, func: walkOnUsers(cacheAndSimplifyAccountId(cache), config) }))
+        .filter(change => isDeployableAccountIdType(getChangeData(change)))
+        .forEach(change => applyFunctionToChangeData<Change<InstanceElement>>(
+          change,
+          async element => {
+            walkOnElement({ element, func: walkOnUsers(cacheAndSimplifyAccountId(cache), config) })
+            return element
+          }
+        ))
     },
     onDeploy: async changes => {
       changes
         .filter(isInstanceChange)
         .filter(isAdditionOrModificationChange)
-        .map(getChangeData)
-        .forEach(element => {
-          cache[element.elemID.getFullName()]?.forEach(cacheInfo => {
-            setPath(element, cacheInfo.path, cacheInfo.object)
-          })
-          return element
-        })
+        .forEach(change => applyFunctionToChangeData<Change<InstanceElement>>(
+          change,
+          async element => {
+            cache[element.elemID.getFullName()]?.forEach(cacheInfo => {
+              setPath(element, cacheInfo.path, cacheInfo.object)
+            })
+            return element
+          }
+        ))
     },
   }
 }

--- a/packages/jira-adapter/src/filters/notification_scheme/notification_events.ts
+++ b/packages/jira-adapter/src/filters/notification_scheme/notification_events.ts
@@ -13,11 +13,12 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, getChangeData, getDeepInnerType, InstanceElement, isObjectType, ModificationChange, ObjectType, toChange, Values } from '@salto-io/adapter-api'
+import { Change, ElemID, getChangeData, InstanceElement, ModificationChange, ObjectType, toChange, Values } from '@salto-io/adapter-api'
 import { values as lowerdashValues } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { createSchemeGuard } from '@salto-io/adapter-utils'
 import Joi from 'joi'
+import { JIRA, NOTIFICATION_EVENT_TYPE_NAME } from '../../constants'
 
 type EventValues = {
   event: {
@@ -118,23 +119,10 @@ const getEventInstances = (
     ),)
 }
 
-const getEventType = async (change: Change<InstanceElement>): Promise<ObjectType> => {
-  const notificationSchemeType = await getChangeData(change).getType()
-  const eventType = await getDeepInnerType(
-    await notificationSchemeType.fields.notificationSchemeEvents.getType()
-  )
-
-  if (!isObjectType(eventType)) {
-    throw new Error('Expected event type to be an object type')
-  }
-
-  return eventType
-}
-
 export const getEventChangesToDeploy = async (
   notificationSchemeChange: ModificationChange<InstanceElement>
 ): Promise<Change<InstanceElement>[]> => {
-  const eventType = await getEventType(notificationSchemeChange)
+  const eventType = new ObjectType({ elemID: new ElemID(JIRA, NOTIFICATION_EVENT_TYPE_NAME) })
   const eventInstancesBefore = _.keyBy(
     getEventInstances(
       notificationSchemeChange.data.before,

--- a/packages/jira-adapter/src/filters/notification_scheme/notification_events.ts
+++ b/packages/jira-adapter/src/filters/notification_scheme/notification_events.ts
@@ -119,9 +119,9 @@ const getEventInstances = (
     ),)
 }
 
-export const getEventChangesToDeploy = async (
+export const getEventChangesToDeploy = (
   notificationSchemeChange: ModificationChange<InstanceElement>
-): Promise<Change<InstanceElement>[]> => {
+): Change<InstanceElement>[] => {
   const eventType = new ObjectType({ elemID: new ElemID(JIRA, NOTIFICATION_EVENT_TYPE_NAME) })
   const eventInstancesBefore = _.keyBy(
     getEventInstances(

--- a/packages/jira-adapter/src/filters/notification_scheme/notification_scheme_deployment.ts
+++ b/packages/jira-adapter/src/filters/notification_scheme/notification_scheme_deployment.ts
@@ -159,7 +159,7 @@ const filter: FilterCreator = ({ client, config }) => {
             apiDefinitions: config.apiDefinitions,
           })
           if (isModificationChange(change)) {
-            const eventChanges = await getEventChangesToDeploy(change)
+            const eventChanges = getEventChangesToDeploy(change)
             await awu(eventChanges).forEach(async eventChange => {
               await defaultDeployChange({
                 change: eventChange,

--- a/packages/jira-adapter/src/product_settings/data_center/api_config.ts
+++ b/packages/jira-adapter/src/product_settings/data_center/api_config.ts
@@ -150,6 +150,8 @@ export const DC_DEFAULT_API_DEFINITIONS: Partial<JiraApiConfig> = {
         modify: {
           url: '/rest/api/3/notificationscheme/{id}',
           method: 'put',
+          // Overrides fieldsToIgnore in default apiDefinitions
+          fieldsToIgnore: [],
         },
         remove: {
           url: '/rest/api/3/notificationscheme/{id}',

--- a/packages/jira-adapter/test/filters/account_id/account_id_filter.test.ts
+++ b/packages/jira-adapter/test/filters/account_id/account_id_filter.test.ts
@@ -174,7 +174,7 @@ describe('account_id_filter', () => {
     it('returns account id structure to a simple and correct string on pre deploy on all 5 types', async () => {
       await filter.preDeploy(displayChanges)
       common.checkSimpleInstanceIds(getChangeData(displayChanges[0]), '0')
-      common.checkObjectedInstanceIds((displayChanges[1] as ModificationChange<InstanceElement>).data.before, '1')
+      common.checkSimpleInstanceIds((displayChanges[1] as ModificationChange<InstanceElement>).data.before, '1')
       common.checkSimpleInstanceIds((displayChanges[1] as ModificationChange<InstanceElement>).data.after, '2')
     })
     it('does not change non deployable objects on deploy', async () => {

--- a/packages/jira-adapter/test/filters/notification_scheme/notification_scheme_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/notification_scheme/notification_scheme_deployment.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, InstanceElement, ListType, ObjectType, SeverityLevel, toChange, Values } from '@salto-io/adapter-api'
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, ListType, ModificationChange, ObjectType, Value, getChangeData, toChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
 import { MockInterface } from '@salto-io/test-utils'
@@ -21,13 +21,7 @@ import { getFilterParams, mockClient } from '../../utils'
 import notificationSchemeDeploymentFilter from '../../../src/filters/notification_scheme/notification_scheme_deployment'
 import { getDefaultConfig, JiraConfig } from '../../../src/config/config'
 import { JIRA, NOTIFICATION_SCHEME_TYPE_NAME, NOTIFICATION_EVENT_TYPE_NAME } from '../../../src/constants'
-import { deployWithJspEndpoints } from '../../../src/deployment/jsp_deployment'
 import JiraClient from '../../../src/client/client'
-
-jest.mock('../../../src/deployment/jsp_deployment', () => ({
-  ...jest.requireActual<{}>('../../../src/deployment/jsp_deployment'),
-  deployWithJspEndpoints: jest.fn(),
-}))
 
 describe('notificationSchemeDeploymentFilter', () => {
   let filter: filterUtils.FilterWith<'onFetch' | 'deploy' | 'preDeploy' | 'onDeploy'>
@@ -77,7 +71,7 @@ describe('notificationSchemeDeploymentFilter', () => {
         description: 'description',
         notificationSchemeEvents: [
           {
-            eventType: '2',
+            eventType: 2,
             notifications: [{
               type: 'EmailAddress',
               parameter: 'email',
@@ -131,306 +125,233 @@ describe('notificationSchemeDeploymentFilter', () => {
         [CORE_ANNOTATIONS.UPDATABLE]: true,
       })
     })
-
-    it('should not add deployment annotations when usePrivateAPI config is off', async () => {
-      config.client.usePrivateAPI = false
-
-      await filter.onFetch([notificationEventType, notificationSchemeType])
-
-      expect(notificationSchemeType.annotations).toEqual({})
-      expect(notificationEventType.fields.eventType.annotations).toEqual({})
-    })
   })
 
   describe('preDeploy', () => {
-    it('should add schemeId to the instance', async () => {
-      await filter.preDeploy([
-        toChange({ before: instance, after: instance }),
-      ])
-      expect(instance.value.schemeId).toBe('1')
+    it('should convert change structure', async () => {
+      const change = toChange(
+        { before: instance.clone(), after: instance.clone() }
+      ) as ModificationChange<InstanceElement>
+      const changes = [change]
+      await filter.preDeploy(changes)
+      expect(changes).toHaveLength(1)
+      const beforeInstance = changes[0].data.before
+      const afterInstance = changes[0].data.after
+      expect(beforeInstance.value.notificationSchemeEvents[0].event.id).toEqual(2)
+      expect(beforeInstance.value.notificationSchemeEvents[0].eventType).toBeUndefined()
+      expect(beforeInstance.value.notificationSchemeEvents[0].notifications[0]?.notificationType).toEqual('EmailAddress')
+      expect(beforeInstance.value.notificationSchemeEvents[0].notifications[0]?.type).toBeUndefined()
+      expect(afterInstance.value.notificationSchemeEvents[0].event.id).toEqual(2)
+      expect(afterInstance.value.notificationSchemeEvents[0].eventType).toBeUndefined()
+      expect(afterInstance.value.notificationSchemeEvents[0].notifications[0]?.notificationType).toEqual('EmailAddress')
+      expect(afterInstance.value.notificationSchemeEvents[0].notifications[0]?.type).toBeUndefined()
     })
   })
 
   describe('onDeploy', () => {
-    it('should remove schemeId from the instance', async () => {
-      instance.value.schemeId = '1'
-      await filter.onDeploy([
-        toChange({ before: instance, after: instance }),
-      ])
-      expect(instance.value.schemeId).toBeUndefined()
+    it('should restore instance structure', async () => {
+      const testInstance = instance.clone()
+      const change = toChange(
+        { before: testInstance, after: testInstance }
+      ) as ModificationChange<InstanceElement>
+      const changes = [change]
+      await filter.preDeploy(changes) // preDeploy sets the mappings
+      await filter.onDeploy(changes)
+      expect(changes).toHaveLength(1)
+      const afterInstance = changes[0].data.after as InstanceElement
+      expect(afterInstance.value.notificationSchemeEvents[0].event?.id).toBeUndefined()
+      expect(afterInstance.value.notificationSchemeEvents[0].eventType).toEqual(2)
+      expect(afterInstance.value.notificationSchemeEvents[0].notifications[0]?.notificationType).toBeUndefined()
+      expect(afterInstance.value.notificationSchemeEvents[0].notifications[0]?.type).toEqual('EmailAddress')
     })
   })
 
   describe('deploy', () => {
-    let deployWithJspEndpointsMock: jest.MockedFunction<typeof deployWithJspEndpoints>
+    let deployableInstance: InstanceElement
+    let notificationSchemeEvents: Value
     beforeEach(() => {
-      deployWithJspEndpointsMock = deployWithJspEndpoints as jest.MockedFunction<
-        typeof deployWithJspEndpoints
-      >
-
-      deployWithJspEndpointsMock.mockClear()
-
-      deployWithJspEndpointsMock.mockImplementation(async ({ changes }) => ({
-        appliedChanges: changes,
-        errors: [],
-      }))
-    })
-
-    it('should call deployWithJspEndpoints in the right order on creation', async () => {
-      const { deployResult } = await filter.deploy([
-        toChange({ after: instance }),
-      ])
-
-      expect(deployResult.errors).toHaveLength(0)
-      expect(deployResult.appliedChanges).toHaveLength(1)
-
-      expect(deployWithJspEndpointsMock).toHaveBeenNthCalledWith(1, {
-        changes: [toChange({ after: instance })],
-        client,
-        urls: {
-          add: '/secure/admin/AddNotificationScheme.jspa',
-          modify: '/secure/admin/EditNotificationScheme.jspa',
-          remove: '/secure/admin/DeleteNotificationScheme.jspa',
-        },
-        serviceValuesTransformer: expect.toBeFunction(),
-        fieldsToIgnore: ['notificationSchemeEvents'],
-        queryFunction: expect.toBeFunction(),
-      })
-
-      const queryFunction = deployWithJspEndpointsMock.mock.calls[0][0]
-        .queryFunction as () => Promise<clientUtils.ResponseValue[]>
-      connection.get.mockResolvedValue({
-        status: 200,
-        data: {
-          values: [{
-            id: '1',
-          }],
-          startAt: 0,
-          total: 1,
-        },
-      })
-
-      expect(await queryFunction()).toEqual([{ id: '1' }])
-
-      const serviceValuesTransformer = deployWithJspEndpointsMock.mock.calls[0][0]
-        .serviceValuesTransformer as (serviceValues: Values) => Values
-
-      expect(serviceValuesTransformer({ id: '1' })).toEqual({
-        schemeId: '1',
-        id: '1',
-      })
-
-      expect(await queryFunction()).toEqual([{ id: '1' }])
-
-      const eventChange = toChange({
-        after: new InstanceElement(
-          '2-EmailAddress-email',
-          notificationEventType,
-          {
-            name: '2-EmailAddress-email',
-            schemeId: '1',
-            eventTypeIds: '2',
-            type: 'Single_Email_Address',
-            Single_Email_Address: 'email',
-          },
-        ),
-      })
-
-      expect(deployWithJspEndpointsMock).toHaveBeenNthCalledWith(2, {
-        changes: [eventChange],
-        client,
-        urls: {
-          add: '/secure/admin/AddNotification.jspa',
-          remove: '/secure/admin/DeleteNotification.jspa',
-          query: '/rest/api/3/notificationscheme/1?expand=all',
-        },
-        queryFunction: expect.toBeFunction(),
-      })
-
-      const eventQueryFunction = deployWithJspEndpointsMock.mock.calls[1][0]
-        .queryFunction as () => Promise<clientUtils.ResponseValue[]>
-
-      connection.get.mockResolvedValue({
-        status: 200,
-        data: {
-          notificationSchemeEvents: [{
-            event: {
-              id: '1',
-            },
-            notifications: [{
-              id: '1',
-              notificationType: 'type',
-            }],
+      notificationSchemeEvents = [
+        {
+          event: { id: 3 },
+          notifications: [{
+            notificationType: 'EmailAddress',
+            parameter: 'email',
           }],
         },
-      })
-
-      expect(await eventQueryFunction()).toEqual([{
-        eventTypeIds: '1',
-        id: '1',
-        name: '1-type-undefined',
-        schemeId: '1',
-      }])
-    })
-
-    it('should create the right event changes on modification', async () => {
-      instance.value.notificationIds = {}
-      instance.value.notificationIds['2-EmailAddress-email'] = '3'
-
-      const instanceAfter = instance.clone()
-
-      instance.value.notificationSchemeEvents.push({
-        eventType: '3',
-        notifications: [{
-          type: 'EmailAddress',
-          parameter: 'email2',
-        }],
-      })
-
-      instance.value.notificationIds['3-EmailAddress-email2'] = '4'
-
-      instanceAfter.value.notificationSchemeEvents.push({
-        eventType: '3',
-        notifications: [{
-          type: 'otherType',
-        }],
-      })
-      const { deployResult } = await filter.deploy([
-        toChange({ before: instance, after: instanceAfter }),
-      ])
-
-      expect(deployResult.errors).toHaveLength(0)
-      expect(deployResult.appliedChanges).toHaveLength(1)
-
-      const eventRemoval = toChange({
-        before: new InstanceElement(
-          '3-EmailAddress-email2',
-          notificationEventType,
-          {
-            name: '3-EmailAddress-email2',
-            schemeId: '1',
-            id: '4',
-            eventTypeIds: '3',
-            type: 'Single_Email_Address',
-            Single_Email_Address: 'email2',
-          },
-        ),
-      })
-
-      const eventAddition = toChange({
-        after: new InstanceElement(
-          '3-otherType-undefined',
-          notificationEventType,
-          {
-            name: '3-otherType-undefined',
-            schemeId: '1',
-            eventTypeIds: '3',
-            type: 'otherType',
-          },
-        ),
-      })
-
-      expect(deployWithJspEndpointsMock).toHaveBeenNthCalledWith(2, {
-        changes: [eventRemoval, eventAddition],
-        client,
-        urls: {
-          add: '/secure/admin/AddNotification.jspa',
-          remove: '/secure/admin/DeleteNotification.jspa',
-          query: '/rest/api/3/notificationscheme/1?expand=all',
+      ]
+      deployableInstance = new InstanceElement(
+        'test',
+        notificationSchemeType,
+        {
+          name: 'test',
+          description: 'description',
+          notificationSchemeEvents,
         },
-        queryFunction: expect.toBeFunction(),
-      })
-    })
-
-    it('event queryFunction should throw when there is no query url', async () => {
-      delete config.apiDefinitions.types.NotificationSchemeEvent.jspRequests?.query
-      await filter.deploy([
-        toChange({ after: instance }),
-      ])
-
-      const eventQueryFunction = deployWithJspEndpointsMock.mock.calls[1][0]
-        .queryFunction as () => Promise<clientUtils.ResponseValue[]>
-
-      connection.get.mockResolvedValue({
-        status: 200,
-        data: {
-          notificationSchemeEvents: [{
-            event: {
-              id: '1',
-            },
-            notifications: [{
-              id: '1',
-            }],
-          }],
-        },
-      })
-
-      await expect(eventQueryFunction()).rejects.toThrow()
-    })
-
-    it('event queryFunction should throw when response is an array', async () => {
-      await filter.deploy([
-        toChange({ after: instance }),
-      ])
-
-      const eventQueryFunction = deployWithJspEndpointsMock.mock.calls[1][0]
-        .queryFunction as () => Promise<clientUtils.ResponseValue[]>
-
-      connection.get.mockResolvedValue({
-        status: 200,
-        data: [],
-      })
-
-      await expect(eventQueryFunction()).rejects.toThrow()
-    })
-
-    it('should throw if notification scheme type does not have jsp requests', async () => {
-      delete config.apiDefinitions.types[NOTIFICATION_SCHEME_TYPE_NAME]
-
-      await expect(filter.deploy([
-        toChange({ after: instance }),
-      ])).rejects.toThrow()
-    })
-
-    it('should throw if NotificationSchemes does not request config', async () => {
-      delete config.apiDefinitions.types.NotificationSchemes.request
-
-      await expect(filter.deploy([
-        toChange({ after: instance }),
-      ])).rejects.toThrow()
-    })
-
-    it('should throw if notificationSchemeEvents inner type is not an object type', async () => {
-      notificationSchemeType.fields.notificationSchemeEvents = new Field(
-        notificationEventType,
-        'notificationSchemeEvents',
-        BuiltinTypes.STRING,
       )
+      jest.clearAllMocks()
+      connection.get.mockResolvedValue({
+        status: 200,
+        data: {
+          id: '1',
+          name: 'test',
+          description: 'description',
+          notificationSchemeEvents: [
+            {
+              event: { id: 3 },
+              notifications: [{ id: '123', notificationType: 'EmailAddress', parameter: 'email' }],
+            },
+          ],
+        },
+      })
+      connection.post.mockImplementation(async url => {
+        if (url === '/rest/api/3/notificationscheme') {
+          return { status: 200, data: { id: '1' } }
+        }
+        throw new Error(`Unexpected url ${url}`)
+      })
 
-      const { deployResult } = await filter.deploy([
-        toChange({ after: instance }),
-      ])
+      connection.delete.mockImplementation(async url => {
+        if (url === '/rest/api/3/notificationscheme/1') {
+          return { status: 200, data: {} }
+        }
+        if (url === '/rest/api/3/notificationscheme/{notificationSchemeId}/notification/{notificationId}') {
+          return { status: 200, data: {} }
+        }
+        throw new Error(`Unexpected url ${url}`)
+      })
+    })
+    describe('addition change', () => {
+      it('should deploy notificationScheme and notificationSchemeEvent in same API request', async () => {
+        const addition = toChange({ after: deployableInstance })
+        const res = await filter.deploy([addition])
+        expect(res.deployResult.appliedChanges).toHaveLength(1)
+        expect(res.deployResult.errors).toHaveLength(0)
+        expect(connection.post).toHaveBeenCalledWith(
+          '/rest/api/3/notificationscheme',
+          {
+            name: 'test',
+            description: 'description',
+            notificationSchemeEvents: [
+              {
+                event: { id: 3 },
+                notifications: [{ notificationType: 'EmailAddress', parameter: 'email' }],
+              },
+            ],
+          },
+          undefined,
+        )
+      })
+      it('should assign ids to instance ad update notificationIds mapping', async () => {
+        const addition = toChange({ after: deployableInstance })
+        const { deployResult } = await filter.deploy([addition])
+        expect(deployResult.appliedChanges).toHaveLength(1)
+        expect(deployResult.errors).toHaveLength(0)
+        const inst = getChangeData(deployResult.appliedChanges[0]) as InstanceElement
+        expect(inst.value.id).toEqual('1')
+        expect(inst.value.notificationIds['3-EmailAddress-email']).toEqual('123')
+      })
+    })
+    // describe('modification change', () => {
 
-      expect(deployResult.errors).toHaveLength(1)
+    // it('should update notificationIds mapping', async () => {
+
+    // })
+    // })
+    describe('removal change', () => {
+      it('should remove instance', async () => {
+        const removal = toChange({ before: instance })
+        const res = await filter.deploy([removal])
+        expect(res.deployResult.appliedChanges).toHaveLength(1)
+        expect(res.deployResult.errors).toHaveLength(0)
+        expect(connection.delete).toHaveBeenCalledWith(
+          '/rest/api/3/notificationscheme/1',
+          { data: undefined },
+        )
+      })
     })
 
-    it('should throw if failed to deploy events', async () => {
-      deployWithJspEndpointsMock.mockImplementationOnce(async ({ changes }) => ({
-        appliedChanges: changes,
-        errors: [],
-      }))
+    // it('should create the right event changes on modification', async () => {
+    //   instance.value.notificationIds = {}
+    //   instance.value.notificationIds['2-EmailAddress-email'] = '3'
 
-      deployWithJspEndpointsMock.mockImplementationOnce(async () => ({
-        appliedChanges: [],
-        errors: [{ message: 'someError', severity: 'Error' as SeverityLevel }],
-      }))
+    //   const instanceAfter = instance.clone()
 
-      const { deployResult } = await filter.deploy([
-        toChange({ after: instance }),
-      ])
+    //   instance.value.notificationSchemeEvents.push({
+    //     eventType: '3',
+    //     notifications: [{
+    //       type: 'EmailAddress',
+    //       parameter: 'email2',
+    //     }],
+    //   })
 
-      expect(deployResult.errors).toHaveLength(1)
-    })
+    //   instance.value.notificationIds['3-EmailAddress-email2'] = '4'
+
+    //   instanceAfter.value.notificationSchemeEvents.push({
+    //     eventType: '3',
+    //     notifications: [{
+    //       type: 'otherType',
+    //     }],
+    //   })
+    //   const { deployResult } = await filter.deploy([
+    //     toChange({ before: instance, after: instanceAfter }),
+    //   ])
+
+    //   expect(deployResult.errors).toHaveLength(0)
+    //   expect(deployResult.appliedChanges).toHaveLength(1)
+
+    //   const eventRemoval = toChange({
+    //     before: new InstanceElement(
+    //       '3-EmailAddress-email2',
+    //       notificationEventType,
+    //       {
+    //         name: '3-EmailAddress-email2',
+    //         schemeId: '1',
+    //         id: '4',
+    //         eventTypeIds: '3',
+    //         type: 'Single_Email_Address',
+    //         Single_Email_Address: 'email2',
+    //       },
+    //     ),
+    //   })
+
+    //   const eventAddition = toChange({
+    //     after: new InstanceElement(
+    //       '3-otherType-undefined',
+    //       notificationEventType,
+    //       {
+    //         name: '3-otherType-undefined',
+    //         schemeId: '1',
+    //         eventTypeIds: '3',
+    //         type: 'otherType',
+    //       },
+    //     ),
+    //   })
+
+    //   expect(deployWithJspEndpointsMock).toHaveBeenNthCalledWith(2, {
+    //     changes: [eventRemoval, eventAddition],
+    //     client,
+    //     urls: {
+    //       add: '/secure/admin/AddNotification.jspa',
+    //       remove: '/secure/admin/DeleteNotification.jspa',
+    //       query: '/rest/api/3/notificationscheme/1?expand=all',
+    //     },
+    //     queryFunction: expect.toBeFunction(),
+    //   })
+    // })
+
+    // it('should throw if notificationSchemeEvents inner type is not an object type', async () => {
+    //   notificationSchemeType.fields.notificationSchemeEvents = new Field(
+    //     notificationEventType,
+    //     'notificationSchemeEvents',
+    //     BuiltinTypes.STRING,
+    //   )
+
+    //   const { deployResult } = await filter.deploy([
+    //     toChange({ after: instance }),
+    //   ])
+
+    //   expect(deployResult.errors).toHaveLength(1)
+    // })
   })
   describe('using DC', () => {
     beforeEach(async () => {
@@ -443,19 +364,6 @@ describe('notificationSchemeDeploymentFilter', () => {
         paginator,
         config,
       })) as filterUtils.FilterWith<'onFetch' | 'deploy' | 'preDeploy' | 'onDeploy'>
-    })
-    it('should not add schemeId in preDeploy', async () => {
-      await filter.preDeploy([
-        toChange({ before: instance, after: instance }),
-      ])
-      expect(instance.value.schemeId).toBeUndefined()
-    })
-    it('should not remove schemeId in onDeploy', async () => {
-      instance.value.schemeId = '1'
-      await filter.onDeploy([
-        toChange({ before: instance, after: instance }),
-      ])
-      expect(instance.value.schemeId).toBe('1')
     })
     it('should not deploy any change', async () => {
       const { deployResult, leftoverChanges } = await filter.deploy([


### PR DESCRIPTION
Our current deployment of NotificationScheme no longer works due to changes in the private API

---

This PR replaces the API used for deployment of `NotificationScheme` from private API deployment (using JSP endpoint) to official `NotificationScheme` API.

unit test are still missing, will add soon

---
_Release Notes_: 

_Jira_adapter_:
- Fix bug in deployment of NotificationScheme type

---
_User Notifications_: 
None
