### PR TITLE
SALTO-4943: initiate getUsers early in fetch

### DIFF
--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -21,7 +21,7 @@ import { logger } from '@salto-io/logging'
 import { collections, objects } from '@salto-io/lowerdash'
 import OktaClient from './client/client'
 import changeValidator from './change_validators'
-import { OktaConfig, API_DEFINITIONS_CONFIG, CLIENT_CONFIG, configType } from './config'
+import { OktaConfig, API_DEFINITIONS_CONFIG, CLIENT_CONFIG, configType, FETCH_CONFIG } from './config'
 import fetchCriteria from './fetch_criteria'
 import { paginate } from './client/pagination'
 import { dependencyChanger } from './dependency_changers'
@@ -57,6 +57,7 @@ import groupPushFilter from './filters/group_push'
 import addImportantValues from './filters/add_important_values'
 import { APP_LOGO_TYPE_NAME, BRAND_LOGO_TYPE_NAME, FAV_ICON_TYPE_NAME, OKTA } from './constants'
 import { getLookUpName } from './reference_mapping'
+import { User, getUsers } from './user_utils'
 
 const { awu } = collections.asynciterable
 
@@ -123,7 +124,7 @@ export interface OktaAdapterParams {
 }
 
 export default class OktaAdapter implements AdapterOperations {
-  private createFiltersRunner: () => Required<Filter>
+  private createFiltersRunner: (usersPromise?: Promise<User[]>) => Required<Filter>
   private client: OktaClient
   private userConfig: OktaConfig
   private configInstance?: InstanceElement
@@ -162,7 +163,7 @@ export default class OktaAdapter implements AdapterOperations {
     this.paginator = paginator
 
     const filterContext = {}
-    this.createFiltersRunner = () => (
+    this.createFiltersRunner = usersPromise => (
       filtersRunner(
         {
           client,
@@ -173,6 +174,7 @@ export default class OktaAdapter implements AdapterOperations {
           fetchQuery: this.fetchQuery,
           adapterContext: filterContext,
           adminClient,
+          usersPromise,
         },
         filterCreators,
         objects.concatObjects
@@ -275,11 +277,12 @@ export default class OktaAdapter implements AdapterOperations {
   @logDuration('fetching account configuration')
   async fetch({ progressReporter }: FetchOptions): Promise<FetchResult> {
     log.debug('going to fetch okta account configuration..')
+    const usersPromise = this.userConfig[FETCH_CONFIG]?.convertUsersIds ? getUsers(this.paginator) : undefined
     const { elements, errors, configChanges } = await this.getAllElements(progressReporter)
 
     log.debug('going to run filters on %d fetched elements', elements.length)
     progressReporter.reportProgress({ message: 'Running filters for additional information' })
-    const filterResult = await this.createFiltersRunner().onFetch(elements) || {}
+    const filterResult = await this.createFiltersRunner(usersPromise).onFetch(elements) || {}
 
     const updatedConfig = configChanges && this.configInstance
       ? configUtils.getUpdatedCofigFromConfigChanges({ configChanges, currentConfig: this.configInstance, configType })

--- a/packages/okta-adapter/src/change_validators/user.ts
+++ b/packages/okta-adapter/src/change_validators/user.ts
@@ -22,7 +22,8 @@ import { values } from '@salto-io/lowerdash'
 import { paginate } from '../client/pagination'
 import OktaClient from '../client/client'
 import { OktaConfig, FETCH_CONFIG } from '../config'
-import { USER_MAPPING, getUsers } from '../filters/user'
+import { USER_MAPPING } from '../filters/user'
+import { getUsers } from '../user_utils'
 
 const { isDefined } = values
 const { createPaginator } = clientUtils

--- a/packages/okta-adapter/src/filter.ts
+++ b/packages/okta-adapter/src/filter.ts
@@ -17,6 +17,7 @@ import { ReadOnlyElementsSource, SaltoError, Values } from '@salto-io/adapter-ap
 import { filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import OktaClient from './client/client'
 import { OktaConfig } from './config'
+import { User } from './user_utils'
 
 export const { filtersRunner } = filterUtils
 
@@ -34,6 +35,7 @@ export type FilterAdditionalParams = {
   // and only when needed.
   adapterContext: Values
   adminClient?: OktaClient
+  usersPromise?: Promise<User[]>
 }
 
 export type FilterCreator = filterUtils.FilterCreator<

--- a/packages/okta-adapter/src/filters/group_members.ts
+++ b/packages/okta-adapter/src/filters/group_members.ts
@@ -20,7 +20,7 @@ import { collections } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
 import { GROUP_TYPE_NAME, GROUP_MEMBERSHIP_TYPE_NAME, OKTA } from '../constants'
-import { areUsers, User } from './user'
+import { areUsers, User } from '../user_utils'
 import { FETCH_CONFIG } from '../config'
 
 const log = logger(module)

--- a/packages/okta-adapter/src/filters/user.ts
+++ b/packages/okta-adapter/src/filters/user.ts
@@ -14,39 +14,18 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import Joi from 'joi'
 import { logger } from '@salto-io/logging'
-import { applyFunctionToChangeData, createSchemeGuard, resolvePath, setPath } from '@salto-io/adapter-utils'
+import { applyFunctionToChangeData, resolvePath, setPath } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { Change, getChangeData, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
-import { client as clientUtils } from '@salto-io/adapter-components'
 import { FilterCreator } from '../filter'
 import { ACCESS_POLICY_RULE_TYPE_NAME, AUTHORIZATION_POLICY_RULE, GROUP_RULE_TYPE_NAME, MFA_RULE_TYPE_NAME, PASSWORD_RULE_TYPE_NAME, SIGN_ON_RULE_TYPE_NAME } from '../constants'
 import { FETCH_CONFIG } from '../config'
+import { getUsers } from '../user_utils'
 
 const log = logger(module)
-const { toArrayAsync, awu } = collections.asynciterable
+const { awu } = collections.asynciterable
 const { makeArray } = collections.array
-
-export type User = {
-  id: string
-  profile: {
-    login: string
-  }
-}
-
-const USER_SCHEMA = Joi.object({
-  id: Joi.string().required(),
-  profile: Joi.object({
-    login: Joi.string().required(),
-  }).unknown(true),
-}).unknown(true)
-
-const USERS_RESPONSE_SCHEMA = Joi.array().items(USER_SCHEMA).required()
-
-export const areUsers = createSchemeGuard<User[]>(
-  USERS_RESPONSE_SCHEMA, 'Received an invalid response for the users'
-)
 
 const EXCLUDE_USERS_PATH = ['conditions', 'people', 'users', 'exclude']
 const INCLUDE_USERS_PATH = ['conditions', 'people', 'users', 'include']
@@ -64,22 +43,6 @@ export const USER_MAPPING: Record<string, string[][]> = {
 const isRelevantInstance = (instance: InstanceElement): boolean => (
   Object.keys(USER_MAPPING).includes(instance.elemID.typeName)
 )
-
-export const getUsers = async (paginator: clientUtils.Paginator): Promise<User[]> => {
-  const paginationArgs = {
-    url: '/api/v1/users',
-    paginationField: 'after',
-    // omit credentials and other unnecessary fields from the response
-    headers: { 'Content-Type': 'application/json; okta-response=omitCredentials,omitCredentialsLinks' },
-  }
-  const users = (await toArrayAsync(
-    paginator(paginationArgs, page => makeArray(page) as clientUtils.ResponseValue[])
-  )).flat()
-  if (!areUsers(users)) {
-    return []
-  }
-  return users
-}
 
 const replaceValues = (instance: InstanceElement, mapping: Record<string, string>): void => {
   const paths = USER_MAPPING[instance.elemID.typeName]
@@ -118,7 +81,7 @@ export const replaceValuesForChanges = async (
 /**
  * Replaces user ids with login name, when 'convertUsersIds' config flag is enabled
  */
-const filterCreator: FilterCreator = ({ paginator, config }) => {
+const filterCreator: FilterCreator = ({ paginator, config, usersPromise }) => {
   let userIdToLogin: Record<string, string> = {}
   return {
     name: 'usersFilter',
@@ -127,8 +90,8 @@ const filterCreator: FilterCreator = ({ paginator, config }) => {
         log.debug('Converting user ids was disabled (onFetch)')
         return
       }
-      const users = await getUsers(paginator)
-      if (_.isEmpty(users)) {
+      const users = await usersPromise
+      if (!users || _.isEmpty(users)) {
         log.warn('Could not find any users (onFetch)')
         return
       }

--- a/packages/okta-adapter/src/user_utils.ts
+++ b/packages/okta-adapter/src/user_utils.ts
@@ -1,0 +1,62 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import Joi from 'joi'
+import { logger } from '@salto-io/logging'
+import { createSchemeGuard } from '@salto-io/adapter-utils'
+import { collections } from '@salto-io/lowerdash'
+import { client as clientUtils } from '@salto-io/adapter-components'
+
+const log = logger(module)
+const { toArrayAsync } = collections.asynciterable
+const { makeArray } = collections.array
+
+export type User = {
+   id: string
+   profile: {
+     login: string
+   }
+ }
+
+const USER_SCHEMA = Joi.object({
+  id: Joi.string().required(),
+  profile: Joi.object({
+    login: Joi.string().required(),
+  }).unknown(true),
+}).unknown(true)
+
+const USERS_RESPONSE_SCHEMA = Joi.array().items(USER_SCHEMA).required()
+
+export const areUsers = createSchemeGuard<User[]>(
+  USERS_RESPONSE_SCHEMA, 'Received an invalid response for the users'
+)
+
+export const getUsers = async (paginator: clientUtils.Paginator): Promise<User[]> => {
+  const paginationArgs = {
+    url: '/api/v1/users',
+    paginationField: 'after',
+    // omit credentials and other unnecessary fields from the response
+    headers: { 'Content-Type': 'application/json; okta-response=omitCredentials,omitCredentialsLinks' },
+  }
+  const users = await log.time(async () => (
+    await toArrayAsync(
+      paginator(paginationArgs, page => makeArray(page) as clientUtils.ResponseValue[])
+    )).flat(),
+  'getUsers with pagination')
+  if (!areUsers(users)) {
+    return []
+  }
+  return users
+}

--- a/packages/okta-adapter/test/adapter.test.ts
+++ b/packages/okta-adapter/test/adapter.test.ts
@@ -49,6 +49,13 @@ jest.mock('@salto-io/adapter-components', () => {
   }
 })
 
+
+const mockGetUsers = jest.fn()
+jest.mock('../src/user_utils', () => ({
+  ...jest.requireActual<{}>('../src/user_utils'),
+  getUsers: jest.fn(args => mockGetUsers(args)),
+}))
+
 describe('Okta adapter', () => {
   let getElemIdFunc: ElemIdGetter
   const adapterSetup = (credentials: InstanceElement): AdapterOperations => {
@@ -72,6 +79,7 @@ describe('Okta adapter', () => {
     let mockAxiosAdapter: MockAdapter
 
     beforeEach(async () => {
+      jest.clearAllMocks()
       oktaTestType = new ObjectType({
         elemID: new ElemID(OKTA, 'okta'),
       })
@@ -120,6 +128,12 @@ describe('Okta adapter', () => {
       })
       expect(result.elements).toContain(oktaTestType)
       expect(result.elements).toContain(testInstance)
+    })
+
+    it('should call getUsers if convertUserIds flag is enabled', async () => {
+      const adapter = adapterSetup(createCredentialsInstance({ baseUrl: 'http:/okta.test', token: 't' }))
+      await adapter.fetch({ progressReporter: { reportProgress: () => null } })
+      expect(mockGetUsers).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/packages/okta-adapter/test/filters/user.test.ts
+++ b/packages/okta-adapter/test/filters/user.test.ts
@@ -18,7 +18,7 @@ import { client as clientUtils, filterUtils } from '@salto-io/adapter-components
 import { mockFunction } from '@salto-io/test-utils'
 import { DEFAULT_CONFIG, FETCH_CONFIG } from '../../src/config'
 import { ACCESS_POLICY_RULE_TYPE_NAME, GROUP_RULE_TYPE_NAME, OKTA } from '../../src/constants'
-import userFilter, { getUsers } from '../../src/filters/user'
+import userFilter from '../../src/filters/user'
 import { getFilterParams } from '../utils'
 
 describe('user filter', () => {
@@ -245,41 +245,6 @@ describe('user filter', () => {
           people: { users: { exclude: ['b@a.com'], include: ['a@a.com', 'c@a.com', 'd@a.com'] } },
         },
       })
-    })
-  })
-  describe('getUsers', () => {
-    const mockPaginator = mockFunction<clientUtils.Paginator>()
-      .mockImplementationOnce(async function *get() {
-        yield [
-          { id: '111', profile: { login: 'a@a.com', name: 'a' } },
-          { id: '222', profile: { login: 'b@a.com' } },
-        ]
-      })
-      .mockImplementationOnce(async function *get() {
-        yield [
-          { id: '111', profile: { name: 'a' } },
-          { id: '222', profile: { name: 'b' } },
-        ]
-      })
-    it('it should return a list of users', async () => {
-      const users = await getUsers(mockPaginator)
-      expect(users).toEqual([
-        { id: '111', profile: { login: 'a@a.com', name: 'a' } },
-        { id: '222', profile: { login: 'b@a.com' } },
-      ])
-      expect(mockPaginator).toHaveBeenNthCalledWith(
-        1,
-        {
-          url: '/api/v1/users',
-          headers: { 'Content-Type': 'application/json; okta-response=omitCredentials,omitCredentialsLinks' },
-          paginationField: 'after',
-        },
-        expect.anything()
-      )
-    })
-    it('it should return an empty list if response is invalid', async () => {
-      const users = await getUsers(mockPaginator)
-      expect(users).toEqual([])
     })
   })
 })

--- a/packages/okta-adapter/test/filters/user.test.ts
+++ b/packages/okta-adapter/test/filters/user.test.ts
@@ -20,6 +20,7 @@ import { DEFAULT_CONFIG, FETCH_CONFIG } from '../../src/config'
 import { ACCESS_POLICY_RULE_TYPE_NAME, GROUP_RULE_TYPE_NAME, OKTA } from '../../src/constants'
 import userFilter from '../../src/filters/user'
 import { getFilterParams } from '../utils'
+import { getUsers } from '../../src/user_utils'
 
 describe('user filter', () => {
   type FilterType = filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
@@ -93,7 +94,9 @@ describe('user filter', () => {
           { id: '555', profile: { login: 'd@a.com' } },
         ]
       })
-      filter = userFilter(getFilterParams({ paginator: mockPaginator })) as FilterType
+      filter = userFilter(
+        getFilterParams({ paginator: mockPaginator, usersPromise: getUsers(mockPaginator) })
+      ) as FilterType
       const elements = [groupRuleType, groupRuleInstance, accessPolicyRuleType,
         accessRuleInstance, endUserSupportType, endUserInstance].map(e => e.clone())
       await filter.onFetch(elements)
@@ -138,7 +141,7 @@ describe('user filter', () => {
           { id: '222', profile: { login: 'b@a.com' } },
         ]
       })
-      filter = userFilter(getFilterParams({ paginator: mockPaginator })) as FilterType
+      filter = userFilter(getFilterParams({ paginator: mockPaginator, usersPromise: getUsers(mockPaginator) })) as FilterType
       const elements = [accessRuleInstance.clone(), accessPolicyRuleType.clone()]
       await filter.onFetch(elements)
       const instances = elements.filter(isInstanceElement)

--- a/packages/okta-adapter/test/filters/user.test.ts
+++ b/packages/okta-adapter/test/filters/user.test.ts
@@ -141,7 +141,9 @@ describe('user filter', () => {
           { id: '222', profile: { login: 'b@a.com' } },
         ]
       })
-      filter = userFilter(getFilterParams({ paginator: mockPaginator, usersPromise: getUsers(mockPaginator) })) as FilterType
+      filter = userFilter(getFilterParams({
+        paginator: mockPaginator, usersPromise: getUsers(mockPaginator),
+      })) as FilterType
       const elements = [accessRuleInstance.clone(), accessPolicyRuleType.clone()]
       await filter.onFetch(elements)
       const instances = elements.filter(isInstanceElement)

--- a/packages/okta-adapter/test/user_utils.test.ts
+++ b/packages/okta-adapter/test/user_utils.test.ts
@@ -1,0 +1,54 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { client as clientUtils } from '@salto-io/adapter-components'
+import { mockFunction } from '@salto-io/test-utils'
+import { getUsers } from '../src/user_utils'
+
+describe('getUsers', () => {
+  const mockPaginator = mockFunction<clientUtils.Paginator>()
+    .mockImplementationOnce(async function *get() {
+      yield [
+        { id: '111', profile: { login: 'a@a.com', name: 'a' } },
+        { id: '222', profile: { login: 'b@a.com' } },
+      ]
+    })
+    .mockImplementationOnce(async function *get() {
+      yield [
+        { id: '111', profile: { name: 'a' } },
+        { id: '222', profile: { name: 'b' } },
+      ]
+    })
+  it('it should return a list of users', async () => {
+    const users = await getUsers(mockPaginator)
+    expect(users).toEqual([
+      { id: '111', profile: { login: 'a@a.com', name: 'a' } },
+      { id: '222', profile: { login: 'b@a.com' } },
+    ])
+    expect(mockPaginator).toHaveBeenNthCalledWith(
+      1,
+      {
+        url: '/api/v1/users',
+        headers: { 'Content-Type': 'application/json; okta-response=omitCredentials,omitCredentialsLinks' },
+        paginationField: 'after',
+      },
+      expect.anything()
+    )
+  })
+  it('it should return an empty list if response is invalid', async () => {
+    const users = await getUsers(mockPaginator)
+    expect(users).toEqual([])
+  })
+})


### PR DESCRIPTION
This is part of an effort to improve fetch times in Okta

---

Until now, we fetched users data in filter. as responses are paginated (max page size 200), in envs with many users we need to make many requests to fetch this data, which we did one-by-one

when initiating getUsers call earlier in fetch flow, we can make API call while we fetch this.

measured with 2000 users and total fetch time improve in 30~ seconds

I only made this change in fetch, LMK if you think we should do the same for deploy

_Release Notes_: 
None

---
_User Notifications_: 
None
