### PR TITLE
SALTO-4904: Initial support for service url JSM

### DIFF
--- a/packages/adapter-components/src/filters/service_url.ts
+++ b/packages/adapter-components/src/filters/service_url.ts
@@ -21,9 +21,10 @@ import { AdapterApiConfig } from '../config'
 
 
 export const addUrlToInstance = <TContext extends { apiDefinitions: AdapterApiConfig }>(
-  instance: InstanceElement, baseUrl: string, config: TContext
+  instance: InstanceElement, baseUrl: string, config: TContext, otherDefinitions?: AdapterApiConfig
 ): void => {
-  const serviceUrl = config.apiDefinitions
+  const definitions = otherDefinitions ?? config.apiDefinitions
+  const serviceUrl = definitions
     .types[instance.elemID.typeName]?.transformation?.serviceUrl
   if (serviceUrl === undefined) {
     return
@@ -36,17 +37,18 @@ export const serviceUrlFilterCreator: <
   TClient,
   TContext extends { apiDefinitions: AdapterApiConfig },
   TResult extends void | filter.FilterResult = void
->(baseUrl: string) => FilterCreator<TClient, TContext, TResult> = baseUrl => ({ config }) => ({
+>(baseUrl: string, otherDefinitions?: AdapterApiConfig)
+=> FilterCreator<TClient, TContext, TResult> = (baseUrl, otherDefinitions) => ({ config }) => ({
   name: 'serviceUrlFilter',
   onFetch: async (elements: Element[]) => {
     elements
       .filter(isInstanceElement)
-      .forEach(instance => addUrlToInstance(instance, baseUrl, config))
+      .forEach(instance => addUrlToInstance(instance, baseUrl, config, otherDefinitions))
   },
   onDeploy: async (changes: Change<InstanceElement>[]) => {
     const relevantChanges = changes.filter(isInstanceChange).filter(isAdditionChange)
     relevantChanges
       .map(getChangeData)
-      .forEach(instance => addUrlToInstance(instance, baseUrl, config))
+      .forEach(instance => addUrlToInstance(instance, baseUrl, config, otherDefinitions))
   },
 })

--- a/packages/adapter-components/src/filters/service_url.ts
+++ b/packages/adapter-components/src/filters/service_url.ts
@@ -21,9 +21,9 @@ import { AdapterApiConfig } from '../config'
 
 
 export const addUrlToInstance = <TContext extends { apiDefinitions: AdapterApiConfig }>(
-  instance: InstanceElement, baseUrl: string, config: TContext, otherDefinitions?: AdapterApiConfig
+  instance: InstanceElement, baseUrl: string, config: TContext, otherApiDefinitions?: AdapterApiConfig
 ): void => {
-  const definitions = otherDefinitions ?? config.apiDefinitions
+  const definitions = otherApiDefinitions ?? config.apiDefinitions
   const serviceUrl = definitions
     .types[instance.elemID.typeName]?.transformation?.serviceUrl
   if (serviceUrl === undefined) {
@@ -37,18 +37,18 @@ export const serviceUrlFilterCreator: <
   TClient,
   TContext extends { apiDefinitions: AdapterApiConfig },
   TResult extends void | filter.FilterResult = void
->(baseUrl: string, otherDefinitions?: AdapterApiConfig)
-=> FilterCreator<TClient, TContext, TResult> = (baseUrl, otherDefinitions) => ({ config }) => ({
+>(baseUrl: string, otherApiDefinitions?: AdapterApiConfig)
+=> FilterCreator<TClient, TContext, TResult> = (baseUrl, otherApiDefinitions) => ({ config }) => ({
   name: 'serviceUrlFilter',
   onFetch: async (elements: Element[]) => {
     elements
       .filter(isInstanceElement)
-      .forEach(instance => addUrlToInstance(instance, baseUrl, config, otherDefinitions))
+      .forEach(instance => addUrlToInstance(instance, baseUrl, config, otherApiDefinitions))
   },
   onDeploy: async (changes: Change<InstanceElement>[]) => {
     const relevantChanges = changes.filter(isInstanceChange).filter(isAdditionChange)
     relevantChanges
       .map(getChangeData)
-      .forEach(instance => addUrlToInstance(instance, baseUrl, config, otherDefinitions))
+      .forEach(instance => addUrlToInstance(instance, baseUrl, config, otherApiDefinitions))
   },
 })

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -91,6 +91,7 @@ import contextReferencesFilter from './filters/fields/context_references_filter'
 import contextsProjectsFilter from './filters/fields/contexts_projects_filter'
 import serviceUrlInformationFilter from './filters/service_url/service_url_information'
 import serviceUrlFilter from './filters/service_url/service_url'
+import serviceUrlJsmFilter from './filters/service_url/service_url_jsm'
 import priorityFilter from './filters/priority'
 import statusDeploymentFilter from './filters/statuses/status_deployment'
 import securitySchemeFilter from './filters/security_scheme/security_scheme'
@@ -287,6 +288,7 @@ export const DEFAULT_FILTERS = [
   // Must run after referenceBySelfLinkFilter
   removeSelfFilter,
   formsFilter,
+  serviceUrlJsmFilter, // Must run before fieldReferencesFilter
   fieldReferencesFilter,
   // Must run after fieldReferencesFilter
   addJsmTypesAsFieldsFilter,

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1981,6 +1981,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       fieldTypeOverrides: [
         { fieldName: 'columns', fieldType: 'List<Field>' },
       ],
+      serviceUrl: '/jira/servicedesk/projects/{projectKey}/queues/custom/{id}',
     },
     deployRequests: {
       add: {
@@ -2022,6 +2023,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       fieldTypeOverrides: [
         { fieldName: 'ticketTypeIds', fieldType: 'List<RequestType>' },
       ],
+      serviceUrl: '/jira/servicedesk/projects/{projectKey}/settings/portal-settings/portal-groups',
     },
     deployRequests: {
       add: {
@@ -2130,6 +2132,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
         { fieldName: 'portalLogoUrl' },
         { fieldName: 'canAdministerJIRA' },
       ],
+      serviceUrl: '/jira/servicedesk/projects/{projectKey}/settings/portal-settings',
     },
   },
   PortalSettings__announcementSettings: {
@@ -2153,6 +2156,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
         { fieldName: 'customFieldId' },
       ],
       serviceIdField: 'id',
+      serviceUrl: '/jira/servicedesk/projects/{projectKey}/settings/sla/custom/{id}',
     },
     deployRequests: {
       add: {
@@ -2270,6 +2274,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       fieldTypeOverrides: [
         { fieldName: 'objectSchemaStatuses', fieldType: 'List<ObjectSchemaStatus>' },
       ],
+      serviceUrl: '/jira/servicedesk/assets/configure/object-schema/{id}',
     },
     deployRequests: {
       add: {

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -2308,11 +2308,10 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       fieldsToHide: [
         { fieldName: 'id' },
         { fieldName: 'workspaceId' },
-      ],
-      serviceIdField: 'id',
-      fieldsToOmit: [
         { fieldName: 'objectSchemaId' },
       ],
+      serviceIdField: 'id',
+      serviceUrl: '/jira/servicedesk/assets/configure/object-schema/{id}',
     },
     deployRequests: {
       add: {
@@ -2347,15 +2346,16 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       idFields: ['&parentObjectTypeId', 'name'],
       fieldsToHide: [
         { fieldName: 'id' },
+        { fieldName: 'objectSchemaId' },
       ],
       fieldsToOmit: [
         { fieldName: 'created' },
         { fieldName: 'updated' },
         { fieldName: 'globalId' },
-        { fieldName: 'objectSchemaId' },
         { fieldName: 'workspaceId' },
       ],
       extendsParentId: false,
+      serviceUrl: '/jira/servicedesk/assets/object-schema/{objectSchemaId}?typeId={id}',
     },
     deployRequests: {
       add: {
@@ -2399,6 +2399,8 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       fieldTypeOverrides: [
         { fieldName: 'typeValue', fieldType: 'string' },
       ],
+      serviceUrl: '/jira/servicedesk/assets/object-schema/{objectSchemaId}?typeId={id}&mode=attribute',
+
     },
     deployRequests: {
       add: {

--- a/packages/jira-adapter/src/filters/service_url/service_url_jsm.ts
+++ b/packages/jira-adapter/src/filters/service_url/service_url_jsm.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2023 Salto Labs Ltd.
+*                      Copyright 2024 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/src/filters/service_url/service_url_jsm.ts
+++ b/packages/jira-adapter/src/filters/service_url/service_url_jsm.ts
@@ -1,0 +1,26 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { filters } from '@salto-io/adapter-components'
+import JiraClient from '../../client/client'
+import { JiraConfig } from '../../config/config'
+import { FilterCreator, FilterResult } from '../../filter'
+
+const filter: FilterCreator = params =>
+  filters.serviceUrlFilterCreator<JiraClient, JiraConfig, FilterResult>(
+    params.client.baseUrl, params.config.jsmApiDefinitions
+  )(params)
+
+export default filter

--- a/packages/jira-adapter/test/filters/service_url/service_url_jsm.test.ts
+++ b/packages/jira-adapter/test/filters/service_url/service_url_jsm.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2023 Salto Labs Ltd.
+*                      Copyright 2024 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/test/filters/service_url/service_url_jsm.test.ts
+++ b/packages/jira-adapter/test/filters/service_url/service_url_jsm.test.ts
@@ -1,0 +1,85 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { InstanceElement, CORE_ANNOTATIONS, toChange } from '@salto-io/adapter-api'
+import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import _ from 'lodash'
+import { createEmptyType, getFilterParams, mockClient } from '../../utils'
+import JiraClient from '../../../src/client/client'
+import { CUSTOMER_PERMISSIONS_TYPE, QUEUE_TYPE } from '../../../src/constants'
+import filterCreator from '../../../src/filters/service_url/service_url_jsm'
+import { getDefaultConfig } from '../../../src/config/config'
+
+describe('service url filter', () => {
+  let client: JiraClient
+  let paginator: clientUtils.Paginator
+  type FilterType = filterUtils.FilterWith<'onFetch' | 'onDeploy'>
+  let filter: FilterType
+  const queueInstance = new InstanceElement(
+    'queue1',
+    createEmptyType(QUEUE_TYPE),
+    {
+      id: 11,
+      projectKey: 'PROJ1',
+    }
+  )
+  const customerPermission = new InstanceElement(
+    'customer_permission',
+    createEmptyType(CUSTOMER_PERMISSIONS_TYPE),
+    {
+      id: 11,
+      projectKey: 'PROJ1',
+    }
+  )
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    const mockCli = mockClient()
+    client = mockCli.client
+    paginator = mockCli.paginator
+    const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+    config.fetch.enableJSM = true
+    config.fetch.enableJsmExperimental = true
+    filter = filterCreator(getFilterParams({
+      client,
+      paginator,
+    })) as typeof filter
+  })
+
+  describe('onFetch', () => {
+    it('should add service url annotation if it is exist in the config', async () => {
+      await filter.onFetch([queueInstance])
+      expect(queueInstance.annotations[CORE_ANNOTATIONS.SERVICE_URL])
+        .toEqual('https://ori-salto-test.atlassian.net/jira/servicedesk/projects/PROJ1/queues/custom/11')
+    })
+    it('should not add service url annotation if it is not exist in the config', async () => {
+      await filter.onFetch([customerPermission])
+      expect(customerPermission.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
+    })
+  })
+  describe('onDeploy', () => {
+    it('should add service url annotation if it is exist in the config', async () => {
+      const changes = [queueInstance].map(e => e.clone()).map(inst => toChange({ after: inst }))
+      await filter.onDeploy(changes)
+      expect(queueInstance.annotations[CORE_ANNOTATIONS.SERVICE_URL])
+        .toEqual('https://ori-salto-test.atlassian.net/jira/servicedesk/projects/PROJ1/queues/custom/11')
+    })
+  })
+  it('should not add service url annotation if it is not exist in the config', async () => {
+    const changes = [customerPermission].map(e => e.clone()).map(inst => toChange({ after: inst }))
+    await filter.onDeploy(changes)
+    expect(customerPermission.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
+  })
+})


### PR DESCRIPTION
In this PR I support serviceUrl in JSM. 

---

_Additional context for reviewer_

---
_Release Notes_: 
_Jira Adapter_:
Jsm types will now have serviceUrl. 

---
_User Notifications_: 
_Jira Adapter_:
Jsm types will now have serviceUrl. 
