### PR TITLE
SALTO-5140: Allow state static files to be stored in S3

### DIFF
--- a/packages/cli/src/commands/env.ts
+++ b/packages/cli/src/commands/env.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import { EOL } from 'os'
-import { diff, localWorkspaceConfigSource, createEnvironmentSource, loadLocalWorkspace } from '@salto-io/core'
+import { diff, createEnvironmentSource, loadLocalWorkspace } from '@salto-io/core'
 import { Workspace, createElementSelectors, remoteMap as rm, EnvironmentSource } from '@salto-io/workspace'
 import { CommandDefAction, createCommandGroupDef, createPublicCommandDef, createWorkspaceCommand, WorkspaceCommandAction } from '../command_builder'
 import { CliOutput, CliExitCode } from '../types'
@@ -340,13 +340,11 @@ Promise<CliExitCode> => {
 
   try {
     await maybeIsolateExistingEnv(args.output, workspace, force, yesAll)
-    const workspaceConfig = await localWorkspaceConfigSource(args.workspacePath)
     const rmcToEnvSource = async (remoteMapCreator: rm.RemoteMapCreator):
     Promise<EnvironmentSource> =>
       createEnvironmentSource({
         env: envName,
         baseDir: args.workspacePath,
-        localStorage: workspaceConfig.localStorage,
         remoteMapCreator,
         persistent: true,
         workspaceConfig: { uid: workspace.uid, name: workspace.name },

--- a/packages/cli/src/commands/workspace.ts
+++ b/packages/cli/src/commands/workspace.ts
@@ -15,7 +15,7 @@
 */
 import { EOL } from 'os'
 import { cleanWorkspace } from '@salto-io/core'
-import { StateConfig, WorkspaceComponents } from '@salto-io/workspace'
+import { ProviderOptionsS3, StateConfig, WorkspaceComponents } from '@salto-io/workspace'
 import { getUserBooleanInput } from '../callbacks'
 import { header, formatCleanWorkspace, formatCancelCommand, formatStepStart, formatStepFailed, formatStepCompleted } from '../formatter'
 import { outputLine, errorOutputLine } from '../outputer'
@@ -154,15 +154,14 @@ const cacheGroupDef = createCommandGroupDef({
 
 type SetStateProviderArgs = {
   provider?: StateConfig['provider']
-  bucket?: string
-}
+} & Partial<ProviderOptionsS3>
 
 export const setStateProviderAction: WorkspaceCommandAction<SetStateProviderArgs> = async ({
   workspace,
   input,
   output,
 }) => {
-  const { provider, bucket } = input
+  const { provider, bucket, prefix } = input
   outputLine(`Setting state provider ${provider} for workspace`, output)
   const stateConfig: StateConfig = { provider: provider ?? 'file' }
 
@@ -171,7 +170,7 @@ export const setStateProviderAction: WorkspaceCommandAction<SetStateProviderArgs
       errorOutputLine('Must set bucket name with provider of type s3', output)
       return CliExitCode.UserInputError
     }
-    stateConfig.options = { s3: { bucket } }
+    stateConfig.options = { s3: { bucket, prefix } }
   }
   if (provider !== 's3' && bucket !== undefined) {
     errorOutputLine('bucket argument is only valid with provider type s3', output)
@@ -199,6 +198,11 @@ const setStateProviderDef = createWorkspaceCommand({
         name: 'bucket',
         type: 'string',
         description: 'When provider is S3, the bucket name were state data can be stored',
+      },
+      {
+        name: 'prefix',
+        type: 'string',
+        description: 'A prefix inside the bucket where files will be stored',
       },
     ],
   },

--- a/packages/cli/test/commands/workspace.test.ts
+++ b/packages/cli/test/commands/workspace.test.ts
@@ -289,11 +289,11 @@ describe('workspace command group', () => {
       it('should set the state config to have a s3 provider', async () => {
         const result = await setStateProviderAction({
           ...cliCommandArgs,
-          input: { provider: 's3', bucket: 'my-bucket' },
+          input: { provider: 's3', bucket: 'my-bucket', prefix: 'prefix' },
           workspace,
         })
         expect(result).toEqual(CliExitCode.Success)
-        expect(workspace.updateStateProvider).toHaveBeenCalledWith({ provider: 's3', options: { s3: { bucket: 'my-bucket' } } })
+        expect(workspace.updateStateProvider).toHaveBeenCalledWith({ provider: 's3', options: { s3: { bucket: 'my-bucket', prefix: 'prefix' } } })
       })
       it('should fail if the bucket argument is missing', async () => {
         const result = await setStateProviderAction({

--- a/packages/core/src/local-workspace/s3_dir_store.ts
+++ b/packages/core/src/local-workspace/s3_dir_store.ts
@@ -22,7 +22,7 @@ import { dirStore, staticFiles } from '@salto-io/workspace'
 import Bottleneck from 'bottleneck'
 import getStream from 'get-stream'
 import { Readable } from 'stream'
-import { values } from '@salto-io/lowerdash'
+// import { values } from '@salto-io/lowerdash'
 
 const log = logger(module)
 
@@ -97,35 +97,36 @@ export const buildS3DirectoryStore = (
     }
   }
 
-  const listPage = async (token: string | undefined): Promise<AWS.ListObjectsV2CommandOutput> =>
-    bottleneck.schedule(
-      () => {
-        log.trace('Listing %s in S3 bucket %s with token %s', baseDir, bucketName, token)
-        return s3.listObjectsV2({
-          Bucket: bucketName,
-          Prefix: baseDir,
-          ContinuationToken: token,
-        })
-      }
-    )
+  // const listPage = async (token: string | undefined): Promise<AWS.ListObjectsV2CommandOutput> =>
+  //   bottleneck.schedule(
+  //     () => {
+  //       log.trace('Listing %s in S3 bucket %s with token %s', baseDir, bucketName, token)
+  //       return s3.listObjectsV2({
+  //         Bucket: bucketName,
+  //         Prefix: baseDir,
+  //         ContinuationToken: token,
+  //       })
+  //     }
+  //   )
 
   const list = async (): Promise<string[]> => log.time(
     async () => {
       const paths = new Set<string>(Object.keys(updated))
-      let currentPage: AWS.ListObjectsV2CommandOutput | undefined
-      try {
-        do {
-          // eslint-disable-next-line no-await-in-loop
-          currentPage = await listPage(currentPage?.NextContinuationToken)
-          currentPage.Contents
-            ?.map(({ Key }) => Key && path.posix.relative(baseDir, Key))
-            .filter(values.isDefined)
-            .forEach(key => paths.add(key))
-        } while (currentPage?.NextContinuationToken !== undefined)
-      } catch (err) {
-        log.warn('Failed listing %s in S3 bucket %s with token %s', baseDir, bucketName, currentPage?.NextContinuationToken)
-        throw err
-      }
+      // let currentPage: AWS.ListObjectsV2CommandOutput | undefined
+      // try {
+      //   do {
+      //     // eslint-disable-next-line no-await-in-loop
+      //     currentPage = await listPage(currentPage?.NextContinuationToken)
+      //     currentPage.Contents
+      //       ?.map(({ Key }) => Key && path.posix.relative(baseDir, Key))
+      //       .filter(values.isDefined)
+      //       .forEach(key => paths.add(key))
+      //   } while (currentPage?.NextContinuationToken !== undefined)
+      // } catch (err) {
+      // eslint-disable-next-line max-len
+      //   log.warn('Failed listing %s in S3 bucket %s with token %s', baseDir, bucketName, currentPage?.NextContinuationToken)
+      //   throw err
+      // }
 
       return Array.from(paths)
     },

--- a/packages/core/src/local-workspace/s3_dir_store.ts
+++ b/packages/core/src/local-workspace/s3_dir_store.ts
@@ -22,7 +22,7 @@ import { dirStore, staticFiles } from '@salto-io/workspace'
 import Bottleneck from 'bottleneck'
 import getStream from 'get-stream'
 import { Readable } from 'stream'
-// import { values } from '@salto-io/lowerdash'
+import { values } from '@salto-io/lowerdash'
 
 const log = logger(module)
 
@@ -97,36 +97,35 @@ export const buildS3DirectoryStore = (
     }
   }
 
-  // const listPage = async (token: string | undefined): Promise<AWS.ListObjectsV2CommandOutput> =>
-  //   bottleneck.schedule(
-  //     () => {
-  //       log.trace('Listing %s in S3 bucket %s with token %s', baseDir, bucketName, token)
-  //       return s3.listObjectsV2({
-  //         Bucket: bucketName,
-  //         Prefix: baseDir,
-  //         ContinuationToken: token,
-  //       })
-  //     }
-  //   )
+  const listPage = async (token: string | undefined): Promise<AWS.ListObjectsV2CommandOutput> =>
+    bottleneck.schedule(
+      () => {
+        log.trace('Listing %s in S3 bucket %s with token %s', baseDir, bucketName, token)
+        return s3.listObjectsV2({
+          Bucket: bucketName,
+          Prefix: baseDir,
+          ContinuationToken: token,
+        })
+      }
+    )
 
   const list = async (): Promise<string[]> => log.time(
     async () => {
       const paths = new Set<string>(Object.keys(updated))
-      // let currentPage: AWS.ListObjectsV2CommandOutput | undefined
-      // try {
-      //   do {
-      //     // eslint-disable-next-line no-await-in-loop
-      //     currentPage = await listPage(currentPage?.NextContinuationToken)
-      //     currentPage.Contents
-      //       ?.map(({ Key }) => Key && path.posix.relative(baseDir, Key))
-      //       .filter(values.isDefined)
-      //       .forEach(key => paths.add(key))
-      //   } while (currentPage?.NextContinuationToken !== undefined)
-      // } catch (err) {
-      // eslint-disable-next-line max-len
-      //   log.warn('Failed listing %s in S3 bucket %s with token %s', baseDir, bucketName, currentPage?.NextContinuationToken)
-      //   throw err
-      // }
+      let currentPage: AWS.ListObjectsV2CommandOutput | undefined
+      try {
+        do {
+          // eslint-disable-next-line no-await-in-loop
+          currentPage = await listPage(currentPage?.NextContinuationToken)
+          currentPage.Contents
+            ?.map(({ Key }) => Key && path.posix.relative(baseDir, Key))
+            .filter(values.isDefined)
+            .forEach(key => paths.add(key))
+        } while (currentPage?.NextContinuationToken !== undefined)
+      } catch (err) {
+        log.warn('Failed listing %s in S3 bucket %s with token %s', baseDir, bucketName, currentPage?.NextContinuationToken)
+        throw err
+      }
 
       return Array.from(paths)
     },

--- a/packages/core/src/local-workspace/state/content_providers/common.ts
+++ b/packages/core/src/local-workspace/state/content_providers/common.ts
@@ -17,6 +17,7 @@ import { logger } from '@salto-io/logging'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { hash } from '@salto-io/lowerdash'
 import { Readable } from 'stream'
+import { staticFiles } from '@salto-io/workspace'
 
 const { toMD5 } = hash
 const log = logger(module)
@@ -39,6 +40,7 @@ export type StateContentProvider = {
   getHash: (filePaths: string[]) => Promise<string>
   readContents: (filePaths: string[]) => AsyncIterable<NamedStream>
   writeContents: (prefix: string, contents: ContentAndHash[]) => Promise<void>
+  staticFilesSource: staticFiles.StateStaticFilesSource
 }
 
 

--- a/packages/core/src/local-workspace/state/content_providers/file_content_provider.ts
+++ b/packages/core/src/local-workspace/state/content_providers/file_content_provider.ts
@@ -20,13 +20,17 @@ import { createHash } from 'crypto'
 import getStream from 'get-stream'
 
 import { collections } from '@salto-io/lowerdash'
+import { state } from '@salto-io/workspace'
 import { exists, rm, rename, replaceContents, createReadStream } from '@salto-io/file'
 import { StateContentProvider, getHashFromHashes } from './common'
+import { localDirectoryStore } from '../../dir_store'
 
 const { awu } = collections.asynciterable
 const glob = promisify(origGlob)
 
-export const createFileStateContentProvider = (): StateContentProvider => {
+export const STATE_STATIC_FILES_LOCAL_DIR = 'static-resources'
+
+export const createFileStateContentProvider = (localStorageDir: string): StateContentProvider => {
   const buildLocalStateFileName = (prefix: string, account: string): string => `${prefix}.${account}.jsonl.zip`
   const findStateFiles = (prefix: string): Promise<string[]> => glob(buildLocalStateFileName(prefix, '*([!.])'))
   return {
@@ -63,5 +67,8 @@ export const createFileStateContentProvider = (): StateContentProvider => {
         })
       )
     },
+    staticFilesSource: state.buildOverrideStateStaticFilesSource(
+      localDirectoryStore({ baseDir: path.resolve(localStorageDir, STATE_STATIC_FILES_LOCAL_DIR) })
+    ),
   }
 }

--- a/packages/core/src/local-workspace/state/content_providers/s3_content_provider.ts
+++ b/packages/core/src/local-workspace/state/content_providers/s3_content_provider.ts
@@ -24,8 +24,10 @@ import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import { readTextFile, rm, rename, replaceContents } from '@salto-io/file'
 import { inspectValue, safeJsonStringify, createSchemeGuard } from '@salto-io/adapter-utils'
+import { state, ProviderOptionsS3 } from '@salto-io/workspace'
 
 import { StateContentProvider, getHashFromHashes } from './common'
+import { buildS3DirectoryStore } from '../../s3_dir_store'
 
 const { awu } = collections.asynciterable
 const glob = promisify(origGlob)
@@ -62,23 +64,26 @@ const findLocalStateFiles = (prefix: string): Promise<string[]> => (
 
 type CreateS3StateContentProviderArgs = {
   workspaceId: string
-  bucketName: string
+  options: ProviderOptionsS3
 }
 export const createS3StateContentProvider = (
-  { workspaceId, bucketName }: CreateS3StateContentProviderArgs
+  { workspaceId, options }: CreateS3StateContentProviderArgs
 ): StateContentProvider => {
+  const { bucket, prefix, uploadConcurrencyLimit } = options
+  const remoteBasePath = prefix === undefined ? `state/${workspaceId}` : `${prefix}/state/${workspaceId}`
+
   const buildRemoteStateFileName = ({ account, contentHash }: LocalStateFileContent): string => (
-    `${workspaceId}/${account}/${contentHash}`
+    `${remoteBasePath}/${account}/${contentHash}`
   )
 
   const s3 = createS3Client()
   return {
     findStateFiles: findLocalStateFiles,
-    clear: async prefix => {
+    clear: async localPrefix => {
       // We do not clear the current state file content from S3 on purpose as we expect that historic states
       // could be useful, and if not, that a lifecycle can be setup on S3 to remove them
       // This is to keep in line with the fact that we do not delete the previous state file on every writeContents
-      const localFiles = await findLocalStateFiles(prefix)
+      const localFiles = await findLocalStateFiles(localPrefix)
       await Promise.all(localFiles.map(filename => rm(filename)))
     },
     rename: async (oldPrefix, newPrefix) => {
@@ -98,8 +103,8 @@ export const createS3StateContentProvider = (
         .map(async filePath => {
           const parsedFile = await parseLocalStateFile(filePath)
           const remoteStatePath = buildRemoteStateFileName(parsedFile)
-          log.debug('Creating state content read stream from %s/%s', bucketName, remoteStatePath)
-          const readRes = await s3.getObject({ Bucket: bucketName, Key: remoteStatePath })
+          log.debug('Creating state content read stream from %s/%s', bucket, remoteStatePath)
+          const readRes = await s3.getObject({ Bucket: bucket, Key: remoteStatePath })
           const stream = readRes.Body
           if (!(stream instanceof Readable)) {
             // Should never happen
@@ -108,20 +113,28 @@ export const createS3StateContentProvider = (
           return { name: filePath, stream }
         })
     ),
-    writeContents: async (prefix, contents) => {
+    writeContents: async (localPrefix, contents) => {
       // Upload content to S3
       await Promise.all(contents.map(async ({ account, content, contentHash }) => {
         const remoteStatePath = buildRemoteStateFileName({ account, contentHash })
-        log.debug('Uploading state content to %s/%s', bucketName, remoteStatePath)
-        await s3.putObject({ Bucket: bucketName, Key: remoteStatePath, Body: content })
+        log.debug('Uploading state content to %s/%s', bucket, remoteStatePath)
+        await s3.putObject({ Bucket: bucket, Key: remoteStatePath, Body: content })
       }))
       // Update local files to point to new hash values
       await Promise.all(contents.map(async ({ account, contentHash }) => {
         await replaceContents(
-          buildLocalStateFileName(prefix, account),
+          buildLocalStateFileName(localPrefix, account),
           safeJsonStringify({ account, contentHash } as LocalStateFileContent)
         )
       }))
     },
+    staticFilesSource: state.buildHistoryStateStaticFilesSource(
+      buildS3DirectoryStore({
+        bucketName: bucket,
+        baseDir: `${prefix}/${workspaceId}`,
+        S3Client: s3,
+        concurrencyLimit: uploadConcurrencyLimit,
+      })
+    ),
   }
 }

--- a/packages/core/src/local-workspace/workspace.ts
+++ b/packages/core/src/local-workspace/workspace.ts
@@ -138,11 +138,10 @@ const getLocalEnvName = (env: string): string => (env === COMMON_ENV_PREFIX
   : path.join(ENVS_PREFIX, env))
 
 export const createEnvironmentSource = async ({
-  env, baseDir, localStorage, remoteMapCreator, stateStaticFilesSource, persistent, workspaceConfig,
+  env, baseDir, remoteMapCreator, stateStaticFilesSource, persistent, workspaceConfig,
 }: {
   env: string
   baseDir: string
-  localStorage: string
   remoteMapCreator: remoteMap.RemoteMapCreator
   stateStaticFilesSource?: staticFiles.StateStaticFilesSource
   persistent: boolean
@@ -164,14 +163,12 @@ export const createEnvironmentSource = async ({
       remoteMapCreator,
       persistent,
       staticFilesSource: stateStaticFilesSource,
-      localStorageDir: localStorage,
     }),
   }
 }
 
 export const loadLocalElementsSources = async ({
   baseDir,
-  localStorage,
   envs,
   remoteMapCreator,
   stateStaticFilesSource,
@@ -179,7 +176,7 @@ export const loadLocalElementsSources = async ({
   persistent = true,
 }: {
   baseDir: string
-  localStorage: string
+  localStorage?: string // TODO: remove unused argument (kept backwards compatibility)
   envs: ReadonlyArray<string>
   remoteMapCreator: remoteMap.RemoteMapCreator
   stateStaticFilesSource?: staticFiles.StateStaticFilesSource
@@ -192,7 +189,7 @@ export const loadLocalElementsSources = async ({
       [
         env,
         await createEnvironmentSource({
-          env, baseDir, localStorage, remoteMapCreator, persistent, stateStaticFilesSource, workspaceConfig,
+          env, baseDir, remoteMapCreator, persistent, stateStaticFilesSource, workspaceConfig,
         }),
       ]))),
     [COMMON_ENV_PREFIX]: {
@@ -297,7 +294,6 @@ const loadLocalWorkspaceImpl = async ({
 
   const elemSources = await loadLocalElementsSources({
     baseDir,
-    localStorage: workspaceConfigSrc.localStorage,
     envs: envNames,
     remoteMapCreator,
     stateStaticFilesSource,
@@ -398,7 +394,6 @@ Promise<Workspace> => {
 
   const elemSources = await loadLocalElementsSources({
     baseDir: path.resolve(baseDir),
-    localStorage,
     envs: [envName],
     remoteMapCreator,
     stateStaticFilesSource,

--- a/packages/core/src/local-workspace/workspace.ts
+++ b/packages/core/src/local-workspace/workspace.ts
@@ -21,7 +21,7 @@ import { exists, isEmptyDir, rm } from '@salto-io/file'
 import { Workspace, loadWorkspace, EnvironmentsSources, initWorkspace, nacl, remoteMap,
   configSource as cs, staticFiles, dirStore, WorkspaceComponents, errors, elementSource,
   COMMON_ENV_PREFIX, isValidEnvName, EnvironmentSource, EnvConfig, adaptersConfigSource,
-  createAdapterReplacedID, state, buildStaticFilesCache } from '@salto-io/workspace'
+  createAdapterReplacedID, buildStaticFilesCache } from '@salto-io/workspace'
 import { collections } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import { localDirectoryStore, createExtensionFileFilter } from './dir_store'
@@ -163,9 +163,8 @@ export const createEnvironmentSource = async ({
       envName: env,
       remoteMapCreator,
       persistent,
-      staticFilesSource: stateStaticFilesSource ?? state.buildOverrideStateStaticFilesSource(
-        localDirectoryStore({ baseDir: path.resolve(localStorage, STATIC_RESOURCES_FOLDER) })
-      ),
+      staticFilesSource: stateStaticFilesSource,
+      localStorageDir: localStorage,
     }),
   }
 }

--- a/packages/core/test/workspace/local/state/content_providers/file_content_provider.test.ts
+++ b/packages/core/test/workspace/local/state/content_providers/file_content_provider.test.ts
@@ -25,7 +25,7 @@ const { awu } = collections.asynciterable
 describe('createFileStateContentProvider', () => {
   let provider: StateContentProvider
   beforeEach(() => {
-    provider = createFileStateContentProvider()
+    provider = createFileStateContentProvider('localStorage')
   })
   const testDir = setupTmpDir()
   const accountNames = ['salesforce', 'netsuite', 'dummy']

--- a/packages/core/test/workspace/local/state/content_providers/s3_content_provider.test.ts
+++ b/packages/core/test/workspace/local/state/content_providers/s3_content_provider.test.ts
@@ -67,7 +67,7 @@ describe('createS3StateContentProvider', () => {
 
   beforeEach(async () => {
     s3mock.reset()
-    provider = createS3StateContentProvider({ workspaceId, bucketName })
+    provider = createS3StateContentProvider({ workspaceId, options: { bucket: bucketName } })
     await Promise.all(
       accountNames.map(name => setupStateFile(name, 'hash'))
     )

--- a/packages/core/test/workspace/local/state/content_providers/s3_content_provider.test.ts
+++ b/packages/core/test/workspace/local/state/content_providers/s3_content_provider.test.ts
@@ -61,7 +61,7 @@ describe('createS3StateContentProvider', () => {
     const localContent: LocalStateFileContent = { account, contentHash }
     await writeFile(path.join(testDir.name(), `env.${account}.json`), safeJsonStringify(localContent))
     s3mock
-      .on(GetObjectCommand, { Bucket: bucketName, Key: `${workspaceId}/${account}/${remoteHash ?? contentHash}` })
+      .on(GetObjectCommand, { Bucket: bucketName, Key: `state/${workspaceId}/${account}/${remoteHash ?? contentHash}` })
       .resolves({ Body: sdkStreamMixin(Readable.from('stateData')) })
   }
 
@@ -168,7 +168,7 @@ describe('createS3StateContentProvider', () => {
     })
     it('should upload new data to S3', () => {
       expect(s3mock.calls().map(({ args }) => args[0].input)).toIncludeSameMembers(
-        accountNames.map(account => expect.objectContaining({ Bucket: bucketName, Key: `${workspaceId}/${account}/newHash` }))
+        accountNames.map(account => expect.objectContaining({ Bucket: bucketName, Key: `state/${workspaceId}/${account}/newHash` }))
       )
     })
     it('should return the new contents when reading', async () => {

--- a/packages/core/test/workspace/local/state/state.test.ts
+++ b/packages/core/test/workspace/local/state/state.test.ts
@@ -18,9 +18,9 @@ import { Readable } from 'stream'
 import { createGzip } from 'zlib'
 import getStream from 'get-stream'
 import { chain } from 'stream-chain'
-import { ObjectType, ElemID, isObjectType, Element, toChange } from '@salto-io/adapter-api'
+import { ObjectType, ElemID, isObjectType, Element, toChange, InstanceElement, StaticFile } from '@salto-io/adapter-api'
 import { getDetailedChanges, safeJsonStringify } from '@salto-io/adapter-utils'
-import { state as wsState, pathIndex, remoteMap, staticFiles, serialization } from '@salto-io/workspace'
+import { state as wsState, pathIndex, remoteMap, staticFiles, serialization, StateConfig, ProviderOptionsS3 } from '@salto-io/workspace'
 import { hash, collections } from '@salto-io/lowerdash'
 import { mockFunction } from '@salto-io/test-utils'
 import { getStateContentProvider, loadState, localState } from '../../../../src/local-workspace/state/state'
@@ -31,6 +31,7 @@ import { mockStaticFilesSource } from '../../../common/state'
 import { inMemRemoteMapCreator } from '../../../common/helpers'
 import { getHashFromHashes, StateContentProvider } from '../../../../src/local-workspace/state/content_providers'
 import * as contentProviders from '../../../../src/local-workspace/state/content_providers'
+import { getLocalStoragePath } from '../../../../src/app_config'
 
 const { awu } = collections.asynciterable
 const { toMD5 } = hash
@@ -86,7 +87,6 @@ describe('localState', () => {
 
   describe('multiple state files', () => {
     let state: wsState.State
-    let stateStaticFilesSource: staticFiles.StateStaticFilesSource
     let contentProvider: jest.Mocked<StateContentProvider>
     let sfElements: Element[]
     let nsElements: Element[]
@@ -96,7 +96,6 @@ describe('localState', () => {
     const pathPrefix = 'multiple_files'
     let mapCreator: remoteMap.RemoteMapCreator
     beforeEach(async () => {
-      stateStaticFilesSource = mockStaticFilesSource()
       nsElements = getTopLevelElements('netsuite')
       sfElements = getTopLevelElements('salesforce')
       sfUpdateDate = new Date('2023-02-01T00:00:00.000Z')
@@ -106,7 +105,7 @@ describe('localState', () => {
         [`${pathPrefix}/salesforce`]: await mockStateContent({ elements: sfElements, date: sfUpdateDate, version: '0.0.1' }),
       })
       mapCreator = inMemRemoteMapCreator()
-      state = localState(pathPrefix, 'env', mapCreator, contentProvider, 'localStorage', stateStaticFilesSource)
+      state = localState(pathPrefix, 'env', mapCreator, contentProvider)
       initialStateHash = await state.getHash()
     })
 
@@ -301,7 +300,7 @@ describe('localState', () => {
     let contentProvider: jest.Mocked<StateContentProvider>
     beforeEach(() => {
       contentProvider = mockContentProvider({})
-      state = localState('empty', '', inMemRemoteMapCreator(), contentProvider, 'localStorage', mockStaticFilesSource())
+      state = localState('empty', '', inMemRemoteMapCreator(), contentProvider)
     })
 
     it('should return an undefined hash', async () => {
@@ -420,12 +419,38 @@ describe('localState', () => {
         'env/extraLine': await mockStateContent({ elements: getTopLevelElements('extra'), extraLine: '"more data?"' }),
         'env/emptyVersion': await mockStateContent({ elements: getTopLevelElements('noVersion'), version: '' }),
       })
-      state = localState('malformed', '', inMemRemoteMapCreator(), contentProvider, 'localStorage')
+      state = localState('malformed', '', inMemRemoteMapCreator(), contentProvider)
     })
     it('should still read elements successfully', async () => {
       await expect(state.getAll()).resolves.toBeDefined()
       const elements = await awu(await state.getAll()).toArray()
       expect(elements).toHaveLength(getTopLevelElements().length * 3)
+    })
+  })
+
+  describe('when given an overriding static files source', () => {
+    let state: wsState.State
+    let contentProvider: jest.Mocked<StateContentProvider>
+    let overridingStateFilesSource: staticFiles.StateStaticFilesSource
+    let instanceWithStaticFile: InstanceElement
+    beforeEach(() => {
+      instanceWithStaticFile = new InstanceElement('inst', mockElement, { content: new StaticFile({ filepath: 'path', content: Buffer.from('asd') }) })
+      overridingStateFilesSource = mockStaticFilesSource([])
+      contentProvider = mockContentProvider({})
+      state = localState('empty', '', inMemRemoteMapCreator(), contentProvider, overridingStateFilesSource)
+    })
+    it('should use the overriding files source and not the one from the content provider', async () => {
+      await state.set(instanceWithStaticFile)
+      await state.flush()
+      expect(overridingStateFilesSource.flush).toHaveBeenCalledTimes(1)
+      expect(contentProvider.staticFilesSource.flush).not.toHaveBeenCalled()
+    })
+    it('should keep the overriding static file source after config update', async () => {
+      await state.updateConfig({ workspaceId: 'wsId', stateConfig: undefined })
+      await state.set(instanceWithStaticFile)
+      await state.flush()
+      expect(overridingStateFilesSource.flush).toHaveBeenCalledTimes(1)
+      expect(contentProvider.staticFilesSource.flush).not.toHaveBeenCalled()
     })
   })
 })
@@ -434,38 +459,44 @@ describe('getStateContentProvider', () => {
   describe('when called with empty state config', () => {
     it('should return a file content provider', () => {
       const createFileStateContentProvider = jest.spyOn(contentProviders, 'createFileStateContentProvider')
-      getStateContentProvider('workspaceId', 'localStorage')
+      getStateContentProvider('workspaceId')
       expect(createFileStateContentProvider).toHaveBeenCalled()
     })
   })
   describe('when state config says file provider', () => {
     it('should return a file content provider', () => {
       const createFileStateContentProvider = jest.spyOn(contentProviders, 'createFileStateContentProvider')
-      getStateContentProvider('workspaceId', 'localStorage', { provider: 'file' })
-      expect(createFileStateContentProvider).toHaveBeenCalled()
+      getStateContentProvider('workspaceId', { provider: 'file' })
+      expect(createFileStateContentProvider).toHaveBeenCalledWith(getLocalStoragePath('workspaceId'))
+    })
+    describe('when local storage is provided in the config', () => {
+      it('should use the local storage from the config', () => {
+        const createFileStateContentProvider = jest.spyOn(contentProviders, 'createFileStateContentProvider')
+        getStateContentProvider('workspaceId', { provider: 'file', options: { file: { localStorageDir: 'myLocalStorage' } } })
+        expect(createFileStateContentProvider).toHaveBeenCalledWith('myLocalStorage')
+      })
     })
   })
   describe('when state config says s3 provider', () => {
     describe('when the config is valid', () => {
       it('should return a s3 content provider', () => {
         const createS3StateContentProvider = jest.spyOn(contentProviders, 'createS3StateContentProvider')
-        getStateContentProvider('workspaceId', 'localStorage', { provider: 's3', options: { s3: { bucket: 'my_bucket' } } })
-        expect(createS3StateContentProvider).toHaveBeenCalledWith({ workspaceId: 'workspaceId', bucketName: 'my_bucket' })
+        const s3Options: ProviderOptionsS3 = { bucket: 'my_bucket', prefix: 'my_prefix' }
+        getStateContentProvider('workspaceId', { provider: 's3', options: { s3: s3Options } })
+        expect(createS3StateContentProvider).toHaveBeenCalledWith({ workspaceId: 'workspaceId', options: s3Options })
       })
     })
     describe('when the config is missing the bucket', () => {
       it('should fail', () => {
-        expect(() => getStateContentProvider('workspaceId', 'localStorage', { provider: 's3' })).toThrow()
-        expect(() => getStateContentProvider('workspaceId', 'localStorage', { provider: 's3', options: {} })).toThrow()
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        expect(() => getStateContentProvider('workspaceId', 'localStorage', { provider: 's3', options: { s3: {} as any } })).toThrow()
+        expect(() => getStateContentProvider('workspaceId', { provider: 's3' })).toThrow()
+        expect(() => getStateContentProvider('workspaceId', { provider: 's3', options: {} })).toThrow()
+        expect(() => getStateContentProvider('workspaceId', { provider: 's3', options: { s3: {} as unknown as ProviderOptionsS3 } })).toThrow()
       })
     })
   })
   describe('when state config says unknown provider', () => {
     it('should fail', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect(() => getStateContentProvider('workspaceId', 'localStorage', { provider: 'something' as any })).toThrow()
+      expect(() => getStateContentProvider('workspaceId', { provider: 'something' } as unknown as StateConfig)).toThrow()
     })
   })
 })
@@ -480,7 +511,6 @@ describe('loadState', () => {
         envName: 'env',
         remoteMapCreator: inMemRemoteMapCreator(),
         staticFilesSource: mockStaticFilesSource(),
-        localStorageDir: 'localStorage',
         persistent: false,
       })
       expect(createFileStateContentProvider).toHaveBeenCalled()

--- a/packages/core/test/workspace/local/workspace.test.ts
+++ b/packages/core/test/workspace/local/workspace.test.ts
@@ -125,14 +125,12 @@ describe('local workspace', () => {
         new ws.remoteMap.InMemoryRemoteMap<T, K>()
       const elemSources = await loadLocalElementsSources({
         baseDir: '.',
-        localStorage: path.join(getSaltoHome(), 'local'),
         envs: ['env1', 'env2'],
         remoteMapCreator: creator,
         stateStaticFilesSource: mockStaticFilesSource(),
         workspaceConfig: { name: 'asd', uid: 'asd' },
       })
       expect(Object.keys(elemSources.sources)).toHaveLength(3)
-      expect(mockCreateDirStore).toHaveBeenCalledTimes(6)
       const dirStoresBaseDirs = mockCreateDirStore.mock.calls.map(c => c[0])
         .map(params => toWorkspaceRelative(params))
       expect(dirStoresBaseDirs).toContain(path.join(ENVS_PREFIX, 'env1'))

--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -22,7 +22,7 @@ import * as hiddenValues from './src/workspace/hidden_values'
 import * as configSource from './src/workspace/config_source'
 import * as workspaceConfigSource from './src/workspace/workspace_config_source'
 import * as adaptersConfigSource from './src/workspace/adapters_config_source'
-import { WorkspaceConfig, EnvConfig, StateConfig } from './src/workspace/config/workspace_config_types'
+import { WorkspaceConfig, EnvConfig, StateConfig, ProviderOptionsS3 } from './src/workspace/config/workspace_config_types'
 import * as state from './src/workspace/state'
 import * as dirStore from './src/workspace/dir_store'
 import * as parseCache from './src/workspace/nacl_files/parsed_nacl_files_cache'
@@ -63,6 +63,7 @@ export {
   elementSource,
   remoteMap,
   WorkspaceConfig,
+  ProviderOptionsS3,
   EnvConfig,
   StateConfig,
   // Workspace exports

--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -22,7 +22,7 @@ import * as hiddenValues from './src/workspace/hidden_values'
 import * as configSource from './src/workspace/config_source'
 import * as workspaceConfigSource from './src/workspace/workspace_config_source'
 import * as adaptersConfigSource from './src/workspace/adapters_config_source'
-import { WorkspaceConfig, EnvConfig, StateConfig, ProviderOptionsS3 } from './src/workspace/config/workspace_config_types'
+import { WorkspaceConfig, EnvConfig, StateConfig, ProviderOptionsS3, ProviderOptionsFile } from './src/workspace/config/workspace_config_types'
 import * as state from './src/workspace/state'
 import * as dirStore from './src/workspace/dir_store'
 import * as parseCache from './src/workspace/nacl_files/parsed_nacl_files_cache'
@@ -64,6 +64,7 @@ export {
   remoteMap,
   WorkspaceConfig,
   ProviderOptionsS3,
+  ProviderOptionsFile,
   EnvConfig,
   StateConfig,
   // Workspace exports

--- a/packages/workspace/src/workspace/config/workspace_config_types.ts
+++ b/packages/workspace/src/workspace/config/workspace_config_types.ts
@@ -33,8 +33,13 @@ export type ProviderOptionsS3 = {
   uploadConcurrencyLimit?: number
 }
 
+export type ProviderOptionsFile = {
+  localStorageDir: string
+}
+
 export type ProviderOptions = {
   s3?: ProviderOptionsS3
+  file?: ProviderOptionsFile
 }
 
 

--- a/packages/workspace/src/workspace/config/workspace_config_types.ts
+++ b/packages/workspace/src/workspace/config/workspace_config_types.ts
@@ -29,6 +29,8 @@ export type AdaptersConfig = {
 
 export type ProviderOptionsS3 = {
   bucket: string
+  prefix?: string
+  uploadConcurrencyLimit?: number
 }
 
 export type ProviderOptions = {


### PR DESCRIPTION
This allows the workspace configuration to determine the location of the static file source for the state
Currently using the same storage provider as the state content

---

_Additional context for reviewer_

---
_Release Notes_: 
Core:
- Added support for storing state static files in S3

---
_User Notifications_: 
_None_