### PR TITLE
SALTO-4902 Validate group is not already mapped before adding a GroupPush instance

### DIFF
--- a/packages/okta-adapter/src/change_validators/group_push_to_application_uniqueness.ts
+++ b/packages/okta-adapter/src/change_validators/group_push_to_application_uniqueness.ts
@@ -1,0 +1,61 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { CORE_ANNOTATIONS, ChangeError, ChangeValidator, getChangeData, isAdditionChange, isInstanceChange, isInstanceElement } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { logger } from '@salto-io/logging'
+import { GROUP_PUSH_TYPE_NAME } from '../constants'
+
+const { awu } = collections.asynciterable
+const log = logger(module)
+
+/**
+ * Validate uniqueness of group push to application
+ */
+export const groupPushToApplicationUniquenessValidator: ChangeValidator = async (changes, elementsSource) => {
+  if (!elementsSource) {
+    log.warn('elementsSource was not provided to groupPushToApplicationUniqueness, skipping validator')
+    return []
+  }
+
+  const existingGroupToApplication = Object.fromEntries(await (awu(await elementsSource.getAll())
+    .filter(isInstanceElement)
+    .filter(instance => instance.elemID.typeName === GROUP_PUSH_TYPE_NAME)
+    .map(groupPush =>
+      ([
+        groupPush.value?.userGroupId?.elemID?.getFullName(),
+        groupPush.annotations[CORE_ANNOTATIONS.PARENT]?.[0]?.elemID?.getFullName(),
+      ])))
+    .toArray())
+
+  return changes
+    .filter(isInstanceChange)
+    .filter(isAdditionChange)
+    .map(change => getChangeData(change))
+    .filter(instance => instance.elemID.typeName === GROUP_PUSH_TYPE_NAME)
+    .flatMap((instance): ChangeError[] => {
+      const group = instance.value?.userGroupId?.elemID?.getFullName()
+      const application = instance.annotations[CORE_ANNOTATIONS.PARENT]?.[0]?.elemID?.getFullName()
+      if (group && application && existingGroupToApplication[group] === application) {
+        return [{
+          elemID: instance.elemID,
+          severity: 'Error',
+          message: `${group} to ${application} can only be defined on a single groupPush instance`,
+          detailedMessage: `${group} to ${application} can only be defined on a single groupPush instance`,
+        }]
+      }
+      return []
+    })
+}

--- a/packages/okta-adapter/src/change_validators/index.ts
+++ b/packages/okta-adapter/src/change_validators/index.ts
@@ -19,6 +19,7 @@ import { deployment } from '@salto-io/adapter-components'
 import { applicationValidator } from './application'
 import { groupRuleStatusValidator } from './group_rule_status'
 import { groupRuleActionsValidator } from './group_rule_actions'
+import { groupPushToApplicationUniquenessValidator } from './group_push_to_application_uniqueness'
 import { defaultPoliciesValidator } from './default_policies'
 import { groupRuleAdministratorValidator } from './group_rule_administrator'
 import { customApplicationStatusValidator } from './custom_application_status'
