### PR TITLE
SALTO-5122 add workflow condition warning

### DIFF
--- a/packages/netsuite-adapter/src/change_validators/workflow_account_specific_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/workflow_account_specific_values.ts
@@ -36,8 +36,10 @@ const toValidationError = (instance: InstanceElement, probField: string): Change
 const toConditionParametersWarning = (elemID: ElemID): ChangeError => ({
   elemID,
   severity: 'Warning',
-  message: 'The condition cannot be applied',
-  detailedMessage: 'A condition builder parameter in this section contains an ACCOUNT_SPECIFIC_VALUE which cannot be deployed due to NetSuite constraints.',
+  message: 'Workflow Condition won\'t be deployed',
+  detailedMessage: 'This Workflow Condition includes an ACCOUNT_SPECIFIC_VALUE, which, due to NetSuite limitations, cannot be deployed.'
+  + ' To ensure a smooth deployment, please edit the element in Salto and replace ACCOUNT_SPECIFIC_VALUE with the real value.'
+  + ' Other non-restricted aspects of the Workflow will be deployed as usual.',
 })
 
 const getClosestInitConditionElemID = (elemID: ElemID): ElemID | undefined => {

--- a/packages/netsuite-adapter/src/change_validators/workflow_account_specific_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/workflow_account_specific_values.ts
@@ -42,14 +42,14 @@ const toConditionParametersWarning = (elemID: ElemID): ChangeError => ({
   + ' Other non-restricted aspects of the Workflow will be deployed as usual.',
 })
 
-const getClosestInitConditionElemID = (elemID: ElemID): ElemID | undefined => {
+const findClosestInitConditionAncestorElemID = (elemID: ElemID): ElemID | undefined => {
   if (elemID.name === INIT_CONDITION) {
     return elemID
   }
   if (elemID.isTopLevel()) {
     return undefined
   }
-  return getClosestInitConditionElemID(elemID.createParentID())
+  return findClosestInitConditionAncestorElemID(elemID.createParentID())
 }
 
 const isNestedValueChanged = (
@@ -88,7 +88,7 @@ const changeValidator: NetsuiteChangeValidator = async changes => (
             }
           }
           if (path.name === PARAMETER) {
-            const conditionElemId = getClosestInitConditionElemID(path) ?? path
+            const conditionElemId = findClosestInitConditionAncestorElemID(path) ?? path
             if (
               !conditionsWithAccountSpecificValues.has(conditionElemId.getFullName())
               && Object.values(value).some((val: Value) => val?.value === ACCOUNT_SPECIFIC_VALUE)

--- a/packages/netsuite-adapter/src/change_validators/workflow_account_specific_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/workflow_account_specific_values.ts
@@ -13,23 +13,18 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { values } from '@salto-io/lowerdash'
-import {
-  ChangeError,
-  getChangeData,
-  InstanceElement,
-  isAdditionOrModificationChange,
-  isInstanceElement,
-} from '@salto-io/adapter-api'
-import { walkOnElement, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
+import { AdditionChange, ChangeError, ElemID, getChangeData, InstanceElement, isAdditionChange, isAdditionOrModificationChange, isEqualValues, isInstanceChange, ModificationChange, Value } from '@salto-io/adapter-api'
+import { walkOnElement, WALK_NEXT_STEP, resolvePath } from '@salto-io/adapter-utils'
 import { ACCOUNT_SPECIFIC_VALUE, WORKFLOW } from '../constants'
 import { NetsuiteChangeValidator } from './types'
 
-
-const { isDefined } = values
+const SEND_EMAIL_ACTION = 'sendemailaction'
 const SENDER = 'sender'
 const RECIPIENT = 'recipient'
 const SPECIFIC = 'SPECIFIC'
+
+const PARAMETER = 'parameter'
+const INIT_CONDITION = 'initcondition'
 
 const toValidationError = (instance: InstanceElement, probField: string): ChangeError => ({
   elemID: instance.elemID,
@@ -38,37 +33,81 @@ const toValidationError = (instance: InstanceElement, probField: string): Change
   detailedMessage: `The Workflow contains a '${probField}' field with an ACCOUNT_SPECIFIC_VALUE which cannot be deployed due to NetSuite constraints. Please refer to https://help.salto.io/en/articles/6845061-deploying-workflows-actions-with-account-specific-value for more information.`,
 })
 
+const toConditionParametersWarning = (elemID: ElemID): ChangeError => ({
+  elemID,
+  severity: 'Warning',
+  message: 'The condition cannot be applied',
+  detailedMessage: 'A condition builder parameter in this section contains an ACCOUNT_SPECIFIC_VALUE which cannot be deployed due to NetSuite constraints.',
+})
+
+const getClosestInitConditionElemID = (elemID: ElemID): ElemID | undefined => {
+  if (elemID.name === INIT_CONDITION) {
+    return elemID
+  }
+  if (elemID.isTopLevel()) {
+    return undefined
+  }
+  return getClosestInitConditionElemID(elemID.createParentID())
+}
+
+const isNestedValueChanged = (
+  change: AdditionChange<InstanceElement> | ModificationChange<InstanceElement>,
+  nestedElemId: ElemID
+): boolean => isAdditionChange(change) || !isEqualValues(
+  resolvePath(change.data.after, nestedElemId),
+  resolvePath(change.data.before, nestedElemId)
+)
 
 const changeValidator: NetsuiteChangeValidator = async changes => (
   changes
     .filter(isAdditionOrModificationChange)
-    .map(getChangeData)
-    .filter(isInstanceElement)
-    .filter(inst => inst.elemID.typeName === WORKFLOW)
-    .map(instance => {
-      let foundError: ChangeError | undefined
+    .filter(isInstanceChange)
+    .flatMap(change => {
+      const instance = getChangeData(change)
+      if (instance.elemID.typeName !== WORKFLOW) {
+        return []
+      }
+
+      const sendEmailActionFieldsWithAccountSpecificValues = new Set<string>()
+      const conditionsWithAccountSpecificValues = new Set<string>()
+
       walkOnElement({
         element: instance,
         func: ({ value, path }) => {
           if (path.isAttrID()) {
             return WALK_NEXT_STEP.SKIP
           }
-          if (path.createParentID().name === 'sendemailaction') {
-            if (value?.sender === ACCOUNT_SPECIFIC_VALUE && value?.sendertype === SPECIFIC) {
-              foundError = toValidationError(instance, SENDER)
-              return WALK_NEXT_STEP.EXIT
+          if (path.createParentID().name === SEND_EMAIL_ACTION) {
+            if (value?.[SENDER] === ACCOUNT_SPECIFIC_VALUE && value?.sendertype === SPECIFIC) {
+              sendEmailActionFieldsWithAccountSpecificValues.add(SENDER)
             }
-            if (value?.recipient === ACCOUNT_SPECIFIC_VALUE && value?.recipienttype === SPECIFIC) {
-              foundError = toValidationError(instance, RECIPIENT)
-              return WALK_NEXT_STEP.EXIT
+            if (value?.[RECIPIENT] === ACCOUNT_SPECIFIC_VALUE && value?.recipienttype === SPECIFIC) {
+              sendEmailActionFieldsWithAccountSpecificValues.add(RECIPIENT)
+            }
+          }
+          if (path.name === PARAMETER) {
+            const conditionElemId = getClosestInitConditionElemID(path) ?? path
+            if (
+              !conditionsWithAccountSpecificValues.has(conditionElemId.getFullName())
+              && Object.values(value).some((val: Value) => val?.value === ACCOUNT_SPECIFIC_VALUE)
+              && isNestedValueChanged(change, conditionElemId)
+            ) {
+              conditionsWithAccountSpecificValues.add(conditionElemId.getFullName())
             }
           }
           return WALK_NEXT_STEP.RECURSE
         },
       })
-      return foundError
+
+      const sendEmailActionErrors = Array.from(sendEmailActionFieldsWithAccountSpecificValues)
+        .map(fieldName => toValidationError(instance, fieldName))
+
+      const conditionWarnings = Array.from(conditionsWithAccountSpecificValues)
+        .map(ElemID.fromFullName)
+        .map(toConditionParametersWarning)
+
+      return sendEmailActionErrors.concat(conditionWarnings)
     })
-    .filter(isDefined)
 )
 
 export default changeValidator

--- a/packages/netsuite-adapter/test/change_validators/workflow_account_specific_values.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/workflow_account_specific_values.test.ts
@@ -170,8 +170,10 @@ describe('workflow account specific values', () => {
         {
           elemID: instance.elemID.createNestedID('initcondition'),
           severity: 'Warning',
-          message: 'The condition cannot be applied',
-          detailedMessage: 'A condition builder parameter in this section contains an ACCOUNT_SPECIFIC_VALUE which cannot be deployed due to NetSuite constraints.',
+          message: 'Workflow Condition won\'t be deployed',
+          detailedMessage: 'This Workflow Condition includes an ACCOUNT_SPECIFIC_VALUE, which, due to NetSuite limitations, cannot be deployed.'
+          + ' To ensure a smooth deployment, please edit the element in Salto and replace ACCOUNT_SPECIFIC_VALUE with the real value.'
+          + ' Other non-restricted aspects of the Workflow will be deployed as usual.',
         },
       ])
     })
@@ -201,8 +203,10 @@ describe('workflow account specific values', () => {
         {
           elemID: instance.elemID.createNestedID('initcondition'),
           severity: 'Warning',
-          message: 'The condition cannot be applied',
-          detailedMessage: 'A condition builder parameter in this section contains an ACCOUNT_SPECIFIC_VALUE which cannot be deployed due to NetSuite constraints.',
+          message: 'Workflow Condition won\'t be deployed',
+          detailedMessage: 'This Workflow Condition includes an ACCOUNT_SPECIFIC_VALUE, which, due to NetSuite limitations, cannot be deployed.'
+          + ' To ensure a smooth deployment, please edit the element in Salto and replace ACCOUNT_SPECIFIC_VALUE with the real value.'
+          + ' Other non-restricted aspects of the Workflow will be deployed as usual.',
         },
       ])
     })
@@ -218,8 +222,10 @@ describe('workflow account specific values', () => {
         {
           elemID: instance.elemID.createNestedID('initcondition'),
           severity: 'Warning',
-          message: 'The condition cannot be applied',
-          detailedMessage: 'A condition builder parameter in this section contains an ACCOUNT_SPECIFIC_VALUE which cannot be deployed due to NetSuite constraints.',
+          message: 'Workflow Condition won\'t be deployed',
+          detailedMessage: 'This Workflow Condition includes an ACCOUNT_SPECIFIC_VALUE, which, due to NetSuite limitations, cannot be deployed.'
+          + ' To ensure a smooth deployment, please edit the element in Salto and replace ACCOUNT_SPECIFIC_VALUE with the real value.'
+          + ' Other non-restricted aspects of the Workflow will be deployed as usual.',
         },
       ])
     })

--- a/packages/netsuite-adapter/test/change_validators/workflow_account_specific_values.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/workflow_account_specific_values.test.ts
@@ -18,7 +18,7 @@ import { workflowType } from '../../src/autogen/types/standard_types/workflow'
 import workflowAccountSpecificValidator from '../../src/change_validators/workflow_account_specific_values'
 import { SCRIPT_ID } from '../../src/constants'
 
-describe('account specific values validator for sender and recepient fields', () => {
+describe('workflow account specific values', () => {
   let instance: InstanceElement
   beforeEach(() => {
     instance = new InstanceElement(
@@ -28,6 +28,34 @@ describe('account specific values validator for sender and recepient fields', ()
         isinactive: false,
         [SCRIPT_ID]: 'customworkflow3',
         name: 'WokrflowName',
+        initcondition: {
+          parameters: {
+            parameter: {
+              Account1: {
+                name: 'Account1',
+                value: '[STDUSERUSER]',
+              },
+              Account2: {
+                name: 'Account2',
+                value: '[STDUSERUSER]',
+              },
+            },
+          },
+        },
+        another: {
+          parameters: {
+            parameter: {
+              Account1: {
+                name: 'Account1',
+                value: '[STDUSERUSER]',
+              },
+              Account2: {
+                name: 'Account2',
+                value: '[STDUSERUSER]',
+              },
+            },
+          },
+        },
         workflowstates: {
           workflowstate: {
             workflowstate1: {
@@ -38,6 +66,20 @@ describe('account specific values validator for sender and recepient fields', ()
                     recipienttype: 'FIELD',
                     sender: '[STDUSERUSER]',
                     sendertype: 'FIELD',
+                    initcondition: {
+                      parameters: {
+                        parameter: {
+                          Account1: {
+                            name: 'Account1',
+                            value: '[STDUSERUSER]',
+                          },
+                          Account2: {
+                            name: 'Account2',
+                            value: '[STDUSERUSER]',
+                          },
+                        },
+                      },
+                    },
                   },
                 },
               },
@@ -56,38 +98,139 @@ describe('account specific values validator for sender and recepient fields', ()
     expect(changeErrors).toHaveLength(0)
   })
 
-  it('should have changeError when deploying an instance with sender = ACCOUNT_SPECIFIC_VALUES and sendertype = SPECIFIC', async () => {
-    const after = instance.clone()
-    after.value.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction.sender = '[ACCOUNT_SPECIFIC_VALUE]'
-    after.value.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction.sendertype = 'SPECIFIC'
-    const changeErrors = await workflowAccountSpecificValidator(
-      [toChange({ before: instance, after })]
-    )
-    expect(changeErrors).toHaveLength(1)
-    expect(changeErrors[0].severity).toEqual('Error')
-    expect(changeErrors[0].elemID).toEqual(instance.elemID)
-    expect(changeErrors[0].detailedMessage).toContain('The Workflow contains a \'sender\' field with an ACCOUNT_SPECIFIC_VALUE')
+  describe('sender and recepient fields', () => {
+    it('should have changeError when deploying an instance with sender = ACCOUNT_SPECIFIC_VALUES and sendertype = SPECIFIC', async () => {
+      const after = instance.clone()
+      after.value.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction.sender = '[ACCOUNT_SPECIFIC_VALUE]'
+      after.value.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction.sendertype = 'SPECIFIC'
+      const changeErrors = await workflowAccountSpecificValidator(
+        [toChange({ before: instance, after })]
+      )
+      expect(changeErrors).toHaveLength(1)
+      expect(changeErrors[0].severity).toEqual('Error')
+      expect(changeErrors[0].elemID).toEqual(instance.elemID)
+      expect(changeErrors[0].detailedMessage).toContain('The Workflow contains a \'sender\' field with an ACCOUNT_SPECIFIC_VALUE')
+    })
+    it('should have changeError when deploying an instance with recipient = ACCOUNT_SPECIFIC_VALUES and recipienttype = SPECIFIC', async () => {
+      const after = instance.clone()
+      after.value.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction.recipient = '[ACCOUNT_SPECIFIC_VALUE]'
+      after.value.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction.recipienttype = 'SPECIFIC'
+      const changeErrors = await workflowAccountSpecificValidator(
+        [toChange({ before: instance, after })]
+      )
+      expect(changeErrors).toHaveLength(1)
+      expect(changeErrors[0].severity).toEqual('Error')
+      expect(changeErrors[0].elemID).toEqual(instance.elemID)
+      expect(changeErrors[0].detailedMessage).toContain('The Workflow contains a \'recipient\' field with an ACCOUNT_SPECIFIC_VALUE')
+    })
+    it('should have changeError for both fields', async () => {
+      const after = instance.clone()
+      after.value.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction.sender = '[ACCOUNT_SPECIFIC_VALUE]'
+      after.value.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction.sendertype = 'SPECIFIC'
+      after.value.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction.recipient = '[ACCOUNT_SPECIFIC_VALUE]'
+      after.value.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction.recipienttype = 'SPECIFIC'
+      const changeErrors = await workflowAccountSpecificValidator(
+        [toChange({ before: instance, after })]
+      )
+      expect(changeErrors).toHaveLength(2)
+      expect(changeErrors).toEqual(expect.arrayContaining([
+        {
+          elemID: instance.elemID,
+          severity: 'Error',
+          message: 'Workflow contains fields which cannot be deployed',
+          detailedMessage: expect.stringContaining('The Workflow contains a \'recipient\' field with an ACCOUNT_SPECIFIC_VALUE'),
+        },
+        {
+          elemID: instance.elemID,
+          severity: 'Error',
+          message: 'Workflow contains fields which cannot be deployed',
+          detailedMessage: expect.stringContaining('The Workflow contains a \'sender\' field with an ACCOUNT_SPECIFIC_VALUE'),
+        },
+      ]))
+    })
+    it('should not have changeError when sendertype is not SPECIFIC', async () => {
+      const after = instance.clone()
+      after.value.sender = '[ACCOUNT_SPECIFIC_VALUE]'
+      const changeErrors = await workflowAccountSpecificValidator(
+        [toChange({ before: instance, after })]
+      )
+      expect(changeErrors).toHaveLength(0)
+    })
   })
 
-  it('should have changeError when deploying an instance with recipient = ACCOUNT_SPECIFIC_VALUES and recipienttype = SPECIFIC', async () => {
-    const after = instance.clone()
-    after.value.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction.recipient = '[ACCOUNT_SPECIFIC_VALUE]'
-    after.value.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction.recipienttype = 'SPECIFIC'
-    const changeErrors = await workflowAccountSpecificValidator(
-      [toChange({ before: instance, after })]
-    )
-    expect(changeErrors).toHaveLength(1)
-    expect(changeErrors[0].severity).toEqual('Error')
-    expect(changeErrors[0].elemID).toEqual(instance.elemID)
-    expect(changeErrors[0].detailedMessage).toContain('The Workflow contains a \'recipient\' field with an ACCOUNT_SPECIFIC_VALUE')
-  })
-
-  it('should not throw and error when sendertype is not SPECIFIC', async () => {
-    const after = instance.clone()
-    after.value.sender = '[ACCOUNT_SPECIFIC_VALUE]'
-    const changeErrors = await workflowAccountSpecificValidator(
-      [toChange({ before: instance, after })]
-    )
-    expect(changeErrors).toHaveLength(0)
+  describe('condition parameters warning', () => {
+    it('should return warning on a condition with ACCOUNT_SPECIFIC_VALUE parameter', async () => {
+      const after = instance.clone()
+      after.value.initcondition.parameters.parameter.Account1.value = '[ACCOUNT_SPECIFIC_VALUE]'
+      const changeErrors = await workflowAccountSpecificValidator(
+        [toChange({ before: instance, after })]
+      )
+      expect(changeErrors).toHaveLength(1)
+      expect(changeErrors).toEqual([
+        {
+          elemID: instance.elemID.createNestedID('initcondition'),
+          severity: 'Warning',
+          message: 'The condition cannot be applied',
+          detailedMessage: 'A condition builder parameter in this section contains an ACCOUNT_SPECIFIC_VALUE which cannot be deployed due to NetSuite constraints.',
+        },
+      ])
+    })
+    it('should return warning on all conditions with ACCOUNT_SPECIFIC_VALUE parameters', async () => {
+      const after = instance.clone()
+      after.value.initcondition.parameters.parameter.Account1.value = '[ACCOUNT_SPECIFIC_VALUE]'
+      after.value.initcondition.parameters.parameter.Account2.value = '[ACCOUNT_SPECIFIC_VALUE]'
+      after.value.another.parameters.parameter.Account2.value = '[ACCOUNT_SPECIFIC_VALUE]'
+      after.value.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction.initcondition.parameters.parameter.Account2.value = '[ACCOUNT_SPECIFIC_VALUE]'
+      const changeErrors = await workflowAccountSpecificValidator(
+        [toChange({ before: instance, after })]
+      )
+      expect(changeErrors).toHaveLength(3)
+      expect(changeErrors).toEqual(expect.arrayContaining([
+        expect.objectContaining({ elemID: instance.elemID.createNestedID('initcondition') }),
+        expect.objectContaining({ elemID: instance.elemID.createNestedID('another', 'parameters', 'parameter') }),
+        expect.objectContaining({ elemID: instance.elemID.createNestedID('workflowstates', 'workflowstate', 'workflowstate1', 'workflowactions', 'sendemailaction', 'workflowaction', 'initcondition') }),
+      ]))
+    })
+    it('should return warning on an addition change', async () => {
+      instance.value.initcondition.parameters.parameter.Account1.value = '[ACCOUNT_SPECIFIC_VALUE]'
+      const changeErrors = await workflowAccountSpecificValidator(
+        [toChange({ after: instance })]
+      )
+      expect(changeErrors).toHaveLength(1)
+      expect(changeErrors).toEqual([
+        {
+          elemID: instance.elemID.createNestedID('initcondition'),
+          severity: 'Warning',
+          message: 'The condition cannot be applied',
+          detailedMessage: 'A condition builder parameter in this section contains an ACCOUNT_SPECIFIC_VALUE which cannot be deployed due to NetSuite constraints.',
+        },
+      ])
+    })
+    it('should return warning when the condition is changed', async () => {
+      instance.value.initcondition.parameters.parameter.Account1.value = '[ACCOUNT_SPECIFIC_VALUE]'
+      const after = instance.clone()
+      after.value.initcondition.formula = '"Account1" EQUALS "Account2"'
+      const changeErrors = await workflowAccountSpecificValidator(
+        [toChange({ before: instance, after })]
+      )
+      expect(changeErrors).toHaveLength(1)
+      expect(changeErrors).toEqual([
+        {
+          elemID: instance.elemID.createNestedID('initcondition'),
+          severity: 'Warning',
+          message: 'The condition cannot be applied',
+          detailedMessage: 'A condition builder parameter in this section contains an ACCOUNT_SPECIFIC_VALUE which cannot be deployed due to NetSuite constraints.',
+        },
+      ])
+    })
+    it('should not return warning when the condition is not changed', async () => {
+      instance.value.initcondition.parameters.parameter.Account1.value = '[ACCOUNT_SPECIFIC_VALUE]'
+      const after = instance.clone()
+      after.value.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction.initcondition.formula = '"Account1" EQUALS "Account2"'
+      const changeErrors = await workflowAccountSpecificValidator(
+        [toChange({ before: instance, after })]
+      )
+      expect(changeErrors).toHaveLength(0)
+    })
   })
 })


### PR DESCRIPTION
When trying to modify a condition within a workflow instance, and the parameters contain ACCOUNT_SPECIFIC_VALUE, SDF will silently ignore the condition and won't apply it.

We should add a warning on the condition in this case, to let the user know that it's not going to be applied. It shouldn't be an error because it will block other changes in the workflow from being deployed (which SDF allows).

---

_Additional context for reviewer_

TODO:
- [x] add tests

---
_Release Notes_: 
Netsuite Adapter:
- Add workflow condition warning when there are parameters with ACCOUNT_SPECIFIC_VALUES

---
_User Notifications_: 
None