### PR TITLE
SAAS-9985: Add TopLevelFilter to preview API

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -150,6 +150,7 @@ export const preview = async (
   accounts = workspace.accounts(),
   checkOnly = false,
   skipValidations = false,
+  topLevelFilters = [shouldElementBeIncluded(accounts)],
 ): Promise<Plan> => {
   const stateElements = workspace.state()
   const adapters = await getAdapters(
@@ -166,7 +167,7 @@ export const preview = async (
       ? {} : getChangeValidators(adapters, checkOnly, await workspace.errors()),
     dependencyChangers: defaultDependencyChangers.concat(getAdapterDependencyChangers(adapters)),
     customGroupIdFunctions: getAdapterChangeGroupIdFunctions(adapters),
-    topLevelFilters: [shouldElementBeIncluded(accounts)],
+    topLevelFilters,
     compareOptions: { compareByValue: true },
   })
 }

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -167,7 +167,7 @@ export const preview = async (
       ? {} : getChangeValidators(adapters, checkOnly, await workspace.errors()),
     dependencyChangers: defaultDependencyChangers.concat(getAdapterDependencyChangers(adapters)),
     customGroupIdFunctions: getAdapterChangeGroupIdFunctions(adapters),
-    topLevelFilters: [...(topLevelFilters ?? []), shouldElementBeIncluded(accounts)],
+    topLevelFilters: [shouldElementBeIncluded(accounts), ...(topLevelFilters ?? [])],
     compareOptions: { compareByValue: true },
   })
 }

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -78,7 +78,7 @@ import {
   getFetchAdapterAndServicesSetup,
   MergeErrorWithElements,
 } from './core/fetch'
-import { defaultDependencyChangers } from './core/plan/plan'
+import { defaultDependencyChangers, IDFilter } from './core/plan/plan'
 import { createRestoreChanges, createRestorePathChanges } from './core/restore'
 import { getAdapterChangeGroupIdFunctions } from './core/adapters/custom_group_key'
 import { createDiffChanges } from './core/diff'
@@ -150,7 +150,7 @@ export const preview = async (
   accounts = workspace.accounts(),
   checkOnly = false,
   skipValidations = false,
-  topLevelFilters = [shouldElementBeIncluded(accounts)],
+  topLevelFilters?: IDFilter[]
 ): Promise<Plan> => {
   const stateElements = workspace.state()
   const adapters = await getAdapters(
@@ -167,7 +167,7 @@ export const preview = async (
       ? {} : getChangeValidators(adapters, checkOnly, await workspace.errors()),
     dependencyChangers: defaultDependencyChangers.concat(getAdapterDependencyChangers(adapters)),
     customGroupIdFunctions: getAdapterChangeGroupIdFunctions(adapters),
-    topLevelFilters,
+    topLevelFilters: [...(topLevelFilters ?? []), shouldElementBeIncluded(accounts)],
     compareOptions: { compareByValue: true },
   })
 }

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -349,6 +349,16 @@ describe('api.ts', () => {
         },
       }))
     })
+    it('should call getPlan with given topLevelFilters', async () => {
+      const topLevelFilters = [() => true]
+      await api.preview(mockWorkspace({}), ACCOUNTS, true, false, topLevelFilters)
+      expect(mockedGetPlan).toHaveBeenCalledWith(expect.objectContaining({
+        topLevelFilters,
+        changeValidators: {
+          [emptyMockService]: expect.any(Function),
+        },
+      }))
+    })
     it('should call getPlan without change validators', async () => {
       await api.preview(mockWorkspace({}), ACCOUNTS, false, true)
       expect(mockedGetPlan).toHaveBeenCalledWith(expect.objectContaining({

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -353,7 +353,7 @@ describe('api.ts', () => {
       const topLevelFilters = [() => true]
       await api.preview(mockWorkspace({}), ACCOUNTS, true, false, topLevelFilters)
       expect(mockedGetPlan).toHaveBeenCalledWith(expect.objectContaining({
-        topLevelFilters,
+        topLevelFilters: expect.arrayContaining(topLevelFilters),
         changeValidators: {
           [emptyMockService]: expect.any(Function),
         },


### PR DESCRIPTION
Add TopLevelFilters to Preview API. this allows consumers to improve the performance of Plan calculation to consider only the elements we expect to have changes on and not the whole workspace.

---

_Additional context for reviewer_

---

_Release Notes_: 
None

---

_User Notifications_: 
None