### PR TITLE
SALTO-5212: Initial support for assets in automations

### DIFF
--- a/packages/jira-adapter/src/filters/automation/automation_deployment.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_deployment.ts
@@ -419,9 +419,7 @@ const filter: FilterCreator = ({ client, config }) => ({
       .filter(isAdditionOrModificationChange)
       .map(getChangeData)
       .filter(instance => instance.elemID.typeName === AUTOMATION_TYPE)
-      .forEach(instance => {
-        addDetailedAssetsComponents(instance)
-      })
+      .forEach(addDetailedAssetsComponents)
   },
   deploy: async changes => {
     const [relevantChanges, leftoverChanges] = _.partition(
@@ -461,9 +459,7 @@ const filter: FilterCreator = ({ client, config }) => ({
       .filter(isAdditionOrModificationChange)
       .map(getChangeData)
       .filter(instance => instance.elemID.typeName === AUTOMATION_TYPE)
-      .forEach(instance => {
-        deleteDetailedAssetsComponents(instance)
-      })
+      .forEach(deleteDetailedAssetsComponents)
   },
 })
 export default filter

--- a/packages/jira-adapter/src/filters/automation/types.ts
+++ b/packages/jira-adapter/src/filters/automation/types.ts
@@ -154,6 +154,11 @@ export const createAutomationTypes = (): {
       project: { refType: projectType },
       role: { refType: roleType },
       compareFieldValue: { refType: compareFieldValueType },
+      workspaceId: { refType: BuiltinTypes.STRING },
+      schemaLabel: { refType: BuiltinTypes.STRING },
+      schemaId: { refType: BuiltinTypes.STRING },
+      objectTypeLabel: { refType: BuiltinTypes.STRING },
+      objectTypeId: { refType: BuiltinTypes.STRING },
     },
     path: [JIRA, elements.TYPES_PATH, elements.SUBTYPES_PATH, AUTOMATION_COMPONENT_VALUE_TYPE],
   })

--- a/packages/jira-adapter/src/filters/jsm_types_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/jsm_types_deploy_filter.ts
@@ -67,7 +67,11 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
     const deployResult = await deployChanges(
       typeFixedChanges,
       async change => {
-        const typeDefinition = jsmApiDefinitions.types[getChangeData(change).elemID.typeName]
+        const instance = getChangeData(change)
+        if (instance.value.typeName === OBJECT_SCHEMA_TYPE) {
+          instance.value.workspaceId = workspaceId
+        }
+        const typeDefinition = jsmApiDefinitions.types[instance.elemID.typeName]
         const deployRequest = typeDefinition.deployRequests ? typeDefinition.deployRequests[change.action] : undefined
         const fieldsToIgnore = deployRequest?.fieldsToIgnore ?? []
         await defaultDeployChange({

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -1178,6 +1178,12 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     jiraMissingRefStrategy: 'typeAndValue',
     target: { typeContext: 'referenceTypeTypeName' },
   },
+  {
+    src: { field: 'objectTypeId', parentTypes: [AUTOMATION_COMPONENT_VALUE_TYPE] },
+    serializationStrategy: 'id',
+    target: { type: OBJECT_TYPE_TYPE },
+  },
+
 ]
 
 const lookupNameFuncs: GetLookupNameFunc[] = [

--- a/packages/jira-adapter/test/filters/automation/automation_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/automation/automation_deployment.test.ts
@@ -825,6 +825,22 @@ describe('automationDeploymentFilter', () => {
             objectTypeId: new ReferenceExpression(objectTypeInstance.elemID, objectTypeInstance),
           })
         })
+        it('should do nothing if there are no components', async () => {
+          automationInstance.value.components = undefined
+          config.fetch.enableJSM = true
+          config.fetch.enableJsmExperimental = true
+          await filter.onDeploy([toChange({ after: automationInstance })])
+          expect(automationInstance.value.components).toBeUndefined()
+        })
+        it('should not throw an error if schema objectType doesn\'t have a parent', async () => {
+          objectTypeInstance.annotations[CORE_ANNOTATIONS.PARENT] = undefined
+          config.fetch.enableJSM = true
+          config.fetch.enableJsmExperimental = true
+          await filter.preDeploy([toChange({ after: automationInstance })])
+          expect(automationInstance.value.components[0].value).toEqual({
+            objectTypeId: new ReferenceExpression(objectTypeInstance.elemID, objectTypeInstance),
+          })
+        })
       })
     })
     describe('onDeploy', () => {
@@ -907,6 +923,13 @@ describe('automationDeploymentFilter', () => {
             schemaLabel: 'schemaName',
             objectTypeLabel: 'objectTypeName',
           })
+        })
+        it('should do nothing if there are no components', async () => {
+          automationInstance.value.components = undefined
+          config.fetch.enableJSM = true
+          config.fetch.enableJsmExperimental = true
+          await filter.onDeploy([toChange({ after: automationInstance })])
+          expect(automationInstance.value.components).toBeUndefined()
         })
       })
     })

