### PR TITLE
SALTO-5190 - Salesforce: Exponential backoff for data instances deploy

### DIFF
--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -303,11 +303,12 @@ For more details see the DeployOptions section in the [salesforce documentation 
 
 ### Client data retry options
 
-| Name              | Default when undefined                                  | Description                           |
-|-------------------|---------------------------------------------------------|---------------------------------------|
-| maxAttempts       | `5`                                                     | Max attempts to deploy data instances |
-| retryDelay        | `1000`                                                  | Delay (in millis) between each retry  |
-| retryableFailures | `FIELD_CUSTOM_VALIDATION_EXCEPTION, UNABLE_TO_LOCK_ROW` | Error messages for which to retry     |
+| Name                 | Default when undefined                                  | Description                                                                                                                                                      |
+|----------------------|---------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| maxAttempts          | `5`                                                     | Max attempts to deploy data instances                                                                                                                            |
+| retryDelay           | `1000`                                                  | Delay (in ms) before the first retry                                                                                                                             |
+| retryDelayMultiplier | `1.5`                                                   | The amount by which the delay is increased between consecutive retries - i.e the first retry is 1000ms, the second is 1.5*1000ms, the third is 1.5*1.5*1000ms... |
+| retryableFailures    | `FIELD_CUSTOM_VALIDATION_EXCEPTION, UNABLE_TO_LOCK_ROW` | Error messages for which to retry                                                                                                                                |
 | 
 
 ### Read metadata chunk size

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -44,7 +44,8 @@ import { logger } from '@salto-io/logging'
 import { Options, RequestCallback } from 'request'
 import { AccountInfo, CredentialError, Value } from '@salto-io/adapter-api'
 import {
-  CUSTOM_OBJECT_ID_FIELD, DEFAULT_CUSTOM_OBJECTS_DEFAULT_RETRY_OPTIONS,
+  CUSTOM_OBJECT_ID_FIELD,
+  DEFAULT_CUSTOM_OBJECTS_DEFAULT_RETRY_OPTIONS,
   DEFAULT_MAX_CONCURRENT_API_REQUESTS,
   SALESFORCE,
 } from '../constants'
@@ -567,7 +568,6 @@ export default class SalesforceClient {
       clientName: SALESFORCE,
     })
     this.dataRetry = config?.dataRetry ?? DEFAULT_CUSTOM_OBJECTS_DEFAULT_RETRY_OPTIONS
