### PR TITLE
SALTO-5154: Disable usePrivateAPI when connected with OAuth

### DIFF
--- a/packages/adapter-components/src/config/index.ts
+++ b/packages/adapter-components/src/config/index.ts
@@ -19,5 +19,5 @@ export { createAdapterApiConfigType, getConfigWithDefault, AdapterApiConfig, Use
 export { mergeWithDefaultConfig } from './merge'
 export { createTypeNameOverrideConfigType, createSwaggerAdapterApiConfigType, AdapterSwaggerApiConfig, RequestableAdapterSwaggerApiConfig, TypeSwaggerConfig, RequestableTypeSwaggerConfig, TypeSwaggerDefaultConfig, TypeNameOverrideConfig, validateApiDefinitionConfig as validateSwaggerApiDefinitionConfig, validateFetchConfig as validateSwaggerFetchConfig } from './swagger'
 export { createTransformationConfigTypes, validateTransoformationConfig, TransformationDefaultConfig, TransformationConfig, StandaloneFieldConfigType, FieldToOmitType, FieldToHideType, getTransformationConfigByType, dereferenceFieldName, isReferencedIdField, NameMappingOptions, DATA_FIELD_ENTIRE_OBJECT, getTypeTransformationConfig, shouldNestFiles } from './transformation'
-export { getConfigWithExcludeFromConfigChanges, ConfigChangeSuggestion } from './config_change'
+export { getUpdatedCofigFromConfigChanges, ConfigChangeSuggestion } from './config_change'
 export * as configMigrations from './config_migrations'

--- a/packages/adapter-components/src/elements/ducktype/transformer.ts
+++ b/packages/adapter-components/src/elements/ducktype/transformer.ts
@@ -31,7 +31,7 @@ import { shouldRecurseIntoEntry } from '../instance_elements'
 import { addRemainingTypes } from './add_remaining_types'
 import { ElementQuery } from '../query'
 import { AdapterFetchError, InvalidSingletonType } from '../../config/shared'
-import { ConfigChangeSuggestion } from '../../config/config_change'
+import { ConfigChangeSuggestion, TYPE_TO_EXCLUDE } from '../../config/config_change'
 
 const { makeArray } = collections.array
 const { toArrayAsync, awu } = collections.asynciterable
@@ -80,7 +80,7 @@ export const getEntriesResponseValues: EntriesRequester = async ({
 
 export const getUniqueConfigSuggestions = (
   configSuggestions: ConfigChangeSuggestion[]
-): ConfigChangeSuggestion[] => (_.uniqBy(configSuggestions, suggestion => suggestion.typeToExclude))
+): ConfigChangeSuggestion[] => (_.uniqBy(configSuggestions, suggestion => `${suggestion.type}-${suggestion.value}-${suggestion.reason}`))
 
 /**
  * Creates new type based on instances values,
@@ -413,7 +413,11 @@ export const getAllElements = async ({
           && (reversedSupportedTypes[args.typeName] !== undefined)) {
           const typesToExclude = reversedSupportedTypes[args.typeName]
           typesToExclude.forEach(type => {
-            configSuggestions.push({ typeToExclude: type })
+            configSuggestions.push({
+              type: TYPE_TO_EXCLUDE,
+              value: type,
+              reason: `Salto failed to fetch type ${type}`,
+            })
           })
           return { elements: [], errors: [] }
         }

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -670,11 +670,10 @@ export default class JiraAdapter implements AdapterOperations {
     const filterResult = await this.createFiltersRunner().onFetch(elements) || {}
 
     const updatedConfig = this.configInstance && configChanges
-      ? configUtils.getConfigWithExcludeFromConfigChanges({
+      ? configUtils.getUpdatedCofigFromConfigChanges({
         configChanges,
         currentConfig: this.configInstance,
         configType,
-        adapterName: JIRA,
       }) : undefined
     // This needs to happen after the onFetch since some filters
     // may add fields that deployment annotation should be added to

--- a/packages/okta-adapter/e2e_test/adapter.ts
+++ b/packages/okta-adapter/e2e_test/adapter.ts
@@ -48,6 +48,7 @@ export const realAdapter = ({ adapterParams, credentials, elementsSource }: Opts
     config: config ?? DEFAULT_CONFIG,
     elementsSource,
     adminClient,
+    isOAuthLogin: false,
   })
   return { client, adapter }
 }

--- a/packages/okta-adapter/src/filters/group_push.ts
+++ b/packages/okta-adapter/src/filters/group_push.ts
@@ -230,11 +230,7 @@ const groupPushFilter: FilterCreator = ({ config, adminClient, getElemIdFunc }) 
 
     if (adminClient === undefined) {
       log.error('Admin client is undefined, could not fetch group push instances')
-      const error: SaltoError = {
-        message: 'Failed to fetch group push instances',
-        severity: 'Warning',
-      }
-      return { errors: [error] }
+      return { errors: [] }
     }
 
     const appsWithGroupPush = elements

--- a/packages/okta-adapter/test/filters/group_push.test.ts
+++ b/packages/okta-adapter/test/filters/group_push.test.ts
@@ -89,15 +89,10 @@ describe('groupPushFilter', () => {
       await filter.onFetch(elements)
       expect(elements).toHaveLength(3)
     })
-    it('should return fetch error when admin client is undefined', async () => {
+    it('should do nothing if admin client is', async () => {
       filter = groupPushFilter(getFilterParams({ adminClient: undefined })) as typeof filter
       const res = await filter.onFetch([appType, appWithGroupPush, appWithNoGroupPush])
-      expect(res).toEqual({
-        errors: [{
-          message: 'Failed to fetch group push instances',
-          severity: 'Warning',
-        }],
-      })
+      expect(res).toEqual({ errors: [] })
     })
     it('should create group push type and group push rule type', async () => {
       mockGet.mockImplementation(params => {

--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -686,11 +686,10 @@ export default class ZendeskAdapter implements AdapterOperations {
     const result = await (await this.createFiltersRunner({ brandIdToClient }))
       .onFetch(elements) as FilterResult
     const updatedConfig = this.configInstance && configChanges
-      ? configUtils.getConfigWithExcludeFromConfigChanges({
+      ? configUtils.getUpdatedCofigFromConfigChanges({
         configChanges,
         currentConfig: this.configInstance,
         configType,
-        adapterName: ZENDESK,
       }) : undefined
 
     const fetchErrors = (errors ?? []).concat(result.errors ?? []).concat(localeError ?? [])


### PR DESCRIPTION
private API types are not supported when account is added with OAuth login

---

When connecting with OAuth, private APIs can't be fetched. the flag is on by default, so each user connecting with OAuth will experience this.
We create fetch warning + add config change to change `usePrivateAPI` to false

---
_Release Notes_: 
None

---
_User Notifications_: 
None