### PR TITLE
SALTO-4943: Improve profileMappingPropertiesFilter

### DIFF
--- a/packages/okta-adapter/src/filters/profile_mapping_properties.ts
+++ b/packages/okta-adapter/src/filters/profile_mapping_properties.ts
@@ -15,13 +15,11 @@
 */
 import { Element, Values, isInstanceElement } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
-import { collections } from '@salto-io/lowerdash'
 import { FilterCreator } from '../filter'
 import { PROFILE_MAPPING_TYPE_NAME } from '../constants'
 import OktaClient from '../client/client'
 import { FETCH_CONFIG } from '../config'
 
-const { awu } = collections.asynciterable
 const log = logger(module)
 
 const getProfileMapping = async (
@@ -45,7 +43,7 @@ const filterCreator: FilterCreator = ({ client, config }) => ({
       .filter(isInstanceElement)
       .filter(instance => instance.elemID.typeName === PROFILE_MAPPING_TYPE_NAME)
 
-    await awu(instances).forEach(async instance => {
+    await Promise.all(instances.map(async instance => {
       const mappingId = instance.value.id
       const mappingProperties = (await getProfileMapping(mappingId, client))?.properties
       // not all mappings have properties
@@ -53,7 +51,7 @@ const filterCreator: FilterCreator = ({ client, config }) => ({
         return
       }
       instance.value.properties = mappingProperties
-    })
+    }))
   },
 })
 


### PR DESCRIPTION
We used awu instead of `Promise.all`, which caused requests for mappings to happen one by one

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