--- a/packages/jira-adapter/test/filters/automation/automation_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/automation/automation_deployment.test.ts
@@ -13,21 +13,21 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ElemID, InstanceElement, ObjectType, CORE_ANNOTATIONS, BuiltinTypes, Values, toChange, Value } from '@salto-io/adapter-api'
+import { ElemID, InstanceElement, ObjectType, CORE_ANNOTATIONS, BuiltinTypes, Values, toChange, Value, ReferenceExpression } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
 import { MockInterface } from '@salto-io/test-utils'
-import { getFilterParams, mockClient } from '../../utils'
+import { createEmptyType, getFilterParams, mockClient } from '../../utils'
 import automationDeploymentFilter from '../../../src/filters/automation/automation_deployment'
 import { getDefaultConfig, JiraConfig } from '../../../src/config/config'
-import { AUTOMATION_TYPE, JIRA } from '../../../src/constants'
+import { AUTOMATION_TYPE, JIRA, OBJECT_SCHEMA_TYPE, OBJECT_TYPE_TYPE } from '../../../src/constants'
 import { PRIVATE_API_HEADERS } from '../../../src/client/headers'
 import JiraClient from '../../../src/client/client'
 import { CLOUD_RESOURCE_FIELD } from '../../../src/filters/automation/cloud_id'
 
 describe('automationDeploymentFilter', () => {
-  let filter: filterUtils.FilterWith<'onFetch' | 'deploy'>
+  let filter: filterUtils.FilterWith<'onFetch' | 'deploy' | 'preDeploy' | 'onDeploy'>
   let type: ObjectType
   let instance: InstanceElement
   let config: JiraConfig
@@ -45,7 +45,7 @@ describe('automationDeploymentFilter', () => {
       client,
       paginator,
       config,
-    })) as filterUtils.FilterWith<'onFetch' | 'deploy'>
+    })) as filterUtils.FilterWith<'onFetch' | 'deploy' | 'preDeploy' | 'onDeploy'>
 
     type = new ObjectType({
       elemID: new ElemID(JIRA, AUTOMATION_TYPE),
@@ -260,7 +260,7 @@ describe('automationDeploymentFilter', () => {
           client,
           paginator,
           config,
-        })) as filterUtils.FilterWith<'onFetch' | 'deploy'>
+        })) as filterUtils.FilterWith<'onFetch' | 'deploy' | 'preDeploy' | 'onDeploy'>
         connection.post.mockImplementation(async url => createPostMockResponse([{ projectId: '1' }])(url))
       })
       it('should wait for a success answer from import', async () => {
@@ -366,7 +366,7 @@ describe('automationDeploymentFilter', () => {
 
       filter = automationDeploymentFilter(getFilterParams({
         client,
-      })) as filterUtils.FilterWith<'onFetch' | 'deploy'>
+      })) as filterUtils.FilterWith<'onFetch' | 'deploy' | 'preDeploy' | 'onDeploy'>
 
       await filter.deploy([toChange({ after: instance })])
 
@@ -602,7 +602,7 @@ describe('automationDeploymentFilter', () => {
 
       filter = automationDeploymentFilter(getFilterParams({
         client,
-      })) as filterUtils.FilterWith<'onFetch' | 'deploy'>
+      })) as filterUtils.FilterWith<'onFetch' | 'deploy' | 'preDeploy' | 'onDeploy'>
 
       instance.value.id = 3
       await filter.deploy([toChange({ before: instance })])
