### PR TITLE
SALTO-5200: Fixed reading workspaceId from undefined 

### DIFF
--- a/packages/jira-adapter/src/change_validators/automation/automation_to_assets.ts
+++ b/packages/jira-adapter/src/change_validators/automation/automation_to_assets.ts
@@ -33,12 +33,13 @@ type Component = {
 
 const hasRelevantComponent = (components: Component[]): boolean =>
   components.some(({ value }) =>
-    value.workspaceId !== undefined
+    value !== undefined && (
+      value.workspaceId !== undefined
     || value.schemaId !== undefined
-    || value.objectTypeId !== undefined)
+    || value.objectTypeId !== undefined))
 
 const getUniqueValues = (components: Component[], key: keyof Component['value']): string[] =>
-  [...new Set(components.map(component => component.value[key]).filter(isDefined))].sort()
+  [...new Set(components.map(component => component.value?.[key]).filter(isDefined))].sort()
 
 const isComponentChanged = (beforeComponents: Component[], afterComponents: Component[]): boolean => {
   const keys: Array<'workspaceId' | 'schemaId' | 'objectTypeId'> = ['workspaceId', 'schemaId', 'objectTypeId']

--- a/packages/jira-adapter/test/change_validators/automations/automation_to_assets.test.ts
+++ b/packages/jira-adapter/test/change_validators/automations/automation_to_assets.test.ts
@@ -111,4 +111,11 @@ describe('automationsToAssetsValidator', () => {
     expect(await validator([toChange({ before: automationInstance, after: automationInstnaceAfter })]))
       .toEqual([])
   })
+  it('should not return a warning when value is undefined in addition change and enableJSM is false', async () => {
+    const automationInstnaceAfter = automationInstance.clone()
+    automationInstnaceAfter.value.components[0].value = undefined
+    const validator = automationToAssetsValidator(config)
+    expect(await validator([toChange({ after: automationInstnaceAfter })]))
+      .toEqual([])
+  })
 })


### PR DESCRIPTION
In this PR I fixed a bug when you are reading workspaceId from undefined value. 

---

_Additional context for reviewer_
None

---
_Release Notes_: 
None

---
_User Notifications_: 
None
