### PR TITLE
SALTO-5162: change the missing dependency error to include a link to a learn more page

### DIFF
--- a/packages/adapter-components/src/deployment/change_validators/outgoing_unresolved_references.ts
+++ b/packages/adapter-components/src/deployment/change_validators/outgoing_unresolved_references.ts
@@ -61,7 +61,7 @@ export const createOutgoingUnresolvedReferencesValidator = (shouldIgnore: ElemID
         elemID: element.elemID,
         severity: 'Error' as SeverityLevel,
         message: 'Element has unresolved references',
-        detailedMessage: `Element ${element.elemID.getFullName()} contains unresolved references: ${unresolvedReferences.map(e => e.getFullName()).join(', ')}. Add the missing dependencies and try again.`,
+        detailedMessage: `Element ${element.elemID.getFullName()} contains unresolved references: ${unresolvedReferences.map(e => e.getFullName()).join(', ')}. Add the missing dependencies and try again. To learn more about fixing this error, go to https://help.salto.io/en/articles/6947056-element-contains-unresolved-references`,
       })
     })
     .filter(values.isDefined)

--- a/packages/adapter-components/test/deployment/change_validators/unresolved_references.test.ts
+++ b/packages/adapter-components/test/deployment/change_validators/unresolved_references.test.ts
@@ -32,7 +32,7 @@ describe('unresolved_references', () => {
     const errors = await createOutgoingUnresolvedReferencesValidator()([toChange({ after: instance })])
     expect(errors).toHaveLength(1)
     expect(errors[0].elemID).toEqual(instance.elemID)
-    expect(errors[0].detailedMessage).toEqual(`Element ${instance.elemID.getFullName()} contains unresolved references: ${unresolvedElemId.getFullName()}. Add the missing dependencies and try again.`)
+    expect(errors[0].detailedMessage).toEqual(`Element ${instance.elemID.getFullName()} contains unresolved references: ${unresolvedElemId.getFullName()}. Add the missing dependencies and try again. To learn more about fixing this error, go to https://help.salto.io/en/articles/6947056-element-contains-unresolved-references`)
   })
 
   it('should find unresolved references in instance annotation', async () => {
@@ -51,7 +51,7 @@ describe('unresolved_references', () => {
     const errors = await createOutgoingUnresolvedReferencesValidator()([toChange({ after: instance })])
     expect(errors).toHaveLength(1)
     expect(errors[0].elemID).toEqual(instance.elemID)
-    expect(errors[0].detailedMessage).toEqual(`Element ${instance.elemID.getFullName()} contains unresolved references: ${unresolvedElemId.getFullName()}. Add the missing dependencies and try again.`)
+    expect(errors[0].detailedMessage).toEqual(`Element ${instance.elemID.getFullName()} contains unresolved references: ${unresolvedElemId.getFullName()}. Add the missing dependencies and try again. To learn more about fixing this error, go to https://help.salto.io/en/articles/6947056-element-contains-unresolved-references`)
   })
 
   it('should find unresolved references in type annotation', async () => {
@@ -68,7 +68,7 @@ describe('unresolved_references', () => {
     const errors = await createOutgoingUnresolvedReferencesValidator()([toChange({ after: type })])
     expect(errors).toHaveLength(1)
     expect(errors[0].elemID).toEqual(type.elemID)
-    expect(errors[0].detailedMessage).toEqual(`Element ${type.elemID.getFullName()} contains unresolved references: ${unresolvedElemId.getFullName()}. Add the missing dependencies and try again.`)
+    expect(errors[0].detailedMessage).toEqual(`Element ${type.elemID.getFullName()} contains unresolved references: ${unresolvedElemId.getFullName()}. Add the missing dependencies and try again. To learn more about fixing this error, go to https://help.salto.io/en/articles/6947056-element-contains-unresolved-references`)
   })
 
   it('should find unresolved references in type field annotation', async () => {
@@ -90,7 +90,7 @@ describe('unresolved_references', () => {
     const errors = await createOutgoingUnresolvedReferencesValidator()([toChange({ after: type })])
     expect(errors).toHaveLength(1)
     expect(errors[0].elemID).toEqual(type.elemID)
-    expect(errors[0].detailedMessage).toEqual(`Element ${type.elemID.getFullName()} contains unresolved references: ${unresolvedElemId.getFullName()}. Add the missing dependencies and try again.`)
+    expect(errors[0].detailedMessage).toEqual(`Element ${type.elemID.getFullName()} contains unresolved references: ${unresolvedElemId.getFullName()}. Add the missing dependencies and try again. To learn more about fixing this error, go to https://help.salto.io/en/articles/6947056-element-contains-unresolved-references`)
   })
 
   it('should find unresolved references in templates', async () => {
@@ -107,7 +107,7 @@ describe('unresolved_references', () => {
     const errors = await createOutgoingUnresolvedReferencesValidator()([toChange({ after: instance })])
     expect(errors).toHaveLength(1)
     expect(errors[0].elemID).toEqual(instance.elemID)
-    expect(errors[0].detailedMessage).toEqual(`Element ${instance.elemID.getFullName()} contains unresolved references: ${unresolvedElemId.getFullName()}. Add the missing dependencies and try again.`)
+    expect(errors[0].detailedMessage).toEqual(`Element ${instance.elemID.getFullName()} contains unresolved references: ${unresolvedElemId.getFullName()}. Add the missing dependencies and try again. To learn more about fixing this error, go to https://help.salto.io/en/articles/6947056-element-contains-unresolved-references`)
   })
 
   it('should not return errors if does not have unresolved references', async () => {


### PR DESCRIPTION
change the missing dependency error to include a link to a learn more page

---

_Additional context for reviewer_

---
_Release Notes_: 
adapter-component:
* change the missing dependency error to include a link to a "learn more" page

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
