### PR TITLE
SALTO-4650: Salesforce InstalledPackage Instances ElemID with version

### DIFF
--- a/packages/salesforce-adapter/e2e_test/adapter.test.ts
+++ b/packages/salesforce-adapter/e2e_test/adapter.test.ts
@@ -46,7 +46,7 @@ import {
 import realAdapter from './adapter'
 import {
   findElements, findStandardFieldsObject, findAnnotationsObject, findCustomFieldsObject,
-  findFullCustomObject,
+  findFullCustomObject, defaultFilterContext,
 } from '../test/utils'
 import SalesforceClient, { API_VERSION } from '../src/client/client'
 import SalesforceAdapter from '../src/adapter'
@@ -684,73 +684,101 @@ describe('Salesforce adapter E2E with real account', () => {
 
     it('should modify an instance', async () => {
       const instanceElementName = 'TestProfileInstanceUpdate__c'
-      const oldInstance = createInstanceElement(
-        {
+      const oldInstance = createInstanceElement({
+        values: {
           ...mockDefaultValues.Profile,
-          [constants.INSTANCE_FULL_NAME_FIELD]: instanceElementName,
+          [constants.INSTANCE_FULL_NAME_FIELD]:
+        instanceElementName,
         },
-        mockTypes.Profile,
-      )
-      const newInstance = createInstanceElement(
-        {
+        type: mockTypes.Profile,
+        fetchProfile: defaultFilterContext.fetchProfile,
+      })
+      const newInstance = createInstanceElement({
+        values: {
           ...oldInstance.value,
-          fieldPermissions: {
-            Lead: {
-              Fax: {
-                field: 'Lead.Fax',
-                readable: true,
-                editable: true,
-              },
-            },
-            Account: {
-              AccountNumber: {
-                editable: false,
-                field: 'Account.AccountNumber',
-                readable: false,
-              },
-              AnnualRevenue: {
-                editable: false,
-                field: 'Account.AnnualRevenue',
-                readable: false,
-              },
-            },
+          fieldPermissions:
+        {
+          Lead: {
+            Fax: {
+              field: 'Lead.Fax',
+              readable:
+              true,
+              editable:
+              true,
+            }
+            ,
           },
+          Account: {
+            AccountNumber: {
+              editable: false,
+              field:
+              'Account.AccountNumber',
+              readable:
+              false,
+            },
+            AnnualRevenue: {
+              editable: false,
+              field:
+              'Account.AnnualRevenue',
+              readable:
+              false,
+            }
+            ,
+          }
+          ,
+        },
           objectPermissions: {
             Account: {
               allowCreate: true,
-              allowDelete: true,
-              allowEdit: true,
-              allowRead: true,
-              modifyAllRecords: true,
-              viewAllRecords: true,
-              object: 'Account',
-            },
+              allowDelete:
+            true,
+              allowEdit:
+            true,
+              allowRead:
+            true,
+              modifyAllRecords:
+            true,
+              viewAllRecords:
+            true,
+              object:
+            'Account',
+            }
+            ,
           },
           userPermissions: {
             ApiEnabled: {
               name: 'ApiEnabled',
-              enabled: true,
-            },
+              enabled:
+            true,
+            }
+            ,
           },
           pageAccesses: {
             ApexPageForProfile: {
               apexPage: 'ApexPageForProfile',
-              enabled: true,
-            },
+              enabled:
+            true,
+            }
+            ,
           },
           classAccesses: {
             ApexClassForProfile: {
               apexClass: 'ApexClassForProfile',
-              enabled: true,
-            },
+              enabled:
+            true,
+            }
+            ,
           },
           loginHours: {
             sundayStart: 300,
-            sundayEnd: 420,
-          },
+            sundayEnd:
+          420,
+          }
+          ,
         },
-        mockTypes.Profile,
-      )
+        type: mockTypes.Profile,
+        fetchProfile: defaultFilterContext.fetchProfile,
+      })
 
       await removeElementIfAlreadyExists(client, oldInstance)
       const post = await createElement(adapter, oldInstance)
@@ -2809,10 +2837,16 @@ describe('Salesforce adapter E2E with real account', () => {
           type: MetadataObjectType,
           fullName: string,
           content: Value,
-        ): MetadataInstanceElement => createInstanceElement(
-          { fullName, apiVersion: API_VERSION, content },
+        ): MetadataInstanceElement => createInstanceElement({
+          values: {
+            fullName,
+            apiVersion:
+          API_VERSION,
+            content,
+          },
           type,
-        )
+          fetchProfile: defaultFilterContext.fetchProfile,
+        })
 
         describe('apex class manipulation', () => {
           const apexClassInstance = createApexInstance(
@@ -3811,7 +3845,11 @@ describe('Salesforce adapter E2E with real account', () => {
     describe('Deploy QuickAction', () => {
       let quickAction: InstanceElement
       beforeAll(async () => {
-        quickAction = createInstanceElement({ fullName: 'onec', optionsCreateFeedItem: true, standardLabel: 'LogACall', type: 'LogACall', targetObject: 'Task', quickActionLayout: { layoutSectionStyle: 'TwoColumnsLeftToRight', quickActionLayoutColumns: [{ quickActionLayoutItems: [{ field: 'Subject', uiBehavior: 'Edit' }] }, {}] } }, mockTypes.QuickAction)
+        quickAction = createInstanceElement({
+          values: { fullName: 'onec', optionsCreateFeedItem: true, standardLabel: 'LogACall', type: 'LogACall', targetObject: 'Task', quickActionLayout: { layoutSectionStyle: 'TwoColumnsLeftToRight', quickActionLayoutColumns: [{ quickActionLayoutItems: [{ field: 'Subject', uiBehavior: 'Edit' }] }, {}] } },
+          type: mockTypes.QuickAction,
+          fetchProfile: defaultFilterContext.fetchProfile,
+        },)
       })
       it('should deploy empty quickActionLayoutColumns without deleting it', async () => {
         const changes: Change[] = [{

--- a/packages/salesforce-adapter/e2e_test/quick_deploy.test.ts
+++ b/packages/salesforce-adapter/e2e_test/quick_deploy.test.ts
@@ -26,6 +26,7 @@ import { testHelpers } from './jest_environment'
 import { mockTypes } from '../test/mock_elements'
 import { createInstanceElement, MetadataInstanceElement } from '../src/transformers/transformer'
 import { nullProgressReporter } from './utils'
+import { defaultFilterContext } from '../test/utils'
 
 describe('validation and quick deploy e2e', () => {
   // Set long timeout as we communicate with salesforce API
@@ -39,21 +40,27 @@ describe('validation and quick deploy e2e', () => {
   let apexTestInstance: MetadataInstanceElement
 
   beforeAll(async () => {
-    apexClassInstance = createInstanceElement({ fullName: 'MyApexClass',
-      apiVersion: API_VERSION,
-      content: new StaticFile({
-        filepath: 'MyApexClass.cls',
-        content: Buffer.from('public class MyApexClass {\n    public static Integer one(){\n          return 1;\n    }\n}'),
-      }) },
-    mockTypes.ApexClass)
+    apexClassInstance = createInstanceElement({
+      values: { fullName: 'MyApexClass',
+        apiVersion: API_VERSION,
+        content: new StaticFile({
+          filepath: 'MyApexClass.cls',
+          content: Buffer.from('public class MyApexClass {\n    public static Integer one(){\n          return 1;\n    }\n}'),
+        }) },
+      type: mockTypes.ApexClass,
+      fetchProfile: defaultFilterContext.fetchProfile,
+    })
 
-    apexTestInstance = createInstanceElement({ fullName: 'MyApexTest',
-      apiVersion: API_VERSION,
-      content: new StaticFile({
-        filepath: 'ApexTest.cls',
-        content: Buffer.from('@isTest\n private class MyApexTest {\n    @isTest static void inOne() {\n         System.assert(MyApexClass.one() == 1);\n    }\n}'),
-      }) },
-    mockTypes.ApexClass)
+    apexTestInstance = createInstanceElement({
+      values: { fullName: 'MyApexTest',
+        apiVersion: API_VERSION,
+        content: new StaticFile({
+          filepath: 'ApexTest.cls',
+          content: Buffer.from('@isTest\n private class MyApexTest {\n    @isTest static void inOne() {\n         System.assert(MyApexClass.one() == 1);\n    }\n}'),
+        }) },
+      type: mockTypes.ApexClass,
+      fetchProfile: defaultFilterContext.fetchProfile,
+    })
 
     changeGroup = {
       groupID: 'add test elements',

--- a/packages/salesforce-adapter/e2e_test/setup.ts
+++ b/packages/salesforce-adapter/e2e_test/setup.ts
@@ -23,6 +23,7 @@ import { MetadataValues, createInstanceElement } from '../src/transformers/trans
 import SalesforceClient from '../src/client/client'
 import { mockTypes, mockDefaultValues } from '../test/mock_elements'
 import { removeMetadataIfAlreadyExists } from './utils'
+import { defaultFilterContext } from '../test/utils'
 
 
 export const gvsName = 'TestGlobalValueSet'
@@ -855,7 +856,11 @@ export const verifyElementsExist = async (client: SalesforceClient): Promise<voi
     ]
     const pkg = createDeployPackage()
     await awu(instances).forEach(async ([values, type]) => {
-      await pkg.add(createInstanceElement(values, type))
+      await pkg.add(createInstanceElement({
+        values,
+        type,
+        fetchProfile: defaultFilterContext.fetchProfile,
+      }))
     })
     await client.deploy(await pkg.getZip())
   }

--- a/packages/salesforce-adapter/e2e_test/utils.ts
+++ b/packages/salesforce-adapter/e2e_test/utils.ts
@@ -130,7 +130,7 @@ export function createInstance(
   const objectType = isObjectType(type)
     ? type
     : findElement(typeElements as Iterable<Element>, new ElemID(SALESFORCE, type)) as ObjectType
-  return createInstanceElement(value, objectType)
+  return createInstanceElement({ values: value, type: objectType, fetchProfile: defaultFilterContext.fetchProfile })
 }
 
 export const getMetadataInstance = async (client: SalesforceClient, type: ObjectType,

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -707,6 +707,7 @@ export default class SalesforceAdapter implements AdapterOperations {
       metadataQuery: fetchProfile.metadataQuery,
       maxInstancesPerType: fetchProfile.maxInstancesPerType,
       addNamespacePrefixToFullName: fetchProfile.addNamespacePrefixToFullName,
+      fetchProfile,
     })
     return {
       elements: instances.elements,
@@ -744,7 +745,11 @@ export default class SalesforceAdapter implements AdapterOperations {
         }
         const listedElemIdsFullNames = new Set(Array.from(this.listedInstancesByType.getOrUndefined(typeName) ?? [])
           // We invoke createInstanceElement to have the correct elemID that we calculate in fetch
-          .map(fullName => createInstanceElement({ fullName }, metadataType).elemID.getFullName()))
+          .map(fullName => createInstanceElement({
+            values: { fullName },
+            type: metadataType,
+            fetchProfile,
+          }).elemID.getFullName()))
 
         elemIdsFromSource.forEach(sourceElemId => {
           if (!listedElemIdsFullNames.has(sourceElemId.getFullName())) {

--- a/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
@@ -36,6 +36,7 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   toolingDepsOfCurrentNamespace: false,
   fixRetrieveFilePaths: true,
   extraDependenciesV2: false,
+  installedPackageWithVersion: false,
 }
 
 type BuildFetchProfileParams = {

--- a/packages/salesforce-adapter/src/filters/create_missing_installed_packages_instances.ts
+++ b/packages/salesforce-adapter/src/filters/create_missing_installed_packages_instances.ts
@@ -22,16 +22,21 @@ import { isInstanceOfType, listMetadataObjects } from './utils'
 import { INSTALLED_PACKAGE_METADATA, INSTANCE_FULL_NAME_FIELD } from '../constants'
 import { notInSkipList } from '../fetch'
 import { apiName, createInstanceElement, getAuthorAnnotations } from '../transformers/transformer'
+import { FetchProfile } from '../types'
 
 const { awu } = collections.asynciterable
 
-const createMissingInstalledPackageInstance = (file: FileProperties, installedPackageType: ObjectType): Element => (
-  createInstanceElement(
-    { [INSTANCE_FULL_NAME_FIELD]: file.fullName },
-    installedPackageType,
-    undefined,
-    getAuthorAnnotations(file)
-  )
+const createMissingInstalledPackageInstance = (
+  file: FileProperties,
+  installedPackageType: ObjectType,
+  fetchProfile: FetchProfile,
+): Element => (
+  createInstanceElement({
+    values: { [INSTANCE_FULL_NAME_FIELD]: file.fullName },
+    type: installedPackageType,
+    annotations: getAuthorAnnotations(file),
+    fetchProfile,
+  })
 )
 
 const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
@@ -57,7 +62,7 @@ const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
     listResult
       .filter(file => notInSkipList(config.fetchProfile.metadataQuery, file, false))
       .filter(file => !existingInstalledPackageNamespaces.includes(file.fullName))
-      .map(file => createMissingInstalledPackageInstance(file, installedPackageType))
+      .map(file => createMissingInstalledPackageInstance(file, installedPackageType, config.fetchProfile))
       .forEach(missingInstalledPackageInstance => elements.push(missingInstalledPackageInstance))
   },
 })

--- a/packages/salesforce-adapter/src/filters/custom_metadata_to_object_type.ts
+++ b/packages/salesforce-adapter/src/filters/custom_metadata_to_object_type.ts
@@ -106,7 +106,7 @@ const filterCreator: LocalFilterCreator = ({ config }) => {
       )
 
       const deployableChanges = await awu(Object.entries(groupedOriginalChangesByApiName))
-        .map(entry => createCustomObjectChange(config.systemFields, ...entry))
+        .map(entry => createCustomObjectChange(config.systemFields, ...entry, config.fetchProfile))
         .toArray()
       _.pullAll(changes, customMetadataRelatedChanges)
       deployableChanges.forEach(c => changes.push(c))

--- a/packages/salesforce-adapter/src/filters/settings_type.ts
+++ b/packages/salesforce-adapter/src/filters/settings_type.ts
@@ -110,6 +110,7 @@ const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
           fileProps: [info],
           metadataQuery: config.fetchProfile.metadataQuery,
           maxInstancesPerType: config.fetchProfile.maxInstancesPerType,
+          fetchProfile: config.fetchProfile,
         }))
     )
     const settingsInstances = settingsInstanceCreateResults.flatMap(res => res.elements)

--- a/packages/salesforce-adapter/src/filters/standard_value_sets.ts
+++ b/packages/salesforce-adapter/src/filters/standard_value_sets.ts
@@ -244,6 +244,7 @@ export const makeFilter = (
           metadataType: svsMetadataType,
           metadataQuery: config.fetchProfile.metadataQuery,
           maxInstancesPerType: config.fetchProfile.maxInstancesPerType,
+          fetchProfile: config.fetchProfile,
         })
         elements.push(...svsInstances.elements)
 

--- a/packages/salesforce-adapter/src/filters/topics_for_objects.ts
+++ b/packages/salesforce-adapter/src/filters/topics_for_objects.ts
@@ -39,6 +39,7 @@ import {
   isCustomObjectSync,
   isInstanceOfTypeChange,
 } from './utils'
+import { FetchProfile } from '../types'
 
 const { awu } = collections.asynciterable
 const { removeAsync } = promises.array
@@ -58,10 +59,10 @@ const setTopicsForObjects = (object: ObjectType, enableTopics: boolean): void =>
 const setDefaultTopicsForObjects = (object: ObjectType): void => setTopicsForObjects(object,
   DEFAULT_ENABLE_TOPICS_VALUE)
 
-const createTopicsForObjectsInstance = (values: TopicsForObjectsInfo): InstanceElement => (
-  createInstanceElement(
+const createTopicsForObjectsInstance = (values: TopicsForObjectsInfo, fetchProfile: FetchProfile): InstanceElement => (
+  createInstanceElement({
     values,
-    new ObjectType({
+    type: new ObjectType({
       elemID: new ElemID(SALESFORCE, TOPICS_FOR_OBJECTS_METADATA_TYPE),
       annotationRefsOrTypes: _.clone(metadataAnnotationTypes),
       annotations: {
@@ -69,8 +70,9 @@ const createTopicsForObjectsInstance = (values: TopicsForObjectsInfo): InstanceE
         dirName: 'topicsForObjects',
         suffix: 'topicsForObjects',
       } as MetadataTypeAnnotations,
-    })
-  )
+    }),
+    fetchProfile,
+  })
 )
 
 type CustomObjectWithTopics = ObjectType & {
@@ -204,7 +206,7 @@ const filterCreator: LocalFilterCreator = ({ config }) => ({
           const topicsEnabled = boolValue(topics[ENABLE_TOPICS] ?? false)
           return new TopicsForObjectsInfo(await apiName(obj), await apiName(obj), topicsEnabled)
         })
-        .map(createTopicsForObjectsInstance)
+        .map(values => createTopicsForObjectsInstance(values, config.fetchProfile))
         .map(after => toChange({ after }))
         .toArray()
     )

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -1538,10 +1538,13 @@ export const createInstanceElement = ({
 }: CrateInstanceElementParams): MetadataInstanceElement => {
   const typeApiName = type.elemID.name
   const fullName = values[INSTANCE_FULL_NAME_FIELD]
-  const typeIdFields = ID_FIELDS_BY_TYPE[typeApiName] ?? [INSTANCE_FULL_NAME_FIELD]
-  const instanceIdValues: Record<string, unknown> = _.pick(
-    values,
-    fetchProfile.isFeatureEnabled('installedPackageWithVersion') ? typeIdFields : [INSTANCE_FULL_NAME_FIELD]
+  const typeIdFields = fetchProfile.isFeatureEnabled('installedPackageWithVersion')
+    ? ID_FIELDS_BY_TYPE[typeApiName] ?? [INSTANCE_FULL_NAME_FIELD]
+    : [INSTANCE_FULL_NAME_FIELD]
+  const instanceIdValues: Record<string, unknown> = Object.fromEntries(
+    typeIdFields
+      .map(idField => [idField, values[idField]])
+      .filter(([_idField, idValue]) => idValue !== undefined)
   )
   const getPackagePath = (): string[] => {
     if (namespacePrefix) {

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -1534,11 +1534,14 @@ export const createInstanceElement = ({
   type,
   namespacePrefix,
   annotations,
+  fetchProfile,
 }: CrateInstanceElementParams): MetadataInstanceElement => {
   const typeApiName = type.elemID.name
   const fullName = values[INSTANCE_FULL_NAME_FIELD]
+  const typeIdFields = ID_FIELDS_BY_TYPE[typeApiName] ?? [INSTANCE_FULL_NAME_FIELD]
   const instanceIdValues: Record<string, unknown> = _.pick(
-    values, ID_FIELDS_BY_TYPE[typeApiName] ?? [INSTANCE_FULL_NAME_FIELD]
+    values,
+    fetchProfile.isFeatureEnabled('installedPackageWithVersion') ? typeIdFields : [INSTANCE_FULL_NAME_FIELD]
   )
   const getPackagePath = (): string[] => {
     if (namespacePrefix) {

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -71,6 +71,7 @@ import {
 import SalesforceClient from '../client/client'
 import { allMissingSubTypes } from './salesforce_types'
 import { defaultMissingFields } from './missing_fields'
+import { FetchProfile } from '../types'
 
 const log = logger(module)
 const { mapValuesAsync, pickAsync } = promises.object
@@ -1520,12 +1521,20 @@ const ID_FIELDS_BY_TYPE: Record<string, string[]> = {
   [INSTALLED_PACKAGE_METADATA]: [INSTANCE_FULL_NAME_FIELD, 'versionNumber'],
 }
 
-export const createInstanceElement = (
-  values: MetadataValues,
-  type: ObjectType,
-  namespacePrefix?: string,
-  annotations?: Values,
-): MetadataInstanceElement => {
+
+type CrateInstanceElementParams = {
+  values: MetadataValues
+  type: ObjectType
+  namespacePrefix?: string
+  annotations?: Values
+  fetchProfile: FetchProfile
+}
+export const createInstanceElement = ({
+  values,
+  type,
+  namespacePrefix,
+  annotations,
+}: CrateInstanceElementParams): MetadataInstanceElement => {
   const typeApiName = type.elemID.name
   const fullName = values[INSTANCE_FULL_NAME_FIELD]
   const instanceIdValues: Record<string, unknown> = _.pick(

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -93,6 +93,7 @@ export type OptionalFeatures = {
   useLabelAsAlias?: boolean
   fixRetrieveFilePaths?: boolean
   organizationWideSharingDefaults?: boolean
+  installedPackageWithVersion?: boolean
 }
 
 export type ChangeValidatorName = (
@@ -716,6 +717,7 @@ const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
     useLabelAsAlias: { refType: BuiltinTypes.BOOLEAN },
     fixRetrieveFilePaths: { refType: BuiltinTypes.BOOLEAN },
     organizationWideSharingDefaults: { refType: BuiltinTypes.BOOLEAN },
+    installedPackageWithVersion: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -41,10 +41,10 @@ import {
   apiName,
   createInstanceElement,
   isMetadataObjectType,
-  MetadataObjectType,
+  MetadataObjectType, MetadataValues,
   Types,
 } from '../src/transformers/transformer'
-import { findElements, ZipFile } from './utils'
+import { defaultFilterContext, findElements, ZipFile } from './utils'
 import mockAdapter from './adapter'
 import * as constants from '../src/constants'
 import { LAYOUT_TYPE_ID } from '../src/filters/layouts'
@@ -213,17 +213,22 @@ describe('SalesforceAdapter fetch', () => {
     describe('partial fetch deletions detection', () => {
       let testAdapter: SalesforceAdapter
       let testConnection: MockInterface<Connection>
+
+      const createTestInstance = (metadataValues: MetadataValues, type: ObjectType): InstanceElement => (
+        createInstanceElement({ values: metadataValues, type, fetchProfile: defaultFilterContext.fetchProfile })
+      )
+
       beforeEach(() => {
         const existingElements = [
           mockInstances().ChangedAtSingleton,
           mockTypes.Layout,
           mockTypes.ApexClass,
-          createInstanceElement({ fullName: 'Layout1' }, mockTypes.Layout),
-          createInstanceElement({ fullName: 'Layout2' }, mockTypes.Layout),
-          createInstanceElement({ fullName: 'DeletedLayout' }, mockTypes.Layout),
-          createInstanceElement({ fullName: 'Apex1' }, mockTypes.ApexClass),
-          createInstanceElement({ fullName: 'Apex2' }, mockTypes.ApexClass),
-          createInstanceElement({ fullName: 'DeletedApex' }, mockTypes.ApexClass),
+          createTestInstance({ fullName: 'Layout1' }, mockTypes.Layout),
+          createTestInstance({ fullName: 'Layout2' }, mockTypes.Layout),
+          createTestInstance({ fullName: 'DeletedLayout' }, mockTypes.Layout),
+          createTestInstance({ fullName: 'Apex1' }, mockTypes.ApexClass),
+          createTestInstance({ fullName: 'Apex2' }, mockTypes.ApexClass),
+          createTestInstance({ fullName: 'DeletedApex' }, mockTypes.ApexClass),
         ]
         const elementsSource = buildElementsSourceFromElements(existingElements);
         ({ connection: testConnection, adapter: testAdapter } = mockAdapter({
@@ -1643,6 +1648,7 @@ public class LargeClass${index} {
           metadataQuery,
           fileProps,
           maxInstancesPerType,
+          fetchProfile: defaultFilterContext.fetchProfile,
         })
 
       beforeAll(() => {

--- a/packages/salesforce-adapter/test/change_validators/account_settings.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/account_settings.test.ts
@@ -20,9 +20,14 @@ import { mockTypes } from '../mock_elements'
 import { createInstanceElement } from '../../src/transformers/transformer'
 import changeValidatorCreator from '../../src/change_validators/account_settings'
 import { SALESFORCE, TYPES_PATH } from '../../src/constants'
+import { defaultFilterContext } from '../utils'
 
 describe('Account settings validator', () => {
-  const instanceBefore = createInstanceElement({ fullName: 'whatever' }, mockTypes.AccountSettings)
+  const instanceBefore = createInstanceElement({
+    values: { fullName: 'whatever' },
+    type: mockTypes.AccountSettings,
+    fetchProfile: defaultFilterContext.fetchProfile,
+  })
   const changeValidator = changeValidatorCreator
 
   const ORGANIZATION_OBJECT_TYPE = new ObjectType({
@@ -37,13 +42,14 @@ describe('Account settings validator', () => {
   })
 
   const mockElementsSource = (defaultAccountAccess: string): ReadOnlyElementsSource => {
-    const element = createInstanceElement(
-      {
+    const element = createInstanceElement({
+      values: {
         fullName: 'OrganizationSettings',
         defaultAccountAccess,
       },
-      ORGANIZATION_OBJECT_TYPE
-    )
+      type: ORGANIZATION_OBJECT_TYPE,
+      fetchProfile: defaultFilterContext.fetchProfile,
+    })
     return buildElementsSourceFromElements([element])
   }
 

--- a/packages/salesforce-adapter/test/change_validators/animation_rule_recordtype.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/animation_rule_recordtype.test.ts
@@ -17,6 +17,7 @@ import { BuiltinTypes, ElemID, ObjectType, toChange } from '@salto-io/adapter-ap
 import changeValidator from '../../src/change_validators/animation_rule_recordtype'
 import { METADATA_TYPE, SALESFORCE } from '../../src/constants'
 import { createInstanceElement } from '../../src/transformers/transformer'
+import { defaultFilterContext } from '../utils'
 
 describe('Invalid AnimationRule RecordType change validator', () => {
   const animationRuleType = new ObjectType({
@@ -33,12 +34,13 @@ describe('Invalid AnimationRule RecordType change validator', () => {
       [METADATA_TYPE]: 'AnimationRule',
     },
   })
-  const animationRuleInstance = createInstanceElement(
-    {
+  const animationRuleInstance = createInstanceElement({
+    values: {
       fullName: new ElemID(SALESFORCE, 'AnimationRule', 'instance', 'SomeAnimationRule').getFullName(),
     },
-    animationRuleType,
-  )
+    type: animationRuleType,
+    fetchProfile: defaultFilterContext.fetchProfile,
+  })
   it('should fail validation if the RecordTypeContext is invalid', async () => {
     const instance = animationRuleInstance.clone()
     instance.value.recordTypeContext = 'Custom'

--- a/packages/salesforce-adapter/test/change_validators/case_assignmentRules.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/case_assignmentRules.test.ts
@@ -17,12 +17,15 @@ import { Change, toChange } from '@salto-io/adapter-api'
 import caseChangeValidator from '../../src/change_validators/case_assignmentRules'
 import { mockTypes } from '../mock_elements'
 import { createInstanceElement } from '../../src/transformers/transformer'
+import { defaultFilterContext } from '../utils'
 
 describe('case AssignmentRules change validator', () => {
   let caseRuleChange: Change
   describe('case AssignmentRules with case teams', () => {
     beforeEach(() => {
-      const caseRule = createInstanceElement({ fullName: 'Case', assignmentRule: [{ ruleEntry: [{ assignedTo: 'user1' }, { assignedTo: 'user2', team: 'team1' }] }] }, mockTypes.AssignmentRules)
+      const caseRule = createInstanceElement({ values: { fullName: 'Case', assignmentRule: [{ ruleEntry: [{ assignedTo: 'user1' }, { assignedTo: 'user2', team: 'team1' }] }] },
+        type: mockTypes.AssignmentRules,
+        fetchProfile: defaultFilterContext.fetchProfile })
       caseRuleChange = toChange({ after: caseRule })
     })
 
@@ -37,7 +40,11 @@ describe('case AssignmentRules change validator', () => {
   })
   describe('case AssignmentRules without case teams', () => {
     beforeEach(() => {
-      const caseRule = createInstanceElement({ fullName: 'Case', assignmentRule: [{ ruleEntry: [{ assignedTo: 'user1' }, { assignedTo: 'user2' }] }] }, mockTypes.AssignmentRules)
+      const caseRule = createInstanceElement({
+        values: { fullName: 'Case', assignmentRule: [{ ruleEntry: [{ assignedTo: 'user1' }, { assignedTo: 'user2' }] }] },
+        type: mockTypes.AssignmentRules,
+        fetchProfile: defaultFilterContext.fetchProfile,
+      })
       caseRuleChange = toChange({ after: caseRule })
     })
 

--- a/packages/salesforce-adapter/test/change_validators/data_category_group.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/data_category_group.test.ts
@@ -17,9 +17,14 @@ import { toChange } from '@salto-io/adapter-api'
 import changeValidator from '../../src/change_validators/data_category_group'
 import { mockTypes } from '../mock_elements'
 import { createInstanceElement } from '../../src/transformers/transformer'
+import { defaultFilterContext } from '../utils'
 
 describe('DataCategoryGroup ChangeValidator', () => {
-  const afterRecord = createInstanceElement({ fullName: 'obj__c.record' }, mockTypes.DataCategoryGroup)
+  const afterRecord = createInstanceElement({
+    values: { fullName: 'obj__c.record' },
+    type: mockTypes.DataCategoryGroup,
+    fetchProfile: defaultFilterContext.fetchProfile,
+  })
 
   it('should have warning when trying to add a new data category group', async () => {
     const changeErrors = await changeValidator(

--- a/packages/salesforce-adapter/test/change_validators/deleted_non_queryable_fields.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/deleted_non_queryable_fields.test.ts
@@ -25,7 +25,7 @@ import {
 } from '@salto-io/adapter-api'
 import {
   createCustomObjectType,
-  createField,
+  createField, defaultFilterContext,
 } from '../utils'
 import { createInstanceElement } from '../../src/transformers/transformer'
 import { FIELD_ANNOTATIONS } from '../../src/constants'
@@ -63,7 +63,11 @@ describe('deletedNonQueryableFields', () => {
           fieldIsHidden: false,
           fieldIsReadOnly: false,
         })
-        const instance = createInstanceElement({ fullName: 'SomeInstance', SomeField: true }, objectType)
+        const instance = createInstanceElement({
+          values: { fullName: 'SomeInstance', SomeField: true },
+          type: objectType,
+          fetchProfile: defaultFilterContext.fetchProfile,
+        })
         warnings = await changeValidator([toChange({ after: instance })])
       })
       it('should not warn', () => {
@@ -74,7 +78,11 @@ describe('deletedNonQueryableFields', () => {
 
   describe('modification change', () => {
     const createInstanceChangeForType = (objectType: ObjectType): ModificationChange<InstanceElement> => {
-      const instanceBefore = createInstanceElement({ fullName: 'SomeInstance', SomeField: true }, objectType)
+      const instanceBefore = createInstanceElement({
+        values: { fullName: 'SomeInstance', SomeField: true },
+        type: objectType,
+        fetchProfile: defaultFilterContext.fetchProfile,
+      })
       const instanceAfter = instanceBefore.clone()
       instanceAfter.value.SomeField = false
       return toChange({ before: instanceBefore, after: instanceAfter }) as ModificationChange<InstanceElement>

--- a/packages/salesforce-adapter/test/change_validators/flows.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/flows.test.ts
@@ -19,6 +19,7 @@ import flowsChangeValidator from '../../src/change_validators/flows'
 import { mockTypes } from '../mock_elements'
 import { createInstanceElement } from '../../src/transformers/transformer'
 import mockClient from '../client'
+import { defaultFilterContext } from '../utils'
 
 describe('flows change validator', () => {
   let flowChanges: Change
@@ -30,7 +31,12 @@ describe('flows change validator', () => {
     let statusChange: InstanceElement
     let otherModifications: InstanceElement
     beforeEach(() => {
-      beforeRecord = createInstanceElement({ fullName: 'flow1', status: 'Active', actionType: 'quick' }, mockTypes.Flow)
+      beforeRecord = createInstanceElement({
+        values: { fullName: 'flow1', status: 'Active', actionType: 'quick' },
+        type: mockTypes.Flow,
+        fetchProfile: defaultFilterContext.fetchProfile,
+      })
+
       statusChange = beforeRecord.clone()
       statusChange.value.status = 'Obsolete'
       otherModifications = statusChange.clone()
@@ -61,7 +67,11 @@ describe('flows change validator', () => {
   })
   describe('adding and editing an active flow', () => {
     beforeEach(() => {
-      const beforeRecord = createInstanceElement({ fullName: 'flow2', status: 'Active', actionType: 'quick' }, mockTypes.Flow)
+      const beforeRecord = createInstanceElement({
+        values: { fullName: 'flow2', status: 'Active', actionType: 'quick' },
+        type: mockTypes.Flow,
+        fetchProfile: defaultFilterContext.fetchProfile,
+      })
       const afterRecord = beforeRecord.clone()
       afterRecord.value.actionType = 'case'
       flowChanges = toChange({ before: beforeRecord, after: afterRecord })
@@ -80,8 +90,12 @@ describe('flows change validator', () => {
       })
     })
     describe('non-sandbox env', () => {
-      const flowSettings = createInstanceElement({ fullName: '',
-        enableFlowDeployAsActiveEnabled: true }, mockTypes.FlowSettings)
+      const flowSettings = createInstanceElement({
+        values: { fullName: '',
+          enableFlowDeployAsActiveEnabled: true },
+        type: mockTypes.FlowSettings,
+        fetchProfile: defaultFilterContext.fetchProfile,
+      })
       const elementsSource = buildElementsSourceFromElements([flowSettings])
       // const elementsSources = elementSource.createInMemoryElementSource([flowSettings])
       beforeEach(() => {
@@ -111,7 +125,11 @@ describe('flows change validator', () => {
       })
       describe('activating a flow', () => {
         beforeEach(() => {
-          const beforeRecord = createInstanceElement({ fullName: 'flow3', status: 'Draft', actionType: 'quick' }, mockTypes.Flow)
+          const beforeRecord = createInstanceElement({
+            values: { fullName: 'flow3', status: 'Draft', actionType: 'quick' },
+            type: mockTypes.Flow,
+            fetchProfile: defaultFilterContext.fetchProfile,
+          })
           const afterRecord = beforeRecord.clone()
           afterRecord.value.status = 'Active'
           flowChanges = toChange({ before: beforeRecord, after: afterRecord })
@@ -135,7 +153,11 @@ describe('flows change validator', () => {
       })
       describe('adding an active flow', () => {
         beforeEach(() => {
-          const afterRecord = createInstanceElement({ fullName: 'flow2', status: 'Active', actionType: 'quick' }, mockTypes.Flow)
+          const afterRecord = createInstanceElement({
+            values: { fullName: 'flow2', status: 'Active', actionType: 'quick' },
+            type: mockTypes.Flow,
+            fetchProfile: defaultFilterContext.fetchProfile,
+          })
           flowChanges = toChange({ after: afterRecord })
         })
         it('should have post deploy action regarding the new flow version', async () => {
@@ -164,7 +186,11 @@ describe('flows change validator', () => {
       changeValidator = flowsChangeValidator(
         { }, false, client
       )
-      const beforeRecord = createInstanceElement({ fullName: 'flow', status: 'Active' }, mockTypes.Flow)
+      const beforeRecord = createInstanceElement({
+        values: { fullName: 'flow', status: 'Active' },
+        type: mockTypes.Flow,
+        fetchProfile: defaultFilterContext.fetchProfile,
+      })
       flowChanges = toChange({ before: beforeRecord })
     })
 
@@ -185,7 +211,11 @@ describe('flows change validator', () => {
     })
     describe('add a new draft flow', () => {
       beforeEach(() => {
-        const afterRecord = createInstanceElement({ fullName: 'flow', status: 'Draft', actionType: 'quick' }, mockTypes.Flow)
+        const afterRecord = createInstanceElement({
+          values: { fullName: 'flow', status: 'Draft', actionType: 'quick' },
+          type: mockTypes.Flow,
+          fetchProfile: defaultFilterContext.fetchProfile,
+        })
         flowChanges = toChange({ after: afterRecord })
       })
       it('should not throw any error', async () => {
@@ -197,7 +227,11 @@ describe('flows change validator', () => {
     })
     describe('edit draft flow', () => {
       beforeEach(() => {
-        const beforeRecord = createInstanceElement({ fullName: 'flow', status: 'Draft', actionType: 'quick' }, mockTypes.Flow)
+        const beforeRecord = createInstanceElement({
+          values: { fullName: 'flow', status: 'Draft', actionType: 'quick' },
+          type: mockTypes.Flow,
+          fetchProfile: defaultFilterContext.fetchProfile,
+        })
         const afterRecord = beforeRecord.clone()
         afterRecord.value.actionType = 'fast'
         flowChanges = toChange({ before: beforeRecord, after: afterRecord })

--- a/packages/salesforce-adapter/test/change_validators/fullname_change.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/fullname_change.test.ts
@@ -18,12 +18,17 @@ import changeValidator from '../../src/change_validators/fullname_changed'
 import { mockTypes } from '../mock_elements'
 import { createInstanceElement } from '../../src/transformers/transformer'
 import { INSTANCE_FULL_NAME_FIELD } from '../../src/constants'
+import { defaultFilterContext } from '../utils'
 
 describe('fullname change validator', () => {
   describe('when fullname changes', () => {
     let fullnameChange: Change
     beforeEach(() => {
-      const beforeRecord = createInstanceElement({ fullName: 'original_fullname' }, mockTypes.RecordType)
+      const beforeRecord = createInstanceElement({
+        values: { fullName: 'original_fullname' },
+        type: mockTypes.RecordType,
+        fetchProfile: defaultFilterContext.fetchProfile,
+      })
       const afterRecord = beforeRecord.clone()
       afterRecord.value[INSTANCE_FULL_NAME_FIELD] = 'modified_fullname'
       fullnameChange = toChange({ before: beforeRecord, after: afterRecord })
@@ -43,7 +48,11 @@ describe('fullname change validator', () => {
   describe('when fullname does not change', () => {
     let fullnameChange: Change
     beforeEach(() => {
-      const beforeRecord = createInstanceElement({ fullName: 'original_fullname', status: 'ACTIVE' }, mockTypes.Flow)
+      const beforeRecord = createInstanceElement({
+        values: { fullName: 'original_fullname', status: 'ACTIVE' },
+        type: mockTypes.Flow,
+        fetchProfile: defaultFilterContext.fetchProfile,
+      })
       const afterRecord = beforeRecord.clone()
       afterRecord.value.status = 'INACTIVE'
       fullnameChange = toChange({ before: beforeRecord, after: afterRecord })

--- a/packages/salesforce-adapter/test/change_validators/invalid_listview_filterscope.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/invalid_listview_filterscope.test.ts
@@ -17,13 +17,18 @@ import { Change, CORE_ANNOTATIONS, getAllChangeData, InstanceElement, toChange }
 import changeValidator from '../../src/change_validators/invalid_listview_filterscope'
 import { mockTypes } from '../mock_elements'
 import { createInstanceElement } from '../../src/transformers/transformer'
+import { defaultFilterContext } from '../utils'
 
-const createListView = (filterScopeValue: string): InstanceElement => createInstanceElement(
-  { fullName: 'Some.FullName', filterScope: filterScopeValue },
-  mockTypes.ListView,
-  undefined,
-  { [CORE_ANNOTATIONS.PARENT]: 'Opportunity' },
-)
+const createListView = (filterScopeValue: string): InstanceElement => createInstanceElement({
+  values: {
+    fullName: 'Some.FullName',
+    filterScope:
+  filterScopeValue,
+  },
+  type: mockTypes.ListView,
+  annotations: { [CORE_ANNOTATIONS.PARENT]: 'Opportunity' },
+  fetchProfile: defaultFilterContext.fetchProfile,
+})
 
 describe('ListView filterScope validator', () => {
   describe('when filterScope changes to invalid value', () => {

--- a/packages/salesforce-adapter/test/change_validators/record_type_deletion.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/record_type_deletion.test.ts
@@ -20,6 +20,7 @@ import recordTypeChangeValidator from '../../src/change_validators/record_type_d
 import { CUSTOM_OBJECT } from '../../src/constants'
 import { mockTypes } from '../mock_elements'
 import { createInstanceElement } from '../../src/transformers/transformer'
+import { defaultFilterContext } from '../utils'
 
 describe('record type deletion change validator', () => {
   const objectType = new ObjectType({
@@ -27,7 +28,11 @@ describe('record type deletion change validator', () => {
     annotations: { metadataType: CUSTOM_OBJECT, apiName: 'obj__c' },
   })
 
-  const beforeRecord = createInstanceElement({ fullName: 'obj__c.record' }, mockTypes.RecordType)
+  const beforeRecord = createInstanceElement({
+    values: { fullName: 'obj__c.record' },
+    type: mockTypes.RecordType,
+    fetchProfile: defaultFilterContext.fetchProfile,
+  })
 
   describe('deletion of record type without the deletion of the type', () => {
     it('should have error when trying to remove record type', async () => {

--- a/packages/salesforce-adapter/test/fetch_installed_packages.test.ts
+++ b/packages/salesforce-adapter/test/fetch_installed_packages.test.ts
@@ -21,6 +21,7 @@ import { fetchMetadataInstances } from '../src/fetch'
 import { buildMetadataQuery } from '../src/fetch_profile/metadata_query'
 import { mockFileProperties, MockFilePropertiesInput } from './connection'
 import { mockTypes } from './mock_elements'
+import { defaultFilterContext } from './utils'
 
 describe('Test fetching installed package metadata', () => {
   type MockFetchArgs = {
@@ -49,6 +50,7 @@ describe('Test fetching installed package metadata', () => {
       metadataType: mockType,
       metadataQuery,
       addNamespacePrefixToFullName,
+      fetchProfile: defaultFilterContext.fetchProfile,
     })
     return elements.filter(isInstanceElement)[0]
   }

--- a/packages/salesforce-adapter/test/filters/convert_maps.test.ts
+++ b/packages/salesforce-adapter/test/filters/convert_maps.test.ts
@@ -531,7 +531,11 @@ describe('Convert maps filter', () => {
     type FilterType = FilterWith<'onFetch'| 'preDeploy'>
     let filter: FilterType
     beforeAll(async () => {
-      const lwc = createInstanceElement({ fullName: 'lwc', lwcResources: { lwcResource: [{ filePath: 'lwc/dir/lwc.js', source: 'lwc.ts' }, { filePath: 'lwc/dir/__mocks__/lwc.js', source: 'lwc.ts' }] } }, mockTypes.LightningComponentBundle)
+      const lwc = createInstanceElement({
+        values: { fullName: 'lwc', lwcResources: { lwcResource: [{ filePath: 'lwc/dir/lwc.js', source: 'lwc.ts' }, { filePath: 'lwc/dir/__mocks__/lwc.js', source: 'lwc.ts' }] } },
+        type: mockTypes.LightningComponentBundle,
+        fetchProfile: defaultFilterContext.fetchProfile,
+      })
       const lwcType = mockTypes.LightningComponentBundle
       elements = [lwc, lwcType]
 

--- a/packages/salesforce-adapter/test/filters/create_missing_installed_packages_instances.test.ts
+++ b/packages/salesforce-adapter/test/filters/create_missing_installed_packages_instances.test.ts
@@ -56,13 +56,16 @@ describe('createMissingInstalledPackagesInstancesFilter', () => {
     )
 
     const createInstalledPackageInstance = (namespace: string): InstanceElement => (
-      createInstanceElement(
-        {
-          [INSTANCE_FULL_NAME_FIELD]: namespace,
-          version: '1.0.0',
+      createInstanceElement({
+        values: {
+          [INSTANCE_FULL_NAME_FIELD]:
+      namespace,
+          version:
+      '1.0.0',
         },
-        mockTypes.InstalledPackage,
-      )
+        type: mockTypes.InstalledPackage,
+        fetchProfile: defaultFilterContext.fetchProfile,
+      })
     )
 
 

--- a/packages/salesforce-adapter/test/filters/custom_metadata.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_metadata.test.ts
@@ -72,10 +72,13 @@ describe('CustomMetadata filter', () => {
   const createCustomMetadataInstanceFromService = (
     values: ServiceMDTRecordValue & MetadataValues
   ): MetadataInstanceElement => (
-    createInstanceElement(
-      { ...values, 'attr_xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance' },
-      mockTypes.CustomMetadata,
-    )
+    createInstanceElement({
+      values: { ...values,
+        'attr_xmlns:xsi':
+    'http://www.w3.org/2001/XMLSchema-instance' },
+      type: mockTypes.CustomMetadata,
+      fetchProfile: defaultFilterContext.fetchProfile,
+    })
   )
 
   const getInstanceByApiName = (
@@ -179,7 +182,11 @@ describe('CustomMetadata filter', () => {
       let afterPreDeployInstance: MetadataInstanceElement
       let afterOnDeployChange: Change
       beforeAll(async () => {
-        const initialInstance = createInstanceElement(naclValues, customMetadataRecordType)
+        const initialInstance = createInstanceElement({
+          values: naclValues,
+          type: customMetadataRecordType,
+          fetchProfile: defaultFilterContext.fetchProfile,
+        })
         initialChange = toChange({ after: initialInstance })
         const changes = [initialChange]
         await filter.preDeploy(changes)

--- a/packages/salesforce-adapter/test/filters/custom_objects_to_object_type.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects_to_object_type.test.ts
@@ -946,13 +946,17 @@ describe('Custom Objects to Object Type filter', () => {
       beforeAll(async () => {
         filter = filterCreator({ config: defaultFilterContext }) as typeof filter
 
-        testFieldSet = createInstanceElement(
-          { fullName: 'Test__c.MyFieldSet', description: 'my field set' },
-          await customObjectType.fields[NESTED_INSTANCE_VALUE_NAME.FIELD_SETS]
+        testFieldSet = createInstanceElement({
+          values: {
+            fullName: 'Test__c.MyFieldSet',
+            description:
+          'my field set',
+          },
+          type: await customObjectType.fields[NESTED_INSTANCE_VALUE_NAME.FIELD_SETS]
             .getType() as ObjectType,
-          undefined,
-          parentAnnotation,
-        )
+          annotations: parentAnnotation,
+          fetchProfile: defaultFilterContext.fetchProfile,
+        })
         changes = [
           toChange({ after: testFieldSet }),
         ]
@@ -990,12 +994,16 @@ describe('Custom Objects to Object Type filter', () => {
       let changes: Change[]
       let sideEffectInst: InstanceElement
       beforeAll(() => {
-        sideEffectInst = createInstanceElement(
-          { fullName: 'SideEffect', description: 'desc' },
-          mockTypes.Layout,
-          undefined,
-          parentAnnotation,
-        )
+        sideEffectInst = createInstanceElement({
+          values: {
+            fullName: 'SideEffect',
+            description:
+          'desc',
+          },
+          type: mockTypes.Layout,
+          annotations: parentAnnotation,
+          fetchProfile: defaultFilterContext.fetchProfile,
+        })
         filter = filterCreator({ config: defaultFilterContext }) as typeof filter
         changes = [
           toChange({ before: testObject }),

--- a/packages/salesforce-adapter/test/filters/email_template_static_files.test.ts
+++ b/packages/salesforce-adapter/test/filters/email_template_static_files.test.ts
@@ -47,10 +47,13 @@ describe('emailTemplate static files filter', () => {
   describe('on fetch', () => {
     describe('attachment as an object', () => {
       beforeEach(async () => {
-        const emailNoArrayAttachment = createInstanceElement({ fullName: 'unfiled$public/emailTemplate',
-          content: staticContent,
-          attachments: { name: ATTACHMENT_NAME, content: ATTACHMENT_AS_STRING } },
-        mockTypes.EmailTemplate)
+        const emailNoArrayAttachment = createInstanceElement({
+          values: { fullName: 'unfiled$public/emailTemplate',
+            content: staticContent,
+            attachments: { name: ATTACHMENT_NAME, content: ATTACHMENT_AS_STRING } },
+          type: mockTypes.EmailTemplate,
+          fetchProfile: defaultFilterContext.fetchProfile,
+        })
 
         elements = [emailNoArrayAttachment]
 
@@ -70,10 +73,13 @@ describe('emailTemplate static files filter', () => {
 
     describe('attachment as an array', () => {
       beforeEach(async () => {
-        const emailArrayAttachment = createInstanceElement({ fullName: 'unfiled$public/emailTemplate',
-          content: staticContent,
-          attachments: [{ name: ATTACHMENT_NAME, content: ATTACHMENT_AS_STRING }] },
-        mockTypes.EmailTemplate)
+        const emailArrayAttachment = createInstanceElement({
+          values: { fullName: 'unfiled$public/emailTemplate',
+            content: staticContent,
+            attachments: [{ name: ATTACHMENT_NAME, content: ATTACHMENT_AS_STRING }] },
+          type: mockTypes.EmailTemplate,
+          fetchProfile: defaultFilterContext.fetchProfile,
+        })
 
         elements = [emailArrayAttachment]
 
@@ -97,10 +103,13 @@ describe('emailTemplate static files filter', () => {
 
     let deployedInstance: InstanceElement
     beforeEach(async () => {
-      deployedInstance = createInstanceElement({ fullName: 'unfiled$public/emailTemplate',
-        content: staticContent,
-        attachments: [{ name: ATTACHMENT_NAME, content: ATTACHMENT_AS_BUFFER }] },
-      mockTypes.EmailTemplate)
+      deployedInstance = createInstanceElement({
+        values: { fullName: 'unfiled$public/emailTemplate',
+          content: staticContent,
+          attachments: [{ name: ATTACHMENT_NAME, content: ATTACHMENT_AS_BUFFER }] },
+        type: mockTypes.EmailTemplate,
+        fetchProfile: defaultFilterContext.fetchProfile,
+      })
     })
 
     it('should encode the attachment to base64 string on preDeploy and revert back to binary buffer on onDeploy', async () => {

--- a/packages/salesforce-adapter/test/filters/field_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/field_references.test.ts
@@ -160,7 +160,11 @@ describe('FieldReferences filter', () => {
         ],
       }
     )
-    const checkLabel = createInstanceElement({ fullName: 'check' }, mockTypes.CustomLabel)
+    const checkLabel = createInstanceElement({
+      values: { fullName: 'check' },
+      type: mockTypes.CustomLabel,
+      fetchProfile: defaultFilterContext.fetchProfile,
+    })
     return [
       customObjectType,
       // sharingRules555 should point to Account.name (rule contains instanceTypes constraint)

--- a/packages/salesforce-adapter/test/filters/filters.test.ts
+++ b/packages/salesforce-adapter/test/filters/filters.test.ts
@@ -22,7 +22,7 @@ import { mockDeployResult, mockDeployMessage } from '../connection'
 import { apiName, createInstanceElement, metadataType } from '../../src/transformers/transformer'
 import { mockTypes } from '../mock_elements'
 import { FilterWith } from './mocks'
-import { nullProgressReporter } from '../utils'
+import { defaultFilterContext, nullProgressReporter } from '../utils'
 
 describe('SalesforceAdapter filters', () => {
   describe('when filter methods are implemented', () => {
@@ -61,9 +61,13 @@ describe('SalesforceAdapter filters', () => {
       let inputChanges: Change[]
       let preDeployInputChanges: Change[]
       beforeEach(async () => {
-        const instance = createInstanceElement(
-          { fullName: 'TestLayout' }, mockTypes.Layout,
-        )
+        const instance = createInstanceElement({
+          values: {
+            fullName: 'TestLayout',
+          },
+          type: mockTypes.Layout,
+          fetchProfile: defaultFilterContext.fetchProfile,
+        })
         connection.metadata.deploy.mockReturnValueOnce(mockDeployResult({
           componentSuccess: [mockDeployMessage(
             { fullName: await apiName(instance), componentType: await metadataType(instance) }

--- a/packages/salesforce-adapter/test/filters/flows_filter.test.ts
+++ b/packages/salesforce-adapter/test/filters/flows_filter.test.ts
@@ -120,10 +120,16 @@ describe('flows filter', () => {
           lastModifiedByName: 'Ruler',
           lastModifiedDate: '2021-10-19T06:30:10.000Z',
         })
-        const flowdef1 = createInstanceElement({ fullName: 'flow1' },
-          mockTypes.FlowDefinition)
-        const flowdef2 = createInstanceElement({ fullName: 'flow2', activeVersionNumber: 2 },
-          mockTypes.FlowDefinition)
+        const flowdef1 = createInstanceElement({
+          values: { fullName: 'flow1' },
+          type: mockTypes.FlowDefinition,
+          fetchProfile: defaultFilterContext.fetchProfile,
+        })
+        const flowdef2 = createInstanceElement({
+          values: { fullName: 'flow2', activeVersionNumber: 2 },
+          type: mockTypes.FlowDefinition,
+          fetchProfile: defaultFilterContext.fetchProfile,
+        })
         const result = createActiveVersionFileProperties(
           [mockedFileProperties1, mockedFileProperties2],
           [flowdef1, flowdef2]
@@ -164,13 +170,19 @@ describe('flows filter', () => {
       // Deactivating a non Flow instance should not be handled
       workflowChange = toChange({
         before: createInstanceElement({
-          [INSTANCE_FULL_NAME_FIELD]: 'workflow',
-          [STATUS]: 'Active',
-        }, mockTypes.Workflow),
-        after: createInstanceElement({
+          values: {
+            [INSTANCE_FULL_NAME_FIELD]: 'workflow',
+            [STATUS]: 'Active',
+          },
+          type: mockTypes.Workflow,
+          fetchProfile: defaultFilterContext.fetchProfile,
+        }),
+        after: createInstanceElement({ values: {
           [INSTANCE_FULL_NAME_FIELD]: 'workflow',
           [STATUS]: 'Draft',
-        }, mockTypes.Workflow),
+        },
+        type: mockTypes.Workflow,
+        fetchProfile: defaultFilterContext.fetchProfile }),
       })
       changes = [alreadyInactiveFlowChange, deactivatedFlowChange, activeFlowChange,
         newInactiveFlowChange, workflowChange, deactivatedFlowChangeWithAdditionalChanges]

--- a/packages/salesforce-adapter/test/filters/formula_deps.test.ts
+++ b/packages/salesforce-adapter/test/filters/formula_deps.test.ts
@@ -130,9 +130,21 @@ describe('Formula dependencies', () => {
       customObjectTypeWithFields('SRM_API_Metadata_Client_Setting__mdt', { CreatedDate: BuiltinTypes.STRING }),
     ]
     referredInstances = [
-      createInstanceElement({ fullName: 'Details' }, mockTypes.CustomLabel),
-      createInstanceElement({ fullName: 'Trigger_Context_Status.by_class' }, someCustomMetadataType),
-      createInstanceElement({ fullName: 'Trigger_Context_Status.by_handler' }, someCustomMetadataType),
+      createInstanceElement({
+        values: { fullName: 'Details' },
+        type: mockTypes.CustomLabel,
+        fetchProfile: defaultFilterContext.fetchProfile,
+      }),
+      createInstanceElement({
+        values: { fullName: 'Trigger_Context_Status.by_class' },
+        type: someCustomMetadataType,
+        fetchProfile: defaultFilterContext.fetchProfile,
+      }),
+      createInstanceElement({
+        values: { fullName: 'Trigger_Context_Status.by_handler' },
+        type: someCustomMetadataType,
+        fetchProfile: defaultFilterContext.fetchProfile,
+      }),
     ]
   })
 
@@ -152,7 +164,11 @@ describe('Formula dependencies', () => {
       const elements = [
         typeUnderTest,
         customMetadataType,
-        createInstanceElement({ fullName: 'SomeCustomMetadataType.SomeCustomMetadataTypeRecord' }, customMetadataType),
+        createInstanceElement({
+          values: { fullName: 'SomeCustomMetadataType.SomeCustomMetadataTypeRecord' },
+          type: customMetadataType,
+          fetchProfile: defaultFilterContext.fetchProfile,
+        }),
       ]
       await filter.onFetch(elements)
       // eslint-disable-next-line no-underscore-dangle

--- a/packages/salesforce-adapter/test/filters/installed_package_generated_dependencies.test.ts
+++ b/packages/salesforce-adapter/test/filters/installed_package_generated_dependencies.test.ts
@@ -29,8 +29,16 @@ describe('installedPackageElementsFilter', () => {
   describe('onFetch', () => {
     beforeEach(() => {
       installedPackageInstances = [
-        createInstanceElement({ fullName: NAMESPACE }, mockTypes.InstalledPackage,),
-        createInstanceElement({ fullName: 'namespace1' }, mockTypes.InstalledPackage,),
+        createInstanceElement({
+          values: { fullName: NAMESPACE },
+          type: mockTypes.InstalledPackage,
+          fetchProfile: defaultFilterContext.fetchProfile,
+        }),
+        createInstanceElement({
+          values: { fullName: 'namespace1' },
+          type: mockTypes.InstalledPackage,
+          fetchProfile: defaultFilterContext.fetchProfile,
+        }),
       ]
       filter = filterCreator({ config: defaultFilterContext }) as FilterWith<'onFetch'>
     })
@@ -119,8 +127,16 @@ describe('installedPackageElementsFilter', () => {
       let instanceFromInstalledPackage: InstanceElement
 
       beforeEach(async () => {
-        instance = createInstanceElement({ fullName: 'TestInstance' }, mockTypes.ApexClass)
-        instanceFromInstalledPackage = createInstanceElement({ fullName: `${NAMESPACE}__TestInstance` }, mockTypes.ApexClass)
+        instance = createInstanceElement({
+          values: { fullName: 'TestInstance' },
+          type: mockTypes.ApexClass,
+          fetchProfile: defaultFilterContext.fetchProfile,
+        })
+        instanceFromInstalledPackage = createInstanceElement({
+          values: { fullName: `${NAMESPACE}__TestInstance` },
+          type: mockTypes.ApexClass,
+          fetchProfile: defaultFilterContext.fetchProfile,
+        })
         await filter.onFetch([...installedPackageInstances, instance, instanceFromInstalledPackage])
       })
       it('should add generated dependencies', () => {

--- a/packages/salesforce-adapter/test/filters/profile_permissions.test.ts
+++ b/packages/salesforce-adapter/test/filters/profile_permissions.test.ts
@@ -49,10 +49,13 @@ describe('Object Permissions filter', () => {
   const mockAdminProfile = (
     objectPermissions: ProfileInfo['objectPermissions'],
     fieldPermissions: ProfileInfo['fieldPermissions'],
-  ): InstanceElement => createInstanceElement(
-    { fullName: 'Admin', objectPermissions, fieldPermissions },
-    mockTypes.Profile,
-  )
+  ): InstanceElement => createInstanceElement({
+    values: {
+      fullName: 'Admin', objectPermissions, fieldPermissions,
+    },
+    type: mockTypes.Profile,
+    fetchProfile: defaultFilterContext.fetchProfile,
+  })
 
   let filter: FilterWith<'preDeploy' | 'onDeploy'>
 

--- a/packages/salesforce-adapter/test/filters/standard_value_sets.test.ts
+++ b/packages/salesforce-adapter/test/filters/standard_value_sets.test.ts
@@ -113,10 +113,14 @@ describe('Standard Value Sets filter', () => {
   ]
 
   const svsInstanceFromSource = createInstanceElement({
-    [INSTANCE_FULL_NAME_FIELD]: 'FromSource',
-    sorted: false,
-    standardValue: SVS_INSTANCE_STANDARD_VALUE,
-  }, mockSVSType)
+    values: {
+      [INSTANCE_FULL_NAME_FIELD]: 'FromSource',
+      sorted: false,
+      standardValue: SVS_INSTANCE_STANDARD_VALUE,
+    },
+    type: mockSVSType,
+    fetchProfile: defaultFilterContext.fetchProfile,
+  })
 
   const filterCreator = async (
     sfClient: SalesforceClient,

--- a/packages/salesforce-adapter/test/filters/territory.test.ts
+++ b/packages/salesforce-adapter/test/filters/territory.test.ts
@@ -41,16 +41,19 @@ describe('territory filter', () => {
           },
         }
       )
-      instance = createInstanceElement(
-        {
+      instance = createInstanceElement({
+        values: {
           fullName: 'TerModel.Territory',
-          description: 'Desc',
-          customFields: [
-            { name: 'f__c', value: { 'attr_xsi:type': 'xsd:boolean', '#text': 'false' } },
-          ],
+          description:
+        'Desc',
+          customFields:
+        [
+          { name: 'f__c', value: { 'attr_xsi:type': 'xsd:boolean', '#text': 'false' } },
+        ],
         },
         type,
-      )
+        fetchProfile: defaultFilterContext.fetchProfile,
+      })
       await filter.onFetch([type, instance])
     })
     it('should remove custom fields from instance', () => {
@@ -96,13 +99,15 @@ describe('territory filter', () => {
           },
         }
       )
-      const territoryInstance = createInstanceElement(
-        {
+      const territoryInstance = createInstanceElement({
+        values: {
           fullName: 'TerModel.testTerritory',
-          description: 'Desc',
+          description:
+        'Desc',
         },
-        territoryType,
-      )
+        type: territoryType,
+        fetchProfile: defaultFilterContext.fetchProfile,
+      })
       beforeElenentTerritory = territoryInstance
       afterElementTerritory = territoryInstance.clone()
       afterElementTerritory.value.description = 'Desc yay'
@@ -121,7 +126,11 @@ describe('territory filter', () => {
           },
         })
 
-      const modelInstance = createInstanceElement({ description: 'Desc', fullName: 'TerModel' }, modelType)
+      const modelInstance = createInstanceElement({
+        values: { description: 'Desc', fullName: 'TerModel' },
+        type: modelType,
+        fetchProfile: defaultFilterContext.fetchProfile,
+      })
       beforeElementModel = modelInstance
       afterElementModel = modelInstance.clone()
       afterElementModel.value.description = 'Desc yay'
@@ -140,16 +149,19 @@ describe('territory filter', () => {
           },
         }
       )
-      const nonTerritoryInstance = createInstanceElement(
-        {
+      const nonTerritoryInstance = createInstanceElement({
+        values: {
           fullName: 'myCustomObject',
-          description: 'Desc',
-          customFields: [
-            { name: 'f__c', value: { 'attr_xsi:type': 'xsd:boolean', '#text': 'false' } },
-          ],
+          description:
+        'Desc',
+          customFields:
+        [
+          { name: 'f__c', value: { 'attr_xsi:type': 'xsd:boolean', '#text': 'false' } },
+        ],
         },
-        nonTerritoryType,
-      )
+        type: nonTerritoryType,
+        fetchProfile: defaultFilterContext.fetchProfile,
+      })
       beforeRegularInstance = nonTerritoryInstance
       afterRegularInstance = nonTerritoryInstance.clone()
       afterRegularInstance.value.description = 'bla'

--- a/packages/salesforce-adapter/test/filters/utils.test.ts
+++ b/packages/salesforce-adapter/test/filters/utils.test.ts
@@ -59,7 +59,7 @@ import {
 import { createInstanceElement, Types } from '../../src/transformers/transformer'
 import { CustomObject } from '../../src/client/types'
 import { createFlowChange, mockInstances, mockTypes } from '../mock_elements'
-import { createCustomObjectType, createField } from '../utils'
+import { createCustomObjectType, createField, defaultFilterContext } from '../utils'
 import { INSTANCE_SUFFIXES } from '../../src/types'
 import { mockFileProperties } from '../connection'
 
@@ -254,14 +254,22 @@ describe('filter utils', () => {
     })
   })
   describe('isCustomMetadataRecordInstance', () => {
-    const customMetadataRecordInstance = createInstanceElement(
-      { [INSTANCE_FULL_NAME_FIELD]: 'MDType.MDTypeInstance' },
-      mockTypes.CustomMetadataRecordType
-    )
-    const profileInstance = createInstanceElement(
-      { [INSTANCE_FULL_NAME_FIELD]: 'profileInstance' },
-      mockTypes.Profile
-    )
+    const customMetadataRecordInstance = createInstanceElement({
+      values: {
+        [INSTANCE_FULL_NAME_FIELD]:
+      'MDType.MDTypeInstance',
+      },
+      type: mockTypes.CustomMetadataRecordType,
+      fetchProfile: defaultFilterContext.fetchProfile,
+    })
+    const profileInstance = createInstanceElement({
+      values: {
+        [INSTANCE_FULL_NAME_FIELD]:
+      'profileInstance',
+      },
+      type: mockTypes.Profile,
+      fetchProfile: defaultFilterContext.fetchProfile,
+    })
     it('should return true for customMetadataRecordType instance', async () => {
       expect(await isCustomMetadataRecordInstance(customMetadataRecordInstance)).toBeTrue()
     })
@@ -289,11 +297,19 @@ describe('filter utils', () => {
         'Parent.Instance',
         ...INSTANCE_SUFFIXES.map(suffix => `Instance__${suffix}`),
       ])('%s', async (name: string) => {
-        const instance = createInstanceElement({ [INSTANCE_FULL_NAME_FIELD]: name }, mockTypes.Profile)
+        const instance = createInstanceElement({
+          values: { [INSTANCE_FULL_NAME_FIELD]: name },
+          type: mockTypes.Profile,
+          fetchProfile: defaultFilterContext.fetchProfile,
+        })
         expect(await getNamespace(instance)).toBeUndefined()
       })
       it('Layout instance', async () => {
-        const instance = createInstanceElement({ [INSTANCE_FULL_NAME_FIELD]: 'Account-Test Layout-Name' }, mockTypes.Layout)
+        const instance = createInstanceElement({
+          values: { [INSTANCE_FULL_NAME_FIELD]: 'Account-Test Layout-Name' },
+          type: mockTypes.Layout,
+          fetchProfile: defaultFilterContext.fetchProfile,
+        })
         expect(await getNamespace(instance)).toBeUndefined()
       })
     })
@@ -305,11 +321,19 @@ describe('filter utils', () => {
         `${NAMESPACE}__configurationSummary`, // There was an edge-case where __c was replaced and caused incorrect result
         ...INSTANCE_SUFFIXES.map(suffix => `${NAMESPACE}__Instance__${suffix}`),
       ])('%s', async (name: string) => {
-        const instance = createInstanceElement({ [INSTANCE_FULL_NAME_FIELD]: name }, mockTypes.Profile)
+        const instance = createInstanceElement({
+          values: { [INSTANCE_FULL_NAME_FIELD]: name },
+          type: mockTypes.Profile,
+          fetchProfile: defaultFilterContext.fetchProfile,
+        })
         expect(await getNamespace(instance)).toEqual(NAMESPACE)
       })
       it('Layout instance', async () => {
-        const instance = createInstanceElement({ [INSTANCE_FULL_NAME_FIELD]: `Account-${NAMESPACE}__Test Layout-Name` }, mockTypes.Layout)
+        const instance = createInstanceElement({
+          values: { [INSTANCE_FULL_NAME_FIELD]: `Account-${NAMESPACE}__Test Layout-Name` },
+          type: mockTypes.Layout,
+          fetchProfile: defaultFilterContext.fetchProfile,
+        })
         expect(await getNamespace(instance)).toEqual(NAMESPACE)
       })
     })
@@ -321,11 +345,19 @@ describe('filter utils', () => {
         'Parent.Instance',
         ...INSTANCE_SUFFIXES.map(suffix => `Instance__${suffix}`),
       ])('%s', (name: string) => {
-        const instance = createInstanceElement({ [INSTANCE_FULL_NAME_FIELD]: name }, mockTypes.Profile)
+        const instance = createInstanceElement({
+          values: { [INSTANCE_FULL_NAME_FIELD]: name },
+          type: mockTypes.Profile,
+          fetchProfile: defaultFilterContext.fetchProfile,
+        })
         expect(getNamespaceSync(instance)).toBeUndefined()
       })
       it('Layout instance', () => {
-        const instance = createInstanceElement({ [INSTANCE_FULL_NAME_FIELD]: 'Account-Test Layout-Name' }, mockTypes.Layout)
+        const instance = createInstanceElement({
+          values: { [INSTANCE_FULL_NAME_FIELD]: 'Account-Test Layout-Name' },
+          type: mockTypes.Layout,
+          fetchProfile: defaultFilterContext.fetchProfile,
+        })
         expect(getNamespaceSync(instance)).toBeUndefined()
       })
     })
@@ -337,11 +369,19 @@ describe('filter utils', () => {
         `${NAMESPACE}__configurationSummary`, // There was an edge-case where __c was replaced and caused incorrect result
         ...INSTANCE_SUFFIXES.map(suffix => `${NAMESPACE}__Instance__${suffix}`),
       ])('%s', (name: string) => {
-        const instance = createInstanceElement({ [INSTANCE_FULL_NAME_FIELD]: name }, mockTypes.Profile)
+        const instance = createInstanceElement({
+          values: { [INSTANCE_FULL_NAME_FIELD]: name },
+          type: mockTypes.Profile,
+          fetchProfile: defaultFilterContext.fetchProfile,
+        })
         expect(getNamespaceSync(instance)).toEqual(NAMESPACE)
       })
       it('Layout instance', () => {
-        const instance = createInstanceElement({ [INSTANCE_FULL_NAME_FIELD]: `Account-${NAMESPACE}__Test Layout-Name` }, mockTypes.Layout)
+        const instance = createInstanceElement({
+          values: { [INSTANCE_FULL_NAME_FIELD]: `Account-${NAMESPACE}__Test Layout-Name` },
+          type: mockTypes.Layout,
+          fetchProfile: defaultFilterContext.fetchProfile,
+        })
         expect(getNamespaceSync(instance)).toEqual(NAMESPACE)
       })
     })
@@ -424,7 +464,11 @@ describe('filter utils', () => {
     let parent: ObjectType
 
     beforeEach(() => {
-      instance = createInstanceElement({ [INSTANCE_FULL_NAME_FIELD]: 'TestFullName' }, mockTypes.WebLink)
+      instance = createInstanceElement({
+        values: { [INSTANCE_FULL_NAME_FIELD]: 'TestFullName' },
+        type: mockTypes.WebLink,
+        fetchProfile: defaultFilterContext.fetchProfile,
+      })
       parent = mockTypes.Account
     })
     it('should return false for element with unresolved parent', () => {
@@ -485,7 +529,11 @@ describe('filter utils', () => {
     let instance: InstanceElement
 
     beforeEach(() => {
-      instance = createInstanceElement({ [INSTANCE_FULL_NAME_FIELD]: 'TestFullName' }, mockTypes.WebLink)
+      instance = createInstanceElement({
+        values: { [INSTANCE_FULL_NAME_FIELD]: 'TestFullName' },
+        type: mockTypes.WebLink,
+        fetchProfile: defaultFilterContext.fetchProfile,
+      })
     })
 
     it('should return undefined on all properties when element is not annotated with any', () => {
@@ -533,9 +581,13 @@ describe('filter utils', () => {
     let instance: InstanceElement
     beforeEach(() => {
       instance = createInstanceElement({
-        [INSTANCE_FULL_NAME_FIELD]: 'TestInstance',
-        description: 'Test Instance',
-      }, mockTypes.Profile)
+        values: {
+          [INSTANCE_FULL_NAME_FIELD]: 'TestInstance',
+          description: 'Test Instance',
+        },
+        type: mockTypes.Profile,
+        fetchProfile: defaultFilterContext.fetchProfile,
+      })
     })
     describe('isInstanceOfTypeSync', () => {
       it('should return true when the instance type is one of the provided types', () => {
@@ -583,13 +635,21 @@ describe('filter utils', () => {
     it('should return false when a non Flow instance was deactivated', () => {
       const workflowChange = toChange({
         before: createInstanceElement({
-          [INSTANCE_FULL_NAME_FIELD]: 'workflow',
-          [STATUS]: 'Active',
-        }, mockTypes.Workflow),
+          values: {
+            [INSTANCE_FULL_NAME_FIELD]: 'workflow',
+            [STATUS]: 'Active',
+          },
+          type: mockTypes.Workflow,
+          fetchProfile: defaultFilterContext.fetchProfile,
+        }),
         after: createInstanceElement({
-          [INSTANCE_FULL_NAME_FIELD]: 'workflow',
-          [STATUS]: 'Draft',
-        }, mockTypes.Workflow),
+          values: {
+            [INSTANCE_FULL_NAME_FIELD]: 'workflow',
+            [STATUS]: 'Draft',
+          },
+          type: mockTypes.Workflow,
+          fetchProfile: defaultFilterContext.fetchProfile,
+        }),
       })
       expect(workflowChange).not.toSatisfy(isDeactivatedFlowChange)
     })
@@ -614,13 +674,21 @@ describe('filter utils', () => {
       it('should return false when a non Flow instance was deactivated with no additional changes', () => {
         const workflowChange = toChange({
           before: createInstanceElement({
-            [INSTANCE_FULL_NAME_FIELD]: 'workflow',
-            [STATUS]: 'Active',
-          }, mockTypes.Workflow),
+            values: {
+              [INSTANCE_FULL_NAME_FIELD]: 'workflow',
+              [STATUS]: 'Active',
+            },
+            type: mockTypes.Workflow,
+            fetchProfile: defaultFilterContext.fetchProfile,
+          }),
           after: createInstanceElement({
-            [INSTANCE_FULL_NAME_FIELD]: 'workflow',
-            [STATUS]: 'Draft',
-          }, mockTypes.Workflow),
+            values: {
+              [INSTANCE_FULL_NAME_FIELD]: 'workflow',
+              [STATUS]: 'Draft',
+            },
+            type: mockTypes.Workflow,
+            fetchProfile: defaultFilterContext.fetchProfile,
+          }),
         })
         expect(workflowChange).not.toSatisfy(isDeactivatedFlowChangeOnly)
       })

--- a/packages/salesforce-adapter/test/filters/utils.test.ts
+++ b/packages/salesforce-adapter/test/filters/utils.test.ts
@@ -759,7 +759,7 @@ describe('filter utils', () => {
     describe('InstalledPackage instances', () => {
       describe('when the feature installedPackageWithVersion is enabled', () => {
         it('should create instance with ElemID that contains the versionNumber', () => {
-          const instance = createInstanceElement({
+          const instanceWithVersion = createInstanceElement({
             type: mockTypes.InstalledPackage,
             values: {
               [INSTANCE_FULL_NAME_FIELD]: 'Test',
@@ -770,7 +770,22 @@ describe('filter utils', () => {
               isFeatureEnabled: (feature: string) => feature === 'installedPackageWithVersion',
             },
           })
-          expect(instance.elemID.getFullName()).toEqual('salesforce.InstalledPackage.instance.Test_130_12@uv')
+          // This is relevant for InstalledPackage instances that were created as part of the
+          // create_missing_installed_packages_instances filter where we don't have a versionNumber value.
+          const instanceWithoutVersion = createInstanceElement({
+            type: mockTypes.InstalledPackage,
+            values: {
+              [INSTANCE_FULL_NAME_FIELD]: 'Test2',
+            },
+            fetchProfile: {
+              ...defaultFilterContext.fetchProfile,
+              isFeatureEnabled: (feature: string) => feature === 'installedPackageWithVersion',
+            },
+          })
+          expect(instanceWithVersion.elemID.getFullName())
+            .toEqual('salesforce.InstalledPackage.instance.Test_130_12@uv')
+          expect(instanceWithoutVersion.elemID.getFullName())
+            .toEqual('salesforce.InstalledPackage.instance.Test2')
         })
         describe('when the feature installedPackageWithVersion is disabled', () => {
           it('should not create instance with ElemID that contains the versionNumber', () => {

--- a/packages/salesforce-adapter/test/filters/utils.test.ts
+++ b/packages/salesforce-adapter/test/filters/utils.test.ts
@@ -755,4 +755,40 @@ describe('filter utils', () => {
       })
     })
   })
+  describe('createInstanceElement', () => {
+    describe('InstalledPackage instances', () => {
+      describe('when the feature installedPackageWithVersion is enabled', () => {
+        it('should create instance with ElemID that contains the versionNumber', () => {
+          const instance = createInstanceElement({
+            type: mockTypes.InstalledPackage,
+            values: {
+              [INSTANCE_FULL_NAME_FIELD]: 'Test',
+              versionNumber: '130.12',
+            },
+            fetchProfile: {
+              ...defaultFilterContext.fetchProfile,
+              isFeatureEnabled: (feature: string) => feature === 'installedPackageWithVersion',
+            },
+          })
+          expect(instance.elemID.getFullName()).toEqual('salesforce.InstalledPackage.instance.Test_130_12@uv')
+        })
+        describe('when the feature installedPackageWithVersion is disabled', () => {
+          it('should not create instance with ElemID that contains the versionNumber', () => {
+            const instance = createInstanceElement({
+              type: mockTypes.InstalledPackage,
+              values: {
+                [INSTANCE_FULL_NAME_FIELD]: 'Test',
+                versionNumber: '130.12',
+              },
+              fetchProfile: {
+                ...defaultFilterContext.fetchProfile,
+                isFeatureEnabled: (_feature: string) => false,
+              },
+            })
+            expect(instance.elemID.getFullName()).toEqual('salesforce.InstalledPackage.instance.Test')
+          })
+        })
+      })
+    })
+  })
 })

--- a/packages/salesforce-adapter/test/filters/workflow.test.ts
+++ b/packages/salesforce-adapter/test/filters/workflow.test.ts
@@ -76,11 +76,12 @@ describe('Workflow filter', () => {
     values: MetadataValues,
     fieldName: string
   ): Promise<InstanceElement> => (
-    createInstanceElement(
+    createInstanceElement({
       values,
-      await (await mockTypes.Workflow.fields[fieldName].getType() as ListType)
+      type: await (await mockTypes.Workflow.fields[fieldName].getType() as ListType)
         .getInnerType() as ObjectType,
-    )
+      fetchProfile: defaultFilterContext.fetchProfile,
+    })
   )
 
   describe('on fetch', () => {

--- a/packages/salesforce-adapter/test/group_changes.test.ts
+++ b/packages/salesforce-adapter/test/group_changes.test.ts
@@ -39,6 +39,7 @@ import {
 import { getChangeGroupIds } from '../src/group_changes'
 import { createInstanceElement } from '../src/transformers/transformer'
 import { mockDefaultValues, mockTypes } from './mock_elements'
+import { defaultFilterContext } from './utils'
 
 describe('Group changes function', () => {
   describe('when changes are not additions of sbaa__ApprovalRule__c and sbaa__ApprovalCondition__c', () => {
@@ -98,10 +99,11 @@ describe('Group changes function', () => {
         path: [SALESFORCE, OBJECTS_PATH, differentCustomObjectName],
       }
     )
-    const metadataInstance = createInstanceElement(
-      mockDefaultValues.StaticResource,
-      mockTypes.StaticResource,
-    )
+    const metadataInstance = createInstanceElement({
+      values: mockDefaultValues.StaticResource,
+      type: mockTypes.StaticResource,
+      fetchProfile: defaultFilterContext.fetchProfile,
+    })
     let changeGroupIds: Map<ChangeId, ChangeGroupId>
 
     const addInstance = new InstanceElement('addInstance', customObject)

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -52,7 +52,7 @@ import { createInstanceElement, createMetadataObjectType, Types } from '../src/t
 import { allMissingSubTypes } from '../src/transformers/salesforce_types'
 import { API_VERSION } from '../src/client/client'
 import { WORKFLOW_FIELD_TO_TYPE } from '../src/filters/workflow'
-import { createCustomObjectType } from './utils'
+import { createCustomObjectType, defaultFilterContext } from './utils'
 import { SORT_ORDER } from '../src/change_validators/duplicate_rules_sort_order'
 
 
@@ -735,10 +735,11 @@ export const mockDefaultValues = {
 export const mockInstances = () => ({
   ..._.mapValues(
     mockDefaultValues,
-    (values, typeName) => createInstanceElement(
+    (values, typeName) => createInstanceElement({
       values,
-      mockTypes[typeName as keyof typeof mockDefaultValues],
-    )
+      type: mockTypes[typeName as keyof typeof mockDefaultValues],
+      fetchProfile: defaultFilterContext.fetchProfile,
+    })
   ),
   [CHANGED_AT_SINGLETON]: new InstanceElement(
     ElemID.CONFIG_NAME,
@@ -761,17 +762,25 @@ export const createFlowChange = ({
   let afterInstance: InstanceElement | undefined
   if (beforeStatus) {
     beforeInstance = createInstanceElement({
-      [INSTANCE_FULL_NAME_FIELD]: flowApiName,
-      [STATUS]: beforeStatus,
-      [LABEL]: flowApiName,
-    }, mockTypes.Flow)
+      values: {
+        [INSTANCE_FULL_NAME_FIELD]: flowApiName,
+        [STATUS]: beforeStatus,
+        [LABEL]: flowApiName,
+      },
+      type: mockTypes.Flow,
+      fetchProfile: defaultFilterContext.fetchProfile,
+    })
   }
   if (afterStatus) {
     afterInstance = createInstanceElement({
-      [INSTANCE_FULL_NAME_FIELD]: flowApiName,
-      [STATUS]: afterStatus,
-      [LABEL]: `${flowApiName}${additionalModifications ? 'Modified' : ''}`,
-    }, mockTypes.Flow)
+      values: {
+        [INSTANCE_FULL_NAME_FIELD]: flowApiName,
+        [STATUS]: afterStatus,
+        [LABEL]: `${flowApiName}${additionalModifications ? 'Modified' : ''}`,
+      },
+      type: mockTypes.Flow,
+      fetchProfile: defaultFilterContext.fetchProfile,
+    })
   }
   return toChange({ before: beforeInstance, after: afterInstance })
 }

--- a/packages/salesforce-adapter/test/sfdx_parser/filters/custom_fields.test.ts
+++ b/packages/salesforce-adapter/test/sfdx_parser/filters/custom_fields.test.ts
@@ -105,7 +105,9 @@ describe('custom fields filter', () => {
   describe('when called with custom object instances', () => {
     let elements: InstanceElement[]
     beforeEach(async () => {
-      elements = [createInstanceElement({ fullName: 'obj__c' }, mockTypes.CustomObject)]
+      elements = [createInstanceElement({ values: { fullName: 'obj__c' },
+        type: mockTypes.CustomObject,
+        fetchProfile: defaultFilterContext.fetchProfile })]
       await filter.onFetch?.(elements)
     })
     it('should add fields to the custom object that exists', () => {


### PR DESCRIPTION
This PR adds an optional feature that changes the ElemID of `InstalledPakcage` instances to contain the Package version as-well.

---

Workspace diff: https://github.com/salto-io/tamir-sf/commit/fc8d6c481741d439f2ebf9eafe848a46ddb11227

Please only review the changes in `transformer.ts` and the test suite `createInstanceElement` I've added to `utils.test.ts`, as all of the other changes are related to the refactor of the params of `createInstanceElement`

This will force alignment between the installed versions in the source and the target, since the `Installeed Package` instances will have different **ElemIDs** 

---
_Release Notes_: 
Salesforce Adapter:
- Add the optional feature `installedPackageWithVersion` that changes the Element ID of `InstalledPackage` instances to contain the package version as-well. 

---
_User Notifications_: 
Salesforce:
When using the feature `installedPackageWithVersion`, expect workspace changes to all the Elements coming from `Installed Package` and the `InstalledPackage` metadata instances
