### PR TITLE
Fix NS deploy config usage in change validators

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -592,7 +592,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
         additionalDependencies: this.additionalDependencies,
         filtersRunner: changesGroupId => this.createFiltersRunner({ operation: 'deploy', changesGroupId }),
         elementsSource: this.elementsSource,
-        validatorsActivationConfig: this.userConfig.deploy?.changeValidators,
+        userConfig: this.userConfig,
       }),
       getChangeGroupIds: getChangeGroupIdsFunc(this.client.isSuiteAppConfigured()),
       dependencyChanger,

--- a/packages/netsuite-adapter/src/change_validator.ts
+++ b/packages/netsuite-adapter/src/change_validator.ts
@@ -59,7 +59,6 @@ import {
 import { Filter } from './filter'
 import { NetsuiteChangeValidator } from './change_validators/types'
 
-type ValidatorsActivationConfig = deployment.changeValidators.ValidatorsActivationConfig
 const { createChangeValidator } = deployment.changeValidators
 
 const defaultChangeValidators = deployment.changeValidators.getDefaultChangeValidators()
@@ -139,7 +138,6 @@ const getChangeValidator: ({
   deployReferencedElements,
   additionalDependencies,
   filtersRunner,
-  validatorsActivationConfig,
 } : {
   client: NetsuiteClient
   withSuiteApp: boolean
@@ -150,8 +148,7 @@ const getChangeValidator: ({
   additionalDependencies: AdditionalDependencies
   filtersRunner: (groupID: string) => Required<Filter>
   elementsSource: ReadOnlyElementsSource
-  validatorsActivationConfig?: ValidatorsActivationConfig
-  userConfig?: NetsuiteConfig
+  userConfig: NetsuiteConfig
   }) => ChangeValidator = (
     {
       client,
@@ -163,7 +160,6 @@ const getChangeValidator: ({
       additionalDependencies,
       filtersRunner,
       elementsSource,
-      validatorsActivationConfig,
       userConfig,
     }
   ) =>
@@ -189,7 +185,7 @@ const getChangeValidator: ({
 
       const mergedValidator = createChangeValidator({
         validators: { ...defaultChangeValidators, ...validators, ...safeDeploy },
-        validatorsActivationConfig,
+        validatorsActivationConfig: userConfig.deploy?.changeValidators,
       })
       const validatorChangeErrors = await mergedValidator(changes, elementSource)
 

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -1016,17 +1016,9 @@ describe('Adapter', () => {
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions
         adapter.deployModifiers
 
-        expect(getChangeValidatorMock).toHaveBeenCalledWith({
-          client: expect.anything(),
-          withSuiteApp: expect.anything(),
+        expect(getChangeValidatorMock).toHaveBeenCalledWith(expect.objectContaining({
           warnStaleData: false,
-          fetchByQuery: expect.anything(),
-          deployReferencedElements: expect.anything(),
-          validate: expect.anything(),
-          filtersRunner: expect.anything(),
-          additionalDependencies: expect.anything(),
-          elementsSource,
-        })
+        }))
       })
 
       it('should call getChangeValidator with warnStaleData=false if warnOnStaleWorkspaceData=false in config', async () => {
@@ -1050,17 +1042,9 @@ describe('Adapter', () => {
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions
         adapter.deployModifiers
 
-        expect(getChangeValidatorMock).toHaveBeenCalledWith({
-          client: expect.anything(),
-          withSuiteApp: expect.anything(),
+        expect(getChangeValidatorMock).toHaveBeenCalledWith(expect.objectContaining({
           warnStaleData: false,
-          fetchByQuery: expect.anything(),
-          filtersRunner: expect.anything(),
-          deployReferencedElements: expect.anything(),
-          validate: expect.anything(),
-          additionalDependencies: expect.anything(),
-          elementsSource,
-        })
+        }))
       })
 
       it('should call getChangeValidator with warnStaleData=true if warnOnStaleWorkspaceData=true in config', async () => {
@@ -1084,17 +1068,9 @@ describe('Adapter', () => {
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions
         adapter.deployModifiers
 
-        expect(getChangeValidatorMock).toHaveBeenCalledWith({
-          client: expect.anything(),
-          withSuiteApp: expect.anything(),
+        expect(getChangeValidatorMock).toHaveBeenCalledWith(expect.objectContaining({
           warnStaleData: true,
-          fetchByQuery: expect.anything(),
-          filtersRunner: expect.anything(),
-          deployReferencedElements: expect.anything(),
-          validate: expect.anything(),
-          additionalDependencies: expect.anything(),
-          elementsSource,
-        })
+        }))
       })
     })
 

--- a/packages/netsuite-adapter/test/change_validator.test.ts
+++ b/packages/netsuite-adapter/test/change_validator.test.ts
@@ -20,7 +20,7 @@ import { fileType } from '../src/types/file_cabinet_types'
 import getChangeValidator from '../src/change_validator'
 import netsuiteClientValidation from '../src/change_validators/client_validation'
 import { FetchByQueryFunc, FetchByQueryReturnType } from '../src/change_validators/safe_deploy'
-import { NetsuiteQuery } from '../src/query'
+import { NetsuiteQuery, fullFetchConfig } from '../src/query'
 import NetsuiteClient from '../src/client/client'
 import * as dependencies from '../src/change_validators/dependencies'
 import { INTERNAL_ID } from '../src/constants'
@@ -39,6 +39,9 @@ const DEFAULT_OPTIONS = {
   }) as unknown as Required<Filter>,
   elementsSource: jest.fn() as unknown as ReadOnlyElementsSource,
   fetchByQuery: jest.fn(),
+  userConfig: {
+    fetch: fullFetchConfig(),
+  },
 }
 
 jest.mock('../src/change_validators/client_validation')


### PR DESCRIPTION
Make sure to pass the adapter config to NS change validators.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None