### PR TITLE
SALTO-3432 add GetSelectValue NetSuite SOAP API

### DIFF
--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -586,4 +586,15 @@ export default class NetsuiteClient {
     }
     return this.suiteAppClient.getCustomRecords(customRecordTypes)
   }
+
+  public async getSelectValue(
+    type: string,
+    field: string,
+    filterBy: { field: string; internalId: string }[] = [],
+  ): Promise<Record<string, string[]>> {
+    if (this.suiteAppClient === undefined) {
+      throw new Error('Cannot call getSelectValue when SuiteApp is not installed')
+    }
+    return this.suiteAppClient.getSelectValue(type, field, filterBy)
+  }
 }

--- a/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/schemas.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/schemas.ts
@@ -474,6 +474,115 @@ export const SEARCH_RESPONSE_SCHEMA = {
   ],
 }
 
+const GET_SELECT_VALUE_ERROR_SCHEMA = {
+  type: 'object',
+  required: ['status'],
+  properties: {
+    status: {
+      type: 'object',
+      required: ['attributes', 'statusDetail'],
+      properties: {
+        attributes: {
+          type: 'object',
+          required: ['isSuccess'],
+          properties: {
+            isSuccess: {
+              enum: ['false'],
+              type: 'string',
+            },
+          },
+        },
+        statusDetail: {
+          type: 'array',
+          minItems: 1,
+          maxItems: 1,
+          items: {
+            type: 'object',
+            required: ['code', 'message'],
+            properties: {
+              code: {
+                type: 'string',
+              },
+              message: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+const GET_SELECT_VALUE_SUCCESS_SCHEMA = {
+  type: 'object',
+  required: ['status', 'totalRecords', 'totalPages'],
+  properties: {
+    status: {
+      type: 'object',
+      required: ['attributes'],
+      properties: {
+        attributes: {
+          type: 'object',
+          required: ['isSuccess'],
+          properties: {
+            isSuccess: {
+              enum: ['true'],
+              type: 'string',
+            },
+          },
+        },
+      },
+    },
+    totalRecords: {
+      type: 'number',
+    },
+    totalPages: {
+      type: 'number',
+    },
+    baseRefList: {
+      type: 'object',
+      required: ['baseRef'],
+      properties: {
+        baseRef: {
+          type: 'array',
+          items: {
+            type: 'object',
+            required: ['attributes', 'name'],
+            properties: {
+              attributes: {
+                type: 'object',
+                required: ['internalId'],
+                properties: {
+                  internalId: {
+                    type: 'string',
+                  },
+                },
+              },
+              name: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+export const GET_SELECT_VALUE_SCHEMA = {
+  type: 'object',
+  required: ['getSelectValueResult'],
+  properties: {
+    getSelectValueResult: {
+      anyOf: [
+        GET_SELECT_VALUE_ERROR_SCHEMA,
+        GET_SELECT_VALUE_SUCCESS_SCHEMA,
+      ],
+    },
+  },
+}
+
 export const GET_ALL_RESPONSE_SCHEMA = {
   definitions: {
     Record: RECORD_DEFINITION,

--- a/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
@@ -27,8 +27,8 @@ import { SuiteAppSoapCredentials, toUrlAccountId } from '../../credentials'
 import { CONSUMER_KEY, CONSUMER_SECRET, ECONN_ERROR, INSUFFICIENT_PERMISSION_ERROR, REQUEST_ABORTED_ERROR, UNEXPECTED_ERROR, VALIDATION_ERROR } from '../constants'
 import { ReadFileError } from '../errors'
 import { CallsLimiter, ExistingFileCabinetInstanceDetails, FileCabinetInstanceDetails, FileDetails, FolderDetails, HasElemIDFunc } from '../types'
-import { CustomRecordResponse, DeployListResults, GetAllResponse, GetResult, isDeployListSuccess, isGetSuccess, isSearchErrorResponse, isWriteResponseSuccess, RecordResponse, RecordValue, SearchErrorResponse, SearchPageResponse, SearchResponse, SoapSearchType, WriteResponse } from './types'
-import { DEPLOY_LIST_SCHEMA, GET_ALL_RESPONSE_SCHEMA, GET_RESULTS_SCHEMA, SEARCH_RESPONSE_SCHEMA } from './schemas'
+import { CustomRecordResponse, DeployListResults, GetAllResponse, GetResult, GetSelectValueResponse, isDeployListSuccess, isGetSelectValueSuccessResponse, isGetSuccess, isSearchErrorResponse, isWriteResponseSuccess, RecordResponse, RecordValue, SearchErrorResponse, SearchPageResponse, SearchResponse, SoapSearchType, WriteResponse } from './types'
+import { DEPLOY_LIST_SCHEMA, GET_ALL_RESPONSE_SCHEMA, GET_RESULTS_SCHEMA, GET_SELECT_VALUE_SCHEMA, SEARCH_RESPONSE_SCHEMA } from './schemas'
 import { InvalidSuiteAppCredentialsError } from '../../types'
 import { isCustomRecordType } from '../../../types'
 import { INTERNAL_ID_TO_TYPES, isItemType, ITEM_TYPE_ID, ITEM_TYPE_TO_SEARCH_STRING, TYPES_TO_INTERNAL_ID } from '../../../data_elements/types'
@@ -834,6 +834,54 @@ export default class SoapClient {
     const response = await this.sendSoapRequest('search', body)
     this.assertSearchResponse(response)
     return SoapClient.toSearchResponse(response)
+  }
+
+  @retryOnBadResponse
+  public async getSelectValue(
+    type: string,
+    field: string,
+    filterBy: { field: string; internalId: string }[],
+    pageIndex = 1,
+  ): Promise<Record<string, string[]>> {
+    // https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_N3504236.html#getSelectValue
+    const body = {
+      pageIndex,
+      fieldDescription: {
+        recordType: {
+          attributes: { xmlns: SOAP_CORE_URN },
+          $value: type,
+        },
+        field: {
+          attributes: { xmlns: SOAP_CORE_URN },
+          $value: field,
+        },
+        filterByValueList: filterBy.length > 0 ? {
+          attributes: { xmlns: SOAP_CORE_URN },
+          filterBy: filterBy.map(row => ({
+            field: row.field,
+            internalId: row.internalId,
+          })),
+        } : undefined,
+      },
+    }
+    const response = await this.sendSoapRequest('getSelectValue', body)
+    if (!this.ajv.validate<GetSelectValueResponse>(GET_SELECT_VALUE_SCHEMA, response)) {
+      log.error(`Got invalid response from getSelectValue request with SOAP api. Errors: ${this.ajv.errorsText()}. Response: ${JSON.stringify(response, undefined, 2)}`)
+      throw new Error(`VALIDATION_ERROR - Got invalid response from getSelectValue request. Errors: ${this.ajv.errorsText()}. Response: ${JSON.stringify(response, undefined, 2)}`)
+    }
+    if (!isGetSelectValueSuccessResponse(response)) {
+      return {}
+    }
+    const allResults = pageIndex < response.getSelectValueResult.totalPages
+      ? await this.getSelectValue(type, field, filterBy, pageIndex + 1)
+      : {}
+    response.getSelectValueResult.baseRefList?.baseRef.forEach(row => {
+      if (allResults[row.name] === undefined) {
+        allResults[row.name] = []
+      }
+      allResults[row.name].push(row.attributes.internalId)
+    })
+    return allResults
   }
 
   @retryOnBadResponse

--- a/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/types.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/types.ts
@@ -19,7 +19,7 @@ type StatusSuccess = {
   }
 }
 
-export type StatusError = {
+type StatusError = {
   attributes: {
     isSuccess: 'false'
   }
@@ -167,3 +167,30 @@ export const SOAP_FIELDS_TYPES = {
   LONG: 'platformCore:LongCustomFieldRef',
   MULTISELECT: 'platformCore:MultiSelectCustomFieldRef',
 }
+
+type GetSelectValueErrorResponse = {
+  status: StatusError
+}
+
+type GetSelectValueSuccessResponse = {
+  status: StatusSuccess
+  totalRecords: number
+  totalPages: number
+  baseRefList?: {
+    baseRef: {
+      attributes: {
+        internalId: string
+      }
+      name: string
+    }[]
+  }
+}
+
+export type GetSelectValueResponse = {
+  getSelectValueResult: GetSelectValueErrorResponse | GetSelectValueSuccessResponse
+}
+
+export const isGetSelectValueSuccessResponse = (
+  response: GetSelectValueResponse
+): response is { getSelectValueResult: GetSelectValueSuccessResponse } =>
+  response.getSelectValueResult.status.attributes.isSuccess === 'true'

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
@@ -655,4 +655,12 @@ export default class SuiteAppClient {
   public async deleteSdfInstances(instances: InstanceElement[]): Promise<(number | Error)[]> {
     return this.soapClient.deleteSdfInstances(instances)
   }
+
+  public async getSelectValue(
+    type: string,
+    field: string,
+    filterBy: { field: string; internalId: string }[],
+  ): Promise<Record<string, string[]>> {
+    return this.soapClient.getSelectValue(type, field, filterBy)
+  }
 }

--- a/packages/netsuite-adapter/test/client/suiteapp_client/soap_client/soap_client.test.ts
+++ b/packages/netsuite-adapter/test/client/suiteapp_client/soap_client/soap_client.test.ts
@@ -42,6 +42,7 @@ describe('soap_client', () => {
   const searchMoreWithIdAsyncMock = jest.fn()
   const getAllAsyncMock = jest.fn()
   const getAsyncMock = jest.fn()
+  const getSelectValueAsyncMock = jest.fn()
   let wsdl: Record<string, unknown>
   const createClientAsyncMock = jest.spyOn(soapClientUtils, 'createClientAsync')
   const defaultSoapTimeOut = DEFAULT_AXIOS_TIMEOUT_IN_MINUTES * 60 * 1000
@@ -70,6 +71,7 @@ describe('soap_client', () => {
       searchAsync: searchAsyncMock,
       searchMoreWithIdAsync: searchMoreWithIdAsyncMock,
       getAllAsync: getAllAsyncMock,
+      getSelectValueAsync: getSelectValueAsyncMock,
       addSoapHeader: (fn: () => object) => fn(),
       wsdl,
     } as unknown as elementUtils.soap.Client)
@@ -1335,6 +1337,237 @@ describe('soap_client', () => {
           }
         ),
       ])).rejects.toThrow('Got invalid response from deleteList request. Errors:')
+    })
+  })
+
+  describe('getSelectValue', () => {
+    it('should make one request and return result', async () => {
+      getSelectValueAsyncMock.mockResolvedValue([{
+        getSelectValueResult: {
+          status: {
+            attributes: {
+              isSuccess: 'true',
+            },
+          },
+          totalRecords: 3,
+          totalPages: 1,
+          baseRefList: {
+            baseRef: [
+              {
+                attributes: {
+                  internalId: '1',
+                },
+                name: 'test1',
+              },
+              {
+                attributes: {
+                  internalId: '2',
+                },
+                name: 'test2',
+              },
+              {
+                attributes: {
+                  internalId: '3',
+                },
+                name: 'test2',
+              },
+            ],
+          },
+        },
+      }])
+      expect(await client.getSelectValue('account', 'unitstype', [])).toEqual({
+        test1: ['1'],
+        test2: ['2', '3'],
+      })
+      expect(getSelectValueAsyncMock).toHaveBeenCalledTimes(1)
+      expect(getSelectValueAsyncMock).toHaveBeenCalledWith({
+        pageIndex: 1,
+        fieldDescription: {
+          recordType: {
+            attributes: { xmlns: 'urn:core_2020_2.platform.webservices.netsuite.com' },
+            $value: 'account',
+          },
+          field: {
+            attributes: { xmlns: 'urn:core_2020_2.platform.webservices.netsuite.com' },
+            $value: 'unitstype',
+          },
+        },
+      })
+    })
+    it('should make several requests and return result', async () => {
+      getSelectValueAsyncMock.mockResolvedValueOnce([{
+        getSelectValueResult: {
+          status: {
+            attributes: {
+              isSuccess: 'true',
+            },
+          },
+          totalRecords: 3,
+          totalPages: 3,
+          baseRefList: {
+            baseRef: [
+              {
+                attributes: {
+                  internalId: '1',
+                },
+                name: 'test1',
+              },
+              {
+                attributes: {
+                  internalId: '2',
+                },
+                name: 'test2',
+              },
+              {
+                attributes: {
+                  internalId: '4',
+                },
+                name: 'test4',
+              },
+            ],
+          },
+        },
+      }])
+      getSelectValueAsyncMock.mockResolvedValueOnce([{
+        getSelectValueResult: {
+          status: {
+            attributes: {
+              isSuccess: 'true',
+            },
+          },
+          totalRecords: 3,
+          totalPages: 3,
+          baseRefList: {
+            baseRef: [
+              {
+                attributes: {
+                  internalId: '3',
+                },
+                name: 'test2',
+              },
+              {
+                attributes: {
+                  internalId: '5',
+                },
+                name: 'test5',
+              },
+              {
+                attributes: {
+                  internalId: '6',
+                },
+                name: 'test5',
+              },
+            ],
+          },
+        },
+      }])
+      getSelectValueAsyncMock.mockResolvedValueOnce([{
+        getSelectValueResult: {
+          status: {
+            attributes: {
+              isSuccess: 'true',
+            },
+          },
+          totalRecords: 0,
+          totalPages: 3,
+        },
+      }])
+      expect(await client.getSelectValue('account', 'unitstype', [])).toEqual({
+        test1: ['1'],
+        test2: ['2', '3'],
+        test4: ['4'],
+        test5: ['5', '6'],
+      })
+      expect(getSelectValueAsyncMock).toHaveBeenCalledTimes(3)
+      expect(getSelectValueAsyncMock).toHaveBeenCalledWith(expect.objectContaining({ pageIndex: 1 }))
+      expect(getSelectValueAsyncMock).toHaveBeenCalledWith(expect.objectContaining({ pageIndex: 2 }))
+      expect(getSelectValueAsyncMock).toHaveBeenCalledWith(expect.objectContaining({ pageIndex: 3 }))
+    })
+    it('should make a request with filterBy', async () => {
+      getSelectValueAsyncMock.mockResolvedValue([{
+        getSelectValueResult: {
+          status: {
+            attributes: {
+              isSuccess: 'true',
+            },
+          },
+          totalRecords: 3,
+          totalPages: 1,
+          baseRefList: {
+            baseRef: [
+              {
+                attributes: {
+                  internalId: '1',
+                },
+                name: 'test1',
+              },
+              {
+                attributes: {
+                  internalId: '2',
+                },
+                name: 'test2',
+              },
+              {
+                attributes: {
+                  internalId: '3',
+                },
+                name: 'test2',
+              },
+            ],
+          },
+        },
+      }])
+      expect(await client.getSelectValue('account', 'unit', [{ field: 'unitstype', internalId: '2' }])).toEqual({
+        test1: ['1'],
+        test2: ['2', '3'],
+      })
+      expect(getSelectValueAsyncMock).toHaveBeenCalledTimes(1)
+      expect(getSelectValueAsyncMock).toHaveBeenCalledWith({
+        pageIndex: 1,
+        fieldDescription: {
+          recordType: {
+            attributes: { xmlns: 'urn:core_2020_2.platform.webservices.netsuite.com' },
+            $value: 'account',
+          },
+          field: {
+            attributes: { xmlns: 'urn:core_2020_2.platform.webservices.netsuite.com' },
+            $value: 'unit',
+          },
+          filterByValueList: {
+            attributes: { xmlns: 'urn:core_2020_2.platform.webservices.netsuite.com' },
+            filterBy: [
+              {
+                field: 'unitstype',
+                internalId: '2',
+              },
+            ],
+          },
+        },
+      })
+    })
+    it('should return empty result when respose isSuccess=false', async () => {
+      getSelectValueAsyncMock.mockResolvedValue([{
+        getSelectValueResult: {
+          status: {
+            attributes: {
+              isSuccess: 'false',
+            },
+            statusDetail: [
+              {
+                code: 'ERROR',
+                message: 'Some error',
+              },
+            ],
+          },
+        },
+      }])
+      expect(await client.getSelectValue('account', 'unitstype', [])).toEqual({})
+    })
+    it('should throw error when result is invalid', async () => {
+      getSelectValueAsyncMock.mockResolvedValue([{
+        getSelectValueResult: {},
+      }])
+      await expect(client.getSelectValue('account', 'unitstype', [])).rejects.toThrow()
     })
   })
 


### PR DESCRIPTION
The [GetSelectValue](https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_N3504236.html#getSelectValue) API can be used to get the correct `internalId` of missing references (ASV) in data instances, as it return a list of the possible options for a specific field of a specific type.
The `filterBy` field should be used for fields that are dependent on the value of another field - for example:
```typescript
getSelectValue('account', 'unitstype')
getSelectValue('account', 'unit', [{ field: 'unitstype', internalId: '2' }])
```

This API should be used in deploy, in order to get missing internalIds in data instances.

---

_Additional context for reviewer_

TODO:
- [x] add tests

---
_Release Notes_: 
None

---
_User Notifications_: 
None
