### PR TITLE
SALTO-5241: Change object type order name

### DIFF
--- a/packages/jira-adapter/src/filters/assets/assets_object_type_order.ts
+++ b/packages/jira-adapter/src/filters/assets/assets_object_type_order.ts
@@ -16,7 +16,7 @@
 import _ from 'lodash'
 import { BuiltinTypes, CORE_ANNOTATIONS, createSaltoElementError, Element, ElemID, getChangeData, InstanceElement, isAdditionChange, isInstanceChange, isInstanceElement, isModificationChange, isReferenceExpression, ListType, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
 import { elements as adapterElements } from '@salto-io/adapter-components'
-import { getParent, naclCase, pathNaclCase } from '@salto-io/adapter-utils'
+import { getParent, invertNaclCase, naclCase, pathNaclCase } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import { deployChanges } from '../../deployment/standard_deployment'
@@ -77,7 +77,7 @@ const createAssetsObjectTypeOrder = (
     log.error(`Failed to create ${OBJECT_TYPE_ORDER_TYPE} for ${treeParent.elemID.getFullName()} because it's parent is not ${OBJECT_SCHEMA_TYPE}`)
     return undefined
   }
-  const name = naclCase(`${treeParent.elemID.name}_order`)
+  const name = naclCase(`${invertNaclCase(treeParent.elemID.name)}_order`)
   const subFolder = treeParent.elemID.typeName === OBJECT_TYPE_TYPE ? ['childOrder'] : ['objectTypes', 'childOrder']
   return new InstanceElement(
     name,

--- a/packages/jira-adapter/src/filters/assets/assets_object_type_order.ts
+++ b/packages/jira-adapter/src/filters/assets/assets_object_type_order.ts
@@ -77,7 +77,7 @@ const createAssetsObjectTypeOrder = (
     log.error(`Failed to create ${OBJECT_TYPE_ORDER_TYPE} for ${treeParent.elemID.getFullName()} because it's parent is not ${OBJECT_SCHEMA_TYPE}`)
     return undefined
   }
-  const name = naclCase(`${treeParent.value.name}_order`)
+  const name = naclCase(`${treeParent.elemID.name}_order`)
   const subFolder = treeParent.elemID.typeName === OBJECT_TYPE_TYPE ? ['childOrder'] : ['objectTypes', 'childOrder']
   return new InstanceElement(
     name,

--- a/packages/jira-adapter/test/filters/assets/assets_object_type_order.test.ts
+++ b/packages/jira-adapter/test/filters/assets/assets_object_type_order.test.ts
@@ -57,7 +57,7 @@ describe('assetsObjectTypeOrderFilter', () => {
     [JIRA, elementUtils.RECORDS_PATH, OBJECT_SCHEMA_TYPE, 'assetsSchema'],
   )
   const parentObjectTypeInstance = new InstanceElement(
-    'parentObjectTypeInstance',
+    'parent_Object_Type_Instance@uuu',
     createEmptyType(OBJECT_TYPE_TYPE),
     {
       id: 'p1',
@@ -93,7 +93,7 @@ describe('assetsObjectTypeOrderFilter', () => {
         .filter(isInstanceElement)
         .filter(e => e.elemID.typeName === OBJECT_TYPE_ORDER_TYPE)
       expect(orderInstances[1]).toBeDefined()
-      expect(orderInstances[1].elemID.name).toEqual('parentObjectTypeInstance_order')
+      expect(orderInstances[1].elemID.name).toEqual('parent_Object_Type_Instance_order')
       expect(orderInstances[1].value.objectTypes).toEqual([
         new ReferenceExpression(assetsObjectTypeInstanceOne.elemID, assetsObjectTypeInstanceOne),
         new ReferenceExpression(assetsObjectTypeInstanceTwo.elemID, assetsObjectTypeInstanceTwo),

--- a/packages/jira-adapter/test/filters/assets/assets_object_type_order.test.ts
+++ b/packages/jira-adapter/test/filters/assets/assets_object_type_order.test.ts
@@ -93,7 +93,7 @@ describe('assetsObjectTypeOrderFilter', () => {
         .filter(isInstanceElement)
         .filter(e => e.elemID.typeName === OBJECT_TYPE_ORDER_TYPE)
       expect(orderInstances[1]).toBeDefined()
-      expect(orderInstances[1].elemID.name).toEqual('AssetsObjectTypeP1_order')
+      expect(orderInstances[1].elemID.name).toEqual('parentObjectTypeInstance_order')
       expect(orderInstances[1].value.objectTypes).toEqual([
         new ReferenceExpression(assetsObjectTypeInstanceOne.elemID, assetsObjectTypeInstanceOne),
         new ReferenceExpression(assetsObjectTypeInstanceTwo.elemID, assetsObjectTypeInstanceTwo),


### PR DESCRIPTION
In this PR I changed the objectTypeOrder name

---

_Additional context for reviewer_
There can be more than one ObjectType, as long as they are in different branches of the tree. The name of their Order is derived from its name and the name of the path should also be added

---
_Release Notes_: 
_Jira Adpater:_
Changed objectTypeOrder instance name. 


---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
