### PR TITLE
SALTO-5146: Fixing Form Fetch

### DIFF
--- a/packages/jira-adapter/src/filters/forms/forms_types.ts
+++ b/packages/jira-adapter/src/filters/forms/forms_types.ts
@@ -40,7 +40,7 @@ type DetailedFormDataResponse = {
 
 type FormResponse = {
   id: number
-  name: string
+  name?: string
 }
 
 type FormsResponse = {
@@ -50,7 +50,7 @@ type FormsResponse = {
 export const FORMS_RESPONSE_SCHEME = Joi.object({
   data: Joi.array().items(Joi.object({
     id: Joi.number().required(),
-    name: Joi.string().required(),
+    name: Joi.string().allow(''),
   }).unknown(true).required()),
 }).unknown(true).required()
 


### PR DESCRIPTION
In this PR I fixed the form schemaGuard to allow a form to be untitled when I get the list of forms in a project. 
Their is additional  schemaGuard that blocks the untitled form to be fetched. 

---

_Additional context for reviewer_
None

---
_Release Notes_: 
None

---
_User Notifications_: 
None
