### PR TITLE
SALTO-5210: Support deploy of default attributes

### DIFF
--- a/packages/jira-adapter/src/change_validators/assets/default_attribute.ts
+++ b/packages/jira-adapter/src/change_validators/assets/default_attribute.ts
@@ -1,0 +1,70 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ChangeValidator, getChangeData, isInstanceChange, SeverityLevel, isModificationChange, isRemovalChange } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import JiraClient from '../../client/client'
+import { OBJECT_TYPE_ATTRIBUTE_TYPE, OBJECT_TYPE_TYPE } from '../../constants'
+import { JiraConfig } from '../../config/config'
+import { DEFAULT_ATTRIBUTES } from '../../filters/assets/attribute_deploy_filter'
+import { getWorkspaceId } from '../../workspace_id'
+
+const { awu } = collections.asynciterable
+
+/*
+* This validator prevents the modification or removal of default attribute.
+*/
+export const defaultAttributeValidator: (
+    config: JiraConfig,
+    client: JiraClient,
+  ) => ChangeValidator = (config, client) => async (changes, elementsSource) => {
+    if (elementsSource === undefined || !config.fetch.enableJSM) {
+      return []
+    }
+    const workspaceId = await getWorkspaceId(client)
+    if (workspaceId === undefined) {
+      return []
+    }
+    const removalObjectTypeNames = await awu(changes)
+      .filter(isInstanceChange)
+      .filter(isRemovalChange)
+      .filter(change => getChangeData(change).elemID.typeName === OBJECT_TYPE_TYPE)
+      .map(change => getChangeData(change).value.name)
+      .toArray()
+
+    return awu(changes)
+      .filter(isInstanceChange)
+      .filter(change => isModificationChange(change) || isRemovalChange(change))
+      .filter(change => getChangeData(change).elemID.typeName === OBJECT_TYPE_ATTRIBUTE_TYPE)
+      .filter(async change => {
+        const instance = getChangeData(change)
+        const objectType = instance.value.objectType?.value.value
+        if (objectType === undefined) {
+          return false
+        }
+        if (!DEFAULT_ATTRIBUTES.includes(instance.value.name)
+        && !(isRemovalChange(change) && instance.value.name === 'Name')) {
+          return false
+        }
+        return !removalObjectTypeNames.includes(objectType.name)
+      })
+      .map(async change => ({
+        elemID: getChangeData(change).elemID,
+        severity: 'Error' as SeverityLevel,
+        message: 'Cannot deploy a system non editable attribute.',
+        detailedMessage: `Cannot deploy this attribute ${getChangeData(change).elemID.name}, as it is a system non editable attribute.`,
+      }))
+      .toArray()
+  }

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -61,6 +61,7 @@ import { issueTypeHierarchyValidator } from './issue_type_hierarchy'
 import { automationProjectsValidator } from './automation/automation_projects'
 import { deleteLastQueueValidator } from './last_queue'
 import { defaultAdditionQueueValidator } from './default_addition_queue'
