### PR TITLE
SALTO-5233: Fetch referenced users only (Okta)

### DIFF
--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { Element, FetchResult, AdapterOperations, DeployResult, InstanceElement, TypeMap, isObjectType, FetchOptions, DeployOptions, Change, isInstanceChange, ElemIdGetter, ReadOnlyElementsSource, getChangeData, ProgressReporter } from '@salto-io/adapter-api'
+import { Element, FetchResult, AdapterOperations, DeployResult, InstanceElement, TypeMap, isObjectType, FetchOptions, DeployOptions, Change, isInstanceChange, ElemIdGetter, ReadOnlyElementsSource, getChangeData, ProgressReporter, isInstanceElement } from '@salto-io/adapter-api'
 import { config as configUtils, elements as elementUtils, client as clientUtils } from '@salto-io/adapter-components'
 import { applyFunctionToChangeData, logDuration, resolveChangeElement, restoreChangeElement } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
@@ -57,7 +57,7 @@ import groupPushFilter from './filters/group_push'
 import addImportantValues from './filters/add_important_values'
 import { APP_LOGO_TYPE_NAME, BRAND_LOGO_TYPE_NAME, FAV_ICON_TYPE_NAME, OKTA } from './constants'
 import { getLookUpName } from './reference_mapping'
-import { User, getUsers } from './user_utils'
+import { User, getUsers, getUsersFromInstances } from './user_utils'
 
 const { awu } = collections.asynciterable
 
