### PR TITLE
SALTO-5230: Omit values from users response before logging

### DIFF
--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -1753,9 +1753,6 @@ export const DEFAULT_API_DEFINITIONS: OktaSwaggerApiConfig = {
   swagger: DEFAULT_SWAGGER_CONFIG,
   typeDefaults: {
     transformation: TRANSFORMATION_DEFAULTS,
-    request: {
-      queryParams: { limit: '200' },
-    },
   },
   types: DEFAULT_TYPE_CUSTOMIZATIONS,
   supportedTypes: SUPPORTED_TYPES,

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -1753,6 +1753,9 @@ export const DEFAULT_API_DEFINITIONS: OktaSwaggerApiConfig = {
   swagger: DEFAULT_SWAGGER_CONFIG,
   typeDefaults: {
     transformation: TRANSFORMATION_DEFAULTS,
+    request: {
+      queryParams: { limit: '200' },
+    },
   },
   types: DEFAULT_TYPE_CUSTOMIZATIONS,
   supportedTypes: SUPPORTED_TYPES,


### PR DESCRIPTION
We fetch users data in order to convert userIds to emails. To avoid logging users data, we should omit it before writing to log.

---

_Additional context for reviewer_

`profile` object might include properties that may vary between account. we only use `login`, so the rest is omitted

---
_Release Notes_: 
None

---
_User Notifications_: 
None