### PR TITLE
SALTO-5214: Remove portal setting

### DIFF
--- a/packages/jira-adapter/src/filters/portal_settings.ts
+++ b/packages/jira-adapter/src/filters/portal_settings.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-import { AdditionChange, Change, InstanceElement, ModificationChange, getChangeData, isAdditionChange, isAdditionOrModificationChange, isInstanceChange } from '@salto-io/adapter-api'
+import { AdditionChange, Change, InstanceElement, ModificationChange, getChangeData, isAdditionChange, isInstanceChange, isRemovalChange } from '@salto-io/adapter-api'
 import { getParent } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { deployChanges } from '../deployment/standard_deployment'
@@ -78,8 +78,13 @@ const filter: FilterCreator = ({ config, client }) => ({
       (change): change is Change<InstanceElement> => isInstanceChange(change)
       && getChangeData(change).elemID.typeName === PORTAL_SETTINGS_TYPE_NAME
     )
-    const deployResult = await deployChanges(portalChanges.filter(isAdditionOrModificationChange),
-      async change => deployPortalSettings(change, client))
+    const deployResult = await deployChanges(portalChanges,
+      async change => {
+        if (isRemovalChange(change)) {
+          return undefined
+        }
+        return deployPortalSettings(change, client)
+      })
 
     return {
       leftoverChanges,

--- a/packages/jira-adapter/test/filters/portal_settings.test.ts
+++ b/packages/jira-adapter/test/filters/portal_settings.test.ts
@@ -178,5 +178,11 @@ describe('portalSettings filter', () => {
         expect(res.deployResult.errors[0].message).toEqual('Error: Failed to put /rest/servicedesk/1/servicedesk-data/project1Key/name with error: Error: error')
         expect(res.deployResult.appliedChanges).toHaveLength(0)
       })
+      it('should deploy removal of a portal settings', async () => {
+        const res = await filter.deploy([{ action: 'remove', data: { before: portalSettingInstance } }])
+        expect(res.leftoverChanges).toHaveLength(0)
+        expect(res.deployResult.errors).toHaveLength(0)
+        expect(res.deployResult.appliedChanges).toHaveLength(1)
+      })
     })
 })


### PR DESCRIPTION
support deletion of portal settings.

---

_Additional context for reviewer_
If we remove portal setting while we deleting its project. then it will be deleted automatically by the project and we don't need to do anything. 

---
_Release Notes_: 
None

---
_User Notifications_: 
None