-
     this.clientName = 'SFDC'
     this.readMetadataChunkSize = _.merge(
       {},

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import { EOL } from 'os'
 import requestretry, { RequestRetryOptions, RetryStrategies, RetryStrategy } from 'requestretry'
 import Bottleneck from 'bottleneck'
-import { collections, decorators, hash, retry as lowerDashRetry } from '@salto-io/lowerdash'
+import { collections, decorators, hash } from '@salto-io/lowerdash'
 import {
   BatchResultInfo,
   BulkLoadOperation,
@@ -44,7 +44,7 @@ import { logger } from '@salto-io/logging'
 import { Options, RequestCallback } from 'request'
 import { AccountInfo, CredentialError, Value } from '@salto-io/adapter-api'
 import {
-  CUSTOM_OBJECT_ID_FIELD,
+  CUSTOM_OBJECT_ID_FIELD, DEFAULT_CUSTOM_OBJECTS_DEFAULT_RETRY_OPTIONS,
   DEFAULT_MAX_CONCURRENT_API_REQUESTS,
   SALESFORCE,
 } from '../constants'
@@ -65,7 +65,6 @@ import { mapToUserFriendlyErrorMessages } from './user_facing_errors'
 import { HANDLED_ERROR_PREDICATES } from '../config_change'
 
 const { makeArray } = collections.array
-const { exponentialBackoff, intervals: constantDelay } = lowerDashRetry.retryStrategies
 const { toMD5 } = hash
 
 const log = logger(module)
@@ -524,20 +523,6 @@ export const validateCredentials = async (
 
 type DeployProgressCallback = (inProgressResult: DeployResult) => void
 
-export type ClientDataRetry = Omit<CustomObjectsDeployRetryConfig, 'retryDelay'> & {
-  retryDelayStrategy: lowerDashRetry.RetryStrategy
-}
-
-export const DEFAULT_CUSTOM_OBJECTS_DEFAULT_RETRY_OPTIONS: ClientDataRetry = {
-  maxAttempts: 5,
-  retryDelayStrategy: exponentialBackoff({ initial: 1000 })(),
-  retryableFailures: [
-    'FIELD_CUSTOM_VALIDATION_EXCEPTION',
-    'UNABLE_TO_LOCK_ROW',
-  ],
-}
-
-
 export default class SalesforceClient {
   private readonly retryOptions: RequestRetryOptions
   private readonly conn: Connection
@@ -548,7 +533,7 @@ export default class SalesforceClient {
   private readonly setFetchPollingTimeout: () => void
   private readonly setDeployPollingTimeout: () => void
   readonly rateLimiters: Record<RateLimitBucketName, Bottleneck>
-  readonly dataRetry: ClientDataRetry
+  readonly dataRetry: CustomObjectsDeployRetryConfig
   readonly clientName: string
   readonly readMetadataChunkSize: Required<ReadMetadataChunkSizeConfig>
   private readonly filePropsByType: Record<string, FileProperties[]>
@@ -556,16 +541,6 @@ export default class SalesforceClient {
   constructor(
     { credentials, connection, config }: SalesforceClientOpts
   ) {
-    const buildDataRetryFromConfig = (retryConfig: CustomObjectsDeployRetryConfig): ClientDataRetry => (
-      _.assign(
-        {},
-        _.omit(retryConfig, 'retryDelay'),
-        {
-          retryDelayStrategy: constantDelay({ interval: retryConfig.retryDelay })(),
-        }
-      )
-    )
-
     this.credentials = credentials
     this.config = config
     this.retryOptions = createRetryOptions(_.defaults({}, config?.retry, DEFAULT_RETRY_OPTS))
@@ -591,9 +566,7 @@ export default class SalesforceClient {
       ),
       clientName: SALESFORCE,
     })
-    this.dataRetry = config?.dataRetry
-      ? buildDataRetryFromConfig(config.dataRetry)
-      : DEFAULT_CUSTOM_OBJECTS_DEFAULT_RETRY_OPTIONS
+    this.dataRetry = config?.dataRetry ?? DEFAULT_CUSTOM_OBJECTS_DEFAULT_RETRY_OPTIONS
 
     this.clientName = 'SFDC'
     this.readMetadataChunkSize = _.merge(

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -312,6 +312,19 @@ export const MINIMUM_MAX_ITEMS_IN_RETRIEVE_REQUEST = 500
 export const MAXIMUM_MAX_ITEMS_IN_RETRIEVE_REQUEST = 10000
 export const DEFAULT_ENUM_FIELD_PERMISSIONS = true
 
+export const DEFAULT_CUSTOM_OBJECT_DEPLOY_RETRY_DELAY = 1000
+
+export const DEFAULT_CUSTOM_OBJECT_DEPLOY_RETRY_DELAY_MULTIPLIER = 1.5
+
+export const DEFAULT_CUSTOM_OBJECTS_DEFAULT_RETRY_OPTIONS = {
+  maxAttempts: 5,
+  retryDelay: DEFAULT_CUSTOM_OBJECT_DEPLOY_RETRY_DELAY,
+  retryDelayMultiplier: DEFAULT_CUSTOM_OBJECT_DEPLOY_RETRY_DELAY_MULTIPLIER,
+  retryableFailures: [
+    'FIELD_CUSTOM_VALIDATION_EXCEPTION',
+    'UNABLE_TO_LOCK_ROW',
+  ],
+}
 export const MAX_TYPES_TO_SEPARATE_TO_FILE_PER_FIELD = 20
 
 // ref. https://developer.salesforce.com/docs/atlas.en-us.salesforce_app_limits_cheatsheet.meta/salesforce_app_limits_cheatsheet/salesforce_app_limits_platform_soslsoql.htm

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -311,14 +311,7 @@ export const DEFAULT_MAX_INSTANCES_PER_TYPE = 5000
 export const MINIMUM_MAX_ITEMS_IN_RETRIEVE_REQUEST = 500
 export const MAXIMUM_MAX_ITEMS_IN_RETRIEVE_REQUEST = 10000
 export const DEFAULT_ENUM_FIELD_PERMISSIONS = true
-export const DEFAULT_CUSTOM_OBJECTS_DEFAULT_RETRY_OPTIONS = {
-  maxAttempts: 5,
-  retryDelay: 1000,
-  retryableFailures: [
-    'FIELD_CUSTOM_VALIDATION_EXCEPTION',
-    'UNABLE_TO_LOCK_ROW',
-  ],
-}
+
 export const MAX_TYPES_TO_SEPARATE_TO_FILE_PER_FIELD = 20
 
 // ref. https://developer.salesforce.com/docs/atlas.en-us.salesforce_app_limits_cheatsheet.meta/salesforce_app_limits_cheatsheet/salesforce_app_limits_platform_soslsoql.htm

--- a/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
+++ b/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
@@ -271,7 +271,7 @@ export const retryFlow = async (
     await sleep(retryDelay)
   } else {
     log.warn('Invalid delay %s', retryDelay)
-    await sleep(1000)
+    await sleep(client.dataRetry.retryDelay)
   }
 
   log.debug('in custom object deploy retry-flow. retries left: %d', retriesLeft)
@@ -280,7 +280,8 @@ export const retryFlow = async (
   const { successInstances, errorInstances } = await retryFlow(
     crudFn,
     { ...crudFnArgs, instances: recoverable.map(instAndRes => instAndRes.instance) },
-    retriesLeft - 1
+    retriesLeft - 1,
+    retryDelayStrategy,
   )
   return {
     successInstances: successes.concat(successInstances),

--- a/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
+++ b/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
@@ -232,7 +232,7 @@ export const retryFlow = async (
   retriesLeft: number,
 ): Promise<ActionResult> => {
   const { client } = crudFnArgs
-  const { retryDelay, retryableFailures } = client.dataRetry
+  const { retryDelayStrategy, retryableFailures } = client.dataRetry
 
   let successes: InstanceElement[] = []
   let errors: (SaltoElementError | SaltoError)[] = []
@@ -256,7 +256,13 @@ export const retryFlow = async (
     }
   }
 
-  await sleep(retryDelay)
+  const retryDelay = retryDelayStrategy()
+  if (_.isNumber(retryDelay)) {
+    await sleep(retryDelay)
+  } else {
+    log.warn('Invalid delay %s', retryDelay)
+    await sleep(1000)
+  }
 
   log.debug('in custom object deploy retry-flow. retries left: %d', retriesLeft)
   logErroredInstances(recoverable, 'recoverable')

--- a/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
+++ b/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
@@ -239,7 +239,7 @@ export const retryFlow = async (
   crudFn: CrudFn,
   crudFnArgs: CrudFnArgs,
   retriesLeft: number,
-  retryDelayStrategy: retry.RetryStrategy = retryDelayStrategyFromConfig(crudFnArgs.client),
+  retryDelayStrategy?: retry.RetryStrategy,
 ): Promise<ActionResult> => {
   const { client } = crudFnArgs
   const { retryableFailures } = client.dataRetry
@@ -266,7 +266,8 @@ export const retryFlow = async (
     }
   }
 
-  const retryDelay = retryDelayStrategy()
+  const actualRetryDelayStrategy = retryDelayStrategy ?? retryDelayStrategyFromConfig(client)
+  const retryDelay = actualRetryDelayStrategy()
   if (_.isNumber(retryDelay)) {
     await sleep(retryDelay)
   } else {
@@ -281,7 +282,7 @@ export const retryFlow = async (
     crudFn,
     { ...crudFnArgs, instances: recoverable.map(instAndRes => instAndRes.instance) },
     retriesLeft - 1,
-    retryDelayStrategy,
+    actualRetryDelayStrategy,
   )
   return {
     successInstances: successes.concat(successInstances),

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -362,6 +362,7 @@ export type ClientRetryConfig = Partial<{
 export type CustomObjectsDeployRetryConfig = {
   maxAttempts: number
   retryDelay: number
+  retryDelayMultiplier: number
   retryableFailures: string[]
 }
 
@@ -623,6 +624,7 @@ const clientRetryConfigType = new ObjectType({
   fields: {
     maxAttempts: { refType: BuiltinTypes.NUMBER },
     retryDelay: { refType: BuiltinTypes.NUMBER },
+    retryDelayMultiplier: { refType: BuiltinTypes.NUMBER },
     retryStrategy: {
       refType: BuiltinTypes.STRING,
       annotations: {

--- a/packages/salesforce-adapter/test/client.ts
+++ b/packages/salesforce-adapter/test/client.ts
@@ -43,6 +43,7 @@ const mockClient = (values?: Values):
       dataRetry: {
         maxAttempts: 3,
         retryDelay: 1000,
+        retryDelayMultiplier: 2,
         retryableFailures: ['err1', 'err2'],
       },
       ...(values ?? {}),

--- a/packages/salesforce-adapter/test/client.ts
+++ b/packages/salesforce-adapter/test/client.ts
@@ -42,8 +42,8 @@ const mockClient = (values?: Values):
       },
       dataRetry: {
         maxAttempts: 3,
-        retryDelay: 1000,
-        retryDelayMultiplier: 2,
+        retryDelay: 100,
+        retryDelayMultiplier: 1.2,
         retryableFailures: ['err1', 'err2'],
       },
       ...(values ?? {}),


### PR DESCRIPTION
Instead of always delaying by the same amount of time, let's have a pluggable strategy. If the user provides an explicit config, use the old constant-interval strategy with the provided value; if there is no explicit config, use an exponential-backoff strategy.

---

See the comment about how the `lowerdash` retry strategies are instantiated.

---
_Release Notes_: 
Salesforce: If no explicit configuration is provided, Salto will now use exponential backoff when retrying deployment of custom object instances.

---
_User Notifications_: 
N/A