@@ -683,7 +683,7 @@ describe('automationDeploymentFilter', () => {
 
         filter = automationDeploymentFilter(getFilterParams({
           client,
-        })) as filterUtils.FilterWith<'onFetch' | 'deploy'>
+        })) as filterUtils.FilterWith<'onFetch' | 'deploy' | 'preDeploy' | 'onDeploy'>
 
         const modifyInstance = instance.clone()
         modifyInstance.value.labels = ['1']
@@ -717,7 +717,7 @@ describe('automationDeploymentFilter', () => {
 
         filter = automationDeploymentFilter(getFilterParams({
           client,
-        })) as filterUtils.FilterWith<'onFetch' | 'deploy'>
+        })) as filterUtils.FilterWith<'onFetch' | 'deploy' | 'preDeploy' | 'onDeploy'>
 
         const modifyInstance = instance.clone()
         instance.value.labels = ['1']
@@ -746,6 +746,168 @@ describe('automationDeploymentFilter', () => {
           '/gateway/api/automation/internal-api/jira/cloudId/pro/rest/GLOBAL/rules/555/labels/1',
           undefined,
         )
+      })
+    })
+    describe('preDeploy', () => {
+      const objectTypeType = new ObjectType({
+        elemID: new ElemID(JIRA, OBJECT_TYPE_TYPE),
+        fields: {
+          name: {
+            refType: BuiltinTypes.STRING,
+          },
+          id: {
+            refType: BuiltinTypes.STRING,
+          },
+        },
+      })
+      const objectSchemaInstance = new InstanceElement(
+        'instance',
+        createEmptyType(OBJECT_SCHEMA_TYPE),
+        {
+          name: 'schemaName',
+          id: '25',
+          workspaceId: 'w11',
+        }
+      )
+      const objectTypeInstance = new InstanceElement(
+        'instance',
+        objectTypeType,
+        {
+          name: 'objectTypeName',
+          id: '35',
+        },
+        undefined,
+        {
+          [CORE_ANNOTATIONS.PARENT]: [
+            new ReferenceExpression(objectSchemaInstance.elemID, objectSchemaInstance),
+          ],
+        }
+      )
+      describe('assets components', () => {
+        let automationInstance: InstanceElement
+        beforeEach(() => {
+          automationInstance = new InstanceElement(
+            'instance',
+            type,
+            {
+              name: 'someName',
+              state: 'ENABLED',
+              projects: [],
+              components: [
+                {
+                  component: 'ACTION',
+                  schemaVersion: 1,
+                  value: {
+                    objectTypeId: new ReferenceExpression(objectTypeInstance.elemID, objectTypeInstance),
+                  },
+                },
+              ],
+            }
+          )
+        })
+        it('should add missing fields to assets components when enable JSM is true', async () => {
+          config.fetch.enableJSM = true
+          config.fetch.enableJsmExperimental = true
+          await filter.preDeploy([toChange({ after: automationInstance })])
+          expect(automationInstance.value.components[0].value).toEqual({
+            objectTypeId: new ReferenceExpression(objectTypeInstance.elemID, objectTypeInstance),
+            schemaId: '25',
+            schemaLabel: 'schemaName',
+            objectTypeLabel: 'objectTypeName',
+            workspaceId: 'w11',
+          })
+        })
+        it('should not add missing fields to assets components when enable JSM is false', async () => {
+          config.fetch.enableJSM = false
+          config.fetch.enableJsmExperimental = false
+          await filter.preDeploy([toChange({ after: automationInstance })])
+          expect(automationInstance.value.components[0].value).toEqual({
+            objectTypeId: new ReferenceExpression(objectTypeInstance.elemID, objectTypeInstance),
+          })
+        })
+      })
+    })
+    describe('onDeploy', () => {
+      const objectTypeType = new ObjectType({
+        elemID: new ElemID(JIRA, OBJECT_TYPE_TYPE),
+        fields: {
+          name: {
+            refType: BuiltinTypes.STRING,
+          },
+          id: {
+            refType: BuiltinTypes.STRING,
+          },
+        },
+      })
+      const objectSchemaInstance = new InstanceElement(
+        'instance',
+        createEmptyType(OBJECT_SCHEMA_TYPE),
+        {
+          name: 'schemaName',
+          id: '25',
+          workspaceId: 'w11',
+        }
+      )
+      const objectTypeInstance = new InstanceElement(
+        'instance',
+        objectTypeType,
+        {
+          name: 'objectTypeName',
+          id: '35',
+        },
+        undefined,
+        {
+          [CORE_ANNOTATIONS.PARENT]: [
+            new ReferenceExpression(objectSchemaInstance.elemID, objectSchemaInstance),
+          ],
+        }
+      )
+      describe('assets components', () => {
+        let automationInstance: InstanceElement
+        beforeEach(() => {
+          automationInstance = new InstanceElement(
+            'instance',
+            type,
+            {
+              name: 'someName',
+              state: 'ENABLED',
+              projects: [],
+              components: [
+                {
+                  component: 'ACTION',
+                  schemaVersion: 1,
+                  value: {
+                    objectTypeId: new ReferenceExpression(objectTypeInstance.elemID, objectTypeInstance),
+                    workspaceId: 'w11',
+                    schemaId: '25',
+                    schemaLabel: 'schemaName',
+                    objectTypeLabel: 'objectTypeName',
+                  },
+                },
+              ],
+            }
+          )
+        })
+        it('should remove extra fields for assets components when enable JSM is true', async () => {
+          config.fetch.enableJSM = true
+          config.fetch.enableJsmExperimental = true
+          await filter.onDeploy([toChange({ after: automationInstance })])
+          expect(automationInstance.value.components[0].value).toEqual({
+            objectTypeId: new ReferenceExpression(objectTypeInstance.elemID, objectTypeInstance),
+          })
+        })
+        it('should not remove missing fields to assets components when enable JSM is false', async () => {
+          config.fetch.enableJSM = false
+          config.fetch.enableJsmExperimental = false
+          await filter.onDeploy([toChange({ after: automationInstance })])
+          expect(automationInstance.value.components[0].value).toEqual({
+            objectTypeId: new ReferenceExpression(objectTypeInstance.elemID, objectTypeInstance),
+            workspaceId: 'w11',
+            schemaId: '25',
+            schemaLabel: 'schemaName',
+            objectTypeLabel: 'objectTypeName',
+          })
+        })
       })
     })
   })

