### PR TITLE
SALTO-5071 Zendesk request timeout

### DIFF
--- a/packages/adapter-components/src/client/config.ts
+++ b/packages/adapter-components/src/client/config.ts
@@ -37,7 +37,7 @@ export type ClientRetryConfig = Partial<{
 
 export type ClientTimeoutConfig = Partial<{
   maxDuration: number
-  resetTimeoutBetweenAttempts: boolean
+  retryOnTimeout: boolean
   lastRetryNoTimeout: boolean
 }>
 
@@ -102,7 +102,7 @@ export const createClientConfigType = <RateLimitConfig extends ClientRateLimitCo
     elemID: new ElemID(adapter, 'clientTimeoutConfig'),
     fields: {
       maxDuration: { refType: BuiltinTypes.NUMBER },
-      resetTimeoutBetweenAttempts: { refType: BuiltinTypes.BOOLEAN },
+      retryOnTimeout: { refType: BuiltinTypes.BOOLEAN },
       lastRetryNoTimeout: { refType: BuiltinTypes.BOOLEAN },
     },
     annotations: {

--- a/packages/adapter-components/src/client/constants.ts
+++ b/packages/adapter-components/src/client/constants.ts
@@ -20,6 +20,8 @@ export const DEFAULT_RETRY_OPTS: Required<ClientRetryConfig> = {
   maxAttempts: 5, // try 5 times
   retryDelay: 5000, // wait for 5s before trying again
   additionalStatusCodesToRetry: [],
+  shouldResetTimeout: true,
+  lastRetryNoTimeout: true,
 }
 
 export const DEFAULT_TIMEOUT_OPTS: Required<ClientTimeoutConfig> = {

--- a/packages/adapter-components/src/client/constants.ts
+++ b/packages/adapter-components/src/client/constants.ts
@@ -24,7 +24,7 @@ export const DEFAULT_RETRY_OPTS: Required<ClientRetryConfig> = {
 
 export const DEFAULT_TIMEOUT_OPTS: Required<ClientTimeoutConfig> = {
   maxDuration: 0,
-  resetTimeoutBetweenAttempts: true,
+  retryOnTimeout: true,
   lastRetryNoTimeout: true,
 }
 

--- a/packages/adapter-components/src/client/constants.ts
+++ b/packages/adapter-components/src/client/constants.ts
@@ -20,8 +20,6 @@ export const DEFAULT_RETRY_OPTS: Required<ClientRetryConfig> = {
   maxAttempts: 5, // try 5 times
   retryDelay: 5000, // wait for 5s before trying again
   additionalStatusCodesToRetry: [],
-  shouldResetTimeout: true,
-  lastRetryNoTimeout: true,
 }
 
 export const DEFAULT_TIMEOUT_OPTS: Required<ClientTimeoutConfig> = {

--- a/packages/adapter-components/src/client/http_connection.ts
+++ b/packages/adapter-components/src/client/http_connection.ts
@@ -131,9 +131,9 @@ export const createRetryOptions = (
       retryCount)
     return retryDelay
   },
-  // We use isSafeRequestError and isIdempotentRequestError instead of isNetworkOrIdempotentRequestError
+  // We use isNetworkError and isSafeRequestError instead of isNetworkOrIdempotentRequestError
   // because we don't want to assume all adapters are idempotent on PUT or DELETE requests
-  retryCondition: err => axiosRetry.isSafeRequestError(err) || axiosRetry.isIdempotentRequestError(err)
+  retryCondition: err => axiosRetry.isNetworkError(err) || axiosRetry.isSafeRequestError(err)
     || shouldRetryStatusCode(err.response?.status, retryOptions.additionalStatusCodesToRetry)
     || shouldRetryOnTimeout(err.code, timeoutOptions?.retryOnTimeout),
   // Note that changing the config is consistent on all retries. For the current use-case, that's fine,

--- a/packages/adapter-components/src/client/http_connection.ts
+++ b/packages/adapter-components/src/client/http_connection.ts
@@ -112,6 +112,10 @@ const getRetryDelay = (retryOptions: Required<ClientRetryConfig>, error: AxiosEr
 const shouldRetryStatusCode = (statusCode?: number, additionalStatusesToRetry: number[] = []): boolean =>
   statusCode !== undefined && [429, ...additionalStatusesToRetry].includes(statusCode)
 
+const shouldRetryOnTimeout = (errorCode: string | undefined, retryOnTimeout: boolean | undefined): boolean =>
+  // axios returns ECONNABORTED on timeouts, but servers can sometimes return ETIMEDOUT
+  (retryOnTimeout ? ['ECONNABORTED', 'ETIMEDOUT'].includes(errorCode ?? '') : false)
+
 export const createRetryOptions = (
   retryOptions: Required<ClientRetryConfig>, timeoutOptions?: ClientTimeoutConfig
 ): RetryOptions => ({
@@ -127,8 +131,11 @@ export const createRetryOptions = (
       retryCount)
     return retryDelay
   },
-  retryCondition: err => axiosRetry.isNetworkOrIdempotentRequestError(err)
-    || shouldRetryStatusCode(err.response?.status, retryOptions.additionalStatusCodesToRetry),
+  // We use isSafeRequestError and isIdempotentRequestError instead of isNetworkOrIdempotentRequestError
+  // because we don't want to assume all adapters are idempotent on PUT or DELETE requests
+  retryCondition: err => axiosRetry.isSafeRequestError(err) || axiosRetry.isIdempotentRequestError(err)
+    || shouldRetryStatusCode(err.response?.status, retryOptions.additionalStatusCodesToRetry)
+    || shouldRetryOnTimeout(err.code, timeoutOptions?.retryOnTimeout),
   // Note that changing the config is consistent on all retries. For the current use-case, that's fine,
   // as we are updating the last retry.
   onRetry: (retryCount, _err, requestConfig) => {
@@ -138,7 +145,8 @@ export const createRetryOptions = (
   },
   // When false, axios-retry interprets the request timeout as a global value,
   // so it is not used for each retry but for the whole request lifecycle.
-  shouldResetTimeout: timeoutOptions?.resetTimeoutBetweenAttempts ?? false,
+  // In our case, if the user wants to retry on timeouts, we need to reset it per retry.
+  shouldResetTimeout: timeoutOptions?.retryOnTimeout,
 })
 
 type ConnectionParams<TCredentials> = {

--- a/packages/adapter-components/src/client/http_connection.ts
+++ b/packages/adapter-components/src/client/http_connection.ts
@@ -201,6 +201,11 @@ export const axiosConnection = <TCredentials>({
       maxBodyLength: Infinity,
       timeout,
     })
+    if (timeout > 0) {
+      // When false, axios-retry interprets the request timeout as a global value,
+      // so it is not used for each retry but for the whole request lifecycle.
+      retryOptions.shouldResetTimeout = true
+    }
     axiosRetry(httpClient, retryOptions)
 
     try {

--- a/packages/adapter-components/src/client/http_connection.ts
+++ b/packages/adapter-components/src/client/http_connection.ts
@@ -201,11 +201,6 @@ export const axiosConnection = <TCredentials>({
       maxBodyLength: Infinity,
       timeout,
     })
-    if (timeout > 0) {
-      // When false, axios-retry interprets the request timeout as a global value,
-      // so it is not used for each retry but for the whole request lifecycle.
-      retryOptions.shouldResetTimeout = true
-    }
     axiosRetry(httpClient, retryOptions)
 
     try {

--- a/packages/adapter-components/test/client/http_client.test.ts
+++ b/packages/adapter-components/test/client/http_client.test.ts
@@ -58,7 +58,7 @@ describe('client_http_client', () => {
           },
           timeout: {
             lastRetryNoTimeout: true,
-            resetTimeoutBetweenAttempts: true,
+            retryOnTimeout: true,
           },
         }
       )

--- a/packages/adapter-components/test/client/http_connection.test.ts
+++ b/packages/adapter-components/test/client/http_connection.test.ts
@@ -105,7 +105,7 @@ describe('client_http_connection', () => {
         additionalStatusCodesToRetry: [],
       },
       {
-        resetTimeoutBetweenAttempts: true,
+        retryOnTimeout: true,
         lastRetryNoTimeout: true,
       })
     })
@@ -115,6 +115,34 @@ describe('client_http_connection', () => {
           status: 429,
         },
       } as AxiosError)).toBeTruthy()
+    })
+
+    it('should retry on timeout if flag is true', () => {
+      expect(retryOptions.retryCondition?.({
+        response: {
+          status: 408,
+        },
+        code: 'ECONNABORTED',
+      } as AxiosError)).toBeTruthy()
+    })
+
+    it('should not retry on timeout if flag is false', () => {
+      retryOptions = createRetryOptions({
+        maxAttempts: 3,
+        retryDelay: 100,
+        additionalStatusCodesToRetry: [],
+      },
+      {
+        retryOnTimeout: false,
+        lastRetryNoTimeout: true,
+      })
+
+      expect(retryOptions.retryCondition?.({
+        response: {
+          status: 408,
+        },
+        code: 'ECONNABORTED',
+      } as AxiosError)).toBeFalsy()
     })
 
     it('should use the retry-after header when available', () => {
@@ -198,7 +226,7 @@ describe('client_http_connection', () => {
             additionalStatusCodesToRetry: [],
           },
           {
-            resetTimeoutBetweenAttempts: true,
+            retryOnTimeout: true,
             lastRetryNoTimeout: false,
           })
           const requestConfig = { timeout: 4 }

--- a/packages/jira-adapter/config_doc.md
+++ b/packages/jira-adapter/config_doc.md
@@ -57,6 +57,13 @@ jira {
 | [rateLimit](#rate-limit-configuration-options)                | `{}` (no overrides)      | Limits on the number of concurrent requests of different types
 | [maxRequestsPerMinute]                                        | unlimited                | Limits on the number of requests per minute
 | usePrivateAPI                                                 | true                     | Whether to use Jira Private API when fetching and deploying changes
+| [timeout](#client-timeout-configuration-options)              | `{}` (no overrides)      | Configuration for setting request timeouts
+
+#### Client timeout configuration options
+
+| Name           | Default when undefined | Description
+|----------------|------------------------|------------
+| [maxDuration]  | `0` (unlimited)     | Set a timeout (in milliseconds) on requests
 
 #### Client retry options
 

--- a/packages/jira-adapter/config_doc.md
+++ b/packages/jira-adapter/config_doc.md
@@ -61,9 +61,11 @@ jira {
 
 #### Client timeout configuration options
 
-| Name           | Default when undefined | Description
-|----------------|------------------------|------------
-| [maxDuration]  | `0` (unlimited)     | Set a timeout (in milliseconds) on requests
+| Name                  | Default when undefined | Description
+|-----------------------|------------------------|------------
+| [maxDuration]         | `0` (unlimited)        | Set a timeout (in milliseconds) on requests
+| [retryOnTimeout]      | true                   | Whether to retry requests that returned a timeout response
+| [lastRetryNoTimeout]  | true                   | Whether to disable the timeout duration on the last retry (if we assume the service will eventually return a response)
 
 #### Client retry options
 

--- a/packages/okta-adapter/config_doc.md
+++ b/packages/okta-adapter/config_doc.md
@@ -45,6 +45,13 @@ okta {
 | [rateLimit](#rate-limit-configuration-options)                | `{}` (no overrides)      | Limits on the number of concurrent requests of different types
 | [maxRequestsPerMinute]                                        |  700                     | Limits on the number of requests per minute
 | usePrivateAPI                                                 | true                     | Whether to use Okta Private API when fetching and deploying changes
+| [timeout](#client-timeout-configuration-options)              | `{}` (no overrides)      | Configuration for setting request timeouts
+
+#### Client timeout configuration options
+
+| Name           | Default when undefined | Description
+|----------------|------------------------|------------
+| [maxDuration]  | `0` (unlimited)     | Set a timeout (in milliseconds) on requests
 
 #### Client retry options
 

--- a/packages/okta-adapter/config_doc.md
+++ b/packages/okta-adapter/config_doc.md
@@ -49,9 +49,11 @@ okta {
 
 #### Client timeout configuration options
 
-| Name           | Default when undefined | Description
-|----------------|------------------------|------------
-| [maxDuration]  | `0` (unlimited)     | Set a timeout (in milliseconds) on requests
+| Name                  | Default when undefined | Description
+|-----------------------|------------------------|------------
+| [maxDuration]         | `0` (unlimited)        | Set a timeout (in milliseconds) on requests
+| [retryOnTimeout]      | true                   | Whether to retry requests that returned a timeout response
+| [lastRetryNoTimeout]  | true                   | Whether to disable the timeout duration on the last retry (if we assume the service will eventually return a response)
 
 #### Client retry options
 

--- a/packages/stripe-adapter/config_doc.md
+++ b/packages/stripe-adapter/config_doc.md
@@ -37,6 +37,13 @@ stripe {
 | [retry](#retry-configuration-options)                         | `{}` (no overrides)      | Configuration for retrying on errors
 | [rateLimit](#rate-limit-configuration-options)                | `{}` (no overrides)      | Limits on the number of concurrent requests of different types
 | [maxRequestsPerMinute]                                        | unlimited                | Limits on the number of requests per minute
+| [timeout](#client-timeout-configuration-options)              | `{}` (no overrides)      | Configuration for setting request timeouts
+
+#### Client timeout configuration options
+
+| Name           | Default when undefined | Description
+|----------------|------------------------|------------
+| [maxDuration]  | `0` (unlimited)     | Set a timeout (in milliseconds) on requests
 
 #### Client retry options
 

--- a/packages/stripe-adapter/config_doc.md
+++ b/packages/stripe-adapter/config_doc.md
@@ -41,9 +41,11 @@ stripe {
 
 #### Client timeout configuration options
 
-| Name           | Default when undefined | Description
-|----------------|------------------------|------------
-| [maxDuration]  | `0` (unlimited)     | Set a timeout (in milliseconds) on requests
+| Name                  | Default when undefined | Description
+|-----------------------|------------------------|------------
+| [maxDuration]         | `0` (unlimited)        | Set a timeout (in milliseconds) on requests
+| [retryOnTimeout]      | true                   | Whether to retry requests that returned a timeout response
+| [lastRetryNoTimeout]  | true                   | Whether to disable the timeout duration on the last retry (if we assume the service will eventually return a response)
 
 #### Client retry options
 

--- a/packages/workato-adapter/config_doc.md
+++ b/packages/workato-adapter/config_doc.md
@@ -46,6 +46,13 @@ workato {
 | [retry](#retry-configuration-options)                         | `{}` (no overrides)      | Configuration for retrying on errors
 | [rateLimit](#rate-limit-configuration-options)                | `{}` (no overrides)      | Limits on the number of concurrent requests of different types
 | [maxRequestsPerMinute]                                        | unlimited                | Limits on the number of requests per minute
+| [timeout](#client-timeout-configuration-options)              | `{}` (no overrides)      | Configuration for setting request timeouts
+
+#### Client timeout configuration options
+
+| Name           | Default when undefined | Description
+|----------------|------------------------|------------
+| [maxDuration]  | `0` (unlimited)     | Set a timeout (in milliseconds) on requests
 
 #### Client retry options
 

--- a/packages/workato-adapter/config_doc.md
+++ b/packages/workato-adapter/config_doc.md
@@ -50,9 +50,11 @@ workato {
 
 #### Client timeout configuration options
 
-| Name           | Default when undefined | Description
-|----------------|------------------------|------------
-| [maxDuration]  | `0` (unlimited)     | Set a timeout (in milliseconds) on requests
+| Name                  | Default when undefined | Description
+|-----------------------|------------------------|------------
+| [maxDuration]         | `0` (unlimited)        | Set a timeout (in milliseconds) on requests
+| [retryOnTimeout]      | true                   | Whether to retry requests that returned a timeout response
+| [lastRetryNoTimeout]  | true                   | Whether to disable the timeout duration on the last retry (if we assume the service will eventually return a response)
 
 #### Client retry options
 

--- a/packages/zendesk-adapter/config_doc.md
+++ b/packages/zendesk-adapter/config_doc.md
@@ -57,9 +57,11 @@ zendesk {
 
 #### Client timeout configuration options
 
-| Name           | Default when undefined | Description
-|----------------|------------------------|------------
-| [maxDuration]  | `5000` (5 seconds)     | Set a timeout (in milliseconds) on requests
+| Name                  | Default when undefined | Description
+|-----------------------|------------------------|------------
+| [maxDuration]         | `5000` (5 seconds)     | Set a timeout (in milliseconds) on requests (setting `0` is unlimited)
+| [retryOnTimeout]      | true                   | Whether to retry requests that returned a timeout response
+| [lastRetryNoTimeout]  | true                   | Whether to disable the timeout duration on the last retry (if we assume the service will eventually return a response)
 
 #### Client retry configuration options
 

--- a/packages/zendesk-adapter/config_doc.md
+++ b/packages/zendesk-adapter/config_doc.md
@@ -53,7 +53,13 @@ zendesk {
 | [retry](#client-retry-configuration-options)                  | `{}` (no overrides)      | Configuration for retrying on errors
 | [rateLimit](#client-rate-limit-configuration-options)         | `{}` (no overrides)      | Limits on the number of concurrent requests of different types
 | [maxRequestsPerMinute]                                        | unlimited                | Limits on the number of requests per minute
-| [timeout]                                                     | `5000` (5 seconds)       | Set a timeout (in milliseconds) on requests to Zendesk
+| [timeout](#client-timeout-configuration-options)              | `{}` (no overrides)      | Configuration for setting request timeouts
+
+#### Client timeout configuration options
+
+| Name           | Default when undefined | Description
+|----------------|------------------------|------------
+| [maxDuration]  | `5000` (5 seconds)     | Set a timeout (in milliseconds) on requests
 
 #### Client retry configuration options
 

--- a/packages/zendesk-adapter/config_doc.md
+++ b/packages/zendesk-adapter/config_doc.md
@@ -50,9 +50,10 @@ zendesk {
 
 | Name                                                          | Default when undefined   | Description
 |---------------------------------------------------------------|--------------------------|------------
-| [retry](#client-retry-configuration-options)                         | `{}` (no overrides)      | Configuration for retrying on errors
-| [rateLimit](#client-rate-limit-configuration-options)                | `{}` (no overrides)      | Limits on the number of concurrent requests of different types
+| [retry](#client-retry-configuration-options)                  | `{}` (no overrides)      | Configuration for retrying on errors
+| [rateLimit](#client-rate-limit-configuration-options)         | `{}` (no overrides)      | Limits on the number of concurrent requests of different types
 | [maxRequestsPerMinute]                                        | unlimited                | Limits on the number of requests per minute
+| [timeout]                                                     | `5000` (5 seconds)       | Set a timeout (in milliseconds) on requests to Zendesk
 
 #### Client retry configuration options
 

--- a/packages/zendesk-adapter/src/client/client.ts
+++ b/packages/zendesk-adapter/src/client/client.ts
@@ -22,7 +22,7 @@ import { Values } from '@salto-io/adapter-api'
 import { createConnection, createResourceConnection, instanceUrl } from './connection'
 import { ZENDESK } from '../constants'
 import { Credentials } from '../auth'
-import { PAGE_SIZE } from '../config'
+import { PAGE_SIZE, DEFAULT_REQUEST_TIMEOUT } from '../config'
 
 const {
   DEFAULT_RETRY_OPTS, DEFAULT_TIMEOUT_OPTS, RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,

--- a/packages/zendesk-adapter/src/client/client.ts
+++ b/packages/zendesk-adapter/src/client/client.ts
@@ -22,10 +22,10 @@ import { Values } from '@salto-io/adapter-api'
 import { createConnection, createResourceConnection, instanceUrl } from './connection'
 import { ZENDESK } from '../constants'
 import { Credentials } from '../auth'
-import { PAGE_SIZE, DEFAULT_REQUEST_TIMEOUT } from '../config'
+import { PAGE_SIZE, DEFAULT_TIMEOUT_OPTS } from '../config'
 
 const {
-  DEFAULT_RETRY_OPTS, DEFAULT_TIMEOUT_OPTS, RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,
+  DEFAULT_RETRY_OPTS, RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,
   throttle, logDecorator, requiresLogin,
 } = clientUtils
 const log = logger(module)

--- a/packages/zendesk-adapter/src/client/connection.ts
+++ b/packages/zendesk-adapter/src/client/connection.ts
@@ -97,10 +97,7 @@ const accessTokenAuthParamsFunc = (
   },
 })
 
-export const createConnection: clientUtils.ConnectionCreator<Credentials> = (
-  retryOptions: clientUtils.RetryOptions,
-  timeout = 0,
-) => (
+export const createConnection: clientUtils.ConnectionCreator<Credentials> = (retryOptions, timeout) => (
   clientUtils.axiosConnection({
     retryOptions,
     authParamsFunc: async (creds: Credentials) => (

--- a/packages/zendesk-adapter/src/client/connection.ts
+++ b/packages/zendesk-adapter/src/client/connection.ts
@@ -97,7 +97,10 @@ const accessTokenAuthParamsFunc = (
   },
 })
 
-export const createConnection: clientUtils.ConnectionCreator<Credentials> = (retryOptions, timeout) => (
+export const createConnection: clientUtils.ConnectionCreator<Credentials> = (
+  retryOptions: clientUtils.RetryOptions,
+  timeout = 0,
+) => (
   clientUtils.axiosConnection({
     retryOptions,
     authParamsFunc: async (creds: Credentials) => (

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -62,6 +62,8 @@ export const DEPLOY_CONFIG = 'deploy'
 
 export const API_DEFINITIONS_CONFIG = 'apiDefinitions'
 
+export const DEFAULT_REQUEST_TIMEOUT = 5000 // Roughly p95 of observed request times
+
 export type IdLocator = {
   fieldRegex: string
   idRegex: string

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -62,7 +62,12 @@ export const DEPLOY_CONFIG = 'deploy'
 
 export const API_DEFINITIONS_CONFIG = 'apiDefinitions'
 
-export const DEFAULT_REQUEST_TIMEOUT = 5000 // Roughly p95 of observed request times
+const DEFAULT_REQUEST_TIMEOUT = 5000 // Roughly p95 of observed request times
+
+export const DEFAULT_TIMEOUT_OPTS = {
+  ...clientUtils.DEFAULT_TIMEOUT_OPTS,
+  maxDuration: DEFAULT_REQUEST_TIMEOUT,
+}
 
 export type IdLocator = {
   fieldRegex: string

--- a/packages/zendesk-adapter/test/change_validators/organization_existence.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/organization_existence.test.ts
@@ -198,7 +198,7 @@ describe('OrganizationExistence', () => {
   })
   it('should not crash if the request for organizations fails', async () => {
     const validator = organizationExistenceValidator(client, DEFAULT_CONFIG[FETCH_CONFIG])
-    mockAxios.onGet().abortRequestOnce()
+    mockAxios.onGet().reply(404)
 
     const slaInstance = createSlaInstance()
     const changes = [toChange({ after: slaInstance })]

--- a/packages/zuora-billing-adapter/config_doc.md
+++ b/packages/zuora-billing-adapter/config_doc.md
@@ -37,6 +37,13 @@ zuora_billing {
 | [retry](#retry-configuration-options)                         | `{}` (no overrides)      | Configuration for retrying on errors
 | [rateLimit](#rate-limit-configuration-options)                | `{}` (no overrides)      | Limits on the number of concurrent requests of different types
 | [maxRequestsPerMinute]                                        | unlimited                | Limits on the number of requests per minute
+| [timeout](#client-timeout-configuration-options)              | `{}` (no overrides)      | Configuration for setting request timeouts
+
+#### Client timeout configuration options
+
+| Name           | Default when undefined | Description
+|----------------|------------------------|------------
+| [maxDuration]  | `0` (unlimited)     | Set a timeout (in milliseconds) on requests
 
 #### Client retry options
 

--- a/packages/zuora-billing-adapter/config_doc.md
+++ b/packages/zuora-billing-adapter/config_doc.md
@@ -41,9 +41,11 @@ zuora_billing {
 
 #### Client timeout configuration options
 
-| Name           | Default when undefined | Description
-|----------------|------------------------|------------
-| [maxDuration]  | `0` (unlimited)     | Set a timeout (in milliseconds) on requests
+| Name                  | Default when undefined | Description
+|-----------------------|------------------------|------------
+| [maxDuration]         | `0` (unlimited)        | Set a timeout (in milliseconds) on requests
+| [retryOnTimeout]      | true                   | Whether to retry requests that returned a timeout response
+| [lastRetryNoTimeout]  | true                   | Whether to disable the timeout duration on the last retry (if we assume the service will eventually return a response)
 
 #### Client retry options
 


### PR DESCRIPTION
Add request timeout documentation for the adapters, add default of 5 seconds for Zendesk with retries.

---

_Additional context for reviewer_

---
_Release Notes_: 
__Zendesk adapter:__
* Add default timeout for requests

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
