### PR TITLE
SALTO-5183: Solved serviceid validator for queue

### DIFF
--- a/packages/jira-adapter/src/deployment/standard_deployment.ts
+++ b/packages/jira-adapter/src/deployment/standard_deployment.ts
@@ -35,7 +35,7 @@ type DeployChangeParam = {
     instance: InstanceElement,
     serviceIdField: string,
     response: clientUtils.ResponseValue
-    ) => void
+  ) => void
 }
 
 const invertKeysNames = (instance: Record<string, unknown>): void => {
@@ -47,7 +47,7 @@ const invertKeysNames = (instance: Record<string, unknown>): void => {
     })
 }
 
-const defaultServiceIdSetter = (
+export const defaultServiceIdSetter = (
   instance: InstanceElement,
   serviceIdField: string,
   response: clientUtils.ResponseValue

--- a/packages/jira-adapter/src/filters/jsm_types_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/jsm_types_deploy_filter.ts
@@ -15,9 +15,9 @@
 */
 
 import _ from 'lodash'
-import { elements as elementUtils } from '@salto-io/adapter-components'
+import { elements as elementUtils, client as clientUtils } from '@salto-io/adapter-components'
 import { getChangeData, isInstanceChange, Change, InstanceElement } from '@salto-io/adapter-api'
-import { defaultDeployChange, deployChanges } from '../deployment/standard_deployment'
+import { defaultDeployChange, defaultServiceIdSetter, deployChanges } from '../deployment/standard_deployment'
 import { FilterCreator } from '../filter'
 import { JSM_DUCKTYPE_SUPPORTED_TYPES } from '../config/api_config'
 import { OBJECT_SCHEMA_TYPE, OBJECT_TYPE_TYPE, OBJECT_SCHEMA_STATUS_TYPE, QUEUE_TYPE } from '../constants'
@@ -28,6 +28,19 @@ const {
 } = elementUtils.ducktype
 const ASSETS_SUPPORTED_TYPES = [OBJECT_SCHEMA_TYPE, OBJECT_SCHEMA_STATUS_TYPE, OBJECT_TYPE_TYPE]
 const SUPPORTED_TYPES = new Set(Object.keys(JSM_DUCKTYPE_SUPPORTED_TYPES).concat(ASSETS_SUPPORTED_TYPES))
+
+const serviceIdSetterQueue = (
+  instance: InstanceElement,
+  serviceIdField: string,
+  response: clientUtils.ResponseValue
+): void => {
+  const serviceFieldValue = response?.[serviceIdField]
+  if (instance.elemID.typeName === QUEUE_TYPE && _.isNumber(serviceFieldValue)) {
+    instance.value[serviceIdField] = serviceFieldValue.toString()
+  } else {
+    instance.value[serviceIdField] = serviceFieldValue
+  }
+}
 
 const filterCreator: FilterCreator = ({ config, client }) => ({
   name: 'jsmDeployFilter',
@@ -65,19 +78,14 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
         const typeDefinition = jsmApiDefinitions.types[getChangeData(change).elemID.typeName]
         const deployRequest = typeDefinition.deployRequests ? typeDefinition.deployRequests[change.action] : undefined
         const fieldsToIgnore = deployRequest?.fieldsToIgnore ?? []
+        const instance = getChangeData(change)
         await defaultDeployChange({
           change,
           client,
           apiDefinitions: jsmApiDefinitions,
           fieldsToIgnore,
           additionalUrlVars,
-          serviceIdSetter: (instance, serviceIdField, response) => {
-            const serviceFieldValue = response?.[serviceIdField]
-            if (instance.elemID.typeName === QUEUE_TYPE && _.isNumber(serviceFieldValue)) {
-              instance.value[serviceIdField] = serviceFieldValue.toString()
-            }
-            instance.value[serviceIdField] = serviceFieldValue
-          },
+          serviceIdSetter: instance.elemID.typeName === QUEUE_TYPE ? serviceIdSetterQueue : defaultServiceIdSetter,
         })
       }
     )

--- a/packages/jira-adapter/src/filters/jsm_types_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/jsm_types_deploy_filter.ts
@@ -71,11 +71,12 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
           apiDefinitions: jsmApiDefinitions,
           fieldsToIgnore,
           additionalUrlVars,
-          modifyChangeFunc: (instance, serviceIdField, response) => {
+          serviceIdSetter: (instance, serviceIdField, response) => {
             const serviceFieldValue = response?.[serviceIdField]
             if (instance.elemID.typeName === QUEUE_TYPE && _.isNumber(serviceFieldValue)) {
               instance.value[serviceIdField] = serviceFieldValue.toString()
             }
+            instance.value[serviceIdField] = serviceFieldValue
           },
         })
       }

--- a/packages/jira-adapter/src/filters/jsm_types_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/jsm_types_deploy_filter.ts
@@ -20,7 +20,7 @@ import { getChangeData, isInstanceChange, Change, InstanceElement } from '@salto
 import { defaultDeployChange, deployChanges } from '../deployment/standard_deployment'
 import { FilterCreator } from '../filter'
 import { JSM_DUCKTYPE_SUPPORTED_TYPES } from '../config/api_config'