--- a/packages/jira-adapter/test/filters/automation/automation_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/automation/automation_deployment.test.ts
@@ -841,6 +841,28 @@ describe('automationDeploymentFilter', () => {
             objectTypeId: new ReferenceExpression(objectTypeInstance.elemID, objectTypeInstance),
           })
         })
+        it('should modify only assets components when enable JSM is true', async () => {
+          config.fetch.enableJSM = true
+          config.fetch.enableJsmExperimental = true
+          automationInstance.value.components.push({
+            component: 'ACTION',
+            schemaVersion: 1,
+            value: {
+              attribute: 'value',
+            },
+          })
+          await filter.preDeploy([toChange({ after: automationInstance })])
+          expect(automationInstance.value.components[0].value).toEqual({
+            objectTypeId: new ReferenceExpression(objectTypeInstance.elemID, objectTypeInstance),
+            schemaId: '25',
+            schemaLabel: 'schemaName',
+            objectTypeLabel: 'objectTypeName',
+            workspaceId: 'w11',
+          })
+          expect(automationInstance.value.components[1].value).toEqual({
+            attribute: 'value',
+          })
+        })
       })
     })
     describe('onDeploy', () => {
@@ -930,6 +952,24 @@ describe('automationDeploymentFilter', () => {
           config.fetch.enableJsmExperimental = true
           await filter.onDeploy([toChange({ after: automationInstance })])
           expect(automationInstance.value.components).toBeUndefined()
+        })
+        it('should modify only assets components when enable JSM is true', async () => {
+          config.fetch.enableJSM = true
+          config.fetch.enableJsmExperimental = true
+          automationInstance.value.components.push({
+            component: 'ACTION',
+            schemaVersion: 1,
+            value: {
+              attribute: 'value',
+            },
+          })
+          await filter.onDeploy([toChange({ after: automationInstance })])
+          expect(automationInstance.value.components[0].value).toEqual({
+            objectTypeId: new ReferenceExpression(objectTypeInstance.elemID, objectTypeInstance),
+          })
+          expect(automationInstance.value.components[1].value).toEqual({
+            attribute: 'value',
+          })
         })
       })
     })

