### PR TITLE
SALTO-4205: block changes in group assignments for inactive apps (Okta)

### DIFF
--- a/packages/okta-adapter/src/change_validators/app_group_assignments.ts
+++ b/packages/okta-adapter/src/change_validators/app_group_assignments.ts
@@ -42,7 +42,7 @@ const isGroupAssignmentChange = (
 }
 
 /**
- * Okta does not support group assignment for applicatons in status inactive.
+ * Okta does not support group assignment for applications in status inactive.
  */
 export const appGroupAssignmentValidator: ChangeValidator = async changes => (
   changes

--- a/packages/okta-adapter/src/change_validators/app_group_assignments.ts
+++ b/packages/okta-adapter/src/change_validators/app_group_assignments.ts
@@ -1,0 +1,60 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { ChangeValidator, getChangeData, isInstanceChange, isAdditionOrModificationChange, InstanceElement, AdditionChange, isAdditionChange, ModificationChange, ReferenceExpression } from '@salto-io/adapter-api'
+import { references } from '@salto-io/adapter-utils'
+import { ACTIVE_STATUS, APPLICATION_TYPE_NAME, INACTIVE_STATUS } from '../constants'
+
+const { isArrayOfRefExprToInstances } = references
+
+const isArrayOfReferencesOrUndefined = (value: unknown): value is ReferenceExpression[] | undefined =>
+  value === undefined || isArrayOfRefExprToInstances(value)
+
+const isGroupAssignmentChange = (
+  change: AdditionChange<InstanceElement> | ModificationChange<InstanceElement>
+): boolean => {
+  if (isAdditionChange(change)) {
+    return !_.isEmpty(getChangeData(change).value.assignedGroups)
+  }
+  // ModificationChange
+  const { before: { value: beforeValue }, after: { value: afterValue } } = change.data
+  const [beforeAssignments, afterAssignments] = [beforeValue.assignedGroups, afterValue.assignedGroups]
+  if (!isArrayOfReferencesOrUndefined(beforeAssignments) || !isArrayOfReferencesOrUndefined(afterAssignments)) {
+    return false
+  }
+  return !_.isEqual(
+    beforeAssignments?.map(ref => ref.elemID.getFullName()),
+    afterAssignments?.map(ref => ref.elemID.getFullName())
+  )
+}
+
+/**
+ * Okta does not support group assignment for applicatons in status inactive.
+ */
+export const appGroupAssignmentValidator: ChangeValidator = async changes => (
+  changes
+    .filter(isInstanceChange)
+    .filter(isAdditionOrModificationChange)
+    .filter(change => getChangeData(change).elemID.typeName === APPLICATION_TYPE_NAME)
+    .filter(change => getChangeData(change).value.status === INACTIVE_STATUS)
+    .filter(isGroupAssignmentChange)
+    .map(change => ({
+      elemID: getChangeData(change).elemID,
+      severity: 'Error',
+      message: `Cannot edit group assignments for application in status ${INACTIVE_STATUS}`,
+      detailedMessage: `Group assignments cannot be changed for applications in status ${INACTIVE_STATUS}. In order to apply this change, modify application status to be ${ACTIVE_STATUS}.`,
+    }))
+)

--- a/packages/okta-adapter/src/change_validators/index.ts
+++ b/packages/okta-adapter/src/change_validators/index.ts
@@ -32,6 +32,8 @@ import { enabledAuthenticatorsValidator } from './enabled_authenticators'
 import { roleAssignmentValidator } from './role_assignment'
 import { usersValidator } from './user'
 import { appWithGroupPushValidator } from './app_with_group_push'
+import { appUserSchemaWithInactiveAppValidator } from './app_schema_with_inactive_app'
+import { appGroupAssignmentValidator } from './app_group_assignments'
 import OktaClient from '../client/client'
 import {
   API_DEFINITIONS_CONFIG,
@@ -40,7 +42,6 @@ import {
   OktaConfig,
   PRIVATE_API_DEFINITIONS_CONFIG,
 } from '../config'
-import { appUserSchemaWithInactiveAppValidator } from './app_schema_with_inactive_app'
 
 const {
   createCheckDeploymentBasedOnConfigValidator,
@@ -77,6 +78,7 @@ export default ({
     appUserSchemaWithInactiveApp: appUserSchemaWithInactiveAppValidator,
     appWithGroupPush: appWithGroupPushValidator,
     groupPushToApplicationUniqueness: groupPushToApplicationUniquenessValidator,
+    appGroupAssignment: appGroupAssignmentValidator,
   }
 
   return createChangeValidator({

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -1793,6 +1793,7 @@ export type ChangeValidatorName = (
   | 'appUserSchemaWithInactiveApp'
   | 'appWithGroupPush'
   | 'groupPushToApplicationUniqueness'
+  | 'appGroupAssignment'
   )
 
 type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
@@ -1818,6 +1819,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     appUserSchemaWithInactiveApp: { refType: BuiltinTypes.BOOLEAN },
     appWithGroupPush: { refType: BuiltinTypes.BOOLEAN },
     groupPushToApplicationUniqueness: { refType: BuiltinTypes.BOOLEAN },
+    appGroupAssignment: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/okta-adapter/test/change_validators/app_group_assignment.test.ts
+++ b/packages/okta-adapter/test/change_validators/app_group_assignment.test.ts
@@ -1,0 +1,96 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { toChange, ObjectType, ElemID, InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
+import { appGroupAssignmentValidator } from '../../src/change_validators/app_group_assignments'
+import { OKTA, APPLICATION_TYPE_NAME, GROUP_TYPE_NAME } from '../../src/constants'
+
+describe('appGroupAssignmentValidator', () => {
+  const appType = new ObjectType({ elemID: new ElemID(OKTA, APPLICATION_TYPE_NAME) })
+  const groupType = new ObjectType({ elemID: new ElemID(OKTA, GROUP_TYPE_NAME) })
+  const groupAInst = new InstanceElement('group', groupType, { id: '123', name: 'group' })
+  const groupBInst = new InstanceElement('group', groupType, { id: '123', name: 'group' })
+  const inactiveApp = new InstanceElement(
+    'bookmarkApp',
+    appType,
+    {
+      label: 'bookmark app',
+      status: 'INACTIVE',
+      signOnMode: 'BOOKMARK',
+      assignedGroups: [new ReferenceExpression(groupAInst.elemID, groupAInst)],
+    },
+  )
+
+  it('should return an error when adding inactive app with group assignments', async () => {
+    expect(await appGroupAssignmentValidator([toChange({ after: inactiveApp })])).toEqual([
+      {
+        elemID: inactiveApp.elemID,
+        severity: 'Error',
+        message: 'Cannot edit group assignments for application in status INACTIVE',
+        detailedMessage: 'Group assignments cannot be changed for applications in status INACTIVE. In order to apply this change, modify application status to be ACTIVE.',
+      },
+    ])
+  })
+  it('should return an error when modifying group assignments for inactive app', async () => {
+    const afterApp1 = inactiveApp.clone()
+    afterApp1.value.assignedGroups.push(new ReferenceExpression(groupBInst.elemID, groupBInst))
+    const beforeApp2 = new InstanceElement(
+      'bookmarkApp2',
+      appType,
+      {
+        label: 'bookmark app',
+        status: 'INACTIVE',
+        signOnMode: 'BOOKMARK',
+        assignedGroups: [new ReferenceExpression(groupAInst.elemID, groupAInst)],
+      },
+    )
+    const afterApp2 = beforeApp2.clone()
+    delete afterApp2.value.assignedGroups
+    const changes = [
+      toChange({ before: inactiveApp, after: afterApp1 }),
+      toChange({ before: beforeApp2, after: afterApp2 }),
+    ]
+    expect(await appGroupAssignmentValidator(changes)).toEqual([
+      {
+        elemID: inactiveApp.elemID,
+        severity: 'Error',
+        message: 'Cannot edit group assignments for application in status INACTIVE',
+        detailedMessage: 'Group assignments cannot be changed for applications in status INACTIVE. In order to apply this change, modify application status to be ACTIVE.',
+      },
+      {
+        elemID: beforeApp2.elemID,
+        severity: 'Error',
+        message: 'Cannot edit group assignments for application in status INACTIVE',
+        detailedMessage: 'Group assignments cannot be changed for applications in status INACTIVE. In order to apply this change, modify application status to be ACTIVE.',
+      },
+    ])
+  })
+  it('should not return error when modifyting group assignments for active app', async () => {
+    const activeApp = new InstanceElement(
+      'bookmarkApp',
+      appType,
+      {
+        label: 'bookmark app',
+        status: 'ACTIVE',
+        signOnMode: 'BOOKMARK',
+        assignedGroups: [new ReferenceExpression(groupAInst.elemID, groupAInst)],
+      },
+    )
+    expect(await appGroupAssignmentValidator([toChange({ after: activeApp })])).toEqual([])
+  })
+  it('should not return error when group assignments for inactive app was not changed', async () => {
+    expect(await appGroupAssignmentValidator([toChange({ before: inactiveApp, after: inactiveApp })])).toEqual([])
+  })
+})

--- a/packages/okta-adapter/test/change_validators/app_group_assignment.test.ts
+++ b/packages/okta-adapter/test/change_validators/app_group_assignment.test.ts
@@ -20,8 +20,8 @@ import { OKTA, APPLICATION_TYPE_NAME, GROUP_TYPE_NAME } from '../../src/constant
 describe('appGroupAssignmentValidator', () => {
   const appType = new ObjectType({ elemID: new ElemID(OKTA, APPLICATION_TYPE_NAME) })
   const groupType = new ObjectType({ elemID: new ElemID(OKTA, GROUP_TYPE_NAME) })
-  const groupAInst = new InstanceElement('group', groupType, { id: '123', name: 'group' })
-  const groupBInst = new InstanceElement('group', groupType, { id: '123', name: 'group' })
+  const groupAInst = new InstanceElement('groupA', groupType, { id: '123', name: 'group' })
+  const groupBInst = new InstanceElement('groupB', groupType, { id: '123', name: 'group' })
   const inactiveApp = new InstanceElement(
     'bookmarkApp',
     appType,
@@ -77,7 +77,7 @@ describe('appGroupAssignmentValidator', () => {
       },
     ])
   })
-  it('should not return error when modifyting group assignments for active app', async () => {
+  it('should not return error when modifying group assignments for active app', async () => {
     const activeApp = new InstanceElement(
       'bookmarkApp',
       appType,


### PR DESCRIPTION
When changing groups assignments for application in status inactive, Okta returns 404 (and also this option blocked on UI)

---

_Additional context for reviewer_

---

_Release Notes_: 

_Okta_adapter_:
- Add validator to verify app groups assignments are not modified in inactive apps

---
_User Notifications_: 
None
