### PR TITLE
SALTO-5222: fix workflow_scheme_migration CV bug

### DIFF
--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -1266,6 +1266,7 @@ export const formatConfigSuggestionsReasons = (reasons: string[]): string => {
 /* Checks for references expression with undefined value or for unresolved references
 * during fetch and deploy. In fetch this can happen when the reference is set to be missing reference.
 * In deploy this can happen when the reference is assigned as unresolved reference.
+* If the element's source is the elementsSource then this function will return always false.
 */
 export const isResolvedReferenceExpression = (value: unknown): value is ReferenceExpression => (
   isReferenceExpression(value) && !(value.value instanceof UnresolvedReference) && value.value !== undefined

--- a/packages/jira-adapter/src/change_validators/workflow_scheme_migration.ts
+++ b/packages/jira-adapter/src/change_validators/workflow_scheme_migration.ts
@@ -13,12 +13,12 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, ChangeDataType, ChangeError, ChangeValidator, CORE_ANNOTATIONS, getChangeData, InstanceElement, isInstanceChange, isInstanceElement, isModificationChange, ModificationChange, ReadOnlyElementsSource, ReferenceExpression } from '@salto-io/adapter-api'
+import { Change, ChangeDataType, ChangeError, ChangeValidator, CORE_ANNOTATIONS, getChangeData, InstanceElement, isInstanceChange, isInstanceElement, isModificationChange, isReferenceExpression, ModificationChange, ReadOnlyElementsSource, ReferenceExpression } from '@salto-io/adapter-api'
 import { values, collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { filters, client as clientUtils } from '@salto-io/adapter-components'
 import os from 'os'
-import { getInstancesFromElementSource, isResolvedReferenceExpression } from '@salto-io/adapter-utils'
+import { getInstancesFromElementSource } from '@salto-io/adapter-utils'
 import { updateSchemeId } from '../filters/workflow_scheme'
 import JiraClient from '../client/client'
 import { JiraConfig } from '../config/config'
@@ -78,14 +78,15 @@ const getAllIssueTypesForWorkflowScheme = async (
 ): Promise<ReferenceExpression[]> => {
   const issueTypeSchemes: InstanceElement[] = await awu(assignedProjects)
     .map(instance => instance.value.issueTypeScheme)
-    .filter(isResolvedReferenceExpression)
-    .map(ref => elementSource.get(ref.elemID))
+    .filter(isReferenceExpression)
+    .map(ref => ref.getResolvedValue(elementSource))
+    .filter(isDefined)
     .filter(isInstanceElement)
     .toArray()
   const issueTypes: ReferenceExpression[] = issueTypeSchemes
     .filter(issueTypeScheme => Array.isArray(issueTypeScheme.value.issueTypeIds))
     .flatMap(issueTypeScheme => issueTypeScheme.value.issueTypeIds)
-    .filter(isResolvedReferenceExpression)
+    .filter(isReferenceExpression)
   return _.uniqBy(
     issueTypes,
     issueType => issueType.elemID.getFullName()

--- a/packages/jira-adapter/test/change_validators/workflow_scheme_migration.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflow_scheme_migration.test.ts
@@ -119,11 +119,11 @@ describe('workflow scheme migration', () => {
       issueTypeSchemeType,
       {
         issueTypeIds: [
-          new ReferenceExpression(issueType1Id, {}),
-          new ReferenceExpression(issueType2Id, {}),
-          new ReferenceExpression(issueType3Id, {}),
-          new ReferenceExpression(issueType4Id, {}),
-          new ReferenceExpression(issueType5Id, {}),
+          new ReferenceExpression(issueType1Id),
+          new ReferenceExpression(issueType2Id),
+          new ReferenceExpression(issueType3Id),
+          new ReferenceExpression(issueType4Id),
+          new ReferenceExpression(issueType5Id),
         ],
       }
     )
@@ -133,9 +133,9 @@ describe('workflow scheme migration', () => {
       projectType,
       {
         name: 'instance',
-        workflowScheme: new ReferenceExpression(new ElemID(JIRA, 'WorkflowScheme', 'instance', 'workflow'), {}),
-        issueTypeScheme: new ReferenceExpression(new ElemID(JIRA, 'IssueTypeScheme', 'instance', 'issueTypeScheme'), {}),
-      }
+        workflowScheme: new ReferenceExpression(new ElemID(JIRA, 'WorkflowScheme', 'instance', 'workflow')),
+        issueTypeScheme: new ReferenceExpression(new ElemID(JIRA, 'IssueTypeScheme', 'instance', 'issueTypeScheme')),
+      } 
     )
     workflowInstance = new InstanceElement(
       'workflow',
@@ -147,15 +147,15 @@ describe('workflow scheme migration', () => {
         items: [
           {
             workflow: workflow2,
-            issueType: new ReferenceExpression(new ElemID(JIRA, 'IssueType', 'instance', 'issueType1'), {}),
+            issueType: new ReferenceExpression(new ElemID(JIRA, 'IssueType', 'instance', 'issueType1')),
           },
           {
             workflow: workflow3,
-            issueType: new ReferenceExpression(new ElemID(JIRA, 'IssueType', 'instance', 'issueType2'), {}),
+            issueType: new ReferenceExpression(new ElemID(JIRA, 'IssueType', 'instance', 'issueType2')),
           },
           {
             workflow: workflow4,
-            issueType: new ReferenceExpression(new ElemID(JIRA, 'IssueType', 'instance', 'issueType3'), {}),
+            issueType: new ReferenceExpression(new ElemID(JIRA, 'IssueType', 'instance', 'issueType3')),
           },
         ],
       }

--- a/packages/jira-adapter/test/change_validators/workflow_scheme_migration.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflow_scheme_migration.test.ts
@@ -135,7 +135,7 @@ describe('workflow scheme migration', () => {
         name: 'instance',
         workflowScheme: new ReferenceExpression(new ElemID(JIRA, 'WorkflowScheme', 'instance', 'workflow')),
         issueTypeScheme: new ReferenceExpression(new ElemID(JIRA, 'IssueTypeScheme', 'instance', 'issueTypeScheme')),
-      } 
+      }
     )
     workflowInstance = new InstanceElement(
       'workflow',


### PR DESCRIPTION
_fix workflow_scheme_migration CV bug_

---

_Additional context for reviewer_
* in this CV the relevant elements are coming via the elementsSource, therefore the function `isResolvedReference` always returns false.

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
