### PR TITLE
SALTO-5206 - Salesforce: Remove fields the user doesn't have permissions to deploy from applied changes

### DIFF
--- a/packages/salesforce-adapter/e2e_test/utils.ts
+++ b/packages/salesforce-adapter/e2e_test/utils.ts
@@ -18,7 +18,7 @@ import {
   Value, ObjectType, ElemID, InstanceElement, Element, isObjectType, ChangeGroup, getChangeData, DeployResult,
   ProgressReporter,
 } from '@salto-io/adapter-api'
-import { filter, findElement } from '@salto-io/adapter-utils'
+import { filter, findElement, safeJsonStringify } from '@salto-io/adapter-utils'
 import { collections, values } from '@salto-io/lowerdash'
 import { MetadataInfo } from '@salto-io/jsforce'
 import { SalesforceRecord } from '../src/client/types'
@@ -191,7 +191,7 @@ export const createElement = async <T extends InstanceElement | ObjectType>(
   const result = await adapter.deploy({ changeGroup, progressReporter: nullProgressReporter })
   if (verify && result.errors.length > 0) {
     if (result.errors.length === 1) throw result.errors[0]
-    throw new Error(`Failed adding element ${element.elemID.getFullName()} with errors: ${result.errors}`)
+    throw new Error(`Failed adding element ${element.elemID.getFullName()} with errors: ${result.errors.map(error => safeJsonStringify(error))}`)
   }
   if (verify && result.appliedChanges.length === 0) {
     throw new Error(`Failed adding element ${element.elemID.getFullName()}: no applied changes`)

--- a/packages/salesforce-adapter/e2e_test/utils.ts
+++ b/packages/salesforce-adapter/e2e_test/utils.ts
@@ -189,8 +189,9 @@ export const createElement = async <T extends InstanceElement | ObjectType>(
     changes: [{ action: 'add', data: { after: element } }],
   }
   const result = await adapter.deploy({ changeGroup, progressReporter: nullProgressReporter })
-  if (verify && result.errors.length > 0) {
-    if (result.errors.length === 1) throw result.errors[0]
+  const errors = result.errors.filter(error => error.severity !== 'Warning')
+  if (verify && errors.length > 0) {
+    if (errors.length === 1) throw result.errors[0]
     throw new Error(`Failed adding element ${element.elemID.getFullName()} with errors: ${result.errors.map(error => safeJsonStringify(error))}`)
   }
   if (verify && result.appliedChanges.length === 0) {

--- a/packages/salesforce-adapter/e2e_test/utils.ts
+++ b/packages/salesforce-adapter/e2e_test/utils.ts
@@ -189,7 +189,7 @@ export const createElement = async <T extends InstanceElement | ObjectType>(
     changes: [{ action: 'add', data: { after: element } }],
   }
   const result = await adapter.deploy({ changeGroup, progressReporter: nullProgressReporter })
-  const errors = result.errors.filter(error => error.severity !== 'Warning')
+  const errors = result.errors.filter(error => error.severity === 'Error')
   if (verify && errors.length > 0) {
     if (errors.length === 1) throw result.errors[0]
     throw new Error(`Failed adding element ${element.elemID.getFullName()} with errors: ${result.errors.map(error => safeJsonStringify(error))}`)

--- a/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
+++ b/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
@@ -294,11 +294,22 @@ const removeFieldsWithNoPermission = async (
   instance: InstanceElement,
   permissionAnnotation: string
 ): Promise<SaltoElementError[]> => {
-  const shouldRemoveField = (type: ObjectType, fieldName: string, fieldValue: Value): boolean => (
-    fieldName !== CUSTOM_OBJECT_ID_FIELD
+  const shouldRemoveField = (type: ObjectType, fieldName: string, fieldValue: Value): boolean => {
+    const shouldRemove = fieldName !== CUSTOM_OBJECT_ID_FIELD
     && (fieldValue === undefined
       || !type.fields[fieldName]?.annotations[permissionAnnotation])
-  )
+
+    if (shouldRemove) {
+      log.debug('Removing field %s from %s: %s=%s, value=%s',
+        fieldName,
+        instance.elemID.getFullName(),
+        permissionAnnotation,
+        type.fields[fieldName]?.annotations[permissionAnnotation],
+        fieldValue)
+    }
+
+    return shouldRemove
+  }
   const createRemovedFieldWarning = (fieldName: string): SaltoElementError => (
     {
       message: `The field ${fieldName} will not be deployed because it lacks the '${permissionAnnotation}' permission`,

--- a/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
+++ b/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
@@ -294,35 +294,30 @@ const removeFieldsWithNoPermission = async (
   instance: InstanceElement,
   permissionAnnotation: string
 ): Promise<SaltoElementError[]> => {
-  const shouldRemoveField = (type: ObjectType, fieldName: string, fieldValue: Value): boolean => {
-    const shouldRemove = fieldName !== CUSTOM_OBJECT_ID_FIELD
+  const shouldRemoveField = (type: ObjectType, fieldName: string, fieldValue: Value): boolean => (
+    fieldName !== CUSTOM_OBJECT_ID_FIELD
     && (fieldValue === undefined
       || !type.fields[fieldName]?.annotations[permissionAnnotation])
-
-    if (shouldRemove) {
-      log.debug('Removing field %s from %s: %s=%s, value=%s',
-        fieldName,
-        instance.elemID.getFullName(),
-        permissionAnnotation,
-        type.fields[fieldName]?.annotations[permissionAnnotation],
-        fieldValue)
-    }
-
-    return shouldRemove
-  }
-  const createRemovedFieldWarning = (fieldName: string): SaltoElementError => (
-    {
+  )
+  const createRemovedFieldWarning = (type: ObjectType, fieldValue: Value, fieldName: string): SaltoElementError => {
+    log.info('Removing field %s from %s: %s=%s, value=%s',
+      fieldName,
+      instance.elemID.getFullName(),
+      permissionAnnotation,
+      type.fields[fieldName]?.annotations[permissionAnnotation],
+      fieldValue)
+    return {
       message: `The field ${fieldName} will not be deployed because it lacks the '${permissionAnnotation}' permission`,
       severity: 'Warning',
       elemID: instance.elemID,
     }
-  )
+  }
   const instanceType = await instance.getType()
   const fieldsToRemove = Object.entries(instance.value)
     .filter(([fieldName, fieldValue]) => shouldRemoveField(instanceType, fieldName, fieldValue))
     .map(([fieldName]) => fieldName)
   const warnings = fieldsToRemove
-    .map(fieldName => createRemovedFieldWarning(fieldName))
+    .map(fieldName => createRemovedFieldWarning(instanceType, instance.value[fieldName], fieldName))
 
   instance.value = _.omit(
     instance.value,

--- a/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
@@ -537,7 +537,6 @@ describe('Custom Object Instances CRUD', () => {
           })
 
           it('Should have result with 2 applied changes, add 3 instances with new Id', async () => {
-            expect(result.errors).toHaveLength(0)
             expect(result.appliedChanges).toHaveLength(3)
 
             // existingInstance appliedChange
@@ -570,6 +569,13 @@ describe('Custom Object Instances CRUD', () => {
           })
 
           it('Should not insert non-creatable fields', () => {
+            expect(result.errors).toEqual([
+              expect.objectContaining({
+                elemID: newInstanceWithNonCreatableField.elemID,
+                message: expect.stringContaining('Creatable'),
+                severity: 'Warning',
+              }),
+            ])
             const newInstanceWithNonCreatableFieldChangeData = result.appliedChanges
               .map(getChangeData)
               .find(element => element.elemID.isEqual(newInstanceWithNonCreatableField.elemID)) as InstanceElement
@@ -614,7 +620,6 @@ describe('Custom Object Instances CRUD', () => {
             })
 
             it('Should have result with 3 applied changes, add 3 instances with insert Id', async () => {
-              expect(result.errors).toHaveLength(0)
               expect(result.appliedChanges).toHaveLength(3)
               // newInstance appliedChange
               const newInstanceChangeData = result.appliedChanges
@@ -643,6 +648,13 @@ describe('Custom Object Instances CRUD', () => {
               expect(anotherNewInstanceChangeData.value.Id).toEqual('newId1')
             })
             it('Should not insert non-creatable fields', () => {
+              expect(result.errors).toEqual([
+                expect.objectContaining({
+                  elemID: newInstanceWithNonCreatableField.elemID,
+                  message: expect.stringContaining('Creatable'),
+                  severity: 'Warning',
+                }),
+              ])
               const newInstanceWithNonCreatableFieldChangeData = result.appliedChanges
                 .map(getChangeData)
                 .find(element => element.elemID.isEqual(newInstanceWithNonCreatableField.elemID)) as InstanceElement
@@ -970,8 +982,14 @@ describe('Custom Object Instances CRUD', () => {
           result = await adapter.deploy({ changeGroup: modifyDeployGroup, progressReporter: nullProgressReporter })
         })
 
-        it('should return no errors and 3 fitting applied changes', async () => {
-          expect(result.errors).toHaveLength(0)
+        it('should return one error and 3 fitting applied changes', async () => {
+          expect(result.errors).toEqual([
+            expect.objectContaining({
+              elemID: instanceWithNonUpdateableFieldToModify.elemID,
+              message: expect.stringContaining('updateable'),
+              severity: 'Warning',
+            }),
+          ])
           expect(result.appliedChanges).toHaveLength(3)
           expect(isModificationChange(result.appliedChanges[0])).toBeTruthy()
           const changeData = getChangeData(result.appliedChanges[0])
@@ -1015,6 +1033,11 @@ describe('Custom Object Instances CRUD', () => {
               elemID: existingInstanceWithNonUpdateableField.elemID,
               message: expect.stringContaining(errorMsgs[1]),
               severity: 'Error',
+            }),
+            expect.objectContaining({
+              elemID: existingInstanceWithNonUpdateableField.elemID,
+              message: expect.stringContaining('updateable'),
+              severity: 'Warning',
             }),
           ])
 
@@ -1063,6 +1086,11 @@ describe('Custom Object Instances CRUD', () => {
               elemID: existingInstanceWithNonUpdateableField.elemID,
               message: expect.stringContaining(errorMsgs[1]),
               severity: 'Error',
+            }),
+            expect.objectContaining({
+              elemID: existingInstanceWithNonUpdateableField.elemID,
+              message: expect.stringContaining('updateable'),
+              severity: 'Warning',
             }),
           ])
 

--- a/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
@@ -288,6 +288,8 @@ describe('Custom Object Instances CRUD', () => {
           refType: idType,
           label: 'id',
           annotations: {
+            [constants.FIELD_ANNOTATIONS.CREATABLE]: true,
+            [constants.FIELD_ANNOTATIONS.UPDATEABLE]: false,
             [constants.FIELD_ANNOTATIONS.QUERYABLE]: true,
             [CORE_ANNOTATIONS.REQUIRED]: false,
             [constants.LABEL]: 'Record ID',
@@ -302,6 +304,7 @@ describe('Custom Object Instances CRUD', () => {
             [constants.LABEL]: 'Name',
             [constants.API_NAME]: 'Name',
             [constants.FIELD_ANNOTATIONS.CREATABLE]: true,
+            [constants.FIELD_ANNOTATIONS.UPDATEABLE]: true,
             [constants.FIELD_ANNOTATIONS.QUERYABLE]: true,
           },
         },
@@ -313,6 +316,7 @@ describe('Custom Object Instances CRUD', () => {
             [constants.LABEL]: 'TestField',
             [constants.API_NAME]: 'Type.TestField__c',
             [constants.FIELD_ANNOTATIONS.CREATABLE]: true,
+            [constants.FIELD_ANNOTATIONS.UPDATEABLE]: true,
             [constants.FIELD_ANNOTATIONS.QUERYABLE]: true,
           },
           annotationRefsOrTypes: {

--- a/packages/salesforce-adapter/test/custom_object_instances_deploy.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances_deploy.test.ts
@@ -198,7 +198,7 @@ describe('Custom Object Deploy', () => {
       expect(clientBulkOpSpy).toHaveBeenCalledTimes(3)
     })
 
-    it('should retry1 on recoverable error(s), failed because of max-retries', async () => {
+    it('should retry on recoverable error(s), failed because of max-retries', async () => {
       clientBulkOpSpy.mockImplementation(
         async (_1: string,
           _2: BulkLoadOperation,


### PR DESCRIPTION
If the user doesn't have access to a field (i.e. it's not creatable for add or updateable for modify), remove it from the instance during deploy.
~UTs still pending.~

---

1. Since we are now making the deploy code remove inaccessible fields, we could go all the way and remove the handling of inaccessible fields from `toRecord`. Would that make sense?
2. I had to use `forEach` instead of `map` when removing the fields because the same instance object is referenced from other instances - thus we can't clone+modify, we have to make the change in-place.

---
_Release Notes_: 
Salesforce: When deploying data instances with fields that are not creatable (for addition) or updateable (for modification) by the fetching user, the fields will now be deleted from the workspace.

---
_User Notifications_: 
N/A
