### PR TITLE
SALTO-5110 NS important values filter

### DIFF
--- a/packages/adapter-utils/src/important_values.ts
+++ b/packages/adapter-utils/src/important_values.ts
@@ -13,17 +13,10 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { logger } from '@salto-io/logging'
-import {
-  CORE_ANNOTATIONS,
-  Element,
-  isField,
-  isInstanceElement,
-  isObjectType, isPrimitiveValue, isReferenceExpression,
-  ReadOnlyElementsSource, Value,
-} from '@salto-io/adapter-api'
-import { values } from '@salto-io/lowerdash'
 import _ from 'lodash'
+import { logger } from '@salto-io/logging'
+import { values } from '@salto-io/lowerdash'
+import { CORE_ANNOTATIONS, Element, isField, isInstanceElement, isObjectType, isPrimitiveValue, isReferenceExpression, ObjectType, ReadOnlyElementsSource, Value } from '@salto-io/adapter-api'
 
 const log = logger(module)
 const { isDefined } = values
@@ -31,6 +24,17 @@ const { isDefined } = values
 type ImportantValue = { value: string; indexed: boolean; highlighted: boolean }
 export type ImportantValues = ImportantValue[]
 export type FormattedImportantValueData = { key: string; value: Value }
+
+export const toImportantValues = (
+  type: ObjectType,
+  fieldNames: string[],
+  { indexed = false, highlighted = false }: {
+    indexed?: boolean
+    highlighted?: boolean
+  }
+): ImportantValues => fieldNames
+  .filter(fieldName => type.fields[fieldName] !== undefined)
+  .map(fieldName => ({ value: fieldName, highlighted, indexed }))
 
 const isValidIndexedValueData = (importantValue: ImportantValue, valueData: unknown): boolean => {
   if (importantValue.indexed !== true) {

--- a/packages/adapter-utils/test/important_values.test.ts
+++ b/packages/adapter-utils/test/important_values.test.ts
@@ -24,7 +24,7 @@ import {
   ReadOnlyElementsSource, ReferenceExpression,
 } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '../src/element_source'
-import { getImportantValues } from '../src/important_values'
+import { getImportantValues, toImportantValues } from '../src/important_values'
 
 const userType = new ObjectType({
   elemID: new ElemID('salto', 'user'),
@@ -112,6 +112,38 @@ const inst = new InstanceElement(
   }
 )
 
+describe('toImportantValues', () => {
+  it('should return only existing fields', () => {
+    expect(toImportantValues(obj, ['name', 'description'], { indexed: true }))
+      .toEqual([
+        {
+          value: 'name',
+          indexed: true,
+          highlighted: false,
+        },
+      ])
+  })
+  it('should return fields in the given order', () => {
+    expect(toImportantValues(obj, ['user', 'name', 'active'], { highlighted: true }))
+      .toEqual([
+        {
+          value: 'user',
+          indexed: false,
+          highlighted: true,
+        },
+        {
+          value: 'name',
+          indexed: false,
+          highlighted: true,
+        },
+        {
+          value: 'active',
+          indexed: false,
+          highlighted: true,
+        },
+      ])
+  })
+})
 
 describe('getImportantValues', () => {
   let elementSource: ReadOnlyElementsSource

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -61,6 +61,7 @@ import currencyUndeployableFieldsFilter from './filters/currency_omit_fields'
 import additionalChanges from './filters/additional_changes'
 import addInstancesFetchTime from './filters/add_instances_fetch_time'
 import addAliasFilter from './filters/add_alias'
+import addImportantValuesFilter from './filters/add_important_values'
 import addBundleReferences from './filters/bundle_ids'
 import excludeCustomRecordTypes from './filters/exclude_by_criteria/exclude_custom_record_types'
 import excludeInstances from './filters/exclude_by_criteria/exclude_instances'
@@ -134,6 +135,7 @@ export const allFilters: (LocalFilterCreatorDefinition | RemoteFilterCreatorDefi
   { creator: customRecordsFilter },
   { creator: addInstancesFetchTime },
   { creator: addAliasFilter },
+  { creator: addImportantValuesFilter },
   // serviceUrls must run after suiteAppInternalIds and SDFInternalIds filter
   { creator: serviceUrls, addsNewInformation: true },
   { creator: addBundleReferences },

--- a/packages/netsuite-adapter/src/change_validators/inactive_parent.ts
+++ b/packages/netsuite-adapter/src/change_validators/inactive_parent.ts
@@ -19,11 +19,9 @@ import { AdditionChange, Change, ChangeError, InstanceElement, ModificationChang
 import { collections } from '@salto-io/lowerdash'
 import { isDataObjectType, isCustomRecordType } from '../types'
 import { NetsuiteChangeValidator } from './types'
-import { PARENT } from '../constants'
+import { INACTIVE_FIELDS, PARENT } from '../constants'
 
 const { awu } = collections.asynciterable
-
-const IS_INACTIVE_FIELD = 'isInactive'
 
 const isDataElementChange = async (change: Change<InstanceElement>): Promise<boolean> => {
   const changeType = await getChangeData(change).getType()
@@ -49,7 +47,7 @@ const hasInactiveParent = async (
 ): Promise<boolean> => (
   isReferenceExpression(instance.value[PARENT])
     && isInstanceElement(instance.value[PARENT].value)
-    ? (instance.value[PARENT].value.value[IS_INACTIVE_FIELD] === true)
+    ? (instance.value[PARENT].value.value[INACTIVE_FIELDS.isInactive] === true)
     : false
 )
 

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -22,11 +22,7 @@ import {
 import { createMatchingObjectType, safeJsonStringify, formatConfigSuggestionsReasons } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { config as configUtils } from '@salto-io/adapter-components'
-import {
-  BIN,
-  CURRENCY, CUSTOM_RECORD_TYPE, CUSTOM_RECORD_TYPE_NAME_PREFIX, DATASET, EXCHANGE_RATE,
-  NETSUITE, PERMISSIONS, SAVED_SEARCH, WORKBOOK,
-} from './constants'
+import { BIN, CURRENCY, CUSTOM_RECORD_TYPE, CUSTOM_RECORD_TYPE_NAME_PREFIX, DATASET, EXCHANGE_RATE, INACTIVE_FIELDS, NETSUITE, PERMISSIONS, SAVED_SEARCH, WORKBOOK } from './constants'
 import { NetsuiteQueryParameters, FetchParams, convertToQueryParams, QueryParams, FetchTypeQueryParams, FieldToOmitParams, validateArrayOfStrings, validatePlainObject, validateFetchParameters, FETCH_PARAMS, validateFieldsToOmitConfig, NetsuiteFilePathsQueryParams, NetsuiteTypesQueryParams, checkTypeNameRegMatch, noSupportedTypeMatch, validateNetsuiteQueryParameters, validateDefined, LockedElementsConfig, emptyQueryParams, fullFetchConfig, isCriteriaQuery, CriteriaQuery } from './query'
 import { ITEM_TYPE_TO_SEARCH_STRING } from './data_elements/types'
 import { isCustomRecordTypeName, netsuiteSupportedTypes } from './types'
@@ -57,15 +53,15 @@ export const UNLIMITED_INSTANCES_VALUE = -1
 export const DEFAULT_AXIOS_TIMEOUT_IN_MINUTES = 20
 
 const ALL_TYPES_REGEX = '.*'
-const INACTIVE_FIELDS_NAMES = ['isinactive', 'inactive', 'isInactive']
 const FILE_TYPES_TO_EXCLUDE_REGEX = '.*\\.(csv|pdf|eml|png|gif|jpeg|xls|xlsx|doc|docx|ppt|pptx)'
 
-const inactiveElementsCriteria = INACTIVE_FIELDS_NAMES.map((fieldName): CriteriaQuery => ({
-  name: ALL_TYPES_REGEX,
-  criteria: {
-    [fieldName]: true,
-  },
-}))
+const inactiveElementsCriteria = Object.values(INACTIVE_FIELDS)
+  .map((fieldName): CriteriaQuery => ({
+    name: ALL_TYPES_REGEX,
+    criteria: {
+      [fieldName]: true,
+    },
+  }))
 
 // Taken from https://github.com/salto-io/netsuite-suitecloud-sdk/blob/e009e0eefcd918635353d093be6a6c2222d223b8/packages/node-cli/src/validation/InteractiveAnswersValidator.js#L27
 const SUITEAPP_ID_FORMAT_REGEX = /^[a-z0-9]+(\.[a-z0-9]+){2}$/
@@ -531,6 +527,7 @@ const fetchConfigType = createMatchingObjectType<FetchParams>({
     fieldsToOmit: { refType: new ListType(fieldsToOmitConfig) },
     addAlias: { refType: BuiltinTypes.BOOLEAN },
     addBundles: { refType: BuiltinTypes.BOOLEAN },
+    addImportantValues: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/netsuite-adapter/src/constants.ts
+++ b/packages/netsuite-adapter/src/constants.ts
@@ -88,6 +88,13 @@ export const CUSTOM_FIELD = 'customField'
 export const CUSTOM_FIELD_LIST = 'customFieldList'
 export const CONTENT = 'content'
 
+type InactiveFields = 'isinactive' | 'inactive' | 'isInactive'
+export const INACTIVE_FIELDS: { [K in InactiveFields]: K } = {
+  isinactive: 'isinactive',
+  inactive: 'inactive',
+  isInactive: 'isInactive',
+}
+
 // Field Annotations
 export const SOAP = 'soap'
 export const IS_ATTRIBUTE = 'isAttribute'

--- a/packages/netsuite-adapter/src/filters/add_important_values.ts
+++ b/packages/netsuite-adapter/src/filters/add_important_values.ts
@@ -16,7 +16,7 @@
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import { CORE_ANNOTATIONS, ObjectType, isObjectType } from '@salto-io/adapter-api'
-import { ImportantValues } from '@salto-io/adapter-utils'
+import { ImportantValues, toImportantValues } from '@salto-io/adapter-utils'
 import { LocalFilterCreator } from '../filter'
 import { isCustomRecordType, netsuiteSupportedTypes } from '../types'
 import { CUSTOM_RECORD_TYPE, INACTIVE_FIELDS, NAME_FIELD, SCRIPT_ID } from '../constants'
@@ -45,31 +45,9 @@ const customRecordInstancesImportantValues = (): ImportantValues => [
   },
 ]
 
-const toHighlightedImportantValues = (
-  type: ObjectType,
-  fieldNames: string[]
-): ImportantValues => fieldNames
-  .filter(fieldName => type.fields[fieldName] !== undefined)
-  .map(fieldName => ({
-    value: fieldName,
-    highlighted: true,
-    indexed: false,
-  }))
-
-const toIndexedHighlightedImportantValues = (
-  type: ObjectType,
-  fieldNames: string[]
-): ImportantValues => fieldNames
-  .filter(fieldName => type.fields[fieldName] !== undefined)
-  .map(fieldName => ({
-    value: fieldName,
-    highlighted: true,
-    indexed: true,
-  }))
-
 const getImportantValues = (type: ObjectType): ImportantValues => [
-  ...toHighlightedImportantValues(type, HIGHLIGHTED_FIELD_NAMES),
-  ...toIndexedHighlightedImportantValues(type, Object.values(INACTIVE_FIELDS)),
+  ...toImportantValues(type, HIGHLIGHTED_FIELD_NAMES, { highlighted: true }),
+  ...toImportantValues(type, Object.values(INACTIVE_FIELDS), { indexed: true, highlighted: true }),
 ]
 
 const filterCreator: LocalFilterCreator = ({ config }) => ({

--- a/packages/netsuite-adapter/src/filters/add_important_values.ts
+++ b/packages/netsuite-adapter/src/filters/add_important_values.ts
@@ -1,0 +1,104 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { logger } from '@salto-io/logging'
+import { CORE_ANNOTATIONS, ObjectType, isObjectType } from '@salto-io/adapter-api'
+import { ImportantValues } from '@salto-io/adapter-utils'
+import { LocalFilterCreator } from '../filter'
+import { isCustomRecordType, netsuiteSupportedTypes } from '../types'
+import { CUSTOM_RECORD_TYPE, INACTIVE_FIELDS, NAME_FIELD, SCRIPT_ID } from '../constants'
+
+const log = logger(module)
+
+const { IMPORTANT_VALUES, SELF_IMPORTANT_VALUES } = CORE_ANNOTATIONS
+
+const HIGHLIGHTED_FIELD_NAMES = [NAME_FIELD, 'label', 'description', SCRIPT_ID]
+
+const customRecordInstancesImportantValues = (): ImportantValues => [
+  {
+    value: NAME_FIELD,
+    highlighted: true,
+    indexed: false,
+  },
+  {
+    value: SCRIPT_ID,
+    highlighted: true,
+    indexed: false,
+  },
+  {
+    value: INACTIVE_FIELDS.isInactive,
+    highlighted: true,
+    indexed: true,
+  },
+]
+
+const toHighlightedImportantValues = (
+  type: ObjectType,
+  fieldNames: string[]
+): ImportantValues => fieldNames
+  .filter(fieldName => type.fields[fieldName] !== undefined)
+  .map(fieldName => ({
+    value: fieldName,
+    highlighted: true,
+    indexed: false,
+  }))
+
+const toIndexedHighlightedImportantValues = (
+  type: ObjectType,
+  fieldNames: string[]
+): ImportantValues => fieldNames
+  .filter(fieldName => type.fields[fieldName] !== undefined)
+  .map(fieldName => ({
+    value: fieldName,
+    highlighted: true,
+    indexed: true,
+  }))
+
+const getImportantValues = (type: ObjectType): ImportantValues => [
+  ...toHighlightedImportantValues(type, HIGHLIGHTED_FIELD_NAMES),
+  ...toIndexedHighlightedImportantValues(type, Object.values(INACTIVE_FIELDS)),
+]
+
+const filterCreator: LocalFilterCreator = ({ config }) => ({
+  name: 'addImportantValues',
+  onFetch: async elements => {
+    if (config.fetch.addImportantValues !== true) {
+      log.info('addImportantValues is disabled')
+      return
+    }
+
+    const [customRecordTypes, types] = _.partition(
+      elements.filter(isObjectType),
+      isCustomRecordType
+    )
+
+    const netsuiteSupportedTypesSet = new Set(netsuiteSupportedTypes)
+    types.filter(type => netsuiteSupportedTypesSet.has(type.elemID.name)).forEach(type => {
+      const importantValues = getImportantValues(type)
+      if (importantValues.length > 0) {
+        type.annotations[IMPORTANT_VALUES] = importantValues
+      }
+    })
+
+    const customRecordType = types.find(type => type.elemID.name === CUSTOM_RECORD_TYPE)
+    customRecordTypes.forEach(type => {
+      type.annotations[SELF_IMPORTANT_VALUES] = customRecordType?.annotations[IMPORTANT_VALUES]
+      type.annotations[IMPORTANT_VALUES] = customRecordInstancesImportantValues()
+    })
+  },
+})
+
+export default filterCreator

--- a/packages/netsuite-adapter/src/query.ts
+++ b/packages/netsuite-adapter/src/query.ts
@@ -77,6 +77,7 @@ export type FetchParams = {
   fieldsToOmit?: FieldToOmitParams[]
   addAlias?: boolean
   addBundles?: boolean
+  addImportantValues?: boolean
 } & LockedElementsConfig['fetch']
 
 export const isCriteriaQuery = (
@@ -114,6 +115,7 @@ export const FETCH_PARAMS: lowerdashTypes.TypeKeysEnum<FetchParams> = {
   fieldsToOmit: 'fieldsToOmit',
   addAlias: 'addAlias',
   addBundles: 'addBundles',
+  addImportantValues: 'addImportantValues',
 }
 
 export const convertToQueryParams = ({

--- a/packages/netsuite-adapter/test/filters/add_important_values.test.ts
+++ b/packages/netsuite-adapter/test/filters/add_important_values.test.ts
@@ -1,0 +1,207 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { CORE_ANNOTATIONS, ElemID, ObjectType, BuiltinTypes } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { LazyElementsSourceIndexes } from '../../src/elements_source_index/types'
+import { getDefaultAdapterConfig } from '../utils'
+import { CUSTOM_RECORD_TYPE, METADATA_TYPE, NETSUITE } from '../../src/constants'
+import filterCreator from '../../src/filters/add_important_values'
+import { LocalFilterOpts } from '../../src/filter'
+import { customrecordtypeType } from '../../src/autogen/types/standard_types/customrecordtype'
+import { workflowType } from '../../src/autogen/types/standard_types/workflow'
+import { entryFormType } from '../../src/autogen/types/standard_types/entryForm'
+import { customlistType } from '../../src/autogen/types/standard_types/customlist'
+import { emptyQueryParams, fullQueryParams } from '../../src/query'
+
+describe('add important values filter', () => {
+  let workflow: ObjectType
+  let innerType: ObjectType
+  let formType: ObjectType
+  let standardCustomRecordType: ObjectType
+  let userCustomRecordType: ObjectType
+  let types: ObjectType[]
+
+  let defaultOpts: LocalFilterOpts
+  let optsWithoutImportantValues: LocalFilterOpts
+  let optsWithImportantValues: LocalFilterOpts
+
+  beforeEach(async () => {
+    workflow = workflowType().type
+    innerType = customlistType().innerTypes.customlist_customvalues_customvalue
+    formType = entryFormType().type
+    standardCustomRecordType = customrecordtypeType().type
+    userCustomRecordType = new ObjectType({
+      elemID: new ElemID(NETSUITE, 'customrecord1'),
+      fields: {
+        scriptid: { refType: BuiltinTypes.SERVICE_ID },
+      },
+      annotations: {
+        [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
+      },
+    })
+
+    types = [
+      workflow,
+      formType,
+      standardCustomRecordType,
+      userCustomRecordType,
+      innerType,
+    ]
+
+    defaultOpts = {
+      elementsSourceIndex: {} as LazyElementsSourceIndexes,
+      elementsSource: buildElementsSourceFromElements([]),
+      isPartial: false,
+      config: await getDefaultAdapterConfig(),
+    }
+    optsWithoutImportantValues = {
+      ...defaultOpts,
+      config: {
+        fetch: {
+          include: fullQueryParams(),
+          exclude: emptyQueryParams(),
+          addImportantValues: false,
+        },
+      },
+    }
+    optsWithImportantValues = {
+      ...defaultOpts,
+      config: {
+        fetch: {
+          include: fullQueryParams(),
+          exclude: emptyQueryParams(),
+          addImportantValues: true,
+        },
+      },
+    }
+  })
+  it('should not add important values when addImportantValues=false', async () => {
+    await filterCreator(optsWithoutImportantValues).onFetch?.(types)
+    expect(types.some(elem => elem.annotations[CORE_ANNOTATIONS.IMPORTANT_VALUES] !== undefined)).toBeFalsy()
+    expect(types.some(elem => elem.annotations[CORE_ANNOTATIONS.SELF_IMPORTANT_VALUES] !== undefined)).toBeFalsy()
+  })
+  it('should not add important values by default', async () => {
+    await filterCreator(defaultOpts).onFetch?.(types)
+    expect(types.some(elem => elem.annotations[CORE_ANNOTATIONS.IMPORTANT_VALUES] !== undefined)).toBeFalsy()
+    expect(types.some(elem => elem.annotations[CORE_ANNOTATIONS.SELF_IMPORTANT_VALUES] !== undefined)).toBeFalsy()
+  })
+  it('should add important values', async () => {
+    await filterCreator(optsWithImportantValues).onFetch?.(types)
+    expect(workflow.annotations).toEqual({
+      _important_values: [
+        {
+          value: 'name',
+          highlighted: true,
+          indexed: false,
+        },
+        {
+          value: 'description',
+          highlighted: true,
+          indexed: false,
+        },
+        {
+          value: 'scriptid',
+          highlighted: true,
+          indexed: false,
+        },
+        {
+          value: 'isinactive',
+          highlighted: true,
+          indexed: true,
+        },
+      ],
+    })
+    expect(formType.annotations).toEqual({
+      _important_values: [
+        {
+          value: 'name',
+          highlighted: true,
+          indexed: false,
+        },
+        {
+          value: 'scriptid',
+          highlighted: true,
+          indexed: false,
+        },
+        {
+          value: 'inactive',
+          highlighted: true,
+          indexed: true,
+        },
+      ],
+    })
+    expect(standardCustomRecordType.annotations).toEqual({
+      _important_values: [
+        {
+          value: 'description',
+          highlighted: true,
+          indexed: false,
+        },
+        {
+          value: 'scriptid',
+          highlighted: true,
+          indexed: false,
+        },
+        {
+          value: 'isinactive',
+          highlighted: true,
+          indexed: true,
+        },
+      ],
+    })
+    expect(userCustomRecordType.annotations).toEqual({
+      _important_values: [
+        {
+          value: 'name',
+          highlighted: true,
+          indexed: false,
+        },
+        {
+          value: 'scriptid',
+          highlighted: true,
+          indexed: false,
+        },
+        {
+          value: 'isInactive',
+          highlighted: true,
+          indexed: true,
+        },
+      ],
+      _self_important_values: [
+        {
+          value: 'description',
+          highlighted: true,
+          indexed: false,
+        },
+        {
+          value: 'scriptid',
+          highlighted: true,
+          indexed: false,
+        },
+        {
+          value: 'isinactive',
+          highlighted: true,
+          indexed: true,
+        },
+      ],
+      [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
+    })
+
+    expect(innerType.fields.scriptid).toBeDefined()
+    expect(innerType.fields.isinactive).toBeDefined()
+    expect(innerType.annotations).toEqual({})
+  })
+})


### PR DESCRIPTION
Adding general important values to all types - only those that exist in the type (in that order):
1. name
2. label
3. description
4. scriptid
5. isinactive / inactive / isInactive

This filter will run with the adapter config value `addImportantValues=true`

---

_Additional context for reviewer_

TODO:
- [x] add tests

---
_Release Notes_: 
Netsuite Adapter:
- Add important values (with adapter config `addImportantValues=true`)

---
_User Notifications_: 
Netsuite Adapter:
- The `_important_values` annotation will be added to all types (custom record types will also have `_self_important_values`)
