### PR TITLE
SALTO-5168: Changed customerPermissions deployment

### DIFF
--- a/packages/jira-adapter/src/filters/project.ts
+++ b/packages/jira-adapter/src/filters/project.ts
@@ -90,12 +90,13 @@ const deployCustomerPermissions = async (
   client: JiraClient,
   config: JiraConfig
 ): Promise<void> => {
-  if (!config.fetch.enableJSM) {
+  if (!config.fetch.enableJSM || instance.value.projectTypeKey !== SERVICE_DESK) {
     return
   }
-  if ((isAdditionChange(change))
+  if (((isAdditionChange(change))
   || (isModificationChange(change)
-  && !isEqualValues(change.data.before.value.customerPermissions, change.data.after.value.customerPermissions))) {
+    && !isEqualValues(change.data.before.value.customerPermissions, change.data.after.value.customerPermissions)))
+  && instance.value.customerPermissions !== undefined) {
     await client.post({
       url: `/rest/servicedesk/1/servicedesk/${instance.value.key}/settings/requestsecurity`,
       data: instance.value.customerPermissions,

--- a/packages/jira-adapter/test/filters/project.test.ts
+++ b/packages/jira-adapter/test/filters/project.test.ts
@@ -289,6 +289,7 @@ describe('projectFilter', () => {
       instance.value.customerPermissions = {
         serviceDeskOpenAccess: true,
       }
+      instance.value.projectTypeKey = 'service_desk'
       const afterInstance = instance.clone()
       afterInstance.value.customerPermissions = {
         serviceDeskOpenAccess: false,
@@ -314,10 +315,54 @@ describe('projectFilter', () => {
         undefined,
       )
     })
+    it('should not call to post customerPermissions when project is not jsm', async () => {
+      instance.value.customerPermissions = {
+        serviceDeskOpenAccess: true,
+      }
+      instance.value.projectTypeKey = 'software'
+      const afterInstance = instance.clone()
+      afterInstance.value.customerPermissions = {
+        serviceDeskOpenAccess: false,
+      }
+      change = toChange({ before: instance, after: afterInstance })
+      const { paginator } = mockClient()
+      const elementsSource = getLicenseElementSource(true)
+      config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+      config.fetch.enableJSM = true
+      filter = projectFilter(getFilterParams({
+        client,
+        paginator,
+        elementsSource,
+        config,
+      })) as typeof filter
+      await filter.deploy([change])
+      expect(deployChangeMock).toHaveBeenCalledTimes(0)
+      expect(connection.post).toHaveBeenCalledTimes(0)
+    })
+    it('should not call to post customerPermissions when project is jsm but there is no customerPremissions', async () => {
+      instance.value.customerPermissions = undefined
+      instance.value.projectTypeKey = 'service_desk'
+      const afterInstance = instance.clone()
+      change = toChange({ before: instance, after: afterInstance })
+      const { paginator } = mockClient()
+      const elementsSource = getLicenseElementSource(true)
+      config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+      config.fetch.enableJSM = true
+      filter = projectFilter(getFilterParams({
+        client,
+        paginator,
+        elementsSource,
+        config,
+      })) as typeof filter
+      await filter.deploy([change])
+      expect(deployChangeMock).toHaveBeenCalledTimes(0)
+      expect(connection.post).toHaveBeenCalledTimes(0)
+    })
     it('should not deploy customerPermissions modification when enableJSM is false', async () => {
       instance.value.customerPermissions = {
         serviceDeskOpenAccess: true,
       }
+      instance.value.projectTypeKey = 'service_desk'
       const afterInstance = instance.clone()
       afterInstance.value.customerPermissions = {
         serviceDeskOpenAccess: false,


### PR DESCRIPTION
Fixed error that when we add software project it calls to jsm endpoint. 

---

_Additional context for reviewer_
None

---
_Release Notes_: 
None

---
_User Notifications_: 
None