@@ -277,8 +277,13 @@ export default class OktaAdapter implements AdapterOperations {
   @logDuration('fetching account configuration')
   async fetch({ progressReporter }: FetchOptions): Promise<FetchResult> {
     log.debug('going to fetch okta account configuration..')
-    const usersPromise = this.userConfig[FETCH_CONFIG]?.convertUsersIds ? getUsers(this.paginator) : undefined
+    const { convertUsersIds, getUsersStrategy } = this.userConfig[FETCH_CONFIG]
     const { elements, errors, configChanges } = await this.getAllElements(progressReporter)
+
+    const usersToFetch = getUsersFromInstances(elements.filter(isInstanceElement))
+    const usersPromise = convertUsersIds
+      ? getUsers(this.paginator, getUsersStrategy === 'searchQuery' ? { userIds: usersToFetch, property: 'id' } : undefined)
+      : undefined
 
     log.debug('going to run filters on %d fetched elements', elements.length)
     progressReporter.reportProgress({ message: 'Running filters for additional information' })

--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -280,9 +280,13 @@ export default class OktaAdapter implements AdapterOperations {
     const { convertUsersIds, getUsersStrategy } = this.userConfig[FETCH_CONFIG]
     const { elements, errors, configChanges } = await this.getAllElements(progressReporter)
 
-    const usersToFetch = getUsersFromInstances(elements.filter(isInstanceElement))
     const usersPromise = convertUsersIds
-      ? getUsers(this.paginator, getUsersStrategy === 'searchQuery' ? { userIds: usersToFetch, property: 'id' } : undefined)
+      ? getUsers(
+        this.paginator,
+        getUsersStrategy === 'searchQuery'
+          ? { userIds: getUsersFromInstances(elements.filter(isInstanceElement)), property: 'id' }
+          : undefined
+      )
       : undefined
 
     log.debug('going to run filters on %d fetched elements', elements.length)

--- a/packages/okta-adapter/src/change_validators/user.ts
+++ b/packages/okta-adapter/src/change_validators/user.ts
@@ -22,7 +22,7 @@ import { values } from '@salto-io/lowerdash'
 import { paginate } from '../client/pagination'
 import OktaClient from '../client/client'
 import { OktaConfig, FETCH_CONFIG } from '../config'
-import { getUsers, getUsersFromInstances, USER_MAPPING } from '../user_utils'
+import { DEFAULT_CONVERT_USERS_IDS_VALUE, getUsers, getUsersFromInstances, USER_MAPPING } from '../user_utils'
 
 const { isDefined } = values
 const { createPaginator } = clientUtils
@@ -34,7 +34,7 @@ const log = logger(module)
 export const usersValidator: (client: OktaClient, config: OktaConfig) =>
     ChangeValidator = (client, config) => async changes => {
       const { convertUsersIds, getUsersStrategy } = config[FETCH_CONFIG]
-      if (!(convertUsersIds ?? true)) {
+      if (!(convertUsersIds ?? DEFAULT_CONVERT_USERS_IDS_VALUE)) {
         log.debug('Skipped usersValidator because convertUsersIds config flag is disabled')
         return []
       }

--- a/packages/okta-adapter/src/change_validators/user.ts
+++ b/packages/okta-adapter/src/change_validators/user.ts
@@ -33,7 +33,7 @@ const log = logger(module)
 */
 export const usersValidator: (client: OktaClient, config: OktaConfig) =>
     ChangeValidator = (client, config) => async changes => {
-      const { convertUsersIds, getUsersStrategy } = config[FETCH_CONFIG]
+      const { convertUsersIds } = config[FETCH_CONFIG]
       if (!(convertUsersIds ?? DEFAULT_CONVERT_USERS_IDS_VALUE)) {
         log.debug('Skipped usersValidator because convertUsersIds config flag is disabled')
         return []
@@ -57,7 +57,7 @@ export const usersValidator: (client: OktaClient, config: OktaConfig) =>
 
       const users = await getUsers(
         paginator,
-        getUsersStrategy === 'searchQuery' ? { userIds: usersToFetch, property: 'profile.login' } : undefined
+        { userIds: usersToFetch, property: 'profile.login' },
       )
 
       const existingUsers = new Set(users.map(user => user.profile.login))

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -14,10 +14,11 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { ElemID, CORE_ANNOTATIONS, ActionName, BuiltinTypes, ObjectType, Field } from '@salto-io/adapter-api'
+import { ElemID, CORE_ANNOTATIONS, ActionName, BuiltinTypes, ObjectType, Field, createRestriction } from '@salto-io/adapter-api'
 import { createMatchingObjectType } from '@salto-io/adapter-utils'
 import { client as clientUtils, config as configUtils, elements } from '@salto-io/adapter-components'
 import { ACCESS_POLICY_TYPE_NAME, CUSTOM_NAME_FIELD, IDP_POLICY_TYPE_NAME, MFA_POLICY_TYPE_NAME, OKTA, PASSWORD_POLICY_TYPE_NAME, PROFILE_ENROLLMENT_POLICY_TYPE_NAME, SIGN_ON_POLICY_TYPE_NAME, AUTOMATION_TYPE_NAME } from './constants'
+import { DEFAULT_CONVERT_USERS_IDS_VALUE, DEFAULT_GET_USERS_STRATEGY } from './user_utils'
 
 type UserDeployConfig = configUtils.UserDeployConfig
 const {
@@ -1764,11 +1765,11 @@ export const DEFAULT_CONFIG: OktaConfig = {
   [FETCH_CONFIG]: {
     ...elements.query.INCLUDE_ALL_CONFIG,
     hideTypes: true,
-    convertUsersIds: true,
+    convertUsersIds: DEFAULT_CONVERT_USERS_IDS_VALUE,
     enableMissingReferences: true,
     includeGroupMemberships: false,
     includeProfileMappingProperties: true,
-    getUsersStrategy: 'searchQuery',
+    getUsersStrategy: DEFAULT_GET_USERS_STRATEGY,
   },
   [API_DEFINITIONS_CONFIG]: DEFAULT_API_DEFINITIONS,
   [PRIVATE_API_DEFINITIONS_CONFIG]: DUCKTYPE_API_DEFINITIONS,
@@ -1849,7 +1850,12 @@ export const configType = createMatchingObjectType<Partial<OktaConfig>>({
           enableMissingReferences: { refType: BuiltinTypes.BOOLEAN },
           includeGroupMemberships: { refType: BuiltinTypes.BOOLEAN },
           includeProfileMappingProperties: { refType: BuiltinTypes.BOOLEAN },
-          getUsersStrategy: { refType: BuiltinTypes.STRING },
+          getUsersStrategy: {
+            refType: BuiltinTypes.STRING,
+            annotations: {
+              [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values: ['searchQuery', 'allUsers'] }),
+            },
+          },
         }
       ),
     },

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -40,11 +40,13 @@ export type OktaClientConfig = clientUtils.ClientBaseConfig<OktaClientRateLimitC
 }
 export type OktaStatusActionName = 'activate' | 'deactivate'
 export type OktaActionName = ActionName | OktaStatusActionName
+type GetUsersStrategy = 'searchQuery' | 'allUsers'
 export type OktaFetchConfig = configUtils.UserFetchConfig & {
   convertUsersIds?: boolean
   enableMissingReferences?: boolean
   includeGroupMemberships?: boolean
   includeProfileMappingProperties?: boolean
+  getUsersStrategy?: GetUsersStrategy
 }
 
 export type OktaSwaggerApiConfig = configUtils.AdapterSwaggerApiConfig<OktaActionName>
@@ -1766,6 +1768,7 @@ export const DEFAULT_CONFIG: OktaConfig = {
     enableMissingReferences: true,
     includeGroupMemberships: false,
     includeProfileMappingProperties: true,
+    getUsersStrategy: 'searchQuery',
   },
   [API_DEFINITIONS_CONFIG]: DEFAULT_API_DEFINITIONS,
   [PRIVATE_API_DEFINITIONS_CONFIG]: DUCKTYPE_API_DEFINITIONS,
@@ -1846,6 +1849,7 @@ export const configType = createMatchingObjectType<Partial<OktaConfig>>({
           enableMissingReferences: { refType: BuiltinTypes.BOOLEAN },
           includeGroupMemberships: { refType: BuiltinTypes.BOOLEAN },
           includeProfileMappingProperties: { refType: BuiltinTypes.BOOLEAN },
+          getUsersStrategy: { refType: BuiltinTypes.STRING },
         }
       ),
     },
@@ -1873,6 +1877,7 @@ export const configType = createMatchingObjectType<Partial<OktaConfig>>({
       CLIENT_CONFIG,
       `${FETCH_CONFIG}.hideTypes`,
       `${FETCH_CONFIG}.enableMissingReferences`,
+      `${FETCH_CONFIG}.getUsersStrategy`
     ),
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },

--- a/packages/okta-adapter/src/filters/user.ts
+++ b/packages/okta-adapter/src/filters/user.ts
@@ -90,7 +90,7 @@ const filterCreator: FilterCreator = ({ paginator, config, usersPromise }) => {
       })
     },
     preDeploy: async (changes: Change<InstanceElement>[]) => {
-      const { convertUsersIds, getUsersStrategy } = config[FETCH_CONFIG]
+      const { convertUsersIds } = config[FETCH_CONFIG]
       if (!(convertUsersIds ?? DEFAULT_CONVERT_USERS_IDS_VALUE)) {
         log.debug('Converting user ids was disabled (preDeploy)')
         return
@@ -102,7 +102,7 @@ const filterCreator: FilterCreator = ({ paginator, config, usersPromise }) => {
       }
       const users = await getUsers(
         paginator,
-        getUsersStrategy === 'searchQuery' ? { userIds: usersToReplace, property: 'profile.login' } : undefined
+        { userIds: usersToReplace, property: 'profile.login' },
       )
       if (_.isEmpty(users)) {
         log.warn('Could not find any users (preDeploy)')

--- a/packages/okta-adapter/src/filters/user.ts
+++ b/packages/okta-adapter/src/filters/user.ts
@@ -20,7 +20,7 @@ import { collections } from '@salto-io/lowerdash'
 import { Change, getChangeData, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
 import { FilterCreator } from '../filter'
 import { FETCH_CONFIG } from '../config'
-import { getUsers, USER_MAPPING, getUsersFromInstances } from '../user_utils'
+import { getUsers, USER_MAPPING, getUsersFromInstances, DEFAULT_CONVERT_USERS_IDS_VALUE } from '../user_utils'
 
 const log = logger(module)
 const { awu } = collections.asynciterable
@@ -72,7 +72,7 @@ const filterCreator: FilterCreator = ({ paginator, config, usersPromise }) => {
   return {
     name: 'usersFilter',
     onFetch: async elements => {
-      if (config[FETCH_CONFIG].convertUsersIds === false) {
+      if (!(config[FETCH_CONFIG].convertUsersIds ?? DEFAULT_CONVERT_USERS_IDS_VALUE)) {
         log.debug('Converting user ids was disabled (onFetch)')
         return
       }
@@ -91,7 +91,7 @@ const filterCreator: FilterCreator = ({ paginator, config, usersPromise }) => {
     },
     preDeploy: async (changes: Change<InstanceElement>[]) => {
       const { convertUsersIds, getUsersStrategy } = config[FETCH_CONFIG]
-      if (convertUsersIds === false) {
+      if (!(convertUsersIds ?? DEFAULT_CONVERT_USERS_IDS_VALUE)) {
         log.debug('Converting user ids was disabled (preDeploy)')
         return
       }
@@ -118,7 +118,7 @@ const filterCreator: FilterCreator = ({ paginator, config, usersPromise }) => {
       await replaceValuesForChanges(changes, loginToUserId)
     },
     onDeploy: async (changes: Change<InstanceElement>[]) => {
-      if (config[FETCH_CONFIG].convertUsersIds === false) {
+      if (!(config[FETCH_CONFIG].convertUsersIds ?? DEFAULT_CONVERT_USERS_IDS_VALUE)) {
         log.debug('Converting user ids was disabled (onDeploy)')
         return
       }

--- a/packages/okta-adapter/src/filters/user.ts
+++ b/packages/okta-adapter/src/filters/user.ts
@@ -19,26 +19,12 @@ import { applyFunctionToChangeData, resolvePath, setPath } from '@salto-io/adapt
 import { collections } from '@salto-io/lowerdash'
 import { Change, getChangeData, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
 import { FilterCreator } from '../filter'
-import { ACCESS_POLICY_RULE_TYPE_NAME, AUTHORIZATION_POLICY_RULE, GROUP_RULE_TYPE_NAME, MFA_RULE_TYPE_NAME, PASSWORD_RULE_TYPE_NAME, SIGN_ON_RULE_TYPE_NAME } from '../constants'
 import { FETCH_CONFIG } from '../config'
-import { getUsers } from '../user_utils'
+import { getUsers, USER_MAPPING, getUsersFromInstances } from '../user_utils'
 
 const log = logger(module)
 const { awu } = collections.asynciterable
 const { makeArray } = collections.array
-
-const EXCLUDE_USERS_PATH = ['conditions', 'people', 'users', 'exclude']
-const INCLUDE_USERS_PATH = ['conditions', 'people', 'users', 'include']
-
-export const USER_MAPPING: Record<string, string[][]> = {
-  [GROUP_RULE_TYPE_NAME]: [EXCLUDE_USERS_PATH],
-  [ACCESS_POLICY_RULE_TYPE_NAME]: [EXCLUDE_USERS_PATH, INCLUDE_USERS_PATH],
-  [PASSWORD_RULE_TYPE_NAME]: [EXCLUDE_USERS_PATH],
-  [SIGN_ON_RULE_TYPE_NAME]: [EXCLUDE_USERS_PATH],
-  [MFA_RULE_TYPE_NAME]: [EXCLUDE_USERS_PATH],
-  [AUTHORIZATION_POLICY_RULE]: [INCLUDE_USERS_PATH],
-  EndUserSupport: [['technicalContactId']],
-}
 
 const isRelevantInstance = (instance: InstanceElement): boolean => (
   Object.keys(USER_MAPPING).includes(instance.elemID.typeName)
@@ -104,16 +90,20 @@ const filterCreator: FilterCreator = ({ paginator, config, usersPromise }) => {
       })
     },
     preDeploy: async (changes: Change<InstanceElement>[]) => {
-      if (config[FETCH_CONFIG].convertUsersIds === false) {
+      const { convertUsersIds, getUsersStrategy } = config[FETCH_CONFIG]
+      if (convertUsersIds === false) {
         log.debug('Converting user ids was disabled (preDeploy)')
         return
       }
-      const relevantChanges = changes
-        .filter(change => isRelevantInstance(getChangeData(change)))
-      if (_.isEmpty(relevantChanges)) {
+      const usersToReplace = getUsersFromInstances(changes.map(getChangeData))
+
+      if (_.isEmpty(usersToReplace)) {
         return
       }
-      const users = await getUsers(paginator)
+      const users = await getUsers(
+        paginator,
+        getUsersStrategy === 'searchQuery' ? { userIds: usersToReplace, property: 'profile.login' } : undefined
+      )
       if (_.isEmpty(users)) {
         log.warn('Could not find any users (preDeploy)')
         return

--- a/packages/okta-adapter/src/user_utils.ts
+++ b/packages/okta-adapter/src/user_utils.ts
@@ -26,6 +26,8 @@ const log = logger(module)
 const { toArrayAsync } = collections.asynciterable
 const { makeArray } = collections.array
 
+export const DEFAULT_CONVERT_USERS_IDS_VALUE = true
+export const DEFAULT_GET_USERS_STRATEGY = 'searchQuery'
 const USER_CHUNK_SIZE = 200
 
 export type User = {
@@ -68,9 +70,11 @@ export const USER_MAPPING: Record<string, string[][]> = {
   EndUserSupport: [['technicalContactId']],
 }
 
+const TYPES_WITH_USERS = new Set(Object.keys(USER_MAPPING))
+
 export const getUsersFromInstances = (instances: InstanceElement[]): string[] => _.uniq(
   instances
-    .filter(instance => Object.keys(USER_MAPPING).includes(instance.elemID.typeName))
+    .filter(instance => TYPES_WITH_USERS.has(instance.elemID.typeName))
     .flatMap(instance => {
       const userPaths = USER_MAPPING[instance.elemID.typeName]
       return userPaths.flatMap(path => resolvePath(instance, instance.elemID.createNestedID(...path)))

--- a/packages/okta-adapter/test/user_utils.test.ts
+++ b/packages/okta-adapter/test/user_utils.test.ts
@@ -18,37 +18,76 @@ import { mockFunction } from '@salto-io/test-utils'
 import { getUsers } from '../src/user_utils'
 
 describe('getUsers', () => {
-  const mockPaginator = mockFunction<clientUtils.Paginator>()
-    .mockImplementationOnce(async function *get() {
-      yield [
+  let mockPaginator: clientUtils.Paginator
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockPaginator = mockFunction<clientUtils.Paginator>()
+      .mockImplementation(async function *get() {
+        yield [
+          { id: '111', profile: { login: 'a@a.com', name: 'a' } },
+          { id: '222', profile: { login: 'b@a.com' } },
+          { id: '333', profile: { login: 'c@a.com' } },
+        ]
+      })
+  })
+  describe('when called with allUsers strategy', () => {
+    it('it should return a list of users', async () => {
+      const users = await getUsers(mockPaginator)
+      expect(users).toEqual([
         { id: '111', profile: { login: 'a@a.com', name: 'a' } },
         { id: '222', profile: { login: 'b@a.com' } },
-      ]
+        { id: '333', profile: { login: 'c@a.com' } },
+      ])
+      expect(mockPaginator).toHaveBeenNthCalledWith(
+        1,
+        {
+          url: '/api/v1/users',
+          headers: { 'Content-Type': 'application/json; okta-response=omitCredentials,omitCredentialsLinks' },
+          paginationField: 'after',
+        },
+        expect.anything()
+      )
     })
-    .mockImplementationOnce(async function *get() {
-      yield [
-        { id: '111', profile: { name: 'a' } },
-        { id: '222', profile: { name: 'b' } },
-      ]
+    it('it should return an empty list if response is invalid', async () => {
+      mockPaginator = mockFunction<clientUtils.Paginator>().mockImplementationOnce(async function *get() {
+        yield [
+          { id: '111', profile: { name: 'a' } },
+          { id: '222', profile: { name: 'b' } },
+        ]
+      })
+      const users = await getUsers(mockPaginator)
+      expect(users).toEqual([])
     })
-  it('it should return a list of users', async () => {
-    const users = await getUsers(mockPaginator)
-    expect(users).toEqual([
-      { id: '111', profile: { login: 'a@a.com', name: 'a' } },
-      { id: '222', profile: { login: 'b@a.com' } },
-    ])
-    expect(mockPaginator).toHaveBeenNthCalledWith(
-      1,
-      {
-        url: '/api/v1/users',
-        headers: { 'Content-Type': 'application/json; okta-response=omitCredentials,omitCredentialsLinks' },
-        paginationField: 'after',
-      },
-      expect.anything()
-    )
   })
-  it('it should return an empty list if response is invalid', async () => {
-    const users = await getUsers(mockPaginator)
-    expect(users).toEqual([])
+  describe('when called with searchQuery strategy', () => {
+    it('it should request users by id', async () => {
+      const userIds = ['111', '333']
+      await getUsers(mockPaginator, { userIds, property: 'id' })
+      expect(mockPaginator).toHaveBeenNthCalledWith(
+        1,
+        {
+          url: '/api/v1/users',
+          headers: { 'Content-Type': 'application/json; okta-response=omitCredentials,omitCredentialsLinks' },
+          paginationField: 'after',
+          queryParams: { search: 'id eq "111" or id eq "333"' },
+        },
+        expect.anything()
+      )
+    })
+    it('it should request users by login name', async () => {
+      const userIds = ['a@a.com', 'c@a.com']
+      await getUsers(mockPaginator, { userIds, property: 'profile.login' })
+      expect(mockPaginator).toHaveBeenNthCalledWith(
+        1,
+        {
+          url: '/api/v1/users',
+          headers: { 'Content-Type': 'application/json; okta-response=omitCredentials,omitCredentialsLinks' },
+          paginationField: 'after',
+          queryParams: { search: 'profile.login eq "a@a.com" or profile.login eq "c@a.com"' },
+        },
+        expect.anything()
+      )
+    })
   })
 })


### PR DESCRIPTION
default `getUsers` in Okta will now fetch specific users instead of getting all users

---

1. Add config option to to determine how we fetch users - `allUsers` or `searchQuery`. in the future we might want to support `oneByOne` strategy (which will use a different endpoint without query params)
2. `searchQuery` will be the default strategy, and will only fetch user ids that appear in nacls (in both fetch and deploy)
3. left the option to use `allUsers` strategy, cause it might be more efficient in certain envs

for my env with (2000 users total, and 300 that appears in nacls), using the both strategies gave almost the same results for fetch times (with a little advantage to  `allUsers`)

---
_Release Notes_: 

_Okta_adapter_:
- Add config option to enable fetching only users referenced by other elements. This will be enabled by default and is more efficient for bigger accounts.

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