-import { OBJECT_SCHEMA_TYPE, OBJECT_TYPE_TYPE, OBJECT_SCHEMA_STATUS_TYPE } from '../constants'
+import { OBJECT_SCHEMA_TYPE, OBJECT_TYPE_TYPE, OBJECT_SCHEMA_STATUS_TYPE, QUEUE_TYPE } from '../constants'
 import { getWorkspaceId } from '../workspace_id'
 
 const {
@@ -71,6 +71,12 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
           apiDefinitions: jsmApiDefinitions,
           fieldsToIgnore,
           additionalUrlVars,
+          modifyChangeFunc: (instance, serviceIdField, response) => {
+            const serviceFieldValue = response?.[serviceIdField]
+            if (instance.elemID.typeName === QUEUE_TYPE && _.isNumber(serviceFieldValue)) {
+              instance.value[serviceIdField] = serviceFieldValue.toString()
+            }
+          },
         })
       }
     )

--- a/packages/jira-adapter/test/filters/jsm_types_deploy_filter.test.ts
+++ b/packages/jira-adapter/test/filters/jsm_types_deploy_filter.test.ts
@@ -20,7 +20,7 @@ import { InstanceElement, ReferenceExpression, CORE_ANNOTATIONS } from '@salto-i
 import { getDefaultConfig } from '../../src/config/config'
 import jsmTypesFilter from '../../src/filters/jsm_types_deploy_filter'
 import { createEmptyType, getFilterParams } from '../utils'
-import { OBJECT_SCHEMA_TYPE, PORTAL_GROUP_TYPE, PROJECT_TYPE } from '../../src/constants'
+import { OBJECT_SCHEMA_TYPE, PORTAL_GROUP_TYPE, PROJECT_TYPE, QUEUE_TYPE } from '../../src/constants'
 
 const mockDeployChange = jest.fn()
 jest.mock('@salto-io/adapter-components', () => {
@@ -120,6 +120,23 @@ describe('jsmTypesDeployFilter', () => {
           ])
         expect(res.deployResult.errors).toHaveLength(0)
         expect(res.deployResult.appliedChanges).toHaveLength(0)
+      })
+      it('should deploy addition of queue types', async () => {
+        const queueInstance = new InstanceElement(
+          'queue110',
+          createEmptyType(QUEUE_TYPE),
+          {
+            id: 'q11',
+            name: 'queue110',
+          },
+        )
+        mockDeployChange.mockImplementation(async () => ({}))
+        const res = await filter
+          .deploy([{ action: 'add', data: { after: queueInstance } }])
+        expect(mockDeployChange).toHaveBeenCalledTimes(1)
+        expect(res.leftoverChanges).toHaveLength(0)
+        expect(res.deployResult.errors).toHaveLength(0)
+        expect(res.deployResult.appliedChanges).toHaveLength(1)
       })
       it('should depoly additon of assets types', async () => {
         mockDeployChange.mockImplementation(async () => ({}))

--- a/packages/jira-adapter/test/filters/layouts/request_types_layouts_to_values.test.ts
+++ b/packages/jira-adapter/test/filters/layouts/request_types_layouts_to_values.test.ts
@@ -79,10 +79,10 @@ describe('requestTypelayoutsToValuesFilter', () => {
           },
         }
       )
-      const issueViewType = createEmptyType(ISSUE_VIEW_TYPE)
+      const requestFormType = createEmptyType(REQUEST_FORM_TYPE)
       requestFormInstance = new InstanceElement(
         'requestForm1',
-        issueViewType,
+        requestFormType,
         {
           id: '1',
           extraDefinerId: new ReferenceExpression(requestTypeInstance.elemID, requestTypeInstance),
@@ -103,10 +103,10 @@ describe('requestTypelayoutsToValuesFilter', () => {
           },
         },
       )
-      const requestFormType = createEmptyType(REQUEST_FORM_TYPE)
+      const issueViewType = createEmptyType(ISSUE_VIEW_TYPE)
       issueViewInstance = new InstanceElement(
         'issueView1',
-        requestFormType,
+        issueViewType,
         {
           id: '2',
           extraDefinerId: new ReferenceExpression(requestTypeInstance.elemID, requestTypeInstance),
@@ -154,6 +154,12 @@ describe('requestTypelayoutsToValuesFilter', () => {
       expect(issueView).toBeUndefined()
       expect(requestType.value.requestForm.issueLayoutConfig).toEqual(requestFormInstance.value.issueLayoutConfig)
       expect(requestType.value.issueView.issueLayoutConfig).toEqual(issueViewInstance.value.issueLayoutConfig)
+    })
+    it('should do nothing if requestType is not of type RequestType', async () => {
+      requestFormInstance.value.extraDefinerId = new ReferenceExpression(projectInstance.elemID, projectInstance)
+      await filter.onFetch(elements)
+      const requestType = elements.find(e => e.elemID.isEqual(requestTypeInstance.elemID)) as InstanceElement
+      expect(requestType.value.requestForm).toBeUndefined()
     })
   })
 })


### PR DESCRIPTION
In this PR I solved serviceId validator for queue type

---

_Additional context for reviewer_
There is an odd bug in standard_deployment relates to queues that brings back workspace warning Error validating `[jira.Queue.instance.Unassigned_issues10_MYJ8@su.id](mailto:jira.Queue.instance.Unassigned_issues10_MYJ8@su.id)": Invalid value type for serviceid` because in the fetch (Get) the id of the queue is a string and in the addition (POST) the id is a number.

---
_Release Notes_: 
None

---
_User Notifications_: 
None
