### PR TITLE
SALTO-5232: Improve performance of filtered plan

### DIFF
--- a/packages/cli/src/commands/env.ts
+++ b/packages/cli/src/commands/env.ts
@@ -115,7 +115,7 @@ export const diffAction: WorkspaceCommandAction<EnvDiffArgs> = async ({
     toEnv,
     hidden,
     state,
-    actualAccounts,
+    accounts === undefined ? undefined : actualAccounts,
     validSelectors,
   )
   outputLine(await formatEnvDiff(changes, detailedPlan, toEnv, fromEnv), output)

--- a/packages/cli/test/commands/diff.test.ts
+++ b/packages/cli/test/commands/diff.test.ts
@@ -84,7 +84,7 @@ describe('diff command', () => {
       expect(result).toBe(CliExitCode.Success)
     })
     it('should invoke the diff api command', async () => {
-      expect(diff).toHaveBeenCalledWith(workspace, 'active', 'inactive', false, false, workspace.accounts(), [])
+      expect(diff).toHaveBeenCalledWith(workspace, 'active', 'inactive', false, false, undefined, [])
     })
   })
 
@@ -110,7 +110,7 @@ describe('diff command', () => {
       expect(result).toBe(CliExitCode.Success)
     })
     it('should invoke the diff api command', async () => {
-      expect(diff).toHaveBeenCalledWith(workspace, 'active', 'inactive', true, false, workspace.accounts(), [])
+      expect(diff).toHaveBeenCalledWith(workspace, 'active', 'inactive', true, false, undefined, [])
     })
   })
 
@@ -136,7 +136,7 @@ describe('diff command', () => {
       expect(result).toBe(CliExitCode.Success)
     })
     it('should invoke the diff api command', async () => {
-      expect(diff).toHaveBeenCalledWith(workspace, 'active', 'inactive', false, true, workspace.accounts(), [])
+      expect(diff).toHaveBeenCalledWith(workspace, 'active', 'inactive', false, true, undefined, [])
     })
   })
 
@@ -165,7 +165,7 @@ describe('diff command', () => {
     })
     it('should invoke the diff api command', async () => {
       expect(diff).toHaveBeenCalledWith(workspace, 'active', 'inactive',
-        false, true, workspace.accounts(), expectElementSelector(regex))
+        false, true, undefined, expectElementSelector(regex))
     })
   })
 

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -593,7 +593,7 @@ export async function diff(
   elementSelectors: ElementSelector[] = [],
   resultType: 'changes' | 'detailedChanges' = 'detailedChanges'
 ): Promise<LocalChange[] | ChangeWithDetails[]> {
-  const diffAccounts = accountFilters ?? workspace.accounts()
+  const accountIDFilter = accountFilters === undefined ? undefined : [shouldElementBeIncluded(accountFilters)]
   const fromElements = useState
     ? workspace.state(fromEnv)
     : await workspace.elements(includeHidden, fromEnv)
@@ -607,7 +607,7 @@ export async function diff(
       fromElements,
       await workspace.getReferenceSourcesIndex(),
       elementSelectors,
-      [shouldElementBeIncluded(diffAccounts)],
+      accountIDFilter,
       'changes'
     )
   }
@@ -617,7 +617,7 @@ export async function diff(
     fromElements,
     await workspace.getReferenceSourcesIndex(),
     elementSelectors,
-    [shouldElementBeIncluded(diffAccounts)],
+    accountIDFilter,
     'detailedChanges'
   )
   return diffChanges.map(change => ({ change, serviceChanges: [change] }))

--- a/packages/core/src/core/plan/plan.ts
+++ b/packages/core/src/core/plan/plan.ts
@@ -314,12 +314,16 @@ const addDifferentElements = (
     }
     return elementPair
   }
-  const getFilteredElements = async (source: ReadOnlyElementsSource):
-    Promise<AsyncIterable<ChangeDataType>> =>
-    (awu(await source.getAll()).filter(async elem =>
-      _.every(await Promise.all(
-        topLevelFilters.map(filter => filter(elem.elemID))
-      )))) as AsyncIterable<ChangeDataType>
+  const getFilteredElements = async (
+    source: ReadOnlyElementsSource
+  ): Promise<AsyncIterable<ChangeDataType>> => (
+    topLevelFilters.length === 0
+      ? await source.getAll()
+      : awu(await source.list())
+        .filter(async id => _.every(await Promise.all(topLevelFilters.map(filter => filter(id)))))
+        .map(id => source.get(id))
+  ) as AsyncIterable<ChangeDataType>
+
   const cmp = (e1: ChangeDataType, e2: ChangeDataType): number => {
     if (e1.elemID.getFullName() < e2.elemID.getFullName()) {
       return -1


### PR DESCRIPTION
When calculating a plan that is filiterd by top level ID, perform the filtering before reading and deserializing the element

---

_Additional context for reviewer_

---
_Release Notes_: 
Core:
- Improved performance for calculating plan / env diff when the diff is filtered

---
_User Notifications_: 
_None_