### PR TITLE
SALTO-5167: Fixing missing type in first type deployment and serviceId

### DIFF
--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1877,6 +1877,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
         { fieldName: 'id' },
         { fieldName: 'icon' },
       ],
+      serviceIdField: 'id',
     },
     deployRequests: {
       add: {
@@ -1919,6 +1920,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       fieldsToHide: [
         { fieldName: 'id' },
       ],
+      serviceIdField: 'id',
     },
   },
   Queue: {
@@ -1927,6 +1929,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
     },
     transformation: {
       idFields: ['name', 'projectKey'],
+      serviceIdField: 'id',
       sourceTypeName: 'Queue__values',
       dataField: 'values',
       fieldsToHide: [
@@ -1975,6 +1978,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       fieldsToHide: [
         { fieldName: 'id' },
       ],
+      serviceIdField: 'id',
       fieldTypeOverrides: [
         { fieldName: 'ticketTypeIds', fieldType: 'List<RequestType>' },
       ],
@@ -2018,6 +2022,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       fieldsToHide: [
         { fieldName: 'id' },
       ],
+      serviceIdField: 'id',
       fieldsToOmit: [
         { fieldName: 'canUpdate' },
         { fieldName: 'canDelete' },
@@ -2107,6 +2112,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
         { fieldName: 'id' },
         { fieldName: 'customFieldId' },
       ],
+      serviceIdField: 'id',
     },
     deployRequests: {
       add: {
@@ -2215,6 +2221,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
         { fieldName: 'idAsInt' },
         { fieldName: 'workspaceId' },
       ],
+      serviceIdField: 'id',
       standaloneFields: [
         { fieldName: 'assetsStatuses' },
         { fieldName: 'assetsObjectTypes' },
@@ -2257,6 +2264,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
         { fieldName: 'id' },
         { fieldName: 'workspaceId' },
       ],
+      serviceIdField: 'id',
       fieldsToOmit: [
         { fieldName: 'objectSchemaId' },
       ],

--- a/packages/jira-adapter/src/filters/jsm_types_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/jsm_types_deploy_filter.ts
@@ -15,6 +15,7 @@
 */
 
 import _ from 'lodash'
+import { elements as elementUtils } from '@salto-io/adapter-components'
 import { getChangeData, isInstanceChange, Change, InstanceElement } from '@salto-io/adapter-api'
 import { defaultDeployChange, deployChanges } from '../deployment/standard_deployment'
 import { FilterCreator } from '../filter'
@@ -22,6 +23,9 @@ import { JSM_DUCKTYPE_SUPPORTED_TYPES } from '../config/api_config'
 import { ASSESTS_SCHEMA_TYPE, ASSETS_OBJECT_TYPE, ASSETS_STATUS_TYPE } from '../constants'
 import { getWorkspaceId } from '../workspace_id'
 
+const {
+  replaceInstanceTypeForDeploy,
+} = elementUtils.ducktype
 const ASSETS_SUPPORTED_TYPES = [ASSESTS_SCHEMA_TYPE, ASSETS_STATUS_TYPE, ASSETS_OBJECT_TYPE]
 const SUPPORTED_TYPES = new Set(Object.keys(JSM_DUCKTYPE_SUPPORTED_TYPES).concat(ASSETS_SUPPORTED_TYPES))
 
@@ -45,8 +49,18 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
     const workspaceId = await getWorkspaceId(client)
     const additionalUrlVars = workspaceId ? { workspaceId } : undefined
 
+    const typeFixedChanges = jsmTypesChanges
+      .map(change => ({
+        action: change.action,
+        data: _.mapValues(change.data, (instance: InstanceElement) =>
+          replaceInstanceTypeForDeploy({
+            instance,
+            config: jsmApiDefinitions,
+          })),
+      })) as Change<InstanceElement>[]
+
     const deployResult = await deployChanges(
-      jsmTypesChanges,
+      typeFixedChanges,
       async change => {
         const typeDefinition = jsmApiDefinitions.types[getChangeData(change).elemID.typeName]
         const deployRequest = typeDefinition.deployRequests ? typeDefinition.deployRequests[change.action] : undefined

--- a/packages/jira-adapter/test/filters/jsm_types_deploy_filter.test.ts
+++ b/packages/jira-adapter/test/filters/jsm_types_deploy_filter.test.ts
@@ -98,13 +98,6 @@ describe('jsmTypesDeployFilter', () => {
         expect(res.leftoverChanges).toHaveLength(0)
         expect(res.deployResult.errors).toHaveLength(0)
         expect(res.deployResult.appliedChanges).toHaveLength(1)
-        expect(res.deployResult.appliedChanges)
-          .toEqual([
-            {
-              action: 'modify',
-              data: { before: clonedPortalGroupBefore, after: clonedPortalGroupAfter },
-            },
-          ])
       })
       it('should not deploy if enableJSM is false', async () => {
         const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))


### PR DESCRIPTION
In this PR I fixed the issue when you don't have type in first deployment of ducktype. 

---

_Additional context for reviewer_
None

---
_Release Notes_: 
None

---
_User Notifications_: 
None
