### PR TITLE
SALTO-5223: replace workflowScheme statusMigration type - Jira

### DIFF
--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1397,6 +1397,9 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
 
   WorkflowScheme: {
     transformation: {
+      fieldTypeOverrides: [
+        { fieldName: 'statusMigrations', fieldType: 'List<StatusMapping>' },
+      ],
       fieldsToHide: [
         {
           fieldName: 'id',

--- a/packages/jira-adapter/src/filters/workflow_scheme.ts
+++ b/packages/jira-adapter/src/filters/workflow_scheme.ts
@@ -371,4 +371,3 @@ const filter: FilterCreator = ({ config, client, paginator, elementsSource }) =>
 })
 
 export default filter
-

--- a/packages/jira-adapter/src/filters/workflow_scheme.ts
+++ b/packages/jira-adapter/src/filters/workflow_scheme.ts
@@ -298,17 +298,10 @@ const filter: FilterCreator = ({ config, client, paginator, elementsSource }) =>
       if (workflowSchemeType.fields.issueTypeMappings !== undefined) {
         delete workflowSchemeType.fields.issueTypeMappings
       }
-      const statusMappingType = findObject(elements, 'StatusMapping')
-      if (statusMappingType !== undefined) {
-        await addAnnotationRecursively(statusMappingType, CORE_ANNOTATIONS.UPDATABLE)
-        workflowSchemeType.fields.statusMigrations = new Field(
-          workflowSchemeType,
-          'statusMigrations',
-          new ListType(statusMappingType),
-          {
-            [CORE_ANNOTATIONS.UPDATABLE]: true,
-          }
-        )
+      const statusMigrationsType = findObject(elements, 'StatusMapping')
+      if (statusMigrationsType !== undefined) {
+        await addAnnotationRecursively(statusMigrationsType, CORE_ANNOTATIONS.UPDATABLE)
+        workflowSchemeType.fields.statusMigrations.annotations[CORE_ANNOTATIONS.UPDATABLE] = true
       } else {
         log.error('StatusMapping type was not found')
       }

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -557,19 +557,19 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     target: { type: ISSUE_TYPE_NAME },
   },
   {
-    src: { field: 'statusId', parentTypes: ['StatusMigration'] },
+    src: { field: 'statusId', parentTypes: ['StatusMapping'] },
     serializationStrategy: 'id',
     jiraMissingRefStrategy: 'typeAndValue',
     target: { type: STATUS_TYPE_NAME },
   },
   {
-    src: { field: 'newStatusId', parentTypes: ['StatusMigration'] },
+    src: { field: 'newStatusId', parentTypes: ['StatusMapping'] },
     serializationStrategy: 'id',
     jiraMissingRefStrategy: 'typeAndValue',
     target: { type: STATUS_TYPE_NAME },
   },
   {
-    src: { field: 'issueTypeId', parentTypes: ['StatusMigration'] },
+    src: { field: 'issueTypeId', parentTypes: ['StatusMapping'] },
     serializationStrategy: 'id',
     jiraMissingRefStrategy: 'typeAndValue',
     target: { type: ISSUE_TYPE_NAME },

--- a/packages/jira-adapter/test/filters/workflow_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/workflow_scheme.test.ts
@@ -48,7 +48,7 @@ class ServiceError {
 
 describe('workflowScheme', () => {
   let workflowSchemeType: ObjectType
-  let statusMappingType: ObjectType
+  let statusMigrationsType: ObjectType
   let filter: Filter
   let client: JiraClient
   let connection: MockInterface<clientUtils.APIConnection>
@@ -65,15 +65,20 @@ describe('workflowScheme', () => {
       paginator,
       elementsSource,
     }))
+    statusMigrationsType = createEmptyType('StatusMapping')
     workflowSchemeType = new ObjectType({
       elemID: new ElemID(JIRA, 'WorkflowScheme'),
+      fields: {
+        statusMigrations: {
+          refType: statusMigrationsType,
+        },
+      },
     })
-    statusMappingType = createEmptyType('StatusMapping')
   })
 
   describe('onFetch', () => {
     it('should add statusMigrations', async () => {
-      await filter.onFetch?.([workflowSchemeType, statusMappingType])
+      await filter.onFetch?.([workflowSchemeType, statusMigrationsType])
       expect(workflowSchemeType.fields.statusMigrations).toBeDefined()
       expect(workflowSchemeType.fields.statusMigrations.annotations).toEqual({
         [CORE_ANNOTATIONS.UPDATABLE]: true,
@@ -81,7 +86,7 @@ describe('workflowScheme', () => {
     })
     it('replace field issueTypeMappings with items', async () => {
       workflowSchemeType.fields.issueTypeMappings = new Field(workflowSchemeType, 'issueTypeMappings', BuiltinTypes.STRING)
-      await filter.onFetch?.([workflowSchemeType, statusMappingType])
+      await filter.onFetch?.([workflowSchemeType, statusMigrationsType])
       expect(workflowSchemeType.fields.issueTypeMappings).toBeUndefined()
       expect(workflowSchemeType.fields.items).toBeDefined()
       expect(workflowSchemeType.fields.items.annotations).toEqual({

--- a/packages/jira-adapter/test/filters/workflow_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/workflow_scheme.test.ts
@@ -20,7 +20,7 @@ import _ from 'lodash'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { ISSUE_TYPE_NAME, JIRA, STATUS_TYPE_NAME } from '../../src/constants'
-import { getFilterParams, mockClient } from '../utils'
+import { createEmptyType, getFilterParams, mockClient } from '../utils'
 import workflowSchemeFilter from '../../src/filters/workflow_scheme'
 import { Filter } from '../../src/filter'
 import { getDefaultConfig } from '../../src/config/config'
@@ -48,6 +48,7 @@ class ServiceError {
 
 describe('workflowScheme', () => {
   let workflowSchemeType: ObjectType
+  let statusMappingType: ObjectType
   let filter: Filter
   let client: JiraClient
   let connection: MockInterface<clientUtils.APIConnection>
@@ -67,11 +68,12 @@ describe('workflowScheme', () => {
     workflowSchemeType = new ObjectType({
       elemID: new ElemID(JIRA, 'WorkflowScheme'),
     })
+    statusMappingType = createEmptyType('StatusMapping')
   })
 
   describe('onFetch', () => {
     it('should add statusMigrations', async () => {
-      await filter.onFetch?.([workflowSchemeType])
+      await filter.onFetch?.([workflowSchemeType, statusMappingType])
       expect(workflowSchemeType.fields.statusMigrations).toBeDefined()
       expect(workflowSchemeType.fields.statusMigrations.annotations).toEqual({
         [CORE_ANNOTATIONS.UPDATABLE]: true,
@@ -79,7 +81,7 @@ describe('workflowScheme', () => {
     })
     it('replace field issueTypeMappings with items', async () => {
       workflowSchemeType.fields.issueTypeMappings = new Field(workflowSchemeType, 'issueTypeMappings', BuiltinTypes.STRING)
-      await filter.onFetch?.([workflowSchemeType])
+      await filter.onFetch?.([workflowSchemeType, statusMappingType])
       expect(workflowSchemeType.fields.issueTypeMappings).toBeUndefined()
       expect(workflowSchemeType.fields.items).toBeDefined()
       expect(workflowSchemeType.fields.items.annotations).toEqual({


### PR DESCRIPTION
_replace workflowScheme statusMigration type_

---

_Additional context for reviewer_
While working on [upgrading Workflow API](https://salto-io.atlassian.net/browse/SALTO-4978) Im using the type statusMigration from the Swagger.
This typeName collides with another type that we create manually [here](https://github.com/salto-io/salto/blob/main/packages/jira-adapter/src/filters/workflow_scheme.ts#L302). 
In this PR I am replacing the type that we created with an identical type from the Swagger for solving the collision.

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
