### PR TITLE
SALTO-5239: make creation of custom_object_field_option to use nacl case

### DIFF
--- a/packages/zendesk-adapter/src/filters/custom_field_options/custom_object_field_options.ts
+++ b/packages/zendesk-adapter/src/filters/custom_field_options/custom_object_field_options.ts
@@ -24,7 +24,7 @@ import {
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
-import { inspectValue } from '@salto-io/adapter-utils'
+import { inspectValue, naclCase, pathNaclCase } from '@salto-io/adapter-utils'
 import {
   CUSTOM_FIELD_OPTIONS_FIELD_NAME,
   CUSTOM_OBJECT_FIELD_OPTIONS_TYPE_NAME,
@@ -82,12 +82,12 @@ const onFetch = async (elements: Element[]): Promise<void> => {
       return
     }
     const optionInstances = options.map(option => {
-      const instanceName = `${customObjectField.elemID.name}__${option.value}`
+      const instanceName = naclCase(`${customObjectField.elemID.name}__${option.value}`)
       return new InstanceElement(
         instanceName,
         customObjectFieldOptionType,
         option,
-        [ZENDESK, RECORDS_PATH, CUSTOM_OBJECT_FIELD_OPTIONS_TYPE_NAME, instanceName],
+        [ZENDESK, RECORDS_PATH, CUSTOM_OBJECT_FIELD_OPTIONS_TYPE_NAME, pathNaclCase(instanceName)],
         { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(customObjectField.elemID, customObjectField)] }
       )
     })

--- a/packages/zendesk-adapter/test/filters/custom_objects/custom_object_field_options.test.ts
+++ b/packages/zendesk-adapter/test/filters/custom_objects/custom_object_field_options.test.ts
@@ -24,6 +24,7 @@ import {
   toChange,
   Value,
 } from '@salto-io/adapter-api'
+import { naclCase, pathNaclCase } from '@salto-io/adapter-utils'
 import filterCreator, {
   customObjectFieldOptionType,
 } from '../../../src/filters/custom_field_options/custom_object_field_options'
@@ -38,19 +39,22 @@ import {
 const { RECORDS_PATH } = elementsUtils
 type FilterType = filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'deploy' | 'onDeploy'>
 
-const createOptionsValue = (id: number): Value => ({
+const createOptionsValue = (id: number, value?: string): Value => ({
   id,
   name: id.toString(),
   raw_name: id.toString().repeat(2),
-  value: id.toString().repeat(3),
+  value: value ?? id.toString().repeat(3),
 })
 
-const createOptionInstance = ({ id, value }: {id: number; value: string}): InstanceElement => new InstanceElement(
-  `customObjectField__${value.toString()}`,
-  customObjectFieldOptionType,
-  createOptionsValue(id),
-  [ZENDESK, RECORDS_PATH, CUSTOM_OBJECT_FIELD_OPTIONS_TYPE_NAME, `customObjectField__${value.toString()}`],
-)
+const createOptionInstance = ({ id, value }: {id: number; value: string}): InstanceElement => {
+  const test = pathNaclCase(naclCase(`customObjectField__${value.toString()}`))
+  return new InstanceElement(
+    naclCase(`customObjectField__${value.toString()}`),
+    customObjectFieldOptionType,
+    createOptionsValue(id, value),
+    [ZENDESK, RECORDS_PATH, CUSTOM_OBJECT_FIELD_OPTIONS_TYPE_NAME, test],
+  )
+}
 
 describe('customObjectFieldOptionsFilter', () => {
   const customObjectFieldOptionsFilter = filterCreator(createFilterCreatorParams({})) as FilterType
@@ -60,7 +64,7 @@ describe('customObjectFieldOptionsFilter', () => {
       new ObjectType({ elemID: new ElemID(ZENDESK, CUSTOM_OBJECT_FIELD_TYPE_NAME) }),
       {
         [CUSTOM_FIELD_OPTIONS_FIELD_NAME]: [
-          createOptionsValue(1),
+          createOptionsValue(1, '!!'),
           createOptionsValue(2),
           createOptionsValue(3),
         ],
@@ -74,7 +78,7 @@ describe('customObjectFieldOptionsFilter', () => {
     expect(elements).toHaveLength(5)
     expect(elements[0]).toMatchObject(customObjectField)
     expect(elements[1]).toMatchObject(invalidCustomObjectField)
-    expect(elements[2]).toMatchObject(createOptionInstance(createOptionsValue(1)))
+    expect(elements[2]).toMatchObject(createOptionInstance(createOptionsValue(1, '!!')))
     expect(elements[3]).toMatchObject(createOptionInstance(createOptionsValue(2)))
     expect(elements[4]).toMatchObject(createOptionInstance(createOptionsValue(3)))
     expect(elements[2].annotations[CORE_ANNOTATIONS.PARENT][0]).toMatchObject(


### PR DESCRIPTION
make creation of custom_object_field_option to use nacl case

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* make creation of custom_object_field_option to use nacl case

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
