### PR TITLE
SALTO-5216: Fixing queue filter

### DIFF
--- a/packages/jira-adapter/test/filters/portal_settings.test.ts
+++ b/packages/jira-adapter/test/filters/portal_settings.test.ts
@@ -184,5 +184,25 @@ describe('portalSettings filter', () => {
         expect(res.deployResult.errors).toHaveLength(0)
         expect(res.deployResult.appliedChanges).toHaveLength(1)
       })
+      it('should deploy only description if project setting has no canAgentsManagePortalAnnouncement', async () => {
+        portalSettingInstance.value.announcementSettings = undefined
+        const projectSettingsInstanceAfter = portalSettingInstance.clone()
+        projectSettingsInstanceAfter.value.description = 'newDescription'
+        const res = await filter.deploy([{ action: 'modify', data: { before: portalSettingInstance, after: projectSettingsInstanceAfter } }])
+        expect(res.leftoverChanges).toHaveLength(0)
+        expect(res.deployResult.errors).toHaveLength(0)
+        expect(res.deployResult.appliedChanges).toHaveLength(1)
+        // One call to deploy description.
+        expect(connection.put).toHaveBeenCalledTimes(1)
+      })
+      it('should call three endpoints if it is addition change and announcementSettings is undefined', async () => {
+        portalSettingInstance.value.announcementSettings = undefined
+        const res = await filter.deploy([{ action: 'add', data: { after: portalSettingInstance } }])
+        expect(res.leftoverChanges).toHaveLength(0)
+        expect(res.deployResult.errors).toHaveLength(0)
+        expect(res.deployResult.appliedChanges).toHaveLength(1)
+        // One call to deploy name and one call to deploy description.
+        expect(connection.put).toHaveBeenCalledTimes(3)
+      })
     })
 })

--- a/packages/jira-adapter/test/filters/queue_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/queue_deployment.test.ts
@@ -187,5 +187,12 @@ describe('queue deployment filter', () => {
         expect(res.leftoverChanges).toEqual([{ action: 'add', data: { after: queueInstance } }])
         expect(res.deployResult.appliedChanges).toHaveLength(0)
       })
+      it('should not deploy and should not reuturn error if not queue changes', async () => {
+        const res = await filter.deploy([{ action: 'add', data: { after: projectInstance } }])
+        expect(res.leftoverChanges).toHaveLength(1)
+        expect(res.leftoverChanges).toEqual([{ action: 'add', data: { after: projectInstance } }])
+        expect(res.deployResult.appliedChanges).toHaveLength(0)
+        expect(res.deployResult.errors).toHaveLength(0)
+      })
     })
 })


### PR DESCRIPTION
In this PR I fixed queue filter to check parent just for queue changes and not all changes.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
