### PR TITLE
SALTO-5133: False masking of data deploy group errors.

### DIFF
--- a/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
+++ b/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
@@ -545,9 +545,9 @@ const deploySingleTypeAndActionCustomObjectInstancesGroup = async (
       return await deployModifyChanges(changes, client, groupId)
     }
     return customObjectInstancesDeployError('Custom Object Instances change group must have one action')
-  } catch (error: unknown) {
-    log.error('Unknown error occurred for Data Deploy group %s: %o', groupId, error)
-    return customObjectInstancesDeployError('Unknown error occurred')
+  } catch (error) {
+    log.error('Error occurred for Data Deploy group %s: %o', groupId, error)
+    return customObjectInstancesDeployError(error.message)
   }
 }
 


### PR DESCRIPTION
Fixed false masking of data deploy group errors

---

_Release Notes_: 
Salesforce Adapter:
- Fixed a bug where data deploy group errors were falsely masked.
---

_User Notifications_: 
_None_