@@ -75,6 +76,7 @@ export default ({
     users: usersValidator(client, config),
     appUserSchemaWithInactiveApp: appUserSchemaWithInactiveAppValidator,
     appWithGroupPush: appWithGroupPushValidator,
+    groupPushToApplicationUniqueness: groupPushToApplicationUniquenessValidator,
   }
 
   return createChangeValidator({

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -1792,6 +1792,7 @@ export type ChangeValidatorName = (
   | 'users'
   | 'appUserSchemaWithInactiveApp'
   | 'appWithGroupPush'
+  | 'groupPushToApplicationUniqueness'
   )
 
 type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
@@ -1816,6 +1817,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     users: { refType: BuiltinTypes.BOOLEAN },
     appUserSchemaWithInactiveApp: { refType: BuiltinTypes.BOOLEAN },
     appWithGroupPush: { refType: BuiltinTypes.BOOLEAN },
+    groupPushToApplicationUniqueness: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/okta-adapter/test/change_validators/group_push_to_application_uniqueness.test.ts
+++ b/packages/okta-adapter/test/change_validators/group_push_to_application_uniqueness.test.ts
@@ -70,7 +70,6 @@ describe('groupPushToApplicationUniquenessValidator', () => {
       [CORE_ANNOTATIONS.ALIAS]: 'groupPushInElementSource_alias',
     },
   )
-  const elementSource = buildElementsSourceFromElements([groupPushInElementSource])
 
   it('should return empty list when elementSource is not provided', async () => {
     const changeErrors = await groupPushToApplicationUniquenessValidator(
@@ -81,6 +80,11 @@ describe('groupPushToApplicationUniquenessValidator', () => {
     expect(changeErrors).toHaveLength(0)
   })
   it('should return empty list when there are no addition changes', async () => {
+    const elementSource = buildElementsSourceFromElements([
+      groupPushInElementSource,
+      groupPush1,
+      groupPush2,
+      groupPush3])
     const changeErrors = await groupPushToApplicationUniquenessValidator(
       [
         toChange({ before: groupPush1 }),
@@ -91,6 +95,7 @@ describe('groupPushToApplicationUniquenessValidator', () => {
     expect(changeErrors).toHaveLength(0)
   })
   it('should return empty list when addition change is on existing instance', async () => {
+    const elementSource = buildElementsSourceFromElements([groupPushInElementSource])
     const changeErrors = await groupPushToApplicationUniquenessValidator(
       [
         toChange({ after: groupPushInElementSource }),
@@ -100,6 +105,11 @@ describe('groupPushToApplicationUniquenessValidator', () => {
     expect(changeErrors).toHaveLength(0)
   })
   it('should return errors only when group to application are defined in element source', async () => {
+    const elementSource = buildElementsSourceFromElements([
+      groupPushInElementSource,
+      groupPush1,
+      groupPush2,
+      groupPush3])
     const changeErrors = await groupPushToApplicationUniquenessValidator(
       [
         toChange({ after: groupPush1 }),

--- a/packages/okta-adapter/test/change_validators/group_push_to_application_uniqueness.test.ts
+++ b/packages/okta-adapter/test/change_validators/group_push_to_application_uniqueness.test.ts
@@ -90,6 +90,15 @@ describe('groupPushToApplicationUniquenessValidator', () => {
     )
     expect(changeErrors).toHaveLength(0)
   })
+  it('should return empty list when addition change is on existing instance', async () => {
+    const changeErrors = await groupPushToApplicationUniquenessValidator(
+      [
+        toChange({ after: groupPushInElementSource }),
+      ],
+      elementSource
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
   it('should return errors only when group to application are defined in element source', async () => {
     const changeErrors = await groupPushToApplicationUniquenessValidator(
       [

--- a/packages/okta-adapter/test/change_validators/group_push_to_application_uniqueness.test.ts
+++ b/packages/okta-adapter/test/change_validators/group_push_to_application_uniqueness.test.ts
@@ -1,0 +1,108 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { toChange, ObjectType, ElemID, InstanceElement, ReferenceExpression, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { groupPushToApplicationUniquenessValidator } from '../../src/change_validators/group_push_to_application_uniqueness'
+import { OKTA, GROUP_PUSH_TYPE_NAME } from '../../src/constants'
+
+describe('groupPushToApplicationUniquenessValidator', () => {
+  const GROUP_NAME = 'group'
+  const APPLICATION_NAME = 'application'
+  const groupPushType = new ObjectType({ elemID: new ElemID(OKTA, GROUP_PUSH_TYPE_NAME) })
+  const groupPush1 = new InstanceElement(
+    'groupPush1',
+    groupPushType,
+    {
+      userGroupId: new ReferenceExpression(new ElemID(GROUP_NAME)),
+    },
+    undefined,
+    {
+      [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(new ElemID(APPLICATION_NAME))],
+    },
+  )
+  const groupPush2 = new InstanceElement(
+    'groupPush2',
+    groupPushType,
+    {
+      userGroupId: [new ReferenceExpression(new ElemID(GROUP_NAME))],
+    },
+    undefined,
+    {
+      [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(new ElemID(`${APPLICATION_NAME}2`))],
+    },
+  )
+  const groupPush3 = new InstanceElement(
+    'groupPush3',
+    groupPushType,
+    {
+      userGroupId: new ReferenceExpression(new ElemID(`${GROUP_NAME}2`)),
+    },
+    undefined,
+    {
+      [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(new ElemID(APPLICATION_NAME))],
+    },
+  )
+  const groupPushInElementSource = new InstanceElement(
+    'groupPushInElementSource',
+    groupPushType,
+    {
+      userGroupId: new ReferenceExpression(new ElemID(GROUP_NAME)),
+    },
+    undefined,
+    {
+      [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(new ElemID(APPLICATION_NAME))],
+    },
+  )
+  const elementSource = buildElementsSourceFromElements([groupPushInElementSource])
+
+  it('should return empty list when elementSource is not provided', async () => {
+    const changeErrors = await groupPushToApplicationUniquenessValidator(
+      [
+        toChange({ after: groupPush1 }),
+      ],
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
+  it('should return empty list when there are no addition changes', async () => {
+    const changeErrors = await groupPushToApplicationUniquenessValidator(
+      [
+        toChange({ before: groupPush1 }),
+        toChange({ before: groupPush2, after: groupPush3 }),
+      ],
+      elementSource
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
+  it('should return errors only when group to application are defined in element source', async () => {
+    const changeErrors = await groupPushToApplicationUniquenessValidator(
+      [
+        toChange({ after: groupPush1 }),
+        toChange({ after: groupPush2 }),
+        toChange({ after: groupPush3 }),
+      ],
+      elementSource
+    )
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors).toEqual([
+      {
+        elemID: groupPush1.elemID,
+        detailedMessage: `${GROUP_NAME} to ${APPLICATION_NAME} can only be defined on a single groupPush instance`,
+        message: `${GROUP_NAME} to ${APPLICATION_NAME} can only be defined on a single groupPush instance`,
+        severity: 'Error',
+      },
+    ])
+  })
+})

--- a/packages/okta-adapter/test/change_validators/group_push_to_application_uniqueness.test.ts
+++ b/packages/okta-adapter/test/change_validators/group_push_to_application_uniqueness.test.ts
@@ -31,6 +31,7 @@ describe('groupPushToApplicationUniquenessValidator', () => {
     undefined,
     {
       [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(new ElemID(APPLICATION_NAME))],
+      [CORE_ANNOTATIONS.ALIAS]: 'groupPush1_alias',
     },
   )
   const groupPush2 = new InstanceElement(
@@ -42,6 +43,7 @@ describe('groupPushToApplicationUniquenessValidator', () => {
     undefined,
     {
       [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(new ElemID(`${APPLICATION_NAME}2`))],
+      [CORE_ANNOTATIONS.ALIAS]: 'groupPush2_alias',
     },
   )
   const groupPush3 = new InstanceElement(
@@ -53,6 +55,7 @@ describe('groupPushToApplicationUniquenessValidator', () => {
     undefined,
     {
       [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(new ElemID(APPLICATION_NAME))],
+      [CORE_ANNOTATIONS.ALIAS]: 'groupPush3_alias',
     },
   )
   const groupPushInElementSource = new InstanceElement(
@@ -64,6 +67,7 @@ describe('groupPushToApplicationUniquenessValidator', () => {
     undefined,
     {
       [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(new ElemID(APPLICATION_NAME))],
+      [CORE_ANNOTATIONS.ALIAS]: 'groupPushInElementSource_alias',
     },
   )
   const elementSource = buildElementsSourceFromElements([groupPushInElementSource])
@@ -95,12 +99,11 @@ describe('groupPushToApplicationUniquenessValidator', () => {
       ],
       elementSource
     )
-    expect(changeErrors).toHaveLength(1)
     expect(changeErrors).toEqual([
       {
         elemID: groupPush1.elemID,
-        detailedMessage: `${GROUP_NAME} to ${APPLICATION_NAME} can only be defined on a single groupPush instance`,
-        message: `${GROUP_NAME} to ${APPLICATION_NAME} can only be defined on a single groupPush instance`,
+        detailedMessage: `GroupPush groupPushInElementSource_alias already maps group ${GROUP_NAME} to application ${APPLICATION_NAME}`,
+        message: `Group ${GROUP_NAME} is already mapped to ${APPLICATION_NAME}`,
         severity: 'Error',
       },
     ])


### PR DESCRIPTION
New change validator that detects if user tries to add groupPush instance with userGroupId and a parent (application)
that already exists in the target env, and return change error with severity `Error`


---



---
_Release Notes_: 
_Okta Adapter_:
Validation error when user tries to add group push with groupId and application relation that already exists in the target environment

---
_User Notifications_: 
None