--- a/packages/jira-adapter/test/filters/automation/automation_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/automation/automation_deployment.test.ts
@@ -817,6 +817,28 @@ describe('automationDeploymentFilter', () => {
             workspaceId: 'w11',
           })
         })
+        it('should modify only assets components when enable JSM is true', async () => {
+          config.fetch.enableJSM = true
+          config.fetch.enableJsmExperimental = true
+          automationInstance.value.components.push({
+            component: 'ACTION',
+            schemaVersion: 1,
+            value: {
+              attribute: 'value',
+            },
+          })
+          await filter.preDeploy([toChange({ after: automationInstance })])
+          expect(automationInstance.value.components[0].value).toEqual({
+            objectTypeId: new ReferenceExpression(objectTypeInstance.elemID, objectTypeInstance),
+            schemaId: '25',
+            schemaLabel: 'schemaName',
+            objectTypeLabel: 'objectTypeName',
+            workspaceId: 'w11',
+          })
+          expect(automationInstance.value.components[1].value).toEqual({
+            attribute: 'value',
+          })
+        })
         it('should not add missing fields to assets components when enable JSM is false', async () => {
           config.fetch.enableJSM = false
           config.fetch.enableJsmExperimental = false
@@ -839,28 +861,6 @@ describe('automationDeploymentFilter', () => {
           await filter.preDeploy([toChange({ after: automationInstance })])
           expect(automationInstance.value.components[0].value).toEqual({
             objectTypeId: new ReferenceExpression(objectTypeInstance.elemID, objectTypeInstance),
-          })
-        })
-        it('should modify only assets components when enable JSM is true', async () => {
-          config.fetch.enableJSM = true
-          config.fetch.enableJsmExperimental = true
-          automationInstance.value.components.push({
-            component: 'ACTION',
-            schemaVersion: 1,
-            value: {
-              attribute: 'value',
-            },
-          })
-          await filter.preDeploy([toChange({ after: automationInstance })])
-          expect(automationInstance.value.components[0].value).toEqual({
-            objectTypeId: new ReferenceExpression(objectTypeInstance.elemID, objectTypeInstance),
-            schemaId: '25',
-            schemaLabel: 'schemaName',
-            objectTypeLabel: 'objectTypeName',
-            workspaceId: 'w11',
-          })
-          expect(automationInstance.value.components[1].value).toEqual({
-            attribute: 'value',
           })
         })
       })

--- a/packages/jira-adapter/test/filters/automation/automation_fetch.test.ts
+++ b/packages/jira-adapter/test/filters/automation/automation_fetch.test.ts
@@ -862,5 +862,72 @@ describe('automationFetchFilter', () => {
         ],
       })
     })
+    it('should do nothing if no components', async () => {
+      connection.post.mockImplementation(async url => {
+        if (url === '/rest/webResources/1.0/resources') {
+          return {
+            status: 200,
+            data: {
+              unparsedData: {
+                [CLOUD_RESOURCE_FIELD]: safeJsonStringify({
+                  tenantId: 'cloudId',
+                }),
+              },
+            },
+          }
+        }
+
+        if (url === '/gateway/api/automation/internal-api/jira/cloudId/pro/rest/GLOBAL/rules') {
+          return {
+            status: 200,
+            data: {
+              total: 1,
+              values: [
+                {
+                  id: '1',
+                  name: 'automationName',
+                  projects: [],
+                  ruleScope: {
+                    resources: ['ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8'],
+                  },
+                },
+              ],
+            },
+          }
+        }
+        throw new Error(`Unexpected url ${url}`)
+      })
+      const { paginator } = mockClient()
+      config.fetch.enableJSM = true
+      config.fetch.enableJsmExperimental = true
+      filter = automationFetchFilter(getFilterParams({
+        client,
+        paginator,
+        config,
+        fetchQuery,
+      })) as filterUtils.FilterWith<'onFetch'>
+      const elements = [objectTypeInstnce]
+      await filter.onFetch(elements)
+      const automationTypes = createAutomationTypes()
+      expect(elements).toHaveLength(
+        1 // original objectTypeInstnce
+        + 1 // new automation
+        + 1 // automation top level type
+        + automationTypes.subTypes.length
+      )
+
+      const automation = elements[1]
+
+      expect(automation.elemID.getFullName()).toEqual('jira.Automation.instance.automationName')
+
+      expect(automation.value).toEqual({
+        id: '1',
+        name: 'automationName',
+        projects: [],
+        ruleScope: {
+          resources: ['ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8'],
+        },
+      })
+    })
   })
 })

