### PR TITLE
SALTO-5131: Salesforce - Rollout the improved tooling extra dependencies implementation

### DIFF
--- a/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
@@ -35,7 +35,7 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   skipAliases: false,
   toolingDepsOfCurrentNamespace: false,
   fixRetrieveFilePaths: true,
-  extraDependenciesV2: false,
+  extraDependenciesV2: true,
 }
 
 type BuildFetchProfileParams = {

--- a/packages/salesforce-adapter/test/filters/extra_dependencies.test.ts
+++ b/packages/salesforce-adapter/test/filters/extra_dependencies.test.ts
@@ -292,7 +292,7 @@ describe('extra dependencies filter', () => {
               fetchProfile: buildFetchProfile({
                 fetchParams: {
                   target: ['meta'],
-                  optionalFeatures: { toolingDepsOfCurrentNamespace: false },
+                  optionalFeatures: { toolingDepsOfCurrentNamespace: false, extraDependenciesV2: false },
                 },
               }),
               elementsSource,
@@ -367,7 +367,7 @@ describe('extra dependencies filter', () => {
               fetchProfile: buildFetchProfile({
                 fetchParams: {
                   target: ['meta'],
-                  optionalFeatures: { toolingDepsOfCurrentNamespace: true },
+                  optionalFeatures: { toolingDepsOfCurrentNamespace: true, extraDependenciesV2: false },
                 },
               }),
               elementsSource: buildElementsSourceFromElements(elements),
@@ -412,7 +412,7 @@ describe('extra dependencies filter', () => {
           config: {
             ...defaultFilterContext,
             fetchProfile: buildFetchProfile({
-              fetchParams: { optionalFeatures: { extraDependencies: false } },
+              fetchParams: { optionalFeatures: { extraDependencies: false, extraDependenciesV2: false } },
             }),
             elementsSource: buildElementsSourceFromElements(elements),
           },


### PR DESCRIPTION
The improved implementation of the `Tooling Extra Dependencies` filter is enabled by default.

---

_Release Notes_: 
Salesforce Adapter:
- The improved implementation of the `Tooling Extra Dependencies` is enabled by default. This will improve IA of Metadata Components.

---
_User Notifications_: 
Salesforce:
- You may encounter changes in Metadata Elements `_extra_dependencies`.