### PR TITLE
SALTO-5141: Allow metadata in requestForm to be null

### DIFF
--- a/packages/jira-adapter/src/filters/layouts/layout_service_operations.ts
+++ b/packages/jira-adapter/src/filters/layouts/layout_service_operations.ts
@@ -107,7 +107,7 @@ const fromLayoutConfigRespToLayoutConfig = (
   layoutConfig: IssueLayoutConfiguration
 ): issueLayoutConfig => {
   const { containers } = layoutConfig.issueLayoutResult
-  const fieldItemIdToMetaData = Object.fromEntries(layoutConfig.metadata.configuration.items.nodes
+  const fieldItemIdToMetaData = Object.fromEntries((layoutConfig.metadata?.configuration.items.nodes ?? [])
     .filter(node => !_.isEmpty(node))
     .map(node => [node.fieldItemId, _.omit(node, 'fieldItemId')]))
 

--- a/packages/jira-adapter/src/filters/layouts/layout_types.ts
+++ b/packages/jira-adapter/src/filters/layouts/layout_types.ts
@@ -102,7 +102,7 @@ export type IssueLayoutConfiguration = {
     name: string
     containers: containerIssueLayoutResponse[]
   }
-  metadata: {
+  metadata?: {
     configuration: {
       items: {
         nodes: {

--- a/packages/jira-adapter/src/filters/layouts/layout_types.ts
+++ b/packages/jira-adapter/src/filters/layouts/layout_types.ts
@@ -145,6 +145,6 @@ export const ISSUE_LAYOUT_RESPONSE_SCHEME = Joi.object({
           nodes: Joi.array().items(Joi.object({}).unknown(true).required()).required(),
         }).required(),
       }).unknown(true).required(),
-    }).unknown(true).required(),
+    }).unknown(true).allow(null).required(),
   }).unknown(true).required(),
 }).unknown(true).required()

--- a/packages/jira-adapter/test/filters/layouts/request_type_request_form.test.ts
+++ b/packages/jira-adapter/test/filters/layouts/request_type_request_form.test.ts
@@ -293,5 +293,49 @@ describe('requestTypeLayoutsFilter', () => {
       const issueLayoutInstance = instances.find(e => e.elemID.typeName === REQUEST_FORM_TYPE)
       expect(issueLayoutInstance?.elemID.getFullName()).toEqual('jira.RequestForm.instance.someName')
     })
+    it('should add request form when metadata is null', async () => {
+      mockGet.mockImplementation(params => {
+        if (params.url === '/rest/gira/1') {
+          return {
+            data: {
+              issueLayoutConfiguration: {
+                issueLayoutResult: {
+                  id: '2',
+                  name: 'Default Issue Layout',
+                  containers: [
+                    {
+                      containerType: 'PRIMARY',
+                      items: {
+                        nodes: [
+                          {
+                            fieldItemId: 'testField1',
+                          },
+                        ],
+                      },
+                    },
+                    {
+                      containerType: 'SECONDARY',
+                      items: {
+                        nodes: [
+                          {
+                            fieldItemId: 'testField2',
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+                metadata: null,
+              },
+            },
+          }
+        }
+        throw new Error('Err')
+      })
+      await filter.onFetch(elements)
+      const instances = elements.filter(isInstanceElement)
+      const issueLayoutInstance = instances.find(e => e.elemID.typeName === REQUEST_FORM_TYPE)
+      expect(issueLayoutInstance).toBeDefined()
+    })
   })
 })


### PR DESCRIPTION
In this PR I added the option to fetch and deploy when metadata is null. 

---

_Additional context for reviewer_
None

---
_Release Notes_: 
None

---
_User Notifications_: 
None