--- a/packages/jira-adapter/test/filters/automation/automation_fetch.test.ts
+++ b/packages/jira-adapter/test/filters/automation/automation_fetch.test.ts
@@ -747,5 +747,120 @@ describe('automationFetchFilter', () => {
         ],
       })
     })
+    it('should not modify components if not expected asset component', async () => {
+      connection.post.mockImplementation(async url => {
+        if (url === '/rest/webResources/1.0/resources') {
+          return {
+            status: 200,
+            data: {
+              unparsedData: {
+                [CLOUD_RESOURCE_FIELD]: safeJsonStringify({
+                  tenantId: 'cloudId',
+                }),
+              },
+            },
+          }
+        }
+
+        if (url === '/gateway/api/automation/internal-api/jira/cloudId/pro/rest/GLOBAL/rules') {
+          return {
+            status: 200,
+            data: {
+              total: 1,
+              values: [
+                {
+                  id: '1',
+                  name: 'automationName',
+                  projects: [],
+                  ruleScope: {
+                    resources: ['ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8'],
+                  },
+                  components: [
+                    {
+                      component: 'ACTION',
+                      schemaVersion: 1,
+                      type: 'cmdb.object.create',
+                      value: {
+                        objectTypeId: '35',
+                        schemaLabel: 'idoA Schema',
+                        schemaId: '5',
+                        objectTypeLabel: 'R&D',
+                        attributes: [
+                          {
+                            name: 'Name',
+                            value: 'idoA automation',
+                            isLabel: true,
+                          },
+                        ],
+                      },
+                      children: [
+                      ],
+                      conditions: [
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          }
+        }
+        throw new Error(`Unexpected url ${url}`)
+      })
+      const { paginator } = mockClient()
+      config.fetch.enableJSM = true
+      config.fetch.enableJsmExperimental = true
+      filter = automationFetchFilter(getFilterParams({
+        client,
+        paginator,
+        config,
+        fetchQuery,
+      })) as filterUtils.FilterWith<'onFetch'>
+      const elements = [objectTypeInstnce]
+      await filter.onFetch(elements)
+      const automationTypes = createAutomationTypes()
+      expect(elements).toHaveLength(
+        1 // original objectTypeInstnce
+        + 1 // new automation
+        + 1 // automation top level type
+        + automationTypes.subTypes.length
+      )
+
+      const automation = elements[1]
+
+      expect(automation.elemID.getFullName()).toEqual('jira.Automation.instance.automationName')
+
+      expect(automation.value).toEqual({
+        id: '1',
+        name: 'automationName',
+        projects: [],
+        ruleScope: {
+          resources: ['ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8'],
+        },
+        components: [
+          {
+            component: 'ACTION',
+            schemaVersion: 1,
+            type: 'cmdb.object.create',
+            value: {
+              objectTypeId: '35',
+              schemaLabel: 'idoA Schema',
+              schemaId: '5',
+              objectTypeLabel: 'R&D',
+              attributes: [
+                {
+                  name: 'Name',
+                  value: 'idoA automation',
+                  isLabel: true,
+                },
+              ],
+            },
+            children: [
+            ],
+            conditions: [
+            ],
+          },
+        ],
+      })
+    })
   })
 })


### PR DESCRIPTION
In this PR I support fetch and deploy for automation with assets components.

---

_Additional context for reviewer_

---
_Release Notes_: 
_Jira Adapter:_
Can now support assets components in automations. 

---
_User Notifications_: 
_Jira Adapter:_
Can now support assets components in automations. 
