### PR TITLE
SALTO-5219: fix removal of missing ticket in ticket_field_ids in ticket_form

### DIFF
--- a/packages/zendesk-adapter/src/filters/ticket_form.ts
+++ b/packages/zendesk-adapter/src/filters/ticket_form.ts
@@ -138,8 +138,11 @@ const getChangeWithoutRemovedFields = (change: ModificationChange<InstanceElemen
   const removedFields = beforeFields.filter(field => !afterFields.has(field))
   // filtering out anything that is a reference since we can have a missing reference in the before that could have
   // been removed in the after and we don't want it to be added to the list again
-  const [finalRemovedFields, referenceFields] = _.partition(removedFields, field => !isReferenceExpression(field))
-  log.trace(`these reference fields are in the before and not in the after. their elemIds are: ${
+  const [finalRemovedFields, referenceFields] = _.partition(
+    removedFields,
+    field => _.isString(field) || _.isNumber(field),
+  )
+  log.debug(`these reference fields are in the before and not in the after. their elemIds are: ${
     referenceFields.filter(isReferenceExpression).map(ref => ref.elemID.getFullName())}`)
   if (_.isEmpty(finalRemovedFields)) {
     return undefined

--- a/packages/zendesk-adapter/src/filters/ticket_form.ts
+++ b/packages/zendesk-adapter/src/filters/ticket_form.ts
@@ -22,12 +22,12 @@ import {
   isAdditionOrModificationChange,
   isInstanceChange,
   isInstanceElement,
-  isModificationChange, isReferenceExpression, ModificationChange,
+  isModificationChange, ModificationChange,
   ReadOnlyElementsSource, ReferenceExpression, toChange,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
-import { applyFunctionToChangeData } from '@salto-io/adapter-utils'
+import { applyFunctionToChangeData, inspectValue } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { FilterCreator } from '../filter'
 import { deployChange, deployChanges } from '../deployment'
@@ -142,8 +142,10 @@ const getChangeWithoutRemovedFields = (change: ModificationChange<InstanceElemen
     removedFields,
     field => _.isString(field) || _.isNumber(field),
   )
-  log.debug(`these reference fields are in the before and not in the after. their elemIds are: ${
-    referenceFields.filter(isReferenceExpression).map(ref => ref.elemID.getFullName())}`)
+  if (!_.isEmpty(referenceFields)) {
+    log.debug(`there are fields which are not a string or a number in the before and not in the after of the change in form: ${before.elemID.getFullName()}`)
+    log.trace(`the form ${before.elemID.getFullName()} before: ${inspectValue(before)}`)
+  }
   if (_.isEmpty(finalRemovedFields)) {
     return undefined
   }

--- a/packages/zendesk-adapter/src/filters/ticket_form.ts
+++ b/packages/zendesk-adapter/src/filters/ticket_form.ts
@@ -135,7 +135,7 @@ const getChangeWithoutRemovedFields = (change: ModificationChange<InstanceElemen
   const { after } = change.data
   const beforeFields: number[] = before.value.ticket_field_ids ?? []
   const afterFields = new Set(after.value.ticket_field_ids ?? [])
-  const removedFields = beforeFields.filter(field => !afterFields.has(field))
+  const removedFields = beforeFields.filter(field => !afterFields.has(field)).filter(field => _.isNumber(field))
   if (_.isEmpty(removedFields)) {
     return undefined
   }

--- a/packages/zendesk-adapter/test/filters/ticket_form.test.ts
+++ b/packages/zendesk-adapter/test/filters/ticket_form.test.ts
@@ -49,6 +49,7 @@ jest.mock('@salto-io/logging', () => ({
   logger: jest.fn()
     .mockReturnValue({
       debug: jest.fn(),
+      trace: jest.fn(),
       info: jest.fn(),
       error: jest.fn((...args) => mockLogError(...args)),
     }),

--- a/packages/zendesk-adapter/test/filters/ticket_form.test.ts
+++ b/packages/zendesk-adapter/test/filters/ticket_form.test.ts
@@ -15,7 +15,7 @@
 * limitations under the License.
 */
 
-import { filterUtils } from '@salto-io/adapter-components'
+import { filterUtils, references as referencesUtils } from '@salto-io/adapter-components'
 import {
   ElemID,
   InstanceElement,
@@ -29,6 +29,8 @@ import filterCreator from '../../src/filters/ticket_form'
 import { createFilterCreatorParams } from '../utils'
 import { ACCOUNT_FEATURES_TYPE_NAME, TICKET_FIELD_TYPE_NAME, TICKET_FORM_TYPE_NAME, ZENDESK } from '../../src/constants'
 
+
+const { createMissingInstance } = referencesUtils
 const mockDeployChange = jest.fn()
 jest.mock('@salto-io/adapter-components', () => {
   const actual = jest.requireActual('@salto-io/adapter-components')
@@ -131,6 +133,7 @@ describe('ticket form filter', () => {
       filter = filterCreator(createFilterCreatorParams({ elementsSource: createElementSource(true) })) as FilterType
     })
     it('should deploy modification change with removal of conditions and field', async () => {
+      const missing = createMissingInstance(ZENDESK, TICKET_FIELD_TYPE_NAME, 'test')
       const beforeTicketForm = new InstanceElement(
         'test',
         ticketFormType,
@@ -140,6 +143,7 @@ describe('ticket form filter', () => {
             11,
             123,
             1234,
+            new ReferenceExpression(missing.elemID, missing),
           ],
           agent_conditions: [
             {


### PR DESCRIPTION
fix removal of missing ticket in ticket_field_ids in ticket_form

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* fix bug where the removal of a missing `ticket_field` by editing from `ticket_field_ids` list in `ticket_form` would fail the deploy

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
