### PR TITLE
SALTO-5213 - Salesforce: Improve UX of deploy failure reason in case of metadata deploy and rollback on error

### DIFF
--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -276,7 +276,7 @@ const processDeployResponse = (
     .map(message => getUnFoundDeleteName(message, deletionsPackageName))
     .filter(isDefined)
 
-  const successfulFullNames = anyErrors ? [] : allSuccessMessages
+  const successfulFullNames = (result.rollbackOnError && anyErrors) ? [] : allSuccessMessages
     .map(success => ({ type: success.componentType, fullName: success.fullName }))
     .concat(unFoundDeleteNames)
 

--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -279,7 +279,7 @@ const processDeployResponse = (
     .map(message => getUnFoundDeleteName(message, deletionsPackageName))
     .filter(isDefined)
 
-  const successfulFullNames = (!isCheckOnly && result.rollbackOnError && anyErrors) ? [] : allSuccessMessages
+  const successfulFullNames = allSuccessMessages
     .map(success => ({ type: success.componentType, fullName: success.fullName }))
     .concat(unFoundDeleteNames)
 

--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -256,11 +256,12 @@ const processDeployResponse = (
       .flatMap(detail => makeArray(detail.componentSuccesses))
       .map(component => ({
         elemID: typeAndNameToElemId[component.componentType]?.[component.fullName],
-        message: 'This metadata type did not deploy because other types in its deployment group encountered failures',
+        message: 'Element was not deployed because other elements had errors and the \'rollbackOnError\' option is enabled (or not set).',
         severity: 'Warning' as const,
         type: 'dependency',
       }))
       .filter(error => error.elemID !== undefined)
+      .forEach(error => errors.push(error))
   }
 
   // In checkOnly none of the changes are actually applied

--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -414,7 +414,8 @@ export const deployMetadata = async (
       names.forEach(name => {
         nameToElemId[name] = elemID
       })
-      deployedComponentsElemIdsByType[type] = nameToElemId
+      // doing it in a slightly more convoluted way because deployedComponentsElemIdsByType[type] may be udefined
+      deployedComponentsElemIdsByType[type] = _.assign({}, deployedComponentsElemIdsByType[type], nameToElemId)
     })
   })
 

--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -256,6 +256,7 @@ const processDeployResponse = (
         elemID: typeAndNameToElemId[component.componentType]?.[component.fullName],
         message: 'This metadata type did not deploy because other types in its deployment group encountered failures',
         severity: 'Warning' as const,
+        type: 'dependency',
       }))
       .filter(error => error.elemID !== undefined)
   }

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -974,6 +974,9 @@ describe('SalesforceAdapter CRUD', () => {
             }),
           ])
         })
+        it('should have no applied changes', () => {
+          expect(result.appliedChanges).toBeEmpty()
+        })
       })
     })
   })

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -37,7 +37,7 @@ import { mockDeployResult, mockRunTestFailure, mockDeployResultComplete } from '
 import { MAPPABLE_PROBLEM_TO_USER_FRIENDLY_MESSAGE, MappableSalesforceProblem } from '../src/client/user_facing_errors'
 import { GLOBAL_VALUE_SET } from '../src/filters/global_value_sets'
 import { apiNameSync, metadataTypeSync } from '../src/filters/utils'
-import { SalesforceArtifacts } from '../src/constants'
+import { SalesforceArtifacts, INSTANCE_FULL_NAME_FIELD } from '../src/constants'
 
 const { makeArray } = collections.array
 
@@ -890,8 +890,16 @@ describe('SalesforceAdapter CRUD', () => {
           expect(result.appliedChanges).toHaveLength(0)
         })
         it('should return the test errors', () => {
-          expect(result.errors).toHaveLength(1)
-          expect(result.errors[0].message).toMatch(/.*Test failed.*/)
+          expect(result.errors).toEqual([
+            expect.objectContaining({
+              message: expect.stringContaining('Test failed'),
+            }),
+            expect.objectContaining({
+              elemID: instance.elemID,
+              message: expect.stringContaining('rollbackOnError'),
+              severity: 'Warning',
+            }),
+          ])
         })
       })
       describe('without rollback on error', () => {
@@ -909,6 +917,62 @@ describe('SalesforceAdapter CRUD', () => {
         it('should return the test errors', () => {
           expect(result.errors).toHaveLength(1)
           expect(result.errors[0].message).toMatch(/.*Test failed.*/)
+        })
+      })
+    })
+
+    describe('when one component fails and others succeed', () => {
+      let deployResultParams: Parameters<typeof mockDeployResult>[0]
+      let successElement: InstanceElement
+      let failureElement: InstanceElement
+      let deployChangeGroup: ChangeGroup
+      beforeEach(() => {
+        successElement = createInstanceElement({
+          [INSTANCE_FULL_NAME_FIELD]: 'SuccessElement',
+        },
+        mockTypes.ApexClass)
+        failureElement = createInstanceElement({
+          [INSTANCE_FULL_NAME_FIELD]: 'FailureElement',
+        },
+        mockTypes.ApexClass)
+
+        deployResultParams = {
+          success: false,
+          componentSuccess: [
+            { fullName: apiNameSync(successElement), componentType: metadataTypeSync(successElement) },
+          ],
+          componentFailure: [
+            { fullName: apiNameSync(failureElement), componentType: metadataTypeSync(failureElement), problem: 'Failed to deploy' },
+          ],
+        }
+
+        deployChangeGroup = {
+          groupID: 'ChangeGroup',
+          changes: [toChange({ after: failureElement }), toChange({ after: successElement })],
+        }
+      })
+      describe('with rollback on error', () => {
+        let result: DeployResult
+        beforeEach(async () => {
+          connection.metadata.deploy.mockReturnValue(mockDeployResult({
+            ...deployResultParams,
+            rollbackOnError: true,
+          }))
+          result = await adapter.deploy({ changeGroup: deployChangeGroup, progressReporter: nullProgressReporter })
+        })
+        it('should return the test errors', () => {
+          expect(result.errors).toEqual([
+            expect.objectContaining({
+              elemID: failureElement.elemID,
+              message: expect.stringContaining('Failed to deploy'),
+              severity: 'Error',
+            }),
+            expect.objectContaining({
+              elemID: successElement.elemID,
+              message: expect.stringContaining('rollbackOnError'),
+              severity: 'Warning',
+            }),
+          ])
         })
       })
     })
@@ -1166,7 +1230,15 @@ describe('SalesforceAdapter CRUD', () => {
           })
         })
         it('should produce a deploy error', () => {
-          expect(result.errors).toHaveLength(1)
+          expect(result.errors).toEqual([
+            expect.objectContaining({
+              message: expect.stringContaining('UNKNOWN_EXCEPTION'),
+            }),
+            expect.objectContaining({
+              elemID: afterInstance.elemID,
+              message: expect.stringContaining('rollbackOnError'),
+            }),
+          ])
         })
       })
 


### PR DESCRIPTION
We deploy with the `rollbackOnError` option, which means if any part of the deploy group fails, the entire group doesn't deploy. Let's make this more obvious to the user.

 - [x] @tomermevorach to review the error message
 - [ ] ~@tomermevorach to provide input on whether we want to keep the successful components if there's an error in the deploy group~
 - [x] Unit tests

---

The current code creates warnings for every successful component in a group where at least one component failed. It also does not return any successful components. We can do either one instead of both if that makes more sense. The current code implements both.
I will add UTs once we decide on what we want to do.

---
_Release Notes_: 
Salesforce: will now be more explicit about metadata types that did not deploy because they were in a deploy group along with types that failed to deploy because of an error.

---
_User Notifications_: 
N/A