+import { defaultAttributeValidator } from './assets/default_attribute'
 import { automationToAssetsValidator } from './automation/automation_to_assets'
 
 const {
@@ -121,6 +122,7 @@ export default (
     deleteLastQueueValidator: deleteLastQueueValidator(config),
     defaultAdditionQueueValidator: defaultAdditionQueueValidator(config),
     automationToAssets: automationToAssetsValidator(config),
+    defaultAttributeValidator: defaultAttributeValidator(config, client),
   }
 
   return createChangeValidator({

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -239,6 +239,7 @@ export type ChangeValidatorName = (
   | 'automationProjects'
   | 'deleteLastQueueValidator'
   | 'defaultAdditionQueueValidator'
+  | 'defaultAttributeValidator'
   | 'boardColumnConfig'
   | 'automationToAssets'
   )
@@ -293,6 +294,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     automationProjects: { refType: BuiltinTypes.BOOLEAN },
     deleteLastQueueValidator: { refType: BuiltinTypes.BOOLEAN },
     defaultAdditionQueueValidator: { refType: BuiltinTypes.BOOLEAN },
+    defaultAttributeValidator: { refType: BuiltinTypes.BOOLEAN },
     automationToAssets: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {

--- a/packages/jira-adapter/src/filters/assets/attribute_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/assets/attribute_deploy_filter.ts
@@ -16,8 +16,10 @@
 
 import { config as configUtils } from '@salto-io/adapter-components'
 import { logger } from '@salto-io/logging'
-import { Change, DeployResult, InstanceElement, createSaltoElementError, getChangeData, isAdditionOrModificationChange, isInstanceChange } from '@salto-io/adapter-api'
+import { AdditionChange, Change, DeployResult, InstanceElement, createSaltoElementError, getChangeData, isAdditionChange, isAdditionOrModificationChange, isInstanceChange, isRemovalChange, toChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
+import { createSchemeGuard } from '@salto-io/adapter-utils'
+import Joi from 'joi'
 import { defaultDeployChange, deployChanges } from '../../deployment/standard_deployment'
 import { FilterCreator } from '../../filter'
 import { OBJECT_TYPE_ATTRIBUTE_TYPE } from '../../constants'
@@ -26,24 +28,93 @@ import JiraClient from '../../client/client'
 
 const log = logger(module)
 
+type AttributeParams = {
+  id: string
+  name: string
+  editable: boolean
+}
+
+type AttributeGetResponse = AttributeParams[]
+
+export const DEFAULT_ATTRIBUTES = ['Key', 'Created', 'Updated']
+
+const ATTRIBUTE_RESOPNSE_SCHEME = Joi.array().items(Joi.object({
+  id: Joi.string().required(),
+  name: Joi.string().required(),
+}).unknown(true)).required()
+
+const isAttributeResponse = createSchemeGuard<AttributeGetResponse>(ATTRIBUTE_RESOPNSE_SCHEME)
+
+const getExsitingAttributesNamesAndIds = async (
+  changes: AdditionChange<InstanceElement>[],
+  client: JiraClient,
+  workspaceId: string
+):Promise<string[][]> => {
+  try {
+    const objectType = changes[0].data.after.value.objectType?.value.value
+    const response = await client.getSinglePage({
+      url: `/gateway/api/jsm/assets/workspace/${workspaceId}/v1/objecttype/${objectType.id}/attributes`,
+    })
+    if (!isAttributeResponse(response.data)) {
+      return []
+    }
+    const editableExistingAttributes = response.data
+      .filter(attribute => attribute.editable)
+      .map(attribute => [attribute.name, attribute.id])
+    return editableExistingAttributes
+  } catch (e) {
+    log.error(`failed to get existing attributes due to an error ${e}`)
+    return []
+  }
+}
+
+const changeSetter = (
+  change: Change<InstanceElement>,
+  objectTypeToEditableExistiningAttributes: Record<string, string[][]>,
+): Change<InstanceElement> => {
+  if (!isAdditionChange(change)) {
+    return change
+  }
+  const instance = getChangeData(change)
+  const objectType = instance.value.objectType.elemID.getFullName()
+  const existingAttributes = Object.fromEntries(objectTypeToEditableExistiningAttributes[objectType])
+  if (existingAttributes !== undefined && Object.keys(existingAttributes).includes(instance.value.name)) {
+    change.data.after.value.id = existingAttributes[change.data.after.value.name]
+    const emptyAttributeInstance = change.data.after.clone()
+    emptyAttributeInstance.value = {}
+    return toChange({ before: emptyAttributeInstance, after: change.data.after })
+  }
+  return change
+}
+
+
 const deployAttributeChanges = async ({
   jsmApiDefinitions,
   changes,
   client,
   workspaceId,
+  objectTypeToEditableExistiningAttributes,
 }: {
   jsmApiDefinitions: configUtils.AdapterDuckTypeApiConfig
   changes: Change<InstanceElement>[]
   client: JiraClient
   workspaceId: string
+  objectTypeToEditableExistiningAttributes: Record<string, string[][]>
 }): Promise<Omit<DeployResult, 'extraProperties'>> => {
   const additionalUrlVars = { workspaceId }
   return deployChanges(
     changes,
     async change => {
+      if (DEFAULT_ATTRIBUTES.includes(getChangeData(change).value.name)) {
+        return
+      }
+      if (isRemovalChange(change) && getChangeData(change).value.name === 'Name') {
+        return
+      }
       const instance = getChangeData(change)
+      const modifiedChange = changeSetter(change, objectTypeToEditableExistiningAttributes)
       await defaultDeployChange({
-        change,
+        change: modifiedChange,
         client,
         apiDefinitions: jsmApiDefinitions,
         additionalUrlVars,
@@ -71,6 +142,7 @@ const filter: FilterCreator = ({ config, client }) => ({
         leftoverChanges: changes,
       }
     }
+
     const [attributesChanges, leftoverChanges] = _.partition(
       changes.filter(isInstanceChange),
       change => isInstanceChange(change)
@@ -90,11 +162,34 @@ const filter: FilterCreator = ({ config, client }) => ({
         leftoverChanges,
       }
     }
+    const attributeAdditionChanges = changes.filter(isAdditionChange)
+      .filter(change => isInstanceChange(change))
+      .filter(change => getChangeData(change).elemID.typeName === OBJECT_TYPE_ATTRIBUTE_TYPE)
+
+    const objectTypeToAttributeAdditions = _.groupBy(attributeAdditionChanges.filter(isInstanceChange),
+      change => {
+        try {
+          const instance = getChangeData(change)
+          return instance.value.objectType.elemID.getFullName()
+        } catch (e) {
+          log.error(`failed to get objectType name for change ${getChangeData(change).elemID.name} due to an error ${e}`)
+          return ''
+        }
+      })
+    const objectTypeToEditableExistiningAttributes: Record<string, string[][]> = Object.fromEntries(
+      await Promise.all(Object.entries(objectTypeToAttributeAdditions).map(async ([objectType, attributeChanges]) =>
+        [
+          objectType,
+          await getExsitingAttributesNamesAndIds(attributeChanges.filter(isInstanceChange),
+            client,
+            workspaceId)]))
+    )
     const deployResult = await deployAttributeChanges({
       jsmApiDefinitions,
       changes: attributesChanges,
       client,
       workspaceId,
+      objectTypeToEditableExistiningAttributes,
     })
 
     return {

--- a/packages/jira-adapter/src/group_change.ts
+++ b/packages/jira-adapter/src/group_change.ts
@@ -13,10 +13,10 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { getChangeData, isModificationChange, isAdditionChange } from '@salto-io/adapter-api'
+import { getChangeData, isModificationChange, isAdditionChange, isInstanceChange } from '@salto-io/adapter-api'
 import { getParent, getParents, isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { deployment } from '@salto-io/adapter-components'
-import { FIELD_CONFIGURATION_ITEM_TYPE_NAME, QUEUE_TYPE, SCRIPT_FRAGMENT_TYPE, SCRIPT_RUNNER_LISTENER_TYPE, SECURITY_LEVEL_TYPE, WORKFLOW_TYPE_NAME } from './constants'
+import { FIELD_CONFIGURATION_ITEM_TYPE_NAME, OBJECT_TYPE_ATTRIBUTE_TYPE, QUEUE_TYPE, SCRIPT_FRAGMENT_TYPE, SCRIPT_RUNNER_LISTENER_TYPE, SECURITY_LEVEL_TYPE, WORKFLOW_TYPE_NAME } from './constants'
 
 export const getWorkflowGroup: deployment.ChangeIdFunction = async change => (
   isModificationChange(change)
@@ -71,6 +71,14 @@ const getQueuesAdditionByProjectGroup: deployment.ChangeIdFunction = async chang
   const parent = getParent(instance)
   return `queue addition of ${parent.elemID.getFullName()}`
 }
+const getAttributeAdditionByObjectTypeGroup: deployment.ChangeIdFunction = async change => {
+  if (!isAdditionChange(change) || !isInstanceChange(change)
+    || getChangeData(change).elemID.typeName !== OBJECT_TYPE_ATTRIBUTE_TYPE) {
+    return undefined
+  }
+  const instance = getChangeData(change)
+  return `queue addition of ${instance.value.objectType.elemID.getFullName()}`
+}
 
 export const getChangeGroupIds = deployment.getChangeGroupIdsFunc([
   getWorkflowGroup,
@@ -79,4 +87,5 @@ export const getChangeGroupIds = deployment.getChangeGroupIdsFunc([
   getScriptListenersGroup,
   getScriptedFragmentsGroup,
   getQueuesAdditionByProjectGroup,
+  getAttributeAdditionByObjectTypeGroup,
 ])

--- a/packages/jira-adapter/src/group_change.ts
+++ b/packages/jira-adapter/src/group_change.ts
@@ -72,12 +72,12 @@ const getQueuesAdditionByProjectGroup: deployment.ChangeIdFunction = async chang
   return `queue addition of ${parent.elemID.getFullName()}`
 }
 const getAttributeAdditionByObjectTypeGroup: deployment.ChangeIdFunction = async change => {
-  if (!isAdditionChange(change) || !isInstanceChange(change)
-    || getChangeData(change).elemID.typeName !== OBJECT_TYPE_ATTRIBUTE_TYPE) {
-    return undefined
+  if (isAdditionChange(change) && isInstanceChange(change)
+    && getChangeData(change).elemID.typeName === OBJECT_TYPE_ATTRIBUTE_TYPE) {
+    const instance = getChangeData(change)
+    return `attribute addition of ${instance.value.objectType.elemID.getFullName()}`
   }
-  const instance = getChangeData(change)
-  return `queue addition of ${instance.value.objectType.elemID.getFullName()}`
+  return undefined
 }
 
 export const getChangeGroupIds = deployment.getChangeGroupIdsFunc([

--- a/packages/jira-adapter/test/change_validators/assets/default_attribute.test.ts
+++ b/packages/jira-adapter/test/change_validators/assets/default_attribute.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2023 Salto Labs Ltd.
+*                      Copyright 2024 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/test/change_validators/assets/default_attribute.test.ts
+++ b/packages/jira-adapter/test/change_validators/assets/default_attribute.test.ts
@@ -1,0 +1,162 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { InstanceElement, ReadOnlyElementsSource, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import _ from 'lodash'
+import { client as clientUtils } from '@salto-io/adapter-components'
+import { MockInterface } from '@salto-io/test-utils'
+import { OBJECT_TYPE_ATTRIBUTE_TYPE, OBJECT_TYPE_TYPE } from '../../../src/constants'
+import { createEmptyType, mockClient } from '../../utils'
+import { defaultAttributeValidator } from '../../../src/change_validators/assets/default_attribute'
+import { JiraConfig, getDefaultConfig } from '../../../src/config/config'
+import JiraClient from '../../../src/client/client'
+
+describe('attributeValidator', () => {
+  let elementsSource: ReadOnlyElementsSource
+  let attributeInstance: InstanceElement
+  let config: JiraConfig
+  let client: JiraClient
+  let connection: MockInterface<clientUtils.APIConnection>
+  const objectTypeInstance = new InstanceElement(
+    'objectTypeInstance',
+    createEmptyType(OBJECT_TYPE_TYPE),
+    {
+      id: '1',
+      name: 'ObjectType',
+    },
+  )
+  beforeEach(async () => {
+    const { client: cli, connection: conn } = mockClient(false)
+    client = cli
+    connection = conn
+    connection.get.mockImplementation(async url => {
+      if (url === '/rest/servicedeskapi/assets/workspace') {
+        return {
+          status: 200,
+          data: {
+            values: [
+              {
+                workspaceId: 'workspaceId',
+              },
+            ],
+          },
+        }
+      }
+      if (url === '/gateway/api/jsm/assets/workspace/workspaceId/v1/objecttype/1') {
+        return {
+          status: 200,
+          data: {},
+        }
+      }
+      throw new Error('Unexpected url')
+    })
+    elementsSource = buildElementsSourceFromElements([])
+    config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+    config.fetch.enableJSM = true
+    config.fetch.enableJsmExperimental = true
+  })
+  it('should return error if trying to add non editable defult attribute', async () => {
+    attributeInstance = new InstanceElement(
+      'attribute1',
+      createEmptyType(OBJECT_TYPE_ATTRIBUTE_TYPE),
+      {
+        id: 22,
+        name: 'Key',
+        editable: false,
+        objectType: new ReferenceExpression(objectTypeInstance.elemID, objectTypeInstance),
+      },
+    )
+    const validator = defaultAttributeValidator(config, client)
+    const changeErrors = await validator(
+      [toChange({ before: attributeInstance })],
+      elementsSource
+    )
+    expect(changeErrors).toHaveLength(1)
+  })
+  it('should return error if trying to modify non editable defult attribute', async () => {
+    attributeInstance = new InstanceElement(
+      'attribute1',
+      createEmptyType(OBJECT_TYPE_ATTRIBUTE_TYPE),
+      {
+        id: 22,
+        name: 'Created',
+        editable: false,
+        objectType: new ReferenceExpression(objectTypeInstance.elemID, objectTypeInstance),
+      },
+    )
+    const validator = defaultAttributeValidator(config, client)
+    const changeErrors = await validator(
+      [toChange({ before: attributeInstance, after: attributeInstance })],
+      elementsSource
+    )
+    expect(changeErrors).toHaveLength(1)
+  })
+  it('should return error if trying to remove non editable defult attribute', async () => {
+    attributeInstance = new InstanceElement(
+      'attribute1',
+      createEmptyType(OBJECT_TYPE_ATTRIBUTE_TYPE),
+      {
+        id: 22,
+        name: 'Updated',
+        editable: false,
+        objectType: new ReferenceExpression(objectTypeInstance.elemID, objectTypeInstance),
+      },
+    )
+    const validator = defaultAttributeValidator(config, client)
+    const changeErrors = await validator(
+      [toChange({ before: attributeInstance })],
+      elementsSource
+    )
+    expect(changeErrors).toHaveLength(1)
+  })
+  it('should not return error if trying to add editable defult attribute', async () => {
+    attributeInstance = new InstanceElement(
+      'attribute1',
+      createEmptyType(OBJECT_TYPE_ATTRIBUTE_TYPE),
+      {
+        id: 22,
+        name: 'Name',
+        editable: true,
+        objectType: new ReferenceExpression(objectTypeInstance.elemID, objectTypeInstance),
+      },
+    )
+    const validator = defaultAttributeValidator(config, client)
+    const changeErrors = await validator(
+      [toChange({ after: attributeInstance })],
+      elementsSource
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
+  it('should return error if trying to remove \'Name\' attribute', async () => {
+    attributeInstance = new InstanceElement(
+      'attribute1',
+      createEmptyType(OBJECT_TYPE_ATTRIBUTE_TYPE),
+      {
+        id: 22,
+        name: 'Name',
+        editable: true,
+        objectType: new ReferenceExpression(objectTypeInstance.elemID, objectTypeInstance),
+      },
+    )
+    const validator = defaultAttributeValidator(config, client)
+    const changeErrors = await validator(
+      [toChange({ before: attributeInstance })],
+      elementsSource
+    )
+    expect(changeErrors).toHaveLength(1)
+  })
+})

--- a/packages/jira-adapter/test/filters/assets/attribute_deploy_filter.test.ts
+++ b/packages/jira-adapter/test/filters/assets/attribute_deploy_filter.test.ts
@@ -18,7 +18,6 @@ import { filterUtils, client as clientUtils } from '@salto-io/adapter-components
 import _ from 'lodash'
 import { BuiltinTypes, ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
 import { MockInterface } from '@salto-io/test-utils'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { getDefaultConfig } from '../../../src/config/config'
 import deployAttributesFilter from '../../../src/filters/assets/attribute_deploy_filter'
 import { createEmptyType, getFilterParams, mockClient } from '../../utils'
@@ -48,14 +47,13 @@ describe('deployAttributesFilter', () => {
   let attributesInstance: InstanceElement
   describe('deploy', () => {
     beforeEach(() => {
-      const elementsSource = buildElementsSourceFromElements([assetsObjectTypeInstance])
       const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
       config.fetch.enableJSM = true
       config.fetch.enableJsmExperimental = true
       const { client: cli, connection: conn } = mockClient(false)
       client = cli
       connection = conn
-      filter = deployAttributesFilter(getFilterParams({ config, client, elementsSource })) as typeof filter
+      filter = deployAttributesFilter(getFilterParams({ config, client })) as typeof filter
       attributesInstance = new InstanceElement(
         'attributesInstance',
         attributeType,

--- a/packages/jira-adapter/test/filters/assets/attribute_deploy_filter.test.ts
+++ b/packages/jira-adapter/test/filters/assets/attribute_deploy_filter.test.ts
@@ -18,6 +18,7 @@ import { filterUtils, client as clientUtils } from '@salto-io/adapter-components
 import _ from 'lodash'
 import { BuiltinTypes, ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
 import { MockInterface } from '@salto-io/test-utils'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { getDefaultConfig } from '../../../src/config/config'
 import deployAttributesFilter from '../../../src/filters/assets/attribute_deploy_filter'
 import { createEmptyType, getFilterParams, mockClient } from '../../utils'
@@ -47,13 +48,14 @@ describe('deployAttributesFilter', () => {
   let attributesInstance: InstanceElement
   describe('deploy', () => {
     beforeEach(() => {
+      const elementsSource = buildElementsSourceFromElements([assetsObjectTypeInstance])
       const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
       config.fetch.enableJSM = true
       config.fetch.enableJsmExperimental = true
       const { client: cli, connection: conn } = mockClient(false)
       client = cli
       connection = conn
-      filter = deployAttributesFilter(getFilterParams({ config, client })) as typeof filter
+      filter = deployAttributesFilter(getFilterParams({ config, client, elementsSource })) as typeof filter
       attributesInstance = new InstanceElement(
         'attributesInstance',
         attributeType,

--- a/packages/jira-adapter/test/filters/assets/attribute_deploy_filter.test.ts
+++ b/packages/jira-adapter/test/filters/assets/attribute_deploy_filter.test.ts
@@ -80,6 +80,23 @@ describe('deployAttributesFilter', () => {
             },
           }
         }
+        if (url === '/gateway/api/jsm/assets/workspace/workspaceId/v1/objecttype/11111/attributes') {
+          return {
+            status: 200,
+            data: [
+              {
+                name: 'Key',
+                id: '1',
+                editable: false,
+              },
+              {
+                name: 'Name',
+                id: '2',
+                editable: true,
+              },
+            ],
+          }
+        }
         throw new Error('Unexpected url')
       })
       connection.post.mockImplementation(async url => {
@@ -138,6 +155,28 @@ describe('deployAttributesFilter', () => {
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(1)
       expect(res.deployResult.appliedChanges).toHaveLength(0)
+      expect(connection.post).toHaveBeenCalledTimes(0)
+      expect(connection.put).toHaveBeenCalledTimes(0)
+    })
+    it('should add an editable default attribute', async () => {
+      const defaultAttributeInstance = attributesInstance.clone()
+      defaultAttributeInstance.value.name = 'Name'
+      const changes = [toChange({ after: defaultAttributeInstance })]
+      const res = await filter.deploy(changes)
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.deployResult.appliedChanges).toHaveLength(1)
+      expect(connection.post).toHaveBeenCalledTimes(0)
+      expect(connection.put).toHaveBeenCalledTimes(2)
+    })
+    it('should not call deploy request on a non editable default attribute', async () => {
+      const defaultAttributeInstance = attributesInstance.clone()
+      defaultAttributeInstance.value.name = 'Key'
+      const changes = [toChange({ after: defaultAttributeInstance })]
+      const res = await filter.deploy(changes)
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.deployResult.appliedChanges).toHaveLength(1)
       expect(connection.post).toHaveBeenCalledTimes(0)
       expect(connection.put).toHaveBeenCalledTimes(0)
     })


### PR DESCRIPTION
In this PR:
1. I added the option to change default attributes addition as modification. 
2. I added a CV that prevent deployment of non editable attributes. (except an addition of them which doesn't really calls to the endpoint, but adding automatically). 

---

_Additional context for reviewer_
1. 'Name' is the only system attribute that can be modified. (but not added or deleted)
---
_Release Notes_: 
None

---
_User Notifications_: 
None
